### PR TITLE
Simplify the mask hash calculation

### DIFF
--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -2174,14 +2174,7 @@ void dt_iop_commit_params(dt_iop_module_t *module,
       dt_masks_form_t *grp = dt_masks_get_from_id(darktable.develop, blendop_params->mask_id);
       if(grp)
       {
-        const size_t mlen = dt_masks_group_get_hash_buffer_length(grp);
-        char *str = malloc(mlen);
-        if(str)
-        {
-          dt_masks_group_get_hash_buffer(grp, str);
-          phash = dt_hash(phash, str, mlen);
-          free(str);
-        }
+        phash = dt_masks_group_hash(phash, grp);
       }
 
       if(blendop_params->mask_mode & DEVELOP_MASK_RASTER && new_raster)

--- a/src/develop/masks.h
+++ b/src/develop/masks.h
@@ -622,9 +622,7 @@ void dt_masks_iop_combo_populate(GtkWidget *w,
                                  struct dt_iop_module_t **m);
 void dt_masks_iop_use_same_as(struct dt_iop_module_t *module,
                               struct dt_iop_module_t *src);
-int dt_masks_group_get_hash_buffer_length(dt_masks_form_t *form);
-char *dt_masks_group_get_hash_buffer(dt_masks_form_t *form,
-                                     char *str);
+dt_hash_t dt_masks_group_hash(dt_hash_t hash, dt_masks_form_t *form);
 
 void dt_masks_form_remove(struct dt_iop_module_t *module,
                           dt_masks_form_t *grp,


### PR DESCRIPTION
1. Use dt_hash() directly instead of calculation after copying avoiding malloc/free
2. Use dt_mask_id_t instead of int