### PR TITLE
icon to display tags list

### DIFF
--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -4922,7 +4922,7 @@ static void _exif_xmp_read_data(Exiv2::XmpData &xmpData,
     xmpData.add(Exiv2::XmpKey("Xmp.dc.subject"), v1.get());
   g_list_free_full(tags, g_free);
 
-  GList *hierarchical = dt_tag_get_hierarchical(imgid);
+  GList *hierarchical = dt_tag_get_hierarchical(imgid, FALSE);
   for(GList *hier = hierarchical; hier; hier = g_list_next(hier))
   {
     v2->read((char *)hier->data);

--- a/src/common/tags.c
+++ b/src/common/tags.c
@@ -937,12 +937,12 @@ GList *dt_tag_get_list(const dt_imgid_t imgid)
   return dt_util_glist_uniq(tags);
 }
 
-GList *dt_tag_get_hierarchical(const dt_imgid_t imgid)
+GList *dt_tag_get_hierarchical(const dt_imgid_t imgid, const gboolean ignore_dt_tags)
 {
   GList *taglist = NULL;
   GList *tags = NULL;
 
-  const uint32_t count = dt_tag_get_attached(imgid, &taglist, FALSE);
+  const uint32_t count = dt_tag_get_attached(imgid, &taglist, ignore_dt_tags);
 
   if(count < 1)
     return NULL;

--- a/src/common/tags.h
+++ b/src/common/tags.h
@@ -177,7 +177,7 @@ GList *dt_tag_get_list_export(const dt_imgid_t imgid,
 /** get a flat list of only hierarchical tags, the difference to
  *  dt_tag_get_attached() is that this one filters out the
  *  "darktable|" tags. */
-GList *dt_tag_get_hierarchical(const dt_imgid_t imgid);
+GList *dt_tag_get_hierarchical(const dt_imgid_t imgid, const gboolean ignore_dt_tags);
 
 /** get a flat list of only hierarchical tags, the difference to
  *  dt_tag_get_hierarchical() is that this one checks option for

--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -1872,6 +1872,28 @@ void dtgtk_cairo_paint_altered(cairo_t *cr, gint x, gint y, gint w, gint h, gint
   FINISH
 }
 
+void dtgtk_cairo_paint_tags(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
+{
+  PREAMBLE(1, 1, 0, 0)
+
+      cairo_move_to(cr, 0.4, 0.05);
+      cairo_line_to(cr, 0.6, 0.3);
+      cairo_line_to(cr, 0.6, 0.8);
+      cairo_line_to(cr, 0.2, 0.8);
+      cairo_line_to(cr, 0.2, 0.3);
+      cairo_line_to(cr, 0.4, 0.05);
+
+      cairo_move_to(cr, 0.6, 0.1);
+      cairo_line_to(cr, 0.8, 0.4);
+      cairo_line_to(cr, 0.8, 0.9);
+      cairo_line_to(cr, 0.4, 0.9);
+
+      cairo_stroke(cr);
+
+  FINISH
+}
+
+
 void dtgtk_cairo_paint_audio(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
   PREAMBLE(1, 1, 0, 0)

--- a/src/dtgtk/paint.h
+++ b/src/dtgtk/paint.h
@@ -139,6 +139,8 @@ void dtgtk_cairo_paint_star(cairo_t *cr, gint x, gint y, gint w, gint h, gint fl
 void dtgtk_cairo_paint_unratestar(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 /** Paint an altered icon on thumbs */
 void dtgtk_cairo_paint_altered(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
+/** Paint an tags icon on thumbs */
+void dtgtk_cairo_paint_tags(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 /** Paint an audio icon on thumbs */
 void dtgtk_cairo_paint_audio(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 /** Paint a colorlabel "flower" icon on thumbs */

--- a/src/dtgtk/thumbnail.c
+++ b/src/dtgtk/thumbnail.c
@@ -79,6 +79,22 @@ static void _thumb_update_extended_infos_line(dt_thumbnail_t *thumb)
   g_free(pattern);
 }
 
+static void _thumb_update_tags_tooltip(dt_thumbnail_t *thumb)
+{
+  const gboolean ignore_dt_tags = !dt_conf_get_bool("plugins/lighttable/tagging/dttags");
+  char *tooltip = dt_util_glist_to_str("\n", dt_tag_get_hierarchical(thumb->imgid, ignore_dt_tags));
+  if(tooltip)
+  {
+    gtk_widget_set_tooltip_text(thumb->w_tags, tooltip);
+    thumb->has_tags = TRUE;
+    g_free(tooltip);
+  }
+  else
+  {
+    thumb->has_tags = FALSE;
+  }
+}
+
 static void _thumb_update_altered_tooltip(dt_thumbnail_t *thumb)
 {
   thumb->is_altered = dt_image_altered(thumb->imgid);
@@ -881,6 +897,8 @@ static void _thumb_update_icons(dt_thumbnail_t *thumb)
   _set_flag(thumb->w_main, GTK_STATE_FLAG_SELECTED, thumb->selected);
 
   gtk_widget_set_visible(thumb->w_altered, thumb->is_altered);
+  _thumb_update_tags_tooltip(thumb);
+  gtk_widget_set_visible(thumb->w_tags, thumb->has_tags);
 }
 
 static gboolean _thumbs_hide_overlays(gpointer user_data)
@@ -900,6 +918,7 @@ static gboolean _thumbs_hide_overlays(gpointer user_data)
   gtk_widget_hide(thumb->w_color);
   gtk_widget_hide(thumb->w_local_copy);
   gtk_widget_hide(thumb->w_altered);
+  gtk_widget_hide(thumb->w_tags);
   gtk_widget_hide(thumb->w_group);
   gtk_widget_hide(thumb->w_audio);
   gtk_widget_hide(thumb->w_zoom_eb);
@@ -1253,7 +1272,10 @@ static gboolean _event_btn_enter_leave(GtkWidget *widget,
   if(thumb->disable_actions)
     return TRUE;
   if(event->type == GDK_ENTER_NOTIFY)
+  {
     _set_flag(thumb->w_image_box, GTK_STATE_FLAG_PRELIGHT, TRUE);
+    _thumb_update_tags_tooltip(thumb);
+  }
   return FALSE;
 }
 
@@ -1574,6 +1596,18 @@ GtkWidget *dt_thumbnail_create_widget(dt_thumbnail_t *thumb,
                      G_CALLBACK(_event_btn_enter_leave), thumb);
     gtk_overlay_add_overlay(GTK_OVERLAY(overlays_parent), thumb->w_altered);
 
+    // the tags icon
+    thumb->w_tags = dtgtk_thumbnail_btn_new(dtgtk_cairo_paint_tags, 0, NULL);
+    gtk_widget_set_name(thumb->w_tags, "thumb-tags");
+    gtk_widget_set_valign(thumb->w_tags, GTK_ALIGN_START);
+    gtk_widget_set_halign(thumb->w_tags, GTK_ALIGN_END);
+    gtk_widget_set_no_show_all(thumb->w_tags, TRUE);
+    g_signal_connect(G_OBJECT(thumb->w_tags), "enter-notify-event",
+                     G_CALLBACK(_event_btn_enter_leave), thumb);
+    g_signal_connect(G_OBJECT(thumb->w_tags), "leave-notify-event",
+                     G_CALLBACK(_event_btn_enter_leave), thumb);
+    gtk_overlay_add_overlay(GTK_OVERLAY(overlays_parent), thumb->w_tags);
+
     // the group bouton
     thumb->w_group = dtgtk_thumbnail_btn_new(dtgtk_cairo_paint_grouping, 0, NULL);
     gtk_widget_set_name(thumb->w_group, "thumb-group-audio");
@@ -1697,6 +1731,7 @@ dt_thumbnail_t *dt_thumbnail_new(const int width,
   _image_update_group_tooltip(thumb);
   _thumb_update_tooltip_text(thumb);
   _thumb_update_altered_tooltip(thumb);
+  _thumb_update_tags_tooltip(thumb);
 
   // get the file extension
   _thumb_write_extension(thumb);
@@ -1837,17 +1872,23 @@ static void _thumb_resize_overlays(dt_thumbnail_t *thumb)
     gtk_widget_set_margin_top(thumb->w_altered, thumb->img_margin->top);
     gtk_widget_set_margin_end(thumb->w_altered, thumb->img_margin->right);
 
+    // the tags icon
+    gtk_widget_set_size_request(thumb->w_tags, 2.0 * r1, 2.0 * r1);
+    gtk_widget_set_halign(thumb->w_tags, GTK_ALIGN_END);
+    gtk_widget_set_margin_top(thumb->w_tags, thumb->img_margin->top);
+    gtk_widget_set_margin_end(thumb->w_tags, thumb->img_margin->right + 2.5 * r1);
+
     // the group bouton
     gtk_widget_set_size_request(thumb->w_group, 2.0 * r1, 2.0 * r1);
     gtk_widget_set_halign(thumb->w_group, GTK_ALIGN_END);
     gtk_widget_set_margin_top(thumb->w_group, thumb->img_margin->top);
-    gtk_widget_set_margin_end(thumb->w_group, thumb->img_margin->right + 2.5 * r1);
+    gtk_widget_set_margin_end(thumb->w_group, thumb->img_margin->right + 5.0 * r1);
 
     // the sound icon
     gtk_widget_set_size_request(thumb->w_audio, 2.0 * r1, 2.0 * r1);
     gtk_widget_set_halign(thumb->w_audio, GTK_ALIGN_END);
     gtk_widget_set_margin_top(thumb->w_audio, thumb->img_margin->top);
-    gtk_widget_set_margin_end(thumb->w_audio, thumb->img_margin->right + 5.0 * r1);
+    gtk_widget_set_margin_end(thumb->w_audio, thumb->img_margin->right + 7.5 * r1);
 
     // the filmstrip cursor
     gtk_widget_set_size_request(thumb->w_cursor, 6.0 * r1, 1.5 * r1);
@@ -1949,12 +1990,17 @@ static void _thumb_resize_overlays(dt_thumbnail_t *thumb)
     gtk_widget_set_size_request(thumb->w_local_copy, icon_size2, icon_size2);
     gtk_widget_set_halign(thumb->w_local_copy, GTK_ALIGN_START);
     gtk_widget_set_margin_top(thumb->w_local_copy, line3 + py);
-    gtk_widget_set_margin_start(thumb->w_local_copy, 10.0 * r1 + px);
+    gtk_widget_set_margin_start(thumb->w_local_copy, 13.0 * r1 + px);
     // the altered icon
     gtk_widget_set_size_request(thumb->w_altered, icon_size2, icon_size2);
     gtk_widget_set_halign(thumb->w_altered, GTK_ALIGN_START);
     gtk_widget_set_margin_top(thumb->w_altered, line3 + py);
-    gtk_widget_set_margin_start(thumb->w_altered, 7.0 * r1 + px);
+    gtk_widget_set_margin_start(thumb->w_altered, 10.0 * r1 + px);
+    // the tags icon
+    gtk_widget_set_size_request(thumb->w_tags, icon_size2, icon_size2);
+    gtk_widget_set_halign(thumb->w_tags, GTK_ALIGN_START);
+    gtk_widget_set_margin_top(thumb->w_tags, line3 + py);
+    gtk_widget_set_margin_start(thumb->w_tags, 7.0 * r1 + px);
     // the group bouton
     gtk_widget_set_size_request(thumb->w_group, icon_size2, icon_size2);
     gtk_widget_set_halign(thumb->w_group, GTK_ALIGN_START);
@@ -2194,6 +2240,7 @@ void dt_thumbnail_set_overlay(dt_thumbnail_t *thumb,
     _widget_change_parent_overlay(thumb->w_color, overlays_parent);
     _widget_change_parent_overlay(thumb->w_local_copy, overlays_parent);
     _widget_change_parent_overlay(thumb->w_altered, overlays_parent);
+    _widget_change_parent_overlay(thumb->w_tags, overlays_parent);
     _widget_change_parent_overlay(thumb->w_group, overlays_parent);
     _widget_change_parent_overlay(thumb->w_audio, overlays_parent);
     _widget_change_parent_overlay(thumb->w_zoom_eb, overlays_parent);

--- a/src/dtgtk/thumbnail.h
+++ b/src/dtgtk/thumbnail.h
@@ -87,6 +87,7 @@ typedef struct
   gchar *info_line;
   gboolean is_altered;
   gboolean has_audio;
+  gboolean has_tags;
   gboolean is_grouped;
   gboolean is_bw;
   gboolean is_bw_flow;
@@ -116,6 +117,7 @@ typedef struct
   GtkWidget *w_local_copy; // GtkDarktableThumbnailBtn -- localcopy triangle
   GtkWidget *w_altered;    // GtkDarktableThumbnailBtn -- Altered icon
   GtkWidget *w_group;      // GtkDarktableThumbnailBtn -- Grouping icon
+  GtkWidget *w_tags;       // GtkDarktableThumbnailBtn -- Tags icon
   GtkWidget *w_audio;      // GtkDarktableThumbnailBtn -- Audio sidecar icon
 
   GtkWidget *w_zoom_eb; // GtkEventBox -- container for the zoom level widget

--- a/src/views/view.h
+++ b/src/views/view.h
@@ -159,7 +159,8 @@ typedef enum dt_view_image_over_t
   DT_VIEW_GROUP   =  7,
   DT_VIEW_AUDIO   =  8,
   DT_VIEW_ALTERED =  9,
-  DT_VIEW_END     = 10, // placeholder for the end of the list
+  DT_VIEW_TAGS    = 10,
+  DT_VIEW_END     = 11, // placeholder for the end of the list
 } dt_view_image_over_t;
 
 /** returns an uppercase string of file extension **plus** some flag information **/


### PR DESCRIPTION
Hello. This PR adds a tags icon ![изображение](https://github.com/user-attachments/assets/74b2b718-c5c2-4770-aac1-2556faf274d8) to thumbnails. 

Hovering over it displays a list of tags. 
![tag1](https://github.com/user-attachments/assets/023e2cd7-1175-4512-9598-4ba925bdfc22)

If the list is empty, the icon is hidden.
![tag2](https://github.com/user-attachments/assets/8f353af3-282a-4880-8fe6-fe166974ab02)

Monitors the hidden tags option. 
![tag3](https://github.com/user-attachments/assets/63c17f6e-eed6-465f-9c65-e1cf8177eab0)


Works in filmstrip.
![tag4](https://github.com/user-attachments/assets/6623f995-23b8-4e7e-8288-28892190ad24)

Thanks.