### PR TITLE
close splash screen by yes/no dialog

### DIFF
--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -2981,6 +2981,10 @@ gboolean dt_gui_show_standalone_yes_no_dialog(const char *title,
   }
 
   gtk_widget_show_all(window);
+
+  // to prevent the splash screen from hiding the yes/no dialog
+  darktable_splash_screen_destroy();
+
   gtk_window_set_keep_above(GTK_WINDOW(window), TRUE);
   gtk_main();
 


### PR DESCRIPTION
It seems that setting the yes/no dialog as the topmost window (#17688) is not sufficient on some systems.

To be on the safe side we close the splash screen when the yes/no dialog pops up.

fixes #17719