### PR TITLE
don't force-refresh center view on side panel refresh

### DIFF
--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -2395,8 +2395,10 @@ static gboolean _side_panel_draw(GtkWidget *widget,
                                  cairo_t *cr,
                                  gpointer user_data)
 {
-  if(darktable.gui->ui->thumbtable->manual_button.x != -1)
-    gtk_widget_queue_draw(darktable.gui->ui->center);
+// manual_button.x seems to always be 0, which means that anything which causes a widget redraw in either
+// side panel results in an expensive redraw request on the center view
+//  if(darktable.gui->ui->thumbtable->manual_button.x != -1)
+//    gtk_widget_queue_draw(darktable.gui->ui->center);
   return FALSE;
 }
 


### PR DESCRIPTION
I figured out why redrawn widgets in the side panels were also causing the center view to be redrawn, resulting in 40+% CPU usage (200+% with an active instance of liquify having a large warp) just from moving the mouse over the list of collections in the collection module or over the steps in the history module (both of which produce a fade-in/fade-out effect on the hovered item): the callback function for the Gtk "draw" signal on the side panels was always invoking a redraw on the center view even though it's entirely unnecessary....  With this patch, CPU usage is in the 4-5% range when moving over those modules.

I think the intent was to change the cursor when over the clickable link to the documentation that gets displayed on an empty lighttable, but it also gets called in the other views, and hovering over that link would not invoke the callback on the side panels anyway.

Since that callback is now a no-op, we could remove it entirely.  Your call.
