### PR TITLE
Improved inpaint opposed for sraws

### DIFF
--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -2534,7 +2534,7 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
             }
             else
             {
-              dt_print_pipe(DT_DEBUG_PIPE,
+              dt_print_pipe(DT_DEBUG_OPENCL,
                 "copy CL data to host", pipe, module, pipe->devid, &roi_in, NULL);
               /* success: cache line is valid now, so we will not need
                  to invalidate it later */
@@ -2710,7 +2710,7 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
     {
       dt_print_pipe(DT_DEBUG_PIPE,
                     "importance hints",
-                    pipe, module, pipe->devid, &roi_in, NULL, " %s%s%s",
+                    pipe, module, pipe->devid, &roi_in, NULL, "%s%s%s",
                     last_history ? "input_hint " : "",
                     has_focus ? "focus " : "",
                     important_cl ? "cldata" : "");


### PR DESCRIPTION
To improve the quality of inpaint opposed algorithm for sraw images we have to use full image data to calculate a proper chrominance correction. Thus
- we change modify_roi_in accordingly
- we provide an internal scaler (as we normally do in demosaic) and process full image data in the pipe until highlights for sraws
- we validate the chrominance correction via a hash (as we do for raw images) and thus have to calculate it just once in full pipe
- if we don't have clipped data we do a fast bypass

While being here some minor log fixes