### PR TITLE
[macOS]: display keyboard accelerators in the macOS menu

### DIFF
--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -1140,15 +1140,16 @@ static void _osx_ctl_switch_mode_to(GtkWidget *mi,
   dt_ctl_switch_mode_to((const char*) mode);
 }
 
-static void _osx_add_view_menu_item(GtkWidget* menu,
-                                    const char* label,
-                                    gpointer mode)
+static GtkWidget *_osx_add_view_menu_item(GtkWidget* menu,
+                                          const char* label,
+                                          gpointer mode)
 {
   GtkWidget *mi = gtk_menu_item_new_with_label(label);
   gtk_menu_shell_append(GTK_MENU_SHELL (menu), mi);
   gtk_widget_show(mi);
   g_signal_connect(G_OBJECT(mi), "activate",
                    G_CALLBACK(_osx_ctl_switch_mode_to), mode);
+  return mi;
 }
 
 static void _open_url(GtkWidget *widget, gpointer url)
@@ -1205,25 +1206,42 @@ int dt_gui_gtk_init(dt_gui_gtk_t *gui)
 #ifdef MAC_INTEGRATION
   GtkosxApplication *OSXApp = g_object_new(GTKOSX_TYPE_APPLICATION, NULL);
 
+  GtkAccelGroup *accel_group = gtk_accel_group_new();
+  gtk_window_add_accel_group(GTK_WINDOW(OSXApp), accel_group);
+
   // View menu
   GtkWidget *view_root_menu = gtk_menu_item_new_with_label(C_("menu", "Views"));
   gtk_widget_show(view_root_menu);
 
   GtkWidget *view_menu = gtk_menu_new();
-  _osx_add_view_menu_item(view_menu, C_("menu", "lighttable"), "lighttable");
-  _osx_add_view_menu_item(view_menu, C_("menu", "darkroom"), "darkroom");
+  GtkWidget *mi;
+  mi = _osx_add_view_menu_item(view_menu, C_("menu", "lighttable"), "lighttable");
+  gtk_widget_add_accelerator(mi, "activate", accel_group,
+                             GDK_KEY_l, 0, GTK_ACCEL_VISIBLE);
+
+  mi = _osx_add_view_menu_item(view_menu, C_("menu", "darkroom"), "darkroom");
+  gtk_widget_add_accelerator(mi, "activate", accel_group,
+                             GDK_KEY_d, 0, GTK_ACCEL_VISIBLE);
 
   GtkWidget *sep = gtk_separator_menu_item_new();
   gtk_menu_shell_append(GTK_MENU_SHELL (view_menu), sep);
   gtk_widget_show(sep);
 
-  _osx_add_view_menu_item(view_menu, C_("menu", "slideshow"), "slideshow");
+  mi = _osx_add_view_menu_item(view_menu, C_("menu", "slideshow"), "slideshow");
+  gtk_widget_add_accelerator(mi, "activate", accel_group,
+                             GDK_KEY_s, 0, GTK_ACCEL_VISIBLE);
 #ifdef HAVE_MAP
-  _osx_add_view_menu_item(view_menu, C_("menu", "map"), "map");
+  mi = _osx_add_view_menu_item(view_menu, C_("menu", "map"), "map");
+  gtk_widget_add_accelerator(mi, "activate", accel_group,
+                             GDK_KEY_m, 0, GTK_ACCEL_VISIBLE);
 #endif
-  _osx_add_view_menu_item(view_menu, C_("menu", "print"), "print");
+  mi = _osx_add_view_menu_item(view_menu, C_("menu", "print"), "print");
+  gtk_widget_add_accelerator(mi, "activate", accel_group,
+                             GDK_KEY_p, 0, GTK_ACCEL_VISIBLE);
 #ifdef HAVE_GPHOTO2
-  _osx_add_view_menu_item(view_menu, C_("menu", "tethering"), "tethering");
+  mi = _osx_add_view_menu_item(view_menu, C_("menu", "tethering"), "tethering");
+  gtk_widget_add_accelerator(mi, "activate", accel_group,
+                             GDK_KEY_t, 0, GTK_ACCEL_VISIBLE);
 #endif
 
   gtk_menu_item_set_submenu(GTK_MENU_ITEM (view_root_menu), view_menu);
