### PR TITLE
[imageio] Allow out of spec DateTimeOriginal without trailing null byte

### DIFF
--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -1138,9 +1138,12 @@ static void _find_datetime_taken(Exiv2::ExifData &exifData,
   // Note: We allow a longer "datetime original" field with an unnecessary
   // trailing byte(s) due to buggy software that creates it.
   // See https://github.com/darktable-org/darktable/issues/17389
+  // We also accept the out of spec Exif.Photo.DateTimeOriginal
+  // without a null terminator, which AnalogExif creates.
+  // See https://github.com/darktable-org/darktable/issues/18146
   if((FIND_EXIF_TAG("Exif.Image.DateTimeOriginal")
       || FIND_EXIF_TAG("Exif.Photo.DateTimeOriginal"))
-     && pos->size() >= DT_DATETIME_EXIF_LENGTH)
+     && pos->size() >= DT_DATETIME_EXIF_LENGTH - 1)
   {
     _strlcpy_to_utf8(exif_datetime_taken, DT_DATETIME_EXIF_LENGTH, pos, exifData);
     if(FIND_EXIF_TAG("Exif.Photo.SubSecTimeOriginal")


### PR DESCRIPTION
Fixes #18146.

This fix is ​​trivial and obviously safe, so it would be useful to have it in 5.0.1 even for the not-so-large AnalogExif user base.
