### PR TITLE
Use dt_atomic for control->running

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1590,7 +1590,7 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
     if(dbfilename_from_command && !strcmp(dbfilename_from_command, ":memory:"))
       dt_gui_presets_init(); // init preset db schema.
 
-    g_atomic_int_set(&darktable.control->running, DT_CONTROL_STATE_DISABLED);
+    dt_atomic_set_int(&darktable.control->running, DT_CONTROL_STATE_DISABLED);
     dt_pthread_mutex_init(&darktable.control->log_mutex, NULL);
   }
 

--- a/src/control/control.h
+++ b/src/control/control.h
@@ -186,7 +186,7 @@ typedef struct dt_control_t
   double last_expose_time;
 
   // job management
-  gint running;
+  dt_atomic_int running;
   gboolean cups_started;
   gboolean export_scheduled;
   dt_pthread_mutex_t queue_mutex, cond_mutex;


### PR DESCRIPTION
As only late glibc has g_atomic_int_exchange() we use the dt_atomic_() variants instead.

In pthread_joining work we do more precise logs as the crash reports might be misleading in location due to inlining and macro expansion.