### PR TITLE
[CI/nightly] bump Xcode to v16.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -312,7 +312,7 @@ jobs:
       matrix:
         build:
           - { os: macos-13,    xcode: 15.2,   deployment: 13.5 } # LLVM16, x86_64
-          - { os: macos-14,    xcode: 15.4,   deployment: 14.0 } # LLVM16, arm64
+          - { os: macos-14,    xcode: 16.1,   deployment: 14.0 } # LLVM16, arm64
         compiler:
           - { compiler: XCode,   CC: cc, CXX: c++ }
         btype: [ Release ]

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -281,7 +281,7 @@ jobs:
       matrix:
         build:
           - { os: macos-13, xcode: 15.2, deployment: 13.5 } # LLVM16, x86_64
-          - { os: macos-14, xcode: 15.4, deployment: 14.0 } # LLVM16, arm64
+          - { os: macos-14, xcode: 16.1, deployment: 14.0 } # LLVM16, arm64
         compiler:
           - { compiler: XCode,   CC: cc, CXX: c++ }
         btype: [ Release ]


### PR DESCRIPTION
With dt 5.0 released we can start a field test with Xcode 16.
