### PR TITLE
[blur module] Soft limit blur radius to protect from extremely long processing time

### DIFF
--- a/src/iop/blurs.c
+++ b/src/iop/blurs.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2021-2024 darktable developers.
+    Copyright (C) 2021-2025 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -15,7 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
-// our includes go first:
+
 #include "bauhaus/bauhaus.h"
 #include "common/dwt.h"
 #include "develop/imageop.h"
@@ -765,6 +765,14 @@ void gui_init(dt_iop_module_t *self)
 
   g->radius = dt_bauhaus_slider_from_params(self, "radius");
   dt_bauhaus_slider_set_format(g->radius, " px");
+
+  // The current implementation's run time is proportional to the square of
+  // the blur radius. Let's soft-limit it to protect users from unacceptably
+  // long processing times for the full image (like when exporting), which
+  // many users perceive as a hang.
+  // NOTE: This is just quick damage control. The correct solution is to
+  // replace the bad implementation with a more efficient one.
+  dt_bauhaus_slider_set_soft_max(g->radius, 64);
 
   g->type = dt_bauhaus_combobox_from_params(self, "type");
 


### PR DESCRIPTION
The current implementation's run time is proportional to the square of the blur radius.

When processing a full image (e.g. when exporting), a large blur radius will result in unacceptably long processing times, which many users perceive as an export failure. We have to soft-limit the blur radius to protect users from this disastrous experience.

I'm fully aware that this is only a quick temporary damage control. The real solution is blurring using FFT, the half-baked, broken and abandoned code of which is even present in the module source. However, I have neither the energy nor the motivation to take on this task right now (to begin with, I have not worked with FFT before), reducing the priority of other things in my To-do.

