### PR TITLE
Some more demosaicer maintenance

### DIFF
--- a/src/develop/imageop_math.c
+++ b/src/develop/imageop_math.c
@@ -263,12 +263,12 @@ void dt_iop_clip_and_zoom_mosaic_half_size(uint16_t *const out,
   {
     uint16_t *outc = out + out_stride * y;
 
-    const float fy = (y + roi_out->y) * px_footprint;
+    const float fy = y * px_footprint;
     const int miny = (CLAMPS((int)floorf(fy - px_footprint),
                              0, roi_in->height-3) & ~1u) + rggby;
     const int maxy = MIN(roi_in->height-1, (int)ceilf(fy + px_footprint));
 
-    float fx = roi_out->x * px_footprint;
+    float fx = 0.0f;
     for(int x = 0; x < roi_out->width; x++, fx += px_footprint, outc++)
     {
       const int minx = (CLAMPS((int)floorf(fx - px_footprint),
@@ -324,7 +324,7 @@ void dt_iop_clip_and_zoom_mosaic_half_size_f(float *const out,
   {
     float *outc = out + out_stride * y;
 
-    const float fy = (y + roi_out->y) * px_footprint;
+    const float fy = y * px_footprint;
     int py = (int)fy & ~1;
     const float dy = (fy - py) / 2;
     py = MIN(((roi_in->height - 6) & ~1u), py) + rggby;
@@ -335,7 +335,7 @@ void dt_iop_clip_and_zoom_mosaic_half_size_f(float *const out,
     {
       dt_aligned_pixel_t col = { 0, 0, 0, 0 };
 
-      const float fx = (x + roi_out->x) * px_footprint;
+      const float fx = x * px_footprint;
       int px = (int)fx & ~1;
       const float dx = (fx - px) / 2;
       px = MIN(((roi_in->width - 6) & ~1u), px) + rggbx;
@@ -503,11 +503,11 @@ void dt_iop_clip_and_zoom_mosaic_third_size_xtrans(uint16_t *const out,
   {
     uint16_t *outc = out + out_stride * y;
 
-    const float fy = (y + roi_out->y) * px_footprint;
+    const float fy = y * px_footprint;
     const int miny = MAX(0, (int)roundf(fy - px_footprint));
     const int maxy = MIN(roi_in->height-1, (int)roundf(fy + px_footprint));
 
-    float fx = roi_out->x * px_footprint;
+    float fx = 0.0f;
     for(int x = 0; x < roi_out->width; x++, fx += px_footprint, outc++)
     {
       const int minx = MAX(0, (int)roundf(fx - px_footprint));
@@ -543,11 +543,11 @@ void dt_iop_clip_and_zoom_mosaic_third_size_xtrans_f(float *const out,
   {
     float *outc = out + out_stride * y;
 
-    const float fy = (y + roi_out->y) * px_footprint;
+    const float fy = y * px_footprint;
     const int miny = MAX(0, (int)roundf(fy - px_footprint));
     const int maxy = MIN(roi_in->height-1, (int)roundf(fy + px_footprint));
 
-    float fx = roi_out->x * px_footprint;
+    float fx = 0.0f;
     for(int x = 0; x < roi_out->width; x++, fx += px_footprint, outc++)
     {
       const int minx = MAX(0, (int)roundf(fx - px_footprint));
@@ -587,7 +587,7 @@ void dt_iop_clip_and_zoom_demosaic_passthrough_monochrome_f(float *out,
   {
     float *outc = out + 4 * (out_stride * y);
 
-    const float fy = (y + roi_out->y) * px_footprint;
+    const float fy = y * px_footprint;
     int py = (int)fy;
     const float dy = fy - py;
     py = MIN(((roi_in->height - 3)), py);
@@ -598,7 +598,7 @@ void dt_iop_clip_and_zoom_demosaic_passthrough_monochrome_f(float *out,
     {
       float col = 0.0f;
 
-      const float fx = (x + roi_out->x) * px_footprint;
+      const float fx = x * px_footprint;
       int px = (int)fx;
       const float dx = fx - px;
       px = MIN(((roi_in->width - 3)), px);
@@ -738,7 +738,7 @@ void dt_iop_clip_and_zoom_demosaic_half_size_f(float *out,
   {
     float *outc = out + 4 * (out_stride * y);
 
-    const float fy = (y + roi_out->y) * px_footprint;
+    const float fy = y * px_footprint;
     int py = (int)fy & ~1;
     const float dy = (fy - py) / 2;
     py = MIN(((roi_in->height - 6) & ~1u), py) + rggby;
@@ -749,7 +749,7 @@ void dt_iop_clip_and_zoom_demosaic_half_size_f(float *out,
     {
       dt_aligned_pixel_t col = { 0, 0, 0, 0 };
 
-      const float fx = (x + roi_out->x) * px_footprint;
+      const float fx = x * px_footprint;
       int px = (int)fx & ~1;
       const float dx = (fx - px) / 2;
       px = MIN(((roi_in->width - 6) & ~1u), px) + rggbx;
@@ -910,7 +910,7 @@ void dt_iop_clip_and_zoom_demosaic_third_size_xtrans_f(float *out,
   for(int y = 0; y < roi_out->height; y++)
   {
     float *outc = out + 4 * (out_stride * y);
-    const int py = CLAMPS((int)round((y + roi_out->y - 0.5f) * px_footprint),
+    const int py = CLAMPS((int)round((y - 0.5f) * px_footprint),
                           0, roi_in->height - 3);
     const int ymax = MIN(roi_in->height - 3, py + 3 * samples);
 
@@ -918,7 +918,7 @@ void dt_iop_clip_and_zoom_demosaic_third_size_xtrans_f(float *out,
     {
       dt_aligned_pixel_t col = { 0.0f };
       int num = 0;
-      const int px = CLAMPS((int)round((x + roi_out->x - 0.5f) * px_footprint),
+      const int px = CLAMPS((int)round((x - 0.5f) * px_footprint),
                             0, roi_in->width - 3);
       const int xmax = MIN(roi_in->width - 3, px + 3 * samples);
       for(int yy = py; yy <= ymax; yy += 3)

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -150,7 +150,7 @@ void dt_print_pipe_ext(const char *title,
   vsnprintf(vbuf, sizeof(vbuf), msg, ap);
   va_end(ap);
 
-  dt_print_ext("%-25s %-3s %-16s %-22s %2s %s%s%s%s",
+  dt_print_ext("%-25s %-3s %-16s %-22s %4s %s%s%s%s",
                vtit, dev, pname, vmod, order, roi, roo, masking, vbuf);
 }
 

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -340,7 +340,7 @@ int legacy_params(dt_iop_module_t *self,
     dt_iop_demosaic_params_v4_t *n = malloc(sizeof(dt_iop_demosaic_params_v4_t));
     n->green_eq = o->green_eq;
     n->median_thrs = o->median_thrs;
-    n->color_smoothing = 0;
+    n->color_smoothing = DT_DEMOSAIC_SMOOTH_OFF;
     n->demosaicing_method = DT_IOP_DEMOSAIC_PPG;
     n->lmmse_refine = DT_LMMSE_REFINE_1;
     n->dual_thrs = 0.20f;
@@ -633,11 +633,11 @@ void process(dt_iop_module_t *self,
   {
     dt_print_pipe(DT_DEBUG_PIPE, "demosaic approx zoom", piece->pipe, self, DT_DEVICE_CPU, roi_in, roi_out);
     if(demosaicing_method == DT_IOP_DEMOSAIC_PASSTHROUGH_MONOCHROME || demosaicing_method == DT_IOP_DEMOSAIC_PASSTHROUGH_COLOR)
-      dt_iop_clip_and_zoom_demosaic_passthrough_monochrome_f(out, in, &roo, roi_in, roi_out->width, width);
+      dt_iop_clip_and_zoom_demosaic_passthrough_monochrome_f(out, in, roi_out, roi_in, roi_out->width, width);
     else if(is_xtrans)
-      dt_iop_clip_and_zoom_demosaic_third_size_xtrans_f(out, in, &roo, roi_in, roi_out->width, width, xtrans);
+      dt_iop_clip_and_zoom_demosaic_third_size_xtrans_f(out, in, roi_out, roi_in, roi_out->width, width, xtrans);
     else
-      dt_iop_clip_and_zoom_demosaic_half_size_f(out, in, &roo, roi_in, roi_out->width, width, piece->pipe->dsc.filters);
+      dt_iop_clip_and_zoom_demosaic_half_size_f(out, in, roi_out, roi_in, roi_out->width, width, piece->pipe->dsc.filters);
 
     return;
   }
@@ -736,7 +736,7 @@ void process(dt_iop_module_t *self,
   dt_print_pipe(DT_DEBUG_PIPE, direct ? "demosaic inplace" : "demosaic clip_and_zoom", piece->pipe, self, DT_DEVICE_CPU, roi_in, roi_out);
   if(!direct)
   {
-    dt_iop_clip_and_zoom_roi((float *)o, out, roi_out, &roo);
+    dt_iop_clip_and_zoom_roi((float *)o, out, roi_out, &roo); // rou_out->scale is always 1.0
     dt_free_align(out);
   }
 }
@@ -1082,13 +1082,13 @@ void commit_params(dt_iop_module_t *self,
   if(passing || bayer4)
   {
     d->green_eq = DT_IOP_GREEN_EQ_NO;
-    d->color_smoothing = 0;
+    d->color_smoothing = DT_DEMOSAIC_SMOOTH_OFF;
   }
 
   if(use_method & DT_DEMOSAIC_DUAL)
   {
     dt_dev_pixelpipe_usedetails(piece->pipe);
-    d->color_smoothing = 0;
+    d->color_smoothing = DT_DEMOSAIC_SMOOTH_OFF;
   }
   d->demosaicing_method = use_method;
 

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -268,7 +268,6 @@ void amaze_demosaic(dt_dev_pixelpipe_iop_t *piece,
                     const float *const in,
                     float *out,
                     const dt_iop_roi_t *const roi_in,
-                    const dt_iop_roi_t *const roi_out,
                     const uint32_t filters);
 
 #include "iop/demosaicing/basics.c"
@@ -719,7 +718,7 @@ void process(dt_iop_module_t *self,
     else if(base_demosaicing_method != DT_IOP_DEMOSAIC_AMAZE)
       demosaic_ppg(out, in, &roo, roi_in, piece->pipe->dsc.filters, d->median_thrs);
     else
-      amaze_demosaic(piece, in, out, roi_in, &roo, piece->pipe->dsc.filters);
+      amaze_demosaic(piece, in, out, roi_in, piece->pipe->dsc.filters);
   }
 
   if(piece->pipe->want_detail_mask)

--- a/src/iop/demosaicing/amaze.cc
+++ b/src/iop/demosaicing/amaze.cc
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2011-2023 darktable developers.
+    Copyright (C) 2011-2024 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -130,20 +130,16 @@ void amaze_demosaic(dt_dev_pixelpipe_iop_t *piece,
                     const float *const in,
                     float *out,
                     const dt_iop_roi_t *const roi_in,
-                    const dt_iop_roi_t *const roi_out,
                     const uint32_t filters)
 {
-  int winx = roi_out->x;
-  int winy = roi_out->y;
-  int winw = roi_in->width;
-  int winh = roi_in->height;
+  const int width = roi_in->width;
+  const int height = roi_in->height;
 
-  const int width = winw, height = winh;
   const float clip_pt = dt_iop_get_processed_minimum(piece);
   const float clip_pt8 = 0.8f * clip_pt;
 
 // this allows to pass AMAZETS to the code. On some machines larger AMAZETS is faster
-// If AMAZETS is undefined it will be set to 160, which is the fastest on modern x86/64 machines
+// If AMAZETS is undefined it will be set to 160, which is the fastest on machines with 1GB cache per thread.
 #ifndef AMAZETS
 #define AMAZETS 160
 #endif
@@ -277,25 +273,25 @@ void amaze_demosaic(dt_dev_pixelpipe_iop_t *piece,
 // use collapse(2) to collapse the 2 loops to one large loop, so there is better scaling
     DT_OMP_PRAGMA(for SIMD() schedule(static) collapse(2) nowait)
 
-    for(int top = winy - 16; top < winy + height; top += ts - 32)
+    for(int top = -16; top < height; top += ts - 32)
     {
-      for(int left = winx - 16; left < winx + width; left += ts - 32)
+      for(int left = -16; left < width; left += ts - 32)
       {
         memset(&nyquist[3 * tsh], 0, sizeof(unsigned char) * (ts - 6) * tsh);
         // location of tile bottom edge
-        const int bottom = MIN(top + ts, winy + height + 16);
+        const int bottom = MIN(top + ts, height + 16);
         // location of tile right edge
-        const int right = MIN(left + ts, winx + width + 16);
+        const int right = MIN(left + ts, width + 16);
         // tile width  (=ts except for right edge of image)
         const int rr1 = bottom - top;
         // tile height (=ts except for bottom edge of image)
         const int cc1 = right - left;
         // bookkeeping for borders
         // min and max row/column in the tile
-        const int rrmin = top < winy ? 16 : 0;
-        const int ccmin = left < winx ? 16 : 0;
-        const int rrmax = bottom > (winy + height) ? winy + height - top : rr1;
-        const int ccmax = right > (winx + width) ? winx + width - left : cc1;
+        const int rrmin = top < 0 ? 16 : 0;
+        const int ccmin = left < 0 ? 16 : 0;
+        const int rrmax = bottom > height ? height - top : rr1;
+        const int ccmax = right > width ? width - left : cc1;
 
 // rgb from input CFA data
 // rgb values should be floating point number between 0 and 1
@@ -333,7 +329,7 @@ void amaze_demosaic(dt_dev_pixelpipe_iop_t *piece,
           for(int rr = 0; rr < 16; rr++)
             for(int cc = ccmin; cc < ccmax; cc++)
             {
-              cfa[(rrmax + rr) * ts + cc] = (in[(winy + height - rr - 2) * width + (left + cc)]);
+              cfa[(rrmax + rr) * ts + cc] = (in[(height - rr - 2) * width + (left + cc)]);
               rgbgreen[(rrmax + rr) * ts + cc] = cfa[(rrmax + rr) * ts + cc];
             }
         }
@@ -354,7 +350,7 @@ void amaze_demosaic(dt_dev_pixelpipe_iop_t *piece,
           for(int rr = rrmin; rr < rrmax; rr++)
             for(int cc = 0; cc < 16; cc++)
             {
-              cfa[rr * ts + ccmax + cc] = (in[(top + rr) * width + ((winx + width - cc - 2))]);
+              cfa[rr * ts + ccmax + cc] = (in[(top + rr) * width + ((width - cc - 2))]);
               rgbgreen[rr * ts + ccmax + cc] = cfa[rr * ts + ccmax + cc];
             }
         }
@@ -365,7 +361,7 @@ void amaze_demosaic(dt_dev_pixelpipe_iop_t *piece,
           for(int rr = 0; rr < 16; rr++)
             for(int cc = 0; cc < 16; cc++)
             {
-              cfa[(rr)*ts + cc] = (in[(winy + 32 - rr) * width + (winx + 32 - cc)]);
+              cfa[(rr)*ts + cc] = (in[(32 - rr) * width + (32 - cc)]);
               rgbgreen[(rr)*ts + cc] = cfa[(rr)*ts + cc];
             }
         }
@@ -376,7 +372,7 @@ void amaze_demosaic(dt_dev_pixelpipe_iop_t *piece,
             for(int cc = 0; cc < 16; cc++)
             {
               cfa[(rrmax + rr) * ts + ccmax + cc]
-                  = (in[(winy + height - rr - 2) * width + ((winx + width - cc - 2))]);
+                  = (in[(height - rr - 2) * width + ((width - cc - 2))]);
               rgbgreen[(rrmax + rr) * ts + ccmax + cc] = cfa[(rrmax + rr) * ts + ccmax + cc];
             }
         }
@@ -386,7 +382,7 @@ void amaze_demosaic(dt_dev_pixelpipe_iop_t *piece,
           for(int rr = 0; rr < 16; rr++)
             for(int cc = 0; cc < 16; cc++)
             {
-              cfa[(rr)*ts + ccmax + cc] = (in[(winy + 32 - rr) * width + ((winx + width - cc - 2))]);
+              cfa[(rr)*ts + ccmax + cc] = (in[(32 - rr) * width + ((width - cc - 2))]);
               rgbgreen[(rr)*ts + ccmax + cc] = cfa[(rr)*ts + ccmax + cc];
             }
         }
@@ -396,7 +392,7 @@ void amaze_demosaic(dt_dev_pixelpipe_iop_t *piece,
           for(int rr = 0; rr < 16; rr++)
             for(int cc = 0; cc < 16; cc++)
             {
-              cfa[(rrmax + rr) * ts + cc] = (in[(winy + height - rr - 2) * width + ((winx + 32 - cc))]);
+              cfa[(rrmax + rr) * ts + cc] = (in[(height - rr - 2) * width + ((32 - cc))]);
               rgbgreen[(rrmax + rr) * ts + cc] = cfa[(rrmax + rr) * ts + cc];
             }
         }
@@ -1221,11 +1217,11 @@ void amaze_demosaic(dt_dev_pixelpipe_iop_t *piece,
           {
             for(; indx < rr * ts + cc1 - 16 - (cc1 & 1); indx++, col++)
             {
-              if(col < roi_out->width && row < roi_out->height)
+              if(col < width && row < height)
               {
                 const float temp = 1.f / (hvwt[(indx - v1) >> 1] + 2.f - hvwt[(indx + 1) >> 1]
                                     - hvwt[(indx - 1) >> 1] + hvwt[(indx + v1) >> 1]);
-                out[(row * roi_out->width + col) * 4]
+                out[(row * width + col) * 4]
                     = _clampnan(rgbgreen[indx]
                                    - ((hvwt[(indx - v1) >> 1]) * Dgrb[0][(indx - v1) >> 1]
                                       + (1.f - hvwt[(indx + 1) >> 1]) * Dgrb[0][(indx + 1) >> 1]
@@ -1234,7 +1230,7 @@ void amaze_demosaic(dt_dev_pixelpipe_iop_t *piece,
                                          * temp,
                                0.0, 1.0);
 
-                out[(row * roi_out->width + col) * 4 + 2]
+                out[(row * width + col) * 4 + 2]
                     = _clampnan(rgbgreen[indx]
                                    - ((hvwt[(indx - v1) >> 1]) * Dgrb[1][(indx - v1) >> 1]
                                       + (1.f - hvwt[(indx + 1) >> 1]) * Dgrb[1][(indx + 1) >> 1]
@@ -1246,22 +1242,22 @@ void amaze_demosaic(dt_dev_pixelpipe_iop_t *piece,
 
               indx++;
               col++;
-              if(col < roi_out->width && row < roi_out->height)
+              if(col < width && row < height)
               {
-                out[(row * roi_out->width + col) * 4]
+                out[(row * width + col) * 4]
                     = _clampnan(rgbgreen[indx] - Dgrb[0][indx >> 1], 0.0, 1.0);
-                out[(row * roi_out->width + col) * 4 + 2]
+                out[(row * width + col) * 4 + 2]
                     = _clampnan(rgbgreen[indx] - Dgrb[1][indx >> 1], 0.0, 1.0);
               }
             }
 
             if(cc1 & 1)
             { // width of tile is odd
-              if(col < roi_out->width && row < roi_out->height)
+              if(col < width && row < height)
               {
                 const float temp = 1.f / (hvwt[(indx - v1) >> 1] + 2.f - hvwt[(indx + 1) >> 1]
                                     - hvwt[(indx - 1) >> 1] + hvwt[(indx + v1) >> 1]);
-                out[(row * roi_out->width + col) * 4]
+                out[(row * width + col) * 4]
                     = _clampnan(rgbgreen[indx]
                                    - ((hvwt[(indx - v1) >> 1]) * Dgrb[0][(indx - v1) >> 1]
                                       + (1.f - hvwt[(indx + 1) >> 1]) * Dgrb[0][(indx + 1) >> 1]
@@ -1269,7 +1265,7 @@ void amaze_demosaic(dt_dev_pixelpipe_iop_t *piece,
                                       + (hvwt[(indx + v1) >> 1]) * Dgrb[0][(indx + v1) >> 1])
                                          * temp,
                                0.0, 1.0);
-                out[(row * roi_out->width + col) * 4 + 2]
+                out[(row * width + col) * 4 + 2]
                     = _clampnan(rgbgreen[indx]
                                    - ((hvwt[(indx - v1) >> 1]) * Dgrb[1][(indx - v1) >> 1]
                                       + (1.f - hvwt[(indx + 1) >> 1]) * Dgrb[1][(indx + 1) >> 1]
@@ -1284,22 +1280,22 @@ void amaze_demosaic(dt_dev_pixelpipe_iop_t *piece,
           {
             for(; indx < rr * ts + cc1 - 16 - (cc1 & 1); indx++, col++)
             {
-              if(col < roi_out->width && row < roi_out->height)
+              if(col < width && row < height)
               {
-                out[(row * roi_out->width + col) * 4]
+                out[(row * width + col) * 4]
                     = _clampnan(rgbgreen[indx] - Dgrb[0][indx >> 1], 0.0f, 1.0f);
-                out[(row * roi_out->width + col) * 4 + 2]
+                out[(row * width + col) * 4 + 2]
                     = _clampnan(rgbgreen[indx] - Dgrb[1][indx >> 1], 0.0f, 1.0f);
               }
 
               indx++;
               col++;
-              if(col < roi_out->width && row < roi_out->height)
+              if(col < width && row < height)
               {
                 const float temp = 1.f / (hvwt[(indx - v1) >> 1] + 2.f - hvwt[(indx + 1) >> 1]
                                     - hvwt[(indx - 1) >> 1] + hvwt[(indx + v1) >> 1]);
 
-                out[(row * roi_out->width + col) * 4]
+                out[(row * width + col) * 4]
                     = _clampnan(rgbgreen[indx]
                                    - ((hvwt[(indx - v1) >> 1]) * Dgrb[0][(indx - v1) >> 1]
                                       + (1.0f - hvwt[(indx + 1) >> 1]) * Dgrb[0][(indx + 1) >> 1]
@@ -1308,7 +1304,7 @@ void amaze_demosaic(dt_dev_pixelpipe_iop_t *piece,
                                          * temp,
                                0.0f, 1.0f);
 
-                out[(row * roi_out->width + col) * 4 + 2]
+                out[(row * width + col) * 4 + 2]
                     = _clampnan(rgbgreen[indx]
                                    - ((hvwt[(indx - v1) >> 1]) * Dgrb[1][(indx - v1) >> 1]
                                       + (1.0f - hvwt[(indx + 1) >> 1]) * Dgrb[1][(indx + 1) >> 1]
@@ -1321,11 +1317,11 @@ void amaze_demosaic(dt_dev_pixelpipe_iop_t *piece,
 
             if(cc1 & 1)
             { // width of tile is odd
-              if(col < roi_out->width && row < roi_out->height)
+              if(col < width && row < height)
               {
-                out[(row * roi_out->width + col) * 4]
+                out[(row * width + col) * 4]
                     = _clampnan(rgbgreen[indx] - Dgrb[0][indx >> 1], 0.0f, 1.0f);
-                out[(row * roi_out->width + col) * 4 + 2]
+                out[(row * width + col) * 4 + 2]
                     = _clampnan(rgbgreen[indx] - Dgrb[1][indx >> 1], 0.0f, 1.0f);
               }
             }
@@ -1340,8 +1336,8 @@ void amaze_demosaic(dt_dev_pixelpipe_iop_t *piece,
           {
             const int col = cc + left;
             const int indx = rr * ts + cc;
-            if(col < roi_out->width && row < roi_out->height)
-              out[(row * roi_out->width + col) * 4 + 1] = _clampnan(rgbgreen[indx], 0.0f, 1.0f);
+            if(col < width && row < height)
+              out[(row * width + col) * 4 + 1] = _clampnan(rgbgreen[indx], 0.0f, 1.0f);
           }
         }
       }


### PR DESCRIPTION
***Demosaic & mipmap maintenance***

We use these in the demosaicer and mipmap reading code:
- dt_iop_clip_and_zoom_mosaic_half_size()
- dt_iop_clip_and_zoom_mosaic_half_size_f()
- dt_iop_clip_and_zoom_mosaic_third_size_xtrans()
- dt_iop_clip_and_zoom_mosaic_third_size_xtrans_f()
- dt_iop_clip_and_zoom_demosaic_passthrough_monochrome_f()
- dt_iop_clip_and_zoom_demosaic_half_size_f()
- dt_iop_clip_and_zoom_demosaic_third_size_xtrans_f()

All functions internally used roi_out->x/y displacements but **all** callers enforced those data to be
set to zero. As using the displacement also doesn't make sense, let's get rid of them and simplify the codebase.

Use DT_DEMOSAIC_SMOOTH_OFF instead of 0

Improved logs while being here,
- with the new iop_order it should be written with 4 digits
- report some mipmap error conditions while -d pipe
- report about the used mipmap dt_iop_clip_and_zoom variant


***AMaZE demosaic maintenance***

Also make the AMaZE demosaicer unaware of roi_out size and displacements as not required.

***PPG demosaicer maintenance***

Also the PPG doesn't require roi_out size and displacements.
While being here let's use roo only where it's required.

_________________________________________________________________________
Checked all instrospection, no difference vs. master before this PR
