### PR TITLE
Further unification: dt_iop_module_so_t *module

### DIFF
--- a/src/develop/blends/blendif_lab.c
+++ b/src/develop/blends/blendif_lab.c
@@ -188,7 +188,7 @@ static void _blendif_combine_channels(const float *const restrict pixels,
   }
 }
 
-void dt_develop_blendif_lab_make_mask(struct dt_dev_pixelpipe_iop_t *piece,
+void dt_develop_blendif_lab_make_mask(dt_dev_pixelpipe_iop_t *piece,
                                       const float *const restrict a,
                                       const float *const restrict b,
                                       const struct dt_iop_roi_t *const roi_in,

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -1312,7 +1312,7 @@ static float _brush_get_position_in_segment(const float x,
   return tmin;
 }
 
-static int _brush_events_mouse_scrolled(struct dt_iop_module_t *module,
+static int _brush_events_mouse_scrolled(dt_iop_module_t *module,
                                         const float pzx,
                                         const float pzy,
                                         const int up,
@@ -1465,7 +1465,7 @@ static int _brush_events_mouse_scrolled(struct dt_iop_module_t *module,
   return 0;
 }
 
-static int _brush_events_button_pressed(struct dt_iop_module_t *module,
+static int _brush_events_button_pressed(dt_iop_module_t *module,
                                         const float pzx,
                                         const float pzy,
                                         const double pressure,
@@ -1798,7 +1798,7 @@ static int _brush_events_button_pressed(struct dt_iop_module_t *module,
   return 0;
 }
 
-static int _brush_events_button_released(struct dt_iop_module_t *module,
+static int _brush_events_button_released(dt_iop_module_t *module,
                                          const float pzx,
                                          const float pzy,
                                          const int which,

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -107,7 +107,7 @@ static void _circle_get_distance(const float x,
   *inside = TRUE;
 }
 
-static int _circle_events_mouse_scrolled(struct dt_iop_module_t *module,
+static int _circle_events_mouse_scrolled(dt_iop_module_t *module,
                                          const float pzx,
                                          const float pzy,
                                          const int up,
@@ -201,7 +201,7 @@ static int _circle_events_mouse_scrolled(struct dt_iop_module_t *module,
   return 0;
 }
 
-static int _circle_events_button_pressed(struct dt_iop_module_t *module,
+static int _circle_events_button_pressed(dt_iop_module_t *module,
                                          float pzx, float pzy,
                                          const double pressure,
                                          const int which,
@@ -385,7 +385,7 @@ static int _circle_events_button_pressed(struct dt_iop_module_t *module,
   return 0;
 }
 
-static int _circle_events_button_released(struct dt_iop_module_t *module,
+static int _circle_events_button_released(dt_iop_module_t *module,
                                           const float pzx,
                                           const float pzy,
                                           const int which,
@@ -507,7 +507,7 @@ static int _circle_events_button_released(struct dt_iop_module_t *module,
   return 0;
 }
 
-static int _circle_events_mouse_moved(struct dt_iop_module_t *module,
+static int _circle_events_mouse_moved(dt_iop_module_t *module,
                                       const float pzx,
                                       const float pzy,
                                       const double pressure,
@@ -1405,7 +1405,7 @@ static void _circle_sanitize_config(dt_masks_type_t type)
   dt_conf_get_and_sanitize_float(DT_MASKS_CONF(type, circle, border), MIN_CIRCLE_BORDER, 0.5f);
 }
 
-static void _circle_set_form_name(struct dt_masks_form_t *const form,
+static void _circle_set_form_name(dt_masks_form_t *const form,
                                   const size_t nb)
 {
   snprintf(form->name, sizeof(form->name), _("circle #%d"), (int)nb);

--- a/src/develop/masks/ellipse.c
+++ b/src/develop/masks/ellipse.c
@@ -419,7 +419,7 @@ static int _ellipse_get_points_border(dt_develop_t *dev,
   return 0;
 }
 
-static int _ellipse_events_mouse_scrolled(struct dt_iop_module_t *module,
+static int _ellipse_events_mouse_scrolled(dt_iop_module_t *module,
                                           const float pzx,
                                           const float pzy,
                                           const int up,
@@ -1969,7 +1969,7 @@ static GSList *_ellipse_setup_mouse_actions(const struct dt_masks_form_t *const 
   return lm;
 }
 
-static void _ellipse_set_form_name(struct dt_masks_form_t *const form,
+static void _ellipse_set_form_name(dt_masks_form_t *const form,
                                    const size_t nb)
 {
   snprintf(form->name, sizeof(form->name), _("ellipse #%d"), (int)nb);

--- a/src/develop/masks/gradient.c
+++ b/src/develop/masks/gradient.c
@@ -1430,7 +1430,7 @@ static void _gradient_sanitize_config(dt_masks_type_t type)
   dt_conf_set_float(DT_MASKS_CONF(type, gradient, curvature), 0.0f);
 }
 
-static void _gradient_set_form_name(struct dt_masks_form_t *const form,
+static void _gradient_set_form_name(dt_masks_form_t *const form,
                                     const size_t nb)
 {
   snprintf(form->name, sizeof(form->name), _("gradient #%d"), (int)nb);

--- a/src/develop/tiling.c
+++ b/src/develop/tiling.c
@@ -488,8 +488,8 @@ static int _simplex(double (*objfunc)(double[], void *[]), double start[], int n
 }
 
 
-static int _nm_fit_output_to_input_roi(struct dt_iop_module_t *self,
-                                       struct dt_dev_pixelpipe_iop_t *piece,
+static int _nm_fit_output_to_input_roi(dt_iop_module_t *self,
+                                       dt_dev_pixelpipe_iop_t *piece,
                                        const dt_iop_roi_t *iroi,
                                        dt_iop_roi_t *oroi,
                                        int delta)
@@ -519,8 +519,8 @@ static int _nm_fit_output_to_input_roi(struct dt_iop_module_t *self,
 /* find a matching oroi_full by probing start value of oroi and get corresponding input roi into iroi_probe.
    We search in two steps. first by a simplicistic iterative search which will succeed in most cases.
    If this does not converge, we do a downhill simplex (nelder-mead) fitting */
-static int _fit_output_to_input_roi(struct dt_iop_module_t *self,
-                                    struct dt_dev_pixelpipe_iop_t *piece,
+static int _fit_output_to_input_roi(dt_iop_module_t *self,
+                                    dt_dev_pixelpipe_iop_t *piece,
                                     const dt_iop_roi_t *iroi,
                                     dt_iop_roi_t *oroi,
                                     int delta,
@@ -564,8 +564,8 @@ static int _fit_output_to_input_roi(struct dt_iop_module_t *self,
 
 
 /* simple tiling algorithm for roi_in == roi_out, i.e. for pixel to pixel modules/operations */
-static void _default_process_tiling_ptp(struct dt_iop_module_t *self,
-                                        struct dt_dev_pixelpipe_iop_t *piece,
+static void _default_process_tiling_ptp(dt_iop_module_t *self,
+                                        dt_dev_pixelpipe_iop_t *piece,
                                         const void *const ivoid,
                                         void *const ovoid,
                                         const dt_iop_roi_t *const roi_in,
@@ -824,8 +824,8 @@ fallback:
 
 /* more elaborate tiling algorithm for roi_in != roi_out: slower than the ptp variant,
    more tiles and larger overlap */
-static void _default_process_tiling_roi(struct dt_iop_module_t *self,
-                                        struct dt_dev_pixelpipe_iop_t *piece,
+static void _default_process_tiling_roi(dt_iop_module_t *self,
+                                        dt_dev_pixelpipe_iop_t *piece,
                                         const void *const ivoid,
                                         void *const ovoid,
                                         const dt_iop_roi_t *const roi_in,
@@ -1176,8 +1176,8 @@ fallback:
    _default_process_tiling_roi() takes care of all other cases where image gets distorted and for module
    "clipping",
    "flip" as this may flip or mirror the image. */
-void default_process_tiling(struct dt_iop_module_t *self,
-                            struct dt_dev_pixelpipe_iop_t *piece,
+void default_process_tiling(dt_iop_module_t *self,
+                            dt_dev_pixelpipe_iop_t *piece,
                             const void *const ivoid,
                             void *const ovoid,
                             const dt_iop_roi_t *const roi_in,
@@ -1191,8 +1191,8 @@ void default_process_tiling(struct dt_iop_module_t *self,
   return;
 }
 
-float dt_tiling_estimate_cpumem(struct dt_develop_tiling_t *tiling,
-                                struct dt_dev_pixelpipe_iop_t *piece,
+float dt_tiling_estimate_cpumem(dt_develop_tiling_t *tiling,
+                                dt_dev_pixelpipe_iop_t *piece,
                                 const dt_iop_roi_t *const roi_in,
                                 const dt_iop_roi_t *const roi_out,
                                 const int max_bpp)
@@ -1252,8 +1252,8 @@ float dt_tiling_estimate_cpumem(struct dt_develop_tiling_t *tiling,
 }
 
 #ifdef HAVE_OPENCL
-float dt_tiling_estimate_clmem(struct dt_develop_tiling_t *tiling,
-                               struct dt_dev_pixelpipe_iop_t *piece,
+float dt_tiling_estimate_clmem(dt_develop_tiling_t *tiling,
+                               dt_dev_pixelpipe_iop_t *piece,
                                const dt_iop_roi_t *const roi_in,
                                const dt_iop_roi_t *const roi_out,
                                const int max_bpp)
@@ -1313,8 +1313,8 @@ float dt_tiling_estimate_clmem(struct dt_develop_tiling_t *tiling,
 }
 
 /* simple tiling algorithm for roi_in == roi_out, i.e. for pixel to pixel modules/operations */
-static int _default_process_tiling_cl_ptp(struct dt_iop_module_t *self,
-                                          struct dt_dev_pixelpipe_iop_t *piece,
+static int _default_process_tiling_cl_ptp(dt_iop_module_t *self,
+                                          dt_dev_pixelpipe_iop_t *piece,
                                           const void *const ivoid,
                                           void *const ovoid,
                                           const dt_iop_roi_t *const roi_in,
@@ -1691,8 +1691,8 @@ error:
 
 /* more elaborate tiling algorithm for roi_in != roi_out: slower than the ptp variant,
    more tiles and larger overlap */
-static int _default_process_tiling_cl_roi(struct dt_iop_module_t *self,
-                                          struct dt_dev_pixelpipe_iop_t *piece,
+static int _default_process_tiling_cl_roi(dt_iop_module_t *self,
+                                          dt_dev_pixelpipe_iop_t *piece,
                                           const void *const ivoid,
                                           void *const ovoid,
                                           const dt_iop_roi_t *const roi_in,
@@ -2157,8 +2157,8 @@ error:
 /* if a module does not implement process_tiling_cl() by itself, this function is called instead.
    _default_process_tiling_cl_ptp() is able to handle standard cases where pixels do not change their places.
    _default_process_tiling_cl_roi() takes care of all other cases where image gets distorted. */
-int default_process_tiling_cl(struct dt_iop_module_t *self,
-                              struct dt_dev_pixelpipe_iop_t *piece,
+int default_process_tiling_cl(dt_iop_module_t *self,
+                              dt_dev_pixelpipe_iop_t *piece,
                               const void *const ivoid,
                               void *const ovoid,
                               const dt_iop_roi_t *const roi_in,
@@ -2172,8 +2172,8 @@ int default_process_tiling_cl(struct dt_iop_module_t *self,
 }
 
 #else
-int default_process_tiling_cl(struct dt_iop_module_t *self,
-                              struct dt_dev_pixelpipe_iop_t *piece,
+int default_process_tiling_cl(dt_iop_module_t *self,
+                              dt_dev_pixelpipe_iop_t *piece,
                               const void *const ivoid,
                               void *const ovoid,
                               const dt_iop_roi_t *const roi_in,
@@ -2191,8 +2191,8 @@ int default_process_tiling_cl(struct dt_iop_module_t *self,
    alignment required. Simple pixel to pixel modules (take tonecurve as an example) can happily
    live with that.
    (1) Small overhead like look-up-tables in tonecurve can be ignored safely. */
-void default_tiling_callback(struct dt_iop_module_t *self,
-                             struct dt_dev_pixelpipe_iop_t *piece,
+void default_tiling_callback(dt_iop_module_t *self,
+                             dt_dev_pixelpipe_iop_t *piece,
                              const dt_iop_roi_t *roi_in,
                              const dt_iop_roi_t *roi_out,
                              struct dt_develop_tiling_t *tiling)

--- a/src/iop/basicadj.c
+++ b/src/iop/basicadj.c
@@ -466,21 +466,21 @@ void gui_post_expose(dt_iop_module_t *self,
   cairo_stroke(cr);
 }
 
-void init_global(dt_iop_module_so_t *module)
+void init_global(dt_iop_module_so_t *self)
 {
   const int program = 24; // basicadj.cl, from programs.conf
   dt_iop_basicadj_global_data_t *gd = malloc(sizeof(dt_iop_basicadj_global_data_t));
-  module->data = gd;
+  self->data = gd;
 
   gd->kernel_basicadj = dt_opencl_create_kernel(program, "basicadj");
 }
 
-void cleanup_global(dt_iop_module_so_t *module)
+void cleanup_global(dt_iop_module_so_t *self)
 {
-  dt_iop_basicadj_global_data_t *gd = module->data;
+  dt_iop_basicadj_global_data_t *gd = self->data;
   dt_opencl_free_kernel(gd->kernel_basicadj);
-  free(module->data);
-  module->data = NULL;
+  free(self->data);
+  self->data = NULL;
 }
 
 void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker,

--- a/src/iop/bloom.c
+++ b/src/iop/bloom.c
@@ -359,11 +359,11 @@ void tiling_callback(dt_iop_module_t *self,
   return;
 }
 
-void init_global(dt_iop_module_so_t *module)
+void init_global(dt_iop_module_so_t *self)
 {
   const int program = 12; // bloom.cl, from programs.conf
   dt_iop_bloom_global_data_t *gd = malloc(sizeof(dt_iop_bloom_global_data_t));
-  module->data = gd;
+  self->data = gd;
 
   gd->kernel_bloom_threshold = dt_opencl_create_kernel(program, "bloom_threshold");
   gd->kernel_bloom_hblur = dt_opencl_create_kernel(program, "bloom_hblur");
@@ -371,15 +371,15 @@ void init_global(dt_iop_module_so_t *module)
   gd->kernel_bloom_mix = dt_opencl_create_kernel(program, "bloom_mix");
 }
 
-void cleanup_global(dt_iop_module_so_t *module)
+void cleanup_global(dt_iop_module_so_t *self)
 {
-  const dt_iop_bloom_global_data_t *gd = module->data;
+  const dt_iop_bloom_global_data_t *gd = self->data;
   dt_opencl_free_kernel(gd->kernel_bloom_threshold);
   dt_opencl_free_kernel(gd->kernel_bloom_hblur);
   dt_opencl_free_kernel(gd->kernel_bloom_vblur);
   dt_opencl_free_kernel(gd->kernel_bloom_mix);
-  free(module->data);
-  module->data = NULL;
+  free(self->data);
+  self->data = NULL;
 }
 
 void commit_params(dt_iop_module_t *self,

--- a/src/iop/blurs.c
+++ b/src/iop/blurs.c
@@ -634,21 +634,21 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
   return err;
 }
 
-void init_global(dt_iop_module_so_t *module)
+void init_global(dt_iop_module_so_t *self)
 {
   const int program = 34;
   dt_iop_blurs_global_data_t *gd = malloc(sizeof(dt_iop_blurs_global_data_t));
-  module->data = gd;
+  self->data = gd;
   gd->kernel_blurs_convolve = dt_opencl_create_kernel(program, "convolve");
 }
 
 
-void cleanup_global(dt_iop_module_so_t *module)
+void cleanup_global(dt_iop_module_so_t *self)
 {
-  dt_iop_blurs_global_data_t *gd = module->data;
+  dt_iop_blurs_global_data_t *gd = self->data;
   dt_opencl_free_kernel(gd->kernel_blurs_convolve);
-  free(module->data);
-  module->data = NULL;
+  free(self->data);
+  self->data = NULL;
 }
 #endif
 

--- a/src/iop/borders.c
+++ b/src/iop/borders.c
@@ -655,22 +655,22 @@ error:
 #endif
 
 
-void init_global(dt_iop_module_so_t *module)
+void init_global(dt_iop_module_so_t *self)
 {
   const int program = 2; // basic.cl from programs.conf
   dt_iop_borders_global_data_t *gd
       = (dt_iop_borders_global_data_t *)malloc(sizeof(dt_iop_borders_global_data_t));
-  module->data = gd;
+  self->data = gd;
   gd->kernel_borders_fill = dt_opencl_create_kernel(program, "borders_fill");
 }
 
 
-void cleanup_global(dt_iop_module_so_t *module)
+void cleanup_global(dt_iop_module_so_t *self)
 {
-  dt_iop_borders_global_data_t *gd = module->data;
+  dt_iop_borders_global_data_t *gd = self->data;
   dt_opencl_free_kernel(gd->kernel_borders_fill);
-  free(module->data);
-  module->data = NULL;
+  free(self->data);
+  self->data = NULL;
 }
 
 

--- a/src/iop/censorize.c
+++ b/src/iop/censorize.c
@@ -395,20 +395,20 @@ void tiling_callback(dt_iop_module_t *self,
   tiling->yalign = 1;
 }
 
-void init_global(dt_iop_module_so_t *module)
+void init_global(dt_iop_module_so_t *self)
 {
   const int program = 6; // gaussian.cl, from programs.conf
   dt_iop_censorize_global_data_t *gd = malloc(sizeof(dt_iop_censorize_global_data_t));
-  module->data = gd;
+  self->data = gd;
   gd->kernel_lowpass_mix = dt_opencl_create_kernel(program, "lowpass_mix");
 }
 
-void cleanup_global(dt_iop_module_so_t *module)
+void cleanup_global(dt_iop_module_so_t *self)
 {
-  dt_iop_censorize_global_data_t *gd = module->data;
+  dt_iop_censorize_global_data_t *gd = self->data;
   dt_opencl_free_kernel(gd->kernel_lowpass_mix);
-  free(module->data);
-  module->data = NULL;
+  free(self->data);
+  self->data = NULL;
 }
 
 #endif

--- a/src/iop/channelmixer.c
+++ b/src/iop/channelmixer.c
@@ -422,21 +422,21 @@ error:
 }
 #endif
 
-void init_global(dt_iop_module_so_t *module)
+void init_global(dt_iop_module_so_t *self)
 {
   const int program = 8; // extended.cl, from programs.conf
   dt_iop_channelmixer_global_data_t *gd
       = (dt_iop_channelmixer_global_data_t *)malloc(sizeof(dt_iop_channelmixer_global_data_t));
-  module->data = gd;
+  self->data = gd;
   gd->kernel_channelmixer = dt_opencl_create_kernel(program, "channelmixer");
 }
 
-void cleanup_global(dt_iop_module_so_t *module)
+void cleanup_global(dt_iop_module_so_t *self)
 {
-  dt_iop_channelmixer_global_data_t *gd = module->data;
+  dt_iop_channelmixer_global_data_t *gd = self->data;
   dt_opencl_free_kernel(gd->kernel_channelmixer);
-  free(module->data);
-  module->data = NULL;
+  free(self->data);
+  self->data = NULL;
 }
 
 static void red_callback(GtkWidget *slider, dt_iop_module_t *self)

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -2407,12 +2407,12 @@ error:
   return err;
 }
 
-void init_global(dt_iop_module_so_t *module)
+void init_global(dt_iop_module_so_t *self)
 {
   const int program = 32; // extended.cl in programs.conf
   dt_iop_channelmixer_rgb_global_data_t *gd = malloc(sizeof(dt_iop_channelmixer_rgb_global_data_t));
 
-  module->data = gd;
+  self->data = gd;
   gd->kernel_channelmixer_rgb_cat16 =
     dt_opencl_create_kernel(program, "channelmixerrgb_CAT16");
   gd->kernel_channelmixer_rgb_bradford_full =
@@ -2426,16 +2426,16 @@ void init_global(dt_iop_module_so_t *module)
 }
 
 
-void cleanup_global(dt_iop_module_so_t *module)
+void cleanup_global(dt_iop_module_so_t *self)
 {
-  dt_iop_channelmixer_rgb_global_data_t *gd = module->data;
+  dt_iop_channelmixer_rgb_global_data_t *gd = self->data;
   dt_opencl_free_kernel(gd->kernel_channelmixer_rgb_cat16);
   dt_opencl_free_kernel(gd->kernel_channelmixer_rgb_bradford_full);
   dt_opencl_free_kernel(gd->kernel_channelmixer_rgb_bradford_linear);
   dt_opencl_free_kernel(gd->kernel_channelmixer_rgb_xyz);
   dt_opencl_free_kernel(gd->kernel_channelmixer_rgb_rgb);
-  free(module->data);
-  module->data = NULL;
+  free(self->data);
+  self->data = NULL;
 }
 #endif
 

--- a/src/iop/clahe.c
+++ b/src/iop/clahe.c
@@ -86,7 +86,7 @@ dt_iop_colorspace_type_t default_colorspace(dt_iop_module_t *self,
   return IOP_CS_RGB;
 }
 
-void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
+void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
              void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_rlce_data_t *data = piece->data;
@@ -277,7 +277,7 @@ void init_pipe(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe
   piece->data = calloc(1, sizeof(dt_iop_rlce_data_t));
 }
 
-void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
+void cleanup_pipe(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
   free(piece->data);
   piece->data = NULL;

--- a/src/iop/clipping.c
+++ b/src/iop/clipping.c
@@ -1158,11 +1158,11 @@ error:
 }
 #endif
 
-void init_global(dt_iop_module_so_t *module)
+void init_global(dt_iop_module_so_t *self)
 {
   const int program = 2; // basic.cl from programs.conf
   dt_iop_clipping_global_data_t *gd = malloc(sizeof(dt_iop_clipping_global_data_t));
-  module->data = gd;
+  self->data = gd;
   gd->kernel_clip_rotate_bilinear = dt_opencl_create_kernel(program, "clip_rotate_bilinear");
   gd->kernel_clip_rotate_bicubic = dt_opencl_create_kernel(program, "clip_rotate_bicubic");
   gd->kernel_clip_rotate_lanczos2 = dt_opencl_create_kernel(program, "clip_rotate_lanczos2");
@@ -1170,15 +1170,15 @@ void init_global(dt_iop_module_so_t *module)
 }
 
 
-void cleanup_global(dt_iop_module_so_t *module)
+void cleanup_global(dt_iop_module_so_t *self)
 {
-  dt_iop_clipping_global_data_t *gd = module->data;
+  dt_iop_clipping_global_data_t *gd = self->data;
   dt_opencl_free_kernel(gd->kernel_clip_rotate_bilinear);
   dt_opencl_free_kernel(gd->kernel_clip_rotate_bicubic);
   dt_opencl_free_kernel(gd->kernel_clip_rotate_lanczos2);
   dt_opencl_free_kernel(gd->kernel_clip_rotate_lanczos3);
-  free(module->data);
-  module->data = NULL;
+  free(self->data);
+  self->data = NULL;
 }
 
 

--- a/src/iop/colisa.c
+++ b/src/iop/colisa.c
@@ -255,21 +255,21 @@ void cleanup_pipe(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelp
   piece->data = NULL;
 }
 
-void init_global(dt_iop_module_so_t *module)
+void init_global(dt_iop_module_so_t *self)
 {
   const int program = 2; // basic.cl, from programs.conf
   dt_iop_colisa_global_data_t *gd = malloc(sizeof(dt_iop_colisa_global_data_t));
-  module->data = gd;
+  self->data = gd;
   gd->kernel_colisa = dt_opencl_create_kernel(program, "colisa");
 }
 
 
-void cleanup_global(dt_iop_module_so_t *module)
+void cleanup_global(dt_iop_module_so_t *self)
 {
-  dt_iop_colisa_global_data_t *gd = module->data;
+  dt_iop_colisa_global_data_t *gd = self->data;
   dt_opencl_free_kernel(gd->kernel_colisa);
-  free(module->data);
-  module->data = NULL;
+  free(self->data);
+  self->data = NULL;
 }
 
 

--- a/src/iop/colorbalance.c
+++ b/src/iop/colorbalance.c
@@ -1375,24 +1375,24 @@ void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker,
   _check_tuner_picker_labels(self);
 }
 
-void init_global(dt_iop_module_so_t *module)
+void init_global(dt_iop_module_so_t *self)
 {
   const int program = 8; // extended.cl, from programs.conf
   dt_iop_colorbalance_global_data_t *gd = malloc(sizeof(dt_iop_colorbalance_global_data_t));
-  module->data = gd;
+  self->data = gd;
   gd->kernel_colorbalance = dt_opencl_create_kernel(program, "colorbalance");
   gd->kernel_colorbalance_lgg = dt_opencl_create_kernel(program, "colorbalance_lgg");
   gd->kernel_colorbalance_cdl = dt_opencl_create_kernel(program, "colorbalance_cdl");
 }
 
-void cleanup_global(dt_iop_module_so_t *module)
+void cleanup_global(dt_iop_module_so_t *self)
 {
-  dt_iop_colorbalance_global_data_t *gd = module->data;
+  dt_iop_colorbalance_global_data_t *gd = self->data;
   dt_opencl_free_kernel(gd->kernel_colorbalance);
   dt_opencl_free_kernel(gd->kernel_colorbalance_lgg);
   dt_opencl_free_kernel(gd->kernel_colorbalance_cdl);
-  free(module->data);
-  module->data = NULL;
+  free(self->data);
+  self->data = NULL;
 }
 
 void commit_params(dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_t *pipe,

--- a/src/iop/colorbalancergb.c
+++ b/src/iop/colorbalancergb.c
@@ -1067,22 +1067,22 @@ error:
   return err;
 }
 
-void init_global(dt_iop_module_so_t *module)
+void init_global(dt_iop_module_so_t *self)
 {
   const int program = 8; // extended.cl in programs.conf
   dt_iop_colorbalancergb_global_data_t *gd = malloc(sizeof(dt_iop_colorbalancergb_global_data_t));
 
-  module->data = gd;
+  self->data = gd;
   gd->kernel_colorbalance_rgb = dt_opencl_create_kernel(program, "colorbalancergb");
 }
 
 
-void cleanup_global(dt_iop_module_so_t *module)
+void cleanup_global(dt_iop_module_so_t *self)
 {
-  dt_iop_colorbalancergb_global_data_t *gd = module->data;
+  dt_iop_colorbalancergb_global_data_t *gd = self->data;
   dt_opencl_free_kernel(gd->kernel_colorbalance_rgb);
-  free(module->data);
-  module->data = NULL;
+  free(self->data);
+  self->data = NULL;
 }
 #endif
 

--- a/src/iop/colorchecker.c
+++ b/src/iop/colorchecker.c
@@ -841,7 +841,7 @@ void _colorchecker_rebuild_patch_list(dt_iop_module_t *self)
   }
 }
 
-void _colorchecker_update_sliders(struct dt_iop_module_t *self)
+void _colorchecker_update_sliders(dt_iop_module_t *self)
 {
   dt_iop_colorchecker_params_t *p = self->params;
   dt_iop_colorchecker_gui_data_t *g = self->gui_data;

--- a/src/iop/colorcontrast.c
+++ b/src/iop/colorcontrast.c
@@ -250,20 +250,20 @@ int process_cl(dt_iop_module_t *self,
 #endif
 
 
-void init_global(dt_iop_module_so_t *module)
+void init_global(dt_iop_module_so_t *self)
 {
   const int program = 8; // extended.cl, from programs.conf
   dt_iop_colorcontrast_global_data_t *gd = malloc(sizeof(dt_iop_colorcontrast_global_data_t));
-  module->data = gd;
+  self->data = gd;
   gd->kernel_colorcontrast = dt_opencl_create_kernel(program, "colorcontrast");
 }
 
-void cleanup_global(dt_iop_module_so_t *module)
+void cleanup_global(dt_iop_module_so_t *self)
 {
-  dt_iop_colorcontrast_global_data_t *gd = module->data;
+  dt_iop_colorcontrast_global_data_t *gd = self->data;
   dt_opencl_free_kernel(gd->kernel_colorcontrast);
-  free(module->data);
-  module->data = NULL;
+  free(self->data);
+  self->data = NULL;
 }
 
 

--- a/src/iop/colorcorrection.c
+++ b/src/iop/colorcorrection.c
@@ -171,21 +171,21 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
 #endif
 
 
-void init_global(dt_iop_module_so_t *module)
+void init_global(dt_iop_module_so_t *self)
 {
   const int program = 2; // basic.cl from programs.conf
   dt_iop_colorcorrection_global_data_t *gd = malloc(sizeof(dt_iop_colorcorrection_global_data_t));
-  module->data = gd;
+  self->data = gd;
   gd->kernel_colorcorrection = dt_opencl_create_kernel(program, "colorcorrection");
 }
 
 
-void cleanup_global(dt_iop_module_so_t *module)
+void cleanup_global(dt_iop_module_so_t *self)
 {
-  dt_iop_colorcorrection_global_data_t *gd = module->data;
+  dt_iop_colorcorrection_global_data_t *gd = self->data;
   dt_opencl_free_kernel(gd->kernel_colorcorrection);
-  free(module->data);
-  module->data = NULL;
+  free(self->data);
+  self->data = NULL;
 }
 
 

--- a/src/iop/colorequal.c
+++ b/src/iop/colorequal.c
@@ -285,12 +285,12 @@ typedef struct dt_iop_colorequal_gui_data_t
   float points[NODES+1][2];
 } dt_iop_colorequal_gui_data_t;
 
-void init_global(dt_iop_module_so_t *module)
+void init_global(dt_iop_module_so_t *self)
 {
   const int program = 37; // colorequal.cl, from programs.conf
 
   dt_iop_colorequal_global_data_t *gd = malloc(sizeof(dt_iop_colorequal_global_data_t));
-  module->data = gd;
+  self->data = gd;
 
   gd->ce_init_covariance = dt_opencl_create_kernel(program, "init_covariance");
   gd->ce_finish_covariance = dt_opencl_create_kernel(program, "finish_covariance");
@@ -310,9 +310,9 @@ void init_global(dt_iop_module_so_t *module)
   gd->ce_bilinear4 = dt_opencl_create_kernel(program, "bilinear4");
 }
 
-void cleanup_global(dt_iop_module_so_t *module)
+void cleanup_global(dt_iop_module_so_t *self)
 {
-  dt_iop_colorequal_global_data_t *gd = (dt_iop_colorequal_global_data_t *)module->data;
+  dt_iop_colorequal_global_data_t *gd = self->data;
   dt_opencl_free_kernel(gd->ce_init_covariance);
   dt_opencl_free_kernel(gd->ce_finish_covariance);
   dt_opencl_free_kernel(gd->ce_prepare_prefilter);
@@ -330,8 +330,8 @@ void cleanup_global(dt_iop_module_so_t *module)
   dt_opencl_free_kernel(gd->ce_bilinear2);
   dt_opencl_free_kernel(gd->ce_bilinear4);
 
-  free(module->data);
-  module->data = NULL;
+  free(self->data);
+  self->data = NULL;
 }
 
 
@@ -2268,7 +2268,7 @@ void init_presets(dt_iop_module_so_t *self)
                              1, DEVELOP_BLEND_CS_RGB_SCENE);
 }
 
-void gui_focus(struct dt_iop_module_t *self, gboolean in)
+void gui_focus(dt_iop_module_t *self, gboolean in)
 {
   dt_iop_colorequal_gui_data_t *g = self->gui_data;
   if(!in)
@@ -2890,7 +2890,7 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
   gtk_widget_queue_draw(GTK_WIDGET(g->area));
 }
 
-void gui_cleanup(struct dt_iop_module_t *self)
+void gui_cleanup(dt_iop_module_t *self)
 {
   dt_iop_colorequal_gui_data_t *g = self->gui_data;
   self->request_color_pick = DT_REQUEST_COLORPICK_OFF;
@@ -2985,7 +2985,7 @@ static const dt_action_def_t _action_def_coloreq
       _action_process_colorequal,
       _action_elements_colorequal };
 
-void gui_init(struct dt_iop_module_t *self)
+void gui_init(dt_iop_module_t *self)
 {
   dt_iop_colorequal_gui_data_t *g = IOP_GUI_ALLOC(colorequal);
 

--- a/src/iop/colorout.c
+++ b/src/iop/colorout.c
@@ -228,20 +228,20 @@ int legacy_params(dt_iop_module_t *self,
 #undef DT_IOP_COLOR_ICC_LEN_V4
 }
 
-void init_global(dt_iop_module_so_t *module)
+void init_global(dt_iop_module_so_t *self)
 {
   const int program = 2; // basic.cl, from programs.conf
   dt_iop_colorout_global_data_t *gd = malloc(sizeof(dt_iop_colorout_global_data_t));
-  module->data = gd;
+  self->data = gd;
   gd->kernel_colorout = dt_opencl_create_kernel(program, "colorout");
 }
 
-void cleanup_global(dt_iop_module_so_t *module)
+void cleanup_global(dt_iop_module_so_t *self)
 {
-  dt_iop_colorout_global_data_t *gd = module->data;
+  dt_iop_colorout_global_data_t *gd = self->data;
   dt_opencl_free_kernel(gd->kernel_colorout);
-  free(module->data);
-  module->data = NULL;
+  free(self->data);
+  self->data = NULL;
 }
 
 static void intent_changed(GtkWidget *widget, dt_iop_module_t *self)

--- a/src/iop/colorreconstruction.c
+++ b/src/iop/colorreconstruction.c
@@ -1197,10 +1197,10 @@ void gui_update(dt_iop_module_t *self)
   dt_iop_gui_leave_critical_section(self);
 }
 
-void init_global(dt_iop_module_so_t *module)
+void init_global(dt_iop_module_so_t *self)
 {
   dt_iop_colorreconstruct_global_data_t *gd = malloc(sizeof(dt_iop_colorreconstruct_global_data_t));
-  module->data = gd;
+  self->data = gd;
   const int program = 13; // colorcorrection.cl, from programs.conf
   gd->kernel_colorreconstruct_zero = dt_opencl_create_kernel(program, "colorreconstruction_zero");
   gd->kernel_colorreconstruct_splat = dt_opencl_create_kernel(program, "colorreconstruction_splat");
@@ -1208,15 +1208,15 @@ void init_global(dt_iop_module_so_t *module)
   gd->kernel_colorreconstruct_slice = dt_opencl_create_kernel(program, "colorreconstruction_slice");
 }
 
-void cleanup_global(dt_iop_module_so_t *module)
+void cleanup_global(dt_iop_module_so_t *self)
 {
-  dt_iop_colorreconstruct_global_data_t *gd = module->data;
+  dt_iop_colorreconstruct_global_data_t *gd = self->data;
   dt_opencl_free_kernel(gd->kernel_colorreconstruct_zero);
   dt_opencl_free_kernel(gd->kernel_colorreconstruct_splat);
   dt_opencl_free_kernel(gd->kernel_colorreconstruct_blur_line);
   dt_opencl_free_kernel(gd->kernel_colorreconstruct_slice);
-  free(module->data);
-  module->data = NULL;
+  free(self->data);
+  self->data = NULL;
 }
 
 

--- a/src/iop/colortransfer.c
+++ b/src/iop/colortransfer.c
@@ -292,7 +292,7 @@ static void kmeans(const float *col, const dt_iop_roi_t *const roi, const int n,
   }
 }
 
-void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
+void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
              void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   // FIXME: this returns nan!!
@@ -392,24 +392,24 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   }
 }
 
-void init_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
+void init_pipe(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
   piece->data = malloc(sizeof(dt_iop_colortransfer_data_t));
   dt_iop_colortransfer_data_t *d = piece->data;
   d->flag = NEUTRAL;
 }
 
-void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
+void cleanup_pipe(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
   free(piece->data);
   piece->data = NULL;
 }
 
-void gui_update(struct dt_iop_module_t *self)
+void gui_update(dt_iop_module_t *self)
 {
 }
 
-void gui_init(struct dt_iop_module_t *self)
+void gui_init(dt_iop_module_t *self)
 {
   IOP_GUI_ALLOC(colortransfer);
 

--- a/src/iop/diffuse.c
+++ b/src/iop/diffuse.c
@@ -1730,12 +1730,12 @@ error:
   return err;
 }
 
-void init_global(dt_iop_module_so_t *module)
+void init_global(dt_iop_module_so_t *self)
 {
   const int program = 33; // extended.cl in programs.conf
   dt_iop_diffuse_global_data_t *gd = malloc(sizeof(dt_iop_diffuse_global_data_t));
 
-  module->data = gd;
+  self->data = gd;
   gd->kernel_diffuse_build_mask = dt_opencl_create_kernel(program, "build_mask");
   gd->kernel_diffuse_inpaint_mask = dt_opencl_create_kernel(program, "inpaint_mask");
   gd->kernel_diffuse_pde = dt_opencl_create_kernel(program, "diffuse_pde");
@@ -1750,9 +1750,9 @@ void init_global(dt_iop_module_so_t *module)
 }
 
 
-void cleanup_global(dt_iop_module_so_t *module)
+void cleanup_global(dt_iop_module_so_t *self)
 {
-  dt_iop_diffuse_global_data_t *gd = module->data;
+  dt_iop_diffuse_global_data_t *gd = self->data;
   dt_opencl_free_kernel(gd->kernel_diffuse_build_mask);
   dt_opencl_free_kernel(gd->kernel_diffuse_inpaint_mask);
   dt_opencl_free_kernel(gd->kernel_diffuse_pde);
@@ -1760,8 +1760,8 @@ void cleanup_global(dt_iop_module_so_t *module)
   dt_opencl_free_kernel(gd->kernel_filmic_bspline_vertical);
   dt_opencl_free_kernel(gd->kernel_filmic_bspline_horizontal);
   dt_opencl_free_kernel(gd->kernel_filmic_wavelets_detail);
-  free(module->data);
-  module->data = NULL;
+  free(self->data);
+  self->data = NULL;
 }
 #endif
 

--- a/src/iop/enlargecanvas.c
+++ b/src/iop/enlargecanvas.c
@@ -75,7 +75,7 @@ const char *name()
   return _("enlarge canvas");
 }
 
-const char** description(struct dt_iop_module_t *self)
+const char** description(dt_iop_module_t *self)
 {
   return dt_iop_set_description
     (self,
@@ -117,8 +117,8 @@ void commit_params(dt_iop_module_t *self,
   memcpy(piece->data, p1, self->params_size);
 }
 
-void modify_roi_out(struct dt_iop_module_t *self,
-                    struct dt_dev_pixelpipe_iop_t *piece,
+void modify_roi_out(dt_iop_module_t *self,
+                    dt_dev_pixelpipe_iop_t *piece,
                     dt_iop_roi_t *roi_out,
                     const dt_iop_roi_t *roi_in)
 {
@@ -151,8 +151,8 @@ void modify_roi_out(struct dt_iop_module_t *self,
   roi_out->height = CLAMP(roi_out->height, 5, roi_in->height * 3);
 }
 
-void modify_roi_in(struct dt_iop_module_t *self,
-                   struct dt_dev_pixelpipe_iop_t *piece,
+void modify_roi_in(dt_iop_module_t *self,
+                   dt_dev_pixelpipe_iop_t *piece,
                    const dt_iop_roi_t *roi_out,
                    dt_iop_roi_t *roi_in)
 {
@@ -290,8 +290,8 @@ static void _compute_pos(const dt_iop_enlargecanvas_data_t *const d,
   *pos_h = CLAMP(*pos_h, 0.0f, 1.0f);
 }
 
-void distort_mask(struct dt_iop_module_t *self,
-                  struct dt_dev_pixelpipe_iop_t *piece,
+void distort_mask(dt_iop_module_t *self,
+                  dt_dev_pixelpipe_iop_t *piece,
                   const float *const in,
                   float *const out,
                   const dt_iop_roi_t *const roi_in,
@@ -328,7 +328,7 @@ void distort_mask(struct dt_iop_module_t *self,
   }
 }
 
-void process(struct dt_iop_module_t *self,
+void process(dt_iop_module_t *self,
              dt_dev_pixelpipe_iop_t *piece,
              const void *const ivoid,
              void *const ovoid,

--- a/src/iop/equalizer.c
+++ b/src/iop/equalizer.c
@@ -113,7 +113,7 @@ const char *deprecated_msg()
 }
 
 
-void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
+void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
              void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   const int chs = piece->colors;
@@ -168,7 +168,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   free(tmp);
 }
 
-void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_t *pipe,
+void commit_params(dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_t *pipe,
                    dt_dev_pixelpipe_iop_t *piece)
 {
   // pull in new params to pipe
@@ -183,7 +183,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
   d->num_levels = MIN(DT_IOP_EQUALIZER_MAX_LEVEL, l);
 }
 
-void init_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
+void init_pipe(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
   // create part of the pixelpipe
   dt_iop_equalizer_data_t *d = malloc(sizeof(dt_iop_equalizer_data_t));
@@ -201,7 +201,7 @@ void init_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pi
   d->num_levels = MIN(DT_IOP_EQUALIZER_MAX_LEVEL, l);
 }
 
-void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
+void cleanup_pipe(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
 // clean up everything again.
   dt_iop_equalizer_data_t *d = piece->data;
@@ -210,7 +210,7 @@ void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev
   piece->data = NULL;
 }
 
-void gui_update(struct dt_iop_module_t *self)
+void gui_update(dt_iop_module_t *self)
 {
   // nothing to do, gui curve is read directly from params during expose event.
   // gtk_widget_queue_draw(self->widget);
@@ -232,7 +232,7 @@ void init(dt_iop_module_t *self)
   }
 }
 
-void gui_init(struct dt_iop_module_t *self)
+void gui_init(dt_iop_module_t *self)
 {
   IOP_GUI_ALLOC(equalizer);
 

--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -122,7 +122,7 @@ const char *name()
   return _("exposure");
 }
 
-const char** description(struct dt_iop_module_t *self)
+const char** description(dt_iop_module_t *self)
 {
   return dt_iop_set_description
     (self,
@@ -1097,12 +1097,12 @@ static void _spot_settings_changed_callback(GtkWidget *slider,
   // else : just record new values and do nothing
 }
 
-void gui_reset(struct dt_iop_module_t *self)
+void gui_reset(dt_iop_module_t *self)
 {
   dt_iop_color_picker_reset(self, TRUE);
 }
 
-void gui_init(struct dt_iop_module_t *self)
+void gui_init(dt_iop_module_t *self)
 {
   dt_iop_exposure_gui_data_t *g = IOP_GUI_ALLOC(exposure);
 
@@ -1265,7 +1265,7 @@ void gui_init(struct dt_iop_module_t *self)
   instance->get_black = _exposure_proxy_get_black;
 }
 
-void gui_cleanup(struct dt_iop_module_t *self)
+void gui_cleanup(dt_iop_module_t *self)
 {
   dt_iop_exposure_gui_data_t *g = self->gui_data;
 

--- a/src/iop/filmic.c
+++ b/src/iop/filmic.c
@@ -552,7 +552,7 @@ void process(dt_iop_module_t *self,
 }
 
 #ifdef HAVE_OPENCL
-int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_in, cl_mem dev_out,
+int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_in, cl_mem dev_out,
                const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_filmic_data_t *d = piece->data;

--- a/src/iop/finalscale.c
+++ b/src/iop/finalscale.c
@@ -115,8 +115,8 @@ void modify_roi_in(dt_iop_module_t *self,
   }
 }
 
-void tiling_callback(struct dt_iop_module_t *self,
-                     struct dt_dev_pixelpipe_iop_t *piece,
+void tiling_callback(dt_iop_module_t *self,
+                     dt_dev_pixelpipe_iop_t *piece,
                      const dt_iop_roi_t *roi_in,
                      const dt_iop_roi_t *roi_out,
                      struct dt_develop_tiling_t *tiling)
@@ -136,8 +136,8 @@ void tiling_callback(struct dt_iop_module_t *self,
   tiling->yalign = 1;
 }
 
-void distort_mask(struct dt_iop_module_t *self,
-                  struct dt_dev_pixelpipe_iop_t *piece,
+void distort_mask(dt_iop_module_t *self,
+                  dt_dev_pixelpipe_iop_t *piece,
                   const float *const in,
                   float *const out,
                   const dt_iop_roi_t *const roi_in,
@@ -149,7 +149,7 @@ void distort_mask(struct dt_iop_module_t *self,
 }
 
 #ifdef HAVE_OPENCL
-int process_cl(struct dt_iop_module_t *self,
+int process_cl(dt_iop_module_t *self,
                dt_dev_pixelpipe_iop_t *piece,
                cl_mem dev_in, cl_mem dev_out,
                const dt_iop_roi_t *const roi_in,

--- a/src/iop/globaltonemap.c
+++ b/src/iop/globaltonemap.c
@@ -168,7 +168,7 @@ int legacy_params(dt_iop_module_t *self,
   return 1;
 }
 
-static inline void process_reinhard(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece,
+static inline void process_reinhard(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece,
                                     const void *const ivoid, void *const ovoid,
                                     const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out,
                                     dt_iop_global_tonemap_data_t *data)
@@ -189,7 +189,7 @@ static inline void process_reinhard(struct dt_iop_module_t *self, dt_dev_pixelpi
   }
 }
 
-static inline void process_drago(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece,
+static inline void process_drago(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece,
                                  const void *const ivoid, void *const ovoid, const dt_iop_roi_t *const roi_in,
                                  const dt_iop_roi_t *const roi_out, dt_iop_global_tonemap_data_t *data)
 {
@@ -266,7 +266,7 @@ static inline void process_drago(struct dt_iop_module_t *self, dt_dev_pixelpipe_
   }
 }
 
-static inline void process_filmic(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece,
+static inline void process_filmic(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece,
                                   const void *const ivoid, void *const ovoid,
                                   const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out,
                                   dt_iop_global_tonemap_data_t *data)
@@ -288,7 +288,7 @@ static inline void process_filmic(struct dt_iop_module_t *self, dt_dev_pixelpipe
   }
 }
 
-void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
+void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
              void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_global_tonemap_data_t *data = piece->data;
@@ -328,7 +328,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 }
 
 #ifdef HAVE_OPENCL
-int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_in, cl_mem dev_out,
+int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_in, cl_mem dev_out,
                const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_global_tonemap_data_t *d = piece->data;
@@ -525,9 +525,9 @@ finally:
 #endif
 
 
-void tiling_callback(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece,
+void tiling_callback(dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece,
                      const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out,
-                     struct dt_develop_tiling_t *tiling)
+                     dt_develop_tiling_t *tiling)
 {
   dt_iop_global_tonemap_data_t *d = piece->data;
 
@@ -554,7 +554,7 @@ void tiling_callback(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t
   return;
 }
 
-void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_t *pipe,
+void commit_params(dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_t *pipe,
                    dt_dev_pixelpipe_iop_t *piece)
 {
   dt_iop_global_tonemap_params_t *p = (dt_iop_global_tonemap_params_t *)p1;
@@ -574,22 +574,22 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
 #endif
 }
 
-void init_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
+void init_pipe(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
   piece->data = calloc(1, sizeof(dt_iop_global_tonemap_data_t));
 }
 
-void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
+void cleanup_pipe(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
   free(piece->data);
   piece->data = NULL;
 }
 
-void init_global(dt_iop_module_so_t *module)
+void init_global(dt_iop_module_so_t *self)
 {
   const int program = 8; // extended.cl from programs.conf
   dt_iop_global_tonemap_global_data_t *gd = malloc(sizeof(dt_iop_global_tonemap_global_data_t));
-  module->data = gd;
+  self->data = gd;
   gd->kernel_pixelmax_first = dt_opencl_create_kernel(program, "pixelmax_first");
   gd->kernel_pixelmax_second = dt_opencl_create_kernel(program, "pixelmax_second");
   gd->kernel_global_tonemap_reinhard = dt_opencl_create_kernel(program, "global_tonemap_reinhard");
@@ -598,16 +598,16 @@ void init_global(dt_iop_module_so_t *module)
 }
 
 
-void cleanup_global(dt_iop_module_so_t *module)
+void cleanup_global(dt_iop_module_so_t *self)
 {
-  dt_iop_global_tonemap_global_data_t *gd = module->data;
+  dt_iop_global_tonemap_global_data_t *gd = self->data;
   dt_opencl_free_kernel(gd->kernel_pixelmax_first);
   dt_opencl_free_kernel(gd->kernel_pixelmax_second);
   dt_opencl_free_kernel(gd->kernel_global_tonemap_reinhard);
   dt_opencl_free_kernel(gd->kernel_global_tonemap_drago);
   dt_opencl_free_kernel(gd->kernel_global_tonemap_filmic);
-  free(module->data);
-  module->data = NULL;
+  free(self->data);
+  self->data = NULL;
 }
 
 void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
@@ -622,7 +622,7 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
   }
 }
 
-void gui_update(struct dt_iop_module_t *self)
+void gui_update(dt_iop_module_t *self)
 {
   dt_iop_global_tonemap_gui_data_t *g = self->gui_data;
 
@@ -634,7 +634,7 @@ void gui_update(struct dt_iop_module_t *self)
   dt_iop_gui_leave_critical_section(self);
 }
 
-void gui_init(struct dt_iop_module_t *self)
+void gui_init(dt_iop_module_t *self)
 {
   dt_iop_global_tonemap_gui_data_t *g = IOP_GUI_ALLOC(global_tonemap);
 
@@ -655,7 +655,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_bauhaus_slider_set_digits(g->detail, 3);
 }
 
-void gui_cleanup(struct dt_iop_module_t *self)
+void gui_cleanup(dt_iop_module_t *self)
 {
   IOP_GUI_FREE;
 }

--- a/src/iop/graduatednd.c
+++ b/src/iop/graduatednd.c
@@ -979,22 +979,22 @@ int process_cl(dt_iop_module_t *self,
 }
 #endif
 
-void init_global(dt_iop_module_so_t *module)
+void init_global(dt_iop_module_so_t *self)
 {
   const int program = 8; // extended.cl, from programs.conf
   dt_iop_graduatednd_global_data_t *gd = malloc(sizeof(dt_iop_graduatednd_global_data_t));
-  module->data = gd;
+  self->data = gd;
   gd->kernel_graduatedndp = dt_opencl_create_kernel(program, "graduatedndp");
   gd->kernel_graduatedndm = dt_opencl_create_kernel(program, "graduatedndm");
 }
 
-void cleanup_global(dt_iop_module_so_t *module)
+void cleanup_global(dt_iop_module_so_t *self)
 {
-  dt_iop_graduatednd_global_data_t *gd = module->data;
+  dt_iop_graduatednd_global_data_t *gd = self->data;
   dt_opencl_free_kernel(gd->kernel_graduatedndp);
   dt_opencl_free_kernel(gd->kernel_graduatedndm);
-  free(module->data);
-  module->data = NULL;
+  free(self->data);
+  self->data = NULL;
 }
 
 void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -916,11 +916,11 @@ void commit_params(dt_iop_module_t *self,
     piece->process_cl_ready = FALSE;
 }
 
-void init_global(dt_iop_module_so_t *module)
+void init_global(dt_iop_module_so_t *self)
 {
   const int program = 2; // basic.cl, from programs.conf
   dt_iop_highlights_global_data_t *gd = malloc(sizeof(dt_iop_highlights_global_data_t));
-  module->data = gd;
+  self->data = gd;
   gd->kernel_highlights_1f_clip = dt_opencl_create_kernel(program, "highlights_1f_clip");
   gd->kernel_highlights_1f_lch_bayer = dt_opencl_create_kernel(program, "highlights_1f_lch_bayer");
   gd->kernel_highlights_1f_lch_xtrans = dt_opencl_create_kernel(program, "highlights_1f_lch_xtrans");
@@ -945,9 +945,9 @@ void init_global(dt_iop_module_so_t *module)
   gd->kernel_filmic_wavelets_detail = dt_opencl_create_kernel(wavelets, "wavelets_detail_level");
 }
 
-void cleanup_global(dt_iop_module_so_t *module)
+void cleanup_global(dt_iop_module_so_t *self)
 {
-  dt_iop_highlights_global_data_t *gd = module->data;
+  dt_iop_highlights_global_data_t *gd = self->data;
   dt_opencl_free_kernel(gd->kernel_highlights_4f_clip);
   dt_opencl_free_kernel(gd->kernel_highlights_1f_lch_bayer);
   dt_opencl_free_kernel(gd->kernel_highlights_1f_lch_xtrans);
@@ -971,8 +971,8 @@ void cleanup_global(dt_iop_module_so_t *module)
 
   dt_opencl_free_kernel(gd->kernel_interpolate_bilinear);
 
-  free(module->data);
-  module->data = NULL;
+  free(self->data);
+  self->data = NULL;
 }
 
 void init_pipe(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)

--- a/src/iop/highpass.c
+++ b/src/iop/highpass.c
@@ -338,26 +338,26 @@ void cleanup_pipe(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelp
   piece->data = NULL;
 }
 
-void init_global(dt_iop_module_so_t *module)
+void init_global(dt_iop_module_so_t *self)
 {
   const int program = 4; // highpass.cl, from programs.conf
   dt_iop_highpass_global_data_t *gd = malloc(sizeof(dt_iop_highpass_global_data_t));
-  module->data = gd;
+  self->data = gd;
   gd->kernel_highpass_invert = dt_opencl_create_kernel(program, "highpass_invert");
   gd->kernel_highpass_hblur = dt_opencl_create_kernel(program, "highpass_hblur");
   gd->kernel_highpass_vblur = dt_opencl_create_kernel(program, "highpass_vblur");
   gd->kernel_highpass_mix = dt_opencl_create_kernel(program, "highpass_mix");
 }
 
-void cleanup_global(dt_iop_module_so_t *module)
+void cleanup_global(dt_iop_module_so_t *self)
 {
-  dt_iop_highpass_global_data_t *gd = module->data;
+  dt_iop_highpass_global_data_t *gd = self->data;
   dt_opencl_free_kernel(gd->kernel_highpass_invert);
   dt_opencl_free_kernel(gd->kernel_highpass_hblur);
   dt_opencl_free_kernel(gd->kernel_highpass_vblur);
   dt_opencl_free_kernel(gd->kernel_highpass_mix);
-  free(module->data);
-  module->data = NULL;
+  free(self->data);
+  self->data = NULL;
 }
 
 

--- a/src/iop/hlreconstruct/laplacian.c
+++ b/src/iop/hlreconstruct/laplacian.c
@@ -583,7 +583,7 @@ static inline gint wavelets_process(const float *const restrict in,
 }
 
 
-static void process_laplacian_bayer(struct dt_iop_module_t *self,
+static void process_laplacian_bayer(dt_iop_module_t *self,
                                     dt_dev_pixelpipe_iop_t *piece,
                                     const void *const restrict ivoid,
                                     void *const restrict ovoid,
@@ -778,7 +778,7 @@ static inline cl_int wavelets_process_cl(const int devid,
   return err;
 }
 
-static cl_int process_laplacian_bayer_cl(struct dt_iop_module_t *self,
+static cl_int process_laplacian_bayer_cl(dt_iop_module_t *self,
                                          dt_dev_pixelpipe_iop_t *piece,
                                          cl_mem dev_in,
                                          cl_mem dev_out,

--- a/src/iop/invert.c
+++ b/src/iop/invert.c
@@ -433,23 +433,23 @@ void reload_defaults(dt_iop_module_t *self)
   }
 }
 
-void init_global(dt_iop_module_so_t *module)
+void init_global(dt_iop_module_so_t *self)
 {
   const int program = 2; // basic.cl, from programs.conf
-  module->data = malloc(sizeof(dt_iop_invert_global_data_t));
+  self->data = malloc(sizeof(dt_iop_invert_global_data_t));
 
-  dt_iop_invert_global_data_t *gd = module->data;
+  dt_iop_invert_global_data_t *gd = self->data;
   gd->kernel_invert_1f = dt_opencl_create_kernel(program, "invert_1f");
   gd->kernel_invert_4f = dt_opencl_create_kernel(program, "invert_4f");
 }
 
-void cleanup_global(dt_iop_module_so_t *module)
+void cleanup_global(dt_iop_module_so_t *self)
 {
-  dt_iop_invert_global_data_t *gd = module->data;
+  dt_iop_invert_global_data_t *gd = self->data;
   dt_opencl_free_kernel(gd->kernel_invert_4f);
   dt_opencl_free_kernel(gd->kernel_invert_1f);
-  free(module->data);
-  module->data = NULL;
+  free(self->data);
+  self->data = NULL;
 }
 
 void commit_params(dt_iop_module_t *self, dt_iop_params_t *params, dt_dev_pixelpipe_t *pipe,

--- a/src/iop/lowpass.c
+++ b/src/iop/lowpass.c
@@ -543,11 +543,11 @@ void cleanup_pipe(dt_iop_module_t *self,
   piece->data = NULL;
 }
 
-void init_global(dt_iop_module_so_t *module)
+void init_global(dt_iop_module_so_t *self)
 {
   const int program = 6; // gaussian.cl, from programs.conf
   dt_iop_lowpass_global_data_t *gd = malloc(sizeof(dt_iop_lowpass_global_data_t));
-  module->data = gd;
+  self->data = gd;
   gd->kernel_lowpass_mix = dt_opencl_create_kernel(program, "lowpass_mix");
 }
 
@@ -562,12 +562,12 @@ void init_presets(dt_iop_module_so_t *self)
   dt_database_release_transaction(darktable.db);
 }
 
-void cleanup_global(dt_iop_module_so_t *module)
+void cleanup_global(dt_iop_module_so_t *self)
 {
-  dt_iop_lowpass_global_data_t *gd = module->data;
+  dt_iop_lowpass_global_data_t *gd = self->data;
   dt_opencl_free_kernel(gd->kernel_lowpass_mix);
-  free(module->data);
-  module->data = NULL;
+  free(self->data);
+  self->data = NULL;
 }
 
 void gui_init(dt_iop_module_t *self)

--- a/src/iop/lut3d.c
+++ b/src/iop/lut3d.c
@@ -1114,11 +1114,11 @@ void filepath_set_unix_separator(char *filepath)
     if(filepath[i]=='\\') filepath[i] = '/';
 }
 
-void init_global(dt_iop_module_so_t *module)
+void init_global(dt_iop_module_so_t *self)
 {
   const int program = 28; // rgbcurve.cl, from programs.conf
   dt_iop_lut3d_global_data_t *gd = malloc(sizeof(dt_iop_lut3d_global_data_t));
-  module->data = gd;
+  self->data = gd;
   gd->kernel_lut3d_tetrahedral = dt_opencl_create_kernel(program, "lut3d_tetrahedral");
   gd->kernel_lut3d_trilinear = dt_opencl_create_kernel(program, "lut3d_trilinear");
   gd->kernel_lut3d_pyramid = dt_opencl_create_kernel(program, "lut3d_pyramid");
@@ -1133,15 +1133,15 @@ void init_global(dt_iop_module_so_t *module)
 #endif // HAVE_GMIC
 }
 
-void cleanup_global(dt_iop_module_so_t *module)
+void cleanup_global(dt_iop_module_so_t *self)
 {
-  dt_iop_lut3d_global_data_t *gd = module->data;
+  dt_iop_lut3d_global_data_t *gd = self->data;
   dt_opencl_free_kernel(gd->kernel_lut3d_tetrahedral);
   dt_opencl_free_kernel(gd->kernel_lut3d_trilinear);
   dt_opencl_free_kernel(gd->kernel_lut3d_pyramid);
   dt_opencl_free_kernel(gd->kernel_lut3d_none);
-  free(module->data);
-  module->data = NULL;
+  free(self->data);
+  self->data = NULL;
 }
 
 static int calculate_clut(dt_iop_lut3d_params_t *const p, float **clut)

--- a/src/iop/monochrome.c
+++ b/src/iop/monochrome.c
@@ -335,22 +335,22 @@ void commit_params(dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_
 
 
 
-void init_global(dt_iop_module_so_t *module)
+void init_global(dt_iop_module_so_t *self)
 {
   const int program = 2; // basic.cl from programs.conf
   dt_iop_monochrome_global_data_t *gd = malloc(sizeof(dt_iop_monochrome_global_data_t));
-  module->data = gd;
+  self->data = gd;
   gd->kernel_monochrome_filter = dt_opencl_create_kernel(program, "monochrome_filter");
   gd->kernel_monochrome = dt_opencl_create_kernel(program, "monochrome");
 }
 
-void cleanup_global(dt_iop_module_so_t *module)
+void cleanup_global(dt_iop_module_so_t *self)
 {
-  dt_iop_monochrome_global_data_t *gd = module->data;
+  dt_iop_monochrome_global_data_t *gd = self->data;
   dt_opencl_free_kernel(gd->kernel_monochrome_filter);
   dt_opencl_free_kernel(gd->kernel_monochrome);
-  free(module->data);
-  module->data = NULL;
+  free(self->data);
+  self->data = NULL;
 }
 
 void gui_update(dt_iop_module_t *self)

--- a/src/iop/nlmeans.c
+++ b/src/iop/nlmeans.c
@@ -402,11 +402,11 @@ void process(
   nlmeans_denoise(ivoid, ovoid, roi_in, roi_out, &params);
 }
 
-void init_global(dt_iop_module_so_t *module)
+void init_global(dt_iop_module_so_t *self)
 {
   const int program = 5; // nlmeans.cl, from programs.conf
   dt_iop_nlmeans_global_data_t *gd = malloc(sizeof(dt_iop_nlmeans_global_data_t));
-  module->data = gd;
+  self->data = gd;
   gd->kernel_nlmeans_init = dt_opencl_create_kernel(program, "nlmeans_init");
   gd->kernel_nlmeans_dist = dt_opencl_create_kernel(program, "nlmeans_dist");
   gd->kernel_nlmeans_horiz = dt_opencl_create_kernel(program, "nlmeans_horiz");
@@ -415,17 +415,17 @@ void init_global(dt_iop_module_so_t *module)
   gd->kernel_nlmeans_finish = dt_opencl_create_kernel(program, "nlmeans_finish");
 }
 
-void cleanup_global(dt_iop_module_so_t *module)
+void cleanup_global(dt_iop_module_so_t *self)
 {
-  dt_iop_nlmeans_global_data_t *gd = module->data;
+  dt_iop_nlmeans_global_data_t *gd = self->data;
   dt_opencl_free_kernel(gd->kernel_nlmeans_init);
   dt_opencl_free_kernel(gd->kernel_nlmeans_dist);
   dt_opencl_free_kernel(gd->kernel_nlmeans_horiz);
   dt_opencl_free_kernel(gd->kernel_nlmeans_vert);
   dt_opencl_free_kernel(gd->kernel_nlmeans_accu);
   dt_opencl_free_kernel(gd->kernel_nlmeans_finish);
-  free(module->data);
-  module->data = NULL;
+  free(self->data);
+  self->data = NULL;
 }
 
 /** commit is the synch point between core and gui, so it copies params to pipe data. */

--- a/src/iop/overexposed.c
+++ b/src/iop/overexposed.c
@@ -372,9 +372,9 @@ error:
 }
 #endif
 
-void tiling_callback(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece,
+void tiling_callback(dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece,
                      const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out,
-                     struct dt_develop_tiling_t *tiling)
+                     dt_develop_tiling_t *tiling)
 {
   tiling->factor = 3.0f;  // in + out + temp
   tiling->factor_cl = 3.0f;

--- a/src/iop/overlay.c
+++ b/src/iop/overlay.c
@@ -937,7 +937,7 @@ void gui_changed(dt_iop_module_t *self,
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 
-void init_global(dt_iop_module_so_t *module)
+void init_global(dt_iop_module_so_t *self)
 {
   dt_iop_overlay_global_data_t *gd = calloc(1, sizeof(dt_iop_overlay_global_data_t));
 
@@ -945,19 +945,19 @@ void init_global(dt_iop_module_so_t *module)
   pthread_mutexattr_init(&recursive_locking);
   pthread_mutexattr_settype(&recursive_locking, PTHREAD_MUTEX_RECURSIVE);
   dt_pthread_mutex_init(&gd->overlay_threadsafe, &recursive_locking);
-  module->data = gd;
+  self->data = gd;
 }
 
-void cleanup_global(dt_iop_module_so_t *module)
+void cleanup_global(dt_iop_module_so_t *self)
 {
-  dt_iop_overlay_global_data_t *gd = module->data;
+  dt_iop_overlay_global_data_t *gd = self->data;
 
   for(int k=0; k<MAX_OVERLAY; k++)
     dt_free_align(gd->cache[k]);
 
   dt_pthread_mutex_destroy(&gd->overlay_threadsafe);
   free(gd);
-  module->data = NULL;
+  self->data = NULL;
 }
 
 static void _signal_image_changed(gpointer instance, dt_iop_module_t *self)

--- a/src/iop/primaries.c
+++ b/src/iop/primaries.c
@@ -424,20 +424,20 @@ void gui_cleanup(dt_iop_module_t *self)
   IOP_GUI_FREE;
 }
 
-void init_global(dt_iop_module_so_t *module)
+void init_global(dt_iop_module_so_t *self)
 {
   const int program = 8; // extended.cl, from programs.conf
   dt_iop_primaries_global_data_t *gd = malloc(sizeof(dt_iop_primaries_global_data_t));
-  module->data = gd;
+  self->data = gd;
   gd->kernel_primaries = dt_opencl_create_kernel(program, "primaries");
 }
 
-void cleanup_global(dt_iop_module_so_t *module)
+void cleanup_global(dt_iop_module_so_t *self)
 {
-  dt_iop_primaries_global_data_t *gd = module->data;
+  dt_iop_primaries_global_data_t *gd = self->data;
   dt_opencl_free_kernel(gd->kernel_primaries);
-  free(module->data);
-  module->data = NULL;
+  free(self->data);
+  self->data = NULL;
 }
 
 // clang-format off

--- a/src/iop/profile_gamma.c
+++ b/src/iop/profile_gamma.c
@@ -575,23 +575,23 @@ void gui_update(dt_iop_module_t *self)
   gui_changed(self, g->mode, 0);
 }
 
-void init_global(dt_iop_module_so_t *module)
+void init_global(dt_iop_module_so_t *self)
 {
   const int program = 2; // basic.cl, from programs.conf
   dt_iop_profilegamma_global_data_t *gd = malloc(sizeof(dt_iop_profilegamma_global_data_t));
 
-  module->data = gd;
+  self->data = gd;
   gd->kernel_profilegamma = dt_opencl_create_kernel(program, "profilegamma");
   gd->kernel_profilegamma_log = dt_opencl_create_kernel(program, "profilegamma_log");
 }
 
-void cleanup_global(dt_iop_module_so_t *module)
+void cleanup_global(dt_iop_module_so_t *self)
 {
-  dt_iop_profilegamma_global_data_t *gd = module->data;
+  dt_iop_profilegamma_global_data_t *gd = self->data;
   dt_opencl_free_kernel(gd->kernel_profilegamma);
   dt_opencl_free_kernel(gd->kernel_profilegamma_log);
-  free(module->data);
-  module->data = NULL;
+  free(self->data);
+  self->data = NULL;
 }
 
 

--- a/src/iop/relight.c
+++ b/src/iop/relight.c
@@ -111,7 +111,7 @@ dt_iop_colorspace_type_t default_colorspace(dt_iop_module_t *self,
 //#define GAUSS(a, b, c, x) (a * powf(2.718281828f, (-powf((x - b), 2) / (powf(c, 2)))))
 #define GAUSS(a, b, c, x) (a * expf(-(x-b)*(x-b) / (c*c)))
 
-void process(struct dt_iop_module_t *self,
+void process(dt_iop_module_t *self,
              dt_dev_pixelpipe_iop_t *piece,
              const void *const ivoid,
              void *const ovoid,
@@ -151,7 +151,7 @@ void process(struct dt_iop_module_t *self,
 
 
 #ifdef HAVE_OPENCL
-int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_in, cl_mem dev_out,
+int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_in, cl_mem dev_out,
                const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_relight_data_t *data = piece->data;
@@ -170,20 +170,20 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
 }
 #endif
 
-void init_global(dt_iop_module_so_t *module)
+void init_global(dt_iop_module_so_t *self)
 {
   const int program = 8; // extended.cl, from programs.conf
   dt_iop_relight_global_data_t *gd = malloc(sizeof(dt_iop_relight_global_data_t));
-  module->data = gd;
+  self->data = gd;
   gd->kernel_relight = dt_opencl_create_kernel(program, "relight");
 }
 
-void cleanup_global(dt_iop_module_so_t *module)
+void cleanup_global(dt_iop_module_so_t *self)
 {
-  dt_iop_relight_global_data_t *gd = module->data;
+  dt_iop_relight_global_data_t *gd = self->data;
   dt_opencl_free_kernel(gd->kernel_relight);
-  free(module->data);
-  module->data = NULL;
+  free(self->data);
+  self->data = NULL;
 }
 
 static void center_callback(GtkDarktableGradientSlider *slider, dt_iop_module_t *self)
@@ -195,7 +195,7 @@ static void center_callback(GtkDarktableGradientSlider *slider, dt_iop_module_t 
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 
-void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_t *pipe,
+void commit_params(dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_t *pipe,
                    dt_dev_pixelpipe_iop_t *piece)
 {
   dt_iop_relight_params_t *p = (dt_iop_relight_params_t *)p1;
@@ -206,18 +206,18 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
   d->center = p->center;
 }
 
-void init_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
+void init_pipe(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
   piece->data = calloc(1, sizeof(dt_iop_relight_data_t));
 }
 
-void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
+void cleanup_pipe(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
   free(piece->data);
   piece->data = NULL;
 }
 
-void gui_update(struct dt_iop_module_t *self)
+void gui_update(dt_iop_module_t *self)
 {
   dt_iop_relight_gui_data_t *g = self->gui_data;
   dt_iop_relight_params_t *p = self->params;
@@ -244,7 +244,7 @@ void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker,
   dtgtk_gradient_slider_set_picker_meanminmax(DTGTK_GRADIENT_SLIDER(g->center), mean, min, max);
 }
 
-void gui_init(struct dt_iop_module_t *self)
+void gui_init(dt_iop_module_t *self)
 {
   dt_iop_relight_gui_data_t *g = IOP_GUI_ALLOC(relight);
 

--- a/src/iop/shadhi.c
+++ b/src/iop/shadhi.c
@@ -661,20 +661,20 @@ void cleanup_pipe(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelp
   piece->data = NULL;
 }
 
-void init_global(dt_iop_module_so_t *module)
+void init_global(dt_iop_module_so_t *self)
 {
   const int program = 6; // gaussian.cl, from programs.conf
   dt_iop_shadhi_global_data_t *gd = malloc(sizeof(dt_iop_shadhi_global_data_t));
-  module->data = gd;
+  self->data = gd;
   gd->kernel_shadows_highlights_mix = dt_opencl_create_kernel(program, "shadows_highlights_mix");
 }
 
-void cleanup_global(dt_iop_module_so_t *module)
+void cleanup_global(dt_iop_module_so_t *self)
 {
-  dt_iop_shadhi_global_data_t *gd = module->data;
+  dt_iop_shadhi_global_data_t *gd = self->data;
   dt_opencl_free_kernel(gd->kernel_shadows_highlights_mix);
-  free(module->data);
-  module->data = NULL;
+  free(self->data);
+  self->data = NULL;
 }
 
 void gui_init(dt_iop_module_t *self)

--- a/src/iop/sharpen.c
+++ b/src/iop/sharpen.c
@@ -403,24 +403,24 @@ void cleanup_pipe(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelp
   piece->data = NULL;
 }
 
-void init_global(dt_iop_module_so_t *module)
+void init_global(dt_iop_module_so_t *self)
 {
   const int program = 7; // sharpen.cl, from programs.conf
   dt_iop_sharpen_global_data_t *gd = malloc(sizeof(dt_iop_sharpen_global_data_t));
-  module->data = gd;
+  self->data = gd;
   gd->kernel_sharpen_hblur = dt_opencl_create_kernel(program, "sharpen_hblur");
   gd->kernel_sharpen_vblur = dt_opencl_create_kernel(program, "sharpen_vblur");
   gd->kernel_sharpen_mix = dt_opencl_create_kernel(program, "sharpen_mix");
 }
 
-void cleanup_global(dt_iop_module_so_t *module)
+void cleanup_global(dt_iop_module_so_t *self)
 {
-  dt_iop_sharpen_global_data_t *gd = module->data;
+  dt_iop_sharpen_global_data_t *gd = self->data;
   dt_opencl_free_kernel(gd->kernel_sharpen_hblur);
   dt_opencl_free_kernel(gd->kernel_sharpen_vblur);
   dt_opencl_free_kernel(gd->kernel_sharpen_mix);
-  free(module->data);
-  module->data = NULL;
+  free(self->data);
+  self->data = NULL;
 }
 
 void gui_init(dt_iop_module_t *self)

--- a/src/iop/sigmoid.c
+++ b/src/iop/sigmoid.c
@@ -854,23 +854,23 @@ cleanup:
 }
 #endif // HAVE_OPENCL
 
-void init_global(dt_iop_module_so_t *module)
+void init_global(dt_iop_module_so_t *self)
 {
   const int program = 36; // sigmoid.cl, from programs.conf
   dt_iop_sigmoid_global_data_t *gd = malloc(sizeof(dt_iop_sigmoid_global_data_t));
 
-  module->data = gd;
+  self->data = gd;
   gd->kernel_sigmoid_loglogistic_per_channel = dt_opencl_create_kernel(program, "sigmoid_loglogistic_per_channel");
   gd->kernel_sigmoid_loglogistic_rgb_ratio = dt_opencl_create_kernel(program, "sigmoid_loglogistic_rgb_ratio");
 }
 
-void cleanup_global(dt_iop_module_so_t *module)
+void cleanup_global(dt_iop_module_so_t *self)
 {
-  dt_iop_sigmoid_global_data_t *gd = module->data;
+  dt_iop_sigmoid_global_data_t *gd = self->data;
   dt_opencl_free_kernel(gd->kernel_sigmoid_loglogistic_per_channel);
   dt_opencl_free_kernel(gd->kernel_sigmoid_loglogistic_rgb_ratio);
-  free(module->data);
-  module->data = NULL;
+  free(self->data);
+  self->data = NULL;
 }
 
 void init_pipe(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)

--- a/src/iop/soften.c
+++ b/src/iop/soften.c
@@ -297,28 +297,27 @@ void tiling_callback(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece,
   return;
 }
 
-void init_global(dt_iop_module_so_t *module)
+void init_global(dt_iop_module_so_t *self)
 {
   const int program = 9; // soften.cl, from programs.conf
   dt_iop_soften_global_data_t *gd = malloc(sizeof(dt_iop_soften_global_data_t));
-  module->data = gd;
+  self->data = gd;
   gd->kernel_soften_overexposed = dt_opencl_create_kernel(program, "soften_overexposed");
   gd->kernel_soften_hblur = dt_opencl_create_kernel(program, "soften_hblur");
   gd->kernel_soften_vblur = dt_opencl_create_kernel(program, "soften_vblur");
   gd->kernel_soften_mix = dt_opencl_create_kernel(program, "soften_mix");
 }
 
-void cleanup_global(dt_iop_module_so_t *module)
+void cleanup_global(dt_iop_module_so_t *self)
 {
-  dt_iop_soften_global_data_t *gd = module->data;
+  dt_iop_soften_global_data_t *gd = self->data;
   dt_opencl_free_kernel(gd->kernel_soften_overexposed);
   dt_opencl_free_kernel(gd->kernel_soften_hblur);
   dt_opencl_free_kernel(gd->kernel_soften_vblur);
   dt_opencl_free_kernel(gd->kernel_soften_mix);
-  free(module->data);
-  module->data = NULL;
+  free(self->data);
+  self->data = NULL;
 }
-
 
 void commit_params(dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_t *pipe,
                    dt_dev_pixelpipe_iop_t *piece)

--- a/src/iop/splittoning.c
+++ b/src/iop/splittoning.c
@@ -236,21 +236,21 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
 #endif
 
 
-void init_global(dt_iop_module_so_t *module)
+void init_global(dt_iop_module_so_t *self)
 {
   const int program = 8; // extended.cl from programs.conf
   dt_iop_splittoning_global_data_t *gd = malloc(sizeof(dt_iop_splittoning_global_data_t));
-  module->data = gd;
+  self->data = gd;
   gd->kernel_splittoning = dt_opencl_create_kernel(program, "splittoning");
 }
 
 
-void cleanup_global(dt_iop_module_so_t *module)
+void cleanup_global(dt_iop_module_so_t *self)
 {
-  dt_iop_splittoning_global_data_t *gd = module->data;
+  dt_iop_splittoning_global_data_t *gd = self->data;
   dt_opencl_free_kernel(gd->kernel_splittoning);
-  free(module->data);
-  module->data = NULL;
+  free(self->data);
+  self->data = NULL;
 }
 
 static inline void update_colorpicker_color(GtkWidget *colorpicker, float hue, float sat)

--- a/src/iop/tonemap.cc
+++ b/src/iop/tonemap.cc
@@ -94,7 +94,7 @@ dt_iop_colorspace_type_t default_colorspace(dt_iop_module_t *self,
   return IOP_CS_RGB;
 }
 
-void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
+void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
              void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_tonemapping_data_t *data = (dt_iop_tonemapping_data_t *)piece->data;
@@ -201,7 +201,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 
 // GUI
 //
-void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_t *pipe,
+void commit_params(dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_t *pipe,
                    dt_dev_pixelpipe_iop_t *piece)
 {
   dt_iop_tonemapping_params_t *p = (dt_iop_tonemapping_params_t *)p1;
@@ -210,18 +210,18 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
   d->Fsize = p->Fsize;
 }
 
-void init_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
+void init_pipe(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
   piece->data = malloc(sizeof(dt_iop_tonemapping_data_t));
 }
 
-void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
+void cleanup_pipe(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
   free(piece->data);
   piece->data = NULL;
 }
 
-void gui_init(struct dt_iop_module_t *self)
+void gui_init(dt_iop_module_t *self)
 {
   dt_iop_tonemapping_gui_data_t *g = IOP_GUI_ALLOC(tonemapping);
 

--- a/src/iop/velvia.c
+++ b/src/iop/velvia.c
@@ -230,20 +230,20 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
 }
 #endif
 
-void init_global(dt_iop_module_so_t *module)
+void init_global(dt_iop_module_so_t *self)
 {
   const int program = 8; // extended.cl, from programs.conf
   dt_iop_velvia_global_data_t *gd = malloc(sizeof(dt_iop_velvia_global_data_t));
-  module->data = gd;
+  self->data = gd;
   gd->kernel_velvia = dt_opencl_create_kernel(program, "velvia");
 }
 
-void cleanup_global(dt_iop_module_so_t *module)
+void cleanup_global(dt_iop_module_so_t *self)
 {
-  dt_iop_velvia_global_data_t *gd = module->data;
+  dt_iop_velvia_global_data_t *gd = self->data;
   dt_opencl_free_kernel(gd->kernel_velvia);
-  free(module->data);
-  module->data = NULL;
+  free(self->data);
+  self->data = NULL;
 }
 
 void commit_params(dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_t *pipe,

--- a/src/iop/vibrance.c
+++ b/src/iop/vibrance.c
@@ -151,22 +151,21 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
 
 
 
-void init_global(dt_iop_module_so_t *module)
+void init_global(dt_iop_module_so_t *self)
 {
   const int program = 8; // extended.cl, from programs.conf
   dt_iop_vibrance_global_data_t *gd = malloc(sizeof(dt_iop_vibrance_global_data_t));
-  module->data = gd;
+  self->data = gd;
   gd->kernel_vibrance = dt_opencl_create_kernel(program, "vibrance");
 }
 
-void cleanup_global(dt_iop_module_so_t *module)
+void cleanup_global(dt_iop_module_so_t *self)
 {
-  dt_iop_vibrance_global_data_t *gd = module->data;
+  dt_iop_vibrance_global_data_t *gd = self->data;
   dt_opencl_free_kernel(gd->kernel_vibrance);
-  free(module->data);
-  module->data = NULL;
+  free(self->data);
+  self->data = NULL;
 }
-
 
 void commit_params(dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_t *pipe,
                    dt_dev_pixelpipe_iop_t *piece)

--- a/src/iop/vignette.c
+++ b/src/iop/vignette.c
@@ -950,21 +950,21 @@ int process_cl(dt_iop_module_t *self,
 #endif
 
 
-void init_global(dt_iop_module_so_t *module)
+void init_global(dt_iop_module_so_t *self)
 {
   const int program = 8; // extended.cl from programs.conf
   dt_iop_vignette_global_data_t *gd = malloc(sizeof(dt_iop_vignette_global_data_t));
-  module->data = gd;
+  self->data = gd;
   gd->kernel_vignette = dt_opencl_create_kernel(program, "vignette");
 }
 
 
-void cleanup_global(dt_iop_module_so_t *module)
+void cleanup_global(dt_iop_module_so_t *self)
 {
-  dt_iop_vignette_global_data_t *gd = module->data;
+  dt_iop_vignette_global_data_t *gd = self->data;
   dt_opencl_free_kernel(gd->kernel_vignette);
-  free(module->data);
-  module->data = NULL;
+  free(self->data);
+  self->data = NULL;
 }
 
 

--- a/src/iop/zonesystem.c
+++ b/src/iop/zonesystem.c
@@ -143,7 +143,7 @@ static inline int _iop_zonesystem_zone_index_from_lightness(float lightness, flo
 }
 
 /* calculate a zonemap with scale values for each zone based on controlpoints from param */
-static inline void _iop_zonesystem_calculate_zonemap(struct dt_iop_zonesystem_params_t *p, float *zonemap)
+static inline void _iop_zonesystem_calculate_zonemap(dt_iop_zonesystem_params_t *p, float *zonemap)
 {
   int steps = 0;
   int pk = 0;
@@ -170,7 +170,7 @@ static inline void _iop_zonesystem_calculate_zonemap(struct dt_iop_zonesystem_pa
   }
 }
 
-static void process_common_setup(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece,
+static void process_common_setup(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece,
                                  const void *const ivoid, void *const ovoid, const dt_iop_roi_t *const roi_in,
                                  const dt_iop_roi_t *const roi_out)
 {
@@ -195,7 +195,7 @@ static void process_common_setup(struct dt_iop_module_t *self, dt_dev_pixelpipe_
   }
 }
 
-static void process_common_cleanup(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece,
+static void process_common_cleanup(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece,
                                    const void *const ivoid, void *const ovoid,
                                    const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
@@ -266,7 +266,7 @@ static void process_common_cleanup(struct dt_iop_module_t *self, dt_dev_pixelpip
   }
 }
 
-void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
+void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
              void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   if(!dt_iop_have_required_input_format(4 /*we need full-color pixels*/, self, piece->colors,
@@ -298,7 +298,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 }
 
 #ifdef HAVE_OPENCL
-int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_in, cl_mem dev_out,
+int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_in, cl_mem dev_out,
                const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_zonesystem_data_t *data = piece->data;
@@ -341,24 +341,24 @@ error:
 
 
 
-void init_global(dt_iop_module_so_t *module)
+void init_global(dt_iop_module_so_t *self)
 {
   const int program = 2; // basic.cl, from programs.conf
   dt_iop_zonesystem_global_data_t *gd = malloc(sizeof(dt_iop_zonesystem_global_data_t));
-  module->data = gd;
+  self->data = gd;
   gd->kernel_zonesystem = dt_opencl_create_kernel(program, "zonesystem");
 }
 
-void cleanup_global(dt_iop_module_so_t *module)
+void cleanup_global(dt_iop_module_so_t *self)
 {
-  dt_iop_zonesystem_global_data_t *gd = module->data;
+  dt_iop_zonesystem_global_data_t *gd = self->data;
   dt_opencl_free_kernel(gd->kernel_zonesystem);
-  free(module->data);
-  module->data = NULL;
+  free(self->data);
+  self->data = NULL;
 }
 
 
-void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_t *pipe,
+void commit_params(dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_t *pipe,
                    dt_dev_pixelpipe_iop_t *piece)
 {
   dt_iop_zonesystem_params_t *p = (dt_iop_zonesystem_params_t *)p1;
@@ -380,18 +380,18 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
     d->zonemap_offset[k] = 100.0f * ((k + 1) * zonemap[k] - k * zonemap[k + 1]);
 }
 
-void init_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
+void init_pipe(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
   piece->data = calloc(1, sizeof(dt_iop_zonesystem_data_t));
 }
 
-void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
+void cleanup_pipe(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
   free(piece->data);
   piece->data = NULL;
 }
 
-void gui_update(struct dt_iop_module_t *self)
+void gui_update(dt_iop_module_t *self)
 {
   dt_iop_zonesystem_gui_data_t *g = self->gui_data;
   gtk_widget_queue_draw(GTK_WIDGET(g->zones));
@@ -438,7 +438,7 @@ static void size_allocate_callback(GtkWidget *widget, GtkAllocation *allocation,
   }
 }
 
-void gui_init(struct dt_iop_module_t *self)
+void gui_init(dt_iop_module_t *self)
 {
   dt_iop_zonesystem_gui_data_t *g = IOP_GUI_ALLOC(zonesystem);
   g->in_preview_buffer = g->out_preview_buffer = NULL;
@@ -489,7 +489,7 @@ void gui_init(struct dt_iop_module_t *self)
   g->image_height = 0;
 }
 
-void gui_cleanup(struct dt_iop_module_t *self)
+void gui_cleanup(dt_iop_module_t *self)
 {
   DT_CONTROL_SIGNAL_DISCONNECT(_iop_zonesystem_redraw_preview_callback, self);
 


### PR DESCRIPTION
In case of internal module functions it should also always be `dt_iop_module_so_t *self`. Not consistent between modules.

While being here some redundant struct removed from function parameters.