### PR TITLE
[maintenance] Compile GM/IM loader sources only when enabled

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -146,8 +146,6 @@ FILE(GLOB SOURCE_FILES
   "gui/splash.c"
   "gui/styles_dialog.c"
   "imageio/imageio.c"
-  "imageio/imageio_gm.c"
-  "imageio/imageio_im.c"
   "imageio/imageio_jpeg.c"
   "imageio/imageio_module.c"
   "imageio/imageio_pfm.c"
@@ -561,6 +559,7 @@ if(USE_GRAPHICSMAGICK)
     set(DT_SUPPORTED_EXTENSIONS ${DT_SUPPORTED_EXTENSIONS} bmp dcm fit fits fts gif jng jp2 jpc jpf jpx miff mng pam webp jxl CACHE INTERNAL "")
     include_directories(SYSTEM ${GraphicsMagick_INCLUDE_DIRS})
     list(APPEND LIBS ${GraphicsMagick_LIBRARIES})
+    list(APPEND SOURCES "imageio/imageio_gm.c")
   endif(GraphicsMagick_FOUND)
 endif(USE_GRAPHICSMAGICK)
 
@@ -569,6 +568,7 @@ if(USE_IMAGEMAGICK AND NOT GraphicsMagick_FOUND)
   find_package(PkgConfig)
   pkg_check_modules(ImageMagick MagickWand)
   if(ImageMagick_FOUND)
+    list(APPEND SOURCES "imageio/imageio_im.c")
     if(ImageMagick_VERSION VERSION_GREATER 7)
       add_definitions(-DHAVE_IMAGEMAGICK7)
       set(DT_SUPPORTED_EXTENSIONS ${DT_SUPPORTED_EXTENSIONS} qoi CACHE INTERNAL "")

--- a/src/imageio/imageio_gm.c
+++ b/src/imageio/imageio_gm.c
@@ -16,7 +16,6 @@
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifdef HAVE_GRAPHICSMAGICK
 #include "imageio_gm.h"
 #include "common/colorspaces.h"
 #include "common/darktable.h"
@@ -188,7 +187,6 @@ error:
 
   return err;
 }
-#endif
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/imageio/imageio_im.c
+++ b/src/imageio/imageio_im.c
@@ -16,7 +16,6 @@
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifdef HAVE_IMAGEMAGICK
 #include "common/darktable.h"
 #include "imageio_common.h"
 #include "imageio_gm.h"
@@ -152,7 +151,6 @@ error:
   DestroyMagickWand(image);
   return err;
 }
-#endif
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py


### PR DESCRIPTION
We used to enable compilation of source files for optional features by conditionally adding their source files to the list managed by cmake. The GM/IM loaders have somehow become an exception, they are included in the list of source files that are always compiled, instead in the source files themselves we wrap the code in #ifdef to check that the build configuration allows them to be compiled.

This is pure maintenance and a very minor point, changes solely for uniformity of approach.
