### PR TITLE
Some IOP maintenance and additions

### DIFF
--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2009-2024 darktable developers.
+    Copyright (C) 2009-2025 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -207,6 +207,11 @@ static dt_introspection_field_t *default_get_f(const char *name)
   return NULL;
 }
 
+void dt_iop_default_cleanup(dt_iop_module_t *module)
+{
+  default_cleanup(module);
+}
+
 void dt_iop_default_init(dt_iop_module_t *module)
 {
   size_t param_size = module->so->get_introspection()->size;
@@ -217,6 +222,7 @@ void dt_iop_default_init(dt_iop_module_t *module)
   module->default_enabled = FALSE;
   module->has_trouble = FALSE;
   module->gui_data = NULL;
+  module->data = NULL;
 
   dt_introspection_field_t *i = module->so->get_introspection_linear();
 

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2009-2024 darktable developers.
+    Copyright (C) 2009-2025 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -118,6 +118,7 @@ typedef enum dt_iop_module_state_t
 typedef void dt_iop_gui_data_t;
 typedef void dt_iop_data_t;
 typedef void dt_iop_global_data_t;
+typedef void dt_iop_module_data_t;
 
 /** color picker request */
 typedef enum dt_dev_request_colorpick_flags_t
@@ -224,6 +225,8 @@ typedef struct dt_iop_module_t
   dt_pthread_mutex_t gui_lock;
   /** other stuff that may be needed by the module, not only in gui mode. */
   dt_iop_global_data_t *global_data;
+  /** data that must be available per module instance */
+  dt_iop_module_data_t *data;
   /** blending params */
   struct dt_develop_blend_params_t *blend_params, *default_blendop_params;
   /** holder for blending ui control */
@@ -402,6 +405,8 @@ void dt_iop_request_focus(dt_iop_module_t *module);
 gboolean dt_iop_has_focus(const dt_iop_module_t *module);
 /** allocate and load default settings from introspection. */
 void dt_iop_default_init(dt_iop_module_t *module);
+/** helper for module cleanup to do the basic stuff */
+void dt_iop_default_cleanup(dt_iop_module_t *module);
 /** loads default settings from database. */
 void dt_iop_load_default_params(dt_iop_module_t *module);
 /** creates the module's gui widget */

--- a/src/iop/clahe.c
+++ b/src/iop/clahe.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2010-2024 darktable developers.
+    Copyright (C) 2010-2025 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -296,14 +296,6 @@ void init(dt_iop_module_t *self)
   self->params_size = sizeof(dt_iop_rlce_params_t);
   self->gui_data = NULL;
   *((dt_iop_rlce_params_t *)self->default_params) = (dt_iop_rlce_params_t){ 64, 1.25 };
-}
-
-void cleanup(dt_iop_module_t *self)
-{
-  free(self->params);
-  self->params = NULL;
-  free(self->default_params);
-  self->default_params = NULL;
 }
 
 void gui_init(dt_iop_module_t *self)

--- a/src/iop/enlargecanvas.c
+++ b/src/iop/enlargecanvas.c
@@ -388,14 +388,6 @@ void process(dt_iop_module_t *self,
   dt_iop_copy_image_with_border((float*)ovoid, (const float*)ivoid, &binfo);
 }
 
-void cleanup(dt_iop_module_t *self)
-{
-  free(self->params);
-  self->params = NULL;
-  free(self->default_params);
-  self->default_params = NULL;
-}
-
 void cleanup_global(dt_iop_module_so_t *self)
 {
   free(self->data);

--- a/src/iop/filmic.c
+++ b/src/iop/filmic.c
@@ -1,6 +1,6 @@
 /*
    This file is part of darktable,
-   Copyright (C) 2018-2024 darktable developers.
+   Copyright (C) 2018-2025 darktable developers.
 
    darktable is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -1321,14 +1321,6 @@ void init_global(dt_iop_module_so_t *self)
 
   self->data = gd;
   gd->kernel_filmic = dt_opencl_create_kernel(program, "filmic");
-}
-
-void cleanup(dt_iop_module_t *self)
-{
-  free(self->params);
-  self->params = NULL;
-  free(self->default_params);
-  self->default_params = NULL;
 }
 
 void cleanup_global(dt_iop_module_so_t *self)

--- a/src/iop/finalscale.c
+++ b/src/iop/finalscale.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2015-2024 darktable developers.
+    Copyright (C) 2015-2025 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -224,14 +224,6 @@ void init(dt_iop_module_t *self)
   self->hide_enable_button = TRUE;
   self->params_size = sizeof(dt_iop_finalscale_params_t);
   self->gui_data = NULL;
-}
-
-void cleanup(dt_iop_module_t *self)
-{
-  free(self->params);
-  self->params = NULL;
-  free(self->default_params);
-  self->default_params = NULL;
 }
 
 // clang-format off

--- a/src/iop/useless.c
+++ b/src/iop/useless.c
@@ -446,7 +446,7 @@ void init(dt_iop_module_t *self)
   dt_iop_default_init(self);
 
   // Any non-default settings; for example disabling the on/off switch:
-  module->hide_enable_button = TRUE;
+  self->hide_enable_button = TRUE;
   // To make this work correctly, you also need to hide the widgets,
   // otherwise moving one would enable the module anyway. The standard
   // way is to set up a gtk_stack and show the page that only has a
@@ -460,13 +460,10 @@ void init_global(dt_iop_module_so_t *self)
 
 void cleanup(dt_iop_module_t *self)
 {
+  dt_iop_default_cleanup(self);
   // Releases any memory allocated in init(module) Implement this
   // function explicitly if the module allocates additional memory
   // besides (default_)params.  this is rare.
-  free(self->params);
-  self->params = NULL;
-  free(self->default_params);
-  self->default_params = NULL;
 }
 
 void cleanup_global(dt_iop_module_so_t *self)


### PR DESCRIPTION
1. `cleanup(module)` For every module we have to do some cleanup, per default this is via `default_cleanup`. It's implementation details (freeing parameters and default parameters) should not be used in iop modules so let's introduce `dt_iop_default_cleanup()`, and mention/use it in useless.

   Current modules not doing anything else than the default got the `cleanup()` removed for maintenance.

2. We have data per piece, global data shared by all module instances and the gui data per module instance.
    As the gui data is only available in gui mode and modules might want to keep data per module instance we now have `dt_iop_instance_data_t *data`.

   It's initialized to NULL in `dt_iop_default_init()`, it must be
   - initialized in the specific module `init()` function after calling `dt_iop_default_init()`
   - reset in the module specific `cleanup()` after calling `dt_iop_default_cleanup()`

@TurboGit (2) is not used so far. There are a lot of use cases for this, in many parts of dt code we write such data with every `commit_params` to `piece->data` but could better write to `module->data` just once leading to performance gains with every pipe run. lut tables would be just one example ...