### PR TITLE
Detect Lens info from in body description for manual lenses on Olympus/OM System cameras

### DIFF
--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -1640,25 +1640,44 @@ static bool _exif_decode_exif_data(dt_image_t *img, Exiv2::ExifData &exifData)
       // For every Olympus camera Exif.OlympusEq.LensType is present.
       _strlcpy_to_utf8(img->exif_lens, sizeof(img->exif_lens), pos, exifData);
 
-      // We have to check if Exif.OlympusEq.LensType has been translated by
-      // Exiv2. If it hasn't, fall back to Exif.OlympusEq.LensModel.
-      std::string lens(img->exif_lens);
-      if(std::string::npos == lens.find_first_not_of(" 1234567890"))
+      // We have to check for the special case "None", which comes with manual lenses
+      if(!strncmp(img->exif_lens, "None", 4))
       {
-        // Exif.OlympusEq.LensType contains only digits and spaces.
-        // This means that Exiv2 couldn't convert it to human readable form.
-        if(FIND_EXIF_TAG("Exif.OlympusEq.LensModel"))
+        // The data from the in camera "Lens Info Settings" Dialog can always be found in
+        // in Exif.Photo.LensModel, if present at all. In newer bodies this is the only place.
+        if(FIND_EXIF_TAG("Exif.Photo.LensModel"))
         {
           _strlcpy_to_utf8(img->exif_lens, sizeof(img->exif_lens), pos, exifData);
         }
-        // Just in case Exif.OlympusEq.LensModel hasn't been found.
-        else if(FIND_EXIF_TAG("Exif.Photo.LensModel"))
-        {
-          _strlcpy_to_utf8(img->exif_lens, sizeof(img->exif_lens), pos, exifData);
-        }
-        dt_print(DT_DEBUG_ALWAYS, "[exif] Warning: lens \"%s\" unknown as \"%s\"",
-                 img->exif_lens, lens.c_str());
       }
+      else
+      {
+        // We have to check if Exif.OlympusEq.LensType has been translated by
+        // Exiv2. If it hasn't, fall back to Exif.OlympusEq.LensModel.
+        std::string lens(img->exif_lens);
+        if(std::string::npos == lens.find_first_not_of(" 1234567890"))
+        {
+          // Exif.OlympusEq.LensType contains only digits and spaces.
+          // It means that Exiv2 couldn't convert it to human readable form.
+          // This happens for lenses not yet known to exiv2
+          if(FIND_EXIF_TAG("Exif.OlympusEq.LensModel"))
+          {
+            _strlcpy_to_utf8(img->exif_lens, sizeof(img->exif_lens), pos, exifData);
+          }
+          // Just in case Exif.OlympusEq.LensModel hasn't been found.
+          else if(FIND_EXIF_TAG("Exif.Photo.LensModel"))
+          {
+            _strlcpy_to_utf8(img->exif_lens, sizeof(img->exif_lens), pos, exifData);
+          }
+          dt_print(DT_DEBUG_ALWAYS, "[exif] Warning: lens \"%s\" unknown as \"%s\"",
+                  img->exif_lens, lens.c_str());
+        }
+      }
+    }
+    else if(FIND_EXIF_TAG("Exif.OlympusEq.LensType"))
+    {
+      _strlcpy_to_utf8(img->exif_lens, sizeof(img->exif_lens), pos, exifData);
+
     }
     else if(Exiv2::testVersion(0,27,4)
             && FIND_EXIF_TAG("Exif.NikonLd4.LensID") && pos->toLong() == 0)


### PR DESCRIPTION
Olympus/OM System cameras have a config dialog, where you can enter name, focal length and aperture value for several lenses and activate one of these settings. This data is then written into the exif data.

Exif.OlympusEq.LensType contains 6 binary bytes, which are translated to the full lens name by table lookup in exiv2. In case of manual lenses, the translation is the string "None". In case of lenses unknown to exiv2, the return value from exiv2 is just these 6 Bytes translated to a string.

The code in this place catches the case of unknown lenses. This patch implements the None-case.

I have two cameras. A 9+ year old Pen-F and a new OM-3. The handling of this case changed over firmware upgrades of the Pen-F. But if the data is present at all in the exif data, then it can be found in Exif.Photo.LensModel (it is not present for some old firmware in jpeg-files). For some cases it is also present in Exif.OlympusEq.LensModel, but not in the OM-3 and the latest Pen-F firmware. And for some old Pen-F firmware it was there, although an electronic lens was attached (Bug). So Exif.Photo.LensModel is the way to go.

I know, this are only 2 cameras. But it can reasonably be expected, that Olympus/OM Software is somewhat consistent over their product range and these two cases cover the last 9+ years. If a special case is missed, that can be fixed when reported.
