### PR TITLE
additional memory allocation checks

### DIFF
--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2012-2023 darktable developers.
+    Copyright (C) 2012-2024 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -145,21 +145,27 @@ static dt_bauhaus_combobox_entry_t *_new_combobox_entry
    void (*free_func)(void *))
 {
   dt_bauhaus_combobox_entry_t *entry = calloc(1, sizeof(dt_bauhaus_combobox_entry_t));
-  entry->label = g_strdup(label);
-  entry->alignment = alignment;
-  entry->sensitive = sensitive;
-  entry->data = data;
-  entry->free_func = free_func;
+  if(entry)
+  {
+    entry->label = g_strdup(label);
+    entry->alignment = alignment;
+    entry->sensitive = sensitive;
+    entry->data = data;
+    entry->free_func = free_func;
+  }
   return entry;
 }
 
 static void _free_combobox_entry(gpointer data)
 {
   dt_bauhaus_combobox_entry_t *entry = (dt_bauhaus_combobox_entry_t *)data;
-  g_free(entry->label);
-  if(entry->free_func)
-    entry->free_func(entry->data);
-  free(entry);
+  if(entry)
+  {
+    g_free(entry->label);
+    if(entry->free_func)
+      entry->free_func(entry->data);
+    free(entry);
+  }
 }
 
 static GdkRGBA * _default_color_assign()
@@ -1560,7 +1566,8 @@ void dt_bauhaus_combobox_add_full(GtkWidget *widget,
     data =_combobox_entry(d, d->entries->len - 1)->data + 1;
   dt_bauhaus_combobox_entry_t *entry = _new_combobox_entry(text, align,
                                                            sensitive, data, free_func);
-  g_ptr_array_add(d->entries, entry);
+  if(entry)
+    g_ptr_array_add(d->entries, entry);
   if(d->active < 0)
     d->active = 0;
   if(d->defpos == -1 && sensitive)
@@ -1662,8 +1669,9 @@ void dt_bauhaus_combobox_insert_full(GtkWidget *widget,
   dt_bauhaus_widget_t *w = DT_BAUHAUS_WIDGET(widget);
   if(w->type != DT_BAUHAUS_COMBOBOX) return;
   dt_bauhaus_combobox_data_t *d = &w->data.combobox;
-  g_ptr_array_insert(d->entries, pos,
-                     _new_combobox_entry(text, align, TRUE, data, free_func));
+  dt_bauhaus_combobox_entry_t *entry = _new_combobox_entry(text, align, TRUE, data, free_func);
+  if(entry)
+    g_ptr_array_insert(d->entries, pos, entry);
   if(d->active < 0) d->active = 0;
 }
 

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -2178,7 +2178,9 @@ static gboolean _opencl_load_program(const int dev,
 
   const size_t filesize = filestat.st_size;
   char *file = malloc(filesize + 2048);
-  size_t rd = fread(file, sizeof(char), filesize, f);
+  size_t rd = 0;
+  if(file)
+    rd = fread(file, sizeof(char), filesize, f);
   fclose(f);
   if(rd != filesize)
   {
@@ -2255,7 +2257,10 @@ static gboolean _opencl_load_program(const int dev,
         size_t cached_filesize = cachedstat.st_size;
 
         unsigned char *cached_content = malloc(cached_filesize + 1);
-        rd = fread(cached_content, sizeof(char), cached_filesize, cached);
+        if(cached_content)
+          rd = fread(cached_content, sizeof(char), cached_filesize, cached);
+        else
+          rd = 0;
         if(rd != cached_filesize)
         {
           dt_print(DT_DEBUG_OPENCL,

--- a/src/common/printprof.c
+++ b/src/common/printprof.c
@@ -66,6 +66,11 @@ int dt_apply_printer_profile(void **in, uint32_t width, uint32_t height, int bpp
   }
 
   void *out = malloc((size_t)3 * width * height);
+  if(!out)
+  {
+    dt_print(DT_DEBUG_ALWAYS, "unable to allocate buffer for printer-proofed image");
+    return 1;
+  }
 
   if(bpp == 8)
   {

--- a/src/common/utility.c
+++ b/src/common/utility.c
@@ -491,6 +491,14 @@ static cairo_surface_t *_util_get_svg_img(gchar *logo, const float size)
     const int stride = cairo_format_stride_for_width(CAIRO_FORMAT_ARGB32, final_width);
 
     guint8 *image_buffer = calloc(stride * final_height, sizeof(guint8));
+    if(!image_buffer)
+    {
+      dt_print(DT_DEBUG_ALWAYS, "warning: unable to allocate rasterization buffer for SVG '%s'", dtlogo);
+      g_free(logo);
+      g_free(dtlogo);
+      g_object_unref(svg);
+      return NULL;
+    }
     if(darktable.gui)
       surface = dt_cairo_image_surface_create_for_data(image_buffer, CAIRO_FORMAT_ARGB32, final_width,
                                                       final_height, stride);


### PR DESCRIPTION
I noticed that this has been sitting around for a while....

Could be tagged bugfix and slotted in for 5.0.1 although it isn't fixing any reported bugs.  Won't fight for that, though.

The checks in pdf.c, printprof.c, and utility.c are the ones most likely to be triggered by OOM since they are allocating full images.
