### PR TITLE
Pixelpipe update & maintenance 5.2_1

### DIFF
--- a/src/develop/pixelpipe_cache.h
+++ b/src/develop/pixelpipe_cache.h
@@ -66,7 +66,7 @@ gboolean dt_dev_pixelpipe_cache_init(struct dt_dev_pixelpipe_t *pipe, const int 
 void dt_dev_pixelpipe_cache_cleanup(struct dt_dev_pixelpipe_t *pipe);
 
 /** creates a hopefully unique hash from the complete module stack up to the module-th, including the roi. */
-dt_hash_t dt_dev_pixelpipe_cache_hash(const dt_imgid_t imgid, const struct dt_iop_roi_t *roi,
+dt_hash_t dt_dev_pixelpipe_cache_hash(const struct dt_iop_roi_t *roi,
                                      struct dt_dev_pixelpipe_t *pipe, const int position);
 
 /** returns a float data buffer in 'data' for the given hash from the cache, dsc is updated too.

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -3622,6 +3622,24 @@ float *dt_dev_distort_detail_mask(dt_dev_pixelpipe_iop_t *piece,
   return resmask;
 }
 
+dt_hash_t dt_dev_pixelpipe_piece_hash(dt_dev_pixelpipe_iop_t *piece,
+                                      const dt_iop_roi_t *roi,
+                                      const gboolean include)
+{
+  int position = include ? 0 : -1;
+  GList *pieces = piece->pipe->nodes;
+  while(pieces)
+  {
+    position++;
+    const dt_dev_pixelpipe_iop_t *node = pieces->data;
+    if(piece == node) break;
+
+    pieces = g_list_next(pieces);
+  }
+  return dt_dev_pixelpipe_cache_hash(roi, piece->pipe, position);
+}
+
+
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -1169,8 +1169,7 @@ static inline dt_hash_t _piece_process_hash(const dt_dev_pixelpipe_iop_t *piece,
                                             const dt_iop_module_t *module,
                                             const int position)
 {
-  dt_hash_t phash =
-    dt_dev_pixelpipe_cache_hash(piece->pipe->image.id, roi, piece->pipe, position -1);
+  dt_hash_t phash = dt_dev_pixelpipe_cache_hash(roi, piece->pipe, position -1);
   phash = dt_hash(phash, roi, sizeof(dt_iop_roi_t));
   phash = dt_hash(phash, &module->so->op, strlen(module->so->op));
   phash = dt_hash(phash, &module->instance, sizeof(module->instance));
@@ -1564,7 +1563,7 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
   if(dt_atomic_get_int(&pipe->shutdown))
     return TRUE;
 
-  dt_hash_t hash = dt_dev_pixelpipe_cache_hash(pipe->image.id, roi_out, pipe, pos);
+  dt_hash_t hash = dt_dev_pixelpipe_cache_hash(roi_out, pipe, pos);
 
   // we do not want data from the preview pixelpipe cache
   // for gamma so we can compute the final scope
@@ -3096,7 +3095,7 @@ restart:
 
   // terminate
   dt_pthread_mutex_lock(&pipe->backbuf_mutex);
-  pipe->backbuf_hash = dt_dev_pixelpipe_cache_hash(pipe->image.id, &roi, pipe, pos);
+  pipe->backbuf_hash = dt_dev_pixelpipe_cache_hash(&roi, pipe, pos);
 
   //FIXME lock/release cache line instead of copying
   if(pipe->type & DT_DEV_PIXELPIPE_SCREEN)

--- a/src/develop/pixelpipe_hb.h
+++ b/src/develop/pixelpipe_hb.h
@@ -325,6 +325,10 @@ float *dt_dev_distort_detail_mask(dt_dev_pixelpipe_iop_t *piece,
                                   float *src,
                                   const struct dt_iop_module_t *target_module);
 
+dt_hash_t dt_dev_pixelpipe_piece_hash(dt_dev_pixelpipe_iop_t *piece,
+                                      const dt_iop_roi_t *roi,
+                                      const gboolean include);
+
 G_END_DECLS
 
 // clang-format off

--- a/src/iop/hlreconstruct/opposed.c
+++ b/src/iop/hlreconstruct/opposed.c
@@ -38,21 +38,12 @@
    Again the algorithm has been developed in collaboration by @garagecoder and @Iain from gmic team and @jenshannoschwalm from dt.
 */
 
-static dt_hash_t _opposed_parhash(dt_dev_pixelpipe_iop_t *piece)
-{
-  dt_iop_buffer_dsc_t *dsc = &piece->pipe->dsc;
-  dt_iop_highlights_data_t *d = piece->data;
-
-  dt_hash_t hash = dt_hash(DT_INITHASH, &dsc->rawprepare, sizeof(dsc->rawprepare));
-  hash = dt_hash(hash, &dsc->temperature, sizeof(dsc->temperature));
-  hash = dt_hash(hash, &d->clip, sizeof(d->clip));
-  return dt_hash(hash, &piece->module->dev->chroma.late_correction, sizeof(int));
-}
-
 static dt_hash_t _opposed_hash(dt_dev_pixelpipe_iop_t *piece)
 {
-  dt_hash_t hash = _opposed_parhash(piece);
-  return dt_hash(hash, &piece->pipe->image.id, sizeof(piece->pipe->image.id));
+  const dt_iop_highlights_data_t *d = piece->data;
+  dt_hash_t hash = dt_dev_pixelpipe_piece_hash(piece, NULL, FALSE);
+  hash = dt_hash(hash, &d->clip, sizeof(d->clip));
+  return dt_hash(hash, &piece->module->dev->chroma.late_correction, sizeof(int));
 }
 
 static inline float _calc_linear_refavg(const float *in, const int color)
@@ -336,7 +327,7 @@ static float *_process_opposed(dt_iop_module_t *self,
           "opposed chroma", piece->pipe, self, DT_DEVICE_CPU, roi_in, roi_out,
           "RGB %3.4f %3.4f %3.4f hash=%" PRIx64 "%s%s",
           chrominance[0], chrominance[1], chrominance[2],
-          _opposed_parhash(piece),
+          _opposed_hash(piece),
           piece->pipe->type == DT_DEV_PIXELPIPE_FULL ? ", saved" : "",
           img_oppclipped ? "" : ", unclipped");
     }
@@ -535,7 +526,7 @@ static cl_int process_opposed_cl(dt_iop_module_t *self,
         "opposed chroma", piece->pipe, self, piece->pipe->devid, roi_in, roi_out,
         "RGB %3.4f %3.4f %3.4f hash=%" PRIx64 "%s%s",
         chrominance[0], chrominance[1], chrominance[2],
-        _opposed_parhash(piece),
+        _opposed_hash(piece),
         piece->pipe->type == DT_DEV_PIXELPIPE_FULL ? ", saved" : "",
         img_oppclipped ? "" : ", unclipped");
   }

