### PR TITLE
macOS: harmonize macports/homebrew packaging

### DIFF
--- a/packaging/macosx/BUILD-ARM64.txt
+++ b/packaging/macosx/BUILD-ARM64.txt
@@ -4,7 +4,7 @@ How to make disk image with darktable application bundle (64 bit ARM only):
     They will need some tuning, so before you install anything add this line to /opt/local/etc/macports/variants.conf:
      +no_gnome +no_x11 +quartz -x11 -gnome -gfortran
     Install required dependencies:
-     $ sudo port install exiv2 libgphoto2 gtk-osx-application-gtk3 lensfun librsvg openexr json-glib GraphicsMagick openjpeg webp libsecret pugixml osm-gps-map adwaita-icon-theme tango-icon-theme intltool iso-codes libomp gmic-lib libheif portmidi libsdl2 libavif libjxl
+     $ sudo port install exiv2 libgphoto2 gtk-osx-application-gtk3 lensfun librsvg openexr json-glib GraphicsMagick openjpeg webp libsecret pugixml osm-gps-map adwaita-icon-theme intltool iso-codes libomp gmic-lib libheif portmidi libsdl2 libavif libjxl
     Clone darktable git repository (in this example into ~/src):
      $ mkdir ~/src
      $ cd ~/src

--- a/packaging/macosx/BUILD.txt
+++ b/packaging/macosx/BUILD.txt
@@ -7,7 +7,7 @@ How to make disk image with darktable application bundle (64 bit Intel only):
     and this line to /opt/local/etc/macports/variants.conf:
      +no_gnome +no_x11 +quartz -x11 -gnome -gfortran
     Install required dependencies:
-     $ sudo port install exiv2 libgphoto2 gtk-osx-application-gtk3 lensfun librsvg openexr json-glib GraphicsMagick openjpeg webp libsecret pugixml osm-gps-map adwaita-icon-theme tango-icon-theme intltool iso-codes libomp gmic-lib libheif portmidi libsdl2 libavif libjxl
+     $ sudo port install exiv2 libgphoto2 gtk-osx-application-gtk3 lensfun librsvg openexr json-glib GraphicsMagick openjpeg webp libsecret pugixml osm-gps-map adwaita-icon-theme intltool iso-codes libomp gmic-lib libheif portmidi libsdl2 libavif libjxl
     Clone darktable git repository (in this example into ~/src):
      $ mkdir ~/src
      $ cd ~/src

--- a/packaging/macosx/darktable.bundle
+++ b/packaging/macosx/darktable.bundle
@@ -43,5 +43,4 @@
   <data dest="${bundle}/Contents/Resources/share/applications/defaults.list">${project}/defaults.list</data>
   <data dest="${bundle}/Contents/Resources/share/applications/open.desktop">${project}/open.desktop</data>
   <icon-theme icons="all">Adwaita</icon-theme>
-  <icon-theme icons="all">Tango</icon-theme>
 </app-bundle>

--- a/packaging/macosx/settings.ini
+++ b/packaging/macosx/settings.ini
@@ -1,2 +1,2 @@
 [Settings]
-gtk-icon-theme-name = Tango
+gtk-icon-theme-name = Adwaita


### PR DESCRIPTION
harmonize packaging macports and homebrew:
get rid of tango theme in favor for adwaita only (like in homebrew packaging)