### PR TITLE
RFC: Don't offer OpenCL "use all GPU memory"

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -366,12 +366,12 @@
     <shortdescription>OpenCL scheduling profile</shortdescription>
     <longdescription>defines how preview and full pixelpipe tasks are scheduled on OpenCL enabled systems:\n - 'default': GPU processes full and CPU processes preview pipe (adaptable by config parameters),\n - 'multiple GPUs': process both pixelpipes in parallel on two different GPUs,\n - 'very fast GPU': process both pixelpipes sequentially on the GPU.</longdescription>
   </dtconfig>
-  <dtconfig prefs="processing" section="opencl" capability="opencl">
+  <dtconfig prefs="processing" section="opencl" capability="multiopencl">
     <name>opencl_tune_headroom</name>
     <type>bool</type>
     <default>false</default>
-    <shortdescription>use all GPU memory</shortdescription>
-    <longdescription>if enabled darktable will use all graphics device memory except a safety margin (headroom, default is 600MB)</longdescription>
+    <shortdescription>tuned GPU memory</shortdescription>
+    <longdescription>if enabled on a system with multiple opencl devices you may specify a safety margin per device (headroom, default is 600MB)</longdescription>
   </dtconfig>
   <dtconfig prefs="processing" section="platform" capability="nonapple" restart="true">
     <name>clplatform_intelropenclhdgraphics</name>

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -334,7 +334,6 @@ typedef struct dt_sys_resources_t
   int *fractions;   // fractions are calculated as res=input / 1024  * fraction
   int *refresource; // for the debug resource modes we use fixed settings
   int level;
-  gboolean tunehead;
 } dt_sys_resources_t;
 
 typedef struct dt_backthumb_t

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -837,14 +837,10 @@ static gboolean _opencl_device_init(dt_opencl_t *cl,
     goto end;
   }
 
-  dt_sys_resources_t *resrc = &darktable.dtresources;
   dt_print_nts(DT_DEBUG_OPENCL,
                "   ASYNC PIXELPIPE:          %s\n", cl->dev[dev].asyncmode ? "YES" : "NO");
   dt_print_nts(DT_DEBUG_OPENCL,
                "   PINNED MEMORY TRANSFER:   %s\n", cl->dev[dev].pinned_memory ? "YES" : "NO");
-  if(resrc->tunehead)
-    dt_print_nts(DT_DEBUG_OPENCL,
-               "   USE HEADROOM:             %iMb\n", cl->dev[dev].headroom);
   dt_print_nts(DT_DEBUG_OPENCL,
                "   AVOID ATOMICS:            %s\n", cl->dev[dev].avoid_atomics ? "YES" : "NO");
   dt_print_nts(DT_DEBUG_OPENCL,
@@ -1449,6 +1445,8 @@ finally:
   if(cl->inited)
   {
     dt_capabilities_add("opencl");
+    if(cl->num_devs > 1)
+      dt_capabilities_add("multiopencl");
     cl->blendop = dt_develop_blend_init_cl_global();
     cl->bilateral = dt_bilateral_init_cl_global();
     cl->gaussian = dt_gaussian_init_cl_global();
@@ -3543,7 +3541,8 @@ void dt_opencl_check_tuning(const int devid)
   if(!_cldev_running(devid)) return;
 
   const int level = res->level;
-  const gboolean tunehead = level >= 0
+  const gboolean tunehead = cl->num_devs > 1
+                          && level >= 0
                           && !dt_gimpmode()
                           && dt_conf_get_bool("opencl_tune_headroom");
 


### PR DESCRIPTION
The "use all GPU memory" preferences option is not helping for darktable OpenCL stability at all and won't give a significant performance gain in the vast majority of settings. Quite a number of dt failing issues on pixls.us forum are directly related to this.

It should only be used in situations with more than one OpenCL device to allow specific tuning for the non-desktop devices.

So let's get rid of this option if there is only one device.

BTW, we can still modify the preferences setting per level ...

