### PR TITLE
Fix crash after deleting style or preset that was selected in shortcuts dialog

### DIFF
--- a/src/common/styles.c
+++ b/src/common/styles.c
@@ -1025,7 +1025,7 @@ void dt_styles_apply_to_dev(const char *name, const dt_imgid_t imgid)
   dt_control_log(_("applied style `%s' on current image"), name);
 }
 
-void dt_styles_delete_by_name_adv(const char *name, const gboolean raise)
+void dt_styles_delete_by_name_adv(const char *name, const gboolean raise, const gboolean shortcut)
 {
   int id = 0;
   if((id = dt_styles_get_id_by_name(name)) != 0)
@@ -1047,9 +1047,12 @@ void dt_styles_delete_by_name_adv(const char *name, const gboolean raise)
     sqlite3_step(stmt);
     sqlite3_finalize(stmt);
 
-    dt_action_t *old = dt_action_locate(&darktable.control->actions_global,
-                                        (gchar *[]){"styles", (gchar *)name, NULL}, FALSE);
-    dt_action_rename(old, NULL);
+    if(shortcut)
+    {
+      dt_action_t *old = dt_action_locate(&darktable.control->actions_global,
+                                          (gchar *[]){"styles", (gchar *)name, NULL}, FALSE);
+      dt_action_rename(old, NULL);
+    }
 
     if(raise)
       DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_STYLE_CHANGED);
