### PR TITLE
Safer malloc in `dt_copy_file` - logging an error instead of terminating

### DIFF
--- a/src/common/utility.c
+++ b/src/common/utility.c
@@ -931,7 +931,8 @@ void dt_copy_file(const char *const sourcefile, const char *dst)
     fseek(fin, 0, SEEK_END);
     const size_t end = ftell(fin);
     rewind(fin);
-    content = (char *)g_malloc_n(end, sizeof(char));
+
+    content = (char *)g_try_malloc_n(end, sizeof(char));
     if(content == NULL) goto END;
     if(fread(content, sizeof(char), end, fin) != end) goto END;
     if(fwrite(content, sizeof(char), end, fout) != end) goto END;

--- a/src/common/utility.c
+++ b/src/common/utility.c
@@ -920,22 +920,22 @@ char *dt_read_file(const char *const filename, size_t *filesize)
   return NULL;
 }
 
-void dt_copy_file(const char *const sourcefile, const char *dst)
+void dt_copy_file(const char *const sourcefile, const char *destination)
 {
   char *content = NULL;
   FILE *fin = g_fopen(sourcefile, "rb");
-  FILE *fout = g_fopen(dst, "wb");
+  FILE *fout = g_fopen(destination, "wb");
 
   if(fin && fout)
   {
     fseek(fin, 0, SEEK_END);
-    const size_t end = ftell(fin);
+    const size_t filesize = ftell(fin);
     rewind(fin);
 
-    content = (char *)g_try_malloc_n(end, sizeof(char));
+    content = (char *)g_try_malloc_n(filesize, sizeof(char));
     if(content == NULL) goto END;
-    if(fread(content, sizeof(char), end, fin) != end) goto END;
-    if(fwrite(content, sizeof(char), end, fout) != end) goto END;
+    if(fread(content, sizeof(char), filesize, fin) != filesize) goto END;
+    if(fwrite(content, sizeof(char), filesize, fout) != filesize) goto END;
   }
 
 END:

--- a/src/common/utility.c
+++ b/src/common/utility.c
@@ -934,11 +934,26 @@ void dt_copy_file(const char *const sourcefile, const char *destination)
 
     content = (char *)g_try_malloc_n(filesize, sizeof(char));
     if(content == NULL)
+    {
+      dt_print(DT_DEBUG_ALWAYS,
+               "[dt_copy_file] failure to allocate memory for copying file '%s'",
+               sourcefile);
       goto END;
+    }
     if(fread(content, sizeof(char), filesize, fin) != filesize)
+    {
+      dt_print(DT_DEBUG_ALWAYS,
+               "[dt_copy_file] error reading file '%s' for copying",
+               sourcefile);
       goto END;
+    }
     if(fwrite(content, sizeof(char), filesize, fout) != filesize)
+    {
+      dt_print(DT_DEBUG_ALWAYS,
+               "[dt_copy_file] error writing file '%s' during copying",
+               destination);
       goto END;
+    }
   }
 
 END:

--- a/src/common/utility.c
+++ b/src/common/utility.c
@@ -933,14 +933,19 @@ void dt_copy_file(const char *const sourcefile, const char *destination)
     rewind(fin);
 
     content = (char *)g_try_malloc_n(filesize, sizeof(char));
-    if(content == NULL) goto END;
-    if(fread(content, sizeof(char), filesize, fin) != filesize) goto END;
-    if(fwrite(content, sizeof(char), filesize, fout) != filesize) goto END;
+    if(content == NULL)
+      goto END;
+    if(fread(content, sizeof(char), filesize, fin) != filesize)
+      goto END;
+    if(fwrite(content, sizeof(char), filesize, fout) != filesize)
+      goto END;
   }
 
 END:
-  if(fout != NULL) fclose(fout);
-  if(fin != NULL) fclose(fin);
+  if(fout != NULL)
+    fclose(fout);
+  if(fin != NULL)
+    fclose(fin);
 
   g_free(content);
 }


### PR DESCRIPTION
While being here, log entries were also added about other causes of failed copying.