### PR TITLE
Avoid collapsing of module header

### DIFF
--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -2250,7 +2250,6 @@ void dt_iop_gui_update(dt_iop_module_t *module)
       dt_iop_gui_update_expanded(module);
     }
     dt_iop_gui_update_header(module);
-    dt_iop_show_hide_header_buttons(module, NULL, FALSE, FALSE);
     dt_guides_update_module_widget(module);
 
     // this signal must be raised only safely when the darkroom and history

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -1124,7 +1124,7 @@ static gboolean _dev_load_requested_image(gpointer user_data)
       {
         dt_iop_gui_init(module);
 
-        /* add module to right panel */
+        /* add module to right panel with safe header buttons */
         dt_iop_gui_set_expander(module);
         dt_iop_gui_update_blending(module);
       }
@@ -1134,6 +1134,8 @@ static gboolean _dev_load_requested_image(gpointer user_data)
       //  update the module header to ensure proper multi-name display
       if(!dt_iop_is_hidden(module))
       {
+        // Make sure module header buttons are reset to a safe state
+        dt_iop_show_hide_header_buttons(module, NULL, FALSE, FALSE);
         snprintf(option, sizeof(option), "plugins/darkroom/%s/expanded", module->op);
         module->expanded = dt_conf_get_bool(option);
         dt_iop_gui_update_expanded(module);


### PR DESCRIPTION
As reported and shortly discussed in #18151 a click on the modules reset-parameters button collapses the module if `darkroom/ui/hide_header_buttons=active` (since 3.8).

We don't have to reset the headerbar buttons to a safe state in 'dt_iop_gui_update()' but only when loading a new image into darkroom as the modules applicable status might have changed (for example modules that only work with raw image data).