### PR TITLE
Tone equalizer 2025-04-06 preview version

### DIFF
--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -37,14 +37,14 @@
  * perfect, and I'm still looking forward to a real spectral energy
  * estimator. The best physically-accurate norm should be the
  * euclidean norm, but the best looking is often the power norm, which
- * has no theoretical background.  The geometric mean also display
+ * has no theoretical background. The geometric mean also display
  * interesting properties as it interprets saturated colours as
  * low-lights, allowing to lighten and desaturate them in a realistic
  * way.
  *
  * The exposure correction is computed as a series of each octave's
  * gain weighted by the gaussian of the radial distance between the
- * current pixel exposure and each octave's center.  This allows for a
+ * current pixel exposure and each octave's center. This allows for a
  * smooth and continuous infinite-order interpolation, preserving
  * exposure gradients as best as possible. The radius of the kernel is
  * user-defined and can be tweaked to get a smoother interpolation
@@ -69,11 +69,11 @@
  * smooth contiguous region (quantization parameter), but also to
  * translate (exposure boost) and dilate (contrast boost) the exposure
  * histogram through the control octaves, to center it on the control
- * view and make maximum use of the available channels.
+ * view and make maximum use of the available NUM_SLIDERS.
  *
  * Users should be aware that not all the available octaves will be
  * useful on every pictures.  Some automatic options will help them to
- * optimize the luminance mask, performing histogram analyse, mapping
+ * optimize the luminance mask, performing histogram analys, mapping
  * the average exposure to -4EV, and mapping the first and last
  * deciles of the histogram on its average ± 4EV. These automatic
  * helpers usually fail on X-Trans sensors, maybe because of bad
@@ -126,22 +126,35 @@
 
 DT_MODULE_INTROSPECTION(2, dt_iop_toneequalizer_params_t)
 
+/****************************************************************************
+ *
+ * Definition of constants
+ *
+ ****************************************************************************/
 
-#define UI_SAMPLES 256 // 128 is a bit small for 4K resolution
+#define UI_HISTO_SAMPLES 256 // 128 is a bit small for 4K resolution
+#define HIRES_HISTO_SAMPLES UI_HISTO_SAMPLES * 3 * 16
 #define CONTRAST_FULCRUM exp2f(-4.0f)
 #define MIN_FLOAT exp2f(-16.0f)
+
+#define DT_TONEEQ_MIN_EV (-8.0f)
+#define DT_TONEEQ_MAX_EV (0.0f)
+#define DT_TONEEQ_USE_LUT TRUE
+
+#define HIRES_HISTO_MIN_EV -16.0f
+#define HIRES_HISTO_MAX_EV 8.0f
 
 /**
  * Build the exposures octaves :
  * band-pass filters with gaussian windows spaced by 1 EV
 **/
 
-#define CHANNELS 9
-#define PIXEL_CHAN 8
+#define NUM_SLIDERS 9
+#define NUM_OCTAVES 8
 #define LUT_RESOLUTION 10000
 
 // radial distances used for pixel ops
-static const float centers_ops[PIXEL_CHAN] DT_ALIGNED_ARRAY =
+static const float centers_ops[NUM_OCTAVES] DT_ALIGNED_ARRAY =
   {-56.0f / 7.0f, // = -8.0f
    -48.0f / 7.0f,
    -40.0f / 7.0f,
@@ -149,12 +162,24 @@ static const float centers_ops[PIXEL_CHAN] DT_ALIGNED_ARRAY =
    -24.0f / 7.0f,
    -16.0f / 7.0f,
    -8.0f / 7.0f,
-   0.0f / 7.0f}; // split 8 EV into 7 evenly-spaced channels
+   0.0f / 7.0f}; // split 8 EV into 7 evenly-spaced NUM_SLIDERS
 
-static const float centers_params[CHANNELS] DT_ALIGNED_ARRAY =
+static const float centers_params[NUM_SLIDERS] DT_ALIGNED_ARRAY =
   { -8.0f, -7.0f, -6.0f, -5.0f,
     -4.0f, -3.0f, -2.0f, -1.0f, 0.0f};
 
+// gaussian-ish kernel - sum is == 1.0f so we don't care much about actual coeffs
+static const dt_colormatrix_t gauss_kernel =
+  { { 0.076555024f, 0.124401914f, 0.076555024f },
+    { 0.124401914f, 0.196172249f, 0.124401914f },
+    { 0.076555024f, 0.124401914f, 0.076555024f } };
+
+
+/****************************************************************************
+ *
+ * Types
+ *
+ ****************************************************************************/
 
 typedef enum dt_iop_toneequalizer_filter_t
 {
@@ -165,40 +190,53 @@ typedef enum dt_iop_toneequalizer_filter_t
   DT_TONEEQ_EIGF        // $DESCRIPTION: "EIGF"
 } dt_iop_toneequalizer_filter_t;
 
+typedef enum dt_iop_toneequalizer_post_auto_align_t
+{
+  DT_TONEEQ_ALIGN_CUSTOM = 0,   // $DESCRIPTION: "custom"
+  DT_TONEEQ_ALIGN_LEFT,         // $DESCRIPTION: "auto-align at shadows"
+  DT_TONEEQ_ALIGN_CENTER,       // $DESCRIPTION: "auto-align at mid-tones"
+  DT_TONEEQ_ALIGN_RIGHT,        // $DESCRIPTION: "auto-align at highlights"
+  DT_TONEEQ_ALIGN_FIT,          // $DESCRIPTION: "fully fit"
+
+} dt_iop_toneequalizer_post_auto_align_t;
 
 typedef struct dt_iop_toneequalizer_params_t
 {
-  float noise; // $MIN: -2.0 $MAX: 2.0 $DEFAULT: 0.0  $DESCRIPTION: "blacks"
+  float noise;             // $MIN: -2.0 $MAX: 2.0 $DEFAULT: 0.0  $DESCRIPTION: "blacks"
   float ultra_deep_blacks; // $MIN: -2.0 $MAX: 2.0 $DEFAULT: 0.0  $DESCRIPTION: "deep shadows"
-  float deep_blacks; // $MIN: -2.0 $MAX: 2.0 $DEFAULT: 0.0  $DESCRIPTION: "shadows"
-  float blacks; // $MIN: -2.0 $MAX: 2.0 $DEFAULT: 0.0  $DESCRIPTION: "light shadows"
-  float shadows; // $MIN: -2.0 $MAX: 2.0 $DEFAULT: 0.0  $DESCRIPTION: "mid-tones"
-  float midtones; // $MIN: -2.0 $MAX: 2.0 $DEFAULT: 0.0  $DESCRIPTION: "dark highlights"
-  float highlights; // $MIN: -2.0 $MAX: 2.0 $DEFAULT: 0.0  $DESCRIPTION: "highlights"
-  float whites; // $MIN: -2.0 $MAX: 2.0 $DEFAULT: 0.0  $DESCRIPTION: "whites"
-  float speculars; // $MIN: -2.0 $MAX: 2.0 $DEFAULT: 0.0  $DESCRIPTION: "speculars"
-  float blending; // $MIN: 0.01 $MAX: 100.0 $DEFAULT: 5.0 $DESCRIPTION: "smoothing diameter"
-  float smoothing; // $DEFAULT: 1.414213562 sqrtf(2.0f)
-  float feathering; // $MIN: 0.01 $MAX: 10000.0 $DEFAULT: 1.0 $DESCRIPTION: "edges refinement/feathering"
-  float quantization; // $MIN: 0.0 $MAX: 2.0 $DEFAULT: 0.0 $DESCRIPTION: "mask quantization"
-  float contrast_boost; // $MIN: -16.0 $MAX: 16.0 $DEFAULT: 0.0 $DESCRIPTION: "mask contrast compensation"
-  float exposure_boost; // $MIN: -16.0 $MAX: 16.0 $DEFAULT: 0.0 $DESCRIPTION: "mask exposure compensation"
-  dt_iop_toneequalizer_filter_t details; // $DEFAULT: DT_TONEEQ_EIGF
-  dt_iop_luminance_mask_method_t method; // $DEFAULT: DT_TONEEQ_NORM_2 $DESCRIPTION: "luminance estimator"
-  int iterations; // $MIN: 1 $MAX: 20 $DEFAULT: 1 $DESCRIPTION: "filter diffusion"
+  float deep_blacks;       // $MIN: -2.0 $MAX: 2.0 $DEFAULT: 0.0  $DESCRIPTION: "shadows"
+  float blacks;            // $MIN: -2.0 $MAX: 2.0 $DEFAULT: 0.0  $DESCRIPTION: "light shadows"
+  float shadows;           // $MIN: -2.0 $MAX: 2.0 $DEFAULT: 0.0  $DESCRIPTION: "mid-tones"
+  float midtones;          // $MIN: -2.0 $MAX: 2.0 $DEFAULT: 0.0  $DESCRIPTION: "dark highlights"
+  float highlights;        // $MIN: -2.0 $MAX: 2.0 $DEFAULT: 0.0  $DESCRIPTION: "highlights"
+  float whites;            // $MIN: -2.0 $MAX: 2.0 $DEFAULT: 0.0  $DESCRIPTION: "whites"
+  float speculars;         // $MIN: -2.0 $MAX: 2.0 $DEFAULT: 0.0  $DESCRIPTION: "speculars"
+  float blending;          // $MIN: 0.01 $MAX: 100.0 $DEFAULT: 5.0 $DESCRIPTION: "smoothing diameter"
+  float smoothing;         // $DEFAULT: 1.414213562 sqrtf(2.0f)
+  float feathering;        // $MIN: 0.01 $MAX: 10000.0 $DEFAULT: 1.0 $DESCRIPTION: "edges refinement/feathering"
+  float quantization;      // $MIN: 0.0 $MAX: 2.0 $DEFAULT: 0.0 $DESCRIPTION: "mask quantization"
+  float contrast_boost;    // $MIN: -16.0 $MAX: 16.0 $DEFAULT: 0.0 $DESCRIPTION: "mask contrast compensation"
+  float exposure_boost;    // $MIN: -16.0 $MAX: 16.0 $DEFAULT: 0.0 $DESCRIPTION: "mask exposure compensation"
+  dt_iop_toneequalizer_filter_t filter;         // $DEFAULT: DT_TONEEQ_EIGF
+  dt_iop_luminance_mask_method_t lum_estimator; // $DEFAULT: DT_TONEEQ_NORM_2 $DESCRIPTION: "luminance estimator"
+  int iterations;          // $MIN: 1 $MAX: 20 $DEFAULT: 1 $DESCRIPTION: "filter diffusion"
+  float post_scale;        // $MIN: -3.0 $MAX: 3.0 $DEFAULT: 0.0 $DESCRIPTION: "mask contrast / scale histogram"
+  float post_shift;        // $MIN: -4.0 $MAX: 4.0 $DEFAULT: 0.0 $DESCRIPTION: "mask brightness / shift histogram"
+  dt_iop_toneequalizer_post_auto_align_t post_auto_align; // $DEFAULT: DT_TONEEQ_ALIGN_CUSTOM $DESCRIPTION: "auto align mask exposure"
 } dt_iop_toneequalizer_params_t;
 
 
 typedef struct dt_iop_toneequalizer_data_t
 {
-  float factors[PIXEL_CHAN] DT_ALIGNED_ARRAY;
-  float correction_lut[PIXEL_CHAN * LUT_RESOLUTION + 1] DT_ALIGNED_ARRAY;
-  float blending, feathering, contrast_boost, exposure_boost, quantization, smoothing;
+  float factors[NUM_OCTAVES] DT_ALIGNED_ARRAY;
+  float correction_lut[NUM_OCTAVES * LUT_RESOLUTION + 1] DT_ALIGNED_ARRAY;
+  float blending, feathering, contrast_boost, exposure_boost, quantization, smoothing, post_scale, post_shift;
   float scale;
   int radius;
   int iterations;
-  dt_iop_luminance_mask_method_t method;
-  dt_iop_toneequalizer_filter_t details;
+  dt_iop_luminance_mask_method_t lum_estimator;
+  dt_iop_toneequalizer_filter_t filter;
+  dt_iop_toneequalizer_post_auto_align_t post_auto_align;
 } dt_iop_toneequalizer_data_t;
 
 
@@ -211,11 +249,15 @@ typedef struct dt_iop_toneequalizer_global_data_t
 typedef struct dt_iop_toneequalizer_gui_data_t
 {
   // Mem arrays 64-bytes aligned - contiguous memory
-  float factors[PIXEL_CHAN] DT_ALIGNED_ARRAY;
-  float gui_lut[UI_SAMPLES] DT_ALIGNED_ARRAY; // LUT for the UI graph
-  float interpolation_matrix[CHANNELS * PIXEL_CHAN] DT_ALIGNED_ARRAY;
-  int histogram[UI_SAMPLES] DT_ALIGNED_ARRAY; // histogram for the UI graph
-  float temp_user_params[CHANNELS] DT_ALIGNED_ARRAY;
+  float factors[NUM_OCTAVES] DT_ALIGNED_ARRAY;
+  float gui_curve[UI_HISTO_SAMPLES] DT_ALIGNED_ARRAY;              // LUT for the UI graph
+  GdkRGBA gui_curve_colors[UI_HISTO_SAMPLES] DT_ALIGNED_ARRAY;     // color for the UI graph
+  float interpolation_matrix[NUM_SLIDERS * NUM_OCTAVES] DT_ALIGNED_ARRAY;
+  int histogram[UI_HISTO_SAMPLES] DT_ALIGNED_ARRAY;                // mask histogram for the UI graph
+  int hires_histogram[HIRES_HISTO_SAMPLES] DT_ALIGNED_ARRAY;       // hires mask histogram
+  int image_histogram[UI_HISTO_SAMPLES] DT_ALIGNED_ARRAY;          // image histogram for UI graph
+  int image_hires_histogram[HIRES_HISTO_SAMPLES] DT_ALIGNED_ARRAY; // hires image histogram
+  float temp_user_params[NUM_SLIDERS] DT_ALIGNED_ARRAY;
   float cursor_exposure; // store the exposure value at current cursor position
   float step; // scrolling step
 
@@ -229,30 +271,47 @@ typedef struct dt_iop_toneequalizer_gui_data_t
   int pipe_order;
 
   // 6 uint64 to pack - contiguous-ish memory
-  dt_hash_t ui_preview_hash;
-  dt_hash_t thumb_preview_hash;
-  size_t full_preview_buf_width, full_preview_buf_height;
-  size_t thumb_preview_buf_width, thumb_preview_buf_height;
+  dt_hash_t full_upstream_hash;
+  dt_hash_t preview_upstream_hash;
+  dt_hash_t sync_hash;
+
+  size_t preview_buf_width, preview_buf_height;
+  size_t full_buf_width, full_buf_height;
+
+  // Heap arrays, 64 bits-aligned, unknown length
+  float *preview_buf;  // For performance and to get the mask luminance under the mouse cursor
+  float *full_buf;     // For performance and for displaying the mask as greyscale
 
   // Misc stuff, contiguity, length and alignment unknown
   float scale;
   float sigma;
-  float histogram_average;
+
+  // stats for the mask histogram
   float histogram_first_decile;
   float histogram_last_decile;
 
-  // Heap arrays, 64 bits-aligned, unknown length
-  float *thumb_preview_buf;
-  float *full_preview_buf;
+  // automatic values for post scale/shift from PREVIEW thread
+  float post_scale_value;
+  float post_shift_value;
+
+  // stats for the image histogram
+  float image_histogram_first_decile;
+  float image_histogram_last_decile;
+  int max_image_histogram;
+  float image_EV_per_UI_sample;
+  gboolean two_histograms_display;
 
   // GTK garbage, nobody cares, no SIMD here
   GtkWidget *noise, *ultra_deep_blacks, *deep_blacks, *blacks, *shadows, *midtones, *highlights, *whites, *speculars;
   GtkDrawingArea *area, *bar;
   GtkWidget *blending, *smoothing, *quantization;
+  GtkWidget *post_auto_align;
   GtkWidget *method;
-  GtkWidget *details, *feathering, *contrast_boost, *iterations, *exposure_boost;
+  GtkWidget *details, *feathering, *contrast_boost, *iterations, *exposure_boost, *post_scale, *post_shift;
   GtkNotebook *notebook;
+  dt_gui_collapsible_section_t sliders_section, advanced_masking_section;
   GtkWidget *show_luminance_mask;
+  GtkWidget *show_two_histograms;
 
   // Cache Pango and Cairo stuff for the equalizer drawing
   float line_height;
@@ -277,8 +336,8 @@ typedef struct dt_iop_toneequalizer_gui_data_t
   GtkStyleContext *context;
 
   // Event for equalizer drawing
-  float nodes_x[CHANNELS] DT_ALIGNED_ARRAY;
-  float nodes_y[CHANNELS] DT_ALIGNED_ARRAY;
+  float nodes_x[NUM_SLIDERS] DT_ALIGNED_ARRAY;
+  float nodes_y[NUM_SLIDERS] DT_ALIGNED_ARRAY;
   float area_x; // x coordinate of cursor over graph/drawing area
   float area_y; // y coordinate
   int area_active_node;
@@ -294,16 +353,20 @@ typedef struct dt_iop_toneequalizer_gui_data_t
   gboolean has_focus;          // TRUE if the widget has the focus from GTK
 
   // Flags for buffer caches invalidation
-  gboolean interpolation_valid; // TRUE if the interpolation_matrix is ready
-  gboolean luminance_valid;     // TRUE if the luminance cache is ready
-  gboolean histogram_valid;     // TRUE if the histogram cache and stats are ready
-  gboolean lut_valid;           // TRUE if the gui_lut is ready
+  gboolean luminance_valid;     // TRUE if the luminance cache is ready,
+                                //      hires_histogram and deciles are valid
+  gboolean gui_histogram_valid; // TRUE if the histogram cache and stats are ready
   gboolean graph_valid;         // TRUE if the UI graph view is ready
+
+  // For the curve interpolation
+  gboolean interpolation_valid; // TRUE if the interpolation_matrix is ready
+
   gboolean user_param_valid;    // TRUE if users params set in
                                 // interactive view are in bounds
   gboolean factors_valid;       // TRUE if radial-basis coeffs are ready
+  gboolean gui_curve_valid;     // TRUE if the gui_curve is ready
 
-  gboolean distort_signal_actif;
+  gboolean distort_signal_active;
 } dt_iop_toneequalizer_gui_data_t;
 
 /* the signal DT_SIGNAL_DEVELOP_DISTORT is used to refresh the internal
@@ -311,10 +374,17 @@ typedef struct dt_iop_toneequalizer_gui_data_t
 static void _set_distort_signal(dt_iop_module_t *self);
 static void _unset_distort_signal(dt_iop_module_t *self);
 
+/****************************************************************************
+ *
+ * Darktable housekeeping functions
+ *
+ ****************************************************************************/
+
 const char *name()
 {
   return _("tone equalizer");
 }
+
 
 const char *aliases()
 {
@@ -332,15 +402,18 @@ const char **description(dt_iop_module_t *self)
      _("quasi-linear, RGB, scene-referred"));
 }
 
+
 int default_group()
 {
   return IOP_GROUP_BASIC | IOP_GROUP_GRADING;
 }
 
+
 int flags()
 {
   return IOP_FLAGS_INCLUDE_IN_STYLES | IOP_FLAGS_SUPPORTS_BLENDING;
 }
