### PR TITLE
Log successful parameter validation only if verbose mode is on

### DIFF
--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -2113,7 +2113,7 @@ gboolean _iop_validate_params(dt_introspection_field_t *field,
 
   if(all_ok)
   {
-    dt_print(DT_DEBUG_ALWAYS,
+    dt_print(DT_DEBUG_VERBOSE,
              "[iop_validate_params] `%s' validated data for type \"%s\"%s%s%s",
              name, field->header.type_name,
              *field->header.name ? ", field: " : "",


### PR DESCRIPTION
Implemented the suggestion from @dterrahe to fix #18497 Locally, the log went down from millions of lines to a few thousand (using the same editing steps), none of those related to valid parameters.