### PR TITLE
jobs maintenance (part 1)

### DIFF
--- a/src/control/control.c
+++ b/src/control/control.c
@@ -289,8 +289,8 @@ void dt_control_change_cursor(dt_cursor_t curs)
 gboolean dt_control_running()
 {
   dt_control_t *dc = darktable.control;
-  const int status = dc ? dt_atomic_get_int(&dc->running) : DT_CONTROL_STATE_DISABLED;
-  return status == DT_CONTROL_STATE_RUNNING;
+  return dc ? dt_atomic_get_int(&dc->running) == DT_CONTROL_STATE_RUNNING
+            : FALSE;
 }
 
 void dt_control_quit()

--- a/src/control/progress.h
+++ b/src/control/progress.h
@@ -21,7 +21,7 @@
 #include <glib.h>
 
 struct dt_control_t;
-struct _dt_job_t;
+struct dt_job_t;
 
 struct _dt_progress_t;
 typedef struct _dt_progress_t dt_progress_t;
@@ -43,7 +43,7 @@ void dt_control_progress_make_cancellable(struct dt_control_t *control, dt_progr
                                           dt_progress_cancel_callback_t cancel, void *data);
 /** convenience function to cancel a job when the progress gets cancelled. */
 void dt_control_progress_attach_job(struct dt_control_t *control, dt_progress_t *progress,
-                                    struct _dt_job_t *job);
+                                    struct dt_job_t *job);
 /** cancel the job linked to with dt_control_progress_attach_job(). don't forget to call
  * dt_control_progress_destroy() afterwards. */
 void dt_control_progress_cancel(struct dt_control_t *control, dt_progress_t *progress);


### PR DESCRIPTION
1. Don't fiddle around with dt_job_t variants declarations
2. make _control_job_set_synchronous() static as only internal and remove from .h
3. remove dt_control_job_wait() as not used in the code at all
4. some verbose job info added for intensive debugging