### PR TITLE
view.c: Refresh the culling view only when in lighttable.

### DIFF
--- a/src/views/view.c
+++ b/src/views/view.c
@@ -1149,13 +1149,15 @@ void dt_view_lighttable_culling_init_mode(dt_view_manager_t *vm)
 
 void dt_view_lighttable_culling_preview_refresh(dt_view_manager_t *vm)
 {
-  if(vm->proxy.lighttable.module)
+  if(vm->proxy.lighttable.module
+     && dt_view_get_current() == DT_VIEW_LIGHTTABLE)
     vm->proxy.lighttable.culling_preview_refresh(vm->proxy.lighttable.view);
 }
 
 void dt_view_lighttable_culling_preview_reload_overlays(dt_view_manager_t *vm)
 {
-  if(vm->proxy.lighttable.module)
+  if(vm->proxy.lighttable.module
+     && dt_view_get_current() == DT_VIEW_LIGHTTABLE)
     vm->proxy.lighttable.culling_preview_reload_overlays(vm->proxy.lighttable.view);
 }
 


### PR DESCRIPTION
This is to avoid a jump in the filmstrip while in darkroom.

To reproduce, have a set of non edited image.

- On lighttable select one and press 'f' (goes in full preview).
- Type 'd' to do to darkroom.
- Select another picture using the filmstrip (double-click).
- Apply and iop change.
- See the jump of selected image in filmstrip to first image.

Closes ##18351.