### PR TITLE
fix memleak for styles popup

### DIFF
--- a/src/libs/export.c
+++ b/src/libs/export.c
@@ -1166,10 +1166,12 @@ static void _update_style(const dt_stylemenu_data_t *menu_data)
 static void _apply_style_activate_callback(GtkMenuItem *menuitem,
                                            const dt_stylemenu_data_t *menu_data)
 {
-  if(gtk_get_current_event()->type == GDK_KEY_PRESS)
+  GdkEvent *event = gtk_get_current_event();
+  if(event && event->type == GDK_KEY_PRESS)
   {
     _update_style(menu_data);
   }
+  gdk_event_free(event);
 }
 
 static gboolean _apply_style_button_callback(GtkMenuItem *menuitem,

--- a/src/libs/print_settings.c
+++ b/src/libs/print_settings.c
@@ -1186,10 +1186,12 @@ static void _update_style(const dt_stylemenu_data_t *menu_data)
 static void _apply_style_activate_callback(GtkMenuItem *menuitem,
                                            const dt_stylemenu_data_t *menu_data)
 {
-  if(gtk_get_current_event()->type == GDK_KEY_PRESS)
+  GdkEvent *event = gtk_get_current_event();
+  if(event && event->type == GDK_KEY_PRESS)
   {
     _update_style(menu_data);
   }
+  gdk_event_free(event);
 }
 
 static gboolean _apply_style_button_callback(GtkMenuItem *menuitem,


### PR DESCRIPTION
gtk_get_current_event() returns a copy which must be freed, but wasn't.  It is also documented as potentially returning NULL, so add a null check as well.

Pointed out by Diederik on 18186.
