### PR TITLE
Revert fixed panel header

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -95,11 +95,6 @@ changes (where available).
       by default reenable the workaround for drivers that need them,
       or warn people with antiquated drivers that they need to update.
 
-- When part of a module has scrolled off the top of the panel, now its
-  header will remain visible, so it for example can be clicked on to
-  collapse the module. This is especially useful when dealing with
-  long modules with masks.
-
 - Presets can now be arranged in sub menus, like styles can, by
   inserting | in their name between levels. The shortcuts
   dialog/preferences tab now show these collapsible hierarchies for

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -585,7 +585,6 @@ dialog .sidebar row:selected:hover label,
 #module-header
 {
   border-bottom: 1px solid @plugin_bg_color;
-  background-color: @bg_color;
   padding: 0.5em;
 }
 

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -2503,10 +2503,9 @@ void dt_iop_gui_set_expanded(dt_iop_module_t *module,
     while(iop)
     {
       dt_iop_module_t *m = iop->data;
-      if(m != module && m->expander && (dt_iop_shown_in_group(m, current_group) || !group_only))
+      if(m != module && (dt_iop_shown_in_group(m, current_group) || !group_only))
       {
         all_other_closed = all_other_closed && !m->expanded;
-        gtk_widget_set_margin_top(DTGTK_EXPANDER(m->expander)->header_evb, 0); // don't scroll to module if at top
         _gui_set_single_expanded(m, FALSE);
       }
 

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -2429,7 +2429,6 @@ static GtkWidget *_ui_init_panel_container_center(GtkWidget *container,
   gtk_widget_set_name(widget, "plugins_vbox_left");
   gtk_container_add(GTK_CONTAINER(container), widget);
   g_signal_connect_swapped(widget, "draw", G_CALLBACK(_side_panel_draw), NULL);
-  g_signal_connect_swapped(gtk_scrolled_window_get_vadjustment(GTK_SCROLLED_WINDOW(container)), "value-changed", G_CALLBACK(gtk_widget_queue_draw), widget);
 
   GtkWidget *empty = gtk_event_box_new();
   gtk_widget_set_tooltip_text(empty, _("right-click to show/hide modules"));


### PR DESCRIPTION
@TurboGit please revert #18323 with this PR

The approach I used has severe problems that our testing didn't reveal and that are not solvable without triggering other problems. #18381 is not one of those; it is easy to prevent (see #18379). But I haven't been able to solve #18375 (which happens when starting without any expanded headers) without many gtk-warning at startup. Even when the headers eventually show (you can press B to trigger a redraw) changing the font size causes many warnings on the command line again.

In the end, gtk just gets very confused when resizing widgets within event boxes after they have been realized and this confused internal state triggers warnings. I'll either have to abandon the idea or come with a different approach (maybe temporarily reparenting the topmost header, which is likely to open its own can of worms).