### PR TITLE
Unify `dt_iop_module_t *self` for `dt_iop_module_t *module`

### DIFF
--- a/src/iop/atrous.c
+++ b/src/iop/atrous.c
@@ -647,11 +647,11 @@ void tiling_callback(dt_iop_module_t *self,
   return;
 }
 
-void init(dt_iop_module_t *module)
+void init(dt_iop_module_t *self)
 {
-  dt_iop_default_init(module);
+  dt_iop_default_init(self);
 
-  dt_iop_atrous_params_t *d = module->default_params;
+  dt_iop_atrous_params_t *d = self->default_params;
 
   for(int k = 0; k < BANDS; k++)
   {
@@ -661,12 +661,11 @@ void init(dt_iop_module_t *module)
   }
 }
 
-void init_global(dt_iop_module_so_t *module)
+void init_global(dt_iop_module_so_t *self)
 {
   const int program = 1; // from programs.conf
-  dt_iop_atrous_global_data_t *gd
-      = (dt_iop_atrous_global_data_t *)malloc(sizeof(dt_iop_atrous_global_data_t));
-  module->data = gd;
+  dt_iop_atrous_global_data_t *gd = malloc(sizeof(dt_iop_atrous_global_data_t));
+  self->data = gd;
   gd->kernel_decompose = dt_opencl_create_kernel(program, "eaw_decompose");
   gd->kernel_synthesize = dt_opencl_create_kernel(program, "eaw_synthesize");
 #ifdef USE_NEW_CL
@@ -675,22 +674,22 @@ void init_global(dt_iop_module_so_t *module)
 #endif
 }
 
