### PR TITLE
increase resolution of error placeholder image

### DIFF
--- a/src/common/mipmap_cache.c
+++ b/src/common/mipmap_cache.c
@@ -57,7 +57,7 @@
 // the number of pixels in the largest static image is the smallest number of pixels we
 // can allocate for the mipmap buffer, since that gets filled in after we attempt to read
 // from the image file on disk
-#define MIN_IMG_PIXELS  540
+#define MIN_IMG_PIXELS  (29*29)
 
 typedef enum dt_mipmap_buffer_dsc_flags
 {
@@ -142,29 +142,36 @@ static const int dt_mipmap_cache_exif_data_adobergb_length
     __,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__ }
 
 #define ERROR_IMAGE \
-  { __,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__, \
-    __,__,__,__,__,__,__,__,__,__,__,XX,__,__,__,__,__,__,__,__,__,__,__, \
-    __,__,__,__,__,__,__,__,__,__,XX,XX,XX,__,__,__,__,__,__,__,__,__,__, \
-    __,__,__,__,__,__,__,__,__,__,XX,__,XX,__,__,__,__,__,__,__,__,__,__, \
-    __,__,__,__,__,__,__,__,__,XX,XX,__,XX,XX,__,__,__,__,__,__,__,__,__, \
-    __,__,__,__,__,__,__,__,__,XX,XX,__,XX,XX,__,__,__,__,__,__,__,__,__, \
-    __,__,__,__,__,__,__,__,XX,XX,__,__,__,XX,XX,__,__,__,__,__,__,__,__, \
-    __,__,__,__,__,__,__,__,XX,XX,__,__,__,XX,XX,__,__,__,__,__,__,__,__, \
-    __,__,__,__,__,__,__,XX,XX,XX,__,__,__,XX,XX,XX,__,__,__,__,__,__,__, \
-    __,__,__,__,__,__,__,XX,XX,XX,__,__,__,XX,XX,XX,__,__,__,__,__,__,__, \
-    __,__,__,__,__,__,XX,XX,XX,XX,__,__,__,XX,XX,XX,XX,__,__,__,__,__,__, \
-    __,__,__,__,__,__,XX,XX,XX,XX,__,__,__,XX,XX,XX,XX,__,__,__,__,__,__, \
-    __,__,__,__,__,XX,XX,XX,XX,XX,__,__,__,XX,XX,XX,XX,XX,__,__,__,__,__, \
-    __,__,__,__,__,XX,XX,XX,XX,XX,XX,__,XX,XX,XX,XX,XX,XX,__,__,__,__,__, \
-    __,__,__,__,XX,XX,XX,XX,XX,XX,XX,__,XX,XX,XX,XX,XX,XX,XX,__,__,__,__, \
-    __,__,__,__,XX,XX,XX,XX,XX,XX,XX,__,XX,XX,XX,XX,XX,XX,XX,__,__,__,__, \
-    __,__,__,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,__,__,__, \
-    __,__,__,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,__,__,__, \
-    __,__,XX,XX,XX,XX,XX,XX,XX,XX,XX,__,XX,XX,XX,XX,XX,XX,XX,XX,XX,__,__, \
-    __,__,XX,XX,XX,XX,XX,XX,XX,XX,__,__,__,XX,XX,XX,XX,XX,XX,XX,XX,__,__, \
-    __,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,__,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,__, \
-    __,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,__, \
-    __,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__ }
+  { __,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__, \
+    __,__,__,__,__,__,__,__,__,__,__,__,__,__,XX,__,__,__,__,__,__,__,__,__,__,__,__,__,__, \
+    __,__,__,__,__,__,__,__,__,__,__,__,__,XX,XX,XX,__,__,__,__,__,__,__,__,__,__,__,__,__, \
+    __,__,__,__,__,__,__,__,__,__,__,__,__,XX,XX,XX,__,__,__,__,__,__,__,__,__,__,__,__,__, \
+    __,__,__,__,__,__,__,__,__,__,__,__,XX,XX,XX,XX,XX,__,__,__,__,__,__,__,__,__,__,__,__, \
+    __,__,__,__,__,__,__,__,__,__,__,__,XX,XX,__,XX,XX,__,__,__,__,__,__,__,__,__,__,__,__, \
+    __,__,__,__,__,__,__,__,__,__,__,XX,XX,__,__,__,XX,XX,__,__,__,__,__,__,__,__,__,__,__, \
+    __,__,__,__,__,__,__,__,__,__,__,XX,XX,__,__,__,XX,XX,__,__,__,__,__,__,__,__,__,__,__, \
+    __,__,__,__,__,__,__,__,__,__,XX,XX,XX,__,__,__,XX,XX,XX,__,__,__,__,__,__,__,__,__,__, \
+    __,__,__,__,__,__,__,__,__,__,XX,XX,XX,__,__,__,XX,XX,XX,__,__,__,__,__,__,__,__,__,__, \
+    __,__,__,__,__,__,__,__,__,XX,XX,XX,XX,__,__,__,XX,XX,XX,XX,__,__,__,__,__,__,__,__,__, \
+    __,__,__,__,__,__,__,__,__,XX,XX,XX,XX,__,__,__,XX,XX,XX,XX,__,__,__,__,__,__,__,__,__, \
+    __,__,__,__,__,__,__,__,XX,XX,XX,XX,XX,__,__,__,XX,XX,XX,XX,XX,__,__,__,__,__,__,__,__, \
+    __,__,__,__,__,__,__,__,XX,XX,XX,XX,XX,__,__,__,XX,XX,XX,XX,XX,__,__,__,__,__,__,__,__, \
+    __,__,__,__,__,__,__,XX,XX,XX,XX,XX,XX,__,__,__,XX,XX,XX,XX,XX,XX,__,__,__,__,__,__,__, \
+    __,__,__,__,__,__,__,XX,XX,XX,XX,XX,XX,__,__,__,XX,XX,XX,XX,XX,XX,__,__,__,__,__,__,__, \
+    __,__,__,__,__,__,XX,XX,XX,XX,XX,XX,XX,__,__,__,XX,XX,XX,XX,XX,XX,XX,__,__,__,__,__,__, \
+    __,__,__,__,__,__,XX,XX,XX,XX,XX,XX,XX,__,__,__,XX,XX,XX,XX,XX,XX,XX,__,__,__,__,__,__, \
+    __,__,__,__,__,XX,XX,XX,XX,XX,XX,XX,XX,XX,__,XX,XX,XX,XX,XX,XX,XX,XX,XX,__,__,__,__,__, \
+    __,__,__,__,__,XX,XX,XX,XX,XX,XX,XX,XX,XX,__,XX,XX,XX,XX,XX,XX,XX,XX,XX,__,__,__,__,__, \
+    __,__,__,__,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,__,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,__,__,__,__, \
+    __,__,__,__,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,__,__,__,__, \
+    __,__,__,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,__,__,__, \
+    __,__,__,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,__,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,__,__,__, \
+    __,__,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,__,__,__,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,__,__, \
+    __,__,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,__,__,__,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,__,__, \
+    __,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,__,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,__, \
+    __,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,__, \
+    __,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__ }
+
 
 struct dt_mipmap_buffer_dsc
 {
@@ -266,7 +273,7 @@ static inline void error_image_8(dt_mipmap_buffer_t *buf)
 {
   if(!buf->buf) return;
   struct dt_mipmap_buffer_dsc *dsc = (struct dt_mipmap_buffer_dsc *)buf->buf - 1;
-  dsc->width = dsc->height = 23;
+  dsc->width = dsc->height = 29;
   dsc->iscale = 1.0f;
   buf->color_space = dsc->color_space = DT_COLORSPACE_DISPLAY;
   assert(dsc->size >= dsc->width * dsc->height * sizeof(uint32_t));
@@ -283,7 +290,7 @@ void error_image_f(dt_mipmap_buffer_t *buf)
 {
   if(!buf->buf) return;
   struct dt_mipmap_buffer_dsc *dsc = (struct dt_mipmap_buffer_dsc *)buf->buf - 1;
-  dsc->width = dsc->height = 23;
+  dsc->width = dsc->height = 29;
   dsc->iscale = 1.0f;
   buf->color_space = dsc->color_space = DT_COLORSPACE_DISPLAY;
   assert(dsc->size >= dsc->width * dsc->height * 4 * sizeof(float));

--- a/src/imageio/imageio.c
+++ b/src/imageio/imageio.c
@@ -1067,15 +1067,17 @@ gboolean dt_imageio_export_with_flags(const dt_imgid_t imgid,
 
   if(!buf.buf || !buf.width || !buf.height)
   {
-    dt_print(DT_DEBUG_ALWAYS,
-             "[dt_imageio_export_with_flags] mipmap allocation for `%s' failed (status %d)",
-             filename,img->load_status);
     if(img->load_status == DT_IMAGEIO_FILE_NOT_FOUND)
       dt_control_log(_("image `%s' is not available!"), img->filename);
     else if(img->load_status == DT_IMAGEIO_LOAD_FAILED
             || img->load_status == DT_IMAGEIO_IOERROR
             || img->load_status == DT_IMAGEIO_CACHE_FULL)
+    {
+      dt_print(DT_DEBUG_ALWAYS,
+               "[dt_imageio_export_with_flags] mipmap allocation for `%s' failed (status %d)",
+               filename,img->load_status);
       dt_control_log(_("unable to load image `%s'!"), img->filename);
+    }
     else
       dt_control_log(_("image '%s' not supported"), img->filename);
     goto error_early;


### PR DESCRIPTION
...to make it more obvious that the triangle contains an exclamation mark.

(someone posted a description of the image as being a triangle containing a plus sign with an unrecognizable symbol above it)

Also suppress a mipmap-allocation error message when the photo is missing or explicitly unsupported.
