### PR TITLE
Avoid nightly build failure by ignoring `-Wshadow` for exiv2 includes

### DIFF
--- a/tools/basecurve/exif-wrapper.cpp
+++ b/tools/basecurve/exif-wrapper.cpp
@@ -16,9 +16,13 @@
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+// avoid error reported when including exiv2.hpp on macOS (XCode 15.2)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wshadow"
 #include <exiv2/exif.hpp>
 #include <exiv2/error.hpp>
 #include <exiv2/image.hpp>
+#pragma GCC diagnostic pop
 
 #include <cstdio>
 #include <cassert>

--- a/tools/basecurve/exif-wrapper.cpp
+++ b/tools/basecurve/exif-wrapper.cpp
@@ -1,6 +1,7 @@
 /*
     This file is part of darktable,
                   2014 Edouard Gomez
+    Copyright (C) 2025 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Same as in #18647 but for source code that is compiled in nightly only (not in CI).
