### PR TITLE
Minor readability fix

### DIFF
--- a/src/common/database.c
+++ b/src/common/database.c
@@ -4330,7 +4330,7 @@ start:
 
 
   /* opening / creating database */
-  if(sqlite3_open(db->dbfilename_library, &db->handle))
+  if(sqlite3_open(db->dbfilename_library, &db->handle) != SQLITE_OK)
   {
     dt_print(DT_DEBUG_ALWAYS, "[init] could not find database %s%s%s",
                               dbname ? " `" : "", dbname ? dbname : "", dbname ? "'!" : "");


### PR DESCRIPTION
It is more readable (and safer) to compare the return code against the defined symbolic code instead of relying on our knowledge that all failure codes are non-zero.