### PR TITLE
Tone Equalizer curve fixes

### DIFF
--- a/src/common/fast_guided_filter.h
+++ b/src/common/fast_guided_filter.h
@@ -199,7 +199,7 @@ static inline void variance_analyse(const float *const restrict guide, // I
     ab[2*idx+1] = b;
   }
 
-  if(input != NULL) dt_free_align(input);
+  dt_free_align(input);
 }
 
 


### PR DESCRIPTION
**Tone equalizer fixes**

- Fix a check in get_luminance_from_buffer()
- pseudo_solve() problems are tracked while committing the parameters.
  This means we always have valid reports even if parameters didn't change and
  we re-open the image in darkroom.
- some refactoring
- some correct use of gboolean instead of int
- Use gboolean for 'checks' when calling pseudo_solve()


Fixes #17866

