### PR TITLE
add alert to hazeremoval if HQ processing is disabled

### DIFF
--- a/src/iop/hazeremoval.c
+++ b/src/iop/hazeremoval.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2017-2024 darktable developers.
+    Copyright (C) 2017-2025 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -80,6 +80,7 @@ typedef struct dt_iop_hazeremoval_gui_data_t
 {
   GtkWidget *strength;
   GtkWidget *distance;
+  GtkWidget *alert;
   rgb_pixel A0;
   float distance_max;
   dt_hash_t hash;
@@ -225,6 +226,8 @@ void gui_update(dt_iop_module_t *self)
   g->A0[1] = NAN;
   g->A0[2] = NAN;
   g->hash = 0;
+  if(self->dev)
+    gtk_widget_set_visible(g->alert, !self->dev->late_scaling.enabled);
   dt_iop_gui_leave_critical_section(self);
 }
 
@@ -254,6 +257,12 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_slider_set_digits(g->distance, 3);
   gtk_widget_set_tooltip_text(g->distance,
                               _("limit haze removal up to a specific spatial depth"));
+  g->alert = gtk_label_new(_("HQ processing must be enabled for correct preview"));
+  gtk_widget_set_name(g->alert,"alert");
+  gtk_label_set_line_wrap(GTK_LABEL(g->alert), TRUE);
+  if(self->dev)
+    gtk_widget_set_visible(g->alert, !self->dev->late_scaling.enabled);
+  gtk_box_pack_start(GTK_BOX(self->widget), g->alert, TRUE, TRUE, 0);
 }
 
 


### PR DESCRIPTION
Candidate for addressing #18384.

The module's gui_update() function doesn't ever seem to be called, so right now the alert message's visibility is only set when first opening the image in darkroom.
