### PR TITLE
Hide "reduce resolution of preview image" preference

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -2414,7 +2414,7 @@
     <shortdescription>whether to show the compute variance mode in denoiseprofile</shortdescription>
     <longdescription>adds a mode in denoiseprofile that allows to compute the variance after the generalized anscombe transform is performed</longdescription>
   </dtconfig>
-  <dtconfig prefs="darkroom" section="general" restart="true">
+  <dtconfig>
     <name>preview_downsampling</name>
     <type>
       <enum>
@@ -2426,7 +2426,7 @@
     </type>
     <default>original</default>
     <shortdescription>reduce resolution of preview image</shortdescription>
-    <longdescription>decrease to speed up preview rendering, may hinder accurate masking</longdescription>
+    <longdescription>decrease to speed up preview rendering, hinders accurate masking, pickers and some module algorithm</longdescription>
   </dtconfig>
   <dtconfig prefs="darkroom" section="general">
     <name>darkroom/ui/loading_screen</name>


### PR DESCRIPTION
As any reduction of preview size leads to a significant quality loss for pickers, some module intenals and masking and may be of use only for very slow systems we keep the option as users might have set for good reasons but won't offer that setting via the preferences UI as a strong hint "Don't touch except you know exactly what this about"

Fixes #18459