### PR TITLE
fix gtk crash on module instance delete

### DIFF
--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -532,8 +532,8 @@ static void _gui_delete_callback(GtkButton *button, dt_iop_module_t *module)
   // we remove the plugin effectively
   if(!dt_iop_is_hidden(module))
   {
-    dt_iop_gui_cleanup_module(module);
     gtk_widget_grab_focus(dt_ui_center(darktable.gui->ui));
+    dt_iop_gui_cleanup_module(module);
   }
 
   // we remove all references in the history stack and dev->iop


### PR DESCRIPTION
If the currently focused module instance is being deleted, gtk crashes on `gtk_widget_grab_focus()`.

To reproduce:
- enter darkroom
- create a new instance of the exposure module
- slightly touch the exposure slider so the module is focused
- delete the instance

Solution is to  move the focus to `dt_ui_center` before the module instance is deleted.

fixes #18052 
fixes #18039 
