### PR TITLE
Use actions for colorpicker & metadata. Tooltips for otherviews

### DIFF
--- a/src/libs/colorpicker.c
+++ b/src/libs/colorpicker.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2011-2023 darktable developers.
+    Copyright (C) 2011-2024 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -713,7 +713,7 @@ void gui_init(dt_lib_module_t *self)
   gtk_box_pack_start(GTK_BOX(sample_row), label, TRUE, TRUE, 0);
 
   data->add_sample_button = dtgtk_button_new(dtgtk_cairo_paint_square_plus, 0, NULL);
-  ;
+
   gtk_widget_set_sensitive(data->add_sample_button, FALSE);
   g_signal_connect(G_OBJECT(data->add_sample_button), "clicked",
                    G_CALLBACK(_add_sample), self);
@@ -734,6 +734,8 @@ void gui_init(dt_lib_module_t *self)
 
   data->display_samples_check_box =
     gtk_check_button_new_with_label(_("display samples on image/vectorscope"));
+  dt_action_define(DT_ACTION(self), NULL, N_("display samples"),
+                   data->display_samples_check_box, &dt_action_def_toggle);
   gtk_label_set_ellipsize
     (GTK_LABEL(gtk_bin_get_child(GTK_BIN(data->display_samples_check_box))),
      PANGO_ELLIPSIZE_MIDDLE);
@@ -745,6 +747,8 @@ void gui_init(dt_lib_module_t *self)
 
   GtkWidget *restrict_button =
     gtk_check_button_new_with_label(_("restrict scope to selection"));
+  dt_action_define(DT_ACTION(self), NULL, N_("restrict scope"),
+                   restrict_button, &dt_action_def_toggle);
   gtk_label_set_ellipsize
     (GTK_LABEL(gtk_bin_get_child(GTK_BIN(restrict_button))),
      PANGO_ELLIPSIZE_MIDDLE);

--- a/src/libs/image.c
+++ b/src/libs/image.c
@@ -54,7 +54,7 @@ typedef struct dt_lib_image_t
   GtkWidget *group_button, *ungroup_button, *cache_button, *uncache_button;
   GtkWidget *refresh_button, *set_monochrome_button, *set_color_button;
   GtkWidget *copy_metadata_button, *paste_metadata_button, *clear_metadata_button;
-  GtkWidget *ratings_flag, *colors_flag, *metadata_flag, *geotags_flag, *tags_flag;
+  GtkWidget *rating_flag, *colors_flag, *metadata_flag, *geotags_flag, *tags_flag;
   GtkWidget *page1; // saved here for lua extensions
   dt_imgid_t imageid;
 } dt_lib_image_t;
@@ -295,9 +295,8 @@ static void _mouse_over_image_callback(gpointer instance,
 }
 
 static void _image_preference_changed(gpointer instance,
-                                      gpointer user_data)
+                                      dt_lib_module_t *self)
 {
-  dt_lib_module_t *self = (dt_lib_module_t*)user_data;
   dt_lib_image_t *d = self->data;
   gboolean trash = dt_conf_get_bool("send_to_trash");
   gtk_label_set_text(GTK_LABEL(gtk_bin_get_child(GTK_BIN(d->delete_button))),
@@ -439,11 +438,11 @@ static void set_color_callback(GtkWidget *widget,
   dt_control_monochrome_images(0);
 }
 
-static void ratings_flag_callback(GtkWidget *widget,
-                                  dt_lib_module_t *self)
+static void rating_flag_callback(GtkWidget *widget,
+                                 dt_lib_module_t *self)
 {
   dt_lib_image_t *d = self->data;
-  const gboolean flag = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(d->ratings_flag));
+  const gboolean flag = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(d->rating_flag));
   dt_conf_set_bool("plugins/lighttable/copy_metadata/rating", flag);
 }
 
