### PR TITLE
IOP_ORDER related log fixes

### DIFF
--- a/src/common/history.c
+++ b/src/common/history.c
@@ -476,7 +476,7 @@ gboolean dt_history_merge_module_into_history(dt_develop_t *dev_dest,
     }
 
     // do some checking...
-    if(mod_src->iop_order <= 0.0 || mod_src->iop_order == INT_MAX)
+    if(mod_src->iop_order <= 0 || mod_src->iop_order == INT_MAX)
       dt_print(DT_DEBUG_ALWAYS,
                "[dt_history_merge_module_into_history]"
                " invalid source module %s %s(%d)(%i)",
@@ -484,7 +484,7 @@ gboolean dt_history_merge_module_into_history(dt_develop_t *dev_dest,
                mod_src->iop_order, mod_src->multi_priority);
 
     if(module_duplicate
-       && (module_duplicate->iop_order <= 0.0
+       && (module_duplicate->iop_order <= 0
            || module_duplicate->iop_order == INT_MAX))
       dt_print(DT_DEBUG_ALWAYS,
                "[dt_history_merge_module_into_history]"
@@ -492,7 +492,7 @@ gboolean dt_history_merge_module_into_history(dt_develop_t *dev_dest,
                module_duplicate->op, module_duplicate->multi_name,
                module_duplicate->iop_order, module_duplicate->multi_priority);
 
-    if(module->iop_order <= 0.0 || module->iop_order == INT_MAX)
+    if(module->iop_order <= 0 || module->iop_order == INT_MAX)
       dt_print(DT_DEBUG_ALWAYS,
                "[dt_history_merge_module_into_history]"
                " invalid iop_order for module %s %s(%d)(%i)",

--- a/src/develop/blend.c
+++ b/src/develop/blend.c
@@ -1475,7 +1475,7 @@ gboolean dt_develop_blend_process_cl(dt_iop_module_t *self,
     const gboolean new = g_hash_table_replace(piece->raster_masks, GINT_TO_POINTER(BLEND_RASTER_ID), _mask);
     dt_dev_pixelpipe_cache_invalidate_later(piece->pipe, self->iop_order);
     dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_MASKS,
-       "write raster mask", piece->pipe, self, piece->pipe->devid, NULL, NULL, "%s at %p (%ix%i)",
+       "write raster mask", piece->pipe, self, devid, NULL, NULL, "%s at %p (%ix%i)",
        new ? "new" : "replaced",
        _mask, roi_out->width, roi_out->height);
   }
@@ -1484,7 +1484,7 @@ gboolean dt_develop_blend_process_cl(dt_iop_module_t *self,
     dt_free_align(_mask);
     if(g_hash_table_remove(piece->raster_masks, GINT_TO_POINTER(BLEND_RASTER_ID)))
       dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_MASKS,
-        "delete raster mask", piece->pipe, self, piece->pipe->devid, roi_in, roi_out, " not requested");
+        "delete raster mask", piece->pipe, self, devid, roi_in, roi_out, " not requested");
   }
 
   dt_opencl_release_mem_object(dev_blendif_params);
@@ -1504,7 +1504,7 @@ error:
   if(g_hash_table_remove(piece->raster_masks, GINT_TO_POINTER(BLEND_RASTER_ID)))
   {
     dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_MASKS,
-      "delete raster mask", piece->pipe, self, piece->pipe->devid, roi_in, roi_out,
+      "delete raster mask", piece->pipe, self, devid, roi_in, roi_out,
       "OpenCL error: %s", cl_errstr(err));
     dt_dev_pixelpipe_cache_invalidate_later(piece->pipe, self->iop_order);
   }


### PR DESCRIPTION
1. In dt_print_pipe() we always log the iop_order if a module is provided. While being here some additional safety string modifications
2. Removed specific iop_order logging where it's now covered by dt_print_pipe() leading to less code.
3. modify iop_order checks to int where correct.
4. minor mods while checking this