### PR TITLE
Ensure DT_DEMOSAIC_FULL_SCALE for second window

### DIFF
--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -569,8 +569,8 @@ static void _dev_pixelpipe_synch(dt_dev_pixelpipe_t *pipe,
         const dt_develop_blend_params_t *const bp = piece->blendop_data;
         const gboolean valid_mask = bp->mask_mode > DEVELOP_MASK_ENABLED;
 
-        if((!feqf(bp->details, 0.0f, 1e-6)) && valid_mask)
-          dt_dev_pixelpipe_usedetails(pipe);
+        if(!feqf(bp->details, 0.0f, 1e-6) && valid_mask)
+          dt_dev_pixelpipe_usedetails(piece);
       }
     }
   }
@@ -690,13 +690,15 @@ void dt_dev_pixelpipe_change(dt_dev_pixelpipe_t *pipe, dt_develop_t *dev)
                                   &pipe->processed_height);
 }
 
-void dt_dev_pixelpipe_usedetails(dt_dev_pixelpipe_t *pipe)
+void dt_dev_pixelpipe_usedetails(dt_dev_pixelpipe_iop_t *piece)
 {
+  dt_dev_pixelpipe_t *pipe = piece->pipe;
   if(!pipe->want_detail_mask)
   {
+    dt_print_pipe(DT_DEBUG_PIPE, "details requested", pipe, piece->module, DT_DEVICE_NONE, NULL, NULL);
     dt_dev_pixelpipe_cache_invalidate_later(pipe, 0);
+    pipe->want_detail_mask = TRUE;
   }
-  pipe->want_detail_mask = TRUE;
 }
 
 static void _dump_pipe_pfm_diff(const char *mod,

--- a/src/develop/pixelpipe_hb.h
+++ b/src/develop/pixelpipe_hb.h
@@ -285,7 +285,7 @@ void dt_dev_pixelpipe_synch_top(dt_dev_pixelpipe_t *pipe, struct dt_develop_t *d
 void dt_dev_pixelpipe_rebuild(struct dt_develop_t *dev);
 
 // switch on details mask processing
-void dt_dev_pixelpipe_usedetails(dt_dev_pixelpipe_t *pipe);
+void dt_dev_pixelpipe_usedetails(dt_dev_pixelpipe_iop_t *piece);
 // process region of interest of pixels. returns TRUE if pipe was altered during processing.
 gboolean dt_dev_pixelpipe_process(dt_dev_pixelpipe_t *pipe,
                              struct dt_develop_t *dev,

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -228,6 +228,9 @@ static dt_iop_demosaic_qual_flags_t demosaic_qual_flags(const dt_dev_pixelpipe_i
   dt_iop_demosaic_qual_flags_t flags = DT_DEMOSAIC_DEFAULT;
   switch(piece->pipe->type & DT_DEV_PIXELPIPE_ANY)
   {
+    case DT_DEV_PIXELPIPE_PREVIEW2:
+      flags |= DT_DEMOSAIC_FULL_SCALE;
+      break;
     case DT_DEV_PIXELPIPE_FULL:
       flags |= DT_DEMOSAIC_FULL_SCALE;
       break;
@@ -1085,7 +1088,7 @@ void commit_params(dt_iop_module_t *self,
 
   if(use_method & DT_DEMOSAIC_DUAL)
   {
-    dt_dev_pixelpipe_usedetails(piece->pipe);
+    dt_dev_pixelpipe_usedetails(piece);
     d->color_smoothing = DT_DEMOSAIC_SMOOTH_OFF;
   }
   d->demosaicing_method = use_method;


### PR DESCRIPTION
1. Ensure high quality demosaicing for the second window for quality
2. While doing so we support details blending and dual demosaicers
3. Redefine `dt_dev_pixelpipe_usedetails()` using `dt_dev_pixelpipe_iop_t *piece` as the parameter to allow log reports who is requesting the details.

Fixes #18651