### PR TITLE
CLUT: add 49-patch colorchecker-type preset

### DIFF
--- a/src/iop/colorchecker.c
+++ b/src/iop/colorchecker.c
@@ -307,6 +307,172 @@ void init_presets(dt_iop_module_so_t *self)
                              self->version(), &p, sizeof(p),
                              1, DEVELOP_BLEND_CS_RGB_DISPLAY);
 
+  memset(&p, 0, sizeof(p));
+  p.num_patches = 49;
+  // red ramp in first row
+  p.target_L[0] = p.source_L[0] = 10;
+  p.target_L[1] = p.source_L[1] = 20;
+  p.target_L[2] = p.source_L[2] = 30;
+  p.target_L[3] = p.source_L[3] = 50;
+  p.target_L[4] = p.source_L[4] = 70;
+  p.target_L[5] = p.source_L[5] = 80;
+  p.target_L[6] = p.source_L[6] = 90;
+  p.target_a[0] = p.source_a[0] = 48;
+  p.target_a[1] = p.source_a[1] = 72;
+  p.target_a[2] = p.source_a[2] = 72;
+  p.target_a[3] = p.source_a[3] = 72;
+  p.target_a[4] = p.source_a[4] = 72;
+  p.target_a[5] = p.source_a[5] = 72;
+  p.target_a[6] = p.source_a[6] = 72;
+  p.target_b[0] = p.source_b[0] = 16;
+  p.target_b[1] = p.source_b[1] = 24;
+  p.target_b[2] = p.source_b[2] = 24;
+  p.target_b[3] = p.source_b[3] = 24;
+  p.target_b[4] = p.source_b[4] = 24;
+  p.target_b[5] = p.source_b[5] = 24;
+  p.target_b[6] = p.source_b[6] = 24;
+
+  // blue ramp in second row
+  p.target_L[ 7] = p.source_L[ 7] = 10;
+  p.target_L[ 8] = p.source_L[ 8] = 20;
+  p.target_L[ 9] = p.source_L[ 9] = 30;
+  p.target_L[10] = p.source_L[10] = 50;
+  p.target_L[11] = p.source_L[11] = 70;
+  p.target_L[12] = p.source_L[12] = 80;
+  p.target_L[13] = p.source_L[13] = 90;
+  p.target_a[ 7] = p.source_a[ 7] = 7;
+  p.target_a[ 8] = p.source_a[ 8] = 14;
+  p.target_a[ 9] = p.source_a[ 9] = 21;
+  p.target_a[10] = p.source_a[10] = 21;
+  p.target_a[11] = p.source_a[11] = 21;
+  p.target_a[12] = p.source_a[12] = 21;
+  p.target_a[13] = p.source_a[13] = 14;
+  p.target_b[ 7] = p.source_b[ 7] = -25;
+  p.target_b[ 8] = p.source_b[ 8] = -50;
+  p.target_b[ 9] = p.source_b[ 9] = -75;
+  p.target_b[10] = p.source_b[10] = -75;
+  p.target_b[11] = p.source_b[11] = -75;
+  p.target_b[12] = p.source_b[12] = -75;
+  p.target_b[13] = p.source_b[13] = -50;
+
+  // green ramp in third row
+  p.target_L[14] = p.source_L[14] = 10;
+  p.target_L[15] = p.source_L[15] = 20;
+  p.target_L[16] = p.source_L[16] = 30;
+  p.target_L[17] = p.source_L[17] = 50;
+  p.target_L[18] = p.source_L[18] = 70;
+  p.target_L[19] = p.source_L[19] = 80;
+  p.target_L[20] = p.source_L[20] = 90;
+  p.target_a[14] = p.source_a[14] = -20;
+  p.target_a[15] = p.source_a[15] = -40;
+  p.target_a[16] = p.source_a[16] = -40;
+  p.target_a[17] = p.source_a[17] = -40;
+  p.target_a[18] = p.source_a[18] = -40;
+  p.target_a[19] = p.source_a[19] = -40;
+  p.target_a[20] = p.source_a[20] = -40;
+  p.target_b[14] = p.source_b[14] = 16;
+  p.target_b[15] = p.source_b[15] = 32;
+  p.target_b[16] = p.source_b[16] = 32;
+  p.target_b[17] = p.source_b[17] = 32;
+  p.target_b[18] = p.source_b[18] = 32;
+  p.target_b[19] = p.source_b[19] = 32;
+  p.target_b[20] = p.source_b[20] = 32;
+
+  // orange/yellow/cyan tones in fourth row
+  p.target_L[21] = p.source_L[21] = 63;	// orange
+  p.target_a[21] = p.source_a[21] = 36;
+  p.target_b[21] = p.source_b[21] = 57;
+  p.target_L[22] = p.source_L[22] = 72; // orange yellow
+  p.target_a[22] = p.source_a[22] = 19;
+  p.target_b[22] = p.source_b[22] = 68;
+  p.target_L[23] = p.source_L[23] = 82; // yellow
+  p.target_a[23] = p.source_a[23] =  4;
+  p.target_b[23] = p.source_b[23] = 80;
+  p.target_L[24] = p.source_L[24] = 72; // yellow green
+  p.target_a[24] = p.source_a[24] = -24;
+  p.target_b[24] = p.source_b[24] = 57;
+  p.target_L[25] = p.source_L[25] = 43; // foliage
+  p.target_a[25] = p.source_a[25] = -13;
+  p.target_b[25] = p.source_b[25] = 22;
+  p.target_L[26] = p.source_L[26] = 71; // bluish green
+  p.target_a[26] = p.source_a[26] = -33;
+  p.target_b[26] = p.source_b[26] = 0;
+  p.target_L[27] = p.source_L[27] = 51; // cyan
+  p.target_a[27] = p.source_a[27] = -60;
+  p.target_b[27] = p.source_b[27] = -60;
+
+  // fifth row: CC24-like skin tone and misc patches
+  p.target_L[28] = p.source_L[28] = 39;  // CC24 dark skin
+  p.target_a[28] = p.source_a[28] = 14;
+  p.target_b[28] = p.source_b[28] = 14;
+  p.target_L[29] = p.source_L[29] = 65;  // CC24 light skin
+  p.target_a[29] = p.source_a[29] = 19;
+  p.target_b[29] = p.source_b[29] = 17;
+  p.target_L[30] = p.source_L[30] = 49;  // blue sky
+  p.target_a[30] = p.source_a[30] = -4;
+  p.target_b[30] = p.source_b[30] = -23;
+  p.target_L[31] = p.source_L[31] = 55;  // blue flower
+  p.target_a[31] = p.source_a[31] =  9;
+  p.target_b[31] = p.source_b[31] = -25;
+  p.target_L[32] = p.source_L[32] = 52;  // magenta
+  p.target_a[32] = p.source_a[32] = 75;
+  p.target_b[32] = p.source_b[32] = -21;
+  p.target_L[33] = p.source_L[33] = 31;  // purple
+  p.target_a[33] = p.source_a[33] = 50;
+  p.target_b[33] = p.source_b[33] = -50;
+  p.target_L[34] = p.source_L[34] = 41;  // purple red
+  p.target_a[34] = p.source_a[34] = 33;
+  p.target_b[34] = p.source_b[34] = -66;
+  
+  // IT8 skin tones in sixth row
+  p.target_L[35] = p.source_L[35] = 17;
+  p.target_a[35] = p.source_a[35] = 8;
+  p.target_b[35] = p.source_b[35] = 0;
+  p.target_L[36] = p.source_L[36] = 30;
+  p.target_a[36] = p.source_a[36] = 9;
+  p.target_b[36] = p.source_b[36] = 3;
+  p.target_L[37] = p.source_L[37] = 26;
+  p.target_a[37] = p.source_a[37] = 28;
+  p.target_b[37] = p.source_b[37] = 15;
+  p.target_L[38] = p.source_L[38] = 32;
+  p.target_a[38] = p.source_a[38] = 39;
+  p.target_b[38] = p.source_b[38] = 23;
+  p.target_L[39] = p.source_L[39] = 54;
+  p.target_a[39] = p.source_a[39] = 34;
+  p.target_b[39] = p.source_b[39] = 32;
+  p.target_L[40] = p.source_L[40] = 70;
+  p.target_a[40] = p.source_a[40] = 11;
+  p.target_b[40] = p.source_b[40] = 41;
+  p.target_L[41] = p.source_L[41] = 76;
+  p.target_a[41] = p.source_a[41] = 5;
+  p.target_b[41] = p.source_b[41] = 33;
+  
+  // 7-level gray ramp in last row
+  p.target_L[42] = p.source_L[42] = 2.0;
+  p.target_L[43] = p.source_L[43] = 18.0;
+  p.target_L[44] = p.source_L[44] = 34.0;
+  p.target_L[45] = p.source_L[45] = 50.0;
+  p.target_L[46] = p.source_L[46] = 66.0;
+  p.target_L[47] = p.source_L[47] = 82.0;
+  p.target_L[48] = p.source_L[48] = 98.0;
+  p.target_a[42] = p.source_a[42] = 0.0;
+  p.target_a[43] = p.source_a[43] = 0.0;
+  p.target_a[44] = p.source_a[44] = 0.0;
+  p.target_a[45] = p.source_a[45] = 0.0;
+  p.target_a[46] = p.source_a[46] = 0.0;
+  p.target_a[47] = p.source_a[47] = 0.0;
+  p.target_a[48] = p.source_a[48] = 0.0;
+  p.target_b[42] = p.source_b[42] = 0.0;
+  p.target_b[43] = p.source_b[43] = 0.0;
+  p.target_b[44] = p.source_b[44] = 0.0;
+  p.target_b[45] = p.source_b[45] = 0.0;
+  p.target_b[46] = p.source_b[46] = 0.0;
+  p.target_b[47] = p.source_b[47] = 0.0;
+  p.target_b[48] = p.source_b[48] = 0.0;
+  dt_gui_presets_add_generic(_("expanded color checker"), self->op,
+                             self->version(), &p, sizeof(p),
+                             1, DEVELOP_BLEND_CS_RGB_DISPLAY);
+
   // Helmholtz/Kohlrausch effect applied to black and white conversion.
   // implemented by wmader as an iop and matched as a clut for increased
   // flexibility. this was done using darktable-chart and this is copied


### PR DESCRIPTION
Another one that's been sitting on my hard-drive for months....

Add a preset to the Color Look Up Table module with seven-level red/green/blue/gray ramps, IT8/CC24-like skin tones, and miscellaneous color patches for more targeted color adjustments across the full spectrum.
