### PR TITLE
[CI/CD] Add the ability to specify which app to run via the AppImage CLI

### DIFF
--- a/packaging/AppImage/AppRun
+++ b/packaging/AppImage/AppRun
@@ -1,8 +1,14 @@
 #!/usr/bin/env bash
 
-# The purpose of this custom AppRun script is to allow symlinking the AppImage
-# and invoking the corresponding binary depending on which symlink was used
-# to invoke the AppImage
+# The purpose of this custom AppRun script is to allow the user to specify
+# which binary from the multi-binary AppImage to run. This can be done in
+# one of two ways:
+# - The binary name can be specified as the first command line argument.
+# If there is a binary with that name inside the AppImage, it will be run
+# instead of the default one.
+# - The user can create a symlink to the AppImage file and run it via the
+# symlink. If inside the AppImage there is a binary with a name that matches
+# the symlink name, it will be launched instead of the default one.
 
 HERE="$(dirname "$(readlink -f "${0}")")"
 

--- a/packaging/AppImage/AppRun
+++ b/packaging/AppImage/AppRun
@@ -10,11 +10,15 @@ source "$HERE"/apprun-hooks/"linuxdeploy-plugin-gtk.sh"
 
 if [[ ! -z $APPIMAGE ]] ; then
   BINARY_NAME=$(basename "$ARGV0")
-  if [[ -e "$HERE/usr/bin/$BINARY_NAME" ]] ; then
-    exec "$HERE/usr/bin/$BINARY_NAME" "$@"
+  if [[ ! -z "$1" ]] && [[ -e "$HERE/usr/bin/$1" ]] ; then
+    EXECFILE="$HERE/usr/bin/$1" ; shift
+  elif [[ -e "$HERE/usr/bin/$BINARY_NAME" ]] ; then
+    EXECFILE="$HERE/usr/bin/$BINARY_NAME"
   else
-    exec "$HERE/usr/bin/darktable" "$@"
+    EXECFILE="$HERE/usr/bin/darktable"
   fi
 else
-  exec "$HERE/usr/bin/darktable" "$@"
+  EXECFILE="$HERE/usr/bin/darktable"
 fi
+
+exec "$EXECFILE" "$@"


### PR DESCRIPTION
The purpose of creating a custom AppRun script is to allow the user to specify which binary from the multi-binary AppImage to run. This can now be done in one of two ways:

- The binary name can be specified as the first command line argument. If there is a binary with that name inside the AppImage, it will be run instead of the default one.

- The user can create a symlink to the AppImage file and run it via the symlink. If inside the AppImage there is a binary with a name that matches the symlink name, it will be launched instead of the default one.