### PR TITLE
fix missing widget for capture time collection filter

### DIFF
--- a/src/libs/filtering.c
+++ b/src/libs/filtering.c
@@ -228,6 +228,7 @@ static _filter_t filters[]
         { DT_COLLECTION_PROP_DAY, _date_widget_init, _date_update },
         { DT_COLLECTION_PROP_CHANGE_TIMESTAMP, _date_widget_init, _date_update },
         { DT_COLLECTION_PROP_EXPORT_TIMESTAMP, _date_widget_init, _date_update },
+        { DT_COLLECTION_PROP_TIME, _date_widget_init, _date_update },
         { DT_COLLECTION_PROP_IMPORT_TIMESTAMP, _date_widget_init, _date_update },
         { DT_COLLECTION_PROP_PRINT_TIMESTAMP, _date_widget_init, _date_update },
         { DT_COLLECTION_PROP_ASPECT_RATIO, _ratio_widget_init, _ratio_update },


### PR DESCRIPTION
Using one of the capture time collection filters creates a useless empty widget:

![Bildschirmfoto 2025-02-26 um 19 35 31](https://github.com/user-attachments/assets/13b8c55d-02c6-4c87-a916-f13be0a3bc55)

![Bildschirmfoto 2025-02-26 um 19 36 00](https://github.com/user-attachments/assets/6c8a99cb-865a-4ceb-9bee-3c9dfbc4f9c3)
