### PR TITLE
Discard history: only detach tags which are attached

### DIFF
--- a/src/common/tags.c
+++ b/src/common/tags.c
@@ -644,7 +644,8 @@ gboolean dt_tag_detach_by_string(const char *name,
      "SELECT tagid"
      " FROM main.tagged_images as ti, data.tags as t"
      " WHERE ti.tagid = t.id"
-     "   AND t.name GLOB ?1",
+     "   AND t.name GLOB ?1"
+     "   AND ti.imgid = ?2",
      -1, &stmt,
      NULL);
 
@@ -661,6 +662,7 @@ gboolean dt_tag_detach_by_string(const char *name,
   }
 
   DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 1, n, -1, SQLITE_TRANSIENT);
+  DT_DEBUG_SQLITE3_BIND_INT(stmt, 2, imgid);
 
   gboolean res = FALSE;
 


### PR DESCRIPTION
Fixes #18246

In `tags.c#dt_tag_detach_by_string`, we ask for all darktable style tags -- and now we have hundreds of those, thanks to the camera styles. And then we try to detach them one by one. With this patch, we add the image ID to the query, only retrieving those tags that are attached and need to be removed.

On my local machine (SATA SSD for the DB, SATA HDD for the images), discarding the history of 175 images too seconds; however, I did see about 23.000 SQL statements logged.
After that operation, there is just one entry per image in tagged_images. Before, there were 362.

$ grep -c "SELECT DISTINCT T.id  FROM main.tagged_images AS I  JOIN data.tags T on T.id = I.tagid" /tmp/discard-history-master 
9071
$ grep -c "DELETE FROM.*tagged_images" /tmp/discard-history-master 
187
$ grep -c "SELECT DISTINCT T.id  FROM main.tagged_images AS I  JOIN data.tags T on T.id = I.tagid" /tmp/discard-history-with-patch 
187
$ grep -c "DELETE FROM.*tagged_images" /tmp/discard-history-with-patch 
187

