### PR TITLE
[GUI] Control the number of displayed thumbnails with the spin-button

### DIFF
--- a/src/libs/tools/lighttable.c
+++ b/src/libs/tools/lighttable.c
@@ -521,9 +521,6 @@ void gui_init(dt_lib_module_t *self)
 
   g_signal_connect(G_OBJECT(d->zoom), "value-changed", G_CALLBACK(_lib_lighttable_zoom_slider_changed), self);
 
-  _lib_lighttable_zoom_slider_changed(d->zoom, self); // the slider defaults to 1 and GTK doesn't
-                                                      // fire a value-changed signal when setting
-                                                      // it to 1 => empty text box
   darktable.view_manager->proxy.lighttable.module = self;
   darktable.view_manager->proxy.lighttable.set_zoom = _lib_lighttable_set_zoom;
   darktable.view_manager->proxy.lighttable.get_zoom = _lib_lighttable_get_zoom;

--- a/src/libs/tools/lighttable.c
+++ b/src/libs/tools/lighttable.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2011-2021 darktable developers.
+    Copyright (C) 2011-2025 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -34,7 +34,6 @@ DT_MODULE(1)
 typedef struct dt_lib_tool_lighttable_t
 {
   GtkWidget *zoom;
-  GtkWidget *zoom_entry;
   GtkWidget *layout_box;
   GtkWidget *layout_filemanager;
   GtkWidget *layout_zoomable;
@@ -56,10 +55,7 @@ static gint _lib_lighttable_get_zoom(dt_lib_module_t *self);
 static dt_lighttable_layout_t _lib_lighttable_get_layout(dt_lib_module_t *self);
 
 /* zoom slider change callback */
-static void _lib_lighttable_zoom_slider_changed(GtkRange *range, dt_lib_module_t *self);
-/* zoom entry change callback */
-static gboolean _lib_lighttable_zoom_entry_changed(GtkWidget *entry, GdkEventKey *event,
-                                                   dt_lib_module_t *self);
+static void _lib_lighttable_zoom_slider_changed(GtkWidget *widget, dt_lib_module_t *self);
 
 static void _set_zoom(dt_lib_module_t *self, int zoom);
 
@@ -129,9 +125,8 @@ static void _lib_lighttable_update_btn(dt_lib_module_t *self)
   else
     gtk_widget_set_tooltip_text(d->layout_culling_dynamic, _("click to exit culling layout."));
 
-  gtk_widget_set_sensitive(d->zoom_entry, (d->layout != DT_LIGHTTABLE_LAYOUT_CULLING_DYNAMIC && !fullpreview));
   gtk_widget_set_sensitive(d->zoom, (d->layout != DT_LIGHTTABLE_LAYOUT_CULLING_DYNAMIC && !fullpreview));
-  gtk_range_set_value(GTK_RANGE(d->zoom), d->current_zoom);
+  gtk_spin_button_set_value(GTK_SPIN_BUTTON(d->zoom), d->current_zoom);
 
   // culling restricted button configuration
   if(d->layout == DT_LIGHTTABLE_LAYOUT_CULLING || fullpreview)
@@ -508,17 +503,8 @@ void gui_init(dt_lib_module_t *self)
   gtk_widget_set_name(d->layout_box, "lighttable-layouts-box");
 
   /* create horizontal zoom slider */
-  d->zoom = gtk_scale_new_with_range(GTK_ORIENTATION_HORIZONTAL, 1, DT_LIGHTTABLE_MAX_ZOOM, 1);
-  gtk_widget_set_size_request(GTK_WIDGET(d->zoom), DT_PIXEL_APPLY_DPI(140), -1);
-  gtk_scale_set_draw_value(GTK_SCALE(d->zoom), FALSE);
-  gtk_range_set_increments(GTK_RANGE(d->zoom), 1, 1);
-
-  /* manual entry of the zoom level */
-  d->zoom_entry = gtk_entry_new();
-  gtk_entry_set_alignment(GTK_ENTRY(d->zoom_entry), 1.0);
-  gtk_entry_set_max_length(GTK_ENTRY(d->zoom_entry), 2);
-  gtk_entry_set_width_chars(GTK_ENTRY(d->zoom_entry), 3);
-  gtk_entry_set_max_width_chars(GTK_ENTRY(d->zoom_entry), 3);
+  d->zoom = gtk_spin_button_new_with_range(1, DT_LIGHTTABLE_MAX_ZOOM, 1);
+  gtk_spin_button_set_value(GTK_SPIN_BUTTON(d->zoom), d->current_zoom);
 
   /* culling restricted icon */
   d->layout_culling_restricted = dtgtk_togglebutton_new(dtgtk_cairo_paint_lock, 0, NULL);
@@ -529,17 +515,15 @@ void gui_init(dt_lib_module_t *self)
   g_signal_connect(G_OBJECT(d->layout_culling_restricted), "button-release-event",
                    G_CALLBACK(_lib_lighttable_restricted_btn_release), self);
 
-  self->widget = dt_gui_hbox(d->layout_box, d->zoom, d->zoom_entry, d->layout_culling_restricted);
+  self->widget = dt_gui_hbox(d->layout_box, d->zoom, d->layout_culling_restricted);
 
   _lib_lighttable_update_btn(self);
 
   g_signal_connect(G_OBJECT(d->zoom), "value-changed", G_CALLBACK(_lib_lighttable_zoom_slider_changed), self);
-  g_signal_connect(d->zoom_entry, "key-press-event", G_CALLBACK(_lib_lighttable_zoom_entry_changed), self);
-  gtk_range_set_value(GTK_RANGE(d->zoom), d->current_zoom);
 
-  _lib_lighttable_zoom_slider_changed(GTK_RANGE(d->zoom), self); // the slider defaults to 1 and GTK doesn't
-                                                                 // fire a value-changed signal when setting
-                                                                 // it to 1 => empty text box
+  _lib_lighttable_zoom_slider_changed(d->zoom, self); // the slider defaults to 1 and GTK doesn't
+                                                      // fire a value-changed signal when setting
+                                                      // it to 1 => empty text box
   darktable.view_manager->proxy.lighttable.module = self;
   darktable.view_manager->proxy.lighttable.set_zoom = _lib_lighttable_set_zoom;
   darktable.view_manager->proxy.lighttable.get_zoom = _lib_lighttable_get_zoom;
@@ -575,83 +559,15 @@ static void _set_zoom(dt_lib_module_t *self, int zoom)
   }
 }
 