+
 
 dt_iop_colorspace_type_t default_colorspace(dt_iop_module_t *self,
                                             dt_dev_pixelpipe_t *pipe,
@@ -349,6 +422,7 @@ dt_iop_colorspace_type_t default_colorspace(dt_iop_module_t *self,
   return IOP_CS_RGB;
 }
 
+
 int legacy_params(dt_iop_module_t *self,
                   const void *const old_params,
                   const int old_version,
@@ -356,7 +430,9 @@ int legacy_params(dt_iop_module_t *self,
                   int32_t *new_params_size,
                   int *new_version)
 {
-  typedef struct dt_iop_toneequalizer_params_v2_t
+  printf("legacy_params old_version=%d\n", old_version);
+
+  typedef struct dt_iop_toneequalizer_params_v3_t
   {
     float noise;
     float ultra_deep_blacks;
@@ -376,7 +452,10 @@ int legacy_params(dt_iop_module_t *self,
     dt_iop_toneequalizer_filter_t details;
     dt_iop_luminance_mask_method_t method;
     int iterations;
-  } dt_iop_toneequalizer_params_v2_t;
+    float post_scale;
+    float post_shift;
+    dt_iop_toneequalizer_post_auto_align_t post_auto_align;
+  } dt_iop_toneequalizer_params_v3_t;
 
   if(old_version == 1)
   {
@@ -391,7 +470,7 @@ int legacy_params(dt_iop_module_t *self,
     } dt_iop_toneequalizer_params_v1_t;
 
     const dt_iop_toneequalizer_params_v1_t *o = old_params;
-    dt_iop_toneequalizer_params_v2_t *n = malloc(sizeof(dt_iop_toneequalizer_params_v2_t));
+    dt_iop_toneequalizer_params_v3_t *n = malloc(sizeof(dt_iop_toneequalizer_params_v3_t));
 
     // Olds params
     n->noise = o->noise;
@@ -413,18 +492,81 @@ int legacy_params(dt_iop_module_t *self,
     n->iterations = o->iterations;
     n->method = o->method;
 
-    // New params
+    // V2 params
     n->quantization = 0.0f;
     n->smoothing = sqrtf(2.0f);
 
+    // V3 params
+    n->post_scale = 0.0f;
+    n->post_shift = 0.0f;
+    n->post_auto_align = DT_TONEEQ_ALIGN_CUSTOM;
+
     *new_params = n;
-    *new_params_size = sizeof(dt_iop_toneequalizer_params_v2_t);
-    *new_version = 2;
+    *new_params_size = sizeof(dt_iop_toneequalizer_params_v3_t);
+    *new_version = 3;
     return 0;
   }
+
+  if(old_version == 2)
+  {
+    typedef struct dt_iop_toneequalizer_params_v2_t
+    {
+      float noise; float ultra_deep_blacks; float deep_blacks; float blacks;
+      float shadows; float midtones; float highlights; float whites;
+      float speculars; float blending; float smoothing; float feathering;
+      float quantization; float contrast_boost; float exposure_boost;
+      dt_iop_toneequalizer_filter_t details;
+      dt_iop_luminance_mask_method_t method;
+      int iterations;
+    } dt_iop_toneequalizer_params_v2_t;
+
+    const dt_iop_toneequalizer_params_v2_t *o = old_params;
+    dt_iop_toneequalizer_params_v3_t *n = malloc(sizeof(dt_iop_toneequalizer_params_v3_t));
+
+    // V1 params
+    n->noise = o->noise;
+    n->ultra_deep_blacks = o->ultra_deep_blacks;
+    n->deep_blacks = o->deep_blacks;
+    n->blacks = o->blacks;
+    n->shadows = o->shadows;
+    n->midtones = o->midtones;
+    n->highlights = o->highlights;
+    n->whites = o->whites;
+    n->speculars = o->speculars;
+
+    n->blending = o->blending;
+    n->feathering = o->feathering;
+    n->contrast_boost = o->contrast_boost;
+    n->exposure_boost = o->exposure_boost;
+
+    n->details = o->details;
+    n->iterations = o->iterations;
+    n->method = o->method;
+
+    // V2 params
+    n->quantization = o->quantization;
+    n->smoothing = o->smoothing;
+
+    // V3 params
+    n->post_scale = 0.0f;
+    n->post_shift = 0.0f;
+    n->post_auto_align = DT_TONEEQ_ALIGN_CUSTOM;
+
+    *new_params = n;
+    *new_params_size = sizeof(dt_iop_toneequalizer_params_v3_t);
+    *new_version = 3;
+    return 0;
+  }
+
   return 1;
 }
 
+
+/****************************************************************************
+ *
+ * Presets
+ *
+ ****************************************************************************/
 static void compress_shadows_highlight_preset_set_exposure_params
   (dt_iop_toneequalizer_params_t* p,
    const float step)
@@ -461,19 +603,23 @@ static void dilate_shadows_highlight_preset_set_exposure_params
   p->speculars = 15.f / 9.f * step;
 }
 
+
 void init_presets(dt_iop_module_so_t *self)
 {
   dt_iop_toneequalizer_params_t p;
   memset(&p, 0, sizeof(p));
 
-  p.method = DT_TONEEQ_NORM_POWER;
+  p.lum_estimator = DT_TONEEQ_NORM_POWER;
   p.contrast_boost = 0.0f;
-  p.details = DT_TONEEQ_NONE;
+  p.filter = DT_TONEEQ_NONE;
   p.exposure_boost = -0.5f;
   p.feathering = 1.0f;
   p.iterations = 1;
   p.smoothing = sqrtf(2.0f);
   p.quantization = 0.0f;
+  p.post_scale = 0.0f;
+  p.post_shift = 0.0f;
+  p.post_auto_align = DT_TONEEQ_ALIGN_CUSTOM;
 
   // Init exposure settings
   p.noise = p.ultra_deep_blacks = p.deep_blacks = p.blacks = 0.0f;
@@ -485,8 +631,8 @@ void init_presets(dt_iop_module_so_t *self)
      self->version(), &p, sizeof(p), 1, DEVELOP_BLEND_CS_RGB_SCENE);
 
   // Simple utils blendings
-  p.details = DT_TONEEQ_EIGF;
-  p.method = DT_TONEEQ_NORM_2;
+  p.filter = DT_TONEEQ_EIGF;
+  p.lum_estimator = DT_TONEEQ_NORM_2;
 
   p.blending = 5.0f;
   p.feathering = 1.0f;
@@ -495,14 +641,14 @@ void init_presets(dt_iop_module_so_t *self)
   p.exposure_boost = 0.0f;
   p.contrast_boost = 0.0f;
   dt_gui_presets_add_generic
-    (_("mask blending | all purposes"), self->op,
+    (_("mask blending: all purposes"), self->op,
      self->version(), &p, sizeof(p), 1, DEVELOP_BLEND_CS_RGB_SCENE);
 
   p.blending = 1.0f;
   p.feathering = 10.0f;
   p.iterations = 3;
   dt_gui_presets_add_generic
-    (_("mask blending | people with backlight"), self->op,
+    (_("mask blending: people with backlight"), self->op,
      self->version(), &p, sizeof(p), 1, DEVELOP_BLEND_CS_RGB_SCENE);
 
   // Shadows/highlights presets
@@ -515,66 +661,66 @@ void init_presets(dt_iop_module_so_t *self)
   p.quantization = 0.0f;
 
   // slight modification to give higher compression
-  p.details = DT_TONEEQ_EIGF;
+  p.filter = DT_TONEEQ_EIGF;
   p.feathering = 20.0f;
   compress_shadows_highlight_preset_set_exposure_params(&p, 0.65f);
   dt_gui_presets_add_generic
-    (_("compress shadows/highlights | EIGF | strong"), self->op,
+    (_("compress shadows/highlights (EIGF): strong"), self->op,
      self->version(), &p, sizeof(p), 1, DEVELOP_BLEND_CS_RGB_SCENE);
-  p.details = DT_TONEEQ_GUIDED;
+  p.filter = DT_TONEEQ_GUIDED;
   p.feathering = 500.0f;
   dt_gui_presets_add_generic
-    (_("compress shadows/highlights | GF | strong"), self->op,
+    (_("compress shadows/highlights (GF): strong"), self->op,
      self->version(), &p, sizeof(p), 1, DEVELOP_BLEND_CS_RGB_SCENE);
 
-  p.details = DT_TONEEQ_EIGF;
+  p.filter = DT_TONEEQ_EIGF;
   p.blending = 3.0f;
   p.feathering = 7.0f;
   p.iterations = 3;
   compress_shadows_highlight_preset_set_exposure_params(&p, 0.45f);
   dt_gui_presets_add_generic
-    (_("compress shadows/highlights | EIGF | medium"), self->op,
+    (_("compress shadows/highlights (EIGF): medium"), self->op,
      self->version(), &p, sizeof(p), 1, DEVELOP_BLEND_CS_RGB_SCENE);
-  p.details = DT_TONEEQ_GUIDED;
+  p.filter = DT_TONEEQ_GUIDED;
   p.feathering = 500.0f;
   dt_gui_presets_add_generic
-    (_("compress shadows/highlights | GF | medium"), self->op,
+    (_("compress shadows/highlights (GF): medium"), self->op,
      self->version(), &p, sizeof(p), 1, DEVELOP_BLEND_CS_RGB_SCENE);
 
-  p.details = DT_TONEEQ_EIGF;
+  p.filter = DT_TONEEQ_EIGF;
   p.blending = 5.0f;
   p.feathering = 1.0f;
   p.iterations = 1;
   compress_shadows_highlight_preset_set_exposure_params(&p, 0.25f);
   dt_gui_presets_add_generic
-    (_("compress shadows/highlights | EIGF | soft"), self->op,
+    (_("compress shadows/highlights (EIGF): soft"), self->op,
      self->version(), &p, sizeof(p), 1, DEVELOP_BLEND_CS_RGB_SCENE);
-  p.details = DT_TONEEQ_GUIDED;
+  p.filter = DT_TONEEQ_GUIDED;
   p.feathering = 500.0f;
   dt_gui_presets_add_generic
-    (_("compress shadows/highlights | GF | soft"), self->op,
+    (_("compress shadows/highlights (GF): soft"), self->op,
      self->version(), &p, sizeof(p), 1, DEVELOP_BLEND_CS_RGB_SCENE);
 
   // build the 1D contrast curves that revert the local compression of
   // contrast above
-  p.details = DT_TONEEQ_NONE;
+  p.filter = DT_TONEEQ_NONE;
   dilate_shadows_highlight_preset_set_exposure_params(&p, 0.25f);
   dt_gui_presets_add_generic
-    (_("contrast tone curve | soft"), self->op,
+    (_("contrast tone curve: soft"), self->op,
      self->version(), &p, sizeof(p), 1, DEVELOP_BLEND_CS_RGB_SCENE);
 
   dilate_shadows_highlight_preset_set_exposure_params(&p, 0.45f);
   dt_gui_presets_add_generic
-    (_("contrast tone curve | medium"), self->op,
+    (_("contrast tone curve: medium"), self->op,
      self->version(), &p, sizeof(p), 1, DEVELOP_BLEND_CS_RGB_SCENE);
 
   dilate_shadows_highlight_preset_set_exposure_params(&p, 0.65f);
   dt_gui_presets_add_generic
-    (_("contrast tone curve | strong"), self->op,
+    (_("contrast tone curve: strong"), self->op,
      self->version(), &p, sizeof(p), 1, DEVELOP_BLEND_CS_RGB_SCENE);
 
   // relight
-  p.details = DT_TONEEQ_EIGF;
+  p.filter = DT_TONEEQ_EIGF;
   p.blending = 5.0f;
   p.feathering = 1.0f;
   p.iterations = 1;
@@ -598,153 +744,323 @@ void init_presets(dt_iop_module_so_t *self)
 }
 
 
-/**
- * Helper functions
- **/
-
-static gboolean in_mask_editing(dt_iop_module_t *self)
+/****************************************************************************
+ *
+ * Functions that are needed by process and therefore
+ * are part of worker threads
+ *
+ ****************************************************************************/
+__DT_CLONE_TARGETS__
+static inline void compute_hires_histogram_and_stats(const float *const restrict luminance,
+                                                     int hires_histogram[HIRES_HISTO_SAMPLES],
+                                                     const size_t num_elem,
+                                                     float *first_decile,
+                                                     float *last_decile,
+                                                     dt_dev_pixelpipe_type_t const debug_pipe)
 {
-  const dt_develop_t *dev = self->dev;
-  return dev->form_gui && dev->form_visible;
+  printf("compute_hires_histogram_and_stats pipe=%d num_elem=%ld\n", debug_pipe, num_elem);
+  // The GUI histogram comprises 8 EV (UI_HISTO_SAMPLES, -8 to 0).
+  // The high resolution histogram extends this to an exta 8 EV before and
+  // 8EV after, for a total of 24.
+  // Also the resolution is increased to compensate for the fact that the user
+  // can scale the histogram.
+  const float temp_ev_range = HIRES_HISTO_MAX_EV - HIRES_HISTO_MIN_EV;
+
+  // (Re)init the histogram
+  memset(hires_histogram, 0, sizeof(int) * HIRES_HISTO_SAMPLES);
+
+  // Split exposure in bins
+  DT_OMP_FOR_SIMD(reduction(+:hires_histogram[:HIRES_HISTO_SAMPLES]))
+  for(size_t k = 0; k < num_elem; k++)
+  {
+    const int index =
+      CLAMP((int)(((log2f(luminance[k]) - HIRES_HISTO_MIN_EV) / temp_ev_range) * (float)HIRES_HISTO_SAMPLES),
+            0, HIRES_HISTO_SAMPLES - 1);
+            hires_histogram[index] += 1;
+  }
+
+  // printf("hires_histogram 0: %d 256: %d 512: %d 767: %d\n", hires_histogram[0], hires_histogram[256], hires_histogram[512], hires_histogram[767]);
+
+  const int first_decile_pop = (int)((float)num_elem * 0.05f);
+  const int last_decile_pop = (int)((float)num_elem * (1.0f - 0.95f));
+  int population = 0;
+  int first_decile_pos = 0;
+  int last_decile_pos = 0;
+  int k;
+
+  // Scout the extended histogram bins looking for the
+  // absolute first and last non-zero values and for deciles.
+  // These would not be accurate with the gui histogram.
+
+  for(k = 0; k < HIRES_HISTO_SAMPLES; ++k)
+  {
+    population += hires_histogram[k];
+    if (population >= first_decile_pop)
+    {
+      first_decile_pos = k;
+      break;
+    }
+  }
+
+  population = 0;
+  for(k = HIRES_HISTO_SAMPLES - 1; k >= 0; --k)
+  {
+    population += hires_histogram[k];
+    if (population >= last_decile_pop)
+    {
+      last_decile_pos = k;
+      break;
+    }
+  }
+  // printf("First pos: %d, Last pos: %d\n", first_pos, last_pos);
+
+  // Convert decile positions to exposures
+  *first_decile = (temp_ev_range * ((float)first_decile_pos / (float)(HIRES_HISTO_SAMPLES - 1))) + HIRES_HISTO_MIN_EV;
+  *last_decile = (temp_ev_range * ((float)last_decile_pos / (float)(HIRES_HISTO_SAMPLES - 1))) + HIRES_HISTO_MIN_EV;
 }
 
-static void hash_set_get(const dt_hash_t *hash_in,
-                         dt_hash_t *hash_out,
-                         dt_pthread_mutex_t *lock)
-{
-  // Set or get a hash in a struct the thread-safe way
-  dt_pthread_mutex_lock(lock);
-  *hash_out = *hash_in;
-  dt_pthread_mutex_unlock(lock);
-}
-
-
-static void invalidate_luminance_cache(dt_iop_module_t *const self)
-{
-  // Invalidate the private luminance cache and histogram when
-  // the luminance mask extraction parameters have changed
-  dt_iop_toneequalizer_gui_data_t *const restrict g = self->gui_data;
-
-  dt_iop_gui_enter_critical_section(self);
-  g->max_histogram = 1;
-  g->luminance_valid = FALSE;
-  g->histogram_valid = FALSE;
-  g->thumb_preview_hash = DT_INVALID_CACHEHASH;
-  g->ui_preview_hash = DT_INVALID_CACHEHASH;
-  dt_iop_gui_leave_critical_section(self);
-  dt_iop_refresh_all(self);
-}
-
-// gaussian-ish kernel - sum is == 1.0f so we don't care much about actual coeffs
-static const dt_colormatrix_t gauss_kernel =
-  { { 0.076555024f, 0.124401914f, 0.076555024f },
-    { 0.124401914f, 0.196172249f, 0.124401914f },
-    { 0.076555024f, 0.124401914f, 0.076555024f } };
 
 __DT_CLONE_TARGETS__
-static float get_luminance_from_buffer(const float *const buffer,
-                                       const size_t width,
-                                       const size_t height,
-                                       const size_t x,
-                                       const size_t y)
+static inline void compute_luminance_mask(const float *const restrict in,
+                                          float *const restrict luminance,
+                                          const size_t width,
+                                          const size_t height,
+                                          const dt_iop_toneequalizer_data_t *const d,
+                                          const gboolean compute_image_stats,       // Optionally get the histogram of the image
+                                          int hires_histogram[HIRES_HISTO_SAMPLES], // only for compute_image_stats 
+                                          float *first_decile,                      // only for compute_image_stats
+                                          float *last_decile,                       // only for compute_image_stats
+                                          dt_dev_pixelpipe_type_t const debug_pipe)
 {
-  // Get the weighted average luminance of the 3×3 pixels region centered in (x, y)
-  // x and y are ratios in [0, 1] of the width and height
-
-  if(y >= height || x >= width) return NAN;
-
-  const size_t y_abs[4] DT_ALIGNED_PIXEL =
-                          { MAX(y, 1) - 1,              // previous line
-                            y,                          // center line
-                            MIN(y + 1, height - 1),     // next line
-                            y };		        // padding for vectorization
-
-  float luminance = 0.0f;
-  if(x > 1 && x < width - 2)
+  printf("compute_luminance_mask pipe=%d width=%ld height=%ld first luminance=%f, compute stats=%d\n", debug_pipe, width, height, luminance[0], compute_image_stats);
+  const int num_elem = width * height;
+  switch(d->filter)
   {
-    // no clamping needed on x, which allows us to vectorize
-    // apply the convolution
-    for(int i = 0; i < 3; ++i)
+    case(DT_TONEEQ_NONE):
     {
-      const size_t y_i = y_abs[i];
-      for_each_channel(j)
-        luminance += buffer[width * y_i + x-1 + j] * gauss_kernel[i][j];
+      // No contrast boost here
+      luminance_mask(in, luminance, width, height,
+                     d->lum_estimator, d->exposure_boost, 0.0f, 1.0f);
+      if (compute_image_stats)
+          compute_hires_histogram_and_stats(in, hires_histogram, num_elem, first_decile, last_decile, debug_pipe);
+      break;
     }
-    return luminance;
+
+    case(DT_TONEEQ_AVG_GUIDED):
+    {
+      // Still no contrast boost
+      luminance_mask(in, luminance, width, height,
+                     d->lum_estimator, d->exposure_boost, 0.0f, 1.0f);
+      if (compute_image_stats)
+          compute_hires_histogram_and_stats(in, hires_histogram, num_elem, first_decile, last_decile, debug_pipe);
+      fast_surface_blur(luminance, width, height, d->radius, d->feathering, d->iterations,
+                        DT_GF_BLENDING_GEOMEAN, d->scale, d->quantization,
+                        exp2f(-14.0f), 4.0f);
+      break;
+    }
+
+    case(DT_TONEEQ_GUIDED):
+    {
+      // Contrast boosting is done around the average luminance of the mask.
+      // This is to make exposure corrections easier to control for users, by spreading
+      // the dynamic range along all exposure NUM_SLIDERS, because guided filters
+      // tend to flatten the luminance mask a lot around an average ± 2 EV
+      // which makes only 2-3 NUM_SLIDERS usable.
+      // we assume the distribution is centered around -4EV, e.g. the center of the nodes
+      // the exposure boost should be used to make this assumption true
+      luminance_mask(in, luminance, width, height, d->lum_estimator, d->exposure_boost,
+                     CONTRAST_FULCRUM, d->contrast_boost);
+      if (compute_image_stats)
+          compute_hires_histogram_and_stats(in, hires_histogram, num_elem, first_decile, last_decile, debug_pipe);
+      fast_surface_blur(luminance, width, height, d->radius, d->feathering, d->iterations,
+                        DT_GF_BLENDING_LINEAR, d->scale, d->quantization,
+                        exp2f(-14.0f), 4.0f);
+      break;
+    }
+
+    case(DT_TONEEQ_AVG_EIGF):
+    {
+      // Still no contrast boost
+      luminance_mask(in, luminance, width, height,
+                     d->lum_estimator, d->exposure_boost, 0.0f, 1.0f);
+      if (compute_image_stats)
+          compute_hires_histogram_and_stats(in, hires_histogram, num_elem, first_decile, last_decile, debug_pipe);
+      fast_eigf_surface_blur(luminance, width, height,
+                             d->radius, d->feathering, d->iterations,
+                             DT_GF_BLENDING_GEOMEAN, d->scale,
+                             d->quantization, exp2f(-14.0f), 4.0f);
+      break;
+    }
+
+    case(DT_TONEEQ_EIGF):
+    {
+      luminance_mask(in, luminance, width, height, d->lum_estimator, d->exposure_boost,
+                     CONTRAST_FULCRUM, d->contrast_boost);
+      if (compute_image_stats)
+          compute_hires_histogram_and_stats(in, hires_histogram, num_elem, first_decile, last_decile, debug_pipe);
+      fast_eigf_surface_blur(luminance, width, height,
+                             d->radius, d->feathering, d->iterations,
+                             DT_GF_BLENDING_LINEAR, d->scale,
+                             d->quantization, exp2f(-14.0f), 4.0f);
+      break;
+    }
+
+    default:
+    {
+      luminance_mask(in, luminance, width, height,
+                     d->lum_estimator, d->exposure_boost, 0.0f, 1.0f);
+      if (compute_image_stats)
+        compute_hires_histogram_and_stats(in, hires_histogram, num_elem, first_decile, last_decile, debug_pipe);
+      break;
+    }
   }
+}
 
-  const size_t x_abs[4] DT_ALIGNED_PIXEL =
-                          { MAX(x, 1) - 1,              // previous column
-                            x,                          // center column
-                            MIN(x + 1, width - 1),      // next column
-                            x };                        // padding for vectorization
 
-  // convolution
-  for(int i = 0; i < 3; ++i)
+// This is similar to exposure/contrast boost.
+// However it is applied AFTER the guided filter calculation, so it is much
+// easier to control and does not mess with the detail detection of the
+// guided filter.
+static inline float post_scale_shift(const float v, const float post_scale, const float post_shift)
+{
+  const float scale_exp = exp2f(post_scale);
+  // signifficant range -8..0, centering around the middle
+  return (v + 4.0f) * scale_exp - 4.0f + post_shift;
+}
+
+
+// This is similar to the auto-buttons for exposure/contrast boost.
+// However it runs automatically in the pipe, so it does not need to be
+// triggered by the user each time the upstream exposure changes.
+void compute_auto_post_scale_shift(float *post_scale, float *post_shift,
+                                   dt_iop_toneequalizer_post_auto_align_t post_auto_align,
+                                   float histogram_first_decile,
+                                   float histogram_last_decile,
+                                   dt_dev_pixelpipe_type_t const debug_pipe
+                                  )
+{
+  const float first_decile_target = -7.0f;
+  const float last_decile_target = -1.0f;
+  const float pivot = -4.0f; // for scaling
+
+  printf("compute_auto_post_shift_scale: Pipe=%d old post_scale=%f post_shift=%f histogram_first_decile=%f histogram_last_decile=%f\n",
+          debug_pipe, *post_scale, *post_shift, histogram_first_decile, histogram_last_decile);
+
+  switch(post_auto_align)
   {
-    const size_t y_i = y_abs[i];
-    for_each_channel(j)
-      luminance += buffer[width * y_i + x_abs[j]] * gauss_kernel[i][j];
+    case(DT_TONEEQ_ALIGN_CUSTOM):
+    {
+      // fully user-controlled, do not modify
+      break;
+    }
+    case(DT_TONEEQ_ALIGN_LEFT):
+    {
+      // auto-align at shadows
+      // the histogram might be scaled around pivot
+      const float scaled_first_decile = (histogram_first_decile - pivot) * exp2f(*post_scale) + pivot;
+      *post_shift = first_decile_target - scaled_first_decile;
+      break;
+    }
+    case(DT_TONEEQ_ALIGN_CENTER):
+    {
+      const float histogram_middle = (histogram_first_decile + histogram_last_decile) / 2.0f;
+      const float target_middle = (first_decile_target + last_decile_target) / 2.0f;
+      const float scaled_middle = (histogram_middle - pivot) * exp2f(*post_scale) + pivot;
+      *post_shift = target_middle - scaled_middle;
+      break;
+    }
+    case(DT_TONEEQ_ALIGN_RIGHT):
+    {
+      // auto-align at highlights
+      const float scaled_last_decile = (histogram_last_decile - pivot) * exp2f(*post_scale) + pivot;
+      *post_shift = last_decile_target - scaled_last_decile;
+      break;
+    }
+    case(DT_TONEEQ_ALIGN_FIT):
+    {
+      // fully fit
+      *post_scale = log2f((last_decile_target - first_decile_target) / (histogram_last_decile - histogram_first_decile));
+      const float scaled_first_decile = (histogram_first_decile - pivot) * exp2f(*post_scale) + pivot;
+      *post_shift = first_decile_target - scaled_first_decile;
+      break;
+    }
   }
-  return luminance;
-}
+  printf("compute_auto_post_shift_scale: New post_scale=%f post_shift=%f\n", *post_scale, *post_shift);
+};
 
-static void _get_point(dt_iop_module_t *self,
-                       const int c_x,
-                       const int c_y,
-                       int *x,
-                       int *y)
+
+__DT_CLONE_TARGETS__
+static inline void display_luminance_mask(const float *const restrict in,
+                                          const float *const restrict luminance,
+                                          float *const restrict out,
+                                          const dt_iop_roi_t *const roi_in,
+                                          const dt_iop_roi_t *const roi_out,
+                                          const float post_scale,
+                                          const float post_shift,
+                                          dt_dev_pixelpipe_type_t const debug_pipe)
 {
-  // TODO: For this to fully work non depending on the place of the module
-  //       in the pipe we need a dt_dev_distort_backtransform_plus that
-  //       can skip crop only. With the current version if toneequalizer
-  //       is moved below rotation & perspective it will fail as we are
-  //       then missing all the transform after tone-eq.
-  const double crop_order =
-    dt_ioppr_get_iop_order(self->dev->iop_order_list, "crop", 0);
+  const size_t offset_x = (roi_in->x < roi_out->x) ? -roi_in->x + roi_out->x : 0;
+  const size_t offset_y = (roi_in->y < roi_out->y) ? -roi_in->y + roi_out->y : 0;
 
-  float pts[2] = { c_x, c_y };
+  printf("display_luminance_mask pipe=%d offset_x=%ld offset_y=%ld roi_in %d %d %d %d roi_out %d %d %d %d, post_scale=%f, post_shift=%f\n",
+         debug_pipe, offset_x, offset_y,
+         roi_in->x, roi_in->y, roi_in->width, roi_in->height,
+         roi_out->x, roi_out->y, roi_out->width, roi_out->height,
+         post_scale, post_shift);
 
-  // only a forward backtransform as the buffer already contains all the transforms
-  // done before toneequal and we are speaking of on-screen cursor coordinates.
-  // also we do transform only after crop as crop does change roi for the whole pipe
-  // and so it is already part of the preview buffer cached in this implementation.
-  dt_dev_distort_backtransform_plus(darktable.develop, darktable.develop->preview_pipe,
-                                    crop_order,
-                                    DT_DEV_TRANSFORM_DIR_FORW_EXCL, pts, 1);
-  *x = pts[0];
-  *y = pts[1];
+  // The output dimensions need to be smaller or equal to the input ones
+  // there is no logical reason they shouldn't, except some weird bug in the pipe
+  // in this case, ensure we don't segfault
+  const size_t in_width = roi_in->width;
+  const size_t out_width = (roi_in->width > roi_out->width)
+    ? roi_out->width
+    : roi_in->width;
+
+  const size_t out_height = (roi_in->height > roi_out->height)
+    ? roi_out->height
+    : roi_in->height;
+
+  DT_OMP_FOR(collapse(2))
+  for(size_t i = 0 ; i < out_height; ++i)
+    for(size_t j = 0; j < out_width; ++j)
+    {
+      // normalize the mask intensity between -8 EV and 0 EV for clarity,
+      // and add a "gamma" 2.0 for better legibility in shadows
+      const int lum_index = (i + offset_y) * in_width + (j + offset_x);
+      const float lum_log = log2f(luminance[lum_index]);
+      const float lum_corrected = post_scale_shift(lum_log, post_scale, post_shift);
+
+      // IMHO it would be fine, to show the log version of the mask to the user.
+      // const float intensity =
+      //   fminf(fmaxf((lum_corrected + 8.0f) / 8.0f, 0.f), 1.f);
+      // However to keep everything identical to before, we go back to linear
+      // space and apply the square root/"gamma".
+      const float lum_linear = exp2f(lum_corrected);
+      const float intensity =
+        sqrtf(fminf(
+                fmaxf(lum_linear - 0.00390625f, 0.f) / 0.99609375f,
+                1.f));
+
+      const size_t index = (i * out_width + j) * 4;
+      // set gray level for the mask
+      for_each_channel(c,aligned(out))
+      {
+        out[index + c] = intensity;
+      }
+      // copy alpha channel
+      out[index + 3] = in[((i + offset_y) * in_width + (j + offset_x)) * 4 + 3];
+    }
 }
 
-static float _luminance_from_module_buffer(dt_iop_module_t *self)
-{
-  dt_iop_toneequalizer_gui_data_t *g = self->gui_data;
-
-  const size_t c_x = g->cursor_pos_x;
-  const size_t c_y = g->cursor_pos_y;
-
-  // get buffer x,y given the cursor position
-  int b_x = 0;
-  int b_y = 0;
-
-  _get_point(self, c_x, c_y, &b_x, &b_y);
-
-  return get_luminance_from_buffer(g->thumb_preview_buf,
-                                   g->thumb_preview_buf_width,
-                                   g->thumb_preview_buf_height,
-                                   b_x,
-                                   b_y);
-}
 
 /***
  * Exposure compensation computation
  *
  * Construct the final correction factor by summing the octaves
- * channels gains weighted by the gaussian of the radial distance
+ * NUM_SLIDERS gains weighted by the gaussian of the radial distance
  * (pixel exposure - octave center)
  *
  ***/
-
 DT_OMP_DECLARE_SIMD()
 __DT_CLONE_TARGETS__
 static float gaussian_denom(const float sigma)
@@ -767,11 +1083,37 @@ static float gaussian_func(const float radius, const float denominator)
   return expf(- radius * radius / denominator);
 }
 
-#define DT_TONEEQ_MIN_EV (-8.0f)
-#define DT_TONEEQ_MAX_EV (0.0f)
-#define DT_TONEEQ_USE_LUT TRUE
-#if DT_TONEEQ_USE_LUT
 
+static void compute_correction_lut(float *restrict lut, const float sigma,
+                                   const float *const restrict factors,
+                                   const float post_scale, const float post_shift,
+                                   dt_dev_pixelpipe_type_t const debug_pipe)
+{
+  printf("compute_correction_lut pipe=%d, post_scale=%f, post_shift=%f\n", debug_pipe, post_scale, post_shift);
+  const float gauss_denom = gaussian_denom(sigma);
+  assert(NUM_OCTAVES == 8);
+
+  // TODO MF: Does the openmp still work here?
+  DT_OMP_FOR(shared(centers_ops))
+  for(int j = 0; j <= LUT_RESOLUTION * NUM_OCTAVES; j++)
+  {
+    // build the correction for each pixel
+    // as the sum of the contribution of each luminance channelcorrection
+    const float exposure_uncorrected = (float)j / (float)LUT_RESOLUTION + DT_TONEEQ_MIN_EV; // [-8...0] EV
+    const float exposure = fast_clamp(post_scale_shift(exposure_uncorrected, post_scale, post_shift),
+                                      DT_TONEEQ_MIN_EV, DT_TONEEQ_MAX_EV);
+    float result = 0.0f;
+    for(int i = 0; i < NUM_OCTAVES; i++)
+    {
+      result += gaussian_func(exposure - centers_ops[i], gauss_denom) * factors[i];
+    }
+    // the user-set correction is expected in [-2;+2] EV, so is the interpolated one
+    lut[j] = fast_clamp(result, 0.25f, 4.0f);
+  }
+}
+
+
+#if DT_TONEEQ_USE_LUT
 // this is the version currently used, as using a lut gives a
 // big performance speedup on some cpus
 __DT_CLONE_TARGETS__
@@ -780,8 +1122,14 @@ static inline void apply_toneequalizer(const float *const restrict in,
                                        float *const restrict out,
                                        const dt_iop_roi_t *const roi_in,
                                        const dt_iop_roi_t *const roi_out,
-                                       const dt_iop_toneequalizer_data_t *const d)
+                                       const dt_iop_toneequalizer_data_t *const d,
+                                       dt_dev_pixelpipe_type_t const debug_pipe)
 {
+  printf("apply_toneequalizer pipe=%d first luminance=%f roi_in %d %d %d %d roi_out %d %d %d %d post_scale=%f, post_shift=%f\n",
+    debug_pipe, luminance[0],
+    roi_in->x, roi_in->y, roi_in->width, roi_in->height,
+    roi_out->x, roi_out->y, roi_out->width, roi_out->height,
+    d->post_scale, d->post_shift);
   const size_t npixels = (size_t)roi_in->width * roi_in->height;
   const float* restrict lut = d->correction_lut;
   const float lutres = LUT_RESOLUTION;
@@ -804,6 +1152,7 @@ static inline void apply_toneequalizer(const float *const restrict in,
 
 // we keep this version for further reference (e.g. for implementing
 // a gpu version)
+// TODO MF: Remove? This is no longer correct anyways.
 __DT_CLONE_TARGETS__
 static inline void apply_toneequalizer(const float *const restrict in,
                                        const float *const restrict luminance,
@@ -828,8 +1177,8 @@ static inline void apply_toneequalizer(const float *const restrict in,
     // quickely diverge outside
     const float exposure = fast_clamp(log2f(luminance[k]), DT_TONEEQ_MIN_EV, DT_TONEEQ_MAX_EV);
 
-    DT_OMP_SIMD(aligned(luminance, centers_ops, factors:64) safelen(PIXEL_CHAN) reduction(+:result))
-    for(int i = 0; i < PIXEL_CHAN; ++i)
+    DT_OMP_SIMD(aligned(luminance, centers_ops, factors:64) safelen(NUM_OCTAVES) reduction(+:result))
+    for(int i = 0; i < NUM_OCTAVES; ++i)
       result += gaussian_func(exposure - centers_ops[i], gauss_denom) * factors[i];
 
     // the user-set correction is expected in [-2;+2] EV, so is the interpolated one
@@ -842,150 +1191,6 @@ static inline void apply_toneequalizer(const float *const restrict in,
 }
 #endif // USE_LUT
 
-__DT_CLONE_TARGETS__
-static inline float pixel_correction(const float exposure,
-                                     const float *const restrict factors,
-                                     const float sigma)
-{
-  // build the correction for the current pixel
-  // as the sum of the contribution of each luminance channel
-  float result = 0.0f;
-  const float gauss_denom = gaussian_denom(sigma);
-  const float expo = fast_clamp(exposure, DT_TONEEQ_MIN_EV, DT_TONEEQ_MAX_EV);
-
-  DT_OMP_SIMD(aligned(centers_ops, factors:64) safelen(PIXEL_CHAN) reduction(+:result))
-  for(int i = 0; i < PIXEL_CHAN; ++i)
-    result += gaussian_func(expo - centers_ops[i], gauss_denom) * factors[i];
-
-  return fast_clamp(result, 0.25f, 4.0f);
-}
-
-
-__DT_CLONE_TARGETS__
-static inline void compute_luminance_mask(const float *const restrict in,
-                                          float *const restrict luminance,
-                                          const size_t width,
-                                          const size_t height,
-                                          const dt_iop_toneequalizer_data_t *const d)
-{
-  switch(d->details)
-  {
-    case(DT_TONEEQ_NONE):
-    {
-      // No contrast boost here
-      luminance_mask(in, luminance, width, height,
-                     d->method, d->exposure_boost, 0.0f, 1.0f);
-      break;
-    }
-
-    case(DT_TONEEQ_AVG_GUIDED):
-    {
-      // Still no contrast boost
-      luminance_mask(in, luminance, width, height,
-                     d->method, d->exposure_boost, 0.0f, 1.0f);
-      fast_surface_blur(luminance, width, height, d->radius, d->feathering, d->iterations,
-                        DT_GF_BLENDING_GEOMEAN, d->scale, d->quantization,
-                        exp2f(-14.0f), 4.0f);
-      break;
-    }
-
-    case(DT_TONEEQ_GUIDED):
-    {
-      // Contrast boosting is done around the average luminance of the mask.
-      // This is to make exposure corrections easier to control for users, by spreading
-      // the dynamic range along all exposure channels, because guided filters
-      // tend to flatten the luminance mask a lot around an average ± 2 EV
-      // which makes only 2-3 channels usable.
-      // we assume the distribution is centered around -4EV, e.g. the center of the nodes
-      // the exposure boost should be used to make this assumption true
-      luminance_mask(in, luminance, width, height, d->method, d->exposure_boost,
-                     CONTRAST_FULCRUM, d->contrast_boost);
-      fast_surface_blur(luminance, width, height, d->radius, d->feathering, d->iterations,
-                        DT_GF_BLENDING_LINEAR, d->scale, d->quantization,
-                        exp2f(-14.0f), 4.0f);
-      break;
-    }
-
-    case(DT_TONEEQ_AVG_EIGF):
-    {
-      // Still no contrast boost
-      luminance_mask(in, luminance, width, height,
-                     d->method, d->exposure_boost, 0.0f, 1.0f);
-      fast_eigf_surface_blur(luminance, width, height,
-                             d->radius, d->feathering, d->iterations,
-                             DT_GF_BLENDING_GEOMEAN, d->scale,
-                             d->quantization, exp2f(-14.0f), 4.0f);
-      break;
-    }
-
-    case(DT_TONEEQ_EIGF):
-    {
-      luminance_mask(in, luminance, width, height, d->method, d->exposure_boost,
-                     CONTRAST_FULCRUM, d->contrast_boost);
-      fast_eigf_surface_blur(luminance, width, height,
-                             d->radius, d->feathering, d->iterations,
-                             DT_GF_BLENDING_LINEAR, d->scale,
-                             d->quantization, exp2f(-14.0f), 4.0f);
-      break;
-    }
-
-    default:
-    {
-      luminance_mask(in, luminance, width, height,
-                     d->method, d->exposure_boost, 0.0f, 1.0f);
-      break;
-    }
-  }
-}
-
-/***
- * Actual transfer functions
- **/
-
-__DT_CLONE_TARGETS__
-static inline void display_luminance_mask(const float *const restrict in,
-                                          const float *const restrict luminance,
-                                          float *const restrict out,
-                                          const dt_iop_roi_t *const roi_in,
-                                          const dt_iop_roi_t *const roi_out)
-{
-  const size_t offset_x = (roi_in->x < roi_out->x) ? -roi_in->x + roi_out->x : 0;
-  const size_t offset_y = (roi_in->y < roi_out->y) ? -roi_in->y + roi_out->y : 0;
-
-  // The output dimensions need to be smaller or equal to the input ones
-  // there is no logical reason they shouldn't, except some weird bug in the pipe
-  // in this case, ensure we don't segfault
-  const size_t in_width = roi_in->width;
-  const size_t out_width = (roi_in->width > roi_out->width)
-    ? roi_out->width
-    : roi_in->width;
-
-  const size_t out_height = (roi_in->height > roi_out->height)
-    ? roi_out->height
-    : roi_in->height;
-
-  DT_OMP_FOR(collapse(2))
-  for(size_t i = 0 ; i < out_height; ++i)
-    for(size_t j = 0; j < out_width; ++j)
-    {
-      // normalize the mask intensity between -8 EV and 0 EV for clarity,
-      // and add a "gamma" 2.0 for better legibility in shadows
-      const float intensity =
-        sqrtf(fminf(
-                fmaxf(luminance[(i + offset_y) * in_width  + (j + offset_x)] - 0.00390625f,
-                      0.f) / 0.99609375f,
-                1.f));
-      const size_t index = (i * out_width + j) * 4;
-      // set gray level for the mask
-      for_each_channel(c,aligned(out))
-      {
-        out[index + c] = intensity;
-      }
-      // copy alpha channel
-      out[index + 3] = in[((i + offset_y) * in_width + (j + offset_x)) * 4 + 3];
-    }
-}
-
 
 __DT_CLONE_TARGETS__
 static
@@ -996,19 +1201,15 @@ void toneeq_process(dt_iop_module_t *self,
                     const dt_iop_roi_t *const roi_in,
                     const dt_iop_roi_t *const roi_out)
 {
-  const dt_iop_toneequalizer_data_t *const d = piece->data;
+  dt_iop_toneequalizer_data_t *const d = piece->data;
   dt_iop_toneequalizer_gui_data_t *const g = self->gui_data;
 
   const float *const restrict in = (float *const)ivoid;
   float *const restrict out = (float *const)ovoid;
-  float *restrict luminance = NULL;
 
   const size_t width = roi_in->width;
   const size_t height = roi_in->height;
   const size_t num_elem = width * height;
-
-  // Get the hash of the upstream pipe to track changes
-  const dt_hash_t hash = dt_dev_pixelpipe_piece_hash(piece, roi_out, TRUE);
 
   // Sanity checks
   if(width < 1 || height < 1) return;
@@ -1016,73 +1217,95 @@ void toneeq_process(dt_iop_module_t *self,
     return; // input should be at least as large as output
   if(piece->colors != 4) return;  // we need RGB signal
 
-  // Init the luminance masks buffers
-  gboolean cached = FALSE;
+  // This will be local memory or global cache stored in g
+  float *restrict luminance = NULL;
+  int *hires_histogram = NULL;
 
+  // Remember to free stuff that is allocated here
+  gboolean local_luminance = FALSE;
+  gboolean local_hires_hist = FALSE;
+
+  printf("toneeq_process, piece type %d, post_align=%d, post_scale=%f, post_shift=%f, roi with=%d, roi_height=%d\n",
+    piece->pipe->type, d->post_auto_align, d->post_scale, d->post_shift, roi_in->width, roi_in->height);
+
+  /**************************************************************************
+   * Initialization
+   **************************************************************************/
   if(self->dev->gui_attached)
   {
     // If the module instance has changed order in the pipe, invalidate the caches
     if(g->pipe_order != piece->module->iop_order)
     {
       dt_iop_gui_enter_critical_section(self);
-      g->ui_preview_hash = DT_INVALID_CACHEHASH;
-      g->thumb_preview_hash = DT_INVALID_CACHEHASH;
+      g->full_upstream_hash = DT_INVALID_CACHEHASH;
+      g->preview_upstream_hash = DT_INVALID_CACHEHASH;
       g->pipe_order = piece->module->iop_order;
       g->luminance_valid = FALSE;
-      g->histogram_valid = FALSE;
+      g->gui_histogram_valid = FALSE;
       dt_iop_gui_leave_critical_section(self);
     }
 
-    if(piece->pipe->type & DT_DEV_PIXELPIPE_FULL)
+    if(piece->pipe->type & DT_DEV_PIXELPIPE_PREVIEW)
+    {
+      // For DT_DEV_PIXELPIPE_PREVIEW, we need to cache the luminace mask
+      // and the hires histogram for the GUI thread.
+      // Locks are required since GUI reads and writes on that buffer.
+
+      // TODO MF: Is the above comment correct? Except for gui_cache_init
+      // there seems to be no place where the GUI writes.
+
+      // Re-allocate a new buffer if the thumb preview size has changed
+      dt_iop_gui_enter_critical_section(self);
+      if(g->preview_buf_width != width || g->preview_buf_height != height)
+      {
+        dt_free_align(g->preview_buf);
+        g->preview_buf = dt_alloc_align_float(num_elem);
+        g->preview_buf_width = width;
+        g->preview_buf_height = height;
+        g->luminance_valid = FALSE;
+      }
+
+      luminance = g->preview_buf;
+      hires_histogram = g->hires_histogram;
+
+      dt_iop_gui_leave_critical_section(self);
+    }
+    else if (piece->pipe->type & DT_DEV_PIXELPIPE_FULL)
     {
       // For DT_DEV_PIXELPIPE_FULL, we cache the luminance mask for performance
       // but it's not accessed from GUI
       // no need for threads lock since no other function is writing/reading that buffer
+      // This is also used to quickly switch between the mask display and the main view.
 
       // Re-allocate a new buffer if the full preview size has changed
-      if(g->full_preview_buf_width != width || g->full_preview_buf_height != height)
+      if(g->full_buf_width != width || g->full_buf_height != height)
       {
-        dt_free_align(g->full_preview_buf);
-        g->full_preview_buf = dt_alloc_align_float(num_elem);
-        g->full_preview_buf_width = width;
-        g->full_preview_buf_height = height;
+        dt_free_align(g->full_buf);
+        g->full_buf = dt_alloc_align_float(num_elem);
+        g->full_buf_width = width;
+        g->full_buf_height = height;
       }
 
-      luminance = g->full_preview_buf;
-      cached = TRUE;
+      luminance = g->full_buf;
+
+      hires_histogram = dt_alloc_align_int(HIRES_HISTO_SAMPLES);
+      local_hires_hist = TRUE;
     }
-    else if(piece->pipe->type & DT_DEV_PIXELPIPE_PREVIEW)
-    {
-      // For DT_DEV_PIXELPIPE_PREVIEW, we need to cache it too to
-      // compute the full image stats upon user request in GUI threads
-      // locks are required since GUI reads and writes on that buffer.
-
-      // Re-allocate a new buffer if the thumb preview size has changed
-      dt_iop_gui_enter_critical_section(self);
-      if(g->thumb_preview_buf_width != width || g->thumb_preview_buf_height != height)
-      {
-        dt_free_align(g->thumb_preview_buf);
-        g->thumb_preview_buf = dt_alloc_align_float(num_elem);
-        g->thumb_preview_buf_width = width;
-        g->thumb_preview_buf_height = height;
-        g->luminance_valid = FALSE;
-      }
-
-      luminance = g->thumb_preview_buf;
-      cached = TRUE;
-
-      dt_iop_gui_leave_critical_section(self);
-    }
-    else // just to please GCC
+    else
     {
       luminance = dt_alloc_align_float(num_elem);
+      local_luminance = TRUE;
+      hires_histogram = dt_alloc_align_int(HIRES_HISTO_SAMPLES);
+      local_hires_hist = TRUE;
     }
-
   }
   else
   {
     // no interactive editing/caching : just allocate a local temp buffer
     luminance = dt_alloc_align_float(num_elem);
+    local_luminance = TRUE;
+    hires_histogram = dt_alloc_align_int(HIRES_HISTO_SAMPLES);
+    local_hires_hist = TRUE;
   }
 
   // Check if the luminance buffer exists
@@ -1092,77 +1315,200 @@ void toneeq_process(dt_iop_module_t *self,
     return;
   }
 
-  // Compute the luminance mask
-  if(cached)
+  // The values from d are set by the user.
+  // If the user requested auto-alignment, these will be changed.
+  float post_scale = d->post_scale;
+  float post_shift = d->post_shift;
+
+  /**************************************************************************
+   * Compute the luminance mask
+   **************************************************************************/
+  if(self->dev->gui_attached && (piece->pipe->type & DT_DEV_PIXELPIPE_PREVIEW))
   {
-    // caching path : store the luminance mask for GUI access
+    // PREVIEW sees the whole image (at a lower resolution).
+    // PREVIEW needs to store the luminance mask, hires_histogram and deciles
+    // for GUI access.
+    // PREVIEW also computes post_scale and post_shift for FULL.
 
-    if(piece->pipe->type & DT_DEV_PIXELPIPE_FULL)
+    // We use the upstream hash to check if the upstream pipe has changed,
+    // which requires us to re-compute this pipe's luminance mask.
+    const dt_hash_t current_upstream_hash
+        = dt_dev_hash_plus(self->dev, self->dev->preview_pipe, self->iop_order, DT_DEV_TRANSFORM_DIR_BACK_EXCL);
+
+    dt_iop_gui_enter_critical_section(self);
+    const dt_hash_t saved_upstream_hash = g->preview_upstream_hash;
+    const gboolean luminance_valid = g->luminance_valid;
+    dt_iop_gui_leave_critical_section(self);
+
+    printf("toneeq_process PIXELPIPE_PREVIEW: hash=%ld saved_hash=%ld luminance_valid=%d\n", current_upstream_hash, saved_upstream_hash,
+           luminance_valid);
+
+    if(saved_upstream_hash != current_upstream_hash || !luminance_valid)
     {
-      dt_hash_t saved_hash;
-      hash_set_get(&g->ui_preview_hash, &saved_hash, &self->gui_lock);
-
+      /* compute only if upstream pipe state has changed */
       dt_iop_gui_enter_critical_section(self);
-      const gboolean luminance_valid = g->luminance_valid;
+      g->preview_upstream_hash = current_upstream_hash;
+      g->gui_histogram_valid = FALSE;
+      compute_luminance_mask(in, luminance, width, height, d,
+                             TRUE, // Also compute an image (not mask!) histogram for coloring the curve
+                             g->image_hires_histogram,
+                             &g->image_histogram_first_decile, &g->image_histogram_last_decile,
+                             piece->pipe->type);
+
+      // Histogram and deciles
+      compute_hires_histogram_and_stats(luminance, hires_histogram, num_elem,
+                                        &g->histogram_first_decile, &g->histogram_last_decile,
+                                        piece->pipe->type);
+
+      // GUI can assume that mask, histogram and deciles are valid
+      g->luminance_valid = TRUE;
+
+      compute_auto_post_scale_shift(&post_scale, &post_shift,
+        d->post_auto_align,
+        g->histogram_first_decile, g->histogram_last_decile,
+        piece->pipe->type);
+
+      // save for FULL
+      g->post_scale_value = post_scale;
+      g->post_shift_value = post_shift;
+
       dt_iop_gui_leave_critical_section(self);
-
-      if(hash != saved_hash || !luminance_valid)
-      {
-        /* compute only if upstream pipe state has changed */
-        compute_luminance_mask(in, luminance, width, height, d);
-        hash_set_get(&hash, &g->ui_preview_hash, &self->gui_lock);
-      }
-    }
-    else if(piece->pipe->type & DT_DEV_PIXELPIPE_PREVIEW)
-    {
-      dt_hash_t saved_hash;
-      hash_set_get(&g->thumb_preview_hash, &saved_hash, &self->gui_lock);
-
-      dt_iop_gui_enter_critical_section(self);
-      const gboolean luminance_valid = g->luminance_valid;
-      dt_iop_gui_leave_critical_section(self);
-
-      if(saved_hash != hash || !luminance_valid)
-      {
-        /* compute only if upstream pipe state has changed */
-        dt_iop_gui_enter_critical_section(self);
-        g->thumb_preview_hash = hash;
-        g->histogram_valid = FALSE;
-        compute_luminance_mask(in, luminance, width, height, d);
-        g->luminance_valid = TRUE;
-        dt_iop_gui_leave_critical_section(self);
-        dt_dev_pixelpipe_cache_invalidate_later(piece->pipe, self->iop_order);
-      }
-    }
-    else // make it dummy-proof
-    {
-      compute_luminance_mask(in, luminance, width, height, d);
-    }
-  }
-  else
-  {
-    // no caching path : compute no matter what
-    compute_luminance_mask(in, luminance, width, height, d);
-  }
-
-  // Display output
-  if(self->dev->gui_attached && (piece->pipe->type & DT_DEV_PIXELPIPE_FULL))
-  {
-    if(g->mask_display)
-    {
-      display_luminance_mask(in, luminance, out, roi_in, roi_out);
-      piece->pipe->mask_display = DT_DEV_PIXELPIPE_DISPLAY_PASSTHRU;
     }
     else
-      apply_toneequalizer(in, luminance, out, roi_in, roi_out, d);
+    {
+      // No need to re-compute mask, histogram, deciles.
+      // We re-use stored deciles for auto alignment.
+      dt_iop_gui_enter_critical_section(self);
+
+      compute_auto_post_scale_shift(&post_scale, &post_shift,
+        d->post_auto_align,
+        g->histogram_first_decile, g->histogram_last_decile,
+        piece->pipe->type);
+
+      // for FULL
+      g->post_scale_value = post_scale;
+      g->post_shift_value = post_shift;
+
+      dt_iop_gui_leave_critical_section(self);
+    }
+
+    // TODO MF: Not completely sure in which cases this must be called.
+    //          Assumption is once per output image change by this module and
+    //          only when the GUI is active.
+    dt_dev_pixelpipe_cache_invalidate_later(piece->pipe, self->iop_order);
+
+    // Sync hash to make FULL wait if it needs auto-alignment
+    // TODO MF: Is it necessary to do this in two steps to prevent DT getting stuck in a race condition?
+    const dt_hash_t sync_hash = dt_dev_hash_plus(self->dev, self->dev->preview_pipe, self->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL);
+    dt_iop_gui_enter_critical_section(self);
+    g->sync_hash = sync_hash;
+    dt_iop_gui_leave_critical_section(self);
+
+  }
+  else if(self->dev->gui_attached && (piece->pipe->type & DT_DEV_PIXELPIPE_FULL))
+  {
+    // FULL may only see a part of the image if the user has zoomed in.
+    // We need to compute a luminance mask for this pipe and cache it for
+    // quick reuse (i.e. if the user only changes the curve).
+    // But we can not compute statistics like histograms or deciles here,
+    // so we re-use values that PREVIEW has stored in g.
+
+    // We use the upstream hash to check if the upstream pipe has changed,
+    // which requires us to re-compute this pipe's luminance mask.
+    // TODO: Is this correct? We take the same hash as in PREVIEW, using self->dev->preview_pipe,
+    //       assuming that this can also be used in FULL to detect upstream changes.
+    const dt_hash_t current_upstream_hash
+        = dt_dev_hash_plus(self->dev, self->dev->preview_pipe, self->iop_order, DT_DEV_TRANSFORM_DIR_BACK_EXCL);
+
+    dt_iop_gui_enter_critical_section(self);
+    const dt_hash_t saved_upstream_hash = g->full_upstream_hash;
+    const gboolean luminance_valid = g->luminance_valid;
+    dt_iop_gui_leave_critical_section(self);
+
+    printf("toneeq_process GUI FULL: hash=%ld saved_hash=%ld luminance_valid=%d\n", current_upstream_hash, saved_upstream_hash,
+           luminance_valid);
+
+    // Re-compute if the upstream state has changed
+    if(current_upstream_hash != saved_upstream_hash || !luminance_valid)
+    {
+      /* compute only if upstream pipe state has changed */
+      dt_iop_gui_enter_critical_section(self);
+      g->full_upstream_hash = current_upstream_hash;
+      dt_iop_gui_leave_critical_section(self);
+
+      compute_luminance_mask(in, luminance, width, height, d,
+                             FALSE, NULL, NULL, NULL,
+                             piece->pipe->type);
+    }
+
+    if (d->post_auto_align != DT_TONEEQ_ALIGN_CUSTOM)
+    {
+      printf("toneeq_process GUI FULL: waiting for sync\n");
+      // Wait for PREVIEW to calculate automatic post scale/shift
+      if(!dt_dev_sync_pixelpipe_hash(self->dev, piece->pipe, self->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL, &self->gui_lock, &g->sync_hash)) {
+        dt_control_log(_("inconsistent output"));
+        printf("toneeq_process GUI FULL: sync failed\n");
+      }
+      else
+      {
+        printf("toneeq_process GUI FULL: synced\n");
+      }
+
+      dt_iop_gui_enter_critical_section(self);
+      post_scale = g->post_scale_value;
+      post_shift = g->post_shift_value;
+      dt_iop_gui_leave_critical_section(self);
+    }
+  } else {
+    // no caching path : compute no matter what
+    // TODO MF: Post scale/shift are calculated with local data.
+    //          Not guraranteed to be identical to what PREVIEW saw.
+
+    compute_luminance_mask(in, luminance, width, height, d,
+                           FALSE, NULL, NULL, NULL,
+                           piece->pipe->type);
+
+    float histogram_first_decile, histogram_last_decile;
+    compute_hires_histogram_and_stats(luminance, hires_histogram, num_elem,
+                                      &histogram_first_decile, &histogram_last_decile,
+                                      piece->pipe->type);
+
+    compute_auto_post_scale_shift(&post_scale, &post_shift, d->post_auto_align,
+                                  histogram_first_decile, histogram_last_decile, piece->pipe->type);
+  }
+
+  /**************************************************************************
+   * Display output
+   **************************************************************************/
+  if(self->dev->gui_attached && (piece->pipe->type & DT_DEV_PIXELPIPE_FULL) && g->mask_display)
+  {
+    display_luminance_mask(in, luminance, out,
+                            roi_in, roi_out,
+                            post_scale, post_shift,
+                            piece->pipe->type);
+    piece->pipe->mask_display = DT_DEV_PIXELPIPE_DISPLAY_PASSTHRU;
   }
   else
   {
-    apply_toneequalizer(in, luminance, out, roi_in, roi_out, d);
+    compute_correction_lut(d->correction_lut, d->smoothing, d->factors,
+                           post_scale, post_shift,
+                           piece->pipe->type);
+    apply_toneequalizer(in, luminance, out,
+                        roi_in, roi_out,
+                        d, piece->pipe->type);
   }
 
-  if(!cached) dt_free_align(luminance);
+  /**************************************************************************
+   * Cleanup
+   **************************************************************************/
+  if(local_luminance) {
+    dt_free_align(luminance);
+  }
+  if(local_hires_hist) {
+    dt_free_align(hires_histogram);
+  }
 }
+
 
 void process(dt_iop_module_t *self,
              dt_dev_pixelpipe_iop_t *piece,
@@ -1172,6 +1518,48 @@ void process(dt_iop_module_t *self,
              const dt_iop_roi_t *const roi_out)
 {
   toneeq_process(self, piece, ivoid, ovoid, roi_in, roi_out);
+}
+
+
+/****************************************************************************
+ *
+ * Initialization and Cleanup
+ *
+ ****************************************************************************/
+
+void init_global(dt_iop_module_so_t *self)
+{
+  printf("toneequalizer init_global\n");
+  dt_iop_toneequalizer_global_data_t *gd = malloc(sizeof(dt_iop_toneequalizer_global_data_t));
+
+  self->data = gd;
+}
+
+
+void cleanup_global(dt_iop_module_so_t *self)
+{
+  printf("toneequalizer cleanup_global\n");
+  free(self->data);
+  self->data = NULL;
+}
+
+
+void init_pipe(dt_iop_module_t *self,
+               dt_dev_pixelpipe_t *pipe,
+               dt_dev_pixelpipe_iop_t *piece)
+{
+  printf("toneequalizer init_pipe, pipe %d\n", pipe->type);
+  piece->data = dt_calloc1_align_type(dt_iop_toneequalizer_data_t);
+}
+
+
+void cleanup_pipe(dt_iop_module_t *self,
+                  dt_dev_pixelpipe_t *pipe,
+                  dt_dev_pixelpipe_iop_t *piece)
+{
+  printf("toneequalizer cleanup_pipe, pipe %d\n", pipe->type);
+  dt_free_align(piece->data);
+  piece->data = NULL;
 }
 
 
@@ -1196,9 +1584,9 @@ void modify_roi_in(dt_iop_module_t *self,
 /***
  * Setters and Getters for parameters
  *
- * Remember the user params split the [-8; 0] EV range in 9 channels
+ * Remember the user params split the [-8; 0] EV range in 9 NUM_SLIDERS
  * and define a set of (x, y) coordinates, where x are the exposure
- * channels (evenly-spaced by 1 EV in [-8; 0] EV) and y are the
+ * NUM_SLIDERS (evenly-spaced by 1 EV in [-8; 0] EV) and y are the
  * desired exposure compensation for each channel.
  *
  * This (x, y) set is interpolated by radial-basis function using a
@@ -1220,34 +1608,12 @@ void modify_roi_in(dt_iop_module_t *self,
  * should be used in combination with a tone curve or filmic.
  *
  ***/
-
-static void compute_correction_lut(float* restrict lut,
-                                   const float sigma,
-                                   const float *const restrict factors)
-{
-  const float gauss_denom = gaussian_denom(sigma);
-  assert(PIXEL_CHAN == 8);
-
-  DT_OMP_FOR(shared(centers_ops))
-  for(int j = 0; j <= LUT_RESOLUTION * PIXEL_CHAN; j++)
-  {
-    // build the correction for each pixel
-    // as the sum of the contribution of each luminance channelcorrection
-    const float exposure = (float)j / (float)LUT_RESOLUTION + DT_TONEEQ_MIN_EV;
-    float result = 0.0f;
-    for(int i = 0; i < PIXEL_CHAN; i++)
-      result += gaussian_func(exposure - centers_ops[i], gauss_denom) * factors[i];
-    // the user-set correction is expected in [-2;+2] EV, so is the interpolated one
-    lut[j] = fast_clamp(result, 0.25f, 4.0f);
-  }
-}
-
-static void get_channels_gains(float factors[CHANNELS],
+static void get_channels_gains(float factors[NUM_SLIDERS],
                                const dt_iop_toneequalizer_params_t *p)
 {
-  assert(CHANNELS == 9);
+  assert(NUM_SLIDERS == 9);
 
-  // Get user-set channels gains in EV (log2)
+  // Get user-set NUM_SLIDERS gains in EV (log2)
   factors[0] = p->noise; // -8 EV
   factors[1] = p->ultra_deep_blacks; // -7 EV
   factors[2] = p->deep_blacks;       // -6 EV
@@ -1260,36 +1626,55 @@ static void get_channels_gains(float factors[CHANNELS],
 }
 
 
-static void get_channels_factors(float factors[CHANNELS],
+static void get_channels_factors(float factors[NUM_SLIDERS],
                                  const dt_iop_toneequalizer_params_t *p)
 {
-  assert(CHANNELS == 9);
+  assert(NUM_SLIDERS == 9);
 
-  // Get user-set channels gains in EV (log2)
+  // Get user-set NUM_SLIDERS gains in EV (log2)
   get_channels_gains(factors, p);
 
   // Convert from EV offsets to linear factors
   DT_OMP_SIMD(aligned(factors:64))
-  for(int c = 0; c < CHANNELS; ++c)
+  for(int c = 0; c < NUM_SLIDERS; ++c)
     factors[c] = exp2f(factors[c]);
 }
 
 
 __DT_CLONE_TARGETS__
-static gboolean compute_channels_factors(const float factors[PIXEL_CHAN],
-                                         float out[CHANNELS],
+static inline float pixel_correction(const float exposure,
+                                     const float *const restrict factors,
+                                     const float sigma)
+{
+  // build the correction for the current pixel
+  // as the sum of the contribution of each luminance channel
+  float result = 0.0f;
+  const float gauss_denom = gaussian_denom(sigma);
+  const float expo = fast_clamp(exposure, DT_TONEEQ_MIN_EV, DT_TONEEQ_MAX_EV);
+
+  DT_OMP_SIMD(aligned(centers_ops, factors:64) safelen(NUM_OCTAVES) reduction(+:result))
+  for(int i = 0; i < NUM_OCTAVES; ++i)
+    result += gaussian_func(expo - centers_ops[i], gauss_denom) * factors[i];
+
+  return fast_clamp(result, 0.25f, 4.0f);
+}
+
+
+__DT_CLONE_TARGETS__
+static gboolean compute_channels_factors(const float factors[NUM_OCTAVES],
+                                         float out[NUM_SLIDERS],
                                          const float sigma)
 {
   // Input factors are the weights for the radial-basis curve
   // approximation of user params Output factors are the gains of the
-  // user parameters channels aka the y coordinates of the
-  // approximation for x = { CHANNELS }
-  assert(PIXEL_CHAN == 8);
+  // user parameters NUM_SLIDERS aka the y coordinates of the
+  // approximation for x = { NUM_SLIDERS }
+  assert(NUM_OCTAVES == 8);
 
   DT_OMP_FOR_SIMD(aligned(factors, out, centers_params:64) firstprivate(centers_params))
-  for(int i = 0; i < CHANNELS; ++i)
+  for(int i = 0; i < NUM_SLIDERS; ++i)
   {
-    // Compute the new channels factors; pixel_correction clamps the factors, so we don't
+    // Compute the new NUM_SLIDERS factors; pixel_correction clamps the factors, so we don't
     // need to check for validity here
     out[i] = pixel_correction(centers_params[i], factors, sigma);
   }
@@ -1298,18 +1683,18 @@ static gboolean compute_channels_factors(const float factors[PIXEL_CHAN],
 
 
 __DT_CLONE_TARGETS__
-static void compute_channels_gains(const float in[CHANNELS],
-                                  float out[CHANNELS])
+static void compute_channels_gains(const float in[NUM_SLIDERS],
+                                  float out[NUM_SLIDERS])
 {
-  // Helper function to compute the new channels gains (log) from the factors (linear)
-  assert(PIXEL_CHAN == 8);
+  // Helper function to compute the new NUM_SLIDERS gains (log) from the factors (linear)
+  assert(NUM_OCTAVES == 8);
 
-  for(int i = 0; i < CHANNELS; ++i)
+  for(int i = 0; i < NUM_SLIDERS; ++i)
     out[i] = log2f(in[i]);
 }
 
 
-static void commit_channels_gains(const float factors[CHANNELS],
+static void commit_channels_gains(const float factors[NUM_SLIDERS],
                                  dt_iop_toneequalizer_params_t *p)
 {
   p->noise = factors[0];
@@ -1324,28 +1709,30 @@ static void commit_channels_gains(const float factors[CHANNELS],
 }
 
 
-/***
- * Cache invalidation and initializatiom
- ***/
-
-
+/****************************************************************************
+ *
+ * Cache invalidation and initialization
+ *
+ ****************************************************************************/
 static void gui_cache_init(dt_iop_module_t *self)
 {
+  printf("gui_cache_init\n");
   dt_iop_toneequalizer_gui_data_t *g = self->gui_data;
   if(g == NULL) return;
 
   dt_iop_gui_enter_critical_section(self);
-  g->ui_preview_hash = DT_INVALID_CACHEHASH;
-  g->thumb_preview_hash = DT_INVALID_CACHEHASH;
+  g->full_upstream_hash = DT_INVALID_CACHEHASH;
+  g->preview_upstream_hash = DT_INVALID_CACHEHASH;
   g->max_histogram = 1;
   g->scale = 1.0f;
   g->sigma = sqrtf(2.0f);
   g->mask_display = FALSE;
+  g->image_EV_per_UI_sample = 0.00001; // In case no value is calculated yet, use something small, but not 0
 
   g->interpolation_valid = FALSE;  // TRUE if the interpolation_matrix is ready
   g->luminance_valid = FALSE;      // TRUE if the luminance cache is ready
-  g->histogram_valid = FALSE;      // TRUE if the histogram cache and stats are ready
-  g->lut_valid = FALSE;            // TRUE if the gui_lut is ready
+  g->gui_histogram_valid = FALSE;  // TRUE if the histogram cache and stats are ready
+  g->gui_curve_valid = FALSE;      // TRUE if the gui_curve_lut is ready
   g->graph_valid = FALSE;          // TRUE if the UI graph view is ready
   g->user_param_valid = FALSE;     // TRUE if users params set in interactive view are in bounds
   g->factors_valid = TRUE;         // TRUE if radial-basis coeffs are ready
@@ -1357,13 +1744,13 @@ static void gui_cache_init(dt_iop_module_t *self)
   g->cursor_valid = FALSE;         // TRUE if mouse cursor is over the preview image
   g->has_focus = FALSE;            // TRUE if module has focus from GTK
 
-  g->full_preview_buf = NULL;
-  g->full_preview_buf_width = 0;
-  g->full_preview_buf_height = 0;
+  g->preview_buf = NULL;
+  g->preview_buf_width = 0;
+  g->preview_buf_height = 0;
 
-  g->thumb_preview_buf = NULL;
-  g->thumb_preview_buf_width = 0;
-  g->thumb_preview_buf_height = 0;
+  g->full_buf = NULL;
+  g->full_buf_width = 0;
+  g->full_buf_height = 0;
 
   g->desc = NULL;
   g->layout = NULL;
@@ -1376,7 +1763,45 @@ static void gui_cache_init(dt_iop_module_t *self)
 }
 
 
-static inline void build_interpolation_matrix(float A[CHANNELS * PIXEL_CHAN],
+static void invalidate_luminance_cache(dt_iop_module_t *const self)
+{
+  printf("invalidate_luminance_cache\n");
+  // Invalidate the private luminance cache and histogram when
+  // the luminance mask extraction parameters have changed
+  dt_iop_toneequalizer_gui_data_t *const restrict g = self->gui_data;
+
+  dt_iop_gui_enter_critical_section(self);
+  g->luminance_valid = FALSE;
+  g->preview_upstream_hash = DT_INVALID_CACHEHASH;
+  g->full_upstream_hash = DT_INVALID_CACHEHASH;
+
+  g->gui_histogram_valid = FALSE;
+  g->max_histogram = 1;
+  dt_iop_gui_leave_critical_section(self);
+  dt_iop_refresh_all(self);
+}
+
+
+static void invalidate_lut_and_histogram(dt_iop_module_t *const self)
+{
+  printf("invalidate_lut_and_histogram\n");
+  dt_iop_toneequalizer_gui_data_t *const restrict g = self->gui_data;
+
+  dt_iop_gui_enter_critical_section(self);
+  g->gui_curve_valid = FALSE;
+  g->gui_histogram_valid = FALSE;
+  g->max_histogram = 1;
+  dt_iop_gui_leave_critical_section(self);
+  dt_iop_refresh_all(self);
+}
+
+
+/****************************************************************************
+ *
+ * Curve Interpolation
+ *
+ ****************************************************************************/
+static inline void build_interpolation_matrix(float A[NUM_SLIDERS * NUM_OCTAVES],
                                               const float sigma)
 {
   // Build the symmetrical definite positive part of the augmented matrix
@@ -1385,135 +1810,38 @@ static inline void build_interpolation_matrix(float A[CHANNELS * PIXEL_CHAN],
   const float gauss_denom = gaussian_denom(sigma);
 
   DT_OMP_SIMD(aligned(A, centers_ops, centers_params:64) collapse(2))
-  for(int i = 0; i < CHANNELS; ++i)
-    for(int j = 0; j < PIXEL_CHAN; ++j)
-      A[i * PIXEL_CHAN + j] =
+  for(int i = 0; i < NUM_SLIDERS; ++i)
+    for(int j = 0; j < NUM_OCTAVES; ++j)
+      A[i * NUM_OCTAVES + j] =
         gaussian_func(centers_params[i] - centers_ops[j], gauss_denom);
 }
 
 
 __DT_CLONE_TARGETS__
-static inline void compute_log_histogram_and_stats(const float *const restrict luminance,
-                                                   int histogram[UI_SAMPLES],
-                                                   const size_t num_elem,
-                                                   int *max_histogram,
-                                                   float *first_decile,
-                                                   float *last_decile)
+static inline void compute_gui_curve(dt_iop_toneequalizer_gui_data_t *g)
 {
-  // (Re)init the histogram
-  memset(histogram, 0, sizeof(int) * UI_SAMPLES);
-
-  // we first calculate an extended histogram for better accuracy
-  #define TEMP_SAMPLES 2 * UI_SAMPLES
-  int temp_hist[TEMP_SAMPLES];
-  memset(temp_hist, 0, sizeof(int) * TEMP_SAMPLES);
-
-  // Split exposure in bins
-  DT_OMP_FOR_SIMD(reduction(+:temp_hist[:TEMP_SAMPLES]))
-  for(size_t k = 0; k < num_elem; k++)
-  {
-    // extended histogram bins between [-10; +6] EV remapped between [0 ; 2 * UI_SAMPLES]
-    const int index =
-      CLAMP((int)(((log2f(luminance[k]) + 10.0f) / 16.0f) * (float)TEMP_SAMPLES),
-            0, TEMP_SAMPLES - 1);
-    temp_hist[index] += 1;
-  }
-
-  const int first = (int)((float)num_elem * 0.05f);
-  const int last = (int)((float)num_elem * (1.0f - 0.95f));
-  int population = 0;
-  int first_pos = 0;
-  int last_pos = 0;
-
-  // scout the extended histogram bins looking for deciles
-  // these would not be accurate with the regular histogram
-  for(int k = 0; k < TEMP_SAMPLES; ++k)
-  {
-    const size_t prev_population = population;
-    population += temp_hist[k];
-    if(prev_population < first && first <= population)
-    {
-      first_pos = k;
-      break;
-    }
-  }
-  population = 0;
-  for(int k = TEMP_SAMPLES - 1; k >= 0; --k)
-  {
-    const size_t prev_population = population;
-    population += temp_hist[k];
-    if(prev_population < last && last <= population)
-    {
-      last_pos = k;
-      break;
-    }
-  }
-
-  // Convert decile positions to exposures
-  *first_decile = 16.0 * (float)first_pos / (float)(TEMP_SAMPLES - 1) - 10.0;
-  *last_decile = 16.0 * (float)last_pos / (float)(TEMP_SAMPLES - 1) - 10.0;
-
-  // remap the extended histogram into the normal one
-  // bins between [-8; 0] EV remapped between [0 ; UI_SAMPLES]
-  for(size_t k = 0; k < TEMP_SAMPLES; ++k)
-  {
-    float EV = 16.0 * (float)k / (float)(TEMP_SAMPLES - 1) - 10.0;
-    const int i =
-      CLAMP((int)(((EV + 8.0f) / 8.0f) * (float)UI_SAMPLES),
-            0, UI_SAMPLES - 1);
-    histogram[i] += temp_hist[k];
-
-    // store the max numbers of elements in bins for later normalization
-    *max_histogram = histogram[i] > *max_histogram ? histogram[i] : *max_histogram;
-  }
-}
-
-static inline void update_histogram(dt_iop_module_t *const self)
-{
-  dt_iop_toneequalizer_gui_data_t *const g = self->gui_data;
-  if(g == NULL) return;
-
-  dt_iop_gui_enter_critical_section(self);
-  if(!g->histogram_valid && g->luminance_valid)
-  {
-    const size_t num_elem = g->thumb_preview_buf_height * g->thumb_preview_buf_width;
-    compute_log_histogram_and_stats(g->thumb_preview_buf, g->histogram, num_elem,
-                                    &g->max_histogram,
-                                    &g->histogram_first_decile, &g->histogram_last_decile);
-    g->histogram_average = (g->histogram_first_decile + g->histogram_last_decile) / 2.0f;
-    g->histogram_valid = TRUE;
-  }
-  dt_iop_gui_leave_critical_section(self);
-}
-
-
-__DT_CLONE_TARGETS__
-static inline void compute_lut_correction(dt_iop_toneequalizer_gui_data_t *g,
-                                          const float offset,
-                                          const float scaling)
-{
-  // Compute the LUT of the exposure corrections in EV,
+  // Compute the curve of the exposure corrections in EV,
   // offset and scale it for display in GUI widget graph
 
   if(g == NULL) return;
 
-  float *const restrict LUT = g->gui_lut;
+  float *const restrict curve = g->gui_curve;
   const float *const restrict factors = g->factors;
   const float sigma = g->sigma;
 
-  DT_OMP_FOR_SIMD(aligned(LUT, factors:64))
-  for(int k = 0; k < UI_SAMPLES; k++)
+  DT_OMP_FOR_SIMD(aligned(curve, factors:64))
+  for(int k = 0; k < UI_HISTO_SAMPLES; k++)
   {
     // build the inset graph curve LUT
     // the x range is [-14;+2] EV
-    const float x = (8.0f * (((float)k) / ((float)(UI_SAMPLES - 1)))) - 8.0f;
-    LUT[k] = offset - log2f(pixel_correction(x, factors, sigma)) / scaling;
+    const float x = (8.0f * (((float)k) / ((float)(UI_HISTO_SAMPLES - 1)))) - 8.0f;
+    // curve[k] = offset - log2f(pixel_correction(x, factors, sigma)) / scaling;
+    curve[k] = log2f(pixel_correction(x, factors, sigma));
   }
 }
 
 
-
-static inline gboolean update_curve_lut(dt_iop_module_t *self)
+static inline gboolean curve_interpolation(dt_iop_module_t *self)
 {
   dt_iop_toneequalizer_params_t *p = self->params;
   dt_iop_toneequalizer_gui_data_t *g = self->gui_data;
@@ -1533,28 +1861,28 @@ static inline gboolean update_curve_lut(dt_iop_module_t *self)
 
   if(!g->user_param_valid)
   {
-    float factors[CHANNELS] DT_ALIGNED_ARRAY;
+    float factors[NUM_SLIDERS] DT_ALIGNED_ARRAY;
     get_channels_factors(factors, p);
-    dt_simd_memcpy(factors, g->temp_user_params, CHANNELS);
+    dt_simd_memcpy(factors, g->temp_user_params, NUM_SLIDERS);
     g->user_param_valid = TRUE;
     g->factors_valid = FALSE;
   }
 
   if(!g->factors_valid && g->user_param_valid)
   {
-    float factors[CHANNELS] DT_ALIGNED_ARRAY;
-    dt_simd_memcpy(g->temp_user_params, factors, CHANNELS);
-    valid = pseudo_solve(g->interpolation_matrix, factors, CHANNELS, PIXEL_CHAN, TRUE);
-    if(valid) dt_simd_memcpy(factors, g->factors, PIXEL_CHAN);
+    float factors[NUM_SLIDERS] DT_ALIGNED_ARRAY;
+    dt_simd_memcpy(g->temp_user_params, factors, NUM_SLIDERS);
+    valid = pseudo_solve(g->interpolation_matrix, factors, NUM_SLIDERS, NUM_OCTAVES, TRUE);
+    if(valid) dt_simd_memcpy(factors, g->factors, NUM_OCTAVES);
     else dt_print(DT_DEBUG_PIPE, "tone equalizer pseudo solve problem");
     g->factors_valid = TRUE;
-    g->lut_valid = FALSE;
+    g->gui_curve_valid = FALSE;
   }
 
-  if(!g->lut_valid && g->factors_valid)
+  if(!g->gui_curve_valid && g->factors_valid)
   {
-    compute_lut_correction(g, 0.5f, 4.0f);
-    g->lut_valid = TRUE;
+    compute_gui_curve(g);
+    g->gui_curve_valid = TRUE;
   }
 
   dt_iop_gui_leave_critical_section(self);
@@ -1563,33 +1891,25 @@ static inline gboolean update_curve_lut(dt_iop_module_t *self)
 }
 
 
-void init_global(dt_iop_module_so_t *self)
-{
-  dt_iop_toneequalizer_global_data_t *gd = malloc(sizeof(dt_iop_toneequalizer_global_data_t));
-
-  self->data = gd;
-}
-
-
-void cleanup_global(dt_iop_module_so_t *self)
-{
-  free(self->data);
-  self->data = NULL;
-}
-
-
-void commit_params(dt_iop_module_t *self,
-                   dt_iop_params_t *p1,
-                   dt_dev_pixelpipe_t *pipe,
+/****************************************************************************
+ *
+ * Commit Params
+ *
+ ****************************************************************************/
+void commit_params(dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_t *pipe,
                    dt_dev_pixelpipe_iop_t *piece)
 {
+
   dt_iop_toneequalizer_params_t *p = (dt_iop_toneequalizer_params_t *)p1;
   dt_iop_toneequalizer_data_t *d = piece->data;
   dt_iop_toneequalizer_gui_data_t *g = self->gui_data;
 
+  printf("commit_params pipe=%d align=%d p->post_scale=%f p->post_shift=%f d->post_scale=%f d->post_shift=%f\n",
+         pipe->type, p->post_auto_align, p->post_scale, p->post_shift, d->post_scale, d->post_shift);
+
   // Trivial params passing
-  d->method = p->method;
-  d->details = p->details;
+  d->lum_estimator = p->lum_estimator;
+  d->filter = p->filter;
   d->iterations = p->iterations;
   d->smoothing = p->smoothing;
   d->quantization = p->quantization;
@@ -1605,65 +1925,129 @@ void commit_params(dt_iop_module_t *self,
   d->contrast_boost = exp2f(p->contrast_boost);
   d->exposure_boost = exp2f(p->exposure_boost);
 
+  // printf("commit_params: post_auto_align %d\n", p->post_auto_align);
+  d->post_auto_align = p->post_auto_align;
+  d->post_scale = p->post_scale;
+  d->post_shift = p->post_shift;
+
   /*
    * Perform a radial-based interpolation using a series gaussian functions
    */
   if(self->dev->gui_attached && g)
   {
     dt_iop_gui_enter_critical_section(self);
-    if(g->sigma != p->smoothing)
-      g->interpolation_valid = FALSE;
+
+    if(g->sigma != p->smoothing) g->interpolation_valid = FALSE;
     g->sigma = p->smoothing;
-    g->user_param_valid = FALSE; // force updating channels factors
+    g->user_param_valid = FALSE; // force updating NUM_SLIDERS factors
     dt_iop_gui_leave_critical_section(self);
 
-    update_curve_lut(self);
+    curve_interpolation(self);
 
     dt_iop_gui_enter_critical_section(self);
-    dt_simd_memcpy(g->factors, d->factors, PIXEL_CHAN);
+    dt_simd_memcpy(g->factors, d->factors, NUM_OCTAVES);
     dt_iop_gui_leave_critical_section(self);
   }
   else
   {
     // No cache : Build / Solve interpolation matrix
-    float factors[CHANNELS] DT_ALIGNED_ARRAY;
+    float factors[NUM_SLIDERS] DT_ALIGNED_ARRAY;
     get_channels_factors(factors, p);
 
-    float A[CHANNELS * PIXEL_CHAN] DT_ALIGNED_ARRAY;
+    float A[NUM_SLIDERS * NUM_OCTAVES] DT_ALIGNED_ARRAY;
     build_interpolation_matrix(A, p->smoothing);
-    pseudo_solve(A, factors, CHANNELS, PIXEL_CHAN, FALSE);
+    pseudo_solve(A, factors, NUM_SLIDERS, NUM_OCTAVES, FALSE);
 
-    dt_simd_memcpy(factors, d->factors, PIXEL_CHAN);
+    dt_simd_memcpy(factors, d->factors, NUM_OCTAVES);
+  }
+}
+
+
+/****************************************************************************
+ *
+ * GUI Helpers
+ *
+ ****************************************************************************/
+static inline void compute_gui_histogram(int hires_histogram[HIRES_HISTO_SAMPLES],
+  int histogram[UI_HISTO_SAMPLES],
+  float histogram_scale,
+  float histogram_shift,
+  int *max_histogram)
+{
+  printf("compute_gui_histogram\n");
+  // (Re)init the histogram
+  memset(histogram, 0, sizeof(int) * UI_HISTO_SAMPLES);
+
+  const float temp_ev_range = HIRES_HISTO_MAX_EV - HIRES_HISTO_MIN_EV;
+
+  // remap the extended histogram into the gui histogram
+  // bins between [-8; 0] EV remapped between [0 ; UI_HISTO_SAMPLES]
+  for(size_t k = 0; k < HIRES_HISTO_SAMPLES; ++k)
+  {
+    // from [0...HIRES_HISTO_SAMPLES] to [-16...8EV]
+    float EV = temp_ev_range * (float)k / (float)(HIRES_HISTO_SAMPLES - 1) + HIRES_HISTO_MIN_EV;
+
+    // apply shift & scale to the EV value
+    const float shift_scaled_EV = post_scale_shift(EV, histogram_scale, histogram_shift);
+
+    // from [-8...0] EV to [0...UI_HISTO_SAMPLES]
+    const int i = CLAMP((int)(((shift_scaled_EV + 8.0f) / 8.0f) * (float)UI_HISTO_SAMPLES), 0, UI_HISTO_SAMPLES - 1);
+
+    histogram[i] += hires_histogram[k];
   }
 
-  // compute the correction LUT here to spare some time in process
-  // when computing several times toneequalizer with same parameters
-  compute_correction_lut(d->correction_lut, d->smoothing, d->factors);
+  // store the max numbers of elements in bins for later normalization
+  // ignore the first and last value to keep the histogram readable
+  *max_histogram = 1; // don't divide by 0 if there are no values at all
+  for (int i = 1; i < UI_HISTO_SAMPLES - 1; i++)
+  {
+    *max_histogram = histogram[i] > *max_histogram ? histogram[i] : *max_histogram;
+  }
 }
 
 
-void init_pipe(dt_iop_module_t *self,
-               dt_dev_pixelpipe_t *pipe,
-               dt_dev_pixelpipe_iop_t *piece)
+static inline void update_gui_histogram(dt_iop_module_t *const self)
 {
-  piece->data = dt_calloc1_align_type(dt_iop_toneequalizer_data_t);
+  dt_iop_toneequalizer_gui_data_t *const g = self->gui_data;
+  dt_iop_toneequalizer_params_t *const p = self->params;
+  if(g == NULL) return;
+
+  dt_iop_gui_enter_critical_section(self);
+  if(!g->gui_histogram_valid && g->luminance_valid)
+  {
+    compute_auto_post_scale_shift(&p->post_scale, &p->post_shift, p->post_auto_align, g->histogram_first_decile, g->histogram_last_decile, 999);
+    compute_gui_histogram(g->hires_histogram, g->histogram, p->post_scale, p->post_shift, &g->max_histogram);
+
+    // Computation of "image_EV_per_UI_sample"
+    // The graph shows 8EV, but when we align the histogram, we consider 6EV [-7; -1] ("target")
+    const float target_EV_range = 6.0f;
+    const float full_EV_range = 8.0f;
+    const float target_to_full = full_EV_range / target_EV_range;
+
+    // What is the real dynamic range of the histogram-part [-7; -1])? We unscale.
+    const float mask_EV_of_target = target_EV_range / exp2f(p->post_scale);
+
+    // The histogram shows mask EV, but for evaluating curve steepness, we need image EVs
+    const float mask_to_image = (g->image_histogram_last_decile - g->image_histogram_first_decile)
+                                / (g->histogram_last_decile - g->histogram_first_decile);
+
+    g->image_EV_per_UI_sample = (mask_EV_of_target * mask_to_image * target_to_full) / (float)UI_HISTO_SAMPLES;
+
+    if (g->show_two_histograms)
+      compute_gui_histogram(g->image_hires_histogram, g->image_histogram, p->post_scale, p->post_shift, &g->max_image_histogram);
+
+    g->gui_histogram_valid = TRUE;
+  }
+  dt_iop_gui_leave_critical_section(self);
 }
 
-
-void cleanup_pipe(dt_iop_module_t *self,
-                  dt_dev_pixelpipe_t *pipe,
-                  dt_dev_pixelpipe_iop_t *piece)
-{
-  dt_free_align(piece->data);
-  piece->data = NULL;
-}
 
 static void show_guiding_controls(dt_iop_module_t *self)
 {
   dt_iop_toneequalizer_gui_data_t *g = self->gui_data;
   const dt_iop_toneequalizer_params_t *p = self->params;
 
-  switch(p->details)
+  switch(p->filter)
   {
     case(DT_TONEEQ_NONE):
     {
@@ -1697,43 +2081,62 @@ static void show_guiding_controls(dt_iop_module_t *self)
       break;
     }
   }
+
+  switch(p->post_auto_align) {
+    case(DT_TONEEQ_ALIGN_LEFT):
+    case(DT_TONEEQ_ALIGN_CENTER):
+    case(DT_TONEEQ_ALIGN_RIGHT):
+    {
+      gtk_widget_set_visible(g->post_scale, TRUE);
+      gtk_widget_set_visible(g->post_shift, FALSE);
+      break;
+    }
+    case(DT_TONEEQ_ALIGN_FIT):
+    {
+      gtk_widget_set_visible(g->post_scale, FALSE);
+      gtk_widget_set_visible(g->post_shift, FALSE);
+      break;
+    }
+    case(DT_TONEEQ_ALIGN_CUSTOM):
+    {
+      gtk_widget_set_visible(g->post_scale, TRUE);
+      gtk_widget_set_visible(g->post_shift, TRUE);
+      break;
+    }
+  }
 }
 
-void update_exposure_sliders(dt_iop_toneequalizer_gui_data_t *g,
-                             dt_iop_toneequalizer_params_t *p)
-{
-  ++darktable.gui->reset;
-  dt_bauhaus_slider_set(g->noise, p->noise);
-  dt_bauhaus_slider_set(g->ultra_deep_blacks, p->ultra_deep_blacks);
-  dt_bauhaus_slider_set(g->deep_blacks, p->deep_blacks);
-  dt_bauhaus_slider_set(g->blacks, p->blacks);
-  dt_bauhaus_slider_set(g->shadows, p->shadows);
-  dt_bauhaus_slider_set(g->midtones, p->midtones);
-  dt_bauhaus_slider_set(g->highlights, p->highlights);
-  dt_bauhaus_slider_set(g->whites, p->whites);
-  dt_bauhaus_slider_set(g->speculars, p->speculars);
-  --darktable.gui->reset;
-}
 
-
+/****************************************************************************
+ *
+ * GUI Callbacks
+ *
+ ****************************************************************************/
 void gui_update(dt_iop_module_t *self)
 {
+  printf("gui_update\n");
   dt_iop_toneequalizer_gui_data_t *g = self->gui_data;
   dt_iop_toneequalizer_params_t *p = self->params;
 
   dt_bauhaus_slider_set(g->smoothing, logf(p->smoothing) / logf(sqrtf(2.0f)) - 1.0f);
 
   show_guiding_controls(self);
+
   invalidate_luminance_cache(self);
 
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->show_luminance_mask), g->mask_display);
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->show_two_histograms), g->two_histograms_display);
+
 }
+
 
 void gui_changed(dt_iop_module_t *self,
                  GtkWidget *w,
                  void *previous)
 {
+  printf("gui_changed\n");
   dt_iop_toneequalizer_gui_data_t *g = self->gui_data;
+  dt_iop_toneequalizer_params_t *p = self->params;
 
   if(w == g->method
      || w == g->blending
@@ -1754,7 +2157,25 @@ void gui_changed(dt_iop_module_t *self,
     invalidate_luminance_cache(self);
     dt_bauhaus_widget_set_quad_active(w, FALSE);
   }
+  else if (w == g->post_scale
+           || w == g->post_shift)
+  {
+    invalidate_lut_and_histogram(self);
+  }
+  else if (w == g->post_auto_align)
+  {
+    // We may have switched from a more automatic to a less automatic mode.
+    // Copy the automatically determined parameters to the GUI sliders.
+    ++darktable.gui->reset;
+    dt_bauhaus_slider_set(g->post_scale, p->post_scale);
+    dt_bauhaus_slider_set(g->post_shift, p->post_shift);
+    --darktable.gui->reset;
+
+    invalidate_lut_and_histogram(self);
+    show_guiding_controls(self);
+  }
 }
+
 
 static void smoothing_callback(GtkWidget *slider, dt_iop_module_t *self)
 {
@@ -1764,11 +2185,11 @@ static void smoothing_callback(GtkWidget *slider, dt_iop_module_t *self)
 
   p->smoothing= powf(sqrtf(2.0f), 1.0f +  dt_bauhaus_slider_get(slider));
 
-  float factors[CHANNELS] DT_ALIGNED_ARRAY;
+  float factors[NUM_SLIDERS] DT_ALIGNED_ARRAY;
   get_channels_factors(factors, p);
 
   // Solve the interpolation by least-squares to check the validity of the smoothing param
-  if(!update_curve_lut(self))
+  if(!curve_interpolation(self))
     dt_control_log
       (_("the interpolation is unstable, decrease the curve smoothing"));
 
@@ -1780,6 +2201,7 @@ static void smoothing_callback(GtkWidget *slider, dt_iop_module_t *self)
   // Unlock the colour picker so we can display our own custom cursor
   dt_iop_color_picker_reset(self, TRUE);
 }
+
 
 static void auto_adjust_exposure_boost(GtkWidget *quad, dt_iop_module_t *self)
 {
@@ -1802,7 +2224,7 @@ static void auto_adjust_exposure_boost(GtkWidget *quad, dt_iop_module_t *self)
     return;
   }
 
-  if(!g->luminance_valid || self->dev->full.pipe->processing || !g->histogram_valid)
+  if(!g->luminance_valid || self->dev->full.pipe->processing || !g->gui_histogram_valid)
   {
     dt_control_log(_("wait for the preview to finish recomputing"));
     return;
@@ -1812,12 +2234,11 @@ static void auto_adjust_exposure_boost(GtkWidget *quad, dt_iop_module_t *self)
   // to spread it over as many nodes as possible for better exposure control.
   // Controls nodes are between -8 and 0 EV,
   // so we aim at centering the exposure distribution on -4 EV
-
   dt_iop_gui_enter_critical_section(self);
-  g->histogram_valid = FALSE;
+  g->gui_histogram_valid = FALSE;
   dt_iop_gui_leave_critical_section(self);
 
-  update_histogram(self);
+  update_gui_histogram(self);
 
   // calculate exposure correction
   const float fd_new = exp2f(g->histogram_first_decile);
@@ -1868,7 +2289,7 @@ static void auto_adjust_contrast_boost(GtkWidget *quad, dt_iop_module_t *self)
     return;
   }
 
-  if(!g->luminance_valid || self->dev->full.pipe->processing || !g->histogram_valid)
+  if(!g->luminance_valid || self->dev->full.pipe->processing || !g->gui_histogram_valid)
   {
     dt_control_log(_("wait for the preview to finish recomputing"));
     return;
@@ -1876,10 +2297,10 @@ static void auto_adjust_contrast_boost(GtkWidget *quad, dt_iop_module_t *self)
 
   // The goal is to spread 90 % of the exposure histogram in the [-7, -1] EV
   dt_iop_gui_enter_critical_section(self);
-  g->histogram_valid = FALSE;
+  g->gui_histogram_valid = FALSE;
   dt_iop_gui_leave_critical_section(self);
 
-  update_histogram(self);
+  update_gui_histogram(self);
 
   // calculate contrast correction
   const float fd_new = exp2f(g->histogram_first_decile);
@@ -1900,7 +2321,7 @@ static void auto_adjust_contrast_boost(GtkWidget *quad, dt_iop_module_t *self)
   // when adding contrast, blur filters modify the histogram in a way
   // difficult to predict here we implement a heuristic correction
   // based on a set of images and regression analysis
-  if(p->details == DT_TONEEQ_EIGF && c > 0.0f)
+  if(p->filter == DT_TONEEQ_EIGF && c > 0.0f)
   {
     const float correction = -0.0276f + 0.01823 * p->feathering + (0.7566f - 1.0f) * c;
     if(p->feathering < 5.0f)
@@ -1908,7 +2329,7 @@ static void auto_adjust_contrast_boost(GtkWidget *quad, dt_iop_module_t *self)
     else if(p->feathering < 10.0f)
       c += correction * (2.0f - p->feathering / 5.0f);
   }
-  else if(p->details == DT_TONEEQ_GUIDED && c > 0.0f)
+  else if(p->filter == DT_TONEEQ_GUIDED && c > 0.0f)
       c = 0.0235f + 1.1225f * c;
 
   p->contrast_boost += c;
@@ -1956,9 +2377,148 @@ static void show_luminance_mask_callback(GtkWidget *togglebutton,
 }
 
 
-/***
+// TODO MF: Remove this again? Two histograms are only useful for debugging.
+static void show_two_histograms_callback(GtkWidget *togglebutton,
+  GdkEventButton *event,
+  dt_iop_module_t *self)
+{
+  if(darktable.gui->reset) return;
+  dt_iop_request_focus(self);
+
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(self->off), TRUE);
+
+  dt_iop_toneequalizer_gui_data_t *g = self->gui_data;
+  g->two_histograms_display = !g->two_histograms_display;
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->show_two_histograms), g->two_histograms_display);
+
+  //  dt_dev_reprocess_center(self->dev);
+  dt_iop_refresh_center(self); // TODO: is this needed?
+  // Unlock the colour picker so we can display our own custom cursor
+  // dt_iop_color_picker_reset(self, TRUE);
+}
+
+
+/****************************************************************************
+ *
  * GUI Interactivity
- **/
+ *
+ ****************************************************************************/
+static void _get_point(dt_iop_module_t *self, const int c_x, const int c_y, int *x, int *y)
+{
+  // TODO: For this to fully work non depending on the place of the module
+  //       in the pipe we need a dt_dev_distort_backtransform_plus that
+  //       can skip crop only. With the current version if toneequalizer
+  //       is moved below rotation & perspective it will fail as we are
+  //       then missing all the transform after tone-eq.
+  const double crop_order = dt_ioppr_get_iop_order(self->dev->iop_order_list, "crop", 0);
+
+  float pts[2] = { c_x, c_y };
+
+  // only a forward backtransform as the buffer already contains all the transforms
+  // done before toneequal and we are speaking of on-screen cursor coordinates.
+  // also we do transform only after crop as crop does change roi for the whole pipe
+  // and so it is already part of the preview buffer cached in this implementation.
+  dt_dev_distort_backtransform_plus(darktable.develop, darktable.develop->preview_pipe, crop_order,
+                                    DT_DEV_TRANSFORM_DIR_FORW_EXCL, pts, 1);
+  *x = pts[0];
+  *y = pts[1];
+}
+
+
+__DT_CLONE_TARGETS__
+static float get_luminance_from_buffer(const float *const buffer,
+                                       const size_t width,
+                                       const size_t height,
+                                       const size_t x,
+                                       const size_t y)
+{
+  // Get the weighted average luminance of the 3×3 pixels region centered in (x, y)
+  // x and y are ratios in [0, 1] of the width and height
+
+  if(y >= height || x >= width) return NAN;
+
+  const size_t y_abs[4] DT_ALIGNED_PIXEL =
+                          { MAX(y, 1) - 1,              // previous line
+                            y,                          // center line
+                            MIN(y + 1, height - 1),     // next line
+                            y };		        // padding for vectorization
+
+  float luminance = 0.0f;
+  if(x > 1 && x < width - 2)
+  {
+    // no clamping needed on x, which allows us to vectorize
+    // apply the convolution
+    for(int i = 0; i < 3; ++i)
+    {
+      const size_t y_i = y_abs[i];
+      for_each_channel(j)
+        luminance += buffer[width * y_i + x-1 + j] * gauss_kernel[i][j];
+    }
+    return luminance;
+  }
+
+  const size_t x_abs[4] DT_ALIGNED_PIXEL =
+                          { MAX(x, 1) - 1,              // previous column
+                            x,                          // center column
+                            MIN(x + 1, width - 1),      // next column
+                            x };                        // padding for vectorization
+
+  // convolution
+  for(int i = 0; i < 3; ++i)
+  {
+    const size_t y_i = y_abs[i];
+    for_each_channel(j)
+      luminance += buffer[width * y_i + x_abs[j]] * gauss_kernel[i][j];
+  }
+  return luminance;
+}
+
+
+// unify with get_luminance_from_buffer
+static float _luminance_from_thumb_preview_buf(dt_iop_module_t *self)
+{
+  dt_iop_toneequalizer_gui_data_t *g = self->gui_data;
+
+  const size_t c_x = g->cursor_pos_x;
+  const size_t c_y = g->cursor_pos_y;
+
+  // get buffer x,y given the cursor position
+  int b_x = 0;
+  int b_y = 0;
+
+  _get_point(self, c_x, c_y, &b_x, &b_y);
+
+  return get_luminance_from_buffer(g->preview_buf,
+    g->preview_buf_width,
+    g->preview_buf_height,
+    b_x,
+    b_y);
+}
+
+
+void update_exposure_sliders(dt_iop_toneequalizer_gui_data_t *g, dt_iop_toneequalizer_params_t *p)
+{
+  // Params to GUI
+  ++darktable.gui->reset;
+  dt_bauhaus_slider_set(g->noise, p->noise);
+  dt_bauhaus_slider_set(g->ultra_deep_blacks, p->ultra_deep_blacks);
+  dt_bauhaus_slider_set(g->deep_blacks, p->deep_blacks);
+  dt_bauhaus_slider_set(g->blacks, p->blacks);
+  dt_bauhaus_slider_set(g->shadows, p->shadows);
+  dt_bauhaus_slider_set(g->midtones, p->midtones);
+  dt_bauhaus_slider_set(g->highlights, p->highlights);
+  dt_bauhaus_slider_set(g->whites, p->whites);
+  dt_bauhaus_slider_set(g->speculars, p->speculars);
+  --darktable.gui->reset;
+}
+
+
+static gboolean in_mask_editing(dt_iop_module_t *self)
+{
+  const dt_develop_t *dev = self->dev;
+  return dev->form_gui && dev->form_visible;
+}
+
 
 static void switch_cursors(dt_iop_module_t *self)
 {
@@ -2039,6 +2599,7 @@ static void switch_cursors(dt_iop_module_t *self)
   }
 }
 
+
 int mouse_moved(dt_iop_module_t *self,
                 const float pzx,
                 const float pzy,
@@ -2051,6 +2612,7 @@ int mouse_moved(dt_iop_module_t *self,
 
   const dt_develop_t *dev = self->dev;
   dt_iop_toneequalizer_gui_data_t *g = self->gui_data;
+  dt_iop_toneequalizer_params_t *const p = self->params;
 
   if(g == NULL) return 0;
 
@@ -2078,8 +2640,10 @@ int mouse_moved(dt_iop_module_t *self,
   dt_iop_gui_leave_critical_section(self);
 
   // store the actual exposure too, to spare I/O op
-  if(g->cursor_valid && !dev->full.pipe->processing && g->luminance_valid)
-    g->cursor_exposure = log2f(_luminance_from_module_buffer(self));
+  if(g->cursor_valid && !dev->full.pipe->processing && g->luminance_valid) {
+    const float lum = log2f(_luminance_from_thumb_preview_buf(self));
+    g->cursor_exposure = fast_clamp(post_scale_shift(lum, p->post_scale, p->post_shift), DT_TONEEQ_MIN_EV, DT_TONEEQ_MAX_EV);
+  }
 
   switch_cursors(self);
 
@@ -2116,7 +2680,7 @@ static inline gboolean set_new_params_interactive(const float control_exposure,
                                                   dt_iop_toneequalizer_gui_data_t *g,
                                                   dt_iop_toneequalizer_params_t *p)
 {
-  // Apply an exposure offset optimized smoothly over all the exposure channels,
+  // Apply an exposure offset optimized smoothly over all the exposure NUM_SLIDERS,
   // taking user instruction to apply exposure_offset EV at control_exposure EV,
   // and commit the new params is the solution is valid.
 
@@ -2126,20 +2690,20 @@ static inline gboolean set_new_params_interactive(const float control_exposure,
   const float std = gaussian_denom(blending_sigma);
   if(g->user_param_valid)
   {
-    for(int i = 0; i < CHANNELS; ++i)
+    for(int i = 0; i < NUM_SLIDERS; ++i)
       g->temp_user_params[i] *=
         exp2f(gaussian_func(centers_params[i] - control_exposure, std) * exposure_offset);
   }
 
   // Get the new weights for the radial-basis approximation
-  float factors[CHANNELS] DT_ALIGNED_ARRAY;
-  dt_simd_memcpy(g->temp_user_params, factors, CHANNELS);
+  float factors[NUM_SLIDERS] DT_ALIGNED_ARRAY;
+  dt_simd_memcpy(g->temp_user_params, factors, NUM_SLIDERS);
   if(g->user_param_valid)
-    g->user_param_valid = pseudo_solve(g->interpolation_matrix, factors, CHANNELS, PIXEL_CHAN, TRUE);
+    g->user_param_valid = pseudo_solve(g->interpolation_matrix, factors, NUM_SLIDERS, NUM_OCTAVES, TRUE);
   if(!g->user_param_valid)
     dt_control_log(_("the interpolation is unstable, decrease the curve smoothing"));
 
-  // Compute new user params for channels and store them locally
+  // Compute new user params for NUM_SLIDERS and store them locally
   if(g->user_param_valid)
     g->user_param_valid = compute_channels_factors(factors, g->temp_user_params, g->sigma);
   if(!g->user_param_valid) dt_control_log(_("some parameters are out-of-bounds"));
@@ -2149,11 +2713,11 @@ static inline gboolean set_new_params_interactive(const float control_exposure,
   if(commit)
   {
     // Accept the solution
-    dt_simd_memcpy(factors, g->factors, PIXEL_CHAN);
-    g->lut_valid = FALSE;
+    dt_simd_memcpy(factors, g->factors, NUM_OCTAVES);
+    g->gui_curve_valid = FALSE;
 
     // Convert the linear temp parameters to log gains and commit
-    float gains[CHANNELS] DT_ALIGNED_ARRAY;
+    float gains[NUM_SLIDERS] DT_ALIGNED_ARRAY;
     compute_channels_gains(g->temp_user_params, gains);
     commit_channels_gains(gains, p);
   }
@@ -2161,7 +2725,7 @@ static inline gboolean set_new_params_interactive(const float control_exposure,
   {
     // Reset the GUI copy of user params
     get_channels_factors(factors, p);
-    dt_simd_memcpy(factors, g->temp_user_params, CHANNELS);
+    dt_simd_memcpy(factors, g->temp_user_params, NUM_SLIDERS);
     g->user_param_valid = TRUE;
   }
 
@@ -2189,6 +2753,9 @@ int scrolled(dt_iop_module_t *self,
 
   if(in_mask_editing(self)) return 0;
 
+  // ALT/Option should work for zooming
+  if (dt_modifier_is(state, GDK_MOD1_MASK)) return 0;
+
   // if GUI buffers not ready, exit but still handle the cursor
   dt_iop_gui_enter_critical_section(self);
 
@@ -2204,7 +2771,9 @@ int scrolled(dt_iop_module_t *self,
 
   // re-read the exposure in case it has changed
   dt_iop_gui_enter_critical_section(self);
-  g->cursor_exposure = log2f(_luminance_from_module_buffer(self));
+
+  const float lum = log2f(_luminance_from_thumb_preview_buf(self));
+  g->cursor_exposure = fast_clamp(post_scale_shift(lum, p->post_scale, p->post_shift), DT_TONEEQ_MIN_EV, DT_TONEEQ_MAX_EV);
 
   dt_iop_gui_leave_critical_section(self);
 
@@ -2221,7 +2790,7 @@ int scrolled(dt_iop_module_t *self,
 
   const float offset = step * ((float)increment);
 
-  // Get the desired correction on exposure channels
+  // Get the desired correction on exposure NUM_SLIDERS
   dt_iop_gui_enter_critical_section(self);
   const gboolean commit = set_new_params_interactive(g->cursor_exposure, offset,
                                                 g->sigma * g->sigma / 2.0f, g, p);
@@ -2240,10 +2809,12 @@ int scrolled(dt_iop_module_t *self,
   return 1;
 }
 
-/***
- * GTK/Cairo drawings and custom widgets
- **/
 
+ /****************************************************************************
+ *
+ * GTK/Cairo drawings and custom widgets
+ *
+ ****************************************************************************/
 static inline gboolean _init_drawing(dt_iop_module_t *const restrict self,
                                      GtkWidget *widget,
                                      dt_iop_toneequalizer_gui_data_t *const restrict g);
@@ -2276,6 +2847,7 @@ void cairo_draw_hatches(cairo_t *cr,
     cairo_stroke(cr);
   }
 }
+
 
 static void get_shade_from_luminance(cairo_t *cr,
                                      const float luminance,
@@ -2349,6 +2921,7 @@ void gui_post_expose(dt_iop_module_t *self,
 
   dt_develop_t *dev = self->dev;
   dt_iop_toneequalizer_gui_data_t *g = self->gui_data;
+  dt_iop_toneequalizer_params_t *p = self->params;
 
   // if we are editing masks, do not display controls
   if(in_mask_editing(self)) return;
@@ -2369,8 +2942,10 @@ void gui_post_expose(dt_iop_module_t *self,
       return;
 
   // re-read the exposure in case it has changed
-  if(g->luminance_valid && self->enabled)
-    g->cursor_exposure = log2f(_luminance_from_module_buffer(self));
+  if(g->luminance_valid && self->enabled) {
+    const float lum = log2f(_luminance_from_thumb_preview_buf(self));
+    g->cursor_exposure = fast_clamp(post_scale_shift(lum, p->post_scale, p->post_shift), DT_TONEEQ_MIN_EV, DT_TONEEQ_MAX_EV);
+  }
 
   dt_iop_gui_enter_critical_section(self);
 
@@ -2491,7 +3066,7 @@ void gui_post_expose(dt_iop_module_t *self,
     const float radius_threshold = 0.45f;
     g->area_active_node = -1;
     if(g->cursor_valid)
-      for(int i = 0; i < CHANNELS; ++i)
+      for(int i = 0; i < NUM_SLIDERS; ++i)
       {
         const float delta_x = fabsf(g->cursor_exposure - centers_params[i]);
         if(delta_x < radius_threshold)
@@ -2502,12 +3077,13 @@ void gui_post_expose(dt_iop_module_t *self,
   }
 }
 
+
 static void _develop_distort_callback(gpointer instance,
                                       dt_iop_module_t *self)
 {
   dt_iop_toneequalizer_gui_data_t *g = self->gui_data;
   if(g == NULL) return;
-  if(!g->distort_signal_actif) return;
+  if(!g->distort_signal_active) return;
 
   /* disable the distort signal now to avoid recursive call on this signal as we are
      about to reprocess the preview pipe which has some module doing distortion. */
@@ -2520,28 +3096,32 @@ static void _develop_distort_callback(gpointer instance,
     dt_dev_reprocess_preview(darktable.develop);
 }
 
+
 static void _set_distort_signal(dt_iop_module_t *self)
 {
   dt_iop_toneequalizer_gui_data_t *g = self->gui_data;
-  if(self->enabled && !g->distort_signal_actif)
+  if(self->enabled && !g->distort_signal_active)
   {
     DT_CONTROL_SIGNAL_HANDLE(DT_SIGNAL_DEVELOP_DISTORT, _develop_distort_callback);
-    g->distort_signal_actif = TRUE;
+    g->distort_signal_active = TRUE;
   }
 }
+
 
 static void _unset_distort_signal(dt_iop_module_t *self)
 {
   dt_iop_toneequalizer_gui_data_t *g = self->gui_data;
-  if(g->distort_signal_actif)
+  if(g->distort_signal_active)
   {
     DT_CONTROL_SIGNAL_DISCONNECT(_develop_distort_callback, self);
-    g->distort_signal_actif = FALSE;
+    g->distort_signal_active = FALSE;
   }
 }
 
+
 void gui_focus(dt_iop_module_t *self, gboolean in)
 {
+  printf("gui_focus %d\n", in);
   dt_iop_toneequalizer_gui_data_t *g = self->gui_data;
   dt_iop_gui_enter_critical_section(self);
   g->has_focus = in;
@@ -2580,6 +3160,8 @@ static inline gboolean _init_drawing(dt_iop_module_t *const restrict self,
 
   if(g->cst)
     cairo_surface_destroy(g->cst);
+
+  g->allocation.height -= DT_RESIZE_HANDLE_SIZE;
   g->cst = dt_cairo_image_surface_create(CAIRO_FORMAT_ARGB32,
                                          g->allocation.width, g->allocation.height);
 
@@ -2640,10 +3222,10 @@ static inline gboolean _init_drawing(dt_iop_module_t *const restrict self,
 
   float value = -8.0f;
 
-  for(int k = 0; k < CHANNELS; k++)
+  for(int k = 0; k < NUM_SLIDERS; k++)
   {
     const float xn =
-      (((float)k) / ((float)(CHANNELS - 1))) * g->graph_width - g->sign_width;
+      (((float)k) / ((float)(NUM_SLIDERS - 1))) * g->graph_width - g->sign_width;
 
     snprintf(text, sizeof(text), "%+.0f", value);
     pango_layout_set_text(g->layout, text, -1);
@@ -2720,8 +3302,8 @@ static inline void init_nodes_x(dt_iop_toneequalizer_gui_data_t *g)
 
   if(!g->valid_nodes_x && g->graph_width > 0)
   {
-    for(int i = 0; i < CHANNELS; ++i)
-      g->nodes_x[i] = (((float)i) / ((float)(CHANNELS - 1))) * g->graph_width;
+    for(int i = 0; i < NUM_SLIDERS; ++i)
+      g->nodes_x[i] = (((float)i) / ((float)(NUM_SLIDERS - 1))) * g->graph_width;
     g->valid_nodes_x = TRUE;
   }
 }
@@ -2734,10 +3316,106 @@ static inline void init_nodes_y(dt_iop_toneequalizer_gui_data_t *g)
 
   if(g->user_param_valid && g->graph_height > 0)
   {
-    for(int i = 0; i < CHANNELS; ++i)
+    for(int i = 0; i < NUM_SLIDERS; ++i)
       g->nodes_y[i] = // assumes factors in [-2 ; 2] EV
         (0.5 - log2f(g->temp_user_params[i]) / 4.0) * g->graph_height;
     g->valid_nodes_y = TRUE;
+  }
+}
+
+
+static inline void interpolate_gui_color(GdkRGBA a, GdkRGBA b, float t, GdkRGBA *out)
+{
+  float t_clamp = fast_clamp(t, 0.0f, 1.0f);
+  out->red = a.red + t_clamp * (b.red - a.red);
+  out->green = a.green + t_clamp * (b.green - a.green);
+  out->blue = a.blue + t_clamp * (b.blue - a.blue);
+  out->alpha = a.alpha + t_clamp * (b.alpha - a.alpha);
+}
+
+
+static inline void compute_gui_curve_colors(dt_iop_module_t *self)
+{
+  dt_iop_toneequalizer_gui_data_t *g = self->gui_data;
+  dt_iop_toneequalizer_params_t *p = self->params;
+
+  const float *const restrict curve = g->gui_curve;
+  GdkRGBA *const restrict colors = g->gui_curve_colors;
+  const gboolean filter_active = (p->filter != DT_TONEEQ_NONE);
+  const float ev_dx = g->image_EV_per_UI_sample;
+
+  const GdkRGBA standard = darktable.bauhaus->graph_fg;
+  const GdkRGBA warning = {0.75, 0.5, 0.0, 1.0};
+  const GdkRGBA error = {1.0, 0.0, 0.0, 1.0};
+  GdkRGBA temp_color = {0.0, 0.0, 0.0, 1.0};
+
+  const int shadows_limit = (int)UI_HISTO_SAMPLES * 0.3333;
+  const int highlights_limit = (int)UI_HISTO_SAMPLES * 0.6666;
+
+  // printf("ev_dx=%f filter_active=%d details=%d\n", ev_dx, filter_active, p->details);
+
+  if (!g->gui_histogram_valid || !g->gui_curve_valid) {
+    // the module is not completely initialized, set all colors to standard
+    for(int k = 0; k < UI_HISTO_SAMPLES; k++)
+      colors[k] = standard;
+    return;
+  };
+
+  colors[0] = standard;
+  for(int k = 1; k < UI_HISTO_SAMPLES; k++)
+  {
+    float ev_dy = (curve[k] - curve[k - 1]);
+    float steepness = ev_dy / ev_dx;
+    colors[k] = standard;
+
+    if(filter_active && k < shadows_limit && curve[k] < 0.0f)
+    {
+      // Lower shadows with filter active, this does not provide the local
+      // contrast that the user probably expects.
+      const float x_dist = ((float)(shadows_limit - k) / (float)UI_HISTO_SAMPLES) * 8.0f;
+      const float color_dist = fminf(x_dist, -curve[k]);
+      interpolate_gui_color(standard, warning, color_dist, &temp_color);
+      colors[k] = temp_color;
+    }
+    else if(filter_active && k > highlights_limit && curve[k] > 0.0f)
+    {
+      // Raise highlights with filter active, this does not provide the local
+      // contrast that the user probably expects.
+      const float x_dist = ((float)(k - highlights_limit) / (float)UI_HISTO_SAMPLES) * 8.0f;
+      const float color_dist = fminf(x_dist, curve[k]);
+      interpolate_gui_color(standard, warning, color_dist, &temp_color);
+      colors[k] = temp_color;
+    }
+    else if(!filter_active && k < shadows_limit && curve[k] > 0.0f)
+    {
+      // Raise shadows without filter, this leads to a loss of contrast.
+      const float x_dist = ((float)(shadows_limit - k) / (float)UI_HISTO_SAMPLES) * 8.0f;
+      const float color_dist = fminf(x_dist, curve[k]);
+      interpolate_gui_color(standard, warning, color_dist, &temp_color);
+      colors[k] = temp_color;
+    }
+    else if(!filter_active && k > highlights_limit && curve[k] < 0.0f)
+    {
+      // Lower highlights without filter, this leads to a loss of contrast.
+      const float x_dist = ((float)(k - highlights_limit) / (float)UI_HISTO_SAMPLES) * 8.0f;
+      const float color_dist = fminf(x_dist, -curve[k]);
+      interpolate_gui_color(standard, warning, color_dist, &temp_color);
+      colors[k] = temp_color;
+    }
+
+    // Too steep downward slopes.
+    // These warnings take precedence, even if the segment was already
+    // colored, we overwrite the colors here.
+    if(steepness < -0.5f && steepness > -1.0f)
+    {
+      colors[k] = warning;
+    }
+    else if(steepness <= -1.0f)
+    {
+      colors[k] = error;
+    }
+
+    // printf("curve[%d]=%f ev_dx=%f ev_dy=%f steepness=%f colors[%d]=%f\n", k, curve[k], ev_dx, ev_dy, steepness, k, colors[k].red);
   }
 }
 
@@ -2748,6 +3426,8 @@ static gboolean area_draw(GtkWidget *widget,
 {
   // Draw the widget equalizer view
   dt_iop_toneequalizer_gui_data_t *g = self->gui_data;
+  dt_iop_toneequalizer_params_t *p = self->params;
+
   if(g == NULL) return FALSE;
 
   // Init or refresh the drawing cache
@@ -2767,8 +3447,11 @@ static gboolean area_draw(GtkWidget *widget,
   dt_iop_gui_leave_critical_section(self);
 
   // Refresh cached UI elements
-  update_histogram(self);
-  update_curve_lut(self);
+  update_gui_histogram(self);
+  curve_interpolation(self);
+
+  // The colors depend on the histogram and the curve
+  compute_gui_curve_colors(self);
 
   // Draw graph background
   cairo_set_line_width(g->cr, DT_PIXEL_APPLY_DPI(0.5));
@@ -2788,26 +3471,52 @@ static gboolean area_draw(GtkWidget *widget,
   cairo_line_to(g->cr, g->graph_width, 0.5 * g->graph_height);
   cairo_stroke(g->cr);
 
-  if(g->histogram_valid && self->enabled)
+  if(g->gui_histogram_valid && self->enabled)
   {
-    // draw the inset histogram
+    float histo_height;
+    if (g->two_histograms_display)
+      histo_height = 0.5 * g->graph_height;
+    else
+      histo_height = g->graph_height;
+
+    // draw the mask histogram background
     set_color(g->cr, darktable.bauhaus->inset_histogram);
     cairo_set_line_width(g->cr, DT_PIXEL_APPLY_DPI(4.0));
     cairo_move_to(g->cr, 0, g->graph_height);
 
-    for(int k = 0; k < UI_SAMPLES; k++)
+    for(int k = 0; k < UI_HISTO_SAMPLES; k++)
     {
       // the x range is [-8;+0] EV
-      const float x_temp = (8.0 * (float)k / (float)(UI_SAMPLES - 1)) - 8.0;
-      const float y_temp = (float)(g->histogram[k]) / (float)(g->max_histogram) * 0.96;
+      const float x_temp = (8.0 * (float)k / (float)(UI_HISTO_SAMPLES - 1)) - 8.0;
+      const float y_temp = fast_clamp((float)(g->histogram[k]) / (float)(g->max_histogram), -1.0f, 1.0f) * 0.96;
       cairo_line_to(g->cr, (x_temp + 8.0) * g->graph_width / 8.0,
-                           (1.0 - y_temp) * g->graph_height );
+                           (g->graph_height - y_temp * histo_height));
     }
     cairo_line_to(g->cr, g->graph_width, g->graph_height);
     cairo_close_path(g->cr);
     cairo_fill(g->cr);
 
-    if(g->histogram_last_decile > -0.1f)
+    // optionally draw the image histogram upside-down in the top half
+    if (g->two_histograms_display)
+    {
+      cairo_move_to(g->cr, 0, 0);
+
+      for(int k = 0; k < UI_HISTO_SAMPLES; k++)
+      {
+        // the x range is [-8;+0] EV
+        const float x_temp = (8.0 * (float)k / (float)(UI_HISTO_SAMPLES - 1)) - 8.0;
+        const float y_temp = fast_clamp((float)(g->image_histogram[k]) / (float)(g->max_image_histogram), -1.0f, 1.0f) * 0.96;
+        cairo_line_to(g->cr, (x_temp + 8.0) * g->graph_width / 8.0,
+                             y_temp * histo_height);
+        //if (k % 5 == 0)
+        // printf("g->image_histogram[%d] = %d, max_image_histogram = %d\n", k, g->image_histogram[k], g->max_image_histogram);
+      }
+      cairo_line_to(g->cr, g->graph_width, 0);
+      cairo_close_path(g->cr);
+      cairo_fill(g->cr);
+    }
+
+    if(post_scale_shift(g->histogram_last_decile, p->post_scale, p->post_shift) > -0.1f)
     {
       // histogram overflows controls in highlights : display warning
       cairo_save(g->cr);
@@ -2819,7 +3528,7 @@ static gboolean area_draw(GtkWidget *widget,
       cairo_restore(g->cr);
     }
 
-    if(g->histogram_first_decile < -7.9f)
+    if(post_scale_shift(g->histogram_first_decile, p->post_scale, p->post_shift) < -7.9f)
     {
       // histogram overflows controls in lowlights : display warning
       cairo_save(g->cr);
@@ -2832,23 +3541,36 @@ static gboolean area_draw(GtkWidget *widget,
     }
   }
 
-  if(g->lut_valid)
+  if(g->gui_curve_valid)
   {
     // draw the interpolation curve
-    set_color(g->cr, darktable.bauhaus->graph_fg);
-    cairo_move_to(g->cr, 0, g->gui_lut[0] * g->graph_height);
+
     cairo_set_line_width(g->cr, DT_PIXEL_APPLY_DPI(3));
+    float x_draw, y_draw;
 
-    for(int k = 1; k < UI_SAMPLES; k++)
+    // The coloring of the curve makes it necessary to draw it as individual segments.
+    // However this led to aliasing artifacts, therefore we draw overlapping segments
+    // from k-1 to k+1.
+    for(int k = 1; k < UI_HISTO_SAMPLES - 1; k++)
     {
-      // the x range is [-8;+0] EV
-      const float x_temp = (8.0f * (((float)k) / ((float)(UI_SAMPLES - 1)))) - 8.0f;
-      const float y_temp = g->gui_lut[k];
+      set_color(g->cr, g->gui_curve_colors[k]);
 
-      cairo_line_to(g->cr, (x_temp + 8.0f) * g->graph_width / 8.0f,
-                            y_temp * g->graph_height );
+      // Map [0;UI_HISTO_SAMPLES] to [0;1] and then to g->graph_width.
+      x_draw = ((float)(k - 1) / (float)(UI_HISTO_SAMPLES - 1)) * g->graph_width;
+      // Map [-2;+2] EV to graph_height, with graph pixel 0 at the top
+      y_draw = (0.5f - g->gui_curve[k - 1] / 4.0f) * g->graph_height;
+
+      cairo_move_to(g->cr, x_draw, y_draw);
+
+      // Map [0;UI_HISTO_SAMPLES] to [0;1] and then to g->graph_width.
+      x_draw = ((float)(k+1) / (float)(UI_HISTO_SAMPLES - 1)) * g->graph_width;
+      // Map [-2;+2] EV to graph_height, with graph pixel 0 at the top
+      y_draw = (0.5f - g->gui_curve[k+1] / 4.0f) * g->graph_height;
+
+      cairo_line_to(g->cr, x_draw, y_draw);
+      cairo_stroke(g->cr);
     }
-    cairo_stroke(g->cr);
+
   }
 
   dt_iop_gui_enter_critical_section(self);
@@ -2862,7 +3584,7 @@ static gboolean area_draw(GtkWidget *widget,
   if(g->user_param_valid)
   {
     // draw nodes positions
-    for(int k = 0; k < CHANNELS; k++)
+    for(int k = 0; k < NUM_SLIDERS; k++)
     {
       const float xn = g->nodes_x[k];
       const float yn = g->nodes_y[k];
@@ -2895,9 +3617,9 @@ static gboolean area_draw(GtkWidget *widget,
     {
       const float radius = g->sigma * g->graph_width / 8.0f / sqrtf(2.0f);
       cairo_set_line_width(g->cr, DT_PIXEL_APPLY_DPI(1.5));
-      const float y =
-        g->gui_lut[(int)CLAMP(((UI_SAMPLES - 1) * g->area_x / g->graph_width),
-                              0, UI_SAMPLES - 1)];
+      const float y = 0.5f -
+        g->gui_curve[(int)CLAMP(((UI_HISTO_SAMPLES - 1) * g->area_x / g->graph_width),
+                              0, UI_HISTO_SAMPLES - 1)] / 4.0f;
       cairo_arc(g->cr, g->area_x, y * g->graph_height, radius, 0, 2. * M_PI);
       set_color(g->cr, darktable.bauhaus->graph_fg);
       cairo_stroke(g->cr);
@@ -2908,13 +3630,13 @@ static gboolean area_draw(GtkWidget *widget,
 
       float x_pos = (g->cursor_exposure + 8.0f) / 8.0f * g->graph_width;
 
-      if(x_pos > g->graph_width || x_pos < 0.0f)
+      if(x_pos >= g->graph_width || x_pos <= 0.0f)
       {
         // exposure at current position is outside [-8; 0] EV :
         // bound it in the graph limits and show it in orange
         cairo_set_source_rgb(g->cr, 0.75, 0.50, 0.);
         cairo_set_line_width(g->cr, DT_PIXEL_APPLY_DPI(3));
-        x_pos = (x_pos < 0.0f) ? 0.0f : g->graph_width;
+        x_pos = (x_pos <= 0.0f) ? 0.0f : g->graph_width;
       }
       else
       {
@@ -2935,6 +3657,7 @@ static gboolean area_draw(GtkWidget *widget,
   return TRUE;
 }
 
+
 static gboolean _toneequalizer_bar_draw(GtkWidget *widget,
                                         cairo_t *crf,
                                         dt_iop_module_t *self)
@@ -2942,7 +3665,7 @@ static gboolean _toneequalizer_bar_draw(GtkWidget *widget,
   // Draw the widget equalizer view
   dt_iop_toneequalizer_gui_data_t *g = self->gui_data;
 
-  update_histogram(self);
+  update_gui_histogram(self);
 
   GtkAllocation allocation;
   gtk_widget_get_allocation(widget, &allocation);
@@ -2958,7 +3681,7 @@ static gboolean _toneequalizer_bar_draw(GtkWidget *widget,
 
   dt_iop_gui_enter_critical_section(self);
 
-  if(g->histogram_valid)
+  if(g->gui_histogram_valid)
   {
     // draw histogram span
     const float left = (g->histogram_first_decile + 8.0f) / 8.0f;
@@ -2972,7 +3695,7 @@ static gboolean _toneequalizer_bar_draw(GtkWidget *widget,
     // draw average bar
     set_color(cr, darktable.bauhaus->graph_fg);
     cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(3));
-    const float average = (g->histogram_average + 8.0f) / 8.0f;
+    const float average = ((g->histogram_first_decile + g->histogram_last_decile) / 2.0f + 8.0f) / 8.0f;
     cairo_move_to(cr, average * allocation.width, 0.0);
     cairo_line_to(cr, average * allocation.width, allocation.height);
     cairo_stroke(cr);
@@ -3113,7 +3836,7 @@ static gboolean area_motion_notify(GtkWidget *widget,
     const float offset = (-event->y + g->area_y) / g->graph_height * 4.0f;
     const float cursor_exposure = g->area_x / g->graph_width * 8.0f - 8.0f;
 
-    // Get the desired correction on exposure channels
+    // Get the desired correction on exposure NUM_SLIDERS
     g->area_dragging = set_new_params_interactive(cursor_exposure, offset,
                                                   g->sigma * g->sigma / 2.0f, g, p);
     dt_iop_gui_leave_critical_section(self);
@@ -3132,7 +3855,7 @@ static gboolean area_motion_notify(GtkWidget *widget,
   if(g->valid_nodes_x)
   {
     const float radius_threshold = fabsf(g->nodes_x[1] - g->nodes_x[0]) * 0.45f;
-    for(int i = 0; i < CHANNELS; ++i)
+    for(int i = 0; i < NUM_SLIDERS; ++i)
     {
       const float delta_x = fabsf(g->area_x - g->nodes_x[i]);
       if(delta_x < radius_threshold)
@@ -3182,6 +3905,7 @@ static gboolean area_button_release(GtkWidget *widget,
   return FALSE;
 }
 
+
 static gboolean area_scroll(GtkWidget *widget,
                             GdkEventScroll *event,
                             gpointer user_data)
@@ -3205,6 +3929,7 @@ static gboolean notebook_button_press(GtkWidget *widget,
   return FALSE;
 }
 
+
 GSList *mouse_actions(dt_iop_module_t *self)
 {
   GSList *lm = NULL;
@@ -3220,13 +3945,14 @@ GSList *mouse_actions(dt_iop_module_t *self)
   return lm;
 }
 
+
 /**
  * Post pipe events
  **/
-
 static void _develop_ui_pipe_started_callback(gpointer instance,
                                               dt_iop_module_t *self)
 {
+  printf("ui pipe started callback\n");
   dt_iop_toneequalizer_gui_data_t *g = self->gui_data;
   if(g == NULL) return;
   switch_cursors(self);
@@ -3251,6 +3977,7 @@ static void _develop_ui_pipe_started_callback(gpointer instance,
 static void _develop_preview_pipe_finished_callback(gpointer instance,
                                                     dt_iop_module_t *self)
 {
+  printf("preview pipe finished callback\n");
   dt_iop_toneequalizer_gui_data_t *g = self->gui_data;
   if(g == NULL) return;
 
@@ -3269,10 +3996,12 @@ static void _develop_preview_pipe_finished_callback(gpointer instance,
 static void _develop_ui_pipe_finished_callback(gpointer instance,
                                                dt_iop_module_t *self)
 {
+  printf("ui pipe finished callback\n");
   dt_iop_toneequalizer_gui_data_t *g = self->gui_data;
   if(g == NULL) return;
   switch_cursors(self);
 }
+
 
 void gui_reset(dt_iop_module_t *self)
 {
@@ -3298,9 +4027,75 @@ void gui_init(dt_iop_module_t *self)
   g->notebook = dt_ui_notebook_new(&notebook_def);
   dt_action_define_iop(self, NULL, N_("page"), GTK_WIDGET(g->notebook), &notebook_def);
 
-  // Simple view
+  // Curve view (former "advanced" page)
+  self->widget = dt_ui_notebook_page(g->notebook, N_("curve"), NULL);
+  gtk_widget_set_vexpand(GTK_WIDGET(self->widget), TRUE);
 
-  self->widget = dt_ui_notebook_page(g->notebook, N_("simple"), NULL);
+  // g->area = GTK_DRAWING_AREA(gtk_drawing_area_new());
+
+  g->area = GTK_DRAWING_AREA(dt_ui_resize_wrap(NULL,
+    0,
+    "plugins/darkroom/toneequal/graphheight"));
+
+  GtkWidget *wrapper = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0); // for CSS size
+  gtk_box_pack_start(GTK_BOX(wrapper), GTK_WIDGET(g->area), TRUE, TRUE, 0);
+  g_object_set_data(G_OBJECT(wrapper), "iop-instance", self);
+  gtk_widget_set_name(GTK_WIDGET(wrapper), "toneeqgraph");
+  dt_action_define_iop(self, NULL, N_("graph"), GTK_WIDGET(wrapper), NULL);
+  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(wrapper), TRUE, TRUE, 0);
+  gtk_widget_add_events(GTK_WIDGET(g->area),
+                        GDK_POINTER_MOTION_MASK | darktable.gui->scroll_mask
+                        | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK
+                        | GDK_ENTER_NOTIFY_MASK | GDK_LEAVE_NOTIFY_MASK);
+  gtk_widget_set_can_focus(GTK_WIDGET(g->area), TRUE);
+  g_signal_connect(G_OBJECT(g->area), "draw", G_CALLBACK(area_draw), self);
+  g_signal_connect(G_OBJECT(g->area), "button-press-event",
+                   G_CALLBACK(area_button_press), self);
+  g_signal_connect(G_OBJECT(g->area), "button-release-event",
+                   G_CALLBACK(area_button_release), self);
+  g_signal_connect(G_OBJECT(g->area), "leave-notify-event",
+                   G_CALLBACK(area_enter_leave_notify), self);
+  g_signal_connect(G_OBJECT(g->area), "enter-notify-event",
+                   G_CALLBACK(area_enter_leave_notify), self);
+  g_signal_connect(G_OBJECT(g->area), "motion-notify-event",
+                   G_CALLBACK(area_motion_notify), self);
+  g_signal_connect(G_OBJECT(g->area), "scroll-event",
+                   G_CALLBACK(area_scroll), self);
+  gtk_widget_set_tooltip_text(GTK_WIDGET(g->area), _("double-click to reset the curve"));
+
+  g->post_auto_align = dt_bauhaus_combobox_from_params(self, "post_auto_align");
+  gtk_widget_set_tooltip_text(g->post_auto_align, _("automatically set the mask exposure/contrast"));
+
+  g->post_scale = dt_bauhaus_slider_from_params(self, "post_scale");
+  dt_bauhaus_slider_set_soft_range(g->post_scale, -2.0, 2.0);
+  gtk_widget_set_tooltip_text
+    (g->post_scale,
+    _("set the mask contrast / scale the histogram"));
+
+  g->post_shift = dt_bauhaus_slider_from_params(self, "post_shift");
+  dt_bauhaus_slider_set_soft_range(g->post_shift, -4.0, 4.0);
+  gtk_widget_set_tooltip_text
+    (g->post_shift,
+    _("set the mask exposure / shift the histogram"));
+
+  g->smoothing = dt_bauhaus_slider_new_with_range(self, -2.33f, +1.67f, 0, 0.0f, 2);
+  dt_bauhaus_slider_set_soft_range(g->smoothing, -1.0f, 1.0f);
+  dt_bauhaus_widget_set_label(g->smoothing, NULL, N_("curve smoothing"));
+  gtk_widget_set_tooltip_text(g->smoothing,
+                              _("positive values will produce more progressive tone transitions\n"
+                                "but the curve might become oscillatory in some settings.\n"
+                                "negative values will avoid oscillations and behave more robustly\n"
+                                "but may produce brutal tone transitions and damage local contrast."));
+  gtk_box_pack_start(GTK_BOX(self->widget), g->smoothing, FALSE, FALSE, 0);
+  g_signal_connect(G_OBJECT(g->smoothing), "value-changed", G_CALLBACK(smoothing_callback), self);
+
+
+  // sliders section (former "simple" page)
+  dt_gui_new_collapsible_section(&g->sliders_section, "plugins/darkroom/toneequal/expand_sliders", _("sliders"),
+                                 GTK_BOX(self->widget), DT_ACTION(self));
+  gtk_widget_set_tooltip_text(g->sliders_section.expander, _("sliders"));
+
+  self->widget = GTK_WIDGET(g->sliders_section.container);
 
   g->noise = dt_bauhaus_slider_from_params(self, "noise");
   dt_bauhaus_slider_set_format(g->noise, _(" EV"));
@@ -3339,52 +4134,8 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_widget_set_label(g->whites, N_("simple"), N_("-1 EV"));
   dt_bauhaus_widget_set_label(g->speculars, N_("simple"), N_("+0 EV"));
 
-  // Advanced view
-
-  self->widget = dt_ui_notebook_page(g->notebook, N_("advanced"), NULL);
-
-  g->area = GTK_DRAWING_AREA(gtk_drawing_area_new());
-  GtkWidget *wrapper = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0); // for CSS size
-  gtk_box_pack_start(GTK_BOX(wrapper), GTK_WIDGET(g->area), TRUE, TRUE, 0);
-  g_object_set_data(G_OBJECT(wrapper), "iop-instance", self);
-  gtk_widget_set_name(GTK_WIDGET(wrapper), "toneeqgraph");
-  dt_action_define_iop(self, NULL, N_("graph"), GTK_WIDGET(wrapper), NULL);
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(wrapper), TRUE, TRUE, 0);
-  gtk_widget_add_events(GTK_WIDGET(g->area),
-                        GDK_POINTER_MOTION_MASK | darktable.gui->scroll_mask
-                        | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK
-                        | GDK_ENTER_NOTIFY_MASK | GDK_LEAVE_NOTIFY_MASK);
-  gtk_widget_set_can_focus(GTK_WIDGET(g->area), TRUE);
-  g_signal_connect(G_OBJECT(g->area), "draw", G_CALLBACK(area_draw), self);
-  g_signal_connect(G_OBJECT(g->area), "button-press-event",
-                   G_CALLBACK(area_button_press), self);
-  g_signal_connect(G_OBJECT(g->area), "button-release-event",
-                   G_CALLBACK(area_button_release), self);
-  g_signal_connect(G_OBJECT(g->area), "leave-notify-event",
-                   G_CALLBACK(area_enter_leave_notify), self);
-  g_signal_connect(G_OBJECT(g->area), "enter-notify-event",
-                   G_CALLBACK(area_enter_leave_notify), self);
-  g_signal_connect(G_OBJECT(g->area), "motion-notify-event",
-                   G_CALLBACK(area_motion_notify), self);
-  g_signal_connect(G_OBJECT(g->area), "scroll-event",
-                   G_CALLBACK(area_scroll), self);
-  gtk_widget_set_tooltip_text(GTK_WIDGET(g->area), _("double-click to reset the curve"));
-
-  g->smoothing = dt_bauhaus_slider_new_with_range(self, -2.33f, +1.67f, 0, 0.0f, 2);
-  dt_bauhaus_slider_set_soft_range(g->smoothing, -1.0f, 1.0f);
-  dt_bauhaus_widget_set_label(g->smoothing, NULL, N_("curve smoothing"));
-  gtk_widget_set_tooltip_text
-    (g->smoothing,
-     _("positive values will produce more progressive tone transitions\n"
-       "but the curve might become oscillatory in some settings.\n"
-       "negative values will avoid oscillations and behave more robustly\n"
-       "but may produce brutal tone transitions and damage local contrast."));
-  gtk_box_pack_start(GTK_BOX(self->widget), g->smoothing, FALSE, FALSE, 0);
-  g_signal_connect(G_OBJECT(g->smoothing), "value-changed",
-                   G_CALLBACK(smoothing_callback), self);
 
   // Masking options
-
   self->widget = dt_ui_notebook_page(g->notebook, N_("masking"), NULL);
 
   g->method = dt_bauhaus_combobox_from_params(self, "method");
@@ -3432,12 +4183,17 @@ void gui_init(dt_iop_module_t *self)
        "lower values give smoother gradients and better smoothing\n"
        "but may lead to inaccurate edges taping and halos"));
 
-  gtk_box_pack_start(GTK_BOX(self->widget),
-                     dt_ui_section_label_new(C_("section", "mask post-processing")),
-                     FALSE, FALSE, 0);
+  // gtk_box_pack_start(GTK_BOX(self->widget),
+  //                    dt_ui_section_label_new(C_("section", "mask post-processing")),
+  //                    FALSE, FALSE, 0);
+  dt_gui_new_collapsible_section(&g->advanced_masking_section, "plugins/darkroom/toneequal/expand_advanced_masking",
+    _("mask pre-processing"), GTK_BOX(self->widget), DT_ACTION(self));
+  gtk_widget_set_tooltip_text(g->advanced_masking_section.expander, _("advanced masking"));
+
+  self->widget = GTK_WIDGET(g->advanced_masking_section.container);
 
   g->bar = GTK_DRAWING_AREA(gtk_drawing_area_new());
-  gtk_widget_set_size_request(GTK_WIDGET(g->bar), -1, 4);
+  gtk_widget_set_size_request(GTK_WIDGET(g->bar), -1, 40);
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->bar), TRUE, TRUE, 0);
   gtk_widget_set_can_focus(GTK_WIDGET(g->bar), TRUE);
   g_signal_connect(G_OBJECT(g->bar), "draw",
@@ -3461,7 +4217,7 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_slider_set_format(g->exposure_boost, _(" EV"));
   gtk_widget_set_tooltip_text
     (g->exposure_boost,
-     _("use this to slide the mask average exposure along channels\n"
+     _("use this to slide the mask average exposure along NUM_SLIDERS\n"
        "for a better control of the exposure correction with the available nodes."));
   dt_bauhaus_widget_set_quad(g->exposure_boost, self, dtgtk_cairo_paint_wand, FALSE, auto_adjust_exposure_boost,
                              _("auto-adjust the average exposure"));
@@ -3473,10 +4229,24 @@ void gui_init(dt_iop_module_t *self)
     (g->contrast_boost,
      _("use this to counter the averaging effect of the guided filter\n"
        "and dilate the mask contrast around -4EV\n"
-       "this allows to spread the exposure histogram over more channels\n"
+       "this allows to spread the exposure histogram over more NUM_SLIDERS\n"
        "for a better control of the exposure correction."));
   dt_bauhaus_widget_set_quad(g->contrast_boost, self, dtgtk_cairo_paint_wand, FALSE, auto_adjust_contrast_boost,
                              _("auto-adjust the contrast"));
+
+  GtkWidget *histo_box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
+  gtk_box_pack_start(GTK_BOX(histo_box),
+                    dt_ui_label_new(_("show image histogram in graph")), TRUE, TRUE, 0);
+  g->show_two_histograms = dt_iop_togglebutton_new
+    (self, NULL,
+    N_("display the image histogram together with mask histogram"), NULL, G_CALLBACK(show_two_histograms_callback),
+    FALSE, 0, 0, dtgtk_cairo_paint_showmask, histo_box);
+  dt_gui_add_class(g->show_two_histograms, "dt_transparent_background");
+  dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(g->show_two_histograms),
+                              dtgtk_cairo_paint_showmask, 0, NULL);
+  dt_gui_add_class(g->show_two_histograms, "dt_bauhaus_alignment");
+  gtk_box_pack_start(GTK_BOX(self->widget), histo_box, FALSE, FALSE, 0);
+
 
   // start building top level widget
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
@@ -3508,6 +4278,7 @@ void gui_init(dt_iop_module_t *self)
   DT_CONTROL_SIGNAL_HANDLE(DT_SIGNAL_DEVELOP_HISTORY_CHANGE, _develop_ui_pipe_started_callback);
 }
 
+
 void gui_cleanup(dt_iop_module_t *self)
 {
   dt_iop_toneequalizer_gui_data_t *g = self->gui_data;
@@ -3516,8 +4287,8 @@ void gui_cleanup(dt_iop_module_t *self)
   dt_conf_set_int("plugins/darkroom/toneequal/gui_page",
                   gtk_notebook_get_current_page (g->notebook));
 
-  dt_free_align(g->thumb_preview_buf);
-  dt_free_align(g->full_preview_buf);
+  dt_free_align(g->preview_buf);
+  dt_free_align(g->full_buf);
 
   if(g->desc)   pango_font_description_free(g->desc);
   if(g->layout) g_object_unref(g->layout);


### PR DESCRIPTION
This is a preview of my proposed changes to the tone equalizer module. There is a lot of debug code still in it and there are known problems, see below.

This message only contains code aspects. I will write a detailed post from a user perspective for pixls.us.

Changes
-------

- Introduced `post_scale`, `post_shift` and `post_auto_align` settings, which allow adjusting mask exposure and contrast AFTER the guided filter calculation.
   - The histogram calculation is now split into two steps. First, a very detailed histogram is calculated over a large dynamic range. The GUI histogram and internal parameters used for automatically computing `post_scale` and `post_shift` are derived from this histogram.
   - The new parameters are not actually applied to the luminance mask, but to the look-up table that is used to modify the image.
   - With `post_auto_align=custom`, `post_scale=0`, `post_shift=0`, the results are the same as with the old tone equalizer (I was not able to get a byte-identical export, but in GIMP the difference between my version and 5.0 was fully black in my tests).
- Changed upstream pipe change detection from `dt_dev_pixelpipe_piece_hash` to `dt_dev_hash_plus` after I noticed that the module constantly re-computed the guided filter, even though this was not necessary.
- Added experimental coloring to the curve in the GUI, it now turns orange or red when the user does something that is probably not a good idea:
  - Raising shadows/lowering highlights with the guided filter turned off.
  - Lowering shadows/raising highlights with the guided filter turned on. The user probably expects a gain in contrast here, but the guided filter will work against this.
  - Setting the downward slope of the curve to be too steep.
- UI changes:
  - Sliders (previously on the "simple" page) are now located in a collapsible section beneath the histogram.
  - Made the histogram/curve graph resizable (see issues!).
- In my efforts to understand the code, I renamed things that were named confusingly in my opinion (i.e. `compute_lut_correction` to `compute_gui_curve`) and sorted the functions. The consequence is that I have touched almost all lines of code, so diffs will not be helpful in tracking my changes.

Known issues
------------

Tbh., I had more problems with the anatomy of a darktable module (threads, params, data, gui-data, all the GTK stuff) than with the actual task at hand.

Known problems are:

- Pulling the histogram/curve graph small causes DT to crash. I am clearly still missing something here. There is also no horizontal bar on mouseover to indicate that the graph can be resized.
- When `post_auto_align` is used to set the mask exposure, the values for `post_scale` and `post_shift` are calculated in PREVIEW and used in FULL. However, other pixel pipes (especially export) calculate the mask exposure on their own and may get a different result that leads to a different output.

Things I noticed about the module (a.k.a issues already present in 5.0)
-----------------------------------------------------------------------

- Resetting the module multiple times makes the histogram disappear until the user moves a slider.

Related Discussion
-----

Issue #17287