@@ -1058,7 +1061,7 @@ void dt_styles_delete_by_name_adv(const char *name, const gboolean raise)
 
 void dt_styles_delete_by_name(const char *name)
 {
-  dt_styles_delete_by_name_adv(name, TRUE);
+  dt_styles_delete_by_name_adv(name, TRUE, FALSE);
 }
 
 GList *dt_styles_get_item_list(const char *name,

--- a/src/common/styles.h
+++ b/src/common/styles.h
@@ -107,7 +107,7 @@ void dt_styles_apply_to_image(const char *name,
 void dt_styles_apply_to_dev(const char *name, const dt_imgid_t imgid);
 
 /** delete a style by name */
-void dt_styles_delete_by_name_adv(const char *name, const gboolean raise);
+void dt_styles_delete_by_name_adv(const char *name, const gboolean raise, const gboolean shortcut);
 
 /** delete a style by name, raise signal */
 void dt_styles_delete_by_name(const char *name);

--- a/src/dtgtk/stylemenu.c
+++ b/src/dtgtk/stylemenu.c
@@ -16,6 +16,7 @@
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include "control/control.h"
 #include "common/act_on.h"
 #include "common/styles.h"
 #include "common/utility.h"
@@ -45,8 +46,6 @@ static gboolean _styles_tooltip_callback(GtkWidget* self,
     dt_dev_write_history(dev);
 
   GtkWidget *ht = dt_gui_style_content_dialog(name, imgid);
-
-  g_object_set_data_full(G_OBJECT(self), "dt-preset-name", g_strdup(name), g_free);
 
   return dt_shortcut_tooltip_callback(self, x, y, keyboard_mode, tooltip, ht);
 }
@@ -94,6 +93,7 @@ static void _build_style_submenus(GtkMenuShell *menu,
       g_signal_connect_data(mi, "query-tooltip",
                             G_CALLBACK(_styles_tooltip_callback),
                             g_strdup(style_name), (GClosureNotify)g_free, 0);
+      dt_action_define(&darktable.control->actions_global, "styles", style_name, GTK_WIDGET(mi), NULL);
     }
     else
       gtk_widget_set_has_tooltip(GTK_WIDGET(mi), FALSE);

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -1316,6 +1316,8 @@ static void _remove_shortcut(GSequenceIter *shortcut)
   dt_shortcut_t *s = g_sequence_get(shortcut);
   if(!s) return;
 
+  _selected_shortcut = NULL;
+
   gboolean disabled = s->views == DT_VIEW_NONE;
   if(s->is_default)
   {

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -870,8 +870,7 @@ static gboolean _find_relative_instance(dt_action_t *action,
 }
 
 static gchar *_shortcut_lua_command(GtkWidget *widget,
-                                    dt_shortcut_t *s,
-                                    gchar *preset_name)
+                                    dt_shortcut_t *s)
 {
   const dt_action_element_def_t *elements = _action_find_elements(s->action);
 
@@ -924,7 +923,7 @@ static gchar *_shortcut_lua_command(GtkWidget *widget,
 
 void _shortcut_copy_lua(GtkWidget *widget, dt_shortcut_t *shortcut, gchar *preset_name)
 {
-  gchar *lua_command = _shortcut_lua_command(widget, shortcut, preset_name);
+  gchar *lua_command = _shortcut_lua_command(widget, shortcut);
   if(!lua_command) return;
   gtk_clipboard_set_text(gtk_clipboard_get_default(gdk_display_get_default()), lua_command, -1);
   dt_control_log(_("Lua script command copied to clipboard:\n\n<tt>%s</tt>"), lua_command);
@@ -1006,7 +1005,6 @@ gboolean dt_shortcut_tooltip_callback(GtkWidget *widget,
 
   gchar *original_markup =
     dt_bauhaus_widget_get_tooltip_markup(widget, darktable.control->element);
-  gchar *preset_name = g_object_get_data(G_OBJECT(widget), "dt-preset-name");
   const gchar *widget_name = gtk_widget_get_name(widget);
 
   if(!strcmp(widget_name, "actions_view") || !strcmp(widget_name, "shortcuts_view"))
@@ -1067,21 +1065,6 @@ gboolean dt_shortcut_tooltip_callback(GtkWidget *widget,
          "\n\nwith fallbacks enabled, the same shortcut can be used with additional modifiers"
          "\nor mouse scroll/clicks/moves to affect a different element or change the effect or speed."
          : "");
-    }
-  }
-  else if(preset_name)
-  {
-    dt_action_t *module = g_object_get_data(G_OBJECT(widget), "dt-preset-module");
-    if(!module)
-    {
-      action = dt_action_locate(&darktable.control->actions_global,
-                                (gchar *[]){"styles", (gchar *)preset_name, NULL}, FALSE);
-    }
-    else
-    {
-      if(module->type == DT_ACTION_TYPE_IOP_INSTANCE)
-        module = &((dt_iop_module_t*)module)->so->actions;
-      action = dt_action_locate(module, (gchar *[]){"preset", preset_name, NULL}, FALSE);
     }
   }
   else
@@ -1185,7 +1168,7 @@ gboolean dt_shortcut_tooltip_callback(GtkWidget *widget,
   if(markup_text)
   {
     if(action) lua_shortcut.action = action;
-    gchar *lua_command = _shortcut_lua_command(widget, &lua_shortcut, preset_name);
+    gchar *lua_command = _shortcut_lua_command(widget, &lua_shortcut);
     if(lua_command)
     {
       gchar *lua_escaped = g_markup_printf_escaped("\n\nLua: <tt>%s</tt>%s %s", lua_command,
@@ -1417,7 +1400,8 @@ static gboolean _insert_shortcut(dt_shortcut_t *shortcut,
                                  const gboolean confirm,
                                  const gboolean disable)
 {
-  if(!shortcut->speed && shortcut->effect != DT_ACTION_EFFECT_SET)
+  if((!shortcut->speed && shortcut->effect != DT_ACTION_EFFECT_SET)
+     || shortcut->action->type == DT_ACTION_TYPE_SECTION)
     return FALSE;
 
   dt_shortcut_t *s = calloc(sizeof(dt_shortcut_t), 1);

--- a/src/gui/presets.c
+++ b/src/gui/presets.c
@@ -1325,6 +1325,7 @@ static void _menuitem_connect_preset(GtkWidget *mi,
 {
   g_object_set_data_full(G_OBJECT(mi), "dt-preset-name", g_strdup(name), g_free);
   g_object_set_data(G_OBJECT(mi), "dt-preset-module", iop);
+  dt_action_define(&iop->so->actions, "preset", name, mi, NULL);
   g_signal_connect(G_OBJECT(mi), "activate",
                    G_CALLBACK(_menuitem_activate_preset), iop);
   g_signal_connect(G_OBJECT(mi), "button-press-event",

--- a/src/libs/lib.c
+++ b/src/libs/lib.c
@@ -507,6 +507,7 @@ static void dt_lib_presets_popup_menu_show(dt_lib_module_info_t *minfo,
     }
     g_object_set_data_full(G_OBJECT(mi), "dt-preset-name", g_strdup(name), g_free);
     g_object_set_data(G_OBJECT(mi), "dt-preset-module", minfo->module);
+    dt_action_define(&minfo->module->actions, "preset", name, mi, NULL);
 
     g_signal_connect(G_OBJECT(mi), "activate",
                      G_CALLBACK(_menuitem_activate_preset), minfo);

--- a/src/libs/styles.c
+++ b/src/libs/styles.c
@@ -410,8 +410,6 @@ static void _delete_clicked(GtkWidget *w, dt_lib_styles_t *d)
   if(style_names == NULL) return;
 
   const gint select_cnt = g_list_length(style_names);
-  const gboolean single_raise = (select_cnt == 1);
-
   const gboolean can_delete = _ask_before_delete_style(select_cnt);
 
   if(can_delete)
@@ -420,14 +418,9 @@ static void _delete_clicked(GtkWidget *w, dt_lib_styles_t *d)
 
     for(const GList *style = style_names; style; style = g_list_next(style))
     {
-      dt_styles_delete_by_name_adv((char*)style->data, single_raise);
+      dt_styles_delete_by_name_adv((char*)style->data, !g_list_next(style), TRUE);
     }
 
-    if(!single_raise) {
-      // raise signal at the end of processing all styles if we have more than 1 to delete
-      // this also calls _gui_styles_update_view
-      DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_STYLE_CHANGED);
-    }
     dt_database_release_transaction(darktable.db);
   }
   g_list_free_full(style_names, g_free);
@@ -989,7 +982,7 @@ void gui_reset(dt_lib_module_t *self)
     for(const GList *result = all_styles; result; result = g_list_next(result))
     {
       dt_style_t *style = result->data;
-      dt_styles_delete_by_name_adv((char*)style->name, FALSE);
+      dt_styles_delete_by_name_adv((char*)style->name, FALSE, TRUE);
     }
     DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_STYLE_CHANGED);
   }


### PR DESCRIPTION
fixes #18241 (both the crash (which could also happen when deleting presets, and the styles shortcut being removed when overwriting).

This also cherry-picks a commit from ancil that shows tooltips assigned to styles when hovering over them in the styles module and allows assigning shortcuts in visual mapping mode (or directly going to the style in shortcuts dialog by selecting mapping mode and clicking on the style in the module's list). @TurboGit you may find this too invasive for 5.0.1