### PR TITLE
[Nightly] Change to make easier test builds in forks

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -130,7 +130,7 @@ jobs:
         run: |
           # Note that we can't make a shallow clone to reduce clone traffic and time, as we have to
           # fetch the entire history to correctly generate the version for the AppImage filename
-          git clone https://github.com/darktable-org/darktable src
+          git clone https://github.com/${{ github.repository }} src
           pushd src
           git submodule init
           git config submodule.src/tests/integration.update none
@@ -240,7 +240,7 @@ jobs:
         run: |
           # Note that we can't make a shallow clone to reduce clone traffic and time, as we have to
           # fetch the entire history to correctly generate the version for the installation package filename
-          git clone https://github.com/darktable-org/darktable src
+          git clone https://github.com/${{ github.repository }} src
           pushd src
           git submodule init
           git config submodule.src/tests/integration.update none
@@ -305,7 +305,7 @@ jobs:
         run: |
           # Note that we can't make a shallow clone to reduce clone traffic and time, as we have to
           # fetch the entire history to correctly generate the version for the disk image filename
-          git clone https://github.com/darktable-org/darktable src
+          git clone https://github.com/${{ github.repository }} src
           pushd src
           git submodule init
           git config submodule.src/tests/integration.update none

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -130,7 +130,7 @@ jobs:
         run: |
           # Note that we can't make a shallow clone to reduce clone traffic and time, as we have to
           # fetch the entire history to correctly generate the version for the AppImage filename
-          git clone https://github.com/${{ github.repository }} src
+          git clone -b ${{ github.ref_name }} https://github.com/${{ github.repository }} src
           pushd src
           git submodule init
           git config submodule.src/tests/integration.update none
@@ -240,7 +240,7 @@ jobs:
         run: |
           # Note that we can't make a shallow clone to reduce clone traffic and time, as we have to
           # fetch the entire history to correctly generate the version for the installation package filename
-          git clone https://github.com/${{ github.repository }} src
+          git clone -b ${{ github.ref_name }} https://github.com/${{ github.repository }} src
           pushd src
           git submodule init
           git config submodule.src/tests/integration.update none
@@ -305,7 +305,7 @@ jobs:
         run: |
           # Note that we can't make a shallow clone to reduce clone traffic and time, as we have to
           # fetch the entire history to correctly generate the version for the disk image filename
-          git clone https://github.com/${{ github.repository }} src
+          git clone -b ${{ github.ref_name }} https://github.com/${{ github.repository }} src
           pushd src
           git submodule init
           git config submodule.src/tests/integration.update none


### PR DESCRIPTION
Sometimes it is necessary to make test packages of the code under development in the fork, before this code is merged in PR. This change greatly simplifies such a build: one can just manually run the nightly workflow from the Actions section of the repo, specifying the desired branch if the code is being developed in a branch.
 