@@ -1265,6 +1283,8 @@ int dt_gui_gtk_init(dt_gui_gtk_t *gui)
   gtkosx_application_insert_app_menu_item(OSXApp, mi_about, 0);
 
   GtkWidget *mi_prefs = gtk_menu_item_new_with_label(C_("menu", "Preferences"));
+  gtk_widget_add_accelerator(mi_prefs, "activate", accel_group,
+                             GDK_KEY_comma, GDK_META_MASK, GTK_ACCEL_VISIBLE);
   g_signal_connect(G_OBJECT(mi_prefs), "activate",
                    G_CALLBACK(dt_gui_preferences_show), NULL);
   gtkosx_application_insert_app_menu_item(OSXApp, mi_prefs, 1);

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -1215,11 +1215,11 @@ int dt_gui_gtk_init(dt_gui_gtk_t *gui)
 
   GtkWidget *view_menu = gtk_menu_new();
   GtkWidget *mi;
-  mi = _osx_add_view_menu_item(view_menu, C_("menu", "lighttable"), "lighttable");
+  mi = _osx_add_view_menu_item(view_menu, C_("menu", "Lighttable"), "lighttable");
   gtk_widget_add_accelerator(mi, "activate", accel_group,
                              GDK_KEY_l, 0, GTK_ACCEL_VISIBLE);
 
-  mi = _osx_add_view_menu_item(view_menu, C_("menu", "darkroom"), "darkroom");
+  mi = _osx_add_view_menu_item(view_menu, C_("menu", "Darkroom"), "darkroom");
   gtk_widget_add_accelerator(mi, "activate", accel_group,
                              GDK_KEY_d, 0, GTK_ACCEL_VISIBLE);
 
@@ -1227,19 +1227,19 @@ int dt_gui_gtk_init(dt_gui_gtk_t *gui)
   gtk_menu_shell_append(GTK_MENU_SHELL (view_menu), sep);
   gtk_widget_show(sep);
 
-  mi = _osx_add_view_menu_item(view_menu, C_("menu", "slideshow"), "slideshow");
+  mi = _osx_add_view_menu_item(view_menu, C_("menu", "Slideshow"), "slideshow");
   gtk_widget_add_accelerator(mi, "activate", accel_group,
                              GDK_KEY_s, 0, GTK_ACCEL_VISIBLE);
 #ifdef HAVE_MAP
-  mi = _osx_add_view_menu_item(view_menu, C_("menu", "map"), "map");
+  mi = _osx_add_view_menu_item(view_menu, C_("menu", "Map"), "map");
   gtk_widget_add_accelerator(mi, "activate", accel_group,
                              GDK_KEY_m, 0, GTK_ACCEL_VISIBLE);
 #endif
-  mi = _osx_add_view_menu_item(view_menu, C_("menu", "print"), "print");
+  mi = _osx_add_view_menu_item(view_menu, C_("menu", "Print"), "print");
   gtk_widget_add_accelerator(mi, "activate", accel_group,
                              GDK_KEY_p, 0, GTK_ACCEL_VISIBLE);
 #ifdef HAVE_GPHOTO2
-  mi = _osx_add_view_menu_item(view_menu, C_("menu", "tethering"), "tethering");
+  mi = _osx_add_view_menu_item(view_menu, C_("menu", "Tethering"), "tethering");
   gtk_widget_add_accelerator(mi, "activate", accel_group,
                              GDK_KEY_t, 0, GTK_ACCEL_VISIBLE);
 #endif


### PR DESCRIPTION
fixes #14484 
fixes #18051

- The keyboard accelerators are displayed in the application menu
- Register shortcut `CMD+,` to open the preferences

This is only for macOS, wrapped in `#ifdef MAC_INTEGRATION`, so no effects on other OS.

![Bildschirmfoto 2024-12-25 um 09 22 45](https://github.com/user-attachments/assets/32838c05-6407-4a3f-b1bf-57c97ad8dabf)

![Bildschirmfoto 2024-12-25 um 11 23 17](https://github.com/user-attachments/assets/7a72cefc-d36d-401a-b346-b630c8e29950)

