### PR TITLE
[imageio] Only libraw can support x3f

### DIFF
--- a/src/imageio/imageio.c
+++ b/src/imageio/imageio.c
@@ -300,7 +300,7 @@ static const dt_magic_bytes_t _magic_signatures[] = {
   { DT_FILETYPE_RW2, TRUE, 0, 8, dt_imageio_open_rawspeed,
     { 'I', 'I', 'U', 0x00, 0x08, 0x00, 0x00, 0x00 } },
   // Sigma Foveon X3F file
-  { DT_FILETYPE_X3F, TRUE, 0, 4, NULL,
+  { DT_FILETYPE_X3F, TRUE, 0, 4, dt_imageio_open_libraw,
     { 'F', 'O', 'V', 'b' } },
   // Nikon NEF files are TIFFs with (usually) the string "NIKON CORP" early in the file
   { DT_FILETYPE_NEF, FALSE, 0, 4, dt_imageio_open_rawspeed,

--- a/src/imageio/imageio_libraw.c
+++ b/src/imageio/imageio_libraw.c
@@ -289,7 +289,7 @@ static gboolean _supported_image(const gchar *filename)
   // At the moment of writing this code CR3 files are not supported by RawSpeed,
   // so they are always processed by LibRaw.
   gchar *extensions_whitelist;
-  const gchar *always_by_libraw = "cr3";
+  const gchar *always_by_libraw = "cr3 x3f";
 
   gchar *ext = g_strrstr(filename, ".");
   if(!ext)


### PR DESCRIPTION
This PR is another step towards removing the need for a common fallback loaders path for all files.

x3f has not been supported in rawspeed [for a long time](https://github.com/darktable-org/rawspeed/issues/195). And since without additional (not very documented) editing of the darktablerc file by the user, x3f files are processed only by the rawspeed loader, in fact, all this time x3f support was guaranteed to be non-working.

This PR adds the ability to work with x3f in the libraw loader, but this does not guarantee support in darktable build, as it all depends on the libraw build. Support for x3f in libraw is not included in the library build by default. There is also reason to believe that most distro packages do not enable this support, since upstream recommends against it for security reasons.