### PR TITLE
Start processing shortcuts after showing main window

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1814,15 +1814,6 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
     // init the gui part of views
     dt_view_manager_gui_init(darktable.view_manager);
 
-    // Save the default shortcuts
-    dt_shortcuts_save(".defaults", FALSE);
-
-    // Then load any shortcuts if available (wipe defaults first if requested)
-    dt_shortcuts_load(NULL, !dt_conf_get_bool("accel/load_defaults"));
-
-    // Save the shortcuts including defaults
-    dt_shortcuts_save(NULL, TRUE);
-
     // now that other initialization is complete, we can show the main window
     // we need to do this before Lua is started or we'll either get a hang, or
     // the module groups don't get set up correctly
@@ -1844,9 +1835,20 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
 
   if(init_gui)
   {
-    // we have to call dt_ctl_switch_mode_to() here already to not run
-    // into a lua deadlock.  having another call later is ok
     dt_ctl_switch_mode_to("lighttable");
+
+    // Save the default shortcuts
+    dt_shortcuts_save(".defaults", FALSE);
+
+    // Then load any shortcuts if available (wipe defaults first if requested)
+    dt_shortcuts_load(NULL, !dt_conf_get_bool("accel/load_defaults"));
+
+    // Save the shortcuts including defaults
+    dt_shortcuts_save(NULL, TRUE);
+
+    // connect the shortcut dispatcher
+    g_signal_connect(dt_ui_main_window(darktable.gui->ui), "event",
+                     G_CALLBACK(dt_shortcut_dispatcher), NULL);
 
 #ifndef MAC_INTEGRATION
     // load image(s) specified on cmdline.  this has to happen after

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -3611,11 +3611,7 @@ static gboolean _shortcut_closest_match(GSequenceIter **current,
 static gboolean _shortcut_match(dt_shortcut_t *f,
                                 gchar **fb_log)
 {
-  if(!darktable.view_manager->current_view)
-    return FALSE;
-
-  f->views =
-    darktable.view_manager->current_view->view(darktable.view_manager->current_view);
+  f->views = dt_view_get_current();
   gpointer v = GINT_TO_POINTER(f->views);
 
   GSequenceIter *existing =
@@ -3974,7 +3970,7 @@ float dt_action_process(const gchar *action,
   }
 
   const dt_view_type_flags_t vws = _find_views(ac);
-  if(!(vws & darktable.view_manager->current_view->view(darktable.view_manager->current_view)))
+  if(!(vws & dt_view_get_current()))
   {
     if(DT_PERFORM_ACTION(move_size))
       dt_print(DT_DEBUG_ALWAYS,
@@ -4207,7 +4203,7 @@ void dt_shortcut_key_press(const dt_input_device_t id,
   }
   else if(g_slist_find_custom(_hold_keys, &this_key, _cmp_key))
   {} // ignore repeating hold key
-  else if(darktable.view_manager && darktable.view_manager->current_view)
+  else
   {
     if(id) _sc.mods = _key_modifiers_clean(dt_key_modifier_state());
 
@@ -4215,7 +4211,7 @@ void dt_shortcut_key_press(const dt_input_device_t id,
       = { .key_device = id,
           .key = key,
           .mods = _sc.mods,
-          .views = darktable.view_manager->current_view->view(darktable.view_manager->current_view) };
+          .views = dt_view_get_current() };
 
     dt_shortcut_t *s = NULL;
     GSequenceIter *existing
@@ -4350,7 +4346,7 @@ static void _delay_for_double_triple(guint time, guint is_key)
     _sc.press += DT_SHORTCUT_DOUBLE & is_key;
     _sc.click += DT_SHORTCUT_DOUBLE & ~is_key;
 
-    _sc.views = darktable.view_manager->current_view->view(darktable.view_manager->current_view);
+    _sc.views = dt_view_get_current();
     GSequenceIter *multi =
       g_sequence_search(darktable.control->shortcuts, &_sc, _shortcut_compare_func,
                         GINT_TO_POINTER(_sc.views));

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -1382,8 +1382,6 @@ int dt_gui_gtk_init(dt_gui_gtk_t *gui)
   widget = dt_ui_main_window(darktable.gui->ui);
   g_signal_connect(G_OBJECT(widget), "configure-event",
                    G_CALLBACK(_window_configure), NULL);
-  g_signal_connect(G_OBJECT(widget), "event",
-                   G_CALLBACK(dt_shortcut_dispatcher), NULL);
   g_signal_override_class_handler("query-tooltip", gtk_widget_get_type(),
                                   G_CALLBACK(dt_shortcut_tooltip_callback));
 


### PR DESCRIPTION
This way is more correct and avoids a later check.

Also make use of dt_view_get_current() for readability where appropriate.