### PR TITLE
Some OpenCL fixes

### DIFF
--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -336,13 +336,6 @@ int dt_opencl_get_kernel_work_group_size(const int dev,
                                          const int kernel,
                                          size_t *kernelworkgroupsize);
 
-/** attach arg. */
-int dt_opencl_set_kernel_arg(const int dev,
-                             const int kernel,
-                             const int num,
-                             const size_t size,
-                             const void *arg);
-
 /** wrap opencl arguments */
 /** the magic number is used for parameter checking; don't use it in your code! */
 #define CLWRAP(size, ptr) (const size_t)0xF111E8, (const size_t)size, (const void *)ptr
@@ -594,8 +587,6 @@ void dt_opencl_dump_pipe_pfm(const char* mod,
                              cl_mem img,
                              const gboolean input,
                              const char *pipe);
-
-int dt_opencl_get_mem_context_id(cl_mem mem);
 
 void dt_opencl_memory_statistics(int devid,
                                  cl_mem mem,

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -2774,7 +2774,7 @@ restart:
                                                                modules, pieces, pos);
   // get status summary of opencl queue by checking the eventlist
   const gboolean oclerr = (pipe->devid > DT_DEVICE_CPU)
-                          ? (dt_opencl_events_flush(pipe->devid, TRUE) != 0)
+                          ? (dt_opencl_events_flush(pipe->devid, TRUE) != CL_SUCCESS)
                           : FALSE;
 
   // Check if we had opencl errors, those can come in two ways:


### PR DESCRIPTION
1. Two functions were purely internal and thus are not exposed any more and got a leading underscore _opencl_set_kernel_arg() and _opencl_get_mem_context_id()
2. _opencl_set_kernel_arg() returns an error condition so it generate them instead of magics. We also should test vs CL_SUCCESS instead of assuming this is zero
3. dt_opencl_events_flush() returns an error code so it should generate them and we should test results vs CL_SUCCESS.

Some codestyle fixes and readability