### PR TITLE
prepare '<leave unchanged>' text for localization

### DIFF
--- a/src/libs/metadata.c
+++ b/src/libs/metadata.c
@@ -705,7 +705,7 @@ void gui_init(dt_lib_module_t *self)
     g_object_set_data(G_OBJECT(textview), "tv_index", GINT_TO_POINTER(i));
     g_object_set_data(G_OBJECT(textview), "tv_multiple", GINT_TO_POINTER(FALSE));
 
-    GtkWidget *unchanged = gtk_label_new("<leave unchanged>");
+    GtkWidget *unchanged = gtk_label_new(_("<leave unchanged>"));
     gtk_widget_set_name(unchanged, "dt-metadata-multi");
     gtk_text_view_add_child_in_window(GTK_TEXT_VIEW(textview), unchanged, GTK_TEXT_WINDOW_WIDGET, 0, 0);
 


### PR DESCRIPTION
The text literal `<leave unchanged>` in the metadata module is not prepared for localization. This text appears if multiple images with different metadata are selected.

![Bildschirmfoto 2024-11-10 um 19 50 22](https://github.com/user-attachments/assets/64f28a59-8387-4450-a736-09b877bda5ae)
