### PR TITLE
Lua labels respect panel width

### DIFF
--- a/src/lua/widget/button.c
+++ b/src/lua/widget/button.c
@@ -138,6 +138,8 @@ static int label_member(lua_State *L)
       gtk_label_set_ellipsize(GTK_LABEL(gtk_bin_get_child(GTK_BIN(button->widget))), ellipsize_store.mode);
       ellipsize_store.used = FALSE;
     }
+    else
+      gtk_label_set_ellipsize(GTK_LABEL(gtk_bin_get_child(GTK_BIN(button->widget))), PANGO_ELLIPSIZE_END);
     if(halign_store.used)
     {
       gtk_widget_set_halign(GTK_WIDGET(GTK_LABEL(gtk_bin_get_child(GTK_BIN(button->widget)))), halign_store.halign);

--- a/src/lua/widget/check_button.c
+++ b/src/lua/widget/check_button.c
@@ -42,6 +42,7 @@ static int label_member(lua_State *L)
   if(lua_gettop(L) > 2) {
     const char * label = luaL_checkstring(L,3);
     gtk_button_set_label(GTK_BUTTON(check_button->widget),label);
+    gtk_label_set_ellipsize(GTK_LABEL(gtk_bin_get_child(GTK_BIN(check_button->widget))), PANGO_ELLIPSIZE_END);
     return 0;
   }
   lua_pushstring(L,gtk_button_get_label(GTK_BUTTON(check_button->widget)));

--- a/src/lua/widget/label.c
+++ b/src/lua/widget/label.c
@@ -34,6 +34,7 @@ static int label_member(lua_State *L)
   if(lua_gettop(L) > 2) {
     const char * text = luaL_checkstring(L, 3);
     gtk_label_set_text(GTK_LABEL(label->widget), text);
+    gtk_label_set_ellipsize(GTK_LABEL(label->widget), PANGO_ELLIPSIZE_END);
     return 0;
   }
   lua_pushstring(L, gtk_label_get_text(GTK_LABEL(label->widget)));

--- a/src/lua/widget/section_label.c
+++ b/src/lua/widget/section_label.c
@@ -43,6 +43,7 @@ static int section_label_member(lua_State *L)
   if(lua_gettop(L) > 2) {
     const char * text = luaL_checkstring(L,3);
     gtk_label_set_text(GTK_LABEL(label->widget),text);
+    gtk_label_set_ellipsize(GTK_LABEL(label->widget), PANGO_ELLIPSIZE_END);
     return 0;
   }
   lua_pushstring(L,gtk_label_get_text(GTK_LABEL(label->widget)));


### PR DESCRIPTION
set label defaults to have PANGO_ELLIPSIZE_END set so that side panels don't expand and contract based on label length

Fixes #16124 @dterrahe added conversation.