### PR TITLE
[imageio] Implement the correct orientation support for JPEG XL images

### DIFF
--- a/src/imageio/imageio_jpegxl.c
+++ b/src/imageio/imageio_jpegxl.c
@@ -174,6 +174,14 @@ dt_imageio_retval_t dt_imageio_open_jpegxl(dt_image_t *img,
         return DT_IMAGEIO_FILE_CORRUPTED;
       }
 
+      // Orientation values in JXL basic info match Exif definitions
+      img->orientation = dt_image_orientation_to_flip_bits(basicinfo.orientation);
+
+      // We don't re-orient the data during decoding, this will be done later
+      // by darktable according to the metadata value (this value can be
+      // either the one obtained above or the value read from Exif data)
+      JxlDecoderSetKeepOrientation(decoder, JXL_TRUE);
+
       uint32_t num_threads =
         JxlResizableParallelRunnerSuggestThreads(basicinfo.xsize,
                                                  basicinfo.ysize);


### PR DESCRIPTION
The ground truth regarding JPEG XL images that contain orientation data are of course images from image capturing devices (photo cameras and cameraphones). But at the moment we do not have such cameras or smartphone apps that create images in JPEG XL format.

Currently, the most direct way to convert JPEG images (that contain Exif orientation data) to JPEG XL format is the cjxl utility from the libjxl standard library. This utility places orientation data in the format's own metadata and also keeps it in the Exif data.

This seems logical. It is also logical that if we have the orientation recorded in 2 places, we should not apply it twice. This is exactly what this PR does.

We instruct the decoder not to apply this transformation during the decoding process. This will avoid double transformation if the same information is recorded in the Exif data. But we don't ignore the JPEG XL metadata completely, but copy it into the data for darktable orientation module. This will also allow us to do the right thing in the absence of Exif.
