### PR TITLE
splashscreen: increase update freq at start of sidecar crawl

### DIFF
--- a/src/control/crawler.c
+++ b/src/control/crawler.c
@@ -141,7 +141,7 @@ GList *dt_control_crawler_run(void)
 
   int image_count = 0;
   double start_time = dt_get_wtime();
-  double last_time = start_time - 0.99; // wait 10ms before first update to ensure visibility
+  double last_time = start_time - 0.19; // wait 10ms before first update to ensure visibility
 
   while(sqlite3_step(stmt) == SQLITE_ROW)
   {
@@ -150,12 +150,13 @@ GList *dt_control_crawler_run(void)
     const int version = sqlite3_column_int(stmt, 2);
     const gchar *image_path = (char *)sqlite3_column_text(stmt, 3);
     int flags = sqlite3_column_int(stmt, 4);
+    ++image_count;
 
-    // update the progress message once per second
-    double fraction = (++image_count) / (double)total_images;
+    // update the progress message - five times per second for first four seconds, then once per second
     double curr_time = dt_get_wtime();
-    if(curr_time >= last_time + 1.0)
+    if(curr_time >= last_time + ((curr_time - start_time > 4.0) ? 1.0 : 0.2))
     {
+      double fraction = image_count / (double)total_images;
       darktable_splash_screen_set_progress_percent(_("checking for updated sidecar files (%d%%)"),
                                                    fraction,
                                                    curr_time - start_time);

--- a/src/gui/splash.c
+++ b/src/gui/splash.c
@@ -287,10 +287,10 @@ void darktable_splash_screen_set_progress_percent(const char *msg,
     gtk_label_set_text(GTK_LABEL(progress_text), text);
     g_free(text);
 
-    if(elapsed >= 2.0 && fraction > 0.02)
+    if(elapsed >= 2.0 || fraction > 0.01)
     {
       const double total = elapsed / fraction;
-      const double remain = total - elapsed;
+      const double remain = (total - elapsed) + 0.5;  // round to full seconds rather than truncating
       const int minutes = remain / 60;
       const int seconds = remain - (60 * minutes);
       char *rem_text = g_strdup_printf(" %4d:%02d", minutes, seconds);


### PR DESCRIPTION
Minimize the time during which --:-- shows instead of an estimate, and do more frequent updates during the first four seconds to help the estimate settle.
