### PR TITLE
[CI/CD] Do not use PPA's gmic package in AppImage build as it's not installable

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -59,6 +59,7 @@ jobs:
             libfuse2 \
             libgdk-pixbuf2.0-dev \
             libglib2.0-dev \
+            libgmic-dev \
             libgraphicsmagick1-dev \
             libgtk-3-dev \
             libinih-dev \
@@ -98,7 +99,6 @@ jobs:
           sudo apt-get update
           sudo apt-get -y install \
             libavif-dev \
-            libgmic-dev \
             libgphoto2-dev \
             libheif-dev \
             libimath-dev \


### PR DESCRIPTION
We are forced to switch from newer libgmic in savoury1 PPA to package from official repo. The package from the PPA is currently not installable due to dependency errors.

Not a big deal, since the PPA has libgmic version 2.9.9, while the official repo has 2.9.4, and we only use libgmic to work with compressed LUT files (which just works in any version).
