### PR TITLE
thumbtable: Fix map & print module views selection handling.

### DIFF
--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -1522,7 +1522,8 @@ static gboolean _event_button_release(GtkWidget *widget,
 
   if(cv != DT_VIEW_DARKROOM
      && cv != DT_VIEW_LIGHTTABLE
-     && cv != DT_VIEW_MAP)
+     && cv != DT_VIEW_MAP
+     && cv != DT_VIEW_PRINT)
     return FALSE;
 
   dt_set_backthumb_time(0.0);
@@ -1575,6 +1576,7 @@ static gboolean _event_button_release(GtkWidget *widget,
       else
       {
         dt_selection_select_single(darktable.selection, id);
+        DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_VIEWMANAGER_THUMBTABLE_ACTIVATE, id);
       }
     }
   }


### PR DESCRIPTION

For the print view a single click must change the current printed image.
For the map view a single click must center the picture if present on the map.
    
Fixes #18143

