### PR TITLE
[GUI] Make the active state of area color mapping more visible

### DIFF
--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -601,7 +601,7 @@ static gboolean _area_mapping_active(const dt_iop_channelmixer_rgb_gui_data_t *g
 
 static const char *_area_mapping_section_text(const dt_iop_channelmixer_rgb_gui_data_t *g)
 {
-  return _area_mapping_active(g) ? _("area color mapping (active)") : _("area color mapping");
+  return _area_mapping_active(g) ? _("(active) area color mapping") : _("area color mapping");
 }
 
 static gboolean _get_white_balance_coeff(dt_iop_module_t *self,


### PR DESCRIPTION
Why do we need it?

The English original, "area color mapping (active)", is quite short, so even with very narrowed panels, this text will be visible completely. But translations into many other languages ​​give a significantly longer text, the end of which can be replaced by ellipsis points in the narrow panel. If this happens, our efforts to inform the user of the active state of the mapping will fail.

You can say that it only has to do with translations and it really is, the original is safely short. But the translators will obviously preserve the word order of the original in the translation. Therefore, I suggest writing "(active) area color mapping" in the original text so that the user is guaranteed to see whether the mapping is active.
