### PR TITLE
[imageio] QOI loader maintenance

### DIFF
--- a/src/imageio/imageio.c
+++ b/src/imageio/imageio.c
@@ -1638,9 +1638,6 @@ dt_imageio_retval_t dt_imageio_open(dt_image_t *img,
       ret = dt_imageio_open_jpeg(img, filename, buf);
 
     if(!_image_handled(ret))
-      ret = dt_imageio_open_qoi(img, filename, buf);
-
-    if(!_image_handled(ret))
       ret = dt_imageio_open_pnm(img, filename, buf);
 
     // final fallback that tries to open file via GraphicsMagick or ImageMagick

--- a/src/imageio/imageio_qoi.c
+++ b/src/imageio/imageio_qoi.c
@@ -90,6 +90,7 @@ dt_imageio_retval_t dt_imageio_open_qoi(dt_image_t *img,
   float *mipbuf = (float *)dt_mipmap_cache_alloc(mbuf, img);
   if(!mipbuf)
   {
+    QOI_FREE(int_RGBA_buf);
     dt_print(DT_DEBUG_ALWAYS,
              "[qoi_open] could not alloc full buffer for image: %s",
              img->filename);

--- a/src/imageio/imageio_qoi.c
+++ b/src/imageio/imageio_qoi.c
@@ -38,19 +38,23 @@ dt_imageio_retval_t dt_imageio_open_qoi(dt_image_t *img,
   FILE *f = g_fopen(filename, "rb");
   if(!f)
   {
-    dt_print(DT_DEBUG_ALWAYS,"[qoi_open] cannot open file for read: %s", filename);
+    dt_print(DT_DEBUG_ALWAYS,
+             "[qoi_open] cannot open file for read: %s",
+             filename);
     return DT_IMAGEIO_FILE_NOT_FOUND;
   }
 
   fseek(f, 0, SEEK_END);
   size_t filesize = ftell(f);
-  fseek(f, 0, SEEK_SET);
+  rewind(f);
 
   void *read_buffer = g_malloc(filesize);
   if(!read_buffer)
   {
     fclose(f);
-    dt_print(DT_DEBUG_ALWAYS, "[qoi_open] failed to allocate buffer for %s", filename);
+    dt_print(DT_DEBUG_ALWAYS,
+             "[qoi_open] failed to allocate read buffer for %s",
+             filename);
     return DT_IMAGEIO_LOAD_FAILED;
   }
 
@@ -59,7 +63,7 @@ dt_imageio_retval_t dt_imageio_open_qoi(dt_image_t *img,
     fclose(f);
     g_free(read_buffer);
     dt_print(DT_DEBUG_ALWAYS,
-             "[qoi_open] failed to read %zu bytes from %s",
+             "[qoi_open] failed to read entire file (%zu bytes) from %s",
              filesize, filename);
     return DT_IMAGEIO_IOERROR;
   }
@@ -71,7 +75,9 @@ dt_imageio_retval_t dt_imageio_open_qoi(dt_image_t *img,
   if(!int_RGBA_buf)
   {
     g_free(read_buffer);
-    dt_print(DT_DEBUG_ALWAYS,"[qoi_open] failed to decode file: %s", filename);
+    dt_print(DT_DEBUG_ALWAYS,
+             "[qoi_open] failed to decode file: %s",
+             filename);
     return DT_IMAGEIO_FILE_CORRUPTED;
   }
 

--- a/src/imageio/imageio_qoi.c
+++ b/src/imageio/imageio_qoi.c
@@ -35,11 +35,6 @@ dt_imageio_retval_t dt_imageio_open_qoi(dt_image_t *img,
                                         const char *filename,
                                         dt_mipmap_buffer_t *mbuf)
 {
-  // We shouldn't expect QOI images in files with an extension other than .qoi
-  char *ext = g_strrstr(filename, ".");
-  if(ext && g_ascii_strcasecmp(ext, ".qoi"))
-    return DT_IMAGEIO_UNSUPPORTED_FORMAT;
-
   FILE *f = g_fopen(filename, "rb");
   if(!f)
   {

--- a/src/imageio/imageio_qoi.c
+++ b/src/imageio/imageio_qoi.c
@@ -72,9 +72,10 @@ dt_imageio_retval_t dt_imageio_open_qoi(dt_image_t *img,
   qoi_desc desc;
   uint8_t *int_RGBA_buf = qoi_decode(read_buffer, (int)filesize, &desc, 4);
 
+  g_free(read_buffer);
+
   if(!int_RGBA_buf)
   {
-    g_free(read_buffer);
     dt_print(DT_DEBUG_ALWAYS,
              "[qoi_open] failed to decode file: %s",
              filename);
@@ -89,7 +90,6 @@ dt_imageio_retval_t dt_imageio_open_qoi(dt_image_t *img,
   float *mipbuf = (float *)dt_mipmap_cache_alloc(mbuf, img);
   if(!mipbuf)
   {
-    g_free(read_buffer);
     dt_print(DT_DEBUG_ALWAYS,
              "[qoi_open] could not alloc full buffer for image: %s",
              img->filename);
@@ -113,7 +113,6 @@ dt_imageio_retval_t dt_imageio_open_qoi(dt_image_t *img,
   img->loader = LOADER_QOI;
 
   QOI_FREE(int_RGBA_buf);
-  g_free(read_buffer);
 
   return DT_IMAGEIO_OK;
 }

--- a/src/imageio/imageio_qoi.c
+++ b/src/imageio/imageio_qoi.c
@@ -59,28 +59,7 @@ dt_imageio_retval_t dt_imageio_open_qoi(dt_image_t *img,
     return DT_IMAGEIO_LOAD_FAILED;
   }
 
-  // Let's check whether the entire content of the file should be read into the buffer.
-  // If we see that it's a non-QOI file, we'll save time by avoiding unnecessary reading
-  // of a potentially large file into the buffer.
-  if(fread(read_buffer, 1, 4, f) != 4)
-  {
-    fclose(f);
-    g_free(read_buffer);
-    dt_print(DT_DEBUG_ALWAYS, "[qoi_open] failed to read from %s", filename);
-    // if we can't read even first 4 bytes, it's more like file disappeared
-    return DT_IMAGEIO_FILE_CORRUPTED;
-  }
-
-  if(memcmp(read_buffer, "qoif", 4) != 0)
-  {
-    fclose(f);
-    g_free(read_buffer);
-    dt_print(DT_DEBUG_ALWAYS,
-             "[qoi_open] no proper file header in %s", filename);
-    return DT_IMAGEIO_UNSUPPORTED_FORMAT;
-  }
-
-  if(fread(read_buffer+4, 1, filesize-4, f) != filesize-4)
+  if(fread(read_buffer, 1, filesize, f) != filesize)
   {
     fclose(f);
     g_free(read_buffer);


### PR DESCRIPTION
The more important or noticeable in use changes from these commits are as follows:

- Reduced maximum RAM usage due to earlier freeing of the read buffer.
- Fixed a memory leak when we already failed to allocate memory for the output buffer (_so this memory leak does not happen during normal operation, only when problems with available memory have already started, but still.._).
- We no longer limit the loading of QOI images to only files with the qoi extension (_not that it would be noticeable in practice, but with signature-based loading there's no point in this additional check_).
