### PR TITLE
Some dt_imgid_t and dt_filmid_t

### DIFF
--- a/src/control/jobs/image_jobs.c
+++ b/src/control/jobs/image_jobs.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2010-2021 darktable developers.
+    Copyright (C) 2010-2024 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -46,7 +46,7 @@ static int32_t dt_image_load_job_run(dt_job_t *job)
   return 0;
 }
 
-dt_job_t *dt_image_load_job_create(int32_t id, dt_mipmap_size_t mip)
+dt_job_t *dt_image_load_job_create(dt_imgid_t id, dt_mipmap_size_t mip)
 {
   dt_job_t *job = dt_control_job_create(&dt_image_load_job_run, "load image %d mip %d", id, mip);
   if(!job) return NULL;
@@ -64,7 +64,7 @@ dt_job_t *dt_image_load_job_create(int32_t id, dt_mipmap_size_t mip)
 
 typedef struct dt_image_import_t
 {
-  uint32_t film_id;
+  dt_filmid_t film_id;
   gchar *filename;
 } dt_image_import_t;
 
@@ -76,8 +76,8 @@ static int32_t dt_image_import_job_run(dt_job_t *job)
   snprintf(message, sizeof(message), _("importing image %s"), params->filename);
   dt_control_job_set_progress_message(job, message);
 
-  const int id = dt_image_import(params->film_id, params->filename, TRUE, TRUE);
-  if(id)
+  const dt_imgid_t id = dt_image_import(params->film_id, params->filename, TRUE, TRUE);
+  if(dt_is_valid_imgid(id))
   {
     DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_VIEWMANAGER_THUMBTABLE_ACTIVATE, id);
     dt_control_queue_redraw();
@@ -96,7 +96,7 @@ static void dt_image_import_job_cleanup(void *p)
   free(params);
 }
 
-dt_job_t *dt_image_import_job_create(uint32_t filmid, const char *filename)
+dt_job_t *dt_image_import_job_create(dt_filmid_t filmid, const char *filename)
 {
   dt_image_import_t *params;
   dt_job_t *job = dt_control_job_create(&dt_image_import_job_run, "import image");

--- a/src/control/jobs/image_jobs.h
+++ b/src/control/jobs/image_jobs.h
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2010-2020 darktable developers.
+    Copyright (C) 2010-2024 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -25,7 +25,7 @@
 
 dt_job_t *dt_image_load_job_create(dt_imgid_t imgid, dt_mipmap_size_t mip);
 
-dt_job_t *dt_image_import_job_create(uint32_t filmid, const char *filename);
+dt_job_t *dt_image_import_job_create(dt_filmid_t filmid, const char *filename);
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py


### PR DESCRIPTION
Spotted some places where we still had the old int/uint definitions and replaced them with the proper types and corrected image_job.c&h.