### PR TITLE
Set title bar light or dark on Windows based on theme

### DIFF
--- a/src/chart/main.c
+++ b/src/chart/main.c
@@ -36,6 +36,7 @@
 
 #ifdef _WIN32
 #include "win/main_wrapper.h"
+#include "win/dtwin.h"
 #endif
 
 const double thrs = 200.0;
@@ -575,6 +576,9 @@ static char *get_export_filename(dt_lut_t *self, const char *extension, char **n
   gtk_file_chooser_set_extra_widget(GTK_FILE_CHOOSER(dialog), grid);
 
   char *filename = NULL;
+#ifdef _WIN32
+  dtwin_set_titlebar_color(dialog);
+#endif
   int res = gtk_dialog_run(GTK_DIALOG(dialog));
   if(res == GTK_RESPONSE_ACCEPT)
   {

--- a/src/common/database.c
+++ b/src/common/database.c
@@ -34,6 +34,9 @@
 #endif
 #include "control/conf.h"
 #include "control/control.h"
+#ifdef _WIN32
+#include "win/dtwin.h"
+#endif
 
 #include <gio/gio.h>
 #include <glib.h>
@@ -4400,6 +4403,9 @@ start:
       g_free(label_text);
       gtk_container_add(GTK_CONTAINER (content_area), label);
 
+#ifdef _WIN32
+      dtwin_set_titlebar_color(content_area);
+#endif
       gtk_widget_show_all(content_area);
 
       const int resp = gtk_dialog_run(GTK_DIALOG(dialog));
@@ -4573,8 +4579,11 @@ start:
     g_free(label_text);
     gtk_container_add(GTK_CONTAINER (content_area), label);
 
+ #ifdef _WIN32
+    dtwin_set_titlebar_color(content_area);
+#endif
     gtk_widget_show_all(content_area);
-
+ 
     const int resp = gtk_dialog_run(GTK_DIALOG(dialog));
 
     gtk_widget_destroy(dialog);

--- a/src/common/film.c
+++ b/src/common/film.c
@@ -45,6 +45,9 @@
 #ifdef GDK_WINDOWING_QUARTZ
 #include "osx/osx.h"
 #endif
+#ifdef _WIN32
+#include "win/dtwin.h"
+#endif
 
 void dt_film_init(dt_film_t *film)
 {
@@ -375,6 +378,9 @@ static gboolean ask_and_delete(gpointer user_data)
 
   gtk_container_add(GTK_CONTAINER(content_area), scroll);
 
+#ifdef _WIN32
+  dtwin_set_titlebar_color(dialog);
+#endif
   gtk_widget_show_all(dialog); // needed for the content area!
 
   const gint res = gtk_dialog_run(GTK_DIALOG(dialog));

--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -1072,6 +1072,9 @@ static gboolean _dt_delete_dialog_main_thread(gpointer user_data)
         ? _("trashing error")
         : _("deletion error"));
 
+#ifdef _WIN32
+  dtwin_set_titlebar_color(dialog);
+#endif
   modal_dialog->dialog_result = gtk_dialog_run(GTK_DIALOG(dialog));
 
   if(!modal_dialog->send_to_trash)

--- a/src/gui/about.c
+++ b/src/gui/about.c
@@ -21,6 +21,9 @@
 #ifdef GDK_WINDOWING_QUARTZ
 #include "osx/osx.h"
 #endif
+#ifdef _WIN32
+#include "win/dtwin.h"
+#endif
 
 void darktable_show_about_dialog()
 {
@@ -59,7 +62,10 @@ void darktable_show_about_dialog()
                                           _("translator-credits"));
 
   gtk_window_set_transient_for(GTK_WINDOW(dialog),
-                               GTK_WINDOW(dt_ui_main_window(darktable.gui->ui)));
+                               GTK_WINDOW(dt_ui_main_window(darktable.gui->ui)));  
+#ifdef _WIN32
+  dtwin_set_titlebar_color(dialog);
+#endif
   gtk_dialog_run(GTK_DIALOG(dialog));
   gtk_widget_destroy(dialog);
 }

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -34,6 +34,9 @@
 #ifdef GDK_WINDOWING_QUARTZ
 #include "osx/osx.h"
 #endif
