### PR TITLE
Pick selected color from image in 4 ways tab in color balance rgb

### DIFF
--- a/src/iop/colorbalancergb.c
+++ b/src/iop/colorbalancergb.c
@@ -1285,7 +1285,8 @@ void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker,
   pipe_RGB_to_Ych(self, pipe, (const float *)self->picked_color, Ych);
   pipe_RGB_to_Ych(self, pipe, (const float *)self->picked_color_max, max_Ych);
   const float picked_hue = get_hue_angle_from_Ych(Ych);
-  const float hue = RAD_TO_DEG(picked_hue) + 180.f;   // take the opponent color
+  GdkModifierType state = gdk_keymap_get_modifier_state(gdk_keymap_get_for_display(gdk_display_get_default()));
+  const float hue = (state & GDK_CONTROL_MASK) ? RAD_TO_DEG(picked_hue) : RAD_TO_DEG(picked_hue) + 180;
 
   ++darktable.gui->reset;
   if(picker == g->global_H)


### PR DESCRIPTION
If you click, the opposite color is selected, and if you ctrl+click, the current color is selected.

Fixes #17469