### PR TITLE
Introduce OpenCL exceptions

### DIFF
--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2010-2024 darktable developers.
+    Copyright (C) 2010-2025 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -37,6 +37,13 @@
 #define DT_OPENCL_SYSMEM_ALLOCATION -998
 #define DT_OPENCL_PROCESS_CL -997
 #define DT_OPENCL_NODEVICE -996
+#define DT_OPENCL_DT_EXCEPTION -995
+
+/* exceptions */
+#define DT_OPENCL_AMD_APP 1
+#define DT_OPENCL_ONLY_CUDA 2
+
+
 #include "common/darktable.h"
 
 #ifdef HAVE_OPENCL
@@ -200,6 +207,9 @@ typedef struct dt_opencl_device_t
 
   // lets keep the vendor for runtime checks
   int vendor_id;
+
+  // exceptions bit mask
+  uint32_t exceptions;
 
   float advantage;
 } dt_opencl_device_t;
@@ -609,6 +619,9 @@ void dt_opencl_check_tuning(const int devid);
 
 /** get size of allocatable single buffer */
 cl_ulong dt_opencl_get_device_memalloc(const int devid);
+
+/** checks for a detected OpenCL runtime exception */
+gboolean dt_opencl_exception(const int devid, const uint32_t mask);
 
 /** round size to a multiple of the value given in the device specifig
  * config parameter for opencl_size_roundup */

--- a/src/common/opencl_drivers_blacklist.h
+++ b/src/common/opencl_drivers_blacklist.h
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2016-2020 darktable developers.
+    Copyright (C) 2016-2025 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -44,7 +44,7 @@ static const gchar *bad_opencl_drivers[] =
 };
 
 // returns TRUE if blacklisted
-gboolean dt_opencl_check_driver_blacklist(const char *device_version)
+static gboolean _opencl_check_driver_blacklist(const char *device_version)
 {
   gchar *device = g_ascii_strdown(device_version, -1);
 
@@ -60,6 +60,34 @@ gboolean dt_opencl_check_driver_blacklist(const char *device_version)
   // did not find in the black list, guess it's ok.
   g_free(device);
   return FALSE;
+}
+
+/*
+   darktable OpenCL runtime exceptions
+   1. We test for a number of problematic or advantage situations and leave a flag about that
+      in the dt_opencl_device_t struct
+   2. gboolean dt_opencl_exception(const int devid, const uint32_t mask)
+      allows to check for such conditions while processing the pixelpipe and
+      possibly using different code or fallbacks
+   3. An example can be found in demosaic testing for DT_OPENCL_AMD_APP while using the
+      DT_IOP_DEMOSAIC_PPG demosaicer, as that OpenCL code fails for unknown reasons we do
+      a fallback to DT_IOP_DEMOSAIC_RCD (which is better anyway).
+   4. We could also fallback to CPU code path in such exceptions, in that case we should return
+      with DT_OPENCL_DT_EXCEPTION as the error code, that would be reported in the -d opencl log
+*/
+
+static void _write_test_exceptions(dt_opencl_device_t *device)
+{
+  if(!strncasecmp(device->device_version, "OpenCL 2.0 AMD-APP", 18))
+  {
+    device->exceptions |= DT_OPENCL_AMD_APP;
+    dt_print_nts(DT_DEBUG_OPENCL, "   CL EXCEPTION:             DT_OPENCL_AMD_APP\n");
+  }
+  if(!strncasecmp(device->platform, "NVIDIA CUDA", 11))
+  {
+    device->exceptions |= DT_OPENCL_ONLY_CUDA;
+    dt_print_nts(DT_DEBUG_OPENCL, "   CL EXCEPTION:             DT_OPENCL_ONLY_CUDA\n");
+  }
 }
 
 // clang-format off

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -754,6 +754,13 @@ int process_cl(dt_iop_module_t *self,
   const dt_iop_demosaic_global_data_t *gd = self->global_data;
 
   int demosaicing_method = d->demosaicing_method;
+
+  // We do a PPG to RCD demosaicer fallback here as the used driver is known to fail.
+  // Also could "return DT_OPENCL_DT_EXCEPTION" for a cpu fallback
+  if(demosaicing_method == DT_IOP_DEMOSAIC_PPG
+     && dt_opencl_exception(piece->pipe->devid, DT_OPENCL_AMD_APP))
+    demosaicing_method = DT_IOP_DEMOSAIC_RCD;
+
   const int width = roi_in->width;
   const int height = roi_in->height;
 


### PR DESCRIPTION
While installing an OpenCL device we do a number of checks for special situations, that could be detecting problematic drivers/devices or some implementations with advantage.

These checks leave a bitflag in device exceptions, they can later be tested while running OpenCL code via `gboolean dt_opencl_exception(const int devid, const uint32_t mask);`

An example is provided in demosaicer module, we know that the default AMD windows driver is bad for PPG so we do a fallback there.

Likely fixes #18042 #18284

__________________________________________
Unfortunately we simply can't fix all OpenCL problems, it has been very difficult to test/debug blindly and most users are not able to compile & debug the kernels themselves. 
This framework at least gives a fair chance to fix some issues in an easy way.