### PR TITLE
Avoid lens vignette & CFA for DT_DEV_PIXELPIPE_DISPLAY_PASSTHRU mode

### DIFF
--- a/data/kernels/basic.cl
+++ b/data/kernels/basic.cl
@@ -3070,7 +3070,8 @@ kernel void md_lens_correction(read_only image2d_t in,
                                const int rooy,
                                const int knots,
                                const int itor_mode,
-                               const int itor_width)
+                               const int itor_width,
+                               const int pass_mode)
 {
   const int x = get_global_id(0);
   const int y = get_global_id(1);
@@ -3084,7 +3085,7 @@ kernel void md_lens_correction(read_only image2d_t in,
   float output[4];
   for(int c = 0; c < 4; c++)
   {
-    const int plane = (c == 3) ? 1 : c;
+    const int plane = (c == 3 || pass_mode) ? 1 : c;
     const float dr =
       _interpolate_linear_spline(knots_dist, &cor_rgb[plane * MAXKNOTS], knots, radius);
     const float xs = clamp(dr*cx + w2 - roix, 0.0f, limw);

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -1064,9 +1064,10 @@ static void _process_lf(dt_iop_module_t *self,
     return;
   }
 
-  const gboolean raw_monochrome =
-    dt_image_is_monochrome(&self->dev->image_storage);
-  const int used_lf_mask = (raw_monochrome)
+  const gboolean raw_monochrome = dt_image_is_monochrome(&self->dev->image_storage);
+  const gboolean pass_mode = piece->pipe->mask_display == DT_DEV_PIXELPIPE_DISPLAY_PASSTHRU;
+
+  const int used_lf_mask = (raw_monochrome || pass_mode)
     ? LF_MODIFY_ALL & ~LF_MODIFY_TCA
     : LF_MODIFY_ALL;
 
@@ -1162,7 +1163,7 @@ static void _process_lf(dt_iop_module_t *self,
                                 roi_out->width, roi_out->height, ch);
     }
 
-    if(modflags & LF_MODIFY_VIGNETTING)
+    if(!pass_mode && (modflags & LF_MODIFY_VIGNETTING))
     {
       DT_OMP_FOR(shared(modifier))
       for(int y = 0; y < roi_out->height; y++)
@@ -1184,7 +1185,7 @@ static void _process_lf(dt_iop_module_t *self,
     void *buf = dt_alloc_aligned(bufsize);
     memcpy(buf, ivoid, bufsize);
 
-    if(modflags & LF_MODIFY_VIGNETTING)
+    if(!pass_mode && (modflags & LF_MODIFY_VIGNETTING))
     {
       DT_OMP_FOR(shared(buf, modifier))
       for(int y = 0; y < roi_in->height; y++)
@@ -1288,9 +1289,9 @@ static int _process_cl_lf(dt_iop_module_t *self,
   dt_iop_lens_data_t *d = (dt_iop_lens_data_t *)piece->data;
   dt_iop_lens_global_data_t *gd = (dt_iop_lens_global_data_t *)self->global_data;
 
-  const gboolean raw_monochrome =
-    dt_image_is_monochrome(&self->dev->image_storage);
-  const int used_lf_mask = (raw_monochrome)
+  const gboolean raw_monochrome = dt_image_is_monochrome(&self->dev->image_storage);
+  const gboolean pass_mode = piece->pipe->mask_display == DT_DEV_PIXELPIPE_DISPLAY_PASSTHRU;
+  const int used_lf_mask = (raw_monochrome || pass_mode)
     ? LF_MODIFY_ALL & ~LF_MODIFY_TCA
     : LF_MODIFY_ALL;
 
@@ -1392,8 +1393,7 @@ static int _process_cl_lf(dt_iop_module_t *self,
                                              tmpbufsize, CL_TRUE);
       if(err != CL_SUCCESS) goto error;
 
-      err = dt_opencl_enqueue_kernel_2d_args
-        (devid, ldkernel, owidth, oheight,
+      err = dt_opencl_enqueue_kernel_2d_args(devid, ldkernel, owidth, oheight,
          CLARG(dev_in), CLARG(dev_tmp),
          CLARG(owidth), CLARG(oheight),
          CLARG(iwidth), CLARG(iheight),
@@ -1408,7 +1408,7 @@ static int _process_cl_lf(dt_iop_module_t *self,
       if(err != CL_SUCCESS) goto error;
     }
 
-    if(modflags & LF_MODIFY_VIGNETTING)
+    if(!pass_mode && (modflags & LF_MODIFY_VIGNETTING))
     {
       DT_OMP_FOR(shared(tmpbuf, modifier, d))
       for(int y = 0; y < roi_out->height; y++)
@@ -1447,8 +1447,7 @@ static int _process_cl_lf(dt_iop_module_t *self,
 
   else // correct distortions:
   {
-
-    if(modflags & LF_MODIFY_VIGNETTING)
+    if(!pass_mode && (modflags & LF_MODIFY_VIGNETTING))
     {
       DT_OMP_FOR(shared(tmpbuf, modifier, d))
       for(int y = 0; y < roi_in->height; y++)
@@ -1797,10 +1796,8 @@ DT_OMP_PRAGMA(barrier)
       dt_interpolation_new(DT_INTERPOLATION_USERPREF_WARP);
     roi_in->x = MAX(0.0f, xm - interpolation->width);
     roi_in->y = MAX(0.0f, ym - interpolation->width);
-    roi_in->width = MIN(orig_w - roi_in->x,
-                          xM - roi_in->x + interpolation->width);
-    roi_in->height = MIN(orig_h - roi_in->y,
-                           yM - roi_in->y + interpolation->width);
+    roi_in->width = MIN(orig_w - roi_in->x,  xM - roi_in->x + interpolation->width);
+    roi_in->height = MIN(orig_h - roi_in->y, yM - roi_in->y + interpolation->width);
 
     // sanity check.
     roi_in->x = CLAMP(roi_in->x, 0, (int)floorf(orig_w - 2.0f));
@@ -1910,8 +1907,7 @@ static void _commit_params_lf(dt_iop_module_t *self,
      && g
      && (piece->pipe->type & DT_DEV_PIXELPIPE_PREVIEW))
   {
-    const gboolean raw_monochrome =
-      dt_image_is_monochrome(&self->dev->image_storage);
+    const gboolean raw_monochrome = dt_image_is_monochrome(&self->dev->image_storage);
     const int used_lf_mask = (raw_monochrome)
       ? LF_MODIFY_ALL & ~LF_MODIFY_TCA
       : LF_MODIFY_ALL;
@@ -2227,8 +2223,7 @@ static int _init_coeffs_md_v2(const dt_image_t *img,
         cor_rgb[2][i] *= p->cor_ca_b_ft * cd->sony.ca_b[i] * powf(2, -21) + 1;
       }
 
-      if(vig
-         && p->modify_flags & DT_IOP_LENS_MODIFY_FLAG_VIGNETTING)
+      if(vig && (p->modify_flags & DT_IOP_LENS_MODIFY_FLAG_VIGNETTING))
         vig[i] = powf (2, 0.5f
                        - powf(2,
                               p->cor_vig_ft * cd->sony.vignetting[i] * powf(2, -13)  - 1));
@@ -2767,8 +2762,8 @@ static void _process_md(dt_iop_module_t *self,
   const float h2 = 0.5f * roi_in->scale * piece->buf_in.height;
   const float r = 1.0f / sqrtf(w2*w2 + h2*h2);
 
-  const struct dt_interpolation *interpolation =
-    dt_interpolation_new(DT_INTERPOLATION_USERPREF_WARP);
+  const struct dt_interpolation *interpolation = dt_interpolation_new(DT_INTERPOLATION_USERPREF_WARP);
+  const gboolean pass_mode = piece->pipe->mask_display == DT_DEV_PIXELPIPE_DISPLAY_PASSTHRU;
 
   // Allocate temporary storage if we haven't got that from manual vignette
   float *buf = (float *) ivoid;
@@ -2778,8 +2773,9 @@ static void _process_md(dt_iop_module_t *self,
     buf = dt_alloc_align_float(bufsize);
     dt_iop_image_copy(buf, (float*)ivoid, bufsize);
   }
+
   // Correct vignetting
-  if(d->modify_flags & DT_IOP_LENS_MODIFY_FLAG_VIGNETTING)
+  if(!pass_mode && (d->modify_flags & DT_IOP_LENS_MODIFY_FLAG_VIGNETTING))
   {
     DT_OMP_FOR(collapse(2))
     for(int y = 0; y < roi_in->height; y++)
@@ -2818,10 +2814,9 @@ static void _process_md(dt_iop_module_t *self,
       for_each_channel(c)
       {
         // use green data for alpha channel
-        const int plane = (c == 3) ? 1 : c;
+        const int plane = (c == 3 || pass_mode) ? 1 : c;
         const float dr =
-          _interpolate_linear_spline(d->knots_dist, d->cor_rgb[plane],
-                                     d->nc, radius);
+          _interpolate_linear_spline(d->knots_dist, d->cor_rgb[plane], d->nc, radius);
         const float xs = CLAMP(dr*cx + w2 - roi_in->x, 0.0f, limw);
         const float ys = CLAMP(dr*cy + h2 - roi_in->y, 0.0f, limh);
         out[odx+c] = dt_interpolation_compute_sample
@@ -2861,9 +2856,9 @@ static int _process_cl_md(dt_iop_module_t *self,
   const float r = 1.0f / sqrtf(w2*w2 + h2*h2);
   const int knots = d->nc;
 
-  const struct dt_interpolation *itor =
-    dt_interpolation_new(DT_INTERPOLATION_USERPREF_WARP);
+  const struct dt_interpolation *itor = dt_interpolation_new(DT_INTERPOLATION_USERPREF_WARP);
   const int itor_width = itor->width;
+  const int pass_mode = piece->pipe->mask_display == DT_DEV_PIXELPIPE_DISPLAY_PASSTHRU;
 
   cl_mem data = dev_in;
   cl_mem knots_dist = NULL;
@@ -2871,19 +2866,16 @@ static int _process_cl_md(dt_iop_module_t *self,
   cl_int err = DT_OPENCL_SYSMEM_ALLOCATION;
 
   // Correct vignetting
-  if(d->modify_flags & DT_IOP_LENS_MODIFY_FLAG_VIGNETTING)
+  if(!pass_mode && (d->modify_flags & DT_IOP_LENS_MODIFY_FLAG_VIGNETTING))
   {
     err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
-    data = (cl_mem)dt_opencl_alloc_device(devid, roi_in->width,
-                                          roi_in->height, 4 * sizeof(float));
+    data = (cl_mem)dt_opencl_alloc_device(devid, roi_in->width, roi_in->height, 4 * sizeof(float));
     if(data == NULL) goto error;
 
     cl_mem knots_vig = (cl_mem)dt_opencl_copy_host_to_device_constant(devid, sizeof(d->knots_vig), &d->knots_vig);
     cl_mem vig = (cl_mem)dt_opencl_copy_host_to_device_constant(devid, sizeof(d->vig), &d->vig);
 
-    err = dt_opencl_enqueue_kernel_2d_args
-      (devid,
-       gd->kernel_md_vignette, roi_in->width, roi_in->height,
+    err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_md_vignette, roi_in->width, roi_in->height,
        CLARG(dev_in), CLARG(data),
        CLARG(knots_vig), CLARG(vig),
        CLARG(roi_in->width), CLARG(roi_in->height),
@@ -2899,8 +2891,7 @@ static int _process_cl_md(dt_iop_module_t *self,
   knots_dist = (cl_mem)dt_opencl_copy_host_to_device_constant(devid, sizeof(d->knots_dist), &d->knots_dist);
   cor_rgb = (cl_mem)dt_opencl_copy_host_to_device_constant(devid, sizeof(d->cor_rgb), &d->cor_rgb);
 
-  err = dt_opencl_enqueue_kernel_2d_args
-    (devid, gd->kernel_md_correct, roi_out->width, roi_out->height,
+  err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_md_correct, roi_out->width, roi_out->height,
      CLARG(data), CLARG(dev_out),
      CLARG(knots_dist), CLARG(cor_rgb),
      CLARG(roi_out->width), CLARG(roi_out->height),
@@ -2908,7 +2899,7 @@ static int _process_cl_md(dt_iop_module_t *self,
      CLARG(w2), CLARG(h2), CLARG(r), CLARG(d->scale_md),
      CLARG(roi_in->x), CLARG(roi_in->y),
      CLARG(roi_out->x), CLARG(roi_out->y),
-     CLARG(knots), CLARG(itor->id), CLARG(itor_width));
+     CLARG(knots), CLARG(itor->id), CLARG(itor_width), CLARG(pass_mode));
 
 error:
   if(data != dev_in) dt_opencl_release_mem_object(data);
@@ -2940,10 +2931,8 @@ static void _modify_roi_in_md(dt_iop_module_t *self,
   const int xoff = roi_in->x;
   const int yoff = roi_in->y;
   const int width = roi_in->width, height = roi_in->height;
-  const float cxs[] = { (xoff - w2) * inv_scale_md,
-                        (xoff + (width - 1) - w2) * inv_scale_md };
-  const float cys[] = { (yoff - h2) * inv_scale_md,
-                        (yoff + (height - 1) - h2) * inv_scale_md };
+  const float cxs[2] = { (xoff - w2) * inv_scale_md, (xoff + (width - 1) - w2) * inv_scale_md };
+  const float cys[2] = { (yoff - h2) * inv_scale_md, (yoff + (height - 1) - h2) * inv_scale_md };
 
   float xm = FLT_MAX;
   float xM = -FLT_MAX;
@@ -3035,13 +3024,14 @@ void process(dt_iop_module_t *self,
   dt_iop_lens_data_t *d = (dt_iop_lens_data_t *)piece->data;
   dt_iop_lens_gui_data_t *g = (dt_iop_lens_gui_data_t *)self->gui_data;
   const gboolean mask = g && g->vig_masking && (piece->pipe->type & DT_DEV_PIXELPIPE_FULL);
-  const gboolean correction = mask || (d->v_strength > 0.0f);
+  const gboolean pre_vignette = mask || (d->v_strength > 0.0f);
+  const gboolean pass_mode = piece->pipe->mask_display == DT_DEV_PIXELPIPE_DISPLAY_PASSTHRU;
   float *data = (float *)ivoid;
 
   if(mask)
     piece->pipe->mask_display =  DT_DEV_PIXELPIPE_DISPLAY_MASK;
 
-  if(correction)
+  if(pre_vignette && !pass_mode)
   {
     data = dt_alloc_align_float((size_t) 4 * roi_in->width * roi_in->height);
     if(data)
@@ -3056,7 +3046,7 @@ void process(dt_iop_module_t *self,
   }
   else if(d->method == DT_IOP_LENS_METHOD_EMBEDDED_METADATA)
   {
-    _process_md(self, piece, data, ovoid, roi_in, roi_out, correction);
+    _process_md(self, piece, data, ovoid, roi_in, roi_out, pre_vignette);
   }
   else
     dt_iop_copy_image_roi((float *)ovoid, data, 4, roi_in, roi_out);
@@ -3088,8 +3078,7 @@ cl_int _preprocess_vignette_cl(dt_iop_module_t *self,
   const float strength = 2.0f * d->v_strength;
   const int splinesize = VIGSPLINES;
 
-  cl_int err = dt_opencl_enqueue_kernel_2d_args
-    (piece->pipe->devid, gd->kernel_lens_man_vignette, roi->width, roi->height,
+  cl_int err = dt_opencl_enqueue_kernel_2d_args(piece->pipe->devid, gd->kernel_lens_man_vignette, roi->width, roi->height,
      CLARG(dev_in), CLARG(dev_vig), CLARG(dev_spline),
      CLARG(roi->width), CLARG(roi->height),
      CLARG(w2), CLARG(h2), CLARG(roi->x), CLARG(roi->y), CLARG(inv_maxr),
@@ -3113,27 +3102,30 @@ int process_cl(dt_iop_module_t *self,
 
   dt_iop_lens_data_t *d = (dt_iop_lens_data_t *)piece->data;
   dt_iop_lens_gui_data_t *g = (dt_iop_lens_gui_data_t *)self->gui_data;
-  const gboolean mask = g
-    && g->vig_masking
-    && (piece->pipe->type & DT_DEV_PIXELPIPE_FULL);
-
-  const gboolean correction = mask || (d->v_strength > 0.0f);
+  const gboolean mask = g && g->vig_masking && (piece->pipe->type & DT_DEV_PIXELPIPE_FULL);
+  const gboolean pre_vignette = mask || (d->v_strength > 0.0f);
+  const gboolean pass_mode = piece->pipe->mask_display == DT_DEV_PIXELPIPE_DISPLAY_PASSTHRU;
 
   if(mask)
     piece->pipe->mask_display =  DT_DEV_PIXELPIPE_DISPLAY_MASK;
 
   cl_int err = CL_SUCCESS;
-  if(correction)
+  if(pre_vignette && !pass_mode)
   {
     data = (cl_mem)dt_opencl_alloc_device(piece->pipe->devid,
                                           roi_in->width,
                                           roi_in->height, 4 * sizeof(float));
-    err = _preprocess_vignette_cl(self, piece, dev_in, data, roi_in, mask);
-    if(err != CL_SUCCESS)
+    if(data)
     {
-      dt_opencl_release_mem_object(data);
-      data = dev_in;
+      err = _preprocess_vignette_cl(self, piece, dev_in, data, roi_in, mask);
+      if(err != CL_SUCCESS)
+      {
+        dt_opencl_release_mem_object(data);
+        data = dev_in;
+      }
     }
+    else
+      data = dev_in;
   }
 
   if(d->method == DT_IOP_LENS_METHOD_LENSFUN)
@@ -3282,9 +3274,8 @@ void commit_params(dt_iop_module_t *self,
 {
   dt_iop_lens_params_t *p = (dt_iop_lens_params_t *)p1;
   dt_iop_lens_data_t *d = (dt_iop_lens_data_t *)piece->data;
-  // check ?  p->method = _get_method(self, method);
 
-  if(p->has_been_set == FALSE)
+  if(!p->has_been_set)
   {
     /*
      * user did not modify anything in gui after autodetection - let's
@@ -4671,7 +4662,7 @@ void gui_update(dt_iop_module_t *self)
   dt_iop_lens_gui_data_t *g = (dt_iop_lens_gui_data_t *)self->gui_data;
   dt_iop_lens_params_t *p = (dt_iop_lens_params_t *)self->params;
 
-  if(p->has_been_set == FALSE)
+  if(!p->has_been_set)
   {
     /*
      * user did not modify anything in GUI after autodetection - let's


### PR DESCRIPTION
While we are in pipe->mask_display == DT_DEV_PIXELPIPE_DISPLAY_PASSTHRU mode we bypass all non-distorting modules in the pixelpipe.

In the lens module we must only distort and leave out
- vignette correction
- CA corrections (this leads to moire error patterns)

Fixed a missing cl memory allocation check