### PR TITLE
darktable: Call dt_iop_set_darktable_iop_table when iop list is set.

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1731,9 +1731,6 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
   darktable.mipmap_cache = (dt_mipmap_cache_t *)calloc(1, sizeof(dt_mipmap_cache_t));
   dt_mipmap_cache_init(darktable.mipmap_cache);
 
-  // set up memory.darktable_iop_names table
-  dt_iop_set_darktable_iop_table();
-
   // set up the list of exiv2 metadata
   dt_exif_set_exiv2_taglist();
 

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -489,9 +489,6 @@ dt_iop_module_t *dt_iop_gui_get_previous_visible_module(const dt_iop_module_t *m
 /** returns the next visible module on the module list */
 dt_iop_module_t *dt_iop_gui_get_next_visible_module(const dt_iop_module_t *module);
 
-// initializes memory.darktable_iop_names
-void dt_iop_set_darktable_iop_table();
-
 /** adds keyboard accels to the first module in the pipe to handle
  * where there are multiple instances */
 void dt_iop_connect_accels_multi(dt_iop_module_so_t *module);


### PR DESCRIPTION
This is important as the list of all iop must be known to populate the memory.darktable_iop_names table for the 'module' collection filter.

Add assert to catch this case and comments to avoid another regression when reordering the darktable start routines.

Fixes #18093.