### PR TITLE
Fix compilation with LLVM 20

### DIFF
--- a/src/gui/gtk.h
+++ b/src/gui/gtk.h
@@ -404,7 +404,7 @@ static inline GtkWidget *dt_ui_section_label_new(const gchar *str)
 static inline GtkWidget *dt_ui_label_new(const gchar *str)
 {
   GtkWidget *label = gtk_label_new(str);
-  g_object_set(label, "halign", GTK_ALIGN_START, "xalign", 0.0f, "ellipsize", PANGO_ELLIPSIZE_END, NULL);
+  g_object_set(label, "halign", GTK_ALIGN_START, "xalign", 0.0f, "ellipsize", PANGO_ELLIPSIZE_END, (void *)0);
   return label;
 };
 


### PR DESCRIPTION
Currently, compiling darktable code with LLVM 20 fails with the following error:

```c
In file included from C:/msys64/home/Victor/darktable/src/common/exif.cc:42:
In file included from C:/msys64/home/Victor/darktable/src/control/control.h:32:
In file included from C:/msys64/home/Victor/darktable/src/control/jobs.h:24:
In file included from C:/msys64/home/Victor/darktable/src/views/view.h:21:
In file included from C:/msys64/home/Victor/darktable/src/common/act_on.h:21:
C:/msys64/home/Victor/darktable/src/gui/gtk.h:407:104: fatal error: missing sentinel in function call [-Wsentinel]
  407 |   g_object_set(label, "halign", GTK_ALIGN_START, "xalign", 0.0f, "ellipsize", PANGO_ELLIPSIZE_END, NULL);
      |                                                                                                        ^
      |                                                                                                        , nullptr
```
<br>

We can't use `NULL` here. The problem is that in this case the code ends up being included from a C++ source file (exif.cc), and in C++ (unlike plain C) `NULL` is defined as simply `0` or `0LL` (which is an integer constant, but not a pointer type), while in plain C it is defined as `((void *)0)`.

LLVM 20 starts flagging this as a warning (which becomes an error in our build process), forcing sentinel to be a null pointer, not just a null value.

The need for sentinel to be a pointer type is documented in https://gcc.gnu.org/onlinedocs/gcc-14.1.0/gcc/Common-Function-Attributes.html#index-sentinel-function-attribute:

> A valid NULL in this context is defined as zero with any pointer type. If your system defines the NULL macro with an integer type then you need to add an explicit cast.


