### PR TITLE
Remove prefer performance over quality preference setting

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -238,13 +238,6 @@
     <shortdescription>darktable resources</shortdescription>
     <longdescription>defines how much darktable may take from your system resources:\n - 'default': darktable takes ~50% of your systems resources, which is enough to be performant.\n - 'small': should be used if you are simultaneously running applications taking large parts of your systems memory or OpenCL/GL applications like games or Hugin.\n - 'large': is the best option if you are not running other applications at the same time as darktable and want it to take most of your systems resources for performance.</longdescription>
   </dtconfig>
-  <dtconfig prefs="processing" section="cpugpu">
-    <name>ui/performance</name>
-    <type>bool</type>
-    <default>false</default>
-    <shortdescription>prefer performance over quality</shortdescription>
-    <longdescription>if switched on, thumbnails and previews are rendered at lower quality but 4 times faster</longdescription>
-  </dtconfig>
   <dtconfig>
     <name>backthumbs_inactivity</name>
     <type>float</type>

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -2339,13 +2339,6 @@ void dt_configure_runtime_performance(const int old, char *info)
 
   // All runtime conf settings only write data if there is no valid
   // data found in conf
-  if(!dt_conf_key_not_empty("ui/performance"))
-  {
-    dt_conf_set_bool("ui/performance", !sufficient);
-    dt_print(DT_DEBUG_DEV,
-             "[dt_configure_runtime_performance] ui/performance=%s",
-             (sufficient) ? "FALSE" : "TRUE");
-  }
 
   if(!dt_conf_key_not_empty("resourcelevel"))
   {

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -1167,7 +1167,7 @@ static void _open_url(GtkWidget *widget, gpointer url)
 }
 #endif
 
-// This is based on GIMP's implementation: 
+// This is based on GIMP's implementation:
 // https://gitlab.gnome.org/GNOME/gimp/-/blob/master/app/widgets/gimpwidgets-utils.c#L2655
 // Set win32 title bar color based on theme (background color).
 #ifdef _WIN32
@@ -1180,7 +1180,7 @@ static void _window_set_titlebar_color_callback(GtkWidget *widget)
     if(style)
     {
       GdkRGBA *bg_color = NULL;
-      gtk_style_context_get(style, GTK_STATE_FLAG_NORMAL, 
+      gtk_style_context_get(style, GTK_STATE_FLAG_NORMAL,
                             GTK_STYLE_PROPERTY_BACKGROUND_COLOR, &bg_color, NULL);
       if(bg_color)
       {
@@ -1649,13 +1649,7 @@ void dt_configure_ppd_dpi(dt_gui_gtk_t *gui)
 
   gui->ppd = gui->ppd_thb = dt_get_system_gui_ppd(widget);
   gui->filter_image = CAIRO_FILTER_GOOD;
-  if(dt_conf_get_bool("ui/performance"))
-  {
-      gui->ppd_thb *= DT_GUI_THUMBSIZE_REDUCE;
-      gui->filter_image = CAIRO_FILTER_FAST;
-  }
-
-   gui->dpi = dt_get_screen_resolution(widget);
+  gui->dpi = dt_get_screen_resolution(widget);
 
 #ifdef GDK_WINDOWING_QUARTZ
   gui->dpi_factor

--- a/src/imageio/imageio.c
+++ b/src/imageio/imageio.c
@@ -1052,18 +1052,11 @@ gboolean dt_imageio_export_with_flags(const dt_imgid_t imgid,
   if(history_end != -1)
     dt_dev_pop_history_items_ext(&dev, history_end);
 
-  const gboolean buf_is_downscaled =
-    (thumbnail_export && dt_conf_get_bool("ui/performance"));
-
   if(!thumbnail_export)
     dt_set_backthumb_time(600.0); // make sure we don't interfere
 
   dt_mipmap_buffer_t buf;
-  if(buf_is_downscaled)
-    dt_mipmap_cache_get(darktable.mipmap_cache, &buf, imgid,
-                        DT_MIPMAP_F, DT_MIPMAP_BLOCKING, 'r');
-  else
-    dt_mipmap_cache_get(darktable.mipmap_cache, &buf, imgid,
+  dt_mipmap_cache_get(darktable.mipmap_cache, &buf, imgid,
                         DT_MIPMAP_FULL, DT_MIPMAP_BLOCKING, 'r');
 
   const dt_image_t *img = &dev.image_storage;


### PR DESCRIPTION
As time goes by ... this preference setting reduces lighttable user experience in a significant way, on any "dt usable" system we would not want this anymore.

Also for the benefit of removing a preference setting and users being possibly irritated about pixelated thumbs.