### PR TITLE
[imageio] [DAM] Hard-code the correct crop factor for Canon EOS 5D Mark IV

### DIFF
--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -87,6 +87,9 @@ using namespace std;
 // For these models we can't calculate the correct crop factor or, for some we could, but we
 // prefer to take it from here, rather than complicate the calculation code with exceptions
 static const struct dt_model_cropfactor dt_cropfactors[] = {
+  {.model = "Canon EOS 5D Mark IV", // tags contain incorrect data, so formula gives us incorrect result
+   .cropfactor = 1.0f
+  },
   {.model = "FinePix SL1000", // exiv2 doesn't yet read the tags we need to calculate correctly
    .cropfactor = 5.6f
   },


### PR DESCRIPTION
The calculation formula gives us a crop factor value of 1.2 instead of the actual 1.0. This is a big inaccuracy, so we have no choice but to hardcode the correct value.