@@ -599,63 +598,34 @@ void gui_init(dt_lib_module_t *self)
   grid = GTK_GRID(gtk_grid_new());
   gtk_container_add(GTK_CONTAINER(page2), GTK_WIDGET(grid));
   gtk_grid_set_column_homogeneous(grid, TRUE);
-  line = 0;
-
-  GtkWidget *flag = gtk_check_button_new_with_label(_("ratings"));
-  d->ratings_flag = flag;
-  gtk_widget_set_tooltip_text(flag, _("select ratings metadata"));
-  ellipsize_button(flag);
-  gtk_grid_attach(grid, flag, 0, line, 3, 1);
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(flag),
-                               dt_conf_get_bool("plugins/lighttable/copy_metadata/rating"));
-  g_signal_connect(G_OBJECT(flag), "clicked", G_CALLBACK(ratings_flag_callback), self);
-
-  flag = gtk_check_button_new_with_label(_("colors"));
-  d->colors_flag = flag;
-  gtk_widget_set_tooltip_text(flag, _("select colors metadata"));
-  ellipsize_button(flag);
-  gtk_grid_attach(grid, flag, 3, line++, 3, 1);
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(flag),
-                               dt_conf_get_bool("plugins/lighttable/copy_metadata/colors"));
-  g_signal_connect(G_OBJECT(flag), "clicked", G_CALLBACK(colors_flag_callback), self);
-
-  flag = gtk_check_button_new_with_label(_("tags"));
-  d->tags_flag = flag;
-  gtk_widget_set_tooltip_text(flag, _("select tags metadata"));
-  ellipsize_button(flag);
-  gtk_grid_attach(grid, flag, 0, line, 3, 1);
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(flag),
-                               dt_conf_get_bool("plugins/lighttable/copy_metadata/tags"));
-  g_signal_connect(G_OBJECT(flag), "clicked", G_CALLBACK(tags_flag_callback), self);
-
-  flag = gtk_check_button_new_with_label(_("geo tags"));
-  d->geotags_flag = flag;
-  gtk_widget_set_tooltip_text(flag, _("select geo tags metadata"));
-  ellipsize_button(flag);
-  gtk_grid_attach(grid, flag, 3, line++, 3, 1);
-  gtk_toggle_button_set_active
-    (GTK_TOGGLE_BUTTON(flag),
-     dt_conf_get_bool("plugins/lighttable/copy_metadata/geotags"));
-  g_signal_connect(G_OBJECT(flag), "clicked", G_CALLBACK(geotags_flag_callback), self);
-
-  flag = gtk_check_button_new_with_label(_("metadata"));
-  d->metadata_flag = flag;
-  gtk_widget_set_tooltip_text(flag,
-                              _("select darktable metadata (from metadata editor module)"));
-  ellipsize_button(flag);
-  gtk_grid_attach(grid, flag, 0, line++, 3, 1);
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(flag),
-                               dt_conf_get_bool("plugins/lighttable/copy_metadata/metadata"));
-  g_signal_connect(G_OBJECT(flag), "clicked",
-                   G_CALLBACK(metadata_flag_callback), self);
 
   dt_lib_module_t *meta = (dt_lib_module_t *)dt_action_section(DT_ACTION(self),
                                                                N_("metadata"));
