### PR TITLE
[imageio] Fix loading of TIFF files misidentified as raw files

### DIFF
--- a/src/imageio/imageio.c
+++ b/src/imageio/imageio.c
@@ -1584,7 +1584,10 @@ dt_imageio_retval_t dt_imageio_open(dt_image_t *img,
 
   // check for known magic numbers and call the appropriate loader if we recognize a magic number
   ret = _open_by_magic_number(img, filename, buf);
-  if(ret == DT_IMAGEIO_UNRECOGNIZED)
+
+  // Go to fallback path if we didn't recognize the magic bytes (UNRECOGNIZED)
+  // or the main loader has rejected the file (UNSUPPORTED_FORMAT)
+  if((ret == DT_IMAGEIO_UNRECOGNIZED) || (ret == DT_IMAGEIO_UNSUPPORTED_FORMAT))
   {
     // special case - most camera RAW files are TIFF containers, so if we have an LDR file extension,
     // try loading the file as TIFF

--- a/src/imageio/imageio_rawspeed.cc
+++ b/src/imageio/imageio_rawspeed.cc
@@ -131,7 +131,7 @@ uint32_t dt_rawspeed_crop_dcraw_filters(const uint32_t filters,
 
 static gboolean _ignore_image(const gchar *filename)
 {
-  gchar *extensions_whitelist;
+  gchar *extensions_ignorelist;
   const gchar *always_by_libraw = "cr3";
 
   gchar *ext = g_strrstr(filename, ".");
@@ -139,24 +139,24 @@ static gboolean _ignore_image(const gchar *filename)
   ext++;
 
   if(dt_conf_key_not_empty("libraw_extensions"))
-    extensions_whitelist = g_strjoin(" ", always_by_libraw,
-                                     dt_conf_get_string_const("libraw_extensions"),
-                                     (char *)NULL);
+    extensions_ignorelist = g_strjoin(" ", always_by_libraw,
+                                      dt_conf_get_string_const("libraw_extensions"),
+                                      (char *)NULL);
   else
-    extensions_whitelist = g_strdup(always_by_libraw);
+    extensions_ignorelist = g_strdup(always_by_libraw);
 
   dt_print(DT_DEBUG_IMAGEIO,
            "[rawspeed_open] extensions list to ignore: `%s'",
-           extensions_whitelist);
+           extensions_ignorelist);
 
   gchar *ext_lowercased = g_ascii_strdown(ext,-1);
-  if(g_strstr_len(extensions_whitelist,-1,ext_lowercased))
+  if(g_strstr_len(extensions_ignorelist,-1,ext_lowercased))
   {
-    g_free(extensions_whitelist);
+    g_free(extensions_ignorelist);
     g_free(ext_lowercased);
     return TRUE;
   }
-  g_free(extensions_whitelist);
+  g_free(extensions_ignorelist);
   g_free(ext_lowercased);
   return FALSE;
 }

--- a/src/imageio/imageio_rawspeed.cc
+++ b/src/imageio/imageio_rawspeed.cc
@@ -132,18 +132,18 @@ uint32_t dt_rawspeed_crop_dcraw_filters(const uint32_t filters,
 static gboolean _ignore_image(const gchar *filename)
 {
   gchar *extensions_ignorelist;
-  const gchar *always_by_libraw = "cr3";
+  const gchar *always_ignore = "cr3 tiff";
 
   gchar *ext = g_strrstr(filename, ".");
   if(!ext) return FALSE;
   ext++;
 
   if(dt_conf_key_not_empty("libraw_extensions"))
-    extensions_ignorelist = g_strjoin(" ", always_by_libraw,
+    extensions_ignorelist = g_strjoin(" ", always_ignore,
                                       dt_conf_get_string_const("libraw_extensions"),
                                       (char *)NULL);
   else
-    extensions_ignorelist = g_strdup(always_by_libraw);
+    extensions_ignorelist = g_strdup(always_ignore);
 
   dt_print(DT_DEBUG_IMAGEIO,
            "[rawspeed_open] extensions list to ignore: `%s'",


### PR DESCRIPTION
Resolves #17738.

Some raw file formats (such as NEF) have TIFF file signatures because they use the TIFF container format, but with special content.

Some programs (Hugin, Zerene Stacker) can create TIFF files without removing the metadata of the original raw files, by which we try to distinguish raw from actual TIFF. Since we define the loader by signature, we can be wrong in this case. That is why we should first check the file extension and transfer it to the fallback loader if the file is in fact a TIFF.
