### PR TITLE
prevent  invalid cairo matrix in expose

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1377,7 +1377,7 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
       darktable.tmp_directory = g_dir_make_tmp("darktable_XXXXXX", NULL);
     dt_print(DT_DEBUG_ALWAYS,
              "[init] darktable dump directory is '%s'",
-             (darktable.tmp_directory) ?: "NOT AVAILABLE");
+             darktable.tmp_directory ? darktable.tmp_directory : "NOT AVAILABLE");
   }
 
   // Set directories as requested or default.

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -578,7 +578,7 @@ float dt_dev_get_zoom_scale(dt_dev_viewport_t *port,
     zoom_scale *= (float)darktable.develop->full.pipe->processed_width
                   / darktable.develop->preview_pipe->processed_width;
 
-  return zoom_scale ?: 1.0f;
+  return zoom_scale ? zoom_scale : 1.0f;
 }
 
 float dt_dev_get_zoom_scale_full(void)

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -2214,7 +2214,7 @@ void dt_iop_gui_cleanup_module(dt_iop_module_t *module)
   module->widget_list = NULL;
   DT_CONTROL_SIGNAL_DISCONNECT_ALL(module, module->so->op);
   if(module->gui_cleanup) module->gui_cleanup(module);
-  gtk_widget_destroy(module->expander ?: module->widget);
+  gtk_widget_destroy(module->expander ? module->expander : module->widget);
   dt_iop_gui_cleanup_blending(module);
   dt_pthread_mutex_destroy(&module->gui_lock);
   dt_free_align(module->gui_data);

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -1843,7 +1843,7 @@ static void _effect_editing_started(GtkCellRenderer *renderer,
 
       for(; values->name; values++)
       {
-        const char *text = values->description ?: values->name;
+        const char *text = values->description ? values->description : values->name;
         if(*text)
           gtk_list_store_insert_with_values
             (store, NULL, -1,
@@ -2116,7 +2116,8 @@ static void _fill_action_fields(GtkTreeViewColumn *column,
     return;
   }
 
-  gchar const *text = (strrchr(action->label, '|') ?: action->label - 1) + 1;
+  gchar const *last_sep = strrchr(action->label, '|');
+  gchar const *text = last_sep ? last_sep + 1 : action->label;
   if(!data)
   {
     const dt_action_def_t *def = _action_find_definition(action);

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -3105,13 +3105,14 @@ void commit_params(dt_iop_module_t *self,
   const gboolean run_profile = preview && g && g->run_profile;
   const gboolean run_validation = preview && g && g->run_validation;
 
+  const char *ill_desc = dt_introspection_get_enum_name(get_f("illuminant"), d->illuminant_type);
   dt_print(DT_DEBUG_PARAMS,
     "[commit color calibration]%s%s  temp=%i  xy=%.4f %.4f - XYZ=%.4f %.4f %.4f - LMS=%.4f %.4f %.4f  %s",
      run_profile ? " [profile]" : "",
      run_validation ? " [validation]" : "",
      (int)p->temperature, x, y, XYZ[0], XYZ[1], XYZ[2],
      d->illuminant[0], d->illuminant[1], d->illuminant[2],
-     dt_introspection_get_enum_name(get_f("illuminant"), d->illuminant_type) ?: "DT_ILLUMINANT_UNDEFINED");
+     ill_desc ? ill_desc : "DT_ILLUMINANT_UNDEFINED");
 
   // blue compensation for Bradford transform = (test illuminant blue
   // / reference illuminant blue)^0.0834 reference illuminant is

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -325,7 +325,7 @@ gboolean dt_view_manager_switch_by_view(dt_view_manager_t *vm,
       if(new_view == old_view && !plugin->expandable(plugin)) continue;
 
       /* does this module belong to current view ?*/
-      GtkWidget *ppw = plugin->expander ?: plugin->widget;
+      GtkWidget *ppw = plugin->expander ? plugin->expander : plugin->widget;
       if(ppw && gtk_widget_get_ancestor(ppw, GTK_TYPE_WINDOW))
       {
         if(plugin->view_leave)


### PR DESCRIPTION
prevent cairo errors reported up the chain after darkroom expose
```
(darktable:21578): Gtk-WARNING **: 10:11:12.748: drawing failure for widget 'GtkDrawingArea': invalid matrix (not invertible)

(darktable:21578): Gtk-WARNING **: 10:11:12.748: drawing failure for widget 'GtkBox': invalid matrix (not invertible)

(darktable:21578): Gtk-WARNING **: 10:11:12.748: drawing failure for widget 'GtkOverlay': invalid matrix (not invertible)

(darktable:21578): Gtk-WARNING **: 10:11:12.748: drawing failure for widget 'GtkGrid': invalid matrix (not invertible)

(darktable:21578): Gtk-WARNING **: 10:11:12.748: drawing failure for widget 'GtkBox': invalid matrix (not invertible)

(darktable:21578): Gtk-WARNING **: 10:11:12.748: drawing failure for widget 'GtkGrid': invalid matrix (not invertible)

(darktable:21578): Gtk-WARNING **: 10:11:12.748: drawing failure for widget 'GtkBox': invalid matrix (not invertible)

(darktable:21578): Gtk-WARNING **: 10:11:12.748: drawing failure for widget 'GtkWindow': invalid matrix (not invertible)
```
as reported here https://github.com/darktable-org/darktable/issues/18375#issuecomment-2644864503

Since we no longer throw away the cairo context when returning from expose (we used to copy into an extra intermediary buffer) these error conditions now persist.

@ralfbrown since you looked at this recently, do these make sense to you?