### PR TITLE
Pixelpipe safety improvements and maintenance

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1372,8 +1372,7 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
               cachedir_from_command,
               tmpdir_from_command);
 
-  dt_print(DT_DEBUG_MEMORY, "[memory] at startup");
-  dt_print_mem_usage();
+  dt_print_mem_usage("at startup");
 
   char sharedir[PATH_MAX] = { 0 };
   dt_loc_get_sharedir(sharedir, sizeof(sharedir));
@@ -1827,9 +1826,6 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
     dt_gui_process_events();
   }
 
-  dt_print(DT_DEBUG_MEMORY, "[memory] after successful startup");
-  dt_print_mem_usage();
-
 /* init lua last, since it's user made stuff it must be in the real environment */
 #ifdef USE_LUA
   darktable_splash_screen_set_progress(_("initializing Lua"));
@@ -1916,6 +1912,9 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
 
   dt_print(DT_DEBUG_CONTROL,
            "[dt_init] startup took %f seconds", dt_get_wtime() - start_wtime);
+
+  dt_print_mem_usage("after successful startup");
+
   return 0;
 }
 
@@ -2482,7 +2481,7 @@ void dt_capabilities_cleanup()
 }
 
 
-void dt_print_mem_usage()
+void dt_print_mem_usage(char *info)
 {
   if(!(darktable.unmuted & DT_DEBUG_MEMORY))
     return;
@@ -2517,11 +2516,12 @@ void dt_print_mem_usage()
   fclose(f);
 
   dt_print(DT_DEBUG_ALWAYS,
-                  "[memory] max address space (vmpeak): %15s"
-                  "            [memory] cur address space (vmsize): %15s"
-                  "            [memory] max used memory   (vmhwm ): %15s"
-                  "            [memory] cur used memory   (vmrss ): %15s",
-          vmpeak, vmsize, vmhwm, vmrss);
+                  "[memory] %s\n"
+                  "             max address space (vmpeak): %15s"
+                  "             cur address space (vmsize): %15s"
+                  "             max used memory   (vmhwm ): %15s"
+                  "             cur used memory   (vmrss ): %15s",
+          info, vmpeak, vmsize, vmhwm, vmrss);
 
 #elif defined(__APPLE__)
   struct task_basic_info t_info;
@@ -2529,17 +2529,18 @@ void dt_print_mem_usage()
 
   if(KERN_SUCCESS != task_info(mach_task_self(), TASK_BASIC_INFO, (task_info_t)&t_info, &t_info_count))
   {
-    dt_print(DT_DEBUG_ALWAYS, "[memory] task memory info unknown.");
+    dt_print(DT_DEBUG_ALWAYS, "[memory] task memory info unknown");
     return;
   }
 
   // Report in kB, to match output of /proc on Linux.
   dt_print(DT_DEBUG_ALWAYS,
-                  "[memory] max address space (vmpeak): %15s\n"
-                  "            [memory] cur address space (vmsize): %12llu kB\n"
-                  "            [memory] max used memory   (vmhwm ): %15s\n"
-                  "            [memory] cur used memory   (vmrss ): %12llu kB",
-          "unknown", (uint64_t)t_info.virtual_size / 1024, "unknown", (uint64_t)t_info.resident_size / 1024);
+                  "[memory] %s\n"
+                  "            max address space (vmpeak): %15s\n"
+                  "            cur address space (vmsize): %12llu kB\n"
+                  "            max used memory   (vmhwm ): %15s\n"
+                  "            cur used memory   (vmrss ): %12llu kB",
+          info, "unknown", (uint64_t)t_info.virtual_size / 1024, "unknown", (uint64_t)t_info.resident_size / 1024);
 #elif defined (_WIN32)
   //Based on: http://stackoverflow.com/questions/63166/how-to-determine-cpu-and-memory-consumption-from-inside-a-process
   MEMORYSTATUSEX memInfo;
@@ -2561,11 +2562,12 @@ void dt_print_mem_usage()
 
 
   dt_print(DT_DEBUG_ALWAYS,
-                  "[memory] max address space (vmpeak): %12llu kB\n"
-                  "            [memory] cur address space (vmsize): %12llu kB\n"
-                  "            [memory] max used memory   (vmhwm ): %12llu kB\n"
-                  "            [memory] cur used memory   (vmrss ): %12llu Kb",
-          virtualMemUsedByMeMax / 1024, virtualMemUsedByMe / 1024, physMemUsedByMeMax / 1024,
+                  "[memory] %s\n"
+                  "            max address space (vmpeak): %12llu kB\n"
+                  "            cur address space (vmsize): %12llu kB\n"
+                  "            max used memory   (vmhwm ): %12llu kB\n"
+                  "            cur used memory   (vmrss ): %12llu Kb",
+          info, virtualMemUsedByMeMax / 1024, virtualMemUsedByMe / 1024, physMemUsedByMeMax / 1024,
           physMemUsedByMe / 1024);
 
 #else

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -884,7 +884,7 @@ static inline gboolean dt_slist_length_equal(GSList *l1, GSList *l2)
 }
 
 // checks internally for DT_DEBUG_MEMORY
