### PR TITLE
Fix 18194: after finding the new imgid of the overlay, use it for processing

### DIFF
--- a/src/iop/overlay.c
+++ b/src/iop/overlay.c
@@ -268,7 +268,7 @@ static void _setup_overlay(dt_iop_module_t *self,
   dt_iop_overlay_gui_data_t *g = self->gui_data;
   dt_iop_overlay_data_t *data = piece->data;
 
-  const dt_imgid_t imgid = data->imgid;
+  dt_imgid_t imgid = data->imgid;
 
   if(!p || !dt_is_valid_imgid(imgid))
     return;
@@ -286,6 +286,7 @@ static void _setup_overlay(dt_iop_module_t *self,
     {
       image_exists = TRUE;
       p->imgid = new_imgid;
+      imgid = new_imgid;
       dt_dev_add_history_item(dev, self, TRUE);
       if(g)
         gtk_widget_queue_draw(GTK_WIDGET(g->area));


### PR DESCRIPTION
Once the new `imgid` of the overlay (assigned during import) is discovered in `overlay.c#_setup_overlay`, use it when calling `_get_disabled_modules` and `dt_dev_image`.