### PR TITLE
Rename IOP order 3.1 to 5.0 to correspond to dt version.

### DIFF
--- a/src/common/iop_order.c
+++ b/src/common/iop_order.c
@@ -61,8 +61,8 @@ const char *iop_order_string[] =
   N_("legacy"),
   N_("v3.0 RAW"),
   N_("v3.0 JPEG"),
-  N_("v3.1 RAW"),
-  N_("v3.1 JPEG")
+  N_("v5.0 RAW"),
+  N_("v5.0 JPEG")
 };
 
 const char *dt_iop_order_string(const dt_iop_order_t order)
@@ -293,7 +293,7 @@ const dt_iop_order_entry_t v30_order[] = {
   { { 0.0f }, "", 0 }
 };
 
-const dt_iop_order_entry_t v31_order[] = {
+const dt_iop_order_entry_t v50_order[] = {
   { { 1.0 }, "rawprepare", 0},
   { { 2.0 }, "invert", 0},
   { { 3.0f }, "temperature", 0},
@@ -529,7 +529,7 @@ const dt_iop_order_entry_t v30_jpg_order[] = {
 };
 
 // default order for JPEG/TIFF/PNG files, non-linear before colorin
-const dt_iop_order_entry_t v31_jpg_order[] = {
+const dt_iop_order_entry_t v50_jpg_order[] = {
   // the following modules are not used anyway for non-RAW images :
   { { 1.0 }, "rawprepare", 0 },
   { { 2.0 }, "invert", 0 },
@@ -653,8 +653,8 @@ const dt_iop_order_entry_t *const _iop_order_tables[DT_IOP_ORDER_LAST] =
   legacy_order,
   v30_order,
   v30_jpg_order,
-  v31_order,
-  v31_jpg_order
+  v50_order,
+  v50_jpg_order
 };
 
 static void *_dup_iop_order_entry(const void *src, gpointer data);

--- a/src/common/iop_order.h
+++ b/src/common/iop_order.h
@@ -137,13 +137,13 @@ typedef enum dt_iop_order_t
   DT_IOP_ORDER_LEGACY  = 1, // up to dt 2.6.3
   DT_IOP_ORDER_V30     = 2, // starts with dt 3.0
   DT_IOP_ORDER_V30_JPG = 3, // same as previous but tuned for non-linear input
-  DT_IOP_ORDER_V31     = 4, // starts with dt 3.0
-  DT_IOP_ORDER_V31_JPG = 5, // same as previous but tuned for non-linear input
+  DT_IOP_ORDER_V50     = 4, // starts with dt 5.0
+  DT_IOP_ORDER_V50_JPG = 5, // same as previous but tuned for non-linear input
   DT_IOP_ORDER_LAST    = 6
 } dt_iop_order_t;
 
-#define DT_DEFAULT_IOP_ORDER_RAW DT_IOP_ORDER_V31
-#define DT_DEFAULT_IOP_ORDER_JPG DT_IOP_ORDER_V31_JPG
+#define DT_DEFAULT_IOP_ORDER_RAW DT_IOP_ORDER_V50
+#define DT_DEFAULT_IOP_ORDER_JPG DT_IOP_ORDER_V50_JPG
 
 typedef struct dt_iop_order_entry_t
 {

--- a/src/libs/ioporder.c
+++ b/src/libs/ioporder.c
@@ -215,18 +215,18 @@ void init_presets(dt_lib_module_t *self)
   dt_ioppr_iop_order_list_free(list);
 
   // make it the default for new RAW
-  list = dt_ioppr_get_iop_order_list_version(DT_IOP_ORDER_V31);
+  list = dt_ioppr_get_iop_order_list_version(DT_IOP_ORDER_V50);
   params = dt_ioppr_serialize_iop_order_list(list, &size);
-  dt_lib_presets_add(_("v3.1 for RAW input"),
+  dt_lib_presets_add(_("v5.0 for RAW input"),
                      self->plugin_name, self->version(),
                      (const char *)params, (int32_t)size, TRUE,
                      is_display_referred ? 0 : FOR_RAW | FOR_MATRIX);
   free(params);
   dt_ioppr_iop_order_list_free(list);
 
-  list = dt_ioppr_get_iop_order_list_version(DT_IOP_ORDER_V31_JPG);
+  list = dt_ioppr_get_iop_order_list_version(DT_IOP_ORDER_V50_JPG);
   params = dt_ioppr_serialize_iop_order_list(list, &size);
-  dt_lib_presets_add(_("v3.1 for JPEG/non-RAW input"),
+  dt_lib_presets_add(_("v5.0 for JPEG/non-RAW input"),
                      self->plugin_name, self->version(),
                      (const char *)params, (int32_t)size, TRUE,
                      is_display_referred ? 0 : FOR_LDR | FOR_NOT_MONO);


### PR DESCRIPTION
As done for 3.0 we name the iop-order based on the dt version introducing it.