### PR TITLE
Make use of DT_INVALID_CACHEHASH

### DIFF
--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -225,7 +225,7 @@ void dt_masks_gui_form_remove(dt_masks_form_t *form,
                               const int index)
 {
   dt_masks_form_gui_points_t *gpt = g_list_nth_data(gui->points, index);
-  gui->pipe_hash = 0;
+  gui->pipe_hash = DT_INVALID_CACHEHASH;
   gui->formid = NO_MASKID;
 
   if(gpt)
@@ -245,12 +245,12 @@ void dt_masks_gui_form_test_create(dt_masks_form_t *form,
                                    dt_iop_module_t *module)
 {
   // we test if the image has changed
-  if(gui->pipe_hash > 0)
+  if(gui->pipe_hash != DT_INVALID_CACHEHASH)
   {
     if(gui->pipe_hash != darktable.develop->preview_pipe->backbuf_hash)
     {
       dt_print(DT_DEBUG_EXPOSE, "[dt_masks_gui_form_test_create] refreshes mask visualizer");
-      gui->pipe_hash = 0;
+      gui->pipe_hash = DT_INVALID_CACHEHASH;
       gui->formid = NO_MASKID;
       g_list_free_full(gui->points, dt_masks_form_gui_points_free);
       gui->points = NULL;
@@ -258,7 +258,7 @@ void dt_masks_gui_form_test_create(dt_masks_form_t *form,
   }
 
   // we create the spots if needed
-  if(gui->pipe_hash == 0)
+  if(gui->pipe_hash == DT_INVALID_CACHEHASH)
   {
     if(form->type & DT_MASKS_GROUP)
     {
@@ -1289,7 +1289,8 @@ void dt_masks_clear_form_gui(dt_develop_t *dev)
   dt_masks_dynbuf_free(dev->form_gui->guipoints_payload);
   dev->form_gui->guipoints_payload = NULL;
   dev->form_gui->guipoints_count = 0;
-  dev->form_gui->pipe_hash = dev->form_gui->formid = 0;
+  dev->form_gui->pipe_hash = DT_INVALID_CACHEHASH;
+  dev->form_gui->formid = 0;
   dev->form_gui->dx = dev->form_gui->dy = 0.0f;
   dev->form_gui->scrollx = dev->form_gui->scrolly = 0.0f;
   dev->form_gui->form_selected = dev->form_gui->border_selected =

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -263,7 +263,7 @@ gboolean dt_dev_pixelpipe_init_cached(dt_dev_pixelpipe_t *pipe,
   pipe->output_profile_info = NULL;
   pipe->runs = 0;
   pipe->bcache_data = NULL;
-  pipe->bcache_hash = 0;
+  pipe->bcache_hash = DT_INVALID_CACHEHASH;
   return dt_dev_pixelpipe_cache_init(pipe, entries, size, memlimit);
 }
 
@@ -435,7 +435,7 @@ void dt_dev_pixelpipe_create_nodes(dt_dev_pixelpipe_t *pipe,
     piece->module = module;
     piece->pipe = pipe;
     piece->data = NULL;
-    piece->hash = 0;
+    piece->hash = DT_INVALID_CACHEHASH;
     piece->process_cl_ready = FALSE;
     piece->process_tiling_ready = FALSE;
     piece->raster_masks = g_hash_table_new_full(g_direct_hash,
@@ -579,7 +579,7 @@ void dt_dev_pixelpipe_synch_all(dt_dev_pixelpipe_t *pipe, dt_develop_t *dev)
   for(GList *nodes = pipe->nodes; nodes; nodes = g_list_next(nodes))
   {
     dt_dev_pixelpipe_iop_t *piece = nodes->data;
-    piece->hash = 0;
+    piece->hash = DT_INVALID_CACHEHASH;
     piece->enabled = piece->module->default_enabled;
     dt_iop_commit_params(piece->module,
                          piece->module->default_params,
@@ -2227,7 +2227,7 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
         if(success_opencl)
         {
           const gboolean relevant = _piece_fast_blend(piece, module);
-          const dt_hash_t phash = relevant ? _piece_process_hash(piece, roi_out, module, pos) : 0;
+          const dt_hash_t phash = relevant ? _piece_process_hash(piece, roi_out, module, pos) : DT_INVALID_CACHEHASH;
           const gboolean bcaching = relevant ? pipe->bcache_data && phash == pipe->bcache_hash : FALSE;
           dt_print_pipe(DT_DEBUG_PIPE,
                         bcaching ? "from focus cache" : "process tiled",

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -5731,7 +5731,7 @@ void reload_defaults(dt_iop_module_t *self)
     g->buf_x_off = 0;
     g->buf_y_off = 0;
     g->buf_scale = 1.0f;
-    g->buf_hash = 0;
+    g->buf_hash = DT_INVALID_CACHEHASH;
     g->isflipped = -1;
     g->lastfit = ASHIFT_FIT_NONE;
     dt_iop_gui_leave_critical_section(self);
@@ -5742,8 +5742,8 @@ void reload_defaults(dt_iop_module_t *self)
     g->lines_count =0;
     g->horizontal_count = 0;
     g->vertical_count = 0;
-    g->grid_hash = 0;
-    g->lines_hash = 0;
+    g->grid_hash = DT_INVALID_CACHEHASH;
+    g->lines_hash = DT_INVALID_CACHEHASH;
     g->rotation_range = ROTATION_RANGE_SOFT;
     g->lensshift_v_range = LENSSHIFT_RANGE_SOFT;
     g->lensshift_h_range = LENSSHIFT_RANGE_SOFT;
@@ -5936,7 +5936,7 @@ void gui_init(dt_iop_module_t *self)
   g->buf_x_off = 0;
   g->buf_y_off = 0;
   g->buf_scale = 1.0f;
-  g->buf_hash = 0;
+  g->buf_hash = DT_INVALID_CACHEHASH;
   g->isflipped = -1;
   g->lastfit = ASHIFT_FIT_NONE;
   dt_iop_gui_leave_critical_section(self);
@@ -5951,8 +5951,8 @@ void gui_init(dt_iop_module_t *self)
   g->points_idx = NULL;
   g->points_lines_count = 0;
   g->points_version = 0;
-  g->grid_hash = 0;
-  g->lines_hash = 0;
+  g->grid_hash = DT_INVALID_CACHEHASH;
+  g->lines_hash = DT_INVALID_CACHEHASH;
   g->rotation_range = ROTATION_RANGE_SOFT;
   g->lensshift_v_range = LENSSHIFT_RANGE_SOFT;
   g->lensshift_h_range = LENSSHIFT_RANGE_SOFT;

--- a/src/iop/clipping.c
+++ b/src/iop/clipping.c
@@ -1352,7 +1352,7 @@ static void _event_preview_updated_callback(gpointer instance, dt_iop_module_t *
 
   DT_CONTROL_SIGNAL_DISCONNECT(_event_preview_updated_callback, self);
   // force max size to be recomputed
-  g->clip_max_pipe_hash = 0;
+  g->clip_max_pipe_hash = DT_INVALID_CACHEHASH;
 }
 
 void gui_focus(dt_iop_module_t *self, gboolean in)
@@ -1390,7 +1390,7 @@ void gui_focus(dt_iop_module_t *self, gboolean in)
       self->dev->gui_module = self;
       commit_box(self, g, p);
       self->dev->gui_module = old_gui;
-      g->clip_max_pipe_hash = 0;
+      g->clip_max_pipe_hash = DT_INVALID_CACHEHASH;
     }
   }
   else if(in)
@@ -2084,7 +2084,7 @@ void gui_init(dt_iop_module_t *self)
   g->clip_w = g->clip_h = 1.0;
   g->clip_max_x = g->clip_max_y = 0.0;
   g->clip_max_w = g->clip_max_h = 1.0;
-  g->clip_max_pipe_hash = 0;
+  g->clip_max_pipe_hash = DT_INVALID_CACHEHASH;
   g->cropping = 0;
   g->straightening = 0;
   g->applied = 1;

--- a/src/iop/colorreconstruction.c
+++ b/src/iop/colorreconstruction.c
@@ -1193,7 +1193,7 @@ void gui_update(dt_iop_module_t *self)
   dt_iop_gui_enter_critical_section(self);
   dt_iop_colorreconstruct_bilateral_dump(g->can);
   g->can = NULL;
-  g->hash = 0;
+  g->hash = DT_INVALID_CACHEHASH;
   dt_iop_gui_leave_critical_section(self);
 }
 
@@ -1225,7 +1225,7 @@ void gui_init(dt_iop_module_t *self)
   dt_iop_colorreconstruct_gui_data_t *g = IOP_GUI_ALLOC(colorreconstruct);
 
   g->can = NULL;
-  g->hash = 0;
+  g->hash = DT_INVALID_CACHEHASH;
 
   GtkWidget *box_enabled = self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
 

--- a/src/iop/crop.c
+++ b/src/iop/crop.c
@@ -452,7 +452,7 @@ static void _event_preview_updated_callback(gpointer instance, dt_iop_module_t *
   DT_CONTROL_SIGNAL_DISCONNECT(_event_preview_updated_callback, self);
 
   // force max size to be recomputed
-  g->clip_max_pipe_hash = 0;
+  g->clip_max_pipe_hash = DT_INVALID_CACHEHASH;
 }
 
 void gui_focus(dt_iop_module_t *self, gboolean in)
@@ -485,7 +485,7 @@ void gui_focus(dt_iop_module_t *self, gboolean in)
       self->dev->gui_module = self;
       _commit_box(self, g, p);
       self->dev->gui_module = old_gui;
-      g->clip_max_pipe_hash = 0;
+      g->clip_max_pipe_hash = DT_INVALID_CACHEHASH;
     }
   }
   else if(in)
@@ -1135,7 +1135,7 @@ void gui_init(dt_iop_module_t *self)
   g->clip_w = g->clip_h = 1.0;
   g->clip_max_x = g->clip_max_y = 0.0;
   g->clip_max_w = g->clip_max_h = 1.0;
-  g->clip_max_pipe_hash = 0;
+  g->clip_max_pipe_hash = DT_INVALID_CACHEHASH;
   g->cropping = GRAB_CENTER;
   g->shift_hold = FALSE;
   g->ctrl_hold = FALSE;

--- a/src/iop/globaltonemap.c
+++ b/src/iop/globaltonemap.c
@@ -216,7 +216,7 @@ static inline void process_drago(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *
     // is -FLT_MAX which initiates special handling below to avoid inconsistent results. in all
     // other cases we make sure that the preview pipe has left us with proper readings for
     // lwmax. if data are not yet there we need to wait (with timeout).
-    if(hash != 0 && !dt_dev_sync_pixelpipe_hash(self->dev, piece->pipe, self->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL, &self->gui_lock, &g->hash))
+    if(hash != DT_INVALID_CACHEHASH && !dt_dev_sync_pixelpipe_hash(self->dev, piece->pipe, self->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL, &self->gui_lock, &g->hash))
       dt_control_log(_("inconsistent output"));
 
     dt_iop_gui_enter_critical_section(self);
@@ -371,7 +371,7 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
       dt_iop_gui_enter_critical_section(self);
       const dt_hash_t hash = g->hash;
       dt_iop_gui_leave_critical_section(self);
-      if(hash != 0 && !dt_dev_sync_pixelpipe_hash(self->dev, piece->pipe, self->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL, &self->gui_lock, &g->hash))
+      if(hash != DT_INVALID_CACHEHASH && !dt_dev_sync_pixelpipe_hash(self->dev, piece->pipe, self->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL, &self->gui_lock, &g->hash))
         dt_control_log(_("inconsistent output"));
 
       dt_iop_gui_enter_critical_section(self);
@@ -630,7 +630,7 @@ void gui_update(dt_iop_module_t *self)
 
   dt_iop_gui_enter_critical_section(self);
   g->lwmax = -FLT_MAX;
-  g->hash = 0;
+  g->hash = DT_INVALID_CACHEHASH;
   dt_iop_gui_leave_critical_section(self);
 }
 
@@ -639,7 +639,7 @@ void gui_init(dt_iop_module_t *self)
   dt_iop_global_tonemap_gui_data_t *g = IOP_GUI_ALLOC(global_tonemap);
 
   g->lwmax = -FLT_MAX;
-  g->hash = 0;
+  g->hash = DT_INVALID_CACHEHASH;
 
   g->operator = dt_bauhaus_combobox_from_params(self, N_("operator"));
   gtk_widget_set_tooltip_text(g->operator, _("the global tonemap operator"));

--- a/src/iop/hazeremoval.c
+++ b/src/iop/hazeremoval.c
@@ -587,7 +587,7 @@ void process(dt_iop_module_t *self,
     // cases we make sure that the preview pipe has left us with
     // proper readings for distance_max and A0.  If data are not yet
     // there we need to wait (with timeout).
-    if(hash != 0
+    if(hash != DT_INVALID_CACHEHASH
        && !dt_dev_sync_pixelpipe_hash(self->dev, piece->pipe, self->iop_order,
                                       DT_DEV_TRANSFORM_DIR_BACK_INCL,
                                       &self->gui_lock, &g->hash))
@@ -846,7 +846,7 @@ int process_cl(dt_iop_module_t *self,
     // cases we make sure that the preview pipe has left us with
     // proper readings for distance_max and A0.  If data are not yet
     // there we need to wait (with timeout).
-    if(hash != 0
+    if(hash != DT_INVALID_CACHEHASH
        && !dt_dev_sync_pixelpipe_hash(self->dev, piece->pipe,
                                       self->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL,
                                       &self->gui_lock, &g->hash))

--- a/src/iop/levels.c
+++ b/src/iop/levels.c
@@ -353,7 +353,7 @@ static void commit_params_late(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *pi
       // contains NANs which initiates special handling below to avoid inconsistent results. in all
       // other cases we make sure that the preview pipe has left us with proper readings for
       // g->auto_levels[]. if data are not yet there we need to wait (with timeout).
-      if(hash != 0 && !dt_dev_sync_pixelpipe_hash(self->dev, piece->pipe, self->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL, &self->gui_lock, &g->hash))
+      if(hash != DT_INVALID_CACHEHASH && !dt_dev_sync_pixelpipe_hash(self->dev, piece->pipe, self->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL, &self->gui_lock, &g->hash))
         dt_control_log(_("inconsistent output"));
 
       dt_iop_gui_enter_critical_section(self);


### PR DESCRIPTION
While setting a hash or comparing vs invalid hash make use of the #defined value instead of magic 0