### PR TITLE
Style dialogs

### DIFF
--- a/src/common/history.c
+++ b/src/common/history.c
@@ -1051,7 +1051,7 @@ GList *dt_history_get_items(const dt_imgid_t imgid,
      " FROM main.history"
      " WHERE imgid=?1"
      "   AND enabled in (1, ?2)"
-     " GROUP BY num, operation, multi_priority"
+     " GROUP BY operation || multi_name, multi_priority"
      " ORDER BY %s DESC, %s DESC",
      multi_priority_order ? "multi_priority" : "num",
      multi_priority_order ? "num" : "multi_priority");

--- a/src/common/styles.c
+++ b/src/common/styles.c
@@ -1098,9 +1098,9 @@ GList *dt_styles_get_item_list(const char *name,
           "        multi_name, FALSE, blendop_version"
           " FROM main.history"
           " WHERE imgid=?2 AND main.history.enabled=1"
-          "   AND (main.history.operation"
-          "        NOT IN (SELECT operation FROM data.style_items WHERE styleid=?1))"
-          " GROUP BY operation HAVING MAX(num) ORDER BY num DESC", -1, &stmt, NULL);
+          "   AND (main.history.operation || multi_name"
+          "        NOT IN (SELECT operation || multi_name FROM data.style_items WHERE styleid=?1))"
+          " GROUP BY (operation || multi_name) HAVING MAX(num) ORDER BY num DESC", -1, &stmt, NULL);
         // clang-format on
       DT_DEBUG_SQLITE3_BIND_INT(stmt, 2, imgid);
     }


### PR DESCRIPTION
1. Makes copies of the module available for adding in 'edit style' dialog.
2. Leaves the latest module settings for adding in the 'create new style' dialog.
