### PR TITLE
Fix details mask tiling issues

### DIFF
--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -119,7 +119,8 @@ typedef enum dt_iop_flags_t
   IOP_FLAGS_GUIDES_SPECIAL_DRAW = 1 << 14, // handle the grid drawing directly
   IOP_FLAGS_GUIDES_WIDGET = 1 << 15,     // require the guides widget
   IOP_FLAGS_CROP_EXPOSER = 1 << 16,      // offers crop exposing
-  IOP_FLAGS_EXPAND_ROI_IN = 1 << 17      // we might have to take special care about roi expansion
+  IOP_FLAGS_EXPAND_ROI_IN = 1 << 17,     // we might have to take special care about roi expansion
+  IOP_FLAGS_WRITE_DETAILS = 1 << 18
 } dt_iop_flags_t;
 
 /** status of a module*/

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -300,7 +300,7 @@ int default_group()
 
 int flags()
 {
-  return IOP_FLAGS_ALLOW_TILING | IOP_FLAGS_ONE_INSTANCE | IOP_FLAGS_FENCE;
+  return IOP_FLAGS_ALLOW_TILING | IOP_FLAGS_ONE_INSTANCE | IOP_FLAGS_FENCE | IOP_FLAGS_WRITE_DETAILS;
 }
 
 dt_iop_colorspace_type_t default_colorspace(dt_iop_module_t *self,

--- a/src/iop/rawprepare.c
+++ b/src/iop/rawprepare.c
@@ -107,7 +107,7 @@ int operation_tags()
 int flags()
 {
   return IOP_FLAGS_ALLOW_TILING | IOP_FLAGS_TILING_FULL_ROI | IOP_FLAGS_ONE_INSTANCE
-    | IOP_FLAGS_UNSAFE_COPY;
+    | IOP_FLAGS_UNSAFE_COPY | IOP_FLAGS_WRITE_DETAILS;
 }
 
 int default_group()


### PR DESCRIPTION
If rawprepare or demosaic run in tiled mode they can't write the details mask, that would require a rewrite of those modules with a special tiled process implementation.

As we set the piece->pipe->want_detail_mask while committing params and that comes *after* the mask writing modules we must check via _piece_may_tile() if we must a) fallback to cpu code or b) process CPU code but at least leave a note.
Used a flag for that check instead of string compare.