--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -1018,8 +1018,7 @@ void toneeq_process(dt_iop_module_t *self,
 
     pieces = g_list_next(pieces);
   }
-  const dt_hash_t hash = dt_dev_pixelpipe_cache_hash(piece->pipe->image.id,
-                                                    roi_out, piece->pipe, position);
+  const dt_hash_t hash = dt_dev_pixelpipe_cache_hash(roi_out, piece->pipe, position);
 
   // Sanity checks
   if(width < 1 || height < 1) return;


### PR DESCRIPTION
**Simplify and improve `dt_dev_pixelpipe_cache_hash()`**

1. We don't have to pass the imgid parameter as it is available via the pipe struct already.
2. The roi is only used for the hash if not NULL.
   This allows the usage of `dt_dev_pixelpipe_cache_hash()` as a check for upstream module parameters.
___________________________________________
**Implement `dt_dev_pixelpipe_piece_hash()`**

`dt_hash_t dt_dev_pixelpipe_piece_hash(dt_dev_pixelpipe_iop_t *piece, const dt_iop_roi_t *roi, const gboolean include)`

Returns a hash reflecting upstream pieces up to the passed `dt_dev_pixelpipe_iop_t *piece`.
If the roi parameter is not NULL it is included in the hash
If `included` is TRUE the hash also uses the provided piece for the hash, otherwise only upstream.
_________________________________________________

Used in inpaint opposed and tone equalizer so far. Also a pre-requisite for haze removal or other modules that require updating/recalculating internal data if any upstream modules changed.  
