### PR TITLE
Cleanup demosaicers

### DIFF
--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -1179,7 +1179,12 @@ static gboolean _pixelpipe_process_on_CPU(dt_dev_pixelpipe_t *pipe,
   if(!fitting && piece->process_tiling_ready)
   {
     dt_print_pipe(DT_DEBUG_PIPE,
-                  "process tiled", piece->pipe, module, DT_DEVICE_CPU, roi_in, roi_out);
+                        "process tiles",
+                        piece->pipe, module, DT_DEVICE_CPU, roi_in, roi_out, "%3i %s%s%s",
+                        module->iop_order,
+                        dt_iop_colorspace_to_name(cst_to),
+                        cst_to != cst_out ? " -> " : "",
+                        cst_to != cst_out ? dt_iop_colorspace_to_name(cst_out) : "");
     module->process_tiling(module, piece, input, *output, roi_in, roi_out, in_bpp);
 
     *pixelpipe_flow |= (PIXELPIPE_FLOW_PROCESSED_ON_CPU
@@ -2095,8 +2100,7 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
         // histogram collection for module
         if(success_opencl)
         {
-          _collect_histogram_on_CPU(pipe, dev, input, &roi_in, module, piece,
-                                    &pixelpipe_flow);
+          _collect_histogram_on_CPU(pipe, dev, input, &roi_in, module, piece, &pixelpipe_flow);
         }
 
         if(dt_atomic_get_int(&pipe->shutdown))
@@ -2113,8 +2117,7 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
                         dt_iop_colorspace_to_name(cst_to),
                         cst_to != cst_out ? " -> " : "",
                         cst_to != cst_out ? dt_iop_colorspace_to_name(cst_out) : "");
-          const int err = module->process_tiling_cl(module, piece, input, *output,
-                                                     &roi_in, roi_out, in_bpp);
+          const int err = module->process_tiling_cl(module, piece, input, *output, &roi_in, roi_out, in_bpp);
           success_opencl = (err == CL_SUCCESS);
 
           if(!success_opencl)

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -119,12 +119,12 @@ typedef enum dt_iop_demosaic_lmmse_t
 
 typedef struct dt_iop_demosaic_params_t
 {
-  dt_iop_demosaic_greeneq_t green_eq; // $DEFAULT: DT_IOP_GREEN_EQ_NO $DESCRIPTION: "match greens"
-  float median_thrs; // $MIN: 0.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "edge threshold"
-  dt_iop_demosaic_smooth_t color_smoothing; // $DEFAULT: DT_DEMOSAIC_SMOOTH_OFF $DESCRIPTION: "color smoothing"
-  dt_iop_demosaic_method_t demosaicing_method; // $DEFAULT: DT_IOP_DEMOSAIC_RCD $DESCRIPTION: "method"
-  dt_iop_demosaic_lmmse_t lmmse_refine; // $DEFAULT: DT_LMMSE_REFINE_1 $DESCRIPTION: "LMMSE refine"
-  float dual_thrs; // $MIN: 0.0 $MAX: 1.0 $DEFAULT: 0.20 $DESCRIPTION: "dual threshold"
+  dt_iop_demosaic_greeneq_t green_eq;           // $DEFAULT: DT_IOP_GREEN_EQ_NO $DESCRIPTION: "match greens"
+  float median_thrs;                            // $MIN: 0.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "edge threshold"
+  dt_iop_demosaic_smooth_t color_smoothing;     // $DEFAULT: DT_DEMOSAIC_SMOOTH_OFF $DESCRIPTION: "color smoothing"
+  dt_iop_demosaic_method_t demosaicing_method;  // $DEFAULT: DT_IOP_DEMOSAIC_RCD $DESCRIPTION: "method"
+  dt_iop_demosaic_lmmse_t lmmse_refine;         // $DEFAULT: DT_LMMSE_REFINE_1 $DESCRIPTION: "LMMSE refine"
+  float dual_thrs;                              // $MIN: 0.0 $MAX: 1.0 $DEFAULT: 0.20 $DESCRIPTION: "dual threshold"
 } dt_iop_demosaic_params_t;
 
 typedef struct dt_iop_demosaic_gui_data_t
@@ -206,7 +206,7 @@ typedef struct dt_iop_demosaic_data_t
   float dual_thrs;
 } dt_iop_demosaic_data_t;
 
