### PR TITLE
Avoid variable expansion for GIMP export

### DIFF
--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -971,6 +971,11 @@ static inline const gchar *NQ_(const gchar *String)
   return context_end ? context_end + 1 : String;
 }
 
+static inline gboolean dt_gimpmode(void)
+{
+  return darktable.gimp.mode ? TRUE : FALSE;
+}
+
 static inline gboolean dt_check_gimpmode(const char *mode)
 {
   return darktable.gimp.mode ? strcmp(darktable.gimp.mode, mode) == 0 : FALSE;

--- a/src/imageio/storage/disk.c
+++ b/src/imageio/storage/disk.c
@@ -190,7 +190,7 @@ void *legacy_params(dt_imageio_module_storage_t *self,
 static void button_clicked(GtkWidget *widget,
                            dt_imageio_module_storage_t *self)
 {
-  disk_t *d = (disk_t *)self->gui_data;
+  disk_t *d = self->gui_data;
   GtkWidget *win = dt_ui_main_window(darktable.gui->ui);
   GtkFileChooserNative *filechooser = gtk_file_chooser_native_new(
         _("select directory"), GTK_WINDOW(win), GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER,
@@ -294,7 +294,7 @@ void gui_cleanup(dt_imageio_module_storage_t *self)
 
 void gui_reset(dt_imageio_module_storage_t *self)
 {
-  disk_t *d = (disk_t *)self->gui_data;
+  disk_t *d = self->gui_data;
   gtk_entry_set_text(d->entry,
                      dt_confgen_get("plugins/imageio/storage/disk/file_directory",
                                     DT_DEFAULT));
@@ -354,21 +354,31 @@ try_again:
     d->vp->imgid = imgid;
     d->vp->sequence = num;
 
-    gchar *result_filename = dt_variables_expand(d->vp, pattern, TRUE);
-    g_strlcpy(filename, result_filename, sizeof(filename));
-    g_free(result_filename);
-
-    // if filenamepattern is a directory just add ${FILE_NAME} as
-    // default..  this can happen if the filename component of the
-    // pattern is an empty variable
-    char last_char = *(filename + strlen(filename) - 1);
-    if(last_char == '/' || last_char == '\\')
+    if(dt_gimpmode())
     {
-      // add to the end of the original pattern without caring about a
-      // potentially added "_$(SEQUENCE)"
-      if(snprintf(pattern, sizeof(pattern), "%s"
+      /* we certainly don't want to use any variable based expansion of the given filename
+         while in gimp mode but just keep it.
+      */
+      g_strlcpy(filename, pattern, sizeof(filename));
+    }
+    else
+    {
+      gchar *result_filename = dt_variables_expand(d->vp, pattern, TRUE);
+      g_strlcpy(filename, result_filename, sizeof(filename));
+      g_free(result_filename);
+
+      // if filenamepattern is a directory just add ${FILE_NAME} as
+      // default..  this can happen if the filename component of the
+      // pattern is an empty variable
+      const char last_char = *(filename + strlen(filename) - 1);
+      if(last_char == '/' || last_char == '\\')
+      {
+        // add to the end of the original pattern without caring about a
+        // potentially added "_$(SEQUENCE)"
+        if(snprintf(pattern, sizeof(pattern), "%s"
                   G_DIR_SEPARATOR_S "$(FILE_NAME)", d->filename) < sizeof(pattern))
-        goto try_again;
+          goto try_again;
+      }
     }
 
     // get the directory path of the output file
@@ -445,8 +455,8 @@ try_again:
       {
         // get the image data
         const dt_image_t *img = dt_image_cache_get(darktable.image_cache, imgid, 'r');
-        GTimeSpan change_timestamp = img->change_timestamp;
-        GTimeSpan export_timestamp = img->export_timestamp;
+        const GTimeSpan change_timestamp = img->change_timestamp;
+        const GTimeSpan export_timestamp = img->export_timestamp;
         dt_image_cache_read_release(darktable.image_cache, img);
 
         // check if the export timestamp in the database is more recent than the change
@@ -529,7 +539,7 @@ int set_params(dt_imageio_module_storage_t *self,
                const int size)
 {
   dt_imageio_disk_t *d = (dt_imageio_disk_t *)params;
-  disk_t *g = (disk_t *)self->gui_data;
+  disk_t *g = self->gui_data;
 
   if(size != self->params_size(self)) return 1;
 
@@ -541,7 +551,7 @@ int set_params(dt_imageio_module_storage_t *self,
 
 char *ask_user_confirmation(dt_imageio_module_storage_t *self)
 {
-  disk_t *g = (disk_t *)self->gui_data;
+  disk_t *g = self->gui_data;
   if(dt_bauhaus_combobox_get(g->onsave_action) == DT_EXPORT_ONCONFLICT_OVERWRITE
      && dt_conf_get_bool("plugins/lighttable/export/ask_before_export_overwrite"))
   {

--- a/src/main.c
+++ b/src/main.c
@@ -106,7 +106,7 @@ int main(int argc, char *argv[])
 
   if(dt_init(argc, argv, TRUE, TRUE, NULL))
   {
-    if(darktable.gimp.mode)
+    if(dt_gimpmode())
       printf("\n<<<gimp\nerror\ngimp>>>\n");
     exit(1);
   }
@@ -142,12 +142,12 @@ int main(int argc, char *argv[])
       darktable.gimp.error = TRUE;
   }
 
-  if(!darktable.gimp.mode || dt_check_gimpmode_ok("file"))
+  if(!dt_gimpmode() || dt_check_gimpmode_ok("file"))
     dt_gui_gtk_run(darktable.gui);
 
   dt_cleanup();
 
-  if(darktable.gimp.mode && darktable.gimp.error)
+  if(dt_gimpmode() && darktable.gimp.error)
     printf("\n<<<gimp\nerror\ngimp>>>\n");
 
 #ifdef _WIN32
@@ -160,7 +160,7 @@ int main(int argc, char *argv[])
   }
 #endif
 
-  const int exitcode = darktable.gimp.mode ? (darktable.gimp.error ? 1 : 0) : 0;
+  const int exitcode = dt_gimpmode() ? (darktable.gimp.error ? 1 : 0) : 0;
   exit(exitcode);
 }
 


### PR DESCRIPTION
1. The generic variable expansion for the output file must be avoided if we export to a specific file as requested in gimping mode.
2. Make use of gboolean dt_gimpmode() testing for a gimp action
3. Strictly avoid the configuration updates when gimping

A few constify while checking this.