### PR TITLE
Darktable 5.0 vs GIMP 3.0RC interface

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1288,11 +1288,6 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
                 darktable.gimp.error = FALSE;
             }
           }
-
-          if(!darktable.gimp.error)
-          {
-            dbfilename_from_command = ":memory:";
-          }
         }
       }
       else if(!strcmp(argv[k], "--"))

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -416,7 +416,7 @@ dt_imgid_t dt_load_from_string(const gchar *input,
                                const gboolean open_image_in_dr,
                                gboolean *single_image)
 {
-  dt_imgid_t id = NO_IMGID;
+  dt_imgid_t imgid = NO_IMGID;
   if(input == NULL || input[0] == '\0') return NO_IMGID;
 
   char *filename = dt_util_normalize_path(input);
@@ -448,20 +448,20 @@ dt_imgid_t dt_load_from_string(const gchar *input,
     gchar *directory = g_path_get_dirname((const gchar *)filename);
     dt_film_t film;
     const dt_filmid_t filmid = dt_film_new(&film, directory);
-    id = dt_image_import(filmid, filename, TRUE, TRUE);
+    imgid = dt_image_import(filmid, filename, TRUE, TRUE);
     g_free(directory);
-    if(dt_is_valid_imgid(id))
+    if(dt_is_valid_imgid(imgid))
     {
       dt_film_open(filmid);
       // make sure buffers are loaded (load full for testing)
       dt_mipmap_buffer_t buf;
-      dt_mipmap_cache_get(darktable.mipmap_cache, &buf, id,
+      dt_mipmap_cache_get(darktable.mipmap_cache, &buf, imgid,
                           DT_MIPMAP_FULL, DT_MIPMAP_BLOCKING, 'r');
-      gboolean loaded = (buf.buf != NULL);
+      const gboolean loaded = (buf.buf != NULL);
       dt_mipmap_cache_release(darktable.mipmap_cache, &buf);
       if(!loaded)
       {
-        id = NO_IMGID;
+        imgid = NO_IMGID;
         if(buf.loader_status == DT_IMAGEIO_UNSUPPORTED_FORMAT || buf.loader_status == DT_IMAGEIO_UNSUPPORTED_FEATURE)
           dt_control_log(_("file `%s' has unsupported format!"), filename);
         else
@@ -471,7 +471,7 @@ dt_imgid_t dt_load_from_string(const gchar *input,
       {
         if(open_image_in_dr)
         {
-          dt_control_set_mouse_over_id(id);
+          dt_control_set_mouse_over_id(imgid);
           dt_ctl_switch_mode_to("darkroom");
         }
       }
@@ -483,7 +483,7 @@ dt_imgid_t dt_load_from_string(const gchar *input,
     if(single_image) *single_image = TRUE;
   }
   g_free(filename);
-  return id;
+  return imgid;
 }
 
 static void dt_codepaths_init()
@@ -1860,7 +1860,7 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
 #ifndef USE_LUA      // may cause UI hang since after LUA init
       darktable_splash_screen_set_progress(_("importing image"));
 #endif
-      (void)dt_load_from_string(argv[1], TRUE, NULL);
+      dt_load_from_string(argv[1], TRUE, NULL);
     }
     else if(argc >= 2)
     {

--- a/src/common/dbus.c
+++ b/src/common/dbus.c
@@ -90,8 +90,8 @@ static void _handle_method_call(GDBusConnection *connection,
   {
     const gchar *filename;
     g_variant_get(parameters, "(&s)", &filename);
-    int32_t id = dt_load_from_string(filename, TRUE, NULL);
-    g_dbus_method_invocation_return_value(invocation, g_variant_new("(i)", id));
+    const dt_imgid_t imgid = dt_load_from_string(filename, TRUE, NULL);
+    g_dbus_method_invocation_return_value(invocation, g_variant_new("(i)", imgid));
   }
 #ifdef USE_LUA
   else if(!g_strcmp0(method_name, "Lua"))

--- a/src/common/gimp.c
+++ b/src/common/gimp.c
@@ -21,7 +21,7 @@
 #include "control/control.h"
 #include <glib.h>
 
-gboolean dt_export_gimp_file(const dt_imgid_t id)
+gboolean dt_export_gimp_file(const dt_imgid_t imgid)
 {
   const gboolean thumb = dt_check_gimpmode("thumb");
   char *tmp_directory = g_dir_make_tmp("darktable_XXXXXX", NULL);
@@ -41,7 +41,7 @@ gboolean dt_export_gimp_file(const dt_imgid_t id)
   // any longer ...
   g_strlcpy((char *)sdata, path, DT_MAX_PATH_FOR_PARAMS);
 
-  dt_imageio_module_format_t *format = dt_imageio_get_format_by_name(thumb ? "jpeg" : "xcf");
+  dt_imageio_module_format_t *format = dt_imageio_get_format_by_name(thumb ? "jpeg" : "exr");
   if(format == NULL) return FALSE;
 
   dt_imageio_module_data_t *fdata = format->get_params(format);
@@ -55,18 +55,18 @@ gboolean dt_export_gimp_file(const dt_imgid_t id)
   fdata->style[0] = '\0';
   fdata->style_append = FALSE;
 
-  storage->store(storage, sdata, id, format, fdata, 1, 1,
+  storage->store(storage, sdata, imgid, format, fdata, 1, 1,
                   thumb ? FALSE : TRUE, // high_quality,
                   FALSE, // never upscale
                   thumb ? FALSE : TRUE, // export_masks
-                  DT_COLORSPACE_SRGB, // for xcf it's irrelevant, for jpeg we want it
+                  thumb ? DT_COLORSPACE_SRGB : DT_COLORSPACE_LIN_REC709,
                   NULL,  // icc_filename
-                  DT_INTENT_PERCEPTUAL, // for xcf it's irrelevant, for jpeg we want it
+                  DT_INTENT_PERCEPTUAL,
                   NULL);  // &metadata
-  fprintf(stdout, "<<<gimp\n%s%s\n", path, thumb ? ".jpg" : ".xcf");
+  fprintf(stdout, "<<<gimp\n%s%s\n", path, thumb ? ".jpg" : ".exr");
   if(thumb)
   {
-    dt_image_t *image = dt_image_cache_get(darktable.image_cache, id, 'r');
+    dt_image_t *image = dt_image_cache_get(darktable.image_cache, imgid, 'r');
     fprintf(stdout, "%i %i\n", image->width, image->height);
     dt_image_cache_read_release(darktable.image_cache, image);
   }
@@ -76,34 +76,16 @@ gboolean dt_export_gimp_file(const dt_imgid_t id)
 
 dt_imgid_t dt_gimp_load_image(const char *file)
 {
-  char *filename = dt_util_normalize_path(file);
-  if(filename == NULL)
-    return NO_IMGID;
-
-  gchar *directory = g_path_get_dirname((const gchar *)filename);
-  dt_film_t film;
-  const dt_filmid_t filmid = dt_film_new(&film, directory);
-  g_free(directory);
-  if(!dt_is_valid_filmid(filmid))
-  {
-    g_free(filename);
-    return NO_IMGID;
-  }
-
-  const dt_imgid_t id = dt_image_import(filmid, filename, TRUE, TRUE);
-  g_free(filename);
-
-  darktable.gimp.imgid = id;
-  return id;
+  gboolean single;
+  darktable.gimp.imgid = dt_load_from_string(file, FALSE, &single);
+  darktable.gimp.error = !single;
+  return darktable.gimp.imgid;
 }
 
 dt_imgid_t dt_gimp_load_darkroom(const char *file)
 {
-  const dt_imgid_t id = dt_gimp_load_image(file);
-  if(dt_is_valid_imgid(id))
-  {
-    dt_control_set_mouse_over_id(id);
-    dt_ctl_switch_mode_to("darkroom");
-  }
-  return id;
+  gboolean single;
+  darktable.gimp.imgid = dt_load_from_string(file, TRUE, &single);
+  darktable.gimp.error = !single;
+  return darktable.gimp.imgid;
 }

--- a/src/common/gimp.h
+++ b/src/common/gimp.h
@@ -52,6 +52,7 @@ thumb <path> <dim> Write a thumbnail jpg file to a temporary location.
 
 #define DT_GIMP_VERSION 1
 
+// returns TRUE in case of success
 gboolean dt_export_gimp_file(const dt_imgid_t id);
 
 dt_imgid_t dt_gimp_load_darkroom(const char *file);

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -339,7 +339,6 @@ void dt_image_film_roll(const dt_image_t *img,
 dt_imageio_write_xmp_t dt_image_get_xmp_mode()
 {
   dt_imageio_write_xmp_t res = DT_WRITE_XMP_NEVER;
-  if(darktable.gimp.mode) return res;
 
   const char *config = dt_conf_get_string_const("write_sidecar_files");
   if(config)

--- a/src/main.c
+++ b/src/main.c
@@ -114,7 +114,8 @@ int main(int argc, char *argv[])
 
   if(dt_check_gimpmode("version")
     || (dt_check_gimpmode("file") && !dt_check_gimpmode_ok("file"))
-    || (dt_check_gimpmode("thumb") && !dt_check_gimpmode_ok("thumb")))
+    || (dt_check_gimpmode("thumb") && !dt_check_gimpmode_ok("thumb"))
+    || darktable.gimp.error)
   {
     fprintf(stdout, "\n<<<gimp\nerror\ngimp>>>\n");
     exit(1);
@@ -131,22 +132,13 @@ int main(int argc, char *argv[])
   {
     const dt_imgid_t id = dt_gimp_load_image(darktable.gimp.path);
     if(dt_is_valid_imgid(id))
-    {
-      if(!dt_export_gimp_file(id))
-        darktable.gimp.error = TRUE;
-    }
+      darktable.gimp.error = !dt_export_gimp_file(id);
     else
       darktable.gimp.error = TRUE;
   }
 
   if(!darktable.gimp.mode || dt_check_gimpmode_ok("file"))
     dt_gui_gtk_run(darktable.gui);
-
-  if(dt_check_gimpmode_ok("file"))
-  {
-    if(!dt_export_gimp_file(darktable.gimp.imgid))
-      darktable.gimp.error = TRUE;
-  }
 
   dt_cleanup();
 

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -241,7 +241,6 @@ gboolean dt_view_manager_switch_by_view(dt_view_manager_t *vm,
   if(old_view
       && new_view
       && dt_check_gimpmode("file")
-      && !darktable.gimp.error
       && dt_view_get_current() == DT_VIEW_DARKROOM)
     return FALSE;
 


### PR DESCRIPTION
After GIMP 3.0RC landed in fedora 41 a number of issues became obvious.

1. Darkroom history is not saved when quitting darktable via ctrl-q or the close button so GIMP does not get what we edited.
2. Using the memory database is not a good idea for the gimp mode as it would be far more expected by the user that existing edits on a raw file would be used.
3. Exporting the file to be used by GIMP was very slow due to the bad shape of `xcf` support (no use of OpenMP right now) so we use `exr` instead.

While being here and analysing (1) some code maintenance.

Note: could not test the GIMP->darktable interface on windows/osx