### PR TITLE
[CSS]: center collapsible section label

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -656,12 +656,19 @@ dialog .sidebar row:selected:hover label,
   background-color: shade(@collapsible_bg_color, 1.04);
 }
 
+.dt_section_expander {
+  padding: 0.07em 0 0.07em 1.7em;  
+}
+
 .dt_section_expander,
 .dt_section_expander label
 {
   background-color: @collapsible_bg_color;
   border: none;
   margin-top: 0.14em;
+}
+
+.dt_section_expander label {
   padding: 0.07em 0;
 }
 


### PR DESCRIPTION
The label of a collapsible section is not centered in regard of the widget width.
This is ugly, especially if the collapsible section is directly above or below a centered element, i.e. a button:

before:
![Bildschirmfoto 2024-12-24 um 10 03 41](https://github.com/user-attachments/assets/2bc52a2e-f618-4e9f-a63b-52017084f878)

after:
![Bildschirmfoto 2024-12-24 um 10 04 09](https://github.com/user-attachments/assets/407a5530-caf0-4cab-be84-bf3e968bb544)

Sigmoid module before:
![Bildschirmfoto 2024-12-24 um 10 05 05](https://github.com/user-attachments/assets/527c1afb-408b-4b9d-982a-1cd273c2fc00)

after:
![Bildschirmfoto 2024-12-24 um 10 05 38](https://github.com/user-attachments/assets/e30f7c3b-778d-4073-9517-963bdbdc7d47)

