### PR TITLE
Minor GIMP protocol fix

### DIFF
--- a/src/common/gimp.c
+++ b/src/common/gimp.c
@@ -63,14 +63,14 @@ gboolean dt_export_gimp_file(const dt_imgid_t imgid)
                   NULL,  // icc_filename
                   DT_INTENT_PERCEPTUAL,
                   NULL);  // &metadata
-  fprintf(stdout, "<<<gimp\n%s%s\n", path, thumb ? ".jpg" : ".exr");
+  printf("<<<gimp\n%s%s\n", path, thumb ? ".jpg" : ".exr");
   if(thumb)
   {
     dt_image_t *image = dt_image_cache_get(darktable.image_cache, imgid, 'r');
-    fprintf(stdout, "%i %i\n", image->width, image->height);
+    printf("%i %i\n", image->width, image->height);
     dt_image_cache_read_release(darktable.image_cache, image);
   }
-  fprintf(stdout, "gimp>>>\n");
+  printf("gimp>>>\n");
   return TRUE;
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -104,11 +104,16 @@ int main(int argc, char *argv[])
   g_setenv("GTK_CSD", "0", TRUE);
 #endif
 
-  if(dt_init(argc, argv, TRUE, TRUE, NULL)) exit(1);
+  if(dt_init(argc, argv, TRUE, TRUE, NULL))
+  {
+    if(darktable.gimp.mode)
+      printf("\n<<<gimp\nerror\ngimp>>>\n");
+    exit(1);
+  }
 
   if(dt_check_gimpmode_ok("version"))
   {
-    fprintf(stdout, "\n<<<gimp\n%d\ngimp>>>\n", DT_GIMP_VERSION);
+    printf("\n<<<gimp\n%d\ngimp>>>\n", DT_GIMP_VERSION);
     exit(0);
   }
 
@@ -117,7 +122,7 @@ int main(int argc, char *argv[])
     || (dt_check_gimpmode("thumb") && !dt_check_gimpmode_ok("thumb"))
     || darktable.gimp.error)
   {
-    fprintf(stdout, "\n<<<gimp\nerror\ngimp>>>\n");
+    printf("\n<<<gimp\nerror\ngimp>>>\n");
     exit(1);
   }
 
@@ -143,7 +148,7 @@ int main(int argc, char *argv[])
   dt_cleanup();
 
   if(darktable.gimp.mode && darktable.gimp.error)
-    fprintf(stdout, "\n<<<gimp\nerror\ngimp>>>\n");
+    printf("\n<<<gimp\nerror\ngimp>>>\n");
 
 #ifdef _WIN32
   if(redirect_output)


### PR DESCRIPTION
If dt_int() fails and there is some gimp operation pending we should also report a gimp protocol error.

While being here use printf() instead of fprintf(stdout, "") for protol messages for simplicity.