### PR TITLE
[imageio] Fix support for ASCII versions of PNM and optimize PAM support

### DIFF
--- a/src/imageio/imageio.c
+++ b/src/imageio/imageio.c
@@ -366,6 +366,9 @@ static const dt_magic_bytes_t _magic_signatures[] = {
   // binary NetPNM (ppm)
   { DT_FILETYPE_PNM, FALSE, 0, 3, dt_imageio_open_pnm,
     { 'P', '6', 0x0A } },
+  // binary NetPNM "Portable Arbitrary Map" (pam)
+  { DT_FILETYPE_PNM, FALSE, 0, 3, dt_imageio_open_exotic,
+    { 'P', '7', 0x0A } },
   // Windows BMP bitmap image
   { DT_FILETYPE_BMP, FALSE, 0, 2, dt_imageio_open_exotic,
     { 'B', 'M' } },

--- a/src/imageio/imageio.c
+++ b/src/imageio/imageio.c
@@ -349,13 +349,13 @@ static const dt_magic_bytes_t _magic_signatures[] = {
   { DT_FILETYPE_OTHER_LDR, FALSE, 0, 4, dt_imageio_open_exotic,
     { 0x80, 0x2A, 0x5F, 0xD7 } },
   // ASCII NetPNM (pbm)
-  { DT_FILETYPE_PNM, FALSE, 0, 3, dt_imageio_open_pnm,
+  { DT_FILETYPE_PNM, FALSE, 0, 3, dt_imageio_open_exotic,
     { 'P', '1', 0x0A } },
   // ASCII NetPNM (pgm)
-  { DT_FILETYPE_PNM, FALSE, 0, 3, dt_imageio_open_pnm,
+  { DT_FILETYPE_PNM, FALSE, 0, 3, dt_imageio_open_exotic,
     { 'P', '2', 0x0A } },
   // ASCII NetPNM (ppm)
-  { DT_FILETYPE_PNM, FALSE, 0, 3, dt_imageio_open_pnm,
+  { DT_FILETYPE_PNM, FALSE, 0, 3, dt_imageio_open_exotic,
     { 'P', '3', 0x0A } },
   // binary NetPNM (pbm)
   { DT_FILETYPE_PNM, FALSE, 0, 3, dt_imageio_open_pnm,


### PR DESCRIPTION
Changes in this PR:

- Our PNM loader does not support ASCII versions of the PNM format, so the GM/IM loader must be called for the corresponding signatures.

- Also added "Portable Arbitrary Map" format signature supported by GM/IM loader. Without this signature, we reached this loader on the fallback path (so the format eventually loaded successfully), but the log file was cluttered with messages from the rawspeed loader that was called earlier.
