### PR TITLE
Handle gimp API

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1335,6 +1335,17 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
     }
   }
 
+  /* We now have all command line options ready and check for gimp API questions.
+      Return right now if
+        - we check for API version
+        - we check for "file" or "thumb" and the file is not physically available
+      and let the caller check again and write out protocol messages.
+  */
+  if(dt_check_gimpmode("version")
+    || (dt_check_gimpmode("file") && !dt_check_gimpmode_ok("file"))
+    || (dt_check_gimpmode("thumb") && !dt_check_gimpmode_ok("thumb")))
+    return 0;
+
   if(darktable.unmuted)
   {
     char *theversion = _get_version_string();

--- a/src/common/gimp.h
+++ b/src/common/gimp.h
@@ -16,6 +16,40 @@
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+/*
+The GIMP support CLI API
+
+Added --gimp <mode> option to the cli interface. <mode> is always a string, can be "version" "file" "thumb"
+
+Whenever we call 'darktable --gimp' the results are written to 'stdout'. All requested results are in a block encapsulated by
+
+a start line `\n<<<gimp\n` and
+a final line `\ngimp>>>\n`
+
+for defined interpretation.
+
+(This allows darktable to use the debug logs and avoids problems with libraries writing to output in an uncontrolled manner.)
+
+In case of an error the <res> is 'error'
+
+The exitcode of darktable while using any --gimp option reflects the error status.
+
+version            Returns the current API version (for initial commit will be 1)
+file <path>        Starts darktable in darkroom mode using image defined by <path>.
+                   When closing the darkroom window the file is exported as an
+                   xcf file to a temporary location.
+                   The full path of the exported file is returned as <res>
+thumb <path> <dim> Write a thumbnail jpg file to a temporary location.
+                   <path> is the image file
+                   <dim> (in pixels) is used for the greater of width/height and ratio is kept.
+                   The returned <res> has the following format:
+                   * The full path of the exported file on the first line
+                   * The width and height as space-separated integers on the second line.
+                     These dimensions are informational and may not be accurate.
+                     For raw files this is sensor size containing valid data.
+*/
+
+
 #define DT_GIMP_VERSION 1
 
 gboolean dt_export_gimp_file(const dt_imgid_t id);

--- a/src/gui/splash.c
+++ b/src/gui/splash.c
@@ -132,6 +132,8 @@ void darktable_splash_screen_create(GtkWindow *parent_window,
   // the splash screen is enabled in the config or we are told to
   // create it regardless.
   if(splash_screen
+     || dt_check_gimpmode("file")
+     || dt_check_gimpmode("thumb")
      || (!dt_conf_get_bool("show_splash_screen") && !force))
   {
     return;
@@ -337,8 +339,9 @@ void darktable_exit_screen_create(GtkWindow *parent_window,
   // run if the splash screen is enabled in the config or we are told
   // to create it regardless
   if(exit_screen
-     || (!dt_conf_get_bool("show_splash_screen")
-         && !force))
+     || dt_check_gimpmode("file")
+     || dt_check_gimpmode("thumb")
+     || (!dt_conf_get_bool("show_splash_screen") && !force))
   {
     return;
   }

--- a/src/main.c
+++ b/src/main.c
@@ -106,7 +106,18 @@ int main(int argc, char *argv[])
   if(dt_init(argc, argv, TRUE, TRUE, NULL)) exit(1);
 
   if(dt_check_gimpmode_ok("version"))
+  {
     fprintf(stdout, "\n<<<gimp\n%d\ngimp>>>\n", DT_GIMP_VERSION);
+    exit(0);
+  }
+
+  if(dt_check_gimpmode("version")
+    || (dt_check_gimpmode("file") && !dt_check_gimpmode_ok("file"))
+    || (dt_check_gimpmode("thumb") && !dt_check_gimpmode_ok("thumb")))
+  {
+    fprintf(stdout, "\n<<<gimp\nerror\ngimp>>>\n");
+    exit(1);
+  }
 
   if(dt_check_gimpmode_ok("file"))
   {


### PR DESCRIPTION
1. Add API reference to src
2. Return early for failing gimp requests or simple version.
3. As darktable might be called as a gimp-plugin we don't want the splash in that case.

Fixes #17785 

This is so far not fixing the issue related to dt crashing if the close button is pressed too early. Not yet found a way to fix that too ...