### PR TITLE
Fix UI to display translated style names.

### DIFF
--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -365,6 +365,8 @@ typedef struct darktable_t
   GList *iop_order_list;
   GList *iop_order_rules;
   GList *capabilities;
+  GHashTable *styles_table;
+
   JsonParser *noiseprofile_parser;
   struct dt_conf_t *conf;
   struct dt_develop_t *develop;


### PR DESCRIPTION
When a built-in style is applied from the button in lighttable or darkroom the name is displyed to the user translated instead of the cryptic "_l10n_darktable|_l10n_examples|_l10n_..."

Also, the styles listed into the global preferences where it is possible to assigned them a shortcut are displayed fully translated.

Closed #18325.