### PR TITLE
Fix two importing issues

### DIFF
--- a/src/libs/import.c
+++ b/src/libs/import.c
@@ -745,7 +745,8 @@ static void _import_add_file_callback(GObject *direnum,
     g_object_unref(gfolder);
     g_object_unref(direnum);
     g_list_free_full(file_list, g_object_unref);
-    dt_print(DT_DEBUG_ALWAYS,
+    if(error->code != G_IO_ERROR_CANCELLED)
+      dt_print(DT_DEBUG_ALWAYS,
              "[_import_add_file_callback] error: %s", error->message);
     g_error_free(error);
     return;


### PR DESCRIPTION
**Only ask for original dng files via github**

We ask for dng files with specific exif tags that are currently not supported in darktable.

As some software (like from adobe) possibly adds those tags we get warnings for such images, but
- we simply don't care about those as we want data from camera vendor
- that gives irrelevant feedback to user
- it spoils the database with tags

So if we find some non-dng name in "Exif.Image.OriginalRawFileName" we ignore those images for backreporting.

_____________________________________________________
**Don't report G_IO_ERROR_CANCELLED in `_import_add_file_callback()`**

As we currently do in `_import_enum_callback()` the G_IO_ERROR_CANCELLED condition is not a real error and should not be reported as such.