### PR TITLE
Use a more portable shell declaration in  generate_styles_string.sh

### DIFF
--- a/tools/generate_styles_string.sh
+++ b/tools/generate_styles_string.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 STYLE_DIR=$1
 OUT=$2


### PR DESCRIPTION
Fixes https://github.com/darktable-org/darktable/issues/18566 when using build.sh in a nix environment.