### PR TITLE
[imageio] Fix interpreting TIFF images as LDR/HDR

### DIFF
--- a/src/imageio/imageio_tiff.c
+++ b/src/imageio/imageio_tiff.c
@@ -451,8 +451,8 @@ dt_imageio_retval_t dt_imageio_open_tiff(dt_image_t *img, const char *filename, 
     return DT_IMAGEIO_CACHE_FULL;
   }
 
-  // flag the image buffer properly depending on sample format
-  if(t.sampleformat == SAMPLEFORMAT_IEEEFP)
+  // Flag the image properly depending on bit depth
+  if(t.bpp > 8)
   {
     // HDR TIFF
     t.image->flags &= ~DT_IMAGE_LDR;


### PR DESCRIPTION
LDR/HDR flag is not determined by the sample format (floating point or integer), but by the bit depth. Actually, we use this flag to choose whether image data in the absence of color space metadata should be treated as linear or nonlinear.