### PR TITLE
Some more code maintenance based on dterrahes work

### DIFF
--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -1123,7 +1123,7 @@ void dt_bauhaus_widget_set_field(GtkWidget *widget,
   if(*w->label)
     dt_print(DT_DEBUG_ALWAYS,
              "[dt_bauhaus_widget_set_field] bauhaus label '%s'"
-             " set before field (needs to be after)\n",
+             " set before field (needs to be after)",
              w->label);
   w->field = field;
   w->field_type = field_type;
@@ -1213,7 +1213,7 @@ void dt_bauhaus_update_from_field(dt_iop_module_t *module,
             break;
           default:
             dt_print(DT_DEBUG_ALWAYS,
-                     "[dt_bauhaus_update_from_field] unsupported slider data type\n");
+                     "[dt_bauhaus_update_from_field] unsupported slider data type");
         }
         break;
       case DT_BAUHAUS_COMBOBOX:
@@ -1233,7 +1233,7 @@ void dt_bauhaus_update_from_field(dt_iop_module_t *module,
             break;
           default:
             dt_print(DT_DEBUG_ALWAYS,
-                     "[dt_bauhaus_update_from_field] unsupported combo data type\n");
+                     "[dt_bauhaus_update_from_field] unsupported combo data type");
         }
         break;
       default:
@@ -1769,7 +1769,7 @@ static void _combobox_set(dt_bauhaus_widget_t *w,
           if(*b != prevb) dt_iop_gui_changed(w->module, GTK_WIDGET(w), &prevb);
           break;
         default:
-          dt_print(DT_DEBUG_ALWAYS, "[_combobox_set] unsupported combo data type\n");
+          dt_print(DT_DEBUG_ALWAYS, "[_combobox_set] unsupported combo data type");
       }
     }
     _highlight_changed_notebook_tab(GTK_WIDGET(w),
@@ -1905,7 +1905,7 @@ void dt_bauhaus_slider_set_stop(GtkWidget *widget,
   else
   {
     dt_print(DT_DEBUG_ALWAYS,
-             "[bauhaus_slider_set_stop] only %d stops allowed.\n",
+             "[bauhaus_slider_set_stop] only %d stops allowed",
              DT_BAUHAUS_SLIDER_MAX_STOPS);
   }
 }
@@ -3230,7 +3230,7 @@ static void _slider_value_change(dt_bauhaus_widget_t *w)
           break;
         default:
           dt_print(DT_DEBUG_ALWAYS,
-                   "[_slider_value_change] unsupported slider data type\n");
+                   "[_slider_value_change] unsupported slider data type");
       }
     }
 
@@ -3554,7 +3554,7 @@ void dt_bauhaus_vimkey_exec(const char *input)
     case DT_BAUHAUS_SLIDER:
       old_value = dt_bauhaus_slider_get(w);
       new_value = dt_calculator_solve(old_value, input);
-      dt_print(DT_DEBUG_ALWAYS, " = %f\n", new_value);
+      dt_print(DT_DEBUG_ALWAYS, " = %f", new_value);
       if(dt_isfinite(new_value))
         dt_bauhaus_slider_set(w, new_value);
       break;
@@ -3562,7 +3562,7 @@ void dt_bauhaus_vimkey_exec(const char *input)
       // TODO: what about text as entry?
       old_value = dt_bauhaus_combobox_get(w);
       new_value = dt_calculator_solve(old_value, input);
-      dt_print(DT_DEBUG_ALWAYS, " = %f\n", new_value);
+      dt_print(DT_DEBUG_ALWAYS, " = %f", new_value);
       if(dt_isfinite(new_value))
         dt_bauhaus_combobox_set(w, new_value);
       break;
@@ -3673,7 +3673,7 @@ static float _action_process_slider(gpointer target,
         break;
       default:
         dt_print(DT_DEBUG_ALWAYS,
-                 "[_action_process_slider] unknown shortcut effect (%d) for slider\n",
+                 "[_action_process_slider] unknown shortcut effect (%d) for slider",
                  effect);
         break;
       }
@@ -3710,7 +3710,7 @@ static float _action_process_slider(gpointer target,
         break;
       default:
         dt_print(DT_DEBUG_ALWAYS,
-                 "[_action_process_slider] unknown shortcut effect (%d) for slider\n",
+                 "[_action_process_slider] unknown shortcut effect (%d) for slider",
                  effect);
         break;
       }
@@ -3719,7 +3719,7 @@ static float _action_process_slider(gpointer target,
       break;
     default:
       dt_print(DT_DEBUG_ALWAYS,
-               "[_action_process_slider] unknown shortcut element (%d) for slider\n",
+               "[_action_process_slider] unknown shortcut element (%d) for slider",
                element);
       break;
     }

--- a/src/common/act_on.c
+++ b/src/common/act_on.c
@@ -252,13 +252,12 @@ gboolean _cache_update(const gboolean only_visible,
   // if needed, we show the list of cached images in terminal
   if((darktable.unmuted & DT_DEBUG_ACT_ON) == DT_DEBUG_ACT_ON)
   {
-    gchar *tx = dt_util_dstrcat
-      (NULL,
-       "[images to act on] new cache (%s) : ", only_visible ? "visible" : "all");
+    gchar *tx = g_strdup_printf
+      ("[images to act on] new cache (%s) : ", only_visible ? "visible" : "all");
 
     for(GList *ll = l;
         ll;
-        ll = g_list_next(ll)) tx = dt_util_dstrcat(tx, "%d ", GPOINTER_TO_INT(ll->data));
+        ll = g_list_next(ll)) dt_util_str_cat(&tx, "%d ", GPOINTER_TO_INT(ll->data));
     dt_print(DT_DEBUG_ACT_ON, "%s\n", tx);
     g_free(tx);
   }
@@ -382,7 +381,7 @@ gchar *dt_act_on_get_query(const gboolean only_visible)
   gchar *images = NULL;
   for(; l; l = g_list_next(l))
   {
-    images = dt_util_dstrcat(images, "%d,", GPOINTER_TO_INT(l->data));
+    dt_util_str_cat(&images, "%d,", GPOINTER_TO_INT(l->data));
   }
   if(images)
   {

--- a/src/common/act_on.c
+++ b/src/common/act_on.c
@@ -258,7 +258,7 @@ gboolean _cache_update(const gboolean only_visible,
     for(GList *ll = l;
         ll;
         ll = g_list_next(ll)) dt_util_str_cat(&tx, "%d ", GPOINTER_TO_INT(ll->data));
-    dt_print(DT_DEBUG_ACT_ON, "%s\n", tx);
+    dt_print(DT_DEBUG_ACT_ON, "%s", tx);
     g_free(tx);
   }
 
@@ -442,7 +442,7 @@ dt_imgid_t dt_act_on_get_main_image()
   }
 
   if((darktable.unmuted & DT_DEBUG_ACT_ON) == DT_DEBUG_ACT_ON)
-    dt_print(DT_DEBUG_ACT_ON, "[images to act on] single image : %d\n", ret);
+    dt_print(DT_DEBUG_ACT_ON, "[images to act on] single image : %d", ret);
 
   return ret;
 }

--- a/src/common/bilateral.c
+++ b/src/common/bilateral.c
@@ -76,10 +76,10 @@ void dt_bilateral_grid_size(dt_bilateral_t *b,
 #if 0
   if(b->sigma_s != sigma_s)
     dt_print(DT_DEBUG_ALWAYS,
-             "[bilateral] clamped sigma_s (%g -> %g)!\n",sigma_s,b->sigma_s);
+             "[bilateral] clamped sigma_s (%g -> %g)!",sigma_s,b->sigma_s);
   if(b->sigma_r != sigma_r)
     dt_print(DT_DEBUG_ALWAYS,
-             "[bilateral] clamped sigma_r (%g -> %g)!\n",sigma_r,b->sigma_r);
+             "[bilateral] clamped sigma_r (%g -> %g)!",sigma_r,b->sigma_r);
 #endif
 }
 
@@ -187,13 +187,13 @@ dt_bilateral_t *dt_bilateral_init(const int width,     // width of input image
   if(!b->buf)
   {
     dt_print(DT_DEBUG_ALWAYS,
-             "[bilateral] unable to allocate buffer for %zux%zux%zu grid\n",
+             "[bilateral] unable to allocate buffer for %zux%zux%zu grid",
              b->size_x,b->size_y,b->size_z);
     free(b);
     return NULL;
   }
   dt_print(DT_DEBUG_DEV,
-           "[bilateral] created grid [%ld %ld %ld] with sigma (%f %f) (%f %f)\n",
+           "[bilateral] created grid [%ld %ld %ld] with sigma (%f %f) (%f %f)",
            b->size_x, b->size_y, b->size_z, b->sigma_s, sigma_s, b->sigma_r, sigma_r);
   return b;
 }

--- a/src/common/bilateralcl.c
+++ b/src/common/bilateralcl.c
@@ -87,14 +87,14 @@ dt_bilateral_cl_t *dt_bilateral_init_cl(const int devid,
   if(!dt_opencl_local_buffer_opt(devid, darktable.opencl->bilateral->kernel_splat, &locopt))
   {
     dt_print(DT_DEBUG_OPENCL,
-             "[opencl_bilateral] can not identify resource limits for device %d in bilateral grid\n", devid);
+             "[opencl_bilateral] can not identify resource limits for device %d in bilateral grid", devid);
     return NULL;
   }
 
   if(locopt.sizex * locopt.sizey < 16 * 16)
   {
     dt_print(DT_DEBUG_OPENCL,
-             "[opencl_bilateral] device %d does not offer sufficient resources to run bilateral grid\n",
+             "[opencl_bilateral] device %d does not offer sufficient resources to run bilateral grid",
              devid);
     return NULL;
   }

--- a/src/common/box_filters.cc
+++ b/src/common/box_filters.cc
@@ -651,7 +651,7 @@ void dt_box_mean_horizontal(float *const __restrict__ buf,
         dt_free_align(scratch);
     }
     else
-      dt_print(DT_DEBUG_ALWAYS,"[box_mean] unable to allocate scratch memory\n");
+      dt_print(DT_DEBUG_ALWAYS, "[box_mean] unable to allocate scratch memory");
   }
   else if(ch == (9|BOXFILTER_KAHAN_SUM))
   {
@@ -664,7 +664,7 @@ void dt_box_mean_horizontal(float *const __restrict__ buf,
         dt_free_align(scratch);
     }
     else
-      dt_print(DT_DEBUG_ALWAYS,"[box_mean] unable to allocate scratch memory\n");
+      dt_print(DT_DEBUG_ALWAYS, "[box_mean] unable to allocate scratch memory");
   }
   else
     dt_unreachable_codepath();

--- a/src/common/cache.c
+++ b/src/common/cache.c
@@ -134,7 +134,7 @@ dt_cache_entry_t *dt_cache_testget(dt_cache_t *cache,
     dt_pthread_mutex_unlock(&cache->lock);
     const double end = dt_get_debug_wtime();
     if(end - start > 0.1)
-      dt_print(DT_DEBUG_ALWAYS, "try+ wait time %.06fs mode %c \n", end - start, mode);
+      dt_print(DT_DEBUG_ALWAYS, "try+ wait time %.06fs mode %c", end - start, mode);
 
     if(mode == 'w')
     {
@@ -149,7 +149,7 @@ dt_cache_entry_t *dt_cache_testget(dt_cache_t *cache,
   dt_pthread_mutex_unlock(&cache->lock);
   const double end = dt_get_debug_wtime();
   if(end - start > 0.1)
-    dt_print(DT_DEBUG_ALWAYS, "try- wait time %.06fs\n", end - start);
+    dt_print(DT_DEBUG_ALWAYS, "try- wait time %.06fs", end - start);
   return 0;
 }
 
@@ -226,7 +226,7 @@ restart:
   // here dies your 32-bit system:
   dt_cache_entry_t *entry = (dt_cache_entry_t *)g_slice_alloc(sizeof(dt_cache_entry_t));
   const int ret = dt_pthread_rwlock_init(&entry->lock, 0);
-  if(ret) dt_print(DT_DEBUG_ALWAYS, "rwlock init: %d\n", ret);
+  if(ret) dt_print(DT_DEBUG_ALWAYS, "rwlock init: %d", ret);
 
   entry->data = 0;
   entry->data_size = cache->entry_size;
@@ -264,7 +264,7 @@ restart:
   dt_pthread_mutex_unlock(&cache->lock);
   const double end = dt_get_debug_wtime();
   if(end - start > 0.1)
-    dt_print(DT_DEBUG_ALWAYS, "wait time %.06fs\n", end - start);
+    dt_print(DT_DEBUG_ALWAYS, "wait time %.06fs", end - start);
 
   // WARNING: do *NOT* unpoison here. it must be done by the caller!
 

--- a/src/common/camera_control.c
+++ b/src/common/camera_control.c
@@ -170,7 +170,7 @@ static void _gphoto_log25(GPLogLevel level,
                           const char *log,
                           void *data)
 {
-  dt_print(DT_DEBUG_CAMCTL, "[camera_control] %s %s\n", domain, log);
+  dt_print(DT_DEBUG_CAMCTL, "[camera_control] %s %s", domain, log);
 }
 
 static void _enable_debug() __attribute__((unused));
@@ -191,7 +191,7 @@ static void _error_func_dispatch25(GPContext *context,
                                    void *data)
 {
   dt_camctl_t *camctl = (dt_camctl_t *)data;
-  dt_print(DT_DEBUG_CAMCTL, "[camera_control] gphoto2 error: %s\n", text);
+  dt_print(DT_DEBUG_CAMCTL, "[camera_control] gphoto2 error: %s", text);
 
   if(strstr(text, "PTP"))
   {
@@ -201,7 +201,7 @@ static void _error_func_dispatch25(GPContext *context,
     {
       dt_camera_t *cam = (dt_camera_t *)ci->data;
       dt_print(DT_DEBUG_CAMCTL,
-               "[camera_control] PTP error `%s' for camera %s on port %s\n",
+               "[camera_control] PTP error `%s' for camera %s on port %s",
                text, cam->model, cam->port);
       dt_control_log
         (_("camera `%s' on port `%s' error %s\n"
@@ -222,21 +222,21 @@ static void _status_func_dispatch25(GPContext *context,
                                     const char *text,
                                     void *data)
 {
-  dt_print(DT_DEBUG_CAMCTL, "[camera_control] gphoto2 status: %s\n", text);
+  dt_print(DT_DEBUG_CAMCTL, "[camera_control] gphoto2 status: %s", text);
 }
 
 static void _message_func_dispatch25(GPContext *context,
                                      const char *text,
                                      void *data)
 {
-  dt_print(DT_DEBUG_CAMCTL, "[camera_control] gphoto2 message: %s\n", text);
+  dt_print(DT_DEBUG_CAMCTL, "[camera_control] gphoto2 message: %s", text);
 }
 
 static gboolean _camera_timeout_job(gpointer data)
 {
   dt_camera_t *cam = (dt_camera_t *)data;
   dt_print(DT_DEBUG_CAMCTL,
-           "[camera_control] Calling timeout func for camera %p.\n", cam);
+           "[camera_control] Calling timeout func for camera %p", cam);
   cam->timeout(cam->gpcam, cam->gpcontext);
   return TRUE;
 }
@@ -247,7 +247,7 @@ static int _camera_start_timeout_func(Camera *c,
                                       void *data)
 {
   dt_print(DT_DEBUG_CAMCTL,
-           "[camera_control] start timeout %d seconds for camera %p requested by driver.\n",
+           "[camera_control] start timeout %d seconds for camera %p requested by driver.",
            timeout, data);
   dt_camera_t *cam = (dt_camera_t *)data;
   cam->timeout = func;
@@ -260,7 +260,7 @@ static void _camera_stop_timeout_func(Camera *c,
 {
   dt_camera_t *cam = (dt_camera_t *)data;
   dt_print(DT_DEBUG_CAMCTL,
-           "[camera_control] Removing timeout %d for camera %p.\n", id, cam);
+           "[camera_control] Removing timeout %d for camera %p", id, cam);
   g_source_remove(id);
   cam->timeout = NULL;
 }
@@ -304,7 +304,7 @@ static void _camera_process_job(const dt_camctl_t *c,
     case _JOB_TYPE_EXECUTE_CAPTURE:
     {
       dt_print(DT_DEBUG_CAMCTL,
-               "[camera_control] executing remote camera capture job\n");
+               "[camera_control] executing remote camera capture job");
       CameraFilePath fp;
       int res = GP_OK;
       if((res = gp_camera_capture(camera->gpcam, GP_CAPTURE_IMAGE, &fp, c->gpcontext)) == GP_OK)
@@ -331,17 +331,17 @@ static void _camera_process_job(const dt_camctl_t *c,
           }
           else
             dt_print(DT_DEBUG_CAMCTL,
-                     "[camera_control] failed to download file %s\n", output);
+                     "[camera_control] failed to download file %s", output);
           close(handle);
         }
         else
           dt_print(DT_DEBUG_CAMCTL,
-                   "[camera_control] failed to download file %s\n", output);
+                   "[camera_control] failed to download file %s", output);
         g_free(output);
       }
       else
         dt_print(DT_DEBUG_CAMCTL,
-                 "[camera_control] capture job failed to capture image: %s\n",
+                 "[camera_control] capture job failed to capture image: %s",
                  gp_result_as_string(res));
     }
     break;
@@ -358,13 +358,13 @@ static void _camera_process_job(const dt_camctl_t *c,
       if((res = gp_camera_capture_preview(cam->gpcam, fp, c->gpcontext)) != GP_OK)
       {
         dt_print(DT_DEBUG_CAMCTL,
-                 "[camera_control] live view failed to capture preview: %s\n",
+                 "[camera_control] live view failed to capture preview: %s",
                  gp_result_as_string(res));
       }
       else if((res = gp_file_get_data_and_size(fp, &data, &data_size)) != GP_OK)
       {
         dt_print(DT_DEBUG_CAMCTL,
-                 "[camera_control] live view failed to get preview data: %s\n",
+                 "[camera_control] live view failed to get preview data: %s",
                  gp_result_as_string(res));
       }
       // to avoid a crash check that data is not null and data_size >
@@ -377,7 +377,7 @@ static void _camera_process_job(const dt_camctl_t *c,
         if(dt_imageio_jpeg_decompress_header(data, data_size, &jpg))
         {
           dt_print(DT_DEBUG_CAMCTL,
-                   "[camera_control] live view failed to decompress jpeg header\n");
+                   "[camera_control] live view failed to decompress jpeg header");
         }
         else
         {
@@ -393,12 +393,12 @@ static void _camera_process_job(const dt_camctl_t *c,
           if(!buffer)
           {
             dt_print(DT_DEBUG_CAMCTL,
-                     "[camera_control] live view could not allocate image buffer\n");
+                     "[camera_control] live view could not allocate image buffer");
           }
           else if(dt_imageio_jpeg_decompress(&jpg, buffer))
           {
             dt_print(DT_DEBUG_CAMCTL,
-                     "[camera_control] live view failed to decompress jpeg\n");
+                     "[camera_control] live view failed to decompress jpeg");
           }
           else
           {
@@ -424,7 +424,7 @@ static void _camera_process_job(const dt_camctl_t *c,
       _camctl_camera_set_property_string_job_t *spj =
         (_camctl_camera_set_property_string_job_t *)job;
       dt_print(DT_DEBUG_CAMCTL,
-               "[camera_control] executing set camera config job %s=%s\n",
+               "[camera_control] executing set camera config job %s=%s",
                spj->name, spj->value);
 
       dt_pthread_mutex_lock(&cam->config_lock);
@@ -474,7 +474,7 @@ static void _camera_process_job(const dt_camctl_t *c,
       _camctl_camera_set_property_toggle_job_t *spj =
         (_camctl_camera_set_property_toggle_job_t *)job;
       dt_print(DT_DEBUG_CAMCTL,
-               "[camera_control] executing camera config job to toggle %s\n",
+               "[camera_control] executing camera config job to toggle %s",
                spj->name);
 
       dt_pthread_mutex_lock(&cam->config_lock);
@@ -494,7 +494,7 @@ static void _camera_process_job(const dt_camctl_t *c,
       _camctl_camera_set_property_int_job_t *spj =
         (_camctl_camera_set_property_int_job_t *)job;
       dt_print(DT_DEBUG_CAMCTL,
-               "[camera_control] executing set camera config job %s=%d\n",
+               "[camera_control] executing set camera config job %s=%d",
                spj->name, spj->value);
 
       dt_pthread_mutex_lock(&cam->config_lock);
@@ -527,7 +527,7 @@ static void _camera_process_job(const dt_camctl_t *c,
       _camctl_camera_set_property_float_job_t *spj =
         (_camctl_camera_set_property_float_job_t *)job;
       dt_print(DT_DEBUG_CAMCTL,
-               "[camera_control] executing set camera config float job %s=%.2f\n",
+               "[camera_control] executing set camera config float job %s=%.2f",
                spj->name, spj->value);
 
       dt_pthread_mutex_lock(&cam->config_lock);
@@ -557,7 +557,7 @@ static void _camera_process_job(const dt_camctl_t *c,
       break;
     default:
       dt_print(DT_DEBUG_CAMCTL,
-               "[camera_control] process of unknown job type 0x%x\n", j->type);
+               "[camera_control] process of unknown job type 0x%x", j->type);
       break;
   }
 
@@ -575,7 +575,7 @@ static void *dt_camctl_camera_get_live_view(void *data)
 
   dt_pthread_setname("live view");
 
-  dt_print(DT_DEBUG_CAMCTL, "[camera_control] live view thread started\n");
+  dt_print(DT_DEBUG_CAMCTL, "[camera_control] live view thread started");
 
   int frames = 0;
   double capture_time = dt_get_wtime();
@@ -590,7 +590,7 @@ static void *dt_camctl_camera_get_live_view(void *data)
     if(current_time - capture_time >= 1.0)
     {
       // a second has passed
-      dt_print(DT_DEBUG_CAMCTL, "%d fps\n", frames + 1);
+      dt_print(DT_DEBUG_CAMCTL, "%d fps", frames + 1);
       frames = 0;
       capture_time = current_time;
     }
@@ -607,7 +607,7 @@ static void *dt_camctl_camera_get_live_view(void *data)
     g_usleep((1.0 / fps) * G_USEC_PER_SEC); // going too fast will result in
                                             // too many redraws without a real benefit
   }
-  dt_print(DT_DEBUG_CAMCTL, "[camera_control] live view thread stopped\n");
+  dt_print(DT_DEBUG_CAMCTL, "[camera_control] live view thread stopped");
   return NULL;
 }
 
@@ -618,17 +618,17 @@ gboolean dt_camctl_camera_start_live_view(const dt_camctl_t *c)
   if(cam == NULL)
   {
     dt_print(DT_DEBUG_CAMCTL,
-             "[camera_control] Failed to start live view, camera==NULL\n");
+             "[camera_control] Failed to start live view, camera==NULL");
     return FALSE;
   }
   else
     dt_print(DT_DEBUG_CAMCTL,
-             "[camera_control] Starting live view\n");
+             "[camera_control] Starting live view");
 
   if(cam->can_live_view == FALSE)
   {
     dt_print(DT_DEBUG_CAMCTL,
-             "[camera_control] Camera does not support live view\n");
+             "[camera_control] Camera does not support live view");
     return FALSE;
   }
   cam->is_live_viewing = TRUE;
@@ -649,10 +649,10 @@ void dt_camctl_camera_stop_live_view(const dt_camctl_t *c)
   if(cam->is_live_viewing == FALSE)
   {
     dt_print(DT_DEBUG_CAMCTL,
-             "[camera_control] Not in live view mode, nothing to stop\n");
+             "[camera_control] Not in live view mode, nothing to stop");
     return;
   }
-  dt_print(DT_DEBUG_CAMCTL, "[camera_control] Stopping live view\n");
+  dt_print(DT_DEBUG_CAMCTL, "[camera_control] Stopping live view");
   cam->is_live_viewing = FALSE;
   pthread_join(cam->live_view_thread, NULL);
   // tell camera to get back to normal state (close mirror)
@@ -665,7 +665,7 @@ static void _camctl_lock(const dt_camctl_t *c, const dt_camera_t *cam)
   dt_camctl_t *camctl = (dt_camctl_t *)c;
   dt_pthread_mutex_BAD_lock(&camctl->lock);
   dt_print(DT_DEBUG_CAMCTL,
-           "[camera_control] camera control locked for %s\n", cam->model);
+           "[camera_control] camera control locked for %s", cam->model);
   camctl->active_camera = cam;
   _dispatch_control_status(c, CAMERA_CONTROL_BUSY);
 }
@@ -678,17 +678,17 @@ static void _camctl_unlock(const dt_camctl_t *c)
   dt_pthread_mutex_BAD_unlock(&camctl->lock);
   if(cam)
     dt_print(DT_DEBUG_CAMCTL,
-             "[camera_control] camera control un-locked for %s\n", cam->model);
+             "[camera_control] camera control un-locked for %s", cam->model);
   else
     dt_print(DT_DEBUG_CAMCTL,
-             "[camera_control] camera control un-locked for unknown camera\n");
+             "[camera_control] camera control un-locked for unknown camera");
   _dispatch_control_status(c, CAMERA_CONTROL_AVAILABLE);
 }
 
 dt_camctl_t *dt_camctl_new()
 {
   dt_camctl_t *camctl = g_malloc0(sizeof(dt_camctl_t));
-  dt_print(DT_DEBUG_CAMCTL, "[camera_control] creating new context %p\n", camctl);
+  dt_print(DT_DEBUG_CAMCTL, "[camera_control] creating new context %p", camctl);
 
   // Initialize gphoto2 context and setup dispatch callbacks
   camctl->gpcontext = gp_context_new();
@@ -706,7 +706,7 @@ dt_camctl_t *dt_camctl_new()
   gp_abilities_list_new(&camctl->gpcams);
   gp_abilities_list_load(camctl->gpcams, camctl->gpcontext);
   dt_print(DT_DEBUG_CAMCTL,
-           "[camera_control] loaded %d camera drivers.\n",
+           "[camera_control] loaded %d camera drivers",
            gp_abilities_list_count(camctl->gpcams));
 
   dt_pthread_mutex_init(&camctl->lock, NULL);
@@ -736,7 +736,7 @@ static void dt_camctl_camera_destroy(dt_camera_t *cam)
 {
   if(!cam) return;
   dt_print(DT_DEBUG_CAMCTL,
-           "[camera_control] destroy %s on port %s\n", cam->model, cam->port);
+           "[camera_control] destroy %s on port %s", cam->model, cam->port);
 
   for(GList *it = cam->open_gpfiles; it; it = g_list_delete_link(it, it))
   {
@@ -761,7 +761,7 @@ void dt_camctl_destroy(dt_camctl_t *camctl)
 {
   if(!camctl) return;
   // Go thru all c->cameras and release them..
-  dt_print(DT_DEBUG_CAMCTL, "[camera_control] destroy darktable camcontrol\n");
+  dt_print(DT_DEBUG_CAMCTL, "[camera_control] destroy darktable camcontrol");
   gp_context_cancel(camctl->gpcontext);
 
   for(GList *it = camctl->cameras; it; it = g_list_delete_link(it, it))
@@ -802,11 +802,11 @@ void dt_camctl_register_listener(const dt_camctl_t *c,
   {
     camctl->listeners = g_list_append(camctl->listeners, listener);
     dt_print(DT_DEBUG_CAMCTL,
-             "[camera_control] registering listener %p\n", listener);
+             "[camera_control] registering listener %p", listener);
   }
   else
     dt_print(DT_DEBUG_CAMCTL,
-             "[camera_control] registering already registered listener %p\n", listener);
+             "[camera_control] registering already registered listener %p", listener);
   dt_pthread_mutex_unlock(&camctl->listeners_lock);
 }
 
@@ -816,7 +816,7 @@ void dt_camctl_unregister_listener(const dt_camctl_t *c,
   dt_camctl_t *camctl = (dt_camctl_t *)c;
   // Just locking mutex and prevent signalling CAMERA_CONTROL_BUSY
   dt_pthread_mutex_lock(&camctl->listeners_lock);
-  dt_print(DT_DEBUG_CAMCTL, "[camera_control] unregistering listener %p\n", listener);
+  dt_print(DT_DEBUG_CAMCTL, "[camera_control] unregistering listener %p", listener);
   camctl->listeners = g_list_remove(camctl->listeners, listener);
   dt_pthread_mutex_unlock(&camctl->listeners_lock);
 }
@@ -854,7 +854,7 @@ static gboolean dt_camctl_update_cameras(const dt_camctl_t *c)
   if(ports_available != ports_cnt)
   {
     dt_print(DT_DEBUG_CAMCTL,
-             "[camera_control] loaded %d port drivers.\n", ports_available);
+             "[camera_control] loaded %d port drivers", ports_available);
     ports_cnt = ports_available;
   }
 
@@ -866,7 +866,7 @@ static gboolean dt_camctl_update_cameras(const dt_camctl_t *c)
   if(connected_cnt != cameras_cnt)
   {
     dt_print(DT_DEBUG_CAMCTL,
-             "[camera_control] %d cameras connected\n", connected_cnt);
+             "[camera_control] %d cameras connected", connected_cnt);
     cameras_cnt = connected_cnt;
   }
 
@@ -896,7 +896,7 @@ static gboolean dt_camctl_update_cameras(const dt_camctl_t *c)
       unused_camera->port = g_strdup(testcam->port);
       camctl->unused_cameras = g_list_append(camctl->unused_cameras, unused_camera);
       dt_print(DT_DEBUG_CAMCTL,
-               "[camera_control] found new %s on port %s\n",
+               "[camera_control] found new %s on port %s",
                testcam->model, testcam->port);
       changed_camera = TRUE;
     }
@@ -923,7 +923,7 @@ static gboolean dt_camctl_update_cameras(const dt_camctl_t *c)
       if(removed)
       {
         dt_print(DT_DEBUG_CAMCTL,
-                 "[camera_control] remove %s on port %s from ununsed camera list\n",
+                 "[camera_control] remove %s on port %s from ununsed camera list",
                  cam->model, cam->port);
         dt_camera_unused_t *oldcam = (dt_camera_unused_t *)unused_item->data;
         camctl->unused_cameras = unused_item =
@@ -944,7 +944,7 @@ static gboolean dt_camctl_update_cameras(const dt_camctl_t *c)
           {
             dt_print(DT_DEBUG_CAMCTL,
                      "[camera_control] failed to initialize %s on port %s, likely "
-                     "causes are: locked by another application, no access to udev etc.\n",
+                     "causes are: locked by another application, no access to udev etc",
                      camera->model, camera->port);
             dt_control_log
               (_("failed to initialize `%s' on port `%s', likely "
@@ -958,7 +958,7 @@ static gboolean dt_camctl_update_cameras(const dt_camctl_t *c)
           if(camera->can_import == FALSE && camera->can_tether == FALSE)
           {
             dt_print(DT_DEBUG_CAMCTL,
-                     "[camera_control] %s on port %s doesn't support import or tether\n",
+                     "[camera_control] %s on port %s doesn't support import or tether",
                      camera->model, camera->port);
             dt_control_log(_("`%s' on port `%s' is not interesting"
                              " because it supports neither tethering nor import"),
@@ -981,7 +981,7 @@ static gboolean dt_camctl_update_cameras(const dt_camctl_t *c)
 
           dt_print(DT_DEBUG_CAMCTL,
                    "[camera_control] remove %s on port %s from"
-                   " ununsed camera list as mounted\n",
+                   " ununsed camera list as mounted",
                    cam->model, cam->port);
           dt_camera_unused_t *oldcam = (dt_camera_unused_t *)unused_item->data;
           camctl->unused_cameras = unused_item =
@@ -1018,7 +1018,7 @@ static gboolean dt_camctl_update_cameras(const dt_camctl_t *c)
         dt_camera_t *oldcam = (dt_camera_t *)citem->data;
         camctl->cameras = citem = g_list_delete_link(c->cameras, citem);
         dt_print(DT_DEBUG_CAMCTL,
-                 "[camera_control] ERROR: %s on port %s disconnected while mounted\n",
+                 "[camera_control] ERROR: %s on port %s disconnected while mounted",
                  cam->model, cam->port);
         dt_control_log(_("camera `%s' on port `%s' disconnected while mounted"),
                        cam->model, cam->port);
@@ -1105,7 +1105,7 @@ static void *_camera_event_thread(void *data)
   const dt_camera_t *camera = camctl->active_camera;
 
   dt_print(DT_DEBUG_CAMCTL,
-           "[camera_control] starting camera event thread of context %p\n", data);
+           "[camera_control] starting camera event thread of context %p", data);
 
   while(camera->is_tethering == TRUE)
   {
@@ -1118,7 +1118,7 @@ static void *_camera_event_thread(void *data)
       _camera_process_job(camctl, camera, job);
   }
 
-  dt_print(DT_DEBUG_CAMCTL, "[camera_control] exiting camera thread.\n");
+  dt_print(DT_DEBUG_CAMCTL, "[camera_control] exiting camera thread.");
 
   return NULL;
 }
@@ -1137,7 +1137,7 @@ static gboolean _camera_initialize(const dt_camctl_t *c,
     if(err != GP_OK)
      {
       dt_print(DT_DEBUG_CAMCTL,
-               "[camera_control] failed to gp_abilities_list_get_abilities %s\n",
+               "[camera_control] failed to gp_abilities_list_get_abilities %s",
                cam->model);
       return FALSE;
     }
@@ -1146,7 +1146,7 @@ static gboolean _camera_initialize(const dt_camctl_t *c,
     if(err != GP_OK)
      {
       dt_print(DT_DEBUG_CAMCTL,
-               "[camera_control] failed to gp_camera_set_abilities %s\n",
+               "[camera_control] failed to gp_camera_set_abilities %s",
                cam->model);
       return FALSE;
     }
@@ -1156,7 +1156,7 @@ static gboolean _camera_initialize(const dt_camctl_t *c,
     if(err != GP_OK)
     {
       dt_print(DT_DEBUG_CAMCTL,
-               "[camera_control] failed to gp_port_info_list_get_info %s\n",
+               "[camera_control] failed to gp_port_info_list_get_info %s",
                cam->model);
       return FALSE;
     }
@@ -1164,7 +1164,7 @@ static gboolean _camera_initialize(const dt_camctl_t *c,
     if(err != GP_OK)
     {
       dt_print(DT_DEBUG_CAMCTL,
-               "[camera_control] failed to gp_camera_set_port_info %s\n",
+               "[camera_control] failed to gp_camera_set_port_info %s",
                cam->model);
       return FALSE;
     }
@@ -1188,7 +1188,7 @@ static gboolean _camera_initialize(const dt_camctl_t *c,
     if(gp_camera_init(cam->gpcam, camctl->gpcontext) != GP_OK)
     {
       dt_print(DT_DEBUG_CAMCTL,
-               "[camera_control] failed to initialize %s on port %s\n", cam->model,
+               "[camera_control] failed to initialize %s on port %s", cam->model,
                cam->port);
       return FALSE;
     }
@@ -1216,7 +1216,7 @@ static gboolean _camera_initialize(const dt_camctl_t *c,
     dt_pthread_mutex_init(&cam->live_view_synch, NULL);
 
     dt_print(DT_DEBUG_CAMCTL,
-             "[camera_control] %s on port %s initialized\n", cam->model, cam->port);
+             "[camera_control] %s on port %s initialized", cam->model, cam->port);
   }
   return TRUE;
 }
@@ -1262,7 +1262,7 @@ void dt_camctl_import(const dt_camctl_t *c,
                                  filename, GP_FILE_TYPE_NORMAL, camfile, NULL)) < GP_OK)
     {
       dt_print(DT_DEBUG_CAMCTL,
-               "[camera_control] gphoto import failed: %s\n", gp_result_as_string(res));
+               "[camera_control] gphoto import failed: %s", gp_result_as_string(res));
       gp_file_free(camfile);
       continue;
     }
@@ -1270,7 +1270,7 @@ void dt_camctl_import(const dt_camctl_t *c,
     if((res = gp_file_get_data_and_size(camfile, (const char**)&data, &gpsize)) < GP_OK)
     {
       dt_print(DT_DEBUG_CAMCTL,
-               "[camera_control] gphoto import failed: %s\n", gp_result_as_string(res));
+               "[camera_control] gphoto import failed: %s", gp_result_as_string(res));
       gp_file_free(camfile);
       continue;
     }
@@ -1304,7 +1304,7 @@ void dt_camctl_import(const dt_camctl_t *c,
     }
 
     if(!g_file_set_contents(output, data, size, NULL))
-       dt_print(DT_DEBUG_CAMCTL, "[camera_control] failed to write file %s\n", output);
+       dt_print(DT_DEBUG_CAMCTL, "[camera_control] failed to write file %s", output);
     else
       _dispatch_camera_image_downloaded(c, cam, folder, filename, output);
 
@@ -1342,7 +1342,7 @@ time_t dt_camctl_get_image_file_timestamp(const dt_camctl_t *c,
   {
     dt_print(DT_DEBUG_CAMCTL,
              "[camera_control] failed to get file information"
-             " of %s in folder %s on device\n",
+             " of %s in folder %s on device",
              filename, path);
   }
   else
@@ -1374,7 +1374,7 @@ static GList *_camctl_recursive_get_list(const dt_camctl_t *c,
       {
         dt_print(DT_DEBUG_CAMCTL,
                  "[camera_control] failed to get file information"
-                 " of %s in folder %s on device\n",
+                 " of %s in folder %s on device",
                  filename, path);
       }
       else
@@ -1443,7 +1443,7 @@ static GdkPixbuf *_camctl_get_thumbnail(const dt_camctl_t *c,
   {
     dt_print(DT_DEBUG_CAMCTL,
              "[camera_control] failed to get file information"
-             " of %s in folder %s on device\n",
+             " of %s in folder %s on device",
              fn, folder);
     return NULL;
   }
@@ -1471,7 +1471,7 @@ static GdkPixbuf *_camctl_get_thumbnail(const dt_camctl_t *c,
     gp_file_free(preview);
     preview = NULL;
     dt_print(DT_DEBUG_CAMCTL,
-             "[camera_control] failed preview of %s in folder %s\n", fn, folder);
+             "[camera_control] failed preview of %s in folder %s", fn, folder);
     return NULL;
   }
 
@@ -1593,7 +1593,7 @@ void dt_camctl_tether_mode(const dt_camctl_t *c,
     {
       _camctl_lock(c, cam);
       // Start up camera event polling thread
-      dt_print(DT_DEBUG_CAMCTL, "[camera_control] enabling tether mode\n");
+      dt_print(DT_DEBUG_CAMCTL, "[camera_control] enabling tether mode");
       camctl->active_camera = camera;
       camera->is_tethering = TRUE;
       dt_pthread_create(&camctl->camera_event_thread, &_camera_event_thread, (void *)c);
@@ -1602,14 +1602,14 @@ void dt_camctl_tether_mode(const dt_camctl_t *c,
     {
       camera->is_live_viewing = FALSE;
       camera->is_tethering = FALSE;
-      dt_print(DT_DEBUG_CAMCTL, "[camera_control] disabling tether mode\n");
+      dt_print(DT_DEBUG_CAMCTL, "[camera_control] disabling tether mode");
       _camctl_unlock(c);
       // Wait for tether thread with join??
     }
   }
   else
     dt_print(DT_DEBUG_CAMCTL,
-             "[camera_control] failed to set tether mode with reason: %s\n",
+             "[camera_control] failed to set tether mode with reason: %s",
              cam ? "device does not support tethered capture" : "no active camera");
 }
 
@@ -1622,7 +1622,7 @@ const char *dt_camctl_camera_get_model(const dt_camctl_t *c,
      && (cam = camctl->wanted_camera) == NULL)
   {
     dt_print(DT_DEBUG_CAMCTL,
-             "[camera_control] failed to get model of camera, camera==NULL\n");
+             "[camera_control] failed to get model of camera, camera==NULL");
     return NULL;
   }
   return cam->model;
@@ -1702,12 +1702,12 @@ void dt_camctl_camera_build_property_menu(const dt_camctl_t *c,
      && (cam = camctl->wanted_camera) == NULL)
   {
     dt_print(DT_DEBUG_CAMCTL,
-             "[camera_control] failed to build property menu from camera, camera==NULL\n");
+             "[camera_control] failed to build property menu from camera, camera==NULL");
     return;
   }
 
   dt_print(DT_DEBUG_CAMCTL,
-           "[camera_control] building property menu from camera configuration\n");
+           "[camera_control] building property menu from camera configuration");
 
   /* lock camera config mutex while recursive building property menu */
   dt_camera_t *camera = (dt_camera_t *)cam;
@@ -1731,7 +1731,7 @@ void dt_camctl_camera_set_property_string(const dt_camctl_t *c,
      && (cam = camctl->wanted_camera) == NULL)
   {
     dt_print(DT_DEBUG_CAMCTL,
-             "[camera_control] failed to set property from camera, camera==NULL\n");
+             "[camera_control] failed to set property from camera, camera==NULL");
     return;
   }
   dt_camera_t *camera = (dt_camera_t *)cam;
@@ -1756,7 +1756,7 @@ void dt_camctl_camera_set_property_toggle(const dt_camctl_t *c,
      && (cam = camctl->wanted_camera) == NULL)
   {
     dt_print(DT_DEBUG_CAMCTL,
-             "[camera_control] failed to set property from camera, camera==NULL\n");
+             "[camera_control] failed to set property from camera, camera==NULL");
     return;
   }
   dt_camera_t *camera = (dt_camera_t *)cam;
@@ -1781,7 +1781,7 @@ void dt_camctl_camera_set_property_choice(const dt_camctl_t *c,
      && (cam = camctl->wanted_camera) == NULL)
   {
     dt_print(DT_DEBUG_CAMCTL,
-             "[camera_control] failed to set property from camera, camera==NULL\n");
+             "[camera_control] failed to set property from camera, camera==NULL");
     return;
   }
   dt_camera_t *camera = (dt_camera_t *)cam;
@@ -1807,7 +1807,7 @@ void dt_camctl_camera_set_property_int(const dt_camctl_t *c,
      && (cam = camctl->wanted_camera) == NULL)
   {
     dt_print(DT_DEBUG_CAMCTL,
-             "[camera_control] failed to set property from camera, camera==NULL\n");
+             "[camera_control] failed to set property from camera, camera==NULL");
     return;
   }
   dt_camera_t *camera = (dt_camera_t *)cam;
@@ -1833,7 +1833,7 @@ void dt_camctl_camera_set_property_float(const dt_camctl_t *c,
      && (cam = camctl->wanted_camera) == NULL)
   {
     dt_print(DT_DEBUG_CAMCTL,
-             "[camera_control] failed to set property from camera, camera==NULL\n");
+             "[camera_control] failed to set property from camera, camera==NULL");
     return;
   }
   dt_camera_t *camera = (dt_camera_t *)cam;
@@ -1858,7 +1858,7 @@ const char *dt_camctl_camera_get_property(const dt_camctl_t *c,
      && (cam = camctl->wanted_camera) == NULL)
   {
     dt_print(DT_DEBUG_CAMCTL,
-             "[camera_control] failed to get property from camera, camera==NULL\n");
+             "[camera_control] failed to get property from camera, camera==NULL");
     return NULL;
   }
   dt_camera_t *camera = (dt_camera_t *)cam;
@@ -1921,7 +1921,7 @@ int dt_camctl_camera_get_property_type(const dt_camctl_t *c,
      && (cam = camctl->wanted_camera) == NULL)
   {
     dt_print(DT_DEBUG_CAMCTL,
-             "[camera_control] failed to get property type from camera, camera==NULL\n");
+             "[camera_control] failed to get property type from camera, camera==NULL");
     return -1;
   }
   dt_camera_t *camera = (dt_camera_t *)cam;
@@ -1934,7 +1934,7 @@ int dt_camctl_camera_get_property_type(const dt_camctl_t *c,
   {
     dt_print(DT_DEBUG_CAMCTL,
              "[camera_control] failed to get property %s from camera config."
-             " Error Code: %d\n",
+             " Error Code: %d",
              property_name, retrieved_property);
   } else {
     retrieved_widget_type = gp_widget_get_type(widget, widget_type);
@@ -1942,7 +1942,7 @@ int dt_camctl_camera_get_property_type(const dt_camctl_t *c,
     {
       dt_print(DT_DEBUG_CAMCTL,
                "[camera_control] failed to get property type for %s from camera config."
-               " Error Code: %d\n",
+               " Error Code: %d",
                property_name, retrieved_widget_type);
     }
   }
@@ -1977,7 +1977,7 @@ const char *dt_camctl_camera_property_get_first_choice(const dt_camctl_t *c,
   }
   else
     dt_print(DT_DEBUG_CAMCTL,
-             "[camera_control] property name '%s' not found in camera configuration.\n",
+             "[camera_control] property name '%s' not found in camera configuration",
              property_name);
 
   dt_pthread_mutex_unlock(&camera->config_lock);
@@ -2031,7 +2031,7 @@ void dt_camctl_camera_capture(const dt_camctl_t *c,
   if(!cam && (cam = camctl->active_camera) == NULL)
   {
     dt_print(DT_DEBUG_CAMCTL,
-             "[camera_control] Failed to capture from camera, camera==NULL\n");
+             "[camera_control] Failed to capture from camera, camera==NULL");
     return;
   }
   dt_camera_t *camera = (dt_camera_t *)cam;
@@ -2063,7 +2063,7 @@ static void _camera_poll_events(const dt_camctl_t *c,
         dt_print
           (DT_DEBUG_CAMCTL,
            "[camera_control] Camera configuration change event '%s', lets update internal "
-           "configuration cache.\n", (char*)data);
+           "configuration cache", (char*)data);
         // Update individual properties with gp_camera_get_single_config
         if (strstr((char*)data, "PTP Property") && strstr((char*)data, "changed"))
         {
@@ -2089,7 +2089,7 @@ static void _camera_poll_events(const dt_camctl_t *c,
               }
             }
             dt_print(DT_DEBUG_CAMCTL, "[camera_control] Unable to parse event '%s', \
-                falling back to updating by code.", (char*)data);
+                falling back to updating by code", (char*)data);
           }
           char code[5];
           strncpy(code, data + strlen("PTP Property "), 4);
@@ -2106,7 +2106,7 @@ static void _camera_poll_events(const dt_camctl_t *c,
     {
       if(cam->is_tethering)
       {
-        dt_print(DT_DEBUG_CAMCTL, "[camera_control] Camera file added event\n");
+        dt_print(DT_DEBUG_CAMCTL, "[camera_control] Camera file added event");
         CameraFilePath *fp = (CameraFilePath *)data;
         CameraFile *destination;
         const char *output_path = _dispatch_request_image_path(c, NULL, cam);
@@ -2129,12 +2129,12 @@ static void _camera_poll_events(const dt_camctl_t *c,
           }
           else
             dt_print(DT_DEBUG_CAMCTL,
-                     "[camera_control] failed to download file %s\n", output);
+                     "[camera_control] failed to download file %s", output);
           close(handle);
         }
         else
           dt_print(DT_DEBUG_CAMCTL,
-                   "[camera_control] failed to download file %s\n", output);
+                   "[camera_control] failed to download file %s", output);
         g_free(output);
       }
     }
@@ -2259,7 +2259,7 @@ static void _camera_configuration_single_update(const dt_camctl_t *c,
   if (gp_camera_get_single_config(camera->gpcam, name, &remote, c->gpcontext) != GP_OK)
   {
     dt_print(DT_DEBUG_CAMCTL,
-             "[camera_control] failed to get config value for property %s\n", name);
+             "[camera_control] failed to get config value for property %s", name);
     dt_pthread_mutex_unlock(&cam->config_lock);
     return;
   }

--- a/src/common/collection.c
+++ b/src/common/collection.c
@@ -197,37 +197,37 @@ static void _dt_collection_set_selq_pre_sort(const dt_collection_t *collection,
   if(collection->params.query_flags & COLLECTION_QUERY_USE_SORT)
   {
     // we always need filename and version : they are fallback orders in any cases
-    fields = dt_util_dstrcat(fields, ", filename, version");
+    dt_util_str_cat(&fields, ", filename, version");
     if(collection->params.sorts[DT_COLLECTION_SORT_GROUP])
-      fields = dt_util_dstrcat(fields, ", group_id");
+      dt_util_str_cat(&fields, ", group_id");
     if(collection->params.sorts[DT_COLLECTION_SORT_PATH])
-      fields = dt_util_dstrcat(fields, ", film_id");
+      dt_util_str_cat(&fields, ", film_id");
     if(collection->params.sorts[DT_COLLECTION_SORT_DATETIME])
-      fields = dt_util_dstrcat(fields, ", datetime_taken");
+      dt_util_str_cat(&fields, ", datetime_taken");
     if(collection->params.sorts[DT_COLLECTION_SORT_IMPORT_TIMESTAMP])
-      fields = dt_util_dstrcat(fields, ", import_timestamp");
+      dt_util_str_cat(&fields, ", import_timestamp");
     if(collection->params.sorts[DT_COLLECTION_SORT_CHANGE_TIMESTAMP])
-      fields = dt_util_dstrcat(fields, ", change_timestamp");
+      dt_util_str_cat(&fields, ", change_timestamp");
     if(collection->params.sorts[DT_COLLECTION_SORT_EXPORT_TIMESTAMP])
-      fields = dt_util_dstrcat(fields, ", export_timestamp");
+      dt_util_str_cat(&fields, ", export_timestamp");
     if(collection->params.sorts[DT_COLLECTION_SORT_PRINT_TIMESTAMP])
-      fields = dt_util_dstrcat(fields, ", print_timestamp");
+      dt_util_str_cat(&fields, ", print_timestamp");
     if(collection->params.sorts[DT_COLLECTION_SORT_ASPECT_RATIO])
-      fields = dt_util_dstrcat(fields, ", aspect_ratio");
+      dt_util_str_cat(&fields, ", aspect_ratio");
     if(collection->params.sorts[DT_COLLECTION_SORT_RATING])
-      fields = dt_util_dstrcat(fields, ", flags");
+      dt_util_str_cat(&fields, ", flags");
     if(collection->params.sorts[DT_COLLECTION_SORT_CUSTOM_ORDER])
     {
       tag_join = (tagid);
-      fields = dt_util_dstrcat(fields,
-                               ", %s position",
-                               tagid ? "CASE WHEN ti.position IS NULL THEN 0 ELSE ti.position END AS" : "");
+      dt_util_str_cat(&fields,
+                      ", %s position",
+                      tagid ? "CASE WHEN ti.position IS NULL THEN 0 ELSE ti.position END AS" : "");
     }
   }
 
   // clang-format off
-  *selq_pre = dt_util_dstrcat
-    (*selq_pre,
+  dt_util_str_cat
+    (selq_pre,
      "SELECT DISTINCT sel.id"
      "  FROM (SELECT %s"
      "        FROM main.images AS mi"
@@ -258,15 +258,15 @@ int dt_collection_update(const dt_collection_t *collection)
                           and_operator(&and_term), collection->params.film_id);
   }
   // DON'T SELECT IMAGES MARKED TO BE DELETED.
-  wq = dt_util_dstrcat(wq, " %s (flags & %d) != %d",
-                        and_operator(&and_term), DT_IMAGE_REMOVE,
-                        DT_IMAGE_REMOVE);
+  dt_util_str_cat(&wq, " %s (flags & %d) != %d",
+                  and_operator(&and_term), DT_IMAGE_REMOVE,
+                  DT_IMAGE_REMOVE);
 
   /* add where ext if wanted */
   if((collection->params.query_flags & COLLECTION_QUERY_USE_WHERE_EXT))
   {
     gchar *where_ext = dt_collection_get_extended_where(collection, -1);
-    wq = dt_util_dstrcat(wq, " %s %s", and_operator(&and_term), where_ext);
+    dt_util_str_cat(&wq, " %s %s", and_operator(&and_term), where_ext);
     g_free(where_ext);
   }
 
@@ -277,8 +277,8 @@ int dt_collection_update(const dt_collection_t *collection)
   {
     // clang-format off
     /* Show the expanded group... */
-    wq = dt_util_dstrcat
-      (wq,
+    dt_util_str_cat
+      (&wq,
        " AND (group_id = %d OR "
        /* ...and, in unexpanded groups, show the representative image.
         * It's possible that the above WHERE clauses will filter out the representative
@@ -297,7 +297,7 @@ int dt_collection_update(const dt_collection_t *collection)
      * representative image wasn't filtered out.  This is important,
      * because otherwise it may be impossible to collapse the group
      * again. */
-    wq = dt_util_dstrcat(wq, " OR (mi.id = %d)", darktable.gui->expanded_group_id);
+    dt_util_str_cat(&wq, " OR (mi.id = %d)", darktable.gui->expanded_group_id);
   }
 
   // get all the sort items
@@ -325,28 +325,28 @@ int dt_collection_update(const dt_collection_t *collection)
     // some sort orders require to join tables to the query
     if(collection->params.sorts[DT_COLLECTION_SORT_COLOR])
     {
-      selq_post = dt_util_dstrcat
-        (selq_post, " LEFT OUTER JOIN main.color_labels AS b ON sel.id = b.imgid");
+      dt_util_str_cat
+        (&selq_post, " LEFT OUTER JOIN main.color_labels AS b ON sel.id = b.imgid");
     }
     if(collection->params.sorts[DT_COLLECTION_SORT_PATH])
     {
       // clang-format off
-      selq_post = dt_util_dstrcat
-        (selq_post, " JOIN (SELECT id AS film_rolls_id, folder"
+      dt_util_str_cat
+        (&selq_post, " JOIN (SELECT id AS film_rolls_id, folder"
                "       FROM main.film_rolls) ON film_id = film_rolls_id");
       // clang-format on
     }
     if(collection->params.sorts[DT_COLLECTION_SORT_TITLE])
     {
-      selq_post = dt_util_dstrcat
-        (selq_post,
+      dt_util_str_cat
+        (&selq_post,
         " LEFT OUTER JOIN main.meta_data AS mt ON sel.id = mt.id AND mt.key = %d",
         DT_METADATA_XMP_DC_TITLE);
     }
     if(collection->params.sorts[DT_COLLECTION_SORT_DESCRIPTION])
     {
-      selq_post = dt_util_dstrcat
-        (selq_post,
+      dt_util_str_cat
+        (&selq_post,
         " LEFT OUTER JOIN main.meta_data AS md ON sel.id = md.id AND md.key = %d",
         DT_METADATA_XMP_DC_DESCRIPTION);
     }
@@ -359,16 +359,14 @@ int dt_collection_update(const dt_collection_t *collection)
   }
 
   /* store the new query */
-  query
-      = dt_util_dstrcat(query, "%s%s%s %s%s",
-                        selq_pre, wq, selq_post, sq ? sq : "",
-                        (collection->params.query_flags & COLLECTION_QUERY_USE_LIMIT)
-                        ? " " LIMIT_QUERY : "");
-  query_no_group
-      = dt_util_dstrcat(query_no_group, "%s%s%s %s%s",
-                        selq_pre, wq_no_group, selq_post, sq ? sq : "",
-                        (collection->params.query_flags & COLLECTION_QUERY_USE_LIMIT)
-                        ? " " LIMIT_QUERY : "");
+  dt_util_str_cat(&query, "%s%s%s %s%s",
+                  selq_pre, wq, selq_post, sq ? sq : "",
+                  (collection->params.query_flags & COLLECTION_QUERY_USE_LIMIT)
+                  ? " " LIMIT_QUERY : "");
+  dt_util_str_cat(&query_no_group, "%s%s%s %s%s",
+                  selq_pre, wq_no_group, selq_post, sq ? sq : "",
+                  (collection->params.query_flags & COLLECTION_QUERY_USE_LIMIT)
+                  ? " " LIMIT_QUERY : "");
   result = _dt_collection_store(collection, query, query_no_group);
 
   /* free memory used */
@@ -470,9 +468,9 @@ gchar *dt_collection_get_extended_where(const dt_collection_t *collection,
     {
       // exclude the one rule from extended where
       if(i != exclude || mode == 1)
-        complete_string = dt_util_dstrcat(complete_string, "%s", collection->where_ext[i]);
+        dt_util_str_cat(&complete_string, "%s", collection->where_ext[i]);
       else if(i == 0 && g_strcmp0(collection->where_ext[i], ""))
-        complete_string = dt_util_dstrcat(complete_string, "1=1");
+        dt_util_str_cat(&complete_string, "1=1");
     }
   }
   else
@@ -488,10 +486,10 @@ gchar *dt_collection_get_extended_where(const dt_collection_t *collection,
         i < nb_rules && collection->where_ext[i] != NULL;
         i++)
     {
-      rules_txt = dt_util_dstrcat(rules_txt, "%s", collection->where_ext[i]);
+      dt_util_str_cat(&rules_txt, "%s", collection->where_ext[i]);
     }
     if(g_strcmp0(rules_txt, ""))
-      complete_string = dt_util_dstrcat(complete_string, "(%s)", rules_txt);
+      dt_util_str_cat(&complete_string, "(%s)", rules_txt);
 
     g_free(rules_txt);
 
@@ -504,20 +502,20 @@ gchar *dt_collection_get_extended_where(const dt_collection_t *collection,
         i < nb_filters && collection->where_ext[i + nb_rules] != NULL;
         i++)
     {
-      rules_txt = dt_util_dstrcat(rules_txt, "%s", collection->where_ext[i + nb_rules]);
+      dt_util_str_cat(&rules_txt, "%s", collection->where_ext[i + nb_rules]);
     }
 
     if(g_strcmp0(rules_txt, ""))
     {
       if(g_strcmp0(complete_string, ""))
-        complete_string = dt_util_dstrcat(complete_string, " AND ");
-      complete_string = dt_util_dstrcat(complete_string, "(%s)", rules_txt);
+        dt_util_str_cat(&complete_string, " AND ");
+      dt_util_str_cat(&complete_string, "(%s)", rules_txt);
     }
     g_free(rules_txt);
   }
 
   if(!g_strcmp0(complete_string, ""))
-    complete_string = dt_util_dstrcat(complete_string, "1=1");
+    dt_util_str_cat(&complete_string, "1=1");
 
   gchar *where_ext = g_strdup_printf("(%s)", complete_string);
   g_free(complete_string);
@@ -807,7 +805,7 @@ gchar *dt_collection_get_sort_query(const dt_collection_t *collection)
 
     // get the sort query
     gchar *sq = _dt_collection_get_sort_text(sort, sortorder);
-    query = dt_util_dstrcat(query, "%s %s", (i == 0) ? "" : ",", sq);
+    dt_util_str_cat(&query, "%s %s", (i == 0) ? "" : ",", sq);
     g_free(sq);
 
     // set the "already done" values
@@ -823,7 +821,7 @@ gchar *dt_collection_get_sort_query(const dt_collection_t *collection)
   if(!already_last_sort)
   {
     gchar *lsq = _dt_collection_get_sort_text(lastsort, lastsortorder);
-    query = dt_util_dstrcat(query, ", %s", lsq);
+    dt_util_str_cat(&query, ", %s", lsq);
     g_free(lsq);
     if(lastsort == DT_COLLECTION_SORT_FILENAME)
       filename = TRUE;
@@ -831,10 +829,10 @@ gchar *dt_collection_get_sort_query(const dt_collection_t *collection)
 
   // complete the query with fallback if needed
   if(!filename)
-    query = dt_util_dstrcat(query, ", filename%s",
+    dt_util_str_cat(&query, ", filename%s",
                             (first_order) ? " DESC" : "");
 
-  query = dt_util_dstrcat(query, ", version ASC");
+  dt_util_str_cat(&query, ", version ASC");
 
   return query;
 }
@@ -1160,7 +1158,7 @@ void dt_collection_split_operator_datetime(const gchar *input,
 
     if(strcmp(*operator, "") == 0 || strcmp(*operator, "=") == 0 || strcmp(*operator, "<>") == 0)
     {
-      *number1 = dt_util_dstrcat(*number1, "%s%%", txt);
+      dt_util_str_cat(&*number1, "%s%%", txt);
       *number2 = _dt_collection_compute_datetime(">", txt);
     }
     else
@@ -1608,24 +1606,24 @@ static gchar *get_query_string(const dt_collection_properties_t property, const 
         if(!g_strcmp0(elems[i], _("unnamed")))
         {
           // clang-format off
-          query = dt_util_dstrcat(query, "%scamera_id IN (SELECT id"
-                                         "                FROM main.cameras"
-                                         "                WHERE (maker IS NULL AND model IS NULL)"
-                                         "                   OR (TRIM(maker)='' AND TRIM(model)=''))",
-                                         i>0?" OR ":"");
+          dt_util_str_cat(&query, "%scamera_id IN (SELECT id"
+                                  "                FROM main.cameras"
+                                  "                WHERE (maker IS NULL AND model IS NULL)"
+                                  "                   OR (TRIM(maker)='' AND TRIM(model)=''))",
+                                  i>0?" OR ":"");
           // clang-format on
         }
         else
         {
           gchar *cam = _add_wildcards(elems[i]);
-          query = dt_util_dstrcat(query,
-                                  "%scamera_id IN (SELECT id FROM main.cameras WHERE maker || ' ' || model LIKE '%s')",
-                                  i>0?" OR ":"", cam);
+          dt_util_str_cat(&query,
+                          "%scamera_id IN (SELECT id FROM main.cameras WHERE maker || ' ' || model LIKE '%s')",
+                          i>0?" OR ":"", cam);
           g_free(cam);
         }
       }
       g_strfreev(elems);
-      query = dt_util_dstrcat(query, ")");
+      dt_util_str_cat(&query, ")");
       break;
 
     case DT_COLLECTION_PROP_TAG: // tag
@@ -1719,23 +1717,23 @@ static gchar *get_query_string(const dt_collection_properties_t property, const 
       {
         if(!g_strcmp0(elems[i], _("unnamed")))
         {
-          query = dt_util_dstrcat
-            (query,
+          dt_util_str_cat
+            (&query,
              "%slens_id IN (SELECT id FROM main.lens WHERE name IS NULL OR TRIM(name)='' OR UPPER(TRIM(name))='N/A')",
              i>0?" OR ":"");
         }
         else
         {
           gchar *lens = _add_wildcards(elems[i]);
-          query = dt_util_dstrcat(query,
-                                  "%slens_id IN (SELECT id FROM main.lens WHERE name LIKE '%s')",
-                                  i>0?" OR ":"", lens);
+          dt_util_str_cat(&query,
+                          "%slens_id IN (SELECT id FROM main.lens WHERE name LIKE '%s')",
+                          i>0?" OR ":"", lens);
           g_free(lens);
         }
 
       }
       g_strfreev(elems);
-      query = dt_util_dstrcat(query, ")");
+      dt_util_str_cat(&query, ")");
       break;
 
     case DT_COLLECTION_PROP_WHITEBALANCE: // white balance
@@ -1746,23 +1744,23 @@ static gchar *get_query_string(const dt_collection_properties_t property, const 
       {
         if(!g_strcmp0(elems[i], _("unnamed")))
         {
-          query = dt_util_dstrcat
-            (query,
+          dt_util_str_cat
+            (&query,
              "%swhitebalance_id IN (SELECT id FROM main.whitebalance WHERE name IS NULL OR TRIM(name)='')",
              i>0?" OR ":"");
         }
         else
         {
           gchar *whitebalance = _add_wildcards(elems[i]);
-          query = dt_util_dstrcat(query,
-                                  "%swhitebalance_id IN (SELECT id FROM main.whitebalance WHERE name LIKE '%s')",
-                                  i>0?" OR ":"", whitebalance);
+          dt_util_str_cat(&query,
+                          "%swhitebalance_id IN (SELECT id FROM main.whitebalance WHERE name LIKE '%s')",
+                          i>0?" OR ":"", whitebalance);
           g_free(whitebalance);
         }
 
       }
       g_strfreev(elems);
-      query = dt_util_dstrcat(query, ")");
+      dt_util_str_cat(&query, ")");
       break;
 
     case DT_COLLECTION_PROP_FLASH: // flash
@@ -1773,22 +1771,22 @@ static gchar *get_query_string(const dt_collection_properties_t property, const 
       {
         if(!g_strcmp0(elems[i], _("unnamed")))
         {
-          query = dt_util_dstrcat
-            (query,
+          dt_util_str_cat
+            (&query,
              "%sflash_id IN (SELECT id FROM main.flash WHERE name IS NULL OR TRIM(name)='')",
              i>0?" OR ":"");
         }
         else
         {
           gchar *flash = _add_wildcards(elems[i]);
-          query = dt_util_dstrcat(query,
-                                  "%sflash_id IN (SELECT id FROM main.flash WHERE name LIKE '%s')",
-                                  i>0?" OR ":"", flash);
+          dt_util_str_cat(&query,
+                          "%sflash_id IN (SELECT id FROM main.flash WHERE name LIKE '%s')",
+                          i>0?" OR ":"", flash);
           g_free(flash);
         }
       }
       g_strfreev(elems);
-      query = dt_util_dstrcat(query, ")");
+      dt_util_str_cat(&query, ")");
       break;
 
     case DT_COLLECTION_PROP_EXPOSURE_PROGRAM: // exposure program
@@ -1799,22 +1797,22 @@ static gchar *get_query_string(const dt_collection_properties_t property, const 
       {
         if(!g_strcmp0(elems[i], _("unnamed")))
         {
-          query = dt_util_dstrcat
-            (query,
+          dt_util_str_cat
+            (&query,
              "%sexposure_program_id IN (SELECT id FROM main.exposure_program WHERE name IS NULL OR TRIM(name)='')",
              i>0?" OR ":"");
         }
         else
         {
           gchar *exposure_program = _add_wildcards(elems[i]);
-          query = dt_util_dstrcat(query,
-                                  "%sexposure_program_id IN (SELECT id FROM main.exposure_program WHERE name LIKE '%s')",
-                                  i>0?" OR ":"", exposure_program);
+          dt_util_str_cat(&query,
+                          "%sexposure_program_id IN (SELECT id FROM main.exposure_program WHERE name LIKE '%s')",
+                          i>0?" OR ":"", exposure_program);
           g_free(exposure_program);
         }
       }
       g_strfreev(elems);
-      query = dt_util_dstrcat(query, ")");
+      dt_util_str_cat(&query, ")");
       break;
 
     case DT_COLLECTION_PROP_METERING_MODE: // metering mode
@@ -1825,22 +1823,22 @@ static gchar *get_query_string(const dt_collection_properties_t property, const 
       {
         if(!g_strcmp0(elems[i], _("unnamed")))
         {
-          query = dt_util_dstrcat
-            (query,
+          dt_util_str_cat
+            (&query,
              "%smetering_mode_id IN (SELECT id FROM main.metering_mode WHERE name IS NULL OR TRIM(name)='')",
              i>0?" OR ":"");
         }
         else
         {
           gchar *metering_mode = _add_wildcards(elems[i]);
-          query = dt_util_dstrcat(query,
-                                  "%smetering_mode_id IN (SELECT id FROM main.metering_mode WHERE name LIKE '%s')",
-                                  i>0?" OR ":"", metering_mode);
+          dt_util_str_cat(&query,
+                          "%smetering_mode_id IN (SELECT id FROM main.metering_mode WHERE name LIKE '%s')",
+                          i>0?" OR ":"", metering_mode);
           g_free(metering_mode);
         }
       }
       g_strfreev(elems);
-      query = dt_util_dstrcat(query, ")");
+      dt_util_str_cat(&query, ")");
       break;
 
     case DT_COLLECTION_PROP_GROUP_ID: // group id
@@ -1850,13 +1848,13 @@ static gchar *get_query_string(const dt_collection_properties_t property, const 
       for(int i = 0; i < g_strv_length(elems); i++)
       {
         gchar *group_ids = _add_wildcards(elems[i]);
-        query = dt_util_dstrcat(query,
-                                "%sgroup_id LIKE '%s'",
-                                i>0?" OR ":"", group_ids);
+        dt_util_str_cat(&query,
+                        "%sgroup_id LIKE '%s'",
+                        i>0?" OR ":"", group_ids);
         g_free(group_ids);
       }
       g_strfreev(elems);
-      query = dt_util_dstrcat(query, ")");
+      dt_util_str_cat(&query, ")");
       break;
 
     case DT_COLLECTION_PROP_FOCAL_LENGTH: // focal length
@@ -2546,9 +2544,9 @@ void dt_collection_update_query(const dt_collection_t *collection,
       {
         const int id = GPOINTER_TO_INT(l->data);
         if(i == 0)
-          txt = dt_util_dstrcat(txt, "%d", id);
+          dt_util_str_cat(&txt, "%d", id);
         else
-          txt = dt_util_dstrcat(txt, ",%d", id);
+          dt_util_str_cat(&txt, ",%d", id);
         i++;
       }
       // 2. search the first imgid not in the list but AFTER the list

--- a/src/common/color_picker.c
+++ b/src/common/color_picker.c
@@ -461,7 +461,7 @@ void dt_color_picker_helper(const dt_iop_buffer_dsc_t *dsc,
       }
       else
         dt_print(DT_DEBUG_ALWAYS,
-                 "[color picker] unable to alloc working memory, denoising skipped\n");
+                 "[color picker] unable to alloc working memory, denoising skipped");
     }
 
     // 4-channel raw images are monochrome, can be read as RGB
@@ -497,7 +497,7 @@ void dt_color_picker_helper(const dt_iop_buffer_dsc_t *dsc,
     {
       // fallback, but this shouldn't happen
       dt_print(DT_DEBUG_ALWAYS,
-               "[colorpicker] unknown colorspace conversion from %s to %s\n",
+               "[colorpicker] unknown colorspace conversion from %s to %s",
                dt_iop_colorspace_to_name(image_cst), dt_iop_colorspace_to_name(picker_cst));
       _color_picker_work_4ch(source, roi, box, pick, NULL, _color_picker_rgb_or_lab, 100);
     }
@@ -519,7 +519,7 @@ void dt_color_picker_helper(const dt_iop_buffer_dsc_t *dsc,
 
   dt_print(DT_DEBUG_PERF,
            "dt_color_picker_helper stats reading %u channels (filters %u) cst %d -> %d "
-           "size %zu denoised %d took %.3f secs (%.3f CPU)\n",
+           "size %zu denoised %d took %.3f secs (%.3f CPU)",
            dsc->channels, dsc->filters, image_cst, picker_cst, _box_size(box), denoise,
            dt_get_lap_time(&start_time.clock), dt_get_lap_utime(&start_time.user));
 }

--- a/src/common/color_vocabulary.c
+++ b/src/common/color_vocabulary.c
@@ -199,7 +199,7 @@ const char *Lch_to_color_name(dt_aligned_pixel_t color)
   // Write all matching ethnicities
   for(int elem = 0; elem < ETHNIE_END; ++elem)
     if(matches[elem])
-      out = dt_util_dstrcat(out, _("average %s skin tone\n"), ethnies[elem].name);
+      dt_util_str_cat(&out, _("average %s skin tone\n"), ethnies[elem].name);
 
   if(is_skin) return out;
 

--- a/src/common/colorchecker.h
+++ b/src/common/colorchecker.h
@@ -497,7 +497,7 @@ static inline const dt_color_checker_patch* dt_color_checker_get_patch_by_name(c
     }
 
   if(patch == NULL)
-    dt_print(DT_DEBUG_ALWAYS, "No patch matching name `%s` was found in %s\n",
+    dt_print(DT_DEBUG_ALWAYS, "No patch matching name `%s` was found in %s",
              name, target_checker->name);
 
   if(index ) *index = idx;

--- a/src/common/colorlabels.c
+++ b/src/common/colorlabels.c
@@ -346,11 +346,11 @@ static float _action_process_color_label(gpointer target,
         for(GList *res_iter = res; res_iter; res_iter = g_list_next(res_iter))
         {
           const GdkRGBA c = darktable.bauhaus->colorlabels[GPOINTER_TO_INT(res_iter->data)];
-          result = dt_util_dstrcat(result,
-                                  "<span foreground='#%02x%02x%02x'>⬤ </span>",
-                                  (guint)(c.red*255),
-                                   (guint)(c.green*255),
-                                   (guint)(c.blue*255));
+          dt_util_str_cat(&result,
+                          "<span foreground='#%02x%02x%02x'>⬤ </span>",
+                          (guint)(c.red*255),
+                          (guint)(c.green*255),
+                          (guint)(c.blue*255));
         }
         g_list_free(res);
         if(result)

--- a/src/common/colorspaces.c
+++ b/src/common/colorspaces.c
@@ -1303,7 +1303,7 @@ static void cms_error_handler(const cmsContext ContextID,
                               const cmsUInt32Number ErrorCode,
                               const char *text)
 {
-  dt_print(DT_DEBUG_ALWAYS, "[lcms2] error %d: %s\n", ErrorCode, text);
+  dt_print(DT_DEBUG_ALWAYS, "[lcms2] error %d: %s", ErrorCode, text);
 }
 
 static gint _sort_profiles(gconstpointer a, gconstpointer b)
@@ -1644,7 +1644,7 @@ dt_colorspaces_t *dt_colorspaces_init()
     {
       dt_print(DT_DEBUG_DEV,
                "output profile `%s' color space `%c%c%c%c'"
-               " not supported for work profile\n",
+               " not supported for work profile",
                prof->name, (char)(color_space >> 24),
                (char)(color_space >> 16),
                (char)(color_space >> 8),
@@ -1660,7 +1660,7 @@ dt_colorspaces_t *dt_colorspaces_init()
                          " it has been replaced by sRGB!"), name);
         dt_print(DT_DEBUG_ALWAYS,
                 "[colorspaces] profile `%s' not usable as histogram profile."
-                 " it has been replaced by sRGB!\n",
+                 " it has been replaced by sRGB!",
                 name);
         res->histogram_type = DT_COLORSPACE_SRGB;
         res->histogram_filename[0] = '\0';
@@ -1857,7 +1857,7 @@ static void dt_colorspaces_get_display_profile_colord_callback(GObject *source,
             _update_display_profile(tmp_data, size, NULL, 0);
           dt_print(DT_DEBUG_CONTROL,
                    "[color profile] colord gave us a new screen profile:"
-                   " '%s' (size: %zu)\n", filename, size);
+                   " '%s' (size: %zu)", filename, size);
         }
         else
         {

--- a/src/common/cups_print.c
+++ b/src/common/cups_print.c
@@ -158,10 +158,10 @@ static int _dest_cb(void *user_data, unsigned flags, cups_dest_t *dest)
     memset(&pr, 0, sizeof(pr));
     dt_get_printer_info(dest->name, &pr);
     if(pctl->cb) pctl->cb(&pr, pctl->user_data);
-    dt_print(DT_DEBUG_PRINT, "[print] new printer %s found\n", dest->name);
+    dt_print(DT_DEBUG_PRINT, "[print] new printer %s found", dest->name);
   }
   else
-    dt_print(DT_DEBUG_PRINT, "[print] skip printer %s as stopped\n", dest->name);
+    dt_print(DT_DEBUG_PRINT, "[print] skip printer %s as stopped", dest->name);
 
   return 1;
 }
@@ -307,7 +307,7 @@ GList *dt_get_papers(const dt_printer_info_t *printer)
               result = g_list_append (result, paper);
 
               dt_print(DT_DEBUG_PRINT,
-                       "[print] new media paper %4d %6.2f x %6.2f (%s) (%s)\n",
+                       "[print] new media paper %4d %6.2f x %6.2f (%s) (%s)",
                        k, paper->width, paper->height, paper->name, paper->common_name);
             }
           }
@@ -317,7 +317,7 @@ GList *dt_get_papers(const dt_printer_info_t *printer)
         httpClose(hcon);
       }
       else
-        dt_print(DT_DEBUG_PRINT, "[print] cannot connect to printer %s (cancel=%d)\n", printer_name, cancel);
+        dt_print(DT_DEBUG_PRINT, "[print] cannot connect to printer %s (cancel=%d)", printer_name, cancel);
     }
 
     cupsFreeDests(num_dests, dests);
@@ -345,7 +345,7 @@ GList *dt_get_papers(const dt_printer_info_t *printer)
         result = g_list_append (result, paper);
 
         dt_print(DT_DEBUG_PRINT,
-                 "[print] new ppd paper %4d %6.2f x %6.2f (%s) (%s)\n",
+                 "[print] new ppd paper %4d %6.2f x %6.2f (%s) (%s)",
                  k, paper->width, paper->height, paper->name, paper->common_name);
       }
       size++;
@@ -384,7 +384,7 @@ GList *dt_get_media_type(const dt_printer_info_t *printer)
           g_strlcpy(media->common_name, choice->text, MAX_NAME);
           result = g_list_prepend (result, media);
 
-          dt_print(DT_DEBUG_PRINT, "[print] new media %2d (%s) (%s)\n", k, media->name, media->common_name);
+          dt_print(DT_DEBUG_PRINT, "[print] new media %2d (%s) (%s)", k, media->name, media->common_name);
           choice++;
         }
       }
@@ -438,7 +438,7 @@ void dt_print_file(const dt_imgid_t imgid, const char *filename, const char *job
     if(fd == -1)
     {
       dt_control_log(_("failed to create temporary file for printing options"));
-      dt_print(DT_DEBUG_ALWAYS, "failed to create temporary PDF for printing options\n");
+      dt_print(DT_DEBUG_ALWAYS, "failed to create temporary PDF for printing options");
       return;
     }
     close(fd);
@@ -507,7 +507,7 @@ void dt_print_file(const dt_imgid_t imgid, const char *filename, const char *job
     else
     {
       dt_control_log(_("printing on `%s' cancelled"), pinfo->printer.name);
-      dt_print(DT_DEBUG_PRINT, "[print]   command fails with %d, cancel printing\n", exit_status);
+      dt_print(DT_DEBUG_PRINT, "[print]   command fails with %d, cancel printing", exit_status);
       return;
     }
   }
@@ -563,9 +563,9 @@ void dt_print_file(const dt_imgid_t imgid, const char *filename, const char *job
 
   // print lp options
 
-  dt_print(DT_DEBUG_PRINT, "[print] printer options (%d)\n", num_options);
+  dt_print(DT_DEBUG_PRINT, "[print] printer options (%d)", num_options);
   for(int k=0; k<num_options; k++)
-    dt_print(DT_DEBUG_PRINT, "[print]   %2d  %s=%s\n", k+1, options[k].name, options[k].value);
+    dt_print(DT_DEBUG_PRINT, "[print]   %2d  %s=%s", k+1, options[k].name, options[k].value);
 
   const int job_id = cupsPrintFile(pinfo->printer.name, filename, job_title, num_options, options);
 

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -539,7 +539,7 @@ static inline size_t _get_total_memory()
   return memInfo.ullTotalPhys / (uint64_t)1024;
 #else
   // assume 2GB until we have a better solution.
-  dt_print(DT_DEBUG_ALWAYS, "[get_total_memory] Unknown memory size. Assuming 2GB\n");
+  dt_print(DT_DEBUG_ALWAYS, "[get_total_memory] Unknown memory size. Assuming 2GB");
   return 2097152;
 #endif
 }
@@ -593,7 +593,7 @@ void dt_dump_pfm_file(
   {
     if(g_mkdir_with_parents(path, 0750))
     {
-      dt_print(DT_DEBUG_ALWAYS, "%20s can't create directory '%s'\n", head, path);
+      dt_print(DT_DEBUG_ALWAYS, "%20s can't create directory '%s'", head, path);
       return;
     }
   }
@@ -614,7 +614,7 @@ void dt_dump_pfm_file(
   FILE *f = g_fopen(fname, "wb");
   if(f == NULL)
   {
-    dt_print(DT_DEBUG_ALWAYS, "%20s can't write file '%s' in wb mode\n", head, fname);
+    dt_print(DT_DEBUG_ALWAYS, "%20s can't write file '%s' in wb mode", head, fname);
     return;
   }
 
@@ -632,7 +632,7 @@ void dt_dump_pfm_file(
     }
   }
 
-  dt_print(DT_DEBUG_ALWAYS, "%-20s %s,  %dx%d, bpp=%d\n", head, fname, width, height, bpp);
+  dt_print(DT_DEBUG_ALWAYS, "%-20s %s,  %dx%d, bpp=%d", head, fname, width, height, bpp);
   fclose(f);
   written += 1;
 }
@@ -884,7 +884,7 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
 #ifndef _WIN32
   if(getuid() == 0 || geteuid() == 0)
     dt_print(DT_DEBUG_ALWAYS,
-        "WARNING: either your user id or the effective user id are 0. are you running darktable as root?\n");
+        "WARNING: either your user id or the effective user id are 0. are you running darktable as root?");
 #endif
 
   // make everything go a lot faster.
@@ -1113,7 +1113,7 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
 #ifdef DT_HAVE_SIGNAL_TRACE
           darktable.unmuted_signal_dbg_acts |= DT_DEBUG_SIGNAL_ACT_PRINT_TRACE; // enable printing of signal tracing
 #else
-          dt_print(DT_DEBUG_ALWAYS, "[signal] print-trace not available, skipping\n");
+          dt_print(DT_DEBUG_ALWAYS, "[signal] print-trace not available, skipping");
 #endif
         }
         else
@@ -1177,7 +1177,7 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
         {
           dt_print(DT_DEBUG_SIGNAL,
                    "[dt_init] unknown signal name: '%s'. use 'ALL'"
-                   " to enable debug for all or use full signal name\n", str);
+                   " to enable debug for all or use full signal name", str);
           g_strfreev(myoptions);
           return usage(argv[0]);
         }
@@ -1196,10 +1196,10 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
         darktable.num_openmp_threads = CLAMP(desired, 1, possible);
         if(desired > possible)
           dt_print(DT_DEBUG_ALWAYS,
-                   "[dt_init --threads] requested %d ompthreads restricted to %d\n",
+                   "[dt_init --threads] requested %d ompthreads restricted to %d",
             desired, possible);
         dt_print(DT_DEBUG_ALWAYS,
-                 "[dt_init --threads] using %d threads for openmp parallel sections\n",
+                 "[dt_init --threads] using %d threads for openmp parallel sections",
           darktable.num_openmp_threads);
         k++;
         argv[k-1] = NULL;
@@ -1360,8 +1360,8 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
     if(darktable.tmp_directory == NULL)
       darktable.tmp_directory = g_dir_make_tmp("darktable_XXXXXX", NULL);
     dt_print(DT_DEBUG_ALWAYS,
-             "[init] darktable dump directory is '%s'\n",
-             (darktable.tmp_directory) ? darktable.tmp_directory : "NOT AVAILABLE");
+             "[init] darktable dump directory is '%s'",
+             (darktable.tmp_directory) ?: "NOT AVAILABLE");
   }
 
   // get valid directories
@@ -1372,7 +1372,7 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
               cachedir_from_command,
               tmpdir_from_command);
 
-  dt_print(DT_DEBUG_MEMORY, "[memory] at startup\n");
+  dt_print(DT_DEBUG_MEMORY, "[memory] at startup");
   dt_print_mem_usage();
 
   char sharedir[PATH_MAX] = { 0 };
@@ -1423,7 +1423,7 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
     }
 
     if(set_env) g_setenv("XDG_DATA_DIRS", new_xdg_data_dirs, 1);
-    dt_print(DT_DEBUG_DEV, "new_xdg_data_dirs: %s\n", new_xdg_data_dirs);
+    dt_print(DT_DEBUG_DEV, "new_xdg_data_dirs: %s", new_xdg_data_dirs);
     g_free(new_xdg_data_dirs);
   }
 
@@ -1512,7 +1512,7 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
   darktable.db = dt_database_init(dbfilename_from_command, load_data, init_gui);
   if(darktable.db == NULL)
   {
-    dt_print(DT_DEBUG_ALWAYS, "ERROR : cannot open database\n");
+    dt_print(DT_DEBUG_ALWAYS, "ERROR : cannot open database");
     darktable_splash_screen_destroy();
     return 1;
   }
@@ -1525,7 +1525,7 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
 #ifndef MAC_INTEGRATION
       // send the images to the other instance via dbus
       dt_print(DT_DEBUG_ALWAYS,
-               "[dt_init] trying to open the images in the running instance\n");
+               "[dt_init] trying to open the images in the running instance");
 
       GDBusConnection *connection = NULL;
       for(int i = 1; i < argc; i++)
@@ -1549,7 +1549,7 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
     darktable_splash_screen_destroy(); // dismiss splash screen before potentially showing error dialog
     if(!image_loaded_elsewhere) dt_database_show_error(darktable.db);
 
-    dt_print(DT_DEBUG_ALWAYS, "ERROR: can't acquire database lock, aborting.\n");
+    dt_print(DT_DEBUG_ALWAYS, "ERROR: can't acquire database lock, aborting.");
     return 1;
   }
 
@@ -1745,7 +1745,7 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
     darktable_splash_screen_set_progress(_("initializing GUI"));
     if(dt_gui_gtk_init(darktable.gui))
     {
-      dt_print(DT_DEBUG_ALWAYS, "[dt_init] ERROR: can't init gui, aborting.\n");
+      dt_print(DT_DEBUG_ALWAYS, "[dt_init] ERROR: can't init gui, aborting.");
       darktable_splash_screen_destroy();
       return 1;
     }
@@ -1761,7 +1761,7 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
   // we'll crash everywhere later on.
   if(!darktable.develop)
   {
-    dt_print(DT_DEBUG_ALWAYS, "[dt_init] ERROR: can't init develop system, aborting.\n");
+    dt_print(DT_DEBUG_ALWAYS, "[dt_init] ERROR: can't init develop system, aborting.");
     darktable_splash_screen_destroy();
     return 1;
   }
@@ -1779,24 +1779,24 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
   // check if all modules have a iop order assigned
   if(dt_ioppr_check_so_iop_order(darktable.iop, darktable.iop_order_list))
   {
-    dt_print(DT_DEBUG_ALWAYS, "[dt_init] ERROR: iop order looks bad, aborting.\n");
+    dt_print(DT_DEBUG_ALWAYS, "[dt_init] ERROR: iop order looks bad, aborting.");
     darktable_splash_screen_destroy();
     return 1;
   }
 
   if(darktable.dump_pfm_module)
     dt_print(DT_DEBUG_ALWAYS,
-             "[dt_init] writing intermediate pfm files for module '%s'\n",
+             "[dt_init] writing intermediate pfm files for module '%s'",
       darktable.dump_pfm_module);
 
   if(darktable.dump_pfm_pipe)
     dt_print(DT_DEBUG_ALWAYS,
-             "[dt_init] writing pfm files for module '%s' processing the pipeline\n",
+             "[dt_init] writing pfm files for module '%s' processing the pipeline",
       darktable.dump_pfm_pipe);
 
   if(darktable.dump_diff_pipe)
     dt_print(DT_DEBUG_ALWAYS,
-             "[dt_init] writing CPU/GPU diff pfm files for module '%s' processing the pipeline\n",
+             "[dt_init] writing CPU/GPU diff pfm files for module '%s' processing the pipeline",
       darktable.dump_diff_pipe);
 
   if(init_gui)
@@ -1827,7 +1827,7 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
     dt_gui_process_events();
   }
 
-  dt_print(DT_DEBUG_MEMORY, "[memory] after successful startup\n");
+  dt_print(DT_DEBUG_MEMORY, "[memory] after successful startup");
   dt_print_mem_usage();
 
 /* init lua last, since it's user made stuff it must be in the real environment */
@@ -1915,7 +1915,7 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
   }
 
   dt_print(DT_DEBUG_CONTROL,
-           "[dt_init] startup took %f seconds\n", dt_get_wtime() - start_wtime);
+           "[dt_init] startup took %f seconds", dt_get_wtime() - start_wtime);
   return 0;
 }
 
@@ -1956,19 +1956,19 @@ void dt_get_sysresource_level()
     const int oldgrp = res->group;
     res->group = 4 * level;
     dt_print(DT_DEBUG_ALWAYS,
-             "[dt_get_sysresource_level] switched to %i as `%s'\n",
+             "[dt_get_sysresource_level] switched to %i as `%s'",
              level, config);
     dt_print(DT_DEBUG_ALWAYS,
-             "  total mem:       %luMB\n",
+             "  total mem:       %luMB",
              res->total_memory / 1024lu / 1024lu);
     dt_print(DT_DEBUG_ALWAYS,
-             "  mipmap cache:    %luMB\n",
+             "  mipmap cache:    %luMB",
              _get_mipmap_size() / 1024lu / 1024lu);
     dt_print(DT_DEBUG_ALWAYS,
-             "  available mem:   %luMB\n",
+             "  available mem:   %luMB",
              dt_get_available_mem() / 1024lu / 1024lu);
     dt_print(DT_DEBUG_ALWAYS,
-             "  singlebuff:      %luMB\n",
+             "  singlebuff:      %luMB",
              dt_get_singlebuffer_mem() / 1024lu / 1024lu);
 
     res->group = oldgrp;
@@ -2100,7 +2100,7 @@ void dt_cleanup()
 
         dt_print(DT_DEBUG_SQL, "[db backup] removing old snap: %s... ", snaps_to_remove[i]);
         const int retunlink = g_remove(snaps_to_remove[i++]);
-        dt_print(DT_DEBUG_SQL, "%s\n", retunlink == 0 ? "success" : "failed!");
+        dt_print(DT_DEBUG_SQL, "%s", retunlink == 0 ? "success" : "failed!");
       }
     }
   }
@@ -2157,7 +2157,7 @@ void dt_print_ext(const char *msg, ...)
   vsnprintf(vbuf, sizeof(vbuf), msg, ap);
   va_end(ap);
 
-  printf("%11.4f %s", dt_get_wtime() - darktable.start_wtime, vbuf);
+  printf("%11.4f %s\n", dt_get_wtime() - darktable.start_wtime, vbuf);
   fflush(stdout);
 }
 
@@ -2231,7 +2231,7 @@ void dt_show_times(const dt_times_t *start, const char *prefix)
              "%s took %.3f secs (%.3f CPU)",
              prefix, end.clock - start->clock,
              end.user - start->user);
-    dt_print(DT_DEBUG_PERF, "%s\n", buf);
+    dt_print(DT_DEBUG_PERF, "%s", buf);
   }
 }
 
@@ -2258,14 +2258,14 @@ void dt_show_times_f(const dt_times_t *start,
       vsnprintf(buf + n, sizeof(buf) - n, suffix, ap);
       va_end(ap);
     }
-    dt_print(DT_DEBUG_PERF, "%s\n", buf);
+    dt_print(DT_DEBUG_PERF, "%s", buf);
   }
 }
 
 int dt_worker_threads()
 {
   const int wthreads = (_get_total_memory() >> 19) >= 15 && dt_get_num_threads() >= 4 ? 7 : 4;
-  dt_print(DT_DEBUG_DEV, "[dt_worker_threads] using %i worker threads\n", wthreads);
+  dt_print(DT_DEBUG_DEV, "[dt_worker_threads] using %i worker threads", wthreads);
   return wthreads;
 }
 
@@ -2302,7 +2302,7 @@ void dt_configure_runtime_performance(const int old, char *info)
 
   dt_print(DT_DEBUG_DEV,
            "[dt_configure_runtime_performance] found a %s %zu-bit"
-           " system with %zu Mb ram and %zu cores\n",
+           " system with %zu Mb ram and %zu cores",
            (sufficient) ? "sufficient" : "low performance",
            bits, mem, threads);
 
@@ -2312,7 +2312,7 @@ void dt_configure_runtime_performance(const int old, char *info)
   {
     dt_conf_set_bool("ui/performance", !sufficient);
     dt_print(DT_DEBUG_DEV,
-             "[dt_configure_runtime_performance] ui/performance=%s\n",
+             "[dt_configure_runtime_performance] ui/performance=%s",
              (sufficient) ? "FALSE" : "TRUE");
   }
 
@@ -2320,7 +2320,7 @@ void dt_configure_runtime_performance(const int old, char *info)
   {
     dt_conf_set_string("resourcelevel", (sufficient) ? "default" : "small");
     dt_print(DT_DEBUG_DEV,
-             "[dt_configure_runtime_performance] resourcelevel=%s\n",
+             "[dt_configure_runtime_performance] resourcelevel=%s",
              (sufficient) ? "default" : "small");
   }
 
@@ -2341,7 +2341,7 @@ void dt_configure_runtime_performance(const int old, char *info)
     // enable cache_disk_backend_full when user has over 8gb free diskspace
     dt_conf_set_bool("cache_disk_backend_full", largedisk);
     dt_print(DT_DEBUG_DEV,
-             "[dt_configure_runtime_performance] cache_disk_backend_full=%s\n",
+             "[dt_configure_runtime_performance] cache_disk_backend_full=%s",
              (largedisk) ? "TRUE" : "FALSE");
   }
 
@@ -2529,7 +2529,7 @@ void dt_print_mem_usage()
 
   if(KERN_SUCCESS != task_info(mach_task_self(), TASK_BASIC_INFO, (task_info_t)&t_info, &t_info_count))
   {
-    dt_print(DT_DEBUG_ALWAYS, "[memory] task memory info unknown.\n");
+    dt_print(DT_DEBUG_ALWAYS, "[memory] task memory info unknown.");
     return;
   }
 
@@ -2538,7 +2538,7 @@ void dt_print_mem_usage()
                   "[memory] max address space (vmpeak): %15s\n"
                   "            [memory] cur address space (vmsize): %12llu kB\n"
                   "            [memory] max used memory   (vmhwm ): %15s\n"
-                  "            [memory] cur used memory   (vmrss ): %12llu kB\n",
+                  "            [memory] cur used memory   (vmrss ): %12llu kB",
           "unknown", (uint64_t)t_info.virtual_size / 1024, "unknown", (uint64_t)t_info.resident_size / 1024);
 #elif defined (_WIN32)
   //Based on: http://stackoverflow.com/questions/63166/how-to-determine-cpu-and-memory-consumption-from-inside-a-process
@@ -2564,12 +2564,12 @@ void dt_print_mem_usage()
                   "[memory] max address space (vmpeak): %12llu kB\n"
                   "            [memory] cur address space (vmsize): %12llu kB\n"
                   "            [memory] max used memory   (vmhwm ): %12llu kB\n"
-                  "            [memory] cur used memory   (vmrss ): %12llu Kb\n",
+                  "            [memory] cur used memory   (vmrss ): %12llu Kb",
           virtualMemUsedByMeMax / 1024, virtualMemUsedByMe / 1024, physMemUsedByMeMax / 1024,
           physMemUsedByMe / 1024);
 
 #else
-  dt_print(DT_DEBUG_ALWAYS, "dt_print_mem_usage() currently unsupported on this platform\n");
+  dt_print(DT_DEBUG_ALWAYS, "dt_print_mem_usage() currently unsupported on this platform");
 #endif
 }
 

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -449,9 +449,10 @@ void dt_cleanup();
          && !(DT_DEBUG_RESTRICT & (thread) & ~darktable.unmuted)) \
         func(__VA_ARGS__); } while(0)
 
-#define dt_print_pipe(thread, ...) dt_debug_if(thread, dt_print_pipe_ext, __VA_ARGS__)
 #define dt_print(thread, ...) dt_debug_if(thread, dt_print_ext, __VA_ARGS__)
 #define dt_print_nts(thread, ...) dt_debug_if(thread, dt_print_nts_ext, __VA_ARGS__)
+#define dt_print_pipe(thread, title, pipe, module, device, roi_in, roi_out, ...) \
+  dt_debug_if(thread, dt_print_pipe_ext, title, pipe, module, device, roi_in, roi_out, " " __VA_ARGS__)
 
 void dt_print_ext(const char *msg, ...)
   __attribute__((format(printf, 1, 2)));
@@ -907,7 +908,7 @@ static inline void dt_unreachable_codepath_with_caller(const char *description,
 {
   dt_print(DT_DEBUG_ALWAYS,
            "[dt_unreachable_codepath] {%s} %s:%d (%s) - we should not be here."
-           " please report this to the developers.",
+           " please report this to the developers",
            description, file, line, function);
   __builtin_unreachable();
 }

--- a/src/common/database.c
+++ b/src/common/database.c
@@ -396,8 +396,8 @@ end:
     sqlite3_exec(db->handle, "COMMIT", NULL, NULL, NULL);
   else
   {
-    dt_print(DT_DEBUG_ALWAYS, "[init] failing query: `%s'\n", failing_query);
-    dt_print(DT_DEBUG_ALWAYS, "[init]   %s\n", sqlite3_errmsg(db->handle));
+    dt_print(DT_DEBUG_ALWAYS, "[init] failing query: `%s'", failing_query);
+    dt_print(DT_DEBUG_ALWAYS, "[init]   %s", sqlite3_errmsg(db->handle));
     sqlite3_exec(db->handle, "ROLLBACK TRANSACTION", NULL, NULL, NULL);
   }
 
@@ -412,7 +412,7 @@ end:
     if(sqlite3_exec(db->handle, _query, NULL, NULL, NULL) != SQLITE_OK)          \
     {                                                                            \
       dt_print(DT_DEBUG_ALWAYS, _message);                                       \
-      dt_print(DT_DEBUG_ALWAYS, "[init]   %s\n", sqlite3_errmsg(db->handle));    \
+      dt_print(DT_DEBUG_ALWAYS, "[init]   %s", sqlite3_errmsg(db->handle));      \
       FINALIZE;                                                                  \
       sqlite3_exec(db->handle, "ROLLBACK TRANSACTION", NULL, NULL, NULL);        \
       return version;                                                            \
@@ -425,7 +425,7 @@ end:
     if(sqlite3_step(_stmt) != _expected)                                         \
     {                                                                            \
       dt_print(DT_DEBUG_ALWAYS, _message);                                       \
-      dt_print(DT_DEBUG_ALWAYS, "[init]   %s\n", sqlite3_errmsg(db->handle));    \
+      dt_print(DT_DEBUG_ALWAYS, "[init]   %s", sqlite3_errmsg(db->handle));      \
       FINALIZE;                                                                  \
       sqlite3_exec(db->handle, "ROLLBACK TRANSACTION", NULL, NULL, NULL);        \
       return version;                                                            \
@@ -438,7 +438,7 @@ end:
     if(sqlite3_prepare_v2(db->handle, _query, -1, &_stmt, NULL) != SQLITE_OK)    \
     {                                                                            \
       dt_print(DT_DEBUG_ALWAYS, _message);                                       \
-      dt_print(DT_DEBUG_ALWAYS, "[init]   %s\n", sqlite3_errmsg(db->handle));    \
+      dt_print(DT_DEBUG_ALWAYS, "[init]   %s", sqlite3_errmsg(db->handle));      \
       FINALIZE;                                                                  \
       sqlite3_exec(db->handle, "ROLLBACK TRANSACTION", NULL, NULL, NULL);        \
       return version;                                                            \
@@ -1147,7 +1147,7 @@ static int _upgrade_library_schema_step(dt_database_t *db, int version)
     while(sqlite3_step(sel_stmt) == SQLITE_ROW)
     {
       const char *op_name = (const char *)sqlite3_column_text(sel_stmt, 0);
-      dt_print(DT_DEBUG_ALWAYS, "[init] operation %s with no iop_order while upgrading database\n", op_name);
+      dt_print(DT_DEBUG_ALWAYS, "[init] operation %s with no iop_order while upgrading database", op_name);
     }
     sqlite3_finalize(sel_stmt);
     // clang-format off
@@ -2990,7 +2990,7 @@ static int _upgrade_data_schema_step(dt_database_t *db, int version)
     while(sqlite3_step(sel_stmt) == SQLITE_ROW)
     {
       const char *op_name = (const char *)sqlite3_column_text(sel_stmt, 0);
-      dt_print(DT_DEBUG_ALWAYS, "[init] operation %s with no iop_order while upgrading style_items in database\n", op_name);
+      dt_print(DT_DEBUG_ALWAYS, "[init] operation %s with no iop_order while upgrading style_items in database", op_name);
     }
     sqlite3_finalize(sel_stmt);
     // clang-format off
@@ -3620,7 +3620,7 @@ static void _sanitize_db(dt_database_t *db)
     {
       gchar *new_tag = dt_util_foo_to_utf8(tag);
       dt_print(DT_DEBUG_ALWAYS,
-               "[init]: tag `%s' is not valid utf8, replacing it with `%s'\n", tag, new_tag);
+               "[init]: tag `%s' is not valid utf8, replacing it with `%s'", tag, new_tag);
       sqlite3_bind_text(innerstmt, 1, new_tag, -1, SQLITE_TRANSIENT);
       sqlite3_bind_int(innerstmt, 2, id);
       sqlite3_step(innerstmt);
@@ -3647,7 +3647,7 @@ static void _sanitize_db(dt_database_t *db)
     if(sqlite3_exec(db->handle, _query, NULL, NULL, NULL) != SQLITE_OK)            \
     {                                                                              \
       dt_print(DT_DEBUG_ALWAYS, _message);                                         \
-      dt_print(DT_DEBUG_ALWAYS, "[init]   %s\n", sqlite3_errmsg(db->handle));      \
+      dt_print(DT_DEBUG_ALWAYS, "[init]   %s", sqlite3_errmsg(db->handle));        \
       FINALIZE;                                                                    \
       sqlite3_exec(db->handle, "ROLLBACK TRANSACTION", NULL, NULL, NULL);          \
       return FALSE;                                                                \
@@ -3660,7 +3660,7 @@ static void _sanitize_db(dt_database_t *db)
     if(sqlite3_step(_stmt) != _expected)                                           \
     {                                                                              \
       dt_print(DT_DEBUG_ALWAYS, _message);                                         \
-      dt_print(DT_DEBUG_ALWAYS, "[init]   %s\n", sqlite3_errmsg(db->handle));      \
+      dt_print(DT_DEBUG_ALWAYS, "[init]   %s", sqlite3_errmsg(db->handle));        \
       FINALIZE;                                                                    \
       sqlite3_exec(db->handle, "ROLLBACK TRANSACTION", NULL, NULL, NULL);          \
       return FALSE;                                                                \
@@ -3673,7 +3673,7 @@ static void _sanitize_db(dt_database_t *db)
     if(sqlite3_prepare_v2(db->handle, _query, -1, &_stmt, NULL) != SQLITE_OK)      \
     {                                                                              \
       dt_print(DT_DEBUG_ALWAYS, _message);                                         \
-      dt_print(DT_DEBUG_ALWAYS, "[init]   %s\n", sqlite3_errmsg(db->handle));      \
+      dt_print(DT_DEBUG_ALWAYS, "[init]   %s", sqlite3_errmsg(db->handle));        \
       FINALIZE;                                                                    \
       sqlite3_exec(db->handle, "ROLLBACK TRANSACTION", NULL, NULL, NULL);          \
       return FALSE;                                                                \
@@ -3874,7 +3874,7 @@ lock_again:
           else
           {
             dt_print(DT_DEBUG_ALWAYS,
-                     "[init] the database lock file contains a pid that seems to be alive in your system: %d\n",
+                     "[init] the database lock file contains a pid that seems to be alive in your system: %d",
                      db->error_other_pid);
             db->error_message
               = g_strdup_printf(_("the database lock file contains a pid that seems to be alive in your system: %d"),
@@ -3883,7 +3883,7 @@ lock_again:
         }
         else
         {
-          dt_print(DT_DEBUG_ALWAYS, "[init] the database lock file seems to be empty\n");
+          dt_print(DT_DEBUG_ALWAYS, "[init] the database lock file seems to be empty");
           db->error_message = g_strdup_printf(_("the database lock file seems to be empty"));
         }
         close(fd);
@@ -3892,7 +3892,7 @@ lock_again:
       {
         int err = errno;
         dt_print(DT_DEBUG_ALWAYS,
-                 "[init] error opening the database lock file for reading: %s\n",
+                 "[init] error opening the database lock file for reading: %s",
                  strerror(err));
         db->error_message = g_strdup_printf(_("error opening the database lock file for reading: %s"), strerror(err));
       }
@@ -3981,7 +3981,7 @@ static void _ask_for_upgrade(const gchar *dbname, const gboolean has_gui)
   // if there's no gui just leave
   if(!has_gui)
   {
-    dt_print(DT_DEBUG_ALWAYS, "[init] database `%s' is out-of-date. aborting.\n", dbname);
+    dt_print(DT_DEBUG_ALWAYS, "[init] database `%s' is out-of-date. aborting", dbname);
     exit(1);
   }
 
@@ -4003,7 +4003,7 @@ static void _ask_for_upgrade(const gchar *dbname, const gboolean has_gui)
   // if no upgrade, we exit now, nothing we can do more
   if(!shall_we_update_the_db)
   {
-    dt_print(DT_DEBUG_ALWAYS, "[init] we shall not update the database, aborting.\n");
+    dt_print(DT_DEBUG_ALWAYS, "[init] we shall not update the database, aborting.");
     exit(1);
   }
 }
@@ -4042,7 +4042,7 @@ void dt_database_backup(const char *filename)
       int fd = g_open(backup, O_CREAT, S_IRUSR);
       if(fd < 0 || !g_close(fd, &gerror)) copy_status = FALSE;
     }
-    if(!copy_status) dt_print(DT_DEBUG_ALWAYS, "[backup failed] %s -> %s\n", filename, backup);
+    if(!copy_status) dt_print(DT_DEBUG_ALWAYS, "[backup failed] %s -> %s", filename, backup);
 
     g_object_unref(src);
     g_object_unref(dest);
@@ -4168,7 +4168,7 @@ start:
     dt_database_backup(dbfilename_library);
   }
 
-  dt_print(DT_DEBUG_SQL, "[init sql] library: %s, data: %s\n",
+  dt_print(DT_DEBUG_SQL, "[init sql] library: %s, data: %s",
            dbfilename_library, dbfilename_data);
 
   /* having more than one instance of darktable using the same database is a bad idea */
@@ -4178,7 +4178,7 @@ start:
   if(!db->lock_acquired)
   {
     dt_print(DT_DEBUG_ALWAYS,
-             "[init] database is locked, probably another process is already using it\n");
+             "[init] database is locked, probably another process is already using it");
     g_free(dbname);
     return db;
   }
@@ -4187,14 +4187,11 @@ start:
   /* opening / creating database */
   if(sqlite3_open(db->dbfilename_library, &db->handle))
   {
-    dt_print(DT_DEBUG_ALWAYS, "[init] could not find database ");
-    if(dbname)
-      dt_print(DT_DEBUG_ALWAYS, "`%s'!\n", dbname);
-    else
-      dt_print(DT_DEBUG_ALWAYS, "\n");
-    dt_print(DT_DEBUG_ALWAYS, "[init] maybe your %s/darktablerc is corrupt?\n", datadir);
+    dt_print(DT_DEBUG_ALWAYS, "[init] could not find database %s%s%s",
+                              dbname ? " `" : "", dbname ? dbname : "", dbname ? "'!" : "");
+    dt_print(DT_DEBUG_ALWAYS, "[init] maybe your %s/darktablerc is corrupt?", datadir);
     dt_loc_get_datadir(dbfilename_library, sizeof(dbfilename_library));
-    dt_print(DT_DEBUG_ALWAYS, "[init] try `cp %s/darktablerc %s/darktablerc'\n",
+    dt_print(DT_DEBUG_ALWAYS, "[init] try `cp %s/darktablerc %s/darktablerc'",
              dbfilename_library, datadir);
     sqlite3_close(db->handle);
     g_free(dbname);
@@ -4219,7 +4216,7 @@ start:
   if(rc != SQLITE_OK || sqlite3_step(stmt) != SQLITE_DONE)
   {
     sqlite3_finalize(stmt);
-    dt_print(DT_DEBUG_ALWAYS, "[init] database `%s' couldn't be opened. aborting\n",
+    dt_print(DT_DEBUG_ALWAYS, "[init] database `%s' couldn't be opened. aborting",
              dbfilename_data);
     dt_database_destroy(db);
     db = NULL;
@@ -4265,7 +4262,7 @@ start:
         {
           // we couldn't upgrade the db for some reason. bail out.
           dt_print(DT_DEBUG_ALWAYS,
-                   "[init] database `%s' couldn't be upgraded from version %d to %d. aborting\n",
+                   "[init] database `%s' couldn't be upgraded from version %d to %d. aborting",
                    dbfilename_data, db_version, CURRENT_DATABASE_VERSION_DATA);
           dt_database_destroy(db);
           db = NULL;
@@ -4282,7 +4279,7 @@ start:
         // newer: bail out
         _too_new_db_version(dbfilename_data, has_gui);
         dt_print(DT_DEBUG_ALWAYS,
-                 "[init] database version of `%s' is too new for this build of darktable. aborting\n",
+                 "[init] database version of `%s' is too new for this build of darktable. aborting",
                  dbfilename_data);
         dt_database_destroy(db);
         db = NULL;
@@ -4375,7 +4372,7 @@ start:
       {
         dt_print(DT_DEBUG_ALWAYS,
                  "[init] database `%s' is corrupt and can't be opened! either replace it from a backup or "
-                 "delete the file so that darktable can create a new one the next time. aborting\n",
+                 "delete the file so that darktable can create a new one the next time. aborting",
                  dbfilename_data);
         g_free(data_snap);
         goto error;
@@ -4386,9 +4383,9 @@ start:
       dt_print(DT_DEBUG_ALWAYS, "[init] deleting `%s' on user request", dbfilename_data);
 
       if(g_unlink(dbfilename_data) == 0)
-        dt_print(DT_DEBUG_ALWAYS, " ... ok\n");
+        dt_print(DT_DEBUG_ALWAYS, " ... ok");
       else
-        dt_print(DT_DEBUG_ALWAYS, " ... failed\n");
+        dt_print(DT_DEBUG_ALWAYS, " ... failed");
 
       if(resp == GTK_RESPONSE_ACCEPT && data_snap)
       {
@@ -4412,9 +4409,9 @@ start:
             if(fd < 0 || !g_close(fd, &gerror)) copy_status = FALSE;
           }
           if(copy_status)
-            dt_print(DT_DEBUG_ALWAYS, " success!\n");
+            dt_print(DT_DEBUG_ALWAYS, " success!");
           else
-            dt_print(DT_DEBUG_ALWAYS, " failed!\n");
+            dt_print(DT_DEBUG_ALWAYS, " failed!");
 
           g_object_unref(src);
           g_object_unref(dest);
@@ -4449,7 +4446,7 @@ start:
       {
         // we couldn't upgrade the db for some reason. bail out.
         dt_print(DT_DEBUG_ALWAYS,
-                 "[init] database `%s' couldn't be upgraded from version %d to %d. aborting\n",
+                 "[init] database `%s' couldn't be upgraded from version %d to %d. aborting",
                  dbname, db_version, CURRENT_DATABASE_VERSION_LIBRARY);
         dt_database_destroy(db);
         db = NULL;
@@ -4465,7 +4462,7 @@ start:
       // newer: bail out. it's better than what we did before: delete everything
       _too_new_db_version(dbfilename_library, has_gui);
       dt_print(DT_DEBUG_ALWAYS,
-               "[init] database version of `%s' is too new for this build of darktable. aborting\n",
+               "[init] database version of `%s' is too new for this build of darktable. aborting",
                dbname);
       dt_database_destroy(db);
       db = NULL;
@@ -4556,7 +4553,7 @@ start:
     {
       dt_print(DT_DEBUG_ALWAYS,
                "[init] database `%s' is corrupt and can't be opened! either replace it from a backup or "
-               "delete the file so that darktable can create a new one the next time. aborting\n",
+               "delete the file so that darktable can create a new one the next time. aborting",
                dbfilename_library);
       g_free(data_snap);
       goto error;
@@ -4567,9 +4564,9 @@ start:
     dt_print(DT_DEBUG_ALWAYS, "[init] deleting `%s' on user request", dbfilename_library);
 
     if(g_unlink(dbfilename_library) == 0)
-      dt_print(DT_DEBUG_ALWAYS, " ... ok\n");
+      dt_print(DT_DEBUG_ALWAYS, " ... ok");
     else
-      dt_print(DT_DEBUG_ALWAYS, " ... failed\n");
+      dt_print(DT_DEBUG_ALWAYS, " ... failed");
 
     if(resp == GTK_RESPONSE_ACCEPT && data_snap)
     {
@@ -4593,9 +4590,9 @@ start:
           if(fd < 0 || !g_close(fd, &gerror)) copy_status = FALSE;
         }
         if(copy_status)
-          dt_print(DT_DEBUG_ALWAYS, " success!\n");
+          dt_print(DT_DEBUG_ALWAYS, " success!");
         else
-          dt_print(DT_DEBUG_ALWAYS, " failed!\n");
+          dt_print(DT_DEBUG_ALWAYS, " failed!");
         g_object_unref(src);
         g_object_unref(dest);
       }
@@ -4620,7 +4617,7 @@ start:
       {
         // we couldn't migrate the db for some reason. bail out.
         dt_print(DT_DEBUG_ALWAYS,
-                 "[init] database `%s' couldn't be migrated from the legacy version %d. aborting\n",
+                 "[init] database `%s' couldn't be migrated from the legacy version %d. aborting",
                  dbname, db_version);
         dt_database_destroy(db);
         db = NULL;
@@ -4630,7 +4627,7 @@ start:
       {
         // we couldn't upgrade the db for some reason. bail out.
         dt_print(DT_DEBUG_ALWAYS,
-                 "[init] database `%s' couldn't be upgraded from version 1 to %d. aborting\n",
+                 "[init] database `%s' couldn't be upgraded from version 1 to %d. aborting",
                  dbname, CURRENT_DATABASE_VERSION_LIBRARY);
         dt_database_destroy(db);
         db = NULL;
@@ -4665,7 +4662,7 @@ start:
   {
     rc = sqlite3IcuInit(db->handle);
     if(rc != SQLITE_OK)
-      dt_print(DT_DEBUG_ALWAYS, "[sqlite] init icu extension error %d\n", rc);
+      dt_print(DT_DEBUG_ALWAYS, "[sqlite] init icu extension error %d", rc);
   }
 #endif
 
@@ -4706,7 +4703,7 @@ void dt_upgrade_maker_model(const dt_database_t *db)
     sqlite3_bind_text(stmt, 1, darktable_package_version, -1, SQLITE_TRANSIENT);
     if(sqlite3_step(stmt) != SQLITE_DONE)
     {
-      dt_print(DT_DEBUG_ALWAYS, "[init] can't insert/update new dt_version\n");
+      dt_print(DT_DEBUG_ALWAYS, "[init] can't insert/update new dt_version");
     }
   }
 
@@ -4759,7 +4756,7 @@ static void _database_migrate_to_xdg_structure()
       gchar *destdbname = g_strdup_printf("%s/%s", datadir, "library.db");
       if(!g_file_test(destdbname, G_FILE_TEST_EXISTS))
       {
-        dt_print(DT_DEBUG_ALWAYS, "[init] moving database into new XDG directory structure\n");
+        dt_print(DT_DEBUG_ALWAYS, "[init] moving database into new XDG directory structure");
         rename(dbfilename, destdbname);
         dt_conf_set_string("database", "library.db");
       }
@@ -4784,7 +4781,7 @@ static void _database_delete_mipmaps_files()
 
   if(g_access(mipmapfilename, F_OK) != -1)
   {
-    dt_print(DT_DEBUG_ALWAYS, "[mipmap_cache] dropping old version file: %s\n", mipmapfilename);
+    dt_print(DT_DEBUG_ALWAYS, "[mipmap_cache] dropping old version file: %s", mipmapfilename);
     g_unlink(mipmapfilename);
 
     snprintf(mipmapfilename, sizeof(mipmapfilename), "%s/mipmaps.fallback", cachedir);
@@ -4807,17 +4804,17 @@ void dt_database_cleanup_busy_statements(const struct dt_database_t *db)
     if(sqlite3_stmt_busy(stmt))
     {
       dt_print(DT_DEBUG_SQL,
-               "[db busy stmt] non-finalized nor stepped through statement: '%s'\n",sql);
+               "[db busy stmt] non-finalized nor stepped through statement: '%s'",sql);
       sqlite3_reset(stmt);
     }
     else {
-      dt_print(DT_DEBUG_SQL, "[db busy stmt] non-finalized statement: '%s'\n",sql);
+      dt_print(DT_DEBUG_SQL, "[db busy stmt] non-finalized statement: '%s'",sql);
     }
     sqlite3_finalize(stmt);
   }
 }
 
-#define ERRCHECK {if(err!=NULL) {dt_print(DT_DEBUG_SQL, "[db maintenance] maintenance error: '%s'\n",err); sqlite3_free(err); err=NULL;}}
+#define ERRCHECK {if(err!=NULL) {dt_print(DT_DEBUG_SQL, "[db maintenance] maintenance error: '%s'",err); sqlite3_free(err); err=NULL;}}
 void dt_database_perform_maintenance(const struct dt_database_t *db)
 {
   char* err = NULL;
@@ -4832,7 +4829,7 @@ void dt_database_perform_maintenance(const struct dt_database_t *db)
   if(calc_pre_size == 0)
   {
     dt_print(DT_DEBUG_SQL,
-             "[db maintenance] maintenance deemed unnecessary, performing only analyze.\n");
+             "[db maintenance] maintenance deemed unnecessary, performing only analyze.");
     DT_DEBUG_SQLITE3_EXEC(db->handle, "ANALYZE data", NULL, NULL, &err);
     ERRCHECK
     DT_DEBUG_SQLITE3_EXEC(db->handle, "ANALYZE main", NULL, NULL, &err);
@@ -4865,13 +4862,13 @@ void dt_database_perform_maintenance(const struct dt_database_t *db)
   const gint64 bytes_freed = calc_pre_size - calc_post_size;
 
   dt_print(DT_DEBUG_SQL,
-           "[db maintenance] maintenance done, %" G_GINT64_FORMAT " bytes freed.\n",
+           "[db maintenance] maintenance done, %" G_GINT64_FORMAT " bytes freed",
            bytes_freed);
 
   if(calc_post_size >= calc_pre_size)
   {
     dt_print(DT_DEBUG_SQL,
-             "[db maintenance] maintenance problem. if no errors logged, it should work fine next time.\n");
+             "[db maintenance] maintenance problem. if no errors logged, it should work fine next time");
   }
 }
 #undef ERRCHECK
@@ -4896,14 +4893,14 @@ gboolean dt_database_maybe_maintenance(const struct dt_database_t *db)
   const int data_page_size = _get_pragma_int_val(db->handle, "data.page_size");
 
   dt_print(DT_DEBUG_SQL,
-           "[db maintenance] main: [%d/%d pages], data: [%d/%d pages].\n",
+           "[db maintenance] main: [%d/%d pages], data: [%d/%d pages]",
            main_free_count, main_page_count, data_free_count, data_page_count);
 
   if(main_page_count <= 0 || data_page_count <= 0)
   {
     //something's wrong with PRAGMA page_size returns. early bail.
     dt_print(DT_DEBUG_SQL,
-             "[db maintenance] page_count <= 0 : main.page_count: %d, data.page_count: %d \n",
+             "[db maintenance] page_count <= 0 : main.page_count: %d, data.page_count: %d ",
              main_page_count, data_page_count);
     return FALSE;
   }
@@ -4919,7 +4916,7 @@ gboolean dt_database_maybe_maintenance(const struct dt_database_t *db)
   {
     const guint64 calc_size = (main_free_count*main_page_size) + (data_free_count*data_page_size);
     dt_print(DT_DEBUG_SQL,
-             "[db maintenance] maintenance, %" G_GUINT64_FORMAT " bytes to free.\n",
+             "[db maintenance] maintenance, %" G_GUINT64_FORMAT " bytes to free",
              calc_size);
     return TRUE;
   }
@@ -4940,7 +4937,7 @@ void dt_database_optimize(const struct dt_database_t *db)
 static void _print_backup_progress(int remaining, int total)
 {
   // TODO if we have closing splashpage - this can be used to advance progressbar :)
-  dt_print(DT_DEBUG_SQL, "[db backup] %d out of %d done\n", total - remaining, total);
+  dt_print(DT_DEBUG_SQL, "[db backup] %d out of %d done", total - remaining, total);
 }
 
 static int _backup_db(
@@ -4961,7 +4958,7 @@ static int _backup_db(
     sqlite3_backup *sb_dest = sqlite3_backup_init(dest_db, "main", src_db, src_db_name);
     if(sb_dest)
     {
-      dt_print(DT_DEBUG_SQL, "[db backup] %s to %s\n", src_db_name, dest_filename);
+      dt_print(DT_DEBUG_SQL, "[db backup] %s to %s", src_db_name, dest_filename);
       gchar *pragma = g_strdup_printf("%s.page_count", src_db_name);
       const int spc = _get_pragma_int_val(src_db, pragma);
       g_free(pragma);
@@ -5052,13 +5049,13 @@ gboolean dt_database_maybe_snapshot(const struct dt_database_t *db)
   {
     // early bail out on "never"
     dt_print(DT_DEBUG_SQL,
-             "[db backup] please consider enabling database snapshots.\n");
+             "[db backup] please consider enabling database snapshots.");
     return FALSE;
   }
   if(!g_strcmp0(config, "on close"))
   {
     // early bail out on "on close"
-    dt_print(DT_DEBUG_SQL, "[db backup] performing unconditional snapshot.\n");
+    dt_print(DT_DEBUG_SQL, "[db backup] performing unconditional snapshot.");
     return TRUE;
   }
 
@@ -5081,7 +5078,7 @@ gboolean dt_database_maybe_snapshot(const struct dt_database_t *db)
   {
     // early bail out on "invalid value"
     dt_print(DT_DEBUG_SQL,
-             "[db backup] invalid timespan requirement expecting never/on close/once a [day/week/month], got %s.\n",
+             "[db backup] invalid timespan requirement expecting never/on close/once a [day/week/month], got %s",
              config);
     return TRUE;
   }
@@ -5091,13 +5088,13 @@ gboolean dt_database_maybe_snapshot(const struct dt_database_t *db)
   //backup may done as last db operation, way after config file is closed. Plus we might be mixing dates of backups for
   //various library.db
 
-  dt_print(DT_DEBUG_SQL, "[db backup] checking snapshots existence.\n");
+  dt_print(DT_DEBUG_SQL, "[db backup] checking snapshots existence.");
   GFile *library = g_file_parse_name(db->dbfilename_library);
   GFile *parent = g_file_get_parent(library);
 
   if(parent == NULL)
   {
-    dt_print(DT_DEBUG_SQL, "[db backup] couldn't get library parent!.\n");
+    dt_print(DT_DEBUG_SQL, "[db backup] couldn't get library parent!.");
     g_object_unref(library);
     return FALSE;
   }
@@ -5107,7 +5104,7 @@ gboolean dt_database_maybe_snapshot(const struct dt_database_t *db)
 
   if(library_dir_files == NULL)
   {
-    dt_print(DT_DEBUG_SQL, "[db backup] couldn't enumerate library parent: %s.\n", error->message);
+    dt_print(DT_DEBUG_SQL, "[db backup] couldn't enumerate library parent: %s", error->message);
     g_object_unref(parent);
     g_object_unref(library);
     g_error_free(error);
@@ -5129,7 +5126,7 @@ gboolean dt_database_maybe_snapshot(const struct dt_database_t *db)
     const char* fname = g_file_info_get_name(info);
     if(g_str_has_prefix(fname, lib_snap_format) || g_str_has_prefix(fname, lib_backup_format))
     {
-      dt_print(DT_DEBUG_SQL, "[db backup] found file: %s.\n", fname);
+      dt_print(DT_DEBUG_SQL, "[db backup] found file: %s", fname);
       if(last_snap == 0)
       {
         last_snap = g_file_info_get_attribute_uint64(info, G_FILE_ATTRIBUTE_TIME_MODIFIED);
@@ -5150,7 +5147,7 @@ gboolean dt_database_maybe_snapshot(const struct dt_database_t *db)
 
   if(error)
   {
-    dt_print(DT_DEBUG_SQL, "[db backup] problem enumerating library parent: %s.\n", error->message);
+    dt_print(DT_DEBUG_SQL, "[db backup] problem enumerating library parent: %s", error->message);
     g_file_enumerator_close(library_dir_files, NULL, NULL);
     g_object_unref(library_dir_files);
     g_error_free(error);
@@ -5167,7 +5164,7 @@ gboolean dt_database_maybe_snapshot(const struct dt_database_t *db)
 
   gchar *now_txt = g_date_time_format(date_now, "%Y%m%d%H%M%S");
   gchar *ls_txt = g_date_time_format(date_last_snap, "%Y%m%d%H%M%S");
-  dt_print(DT_DEBUG_SQL, "[db backup] last snap: %s; curr date: %s.\n", ls_txt, now_txt);
+  dt_print(DT_DEBUG_SQL, "[db backup] last snap: %s; curr date: %s", ls_txt, now_txt);
   g_free(now_txt);
   g_free(ls_txt);
 
@@ -5263,13 +5260,13 @@ char **dt_database_snaps_to_remove(const struct dt_database_t *db)
   if(keep_snaps < 0)
     return NULL;
 
-  dt_print(DT_DEBUG_SQL, "[db backup] checking snapshots existence.\n");
+  dt_print(DT_DEBUG_SQL, "[db backup] checking snapshots existence");
   GFile *lib_file = g_file_parse_name(db->dbfilename_library);
   GFile *lib_parent = g_file_get_parent(lib_file);
 
   if(lib_parent == NULL)
   {
-    dt_print(DT_DEBUG_SQL, "[db backup] couldn't get library parent!.\n");
+    dt_print(DT_DEBUG_SQL, "[db backup] couldn't get library parent!");
     g_object_unref(lib_file);
     return NULL;
   }
@@ -5279,7 +5276,7 @@ char **dt_database_snaps_to_remove(const struct dt_database_t *db)
 
   if(dat_parent == NULL)
   {
-    dt_print(DT_DEBUG_SQL, "[db backup] couldn't get data parent!.\n");
+    dt_print(DT_DEBUG_SQL, "[db backup] couldn't get data parent!");
     g_object_unref(dat_file);
     g_object_unref(lib_file);
     g_object_unref(lib_parent);
@@ -5311,7 +5308,7 @@ char **dt_database_snaps_to_remove(const struct dt_database_t *db)
     if(library_dir_files == NULL)
     {
       dt_print(DT_DEBUG_SQL,
-               "[db backup] couldn't enumerate library parent: %s.\n",
+               "[db backup] couldn't enumerate library parent: %s",
                error->message);
       g_object_unref(lib_parent);
       g_object_unref(dat_parent);
@@ -5334,12 +5331,12 @@ char **dt_database_snaps_to_remove(const struct dt_database_t *db)
       const char* fname = g_file_info_get_name(info);
       if(g_str_has_prefix(fname, lib_snap_format))
       {
-        dt_print(DT_DEBUG_SQL, "[db backup] found file: %s.\n", fname);
+        dt_print(DT_DEBUG_SQL, "[db backup] found file: %s", fname);
         g_queue_insert_sorted(lib_snaps, g_strdup(fname), _db_snap_sort, NULL);
       }
       else if(g_str_has_prefix(fname, dat_snap_format))
       {
-        dt_print(DT_DEBUG_SQL, "[db backup] found file: %s.\n", fname);
+        dt_print(DT_DEBUG_SQL, "[db backup] found file: %s", fname);
         g_queue_insert_sorted(dat_snaps, g_strdup(fname), _db_snap_sort, NULL);
       }
       else if(g_str_has_prefix(fname, lib_tmp_format) || g_str_has_prefix(fname, dat_tmp_format))
@@ -5354,7 +5351,7 @@ char **dt_database_snaps_to_remove(const struct dt_database_t *db)
 
     if(error)
     {
-      dt_print(DT_DEBUG_SQL, "[db backup] problem enumerating library parent: %s.\n", error->message);
+      dt_print(DT_DEBUG_SQL, "[db backup] problem enumerating library parent: %s", error->message);
       g_object_unref(lib_parent);
       g_object_unref(dat_parent);
       g_free(lib_tmp_format);
@@ -5380,7 +5377,7 @@ char **dt_database_snaps_to_remove(const struct dt_database_t *db)
     if(library_dir_files == NULL)
     {
       dt_print(DT_DEBUG_SQL,
-               "[db backup] couldn't enumerate library parent: %s.\n",
+               "[db backup] couldn't enumerate library parent: %s",
                error->message);
       g_object_unref(lib_parent);
       g_object_unref(dat_parent);
@@ -5400,7 +5397,7 @@ char **dt_database_snaps_to_remove(const struct dt_database_t *db)
     if(data_dir_files == NULL)
     {
       dt_print(DT_DEBUG_SQL,
-               "[db backup] couldn't enumerate data parent: %s.\n",
+               "[db backup] couldn't enumerate data parent: %s",
                error->message);
       g_object_unref(lib_parent);
       g_object_unref(dat_parent);
@@ -5425,7 +5422,7 @@ char **dt_database_snaps_to_remove(const struct dt_database_t *db)
       const char* fname = g_file_info_get_name(info);
       if(g_str_has_prefix(fname, lib_snap_format))
       {
-        dt_print(DT_DEBUG_SQL, "[db backup] found file: %s.\n", fname);
+        dt_print(DT_DEBUG_SQL, "[db backup] found file: %s", fname);
         g_queue_insert_sorted(lib_snaps, g_strdup(fname), _db_snap_sort, NULL);
       }
       else if(g_str_has_prefix(fname, lib_tmp_format) || g_str_has_prefix(fname, dat_tmp_format))
@@ -5440,7 +5437,7 @@ char **dt_database_snaps_to_remove(const struct dt_database_t *db)
     if(error)
     {
       dt_print(DT_DEBUG_SQL,
-               "[db backup] problem enumerating library parent: %s.\n",
+               "[db backup] problem enumerating library parent: %s",
                error->message);
       g_object_unref(lib_parent);
       g_object_unref(dat_parent);
@@ -5465,7 +5462,7 @@ char **dt_database_snaps_to_remove(const struct dt_database_t *db)
       const char* fname = g_file_info_get_name(info);
       if(g_str_has_prefix(fname, dat_snap_format))
       {
-        dt_print(DT_DEBUG_SQL, "[db backup] found file: %s.\n", fname);
+        dt_print(DT_DEBUG_SQL, "[db backup] found file: %s.", fname);
         g_queue_insert_sorted(dat_snaps, g_strdup(fname), _db_snap_sort, NULL);
       }
       else if(g_str_has_prefix(fname, lib_tmp_format) || g_str_has_prefix(fname, dat_tmp_format))
@@ -5482,7 +5479,7 @@ char **dt_database_snaps_to_remove(const struct dt_database_t *db)
     if(error)
     {
       dt_print(DT_DEBUG_SQL,
-               "[db backup] problem enumerating data parent: %s.\n",
+               "[db backup] problem enumerating data parent: %s",
                error->message);
       g_object_unref(lib_parent);
       g_object_unref(dat_parent);
@@ -5553,13 +5550,13 @@ gchar *dt_database_get_most_recent_snap(const char* db_filename)
   if(!g_strcmp0(db_filename, ":memory:"))
     return NULL;
 
-  dt_print(DT_DEBUG_SQL, "[db backup] checking snapshots existence.\n");
+  dt_print(DT_DEBUG_SQL, "[db backup] checking snapshots existence");
   GFile *db_file = g_file_parse_name(db_filename);
   GFile *parent = g_file_get_parent(db_file);
 
   if(parent == NULL)
   {
-    dt_print(DT_DEBUG_SQL, "[db backup] couldn't get database parent!.\n");
+    dt_print(DT_DEBUG_SQL, "[db backup] couldn't get database parent!");
     g_object_unref(db_file);
     return NULL;
   }
@@ -5570,7 +5567,7 @@ gchar *dt_database_get_most_recent_snap(const char* db_filename)
   if(db_dir_files == NULL)
   {
     dt_print(DT_DEBUG_SQL,
-             "[db backup] couldn't enumerate database parent: %s.\n",
+             "[db backup] couldn't enumerate database parent: %s",
              error->message);
     g_object_unref(parent);
     g_object_unref(db_file);
@@ -5594,7 +5591,7 @@ gchar *dt_database_get_most_recent_snap(const char* db_filename)
     const char* fname = g_file_info_get_name(info);
     if(g_str_has_prefix(fname, db_snap_format) || g_str_has_prefix(fname, db_backup_format))
     {
-      dt_print(DT_DEBUG_SQL, "[db backup] found file: %s.\n", fname);
+      dt_print(DT_DEBUG_SQL, "[db backup] found file: %s", fname);
       if(last_snap == 0)
       {
         last_snap = g_file_info_get_attribute_uint64(info, G_FILE_ATTRIBUTE_TIME_MODIFIED);
@@ -5618,7 +5615,7 @@ gchar *dt_database_get_most_recent_snap(const char* db_filename)
   if(error)
   {
     dt_print(DT_DEBUG_SQL,
-             "[db backup] problem enumerating database parent: %s.\n",
+             "[db backup] problem enumerating database parent: %s",
              error->message);
     g_file_enumerator_close(db_dir_files, NULL, NULL);
     g_object_unref(db_dir_files);
@@ -5681,14 +5678,14 @@ void dt_database_start_transaction(const struct dt_database_t *db)
 #else
   {
     dt_print(DT_DEBUG_ALWAYS,
-             "[dt_database_start_transaction] nested transaction detected (%d)\n",
+             "[dt_database_start_transaction] nested transaction detected (%d)",
              trxid);
   }
 #endif
 
   if(trxid > MAX_NESTED_TRANSACTIONS)
     dt_print(DT_DEBUG_ALWAYS,
-             "[dt_database_start_transaction] more than %d nested transaction\n",
+             "[dt_database_start_transaction] more than %d nested transaction",
              MAX_NESTED_TRANSACTIONS);
 }
 
@@ -5698,7 +5695,7 @@ void dt_database_release_transaction(const struct dt_database_t *db)
 
   if(trxid <= 0)
     dt_print(DT_DEBUG_ALWAYS,
-             "[dt_database_release_transaction] COMMIT outside a transaction\n");
+             "[dt_database_release_transaction] COMMIT outside a transaction");
 
   if(trxid == 1)
   {
@@ -5714,7 +5711,7 @@ void dt_database_release_transaction(const struct dt_database_t *db)
 #else
   {
     dt_print(DT_DEBUG_ALWAYS,
-             "[dt_database_end_transaction] nested transaction detected (%d)\n",
+             "[dt_database_end_transaction] nested transaction detected (%d)",
              trxid);
   }
 #endif
@@ -5726,7 +5723,7 @@ void dt_database_rollback_transaction(const struct dt_database_t *db)
 
   if(trxid <= 0)
     dt_print(DT_DEBUG_ALWAYS,
-             "[dt_database_rollback_transaction] ROLLBACK outside a transaction\n");
+             "[dt_database_rollback_transaction] ROLLBACK outside a transaction");
 
   if(trxid == 1)
   {
@@ -5742,7 +5739,7 @@ void dt_database_rollback_transaction(const struct dt_database_t *db)
 #else
   {
     dt_print(DT_DEBUG_ALWAYS,
-             "[dt_database_rollback_transaction] nested transaction detected (%d)\n",
+             "[dt_database_rollback_transaction] nested transaction detected (%d)",
              trxid);
   }
 #endif

--- a/src/common/debug.h
+++ b/src/common/debug.h
@@ -85,7 +85,7 @@
 #define DT_DEBUG_SQLITE3_EXEC(a, b, c, d, e)                                                                      \
   do                                                                                                              \
   {                                                                                                               \
-    dt_print(DT_DEBUG_SQL, "[sql] %s:%d, function %s(): exec \"%s\"\n", __FILE__, __LINE__, __FUNCTION__, (b));   \
+    dt_print(DT_DEBUG_SQL, "[sql] %s:%d, function %s(): exec \"%s\"", __FILE__, __LINE__, __FUNCTION__, (b));     \
     __DT_DEBUG_ASSERT_WITH_QUERY__(sqlite3_exec(a, b, c, d, e), (b));                                             \
     __DT_DEBUG_SQL_QUERY__(b)                                                                                     \
   } while(0)
@@ -93,7 +93,7 @@
 #define DT_DEBUG_SQLITE3_PREPARE_V2(a, b, c, d, e)                                                                \
   do                                                                                                              \
   {                                                                                                               \
-    dt_print(DT_DEBUG_SQL, "[sql] %s:%d, function %s(): prepare \"%s\"\n", __FILE__, __LINE__, __FUNCTION__, (b));\
+    dt_print(DT_DEBUG_SQL, "[sql] %s:%d, function %s(): prepare \"%s\"", __FILE__, __LINE__, __FUNCTION__, (b));  \
     __DT_DEBUG_ASSERT_WITH_QUERY__(sqlite3_prepare_v2(a, b, c, d, e), (b));                                       \
     __DT_DEBUG_SQL_QUERY__(b)                                                                                     \
   } while(0)

--- a/src/common/distance_transform.c
+++ b/src/common/distance_transform.c
@@ -107,7 +107,7 @@ float dt_image_distance_transform(float *const src,
       break;
     default:
       dt_iop_image_fill(out, 0.0f, width, height, 1);
-      dt_print(DT_DEBUG_ALWAYS,"[dt_image_distance_transform] called with unsupported mode %i\n", mode);
+      dt_print(DT_DEBUG_ALWAYS,"[dt_image_distance_transform] called with unsupported mode %i", mode);
       return 0.0f;
   }
 

--- a/src/common/dlopencl.c
+++ b/src/common/dlopencl.c
@@ -41,7 +41,7 @@ static const char *ocllib[] = { "libOpenCL", "libOpenCL.so", "libOpenCL.so.1", N
 void dt_dlopencl_noop(void)
 {
   /* we should normally never get here */
-  dt_print(DT_DEBUG_ALWAYS, "dt_dlopencl internal error: unsupported function call\n");
+  dt_print(DT_DEBUG_ALWAYS, "dt_dlopencl internal error: unsupported function call");
   raise(SIGABRT);
 }
 
@@ -63,9 +63,9 @@ dt_dlopencl_t *dt_dlopencl_init(const char *name)
     library = name;
     module = dt_gmodule_open(library);
     if(module == NULL)
-      dt_print(DT_DEBUG_OPENCL, "[dt_dlopencl_init] could not find specified opencl runtime library '%s'\n", library);
+      dt_print(DT_DEBUG_OPENCL, "[dt_dlopencl_init] could not find specified opencl runtime library '%s'", library);
     else
-      dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE, "[dt_dlopencl_init] found specified opencl runtime library '%s'\n", library);
+      dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE, "[dt_dlopencl_init] found specified opencl runtime library '%s'", library);
   }
   else
   {
@@ -75,9 +75,9 @@ dt_dlopencl_t *dt_dlopencl_init(const char *name)
       library = *iter;
       module = dt_gmodule_open(library);
       if(module == NULL)
-        dt_print(DT_DEBUG_OPENCL, "[dt_dlopencl_init] could not find default opencl runtime library '%s'\n", library);
+        dt_print(DT_DEBUG_OPENCL, "[dt_dlopencl_init] could not find default opencl runtime library '%s'", library);
       else
-        dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE, "[dt_dlopencl_init] found default opencl runtime library '%s'\n", library);
+        dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE, "[dt_dlopencl_init] found default opencl runtime library '%s'", library);
       iter++;
     }
   }
@@ -209,7 +209,7 @@ dt_dlopencl_t *dt_dlopencl_init(const char *name)
   ocl->have_opencl = success;
 
   if(!success)
-    dt_print(DT_DEBUG_OPENCL, "[opencl_init] could not load all required symbols from library\n");
+    dt_print(DT_DEBUG_OPENCL, "[opencl_init] could not load all required symbols from library");
 
   free(module);
 

--- a/src/common/dng_opcode.c
+++ b/src/common/dng_opcode.c
@@ -73,7 +73,7 @@ void dt_dng_opcode_process_opcode_list_2(uint8_t *buf, uint32_t buf_size, dt_ima
 
     if(offset + 16 + param_size > buf_size)
     {
-      dt_print(DT_DEBUG_IMAGEIO, "[dng_opcode] Invalid opcode size in OpcodeList2\n");
+      dt_print(DT_DEBUG_IMAGEIO, "[dng_opcode] Invalid opcode size in OpcodeList2");
       return;
     }
 
@@ -103,7 +103,7 @@ void dt_dng_opcode_process_opcode_list_2(uint8_t *buf, uint32_t buf_size, dt_ima
     }
     else
     {
-      dt_print(DT_DEBUG_IMAGEIO, "[dng_opcode] OpcodeList2 has unsupported %s opcode %d\n",
+      dt_print(DT_DEBUG_IMAGEIO, "[dng_opcode] OpcodeList2 has unsupported %s opcode %d",
         flags & 1 ? "optional" : "mandatory", opcode_id);
     }
 
@@ -129,7 +129,7 @@ void dt_dng_opcode_process_opcode_list_3(uint8_t *buf, uint32_t buf_size, dt_ima
 
     if(offset + 16 + param_size > buf_size)
     {
-      dt_print(DT_DEBUG_IMAGEIO, "[dng_opcode] Invalid opcode size in OpcodeList3\n");
+      dt_print(DT_DEBUG_IMAGEIO, "[dng_opcode] Invalid opcode size in OpcodeList3");
       return;
     }
 
@@ -138,7 +138,7 @@ void dt_dng_opcode_process_opcode_list_3(uint8_t *buf, uint32_t buf_size, dt_ima
       const int planes = _get_long(&param[0]);
       if((planes != 1) && (planes != 3))
       {
-        dt_print(DT_DEBUG_IMAGEIO, "[OPCODE_ID_WARP_RECTILINEAR] Invalid number of planes %i\n", planes);
+        dt_print(DT_DEBUG_IMAGEIO, "[OPCODE_ID_WARP_RECTILINEAR] Invalid number of planes %i", planes);
         return;
       }
 
@@ -169,7 +169,7 @@ void dt_dng_opcode_process_opcode_list_3(uint8_t *buf, uint32_t buf_size, dt_ima
 
     else
     {
-      dt_print(DT_DEBUG_IMAGEIO, "[dng_opcode] OpcodeList3 has unsupported %s opcode %d\n",
+      dt_print(DT_DEBUG_IMAGEIO, "[dng_opcode] OpcodeList3 has unsupported %s opcode %d",
         flags & 1 ? "optional" : "mandatory", opcode_id);
     }
 

--- a/src/common/dwt.c
+++ b/src/common/dwt.c
@@ -248,7 +248,7 @@ static void dwt_wavelet_decompose(float *img,
                                   0, NULL))
   {
     dt_print(DT_DEBUG_ALWAYS,
-             "[dwt] unable to alloc working memory, skipping wavelet decomposition\n");
+             "[dwt] unable to alloc working memory, skipping wavelet decomposition");
     return;
   }
 
@@ -497,7 +497,7 @@ void dwt_denoise(float *const img,
   float *const details = dt_alloc_align_float((size_t)2 * width * height);
   if(!details)
   {
-    dt_print(DT_DEBUG_ALWAYS,"[dwt_denoise] unable to alloc working memory, skipping denoise\n");
+    dt_print(DT_DEBUG_ALWAYS,"[dwt_denoise] unable to alloc working memory, skipping denoise");
     return;
   }
   float *const interm = details + width * height;	// temporary storage for use during each pass

--- a/src/common/dynload.c
+++ b/src/common/dynload.c
@@ -76,7 +76,7 @@ gboolean dt_gmodule_symbol(dt_gmodule_t *module, const char *name, void (**point
   const gboolean symbol = g_module_symbol(module->gmodule, name, (gpointer)pointer);
   const gboolean valid = *pointer != NULL;
   if(!(symbol && valid))
-    dt_print(DT_DEBUG_OPENCL, "[opencl init] missing symbol `%s` in library`\n", name);
+    dt_print(DT_DEBUG_OPENCL, "[opencl init] missing symbol `%s` in library`", name);
   return symbol && valid ? TRUE : FALSE;
 }
 #else //!__APPLE__
@@ -109,7 +109,7 @@ gboolean dt_gmodule_symbol(dt_gmodule_t *module, const char *name, void (**point
   *pointer = dlsym(module->gmodule, name);
   const gboolean valid = *pointer != NULL;
   if(!valid)
-    dt_print(DT_DEBUG_OPENCL, "[opencl init] missing symbol `%s` in library`\n", name);
+    dt_print(DT_DEBUG_OPENCL, "[opencl init] missing symbol `%s` in library`", name);
 
   return valid;
 }

--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -179,7 +179,7 @@ static void _get_xmp_tags(const char *prefix,
   {
     for(int i = 0; pl[i].name_ != 0; ++i)
     {
-      char *tag = dt_util_dstrcat(NULL, "Xmp.%s.%s,%s",
+      char *tag = g_strdup_printf("Xmp.%s.%s,%s",
                                   prefix, pl[i].name_, _get_exiv2_type(pl[i].typeId_));
       *taglist = g_list_prepend(*taglist, tag);
     }
@@ -251,7 +251,7 @@ void dt_exif_set_exiv2_taglist()
           const Exiv2::TagInfo *tagInfo = groupList->tagList_();
           while(tagInfo->tag_ != 0xFFFF)
           {
-            char *tag = dt_util_dstrcat(NULL, "Exif.%s.%s,%s",
+            char *tag = g_strdup_printf("Exif.%s.%s,%s",
                                         groupList->groupName_,
                                         tagInfo->name_,
                                         _get_exiv2_type(tagInfo->typeId_));
@@ -266,7 +266,7 @@ void dt_exif_set_exiv2_taglist()
     const Exiv2::DataSet *iptcEnvelopeList = Exiv2::IptcDataSets::envelopeRecordList();
     while(iptcEnvelopeList->number_ != 0xFFFF)
     {
-      char *tag = dt_util_dstrcat(NULL, "Iptc.Envelope.%s,%s%s",
+      char *tag = g_strdup_printf("Iptc.Envelope.%s,%s%s",
                                   iptcEnvelopeList->name_,
                                   _get_exiv2_type(iptcEnvelopeList->type_),
                                   iptcEnvelopeList->repeatable_ ? "-R" : "");
@@ -278,7 +278,7 @@ void dt_exif_set_exiv2_taglist()
       Exiv2::IptcDataSets::application2RecordList();
     while(iptcApplication2List->number_ != 0xFFFF)
     {
-      char *tag = dt_util_dstrcat(NULL, "Iptc.Application2.%s,%s%s",
+      char *tag = g_strdup_printf("Iptc.Application2.%s,%s%s",
                                   iptcApplication2List->name_,
                                   _get_exiv2_type(iptcApplication2List->type_),
                                   iptcApplication2List->repeatable_ ? "-R" : "");
@@ -2109,13 +2109,13 @@ void dt_exif_apply_default_metadata(dt_image_t *img)
       if(dt_metadata_get_type(i) != DT_METADATA_TYPE_INTERNAL)
       {
         const char *name = dt_metadata_get_name(i);
-        char *setting = dt_util_dstrcat(NULL, "plugins/lighttable/metadata/%s_flag", name);
+        char *setting = g_strdup_printf("plugins/lighttable/metadata/%s_flag", name);
         const gboolean hidden = dt_conf_get_int(setting) & DT_METADATA_FLAG_HIDDEN;
         g_free(setting);
         // don't import hidden stuff
         if(!hidden)
         {
-          setting = dt_util_dstrcat(NULL, "ui_last/import_last_%s", name);
+          setting = g_strdup_printf("ui_last/import_last_%s", name);
           str = dt_conf_get_string(setting);
           if(str && str[0])
           {
@@ -4709,7 +4709,7 @@ static void _set_xmp_dt_metadata(Exiv2::XmpData &xmpData,
        && (dt_metadata_get_type(keyid) != DT_METADATA_TYPE_INTERNAL))
     {
       const gchar *name = dt_metadata_get_name(keyid);
-      gchar *setting = dt_util_dstrcat(NULL, "plugins/lighttable/metadata/%s_flag", name);
+      gchar *setting = g_strdup_printf("plugins/lighttable/metadata/%s_flag", name);
       const uint32_t flag =  dt_conf_get_int(setting);
       g_free(setting);
       if(!(flag & (DT_METADATA_FLAG_PRIVATE | DT_METADATA_FLAG_HIDDEN)))

--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -322,7 +322,7 @@ void dt_exif_set_exiv2_taglist()
   catch (Exiv2::AnyError& e)
   {
     const char *errstring = e.what();
-    dt_print(DT_DEBUG_IMAGEIO, "[exiv2 taglist] %s\n", errstring);
+    dt_print(DT_DEBUG_IMAGEIO, "[exiv2 taglist] %s", errstring);
   }
 }
 
@@ -532,7 +532,7 @@ static bool _exif_read_xmp_tag(Exiv2::XmpData &xmpData,
   catch(Exiv2::AnyError &e)
   {
     const char *errstring = e.what();
-    dt_print(DT_DEBUG_IMAGEIO, "[exiv2 read_xmp_tag] %s\n", errstring);
+    dt_print(DT_DEBUG_IMAGEIO, "[exiv2 read_xmp_tag] %s", errstring);
     return false;
   }
 }
@@ -697,7 +697,7 @@ static bool _exif_decode_xmp_data(dt_image_t *img,
     imgs = NULL;
     const char *errstring = e.what();
     dt_print(DT_DEBUG_IMAGEIO,
-             "[exiv2 _exif_decode_xmp_data] %s: %s\n",
+             "[exiv2 _exif_decode_xmp_data] %s: %s",
              img->filename,
              errstring);
     return false;
@@ -716,7 +716,7 @@ static bool _exif_read_iptc_tag(Exiv2::IptcData &iptcData,
   catch(Exiv2::AnyError &e)
   {
     const char *errstring = e.what();
-    dt_print(DT_DEBUG_IMAGEIO, "[exiv2 read_iptc_tag] %s\n", errstring);
+    dt_print(DT_DEBUG_IMAGEIO, "[exiv2 read_iptc_tag] %s", errstring);
     return false;
   }
 }
@@ -801,7 +801,7 @@ static bool _exif_decode_iptc_data(dt_image_t *img,
   {
     const char *errstring = e.what();
     dt_print(DT_DEBUG_IMAGEIO,
-             "[exiv2 _exif_decode_iptc_data] %s: %s\n",
+             "[exiv2 _exif_decode_iptc_data] %s: %s",
              img->filename,
              errstring);
     return false;
@@ -820,7 +820,7 @@ static bool _exif_read_exif_tag(Exiv2::ExifData &exifData,
   catch(Exiv2::AnyError &e)
   {
     const char *errstring = e.what();
-    dt_print(DT_DEBUG_IMAGEIO, "[exiv2 read_exif_tag] %s\n", errstring);
+    dt_print(DT_DEBUG_IMAGEIO, "[exiv2 read_exif_tag] %s", errstring);
     return false;
   }
 }
@@ -1080,7 +1080,7 @@ void dt_exif_img_check_additional_tags(dt_image_t *img,
   catch(Exiv2::AnyError &e)
   {
     const char *errstring = e.what();
-    dt_print(DT_DEBUG_IMAGEIO, "[exiv2 reading DefaultUserCrop] %s: %s\n", filename, errstring);
+    dt_print(DT_DEBUG_IMAGEIO, "[exiv2 reading DefaultUserCrop] %s: %s", filename, errstring);
     return;
   }
 }
@@ -1596,7 +1596,7 @@ static bool _exif_decode_exif_data(dt_image_t *img, Exiv2::ExifData &exifData)
         {
           _strlcpy_to_utf8(img->exif_lens, sizeof(img->exif_lens), pos, exifData);
         }
-        dt_print(DT_DEBUG_ALWAYS, "[exif] Warning: lens \"%s\" unknown as \"%s\"\n",
+        dt_print(DT_DEBUG_ALWAYS, "[exif] Warning: lens \"%s\" unknown as \"%s\"",
                  img->exif_lens, lens.c_str());
       }
     }
@@ -1912,7 +1912,7 @@ static bool _exif_decode_exif_data(dt_image_t *img, Exiv2::ExifData &exifData)
       if(sel_illu > -1)
         dt_print(DT_DEBUG_IMAGEIO,
                  "[exif] `%s` dng illuminant %i (%iK) selected from"
-                 "  [1] %i (%iK), [2] %i (%iK), [3] %i (%iK)\n",
+                 "  [1] %i (%iK), [2] %i (%iK), [3] %i (%iK)",
                  img->filename, illu[sel_illu], sel_temp,
                  illu[0], _illu_to_temp(illu[0]),
                  illu[1], _illu_to_temp(illu[1]),
@@ -1980,11 +1980,11 @@ static bool _exif_decode_exif_data(dt_image_t *img, Exiv2::ExifData &exifData)
           default:
             dt_print(DT_DEBUG_ALWAYS,
                      "[exif] did not find a proper DNG correction matrix"
-                     " for illuminant %i\n",
+                     " for illuminant %i",
                      illu[sel_illu]);
             break;
         }
-        dt_print(DT_DEBUG_IMAGEIO, "[exif] d65 matrix: %.4f %.4f %.4f | %.4f %.4f %.4f | %.4f %.4f %.4f\n",
+        dt_print(DT_DEBUG_IMAGEIO, "[exif] d65 matrix: %.4f %.4f %.4f | %.4f %.4f %.4f | %.4f %.4f %.4f",
            img->d65_color_matrix[0], img->d65_color_matrix[1], img->d65_color_matrix[2],
            img->d65_color_matrix[3], img->d65_color_matrix[4], img->d65_color_matrix[5],
            img->d65_color_matrix[6], img->d65_color_matrix[7], img->d65_color_matrix[8]);
@@ -2092,7 +2092,7 @@ static bool _exif_decode_exif_data(dt_image_t *img, Exiv2::ExifData &exifData)
   catch(Exiv2::AnyError &e)
   {
     const char *errstring = e.what();
-    dt_print(DT_DEBUG_IMAGEIO, "[exiv2 _exif_decode_exif_data] %s: %s\n", img->filename, errstring);
+    dt_print(DT_DEBUG_IMAGEIO, "[exiv2 _exif_decode_exif_data] %s: %s", img->filename, errstring);
     return false;
   }
 }
@@ -2173,7 +2173,7 @@ gboolean dt_exif_read_from_blob(dt_image_t *img,
   catch(Exiv2::AnyError &e)
   {
     const char *errstring = e.what();
-    dt_print(DT_DEBUG_IMAGEIO, "[exiv2 dt_exif_read_from_blob] %s: %s\n", img->filename, errstring);
+    dt_print(DT_DEBUG_IMAGEIO, "[exiv2 dt_exif_read_from_blob] %s: %s", img->filename, errstring);
     return TRUE;
   }
 }
@@ -2218,7 +2218,7 @@ gboolean dt_exif_get_thumbnail(const char *path,
     *buffer = (uint8_t *)malloc(_size);
     if(!*buffer) {
       dt_print(DT_DEBUG_IMAGEIO,
-               "[exiv2 dt_exif_get_thumbnail] couldn't allocate memory for thumbnail for %s\n",
+               "[exiv2 dt_exif_get_thumbnail] couldn't allocate memory for thumbnail for %s",
                path);
       return TRUE;
     }
@@ -2230,7 +2230,7 @@ gboolean dt_exif_get_thumbnail(const char *path,
   catch(Exiv2::AnyError &e)
   {
     dt_print(DT_DEBUG_IMAGEIO,
-             "[exiv2 dt_exif_get_thumbnail] %s: %s\n",
+             "[exiv2 dt_exif_get_thumbnail] %s: %s",
              path,
              e.what());
     return TRUE;
@@ -2308,7 +2308,7 @@ gboolean dt_exif_read(dt_image_t *img,
   catch(Exiv2::AnyError &e)
   {
     dt_print(DT_DEBUG_IMAGEIO,
-             "[exiv2 dt_exif_read] %s: %s\n",
+             "[exiv2 dt_exif_read] %s: %s",
              path,
              e.what());
     return TRUE;
@@ -2370,7 +2370,7 @@ int dt_exif_write_blob(uint8_t *blob,
   catch(Exiv2::AnyError &e)
   {
     dt_print(DT_DEBUG_IMAGEIO,
-             "[exiv2 dt_exif_write_blob] %s: %s\n",
+             "[exiv2 dt_exif_write_blob] %s: %s",
              path,
              e.what());
     return 0;
@@ -2753,7 +2753,7 @@ int dt_exif_read_blob(uint8_t **buf,
   {
     // std::cerr.rdbuf(savecerr);
     dt_print(DT_DEBUG_IMAGEIO,
-             "[exiv2 dt_exif_read_blob] %s: %s\n",
+             "[exiv2 dt_exif_read_blob] %s: %s",
              path,
              e.what());
     free(*buf);
@@ -2993,7 +2993,7 @@ static void _exif_import_tags(dt_image_t *img,
 
         if(tagid > 0) break;
 
-        dt_print(DT_DEBUG_ALWAYS, "[xmp_import] creating tag: %s\n", tag);
+        dt_print(DT_DEBUG_ALWAYS, "[xmp_import] creating tag: %s", tag);
 
         // Create this tag (increment id, leave icon empty), retry.
         DT_DEBUG_SQLITE3_BIND_TEXT(stmt_ins_tags, 1, tag, -1, SQLITE_TRANSIENT);
@@ -3118,7 +3118,7 @@ static GList *_read_history_v1(const std::string &xmpPacket,
     dt_print(DT_DEBUG_IMAGEIO,
              "XML '%s' parsed with errors\n"
              "Error description: %s\n"
-             "Error offset: %td\n",
+             "Error offset: %td",
              filename,
              result.description(),
              result.offset);
@@ -3241,7 +3241,7 @@ static GList *_read_history_v2(Exiv2::XmpData &xmpData,
       if(errno)
       {
         dt_print(DT_DEBUG_IMAGEIO,
-                 "error reading history from '%s' (%s)\n",
+                 "error reading history from '%s' (%s)",
                  key,
                  filename);
         g_list_free_full(history_entries, _free_history_entry);
@@ -3253,7 +3253,7 @@ static GList *_read_history_v2(Exiv2::XmpData &xmpData,
       if(*(key_iter++) != ']')
       {
         dt_print(DT_DEBUG_IMAGEIO,
-                 "error reading history from '%s' (%s)\n",
+                 "error reading history from '%s' (%s)",
                  key,
                  filename);
         g_list_free_full(history_entries, _free_history_entry);
@@ -3361,7 +3361,7 @@ skip:
     if(!(entry->have_operation && entry->have_params && entry->have_modversion))
     {
       dt_print(DT_DEBUG_IMAGEIO,
-               "[exif] error: reading history from '%s' failed due to missing tags\n",
+               "[exif] error: reading history from '%s' failed due to missing tags",
                filename);
       g_list_free_full(history_entries, _free_history_entry);
       history_entries = NULL;
@@ -3488,7 +3488,7 @@ static GList *_read_masks_v3(Exiv2::XmpData &xmpData,
       if(errno)
       {
         dt_print(DT_DEBUG_IMAGEIO,
-                 "error reading masks history from '%s' (%s)\n",
+                 "error reading masks history from '%s' (%s)",
                  key,
                  filename);
         g_list_free_full(history_entries, _free_mask_entry);
@@ -3500,7 +3500,7 @@ static GList *_read_masks_v3(Exiv2::XmpData &xmpData,
       if(*(key_iter++) != ']')
       {
         dt_print(DT_DEBUG_IMAGEIO,
-                 "error reading masks history from '%s' (%s)\n",
+                 "error reading masks history from '%s' (%s)",
                  key,
                  filename);
         g_list_free_full(history_entries, _free_mask_entry);
@@ -3651,7 +3651,7 @@ static void _add_mask_entries_to_db(const dt_imgid_t imgid,
     if((int)(entry->mask_nb * sizeof(dt_masks_point_group_t)) != entry->mask_points_len)
     {
       dt_print(DT_DEBUG_ALWAYS,
-               "[masks] error loading masks from XMP file, bad binary blob size.\n");
+               "[masks] error loading masks from XMP file, bad binary blob size.");
       return;
     }
     for(int i = 0; i < entry->mask_nb; i++)
@@ -3889,7 +3889,7 @@ gboolean dt_exif_xmp_read(dt_image_t *img,
     else
     {
       dt_print(DT_DEBUG_IMAGEIO,
-               "error: XMP schema version %d in '%s' not supported\n",
+               "error: XMP schema version %d in '%s' not supported",
                xmp_version,
                filename);
       g_hash_table_destroy(mask_entries);
@@ -3905,9 +3905,9 @@ gboolean dt_exif_xmp_read(dt_image_t *img,
     if(sqlite3_step(stmt) != SQLITE_DONE)
     {
       dt_print(DT_DEBUG_ALWAYS,
-               "[exif] error deleting history for image %d\n", img->id);
+               "[exif] error deleting history for image %d", img->id);
       dt_print(DT_DEBUG_ALWAYS,
-               "[exif]   %s\n", sqlite3_errmsg(dt_database_get(darktable.db)));
+               "[exif]   %s", sqlite3_errmsg(dt_database_get(darktable.db)));
       all_ok = FALSE;
       goto end;
     }
@@ -4047,9 +4047,9 @@ gboolean dt_exif_xmp_read(dt_image_t *img,
       if(sqlite3_step(stmt) != SQLITE_DONE)
       {
         dt_print(DT_DEBUG_ALWAYS,
-                 "[exif] error adding history entry for image %d\n", img->id);
+                 "[exif] error adding history entry for image %d", img->id);
         dt_print(DT_DEBUG_ALWAYS,
-                 "[exif]   %s\n", sqlite3_errmsg(dt_database_get(darktable.db)));
+                 "[exif]   %s", sqlite3_errmsg(dt_database_get(darktable.db)));
         all_ok = FALSE;
         goto end;
       }
@@ -4090,7 +4090,7 @@ gboolean dt_exif_xmp_read(dt_image_t *img,
           else
           {
             dt_print(DT_DEBUG_ALWAYS,
-                     "[exif] cannot get iop-order for module '%s', XMP may be corrupted\n",
+                     "[exif] cannot get iop-order for module '%s', XMP may be corrupted",
                      entry->operation);
             g_list_free_full(iop_order_list, free);
             g_list_free_full(history_entries, _free_history_entry);
@@ -4165,9 +4165,9 @@ gboolean dt_exif_xmp_read(dt_image_t *img,
         if(sqlite3_step(stmt) != SQLITE_DONE)
         {
           dt_print(DT_DEBUG_ALWAYS,
-                   "[exif] error adding mask history entry for image %d\n", img->id);
+                   "[exif] error adding mask history entry for image %d", img->id);
           dt_print(DT_DEBUG_ALWAYS,
-                   "[exif]   %s\n", sqlite3_errmsg(dt_database_get(darktable.db)));
+                   "[exif]   %s", sqlite3_errmsg(dt_database_get(darktable.db)));
           all_ok = FALSE;
           goto end;
         }
@@ -4195,9 +4195,9 @@ gboolean dt_exif_xmp_read(dt_image_t *img,
       if(!ok)
       {
         dt_print(DT_DEBUG_ALWAYS,
-                 "[exif] error writing history_end for image %d\n", img->id);
+                 "[exif] error writing history_end for image %d", img->id);
         dt_print(DT_DEBUG_ALWAYS,
-                 "[exif]   %s\n", sqlite3_errmsg(dt_database_get(darktable.db)));
+                 "[exif]   %s", sqlite3_errmsg(dt_database_get(darktable.db)));
         all_ok = FALSE;
         goto end;
       }
@@ -4219,9 +4219,9 @@ gboolean dt_exif_xmp_read(dt_image_t *img,
       if(sqlite3_step(stmt) != SQLITE_DONE)
       {
         dt_print(DT_DEBUG_ALWAYS,
-                 "[exif] error writing history_end for image %d\n", img->id);
+                 "[exif] error writing history_end for image %d", img->id);
         dt_print(DT_DEBUG_ALWAYS,
-                 "[exif]   %s\n", sqlite3_errmsg(dt_database_get(darktable.db)));
+                 "[exif]   %s", sqlite3_errmsg(dt_database_get(darktable.db)));
         all_ok = FALSE;
         goto end;
       }
@@ -4229,9 +4229,9 @@ gboolean dt_exif_xmp_read(dt_image_t *img,
     if(!dt_ioppr_write_iop_order_list(iop_order_list, img->id))
     {
       dt_print(DT_DEBUG_ALWAYS,
-               "[exif] error writing iop_list for image %d\n", img->id);
+               "[exif] error writing iop_list for image %d", img->id);
       dt_print(DT_DEBUG_ALWAYS,
-               "[exif]   %s\n", sqlite3_errmsg(dt_database_get(darktable.db)));
+               "[exif]   %s", sqlite3_errmsg(dt_database_get(darktable.db)));
       all_ok = FALSE;
       goto end;
     }
@@ -4261,7 +4261,7 @@ gboolean dt_exif_xmp_read(dt_image_t *img,
       {
         dt_print(DT_DEBUG_ALWAYS,
                  "[exif] dt_exif_xmp_read for %s, id %i found auto_presets_applied"
-                 " but there was no history\n",
+                 " but there was no history",
                  filename,img->id);
       }
     }
@@ -4315,7 +4315,7 @@ gboolean dt_exif_xmp_read(dt_image_t *img,
     else
     {
       dt_print(DT_DEBUG_IMAGEIO,
-               "[exif] error reading history from '%s'\n",
+               "[exif] error reading history from '%s'",
                filename);
       dt_database_rollback_transaction(darktable.db);
       return TRUE;
@@ -4885,7 +4885,7 @@ static void _exif_xmp_read_data(Exiv2::XmpData &xmpData,
 
   const double end = dt_get_debug_wtime();
   dt_print(DT_DEBUG_DEV,
-           "exif_xmp_read_data: %s. imgid=%i, hist=%i, took %.3fs\n",
+           "exif_xmp_read_data: %s. imgid=%i, hist=%i, took %.3fs",
            info,
            imgid,
            history_end,
@@ -5087,7 +5087,7 @@ char *dt_exif_xmp_read_string(const dt_imgid_t imgid)
   catch(Exiv2::AnyError &e)
   {
     dt_print(DT_DEBUG_IMAGEIO,
-             "[xmp_read_blob] caught exiv2 exception '%s'\n",
+             "[xmp_read_blob] caught exiv2 exception '%s'",
              e.what());
     return NULL;
   }
@@ -5405,7 +5405,7 @@ gboolean dt_exif_xmp_attach_export(const dt_imgid_t imgid,
     catch(Exiv2::AnyError &e)
     {
       dt_print(DT_DEBUG_IMAGEIO,
-               "[xmp_attach] %s: caught exiv2 exception '%s'\n",
+               "[xmp_attach] %s: caught exiv2 exception '%s'",
                input_filename,
                e.what());
     }
@@ -5619,7 +5619,7 @@ gboolean dt_exif_xmp_attach_export(const dt_imgid_t imgid,
         catch(Exiv2::AnyError &e2)
         {
           dt_print(DT_DEBUG_IMAGEIO,
-                   "[dt_exif_xmp_attach_export] without history %s: caught exiv2 exception '%s'\n",
+                   "[dt_exif_xmp_attach_export] without history %s: caught exiv2 exception '%s'",
                    filename,
                    e2.what());
           return TRUE;
@@ -5633,7 +5633,7 @@ gboolean dt_exif_xmp_attach_export(const dt_imgid_t imgid,
   catch(Exiv2::AnyError &e)
   {
     dt_print(DT_DEBUG_IMAGEIO,
-             "[dt_exif_xmp_attach_export] %s: caught exiv2 exception '%s'\n",
+             "[dt_exif_xmp_attach_export] %s: caught exiv2 exception '%s'",
              filename,
              e.what());
     return TRUE;
@@ -5675,7 +5675,7 @@ gboolean dt_exif_xmp_write(const dt_imgid_t imgid,
       else
       {
         dt_print(DT_DEBUG_ALWAYS,
-                 "cannot read XMP file '%s': '%s'\n", filename, strerror(errno));
+                 "cannot read XMP file '%s': '%s'", filename, strerror(errno));
         dt_control_log(_("cannot read XMP file '%s': '%s'"), filename, strerror(errno));
       }
 
@@ -5734,7 +5734,7 @@ gboolean dt_exif_xmp_write(const dt_imgid_t imgid,
       else
       {
         dt_print(DT_DEBUG_ALWAYS,
-                 "cannot write XMP file '%s': '%s'\n", filename, strerror(errno));
+                 "cannot write XMP file '%s': '%s'", filename, strerror(errno));
         dt_control_log(_("cannot write XMP file '%s': '%s'"), filename, strerror(errno));
         return TRUE;
       }
@@ -5745,7 +5745,7 @@ gboolean dt_exif_xmp_write(const dt_imgid_t imgid,
   catch(Exiv2::AnyError &e)
   {
     dt_print(DT_DEBUG_IMAGEIO,
-             "[dt_exif_xmp_write] %s: caught exiv2 exception '%s'\n",
+             "[dt_exif_xmp_write] %s: caught exiv2 exception '%s'",
              filename,
              e.what());
     return TRUE;
@@ -5795,7 +5795,7 @@ dt_colorspaces_color_profile_type_t dt_exif_get_color_space(const uint8_t *data,
   catch(Exiv2::AnyError &e)
   {
     dt_print(DT_DEBUG_IMAGEIO,
-             "[exiv2 dt_exif_get_color_space] %s\n",
+             "[exiv2 dt_exif_get_color_space] %s",
              e.what());
     return DT_COLORSPACE_DISPLAY;
   }
@@ -5818,7 +5818,7 @@ void dt_exif_get_basic_data(const uint8_t *data,
   catch(Exiv2::AnyError &e)
   {
     dt_print(DT_DEBUG_IMAGEIO,
-             "[exiv2 dt_exif_get_basic_data] %s\n",
+             "[exiv2 dt_exif_get_basic_data] %s",
              e.what());
   }
 }

--- a/src/common/fast_guided_filter.h
+++ b/src/common/fast_guided_filter.h
@@ -297,7 +297,7 @@ static inline void fast_surface_blur(float *const restrict image,
 
   if(!ds_image || !ds_mask || !ds_ab || !ab)
   {
-    dt_print(DT_DEBUG_PIPE, "fast guided filter failed to allocate memory\n");
+    dt_print(DT_DEBUG_PIPE, "fast guided filter failed to allocate memory");
     dt_control_log(_("fast guided filter failed to allocate memory, check your RAM settings"));
     goto clean;
   }

--- a/src/common/file_location.c
+++ b/src/common/file_location.c
@@ -56,7 +56,7 @@ void dt_loc_init(const char *datadir, const char *moduledir, const char *localed
     // strip of the executable name from the path to retrieve the path alone
     application_directory[dirname_length] = '\0';
   }
-  dt_print(DT_DEBUG_DEV, "application_directory: %s\n", application_directory);
+  dt_print(DT_DEBUG_DEV, "application_directory: %s", application_directory);
 
   // set up absolute pathes based on their relative value
   dt_loc_init_datadir(application_directory, datadir);
@@ -211,7 +211,7 @@ void dt_check_opendir(const char* context, const char* directory)
 {
   if(!directory)
   {
-    dt_print(DT_DEBUG_ALWAYS, "directory for %s has not been set.\n", context);
+    dt_print(DT_DEBUG_ALWAYS, "directory for %s has not been set", context);
     exit(EXIT_FAILURE);
   }
 
@@ -222,23 +222,23 @@ void dt_check_opendir(const char* context, const char* directory)
   if(attribs != INVALID_FILE_ATTRIBUTES &&
       (attribs & FILE_ATTRIBUTE_DIRECTORY))
   {
-    dt_print(DT_DEBUG_DEV, "%s: %s\n", context, directory);
+    dt_print(DT_DEBUG_DEV, "%s: %s", context, directory);
   }
   else
   {
-    dt_print(DT_DEBUG_ALWAYS, "%s: directory '%s' fails to open.'\n", context, directory);
+    dt_print(DT_DEBUG_ALWAYS, "%s: directory '%s' fails to open", context, directory);
     exit(EXIT_FAILURE);
   }
 #else
   DIR* dir = opendir(directory);
   if(dir)
   {
-    dt_print(DT_DEBUG_DEV, "%s: %s\n", context, directory);
+    dt_print(DT_DEBUG_DEV, "%s: %s", context, directory);
     closedir(dir);
   }
   else
   {
-    dt_print(DT_DEBUG_ALWAYS, "opendir '%s' fails with: '%s'\n", directory, strerror(errno));
+    dt_print(DT_DEBUG_ALWAYS, "opendir '%s' fails with: '%s'", directory, strerror(errno));
     exit(EXIT_FAILURE);
   }
 #endif

--- a/src/common/film.c
+++ b/src/common/film.c
@@ -234,7 +234,7 @@ dt_filmid_t dt_film_new(dt_film_t *film, const char *directory)
     DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 1, film->dirname, -1, SQLITE_STATIC);
     const int rc = sqlite3_step(stmt);
     if(rc != SQLITE_DONE)
-      dt_print(DT_DEBUG_ALWAYS, "[film_new] failed to insert film roll! %s\n",
+      dt_print(DT_DEBUG_ALWAYS, "[film_new] failed to insert film roll! %s",
               sqlite3_errmsg(dt_database_get(darktable.db)));
     sqlite3_finalize(stmt);
     /* requery for filmroll and fetch new id */
@@ -309,7 +309,7 @@ dt_filmid_t dt_film_import(const char *dirname)
   film->dir = g_dir_open(film->dirname, 0, &error);
   if(error)
   {
-    dt_print(DT_DEBUG_ALWAYS, "[film_import] failed to open directory %s: %s\n",
+    dt_print(DT_DEBUG_ALWAYS, "[film_import] failed to open directory %s: %s",
              film->dirname, error->message);
     g_error_free(error);
     dt_film_cleanup(film);

--- a/src/common/gpx.c
+++ b/src/common/gpx.c
@@ -114,7 +114,7 @@ dt_gpx_t *dt_gpx_new(const gchar *filename)
 error:
   if(err)
   {
-    dt_print(DT_DEBUG_ALWAYS, "dt_gpx_new: %s\n", err->message);
+    dt_print(DT_DEBUG_ALWAYS, "dt_gpx_new: %s", err->message);
     dt_control_log("%s", err->message);
     g_error_free(err);
   }
@@ -286,7 +286,7 @@ void _gpx_parser_start_element(GMarkupParseContext *ctx, const gchar *element_na
     if(gpx->current_track_point)
     {
       dt_print(DT_DEBUG_ALWAYS,
-               "broken GPX file, new trkpt element before the previous ended.\n");
+               "broken GPX file, new trkpt element before the previous ended.");
       g_free(gpx->current_track_point);
       _gpx_parse_error(error);
       return;
@@ -323,7 +323,7 @@ void _gpx_parser_start_element(GMarkupParseContext *ctx, const gchar *element_na
       if(isnan(gpx->current_track_point->longitude) || isnan(gpx->current_track_point->latitude))
       {
         dt_print(DT_DEBUG_ALWAYS,
-                 "broken GPX file, failed to get lon/lat attribute values for trkpt\n");
+                 "broken GPX file, failed to get lon/lat attribute values for trkpt");
         gpx->invalid_track_point = TRUE;
         _gpx_parse_error(error);
         return;
@@ -332,7 +332,7 @@ void _gpx_parser_start_element(GMarkupParseContext *ctx, const gchar *element_na
     else
     {
       dt_print(DT_DEBUG_ALWAYS,
-               "broken GPX file, trkpt element doesn't have lon/lat attributes\n");
+               "broken GPX file, trkpt element doesn't have lon/lat attributes");
       _gpx_parse_error(error);
       return;
     }
@@ -370,7 +370,7 @@ end:
 
 element_error:
   dt_print(DT_DEBUG_ALWAYS,
-           "broken GPX file, element '%s' found outside of trkpt.\n", element_name);
+           "broken GPX file, element '%s' found outside of trkpt", element_name);
   _gpx_parse_error(error);
 }
 
@@ -411,7 +411,7 @@ void _gpx_parser_text(GMarkupParseContext *context, const gchar *text, gsize tex
                       GError **error)
 {
   g_return_if_fail(*error == NULL);
- 
+
   dt_gpx_t *gpx = (dt_gpx_t *)user_data;
 
   if(gpx->current_parser_element == GPX_PARSER_ELEMENT_NAME)
@@ -429,7 +429,7 @@ void _gpx_parser_text(GMarkupParseContext *context, const gchar *text, gsize tex
     {
       gpx->invalid_track_point = TRUE;
       dt_print(DT_DEBUG_ALWAYS,
-               "broken GPX file, failed to parse iso8601 time '%s' for trackpoint\n", text);
+               "broken GPX file, failed to parse iso8601 time '%s' for trackpoint", text);
       _gpx_parse_error(error);
       return;
     }
@@ -437,7 +437,7 @@ void _gpx_parser_text(GMarkupParseContext *context, const gchar *text, gsize tex
     if(!gpx->trksegs)
     {
       dt_print(DT_DEBUG_ALWAYS,
-               "broken GPX file, no <trkseg> found\n");
+               "broken GPX file, no <trkseg> found");
       _gpx_parse_error(error);
       return;
     }
@@ -468,7 +468,7 @@ GList *dt_gpx_get_trkpts(struct dt_gpx_t *gpx, const guint segid)
 {
   if(gpx == NULL)
     return NULL;
-    
+
   GList *pts = NULL;
   GList *ts = g_list_nth(gpx->trksegs, segid);
   if(!ts) return pts;

--- a/src/common/guided_filter.c
+++ b/src/common/guided_filter.c
@@ -638,13 +638,13 @@ int guided_filter_cl(int devid,
   {
     err = _guided_filter_cl_impl(devid, guide, in, out, width, height, ch, w, sqrt_eps, guide_weight, min, max);
     if(err != CL_SUCCESS)
-      dt_print(DT_DEBUG_OPENCL, "[guided filter] opencl error %s\n", cl_errstr(err));
+      dt_print(DT_DEBUG_OPENCL, "[guided filter] opencl error %s", cl_errstr(err));
   }
   if(err != CL_SUCCESS)
   {
     err = _guided_filter_cl_fallback(devid, guide, in, out, width, height, ch, w, sqrt_eps, guide_weight, min, max);
     if(err != CL_SUCCESS)
-      dt_print(DT_DEBUG_OPENCL, "[guided filter] opencl cpu fallback error %s\n", cl_errstr(err));
+      dt_print(DT_DEBUG_OPENCL, "[guided filter] opencl cpu fallback error %s", cl_errstr(err));
   }
   return err;
 }

--- a/src/common/heal.c
+++ b/src/common/heal.c
@@ -304,7 +304,7 @@ static void _heal_laplace_loop(float *const restrict red_pixels, float *const re
   unsigned *const restrict black_runs = dt_alloc_align_type(unsigned, subwidth * (height + 2));
   if(!red_runs || !black_runs)
   {
-    dt_print(DT_DEBUG_ALWAYS, "_heal_laplace_loop: error allocating memory for healing\n");
+    dt_print(DT_DEBUG_ALWAYS, "_heal_laplace_loop: error allocating memory for healing");
     goto cleanup;
   }
 
@@ -356,7 +356,7 @@ void dt_heal(const float *const src_buffer, float *dest_buffer, const float *con
 {
   if(ch != 4)
   {
-    dt_print(DT_DEBUG_ALWAYS, "dt_heal: full-color image required\n");
+    dt_print(DT_DEBUG_ALWAYS, "dt_heal: full-color image required");
     return;
   }
   const size_t subwidth = 4 * ((width+1)/2);  // round up to be able to handle odd widths
@@ -364,7 +364,7 @@ void dt_heal(const float *const src_buffer, float *dest_buffer, const float *con
   float *const restrict black_buffer = dt_alloc_align_float(subwidth * (height + 2));
   if(red_buffer == NULL || black_buffer == NULL)
   {
-    dt_print(DT_DEBUG_ALWAYS, "dt_heal: error allocating memory for healing\n");
+    dt_print(DT_DEBUG_ALWAYS, "dt_heal: error allocating memory for healing");
     goto cleanup;
   }
 

--- a/src/common/histogram.c
+++ b/src/common/histogram.c
@@ -287,7 +287,7 @@ void dt_histogram_helper(dt_dev_histogram_collection_params_t *histogram_params,
 
   dt_print(DT_DEBUG_PERF,
             "histogram calculation %u bins %d -> %d"
-            " compensate %d %u channels %u pixels took %.3f secs (%.3f CPU)\n",
+            " compensate %d %u channels %u pixels took %.3f secs (%.3f CPU)",
             histogram_params->bins_count, cst, cst_to,
             compensate_middle_grey && profile_info, histogram_stats->ch,
             histogram_stats->pixels,

--- a/src/common/history.c
+++ b/src/common/history.c
@@ -788,9 +788,9 @@ static gboolean _history_copy_and_paste_on_image_overwrite(const dt_imgid_t imgi
         if(dt_history_module_skip_copy(module->flags()))
         {
           if(skip_modules)
-            skip_modules = dt_util_dstrcat(skip_modules, ",");
+            dt_util_str_cat(&skip_modules, ",");
 
-          skip_modules = dt_util_dstrcat(skip_modules, "'%s'", module->op);
+          dt_util_str_cat(&skip_modules, "'%s'", module->op);
         }
       }
     }
@@ -1651,15 +1651,15 @@ void dt_history_hash_write_from_history(const dt_imgid_t imgid,
     }
     if(type & DT_HISTORY_HASH_AUTO)
     {
-      fields = dt_util_dstrcat(fields, "%s,", "auto_hash");
-      values = dt_util_dstrcat(values, "?2,");
-      conflict = dt_util_dstrcat(conflict, "auto_hash=?2,");
+      dt_util_str_cat(&fields, "%s,", "auto_hash");
+      dt_util_str_cat(&values, "?2,");
+      dt_util_str_cat(&conflict, "auto_hash=?2,");
     }
     if(type & DT_HISTORY_HASH_CURRENT)
     {
-      fields = dt_util_dstrcat(fields, "%s,", "current_hash");
-      values = dt_util_dstrcat(values, "?2,");
-      conflict = dt_util_dstrcat(conflict, "current_hash=?2,");
+      dt_util_str_cat(&fields, "%s,", "current_hash");
+      dt_util_str_cat(&values, "?2,");
+      dt_util_str_cat(&conflict, "current_hash=?2,");
     }
     // remove the useless last comma
     if(fields) fields[strlen(fields) - 1] = '\0';

--- a/src/common/history.c
+++ b/src/common/history.c
@@ -325,7 +325,7 @@ gboolean dt_history_merge_module_into_history(dt_develop_t *dev_dest,
     {
       dt_print(DT_DEBUG_ALWAYS,
                "[dt_history_merge_module_into_history]"
-               " can't find single instance module %s\n",
+               " can't find single instance module %s",
                mod_src->op);
       module_added = FALSE;
     }
@@ -412,7 +412,7 @@ gboolean dt_history_merge_module_into_history(dt_develop_t *dev_dest,
       {
         dt_print(DT_DEBUG_ALWAYS,
                  "[dt_history_merge_module_into_history]"
-                 " can't load module %s\n", mod_src->op);
+                 " can't load module %s", mod_src->op);
         module_added = FALSE;
       }
       else
@@ -479,7 +479,7 @@ gboolean dt_history_merge_module_into_history(dt_develop_t *dev_dest,
     if(mod_src->iop_order <= 0.0 || mod_src->iop_order == INT_MAX)
       dt_print(DT_DEBUG_ALWAYS,
                "[dt_history_merge_module_into_history]"
-               " invalid source module %s %s(%d)(%i)\n",
+               " invalid source module %s %s(%d)(%i)",
                mod_src->op, mod_src->multi_name,
                mod_src->iop_order, mod_src->multi_priority);
 
@@ -488,14 +488,14 @@ gboolean dt_history_merge_module_into_history(dt_develop_t *dev_dest,
            || module_duplicate->iop_order == INT_MAX))
       dt_print(DT_DEBUG_ALWAYS,
                "[dt_history_merge_module_into_history]"
-               " invalid duplicate module module %s %s(%d)(%i)\n",
+               " invalid duplicate module module %s %s(%d)(%i)",
                module_duplicate->op, module_duplicate->multi_name,
                module_duplicate->iop_order, module_duplicate->multi_priority);
 
     if(module->iop_order <= 0.0 || module->iop_order == INT_MAX)
       dt_print(DT_DEBUG_ALWAYS,
                "[dt_history_merge_module_into_history]"
-               " invalid iop_order for module %s %s(%d)(%i)\n",
+               " invalid iop_order for module %s %s(%d)(%i)",
                module->op, module->multi_name, module->iop_order,
                module->multi_priority);
 
@@ -549,7 +549,7 @@ gboolean dt_history_merge_module_into_history(dt_develop_t *dev_dest,
           else
             dt_print(DT_DEBUG_ALWAYS,
                      "[dt_history_merge_module_into_history]"
-                     " form %i not found in source image\n",
+                     " form %i not found in source image",
                      forms_used_replace[i]);
         }
       }
@@ -620,7 +620,7 @@ static gboolean _history_copy_and_paste_on_image_merge(const dt_imgid_t imgid,
   if(ops)
   {
     dt_print(DT_DEBUG_IOPORDER,
-             "[history_copy_and_paste_on_image_merge] selected modules\n");
+             "[history_copy_and_paste_on_image_merge] selected modules");
     // copy only selected history entries
     for(const GList *l = g_list_last(ops); l; l = g_list_previous(l))
     {
@@ -655,7 +655,7 @@ static gboolean _history_copy_and_paste_on_image_merge(const dt_imgid_t imgid,
       {
         if(!dt_iop_is_hidden(hist->module))
         {
-          dt_print(DT_DEBUG_IOPORDER, "  module %20s, multiprio %i, num %d\n",
+          dt_print(DT_DEBUG_IOPORDER, "  module %20s, multiprio %i, num %d",
                    hist->module->op, hist->module->multi_priority, num);
 
           // make sure we use the proper params/blend as the module is set with the
@@ -673,7 +673,7 @@ static gboolean _history_copy_and_paste_on_image_merge(const dt_imgid_t imgid,
   }
   else
   {
-    dt_print(DT_DEBUG_IOPORDER, "[history_copy_and_paste_on_image_merge] all modules\n");
+    dt_print(DT_DEBUG_IOPORDER, "[history_copy_and_paste_on_image_merge] all modules");
     // we will copy all modules
     for(GList *modules_src = dev_src->iop;
         modules_src;
@@ -1123,7 +1123,7 @@ char *dt_history_get_items_as_string(const dt_imgid_t imgid)
   }
   sqlite3_finalize(stmt);
   items = g_list_reverse(items); // list was built in reverse order, so un-reverse it
-  char *result = dt_util_glist_to_str("\n", items);
+  char *result = dt_util_glist_to_str("", items);
   g_list_free_full(items, g_free);
   return result;
 }

--- a/src/common/history_snapshot.c
+++ b/src/common/history_snapshot.c
@@ -110,7 +110,7 @@ void dt_history_snapshot_create(const dt_imgid_t imgid,
   {
     dt_database_rollback_transaction(darktable.db);
     dt_print(DT_DEBUG_ALWAYS,
-             "[dt_history_snapshot_undo_create] fails to create a snapshot for %d\n",
+             "[dt_history_snapshot_undo_create] fails to create a snapshot for %d",
              imgid);
   }
 }
@@ -234,7 +234,7 @@ static void _history_snapshot_restore(const dt_imgid_t imgid,
   {
     dt_database_rollback_transaction(darktable.db);
     dt_print(DT_DEBUG_ALWAYS,
-             "[_history_snapshot_undo_restore] fails to restore a snapshot for %d\n",
+             "[_history_snapshot_undo_restore] fails to restore a snapshot for %d",
              imgid);
   }
   dt_unlock_image(imgid);

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -228,7 +228,7 @@ static void _image_set_monochrome_flag(const dt_imgid_t imgid,
   }
   else
     dt_print(DT_DEBUG_ALWAYS,
-             "[image_set_monochrome_flag] could not get imgid=%i from cache\n", imgid);
+             "[image_set_monochrome_flag] could not get imgid=%i from cache", imgid);
 }
 
 void dt_image_set_monochrome_flag(const dt_imgid_t imgid, const gboolean monochrome)
@@ -865,7 +865,7 @@ void dt_image_update_final_size(const dt_imgid_t imgid)
       DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_DEVELOP_IMAGE_CHANGED);
     }
   }
-  dt_print(DT_DEBUG_PIPE, "[dt_image_update_final_size] for ID=%i, updated to %ix%i\n", imgid, ww, hh);
+  dt_print(DT_DEBUG_PIPE, "[dt_image_update_final_size] for ID=%i, updated to %ix%i", imgid, ww, hh);
 }
 
 gboolean dt_image_get_final_size(const dt_imgid_t imgid, int *width, int *height)
@@ -883,12 +883,12 @@ gboolean dt_image_get_final_size(const dt_imgid_t imgid, int *width, int *height
   {
     *width = img.final_width;
     *height = img.final_height;
-    dt_print(DT_DEBUG_PIPE, "[dt_image_get_final_size] for ID=%i from cache %ix%i\n", imgid, *width, *height);
+    dt_print(DT_DEBUG_PIPE, "[dt_image_get_final_size] for ID=%i from cache %ix%i", imgid, *width, *height);
     return FALSE;
   }
 
   // we have to do the costly pipe run to get the final image size
-  dt_print(DT_DEBUG_PIPE, "[dt_image_get_final_size] calculate it for ID=%i\n", imgid);
+  dt_print(DT_DEBUG_PIPE, "[dt_image_get_final_size] calculate it for ID=%i", imgid);
   dt_develop_t dev;
   dt_dev_init(&dev, FALSE);
   dt_dev_load_image(&dev, imgid);
@@ -1236,7 +1236,7 @@ static int32_t _image_get_possible_version(const dt_imgid_t imgid,
   }
   if(safe_max_version == 0)
   {
-    dt_print(DT_DEBUG_ALWAYS, "image_get_possible_version couldn't find a safe new version above %d\n",
+    dt_print(DT_DEBUG_ALWAYS, "image_get_possible_version couldn't find a safe new version above %d",
       max_version);
     safe_max_version = max_version;
   }
@@ -1400,7 +1400,7 @@ static dt_imgid_t _image_duplicate_with_version_ext(const dt_imgid_t imgid,
       // b) duplicates had been removed from and later added to database.
       safe_new_version = _image_get_possible_version(imgid, safe_new_version);
       if(safe_new_version != max_version + 1)
-        dt_print(DT_DEBUG_ALWAYS, "dt_image_duplicate version forced %d -> %d\n",
+        dt_print(DT_DEBUG_ALWAYS, "dt_image_duplicate version forced %d -> %d",
           max_version + 1, safe_new_version);
     }
 
@@ -1824,7 +1824,7 @@ static dt_imgid_t _image_import_internal(const dt_filmid_t film_id,
   rc = sqlite3_step(stmt);
   if(rc != SQLITE_DONE)
     dt_print(DT_DEBUG_ALWAYS,
-             "[image_import_internal] sqlite3 error %d in `%s`\n", rc, filename);
+             "[image_import_internal] sqlite3 error %d in `%s`", rc, filename);
   sqlite3_finalize(stmt);
 
   id = dt_image_get_id(film_id, imgfname);
@@ -2307,7 +2307,7 @@ gboolean dt_image_rename(const dt_imgid_t imgid,
         if(!moveStatus)
         {
           dt_print(DT_DEBUG_ALWAYS,
-                   "[dt_image_rename] error moving local copy `%s' -> `%s'\n",
+                   "[dt_image_rename] error moving local copy `%s' -> `%s'",
                    copysrcpath, copydestpath);
 
           if(g_error_matches(moveError, G_IO_ERROR, G_IO_ERROR_NOT_FOUND))
@@ -2638,7 +2638,7 @@ dt_imgid_t dt_image_copy_rename(const dt_imgid_t imgid,
     else
     {
       dt_print(DT_DEBUG_ALWAYS,
-               "[dt_image_copy_rename] Failed to copy image %s: %s\n",
+               "[dt_image_copy_rename] Failed to copy image %s: %s",
                srcpath, gerror->message);
     }
     g_object_unref(dest);

--- a/src/common/image_cache.c
+++ b/src/common/image_cache.c
@@ -190,7 +190,7 @@ static void _image_cache_allocate(void *data,
   {
     img->id = NO_IMGID;
     dt_print(DT_DEBUG_ALWAYS,
-             "[image_cache_allocate] failed to open image %" PRIu32 " from database: %s\n",
+             "[image_cache_allocate] failed to open image %" PRIu32 " from database: %s",
              entry->key, sqlite3_errmsg(dt_database_get(darktable.db)));
   }
   sqlite3_finalize(stmt);
@@ -221,7 +221,7 @@ void dt_image_cache_init(dt_image_cache_t *cache)
   dt_cache_set_allocate_callback(&cache->cache, &_image_cache_allocate, cache);
   dt_cache_set_cleanup_callback(&cache->cache, &_image_cache_deallocate, cache);
 
-  dt_print(DT_DEBUG_CACHE, "[image_cache] has %d entries\n", num);
+  dt_print(DT_DEBUG_CACHE, "[image_cache] has %d entries", num);
 }
 
 void dt_image_cache_cleanup(dt_image_cache_t *cache)
@@ -232,7 +232,7 @@ void dt_image_cache_cleanup(dt_image_cache_t *cache)
 void dt_image_cache_print(dt_image_cache_t *cache)
 {
   dt_print(DT_DEBUG_ALWAYS,
-           "[image cache] fill %.2f/%.2f MB (%.2f%%)\n",
+           "[image cache] fill %.2f/%.2f MB (%.2f%%)",
            cache->cache.cost / (1024.0 * 1024.0),
            cache->cache.cost_quota / (1024.0 * 1024.0),
            (float)cache->cache.cost / (float)cache->cache.cost_quota);
@@ -297,7 +297,7 @@ void dt_image_cache_write_release_info(dt_image_cache_t *cache,
   if(!dt_is_valid_imgid(img->id))
   {
     dt_print(DT_DEBUG_ALWAYS,
-             "[image_cache_write_release] from `%s`. FATAL invalid image id %d\n",
+             "[image_cache_write_release] from `%s`. FATAL invalid image id %d",
              info, img->id);
     return;
   }
@@ -388,7 +388,7 @@ void dt_image_cache_write_release_info(dt_image_cache_t *cache,
   const int rc = sqlite3_step(stmt);
   if(rc != SQLITE_DONE)
     dt_print(DT_DEBUG_ALWAYS,
-             "[image_cache_write_release] from `%s' sqlite3 error %d (%s) for imgid %d\n",
+             "[image_cache_write_release] from `%s' sqlite3 error %d (%s) for imgid %d",
              info,
              rc,
              sqlite3_errmsg(dt_database_get(darktable.db)),
@@ -402,7 +402,7 @@ void dt_image_cache_write_release_info(dt_image_cache_t *cache,
     {
       const double spent = dt_get_debug_wtime() - start;
       dt_print(DT_DEBUG_CACHE,
-               "[image_cache_write_release] from `%s', imgid=%i took %.3fs\n",
+               "[image_cache_write_release] from `%s', imgid=%i took %.3fs",
                info, img->id, spent);
     }
   }

--- a/src/common/import_session.c
+++ b/src/common/import_session.c
@@ -73,7 +73,7 @@ static gboolean _import_session_initialize_filmroll(dt_import_session_t *self, c
   /* recursively create directories, abort if failed */
   if(g_mkdir_with_parents(path, 0755) == -1)
   {
-    dt_print(DT_DEBUG_ALWAYS, "[import_session] failed to create session path %s.\n", path);
+    dt_print(DT_DEBUG_ALWAYS, "[import_session] failed to create session path %s", path);
     _import_session_cleanup_filmroll(self); // superfluous?
     return TRUE;
   }
@@ -82,7 +82,7 @@ static gboolean _import_session_initialize_filmroll(dt_import_session_t *self, c
   const dt_filmid_t film_id = dt_film_new(self->film, path);
   if(!dt_is_valid_filmid(film_id))
   {
-    dt_print(DT_DEBUG_ALWAYS, "[import_session] Failed to initialize film roll.\n");
+    dt_print(DT_DEBUG_ALWAYS, "[import_session] Failed to initialize film roll");
     _import_session_cleanup_filmroll(self);
     return TRUE;
   }
@@ -119,7 +119,7 @@ static gchar *_import_session_path_pattern()
 
   if(!sub || !base)
   {
-    dt_print(DT_DEBUG_ALWAYS, "[import_session] No base or subpath configured...\n");
+    dt_print(DT_DEBUG_ALWAYS, "[import_session] No base or subpath configured...");
     goto bail_out;
   }
 
@@ -143,7 +143,7 @@ static char *_import_session_filename_pattern()
   gchar *name = dt_conf_get_string("session/filename_pattern");
   if(!name)
   {
-    dt_print(DT_DEBUG_ALWAYS, "[import_session] No name configured...\n");
+    dt_print(DT_DEBUG_ALWAYS, "[import_session] No name configured...");
     return NULL;
   }
 
@@ -266,7 +266,7 @@ const char *dt_import_session_filename(struct dt_import_session_t *self, gboolea
   char *pattern = _import_session_filename_pattern();
   if(pattern == NULL)
   {
-    dt_print(DT_DEBUG_ALWAYS, "[import_session] Failed to get session filaname pattern.\n");
+    dt_print(DT_DEBUG_ALWAYS, "[import_session] Failed to get session filaname pattern");
     return NULL;
   }
 
@@ -282,7 +282,7 @@ const char *dt_import_session_filename(struct dt_import_session_t *self, gboolea
   char *previous_fname = fname;
   if(g_file_test(fname, G_FILE_TEST_EXISTS) == TRUE)
   {
-    dt_print(DT_DEBUG_ALWAYS, "[import_session] File %s exists.\n", fname);
+    dt_print(DT_DEBUG_ALWAYS, "[import_session] File %s exists", fname);
     do
     {
       /* file exists, yield a new filename */
@@ -290,14 +290,14 @@ const char *dt_import_session_filename(struct dt_import_session_t *self, gboolea
       result_fname = _import_session_filename_from_pattern(self, pattern);
       fname = g_build_path(G_DIR_SEPARATOR_S, path, result_fname, (char *)NULL);
 
-      dt_print(DT_DEBUG_ALWAYS, "[import_session] Testing %s.\n", fname);
+      dt_print(DT_DEBUG_ALWAYS, "[import_session] Testing %s", fname);
       /* check if same filename was yielded as before */
       if(strcmp(previous_fname, fname) == 0)
       {
         g_free(previous_fname);
         g_free(fname);
         dt_control_log(_(
-            "couldn't expand to a unique filename for session, please check your import session settings."));
+            "couldn't expand to a unique filename for session, please check your import session settings"));
         return NULL;
       }
 
@@ -311,7 +311,7 @@ const char *dt_import_session_filename(struct dt_import_session_t *self, gboolea
   g_free(pattern);
 
   self->current_filename = result_fname;
-  dt_print(DT_DEBUG_ALWAYS, "[import_session] Using filename %s.\n", self->current_filename);
+  dt_print(DT_DEBUG_ALWAYS, "[import_session] Using filename %s.", self->current_filename);
 
   return self->current_filename;
 }
@@ -333,7 +333,7 @@ static const char *_import_session_path(struct dt_import_session_t *self, gboole
   gchar *pattern = _import_session_path_pattern();
   if(pattern == NULL)
   {
-    dt_print(DT_DEBUG_ALWAYS, "[import_session] Failed to get session path pattern.\n");
+    dt_print(DT_DEBUG_ALWAYS, "[import_session] Failed to get session path pattern.");
     return NULL;
   }
 
@@ -389,7 +389,7 @@ const char *dt_import_session_path(struct dt_import_session_t *self, gboolean us
   const char *path = _import_session_path(self, use_current_path);
   if(path == NULL)
   {
-    dt_print(DT_DEBUG_ALWAYS, "[import_session] Failed to get session path.\n");
+    dt_print(DT_DEBUG_ALWAYS, "[import_session] Failed to get session path");
     dt_control_log(_("requested session path not available. "
                      "device not mounted?"));
   }

--- a/src/common/interpolation.c
+++ b/src/common/interpolation.c
@@ -64,7 +64,7 @@ static void _show_2_times(const dt_times_t *start,
     dt_times_t end;
     dt_get_times(&end);
     dt_print(DT_DEBUG_PERF,
-             "[%s] plan %.3f secs (%.3f CPU) resample %.3f secs (%.3f CPU)\n",
+             "[%s] plan %.3f secs (%.3f CPU) resample %.3f secs (%.3f CPU)",
              prefix, mid->clock - start->clock, mid->user - start->user,
              end.clock - mid->clock, end.user - mid->user);
   }
@@ -1025,7 +1025,7 @@ static void _interpolation_resample_plain(const struct dt_interpolation *itor,
   const int32_t out_stride_floats = roi_out->width * 4;
 
   dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_VERBOSE,
-                "resample_plain", NULL, NULL, DT_DEVICE_CPU, roi_in, roi_out, "%s\n",itor->name);
+                "resample_plain", NULL, NULL, DT_DEVICE_CPU, roi_in, roi_out, "%s",itor->name);
   dt_times_t start = { 0 }, mid = { 0 };
   dt_get_perf_times(&start);
 
@@ -1157,7 +1157,7 @@ void dt_interpolation_resample(const struct dt_interpolation *itor,
 {
   if(out == NULL)
   {
-    dt_print(DT_DEBUG_ALWAYS, "[dt_interpolation_resample] no valid output buffer\n");
+    dt_print(DT_DEBUG_ALWAYS, "[dt_interpolation_resample] no valid output buffer");
     return;
   }
 
@@ -1247,7 +1247,7 @@ int dt_interpolation_resample_cl(const struct dt_interpolation *itor,
   cl_mem dev_vmeta = NULL;
 
   dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_VERBOSE,
-                "resample", NULL, NULL, devid, roi_in, roi_out, "%s\n", itor->name);
+                "resample", NULL, NULL, devid, roi_in, roi_out, "%s", itor->name);
   dt_times_t start = { 0 }, mid = { 0 };
   dt_get_perf_times(&start);
 
@@ -1385,7 +1385,7 @@ error:
     _show_2_times(&start, &mid, "resample_cl");
   else if(err != CL_INVALID_WORK_GROUP_SIZE)
     dt_print_pipe(DT_DEBUG_OPENCL, "interpolation_resample", NULL, NULL, devid, roi_in, roi_out,
-      "Error: %s\n", cl_errstr(err));
+      "Error: %s", cl_errstr(err));
 
   dt_opencl_release_mem_object(dev_hindex);
   dt_opencl_release_mem_object(dev_hlength);
@@ -1437,7 +1437,7 @@ static void _interpolation_resample_1c_plain(const struct dt_interpolation *itor
   int *vmeta = NULL;
 
   dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_VERBOSE,
-      "resample_1c_plain", NULL, NULL, DT_DEVICE_CPU, roi_in, roi_out, "%s\n", itor->name);
+      "resample_1c_plain", NULL, NULL, DT_DEVICE_CPU, roi_in, roi_out, "%s", itor->name);
   dt_times_t start = { 0 }, mid = { 0 };
   dt_get_perf_times(&start);
 

--- a/src/common/iop_order.c
+++ b/src/common/iop_order.c
@@ -569,7 +569,7 @@ int dt_ioppr_get_iop_order(GList *iop_order_list,
   }
   else
     dt_print(DT_DEBUG_ALWAYS,
-             "cannot get iop-order for %s instance %d\n",
+             "cannot get iop-order for %s instance %d",
              op_name, multi_priority);
 
   return iop_order;
@@ -930,7 +930,7 @@ GList *dt_ioppr_get_iop_order_list(const dt_imgid_t imgid,
           // preset not found, fall back to last built-in version, will be loaded below
           dt_print(DT_DEBUG_ALWAYS,
                    "[dt_ioppr_get_iop_order_list] error building"
-                   " iop_order_list imgid %d\n",
+                   " iop_order_list imgid %d",
                    imgid);
         }
         else
@@ -969,7 +969,7 @@ GList *dt_ioppr_get_iop_order_list(const dt_imgid_t imgid,
       else
         dt_print(DT_DEBUG_ALWAYS,
                  "[dt_ioppr_get_iop_order_list] invalid iop order"
-                 " version %d for imgid %d\n",
+                 " version %d for imgid %d",
                  version, imgid);
 
       if(iop_order_list)
@@ -1595,7 +1595,7 @@ void dt_ioppr_check_duplicate_iop_order(GList **_iop_list,
             can_move = FALSE;
             dt_print(DT_DEBUG_ALWAYS,
                      "[dt_ioppr_check_duplicate_iop_order 1] modules %s %s(%d)"
-                     " and %s %s(%d) have the same iop_order\n",
+                     " and %s %s(%d) have the same iop_order",
                      mod_prev->op, mod_prev->multi_name, mod_prev->iop_order, mod->op,
                      mod->multi_name, mod->iop_order);
           }
@@ -1610,7 +1610,7 @@ void dt_ioppr_check_duplicate_iop_order(GList **_iop_list,
       {
         dt_print(DT_DEBUG_ALWAYS,
                  "[dt_ioppr_check_duplicate_iop_order] modules %s %s(%d)"
-                 " and %s %s(%d) have the same iop_order\n",
+                 " and %s %s(%d) have the same iop_order",
                  mod_prev->op, mod_prev->multi_name, mod_prev->iop_order, mod->op,
                  mod->multi_name, mod->iop_order);
       }
@@ -1653,7 +1653,7 @@ gboolean dt_ioppr_check_so_iop_order(GList *iop_list,
     {
       iop_order_missing = TRUE;
       dt_print(DT_DEBUG_ALWAYS,
-               "[dt_ioppr_check_so_iop_order] missing iop_order for module %s\n", mod->op);
+               "[dt_ioppr_check_so_iop_order] missing iop_order for module %s", mod->op);
     }
   }
 
@@ -1768,7 +1768,7 @@ gboolean dt_ioppr_check_can_move_before_iop(GList *iop_list,
         {
           dt_print(DT_DEBUG_ALWAYS,
                    "[dt_ioppr_get_iop_order_before_iop] %s %s(%d)"
-                   " and %s %s(%d) have the same iop_order\n",
+                   " and %s %s(%d) have the same iop_order",
                    mod1->op, mod1->multi_name, mod1->iop_order, mod2->op,
                    mod2->multi_name, mod2->iop_order);
         }
@@ -1780,7 +1780,7 @@ gboolean dt_ioppr_check_can_move_before_iop(GList *iop_list,
     }
     else
       dt_print(DT_DEBUG_ALWAYS,
-               "[dt_ioppr_get_iop_order_before_iop] can't find module %s %s\n",
+               "[dt_ioppr_get_iop_order_before_iop] can't find module %s %s",
                module->op, module->multi_name);
   }
   // module is next on the pipe
@@ -1855,7 +1855,7 @@ gboolean dt_ioppr_check_can_move_before_iop(GList *iop_list,
         {
           dt_print(DT_DEBUG_ALWAYS,
                    "[dt_ioppr_get_iop_order_before_iop] %s %s(%d)"
-                   " and %s %s(%d) have the same iop_order\n",
+                   " and %s %s(%d) have the same iop_order",
                    mod1->op, mod1->multi_name, mod1->iop_order, mod2->op,
                    mod2->multi_name, mod2->iop_order);
         }
@@ -1867,14 +1867,14 @@ gboolean dt_ioppr_check_can_move_before_iop(GList *iop_list,
     }
     else
       dt_print(DT_DEBUG_ALWAYS,
-               "[dt_ioppr_get_iop_order_before_iop] can't find module %s %s\n",
+               "[dt_ioppr_get_iop_order_before_iop] can't find module %s %s",
                module->op, module->multi_name);
   }
   else
   {
     dt_print(DT_DEBUG_ALWAYS,
              "[dt_ioppr_get_iop_order_before_iop] modules %s %s(%d)"
-             " and %s %s(%d) have the same iop_order\n",
+             " and %s %s(%d) have the same iop_order",
              module->op, module->multi_name, module->iop_order, module_next->op,
              module_next->multi_name, module_next->iop_order);
   }
@@ -1909,7 +1909,7 @@ gboolean dt_ioppr_check_can_move_after_iop(GList *iop_list,
   {
     dt_print(DT_DEBUG_ALWAYS,
              "[dt_ioppr_get_iop_order_after_iop] can't find module"
-             " previous to %s %s(%d) while moving %s %s(%d) after it\n",
+             " previous to %s %s(%d) while moving %s %s(%d) after it",
              module_prev->op, module_prev->multi_name,
              module_prev->iop_order, module->op, module->multi_name,
              module->iop_order);
@@ -1987,7 +1987,7 @@ void dt_ioppr_print_module_iop_order(GList *iop_list, const char *msg)
     dt_iop_module_t *mod = modules->data;
 
     dt_print(DT_DEBUG_ALWAYS,
-             "[%s] module %s %s multi_priority=%i, iop_order=%d\n",
+             "[%s] module %s %s multi_priority=%i, iop_order=%d",
              msg, mod->op, mod->multi_name, mod->multi_priority, mod->iop_order);
   }
 }
@@ -2001,7 +2001,7 @@ void dt_ioppr_print_history_iop_order(GList *history_list, const char *msg)
     dt_dev_history_item_t *hist = history->data;
 
     dt_print(DT_DEBUG_ALWAYS,
-             "[%s] module %s %s multi_priority=%i, iop_order=%d\n",
+             "[%s] module %s %s multi_priority=%i, iop_order=%d",
              msg, hist->op_name, hist->multi_name,
              hist->multi_priority, hist->iop_order);
   }
@@ -2016,7 +2016,7 @@ void dt_ioppr_print_iop_order(GList *iop_order_list, const char *msg)
     dt_iop_order_entry_t *order_entry = iops_order->data;
 
     dt_print(DT_DEBUG_ALWAYS,
-             "[%s] op %20s (inst %d) iop_order=%d\n",
+             "[%s] op %20s (inst %d) iop_order=%d",
              msg, order_entry->operation,
              order_entry->instance, order_entry->o.iop_order);
   }
@@ -2088,7 +2088,7 @@ static void _ioppr_check_rules(GList *iop_list,
     {
       dt_print(DT_DEBUG_ALWAYS,
                "[_ioppr_check_rules] found fence %s %s module %s %s(%d)"
-               " is after %s %s(%d) image %i (%s)\n",
+               " is after %s %s(%d) image %i (%s)",
                fence_next->op, fence_next->multi_name, mod->op, mod->multi_name,
                mod->iop_order, fence_next->op, fence_next->multi_name,
                fence_next->iop_order, imgid, msg);
@@ -2097,7 +2097,7 @@ static void _ioppr_check_rules(GList *iop_list,
     {
       dt_print(DT_DEBUG_ALWAYS,
                "[_ioppr_check_rules] found fence %s %s module %s %s(%d)"
-               " is before %s %s(%d) image %i (%s)\n",
+               " is before %s %s(%d) image %i (%s)",
                fence_prev->op, fence_prev->multi_name, mod->op,
                mod->multi_name, mod->iop_order,
                fence_prev->op, fence_prev->multi_name, fence_prev->iop_order,
@@ -2137,7 +2137,7 @@ static void _ioppr_check_rules(GList *iop_list,
           {
             dt_print(DT_DEBUG_ALWAYS,
                      "[_ioppr_check_rules] found rule %s %s module %s %s(%d)"
-                     " is after %s %s(%d) image %i (%s)\n",
+                     " is after %s %s(%d) image %i (%s)",
                      rule->op_prev, rule->op_next, mod->op,
                      mod->multi_name, mod->iop_order,
                      mod_prev->op, mod_prev->multi_name, mod_prev->iop_order,
@@ -2159,7 +2159,7 @@ static void _ioppr_check_rules(GList *iop_list,
           {
             dt_print(DT_DEBUG_ALWAYS,
                      "[_ioppr_check_rules] found rule %s %s"
-                     " module %s %s(%d) is before %s %s(%d) image %i (%s)\n",
+                     " module %s %s(%d) is before %s %s(%d) image %i (%s)",
                      rule->op_prev, rule->op_next, mod->op,
                      mod->multi_name, mod->iop_order,
                      mod_next->op, mod_next->multi_name, mod_next->iop_order,
@@ -2230,7 +2230,7 @@ gboolean dt_ioppr_check_iop_order_ext(dt_develop_t *dev,
         iop_order_ok = FALSE;
         dt_print(DT_DEBUG_ALWAYS,
                  "[dt_ioppr_check_iop_order] gamma is not the last iop,"
-                 " last is %s %s(%d) image %i (%s)\n",
+                 " last is %s %s(%d) image %i (%s)",
                  mod->op, mod->multi_name, mod->iop_order,imgid, msg);
       }
     }
@@ -2250,7 +2250,7 @@ gboolean dt_ioppr_check_iop_order_ext(dt_develop_t *dev,
           iop_order_ok = FALSE;
           dt_print(DT_DEBUG_ALWAYS,
                    "[dt_ioppr_check_iop_order] module not used but enabled!!"
-                   " %s %s(%d) image %i (%s)\n",
+                   " %s %s(%d) image %i (%s)",
                    mod->op, mod->multi_name, mod->iop_order,imgid, msg);
         }
         if(mod->multi_priority == 0)
@@ -2258,7 +2258,7 @@ gboolean dt_ioppr_check_iop_order_ext(dt_develop_t *dev,
           iop_order_ok = FALSE;
           dt_print(DT_DEBUG_ALWAYS,
                    "[dt_ioppr_check_iop_order] base module"
-                   " set as not used %s %s(%d) image %i (%s)\n",
+                   " set as not used %s %s(%d) image %i (%s)",
                    mod->op, mod->multi_name, mod->iop_order,imgid, msg);
         }
       }
@@ -2282,7 +2282,7 @@ gboolean dt_ioppr_check_iop_order_ext(dt_develop_t *dev,
             iop_order_ok = FALSE;
             dt_print(DT_DEBUG_ALWAYS,
                      "[dt_ioppr_check_iop_order] module %s %s(%d)"
-                     " should be after %s %s(%d) image %i (%s)\n",
+                     " should be after %s %s(%d) image %i (%s)",
                      mod->op, mod->multi_name, mod->iop_order, mod_prev->op,
                      mod_prev->multi_name,
                      mod_prev->iop_order, imgid, msg);
@@ -2292,7 +2292,7 @@ gboolean dt_ioppr_check_iop_order_ext(dt_develop_t *dev,
             iop_order_ok = FALSE;
             dt_print(DT_DEBUG_ALWAYS,
                 "[dt_ioppr_check_iop_order] module %s %s(%i)(%d)"
-                     " and %s %s(%i)(%d) have the same order image %i (%s)\n",
+                     " and %s %s(%i)(%d) have the same order image %i (%s)",
                      mod->op, mod->multi_name, mod->multi_priority,
                      mod->iop_order, mod_prev->op,
                      mod_prev->multi_name, mod_prev->multi_priority,
@@ -2319,7 +2319,7 @@ gboolean dt_ioppr_check_iop_order_ext(dt_develop_t *dev,
         iop_order_ok = FALSE;
         dt_print(DT_DEBUG_ALWAYS,
                  "[dt_ioppr_check_iop_order] history module not"
-                 " used but enabled!! %s %s(%d) image %i (%s)\n",
+                 " used but enabled!! %s %s(%d) image %i (%s)",
                  hist->op_name, hist->multi_name, hist->iop_order, imgid, msg);
       }
       if(hist->multi_priority == 0)
@@ -2327,7 +2327,7 @@ gboolean dt_ioppr_check_iop_order_ext(dt_develop_t *dev,
         iop_order_ok = FALSE;
         dt_print(DT_DEBUG_ALWAYS,
                  "[dt_ioppr_check_iop_order] history base module"
-                 " set as not used %s %s(%d) image %i (%s)\n",
+                 " set as not used %s %s(%d) image %i (%s)",
                  hist->op_name, hist->multi_name, hist->iop_order, imgid, msg);
       }
     }
@@ -2531,7 +2531,7 @@ GList *dt_ioppr_deserialize_iop_order_list(const char *buf,
 
  error:
   dt_print(DT_DEBUG_ALWAYS,
-           "[deserialize iop_order_list] corrupted iop order list (size %d)\n", (int)size);
+           "[deserialize iop_order_list] corrupted iop order list (size %d)", (int)size);
   g_list_free_full(iop_order_list, free);
   return NULL;
 }

--- a/src/common/iop_profile.c
+++ b/src/common/iop_profile.c
@@ -101,7 +101,7 @@ static void _transform_from_to_rgb_lab_lcms2(const float *const image_in,
     if(rgb_color_space != cmsSigRgbData)
     {
       dt_print(DT_DEBUG_ALWAYS,
-               "working profile color space `%c%c%c%c' not supported\n",
+               "working profile color space `%c%c%c%c' not supported",
                (char)(rgb_color_space>>24),
                (char)(rgb_color_space>>16),
                (char)(rgb_color_space>>8),
@@ -115,7 +115,7 @@ static void _transform_from_to_rgb_lab_lcms2(const float *const image_in,
                                              DT_PROFILE_DIRECTION_WORK)->profile;
     dt_print(DT_DEBUG_ALWAYS,
              "[transform_from_to_rgb_lab_lcms2] unsupported working profile %s"
-             " has been replaced by Rec2020 RGB!\n",
+             " has been replaced by Rec2020 RGB!",
              filename);
   }
 
@@ -159,7 +159,7 @@ static void _transform_from_to_rgb_lab_lcms2(const float *const image_in,
   }
   else
     dt_print(DT_DEBUG_ALWAYS,
-             "[_transform_from_to_rgb_lab_lcms2] cannot create transform\n");
+             "[_transform_from_to_rgb_lab_lcms2] cannot create transform");
 
   if(xform) cmsDeleteTransform(xform);
 }
@@ -193,7 +193,7 @@ static void _transform_rgb_to_rgb_lcms2
   }
   else
   {
-    dt_print(DT_DEBUG_ALWAYS, "[_transform_rgb_to_rgb_lcms2] invalid *from profile* `%s`\n",
+    dt_print(DT_DEBUG_ALWAYS, "[_transform_rgb_to_rgb_lcms2] invalid *from profile* `%s`",
        dt_colorspaces_get_name(type_from, NULL));
   }
 
@@ -206,7 +206,7 @@ static void _transform_rgb_to_rgb_lcms2
   else
   {
     dt_print(DT_DEBUG_ALWAYS,
-             "[_transform_rgb_to_rgb_lcms2] invalid *to profile* `%s`\n",
+             "[_transform_rgb_to_rgb_lcms2] invalid *to profile* `%s`",
        dt_colorspaces_get_name(type_to, NULL));
   }
 
@@ -219,7 +219,7 @@ static void _transform_rgb_to_rgb_lcms2
   if(!from_is_rgb)
   {
     dt_print(DT_DEBUG_ALWAYS,
-             "[_transform_rgb_to_rgb_lcms2] *from profile* color space `%c%c%c%c' not supported\n",
+             "[_transform_rgb_to_rgb_lcms2] *from profile* color space `%c%c%c%c' not supported",
              (char)(rgb_from_color_space >> 24),
              (char)(rgb_from_color_space >> 16),
              (char)(rgb_from_color_space >> 8),
@@ -230,7 +230,7 @@ static void _transform_rgb_to_rgb_lcms2
   if(!to_is_rgb && !to_is_cmyk)
   {
     dt_print(DT_DEBUG_ALWAYS,
-      "[_transform_rgb_to_rgb_lcms2] *to profile* color space `%c%c%c%c' not supported\n",
+      "[_transform_rgb_to_rgb_lcms2] *to profile* color space `%c%c%c%c' not supported",
       (char)(rgb_to_color_space >> 24),
       (char)(rgb_to_color_space >> 16),
       (char)(rgb_to_color_space >> 8),
@@ -270,7 +270,7 @@ static void _transform_rgb_to_rgb_lcms2
     }
   }
   else
-    dt_print(DT_DEBUG_ALWAYS, "[_transform_rgb_to_rgb_lcms2] cannot create transform\n");
+    dt_print(DT_DEBUG_ALWAYS, "[_transform_rgb_to_rgb_lcms2] cannot create transform");
 
   if(xform) cmsDeleteTransform(xform);
 }
@@ -290,7 +290,7 @@ static void _transform_lcms2(struct dt_iop_module_t *self,
   if(cst_from == IOP_CS_RGB && cst_to == IOP_CS_LAB)
   {
     dt_print(DT_DEBUG_DEV,
-             "[_transform_lcms2] transfoming from RGB to Lab (%s %s)\n",
+             "[_transform_lcms2] transfoming from RGB to Lab (%s %s)",
              self->op, self->multi_name);
     _transform_from_to_rgb_lab_lcms2(image_in, image_out, width, height, profile_info->type,
                                      profile_info->filename, profile_info->intent, 1);
@@ -298,7 +298,7 @@ static void _transform_lcms2(struct dt_iop_module_t *self,
   else if(cst_from == IOP_CS_LAB && cst_to == IOP_CS_RGB)
   {
     dt_print(DT_DEBUG_DEV,
-             "[_transform_lcms2] transfoming from Lab to RGB (%s %s)\n",
+             "[_transform_lcms2] transfoming from Lab to RGB (%s %s)",
              self->op, self->multi_name);
     _transform_from_to_rgb_lab_lcms2(image_in, image_out, width, height, profile_info->type,
                                      profile_info->filename, profile_info->intent, -1);
@@ -307,7 +307,7 @@ static void _transform_lcms2(struct dt_iop_module_t *self,
   {
     *converted_cst = cst_from;
     dt_print(DT_DEBUG_ALWAYS,
-             "[_transform_lcms2] invalid conversion from %s to %s\n",
+             "[_transform_lcms2] invalid conversion from %s to %s",
              dt_colorspaces_get_name(cst_from, NULL),
              dt_colorspaces_get_name(cst_to, NULL));
   }
@@ -626,7 +626,7 @@ static inline void _transform_matrix(struct dt_iop_module_t *self,
 
   *converted_cst = cst_from;
   dt_print(DT_DEBUG_ALWAYS,
-             "[_transform_matrix] invalid conversion from %s to %s\n",
+             "[_transform_matrix] invalid conversion from %s to %s",
              dt_iop_colorspace_to_name(cst_from), dt_iop_colorspace_to_name(cst_to));
 }
 
@@ -703,7 +703,7 @@ static gboolean _ioppr_generate_profile_info(dt_iop_order_iccprofile_info_t *pro
   cmsColorSpaceSignature rgb_profile_color_space = rgb_profile ? cmsGetColorSpace(rgb_profile) : 0;
 
   if(filename[0])
-    dt_print(DT_DEBUG_PIPE, "[generate_profile_info] profile `%s': color space `%c%c%c%c'\n",
+    dt_print(DT_DEBUG_PIPE, "[generate_profile_info] profile `%s': color space `%c%c%c%c'",
       filename,
       (char)(rgb_profile_color_space>>24),
       (char)(rgb_profile_color_space>>16),
@@ -881,7 +881,7 @@ dt_ioppr_set_pipe_work_profile_info(struct dt_develop_t *dev,
   {
     dt_print(DT_DEBUG_ALWAYS,
              "[dt_ioppr_set_pipe_work_profile_info] unsupported working profile %s %s, "
-             "it will be replaced with linear Rec2020\n",
+             "it will be replaced with linear Rec2020",
              dt_colorspaces_get_name(type, NULL), filename);
     profile_info = dt_ioppr_add_profile_info_to_list(dev, DT_COLORSPACE_LIN_REC2020, "", intent);
   }
@@ -905,7 +905,7 @@ dt_ioppr_set_pipe_input_profile_info(struct dt_develop_t *dev,
   {
     dt_print(DT_DEBUG_PIPE,
              "[dt_ioppr_set_pipe_input_profile_info] profile `%s' in `%s'"
-             " replaced by linear Rec2020\n",
+             " replaced by linear Rec2020",
              dt_colorspaces_get_name(type, NULL), filename);
     profile_info = dt_ioppr_add_profile_info_to_list(dev, DT_COLORSPACE_LIN_REC2020, "", intent);
   }
@@ -945,7 +945,7 @@ dt_ioppr_set_pipe_output_profile_info(struct dt_develop_t *dev,
       // ??? this error output has been disabled for a display profile.
       // see discussion in https://github.com/darktable-org/darktable/issues/6774
       dt_print(DT_DEBUG_PIPE,
-         "[dt_ioppr_set_pipe_output_profile_info] profile `%s' in `%s' replaced by sRGB\n",
+         "[dt_ioppr_set_pipe_output_profile_info] profile `%s' in `%s' replaced by sRGB",
          dt_colorspaces_get_name(type, NULL), filename);
     }
     profile_info = dt_ioppr_add_profile_info_to_list(dev, DT_COLORSPACE_SRGB, "", intent);
@@ -1042,11 +1042,11 @@ void dt_ioppr_get_work_profile_type(struct dt_develop_t *dev,
     }
     else
       dt_print(DT_DEBUG_ALWAYS,
-               "[dt_ioppr_get_work_profile_type] can't get colorin parameters\n");
+               "[dt_ioppr_get_work_profile_type] can't get colorin parameters");
   }
   else
     dt_print(DT_DEBUG_ALWAYS,
-             "[dt_ioppr_get_work_profile_type] can't find colorin iop\n");
+             "[dt_ioppr_get_work_profile_type] can't find colorin iop");
 }
 
 void dt_ioppr_get_export_profile_type(struct dt_develop_t *dev,
@@ -1094,11 +1094,11 @@ void dt_ioppr_get_export_profile_type(struct dt_develop_t *dev,
     }
     else
       dt_print(DT_DEBUG_ALWAYS,
-               "[dt_ioppr_get_export_profile_type] can't get colorout parameters\n");
+               "[dt_ioppr_get_export_profile_type] can't get colorout parameters");
   }
   else
     dt_print(DT_DEBUG_ALWAYS,
-             "[dt_ioppr_get_export_profile_type] can't find colorout iop\n");
+             "[dt_ioppr_get_export_profile_type] can't find colorout iop");
 }
 
 void dt_ioppr_get_histogram_profile_type(dt_colorspaces_color_profile_type_t *profile_type,
@@ -1181,7 +1181,7 @@ void dt_ioppr_transform_image_colorspace
     if(!inplace || anyraw)
       dt_print(DT_DEBUG_PIPE,
         "[dt_ioppr_transform_image_colorspace] in `%s%s', profile `%s',"
-        " can't %s from %s to %s\n",
+        " can't %s from %s to %s",
         self->op, dt_iop_get_instance_id(self),
         profile_info
           ? dt_colorspaces_get_name(profile_info->type, profile_info->filename)
@@ -1207,7 +1207,7 @@ void dt_ioppr_transform_image_colorspace
                      cst_from, cst_to, converted_cst, profile_info);
 
   dt_print(DT_DEBUG_PERF,
-             "[dt_ioppr_transform_image_colorspace%s] %s-->%s took %.3f secs (%.3f CPU) [%s%s]\n",
+             "[dt_ioppr_transform_image_colorspace%s] %s-->%s took %.3f secs (%.3f CPU) [%s%s]",
              no_lcms ? "" : "_lcms2",
              dt_iop_colorspace_to_name(cst_from), dt_iop_colorspace_to_name(cst_to),
              dt_get_lap_time(&start_time.clock),
@@ -1218,7 +1218,7 @@ void dt_ioppr_transform_image_colorspace
   {
     dt_print(DT_DEBUG_ALWAYS,
         "[dt_ioppr_transform_image_colorspace%s] in `%s%s', profile `%s',"
-        " can't %s from %s to %s\n",
+        " can't %s from %s to %s",
         no_lcms ? "" : "_lcms2",
         self->op, dt_iop_get_instance_id(self),
         dt_colorspaces_get_name(profile_info->type, profile_info->filename),
@@ -1272,14 +1272,14 @@ void dt_ioppr_transform_image_colorspace_rgb
     _transform_lcms2_rgb(image_in, image_out, width, height, profile_info_from, profile_info_to);
 
   dt_print(DT_DEBUG_PIPE,
-    "dt_ioppr_transform_image_colorspace_rgb%s `%s' -> `%s' [%s]\n",
+    "dt_ioppr_transform_image_colorspace_rgb%s `%s' -> `%s' [%s]",
              no_lcms ? "" : "_lcms2",
              dt_colorspaces_get_name(profile_info_from->type, profile_info_from->filename),
              dt_colorspaces_get_name(profile_info_to->type, profile_info_to->filename),
              message ? message : "");
 
   dt_print(DT_DEBUG_PERF,
-             "[dt_ioppr_transform_image_colorspace_rgb%s] `%s' -> `%s' took %.3f secs (%.3f CPU) [%s]\n",
+             "[dt_ioppr_transform_image_colorspace_rgb%s] `%s' -> `%s' took %.3f secs (%.3f CPU) [%s]",
              no_lcms ? "" : "_lcms2",
              dt_colorspaces_get_name(profile_info_from->type, profile_info_from->filename),
              dt_colorspaces_get_name(profile_info_to->type, profile_info_to->filename),
@@ -1404,7 +1404,7 @@ cl_int dt_ioppr_build_iccprofile_params_cl(const dt_iop_order_iccprofile_info_t 
 cleanup:
   if(err != CL_SUCCESS)
     dt_print(DT_DEBUG_OPENCL,
-             "[dt_ioppr_build_iccprofile_params_cl] had error: %s\n", cl_errstr(err));
+             "[dt_ioppr_build_iccprofile_params_cl] had error: %s", cl_errstr(err));
   *_profile_info_cl = profile_info_cl;
   *_profile_lut_cl = profile_lut_cl;
   *_dev_profile_info = dev_profile_info;
@@ -1473,7 +1473,7 @@ gboolean dt_ioppr_transform_image_colorspace_cl
     if(!inplace || cst_to == IOP_CS_RAW || cst_from == IOP_CS_RAW)
       dt_print(DT_DEBUG_PIPE,
         "[dt_ioppr_transform_image_colorspace_cl]%s in `%s%s', profile `%s',"
-        " can't %s from %s to %s\n",
+        " can't %s from %s to %s",
         err == CL_SUCCESS ? "" : " error",
         self->op, dt_iop_get_instance_id(self),
         profile_info
@@ -1518,7 +1518,7 @@ gboolean dt_ioppr_transform_image_colorspace_cl
       *converted_cst = cst_from;
       dt_print(DT_DEBUG_ALWAYS,
                "[dt_ioppr_transform_image_colorspace_cl] in `%s%s', profile `%s',"
-               " can't %s from %s to %s\n",
+               " can't %s from %s to %s",
                self->op, dt_iop_get_instance_id(self),
                dt_colorspaces_get_name(profile_info->type, profile_info->filename),
                inplace ? "convert inplace" : "write converted data",
@@ -1570,7 +1570,7 @@ gboolean dt_ioppr_transform_image_colorspace_cl
       goto cleanup;
 
     dt_print(DT_DEBUG_PERF,
-             "[dt_ioppr_transform_image_colorspace_cl] %s-->%s took %.3f secs (%.3f GPU) [%s%s]\n",
+             "[dt_ioppr_transform_image_colorspace_cl] %s-->%s took %.3f secs (%.3f GPU) [%s%s]",
              dt_iop_colorspace_to_name(cst_from), dt_iop_colorspace_to_name(cst_to),
              dt_get_lap_time(&start_time.clock),
              dt_get_lap_utime(&start_time.user),
@@ -1603,7 +1603,7 @@ gboolean dt_ioppr_transform_image_colorspace_cl
 cleanup:
   if(err != CL_SUCCESS)
     dt_print(DT_DEBUG_OPENCL,
-             "[dt_ioppr_transform_image_colorspace_cl] had error: %s\n", cl_errstr(err));
+             "[dt_ioppr_transform_image_colorspace_cl] had error: %s", cl_errstr(err));
 
   dt_free_align(src_buffer);
   if(dev_tmp && inplace)
@@ -1765,13 +1765,13 @@ gboolean dt_ioppr_transform_image_colorspace_rgb_cl
       goto cleanup;
 
   dt_print(DT_DEBUG_PIPE,
-    "dt_ioppr_transform_image_colorspace_rgb_CL `%s' -> `%s' [%s]\n",
+    "dt_ioppr_transform_image_colorspace_rgb_CL `%s' -> `%s' [%s]",
              dt_colorspaces_get_name(profile_info_from->type, profile_info_from->filename),
              dt_colorspaces_get_name(profile_info_to->type, profile_info_to->filename),
             message ? message : "");
 
     dt_print(DT_DEBUG_PERF,
-             "image colorspace transform_rgb_CL  `%s' -> `%s' took %.3f secs (%.3f GPU) [%s]\n",
+             "image colorspace transform_rgb_CL  `%s' -> `%s' took %.3f secs (%.3f GPU) [%s]",
              dt_colorspaces_get_name(profile_info_from->type, profile_info_from->filename),
              dt_colorspaces_get_name(profile_info_to->type, profile_info_to->filename),
              dt_get_lap_time(&start_time.clock),
@@ -1806,7 +1806,7 @@ gboolean dt_ioppr_transform_image_colorspace_rgb_cl
 cleanup:
   if(err != CL_SUCCESS)
     dt_print(DT_DEBUG_OPENCL,
-             "[dt_ioppr_transform_image_colorspace_rgb_cl] had error: %s\n", cl_errstr(err));
+             "[dt_ioppr_transform_image_colorspace_rgb_cl] had error: %s", cl_errstr(err));
 
   dt_free_align(src_buffer_in);
   dt_free_align(src_buffer_out);

--- a/src/common/l10n.c
+++ b/src/common/l10n.c
@@ -45,7 +45,7 @@ static gchar* _dt_full_locale_name(const char *locale)
     if(error)
     {
       dt_print(DT_DEBUG_ALWAYS,
-               "[l10n] couldn't check locale: '%s'\n", error->message);
+               "[l10n] couldn't check locale: '%s'", error->message);
       g_error_free(error);
     }
   }
@@ -143,7 +143,7 @@ static void get_language_names(GList *languages)
     dt_print(DT_DEBUG_ALWAYS,
              "[l10n] error: can't open iso-codes file `%s'\n"
              "                   there won't be nicely translated language names"
-             " in the preferences.\n", filename);
+             " in the preferences", filename);
     goto end;
   }
 
@@ -171,7 +171,7 @@ static void get_language_names(GList *languages)
   if(!json_parser_load_from_file(parser, filename, &error))
   {
     dt_print(DT_DEBUG_ALWAYS,
-             "[l10n] error: parsing json from `%s' failed\n%s\n",
+             "[l10n] error: parsing json from `%s' failed\n%s",
              filename, error->message);
     goto end;
   }
@@ -181,7 +181,7 @@ static void get_language_names(GList *languages)
   if(!root)
   {
     dt_print(DT_DEBUG_ALWAYS,
-             "[l10n] error: can't get root node of `%s'\n", filename);
+             "[l10n] error: can't get root node of `%s'", filename);
     goto end;
   }
 
@@ -190,13 +190,13 @@ static void get_language_names(GList *languages)
   if(!json_reader_read_member(reader, "639-2"))
   {
     dt_print(DT_DEBUG_ALWAYS,
-             "[l10n] error: unexpected layout of `%s'\n", filename);
+             "[l10n] error: unexpected layout of `%s'", filename);
     goto end;
   }
 
   if(!json_reader_is_array(reader))
   {
-    dt_print(DT_DEBUG_ALWAYS, "[l10n] error: unexpected layout of `%s'\n", filename);
+    dt_print(DT_DEBUG_ALWAYS, "[l10n] error: unexpected layout of `%s'", filename);
     goto end;
   }
 
@@ -209,7 +209,7 @@ static void get_language_names(GList *languages)
     if(!json_reader_is_object(reader))
     {
       dt_print(DT_DEBUG_ALWAYS,
-               "[l10n] error: unexpected layout of `%s' (element %d)\n", filename, i);
+               "[l10n] error: unexpected layout of `%s' (element %d)", filename, i);
       free(saved_locale);
       saved_locale = NULL;
       goto end;
@@ -281,7 +281,7 @@ static void get_language_names(GList *languages)
     }
     else
       dt_print(DT_DEBUG_ALWAYS,
-               "[l10n] error: element %d has no name, skipping\n", i);
+               "[l10n] error: element %d has no name, skipping", i);
 
     json_reader_end_element(reader);
   }
@@ -432,7 +432,7 @@ dt_l10n_t *dt_l10n_init(const gchar *filename, const gboolean init_list)
     }
     else
       dt_print(DT_DEBUG_ALWAYS,
-               "[l10n] error: can't open directory `%s'\n", localedir);
+               "[l10n] error: can't open directory `%s'", localedir);
 
     // default to English if no other language matched
     if(!sys_default)

--- a/src/common/locallaplaciancl.c
+++ b/src/common/locallaplaciancl.c
@@ -116,7 +116,7 @@ dt_local_laplacian_cl_t *dt_local_laplacian_init_cl(
   return g;
 
 error:
-  dt_print(DT_DEBUG_OPENCL, "[local laplacian cl] could not allocate temporary buffers\n");
+  dt_print(DT_DEBUG_OPENCL, "[local laplacian cl] could not allocate temporary buffers");
   dt_local_laplacian_free_cl(g);
   return NULL;
 }
@@ -185,7 +185,7 @@ cl_int dt_local_laplacian_cl(
 
 error:
   if(err != CL_SUCCESS)
-    dt_print(DT_DEBUG_OPENCL, "[local laplacian cl] error %s\n", cl_errstr(err));
+    dt_print(DT_DEBUG_OPENCL, "[local laplacian cl] error %s", cl_errstr(err));
   return err;
 }
 

--- a/src/common/metadata.c
+++ b/src/common/metadata.c
@@ -234,7 +234,7 @@ static gchar *_get_tb_removed_metadata_string_values(GList *before, GList *after
     }
     if(!same_key || different_value || !value[0])
     {
-      metadata_list = dt_util_dstrcat(metadata_list, "%d,", atoi(b->data));
+      dt_util_str_cat(&metadata_list, "%d,", atoi(b->data));
     }
     b = g_list_next(b);
     b = g_list_next(b);
@@ -265,7 +265,7 @@ static gchar *_get_tb_added_metadata_string_values(const dt_imgid_t imgid,
     if((!same_key || different_value) && value[0])
     {
       char *escaped_text = sqlite3_mprintf("%q", value);
-      metadata_list = dt_util_dstrcat(metadata_list, "(%d,%d,'%s'),", GPOINTER_TO_INT(imgid), atoi(a->data), escaped_text);
+      dt_util_str_cat(&metadata_list, "(%d,%d,'%s'),", GPOINTER_TO_INT(imgid), atoi(a->data), escaped_text);
       sqlite3_free(escaped_text);
     }
     a = g_list_next(a);

--- a/src/common/metadata_export.c
+++ b/src/common/metadata_export.c
@@ -55,7 +55,7 @@ char *dt_lib_export_metadata_get_conf(void)
         {
           formula[0] = '\0';
           formula ++;
-          metadata_presets = dt_util_dstrcat(metadata_presets,"\1%s\1%s", nameformula, formula);
+          dt_util_str_cat(&metadata_presets,"\1%s\1%s", nameformula, formula);
         }
       }
       g_free(nameformula);

--- a/src/common/mipmap_cache.c
+++ b/src/common/mipmap_cache.c
@@ -434,7 +434,7 @@ void *dt_mipmap_cache_alloc(dt_mipmap_buffer_t *buf, const dt_image_t *img)
   dsc->flags = DT_MIPMAP_BUFFER_DSC_FLAG_GENERATE;
   buf->buf = (uint8_t *)(dsc + 1);
 
-  // dt_print(DT_DEBUG_ALWAYS, "full buffer allocating img %u %d x %d = %u bytes (%p)\n", img->id, img->width,
+  // dt_print(DT_DEBUG_ALWAYS, "full buffer allocating img %u %d x %d = %u bytes (%p)", img->id, img->width,
   // img->height, buffer_size, *buf);
 
   assert(entry->data_size);
@@ -479,10 +479,10 @@ static void _mipmap_cache_allocate_dynamic(void *data, dt_cache_entry_t *entry)
 
     entry->data = dt_alloc_aligned(entry->data_size);
 
-    // dt_print(DT_DEBUG_ALWAYS, "[mipmap cache] alloc dynamic for key %u %p\n", key, *buf);
+    // dt_print(DT_DEBUG_ALWAYS, "[mipmap cache] alloc dynamic for key %u %p", key, *buf);
     if(!(entry->data))
     {
-      dt_print(DT_DEBUG_ALWAYS, "[mipmap_cache] memory allocation failed!\n");
+      dt_print(DT_DEBUG_ALWAYS, "[mipmap_cache] memory allocation failed!");
       exit(1);
     }
 
@@ -538,12 +538,12 @@ static void _mipmap_cache_allocate_dynamic(void *data, dt_cache_entry_t *entry)
            || dt_imageio_jpeg_decompress(&jpg, (uint8_t *)entry->data + sizeof(*dsc)))
         {
           dt_print(DT_DEBUG_ALWAYS,
-                   "[mipmap_cache] failed to decompress thumbnail for image %" PRIu32 " from `%s'!\n",
+                   "[mipmap_cache] failed to decompress thumbnail for image %" PRIu32 " from `%s'!",
                    get_imgid(entry->key), filename);
           goto read_error;
         }
         dt_print(DT_DEBUG_CACHE,
-                 "[mipmap_cache] grab mip %d for ID=%d from disk cache\n", mip,
+                 "[mipmap_cache] grab mip %d for ID=%d from disk cache", mip,
                  get_imgid(entry->key));
         dsc->width = jpg.width;
         dsc->height = jpg.height;
@@ -629,7 +629,7 @@ static void _mipmap_cache_deallocate_dynamic(void *data, dt_cache_entry_t *entry
               if(free_mb < 100)
               {
                 dt_print(DT_DEBUG_ALWAYS,
-                         "[mipmap_cache] aborting image write as only %" PRId64 " MB free to write %s\n",
+                         "[mipmap_cache] aborting image write as only %" PRId64 " MB free to write %s",
                          free_mb, filename);
                 goto write_error;
               }
@@ -637,7 +637,7 @@ static void _mipmap_cache_deallocate_dynamic(void *data, dt_cache_entry_t *entry
             else
             {
               dt_print(DT_DEBUG_ALWAYS,
-                       "[mipmap_cache] aborting image write since couldn't determine free space available to write %s\n",
+                       "[mipmap_cache] aborting image write since couldn't determine free space available to write %s",
                        filename);
               goto write_error;
             }
@@ -767,14 +767,14 @@ void dt_mipmap_cache_cleanup(dt_mipmap_cache_t *cache)
 
 void dt_mipmap_cache_print(dt_mipmap_cache_t *cache)
 {
-  dt_print(DT_DEBUG_ALWAYS,"[mipmap_cache] thumbs fill %.2f/%.2f MB (%.2f%%)\n",
+  dt_print(DT_DEBUG_ALWAYS,"[mipmap_cache] thumbs fill %.2f/%.2f MB (%.2f%%)",
            cache->mip_thumbs.cache.cost / (1024.0 * 1024.0),
            cache->mip_thumbs.cache.cost_quota / (1024.0 * 1024.0),
            100.0f * (float)cache->mip_thumbs.cache.cost / (float)cache->mip_thumbs.cache.cost_quota);
-  dt_print(DT_DEBUG_ALWAYS,"[mipmap_cache] float fill %"PRIu32"/%"PRIu32" slots (%.2f%%)\n",
+  dt_print(DT_DEBUG_ALWAYS,"[mipmap_cache] float fill %"PRIu32"/%"PRIu32" slots (%.2f%%)",
            (uint32_t)cache->mip_f.cache.cost, (uint32_t)cache->mip_f.cache.cost_quota,
            100.0f * (float)cache->mip_f.cache.cost / (float)cache->mip_f.cache.cost_quota);
-  dt_print(DT_DEBUG_ALWAYS,"[mipmap_cache] full  fill %"PRIu32"/%"PRIu32" slots (%.2f%%)\n",
+  dt_print(DT_DEBUG_ALWAYS,"[mipmap_cache] full  fill %"PRIu32"/%"PRIu32" slots (%.2f%%)",
            (uint32_t)cache->mip_full.cache.cost, (uint32_t)cache->mip_full.cache.cost_quota,
            100.0f * (float)cache->mip_full.cache.cost / (float)cache->mip_full.cache.cost_quota);
 
@@ -790,20 +790,20 @@ void dt_mipmap_cache_print(dt_mipmap_cache_t *cache)
   sum += cache->mip_full.stats_requests;
   sum_fetches += cache->mip_full.stats_fetches;
   sum_standins += cache->mip_full.stats_standin;
-  dt_print(DT_DEBUG_ALWAYS,"[mipmap_cache] level | near match | miss | stand-in | fetches | total rq\n");
-  dt_print(DT_DEBUG_ALWAYS,"[mipmap_cache] thumb | %6.2f%% | %6.2f%% | %6.2f%%  | %6.2f%% | %6.2f%%\n",
+  dt_print(DT_DEBUG_ALWAYS,"[mipmap_cache] level | near match | miss | stand-in | fetches | total rq");
+  dt_print(DT_DEBUG_ALWAYS,"[mipmap_cache] thumb | %6.2f%% | %6.2f%% | %6.2f%%  | %6.2f%% | %6.2f%%",
            100.0 * cache->mip_thumbs.stats_near_match / (float)cache->mip_thumbs.stats_requests,
            100.0 * cache->mip_thumbs.stats_misses / (float)cache->mip_thumbs.stats_requests,
            100.0 * cache->mip_thumbs.stats_standin / (float)sum_standins,
            100.0 * cache->mip_thumbs.stats_fetches / (float)sum_fetches,
            100.0 * cache->mip_thumbs.stats_requests / (float)sum);
-  dt_print(DT_DEBUG_ALWAYS,"[mipmap_cache] float | %6.2f%% | %6.2f%% | %6.2f%%  | %6.2f%% | %6.2f%%\n",
+  dt_print(DT_DEBUG_ALWAYS,"[mipmap_cache] float | %6.2f%% | %6.2f%% | %6.2f%%  | %6.2f%% | %6.2f%%",
            100.0 * cache->mip_f.stats_near_match / (float)cache->mip_f.stats_requests,
            100.0 * cache->mip_f.stats_misses / (float)cache->mip_f.stats_requests,
            100.0 * cache->mip_f.stats_standin / (float)sum_standins,
            100.0 * cache->mip_f.stats_fetches / (float)sum_fetches,
            100.0 * cache->mip_f.stats_requests / (float)sum);
-  dt_print(DT_DEBUG_ALWAYS,"[mipmap_cache] full  | %6.2f%% | %6.2f%% | %6.2f%%  | %6.2f%% | %6.2f%%\n\n\n",
+  dt_print(DT_DEBUG_ALWAYS,"[mipmap_cache] full  | %6.2f%% | %6.2f%% | %6.2f%%  | %6.2f%% | %6.2f%%\n\n",
            100.0 * cache->mip_full.stats_near_match / (float)cache->mip_full.stats_requests,
            100.0 * cache->mip_full.stats_misses / (float)cache->mip_full.stats_requests,
            100.0 * cache->mip_full.stats_standin / (float)sum_standins,
@@ -914,7 +914,7 @@ void dt_mipmap_cache_get_with_caller(
       mipmap_generated = 1;
 
       __sync_fetch_and_add(&(_get_cache(cache, mip)->stats_fetches), 1);
-      // dt_print(DT_DEBUG_ALWAYS, "[mipmap cache get] now initializing buffer for img %u mip %d!\n", imgid, mip);
+      // dt_print(DT_DEBUG_ALWAYS, "[mipmap cache get] now initializing buffer for img %u mip %d!", imgid, mip);
       // we're write locked here, as requested by the alloc callback.
       // now fill it with data:
       if(mip == DT_MIPMAP_FULL)
@@ -949,14 +949,14 @@ void dt_mipmap_cache_get_with_caller(
           dt_image_t *img = dt_image_cache_get(darktable.image_cache, imgid, 'w');
           *img = buffered_image;
           img->load_status = DT_IMAGEIO_OK;
-          // dt_print(DT_DEBUG_ALWAYS, "[mipmap read get] initializing full buffer img %u with %u %u -> %d %d (%p)\n",
+          // dt_print(DT_DEBUG_ALWAYS, "[mipmap read get] initializing full buffer img %u with %u %u -> %d %d (%p)",
           // imgid, data[0], data[1], img->width, img->height, data);
           // don't write xmp for this (we only changed db stuff):
           dt_image_cache_write_release(darktable.image_cache, img, DT_IMAGE_CACHE_RELAXED);
         }
         else
         {
-          // dt_print(DT_DEBUG_ALWAYS, "[mipmap read get] error loading image: %d\n", ret);
+          // dt_print(DT_DEBUG_ALWAYS, "[mipmap read get] error loading image: %d", ret);
           //
           // we can only return a zero dimension buffer if the buffer has been allocated.
           // in case dsc couldn't be allocated and points to the static buffer, it contains
@@ -1040,7 +1040,7 @@ void dt_mipmap_cache_get_with_caller(
       dt_image_t *img = dt_image_cache_get(darktable.image_cache, imgid, 'r');
       dt_imageio_retval_t ret = img->load_status;
       dt_image_cache_read_release(darktable.image_cache, img);
-      // dt_print(DT_DEBUG_ALWAYS, "[mipmap cache get] got a zero-sized image for img %u mip %d!\n", imgid, mip);
+      // dt_print(DT_DEBUG_ALWAYS, "[mipmap cache get] got a zero-sized image for img %u mip %d!", imgid, mip);
       if(mip < DT_MIPMAP_F)
       {
         switch(ret)
@@ -1139,7 +1139,7 @@ void dt_mipmap_cache_get_with_caller(
   }
 
   dt_print(DT_DEBUG_CACHE | DT_DEBUG_VERBOSE,
-    "[dt_mipmap_cache_get] %s%s%s%s%s for ID=%d mip=%d mode=%c at %p\n",
+    "[dt_mipmap_cache_get] %s%s%s%s%s for ID=%d mip=%d mode=%c at %p",
     flags == DT_MIPMAP_TESTLOCK ? "DT_MIPMAP_TESTLOCK" : "",
     flags == DT_MIPMAP_PREFETCH ? "DT_MIPMAP_PREFETCH" : "",
     flags == DT_MIPMAP_PREFETCH_DISK ? "DT_MIPMAP_PREFETCH_DISK" : "",
@@ -1343,7 +1343,7 @@ static void _init_f(dt_mipmap_buffer_t *mipmap_buf,
   {
     // downsample
     dt_print_pipe(DT_DEBUG_PIPE,
-      "mipmap clip and zoom", NULL, NULL, DT_DEVICE_CPU, &roi_in, &roi_out, "\n");
+      "mipmap clip and zoom", NULL, NULL, DT_DEVICE_CPU, &roi_in, &roi_out);
     dt_iop_clip_and_zoom(out, (const float *)buf.buf, &roi_out, &roi_in);
   }
 
@@ -1452,7 +1452,7 @@ static void _init_8(uint8_t *buf,
         {
           // scale to fit
           dt_print(DT_DEBUG_CACHE,
-                   "[mipmap_cache] generate mip %d for ID=%d from jpeg\n", size, imgid);
+                   "[mipmap_cache] generate mip %d for ID=%d from jpeg", size, imgid);
           dt_iop_flip_and_zoom_8(tmp, jpg.width, jpg.height, buf, wd, ht, orientation, width, height);
           res = FALSE;
         }
@@ -1482,7 +1482,7 @@ static void _init_8(uint8_t *buf,
         {
           // scale to fit
           dt_print(DT_DEBUG_CACHE,
-                   "[mipmap_cache] generate mip %d for ID=%d from embedded jpeg\n",
+                   "[mipmap_cache] generate mip %d for ID=%d from embedded jpeg",
                    size, imgid);
           dt_iop_flip_and_zoom_8(tmp, thumb_width, thumb_height,
                                  buf, wd, ht, orientation, width, height);
@@ -1502,7 +1502,7 @@ static void _init_8(uint8_t *buf,
       if(tmp.buf == NULL)
         continue;
       dt_print(DT_DEBUG_CACHE,
-               "[mipmap_cache] generate mip %d for ID=%d from level %d\n",
+               "[mipmap_cache] generate mip %d for ID=%d from level %d",
                size, imgid, k);
       *color_space = tmp.color_space;
       // downsample
@@ -1534,7 +1534,7 @@ static void _init_8(uint8_t *buf,
     if(!res)
     {
       dt_print(DT_DEBUG_CACHE,
-               "[mipmap_cache] generate mip %d for ID=%d from scratch\n",
+               "[mipmap_cache] generate mip %d for ID=%d from scratch",
                size, imgid);
       // might be smaller, or have a different aspect than what we got as input.
       *width = dat.head.width;
@@ -1544,13 +1544,13 @@ static void _init_8(uint8_t *buf,
     }
   }
 
-  // dt_print(DT_DEBUG_ALWAYS, "[mipmap init 8] export image %u finished (sizes %d %d => %d %d)!\n", imgid, wd, ht,
+  // dt_print(DT_DEBUG_ALWAYS, "[mipmap init 8] export image %u finished (sizes %d %d => %d %d)!", imgid, wd, ht,
   // dat.head.width, dat.head.height);
 
   // any errors?
   if(res)
   {
-    // dt_print(DT_DEBUG_ALWAYS, "[mipmap_cache] could not process thumbnail!\n");
+    // dt_print(DT_DEBUG_ALWAYS, "[mipmap_cache] could not process thumbnail!");
     *width = *height = 0;
     *iscale = 0.0f;
     *color_space = DT_COLORSPACE_NONE;

--- a/src/common/module_api.h
+++ b/src/common/module_api.h
@@ -35,7 +35,7 @@
       if(!g_module_symbol(module->module, #function_name, (gpointer) & (module->function_name))) \
           module->function_name = default_ ## function_name
 
-  dt_print(DT_DEBUG_CONTROL, "[" INCLUDE_API_FROM_MODULE_LOAD "] loading `%s' from %s\n", module_name, libname);
+  dt_print(DT_DEBUG_CONTROL, "[" INCLUDE_API_FROM_MODULE_LOAD "] loading `%s' from %s", module_name, libname);
   module->module = g_module_open(libname, G_MODULE_BIND_LAZY | G_MODULE_BIND_LOCAL);
   if(!module->module) goto api_h_error;
   int (*version)();
@@ -43,7 +43,7 @@
   if(version() != dt_version())
   {
     dt_print(DT_DEBUG_ALWAYS,
-            "[" INCLUDE_API_FROM_MODULE_LOAD "] `%s' is compiled for another version of dt (module %d (%s) != dt %d (%s)) !\n",
+            "[" INCLUDE_API_FROM_MODULE_LOAD "] `%s' is compiled for another version of dt (module %d (%s) != dt %d (%s)) !",
             libname, abs(version()), version() < 0 ? "debug" : "opt", abs(dt_version()),
             dt_version() < 0 ? "debug" : "opt");
     goto api_h_error;
@@ -52,7 +52,7 @@
 
   goto skip_error;
 api_h_error:
-  dt_print(DT_DEBUG_ALWAYS, "[" INCLUDE_API_FROM_MODULE_LOAD "] failed to open `%s': %s\n", module_name, g_module_error());
+  dt_print(DT_DEBUG_ALWAYS, "[" INCLUDE_API_FROM_MODULE_LOAD "] failed to open `%s': %s", module_name, g_module_error());
   if(module->module) g_module_close(module->module);
   module->module = NULL;
   return 1;

--- a/src/common/noiseprofiles.c
+++ b/src/common/noiseprofiles.c
@@ -42,14 +42,14 @@ JsonParser *dt_noiseprofile_init(const char *alternative)
   else
     g_strlcpy(filename, alternative, sizeof(filename));
 
-  dt_print(DT_DEBUG_CONTROL, "[noiseprofile] loading noiseprofiles from `%s'\n", filename);
+  dt_print(DT_DEBUG_CONTROL, "[noiseprofile] loading noiseprofiles from `%s'", filename);
   if(!g_file_test(filename, G_FILE_TEST_EXISTS)) return NULL;
 
   // TODO: shall we cache the content? for now this looks fast enough(TM)
   JsonParser *parser = json_parser_new();
   if(!json_parser_load_from_file(parser, filename, &error))
   {
-    dt_print(DT_DEBUG_ALWAYS, "[noiseprofile] error: parsing json from `%s' failed\n%s\n", filename, error->message);
+    dt_print(DT_DEBUG_ALWAYS, "[noiseprofile] error: parsing json from `%s' failed\n%s", filename, error->message);
     g_error_free(error);
     g_object_unref(parser);
     return NULL;
@@ -59,7 +59,7 @@ JsonParser *dt_noiseprofile_init(const char *alternative)
   if(!dt_noiseprofile_verify(parser))
   {
     dt_control_log(_("noiseprofile file `%s' is not valid"), filename);
-    dt_print(DT_DEBUG_ALWAYS, "[noiseprofile] error: `%s' is not a valid noiseprofile file. run with -d control for details\n", filename);
+    dt_print(DT_DEBUG_ALWAYS, "[noiseprofile] error: `%s' is not a valid noiseprofile file. run with -d control for details", filename);
     g_object_unref(parser);
     return NULL;
   }
@@ -87,9 +87,7 @@ static gint _sort_by_iso(gconstpointer a, gconstpointer b)
 }
 
 #define _ERROR(...)     {\
-                          dt_print(DT_DEBUG_CONTROL, "[noiseprofile] error: " );\
-                          dt_print(DT_DEBUG_CONTROL, __VA_ARGS__);\
-                          dt_print(DT_DEBUG_CONTROL, "\n");\
+                          dt_print(DT_DEBUG_CONTROL, "[noiseprofile] error: " __VA_ARGS__);\
                           valid = FALSE;\
                           goto end;\
                         }
@@ -99,7 +97,7 @@ static gboolean dt_noiseprofile_verify(JsonParser *parser)
   JsonReader *reader = NULL;
   gboolean valid = TRUE;
 
-  dt_print(DT_DEBUG_CONTROL, "[noiseprofile] verifying noiseprofile file\n");
+  dt_print(DT_DEBUG_CONTROL, "[noiseprofile] verifying noiseprofile file");
 
   JsonNode *root = json_parser_get_root(parser);
   if(!root) _ERROR("can't get the root node");
@@ -122,21 +120,21 @@ static gboolean dt_noiseprofile_verify(JsonParser *parser)
 
   // go through all makers
   const int n_makers = json_reader_count_elements(reader);
-  dt_print(DT_DEBUG_CONTROL, "[noiseprofile] found %d makers\n", n_makers);
+  dt_print(DT_DEBUG_CONTROL, "[noiseprofile] found %d makers", n_makers);
   for(int i = 0; i < n_makers; i++)
   {
     if(!json_reader_read_element(reader, i)) _ERROR("can't access maker at position %d / %d", i+1, n_makers);
 
     if(!json_reader_read_member(reader, "maker")) _ERROR("missing `maker`");
 
-    dt_print(DT_DEBUG_CONTROL, "[noiseprofile] found maker `%s'\n", json_reader_get_string_value(reader));
+    dt_print(DT_DEBUG_CONTROL, "[noiseprofile] found maker `%s'", json_reader_get_string_value(reader));
     // go through all models and check those
     json_reader_end_member(reader);
 
     if(!json_reader_read_member(reader, "models")) _ERROR("missing `models`");
 
     const int n_models = json_reader_count_elements(reader);
-    dt_print(DT_DEBUG_CONTROL, "[noiseprofile] found %d models\n", n_models);
+    dt_print(DT_DEBUG_CONTROL, "[noiseprofile] found %d models", n_models);
     n_profiles_total += n_models;
     for(int j = 0; j < n_models; j++)
     {
@@ -144,13 +142,13 @@ static gboolean dt_noiseprofile_verify(JsonParser *parser)
 
       if(!json_reader_read_member(reader, "model")) _ERROR("missing `model`");
 
-      dt_print(DT_DEBUG_CONTROL, "[noiseprofile] found %s\n", json_reader_get_string_value(reader));
+      dt_print(DT_DEBUG_CONTROL, "[noiseprofile] found %s", json_reader_get_string_value(reader));
       json_reader_end_member(reader);
 
       if(!json_reader_read_member(reader, "profiles")) _ERROR("missing `profiles`");
 
       const int n_profiles = json_reader_count_elements(reader);
-      dt_print(DT_DEBUG_CONTROL, "[noiseprofile] found %d profiles\n", n_profiles);
+      dt_print(DT_DEBUG_CONTROL, "[noiseprofile] found %d profiles", n_profiles);
       for(int k = 0; k < n_profiles; k++)
       {
         if(!json_reader_read_element(reader, k)) _ERROR("can't access profile at position %d / %d", k+1, n_profiles);
@@ -214,8 +212,8 @@ static gboolean dt_noiseprofile_verify(JsonParser *parser)
 
   json_reader_end_member(reader);
 
-  dt_print(DT_DEBUG_CONTROL, "[noiseprofile] verifying noiseprofile completed\n");
-  dt_print(DT_DEBUG_CONTROL, "[noiseprofile] found %zu profiles total\n", n_profiles_total);
+  dt_print(DT_DEBUG_CONTROL, "[noiseprofile] verifying noiseprofile completed");
+  dt_print(DT_DEBUG_CONTROL, "[noiseprofile] found %zu profiles total", n_profiles_total);
 
 end:
   if(reader) g_object_unref(reader);
@@ -231,7 +229,7 @@ GList *dt_noiseprofile_get_matching(const dt_image_t *cimg)
 
   if(!parser) goto end;
 
-  dt_print(DT_DEBUG_CONTROL, "[noiseprofile] looking for maker `%s', model `%s'\n", cimg->camera_maker, cimg->camera_model);
+  dt_print(DT_DEBUG_CONTROL, "[noiseprofile] looking for maker `%s', model `%s'", cimg->camera_maker, cimg->camera_model);
 
   JsonNode *root = json_parser_get_root(parser);
 
@@ -241,7 +239,7 @@ GList *dt_noiseprofile_get_matching(const dt_image_t *cimg)
 
   // go through all makers
   const int n_makers = json_reader_count_elements(reader);
-  dt_print(DT_DEBUG_CONTROL, "[noiseprofile] found %d makers\n", n_makers);
+  dt_print(DT_DEBUG_CONTROL, "[noiseprofile] found %d makers", n_makers);
   for(int i = 0; i < n_makers; i++)
   {
     json_reader_read_element(reader, i);
@@ -250,14 +248,14 @@ GList *dt_noiseprofile_get_matching(const dt_image_t *cimg)
 
     if(g_strstr_len(cimg->camera_maker, -1, json_reader_get_string_value(reader)))
     {
-      dt_print(DT_DEBUG_CONTROL, "[noiseprofile] found `%s' as `%s'\n", cimg->camera_maker, json_reader_get_string_value(reader));
+      dt_print(DT_DEBUG_CONTROL, "[noiseprofile] found `%s' as `%s'", cimg->camera_maker, json_reader_get_string_value(reader));
       // go through all models and check those
       json_reader_end_member(reader);
 
       json_reader_read_member(reader, "models");
 
       const int n_models = json_reader_count_elements(reader);
-      dt_print(DT_DEBUG_CONTROL, "[noiseprofile] found %d models\n", n_models);
+      dt_print(DT_DEBUG_CONTROL, "[noiseprofile] found %d models", n_models);
       for(int j = 0; j < n_models; j++)
       {
         json_reader_read_element(reader, j);
@@ -266,14 +264,14 @@ GList *dt_noiseprofile_get_matching(const dt_image_t *cimg)
 
         if(!g_strcmp0(cimg->camera_model, json_reader_get_string_value(reader)))
         {
-          dt_print(DT_DEBUG_CONTROL, "[noiseprofile] found %s\n", cimg->camera_model);
+          dt_print(DT_DEBUG_CONTROL, "[noiseprofile] found %s", cimg->camera_model);
           // we got a match, return at most bufsize elements
           json_reader_end_member(reader);
 
           json_reader_read_member(reader, "profiles");
 
           const int n_profiles = json_reader_count_elements(reader);
-          dt_print(DT_DEBUG_CONTROL, "[noiseprofile] found %d profiles\n", n_profiles);
+          dt_print(DT_DEBUG_CONTROL, "[noiseprofile] found %d profiles", n_profiles);
           for(int k = 0; k < n_profiles; k++)
           {
             dt_noiseprofile_t tmp_profile = { 0 };

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -250,7 +250,7 @@ int dt_opencl_get_device_info(dt_opencl_t *cl,
   {
     dt_print(DT_DEBUG_OPENCL,
              "[dt_opencl_get_device_info] could not query the actual size"
-             " in bytes of info %d: %s\n", param_name, cl_errstr(err));
+             " in bytes of info %d: %s", param_name, cl_errstr(err));
     goto error;
   }
 
@@ -262,7 +262,7 @@ int dt_opencl_get_device_info(dt_opencl_t *cl,
     // spec, or opencl implementation bug?
     dt_print(DT_DEBUG_OPENCL,
              "[dt_opencl_get_device_info] ERROR: no size returned,"
-             " or zero size returned for data %d: %zu\n",
+             " or zero size returned for data %d: %zu",
              param_name, *param_value_size);
     err = CL_INVALID_VALUE; // FIXME: anything better?
     goto error;
@@ -291,7 +291,7 @@ int dt_opencl_get_device_info(dt_opencl_t *cl,
   if(err != CL_SUCCESS)
   {
     dt_print(DT_DEBUG_OPENCL,
-             "[dt_opencl_get_device_info] could not query info %d: %s\n",
+             "[dt_opencl_get_device_info] could not query info %d: %s",
              param_name, cl_errstr(err));
     goto error;
   }
@@ -343,7 +343,7 @@ void dt_opencl_write_device_config(const int devid)
     cl->dev[devid].advantage,
     cl->dev[devid].unified_fraction);
   dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE,
-           "[dt_opencl_write_device_config] writing data '%s' for '%s'\n", dat, key);
+           "[dt_opencl_write_device_config] writing data '%s' for '%s'", dat, key);
   dt_conf_set_string(key, dat);
 
   // Also take care of extended device data, these are not only device
@@ -352,7 +352,7 @@ void dt_opencl_write_device_config(const int devid)
   g_snprintf(key, 254, "%s%s_id%i", DT_CLDEVICE_HEAD, cl->dev[devid].cname, devid);
   g_snprintf(dat, 510, "%i", cl->dev[devid].headroom);
   dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE,
-           "[dt_opencl_write_device_config] writing data '%s' for '%s'\n", dat, key);
+           "[dt_opencl_write_device_config] writing data '%s' for '%s'", dat, key);
   dt_conf_set_string(key, dat);
 }
 
@@ -403,7 +403,7 @@ gboolean dt_opencl_read_device_config(const int devid)
     else // if there is something wrong with the found conf key reset to defaults
     {
       dt_print(DT_DEBUG_OPENCL,
-               "[dt_opencl_read_device_config] malformed data '%s' for '%s'\n", dat, key);
+               "[dt_opencl_read_device_config] malformed data '%s' for '%s'", dat, key);
     }
   }
   // do some safety housekeeping
@@ -1030,7 +1030,7 @@ static gboolean _opencl_device_init(dt_opencl_t *cl,
       {
         dt_print(DT_DEBUG_OPENCL,
                  "[dt_opencl_device_init] malformed entry in programs.conf `%s';"
-                 " ignoring it!\n", confentry);
+                 " ignoring it!", confentry);
         continue;
       }
 
@@ -1039,7 +1039,7 @@ static gboolean _opencl_device_init(dt_opencl_t *cl,
       snprintf(binname, PATH_MAX * sizeof(char),
                "%s" G_DIR_SEPARATOR_S "%s.bin", cachedir, programname);
       dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE,
-               "[dt_opencl_device_init] testing program `%s' ..\n", programname);
+               "[dt_opencl_device_init] testing program `%s' ..", programname);
       int loaded_cached;
       char md5sum[33];
       if(_opencl_load_program(dev, prog, programname, filename, binname, cachedir,
@@ -1047,7 +1047,7 @@ static gboolean _opencl_device_init(dt_opencl_t *cl,
          && _opencl_build_program(dev, prog, binname, cachedir, md5sum, loaded_cached))
       {
         dt_print(DT_DEBUG_OPENCL,
-                 "[dt_opencl_device_init] failed to compile program `%s'!\n",
+                 "[dt_opencl_device_init] failed to compile program `%s'!",
                  programname);
         fclose(f);
         g_strfreev(tokens);
@@ -1141,13 +1141,13 @@ void dt_opencl_init(
   if(exclude_opencl)
   {
     dt_print(DT_DEBUG_OPENCL,
-             "[opencl_init] opencl disabled due to explicit user request\n");
+             "[opencl_init] opencl disabled due to explicit user request");
     goto finally;
   }
 
   if(!opencl_requested)
     dt_print(DT_DEBUG_OPENCL,
-             "[opencl_init] opencl disabled via darktable preferences\n");
+             "[opencl_init] opencl disabled via darktable preferences");
 
   // look for explicit definition of opencl_runtime library in preferences
   const char *library = dt_conf_get_string_const("opencl_library");
@@ -1159,7 +1159,7 @@ void dt_opencl_init(
     logerror = _("no working OpenCL library found");
     dt_print(DT_DEBUG_OPENCL,
              "[opencl_init] no working opencl '%s' library found."
-             " Continue with opencl disabled\n",
+             " Continue with opencl disabled",
              (strlen(library) == 0) ? "default path" : library);
     goto finally;
   }
@@ -1167,7 +1167,7 @@ void dt_opencl_init(
   {
     dt_print(DT_DEBUG_OPENCL,
              "[opencl_init] opencl library '%s' found on your system and loaded,"
-             " preference '%s'\n",
+             " preference '%s'",
              cl->dlocl->library,
              (strlen(library) == 0) ? "default path" : library);
   }
@@ -1188,7 +1188,7 @@ void dt_opencl_init(
   if((err != CL_SUCCESS) || (num_platforms == 0))
   {
     dt_print(DT_DEBUG_OPENCL,
-             "[opencl_init] %i platforms detected, error: %s\n",
+             "[opencl_init] %i platforms detected, error: %s",
              num_platforms, cl_errstr(err));
     goto finally;
   }
@@ -1199,18 +1199,18 @@ void dt_opencl_init(
   if(err != CL_SUCCESS)
   {
     dt_print(DT_DEBUG_OPENCL,
-             "[opencl_init] could not get platforms IDs: %s\n", cl_errstr(err));
+             "[opencl_init] could not get platforms IDs: %s", cl_errstr(err));
     goto finally;
   }
   if(num_platforms == 0)
   {
-    dt_print(DT_DEBUG_OPENCL, "[opencl_init] no opencl platform available\n");
+    dt_print(DT_DEBUG_OPENCL, "[opencl_init] no opencl platform available");
     goto finally;
   }
 
   logerror = NULL;
   dt_print(DT_DEBUG_OPENCL,
-           "[opencl_init] found %d platform%s\n",
+           "[opencl_init] found %d platform%s",
            num_platforms, num_platforms > 1 ? "s" : "");
 
   // safety check for platforms; we must not have several versions for the same platform
@@ -1227,7 +1227,7 @@ void dt_opencl_init(
       {
         if(!strcmp(platforms + n * DT_OPENCL_CBUFFSIZE, platforms + k * DT_OPENCL_CBUFFSIZE))
         dt_print(DT_DEBUG_OPENCL,
-           "[opencl_init] possibly a multiple platform problem for `%s'\n",
+           "[opencl_init] possibly a multiple platform problem for `%s'",
            platforms + n * DT_OPENCL_CBUFFSIZE);
       }
     }
@@ -1279,17 +1279,17 @@ void dt_opencl_init(
       if(!valid_platform)
       {
         dt_print(DT_DEBUG_OPENCL,
-                 "[check platform] platform '%s' with key '%s' is NOT active\n",
+                 "[check platform] platform '%s' with key '%s' is NOT active",
                  platform_name, platform_key);
       }
       else if((errn == CL_SUCCESS) && (errv == CL_SUCCESS))
         dt_print(DT_DEBUG_OPENCL,
-                 "[opencl_init] no devices found for %s (vendor) - %s (name)\n",
+                 "[opencl_init] no devices found for %s (vendor) - %s (name)",
                  platform_vendor, platform_name);
       else
       {
         dt_print(DT_DEBUG_OPENCL,
-                 "[opencl_init] no devices found for unknown platform\n");
+                 "[opencl_init] no devices found for unknown platform");
         logerror = _("no devices found for unknown platform");
       }
       all_num_devices[n] = 0;
@@ -1304,7 +1304,7 @@ void dt_opencl_init(
       {
         all_num_devices[n] = 0;
         dt_print(DT_DEBUG_OPENCL,
-                 "[opencl_init] could not get profile for platform '%s': %s\n",
+                 "[opencl_init] could not get profile for platform '%s': %s",
                  platform_name, cl_errstr(err));
       }
       else
@@ -1313,7 +1313,7 @@ void dt_opencl_init(
         {
           all_num_devices[n] = 0;
           dt_print(DT_DEBUG_OPENCL,
-                   "[opencl_init] platform '%s' is not FULL_PROFILE\n",
+                   "[opencl_init] platform '%s' is not FULL_PROFILE",
                    platform_name);
         }
       }
@@ -1335,7 +1335,7 @@ void dt_opencl_init(
       cl->dev = NULL;
       free(devices);
       dt_print(DT_DEBUG_OPENCL,
-               "[opencl_init] could not allocate memory for device resources\n");
+               "[opencl_init] could not allocate memory for device resources");
       logerror = _("not enough memory for OpenCL devices");
       goto finally;
     }
@@ -1356,7 +1356,7 @@ void dt_opencl_init(
       {
         num_devices -= all_num_devices[n];
         dt_print(DT_DEBUG_OPENCL,
-                 "[opencl_init] could not get devices list: %s\n",
+                 "[opencl_init] could not get devices list: %s",
                  cl_errstr(err));
       }
       devs += all_num_devices[n];
@@ -1420,7 +1420,7 @@ void dt_opencl_init(
 
 finally:
   dt_print(DT_DEBUG_OPENCL,
-           "[opencl_init] FINALLY: opencl PREFERENCE=%s is %sAVAILABLE and %sENABLED.\n",
+           "[opencl_init] FINALLY: opencl PREFERENCE=%s is %sAVAILABLE and %sENABLED.",
            opencl_requested ? "ON" : "OFF",
            cl->inited ? "" : "NOT ",
            cl->enabled ? "" : "NOT ");
@@ -1471,7 +1471,7 @@ finally:
       // set scheduling profile to "default"
       dt_conf_set_string("opencl_scheduling_profile", "default");
       dt_print(DT_DEBUG_OPENCL,
-               "[opencl_init] set scheduling profile to default, setup has changed.\n");
+               "[opencl_init] set scheduling profile to default, setup has changed.");
       dt_control_log(_("OpenCL scheduling profile set to default, setup has changed"));
     }
     // apply config settings for scheduling profile: sets device
@@ -1489,7 +1489,7 @@ finally:
           darktable.dtresources.total_memory * cl->dev[i].unified_fraction);
         cl->dev[i].max_global_mem = reserved;
         dt_print_nts(DT_DEBUG_OPENCL,
-               "   UNIFIED MEM SIZE:         %.0f MB reserved for '%s'\n",
+               "   UNIFIED MEM SIZE:         %.0f MB reserved for '%s'",
                (double)reserved / 1024.0 / 1024.0,
                cl->dev[i].cname);
         unified_sysmem = MAX(unified_sysmem, reserved);
@@ -2068,14 +2068,14 @@ static FILE *_fopen_stat(const char *filename, struct stat *st)
   if(!f)
   {
     dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE,
-             "[opencl_fopen_stat] could not open file `%s'!\n", filename);
+             "[opencl_fopen_stat] could not open file `%s'!", filename);
     return NULL;
   }
   const int fd = fileno(f);
   if(fstat(fd, st) < 0)
   {
     dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE,
-             "[opencl_fopen_stat] could not stat file `%s'!\n", filename);
+             "[opencl_fopen_stat] could not stat file `%s'!", filename);
     return NULL;
   }
   return f;
@@ -2104,7 +2104,7 @@ static void _opencl_md5sum(const char **files,
     if(!f)
     {
       dt_print(DT_DEBUG_OPENCL,
-               "[opencl_md5sums] could not open file `%s'!\n", filename);
+               "[opencl_md5sums] could not open file `%s'!", filename);
       *md5sums = NULL;
       continue;
     }
@@ -2115,7 +2115,7 @@ static void _opencl_md5sum(const char **files,
     if(!file)
     {
       dt_print(DT_DEBUG_OPENCL,
-               "[opencl_md5sums] could not allocate buffer for file `%s'!\n", filename);
+               "[opencl_md5sums] could not allocate buffer for file `%s'!", filename);
       *md5sums = NULL;
       fclose(f);
       continue;
@@ -2128,7 +2128,7 @@ static void _opencl_md5sum(const char **files,
     {
       free(file);
       dt_print(DT_DEBUG_OPENCL,
-               "[opencl_md5sums] could not read all of file `%s'!\n", filename);
+               "[opencl_md5sums] could not read all of file `%s'!", filename);
       *md5sums = NULL;
       continue;
     }
@@ -2159,7 +2159,7 @@ static gboolean _opencl_load_program(const int dev,
   if(prog < 0 || prog >= DT_OPENCL_MAX_PROGRAMS)
   {
     dt_print(DT_DEBUG_OPENCL,
-             "[opencl_load_source] invalid program number `%d' of file `%s'!\n", prog,
+             "[opencl_load_source] invalid program number `%d' of file `%s'!", prog,
              filename);
     return FALSE;
   }
@@ -2168,7 +2168,7 @@ static gboolean _opencl_load_program(const int dev,
   {
     dt_print(DT_DEBUG_OPENCL,
              "[opencl_load_source] program number `%d' already in use"
-             " when loading file `%s'!\n", prog,
+             " when loading file `%s'!", prog,
              filename);
     return FALSE;
   }
@@ -2185,7 +2185,7 @@ static gboolean _opencl_load_program(const int dev,
     free(file);
     dt_print(DT_DEBUG_OPENCL,
              "[opencl_load_source] could not read all"
-             " of file `%s' for program number %d!\n",
+             " of file `%s' for program number %d!",
       filename, prog);
     return FALSE;
   }
@@ -2259,7 +2259,7 @@ static gboolean _opencl_load_program(const int dev,
         if(rd != cached_filesize)
         {
           dt_print(DT_DEBUG_OPENCL,
-                   "[opencl_load_program] could not read all of file '%s' MD5: %s!\n",
+                   "[opencl_load_program] could not read all of file '%s' MD5: %s!",
                    binname, md5sum);
         }
         else
@@ -2271,7 +2271,7 @@ static gboolean _opencl_load_program(const int dev,
           {
             dt_print(DT_DEBUG_OPENCL,
                      "[opencl_load_program] could not load cached binary"
-                     " program from file '%s' MD5: '%s'! (%s)\n",
+                     " program from file '%s' MD5: '%s'! (%s)",
                      binname, md5sum, cl_errstr(err));
           }
           else
@@ -2317,7 +2317,7 @@ static gboolean _opencl_load_program(const int dev,
     if((err != CL_SUCCESS) || (cl->dev[dev].program[prog] == NULL))
     {
       dt_print(DT_DEBUG_OPENCL,
-               "[opencl_load_source] could not create program from file `%s'! (%s)\n",
+               "[opencl_load_source] could not create program from file `%s'! (%s)",
                filename, cl_errstr(err));
       return FALSE;
     }
@@ -2331,11 +2331,11 @@ static gboolean _opencl_load_program(const int dev,
     free(file);
     dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE,
              "[opencl_load_program] loaded cached"
-             " binary program from file '%s' MD5: '%s' \n", binname, md5sum);
+             " binary program from file '%s' MD5: '%s' ", binname, md5sum);
   }
 
   dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE,
-           "[opencl_load_program] successfully loaded program from '%s' MD5: '%s'\n",
+           "[opencl_load_program] successfully loaded program from '%s' MD5: '%s'",
            filename, md5sum);
 
   return TRUE;
@@ -2357,10 +2357,10 @@ static gboolean _opencl_build_program(const int dev,
 
   if(err != CL_SUCCESS)
     dt_print(DT_DEBUG_OPENCL,
-             "[opencl_build_program] could not build program: %s\n", cl_errstr(err));
+             "[opencl_build_program] could not build program: %s", cl_errstr(err));
   else
     dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE,
-             "[opencl_build_program] successfully built program\n");
+             "[opencl_build_program] successfully built program");
 
   cl_build_status build_status;
   (cl->dlocl->symbols->dt_clGetProgramBuildInfo)(program, cl->dev[dev].devid,
@@ -2368,7 +2368,7 @@ static gboolean _opencl_build_program(const int dev,
                                                  sizeof(cl_build_status),
                                                  &build_status, NULL);
   dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE,
-           "[opencl_build_program] BUILD STATUS: %d\n", build_status);
+           "[opencl_build_program] BUILD STATUS: %d", build_status);
 
   char *build_log;
   size_t ret_val_size;
@@ -2386,8 +2386,8 @@ static gboolean _opencl_build_program(const int dev,
 
       build_log[ret_val_size] = '\0';
 
-      dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE, "BUILD LOG:\n");
-      dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE, "%s\n", build_log);
+      dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE, "BUILD LOG:");
+      dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE, "%s", build_log);
 
       free(build_log);
     }
@@ -2399,7 +2399,7 @@ static gboolean _opencl_build_program(const int dev,
   if(!loaded_cached)
   {
     dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE,
-             "[opencl_build_program] saving binary\n");
+             "[opencl_build_program] saving binary");
 
     cl_uint numdev = 0;
     err = (cl->dlocl->symbols->dt_clGetProgramInfo)(program, CL_PROGRAM_NUM_DEVICES,
@@ -2408,7 +2408,7 @@ static gboolean _opencl_build_program(const int dev,
     if(err != CL_SUCCESS)
     {
       dt_print(DT_DEBUG_OPENCL,
-               "[opencl_build_program] CL_PROGRAM_NUM_DEVICES failed: %s\n",
+               "[opencl_build_program] CL_PROGRAM_NUM_DEVICES failed: %s",
                cl_errstr(err));
       return TRUE;
     }
@@ -2420,7 +2420,7 @@ static gboolean _opencl_build_program(const int dev,
     if(err != CL_SUCCESS)
     {
       dt_print(DT_DEBUG_OPENCL,
-               "[opencl_build_program] CL_PROGRAM_DEVICES failed: %s\n", cl_errstr(err));
+               "[opencl_build_program] CL_PROGRAM_DEVICES failed: %s", cl_errstr(err));
       free(devices);
       return TRUE;
     }
@@ -2432,7 +2432,7 @@ static gboolean _opencl_build_program(const int dev,
     if(err != CL_SUCCESS)
     {
       dt_print(DT_DEBUG_OPENCL,
-               "[opencl_build_program] CL_PROGRAM_BINARY_SIZES failed: %s\n",
+               "[opencl_build_program] CL_PROGRAM_BINARY_SIZES failed: %s",
                cl_errstr(err));
       free(binary_sizes);
       free(devices);
@@ -2448,7 +2448,7 @@ static gboolean _opencl_build_program(const int dev,
     if(err != CL_SUCCESS)
     {
       dt_print(DT_DEBUG_OPENCL,
-               "[opencl_build_program] CL_PROGRAM_BINARIES failed: %s\n",
+               "[opencl_build_program] CL_PROGRAM_BINARIES failed: %s",
                cl_errstr(err));
       goto ret;
     }
@@ -2497,7 +2497,7 @@ static gboolean _opencl_build_program(const int dev,
       free(devices);
     if(err != CL_SUCCESS)
       dt_print(DT_DEBUG_OPENCL,
-               "[dt_opencl_build_program] problems while writing OpenCL kernel files\n");
+               "[dt_opencl_build_program] problems while writing OpenCL kernel files");
   }
 
   return err != CL_SUCCESS;
@@ -2515,7 +2515,7 @@ int dt_opencl_create_kernel(const int prog,
   if(k >= DT_OPENCL_MAX_KERNELS)
   {
     dt_print(DT_DEBUG_OPENCL,
-             "[opencl_create_kernel] too many kernels! can't create kernel `%s'\n",
+             "[opencl_create_kernel] too many kernels! can't create kernel `%s'",
               name);
     return -1;
   }
@@ -2548,7 +2548,7 @@ static gboolean _check_kernel(const int dev,
     if(err != CL_SUCCESS)
     {
       dt_print(DT_DEBUG_OPENCL,
-               "[opencl_create_kernel] could not create kernel `%s'! (%s)\n",
+               "[opencl_create_kernel] could not create kernel `%s'! (%s)",
                cl->name_saved[kernel], cl_errstr(err));
       cl->dev[dev].kernel_used[kernel] = 0;
       cl->name_saved[kernel] = NULL; // don't try again
@@ -2639,7 +2639,7 @@ int dt_opencl_set_kernel_arg(const int dev,
 
   if(err != CL_SUCCESS)
     dt_print(DT_DEBUG_OPENCL,
-             "[dt_opencl_set_kernel_arg] error kernel `%s' (%i) on device %d: %s\n",
+             "[dt_opencl_set_kernel_arg] error kernel `%s' (%i) on device %d: %s",
               darktable.opencl->name_saved[kernel], kernel, dev, cl_errstr(err));
   return err;
 }
@@ -2718,7 +2718,7 @@ int dt_opencl_enqueue_kernel_ndim_with_local(const int dev,
 
   if(err != CL_SUCCESS)
     dt_print(DT_DEBUG_OPENCL,
-             "[dt_opencl_enqueue_kernel_%id%s] kernel `%s' (%i) on device %d: %s\n",
+             "[dt_opencl_enqueue_kernel_%id%s] kernel `%s' (%i) on device %d: %s",
               dimensions, local ? "_with_local" : "",
               darktable.opencl->name_saved[kernel], kernel, dev, cl_errstr(err));
   _check_clmem_err(dev, err);
@@ -2745,7 +2745,7 @@ int dt_opencl_enqueue_kernel_2d_args_internal(const int dev,
   if(err != CL_SUCCESS)
   {
     dt_print(DT_DEBUG_OPENCL,
-             "[dt_opencl_enqueue_kernel_2d_args_internal] kernel `%s' (%i) on device %d: %s\n",
+             "[dt_opencl_enqueue_kernel_2d_args_internal] kernel `%s' (%i) on device %d: %s",
               darktable.opencl->name_saved[kernel], kernel, dev, cl_errstr(err));
     return err;
   }
@@ -2766,7 +2766,7 @@ int dt_opencl_enqueue_kernel_1d_args_internal(const int dev,
   if(err != CL_SUCCESS)
   {
     dt_print(DT_DEBUG_OPENCL,
-             "[dt_opencl_enqueue_kernel_1d_args_internal] kernel `%s' (%i) on device %d: %s\n",
+             "[dt_opencl_enqueue_kernel_1d_args_internal] kernel `%s' (%i) on device %d: %s",
               darktable.opencl->name_saved[kernel], kernel, dev, cl_errstr(err));
     return err;
   }
@@ -2960,7 +2960,7 @@ int dt_opencl_enqueue_copy_image(const int devid,
 
   if(err != CL_SUCCESS)
     dt_print(DT_DEBUG_OPENCL,
-             "[opencl copy_image] could not copy on device %d: %s\n",
+             "[opencl copy_image] could not copy on device %d: %s",
              devid, cl_errstr(err));
   _check_clmem_err(devid, err);
   return err;
@@ -2983,7 +2983,7 @@ int dt_opencl_enqueue_copy_image_to_buffer(const int devid,
 
   if(err != CL_SUCCESS)
     dt_print(DT_DEBUG_OPENCL,
-             "[opencl copy_image_to_buffer] could not copy on device %d: %s\n",
+             "[opencl copy_image_to_buffer] could not copy on device %d: %s",
              devid, cl_errstr(err));
   _check_clmem_err(devid, err);
   return err;
@@ -3006,7 +3006,7 @@ int dt_opencl_enqueue_copy_buffer_to_image(const int devid,
 
   if(err != CL_SUCCESS)
     dt_print(DT_DEBUG_OPENCL,
-             "[opencl copy_buffer_to_image] could not copy on device %d: %s\n",
+             "[opencl copy_buffer_to_image] could not copy on device %d: %s",
              devid, cl_errstr(err));
   _check_clmem_err(devid, err);
   return err;
@@ -3029,7 +3029,7 @@ int dt_opencl_enqueue_copy_buffer_to_buffer(const int devid,
      dstoffset, size, 0, NULL, eventp);
   if(err != CL_SUCCESS)
     dt_print(DT_DEBUG_OPENCL,
-             "[opencl copy_buffer_to_buffer] could not copy on device %d: %s\n",
+             "[opencl copy_buffer_to_buffer] could not copy on device %d: %s",
              devid, cl_errstr(err));
   _check_clmem_err(devid, err);
   return err;
@@ -3054,7 +3054,7 @@ int dt_opencl_read_buffer_from_device(const int devid,
      offset, size, host, 0, NULL, eventp);
   if(err != CL_SUCCESS)
     dt_print(DT_DEBUG_OPENCL,
-             "[opencl read_buffer_from_device] could not read from device %d: %s\n",
+             "[opencl read_buffer_from_device] could not read from device %d: %s",
              devid, cl_errstr(err));
   return err;
 }
@@ -3079,7 +3079,7 @@ int dt_opencl_write_buffer_to_device(const int devid,
 
   if(err != CL_SUCCESS)
     dt_print(DT_DEBUG_OPENCL,
-             "[opencl write_buffer_to_device] could not write to device %d: %s\n",
+             "[opencl write_buffer_to_device] could not write to device %d: %s",
              devid, cl_errstr(err));
   return err;
 }
@@ -3100,7 +3100,7 @@ void *dt_opencl_copy_host_to_device_constant(const int devid,
   if(err != CL_SUCCESS)
     dt_print(DT_DEBUG_OPENCL,
              "[opencl copy_host_to_device_constant]"
-             " could not alloc buffer on device %d: %s\n",
+             " could not alloc buffer on device %d: %s",
              devid, cl_errstr(err));
 
   dt_opencl_memory_statistics(devid, dev, OPENCL_MEMORY_ADD);
@@ -3149,7 +3149,7 @@ void *dt_opencl_copy_host_to_device_rowpitch(const int devid,
   if(err != CL_SUCCESS)
     dt_print(DT_DEBUG_OPENCL,
              "[opencl copy_host_to_device]"
-             " could not alloc/copy img buffer on device %d: %s\n",
+             " could not alloc/copy img buffer on device %d: %s",
              devid, cl_errstr(err));
 
   _check_clmem_err(devid, err);
@@ -3195,7 +3195,7 @@ void *dt_opencl_map_buffer(const int devid,
 
   if(err != CL_SUCCESS)
     dt_print(DT_DEBUG_OPENCL,
-             "[opencl map buffer] could not map buffer on device %d: %s\n",
+             "[opencl map buffer] could not map buffer on device %d: %s",
              devid, cl_errstr(err));
   _check_clmem_err(devid, err);
   return ptr;
@@ -3214,7 +3214,7 @@ int dt_opencl_unmap_mem_object(const int devid,
 
   if(err != CL_SUCCESS)
     dt_print(DT_DEBUG_OPENCL,
-             "[opencl unmap mem object] could not unmap mem object on device %d: %s\n",
+             "[opencl unmap mem object] could not unmap mem object on device %d: %s",
              devid, cl_errstr(err));
   return err;
 }
@@ -3255,7 +3255,7 @@ void *dt_opencl_alloc_device(const int devid,
 
   if(err != CL_SUCCESS)
     dt_print(DT_DEBUG_OPENCL,
-             "[opencl alloc_device] could not alloc img buffer on device %d: %s\n",
+             "[opencl alloc_device] could not alloc img buffer on device %d: %s",
              devid, cl_errstr(err));
 
   _check_clmem_err(devid, err);
@@ -3304,7 +3304,7 @@ void *dt_opencl_alloc_device_use_host_pointer(const int devid,
   if(err != CL_SUCCESS || dev == NULL)
     dt_print(DT_DEBUG_OPENCL,
              "[opencl alloc_device_use_host_pointer]"
-             " could not allocate cl image on device %d: %s\n",
+             " could not allocate cl image on device %d: %s",
              devid, cl_errstr(err));
 
   _check_clmem_err(devid, err);
@@ -3329,7 +3329,7 @@ void *dt_opencl_alloc_device_buffer(const int devid,
      CL_MEM_READ_WRITE, size, NULL, &err);
   if(err != CL_SUCCESS || buf == NULL)
     dt_print(DT_DEBUG_OPENCL,
-             "[opencl alloc_device_buffer] could not allocate cl buffer on device %d: %s\n",
+             "[opencl alloc_device_buffer] could not allocate cl buffer on device %d: %s",
              devid, cl_errstr(err));
 
   _check_clmem_err(devid, err);
@@ -3355,7 +3355,7 @@ void *dt_opencl_alloc_device_buffer_with_flags(const int devid,
      flags, size, NULL, &err);
   if(err != CL_SUCCESS || buf == NULL)
     dt_print(DT_DEBUG_OPENCL,
-             "[opencl alloc_device_buffer_with_flags] could not allocate cl buffer on device %d: %s\n",
+             "[opencl alloc_device_buffer_with_flags] could not allocate cl buffer on device %d: %s",
              devid, cl_errstr(err));
 
   _check_clmem_err(devid, err);
@@ -3501,7 +3501,7 @@ void dt_opencl_memory_statistics(int devid,
 
   if(darktable.unmuted & DT_DEBUG_MEMORY)
   {
-    dt_print(DT_DEBUG_OPENCL,"[opencl memory] device %d: %zu bytes (%.1f MB) in use, %.1f MB available GPU memory, %.1f MB global GPU mem size\n",
+    dt_print(DT_DEBUG_OPENCL,"[opencl memory] device %d: %zu bytes (%.1f MB) in use, %.1f MB available GPU memory, %.1f MB global GPU mem size",
              devid,
              darktable.opencl->dev[devid].memory_in_use,
              (float)darktable.opencl->dev[devid].memory_in_use/(1024*1024),
@@ -3510,7 +3510,7 @@ void dt_opencl_memory_statistics(int devid,
       if(darktable.opencl->dev[devid].memory_in_use > darktable.opencl->dev[devid].used_available)
       {
         dt_print(DT_DEBUG_OPENCL,
-                 "[opencl memory] Warning, device %d used more GPU memory than available\n",
+                 "[opencl memory] Warning, device %d used more GPU memory than available",
                  devid);
       }
   }
@@ -3551,7 +3551,7 @@ void dt_opencl_check_tuning(const int devid)
     if(info)
       dt_print(DT_DEBUG_OPENCL | DT_DEBUG_MEMORY,
                "[dt_opencl_check_tuning] reference mode %i,"
-               " use %luMB (pinning=%s) on device `%s' id=%i\n",
+               " use %luMB (pinning=%s) on device `%s' id=%i",
                level,
                cl->dev[devid].used_available / 1024lu / 1024lu,
                cl->dev[devid].pinned_memory ? "ON" : "OFF",
@@ -3585,7 +3585,7 @@ void dt_opencl_check_tuning(const int devid)
   if(info)
     dt_print(DT_DEBUG_OPENCL | DT_DEBUG_MEMORY,
              "[dt_opencl_check_tuning] use %luMB (headroom=%s, pinning=%s)"
-             " on device `%s' id=%i\n",
+             " on device `%s' id=%i",
              cl->dev[devid].used_available / 1024lu / 1024lu,
              cl->dev[devid].tunehead ? "ON" : "OFF",
              cl->dev[devid].pinned_memory  ? "ON" : "OFF",
@@ -3687,7 +3687,7 @@ void dt_opencl_update_settings(void)
   _opencl_apply_scheduling_profile(profile);
   const char *pstr = dt_conf_get_string_const("opencl_scheduling_profile");
   dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE,
-           "[opencl_update_settings] scheduling profile set to %s\n", pstr);
+           "[opencl_update_settings] scheduling profile set to %s", pstr);
 }
 
 /** read scheduling profile for config variables */
@@ -3776,7 +3776,7 @@ static cl_event *_opencl_events_get_slot(const int devid,
       *eventlist = NULL;
       *eventtags = NULL;
       dt_print(DT_DEBUG_OPENCL,
-               "[opencl_events_get_slot] NO eventlist for device %i\n", devid);
+               "[opencl_events_get_slot] NO eventlist for device %i", devid);
       return NULL;
     }
     *maxevents = newevents;
@@ -3815,7 +3815,7 @@ static cl_event *_opencl_events_get_slot(const int devid,
     if(!neweventlist || !neweventtags)
     {
       dt_print(DT_DEBUG_OPENCL,
-               "[opencl_events_get_slot] NO new eventlist with size %i for device %i\n",
+               "[opencl_events_get_slot] NO new eventlist with size %i for device %i",
                newevents, devid);
       free(neweventlist);
       free(neweventtags);
@@ -3917,7 +3917,7 @@ static void _opencl_events_wait_for(const int devid)
                                            (*eventlist) + *eventsconsolidated);
   if((err != CL_SUCCESS) && (err != CL_INVALID_VALUE))
     dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE,
-             "[dt_opencl_events_wait_for] reported %s for device %i\n",
+             "[dt_opencl_events_wait_for] reported %s for device %i",
        cl_errstr(err), devid);
 }
 
@@ -3990,13 +3990,13 @@ static void _opencl_events_profiling(const int devid,
 
   // now display profiling info
   dt_print(DT_DEBUG_OPENCL,
-           "[opencl_profiling] profiling device %d ('%s'):\n",
+           "[opencl_profiling] profiling device %d ('%s'):",
            devid, cl->dev[devid].fullname);
 
   float total = 0.0f;
   for(int i = 1; i < items; i++)
   {
-    dt_print(DT_DEBUG_OPENCL, "[opencl_profiling] spent %7.4f seconds in %s\n",
+    dt_print(DT_DEBUG_OPENCL, "[opencl_profiling] spent %7.4f seconds in %s",
              (double)timings[i],
              tags[i][0] == '\0' ? "<?>" : tags[i]);
     total += timings[i];
@@ -4004,14 +4004,14 @@ static void _opencl_events_profiling(const int devid,
   // aggregated timing info for items without tag (if any)
   if(timings[0] != 0.0f)
   {
-    dt_print(DT_DEBUG_OPENCL, "[opencl_profiling] spent %7.4f seconds (unallocated)\n",
+    dt_print(DT_DEBUG_OPENCL, "[opencl_profiling] spent %7.4f seconds (unallocated)",
              (double)timings[0]);
     total += timings[0];
   }
 
   dt_print(DT_DEBUG_OPENCL,
            "[opencl_profiling] spent %7.4f seconds totally in"
-           " command queue (with %d event%s missing)\n",
+           " command queue (with %d event%s missing)",
            (double)total, *lostevents, *lostevents == 1 ? "" : "s");
   free(timings);
   free(tags);
@@ -4059,12 +4059,12 @@ cl_int dt_opencl_events_flush(const int devid,
     if(err != CL_SUCCESS)
     {
       dt_print(DT_DEBUG_OPENCL,
-               "[opencl_events_flush] could not get event info for '%s': %s\n",
+               "[opencl_events_flush] could not get event info for '%s': %s",
                tag[0] == '\0' ? "<?>" : tag, cl_errstr(err));
     }
     else if(*retval != CL_COMPLETE)
     {
-      dt_print(DT_DEBUG_OPENCL, "[opencl_events_flush] execution of '%s' %s: %d\n",
+      dt_print(DT_DEBUG_OPENCL, "[opencl_events_flush] execution of '%s' %s: %d",
                tag[0] == '\0' ? "<?>" : tag,
                *retval == CL_COMPLETE ? "was successful" : "failed",
                *retval);
@@ -4165,7 +4165,7 @@ int dt_opencl_local_buffer_opt(const int devid,
       if(*blocksizex == 1 && *blocksizey == 1)
       {
         dt_print(DT_DEBUG_OPENCL,
-             "[dt_opencl_local_buffer_opt] no valid resource limits for device %d\n",
+             "[dt_opencl_local_buffer_opt] no valid resource limits for device %d",
                  devid);
         return FALSE;
       }
@@ -4180,7 +4180,7 @@ int dt_opencl_local_buffer_opt(const int devid,
   {
     dt_print(DT_DEBUG_OPENCL,
              "[dt_opencl_local_buffer_opt] can not identify"
-             " resource limits for device %d\n", devid);
+             " resource limits for device %d", devid);
     return FALSE;
   }
 

--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -672,7 +672,7 @@ static inline void dt_opencl_init(dt_opencl_t *cl,
   cl->error_count = 0;
   dt_conf_set_bool("opencl", FALSE);
   dt_print(DT_DEBUG_OPENCL,
-           "[opencl_init] this version of darktable was built without opencl support\n");
+           "[opencl_init] this version of darktable was built without opencl support");
 }
 static inline void dt_opencl_cleanup(dt_opencl_t *cl)
 {

--- a/src/common/overlay.c
+++ b/src/common/overlay.c
@@ -196,7 +196,7 @@ void dt_overlay_add_from_history(const dt_imgid_t imgid)
 
       dt_print(DT_DEBUG_PARAMS,
                "[dt_overlay_add_from_history] "
-               "add overlay %d to imgid %d\n",
+               "add overlay %d to imgid %d",
                *overlay_id, imgid);
     }
   }
@@ -238,7 +238,7 @@ void dt_overlay_remove_from_history(const dt_imgid_t imgid,
 
       dt_print(DT_DEBUG_PARAMS,
                "[dt_overlay_remove_from_history] "
-               "remove overlay %d from imgid %d\n",
+               "remove overlay %d from imgid %d",
                *overlay_id, imgid);
     }
   }

--- a/src/common/printing.c
+++ b/src/common/printing.c
@@ -127,9 +127,9 @@ void dt_printing_setup_display(dt_images_box *imgs,
   imgs->screen.print_area.width  = awidth;
   imgs->screen.print_area.height = aheight;
 
-  dt_print(DT_DEBUG_PRINT, "[printing] screen/page  (%3.1f, %3.1f) -> (%3.1f, %3.1f)\n",
+  dt_print(DT_DEBUG_PRINT, "[printing] screen/page  (%3.1f, %3.1f) -> (%3.1f, %3.1f)",
            px, py, pwidth, pheight);
-  dt_print(DT_DEBUG_PRINT, "[printing] screen/parea (%3.1f, %3.1f) -> (%3.1f, %3.1f)\n",
+  dt_print(DT_DEBUG_PRINT, "[printing] screen/parea (%3.1f, %3.1f) -> (%3.1f, %3.1f)",
            ax, ay, awidth, aheight);
 
   imgs->screen.borderless = borderless;

--- a/src/common/printprof.c
+++ b/src/common/printprof.c
@@ -61,7 +61,7 @@ int dt_apply_printer_profile(void **in, uint32_t width, uint32_t height, int bpp
 
   if(!hTransform)
   {
-    dt_print(DT_DEBUG_ALWAYS, "error printer profile may be corrupted\n");
+    dt_print(DT_DEBUG_ALWAYS, "error printer profile may be corrupted");
     return 1;
   }
 

--- a/src/common/profiling.c
+++ b/src/common/profiling.c
@@ -33,7 +33,7 @@ void dt_timer_stop_with_name(dt_timer_t *t)
   g_assert(t != NULL);
   g_timer_stop(t->timer);
   gulong ms = 0;
-  dt_print(DT_DEBUG_PERF, "Timer %s in function %s took %.3f seconds to execute.\n", t->description, t->function,
+  dt_print(DT_DEBUG_PERF, "Timer %s in function %s took %.3f seconds to execute", t->description, t->function,
           g_timer_elapsed(t->timer, &ms));
   g_timer_destroy(t->timer);
   g_free(t);

--- a/src/common/pwstorage/backend_apple_keychain.c
+++ b/src/common/pwstorage/backend_apple_keychain.c
@@ -62,7 +62,7 @@ gboolean dt_pwstorage_apple_keychain_set(const backend_apple_keychain_context_t 
 
   while(g_hash_table_iter_next(&iter, &key, &value))
   {
-    dt_print(DT_DEBUG_PWSTORAGE, "[pwstorage_apple_keychain_set] storing (%s, %s)\n", (gchar *) key, (gchar *) value);
+    dt_print(DT_DEBUG_PWSTORAGE, "[pwstorage_apple_keychain_set] storing (%s, %s)", (gchar *) key, (gchar *) value);
 
     gchar *lbl = g_strconcat("darktable - ", slot, NULL);
     const CFStringRef label = CFStringCreateWithCString(NULL, lbl, kCFStringEncodingUTF8);
@@ -74,7 +74,7 @@ gboolean dt_pwstorage_apple_keychain_set(const backend_apple_keychain_context_t 
 
     if(json_parser_load_from_data(json_parser, value, -1, NULL) == FALSE)
     {
-      dt_print(DT_DEBUG_PWSTORAGE, "[pwstorage_apple_keychain_set] unable to parse JSON from value (%s)\n", (gchar *) value);
+      dt_print(DT_DEBUG_PWSTORAGE, "[pwstorage_apple_keychain_set] unable to parse JSON from value (%s)", (gchar *) value);
       g_object_unref(json_parser);
       return FALSE;
     }
@@ -231,7 +231,7 @@ GHashTable *dt_pwstorage_apple_keychain_get(const backend_apple_keychain_context
         g_object_unref(json_generator);
         g_object_unref(json_builder);
 
-        dt_print(DT_DEBUG_PWSTORAGE, "[pwstorage_apple_keychain_get] reading (%s, %s)\n", server, json_data);
+        dt_print(DT_DEBUG_PWSTORAGE, "[pwstorage_apple_keychain_get] reading (%s, %s)", server, json_data);
 
         g_hash_table_insert(table, g_strdup(server), g_strdup(json_data));
 

--- a/src/common/pwstorage/backend_kwallet.c
+++ b/src/common/pwstorage/backend_kwallet.c
@@ -86,7 +86,7 @@ static gchar *char2qstring(const gchar *in, gsize *size)
 
   if(error)
   {
-    dt_print(DT_DEBUG_PWSTORAGE, "[pwstorage_kwallet] ERROR: error converting string: %s\n", error->message);
+    dt_print(DT_DEBUG_PWSTORAGE, "[pwstorage_kwallet] ERROR: error converting string: %s", error->message);
     g_free(out);
     g_error_free(error);
     return NULL;
@@ -115,7 +115,7 @@ static gboolean check_error(GError *error)
 {
   if(error)
   {
-    dt_print(DT_DEBUG_PWSTORAGE, "[pwstorage_kwallet] ERROR: failed to complete kwallet call: %s\n",
+    dt_print(DT_DEBUG_PWSTORAGE, "[pwstorage_kwallet] ERROR: failed to complete kwallet call: %s",
              error->message);
     g_error_free(error);
     return TRUE;
@@ -161,7 +161,7 @@ static gboolean start_kwallet(backend_kwallet_context_t *context)
 
   if(error_string && error_string[0] != '\0')
   {
-    dt_print(DT_DEBUG_PWSTORAGE, "[pwstorage_kwallet] ERROR: error launching kwalletd: %s\n", error_string);
+    dt_print(DT_DEBUG_PWSTORAGE, "[pwstorage_kwallet] ERROR: error launching kwalletd: %s", error_string);
     g_free(error_string);
     return FALSE;
   }
@@ -369,7 +369,7 @@ gboolean dt_pwstorage_kwallet_set(const backend_kwallet_context_t *context, cons
 
   while(g_hash_table_iter_next(&iter, &key, &value))
   {
-    dt_print(DT_DEBUG_PWSTORAGE, "[pwstorage_kwallet_set] storing (%s, %s)\n", (gchar *)key, (gchar *)value);
+    dt_print(DT_DEBUG_PWSTORAGE, "[pwstorage_kwallet_set] storing (%s, %s)", (gchar *)key, (gchar *)value);
     gsize length;
     gchar *new_key = char2qstring(key, &length);
     if(new_key == NULL)
@@ -425,7 +425,7 @@ gboolean dt_pwstorage_kwallet_set(const backend_kwallet_context_t *context, cons
   g_variant_unref(ret);
 
   if(return_code != 0)
-    dt_print(DT_DEBUG_PWSTORAGE, "[pwstorage_kwallet_set] Warning: bad return code %d from kwallet\n",
+    dt_print(DT_DEBUG_PWSTORAGE, "[pwstorage_kwallet_set] Warning: bad return code %d from kwallet",
              return_code);
 
   return return_code == 0;
@@ -454,7 +454,7 @@ static gchar *array2string(const gchar *pos, guint *length)
 
   if(error)
   {
-    dt_print(DT_DEBUG_PWSTORAGE, "[pwstorage_kwallet] ERROR: Error converting string: %s\n", error->message);
+    dt_print(DT_DEBUG_PWSTORAGE, "[pwstorage_kwallet] ERROR: Error converting string: %s", error->message);
     g_error_free(error);
     return NULL;
   }
@@ -556,7 +556,7 @@ GHashTable *dt_pwstorage_kwallet_get(const backend_kwallet_context_t *context, c
 
     byte_array += length;
 
-    dt_print(DT_DEBUG_PWSTORAGE, "[pwstorage_kwallet_get] reading (%s, %s)\n", (gchar *)key, (gchar *)value);
+    dt_print(DT_DEBUG_PWSTORAGE, "[pwstorage_kwallet_get] reading (%s, %s)", (gchar *)key, (gchar *)value);
 
     g_hash_table_insert(table, key, value);
   }

--- a/src/common/pwstorage/backend_libsecret.c
+++ b/src/common/pwstorage/backend_libsecret.c
@@ -66,7 +66,7 @@ const backend_libsecret_context_t *dt_pwstorage_libsecret_new()
   SecretService *secret_service = secret_service_get_sync(SECRET_SERVICE_LOAD_COLLECTIONS, NULL, &error);
   if(error)
   {
-    dt_print(DT_DEBUG_ALWAYS, "[pwstorage_libsecret] error connecting to Secret Service: %s\n", error->message);
+    dt_print(DT_DEBUG_ALWAYS, "[pwstorage_libsecret] error connecting to Secret Service: %s", error->message);
     g_error_free(error);
     if(secret_service) g_object_unref(secret_service);
     dt_pwstorage_libsecret_destroy(context);
@@ -118,7 +118,7 @@ gboolean dt_pwstorage_libsecret_set(const backend_libsecret_context_t *context, 
                                             NULL);
   if(!res)
   {
-    dt_print(DT_DEBUG_ALWAYS, "[pwstorage_libsecret] error storing password: %s\n", error->message);
+    dt_print(DT_DEBUG_ALWAYS, "[pwstorage_libsecret] error storing password: %s", error->message);
     g_error_free(error);
   }
 
@@ -147,7 +147,7 @@ GHashTable *dt_pwstorage_libsecret_get(const backend_libsecret_context_t *contex
                                              NULL);
   if(error)
   {
-    dt_print(DT_DEBUG_ALWAYS, "[pwstorage_libsecret] error retrieving password: %s\n", error->message);
+    dt_print(DT_DEBUG_ALWAYS, "[pwstorage_libsecret] error retrieving password: %s", error->message);
     g_error_free(error);
     goto error;
   }

--- a/src/common/pwstorage/backend_windows_credentials.c
+++ b/src/common/pwstorage/backend_windows_credentials.c
@@ -35,7 +35,7 @@ static void _logError(const char *action)
                  NULL);
 
   dt_print(DT_DEBUG_PWSTORAGE,
-           "[%s] ERROR: failed to complete windows_credential call: %s\n",
+           "[%s] ERROR: failed to complete windows_credential call: %s",
            action,
            message);
 
@@ -65,7 +65,7 @@ gboolean dt_pwstorage_windows_credentials_set(const backend_windows_credentials_
   while(g_hash_table_iter_next(&iter, &key, &value))
   {
     dt_print(DT_DEBUG_PWSTORAGE,
-             "[pwstorage_windows_credentials_set] storing (%s, %s)\n",
+             "[pwstorage_windows_credentials_set] storing (%s, %s)",
              (gchar *)key,
              (gchar *)value);
 
@@ -76,7 +76,7 @@ gboolean dt_pwstorage_windows_credentials_set(const backend_windows_credentials_
     if(json_parser_load_from_data(json_parser, value, -1, NULL) == FALSE)
     {
       dt_print(DT_DEBUG_PWSTORAGE,
-               "[pwstorage_windows_credentials_set] unable to parse JSON from value (%s)\n",
+               "[pwstorage_windows_credentials_set] unable to parse JSON from value (%s)",
                (gchar *)value);
                
       g_object_unref(json_parser);
@@ -182,7 +182,7 @@ GHashTable *dt_pwstorage_windows_credentials_get(const backend_windows_credentia
       g_object_unref(json_builder);
 
       dt_print(DT_DEBUG_PWSTORAGE,
-               "[pwstorage_windows_credentials_get] reading (%s, %s)\n",
+               "[pwstorage_windows_credentials_get] reading (%s, %s)",
                (gchar *)pcred->Comment,
                json_data);
 

--- a/src/common/pwstorage/pwstorage.c
+++ b/src/common/pwstorage/pwstorage.c
@@ -62,7 +62,7 @@ const dt_pwstorage_t *dt_pwstorage_new()
 #endif
 
   dt_pwstorage_t *pwstorage = g_malloc(sizeof(dt_pwstorage_t));
-  dt_print(DT_DEBUG_PWSTORAGE, "[pwstorage_new] Creating new context %p\n", pwstorage);
+  dt_print(DT_DEBUG_PWSTORAGE, "[pwstorage_new] Creating new context %p", pwstorage);
 
   if(pwstorage == NULL) return NULL;
 
@@ -87,7 +87,7 @@ const dt_pwstorage_t *dt_pwstorage_new()
         _backend = PW_STORAGE_BACKEND_LIBSECRET;
     #endif
 
-    dt_print(DT_DEBUG_PWSTORAGE, "[pwstorage_new] autodetected storage backend.\n");
+    dt_print(DT_DEBUG_PWSTORAGE, "[pwstorage_new] autodetected storage backend.");
   }
   else if(strcmp(_backend_str, "none") == 0)
     _backend = PW_STORAGE_BACKEND_NONE;
@@ -109,7 +109,7 @@ const dt_pwstorage_t *dt_pwstorage_new()
 #endif
   else if(strcmp(_backend_str, "gnome keyring") == 0)
   {
-    dt_print(DT_DEBUG_ALWAYS, "[pwstorage_new] GNOME Keyring backend is no longer supported.\n");
+    dt_print(DT_DEBUG_ALWAYS, "[pwstorage_new] GNOME Keyring backend is no longer supported.");
     dt_control_log(_("GNOME Keyring backend is no longer supported. configure a different one"));
     _backend = PW_STORAGE_BACKEND_NONE;
   }
@@ -117,7 +117,7 @@ const dt_pwstorage_t *dt_pwstorage_new()
   switch(_backend)
   {
     default:
-      dt_print(DT_DEBUG_PWSTORAGE, "[pwstorage_new] unknown storage backend. Using none.\n");
+      dt_print(DT_DEBUG_PWSTORAGE, "[pwstorage_new] unknown storage backend. Using none.");
     case PW_STORAGE_BACKEND_NONE:
       pwstorage->pw_storage_backend = PW_STORAGE_BACKEND_NONE;
       pwstorage->backend_context = NULL;
@@ -126,11 +126,11 @@ const dt_pwstorage_t *dt_pwstorage_new()
       break;
     case PW_STORAGE_BACKEND_LIBSECRET:
 #ifdef HAVE_LIBSECRET
-      dt_print(DT_DEBUG_PWSTORAGE, "[pwstorage_new] using libsecret backend for username/password storage.\n");
+      dt_print(DT_DEBUG_PWSTORAGE, "[pwstorage_new] using libsecret backend for username/password storage.");
       pwstorage->backend_context = (void *)dt_pwstorage_libsecret_new();
       if(pwstorage->backend_context == NULL)
       {
-        dt_print(DT_DEBUG_PWSTORAGE, "[pwstorage_new] error starting libsecret. using no storage backend.\n");
+        dt_print(DT_DEBUG_PWSTORAGE, "[pwstorage_new] error starting libsecret. using no storage backend.");
         pwstorage->backend_context = NULL;
         pwstorage->pw_storage_backend = PW_STORAGE_BACKEND_NONE;
       }
@@ -141,17 +141,17 @@ const dt_pwstorage_t *dt_pwstorage_new()
       break;
 #else
       dt_print(DT_DEBUG_PWSTORAGE,
-               "[pwstorage_new] libsecret backend not available. using no storage backend.\n");
+               "[pwstorage_new] libsecret backend not available. using no storage backend.");
       pwstorage->backend_context = NULL;
       pwstorage->pw_storage_backend = PW_STORAGE_BACKEND_NONE;
 #endif
     case PW_STORAGE_BACKEND_KWALLET:
 #ifdef HAVE_KWALLET
-      dt_print(DT_DEBUG_PWSTORAGE, "[pwstorage_new] using kwallet backend for username/password storage.\n");
+      dt_print(DT_DEBUG_PWSTORAGE, "[pwstorage_new] using kwallet backend for username/password storage.");
       pwstorage->backend_context = (void *)dt_pwstorage_kwallet_new();
       if(pwstorage->backend_context == NULL)
       {
-        dt_print(DT_DEBUG_PWSTORAGE, "[pwstorage_new] error starting kwallet. using no storage backend.\n");
+        dt_print(DT_DEBUG_PWSTORAGE, "[pwstorage_new] error starting kwallet. using no storage backend.");
         pwstorage->backend_context = NULL;
         pwstorage->pw_storage_backend = PW_STORAGE_BACKEND_NONE;
       }
@@ -159,34 +159,34 @@ const dt_pwstorage_t *dt_pwstorage_new()
       {
         pwstorage->pw_storage_backend = PW_STORAGE_BACKEND_KWALLET;
       }
-      dt_print(DT_DEBUG_PWSTORAGE, "  done.\n");
+      dt_print(DT_DEBUG_PWSTORAGE, "  done.");
       break;
 #else
       dt_print(DT_DEBUG_PWSTORAGE,
-               "[pwstorage_new] kwallet backend not available. using no storage backend.\n");
+               "[pwstorage_new] kwallet backend not available. using no storage backend.");
       pwstorage->backend_context = NULL;
       pwstorage->pw_storage_backend = PW_STORAGE_BACKEND_NONE;
 #endif
     case PW_STORAGE_BACKEND_APPLE_KEYCHAIN:
 #ifdef HAVE_APPLE_KEYCHAIN
-      dt_print(DT_DEBUG_PWSTORAGE, "[pwstorage_new] using apple keychain backend for username/password storage.\n");
+      dt_print(DT_DEBUG_PWSTORAGE, "[pwstorage_new] using apple keychain backend for username/password storage.");
       pwstorage->backend_context = (void *)dt_pwstorage_apple_keychain_new();
       pwstorage->pw_storage_backend = PW_STORAGE_BACKEND_APPLE_KEYCHAIN;
 #else
       dt_print(DT_DEBUG_PWSTORAGE,
-               "[pwstorage_new] apple keychain backend not available. using no storage backend.\n");
+               "[pwstorage_new] apple keychain backend not available. using no storage backend.");
       pwstorage->backend_context = NULL;
       pwstorage->pw_storage_backend = PW_STORAGE_BACKEND_NONE;
 #endif
       break;
     case PW_STORAGE_BACKEND_WINDOWS_CREDENTIALS:
 #ifdef HAVE_WINDOWS_CREDENTIALS
-      dt_print(DT_DEBUG_PWSTORAGE, "[pwstorage_new] using windows credentials backend for username/password storage.\n");
+      dt_print(DT_DEBUG_PWSTORAGE, "[pwstorage_new] using windows credentials backend for username/password storage.");
       pwstorage->backend_context = (void *)dt_pwstorage_windows_credentials_new();
       pwstorage->pw_storage_backend = PW_STORAGE_BACKEND_WINDOWS_CREDENTIALS;
 #else
       dt_print(DT_DEBUG_PWSTORAGE,
-               "[pwstorage_new] windows credentials backend not available. using no storage backend.\n");
+               "[pwstorage_new] windows credentials backend not available. using no storage backend.");
       pwstorage->backend_context = NULL;
       pwstorage->pw_storage_backend = PW_STORAGE_BACKEND_NONE;
 #endif
@@ -218,7 +218,7 @@ const dt_pwstorage_t *dt_pwstorage_new()
 /** Cleanup and destroy pwstorage context. \remarks After this point pointer at pwstorage is invalid. */
 void dt_pwstorage_destroy(const dt_pwstorage_t *pwstorage)
 {
-  dt_print(DT_DEBUG_PWSTORAGE, "[pwstorage_new] Destroying context %p\n", pwstorage);
+  dt_print(DT_DEBUG_PWSTORAGE, "[pwstorage_new] Destroying context %p", pwstorage);
   switch(darktable.pwstorage->pw_storage_backend)
   {
     case PW_STORAGE_BACKEND_NONE:
@@ -253,7 +253,7 @@ gboolean dt_pwstorage_set(const gchar *slot, GHashTable *table)
   switch(darktable.pwstorage->pw_storage_backend)
   {
     case PW_STORAGE_BACKEND_NONE:
-      dt_print(DT_DEBUG_PWSTORAGE, "[pwstorage_set] no backend. not storing anything.\n");
+      dt_print(DT_DEBUG_PWSTORAGE, "[pwstorage_set] no backend. not storing anything.");
       break;
     case PW_STORAGE_BACKEND_LIBSECRET:
 #if HAVE_LIBSECRET
@@ -289,7 +289,7 @@ GHashTable *dt_pwstorage_get(const gchar *slot)
   switch(darktable.pwstorage->pw_storage_backend)
   {
     case PW_STORAGE_BACKEND_NONE:
-      dt_print(DT_DEBUG_PWSTORAGE, "[pwstorage_get] no backend. not reading anything.\n");
+      dt_print(DT_DEBUG_PWSTORAGE, "[pwstorage_get] no backend. not reading anything.");
       break;
     case PW_STORAGE_BACKEND_LIBSECRET:
 #if HAVE_LIBSECRET

--- a/src/common/ratings.c
+++ b/src/common/ratings.c
@@ -263,7 +263,7 @@ static float _action_process_rating(gpointer target,
         break;
       default:
         dt_print(DT_DEBUG_ALWAYS,
-                 "[_action_process_rating] unknown shortcut effect (%d) for rating\n", effect);
+                 "[_action_process_rating] unknown shortcut effect (%d) for rating", effect);
         break;
       }
     }

--- a/src/common/selection.c
+++ b/src/common/selection.c
@@ -480,7 +480,7 @@ void dt_selection_select_list(struct dt_selection_t *selection, GList *list)
       imgid = GPOINTER_TO_INT(list->data);
       count++;
       selection->last_single_id = imgid;
-      query = dt_util_dstrcat(query, ",(%d)", imgid);
+      dt_util_str_cat(&query, ",(%d)", imgid);
       list = g_list_next(list);
     }
     DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), query, NULL, NULL, NULL);

--- a/src/common/styles.c
+++ b/src/common/styles.c
@@ -678,7 +678,7 @@ void dt_styles_apply_style_item(dt_develop_t *dev,
     {
       module = NULL;
       dt_print(DT_DEBUG_ALWAYS,
-               "[dt_styles_apply_style_item] can't load module %s %s\n",
+               "[dt_styles_apply_style_item] can't load module %s %s",
                style_item->operation,
                style_item->multi_name);
     }
@@ -734,7 +734,7 @@ void dt_styles_apply_style_item(dt_develop_t *dev,
         {
           dt_print(DT_DEBUG_ALWAYS,
                    "[dt_styles_apply_style_item] module `%s' version mismatch:"
-                   " history is %d, darktable is %d.\n",
+                   " history is %d, darktable is %d",
                    module->op, style_item->module_version, module->version());
           dt_control_log(_("module `%s' version mismatch: %d != %d"), module->op,
                          module->version(), style_item->module_version);
@@ -1209,7 +1209,7 @@ char *dt_styles_get_item_list_as_string(const char *name)
   }
   names = g_list_reverse(names);  // list was built in reverse order, so un-reverse it
 
-  char *result = dt_util_glist_to_str("\n", names);
+  char *result = dt_util_glist_to_str("", names);
   g_list_free_full(names, g_free);
   g_list_free_full(items, dt_style_item_free);
   return result;
@@ -1744,7 +1744,7 @@ gchar *dt_get_style_name(const char *filename)
   if(document == NULL || root == NULL || xmlStrcmp(root->name, BAD_CAST "darktable_style"))
   {
     dt_print(DT_DEBUG_CONTROL,
-             "[styles] file %s is not a style file\n", filename);
+             "[styles] file %s is not a style file", filename);
     if(document)
       xmlFreeDoc(document);
     return bname;
@@ -1769,7 +1769,7 @@ gchar *dt_get_style_name(const char *filename)
 
   if(!bname){
     dt_print(DT_DEBUG_CONTROL,
-             "[styles] file %s is a malformed style file\n", filename);
+             "[styles] file %s is a malformed style file", filename);
   }
   return bname;
 }
@@ -1800,7 +1800,7 @@ void dt_import_default_styles(const char *folder)
     {
       if(darktable.gui)
         dt_print(DT_DEBUG_ALWAYS,
-                 "[styles] importing default style '%s'\n", filename);
+                 "[styles] importing default style '%s'", filename);
       dt_styles_import_from_file(filename);
     }
     g_free(bname);

--- a/src/common/system_signal_handling.c
+++ b/src/common/system_signal_handling.c
@@ -227,7 +227,7 @@ void dt_set_signal_handlers()
   {
     const int errsv = errno;
     dt_print(DT_DEBUG_ALWAYS,
-             "[dt_set_signal_handlers] error: signal(SIGSEGV) returned SIG_ERR: %i (%s)\n",
+             "[dt_set_signal_handlers] error: signal(SIGSEGV) returned SIG_ERR: %i (%s)",
              errsv,
              strerror(errsv));
   }

--- a/src/common/tags.c
+++ b/src/common/tags.c
@@ -45,7 +45,7 @@ static gchar *_get_tb_removed_tag_string_values(GList *before,
   {
     if(!g_list_find(a, b->data))
     {
-      tag_list = dt_util_dstrcat(tag_list, "%d,", GPOINTER_TO_INT(b->data));
+      dt_util_str_cat(&tag_list, "%d,", GPOINTER_TO_INT(b->data));
     }
   }
   if(tag_list) tag_list[strlen(tag_list) - 1] = '\0';
@@ -63,8 +63,8 @@ static gchar *_get_tb_added_tag_string_values(const dt_imgid_t img,
     if(!g_list_find(b, a->data))
     {
       // clang-format off
-      tag_list = dt_util_dstrcat
-        (tag_list,
+      dt_util_str_cat
+        (&tag_list,
          "(%d,%d,"
          "  (SELECT (IFNULL(MAX(position),0) & 0xFFFFFFFF00000000) + (1 << 32)"
          "    FROM main.tagged_images)"
@@ -297,7 +297,7 @@ guint dt_tag_remove_list(GList *tag_list)
   for(GList *taglist = tag_list; taglist ; taglist = g_list_next(taglist))
   {
     const guint tagid = ((dt_tag_t *)taglist->data)->id;
-    flatlist = dt_util_dstrcat(flatlist, "%u,", tagid);
+    dt_util_str_cat(&flatlist, "%u,", tagid);
     count++;
     if(flatlist && count > 1000)
     {
@@ -1161,7 +1161,7 @@ GList *dt_tag_get_images_from_list(const GList *img, const gint tagid)
   char *images = NULL;
   for(GList *imgs = (GList *)img; imgs; imgs = g_list_next(imgs))
   {
-    images = dt_util_dstrcat(images, "%d,",GPOINTER_TO_INT(imgs->data));
+    dt_util_str_cat(&images, "%d,",GPOINTER_TO_INT(imgs->data));
   }
   if(images)
   {
@@ -1528,7 +1528,7 @@ static gchar *dt_cleanup_synonyms(gchar *synonyms_entry)
       char *e = g_strstrip(*entry);
       if(*e)
       {
-        synonyms = dt_util_dstrcat(synonyms, "%s, ", e);
+        dt_util_str_cat(&synonyms, "%s, ", e);
       }
       entry++;
     }
@@ -1612,7 +1612,7 @@ void dt_tag_add_synonym(const gint tagid,
   char *synonyms = dt_tag_get_synonyms(tagid);
   if(synonyms)
   {
-    synonyms = dt_util_dstrcat(synonyms, ", %s", synonym);
+    dt_util_str_cat(&synonyms, ", %s", synonym);
   }
   else
   {
@@ -1912,7 +1912,7 @@ char *dt_tag_get_subtags(const dt_imgid_t imgid,
           valid = FALSE;
       }
       if(valid)
-        tags = dt_util_dstrcat(tags, "%s,", subtag);
+        dt_util_str_cat(&tags, "%s,", subtag);
       g_strfreev(pch);
     }
   }

--- a/src/common/undo.c
+++ b/src/common/undo.c
@@ -57,7 +57,7 @@ dt_undo_t *dt_undo_init(void)
 
   udata->group = DT_UNDO_NONE;
   udata->group_indent = 0;
-  dt_print(DT_DEBUG_UNDO, "[undo] init\n");
+  dt_print(DT_DEBUG_UNDO, "[undo] init");
   return udata;
 }
 
@@ -67,7 +67,7 @@ dt_undo_t *dt_undo_init(void)
 void dt_undo_disable_next(dt_undo_t *self)
 {
   self->disable_next = TRUE;
-  dt_print(DT_DEBUG_UNDO, "[undo] disable next\n");
+  dt_print(DT_DEBUG_UNDO, "[undo] disable next");
 }
 
 void dt_undo_cleanup(dt_undo_t *self)
@@ -123,7 +123,7 @@ static void _undo_record(dt_undo_t *self,
     g_list_free_full(self->redo_list, _free_undo_data);
     self->redo_list = NULL;
 
-    dt_print(DT_DEBUG_UNDO, "[undo] record for type %d (length %d)%s\n",
+    dt_print(DT_DEBUG_UNDO, "[undo] record for type %d (length %d)%s",
              type, g_list_length(self->undo_list),
              disable_next ? ", disable next": "");
   }
@@ -139,7 +139,7 @@ void dt_undo_start_group(dt_undo_t *self,
   LOCK;
   if(self->group == DT_UNDO_NONE)
   {
-    dt_print(DT_DEBUG_UNDO, "[undo] start group for type %d\n", type);
+    dt_print(DT_DEBUG_UNDO, "[undo] start group for type %d", type);
     self->group = type;
     self->group_indent = 1;
     _undo_record(self, NULL, type, NULL, TRUE, NULL, NULL);
@@ -158,7 +158,7 @@ void dt_undo_end_group(dt_undo_t *self)
   if(self->group_indent == 0)
   {
     _undo_record(self, NULL, self->group, NULL, TRUE, NULL, NULL);
-    dt_print(DT_DEBUG_UNDO, "[undo] end group for type %d\n", self->group);
+    dt_print(DT_DEBUG_UNDO, "[undo] end group for type %d", self->group);
     self->group = DT_UNDO_NONE;
   }
   UNLOCK;
@@ -200,7 +200,7 @@ static void _undo_do_undo_redo(dt_undo_t *self,
   // check for first item that is matching the given pattern
 
   dt_print(DT_DEBUG_UNDO,
-           "[undo] action %s for %d (from length %d -> to length %d)\n",
+           "[undo] action %s for %d (from length %d -> to length %d)",
            action == DT_ACTION_UNDO ? "UNDO" : "DO",
            filter,
            g_list_length(*from),
@@ -325,7 +325,7 @@ static void _undo_clear_list(GList **list, const uint32_t filter)
     }
   };
 
-  dt_print(DT_DEBUG_UNDO, "[undo] clear list for %d (length %d)\n",
+  dt_print(DT_DEBUG_UNDO, "[undo] clear list for %d (length %d)",
            filter, g_list_length(*list));
 }
 

--- a/src/common/utility.c
+++ b/src/common/utility.c
@@ -89,28 +89,26 @@ gchar *dt_util_localize_segmented_name(const char *s)
   return localized;
 }
 
-gchar *dt_util_dstrcat(gchar *str, const gchar *format, ...)
+void dt_util_str_cat(gchar **str, const gchar *format, ...)
 {
+  if(!str) return;
+
   va_list args;
-  gchar *ns;
   va_start(args, format);
-  const size_t clen = str ? strlen(str) : 0;
+  const size_t clen = *str ? strlen(*str) : 0;
   const int alen = g_vsnprintf(NULL, 0, format, args);
+  va_end(args);
   const int nsize = alen + clen + 1;
 
   /* realloc for new string */
-  ns = g_realloc(str, nsize);
-  if(str == NULL) ns[0] = '\0';
-  va_end(args);
+  *str = g_realloc(*str, nsize);
 
   /* append string */
   va_start(args, format);
-  g_vsnprintf(ns + clen, alen + 1, format, args);
+  g_vsnprintf(*str + clen, alen + 1, format, args);
   va_end(args);
 
-  ns[nsize - 1] = '\0';
-
-  return ns;
+  (*str)[nsize - 1] = '\0';
 }
 
 guint dt_util_str_occurence(const gchar *haystack, const gchar *needle)

--- a/src/common/utility.c
+++ b/src/common/utility.c
@@ -499,7 +499,7 @@ static cairo_surface_t *_util_get_svg_img(gchar *logo, const float size)
                                                        final_height, stride);
     if(cairo_surface_status(surface) != CAIRO_STATUS_SUCCESS)
     {
-      dt_print(DT_DEBUG_ALWAYS, "warning: can't load darktable logo from SVG file `%s'\n", dtlogo);
+      dt_print(DT_DEBUG_ALWAYS, "warning: can't load darktable logo from SVG file `%s'", dtlogo);
       cairo_surface_destroy(surface);
       free(image_buffer);
       image_buffer = NULL;
@@ -518,7 +518,7 @@ static cairo_surface_t *_util_get_svg_img(gchar *logo, const float size)
   else
   {
     dt_print(DT_DEBUG_ALWAYS,
-             "warning: can't load darktable logo from SVG file `%s'\n%s\n", dtlogo, error->message);
+             "warning: can't load darktable logo from SVG file `%s'\n%s", dtlogo, error->message);
     g_error_free(error);
   }
 

--- a/src/common/utility.h
+++ b/src/common/utility.h
@@ -33,7 +33,7 @@ const char *dt_util_localize_string(const char *s);
 gchar *dt_util_localize_segmented_name(const char *s);
 
 /** dynamically allocate and concatenate string */
-gchar *dt_util_dstrcat(gchar *str, const gchar *format, ...) __attribute__((format(printf, 2, 3)));
+void dt_util_str_cat(gchar **str, const gchar *format, ...) __attribute__((format(printf, 2, 3)));
 
 /** replace all occurrences of pattern by substitute. the returned value has to be freed after use. */
 gchar *dt_util_str_replace(const gchar *string, const gchar *pattern, const gchar *substitute);

--- a/src/common/variables.c
+++ b/src/common/variables.c
@@ -790,8 +790,8 @@ static char *_get_base_value(dt_variables_params_t *params, char **variable)
     {
       const int dot_index = GPOINTER_TO_INT(res_iter->data);
       const GdkRGBA c = darktable.bauhaus->colorlabels[dot_index];
-      result = dt_util_dstrcat
-        (result,
+      dt_util_str_cat
+        (&result,
          "<span foreground='#%02x%02x%02x'>⬤ </span>",
          (guint)(c.red*255), (guint)(c.green*255), (guint)(c.blue*255));
     }

--- a/src/common/wb_presets.c
+++ b/src/common/wb_presets.c
@@ -100,9 +100,7 @@ int wb_presets_size = 10000;
 int wb_presets_count = 0;
 
 #define _ERROR(...)     {\
-                          dt_print(DT_DEBUG_CONTROL, "[wb_presets] error: " );\
-                          dt_print(DT_DEBUG_CONTROL, __VA_ARGS__);\
-                          dt_print(DT_DEBUG_CONTROL, "\n");\
+                          dt_print(DT_DEBUG_CONTROL, "[wb_presets] error: " __VA_ARGS__);\
                           valid = FALSE; \
                           goto end;\
                         }
@@ -127,7 +125,7 @@ void dt_wb_presets_init(const char *alternative)
   if(!wb_presets)
   {
     wb_presets_size = 0;
-    dt_print(DT_DEBUG_ALWAYS, "[wb_presets] out of memory while initializing\n");
+    dt_print(DT_DEBUG_ALWAYS, "[wb_presets] out of memory while initializing");
     return;
   }
 
@@ -146,14 +144,14 @@ void dt_wb_presets_init(const char *alternative)
   else
     g_strlcpy(filename, alternative, sizeof(filename));
 
-  dt_print(DT_DEBUG_CONTROL, "[wb_presets] loading wb_presets from `%s'\n", filename);
+  dt_print(DT_DEBUG_CONTROL, "[wb_presets] loading wb_presets from `%s'", filename);
   if(!g_file_test(filename, G_FILE_TEST_EXISTS)) return;
 
   JsonParser *parser = json_parser_new();
   if(!json_parser_load_from_file(parser, filename, &error))
   {
     dt_print(DT_DEBUG_ALWAYS,
-             "[wb_presets] error: parsing json from `%s' failed\n%s\n", filename, error->message);
+             "[wb_presets] error: parsing json from `%s' failed\n%s", filename, error->message);
     g_error_free(error);
     g_object_unref(parser);
     return;
@@ -164,7 +162,7 @@ void dt_wb_presets_init(const char *alternative)
   JsonReader *reader = NULL;
   gboolean valid = TRUE;
 
-  dt_print(DT_DEBUG_CONTROL, "[wb_presets] loading noiseprofile file\n");
+  dt_print(DT_DEBUG_CONTROL, "[wb_presets] loading noiseprofile file");
 
   JsonNode *root = json_parser_get_root(parser);
   if(!root) _ERROR("can't get the root node");
@@ -188,7 +186,7 @@ void dt_wb_presets_init(const char *alternative)
     _ERROR("`wb_presets' is supposed to be an array");
 
   const int n_makers = json_reader_count_elements(reader);
-  dt_print(DT_DEBUG_CONTROL, "[wb_presets] found %d makers\n", n_makers);
+  dt_print(DT_DEBUG_CONTROL, "[wb_presets] found %d makers", n_makers);
 
   for(int i = 0; i < n_makers; i++)
   {
@@ -204,7 +202,7 @@ void dt_wb_presets_init(const char *alternative)
       g_strdup(json_reader_get_string_value(reader));
     json_reader_end_member(reader);
 
-    dt_print(DT_DEBUG_CONTROL, "[wb_presets] found maker `%s'\n",
+    dt_print(DT_DEBUG_CONTROL, "[wb_presets] found maker `%s'",
              wb_presets[wb_presets_count].make);
     // go through all models and check those
 
@@ -212,7 +210,7 @@ void dt_wb_presets_init(const char *alternative)
       _ERROR("missing `models`");
 
     const int n_models = json_reader_count_elements(reader);
-    dt_print(DT_DEBUG_CONTROL, "[wb_presets] found %d models\n", n_models);
+    dt_print(DT_DEBUG_CONTROL, "[wb_presets] found %d models", n_models);
 
     for(int j = 0; j < n_models; j++)
     {
@@ -229,14 +227,14 @@ void dt_wb_presets_init(const char *alternative)
 
       json_reader_end_member(reader);
 
-      dt_print(DT_DEBUG_CONTROL, "[wb_presets] found %s\n",
+      dt_print(DT_DEBUG_CONTROL, "[wb_presets] found %s",
                wb_presets[wb_presets_count].model);
 
       if(!json_reader_read_member(reader, "presets"))
         _ERROR("missing `presets`");
 
       const int n_presets = json_reader_count_elements(reader);
-      dt_print(DT_DEBUG_CONTROL, "[wb_presets] found %d presets\n",
+      dt_print(DT_DEBUG_CONTROL, "[wb_presets] found %d presets",
                n_presets);
 
       for(int k = 0; k < n_presets; k++)
@@ -304,7 +302,7 @@ void dt_wb_presets_init(const char *alternative)
     json_reader_end_element(reader); // makers
   }
 
-  dt_print(DT_DEBUG_CONTROL, "[wb_presets] found %d wb presets\n",
+  dt_print(DT_DEBUG_CONTROL, "[wb_presets] found %d wb presets",
            wb_presets_count);
 
 end:

--- a/src/control/crawler.c
+++ b/src/control/crawler.c
@@ -165,7 +165,7 @@ GList *dt_control_crawler_run(void)
     // if the image is missing we ignore it.
     if(!g_file_test(image_path, G_FILE_TEST_EXISTS))
     {
-      dt_print(DT_DEBUG_CONTROL, "[crawler] `%s' (id: %d) is missing.\n", image_path, id);
+      dt_print(DT_DEBUG_CONTROL, "[crawler] `%s' (id: %d) is missing", image_path, id);
       continue;
     }
 
@@ -217,7 +217,7 @@ GList *dt_control_crawler_run(void)
 
         result = g_list_prepend(result, item);
         dt_print(DT_DEBUG_CONTROL,
-                 "[crawler] `%s' (id: %d) is a newer XMP file.\n", xmp_path, id);
+                 "[crawler] `%s' (id: %d) is a newer XMP file", xmp_path, id);
       }
       // older timestamps are the case for all images after the db
       // upgrade. better not report these
@@ -529,7 +529,7 @@ static void sync_newest_to_oldest(GtkTreeModel *model,
     error = dt_image_write_sidecar_file(entry.id);
     _set_modification_time(entry.xmp_path, entry.timestamp_db);
 
-    dt_print(DT_DEBUG_ALWAYS, "%s synced DB (new) → XMP (old)\n", entry.image_path);
+    dt_print(DT_DEBUG_ALWAYS, "%s synced DB (new) → XMP (old)", entry.image_path);
     if(error)
     {
       _log_synchronization
@@ -955,14 +955,14 @@ static int _update_all_thumbs(const dt_mipmap_size_t max_mip)
     else
     {
       missed++;
-      dt_print(DT_DEBUG_CACHE, "[thumb crawler] '%s' ID=%d NOT available\n", path, imgid);
+      dt_print(DT_DEBUG_CACHE, "[thumb crawler] '%s' ID=%d NOT available", path, imgid);
     }
   }
   sqlite3_finalize(stmt);
 
   if(updated)
     dt_print(DT_DEBUG_CACHE,
-      "[thumb crawler] max_mip=%d, %d thumbs updated, %d not found, %s.\n",
+      "[thumb crawler] max_mip=%d, %d thumbs updated, %d not found, %s",
       max_mip, updated, missed,
       _still_thumbing() ? "all done" : "interrupted by user activity");
 
@@ -973,7 +973,7 @@ static void _reinitialize_thumbs_database(void)
 {
   dt_conf_set_bool("backthumbs_initialize", FALSE);
 
-  dt_print(DT_DEBUG_CACHE, "[thumb crawler] initialize database\n");
+  dt_print(DT_DEBUG_CACHE, "[thumb crawler] initialize database");
 
   sqlite3_stmt *stmt;
   DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
@@ -999,7 +999,7 @@ void dt_set_backthumb_time(const double next)
 void dt_update_thumbs_thread(void *p)
 {
   dt_pthread_setname("thumbs_update");
-  dt_print(DT_DEBUG_CACHE, "[thumb crawler] started\n");
+  dt_print(DT_DEBUG_CACHE, "[thumb crawler] started");
   dt_backthumb_t *bt = &darktable.backthumbs;
 
   bt->idle = (double)dt_conf_get_float("backthumbs_inactivity");
@@ -1009,7 +1009,7 @@ void dt_update_thumbs_thread(void *p)
   if(!dwriting || !_valid_mip(bt->mipsize) || !darktable.view_manager)
   {
     bt->running = FALSE;
-    dt_print(DT_DEBUG_CACHE, "[thumb crawler] closing due to preferences setting\n");
+    dt_print(DT_DEBUG_CACHE, "[thumb crawler] closing due to preferences setting");
     return;
   }
   bt->running = TRUE;
@@ -1023,7 +1023,7 @@ void dt_update_thumbs_thread(void *p)
     snprintf(dirname, sizeof(dirname), "%s.d/%d", darktable.mipmap_cache->cachedir, k);
     if(g_mkdir_with_parents(dirname, 0750))
     {
-      dt_print(DT_DEBUG_CACHE, "[thumb crawler] can't create mipmap dir '%s'\n", dirname);
+      dt_print(DT_DEBUG_CACHE, "[thumb crawler] can't create mipmap dir '%s'", dirname);
       return;
     }
   }
@@ -1046,7 +1046,7 @@ void dt_update_thumbs_thread(void *p)
     if(!_valid_mip(bt->mipsize))
       bt->running = FALSE;
   }
-  dt_print(DT_DEBUG_CACHE, "[thumb crawler] closing, %d mipmaps updated\n", updated);
+  dt_print(DT_DEBUG_CACHE, "[thumb crawler] closing, %d mipmaps updated", updated);
 }
 
 // clang-format off

--- a/src/control/jobs.c
+++ b/src/control/jobs.c
@@ -561,7 +561,7 @@ static void *_control_work_res(void *ptr)
   int32_t threadid_res = _control_get_threadid_res();
   while(dt_control_running())
   {
-    // dt_print(DT_DEBUG_CONTROL, "[control_work] %d\n", threadid_res);
+    // dt_print(DT_DEBUG_CONTROL, "[control_work] %d", threadid_res);
     if(_control_run_job_res(s, threadid_res))
     {
       // wait for a new job.
@@ -606,7 +606,7 @@ static void *_control_work(void *ptr)
   // int32_t threadid = dt_control_get_threadid();
   while(dt_control_running())
   {
-    // dt_print(DT_DEBUG_CONTROL, "[control_work] %d\n", threadid);
+    // dt_print(DT_DEBUG_CONTROL, "[control_work] %d", threadid);
     if(_control_run_job(control))
     {
       // wait for a new job.

--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -811,7 +811,7 @@ static int32_t dt_control_monochrome_images_job_run(dt_job_t *job)
     }
     else
       dt_print(DT_DEBUG_ALWAYS,
-               "[dt_control_monochrome_images_job_run] got illegal imgid %i\n", imgid);
+               "[dt_control_monochrome_images_job_run] got illegal imgid %i", imgid);
 
     fraction += 1.0 / total;
     _update_progress(job, fraction, &prev_time);
@@ -1547,13 +1547,13 @@ static int32_t dt_control_refresh_exif_run(dt_job_t *job)
       }
       else
         dt_print(DT_DEBUG_ALWAYS,
-                 "[dt_control_refresh_exif_run] couldn't dt_image_cache_get for imgid %i\n",
+                 "[dt_control_refresh_exif_run] couldn't dt_image_cache_get for imgid %i",
                  imgid);
 
       DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_DEVELOP_IMAGE_CHANGED);
     }
     else
-      dt_print(DT_DEBUG_ALWAYS,"[dt_control_refresh_exif_run] illegal imgid %i\n", imgid);
+      dt_print(DT_DEBUG_ALWAYS,"[dt_control_refresh_exif_run] illegal imgid %i", imgid);
 
     t = g_list_next(t);
     fraction += 1.0 / total;
@@ -1895,7 +1895,7 @@ static int32_t dt_control_export_job_run(dt_job_t *job)
       if(!g_file_test(imgfilename, G_FILE_TEST_IS_REGULAR))
       {
         dt_control_log(_("image `%s' is currently unavailable"), image->filename);
-        dt_print(DT_DEBUG_ALWAYS, "image `%s' is currently unavailable\n", imgfilename);
+        dt_print(DT_DEBUG_ALWAYS, "image `%s' is currently unavailable", imgfilename);
         // dt_image_remove(imgid);
         dt_image_cache_read_release(darktable.image_cache, image);
       }
@@ -2676,7 +2676,7 @@ static int _control_import_image_copy(const char *filename,
   gboolean res = TRUE;
   if(!g_file_get_contents(filename, &data, &size, NULL))
   {
-    dt_print(DT_DEBUG_CONTROL, "[import_from] failed to read file `%s`\n", filename);
+    dt_print(DT_DEBUG_CONTROL, "[import_from] failed to read file `%s`", filename);
     return -1;
   }
   char *output = NULL;
@@ -2709,7 +2709,7 @@ static int _control_import_image_copy(const char *filename,
 
   if(!g_file_set_contents(output, data, size, NULL))
   {
-    dt_print(DT_DEBUG_CONTROL, "[import_from] failed to write file %s\n", output);
+    dt_print(DT_DEBUG_CONTROL, "[import_from] failed to write file %s", output);
     res = FALSE;
   }
   else

--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -958,7 +958,7 @@ static int32_t dt_control_remove_images_job_run(dt_job_t *job)
     }
     else
     {
-      really_removed = dt_util_dstrcat(really_removed, really_removed?",%d":"%d", imgid);
+      dt_util_str_cat(&really_removed, really_removed?",%d":"%d", imgid);
       dt_image_remove(imgid);
     }
     fraction += 1.0 / total;
@@ -1854,10 +1854,10 @@ static int32_t dt_control_export_job_run(dt_job_t *job)
   if(!g_strstr_len(settings->metadata_export, -1, iptc_envelope_characterset))
   {
     // IPTC character encoding not set by user, so we set the default utf8 here
-    settings->metadata_export = dt_util_dstrcat(settings->metadata_export,
-                                                "\1%s\1%s",
-                                                iptc_envelope_characterset,
-                                                "\x1b%G");  // ESC % G
+    dt_util_str_cat(&settings->metadata_export,
+                    "\1%s\1%s",
+                    iptc_envelope_characterset,
+                    "\x1b%G");  // ESC % G
   }
 
   dt_export_metadata_t metadata;

--- a/src/control/progress.c
+++ b/src/control/progress.c
@@ -95,7 +95,7 @@ static void global_progress_start(dt_control_t *control, dt_progress_t *progress
                                   &error);
     if(error)
     {
-      dt_print(DT_DEBUG_ALWAYS, "[progress_create] dbus error: %s\n", error->message);
+      dt_print(DT_DEBUG_ALWAYS, "[progress_create] dbus error: %s", error->message);
       g_error_free(error);
     }
   }
@@ -117,9 +117,9 @@ static void global_progress_start(dt_control_t *control, dt_progress_t *progress
   {
     HWND hwnd = GDK_WINDOW_HWND(gtk_widget_get_window(dt_ui_main_window(darktable.gui->ui)));
     if(ITaskbarList3_SetProgressState(control->progress_system.taskbarlist, hwnd, TBPF_NORMAL) != S_OK)
-      dt_print(DT_DEBUG_ALWAYS, "[progress_create] SetProgressState failed\n");
+      dt_print(DT_DEBUG_ALWAYS, "[progress_create] SetProgressState failed");
     if(ITaskbarList3_SetProgressValue(control->progress_system.taskbarlist, hwnd, control->progress_system.global_progress * 100, 100) != S_OK)
-      dt_print(DT_DEBUG_ALWAYS, "[progress_create] SetProgressValue failed\n");
+      dt_print(DT_DEBUG_ALWAYS, "[progress_create] SetProgressValue failed");
   }
 
 #endif
@@ -155,7 +155,7 @@ static void global_progress_set(dt_control_t *control, dt_progress_t *progress, 
                                   &error);
     if(error)
     {
-      dt_print(DT_DEBUG_ALWAYS, "[progress_set] dbus error: %s\n", error->message);
+      dt_print(DT_DEBUG_ALWAYS, "[progress_set] dbus error: %s", error->message);
       g_error_free(error);
     }
   }
@@ -168,7 +168,7 @@ static void global_progress_set(dt_control_t *control, dt_progress_t *progress, 
   {
     HWND hwnd = GDK_WINDOW_HWND(gtk_widget_get_window(dt_ui_main_window(darktable.gui->ui)));
     if(ITaskbarList3_SetProgressValue(control->progress_system.taskbarlist, hwnd, control->progress_system.global_progress * 100, 100) != S_OK)
-      dt_print(DT_DEBUG_ALWAYS, "[progress_create] SetProgressValue failed\n");
+      dt_print(DT_DEBUG_ALWAYS, "[progress_create] SetProgressValue failed");
   }
 
 #endif
@@ -217,7 +217,7 @@ static void global_progress_end(dt_control_t *control, dt_progress_t *progress)
                                   &error);
     if(error)
     {
-      dt_print(DT_DEBUG_ALWAYS, "[progress_destroy] dbus error: %s\n", error->message);
+      dt_print(DT_DEBUG_ALWAYS, "[progress_destroy] dbus error: %s", error->message);
       g_error_free(error);
     }
 
@@ -235,13 +235,13 @@ static void global_progress_end(dt_control_t *control, dt_progress_t *progress)
     if(control->progress_system.n_progress_bar == 0)
     {
       if(ITaskbarList3_SetProgressState(control->progress_system.taskbarlist, hwnd, TBPF_NOPROGRESS) != S_OK)
-        dt_print(DT_DEBUG_ALWAYS, "[progress_create] SetProgressState failed\n");
+        dt_print(DT_DEBUG_ALWAYS, "[progress_create] SetProgressState failed");
     }
     else
     {
       if(ITaskbarList3_SetProgressValue(control->progress_system.taskbarlist, hwnd,
                                         control->progress_system.global_progress * 100, 100) != S_OK)
-        dt_print(DT_DEBUG_ALWAYS, "[progress_create] SetProgressValue failed\n");
+        dt_print(DT_DEBUG_ALWAYS, "[progress_create] SetProgressValue failed");
     }
   }
 
@@ -277,7 +277,7 @@ void dt_control_progress_init(struct dt_control_t *control)
                                   &error);
     if(error)
     {
-      dt_print(DT_DEBUG_ALWAYS, "[progress_init] dbus error: %s\n", error->message);
+      dt_print(DT_DEBUG_ALWAYS, "[progress_init] dbus error: %s", error->message);
       g_error_free(error);
     }
 

--- a/src/control/signal.c
+++ b/src/control/signal.c
@@ -297,7 +297,7 @@ static void _print_trace(int signal, dt_debug_signal_action_t action, const char
     strings = backtrace_symbols (array, size);
 
     for(i = 0; i < size; i++)
-      dt_print(DT_DEBUG_SIGNAL, "[signal-trace-%s]: %s\n", op, strings[i]);
+      dt_print(DT_DEBUG_SIGNAL, "[signal-trace-%s]: %s", op, strings[i]);
 
     free (strings);
   }
@@ -346,7 +346,7 @@ void dt_control_signal_raise(const dt_control_signal_t *ctlsig, dt_signal_t sign
         g_value_set_pointer(&instance_and_params[i], va_arg(extra_args, void *));
         break;
       default:
-        dt_print(DT_DEBUG_ALWAYS, "error: unsupported parameter type `%s' for signal `%s'\n",
+        dt_print(DT_DEBUG_ALWAYS, "error: unsupported parameter type `%s' for signal `%s'",
                 g_type_name(type), signal_description->name);
         va_end(extra_args);
         for(int j = 0; j <= i; j++) g_value_unset(&instance_and_params[j]);

--- a/src/control/signal.h
+++ b/src/control/signal.h
@@ -312,7 +312,7 @@ void dt_control_signal_unblock_by_func(const struct dt_control_signal_t *ctlsig,
   {                                                                                                                        \
     if((darktable.unmuted_signal_dbg_acts & DT_DEBUG_SIGNAL_ACT_RAISE) && darktable.unmuted_signal_dbg[signal])            \
     {                                                                                                                      \
-      dt_print(DT_DEBUG_SIGNAL, "[signal] raise %s; %s:%d, function %s()\n", #signal, __FILE__, __LINE__, __FUNCTION__);   \
+      dt_print(DT_DEBUG_SIGNAL, "[signal] raise %s; %s:%d, function %s()", #signal, __FILE__, __LINE__, __FUNCTION__);   \
     }                                                                                                                      \
     dt_control_signal_raise(darktable.signals, signal, ##__VA_ARGS__);                                                     \
   } while (0)
@@ -322,7 +322,7 @@ void dt_control_signal_unblock_by_func(const struct dt_control_signal_t *ctlsig,
   {                                                                                                                        \
     if((darktable.unmuted_signal_dbg_acts & DT_DEBUG_SIGNAL_ACT_CONNECT) && darktable.unmuted_signal_dbg[signal])          \
     {                                                                                                                      \
-      dt_print(DT_DEBUG_SIGNAL, "[signal] connect    %s to %s; %s:%d, function: %s()\n", #cb, #signal,                        \
+      dt_print(DT_DEBUG_SIGNAL, "[signal] connect    %s to %s; %s:%d, function: %s()", #cb, #signal,                        \
                                 __FILE__, __LINE__, __FUNCTION__);                                                         \
     }                                                                                                                      \
     dt_control_signal_connect(darktable.signals, signal, G_CALLBACK(cb), user_data);                                       \
@@ -333,7 +333,7 @@ void dt_control_signal_unblock_by_func(const struct dt_control_signal_t *ctlsig,
   {                                                                                                                        \
     if(darktable.unmuted_signal_dbg_acts & DT_DEBUG_SIGNAL_ACT_DISCONNECT)                                                 \
     {                                                                                                                      \
-      dt_print(DT_DEBUG_SIGNAL, "[signal] disconnect %s; %s:%d, function: %s()\n", #cb, __FILE__, __LINE__, __FUNCTION__); \
+      dt_print(DT_DEBUG_SIGNAL, "[signal] disconnect %s; %s:%d, function: %s()", #cb, __FILE__, __LINE__, __FUNCTION__); \
     }                                                                                                                      \
     dt_control_signal_disconnect(darktable.signals, G_CALLBACK(cb), user_data);                                            \
   } while (0)

--- a/src/develop/blend.c
+++ b/src/develop/blend.c
@@ -289,7 +289,7 @@ static void _refine_with_detail_mask(dt_iop_module_t *self,
 
   dt_print_pipe(DT_DEBUG_PIPE,
        "refine with detail mask",
-       piece->pipe, self, DT_DEVICE_CPU, roi_in, roi_out, "\n");
+       piece->pipe, self, DT_DEVICE_CPU, roi_in, roi_out);
 
   const size_t msize = (size_t)roi_out->width * roi_out->height;
   DT_OMP_FOR_SIMD(aligned(mask, warp_mask : 64))
@@ -302,7 +302,7 @@ static void _refine_with_detail_mask(dt_iop_module_t *self,
   error:
   dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_MASKS,
        "refine with detail mask",
-       piece->pipe, self, DT_DEVICE_CPU, roi_in, roi_out, "no mask data available\n");
+       piece->pipe, self, DT_DEVICE_CPU, roi_in, roi_out, "no mask data available");
   dt_control_log(_("detail mask blending error"));
   dt_free_align(warp_mask);
   dt_free_align(lum);
@@ -541,7 +541,7 @@ void dt_develop_blend_process(dt_iop_module_t *self,
     dt_print_pipe(DT_DEBUG_PIPE,
                   "dt_develop_blend",
                   piece->pipe, self, DT_DEVICE_CPU, roi_in, roi_out,
-                  "skip blending, work area mismatch\n");
+                  "skip blending, work area mismatch");
     return;
   }
 
@@ -586,7 +586,7 @@ void dt_develop_blend_process(dt_iop_module_t *self,
     dt_print_pipe(DT_DEBUG_PIPE,
        "dt_develop_blend",
        piece->pipe, self, DT_DEVICE_CPU, roi_in, roi_out,
-       "could not allocate buffer for blending\n");
+       "could not allocate buffer for blending");
     return;
   }
 
@@ -610,7 +610,7 @@ void dt_develop_blend_process(dt_iop_module_t *self,
                                                 self, &free_mask);
     dt_print_pipe(DT_DEBUG_PIPE,
        "blend raster",
-       piece->pipe, self, DT_DEVICE_CPU, roi_in, roi_out, "%s %s %s at %p\n",
+       piece->pipe, self, DT_DEVICE_CPU, roi_in, roi_out, "%s %s %s at %p",
        dt_iop_colorspace_to_name(cst),
        free_mask ? "temp" : "permanent",
        d->raster_mask_invert ? "inverted" : "",
@@ -675,7 +675,7 @@ void dt_develop_blend_process(dt_iop_module_t *self,
 
     dt_print_pipe(DT_DEBUG_PIPE,
        form && form_ok ? "blend with form" : "blend without form",
-       piece->pipe, self, DT_DEVICE_CPU, roi_in, roi_out, "%s, %s%s%s\n",
+       piece->pipe, self, DT_DEVICE_CPU, roi_in, roi_out, "%s, %s%s%s",
        dt_iop_colorspace_to_name(cst),
        _develop_blend_colorspace_to_str(blend_csp),
        inverted ? ", inverted" : "",
@@ -819,7 +819,7 @@ void dt_develop_blend_process(dt_iop_module_t *self,
     const gboolean new = g_hash_table_replace(piece->raster_masks, GINT_TO_POINTER(BLEND_RASTER_ID), _mask);
     dt_dev_pixelpipe_cache_invalidate_later(piece->pipe, self->iop_order);
     dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_MASKS,
-       "write raster mask", piece->pipe, self, DT_DEVICE_CPU, NULL, NULL, "%s at %p (%ix%i)\n",
+       "write raster mask", piece->pipe, self, DT_DEVICE_CPU, NULL, NULL, "%s at %p (%ix%i)",
        new ? "new" : "replaced",
        _mask, roi_out->width, roi_out->height);
   }
@@ -828,7 +828,7 @@ void dt_develop_blend_process(dt_iop_module_t *self,
     dt_free_align(_mask);
     if(g_hash_table_remove(piece->raster_masks, GINT_TO_POINTER(BLEND_RASTER_ID)))
       dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_MASKS,
-        "delete raster mask", piece->pipe, self, DT_DEVICE_CPU, roi_in, roi_out, " not requested\n");
+        "delete raster mask", piece->pipe, self, DT_DEVICE_CPU, roi_in, roi_out, " not requested");
   }
 }
 
@@ -856,7 +856,7 @@ static void _refine_with_detail_mask_cl(dt_iop_module_t *self,
   {
     dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_OPENCL,
        "refine with detail mask",
-       piece->pipe, self, piece->pipe->devid, roi_in, roi_out, "no detail data available\n");
+       piece->pipe, self, piece->pipe->devid, roi_in, roi_out, "no detail data available");
     return;
   }
   const int iwidth  = p->scharr.roi.width;
@@ -898,7 +898,7 @@ static void _refine_with_detail_mask_cl(dt_iop_module_t *self,
 
   dt_print_pipe(DT_DEBUG_PIPE,
        "refine with detail mask",
-       piece->pipe, self, piece->pipe->devid, roi_in, roi_out, "\n");
+       piece->pipe, self, piece->pipe->devid, roi_in, roi_out);
 
   const size_t msize = (size_t)roi_out->width * roi_out->height;
   DT_OMP_FOR_SIMD(aligned(mask, warp_mask : 64))
@@ -912,7 +912,7 @@ static void _refine_with_detail_mask_cl(dt_iop_module_t *self,
   dt_control_log(_("detail mask CL blending problem"));
   dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_OPENCL,
        "refine with detail_mask",
-        piece->pipe, self, piece->pipe->devid, roi_in, roi_out, "OpenCL error: %s\n", cl_errstr(err));
+        piece->pipe, self, piece->pipe->devid, roi_in, roi_out, "OpenCL error: %s", cl_errstr(err));
 
   dt_free_align(lum);
   dt_opencl_release_mem_object(tmp);
@@ -965,7 +965,7 @@ gboolean dt_develop_blend_process_cl(dt_iop_module_t *self,
     dt_print_pipe(DT_DEBUG_PIPE,
                   "dt_develop_blend",
                   piece->pipe, self, piece->pipe->devid, roi_in, roi_out,
-                  "skip OpenCL blending, work area mismatch\n");
+                  "skip OpenCL blending, work area mismatch");
     return TRUE;
   }
   // only non-zero if mask_display was set by an _earlier_ module
@@ -1012,7 +1012,7 @@ gboolean dt_develop_blend_process_cl(dt_iop_module_t *self,
     dt_print_pipe(DT_DEBUG_PIPE,
        "dt_develop_blend",
        piece->pipe, self, piece->pipe->devid, roi_in, roi_out,
-       "could not allocate buffer for blending\n");
+       "could not allocate buffer for blending");
    return FALSE;
   }
 
@@ -1099,7 +1099,7 @@ gboolean dt_develop_blend_process_cl(dt_iop_module_t *self,
   if(err != CL_SUCCESS)
   {
     dt_print(DT_DEBUG_OPENCL,
-             "[opencl_blendop] profile_info_cl: %s\n", cl_errstr(err));
+             "[opencl_blendop] profile_info_cl: %s", cl_errstr(err));
     goto error;
   }
   if(mask_mode == DEVELOP_MASK_ENABLED || suppress_mask)
@@ -1115,7 +1115,7 @@ gboolean dt_develop_blend_process_cl(dt_iop_module_t *self,
     if(err != CL_SUCCESS)
     {
       dt_print(DT_DEBUG_OPENCL,
-               "[opencl_blendop] kernel_set_mask: %s\n", cl_errstr(err));
+               "[opencl_blendop] kernel_set_mask: %s", cl_errstr(err));
       goto error;
     }
   }
@@ -1132,7 +1132,7 @@ gboolean dt_develop_blend_process_cl(dt_iop_module_t *self,
                                                 self, &free_mask);
     dt_print_pipe(DT_DEBUG_PIPE,
        "blend raster",
-       piece->pipe, self, piece->pipe->devid, roi_in, roi_out, "%s %s %s at %p\n",
+       piece->pipe, self, piece->pipe->devid, roi_in, roi_out, "%s %s %s at %p",
        dt_iop_colorspace_to_name(cst),
        d->raster_mask_invert ? "inverted" : "",
        free_mask ? "temp" : "permanent",
@@ -1164,7 +1164,7 @@ gboolean dt_develop_blend_process_cl(dt_iop_module_t *self,
     if(err != CL_SUCCESS)
     {
       dt_print(DT_DEBUG_OPENCL,
-               "[opencl_blendop] write raster mask dev_mask_1: %s\n",
+               "[opencl_blendop] write raster mask dev_mask_1: %s",
                cl_errstr(err));
       goto error;
     }
@@ -1206,7 +1206,7 @@ gboolean dt_develop_blend_process_cl(dt_iop_module_t *self,
 
     dt_print_pipe(DT_DEBUG_PIPE,
        form && form_ok ? "blend with form" : "blend without form",
-       piece->pipe, self, piece->pipe->devid, roi_in, roi_out, "%s, %s%s%s\n",
+       piece->pipe, self, piece->pipe->devid, roi_in, roi_out, "%s, %s%s%s",
        dt_iop_colorspace_to_name(cst),
        _develop_blend_colorspace_to_str(blend_csp),
        inverted ? ", inverted" : "",
@@ -1223,7 +1223,7 @@ gboolean dt_develop_blend_process_cl(dt_iop_module_t *self,
     if(err != CL_SUCCESS)
     {
       dt_print(DT_DEBUG_OPENCL,
-               "[opencl_blendop] write drawn mask dev_mask_1: %s\n", cl_errstr(err));
+               "[opencl_blendop] write drawn mask dev_mask_1: %s", cl_errstr(err));
       goto error;
     }
     // The following call to clFinish() works around a bug in some OpenCL
@@ -1251,7 +1251,7 @@ gboolean dt_develop_blend_process_cl(dt_iop_module_t *self,
     if(err != CL_SUCCESS)
     {
       dt_print(DT_DEBUG_OPENCL,
-               "[opencl_blendop] apply global opacity: %s\n", cl_errstr(err));
+               "[opencl_blendop] apply global opacity: %s", cl_errstr(err));
       goto error;
     }
 
@@ -1321,7 +1321,7 @@ gboolean dt_develop_blend_process_cl(dt_iop_module_t *self,
         if(err != CL_SUCCESS)
         {
           dt_print(DT_DEBUG_OPENCL,
-                   "[opencl_blendop] DEVELOP_MASK_POST_BLUR: %s\n", cl_errstr(err));
+                   "[opencl_blendop] DEVELOP_MASK_POST_BLUR: %s", cl_errstr(err));
           goto error;
         }
         _blend_process_cl_exchange(&dev_mask_1, &dev_mask_2);
@@ -1338,7 +1338,7 @@ gboolean dt_develop_blend_process_cl(dt_iop_module_t *self,
         if(err != CL_SUCCESS)
         {
           dt_print(DT_DEBUG_OPENCL,
-                   "[opencl_blendop] DEVELOP_MASK_POST_TONE_CURVE: %s\n", cl_errstr(err));
+                   "[opencl_blendop] DEVELOP_MASK_POST_TONE_CURVE: %s", cl_errstr(err));
           goto error;
         }
         _blend_process_cl_exchange(&dev_mask_1, &dev_mask_2);
@@ -1385,7 +1385,7 @@ gboolean dt_develop_blend_process_cl(dt_iop_module_t *self,
     if(err != CL_SUCCESS)
     {
       dt_print(DT_DEBUG_OPENCL,
-               "[opencl_blendop] work_profile_info_cl: %s\n", cl_errstr(err));
+               "[opencl_blendop] work_profile_info_cl: %s", cl_errstr(err));
       goto error;
     }
     // let us display a specific channel
@@ -1400,7 +1400,7 @@ gboolean dt_develop_blend_process_cl(dt_iop_module_t *self,
     if(err != CL_SUCCESS)
     {
       dt_print(DT_DEBUG_OPENCL,
-               "[opencl_blendop] kernel_display_channel: %s\n", cl_errstr(err));
+               "[opencl_blendop] kernel_display_channel: %s", cl_errstr(err));
       goto error;
     }
   }
@@ -1416,7 +1416,7 @@ gboolean dt_develop_blend_process_cl(dt_iop_module_t *self,
     if(err != CL_SUCCESS)
     {
       dt_print(DT_DEBUG_OPENCL,
-               "[opencl_blendop] blend_parameter: %s\n", cl_errstr(err));
+               "[opencl_blendop] blend_parameter: %s", cl_errstr(err));
       goto error;
     }
   }
@@ -1475,7 +1475,7 @@ gboolean dt_develop_blend_process_cl(dt_iop_module_t *self,
     const gboolean new = g_hash_table_replace(piece->raster_masks, GINT_TO_POINTER(BLEND_RASTER_ID), _mask);
     dt_dev_pixelpipe_cache_invalidate_later(piece->pipe, self->iop_order);
     dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_MASKS,
-       "write raster mask", piece->pipe, self, piece->pipe->devid, NULL, NULL, "%s at %p (%ix%i)\n",
+       "write raster mask", piece->pipe, self, piece->pipe->devid, NULL, NULL, "%s at %p (%ix%i)",
        new ? "new" : "replaced",
        _mask, roi_out->width, roi_out->height);
   }
@@ -1484,7 +1484,7 @@ gboolean dt_develop_blend_process_cl(dt_iop_module_t *self,
     dt_free_align(_mask);
     if(g_hash_table_remove(piece->raster_masks, GINT_TO_POINTER(BLEND_RASTER_ID)))
       dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_MASKS,
-        "delete raster mask", piece->pipe, self, piece->pipe->devid, roi_in, roi_out, " not requested\n");
+        "delete raster mask", piece->pipe, self, piece->pipe->devid, roi_in, roi_out, " not requested");
   }
 
   dt_opencl_release_mem_object(dev_blendif_params);
@@ -1505,7 +1505,7 @@ error:
   {
     dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_MASKS,
       "delete raster mask", piece->pipe, self, piece->pipe->devid, roi_in, roi_out,
-      "OpenCL error: %s\n", cl_errstr(err));
+      "OpenCL error: %s", cl_errstr(err));
     dt_dev_pixelpipe_cache_invalidate_later(piece->pipe, self->iop_order);
   }
   dt_free_align(_mask);
@@ -1519,7 +1519,7 @@ error:
   dt_ioppr_free_iccprofile_params_cl(&work_profile_info_cl, &work_profile_lut_cl,
                                      &dev_work_profile_info,
                                      &dev_work_profile_lut);
-  dt_print(DT_DEBUG_OPENCL | DT_DEBUG_PIPE, "[opencl_blendop] error: %s\n", cl_errstr(err));
+  dt_print(DT_DEBUG_OPENCL | DT_DEBUG_PIPE, "[opencl_blendop] error: %s", cl_errstr(err));
   return FALSE;
 }
 #endif

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -226,7 +226,7 @@ void dt_dev_process_image(dt_develop_t *dev)
   const gboolean err
       = dt_control_add_job_res(darktable.control,
                                dt_dev_process_image_job_create(dev), DT_CTL_WORKER_ZOOM_1);
-  if(err) dt_print(DT_DEBUG_ALWAYS, "[dev_process_image] job queue exceeded!\n");
+  if(err) dt_print(DT_DEBUG_ALWAYS, "[dev_process_image] job queue exceeded!");
 }
 
 void dt_dev_process_preview(dt_develop_t *dev)
@@ -235,7 +235,7 @@ void dt_dev_process_preview(dt_develop_t *dev)
   const gboolean err = dt_control_add_job_res(darktable.control,
                                          dt_dev_process_preview_job_create(dev),
                                          DT_CTL_WORKER_ZOOM_FILL);
-  if(err) dt_print(DT_DEBUG_ALWAYS, "[dev_process_preview] job queue exceeded!\n");
+  if(err) dt_print(DT_DEBUG_ALWAYS, "[dev_process_preview] job queue exceeded!");
 }
 
 void dt_dev_process_preview2(dt_develop_t *dev)
@@ -243,7 +243,7 @@ void dt_dev_process_preview2(dt_develop_t *dev)
   const gboolean err = dt_control_add_job_res(darktable.control,
                                          dt_dev_process_preview2_job_create(dev),
                                          DT_CTL_WORKER_ZOOM_2);
-  if(err) dt_print(DT_DEBUG_ALWAYS, "[dev_process_preview2] job queue exceeded!\n");
+  if(err) dt_print(DT_DEBUG_ALWAYS, "[dev_process_preview2] job queue exceeded!");
 }
 
 void dt_dev_invalidate(dt_develop_t *dev)
@@ -739,7 +739,7 @@ static void _dev_auto_save(dt_develop_t *dev)
     if((after - start) > 0.5)
     {
       dev->autosaving = FALSE;
-      dt_print(DT_DEBUG_DEV, "autosave history disabled, took %.3fs\n", after - start);
+      dt_print(DT_DEBUG_DEV, "autosave history disabled, took %.3fs", after - start);
 
       dt_control_log(_("autosaving history has been disabled for this image"
                        " because of a very large history or a slow drive being used"));
@@ -1087,7 +1087,7 @@ void dt_dev_add_masks_history_item_ext(dt_develop_t *dev,
   }
   else
     dt_print(DT_DEBUG_ALWAYS,
-             "[dt_dev_add_masks_history_item_ext] can't find mask manager module\n");
+             "[dt_dev_add_masks_history_item_ext] can't find mask manager module");
 }
 
 void dt_dev_add_masks_history_item(
@@ -1373,14 +1373,14 @@ void dt_dev_write_history_ext(dt_develop_t *dev,
 
   GList *history = dev->history;
   dt_print(DT_DEBUG_IOPORDER,
-           "[dt_dev_write_history_ext] Writing history image id=%d `%s', iop version: %i\n",
+           "[dt_dev_write_history_ext] Writing history image id=%d `%s', iop version: %i",
            imgid, dev->image_storage.filename, dev->iop_order_version);
   for(int i = 0; history; i++)
   {
     dt_dev_history_item_t *hist = history->data;
     _dev_write_history_item(imgid, hist, i);
 
-    dt_print(DT_DEBUG_IOPORDER, "%20s, num %2i, order %2d, v(%i), multiprio %i%s\n",
+    dt_print(DT_DEBUG_IOPORDER, "%20s, num %2i, order %2d, v(%i), multiprio %i%s",
       hist->module->op, i, hist->iop_order, hist->module->version(), hist->multi_priority,
       (hist->enabled) ? ", enabled" : "");
 
@@ -1446,7 +1446,7 @@ static void _dev_insert_module(dt_develop_t *dev,
 
   g_free(preset_name);
 
-  dt_print(DT_DEBUG_PARAMS, "[dev_insert_module] `%s' inserted to history\n", module->op);
+  dt_print(DT_DEBUG_PARAMS, "[dev_insert_module] `%s' inserted to history", module->op);
 }
 
 static gboolean _dev_auto_apply_presets(dt_develop_t *dev)
@@ -1497,7 +1497,7 @@ static gboolean _dev_auto_apply_presets(dt_develop_t *dev)
         {
           dt_print(DT_DEBUG_PARAMS,
                    "[_dev_auto_apply_presets] missing mandatory module %s"
-                   " for image id=%d `%s'\n",
+                   " for image id=%d `%s'",
                    module->op, imgid, dev->image_storage.filename);
 
           // If the module is white-balance and we are dealing with a
@@ -1902,7 +1902,7 @@ void dt_dev_read_history_ext(dt_develop_t *dev,
     DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db),
                           "DELETE FROM memory.history", NULL, NULL, NULL);
 
-    dt_print(DT_DEBUG_PARAMS, "[dt_dev_read_history_ext] temporary history deleted\n");
+    dt_print(DT_DEBUG_PARAMS, "[dt_dev_read_history_ext] temporary history deleted");
 
     // Make sure all modules default params are loaded to init
     // history. This is important as some modules have specific
@@ -1928,7 +1928,7 @@ void dt_dev_read_history_ext(dt_develop_t *dev,
     _dev_merge_history(dev, imgid);
 
     dt_print(DT_DEBUG_PARAMS,
-             "[dt_dev_read_history_ext] temporary history merged with image history\n");
+             "[dt_dev_read_history_ext] temporary history merged with image history");
 
     //  first time we are loading the image, try to import lightroom .xmp if any
     if(dev->full.pipe && dev->full.pipe->loading && first_run)
@@ -2038,7 +2038,7 @@ void dt_dev_read_history_ext(dt_develop_t *dev,
     {
       dt_print(DT_DEBUG_ALWAYS,
                "[dev_read_history_ext] database history for image"
-               " id=%d `%s' seems to be corrupted!\n",
+               " id=%d `%s' seems to be corrupted!",
                imgid, dev->image_storage.filename);
       continue;
     }
@@ -2049,7 +2049,7 @@ void dt_dev_read_history_ext(dt_develop_t *dev,
     {
       dt_print(DT_DEBUG_PIPE | DT_DEBUG_UNDO,
                "[dev_read_history_ext] illegal iop_order for module `%s.%i' in history for image"
-               " id=%d `%s'!\n",
+               " id=%d `%s'!",
                module_name, multi_priority, imgid, dev->image_storage.filename);
       continue;
     }
@@ -2110,7 +2110,7 @@ void dt_dev_read_history_ext(dt_develop_t *dev,
     {
       dt_print(DT_DEBUG_ALWAYS,
                "[dev_read_history] the module `%s' requested by image"
-               " id=%d `%s' is not installed on this computer!\n",
+               " id=%d `%s' is not installed on this computer!",
                module_name, imgid, dev->image_storage.filename);
       free(hist);
       continue;
@@ -2146,7 +2146,7 @@ void dt_dev_read_history_ext(dt_develop_t *dev,
     dt_print(DT_DEBUG_PARAMS,
              "[history] successfully loaded module %s from history\n"
              "\t\t\tblendop v. %i:\tversion %s\tparams %s\n"
-             "\t\t\tparams v. %i:\tversion %s\tparams %s\n",
+             "\t\t\tparams v. %i:\tversion %s\tparams %s",
              module_name,
              blendop_version, _print_validity(is_valid_blendop_version),
              _print_validity(is_valid_blendop_size),
@@ -2211,7 +2211,7 @@ void dt_dev_read_history_ext(dt_develop_t *dev,
       {
         dt_print(DT_DEBUG_ALWAYS,
                  "[dev_read_history] module `%s' version mismatch: history"
-                 " is %d, darktable is %d, image id=%d `%s'\n",
+                 " is %d, darktable is %d, image id=%d `%s'",
                  hist->module->op, modversion, hist->module->version(),
                  imgid, dev->image_storage.filename);
 
@@ -2268,7 +2268,7 @@ void dt_dev_read_history_ext(dt_develop_t *dev,
   if(temperature && channelmixerrgb)
   {
     dt_print(DT_DEBUG_PARAMS,
-             "[dt_dev_read_history_ext] reset defaults for workflow none\n");
+             "[dt_dev_read_history_ext] reset defaults for workflow none");
     temperature->reload_defaults(temperature);
   }
 
@@ -3105,7 +3105,7 @@ dt_iop_module_t *dt_dev_module_duplicate_ext(dt_develop_t *dev,
   if(reorder_iop && !dt_ioppr_move_iop_after(base->dev, module, base))
   {
     dt_print(DT_DEBUG_ALWAYS,
-             "[dt_dev_module_duplicate] can't move new instance after the base one\n");
+             "[dt_dev_module_duplicate] can't move new instance after the base one");
     dt_control_log(_("duplicate module, can't move new instance after the base one\n"));
   }
 

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -3362,7 +3362,7 @@ void dt_iop_set_darktable_iop_table()
   for(GList *iop = darktable.iop; iop; iop = g_list_next(iop))
   {
     dt_iop_module_so_t *module = iop->data;
-    module_list = dt_util_dstrcat(module_list, "(\"%s\",\"%s\"),",
+    dt_util_str_cat(&module_list, "(\"%s\",\"%s\"),",
                                   module->op, module->name());
   }
 

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -307,7 +307,7 @@ void dt_iop_default_init(dt_iop_module_t *module)
       dt_print(DT_DEBUG_PARAMS,
                "[dt_iop_default_init] in `%s' unsupported introspection"
                " type \"%s\" encountered"
-               " in (field %s)\n",
+               " in (field %s)",
                module->op, i->header.type_name, i->header.field_name);
       break;
     }
@@ -353,7 +353,7 @@ int dt_iop_load_module_so(void *m, const char *libname, const char *module_name)
     }
     else
       dt_print(DT_DEBUG_ALWAYS,
-               "[iop_load_module] failed to initialize introspection for operation `%s'\n",
+               "[iop_load_module] failed to initialize introspection for operation `%s'",
                module_name);
   }
 
@@ -447,7 +447,7 @@ gboolean dt_iop_load_module_by_so(dt_iop_module_t *module,
   if(module->params_size == 0)
   {
     dt_print(DT_DEBUG_ALWAYS,
-             "[iop_load_module] `%s' needs to have a params size > 0!\n", so->op);
+             "[iop_load_module] `%s' needs to have a params size > 0!", so->op);
     return TRUE; // empty params hurt us in many places, just add a dummy value
   }
   module->enabled = module->default_enabled; // apply (possibly new) default.
@@ -1281,7 +1281,7 @@ void dt_iop_set_module_trouble_message(dt_iop_module_t *const module,
     const dt_image_t *img = module ? &module->dev->image_storage : NULL;
     const char *name = module ? module->name() : "?";
 
-    dt_print(DT_DEBUG_ALWAYS, "Trouble: [%s] %s (%s %d)\n",
+    dt_print(DT_DEBUG_ALWAYS, "Trouble: [%s] %s (%s %d)",
              name,
              stderr_message,
              img ? img->filename : "?",
@@ -1320,11 +1320,11 @@ void dt_iop_reload_defaults(dt_iop_module_t *module)
     {
       module->reload_defaults(module);
       dt_print(DT_DEBUG_PARAMS,
-               "[dt_iop_reload_defaults] defaults reloaded for %s\n", module->op);
+               "[dt_iop_reload_defaults] defaults reloaded for %s", module->op);
     }
     else
       dt_print(DT_DEBUG_PARAMS,
-               "[dt_iop_reload_defaults] should not be called without image.\n");
+               "[dt_iop_reload_defaults] should not be called without image.");
   }
 
   dt_iop_load_default_params(module);
@@ -1453,7 +1453,7 @@ static void _init_presets(dt_iop_module_so_t *module_so)
           (DT_DEBUG_ALWAYS,
            "[imageop_init_presets] WARNING: Could not find versioning information for '%s' "
            "preset '%s'\nUntil some is found, the preset will be unavailable.\n(To make it "
-           "return, please load an image that uses the preset.)\n",
+           "return, please load an image that uses the preset.)",
            module_so->op, name);
         sqlite3_finalize(stmt2);
         continue;
@@ -1464,7 +1464,7 @@ static void _init_presets(dt_iop_module_so_t *module_so)
       // we found an old params version.  Update the database with it.
 
       dt_print(DT_DEBUG_PARAMS,
-               "[imageop_init_presets] found version %d for '%s' preset '%s'\n",
+               "[imageop_init_presets] found version %d for '%s' preset '%s'",
                old_params_version, module_so->op, name);
 
       DT_DEBUG_SQLITE3_PREPARE_V2
@@ -1554,7 +1554,7 @@ static void _init_presets(dt_iop_module_so_t *module_so)
     {
       dt_print(DT_DEBUG_ALWAYS,
                "[imageop_init_presets] Can't upgrade '%s' preset '%s' "
-               "from version %d to %d, no legacy_params() implemented \n",
+               "from version %d to %d, no legacy_params() implemented ",
                module_so->op, name, old_params_version, module_version);
     }
 
@@ -1562,7 +1562,7 @@ static void _init_presets(dt_iop_module_so_t *module_so)
     {
       dt_print(DT_DEBUG_ALWAYS,
               "[imageop_init_presets] updating '%s' preset '%s' from blendop"
-               " version %d to version %d\n",
+               " version %d to version %d",
                module_so->op, name, old_blend_params_version, dt_develop_blend_version());
 
       // we need a dt_iop_module_t for dt_develop_blend_legacy_params()
@@ -1838,7 +1838,7 @@ void dt_iop_advertise_rastermask(dt_iop_module_t *module, const int mask_mode)
     if(g_hash_table_insert(module->raster_mask.source.masks, GINT_TO_POINTER(key), modulename))
     {
       dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_MASKS | DT_DEBUG_VERBOSE,
-        "raster mask advertised", NULL, module, DT_DEVICE_NONE, NULL, NULL, "\n");
+        "raster mask advertised", NULL, module, DT_DEVICE_NONE, NULL, NULL);
     }
   }
   else
@@ -1846,7 +1846,7 @@ void dt_iop_advertise_rastermask(dt_iop_module_t *module, const int mask_mode)
     if(g_hash_table_remove(module->raster_mask.source.masks, GINT_TO_POINTER(key)))
     {
       dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_MASKS | DT_DEBUG_VERBOSE,
-        "NO raster mask support", NULL, module, DT_DEVICE_NONE, NULL, NULL, "\n");
+        "NO raster mask support", NULL, module, DT_DEVICE_NONE, NULL, NULL);
     }
   }
 }
@@ -1894,7 +1894,7 @@ dt_iop_module_t *dt_iop_commit_blend_params(dt_iop_module_t *module,
         module->raster_mask.sink.id = blendop_params->raster_mask_id;
         dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_MASKS,
                       "request raster mask",
-                      NULL, module, DT_DEVICE_NONE, NULL, NULL, "from '%s%s' %s\n",
+                      NULL, module, DT_DEVICE_NONE, NULL, NULL, "from '%s%s' %s",
                       candidate->op, dt_iop_get_instance_id(candidate),
                       new ? "new" : "replaced");
 
@@ -1913,7 +1913,7 @@ dt_iop_module_t *dt_iop_commit_blend_params(dt_iop_module_t *module,
     if(g_hash_table_remove(module->raster_mask.sink.source->raster_mask.source.users, module))
       dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_MASKS,
                   "clear as raster user",
-                  NULL, module, DT_DEVICE_NONE, NULL, NULL, "from '%s%s'\n",
+                  NULL, module, DT_DEVICE_NONE, NULL, NULL, "from '%s%s'",
                   sink_source->op, dt_iop_get_instance_id(sink_source));
   }
   module->raster_mask.sink.source = NULL;
@@ -1962,7 +1962,7 @@ gboolean _iop_validate_params(dt_introspection_field_t *field,
         if(report)
           dt_print(DT_DEBUG_ALWAYS,
              "[iop_validate_params] `%s' failed for not null terminated type string"
-             " \"%s\";\n",
+             " \"%s\";",
                name, field->header.type_name);
         all_ok = FALSE;
       }
@@ -2081,7 +2081,7 @@ gboolean _iop_validate_params(dt_introspection_field_t *field,
   default:
     dt_print(DT_DEBUG_ALWAYS,
              "[iop_validate_params] `%s' unsupported introspection type \"%s\" encountered,"
-             " (field %s)\n",
+             " (field %s)",
              name, field->header.type_name, field->header.name);
     all_ok = FALSE;
     break;
@@ -2090,7 +2090,7 @@ gboolean _iop_validate_params(dt_introspection_field_t *field,
   if(all_ok)
   {
     dt_print(DT_DEBUG_ALWAYS,
-             "[iop_validate_params] `%s' validated data for type \"%s\"%s%s%s\n",
+             "[iop_validate_params] `%s' validated data for type \"%s\"%s%s%s",
              name, field->header.type_name,
              *field->header.name ? ", field: " : "",
              field->header.name, values ? values : "");
@@ -2098,7 +2098,7 @@ gboolean _iop_validate_params(dt_introspection_field_t *field,
   else if(report)
   {
     dt_print(DT_DEBUG_ALWAYS,
-             "[iop_validate_params] `%s' failed for type \"%s\"%s%s%s\n",
+             "[iop_validate_params] `%s' failed for type \"%s\"%s%s%s",
              name, field->header.type_name,
              *field->header.name ? ", field: " : "",
              field->header.name, values ? values : "");
@@ -2622,7 +2622,7 @@ static void _header_size_callback(GtkWidget *widget,
         {
           dt_print(DT_DEBUG_ALWAYS,
                    "[header size callback] unknown darkroom/ui/hide_header_buttons"
-                   " option %s\n", config);
+                   " option %s", config);
         }
       }
     }
@@ -2773,7 +2773,7 @@ static gboolean _mask_indicator_tooltip(GtkWidget *treeview,
     else if(mm & DEVELOP_MASK_RASTER)
       type=_("raster mask");
     else
-      dt_print(DT_DEBUG_PARAMS, "unknown mask mode '%u' in module '%s'\n", mm, module->op);
+      dt_print(DT_DEBUG_PARAMS, "unknown mask mode '%u' in module '%s'", mm, module->op);
     gchar *part1 = g_strdup_printf(_("this module has a `%s'"), type);
     gchar *part2 = NULL;
     if(raster && module->raster_mask.sink.source)
@@ -3835,12 +3835,12 @@ gboolean dt_iop_have_required_input_format(const int req_ch,
            "the data format does not match\n"
            "its requirements."), NULL);
       dt_print_pipe(DT_DEBUG_ALWAYS,
-        "unsupported data format", NULL, module, DT_DEVICE_NONE, roi_in, roi_out, "\n");
+        "unsupported data format", NULL, module, DT_DEVICE_NONE, roi_in, roi_out);
     }
     else
     {
       dt_print_pipe(DT_DEBUG_ALWAYS,
-        "unsupported data format", NULL, NULL, DT_DEVICE_NONE, roi_in, roi_out, "no module given\n");
+        "unsupported data format", NULL, NULL, DT_DEVICE_NONE, roi_in, roi_out, "no module given");
     }
     return FALSE;
   }
@@ -3944,7 +3944,7 @@ static float _action_process(gpointer target,
         return 0; // don't overwrite toast below
       default:
         dt_print(DT_DEBUG_ALWAYS,
-                 "[imageop::_action_process] effect %d for presets not yet implemented\n",
+                 "[imageop::_action_process] effect %d for presets not yet implemented",
                  effect);
         break;
       }

--- a/src/develop/imageop_math.c
+++ b/src/develop/imageop_math.c
@@ -209,10 +209,10 @@ int dt_iop_clip_and_zoom_roi_cl(int devid,
     }
     if(err == CL_SUCCESS)
       dt_print_pipe(DT_DEBUG_OPENCL, "clip and zoom roi", NULL, NULL, devid, roi_in, roi_out,
-          "did fast cpu fallback\n");
+          "did fast cpu fallback");
     else
       dt_print_pipe(DT_DEBUG_OPENCL, "clip and zoom roi", NULL, NULL, devid, roi_in, roi_out,
-          "fast cpu fallback failing: %s\n", cl_errstr(err));
+          "fast cpu fallback failing: %s", cl_errstr(err));
 
     dt_free_align(in);
     dt_free_align(out);

--- a/src/develop/masks.h
+++ b/src/develop/masks.h
@@ -726,14 +726,14 @@ static inline gboolean _dt_masks_dynbuf_growto(dt_masks_dynbuf_t *a,
   {
     // not much we can do here except emit an error message
     dt_print(DT_DEBUG_ALWAYS,
-             "critical: out of memory for dynbuf '%s' with size request %zu!\n",
+             "critical: out of memory for dynbuf '%s' with size request %zu!",
              a->tag, newsize);
     return FALSE;
   }
   if (a->buffer)
   {
     memcpy(newbuf, a->buffer, a->size * sizeof(float));
-    dt_print(DT_DEBUG_MASKS, "[masks dynbuf '%s'] grows to size %lu (is %p, was %p)\n",
+    dt_print(DT_DEBUG_MASKS, "[masks dynbuf '%s'] grows to size %lu (is %p, was %p)",
              a->tag,
              (unsigned long)a->size, newbuf, a->buffer);
     dt_free_align(a->buffer);
@@ -754,7 +754,7 @@ dt_masks_dynbuf_t *dt_masks_dynbuf_init(const size_t size, const char *tag)
     g_strlcpy(a->tag, tag, sizeof(a->tag)); //only for debugging purposes
     a->pos = 0;
     if(_dt_masks_dynbuf_growto(a, size))
-      dt_print(DT_DEBUG_MASKS, "[masks dynbuf '%s'] with initial size %lu (is %p)\n",
+      dt_print(DT_DEBUG_MASKS, "[masks dynbuf '%s'] with initial size %lu (is %p)",
                a->tag,
                (unsigned long)a->size, a->buffer);
     if(a->buffer == NULL)
@@ -922,7 +922,7 @@ static inline
 void dt_masks_dynbuf_free(dt_masks_dynbuf_t *a)
 {
   if(a == NULL) return;
-  dt_print(DT_DEBUG_MASKS, "[masks dynbuf '%s'] freed (was %p)\n", a->tag,
+  dt_print(DT_DEBUG_MASKS, "[masks dynbuf '%s'] freed (was %p)", a->tag,
           a->buffer);
   dt_free_align(a->buffer);
   free(a);

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -791,7 +791,7 @@ static int _brush_get_pts_border(dt_develop_t *dev,
   int start_stamp = 0;
 
   dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
-           "[masks %s] brush_points init took %0.04f sec\n", form->name,
+           "[masks %s] brush_points init took %0.04f sec", form->name,
            dt_get_lap_time(&start2));
 
   // we render all segments first upwards, then downwards
@@ -1040,7 +1040,7 @@ static int _brush_get_pts_border(dt_develop_t *dev,
   // *payload_count : -1);
 
   dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
-           "[masks %s] brush_points point recurs %0.04f sec\n", form->name,
+           "[masks %s] brush_points point recurs %0.04f sec", form->name,
            dt_get_lap_time(&start2));
 
   // and we transform them with all distorted modules
@@ -1082,7 +1082,7 @@ static int _brush_get_pts_border(dt_develop_t *dev,
     }
 
     dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
-             "[masks %s] path_points end took %0.04f sec\n",
+             "[masks %s] path_points end took %0.04f sec",
              form->name, dt_get_lap_time(&start2));
 
     return 1;
@@ -1094,7 +1094,7 @@ static int _brush_get_pts_border(dt_develop_t *dev,
                                                 transf_direction, *border, *border_count))
     {
       dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
-               "[masks %s] brush_points transform took %0.04f sec\n", form->name,
+               "[masks %s] brush_points transform took %0.04f sec", form->name,
                dt_get_lap_time(&start2));
       return 1;
     }
@@ -2938,14 +2938,14 @@ static int _brush_get_mask(const dt_iop_module_t *const module,
   }
 
   dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
-           "[masks %s] brush points took %0.04f sec\n",
+           "[masks %s] brush points took %0.04f sec",
            form->name, dt_get_lap_time(&start2));
 
   const guint nb_corner = g_list_length(form->points);
   _brush_bounding_box(points, border, nb_corner, points_count, width, height, posx, posy);
 
   dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
-           "[masks %s] brush_fill min max took %0.04f sec\n", form->name,
+           "[masks %s] brush_fill min max took %0.04f sec", form->name,
            dt_get_lap_time(&start2));
 
   // we allocate the buffer
@@ -2980,7 +2980,7 @@ static int _brush_get_mask(const dt_iop_module_t *const module,
   dt_free_align(payload);
 
   dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
-           "[masks %s] brush fill buffer took %0.04f sec\n", form->name,
+           "[masks %s] brush fill buffer took %0.04f sec", form->name,
            dt_get_lap_time(&start));
 
   return 1;
@@ -3071,7 +3071,7 @@ static int _brush_get_mask_roi(const dt_iop_module_t *const module,
   }
 
   dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
-           "[masks %s] brush points took %0.04f sec\n",
+           "[masks %s] brush points took %0.04f sec",
            form->name, dt_get_lap_time(&start2));
 
   const guint nb_corner = g_list_length(form->points);
@@ -3099,7 +3099,7 @@ static int _brush_get_mask_roi(const dt_iop_module_t *const module,
                           points_count, &xmin, &xmax, &ymin, &ymax);
 
   dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
-           "[masks %s] brush_fill min max took %0.04f sec\n", form->name,
+           "[masks %s] brush_fill min max took %0.04f sec", form->name,
            dt_get_lap_time(&start2));
 
   // check if the path completely lies outside of roi -> we're done/mask remains empty
@@ -3130,10 +3130,10 @@ static int _brush_get_mask_roi(const dt_iop_module_t *const module,
   dt_free_align(payload);
 
   dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
-           "[masks %s] brush set falloff took %0.04f sec\n", form->name,
+           "[masks %s] brush set falloff took %0.04f sec", form->name,
            dt_get_lap_time(&start2));
   dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
-           "[masks %s] brush fill buffer took %0.04f sec\n", form->name,
+           "[masks %s] brush fill buffer took %0.04f sec", form->name,
            dt_get_lap_time(&start));
 
   return 1;

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -1084,7 +1084,7 @@ static int _circle_get_mask(const dt_iop_module_t *const restrict module,
   if(!_circle_get_area(module, piece, form, width, height, posx, posy)) return 0;
 
   dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
-           "[masks %s] circle area took %0.04f sec\n",
+           "[masks %s] circle area took %0.04f sec",
            form->name, dt_get_lap_time(&start2));
 
   // we get the circle values
@@ -1111,7 +1111,7 @@ static int _circle_get_mask(const dt_iop_module_t *const restrict module,
     }
   }
   dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
-           "[masks %s] circle draw took %0.04f sec\n", form->name, dt_get_lap_time(&start2));
+           "[masks %s] circle draw took %0.04f sec", form->name, dt_get_lap_time(&start2));
 
   // we back transform all this points
   if(!dt_dev_distort_backtransform_plus(module->dev, piece->pipe, module->iop_order,
@@ -1123,7 +1123,7 @@ static int _circle_get_mask(const dt_iop_module_t *const restrict module,
   }
 
   dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
-           "[masks %s] circle transform took %0.04f sec\n", form->name,
+           "[masks %s] circle transform took %0.04f sec", form->name,
            dt_get_lap_time(&start2));
 
   // we allocate the buffer
@@ -1161,7 +1161,7 @@ static int _circle_get_mask(const dt_iop_module_t *const restrict module,
   dt_free_align(points);
 
   dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
-           "[masks %s] circle fill took %0.04f sec\n",
+           "[masks %s] circle fill took %0.04f sec",
            form->name, dt_get_lap_time(&start2));
 
   return 1;
@@ -1205,7 +1205,7 @@ static int _circle_get_mask_roi(const dt_iop_module_t *const restrict module,
   memset(buffer, 0, sizeof(float) * w * h);
 
   dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
-           "[masks %s] circle init took %0.04f sec\n",
+           "[masks %s] circle init took %0.04f sec",
            form->name, dt_get_lap_time(&start2));
 
   // we look at the outer circle of the shape - no effects outside of
@@ -1254,7 +1254,7 @@ static int _circle_get_mask_roi(const dt_iop_module_t *const restrict module,
   }
 
   dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
-           "[masks %s] circle outline took %0.04f sec\n",
+           "[masks %s] circle outline took %0.04f sec",
            form->name, dt_get_lap_time(&start2));
 
   // we get the min/max values ...
@@ -1292,7 +1292,7 @@ static int _circle_get_mask_roi(const dt_iop_module_t *const restrict module,
   dt_free_align(circ);
 
   dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
-           "[masks %s] circle bounding box took %0.04f sec\n",
+           "[masks %s] circle bounding box took %0.04f sec",
            form->name, dt_get_lap_time(&start2));
 
   // check if there is anything to do at all; only if width and height
@@ -1315,7 +1315,7 @@ static int _circle_get_mask_roi(const dt_iop_module_t *const restrict module,
     }
 
   dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
-           "[masks %s] circle grid took %0.04f sec\n", form->name, dt_get_lap_time(&start2));
+           "[masks %s] circle grid took %0.04f sec", form->name, dt_get_lap_time(&start2));
 
   // we back transform all these points to the input image coordinates
   if(!dt_dev_distort_backtransform_plus(module->dev, piece->pipe, module->iop_order,
@@ -1327,7 +1327,7 @@ static int _circle_get_mask_roi(const dt_iop_module_t *const restrict module,
   }
 
   dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
-           "[masks %s] circle transform took %0.04f sec\n", form->name,
+           "[masks %s] circle transform took %0.04f sec", form->name,
            dt_get_lap_time(&start2));
 
   // we calculate the mask values at the transformed points;
@@ -1349,7 +1349,7 @@ static int _circle_get_mask_roi(const dt_iop_module_t *const restrict module,
     }
 
   dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
-           "[masks %s] circle draw took %0.04f sec\n", form->name,
+           "[masks %s] circle draw took %0.04f sec", form->name,
            dt_get_lap_time(&start2));
 
   // we fill the pre-initialized output buffer by interpolation;
@@ -1378,10 +1378,10 @@ static int _circle_get_mask_roi(const dt_iop_module_t *const restrict module,
   dt_free_align(points);
 
   dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
-           "[masks %s] circle fill took %0.04f sec\n",
+           "[masks %s] circle fill took %0.04f sec",
            form->name, dt_get_lap_time(&start2));
   dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
-           "[masks %s] circle total render took %0.04f sec\n", form->name,
+           "[masks %s] circle total render took %0.04f sec", form->name,
            dt_get_lap_time(&start1));
 
   return 1;

--- a/src/develop/masks/ellipse.c
+++ b/src/develop/masks/ellipse.c
@@ -1654,7 +1654,7 @@ static int _ellipse_get_mask(const dt_iop_module_t *const module,
   if(!_ellipse_get_area(module, piece, form, width, height, posx, posy)) return 0;
 
   dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
-           "[masks %s] ellipse area took %0.04f sec\n",
+           "[masks %s] ellipse area took %0.04f sec",
            form->name, dt_get_lap_time(&start2));
 
   // we get the ellipse values
@@ -1674,7 +1674,7 @@ static int _ellipse_get_mask(const dt_iop_module_t *const module,
     }
 
   dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
-           "[masks %s] ellipse draw took %0.04f sec\n",
+           "[masks %s] ellipse draw took %0.04f sec",
            form->name, dt_get_lap_time(&start2));
 
   // we back transform all this points
@@ -1687,7 +1687,7 @@ static int _ellipse_get_mask(const dt_iop_module_t *const module,
   }
 
   dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
-           "[masks %s] ellipse transform took %0.04f sec\n", form->name,
+           "[masks %s] ellipse transform took %0.04f sec", form->name,
            dt_get_lap_time(&start2));
 
   // we allocate the buffer
@@ -1737,7 +1737,7 @@ static int _ellipse_get_mask(const dt_iop_module_t *const module,
   dt_free_align(points);
 
   dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
-           "[masks %s] ellipse fill took %0.04f sec\n",
+           "[masks %s] ellipse fill took %0.04f sec",
            form->name, dt_get_lap_time(&start2));
 
   return 1;
@@ -1787,7 +1787,7 @@ static int _ellipse_get_mask_roi(const dt_iop_module_t *const module,
   const int gh = (h + grid - 1) / grid + 1;  // grid dimension of total roi
 
   dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
-           "[masks %s] ellipse init took %0.04f sec\n",
+           "[masks %s] ellipse init took %0.04f sec",
            form->name, dt_get_lap_time(&start2));
 
   // we look at the outer line of the shape - no effects outside of
@@ -1812,7 +1812,7 @@ static int _ellipse_get_mask_roi(const dt_iop_module_t *const module,
   }
 
   dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
-           "[masks %s] ellipse outline took %0.04f sec\n",
+           "[masks %s] ellipse outline took %0.04f sec",
            form->name, dt_get_lap_time(&start2));
 
   // we transform the outline from input image coordinates to current position in pixelpipe
@@ -1825,7 +1825,7 @@ static int _ellipse_get_mask_roi(const dt_iop_module_t *const module,
   }
 
   dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
-           "[masks %s] ellipse outline transform took %0.04f sec\n",
+           "[masks %s] ellipse outline transform took %0.04f sec",
            form->name, dt_get_lap_time(&start2));
 
   // we get the min/max values ...
@@ -1863,7 +1863,7 @@ static int _ellipse_get_mask_roi(const dt_iop_module_t *const module,
   dt_free_align(ell);
 
   dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
-           "[masks %s] ellipse bounding box took %0.04f sec\n",
+           "[masks %s] ellipse bounding box took %0.04f sec",
            form->name, dt_get_lap_time(&start2));
 
   // check if there is anything to do at all; only if width and height
@@ -1886,7 +1886,7 @@ static int _ellipse_get_mask_roi(const dt_iop_module_t *const module,
     }
 
   dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
-           "[masks %s] ellipse grid took %0.04f sec\n",
+           "[masks %s] ellipse grid took %0.04f sec",
            form->name, dt_get_lap_time(&start2));
 
   // we back transform all these points to the input image coordinates
@@ -1899,7 +1899,7 @@ static int _ellipse_get_mask_roi(const dt_iop_module_t *const module,
   }
 
   dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
-           "[masks %s] ellipse transform took %0.04f sec\n", form->name,
+           "[masks %s] ellipse transform took %0.04f sec", form->name,
            dt_get_lap_time(&start2));
 
   // we calculate the mask values at the transformed points; re-use
@@ -1908,7 +1908,7 @@ static int _ellipse_get_mask_roi(const dt_iop_module_t *const module,
   _fill_mask((size_t)(bbh)*bbw, points, points, center, a, b, ta, tb, alpha, 1);
 
   dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
-           "[masks %s] ellipse draw took %0.04f sec\n", form->name,
+           "[masks %s] ellipse draw took %0.04f sec", form->name,
            dt_get_wtime() - start2);
 
   // we fill the pre-initialized output buffer by interpolation;
@@ -1937,10 +1937,10 @@ static int _ellipse_get_mask_roi(const dt_iop_module_t *const module,
   dt_free_align(points);
 
   dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
-           "[masks %s] ellipse fill took %0.04f sec\n",
+           "[masks %s] ellipse fill took %0.04f sec",
            form->name, dt_get_lap_time(&start2));
   dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
-           "[masks %s] ellipse total render took %0.04f sec\n", form->name,
+           "[masks %s] ellipse total render took %0.04f sec", form->name,
            dt_get_lap_time(&start1));
 
   return 1;

--- a/src/develop/masks/gradient.c
+++ b/src/develop/masks/gradient.c
@@ -1118,7 +1118,7 @@ static int _gradient_get_mask(const dt_iop_module_t *const module,
   if(!_gradient_get_area(module, piece, form, width, height, posx, posy)) return 0;
 
   dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
-           "[masks %s] gradient area took %0.04f sec\n", form->name,
+           "[masks %s] gradient area took %0.04f sec", form->name,
            dt_get_lap_time(&start2));
 
   // we get the gradient values
@@ -1146,7 +1146,7 @@ static int _gradient_get_mask(const dt_iop_module_t *const module,
     }
 
   dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
-           "[masks %s] gradient draw took %0.04f sec\n", form->name,
+           "[masks %s] gradient draw took %0.04f sec", form->name,
            dt_get_lap_time(&start2));
 
   // we backtransform all these points
@@ -1160,7 +1160,7 @@ static int _gradient_get_mask(const dt_iop_module_t *const module,
   }
 
   dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
-           "[masks %s] gradient transform took %0.04f sec\n", form->name,
+           "[masks %s] gradient transform took %0.04f sec", form->name,
            dt_get_lap_time(&start2));
 
   // we calculate the mask at grid points and recycle point buffer to store results
@@ -1255,7 +1255,7 @@ static int _gradient_get_mask(const dt_iop_module_t *const module,
   dt_free_align(points);
 
   dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
-           "[masks %s] gradient fill took %0.04f sec\n", form->name,
+           "[masks %s] gradient fill took %0.04f sec", form->name,
            dt_get_lap_time(&start2));
 
   return 1;
@@ -1298,7 +1298,7 @@ static int _gradient_get_mask_roi(const dt_iop_module_t *const module,
     }
 
   dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
-           "[masks %s] gradient draw took %0.04f sec\n", form->name,
+           "[masks %s] gradient draw took %0.04f sec", form->name,
            dt_get_lap_time(&start2));
 
   // we backtransform all these points
@@ -1312,7 +1312,7 @@ static int _gradient_get_mask_roi(const dt_iop_module_t *const module,
   }
 
   dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
-           "[masks %s] gradient transform took %0.04f sec\n", form->name,
+           "[masks %s] gradient transform took %0.04f sec", form->name,
            dt_get_lap_time(&start2));
 
   // we calculate the mask at grid points and recycle point buffer to store results
@@ -1402,7 +1402,7 @@ static int _gradient_get_mask_roi(const dt_iop_module_t *const module,
   dt_free_align(points);
 
   dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
-           "[masks %s] gradient fill took %0.04f sec\n", form->name,
+           "[masks %s] gradient fill took %0.04f sec", form->name,
            dt_get_lap_time(&start2));
 
   return 1;

--- a/src/develop/masks/group.c
+++ b/src/develop/masks/group.c
@@ -327,7 +327,7 @@ static int _group_get_mask(const dt_iop_module_t *const module,
         double start = dt_get_wtime();
         _inverse_mask(module, piece, sel, &bufs[pos], &w[pos], &h[pos], &px[pos], &py[pos]);
         dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
-                 "[masks %s] inverse took %0.04f sec\n",
+                 "[masks %s] inverse took %0.04f sec",
                  sel->name, dt_get_lap_time(&start));
       }
       op[pos] = fpt->opacity;
@@ -440,7 +440,7 @@ static int _group_get_mask(const dt_iop_module_t *const module,
     }
 
     dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
-             "[masks %d] combine took %0.04f sec\n",
+             "[masks %d] combine took %0.04f sec",
              i, dt_get_lap_time(&start));
   }
 
@@ -694,7 +694,7 @@ static int _group_get_mask_roi(const dt_iop_module_t *const restrict module,
         }
 
         dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
-                 "[masks %d] combine took %0.04f sec\n",
+                 "[masks %d] combine took %0.04f sec",
                  nb_ok, dt_get_lap_time(&start));
 
         nb_ok++;
@@ -731,7 +731,7 @@ int dt_masks_group_render_roi(dt_iop_module_t *module,
   const int ok = dt_masks_get_mask_roi(module, piece, form, roi, buffer);
 
   dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
-           "[masks] render all masks took %0.04f sec\n",
+           "[masks] render all masks took %0.04f sec",
            dt_get_lap_time(&start));
   return ok;
 }

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -251,7 +251,7 @@ void dt_masks_gui_form_test_create(dt_masks_form_t *form,
   {
     if(gui->pipe_hash != darktable.develop->preview_pipe->backbuf_hash)
     {
-      dt_print(DT_DEBUG_EXPOSE, "[dt_masks_gui_form_test_create] refreshes mask visualizer\n");
+      dt_print(DT_DEBUG_EXPOSE, "[dt_masks_gui_form_test_create] refreshes mask visualizer");
       gui->pipe_hash = 0;
       gui->formid = NO_MASKID;
       g_list_free_full(gui->points, dt_masks_form_gui_points_free);
@@ -981,7 +981,7 @@ void dt_masks_read_masks_history(dt_develop_t *dev, const dt_imgid_t imgid)
 
         dt_print(DT_DEBUG_ALWAYS,
                  "[_dev_read_masks_history] %s (imgid `%i'):"
-                 " mask version mismatch: history is %d, darktable is %d.\n",
+                 " mask version mismatch: history is %d, darktable is %d",
                  fname, imgid, form->version, dt_masks_version());
         dt_control_log(_("%s: mask version mismatch: %d != %d"),
                        fname, dt_masks_version(), form->version);
@@ -1013,7 +1013,7 @@ void dt_masks_read_masks_history(dt_develop_t *dev, const dt_imgid_t imgid)
     else
       dt_print(DT_DEBUG_ALWAYS,
                "[_dev_read_masks_history] can't find history entry %i"
-               " while adding mask %s(%i)\n",
+               " while adding mask %s(%i)",
                num, form->name, formid);
 
     if(num < dev->history_end) hist_item_last = hist_item;
@@ -2465,7 +2465,7 @@ void dt_masks_set_source_pos_initial_state(dt_masks_form_gui_t *gui,
     gui->source_pos_type = DT_MASKS_SOURCE_POS_RELATIVE_TEMP;
   else
     dt_print(DT_DEBUG_ALWAYS,
-             "[dt_masks_set_source_pos_initial_state] unknown state for setting masks position type\n");
+             "[dt_masks_set_source_pos_initial_state] unknown state for setting masks position type");
 
   // both source types record an absolute position, for the relative
   // type, the first time is used the position is recorded, the second

--- a/src/develop/masks/path.c
+++ b/src/develop/masks/path.c
@@ -1350,7 +1350,7 @@ static int _path_get_pts_border(dt_develop_t *dev,
   if(cw == 0) cw = -1;
 
   dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
-           "[masks %s] path_points init took %0.04f sec\n", form->name,
+           "[masks %s] path_points init took %0.04f sec", form->name,
            dt_get_lap_time(&start2));
 
   // we render all segments
@@ -1474,7 +1474,7 @@ static int _path_get_pts_border(dt_develop_t *dev,
   }
 
   dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
-           "[masks %s] path_points point recurs %0.04f sec\n",
+           "[masks %s] path_points point recurs %0.04f sec",
            form->name, dt_get_lap_time(&start2));
 
   // we don't want the border to self-intersect
@@ -1485,7 +1485,7 @@ static int _path_get_pts_border(dt_develop_t *dev,
     inter_count = _path_find_self_intersection(intersections, gap_fill_segs, nb, *border, *border_count);
 
     dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
-             "[masks %s] path_points self-intersect took %0.04f sec\n", form->name,
+             "[masks %s] path_points self-intersect took %0.04f sec", form->name,
              dt_get_lap_time(&start2));
   }
 
@@ -1525,7 +1525,7 @@ static int _path_get_pts_border(dt_develop_t *dev,
     }
 
     dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
-             "[masks %s] path_points end took %0.04f sec\n",
+             "[masks %s] path_points end took %0.04f sec",
              form->name, dt_get_lap_time(&start2));
 
     dt_masks_dynbuf_free(intersections);
@@ -1542,7 +1542,7 @@ static int _path_get_pts_border(dt_develop_t *dev,
                                         transf_direction, *border, *border_count))
     {
       dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
-               "[masks %s] path_points transform took %0.04f sec\n", form->name,
+               "[masks %s] path_points transform took %0.04f sec", form->name,
                dt_get_lap_time(&start2));
 
       if(border)
@@ -1580,7 +1580,7 @@ static int _path_get_pts_border(dt_develop_t *dev,
       }
 
       dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
-               "[masks %s] path_points end took %0.04f sec\n", form->name,
+               "[masks %s] path_points end took %0.04f sec", form->name,
                dt_get_lap_time(&start2));
 
       dt_masks_dynbuf_free(intersections);
@@ -3186,7 +3186,7 @@ static int _path_get_mask(const dt_iop_module_t *const module,
   }
 
   dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
-           "[masks %s] path points took %0.04f sec\n",
+           "[masks %s] path points took %0.04f sec",
            form->name, dt_get_lap_time(&start));
   start2 = start;
 
@@ -3199,7 +3199,7 @@ static int _path_get_mask(const dt_iop_module_t *const module,
   const int wb = *width;
 
   dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
-           "[masks %s] path_fill min max took %0.04f sec\n", form->name,
+           "[masks %s] path_fill min max took %0.04f sec", form->name,
            dt_get_lap_time(&start2));
 
   // we allocate the buffer
@@ -3321,7 +3321,7 @@ static int _path_get_mask(const dt_iop_module_t *const module,
     }
   }
   dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
-           "[masks %s] path_fill draw path took %0.04f sec\n", form->name,
+           "[masks %s] path_fill draw path took %0.04f sec", form->name,
            dt_get_lap_time(&start2));
 
   DT_OMP_FOR()
@@ -3337,7 +3337,7 @@ static int _path_get_mask(const dt_iop_module_t *const module,
   }
 
   dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
-           "[masks %s] path_fill fill plain took %0.04f sec\n", form->name,
+           "[masks %s] path_fill fill plain took %0.04f sec", form->name,
            dt_get_lap_time(&start2));
 
   // now we fill the falloff
@@ -3381,14 +3381,14 @@ static int _path_get_mask(const dt_iop_module_t *const module,
   }
 
   dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
-           "[masks %s] path_fill fill falloff took %0.04f sec\n", form->name,
+           "[masks %s] path_fill fill falloff took %0.04f sec", form->name,
            dt_get_lap_time(&start2));
 
   dt_free_align(points);
   dt_free_align(border);
 
   dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
-           "[masks %s] path fill buffer took %0.04f sec\n", form->name,
+           "[masks %s] path fill buffer took %0.04f sec", form->name,
            dt_get_lap_time(&start));
 
   return 1;
@@ -3630,7 +3630,7 @@ static int _path_get_mask_roi(const dt_iop_module_t *const module,
   }
 
   dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
-           "[masks %s] path points took %0.04f sec\n",
+           "[masks %s] path points took %0.04f sec",
            form->name, dt_get_lap_time(&start));
   start2 = start;
 
@@ -3731,11 +3731,11 @@ static int _path_get_mask_roi(const dt_iop_module_t *const module,
                          &xmin, &xmax, &ymin, &ymax);
 
   dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
-           "[masks %s] path_fill min max took %0.04f sec\n", form->name,
+           "[masks %s] path_fill min max took %0.04f sec", form->name,
            dt_get_lap_time(&start2));
 
   dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
-           "[masks %s] path_fill clear mask took %0.04f sec\n", form->name,
+           "[masks %s] path_fill clear mask took %0.04f sec", form->name,
            dt_get_lap_time(&start2));
 
   // deal with path if it does not lie outside of roi
@@ -3765,7 +3765,7 @@ static int _path_get_mask_roi(const dt_iop_module_t *const module,
     path_encircles_roi = path_encircles_roi || !crop_success;
 
     dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
-             "[masks %s] path_fill crop to roi took %0.04f sec\n", form->name,
+             "[masks %s] path_fill crop to roi took %0.04f sec", form->name,
              dt_get_lap_time(&start2));
 
     if(path_encircles_roi)
@@ -3822,7 +3822,7 @@ static int _path_get_mask_roi(const dt_iop_module_t *const module,
       }
 
       dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
-               "[masks %s] path_fill draw path took %0.04f sec\n", form->name,
+               "[masks %s] path_fill draw path took %0.04f sec", form->name,
                dt_get_lap_time(&start2));
 
       // we fill the inside plain
@@ -3846,7 +3846,7 @@ static int _path_get_mask_roi(const dt_iop_module_t *const module,
       }
 
       dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
-               "[masks %s] path_fill fill plain took %0.04f sec\n", form->name,
+               "[masks %s] path_fill fill plain took %0.04f sec", form->name,
                dt_get_lap_time(&start2));
     }
     dt_free_align(cpoints);
@@ -3922,7 +3922,7 @@ static int _path_get_mask_roi(const dt_iop_module_t *const module,
     dt_free_align(dpoints);
 
     dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
-             "[masks %s] path_fill fill falloff took %0.04f sec\n", form->name,
+             "[masks %s] path_fill fill falloff took %0.04f sec", form->name,
              dt_get_lap_time(&start2));
   }
 
@@ -3930,7 +3930,7 @@ static int _path_get_mask_roi(const dt_iop_module_t *const module,
   dt_free_align(border);
 
   dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
-           "[masks %s] path fill buffer took %0.04f sec\n", form->name,
+           "[masks %s] path fill buffer took %0.04f sec", form->name,
            dt_get_lap_time(&start));
 
   return 1;

--- a/src/develop/pixelpipe_cache.c
+++ b/src/develop/pixelpipe_cache.c
@@ -88,7 +88,7 @@ void dt_dev_pixelpipe_cache_cleanup(dt_dev_pixelpipe_t *pipe)
 
   if(pipe->type == DT_DEV_PIXELPIPE_FULL)
   {
-    dt_print(DT_DEBUG_PIPE, "Session fullpipe cache report. hits/run=%.2f, hits/test=%.3f\n",
+    dt_print(DT_DEBUG_PIPE, "Session fullpipe cache report. hits/run=%.2f, hits/test=%.3f",
     (double)(cache->hits) / fmax(1.0, pipe->runs),
     (double)(cache->hits) / fmax(1.0, cache->tests));
   }
@@ -259,7 +259,7 @@ static gboolean _get_by_hash(dt_dev_pixelpipe_t *pipe,
         */
         cache->hash[k] = INVALID_CACHEHASH;
         dt_print_pipe(DT_DEBUG_ALWAYS, "CACHELINE_SIZE ERROR",
-          pipe, module, DT_DEVICE_NONE, NULL, NULL, "\n");
+          pipe, module, DT_DEVICE_NONE, NULL, NULL);
       }
       else if(pipe->mask_display || pipe->nocache)
       {
@@ -301,7 +301,7 @@ gboolean dt_dev_pixelpipe_cache_get(dt_dev_pixelpipe_t *pipe,
     const dt_iop_buffer_dsc_t *cdsc = *dsc;
     dt_print_pipe(DT_DEBUG_PIPE, "cache HIT",
           pipe, module, DT_DEVICE_NONE, NULL, NULL,
-          "%s, hash=%" PRIx64 "\n",
+          "%s, hash=%" PRIx64,
           dt_iop_colorspace_to_name(cdsc->cst), hash);
     return FALSE;
   }
@@ -343,7 +343,7 @@ gboolean dt_dev_pixelpipe_cache_get(dt_dev_pixelpipe_t *pipe,
   const dt_iop_buffer_dsc_t *cdsc = *dsc;
   dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_VERBOSE, "pipe cache get",
     pipe, module, DT_DEVICE_NONE, NULL, NULL,
-    "%s %sline%3i(%2i) at %p. hash=%" PRIx64 "%s\n",
+    "%s %sline%3i(%2i) at %p. hash=%" PRIx64 "%s",
      dt_iop_colorspace_to_name(cdsc->cst),
      important ? "important " : "",
      cline, cache->used[cline], cache->data[cline], cache->hash[cline],
@@ -378,7 +378,7 @@ void dt_dev_pixelpipe_cache_invalidate_later(const dt_dev_pixelpipe_t *pipe,
     dt_print_pipe(DT_DEBUG_PIPE,
     order ? "pipecache invalidate" : "pipecache flush",
     pipe, NULL, DT_DEVICE_NONE, NULL, NULL,
-    "%i cachelines after ioporder=%i\n", invalidated, order);
+    "%i cachelines after ioporder=%i", invalidated, order);
 }
 
 void dt_dev_pixelpipe_cache_flush(const dt_dev_pixelpipe_t *pipe)
@@ -460,7 +460,7 @@ void dt_dev_pixelpipe_cache_checkmem(dt_dev_pixelpipe_t *pipe)
 
   _cline_stats(cache);
   dt_print_pipe(DT_DEBUG_PIPE, "pipe cache check", pipe, NULL, DT_DEVICE_NONE, NULL, NULL,
-    "%i lines (important=%i, used=%i). Freed %iMB. Using using %iMB, limit=%iMB\n",
+    "%i lines (important=%i, used=%i). Freed %iMB. Using using %iMB, limit=%iMB",
     cache->entries, cache->limportant, cache->lused,
     _to_mb(freed), _to_mb(cache->allmem), _to_mb(cache->memlimit));
 }
@@ -471,7 +471,7 @@ void dt_dev_pixelpipe_cache_report(dt_dev_pixelpipe_t *pipe)
 
   _cline_stats(cache);
   dt_print_pipe(DT_DEBUG_PIPE, "cache report", pipe, NULL, DT_DEVICE_NONE, NULL, NULL,
-    "%i lines (important=%i, used=%i, invalid=%i). Using %iMB, limit=%iMB. Hits/run=%.2f. Hits/test=%.3f\n",
+    "%i lines (important=%i, used=%i, invalid=%i). Using %iMB, limit=%iMB. Hits/run=%.2f. Hits/test=%.3f",
     cache->entries, cache->limportant, cache->lused, cache->linvalid,
     _to_mb(cache->allmem), _to_mb(cache->memlimit),
     (double)(cache->hits) / fmax(1.0, pipe->runs),

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -499,7 +499,7 @@ static void _dev_pixelpipe_synch(dt_dev_pixelpipe_t *pipe,
 
         dt_print_pipe(DT_DEBUG_PIPE, "pipe synch problem",
           pipe, piece->module, DT_DEVICE_NONE, NULL, NULL,
-          "piece enabling mismatch for image %i, piece hash=%" PRIx64 ", \n",
+          "piece enabling mismatch for image %i, piece hash=%" PRIx64,
           imgid, piece->hash);
       }
 
@@ -508,7 +508,7 @@ static void _dev_pixelpipe_synch(dt_dev_pixelpipe_t *pipe,
         piece->enabled = FALSE;
         dt_print_pipe(DT_DEBUG_PARAMS | DT_DEBUG_PIPE, "dt_dev_pixelpipe_synch",
           pipe, piece->module, DT_DEVICE_NONE, NULL, NULL,
-          "enabled module with iop_order of INT_MAX is disabled\n");
+          "enabled module with iop_order of INT_MAX is disabled");
       }
 
       // disable pieces if included in list
@@ -522,7 +522,7 @@ static void _dev_pixelpipe_synch(dt_dev_pixelpipe_t *pipe,
             piece->enabled = FALSE;
             dt_print_pipe(DT_DEBUG_PARAMS | DT_DEBUG_PIPE, "dt_dev_pixelpipe_synch",
               pipe, piece->module, DT_DEVICE_NONE, NULL, NULL,
-              "module is disabled because it's included in module_filter_out\n");
+              "module is disabled because it's included in module_filter_out");
           }
         }
       }
@@ -531,7 +531,7 @@ static void _dev_pixelpipe_synch(dt_dev_pixelpipe_t *pipe,
 
       dt_print_pipe(DT_DEBUG_PARAMS, "committed",
           pipe, piece->module, DT_DEVICE_NONE, NULL, NULL,
-          "%s order=%2i, piece hash=%" PRIx64 "\n",
+          "%s order=%2i, piece hash=%" PRIx64,
           piece->enabled ? "enabled " : "disabled",
           piece->module->iop_order,
           piece->hash);
@@ -556,7 +556,7 @@ void dt_dev_pixelpipe_synch_all(dt_dev_pixelpipe_t *pipe, dt_develop_t *dev)
 
   dev->cropping.exposer = NULL;
   dt_print_pipe(DT_DEBUG_PARAMS, "synch all module defaults",
-    pipe, NULL, DT_DEVICE_NONE, NULL, NULL, "\n");
+    pipe, NULL, DT_DEVICE_NONE, NULL, NULL);
 
   // call reset_params on all pieces first. This is mandatory to init
   // utility modules that don't have an history stack
@@ -573,7 +573,7 @@ void dt_dev_pixelpipe_synch_all(dt_dev_pixelpipe_t *pipe, dt_develop_t *dev)
   double defaults = dt_get_debug_wtime();
 
   dt_print_pipe(DT_DEBUG_PARAMS, "synch all module history",
-    pipe, NULL, DT_DEVICE_NONE, NULL, NULL, "\n");
+    pipe, NULL, DT_DEVICE_NONE, NULL, NULL);
 
   dt_dev_clear_scharr_mask(pipe);
   pipe->want_detail_mask = FALSE;
@@ -592,7 +592,7 @@ void dt_dev_pixelpipe_synch_all(dt_dev_pixelpipe_t *pipe, dt_develop_t *dev)
   dt_print_pipe(DT_DEBUG_PARAMS,
            "synch all modules done",
            pipe, NULL, DT_DEVICE_NONE, NULL, NULL,
-           "defaults %.4fs, history %.4fs\n",
+           "defaults %.4fs, history %.4fs",
            defaults - start, dt_get_wtime() - defaults);
   dt_pthread_mutex_unlock(&pipe->busy_mutex);
 }
@@ -605,13 +605,13 @@ void dt_dev_pixelpipe_synch_top(dt_dev_pixelpipe_t *pipe, dt_develop_t *dev)
   {
     dt_dev_history_item_t *hist = history->data;
     dt_print_pipe(DT_DEBUG_PARAMS, "synch top history module",
-      pipe, hist->module, DT_DEVICE_NONE, NULL, NULL, "\n");
+      pipe, hist->module, DT_DEVICE_NONE, NULL, NULL);
     _dev_pixelpipe_synch(pipe, dev, history);
   }
   else
   {
     dt_print_pipe(DT_DEBUG_PARAMS, "synch top history module missing!",
-      pipe, NULL, DT_DEVICE_NONE, NULL, NULL, "\n");
+      pipe, NULL, DT_DEVICE_NONE, NULL, NULL);
   }
   dt_pthread_mutex_unlock(&pipe->busy_mutex);
 }
@@ -621,7 +621,7 @@ void dt_dev_pixelpipe_change(dt_dev_pixelpipe_t *pipe, struct dt_develop_t *dev)
   dt_pthread_mutex_lock(&dev->history_mutex);
 
   dt_print_pipe(DT_DEBUG_PIPE, "pipe state changing",
-      pipe, NULL, DT_DEVICE_NONE, NULL, NULL, "%s%s%s%s\n",
+      pipe, NULL, DT_DEVICE_NONE, NULL, NULL, "%s%s%s%s",
       pipe->changed & DT_DEV_PIPE_ZOOMED      ? "zoomed, " : "",
       pipe->changed & DT_DEV_PIPE_TOP_CHANGED ? "top changed, " : "",
       pipe->changed & DT_DEV_PIPE_SYNCH       ? "synch all, " : "",
@@ -839,7 +839,7 @@ static void _pixelpipe_picker(dt_iop_module_t *module,
 
     dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_PICKER,
       picker_source == PIXELPIPE_PICKER_INPUT ? "pixelpipe IN picker" : "pixelpipe OUT picker",
-      piece->pipe, module, DT_DEVICE_CPU, roi, NULL, " %s -> %s, %sbox %i/%i -- %i/%i\n",
+      piece->pipe, module, DT_DEVICE_CPU, roi, NULL, " %s -> %s, %sbox %i/%i -- %i/%i",
       dt_iop_colorspace_to_name(image_cst),
       dt_iop_colorspace_to_name(dt_iop_color_picker_get_active_cst(module)),
       darktable.lib->proxy.colorpicker.primary_sample->denoise ? "denoised " : "",
@@ -926,7 +926,7 @@ static void _pixelpipe_picker_cl(const int devid,
 
   dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_PICKER,
     picker_source == PIXELPIPE_PICKER_INPUT ? "pixelpipe IN picker CL" : "pixelpipe OUT picker CL",
-    piece->pipe, module, devid, roi, NULL, " %s -> %s, %sbox %i/%i -- %i/%i\n",
+    piece->pipe, module, devid, roi, NULL, " %s -> %s, %sbox %i/%i -- %i/%i",
     dt_iop_colorspace_to_name(image_cst),
     dt_iop_colorspace_to_name(dt_iop_color_picker_get_active_cst(module)),
     darktable.lib->proxy.colorpicker.primary_sample->denoise ? "denoised " : "",
@@ -999,7 +999,7 @@ static void _pixelpipe_pick_samples(dt_develop_t *dev,
     {
       // pixel input is in display profile, hence the sample output will be as well
       dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_PICKER, "pixelpipe pick samples",
-        NULL, module, DT_DEVICE_NONE, roi_in, NULL, " %sbox %i/%i -- %i/%i\n",
+        NULL, module, DT_DEVICE_NONE, roi_in, NULL, " %sbox %i/%i -- %i/%i",
         darktable.lib->proxy.colorpicker.primary_sample->denoise ? "denoised " : "",
         box[0], box[1], box[2], box[3]);
 
@@ -1112,7 +1112,7 @@ static gboolean _pixelpipe_process_on_CPU(
     dt_print_pipe(DT_DEBUG_ALWAYS,
         "fatal process alignment",
         piece->pipe, module, DT_DEVICE_NONE, roi_in, roi_out,
-        "non-aligned buffers IN=%p OUT=%p\n",
+        "non-aligned buffers IN=%p OUT=%p",
         input, *output);
 
     dt_control_log(_("fatal pixelpipe abort due to non-aligned buffers\n"
@@ -1138,7 +1138,7 @@ static gboolean _pixelpipe_process_on_CPU(
   if(cst_from != cst_to)
     dt_print_pipe(DT_DEBUG_PIPE,
            "transform colorspace",
-           piece->pipe, module, DT_DEVICE_CPU, roi_in, NULL, " %s -> %s `%s'\n",
+           piece->pipe, module, DT_DEVICE_CPU, roi_in, NULL, " %s -> %s `%s'",
            dt_iop_colorspace_to_name(cst_from),
            dt_iop_colorspace_to_name(cst_to),
            work_profile ? dt_colorspaces_get_name(work_profile->type, work_profile->filename) : "no work profile");
@@ -1176,7 +1176,7 @@ static gboolean _pixelpipe_process_on_CPU(
   if(!fitting && piece->process_tiling_ready)
   {
     dt_print_pipe(DT_DEBUG_PIPE,
-                  "process tiled", piece->pipe, module, DT_DEVICE_CPU, roi_in, roi_out, "\n");
+                  "process tiled", piece->pipe, module, DT_DEVICE_CPU, roi_in, roi_out);
     module->process_tiling(module, piece, input, *output, roi_in, roi_out, in_bpp);
 
     *pixelpipe_flow |= (PIXELPIPE_FLOW_PROCESSED_ON_CPU
@@ -1187,7 +1187,7 @@ static gboolean _pixelpipe_process_on_CPU(
   {
     dt_print_pipe(DT_DEBUG_PIPE,
        "process",
-       piece->pipe, module, DT_DEVICE_CPU, roi_in, roi_out, "%3i %s%s%s%s %.fMB\n",
+       piece->pipe, module, DT_DEVICE_CPU, roi_in, roi_out, "%3i %s%s%s%s %.fMB",
        piece->module->iop_order,
        dt_iop_colorspace_to_name(cst_to),
        cst_to != cst_out ? " -> " : "",
@@ -1219,7 +1219,7 @@ static gboolean _pixelpipe_process_on_CPU(
           dt_get_times(&end);
           const float clock = (end.clock - start.clock) / (float) counter;
           dt_print(DT_DEBUG_ALWAYS,
-                   "[bench module %s plain] `%s' takes %8.5fs,%7.2fmpix,%9.3fpix/us\n",
+                   "[bench module %s plain] `%s' takes %8.5fs,%7.2fmpix,%9.3fpix/us",
                    full ? "full" : "export", module->op, clock, mpix, mpix/clock);
         }
         darktable.unmuted = old_muted;
@@ -1367,7 +1367,7 @@ static gboolean _dev_pixelpipe_process_rec(
   if(old_pipetype != pipe->type)
     dt_print_pipe(DT_DEBUG_PIPE,
       pipe->type & DT_DEV_PIXELPIPE_FAST ? "enable fast pipe" : "disable fast pipe",
-      pipe, gui_module, DT_DEVICE_NONE, NULL, NULL, "\n");
+      pipe, gui_module, DT_DEVICE_NONE, NULL, NULL);
 
   if(modules)
   {
@@ -1417,7 +1417,7 @@ static gboolean _dev_pixelpipe_process_rec(
       return TRUE;
 
     dt_print_pipe(DT_DEBUG_PIPE,
-        "pipe data: from cache", pipe, module, DT_DEVICE_NONE, &roi_in, NULL, "\n");
+        "pipe data: from cache", pipe, module, DT_DEVICE_NONE, &roi_in, NULL);
     // we're done! as colorpicker/scopes only work on gamma iop
     // input -- which is unavailable via cache -- there's no need to
     // run these
@@ -1453,7 +1453,7 @@ static gboolean _dev_pixelpipe_process_rec(
     {
       *output = pipe->input;
       dt_print_pipe(DT_DEBUG_PIPE,
-          "pipe data: full", pipe, module, DT_DEVICE_NONE, &roi_in, roi_out, "\n");
+          "pipe data: full", pipe, module, DT_DEVICE_NONE, &roi_in, roi_out);
     }
     else if(dt_dev_pixelpipe_cache_get(pipe, hash, bufsize,
                                        output, out_format, NULL, FALSE))
@@ -1470,7 +1470,7 @@ static gboolean _dev_pixelpipe_process_rec(
 
         dt_print_pipe(DT_DEBUG_PIPE,
           (cp_width > 0) ? "pixelpipe data 1:1 copied" : "pixelpipe data 1:1 none",
-          pipe, module, DT_DEVICE_NONE, &roi_in, roi_out, "%sbpp=%lu\n",
+          pipe, module, DT_DEVICE_NONE, &roi_in, roi_out, "%sbpp=%lu",
           aligned_input ? "" : "non-aligned input ",
           bpp);
         if(cp_width > 0)
@@ -1491,7 +1491,7 @@ static gboolean _dev_pixelpipe_process_rec(
         roi_in.scale = 1.0f;
         const gboolean valid_bpp = (bpp == 4 * sizeof(float));
         dt_print_pipe(DT_DEBUG_PIPE,
-          "pipe data: clip&zoom", pipe, module, DT_DEVICE_CPU, &roi_in, roi_out, "%s%s\n",
+          "pipe data: clip&zoom", pipe, module, DT_DEVICE_CPU, &roi_in, roi_out, "%s%s",
           valid_bpp ? "" : "requires 4 floats data",
           aligned_input ? "" : "non-aligned input buffer");
         if(valid_bpp && aligned_input)
@@ -1504,14 +1504,14 @@ static gboolean _dev_pixelpipe_process_rec(
             dt_print_pipe(DT_DEBUG_ALWAYS,
               "fatal input misalignment",
               pipe, NULL, DT_DEVICE_NONE, &roi_in, roi_out,
-              "non-aligned IN=%p\n", pipe->input);
+              "non-aligned IN=%p", pipe->input);
             dt_control_log(_("fatal input misalignment, please report on GitHub\n"));
           }
           if(!valid_bpp)
             dt_print_pipe(DT_DEBUG_ALWAYS,
               "invalid input bpp",
               pipe, NULL, DT_DEVICE_NONE, &roi_in, roi_out,
-              "bpp=%d\n", (int)bpp);
+              "bpp=%d", (int)bpp);
         }
       }
     }
@@ -1531,7 +1531,7 @@ static gboolean _dev_pixelpipe_process_rec(
   module->modify_roi_in(module, piece, roi_out, &roi_in);
   if((darktable.unmuted & DT_DEBUG_PIPE) && memcmp(roi_out, &roi_in, sizeof(dt_iop_roi_t)))
     dt_print_pipe(DT_DEBUG_PIPE,
-                  "modify roi IN", piece->pipe, module, DT_DEVICE_NONE, roi_out, &roi_in, "ID=%i\n",
+                  "modify roi IN", piece->pipe, module, DT_DEVICE_NONE, roi_out, &roi_in, "ID=%i",
                   pipe->image.id);
   // recurse to get actual data of input buffer
 
@@ -1594,7 +1594,7 @@ static gboolean _dev_pixelpipe_process_rec(
      && !memcmp(&roi_in, roi_out, sizeof(struct dt_iop_roi_t)))
   {
     dt_print_pipe(DT_DEBUG_PIPE,
-                    "pipe bypass", pipe, module, DT_DEVICE_NONE, &roi_in, roi_out, "\n");
+                    "pipe bypass", pipe, module, DT_DEVICE_NONE, &roi_in, roi_out);
     // since we're not actually running the module, the output format
     // is the same as the input format
     **out_format = pipe->dsc = piece->dsc_out = piece->dsc_in;
@@ -1712,7 +1712,7 @@ static gboolean _dev_pixelpipe_process_rec(
         {
           dt_print(DT_DEBUG_OPENCL | DT_DEBUG_TILING,
                    "[dt_dev_pixelpipetiling_cl] [%s] estimates cpu"
-                   " advantage in `%s', (dev=%i, adv=%.2f, GPU %.2f CPU %.2f)\n",
+                   " advantage in `%s', (dev=%i, adv=%.2f, GPU %.2f CPU %.2f)",
                    dt_dev_pixelpipe_type_to_str(pipe->type), module->op, pipe->devid,
                    advantage, tilemem_cl / 1e9, tilemem_cpu / 1e9);
           possible_cl = FALSE;
@@ -1738,7 +1738,7 @@ static gboolean _dev_pixelpipe_process_rec(
           {
             dt_print_pipe(DT_DEBUG_OPENCL | DT_DEBUG_PIPE,
               "no input cl_mem",
-              piece->pipe, module, pipe->devid, &roi_in, roi_out, "\n");
+              piece->pipe, module, pipe->devid, &roi_in, roi_out);
             success_opencl = FALSE;
           }
 
@@ -1748,7 +1748,7 @@ static gboolean _dev_pixelpipe_process_rec(
                                               roi_in.width, roi_in.height, in_bpp) != CL_SUCCESS)
             {
               dt_print_pipe(DT_DEBUG_OPENCL,
-                "process", pipe, module, pipe->devid, &roi_in, roi_out, "%s\n",
+                "process", pipe, module, pipe->devid, &roi_in, roi_out, "%s",
                   "couldn't copy image to OpenCL device");
               success_opencl = FALSE;
             }
@@ -1770,7 +1770,7 @@ static gboolean _dev_pixelpipe_process_rec(
           {
             dt_print_pipe(DT_DEBUG_OPENCL | DT_DEBUG_PIPE,
               "no output cl_mem",
-              piece->pipe, module, pipe->devid, &roi_in, roi_out, "\n");
+              piece->pipe, module, pipe->devid, &roi_in, roi_out);
             success_opencl = FALSE;
           }
         }
@@ -1783,7 +1783,7 @@ static gboolean _dev_pixelpipe_process_rec(
         {
           if(cst_from != cst_to)
             dt_print_pipe(DT_DEBUG_PIPE,
-               "transform colorspace", piece->pipe, module, pipe->devid, &roi_in, NULL, " %s -> %s `%s'\n",
+               "transform colorspace", piece->pipe, module, pipe->devid, &roi_in, NULL, " %s -> %s `%s'",
                dt_iop_colorspace_to_name(cst_from),
                dt_iop_colorspace_to_name(cst_to),
                work_profile ? dt_colorspaces_get_name(work_profile->type, work_profile->filename) : "no work profile");
@@ -1839,7 +1839,7 @@ static gboolean _dev_pixelpipe_process_rec(
         {
           dt_print_pipe(DT_DEBUG_PIPE,
                         "process",
-                        piece->pipe, module, pipe->devid, &roi_in, roi_out, "%3i %s%s%s %.1fMB\n",
+                        piece->pipe, module, pipe->devid, &roi_in, roi_out, "%3i %s%s%s %.1fMB",
                         module->iop_order,
                         dt_iop_colorspace_to_name(cst_to),
                         cst_to != cst_out ? " -> " : "",
@@ -1872,14 +1872,14 @@ static gboolean _dev_pixelpipe_process_rec(
                 dt_get_times(&end);
                 const float clock = (end.clock - bench.clock) / (float)counter;
                 dt_print(DT_DEBUG_ALWAYS,
-                         "[bench module %s GPU] `%s' takes %8.5fs,%7.2fmpix,%9.3fpix/us\n",
+                         "[bench module %s GPU] `%s' takes %8.5fs,%7.2fmpix,%9.3fpix/us",
                          full ? "full" : "export",
                          module->op,
                          clock, mpix, mpix/clock);
               }
               else
                 dt_print(DT_DEBUG_ALWAYS,
-                         "[bench module %s GPU] `%s' finished without success\n",
+                         "[bench module %s GPU] `%s' finished without success",
                          full ? "full" : "export", module->op);
               darktable.unmuted = old_muted;
             }
@@ -1899,7 +1899,7 @@ static gboolean _dev_pixelpipe_process_rec(
           if(!success_opencl)
             dt_print_pipe(DT_DEBUG_OPENCL,
               "Error: process", piece->pipe, module, pipe->devid, &roi_in, roi_out,
-              "device=%i (%s), %s\n",
+              "device=%i (%s), %s",
               pipe->devid, darktable.opencl->dev[pipe->devid].cname, cl_errstr(err));
 
           if(success_opencl)
@@ -2054,7 +2054,7 @@ static gboolean _dev_pixelpipe_process_rec(
                                                            in_bpp) != CL_SUCCESS)
           {
             dt_print_pipe(DT_DEBUG_OPENCL,
-              "process", pipe, module, pipe->devid, &roi_in, roi_out, "%s\n",
+              "process", pipe, module, pipe->devid, &roi_in, roi_out, "%s",
                 "couldn't copy data back to host memory (A)");
             dt_opencl_release_mem_object(cl_mem_input);
             pipe->opencl_error = TRUE;
@@ -2078,7 +2078,7 @@ static gboolean _dev_pixelpipe_process_rec(
         {
           if(cst_from != cst_to)
             dt_print_pipe(DT_DEBUG_PIPE,
-               "transform colorspace", piece->pipe, module, pipe->devid, &roi_in, NULL, " %s -> %s\n",
+               "transform colorspace", piece->pipe, module, pipe->devid, &roi_in, NULL, " %s -> %s",
                dt_iop_colorspace_to_name(cst_from),
                dt_iop_colorspace_to_name(cst_to));
           dt_ioppr_transform_image_colorspace
@@ -2106,7 +2106,7 @@ static gboolean _dev_pixelpipe_process_rec(
         {
           dt_print_pipe(DT_DEBUG_PIPE,
                         "process tiled",
-                        piece->pipe, module, pipe->devid, &roi_in, roi_out, "%3i %s%s%s\n",
+                        piece->pipe, module, pipe->devid, &roi_in, roi_out, "%3i %s%s%s",
                         module->iop_order,
                         dt_iop_colorspace_to_name(cst_to),
                         cst_to != cst_out ? " -> " : "",
@@ -2118,7 +2118,7 @@ static gboolean _dev_pixelpipe_process_rec(
           if(!success_opencl)
             dt_print_pipe(DT_DEBUG_OPENCL,
               "Error: process_tiling", piece->pipe, module, pipe->devid, &roi_in, roi_out,
-              "device=%i (%s), %s\n",
+              "device=%i (%s), %s",
               pipe->devid, darktable.opencl->dev[pipe->devid].cname, cl_errstr(err));
 
           pixelpipe_flow |= (PIXELPIPE_FLOW_PROCESSED_ON_GPU
@@ -2259,7 +2259,7 @@ static gboolean _dev_pixelpipe_process_rec(
             {
               important_cl = FALSE;
               dt_print_pipe(DT_DEBUG_OPENCL,
-                "process", pipe, module, pipe->devid, &roi_in, roi_out, "%s\n",
+                "process", pipe, module, pipe->devid, &roi_in, roi_out, "%s",
                   "couldn't copy important data back to host memory (B)");
               /* late opencl error, not likely to happen here */
               /* that's all we do here, we later make sure to invalidate cache line */
@@ -2267,7 +2267,7 @@ static gboolean _dev_pixelpipe_process_rec(
             else
             {
               dt_print_pipe(DT_DEBUG_PIPE,
-                "copy CL data to host", pipe, module, pipe->devid, &roi_in, NULL, "\n");
+                "copy CL data to host", pipe, module, pipe->devid, &roi_in, NULL);
               /* success: cache line is valid now, so we will not need
                  to invalidate it later */
               valid_input_on_gpu_only = FALSE;
@@ -2297,7 +2297,7 @@ static gboolean _dev_pixelpipe_process_rec(
       {
         /* Bad luck, opencl failed. Let's clean up and fall back to cpu module */
         dt_print_pipe(DT_DEBUG_OPENCL,
-           "pipe aborts", pipe, module, pipe->devid, &roi_in, roi_out, "%s\n",
+           "pipe aborts", pipe, module, pipe->devid, &roi_in, roi_out, "%s",
                 "couldn't run module on GPU, falling back to CPU");
 
         /* we might need to free unused output buffer */
@@ -2315,7 +2315,7 @@ static gboolean _dev_pixelpipe_process_rec(
                                            in_bpp) != CL_SUCCESS)
           {
             dt_print_pipe(DT_DEBUG_OPENCL,
-              "process", pipe, module, pipe->devid, &roi_in, roi_out, "%s\n",
+              "process", pipe, module, pipe->devid, &roi_in, roi_out, "%s",
                 "couldn't copy data back to host memory (C)");
             dt_opencl_release_mem_object(cl_mem_input);
             pipe->opencl_error = TRUE;
@@ -2352,7 +2352,7 @@ static gboolean _dev_pixelpipe_process_rec(
                                          in_bpp) != CL_SUCCESS)
         {
           dt_print_pipe(DT_DEBUG_OPENCL,
-            "process", pipe, module, pipe->devid, &roi_in, roi_out, "%s\n",
+            "process", pipe, module, pipe->devid, &roi_in, roi_out, "%s",
               "couldn't copy data back to host memory (D)");
           dt_opencl_release_mem_object(cl_mem_input);
           pipe->opencl_error = TRUE;
@@ -2440,7 +2440,7 @@ static gboolean _dev_pixelpipe_process_rec(
         && (has_focus || darktable.develop->history_last_module == module || important_cl))
     {
       dt_print_pipe(DT_DEBUG_PIPE,
-        "importance hints", pipe, module, pipe->devid, &roi_in, NULL, " %s%s%s\n",
+        "importance hints", pipe, module, pipe->devid, &roi_in, NULL, " %s%s%s",
         darktable.develop->history_last_module == module ? "input_hint " : "",
         has_focus ? "focus " : "",
         important_cl ? "cldata" : "");
@@ -2454,7 +2454,7 @@ static gboolean _dev_pixelpipe_process_rec(
        && (pipe->type & DT_DEV_PIXELPIPE_BASIC)
        && (module->request_histogram & DT_REQUEST_EXPANDED))
     {
-      dt_print_pipe(DT_DEBUG_PIPE, "internal histogram", pipe, module, DT_DEVICE_NONE, &roi_in, roi_out, "\n");
+      dt_print_pipe(DT_DEBUG_PIPE, "internal histogram", pipe, module, DT_DEVICE_NONE, &roi_in, roi_out);
       pipe->nocache = TRUE;
       dt_dev_pixelpipe_invalidate_cacheline(pipe, *output);
     }
@@ -2498,15 +2498,15 @@ static gboolean _dev_pixelpipe_process_rec(
       }
       if(hasnan)
         dt_print(DT_DEBUG_ALWAYS,
-                 "[dev_pixelpipe] module `%s%s' outputs NaNs! [%s]\n", module->op, dt_iop_get_instance_id(module),
+                 "[dev_pixelpipe] module `%s%s' outputs NaNs! [%s]", module->op, dt_iop_get_instance_id(module),
                  dt_dev_pixelpipe_type_to_str(pipe->type));
       if(hasinf)
         dt_print(DT_DEBUG_ALWAYS,
-                 "[dev_pixelpipe] module `%s%s' outputs non-finite floats! [%s]\n",
+                 "[dev_pixelpipe] module `%s%s' outputs non-finite floats! [%s]",
                  module->op, dt_iop_get_instance_id(module),
                  dt_dev_pixelpipe_type_to_str(pipe->type));
       dt_print(DT_DEBUG_ALWAYS,
-               "[dev_pixelpipe] module `%s%s' min: (%f; %f; %f) max: (%f; %f; %f) [%s]\n",
+               "[dev_pixelpipe] module `%s%s' min: (%f; %f; %f) max: (%f; %f; %f) [%s]",
                 module->op, dt_iop_get_instance_id(module),
                 min[0], min[1], min[2], max[0], max[1], max[2],
                 dt_dev_pixelpipe_type_to_str(pipe->type));
@@ -2533,16 +2533,16 @@ static gboolean _dev_pixelpipe_process_rec(
 
       if(hasnan)
         dt_print(DT_DEBUG_ALWAYS,
-                 "[dev_pixelpipe] module `%s%s' outputs NaNs! [%s]\n",
+                 "[dev_pixelpipe] module `%s%s' outputs NaNs! [%s]",
                  module->op, dt_iop_get_instance_id(module),
                  dt_dev_pixelpipe_type_to_str(pipe->type));
       if(hasinf)
         dt_print(DT_DEBUG_ALWAYS,
-                 "[dev_pixelpipe] module `%s%s' outputs non-finite floats! [%s]\n",
+                 "[dev_pixelpipe] module `%s%s' outputs non-finite floats! [%s]",
                  module->op, dt_iop_get_instance_id(module),
                  dt_dev_pixelpipe_type_to_str(pipe->type));
       dt_print(DT_DEBUG_ALWAYS,
-               "[dev_pixelpipe] module `%s%s' min: (%f) max: (%f) [%s]\n",
+               "[dev_pixelpipe] module `%s%s' min: (%f) max: (%f) [%s]",
                module->op, dt_iop_get_instance_id(module), min, max,
                dt_dev_pixelpipe_type_to_str(pipe->type));
     }
@@ -2680,7 +2680,7 @@ static gboolean _dev_pixelpipe_process_rec_and_backcopy(
         /* this indicates a opencl problem earlier in the pipeline */
         dt_print_pipe(DT_DEBUG_OPENCL,
             "process", pipe, NULL, pipe->devid, NULL, roi_out,
-            "late opencl error detected while copying back to cpu buffer:%s\n", cl_errstr(err));
+            "late opencl error detected while copying back to cpu buffer:%s", cl_errstr(err));
         pipe->opencl_error = TRUE;
         ret = TRUE;
       }
@@ -2713,7 +2713,7 @@ gboolean dt_dev_pixelpipe_process(
   if(!claimed)  // don't free cachelines as the caller is using them
     dt_dev_pixelpipe_cache_checkmem(pipe);
 
-  dt_print(DT_DEBUG_MEMORY, "[memory] before pixelpipe process\n");
+  dt_print(DT_DEBUG_MEMORY, "[memory] before pixelpipe process");
   dt_print_mem_usage();
 
   if(pipe->devid > DT_DEVICE_CPU) dt_opencl_events_reset(pipe->devid);
@@ -2754,12 +2754,12 @@ restart:
 
 #ifdef HAVE_OPENCL
   if(pipe->devid > DT_DEVICE_CPU)
-    dt_print_pipe(DT_DEBUG_PIPE, "pipe starting", pipe, NULL, pipe->devid, &roi, &roi, "ID=%i, %s\n",
+    dt_print_pipe(DT_DEBUG_PIPE, "pipe starting", pipe, NULL, pipe->devid, &roi, &roi, "ID=%i, %s",
       pipe->image.id,
       darktable.opencl->dev[pipe->devid].cname);
   else
 #endif
-    dt_print_pipe(DT_DEBUG_PIPE, "pipe starting", pipe, NULL, pipe->devid, &roi, &roi, "ID=%i\n",
+    dt_print_pipe(DT_DEBUG_PIPE, "pipe starting", pipe, NULL, pipe->devid, &roi, &roi, "ID=%i",
       pipe->image.id);
 
   // run pixelpipe recursively and get error status
@@ -2815,7 +2815,7 @@ restart:
     dt_dev_pixelpipe_change(pipe, dev);
 
     dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_OPENCL,
-      "pipe restarting on CPU", pipe, NULL, old_devid, &roi, &roi, "ID=%i\n",
+      "pipe restarting on CPU", pipe, NULL, old_devid, &roi, &roi, "ID=%i",
       pipe->image.id);
 
     goto restart; // try again (this time without opencl)
@@ -2874,7 +2874,7 @@ restart:
   if(!claimed)
     dt_dev_pixelpipe_cache_report(pipe);
 
-  dt_print_pipe(DT_DEBUG_PIPE, "pipe finished", pipe, NULL, old_devid, &roi, &roi, "ID=%i\n\n",
+  dt_print_pipe(DT_DEBUG_PIPE, "pipe finished", pipe, NULL, old_devid, &roi, &roi, "ID=%i\n",
     pipe->image.id);
 
   pipe->processing = FALSE;
@@ -2906,7 +2906,7 @@ void dt_dev_pixelpipe_get_dimensions(dt_dev_pixelpipe_t *pipe,
       module->modify_roi_out(module, piece, &roi_out, &roi_in);
       if((darktable.unmuted & DT_DEBUG_PIPE) && memcmp(&roi_out, &roi_in, sizeof(dt_iop_roi_t)))
       dt_print_pipe(DT_DEBUG_PIPE,
-                  "modify roi OUT", piece->pipe, module, DT_DEVICE_NONE, &roi_in, &roi_out, "ID=%i\n",
+                  "modify roi OUT", piece->pipe, module, DT_DEVICE_NONE, &roi_in, &roi_out, "ID=%i",
                   pipe->image.id);
     }
     else
@@ -2949,7 +2949,7 @@ float *dt_dev_get_raster_mask(dt_dev_pixelpipe_iop_t *piece,
   {
     dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_MASKS,
       "get raster mask", piece->pipe, target_module, DT_DEVICE_NONE, NULL, NULL,
-      "no raster mask source provided\n");
+      "no raster mask source provided");
     return NULL;
   }
 
@@ -2974,7 +2974,7 @@ float *dt_dev_get_raster_mask(dt_dev_pixelpipe_iop_t *piece,
 
       dt_print(DT_DEBUG_ALWAYS,
                "module `%s%s' can't get raster mask id=%i from module `%s%s'"
-               " as that is processed later in the pixel pipe\n",
+               " as that is processed later in the pixel pipe",
                target_module->op, dt_iop_get_instance_id(target_module),
                raster_mask_id,
                raster_mask_source->op, dt_iop_get_instance_id(raster_mask_source));
@@ -3002,7 +3002,7 @@ float *dt_dev_get_raster_mask(dt_dev_pixelpipe_iop_t *piece,
       const gboolean deleted = g_hash_table_remove(source_piece->raster_masks, GINT_TO_POINTER(BLEND_RASTER_ID));
       dt_print_pipe(DT_DEBUG_PIPE,
          "no raster mask", piece->pipe, piece->module, DT_DEVICE_NONE, NULL, NULL,
-         "as source module `%s%s' is disabled%s\n",
+         "as source module `%s%s' is disabled%s",
          raster_mask_source->op, dt_iop_get_instance_id(raster_mask_source),
          deleted ? ", stale mask deleted" : "");
       return NULL;
@@ -3012,7 +3012,7 @@ float *dt_dev_get_raster_mask(dt_dev_pixelpipe_iop_t *piece,
       const gboolean deleted = g_hash_table_remove(source_piece->raster_masks, GINT_TO_POINTER(BLEND_RASTER_ID));
       dt_print_pipe(DT_DEBUG_PIPE,
          "no raster mask", piece->pipe, piece->module, DT_DEVICE_NONE, NULL, NULL,
-         "as source module `%s%s' does not write raster masks%s\n",
+         "as source module `%s%s' does not write raster masks%s",
          raster_mask_source->op, dt_iop_get_instance_id(raster_mask_source),
          deleted ? ", stale mask deleted" : "");
       return NULL;
@@ -3025,7 +3025,7 @@ float *dt_dev_get_raster_mask(dt_dev_pixelpipe_iop_t *piece,
       {
         dt_print_pipe(DT_DEBUG_PIPE,
           "no raster mask found", piece->pipe, piece->module, DT_DEVICE_NONE, NULL, NULL,
-          "raster mask seems to be lost in module `%s%s'\n",
+          "raster mask seems to be lost in module `%s%s'",
           raster_mask_source->op, dt_iop_get_instance_id(raster_mask_source));
         return NULL;
       }
@@ -3051,7 +3051,7 @@ float *dt_dev_get_raster_mask(dt_dev_pixelpipe_iop_t *piece,
                 dt_print_pipe(DT_DEBUG_MASKS | DT_DEBUG_PIPE | DT_DEBUG_VERBOSE,
                   "distort raster mask",
                   piece->pipe, it_piece->module, DT_DEVICE_NONE,
-                  &it_piece->processed_roi_in, &it_piece->processed_roi_out, "\n");
+                  &it_piece->processed_roi_in, &it_piece->processed_roi_out);
                 it_piece->module->distort_mask(it_piece->module,
                                              it_piece,
                                              raster_mask,
@@ -3076,7 +3076,7 @@ float *dt_dev_get_raster_mask(dt_dev_pixelpipe_iop_t *piece,
                       "no distort raster mask",
                       piece->pipe, it_piece->module, DT_DEVICE_NONE,
                       &it_piece->processed_roi_in, &it_piece->processed_roi_out,
-                      "skipped transforming mask due to lack of memory\n");
+                      "skipped transforming mask due to lack of memory");
                 return NULL;
               }
             }
@@ -3090,7 +3090,7 @@ float *dt_dev_get_raster_mask(dt_dev_pixelpipe_iop_t *piece,
                       "distort raster mask",
                       piece->pipe, it_piece->module, DT_DEVICE_NONE,
                       &it_piece->processed_roi_in, &it_piece->processed_roi_out,
-                      "misses distort_mask() function\n");
+                      "misses distort_mask() function");
               return NULL;
             }
           }
@@ -3109,7 +3109,7 @@ float *dt_dev_get_raster_mask(dt_dev_pixelpipe_iop_t *piece,
   dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_MASKS,
                 correct ? "got raster mask" : "RASTER SIZE MISMATCH",
                  piece->pipe, target_module, DT_DEVICE_NONE, NULL, NULL,
-                "from module `%s%s'%s at %p (%ix%i) %sdistorted to %p (%ix%i)\n",
+                "from module `%s%s'%s at %p (%ix%i) %sdistorted to %p (%ix%i)",
                 raster_mask_source->op, dt_iop_get_instance_id(raster_mask_source),
                 *free_mask ? ", free mask" : "",
                 provided_raster_mask,
@@ -3162,7 +3162,7 @@ gboolean dt_dev_write_scharr_mask(dt_dev_pixelpipe_iop_t *piece,
 
   p->scharr.hash = dt_hash(DT_INITHASH, &p->scharr.roi, sizeof(dt_iop_roi_t));
 
-  dt_print_pipe(DT_DEBUG_PIPE, "write scharr mask CPU", p, NULL, DT_DEVICE_CPU, NULL, NULL, "%p (%ix%i)\n",
+  dt_print_pipe(DT_DEBUG_PIPE, "write scharr mask CPU", p, NULL, DT_DEVICE_CPU, NULL, NULL, "%p (%ix%i)",
     mask, width, height);
 
   if(darktable.dump_pfm_module && (piece->pipe->type & DT_DEV_PIXELPIPE_EXPORT))
@@ -3172,7 +3172,7 @@ gboolean dt_dev_write_scharr_mask(dt_dev_pixelpipe_iop_t *piece,
 
   error:
   dt_print_pipe(DT_DEBUG_ALWAYS,
-           "couldn't write scharr mask CPU", p, NULL, DT_DEVICE_CPU, NULL, NULL, "\n");
+           "couldn't write scharr mask CPU", p, NULL, DT_DEVICE_CPU, NULL, NULL);
   dt_dev_clear_scharr_mask(p);
   return TRUE;
 }
@@ -3227,7 +3227,7 @@ int dt_dev_write_scharr_mask_cl(dt_dev_pixelpipe_iop_t *piece,
 
   p->scharr.hash = dt_hash(DT_INITHASH, &p->scharr.roi, sizeof(dt_iop_roi_t));
 
-  dt_print_pipe(DT_DEBUG_PIPE, "write scharr mask CL", p, NULL, piece->pipe->devid, NULL, NULL, "%p (%ix%i)\n",
+  dt_print_pipe(DT_DEBUG_PIPE, "write scharr mask CL", p, NULL, piece->pipe->devid, NULL, NULL, "%p (%ix%i)",
     mask, width, height);
 
   if(darktable.dump_pfm_module && (piece->pipe->type & DT_DEV_PIXELPIPE_EXPORT))
@@ -3238,7 +3238,7 @@ int dt_dev_write_scharr_mask_cl(dt_dev_pixelpipe_iop_t *piece,
   {
     dt_print_pipe(DT_DEBUG_ALWAYS,
            "couldn't write scharr mask CL", p, NULL, piece->pipe->devid, NULL, NULL,
-           "%s\n", cl_errstr(err));
+           "%s", cl_errstr(err));
     dt_dev_clear_scharr_mask(p);
   }
   dt_opencl_release_mem_object(out);
@@ -3298,7 +3298,7 @@ float *dt_dev_distort_detail_mask(dt_dev_pixelpipe_iop_t *piece,
           float *tmp = dt_alloc_align_float((size_t)it_piece->processed_roi_out.width
                                             * it_piece->processed_roi_out.height);
           dt_print_pipe(DT_DEBUG_MASKS | DT_DEBUG_PIPE | DT_DEBUG_VERBOSE,
-             "distort detail mask", pipe, it_piece->module, DT_DEVICE_NONE, &it_piece->processed_roi_in, &it_piece->processed_roi_out, "\n");
+             "distort detail mask", pipe, it_piece->module, DT_DEVICE_NONE, &it_piece->processed_roi_in, &it_piece->processed_roi_out);
 
           it_piece->module->distort_mask(it_piece->module, it_piece, inmask, tmp,
                                        &it_piece->processed_roi_in,
@@ -3317,7 +3317,7 @@ float *dt_dev_distort_detail_mask(dt_dev_pixelpipe_iop_t *piece,
                       "distort details mask",
                       pipe, it_piece->module, DT_DEVICE_NONE,
                       &it_piece->processed_roi_in, &it_piece->processed_roi_out,
-                      "misses distort_mask()\n");
+                      "misses distort_mask()");
 
         if(it_piece->module == target_module) break;
       }
@@ -3329,7 +3329,7 @@ float *dt_dev_distort_detail_mask(dt_dev_pixelpipe_iop_t *piece,
   dt_print_pipe(DT_DEBUG_MASKS | DT_DEBUG_PIPE,
     correct ? "got detail mask" : "DETAIL SIZE MISMATCH",
     pipe, target_module, DT_DEVICE_NONE, NULL, NULL,
-    "from %p (%ix%i) distorted to %p (%ix%i)\n",
+    "from %p (%ix%i) distorted to %p (%ix%i)",
     pipe->scharr.data, pipe->scharr.roi.width, pipe->scharr.roi.height,
     resmask, final_roi->width, final_roi->height);
 

--- a/src/develop/tiling.c
+++ b/src/develop/tiling.c
@@ -88,7 +88,7 @@ static inline int _maximum_number_tiles()
 
 static inline void _print_roi(const dt_iop_roi_t *roi, const char *label)
 {
-  dt_print(DT_DEBUG_TILING | DT_DEBUG_VERBOSE,"     {%5d %5d ->%5d %5d (%5dx%5d)  %.6f } %s\n",
+  dt_print(DT_DEBUG_TILING | DT_DEBUG_VERBOSE,"     {%5d %5d ->%5d %5d (%5dx%5d)  %.6f } %s",
            roi->x, roi->y, roi->x + roi->width, roi->y + roi->height,
            roi->width, roi->height, roi->scale, label);
 }
@@ -503,7 +503,7 @@ static int _nm_fit_output_to_input_roi(struct dt_iop_module_t *self,
   int iter = _simplex(_nm_fitness, start, 4, epsilon, 1.0, maxiter, NULL, rest);
 
   dt_print(DT_DEBUG_TILING | DT_DEBUG_VERBOSE,
-           "[_nm_fit_output_to_input_roi] _simplex: %d, delta: %d, epsilon: %f\n",
+           "[_nm_fit_output_to_input_roi] _simplex: %d, delta: %d, epsilon: %f",
            iter, delta, epsilon);
 
   oroi->x = start[0] * piece->iwidth;
@@ -575,7 +575,7 @@ static void _default_process_tiling_ptp(struct dt_iop_module_t *self,
   void *input = NULL;
   void *output = NULL;
   dt_print(DT_DEBUG_TILING,
-           "[default_process_tiling_ptp] [%s] **** tiling module '%s%s' for image with size %dx%d --> %dx%d\n",
+           "[default_process_tiling_ptp] [%s] **** tiling module '%s%s' for image with size %dx%d --> %dx%d",
            dt_dev_pixelpipe_type_to_str(piece->pipe->type), self->op, dt_iop_get_instance_id(self),
            roi_in->width, roi_in->height, roi_out->width, roi_out->height);
   dt_iop_buffer_dsc_t dsc;
@@ -600,7 +600,7 @@ static void _default_process_tiling_ptp(struct dt_iop_module_t *self,
   {
     dt_print(DT_DEBUG_TILING,
              "[default_process_tiling_ptp] [%s]  no need to use tiling for module '%s%s' "
-             "as no real memory saving to be expected\n",
+             "as no real memory saving to be expected",
              dt_dev_pixelpipe_type_to_str(piece->pipe->type), self->op, dt_iop_get_instance_id(self));
     goto fallback;
   }
@@ -644,7 +644,7 @@ static void _default_process_tiling_ptp(struct dt_iop_module_t *self,
       height = floorf(height * sqrtf(scale));
     }
     dt_print(DT_DEBUG_TILING | DT_DEBUG_VERBOSE,
-             "[default_process_tiling_ptp] buffer exceeds singlebuffer, corrected to %dx%d\n",
+             "[default_process_tiling_ptp] buffer exceeds singlebuffer, corrected to %dx%d",
              width, height);
   }
 
@@ -653,7 +653,7 @@ static void _default_process_tiling_ptp(struct dt_iop_module_t *self,
   {
     width = height = floorf(sqrtf((float)width * height));
     dt_print(DT_DEBUG_TILING | DT_DEBUG_VERBOSE,
-             "[default_process_tiling_roi] use squares because of overlap, corrected to %dx%d\n",
+             "[default_process_tiling_roi] use squares because of overlap, corrected to %dx%d",
              width, height);
   }
 
@@ -688,14 +688,14 @@ static void _default_process_tiling_ptp(struct dt_iop_module_t *self,
   if(tiles_x * tiles_y > _maximum_number_tiles())
   {
     dt_print(DT_DEBUG_TILING,
-             "[default_process_tiling_ptp] [%s] gave up tiling for module '%s%s'. too many tiles: %d x %d\n",
+             "[default_process_tiling_ptp] [%s] gave up tiling for module '%s%s'. too many tiles: %d x %d",
              dt_dev_pixelpipe_type_to_str(piece->pipe->type),
              self->op, dt_iop_get_instance_id(self), tiles_x, tiles_y);
     goto error;
   }
 
   dt_print(DT_DEBUG_TILING,
-           "[default_process_tiling_ptp] [%s] (%dx%d) tiles with max dimensions %dx%d and overlap %d\n",
+           "[default_process_tiling_ptp] [%s] (%dx%d) tiles with max dimensions %dx%d and overlap %d",
            dt_dev_pixelpipe_type_to_str(piece->pipe->type), tiles_x, tiles_y, width, height, overlap);
 
   /* reserve input and output buffers for tiles */
@@ -703,7 +703,7 @@ static void _default_process_tiling_ptp(struct dt_iop_module_t *self,
   if(input == NULL)
   {
     dt_print(DT_DEBUG_TILING,
-             "[default_process_tiling_ptp] [%s] could not alloc input buffer for module '%s%s'\n",
+             "[default_process_tiling_ptp] [%s] could not alloc input buffer for module '%s%s'",
              dt_dev_pixelpipe_type_to_str(piece->pipe->type), self->op, dt_iop_get_instance_id(self));
     goto error;
   }
@@ -711,7 +711,7 @@ static void _default_process_tiling_ptp(struct dt_iop_module_t *self,
   if(output == NULL)
   {
     dt_print(DT_DEBUG_TILING,
-             "[default_process_tiling_ptp] [%s]  could not alloc output buffer for module '%s%s'\n",
+             "[default_process_tiling_ptp] [%s]  could not alloc output buffer for module '%s%s'",
              dt_dev_pixelpipe_type_to_str(piece->pipe->type), self->op, dt_iop_get_instance_id(self));
     goto error;
   }
@@ -747,7 +747,7 @@ static void _default_process_tiling_ptp(struct dt_iop_module_t *self,
       size_t ooffs = (ty * tile_ht) * opitch + (tx * tile_wd) * out_bpp;
 
       dt_print(DT_DEBUG_TILING,
-               "[default_process_tiling_ptp] [%s] tile (%zu,%zu) with %zux%zu at origin [%zu,%zu]\n",
+               "[default_process_tiling_ptp] [%s] tile (%zu,%zu) with %zux%zu at origin [%zu,%zu]",
                dt_dev_pixelpipe_type_to_str(piece->pipe->type), tx, ty, wd, ht, tx * tile_wd, ty * tile_ht);
 
 /* prepare input tile buffer */
@@ -768,7 +768,7 @@ static void _default_process_tiling_ptp(struct dt_iop_module_t *self,
       {
         if(tx + ty > 0 && fabs(processed_maximum_new[k] - piece->pipe->dsc.processed_maximum[k]) > 1.0e-6f)
           dt_print(DT_DEBUG_TILING,
-                   "[default_process_tiling_ptp] [%s] processed_maximum[%d] differs between tiles in module '%s%s'\n",
+                   "[default_process_tiling_ptp] [%s] processed_maximum[%d] differs between tiles in module '%s%s'",
                    dt_dev_pixelpipe_type_to_str(piece->pipe->type), k,
                    self->op, dt_iop_get_instance_id(self));
         processed_maximum_new[k] = piece->pipe->dsc.processed_maximum[k];
@@ -814,7 +814,7 @@ fallback:
   if(output != NULL) dt_free_align(output);
   piece->pipe->tiling = FALSE;
   dt_print(DT_DEBUG_TILING,
-           "[default_process_tiling_ptp] [%s] fall back to standard processing for module '%s%s'\n",
+           "[default_process_tiling_ptp] [%s] fall back to standard processing for module '%s%s'",
            dt_dev_pixelpipe_type_to_str(piece->pipe->type), self->op, dt_iop_get_instance_id(self));
   self->process(self, piece, ivoid, ovoid, roi_in, roi_out);
   return;
@@ -837,7 +837,7 @@ static void _default_process_tiling_roi(struct dt_iop_module_t *self,
 
   dt_print(DT_DEBUG_TILING,
            "[default_process_tiling_roi] [%s] **** tiling module '%s%s' for "
-           "image input size %dx%d --> %dx%d\n",
+           "image input size %dx%d --> %dx%d",
            dt_dev_pixelpipe_type_to_str(piece->pipe->type),
            self->op, dt_iop_get_instance_id(self),
            roi_in->width, roi_in->height, roi_out->width, roi_out->height);
@@ -874,7 +874,7 @@ static void _default_process_tiling_roi(struct dt_iop_module_t *self,
   {
     dt_print(DT_DEBUG_TILING,
              "[default_process_tiling_roi] [%s] no need to use tiling for module "
-             "'%s%s' as no memory saving is expected\n",
+             "'%s%s' as no memory saving is expected",
              dt_dev_pixelpipe_type_to_str(piece->pipe->type), self->op, dt_iop_get_instance_id(self));
     goto fallback;
   }
@@ -928,7 +928,7 @@ static void _default_process_tiling_roi(struct dt_iop_module_t *self,
       height = _align_down((int)floorf(height * sqrtf(scale)), xyalign);
     }
     dt_print(DT_DEBUG_TILING | DT_DEBUG_VERBOSE,
-             "[default_process_tiling_roi] [%s] buffer exceeds singlebuffer, corrected to %dx%d\n",
+             "[default_process_tiling_roi] [%s] buffer exceeds singlebuffer, corrected to %dx%d",
              dt_dev_pixelpipe_type_to_str(piece->pipe->type), width, height);
   }
 
@@ -937,7 +937,7 @@ static void _default_process_tiling_roi(struct dt_iop_module_t *self,
   {
     width = height = _align_down((int)floorf(sqrtf((float)width * height)), xyalign);
     dt_print(DT_DEBUG_TILING | DT_DEBUG_VERBOSE,
-             "[default_process_tiling_roi] [%s] use squares because of overlap, corrected to %dx%d\n",
+             "[default_process_tiling_roi] [%s] use squares because of overlap, corrected to %dx%d",
              dt_dev_pixelpipe_type_to_str(piece->pipe->type), width, height);
   }
 
@@ -971,7 +971,7 @@ static void _default_process_tiling_roi(struct dt_iop_module_t *self,
   if(tiles_x * tiles_y > _maximum_number_tiles())
   {
     dt_print(DT_DEBUG_TILING,
-             "[default_process_tiling_roi] [%s] gave up tiling for module '%s%s'. too many tiles: %d x %d\n",
+             "[default_process_tiling_roi] [%s] gave up tiling for module '%s%s'. too many tiles: %d x %d",
              dt_dev_pixelpipe_type_to_str(piece->pipe->type),
              self->op, dt_iop_get_instance_id(self), tiles_x, tiles_y);
     goto error;
@@ -986,7 +986,7 @@ static void _default_process_tiling_roi(struct dt_iop_module_t *self,
       roi_out->height % tiles_y == 0 ? roi_out->height / tiles_y : roi_out->height / tiles_y + 1, xyalign);
 
   dt_print(DT_DEBUG_TILING,
-           "[default_process_tiling_roi] [%s] (%dx%d) tiles with max dimensions %dx%d, good %dx%d, overlap %d->%d\n",
+           "[default_process_tiling_roi] [%s] (%dx%d) tiles with max dimensions %dx%d, good %dx%d, overlap %d->%d",
            dt_dev_pixelpipe_type_to_str(piece->pipe->type), tiles_x, tiles_y,
            width, height, tile_wd, tile_ht, overlap_in, overlap_out);
 
@@ -1049,7 +1049,7 @@ static void _default_process_tiling_roi(struct dt_iop_module_t *self,
       {
         dt_print(DT_DEBUG_TILING,
                  "[default_process_tiling_roi] [%s] can not handle requested roi's. "
-                 "tiling for module '%s%s' not possible.\n",
+                 "tiling for module '%s%s' not possible",
                  dt_dev_pixelpipe_type_to_str(piece->pipe->type), self->op, dt_iop_get_instance_id(self));
         goto error;
       }
@@ -1087,7 +1087,7 @@ static void _default_process_tiling_roi(struct dt_iop_module_t *self,
             size_t ooffs = ((size_t)oroi_good.y - roi_out->y) * opitch + ((size_t)oroi_good.x - roi_out->x) * out_bpp;
 
       dt_print(DT_DEBUG_TILING,
-               "[default_process_tiling_roi] [%s] process tile (%zu,%zu) size %dx%d at origin [%d,%d]\n",
+               "[default_process_tiling_roi] [%s] process tile (%zu,%zu) size %dx%d at origin [%d,%d]",
                dt_dev_pixelpipe_type_to_str(piece->pipe->type), tx, ty,
                iroi_full.width, iroi_full.height, iroi_full.x, iroi_full.y);
 
@@ -1096,7 +1096,7 @@ static void _default_process_tiling_roi(struct dt_iop_module_t *self,
       if(input == NULL)
       {
         dt_print(DT_DEBUG_TILING,
-                 "[default_process_tiling_roi] [%s] could not alloc input buffer for module '%s%s'\n",
+                 "[default_process_tiling_roi] [%s] could not alloc input buffer for module '%s%s'",
                  dt_dev_pixelpipe_type_to_str(piece->pipe->type), self->op, dt_iop_get_instance_id(self));
         goto error;
       }
@@ -1104,7 +1104,7 @@ static void _default_process_tiling_roi(struct dt_iop_module_t *self,
       if(output == NULL)
       {
         dt_print(DT_DEBUG_TILING,
-                 "[default_process_tiling_roi] [%s] could not alloc output buffer for module '%s%s'\n",
+                 "[default_process_tiling_roi] [%s] could not alloc output buffer for module '%s%s'",
                  dt_dev_pixelpipe_type_to_str(piece->pipe->type), self->op, dt_iop_get_instance_id(self));
         goto error;
       }
@@ -1127,7 +1127,7 @@ static void _default_process_tiling_roi(struct dt_iop_module_t *self,
       {
         if(tx + ty > 0 && fabs(processed_maximum_new[k] - piece->pipe->dsc.processed_maximum[k]) > 1.0e-6f)
           dt_print(DT_DEBUG_TILING,
-                   "[default_process_tiling_roi] processed_maximum[%d] differs between tiles in module '%s%s'\n",
+                   "[default_process_tiling_roi] processed_maximum[%d] differs between tiles in module '%s%s'",
                    k, self->op, dt_iop_get_instance_id(self));
         processed_maximum_new[k] = piece->pipe->dsc.processed_maximum[k];
       }
@@ -1163,7 +1163,7 @@ fallback:
   if(output != NULL) dt_free_align(output);
   piece->pipe->tiling = FALSE;
   dt_print(DT_DEBUG_TILING,
-           "[default_process_tiling_roi] [%s] fall back to standard processing for module '%s%s'\n",
+           "[default_process_tiling_roi] [%s] fall back to standard processing for module '%s%s'",
            dt_dev_pixelpipe_type_to_str(piece->pipe->type), self->op, dt_iop_get_instance_id(self));
   self->process(self, piece, ivoid, ovoid, roi_in, roi_out);
   return;
@@ -1247,7 +1247,7 @@ float dt_tiling_estimate_cpumem(struct dt_develop_tiling_t *tiling,
     tiles_y = (height < roi_in->height) ? ceilf((float)roi_in->height / (float)MAX(height - 2 * overlap_in, 1)) : 1;
   else
     tiles_y = (height < roi_out->height) ? ceilf((float)roi_out->height / (float)MAX(height - 2 * overlap_out, 1)) : 1;
-  dt_print(DT_DEBUG_TILING, "tilex = %i, tiley = %i\n", tiles_x, tiles_y);
+  dt_print(DT_DEBUG_TILING, "tilex = %i, tiley = %i", tiles_x, tiles_y);
   return (float)tiles_x * tiles_y * singlebuffer ;
 }
 
@@ -1331,7 +1331,7 @@ static int _default_process_tiling_cl_ptp(struct dt_iop_module_t *self,
 
   dt_print(DT_DEBUG_TILING,
            "[default_process_tiling_cl_ptp] [%s] **** tiling module '%s%s' "
-           "for image with size %dx%d --> %dx%d\n",
+           "for image with size %dx%d --> %dx%d",
            dt_dev_pixelpipe_type_to_str(piece->pipe->type), self->op, dt_iop_get_instance_id(self),
            roi_in->width, roi_in->height, roi_out->width, roi_out->height);
 
@@ -1385,7 +1385,7 @@ static int _default_process_tiling_cl_ptp(struct dt_iop_module_t *self,
       height = floorf(height * sqrtf(scale));
     }
     dt_print(DT_DEBUG_TILING | DT_DEBUG_VERBOSE,
-             "[default_process_tiling_cl_ptp] [%s] buffer exceeds singlebuffer, corrected to %dx%d\n",
+             "[default_process_tiling_cl_ptp] [%s] buffer exceeds singlebuffer, corrected to %dx%d",
              dt_dev_pixelpipe_type_to_str(piece->pipe->type), width, height);
   }
 
@@ -1394,7 +1394,7 @@ static int _default_process_tiling_cl_ptp(struct dt_iop_module_t *self,
   {
     width = height = floorf(sqrtf((float)width * height));
     dt_print(DT_DEBUG_TILING | DT_DEBUG_VERBOSE,
-             "[default_process_tiling_cl_ptp] [%s] use squares because of overlap, corrected to %dx%d\n",
+             "[default_process_tiling_cl_ptp] [%s] use squares because of overlap, corrected to %dx%d",
              dt_dev_pixelpipe_type_to_str(piece->pipe->type), width, height);
   }
 
@@ -1438,7 +1438,7 @@ static int _default_process_tiling_cl_ptp(struct dt_iop_module_t *self,
   {
     dt_print(DT_DEBUG_TILING,
              "[default_process_tiling_cl_ptp] [%s] aborted tiling for module '%s%s'. "
-             "too many tiles: %d x %d\n",
+             "too many tiles: %d x %d",
              dt_dev_pixelpipe_type_to_str(piece->pipe->type),
              self->op, dt_iop_get_instance_id(self), tiles_x, tiles_y);
     return DT_OPENCL_PROCESS_CL;
@@ -1446,7 +1446,7 @@ static int _default_process_tiling_cl_ptp(struct dt_iop_module_t *self,
 
   dt_print(DT_DEBUG_TILING,
            "[default_process_tiling_cl_ptp] [%s] (%dx%d) tiles with max dimensions "
-           "%dx%d, pinned=%s, good %dx%d and overlap %d\n",
+           "%dx%d, pinned=%s, good %dx%d and overlap %d",
            dt_dev_pixelpipe_type_to_str(piece->pipe->type), tiles_x, tiles_y,
            width, height, (use_pinned_memory) ? "ON" : "OFF", tile_wd, tile_ht, overlap);
 
@@ -1464,7 +1464,7 @@ static int _default_process_tiling_cl_ptp(struct dt_iop_module_t *self,
     {
       dt_print(DT_DEBUG_OPENCL | DT_DEBUG_TILING,
                "[default_process_tiling_cl_ptp] could not alloc pinned "
-               "input buffer for module '%s%s'\n",
+               "input buffer for module '%s%s'",
                self->op, dt_iop_get_instance_id(self));
       use_pinned_memory = FALSE;
     }
@@ -1479,7 +1479,7 @@ static int _default_process_tiling_cl_ptp(struct dt_iop_module_t *self,
     {
       dt_print(DT_DEBUG_OPENCL | DT_DEBUG_TILING,
                "[default_process_tiling_cl_ptp] [%s] could not map pinned input buffer to host "
-               "memory for module '%s%s'\n",
+               "memory for module '%s%s'",
                dt_dev_pixelpipe_type_to_str(piece->pipe->type), self->op, dt_iop_get_instance_id(self));
       use_pinned_memory = FALSE;
     }
@@ -1494,7 +1494,7 @@ static int _default_process_tiling_cl_ptp(struct dt_iop_module_t *self,
     {
       dt_print(DT_DEBUG_OPENCL | DT_DEBUG_TILING,
                "[default_process_tiling_cl_ptp] could not alloc pinned output "
-               "buffer for module '%s%s'\n",
+               "buffer for module '%s%s'",
                self->op, dt_iop_get_instance_id(self));
       use_pinned_memory = FALSE;
     }
@@ -1509,7 +1509,7 @@ static int _default_process_tiling_cl_ptp(struct dt_iop_module_t *self,
     {
       dt_print(DT_DEBUG_OPENCL | DT_DEBUG_TILING,
                "[default_process_tiling_cl_ptp] [%s] could not map pinned output buffer to host "
-               "memory for module '%s%s'\n",
+               "memory for module '%s%s'",
                dt_dev_pixelpipe_type_to_str(piece->pipe->type), self->op, dt_iop_get_instance_id(self));
       use_pinned_memory = FALSE;
     }
@@ -1543,7 +1543,7 @@ static int _default_process_tiling_cl_ptp(struct dt_iop_module_t *self,
 
 
       dt_print(DT_DEBUG_TILING,
-               "[default_process_tiling_cl_ptp] [%s] tile (%zu,%zu) size %zux%zu at origin [%zu,%zu]\n",
+               "[default_process_tiling_cl_ptp] [%s] tile (%zu,%zu) size %zux%zu at origin [%zu,%zu]",
                dt_dev_pixelpipe_type_to_str(piece->pipe->type), tx, ty,
                wd, ht, tx * tile_wd, ty * tile_ht);
 
@@ -1596,7 +1596,7 @@ static int _default_process_tiling_cl_ptp(struct dt_iop_module_t *self,
       {
         if(tx + ty > 0 && fabs(processed_maximum_new[k] - piece->pipe->dsc.processed_maximum[k]) > 1.0e-6f)
           dt_print(DT_DEBUG_TILING,
-                   "[default_process_tiling_cl_ptp] [%s] processed_maximum[%d] differs between tiles in module '%s%s'\n",
+                   "[default_process_tiling_cl_ptp] [%s] processed_maximum[%d] differs between tiles in module '%s%s'",
                    dt_dev_pixelpipe_type_to_str(piece->pipe->type), k, self->op, dt_iop_get_instance_id(self));
         processed_maximum_new[k] = piece->pipe->dsc.processed_maximum[k];
       }
@@ -1681,7 +1681,7 @@ error:
   const gboolean pinning_error = !use_pinned_memory && dt_opencl_use_pinned_memory(devid);
   dt_print(DT_DEBUG_TILING | DT_DEBUG_OPENCL,
            "[default_process_tiling_opencl_ptp] [%s] couldn't run process_cl() for "
-           "module '%s%s' in tiling mode:%s %s\n",
+           "module '%s%s' in tiling mode:%s %s",
            dt_dev_pixelpipe_type_to_str(piece->pipe->type), self->op, dt_iop_get_instance_id(self),
            (pinning_error) ? " pinning problem" : "", cl_errstr(err));
 
@@ -1709,7 +1709,7 @@ static int _default_process_tiling_cl_roi(struct dt_iop_module_t *self,
 
   dt_print(DT_DEBUG_TILING,
            "[default_process_tiling_cl_roi] [%s] **** tiling module '%s%s' "
-           "for image with input size %dx%d --> %dx%d\n",
+           "for image with input size %dx%d --> %dx%d",
            dt_dev_pixelpipe_type_to_str(piece->pipe->type), self->op, dt_iop_get_instance_id(self),
            roi_in->width, roi_in->height, roi_out->width, roi_out->height);
   _print_roi(roi_in, "module roi_in");
@@ -1786,7 +1786,7 @@ static int _default_process_tiling_cl_roi(struct dt_iop_module_t *self,
       height = _align_down((int)floorf(height * sqrtf(scale)), xyalign);
     }
     dt_print(DT_DEBUG_TILING | DT_DEBUG_VERBOSE,
-             "[default_process_tiling_cl_roi] [%s] buffer exceeds singlebuffer, corrected to %dx%d\n",
+             "[default_process_tiling_cl_roi] [%s] buffer exceeds singlebuffer, corrected to %dx%d",
              dt_dev_pixelpipe_type_to_str(piece->pipe->type), width, height);
   }
 
@@ -1795,7 +1795,7 @@ static int _default_process_tiling_cl_roi(struct dt_iop_module_t *self,
   {
     width = height = _align_down((int)floorf(sqrtf((float)width * height)), xyalign);
     dt_print(DT_DEBUG_TILING | DT_DEBUG_VERBOSE,
-             "[default_process_tiling_cl_roi] [%s] use squares because of overlap, corrected to %dx%d\n",
+             "[default_process_tiling_cl_roi] [%s] use squares because of overlap, corrected to %dx%d",
              dt_dev_pixelpipe_type_to_str(piece->pipe->type), width, height);
   }
 
@@ -1829,7 +1829,7 @@ static int _default_process_tiling_cl_roi(struct dt_iop_module_t *self,
   if(tiles_x * tiles_y > _maximum_number_tiles())
   {
     dt_print(DT_DEBUG_TILING,
-             "[default_process_tiling_cl_roi] [%s] aborted tiling for module '%s%s'. too many tiles: %dx%d\n",
+             "[default_process_tiling_cl_roi] [%s] aborted tiling for module '%s%s'. too many tiles: %dx%d",
              dt_dev_pixelpipe_type_to_str(piece->pipe->type),
              self->op, dt_iop_get_instance_id(self), tiles_x, tiles_y);
     return DT_OPENCL_PROCESS_CL;
@@ -1844,7 +1844,7 @@ static int _default_process_tiling_cl_roi(struct dt_iop_module_t *self,
 
   dt_print(DT_DEBUG_TILING,
            "[default_process_tiling_cl_roi] [%s] (%dx%d) tiles with max input "
-           "dimensions %dx%d, pinned=%s, good %ix%i\n",
+           "dimensions %dx%d, pinned=%s, good %ix%i",
            dt_dev_pixelpipe_type_to_str(piece->pipe->type), tiles_x, tiles_y,
            width, height, (use_pinned_memory) ? "ON" : "OFF", tile_wd, tile_ht);
 
@@ -1861,7 +1861,7 @@ static int _default_process_tiling_cl_roi(struct dt_iop_module_t *self,
     if(pinned_input == NULL)
     {
       dt_print(DT_DEBUG_OPENCL | DT_DEBUG_TILING,
-               "[default_process_tiling_cl_roi] [%s] could not alloc pinned input buffer for module '%s%s'\n",
+               "[default_process_tiling_cl_roi] [%s] could not alloc pinned input buffer for module '%s%s'",
                dt_dev_pixelpipe_type_to_str(piece->pipe->type), self->op, dt_iop_get_instance_id(self));
       use_pinned_memory = FALSE;
     }
@@ -1876,7 +1876,7 @@ static int _default_process_tiling_cl_roi(struct dt_iop_module_t *self,
     {
       dt_print(DT_DEBUG_OPENCL | DT_DEBUG_TILING,
                "[default_process_tiling_cl_roi] [%s] could not map pinned input buffer to host "
-               "memory for module '%s%s'\n",
+               "memory for module '%s%s'",
                dt_dev_pixelpipe_type_to_str(piece->pipe->type), self->op, dt_iop_get_instance_id(self));
       use_pinned_memory = FALSE;
     }
@@ -1890,7 +1890,7 @@ static int _default_process_tiling_cl_roi(struct dt_iop_module_t *self,
     if(pinned_output == NULL)
     {
       dt_print(DT_DEBUG_OPENCL | DT_DEBUG_TILING,
-               "[default_process_tiling_cl_roi] [%s] could not alloc pinned output buffer for module '%s%s'\n",
+               "[default_process_tiling_cl_roi] [%s] could not alloc pinned output buffer for module '%s%s'",
                dt_dev_pixelpipe_type_to_str(piece->pipe->type), self->op, dt_iop_get_instance_id(self));
       use_pinned_memory = FALSE;
     }
@@ -1905,7 +1905,7 @@ static int _default_process_tiling_cl_roi(struct dt_iop_module_t *self,
     {
       dt_print(DT_DEBUG_OPENCL | DT_DEBUG_TILING,
                "[default_process_tiling_cl_roi] [%s] could not map pinned output buffer to host "
-               "memory for module '%s%s'\n",
+               "memory for module '%s%s'",
                dt_dev_pixelpipe_type_to_str(piece->pipe->type), self->op, dt_iop_get_instance_id(self));
       use_pinned_memory = FALSE;
     }
@@ -1967,7 +1967,7 @@ static int _default_process_tiling_cl_roi(struct dt_iop_module_t *self,
       {
         dt_print(DT_DEBUG_OPENCL | DT_DEBUG_TILING,
                  "[default_process_tiling_cl_roi] [%s] can not handle requested roi's tiling "
-                 "for module '%s%s' not possible.\n",
+                 "for module '%s%s' not possible",
                  dt_dev_pixelpipe_type_to_str(piece->pipe->type), self->op, dt_iop_get_instance_id(self));
         err = DT_OPENCL_PROCESS_CL;
         goto error;
@@ -2021,12 +2021,12 @@ static int _default_process_tiling_cl_roi(struct dt_iop_module_t *self,
       size_t oregion[] = { oroi_good.width, oroi_good.height, 1 };
 
       dt_print(DT_DEBUG_TILING,
-               "[default_process_tiling_cl_roi] [%s] process tile (%zu,%zu) size %dx%d at origin [%d,%d]\n",
+               "[default_process_tiling_cl_roi] [%s] process tile (%zu,%zu) size %dx%d at origin [%d,%d]",
                dt_dev_pixelpipe_type_to_str(piece->pipe->type), tx, ty,
                iroi_full.width, iroi_full.height, iroi_full.x, iroi_full.y);
       dt_print(DT_DEBUG_TILING | DT_DEBUG_VERBOSE,
                "[default_process_tiling_cl_roi]    dest [%lu,%lu] at [%lu,%lu], "
-               "offsets [%i,%i] -> [%i,%i], delta=%i\n\n",
+               "offsets [%i,%i] -> [%i,%i], delta=%i\n",
                oregion[0], oregion[1], oorigin[0], oorigin[1], in_dx, in_dy,
                out_dx, out_dy, delta);
 
@@ -2080,7 +2080,7 @@ static int _default_process_tiling_cl_roi(struct dt_iop_module_t *self,
         if(tx + ty > 0 && fabs(processed_maximum_new[k] - piece->pipe->dsc.processed_maximum[k]) > 1.0e-6f)
           dt_print(DT_DEBUG_TILING,
                    "[default_process_tiling_cl_roi] [%s] processed_maximum[%d] "
-                   "differs between tiles in module '%s%s'\n",
+                   "differs between tiles in module '%s%s'",
                    dt_dev_pixelpipe_type_to_str(piece->pipe->type), k, self->op, dt_iop_get_instance_id(self));
         processed_maximum_new[k] = piece->pipe->dsc.processed_maximum[k];
       }
@@ -2144,7 +2144,7 @@ error:
   const gboolean pinning_error = (use_pinned_memory == FALSE) && dt_opencl_use_pinned_memory(devid);
   dt_print(DT_DEBUG_OPENCL | DT_DEBUG_TILING,
            "[default_process_tiling_opencl_roi] [%s] couldn't run process_cl() "
-           "for module '%s%s' in tiling mode:%s %s\n",
+           "for module '%s%s' in tiling mode:%s %s",
            dt_dev_pixelpipe_type_to_str(piece->pipe->type),
            self->op, dt_iop_get_instance_id(self),
            (pinning_error) ? " pinning problem" : "", cl_errstr(err));

--- a/src/dtgtk/culling.c
+++ b/src/dtgtk/culling.c
@@ -1725,7 +1725,7 @@ static gboolean _thumbs_compute_positions(dt_culling_t *table)
 
     dt_print(DT_DEBUG_LIGHTTABLE,
       "[culling_placement] thumb_id=%d, x=%d, y=%d, width=%d, height=%d"
-             " - table_width=%d, table_height=%d\n",
+             " - table_width=%d, table_height=%d",
              thumb->imgid, thumb->x, thumb->y, thumb->width, thumb->height,
              table->view_width, table->view_height);
   }
@@ -1867,7 +1867,7 @@ void dt_culling_full_redraw(dt_culling_t *table, const gboolean force)
     }
   }
 
-  dt_print(DT_DEBUG_LIGHTTABLE | DT_DEBUG_PERF, "[dt_culling_full_redraw] done in %0.04f sec\n", dt_get_wtime() - start);
+  dt_print(DT_DEBUG_LIGHTTABLE | DT_DEBUG_PERF, "[dt_culling_full_redraw] done in %0.04f sec", dt_get_wtime() - start);
 
   if(darktable.unmuted & DT_DEBUG_CACHE) dt_mipmap_cache_print(darktable.mipmap_cache);
 }

--- a/src/dtgtk/range.c
+++ b/src/dtgtk/range.c
@@ -1112,7 +1112,7 @@ static GtkWidget *_popup_get_numeric_menu(GtkDarktableRangeSelect *range, GtkWid
       continue;
 
     gchar *txt = (blo->txt) ? g_strdup(blo->txt) : range->print(blo->value_r, TRUE);
-    if(blo->nb > 0) txt = dt_util_dstrcat(txt, " (%d)", blo->nb);
+    if(blo->nb > 0) dt_util_str_cat(&txt, " (%d)", blo->nb);
     GtkWidget *smt = gtk_menu_item_new_with_label(txt);
     g_free(txt);
     g_object_set_data(G_OBJECT(smt), "range_block", blo);
@@ -1139,7 +1139,7 @@ static GtkWidget *_popup_get_numeric_menu(GtkDarktableRangeSelect *range, GtkWid
       continue;
 
     gchar *txt = (blo->txt) ? g_strdup(blo->txt) : range->print(blo->value_r, TRUE);
-    if(blo->nb > 0) txt = dt_util_dstrcat(txt, " (%d)", blo->nb);
+    if(blo->nb > 0) dt_util_str_cat(&txt, " (%d)", blo->nb);
     GtkWidget *smt = gtk_menu_item_new_with_label(txt);
     g_free(txt);
     g_object_set_data(G_OBJECT(smt), "range_block", blo);
@@ -1772,19 +1772,19 @@ gchar *dtgtk_range_select_get_bounds_pretty(GtkDarktableRangeSelect *range)
   else
     txt = range->print(range->select_min_r, TRUE);
 
-  txt = dt_util_dstrcat(txt, " → ");
+  dt_util_str_cat(&txt, " → ");
 
   if(range->bounds & DT_RANGE_BOUND_MAX)
-    txt = dt_util_dstrcat(txt, _("max"));
+    dt_util_str_cat(&txt, _("max"));
   else if(range->bounds & DT_RANGE_BOUND_MAX_RELATIVE)
-    txt = dt_util_dstrcat(txt, "+%04d:%02d:%02d %02d:%02d:%02d", range->select_relative_date_r.year,
+    dt_util_str_cat(&txt, "+%04d:%02d:%02d %02d:%02d:%02d", range->select_relative_date_r.year,
                           range->select_relative_date_r.month, range->select_relative_date_r.day,
                           range->select_relative_date_r.hour, range->select_relative_date_r.minute,
                           range->select_relative_date_r.second);
   else if(range->bounds & DT_RANGE_BOUND_MAX_NOW)
-    txt = dt_util_dstrcat(txt, _("now"));
+    dt_util_str_cat(&txt, _("now"));
   else
-    txt = dt_util_dstrcat(txt, "%s", range->print(range->select_max_r, TRUE));
+    dt_util_str_cat(&txt, "%s", range->print(range->select_max_r, TRUE));
 
   return txt;
 }

--- a/src/dtgtk/resetlabel.c
+++ b/src/dtgtk/resetlabel.c
@@ -54,7 +54,7 @@ GtkWidget *dtgtk_reset_label_new(const gchar *text, dt_iop_module_t *module, voi
   {
     label->offset = param - (void *)module->default_params;
     if(label->offset < 0 || label->offset + label->size > module->params_size)
-        dt_print(DT_DEBUG_ALWAYS, "[dtgtk_reset_label_new] reference outside %s params\n", module->so->op);
+        dt_print(DT_DEBUG_ALWAYS, "[dtgtk_reset_label_new] reference outside %s params", module->so->op);
   }
 
   label->lb = GTK_LABEL(gtk_label_new(text));

--- a/src/dtgtk/thumbnail.c
+++ b/src/dtgtk/thumbnail.c
@@ -176,12 +176,12 @@ static void _image_update_group_tooltip(dt_thumbnail_t *thumb)
     if(id != thumb->groupid)
     {
       if(id == thumb->imgid)
-        tt = dt_util_dstrcat(tt, "\n\u2022 %s", _("current"));
+        dt_util_str_cat(&tt, "\n\u2022 %s", _("current"));
       else
       {
-        tt = dt_util_dstrcat(tt, "\n\u2022 %s", sqlite3_column_text(stmt, 2));
+        dt_util_str_cat(&tt, "\n\u2022 %s", sqlite3_column_text(stmt, 2));
         if(v > 0)
-          tt = dt_util_dstrcat(tt, " v%d", v);
+          dt_util_str_cat(&tt, " v%d", v);
       }
     }
   }

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -1672,24 +1672,24 @@ static void _thumbs_ask_for_discard(dt_thumbtable_t *table)
       g_strdup(_("you have changed the settings related to"
                  " how thumbnails are generated.\n"));
     if(max_level >= DT_MIPMAP_8 && min_level == DT_MIPMAP_0)
-      txt = dt_util_dstrcat(txt, _("all cached thumbnails need to be invalidated.\n\n"));
+      dt_util_str_cat(&txt, _("all cached thumbnails need to be invalidated.\n\n"));
     else if(max_level >= DT_MIPMAP_8)
-      txt = dt_util_dstrcat
-        (txt,
+      dt_util_str_cat
+        (&txt,
          _("cached thumbnails starting from level %d need to be invalidated.\n\n"),
          min_level);
     else if(min_level == DT_MIPMAP_0)
-      txt = dt_util_dstrcat
-        (txt,
+      dt_util_str_cat
+        (&txt,
          _("cached thumbnails below level %d need to be invalidated.\n\n"),
          max_level);
     else
-      txt = dt_util_dstrcat
-        (txt,
+      dt_util_str_cat
+        (&txt,
          _("cached thumbnails between level %d and %d need to be invalidated.\n\n"),
          min_level, max_level);
 
-    txt = dt_util_dstrcat(txt, _("do you want to do that now?"));
+    dt_util_str_cat(&txt, _("do you want to do that now?"));
 
     if(dt_gui_show_yes_no_dialog(_("cached thumbnails invalidation"),
                                  "%s", txt))

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -2168,7 +2168,7 @@ static void _event_dnd_get(GtkWidget *widget,
         dt_imgid_t *imgs = calloc(imgs_nb, sizeof(dt_imgid_t));
         if(!imgs)
         {
-          dt_print(DT_DEBUG_ALWAYS,"[thumbtable] out of memory preparing drop target\n");
+          dt_print(DT_DEBUG_ALWAYS,"[thumbtable] out of memory preparing drop target");
           break;
         }
         GList *l = table->drag_list;
@@ -2508,7 +2508,7 @@ void dt_thumbtable_full_redraw(dt_thumbtable_t *table,
     sqlite3_stmt *stmt;
     dt_print(DT_DEBUG_LIGHTTABLE,
              "reload thumbs from db. force=%d w=%d h=%d zoom=%d rows=%d size=%d"
-             " offset=%d centering=%d...\n",
+             " offset=%d centering=%d...",
              force, table->view_width, table->view_height,
              table->thumbs_per_row, table->rows, table->thumb_size,
              table->offset, table->center_offset);
@@ -2703,7 +2703,7 @@ void dt_thumbtable_full_redraw(dt_thumbtable_t *table,
     }
 
     dt_print(DT_DEBUG_LIGHTTABLE,
-             "done in %0.04f sec %d thumbs reloaded\n",
+             "done in %0.04f sec %d thumbs reloaded",
              dt_get_wtime() - start, nbnew);
     g_free(query);
     sqlite3_finalize(stmt);

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -631,7 +631,7 @@ static gchar *_shortcut_key_move_name(dt_input_device_t id,
         gchar *key_name = gtk_accelerator_get_label(key_or_move, 0);
         post_name = g_utf8_strdown(key_name, -1);
         if(strlen(post_name) == 1 && _is_kp_key(key_or_move))
-          post_name = dt_util_dstrcat(post_name, " %s", _("(keypad)"));
+          dt_util_str_cat(&post_name, " %s", _("(keypad)"));
         g_free(key_name);
       }
       else
@@ -1087,7 +1087,7 @@ gboolean dt_shortcut_tooltip_callback(GtkWidget *widget,
   else
   {
     if(g_object_get_data(G_OBJECT(widget), "scroll-resize-tooltip"))
-      original_markup = dt_util_dstrcat(original_markup, "%s%s",
+      dt_util_str_cat(&original_markup, "%s%s",
                                         original_markup ? "\n" : "", _("shift+alt+scroll to change height"));
     action = dt_action_widget(widget);
     if(!action)
@@ -1124,8 +1124,7 @@ gboolean dt_shortcut_tooltip_callback(GtkWidget *widget,
       if(dt_bauhaus_slider_get_soft_min(widget) != hard_min ||
          dt_bauhaus_slider_get_soft_max(widget) != hard_max)
       {
-        original_markup = dt_util_dstrcat
-          (original_markup,
+        dt_util_str_cat(&original_markup,
            _("%sright-click to type a specific value between <b>%s</b> and <b>%s</b>"
              "\nor hold ctrl+shift while dragging to ignore soft limits."),
            original_markup ? "\n\n" : "",
@@ -1171,9 +1170,9 @@ gboolean dt_shortcut_tooltip_callback(GtkWidget *widget,
       gchar *sc_escaped = g_markup_escape_text(_shortcut_description(s), -1);
       const int components = (show_element > 0 || s->element != darktable.control->element) ? 1 : 0;
       gchar *ac_escaped = g_markup_escape_text(_action_description(s, components), -1);
-      description = dt_util_dstrcat(description, "%s<b><big>%s</big></b><i>%s</i>",
-                                                 description ? "\n" : "",
-                                                 sc_escaped, ac_escaped);
+      dt_util_str_cat(&description, "%s<b><big>%s</big></b><i>%s</i>",
+                                    description ? "\n" : "",
+                                    sc_escaped, ac_escaped);
       g_free(sc_escaped);
       g_free(ac_escaped);
     }
@@ -1191,7 +1190,7 @@ gboolean dt_shortcut_tooltip_callback(GtkWidget *widget,
     {
       gchar *lua_escaped = g_markup_printf_escaped("\n\nLua: <tt>%s</tt>%s %s", lua_command,
                                     show_element == 1 ? _("ctrl+v") : _("right long click") , _("to copy Lua command"));
-      markup_text = dt_util_dstrcat(markup_text, "%s", lua_escaped);
+      dt_util_str_cat(&markup_text, "%s", lua_escaped);
       g_free(lua_escaped);
       g_free(lua_command);
     }
@@ -1200,8 +1199,8 @@ gboolean dt_shortcut_tooltip_callback(GtkWidget *widget,
 
   if(description || original_markup || markup_text)
   {
-    if(original_markup) markup_text = dt_util_dstrcat(markup_text, markup_text ? "\n\n%s" : "%s", original_markup);
-    if(description    ) markup_text = dt_util_dstrcat(markup_text, markup_text ? "\n\n%s" : "%s", description);
+    if(original_markup) dt_util_str_cat(&markup_text, markup_text ? "\n\n%s" : "%s", original_markup);
+    if(description    ) dt_util_str_cat(&markup_text, markup_text ? "\n\n%s" : "%s", description);
 
     GtkWidget *label = gtk_label_new(NULL);
     gtk_label_set_markup(GTK_LABEL(label), markup_text);
@@ -3527,7 +3526,7 @@ gboolean dt_action_widget_invisible(GtkWidget *w)
 }
 
 #define ADD_EXPLANATION(cause, effect, extra, ...) if(*fb_log) \
-      *fb_log = dt_util_dstrcat(*fb_log, "\n%s \u2192 %s" extra, cause, effect, ##__VA_ARGS__)
+      dt_util_str_cat(&*fb_log, "\n%s \u2192 %s" extra, cause, effect, ##__VA_ARGS__)
 
 static gboolean _shortcut_closest_match(GSequenceIter **current,
                                         dt_shortcut_t *s,

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -1267,7 +1267,7 @@ static dt_view_type_flags_t _find_views(dt_action_t *action)
     }
     else
       dt_print(DT_DEBUG_ALWAYS,
-               "[find_views] views for category '%s' unknown\n", owner->id);
+               "[find_views] views for category '%s' unknown", owner->id);
     break;
   case DT_ACTION_TYPE_GLOBAL:
     vws = DT_VIEW_ALL;
@@ -3210,7 +3210,7 @@ static void _shortcuts_load(const gchar *shortcuts_file,
         if(!act_start)
         {
           dt_print(DT_DEBUG_ALWAYS,
-                   "[dt_shortcuts_load] line '%s' is not an assignment\n",
+                   "[dt_shortcuts_load] line '%s' is not an assignment",
                    line);
           continue;
         }
@@ -3226,13 +3226,13 @@ static void _shortcuts_load(const gchar *shortcuts_file,
             gtk_accelerator_parse(token, &s.key, &s.mods);
             if(s.mods)
               dt_print(DT_DEBUG_ALWAYS,
-                       "[dt_shortcuts_load] unexpected modifiers found in %s\n",
+                       "[dt_shortcuts_load] unexpected modifiers found in %s",
                        token);
             if(!s.key && sscanf(token, "tablet button %u", &s.key))
               s.key_device = DT_SHORTCUT_DEVICE_TABLET;
             if(!s.key)
               dt_print(DT_DEBUG_ALWAYS,
-                       "[dt_shortcuts_load] no key name found in %s\n",
+                       "[dt_shortcuts_load] no key name found in %s",
                        token);
           }
           else
@@ -3242,7 +3242,7 @@ static void _shortcuts_load(const gchar *shortcuts_file,
             if(colon == token)
             {
               dt_print(DT_DEBUG_ALWAYS,
-                       "[dt_shortcuts_load] missing driver name in %s\n", token);
+                       "[dt_shortcuts_load] missing driver name in %s", token);
               continue;
             }
             dt_input_device_t id = *colon - '0';
@@ -3260,7 +3260,7 @@ static void _shortcuts_load(const gchar *shortcuts_file,
               {
                 if(!callbacks->string_to_key(key_start, &s.key))
                   dt_print(DT_DEBUG_ALWAYS,
-                           "[dt_shortcuts_load] key not recognised in %s\n", key_start);
+                           "[dt_shortcuts_load] key not recognised in %s", key_start);
 
                 s.key_device = id;
                 break;
@@ -3270,7 +3270,7 @@ static void _shortcuts_load(const gchar *shortcuts_file,
             if(!driver)
             {
               dt_print(DT_DEBUG_ALWAYS,
-                       "[dt_shortcuts_load] '%s' is not a valid driver\n", token);
+                       "[dt_shortcuts_load] '%s' is not a valid driver", token);
               continue;
             }
           }
@@ -3320,7 +3320,7 @@ static void _shortcuts_load(const gchar *shortcuts_file,
             if(!g_ascii_strcasecmp(token, "down")) { s.direction= DT_SHORTCUT_DOWN; continue; }
 
             dt_print(DT_DEBUG_ALWAYS,
-                     "[dt_shortcuts_load] token '%s' not recognised\n", token);
+                     "[dt_shortcuts_load] token '%s' not recognised", token);
           }
           else
           {
@@ -3329,7 +3329,7 @@ static void _shortcuts_load(const gchar *shortcuts_file,
             if(colon == token)
             {
               dt_print(DT_DEBUG_ALWAYS,
-                       "[dt_shortcuts_load] missing driver name in %s\n", token);
+                       "[dt_shortcuts_load] missing driver name in %s", token);
               continue;
             }
             dt_input_device_t id = *colon - '0';
@@ -3347,7 +3347,7 @@ static void _shortcuts_load(const gchar *shortcuts_file,
               {
                 if(!callbacks->string_to_move(move_start, &s.move))
                   dt_print(DT_DEBUG_ALWAYS,
-                           "[dt_shortcuts_load] move not recognised in %s\n", move_start);
+                           "[dt_shortcuts_load] move not recognised in %s", move_start);
 
                 s.move_device = id;
                 break;
@@ -3357,7 +3357,7 @@ static void _shortcuts_load(const gchar *shortcuts_file,
             if(!driver)
             {
               dt_print(DT_DEBUG_ALWAYS,
-                       "[dt_shortcuts_load] '%s' is not a valid driver\n", token);
+                       "[dt_shortcuts_load] '%s' is not a valid driver", token);
               continue;
             }
           }
@@ -3374,7 +3374,7 @@ static void _shortcuts_load(const gchar *shortcuts_file,
         if(!s.action)
         {
           dt_print(DT_DEBUG_ALWAYS,
-                   "[dt_shortcuts_load] action path '%s' not found\n", token);
+                   "[dt_shortcuts_load] action path '%s' not found", token);
           continue;
         }
 
@@ -3424,7 +3424,7 @@ static void _shortcuts_load(const gchar *shortcuts_file,
             sscanf(token, "*%g", &s.speed);
           else
             dt_print(DT_DEBUG_ALWAYS,
-                     "[dt_shortcuts_load] token '%s' not recognised\n", token);
+                     "[dt_shortcuts_load] token '%s' not recognised", token);
         }
 
         if(file_dev == DT_ALL_DEVICES ||
@@ -3794,7 +3794,7 @@ static float _process_action(dt_action_t *action,
     }
     else
       dt_print(DT_DEBUG_ALWAYS,
-               "[process_action] preset '%s' has unsupported type\n", action->label);
+               "[process_action] preset '%s' has unsupported type", action->label);
   }
   else
   {
@@ -3897,14 +3897,14 @@ static float _process_shortcut(float move_size)
   float return_value = DT_ACTION_NOT_VALID;
 
   dt_print(DT_DEBUG_INPUT | DT_DEBUG_VERBOSE,
-            "  [_process_shortcut] processing shortcut: %s\n",
+            "  [_process_shortcut] processing shortcut: %s",
             _shortcut_description(&_sc));
 
   if(DT_PERFORM_ACTION(move_size) &&
      gtk_widget_has_grab(darktable.control->progress_system.proxy.module->widget))
   {
     if(_sc.key_device == DT_SHORTCUT_DEVICE_KEYBOARD_MOUSE && _sc.key == GDK_KEY_Escape)
-      dt_print(DT_DEBUG_ALWAYS, "this should cancel the running blocking job\n"); // TODO
+      dt_print(DT_DEBUG_ALWAYS, "this should cancel the running blocking job"); // TODO
 
     return return_value;
   }
@@ -3962,14 +3962,14 @@ float dt_action_process(const gchar *action,
 
   if(!ac)
   {
-    dt_print(DT_DEBUG_ALWAYS, "[dt_action_process] action path '%s' not found\n", action);
+    dt_print(DT_DEBUG_ALWAYS, "[dt_action_process] action path '%s' not found", action);
     return DT_ACTION_NOT_VALID;
   }
 
   if(ac->owner == &darktable.control->actions_lua)
   {
     dt_print(DT_DEBUG_ALWAYS,
-             "[dt_action_process] lua action '%s' triggered from lua\n", action);
+             "[dt_action_process] lua action '%s' triggered from lua", action);
     return DT_ACTION_NOT_VALID;
   }
 
@@ -3978,7 +3978,7 @@ float dt_action_process(const gchar *action,
   {
     if(DT_PERFORM_ACTION(move_size))
       dt_print(DT_DEBUG_ALWAYS,
-              "[dt_action_process] action '%s' not valid for current view\n", action);
+              "[dt_action_process] action '%s' not valid for current view", action);
     return DT_ACTION_NOT_VALID;
   }
 
@@ -4003,7 +4003,7 @@ float dt_action_process(const gchar *action,
         if(!elements[el].name)
         {
           dt_print(DT_DEBUG_ALWAYS,
-                   "[dt_action_process] element '%s' not valid for action '%s'\n",
+                   "[dt_action_process] element '%s' not valid for action '%s'",
                    element, action);
           return DT_ACTION_NOT_VALID;
         }
@@ -4021,7 +4021,7 @@ float dt_action_process(const gchar *action,
         if(!effects[ef])
         {
           dt_print(DT_DEBUG_ALWAYS,
-                   "[dt_action_process] effect '%s' not valid for action '%s'\n",
+                   "[dt_action_process] effect '%s' not valid for action '%s'",
                    effect, action);
           return DT_ACTION_NOT_VALID;
         }
@@ -4099,7 +4099,7 @@ float dt_shortcut_move(dt_input_device_t id, guint time, guint move, float move_
       _ungrab_grab_widget();
 
     dt_print(DT_DEBUG_INPUT,
-             "  [dt_shortcut_move] shortcut received: %s\n",
+             "  [dt_shortcut_move] shortcut received: %s",
              _shortcut_description(&_sc));
 
     _lookup_mapping_widget();
@@ -4733,7 +4733,7 @@ dt_action_t *dt_action_locate(dt_action_t *owner,
     {
       if(!owner || !create)
       {
-        dt_print(DT_DEBUG_ALWAYS, "[dt_action_locate] action '%s' %s\n", *path,
+        dt_print(DT_DEBUG_ALWAYS, "[dt_action_locate] action '%s' %s", *path,
                 !owner ? "not valid base node" : "doesn't exist");
         g_free(clean_path);
         return NULL;
@@ -4770,7 +4770,7 @@ dt_action_t *dt_action_locate(dt_action_t *owner,
     if(owner->type <= DT_ACTION_TYPE_VIEW)
     {
       dt_print(DT_DEBUG_ALWAYS,
-               "[dt_action_locate] found action '%s' internal node\n", owner->id);
+               "[dt_action_locate] found action '%s' internal node", owner->id);
       return NULL;
     }
   }

--- a/src/gui/color_picker_proxy.c
+++ b/src/gui/color_picker_proxy.c
@@ -322,7 +322,7 @@ static void _iop_color_picker_pickerdata_ready_callback(gpointer instance,
         dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_PICKER,
                       "color picker apply",
                       pipe, module, DT_DEVICE_NONE, NULL, NULL,
-                      "%s%s.%s%s. point=%.3f - %.3f. area=%.3f - %.3f / %.3f - %.3f\n",
+                      "%s%s.%s%s. point=%.3f - %.3f. area=%.3f - %.3f / %.3f - %.3f",
                       picker->flags & DT_COLOR_PICKER_POINT ? " point" : "",
                       picker->flags & DT_COLOR_PICKER_AREA  ? " area" : "",
                       picker->flags & DT_COLOR_PICKER_DENOISE ? " denoise" : "",
@@ -355,7 +355,7 @@ static void _color_picker_proxy_preview_pipe_callback(gpointer instance,
   {
     dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_PICKER | DT_DEBUG_VERBOSE,
                   "picker update callback",
-                  NULL, NULL, DT_DEVICE_NONE, NULL, NULL, "\n");
+                  NULL, NULL, DT_DEVICE_NONE, NULL, NULL);
 
     // pixelpipe may have run because sample area changed or an iop,
     // regardless we want to the colorpicker lib, which also can

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -1106,7 +1106,7 @@ void dt_open_url(const char* url)
     dt_control_log(_("error while opening URL in web browser"));
     if(error != NULL)
     {
-      dt_print(DT_DEBUG_ALWAYS, "unable to read file: %s\n", error->message);
+      dt_print(DT_DEBUG_ALWAYS, "unable to read file: %s", error->message);
       g_error_free(error);
     }
   }
@@ -1415,7 +1415,7 @@ int dt_gui_gtk_init(dt_gui_gtk_t *gui)
   darktable.gui->reset = 0;
 
   // let's try to support pressure sensitive input devices like tablets for mask drawing
-  dt_print(DT_DEBUG_INPUT, "[input device] Input devices found:\n\n");
+  dt_print(DT_DEBUG_INPUT, "[input device] Input devices found:\n");
 
   GList *input_devices
       = gdk_seat_get_slaves(gdk_display_get_default_seat(gdk_display_get_default()),
@@ -1428,7 +1428,7 @@ int dt_gui_gtk_init(dt_gui_gtk_t *gui)
     const gint n_axes = (source == GDK_SOURCE_KEYBOARD ? 0 : gdk_device_get_n_axes(device));
 
     dt_print(DT_DEBUG_INPUT,
-             "%s (%s), source: %s, mode: %s, %d axes, %d keys\n",
+             "%s (%s), source: %s, mode: %s, %d axes, %d keys",
              gdk_device_get_name(device),
              (source != GDK_SOURCE_KEYBOARD) && gdk_device_get_has_cursor(device)
              ? "with cursor"
@@ -1439,10 +1439,9 @@ int dt_gui_gtk_init(dt_gui_gtk_t *gui)
 
     for(int i = 0; i < n_axes; i++)
     {
-      dt_print(DT_DEBUG_INPUT, "  %s\n",
+      dt_print(DT_DEBUG_INPUT, "  %s",
                _get_axis_name(gdk_device_get_axis_use(device, i)));
     }
-    dt_print(DT_DEBUG_INPUT, "\n");
   }
   g_list_free(input_devices);
 
@@ -1511,10 +1510,10 @@ double dt_get_system_gui_ppd(GtkWidget *widget)
 #endif
   if((res < 1.0f) || (res > 4.0f))
   {
-    dt_print(DT_DEBUG_CONTROL, "[dt_get_system_gui_ppd] can't detect system ppd\n");
+    dt_print(DT_DEBUG_CONTROL, "[dt_get_system_gui_ppd] can't detect system ppd");
     return 1.0f;
   }
-  dt_print(DT_DEBUG_CONTROL, "[dt_get_system_gui_ppd] system ppd is %f\n", res);
+  dt_print(DT_DEBUG_CONTROL, "[dt_get_system_gui_ppd] system ppd is %f", res);
   return res;
 }
 
@@ -1527,7 +1526,7 @@ double dt_get_screen_resolution(GtkWidget *widget)
     gdk_screen_set_resolution(gtk_widget_get_screen(widget), screen_dpi);
     dt_print(DT_DEBUG_CONTROL,
              "[screen resolution] setting the screen resolution to %f dpi as specified in "
-             "the configuration file\n",
+             "the configuration file",
              screen_dpi);
   }
   else
@@ -1538,11 +1537,11 @@ double dt_get_screen_resolution(GtkWidget *widget)
       screen_dpi = 96.0;
       gdk_screen_set_resolution(gtk_widget_get_screen(widget), 96.0);
       dt_print(DT_DEBUG_CONTROL,
-               "[screen resolution] setting the screen resolution to the default 96 dpi\n");
+               "[screen resolution] setting the screen resolution to the default 96 dpi");
     }
     else
       dt_print(DT_DEBUG_CONTROL,
-               "[screen resolution] setting the screen resolution to %f dpi\n",
+               "[screen resolution] setting the screen resolution to %f dpi",
                screen_dpi);
   }
   return screen_dpi;
@@ -3180,7 +3179,7 @@ void dt_gui_show_help(GtkWidget *widget)
   gchar *help_url = dt_gui_get_help_url(widget);
   if(help_url && *help_url)
   {
-    dt_print(DT_DEBUG_CONTROL, "[context help] opening `%s'\n", help_url);
+    dt_print(DT_DEBUG_CONTROL, "[context help] opening `%s'", help_url);
     char *base_url = _get_base_url();
 
     // The base_url is: docs.darktable.org/usermanual
@@ -3354,13 +3353,13 @@ void dt_gui_load_theme(const char *theme)
   gchar *path_uri = g_filename_to_uri(path, NULL, &error);
   if(path_uri == NULL)
     dt_print(DT_DEBUG_ALWAYS,
-             "%s: could not convert path %s to URI. Error: %s\n",
+             "%s: could not convert path %s to URI. Error: %s",
              G_STRFUNC, path, error->message);
 
   gchar *usercsspath_uri = g_filename_to_uri(usercsspath, NULL, &error);
   if(usercsspath_uri == NULL)
     dt_print(DT_DEBUG_ALWAYS,
-             "%s: could not convert path %s to URI. Error: %s\n",
+             "%s: could not convert path %s to URI. Error: %s",
              G_STRFUNC, usercsspath, error->message);
 
   gchar *themecss = NULL;
@@ -3393,7 +3392,7 @@ void dt_gui_load_theme(const char *theme)
                                       themecss, -1, &error))
   {
     dt_print(DT_DEBUG_ALWAYS,
-             "%s: error parsing combined CSS %s: %s\n",
+             "%s: error parsing combined CSS %s: %s",
              G_STRFUNC, themecss, error->message);
     g_clear_error(&error);
   }
@@ -3598,7 +3597,7 @@ static float _action_process_tabs(gpointer target,
       break;
     default:
       dt_print(DT_DEBUG_ALWAYS,
-               "[_action_process_tabs] unknown shortcut effect (%d) for tabs\n",
+               "[_action_process_tabs] unknown shortcut effect (%d) for tabs",
                effect);
       break;
     }

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -256,7 +256,8 @@ static gchar *_panels_get_panel_path(dt_ui_panel_t panel,
 {
   gchar *v = _panels_get_view_path("");
   if(!v) return NULL;
-  return dt_util_dstrcat(v, "%s%s", _ui_panel_config_names[panel], suffix);
+  dt_util_str_cat(&v, "%s%s", _ui_panel_config_names[panel], suffix);
+  return v;
 }
 
 static gboolean _panel_is_visible(dt_ui_panel_t panel)
@@ -3192,12 +3193,12 @@ void dt_gui_show_help(GtkWidget *widget)
     // in case of a standard release, append the dt version to the url
     if(dt_is_dev_version())
     {
-      base_url = dt_util_dstrcat(base_url, "development/");
+      dt_util_str_cat(&base_url, "development/");
     }
     else
     {
       char *ver = dt_version_major_minor();
-      base_url = dt_util_dstrcat(base_url, "%s/", ver);
+      dt_util_str_cat(&base_url, "%s/", ver);
       g_free(ver);
     }
 

--- a/src/gui/guides.c
+++ b/src/gui/guides.c
@@ -99,9 +99,9 @@ static gchar *_conf_get_path(gchar *module_name, gchar *property_1, gchar *prope
   }
 
   if(property_2)
-    return dt_util_dstrcat(NULL, "guides/%s/%s%s/%s/%s", cv->module_name, lay, module_name, property_1, property_2);
+    return g_strdup_printf("guides/%s/%s%s/%s/%s", cv->module_name, lay, module_name, property_1, property_2);
   else
-    return dt_util_dstrcat(NULL, "guides/%s/%s%s/%s", cv->module_name, lay, module_name, property_1);
+    return g_strdup_printf("guides/%s/%s%s/%s", cv->module_name, lay, module_name, property_1);
 }
 
 static dt_guides_t *_conf_get_guide(gchar *module_name)

--- a/src/gui/import_metadata.c
+++ b/src/gui/import_metadata.c
@@ -316,7 +316,7 @@ static void _import_tags_presets_update(dt_import_metadata_t *metadata)
         {
           const guint tagid = strtoul(*entry, NULL, 0);
           char *tag = dt_tag_get_name(tagid);
-          tags = dt_util_dstrcat(tags, "%s,", tag);
+          dt_util_str_cat(&tags, "%s,", tag);
           g_free(tag);
           entry++;
         }

--- a/src/gui/preferences.c
+++ b/src/gui/preferences.c
@@ -99,7 +99,7 @@ static void load_themes_dir(const char *basedir)
   GDir *dir = g_dir_open(themes_dir, 0, NULL);
   if(dir)
   {
-    dt_print(DT_DEBUG_DEV, "adding themes directory: %s\n", themes_dir);
+    dt_print(DT_DEBUG_DEV, "adding themes directory: %s", themes_dir);
 
     const gchar *d_name;
     while((d_name = g_dir_read_name(dir)))
@@ -192,7 +192,7 @@ static void save_usercss(GtkTextBuffer *buffer)
   GError *error = NULL;
   if(!g_file_set_contents(usercsspath, usercsscontent, -1, &error))
   {
-    dt_print(DT_DEBUG_ALWAYS, "%s: error saving css to %s: %s\n",
+    dt_print(DT_DEBUG_ALWAYS, "%s: error saving css to %s: %s",
              G_STRFUNC, usercsspath, error->message);
     g_clear_error(&error);
   }

--- a/src/gui/presets.c
+++ b/src/gui/presets.c
@@ -1349,7 +1349,7 @@ static gboolean _menuitem_manage_quick_presets_traverse(GtkTreeModel *model,
 
   if(active && preset && iop_name)
   {
-    *txt = dt_util_dstrcat(*txt, "ꬹ%s|%sꬹ", iop_name, preset);
+    dt_util_str_cat(&*txt, "ꬹ%s|%sꬹ", iop_name, preset);
   }
   g_free(iop_name);
   g_free(preset);
@@ -1568,7 +1568,7 @@ void dt_gui_favorite_presets_menu_show(GtkWidget *w)
           gchar *key = g_strdup_printf("plugins/darkroom/%s/favorite", iop->so->op);
           const gboolean fav = dt_conf_get_bool(key);
           g_free(key);
-          if(fav) config = dt_util_dstrcat(config, "ꬹ%s|%sꬹ", iop->so->op, name);
+          if(fav) dt_util_str_cat(&config, "ꬹ%s|%sꬹ", iop->so->op, name);
         }
 
         // check that this preset is in the config list

--- a/src/imageio/format/avif.c
+++ b/src/imageio/format/avif.c
@@ -146,7 +146,7 @@ void init(dt_imageio_module_format_t *self)
   if(codecName == NULL)
   {
     dt_print(DT_DEBUG_IMAGEIO,
-             "libavif doesn't offer encoding support!\n");
+             "libavif doesn't offer encoding support!");
     self->ready = FALSE;
     return;
   }
@@ -293,7 +293,7 @@ int write_image(struct dt_imageio_module_data_t *data,
 
   dt_print(DT_DEBUG_IMAGEIO,
            "Exporting AVIF image [%s] "
-           "[width: %zu, height: %zu, bit depth: %zu, comp: %s, quality: %u]\n",
+           "[width: %zu, height: %zu, bit depth: %zu, comp: %s, quality: %u]",
            filename,
            width,
            height,
@@ -369,7 +369,7 @@ int write_image(struct dt_imageio_module_data_t *data,
   if(format == AVIF_PIXEL_FORMAT_YUV444 && d->compression_type == AVIF_COMP_LOSSLESS)
     image->matrixCoefficients = AVIF_MATRIX_COEFFICIENTS_IDENTITY;
 
-  dt_print(DT_DEBUG_IMAGEIO, "[avif colorprofile profile: %s]\n", dt_colorspaces_get_name(cp->type, filename));
+  dt_print(DT_DEBUG_IMAGEIO, "[avif colorprofile profile: %s]", dt_colorspaces_get_name(cp->type, filename));
 
   if(!have_nclx)
   {
@@ -381,7 +381,7 @@ int write_image(struct dt_imageio_module_data_t *data,
       icc_profile_data = malloc(sizeof(uint8_t) * icc_profile_len);
       if(icc_profile_data == NULL)
       {
-        dt_print(DT_DEBUG_IMAGEIO, "Failed to allocate ICC profile\n");
+        dt_print(DT_DEBUG_IMAGEIO, "Failed to allocate ICC profile");
         rc = 1;
         goto out;
       }
@@ -390,7 +390,7 @@ int write_image(struct dt_imageio_module_data_t *data,
       result = avifImageSetProfileICC(image, icc_profile_data, icc_profile_len);
       if(result != AVIF_RESULT_OK)
       {
-        dt_print(DT_DEBUG_IMAGEIO, "avifImageSetProfileICC failed\n");
+        dt_print(DT_DEBUG_IMAGEIO, "avifImageSetProfileICC failed");
         rc = 1;
         goto out;
       }
@@ -423,7 +423,7 @@ int write_image(struct dt_imageio_module_data_t *data,
   result = avifRGBImageAllocatePixels(&rgb);
   if(result != AVIF_RESULT_OK)
   {
-    dt_print(DT_DEBUG_IMAGEIO, "avifRGBImageAllocatePixels failed\n");
+    dt_print(DT_DEBUG_IMAGEIO, "avifRGBImageAllocatePixels failed");
     rc = 1;
     goto out;
   }
@@ -484,7 +484,7 @@ int write_image(struct dt_imageio_module_data_t *data,
   result = avifImageRGBToYUV(image, &rgb);
   if(result != AVIF_RESULT_OK)
   {
-    dt_print(DT_DEBUG_IMAGEIO, "avifImageRGBToYUV failed\n");
+    dt_print(DT_DEBUG_IMAGEIO, "avifImageRGBToYUV failed");
     rc = 1;
     goto out;
   }
@@ -497,7 +497,7 @@ int write_image(struct dt_imageio_module_data_t *data,
     result = avifImageSetMetadataExif(image, exif, exif_len);
     if(result != AVIF_RESULT_OK)
     {
-      dt_print(DT_DEBUG_IMAGEIO, "avifImageSetMetadataExif failed\n");
+      dt_print(DT_DEBUG_IMAGEIO, "avifImageSetMetadataExif failed");
       // as this error does not lead to invalid files keep going
     }
 #else
@@ -518,7 +518,7 @@ int write_image(struct dt_imageio_module_data_t *data,
       g_free(xmp_string);
       if(result != AVIF_RESULT_OK)
       {
-        dt_print(DT_DEBUG_IMAGEIO, "avifImageSetMetadataXMP failed\n");
+        dt_print(DT_DEBUG_IMAGEIO, "avifImageSetMetadataXMP failed");
         // as this error does not lead to invalid files keep going
       }
 #else
@@ -530,7 +530,7 @@ int write_image(struct dt_imageio_module_data_t *data,
   encoder = avifEncoderCreate();
   if(encoder == NULL)
   {
-    dt_print(DT_DEBUG_IMAGEIO, "avifEncoderCreate failed\n");
+    dt_print(DT_DEBUG_IMAGEIO, "avifEncoderCreate failed");
     result = AVIF_RESULT_UNKNOWN_ERROR;
     rc = 1;
     goto out;
@@ -609,7 +609,7 @@ int write_image(struct dt_imageio_module_data_t *data,
 
   dt_print(DT_DEBUG_IMAGEIO,
            "[avif quality: %u => maxQuantizer: %u, minQuantizer: %u, "
-           "tileColsLog2: %u, tileRowsLog2: %u, threads: %u, speed: %u]\n",
+           "tileColsLog2: %u, tileRowsLog2: %u, threads: %u, speed: %u]",
            d->quality,
            encoder->maxQuantizer,
            encoder->minQuantizer,
@@ -623,14 +623,14 @@ int write_image(struct dt_imageio_module_data_t *data,
   result = avifEncoderWrite(encoder, image, &output);
   if(result != AVIF_RESULT_OK)
   {
-    dt_print(DT_DEBUG_IMAGEIO, "avifEncoderWrite failed\n");
+    dt_print(DT_DEBUG_IMAGEIO, "avifEncoderWrite failed");
     rc = 1;
     goto out;
   }
 
   if(output.size == 0 || output.data == NULL)
   {
-    dt_print(DT_DEBUG_IMAGEIO, "avifEncoderWrite returned empty data\n");
+    dt_print(DT_DEBUG_IMAGEIO, "avifEncoderWrite returned empty data");
     result = AVIF_RESULT_UNKNOWN_ERROR;
     rc = 1;
     goto out;
@@ -662,7 +662,7 @@ int write_image(struct dt_imageio_module_data_t *data,
 out:
 
   if(result || rc)
-    dt_print(DT_DEBUG_IMAGEIO, "%s `%s'%s%s\n",
+    dt_print(DT_DEBUG_IMAGEIO, "%s `%s'%s%s",
         image     ? "Write AVIF image error"
                   : "Failed to create AVIF image",
         filename,

--- a/src/imageio/format/exr.cc
+++ b/src/imageio/format/exr.cc
@@ -251,7 +251,7 @@ icc_end:
     out_image = dt_alloc_aligned(stride * width * height);
     if(out_image == NULL)
     {
-      dt_print(DT_DEBUG_ALWAYS, "[exr export] error allocating image conversion buffer\n");
+      dt_print(DT_DEBUG_ALWAYS, "[exr export] error allocating image conversion buffer");
       return 1;
     }
 
@@ -327,7 +327,7 @@ icc_end:
           void *out_mask = dt_alloc_aligned(stride * width * height);
           if(out_mask == NULL)
           {
-            dt_print(DT_DEBUG_ALWAYS, "[exr export] error allocating mask conversion buffer\n");
+            dt_print(DT_DEBUG_ALWAYS, "[exr export] error allocating mask conversion buffer");
             return 1;
           }
 

--- a/src/imageio/format/j2k.c
+++ b/src/imageio/format/j2k.c
@@ -214,7 +214,7 @@ static void cinema_setup_encoder(opj_cparameters_t *parameters, opj_image_t *ima
       {
         dt_print(DT_DEBUG_ALWAYS,
                  "Image coordinates %d x %d is not 2K compliant.\nJPEG Digital Cinema Profile-3 "
-                 "(2K profile) compliance requires that at least one of coordinates match 2048 x 1080\n",
+                 "(2K profile) compliance requires that at least one of coordinates match 2048 x 1080",
                  image->comps[0].w, image->comps[0].h);
         parameters->cp_rsiz = OPJ_STD_RSIZ;
       }
@@ -234,7 +234,7 @@ static void cinema_setup_encoder(opj_cparameters_t *parameters, opj_image_t *ima
       {
         dt_print(DT_DEBUG_ALWAYS,
                  "Image coordinates %d x %d is not 4K compliant.\nJPEG Digital Cinema Profile-4 "
-                 "(4K profile) compliance requires that at least one of coordinates match 4096 x 2160\n",
+                 "(4K profile) compliance requires that at least one of coordinates match 4096 x 2160",
                  image->comps[0].w, image->comps[0].h);
         parameters->cp_rsiz = OPJ_STD_RSIZ;
       }
@@ -374,7 +374,7 @@ int write_image(dt_imageio_module_data_t *j2k_tmp, const char *filename, const v
     image = opj_image_create(numcomps, &cmptparm[0], OPJ_CLRSPC_SRGB);
     if(!image)
     {
-      dt_print(DT_DEBUG_ALWAYS, "Error: opj_image_create() failed\n");
+      dt_print(DT_DEBUG_ALWAYS, "Error: opj_image_create() failed");
       free(rates);
       rc = 0;
       goto exit;
@@ -410,7 +410,7 @@ int write_image(dt_imageio_module_data_t *j2k_tmp, const char *filename, const v
 //        }
 //        break;
 //      default:
-//        dt_print(DT_DEBUG_ALWAYS, "Error: this shouldn't happen, there is no bit depth of %d for jpeg 2000 images.\n",
+//        dt_print(DT_DEBUG_ALWAYS, "Error: this shouldn't happen, there is no bit depth of %d for jpeg 2000 images.",
 //                prec);
 //        free(rates);
 //        opj_image_destroy(image);
@@ -452,7 +452,7 @@ int write_image(dt_imageio_module_data_t *j2k_tmp, const char *filename, const v
   {
     opj_destroy_codec(ccodec);
     opj_image_destroy(image);
-    dt_print(DT_DEBUG_ALWAYS, "failed to create output stream\n");
+    dt_print(DT_DEBUG_ALWAYS, "failed to create output stream");
     rc = 0;
     goto exit;
   }
@@ -462,7 +462,7 @@ int write_image(dt_imageio_module_data_t *j2k_tmp, const char *filename, const v
     opj_stream_destroy(cstream);
     opj_destroy_codec(ccodec);
     opj_image_destroy(image);
-    dt_print(DT_DEBUG_ALWAYS, "failed to encode image: opj_start_compress\n");
+    dt_print(DT_DEBUG_ALWAYS, "failed to encode image: opj_start_compress");
     rc = 0;
     goto exit;
   }
@@ -473,7 +473,7 @@ int write_image(dt_imageio_module_data_t *j2k_tmp, const char *filename, const v
     opj_stream_destroy(cstream);
     opj_destroy_codec(ccodec);
     opj_image_destroy(image);
-    dt_print(DT_DEBUG_ALWAYS, "failed to encode image: opj_encode\n");
+    dt_print(DT_DEBUG_ALWAYS, "failed to encode image: opj_encode");
     rc = 0;
     goto exit;
   }
@@ -484,7 +484,7 @@ int write_image(dt_imageio_module_data_t *j2k_tmp, const char *filename, const v
     opj_stream_destroy(cstream);
     opj_destroy_codec(ccodec);
     opj_image_destroy(image);
-    dt_print(DT_DEBUG_ALWAYS, "failed to encode image: opj_end_compress\n");
+    dt_print(DT_DEBUG_ALWAYS, "failed to encode image: opj_end_compress");
     rc = 0;
     goto exit;
   }

--- a/src/imageio/format/jxl.c
+++ b/src/imageio/format/jxl.c
@@ -132,7 +132,7 @@ int write_image(struct dt_imageio_module_data_t *data,
     if((JxlEncoderStatus)code != JXL_ENC_SUCCESS)                                                                 \
     {                                                                                                             \
       JxlEncoderError err = JxlEncoderGetError(encoder);                                                          \
-      dt_print(DT_DEBUG_IMAGEIO, "[jxl] libjxl call failed with err %d (src/imageio/format/jxl.c#L%d)\n", err,    \
+      dt_print(DT_DEBUG_IMAGEIO, "[jxl] libjxl call failed with err %d (src/imageio/format/jxl.c#L%d)", err,      \
                __LINE__);                                                                                         \
       goto end;                                                                                                   \
     }                                                                                                             \
@@ -140,7 +140,7 @@ int write_image(struct dt_imageio_module_data_t *data,
 
 #define JXL_FAIL(msg, ...)                                                                                        \
   {                                                                                                               \
-    dt_print(DT_DEBUG_IMAGEIO, "[jxl] " msg "\n", ##__VA_ARGS__);                                                 \
+    dt_print(DT_DEBUG_IMAGEIO, "[jxl] " msg "", ##__VA_ARGS__);                                                   \
     goto end;                                                                                                     \
   }
 
@@ -282,7 +282,7 @@ int write_image(struct dt_imageio_module_data_t *data,
   {
     // If we didn't manage to write the color encoding natively we need to fallback to ICC
     dt_print(DT_DEBUG_IMAGEIO,
-             "[jxl] could not generate color encoding structure, falling back to ICC\n");
+             "[jxl] could not generate color encoding structure, falling back to ICC");
 
     cmsUInt32Number icc_size = 0;
     // First find the size of the ICC buffer

--- a/src/imageio/format/pdf.c
+++ b/src/imageio/format/pdf.c
@@ -196,14 +196,14 @@ static int _paper_size(dt_imageio_pdf_params_t *d, float *page_width, float *pag
 
   if(!dt_pdf_parse_paper_size(d->size, &width, &height))
   {
-    dt_print(DT_DEBUG_ALWAYS, "[imageio_format_pdf] invalid paper size: `%s'!\n", d->size);
+    dt_print(DT_DEBUG_ALWAYS, "[imageio_format_pdf] invalid paper size: `%s'!", d->size);
     dt_control_log(_("invalid paper size"));
     return 1;
   }
 
   if(!dt_pdf_parse_length(d->border, &border))
   {
-    dt_print(DT_DEBUG_ALWAYS, "[imageio_format_pdf] invalid border size: `%s'! using 0\n", d->border);
+    dt_print(DT_DEBUG_ALWAYS, "[imageio_format_pdf] invalid border size: `%s'! using 0", d->border);
     dt_control_log(_("invalid border size, using 0"));
 //     return 1;
     border = 0.0;
@@ -253,7 +253,7 @@ int write_image(dt_imageio_module_data_t *data, const char *filename, const void
     dt_pdf_t *pdf = dt_pdf_start(filename, page_width, page_height, page_dpi, compression);
     if(!pdf)
     {
-      dt_print(DT_DEBUG_ALWAYS, "[imageio_format_pdf] could not export to file: `%s'!\n", filename);
+      dt_print(DT_DEBUG_ALWAYS, "[imageio_format_pdf] could not export to file: `%s'!", filename);
       dt_control_log(_("could not export to file `%s'!"), filename);
       return 1;
     }

--- a/src/imageio/format/png.c
+++ b/src/imageio/format/png.c
@@ -82,7 +82,7 @@ static void PNGwriteRawProfile(png_struct *ping,
   text = png_malloc(ping, sizeof(png_text));
   if(!text)
   {
-    dt_print(DT_DEBUG_ALWAYS,"[png] out of memory adding profile to image\n");
+    dt_print(DT_DEBUG_ALWAYS,"[png] out of memory adding profile to image");
     return;
   }
   description_length = strlen(profile_type);
@@ -94,7 +94,7 @@ static void PNGwriteRawProfile(png_struct *ping,
   if(!text[0].text || !text[0].key)
   {
     dt_print(DT_DEBUG_ALWAYS,
-             "[png] out of memory adding profile to image\n");
+             "[png] out of memory adding profile to image");
     goto cleanup;
   }
 
@@ -333,7 +333,7 @@ int write_image(dt_imageio_module_data_t *p_tmp,
   }
   else
   {
-    dt_print(DT_DEBUG_ALWAYS, "[png] out of memory writing %s\n", filename);
+    dt_print(DT_DEBUG_ALWAYS, "[png] out of memory writing %s", filename);
   }
   png_write_end(png_ptr, info_ptr);
   png_destroy_write_struct(&png_ptr, &info_ptr);

--- a/src/imageio/format/webp.c
+++ b/src/imageio/format/webp.c
@@ -152,7 +152,7 @@ int write_image(dt_imageio_module_data_t *webp, const char *filename, const void
   config.partition_limit = 70;
   if(!WebPValidateConfig(&config))
   {
-    dt_print(DT_DEBUG_ALWAYS, "[webp export] error validating encoder configuration\n");
+    dt_print(DT_DEBUG_ALWAYS, "[webp export] error validating encoder configuration");
     goto error;
   }
 
@@ -171,13 +171,13 @@ int write_image(dt_imageio_module_data_t *webp, const char *filename, const void
       err = WebPMuxSetChunk(mux, "ICCP", &icc_profile, 0);
       if(err != WEBP_MUX_OK)
       {
-        dt_print(DT_DEBUG_ALWAYS, "[webp export] error adding ICC profile to WebP stream\n");
+        dt_print(DT_DEBUG_ALWAYS, "[webp export] error adding ICC profile to WebP stream");
         goto error;
       }
     }
     else
     {
-      dt_print(DT_DEBUG_ALWAYS, "[webp export] error allocating ICC profile buffer\n");
+      dt_print(DT_DEBUG_ALWAYS, "[webp export] error allocating ICC profile buffer");
       goto error;
     }
   }
@@ -203,7 +203,7 @@ int write_image(dt_imageio_module_data_t *webp, const char *filename, const void
 
   if(!WebPEncode(&config, &pic))
   {
-    dt_print(DT_DEBUG_ALWAYS, "[webp export] error (%d) during encoding: %s\n", pic.error_code,
+    dt_print(DT_DEBUG_ALWAYS, "[webp export] error (%d) during encoding: %s", pic.error_code,
             get_error_str(pic.error_code));
     goto error;
   }
@@ -213,7 +213,7 @@ int write_image(dt_imageio_module_data_t *webp, const char *filename, const void
   err = WebPMuxSetImage(mux, &bitstream, 0);
   if(err != WEBP_MUX_OK)
   {
-    dt_print(DT_DEBUG_ALWAYS, "[webp export] error adding image to WebP stream\n");
+    dt_print(DT_DEBUG_ALWAYS, "[webp export] error adding image to WebP stream");
     goto error;
   }
 
@@ -221,19 +221,19 @@ int write_image(dt_imageio_module_data_t *webp, const char *filename, const void
   err = WebPMuxAssemble(mux, &assembled_data);
   if(err != WEBP_MUX_OK)
   {
-    dt_print(DT_DEBUG_ALWAYS, "[webp export] error assembling the WebP file\n");
+    dt_print(DT_DEBUG_ALWAYS, "[webp export] error assembling the WebP file");
     goto error;
   }
 
   out = g_fopen(filename, "w+b");
   if(!out)
   {
-    dt_print(DT_DEBUG_ALWAYS, "[webp export] error creating file %s\n", filename);
+    dt_print(DT_DEBUG_ALWAYS, "[webp export] error creating file %s", filename);
     goto error;
   }
   if(fwrite(assembled_data.bytes, assembled_data.size, 1, out) != 1)
   {
-    dt_print(DT_DEBUG_ALWAYS, "[webp export] error writing %zu bytes to file %s\n", assembled_data.size, filename);
+    dt_print(DT_DEBUG_ALWAYS, "[webp export] error writing %zu bytes to file %s", assembled_data.size, filename);
     goto error;
   }
 

--- a/src/imageio/format/xcf.c
+++ b/src/imageio/format/xcf.c
@@ -63,7 +63,7 @@ int write_image(dt_imageio_module_data_t *data, const char *filename, const void
     profile = malloc(profile_len);
     if(!profile)
     {
-      dt_print(DT_DEBUG_ALWAYS, "[xcf] error: can't allocate %u bytes of memory\n", profile_len);
+      dt_print(DT_DEBUG_ALWAYS, "[xcf] error: can't allocate %u bytes of memory", profile_len);
       return 1;
     }
     cmsSaveProfileToMem(out_profile, profile, &profile_len);
@@ -86,7 +86,7 @@ int write_image(dt_imageio_module_data_t *data, const char *filename, const void
 
   if(!xcf)
   {
-    dt_print(DT_DEBUG_ALWAYS, "[xcf] error: can't open `%s'\n", filename);
+    dt_print(DT_DEBUG_ALWAYS, "[xcf] error: can't open `%s'", filename);
     goto exit;
   }
 
@@ -102,7 +102,7 @@ int write_image(dt_imageio_module_data_t *data, const char *filename, const void
     xcf_set(xcf, XCF_PRECISION, profile_is_linear ? XCF_PRECISION_F_32_L : XCF_PRECISION_F_32_G);
   else
   {
-    dt_print(DT_DEBUG_ALWAYS, "[xcf] error: bpp of %d is not supported\n", d->bpp);
+    dt_print(DT_DEBUG_ALWAYS, "[xcf] error: bpp of %d is not supported", d->bpp);
     goto exit;
   }
 
@@ -132,7 +132,7 @@ int write_image(dt_imageio_module_data_t *data, const char *filename, const void
     uint8_t *exif_buf = g_malloc0(exif_len + 6);
     if(!exif_buf)
     {
-      dt_print(DT_DEBUG_ALWAYS, "[xcf] error: can't allocate %d bytes of memory\n", exif_len + 6);
+      dt_print(DT_DEBUG_ALWAYS, "[xcf] error: can't allocate %d bytes of memory", exif_len + 6);
       goto exit;
     }
     memcpy(exif_buf, "Exif\0\0", 6);
@@ -224,7 +224,7 @@ int write_image(dt_imageio_module_data_t *data, const char *filename, const void
         if(channel_data)
           xcf_add_data(xcf, channel_data, 1);
         else
-          dt_print(DT_DEBUG_ALWAYS, "[xcf] out of memory writing image data to %s\n", filename);
+          dt_print(DT_DEBUG_ALWAYS, "[xcf] out of memory writing image data to %s", filename);
 
         if(free_channel_data)
           free(channel_data);

--- a/src/imageio/imageio.c
+++ b/src/imageio/imageio.c
@@ -650,7 +650,7 @@ gboolean dt_imageio_large_thumbnail(const char *filename,
     if(!image)
     {
       dt_print(DT_DEBUG_ALWAYS,
-               "[dt_imageio_large_thumbnail GM] thumbnail not found?\n");
+               "[dt_imageio_large_thumbnail GM] thumbnail not found?");
       goto error_gm;
     }
 
@@ -674,7 +674,7 @@ gboolean dt_imageio_large_thumbnail(const char *filename,
       if(gm_ret != MagickPass)
       {
         dt_print(DT_DEBUG_ALWAYS,
-                 "[dt_imageio_large_thumbnail GM] error_gm reading thumbnail\n");
+                 "[dt_imageio_large_thumbnail GM] error_gm reading thumbnail");
         dt_free_align(*buffer);
         *buffer = NULL;
         goto error_gm;
@@ -698,7 +698,7 @@ gboolean dt_imageio_large_thumbnail(const char *filename,
     if(mret != MagickTrue)
     {
       dt_print(DT_DEBUG_ALWAYS,
-               "[dt_imageio_large_thumbnail IM] thumbnail not found?\n");
+               "[dt_imageio_large_thumbnail IM] thumbnail not found?");
       goto error_im;
     }
 
@@ -728,7 +728,7 @@ gboolean dt_imageio_large_thumbnail(const char *filename,
       free(*buffer);
       *buffer = NULL;
       dt_print(DT_DEBUG_ALWAYS,
-          "[dt_imageio_large_thumbnail IM] error while reading thumbnail\n");
+          "[dt_imageio_large_thumbnail IM] error while reading thumbnail");
       goto error_im;
     }
 
@@ -750,7 +750,7 @@ error_im:
   {
     dt_print(DT_DEBUG_ALWAYS,
              "[dt_imageio_large_thumbnail] error: Not a supported thumbnail "
-             "image format or broken thumbnail: %s\n",
+             "image format or broken thumbnail: %s",
              mime_type);
     goto error;
   }
@@ -791,7 +791,7 @@ gboolean dt_imageio_has_mono_preview(const char *filename)
   cleanup:
 
   dt_print(DT_DEBUG_IMAGEIO,
-           "[dt_imageio_has_mono_preview] testing `%s', monochrome=%s, %ix%i\n",
+           "[dt_imageio_has_mono_preview] testing `%s', monochrome=%s, %ix%i",
            filename, mono ? "YES" : "FALSE", thumb_width, thumb_height);
   dt_free_align(tmp);
   return mono;
@@ -1053,7 +1053,7 @@ gboolean dt_imageio_export_with_flags(const dt_imgid_t imgid,
   if(!buf.buf || !buf.width || !buf.height)
   {
     dt_print(DT_DEBUG_ALWAYS,
-             "[dt_imageio_export_with_flags] mipmap allocation for `%s' failed (status %d)\n",
+             "[dt_imageio_export_with_flags] mipmap allocation for `%s' failed (status %d)",
              filename,img->load_status);
     if(img->load_status == DT_IMAGEIO_FILE_NOT_FOUND)
       dt_control_log(_("image `%s' is not available!"), img->filename);
@@ -1095,7 +1095,7 @@ gboolean dt_imageio_export_with_flags(const dt_imgid_t imgid,
     if(!style_items)
     {
       dt_print(DT_DEBUG_ALWAYS,
-               "[imageio] cannot find the style '%s' to apply during export\n",
+               "[imageio] cannot find the style '%s' to apply during export",
                format_params->style);
       if(darktable.gui)
         dt_control_log(_("cannot find the style '%s' to apply during export"),
@@ -1136,7 +1136,7 @@ gboolean dt_imageio_export_with_flags(const dt_imgid_t imgid,
         else
         {
           dt_print(DT_DEBUG_ALWAYS,
-                  "[dt_imageio_export_with_flags] cannot find module %s for style\n",
+                  "[dt_imageio_export_with_flags] cannot find module %s for style",
                   st_item->operation);
           ok = FALSE;
         }
@@ -1177,7 +1177,7 @@ gboolean dt_imageio_export_with_flags(const dt_imgid_t imgid,
     }
 
     dt_print(DT_DEBUG_ALWAYS,
-             "[dt_imageio_export_with_flags] %s%s%s%s%s modules:%s\n",
+             "[dt_imageio_export_with_flags] %s%s%s%s%s modules:%s",
              use_style && appending      ? "append style history " : "",
              use_style && !appending     ? "replace style history " : "",
              use_style                   ? "`" : "",
@@ -1269,7 +1269,7 @@ gboolean dt_imageio_export_with_flags(const dt_imgid_t imgid,
   const gboolean size_warning = processed_width < 1 || processed_height < 1;
   dt_print(DT_DEBUG_IMAGEIO,
            "[dt_imageio_export] %s%s imgid %d, %ix%i --> %ix%i (scale=%.4f, maxscale=%.4f)."
-           " upscale=%s, hq=%s\n",
+           " upscale=%s, hq=%s",
            size_warning ? "**missing size** " : "",
            thumbnail_export ? "thumbnail" : "export", imgid,
            pipe.processed_width, pipe.processed_height,
@@ -1334,7 +1334,7 @@ gboolean dt_imageio_export_with_flags(const dt_imgid_t imgid,
   if(outbuf == NULL)
   {
     dt_print(DT_DEBUG_IMAGEIO,
-             "[dt_imageio_export_with_flags] no valid output buffer\n");
+             "[dt_imageio_export_with_flags] no valid output buffer");
     goto error;
   }
 

--- a/src/imageio/imageio_avif.c
+++ b/src/imageio/imageio_avif.c
@@ -51,7 +51,7 @@ dt_imageio_retval_t dt_imageio_open_avif(dt_image_t *img,
 
   if(decoder == NULL || avif_image == NULL)
   {
-    dt_print(DT_DEBUG_IMAGEIO, "[avif_open] failed to create decoder or image struct for `%s'\n", filename);
+    dt_print(DT_DEBUG_IMAGEIO, "[avif_open] failed to create decoder or image struct for `%s'", filename);
     ret = DT_IMAGEIO_LOAD_FAILED;
     goto out;
   }
@@ -62,7 +62,7 @@ dt_imageio_retval_t dt_imageio_open_avif(dt_image_t *img,
   result = avifDecoderReadFile(decoder, avif_image, filename);
   if(result != AVIF_RESULT_OK)
   {
-    dt_print(DT_DEBUG_IMAGEIO, "[avif_open] failed to parse `%s': %s\n", filename, avifResultToString(result));
+    dt_print(DT_DEBUG_IMAGEIO, "[avif_open] failed to parse `%s': %s", filename, avifResultToString(result));
     ret = DT_IMAGEIO_FILE_CORRUPTED;
     goto out;
   }
@@ -84,7 +84,7 @@ dt_imageio_retval_t dt_imageio_open_avif(dt_image_t *img,
       result = avifGetExifTiffHeaderOffset(exif->data, exif->size, &offset);
       if(result != AVIF_RESULT_OK)
       {
-        dt_print(DT_DEBUG_IMAGEIO, "[avif_open] failed to read tiff header `%s': %s\n",
+        dt_print(DT_DEBUG_IMAGEIO, "[avif_open] failed to read tiff header `%s': %s",
           filename, avifResultToString(result));
         ret = DT_IMAGEIO_LOAD_FAILED;
         goto out;
@@ -115,7 +115,7 @@ dt_imageio_retval_t dt_imageio_open_avif(dt_image_t *img,
   result = avifRGBImageAllocatePixels(&rgb);
   if(result != AVIF_RESULT_OK)
   {
-    dt_print(DT_DEBUG_IMAGEIO, "[avif_open] failed to allocate pixels `%s' : %s\n",
+    dt_print(DT_DEBUG_IMAGEIO, "[avif_open] failed to allocate pixels `%s' : %s",
       filename, avifResultToString(result));
     ret = DT_IMAGEIO_LOAD_FAILED;
     goto out;
@@ -127,7 +127,7 @@ dt_imageio_retval_t dt_imageio_open_avif(dt_image_t *img,
   result = avifImageYUVToRGB(avif_image, &rgb);
   if(result != AVIF_RESULT_OK)
   {
-    dt_print(DT_DEBUG_IMAGEIO, "[avif_open] failed to convert `%s' from YUV to RGB: %s\n",
+    dt_print(DT_DEBUG_IMAGEIO, "[avif_open] failed to convert `%s' from YUV to RGB: %s",
       filename, avifResultToString(result));
     ret = DT_IMAGEIO_LOAD_FAILED;
     goto out;
@@ -149,7 +149,7 @@ dt_imageio_retval_t dt_imageio_open_avif(dt_image_t *img,
   float *mipbuf = (float *)dt_mipmap_cache_alloc(mbuf, img);
   if(mipbuf == NULL)
   {
-    dt_print(DT_DEBUG_IMAGEIO, "[avif_open] failed to allocate mipmap buffer for `%s'\n", filename);
+    dt_print(DT_DEBUG_IMAGEIO, "[avif_open] failed to allocate mipmap buffer for `%s'", filename);
     ret = DT_IMAGEIO_CACHE_FULL;
     goto out;
   }
@@ -208,7 +208,7 @@ dt_imageio_retval_t dt_imageio_open_avif(dt_image_t *img,
     break;
   }
   default:
-    dt_print(DT_DEBUG_IMAGEIO, "[avif_open] invalid bit depth for `%s'\n", filename);
+    dt_print(DT_DEBUG_IMAGEIO, "[avif_open] invalid bit depth for `%s'", filename);
     ret = DT_IMAGEIO_CACHE_FULL;
     goto out;
   }
@@ -251,14 +251,14 @@ int dt_imageio_avif_read_profile(const char *filename, uint8_t **out, dt_colorsp
 
   if(decoder == NULL || avif_image == NULL)
   {
-    dt_print(DT_DEBUG_IMAGEIO, "[avif read profile] failed to create decoder or image struct for `%s'\n", filename);
+    dt_print(DT_DEBUG_IMAGEIO, "[avif read profile] failed to create decoder or image struct for `%s'", filename);
     goto out;
   }
 
   result = avifDecoderReadFile(decoder, avif_image, filename);
   if(result != AVIF_RESULT_OK)
   {
-    dt_print(DT_DEBUG_IMAGEIO, "[avif read profile] failed to parse `%s': %s\n", filename, avifResultToString(result));
+    dt_print(DT_DEBUG_IMAGEIO, "[avif read profile] failed to parse `%s': %s", filename, avifResultToString(result));
     goto out;
   }
 
@@ -293,7 +293,7 @@ int dt_imageio_avif_read_profile(const char *filename, uint8_t **out, dt_colorsp
 
       if(over)
       {
-        dt_print(DT_DEBUG_IMAGEIO, "[avif_open] overriding nclx color profile for `%s': 1/%d/%d to 1/%d/%d\n",
+        dt_print(DT_DEBUG_IMAGEIO, "[avif_open] overriding nclx color profile for `%s': 1/%d/%d to 1/%d/%d",
                  filename, avif_image->transferCharacteristics, avif_image->matrixCoefficients,
                  cicp->transfer_characteristics, cicp->matrix_coefficients);
       }

--- a/src/imageio/imageio_dng.h
+++ b/src/imageio/imageio_dng.h
@@ -212,19 +212,19 @@ static inline void _imageio_dng_write_tiff_header(
 
   if(buf[8] != cnt)
   {
-    dt_print(DT_DEBUG_ALWAYS, "[dng_write_header] can't write valid header, unexpected number of entries!\n");
+    dt_print(DT_DEBUG_ALWAYS, "[dng_write_header] can't write valid header, unexpected number of entries!");
     return;
   }
 
   if(data >= HEADBUFFSIZE)
   {
-    dt_print(DT_DEBUG_ALWAYS, "[dng_write_header] can't write valid header as it exceeds buffer size!\n");
+    dt_print(DT_DEBUG_ALWAYS, "[dng_write_header] can't write valid header as it exceeds buffer size!");
     return;
   }
 
   // exif is written later, by exiv2:
   const int written = fwrite(buf, 1, data, fp);
-  if(written != data) dt_print(DT_DEBUG_ALWAYS, "[dng_write_header] failed to write image header!\n");
+  if(written != data) dt_print(DT_DEBUG_ALWAYS, "[dng_write_header] failed to write image header!");
 }
 
 
@@ -242,7 +242,7 @@ static inline void dt_imageio_write_dng(
     _imageio_dng_write_tiff_header(f, wd, ht, 1.0f / 100.0f, 1.0f / 4.0f, 50.0f, 100.0f,
                                      filter, xtrans, whitelevel, wb_coeffs, adobe_XYZ_to_CAM);
     const int k = fwrite(pixel, sizeof(float), (size_t)wd * ht, f);
-    if(k != wd * ht) dt_print(DT_DEBUG_ALWAYS, "[dng_write] Error writing image data to %s\n", filename);
+    if(k != wd * ht) dt_print(DT_DEBUG_ALWAYS, "[dng_write] Error writing image data to %s", filename);
     fclose(f);
     if(exif) dt_exif_write_blob(exif, exif_len, filename, 0);
   }

--- a/src/imageio/imageio_exr.cc
+++ b/src/imageio/imageio_exr.cc
@@ -105,7 +105,7 @@ dt_imageio_retval_t dt_imageio_open_exr(dt_image_t *img,
   {
     dt_print(DT_DEBUG_ALWAYS,
              "[exr_open] error: only images with RGB(A) channels are supported,"
-             " skipping `%s'\n", img->filename);
+             " skipping `%s'", img->filename);
     return DT_IMAGEIO_UNSUPPORTED_FEATURE;
   }
 
@@ -219,7 +219,7 @@ dt_imageio_retval_t dt_imageio_open_exr(dt_image_t *img,
   if(!buf)
   {
     dt_print(DT_DEBUG_ALWAYS,
-             "[exr_open] error: could not alloc full buffer for image `%s'\n",
+             "[exr_open] error: could not alloc full buffer for image `%s'",
              img->filename);
     return DT_IMAGEIO_CACHE_FULL;
   }

--- a/src/imageio/imageio_gm.c
+++ b/src/imageio/imageio_gm.c
@@ -77,16 +77,16 @@ dt_imageio_retval_t dt_imageio_open_gm(dt_image_t *img, const char *filename, dt
   if(exception.severity != UndefinedException) CatchException(&exception);
   if(!image)
   {
-    dt_print(DT_DEBUG_ALWAYS, "[GraphicsMagick_open] image `%s' not found\n", img->filename);
+    dt_print(DT_DEBUG_ALWAYS, "[GraphicsMagick_open] image `%s' not found", img->filename);
     err = DT_IMAGEIO_FILE_NOT_FOUND;
     goto error;
   }
 
-  dt_print(DT_DEBUG_IMAGEIO, "[GraphicsMagick_open] image `%s' loading\n", img->filename);
+  dt_print(DT_DEBUG_IMAGEIO, "[GraphicsMagick_open] image `%s' loading", img->filename);
 
   if(IsCMYKColorspace(image->colorspace))
   {
-    dt_print(DT_DEBUG_ALWAYS, "[GraphicsMagick_open] error: CMYK images are not supported.\n");
+    dt_print(DT_DEBUG_ALWAYS, "[GraphicsMagick_open] error: CMYK images are not supported.");
     err =  DT_IMAGEIO_LOAD_FAILED;
     goto error;
   }
@@ -103,7 +103,7 @@ dt_imageio_retval_t dt_imageio_open_gm(dt_image_t *img, const char *filename, dt
   float *mipbuf = (float *)dt_mipmap_cache_alloc(mbuf, img);
   if(!mipbuf)
   {
-    dt_print(DT_DEBUG_ALWAYS, "[GraphicsMagick_open] could not alloc full buffer for image `%s'\n", img->filename);
+    dt_print(DT_DEBUG_ALWAYS, "[GraphicsMagick_open] could not alloc full buffer for image `%s'", img->filename);
     err = DT_IMAGEIO_CACHE_FULL;
     goto error;
   }
@@ -115,7 +115,7 @@ dt_imageio_retval_t dt_imageio_open_gm(dt_image_t *img, const char *filename, dt
     if(exception.severity != UndefinedException) CatchException(&exception);
     if(ret != MagickPass)
     {
-      dt_print(DT_DEBUG_ALWAYS, "[GraphicsMagick_open] error reading image `%s'\n", img->filename);
+      dt_print(DT_DEBUG_ALWAYS, "[GraphicsMagick_open] error reading image `%s'", img->filename);
       err = DT_IMAGEIO_LOAD_FAILED;
       goto error;
     }

--- a/src/imageio/imageio_heif.c
+++ b/src/imageio/imageio_heif.c
@@ -55,7 +55,7 @@ dt_imageio_retval_t dt_imageio_open_heif(dt_image_t *img,
   if(!ctx)
   {
     dt_print(DT_DEBUG_IMAGEIO,
-             "Unable to allocate HEIF context\n");
+             "Unable to allocate HEIF context");
     return DT_IMAGEIO_CACHE_FULL;
   }
 
@@ -68,14 +68,14 @@ dt_imageio_retval_t dt_imageio_open_heif(dt_image_t *img,
       /* we want to feedback this to the user, so output to stderr */
       dt_print(DT_DEBUG_ALWAYS,
                "[imageio_heif] Unsupported codec for `%s'. "
-               "Check if your libheif is built with HEVC and/or AV1 decoding support.\n",
+               "Check if your libheif is built with HEVC and/or AV1 decoding support",
                filename);
       ret = DT_IMAGEIO_UNSUPPORTED_FEATURE;
     }
     else if(err.code != heif_error_Unsupported_filetype && err.subcode != heif_suberror_No_ftyp_box)
     {
       /* print debug info only if genuine HEIF */
-      dt_print(DT_DEBUG_IMAGEIO, "Failed to read HEIF file [%s]: %s\n", filename, err.message);
+      dt_print(DT_DEBUG_IMAGEIO, "Failed to read HEIF file [%s]: %s", filename, err.message);
       ret = DT_IMAGEIO_UNSUPPORTED_FORMAT;
     }
     goto out;
@@ -86,7 +86,7 @@ dt_imageio_retval_t dt_imageio_open_heif(dt_image_t *img,
   if(num_images == 0)
   {
     dt_print(DT_DEBUG_IMAGEIO,
-             "No images found in HEIF file [%s]\n",
+             "No images found in HEIF file [%s]",
              filename);
     ret = DT_IMAGEIO_FILE_CORRUPTED;
     goto out;
@@ -97,7 +97,7 @@ dt_imageio_retval_t dt_imageio_open_heif(dt_image_t *img,
   if(err.code != heif_error_Ok)
   {
     dt_print(DT_DEBUG_IMAGEIO,
-             "Failed to read primary image from HEIF file [%s]\n",
+             "Failed to read primary image from HEIF file [%s]",
              filename);
     ret = DT_IMAGEIO_UNSUPPORTED_FEATURE;
     goto out;
@@ -177,7 +177,7 @@ dt_imageio_retval_t dt_imageio_open_heif(dt_image_t *img,
   if(err.code != heif_error_Ok)
   {
     dt_print(DT_DEBUG_IMAGEIO,
-             "Failed to decode HEIF file [%s]\n",
+             "Failed to decode HEIF file [%s]",
              filename);
     ret = DT_IMAGEIO_FILE_CORRUPTED;
     goto out;
@@ -208,7 +208,7 @@ dt_imageio_retval_t dt_imageio_open_heif(dt_image_t *img,
   if(mipbuf == NULL)
   {
     dt_print(DT_DEBUG_IMAGEIO,
-             "Failed to allocate mipmap buffer for HEIF image [%s]\n",
+             "Failed to allocate mipmap buffer for HEIF image [%s]",
              filename);
     ret = DT_IMAGEIO_CACHE_FULL;
     goto out;
@@ -226,7 +226,7 @@ dt_imageio_retval_t dt_imageio_open_heif(dt_image_t *img,
   const int original_values_bit_depth = heif_image_handle_get_luma_bits_per_pixel(handle);
 
   dt_print(DT_DEBUG_IMAGEIO,
-             "Bit depth: '%d' for HEIF image [%s]\n",
+             "Bit depth: '%d' for HEIF image [%s]",
              original_values_bit_depth,
              filename);
 
@@ -309,7 +309,7 @@ int dt_imageio_heif_read_profile(const char *filename,
   if(!ctx)
   {
     dt_print(DT_DEBUG_IMAGEIO,
-             "Unable to allocate HEIF context\n");
+             "Unable to allocate HEIF context");
     goto out;
   }
 
@@ -317,7 +317,7 @@ int dt_imageio_heif_read_profile(const char *filename,
   if(err.code != heif_error_Ok)
   {
     dt_print(DT_DEBUG_IMAGEIO,
-             "Failed to read HEIF file [%s]\n",
+             "Failed to read HEIF file [%s]",
              filename);
     goto out;
   }
@@ -327,7 +327,7 @@ int dt_imageio_heif_read_profile(const char *filename,
   if(num_images == 0)
   {
         dt_print(DT_DEBUG_IMAGEIO,
-             "No images found in HEIF file [%s]\n",
+             "No images found in HEIF file [%s]",
              filename);
     goto out;
   }
@@ -337,7 +337,7 @@ int dt_imageio_heif_read_profile(const char *filename,
   if(err.code != heif_error_Ok)
   {
     dt_print(DT_DEBUG_IMAGEIO,
-             "Failed to read primary image from HEIF file [%s]\n",
+             "Failed to read primary image from HEIF file [%s]",
              filename);
     goto out;
   }
@@ -349,13 +349,13 @@ int dt_imageio_heif_read_profile(const char *filename,
   {
     case heif_color_profile_type_nclx:
       dt_print(DT_DEBUG_IMAGEIO,
-             "Found NCLX color profile for HEIF file [%s]\n",
+             "Found NCLX color profile for HEIF file [%s]",
              filename);
       err = heif_image_handle_get_nclx_color_profile(handle, &profile_info_nclx);
       if(err.code != heif_error_Ok)
       {
         dt_print(DT_DEBUG_IMAGEIO,
-                "Failed to get NCLX color profile data from HEIF file [%s]\n",
+                "Failed to get NCLX color profile data from HEIF file [%s]",
                 filename);
         goto out;
       }
@@ -378,7 +378,7 @@ int dt_imageio_heif_read_profile(const char *filename,
 
         if(over)
         {
-          dt_print(DT_DEBUG_IMAGEIO, "Overriding nclx color profile for HEIF file `%s': 1/%d/%d to 1/%d/%d\n",
+          dt_print(DT_DEBUG_IMAGEIO, "Overriding nclx color profile for HEIF file `%s': 1/%d/%d to 1/%d/%d",
                    filename, profile_info_nclx->transfer_characteristics, profile_info_nclx->matrix_coefficients,
                    cicp->transfer_characteristics, cicp->matrix_coefficients);
         }
@@ -402,7 +402,7 @@ int dt_imageio_heif_read_profile(const char *filename,
       if(err.code != heif_error_Ok)
       {
         dt_print(DT_DEBUG_IMAGEIO,
-                "Failed to read embedded ICC profile from HEIF image [%s]\n",
+                "Failed to read embedded ICC profile from HEIF image [%s]",
                 filename);
         g_free(icc_data);
         goto out;
@@ -413,13 +413,13 @@ int dt_imageio_heif_read_profile(const char *filename,
 
     case heif_color_profile_type_not_present:
       dt_print(DT_DEBUG_IMAGEIO,
-             "No color profile for HEIF file [%s]\n",
+             "No color profile for HEIF file [%s]",
              filename);
       break; /* heif_color_profile_type_not_present */
 
     default:
       dt_print(DT_DEBUG_IMAGEIO,
-                "Unknown color profile data from HEIF file [%s]\n",
+                "Unknown color profile data from HEIF file [%s]",
                 filename);
       break;
   }

--- a/src/imageio/imageio_im.c
+++ b/src/imageio/imageio_im.c
@@ -79,11 +79,11 @@ dt_imageio_retval_t dt_imageio_open_im(dt_image_t *img, const char *filename, dt
 
   ret = MagickReadImage(image, filename);
   if(ret != MagickTrue) {
-    dt_print(DT_DEBUG_ALWAYS, "[ImageMagick_open] cannot open `%s'\n", img->filename);
+    dt_print(DT_DEBUG_ALWAYS, "[ImageMagick_open] cannot open `%s'", img->filename);
     err = DT_IMAGEIO_FILE_NOT_FOUND;
     goto error;
   }
-  dt_print(DT_DEBUG_IMAGEIO, "[ImageMagick_open] image `%s' loading\n", img->filename);
+  dt_print(DT_DEBUG_IMAGEIO, "[ImageMagick_open] image `%s' loading", img->filename);
 
   ColorspaceType colorspace;
 
@@ -91,7 +91,7 @@ dt_imageio_retval_t dt_imageio_open_im(dt_image_t *img, const char *filename, dt
 
   if((colorspace == CMYColorspace) || (colorspace == CMYKColorspace))
   {
-    dt_print(DT_DEBUG_ALWAYS, "[ImageMagick_open] error: CMY(K) images are not supported.\n");
+    dt_print(DT_DEBUG_ALWAYS, "[ImageMagick_open] error: CMY(K) images are not supported.");
     err =  DT_IMAGEIO_LOAD_FAILED;
     goto error;
   }
@@ -105,7 +105,7 @@ dt_imageio_retval_t dt_imageio_open_im(dt_image_t *img, const char *filename, dt
   float *mipbuf = dt_mipmap_cache_alloc(mbuf, img);
   if(mipbuf == NULL) {
     dt_print(DT_DEBUG_ALWAYS,
-        "[ImageMagick_open] could not alloc full buffer for image `%s'\n",
+        "[ImageMagick_open] could not alloc full buffer for image `%s'",
         img->filename);
     err = DT_IMAGEIO_CACHE_FULL;
     goto error;
@@ -114,7 +114,7 @@ dt_imageio_retval_t dt_imageio_open_im(dt_image_t *img, const char *filename, dt
   ret = MagickExportImagePixels(image, 0, 0, img->width, img->height, "RGBP", FloatPixel, mipbuf);
   if(ret != MagickTrue) {
     dt_print(DT_DEBUG_ALWAYS,
-        "[ImageMagick_open] error reading image `%s'\n", img->filename);
+        "[ImageMagick_open] error reading image `%s'", img->filename);
     goto error;
   }
 

--- a/src/imageio/imageio_j2k.c
+++ b/src/imageio/imageio_j2k.c
@@ -98,14 +98,14 @@ dt_imageio_retval_t dt_imageio_open_j2k(dt_image_t *img,
   if(!fsrc)
   {
     dt_print(DT_DEBUG_ALWAYS,
-             "[j2k_open] Error: failed to open '%s' for reading\n", filename);
+             "[j2k_open] Error: failed to open '%s' for reading", filename);
     return DT_IMAGEIO_FILE_NOT_FOUND;
   }
   if(fread(src_header, 1, 12, fsrc) != 12)
   {
     fclose(fsrc);
     dt_print(DT_DEBUG_ALWAYS,
-             "[j2k_open] Error: fread returned a number of elements different from the expected.\n");
+             "[j2k_open] Error: fread returned a number of elements different from the expected.");
     return DT_IMAGEIO_FILE_CORRUPTED;
   }
   fclose(fsrc);
@@ -122,7 +122,7 @@ dt_imageio_retval_t dt_imageio_open_j2k(dt_image_t *img,
   else // this will also reject jpt files.
   {
     dt_print(DT_DEBUG_ALWAYS,
-             "[j2k_open] Error: '%s' has unsupported file format.\n", filename);
+             "[j2k_open] Error: '%s' has unsupported file format", filename);
     return DT_IMAGEIO_UNSUPPORTED_FORMAT;
   }
 
@@ -143,7 +143,7 @@ dt_imageio_retval_t dt_imageio_open_j2k(dt_image_t *img,
   d_codec = opj_create_decompress(codec);
   if(!d_codec)
   {
-    dt_print(DT_DEBUG_ALWAYS, "[j2k_open] Error: failed to create the decoder\n");
+    dt_print(DT_DEBUG_ALWAYS, "[j2k_open] Error: failed to create the decoder");
     return DT_IMAGEIO_LOAD_FAILED;
   }
 
@@ -159,7 +159,7 @@ dt_imageio_retval_t dt_imageio_open_j2k(dt_image_t *img,
     // the threads is a sign of major resource exhaustion, better to fail
     // as soon as possible to save overall stability.
     dt_print(DT_DEBUG_ALWAYS,
-             "[j2k_open] Error: failed to setup the threads for decoder %s\n",
+             "[j2k_open] Error: failed to setup the threads for decoder %s",
              parameters.infile);
     opj_destroy_codec(d_codec);
     return DT_IMAGEIO_LOAD_FAILED;
@@ -169,7 +169,7 @@ dt_imageio_retval_t dt_imageio_open_j2k(dt_image_t *img,
   if(!opj_setup_decoder(d_codec, &parameters))
   {
     dt_print(DT_DEBUG_ALWAYS,
-             "[j2k_open] Error: failed to setup the decoder %s\n",
+             "[j2k_open] Error: failed to setup the decoder %s",
              parameters.infile);
     opj_destroy_codec(d_codec);
     return DT_IMAGEIO_LOAD_FAILED;
@@ -179,7 +179,7 @@ dt_imageio_retval_t dt_imageio_open_j2k(dt_image_t *img,
   if(!d_stream)
   {
     dt_print(DT_DEBUG_ALWAYS,
-             "[j2k_open] Error: failed to create the stream from the file %s\n",
+             "[j2k_open] Error: failed to create the stream from the file %s",
              parameters.infile);
     opj_destroy_codec(d_codec);
     return DT_IMAGEIO_LOAD_FAILED;
@@ -188,7 +188,7 @@ dt_imageio_retval_t dt_imageio_open_j2k(dt_image_t *img,
   /* Read the main header of the codestream and if necessary the JP2 boxes*/
   if(!opj_read_header(d_stream, d_codec, &image))
   {
-    dt_print(DT_DEBUG_ALWAYS, "[j2k_open] Error: failed to read the header\n");
+    dt_print(DT_DEBUG_ALWAYS, "[j2k_open] Error: failed to read the header");
     opj_stream_destroy(d_stream);
     opj_destroy_codec(d_codec);
     opj_image_destroy(image);
@@ -198,7 +198,7 @@ dt_imageio_retval_t dt_imageio_open_j2k(dt_image_t *img,
   /* Get the decoded image */
   if(!(opj_decode(d_codec, d_stream, image) && opj_end_decompress(d_codec, d_stream)))
   {
-    dt_print(DT_DEBUG_ALWAYS, "[j2k_open] Error: failed to decode image!\n");
+    dt_print(DT_DEBUG_ALWAYS, "[j2k_open] Error: failed to decode image!");
     opj_destroy_codec(d_codec);
     opj_stream_destroy(d_stream);
     opj_image_destroy(image);
@@ -211,7 +211,7 @@ dt_imageio_retval_t dt_imageio_open_j2k(dt_image_t *img,
   if(!image)
   {
     dt_print(DT_DEBUG_ALWAYS,
-             "[j2k_open] Error: failed to decode image '%s'\n",
+             "[j2k_open] Error: failed to decode image '%s'",
              filename);
     ret = DT_IMAGEIO_FILE_CORRUPTED;
     goto end_of_the_world;
@@ -243,7 +243,7 @@ dt_imageio_retval_t dt_imageio_open_j2k(dt_image_t *img,
   if(image->numcomps == 0 || image->x1 == 0 || image->y1 == 0)
   {
     dt_print(DT_DEBUG_ALWAYS,
-             "[j2k_open] Error: invalid raw image parameters in '%s'\n",
+             "[j2k_open] Error: invalid raw image parameters in '%s'",
              filename);
     ret = DT_IMAGEIO_FILE_CORRUPTED;
     goto end_of_the_world;
@@ -254,7 +254,7 @@ dt_imageio_retval_t dt_imageio_open_j2k(dt_image_t *img,
     if(image->comps[i].w != image->x1 || image->comps[i].h != image->y1)
     {
       dt_print(DT_DEBUG_ALWAYS,
-               "[j2k_open] Error: some component has different size in '%s'\n",
+               "[j2k_open] Error: some component has different size in '%s'",
                filename);
       ret = DT_IMAGEIO_FILE_CORRUPTED;
       goto end_of_the_world;
@@ -262,7 +262,7 @@ dt_imageio_retval_t dt_imageio_open_j2k(dt_image_t *img,
     if(image->comps[i].prec > 16)
     {
       dt_print(DT_DEBUG_ALWAYS,
-               "[j2k_open] Error: precision %d is larger than 16 in '%s'\n",
+               "[j2k_open] Error: precision %d is larger than 16 in '%s'",
                image->comps[1].prec,
                filename);
       ret = DT_IMAGEIO_UNSUPPORTED_FEATURE;
@@ -557,7 +557,7 @@ static void color_sycc_to_rgb(opj_image_t *img)
   else
   {
     dt_print(DT_DEBUG_ALWAYS,
-             "%s:%d:color_sycc_to_rgb\n\tCAN NOT CONVERT\n", __FILE__, __LINE__);
+             "%s:%d:color_sycc_to_rgb\n\tCAN NOT CONVERT", __FILE__, __LINE__);
     return;
   }
   img->color_space = OPJ_CLRSPC_SRGB;

--- a/src/imageio/imageio_jpeg.c
+++ b/src/imageio/imageio_jpeg.c
@@ -48,7 +48,7 @@ static void dt_imageio_jpeg_init_destination(j_compress_ptr cinfo)
 }
 static boolean dt_imageio_jpeg_empty_output_buffer(j_compress_ptr cinfo)
 {
-  dt_print(DT_DEBUG_ALWAYS, "[imageio_jpeg] output buffer full!\n");
+  dt_print(DT_DEBUG_ALWAYS, "[imageio_jpeg] output buffer full!");
   return FALSE;
 }
 static void dt_imageio_jpeg_term_destination(j_compress_ptr cinfo)
@@ -763,14 +763,14 @@ dt_imageio_retval_t dt_imageio_open_jpeg(dt_image_t *img,
   FILE *f = g_fopen(filename, "rb");
   if(!f)
   {
-    dt_print(DT_DEBUG_ALWAYS, "[jpeg_open] Error: failed to open '%s' for reading\n", filename);
+    dt_print(DT_DEBUG_ALWAYS, "[jpeg_open] Error: failed to open '%s' for reading", filename);
     return DT_IMAGEIO_FILE_NOT_FOUND;
   }
 
   if(fread(first3bytes, 1, 3, f) != 3)
   {
     fclose(f);
-    dt_print(DT_DEBUG_ALWAYS, "[jpeg_open] Error: file is empty or read error.\n");
+    dt_print(DT_DEBUG_ALWAYS, "[jpeg_open] Error: file is empty or read error.");
     return DT_IMAGEIO_FILE_NOT_FOUND;
   }
   fclose(f);

--- a/src/imageio/imageio_jpegxl.c
+++ b/src/imageio/imageio_jpegxl.c
@@ -47,7 +47,7 @@ dt_imageio_retval_t dt_imageio_open_jpegxl(dt_image_t *img,
   if(!inputfile)
   {
     dt_print(DT_DEBUG_ALWAYS,
-             "[jpegxl_open] ERROR: cannot open file for read: '%s'\n",
+             "[jpegxl_open] ERROR: cannot open file for read: '%s'",
              filename);
     return DT_IMAGEIO_FILE_NOT_FOUND;
   }
@@ -65,7 +65,7 @@ dt_imageio_retval_t dt_imageio_open_jpegxl(dt_image_t *img,
   if(fread(read_buffer, 1, inputFileSize, inputfile) != inputFileSize)
   {
     dt_print(DT_DEBUG_ALWAYS,
-             "[jpegxl_open] ERROR: failed to read %zu bytes from '%s'\n",
+             "[jpegxl_open] ERROR: failed to read %zu bytes from '%s'",
              inputFileSize,
              filename);
     free(read_buffer);
@@ -95,7 +95,7 @@ dt_imageio_retval_t dt_imageio_open_jpegxl(dt_image_t *img,
 
   if(!decoder)
   {
-    dt_print(DT_DEBUG_ALWAYS, "[jpegxl_open] ERROR: JxlDecoderCreate failed\n");
+    dt_print(DT_DEBUG_ALWAYS, "[jpegxl_open] ERROR: JxlDecoderCreate failed");
     free(read_buffer);
     return DT_IMAGEIO_LOAD_FAILED;
   }
@@ -103,7 +103,7 @@ dt_imageio_retval_t dt_imageio_open_jpegxl(dt_image_t *img,
   JxlParallelRunner *runner = JxlResizableParallelRunnerCreate(NULL);
   if(!runner)
   {
-    dt_print(DT_DEBUG_ALWAYS, "[jpegxl_open] ERROR: JxlResizableParallelRunnerCreate failed\n");
+    dt_print(DT_DEBUG_ALWAYS, "[jpegxl_open] ERROR: JxlResizableParallelRunnerCreate failed");
     JxlDecoderDestroy(decoder);
     free(read_buffer);
     return DT_IMAGEIO_LOAD_FAILED;
@@ -111,7 +111,7 @@ dt_imageio_retval_t dt_imageio_open_jpegxl(dt_image_t *img,
 
   if(JxlDecoderSetInput(decoder, read_buffer, inputFileSize) != JXL_DEC_SUCCESS)
   {
-    dt_print(DT_DEBUG_ALWAYS, "[jpegxl_open] ERROR: JxlDecoderSetInput failed\n");
+    dt_print(DT_DEBUG_ALWAYS, "[jpegxl_open] ERROR: JxlDecoderSetInput failed");
     JxlResizableParallelRunnerDestroy(runner);
     JxlDecoderDestroy(decoder);
     free(read_buffer);
@@ -125,7 +125,7 @@ dt_imageio_retval_t dt_imageio_open_jpegxl(dt_image_t *img,
                                JXL_DEC_FULL_IMAGE)
      != JXL_DEC_SUCCESS)
   {
-    dt_print(DT_DEBUG_ALWAYS, "[jpegxl_open] ERROR: JxlDecoderSubscribeEvents failed\n");
+    dt_print(DT_DEBUG_ALWAYS, "[jpegxl_open] ERROR: JxlDecoderSubscribeEvents failed");
     JxlResizableParallelRunnerDestroy(runner);
     JxlDecoderDestroy(decoder);
     free(read_buffer);
@@ -134,7 +134,7 @@ dt_imageio_retval_t dt_imageio_open_jpegxl(dt_image_t *img,
 
   if(JxlDecoderSetParallelRunner(decoder, JxlResizableParallelRunner, runner) != JXL_DEC_SUCCESS)
   {
-    dt_print(DT_DEBUG_ALWAYS, "[jpegxl_open] ERROR: JxlDecoderSetParallelRunner failed\n");
+    dt_print(DT_DEBUG_ALWAYS, "[jpegxl_open] ERROR: JxlDecoderSetParallelRunner failed");
     JxlResizableParallelRunnerDestroy(runner);
     JxlDecoderDestroy(decoder);
     free(read_buffer);
@@ -149,7 +149,7 @@ dt_imageio_retval_t dt_imageio_open_jpegxl(dt_image_t *img,
 
     if(status == JXL_DEC_ERROR)
     {
-      dt_print(DT_DEBUG_ALWAYS, "[jpegxl_open] ERROR: JXL decoding failed\n");
+      dt_print(DT_DEBUG_ALWAYS, "[jpegxl_open] ERROR: JXL decoding failed");
       JxlResizableParallelRunnerDestroy(runner);
       JxlDecoderDestroy(decoder);
       free(read_buffer);
@@ -158,7 +158,7 @@ dt_imageio_retval_t dt_imageio_open_jpegxl(dt_image_t *img,
 
     if(status == JXL_DEC_NEED_MORE_INPUT)
     {
-      dt_print(DT_DEBUG_ALWAYS, "[jpegxl_open] ERROR: JXL data incomplete\n");
+      dt_print(DT_DEBUG_ALWAYS, "[jpegxl_open] ERROR: JXL data incomplete");
       JxlResizableParallelRunnerDestroy(runner);
       JxlDecoderDestroy(decoder);
       free(read_buffer);
@@ -169,7 +169,7 @@ dt_imageio_retval_t dt_imageio_open_jpegxl(dt_image_t *img,
     {
       if(JxlDecoderGetBasicInfo(decoder, &basicinfo) != JXL_DEC_SUCCESS)
       {
-        dt_print(DT_DEBUG_ALWAYS, "[jpegxl_open] ERROR: JXL basic info not available\n");
+        dt_print(DT_DEBUG_ALWAYS, "[jpegxl_open] ERROR: JXL basic info not available");
         JxlResizableParallelRunnerDestroy(runner);
         JxlDecoderDestroy(decoder);
         free(read_buffer);
@@ -179,7 +179,7 @@ dt_imageio_retval_t dt_imageio_open_jpegxl(dt_image_t *img,
       // Unlikely to happen, but let there be a sanity check
       if(basicinfo.xsize == 0 || basicinfo.ysize == 0)
       {
-        dt_print(DT_DEBUG_ALWAYS,"[jpegxl_open] ERROR: JXL image declares zero dimensions\n");
+        dt_print(DT_DEBUG_ALWAYS,"[jpegxl_open] ERROR: JXL image declares zero dimensions");
         JxlResizableParallelRunnerDestroy(runner);
         JxlDecoderDestroy(decoder);
         free(read_buffer);
@@ -263,7 +263,7 @@ dt_imageio_retval_t dt_imageio_open_jpegxl(dt_image_t *img,
         // will support the XYB color space, we can add code here to handle that case.
         dt_print(DT_DEBUG_ALWAYS,
                  "[jpegxl_open] ERROR: the image '%s' has an unknown or XYB color space. "
-                 "We do not import such images\n",
+                 "We do not import such images",
                  filename);
         JxlResizableParallelRunnerDestroy(runner);
         JxlDecoderDestroy(decoder);
@@ -286,7 +286,7 @@ dt_imageio_retval_t dt_imageio_open_jpegxl(dt_image_t *img,
         JxlDecoderDestroy(decoder);
         g_free(read_buffer);
         dt_print(DT_DEBUG_ALWAYS,
-                 "[jpegxl_open] ERROR: could not alloc full buffer for image: '%s'\n",
+                 "[jpegxl_open] ERROR: could not alloc full buffer for image: '%s'",
                  img->filename);
         return DT_IMAGEIO_CACHE_FULL;
       }

--- a/src/imageio/imageio_libraw.c
+++ b/src/imageio/imageio_libraw.c
@@ -296,7 +296,7 @@ static gboolean _supported_image(const gchar *filename)
     extensions_whitelist = g_strdup(always_by_libraw);
 
   dt_print(DT_DEBUG_IMAGEIO,
-           "[libraw_open] extensions whitelist: '%s'\n", extensions_whitelist);
+           "[libraw_open] extensions whitelist: '%s'", extensions_whitelist);
 
   gchar *ext_lowercased = g_ascii_strdown(ext, -1);
   if(g_strstr_len(extensions_whitelist, -1, ext_lowercased))
@@ -397,7 +397,7 @@ dt_imageio_retval_t dt_imageio_open_libraw(dt_image_t *img,
      || !raw->rawdata.raw_image)
   {
     dt_print(DT_DEBUG_ALWAYS,
-             "[libraw_open] detected unsupported image `%s'\n", img->filename);
+             "[libraw_open] detected unsupported image `%s'", img->filename);
     err = DT_IMAGEIO_UNSUPPORTED_FEATURE;
     goto error;
   }
@@ -477,7 +477,7 @@ dt_imageio_retval_t dt_imageio_open_libraw(dt_image_t *img,
   if(!buf)
   {
     dt_print(DT_DEBUG_ALWAYS,
-             "[libraw_open] could not alloc full buffer for image `%s'\n",
+             "[libraw_open] could not alloc full buffer for image `%s'",
              img->filename);
     err = DT_IMAGEIO_CACHE_FULL;
     goto error;
@@ -530,7 +530,7 @@ error:
   if(libraw_err != LIBRAW_SUCCESS)
   {
     dt_print(DT_DEBUG_ALWAYS,
-             "[libraw_open] `%s': %s\n",
+             "[libraw_open] `%s': %s",
              img->filename, libraw_strerror(libraw_err));
     switch(libraw_err)
     {

--- a/src/imageio/imageio_png.c
+++ b/src/imageio/imageio_png.c
@@ -186,7 +186,7 @@ dt_imageio_retval_t dt_imageio_open_png(dt_image_t *img, const char *filename, d
   {
     fclose(image.f);
     png_destroy_read_struct(&image.png_ptr, &image.info_ptr, NULL);
-    dt_print(DT_DEBUG_ALWAYS, "[png_open] could not alloc full buffer for image `%s'\n", img->filename);
+    dt_print(DT_DEBUG_ALWAYS, "[png_open] could not alloc full buffer for image `%s'", img->filename);
     return DT_IMAGEIO_CACHE_FULL;
   }
 
@@ -196,14 +196,14 @@ dt_imageio_retval_t dt_imageio_open_png(dt_image_t *img, const char *filename, d
   {
     fclose(image.f);
     png_destroy_read_struct(&image.png_ptr, &image.info_ptr, NULL);
-    dt_print(DT_DEBUG_ALWAYS, "[png_open] could not alloc intermediate buffer for image `%s'\n", img->filename);
+    dt_print(DT_DEBUG_ALWAYS, "[png_open] could not alloc intermediate buffer for image `%s'", img->filename);
     return DT_IMAGEIO_CACHE_FULL;
   }
 
   if(!dt_imageio_png_read_image(&image, (void *)buf))
   {
     dt_free_align(buf);
-    dt_print(DT_DEBUG_ALWAYS, "[png_open] could not read image `%s'\n", img->filename);
+    dt_print(DT_DEBUG_ALWAYS, "[png_open] could not read image `%s'", img->filename);
     return DT_IMAGEIO_FILE_CORRUPTED;
   }
 
@@ -286,7 +286,7 @@ int dt_imageio_png_read_profile(const char *filename, uint8_t **out, dt_colorspa
         cicp->matrix_coefficients = (dt_colorspaces_cicp_matrix_coefficients_t)unknowns[c].data[2];
       }
       else
-        dt_print(DT_DEBUG_IMAGEIO, "[png_open] encountered YUV and/or narrow-range image `%s', assuming unknown CICP\n", filename);
+        dt_print(DT_DEBUG_IMAGEIO, "[png_open] encountered YUV and/or narrow-range image `%s', assuming unknown CICP", filename);
       break;
     }
 #endif

--- a/src/imageio/imageio_qoi.c
+++ b/src/imageio/imageio_qoi.c
@@ -43,7 +43,7 @@ dt_imageio_retval_t dt_imageio_open_qoi(dt_image_t *img,
   FILE *f = g_fopen(filename, "rb");
   if(!f)
   {
-    dt_print(DT_DEBUG_ALWAYS,"[qoi_open] cannot open file for read: %s\n", filename);
+    dt_print(DT_DEBUG_ALWAYS,"[qoi_open] cannot open file for read: %s", filename);
     return DT_IMAGEIO_FILE_NOT_FOUND;
   }
 
@@ -55,7 +55,7 @@ dt_imageio_retval_t dt_imageio_open_qoi(dt_image_t *img,
   if(!read_buffer)
   {
     fclose(f);
-    dt_print(DT_DEBUG_ALWAYS, "[qoi_open] failed to allocate buffer for %s\n", filename);
+    dt_print(DT_DEBUG_ALWAYS, "[qoi_open] failed to allocate buffer for %s", filename);
     return DT_IMAGEIO_LOAD_FAILED;
   }
 
@@ -66,7 +66,7 @@ dt_imageio_retval_t dt_imageio_open_qoi(dt_image_t *img,
   {
     fclose(f);
     g_free(read_buffer);
-    dt_print(DT_DEBUG_ALWAYS, "[qoi_open] failed to read from %s\n", filename);
+    dt_print(DT_DEBUG_ALWAYS, "[qoi_open] failed to read from %s", filename);
     // if we can't read even first 4 bytes, it's more like file disappeared
     return DT_IMAGEIO_FILE_CORRUPTED;
   }
@@ -76,7 +76,7 @@ dt_imageio_retval_t dt_imageio_open_qoi(dt_image_t *img,
     fclose(f);
     g_free(read_buffer);
     dt_print(DT_DEBUG_ALWAYS,
-             "[qoi_open] no proper file header in %s\n", filename);
+             "[qoi_open] no proper file header in %s", filename);
     return DT_IMAGEIO_UNSUPPORTED_FORMAT;
   }
 
@@ -85,7 +85,7 @@ dt_imageio_retval_t dt_imageio_open_qoi(dt_image_t *img,
     fclose(f);
     g_free(read_buffer);
     dt_print(DT_DEBUG_ALWAYS,
-             "[qoi_open] failed to read %zu bytes from %s\n",
+             "[qoi_open] failed to read %zu bytes from %s",
              filesize, filename);
     return DT_IMAGEIO_IOERROR;
   }
@@ -97,7 +97,7 @@ dt_imageio_retval_t dt_imageio_open_qoi(dt_image_t *img,
   if(!int_RGBA_buf)
   {
     g_free(read_buffer);
-    dt_print(DT_DEBUG_ALWAYS,"[qoi_open] failed to decode file: %s\n", filename);
+    dt_print(DT_DEBUG_ALWAYS,"[qoi_open] failed to decode file: %s", filename);
     return DT_IMAGEIO_FILE_CORRUPTED;
   }
 
@@ -111,7 +111,7 @@ dt_imageio_retval_t dt_imageio_open_qoi(dt_image_t *img,
   {
     g_free(read_buffer);
     dt_print(DT_DEBUG_ALWAYS,
-             "[qoi_open] could not alloc full buffer for image: %s\n",
+             "[qoi_open] could not alloc full buffer for image: %s",
              img->filename);
     return DT_IMAGEIO_CACHE_FULL;
   }

--- a/src/imageio/imageio_rawspeed.cc
+++ b/src/imageio/imageio_rawspeed.cc
@@ -102,7 +102,7 @@ gboolean dt_rawspeed_lookup_makermodel(const char *maker,
   }
   catch(const std::exception &exc)
   {
-    dt_print(DT_DEBUG_ALWAYS, "[rawspeed] %s\n", exc.what());
+    dt_print(DT_DEBUG_ALWAYS, "[rawspeed] %s", exc.what());
   }
 
   if(!got_it_done)
@@ -146,7 +146,7 @@ static gboolean _ignore_image(const gchar *filename)
     extensions_whitelist = g_strdup(always_by_libraw);
 
   dt_print(DT_DEBUG_IMAGEIO,
-           "[rawspeed_open] extensions list to ignore: `%s'\n",
+           "[rawspeed_open] extensions list to ignore: `%s'",
            extensions_whitelist);
 
   gchar *ext_lowercased = g_ascii_strdown(ext,-1);
@@ -196,7 +196,7 @@ dt_imageio_retval_t dt_imageio_open_rawspeed(dt_image_t *img,
 
     const auto errors = r->getErrors();
     for(const auto &error : errors)
-      dt_print(DT_DEBUG_ALWAYS, "[rawspeed] (%s) %s\n", img->filename, error.c_str());
+      dt_print(DT_DEBUG_ALWAYS, "[rawspeed] (%s) %s", img->filename, error.c_str());
 
     g_strlcpy(img->camera_maker,
               r->metadata.canonical_make.c_str(),
@@ -413,12 +413,12 @@ dt_imageio_retval_t dt_imageio_open_rawspeed(dt_image_t *img,
   }
   catch(const rawspeed::IOException &exc)
   {
-    dt_print(DT_DEBUG_ALWAYS, "[rawspeed] (%s) I/O error: %s\n", img->filename, exc.what());
+    dt_print(DT_DEBUG_ALWAYS, "[rawspeed] (%s) I/O error: %s", img->filename, exc.what());
     return DT_IMAGEIO_IOERROR;
   }
   catch(const rawspeed::FileIOException &exc)
   {
-    dt_print(DT_DEBUG_ALWAYS, "[rawspeed] (%s) File I/O error: %s\n", img->filename, exc.what());
+    dt_print(DT_DEBUG_ALWAYS, "[rawspeed] (%s) File I/O error: %s", img->filename, exc.what());
     return DT_IMAGEIO_IOERROR;
   }
   catch(const rawspeed::RawDecoderException &exc)
@@ -431,33 +431,33 @@ dt_imageio_retval_t dt_imageio_open_rawspeed(dt_image_t *img,
     // or unsupported feature (e.g. bit depth, compression, aspect ratio mode, ...)
     if(msg && (strstr(msg, "Camera not supported") || strstr(msg, "not supported, and not allowed to guess")))
     {
-      dt_print(DT_DEBUG_ALWAYS, "[rawspeed] Unsupported camera model for %s\n", img->filename);
+      dt_print(DT_DEBUG_ALWAYS, "[rawspeed] Unsupported camera model for %s", img->filename);
       return DT_IMAGEIO_UNSUPPORTED_CAMERA;
     }
     else if (msg && strstr(msg, "supported"))
     {
-      dt_print(DT_DEBUG_ALWAYS, "[rawspeed] (%s) %s\n", img->filename, msg);
+      dt_print(DT_DEBUG_ALWAYS, "[rawspeed] (%s) %s", img->filename, msg);
       return DT_IMAGEIO_UNSUPPORTED_FEATURE;
     }
     else
     {
-      dt_print(DT_DEBUG_ALWAYS, "[rawspeed] %s corrupt: %s\n", img->filename, exc.what());
+      dt_print(DT_DEBUG_ALWAYS, "[rawspeed] %s corrupt: %s", img->filename, exc.what());
       return DT_IMAGEIO_FILE_CORRUPTED;
     }
   }
   catch(const rawspeed::RawParserException &exc)
   {
-    dt_print(DT_DEBUG_ALWAYS, "[rawspeed] (%s) CIFF/FIFF error: %s\n", img->filename, exc.what());
+    dt_print(DT_DEBUG_ALWAYS, "[rawspeed] (%s) CIFF/FIFF error: %s", img->filename, exc.what());
     return DT_IMAGEIO_UNSUPPORTED_FORMAT;
   }
   catch(const rawspeed::CameraMetadataException &exc)
   {
-    dt_print(DT_DEBUG_ALWAYS, "[rawspeed] (%s) metadata error: %s\n", img->filename, exc.what());
+    dt_print(DT_DEBUG_ALWAYS, "[rawspeed] (%s) metadata error: %s", img->filename, exc.what());
     return DT_IMAGEIO_UNSUPPORTED_FEATURE;
   }
   catch(const std::exception &exc)
   {
-    dt_print(DT_DEBUG_ALWAYS, "[rawspeed] (%s) %s\n", img->filename, exc.what());
+    dt_print(DT_DEBUG_ALWAYS, "[rawspeed] (%s) %s", img->filename, exc.what());
 
     /* if an exception is raised lets not retry or handle the
      specific ones, consider the file as corrupted */
@@ -465,7 +465,7 @@ dt_imageio_retval_t dt_imageio_open_rawspeed(dt_image_t *img,
   }
   catch(...)
   {
-    dt_print(DT_DEBUG_ALWAYS, "[rawspeed] unhandled exception in imageio_rawspeed\n");
+    dt_print(DT_DEBUG_ALWAYS, "[rawspeed] unhandled exception in imageio_rawspeed");
     return DT_IMAGEIO_FILE_CORRUPTED;
   }
 

--- a/src/imageio/imageio_rgbe.c
+++ b/src/imageio/imageio_rgbe.c
@@ -81,17 +81,17 @@ static int rgbe_error(int rgbe_error_code, char *msg)
   switch(rgbe_error_code)
   {
     case rgbe_read_error:
-      dt_print(DT_DEBUG_ALWAYS, "[rgbe_open] RGBE read error: %s\n", strerror(errno));
+      dt_print(DT_DEBUG_ALWAYS, "[rgbe_open] RGBE read error: %s", strerror(errno));
       break;
     case rgbe_write_error:
-      dt_print(DT_DEBUG_ALWAYS, "[rgbe_open] RGBE write error: %s\n", strerror(errno));
+      dt_print(DT_DEBUG_ALWAYS, "[rgbe_open] RGBE write error: %s", strerror(errno));
       break;
     case rgbe_format_error:
-      dt_print(DT_DEBUG_ALWAYS, "[rgbe_open] RGBE bad file format: %s\n", msg);
+      dt_print(DT_DEBUG_ALWAYS, "[rgbe_open] RGBE bad file format: %s", msg);
       break;
     default:
     case rgbe_memory_error:
-      dt_print(DT_DEBUG_ALWAYS, "[rgbe_open] RGBE error: %s\n", msg);
+      dt_print(DT_DEBUG_ALWAYS, "[rgbe_open] RGBE error: %s", msg);
   }
   return RGBE_RETURN_FAILURE;
 }

--- a/src/imageio/imageio_tiff.c
+++ b/src/imageio/imageio_tiff.c
@@ -389,7 +389,7 @@ dt_imageio_retval_t dt_imageio_open_tiff(dt_image_t *img, const char *filename, 
 
   if(inkset == INKSET_CMYK || inkset == INKSET_MULTIINK)
   {
-    dt_print(DT_DEBUG_ALWAYS, "[tiff_open] error: CMYK (or multiink) TIFFs are not supported.\n");
+    dt_print(DT_DEBUG_ALWAYS, "[tiff_open] error: CMYK (or multiink) TIFFs are not supported.");
     TIFFClose(t.tiff);
     return DT_IMAGEIO_UNSUPPORTED_FEATURE;
   }
@@ -402,7 +402,7 @@ dt_imageio_retval_t dt_imageio_open_tiff(dt_image_t *img, const char *filename, 
 
   t.scanlinesize = TIFFScanlineSize(t.tiff);
 
-  dt_print(DT_DEBUG_IMAGEIO, "[tiff_open] %dx%d %dbpp, %d samples per pixel.\n", t.width, t.height, t.bpp, t.spp);
+  dt_print(DT_DEBUG_IMAGEIO, "[tiff_open] %dx%d %dbpp, %d samples per pixel", t.width, t.height, t.bpp, t.spp);
 
   // we only support 8, 16 and 32 bits per pixel formats.
   if(t.bpp != 8 && t.bpp != 16 && t.bpp != 32)
@@ -421,7 +421,7 @@ dt_imageio_retval_t dt_imageio_open_tiff(dt_image_t *img, const char *filename, 
   /* don't depend on planar config if spp == 1 */
   if(t.spp > 1 && config != PLANARCONFIG_CONTIG)
   {
-    dt_print(DT_DEBUG_ALWAYS, "[tiff_open] error: PlanarConfiguration other than chunky is not supported.\n");
+    dt_print(DT_DEBUG_ALWAYS, "[tiff_open] error: PlanarConfiguration other than chunky is not supported.");
     TIFFClose(t.tiff);
     return DT_IMAGEIO_UNSUPPORTED_FEATURE;
   }
@@ -438,7 +438,7 @@ dt_imageio_retval_t dt_imageio_open_tiff(dt_image_t *img, const char *filename, 
   t.mipbuf = (float *)dt_mipmap_cache_alloc(mbuf, t.image);
   if(!t.mipbuf)
   {
-    dt_print(DT_DEBUG_ALWAYS, "[tiff_open] error: could not alloc full buffer for image `%s'\n", t.image->filename);
+    dt_print(DT_DEBUG_ALWAYS, "[tiff_open] error: could not alloc full buffer for image `%s'", t.image->filename);
     TIFFClose(t.tiff);
     return DT_IMAGEIO_CACHE_FULL;
   }
@@ -480,7 +480,7 @@ dt_imageio_retval_t dt_imageio_open_tiff(dt_image_t *img, const char *filename, 
     ok = _read_chunky_f(&t);
   else
   {
-    dt_print(DT_DEBUG_ALWAYS, "[tiff_open] error: not a supported tiff image format.\n");
+    dt_print(DT_DEBUG_ALWAYS, "[tiff_open] error: not a supported tiff image format.");
     ok = 0;
     ret = DT_IMAGEIO_UNSUPPORTED_FEATURE;
   }

--- a/src/imageio/imageio_webp.c
+++ b/src/imageio/imageio_webp.c
@@ -28,7 +28,7 @@ dt_imageio_retval_t dt_imageio_open_webp(dt_image_t *img, const char *filename, 
   FILE *f = g_fopen(filename, "rb");
   if(!f)
   {
-    dt_print(DT_DEBUG_ALWAYS,"[webp_open] cannot open file for read: %s\n", filename);
+    dt_print(DT_DEBUG_ALWAYS,"[webp_open] cannot open file for read: %s", filename);
     return DT_IMAGEIO_FILE_NOT_FOUND;
   }
 
@@ -40,14 +40,14 @@ dt_imageio_retval_t dt_imageio_open_webp(dt_image_t *img, const char *filename, 
   if(!read_buffer)
   {
     fclose(f);
-    dt_print(DT_DEBUG_ALWAYS,"[webp_open] failed to allocate buffer for %s\n", filename);
+    dt_print(DT_DEBUG_ALWAYS,"[webp_open] failed to allocate buffer for %s", filename);
     return DT_IMAGEIO_LOAD_FAILED;
   }
   if(fread(read_buffer, 1, filesize, f) != filesize)
   {
     fclose(f);
     g_free(read_buffer);
-    dt_print(DT_DEBUG_ALWAYS,"[webp_open] failed to read %zu bytes from %s\n", filesize, filename);
+    dt_print(DT_DEBUG_ALWAYS,"[webp_open] failed to read %zu bytes from %s", filesize, filename);
     return DT_IMAGEIO_IOERROR;
   }
   fclose(f);
@@ -73,7 +73,7 @@ dt_imageio_retval_t dt_imageio_open_webp(dt_image_t *img, const char *filename, 
   if(!int_RGBA_buffer)
   {
     g_free(read_buffer);
-    dt_print(DT_DEBUG_ALWAYS,"[webp_open] failed to alloc RGBA buffer for %s\n", filename);
+    dt_print(DT_DEBUG_ALWAYS,"[webp_open] failed to alloc RGBA buffer for %s", filename);
     return DT_IMAGEIO_LOAD_FAILED;
   }
   uint8_t *int_RGBA_buf = WebPDecodeRGBAInto(read_buffer, filesize, int_RGBA_buffer, npixels * 4, width * 4);
@@ -81,7 +81,7 @@ dt_imageio_retval_t dt_imageio_open_webp(dt_image_t *img, const char *filename, 
   {
     g_free(read_buffer);
     dt_free_align(int_RGBA_buffer);
-    dt_print(DT_DEBUG_ALWAYS,"[webp_open] failed to decode file: %s\n", filename);
+    dt_print(DT_DEBUG_ALWAYS,"[webp_open] failed to decode file: %s", filename);
     return DT_IMAGEIO_LOAD_FAILED;
   }
 
@@ -118,7 +118,7 @@ dt_imageio_retval_t dt_imageio_open_webp(dt_image_t *img, const char *filename, 
   {
     g_free(read_buffer);
     dt_free_align(int_RGBA_buffer);
-    dt_print(DT_DEBUG_ALWAYS, "[webp_open] could not alloc full buffer for image: %s\n", img->filename);
+    dt_print(DT_DEBUG_ALWAYS, "[webp_open] could not alloc full buffer for image: %s", img->filename);
     return DT_IMAGEIO_CACHE_FULL;
   }
 

--- a/src/imageio/storage/disk.c
+++ b/src/imageio/storage/disk.c
@@ -380,7 +380,7 @@ try_again:
     {
       // output directory could not be created
       dt_print(DT_DEBUG_ALWAYS,
-               "[imageio_storage_disk] could not create directory: `%s'!\n",
+               "[imageio_storage_disk] could not create directory: `%s'!",
                output_dir);
       dt_control_log(_("could not create directory `%s'!"), output_dir);
       fail = TRUE;
@@ -391,7 +391,7 @@ try_again:
     {
       // output directory is not writeable
       dt_print(DT_DEBUG_ALWAYS,
-               "[imageio_storage_disk] could not write to directory: `%s'!\n",
+               "[imageio_storage_disk] could not write to directory: `%s'!",
                output_dir);
       dt_control_log(_("could not write to directory `%s'!"), output_dir);
       fail = TRUE;
@@ -429,7 +429,7 @@ try_again:
       {
         // file exists, skip
         dt_pthread_mutex_unlock(&darktable.plugin_threadsafe);
-        dt_print(DT_DEBUG_ALWAYS, "[export_job] skipping `%s'\n", filename);
+        dt_print(DT_DEBUG_ALWAYS, "[export_job] skipping `%s'", filename);
         dt_control_log(ngettext("%d/%d skipping `%s'", "%d/%d skipping `%s'", num),
                        num, total, filename);
         return 0;
@@ -454,7 +454,7 @@ try_again:
         if(export_timestamp > change_timestamp)
         {
           dt_pthread_mutex_unlock(&darktable.plugin_threadsafe);
-          dt_print(DT_DEBUG_ALWAYS, "[export_job] skipping (not modified since export) `%s'\n", filename);
+          dt_print(DT_DEBUG_ALWAYS, "[export_job] skipping (not modified since export) `%s'", filename);
           dt_control_log(ngettext("%d/%d skipping (not modified since export) `%s'",
                                   "%d/%d skipping (not modified since export) `%s'", num),
                          num, total, filename);
@@ -473,13 +473,13 @@ try_again:
                        num, total, metadata) != 0)
   {
     dt_print(DT_DEBUG_ALWAYS,
-             "[imageio_storage_disk] could not export to file: `%s'!\n",
+             "[imageio_storage_disk] could not export to file: `%s'!",
              filename);
     dt_control_log(_("could not export to file `%s'!"), filename);
     return 1;
   }
 
-  dt_print(DT_DEBUG_ALWAYS, "[export_job] exported to `%s'\n", filename);
+  dt_print(DT_DEBUG_ALWAYS, "[export_job] exported to `%s'", filename);
   dt_control_log(ngettext("%d/%d exported to `%s'", "%d/%d exported to `%s'", num),
                  num, total, filename);
   return 0;

--- a/src/imageio/storage/email.c
+++ b/src/imageio/storage/email.c
@@ -180,7 +180,7 @@ int store(dt_imageio_module_storage_t *self,
                        icc_filename, icc_intent, self, sdata, num, total, metadata) != 0)
   {
     dt_print(DT_DEBUG_ALWAYS,
-             "[imageio_storage_email] could not export to file: `%s'!\n",
+             "[imageio_storage_email] could not export to file: `%s'!",
              attachment->file);
     dt_control_log(_("could not export to file `%s'!"), attachment->file);
     g_free(attachment->file);
@@ -365,7 +365,7 @@ void finalize_store(dt_imageio_module_storage_t *self,
   argv[argc] = NULL;
 
   gchar *cmdline = g_strjoinv(" ", argv);
-  dt_print(DT_DEBUG_IMAGEIO, "[email] launching '%s'\n", cmdline);
+  dt_print(DT_DEBUG_IMAGEIO, "[email] launching '%s'", cmdline);
   g_free(cmdline);
 
   gint exit_status = 0;
@@ -444,7 +444,7 @@ void finalize_store(dt_imageio_module_storage_t *self,
   argv[argc] = NULL;
 
   gchar *cmdline = g_strjoinv(" ", argv);
-  dt_print(DT_DEBUG_IMAGEIO, "[email] launching '%s'\n", cmdline);
+  dt_print(DT_DEBUG_IMAGEIO, "[email] launching '%s'", cmdline);
   g_free(cmdline);
 
   gint exit_status = 0;

--- a/src/imageio/storage/gallery.c
+++ b/src/imageio/storage/gallery.c
@@ -320,7 +320,7 @@ int store(dt_imageio_module_storage_t *self,
   if(g_mkdir_with_parents(dirname, 0755))
   {
     dt_print(DT_DEBUG_ALWAYS,
-             "[imageio_storage_gallery] could not create directory: `%s'!\n", dirname);
+             "[imageio_storage_gallery] could not create directory: `%s'!", dirname);
     dt_control_log(_("could not create directory `%s'!"), dirname);
     return 1;
   }
@@ -403,7 +403,7 @@ int store(dt_imageio_module_storage_t *self,
                        icc_filename, icc_intent, self, sdata, num, total, metadata) != 0)
   {
     dt_print(DT_DEBUG_ALWAYS,
-             "[imageio_storage_gallery] could not export to file: `%s'!\n", filename);
+             "[imageio_storage_gallery] could not export to file: `%s'!", filename);
     dt_control_log(_("could not export to file `%s'!"), filename);
     free(pair);
     g_free(esc_relfilename);
@@ -444,7 +444,7 @@ int store(dt_imageio_module_storage_t *self,
                        icc_intent, self, sdata, num, total, NULL) != 0)
   {
     dt_print(DT_DEBUG_ALWAYS,
-             "[imageio_storage_gallery] could not export to file: `%s'!\n", filename);
+             "[imageio_storage_gallery] could not export to file: `%s'!", filename);
     dt_control_log(_("could not export to file `%s'!"), filename);
     return 1;
   }
@@ -452,7 +452,7 @@ int store(dt_imageio_module_storage_t *self,
   fdata->max_width = save_max_width;
   fdata->max_height = save_max_height;
 
-  dt_print(DT_DEBUG_ALWAYS, "[export_job] exported to `%s'\n", filename);
+  dt_print(DT_DEBUG_ALWAYS, "[export_job] exported to `%s'", filename);
   dt_control_log(ngettext("%d/%d exported to `%s'", "%d/%d exported to `%s'", num),
                  num, total, filename);
   return 0;

--- a/src/imageio/storage/latex.c
+++ b/src/imageio/storage/latex.c
@@ -283,7 +283,7 @@ int store(dt_imageio_module_storage_t *self, dt_imageio_module_data_t *sdata, co
     if(*c == '/') *c = '\0';
     if(g_mkdir_with_parents(dirname, 0755))
     {
-      dt_print(DT_DEBUG_ALWAYS, "[imageio_storage_latex] could not create directory: `%s'!\n", dirname);
+      dt_print(DT_DEBUG_ALWAYS, "[imageio_storage_latex] could not create directory: `%s'!", dirname);
       dt_control_log(_("could not create directory `%s'!"), dirname);
       dt_pthread_mutex_unlock(&darktable.plugin_threadsafe);
       return 1;
@@ -372,7 +372,7 @@ int store(dt_imageio_module_storage_t *self, dt_imageio_module_data_t *sdata, co
                     TRUE, export_masks, icc_type, icc_filename,
                     icc_intent, self, sdata, num, total, metadata);
 
-  dt_print(DT_DEBUG_ALWAYS, "[export_job] exported to `%s'\n", filename);
+  dt_print(DT_DEBUG_ALWAYS, "[export_job] exported to `%s'", filename);
   dt_control_log(ngettext("%d/%d exported to `%s'", "%d/%d exported to `%s'",
                           num),
                  num, total, filename);

--- a/src/imageio/storage/piwigo.c
+++ b/src/imageio/storage/piwigo.c
@@ -589,7 +589,7 @@ static void _piwigo_authenticate(dt_storage_piwigo_gui_data_t *ui)
       const gchar *errormessage =
         json_object_get_string_member(ui->api->response, "message");
       dt_print(DT_DEBUG_ALWAYS,
-               "[imageio_storage_piwigo] could not authenticate: `%s'!\n",
+               "[imageio_storage_piwigo] could not authenticate: `%s'!",
                errormessage);
       _piwigo_set_status(ui, _("not authenticated"), "#e07f7f");
       _piwigo_ctx_destroy(&ui->api);
@@ -1279,7 +1279,7 @@ int store(dt_imageio_module_storage_t *self,
   if(p->api == NULL)
   {
     dt_print(DT_DEBUG_ALWAYS,
-             "[imageio_storage_piwigo] not logged in to Piwigo server!\n");
+             "[imageio_storage_piwigo] not logged in to Piwigo server!");
     dt_control_log(_("not logged in to Piwigo server!"));
     return 1;
   }
@@ -1353,7 +1353,7 @@ int store(dt_imageio_module_storage_t *self,
                        icc_intent, self, sdata, num, total, metadata) != 0)
   {
     dt_print(DT_DEBUG_ALWAYS,
-             "[imageio_storage_piwigo] could not export to file: `%s'!\n",
+             "[imageio_storage_piwigo] could not export to file: `%s'!",
              fname);
     dt_control_log(_("could not export to file `%s'!"), fname);
     result = 1;
@@ -1391,7 +1391,7 @@ int store(dt_imageio_module_storage_t *self,
         if(!status)
         {
           dt_print(DT_DEBUG_ALWAYS,
-                   "[imageio_storage_piwigo] could not update to Piwigo!\n");
+                   "[imageio_storage_piwigo] could not update to Piwigo!");
           dt_control_log(_("could not update to Piwigo!"));
           result = 1;
         }
@@ -1407,7 +1407,7 @@ int store(dt_imageio_module_storage_t *self,
         if(!status)
         {
           dt_print(DT_DEBUG_ALWAYS,
-                   "[imageio_storage_piwigo] could not upload to Piwigo!\n");
+                   "[imageio_storage_piwigo] could not upload to Piwigo!");
           dt_control_log(_("could not upload to Piwigo!"));
           result = 1;
         }
@@ -1537,7 +1537,7 @@ void *get_params(dt_imageio_module_storage_t *self)
           {
             // Something went wrong...
             dt_print(DT_DEBUG_ALWAYS,
-                     "Something went wrong.. album index %d = NULL\n", index - 2);
+                     "Something went wrong.. album index %d = NULL", index - 2);
           }
           else
           {
@@ -1547,7 +1547,7 @@ void *get_params(dt_imageio_module_storage_t *self)
           if(!p->album_id)
           {
             dt_print(DT_DEBUG_ALWAYS,
-                     "[imageio_storage_piwigo] cannot find album `%s'!\n", p->album);
+                     "[imageio_storage_piwigo] cannot find album `%s'!", p->album);
           }
           break;
       }

--- a/src/iop/Permutohedral.h
+++ b/src/iop/Permutohedral.h
@@ -672,7 +672,7 @@ public:
     }
     dt_print(DT_DEBUG_MEMORY,
       "[permutohedral] hash tables %lu bytes (%lu initially), %lu entries, [permutohedral] tables grew %lu times, "
-      "replay using %lu bytes for %lu pixels, [permutohedral] fill factor %f%%, remap using %lu bytes\n",
+      "replay using %lu bytes for %lu pixels, [permutohedral] fill factor %f%%, remap using %lu bytes",
       total_bytes, init_bytes, total_entries, total_grows,
       (sizeof(ReplayEntry)*nData), nData, (float)100.0f * total_entries / alloc_entries, remap_bytes);
 
@@ -718,7 +718,7 @@ public:
     const Value *const zeroPtr = &zero;
 
     dt_print(DT_DEBUG_MEMORY,
-      "[permutohedral] blur using %lu bytes for newValue\n",
+      "[permutohedral] blur using %lu bytes for newValue",
       (sizeof(Value)*hashTables[0].size()));
 
     // For each of d+1 axes,

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -1205,7 +1205,7 @@ void modify_roi_out(struct dt_iop_module_t *self,
   if(roi_out->width < 4 || roi_out->height < 4)
   {
     dt_print_pipe(DT_DEBUG_PIPE,
-                  "safety check", piece->pipe, self, DT_DEVICE_NONE, roi_in, roi_out, "\n");
+                  "safety check", piece->pipe, self, DT_DEVICE_NONE, roi_in, roi_out);
 
     roi_out->width = roi_in->width;
     roi_out->height = roi_in->height;
@@ -2804,7 +2804,7 @@ static void do_crop(dt_iop_module_t *module, dt_iop_ashift_params_t *p)
 
   dt_print(DT_DEBUG_PIPE | DT_DEBUG_VERBOSE,
     "margins after crop fitting: iter=%d x=%.4f y=%.4f angle=%.4f"
-    " crop area (%.4f %.4f %.4f %.4f) wd=%i ht=%i\n",
+    " crop area (%.4f %.4f %.4f %.4f) wd=%i ht=%i",
     iter, cropfit.x, cropfit.y, cropfit.alpha,
     g->cl, g->cr, g->ct, g->cb, cropfit.width, cropfit.height);
   dt_control_queue_redraw_center();
@@ -2949,7 +2949,7 @@ static void crop_adjust(dt_iop_module_t *module,
 
   dt_print(DT_DEBUG_PIPE | DT_DEBUG_VERBOSE,
     "margins after crop adjustment: x=%.3f y=%.3f angle=%.3f"
-    " crop area (%.3f %.3f %.3f %.3f) width=%i height=%i\n",
+    " crop area (%.3f %.3f %.3f %.3f) width=%i height=%i",
     0.5f * (g->cl + g->cr), 0.5f * (g->ct + g->cb), alpha,
     g->cl, g->cr, g->ct, g->cb, (int)wd, (int)ht);
   return;

--- a/src/iop/ashift_lsd.c
+++ b/src/iop/ashift_lsd.c
@@ -191,7 +191,7 @@ struct point {int x,y;};
  */
 static void error(char * msg)
 {
-  dt_print(DT_DEBUG_ALWAYS,"LSD Error: %s\n",msg);
+  dt_print(DT_DEBUG_ALWAYS,"LSD Error: %s",msg);
   exit(EXIT_FAILURE);
 }
 

--- a/src/iop/atrous.c
+++ b/src/iop/atrous.c
@@ -1701,7 +1701,7 @@ static float _action_process_equalizer(gpointer target,
       default:
         dt_print(DT_DEBUG_ALWAYS,
                  "[_action_process_equalizer] unknown shortcut effect (%d)"
-                 " for contrast equalizer node\n",
+                 " for contrast equalizer node",
                  effect);
         break;
       }
@@ -1729,7 +1729,7 @@ static float _action_process_equalizer(gpointer target,
       default:
         dt_print(DT_DEBUG_ALWAYS,
                  "[_action_process_equalizer] unknown shortcut effect (%d)"
-                 " for contrast equalizer radius\n", effect);
+                 " for contrast equalizer radius", effect);
         break;
       }
 

--- a/src/iop/basecurve.c
+++ b/src/iop/basecurve.c
@@ -1212,7 +1212,7 @@ static inline void gauss_reduce(
   else
   {
     blurred = (float*)input;
-    dt_print(DT_DEBUG_ALWAYS,"[basecurve] gauss_reduce out of memory, skipping blurring\n");
+    dt_print(DT_DEBUG_ALWAYS,"[basecurve] gauss_reduce out of memory, skipping blurring");
   }
   for(size_t j=0;j<ch;j++)
     for(size_t i=0;i<cw;i++)
@@ -1260,7 +1260,7 @@ void process_fusion(struct dt_iop_module_t *self,
     if(!col[k] || !comb[k])
     {
       dt_iop_copy_image_roi(ovoid, ivoid, piece->colors, roi_in, roi_out);
-      dt_print(DT_DEBUG_ALWAYS,"[basecurve] process_fusion out of memory, skipping\n");
+      dt_print(DT_DEBUG_ALWAYS,"[basecurve] process_fusion out of memory, skipping");
       goto cleanup;
     }
     dt_iop_image_fill(comb[k],  0.0f, w, h, 4);

--- a/src/iop/basicadj.c
+++ b/src/iop/basicadj.c
@@ -1172,32 +1172,32 @@ cleanup:
   if(dt_isnan(expcomp))
   {
     expcomp = 0.f;
-    dt_print(DT_DEBUG_ALWAYS, "[_get_auto_exp] expcomp is NaN!!!\n");
+    dt_print(DT_DEBUG_ALWAYS, "[_get_auto_exp] expcomp is NaN!!!");
   }
   if(dt_isnan(black))
   {
     black = 0.f;
-    dt_print(DT_DEBUG_ALWAYS, "[_get_auto_exp] black is NaN!!!\n");
+    dt_print(DT_DEBUG_ALWAYS, "[_get_auto_exp] black is NaN!!!");
   }
   if(dt_isnan(bright))
   {
     bright = 0.f;
-    dt_print(DT_DEBUG_ALWAYS, "[_get_auto_exp] bright is NaN!!!\n");
+    dt_print(DT_DEBUG_ALWAYS, "[_get_auto_exp] bright is NaN!!!");
   }
   if(dt_isnan(contr))
   {
     contr = 0.f;
-    dt_print(DT_DEBUG_ALWAYS, "[_get_auto_exp] contr is NaN!!!\n");
+    dt_print(DT_DEBUG_ALWAYS, "[_get_auto_exp] contr is NaN!!!");
   }
   if(dt_isnan(hlcompr))
   {
     hlcompr = 0.f;
-    dt_print(DT_DEBUG_ALWAYS, "[_get_auto_exp] hlcompr is NaN!!!\n");
+    dt_print(DT_DEBUG_ALWAYS, "[_get_auto_exp] hlcompr is NaN!!!");
   }
   if(dt_isnan(hlcomprthresh))
   {
     hlcomprthresh = 0.f;
-    dt_print(DT_DEBUG_ALWAYS, "[_get_auto_exp] hlcomprthresh is NaN!!!\n");
+    dt_print(DT_DEBUG_ALWAYS, "[_get_auto_exp] hlcomprthresh is NaN!!!");
   }
 
   *_expcomp = expcomp;
@@ -1322,7 +1322,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
       src_buffer = dt_alloc_align_float((size_t)ch * width * height);
       if(src_buffer == NULL)
       {
-        dt_print(DT_DEBUG_ALWAYS, "[basicadj process_cl] error allocating memory for color transformation 1\n");
+        dt_print(DT_DEBUG_ALWAYS, "[basicadj process_cl] error allocating memory for color transformation 1");
         err = DT_OPENCL_SYSMEM_ALLOCATION;
         goto cleanup;
       }
@@ -1330,7 +1330,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
       err = dt_opencl_copy_device_to_host(devid, src_buffer, dev_in, width, height, ch * sizeof(float));
       if(err != CL_SUCCESS)
       {
-        dt_print(DT_DEBUG_ALWAYS, "[basicadj process_cl] error allocating memory for color transformation 2\n");
+        dt_print(DT_DEBUG_ALWAYS, "[basicadj process_cl] error allocating memory for color transformation 2");
         goto cleanup;
       }
 
@@ -1387,7 +1387,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   dev_gamma = dt_opencl_copy_host_to_device(devid, d->lut_gamma, 256, 256, sizeof(float));
   if(dev_gamma == NULL)
   {
-    dt_print(DT_DEBUG_ALWAYS, "[basicadj process_cl] error allocating memory 3\n");
+    dt_print(DT_DEBUG_ALWAYS, "[basicadj process_cl] error allocating memory 3");
     err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
     goto cleanup;
   }
@@ -1395,7 +1395,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   dev_contrast = dt_opencl_copy_host_to_device(devid, d->lut_contrast, 256, 256, sizeof(float));
   if(dev_contrast == NULL)
   {
-    dt_print(DT_DEBUG_ALWAYS, "[basicadj process_cl] error allocating memory 4\n");
+    dt_print(DT_DEBUG_ALWAYS, "[basicadj process_cl] error allocating memory 4");
     err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
     goto cleanup;
   }

--- a/src/iop/bilateral.cc
+++ b/src/iop/bilateral.cc
@@ -351,7 +351,7 @@ void tiling_callback(struct dt_iop_module_t *self,
 
     dt_print(DT_DEBUG_MEMORY,
              "[bilateral tiling requirements] "
-             "tiling factor=%f, npixels=%lu, estimated hashbytes=%lu\n",
+             "tiling factor=%f, npixels=%lu, estimated hashbytes=%lu",
              tiling->factor, npixels, hash_bytes);
   }
   tiling->overhead = 0;

--- a/src/iop/blurs.c
+++ b/src/iop/blurs.c
@@ -284,7 +284,7 @@ static inline void build_gui_kernel(unsigned char *const buffer, const size_t wi
   float *const restrict kernel_2 = dt_alloc_align_float(width * height);
   if(!kernel_1 || !kernel_2)
   {
-    dt_print(DT_DEBUG_ALWAYS,"[blurs] out of memory, skipping build_gui_kernel\n");
+    dt_print(DT_DEBUG_ALWAYS,"[blurs] out of memory, skipping build_gui_kernel");
     goto cleanup;
   }
 
@@ -350,7 +350,7 @@ static inline void build_pixel_kernel(float *const buffer, const size_t width, c
   float *const restrict kernel_1 = dt_alloc_align_float(width * height);
   if(!kernel_1)
   {
-    dt_print(DT_DEBUG_ALWAYS,"[blurs] out of memory, skippping build_pixel_kernel\n");
+    dt_print(DT_DEBUG_ALWAYS,"[blurs] out of memory, skippping build_pixel_kernel");
     return;
   }
 
@@ -411,7 +411,7 @@ static void process_fft(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *pi
   float *const restrict padded_out = dt_alloc_align_float(padded_width * padded_height * 4);
   if(!padded_in || !padded_out)
   {
-    dt_print(DT_DEBUG_ALWAYS,"[blurs] out of memory, skipping process_fft\n");
+    dt_print(DT_DEBUG_ALWAYS,"[blurs] out of memory, skipping process_fft");
     goto cleanup;
   }
 

--- a/src/iop/cacorrect.c
+++ b/src/iop/cacorrect.c
@@ -292,7 +292,7 @@ void process(
   if(!out)
   {
     dt_iop_copy_image_roi(ovoid, ivoid, piece->colors, roi_in, roi_out);
-    dt_print(DT_DEBUG_ALWAYS,"[cacorrect] out of memory, skipping\n");
+    dt_print(DT_DEBUG_ALWAYS,"[cacorrect] out of memory, skipping");
     return;
   }
 
@@ -324,7 +324,7 @@ void process(
     oldraw = dt_calloc_align_float(h_bsize * 2);
     if(!redfactor || !bluefactor || !oldraw)
     {
-      dt_print(DT_DEBUG_ALWAYS,"[cacorrect] out of memory, skipping\n");
+      dt_print(DT_DEBUG_ALWAYS,"[cacorrect] out of memory, skipping");
       goto writeout;
     }
     // copy raw values before ca correction
@@ -348,7 +348,7 @@ void process(
 
   if(!Gtmp || !RawDataTmp)
   {
-    dt_print(DT_DEBUG_ALWAYS,"[cacorrect] out of memory, skipping\n");
+    dt_print(DT_DEBUG_ALWAYS,"[cacorrect] out of memory, skipping");
     goto writeout;
   }
 
@@ -702,7 +702,7 @@ void process(
             else
             {
               processpasstwo = FALSE;
-              dt_print(DT_DEBUG_PIPE, "[cacorrect] blockdenom vanishes\n");
+              dt_print(DT_DEBUG_PIPE, "[cacorrect] blockdenom vanishes");
               break;
             }
           }
@@ -813,7 +813,7 @@ void process(
 
             if(numblox[1] < 10)
             {
-              dt_print(DT_DEBUG_PIPE, "[cacorrect] restrict fit to linear, numblox = %d \n", numblox[1]);
+              dt_print(DT_DEBUG_PIPE, "[cacorrect] restrict fit to linear, numblox = %d ", numblox[1]);
               processpasstwo = FALSE;
             }
           }
@@ -975,7 +975,7 @@ void process(
                 float powHblock = powVblock;
                 for(int j = 0; j < polyord; j++)
                 {
-                  // printf("i= %d j= %d polycoeff= %f \n",i,j,fitparams[0][0][polyord*i+j]);
+                  // printf("i= %d j= %d polycoeff= %f ",i,j,fitparams[0][0][polyord*i+j]);
                   lblockshifts[0][0] += powHblock * fitparams[0][0][polyord * i + j];
                   lblockshifts[0][1] += powHblock * fitparams[0][1][polyord * i + j];
                   lblockshifts[1][0] += powHblock * fitparams[1][0][polyord * i + j];

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -1199,7 +1199,7 @@ static void _declare_cat_on_pipe(struct dt_iop_module_t *self, const gboolean pr
   }
 
   if(origcat != chr->adaptation)
-    dt_print(DT_DEBUG_PIPE, "changed CAT for %s%s from %p to %p\n",
+    dt_print(DT_DEBUG_PIPE, "changed CAT for %s%s from %p to %p",
       self->op, dt_iop_get_instance_id(self), origcat, chr->adaptation);
 }
 
@@ -1985,7 +1985,7 @@ static void _set_trouble_messages(struct dt_iop_module_t *self)
   const dt_develop_t *dev = self->dev;
   const dt_dev_chroma_t *chr = &dev->chroma;
 
-  dt_print(DT_DEBUG_PIPE | DT_DEBUG_VERBOSE, "trouble message for %s%s : temp=%p adapt=%p\n",
+  dt_print(DT_DEBUG_PIPE | DT_DEBUG_VERBOSE, "trouble message for %s%s : temp=%p adapt=%p",
     self->op, dt_iop_get_instance_id(self), chr->temperature, chr->adaptation);
 
   // in temperature module we make sure this is only presented if temperature is enabled
@@ -2038,7 +2038,7 @@ static void _set_trouble_messages(struct dt_iop_module_t *self)
   const dt_image_t *img = &dev->image_storage;
   dt_print_pipe(DT_DEBUG_PIPE, anyproblem ? "chroma trouble" : "chroma data",
       NULL, self, DT_DEVICE_NONE, NULL, NULL,
-      "%s%s%sD65=%s.  NOW %.3f %.3f %.3f, D65 %.3f %.3f %.3f, AS-SHOT %.3f %.3f %.3f File `%s' ID=%i\n",
+      "%s%s%sD65=%s.  NOW %.3f %.3f %.3f, D65 %.3f %.3f %.3f, AS-SHOT %.3f %.3f %.3f File `%s' ID=%i",
       problem1 ? "white balance applied twice, " : "",
       problem2 ? "double CAT applied, " : "",
       problem3 ? "white balance missing, " : "",
@@ -3118,7 +3118,7 @@ void commit_params(struct dt_iop_module_t *self,
   const gboolean run_validation = preview && g && g->run_validation;
 
   dt_print(DT_DEBUG_PARAMS,
-    "[commit color calibration]%s%s  temp=%i  xy=%.4f %.4f - XYZ=%.4f %.4f %.4f - LMS=%.4f %.4f %.4f  %s\n",
+    "[commit color calibration]%s%s  temp=%i  xy=%.4f %.4f - XYZ=%.4f %.4f %.4f - LMS=%.4f %.4f %.4f  %s",
      run_profile ? " [profile]" : "",
      run_validation ? " [validation]" : "",
      (int)p->temperature, x, y, XYZ[0], XYZ[1], XYZ[2],

--- a/src/iop/choleski.h
+++ b/src/iop/choleski.h
@@ -309,25 +309,25 @@ static inline gboolean _solve_hermitian(const float *const restrict A,
   // LU decomposition
   valid = (checks) ? _choleski_decompose_safe(A, L, n) :
                      _choleski_decompose_fast(A, L, n) ;
-  if(!valid) dt_print(DT_DEBUG_ALWAYS, "Cholesky decomposition returned NaNs\n");
+  if(!valid) dt_print(DT_DEBUG_ALWAYS, "Cholesky decomposition returned NaNs");
 
   // Triangular descent
   if(valid)
     valid = (checks) ? _triangular_descent_safe(L, y, x, n) :
                        _triangular_descent_fast(L, y, x, n) ;
-  if(!valid) dt_print(DT_DEBUG_ALWAYS, "Cholesky LU triangular descent returned NaNs\n");
+  if(!valid) dt_print(DT_DEBUG_ALWAYS, "Cholesky LU triangular descent returned NaNs");
 
   // Triangular ascent
   if(valid)
     valid = (checks) ? _triangular_ascent_safe(L, x, y, n) :
                        _triangular_ascent_fast(L, x, y, n);
-  if(!valid) dt_print(DT_DEBUG_ALWAYS, "Cholesky LU triangular ascent returned NaNs\n");
+  if(!valid) dt_print(DT_DEBUG_ALWAYS, "Cholesky LU triangular ascent returned NaNs");
 
   dt_free_align(x);
   dt_free_align(L);
 
   //clock_t end = clock();
-  //dt_print(DT_DEBUG_ALWAYS, "hermitian matrix solving took : %f s\n", ((float) (end - start)) / CLOCKS_PER_SEC);
+  //dt_print(DT_DEBUG_ALWAYS, "hermitian matrix solving took : %f s", ((float) (end - start)) / CLOCKS_PER_SEC);
 
   return valid;
 }
@@ -394,7 +394,7 @@ static inline gboolean pseudo_solve(float *const restrict A,
   gboolean valid = TRUE;
   if(m < n)
   {
-    dt_print(DT_DEBUG_ALWAYS, "Pseudo solve: cannot cast %zu × %zu matrice\n", m, n);
+    dt_print(DT_DEBUG_ALWAYS, "Pseudo solve: cannot cast %zu × %zu matrice", m, n);
     return FALSE;
   }
 
@@ -433,7 +433,7 @@ static inline gboolean pseudo_solve(float *const restrict A,
   dt_free_align(A_square);
 
   //clock_t end = clock();
-  //dt_print(DT_DEBUG_ALWAYS, "hermitian matrix solving took : %f s\n", ((float) (end - start)) / CLOCKS_PER_SEC);
+  //dt_print(DT_DEBUG_ALWAYS, "hermitian matrix solving took : %f s", ((float) (end - start)) / CLOCKS_PER_SEC);
 
   return valid;
 }

--- a/src/iop/clipping.c
+++ b/src/iop/clipping.c
@@ -908,7 +908,7 @@ void modify_roi_out(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t 
   if(roi_out->width < 4 || roi_out->height < 4)
   {
     dt_print_pipe(DT_DEBUG_PIPE,
-      "safety check", piece->pipe, self, DT_DEVICE_NONE, roi_in, roi_out, "\n");
+      "safety check", piece->pipe, self, DT_DEVICE_NONE, roi_in, roi_out);
 
     roi_out->x = roi_in->x;
     roi_out->y = roi_in->y;
@@ -1346,7 +1346,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
     if(d->cx != p->cx || d->cy != p->cy || d->cw != fabsf(p->cw) || d->ch != fabsf(p->ch))
     {
       dt_print(DT_DEBUG_ALWAYS,
-               "[crop&rotate] invalid crop data for %d : x=%0.04f y=%0.04f w=%0.04f h=%0.04f\n",
+               "[crop&rotate] invalid crop data for %d : x=%0.04f y=%0.04f w=%0.04f h=%0.04f",
                pipe->image.id, p->cx, p->cy, p->cw, p->ch);
     }
   }
@@ -2186,7 +2186,7 @@ void gui_init(struct dt_iop_module_t *self)
       // some sanity check
       if(n == 0 || d == 0)
       {
-        dt_print(DT_DEBUG_ALWAYS, "invalid ratio format for `%s'. it should be \"number:number\"\n", nv->key);
+        dt_print(DT_DEBUG_ALWAYS, "invalid ratio format for `%s'. it should be \"number:number\"", nv->key);
         dt_control_log(_("invalid ratio format for `%s'. it should be \"number:number\""), nv->key);
         continue;
       }
@@ -2198,7 +2198,7 @@ void gui_init(struct dt_iop_module_t *self)
     }
     else
     {
-      dt_print(DT_DEBUG_ALWAYS, "invalid ratio format for `%s'. it should be \"number:number\"\n", nv->key);
+      dt_print(DT_DEBUG_ALWAYS, "invalid ratio format for `%s'. it should be \"number:number\"", nv->key);
       dt_control_log(_("invalid ratio format for `%s'. it should be \"number:number\""), nv->key);
       continue;
     }
@@ -3124,7 +3124,7 @@ static void commit_box(dt_iop_module_t *self, dt_iop_clipping_gui_data_t *g, dt_
   }
   g->applied = 1;
   const gboolean changed = fabs(p->cx - old[0]) > eps || fabs(p->cy - old[1]) > eps || fabs(p->cw - old[2]) > eps || fabs(p->ch - old[3]) > eps;
-  // dt_print(DT_DEBUG_ALWAYS, "[crop commit box] %i:  %e %e %e %e\n", changed, p->cx - old[0], p->cy - old[1], p->cw - old[2], p->ch - old[3]);
+  // dt_print(DT_DEBUG_ALWAYS, "[crop commit box] %i:  %e %e %e %e", changed, p->cx - old[0], p->cy - old[1], p->cw - old[2], p->ch - old[3]);
   if(changed) dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 

--- a/src/iop/colorbalance.c
+++ b/src/iop/colorbalance.c
@@ -1370,7 +1370,7 @@ void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker,
   else if(picker == g->auto_color)
     apply_autocolor(self);
   else
-    dt_print(DT_DEBUG_ALWAYS, "[colorbalance] unknown color picker\n");
+    dt_print(DT_DEBUG_ALWAYS, "[colorbalance] unknown color picker");
 
   _check_tuner_picker_labels(self);
 }

--- a/src/iop/colorbalancergb.c
+++ b/src/iop/colorbalancergb.c
@@ -1331,7 +1331,7 @@ void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker,
     dt_bauhaus_slider_set(g->grey_fulcrum, p->grey_fulcrum);
   }
   else
-    dt_print(DT_DEBUG_ALWAYS, "[colorbalancergb] unknown color picker\n");
+    dt_print(DT_DEBUG_ALWAYS, "[colorbalancergb] unknown color picker");
   --darktable.gui->reset;
 
   gui_changed(self, picker, NULL);

--- a/src/iop/colorequal.c
+++ b/src/iop/colorequal.c
@@ -2866,7 +2866,7 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
     if(g->white_adapted_profile != NULL)
       memcpy(input_matrix, g->white_adapted_profile->matrix_in, sizeof(dt_colormatrix_t));
     else
-      dt_print(DT_DEBUG_PIPE, "[colorequal] display color space falls back to sRGB\n");
+      dt_print(DT_DEBUG_PIPE, "[colorequal] display color space falls back to sRGB");
 
     dt_UCS_22_build_gamut_LUT(input_matrix, g->gamut_LUT);
     g->max_saturation = get_minimum_saturation(g->gamut_LUT, 0.2f, 1.f);

--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -185,7 +185,7 @@ static void _resolve_work_profile(dt_colorspaces_color_profile_type_t *work_type
 
   dt_print(DT_DEBUG_ALWAYS,
            "[colorin] profile `%s' not suitable for work profile."
-           " it has been replaced by linear Rec2020 RGB!\n",
+           " it has been replaced by linear Rec2020 RGB!",
            dt_colorspaces_get_name(*work_type, work_filename));
   *work_type = DT_COLORSPACE_LIN_REC2020;
   work_filename[0] = '\0';
@@ -527,7 +527,7 @@ static void _profile_changed(GtkWidget *widget, dt_iop_module_t *self)
   }
   // should really never happen.
   dt_print(DT_DEBUG_ALWAYS,
-           "[colorin] color profile %s seems to have disappeared!\n",
+           "[colorin] color profile %s seems to have disappeared!",
            dt_colorspaces_get_name(p->type, p->filename));
 }
 
@@ -569,7 +569,7 @@ static void _workicc_changed(GtkWidget *widget, dt_iop_module_t *self)
     {
       dt_print(DT_DEBUG_ALWAYS,
                "[colorin] can't extract matrix from colorspace `%s',"
-               " it will be replaced by Rec2020 RGB!\n", p->filename_work);
+               " it will be replaced by Rec2020 RGB!", p->filename_work);
       dt_control_log(_("can't extract matrix from colorspace `%s'"
                        ", it will be replaced by Rec2020 RGB!"), p->filename_work);
 
@@ -585,7 +585,7 @@ static void _workicc_changed(GtkWidget *widget, dt_iop_module_t *self)
   {
     // should really never happen.
     dt_print(DT_DEBUG_ALWAYS,
-             "[colorin] color profile %s seems to have disappeared!\n",
+             "[colorin] color profile %s seems to have disappeared!",
              dt_colorspaces_get_name(p->type_work, p->filename_work));
   }
 }
@@ -667,7 +667,7 @@ int process_cl(struct dt_iop_module_t *self,
 
   dt_print_pipe(DT_DEBUG_PARAMS,
     "matrix conversion",
-    piece->pipe, self, piece->pipe->devid, roi_in, roi_out, "`%s', %s: %.3f %.3f %.3f\n",
+    piece->pipe, self, piece->pipe->devid, roi_in, roi_out, "`%s', %s: %.3f %.3f %.3f",
     dt_colorspaces_get_name(d->type, NULL),
     corrected ? "corrected by" : "",
     coeffs[0], coeffs[1], coeffs[2]);
@@ -788,7 +788,7 @@ static void _process_cmatrix_bm(struct dt_iop_module_t *self,
   transpose_3xSSE(d->lmatrix, lmatrix);
 
   const size_t npixels = (size_t)roi_out->height * roi_out->width;
-  // dt_print(DT_DEBUG_ALWAYS, "Using cmatrix codepath\n");
+  // dt_print(DT_DEBUG_ALWAYS, "Using cmatrix codepath");
   // only color matrix. use our optimized fast path!
   DT_OMP_FOR(shared(cmatrix, nmatrix, lmatrix))
   for(int j = 0; j < npixels; j++)
@@ -1233,7 +1233,7 @@ void process(struct dt_iop_module_t *self,
 
   dt_print_pipe(DT_DEBUG_PARAMS,
     "matrix conversion",
-    piece->pipe, self, DT_DEVICE_CPU, roi_in, roi_out, "`%s', %s: %.3f %.3f %.3f\n",
+    piece->pipe, self, DT_DEVICE_CPU, roi_in, roi_out, "`%s', %s: %.3f %.3f %.3f",
       dt_colorspaces_get_name(d->type, NULL),
       corrected ? "corrected by" : "",
       coeffs[0], coeffs[1], coeffs[2]);
@@ -1405,7 +1405,7 @@ void commit_params(struct dt_iop_module_t *self,
     {
       if(dt_image_is_matrix_correction_supported(&pipe->image))
       {
-        dt_print(DT_DEBUG_ALWAYS, "[colorin] `%s' color matrix not found!\n",
+        dt_print(DT_DEBUG_ALWAYS, "[colorin] `%s' color matrix not found!",
                  pipe->image.camera_makermodel);
         dt_control_log(_("`%s' color matrix not found!"), pipe->image.camera_makermodel);
       }
@@ -1445,7 +1445,7 @@ void commit_params(struct dt_iop_module_t *self,
   // should never happen, but catch that case to avoid a crash
   if(!d->input)
   {
-    dt_print(DT_DEBUG_ALWAYS, "[colorin] input profile could not be generated!\n");
+    dt_print(DT_DEBUG_ALWAYS, "[colorin] input profile could not be generated!");
     dt_control_log(_("input profile could not be generated!"));
     piece->enabled = FALSE;
     return;
@@ -1466,7 +1466,7 @@ void commit_params(struct dt_iop_module_t *self,
       break;
     default:
       dt_print(DT_DEBUG_ALWAYS,
-               "[colorin] input profile color space `%c%c%c%c' not supported\n",
+               "[colorin] input profile color space `%c%c%c%c' not supported",
                (char)(input_color_space>>24),
                (char)(input_color_space>>16),
                (char)(input_color_space>>8),
@@ -1658,7 +1658,7 @@ void gui_update(struct dt_iop_module_t *self)
   {
     idx = 0;
     dt_print(DT_DEBUG_ALWAYS,
-             "[gui colorin] could not find requested working profile `%s'!\n",
+             "[gui colorin] could not find requested working profile `%s'!",
              dt_colorspaces_get_name(p->type_work, p->filename_work));
   }
   dt_bauhaus_combobox_set(g->work_combobox, idx);
@@ -1693,7 +1693,7 @@ void gui_update(struct dt_iop_module_t *self)
   }
   dt_bauhaus_combobox_set(g->profile_combobox, 0);
 
-  dt_print(DT_DEBUG_PIPE, "[gui colorin] using default instead of `%s'\n",
+  dt_print(DT_DEBUG_PIPE, "[gui colorin] using default instead of `%s'",
              dt_colorspaces_get_name(p->type, p->filename));
 }
 

--- a/src/iop/colormapping.c
+++ b/src/iop/colormapping.c
@@ -968,7 +968,7 @@ static void process_clusters(gpointer instance, dt_iop_module_t *self)
     {
       if(fwrite(&g->flowback, sizeof(g->flowback), 1, f) < 1)
         dt_print(DT_DEBUG_ALWAYS,
-                 "[colormapping] could not write flowback file /tmp/dt_colormapping_loaded\n");
+                 "[colormapping] could not write flowback file /tmp/dt_colormapping_loaded");
       fclose(f);
     }
   }

--- a/src/iop/colorout.c
+++ b/src/iop/colorout.c
@@ -274,7 +274,7 @@ static void output_profile_changed(GtkWidget *widget, dt_iop_module_t *self)
   }
 
   dt_print(DT_DEBUG_ALWAYS,
-           "[colorout] color profile %s seems to have disappeared!\n",
+           "[colorout] color profile %s seems to have disappeared!",
            dt_colorspaces_get_name(p->type, p->filename));
 }
 
@@ -652,7 +652,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
                                         | DT_PROFILE_DIRECTION_DISPLAY2)
                  ->profile;
     dt_control_log(_("missing output profile has been replaced by sRGB!"));
-    dt_print(DT_DEBUG_ALWAYS, "missing output profile `%s' has been replaced by sRGB!\n",
+    dt_print(DT_DEBUG_ALWAYS, "missing output profile `%s' has been replaced by sRGB!",
              dt_colorspaces_get_name(out_type, out_filename));
   }
 
@@ -674,7 +674,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
                                              | DT_PROFILE_DIRECTION_DISPLAY2)
                       ->profile;
       dt_control_log(_("missing softproof profile has been replaced by sRGB!"));
-      dt_print(DT_DEBUG_ALWAYS, "missing softproof profile `%s' has been replaced by sRGB!\n",
+      dt_print(DT_DEBUG_ALWAYS, "missing softproof profile `%s' has been replaced by sRGB!",
                dt_colorspaces_get_name(darktable.color_profiles->softproof_type,
                                        darktable.color_profiles->softproof_filename));
     }
@@ -718,7 +718,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
   {
     dt_control_log(_("unsupported output profile has been replaced by sRGB!"));
     dt_print(DT_DEBUG_ALWAYS,
-             "unsupported output profile `%s' has been replaced by sRGB!\n",
+             "unsupported output profile `%s' has been replaced by sRGB!",
              out_profile->name);
     output = dt_colorspaces_get_profile(DT_COLORSPACE_SRGB, "", DT_PROFILE_DIRECTION_OUT)->profile;
 
@@ -803,7 +803,7 @@ void gui_update(struct dt_iop_module_t *self)
 
   dt_bauhaus_combobox_set(g->output_profile, 0);
   dt_print(DT_DEBUG_ALWAYS,
-           "[colorout] could not find requested profile `%s'!\n",
+           "[colorout] could not find requested profile `%s'!",
            dt_colorspaces_get_name(p->type, p->filename));
 }
 

--- a/src/iop/colorreconstruction.c
+++ b/src/iop/colorreconstruction.c
@@ -270,7 +270,7 @@ static dt_iop_colorreconstruct_bilateral_t *dt_iop_colorreconstruct_bilateral_in
   dt_iop_colorreconstruct_bilateral_t *b = (dt_iop_colorreconstruct_bilateral_t *)malloc(sizeof(dt_iop_colorreconstruct_bilateral_t));
   if(!b)
   {
-    dt_print(DT_DEBUG_ALWAYS, "[color reconstruction] not able to allocate buffer (a)\n");
+    dt_print(DT_DEBUG_ALWAYS, "[color reconstruction] not able to allocate buffer (a)");
     return NULL;
   }
   float _x = roundf(roi->width / sigma_s);
@@ -289,7 +289,7 @@ static dt_iop_colorreconstruct_bilateral_t *dt_iop_colorreconstruct_bilateral_in
   b->buf = dt_alloc_align_type(dt_iop_colorreconstruct_Lab_t, b->size_x * b->size_y * b->size_z);
   if(!b->buf)
   {
-    dt_print(DT_DEBUG_ALWAYS, "[color reconstruction] not able to allocate buffer (b)\n");
+    dt_print(DT_DEBUG_ALWAYS, "[color reconstruction] not able to allocate buffer (b)");
     dt_iop_colorreconstruct_bilateral_free(b);
     return NULL;
   }
@@ -310,7 +310,7 @@ static dt_iop_colorreconstruct_bilateral_frozen_t *dt_iop_colorreconstruct_bilat
   dt_iop_colorreconstruct_bilateral_frozen_t *bf = (dt_iop_colorreconstruct_bilateral_frozen_t *)malloc(sizeof(dt_iop_colorreconstruct_bilateral_frozen_t));
   if(!bf)
   {
-    dt_print(DT_DEBUG_ALWAYS, "[color reconstruction] not able to allocate buffer (c)\n");
+    dt_print(DT_DEBUG_ALWAYS, "[color reconstruction] not able to allocate buffer (c)");
     return NULL;
   }
 
@@ -331,7 +331,7 @@ static dt_iop_colorreconstruct_bilateral_frozen_t *dt_iop_colorreconstruct_bilat
   }
   else
   {
-    dt_print(DT_DEBUG_ALWAYS, "[color reconstruction] not able to allocate buffer (d)\n");
+    dt_print(DT_DEBUG_ALWAYS, "[color reconstruction] not able to allocate buffer (d)");
     dt_iop_colorreconstruct_bilateral_dump(bf);
     return NULL;
   }
@@ -346,7 +346,7 @@ static dt_iop_colorreconstruct_bilateral_t *dt_iop_colorreconstruct_bilateral_th
   dt_iop_colorreconstruct_bilateral_t *b = (dt_iop_colorreconstruct_bilateral_t *)malloc(sizeof(dt_iop_colorreconstruct_bilateral_t));
   if(!b)
   {
-    dt_print(DT_DEBUG_ALWAYS, "[color reconstruction] not able to allocate buffer (e)\n");
+    dt_print(DT_DEBUG_ALWAYS, "[color reconstruction] not able to allocate buffer (e)");
     return NULL;
   }
 
@@ -367,7 +367,7 @@ static dt_iop_colorreconstruct_bilateral_t *dt_iop_colorreconstruct_bilateral_th
   }
   else
   {
-    dt_print(DT_DEBUG_ALWAYS, "[color reconstruction] not able to allocate buffer (f)\n");
+    dt_print(DT_DEBUG_ALWAYS, "[color reconstruction] not able to allocate buffer (f)");
     dt_iop_colorreconstruct_bilateral_free(b);
     return NULL;
   }
@@ -726,7 +726,7 @@ static dt_iop_colorreconstruct_bilateral_cl_t *dt_iop_colorreconstruct_bilateral
   if(blocksizex * blocksizey < 16 * 16)
   {
     dt_print(DT_DEBUG_OPENCL,
-             "[opencl_colorreconstruction] device %d does not offer sufficient resources to run bilateral grid\n",
+             "[opencl_colorreconstruction] device %d does not offer sufficient resources to run bilateral grid",
              devid);
     return NULL;
   }
@@ -734,7 +734,7 @@ static dt_iop_colorreconstruct_bilateral_cl_t *dt_iop_colorreconstruct_bilateral
   dt_iop_colorreconstruct_bilateral_cl_t *b = (dt_iop_colorreconstruct_bilateral_cl_t *)malloc(sizeof(dt_iop_colorreconstruct_bilateral_cl_t));
   if(!b)
   {
-    dt_print(DT_DEBUG_OPENCL, "[opencl_colorreconstruction] not able to allocate host buffer (a)\n");
+    dt_print(DT_DEBUG_OPENCL, "[opencl_colorreconstruction] not able to allocate host buffer (a)");
     return NULL;
   }
 
@@ -763,7 +763,7 @@ static dt_iop_colorreconstruct_bilateral_cl_t *dt_iop_colorreconstruct_bilateral
       = dt_opencl_alloc_device_buffer(b->devid, sizeof(float) * 4 * b->size_x * b->size_y * b->size_z);
   if(!b->dev_grid)
   {
-    dt_print(DT_DEBUG_OPENCL, "[opencl_colorreconstruction] not able to allocate device buffer (b)\n");
+    dt_print(DT_DEBUG_OPENCL, "[opencl_colorreconstruction] not able to allocate device buffer (b)");
     dt_iop_colorreconstruct_bilateral_free_cl(b);
     return NULL;
   }
@@ -773,7 +773,7 @@ static dt_iop_colorreconstruct_bilateral_cl_t *dt_iop_colorreconstruct_bilateral
       = dt_opencl_alloc_device_buffer(b->devid, sizeof(float) * 4 * b->size_x * b->size_y * b->size_z);
   if(!b->dev_grid_tmp)
   {
-    dt_print(DT_DEBUG_OPENCL, "[opencl_colorreconstruction] not able to allocate device buffer (c)\n");
+    dt_print(DT_DEBUG_OPENCL, "[opencl_colorreconstruction] not able to allocate device buffer (c)");
     dt_iop_colorreconstruct_bilateral_free_cl(b);
     return NULL;
   }
@@ -784,7 +784,7 @@ static dt_iop_colorreconstruct_bilateral_cl_t *dt_iop_colorreconstruct_bilateral
     CLARG(b->dev_grid), CLARG(wd), CLARG(ht));
   if(err != CL_SUCCESS)
   {
-    dt_print(DT_DEBUG_OPENCL, "[opencl_colorreconstruction] error running kernel colorreconstruct_zero: %d\n", err);
+    dt_print(DT_DEBUG_OPENCL, "[opencl_colorreconstruction] error running kernel colorreconstruct_zero: %d", err);
     dt_iop_colorreconstruct_bilateral_free_cl(b);
     return NULL;
   }
@@ -804,7 +804,7 @@ static dt_iop_colorreconstruct_bilateral_frozen_t *dt_iop_colorreconstruct_bilat
   dt_iop_colorreconstruct_bilateral_frozen_t *bf = (dt_iop_colorreconstruct_bilateral_frozen_t *)malloc(sizeof(dt_iop_colorreconstruct_bilateral_frozen_t));
   if(!bf)
   {
-    dt_print(DT_DEBUG_OPENCL, "[opencl_colorreconstruction] not able to allocate host buffer (d)\n");
+    dt_print(DT_DEBUG_OPENCL, "[opencl_colorreconstruction] not able to allocate host buffer (d)");
     return NULL;
   }
 
@@ -827,14 +827,14 @@ static dt_iop_colorreconstruct_bilateral_frozen_t *dt_iop_colorreconstruct_bilat
     if(err != CL_SUCCESS)
     {
       dt_print(DT_DEBUG_OPENCL,
-           "[opencl_colorreconstruction] can not read bilateral grid from device %d\n", b->devid);
+           "[opencl_colorreconstruction] can not read bilateral grid from device %d", b->devid);
       dt_iop_colorreconstruct_bilateral_dump(bf);
       return NULL;
     }
   }
   else
   {
-    dt_print(DT_DEBUG_OPENCL, "[opencl_colorreconstruction] not able to allocate host buffer (e)\n");
+    dt_print(DT_DEBUG_OPENCL, "[opencl_colorreconstruction] not able to allocate host buffer (e)");
     dt_iop_colorreconstruct_bilateral_dump(bf);
     return NULL;
   }
@@ -866,7 +866,7 @@ static dt_iop_colorreconstruct_bilateral_cl_t *dt_iop_colorreconstruct_bilateral
   if(blocksizex * blocksizey < 16 * 16)
   {
     dt_print(DT_DEBUG_OPENCL,
-             "[opencl_colorreconstruction] device %d does not offer sufficient resources to run bilateral grid\n",
+             "[opencl_colorreconstruction] device %d does not offer sufficient resources to run bilateral grid",
              devid);
     return NULL;
   }
@@ -874,7 +874,7 @@ static dt_iop_colorreconstruct_bilateral_cl_t *dt_iop_colorreconstruct_bilateral
   dt_iop_colorreconstruct_bilateral_cl_t *b = (dt_iop_colorreconstruct_bilateral_cl_t *)malloc(sizeof(dt_iop_colorreconstruct_bilateral_cl_t));
   if(!b)
   {
-    dt_print(DT_DEBUG_OPENCL, "[opencl_colorreconstruction] not able to allocate host buffer (f)\n");
+    dt_print(DT_DEBUG_OPENCL, "[opencl_colorreconstruction] not able to allocate host buffer (f)");
     return NULL;
   }
 
@@ -900,7 +900,7 @@ static dt_iop_colorreconstruct_bilateral_cl_t *dt_iop_colorreconstruct_bilateral
       = dt_opencl_alloc_device_buffer(b->devid, sizeof(float) * 4 * b->size_x * b->size_y * b->size_z);
   if(!b->dev_grid)
   {
-    dt_print(DT_DEBUG_OPENCL, "[opencl_colorreconstruction] not able to allocate device buffer (g)\n");
+    dt_print(DT_DEBUG_OPENCL, "[opencl_colorreconstruction] not able to allocate device buffer (g)");
     dt_iop_colorreconstruct_bilateral_free_cl(b);
     return NULL;
   }
@@ -910,7 +910,7 @@ static dt_iop_colorreconstruct_bilateral_cl_t *dt_iop_colorreconstruct_bilateral
       = dt_opencl_alloc_device_buffer(b->devid, sizeof(float) * 4 * b->size_x * b->size_y * b->size_z);
   if(!b->dev_grid_tmp)
   {
-    dt_print(DT_DEBUG_OPENCL, "[opencl_colorreconstruction] not able to allocate device buffer (h)\n");
+    dt_print(DT_DEBUG_OPENCL, "[opencl_colorreconstruction] not able to allocate device buffer (h)");
     dt_iop_colorreconstruct_bilateral_free_cl(b);
     return NULL;
   }
@@ -923,7 +923,7 @@ static dt_iop_colorreconstruct_bilateral_cl_t *dt_iop_colorreconstruct_bilateral
     if(err != CL_SUCCESS)
     {
       dt_print(DT_DEBUG_OPENCL,
-           "[opencl_colorreconstruction] can not write bilateral grid to device %d\n", b->devid);
+           "[opencl_colorreconstruction] can not write bilateral grid to device %d", b->devid);
       dt_iop_colorreconstruct_bilateral_free_cl(b);
       return NULL;
     }

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -2543,7 +2543,7 @@ static float _action_process_zones(gpointer target,
       break;
     default:
       dt_print(DT_DEBUG_ALWAYS,
-               "[_action_process_zones] unknown shortcut effect (%d) for color zones\n",
+               "[_action_process_zones] unknown shortcut effect (%d) for color zones",
                effect);
       break;
     }

--- a/src/iop/crop.c
+++ b/src/iop/crop.c
@@ -359,7 +359,7 @@ void modify_roi_out(struct dt_iop_module_t *self,
 
   dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_VERBOSE,
     "crop aspects", piece->pipe, self, DT_DEVICE_NONE, roi_in, NULL,
-    " %s%s%sAspect=%.5f. odx: %.4f ody: %.4f --> dx: %.4f dy: %.4f\n",
+    " %s%s%sAspect=%.5f. odx: %.4f ody: %.4f --> dx: %.4f dy: %.4f",
     d->aspect < 0.0f ? "toggled " : "",
     keep_aspect ? "fixed " : "",
     landscape ? "landscape " : "portrait ",
@@ -1182,7 +1182,7 @@ void gui_init(struct dt_iop_module_t *self)
       if(n == 0 || d == 0)
       {
         dt_print(DT_DEBUG_ALWAYS,
-                 "invalid ratio format for `%s'. it should be \"number:number\"\n",
+                 "invalid ratio format for `%s'. it should be \"number:number\"",
                  nv->key);
         dt_control_log
           (_("invalid ratio format for `%s'. it should be \"number:number\""),
@@ -1199,7 +1199,7 @@ void gui_init(struct dt_iop_module_t *self)
     else
     {
       dt_print(DT_DEBUG_ALWAYS,
-               "invalid ratio format for `%s'. it should be \"number:number\"\n",
+               "invalid ratio format for `%s'. it should be \"number:number\"",
                nv->key);
       dt_control_log
         (_("invalid ratio format for `%s'. it should be \"number:number\""),

--- a/src/iop/defringe.c
+++ b/src/iop/defringe.c
@@ -144,7 +144,7 @@ static inline void _fib_latt(int *const x, int *const y, float radius, int step,
   {
     *x = 0;
     *y = 0;
-    dt_print(DT_DEBUG_ALWAYS, "Fibonacci lattice index wrong/out of bounds in defringe module\n");
+    dt_print(DT_DEBUG_ALWAYS, "Fibonacci lattice index wrong/out of bounds in defringe module");
     return;
   }
   float px = step / fib[idx], py = step * (fib[idx + 1] / fib[idx]);
@@ -204,7 +204,7 @@ void process(struct dt_iop_module_t *module,
   gauss = dt_gaussian_init(width, height, 4, Labmax, Labmin, sigma, order);
   if(!gauss)
   {
-    dt_print(DT_DEBUG_ALWAYS, "Error allocating memory for gaussian blur in defringe module\n");
+    dt_print(DT_DEBUG_ALWAYS, "Error allocating memory for gaussian blur in defringe module");
     goto ERROR_EXIT;
   }
   dt_gaussian_blur_4c(gauss, in, out);
@@ -251,7 +251,7 @@ void process(struct dt_iop_module_t *module,
   xy_small = malloc(sizeof(int) * 2 * samples_small);
   if(!xy_avg || !xy_small)
   {
-    dt_print(DT_DEBUG_ALWAYS, "Error allocating memory for fibonacci lattice in defringe module\n");
+    dt_print(DT_DEBUG_ALWAYS, "Error allocating memory for fibonacci lattice in defringe module");
     goto ERROR_EXIT;
   }
 

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -728,7 +728,7 @@ void process(dt_iop_module_t *self,
     {
       roi = *roi_out;
       dt_print_pipe(DT_DEBUG_PIPE, "clip_and_zoom_roi",
-        piece->pipe, self, DT_DEVICE_CPU, roi_in, roi_out, "\n");
+        piece->pipe, self, DT_DEVICE_CPU, roi_in, roi_out);
       dt_iop_clip_and_zoom_roi((float *)o, tmp, &roi, &roo);
       dt_free_align(tmp);
     }
@@ -851,7 +851,7 @@ int process_cl(dt_iop_module_t *self,
   }
   else
   {
-    dt_print(DT_DEBUG_OPENCL, "[opencl_demosaic] demosaicing method %d not yet supported by opencl code\n", demosaicing_method);
+    dt_print(DT_DEBUG_OPENCL, "[opencl_demosaic] demosaicing method %d not yet supported by opencl code", demosaicing_method);
     return DT_OPENCL_PROCESS_CL;
   }
 
@@ -1126,7 +1126,7 @@ void commit_params(dt_iop_module_t *self,
                                                self->dev->image_storage.d65_color_matrix, NULL))
     {
       const char *camera = self->dev->image_storage.camera_makermodel;
-      dt_print(DT_DEBUG_ALWAYS, "[colorspaces] `%s' color matrix not found for 4bayer image!\n", camera);
+      dt_print(DT_DEBUG_ALWAYS, "[colorspaces] `%s' color matrix not found for 4bayer image!", camera);
       dt_control_log(_("`%s' color matrix not found for 4bayer image!"), camera);
     }
   }

--- a/src/iop/demosaicing/basics.c
+++ b/src/iop/demosaicing/basics.c
@@ -304,7 +304,7 @@ static int color_smoothing_cl(
 error:
   dt_opencl_release_mem_object(dev_tmp);
   if(err != CL_SUCCESS)
-    dt_print(DT_DEBUG_OPENCL, "[opencl_demosaic_color_smoothing] problem '%s'\n", cl_errstr(err));
+    dt_print(DT_DEBUG_OPENCL, "[opencl_demosaic_color_smoothing] problem '%s'", cl_errstr(err));
   return err;
 }
 
@@ -479,7 +479,7 @@ error:
   dt_opencl_release_mem_object(dev_r);
   dt_free_align(sumsum);
   if(err != CL_SUCCESS)
-    dt_print(DT_DEBUG_OPENCL, "[opencl_demosaic_green_equilibration] problem  '%s'\n", cl_errstr(err));
+    dt_print(DT_DEBUG_OPENCL, "[opencl_demosaic_green_equilibration] problem  '%s'", cl_errstr(err));
   return err;
 }
 
@@ -652,7 +652,7 @@ static int process_default_cl(
 
     if(scaled)
     {
-      dt_print_pipe(DT_DEBUG_PIPE, "clip_and_zoom_roi", piece->pipe, self, piece->pipe->devid, roi_in, roi_out, "\n");
+      dt_print_pipe(DT_DEBUG_PIPE, "clip_and_zoom_roi", piece->pipe, self, piece->pipe->devid, roi_in, roi_out);
       // scale aux buffer to output buffer
       err = dt_iop_clip_and_zoom_roi_cl(devid, dev_out, dev_aux, roi_out, roi_in);
     }
@@ -687,7 +687,7 @@ error:
     err = color_smoothing_cl(self, piece, dev_out, dev_out, roi_out, data->color_smoothing);
 
   if(err != CL_SUCCESS)
-    dt_print(DT_DEBUG_OPENCL, "[opencl_demosaic] basic kernel problem '%s'\n", cl_errstr(err));
+    dt_print(DT_DEBUG_OPENCL, "[opencl_demosaic] basic kernel problem '%s'", cl_errstr(err));
   return err;
 }
 

--- a/src/iop/demosaicing/lmmse.c
+++ b/src/iop/demosaicing/lmmse.c
@@ -83,7 +83,7 @@ static void _init_lmmse_gamma()
   if(!lmmse_gamma_in || !lmmse_gamma_out)
   {
     _cleanup_lmmse_gamma();
-    dt_print(DT_DEBUG_ALWAYS, "[demosaic lmmse] Can't allocate gamma memory\n");
+    dt_print(DT_DEBUG_ALWAYS, "[demosaic lmmse] Can't allocate gamma memory");
     return;
   }
   DT_OMP_PRAGMA(for)

--- a/src/iop/demosaicing/rcd.c
+++ b/src/iop/demosaicing/rcd.c
@@ -764,7 +764,7 @@ static int process_rcd_cl(
     if(scaled)
     {
       dt_print_pipe(DT_DEBUG_PIPE, "clip_and_zoom_roi",
-        piece->pipe, self, piece->pipe->devid, roi_in, roi_out, "\n");
+        piece->pipe, self, piece->pipe->devid, roi_in, roi_out);
       // scale aux buffer to output buffer
       err = dt_iop_clip_and_zoom_roi_cl(devid, dev_out, dev_aux, roi_out, roi_in);
     }
@@ -802,7 +802,7 @@ error:
   dt_opencl_release_mem_object(HQ_diff);
 
   if(err != CL_SUCCESS)
-    dt_print(DT_DEBUG_OPENCL, "[opencl_demosaic] rcd problem '%s'\n", cl_errstr(err));
+    dt_print(DT_DEBUG_OPENCL, "[opencl_demosaic] rcd problem '%s'", cl_errstr(err));
   return err;
 }
 

--- a/src/iop/demosaicing/vng.c
+++ b/src/iop/demosaicing/vng.c
@@ -196,7 +196,7 @@ static void vng_interpolate(
   char *buffer = (char *)dt_alloc_aligned(sizeof(**brow) * width * 3 + sizeof(*ip) * prow * pcol * 320);
   if(!buffer)
   {
-    dt_print(DT_DEBUG_ALWAYS, "[demosaic] not able to allocate VNG buffer\n");
+    dt_print(DT_DEBUG_ALWAYS, "[demosaic] not able to allocate VNG buffer");
     return;
   }
   for(int row = 0; row < 3; row++) brow[row] = (float(*)[4])buffer + row * width;
@@ -619,7 +619,7 @@ static int process_vng_cl(dt_iop_module_t *self,
     if(scaled)
     {
       dt_print_pipe(DT_DEBUG_PIPE, "clip_and_zoom_roi",
-        piece->pipe, self, piece->pipe->devid, roi_in, roi_out, "\n");
+        piece->pipe, self, piece->pipe->devid, roi_in, roi_out);
       // scale temp buffer to output buffer
       err = dt_iop_clip_and_zoom_roi_cl(devid, dev_out, dev_aux, roi_out, roi_in);
       if(err != CL_SUCCESS) goto finish;
@@ -655,7 +655,7 @@ finish:
     err = color_smoothing_cl(self, piece, dev_out, dev_out, roi_out, data->color_smoothing);
 
   if(err != CL_SUCCESS)
-    dt_print(DT_DEBUG_OPENCL, "[opencl_demosaic] vng problem '%s'\n", cl_errstr(err));
+    dt_print(DT_DEBUG_OPENCL, "[opencl_demosaic] vng problem '%s'", cl_errstr(err));
   return err;
 }
 

--- a/src/iop/demosaicing/xtrans.c
+++ b/src/iop/demosaicing/xtrans.c
@@ -66,7 +66,7 @@ static void xtrans_markesteijn_interpolate(float *out,
   char *const all_buffers = (char *)dt_alloc_perthread(buffer_size, sizeof(char), &padded_buffer_size);
   if(!all_buffers)
   {
-    dt_print(DT_DEBUG_ALWAYS, "[demosaic] not able to allocate Markesteijn buffers\n");
+    dt_print(DT_DEBUG_ALWAYS, "[demosaic] not able to allocate Markesteijn buffers");
     return;
   }
 
@@ -1069,7 +1069,7 @@ static void xtrans_fdc_interpolate(dt_iop_module_t *self,
   char *const all_buffers = (char *)dt_alloc_perthread(buffer_size, sizeof(char), &padded_buffer_size);
   if(!all_buffers)
   {
-    dt_print(DT_DEBUG_ALWAYS, "[demosaic] not able to allocate FDC base buffers\n");
+    dt_print(DT_DEBUG_ALWAYS, "[demosaic] not able to allocate FDC base buffers");
     return;
   }
 
@@ -2196,7 +2196,7 @@ static int process_markesteijn_cl(dt_iop_module_t *self,
     if(scaled)
     {
       dt_print_pipe(DT_DEBUG_PIPE, "clip_and_zoom_roi",
-        piece->pipe, self, piece->pipe->devid, roi_in, roi_out, "\n");
+        piece->pipe, self, piece->pipe->devid, roi_in, roi_out);
       // scale temp buffer to output buffer
       err = dt_iop_clip_and_zoom_roi_cl(devid, dev_out, dev_tmp, roi_out, roi_in);
       if(err != CL_SUCCESS) goto error;
@@ -2247,7 +2247,7 @@ error:
   dt_opencl_release_mem_object(dev_aux);
   dt_opencl_release_mem_object(dev_edge_in);
   dt_opencl_release_mem_object(dev_edge_out);
-  dt_print(DT_DEBUG_OPENCL, "[opencl_demosaic] markesteijn problem '%s'\n", cl_errstr(err));
+  dt_print(DT_DEBUG_OPENCL, "[opencl_demosaic] markesteijn problem '%s'", cl_errstr(err));
   return err;
 }
 

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -2613,7 +2613,7 @@ static int process_wavelets_cl(struct dt_iop_module_t *self,
                                       adjt[1] * sb2 / std_x[1],
                                       adjt[2] * sb2 / std_x[2],
                                       0.0f };
-    // dt_print(DT_DEBUG_ALWAYS, "scale %d thrs %f %f %f\n", s, thrs[0], thrs[1], thrs[2]);
+    // dt_print(DT_DEBUG_ALWAYS, "scale %d thrs %f %f %f", s, thrs[0], thrs[1], thrs[2]);
 
     const dt_aligned_pixel_t boost = { 1.0f, 1.0f, 1.0f, 1.0f };
 
@@ -2720,7 +2720,7 @@ int process_cl(struct dt_iop_module_t *self,
   else
   {
     dt_print(DT_DEBUG_OPENCL,
-             "[opencl_denoiseprofile] compute variance not yet supported by opencl code\n");
+             "[opencl_denoiseprofile] compute variance not yet supported by opencl code");
     return DT_OPENCL_PROCESS_CL;
   }
 }

--- a/src/iop/filmic.c
+++ b/src/iop/filmic.c
@@ -772,7 +772,7 @@ void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker,
   else if(picker == g->auto_button)
     apply_autotune(self);
   else
-    dt_print(DT_DEBUG_ALWAYS, "[filmic] unknown color picker\n");
+    dt_print(DT_DEBUG_ALWAYS, "[filmic] unknown color picker");
 }
 
 static void grey_point_source_callback(GtkWidget *slider, dt_iop_module_t *self)

--- a/src/iop/finalscale.c
+++ b/src/iop/finalscale.c
@@ -158,7 +158,7 @@ int process_cl(struct dt_iop_module_t *self,
   if(roi_out->scale > 1.0f) // trust cl code for 1:1 copy here or downscale
   {
     dt_print(DT_DEBUG_OPENCL,
-             "[opencl_finalscale] upscaling not yet supported by opencl code\n");
+             "[opencl_finalscale] upscaling not yet supported by opencl code");
     return DT_OPENCL_PROCESS_CL;
   }
 
@@ -167,7 +167,7 @@ int process_cl(struct dt_iop_module_t *self,
 
   dt_print_pipe(DT_DEBUG_IMAGEIO,
                 exporting ? "clip_and_zoom_roi" : "clip_and_zoom",
-                piece->pipe, self, piece->pipe->devid, roi_in, roi_out, "device=%i\n", devid);
+                piece->pipe, self, piece->pipe->devid, roi_in, roi_out, "device=%i", devid);
   if(exporting)
     return dt_iop_clip_and_zoom_roi_cl(devid, dev_out, dev_in, roi_out, roi_in);
   else
@@ -185,7 +185,7 @@ void process(dt_iop_module_t *self,
   const gboolean exporting = piece->pipe->type == DT_DEV_PIXELPIPE_EXPORT;
   dt_print_pipe(DT_DEBUG_IMAGEIO,
                 exporting ? "clip_and_zoom_roi" : "clip_and_zoom",
-                piece->pipe, self, DT_DEVICE_CPU, roi_in, roi_out, "\n");
+                piece->pipe, self, DT_DEVICE_CPU, roi_in, roi_out);
 
   if(exporting)
     dt_iop_clip_and_zoom_roi((float *)ovoid, (float *)ivoid, roi_out, roi_in);

--- a/src/iop/gaussian_elimination.h
+++ b/src/iop/gaussian_elimination.h
@@ -155,7 +155,7 @@ static inline int pseudo_solve_gaussian(double *const restrict A,
 
   if(m < n)
   {
-    dt_print(DT_DEBUG_ALWAYS, "pseudo solve: cannot cast %zu x %zu matrix\n", m, n);
+    dt_print(DT_DEBUG_ALWAYS, "pseudo solve: cannot cast %zu x %zu matrix", m, n);
     return 0;
   }
 

--- a/src/iop/hazeremoval.c
+++ b/src/iop/hazeremoval.c
@@ -667,7 +667,7 @@ static float _ambient_light_cl(dt_iop_module_t *self,
   dt_free_align(in);
   return max_depth;
 error:
-  dt_print(DT_DEBUG_OPENCL, "[hazeremoval, ambient_light_cl] unknown error: %d\n", err);
+  dt_print(DT_DEBUG_OPENCL, "[hazeremoval, ambient_light_cl] unknown error: %d", err);
   dt_free_align(in);
   return 0.f;
 }

--- a/src/iop/hlreconstruct/laplacian.c
+++ b/src/iop/hlreconstruct/laplacian.c
@@ -535,7 +535,7 @@ static inline gint wavelets_process(const float *const restrict in,
   float *const tempbuf = dt_alloc_perthread_float(4 * width, &padded_size); //TODO: alloc in caller
   for(int s = 0; s < scales; ++s)
   {
-    //dt_print(DT_DEBUG_ALWAYS, "CPU Wavelet decompose : scale %i\n", s);
+    //dt_print(DT_DEBUG_ALWAYS, "CPU Wavelet decompose : scale %i", s);
     const int mult = 1 << s;
 
     const float *restrict buffer_in;
@@ -709,7 +709,7 @@ static inline cl_int wavelets_process_cl(const int devid,
   // the wavelets decomposition here is the same as the equalizer/atrous module,
   for(int s = 0; s < scales; ++s)
   {
-    //dt_print(DT_DEBUG_ALWAYS, "GPU Wavelet decompose : scale %i\n", s);
+    //dt_print(DT_DEBUG_ALWAYS, "GPU Wavelet decompose : scale %i", s);
     const int mult = 1 << s;
 
     cl_mem buffer_in;

--- a/src/iop/hlreconstruct/opposed.c
+++ b/src/iop/hlreconstruct/opposed.c
@@ -335,7 +335,7 @@ static float *_process_opposed(
 
       dt_print_pipe(DT_DEBUG_PIPE,
           "opposed chroma", piece->pipe, self, DT_DEVICE_CPU, roi_in, roi_out,
-          "RGB %3.4f %3.4f %3.4f hash=%" PRIx64 "%s%s\n",
+          "RGB %3.4f %3.4f %3.4f hash=%" PRIx64 "%s%s",
           chrominance[0], chrominance[1], chrominance[2],
           _opposed_parhash(piece),
           piece->pipe->type == DT_DEV_PIXELPIPE_FULL ? ", saved" : "",
@@ -534,7 +534,7 @@ static cl_int process_opposed_cl(
 
     dt_print_pipe(DT_DEBUG_PIPE,
         "opposed chroma", piece->pipe, self, piece->pipe->devid, roi_in, roi_out,
-        "RGB %3.4f %3.4f %3.4f hash=%" PRIx64 "%s%s\n",
+        "RGB %3.4f %3.4f %3.4f hash=%" PRIx64 "%s%s",
         chrominance[0], chrominance[1], chrominance[2],
         _opposed_parhash(piece),
         piece->pipe->type == DT_DEV_PIXELPIPE_FULL ? ", saved" : "",

--- a/src/iop/hlreconstruct/segbased.c
+++ b/src/iop/hlreconstruct/segbased.c
@@ -485,7 +485,7 @@ static void _process_segmentation(dt_dev_pixelpipe_iop_t *piece,
   float *fbuffer = dt_alloc_align_float(HL_FLOAT_PLANES * p_size);
   if(!fbuffer)
   {
-    dt_print(DT_DEBUG_PIPE, "[process segmentation] can't allocate intermediate buffers\n");
+    dt_print(DT_DEBUG_PIPE, "[process segmentation] can't allocate intermediate buffers");
     return;
   }
 
@@ -505,7 +505,7 @@ static void _process_segmentation(dt_dev_pixelpipe_iop_t *piece,
 
   if(segerror)
   {
-    dt_print(DT_DEBUG_PIPE, "[process segmentation] can't allocate segmentation buffers\n");
+    dt_print(DT_DEBUG_PIPE, "[process segmentation] can't allocate segmentation buffers");
     for(int i = 0; i < HL_SEGMENT_PLANES; i++)
       dt_segmentation_free_struct(&isegments[i]);
 
@@ -745,7 +745,7 @@ static void _process_segmentation(dt_dev_pixelpipe_iop_t *piece,
     }
   }
 
-  dt_print(DT_DEBUG_PERF, "[segmentation report %-12s] %5.1fMpix, segments: %3i red, %3i green, %3i blue, %3i all, %4i allowed.\n",
+  dt_print(DT_DEBUG_PERF, "[segmentation report %-12s] %5.1fMpix, segments: %3i red, %3i green, %3i blue, %3i all, %4i allowed",
       dt_dev_pixelpipe_type_to_str(piece->pipe->type),
       (float) (roi_in->width * roi_in->height) / 1.0e6f, isegments[0].nr -2, isegments[1].nr-2, isegments[2].nr-2, isegments[3].nr-2,
       segmentation_limit-2);

--- a/src/iop/hlreconstruct/segmentation.c
+++ b/src/iop/hlreconstruct/segmentation.c
@@ -66,7 +66,7 @@ static inline void _push_stack(int xpos, int ypos, dt_ff_stack_t *stack)
   const int i = stack->pos;
   if(i >= stack->size - 1)
   {
-    dt_print(DT_DEBUG_ALWAYS, "[segmentation stack overflow] %i\n", stack->size);
+    dt_print(DT_DEBUG_ALWAYS, "[segmentation stack overflow] %i", stack->size);
     return;
   }
   stack->el[i].xpos = xpos;
@@ -88,7 +88,7 @@ static inline dt_pos_t * _pop_stack(dt_ff_stack_t *stack)
   if(stack->pos > 0)
     stack->pos--;
   else
-    dt_print(DT_DEBUG_ALWAYS, "[segmentation stack underflow]\n");
+    dt_print(DT_DEBUG_ALWAYS, "[segmentation stack underflow]");
   return &stack->el[stack->pos];
 }
 
@@ -554,7 +554,7 @@ void dt_segmentize_plane(dt_iop_segmentation_t *seg)
   stack.el = dt_alloc_align_type(dt_pos_t, stack.size);
   if(!stack.el)
   {
-    dt_print(DT_DEBUG_ALWAYS, "[segmentize_plane] can't allocate segmentation stack\n");
+    dt_print(DT_DEBUG_ALWAYS, "[segmentize_plane] can't allocate segmentation stack");
     return;
   }
   const int border = seg->border;
@@ -576,7 +576,7 @@ void dt_segmentize_plane(dt_iop_segmentation_t *seg)
   finish:
 
   if(id >= (seg->slots - 2))
-    dt_print(DT_DEBUG_ALWAYS, "[segmentize_plane] %ix%i number of segments exceeds maximum=%i\n",
+    dt_print(DT_DEBUG_ALWAYS, "[segmentize_plane] %ix%i number of segments exceeds maximum=%i",
              (int)width, (int)height, seg->slots);
 
   dt_free_align(stack.el);

--- a/src/iop/invert.c
+++ b/src/iop/invert.c
@@ -101,7 +101,7 @@ int legacy_params(dt_iop_module_t *self,
       {
         const char *camera = self->dev->image_storage.camera_makermodel;
         dt_print(DT_DEBUG_ALWAYS,
-                 "[invert] `%s' color matrix not found for 4bayer image\n", camera);
+                 "[invert] `%s' color matrix not found for 4bayer image", camera);
         dt_control_log(_("`%s' color matrix not found for 4bayer image"), camera);
       }
       else
@@ -425,7 +425,7 @@ void reload_defaults(dt_iop_module_t *self)
                                                    self->dev->image_storage.d65_color_matrix, NULL))
         {
           const char *camera = self->dev->image_storage.camera_makermodel;
-          dt_print(DT_DEBUG_ALWAYS, "[invert] `%s' color matrix not found for 4bayer image\n", camera);
+          dt_print(DT_DEBUG_ALWAYS, "[invert] `%s' color matrix not found for 4bayer image", camera);
           dt_control_log(_("`%s' color matrix not found for 4bayer image"), camera);
         }
       }

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -3401,7 +3401,7 @@ void init_global(dt_iop_module_so_t *module)
       userdbts > sysdbts ? dt_iop_lensfun_db->UserUpdatesLocation : sysdbpath;
     if(dt_iop_lensfun_db->Load(dbpath) != LF_NO_ERROR)
       dt_print(DT_DEBUG_ALWAYS,
-               "[iop_lens]: could not load Lensfun database in `%s'!\n",
+               "[iop_lens]: could not load Lensfun database in `%s'!",
                dbpath);
     else
       dt_iop_lensfun_db->Load(dt_iop_lensfun_db->UserLocation);
@@ -3413,7 +3413,7 @@ void init_global(dt_iop_module_so_t *module)
     if(dt_iop_lensfun_db->Load() != LF_NO_ERROR)
     {
       dt_print(DT_DEBUG_ALWAYS,
-               "[iop_lens]: could not load Lensfun database in `%s'!\n",
+               "[iop_lens]: could not load Lensfun database in `%s'!",
                sysdbpath);
 #endif
       g_free(dt_iop_lensfun_db->HomeDataDir);
@@ -3421,7 +3421,7 @@ void init_global(dt_iop_module_so_t *module)
                                                         (char *)NULL);
       if(dt_iop_lensfun_db->Load() != LF_NO_ERROR)
         dt_print(DT_DEBUG_ALWAYS,
-                 "[iop_lens]: could not load Lensfun database in `%s'!\n",
+                 "[iop_lens]: could not load Lensfun database in `%s'!",
                  dt_iop_lensfun_db->HomeDataDir);
 #ifdef LF_MAX_DATABASE_VERSION
     }

--- a/src/iop/liquify.c
+++ b/src/iop/liquify.c
@@ -939,7 +939,7 @@ static void apply_round_stamp(const dt_liquify_warp_t *const restrict warp,
   if(!lookup_table)
   {
     dt_free_align((void*)lookup_table);
-    dt_print(DT_DEBUG_ALWAYS,"[liquify] out of memory, round stamp skipped\n");
+    dt_print(DT_DEBUG_ALWAYS,"[liquify] out of memory, round stamp skipped");
     return;
   }
 

--- a/src/iop/lut3d.c
+++ b/src/iop/lut3d.c
@@ -471,7 +471,7 @@ uint8_t calculate_clut_compressed(dt_iop_lut3d_params_t *const p, const char *co
   lclut = dt_alloc_align_float(buf_size_lut);
   if(!lclut)
   {
-    dt_print(DT_DEBUG_ALWAYS, "[lut3d] error allocating buffer for gmz LUT\n");
+    dt_print(DT_DEBUG_ALWAYS, "[lut3d] error allocating buffer for gmz LUT");
     dt_control_log(_("error allocating buffer for gmz LUT"));
     level = 0;
   }
@@ -497,15 +497,15 @@ uint16_t calculate_clut_haldclut(dt_iop_lut3d_params_t *const p, const char *con
   dt_imageio_png_t png;
   if(!dt_imageio_png_read_header(filepath, &png))
   {
-    dt_print(DT_DEBUG_ALWAYS, "[lut3d] invalid png file %s\n", filepath);
+    dt_print(DT_DEBUG_ALWAYS, "[lut3d] invalid png file %s", filepath);
     dt_control_log(_("invalid png file %s"), filepath);
     return 0;
   }
-  dt_print(DT_DEBUG_DEV, "[lut3d] png: width=%d, height=%d, color_type=%d, bit_depth=%d\n", png.width,
+  dt_print(DT_DEBUG_DEV, "[lut3d] png: width=%d, height=%d, color_type=%d, bit_depth=%d", png.width,
            png.height, png.color_type, png.bit_depth);
   if(png.bit_depth !=8 && png.bit_depth != 16)
   {
-    dt_print(DT_DEBUG_ALWAYS, "[lut3d] png bit depth %d is not supported\n", png.bit_depth);
+    dt_print(DT_DEBUG_ALWAYS, "[lut3d] png bit depth %d is not supported", png.bit_depth);
     dt_control_log(_("png bit depth %d is not supported"), png.bit_depth);
     fclose(png.f);
     png_destroy_read_struct(&png.png_ptr, &png.info_ptr, NULL);
@@ -519,17 +519,17 @@ uint16_t calculate_clut_haldclut(dt_iop_lut3d_params_t *const p, const char *con
   if(level * level * level != png.width)
   {
 #ifdef HAVE_GMIC
-    dt_print(DT_DEBUG_ALWAYS, "[lut3d] invalid level in png file %d %d\n", level, png.width);
+    dt_print(DT_DEBUG_ALWAYS, "[lut3d] invalid level in png file %d %d", level, png.width);
     dt_control_log(_("invalid level in png file %d %d"), level, png.width);
 #else
     if(png.height == 2)
     {
-      dt_print(DT_DEBUG_ALWAYS, "[lut3d] this darktable build is not compatible with compressed CLUT\n");
+      dt_print(DT_DEBUG_ALWAYS, "[lut3d] this darktable build is not compatible with compressed CLUT");
       dt_control_log(_("this darktable build is not compatible with compressed CLUT"));
     }
     else
     {
-      dt_print(DT_DEBUG_ALWAYS, "[lut3d] invalid level in png file %d %d\n", level, png.width);
+      dt_print(DT_DEBUG_ALWAYS, "[lut3d] invalid level in png file %d %d", level, png.width);
       dt_control_log(_("invalid level in png file %d %d"), level, png.width);
     }
 #endif // HAVE_GMIC
@@ -541,19 +541,19 @@ uint16_t calculate_clut_haldclut(dt_iop_lut3d_params_t *const p, const char *con
   level *= level;  // to be equivalent to cube level
   if(level > 256)
   {
-    dt_print(DT_DEBUG_ALWAYS, "[lut3d] error - LUT 3D size %d > 256\n", level);
+    dt_print(DT_DEBUG_ALWAYS, "[lut3d] error - LUT 3D size %d > 256", level);
     dt_control_log(_("error - LUT 3D size %d exceeds the maximum supported"), level);
     fclose(png.f);
     png_destroy_read_struct(&png.png_ptr, &png.info_ptr, NULL);
     return 0;
   }
   const size_t buf_size = (size_t)png.height * png_get_rowbytes(png.png_ptr, png.info_ptr);
-  dt_print(DT_DEBUG_DEV, "[lut3d] allocating %zu bytes for png file\n", buf_size);
+  dt_print(DT_DEBUG_DEV, "[lut3d] allocating %zu bytes for png file", buf_size);
   uint8_t *buf = NULL;
   buf = dt_alloc_aligned(buf_size);
   if(!buf)
   {
-    dt_print(DT_DEBUG_ALWAYS, "[lut3d] error allocating buffer for png LUT\n");
+    dt_print(DT_DEBUG_ALWAYS, "[lut3d] error allocating buffer for png LUT");
     dt_control_log(_("error allocating buffer for png LUT"));
     fclose(png.f);
     png_destroy_read_struct(&png.png_ptr, &png.info_ptr, NULL);
@@ -561,17 +561,17 @@ uint16_t calculate_clut_haldclut(dt_iop_lut3d_params_t *const p, const char *con
   }
   if(!dt_imageio_png_read_image(&png, buf))
   {
-    dt_print(DT_DEBUG_ALWAYS, "[lut3d] error - could not read png image `%s'\n", filepath);
+    dt_print(DT_DEBUG_ALWAYS, "[lut3d] error - could not read png image `%s'", filepath);
     dt_control_log(_("error - could not read png image %s"), filepath);
     dt_free_align(buf);
     return 0;
   }
   const size_t buf_size_lut = (size_t)png.height * png.height * 3;
-  dt_print(DT_DEBUG_DEV, "[lut3d] allocating %zu floats for png LUT - level %d\n", buf_size_lut, level);
+  dt_print(DT_DEBUG_DEV, "[lut3d] allocating %zu floats for png LUT - level %d", buf_size_lut, level);
   float *lclut = dt_alloc_align_float(buf_size_lut);
   if(!lclut)
   {
-    dt_print(DT_DEBUG_ALWAYS, "[lut3d] error - allocating buffer for png LUT\n");
+    dt_print(DT_DEBUG_ALWAYS, "[lut3d] error - allocating buffer for png LUT");
     dt_control_log(_("error - allocating buffer for png LUT"));
     dt_free_align(buf);
     return 0;
@@ -746,7 +746,7 @@ uint16_t calculate_clut_cube(const char *const filepath, float **clut)
 
   if(!cube_file)
   {
-    dt_print(DT_DEBUG_ALWAYS, "[lut3d] invalid cube file: %s\n", filepath);
+    dt_print(DT_DEBUG_ALWAYS, "[lut3d] invalid cube file: %s", filepath);
     dt_control_log(_("error - invalid cube file: %s"), filepath);
     return 0;
   }
@@ -760,7 +760,7 @@ uint16_t calculate_clut_cube(const char *const filepath, float **clut)
       {
         if(strtod(token[1], NULL) != 0.0f)
         {
-          dt_print(DT_DEBUG_ALWAYS, "[lut3d] DOMAIN MIN other than 0 is not supported\n");
+          dt_print(DT_DEBUG_ALWAYS, "[lut3d] DOMAIN MIN other than 0 is not supported");
           dt_control_log(_("DOMAIN MIN other than 0 is not supported"));
           dt_free_align(lclut);
           free(line);
@@ -772,7 +772,7 @@ uint16_t calculate_clut_cube(const char *const filepath, float **clut)
       {
         if(strtod(token[1], NULL) != 1.0f)
         {
-          dt_print(DT_DEBUG_ALWAYS, "[lut3d] DOMAIN MAX other than 1 is not supported\n");
+          dt_print(DT_DEBUG_ALWAYS, "[lut3d] DOMAIN MAX other than 1 is not supported");
           dt_control_log(_("DOMAIN MAX other than 1 is not supported"));
           dt_free_align(lclut);
           free(line);
@@ -782,7 +782,7 @@ uint16_t calculate_clut_cube(const char *const filepath, float **clut)
       }
       else if(strcmp("LUT_1D_SIZE", token[0]) == 0)
       {
-        dt_print(DT_DEBUG_ALWAYS, "[lut3d] 1D cube LUT is not supported\n");
+        dt_print(DT_DEBUG_ALWAYS, "[lut3d] 1D cube LUT is not supported");
         dt_control_log(_("1D cube LUT is not supported"));
         free(line);
         fclose(cube_file);
@@ -793,18 +793,18 @@ uint16_t calculate_clut_cube(const char *const filepath, float **clut)
         level = atoll(token[1]);
         if(level > 256)
         {
-          dt_print(DT_DEBUG_ALWAYS, "[lut3d] error - LUT 3D size %d > 256\n", level);
+          dt_print(DT_DEBUG_ALWAYS, "[lut3d] error - LUT 3D size %d > 256", level);
           dt_control_log(_("error - LUT 3D size %d exceeds the maximum supported"), level);
           free(line);
           fclose(cube_file);
           return 0;
         }
         buf_size = level * level * level * 3;
-        dt_print(DT_DEBUG_DEV, "[lut3d] allocating %zu bytes for cube LUT - level %d\n", buf_size, level);
+        dt_print(DT_DEBUG_DEV, "[lut3d] allocating %zu bytes for cube LUT - level %d", buf_size, level);
         lclut = dt_alloc_align_float(buf_size);
         if(!lclut)
         {
-          dt_print(DT_DEBUG_ALWAYS, "[lut3d] error - allocating buffer for cube LUT\n");
+          dt_print(DT_DEBUG_ALWAYS, "[lut3d] error - allocating buffer for cube LUT");
           dt_control_log(_("error - allocating buffer for cube LUT"));
           free(line);
           fclose(cube_file);
@@ -815,7 +815,7 @@ uint16_t calculate_clut_cube(const char *const filepath, float **clut)
       {
         if(!level)
         {
-          dt_print(DT_DEBUG_ALWAYS, "[lut3d] error - cube LUT size is not defined\n");
+          dt_print(DT_DEBUG_ALWAYS, "[lut3d] error - cube LUT size is not defined");
           dt_control_log(_("error - cube LUT size is not defined"));
           free(line);
           fclose(cube_file);
@@ -826,7 +826,7 @@ uint16_t calculate_clut_cube(const char *const filepath, float **clut)
           lclut[i+j] = dt_atof(token[j]);
           if(dt_isnan(lclut[i+j]))
           {
-            dt_print(DT_DEBUG_ALWAYS, "[lut3d] error - invalid number line %d\n", (int)i/3);
+            dt_print(DT_DEBUG_ALWAYS, "[lut3d] error - invalid number line %d", (int)i/3);
             dt_control_log(_("error - cube LUT invalid number line %d"), (int)i/3);
             free(line);
             fclose(cube_file);
@@ -841,7 +841,7 @@ uint16_t calculate_clut_cube(const char *const filepath, float **clut)
   }
   if(i != buf_size || i == 0)
   {
-    dt_print(DT_DEBUG_ALWAYS, "[lut3d] error - cube LUT lines number %d is not correct, should be %d\n",
+    dt_print(DT_DEBUG_ALWAYS, "[lut3d] error - cube LUT lines number %d is not correct, should be %d",
              (int)i/3, (int)buf_size/3);
     dt_control_log(_("error - cube LUT lines number %d is not correct, should be %d"),
                    (int)i/3, (int)buf_size/3);
@@ -852,7 +852,7 @@ uint16_t calculate_clut_cube(const char *const filepath, float **clut)
   }
   if(out_of_range_nb)
   {
-    dt_print(DT_DEBUG_ALWAYS, "[lut3d] warning - %u values out of range [0,1]\n", out_of_range_nb);
+    dt_print(DT_DEBUG_ALWAYS, "[lut3d] warning - %u values out of range [0,1]", out_of_range_nb);
     dt_control_log(_("warning - cube LUT has %d values out of range [0,1]"), out_of_range_nb);
   }
   *clut = lclut;
@@ -877,7 +877,7 @@ uint16_t calculate_clut_3dl(const char *const filepath, float **clut)
 
   if(!cube_file)
   {
-    dt_print(DT_DEBUG_ALWAYS, "[lut3d] invalid 3dl file: %s\n", filepath);
+    dt_print(DT_DEBUG_ALWAYS, "[lut3d] invalid 3dl file: %s", filepath);
     dt_control_log(_("error - invalid 3dl file: %s"), filepath);
     return 0;
   }
@@ -898,18 +898,18 @@ uint16_t calculate_clut_3dl(const char *const filepath, float **clut)
             level = nb_token; // max nb_token = 50 < 256
             if(max_shaper < 128)
             {
-              dt_print(DT_DEBUG_ALWAYS, "[lut3d] error - the maximum shaper LUT value %d is too low\n", max_shaper);
+              dt_print(DT_DEBUG_ALWAYS, "[lut3d] error - the maximum shaper LUT value %d is too low", max_shaper);
               dt_control_log(_("error - the maximum shaper LUT value %d is too low"), max_shaper);
               free(line);
               fclose(cube_file);
               return 0;
             }
             buf_size = level * level * level * 3;
-            dt_print(DT_DEBUG_DEV, "[lut3d] allocating %zu bytes for 3dl LUT - level %d\n", buf_size, level);
+            dt_print(DT_DEBUG_DEV, "[lut3d] allocating %zu bytes for 3dl LUT - level %d", buf_size, level);
             lclut = dt_alloc_align_float(buf_size);
             if(!lclut)
             {
-              dt_print(DT_DEBUG_ALWAYS, "[lut3d] error - allocating buffer for 3dl LUT\n");
+              dt_print(DT_DEBUG_ALWAYS, "[lut3d] error - allocating buffer for 3dl LUT");
               dt_control_log(_("error - allocating buffer for 3dl LUT"));
               free(line);
               fclose(cube_file);
@@ -922,7 +922,7 @@ uint16_t calculate_clut_3dl(const char *const filepath, float **clut)
       {
         if(!level)
         {
-          dt_print(DT_DEBUG_ALWAYS, "[lut3d] error - 3dl LUT size is not defined\n");
+          dt_print(DT_DEBUG_ALWAYS, "[lut3d] error - 3dl LUT size is not defined");
           dt_control_log(_("error - 3dl LUT size is not defined"));
           free(line);
           fclose(cube_file);
@@ -950,7 +950,7 @@ uint16_t calculate_clut_3dl(const char *const filepath, float **clut)
   }
   if(i * 3 != buf_size || i == 0)
   {
-    dt_print(DT_DEBUG_ALWAYS, "[lut3d] error - 3dl LUT lines number is not correct\n");
+    dt_print(DT_DEBUG_ALWAYS, "[lut3d] error - 3dl LUT lines number is not correct");
     dt_control_log(_("error - 3dl LUT lines number is not correct"));
     dt_free_align(lclut);
     free(line);
@@ -966,7 +966,7 @@ uint16_t calculate_clut_3dl(const char *const filepath, float **clut)
     inorm <<= 1;
   if(inorm < 128)  // bit depth 7
   {
-    dt_print(DT_DEBUG_ALWAYS, "[lut3d] error - the maximum LUT value does not match any valid bit depth\n");
+    dt_print(DT_DEBUG_ALWAYS, "[lut3d] error - the maximum LUT value does not match any valid bit depth");
     dt_control_log(_("error - the maximum LUT value does not match any valid bit depth"));
     dt_free_align(lclut);
     return 0;
@@ -1545,7 +1545,7 @@ static void button_clicked(GtkWidget *widget, dt_iop_module_t *self)
   gchar* lutfolder = dt_conf_get_string("plugins/darkroom/lut3d/def_path");
   if(strlen(lutfolder) == 0)
   {
-    dt_print(DT_DEBUG_ALWAYS, "[lut3d] LUT root folder not defined\n");
+    dt_print(DT_DEBUG_ALWAYS, "[lut3d] LUT root folder not defined");
     dt_control_log(_("LUT root folder not defined"));
     g_free(lutfolder);
     return;
@@ -1598,7 +1598,7 @@ static void button_clicked(GtkWidget *widget, dt_iop_module_t *self)
     }
     else if(!filepath[0])// file chosen outside of root folder
     {
-      dt_print(DT_DEBUG_ALWAYS, "[lut3d] select file outside LUT root folder is not allowed\n");
+      dt_print(DT_DEBUG_ALWAYS, "[lut3d] select file outside LUT root folder is not allowed");
       dt_control_log(_("select file outside LUT root folder is not allowed"));
     }
     g_free(filepath);

--- a/src/iop/negadoctor.c
+++ b/src/iop/negadoctor.c
@@ -485,7 +485,7 @@ static void toggle_stock_controls(dt_iop_module_t *const self)
   else
   {
     // We shouldn't be there
-    dt_print(DT_DEBUG_ALWAYS, "negadoctor film stock: undefined behavior\n");
+    dt_print(DT_DEBUG_ALWAYS, "negadoctor film stock: undefined behavior");
   }
 }
 
@@ -830,7 +830,7 @@ void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker,
   else if(picker == g->black)
     apply_auto_black(self);
   else
-    dt_print(DT_DEBUG_ALWAYS, "[negadoctor] unknown color picker\n");
+    dt_print(DT_DEBUG_ALWAYS, "[negadoctor] unknown color picker");
 }
 
 void gui_init(dt_iop_module_t *self)

--- a/src/iop/overexposed.c
+++ b/src/iop/overexposed.c
@@ -144,7 +144,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
                                             work_profile, self->op);
   else
   {
-    dt_print(DT_DEBUG_ALWAYS, "[overexposed process] can't create transform profile\n");
+    dt_print(DT_DEBUG_ALWAYS, "[overexposed process] can't create transform profile");
     dt_iop_copy_image_roi(ovoid, ivoid, ch, roi_in, roi_out);
     dt_control_log(_("module overexposed failed in color conversion"));
     goto process_finish;
@@ -338,7 +338,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
                                                current_profile, work_profile, self->op);
   else
   {
-    dt_print(DT_DEBUG_ALWAYS, "[overexposed process_cl] can't create transform profile\n");
+    dt_print(DT_DEBUG_ALWAYS, "[overexposed process_cl] can't create transform profile");
     dt_control_log(_("module overexposed failed in color conversion"));
     goto error;
   }

--- a/src/iop/overlay.c
+++ b/src/iop/overlay.c
@@ -231,7 +231,7 @@ static GList *_get_disabled_modules(const dt_iop_module_t *self,
     }
     dt_print_pipe(DT_DEBUG_PARAMS | DT_DEBUG_PIPE, "module_filter_out",
           NULL, self, DT_DEVICE_NONE, NULL, NULL,
-          "%s\n", buf);
+          "%s", buf);
     g_free(buf);
   }
 
@@ -408,7 +408,7 @@ void process(struct dt_iop_module_t *self,
   const int stride = cairo_format_stride_for_width(CAIRO_FORMAT_ARGB32, roi_out->width);
   if(stride == -1)
   {
-    dt_print(DT_DEBUG_ALWAYS, "[overlay] cairo stride error\n");
+    dt_print(DT_DEBUG_ALWAYS, "[overlay] cairo stride error");
     dt_iop_image_copy_by_size(ovoid, ivoid, roi_out->width, roi_out->height, ch);
     return;
   }
@@ -423,7 +423,7 @@ void process(struct dt_iop_module_t *self,
 
   if((cairo_surface_status(surface) != CAIRO_STATUS_SUCCESS) || (image == NULL))
   {
-    dt_print(DT_DEBUG_ALWAYS, "[overlay] cairo surface error: %s\n",
+    dt_print(DT_DEBUG_ALWAYS, "[overlay] cairo surface error: %s",
              cairo_status_to_string(cairo_surface_status(surface)));
     g_free(image);
     dt_iop_image_copy_by_size(ovoid, ivoid, roi_out->width, roi_out->height, ch);
@@ -453,7 +453,7 @@ void process(struct dt_iop_module_t *self,
 
   if((cairo_surface_status(surface_two) != CAIRO_STATUS_SUCCESS))
   {
-    dt_print(DT_DEBUG_ALWAYS, "[overlay] cairo png surface 2 error: %s\n",
+    dt_print(DT_DEBUG_ALWAYS, "[overlay] cairo png surface 2 error: %s",
              cairo_status_to_string(cairo_surface_status(surface_two)));
     cairo_surface_destroy(surface);
     g_free(image);

--- a/src/iop/primaries.c
+++ b/src/iop/primaries.c
@@ -179,7 +179,7 @@ int process_cl(struct dt_iop_module_t *self,
   cl_mem dev_matrix = dt_opencl_copy_host_to_device_constant(devid, sizeof(matrix), matrix);
   if(dev_matrix == NULL)
   {
-    dt_print(DT_DEBUG_OPENCL, "[opencl_primaries] couldn't allocate memory!\n");
+    dt_print(DT_DEBUG_OPENCL, "[opencl_primaries] couldn't allocate memory!");
     return DT_OPENCL_DEFAULT_ERROR;
   }
 

--- a/src/iop/profile_gamma.c
+++ b/src/iop/profile_gamma.c
@@ -474,7 +474,7 @@ void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker,
   else if(picker == g->auto_button)
     apply_autotune(self);
   else
-    dt_print(DT_DEBUG_ALWAYS, "[profile_gamma] unknown color picker\n");
+    dt_print(DT_DEBUG_ALWAYS, "[profile_gamma] unknown color picker");
 }
 
 void commit_params(dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_t *pipe,

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -3379,7 +3379,7 @@ static void rt_build_scaled_mask(float *const mask,
   mask_tmp = dt_alloc_align_float((size_t)roi_mask_scaled->width * roi_mask_scaled->height);
   if(mask_tmp == NULL)
   {
-    dt_print(DT_DEBUG_ALWAYS, "[retouch] rt_build_scaled_mask: error allocating memory\n");
+    dt_print(DT_DEBUG_ALWAYS, "[retouch] rt_build_scaled_mask: error allocating memory");
     goto cleanup;
   }
   dt_iop_image_fill(mask_tmp, 0.0f, roi_mask_scaled->width, roi_mask_scaled->height, 1);
@@ -3509,7 +3509,7 @@ static void _retouch_clone(float *const in,
     dt_alloc_align_float((size_t)4 * roi_mask_scaled->width * roi_mask_scaled->height);
   if(img_src == NULL)
   {
-    dt_print(DT_DEBUG_ALWAYS, "[retouch] error allocating memory for cloning\n");
+    dt_print(DT_DEBUG_ALWAYS, "[retouch] error allocating memory for cloning");
     goto cleanup;
   }
 
@@ -3544,7 +3544,7 @@ static void _retouch_blur(dt_iop_module_t *self,
     dt_alloc_align_float((size_t)4 * roi_mask_scaled->width * roi_mask_scaled->height);
   if(img_dest == NULL)
   {
-    dt_print(DT_DEBUG_ALWAYS, "[retouch] error allocating memory for blurring\n");
+    dt_print(DT_DEBUG_ALWAYS, "[retouch] error allocating memory for blurring");
     goto cleanup;
   }
 
@@ -3634,7 +3634,7 @@ static void _retouch_heal(float *const in,
     dt_alloc_align_float((size_t)4 * roi_mask_scaled->width * roi_mask_scaled->height);
   if((img_src == NULL) || (img_dest == NULL))
   {
-    dt_print(DT_DEBUG_ALWAYS, "[retouch] error allocating memory for healing\n");
+    dt_print(DT_DEBUG_ALWAYS, "[retouch] error allocating memory for healing");
     goto cleanup;
   }
 
@@ -3698,14 +3698,14 @@ static void rt_process_forms(float *layer, dwt_params_t *const wt_p, const int s
         const dt_masks_point_group_t *grpt = forms->data;
         if(grpt == NULL)
         {
-          dt_print(DT_DEBUG_ALWAYS, "rt_process_forms: invalid form\n");
+          dt_print(DT_DEBUG_ALWAYS, "rt_process_forms: invalid form");
           continue;
         }
         const dt_mask_id_t formid = grpt->formid;
         const float form_opacity = grpt->opacity;
         if(!dt_is_valid_maskid(formid))
         {
-          dt_print(DT_DEBUG_ALWAYS, "rt_process_forms: form is null\n");
+          dt_print(DT_DEBUG_ALWAYS, "rt_process_forms: form is null");
           continue;
         }
         const int index = rt_get_index_from_formid(p, formid);
@@ -3714,7 +3714,7 @@ static void rt_process_forms(float *layer, dwt_params_t *const wt_p, const int s
           // FIXME: we get this error when user go back in history, so
           // forms are the same but the array has changed
           dt_print(DT_DEBUG_ALWAYS,
-                   "rt_process_forms: missing form=%i from array\n", formid);
+                   "rt_process_forms: missing form=%i from array", formid);
           continue;
         }
 
@@ -3729,7 +3729,7 @@ static void rt_process_forms(float *layer, dwt_params_t *const wt_p, const int s
         if(form == NULL)
         {
           dt_print(DT_DEBUG_ALWAYS,
-                   "rt_process_forms: missing form=%i from masks\n", formid);
+                   "rt_process_forms: missing form=%i from masks", formid);
           continue;
         }
 
@@ -3747,7 +3747,7 @@ static void rt_process_forms(float *layer, dwt_params_t *const wt_p, const int s
                           &roi_mask.width, &roi_mask.height, &roi_mask.x, &roi_mask.y);
         if(mask == NULL)
         {
-          dt_print(DT_DEBUG_ALWAYS, "rt_process_forms: error retrieving mask\n");
+          dt_print(DT_DEBUG_ALWAYS, "rt_process_forms: error retrieving mask");
           continue;
         }
 
@@ -3834,7 +3834,7 @@ static void rt_process_forms(float *layer, dwt_params_t *const wt_p, const int s
           }
           else
             dt_print(DT_DEBUG_ALWAYS,
-                     "rt_process_forms: unknown algorithm %i\n", algo);
+                     "rt_process_forms: unknown algorithm %i", algo);
 
           if(mask_display)
             rt_copy_mask_to_alpha(layer, roi_layer, wt_p->ch,
@@ -3880,7 +3880,7 @@ void process(struct dt_iop_module_t *self,
   in_retouch = dt_alloc_align_float((size_t)4 * roi_rt->width * roi_rt->height);
   if(in_retouch == NULL)
   {
-    dt_print(DT_DEBUG_ALWAYS,"[retouch] out of memory\n");
+    dt_print(DT_DEBUG_ALWAYS,"[retouch] out of memory");
     goto cleanup;
   }
   dt_iop_image_copy_by_size(in_retouch, ivoid, roi_rt->width, roi_rt->height, 4);
@@ -4019,7 +4019,7 @@ cl_int rt_process_stats_cl(struct dt_iop_module_t *self,
   src_buffer = dt_alloc_align_float((size_t)ch * width * height);
   if(src_buffer == NULL)
   {
-    dt_print(DT_DEBUG_ALWAYS, "[retouch] error allocating memory for healing (OpenCL)\n");
+    dt_print(DT_DEBUG_ALWAYS, "[retouch] error allocating memory for healing (OpenCL)");
     err = DT_OPENCL_SYSMEM_ALLOCATION;
     goto cleanup;
   }
@@ -4068,7 +4068,7 @@ cl_int rt_adjust_levels_cl(struct dt_iop_module_t *self,
   if(src_buffer == NULL)
   {
     dt_print(DT_DEBUG_ALWAYS,
-             "[retouch] error allocating memory for healing (OpenCL)\n");
+             "[retouch] error allocating memory for healing (OpenCL)");
     err = DT_OPENCL_SYSMEM_ALLOCATION;
     goto cleanup;
   }
@@ -4122,7 +4122,7 @@ static cl_int rt_copy_in_to_out_cl(const int devid,
     dt_opencl_copy_host_to_device_constant(devid, sizeof(dt_iop_roi_t), (void *)roi_out);
   if(dev_roi_in == NULL || dev_roi_out == NULL)
   {
-    dt_print(DT_DEBUG_ALWAYS, "rt_copy_in_to_out_cl error 1\n");
+    dt_print(DT_DEBUG_ALWAYS, "rt_copy_in_to_out_cl error 1");
     err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
     goto cleanup;
   }
@@ -4137,7 +4137,7 @@ static cl_int rt_copy_in_to_out_cl(const int devid,
      CLARG(xoffs), CLARG(yoffs));
   if(err != CL_SUCCESS)
   {
-    dt_print(DT_DEBUG_ALWAYS, "rt_copy_in_to_out_cl error 2\n");
+    dt_print(DT_DEBUG_ALWAYS, "rt_copy_in_to_out_cl error 2");
     goto cleanup;
   }
 
@@ -4173,7 +4173,7 @@ static cl_int rt_build_scaled_mask_cl(const int devid,
      sizeof(float) * roi_mask_scaled->width * roi_mask_scaled->height);
   if(dev_mask_scaled == NULL)
   {
-    dt_print(DT_DEBUG_ALWAYS, "rt_build_scaled_mask_cl error 2\n");
+    dt_print(DT_DEBUG_ALWAYS, "rt_build_scaled_mask_cl error 2");
     err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
     goto cleanup;
   }
@@ -4185,14 +4185,14 @@ static cl_int rt_build_scaled_mask_cl(const int devid,
      CL_TRUE);
   if(err != CL_SUCCESS)
   {
-    dt_print(DT_DEBUG_ALWAYS, "rt_build_scaled_mask_cl error 4\n");
+    dt_print(DT_DEBUG_ALWAYS, "rt_build_scaled_mask_cl error 4");
     goto cleanup;
   }
 
   *p_dev_mask_scaled = dev_mask_scaled;
 
 cleanup:
-  if(err != CL_SUCCESS) dt_print(DT_DEBUG_ALWAYS, "rt_build_scaled_mask_cl error\n");
+  if(err != CL_SUCCESS) dt_print(DT_DEBUG_ALWAYS, "rt_build_scaled_mask_cl error");
 
   return err;
 }
@@ -4300,7 +4300,7 @@ static cl_int _retouch_clone_cl(const int devid,
      sizeof(float) * ch * roi_mask_scaled->width * roi_mask_scaled->height);
   if(dev_src == NULL)
   {
-    dt_print(DT_DEBUG_ALWAYS, "retouch_clone_cl error 2\n");
+    dt_print(DT_DEBUG_ALWAYS, "retouch_clone_cl error 2");
     err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
     goto cleanup;
   }
@@ -4311,7 +4311,7 @@ static cl_int _retouch_clone_cl(const int devid,
                              gd->kernel_retouch_copy_buffer_to_buffer);
   if(err != CL_SUCCESS)
   {
-    dt_print(DT_DEBUG_ALWAYS, "retouch_clone_cl error 4\n");
+    dt_print(DT_DEBUG_ALWAYS, "retouch_clone_cl error 4");
     goto cleanup;
   }
 
@@ -4321,7 +4321,7 @@ static cl_int _retouch_clone_cl(const int devid,
      gd->kernel_retouch_copy_buffer_to_buffer_masked);
   if(err != CL_SUCCESS)
   {
-    dt_print(DT_DEBUG_ALWAYS, "retouch_clone_cl error 5\n");
+    dt_print(DT_DEBUG_ALWAYS, "retouch_clone_cl error 5");
     goto cleanup;
   }
 
@@ -4400,7 +4400,7 @@ static cl_int _retouch_blur_cl(const int devid,
                            sizeof(float) * ch);
   if(dev_dest == NULL)
   {
-    dt_print(DT_DEBUG_ALWAYS, "retouch_blur_cl error 2\n");
+    dt_print(DT_DEBUG_ALWAYS, "retouch_blur_cl error 2");
     err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
     goto cleanup;
   }
@@ -4420,7 +4420,7 @@ static cl_int _retouch_blur_cl(const int devid,
                              gd->kernel_retouch_copy_buffer_to_image);
   if(err != CL_SUCCESS)
   {
-    dt_print(DT_DEBUG_ALWAYS, "retouch_blur_cl error 4\n");
+    dt_print(DT_DEBUG_ALWAYS, "retouch_blur_cl error 4");
     goto cleanup;
   }
 
@@ -4464,7 +4464,7 @@ static cl_int _retouch_blur_cl(const int devid,
                                 gd->kernel_retouch_copy_image_to_buffer_masked);
   if(err != CL_SUCCESS)
   {
-    dt_print(DT_DEBUG_ALWAYS, "retouch_blur_cl error 5\n");
+    dt_print(DT_DEBUG_ALWAYS, "retouch_blur_cl error 5");
     goto cleanup;
   }
 
@@ -4508,7 +4508,7 @@ static cl_int _retouch_heal_cl(const int devid,
   if(dev_src == NULL)
   {
     dt_print(DT_DEBUG_ALWAYS,
-             "retouch_heal_cl: error allocating memory for healing\n");
+             "retouch_heal_cl: error allocating memory for healing");
     err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
     goto cleanup;
   }
@@ -4519,7 +4519,7 @@ static cl_int _retouch_heal_cl(const int devid,
   if(dev_dest == NULL)
   {
     dt_print(DT_DEBUG_ALWAYS,
-             "retouch_heal_cl: error allocating memory for healing\n");
+             "retouch_heal_cl: error allocating memory for healing");
     err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
     goto cleanup;
   }
@@ -4530,7 +4530,7 @@ static cl_int _retouch_heal_cl(const int devid,
   if(err != CL_SUCCESS)
   {
     dt_print(DT_DEBUG_ALWAYS,
-             "retouch_heal_cl error 4\n");
+             "retouch_heal_cl error 4");
     goto cleanup;
   }
 
@@ -4539,7 +4539,7 @@ static cl_int _retouch_heal_cl(const int devid,
                              gd->kernel_retouch_copy_buffer_to_buffer);
   if(err != CL_SUCCESS)
   {
-    dt_print(DT_DEBUG_ALWAYS, "retouch_heal_cl error 4\n");
+    dt_print(DT_DEBUG_ALWAYS, "retouch_heal_cl error 4");
     goto cleanup;
   }
 
@@ -4563,7 +4563,7 @@ static cl_int _retouch_heal_cl(const int devid,
                                 gd->kernel_retouch_copy_buffer_to_buffer_masked);
   if(err != CL_SUCCESS)
   {
-    dt_print(DT_DEBUG_ALWAYS, "retouch_heal_cl error 6\n");
+    dt_print(DT_DEBUG_ALWAYS, "retouch_heal_cl error 6");
     goto cleanup;
   }
 
@@ -4626,14 +4626,14 @@ static cl_int rt_process_forms_cl(cl_mem dev_layer,
         dt_masks_point_group_t *grpt = forms->data;
         if(grpt == NULL)
         {
-          dt_print(DT_DEBUG_ALWAYS, "rt_process_forms: invalid form\n");
+          dt_print(DT_DEBUG_ALWAYS, "rt_process_forms: invalid form");
           continue;
         }
         const dt_mask_id_t formid = grpt->formid;
         const float form_opacity = grpt->opacity;
         if(!dt_is_valid_maskid(formid))
         {
-          dt_print(DT_DEBUG_ALWAYS, "rt_process_forms: form is null\n");
+          dt_print(DT_DEBUG_ALWAYS, "rt_process_forms: form is null");
           continue;
         }
         const int index = rt_get_index_from_formid(p, formid);
@@ -4642,7 +4642,7 @@ static cl_int rt_process_forms_cl(cl_mem dev_layer,
           // FIXME: we get this error when user go back in history, so
           // forms are the same but the array has changed
           dt_print(DT_DEBUG_ALWAYS,
-                   "rt_process_forms: missing form=%i from array\n", formid);
+                   "rt_process_forms: missing form=%i from array", formid);
           continue;
         }
 
@@ -4657,7 +4657,7 @@ static cl_int rt_process_forms_cl(cl_mem dev_layer,
         if(form == NULL)
         {
           dt_print(DT_DEBUG_ALWAYS,
-                   "rt_process_forms: missing form=%i from masks\n", formid);
+                   "rt_process_forms: missing form=%i from masks", formid);
           continue;
         }
 
@@ -4676,7 +4676,7 @@ static cl_int rt_process_forms_cl(cl_mem dev_layer,
                           &roi_mask.x, &roi_mask.y);
         if(mask == NULL)
         {
-          dt_print(DT_DEBUG_ALWAYS, "rt_process_forms: error retrieving mask\n");
+          dt_print(DT_DEBUG_ALWAYS, "rt_process_forms: error retrieving mask");
           continue;
         }
 
@@ -4780,7 +4780,7 @@ static cl_int rt_process_forms_cl(cl_mem dev_layer,
           }
           else
             dt_print(DT_DEBUG_ALWAYS,
-                     "rt_process_forms: unknown algorithm %i\n", algo);
+                     "rt_process_forms: unknown algorithm %i", algo);
 
           if(mask_display)
             rt_copy_mask_to_alpha_cl(devid, dev_layer, roi_layer,

--- a/src/iop/rgblevels.c
+++ b/src/iop/rgblevels.c
@@ -1004,7 +1004,7 @@ static float _action_process(gpointer target,
       _rgblevels_move_handle(self, element, new_position, p->levels[g->channel], g->drag_start_percentage);
     default:
       dt_print(DT_DEBUG_ALWAYS,
-               "[_action_process_tabs] unknown shortcut effect (%d) for levels\n", effect);
+               "[_action_process_tabs] unknown shortcut effect (%d) for levels", effect);
       break;
     }
 
@@ -1469,7 +1469,7 @@ int process_cl(dt_iop_module_t *self,
       if(src_buffer == NULL)
       {
         dt_print(DT_DEBUG_ALWAYS,
-                 "[rgblevels process_cl] error allocating memory for temp table 1\n");
+                 "[rgblevels process_cl] error allocating memory for temp table 1");
         err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
         goto cleanup;
       }
@@ -1479,7 +1479,7 @@ int process_cl(dt_iop_module_t *self,
       if(err != CL_SUCCESS)
       {
         dt_print(DT_DEBUG_ALWAYS,
-                 "[rgblevels process_cl] error allocating memory for temp table 2\n");
+                 "[rgblevels process_cl] error allocating memory for temp table 2");
         goto cleanup;
       }
 

--- a/src/iop/rotatepixels.c
+++ b/src/iop/rotatepixels.c
@@ -188,7 +188,7 @@ void distort_mask(struct dt_iop_module_t *self,
 {
   // TODO
   memset(out, 0, sizeof(float) * roi_out->width * roi_out->height);
-  dt_print(DT_DEBUG_ALWAYS, "TODO: implement %s() in %s\n", __FUNCTION__, __FILE__);
+  dt_print(DT_DEBUG_ALWAYS, "TODO: implement %s() in %s", __FUNCTION__, __FILE__);
 }
 
 void modify_roi_out(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, dt_iop_roi_t *roi_out,

--- a/src/iop/sharpen.c
+++ b/src/iop/sharpen.c
@@ -297,7 +297,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   float *const mat = init_gaussian_kernel(rad, mat_size, sigma2);
   if(!mat)
   {
-    dt_print(DT_DEBUG_ALWAYS,"[sharpen] out of memory\n");
+    dt_print(DT_DEBUG_ALWAYS,"[sharpen] out of memory");
     dt_iop_copy_image_roi(ovoid, ivoid, 4, roi_in, roi_out);
     return;
   }

--- a/src/iop/sigmoid.c
+++ b/src/iop/sigmoid.c
@@ -824,7 +824,7 @@ int process_cl(struct dt_iop_module_t *self,
       = dt_opencl_copy_host_to_device_constant(devid, sizeof(rendering_to_pipe), rendering_to_pipe);
   if(dev_pipe_to_base == NULL || dev_base_to_rendering == NULL || dev_rendering_to_pipe == NULL)
   {
-    dt_print(DT_DEBUG_OPENCL, "[opencl_sigmoid] couldn't allocate memory!\n");
+    dt_print(DT_DEBUG_OPENCL, "[opencl_sigmoid] couldn't allocate memory!");
     goto cleanup;
   }
 

--- a/src/iop/svd.h
+++ b/src/iop/svd.h
@@ -65,7 +65,7 @@ static inline int dsvd(
 {
   if (m < n)
   {
-    dt_print(DT_DEBUG_ALWAYS, "[svd] #rows must be >= #cols \n");
+    dt_print(DT_DEBUG_ALWAYS, "[svd] #rows must be >= #cols ");
     return 0;
   }
 
@@ -267,7 +267,7 @@ static inline int dsvd(
         break;
       }
       if (its >= max_its) {
-        dt_print(DT_DEBUG_ALWAYS, "[svd] no convergence after %d iterations\n", its);
+        dt_print(DT_DEBUG_ALWAYS, "[svd] no convergence after %d iterations", its);
         free(rv1);
         return 0;
       }

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -1388,7 +1388,7 @@ void gui_update(struct dt_iop_module_t *self)
 
   dt_print_pipe(DT_DEBUG_PIPE,
     "used preset", NULL, self, DT_DEVICE_NONE, NULL, NULL,
-    "preset='%s': D65 %.3f %.3f %.3f, AS-SHOT %.3f %.3f %.3f\n",
+    "preset='%s': D65 %.3f %.3f %.3f, AS-SHOT %.3f %.3f %.3f",
     _preset_to_str(p->preset),
     chr->D65coeffs[0], chr->D65coeffs[1], chr->D65coeffs[2], chr->as_shot[0], chr->as_shot[1], chr->as_shot[2]);
 
@@ -1457,7 +1457,7 @@ static void _prepare_matrices(dt_iop_module_t *module)
     if(module->dev->image_storage.load_status == DT_IMAGEIO_OK)  // suppress spurious error messages
     {
       char *camera = module->dev->image_storage.camera_makermodel;
-      dt_print(DT_DEBUG_ALWAYS, "[temperature] `%s' color matrix not found for image\n", camera);
+      dt_print(DT_DEBUG_ALWAYS, "[temperature] `%s' color matrix not found for image", camera);
       dt_control_log(_("`%s' color matrix not found for image"), camera);
     }
   }
@@ -1517,7 +1517,7 @@ static void _find_coeffs(dt_iop_module_t *module, double coeffs[4])
       dt_control_log(_("failed to read camera white balance information from `%s'!"),
                      img->filename);
     dt_print(DT_DEBUG_ALWAYS,
-             "[temperature] failed to read camera white balance information from `%s'!\n",
+             "[temperature] failed to read camera white balance information from `%s'!",
              img->filename);
   }
 
@@ -1612,7 +1612,7 @@ void reload_defaults(dt_iop_module_t *module)
   }
 
   dt_print(DT_DEBUG_PARAMS,
-    "[dt_iop_reload_defaults] scene=%s, modern=%s, CAT=%s. D65 %.3f %.3f %.3f, AS-SHOT %.3f %.3f %.3f\n",
+    "[dt_iop_reload_defaults] scene=%s, modern=%s, CAT=%s. D65 %.3f %.3f %.3f, AS-SHOT %.3f %.3f %.3f",
     dt_is_scene_referred() ? "YES" : "NO",
     is_modern ? "YES" : "NO",
     another_cat_defined ? "YES" : "NO",
@@ -1792,7 +1792,7 @@ static gboolean _btn_toggled(GtkWidget *togglebutton,
   const dt_dev_chroma_t *chr = &self->dev->chroma;
   dt_print_pipe(DT_DEBUG_PIPE,
     "toggled preset", NULL, self, DT_DEVICE_NONE, NULL, NULL,
-    "preset='%s': D65 %.3f %.3f %.3f, AS-SHOT %.3f %.3f %.3f\n",
+    "preset='%s': D65 %.3f %.3f %.3f, AS-SHOT %.3f %.3f %.3f",
     _preset_to_str(preset),
     chr->D65coeffs[0], chr->D65coeffs[1], chr->D65coeffs[2], chr->as_shot[0], chr->as_shot[1], chr->as_shot[2]);
   return TRUE;

--- a/src/iop/watermark.c
+++ b/src/iop/watermark.c
@@ -633,7 +633,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   const int stride = cairo_format_stride_for_width(CAIRO_FORMAT_ARGB32, roi_out->width);
   if(stride == -1)
   {
-    dt_print(DT_DEBUG_ALWAYS, "[watermark] cairo stride error\n");
+    dt_print(DT_DEBUG_ALWAYS, "[watermark] cairo stride error");
     dt_iop_image_copy_by_size(ovoid, ivoid, roi_out->width, roi_out->height, ch);
     return;
   }
@@ -644,7 +644,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
                                                                  roi_out->height, stride);
   if((cairo_surface_status(surface) != CAIRO_STATUS_SUCCESS) || (image == NULL))
   {
-    dt_print(DT_DEBUG_ALWAYS, "[watermark] cairo surface error: %s\n",
+    dt_print(DT_DEBUG_ALWAYS, "[watermark] cairo surface error: %s",
              cairo_status_to_string(cairo_surface_status(surface)));
     g_free(image);
     dt_iop_image_copy_by_size(ovoid, ivoid, roi_out->width, roi_out->height, ch);
@@ -667,7 +667,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
       g_free(image);
       dt_iop_image_copy_by_size(ovoid, ivoid, roi_out->width, roi_out->height, ch);
       dt_pthread_mutex_unlock(&darktable.plugin_threadsafe);
-      dt_print(DT_DEBUG_ALWAYS, "[watermark] error processing svg file: %s\n", error->message);
+      dt_print(DT_DEBUG_ALWAYS, "[watermark] error processing svg file: %s", error->message);
       g_error_free(error);
       return;
     }
@@ -689,7 +689,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
       surface_two = cairo_image_surface_create_from_png(filename);
       if((cairo_surface_status(surface_two) != CAIRO_STATUS_SUCCESS))
       {
-        dt_print(DT_DEBUG_ALWAYS, "[watermark] cairo png surface 2 error: %s\n",
+        dt_print(DT_DEBUG_ALWAYS, "[watermark] cairo png surface 2 error: %s",
                  cairo_status_to_string(cairo_surface_status(surface_two)));
         cairo_surface_destroy(surface);
         g_free(image);
@@ -881,7 +881,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
                                                                    watermark_height, stride_two);
     if((cairo_surface_status(surface_two) != CAIRO_STATUS_SUCCESS) || (image_two == NULL))
     {
-      dt_print(DT_DEBUG_ALWAYS, "[watermark] cairo surface 2 error: %s\n",
+      dt_print(DT_DEBUG_ALWAYS, "[watermark] cairo surface 2 error: %s",
                cairo_status_to_string(cairo_surface_status(surface_two)));
       cairo_surface_destroy(surface);
       g_object_unref(svg);
@@ -1197,7 +1197,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
   memset(d->font, 0, sizeof(d->font));
   g_strlcpy(d->font, p->font, sizeof(d->font));
 
-// dt_print(DT_DEBUG_ALWAYS, "Commit params: %s...\n",d->filename);
+// dt_print(DT_DEBUG_ALWAYS, "Commit params: %s...",d->filename);
 }
 
 void init_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -1434,8 +1434,8 @@ static void _tree_view(dt_lib_collect_rule_t *dr)
           // clang-format on
 
         // clang-format off
-        query = dt_util_dstrcat
-          (query, " UNION ALL "
+        dt_util_str_cat
+          (&query, " UNION ALL "
            "SELECT '%s' AS name, 0 as id, COUNT(*) AS count "
            "FROM main.images AS mi "
            "WHERE mi.id NOT IN"
@@ -1680,13 +1680,13 @@ static void _tree_view(dt_lib_collect_rule_t *dr)
           if(property == DT_COLLECTION_PROP_FOLDERS) pth = g_strdup("/");
 #endif
           for(int i = 0; i < common_length; i++)
-            pth = dt_util_dstrcat(pth, format_separator, tokens[i]);
+            dt_util_str_cat(&pth, format_separator, tokens[i]);
 
           for(char **token = &tokens[common_length]; *token; token++)
           {
             GtkTreeIter iter;
 
-            pth = dt_util_dstrcat(pth, format_separator, *token);
+            dt_util_str_cat(&pth, format_separator, *token);
             if(_is_time_property(property) && !*(token + 1)) pth[10] = ' ';
 
             gchar *pth2 = g_strdup(pth);
@@ -2139,10 +2139,10 @@ static void _list_view(dt_lib_collect_rule_t *dr)
           char *orders = NULL;
           for(int i = 0; i < DT_IOP_ORDER_LAST; i++)
           {
-            orders = dt_util_dstrcat(orders, "WHEN mo.version = %d THEN '%s' ",
+            dt_util_str_cat(&orders, "WHEN mo.version = %d THEN '%s' ",
                                      i, _(dt_iop_order_string(i)));
           }
-          orders = dt_util_dstrcat(orders, "ELSE '%s' ", _("none"));
+          dt_util_str_cat(&orders, "ELSE '%s' ", _("none"));
           // clang-format off
           snprintf(query, sizeof(query),
                    "SELECT CASE %s END as ver, 1, COUNT(*) AS count"

--- a/src/libs/export.c
+++ b/src/libs/export.c
@@ -1619,7 +1619,7 @@ void init_presets(dt_lib_module_t *self)
       // before calling this
       dt_print(DT_DEBUG_ALWAYS,
                "[export_init_presets] found export preset '%s' with version %d,"
-               " version %d was expected. dropping preset.\n",
+               " version %d was expected. dropping preset",
                name, op_version, version);
       sqlite3_stmt *innerstmt;
       DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
@@ -1756,7 +1756,7 @@ void init_presets(dt_lib_module_t *self)
         // write the updated preset back to db
         dt_print(DT_DEBUG_ALWAYS,
                  "[export_init_presets] updating export preset '%s'"
-                 " from versions %d/%d to versions %d/%d\n",
+                 " from versions %d/%d to versions %d/%d",
                  name, fversion, sversion, new_fversion, new_sversion);
         sqlite3_stmt *innerstmt;
         DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
@@ -1782,7 +1782,7 @@ void init_presets(dt_lib_module_t *self)
       free(new_sdata);
       dt_print(DT_DEBUG_ALWAYS,
                "[export_init_presets] export preset '%s' can't be updated"
-               " from versions %d/%d to versions %d/%d. dropping preset\n",
+               " from versions %d/%d to versions %d/%d. dropping preset",
                name, fversion, sversion, new_fversion, new_sversion);
       sqlite3_stmt *innerstmt;
       DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
@@ -2028,8 +2028,8 @@ void *legacy_params(dt_lib_module_t *self,
     const int scale_size = strlen(scale) + 1;
     const int print_dpi = dt_confgen_get_int("plugins/lighttable/export/print_dpi", DT_DEFAULT);
 
-    const size_t new_params_size = old_params_size 
-                                   + sizeof(int32_t) * 2 
+    const size_t new_params_size = old_params_size
+                                   + sizeof(int32_t) * 2
                                    + scale_size;
     void *new_params = calloc(1, new_params_size);
 

--- a/src/libs/export_metadata.c
+++ b/src/libs/export_metadata.c
@@ -466,7 +466,7 @@ char *dt_lib_export_metadata_configuration_dialog(char *metadata_presets, const 
       gtk_tree_model_get(GTK_TREE_MODEL(d->liststore), &iter, DT_LIB_EXPORT_METADATA_COL_XMP, &tagname,
           DT_LIB_EXPORT_METADATA_COL_FORMULA, &formula, -1);
       // metadata presets are stored into a single string with '\1' as a separator
-      newlist = dt_util_dstrcat(newlist,"\1%s\1%s", tagname, formula);
+      dt_util_str_cat(&newlist,"\1%s\1%s", tagname, formula);
       g_free(tagname);
       g_free(formula);
       valid = gtk_tree_model_iter_next (GTK_TREE_MODEL(d->liststore), &iter);

--- a/src/libs/filters/colors.c
+++ b/src/libs/filters/colors.c
@@ -149,7 +149,7 @@ static gchar *_colors_pretty_print(const gchar *raw_txt)
         col = g_strdup(_("P"));
         break;
     }
-    txt = dt_util_dstrcat(txt, "%s%s%s%s", (i == 0) ? "" : " ", (incl) ? "" : "<s>", col, (incl) ? "" : "</s>");
+    dt_util_str_cat(&txt, "%s%s%s%s", (i == 0) ? "" : " ", (incl) ? "" : "<s>", col, (incl) ? "" : "</s>");
     g_free(col);
   }
   if(nb == 0)

--- a/src/libs/filters/filename.c
+++ b/src/libs/filters/filename.c
@@ -313,7 +313,7 @@ static void _filename_tree_selection_change(GtkTreeSelection *sel, _widgets_file
     {
       gchar *val = NULL;
       gtk_tree_model_get(model, &iter, TREE_COL_PATH, &val, -1);
-      if(val) txt = dt_util_dstrcat(txt, "%s%s", (txt == NULL) ? "" : ",", val);
+      if(val) dt_util_str_cat(&txt, "%s%s", (txt == NULL) ? "" : ",", val);
     }
   }
   g_list_free_full(list, (GDestroyNotify)gtk_tree_path_free);

--- a/src/libs/filters/focal.c
+++ b/src/libs/filters/focal.c
@@ -71,7 +71,7 @@ static gchar *_focal_print_func(const double value, const gboolean detailled)
 
   if(detailled)
   {
-    txt = dt_util_dstrcat(txt, " %s", _("mm"));
+    dt_util_str_cat(&txt, " %s", _("mm"));
   }
   return txt;
 }

--- a/src/libs/filters/misc.c
+++ b/src/libs/filters/misc.c
@@ -340,7 +340,7 @@ static void _misc_tree_selection_changed(GtkTreeSelection *sel,
     {
       gchar *val = NULL;
       gtk_tree_model_get(model, &iter, TREE_COL_PATH, &val, -1);
-      if(val) txt = dt_util_dstrcat(txt, "%s%s", (txt == NULL) ? "" : ",", val);
+      if(val) dt_util_str_cat(&txt, "%s%s", (txt == NULL) ? "" : ",", val);
     }
   }
   g_list_free_full(list, (GDestroyNotify)gtk_tree_path_free);

--- a/src/libs/filters/ratio.c
+++ b/src/libs/filters/ratio.c
@@ -117,11 +117,11 @@ static gchar *_ratio_print_func(const double value, const gboolean detailled)
   if(detailled)
   {
     if(value < 1.0)
-      return dt_util_dstrcat(txt, " %s", _("portrait"));
+      dt_util_str_cat(&txt, " %s", _("portrait"));
     else if(value > 1.0)
-      return dt_util_dstrcat(txt, " %s", _("landscape"));
+      dt_util_str_cat(&txt, " %s", _("landscape"));
     else if(value == 1.0)
-      return dt_util_dstrcat(txt, " %s", _("square"));
+      dt_util_str_cat(&txt, " %s", _("square"));
   }
   return txt;
 }

--- a/src/libs/geotagging.c
+++ b/src/libs/geotagging.c
@@ -679,7 +679,7 @@ static void _show_gpx_tracks(dt_lib_module_t *self)
   if(!d->map.tracks)
   {
     d->map.nb_tracks = 0;
-    dt_print(DT_DEBUG_ALWAYS, "[geotagging] unable to allocate storage for tracks\n");
+    dt_print(DT_DEBUG_ALWAYS, "[geotagging] unable to allocate storage for tracks");
   }
 
   _remove_images_from_map(self);

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -1696,7 +1696,7 @@ static gboolean _drawable_motion_notify_callback(GtkWidget *widget,
       if(d->scope_type == DT_LIB_HISTOGRAM_SCOPE_VECTORSCOPE &&
               d->vectorscope_type == DT_LIB_HISTOGRAM_VECTORSCOPE_RYB &&
               d->harmony_guide.type != DT_COLOR_HARMONY_NONE)
-        tip = dt_util_dstrcat(tip, "\n%s\n%s\n%s\n%s",
+        dt_util_str_cat(&tip, "\n%s\n%s\n%s\n%s",
                               _("scroll to coarse-rotate"),
                               _("ctrl+scroll to fine rotate"),
                               _("shift+scroll to change width"),
@@ -1713,14 +1713,14 @@ static gboolean _drawable_motion_notify_callback(GtkWidget *widget,
                      && d->scope_orient == DT_LIB_HISTOGRAM_ORIENT_VERT))))
       {
         d->highlight = DT_LIB_HISTOGRAM_HIGHLIGHT_BLACK_POINT;
-        tip = dt_util_dstrcat(tip, "\n%s\n%s",
+        dt_util_str_cat(&tip, "\n%s\n%s",
                               _("drag to change black point"),
                               _("double-click resets"));
       }
       else
       {
         d->highlight = DT_LIB_HISTOGRAM_HIGHLIGHT_EXPOSURE;
-        tip = dt_util_dstrcat(tip, "\n%s\n%s",
+        dt_util_str_cat(&tip, "\n%s\n%s",
                               _("drag to change exposure"),
                               _("double-click resets"));
       }

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -1011,7 +1011,7 @@ static void dt_lib_histogram_process
   if(!profile_info_to)
   {
     dt_print(DT_DEBUG_ALWAYS,
-       "[histogram] no histogram profile, replaced with linear Rec2020\n");
+       "[histogram] no histogram profile, replaced with linear Rec2020");
     dt_control_log(_("unsupported profile selected for histogram,"
                      " it will be replaced with linear Rec2020"));
   }
@@ -1685,7 +1685,7 @@ static gboolean _drawable_motion_notify_callback(GtkWidget *widget,
 
     // FIXME: make just one tooltip for the widget depending on
     // whether it is draggable or not, and set it when enter the view
-    gchar *tip = g_strdup_printf("%s\n(%s)\n%s\n%s\n",
+    gchar *tip = g_strdup_printf("%s\n(%s)\n%s\n%s",
                                  _(dt_lib_histogram_scope_type_names[d->scope_type]),
                                  _("use buttons at top of graph to change type"),
                                  _("click on ❓ and then graph for documentation"),

--- a/src/libs/history.c
+++ b/src/libs/history.c
@@ -386,14 +386,14 @@ static gboolean _check_deleted_instances(dt_develop_t *dev,
             if(mod_in_history && mod_next_in_history)
               dt_print(DT_DEBUG_ALWAYS,
                   "[_check_deleted_instances] found duplicate module"
-                  " %s %s (%i) and %s %s (%i) both in history\n",
+                  " %s %s (%i) and %s %s (%i) both in history",
                   mod->op, mod->multi_name, mod->multi_priority,
                   mod_next->op, mod_next->multi_name,
                   mod_next->multi_priority);
             else
               dt_print(DT_DEBUG_ALWAYS,
                   "[_check_deleted_instances] found duplicate module"
-                  " %s %s (%i) and %s %s (%i) none in history\n",
+                  " %s %s (%i) and %s %s (%i) none in history",
                   mod->op, mod->multi_name, mod->multi_priority,
                   mod_next->op, mod_next->multi_name,
                   mod_next->multi_priority);
@@ -517,7 +517,7 @@ static gboolean _create_deleted_modules(GList **_iop_list, GList *history_list)
       if(base_module == NULL)
       {
         dt_print(DT_DEBUG_ALWAYS,
-                 "[_create_deleted_modules] can't find base module for %s\n",
+                 "[_create_deleted_modules] can't find base module for %s",
                  hitem->op_name);
         return changed;
       }

--- a/src/libs/import.c
+++ b/src/libs/import.c
@@ -746,7 +746,7 @@ static void _import_add_file_callback(GObject *direnum,
     g_object_unref(direnum);
     g_list_free_full(file_list, g_object_unref);
     dt_print(DT_DEBUG_ALWAYS,
-             "[_import_add_file_callback] error: %s\n", error->message);
+             "[_import_add_file_callback] error: %s", error->message);
     g_error_free(error);
     return;
   }
@@ -846,7 +846,7 @@ static void _import_add_file_callback(GObject *direnum,
       {
         if(g_file_test(fullname, G_FILE_TEST_IS_SYMLINK))
         {
-          dt_print(DT_DEBUG_CONTROL, "[import] skip symlink %s\n", fullname);
+          dt_print(DT_DEBUG_CONTROL, "[import] skip symlink %s", fullname);
         }
         else
         {

--- a/src/libs/import.c
+++ b/src/libs/import.c
@@ -2317,7 +2317,7 @@ static void _import_from_dialog_run(dt_lib_module_t* self)
       if(d->import_case == DT_IMPORT_INPLACE)
       {
         if(gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(d->recursive)))
-          folder = dt_util_dstrcat(folder, "%%");
+          dt_util_str_cat(&folder, "%%");
         _import_set_collection(folder);
         const dt_imgid_t imgid = dt_conf_get_int("ui_last/import_last_image");
         if(unique && dt_is_valid_imgid(imgid))
@@ -2598,18 +2598,18 @@ static char *_get_current_configuration(dt_lib_module_t *self)
   {
     if(_pref[i].type == DT_BOOL)
     {
-      pref = dt_util_dstrcat(pref, "%s=%d,", _pref[i].name,
+      dt_util_str_cat(&pref, "%s=%d,", _pref[i].name,
                              dt_conf_get_bool(_pref[i].key) ? 1 : 0);
     }
     else if(_pref[i].type == DT_INT)
     {
-      pref = dt_util_dstrcat(pref, "%s=%d,", _pref[i].name,
+      dt_util_str_cat(&pref, "%s=%d,", _pref[i].name,
                              dt_conf_get_int(_pref[i].key));
     }
     else if(_pref[i].type == DT_STRING)
     {
       const char *s = dt_conf_get_string_const(_pref[i].key);
-      pref = dt_util_dstrcat(pref, "%s=%s,", _pref[i].name, s);
+      dt_util_str_cat(&pref, "%s=%s,", _pref[i].name, s);
     }
   }
 
@@ -2625,7 +2625,7 @@ static char *_get_current_configuration(dt_lib_module_t *self)
 
       setting = g_strdup_printf("ui_last/import_last_%s", metadata_name);
       const char *metadata_value = dt_conf_get_string_const(setting);
-      pref = dt_util_dstrcat(pref, "%s=%d%s,", metadata_name,
+      dt_util_str_cat(&pref, "%s=%d%s,", metadata_name,
                              imported ? 1 : 0, metadata_value);
       g_free(setting);
     }
@@ -2633,7 +2633,7 @@ static char *_get_current_configuration(dt_lib_module_t *self)
   // must be the last (comma separated list)
   const gboolean imported = dt_conf_get_bool("ui_last/import_last_tags_imported");
   const char *tags_value = dt_conf_get_string_const("ui_last/import_last_tags");
-  pref = dt_util_dstrcat(pref, "%s=%d%s,", "tags", imported ? 1 : 0, tags_value);
+  dt_util_str_cat(&pref, "%s=%d%s,", "tags", imported ? 1 : 0, tags_value);
   if(pref && *pref)
     pref[strlen(pref) - 1] = '\0';
 
@@ -2703,7 +2703,7 @@ static void _apply_preferences(const char *pref,
       for(GList *iter2 = g_list_next(iter); iter2; iter2 = g_list_next(iter2))
       {
         if(strlen((char *)iter2->data))
-          tags = dt_util_dstrcat(tags, ",%s", (char *)iter2->data);
+          dt_util_str_cat(&tags, ",%s", (char *)iter2->data);
       }
       dt_conf_set_string("ui_last/import_last_tags", tags);
       g_free(tags);

--- a/src/libs/lib.c
+++ b/src/libs/lib.c
@@ -56,7 +56,7 @@ gboolean dt_lib_is_visible_in_view(dt_lib_module_t *module,
   if(!module->views)
   {
     dt_print(DT_DEBUG_ALWAYS,
-             "module %s doesn't have views flags\n",
+             "module %s doesn't have views flags",
              module->name(module));
     return FALSE;
   }
@@ -653,7 +653,7 @@ static int dt_lib_load_module(void *m,
       && (module->legacy_params || module->set_params || module->get_params))
      || (!module->init_presets && module->manage_presets))
   {
-    dt_print(DT_DEBUG_ALWAYS, "[dt_lib_load_module] illegal method combination in '%s'\n",
+    dt_print(DT_DEBUG_ALWAYS, "[dt_lib_load_module] illegal method combination in '%s'",
              module->plugin_name);
   }
 
@@ -774,7 +774,7 @@ void dt_lib_init_presets(dt_lib_module_t *module)
           // write the updated preset back to db
           dt_print(DT_DEBUG_ALWAYS,
                    "[lighttable_init_presets] updating '%s' preset '%s'"
-                   " from version %d to version %d\n",
+                   " from version %d to version %d",
                    module->plugin_name, name, op_version, version);
           sqlite3_stmt *innerstmt;
           // clang-format off
@@ -797,7 +797,7 @@ void dt_lib_init_presets(dt_lib_module_t *module)
           dt_print(DT_DEBUG_ALWAYS,
                    "[lighttable_init_presets] Can't upgrade '%s' preset '%s'"
                    " from version %d to %d, "
-                   "no legacy_params() implemented or unable to update\n",
+                   "no legacy_params() implemented or unable to update",
                    module->plugin_name, name, op_version, version);
           sqlite3_stmt *innerstmt;
           // clang-format off

--- a/src/libs/live_view.c
+++ b/src/libs/live_view.c
@@ -175,7 +175,7 @@ static void _auto_focus_button_clicked(GtkWidget *widget, gpointer user_data)
   CameraWidgetType property_type;
   if(dt_camctl_camera_get_property_type(darktable.camctl, NULL, property, &property_type))
   {
-    dt_print(DT_DEBUG_CAMCTL, "[camera control] unable to get property type for %s\n", property);
+    dt_print(DT_DEBUG_CAMCTL, "[camera control] unable to get property type for %s", property);
   }
   else
   {
@@ -186,7 +186,7 @@ static void _auto_focus_button_clicked(GtkWidget *widget, gpointer user_data)
     else
     {
       // TODO evaluate if this is the right thing to do in default scenario
-      dt_print(DT_DEBUG_CAMCTL, "[camera control] unable to set %s for property type %d\n", property, property_type);
+      dt_print(DT_DEBUG_CAMCTL, "[camera control] unable to set %s for property type %d", property, property_type);
     }
   }
 }
@@ -515,7 +515,7 @@ void gui_post_expose(dt_lib_module_t *self, cairo_t *cr, int32_t width, int32_t 
             y1 = buf.height;
             break;
           default:
-            dt_print(DT_DEBUG_ALWAYS, "OMFG, the world will collapse, this shouldn't be reachable!\n");
+            dt_print(DT_DEBUG_ALWAYS, "OMFG, the world will collapse, this shouldn't be reachable!");
             dt_pthread_mutex_unlock(&cam->live_view_buffer_mutex);
             return;
         }

--- a/src/libs/location.c
+++ b/src/libs/location.c
@@ -428,7 +428,7 @@ static gboolean _lib_location_search(dt_lib_module_t *self)
 bail_out:
   if(err)
   {
-    dt_print(DT_DEBUG_ALWAYS, "location search: %s\n", err->message);
+    dt_print(DT_DEBUG_ALWAYS, "location search: %s", err->message);
     g_error_free(err);
   }
 
@@ -660,7 +660,7 @@ broken_bbox:
         else
         {
           gchar *s = g_strndup(*avalue, 100);
-          dt_print(DT_DEBUG_ALWAYS, "unsupported outline: %s%s\n",
+          dt_print(DT_DEBUG_ALWAYS, "unsupported outline: %s%s",
                    s, strlen(s) == strlen(*avalue) ? "" : " ...");
           g_free(s);
         }
@@ -781,7 +781,7 @@ int set_params(dt_lib_module_t *self,
   _lib_location_result_t *location = malloc(sizeof(_lib_location_result_t));
   if(!location)
   {
-    dt_print(DT_DEBUG_ALWAYS, "[location] out of memory\n");
+    dt_print(DT_DEBUG_ALWAYS, "[location] out of memory");
     return 1;
   }
 

--- a/src/libs/map_locations.c
+++ b/src/libs/map_locations.c
@@ -166,11 +166,11 @@ static void _locations_tree_update(dt_lib_module_t *self, const guint locid)
         // insert everything from tokens past the common part
         char *pth = NULL;
         for(int i = 0; i < common_length; i++)
-          pth = dt_util_dstrcat(pth, "%s|", tokens[i]);
+          dt_util_str_cat(&pth, "%s|", tokens[i]);
 
         for(char **token = &tokens[common_length]; *token; token++)
         {
-          pth = dt_util_dstrcat(pth, "%s|", *token);
+          dt_util_str_cat(&pth, "%s|", *token);
           gchar *pth2 = g_strdup(pth);
           pth2[strlen(pth2) - 1] = '\0';
           gtk_tree_store_insert(GTK_TREE_STORE(model), &iter, common_length > 0 ? &parent : NULL, -1);
@@ -283,7 +283,7 @@ static void _new_button_clicked(GtkButton *button, dt_lib_module_t *self)
   name = path ? g_strconcat(path, "|", NULL) : g_strdup("");
   const int base_len = strlen(name);
   int i = 1;
-  name = dt_util_dstrcat(name, "%s", _("new location"));
+  dt_util_str_cat(&name, "%s", _("new location"));
   char *new_name = g_strdup(name);
   while(dt_map_location_name_exists(new_name))
   {

--- a/src/libs/metadata_view.c
+++ b/src/libs/metadata_view.c
@@ -969,10 +969,10 @@ void gui_update(dt_lib_module_t *self)
               // tags - just keywords
               length = length + strlen(tagname) + 2u;
               if(length < 45u)
-                tagstring = dt_util_dstrcat(tagstring, "%s, ", tagname);
+                dt_util_str_cat(&tagstring, "%s, ", tagname);
               else
               {
-                tagstring = dt_util_dstrcat(tagstring, "\n%s, ", tagname);
+                dt_util_str_cat(&tagstring, "\n%s, ", tagname);
                 length = strlen(tagname) + 2u;
               }
             }
@@ -986,11 +986,11 @@ void gui_update(dt_lib_module_t *self)
                 catend[0] = '\0';
                 char *catstart = g_strrstr(category, "|");
                 catstart = catstart ? catstart + 1 : category;
-                categoriesstring = dt_util_dstrcat(categoriesstring, categoriesstring ? "\n%s: %s " : "%s: %s ",
+                dt_util_str_cat(&categoriesstring, categoriesstring ? "\n%s: %s " : "%s: %s ",
                                                    catstart, ((dt_tag_t *)taglist->data)->leave);
               }
               else
-                categoriesstring = dt_util_dstrcat(categoriesstring, categoriesstring ? "\n%s" : "%s",
+                dt_util_str_cat(&categoriesstring, categoriesstring ? "\n%s" : "%s",
                                                    ((dt_tag_t *)taglist->data)->leave);
               g_free(category);
             }
@@ -1115,7 +1115,7 @@ static char *_get_current_configuration(dt_lib_module_t *self)
   {
     dt_lib_metadata_info_t *m = meta->data;
     if(_is_metadata_ui(m->index))
-      pref = dt_util_dstrcat(pref, "%s%s,", m->visible ? "" : "|", m->name);
+      dt_util_str_cat(&pref, "%s%s,", m->visible ? "" : "|", m->name);
   }
   if(pref)
   {

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -815,7 +815,7 @@ static void _lib_modulegroups_update_iop_visibility(dt_lib_module_t *self)
                                   ? gtk_entry_get_text(GTK_ENTRY(d->text_entry))
                                   : NULL;
 
-  dt_print(DT_DEBUG_IOPORDER, "[lib_modulegroups_update_iop_visibility] modulegroups\n");
+  dt_print(DT_DEBUG_IOPORDER, "[lib_modulegroups_update_iop_visibility] modulegroups");
 
   // update basic button selection too
   ++darktable.gui->reset;
@@ -849,7 +849,7 @@ static void _lib_modulegroups_update_iop_visibility(dt_lib_module_t *self)
     GtkWidget *w = module->expander;
 
     if(module->enabled)
-    dt_print(DT_DEBUG_IOPORDER, "%20s %d%s\n",
+    dt_print(DT_DEBUG_IOPORDER, "%20s %d%s",
       module->op, module->iop_order, (dt_iop_is_hidden(module)) ? ", hidden" : "");
 
       /* skip modules without an gui */

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -1095,19 +1095,19 @@ static dt_lib_modulegroup_iop_visibility_type_t _preset_retrieve_old_search_pref
   if(strcmp(show_text_entry, "show search text") == 0)
   {
     // we only show the search box. no groups
-    *ret = dt_util_dstrcat(*ret, "1ꬹ1");
+    dt_util_str_cat(&*ret, "1ꬹ1");
     val = DT_MODULEGROUP_SEARCH_IOP_TEXT_VISIBLE;
   }
   else if(strcmp(show_text_entry, "show groups") == 0)
   {
     // we don't show the search box
-    *ret = dt_util_dstrcat(*ret, "0");
+    dt_util_str_cat(&*ret, "0");
     val = DT_MODULEGROUP_SEARCH_IOP_GROUPS_VISIBLE;
   }
   else
   {
     // we show both
-    *ret = dt_util_dstrcat(*ret, "1");
+    dt_util_str_cat(&*ret, "1");
     val = DT_MODULEGROUP_SEARCH_IOP_TEXT_GROUPS_VISIBLE;
   }
   return val;
@@ -1135,19 +1135,19 @@ static gchar *_preset_retrieve_old_layout_updated()
     // group name and icon
     if(i == 0)
     {
-      ret = dt_util_dstrcat(
-          ret, "1|0ꬹ1|||%s",
+      dt_util_str_cat(&ret,
+          "1|0ꬹ1|||%s",
           "exposure/exposure|temperature/temperature|temperature/tint|colorbalancergb/contrast"
           "|colorbalancergb/global vibrance|colorbalancergb/global chroma|colorbalancergb/global saturation"
           "|ashift/rotation|denoiseprofile|lens|bilat");
-      ret = dt_util_dstrcat(ret, "ꬹfavorites|favorites|");
+      dt_util_str_cat(&ret, "ꬹfavorites|favorites|");
     }
     else if(i == 1)
-      ret = dt_util_dstrcat(ret, "ꬹtechnical|technical|");
+      dt_util_str_cat(&ret, "ꬹtechnical|technical|");
     else if(i == 2)
-      ret = dt_util_dstrcat(ret, "ꬹgrading|grading|");
+      dt_util_str_cat(&ret, "ꬹgrading|grading|");
     else if(i == 3)
-      ret = dt_util_dstrcat(ret, "ꬹeffects|effect|");
+      dt_util_str_cat(&ret, "ꬹeffects|effect|");
 
     // list of modules
     for(const GList *modules = darktable.iop; modules; modules = g_list_next(modules))
@@ -1168,7 +1168,7 @@ static gchar *_preset_retrieve_old_layout_updated()
         if((i == 0 && fav && visi) || (i == 1 && (group & IOP_GROUP_TECHNICAL) && visi)
            || (i == 2 && (group & IOP_GROUP_GRADING) && visi) || (i == 3 && (group & IOP_GROUP_EFFECTS) && visi))
         {
-          ret = dt_util_dstrcat(ret, "|%s", module->op);
+          dt_util_str_cat(&ret, "|%s", module->op);
         }
       }
     }
@@ -1190,23 +1190,23 @@ static gchar *_preset_retrieve_old_layout(const char *list, const char *list_fav
     if(i == 0)
     {
       // we don't have to care about "modern" workflow for temperature as it's more recent than this layout
-      ret = dt_util_dstrcat(
-          ret, "1|0ꬹ1|||%s",
+      dt_util_str_cat(&ret,
+          "1|0ꬹ1|||%s",
           "exposure/exposure|temperature/temperature|temperature/tint|colorbalancergb/contrast"
           "|colorbalancergb/global vibrance|colorbalancergb/global chroma|colorbalancergb/global saturation"
           "|ashift/rotation|denoiseprofile|lens|bilat");
-      ret = dt_util_dstrcat(ret, "ꬹfavorites|favorites|");
+      dt_util_str_cat(&ret, "ꬹfavorites|favorites|");
     }
     else if(i == 1)
-      ret = dt_util_dstrcat(ret, "ꬹbase|basic|");
+      dt_util_str_cat(&ret, "ꬹbase|basic|");
     else if(i == 2)
-      ret = dt_util_dstrcat(ret, "ꬹtone|tone|");
+      dt_util_str_cat(&ret, "ꬹtone|tone|");
     else if(i == 3)
-      ret = dt_util_dstrcat(ret, "ꬹcolor|color|");
+      dt_util_str_cat(&ret, "ꬹcolor|color|");
     else if(i == 4)
-      ret = dt_util_dstrcat(ret, "ꬹcorrect|correct|");
+      dt_util_str_cat(&ret, "ꬹcorrect|correct|");
     else if(i == 5)
-      ret = dt_util_dstrcat(ret, "ꬹeffect|effect|");
+      dt_util_str_cat(&ret, "ꬹeffect|effect|");
 
     // list of modules
     for(const GList *modules = darktable.iop; modules; modules = g_list_next(modules))
@@ -1264,7 +1264,7 @@ static gchar *_preset_retrieve_old_layout(const char *list, const char *list_fav
 
         if((i == 0 && fav && visi) || (i == group && visi))
         {
-          ret = dt_util_dstrcat(ret, "|%s", module->op);
+          dt_util_str_cat(&ret, "|%s", module->op);
         }
 
         g_free(search);
@@ -1302,16 +1302,16 @@ static void _preset_retrieve_old_presets(dt_lib_module_t *self)
       dt_iop_module_state_t state = p[pos + op_len + 1];
 
       if(state == IOP_STATE_ACTIVE)
-        list = dt_util_dstrcat(list, "|%s", op);
+        dt_util_str_cat(&list, "|%s", op);
       else if(state == IOP_STATE_FAVORITE)
       {
-        fav = dt_util_dstrcat(fav, "|%s", op);
-        list = dt_util_dstrcat(list, "|%s", op);
+        dt_util_str_cat(&fav, "|%s", op);
+        dt_util_str_cat(&list, "|%s", op);
       }
       pos += op_len + 2;
     }
-    list = dt_util_dstrcat(list, "|");
-    fav = dt_util_dstrcat(fav, "|");
+    dt_util_str_cat(&list, "|");
+    dt_util_str_cat(&fav, "|");
 
     gchar *tx = _preset_retrieve_old_layout(list, fav);
     dt_lib_presets_add(pname, self->plugin_name, self->version(), tx, strlen(tx), FALSE, 0);
@@ -1334,28 +1334,28 @@ static gchar *_preset_to_string(dt_lib_module_t *self, gboolean edition)
   gchar *res = NULL;
   const gboolean show_search = edition ? d->edit_show_search : d->show_search;
   const gboolean full_active = edition ? d->edit_full_active : d->full_active;
-  res = dt_util_dstrcat(res, "%d|%d", show_search ? 1 : 0, full_active ? 1 : 0);
+  dt_util_str_cat(&res, "%d|%d", show_search ? 1 : 0, full_active ? 1 : 0);
 
   const gboolean basics_show = edition ? d->edit_basics_show : d->basics_show;
   GList *basics = edition ? d->edit_basics : d->basics;
   GList *groups = edition ? d->edit_groups : d->groups;
 
   // basics widgets
-  res = dt_util_dstrcat(res, "ꬹ%d||", basics_show ? 1 : 0);
+  dt_util_str_cat(&res, "ꬹ%d||", basics_show ? 1 : 0);
   for(const GList *l = basics; l; l = g_list_next(l))
   {
     dt_lib_modulegroups_basic_item_t *item = l->data;
-    res = dt_util_dstrcat(res, "|%s", item->id);
+    dt_util_str_cat(&res, "|%s", item->id);
   }
 
   for(const GList *l = groups; l; l = g_list_next(l))
   {
     dt_lib_modulegroups_group_t *g = l->data;
-    res = dt_util_dstrcat(res, "ꬹ%s|%s|", g->name, g->icon);
+    dt_util_str_cat(&res, "ꬹ%s|%s|", g->name, g->icon);
     for(const GList *ll = g->modules; ll; ll = g_list_next(ll))
     {
       gchar *m = (gchar *)ll->data;
-      res = dt_util_dstrcat(res, "|%s", m);
+      dt_util_str_cat(&res, "|%s", m);
     }
   }
 
@@ -1515,10 +1515,10 @@ static void _preset_from_string(dt_lib_module_t *self, gchar *txt, gboolean edit
   }
 
 // start module group
-#define SMG(g,n) tx = dt_util_dstrcat(tx, "ꬹ%s|%s|", g, n)
+#define SMG(g,n) dt_util_str_cat(&tx, "ꬹ%s|%s|", g, n)
 
 // add module
-#define AM(n)    tx = dt_util_dstrcat(tx, "|%s", n)
+#define AM(n)    dt_util_str_cat(&tx, "|%s", n)
 
 void init_presets(dt_lib_module_t *self)
 {
@@ -2549,7 +2549,7 @@ static GtkWidget *_build_menu_from_actions(dt_action_t *actions,
         {
           gtk_check_menu_item_set_inconsistent(GTK_CHECK_MENU_ITEM(item), TRUE);
           gchar *toolmark = gtk_widget_get_tooltip_text(item);
-          toolmark = dt_util_dstrcat(toolmark, " <i>(%s)</i>", _("currently invisible"));
+          dt_util_str_cat(&toolmark, " <i>(%s)</i>", _("currently invisible"));
           gtk_widget_set_tooltip_markup(item, toolmark);
           if(item_top)
             gtk_widget_set_tooltip_markup(item_top, toolmark);

--- a/src/libs/print_settings.c
+++ b/src/libs/print_settings.c
@@ -310,7 +310,7 @@ static int write_image(dt_imageio_module_data_t *data,
     (uint16_t *)malloc((size_t)3 * (d->bpp == 8?1:2) * d->head.width * d->head.height);
   if(!d->params->buf)
   {
-    dt_print(DT_DEBUG_ALWAYS, "[print] unable to allocate memory for image %s\n", filename);
+    dt_print(DT_DEBUG_ALWAYS, "[print] unable to allocate memory for image %s", filename);
     return 1;
   }
 
@@ -394,7 +394,7 @@ static int _export_image(dt_job_t *job, dt_image_box *img)
     {
       dt_control_log(_("cannot open printer profile `%s'"), params->p_icc_profile);
       dt_print(DT_DEBUG_ALWAYS,
-               "cannot open printer profile `%s'\n",
+               "cannot open printer profile `%s'",
                params->p_icc_profile);
       dt_control_queue_redraw();
       return 1;
@@ -405,7 +405,7 @@ static int _export_image(dt_job_t *job, dt_image_box *img)
       {
         dt_control_log(_("error getting output profile for image %d"), img->imgid);
         dt_print(DT_DEBUG_ALWAYS,
-                 "error getting output profile for image %d\n",
+                 "error getting output profile for image %d",
                  img->imgid);
         dt_control_queue_redraw();
         return 1;
@@ -418,7 +418,7 @@ static int _export_image(dt_job_t *job, dt_image_box *img)
         dt_control_log(_("cannot apply printer profile `%s'"),
                        params->p_icc_profile);
         dt_print(DT_DEBUG_ALWAYS,
-                 "cannot apply printer profile `%s'\n",
+                 "cannot apply printer profile `%s'",
                  params->p_icc_profile);
         dt_control_queue_redraw();
         return 1;
@@ -537,7 +537,7 @@ static int _export_and_setup_pos(dt_job_t *job,
 
   dt_printing_setup_page(&params->imgs, width, height, params->prt.printer.resolution);
 
-  dt_print(DT_DEBUG_PRINT, "[print] max image size %d x %d (at resolution %d)\n",
+  dt_print(DT_DEBUG_PRINT, "[print] max image size %d x %d (at resolution %d)",
            img->max_width, img->max_height, params->prt.printer.resolution);
 
   if(_export_image(job, img))
@@ -580,7 +580,7 @@ static int _print_job_run(dt_job_t *job)
   if(fd == -1)
   {
     dt_control_log(_("failed to create temporary PDF for printing"));
-    dt_print(DT_DEBUG_ALWAYS, "failed to create temporary PDF for printing\n");
+    dt_print(DT_DEBUG_ALWAYS, "failed to create temporary PDF for printing");
     return 1;
   }
   close(fd);

--- a/src/libs/tagging.c
+++ b/src/libs/tagging.c
@@ -189,7 +189,7 @@ static gboolean _set_matching_tag_visibility(GtkTreeModel *model, GtkTreePath *p
     visible = TRUE;
   else
   {
-    if(synonyms && synonyms[0]) tagname = dt_util_dstrcat(tagname, ", %s", synonyms);
+    if(synonyms && synonyms[0]) dt_util_str_cat(&tagname, ", %s", synonyms);
     gchar *haystack = g_utf8_strdown(tagname, -1);
     gchar *needle = g_utf8_strdown(d->keyword, -1);
     visible = (g_strrstr(haystack, needle) != NULL);
@@ -444,11 +444,11 @@ static void _init_treeview(dt_lib_module_t *self, const int which)
           // insert everything from tokens past the common part
           char *pth = NULL;
           for(int i = 0; i < common_length; i++)
-            pth = dt_util_dstrcat(pth, "%s|", tokens[i]);
+            dt_util_str_cat(&pth, "%s|", tokens[i]);
 
           for(char **token = &tokens[common_length]; *token; token++)
           {
-            pth = dt_util_dstrcat(pth, "%s|", *token);
+            dt_util_str_cat(&pth, "%s|", *token);
             gchar *pth2 = g_strdup(pth);
             pth2[strlen(pth2) - 1] = '\0';
             gtk_tree_store_insert(GTK_TREE_STORE(store), &iter, common_length > 0 ? &parent : NULL, -1);
@@ -1008,7 +1008,7 @@ void *get_params(dt_lib_module_t *self, int *size)
   {
     for(GList *taglist = tags; taglist; taglist = g_list_next(taglist))
     {
-      params = dt_util_dstrcat(params, "%d,", ((dt_tag_t *)taglist->data)->id);
+      dt_util_str_cat(&params, "%d,", ((dt_tag_t *)taglist->data)->id);
     }
     dt_tag_free_result(&tags);
     if(params == NULL)
@@ -1778,7 +1778,7 @@ static void _pop_menu_dictionary_create_tag(GtkWidget *menuitem, dt_lib_module_t
     if(!root)
     {
       new_tagname = g_strdup(path);
-      new_tagname = dt_util_dstrcat(new_tagname, "|%s", newtag);
+      dt_util_str_cat(&new_tagname, "|%s", newtag);
     }
     else new_tagname = g_strdup(newtag);
 
@@ -2563,8 +2563,8 @@ static gboolean _row_tooltip_setup(GtkWidget *treeview, gint x, gint y, gboolean
         if((flags & DT_TF_PRIVATE) || (synonyms && synonyms[0]))
         {
           gchar *text = g_strdup_printf(_("%s"), tagname);
-          text = dt_util_dstrcat(text, " %s\n", (flags & DT_TF_PRIVATE) ? _("(private)") : "");
-          text = dt_util_dstrcat(text, "synonyms: %s", (synonyms && synonyms[0]) ? synonyms : " - ");
+          dt_util_str_cat(&text, " %s\n", (flags & DT_TF_PRIVATE) ? _("(private)") : "");
+          dt_util_str_cat(&text, "synonyms: %s", (synonyms && synonyms[0]) ? synonyms : " - ");
           gtk_tooltip_set_text(tooltip, text);
           g_free(text);
           res = TRUE;
@@ -3012,7 +3012,7 @@ static void _event_dnd_received(GtkWidget *widget, GdkDragContext *context, gint
       const gboolean root = (name && name[0] == '\0');
       char *leave = g_strrstr(d->drag.tagname, "|");
       if(leave) leave++;
-      name = dt_util_dstrcat(name, "%s%s", root ? "" : "|", leave ? leave : d->drag.tagname);
+      dt_util_str_cat(&name, "%s%s", root ? "" : "|", leave ? leave : d->drag.tagname);
       _apply_rename_path(NULL, d->drag.tagname, name, self);
 
       g_free(name);

--- a/src/libs/tools/darktable.c
+++ b/src/libs/tools/darktable.c
@@ -119,7 +119,7 @@ void gui_init(dt_lib_module_t *self)
     g_free(logo);
     if(cairo_surface_status(surface) != CAIRO_STATUS_SUCCESS)
     {
-      dt_print(DT_DEBUG_ALWAYS, "warning: can't load darktable logo from PNG file `%s'\n", filename);
+      dt_print(DT_DEBUG_ALWAYS, "warning: can't load darktable logo from PNG file `%s'", filename);
       goto done;
     }
     const int png_width = cairo_image_surface_get_width(surface),
@@ -135,7 +135,7 @@ void gui_init(dt_lib_module_t *self)
         = dt_cairo_image_surface_create_for_data(d->image_buffer, CAIRO_FORMAT_ARGB32, width, height, stride);
     if(cairo_surface_status(d->image) != CAIRO_STATUS_SUCCESS)
     {
-      dt_print(DT_DEBUG_ALWAYS, "warning: can't load darktable logo from PNG file `%s'\n", filename);
+      dt_print(DT_DEBUG_ALWAYS, "warning: can't load darktable logo from PNG file `%s'", filename);
       free(d->image_buffer);
       d->image_buffer = NULL;
       cairo_surface_destroy(d->image);

--- a/src/libs/tools/gamepad.c
+++ b/src/libs/tools/gamepad.c
@@ -209,18 +209,18 @@ static gboolean _poll_devices(gpointer user_data)
     switch(event.type)
     {
     case SDL_CONTROLLERBUTTONDOWN:
-      dt_print(DT_DEBUG_INPUT, "SDL button down event time %d id %d button %hhd state %hhd\n", event.cbutton.timestamp, event.cbutton.which, event.cbutton.button, event.cbutton.state);
+      dt_print(DT_DEBUG_INPUT, "SDL button down event time %d id %d button %hhd state %hhd", event.cbutton.timestamp, event.cbutton.which, event.cbutton.button, event.cbutton.state);
       _process_axis_and_send(gamepad, event.cbutton.timestamp);
       dt_shortcut_key_press(gamepad->id, event.cbutton.timestamp, event.cbutton.button);
 
       break;
     case SDL_CONTROLLERBUTTONUP:
-      dt_print(DT_DEBUG_INPUT, "SDL button up event time %d id %d button %hhd state %hhd\n", event.cbutton.timestamp, event.cbutton.which, event.cbutton.button, event.cbutton.state);
+      dt_print(DT_DEBUG_INPUT, "SDL button up event time %d id %d button %hhd state %hhd", event.cbutton.timestamp, event.cbutton.which, event.cbutton.button, event.cbutton.state);
       _process_axis_and_send(gamepad, event.cbutton.timestamp);
       dt_shortcut_key_release(gamepad->id, event.cbutton.timestamp, event.cbutton.button);
       break;
     case SDL_CONTROLLERAXISMOTION:
-      dt_print(DT_DEBUG_INPUT, "SDL axis event type %d time %d id %d axis %hhd value %hd\n", event.caxis.type, event.caxis.timestamp, event.caxis.which, event.caxis.axis, event.caxis.value);
+      dt_print(DT_DEBUG_INPUT, "SDL axis event type %d time %d id %d axis %hhd value %hd", event.caxis.type, event.caxis.timestamp, event.caxis.which, event.caxis.axis, event.caxis.value);
 
       if(event.caxis.axis == SDL_CONTROLLER_AXIS_TRIGGERLEFT || event.caxis.axis == SDL_CONTROLLER_AXIS_TRIGGERRIGHT)
       {
@@ -250,7 +250,7 @@ static gboolean _poll_devices(gpointer user_data)
 
   for(GSList *gamepads = self->data; gamepads; gamepads = gamepads->next) _process_axis_and_send(gamepads->data, SDL_GetTicks());
 
-  if(num_events) dt_print(DT_DEBUG_INPUT, "sdl num_events: %d time: %u\n", num_events, SDL_GetTicks());
+  if(num_events) dt_print(DT_DEBUG_INPUT, "sdl num_events: %d time: %u", num_events, SDL_GetTicks());
   return G_SOURCE_CONTINUE;
 }
 
@@ -258,11 +258,11 @@ static void _gamepad_open_devices(dt_lib_module_t *self)
 {
   if(SDL_Init(SDL_INIT_GAMECONTROLLER))
   {
-    dt_print(DT_DEBUG_ALWAYS, "[_gamepad_open_devices] ERROR initialising SDL\n");
+    dt_print(DT_DEBUG_ALWAYS, "[_gamepad_open_devices] ERROR initialising SDL");
     return;
   }
   else
-    dt_print(DT_DEBUG_INPUT, "[_gamepad_open_devices] SDL initialized\n");
+    dt_print(DT_DEBUG_INPUT, "[_gamepad_open_devices] SDL initialized");
 
   dt_input_device_t id = dt_register_input_driver(self, &_driver_definition);
 
@@ -274,13 +274,13 @@ static void _gamepad_open_devices(dt_lib_module_t *self)
 
       if(!controller)
       {
-        dt_print(DT_DEBUG_ALWAYS, "[_gamepad_open_devices] ERROR opening game controller '%s'\n",
+        dt_print(DT_DEBUG_ALWAYS, "[_gamepad_open_devices] ERROR opening game controller '%s'",
                  SDL_GameControllerNameForIndex(i));
         continue;
       }
       else
       {
-        dt_print(DT_DEBUG_ALWAYS, "[_gamepad_open_devices] opened game controller '%s'\n",
+        dt_print(DT_DEBUG_ALWAYS, "[_gamepad_open_devices] opened game controller '%s'",
                  SDL_GameControllerNameForIndex(i));
       }
 

--- a/src/libs/tools/midi.c
+++ b/src/libs/tools/midi.c
@@ -375,7 +375,7 @@ static void _update_with_move(dt_midi_device_t *midi,
   midi->last_known[controller] = rotor_position;
   _midi_write(midi, midi->channel, 0xB, controller, rotor_position);
 
-  // dt_print(DT_DEBUG_INPUT, "Controller: Channel %d, controller %d, position: %d\n", midi->channel, controller, rotor_position);
+  // dt_print(DT_DEBUG_INPUT, "Controller: Channel %d, controller %d, position: %d", midi->channel, controller, rotor_position);
 }
 
 static gboolean _poll_devices(gpointer user_data)
@@ -410,7 +410,7 @@ static gboolean _poll_devices(gpointer user_data)
       switch(event_type)
       {
       case 0x9:  // note on
-        dt_print(DT_DEBUG_INPUT, "Note On: Channel %d, Data1 %d\n", midi->channel, event_data1);
+        dt_print(DT_DEBUG_INPUT, "Note On: Channel %d, Data1 %d", midi->channel, event_data1);
 
         layer_B = event_data1 > (midi->behringer == 'M' ? 23 : 54);
 
@@ -421,7 +421,7 @@ static gboolean _poll_devices(gpointer user_data)
         dt_shortcut_key_press(midi->id, event[i].timestamp, event_data1);
         break;
       case 0x8:  // note off
-        dt_print(DT_DEBUG_INPUT, "Note Off: Channel %d, Data1 %d\n", midi->channel, event_data1);
+        dt_print(DT_DEBUG_INPUT, "Note Off: Channel %d, Data1 %d", midi->channel, event_data1);
 
         layer_B = event_data1 > (midi->behringer == 'M' ? 23 : 54);
 
@@ -443,7 +443,7 @@ static gboolean _poll_devices(gpointer user_data)
              Pm_MessageData1(event[j].message) == event_data1)
           {
             event_data2 = Pm_MessageData2(event[j].message);
-            dt_print(DT_DEBUG_INPUT, "Controller: Channel %d, Data1 %d, Data2 %d\n", midi->channel, event_data1, event_data2);
+            dt_print(DT_DEBUG_INPUT, "Controller: Channel %d, Data1 %d, Data2 %d", midi->channel, event_data1, event_data2);
 
             accum += _calculate_move(midi, event_data1, event_data2);
             event[j].message = 0; // don't process again later
@@ -481,11 +481,11 @@ static void _midi_open_devices(dt_lib_module_t *self)
 {
   if(Pm_Initialize())
   {
-    dt_print(DT_DEBUG_ALWAYS, "[_midi_open_devices] ERROR initialising PortMidi\n");
+    dt_print(DT_DEBUG_ALWAYS, "[_midi_open_devices] ERROR initialising PortMidi");
     return;
   }
   else
-    dt_print(DT_DEBUG_INPUT, "[_midi_open_devices] PortMidi initialized\n");
+    dt_print(DT_DEBUG_INPUT, "[_midi_open_devices] PortMidi initialized");
 
   dt_input_device_t id = dt_register_input_driver(self, &_driver_definition);
 
@@ -497,7 +497,7 @@ static void _midi_open_devices(dt_lib_module_t *self)
   for(int i = 0; i < Pm_CountDevices(); i++)
   {
     const PmDeviceInfo *info = Pm_GetDeviceInfo(i);
-    dt_print(DT_DEBUG_INPUT, "[_midi_open_devices] found midi device '%s' via '%s'\n", info->name, info->interf);
+    dt_print(DT_DEBUG_INPUT, "[_midi_open_devices] found midi device '%s' via '%s'", info->name, info->interf);
 
     if(info->input && !strstr(info->name, "Midi Through Port"))
     {
@@ -546,13 +546,13 @@ static void _midi_open_devices(dt_lib_module_t *self)
 
       if(error < 0)
       {
-        dt_print(DT_DEBUG_ALWAYS, "[_midi_open_devices] ERROR opening midi device '%s' via '%s'\n",
+        dt_print(DT_DEBUG_ALWAYS, "[_midi_open_devices] ERROR opening midi device '%s' via '%s'",
                  info->name, info->interf);
         continue;
       }
       else
       {
-        dt_print(DT_DEBUG_INPUT, "[_midi_open_devices] opened midi device '%s' via '%s' as midi%d\n",
+        dt_print(DT_DEBUG_INPUT, "[_midi_open_devices] opened midi device '%s' via '%s' as midi%d",
                  info->name, info->interf, dev);
         if(!cur_dev || !*cur_dev)
           dt_control_log(_("%s opened as midi%d"), info->name, dev);

--- a/src/lua/call.c
+++ b/src/lua/call.c
@@ -30,7 +30,7 @@
 int dt_lua_check_print_error(lua_State* L, int result)
 {
   if(result == LUA_OK) return result;
-  dt_print(DT_DEBUG_LUA, "LUA ERROR : %s\n", lua_tostring(L, -1));
+  dt_print(DT_DEBUG_LUA, "LUA ERROR : %s", lua_tostring(L, -1));
   lua_pop(L,1); // remove the error message, it has been handled
   return result;
 }
@@ -125,7 +125,7 @@ static void run_async_thread_main(gpointer data,gpointer user_data)
   lua_State*L = darktable.lua_state.state;
   lua_State* thread = get_thread(L,thread_num);
   if(!thread) {
-    dt_print(DT_DEBUG_LUA, "LUA ERROR : no thread found, this should never happen\n");
+    dt_print(DT_DEBUG_LUA, "LUA ERROR : no thread found, this should never happen");
     return;
   }
   dt_lua_finish_callback  cb = lua_touserdata(thread,1);
@@ -469,7 +469,7 @@ static void string_job_init()
 void dt_lua_async_call_internal(const char* function, int line,lua_State *L, int nargs,int nresults,dt_lua_finish_callback cb, void*data)
 {
 #ifdef _DEBUG
-  dt_print(DT_DEBUG_LUA,"LUA DEBUG : %s called from %s %d, nargs : %d\n",__FUNCTION__,function,line,nargs);
+  dt_print(DT_DEBUG_LUA,"LUA DEBUG : %s called from %s %d, nargs : %d",__FUNCTION__,function,line,nargs);
 #endif
 
   lua_State *new_thread = lua_newthread(L);
@@ -487,12 +487,12 @@ void dt_lua_async_call_alien_internal(const char * call_function, int line,lua_C
   if(!darktable.lua_state.alien_job_queue) {
     // early call before lua has properly been initialized, ignore
 #ifdef _DEBUG
-  dt_print(DT_DEBUG_LUA,"LUA DEBUG : %s called early. probably ok.\n",__FUNCTION__);
+  dt_print(DT_DEBUG_LUA,"LUA DEBUG : %s called early. probably ok",__FUNCTION__);
 #endif
     return;
   }
 #ifdef _DEBUG
-  dt_print(DT_DEBUG_LUA,"LUA DEBUG : %s called from %s %d\n",__FUNCTION__,call_function,line);
+  dt_print(DT_DEBUG_LUA,"LUA DEBUG : %s called from %s %d",__FUNCTION__,call_function,line);
 #endif
   async_call_data*data = malloc(sizeof(async_call_data));
   data->pusher = pusher;
@@ -554,7 +554,7 @@ void dt_lua_async_call_alien_internal(const char * call_function, int line,lua_C
 void dt_lua_async_call_string_internal(const char* function, int line,const char* lua_string,int nresults,dt_lua_finish_callback cb, void*cb_data)
 {
 #ifdef _DEBUG
-  dt_print(DT_DEBUG_LUA,"LUA DEBUG : %s called from %s %d, string %s\n",__FUNCTION__,function,line,lua_string);
+  dt_print(DT_DEBUG_LUA,"LUA DEBUG : %s called from %s %d, string %s",__FUNCTION__,function,line,lua_string);
 #endif
   string_call_data*data = malloc(sizeof(string_call_data));
   data->function = strdup(lua_string);
@@ -654,7 +654,7 @@ static int gtk_wrap(lua_State*L)
     return lua_gettop(L);
   } else {
 #ifdef _DEBUG
-    dt_print(DT_DEBUG_LUA, "LUA DEBUG : %s called from %s %llu\n", __FUNCTION__,
+    dt_print(DT_DEBUG_LUA, "LUA DEBUG : %s called from %s %llu", __FUNCTION__,
              lua_tostring(L, lua_upvalueindex(2)), lua_tointeger(L, lua_upvalueindex(3)));
 #endif
     dt_lua_unlock();
@@ -669,7 +669,7 @@ static int gtk_wrap(lua_State*L)
     g_mutex_clear(&communication.end_mutex);
     dt_lua_lock();
 #ifdef _DEBUG
-    dt_print(DT_DEBUG_LUA, "LUA DEBUG : %s return for call from from %s %llu\n", __FUNCTION__,
+    dt_print(DT_DEBUG_LUA, "LUA DEBUG : %s return for call from from %s %llu", __FUNCTION__,
              lua_tostring(L, lua_upvalueindex(2)), lua_tointeger(L, lua_upvalueindex(3)));
 #endif
     if(communication.retval == LUA_OK) {

--- a/src/lua/configuration.c
+++ b/src/lua/configuration.c
@@ -64,7 +64,7 @@ static int check_version(lua_State *L)
   }
   else
   {
-    dt_print(DT_DEBUG_LUA, "LUA ERROR Module %s is not compatible with API %d.%d.%d-%s\n", module_name,
+    dt_print(DT_DEBUG_LUA, "LUA ERROR Module %s is not compatible with API %d.%d.%d-%s", module_name,
              LUA_API_VERSION_MAJOR, LUA_API_VERSION_MINOR, LUA_API_VERSION_PATCH, LUA_API_VERSION_SUFFIX);
   }
   return 0;

--- a/src/lua/events.c
+++ b/src/lua/events.c
@@ -110,7 +110,7 @@ void dt_lua_event_add(lua_State *L, const char *evt_name)
   if(args != 3)
   {
     lua_pop(L, args);
-    dt_print(DT_DEBUG_LUA, "LUA ERROR : %s: wrong number of args for %s, expected 3, got %d\n", __FUNCTION__, evt_name, args);
+    dt_print(DT_DEBUG_LUA, "LUA ERROR : %s: wrong number of args for %s, expected 3, got %d", __FUNCTION__, evt_name, args);
     return;
   }
 
@@ -128,7 +128,7 @@ void dt_lua_event_add(lua_State *L, const char *evt_name)
     lua_setfield(L, -2, "on_event");
   }
   else{
-    dt_print(DT_DEBUG_LUA, "LUA ERROR :%s: function argument not found for on_event for event %s\n", __FUNCTION__, evt_name);
+    dt_print(DT_DEBUG_LUA, "LUA ERROR :%s: function argument not found for on_event for event %s", __FUNCTION__, evt_name);
     return;
   }
 
@@ -140,7 +140,7 @@ void dt_lua_event_add(lua_State *L, const char *evt_name)
   }
   else
   {
-    dt_print(DT_DEBUG_LUA, "LUA ERROR : %s: function argument not found for on_destroy for event %s\n", __FUNCTION__, evt_name);
+    dt_print(DT_DEBUG_LUA, "LUA ERROR : %s: function argument not found for on_destroy for event %s", __FUNCTION__, evt_name);
     return;
   }
 
@@ -153,7 +153,7 @@ void dt_lua_event_add(lua_State *L, const char *evt_name)
   }
   else
   {
-    dt_print(DT_DEBUG_LUA, "LUA ERROR : %s: function argument not found for on_register for event %s\n", __FUNCTION__, evt_name);
+    dt_print(DT_DEBUG_LUA, "LUA ERROR : %s: function argument not found for on_register for event %s", __FUNCTION__, evt_name);
     return;
   }
 

--- a/src/lua/image.c
+++ b/src/lua/image.c
@@ -121,7 +121,7 @@ static int generate_cache(lua_State *L)
       {
         if(g_mkdir_with_parents(dirname, 0750))
         {
-          dt_print(DT_DEBUG_ALWAYS, "[lua] could not create directory '%s'!\n", dirname);
+          dt_print(DT_DEBUG_ALWAYS, "[lua] could not create directory '%s'!", dirname);
           return 1;
         }
       }

--- a/src/lua/lua.c
+++ b/src/lua/lua.c
@@ -135,11 +135,11 @@ void dt_lua_lock_internal(const char *function, const char *file, int line, gboo
 #ifdef _DEBUG
   if(!silent && !darktable.lua_state.ending && pthread_equal(darktable.control->gui_thread, pthread_self()) != 0)
   {
-    dt_print(DT_DEBUG_LUA, "LUA WARNING locking from the gui thread should be avoided\n");
+    dt_print(DT_DEBUG_LUA, "LUA WARNING locking from the gui thread should be avoided");
     //g_assert(false);
   }
 
-  dt_print(DT_DEBUG_LUA,"LUA DEBUG : thread %p waiting from %s:%d\n", g_thread_self(), function, line);
+  dt_print(DT_DEBUG_LUA,"LUA DEBUG : thread %p waiting from %s:%d", g_thread_self(), function, line);
 #endif
   dt_pthread_mutex_lock(&darktable.lua_state.mutex);
   while(darktable.lua_state.exec_lock == true) {
@@ -148,13 +148,13 @@ void dt_lua_lock_internal(const char *function, const char *file, int line, gboo
   darktable.lua_state.exec_lock = true;
   dt_pthread_mutex_unlock(&darktable.lua_state.mutex);
 #ifdef _DEBUG
-  dt_print(DT_DEBUG_LUA,"LUA DEBUG : thread %p taken from %s:%d\n",  g_thread_self(), function, line);
+  dt_print(DT_DEBUG_LUA,"LUA DEBUG : thread %p taken from %s:%d",  g_thread_self(), function, line);
 #endif
 }
 void dt_lua_unlock_internal(const char *function, int line)
 {
 #ifdef _DEBUG
-  dt_print(DT_DEBUG_LUA,"LUA DEBUG : thread %p released from %s:%d\n",g_thread_self(), function,line);
+  dt_print(DT_DEBUG_LUA,"LUA DEBUG : thread %p released from %s:%d",g_thread_self(), function,line);
 #endif
   dt_pthread_mutex_lock(&darktable.lua_state.mutex);
   darktable.lua_state.exec_lock = false;

--- a/src/lua/luastorage.c
+++ b/src/lua/luastorage.c
@@ -115,7 +115,7 @@ static int store_wrapper(struct dt_imageio_module_storage_t *self,
                        icc_type, icc_filename, icc_intent, self, self_data, num, total, metadata) != 0)
   {
     dt_print(DT_DEBUG_ALWAYS,
-             "[lua] %s: could not export to file `%s'!\n", self->name(self), complete_name);
+             "[lua] %s: could not export to file `%s'!", self->name(self), complete_name);
     g_free(complete_name);
     g_free(filename);
     return 1;
@@ -208,7 +208,7 @@ static int initialize_store_wrapper(struct dt_imageio_module_storage_t *self,
     if(lua_type(L, -1) != LUA_TTABLE)
     {
       dt_print(DT_DEBUG_LUA,
-               "LUA ERROR initialization function of storage did not return nil or table\n");
+               "LUA ERROR initialization function of storage did not return nil or table");
       dt_lua_unlock();
       return 1;
     }

--- a/src/lua/password.c
+++ b/src/lua/password.c
@@ -49,7 +49,7 @@ static int save_password(lua_State *L)
 
   if(!dt_pwstorage_set(application, table))
   {
-    dt_print(DT_DEBUG_PWSTORAGE, "[%s] cannot store username/token\n", application);
+    dt_print(DT_DEBUG_PWSTORAGE, "[%s] cannot store username/token", application);
     result = FALSE;
   }
 

--- a/src/lua/print.c
+++ b/src/lua/print.c
@@ -65,13 +65,13 @@ static int lua_print_hinter(lua_State *L)
 
 static int lua_print_log(lua_State *L)
 {
-  dt_print(DT_DEBUG_LUA, "LUA %s\n", luaL_checkstring(L, -1));
+  dt_print(DT_DEBUG_LUA, "LUA %s", luaL_checkstring(L, -1));
   return 0;
 }
 
 static int lua_print_error(lua_State *L)
 {
-  dt_print(DT_DEBUG_LUA, "LUA ERROR %s\n", luaL_checkstring(L, -1));
+  dt_print(DT_DEBUG_LUA, "LUA ERROR %s", luaL_checkstring(L, -1));
   return 0;
 }
 

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -648,7 +648,7 @@ void expose(
   {
     dt_print_pipe(DT_DEBUG_EXPOSE,
         "expose livesamples FALSE",
-         port->pipe, NULL, DT_DEVICE_NONE, NULL, NULL, "%dx%d, px=%d py=%d\n",
+         port->pipe, NULL, DT_DEVICE_NONE, NULL, NULL, "%dx%d, px=%d py=%d",
          width, height, pointerx, pointery);
     _darkroom_pickers_draw(self, cri, wd, ht, zoom_scale,
                            darktable.lib->proxy.colorpicker.live_samples, FALSE);
@@ -663,7 +663,7 @@ void expose(
   {
     dt_print_pipe(DT_DEBUG_EXPOSE,
         "expose livesample TRUE",
-         port->pipe, NULL, DT_DEVICE_NONE, NULL, NULL, "%dx%d, px=%d py=%d\n",
+         port->pipe, NULL, DT_DEVICE_NONE, NULL, NULL, "%dx%d, px=%d py=%d",
          width, height, pointerx, pointery);
     GSList samples = { .data = darktable.lib->proxy.colorpicker.primary_sample,
                        .next = NULL };
@@ -684,7 +684,7 @@ void expose(
   {
     dt_print_pipe(DT_DEBUG_EXPOSE,
         "expose masks",
-         port->pipe, dev->gui_module, DT_DEVICE_NONE, NULL, NULL, "%dx%d, px=%d py=%d\n",
+         port->pipe, dev->gui_module, DT_DEVICE_NONE, NULL, NULL, "%dx%d, px=%d py=%d",
          width, height, pointerx, pointery);
     dt_masks_events_post_expose(dev->gui_module, cri, width, height, pzx, pzy, zoom_scale);
   }
@@ -710,7 +710,7 @@ void expose(
         dt_print_pipe(DT_DEBUG_EXPOSE,
                       "expose cropper",
                       port->pipe, dev->cropping.exposer,
-                      DT_DEVICE_NONE, NULL, NULL, "%dx%d, px=%d py=%d\n",
+                      DT_DEVICE_NONE, NULL, NULL, "%dx%d, px=%d py=%d",
                       width, height, pointerx, pointery);
         _module_gui_post_expose(dev->cropping.exposer, cri, wd, ht, pzx, pzy, zoom_scale);
         guides = TRUE;
@@ -723,7 +723,7 @@ void expose(
                       "expose module",
                       port->pipe, dev->gui_module,
                       DT_DEVICE_NONE, NULL, NULL,
-                      "%dx%d, px=%d py=%d\n",
+                      "%dx%d, px=%d py=%d",
                       width, height, pointerx, pointery);
         _module_gui_post_expose(dev->gui_module, cri, wd, ht, pzx, pzy, zoom_scale);
         guides = TRUE;
@@ -742,7 +742,7 @@ void expose(
     gchar *label = darktable.color_profiles->mode == DT_PROFILE_GAMUTCHECK ? _("gamut check") : _("soft proof");
     dt_print_pipe(DT_DEBUG_EXPOSE,
         "expose profile",
-         port->pipe, NULL, port->pipe->devid, NULL, NULL, "%dx%d, px=%d py=%d. proof: %s\n",
+         port->pipe, NULL, port->pipe->devid, NULL, NULL, "%dx%d, px=%d py=%d. proof: %s",
          width, height, pointerx, pointery, label);
 
     cairo_set_source_rgba(cri, 0.5, 0.5, 0.5, 0.5);
@@ -1694,7 +1694,7 @@ static void _softproof_profile_callback(GtkWidget *combo, gpointer user_data)
 
   // profile not found, fall back to sRGB. shouldn't happen
   dt_print(DT_DEBUG_ALWAYS,
-           "can't find softproof profile `%s', using sRGB instead\n",
+           "can't find softproof profile `%s', using sRGB instead",
            dt_bauhaus_combobox_get_text(combo));
   profile_changed = darktable.color_profiles->softproof_type != DT_COLORSPACE_SRGB;
   darktable.color_profiles->softproof_type = DT_COLORSPACE_SRGB;
@@ -1733,7 +1733,7 @@ static void _display_profile_callback(GtkWidget *combo, gpointer user_data)
 
   // profile not found, fall back to system display profile. shouldn't happen
   dt_print(DT_DEBUG_ALWAYS,
-           "can't find display profile `%s', using system display profile instead\n",
+           "can't find display profile `%s', using system display profile instead",
            dt_bauhaus_combobox_get_text(combo));
   profile_changed = darktable.color_profiles->display_type != DT_COLORSPACE_DISPLAY;
   darktable.color_profiles->display_type = DT_COLORSPACE_DISPLAY;
@@ -1775,7 +1775,7 @@ static void _display2_profile_callback(GtkWidget *combo, gpointer user_data)
 
   // profile not found, fall back to system display2 profile. shouldn't happen
   dt_print(DT_DEBUG_ALWAYS,
-           "can't find preview display profile `%s', using system display profile instead\n",
+           "can't find preview display profile `%s', using system display profile instead",
           dt_bauhaus_combobox_get_text(combo));
   profile_changed = darktable.color_profiles->display2_type != DT_COLORSPACE_DISPLAY2;
   darktable.color_profiles->display2_type = DT_COLORSPACE_DISPLAY2;
@@ -1825,7 +1825,7 @@ static void _histogram_profile_callback(GtkWidget *combo, gpointer user_data)
 
   // profile not found, fall back to export profile. shouldn't happen
   dt_print(DT_DEBUG_ALWAYS,
-           "can't find histogram profile `%s', using export profile instead\n",
+           "can't find histogram profile `%s', using export profile instead",
            dt_bauhaus_combobox_get_text(combo));
   profile_changed = darktable.color_profiles->histogram_type != DT_COLORSPACE_WORK;
   darktable.color_profiles->histogram_type = DT_COLORSPACE_WORK;
@@ -2673,7 +2673,7 @@ void enter(dt_view_t *self)
   DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_DEVELOP_PREVIEW2_PIPE_FINISHED, _darkroom_ui_preview2_pipe_finish_signal_callback, self);
   DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_TROUBLE_MESSAGE, _display_module_trouble_message_callback, self);
 
-  dt_print(DT_DEBUG_CONTROL, "[run_job+] 11 %f in darkroom mode\n", dt_get_wtime());
+  dt_print(DT_DEBUG_CONTROL, "[run_job+] 11 %f in darkroom mode", dt_get_wtime());
   dt_develop_t *dev = self->data;
   if(!dev->form_gui)
   {
@@ -2949,7 +2949,7 @@ void leave(dt_view_t *self)
 
   darktable.develop->image_storage.id = NO_IMGID;
 
-  dt_print(DT_DEBUG_CONTROL, "[run_job-] 11 %f in darkroom mode\n", dt_get_wtime());
+  dt_print(DT_DEBUG_CONTROL, "[run_job-] 11 %f in darkroom mode", dt_get_wtime());
 }
 
 void mouse_leave(dt_view_t *self)

--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -430,7 +430,7 @@ void expose(dt_view_t *self, cairo_t *cr, int32_t width, int32_t height, int32_t
   lib->already_started = TRUE;
 
   dt_print(DT_DEBUG_LIGHTTABLE | DT_DEBUG_PERF,
-           "[lighttable] expose took %0.04f sec\n",
+           "[lighttable] expose took %0.04f sec",
            dt_get_wtime() - start);
 }
 
@@ -1020,7 +1020,7 @@ static void _profile_display_profile_callback(GtkWidget *combo, gpointer user_da
 
   // profile not found, fall back to system display profile. shouldn't happen
   dt_print(DT_DEBUG_ALWAYS,
-           "can't find display profile `%s', using system display profile instead\n",
+           "can't find display profile `%s', using system display profile instead",
            dt_bauhaus_combobox_get_text(combo));
   profile_changed = darktable.color_profiles->display_type != DT_COLORSPACE_DISPLAY;
   darktable.color_profiles->display_type = DT_COLORSPACE_DISPLAY;
@@ -1062,7 +1062,7 @@ static void _profile_display2_profile_callback(GtkWidget *combo, gpointer user_d
 
   // profile not found, fall back to system display2 profile. shouldn't happen
   dt_print(DT_DEBUG_ALWAYS,
-           "can't find preview display profile `%s', using system display profile instead\n",
+           "can't find preview display profile `%s', using system display profile instead",
            dt_bauhaus_combobox_get_text(combo));
   profile_changed = darktable.color_profiles->display2_type != DT_COLORSPACE_DISPLAY2;
   darktable.color_profiles->display2_type = DT_COLORSPACE_DISPLAY2;

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -1356,44 +1356,44 @@ static gchar *_mouse_action_get_string(dt_mouse_action_t *ma)
 {
   gchar *atxt = NULL;
   if(ma->mods & GDK_SHIFT_MASK  )
-    atxt = dt_util_dstrcat(atxt, "%s+", _("shift"));
+    dt_util_str_cat(&atxt, "%s+", _("shift"));
   if(ma->mods & GDK_CONTROL_MASK)
-    atxt = dt_util_dstrcat(atxt, "%s+", _("ctrl"));
+    dt_util_str_cat(&atxt, "%s+", _("ctrl"));
   if(ma->mods & GDK_MOD1_MASK   )
 #ifdef __APPLE__
-    atxt = dt_util_dstrcat(atxt, "%s+", _("option"));
+    dt_util_str_cat(&atxt, "%s+", _("option"));
 #else
-    atxt = dt_util_dstrcat(atxt, "%s+", _("alt"));
+    dt_util_str_cat(&atxt, "%s+", _("alt"));
 #endif
 
   switch(ma->action)
   {
     case DT_MOUSE_ACTION_LEFT:
-      atxt = dt_util_dstrcat(atxt, _("left click"));
+      dt_util_str_cat(&atxt, _("left click"));
       break;
     case DT_MOUSE_ACTION_RIGHT:
-      atxt = dt_util_dstrcat(atxt, _("right click"));
+      dt_util_str_cat(&atxt, _("right click"));
       break;
     case DT_MOUSE_ACTION_MIDDLE:
-      atxt = dt_util_dstrcat(atxt, _("middle click"));
+      dt_util_str_cat(&atxt, _("middle click"));
       break;
     case DT_MOUSE_ACTION_SCROLL:
-      atxt = dt_util_dstrcat(atxt, _("scroll"));
+      dt_util_str_cat(&atxt, _("scroll"));
       break;
     case DT_MOUSE_ACTION_DOUBLE_LEFT:
-      atxt = dt_util_dstrcat(atxt, _("left double-click"));
+      dt_util_str_cat(&atxt, _("left double-click"));
       break;
     case DT_MOUSE_ACTION_DOUBLE_RIGHT:
-      atxt = dt_util_dstrcat(atxt, _("right double-click"));
+      dt_util_str_cat(&atxt, _("right double-click"));
       break;
     case DT_MOUSE_ACTION_DRAG_DROP:
-      atxt = dt_util_dstrcat(atxt, _("drag and drop"));
+      dt_util_str_cat(&atxt, _("drag and drop"));
       break;
     case DT_MOUSE_ACTION_LEFT_DRAG:
-      atxt = dt_util_dstrcat(atxt, _("left click+drag"));
+      dt_util_str_cat(&atxt, _("left click+drag"));
       break;
     case DT_MOUSE_ACTION_RIGHT_DRAG:
-      atxt = dt_util_dstrcat(atxt, _("right click+drag"));
+      dt_util_str_cat(&atxt, _("right click+drag"));
       break;
   }
 

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -734,7 +734,7 @@ dt_view_surface_value_t dt_view_image_get_surface(const dt_imgid_t imgid,
   const int32_t buf_ht = buf.height;
 
   dt_print(DT_DEBUG_LIGHTTABLE,
-      "dt_view_image_get_surface  id %i, dots %ix%i -> mip %ix%i, found %ix%i\n",
+      "dt_view_image_get_surface  id %i, dots %ix%i -> mip %ix%i, found %ix%i",
       imgid, mipwidth, mipheight, cache->max_width[mip], cache->max_height[mip], buf_wd, buf_ht);
 
   // no image is available at the moment as we didn't get buffer data
@@ -793,7 +793,7 @@ dt_view_surface_value_t dt_view_image_get_surface(const dt_imgid_t imgid,
         {
           dt_print(DT_DEBUG_ALWAYS,
                   "oops, there seems to be a code path setting an"
-                  " unhandled color space of thumbnails (%s)!\n",
+                  " unhandled color space of thumbnails (%s)!",
                   dt_colorspaces_get_name(buf.color_space, "from file"));
         }
       }
@@ -886,13 +886,13 @@ dt_view_surface_value_t dt_view_image_get_surface(const dt_imgid_t imgid,
   // logs
   if(darktable.unmuted & DT_DEBUG_PERF)
     dt_print(DT_DEBUG_LIGHTTABLE | DT_DEBUG_PERF,
-             "got surface  %ix%i created in %0.04f sec\n",
+             "got surface  %ix%i created in %0.04f sec",
              img_width, img_height, dt_get_wtime() - tt);
 
   // we consider skull as ok as the image hasn't to be reload
   if(ret != DT_VIEW_SURFACE_OK)
     dt_print(DT_DEBUG_LIGHTTABLE,
-      "dt_view_image_get_surface  ID=%i with surface problem %s%s%s\n",
+      "dt_view_image_get_surface  ID=%i with surface problem %s%s%s",
       imgid,
       tmp_surface ? "" : "no tmp_surface, ",
       ret == DT_VIEW_SURFACE_SMALLER ? "DT_VIEW_SURFACE_SMALLER" : "",
@@ -1694,7 +1694,7 @@ void dt_view_paint_surface(cairo_t *cr,
       "dt_view_paint_surface",
         port->pipe, NULL, DT_DEVICE_NONE, NULL, NULL,
         "viewport zoom_scale %6.3f backbuf_scale %6.3f "
-        "(x=%6.2f y=%6.2f) -> (x=%+.3f y=%+.3f)\n",
+        "(x=%6.2f y=%6.2f) -> (x=%+.3f y=%+.3f)",
         zoom_scale, backbuf_scale,
         port->zoom_x, port->zoom_y, zoom_x, zoom_y);
 
@@ -1769,7 +1769,7 @@ void dt_view_paint_surface(cairo_t *cr,
          dev->preview_pipe, NULL, DT_DEVICE_NONE, NULL, NULL,
          "size %4lux%-4lu processed %4.0fx%-4.0f "
          "buf %4dx%-4d scale=%.3f "
-         "zoom (x=%6.2f y=%6.2f) -> offset (x=%+.3f y=%+.3f)\n",
+         "zoom (x=%6.2f y=%6.2f) -> offset (x=%+.3f y=%+.3f)",
          width, height, wd, ht,
          dev->preview_pipe->backbuf_width, dev->preview_pipe->backbuf_height, zoom_scale,
          dev->preview_pipe->backbuf_zoom_x, dev->preview_pipe->backbuf_zoom_y,
@@ -1787,7 +1787,7 @@ void dt_view_paint_surface(cairo_t *cr,
          port->pipe, NULL, DT_DEVICE_NONE, NULL, NULL,
          "size %4lux%-4lu processed %4dx%-4d "
          "buf %4dx%-4d scale=%.3f "
-         "zoom (x=%6.2f y=%6.2f) -> offset (x=%+.3f y=%+.3f)\n",
+         "zoom (x=%6.2f y=%6.2f) -> offset (x=%+.3f y=%+.3f)",
          width, height, processed_width, processed_height,
          buf_width, buf_height, buf_scale,
          buf_zoom_x, buf_zoom_y,

--- a/src/win/getrusage.c
+++ b/src/win/getrusage.c
@@ -62,13 +62,13 @@ int getrusage(int who, struct rusage *usage)
   {
     if(!GetProcessTimes(GetCurrentProcess(), &creation_time, &exit_time, &kernel_time, &user_time))
     {
-      dt_print(DT_DEBUG_ALWAYS, "failed at GetProcessTimes\n");
+      dt_print(DT_DEBUG_ALWAYS, "failed at GetProcessTimes");
       return -1;
     }
 
     if(!GetProcessMemoryInfo(GetCurrentProcess(), &pmc, sizeof(pmc)))
     {
-      dt_print(DT_DEBUG_ALWAYS, "failed at GetProcessMemoryInfo\n");
+      dt_print(DT_DEBUG_ALWAYS, "failed at GetProcessMemoryInfo");
       return -1;
     }
 
@@ -82,7 +82,7 @@ int getrusage(int who, struct rusage *usage)
   {
     if(!GetThreadTimes(GetCurrentThread(), &creation_time, &exit_time, &kernel_time, &user_time))
     {
-      dt_print(DT_DEBUG_ALWAYS, "failed at GetThreadTimes\n");
+      dt_print(DT_DEBUG_ALWAYS, "failed at GetThreadTimes");
       return -1;
     }
     usage_to_timeval(&kernel_time, &usage->ru_stime);


### PR DESCRIPTION
***Refactor `dt_util_dstrcat` to `dt_util_str_cat`***

`gchar *dt_util_dstrcat(gchar *str, const gchar *format, ...)`
has been changed to
`void dt_util_str_cat(gchar **str, const gchar *format, ...)`

As the resulting string replaces str in most cases the code is more dense and clear.

Originally implemented by dterrahe

Minor formatting and checked.

***Refactor `dt_print()` to add newline automatically***

Leaving out the burden thinking about a newline while using `dt_print()`

Original work done by dterrahe

While being here and touching all those files, ensure all log message lines don't end
with a dot. (so far most did not, some did, and some even had a dot after an exclamation mark)

Nothing "big" but still worthwhile