### PR TITLE
Fix to avoid cmake 4 warning

### DIFF
--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -73,7 +73,6 @@ if(NOT WIN32)
   file(GLOB PO_FILES "${CMAKE_CURRENT_SOURCE_DIR}/../po/*.po")
   add_custom_command(
     OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/org.darktable.darktable.desktop
-    SOURCE ${CMAKE_CURRENT_BINARY_DIR}/org.darktable.darktable.desktop.in
     COMMAND sh -c "${intltool_merge_BIN} --desktop-style ${CMAKE_CURRENT_SOURCE_DIR}/../po ${CMAKE_CURRENT_BINARY_DIR}/org.darktable.darktable.desktop.in ${CMAKE_CURRENT_BINARY_DIR}/org.darktable.darktable.desktop"
     MAIN_DEPENDENCY ${CMAKE_CURRENT_BINARY_DIR}/org.darktable.darktable.desktop.in
     DEPENDS ${PO_FILES}
@@ -104,7 +103,6 @@ if(NOT WIN32)
   else()
     add_custom_command(
       OUTPUT ${DARKTABLE_SHAREDIR}/metainfo/org.darktable.darktable.appdata.xml
-      SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/org.darktable.darktable.appdata.xml.in
       COMMAND ${CMAKE_COMMAND} -E make_directory ${DARKTABLE_SHAREDIR}/metainfo
       COMMAND sh -c "${intltool_merge_BIN} --xml-style ${CMAKE_CURRENT_SOURCE_DIR}/../po ${CMAKE_CURRENT_SOURCE_DIR}/org.darktable.darktable.appdata.xml.in ${DARKTABLE_SHAREDIR}/metainfo/org.darktable.darktable.appdata.xml"
       MAIN_DEPENDENCY ${CMAKE_CURRENT_SOURCE_DIR}/org.darktable.darktable.appdata.xml.in


### PR DESCRIPTION
When building with cmake 4, the following warnings started to appear:
```
CMake Warning (dev) at data/CMakeLists.txt:74 (add_custom_command):
The following keywords are not supported when using
add_custom_command(OUTPUT): SOURCE.
```

This PR fixes the cause to avoid the warning.
