### PR TITLE
Gamma pipeline cache fix

### DIFF
--- a/src/iop/gamma.c
+++ b/src/iop/gamma.c
@@ -322,6 +322,9 @@ void process(dt_iop_module_t *self,
   {
     _copy_output((const float *const restrict)i, (uint8_t *const restrict)o, buffsize);
   }
+
+  if(mask_display)
+    dt_dev_pixelpipe_invalidate_cacheline(piece->pipe, i);
 }
 
 void init(dt_iop_module_t *self)


### PR DESCRIPTION
If we bypass modules in the pixelpipe because of any mask visualizing we must invalidate the input cacheline of 'gamma' module - although that already has low priority - for a safe toggle of any pipe->mask_display while processing the pipe like using DT_DEV_PIXELPIPE_DISPLAY_PASSTHRU.

I don't think a release note is required for this ...