### PR TITLE
finetune presets selection for long lists

### DIFF
--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -4367,12 +4367,12 @@ void dt_gui_collapsible_section_set_label(dt_gui_collapsible_section_t *cs,
   dt_control_queue_redraw_widget(cs->label);
 }
 
-gboolean dt_gui_long_click(const int second,
-                           const int first)
+gboolean dt_gui_long_click(const guint second,
+                           const guint first)
 {
   int delay = 0;
   g_object_get(gtk_settings_get_default(), "gtk-double-click-time", &delay, NULL);
-  return second - first > delay;
+  return second - delay > first;
 }
 
 static int busy_nest_count = 0;

--- a/src/gui/gtk.h
+++ b/src/gui/gtk.h
@@ -534,8 +534,8 @@ void dt_gui_update_collapsible_section(dt_gui_collapsible_section_t *cs);
 void dt_gui_hide_collapsible_section(dt_gui_collapsible_section_t *cs);
 
 // is delay between first and second click/press longer than double-click time?
-gboolean dt_gui_long_click(const int second,
-                           const int first);
+gboolean dt_gui_long_click(const guint second,
+                           const guint first);
 
 // control whether the mouse pointer displays as a "busy" cursor, e.g. watch or timer
 // the calls may be nested, but must be matched

--- a/src/gui/presets.c
+++ b/src/gui/presets.c
@@ -1262,7 +1262,7 @@ static gboolean _menuitem_button_preset(GtkMenuItem *menuitem,
 
   gchar *name = g_object_get_data(G_OBJECT(menuitem), "dt-preset-name");
 
-  if(event->button == 1 || (module->flags() & IOP_FLAGS_ONE_INSTANCE))
+  if(event->button == 1)
   {
     if(click_time > event->time)
     {
@@ -1276,7 +1276,7 @@ static gboolean _menuitem_button_preset(GtkMenuItem *menuitem,
   }
   else if(event->button == 3 && event->type == GDK_BUTTON_RELEASE)
   {
-    if(long_click)
+    if(long_click || (module->flags() & IOP_FLAGS_ONE_INSTANCE))
       dt_shortcut_copy_lua((dt_action_t*)module, name);
     else
     {


### PR DESCRIPTION
Tries to address the issue mentioned here https://github.com/darktable-org/darktable/pull/17987#issuecomment-2551605304 (@todd-prior) and also fixes #18080 which, if I understand correctly, is the same issue.

If you click-and-hold the mouse button on the presets button, you can move the mouse to your desired preset which then gets selected immediately upon releasing the mouse button. This creates a problem if the preset list is so long that it doesn't fit above or below the preset button; it will then be placed on top of the button and some preset will be under the mouse when you release it, even if you intended it to be a "normal" (quick, non-hold) click that should have _just_ opened the list and not selected anything.

This PR first checks if the mouse has been moved, before acting when the mouse-button is released.

It also fixes a (totally) unrelated bug that would disable the "long right-click on preset copies the lua code to activate the preset to the clipboard" functionality for modules that cannot have multiple instances (and where therefore a _short_ right-click does not create a new instance).

I cannot reproduce #18064 but maybe someone can check if this PR changes anything for that issue?