+  line = -1;
+#define META_FLAG_BUTTON(label, item, left, tooltip) {            \
+  GtkWidget *flag = gtk_check_button_new_with_label(_(label));    \
+  d->item##_flag = flag;                                          \
+  gtk_widget_set_tooltip_text(flag, tooltip);                     \
+  ellipsize_button(flag);                                         \
+  gtk_grid_attach(grid, flag, left, !left ? ++line : line, 3, 1); \
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(flag),           \
+    dt_conf_get_bool("plugins/lighttable/copy_metadata/" #item)); \
+  dt_action_define(DT_ACTION(meta), N_("flags"),                  \
+                   label, flag, &dt_action_def_toggle);           \
+  g_signal_connect(G_OBJECT(flag), "clicked",                     \
+                   G_CALLBACK(item##_flag_callback), self); }
+
+  META_FLAG_BUTTON(N_("ratings"),  rating,   0, _("select ratings metadata"));
+  META_FLAG_BUTTON(N_("colors"),   colors,   3, _("select colors metadata"));
+  META_FLAG_BUTTON(N_("tags"),     tags,     0, _("select tags metadata"));
+  META_FLAG_BUTTON(N_("geo tags"), geotags,  3, _("select geo tags metadata"));
+  META_FLAG_BUTTON(N_("metadata"), metadata, 0, _("select darktable metadata (from metadata editor module)"));
+
   d->copy_metadata_button = dt_action_button_new
     (meta, N_("copy"),
      copy_metadata_callback, self,
      _("set the selected image as source of metadata"), 0, 0);
-  gtk_grid_attach(grid, d->copy_metadata_button, 0, line, 2, 1);
+  gtk_grid_attach(grid, d->copy_metadata_button, 0, ++line, 2, 1);
   g_signal_connect(G_OBJECT(d->copy_metadata_button), "clicked",
                    G_CALLBACK(copy_metadata_callback), self);
 
@@ -671,7 +641,7 @@ void gui_init(dt_lib_module_t *self)
 
   GtkWidget *pastemode = NULL;
   DT_BAUHAUS_COMBOBOX_NEW_FULL
-    (pastemode, self, NULL, N_("mode"),
+    (pastemode, meta, NULL, N_("mode"),
      _("how to handle existing metadata"),
      dt_conf_get_int("plugins/lighttable/copy_metadata/pastemode"),
      pastemode_combobox_changed, self,
@@ -679,18 +649,18 @@ void gui_init(dt_lib_module_t *self)
   gtk_grid_attach(grid, pastemode, 0, line++, 6, 1);
 
   d->refresh_button = dt_action_button_new
-    (self, N_("refresh EXIF"), button_clicked, GINT_TO_POINTER(14),
+    (meta, N_("refresh EXIF"), button_clicked, GINT_TO_POINTER(14),
      _("update all image information to match changes to file\n"
        "warning: resets star ratings unless you select\n"
-       "'ignore EXIF rating' in the 'import' module\n"), 0, 0);
+       "'ignore EXIF rating' in the 'import' module"), 0, 0);
   gtk_grid_attach(grid, d->refresh_button, 0, line++, 6, 1);
 
   d->set_monochrome_button = dt_action_button_new
-    (self, N_("monochrome"), set_monochrome_callback, self,
+    (meta, N_("monochrome"), set_monochrome_callback, self,
      _("set selection as monochrome images and activate monochrome workflow"), 0, 0);
   gtk_grid_attach(grid, d->set_monochrome_button, 0, line, 3, 1);
 
-  d->set_color_button = dt_action_button_new(self, N_("color"), set_color_callback, self,
+  d->set_color_button = dt_action_button_new(meta, N_("color"), set_color_callback, self,
                                              _("set selection as color images"), 0, 0);
   gtk_grid_attach(grid, d->set_color_button, 3, line++, 3, 1);
 
@@ -883,7 +853,7 @@ static int lua_set_action_sensitive(lua_State *L)
   return 0;
 }
 
-void init(struct dt_lib_module_t *self)
+void init(dt_lib_module_t *self)
 {
 
   lua_State *L = darktable.lua_state.state;

--- a/src/libs/styles.c
+++ b/src/libs/styles.c
@@ -135,7 +135,7 @@ gboolean _styles_tooltip_callback(GtkWidget* self,
                                   gint y,
                                   gboolean keyboard_mode,
                                   GtkTooltip* tooltip,
-                                  gpointer user_data)
+                                  dt_lib_styles_t *d)
 {
   GtkTreeModel* model;
   GtkTreePath* path;
@@ -222,11 +222,9 @@ static void _gui_styles_update_view(dt_lib_styles_t *d)
 static void _styles_row_activated_callback(GtkTreeView *view,
                                            GtkTreePath *path,
                                            GtkTreeViewColumn *col,
-                                           gpointer user_data)
+                                           dt_lib_styles_t *d)
 {
   // This works on double click, so it's for single style
-  dt_lib_styles_t *d = (dt_lib_styles_t *)user_data;
-
   GtkTreeModel *model;
   GtkTreeIter iter;
   model = gtk_tree_view_get_model(d->tree);
@@ -268,9 +266,8 @@ GList* _get_selected_style_names(GList* selected_styles, GtkTreeModel *model)
   return g_list_reverse(style_names); // list was built in reverse order, so un-reverse it
 }
 
-static void _apply_clicked(GtkWidget *w, gpointer user_data)
+static void _apply_clicked(GtkWidget *w, dt_lib_styles_t *d)
 {
-  dt_lib_styles_t *d = (dt_lib_styles_t *)user_data;
   GtkTreeSelection *selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(d->tree));
 
   if(gtk_tree_selection_count_selected_rows(selection) == 0) return;
@@ -292,19 +289,16 @@ static void _apply_clicked(GtkWidget *w, gpointer user_data)
     g_list_free_full(style_names, g_free);
 }
 
-static void _create_clicked(GtkWidget *w, gpointer user_data)
+static void _create_clicked(GtkWidget *w, dt_lib_styles_t *d)
 {
-  dt_lib_styles_t *d = (dt_lib_styles_t *)user_data;
-
   GList *list = dt_act_on_get_images(TRUE, TRUE, FALSE);
   dt_styles_create_from_list(list);
   g_list_free(list);
   _gui_styles_update_view(d);
 }
 
-static void _edit_clicked(GtkWidget *w, gpointer user_data)
+static void _edit_clicked(GtkWidget *w, dt_lib_styles_t *d)
 {
-  dt_lib_styles_t *d = (dt_lib_styles_t *)user_data;
   GtkTreeSelection *selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(d->tree));
 
   if(gtk_tree_selection_count_selected_rows(selection) == 0) return;
@@ -379,10 +373,8 @@ gboolean _ask_before_delete_style(const gint style_cnt)
       style_cnt);
 }
 
-static void _delete_clicked(GtkWidget *w, gpointer user_data)
+static void _delete_clicked(GtkWidget *w, dt_lib_styles_t *d)
 {
-  dt_lib_styles_t *d = (dt_lib_styles_t *)user_data;
-
   GtkTreeSelection *selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(d->tree));
 
   if(gtk_tree_selection_count_selected_rows(selection) == 0) return;
@@ -418,10 +410,8 @@ static void _delete_clicked(GtkWidget *w, gpointer user_data)
   g_list_free_full(style_names, g_free);
 }
 
-static void _export_clicked(GtkWidget *w, gpointer user_data)
+static void _export_clicked(GtkWidget *w, dt_lib_styles_t *d)
 {
-  dt_lib_styles_t *d = (dt_lib_styles_t *)user_data;
-
   GtkTreeSelection *selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(d->tree));
 
   if(gtk_tree_selection_count_selected_rows(selection) == 0) return;
@@ -572,7 +562,7 @@ static void _export_clicked(GtkWidget *w, gpointer user_data)
   g_list_free_full(style_names, g_free);
 }
 
