### PR TITLE
fix early-exit crash in dt_control_quit and dt_control_shutdown

### DIFF
--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -416,6 +416,7 @@ typedef struct darktable_t
   int32_t unmuted_signal_dbg_acts;
   gboolean unmuted_signal_dbg[DT_SIGNAL_COUNT];
   gboolean pipe_cache;
+  int gui_running;		// atomic, access with g_atomic_int_*()
   GTimeZone *utc_tz;
   GDateTime *origin_gdt;
   struct dt_sys_resources_t dtresources;

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -1509,7 +1509,12 @@ void dt_gui_gtk_run(dt_gui_gtk_t *gui)
   dt_osx_focus_window();
 #endif
   /* start the event loop */
-  gtk_main();
+  if(darktable.control->running)
+  {
+    g_atomic_int_set(&darktable.gui_running, 1);
+    gtk_main();
+    g_atomic_int_set(&darktable.gui_running, 0);
+  }
 
   if(darktable.gui->surface)
   {

--- a/src/lua/init.c
+++ b/src/lua/init.c
@@ -1,6 +1,6 @@
 /*
    This file is part of darktable,
-   Copyright (C) 2013-2021 darktable developers.
+   Copyright (C) 2013-2024 darktable developers.
 
    darktable is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -46,6 +46,8 @@
 #include "lua/util.h"
 #include "lua/view.h"
 #include "lua/widget/widget.h"
+
+static int _lua_fully_initialized = false;
 
 static int dt_lua_init_init(lua_State*L)
 {
@@ -129,6 +131,7 @@ static int run_early_script(lua_State* L)
     dt_lua_check_print_error(L,luaL_dostring(L,lua_command));
   }
   dt_lua_redraw_screen();
+  g_atomic_int_set(&_lua_fully_initialized,true);
   return 0;
 }
 
@@ -241,13 +244,20 @@ int luaopen_darktable(lua_State *L)
   lua_pop(L, 1);
   return 1;
 }
+
 void dt_lua_finalize_early()
 {
   darktable.lua_state.ending = true;
-  dt_lua_lock();
-  dt_lua_event_trigger(darktable.lua_state.state,"exit",0);
-  dt_lua_unlock();
-  g_main_context_wakeup(darktable.lua_state.context);
+  gboolean running = (darktable.lua_state.loop
+                      && g_atomic_int_get(&_lua_fully_initialized)
+                      && g_main_loop_is_running(darktable.lua_state.loop));
+  if(running)
+  {
+    dt_lua_lock();
+    dt_lua_event_trigger(darktable.lua_state.state,"exit",0);
+    dt_lua_unlock();
+    g_main_context_wakeup(darktable.lua_state.context);
+  }
 }
 
 void dt_lua_finalize()

--- a/src/lua/lua.h
+++ b/src/lua/lua.h
@@ -1,6 +1,6 @@
 /*
    This file is part of darktable,
-   Copyright (C) 2013-2020 darktable developers.
+   Copyright (C) 2013-2024 darktable developers.
 
    darktable is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -69,7 +69,7 @@ typedef struct
 
   dt_pthread_mutex_t mutex;          // mutex protecting the lua condition variable
   pthread_cond_t cond;               // condition variable to wait for the lua lock
-  bool exec_lock;                    // true if some lua code is running. this is logically a mutex
+  volatile bool exec_lock;           // true if some lua code is running. this is logically a mutex
 
   bool ending;                       // true if we are in the process of terminating DT
 


### PR DESCRIPTION
Add synchronization variables to avoid an early user-requested exit causing a crash from trying to cleanup threads etc. which haven't actually been initialized yet.  Also avoid calling gtk_main() if we've already started shutdown by the time that point is reached, as that would cause a hang with no window displayed.

Fixes a Lua deadlock on early exit.

Should fix #17840, but I can't verify because I was never able to reproduce.
