### PR TITLE
[imageio] Streamline ISOBMFF files loading

### DIFF
--- a/src/imageio/imageio.c
+++ b/src/imageio/imageio.c
@@ -234,8 +234,9 @@ static const dt_magic_bytes_t _magic_signatures[] = {
   { DT_FILETYPE_HEIC, FALSE, 4, 8, dt_imageio_open_heif,
     { 'f', 't', 'y', 'p', 'a', 'v', 'c', 'i' } }, // AVC (H.264) encoded HEIF
   // AVIF image
-  { DT_FILETYPE_AVIF, TRUE, 4, 8, dt_imageio_open_avif,
-    { 'f', 't', 'y', 'p', 'a', 'v', 'i', 'f' } },
+  // this matches 'avif' and 'avis'
+  { DT_FILETYPE_AVIF, TRUE, 4, 7, dt_imageio_open_avif,
+    { 'f', 't', 'y', 'p', 'a', 'v', 'i' } },
   // Technically, files with major brand names starting with 'mif' or 'msf'
   // can be either HEIF or AVIF files, depending on information in the
   // next bytes. But the HEIF loader can read files of both formats, so

--- a/src/imageio/imageio.c
+++ b/src/imageio/imageio.c
@@ -237,8 +237,14 @@ static const dt_magic_bytes_t _magic_signatures[] = {
   // AVIF image
   { DT_FILETYPE_AVIF, TRUE, 4, 8, dt_imageio_open_avif,
     { 'f', 't', 'y', 'p', 'a', 'v', 'i', 'f' } },
-//  { DT_FILETYPE_AVIF, TRUE, 4, 8, dt_imageio_open_avif,
-//    { 'f', 't', 'y', 'p', 'm', 'i', 'f', '1' } },  //alternate? HEIF or AVIF, depending on bytes 16-19
+  // Technically, files with major brand names starting with 'mif' or 'msf'
+  // can be either HEIF or AVIF files, depending on information in the
+  // next bytes. But the HEIF loader can read files of both formats, so
+  // that's the loader we're calling in this case.
+  { DT_FILETYPE_AVIF, TRUE, 4, 7, dt_imageio_open_heif,
+    { 'f', 't', 'y', 'p', 'm', 'i', 'f' } },
+  { DT_FILETYPE_AVIF, TRUE, 4, 7, dt_imageio_open_heif,
+    { 'f', 't', 'y', 'p', 'm', 's', 'f' } },
   // Quite OK Image Format (QOI)
   { DT_FILETYPE_QOI, FALSE, 0, 4, dt_imageio_open_qoi,
     { 'q', 'o', 'i', 'f' } },

--- a/src/imageio/imageio.c
+++ b/src/imageio/imageio.c
@@ -225,11 +225,10 @@ static const dt_magic_bytes_t _magic_signatures[] = {
   // WEBP image
   { DT_FILETYPE_WEBP, FALSE, 8, 4, dt_imageio_open_webp,
     { 'W', 'E', 'B', 'P' } },  // full signature is RIFF????WEPB, where ???? is the file size
-  // HEIC/HEIF image
-  { DT_FILETYPE_HEIC, FALSE, 4, 8, dt_imageio_open_heif,
-    { 'f', 't', 'y', 'p', 'h', 'e', 'i', 'c' } },
-  { DT_FILETYPE_HEIC, TRUE, 4, 8, dt_imageio_open_heif,
-    { 'f', 't', 'y', 'p', 'h', 'e', 'i', 'x' } }, // 10-bit
+  // HEIC/HEIF images
+  // this matches heic, heix, heim, heis, hevc, hevx, hevm and hevs major brands
+  { DT_FILETYPE_HEIC, FALSE, 4, 6, dt_imageio_open_heif,
+    { 'f', 't', 'y', 'p', 'h', 'e' } },
   { DT_FILETYPE_HEIC, FALSE, 4, 8, dt_imageio_open_heif,
     { 'f', 't', 'y', 'p', 'j', '2', 'k', 'i' } }, // JPEG 2000 encapsulated in HEIF
   { DT_FILETYPE_HEIC, FALSE, 4, 8, dt_imageio_open_heif,

--- a/src/imageio/imageio.c
+++ b/src/imageio/imageio.c
@@ -1617,14 +1617,6 @@ dt_imageio_retval_t dt_imageio_open(dt_image_t *img,
     if(!_image_handled(ret))
       ret = dt_imageio_open_libraw(img, filename, buf);
 
-    // there are reports that AVIF and HEIF files with alternate magic bytes exist, so try loading
-    // as such if we haven't yet succeeded
-    if(!_image_handled(ret))
-      ret = dt_imageio_open_avif(img, filename, buf);
-
-    if(!_image_handled(ret))
-      ret = dt_imageio_open_heif(img, filename, buf);
-
     if(!_image_handled(ret))
       ret = dt_imageio_open_exr(img, filename, buf);
 


### PR DESCRIPTION
This PR does not add functionality or make file loading noticeably faster. Just like Ralf's redesign of the loader call architecture, the change in this PR (and the next few) aims to make the image reading process more uniform, logical, and therefore more understandable. The ultimate goal is to minimize the length of the fallback path (perhaps even eliminate it altogether).

As for testing, samples of less common major brands can be found at [nokiatech's heif_conformance](https://github.com/nokiatech/heif_conformance/tree/master/conformance_files)  - there are files of brands `mif1`, `msf1`, "multilayer" files are `heis`.

In this PR we provide signatures that match all files that can contain images in ISOBMFF containers and can be read by libheif or libavif. Having provided a direct loader call by signature for all such files, we remove the corresponding loaders from the fallback path because they will never be used there.

