### PR TITLE
don't set top margin on module header unless it has actually changed

### DIFF
--- a/src/dtgtk/expander.c
+++ b/src/dtgtk/expander.c
@@ -280,9 +280,13 @@ static gboolean _adjust_header_position(GtkWidget *widget, cairo_t *cr, GtkWidge
   GtkAdjustment *adjustment = gtk_scrolled_window_get_vadjustment(GTK_SCROLLED_WINDOW(sw));
   gdouble value = gtk_adjustment_get_value(adjustment);
 
-  gtk_widget_set_margin_top(header,
-    CLAMP(value - allocation.y, 0, allocation.height - gtk_widget_get_allocated_height(header)));
-  dt_gui_widget_reallocate_now(widget);
+  int curr_margin_top = gtk_widget_get_margin_top(header);
+  int new_margin_top = CLAMP(value - allocation.y, 0, allocation.height - gtk_widget_get_allocated_height(header));
+  if(new_margin_top != curr_margin_top)
+  {
+    gtk_widget_set_margin_top(header, new_margin_top);
+    dt_gui_widget_reallocate_now(widget);
+  }
 
   return FALSE;
 }

--- a/src/dtgtk/expander.c
+++ b/src/dtgtk/expander.c
@@ -280,8 +280,9 @@ static gboolean _adjust_header_position(GtkWidget *widget, cairo_t *cr, GtkWidge
   GtkAdjustment *adjustment = gtk_scrolled_window_get_vadjustment(GTK_SCROLLED_WINDOW(sw));
   gdouble value = gtk_adjustment_get_value(adjustment);
 
-  int curr_margin_top = gtk_widget_get_margin_top(header);
-  int new_margin_top = CLAMP(value - allocation.y, 0, allocation.height - gtk_widget_get_allocated_height(header));
+  const int curr_margin_top = gtk_widget_get_margin_top(header);
+  const int new_margin_top = CLAMP(value - allocation.y, 0,
+                                   allocation.height - gtk_widget_get_allocated_height(header));
   if(new_margin_top != curr_margin_top)
   {
     gtk_widget_set_margin_top(header, new_margin_top);


### PR DESCRIPTION
This eliminates an infinite refresh loop in the GUI.

Fixes #18374 

It seems that we have an architectural problem, since this is the second time I've fixed an infinite refresh loop by limiting a widget update to only take place when the particular attribute has actually changed its value.  I haven't been able to track it down, but it's pretty clear that the handling of the "draw" signal for the sidebar eventually requests all (expanded?) modules to refresh their display, and if any of them actually update any of their widgets, a redraw of the sidebar is triggered, starting the process all over again.
