### PR TITLE
Add clear warning for OpenCL tune headroom

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -378,7 +378,7 @@
     <type>bool</type>
     <default>false</default>
     <shortdescription>use all GPU memory</shortdescription>
-    <longdescription>if enabled darktable will use all graphics device memory except a safety margin (headroom, default is 600MB)</longdescription>
+    <longdescription>if enabled darktable will use all graphics device memory except a safety margin (headroom, default is 600MB)\nnot recommended and use with great care as it can crash your system easily!</longdescription>
   </dtconfig>
   <dtconfig prefs="processing" section="platform" capability="nonapple" restart="true">
     <name>clplatform_intelropenclhdgraphics</name>


### PR DESCRIPTION
The tune for headroom setting has become even more dangerous on late systems as the OS - wayland for example - likes to take much more than before.

For now we should at least put a bigger warning to the tooltip for this preference setting.