### PR TITLE
Fix GIMP API on windows

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -57,7 +57,8 @@ int main(int argc, char *argv[])
     if(!strcmp(argv[k], "--help") ||
        !strcmp(argv[k], "-h") ||
        !strcmp(argv[k], "/?") ||
-       !strcmp(argv[k], "--version"))
+       !strcmp(argv[k], "--version") ||
+       !strcmp(argv[k], "--gimp"))
     {
       redirect_output = FALSE;
       break;


### PR DESCRIPTION
The darktable API for connecting to GIMP requires output to be written to `STD_OUTPUT_HANDLE` / `STD_ERROR_HANDLE` so let's not redirect output if we find `--gimp` as an `argv`.

Hopefully fixes https://gitlab.gnome.org/GNOME/gimp/-/issues/12260#note_2270662

Can't test personally as i have absolutely no access to any windows machine, @wpferguson @zisoft i think you both could check.