### PR TITLE
Fix flash firing detection

### DIFF
--- a/src/common/variables.c
+++ b/src/common/variables.c
@@ -106,6 +106,16 @@ typedef struct dt_variables_data_t
 
 static char *_expand_source(dt_variables_params_t *params, char **source, char extra_stop);
 
+static gboolean _is_flash_fired(const dt_image_t *img)
+{
+  if(g_strrstr(img->exif_flash, "did not fire"))
+    return FALSE;
+  if(img->exif_flash[0] == 'N')  // "No", that is no flash function present
+    return FALSE;
+  else
+    return TRUE;  // all other strings mean that the flash fired
+}
+
 // gather some data that might be used for variable expansion
 static void _init_expansion(dt_variables_params_t *params, gboolean iterate)
 {
@@ -180,8 +190,8 @@ static void _init_expansion(dt_variables_params_t *params, gboolean iterate)
     params->data->longitude = img->geoloc.longitude;
     params->data->latitude = img->geoloc.latitude;
     params->data->elevation = img->geoloc.elevation;
-    params->data->exif_flash_icon = img->exif_flash[0] == 'Y' ? "⚡" : "";
-    params->data->exif_flash = img->exif_flash[0] == 'Y' ? _("yes") : (img->exif_flash[0] == 'N' ? _("no") : _("n/a"));
+    params->data->exif_flash_icon = _is_flash_fired(img) ? "⚡" : "";
+    params->data->exif_flash = _is_flash_fired(img) ? _("yes") : _("no");
     params->data->exif_exposure_program = img->exif_exposure_program;
     params->data->exif_metering_mode = img->exif_metering_mode;
     params->data->exif_whitebalance = img->exif_whitebalance;


### PR DESCRIPTION
"Yes" at the beginning of the string does not mean that the flash fired, but that the flash function is present (for example, there is a built-in flash or an external flash is connected). There is a string from exiv2 "Yes, did not fire" for which checking only the first letter gave a false detection of the flash firing.

Similarly, not only "Y" as the first letter indicates the flash firing, the string obtained from exiv2 can also begin with the word "Fired".

Also removed "n/a" as the content of the text variable that indicates "flash firing". In fact, we always know whether the flash fired or not, "n/a" is meaningless.

