### PR TITLE
Revert "Call generate_styles_string.sh with bash explicitly." due to build failure on Windows

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -928,7 +928,7 @@ file(GLOB darktable_STYLES
 add_custom_command(
   DEPENDS ${darktable_STYLES} ${CMAKE_SOURCE_DIR}/tools/generate_styles_string.sh
   OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/styles_string.h
-  COMMAND bash ${CMAKE_SOURCE_DIR}/tools/generate_styles_string.sh ${DARKTABLE_DATADIR}/styles ${CMAKE_CURRENT_BINARY_DIR}/styles_string.h
+  COMMAND ${CMAKE_SOURCE_DIR}/tools/generate_styles_string.sh ${DARKTABLE_DATADIR}/styles ${CMAKE_CURRENT_BINARY_DIR}/styles_string.h
   COMMENT "Generating styles strings for translation"
 )
 


### PR DESCRIPTION
This reverts commit ff6292a01c8d3ca1825cf66a622ff62a19cffbe9.

After the commit reverted by this PR, when building on Windows, I see the output of lines like the following:
```
      0 [sig] bash 2724 get_proc_lock: Couldn't acquire sync_proc_subproc for(4,0), last 6, Win32 error 0
    397 [sig] bash 2724 proc_subproc: couldn't get proc lock. what 4, val 0
      0 [sig] bash 2853 get_proc_lock: Couldn't acquire sync_proc_subproc for(4,0), last 6, Win32 error 0
    368 [sig] bash 2853 proc_subproc: couldn't get proc lock. what 4, val 0
      0 [sig] bash 2877 get_proc_lock: Couldn't acquire sync_proc_subproc for(4,0), last 6, Win32 error 0
    545 [sig] bash 2877 proc_subproc: couldn't get proc lock. what 4, val 0
      0 [sig] bash 2985 get_proc_lock: Couldn't acquire sync_proc_subproc for(4,0), last 6, Win32 error 0
```

Each new line appears after a big timeout, it goes on for a very long time and I'm not even sure it will finish (at least within the 6 hour limit on the GitHub job).

Maybe the cause of the error is in the script, not in the reverted commit, but merging the mentioned commit makes building on Windows practically impossible.