-static gboolean get_thumb_quality(int width, int height)
+static gboolean _get_thumb_quality(const int width, const int height)
 {
   // we check if we need ultra-high quality thumbnail for this size
   const dt_mipmap_size_t level = dt_mipmap_cache_get_matching_size(darktable.mipmap_cache, width, height);
@@ -218,10 +218,9 @@ static gboolean get_thumb_quality(int width, int height)
 
 // set flags for demosaic quality based on factors besides demosaic
 // method (e.g. config, scale, pixelpipe type)
-static dt_iop_demosaic_qual_flags_t demosaic_qual_flags(
-        const dt_dev_pixelpipe_iop_t *const piece,
-        const dt_image_t *const img,
-        const dt_iop_roi_t *const roi_out)
+static dt_iop_demosaic_qual_flags_t demosaic_qual_flags(const dt_dev_pixelpipe_iop_t *const piece,
+                                                        const dt_image_t *const img,
+                                                        const dt_iop_roi_t *const roi_out)
 {
   const uint32_t filters = piece->pipe->dsc.filters;
   const gboolean is_xtrans = filters == 9u;
@@ -236,8 +235,7 @@ static dt_iop_demosaic_qual_flags_t demosaic_qual_flags(
       flags |= DT_DEMOSAIC_FULL_SCALE;
       break;
     case DT_DEV_PIXELPIPE_THUMBNAIL:
-      flags |= (piece->pipe->want_detail_mask
-                || (get_thumb_quality(roi_out->width, roi_out->height)))
+      flags |= (piece->pipe->want_detail_mask || _get_thumb_quality(roi_out->width, roi_out->height))
                   ? DT_DEMOSAIC_FULL_SCALE
                   : DT_DEMOSAIC_DEFAULT;
       break;
@@ -266,13 +264,12 @@ static dt_iop_demosaic_qual_flags_t demosaic_qual_flags(
 }
 
 // Implemented in demosaicing/amaze.cc
-void amaze_demosaic(
-    dt_dev_pixelpipe_iop_t *piece,
-    const float *const in,
-    float *out,
-    const dt_iop_roi_t *const roi_in,
-    const dt_iop_roi_t *const roi_out,
-    const uint32_t filters);
+void amaze_demosaic(dt_dev_pixelpipe_iop_t *piece,
+                    const float *const in,
+                    float *out,
+                    const dt_iop_roi_t *const roi_in,
+                    const dt_iop_roi_t *const roi_out,
+                    const uint32_t filters);
 
 #include "iop/demosaicing/basics.c"
 #include "iop/demosaicing/vng.c"
@@ -427,12 +424,12 @@ void modify_roi_in(dt_iop_module_t *self,
   roi_in->height /= roi_out->scale;
   roi_in->scale = 1.0f;
 
-  dt_iop_demosaic_data_t *data = piece->data;
-  const dt_iop_demosaic_method_t method = data->demosaicing_method;
-  const gboolean passthrough = (method == DT_IOP_DEMOSAIC_PASSTHROUGH_MONOCHROME) ||
-                               (method == DT_IOP_DEMOSAIC_PASSTHR_MONOX) ||
-                               (method == DT_IOP_DEMOSAIC_PASSTHROUGH_COLOR) ||
-                               (method == DT_IOP_DEMOSAIC_PASSTHR_COLORX);
+  dt_iop_demosaic_data_t *d = piece->data;
+  const dt_iop_demosaic_method_t method = d->demosaicing_method;
+  const gboolean passthrough = method == DT_IOP_DEMOSAIC_PASSTHROUGH_MONOCHROME ||
+                               method == DT_IOP_DEMOSAIC_PASSTHR_MONOX ||
+                               method == DT_IOP_DEMOSAIC_PASSTHROUGH_COLOR ||
+                               method == DT_IOP_DEMOSAIC_PASSTHR_COLORX;
   // set position to closest top/left sensor pattern snap
   if(!passthrough)
   {
@@ -468,21 +465,21 @@ void tiling_callback(dt_iop_module_t *self,
                      const dt_iop_roi_t *roi_out,
                      dt_develop_tiling_t *tiling)
 {
-  dt_iop_demosaic_data_t *data = piece->data;
+  dt_iop_demosaic_data_t *d = piece->data;
 
   const float ioratio = (float)roi_out->width * roi_out->height / ((float)roi_in->width * roi_in->height);
-  const float smooth = data->color_smoothing ? ioratio : 0.0f;
+  const float smooth = d->color_smoothing ? ioratio : 0.0f;
   const gboolean is_xtrans = piece->pipe->dsc.filters == 9u;
-  const float greeneq = (!is_xtrans && (data->green_eq != DT_IOP_GREEN_EQ_NO)) ? 0.25f : 0.0f;
-  const dt_iop_demosaic_method_t demosaicing_method = data->demosaicing_method & ~DT_DEMOSAIC_DUAL;
+  const float greeneq = (!is_xtrans && (d->green_eq != DT_IOP_GREEN_EQ_NO)) ? 0.25f : 0.0f;
+  const dt_iop_demosaic_method_t demosaicing_method = d->demosaicing_method & ~DT_DEMOSAIC_DUAL;
 
   const int qual_flags = demosaic_qual_flags(piece, &self->dev->image_storage, roi_out);
   const int full_scale = qual_flags & DT_DEMOSAIC_FULL_SCALE;
 
   // check if output buffer has same dimension as input buffer (thus avoiding one
   // additional temporary buffer)
-  const gboolean unscaled = (roi_out->width == roi_in->width && roi_out->height == roi_in->height);
-  const gboolean is_opencl = piece->pipe->devid >= 0;
+  const gboolean unscaled = roi_out->width == roi_in->width && roi_out->height == roi_in->height;
+  const gboolean is_opencl = piece->pipe->devid > DT_DEVICE_CPU;
   // define aligners
   tiling->xalign = is_xtrans ? DT_XTRANS_SNAPPER : DT_BAYER_SNAPPER;
   tiling->yalign = is_xtrans ? DT_XTRANS_SNAPPER : DT_BAYER_SNAPPER;
@@ -490,10 +487,10 @@ void tiling_callback(dt_iop_module_t *self,
   tiling->maxbuf = 1.0f;
   tiling->overhead = 0;
 
-  if((demosaicing_method == DT_IOP_DEMOSAIC_PPG) ||
-      (demosaicing_method == DT_IOP_DEMOSAIC_PASSTHROUGH_MONOCHROME) ||
-      (demosaicing_method == DT_IOP_DEMOSAIC_PASSTHROUGH_COLOR) ||
-      (demosaicing_method == DT_IOP_DEMOSAIC_AMAZE))
+  if(demosaicing_method == DT_IOP_DEMOSAIC_PPG ||
+     demosaicing_method == DT_IOP_DEMOSAIC_PASSTHROUGH_MONOCHROME ||
+     demosaicing_method == DT_IOP_DEMOSAIC_PASSTHROUGH_COLOR ||
+     demosaicing_method == DT_IOP_DEMOSAIC_AMAZE)
   {
     // Bayer pattern with PPG, Passthrough or Amaze
     tiling->factor = 1.0f + ioratio;         // in + out
@@ -508,13 +505,13 @@ void tiling_callback(dt_iop_module_t *self,
     tiling->overhead = 0;
     tiling->overlap = 5; // take care of border handling
   }
-  else if(((demosaicing_method == DT_IOP_DEMOSAIC_MARKESTEIJN) ||
-           (demosaicing_method == DT_IOP_DEMOSAIC_MARKESTEIJN_3) ||
-           (demosaicing_method == DT_IOP_DEMOSAIC_FDC)))
+  else if(demosaicing_method == DT_IOP_DEMOSAIC_MARKESTEIJN ||
+          demosaicing_method == DT_IOP_DEMOSAIC_MARKESTEIJN_3 ||
+          demosaicing_method == DT_IOP_DEMOSAIC_FDC)
   {
     // X-Trans pattern full Markesteijn processing
-    const int ndir = (demosaicing_method == DT_IOP_DEMOSAIC_MARKESTEIJN_3) ? 8 : 4;
-    const int overlap = (demosaicing_method == DT_IOP_DEMOSAIC_MARKESTEIJN_3) ? 18 : 12;
+    const int ndir = demosaicing_method == DT_IOP_DEMOSAIC_MARKESTEIJN_3 ? 8 : 4;
+    const int overlap = demosaicing_method == DT_IOP_DEMOSAIC_MARKESTEIJN_3 ? 18 : 12;
 
     tiling->factor = 1.0f + ioratio;
     tiling->factor += ndir * 1.0f      // rgb
@@ -572,7 +569,7 @@ void tiling_callback(dt_iop_module_t *self,
     tiling->overlap = 6;
   }
 
-  if(data->demosaicing_method & DT_DEMOSAIC_DUAL)
+  if(d->demosaicing_method & DT_DEMOSAIC_DUAL)
   {
     // make sure VNG4 is also possible
     tiling->factor += 1.0f;
@@ -592,26 +589,33 @@ void process(dt_iop_module_t *self,
 
   dt_dev_clear_scharr_mask(piece->pipe);
 
-  dt_iop_roi_t roi = *roi_in;
   dt_iop_roi_t roo = *roi_out;
   roo.x = roo.y = 0;
-  // roi_out->scale = global scale: (iscale == 1.0, always when demosaic is on)
+
   const gboolean run_fast = piece->pipe->type & DT_DEV_PIXELPIPE_FAST;
+  const gboolean fullpipe = piece->pipe->type & DT_DEV_PIXELPIPE_FULL;
 
   const uint8_t(*const xtrans)[6] = (const uint8_t(*const)[6])piece->pipe->dsc.xtrans;
 
-  dt_iop_demosaic_data_t *data = piece->data;
+  const dt_iop_demosaic_data_t *d = piece->data;
+  const dt_iop_demosaic_gui_data_t *g = self->gui_data;
 
   const int qual_flags = demosaic_qual_flags(piece, img, roi_out);
-  int demosaicing_method = data->demosaicing_method;
+  const gboolean fullscale = qual_flags & DT_DEMOSAIC_FULL_SCALE;
+  const gboolean is_xtrans = piece->pipe->dsc.filters == 9u;
+  const gboolean is_4bayer = img->flags & DT_IMAGE_4BAYER;
+  const gboolean is_bayer = !is_xtrans && piece->pipe->dsc.filters != 0;
 
-  if(roi_out->width < 16 || roi_out->height < 16)
-    demosaicing_method = (piece->pipe->dsc.filters == 9u) ? DT_IOP_DEMOSAIC_MARKEST3_VNG : DT_IOP_DEMOSAIC_VNG4;
+  int demosaicing_method = d->demosaicing_method;
+  const int width = roi_in->width;
+  const int height = roi_in->height;
+
+  if(width < 16 || height < 16)
+    demosaicing_method = is_xtrans ? DT_IOP_DEMOSAIC_MARKEST3_VNG : DT_IOP_DEMOSAIC_VNG4;
 
   gboolean showmask = FALSE;
-  if(self->dev->gui_attached && (piece->pipe->type & DT_DEV_PIXELPIPE_FULL))
+  if(self->dev->gui_attached && fullpipe)
   {
-    dt_iop_demosaic_gui_data_t *g = self->gui_data;
     if(g->visual_mask)
     {
       showmask = TRUE;
@@ -619,138 +623,120 @@ void process(dt_iop_module_t *self,
     }
     // take care of passthru modes
     if(piece->pipe->mask_display == DT_DEV_PIXELPIPE_DISPLAY_PASSTHRU)
-      demosaicing_method = (piece->pipe->dsc.filters != 9u) ? DT_IOP_DEMOSAIC_RCD : DT_IOP_DEMOSAIC_MARKESTEIJN;
+      demosaicing_method = is_xtrans ? DT_IOP_DEMOSAIC_MARKESTEIJN : DT_IOP_DEMOSAIC_RCD;
   }
 
-  const float *const pixels = (float *)i;
+  float *in  = (float *)i;
+  float *out = (float *) o;
 
-  if(qual_flags & DT_DEMOSAIC_FULL_SCALE)
+  if(!fullscale)
   {
-    // Full demosaic and then scaling if needed
-    const gboolean scaled = (roi_out->width != roi_in->width || roi_out->height != roi_in->height);
-    float *tmp = (float *) o;
-    if(scaled)
-    {
-      // demosaic and then clip and zoom
-      // we demosaic at 1:1 the size of input roi, so make sure
-      // we fit these bounds exactly, to avoid crashes..
-      roo.width = roi_in->width;
-      roo.height = roi_in->height;
-      roo.scale = 1.0f;
-      tmp = (float *)dt_alloc_align_float((size_t)4 * roo.width * roo.height);
-    }
-
-    if(demosaicing_method == DT_IOP_DEMOSAIC_PASSTHROUGH_MONOCHROME)
-    {
-      passthrough_monochrome(tmp, pixels, &roo, &roi);
-    }
-    else if(demosaicing_method == DT_IOP_DEMOSAIC_PASSTHROUGH_COLOR)
-    {
-      passthrough_color(tmp, pixels, &roo, &roi, piece->pipe->dsc.filters, xtrans);
-    }
-    else if(piece->pipe->dsc.filters == 9u)
-    {
-      const int passes = (demosaicing_method == DT_IOP_DEMOSAIC_MARKESTEIJN) ? 1 : 3;
-      if(demosaicing_method == DT_IOP_DEMOSAIC_MARKEST3_VNG)
-        xtrans_markesteijn_interpolate(tmp, pixels, &roo, &roi, xtrans, passes);
-      else if(demosaicing_method == DT_IOP_DEMOSAIC_FDC && (qual_flags & DT_DEMOSAIC_FULL_SCALE))
-        xtrans_fdc_interpolate(self, tmp, pixels, &roo, &roi, xtrans);
-      else if(demosaicing_method >= DT_IOP_DEMOSAIC_MARKESTEIJN && (qual_flags & DT_DEMOSAIC_FULL_SCALE))
-        xtrans_markesteijn_interpolate(tmp, pixels, &roo, &roi, xtrans, passes);
-      else
-        vng_interpolate(tmp, pixels, &roo, &roi, piece->pipe->dsc.filters, xtrans, qual_flags & DT_DEMOSAIC_ONLY_VNG_LINEAR);
-    }
+    dt_print_pipe(DT_DEBUG_PIPE, "demosaic approx zoom", piece->pipe, self, DT_DEVICE_CPU, roi_in, roi_out);
+    if(demosaicing_method == DT_IOP_DEMOSAIC_PASSTHROUGH_MONOCHROME || demosaicing_method == DT_IOP_DEMOSAIC_PASSTHROUGH_COLOR)
+      dt_iop_clip_and_zoom_demosaic_passthrough_monochrome_f(out, in, &roo, roi_in, roi_out->width, width);
+    else if(is_xtrans)
+      dt_iop_clip_and_zoom_demosaic_third_size_xtrans_f(out, in, &roo, roi_in, roi_out->width, width, xtrans);
     else
+      dt_iop_clip_and_zoom_demosaic_half_size_f(out, in, &roo, roi_in, roi_out->width, width, piece->pipe->dsc.filters);
+
+    return;
+  }
+
+  const int base_demosaicing_method = demosaicing_method & ~DT_DEMOSAIC_DUAL;
+  const gboolean dual = (demosaicing_method & DT_DEMOSAIC_DUAL) && !run_fast;
+
+  const gboolean direct = roi_out->width == width && roi_out->height == height;
+
+  if(!direct)
+  {
+    // demosaic and then clip and zoom
+    // we demosaic at 1:1 the size of input roi, so make sure
+    // we fit these bounds exactly, to avoid crashes.
+    // FIXME: instead of fighting with roi_out data for the CPU demosaicers we should rework all
+    // CPU demosaicer code using only roi_in as we do already for OpenCL code path.
+    roo.width = width;
+    roo.height = height;
+    roo.scale = 1.0f;
+    out = dt_alloc_align_float((size_t)4 * width * height);
+  }
+
+  if(is_bayer && d->green_eq != DT_IOP_GREEN_EQ_NO)
+  {
+    const float threshold = 0.0001f * img->exif_iso;
+    in = dt_alloc_align_float((size_t)height * width);
+    float *aux = NULL;
+
+    switch(d->green_eq)
     {
-      float *in = (float *)pixels;
-      float *aux;
-
-      if(!(img->flags & DT_IMAGE_4BAYER) && data->green_eq != DT_IOP_GREEN_EQ_NO)
-      {
-        const float threshold = 0.0001f * img->exif_iso;
-        in = (float *)dt_alloc_align_float((size_t)roi_in->height * roi_in->width);
-        switch(data->green_eq)
-        {
-          case DT_IOP_GREEN_EQ_FULL:
-            green_equilibration_favg(in, pixels, roi_in->width, roi_in->height, piece->pipe->dsc.filters,
-                                     roi_in->x, roi_in->y);
-            break;
-          case DT_IOP_GREEN_EQ_LOCAL:
-            green_equilibration_lavg(in, pixels, roi_in->width, roi_in->height, piece->pipe->dsc.filters,
-                                     roi_in->x, roi_in->y, threshold);
-            break;
-          case DT_IOP_GREEN_EQ_BOTH:
-            aux = dt_alloc_align_float((size_t)roi_in->height * roi_in->width);
-            green_equilibration_favg(aux, pixels, roi_in->width, roi_in->height, piece->pipe->dsc.filters,
-                                     roi_in->x, roi_in->y);
-            green_equilibration_lavg(in, aux, roi_in->width, roi_in->height, piece->pipe->dsc.filters, roi_in->x,
-                                     roi_in->y, threshold);
-            dt_free_align(aux);
-            break;
-        }
-      }
-
-      if(demosaicing_method == DT_IOP_DEMOSAIC_VNG4 || (img->flags & DT_IMAGE_4BAYER))
-      {
-        vng_interpolate(tmp, in, &roo, &roi, piece->pipe->dsc.filters, xtrans, qual_flags & DT_DEMOSAIC_ONLY_VNG_LINEAR);
-        if(img->flags & DT_IMAGE_4BAYER)
-        {
-          dt_colorspaces_cygm_to_rgb(tmp, roo.width*roo.height, data->CAM_to_RGB);
-          dt_colorspaces_cygm_to_rgb(piece->pipe->dsc.processed_maximum, 1, data->CAM_to_RGB);
-        }
-      }
-      else if((demosaicing_method & ~DT_DEMOSAIC_DUAL) == DT_IOP_DEMOSAIC_RCD)
-      {
-        rcd_demosaic(piece, tmp, in, &roo, &roi, piece->pipe->dsc.filters);
-      }
-      else if(demosaicing_method == DT_IOP_DEMOSAIC_LMMSE)
-      {
-        lmmse_demosaic(piece, tmp, in, &roo, &roi, piece->pipe->dsc.filters, data->lmmse_refine);
-      }
-      else if((demosaicing_method & ~DT_DEMOSAIC_DUAL) != DT_IOP_DEMOSAIC_AMAZE)
-        demosaic_ppg(tmp, in, &roo, &roi, piece->pipe->dsc.filters, data->median_thrs);
-      else
-        amaze_demosaic(piece, in, tmp, &roi, &roo, piece->pipe->dsc.filters);
-
-      if(!(img->flags & DT_IMAGE_4BAYER) && data->green_eq != DT_IOP_GREEN_EQ_NO)
-        dt_free_align(in);
+      case DT_IOP_GREEN_EQ_FULL:
+        green_equilibration_favg(in, (float *)i, width, height, piece->pipe->dsc.filters, roi_in->x, roi_in->y);
+        break;
+      case DT_IOP_GREEN_EQ_LOCAL:
+        green_equilibration_lavg(in, (float *)i, width, height, piece->pipe->dsc.filters, roi_in->x, roi_in->y, threshold);
+        break;
+      case DT_IOP_GREEN_EQ_BOTH:
+        aux = dt_alloc_align_float((size_t)height * width);
+        green_equilibration_favg(aux, (float *)i, width, height, piece->pipe->dsc.filters, roi_in->x, roi_in->y);
+        green_equilibration_lavg(in, aux, width, height, piece->pipe->dsc.filters, roi_in->x, roi_in->y, threshold);
+        dt_free_align(aux);
+        break;
     }
+  }
 
-    if(piece->pipe->want_detail_mask)
-      dt_dev_write_scharr_mask(piece, tmp, roi_in, TRUE);
-
-    if((demosaicing_method & DT_DEMOSAIC_DUAL) && !run_fast)
-    {
-      dual_demosaic(piece, tmp, pixels, &roo, &roi, piece->pipe->dsc.filters, xtrans, showmask, data->dual_thrs);
-    }
-
-    if(scaled)
-    {
-      roi = *roi_out;
-      dt_print_pipe(DT_DEBUG_PIPE, "clip_and_zoom_roi",
-        piece->pipe, self, DT_DEVICE_CPU, roi_in, roi_out);
-      dt_iop_clip_and_zoom_roi((float *)o, tmp, &roi, &roo);
-      dt_free_align(tmp);
-    }
+  if(demosaicing_method == DT_IOP_DEMOSAIC_PASSTHROUGH_MONOCHROME)
+    passthrough_monochrome(out, in, &roo, roi_in);
+  else if(demosaicing_method == DT_IOP_DEMOSAIC_PASSTHROUGH_COLOR)
+    passthrough_color(out, in, &roo, roi_in, piece->pipe->dsc.filters, xtrans);
+  else if(is_xtrans)
+  {
+    const int passes = base_demosaicing_method == DT_IOP_DEMOSAIC_MARKESTEIJN_3 ? 3 : 1;
+    if(demosaicing_method == DT_IOP_DEMOSAIC_MARKEST3_VNG)
+      vng_interpolate(out, in, &roo, roi_in, piece->pipe->dsc.filters, xtrans, qual_flags & DT_DEMOSAIC_ONLY_VNG_LINEAR);
+    else if(demosaicing_method == DT_IOP_DEMOSAIC_FDC)
+      xtrans_fdc_interpolate(self, out, in, &roo, roi_in, xtrans);
+    else if(base_demosaicing_method == DT_IOP_DEMOSAIC_MARKESTEIJN || base_demosaicing_method == DT_IOP_DEMOSAIC_MARKESTEIJN_3)
+      xtrans_markesteijn_interpolate(out, in, &roo, roi_in, xtrans, passes);
+    else
+      vng_interpolate(out, in, &roo, roi_in, piece->pipe->dsc.filters, xtrans, qual_flags & DT_DEMOSAIC_ONLY_VNG_LINEAR);
   }
   else
   {
-    if(demosaicing_method == DT_IOP_DEMOSAIC_PASSTHROUGH_MONOCHROME)
-      dt_iop_clip_and_zoom_demosaic_passthrough_monochrome_f((float *)o, pixels, &roo, &roi, roo.width, roi.width);
-    else if(demosaicing_method == DT_IOP_DEMOSAIC_PASSTHROUGH_COLOR)
-       dt_iop_clip_and_zoom_demosaic_passthrough_monochrome_f((float *)o, pixels, &roo, &roi, roo.width, roi.width);
-    else if(piece->pipe->dsc.filters == 9u)
-      dt_iop_clip_and_zoom_demosaic_third_size_xtrans_f((float *)o, pixels, &roo, &roi, roo.width, roi.width, xtrans);
+    if(demosaicing_method == DT_IOP_DEMOSAIC_VNG4 || is_4bayer)
+    {
+      vng_interpolate(out, in, &roo, roi_in, piece->pipe->dsc.filters, xtrans, qual_flags & DT_DEMOSAIC_ONLY_VNG_LINEAR);
+      if(is_4bayer)
+      {
+        dt_colorspaces_cygm_to_rgb(out, width * height, d->CAM_to_RGB);
+        dt_colorspaces_cygm_to_rgb(piece->pipe->dsc.processed_maximum, 1, d->CAM_to_RGB);
+      }
+    }
+    else if(base_demosaicing_method == DT_IOP_DEMOSAIC_RCD)
+      rcd_demosaic(piece, out, in, roi_in, piece->pipe->dsc.filters);
+    else if(demosaicing_method == DT_IOP_DEMOSAIC_LMMSE)
+      lmmse_demosaic(piece, out, in, roi_in, piece->pipe->dsc.filters, d->lmmse_refine);
+    else if(base_demosaicing_method != DT_IOP_DEMOSAIC_AMAZE)
+      demosaic_ppg(out, in, &roo, roi_in, piece->pipe->dsc.filters, d->median_thrs);
     else
-      dt_iop_clip_and_zoom_demosaic_half_size_f((float *)o, pixels, &roo, &roi, roo.width, roi.width,
-                                                piece->pipe->dsc.filters);
-
-    // this is used for preview pipes, currently there is now writing mask implemented
-    // we just clear the mask data as we might have changed the preview downsampling
-    dt_dev_clear_scharr_mask(piece->pipe);
+      amaze_demosaic(piece, in, out, roi_in, &roo, piece->pipe->dsc.filters);
   }
-  if(data->color_smoothing)
-    color_smoothing(o, roi_out, data->color_smoothing);
+
+  if(piece->pipe->want_detail_mask)
+    dt_dev_write_scharr_mask(piece, out, roi_in, TRUE);
+
+  if(dual)
+    dual_demosaic(piece, out, in, &roo, roi_in, piece->pipe->dsc.filters, xtrans, showmask, d->dual_thrs);
+
+  if((float *)i != in) dt_free_align(in);
+
+  if(d->color_smoothing)
+    color_smoothing(out, roi_in, d->color_smoothing);
+
+  if(!direct)
+  {
+    dt_print_pipe(DT_DEBUG_PIPE, "demosaic clip_and_zoom", piece->pipe, self, DT_DEVICE_CPU, roi_in, roi_out);
+    dt_iop_clip_and_zoom_roi((float *)o, out, roi_out, &roo);
+    dt_free_align(out);
+  }
 }
 
 #ifdef HAVE_OPENCL
@@ -761,21 +747,30 @@ int process_cl(dt_iop_module_t *self,
                const dt_iop_roi_t *const roi_in,
                const dt_iop_roi_t *const roi_out)
 {
+  const dt_image_t *img = &self->dev->image_storage;
   const gboolean run_fast = piece->pipe->type & DT_DEV_PIXELPIPE_FAST;
+  const gboolean fullpipe = piece->pipe->type & DT_DEV_PIXELPIPE_FULL;
+  const int qual_flags = demosaic_qual_flags(piece, img, roi_out);
+  const gboolean fullscale = qual_flags & DT_DEMOSAIC_FULL_SCALE;
+  const gboolean is_xtrans = piece->pipe->dsc.filters == 9u;
+  const gboolean is_bayer = !is_xtrans && piece->pipe->dsc.filters != 0;
 
   dt_dev_clear_scharr_mask(piece->pipe);
 
-  dt_iop_demosaic_data_t *data = piece->data;
+  const dt_iop_demosaic_data_t *d = piece->data;
+  const dt_iop_demosaic_gui_data_t *g = self->gui_data;
+  const dt_iop_demosaic_global_data_t *gd = self->global_data;
 
-  int demosaicing_method = data->demosaicing_method;
+  int demosaicing_method = d->demosaicing_method;
+  const int width = roi_in->width;
+  const int height = roi_in->height;
 
-  if(roi_out->width < 16 || roi_out->height < 16)
-    demosaicing_method = (piece->pipe->dsc.filters == 9u) ? DT_IOP_DEMOSAIC_MARKEST3_VNG : DT_IOP_DEMOSAIC_VNG4;
+  if(width < 16 || height < 16)
+    demosaicing_method = is_xtrans ? DT_IOP_DEMOSAIC_MARKEST3_VNG : DT_IOP_DEMOSAIC_VNG4;
 
   gboolean showmask = FALSE;
-  if(self->dev->gui_attached && (piece->pipe->type & DT_DEV_PIXELPIPE_FULL))
+  if(self->dev->gui_attached && fullpipe)
   {
-    dt_iop_demosaic_gui_data_t *g = self->gui_data;
     if(g->visual_mask)
     {
       showmask = TRUE;
@@ -783,100 +778,128 @@ int process_cl(dt_iop_module_t *self,
     }
     // take care of passthru modes
     if(piece->pipe->mask_display == DT_DEV_PIXELPIPE_DISPLAY_PASSTHRU)
-      demosaicing_method = (piece->pipe->dsc.filters != 9u) ? DT_IOP_DEMOSAIC_RCD : DT_IOP_DEMOSAIC_MARKESTEIJN;
+      demosaicing_method = is_xtrans ? DT_IOP_DEMOSAIC_MARKESTEIJN : DT_IOP_DEMOSAIC_RCD;
   }
 
-  const int qual_flags = demosaic_qual_flags(piece, &self->dev->image_storage, roi_out);
-  cl_mem high_image = NULL;
-  cl_mem low_image = NULL;
-
-  const gboolean dual = ((demosaicing_method & DT_DEMOSAIC_DUAL) && (qual_flags & DT_DEMOSAIC_FULL_SCALE) && !run_fast);
   const int devid = piece->pipe->devid;
-  int err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
 
-  if(dev_in  == NULL || dev_out == NULL)
+  cl_int err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
+
+  if(dev_in  == NULL || dev_out == NULL) return err;
+
+  if(!fullscale)
+  {
+    dt_print_pipe(DT_DEBUG_PIPE, "demosaic approx zoom", piece->pipe, self, piece->pipe->devid, roi_in, roi_out);
+    const int zero = 0;
+    if(is_xtrans)
+    {
+      cl_mem dev_xtrans = dt_opencl_copy_host_to_device_constant(devid, sizeof(piece->pipe->dsc.xtrans), piece->pipe->dsc.xtrans);
+      if(dev_xtrans == NULL) return err;
+      // sample third-size image
+      err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_zoom_third_size, roi_out->width, roi_out->height,
+          CLARG(dev_in), CLARG(dev_out), CLARG(roi_out->width), CLARG(roi_out->height), CLARG(roi_in->x), CLARG(roi_in->y),
+          CLARG(width), CLARG(height), CLARG(roi_out->scale), CLARG(dev_xtrans));
+      dt_opencl_release_mem_object(dev_xtrans);
+      return err;
+    }
+    else if(demosaicing_method == DT_IOP_DEMOSAIC_PASSTHROUGH_MONOCHROME)
+      return dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_zoom_passthrough_monochrome, roi_out->width, roi_out->height,
+          CLARG(dev_in), CLARG(dev_out), CLARG(roi_out->width), CLARG(roi_out->height), CLARG(zero), CLARG(zero), CLARG(width),
+          CLARG(height), CLARG(roi_out->scale), CLARG(piece->pipe->dsc.filters));
+    else // bayer
+      return dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_zoom_half_size, roi_out->width, roi_out->height,
+          CLARG(dev_in), CLARG(dev_out), CLARG(roi_out->width), CLARG(roi_out->height), CLARG(zero), CLARG(zero), CLARG(width),
+          CLARG(height), CLARG(roi_out->scale), CLARG(piece->pipe->dsc.filters));
+  }
+
+  const gboolean direct = roi_out->width == width && roi_out->height == height;
+  const int base_demosaicing_method = demosaicing_method & ~DT_DEMOSAIC_DUAL;
+  const gboolean dual = (demosaicing_method & DT_DEMOSAIC_DUAL) && !run_fast;
+
+  cl_mem out_image = direct ? dev_out : dt_opencl_alloc_device(devid, width, height, sizeof(float) * 4);
+  cl_mem in_image = dev_in;
+
+  if(out_image == NULL)
     goto finish;
 
-  if(dual)
+  if(is_bayer && d->green_eq != DT_IOP_GREEN_EQ_NO)
   {
-    high_image = dt_opencl_alloc_device(devid, roi_in->width, roi_in->height, sizeof(float) * 4);
-    if(high_image == NULL)
-      goto finish;
+    in_image = dt_opencl_alloc_device(devid, width, height, sizeof(float));
+    if(in_image == NULL) goto finish;
+
+    err = green_equilibration_cl(self, piece, dev_in, in_image, roi_in);
+    if(err != CL_SUCCESS) goto finish;
   }
 
   if(demosaicing_method == DT_IOP_DEMOSAIC_PASSTHROUGH_MONOCHROME ||
      demosaicing_method == DT_IOP_DEMOSAIC_PPG ||
-     demosaicing_method == DT_IOP_DEMOSAIC_PASSTHROUGH_COLOR )
+     demosaicing_method == DT_IOP_DEMOSAIC_PASSTHROUGH_COLOR)
   {
-    err = process_default_cl(self, piece, dev_in, dev_out, roi_in, roi_out, demosaicing_method);
+    err = process_default_cl(self, piece, in_image, out_image, roi_in, demosaicing_method);
     if(err != CL_SUCCESS) return err;
   }
-  else if((demosaicing_method & ~DT_DEMOSAIC_DUAL) == DT_IOP_DEMOSAIC_RCD)
+  else if(base_demosaicing_method == DT_IOP_DEMOSAIC_RCD)
   {
-    if(dual)
-    {
-      err = process_rcd_cl(self, piece, dev_in, high_image, roi_in, roi_in, FALSE);
-      if(err != CL_SUCCESS) goto finish;
-    }
-    else
-    {
-      err = process_rcd_cl(self, piece, dev_in, dev_out, roi_in, roi_out, TRUE);
-      if(err != CL_SUCCESS) return err;
-    }
+    err = process_rcd_cl(self, piece, in_image, out_image, roi_in);
+    if(err != CL_SUCCESS) goto finish;
   }
   else if(demosaicing_method == DT_IOP_DEMOSAIC_VNG4 || demosaicing_method == DT_IOP_DEMOSAIC_VNG)
   {
-    err = process_vng_cl(self, piece, dev_in, dev_out, roi_in, roi_out, TRUE, FALSE, TRUE);
-    if(err != CL_SUCCESS) return err;
+    err = process_vng_cl(self, piece, in_image, out_image, roi_in, FALSE);
+    if(err != CL_SUCCESS) goto finish;
   }
-  else if((demosaicing_method == DT_IOP_DEMOSAIC_MARKESTEIJN || demosaicing_method == DT_IOP_DEMOSAIC_MARKESTEIJN_3) &&
-    !(qual_flags & DT_DEMOSAIC_FULL_SCALE))
+  else if(demosaicing_method == DT_IOP_DEMOSAIC_MARKEST3_VNG)
   {
-    err = process_vng_cl(self, piece, dev_in, dev_out, roi_in, roi_out, TRUE, qual_flags & DT_DEMOSAIC_ONLY_VNG_LINEAR, TRUE);
-    if(err != CL_SUCCESS) return err;
+    err = process_vng_cl(self, piece, in_image, out_image, roi_in, qual_flags & DT_DEMOSAIC_ONLY_VNG_LINEAR);
+    if(err != CL_SUCCESS) goto finish;
   }
-  else if(((demosaicing_method & ~DT_DEMOSAIC_DUAL) == DT_IOP_DEMOSAIC_MARKESTEIJN ) ||
-          ((demosaicing_method & ~DT_DEMOSAIC_DUAL) == DT_IOP_DEMOSAIC_MARKESTEIJN_3))
+  else if(base_demosaicing_method == DT_IOP_DEMOSAIC_MARKESTEIJN || base_demosaicing_method == DT_IOP_DEMOSAIC_MARKESTEIJN_3)
   {
-    if(dual)
-    {
-      err = process_markesteijn_cl(self, piece, dev_in, high_image, roi_in, roi_in, FALSE);
-      if(err != CL_SUCCESS) goto finish;
-    }
-    else
-    {
-      err = process_markesteijn_cl(self, piece, dev_in, dev_out, roi_in, roi_out, TRUE);
-      if(err != CL_SUCCESS) return err;
-    }
+    err = process_markesteijn_cl(self, piece, in_image, out_image, roi_in);
+    if(err != CL_SUCCESS) goto finish;
   }
   else
   {
     dt_print(DT_DEBUG_OPENCL, "[opencl_demosaic] demosaicing method %d not yet supported by opencl code", demosaicing_method);
-    return DT_OPENCL_PROCESS_CL;
+    err = DT_OPENCL_PROCESS_CL;
+    goto finish;
   }
 
-  if(!dual) goto finish;
-
-  err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
-  low_image = dt_opencl_alloc_device(devid, roi_in->width, roi_in->height, sizeof(float) * 4);
-  if(low_image == NULL) goto finish;
-
-  err = process_vng_cl(self, piece, dev_in, low_image, roi_in, roi_in, FALSE, FALSE, FALSE);
-  if(err == CL_SUCCESS)
+  if(piece->pipe->want_detail_mask)
   {
-    err = color_smoothing_cl(self, piece, low_image, low_image, roi_in, 2);
+    err = dt_dev_write_scharr_mask_cl(piece, out_image, roi_in, TRUE);
     if(err != CL_SUCCESS) goto finish;
-    err = dual_demosaic_cl(self, piece, high_image, low_image, high_image, roi_in, showmask);
   }
 
-  dt_opencl_release_mem_object(low_image);
-  low_image = NULL;
+  if(dual)
+  {
+    err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
+    cl_mem low_image = dt_opencl_alloc_device(devid, width, height, sizeof(float) * 4);
+    if(low_image)
+    {
+      err = process_vng_cl(self, piece, in_image, low_image, roi_in, FALSE);
+      if(err == CL_SUCCESS)
+        err = color_smoothing_cl(self, piece, low_image, low_image, roi_out, d->color_smoothing);
+      if(err == CL_SUCCESS)
+        err = dual_demosaic_cl(self, piece, out_image, low_image, out_image, roi_in, showmask);
+      dt_opencl_release_mem_object(low_image);
+    }
+    if(err != CL_SUCCESS) goto finish;
+  }
 
-  err = dt_iop_clip_and_zoom_roi_cl(devid, dev_out, high_image, roi_out, roi_in);
+  if(d->color_smoothing)
+  {
+    err = color_smoothing_cl(self, piece, out_image, out_image, roi_out, d->color_smoothing);
+    if(err != CL_SUCCESS) goto finish;
+  }
 
-  finish:
-  dt_opencl_release_mem_object(high_image);
-  dt_opencl_release_mem_object(low_image);
+  dt_print_pipe(DT_DEBUG_PIPE, "demosaic clip_and_zoom", piece->pipe, self, piece->pipe->devid, roi_in, roi_out);
+  err = dt_iop_clip_and_zoom_roi_cl(devid, dev_out, out_image, roi_out, roi_in);
+
+finish:
+
+  if(in_image != dev_in) dt_opencl_release_mem_object(in_image);
+  if(out_image != dev_out) dt_opencl_release_mem_object(out_image);
 
   return err;
 }
@@ -887,6 +910,7 @@ void init_global(dt_iop_module_so_t *self)
   const int program = 0; // from programs.conf
   dt_iop_demosaic_global_data_t *gd = malloc(sizeof(dt_iop_demosaic_global_data_t));
   self->data = gd;
+
   gd->kernel_zoom_half_size = dt_opencl_create_kernel(program, "clip_and_zoom_demosaic_half_size");
   gd->kernel_ppg_green = dt_opencl_create_kernel(program, "ppg_demosaic_green");
   gd->kernel_green_eq_lavg = dt_opencl_create_kernel(program, "green_equilibration_lavg");
@@ -1010,10 +1034,11 @@ void commit_params(dt_iop_module_t *self,
                    dt_dev_pixelpipe_t *pipe,
                    dt_dev_pixelpipe_iop_t *piece)
 {
-  dt_iop_demosaic_params_t *p = (dt_iop_demosaic_params_t *)params;
+  const dt_iop_demosaic_params_t *const p = (dt_iop_demosaic_params_t *)params;
   dt_iop_demosaic_data_t *d = piece->data;
 
-  if(!(dt_image_is_raw(&pipe->image))) piece->enabled = FALSE;
+  if(!dt_image_is_raw(&pipe->image))
+    piece->enabled = FALSE;
   d->green_eq = p->green_eq;
   d->color_smoothing = p->color_smoothing;
   d->median_thrs = p->median_thrs;
@@ -1023,21 +1048,24 @@ void commit_params(dt_iop_module_t *self,
 
   const gboolean xmethod = use_method & DT_DEMOSAIC_XTRANS;
   const gboolean bayer4  = self->dev->image_storage.flags & DT_IMAGE_4BAYER;
-  const gboolean bayer   = (self->dev->image_storage.buf_dsc.filters != 9u) && !bayer4;
-  const gboolean xtrans = self->dev->image_storage.buf_dsc.filters == 9u;
+  const gboolean bayer   = self->dev->image_storage.buf_dsc.filters != 9u && !bayer4;
+  const gboolean xtrans  = self->dev->image_storage.buf_dsc.filters == 9u;
 
-  if(bayer && xmethod)   use_method = DT_IOP_DEMOSAIC_RCD;
-  if(xtrans && !xmethod) use_method = DT_IOP_DEMOSAIC_MARKESTEIJN;
-
+  if(bayer && xmethod)
+    use_method = DT_IOP_DEMOSAIC_RCD;
+  if(xtrans && !xmethod)
+    use_method = DT_IOP_DEMOSAIC_MARKESTEIJN;
   // we don't have to fully check for available bayer4 modes here as process() takes care of this
-  if(bayer4)             use_method &= ~DT_DEMOSAIC_DUAL;
+  if(bayer4)
+    use_method &= ~DT_DEMOSAIC_DUAL;
 
   if(use_method == DT_IOP_DEMOSAIC_PASSTHROUGH_MONOCHROME || use_method == DT_IOP_DEMOSAIC_PASSTHR_MONOX)
     use_method = DT_IOP_DEMOSAIC_PASSTHROUGH_MONOCHROME;
   if(use_method == DT_IOP_DEMOSAIC_PASSTHROUGH_COLOR || use_method == DT_IOP_DEMOSAIC_PASSTHR_COLORX)
     use_method = DT_IOP_DEMOSAIC_PASSTHROUGH_COLOR;
 
-  const gboolean passing = (use_method == DT_IOP_DEMOSAIC_PASSTHROUGH_MONOCHROME || use_method == DT_IOP_DEMOSAIC_PASSTHROUGH_COLOR);
+  const gboolean passing = use_method == DT_IOP_DEMOSAIC_PASSTHROUGH_MONOCHROME
+                        || use_method == DT_IOP_DEMOSAIC_PASSTHROUGH_COLOR;
 
   if(!(use_method == DT_IOP_DEMOSAIC_PPG))
     d->median_thrs = 0.0f;
@@ -1118,7 +1146,7 @@ void commit_params(dt_iop_module_t *self,
   if(bayer4)
   {
     // 4Bayer images not implemented in OpenCL yet
-    piece->process_cl_ready = 0;
+    piece->process_cl_ready = FALSE;
 
     // Get and store the matrix to go from camera to RGB for 4Bayer images
     if(!dt_colorspaces_conversion_matrices_rgb(self->dev->image_storage.adobe_XYZ_to_CAM,
@@ -1168,30 +1196,31 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
   dt_iop_demosaic_gui_data_t *g = self->gui_data;
   dt_iop_demosaic_params_t *p = self->params;
 
-  const gboolean bayer4  = self->dev->image_storage.flags & DT_IMAGE_4BAYER;
-  const gboolean bayer = (self->dev->image_storage.buf_dsc.filters != 9u) && !bayer4;
+  const gboolean bayer4 = self->dev->image_storage.flags & DT_IMAGE_4BAYER;
+  const gboolean bayer  = self->dev->image_storage.buf_dsc.filters != 9u && !bayer4;
   const gboolean xtrans = self->dev->image_storage.buf_dsc.filters == 9u;
 
   dt_iop_demosaic_method_t use_method = p->demosaicing_method;
   const gboolean xmethod = use_method & DT_DEMOSAIC_XTRANS;
 
-  if(bayer && xmethod)   use_method = DT_IOP_DEMOSAIC_RCD;
-  if(xtrans && !xmethod) use_method = DT_IOP_DEMOSAIC_MARKESTEIJN;
+  if(bayer && xmethod)
+    use_method = DT_IOP_DEMOSAIC_RCD;
+  if(xtrans && !xmethod)
+    use_method = DT_IOP_DEMOSAIC_MARKESTEIJN;
 
   const gboolean bayerpassing =
-   (use_method == DT_IOP_DEMOSAIC_PASSTHROUGH_MONOCHROME)
-   || (use_method == DT_IOP_DEMOSAIC_PASSTHROUGH_COLOR);
+      use_method == DT_IOP_DEMOSAIC_PASSTHROUGH_MONOCHROME
+   || use_method == DT_IOP_DEMOSAIC_PASSTHROUGH_COLOR;
 
   if(bayer4 && !(bayerpassing || (use_method == DT_IOP_DEMOSAIC_VNG4)))
     use_method = DT_IOP_DEMOSAIC_VNG4;
 
-  const gboolean isppg = (use_method == DT_IOP_DEMOSAIC_PPG);
-  const gboolean isdual = (use_method & DT_DEMOSAIC_DUAL) && !bayer4;
-  const gboolean islmmse = (use_method == DT_IOP_DEMOSAIC_LMMSE);
-  const gboolean passing =
-    bayerpassing
-    || (use_method == DT_IOP_DEMOSAIC_PASSTHR_MONOX)
-    || (use_method == DT_IOP_DEMOSAIC_PASSTHR_COLORX);
+  const gboolean isppg = use_method == DT_IOP_DEMOSAIC_PPG;
+  const gboolean isdual = use_method & DT_DEMOSAIC_DUAL && !bayer4;
+  const gboolean islmmse = use_method == DT_IOP_DEMOSAIC_LMMSE;
+  const gboolean passing = bayerpassing
+    || use_method == DT_IOP_DEMOSAIC_PASSTHR_MONOX
+    || use_method == DT_IOP_DEMOSAIC_PASSTHR_COLORX;
 
   gtk_widget_set_visible(g->demosaic_method_bayer, bayer);
   gtk_widget_set_visible(g->demosaic_method_bayerfour, bayer4);
@@ -1208,15 +1237,15 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
   p->demosaicing_method = use_method;
 
   gtk_widget_set_visible(g->median_thrs, bayer && isppg);
-  gtk_widget_set_visible(g->greeneq, !passing && !bayer4);
-  gtk_widget_set_visible(g->color_smoothing, !passing && !isdual && !bayer4);
+  gtk_widget_set_visible(g->greeneq, !passing && !bayer4 && !xtrans);
+  gtk_widget_set_visible(g->color_smoothing, !passing && !bayer4);
   gtk_widget_set_visible(g->dual_thrs, isdual);
   gtk_widget_set_visible(g->lmmse_refine, islmmse);
 
   dt_image_t *img = dt_image_cache_get(darktable.image_cache, self->dev->image_storage.id, 'w');
   int mono_changed = img->flags & DT_IMAGE_MONOCHROME_BAYER;
-  if((p->demosaicing_method == DT_IOP_DEMOSAIC_PASSTHROUGH_MONOCHROME) ||
-     (p->demosaicing_method == DT_IOP_DEMOSAIC_PASSTHR_MONOX))
+  if(p->demosaicing_method == DT_IOP_DEMOSAIC_PASSTHROUGH_MONOCHROME
+       || p->demosaicing_method == DT_IOP_DEMOSAIC_PASSTHR_MONOX)
     img->flags |= DT_IMAGE_MONOCHROME_BAYER;
   else
     img->flags &= ~DT_IMAGE_MONOCHROME_BAYER;

--- a/src/iop/demosaicing/amaze.cc
+++ b/src/iop/demosaicing/amaze.cc
@@ -127,11 +127,11 @@ static inline float _xdivf(float d, int n)
 
 
 void amaze_demosaic(dt_dev_pixelpipe_iop_t *piece,
-                       const float *const in,
-                       float *out,
-                       const dt_iop_roi_t *const roi_in,
-                       const dt_iop_roi_t *const roi_out,
-                       const uint32_t filters)
+                    const float *const in,
+                    float *out,
+                    const dt_iop_roi_t *const roi_in,
+                    const dt_iop_roi_t *const roi_out,
+                    const uint32_t filters)
 {
   int winx = roi_out->x;
   int winy = roi_out->y;

--- a/src/iop/demosaicing/basics.c
+++ b/src/iop/demosaicing/basics.c
@@ -24,13 +24,12 @@
   }
 
 DT_OMP_DECLARE_SIMD(aligned(in, out))
-static void pre_median_b(
-        float *out,
-        const float *const in,
-        const dt_iop_roi_t *const roi,
-        const uint32_t filters,
-        const int num_passes,
-        const float threshold)
+static void pre_median_b(float *out,
+                         const float *const in,
+                         const dt_iop_roi_t *const roi,
+                         const uint32_t filters,
+                         const int num_passes,
+                         const float threshold)
 {
   dt_iop_image_copy_by_size(out, in, roi->width, roi->height, 1);
 
@@ -74,13 +73,12 @@ static void pre_median_b(
   }
 }
 
-static void pre_median(
-        float *out,
-        const float *const in,
-        const dt_iop_roi_t *const roi,
-        const uint32_t filters,
-        const int num_passes,
-        const float threshold)
+static void pre_median(float *out,
+                       const float *const in,
+                       const dt_iop_roi_t *const roi,
+                       const uint32_t filters,
+                       const int num_passes,
+                       const float threshold)
 {
   pre_median_b(out, in, roi, filters, num_passes, threshold);
 }
@@ -88,10 +86,9 @@ static void pre_median(
 #define SWAPmed(I, J)                                                                                        \
   if(med[I] > med[J]) SWAP(med[I], med[J])
 
-static void color_smoothing(
-        float *out,
-        const dt_iop_roi_t *const roi_out,
-        const int num_passes)
+static void color_smoothing(float *out,
+                            const dt_iop_roi_t *const roi_out,
+                            const int num_passes)
 {
   const int width4 = 4 * roi_out->width;
 
@@ -145,15 +142,14 @@ static void color_smoothing(
 }
 #undef SWAP
 
-static void green_equilibration_lavg(
-        float *out,
-        const float *const in,
-        const int width,
-        const int height,
-        const uint32_t filters,
-        const int x,
-        const int y,
-        const float thr)
+static void green_equilibration_lavg(float *out,
+                                     const float *const in,
+                                     const int width,
+                                     const int height,
+                                     const uint32_t filters,
+                                     const int x,
+                                     const int y,
+                                     const float thr)
 {
   const float maximum = 1.0f;
 
@@ -199,14 +195,13 @@ static void green_equilibration_lavg(
   }
 }
 
-static void green_equilibration_favg(
-        float *out,
-        const float *const in,
-        const int width,
-        const int height,
-        const uint32_t filters,
-        const int x,
-        const int y)
+static void green_equilibration_favg(float *out,
+                                     const float *const in,
+                                     const int width,
+                                     const int height,
+                                     const uint32_t filters,
+                                     const int x,
+                                     const int y)
 {
   int oj = 0, oi = 0;
   // const float ratio_max = 1.1f;
@@ -242,19 +237,18 @@ static void green_equilibration_favg(
 
 #ifdef HAVE_OPENCL
 // color smoothing step by multiple passes of median filtering
-static int color_smoothing_cl(
-        struct dt_iop_module_t *self,
-        dt_dev_pixelpipe_iop_t *piece,
-        cl_mem dev_in,
-        cl_mem dev_out,
-        const dt_iop_roi_t *const roi_out,
-        const int passes)
+static int color_smoothing_cl(dt_iop_module_t *self,
+                              dt_dev_pixelpipe_iop_t *piece,
+                              cl_mem dev_in,
+                              cl_mem dev_out,
+                              const dt_iop_roi_t *const roi,
+                              const int passes)
 {
   dt_iop_demosaic_global_data_t *gd = self->global_data;
 
   const int devid = piece->pipe->devid;
-  const int width = roi_out->width;
-  const int height = roi_out->height;
+  const int width = roi->width;
+  const int height = roi->height;
 
   cl_int err = DT_OPENCL_DEFAULT_ERROR;
 
@@ -308,14 +302,13 @@ error:
   return err;
 }
 
-static int green_equilibration_cl(
-        struct dt_iop_module_t *self,
-        dt_dev_pixelpipe_iop_t *piece,
-        cl_mem dev_in,
-        cl_mem dev_out,
-        const dt_iop_roi_t *const roi_in)
+static int green_equilibration_cl(dt_iop_module_t *self,
+                                  dt_dev_pixelpipe_iop_t *piece,
+                                  cl_mem dev_in,
+                                  cl_mem dev_out,
+                                  const dt_iop_roi_t *const roi_in)
 {
-  dt_iop_demosaic_data_t *data = piece->data;
+  dt_iop_demosaic_data_t *d = piece->data;
   dt_iop_demosaic_global_data_t *gd = self->global_data;
 
   const int devid = piece->pipe->devid;
@@ -333,13 +326,13 @@ static int green_equilibration_cl(
 
   cl_int err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
 
-  if(data->green_eq == DT_IOP_GREEN_EQ_BOTH)
+  if(d->green_eq == DT_IOP_GREEN_EQ_BOTH)
   {
     dev_tmp = dt_opencl_alloc_device(devid, width, height, sizeof(float));
     if(dev_tmp == NULL) goto error;
   }
 
-  switch(data->green_eq)
+  switch(d->green_eq)
   {
     case DT_IOP_GREEN_EQ_FULL:
       dev_in1 = dev_in;
@@ -360,7 +353,7 @@ static int green_equilibration_cl(
       goto error;
   }
 
-  if(data->green_eq == DT_IOP_GREEN_EQ_FULL || data->green_eq == DT_IOP_GREEN_EQ_BOTH)
+  if(d->green_eq == DT_IOP_GREEN_EQ_FULL || d->green_eq == DT_IOP_GREEN_EQ_BOTH)
   {
     dt_opencl_local_buffer_t flocopt
       = (dt_opencl_local_buffer_t){ .xoffset = 0, .xfactor = 1, .yoffset = 0, .yfactor = 1,
@@ -448,7 +441,7 @@ static int green_equilibration_cl(
     if(err != CL_SUCCESS) goto error;
   }
 
-  if(data->green_eq == DT_IOP_GREEN_EQ_LOCAL || data->green_eq == DT_IOP_GREEN_EQ_BOTH)
+  if(d->green_eq == DT_IOP_GREEN_EQ_LOCAL || d->green_eq == DT_IOP_GREEN_EQ_BOTH)
   {
     const dt_image_t *img = &self->dev->image_storage;
     const float threshold = 0.0001f * img->exif_iso;
@@ -483,64 +476,29 @@ error:
   return err;
 }
 
-static int process_default_cl(
-        struct dt_iop_module_t *self,
-        dt_dev_pixelpipe_iop_t *piece,
-        cl_mem dev_in,
-        cl_mem dev_out,
-        const dt_iop_roi_t *const roi_in,
-        const dt_iop_roi_t *const roi_out,
-        const int demosaicing_method)
+static int process_default_cl(dt_iop_module_t *self,
+                              dt_dev_pixelpipe_iop_t *piece,
+                              cl_mem dev_in,
+                              cl_mem dev_out,
+                              const dt_iop_roi_t *const roi_in,
+                              const int demosaicing_method)
 {
-  dt_iop_demosaic_data_t *data = piece->data;
+  dt_iop_demosaic_data_t *d = piece->data;
   dt_iop_demosaic_global_data_t *gd = self->global_data;
-  const dt_image_t *img = &self->dev->image_storage;
 
   const int devid = piece->pipe->devid;
-  const int qual_flags = demosaic_qual_flags(piece, img, roi_out);
 
-  cl_mem dev_aux = NULL;
   cl_mem dev_tmp = NULL;
   cl_mem dev_med = NULL;
-  cl_mem dev_green_eq = NULL;
   cl_int err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
 
-  if(qual_flags & DT_DEMOSAIC_FULL_SCALE)
-  {
-    // Full demosaic and then scaling if needed
-    const int scaled = (roi_out->width != roi_in->width || roi_out->height != roi_in->height);
+  const int width = roi_in->width;
+  const int height = roi_in->height;
 
-    int width = roi_out->width;
-    int height = roi_out->height;
-
-    // green equilibration
-    if(data->green_eq != DT_IOP_GREEN_EQ_NO)
-    {
-      dev_green_eq = dt_opencl_alloc_device(devid, roi_in->width, roi_in->height, sizeof(float));
-      if(dev_green_eq == NULL) goto error;
-
-      err = green_equilibration_cl(self, piece, dev_in, dev_green_eq, roi_in);
-      if(err != CL_SUCCESS) goto error;
-
-      dev_in = dev_green_eq;
-    }
-
-    // need to reserve scaled auxiliary buffer or use dev_out
-    err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
-    if(scaled)
-    {
-      dev_aux = dt_opencl_alloc_device(devid, roi_in->width, roi_in->height, sizeof(float) * 4);
-      if(dev_aux == NULL) goto error;
-      width = roi_in->width;
-      height = roi_in->height;
-    }
-    else
-      dev_aux = dev_out;
-
-    if(demosaicing_method == DT_IOP_DEMOSAIC_PASSTHROUGH_MONOCHROME)
+     if(demosaicing_method == DT_IOP_DEMOSAIC_PASSTHROUGH_MONOCHROME)
     {
       err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_passthrough_monochrome, width, height,
-        CLARG(dev_in), CLARG(dev_aux), CLARG(width), CLARG(height));
+        CLARG(dev_in), CLARG(dev_out), CLARG(width), CLARG(height));
       if(err != CL_SUCCESS) goto error;
     }
     else if(demosaicing_method == DT_IOP_DEMOSAIC_PASSTHROUGH_COLOR)
@@ -549,14 +507,14 @@ static int process_default_cl(
       if(dev_xtrans == NULL) goto error;
 
       err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_passthrough_color, width, height,
-        CLARG(dev_in), CLARG(dev_aux), CLARG(width), CLARG(height), CLARG(roi_in->x), CLARG(roi_in->y),
+        CLARG(dev_in), CLARG(dev_out), CLARG(width), CLARG(height), CLARG(roi_in->x), CLARG(roi_in->y),
         CLARG(piece->pipe->dsc.filters), CLARG(dev_xtrans));
       dt_opencl_release_mem_object(dev_xtrans);
       if(err != CL_SUCCESS) goto error;
     }
     else if(demosaicing_method == DT_IOP_DEMOSAIC_PPG)
     {
-      dev_tmp = dt_opencl_alloc_device(devid, roi_in->width, roi_in->height, sizeof(float) * 4);
+      dev_tmp = dt_opencl_alloc_device(devid, width, height, sizeof(float) * 4);
       if(dev_tmp == NULL)
       {
         err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
@@ -571,9 +529,9 @@ static int process_default_cl(
         if(err != CL_SUCCESS) goto error;
       }
 
-      if(data->median_thrs > 0.0f)
+      if(d->median_thrs > 0.0f)
       {
-        dev_med = dt_opencl_alloc_device(devid, roi_in->width, roi_in->height, sizeof(float) * 4);
+        dev_med = dt_opencl_alloc_device(devid, width, height, sizeof(float) * 4);
         if(dev_med == NULL)
         {
           err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
@@ -594,10 +552,10 @@ static int process_default_cl(
         size_t sizes[3] = { ROUNDUP(width, locopt.sizex), ROUNDUP(height, locopt.sizey), 1 };
         size_t local[3] = { locopt.sizex, locopt.sizey, 1 };
         dt_opencl_set_kernel_args(devid, gd->kernel_pre_median, 0, CLARG(dev_in), CLARG(dev_med), CLARG(width),
-          CLARG(height), CLARG(piece->pipe->dsc.filters), CLARG(data->median_thrs), CLLOCAL(sizeof(float) * (locopt.sizex + 4) * (locopt.sizey + 4)));
+          CLARG(height), CLARG(piece->pipe->dsc.filters), CLARG(d->median_thrs), CLLOCAL(sizeof(float) * (locopt.sizex + 4) * (locopt.sizey + 4)));
         err = dt_opencl_enqueue_kernel_2d_with_local(devid, gd->kernel_pre_median, sizes, local);
         if(err != CL_SUCCESS) goto error;
-        dev_in = dev_aux;
+        dev_in = dev_out;
       }
       else dev_med = dev_in;
 
@@ -636,7 +594,7 @@ static int process_default_cl(
 
         size_t sizes[3] = { ROUNDUP(width, locopt.sizex), ROUNDUP(height, locopt.sizey), 1 };
         size_t local[3] = { locopt.sizex, locopt.sizey, 1 };
-        dt_opencl_set_kernel_args(devid, gd->kernel_ppg_redblue, 0, CLARG(dev_tmp), CLARG(dev_aux), CLARG(width),
+        dt_opencl_set_kernel_args(devid, gd->kernel_ppg_redblue, 0, CLARG(dev_tmp), CLARG(dev_out), CLARG(width),
           CLARG(height), CLARG(piece->pipe->dsc.filters), CLLOCAL(sizeof(float) * 4 * (locopt.sizex + 2) * (locopt.sizey + 2)));
 
         err = dt_opencl_enqueue_kernel_2d_with_local(devid, gd->kernel_ppg_redblue, sizes, local);
@@ -644,49 +602,11 @@ static int process_default_cl(
       }
     }
 
-    if(piece->pipe->want_detail_mask)
-    {
-      err = dt_dev_write_scharr_mask_cl(piece, dev_aux, roi_in, TRUE);
-      if(err != CL_SUCCESS) goto error;
-    }
-
-    if(scaled)
-    {
-      dt_print_pipe(DT_DEBUG_PIPE, "clip_and_zoom_roi", piece->pipe, self, piece->pipe->devid, roi_in, roi_out);
-      // scale aux buffer to output buffer
-      err = dt_iop_clip_and_zoom_roi_cl(devid, dev_out, dev_aux, roi_out, roi_in);
-    }
-  }
-  else
-  {
-    if(demosaicing_method == DT_IOP_DEMOSAIC_PASSTHROUGH_MONOCHROME)
-    {
-      // sample image:
-      const int zero = 0;
-      err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_zoom_passthrough_monochrome, roi_out->width, roi_out->height,
-        CLARG(dev_in), CLARG(dev_out), CLARG(roi_out->width), CLARG(roi_out->height), CLARG(zero), CLARG(zero), CLARG(roi_in->width),
-        CLARG(roi_in->height), CLARG(roi_out->scale), CLARG(piece->pipe->dsc.filters));
-    }
-    else
-    {
-      // sample half-size image:
-      const int zero = 0;
-      err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_zoom_half_size, roi_out->width, roi_out->height,
-        CLARG(dev_in), CLARG(dev_out), CLARG(roi_out->width), CLARG(roi_out->height), CLARG(zero), CLARG(zero), CLARG(roi_in->width),
-        CLARG(roi_in->height), CLARG(roi_out->scale), CLARG(piece->pipe->dsc.filters));
-    }
-  }
-
 error:
-  if(dev_aux != dev_out) dt_opencl_release_mem_object(dev_aux);
   if(dev_med != dev_in) dt_opencl_release_mem_object(dev_med);
-  dt_opencl_release_mem_object(dev_green_eq);
   dt_opencl_release_mem_object(dev_tmp);
 
-  if(data->color_smoothing && err == CL_SUCCESS)
-    err = color_smoothing_cl(self, piece, dev_out, dev_out, roi_out, data->color_smoothing);
-
-  if(err != CL_SUCCESS)
+ if(err != CL_SUCCESS)
     dt_print(DT_DEBUG_OPENCL, "[opencl_demosaic] basic kernel problem '%s'", cl_errstr(err));
   return err;
 }

--- a/src/iop/demosaicing/dual.c
+++ b/src/iop/demosaicing/dual.c
@@ -28,16 +28,15 @@ static float slider2contrast(float slider)
 {
   return 0.005f * powf(slider, 1.1f);
 }
-static void dual_demosaic(
-        dt_dev_pixelpipe_iop_t *piece,
-        float *const restrict high_data,
-        const float *const restrict raw_data,
-        dt_iop_roi_t *const roi_out,
-        const dt_iop_roi_t *const roi_in,
-        const uint32_t filters,
-        const uint8_t (*const xtrans)[6],
-        const gboolean dual_mask,
-        const float dual_threshold)
+static void dual_demosaic(dt_dev_pixelpipe_iop_t *piece,
+                          float *const restrict high_data,
+                          const float *const restrict raw_data,
+                          const dt_iop_roi_t *const roi_out,
+                          const dt_iop_roi_t *const roi_in,
+                          const uint32_t filters,
+                          const uint8_t (*const xtrans)[6],
+                          const gboolean dual_mask,
+                          const float dual_threshold)
 {
   if((roi_in->width < 16) || (roi_in->height < 16)) return;
 
@@ -64,7 +63,7 @@ static void dual_demosaic(
     if(!vng_image) goto error;
 
     vng_interpolate(vng_image, raw_data, roi_out, roi_in, filters, xtrans, FALSE);
-    color_smoothing(vng_image, roi_out, 2);
+    color_smoothing(vng_image, roi_in, 2);
 
     DT_OMP_FOR_SIMD(aligned(mask, vng_image, high_data : 64))
     for(int idx = 0; idx < msize; idx++)
@@ -83,7 +82,7 @@ static void dual_demosaic(
 }
 
 #ifdef HAVE_OPENCL
-gboolean dual_demosaic_cl(struct dt_iop_module_t *self,
+gboolean dual_demosaic_cl(dt_iop_module_t *self,
                           dt_dev_pixelpipe_iop_t *piece,
                           cl_mem high_image,
                           cl_mem low_image,

--- a/src/iop/demosaicing/lmmse.c
+++ b/src/iop/demosaicing/lmmse.c
@@ -116,21 +116,19 @@ static inline float _calc_gamma(float val, float *table)
   return (p1 + p2 * diff);
 }
 
-DT_OMP_DECLARE_SIMD(aligned(in, out))
-static void lmmse_demosaic(
-        dt_dev_pixelpipe_iop_t *piece,
-        float *const restrict out,
-        const float *const restrict in,
-        dt_iop_roi_t *const roi_out,
-        const dt_iop_roi_t *const roi_in,
-        const uint32_t filters,
-        const uint32_t mode)
+DT_OMP_DECLARE_SIMD(aligned(in, out : 64))
+static void lmmse_demosaic(dt_dev_pixelpipe_iop_t *piece,
+                           float *const restrict out,
+                           const float *const restrict in,
+                           const dt_iop_roi_t *const roi_in,
+                           const uint32_t filters,
+                           const uint32_t mode)
 {
   const int width = roi_in->width;
   const int height = roi_in->height;
 
   rcd_ppg_border(out, in, width, height, filters, BORDER_AROUND);
-  if((width < 2 * BORDER_AROUND) || (height < 2 * BORDER_AROUND))
+  if(width < 2 * BORDER_AROUND || height < 2 * BORDER_AROUND)
     return;
 
   if(!lmmse_gamma_in) _init_lmmse_gamma();

--- a/src/iop/demosaicing/passthrough.c
+++ b/src/iop/demosaicing/passthrough.c
@@ -18,11 +18,10 @@
 
 
 /** 1:1 demosaic from in to out, in is full buf, out is translated/cropped (scale == 1.0!) */
-static void passthrough_monochrome(
-        float *out,
-        const float *const in,
-        dt_iop_roi_t *const roi_out,
-        const dt_iop_roi_t *const roi_in)
+static void passthrough_monochrome(float *out,
+                                   const float *const in,
+                                   const dt_iop_roi_t *const roi_out,
+                                   const dt_iop_roi_t *const roi_in)
 {
   // we never want to access the input out of bounds though:
   assert(roi_in->width >= roi_out->width);
@@ -42,13 +41,12 @@ static void passthrough_monochrome(
   }
 }
 
-static void passthrough_color(
-        float *out,
-        const float *const in,
-        dt_iop_roi_t *const roi_out,
-        const dt_iop_roi_t *const roi_in,
-        const uint32_t filters,
-        const uint8_t (*const xtrans)[6])
+static void passthrough_color(float *out,
+                              const float *const in,
+                              const dt_iop_roi_t *const roi_out,
+                              const dt_iop_roi_t *const roi_in,
+                              const uint32_t filters,
+                              const uint8_t (*const xtrans)[6])
 {
   assert(roi_in->width >= roi_out->width);
   assert(roi_in->height >= roi_out->height);

--- a/src/iop/demosaicing/ppg.c
+++ b/src/iop/demosaicing/ppg.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2010-2023 darktable developers.
+    Copyright (C) 2010-2024 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -17,13 +17,12 @@
 */
 
 DT_OMP_DECLARE_SIMD(aligned(in, out))
-static void demosaic_ppg(
-        float *const out,
-        const float *const in,
-        const dt_iop_roi_t *const roi_out,
-        const dt_iop_roi_t *const roi_in,
-        const uint32_t filters,
-        const float thrs)
+static void demosaic_ppg(float *const out,
+                         const float *const in,
+                         const dt_iop_roi_t *const roi_out,
+                         const dt_iop_roi_t *const roi_in,
+                         const uint32_t filters,
+                         const float thrs)
 {
   // these may differ a little, if you're unlucky enough to split a bayer block with cropping or similar.
   // we never want to access the input out of bounds though:

--- a/src/iop/demosaicing/rcd.c
+++ b/src/iop/demosaicing/rcd.c
@@ -83,13 +83,12 @@ static inline float _safe_in(float a, float scale)
 }
 
 /** This is basically ppg adopted to only write data to RCD_MARGIN */
-static void rcd_ppg_border(
-        float *const out,
-        const float *const in,
-        const int width,
-        const int height,
-        const uint32_t filters,
-        const int margin)
+static void rcd_ppg_border(float *const out,
+                           const float *const in,
+                           const int width,
+                           const int height,
+                           const uint32_t filters,
+                           const int margin)
 {
   const int border = margin + 3;
   // write approximatad 3-pixel border region to out
@@ -124,20 +123,18 @@ static void rcd_ppg_border(
     }
   }
 
-  const float *input = in;
-
   DT_OMP_FOR()
   for(int j = 3; j < height - 3; j++)
   {
     float *buf = out + (size_t)4 * width * j + 4 * 3;
-    const float *buf_in = input + (size_t)width * j + 3;
+    const float *buf_in = in + (size_t)width * j + 3;
     for(int i = 3; i < width - 3; i++)
     {
       if(i == border && j >= border && j < height - border)
       {
         i = width - border;
         buf = out + (size_t)4 * width * j + 4 * i;
-        buf_in = input + (size_t)width * j + i;
+        buf_in = in + (size_t)width * j + i;
       }
       if(i == width) break;
 
@@ -270,19 +267,17 @@ static void rcd_ppg_border(
   }
 }
 
-DT_OMP_DECLARE_SIMD(aligned(in, out))
-static void rcd_demosaic(
-        dt_dev_pixelpipe_iop_t *piece,
-        float *const restrict out,
-        const float *const restrict in,
-        dt_iop_roi_t *const roi_out,
-        const dt_iop_roi_t *const roi_in,
-        const uint32_t filters)
+DT_OMP_DECLARE_SIMD(aligned(in, out : 64))
+static void rcd_demosaic(dt_dev_pixelpipe_iop_t *piece,
+                         float *const restrict out,
+                         const float *const restrict in,
+                         const dt_iop_roi_t *const roi_in,
+                         const uint32_t filters)
 {
   const int width = roi_in->width;
   const int height = roi_in->height;
 
-  if((width < 2*RCD_BORDER) || (height < 2*RCD_BORDER))
+  if(width < 2*RCD_BORDER || height < 2*RCD_BORDER)
   {
     rcd_ppg_border(out, in, width, height, filters, RCD_BORDER);
     return;
@@ -298,9 +293,8 @@ static void rcd_demosaic(
 
   DT_OMP_PRAGMA(parallel firstprivate(width, height, filters, out, in, scaler, revscaler))
   {
-    float *const VH_Dir = dt_alloc_align_float((size_t) DT_RCD_TILESIZE * DT_RCD_TILESIZE);
-    // ensure that border elements which are read but never actually set below are zeroed out
-    memset(VH_Dir, 0, sizeof(*VH_Dir) * DT_RCD_TILESIZE * DT_RCD_TILESIZE);
+    // ensure that border elements which are read but never actually set below are zeroed out so use calloc
+    float *const VH_Dir = dt_calloc_align_float((size_t) DT_RCD_TILESIZE * DT_RCD_TILESIZE);
     float *const PQ_Dir = dt_alloc_align_float((size_t) DT_RCD_TILESIZE * DT_RCD_TILESIZE / 2);
     float *const cfa =    dt_alloc_align_float((size_t) DT_RCD_TILESIZE * DT_RCD_TILESIZE);
     float *const P_CDiff_Hpf = dt_alloc_align_float((size_t) DT_RCD_TILESIZE * DT_RCD_TILESIZE / 2);
@@ -563,25 +557,17 @@ static void rcd_demosaic(
 #endif
 
 #ifdef HAVE_OPENCL
-static int process_rcd_cl(
-        struct dt_iop_module_t *self,
-        dt_dev_pixelpipe_iop_t *piece,
-        cl_mem dev_in,
-        cl_mem dev_out,
-        const dt_iop_roi_t *const roi_in,
-        const dt_iop_roi_t *const roi_out,
-        const gboolean smooth)
+static cl_int process_rcd_cl(dt_iop_module_t *self,
+                             dt_dev_pixelpipe_iop_t *piece,
+                             cl_mem dev_in,
+                             cl_mem dev_out,
+                             const dt_iop_roi_t *const roi_in)
 {
-  dt_iop_demosaic_data_t *data = piece->data;
-  dt_iop_demosaic_global_data_t *gd = self->global_data;
-  const dt_image_t *img = &self->dev->image_storage;
+  const dt_iop_demosaic_global_data_t *gd = self->global_data;
 
   const int devid = piece->pipe->devid;
-  const int qual_flags = demosaic_qual_flags(piece, img, roi_out);
 
-  cl_mem dev_aux = NULL;
   cl_mem dev_tmp = NULL;
-  cl_mem dev_green_eq = NULL;
   cl_mem cfa = NULL;
   cl_mem rgb0 = NULL;
   cl_mem rgb1 = NULL;
@@ -593,37 +579,10 @@ static int process_rcd_cl(
 
   cl_int err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
 
-  if(qual_flags & DT_DEMOSAIC_FULL_SCALE)
-  {
-     // Full demosaic and then scaling if needed
-    const int scaled = (roi_out->width != roi_in->width || roi_out->height != roi_in->height);
-
-    int width = roi_out->width;
-    int height = roi_out->height;
-
-    // green equilibration
-    if(data->green_eq != DT_IOP_GREEN_EQ_NO)
-    {
-      dev_green_eq = dt_opencl_alloc_device(devid, roi_in->width, roi_in->height, sizeof(float));
-      if(dev_green_eq == NULL) goto error;
-
-      err = green_equilibration_cl(self, piece, dev_in, dev_green_eq, roi_in);
-      if(err != CL_SUCCESS) goto error;
-      dev_in = dev_green_eq;
-    }
+    const int width = roi_in->width;
+    const int height = roi_in->height;
 
     err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
-    // need to reserve scaled auxiliary buffer or use dev_out
-    if(scaled)
-    {
-      dev_aux = dt_opencl_alloc_device(devid, roi_in->width, roi_in->height, sizeof(float) * 4);
-      if(dev_aux == NULL) goto error;
-
-      width = roi_in->width;
-      height = roi_in->height;
-    }
-    else
-      dev_aux = dev_out;
 
     dev_tmp = dt_opencl_alloc_device(devid, roi_in->width, roi_in->height, sizeof(float) * 4);
     if(dev_tmp == NULL) goto error;
@@ -668,7 +627,7 @@ static int process_rcd_cl(
       myborder = 16;
       size_t sizes[3] = { ROUNDUP(width, locopt.sizex), ROUNDUP(height, locopt.sizey), 1 };
       size_t local[3] = { locopt.sizex, locopt.sizey, 1 };
-      dt_opencl_set_kernel_args(devid, gd->kernel_rcd_border_redblue, 0, CLARG(dev_tmp), CLARG(dev_aux),
+      dt_opencl_set_kernel_args(devid, gd->kernel_rcd_border_redblue, 0, CLARG(dev_tmp), CLARG(dev_out),
         CLARG(width), CLARG(height), CLARG(piece->pipe->dsc.filters), CLLOCAL(sizeof(float) * 4 * (locopt.sizex + 2) * (locopt.sizey + 2)),
         CLARG(myborder));
       err = dt_opencl_enqueue_kernel_2d_with_local(devid, gd->kernel_rcd_border_redblue, sizes, local);
@@ -677,15 +636,16 @@ static int process_rcd_cl(
     dt_opencl_release_mem_object(dev_tmp);
     dev_tmp = NULL;
 
+    const size_t bsize = sizeof(float) * width * height;
     err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
-    cfa = dt_opencl_alloc_device_buffer(devid, sizeof(float) * roi_in->width * roi_in->height);
-    VH_dir = dt_opencl_alloc_device_buffer(devid, sizeof(float) * roi_in->width * roi_in->height);
-    PQ_dir = dt_opencl_alloc_device_buffer(devid, sizeof(float) * roi_in->width * roi_in->height);
-    VP_diff = dt_opencl_alloc_device_buffer(devid, sizeof(float) * roi_in->width * roi_in->height);
-    HQ_diff = dt_opencl_alloc_device_buffer(devid, sizeof(float) * roi_in->width * roi_in->height);
-    rgb0 = dt_opencl_alloc_device_buffer(devid, sizeof(float) * roi_in->width * roi_in->height);
-    rgb1 = dt_opencl_alloc_device_buffer(devid, sizeof(float) * roi_in->width * roi_in->height);
-    rgb2 = dt_opencl_alloc_device_buffer(devid, sizeof(float) * roi_in->width * roi_in->height);
+    cfa = dt_opencl_alloc_device_buffer(devid, bsize);
+    VH_dir = dt_opencl_alloc_device_buffer(devid, bsize);
+    PQ_dir = dt_opencl_alloc_device_buffer(devid, bsize);
+    VP_diff = dt_opencl_alloc_device_buffer(devid, bsize);
+    HQ_diff = dt_opencl_alloc_device_buffer(devid, bsize);
+    rgb0 = dt_opencl_alloc_device_buffer(devid, bsize);
+    rgb1 = dt_opencl_alloc_device_buffer(devid, bsize);
+    rgb2 = dt_opencl_alloc_device_buffer(devid, bsize);
     if(cfa == NULL || VH_dir == NULL || PQ_dir == NULL || VP_diff == NULL || HQ_diff == NULL || rgb0 == NULL || rgb1 == NULL || rgb2 == NULL)
       goto error;
 
@@ -740,57 +700,9 @@ static int process_rcd_cl(
     // write output
     myborder = RCD_MARGIN;
     err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_rcd_write_output, width, height,
-        CLARG(dev_aux), CLARG(rgb0), CLARG(rgb1), CLARG(rgb2), CLARG(width), CLARG(height), CLARG(scaler),
-        CLARG(myborder));
-    if(err != CL_SUCCESS) goto error;
-
-    dt_opencl_release_mem_object(cfa);
-    dt_opencl_release_mem_object(rgb0);
-    dt_opencl_release_mem_object(rgb1);
-    dt_opencl_release_mem_object(rgb2);
-    dt_opencl_release_mem_object(VH_dir);
-    dt_opencl_release_mem_object(PQ_dir);
-    dt_opencl_release_mem_object(VP_diff);
-    dt_opencl_release_mem_object(HQ_diff);
-    dt_opencl_release_mem_object(dev_green_eq);
-    dev_green_eq = cfa = rgb0 = rgb1 = rgb2 = VH_dir = PQ_dir = VP_diff = HQ_diff = NULL;
-
-    if(piece->pipe->want_detail_mask)
-    {
-      err = dt_dev_write_scharr_mask_cl(piece, dev_aux, roi_in, TRUE);
-      if(err != CL_SUCCESS) goto error;
-    }
-
-    if(scaled)
-    {
-      dt_print_pipe(DT_DEBUG_PIPE, "clip_and_zoom_roi",
-        piece->pipe, self, piece->pipe->devid, roi_in, roi_out);
-      // scale aux buffer to output buffer
-      err = dt_iop_clip_and_zoom_roi_cl(devid, dev_out, dev_aux, roi_out, roi_in);
-    }
-  }
-  else
-  {
-    // sample half-size image:
-    const int zero = 0;
-    cl_mem dev_pix = dev_in;
-
-    err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_zoom_half_size, roi_out->width, roi_out->height,
-      CLARG(dev_pix), CLARG(dev_out), CLARG(roi_out->width), CLARG(roi_out->height), CLARG(zero), CLARG(zero), CLARG(roi_in->width),
-      CLARG(roi_in->height), CLARG(roi_out->scale), CLARG(piece->pipe->dsc.filters));
-  }
-  if(err != CL_SUCCESS) goto error;
-
-  if(dev_aux != dev_out) dt_opencl_release_mem_object(dev_aux);
-  dev_aux = NULL;
-
-  // color smoothing
-  if((data->color_smoothing) && smooth)
-    err = color_smoothing_cl(self, piece, dev_out, dev_out, roi_out, data->color_smoothing);
+        CLARG(dev_out), CLARG(rgb0), CLARG(rgb1), CLARG(rgb2), CLARG(width), CLARG(height), CLARG(scaler), CLARG(myborder));
 
 error:
-  if(dev_aux != dev_out) dt_opencl_release_mem_object(dev_aux);
-  dt_opencl_release_mem_object(dev_green_eq);
   dt_opencl_release_mem_object(dev_tmp);
   dt_opencl_release_mem_object(cfa);
   dt_opencl_release_mem_object(rgb0);

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -326,13 +326,12 @@ static dt_hash_t img_opphash = ULLONG_MAX;
 #include "hlreconstruct/inpaint.c"
 #include "hlreconstruct/lch.c"
 
-void distort_mask(
-        dt_iop_module_t *self,
-        dt_dev_pixelpipe_iop_t *piece,
-        const float *const in,
-        float *const out,
-        const dt_iop_roi_t *const roi_in,
-        const dt_iop_roi_t *const roi_out)
+void distort_mask(dt_iop_module_t *self,
+                  dt_dev_pixelpipe_iop_t *piece,
+                  const float *const in,
+                  float *const out,
+                  const dt_iop_roi_t *const roi_in,
+                  const dt_iop_roi_t *const roi_out)
 {
   dt_iop_copy_image_roi(out, in, 1, roi_in, roi_out);
 }

--- a/src/iop/hlreconstruct/segmentation.c
+++ b/src/iop/hlreconstruct/segmentation.c
@@ -124,7 +124,7 @@ static inline int _test_dilate(const uint32_t *img, const size_t i, const size_t
            img[i-3]    | img[i+3]    |
            img[i+w1-3] | img[i+w1+3] |
            img[i+w2-3] | img[i+w2-2] | img[i+w2+2] | img[i+w2+3] |
-           img[i+w3-2] | img[i+w3-1] | img[i+w3] | img[i+w3+1] | img[i+w3+2]; 
+           img[i+w3-2] | img[i+w3-1] | img[i+w3] | img[i+w3+1] | img[i+w3+2];
   if(retval || (radius < 4)) return retval;
 
   const size_t w4 = 4*w1;
@@ -150,7 +150,7 @@ static inline int _test_dilate(const uint32_t *img, const size_t i, const size_t
            img[i+w2-5] | img[i+w2+5] |
            img[i+w3-4] | img[i+w3+4] |
            img[i+w4-4] | img[i+w4-3] | img[i+w4+3] | img[i+w4+4] |
-           img[i+w5-2] | img[i+w5-1] | img[i+w5] | img[i+w5+1] | img[i+w5+2]; 
+           img[i+w5-2] | img[i+w5-1] | img[i+w5] | img[i+w5+1] | img[i+w5+2];
   if(retval || (radius < 6)) return retval;
 
   const size_t w6 = 6*w1;
@@ -249,7 +249,7 @@ static inline int _test_erode(const uint32_t *img, const size_t i, const size_t 
            img[i-3]    & img[i+3]    &
            img[i+w1-3] & img[i+w1+3] &
            img[i+w2-3] & img[i+w2-2] & img[i+w2+2] & img[i+w2+3] &
-           img[i+w3-2] & img[i+w3-1] & img[i+w3] & img[i+w3+1] & img[i+w3+2]; 
+           img[i+w3-2] & img[i+w3-1] & img[i+w3] & img[i+w3+1] & img[i+w3+2];
   if((retval == 0) || (radius < 4)) return retval;
 
   const size_t w4 = 4*w1;
@@ -258,10 +258,10 @@ static inline int _test_erode(const uint32_t *img, const size_t i, const size_t 
            img[i-w2-4] & img[i-w2+4] &
            img[i-w1-4] & img[i-w1+4] &
            img[i-4]    & img[i+4] &
-           img[i+w1-4] & img[i+w1+4] & 
-           img[i+w2-4] & img[i+w2+4] & 
+           img[i+w1-4] & img[i+w1+4] &
+           img[i+w2-4] & img[i+w2+4] &
            img[i+w3-3] & img[i+w3+3] &
-           img[i+w4-2] & img[i+w4-1] & img[i+w4] & img[i+w4+1] & img[i+w4+2]; 
+           img[i+w4-2] & img[i+w4-1] & img[i+w4] & img[i+w4+1] & img[i+w4+2];
   if((retval == 0) || (radius < 5)) return retval;
 
   const size_t w5 = 5*w1;
@@ -275,7 +275,7 @@ static inline int _test_erode(const uint32_t *img, const size_t i, const size_t 
            img[i+w2-5] & img[i+w2+5] &
            img[i+w3-4] & img[i+w3+4] &
            img[i+w4-4] & img[i+w4-3] & img[i+w4+3] & img[i+w4+4] &
-           img[i+w5-2] & img[i+w5-1] & img[i+w5] & img[i+w5+1] & img[i+w5+2]; 
+           img[i+w5-2] & img[i+w5-1] & img[i+w5] & img[i+w5+1] & img[i+w5+2];
   return retval;
 }
 
@@ -291,7 +291,7 @@ static inline void _eroding(const uint32_t *img,
   {
     for(int col = border; col < w1 - border; col++)
     {
-      const size_t i = (size_t)row*w1 + col; 
+      const size_t i = (size_t)row*w1 + col;
       o[i] = _test_erode(img, i, w1, radius) ? 1 : 0;
     }
   }
@@ -439,7 +439,7 @@ static gboolean _floodfill_segmentize(int yin,
       xp = xr;
       yp = y;
       rp = yp*w + xp;
-      if(xp < w-border-2 && d[rp] == 0) 
+      if(xp < w-border-2 && d[rp] == 0)
       {
         min_x = MIN(min_x, xp);
         max_x = MAX(max_x, xp);
@@ -547,7 +547,7 @@ static gboolean _floodfill_segmentize(int yin,
 // User interface
 void dt_segmentize_plane(dt_iop_segmentation_t *seg)
 {
-  dt_ff_stack_t stack;  
+  dt_ff_stack_t stack;
   const int width = seg->width;
   const int height = seg->height;
   stack.size = (size_t)width * height / 32;
@@ -613,17 +613,17 @@ void dt_segmentation_free_struct(dt_iop_segmentation_t *seg)
   dt_free_align(seg->ymax);
   dt_free_align(seg->val1);
   dt_free_align(seg->val2);
-  memset(seg, 0, sizeof(dt_iop_segmentation_t)); 
+  memset(seg, 0, sizeof(dt_iop_segmentation_t));
 }
 
 // returns TRUE in case of errors
 gboolean dt_segmentation_init_struct(dt_iop_segmentation_t *seg,
-                                 const int width,
-                                 const int height,
-                                 const int border,
-                                 const int islots)
+                                     const int width,
+                                     const int height,
+                                     const int border,
+                                     const int islots)
 {
-  memset(seg, 0, sizeof(dt_iop_segmentation_t)); 
+  memset(seg, 0, sizeof(dt_iop_segmentation_t));
   const int slots = MAX(256, MIN(islots, DT_SEG_ID_MASK - 2));
   const size_t bsize = (size_t) width * height * sizeof(uint32_t);
 


### PR DESCRIPTION
Descriptions from commit messages:

***Minor improvements for tiling logs***

Make use of dt_print_pipe() to simplify code in a few cases.
Some code maintenance.


***Cleanup demosaic module codebase***

As we do more things than just plain demosaicing here and all that functionality was spread and duplicated over the special algorithms we want some code cleanup for maintenance and better code understanding. This is required to possibly add more functionality.

For CPU and OpenCL we strictly process() or process_cl() in this order:

1. If no full processed data is required we immediately fallback to the special low-res approximators
2. Only for bayer sensors we support green-matching on raw data as a pre-processing step
3. Use the chosen demosaicer algorithm
4. Possibly write the scharr mask required for dual demosaicing or detail masks
5. In dual demosaicing modes demosaic again for low-frequency content using VNG and interpolate results
6. color smoothing as a post-processing step available for all non-passthru algorithms
7. Downscale and insert according to roi_out

4 bugs were found and have been fixed
1. For xtrans sensors there should be no greens-matching option in UI
2. Color smoothing in CPU path should be done for quality before scaling as we already do for OpenCL
3. In OpenCL dual demosaicing we missed the low-frequ color smoothing
4. Correctly set OpenCL VNG for xtrans instead of using markesteijn

Maintenance:
some pragmas, formatting for code style, renaming parameters for understanding, use roi_in instead roi for clarity, added some const declarations, report non-fullscale scaling, trailing whitespaces, ...

***Bump demosaic module version***

1. Prepare capture sharpening to be done within the demosaic module
2. Add two reserved parameters while doing the bump to be possibly used by capture sharpening or moire filtering.

