### PR TITLE
Relax splash on top

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1618,6 +1618,8 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
       darktable_splash_screen_create(NULL, TRUE); // force the splash screen for the crawl even if user-disabled
       // scan for cases where the database and xmp files have different timestamps
       changed_xmp_files = dt_control_crawler_run();
+      if(!dt_conf_get_bool("show_splash_screen"))
+        darktable_splash_screen_destroy();
     }
   }
 
@@ -1813,20 +1815,19 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
 
   if(init_gui)
   {
+//    darktable_splash_screen_set_progress(_("loading utility modules"));
     darktable.lib = (dt_lib_t *)calloc(1, sizeof(dt_lib_t));
     dt_lib_init(darktable.lib);
 
     // init the gui part of views
+//    darktable_splash_screen_set_progress(_("loading views"));
     dt_view_manager_gui_init(darktable.view_manager);
 
-    // now that other initialization is complete, we can show the main window
+    // start by loading the main window position as stored in the config file
     // we need to do this before Lua is started or we'll either get a hang, or
     // the module groups don't get set up correctly
-
-    // start by restoring the main window position as stored in the config file
     dt_gui_gtk_load_config();
-    gtk_widget_show_all(dt_ui_main_window(darktable.gui->ui));
-    // give Gtk a chance to actually process the resizing
+
     dt_gui_process_events();
   }
 
@@ -1911,6 +1912,7 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
     if(changed_xmp_files)
       dt_control_crawler_show_image_list(changed_xmp_files);
 
+    gtk_widget_show_all(dt_ui_main_window(darktable.gui->ui));
     darktable_splash_screen_destroy();
 
     if(!dt_gimpmode())

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1815,12 +1815,12 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
 
   if(init_gui)
   {
-//    darktable_splash_screen_set_progress(_("loading utility modules"));
+    darktable_splash_screen_set_progress(_("loading utility modules"));
     darktable.lib = (dt_lib_t *)calloc(1, sizeof(dt_lib_t));
     dt_lib_init(darktable.lib);
 
     // init the gui part of views
-//    darktable_splash_screen_set_progress(_("loading views"));
+    darktable_splash_screen_set_progress(_("loading views"));
     dt_view_manager_gui_init(darktable.view_manager);
 
     // start by loading the main window position as stored in the config file

--- a/src/gui/splash.c
+++ b/src/gui/splash.c
@@ -257,7 +257,6 @@ void darktable_splash_screen_create(GtkWindow *parent_window,
   gtk_window_set_decorated(GTK_WINDOW(splash_screen), FALSE);
   gtk_widget_show_all(splash_screen);
   gtk_widget_hide(GTK_WIDGET(remaining_box));
-  gtk_window_set_keep_above(GTK_WINDOW(splash_screen), TRUE);
   _process_all_gui_events();
 }
 


### PR DESCRIPTION
While we possibly spend a lot of time (like in xmp crawler ...) while having the splash screen open users might want to do other work but the splash requested to be "above" prohibits that.

So let us **not** interfere in WM/user actions.

See #18209 

__________________________________________________________
Other options "how-to-fix" might be `gtk_window_set_keep_above(GTK_WINDOW(splash_screen), FALSE)` after some timeout or alike.