### PR TITLE
Remove code that interprets vim-style commands

### DIFF
--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2012-2024 darktable developers.
+    Copyright (C) 2012-2025 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -3507,103 +3507,6 @@ static gboolean _widget_motion_notify(GtkWidget *widget,
 
   gtk_widget_queue_draw(widget);
   return TRUE;
-}
-
-void dt_bauhaus_vimkey_exec(const char *input)
-{
-  dt_action_t *ac = darktable.control->actions_iops.target;
-  input += 5; // skip ":set "
-
-  while(ac)
-  {
-    const int prefix = strcspn(input, ".=");
-
-    if(ac->type >= DT_ACTION_TYPE_WIDGET ||
-       ac->type <= DT_ACTION_TYPE_SECTION)
-    {
-      if(!strncasecmp(ac->label, input, prefix))
-      {
-        if(!ac->label[prefix])
-        {
-          input += prefix;
-          if(*input) input++; // skip . or =
-
-          if(ac->type <= DT_ACTION_TYPE_SECTION)
-          {
-            ac = ac->target;
-            continue;
-          }
-          else
-            break;
-        }
-      }
-    }
-
-    ac = ac->next;
-  }
-
-  if(!ac
-     || ac->type != DT_ACTION_TYPE_WIDGET
-     || !ac->target
-     || !DT_IS_BAUHAUS_WIDGET(ac->target))
-    return;
-
-  float old_value = .0f, new_value = .0f;
-
-  GtkWidget *w = ac->target;
-
-  switch(DT_BAUHAUS_WIDGET(w)->type)
-  {
-    case DT_BAUHAUS_SLIDER:
-      old_value = dt_bauhaus_slider_get(w);
-      new_value = dt_calculator_solve(old_value, input);
-      dt_print(DT_DEBUG_ALWAYS, " = %f", new_value);
-      if(dt_isfinite(new_value))
-        dt_bauhaus_slider_set(w, new_value);
-      break;
-    case DT_BAUHAUS_COMBOBOX:
-      // TODO: what about text as entry?
-      old_value = dt_bauhaus_combobox_get(w);
-      new_value = dt_calculator_solve(old_value, input);
-      dt_print(DT_DEBUG_ALWAYS, " = %f", new_value);
-      if(dt_isfinite(new_value))
-        dt_bauhaus_combobox_set(w, new_value);
-      break;
-    default:
-      break;
-  }
-}
-
-// give autocomplete suggestions
-GList *dt_bauhaus_vimkey_complete(const char *input)
-{
-  GList *res = NULL;
-
-  dt_action_t *ac = darktable.control->actions_iops.target;
-
-  while(ac)
-  {
-    const int prefix = strcspn(input, ".");
-
-    if(ac->type >= DT_ACTION_TYPE_WIDGET ||
-       ac->type <= DT_ACTION_TYPE_SECTION)
-    {
-      if(!prefix || !strncasecmp(ac->label, input, prefix))
-      {
-        if(!ac->label[prefix] && input[prefix] == '.')
-        {
-            input += prefix + 1;
-          if(ac->type <= DT_ACTION_TYPE_SECTION) ac = ac->target;
-          continue;
-        }
-        else
-          res = g_list_append(res, (gchar *)ac->label + prefix);
-      }
-    }
-
-    ac = ac->next;
-  }
-  return res;
 }
 
 void dt_bauhaus_combobox_mute_scrolling(GtkWidget *widget)

--- a/src/bauhaus/bauhaus.h
+++ b/src/bauhaus/bauhaus.h
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2012-2021 darktable developers.
+    Copyright (C) 2012-2025 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -469,12 +469,6 @@ void dt_bauhaus_combobox_set_entries_ellipsis(GtkWidget *widget,
                                               PangoEllipsizeMode ellipis);
 PangoEllipsizeMode dt_bauhaus_combobox_get_entries_ellipsis(GtkWidget *widget);
 void dt_bauhaus_combobox_mute_scrolling(GtkWidget *widget);
-
-// key accel parsing:
-// execute a line of input
-void dt_bauhaus_vimkey_exec(const char *input);
-// give autocomplete suggestions
-GList *dt_bauhaus_vimkey_complete(const char *input);
 
 static inline void set_color(cairo_t *cr, GdkRGBA color)
 {

--- a/src/control/control.h
+++ b/src/control/control.h
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2009-2021 darktable developers.
+    Copyright (C) 2009-2025 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -53,7 +53,6 @@ void dt_control_button_released(double x, double y, int which, uint32_t state);
 void dt_control_mouse_moved(double x, double y, double pressure, int which);
 void dt_control_mouse_leave(void);
 void dt_control_mouse_enter(void);
-gboolean dt_control_key_pressed_override(guint key, guint state);
 gboolean dt_control_configure(GtkWidget *da, GdkEventConfigure *event, gpointer user_data);
 void dt_control_log(const char *msg, ...) __attribute__((format(printf, 1, 2)));
 void dt_toast_log(const char *msg, ...) __attribute__((format(printf, 1, 2)));
@@ -150,9 +149,6 @@ typedef struct dt_control_t
   dt_action_element_t element;
   GPtrArray *widget_definitions;
   GSList *input_drivers;
-
-  char vimkey[256];
-  int vimkey_cnt;
 
   // gui related stuff
   double tabborder;

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -4528,11 +4528,6 @@ gboolean dt_shortcut_dispatcher(GtkWidget *w,
 
     _sc.mods = _key_modifiers_clean(event->key.state);
 
-    // FIXME: for vimkeys and game. Needs generalising for non-bauhaus/non-darkroom
-    if(!_grab_widget && !darktable.control->mapping_widget &&
-       dt_control_key_pressed_override(event->key.keyval, dt_gui_translated_key_state(&event->key)))
-      return TRUE;
-
     dt_shortcut_key_press(DT_SHORTCUT_DEVICE_KEYBOARD_MOUSE, event->key.time, _fix_keyval(event));
     break;
   case GDK_KEY_RELEASE:


### PR DESCRIPTION
— Why did we make this feature?
— Because we could.

But was there any point in doing it? ...

Currently, widget values ​​do not change after entering vim commands that should do this. At the moment, it is just a broken feature, perhaps for a long time. I think it won't be difficult to fix, I'm just stating a fact. Only the famous exit command ":q!" works, which can be used to terminate darktable.

The feature I propose to remove is in a sense an anti-Easter-egg. The Easter egg with the game inside darktable was annoying and was visible to everyone who started the program on the day the Easter egg was triggered. This feature is not annoying at all, since it is difficult to find a person (I did not succeed) who knows about its existence.

The vim-style commands for controlling widget values ​​have NEVER been documented. I have not even found any mention of it in the release notes, mailing lists, articles on websites, anywhere. I accidentally stumbled upon this feature while studying the source code. So it is possible that only the author himself and maybe a few developers who were active at the time could use it.


The main shortcoming of this feature is not even that it takes longer to type commands than to control widgets directly (with the mouse and shortcuts), and this is even taking into account the tab-completion of names. By dragging the slider, you have image feedback and see if further adjustments are needed and in which direction, based on the image change. Changing values ​​with commands assumes that the user knows exactly what the parameter value should be. As a rule, this is not the case, so we implemented a workflow that no one needs.
