### PR TITLE
Temporary bugfix for flash firing detection when flash data is missing

### DIFF
--- a/src/common/variables.c
+++ b/src/common/variables.c
@@ -108,6 +108,8 @@ static char *_expand_source(dt_variables_params_t *params, char **source, char e
 
 static gboolean _is_flash_fired(const dt_image_t *img)
 {
+  if(img->exif_flash[0] == '\0') // string is empty
+    return FALSE;                // so we can't claim that flash fired
   if(g_strrstr(img->exif_flash, "did not fire"))
     return FALSE;
   if(img->exif_flash[0] == 'N')  // "No", that is no flash function present


### PR DESCRIPTION
Fixes #18424.

This is a temporary quick fix that addresses the bug in PR #18415. However, the mentioned PR does not address the issue with translated strings from exiv2, which make it impossible to reliably determine whether a flash has been fired. The correct solution to this issue will be in the next PR.

@TurboGit Please accept this as a quick fix for dev snapshot users while I prepare a proper solution.