+#ifdef _WIN32
+#include "win/dtwin.h"
+#endif
 
 typedef struct dt_shortcut_t
 {
@@ -2522,8 +2525,11 @@ static void _restore_clicked(GtkButton *button, gpointer user_data)
        "(instead of just restoring changed ones)"));
   gtk_container_add(content_area, clear);
 
+#ifdef _WIN32
+  dtwin_set_titlebar_color(GTK_WIDGET(content_area));
+#endif
   gtk_widget_show_all(GTK_WIDGET(content_area));
-
+  
   const int resp = gtk_dialog_run(GTK_DIALOG(dialog));
   const gboolean wipe = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(clear));
 
@@ -2623,6 +2629,9 @@ static void _export_clicked(GtkButton *button, gpointer user_data)
   g_signal_connect(combo_dev, "changed", G_CALLBACK(_import_export_dev_changed), combo_id);
   g_signal_connect(combo_id, "changed", G_CALLBACK(_export_id_changed), count);
 
+#ifdef _WIN32
+  dtwin_set_titlebar_color(GTK_WIDGET(content_area));
+#endif
   gtk_widget_show_all(GTK_WIDGET(content_area));
 
   gtk_combo_box_set_active(GTK_COMBO_BOX(combo_dev), 0);
@@ -2712,6 +2721,9 @@ static void _import_clicked(GtkButton *button, gpointer user_data)
                    combo_from_id);
   g_signal_connect(combo_from_id, "changed", G_CALLBACK(_import_id_changed), combo_to_id);
 
+#ifdef _WIN32
+  dtwin_set_titlebar_color(GTK_WIDGET(content_area));
+#endif
   gtk_widget_show_all(GTK_WIDGET(content_area));
 
   gtk_combo_box_set_active(GTK_COMBO_BOX(combo_dev), 0);

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -65,6 +65,9 @@
 #ifdef GDK_WINDOWING_QUARTZ
 #include "osx/osx.h"
 #endif
+#ifdef _WIN32
+#include "win/dtwin.h"
+#endif
 #include <pthread.h>
 
 /*
@@ -1732,6 +1735,9 @@ static void _init_widgets(dt_gui_gtk_t *gui)
   // initialization is complete
 //  gtk_widget_hide(dt_ui_main_window(gui->ui));  //FIXME: on some systems, the main window never un-hides later...
 
+  // set the titlebar color on win32
+  // dt_gui_set_tittlebar_color(dt_ui_main_window(gui->ui));
+
   // finally, process all accumulated GUI events so that everything is properly
   // set up before proceeding
   for(int i = 0; i < 5; i++)
@@ -1871,6 +1877,9 @@ static void _init_main_table(GtkWidget *container)
   /* initialize right panel */
   _ui_init_panel_right(darktable.gui->ui, container);
 
