### PR TITLE
enable fallback loading when signature test identifies TIFF as a RAW …

### DIFF
--- a/src/imageio/imageio.c
+++ b/src/imageio/imageio.c
@@ -547,7 +547,14 @@ static dt_imageio_retval_t _open_by_magic_number(dt_image_t *img, const char *fi
 {
   const dt_magic_bytes_t *sig = _find_signature(filename);
   if(sig && sig->loader)
-    return sig->loader(img, filename, buf);
+  {
+    dt_imageio_retval_t status = sig->loader(img, filename, buf);
+    // if there's a secondary search string in the signature, it might have shown up spuriously,
+    // so if the loader says the file is corrupt, request the fallback loaders
+    if(status == DT_IMAGEIO_FILE_CORRUPTED && sig->searchstring)
+      return DT_IMAGEIO_UNRECOGNIZED;
+    return status;
+  }
   return DT_IMAGEIO_UNRECOGNIZED;
 }
 


### PR DESCRIPTION
…file due to presence of a manufaturer name in first 512 bytes

Fixes #17738 

The stacked file was identified as a NEF due to info copied from the original file's Exif data.  But as it wasn't actually one, rawspeed said it was corrupt.
