### PR TITLE
Drop Minolta DiMAGE 5 from suspended list

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -459,7 +459,6 @@ Support for the following cameras is suspended because no samples are available 
 - Leaf Aptus-II 5(LI300059)/Mamiya 645 AFD
 - Leaf Credo 60
 - Leaf Credo 80
-- Minolta DiMAGE 5
 - Olympus SP320
 - Phase One IQ250
 - Sinar Hy6/ Sinarback eXact


### PR DESCRIPTION
Samples received in https://github.com/darktable-org/darktable/issues/17954

Should be implemented in rawspeed bump for 5.0.1 (and relnotes updated on branch as well).