### PR TITLE
Various code cleanups

### DIFF
--- a/src/common/gpx.c
+++ b/src/common/gpx.c
@@ -140,7 +140,7 @@ void _track_pts_free(dt_gpx_track_point_t *trkpt)
   g_free(trkpt);
 }
 
-void dt_gpx_destroy(struct dt_gpx_t *gpx)
+void dt_gpx_destroy(dt_gpx_t *gpx)
 {
   g_assert(gpx != NULL);
 
@@ -150,7 +150,7 @@ void dt_gpx_destroy(struct dt_gpx_t *gpx)
   g_free(gpx);
 }
 
-gboolean dt_gpx_get_location(struct dt_gpx_t *gpx, GDateTime *timestamp, dt_image_geoloc_t *geoloc)
+gboolean dt_gpx_get_location(dt_gpx_t *gpx, GDateTime *timestamp, dt_image_geoloc_t *geoloc)
 {
   g_assert(gpx != NULL);
 
@@ -464,7 +464,7 @@ GList *dt_gpx_get_trkseg(struct dt_gpx_t *gpx)
                       : NULL;
 }
 
-GList *dt_gpx_get_trkpts(struct dt_gpx_t *gpx, const guint segid)
+GList *dt_gpx_get_trkpts(dt_gpx_t *gpx, const guint segid)
 {
   if(gpx == NULL)
     return NULL;

--- a/src/common/import_session.c
+++ b/src/common/import_session.c
@@ -78,7 +78,7 @@ static gboolean _import_session_initialize_filmroll(dt_import_session_t *self, c
     return TRUE;
   }
   /* open one or initialize a filmroll for the session */
-  self->film = (dt_film_t *)g_malloc0(sizeof(dt_film_t));
+  self->film = g_malloc0(sizeof(dt_film_t));
   const dt_filmid_t film_id = dt_film_new(self->film, path);
   if(!dt_is_valid_filmid(film_id))
   {
@@ -151,11 +151,9 @@ static char *_import_session_filename_pattern()
 }
 
 
-struct dt_import_session_t *dt_import_session_new()
+dt_import_session_t *dt_import_session_new()
 {
-  dt_import_session_t *is;
-
-  is = (dt_import_session_t *)g_malloc0(sizeof(dt_import_session_t));
+  dt_import_session_t *is = g_malloc0(sizeof(dt_import_session_t));
 
   dt_variables_params_init(&is->vp);
 
@@ -165,7 +163,7 @@ struct dt_import_session_t *dt_import_session_new()
 }
 
 
-void dt_import_session_destroy(struct dt_import_session_t *self)
+void dt_import_session_destroy(dt_import_session_t *self)
 {
   if(--self->ref != 0) return;
 
@@ -177,17 +175,17 @@ void dt_import_session_destroy(struct dt_import_session_t *self)
   g_free(self);
 }
 
-void dt_import_session_ref(struct dt_import_session_t *self)
+void dt_import_session_ref(dt_import_session_t *self)
 {
   self->ref++;
 }
 
-void dt_import_session_unref(struct dt_import_session_t *self)
+void dt_import_session_unref(dt_import_session_t *self)
 {
   self->ref--;
 }
 
-void dt_import_session_import(struct dt_import_session_t *self)
+void dt_import_session_import(dt_import_session_t *self)
 {
   const dt_imgid_t imgid = dt_image_import(self->film->id, self->current_filename, TRUE, TRUE);
   if(dt_is_valid_imgid(imgid))
@@ -198,7 +196,7 @@ void dt_import_session_import(struct dt_import_session_t *self)
 }
 
 
-void dt_import_session_set_name(struct dt_import_session_t *self, const char *name)
+void dt_import_session_set_name(dt_import_session_t *self, const char *name)
 {
   /* free previous jobcode name */
   g_free((void *)self->vp->jobcode);
@@ -207,33 +205,33 @@ void dt_import_session_set_name(struct dt_import_session_t *self, const char *na
 }
 
 
-void dt_import_session_set_time(struct dt_import_session_t *self, const char *time)
+void dt_import_session_set_time(dt_import_session_t *self, const char *time)
 {
   dt_variables_set_time(self->vp, time);
 }
 
 
-void dt_import_session_set_exif_basic_info(struct dt_import_session_t *self, const dt_image_basic_exif_t *basic_exif)
+void dt_import_session_set_exif_basic_info(dt_import_session_t *self, const dt_image_basic_exif_t *basic_exif)
 {
   dt_variables_set_exif_basic_info(self->vp, basic_exif);
 }
 
 
-void dt_import_session_set_filename(struct dt_import_session_t *self, const char *filename)
+void dt_import_session_set_filename(dt_import_session_t *self, const char *filename)
 {
   self->vp->filename = filename;
 }
 
 
-int32_t dt_import_session_film_id(struct dt_import_session_t *self)
+dt_filmid_t dt_import_session_film_id(const dt_import_session_t *self)
 {
   if(self->film) return self->film->id;
 
-  return -1;
+  return NO_FILMID;
 }
 
 
-const char *dt_import_session_name(struct dt_import_session_t *self)
+const char *dt_import_session_name(const dt_import_session_t *self)
 {
   return self->vp->jobcode;
 }
@@ -244,18 +242,16 @@ const char *dt_import_session_name(struct dt_import_session_t *self)
  *
  * The returned string should be freed with g_free() when no longer needed.
  */
-static char *_import_session_filename_from_pattern(struct dt_import_session_t *self, gchar *pattern)
+static char *_import_session_filename_from_pattern(dt_import_session_t *self, gchar *pattern)
 {
-  gchar *result_fname = NULL;
-
-  result_fname = dt_variables_expand(self->vp, pattern, TRUE);
+  gchar *result_fname = dt_variables_expand(self->vp, pattern, TRUE);
   return g_strchomp(result_fname);
 }
 
 /* This returns a unique filename using session path **and** the filename.
    If use_filename is true we will use the original filename otherwise use the pattern.
 */
-const char *dt_import_session_filename(struct dt_import_session_t *self, gboolean use_filename)
+const char *dt_import_session_filename(dt_import_session_t *self, const gboolean use_filename)
 {
   gchar *result_fname = NULL;
 
@@ -316,7 +312,7 @@ const char *dt_import_session_filename(struct dt_import_session_t *self, gboolea
   return self->current_filename;
 }
 
-static const char *_import_session_path(struct dt_import_session_t *self, gboolean use_current_path)
+static const char *_import_session_path(dt_import_session_t *self, const gboolean use_current_path)
 {
   const gboolean currentok = dt_util_test_writable_dir(self->current_path);
 
@@ -384,7 +380,7 @@ static const char *_import_session_path(struct dt_import_session_t *self, gboole
   return self->current_path;
 }
 
-const char *dt_import_session_path(struct dt_import_session_t *self, gboolean use_current_path)
+const char *dt_import_session_path(dt_import_session_t *self, const gboolean use_current_path)
 {
   const char *path = _import_session_path(self, use_current_path);
   if(path == NULL)

--- a/src/common/import_session.h
+++ b/src/common/import_session.h
@@ -47,10 +47,10 @@ void dt_import_session_set_exif_basic_info(struct dt_import_session_t *self, con
 void dt_import_session_set_filename(struct dt_import_session_t *self, const char *filename);
 
 /** \brief current film id for the import session */
-int32_t dt_import_session_film_id(struct dt_import_session_t *self);
+dt_filmid_t dt_import_session_film_id(const struct dt_import_session_t *self);
 
 /** \brief get import session name */
-const char *dt_import_session_name(struct dt_import_session_t *self);
+const char *dt_import_session_name(const struct dt_import_session_t *self);
 /** \brief get import session filename.
     \param[in] current If TRUE the current filename will be returned without evaluating a new filename.
  */

--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -2740,7 +2740,7 @@ static int _control_import_image_copy(const char *filename,
 
     const dt_imgid_t imgid = dt_image_import(dt_import_session_film_id(session),
                                              output, FALSE, FALSE);
-    if(!imgid) dt_control_log(_("error loading file `%s'"), output);
+    if(!dt_is_valid_imgid(imgid)) dt_control_log(_("error loading file `%s'"), output);
     else
     {
       GError *error = NULL;

--- a/src/imageio/format/copy.c
+++ b/src/imageio/format/copy.c
@@ -32,7 +32,7 @@ DT_MODULE(1)
 // FIXME: we can't rely on darktable to avoid file overwriting -- it doesn't know the filename (extension).
 int write_image(dt_imageio_module_data_t *data, const char *filename, const void *in,
                 dt_colorspaces_color_profile_type_t over_type, const char *over_filename,
-                void *exif, int exif_len, dt_imgid_t imgid, int num, int total, struct dt_dev_pixelpipe_t *pipe,
+                void *exif, int exif_len, dt_imgid_t imgid, int num, int total, dt_dev_pixelpipe_t *pipe,
                 const gboolean export_masks)
 {
   int status = 1;

--- a/src/imageio/format/webp.c
+++ b/src/imageio/format/webp.c
@@ -117,7 +117,7 @@ void cleanup(dt_imageio_module_format_t *self)
 
 int write_image(dt_imageio_module_data_t *webp, const char *filename, const void *in_tmp,
                 dt_colorspaces_color_profile_type_t over_type, const char *over_filename,
-                void *exif, int exif_len, dt_imgid_t imgid, int num, int total, struct dt_dev_pixelpipe_t *pipe,
+                void *exif, int exif_len, dt_imgid_t imgid, int num, int total, dt_dev_pixelpipe_t *pipe,
                 const gboolean export_masks)
 {
   int res = 1;

--- a/src/libs/tools/module_toolbox.c
+++ b/src/libs/tools/module_toolbox.c
@@ -89,13 +89,13 @@ void gui_cleanup(dt_lib_module_t *self)
   self->data = NULL;
 }
 
-void view_enter(struct dt_lib_module_t *self,struct dt_view_t *old_view,struct dt_view_t *new_view)
+void view_enter(dt_lib_module_t *self, dt_view_t *old_view, dt_view_t *new_view)
 {
   dt_lib_module_toolbox_t *d = self->data;
   dt_view_type_flags_t nv= new_view->view(new_view);
   for(const GList *child_elt = d->child_views; child_elt; child_elt = g_list_next(child_elt))
   {
-    child_data_t* child_data = (child_data_t*)child_elt->data;
+    child_data_t* child_data = child_elt->data;
     if(child_data->views & nv)
     {
       gtk_widget_show_all(child_data->child);

--- a/src/libs/tools/view_toolbox.c
+++ b/src/libs/tools/view_toolbox.c
@@ -88,13 +88,13 @@ void gui_cleanup(dt_lib_module_t *self)
   self->data = NULL;
 }
 
-void view_enter(struct dt_lib_module_t *self,struct dt_view_t *old_view,struct dt_view_t *new_view)
+void view_enter(dt_lib_module_t *self, dt_view_t *old_view, dt_view_t *new_view)
 {
   dt_lib_view_toolbox_t *d = self->data;
   dt_view_type_flags_t nv= new_view->view(new_view);
   for(const GList *child_elt = d->child_views; child_elt; child_elt = g_list_next(child_elt))
   {
-    child_data_t* child_data = (child_data_t*)child_elt->data;
+    child_data_t* child_data = child_elt->data;
     if(child_data->views & nv)
     {
       gtk_widget_show_all(child_data->child);


### PR DESCRIPTION
Use proper test for dt_is_valid_imgid() in control_import Use proper dt_filmid_t as result in dt_import_session_film_id() and return NO_FILMID in error case

Some: constify, struct parameter avoiding, remove overcasting, code simplifications