+#ifdef _WIN32
+  dtwin_set_titlebar_color(container);
+#endif
   gtk_widget_show_all(container);
 
    dt_action_define(&darktable.control->actions_focus, NULL,
@@ -3004,6 +3013,9 @@ gboolean dt_gui_show_standalone_yes_no_dialog(const char *title,
     gtk_box_pack_start(GTK_BOX(hbox), button, TRUE, TRUE, 0);
   }
 
+#ifdef _WIN32
+  dtwin_set_titlebar_color(window);
+#endif
   gtk_widget_show_all(window);
 
   // to prevent the splash screen from hiding the yes/no dialog
@@ -3091,6 +3103,9 @@ char *dt_gui_show_standalone_string_dialog(const char *title,
     gtk_box_pack_start(GTK_BOX(hbox), button, TRUE, TRUE, 0);
   }
 
+#ifdef _WIN32
+  dtwin_set_titlebar_color(window);
+#endif
   gtk_widget_show_all(window);
   gtk_main();
 
@@ -3134,6 +3149,9 @@ gboolean dt_gui_show_yes_no_dialog(const char *title,
     dt_osx_disallow_fullscreen(dialog);
 #endif
 
+#ifdef _WIN32
+  dtwin_set_titlebar_color(dialog);
+#endif
   const int resp = gtk_dialog_run(GTK_DIALOG(dialog));
   gtk_widget_destroy(dialog);
   g_free(question);

--- a/src/gui/gtk.h
+++ b/src/gui/gtk.h
@@ -461,6 +461,9 @@ void dt_gui_show_help(GtkWidget *widget);
 void dt_gui_load_theme(const char *theme); // read them and add user tweaks
 void dt_gui_apply_theme();                 // apply the loaded theme to darktable's windows
 
+// set light or dark color of the titlebar on win32
+void dtwin_set_titlebar_color(GtkWidget *widget);
+
 // reload GUI scalings
 void dt_configure_ppd_dpi(dt_gui_gtk_t *gui);
 

--- a/src/gui/hist_dialog.c
+++ b/src/gui/hist_dialog.c
@@ -31,6 +31,9 @@
 #ifdef GDK_WINDOWING_QUARTZ
 #include "osx/osx.h"
 #endif
+#ifdef _WIN32
+#include "win/dtwin.h"
+#endif
 
 typedef enum _style_items_columns_t
 {
@@ -367,6 +370,9 @@ int dt_gui_hist_dialog_new(dt_history_copy_item_t *d,
 
   g_signal_connect(dialog, "response", G_CALLBACK(_gui_hist_copy_response), d);
 
+#ifdef _WIN32
+  dtwin_set_titlebar_color(GTK_WIDGET(dialog));
+#endif
   gtk_widget_show_all(GTK_WIDGET(dialog));
 
   while(1)

--- a/src/gui/preferences.c
+++ b/src/gui/preferences.c
@@ -40,6 +40,9 @@
 #ifdef GDK_WINDOWING_QUARTZ
 #include "osx/osx.h"
 #endif
+#ifdef _WIN32
+#include "win/dtwin.h"
+#endif
 #define ICON_SIZE 13
 
 typedef struct dt_gui_themetweak_widgets_t
@@ -555,6 +558,9 @@ void dt_gui_preferences_show()
   GtkGrid* lua_grid = init_tab_lua(_preferences_dialog, stack);
 #endif
 
+#ifdef _WIN32
+  dtwin_set_titlebar_color(_preferences_dialog);
+#endif
   gtk_widget_show_all(_preferences_dialog);
 
   //open in the appropriate tab if currently in darkroom or lighttable view

--- a/src/gui/presets.c
+++ b/src/gui/presets.c
@@ -34,6 +34,9 @@
 #ifdef GDK_WINDOWING_QUARTZ
 #include "osx/osx.h"
 #endif
+#ifdef _WIN32
+#include "win/dtwin.h"
+#endif
 #include <assert.h>
 #include <stdlib.h>
 
@@ -214,6 +217,9 @@ static void _edit_preset_response(GtkDialog *dialog,
 
         gtk_window_set_title(GTK_WINDOW(dlg_changename), _("unnamed preset"));
 
+#ifdef _WIN32
+        dtwin_set_titlebar_color(dlg_changename);
+#endif
         gtk_dialog_run(GTK_DIALOG(dlg_changename));
         gtk_widget_destroy(dlg_changename);
         return;
@@ -901,6 +907,9 @@ static void _presets_show_edit_dialog(dt_gui_presets_edit_dialog_t *g,
   }
 
   g_signal_connect(dialog, "response", G_CALLBACK(_edit_preset_response), g);
+#ifdef _WIN32
+  dtwin_set_titlebar_color(dialog);
+#endif
   gtk_widget_show_all(dialog);
 }
 
@@ -1524,6 +1533,9 @@ static void _menuitem_manage_quick_presets(GtkMenuItem *menuitem,
   gtk_window_set_resizable(GTK_WINDOW(dialog), TRUE);
 
   gtk_window_set_position(GTK_WINDOW(dialog), GTK_WIN_POS_CENTER_ON_PARENT);
+#ifdef _WIN32
+  dtwin_set_titlebar_color(dialog);
+#endif
   gtk_widget_show_all(dialog);
 }
 

--- a/src/gui/styles_dialog.c
+++ b/src/gui/styles_dialog.c
@@ -32,6 +32,9 @@
 #ifdef GDK_WINDOWING_QUARTZ
 #include "osx/osx.h"
 #endif
+#ifdef _WIN32
+#include "win/dtwin.h"
+#endif
 
 /* creates a styles dialog, if edit equals true id=styleid else id=imgid */
 static void _gui_styles_dialog_run(gboolean edit,
@@ -264,6 +267,9 @@ static void _gui_styles_new_style_response(GtkDialog *dialog,
       dt_osx_disallow_fullscreen(dlg_changename);
 #endif
       gtk_window_set_title(GTK_WINDOW(dlg_changename), _("unnamed style"));
+#ifdef _WIN32
+      dtwin_set_titlebar_color(dlg_changename);
+#endif
       gtk_dialog_run(GTK_DIALOG(dlg_changename));
       gtk_widget_destroy(dlg_changename);
       return;
@@ -344,6 +350,9 @@ static void _gui_styles_edit_style_response(GtkDialog *dialog,
       dt_osx_disallow_fullscreen(dlg_changename);
 #endif
       gtk_window_set_title(GTK_WINDOW(dlg_changename), _("unnamed style"));
+#ifdef _WIN32
+      dtwin_set_titlebar_color(dlg_changename);
+#endif
       gtk_dialog_run(GTK_DIALOG(dlg_changename));
       gtk_widget_destroy(dlg_changename);
       return;
@@ -883,6 +892,9 @@ static void _gui_styles_dialog_run(gboolean edit,
   else
     g_signal_connect(dialog, "response", G_CALLBACK(_gui_styles_new_style_response), sd);
 
+#ifdef _WIN32
+  dtwin_set_titlebar_color(GTK_WIDGET(dialog));
+#endif
   gtk_widget_show_all(GTK_WIDGET(dialog));
   gtk_dialog_run(GTK_DIALOG(dialog));
 

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -44,6 +44,9 @@
 #ifdef GDK_WINDOWING_QUARTZ
 #include "osx/osx.h"
 #endif
+#ifdef _WIN32
+#include "win/dtwin.h"
+#endif
 
 DT_MODULE(3)
 
@@ -3410,6 +3413,9 @@ void _menuitem_preferences(GtkMenuItem *menuitem,
 
 #ifdef GDK_WINDOWING_QUARTZ
   dt_osx_disallow_fullscreen(dialog);
+#endif
+#ifdef _WIN32
+  dtwin_set_titlebar_color(dialog);
 #endif
   gtk_widget_show_all(dialog);
   gtk_dialog_run(GTK_DIALOG(dialog));

--- a/src/libs/copy_history.c
+++ b/src/libs/copy_history.c
@@ -34,6 +34,9 @@
 #ifdef GDK_WINDOWING_QUARTZ
 #include "osx/osx.h"
 #endif
+#ifdef _WIN32
+#include "win/dtwin.h"
+#endif
 #include <gdk/gdkkeysyms.h>
 #include <gtk/gtk.h>
 #include <stdlib.h>
@@ -173,6 +176,9 @@ static void load_button_clicked(GtkWidget *widget, dt_lib_module_t *self)
                                    _("error loading file '%s'"), dtfilename);
 #ifdef GDK_WINDOWING_QUARTZ
       dt_osx_disallow_fullscreen(dialog);
+#endif
+#ifdef _WIN32
+      dtwin_set_titlebar_color(dialog);
 #endif
       gtk_dialog_run(GTK_DIALOG(dialog));
       gtk_widget_destroy(dialog);

--- a/src/libs/export_metadata.c
+++ b/src/libs/export_metadata.c
@@ -32,6 +32,9 @@
 #ifdef GDK_WINDOWING_QUARTZ
 #include "osx/osx.h"
 #endif
+#ifdef _WIN32
+#include "win/dtwin.h"
+#endif
 #include <gdk/gdkkeysyms.h>
 #include <gtk/gtk.h>
 #include <stdlib.h>
@@ -211,6 +214,9 @@ static void _add_tag_button_clicked(GtkButton *button, dt_lib_export_metadata_t 
   #ifdef GDK_WINDOWING_QUARTZ
     dt_osx_disallow_fullscreen(dialog);
   #endif
+#ifdef _WIN32
+    dtwin_set_titlebar_color(dialog);
+#endif
     gtk_widget_show_all(dialog);
   while(gtk_dialog_run(GTK_DIALOG(dialog)) == GTK_RESPONSE_ACCEPT)
   {
@@ -438,6 +444,9 @@ char *dt_lib_export_metadata_configuration_dialog(char *metadata_presets, const 
 
 #ifdef GDK_WINDOWING_QUARTZ
   dt_osx_disallow_fullscreen(dialog);
+#endif
+#ifdef _WIN32
+  dtwin_set_titlebar_color(dialog);
 #endif
   gtk_widget_show_all(dialog);
 

--- a/src/libs/geotagging.c
+++ b/src/libs/geotagging.c
@@ -34,6 +34,9 @@
 #ifdef GDK_WINDOWING_QUARTZ
 #include "osx/osx.h"
 #endif
+#ifdef _WIN32
+#include "win/dtwin.h"
+#endif
 
 #include <gdk/gdkkeysyms.h>
 
@@ -891,6 +894,9 @@ static void _preview_gpx_file(GtkWidget *widget, dt_lib_module_t *self)
 #ifdef GDK_WINDOWING_QUARTZ
   dt_osx_disallow_fullscreen(dialog);
 #endif
+#ifdef _WIN32
+  dtwin_set_titlebar_color(dialog);
+#endif
   gtk_widget_show_all(dialog);
   gtk_dialog_run(GTK_DIALOG(dialog));
 
@@ -964,6 +970,9 @@ static void _choose_gpx_callback(GtkWidget *widget, dt_lib_module_t *self)
   if(!d->imgs)
     _setup_selected_images_list(self);
 
+#ifdef _WIN32
+  dtwin_set_titlebar_color(filechooser);
+#endif
   int res = gtk_dialog_run(GTK_DIALOG(filechooser));
   while(res == GTK_RESPONSE_ACCEPT)
   {

--- a/src/libs/import.c
+++ b/src/libs/import.c
@@ -43,6 +43,7 @@
 #include "osx/osx.h"
 #endif
 #ifdef _WIN32
+#include "win/dtwin.h"
 //MSVCRT does not have strptime implemented
 #include "win/strptime.h"
 #endif
@@ -2184,11 +2185,17 @@ static void _import_from_dialog_new(dt_lib_module_t* self)
   if(d->import_case != DT_IMPORT_INPLACE)
   {
     _set_expander_content(rbox, self);
+#ifdef _WIN32
+    dtwin_set_titlebar_color(d->from.dialog);
+#endif
     gtk_widget_show_all(d->from.dialog);
     dt_gui_update_collapsible_section(&d->from.cs);
   }
   else
   {
+#ifdef _WIN32
+    dtwin_set_titlebar_color(d->from.dialog);
+#endif
     gtk_widget_show_all(d->from.dialog);
   }
 
@@ -2269,6 +2276,9 @@ static void _import_from_dialog_run(dt_lib_module_t* self)
 {
   dt_lib_import_t *d = self->data;
 
+#ifdef _WIN32
+  dtwin_set_titlebar_color(d->from.dialog);
+#endif
   while(gtk_dialog_run(GTK_DIALOG(d->from.dialog)) == GTK_RESPONSE_ACCEPT)
   {
     // reset filter so that view isn't empty

--- a/src/libs/metadata.c
+++ b/src/libs/metadata.c
@@ -31,6 +31,9 @@
 #ifdef GDK_WINDOWING_QUARTZ
 #include "osx/osx.h"
 #endif
+#ifdef _WIN32
+#include "win/dtwin.h"
+#endif
 #include <gdk/gdkkeysyms.h>
 
 DT_MODULE(4)
@@ -544,6 +547,9 @@ static void _menuitem_preferences(GtkMenuItem *menuitem,
 
 #ifdef GDK_WINDOWING_QUARTZ
   dt_osx_disallow_fullscreen(dialog);
+#endif
+#ifdef _WIN32
+  dtwin_set_titlebar_color(dialog);
 #endif
   gtk_widget_show_all(dialog);
 

--- a/src/libs/metadata_view.c
+++ b/src/libs/metadata_view.c
@@ -36,6 +36,9 @@
 #ifdef GDK_WINDOWING_QUARTZ
 #include "osx/osx.h"
 #endif
+#ifdef _WIN32
+#include "win/dtwin.h"
+#endif
 #ifdef USE_LUA
 #include "lua/call.h"
 #include "lua/image.h"
@@ -1320,6 +1323,9 @@ void _menuitem_preferences(GtkMenuItem *menuitem, dt_lib_module_t *self)
 
 #ifdef GDK_WINDOWING_QUARTZ
   dt_osx_disallow_fullscreen(dialog);
+#endif
+#ifdef _WIN32
+  dtwin_set_titlebar_color(dialog);
 #endif
   gtk_widget_show_all(dialog);
 

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -34,6 +34,9 @@
 #ifdef GDK_WINDOWING_QUARTZ
 #include "osx/osx.h"
 #endif
+#ifdef _WIN32
+#include "win/dtwin.h"
+#endif
 
 DT_MODULE(1)
 
@@ -3641,6 +3644,9 @@ static void _manage_editor_preset_action(GtkWidget *btn,
   gtk_box_pack_start(GTK_BOX(content_area), lb, FALSE, TRUE, 0);
   gtk_widget_show_all(content_area);
   gtk_entry_set_text(GTK_ENTRY(tb), new_name);
+#ifdef _WIN32
+  dtwin_set_titlebar_color(dialog);
+#endif
   res = gtk_dialog_run(GTK_DIALOG(dialog));
 
   g_free(new_name);

--- a/src/libs/recentcollect.c
+++ b/src/libs/recentcollect.c
@@ -32,6 +32,9 @@
 #ifdef GDK_WINDOWING_QUARTZ
 #include "osx/osx.h"
 #endif
+#ifdef _WIN32
+#include "win/dtwin.h"
+#endif
 
 DT_MODULE(1)
 
@@ -237,6 +240,9 @@ void _menuitem_preferences(GtkMenuItem *menuitem, dt_lib_module_t *self)
 
 #ifdef GDK_WINDOWING_QUARTZ
   dt_osx_disallow_fullscreen(dialog);
+#endif
+#ifdef _WIN32
+  dtwin_set_titlebar_color(dialog);
 #endif
   gtk_widget_show_all(dialog);
 

--- a/src/libs/styles.c
+++ b/src/libs/styles.c
@@ -33,6 +33,9 @@
 #ifdef GDK_WINDOWING_QUARTZ
 #include "osx/osx.h"
 #endif
+#ifdef _WIN32
+#include "win/dtwin.h"
+#endif
 #include <gdk/gdkkeysyms.h>
 #include <gtk/gtk.h>
 #include <stdlib.h>
@@ -494,6 +497,9 @@ static void _export_clicked(GtkWidget *w, dt_lib_styles_t *d)
 
             gtk_container_add(GTK_CONTAINER(content_area), label);
             gtk_container_add(GTK_CONTAINER(content_area), overwrite_dialog_check_button);
+#ifdef _WIN32
+            dtwin_set_titlebar_color(dialog_overwrite_export);
+#endif
             gtk_widget_show_all(dialog_overwrite_export);
 
             // disable check button and skip button when only one style is selected
@@ -647,6 +653,9 @@ static void _import_clicked(GtkWidget *w, dt_lib_styles_t *d)
 
             gtk_container_add(GTK_CONTAINER(content_area), label);
             gtk_container_add(GTK_CONTAINER(content_area), overwrite_dialog_check_button);
+#ifdef _WIN32
+            dtwin_set_titlebar_color(dialog_overwrite_import);
+#endif
             gtk_widget_show_all(dialog_overwrite_import);
 
             // disable check button and skip button when dealing with one style

--- a/src/libs/tagging.c
+++ b/src/libs/tagging.c
@@ -34,6 +34,9 @@
 #ifdef GDK_WINDOWING_QUARTZ
 #include "osx/osx.h"
 #endif
+#ifdef _WIN32
+#include "win/dtwin.h"
+#endif
 #include <gdk/gdkkeysyms.h>
 #include <math.h>
 
@@ -1557,6 +1560,9 @@ static void _pop_menu_dictionary_delete_tag(GtkWidget *menuitem, dt_lib_module_t
   #ifdef GDK_WINDOWING_QUARTZ
     dt_osx_disallow_fullscreen(dialog);
   #endif
+#ifdef _WIN32
+    dtwin_set_titlebar_color(dialog);
+#endif
     gtk_widget_show_all(dialog);
 
     res = gtk_dialog_run(GTK_DIALOG(dialog));
@@ -1651,6 +1657,9 @@ static void _pop_menu_dictionary_delete_node(GtkWidget *menuitem, dt_lib_module_
 
 #ifdef GDK_WINDOWING_QUARTZ
   dt_osx_disallow_fullscreen(dialog);
+#endif
+#ifdef _WIN32
+  dtwin_set_titlebar_color(dialog);
 #endif
   gtk_widget_show_all(dialog);
 
@@ -1764,6 +1773,9 @@ static void _pop_menu_dictionary_create_tag(GtkWidget *menuitem, dt_lib_module_t
 
 #ifdef GDK_WINDOWING_QUARTZ
   dt_osx_disallow_fullscreen(dialog);
+#endif
+#ifdef _WIN32
+  dtwin_set_titlebar_color(dialog);
 #endif
   gtk_widget_show_all(dialog);
 
@@ -1915,6 +1927,9 @@ static void _pop_menu_dictionary_edit_tag(GtkWidget *menuitem, dt_lib_module_t *
 
 #ifdef GDK_WINDOWING_QUARTZ
   dt_osx_disallow_fullscreen(dialog);
+#endif
+#ifdef _WIN32
+  dtwin_set_titlebar_color(dialog);
 #endif
   gtk_widget_show_all(dialog);
 
@@ -2167,6 +2182,9 @@ static void _pop_menu_dictionary_change_path(GtkWidget *menuitem, dt_lib_module_
 
 #ifdef GDK_WINDOWING_QUARTZ
   dt_osx_disallow_fullscreen(dialog);
+#endif
+#ifdef _WIN32
+  dtwin_set_titlebar_color(dialog);
 #endif
   gtk_widget_show_all(dialog);
 
@@ -3592,6 +3610,9 @@ void _menuitem_preferences(GtkMenuItem *menuitem, dt_lib_module_t *self)
 
 #ifdef GDK_WINDOWING_QUARTZ
   dt_osx_disallow_fullscreen(dialog);
+#endif
+#ifdef _WIN32
+  dtwin_set_titlebar_color(dialog);
 #endif
   gtk_widget_show_all(dialog);
   gtk_dialog_run(GTK_DIALOG(dialog));

--- a/src/libs/tools/global_toolbox.c
+++ b/src/libs/tools/global_toolbox.c
@@ -31,6 +31,9 @@
 #ifdef GDK_WINDOWING_QUARTZ
 #include "osx/osx.h"
 #endif
+#ifdef _WIN32
+#include "win/dtwin.h"
+#endif
 
 DT_MODULE(1)
 
@@ -671,6 +674,9 @@ static void _show_shortcuts_prefs(GtkWidget *w)
     gtk_window_resize(GTK_WINDOW(shortcuts_dialog), _shortcuts_dialog_posize.w, _shortcuts_dialog_posize.h);
   }
   g_signal_connect(G_OBJECT(shortcuts_dialog), "configure-event", G_CALLBACK(_resize_shortcuts_dialog), NULL);
+#ifdef _WIN32
+  dtwin_set_titlebar_color(shortcuts_dialog);
+#endif
   gtk_widget_show_all(shortcuts_dialog); // separately show_all content later, otherwise activates first treeview
 
   //grab the content area of the dialog

--- a/src/win/dtwin.c
+++ b/src/win/dtwin.c
@@ -17,8 +17,11 @@
 */
 
 #include "dtwin.h"
+#include <dwmapi.h>
+#include <gdk/gdkwin32.h>
 #include <setjmp.h>
 #include <windows.h>
+
 
 // Required by (at least) clang 10.0 as packaged by MSYS2 MinGW64.
 #ifdef __clang__
@@ -379,6 +382,45 @@ boolean dt_win_file_trash(GFile *file, GCancellable *cancellable, GError **error
 
   g_free(wfilename);
   return success;
+}
+
+// This is taken from: https://gitlab.gnome.org/GNOME/gimp/-/blob/master/app/widgets/gimpwidgets-utils.c#L2655
+// Set win32 title bar color based on theme (background color)
+// Note: This function explicitly realizes the widget 
+void dtwin_set_titlebar_color(GtkWidget *widget)
+{
+  HWND hwnd;
+  GdkWindow *window = NULL;
+  GtkStyleContext *style;
+  GdkRGBA *color = NULL;
+  gboolean use_dark_mode = FALSE;
+
+  gtk_widget_realize(widget); // creates GdkWindow but does not show the dialog
+  window = gtk_widget_get_window(GTK_WIDGET(widget));
+  if(window)
+  {
+    // if the background color is below the threshold, then we're
+    // likely in dark mode
+    style = gtk_widget_get_style_context(widget);
+    gtk_style_context_get(style, gtk_style_context_get_state(style),
+                          GTK_STYLE_PROPERTY_BACKGROUND_COLOR, &color,
+                          NULL);
+    if(color)
+    {
+      if(color->red * color->alpha < 0.5
+          && color->green * color->alpha < 0.5
+          && color->blue * color->alpha < 0.5)
+      {
+        use_dark_mode = TRUE;
+      }
+
+      gdk_rgba_free(color);
+    }
+
+    hwnd = (HWND) gdk_win32_window_get_handle(window);
+    DwmSetWindowAttribute(hwnd, DWMWA_USE_IMMERSIVE_DARK_MODE,
+                          &use_dark_mode, sizeof(use_dark_mode));
+  }
 }
 
 // clang-format off

--- a/src/win/dtwin.h
+++ b/src/win/dtwin.h
@@ -24,6 +24,7 @@
 const wchar_t *dtwin_get_locale();
 void dtwin_set_thread_name(DWORD dwThreadID, const char *threadName);
 boolean dt_win_file_trash(GFile *file, GCancellable *cancellable, GError **error);
+void dtwin_set_titlebar_color(GtkWidget *widget);
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py


### PR DESCRIPTION
Fixes #17392 

This implementation is based on this approach from GIMP https://gitlab.gnome.org/GNOME/gimp/-/issues/9646.
It uses `DwmSetWindowAttribute()` to set dialogue title bars to either dark or light mode on Windows. This is done by checking the dialogue's background color and setting to dark mode if it's below a threshold (currently 0.5, 0.5, 0.5).
The function `dtwin_set_titlebar_color(GtkWidget *widget)` needs to be called just before each dialog window in darktable is shown.