-void cleanup_global(dt_iop_module_so_t *module)
+void cleanup_global(dt_iop_module_so_t *self)
 {
-  dt_iop_atrous_global_data_t *gd = module->data;
+  dt_iop_atrous_global_data_t *gd = self->data;
   dt_opencl_free_kernel(gd->kernel_decompose);
   dt_opencl_free_kernel(gd->kernel_synthesize);
 #ifdef USE_NEW_CL
   dt_opencl_free_kernel(gd->kernel_zero);
   dt_opencl_free_kernel(gd->kernel_addbuffers);
 #endif
-  free(module->data);
-  module->data = NULL;
+  free(self->data);
+  self->data = NULL;
 }
 
 static inline void _apply_mix(dt_iop_module_t *self,
-                              const int ch
-                              , const int k,
+                              const int ch,
+                              const int k,
                               const float mix,
                               const float px,
                               const float py,

--- a/src/iop/basecurve.c
+++ b/src/iop/basecurve.c
@@ -503,15 +503,15 @@ static gboolean _check_camera(dt_iop_basecurve_params_t *d,
   return FALSE;
 }
 
-void reload_defaults(dt_iop_module_t *module)
+void reload_defaults(dt_iop_module_t *self)
 {
-  dt_iop_basecurve_params_t *const d = module->default_params;
+  dt_iop_basecurve_params_t *const d = self->default_params;
 
-  if(module->multi_priority == 0)
+  if(self->multi_priority == 0)
   {
-    const dt_image_t *const image = &(module->dev->image_storage);
+    const dt_image_t *const image = &(self->dev->image_storage);
 
-    module->default_enabled = FALSE;
+    self->default_enabled = FALSE;
 
     gboolean FOUND = FALSE;
 
@@ -1530,19 +1530,19 @@ static float eval_grey(float x)
   return x;
 }
 
-void init(dt_iop_module_t *module)
+void init(dt_iop_module_t *self)
 {
-  dt_iop_default_init(module);
-  dt_iop_basecurve_params_t *d = module->default_params;
+  dt_iop_default_init(self);
+  dt_iop_basecurve_params_t *d = self->default_params;
   d->basecurve[0][1].x = d->basecurve[0][1].y = 1.0;
   d->basecurve_nodes[0] = 2;
 }
 
-void init_global(dt_iop_module_so_t *module)
+void init_global(dt_iop_module_so_t *self)
 {
   const int program = 18; // basecurve.cl, from programs.conf
   dt_iop_basecurve_global_data_t *gd = malloc(sizeof(dt_iop_basecurve_global_data_t));
-  module->data = gd;
+  self->data = gd;
   gd->kernel_basecurve_lut = dt_opencl_create_kernel(program, "basecurve_lut");
   gd->kernel_basecurve_zero = dt_opencl_create_kernel(program, "basecurve_zero");
   gd->kernel_basecurve_legacy_lut = dt_opencl_create_kernel(program, "basecurve_legacy_lut");
@@ -1560,9 +1560,9 @@ void init_global(dt_iop_module_so_t *module)
   gd->kernel_basecurve_finalize = dt_opencl_create_kernel(program, "basecurve_finalize");
 }
 
-void cleanup_global(dt_iop_module_so_t *module)
+void cleanup_global(dt_iop_module_so_t *self)
 {
-  dt_iop_basecurve_global_data_t *gd = module->data;
+  dt_iop_basecurve_global_data_t *gd = self->data;
   dt_opencl_free_kernel(gd->kernel_basecurve_lut);
   dt_opencl_free_kernel(gd->kernel_basecurve_zero);
   dt_opencl_free_kernel(gd->kernel_basecurve_legacy_lut);
@@ -1578,8 +1578,8 @@ void cleanup_global(dt_iop_module_so_t *module)
   dt_opencl_free_kernel(gd->kernel_basecurve_normalize);
   dt_opencl_free_kernel(gd->kernel_basecurve_reconstruct);
   dt_opencl_free_kernel(gd->kernel_basecurve_finalize);
-  free(module->data);
-  module->data = NULL;
+  free(self->data);
+  self->data = NULL;
 }
 
 static gboolean dt_iop_basecurve_leave_notify(GtkWidget *widget,

--- a/src/iop/cacorrect.c
+++ b/src/iop/cacorrect.c
@@ -1218,14 +1218,18 @@ DT_OMP_PRAGMA(barrier)
 /*==================================================================================
  * end raw therapee code
  *==================================================================================*/
-void modify_roi_out(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, dt_iop_roi_t *roi_out,
+void modify_roi_out(dt_iop_module_t *self,
+                    dt_dev_pixelpipe_iop_t *piece,
+                    dt_iop_roi_t *roi_out,
                     const dt_iop_roi_t *const roi_in)
 {
   *roi_out = *roi_in;
   roi_out->x = MAX(0, roi_in->x);
   roi_out->y = MAX(0, roi_in->y);
 }
-void modify_roi_in(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const dt_iop_roi_t *const roi_out,
+void modify_roi_in(dt_iop_module_t *self,
+                   dt_dev_pixelpipe_iop_t *piece,
+                   const dt_iop_roi_t *const roi_out,
                    dt_iop_roi_t *roi_in)
 {
   *roi_in = *roi_out;
@@ -1236,24 +1240,23 @@ void modify_roi_in(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const d
   roi_in->scale = 1.0f;
 }
 
-void distort_mask(
-        dt_iop_module_t *self,
-        dt_dev_pixelpipe_iop_t *piece,
-        const float *const in,
-        float *const out,
-        const dt_iop_roi_t *const roi_in,
-        const dt_iop_roi_t *const roi_out)
+void distort_mask(dt_iop_module_t *self,
+                  dt_dev_pixelpipe_iop_t *piece,
+                  const float *const in,
+                  float *const out,
+                  const dt_iop_roi_t *const roi_in,
+                  const dt_iop_roi_t *const roi_out)
 {
   dt_iop_copy_image_roi(out, in, 1, roi_in, roi_out);
 }
 
-void reload_defaults(dt_iop_module_t *module)
+void reload_defaults(dt_iop_module_t *self)
 {
   // can't be switched on for non bayer RGB images:
-  if(!dt_image_is_bayerRGB(&module->dev->image_storage))
+  if(!dt_image_is_bayerRGB(&self->dev->image_storage))
   {
-    module->hide_enable_button = TRUE;
-    module->default_enabled = FALSE;
+    self->hide_enable_button = TRUE;
+    self->default_enabled = FALSE;
   }
 }
 

--- a/src/iop/cacorrectrgb.c
+++ b/src/iop/cacorrectrgb.c
@@ -692,9 +692,9 @@ void gui_update(dt_iop_module_t *self)
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->refine_manifolds), p->refine_manifolds);
 }
 
-void reload_defaults(dt_iop_module_t *module)
+void reload_defaults(dt_iop_module_t *self)
 {
-  dt_iop_cacorrectrgb_params_t *d = module->default_params;
+  dt_iop_cacorrectrgb_params_t *d = self->default_params;
 
   d->guide_channel = DT_CACORRECT_RGB_G;
   d->radius = 5.0f;
@@ -702,7 +702,7 @@ void reload_defaults(dt_iop_module_t *module)
   d->mode = DT_CACORRECT_MODE_STANDARD;
   d->refine_manifolds = FALSE;
 
-  dt_iop_cacorrectrgb_gui_data_t *g = module->gui_data;
+  dt_iop_cacorrectrgb_gui_data_t *g = self->gui_data;
   if(g)
   {
     dt_bauhaus_combobox_set_default(g->guide_channel, d->guide_channel);

--- a/src/iop/channelmixer.c
+++ b/src/iop/channelmixer.c
@@ -1,6 +1,6 @@
 /*
   This file is part of darktable,
-  Copyright (C) 2010-2023 darktable developers.
+  Copyright (C) 2010-2024 darktable developers.
 
   darktable is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -589,17 +589,17 @@ void gui_update(dt_iop_module_t *self)
   }
 }
 
-void init(dt_iop_module_t *module)
+void init(dt_iop_module_t *self)
 {
-  dt_iop_default_init(module);
+  dt_iop_default_init(self);
 
-  dt_iop_channelmixer_params_t *d = module->default_params;
+  dt_iop_channelmixer_params_t *d = self->default_params;
 
   d->algorithm_version = CHANNEL_MIXER_VERSION_2;
   d->red[CHANNEL_RED] = d->green[CHANNEL_GREEN] = d->blue[CHANNEL_BLUE] = 1.0;
 }
 
-void gui_init(struct dt_iop_module_t *self)
+void gui_init(dt_iop_module_t *self)
 {
   dt_iop_channelmixer_gui_data_t *g = IOP_GUI_ALLOC(channelmixer);
   const dt_iop_channelmixer_params_t *const p = self->default_params;

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -3756,9 +3756,8 @@ void gui_reset(dt_iop_module_t *self)
 
 void gui_update(dt_iop_module_t *self)
 {
-  dt_iop_module_t *module = (dt_iop_module_t *)self;
   dt_iop_channelmixer_rgb_gui_data_t *g = self->gui_data;
-  dt_iop_channelmixer_rgb_params_t *p = module->params;
+  dt_iop_channelmixer_rgb_params_t *p = self->params;
 
   dt_iop_color_picker_reset(self, TRUE);
 
@@ -3822,8 +3821,7 @@ void gui_update(dt_iop_module_t *self)
   // always disable profiling mode by default
   g->is_profiling_started = FALSE;
 
-  dt_iop_channelmixer_rgb_params_t *d =
-    (dt_iop_channelmixer_rgb_params_t *)module->default_params;
+  dt_iop_channelmixer_rgb_params_t *d = self->default_params;
   g->last_daylight_temperature = d->temperature;
   g->last_bb_temperature = d->temperature;
 
@@ -3839,23 +3837,23 @@ void gui_update(dt_iop_module_t *self)
   gui_changed(self, NULL, NULL);
 }
 
-void init(dt_iop_module_t *module)
+void init(dt_iop_module_t *self)
 {
-  dt_iop_default_init(module);
+  dt_iop_default_init(self);
 
-  dt_iop_channelmixer_rgb_params_t *d = module->default_params;
+  dt_iop_channelmixer_rgb_params_t *d = self->default_params;
   d->red[0] = d->green[1] = d->blue[2] = 1.0;
 }
 
-void reload_defaults(dt_iop_module_t *module)
+void reload_defaults(dt_iop_module_t *self)
 {
-  dt_iop_channelmixer_rgb_params_t *d = module->default_params;
+  dt_iop_channelmixer_rgb_params_t *d = self->default_params;
 
-  d->x = module->get_f("x")->Float.Default;
-  d->y = module->get_f("y")->Float.Default;
-  d->temperature = module->get_f("temperature")->Float.Default;
-  d->illuminant = module->get_f("illuminant")->Enum.Default;
-  d->adaptation = module->get_f("adaptation")->Enum.Default;
+  d->x = self->get_f("x")->Float.Default;
+  d->y = self->get_f("y")->Float.Default;
+  d->temperature = self->get_f("temperature")->Float.Default;
+  d->illuminant = self->get_f("illuminant")->Enum.Default;
+  d->adaptation = self->get_f("adaptation")->Enum.Default;
 
   const gboolean is_workflow_none = dt_conf_is_equal("plugins/darkroom/workflow", "none");
   const gboolean is_modern = dt_is_scene_referred() || is_workflow_none;
@@ -3863,15 +3861,15 @@ void reload_defaults(dt_iop_module_t *module)
   // note that if there is already an instance of this module with an
   // adaptation set we default to RGB (none) in this instance.
   // try to register the CAT here
-  _declare_cat_on_pipe(module, is_modern);
-  const dt_image_t *img = &module->dev->image_storage;
+  _declare_cat_on_pipe(self, is_modern);
+  const dt_image_t *img = &self->dev->image_storage;
 
   // check if we could register
   const gboolean CAT_already_applied =
-    (module->dev->chroma.adaptation != NULL)       // CAT exists
-    && (module->dev->chroma.adaptation != module); // and it is not us
+    (self->dev->chroma.adaptation != NULL)       // CAT exists
+    && (self->dev->chroma.adaptation != self); // and it is not us
 
-  module->default_enabled = FALSE;
+  self->default_enabled = FALSE;
 
   if(CAT_already_applied || dt_image_is_monochrome(img))
   {
@@ -3884,7 +3882,7 @@ void reload_defaults(dt_iop_module_t *module)
     d->adaptation = DT_ADAPTATION_CAT16;
 
     dt_aligned_pixel_t custom_wb;
-    if(!_get_white_balance_coeff(module, custom_wb))
+    if(!_get_white_balance_coeff(self, custom_wb))
     {
       if(find_temperature_from_raw_coeffs(img, custom_wb, &(d->x), &(d->y)))
         d->illuminant = DT_ILLUMINANT_CAMERA;
@@ -3893,7 +3891,7 @@ void reload_defaults(dt_iop_module_t *module)
     }
   }
 
-  dt_iop_channelmixer_rgb_gui_data_t *g = module->gui_data;
+  dt_iop_channelmixer_rgb_gui_data_t *g = self->gui_data;
   if(g)
   {
     const dt_aligned_pixel_t xyY = { d->x, d->y, 1.f };
@@ -3919,13 +3917,13 @@ void reload_defaults(dt_iop_module_t *module)
     {
       if(pos == -1)
         dt_bauhaus_combobox_add_introspection(g->illuminant, NULL,
-                                              module->so->get_f("illuminant")->Enum.values,
+                                              self->so->get_f("illuminant")->Enum.values,
                                               DT_ILLUMINANT_CAMERA, DT_ILLUMINANT_CAMERA);
     }
     else
       dt_bauhaus_combobox_remove_at(g->illuminant, pos);
 
-    gui_changed(module, NULL, NULL);
+    gui_changed(self, NULL, NULL);
   }
 }
 

--- a/src/iop/clahe.c
+++ b/src/iop/clahe.c
@@ -262,7 +262,7 @@ static void slope_callback(GtkWidget *slider, dt_iop_module_t *self)
 
 
 
-void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_t *pipe,
+void commit_params(dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_t *pipe,
                    dt_dev_pixelpipe_iop_t *piece)
 {
   dt_iop_rlce_params_t *p = (dt_iop_rlce_params_t *)p1;
@@ -272,7 +272,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
   d->slope = p->slope;
 }
 
-void init_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
+void init_pipe(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
   piece->data = calloc(1, sizeof(dt_iop_rlce_data_t));
 }
@@ -283,7 +283,7 @@ void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev
   piece->data = NULL;
 }
 
-void gui_update(struct dt_iop_module_t *self)
+void gui_update(dt_iop_module_t *self)
 {
   dt_iop_rlce_gui_data_t *g = self->gui_data;
   dt_iop_rlce_params_t *p = self->params;
@@ -291,25 +291,25 @@ void gui_update(struct dt_iop_module_t *self)
   dt_bauhaus_slider_set(g->scale2, p->slope);
 }
 
-void init(dt_iop_module_t *module)
+void init(dt_iop_module_t *self)
 {
-  module->params = calloc(1, sizeof(dt_iop_rlce_params_t));
-  module->default_params = calloc(1, sizeof(dt_iop_rlce_params_t));
-  module->default_enabled = FALSE;
-  module->params_size = sizeof(dt_iop_rlce_params_t);
-  module->gui_data = NULL;
-  *((dt_iop_rlce_params_t *)module->default_params) = (dt_iop_rlce_params_t){ 64, 1.25 };
+  self->params = calloc(1, sizeof(dt_iop_rlce_params_t));
+  self->default_params = calloc(1, sizeof(dt_iop_rlce_params_t));
+  self->default_enabled = FALSE;
+  self->params_size = sizeof(dt_iop_rlce_params_t);
+  self->gui_data = NULL;
+  *((dt_iop_rlce_params_t *)self->default_params) = (dt_iop_rlce_params_t){ 64, 1.25 };
 }
 
-void cleanup(dt_iop_module_t *module)
+void cleanup(dt_iop_module_t *self)
 {
-  free(module->params);
-  module->params = NULL;
-  free(module->default_params);
-  module->default_params = NULL;
+  free(self->params);
+  self->params = NULL;
+  free(self->default_params);
+  self->default_params = NULL;
 }
 
-void gui_init(struct dt_iop_module_t *self)
+void gui_init(dt_iop_module_t *self)
 {
   dt_iop_rlce_gui_data_t *g = IOP_GUI_ALLOC(rlce);
   dt_iop_rlce_params_t *p = self->default_params;

--- a/src/iop/colorchecker.c
+++ b/src/iop/colorchecker.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2016-2023 darktable developers.
+    Copyright (C) 2016-2024 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -888,15 +888,15 @@ void gui_update(dt_iop_module_t *self)
   gtk_widget_queue_draw(g->area);
 }
 
-void init(dt_iop_module_t *module)
+void init(dt_iop_module_t *self)
 {
-  module->params = calloc(1, sizeof(dt_iop_colorchecker_params_t));
-  module->default_params = calloc(1, sizeof(dt_iop_colorchecker_params_t));
-  module->default_enabled = FALSE;
-  module->params_size = sizeof(dt_iop_colorchecker_params_t);
-  module->gui_data = NULL;
+  self->params = calloc(1, sizeof(dt_iop_colorchecker_params_t));
+  self->default_params = calloc(1, sizeof(dt_iop_colorchecker_params_t));
+  self->default_enabled = FALSE;
+  self->params_size = sizeof(dt_iop_colorchecker_params_t);
+  self->gui_data = NULL;
 
-  dt_iop_colorchecker_params_t *d = module->default_params;
+  dt_iop_colorchecker_params_t *d = self->default_params;
   d->num_patches = colorchecker_patches;
   for(int k = 0; k < d->num_patches; k++)
   {
@@ -906,21 +906,21 @@ void init(dt_iop_module_t *module)
   }
 }
 
-void init_global(dt_iop_module_so_t *module)
+void init_global(dt_iop_module_so_t *self)
 {
   dt_iop_colorchecker_global_data_t *gd = malloc(sizeof(dt_iop_colorchecker_global_data_t));
-  module->data = gd;
+  self->data = gd;
 
   const int program = 8; // extended.cl, from programs.conf
   gd->kernel_colorchecker = dt_opencl_create_kernel(program, "colorchecker");
 }
 
-void cleanup_global(dt_iop_module_so_t *module)
+void cleanup_global(dt_iop_module_so_t *self)
 {
-  dt_iop_colorchecker_global_data_t *gd = module->data;
+  dt_iop_colorchecker_global_data_t *gd = self->data;
   dt_opencl_free_kernel(gd->kernel_colorchecker);
-  free(module->data);
-  module->data = NULL;
+  free(self->data);
+  self->data = NULL;
 }
 
 void color_picker_apply(dt_iop_module_t *self,

--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -475,24 +475,24 @@ int legacy_params(dt_iop_module_t *self,
 #undef DT_IOP_COLOR_ICC_LEN_V5
 }
 
-void init_global(dt_iop_module_so_t *module)
+void init_global(dt_iop_module_so_t *self)
 {
   const int program = 2; // basic.cl, from programs.conf
   dt_iop_colorin_global_data_t *gd = malloc(sizeof(dt_iop_colorin_global_data_t));
-  module->data = gd;
+  self->data = gd;
   gd->kernel_colorin_unbound = dt_opencl_create_kernel(program, "colorin_unbound");
   gd->kernel_colorin_clipping = dt_opencl_create_kernel(program, "colorin_clipping");
   gd->kernel_colorin_correction =  dt_opencl_create_kernel(program, "colorin_correct");
 }
 
-void cleanup_global(dt_iop_module_so_t *module)
+void cleanup_global(dt_iop_module_so_t *self)
 {
-  dt_iop_colorin_global_data_t *gd = module->data;
+  dt_iop_colorin_global_data_t *gd = self->data;
   dt_opencl_free_kernel(gd->kernel_colorin_unbound);
   dt_opencl_free_kernel(gd->kernel_colorin_clipping);
   dt_opencl_free_kernel(gd->kernel_colorin_correction);
-  free(module->data);
-  module->data = NULL;
+  free(self->data);
+  self->data = NULL;
 }
 
 static void _profile_changed(GtkWidget *widget, dt_iop_module_t *self)
@@ -1697,19 +1697,19 @@ void gui_update(dt_iop_module_t *self)
 }
 
 // FIXME: update the gui when we add/remove the eprofile or ematrix
-void reload_defaults(dt_iop_module_t *module)
+void reload_defaults(dt_iop_module_t *self)
 {
-  module->default_enabled = TRUE;
-  module->hide_enable_button = TRUE;
+  self->default_enabled = TRUE;
+  self->hide_enable_button = TRUE;
 
-  dt_iop_colorin_params_t *d = module->default_params;
+  dt_iop_colorin_params_t *d = self->default_params;
 
   dt_colorspaces_color_profile_type_t color_profile = DT_COLORSPACE_NONE;
 
   // some file formats like jpeg can have an embedded color profile
   // currently we only support jpeg, j2k, tiff, png, avif, and heif
   dt_image_t *img = dt_image_cache_get(darktable.image_cache,
-                                       module->dev->image_storage.id, 'w');
+                                       self->dev->image_storage.id, 'w');
 
   if(!img->profile)
   {
@@ -1805,7 +1805,7 @@ void reload_defaults(dt_iop_module_t *module)
   // change.
 
   // We need gui_data to access widget in order to change tooltip.
-  dt_iop_colorin_gui_data_t *g = module->gui_data;
+  dt_iop_colorin_gui_data_t *g = self->gui_data;
 
   // reload_defaults() can be called with unavailable (i.e., NULL) gui_data.
   // In this case, we have nothing to do with tooltips.
@@ -1911,7 +1911,7 @@ void reload_defaults(dt_iop_module_t *module)
 
   dt_image_cache_write_release(darktable.image_cache, img, DT_IMAGE_CACHE_RELAXED);
 
-  update_profile_list(module);
+  update_profile_list(self);
 }
 
 static void update_profile_list(dt_iop_module_t *self)

--- a/src/iop/colorize.c
+++ b/src/iop/colorize.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2011-2023 darktable developers.
+    Copyright (C) 2011-2024 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -197,20 +197,20 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
 }
 #endif
 
-void init_global(dt_iop_module_so_t *module)
+void init_global(dt_iop_module_so_t *self)
 {
   const int program = 8; // extended.cl, from programs.conf
   dt_iop_colorize_global_data_t *gd = malloc(sizeof(dt_iop_colorize_global_data_t));
-  module->data = gd;
+  self->data = gd;
   gd->kernel_colorize = dt_opencl_create_kernel(program, "colorize");
 }
 
-void cleanup_global(dt_iop_module_so_t *module)
+void cleanup_global(dt_iop_module_so_t *self)
 {
-  dt_iop_colorize_global_data_t *gd = module->data;
+  dt_iop_colorize_global_data_t *gd = self->data;
   dt_opencl_free_kernel(gd->kernel_colorize);
-  free(module->data);
-  module->data = NULL;
+  free(self->data);
+  self->data = NULL;
 }
 
 static inline void update_saturation_slider_end_color(GtkWidget *slider, float hue)
@@ -323,11 +323,11 @@ void gui_update(dt_iop_module_t *self)
   update_saturation_slider_end_color(g->saturation, p->hue);
 }
 
-void init(dt_iop_module_t *module)
+void init(dt_iop_module_t *self)
 {
-  dt_iop_default_init(module);
+  dt_iop_default_init(self);
 
-  ((dt_iop_colorize_params_t *)module->default_params)->version = module->version();
+  ((dt_iop_colorize_params_t *)self->default_params)->version = self->version();
 }
 
 void gui_init(dt_iop_module_t *self)

--- a/src/iop/colormapping.c
+++ b/src/iop/colormapping.c
@@ -798,29 +798,29 @@ void cleanup_pipe(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelp
   piece->data = NULL;
 }
 
-void init_global(dt_iop_module_so_t *module)
+void init_global(dt_iop_module_so_t *self)
 {
   const int program = 8; // extended.cl, from programs.conf
   dt_iop_colormapping_global_data_t *gd = malloc(sizeof(dt_iop_colormapping_global_data_t));
-  module->data = gd;
+  self->data = gd;
   gd->kernel_histogram = dt_opencl_create_kernel(program, "colormapping_histogram");
   gd->kernel_mapping = dt_opencl_create_kernel(program, "colormapping_mapping");
 }
 
-void cleanup_global(dt_iop_module_so_t *module)
+void cleanup_global(dt_iop_module_so_t *self)
 {
-  dt_iop_colormapping_global_data_t *gd = module->data;
+  dt_iop_colormapping_global_data_t *gd = self->data;
   dt_opencl_free_kernel(gd->kernel_histogram);
   dt_opencl_free_kernel(gd->kernel_mapping);
-  free(module->data);
-  module->data = NULL;
+  free(self->data);
+  self->data = NULL;
 }
 
-void reload_defaults(dt_iop_module_t *module)
+void reload_defaults(dt_iop_module_t *self)
 {
-  dt_iop_colormapping_params_t *d = module->default_params;
-  dt_iop_colormapping_gui_data_t *g = module->gui_data;
-  if(module->dev->gui_attached && g && g->flowback_set)
+  dt_iop_colormapping_params_t *d = self->default_params;
+  dt_iop_colormapping_gui_data_t *g = self->gui_data;
+  if(self->dev->gui_attached && g && g->flowback_set)
   {
     memcpy(d->source_ihist, g->flowback.hist, sizeof(float) * HISTN);
     memcpy(d->source_mean, g->flowback.mean, sizeof(float) * MAXN * 2);

--- a/src/iop/colorout.c
+++ b/src/iop/colorout.c
@@ -806,12 +806,12 @@ void gui_update(dt_iop_module_t *self)
            dt_colorspaces_get_name(p->type, p->filename));
 }
 
-void init(dt_iop_module_t *module)
+void init(dt_iop_module_t *self)
 {
-  dt_iop_default_init(module);
+  dt_iop_default_init(self);
 
-  module->hide_enable_button = TRUE;
-  module->default_enabled = TRUE;
+  self->hide_enable_button = TRUE;
+  self->default_enabled = TRUE;
 }
 
 static void _preference_changed(gpointer instance, dt_iop_module_t *self)

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -2372,14 +2372,14 @@ static void _edit_by_area_callback(GtkWidget *widget,
 }
 
 static void _display_mask_callback(GtkToggleButton *togglebutton,
-                                   dt_iop_module_t *module)
+                                   dt_iop_module_t *self)
 {
   if(darktable.gui->reset) return;
 
-  dt_iop_colorzones_gui_data_t *g = module->gui_data;
+  dt_iop_colorzones_gui_data_t *g = self->gui_data;
 
   // if blend module is displaying mask do not display it here
-  if(module->request_mask_display && !g->display_mask)
+  if(self->request_mask_display && !g->display_mask)
   {
     dt_control_log(_("cannot display masks when the blending mask is displayed"));
 
@@ -2391,9 +2391,9 @@ static void _display_mask_callback(GtkToggleButton *togglebutton,
 
   g->display_mask = gtk_toggle_button_get_active(togglebutton);
 
-  if(module->off) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(module->off), 1);
-  dt_iop_request_focus(module);
-  dt_iop_refresh_center(module);
+  if(self->off) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(self->off), 1);
+  dt_iop_request_focus(self);
+  dt_iop_refresh_center(self);
 }
 
 void color_picker_apply(dt_iop_module_t *self,
@@ -2783,24 +2783,24 @@ void gui_cleanup(dt_iop_module_t *self)
   IOP_GUI_FREE;
 }
 
-void init_global(dt_iop_module_so_t *module)
+void init_global(dt_iop_module_so_t *self)
 {
   const int program = 2; // basic.cl, from programs.conf
   dt_iop_colorzones_global_data_t *gd = malloc(sizeof(dt_iop_colorzones_global_data_t));
-  module->data = gd;
+  self->data = gd;
   gd->kernel_colorzones = dt_opencl_create_kernel(program, "colorzones");
   gd->kernel_colorzones_v3 = dt_opencl_create_kernel(program, "colorzones_v3");
 }
 
-void cleanup_global(dt_iop_module_so_t *module)
+void cleanup_global(dt_iop_module_so_t *self)
 {
-  dt_iop_colorzones_global_data_t *gd = module->data;
+  dt_iop_colorzones_global_data_t *gd = self->data;
 
   dt_opencl_free_kernel(gd->kernel_colorzones);
   dt_opencl_free_kernel(gd->kernel_colorzones_v3);
 
-  free(module->data);
-  module->data = NULL;
+  free(self->data);
+  self->data = NULL;
 }
 
 void commit_params(dt_iop_module_t *self,
@@ -2960,16 +2960,16 @@ void cleanup_pipe(dt_iop_module_t *self,
   piece->data = NULL;
 }
 
-void init(dt_iop_module_t *module)
+void init(dt_iop_module_t *self)
 {
-  module->params = calloc(1, sizeof(dt_iop_colorzones_params_t));
-  module->default_params = calloc(1, sizeof(dt_iop_colorzones_params_t));
-  module->default_enabled = FALSE;
-  module->params_size = sizeof(dt_iop_colorzones_params_t);
-  module->gui_data = NULL;
-  module->request_histogram |= DT_REQUEST_ON;
+  self->params = calloc(1, sizeof(dt_iop_colorzones_params_t));
+  self->default_params = calloc(1, sizeof(dt_iop_colorzones_params_t));
+  self->default_enabled = FALSE;
+  self->params_size = sizeof(dt_iop_colorzones_params_t);
+  self->gui_data = NULL;
+  self->request_histogram |= DT_REQUEST_ON;
 
-  _reset_parameters(module->default_params, DT_IOP_COLORZONES_h,
+  _reset_parameters(self->default_params, DT_IOP_COLORZONES_h,
                     DT_IOP_COLORZONES_SPLINES_V2);
 }
 

--- a/src/iop/defringe.c
+++ b/src/iop/defringe.c
@@ -109,7 +109,7 @@ dt_iop_colorspace_type_t default_colorspace(dt_iop_module_t *self,
   return IOP_CS_LAB;
 }
 
-void tiling_callback(dt_iop_module_t *module,
+void tiling_callback(dt_iop_module_t *self,
                      dt_dev_pixelpipe_iop_t *piece,
                      const dt_iop_roi_t *roi_in,
                      const dt_iop_roi_t *roi_out,
@@ -168,7 +168,7 @@ static inline void _fib_latt(int *const x, int *const y, float radius, int step,
 // most are chosen arbitrarily and/or by experiment/trial+error ... I am sorry ;-)
 // and having everything user-defineable would be just too much
 // -----------------------------------------------------------------------------------------
-void process(dt_iop_module_t *module,
+void process(dt_iop_module_t *self,
              dt_dev_pixelpipe_iop_t *piece,
              const void *const i,
              void *const o,
@@ -176,7 +176,7 @@ void process(dt_iop_module_t *module,
              const dt_iop_roi_t *const roi_out)
 {
   const dt_iop_defringe_data_t *const d = piece->data;
-  if(!dt_iop_have_required_input_format(4 /*we need full-color pixels*/, module, piece->colors,
+  if(!dt_iop_have_required_input_format(4 /*we need full-color pixels*/, self, piece->colors,
                                          i, o, roi_in, roi_out))
     return; // image has been copied through to output and module's trouble flag has been updated
 
@@ -416,10 +416,10 @@ void gui_init(dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->thresh_scale, _("threshold for defringe, higher values mean less defringing"));
 }
 
-void gui_update(dt_iop_module_t *module)
+void gui_update(dt_iop_module_t *self)
 {
-  dt_iop_defringe_gui_data_t *g = module->gui_data;
-  dt_iop_defringe_params_t *p = module->params;
+  dt_iop_defringe_gui_data_t *g = self->gui_data;
+  dt_iop_defringe_params_t *p = self->params;
   dt_bauhaus_combobox_set(g->mode_select, p->op_mode);
   dt_bauhaus_slider_set(g->radius_scale, p->radius);
   dt_bauhaus_slider_set(g->thresh_scale, p->thresh);

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -882,11 +882,11 @@ int process_cl(dt_iop_module_t *self,
 }
 #endif
 
-void init_global(dt_iop_module_so_t *module)
+void init_global(dt_iop_module_so_t *self)
 {
   const int program = 0; // from programs.conf
   dt_iop_demosaic_global_data_t *gd = malloc(sizeof(dt_iop_demosaic_global_data_t));
-  module->data = gd;
+  self->data = gd;
   gd->kernel_zoom_half_size = dt_opencl_create_kernel(program, "clip_and_zoom_demosaic_half_size");
   gd->kernel_ppg_green = dt_opencl_create_kernel(program, "ppg_demosaic_green");
   gd->kernel_green_eq_lavg = dt_opencl_create_kernel(program, "green_equilibration_lavg");
@@ -947,9 +947,9 @@ void init_global(dt_iop_module_so_t *module)
   gd->kernel_write_blended_dual  = dt_opencl_create_kernel(rcd, "write_blended_dual");
 }
 
-void cleanup_global(dt_iop_module_so_t *module)
+void cleanup_global(dt_iop_module_so_t *self)
 {
-  dt_iop_demosaic_global_data_t *gd = module->data;
+  dt_iop_demosaic_global_data_t *gd = self->data;
   dt_opencl_free_kernel(gd->kernel_zoom_half_size);
   dt_opencl_free_kernel(gd->kernel_ppg_green);
   dt_opencl_free_kernel(gd->kernel_pre_median);
@@ -1000,8 +1000,8 @@ void cleanup_global(dt_iop_module_so_t *module)
   dt_opencl_free_kernel(gd->kernel_rcd_border_redblue);
   dt_opencl_free_kernel(gd->kernel_rcd_border_green);
   dt_opencl_free_kernel(gd->kernel_write_blended_dual);
-  free(module->data);
-  module->data = NULL;
+  free(self->data);
+  self->data = NULL;
   _cleanup_lmmse_gamma();
 }
 
@@ -1143,24 +1143,24 @@ void cleanup_pipe(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelp
   piece->data = NULL;
 }
 
-void reload_defaults(dt_iop_module_t *module)
+void reload_defaults(dt_iop_module_t *self)
 {
-  dt_iop_demosaic_params_t *d = module->default_params;
+  dt_iop_demosaic_params_t *d = self->default_params;
 
-  if(dt_image_is_monochrome(&module->dev->image_storage))
+  if(dt_image_is_monochrome(&self->dev->image_storage))
     d->demosaicing_method = DT_IOP_DEMOSAIC_PASSTHROUGH_MONOCHROME;
-  else if(module->dev->image_storage.buf_dsc.filters == 9u)
+  else if(self->dev->image_storage.buf_dsc.filters == 9u)
     d->demosaicing_method = DT_IOP_DEMOSAIC_MARKESTEIJN;
   else
-    d->demosaicing_method = module->dev->image_storage.flags & DT_IMAGE_4BAYER
+    d->demosaicing_method = self->dev->image_storage.flags & DT_IMAGE_4BAYER
                             ? DT_IOP_DEMOSAIC_VNG4
                             : DT_IOP_DEMOSAIC_RCD;
 
-  module->hide_enable_button = TRUE;
+  self->hide_enable_button = TRUE;
 
-  module->default_enabled = dt_image_is_raw(&module->dev->image_storage);
-  if(module->widget)
-    gtk_stack_set_visible_child_name(GTK_STACK(module->widget), module->default_enabled ? "raw" : "non_raw");
+  self->default_enabled = dt_image_is_raw(&self->dev->image_storage);
+  if(self->widget)
+    gtk_stack_set_visible_child_name(GTK_STACK(self->widget), self->default_enabled ? "raw" : "non_raw");
 }
 
 void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -2766,11 +2766,11 @@ static inline float infer_bias_from_profile(const float a)
   return -MAX(5 + 0.5 * logf(a), 0.0);
 }
 
-void init(dt_iop_module_t *module)
+void init(dt_iop_module_t *self)
 {
-  dt_iop_default_init(module);
+  dt_iop_default_init(self);
 
-  dt_iop_denoiseprofile_params_t *d = module->default_params;
+  dt_iop_denoiseprofile_params_t *d = self->default_params;
 
   for(int k = 0; k < DT_IOP_DENOISE_PROFILE_BANDS; k++)
   {
@@ -2783,10 +2783,10 @@ void init(dt_iop_module_t *module)
 
 /** this will be called to init new defaults if a new image is loaded
  * from film strip mode. */
-void reload_defaults(dt_iop_module_t *module)
+void reload_defaults(dt_iop_module_t *self)
 {
-  dt_iop_denoiseprofile_gui_data_t *g = module->gui_data;
-  dt_iop_denoiseprofile_params_t *d = module->default_params;
+  dt_iop_denoiseprofile_gui_data_t *g = self->gui_data;
+  dt_iop_denoiseprofile_params_t *d = self->default_params;
 
   d->radius = 1.0f;
   d->nbhood = 7.0f;
@@ -2802,8 +2802,8 @@ void reload_defaults(dt_iop_module_t *module)
   d->use_new_vst = TRUE;
   d->wavelet_color_mode = MODE_Y0U0V0;
 
-  GList *profiles = dt_noiseprofile_get_matching(&module->dev->image_storage);
-  const int iso = module->dev->image_storage.exif_iso;
+  GList *profiles = dt_noiseprofile_get_matching(&self->dev->image_storage);
+  const int iso = self->dev->image_storage.exif_iso;
 
   // default to generic poissonian
   dt_noiseprofile_t interpolated = dt_noiseprofile_generic;
@@ -2869,16 +2869,16 @@ void reload_defaults(dt_iop_module_t *module)
     }
     dt_bauhaus_combobox_set(g->profile, 0);
 
-    gui_update(module);
+    gui_update(self);
   }
 }
 
-void init_global(dt_iop_module_so_t *module)
+void init_global(dt_iop_module_so_t *self)
 {
   const int program = 11; // denoiseprofile.cl, from programs.conf
   dt_iop_denoiseprofile_global_data_t *gd = malloc(sizeof(dt_iop_denoiseprofile_global_data_t));
 
-  module->data = gd;
+  self->data = gd;
   gd->kernel_denoiseprofile_precondition =
     dt_opencl_create_kernel(program, "denoiseprofile_precondition");
   gd->kernel_denoiseprofile_precondition_v2 =
@@ -2915,9 +2915,9 @@ void init_global(dt_iop_module_so_t *module)
     dt_opencl_create_kernel(program, "denoiseprofile_reduce_second");
 }
 
-void cleanup_global(dt_iop_module_so_t *module)
+void cleanup_global(dt_iop_module_so_t *self)
 {
-  dt_iop_denoiseprofile_global_data_t *gd = module->data;
+  dt_iop_denoiseprofile_global_data_t *gd = self->data;
   dt_opencl_free_kernel(gd->kernel_denoiseprofile_precondition);
   dt_opencl_free_kernel(gd->kernel_denoiseprofile_precondition_v2);
   dt_opencl_free_kernel(gd->kernel_denoiseprofile_init);
@@ -2933,8 +2933,8 @@ void cleanup_global(dt_iop_module_so_t *module)
   dt_opencl_free_kernel(gd->kernel_denoiseprofile_synthesize);
   dt_opencl_free_kernel(gd->kernel_denoiseprofile_reduce_first);
   dt_opencl_free_kernel(gd->kernel_denoiseprofile_reduce_second);
-  free(module->data);
-  module->data = NULL;
+  free(self->data);
+  self->data = NULL;
 }
 
 static dt_noiseprofile_t dt_iop_denoiseprofile_get_auto_profile(dt_iop_module_t *self)

--- a/src/iop/enlargecanvas.c
+++ b/src/iop/enlargecanvas.c
@@ -388,18 +388,18 @@ void process(struct dt_iop_module_t *self,
   dt_iop_copy_image_with_border((float*)ovoid, (const float*)ivoid, &binfo);
 }
 
-void cleanup(dt_iop_module_t *module)
+void cleanup(dt_iop_module_t *self)
 {
-  free(module->params);
-  module->params = NULL;
-  free(module->default_params);
-  module->default_params = NULL;
+  free(self->params);
+  self->params = NULL;
+  free(self->default_params);
+  self->default_params = NULL;
 }
 
-void cleanup_global(dt_iop_module_so_t *module)
+void cleanup_global(dt_iop_module_so_t *self)
 {
-  free(module->data);
-  module->data = NULL;
+  free(self->data);
+  self->data = NULL;
 }
 
 /** gui setup and update, these are needed. */

--- a/src/iop/equalizer.c
+++ b/src/iop/equalizer.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2009-2020 darktable developers.
+    Copyright (C) 2009-2024 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -216,14 +216,14 @@ void gui_update(struct dt_iop_module_t *self)
   // gtk_widget_queue_draw(self->widget);
 }
 
-void init(dt_iop_module_t *module)
+void init(dt_iop_module_t *self)
 {
-  module->params = calloc(1, sizeof(dt_iop_equalizer_params_t));
-  module->default_params = calloc(1, sizeof(dt_iop_equalizer_params_t));
-  module->default_enabled = FALSE; // we're a rather slow and rare op.
-  module->params_size = sizeof(dt_iop_equalizer_params_t);
-  module->gui_data = NULL;
-  dt_iop_equalizer_params_t *d = module->default_params;
+  self->params = calloc(1, sizeof(dt_iop_equalizer_params_t));
+  self->default_params = calloc(1, sizeof(dt_iop_equalizer_params_t));
+  self->default_enabled = FALSE; // we're a rather slow and rare op.
+  self->params_size = sizeof(dt_iop_equalizer_params_t);
+  self->gui_data = NULL;
+  dt_iop_equalizer_params_t *d = self->default_params;
   for(int ch = 0; ch < 3; ch++)
   {
     for(int k = 0; k < DT_IOP_EQUALIZER_BANDS; k++)

--- a/src/iop/filmic.c
+++ b/src/iop/filmic.c
@@ -1289,15 +1289,15 @@ void gui_update(dt_iop_module_t *self)
 
 }
 
-void init(dt_iop_module_t *module)
+void init(dt_iop_module_t *self)
 {
-  module->params = calloc(1, sizeof(dt_iop_filmic_params_t));
-  module->default_params = calloc(1, sizeof(dt_iop_filmic_params_t));
-  module->default_enabled = FALSE;
-  module->params_size = sizeof(dt_iop_filmic_params_t);
-  module->gui_data = NULL;
+  self->params = calloc(1, sizeof(dt_iop_filmic_params_t));
+  self->default_params = calloc(1, sizeof(dt_iop_filmic_params_t));
+  self->default_enabled = FALSE;
+  self->params_size = sizeof(dt_iop_filmic_params_t);
+  self->gui_data = NULL;
 
-  *(dt_iop_filmic_params_t *)module->default_params
+  *(dt_iop_filmic_params_t *)self->default_params
     = (dt_iop_filmic_params_t){
                                  .grey_point_source   = 18, // source grey
                                  .black_point_source  = -8.65,  // source black
@@ -1317,29 +1317,29 @@ void init(dt_iop_module_t *module)
                               };
 }
 
-void init_global(dt_iop_module_so_t *module)
+void init_global(dt_iop_module_so_t *self)
 {
   const int program = 22; // filmic.cl, from programs.conf
   dt_iop_filmic_global_data_t *gd = malloc(sizeof(dt_iop_filmic_global_data_t));
 
-  module->data = gd;
+  self->data = gd;
   gd->kernel_filmic = dt_opencl_create_kernel(program, "filmic");
 }
 
-void cleanup(dt_iop_module_t *module)
+void cleanup(dt_iop_module_t *self)
 {
-  free(module->params);
-  module->params = NULL;
-  free(module->default_params);
-  module->default_params = NULL;
+  free(self->params);
+  self->params = NULL;
+  free(self->default_params);
+  self->default_params = NULL;
 }
 
-void cleanup_global(dt_iop_module_so_t *module)
+void cleanup_global(dt_iop_module_so_t *self)
 {
-  dt_iop_filmic_global_data_t *gd = module->data;
+  dt_iop_filmic_global_data_t *gd = self->data;
   dt_opencl_free_kernel(gd->kernel_filmic);
-  free(module->data);
-  module->data = NULL;
+  free(self->data);
+  self->data = NULL;
 }
 
 void gui_reset(dt_iop_module_t *self)

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -3169,31 +3169,31 @@ void gui_update(dt_iop_module_t *self)
   gui_changed(self, NULL, NULL);
 }
 
-void reload_defaults(dt_iop_module_t *module)
+void reload_defaults(dt_iop_module_t *self)
 {
-  dt_iop_filmicrgb_params_t *d = module->default_params;
+  dt_iop_filmicrgb_params_t *d = self->default_params;
 
-  d->black_point_source = module->so->get_f("black_point_source")->Float.Default;
-  d->white_point_source = module->so->get_f("white_point_source")->Float.Default;
-  d->output_power = module->so->get_f("output_power")->Float.Default;
+  d->black_point_source = self->so->get_f("black_point_source")->Float.Default;
+  d->white_point_source = self->so->get_f("white_point_source")->Float.Default;
+  d->output_power = self->so->get_f("output_power")->Float.Default;
 
-  module->default_enabled = FALSE;
+  self->default_enabled = FALSE;
 
   const gboolean is_scene_referred = dt_is_scene_referred();
 
-  if(dt_image_is_matrix_correction_supported(&module->dev->image_storage)
+  if(dt_image_is_matrix_correction_supported(&self->dev->image_storage)
      && is_scene_referred)
   {
     // For scene-referred workflow, auto-enable and adjust based on exposure
     // TODO: fetch actual exposure in module, don't assume 1.
-    const float exposure = 0.7f - dt_image_get_exposure_bias(&module->dev->image_storage);
+    const float exposure = 0.7f - dt_image_get_exposure_bias(&self->dev->image_storage);
 
     // As global exposure increases, white exposure increases faster than black
     // this is probably because raw black/white points offsets the lower bound of the dynamic range to 0
     // so exposure compensation actually increases the dynamic range too (stretches only white).
     d->black_point_source += 0.5f * exposure;
     d->white_point_source += 0.8f * exposure;
-    _compute_output_power(module, d);
+    _compute_output_power(self, d);
   }
 }
 
@@ -3220,12 +3220,12 @@ void init_presets(dt_iop_module_so_t *self)
   }
 }
 
-void init_global(dt_iop_module_so_t *module)
+void init_global(dt_iop_module_so_t *self)
 {
   const int program = 22; // filmic.cl, from programs.conf
   dt_iop_filmicrgb_global_data_t *gd = malloc(sizeof(dt_iop_filmicrgb_global_data_t));
 
-  module->data = gd;
+  self->data = gd;
   gd->kernel_filmic_rgb_split = dt_opencl_create_kernel(program, "filmicrgb_split");
   gd->kernel_filmic_rgb_chroma = dt_opencl_create_kernel(program, "filmicrgb_chroma");
   gd->kernel_filmic_mask = dt_opencl_create_kernel(program, "filmic_mask_clipped_pixels");
@@ -3242,9 +3242,9 @@ void init_global(dt_iop_module_so_t *module)
   gd->kernel_filmic_wavelets_detail = dt_opencl_create_kernel(wavelets, "wavelets_detail_level");
 }
 
-void cleanup_global(dt_iop_module_so_t *module)
+void cleanup_global(dt_iop_module_so_t *self)
 {
-  dt_iop_filmicrgb_global_data_t *gd = module->data;
+  dt_iop_filmicrgb_global_data_t *gd = self->data;
   dt_opencl_free_kernel(gd->kernel_filmic_rgb_split);
   dt_opencl_free_kernel(gd->kernel_filmic_rgb_chroma);
   dt_opencl_free_kernel(gd->kernel_filmic_mask);
@@ -3257,8 +3257,8 @@ void cleanup_global(dt_iop_module_so_t *module)
   dt_opencl_free_kernel(gd->kernel_filmic_wavelets_reconstruct);
   dt_opencl_free_kernel(gd->kernel_filmic_compute_ratios);
   dt_opencl_free_kernel(gd->kernel_filmic_restore_ratios);
-  free(module->data);
-  module->data = NULL;
+  free(self->data);
+  self->data = NULL;
 }
 
 

--- a/src/iop/gamma.c
+++ b/src/iop/gamma.c
@@ -281,7 +281,7 @@ static void _copy_output(const float *const restrict in,
 }
 
 
-void process(struct dt_iop_module_t *self,
+void process(dt_iop_module_t *self,
              dt_dev_pixelpipe_iop_t *piece,
              const void *const i,
              void *const o,
@@ -327,15 +327,15 @@ void process(struct dt_iop_module_t *self,
   }
 }
 
-void init(dt_iop_module_t *module)
+void init(dt_iop_module_t *self)
 {
-  // module->data = malloc(sizeof(dt_iop_gamma_data_t));
-  module->params = calloc(1, sizeof(dt_iop_gamma_params_t));
-  module->default_params = calloc(1, sizeof(dt_iop_gamma_params_t));
-  module->params_size = sizeof(dt_iop_gamma_params_t);
-  module->gui_data = NULL;
-  module->hide_enable_button = TRUE;
-  module->default_enabled = TRUE;
+  // self->data = malloc(sizeof(dt_iop_gamma_data_t));
+  self->params = calloc(1, sizeof(dt_iop_gamma_params_t));
+  self->default_params = calloc(1, sizeof(dt_iop_gamma_params_t));
+  self->params_size = sizeof(dt_iop_gamma_params_t);
+  self->gui_data = NULL;
+  self->hide_enable_button = TRUE;
+  self->default_enabled = TRUE;
 }
 
 // clang-format off

--- a/src/iop/hotpixels.c
+++ b/src/iop/hotpixels.c
@@ -354,14 +354,14 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
   }
 }
 
-void reload_defaults(dt_iop_module_t *module)
+void reload_defaults(dt_iop_module_t *self)
 {
-  const dt_image_t *img = &module->dev->image_storage;
+  const dt_image_t *img = &self->dev->image_storage;
 
   const gboolean monoraw = (img->flags & DT_IMAGE_S_RAW) && (img->flags & DT_IMAGE_MONOCHROME);
   const gboolean supported = dt_image_is_raw(img) || monoraw;
   // can't be switched on for non-raw images:
-  module->hide_enable_button = !supported;
+  self->hide_enable_button = !supported;
 }
 
 void commit_params(dt_iop_module_t *self, dt_iop_params_t *params, dt_dev_pixelpipe_t *pipe,

--- a/src/iop/levels.c
+++ b/src/iop/levels.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2011-2023 darktable developers.
+    Copyright (C) 2011-2024 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -581,13 +581,13 @@ void gui_update(dt_iop_module_t *self)
   gtk_widget_queue_draw(GTK_WIDGET(g->area));
 }
 
-void init(dt_iop_module_t *module)
+void init(dt_iop_module_t *self)
 {
-  dt_iop_default_init(module);
+  dt_iop_default_init(self);
 
-  module->request_histogram |= DT_REQUEST_ON;
+  self->request_histogram |= DT_REQUEST_ON;
 
-  dt_iop_levels_params_t *d = module->default_params;
+  dt_iop_levels_params_t *d = self->default_params;
 
   d->levels[0] = 0.0f;
   d->levels[1] = 0.5f;

--- a/src/iop/lowlight.c
+++ b/src/iop/lowlight.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2011-2023 darktable developers.
+    Copyright (C) 2011-2024 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -219,21 +219,21 @@ finish:
 #endif
 
 
-void init_global(dt_iop_module_so_t *module)
+void init_global(dt_iop_module_so_t *self)
 {
   const int program = 2; // basic.cl from programs.conf
   dt_iop_lowlight_global_data_t *gd = malloc(sizeof(dt_iop_lowlight_global_data_t));
-  module->data = gd;
+  self->data = gd;
   gd->kernel_lowlight = dt_opencl_create_kernel(program, "lowlight");
 }
 
 
-void cleanup_global(dt_iop_module_so_t *module)
+void cleanup_global(dt_iop_module_so_t *self)
 {
-  dt_iop_lowlight_global_data_t *gd = module->data;
+  dt_iop_lowlight_global_data_t *gd = self->data;
   dt_opencl_free_kernel(gd->kernel_lowlight);
-  free(module->data);
-  module->data = NULL;
+  free(self->data);
+  self->data = NULL;
 }
 
 
@@ -257,11 +257,11 @@ void init_pipe(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe
   const dt_iop_lowlight_params_t *const default_params = self->default_params;
   piece->data = (void *)d;
   d->curve = dt_draw_curve_new(0.0, 1.0, CATMULL_ROM);
-  (void)dt_draw_curve_add_point(d->curve, default_params->transition_x[DT_IOP_LOWLIGHT_BANDS - 2] - 1.0,
+  dt_draw_curve_add_point(d->curve, default_params->transition_x[DT_IOP_LOWLIGHT_BANDS - 2] - 1.0,
                                 default_params->transition_y[DT_IOP_LOWLIGHT_BANDS - 2]);
   for(int k = 0; k < DT_IOP_LOWLIGHT_BANDS; k++)
-    (void)dt_draw_curve_add_point(d->curve, default_params->transition_x[k], default_params->transition_y[k]);
-  (void)dt_draw_curve_add_point(d->curve, default_params->transition_x[1] + 1.0,
+    dt_draw_curve_add_point(d->curve, default_params->transition_x[k], default_params->transition_y[k]);
+  dt_draw_curve_add_point(d->curve, default_params->transition_x[1] + 1.0,
                                 default_params->transition_y[1]);
 }
 
@@ -282,11 +282,11 @@ void gui_update(dt_iop_module_t *self)
   gtk_widget_queue_draw(GTK_WIDGET(g->area));;
 }
 
-void init(dt_iop_module_t *module)
+void init(dt_iop_module_t *self)
 {
-  dt_iop_default_init(module);
+  dt_iop_default_init(self);
 
-  dt_iop_lowlight_params_t *d = module->default_params;
+  dt_iop_lowlight_params_t *d = self->default_params;
 
   for(int k = 0; k < DT_IOP_LOWLIGHT_BANDS; k++) d->transition_x[k] = k / (DT_IOP_LOWLIGHT_BANDS - 1.0);
 }

--- a/src/iop/negadoctor.c
+++ b/src/iop/negadoctor.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2020-2023 darktable developers.
+    Copyright (C) 2020-2024 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -381,11 +381,11 @@ int process_cl(dt_iop_module_t *const self, dt_dev_pixelpipe_iop_t *const piece,
 #endif
 
 
-void init(dt_iop_module_t *module)
+void init(dt_iop_module_t *self)
 {
-  dt_iop_default_init(module);
+  dt_iop_default_init(self);
 
-  dt_iop_negadoctor_params_t *d = module->default_params;
+  dt_iop_negadoctor_params_t *d = self->default_params;
 
   d->Dmin[0] = 1.00f;
   d->Dmin[1] = 0.45f;
@@ -426,21 +426,21 @@ void init_presets(dt_iop_module_so_t *self)
                              self->version(), &tmq, sizeof(tmq), 1, DEVELOP_BLEND_CS_RGB_DISPLAY);
 }
 
-void init_global(dt_iop_module_so_t *module)
+void init_global(dt_iop_module_so_t *self)
 {
   dt_iop_negadoctor_global_data_t *gd = malloc(sizeof(dt_iop_negadoctor_global_data_t));
 
-  module->data = gd;
+  self->data = gd;
   const int program = 30; // negadoctor.cl, from programs.conf
   gd->kernel_negadoctor = dt_opencl_create_kernel(program, "negadoctor");
 }
 
-void cleanup_global(dt_iop_module_so_t *module)
+void cleanup_global(dt_iop_module_so_t *self)
 {
-  dt_iop_negadoctor_global_data_t *gd = module->data;
+  dt_iop_negadoctor_global_data_t *gd = self->data;
   dt_opencl_free_kernel(gd->kernel_negadoctor);
-  free(module->data);
-  module->data = NULL;
+  free(self->data);
+  self->data = NULL;
 }
 
 void init_pipe(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)

--- a/src/iop/overexposed.c
+++ b/src/iop/overexposed.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2010-2023 darktable developers.
+    Copyright (C) 2010-2024 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -105,7 +105,7 @@ dt_iop_colorspace_type_t default_colorspace(dt_iop_module_t *self,
 //   dt_accel_connect_slider_iop(self, "color scheme", GTK_WIDGET(g->colorscheme));
 // }
 
-void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
+void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
              void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   if(!dt_iop_have_required_input_format(4 /*we need full-color pixels*/, piece->module, piece->colors,
@@ -306,7 +306,7 @@ process_finish:
 }
 
 #ifdef HAVE_OPENCL
-int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_in, cl_mem dev_out,
+int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_in, cl_mem dev_out,
                const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_develop_t *dev = self->dev;
@@ -387,47 +387,47 @@ void tiling_callback(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t
 }
 
 
-void init_global(dt_iop_module_so_t *module)
+void init_global(dt_iop_module_so_t *self)
 {
   const int program = 2; // basic.cl from programs.conf
   dt_iop_overexposed_global_data_t *gd = malloc(sizeof(dt_iop_overexposed_global_data_t));
-  module->data = gd;
+  self->data = gd;
   gd->kernel_overexposed = dt_opencl_create_kernel(program, "overexposed");
 }
 
 
-void cleanup_global(dt_iop_module_so_t *module)
+void cleanup_global(dt_iop_module_so_t *self)
 {
-  dt_iop_overexposed_global_data_t *gd = module->data;
+  dt_iop_overexposed_global_data_t *gd = self->data;
   dt_opencl_free_kernel(gd->kernel_overexposed);
-  free(module->data);
-  module->data = NULL;
+  free(self->data);
+  self->data = NULL;
 }
 
-void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_t *pipe,
+void commit_params(dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_t *pipe,
                    dt_dev_pixelpipe_iop_t *piece)
 {
   const gboolean fullpipe = piece->pipe->type & DT_DEV_PIXELPIPE_FULL;
   piece->enabled = self->dev->overexposed.enabled && fullpipe && self->dev->gui_attached;
 }
 
-void init_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
+void init_pipe(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
   piece->data = NULL;
 }
 
-void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
+void cleanup_pipe(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
 }
 
-void init(dt_iop_module_t *module)
+void init(dt_iop_module_t *self)
 {
-  module->params = calloc(1, sizeof(dt_iop_overexposed_t));
-  module->default_params = calloc(1, sizeof(dt_iop_overexposed_t));
-  module->hide_enable_button = TRUE;
-  module->default_enabled = TRUE;
-  module->params_size = sizeof(dt_iop_overexposed_t);
-  module->gui_data = NULL;
+  self->params = calloc(1, sizeof(dt_iop_overexposed_t));
+  self->default_params = calloc(1, sizeof(dt_iop_overexposed_t));
+  self->hide_enable_button = TRUE;
+  self->default_enabled = TRUE;
+  self->params_size = sizeof(dt_iop_overexposed_t);
+  self->gui_data = NULL;
 }
 
 // clang-format off

--- a/src/iop/rawdenoise.c
+++ b/src/iop/rawdenoise.c
@@ -489,11 +489,11 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
   }
 }
 
-void init(dt_iop_module_t *module)
+void init(dt_iop_module_t *self)
 {
-  dt_iop_default_init(module);
+  dt_iop_default_init(self);
 
-  dt_iop_rawdenoise_params_t *d = module->default_params;
+  dt_iop_rawdenoise_params_t *d = self->default_params;
 
   for(int k = 0; k < DT_IOP_RAWDENOISE_BANDS; k++)
   {
@@ -504,17 +504,17 @@ void init(dt_iop_module_t *module)
   }
 }
 
-void reload_defaults(dt_iop_module_t *module)
+void reload_defaults(dt_iop_module_t *self)
 {
   // can't be switched on for non-raw images:
-  module->hide_enable_button = !dt_image_is_raw(&module->dev->image_storage);
+  self->hide_enable_button = !dt_image_is_raw(&self->dev->image_storage);
 
-  if(module->widget)
+  if(self->widget)
   {
-    gtk_stack_set_visible_child_name(GTK_STACK(module->widget), module->hide_enable_button ? "non_raw" : "raw");
+    gtk_stack_set_visible_child_name(GTK_STACK(self->widget), self->hide_enable_button ? "non_raw" : "raw");
   }
 
-  module->default_enabled = FALSE;
+  self->default_enabled = FALSE;
 }
 
 void commit_params(dt_iop_module_t *self, dt_iop_params_t *params, dt_dev_pixelpipe_t *pipe,

--- a/src/iop/rawoverexposed.c
+++ b/src/iop/rawoverexposed.c
@@ -223,7 +223,7 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
 }
 
 #ifdef HAVE_OPENCL
-int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_in, cl_mem dev_out,
+int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_in, cl_mem dev_out,
                const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   const dt_iop_rawoverexposed_data_t *const d = piece->data;
@@ -363,9 +363,9 @@ error:
 }
 #endif
 
-void tiling_callback(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece,
+void tiling_callback(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece,
                      const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out,
-                     struct dt_develop_tiling_t *tiling)
+                     dt_develop_tiling_t *tiling)
 {
   dt_develop_t *dev = self->dev;
   const dt_image_t *const image = &(dev->image_storage);
@@ -410,25 +410,25 @@ void commit_params(dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_
   if(image->buf_dsc.datatype != TYPE_UINT16 || !image->buf_dsc.filters) piece->enabled = FALSE;
 }
 
-void init_global(dt_iop_module_so_t *module)
+void init_global(dt_iop_module_so_t *self)
 {
   const int program = 2; // basic.cl from programs.conf
-  module->data = malloc(sizeof(dt_iop_rawoverexposed_global_data_t));
-  dt_iop_rawoverexposed_global_data_t *gd = module->data;
+  self->data = malloc(sizeof(dt_iop_rawoverexposed_global_data_t));
+  dt_iop_rawoverexposed_global_data_t *gd = self->data;
   gd->kernel_rawoverexposed_mark_cfa = dt_opencl_create_kernel(program, "rawoverexposed_mark_cfa");
   gd->kernel_rawoverexposed_mark_solid = dt_opencl_create_kernel(program, "rawoverexposed_mark_solid");
   gd->kernel_rawoverexposed_falsecolor = dt_opencl_create_kernel(program, "rawoverexposed_falsecolor");
 }
 
 
-void cleanup_global(dt_iop_module_so_t *module)
+void cleanup_global(dt_iop_module_so_t *self)
 {
-  dt_iop_rawoverexposed_global_data_t *gd = module->data;
+  dt_iop_rawoverexposed_global_data_t *gd = self->data;
   dt_opencl_free_kernel(gd->kernel_rawoverexposed_falsecolor);
   dt_opencl_free_kernel(gd->kernel_rawoverexposed_mark_solid);
   dt_opencl_free_kernel(gd->kernel_rawoverexposed_mark_cfa);
-  free(module->data);
-  module->data = NULL;
+  free(self->data);
+  self->data = NULL;
 }
 
 void init_pipe(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
@@ -442,14 +442,14 @@ void cleanup_pipe(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelp
   piece->data = NULL;
 }
 
-void init(dt_iop_module_t *module)
+void init(dt_iop_module_t *self)
 {
-  module->params = calloc(1, sizeof(dt_iop_rawoverexposed_t));
-  module->default_params = calloc(1, sizeof(dt_iop_rawoverexposed_t));
-  module->hide_enable_button = TRUE;
-  module->default_enabled = TRUE;
-  module->params_size = sizeof(dt_iop_rawoverexposed_t);
-  module->gui_data = NULL;
+  self->params = calloc(1, sizeof(dt_iop_rawoverexposed_t));
+  self->default_params = calloc(1, sizeof(dt_iop_rawoverexposed_t));
+  self->hide_enable_button = TRUE;
+  self->default_enabled = TRUE;
+  self->params_size = sizeof(dt_iop_rawoverexposed_t);
+  self->gui_data = NULL;
 }
 
 // clang-format off

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -2049,14 +2049,14 @@ static gboolean rt_select_algorithm_callback(GtkToggleButton *togglebutton,
 
 static gboolean rt_showmask_callback(GtkToggleButton *togglebutton,
                                      GdkEventButton *event,
-                                     dt_iop_module_t *module)
+                                     dt_iop_module_t *self)
 {
   if(darktable.gui->reset) return TRUE;
 
-  dt_iop_retouch_gui_data_t *g = module->gui_data;
+  dt_iop_retouch_gui_data_t *g = self->gui_data;
 
   // if blend module is displaying mask do not display it here
-  if((module->request_mask_display != DT_DEV_PIXELPIPE_DISPLAY_NONE)
+  if((self->request_mask_display != DT_DEV_PIXELPIPE_DISPLAY_NONE)
      && !g->mask_display)
   {
     dt_control_log(_("cannot display masks when the blending mask is displayed"));
@@ -2067,11 +2067,11 @@ static gboolean rt_showmask_callback(GtkToggleButton *togglebutton,
 
   g->mask_display = !gtk_toggle_button_get_active(togglebutton);
 
-  if(module->off)
-    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(module->off), 1);
-  dt_iop_request_focus(module);
+  if(self->off)
+    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(self->off), 1);
+  dt_iop_request_focus(self);
 
-  dt_iop_refresh_center(module);
+  dt_iop_refresh_center(self);
 
   gtk_toggle_button_set_active(togglebutton, g->mask_display);
   return TRUE;
@@ -2079,17 +2079,17 @@ static gboolean rt_showmask_callback(GtkToggleButton *togglebutton,
 
 static gboolean rt_suppress_callback(GtkToggleButton *togglebutton,
                                      GdkEventButton *event,
-                                     dt_iop_module_t *module)
+                                     dt_iop_module_t *self)
 {
   if(darktable.gui->reset) return TRUE;
 
-  dt_iop_retouch_gui_data_t *g = module->gui_data;
+  dt_iop_retouch_gui_data_t *g = self->gui_data;
   g->suppress_mask = !gtk_toggle_button_get_active(togglebutton);
 
-  if(module->off) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(module->off), 1);
-  dt_iop_request_focus(module);
+  if(self->off) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(self->off), 1);
+  dt_iop_request_focus(self);
 
-  dt_iop_refresh_center(module);
+  dt_iop_refresh_center(self);
 
   gtk_toggle_button_set_active(togglebutton, g->suppress_mask);
   return TRUE;
@@ -2139,11 +2139,11 @@ void masks_selection_changed(dt_iop_module_t *self, const int form_selected_id)
   dt_iop_gui_leave_critical_section(self);
 }
 
-void init(dt_iop_module_t *module)
+void init(dt_iop_module_t *self)
 {
-  dt_iop_default_init(module);
+  dt_iop_default_init(self);
 
-  dt_iop_retouch_params_t *d = module->default_params;
+  dt_iop_retouch_params_t *d = self->default_params;
 
   d->preview_levels[0] = RETOUCH_PREVIEW_LVL_MIN;
   d->preview_levels[1] = 0.f;
@@ -2151,11 +2151,11 @@ void init(dt_iop_module_t *module)
   d->algorithm = dt_conf_get_int("plugins/darkroom/retouch/default_algo");
 }
 
-void init_global(dt_iop_module_so_t *module)
+void init_global(dt_iop_module_so_t *self)
 {
   const int program = 21; // retouch.cl, from programs.conf
   dt_iop_retouch_global_data_t *gd = malloc(sizeof(dt_iop_retouch_global_data_t));
-  module->data = gd;
+  self->data = gd;
   gd->kernel_retouch_clear_alpha =
     dt_opencl_create_kernel(program, "retouch_clear_alpha");
   gd->kernel_retouch_copy_alpha =
@@ -2178,9 +2178,9 @@ void init_global(dt_iop_module_so_t *module)
     dt_opencl_create_kernel(program, "retouch_copy_mask_to_alpha");
 }
 
-void cleanup_global(dt_iop_module_so_t *module)
+void cleanup_global(dt_iop_module_so_t *self)
 {
-  dt_iop_retouch_global_data_t *gd = module->data;
+  dt_iop_retouch_global_data_t *gd = self->data;
 
   dt_opencl_free_kernel(gd->kernel_retouch_clear_alpha);
   dt_opencl_free_kernel(gd->kernel_retouch_copy_alpha);
@@ -2193,12 +2193,11 @@ void cleanup_global(dt_iop_module_so_t *module)
   dt_opencl_free_kernel(gd->kernel_retouch_image_lab2rgb);
   dt_opencl_free_kernel(gd->kernel_retouch_copy_mask_to_alpha);
 
-  free(module->data);
-  module->data = NULL;
+  free(self->data);
+  self->data = NULL;
 }
 
-void gui_focus(dt_iop_module_t *self,
-               const gboolean in)
+void gui_focus(dt_iop_module_t *self, const gboolean in)
 {
   if(self->enabled
      && !darktable.develop->full.pipe->loading)

--- a/src/iop/rgbcurve.c
+++ b/src/iop/rgbcurve.c
@@ -1656,36 +1656,36 @@ void cleanup_pipe(dt_iop_module_t *self,
   piece->data = NULL;
 }
 
-void init(dt_iop_module_t *module)
+void init(dt_iop_module_t *self)
 {
-  dt_iop_default_init(module);
+  dt_iop_default_init(self);
 
-  module->request_histogram |= (DT_REQUEST_ON | DT_REQUEST_EXPANDED);
+  self->request_histogram |= (DT_REQUEST_ON | DT_REQUEST_EXPANDED);
 
-  dt_iop_rgbcurve_params_t *d = module->default_params;
+  dt_iop_rgbcurve_params_t *d = self->default_params;
 
   d->curve_nodes[0][1].x = d->curve_nodes[0][1].y =
   d->curve_nodes[1][1].x = d->curve_nodes[1][1].y =
   d->curve_nodes[2][1].x = d->curve_nodes[2][1].y = 1.0;
 
-  module->histogram_middle_grey = d->compensate_middle_grey;
+  self->histogram_middle_grey = d->compensate_middle_grey;
 }
 
-void init_global(dt_iop_module_so_t *module)
+void init_global(dt_iop_module_so_t *self)
 {
   const int program = 25; // rgbcurve.cl, from programs.conf
   dt_iop_rgbcurve_global_data_t *gd =dt_alloc1_align_type(dt_iop_rgbcurve_global_data_t);
-  module->data = gd;
+  self->data = gd;
 
   gd->kernel_rgbcurve = dt_opencl_create_kernel(program, "rgbcurve");
 }
 
-void cleanup_global(dt_iop_module_so_t *module)
+void cleanup_global(dt_iop_module_so_t *self)
 {
-  dt_iop_rgbcurve_global_data_t *gd = module->data;
+  dt_iop_rgbcurve_global_data_t *gd = self->data;
   dt_opencl_free_kernel(gd->kernel_rgbcurve);
-  dt_free_align(module->data);
-  module->data = NULL;
+  dt_free_align(self->data);
+  self->data = NULL;
 }
 
 // called from process*(), takes care of changed curve type

--- a/src/iop/spots.c
+++ b/src/iop/spots.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2011-2023 darktable developers.
+    Copyright (C) 2011-2024 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -745,21 +745,21 @@ void distort_mask(dt_iop_module_t *self,
 }
 
 /** init, cleanup, commit to pipeline */
-void init(dt_iop_module_t *module)
+void init(dt_iop_module_t *self)
 {
   // we don't need global data:
-  module->global_data = NULL; // malloc(sizeof(dt_iop_spots_global_data_t));
-  module->params = calloc(1, sizeof(dt_iop_spots_params_t));
-  module->default_params = calloc(1, sizeof(dt_iop_spots_params_t));
+  self->global_data = NULL; // malloc(sizeof(dt_iop_spots_global_data_t));
+  self->params = calloc(1, sizeof(dt_iop_spots_params_t));
+  self->default_params = calloc(1, sizeof(dt_iop_spots_params_t));
   // our module is disabled by default
   // by default:
-  module->default_enabled = FALSE;
-  module->params_size = sizeof(dt_iop_spots_params_t);
-  module->gui_data = NULL;
+  self->default_enabled = FALSE;
+  self->params_size = sizeof(dt_iop_spots_params_t);
+  self->gui_data = NULL;
   // init defaults:
   dt_iop_spots_params_t tmp = (dt_iop_spots_params_t){ { 0 }, { 2 } };
 
-  memcpy(module->default_params, &tmp, sizeof(dt_iop_spots_params_t));
+  memcpy(self->default_params, &tmp, sizeof(dt_iop_spots_params_t));
 }
 
 void gui_focus(dt_iop_module_t *self, gboolean in)

--- a/src/iop/tonecurve.c
+++ b/src/iop/tonecurve.c
@@ -914,13 +914,13 @@ void gui_update(dt_iop_module_t *self)
   gtk_widget_queue_draw(GTK_WIDGET(g->area));
 }
 
-void init(dt_iop_module_t *module)
+void init(dt_iop_module_t *self)
 {
-  dt_iop_default_init(module);
+  dt_iop_default_init(self);
 
-  module->request_histogram |=  (DT_REQUEST_ON | DT_REQUEST_EXPANDED);
+  self->request_histogram |=  (DT_REQUEST_ON | DT_REQUEST_EXPANDED);
 
-  dt_iop_tonecurve_params_t *d = module->default_params;
+  dt_iop_tonecurve_params_t *d = self->default_params;
 
   d->tonecurve_nodes[0] = 2;
   d->tonecurve_nodes[1] =
@@ -933,11 +933,11 @@ void init(dt_iop_module_t *module)
     d->tonecurve[2][1].x = d->tonecurve[2][1].y = 0.5f;
 }
 
-void init_global(dt_iop_module_so_t *module)
+void init_global(dt_iop_module_so_t *self)
 {
   const int program = 2; // basic.cl, from programs.conf
   dt_iop_tonecurve_global_data_t *gd = malloc(sizeof(dt_iop_tonecurve_global_data_t));
-  module->data = gd;
+  self->data = gd;
   gd->kernel_tonecurve = dt_opencl_create_kernel(program, "tonecurve");
   for(int k = 0; k < 3; k++)
   {
@@ -948,12 +948,12 @@ void init_global(dt_iop_module_so_t *module)
   }
 }
 
-void cleanup_global(dt_iop_module_so_t *module)
+void cleanup_global(dt_iop_module_so_t *self)
 {
-  dt_iop_tonecurve_global_data_t *gd = module->data;
+  dt_iop_tonecurve_global_data_t *gd = self->data;
   dt_opencl_free_kernel(gd->kernel_tonecurve);
-  free(module->data);
-  module->data = NULL;
+  free(self->data);
+  self->data = NULL;
 }
 
 static void logbase_callback(GtkWidget *slider,

--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -692,7 +692,7 @@ static float get_luminance_from_buffer(const float *const buffer,
   return luminance;
 }
 
-static void _get_point(dt_iop_module_t *module,
+static void _get_point(dt_iop_module_t *self,
                        const int c_x,
                        const int c_y,
                        int *x,
@@ -704,7 +704,7 @@ static void _get_point(dt_iop_module_t *module,
   //       is moved below rotation & perspective it will fail as we are
   //       then missing all the transform after tone-eq.
   const double crop_order =
-    dt_ioppr_get_iop_order(module->dev->iop_order_list, "crop", 0);
+    dt_ioppr_get_iop_order(self->dev->iop_order_list, "crop", 0);
 
   float pts[2] = { c_x, c_y };
 
@@ -1572,18 +1572,18 @@ static inline gboolean update_curve_lut(dt_iop_module_t *self)
 }
 
 
-void init_global(dt_iop_module_so_t *module)
+void init_global(dt_iop_module_so_t *self)
 {
   dt_iop_toneequalizer_global_data_t *gd = malloc(sizeof(dt_iop_toneequalizer_global_data_t));
 
-  module->data = gd;
+  self->data = gd;
 }
 
 
-void cleanup_global(dt_iop_module_so_t *module)
+void cleanup_global(dt_iop_module_so_t *self)
 {
-  free(module->data);
-  module->data = NULL;
+  free(self->data);
+  self->data = NULL;
 }
 
 
@@ -1669,9 +1669,8 @@ void cleanup_pipe(dt_iop_module_t *self,
 
 void show_guiding_controls(dt_iop_module_t *self)
 {
-  dt_iop_module_t *module = (dt_iop_module_t *)self;
   dt_iop_toneequalizer_gui_data_t *g = self->gui_data;
-  const dt_iop_toneequalizer_params_t *p = module->params;
+  const dt_iop_toneequalizer_params_t *p = self->params;
 
   switch(p->details)
   {

--- a/src/iop/useless.c
+++ b/src/iop/useless.c
@@ -434,7 +434,7 @@ void process(dt_iop_module_t *self,
 }
 
 /** Optional init and cleanup */
-void init(dt_iop_module_t *module)
+void init(dt_iop_module_t *self)
 {
   // Allocates memory for a module instance and fills default_params.
   // If this callback is not provided, the standard implementation in
@@ -447,7 +447,7 @@ void init(dt_iop_module_t *module)
   // initialisation.  The values in params will not be used and
   // default_params can be overwritten by reload_params on a per-image
   // basis.
-  dt_iop_default_init(module);
+  dt_iop_default_init(self);
 
   // Any non-default settings; for example disabling the on/off switch:
   module->hide_enable_button = TRUE;
@@ -457,26 +457,26 @@ void init(dt_iop_module_t *module)
   // label with an explanatory text when the module can't be used.
 }
 
-void init_global(dt_iop_module_so_t *module)
+void init_global(dt_iop_module_so_t *self)
 {
-  module->data = malloc(sizeof(dt_iop_useless_global_data_t));
+  self->data = malloc(sizeof(dt_iop_useless_global_data_t));
 }
 
-void cleanup(dt_iop_module_t *module)
+void cleanup(dt_iop_module_t *self)
 {
   // Releases any memory allocated in init(module) Implement this
   // function explicitly if the module allocates additional memory
   // besides (default_)params.  this is rare.
-  free(module->params);
-  module->params = NULL;
-  free(module->default_params);
-  module->default_params = NULL;
+  free(self->params);
+  self->params = NULL;
+  free(self->default_params);
+  self->default_params = NULL;
 }
 
-void cleanup_global(dt_iop_module_so_t *module)
+void cleanup_global(dt_iop_module_so_t *self)
 {
-  free(module->data);
-  module->data = NULL;
+  free(self->data);
+  self->data = NULL;
 }
 
 /** Put your local callbacks here, be sure to make them static so they
@@ -582,23 +582,23 @@ void gui_update(dt_iop_module_t *self)
 
 /** optional: if this exists, it will be called to init new defaults if a new image is
  * loaded from film strip mode. */
-void reload_defaults(dt_iop_module_t *module)
+void reload_defaults(dt_iop_module_t *self)
 {
   // This only has to be provided if module settings or default_params
   // need to depend on image type (raw?) or exif data.  Make sure to
   // always reset to the default for non-special cases, otherwise the
   // override will stick when switching to another image.
-  dt_iop_useless_params_t *d = module->default_params;
+  dt_iop_useless_params_t *d = self->default_params;
 
   // As an example, switch off for non-raw images. The enable button
   // was already hidden in init().
-  if(!dt_image_is_raw(&module->dev->image_storage))
+  if(!dt_image_is_raw(&self->dev->image_storage))
   {
-    module->default_enabled = FALSE;
+    self->default_enabled = FALSE;
   }
   else
   {
-    module->default_enabled = TRUE;
+    self->default_enabled = TRUE;
     d->checker_scale = 3; // something dependent on exif, for example.
   }
 
@@ -608,7 +608,7 @@ void reload_defaults(dt_iop_module_t *module)
   // the default values in widgets. Resetting the individual widgets
   // will then have the same effect as resetting the whole module at
   // once.
-  dt_iop_useless_gui_data_t *g = module->gui_data;
+  dt_iop_useless_gui_data_t *g = self->gui_data;
   if(g)
   {
     dt_bauhaus_slider_set_default(g->scale, d->checker_scale);

--- a/src/iop/watermark.c
+++ b/src/iop/watermark.c
@@ -1265,11 +1265,11 @@ void gui_changed(dt_iop_module_t *self,
   }
 }
 
-void init(dt_iop_module_t *module)
+void init(dt_iop_module_t *self)
 {
-  dt_iop_default_init(module);
+  dt_iop_default_init(self);
 
-  dt_iop_watermark_params_t *d = module->default_params;
+  dt_iop_watermark_params_t *d = self->default_params;
 
   g_strlcpy(d->filename, "darktable.svg", sizeof(d->filename));
   g_strlcpy(d->font, "DejaVu Sans 10", sizeof(d->font));


### PR DESCRIPTION
Just code style unify, as that's not coherently used in the iop/lib modules.

1. If the pointer `dt_iop_module_t *module` is used in the module "itself", it should be `dt_iop_module_t *self` for clarity.
2. We keep `dt_iop_module_t *module` elsewhere.

Otherwise a few remaining structs in function parameters, overcastings and formatting.