### PR TITLE
[README.md] Fix minimum required pugixml version as rawspeed requires 1.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Required dependencies (minimum version):
 * libcurl 7.56
 * libpng 1.5.0 *(for PNG import & export, also for reading LUT files in PNG format)*
 * Exiv2 0.27.2 *(but at least 0.27.4 built with ISO BMFF support needed for Canon CR3 raw import)*
-* pugixml 1.5
+* pugixml 1.8
 
 Required dependencies (no version requirement):
 * Lensfun *(for automatic lens correction)* (Note: alpha 0.3.95 and git master branch are not supported)


### PR DESCRIPTION
See https://github.com/darktable-org/rawspeed/blob/develop/cmake/src-dependencies.cmake#L121