### PR TITLE
Fix opencl checksum calculation

### DIFF
--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -129,6 +129,7 @@ typedef struct dt_opencl_device_t
   const char *fullname;
   const char *cname;
   const char *options;
+  const char *cflags;
   cl_int summary;
   size_t memory_in_use;
   size_t peak_memory;


### PR DESCRIPTION
We must only include the cl compiler flags in the checksum calculation data but not the source location.

Fixes #18068

I think this would qualify for master and 5.0 branch