### PR TITLE
Safer malloc - degrade gracefully instead of terminating

### DIFF
--- a/src/common/camera_control.c
+++ b/src/common/camera_control.c
@@ -2080,11 +2080,14 @@ static void _camera_poll_events(const dt_camctl_t *c,
               const char *nameEnd = strchr(nameStart, '"');
               if (nameEnd != NULL)
               {
-                char *name = g_malloc0(nameEnd - nameStart + 1);
-                strncpy(name, nameStart, nameEnd - nameStart);
-                name[nameEnd - nameStart] = '\0';
-                _camera_configuration_single_update(c, cam, name);
-                dt_free_align(name);
+                char *name = g_try_malloc0(nameEnd - nameStart + 1);
+                if(name)
+                {
+                  strncpy(name, nameStart, nameEnd - nameStart);
+                  name[nameEnd - nameStart] = '\0';
+                  _camera_configuration_single_update(c, cam, name);
+                  g_free(name);
+                }
                 return;
               }
             }

--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -911,11 +911,14 @@ static gboolean _check_dng_opcodes(Exiv2::ExifData &exifData,
     pos = exifData.findKey(Exiv2::ExifKey("Exif.Image.OpcodeList2"));
   if(pos != exifData.end())
   {
-    uint8_t *data = (uint8_t *)g_malloc(pos->size());
-    pos->copy(data, Exiv2::invalidByteOrder);
-    dt_dng_opcode_process_opcode_list_2(data, pos->size(), img);
-    g_free(data);
-    has_opcodes = TRUE;
+    uint8_t *data = (uint8_t *)g_try_malloc(pos->size());
+    if(data)
+    {
+      pos->copy(data, Exiv2::invalidByteOrder);
+      dt_dng_opcode_process_opcode_list_2(data, pos->size(), img);
+      g_free(data);
+      has_opcodes = TRUE;
+    }
   }
 
   Exiv2::ExifData::const_iterator posb =
@@ -927,11 +930,14 @@ static gboolean _check_dng_opcodes(Exiv2::ExifData &exifData,
     posb = exifData.findKey(Exiv2::ExifKey("Exif.Image.OpcodeList3"));
   if(posb != exifData.end())
   {
-    uint8_t *data = (uint8_t *)g_malloc(posb->size());
-    posb->copy(data, Exiv2::invalidByteOrder);
-    dt_dng_opcode_process_opcode_list_3(data, posb->size(), img);
-    g_free(data);
-    has_opcodes = TRUE;
+    uint8_t *data = (uint8_t *)g_try_malloc(posb->size());
+    if(data)
+    {
+      posb->copy(data, Exiv2::invalidByteOrder);
+      dt_dng_opcode_process_opcode_list_3(data, posb->size(), img);
+      g_free(data);
+      has_opcodes = TRUE;
+    }
   }
   return has_opcodes;
 }

--- a/src/common/utility.c
+++ b/src/common/utility.c
@@ -1040,7 +1040,7 @@ char *dt_filename_change_extension(const char *filename, const char *ext)
   if(!dot) return NULL;
   const int name_lgth = dot - filename + 1;
   const int ext_lgth = strlen(ext);
-  char *output = g_malloc(name_lgth + ext_lgth + 1);
+  char *output = g_try_malloc(name_lgth + ext_lgth + 1);
   if(output)
   {
     memcpy(output, filename, name_lgth);

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -2793,7 +2793,7 @@ static void _ui_log_redraw_callback(gpointer instance,
   if(dc->log_ack != dc->log_pos)
   {
     const int32_t first_message = MAX(dc->log_ack, dc->log_pos - (DT_CTL_LOG_SIZE-1));
-    gchar *message = g_malloc(ALLMESSSIZE);
+    gchar *message = g_try_malloc(ALLMESSSIZE);
     if(message)
     {
       message[0] = 0;
@@ -2831,7 +2831,7 @@ static void _ui_toast_redraw_callback(gpointer instance,
   if(dc->toast_ack != dc->toast_pos)
   {
     const int32_t first_message = MAX(dc->toast_ack, dc->toast_pos - (DT_CTL_TOAST_SIZE-1));
-    gchar *message = g_malloc(ALLMESSSIZE);
+    gchar *message = g_try_malloc(ALLMESSSIZE);
     if(message)
     {
       message[0] = 0;

--- a/src/imageio/format/jxl.c
+++ b/src/imageio/format/jxl.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2021-2023 darktable developers.
+    Copyright (C) 2021-2024 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -289,7 +289,7 @@ int write_image(struct dt_imageio_module_data_t *data,
     if(!cmsSaveProfileToMem(out_profile, NULL, &icc_size))
       JXL_FAIL("error finding ICC data length");
     if(icc_size > 0)
-      icc_buf = g_malloc(icc_size);
+      icc_buf = g_try_malloc(icc_size);
     if(!icc_buf)
       JXL_FAIL("could not allocate ICC buffer of size %u", icc_size);
 
@@ -312,7 +312,7 @@ int write_image(struct dt_imageio_module_data_t *data,
   {
     // Prepend the 4 byte (zero) offset to the blob before writing
     // (as required in the equivalent HEIF/JPEG XS Exif box specs)
-    exif_buf = g_malloc0(exif_len + 4);
+    exif_buf = g_try_malloc0(exif_len + 4);
     if(!exif_buf)
       JXL_FAIL("could not allocate Exif buffer of size %zu", (size_t)(exif_len + 4));
     memmove(exif_buf + 4, exif, exif_len);
@@ -339,7 +339,7 @@ int write_image(struct dt_imageio_module_data_t *data,
 
   // Fix pixel stride
   const size_t pixels_size = width * height * 3 * sizeof(float);
-  pixels = g_malloc(pixels_size);
+  pixels = g_try_malloc(pixels_size);
   if(!pixels)
     JXL_FAIL("could not allocate output pixel buffer of size %zu", pixels_size);
 
@@ -366,7 +366,7 @@ int write_image(struct dt_imageio_module_data_t *data,
   // TODO: Can we better estimate what the optimal size of chunks is for this image?
   size_t chunk_size = 1 << 16;
   size_t out_len = chunk_size;
-  out_buf = g_malloc(out_len);
+  out_buf = g_try_malloc(out_len);
   if(!out_buf) JXL_FAIL("could not allocate codestream buffer of size %zu", out_len);
   uint8_t *out_cur = out_buf;
   size_t out_avail = out_len;

--- a/src/imageio/format/png.c
+++ b/src/imageio/format/png.c
@@ -90,13 +90,13 @@ static void PNGwriteRawProfile(png_struct *ping,
 
   text[0].text = png_malloc(ping, allocated_length);
   text[0].key = png_malloc(ping, 80);
-  text[0].key[0] = '\0';
   if(!text[0].text || !text[0].key)
   {
     dt_print(DT_DEBUG_ALWAYS,
              "[png] out of memory adding profile to image");
     goto cleanup;
   }
+  text[0].key[0] = '\0';
 
   g_strlcat(text[0].key, "Raw profile type ", 80);
   g_strlcat(text[0].key, profile_type, 80);

--- a/src/imageio/format/webp.c
+++ b/src/imageio/format/webp.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2013-2023 darktable developers.
+    Copyright (C) 2013-2024 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -162,7 +162,7 @@ int write_image(dt_imageio_module_data_t *webp, const char *filename, const void
   cmsSaveProfileToMem(out_profile, NULL, &len);
   if(len > 0)
   {
-    buf = (uint8_t *)g_malloc(len);
+    buf = (uint8_t *)g_try_malloc(len);
     if(buf)
     {
       cmsSaveProfileToMem(out_profile, buf, &len);

--- a/src/imageio/format/xcf.c
+++ b/src/imageio/format/xcf.c
@@ -129,7 +129,7 @@ int write_image(dt_imageio_module_data_t *data, const char *filename, const void
   if(exif && exif_len > 0)
   {
     // Prepend the libexif expected "Exif\0\0" APP1 prefix (see GIMP parasites.txt)
-    uint8_t *exif_buf = g_malloc0(exif_len + 6);
+    uint8_t *exif_buf = g_try_malloc0(exif_len + 6);
     if(!exif_buf)
     {
       dt_print(DT_DEBUG_ALWAYS, "[xcf] error: can't allocate %d bytes of memory", exif_len + 6);

--- a/src/imageio/imageio_avif.c
+++ b/src/imageio/imageio_avif.c
@@ -217,7 +217,7 @@ dt_imageio_retval_t dt_imageio_open_avif(dt_image_t *img,
   avifRWData *icc = &avif_image->icc;
   if(icc->size && icc->data)
   {
-    img->profile = (uint8_t *)g_malloc0(icc->size);
+    img->profile = g_try_malloc0(icc->size);
     if(img->profile)
     {
       memcpy(img->profile, icc->data, icc->size);
@@ -265,7 +265,7 @@ int dt_imageio_avif_read_profile(const char *filename, uint8_t **out, dt_colorsp
   avifRWData *icc = &avif_image->icc;
   if(icc->size && icc->data)
   {
-    *out = (uint8_t *)g_malloc0(icc->size);
+    *out = g_try_malloc0(icc->size);
     if(*out)
     {
       memcpy(*out, icc->data, icc->size);

--- a/src/imageio/imageio_gm.c
+++ b/src/imageio/imageio_gm.c
@@ -125,7 +125,7 @@ dt_imageio_retval_t dt_imageio_open_gm(dt_image_t *img, const char *filename, dt
   const uint8_t *profile_data = (const uint8_t *)GetImageProfile(image, "ICM", &profile_length);
   if(profile_data)
   {
-    img->profile = (uint8_t *)g_malloc0(profile_length);
+    img->profile = g_try_malloc0(profile_length);
     if(img->profile)
     {
       memcpy(img->profile, profile_data, profile_length);

--- a/src/imageio/imageio_heif.c
+++ b/src/imageio/imageio_heif.c
@@ -113,7 +113,7 @@ dt_imageio_retval_t dt_imageio_open_heif(dt_image_t *img,
       const size_t exif_size = heif_image_handle_get_metadata_size(handle, exif_id);
       if(exif_size > 4)
       {
-        uint8_t *exif_data = g_malloc0(exif_size);
+        uint8_t *exif_data = g_try_malloc0(exif_size);
         if(exif_data)
         {
           err = heif_image_handle_get_metadata(handle, exif_id, exif_data);
@@ -266,7 +266,7 @@ dt_imageio_retval_t dt_imageio_open_heif(dt_image_t *img,
   size_t icc_size = heif_image_handle_get_raw_color_profile_size(handle);
   if(icc_size)
   {
-    img->profile = (uint8_t *)g_malloc0(icc_size);
+    img->profile = g_try_malloc0(icc_size);
     if(img->profile)
     {
       err = heif_image_handle_get_raw_color_profile(handle, img->profile);

--- a/src/imageio/imageio_im.c
+++ b/src/imageio/imageio_im.c
@@ -124,7 +124,7 @@ dt_imageio_retval_t dt_imageio_open_im(dt_image_t *img, const char *filename, dt
   if(profile_data == NULL) profile_data = (uint8_t *)MagickGetImageProfile(image, "icm", &profile_length);
   if(profile_data)
   {
-    img->profile = (uint8_t *)g_malloc0(profile_length);
+    img->profile = g_try_malloc0(profile_length);
     if(img->profile)
     {
       memcpy(img->profile, profile_data, profile_length);

--- a/src/imageio/imageio_j2k.c
+++ b/src/imageio/imageio_j2k.c
@@ -225,7 +225,7 @@ dt_imageio_retval_t dt_imageio_open_j2k(dt_image_t *img,
   /* Get the ICC profile if available */
   if(image->icc_profile_len > 0 && image->icc_profile_buf)
   {
-    uint8_t *profile = (uint8_t *)g_malloc0(image->icc_profile_len);
+    uint8_t *profile = g_try_malloc0(image->icc_profile_len);
     if(profile)
     {
       img->profile = profile;

--- a/src/imageio/imageio_jpegxl.c
+++ b/src/imageio/imageio_jpegxl.c
@@ -235,7 +235,7 @@ dt_imageio_retval_t dt_imageio_open_jpegxl(dt_image_t *img,
       {
         if(icc_size)
         {
-          img->profile = (uint8_t *)g_malloc0(icc_size);
+          img->profile = g_try_malloc0(icc_size);
           if(img->profile)
           {
             JxlDecoderGetColorAsICCProfile(decoder,

--- a/src/imageio/imageio_png.c
+++ b/src/imageio/imageio_png.c
@@ -303,7 +303,7 @@ int dt_imageio_png_read_profile(const char *filename,
   if(png_get_valid(image.png_ptr, image.info_ptr, PNG_INFO_iCCP) != 0
      && png_get_iCCP(image.png_ptr, image.info_ptr, &name, NULL, &profile, &proflen) != 0)
   {
-    *out = (uint8_t *)g_malloc(proflen);
+    *out = g_try_malloc(proflen);
     if(*out)
       memcpy(*out, profile, proflen);
   }

--- a/src/imageio/imageio_tiff.c
+++ b/src/imageio/imageio_tiff.c
@@ -527,7 +527,7 @@ int dt_imageio_tiff_read_profile(const char *filename, uint8_t **out)
     cmsSaveProfileToMem(profile, 0, &profile_len);
     if(profile_len > 0)
     {
-      *out = (uint8_t *)g_malloc(profile_len);
+      *out = g_try_malloc(profile_len);
       if(*out)
         cmsSaveProfileToMem(profile, *out, &profile_len);
     }
@@ -536,7 +536,7 @@ int dt_imageio_tiff_read_profile(const char *filename, uint8_t **out)
   {
     if(profile_len > 0)
     {
-      *out = (uint8_t *)g_malloc(profile_len);
+      *out = g_try_malloc(profile_len);
       if(*out)
         memcpy(*out, profile, profile_len);
     }

--- a/src/iop/overlay.c
+++ b/src/iop/overlay.c
@@ -415,7 +415,14 @@ void process(dt_iop_module_t *self,
 
   /* create a cairo memory surface that is later used for reading
    * overlay overlay data */
-  guint8 *image = (guint8 *)g_malloc0_n(roi_out->height, stride);
+  guint8 *image = (guint8 *)g_try_malloc0_n(roi_out->height, stride);
+  if(!image)
+  {
+    dt_print(DT_DEBUG_ALWAYS, "[overlay] out of memory - could not allocate %d*%d",
+             roi_out->height, stride);
+    dt_iop_image_copy_by_size(ovoid, ivoid, roi_out->width, roi_out->height, ch);
+    return;
+  }
   cairo_surface_t *surface =
     cairo_image_surface_create_for_data(image, CAIRO_FORMAT_ARGB32,
                                         roi_out->width,

--- a/src/iop/watermark.c
+++ b/src/iop/watermark.c
@@ -640,6 +640,13 @@ void process(dt_iop_module_t *self,
 
   /* create a cairo memory surface that is later used for reading watermark overlay data */
   guint8 *image = (guint8 *)g_malloc0_n(roi_out->height, stride);
+  if(!image)
+  {
+    dt_print(DT_DEBUG_ALWAYS, "[watermark] out of memory, could not allocate %d*%d",
+             roi_out->height, stride);
+    dt_iop_image_copy_by_size(ovoid, ivoid, roi_out->width, roi_out->height, ch);
+    return;
+  }
   cairo_surface_t *surface = cairo_image_surface_create_for_data(image, CAIRO_FORMAT_ARGB32, roi_out->width,
                                                                  roi_out->height, stride);
   if((cairo_surface_status(surface) != CAIRO_STATUS_SUCCESS) || (image == NULL))
@@ -876,7 +883,17 @@ void process(dt_iop_module_t *self,
     const int watermark_height = (int)((dimension.height * scale) + 3* svg_offset_y) ;
 
     const int stride_two = cairo_format_stride_for_width(CAIRO_FORMAT_ARGB32, watermark_width);
-    image_two = (guint8 *)g_malloc0_n(watermark_height, stride_two);
+    image_two = g_try_malloc0_n(watermark_height, stride_two);
+    if(!image_two)
+    {
+      dt_print(DT_DEBUG_ALWAYS, "[watermark] out of memory, could not allocate %d*%d",
+               watermark_height, stride_two);
+      g_object_unref(svg);
+      g_free(image);
+      dt_iop_image_copy_by_size(ovoid, ivoid, roi_out->width, roi_out->height, ch);
+      dt_pthread_mutex_unlock(&darktable.plugin_threadsafe);
+      return;
+    }
     surface_two = cairo_image_surface_create_for_data(image_two, CAIRO_FORMAT_ARGB32, watermark_width,
                                                                    watermark_height, stride_two);
     if((cairo_surface_status(surface_two) != CAIRO_STATUS_SUCCESS) || (image_two == NULL))

--- a/src/libs/location.c
+++ b/src/libs/location.c
@@ -229,7 +229,7 @@ static size_t _lib_location_curl_write_data(void *buffer,
 {
   dt_lib_location_t *lib = (dt_lib_location_t *)userp;
 
-  char *newdata = g_malloc0(lib->response_size + nmemb + 1);
+  char *newdata = g_try_malloc0(lib->response_size + nmemb + 1);
   if(newdata)
   {
     if(lib->response != NULL)

--- a/src/libs/tagging.c
+++ b/src/libs/tagging.c
@@ -2385,7 +2385,7 @@ static void _pop_menu_dictionary(GtkWidget *treeview, GdkEventButton *event, dt_
 
     if(d->collection[0])
     {
-      char *collection = g_malloc(4096);
+      char *collection = g_try_malloc(4096);
       if(collection)
       {
         dt_collection_serialize(collection, 4096, FALSE);


### PR DESCRIPTION
Following up on #17776 with additional replacements of large(ish) allocations via `g_malloc` by `g_try_malloc`.