-static void _lib_lighttable_zoom_slider_changed(GtkRange *range, dt_lib_module_t *self)
+static void _lib_lighttable_zoom_slider_changed(GtkWidget *widget, dt_lib_module_t *self)
 {
   dt_lib_tool_lighttable_t *d = self->data;
 
-  const int i = gtk_range_get_value(range);
-  gchar *i_as_str = g_strdup_printf("%d", i);
-  gtk_entry_set_text(GTK_ENTRY(d->zoom_entry), i_as_str);
+  const int i = gtk_spin_button_get_value_as_int(GTK_SPIN_BUTTON(widget));
   _set_zoom(self, i);
   d->current_zoom = i;
-  g_free(i_as_str);
 }
 
-static gboolean _lib_lighttable_zoom_entry_changed(GtkWidget *entry, GdkEventKey *event, dt_lib_module_t *self)
-{
-  dt_lib_tool_lighttable_t *d = self->data;
-  switch(event->keyval)
-  {
-    case GDK_KEY_Escape:
-    case GDK_KEY_Tab:
-    {
-      // reset
-      int i = 0;
-      if(d->layout == DT_LIGHTTABLE_LAYOUT_CULLING || d->layout == DT_LIGHTTABLE_LAYOUT_CULLING_DYNAMIC)
-        i = dt_conf_get_int("plugins/lighttable/culling_num_images");
-      else
-        i = dt_conf_get_int("plugins/lighttable/images_in_row");
-      gchar *i_as_str = g_strdup_printf("%d", i);
-      gtk_entry_set_text(GTK_ENTRY(d->zoom_entry), i_as_str);
-      g_free(i_as_str);
-      gtk_window_set_focus(GTK_WINDOW(dt_ui_main_window(darktable.gui->ui)), NULL);
-      return FALSE;
-    }
-
-    case GDK_KEY_Return:
-    case GDK_KEY_KP_Enter:
-    {
-      // apply zoom level
-      const gchar *value = gtk_entry_get_text(GTK_ENTRY(d->zoom_entry));
-      int i = atoi(value);
-      gtk_range_set_value(GTK_RANGE(d->zoom), i);
-      gtk_window_set_focus(GTK_WINDOW(dt_ui_main_window(darktable.gui->ui)), NULL);
-      return FALSE;
-    }
-
-    // allow 0 .. 9, left/right movement using arrow keys and del/backspace
-    case GDK_KEY_0:
-    case GDK_KEY_KP_0:
-    case GDK_KEY_1:
-    case GDK_KEY_KP_1:
-    case GDK_KEY_2:
-    case GDK_KEY_KP_2:
-    case GDK_KEY_3:
-    case GDK_KEY_KP_3:
-    case GDK_KEY_4:
-    case GDK_KEY_KP_4:
-    case GDK_KEY_5:
-    case GDK_KEY_KP_5:
-    case GDK_KEY_6:
-    case GDK_KEY_KP_6:
-    case GDK_KEY_7:
-    case GDK_KEY_KP_7:
-    case GDK_KEY_8:
-    case GDK_KEY_KP_8:
-    case GDK_KEY_9:
-    case GDK_KEY_KP_9:
-
-    case GDK_KEY_Left:
-    case GDK_KEY_Right:
-    case GDK_KEY_Delete:
-    case GDK_KEY_BackSpace:
-      return FALSE;
-
-    default: // let shortcut system deal with everything else
-      g_signal_stop_emission_by_name(entry, "key-press-event");
-      return FALSE;
-  }
-}
 
 static dt_lighttable_layout_t _lib_lighttable_get_layout(dt_lib_module_t *self)
 {
@@ -662,7 +578,7 @@ static dt_lighttable_layout_t _lib_lighttable_get_layout(dt_lib_module_t *self)
 static void _lib_lighttable_set_zoom(dt_lib_module_t *self, gint zoom)
 {
   dt_lib_tool_lighttable_t *d = self->data;
-  gtk_range_set_value(GTK_RANGE(d->zoom), zoom);
+  gtk_spin_button_set_value(GTK_SPIN_BUTTON(d->zoom), zoom);
   d->current_zoom = zoom;
 }
 

--- a/src/libs/tools/lighttable.c
+++ b/src/libs/tools/lighttable.c
@@ -505,6 +505,9 @@ void gui_init(dt_lib_module_t *self)
   /* create horizontal zoom slider */
   d->zoom = gtk_spin_button_new_with_range(1, DT_LIGHTTABLE_MAX_ZOOM, 1);
   gtk_spin_button_set_value(GTK_SPIN_BUTTON(d->zoom), d->current_zoom);
+  gtk_widget_set_tooltip_text(d->zoom,
+                              _("set the number of thumbnails per row in filemanager layout,\n"
+                                "or the total number of thumbnails shown in culling layouts"));
 
   /* culling restricted icon */
   d->layout_culling_restricted = dtgtk_togglebutton_new(dtgtk_cairo_paint_lock, 0, NULL);


### PR DESCRIPTION
Improved control of the number of displayed thumbnails on the thumbtable. This is a fix I've been mulling over for quite some time. I'm finally proposing it because I feel like the current way of controlling it is really uncomfortable for me.

Eliminates the following shortcomings:

- In order to provide at least some accuracy, the range widget must take up a lot of space. The spin button is much more compact.

- Despite the rather significant width, it was quite difficult to precisely control the value. You have to make a very small movement in the end to get the exact desired number. This requires significant concentration. Eventually, this becomes annoying and the user realizes that it's much faster to type a number in the box next to it.

- Finally, a tooltip has been added to explain in which layouts and what this control does.
