### PR TITLE
[imageio] Remove unnecessary loaders from fallback path

### DIFF
--- a/src/imageio/imageio.c
+++ b/src/imageio/imageio.c
@@ -1618,16 +1618,7 @@ dt_imageio_retval_t dt_imageio_open(dt_image_t *img,
       ret = dt_imageio_open_libraw(img, filename, buf);
 
     if(!_image_handled(ret))
-      ret = dt_imageio_open_exr(img, filename, buf);
-
-    if(!_image_handled(ret))
       ret = dt_imageio_open_rgbe(img, filename, buf);
-
-    if(!_image_handled(ret))
-      ret = dt_imageio_open_j2k(img, filename, buf);
-
-    if(!_image_handled(ret))
-      ret = dt_imageio_open_jpeg(img, filename, buf);
 
     // final fallback that tries to open file via GraphicsMagick or ImageMagick
     if(!_image_handled(ret))

--- a/src/imageio/imageio.c
+++ b/src/imageio/imageio.c
@@ -1617,9 +1617,6 @@ dt_imageio_retval_t dt_imageio_open(dt_image_t *img,
     if(!_image_handled(ret))
       ret = dt_imageio_open_libraw(img, filename, buf);
 
-    if(!_image_handled(ret))
-      ret = dt_imageio_open_rgbe(img, filename, buf);
-
     // final fallback that tries to open file via GraphicsMagick or ImageMagick
     if(!_image_handled(ret))
       ret = dt_imageio_open_exotic(img, filename, buf);


### PR DESCRIPTION
This is a continuation of the work on streamlining and simplifying the file loading process started with #18483.

These loaders will be called when the corresponding format signature is recognized. The signatures of these files are unambiguous and match all possible variations of the format, so the corresponding loaders in the fallback path will never be used.

Regarding the RGBE format, theoretically there may be files created at the very dawn of the format, when the author of the format himself did not yet think about the need for a signature. But the probability that someone will need to read those really ancient files in darktable is almost zero. Still, the commit that removes this loader from the fallback path is made separate, to facilitate reverting.
