### PR TITLE
[nightly] Bump exiv2 for AppImage build

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -107,7 +107,7 @@ jobs:
             libxfixes-dev;
       - name: Build and install a more recent version of exiv2
         run: |
-          git clone --branch v0.28.4 --depth 1 https://github.com/Exiv2/exiv2 src-exiv2
+          git clone --branch v0.28.5 --depth 1 https://github.com/Exiv2/exiv2 src-exiv2
           cd src-exiv2
           cmake -S . -B build -G Ninja \
             -DCMAKE_BUILD_TYPE=Release \


### PR DESCRIPTION
The updated version fixes a security vulnerability: https://github.com/Exiv2/exiv2/security/advisories/GHSA-38h4-fx85-qcx7