### PR TITLE
RFC: replace union and intersection symbols of filters

### DIFF
--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -2160,9 +2160,10 @@ void dtgtk_cairo_paint_or(cairo_t *cr, gint x, gint y, gint w, gint h, gint flag
 {
   PREAMBLE(1, 1, 0, 0)
 
-  cairo_move_to(cr, 0.1, 0.3);
-  cairo_curve_to(cr, 0.1, 1.1, 0.9, 1.1, 0.9, 0.3);
-  cairo_stroke(cr);
+  cairo_set_font_size(cr, 0.9);
+
+  cairo_move_to(cr, 0.2, 0.85);
+  cairo_show_text(cr, "||");  
 
   FINISH
 }
@@ -2171,9 +2172,10 @@ void dtgtk_cairo_paint_and(cairo_t *cr, gint x, gint y, gint w, gint h, gint fla
 {
   PREAMBLE(1, 1, 0, 0)
 
-  cairo_move_to(cr, 0.1, 0.9);
-  cairo_curve_to(cr, 0.1, 0.1, 0.9, 0.1, 0.9, 0.9);
-  cairo_stroke(cr);
+  cairo_set_font_size(cr, 0.9);
+
+  cairo_move_to(cr, 0.2, 0.85);
+  cairo_show_text(cr, "&");  
 
   FINISH
 }

--- a/src/libs/filters/colors.c
+++ b/src/libs/filters/colors.c
@@ -304,8 +304,8 @@ static void _colors_widget_init(dt_lib_filtering_rule_t *rule, const dt_collecti
   gtk_box_pack_start(GTK_BOX(hbox), colors->operator, FALSE, FALSE, 2);
   gtk_widget_set_tooltip_text(colors->operator,
                               _("filter by images color label"
-                                "\nand (∩): images having all selected color labels"
-                                "\nor (∪): images with at least one of the selected color labels"));
+                                "\nand (&): images having all selected color labels"
+                                "\nor (||): images with at least one of the selected color labels"));
   g_signal_connect(G_OBJECT(colors->operator), "clicked", G_CALLBACK(_colors_operator_clicked), colors);
   g_signal_connect(G_OBJECT(colors->operator), "enter-notify-event", G_CALLBACK(_colors_enter_notify),
                    GINT_TO_POINTER(-1));


### PR DESCRIPTION
This PR replaces the mathematical union and intersection symbols of the color label filter with (IMO) easier to understand `&` for AND and `||` for OR.

I have marked this as RFC because this will for sure not meet everyone's taste.

fixes #15152 
