### PR TITLE
lua/database.c - expose dublicate_image_with_history function to the API

### DIFF
--- a/src/lua/database.c
+++ b/src/lua/database.c
@@ -296,6 +296,9 @@ int dt_lua_init_database(lua_State *L)
   lua_pushcfunction(L, dt_lua_duplicate_image);
   lua_pushcclosure(L, dt_lua_type_member_common, 1);
   dt_lua_type_register_const_type(L, type_id, "duplicate");
+  lua_pushcfunction(L, dt_lua_duplicate_image_with_history);
+  lua_pushcclosure(L, dt_lua_type_member_common, 1);
+  dt_lua_type_register_const_type(L, type_id, "duplicate_with_history");
   lua_pushcfunction(L, dt_lua_delete_image);
   lua_pushcclosure(L, dt_lua_type_member_common, 1);
   dt_lua_type_register_const_type(L, type_id, "delete");


### PR DESCRIPTION
lua/database.c - expose dublicate_image_with_history function to the API with name duplicate_with_history which matches the other entry point, for database dt_lua_image_t,  in lua/image.c

Fixes #17919.

This doesn't create any functionality, it just exposes it to the API.  If you don't want to merge for 5.0, I'll just remove it from the docs.  It's still accessible through `dt_lua_image_t:duplicate_with_history() `.

Here's a test script that has both methods (darktable.database and dt_lua_image_t) with one commented out.  Assign a keystroke to the shortcut, then hover over an image and hit the shortcut.

[duplicate_image_with_history.zip](https://github.com/user-attachments/files/17970069/duplicate_image_with_history.zip)
