### PR TITLE
Fix guide drawing

### DIFF
--- a/src/gui/guides.c
+++ b/src/gui/guides.c
@@ -842,7 +842,7 @@ static void _settings_autoshow_change(GtkWidget *mi, dt_iop_module_t *module)
   dt_control_queue_redraw_center();
 }
 
-void dt_guides_add_module_menuitem(void *menu, struct dt_iop_module_t *module)
+void dt_guides_add_module_menuitem(void *menu, dt_iop_module_t *module)
 {
   GtkWidget *mi = gtk_check_menu_item_new_with_label(_("show guides"));
   gchar *key = _conf_get_path(module->op, "autoshow", NULL);
@@ -864,7 +864,7 @@ void dt_guides_cleanup(GList *guides)
   g_list_free_full(guides, free_guide);
 }
 
-static void _settings_autoshow_change2(GtkWidget *combo, struct dt_iop_module_t *module)
+static void _settings_autoshow_change2(GtkWidget *combo, dt_iop_module_t *module)
 {
   if(darktable.gui->reset) return;
   gchar *key = _conf_get_path(module->op, "autoshow", NULL);
@@ -873,7 +873,7 @@ static void _settings_autoshow_change2(GtkWidget *combo, struct dt_iop_module_t 
   dt_control_queue_redraw_center();
 }
 
-static void _settings_autoshow_menu(GtkWidget *button, struct dt_iop_module_t *module)
+static void _settings_autoshow_menu(GtkWidget *button, dt_iop_module_t *module)
 {
   GtkWidget *popover = darktable.view_manager->guides_popover;
   gtk_popover_set_relative_to(GTK_POPOVER(popover), button);
@@ -885,7 +885,7 @@ static void _settings_autoshow_menu(GtkWidget *button, struct dt_iop_module_t *m
   gtk_widget_show_all(popover);
 }
 
-void dt_guides_init_module_widget(GtkWidget *iopw, struct dt_iop_module_t *module)
+void dt_guides_init_module_widget(GtkWidget *iopw, dt_iop_module_t *module)
 {
   if(!(module->flags() & IOP_FLAGS_GUIDES_WIDGET)) return;
 
@@ -915,7 +915,7 @@ void dt_guides_init_module_widget(GtkWidget *iopw, struct dt_iop_module_t *modul
   gtk_box_pack_start(GTK_BOX(iopw), box, TRUE, TRUE, 0);
 }
 
-void dt_guides_update_module_widget(struct dt_iop_module_t *module)
+void dt_guides_update_module_widget(dt_iop_module_t *module)
 {
   if(!module->guides_combo) return;
 

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -409,7 +409,8 @@ static inline gboolean _preview2_request(dt_develop_t *dev)
      && GTK_IS_WIDGET(dev->preview2.widget);
 }
 
-static void _module_gui_post_expose(dt_iop_module_t *module, cairo_t *cri,
+static void _module_gui_post_expose(dt_iop_module_t *module,
+                                    cairo_t *cri,
                                     float width, float height,
                                     float x, float y, float zoom_scale)
 {
@@ -439,13 +440,12 @@ static void _view_paint_surface(cairo_t *cr,
   dt_pthread_mutex_unlock(&p->backbuf_mutex);
 }
 
-void expose(
-    dt_view_t *self,
-    cairo_t *cri,
-    const int32_t width,
-    const int32_t height,
-    int32_t pointerx,
-    int32_t pointery)
+void expose(dt_view_t *self,
+            cairo_t *cri,
+            const int32_t width,
+            const int32_t height,
+            int32_t pointerx,
+            int32_t pointery)
 {
   cairo_set_source_rgb(cri, .2, .2, .2);
 
@@ -672,12 +672,11 @@ void expose(
 
   cairo_reset_clip(cri);
 
+  dt_iop_module_t *dmod = dev->gui_module;
+
   // display mask if we have a current module activated or if the
   // masks manager module is expanded
-  const gboolean display_masks =
-    (dev->gui_module
-      && dev->gui_module->enabled
-      && dt_dev_modulegroups_test_activated(darktable.develop))
+  const gboolean display_masks = (dmod && dmod->enabled && dt_dev_modulegroups_test_activated(darktable.develop))
     || dt_lib_gui_get_expanded(dt_lib_get_module("masks"));
 
   if(dev->form_visible && display_masks)
@@ -686,26 +685,25 @@ void expose(
         "expose masks",
          port->pipe, dev->gui_module, DT_DEVICE_NONE, NULL, NULL, "%dx%d, px=%d py=%d",
          width, height, pointerx, pointery);
-    dt_masks_events_post_expose(dev->gui_module, cri, width, height, pzx, pzy, zoom_scale);
+    dt_masks_events_post_expose(dmod, cri, width, height, pzx, pzy, zoom_scale);
   }
 
   // if dragging the rotation line, do it and nothing else
   if(dev->proxy.rotate
      && (darktable.control->button_down_which == 3
-         || dev->gui_module == dev->proxy.rotate))
+         || dmod == dev->proxy.rotate))
   {
     // reminder, we want this to be exposed always for guidings
     _module_gui_post_expose(dev->proxy.rotate, cri, wd, ht, pzx, pzy, zoom_scale);
   }
   else
   {
-    gboolean guides = FALSE;
+    gboolean guides = TRUE;
     // true if anything could be exposed
-    if(dev->gui_module && dev->gui_module != dev->proxy.rotate)
+    if(dmod && dmod != dev->proxy.rotate)
     {
       // the cropping.exposer->gui_post_expose needs special care
-      if(expose_full
-         && dev->gui_module->operation_tags_filter() & IOP_TAG_CROPPING)
+      if(expose_full && dmod->operation_tags_filter() & IOP_TAG_CROPPING)
       {
         dt_print_pipe(DT_DEBUG_EXPOSE,
                       "expose cropper",
@@ -713,7 +711,7 @@ void expose(
                       DT_DEVICE_NONE, NULL, NULL, "%dx%d, px=%d py=%d",
                       width, height, pointerx, pointery);
         _module_gui_post_expose(dev->cropping.exposer, cri, wd, ht, pzx, pzy, zoom_scale);
-        guides = TRUE;
+        guides = FALSE;
       }
 
       // gui active module
@@ -721,16 +719,18 @@ void expose(
       {
         dt_print_pipe(DT_DEBUG_EXPOSE,
                       "expose module",
-                      port->pipe, dev->gui_module,
+                      port->pipe, dmod,
                       DT_DEVICE_NONE, NULL, NULL,
                       "%dx%d, px=%d py=%d",
                       width, height, pointerx, pointery);
-        _module_gui_post_expose(dev->gui_module, cri, wd, ht, pzx, pzy, zoom_scale);
-        guides = TRUE;
+        _module_gui_post_expose(dmod, cri, wd, ht, pzx, pzy, zoom_scale);
+
+        // avoid drawing later if we just did via post_expose
+        if(dmod->flags() & IOP_FLAGS_GUIDES_SPECIAL_DRAW)
+          guides = FALSE;
       }
     }
-
-    if(!guides)
+    if(guides)
       dt_guides_draw(cri, 0.0f, 0.0f, wd, ht, zoom_scale);
   }
 
@@ -2808,7 +2808,7 @@ void leave(dt_view_t *self)
   DT_CONTROL_SIGNAL_DISCONNECT(_darkroom_ui_pipe_finish_signal_callback, self);
   DT_CONTROL_SIGNAL_DISCONNECT(_darkroom_ui_preview2_pipe_finish_signal_callback, self);
   DT_CONTROL_SIGNAL_DISCONNECT(_display_module_trouble_message_callback, self);
-  
+
   // store groups for next time:
   dt_conf_set_int("plugins/darkroom/groups", dt_dev_modulegroups_get(darktable.develop));
 


### PR DESCRIPTION
We should draw the guides if
1. The in-module checkbox is active and the module is active.
2. If the global checkbox is active and we have no active module
3. Respect special draws.

Fixes #17623