### PR TITLE
Fix YAML bug report template to avoid syntax errors

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -118,7 +118,7 @@ body:
     attributes:
       label: What is the version of your OS?
       description: Please fill out the distro or OS version from the previous dropdown
-      placeholder: like: Fedora 40, Ubuntu 24.10, Windows 11 Pro, MacOS 14 Sonoma
+      placeholder: "like: Fedora 40, Ubuntu 24.10, Windows 11 Pro, MacOS 14 Sonoma"
     validations:
       required: true
 


### PR DESCRIPTION
This template worked initially, but it seems that GitHub has recently tightened up the syntax checking (or changed the way parameter values ​​are interpreted in YAML).