### PR TITLE
Fix calculation and tests for pending jobs

### DIFF
--- a/src/control/control.c
+++ b/src/control/control.c
@@ -309,11 +309,12 @@ void dt_control_quit()
     g_usleep(1000);
 #endif
 
-  if(dt_control_jobs_pending())
+  // We test pending jobs vs 1 as we always accept one DT_JOB_QUEUE_SYSTEM_FG job
+  if(dt_control_jobs_pending() > 1)
      dt_control_log(_("<span foreground='#FF0000' background='#000000'>"
                       "darktable will be locked until background work has been done"
                       "</span>"));
-  for(int i = 0; i < 50 && dt_control_jobs_pending(); i++)
+  for(int i = 0; i < 50 && (dt_control_jobs_pending() > 1); i++)
   {
     g_usleep(100000);
     dt_gui_process_events();

--- a/src/control/jobs.c
+++ b/src/control/jobs.c
@@ -661,9 +661,6 @@ int dt_control_jobs_pending()
   int pending = dt_atomic_get_int(&control->pending_jobs);
   if(darktable.backthumbs.running)
     pending--;
-#ifdef HAVE_PRINT
-  pending--;
-#endif
   return pending;
 }
 // clang-format off


### PR DESCRIPTION
1. The CUPS detection job should be taken into account if not finished yet
2. Always accept at least one DT_JOB_QUEUE_SYSTEM_FG job while testing for a note