### PR TITLE
Support running other apps from AppImage using symlinks

### DIFF
--- a/packaging/AppImage/AppRun
+++ b/packaging/AppImage/AppRun
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# The purpose of this custom AppRun script is to allow symlinking the AppImage
+# and invoking the corresponding binary depending on which symlink was used
+# to invoke the AppImage
+
+HERE="$(dirname "$(readlink -f "${0}")")"
+
+source "$HERE"/apprun-hooks/"linuxdeploy-plugin-gtk.sh"
+
+if [ ! -z $APPIMAGE ] ; then
+  BINARY_NAME=$(basename "$ARGV0")
+  if [ -e "$HERE/usr/bin/$BINARY_NAME" ] ; then
+    exec "$HERE/usr/bin/$BINARY_NAME" "$@"
+  else
+    exec "$HERE/usr/bin/darktable" "$@"
+  fi
+else
+  exec "$HERE/usr/bin/darktable" "$@"
+fi

--- a/tools/appimage-build-script.sh
+++ b/tools/appimage-build-script.sh
@@ -21,6 +21,7 @@ mkdir {build,AppDir}
 
 # For AppImage we have to install app in /usr subfolder of the AppDir
 export DESTDIR=../AppDir
+
 # The CLI parameters of this script will be passed verbatim to build.sh.
 # This allows you to conveniently manage the enabling/disabling of various features.
 # For example, you can easily build darktable with support for ImageMagick instead of GraphicsMagick
@@ -62,4 +63,5 @@ fi
   --deploy-deps-only ../AppDir/usr/lib/x86_64-linux-gnu/darktable/plugins/imageio/storage \
   --deploy-deps-only ../AppDir/usr/lib/x86_64-linux-gnu/darktable/plugins/lighttable \
   --deploy-deps-only ../AppDir/usr/lib/x86_64-linux-gnu/darktable/views \
+  --custom-apprun ../packaging/AppImage/AppRun \
   --output appimage


### PR DESCRIPTION
This PR allows the launch of other apps from AppImage (such as darktable-cli, for example) by calling through a symlink to the AppImage file with the corresponding name.