-static void _import_clicked(GtkWidget *w, gpointer user_data)
+static void _import_clicked(GtkWidget *w, dt_lib_styles_t *d)
 {
   /* variables for overwrite dialog */
   gint overwrite_check_button = 0;
@@ -722,22 +712,20 @@ static void _import_clicked(GtkWidget *w, gpointer user_data)
     }
     g_slist_free_full(filenames, g_free);
 
-    dt_lib_styles_t *d = (dt_lib_styles_t *)user_data;
     _gui_styles_update_view(d);
     dt_conf_set_folder_from_file_chooser("ui_last/import_path", GTK_FILE_CHOOSER(filechooser));
   }
   g_object_unref(filechooser);
 }
 
-static gboolean _entry_callback(GtkEntry *entry, gpointer user_data)
+static gboolean _entry_callback(GtkEntry *entry, dt_lib_styles_t *d)
 {
-  _gui_styles_update_view(user_data);
+  _gui_styles_update_view(d);
   return FALSE;
 }
 
-static gboolean _entry_activated(GtkEntry *entry, gpointer user_data)
+static gboolean _entry_activated(GtkEntry *entry, dt_lib_styles_t *d)
 {
-  dt_lib_styles_t *d = (dt_lib_styles_t *)user_data;
   const gchar *name = gtk_entry_get_text(d->entry);
   if(name)
   {
@@ -753,9 +741,8 @@ static gboolean _entry_activated(GtkEntry *entry, gpointer user_data)
   return FALSE;
 }
 
-static gboolean _duplicate_callback(GtkEntry *entry, gpointer user_data)
+static gboolean _duplicate_callback(GtkEntry *entry, dt_lib_styles_t *d)
 {
-  dt_lib_styles_t *d = (dt_lib_styles_t *)user_data;
   dt_conf_set_bool("ui_last/styles_create_duplicate",
                    gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(d->duplicate)));
   return FALSE;
@@ -771,19 +758,19 @@ void gui_update(dt_lib_module_t *self)
 {
   dt_lib_styles_t *d = self->data;
 
-  const gboolean has_act_on = (dt_act_on_get_images_nb(TRUE, FALSE) > 0);
+  const gboolean has_act_on = dt_act_on_get_images_nb(TRUE, FALSE) > 0;
 
   GtkTreeSelection *selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(d->tree));
-  const gint sel_styles_cnt = gtk_tree_selection_count_selected_rows(selection);
+  const gboolean any_style = gtk_tree_selection_count_selected_rows(selection) > 0;
 
   gtk_widget_set_sensitive(GTK_WIDGET(d->create_button), has_act_on);
-  gtk_widget_set_sensitive(GTK_WIDGET(d->edit_button), sel_styles_cnt > 0);
-  gtk_widget_set_sensitive(GTK_WIDGET(d->delete_button), sel_styles_cnt > 0);
+  gtk_widget_set_sensitive(GTK_WIDGET(d->edit_button), any_style);
+  gtk_widget_set_sensitive(GTK_WIDGET(d->delete_button), any_style);
 
   //import is ALWAYS enabled.
-  gtk_widget_set_sensitive(GTK_WIDGET(d->export_button), sel_styles_cnt > 0);
+  gtk_widget_set_sensitive(GTK_WIDGET(d->export_button), any_style);
 
-  gtk_widget_set_sensitive(GTK_WIDGET(d->apply_button), has_act_on && sel_styles_cnt > 0);
+  gtk_widget_set_sensitive(GTK_WIDGET(d->apply_button), has_act_on && any_style);
 }
 
 static void _styles_changed_callback(gpointer instance, dt_lib_module_t *self)
@@ -864,6 +851,8 @@ void gui_init(dt_lib_module_t *self)
                      FALSE, FALSE, 0);
 
   d->duplicate = gtk_check_button_new_with_label(_("create duplicate"));
+  dt_action_define(DT_ACTION(self), NULL, N_("create duplicate"),
+                   d->duplicate, &dt_action_def_toggle);
   gtk_label_set_ellipsize(GTK_LABEL(gtk_bin_get_child(GTK_BIN(d->duplicate))), PANGO_ELLIPSIZE_START);
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(d->duplicate), TRUE, FALSE, 0);
   g_signal_connect(d->duplicate, "toggled", G_CALLBACK(_duplicate_callback), d);


### PR DESCRIPTION
***Add shortcut tooltip for active other view***

For completeness, if we switch to other-view like printer we should also offer the according tooltip.

***Use dt_action_define() for colorpickers and metadata***

Let's make use of the dt_action infrastructure for colorpickers and metadata buttons.

Some maintenance for lib/styles.c