### PR TITLE
Changes to permit group persistence

### DIFF
--- a/src/common/grouping.c
+++ b/src/common/grouping.c
@@ -25,6 +25,12 @@
 #include "control/signal.h"
 #include "gui/gtk.h"
 
+#ifdef USE_LUA
+#include "lua/call.h"
+#include "lua/events.h"
+#include "lua/image.h"
+#endif
+
 /** add an image to a group */
 void dt_grouping_add_to_group(const dt_imgid_t group_id,
                               const dt_imgid_t image_id)
@@ -39,6 +45,16 @@ void dt_grouping_add_to_group(const dt_imgid_t group_id,
   GList *imgs = NULL;
   imgs = g_list_prepend(imgs, GINT_TO_POINTER(image_id));
   DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_IMAGE_INFO_CHANGED, imgs);
+
+#ifdef USE_LUA
+   dt_lua_async_call_alien(dt_lua_event_trigger_wrapper,
+      0, NULL, NULL,
+      LUA_ASYNC_TYPENAME, "const char*", "image-group-information-changed",
+      LUA_ASYNC_TYPENAME, "const char*", "add",
+      LUA_ASYNC_TYPENAME, "dt_lua_image_t", GINT_TO_POINTER(image_id),
+      LUA_ASYNC_TYPENAME, "dt_lua_image_t", GINT_TO_POINTER(group_id),
+      LUA_ASYNC_DONE);
+#endif
 }
 
 /** remove an image from a group */
@@ -86,6 +102,15 @@ dt_imgid_t dt_grouping_remove_from_group(const dt_imgid_t image_id)
       DT_DEBUG_SQLITE3_BIND_INT(stmt, 3, image_id);
       sqlite3_step(stmt);
       sqlite3_finalize(stmt);
+#ifdef USE_LUA
+      dt_lua_async_call_alien(dt_lua_event_trigger_wrapper,
+          0, NULL, NULL,
+          LUA_ASYNC_TYPENAME, "const char*", "image-group-information-changed",
+          LUA_ASYNC_TYPENAME, "const char*", "remove-leader",
+          LUA_ASYNC_TYPENAME, "dt_lua_image_t", GINT_TO_POINTER(image_id),
+          LUA_ASYNC_TYPENAME, "dt_lua_image_t", GINT_TO_POINTER(new_group_id),
+          LUA_ASYNC_DONE);
+#endif
     }
     else
     {
@@ -104,6 +129,15 @@ dt_imgid_t dt_grouping_remove_from_group(const dt_imgid_t image_id)
     imgs = g_list_prepend(imgs, GINT_TO_POINTER(image_id));
     // refresh also the group leader which may be alone now
     imgs = g_list_prepend(imgs, GINT_TO_POINTER(img_group_id));
+#ifdef USE_LUA
+    dt_lua_async_call_alien(dt_lua_event_trigger_wrapper,
+      0, NULL, NULL,
+      LUA_ASYNC_TYPENAME, "const char*", "image-group-information-changed",
+      LUA_ASYNC_TYPENAME, "const char*", "remove",
+      LUA_ASYNC_TYPENAME, "dt_lua_image_t", GINT_TO_POINTER(image_id),
+      LUA_ASYNC_TYPENAME, "dt_lua_image_t", GINT_TO_POINTER(img_group_id),
+      LUA_ASYNC_DONE);
+#endif
   }
   DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_IMAGE_INFO_CHANGED, imgs);
 
@@ -135,6 +169,16 @@ dt_imgid_t dt_grouping_change_representative(const dt_imgid_t image_id)
   }
   sqlite3_finalize(stmt);
   DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_IMAGE_INFO_CHANGED, imgs);
+
+#ifdef USE_LUA
+  dt_lua_async_call_alien(dt_lua_event_trigger_wrapper,
+      0, NULL, NULL,
+      LUA_ASYNC_TYPENAME, "const char*", "image-group-information-changed",
+      LUA_ASYNC_TYPENAME, "const char*", "leader-change",
+      LUA_ASYNC_TYPENAME, "dt_lua_image_t", GINT_TO_POINTER(image_id),
+      LUA_ASYNC_TYPENAME, "dt_lua_image_t", GINT_TO_POINTER(image_id),
+      LUA_ASYNC_DONE);
+#endif
 
   return image_id;
 }

--- a/src/common/tags.c
+++ b/src/common/tags.c
@@ -895,7 +895,7 @@ GList *dt_tag_get_list(const dt_imgid_t imgid)
 
   gboolean omit_tag_hierarchy = dt_conf_get_bool("omit_tag_hierarchy");
 
-  const uint32_t count = dt_tag_get_attached(imgid, &taglist, TRUE);
+  const uint32_t count = dt_tag_get_attached(imgid, &taglist, FALSE);
 
   if(count < 1)
     return NULL;
@@ -938,7 +938,7 @@ GList *dt_tag_get_hierarchical(const dt_imgid_t imgid)
   GList *taglist = NULL;
   GList *tags = NULL;
 
-  const uint32_t count = dt_tag_get_attached(imgid, &taglist, TRUE);
+  const uint32_t count = dt_tag_get_attached(imgid, &taglist, FALSE);
 
   if(count < 1)
     return NULL;

--- a/src/lua/events.c
+++ b/src/lua/events.c
@@ -663,6 +663,11 @@ int dt_lua_init_events(lua_State *L)
   lua_pushcfunction(L, dt_lua_event_multiinstance_trigger);
   dt_lua_event_add(L, "pixelpipe-processing-complete");
 
+  lua_pushcfunction(L, dt_lua_event_multiinstance_register);
+  lua_pushcfunction(L, dt_lua_event_multiinstance_destroy);
+  lua_pushcfunction(L, dt_lua_event_multiinstance_trigger);
+  dt_lua_event_add(L, "image-group-information-changed");
+
   return 0;
 }
 // clang-format off

--- a/src/lua/util.c
+++ b/src/lua/util.c
@@ -21,6 +21,17 @@
 #include <glib.h>
 #include <stdlib.h>
 #include <string.h>
+#include <uuid.h>
+
+static int gen_uuid(lua_State *L)
+{
+  uuid_t uuid;
+  char uuid_string[37];
+  uuid_generate(uuid);
+  uuid_unparse_upper(uuid, uuid_string);
+  lua_pushstring(L, uuid_string);
+  return 1;
+}
 
 static int message(lua_State *L)
 {
@@ -44,6 +55,9 @@ int dt_lua_init_util(lua_State *L)
 {
   dt_lua_push_darktable_lib(L);
   dt_lua_goto_subtable(L, "util");
+
+  lua_pushcfunction(L, gen_uuid);
+  lua_setfield(L, -2, "gen_uuid");
 
   lua_pushcfunction(L, message);
   lua_setfield(L, -2, "message");


### PR DESCRIPTION
Partial fix for #16827.  Actually, according to the title it's a complete fix, but the meaning is to have a way to maintain image grouping across database instances.

In order to make the grouping information survive between database instances I use `darktable|` tags.  This has the advantage of not cluttering up the tagging UI with lots of grouping tags while allowing the information to be stored.  `darktable|` tags aren't included in the XMP files, but should be IMHO since they contain state information about the image.   So, I added the `darktable|` tags to the XMP.

I added a `gen_uuid()` function to `darktable.util`, in the Lua API,  to generate a UUID string for each group.

I added a `image-group-information-changed` Lua event that fires whenever a grouping change is made so the I could create/update the group tags for the image.

The final piece to fix #16827 is a lua-script that monitors grouping changes and tags them, then rebuilds the groups on import.