### PR TITLE
Fix skipped module handling

### DIFF
--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -3217,7 +3217,7 @@ GtkWidget *dt_iop_gui_get_pluginui(dt_iop_module_t *module)
   return dtgtk_expander_get_frame(DTGTK_EXPANDER(module->expander));
 }
 
-gboolean dt_iop_breakpoint(struct dt_develop_t *dev, struct dt_dev_pixelpipe_t *pipe)
+gboolean dt_iop_breakpoint(dt_develop_t *dev, dt_dev_pixelpipe_t *pipe)
 {
   if(pipe != dev->preview_pipe
      && pipe != dev->preview2.pipe)
@@ -3839,7 +3839,7 @@ gboolean dt_iop_have_required_input_format(const int req_ch,
   }
 }
 
-gboolean dt_iop_canvas_not_sensitive(const struct dt_develop_t *dev)
+gboolean dt_iop_canvas_not_sensitive(const dt_develop_t *dev)
 {
   return dt_iop_color_picker_is_visible(dev)
          || darktable.lib->proxy.snapshots.enabled;
@@ -3857,12 +3857,13 @@ void dt_iop_gui_changed(dt_action_t *action, GtkWidget *widget, gpointer data)
   dt_dev_add_history_item_target(darktable.develop, module, TRUE, widget);
 }
 
-gboolean dt_iop_module_is_skipped(const struct dt_develop_t *dev,
+gboolean dt_iop_module_is_skipped(const dt_develop_t *dev,
                                   const dt_iop_module_t *module)
 {
   return dev->gui_module
       && dev->gui_module != module
-      && (dev->gui_module->operation_tags_filter() & module->operation_tags());
+      && (dev->gui_module->operation_tags_filter() & module->operation_tags())
+      && (dev->gui_module->iop_order < module->iop_order);
 }
 
 enum

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -703,7 +703,9 @@ void expose(dt_view_t *self,
     if(dmod && dmod != dev->proxy.rotate)
     {
       // the cropping.exposer->gui_post_expose needs special care
-      if(expose_full && dmod->operation_tags_filter() & IOP_TAG_CROPPING)
+      if(expose_full
+        && (dmod->operation_tags_filter() & IOP_TAG_CROPPING)
+        && (dmod->iop_order < dev->cropping.exposer->iop_order))
       {
         dt_print_pipe(DT_DEBUG_EXPOSE,
                       "expose cropper",


### PR DESCRIPTION
1. `dt_iop_module_is_skipped()` checks a given module vs the focused module and returns a flag if it should be skipped in the processing pipe depending on `operation_tags_filter()` and `operation_tags()`.
We should also take into account if the module tested for being skipped is later in the pipe.

3. Also test for iop_order in the post_expose action in darkroom.

Fixes #17403 




