### PR TITLE
Implement module to support AI segmentation (pixelpipe backend)

### DIFF
--- a/src/common/iop_order.c
+++ b/src/common/iop_order.c
@@ -91,6 +91,7 @@ const dt_iop_order_entry_t legacy_order[] = {
   { { 6.0f }, "hotpixels", 0},
   { { 7.0f }, "rawdenoise", 0},
   { { 8.0f }, "demosaic", 0},
+  { { 8.5f }, "segmentation", 0},
   { { 9.0f }, "mask_manager", 0},
   { {10.0f }, "denoiseprofile", 0},
   { {11.0f }, "tonemap", 0},
@@ -178,14 +179,15 @@ const dt_iop_order_entry_t legacy_order[] = {
 
 // default order for RAW files, assumed to be linear from start
 const dt_iop_order_entry_t v30_order[] = {
-  { { 1.0 }, "rawprepare", 0},
-  { { 2.0 }, "invert", 0},
+  { { 1.0f }, "rawprepare", 0},
+  { { 2.0f }, "invert", 0},
   { { 3.0f }, "temperature", 0},
   { { 4.0f }, "highlights", 0},
   { { 5.0f }, "cacorrect", 0},
   { { 6.0f }, "hotpixels", 0},
   { { 7.0f }, "rawdenoise", 0},
   { { 8.0f }, "demosaic", 0},
+  { { 8.3f }, "segmentation", 0},
   { { 9.0f }, "denoiseprofile", 0},
   { {10.0f }, "bilateral", 0},
   { {11.0f }, "rotatepixels", 0},
@@ -302,6 +304,7 @@ const dt_iop_order_entry_t v50_order[] = {
   { { 6.0f }, "hotpixels", 0},
   { { 7.0f }, "rawdenoise", 0},
   { { 8.0f }, "demosaic", 0},
+  { { 8.5f }, "segmentation", 0},
   { { 9.0f }, "denoiseprofile", 0},
   { {10.0f }, "bilateral", 0},
   { {11.0f }, "rotatepixels", 0},
@@ -412,14 +415,15 @@ const dt_iop_order_entry_t v50_order[] = {
 // default order for JPEG/TIFF/PNG files, non-linear before colorin
 const dt_iop_order_entry_t v30_jpg_order[] = {
   // the following modules are not used anyway for non-RAW images :
-  { { 1.0 }, "rawprepare", 0 },
-  { { 2.0 }, "invert", 0 },
+  { { 1.0f }, "rawprepare", 0 },
+  { { 2.0f }, "invert", 0 },
   { { 3.0f }, "temperature", 0 },
   { { 4.0f }, "highlights", 0 },
   { { 5.0f }, "cacorrect", 0 },
   { { 6.0f }, "hotpixels", 0 },
   { { 7.0f }, "rawdenoise", 0 },
   { { 8.0f }, "demosaic", 0 },
+  { { 8.5f }, "segmentation", 0},
   // all the modules between [8; 28] expect linear RGB, so they need to be moved after colorin
   { { 28.0f }, "colorin", 0 },
   // moved modules : (copy-pasted in the same order)
@@ -539,6 +543,7 @@ const dt_iop_order_entry_t v50_jpg_order[] = {
   { { 6.0f }, "hotpixels", 0 },
   { { 7.0f }, "rawdenoise", 0 },
   { { 8.0f }, "demosaic", 0 },
+  { { 8.5f }, "segmentation", 0},
   // all the modules between [8; 28] expect linear RGB, so they need to be moved after colorin
   { { 28.0f }, "colorin", 0 },
   // moved modules : (copy-pasted in the same order)

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -337,6 +337,7 @@ typedef struct dt_develop_t
   {
     GtkWidget *button;
     gboolean enabled;
+    gboolean segmentation;
   } late_scaling;
 
   // the display profile related things (softproof, gamut check, profiles ...)

--- a/src/develop/masks.h
+++ b/src/develop/masks.h
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2013-2024 darktable developers.
+    Copyright (C) 2013-2025 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -702,6 +702,7 @@ gboolean dt_masks_calc_scharr_mask(dt_dev_detail_mask_t *details,
 float *dt_masks_calc_detail_mask(struct dt_dev_pixelpipe_iop_t *piece,
                                  const float threshold,
                                  const gboolean detail);
+float *dt_masks_get_ai_segments(struct dt_dev_pixelpipe_iop_t *piece, const int cnt, const int *list);
 
 /** return the list of possible mouse actions */
 GSList *dt_masks_mouse_actions(dt_masks_form_t *form);

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -2785,6 +2785,7 @@ void dt_masks_line_stroke(cairo_t *cr,
 }
 
 #include "detail.c"
+#include "segmentation.c"
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/develop/masks/segmentation.c
+++ b/src/develop/masks/segmentation.c
@@ -1,0 +1,111 @@
+/*
+    This file is part of darktable,
+    Copyright (C) 2025 darktable developers.
+
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    darktable is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/*
+  Initial docs
+  For each pipe we have the dt_dev_segmentation_t struct holding all required
+  data to be used later by other modules requesting a segment mask.
+
+  As we might want to ask for a combined mask of several segments we always
+  pass a list of segments amd the number of segments it holds.
+
+  For every location in the segments map we have segments uint8_t data, we might
+  reconcider to use just bits for this but using uint8_t would allow some border attenuation.
+
+  If any module wants a segmentation mask it
+  a) must request to do so via dt_dev_pixelpipe_segmentation()
+  b) gets the distorted mask for a list of segments via dt_dev_distort_segmentation_mask()
+
+  Currently the segmentation module is default enabled and visible, processing each piece
+  in the pipe will be disabled until dt_dev_pixelpipe_segmentation() has been called
+  As we haven't decided yet about the model we allow several models for testing right now
+  and pass a single parameter. This might all be changed/fixed after evaluation.
+
+  Note: As we don't have a UI mask getter yet this is switched on via the details mask requested
+  to allow preliminary testing.
+
+  Some runtime logs are provided via the -d pipe switch.
+*/
+
+
+// generate a combined float mask with original dimensions
+// *list holds the segments to be tested
+float *dt_masks_get_ai_segments(dt_dev_pixelpipe_iop_t *piece,
+                                const int tested,
+                                const int *list)
+{
+  dt_dev_pixelpipe_t *pipe = piece->pipe;
+  dt_dev_segmentation_t *seg = &pipe->segmentation;
+
+  if(tested < 1 || list == NULL)
+  {
+    dt_print(DT_DEBUG_ALWAYS, "[dt_masks_get_ai_segments] no valid data provided");
+    return NULL;
+  }
+  for(int i = 0; i < tested; i++)
+  {
+    if(list[i] < 1 || list[i] >= seg->segments)
+    {
+      dt_print(DT_DEBUG_ALWAYS, "[dt_masks_get_ai_segments] invalid segment %d (%d)", list[i], seg->segments);
+      return NULL;
+    }
+  }
+
+  const size_t owidth = seg->iwidth;
+  const size_t oheight = seg->iheight;
+
+  float *tmp = dt_calloc_align_float(owidth * oheight);
+  float *mask = dt_alloc_align_float(owidth * oheight);
+  if(!tmp || !mask)
+  {
+    dt_free_align(tmp);
+    dt_free_align(mask);
+    dt_print(DT_DEBUG_ALWAYS, "[dt_masks_get_ai_segments] could not allocate mask memory");
+    return NULL;
+  }
+
+  const size_t iwidth = seg->swidth;
+  const size_t iheight = seg->sheight;
+  const float height_ratio = (float)iheight / (float)oheight;
+  const float width_ratio = (float)iwidth / (float)owidth;
+
+  DT_OMP_FOR()
+  for(size_t row = 0; row < oheight; row++)
+  {
+    for(size_t col = 0; col < owidth; col++)
+    {
+      const size_t in_row = (size_t)((float)row * height_ratio);
+      const size_t in_col = (size_t)((float)col * width_ratio);
+      const size_t start = (size_t)seg->segments * (in_row*iwidth + in_col);
+      float val = 0.0f;
+      for(int i = 0; i < tested; i++)
+        val = MAX(val, (float)seg->map[start + list[i]] / 255.0f);
+      tmp[row*owidth + col] = val;
+    }
+  }
+
+  dt_gaussian_fast_blur(tmp, mask, owidth, oheight, 1.0f, 0.0f, 1.0f, 1);
+  dt_free_align(tmp);
+  return mask;
+}
+
+// clang-format off
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
+// clang-format on

--- a/src/develop/pixelpipe_cache.c
+++ b/src/develop/pixelpipe_cache.c
@@ -113,10 +113,13 @@ static dt_hash_t _dev_pixelpipe_cache_basichash(const dt_imgid_t imgid,
           Do we have to keep the roi of details mask? No as that is always defined by roi_in
           of the mask writing module (rawprepare or demosaic)
        4) Please note that position is not the iop_order but the n-th node position in the pipe
+       5) Include segmentation stuff
   */
-  const uint32_t hashing_pipemode[3] = {(uint32_t)imgid,
+  const uint32_t hashing_pipemode[5] = {(uint32_t)imgid,
                                         (uint32_t)pipe->type,
-                                        (uint32_t)pipe->want_detail_mask };
+                                        (uint32_t)pipe->want_detail_mask,
+                                        (uint32_t)pipe->want_segmentation,
+                                        (uint32_t)pipe->segmentation.model };
   dt_hash_t hash = dt_hash(DT_INITHASH, &hashing_pipemode, sizeof(hashing_pipemode));
 
   // go through all modules up to position and compute a hash using the operation and params.

--- a/src/develop/pixelpipe_hb.h
+++ b/src/develop/pixelpipe_hb.h
@@ -99,6 +99,18 @@ typedef struct dt_dev_detail_mask_t
   float *data;
 } dt_dev_detail_mask_t;
 
+typedef struct dt_dev_segmentation_t
+{
+  dt_hash_t hash;   // based on model, input dimension and maxsegments
+  int iwidth;       // dimension of pipe image data to generate the AI masks
+  int iheight;
+  int model;        // the model chosen; valid after AI algorithm
+  int segments;     // available segments after the AI algorithm
+  int swidth;       // dimension of each AI segment mask
+  int sheight;
+  uint8_t *map;
+} dt_dev_segmentation_t;
+
 /**
  * this encapsulates the pixelpipe.
  * a develop module will need several of these:
@@ -154,6 +166,9 @@ typedef struct dt_dev_pixelpipe_t
   // as we have to scale the mask later we keep size at that stage
   gboolean want_detail_mask;
   struct dt_dev_detail_mask_t scharr;
+
+  gboolean want_segmentation;
+  struct dt_dev_segmentation_t segmentation;
 
   // avoid cached data for processed module
   gboolean nocache;
@@ -277,6 +292,10 @@ void dt_dev_pixelpipe_rebuild(struct dt_develop_t *dev);
 
 // switch on details mask processing
 void dt_dev_pixelpipe_usedetails(dt_dev_pixelpipe_t *pipe);
+
+void dt_dev_pixelpipe_segmentation(dt_dev_pixelpipe_t *pipe);
+void dt_dev_clear_segmentation(dt_dev_pixelpipe_t *pipe);
+
 // process region of interest of pixels. returns TRUE if pipe was altered during processing.
 gboolean dt_dev_pixelpipe_process(dt_dev_pixelpipe_t *pipe,
                              struct dt_develop_t *dev,
@@ -334,6 +353,11 @@ void dt_print_pipe_ext(const char *title,
 float *dt_dev_distort_detail_mask(dt_dev_pixelpipe_iop_t *piece,
                                   float *src,
                                   const struct dt_iop_module_t *target_module);
+
+float *dt_dev_distort_segmentation_mask(struct dt_dev_pixelpipe_iop_t *piece,
+                                        const struct dt_iop_module_t *target_module,
+                                        const int tested,
+                                        const int *list);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/src/iop/CMakeLists.txt
+++ b/src/iop/CMakeLists.txt
@@ -154,6 +154,7 @@ add_iop(blurs "blurs.c")
 add_iop(sigmoid "sigmoid.c")
 add_iop(primaries "primaries.c")
 add_iop(colorequal "colorequal.c")
+add_iop(segmentation "segmentation.c")
 
 if(Rsvg2_FOUND)
   add_iop(watermark "watermark.c")

--- a/src/iop/finalscale.c
+++ b/src/iop/finalscale.c
@@ -63,7 +63,7 @@ static inline gboolean _gui_fullpipe(dt_dev_pixelpipe_iop_t *piece)
   return piece->pipe->type & (DT_DEV_PIXELPIPE_FULL
                               | DT_DEV_PIXELPIPE_PREVIEW2
                               | DT_DEV_PIXELPIPE_IMAGE)
-    && darktable.develop->late_scaling.enabled;
+    && (darktable.develop->late_scaling.enabled || darktable.develop->late_scaling.segmentation);
 }
 
 void modify_roi_in(dt_iop_module_t *self,

--- a/src/iop/segmentation.c
+++ b/src/iop/segmentation.c
@@ -1,0 +1,327 @@
+/*
+    This file is part of darktable,
+    Copyright (C) 2025 darktable developers.
+
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    darktable is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <math.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+
+#include "bauhaus/bauhaus.h"
+#include "develop/tiling.h"
+#include "develop/develop.h"
+#include "develop/imageop.h"
+#include "develop/imageop_gui.h"
+#include "develop/imageop_math.h"
+#include "gui/accelerators.h"
+#include "gui/gtk.h"
+#include "iop/iop_api.h"
+
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+DT_MODULE_INTROSPECTION(1, dt_iop_segmentation_params_t)
+
+typedef enum dt_iop_segmentation_model_t
+{
+  DT_IOP_SEGMENTATION_MODEL_FELSENZWALB = 0,  // $DESCRIPTION: "felsenzwalb"
+  DT_IOP_SEGMENTATION_MODEL_FASTS_SAM = 1,    // $DESCRIPTION: "fast SAM"
+  DT_IOP_SEGMENTATION_MODEL_OBJECT_SAM = 2,   // $DESCRIPTION: "content aware SAM"
+} dt_iop_segmentation_model_t;
+
+typedef struct dt_iop_segmentation_params_t
+{
+  dt_iop_segmentation_model_t model;  // $DEFAULT: DT_IOP_SEGMENTATION_MODEL_FASTS_SAM $DESCRIPTION: "model"
+  float depth;                        // $MIN: 0.0 $MAX: 1.0 $DEFAULT: 0.1 $DESCRIPTION: "segment depth"
+} dt_iop_segmentation_params_t;
+
+typedef struct dt_iop_segmentation_data_t
+{
+  dt_iop_segmentation_model_t model;
+  float depth;
+} dt_iop_segmentation_data_t;
+
+typedef struct dt_iop_segmentation_global_data_t
+{
+  int dummy;
+} dt_iop_segmentation_global_data_t;
+
+
+const char *name()
+{
+  return _("AI segmentation");
+}
+
+const char *aliases()
+{
+  return _("AI masks");
+}
+
+const char **description(dt_iop_module_t *self)
+{
+  return dt_iop_set_description(self,
+      _("generate segment masks"),
+      _("corrective"),
+      _("linear, RGB, scene-referred"),
+      _("linear, RGB"),
+      _("linear, RGB, scene-referred"));
+}
+
+int default_group()
+{
+  return IOP_GROUP_BASIC | IOP_GROUP_TECHNICAL;
+}
+
+int flags()
+{
+  return IOP_FLAGS_ONE_INSTANCE;
+}
+
+dt_iop_colorspace_type_t default_colorspace(dt_iop_module_t *self,
+                                            dt_dev_pixelpipe_t *pipe,
+                                            dt_dev_pixelpipe_iop_t *piece)
+{
+  return IOP_CS_RGB;
+}
+
+typedef struct dt_iop_segmentation_gui_data_t
+{
+  GtkWidget *model;
+  GtkWidget *depth;
+} dt_iop_segmentation_gui_data_t;
+
+/*
+void init_global(dt_iop_module_so_t *module)
+{
+  dt_iop_segmentation_global_data_t *gd = malloc(sizeof(dt_iop_segmentation_global_data_t));
+  module->data = gd;
+}
+
+void cleanup_global(dt_iop_module_so_t *module)
+{
+  dt_iop_segmentation_global_data_t *gd = (dt_iop_segmentation_global_data_t *)module->data;
+
+  free(gd);
+  module->data = NULL;
+}
+*/
+
+int legacy_params(dt_iop_module_t *self,
+                  const void *const old_params,
+                  const int old_version,
+                  void **new_params,
+                  int32_t *new_params_size,
+                  int *new_version)
+{
+  return 1;
+}
+
+static void _dummy_segmentation(dt_dev_segmentation_t *seg)
+{
+  const int width = 256;
+  const int height = 160;
+  const int segments = 4;
+  uint8_t *map = dt_calloc_align_type(uint8_t, (size_t)width * height * segments);
+
+  seg->swidth = width;  // segment dimension as that is later required for the mask scale & distortion
+  seg->sheight = height;
+  seg->segments = segments;
+  seg->map = map;
+
+  // just do something that can be seen
+  DT_OMP_FOR()
+  for(size_t row = 0; row < height; row++)
+  {
+    for(size_t col = 0; col < width; col++)
+    {
+      const size_t start = (size_t)segments * (row*width + col);
+      if     ((row < height / 2) && (col < width / 2)) map[start] = 255;
+      else if((row > height / 2) && (col < width / 2)) map[start+1] = 255;
+      else if((row < height / 2) && (col > width / 2)) map[start+2] = 255;
+      else map[start+3] = 255;
+    }
+  }
+}
+
+static char *_algo_name(const int model)
+{
+  switch(model)
+  {
+    case DT_IOP_SEGMENTATION_MODEL_FELSENZWALB: return "felsenzwalb";
+    case DT_IOP_SEGMENTATION_MODEL_FASTS_SAM:   return "fast SAM";
+    case DT_IOP_SEGMENTATION_MODEL_OBJECT_SAM:  return "content aware SAM";
+    default:                                    return "unknown segmentation algorithm";
+  }
+}
+
+void process(dt_iop_module_t *self,
+             dt_dev_pixelpipe_iop_t *piece,
+             const void *const ivoid,
+             void *const ovoid,
+             const dt_iop_roi_t *const roi_in,
+             const dt_iop_roi_t *const roi_out)
+{
+  float *input = (float *)ivoid;
+  float *output = (float *)ovoid;
+
+  const int iwidth = roi_in->width;
+  const int iheight = roi_in->height;
+  dt_iop_image_copy(output, input, (size_t)iwidth * iheight * 4);
+
+  dt_dev_pixelpipe_t *pipe = piece->pipe;
+  dt_iop_segmentation_data_t *d = piece->data;
+  dt_dev_segmentation_t *seg = &pipe->segmentation;
+
+  const gboolean fullpipe = pipe->type & DT_DEV_PIXELPIPE_FULL;
+
+  if(!pipe->want_segmentation)
+  {
+    dt_print_pipe(DT_DEBUG_PIPE,
+      "segmentation none", pipe, self, pipe->devid, roi_in, roi_out);
+    return;
+  }
+
+  const int hdata[6] = {(int)self->dev->image_storage.id,
+                        (int)seg->model,
+                        (int)d->model,
+                        (int)iwidth,
+                        (int)iheight,
+                        (int)d->depth * 1e6f };
+  const dt_hash_t hash = dt_hash(DT_INITHASH, &hdata, sizeof(hdata));
+
+  if(seg->segments && (hash == seg->hash))
+  {
+    dt_print_pipe(DT_DEBUG_PIPE,
+      "segmentation available", pipe, self, pipe->devid, roi_in, roi_out,
+      "'%s`: %d segments %dx%d",
+      _algo_name(seg->model), seg->segments, seg->swidth, seg->sheight);
+    return;
+  }
+
+  const gboolean fullscale = darktable.develop->late_scaling.enabled
+                          || darktable.develop->late_scaling.segmentation;
+
+  // NOTE: requires further investigation for export and image pipes
+  if(!fullscale && fullpipe)
+  {
+    dt_print_pipe(DT_DEBUG_PIPE,
+      "segmentation up", pipe, self, pipe->devid, roi_in, roi_out);
+    darktable.develop->late_scaling.segmentation = TRUE;
+    dt_dev_reprocess_center(self->dev);
+    return;
+  }
+  dt_dev_clear_segmentation(pipe);
+
+  // define those that are shared for all algos
+  seg->iwidth = iwidth;
+  seg->iheight = iheight;
+  seg->hash = hash;
+  seg->model = d->model;
+
+  // We can now process the AI segmentation algorithm, that must define the structs data
+  switch(seg->model)
+  {
+    default: _dummy_segmentation(seg);
+  }
+
+  dt_print_pipe(DT_DEBUG_PIPE,
+      "segmentation done", pipe, self, pipe->devid, roi_in, roi_out,
+      "'%s`: %d segments %dx%d",
+      _algo_name(seg->model), seg->segments, seg->swidth, seg->sheight);
+
+  if(fullscale && fullpipe)
+  {
+    dt_print_pipe(DT_DEBUG_PIPE,
+      "segmentation down", pipe, self, pipe->devid, roi_in, roi_out);
+    darktable.develop->late_scaling.segmentation = FALSE;
+    dt_dev_reprocess_center(self->dev);
+  }
+}
+
+void commit_params(dt_iop_module_t *self,
+                   dt_iop_params_t *p1,
+                   dt_dev_pixelpipe_t *pipe,
+                   dt_dev_pixelpipe_iop_t *piece)
+{
+  dt_iop_segmentation_params_t *p = (dt_iop_segmentation_params_t *)p1;
+  dt_iop_segmentation_data_t *d = piece->data;
+
+  d->depth = p->depth;
+  d->model = p->model;
+
+  piece->enabled = pipe->want_segmentation;
+  piece->process_cl_ready = FALSE;
+}
+
+void tiling_callback(dt_iop_module_t *self,
+                     dt_dev_pixelpipe_iop_t *piece,
+                     const dt_iop_roi_t *roi_in,
+                     const dt_iop_roi_t *roi_out,
+                     dt_develop_tiling_t *tiling)
+{
+  tiling->maxbuf = 1.0f;
+  tiling->xalign = 1;
+  tiling->yalign = 1;
+  tiling->overhead = 0;  // following have to be according to the chosen algorithm
+  tiling->factor = 5.0f;
+}
+
+/*
+void reload_defaults(dt_iop_module_t *self)
+{
+//  if(!self->dev || !dt_is_valid_imgid(self->dev->image_storage.id)) return;
+
+}
+*/
+void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
+{
+  self->hide_enable_button = TRUE;
+  self->default_enabled = TRUE;
+}
+
+/*
+void gui_update(dt_iop_module_t *self)
+{
+  gui_changed(self, NULL, NULL);
+}
+*/
+void gui_init(dt_iop_module_t *self)
+{
+  dt_iop_segmentation_gui_data_t *g = IOP_GUI_ALLOC(segmentation);
+
+  self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
+
+  g->model = dt_bauhaus_combobox_from_params(self, "model");
+  gtk_widget_set_tooltip_text(g->model, _("chosen AI model"));
+
+  g->depth = dt_bauhaus_slider_from_params(self, "depth");
+  gtk_widget_set_tooltip_text(g->depth, _("restrict maximum number of segments. effect depends on chosen model"));
+  dt_bauhaus_slider_set_format(g->depth, "%");
+  dt_bauhaus_slider_set_digits(g->depth, 0);
+}
+
+// clang-format off
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
+// clang-format on

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -1604,6 +1604,7 @@ void init_presets(dt_lib_module_t *self)
   AM("lens");
   AM("liquify");
   AM("nlmeans");
+  AM("segmentation");
   AM("rawdenoise");
   AM("retouch");
   AM("rotatepixels");
@@ -1705,6 +1706,7 @@ void init_presets(dt_lib_module_t *self)
   AM("lens");
   AM("retouch");
   AM("liquify");
+  AM("segmentation");
   AM("sharpen");
   AM("nlmeans");
 
@@ -1756,6 +1758,7 @@ void init_presets(dt_lib_module_t *self)
   AM("lens");
   AM("retouch");
   AM("liquify");
+  AM("segmentation");
   AM("sharpen");
   AM("nlmeans");
 


### PR DESCRIPTION
  Initial docs
  For each pipe we have the `dt_dev_segmentation_t` struct holding all required data to be used later by other modules requesting a segment mask.

  As we might want to ask for a combined mask of several segments we always pass a list of segments and the number of segments it holds.

  For every location in the segments map we have segments uint8_t data, we might reconcider to use just bits for this but using uint8_t would allow some border attenuation.

  If any module wants a segmentation mask it
  a) must request to do so via `dt_dev_pixelpipe_segmentation()`
  b) gets the distorted mask for a list of segments via `dt_dev_distort_segmentation_mask()`

  Currently the segmentation module is default enabled and visible, processing each piece in the pipe will be disabled until `dt_dev_pixelpipe_segmentation()` has been called.

  As we haven't decided yet about the model we allow several models for testing right now and pass a single parameter for possibly adoption of the algo. This might all be changed/fixed after evaluation.

  Note: As we don't have a UI mask getter yet this is switched on via the details mask requested to allow preliminary testing.

  Some runtime logs are provided via the -d pipe switch.