-void dt_print_mem_usage();
+void dt_print_mem_usage(char *info);
 
 // try to start the backthumbs crawler
 void dt_start_backtumbs_crawler();

--- a/src/develop/pixelpipe_cache.c
+++ b/src/develop/pixelpipe_cache.c
@@ -459,7 +459,7 @@ void dt_dev_pixelpipe_cache_checkmem(dt_dev_pixelpipe_t *pipe)
   }
 
   _cline_stats(cache);
-  dt_print_pipe(DT_DEBUG_PIPE, "pipe cache check", pipe, NULL, DT_DEVICE_NONE, NULL, NULL,
+  dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_MEMORY, "pipe cache check", pipe, NULL, DT_DEVICE_NONE, NULL, NULL,
     "%i lines (important=%i, used=%i). Freed %iMB. Using using %iMB, limit=%iMB",
     cache->entries, cache->limportant, cache->lused,
     _to_mb(freed), _to_mb(cache->allmem), _to_mb(cache->memlimit));
@@ -470,7 +470,7 @@ void dt_dev_pixelpipe_cache_report(dt_dev_pixelpipe_t *pipe)
   dt_dev_pixelpipe_cache_t *cache = &(pipe->cache);
 
   _cline_stats(cache);
-  dt_print_pipe(DT_DEBUG_PIPE, "cache report", pipe, NULL, DT_DEVICE_NONE, NULL, NULL,
+  dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_MEMORY, "cache report", pipe, NULL, DT_DEVICE_NONE, NULL, NULL,
     "%i lines (important=%i, used=%i, invalid=%i). Using %iMB, limit=%iMB. Hits/run=%.2f. Hits/test=%.3f",
     cache->entries, cache->limportant, cache->lused, cache->linvalid,
     _to_mb(cache->allmem), _to_mb(cache->memlimit),

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -1919,13 +1919,13 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
                   && (cho == 1 || cho == 4)
                   && dt_str_commasubstring(darktable.dump_diff_pipe, module->op))
               {
-                const size_t ow = roi_out->width;
-                const size_t oh = roi_out->height;
-                const size_t iw = roi_in.width;
-                const size_t ih = roi_in.height;
-                float *clindata = dt_alloc_align_float(iw * ih * ch);
-                float *cloutdata = dt_alloc_align_float(ow * oh * cho);
-                float *cpudata = dt_alloc_align_float(ow * oh * cho);
+                const int ow = roi_out->width;
+                const int oh = roi_out->height;
+                const int iw = roi_in.width;
+                const int ih = roi_in.height;
+                float *clindata = dt_alloc_align_float((size_t)iw * ih * ch);
+                float *cloutdata = dt_alloc_align_float((size_t)ow * oh * cho);
+                float *cpudata = dt_alloc_align_float((size_t)ow * oh * cho);
                 if(clindata && cloutdata && cpudata)
                 {
                   cl_int terr = dt_opencl_read_host_from_device(pipe->devid, cloutdata, *cl_mem_output, ow, oh, cho * sizeof(float));

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -256,12 +256,17 @@ gboolean dt_dev_pixelpipe_init_cached(dt_dev_pixelpipe_t *pipe,
   return dt_dev_pixelpipe_cache_init(pipe, entries, size, memlimit);
 }
 
-static void get_output_format(
-              dt_iop_module_t *module,
-              dt_dev_pixelpipe_t *pipe,
-              dt_dev_pixelpipe_iop_t *piece,
-              dt_develop_t *dev,
-              dt_iop_buffer_dsc_t *dsc)
+size_t dt_get_available_pipe_mem(const dt_dev_pixelpipe_t *pipe)
+{
+  size_t allmem = dt_get_available_mem();
+  return MAX(1lu * 1024lu * 1024lu, allmem / (pipe->type & DT_DEV_PIXELPIPE_THUMBNAIL ? 3 : 1));
+}
+
+static void get_output_format(dt_iop_module_t *module,
+                              dt_dev_pixelpipe_t *pipe,
+                              dt_dev_pixelpipe_iop_t *piece,
+                              dt_develop_t *dev,
+                              dt_iop_buffer_dsc_t *dsc)
 {
   if(module) return module->output_format(module, pipe, piece, dsc);
 
@@ -662,15 +667,14 @@ void dt_dev_pixelpipe_usedetails(dt_dev_pixelpipe_t *pipe)
   pipe->want_detail_mask = TRUE;
 }
 
-static void _dump_pipe_pfm_diff(
-        const char *mod,
-        const void *indata,
-        const dt_iop_roi_t *roi_in,
-        const int inbpp,
-        const void *outdata,
-        const dt_iop_roi_t *roi_out,
-        const int outbpp,
-        const char *pipe)
+static void _dump_pipe_pfm_diff(const char *mod,
+                                const void *indata,
+                                const dt_iop_roi_t *roi_in,
+                                const int inbpp,
+                                const void *outdata,
+                                const dt_iop_roi_t *roi_out,
+                                const int outbpp,
+                                const char *pipe)
 {
   if(!darktable.dump_pfm_pipe) return;
   if(!mod) return;

--- a/src/develop/pixelpipe_hb.h
+++ b/src/develop/pixelpipe_hb.h
@@ -231,6 +231,8 @@ gboolean dt_dev_pixelpipe_init_cached(dt_dev_pixelpipe_t *pipe,
                                       const size_t size,
                                       const int32_t entries,
                                       const size_t memlimit);
+// returns available memory for the pipe
+size_t dt_get_available_pipe_mem(const dt_dev_pixelpipe_t *pipe);
 // constructs a new input buffer from given RGB float array.
 void dt_dev_pixelpipe_set_input(dt_dev_pixelpipe_t *pipe,
                                 struct dt_develop_t *dev,

--- a/src/develop/tiling.c
+++ b/src/develop/tiling.c
@@ -606,7 +606,7 @@ static void _default_process_tiling_ptp(dt_iop_module_t *self,
   }
 
   /* calculate optimal size of tiles */
-  float available = dt_get_available_mem();
+  float available = dt_get_available_pipe_mem(piece->pipe);
   assert(available >= 500.0f * 1024.0f * 1024.0f);
   /* correct for size of ivoid and ovoid which are needed on top of tiling */
   available = fmaxf(available - ((float)roi_out->width * roi_out->height * out_bpp)
@@ -880,7 +880,7 @@ static void _default_process_tiling_roi(dt_iop_module_t *self,
   }
 
   /* calculate optimal size of tiles */
-  float available = dt_get_available_mem();
+  float available = dt_get_available_pipe_mem(piece->pipe);
   assert(available >= 500.0f * 1024.0f * 1024.0f);
   /* correct for size of ivoid and ovoid which are needed on top of tiling */
   available = fmaxf(available - ((float)roi_out->width * roi_out->height * out_bpp)
@@ -1204,7 +1204,7 @@ float dt_tiling_estimate_cpumem(dt_develop_tiling_t *tiling,
 
   float fullscale = fmaxf(roi_in->scale / roi_out->scale, sqrtf(((float)roi_in->width * roi_in->height)
                                                               / ((float)roi_out->width * roi_out->height)));
-  float available = dt_get_available_mem();
+  float available = dt_get_available_pipe_mem(piece->pipe);
   available = fmaxf(available - ((float)roi_out->width * roi_out->height * max_bpp)
                    - ((float)roi_in->width * roi_in->height * max_bpp) - tiling->overhead, 0.0f);
 
@@ -2240,7 +2240,7 @@ gboolean dt_tiling_piece_fits_host_memory(const dt_dev_pixelpipe_iop_t *piece,
                                           const float factor,
                                           const size_t overhead)
 {
-  const size_t available = dt_get_available_mem();
+  const size_t available = dt_get_available_pipe_mem(piece->pipe);
   const size_t total = factor * width * height * bpp + overhead;
 
   return (total <= available) ? TRUE : FALSE;

--- a/src/develop/tiling.c
+++ b/src/develop/tiling.c
@@ -1199,7 +1199,7 @@ float dt_tiling_estimate_cpumem(dt_develop_tiling_t *tiling,
 {
   const int m_dx = MAX(roi_in->width, roi_out->width);
   const int m_dy = MAX(roi_in->height, roi_out->height);
-  if(dt_tiling_piece_fits_host_memory(m_dx, m_dy, max_bpp, tiling->factor, tiling->overhead))
+  if(dt_tiling_piece_fits_host_memory(piece, m_dx, m_dy, max_bpp, tiling->factor, tiling->overhead))
     return (float)m_dx * m_dy * max_bpp * tiling->factor + tiling->overhead;
 
   float fullscale = fmaxf(roi_in->scale / roi_out->scale, sqrtf(((float)roi_in->width * roi_in->height)
@@ -2233,7 +2233,8 @@ void default_tiling_callback(dt_iop_module_t *self,
   return;
 }
 
-gboolean dt_tiling_piece_fits_host_memory(const size_t width,
+gboolean dt_tiling_piece_fits_host_memory(const dt_dev_pixelpipe_iop_t *piece,
+                                          const size_t width,
                                           const size_t height,
                                           const unsigned bpp,
                                           const float factor,

--- a/src/develop/tiling.h
+++ b/src/develop/tiling.h
@@ -71,7 +71,7 @@ void tiling_callback(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t
                      const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out,
                      struct dt_develop_tiling_t *tiling);
 
-gboolean dt_tiling_piece_fits_host_memory(const size_t width, const size_t height, const unsigned bpp,
+gboolean dt_tiling_piece_fits_host_memory(const struct dt_dev_pixelpipe_iop_t *piece, const size_t width, const size_t height, const unsigned bpp,
                                      const float factor, const size_t overhead);
 
 float dt_tiling_estimate_cpumem(struct dt_develop_tiling_t *tiling, struct dt_dev_pixelpipe_iop_t *piece,

--- a/src/imageio/imageio.c
+++ b/src/imageio/imageio.c
@@ -126,7 +126,7 @@ typedef enum {
   DT_FILETYPE_PEF,	// Pentax
   DT_FILETYPE_RAF,	// Fujifilm
   DT_FILETYPE_RW2,	// Panasonic
-  DT_FILETYPE_SRW,	
+  DT_FILETYPE_SRW,
   DT_FILETYPE_X3F,	// Sigma Foveon
   DT_FILETYPE_OTHER_RAW,
   DT_FILETYPE_DNG,
@@ -1236,7 +1236,7 @@ gboolean dt_imageio_export_with_flags(const dt_imgid_t imgid,
   // note: not perfect but a reasonable good guess looking at overall pixelpipe requirements
   // and specific stuff in finalscale.
   const double max_possible_scale = fmin(100.0, fmax(1.0, // keep maximum allowed scale as we had in 4.6
-      (double)dt_get_available_mem() / (double)(1 + 64 * sizeof(float) * pipe.processed_width * pipe.processed_height)));
+      (double)dt_get_available_pipe_mem(&pipe) / (double)(1 + 64 * sizeof(float) * pipe.processed_width * pipe.processed_height)));
 
   const gboolean doscale = upscale && ((width > 0 || height > 0) || is_scaling);
   const double max_scale = doscale ? max_possible_scale : 1.00;
@@ -1612,25 +1612,25 @@ dt_imageio_retval_t dt_imageio_open(dt_image_t *img,
 
     if(!_image_handled(ret))
       ret = dt_imageio_open_exr(img, filename, buf);
-    
+
     if(!_image_handled(ret))
       ret = dt_imageio_open_rgbe(img, filename, buf);
-    
+
     if(!_image_handled(ret))
       ret = dt_imageio_open_j2k(img, filename, buf);
-    
+
     if(!_image_handled(ret))
       ret = dt_imageio_open_jpegxl(img, filename, buf);
-    
+
     if(!_image_handled(ret))
       ret = dt_imageio_open_jpeg(img, filename, buf);
-    
+
     if(!_image_handled(ret))
       ret = dt_imageio_open_qoi(img, filename, buf);
 
     if(!_image_handled(ret))
       ret = dt_imageio_open_pnm(img, filename, buf);
-    
+
     // final fallback that tries to open file via GraphicsMagick or ImageMagick
     if(!_image_handled(ret))
       ret = dt_imageio_open_exotic(img, filename, buf);


### PR DESCRIPTION
Inspired by #17684 (provided logs explaining the issue) and various reports like #17016 #15939 #13464 

As we don't keep track of allocated memory we can at least make sure the background thumbnail pipes don't take too much memory. For sure this is not a "complete" fix but it will certainly help to restrict memory consumption for those.

_________________________________________________________

Docs from commit messages

***Pixelpipe memory log maintenance***

1. Avoid double reports for pipe starting
2. refactor dt_print_mem_usage(), it now gets a message string passed avoiding
   am extra dt_print() call
3. log memory consumption also after pixelpipe has ended
4. log pixelpipe cache checks also with DT_DEBUG_MEMORY
5. dt_tiling_piece_fits_host_memory() gets the piece as an additional parameter.
   This allows it to check for pipe type and more.

***Introduce dt_get_available_pipe_mem()***

size_t dt_get_available_pipe_mem(const dt_dev_pixelpipe_t *pipe);

returns dt_get_available_mem() reduced in case the pixelpipe is DT_DEV_PIXELPIPE_THUMBNAIL
to allow safer background thumbnail generation.
In case of low-memory systems (8GB or so) this will prevent crashes due to OOM killer or
too high memory stress.

All checks within tiling code or tests for CPU tiling-required now use this variant instead of
full dt_get_available_mem()

***Fix OpenCL parameters when writing PFM diff files***

Resulting file when writing CPU vs GPU difference could be wrong due to wrong kernel parameters
for dt_opencl_read_host_from_device().
