### PR TITLE
cli: refactor cli into smaller functions

### DIFF
--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -43,6 +43,9 @@
 
 #include <inttypes.h>
 #include <libintl.h>
+#include <limits.h>
+#include <stdlib.h>
+#include <string.h>
 #include <sys/time.h>
 #include <unistd.h>
 
@@ -107,7 +110,7 @@ fprintf(stderr, "darktable %s\n"
   // FS TODO: to add instructions for DARKTABLE_OPTIONS
 }
 
-static void icc_types()
+static void icc_types(void)
 {
   // TODO: Can this be automated to keep in sync with colorspaces.h?
   fprintf(stderr, "available ICC types:\n");
@@ -176,7 +179,7 @@ static dt_colorspaces_color_profile_type_t get_icc_type(const char* option)
 }
 #undef ICC_FROM_STR
 
-static void icc_intents()
+static void icc_intents(void)
 {
   // TODO: Can this be automated to keep in sync with colorspaces.h?
   fprintf(stderr, "available ICC intents:\n");
@@ -185,6 +188,7 @@ static void icc_intents()
   fprintf(stderr, " SATURATION\n");
   fprintf(stderr, " ABSOLUTE_COLORIMETRIC\n");
 }
+
 #define ICC_INTENT_FROM_STR(name) if(!strcmp(option, #name)) return DT_INTENT_ ## name;
 static dt_iop_color_intent_t get_icc_intent(const char* option)
 {
@@ -196,37 +200,44 @@ static dt_iop_color_intent_t get_icc_intent(const char* option)
 }
 #undef ICC_INTENT_FROM_STR
 
-int main(int argc, char *arg[])
+
+typedef struct _options_t
 {
-#ifdef __APPLE__
-  dt_osx_prepare_environment();
-#endif
+  int last_arg_pos;
+  char *input_filename;
+  char *xmp_filename;
+  gchar *output_filename;
+  gchar *output_ext;
+  char *style;
+  gboolean style_overwrite;
+  int width;
+  int height;
+  int bpp;
+  gboolean verbose;
+  gboolean high_quality;
+  gboolean upscale;
+  gboolean custom_presets;
+  gboolean export_masks;
+  GList *imports;
+  dt_colorspaces_color_profile_type_t icc_type;
+  gchar *icc_filename;
+  dt_iop_color_intent_t icc_intent;
+} options_t;
 
-  // get valid locale dir
-  dt_loc_init(NULL, NULL, NULL, NULL, NULL, NULL);
-  char localedir[PATH_MAX] = { 0 };
-  dt_loc_get_localedir(localedir, sizeof(localedir));
-  bindtextdomain(GETTEXT_PACKAGE, localedir);
 
-  if(!gtk_parse_args(&argc, &arg)) exit(1);
+static options_t *parse_options(int argc, char *arg[])
+{
+  options_t *opts = g_malloc0(sizeof(options_t));
 
-  // parse command line arguments
-  char *input_filename = NULL;
-  char *xmp_filename = NULL;
-  gchar *output_filename = NULL;
-  gchar *output_ext = NULL;
-  char *style = NULL;
+  // Set non-zero defaults
+  opts->high_quality = TRUE;
+  opts->custom_presets = TRUE;
+  opts->icc_type = DT_COLORSPACE_NONE;
+  opts->icc_intent = DT_INTENT_LAST;
+
   int file_counter = 0;
-  int width = 0, height = 0, bpp = 0;
-  gboolean verbose = FALSE, high_quality = TRUE, upscale = FALSE,
-           style_overwrite = FALSE, custom_presets = TRUE, export_masks = FALSE,
-           output_to_dir = FALSE;
-
-  GList* inputs = NULL;
-
-  dt_colorspaces_color_profile_type_t icc_type = DT_COLORSPACE_NONE;
-  gchar *icc_filename = NULL;
-  dt_iop_color_intent_t icc_intent = DT_INTENT_LAST;
+  // Use GList for --import values. Caller will free these.
+  opts->imports = NULL;
 
   int k;
   for(k = 1; k < argc; k++)
@@ -254,28 +265,28 @@ int main(int argc, char *arg[])
       else if(!strcmp(arg[k], "--width") && argc > k + 1)
       {
         k++;
-        width = MAX(atoi(arg[k]), 0);
+        opts->width = MAX(atoi(arg[k]), 0);
       }
       else if(!strcmp(arg[k], "--height") && argc > k + 1)
       {
         k++;
-        height = MAX(atoi(arg[k]), 0);
+        opts->height = MAX(atoi(arg[k]), 0);
       }
       else if(!strcmp(arg[k], "--bpp") && argc > k + 1)
       {
         k++;
-        bpp = MAX(atoi(arg[k]), 0);
-        fprintf(stderr, "%s %d\n",
-                _("TODO: sorry, due to API restrictions we currently cannot set the BPP to"), bpp);
+        opts->bpp = MAX(atoi(arg[k]), 0);
+        fprintf(stderr, "%s %d\n", _("TODO: sorry, due to API restrictions we currently cannot set the BPP to"),
+                opts->bpp);
       }
       else if(!strcmp(arg[k], "--hq") && argc > k + 1)
       {
         k++;
         gchar *str = g_ascii_strup(arg[k], -1);
         if(!g_strcmp0(str, "0") || !g_strcmp0(str, "FALSE"))
-          high_quality = FALSE;
+          opts->high_quality = FALSE;
         else if(!g_strcmp0(str, "1") || !g_strcmp0(str, "TRUE"))
-          high_quality = TRUE;
+          opts->high_quality = TRUE;
         else
         {
           fprintf(stderr, "%s: %s\n", _("unknown option for --hq"), arg[k]);
@@ -289,9 +300,9 @@ int main(int argc, char *arg[])
         k++;
         gchar *str = g_ascii_strup(arg[k], -1);
         if(!g_strcmp0(str, "0") || !g_strcmp0(str, "FALSE"))
-          export_masks = FALSE;
+          opts->export_masks = FALSE;
         else if(!g_strcmp0(str, "1") || !g_strcmp0(str, "TRUE"))
-          export_masks = TRUE;
+          opts->export_masks = TRUE;
         else
         {
           fprintf(stderr, "%s: %s\n", _("unknown option for --export_masks"), arg[k]);
@@ -305,9 +316,9 @@ int main(int argc, char *arg[])
         k++;
         gchar *str = g_ascii_strup(arg[k], -1);
         if(!g_strcmp0(str, "0") || !g_strcmp0(str, "FALSE"))
-          upscale = FALSE;
+          opts->upscale = FALSE;
         else if(!g_strcmp0(str, "1") || !g_strcmp0(str, "TRUE"))
-          upscale= TRUE;
+          opts->upscale = TRUE;
         else
         {
           fprintf(stderr, "%s: %s\n", _("unknown option for --upscale"), arg[k]);
@@ -319,20 +330,18 @@ int main(int argc, char *arg[])
       else if(!strcmp(arg[k], "--style") && argc > k + 1)
       {
         k++;
-        style = arg[k];
+        opts->style = arg[k];
       }
       else if(!strcmp(arg[k], "--style-overwrite"))
-      {
-        style_overwrite = TRUE;
-      }
+        opts->style_overwrite = TRUE;
       else if(!strcmp(arg[k], "--apply-custom-presets") && argc > k + 1)
       {
         k++;
         gchar *str = g_ascii_strup(arg[k], -1);
         if(!g_strcmp0(str, "0") || !g_strcmp0(str, "FALSE"))
-          custom_presets = FALSE;
+          opts->custom_presets = FALSE;
         else if(!g_strcmp0(str, "1") || !g_strcmp0(str, "TRUE"))
-          custom_presets = TRUE;
+          opts->custom_presets = TRUE;
         else
         {
           fprintf(stderr, "%s: %s\n", _("unknown option for --apply-custom-presets"), arg[k]);
@@ -344,7 +353,7 @@ int main(int argc, char *arg[])
       else if(!strcmp(arg[k], "--out-ext") && argc > k + 1)
       {
         k++;
-        if(strlen(arg[k])> DT_MAX_OUTPUT_EXT_LENGTH)
+        if(strlen(arg[k]) > DT_MAX_OUTPUT_EXT_LENGTH)
         {
           fprintf(stderr, "%s: %s\n", _("too long ext for --out-ext"), arg[k]);
           usage(arg[0]);
@@ -355,23 +364,26 @@ int main(int argc, char *arg[])
           //remove dot ;)
           arg[k]++;
         }
-        output_ext = g_strdup(arg[k]);
+        opts->output_ext = g_strdup(arg[k]);
       }
       else if(!strcmp(arg[k], "--import") && argc > k + 1)
       {
         k++;
         if(g_file_test(arg[k], G_FILE_TEST_EXISTS))
-          inputs = g_list_prepend(inputs, g_strdup(arg[k]));
+          opts->imports = g_list_prepend(opts->imports, g_strdup(arg[k]));
         else
+        {
           fprintf(stderr, _("notice: input file or dir '%s' doesn't exist, skipping\n"), arg[k]);
+        }
       }
       else if(!strcmp(arg[k], "--icc-type") && argc > k + 1)
       {
         k++;
         gchar *str = g_ascii_strup(arg[k], -1);
-        icc_type = get_icc_type(str);
+        opts->icc_type = get_icc_type(str);
         g_free(str);
-        if(icc_type >= DT_COLORSPACE_LAST){
+        if(opts->icc_type >= DT_COLORSPACE_LAST)
+        {
           fprintf(stderr, _("incorrect ICC type for --icc-type: '%s'\n"), arg[k]);
           icc_types();
           usage(arg[0]);
@@ -381,22 +393,25 @@ int main(int argc, char *arg[])
       else if(!strcmp(arg[k], "--icc-file") && argc > k + 1)
       {
         k++;
-        if(g_file_test(arg[k], G_FILE_TEST_EXISTS) && ! g_file_test(arg[k], G_FILE_TEST_IS_DIR))
+        if(g_file_test(arg[k], G_FILE_TEST_EXISTS) && !g_file_test(arg[k], G_FILE_TEST_IS_DIR))
         {
-          if(icc_filename)
-            g_free(icc_filename);
-          icc_filename = g_strdup(arg[k]);
+          if(opts->icc_filename)
+            g_free(opts->icc_filename);
+          opts->icc_filename = g_strdup(arg[k]);
         }
         else
+        {
           fprintf(stderr, _("notice: ICC file '%s' doesn't exist, skipping\n"), arg[k]);
+        }
       }
       else if(!strcmp(arg[k], "--icc-intent") && argc > k + 1)
       {
         k++;
         gchar *str = g_ascii_strup(arg[k], -1);
-        icc_intent = get_icc_intent(str);
+        opts->icc_intent = get_icc_intent(str);
         g_free(str);
-        if(icc_intent >= DT_INTENT_LAST){
+        if(opts->icc_intent >= DT_INTENT_LAST)
+        {
           fprintf(stderr, _("incorrect ICC intent for --icc-intent: '%s'\n"), arg[k]);
           icc_intents();
           usage(arg[0]);
@@ -404,9 +419,7 @@ int main(int argc, char *arg[])
         }
       }
       else if(!strcmp(arg[k], "-v") || !strcmp(arg[k], "--verbose"))
-      {
-        verbose = TRUE;
-      }
+        opts->verbose = TRUE;
       else if(!strcmp(arg[k], "--core"))
       {
         // everything from here on should be passed to the core
@@ -420,139 +433,96 @@ int main(int argc, char *arg[])
     }
     else
     {
-      if(file_counter == 0)
-        input_filename = arg[k];
-      else if(file_counter == 1)
-        xmp_filename = arg[k];
-      else if(file_counter == 2)
+      // Positional arguments. They are processed in order.
+      switch(file_counter)
       {
-        output_filename = g_strdup(arg[k]);
+        case 0:
+          opts->input_filename = arg[k];
+          break;
+        case 1:
+          opts->xmp_filename = arg[k];
+          break;
+        case 2:
+          opts->output_filename = g_strdup(arg[k]);
+          break;
+        default:
+          break;
       }
       file_counter++;
     }
   }
 
-  int m_argc = 0;
-  char **m_arg = malloc(sizeof(char *) * (5 + argc - k + 1));
-  m_arg[m_argc++] = "darktable-cli";
-  m_arg[m_argc++] = "--library";
-  m_arg[m_argc++] = ":memory:";
-  m_arg[m_argc++] = "--conf";
-  m_arg[m_argc++] = "write_sidecar_files=never";
-  for(; k < argc; k++) m_arg[m_argc++] = arg[k];
-  m_arg[m_argc] = NULL;
+  opts->last_arg_pos = k;
 
-  if( (inputs && file_counter < 1) || (!inputs && file_counter < 2) || file_counter > 3)
+  if((opts->imports && file_counter < 1) || (!opts->imports && file_counter < 2) || file_counter > 3)
   {
     usage(arg[0]);
-    free(m_arg);
-    if(output_filename)
-      g_free(output_filename);
-    if(output_ext)
-      g_free(output_ext);
-    if(inputs)
-      g_list_free_full(inputs, g_free);
     exit(1);
   }
-  else if(inputs && file_counter == 1)
+  else if(opts->imports && file_counter == 1)
   {
-    //user specified inputs as options, and only dest is present
-    if(output_filename)
-      g_free(output_filename);
-    output_filename = g_strdup(input_filename);
-    input_filename = xmp_filename = NULL;
+    if(opts->output_filename) g_free(opts->output_filename);
+    opts->output_filename = g_strdup(opts->input_filename);
+    opts->input_filename = opts->xmp_filename = NULL;
   }
-  else if(inputs && file_counter == 2)
+  else if(opts->imports && file_counter == 2)
   {
-    // inputs as options, xmp & output specified
-    if(output_filename)
-      g_free(output_filename);
-    output_filename = g_strdup(xmp_filename);
-    xmp_filename = input_filename;
-    input_filename = NULL;
+    if(opts->output_filename) g_free(opts->output_filename);
+    opts->output_filename = g_strdup(opts->xmp_filename);
+    opts->xmp_filename = opts->input_filename;
+    opts->input_filename = NULL;
   }
-  else if(inputs && file_counter == 3)
+  else if(opts->imports && file_counter == 3)
   {
     fprintf(stderr, _("error: input file and import opts specified! that's not supported!\n"));
     usage(arg[0]);
-    free(m_arg);
-    if(output_filename)
-      g_free(output_filename);
-    if(output_ext)
-      g_free(output_ext);
-    g_list_free_full(inputs, g_free);
     exit(1);
   }
   else if(file_counter == 2)
   {
-    // assume no xmp file given
-    if(output_filename)
-      g_free(output_filename);
-    output_filename = g_strdup(xmp_filename);
-    xmp_filename = NULL;
+    /* Assume no XMP file provided */
+    if(opts->output_filename) g_free(opts->output_filename);
+    opts->output_filename = g_strdup(opts->xmp_filename);
+    opts->xmp_filename = NULL;
   }
 
-  if(!inputs && input_filename)
+  if(!opts->imports && opts->input_filename)
   {
-    // input is present as param
-    inputs = g_list_prepend(inputs, g_strdup(input_filename));
-    input_filename = NULL;
+    opts->imports = g_list_prepend(opts->imports, g_strdup(opts->input_filename));
+    opts->input_filename = NULL;
   }
 
-  if(g_file_test(output_filename, G_FILE_TEST_IS_DIR))
+  /* Handle output filename if it is a directory */
+  if(g_file_test(opts->output_filename, G_FILE_TEST_IS_DIR))
   {
-    output_to_dir = TRUE;
-    if(!output_ext)
+    if(!opts->output_ext)
     {
-      output_ext = g_strdup("jpg");
+      opts->output_ext = g_strdup("jpg");
     }
-    fprintf(stderr, _("notice: output location is a directory. assuming '%s/$(FILE_NAME).%s' output pattern"), output_filename, output_ext);
-    fprintf(stderr, "\n");
-    gchar* temp_of = g_strdup(output_filename);
-    g_free(output_filename);
-    if(g_str_has_suffix(temp_of, "/"))
-      temp_of[strlen(temp_of) - 1] = '\0';
-    output_filename = g_strconcat(temp_of, "/$(FILE_NAME)", NULL);
+    fprintf(stderr, _("notice: output location is a directory. assuming '%s/$(FILE_NAME).%s' output pattern\n"),
+            opts->output_filename, opts->output_ext);
+    gchar *temp_of = g_strdup(opts->output_filename);
+    g_free(opts->output_filename);
+    if(g_str_has_suffix(temp_of, "/")) temp_of[strlen(temp_of) - 1] = '\0';
+    opts->output_filename = g_strconcat(temp_of, "/$(FILE_NAME)", NULL);
     g_free(temp_of);
   }
+  return opts;
+}
 
-  // the output file already exists, so there will be a sequence number added
-  if(g_file_test(output_filename, G_FILE_TEST_EXISTS) && !output_to_dir)
-  {
-    if(!output_ext || (output_ext && g_str_has_suffix(output_filename, output_ext) && !g_strcmp0(output_ext,strrchr(output_filename, '.')+1))){
-      //output file exists or there's output ext specified and it's same as file...
-      fprintf(stderr, "%s\n", _("output file already exists, it will get renamed"));
-    }
-    //TODO: test if file with replaced ext exists
-    // or not if we decide we don't replace file ext with output ext specified
-  }
-
-  // init dt without gui and without data.db:
-  if(dt_init(m_argc, m_arg, FALSE, custom_presets, NULL))
-  {
-    free(m_arg);
-    g_free(output_filename);
-    if(output_ext)
-      g_free(output_ext);
-    if(inputs)
-      g_list_free_full(inputs, g_free);
-    exit(1);
-  }
-
+static int process_images(options_t *opts)
+{
   GList *id_list = NULL;
-
-  for(GList *l = inputs; l != NULL; l=g_list_next(l))
+  // Process each input (dir or file)
+  for(GList *l = opts->imports; l != NULL; l = g_list_next(l))
   {
-    gchar* input = l->data;
-
+    gchar *input = l->data;
     if(g_file_test(input, G_FILE_TEST_IS_DIR))
     {
       const dt_filmid_t filmid = dt_film_import(input);
       if(!filmid)
       {
-        // one of inputs was a failure, no prob
-        fprintf(stderr, _("error: can't open folder %s"), input);
-        fprintf(stderr, "\n");
+        fprintf(stderr, _("error: can't open folder %s\n"), input);
         continue;
       }
       id_list = g_list_concat(id_list, dt_film_get_image_ids(filmid));
@@ -561,240 +531,215 @@ int main(int argc, char *arg[])
     {
       dt_film_t film;
       dt_filmid_t filmid = NO_FILMID;
-
       gchar *directory = g_path_get_dirname(input);
       filmid = dt_film_new(&film, directory);
       const dt_imgid_t id = dt_image_import(filmid, input, TRUE, TRUE);
       g_free(directory);
       if(!dt_is_valid_imgid(id))
       {
-        fprintf(stderr, _("error: can't open file %s"), input);
-        fprintf(stderr, "\n");
+        fprintf(stderr, _("error: can't open file %s\n"), input);
         continue;
       }
       id_list = g_list_append(id_list, GINT_TO_POINTER(id));
     }
   }
+  g_list_free_full(opts->imports, g_free);
+  opts->imports = NULL;
 
-  //we no longer need inputs
-  if(inputs)
-      g_list_free_full(inputs, g_free);
-  inputs = NULL;
-
-  const int total = g_list_length(id_list);
-
+  int total = g_list_length(id_list);
   if(total == 0)
   {
     fprintf(stderr, _("no images to export, aborting\n"));
-    free(m_arg);
-    g_free(output_filename);
-    if(output_ext)
-      g_free(output_ext);
-    exit(1);
+    return 1;
   }
 
-  // attach xmp, if requested:
-  if(xmp_filename)
+  // Attach XMP if requested
+  if(opts->xmp_filename)
   {
     for(GList *iter = id_list; iter; iter = g_list_next(iter))
     {
       int id = GPOINTER_TO_INT(iter->data);
       dt_image_t *image = dt_image_cache_get(id, 'w');
-      if(dt_exif_xmp_read(image, xmp_filename, 1))
+      if(dt_exif_xmp_read(image, opts->xmp_filename, 1))
       {
-        fprintf(stderr, _("error: can't open XMP file %s"), xmp_filename);
-        fprintf(stderr, "\n");
-        free(m_arg);
-        g_free(output_filename);
-        if(output_ext)
-          g_free(output_ext);
-        exit(1);
+        fprintf(stderr, _("error: can't open XMP file %s\n"), opts->xmp_filename);
+        return 1;
       }
-      // don't write new xmp:
       dt_image_cache_write_release(image, DT_IMAGE_CACHE_RELAXED);
     }
   }
 
-  // print the history stack. only look at the first image and assume all got the same processing applied
-  if(verbose)
+  // Display history if verbose is set (using first image as reference)
+  if(opts->verbose)
   {
-    int id = GPOINTER_TO_INT(id_list->data);
-    gchar *history = dt_history_get_items_as_string(id);
+    int first_id = GPOINTER_TO_INT(id_list->data);
+    gchar *history = dt_history_get_items_as_string(first_id);
     if(history)
       printf("%s\n", history);
     else
       printf("[%s]\n", _("empty history stack"));
   }
 
-  if(!output_ext)
+  /* Determine output extension from opts->output_filename if not already set */
+  if(!opts->output_ext)
   {
-    // by this point we're sure output is not dir, there's no output ext specified
-    // so only place to look for it is in filename
-    // try to find out the export format from the output_filename
-    char *ext = strrchr(output_filename, '.');
+    char *ext = strrchr(opts->output_filename, '.');
     if(ext && strlen(ext) > DT_MAX_OUTPUT_EXT_LENGTH)
     {
-      // too long ext, no point in wasting time
       fprintf(stderr, _("too long output file extension: %s\n"), ext);
-      usage(arg[0]);
-      g_free(output_filename);
-      exit(1);
+      return 1;
     }
     else if(!ext || strlen(ext) <= 1)
     {
-      // no ext or empty ext, no point in wasting time
       fprintf(stderr, _("no output file extension given\n"));
-      usage(arg[0]);
-      g_free(output_filename);
-      exit(1);
+      return 1;
     }
     *ext = '\0';
     ext++;
-    output_ext = g_strdup(ext);
-  } else {
-    // check and remove redundant file ext
-    char *ext = strrchr(output_filename, '.');
-    if(ext && !strcmp(output_ext, ext+1))
-    {
-      *ext = '\0';
-    }
+    opts->output_ext = g_strdup(ext);
   }
-
-  if(!strcmp(output_ext, "jpg"))
+  else
   {
-    g_free(output_ext);
-    output_ext = g_strdup("jpeg");
+    /* Remove redundant file ext if needed */
+    char *ext = strrchr(opts->output_filename, '.');
+    if(ext && !strcmp(opts->output_ext, ext + 1)) *ext = '\0';
   }
 
-  if(!strcmp(output_ext, "tif"))
+  /* Normalize common file extension differences */
+  if(!strcmp(opts->output_ext, "jpg"))
   {
-    g_free(output_ext);
-    output_ext = g_strdup("tiff");
+    g_free(opts->output_ext);
+    opts->output_ext = g_strdup("jpeg");
   }
-
-  if(!strcmp(output_ext, "jxl"))
+  if(!strcmp(opts->output_ext, "tif"))
   {
-    g_free(output_ext);
-    output_ext = g_strdup("jpegxl");
+    g_free(opts->output_ext);
+    opts->output_ext = g_strdup("tiff");
+  }
+  if(!strcmp(opts->output_ext, "jxl"))
+  {
+    g_free(opts->output_ext);
+    opts->output_ext = g_strdup("jpegxl");
   }
 
-  // init the export data structures
-  dt_imageio_module_format_t *format;
-  dt_imageio_module_storage_t *storage;
-  dt_imageio_module_data_t *sdata, *fdata;
-
-  storage = dt_imageio_get_storage_by_name("disk"); // only exporting to disk makes sense
+  /* Initialize storage and format modules */
+  dt_imageio_module_storage_t *storage = dt_imageio_get_storage_by_name("disk");
   if(storage == NULL)
   {
-    fprintf(
-        stderr, "%s\n",
-        _("cannot find disk storage module. please check your installation, something seems to be broken."));
-    free(m_arg);
-    g_free(output_filename);
-    g_free(output_ext);
-    exit(1);
+    fprintf(stderr, "%s\n",
+            _("cannot find disk storage module. please check your installation, something seems to be broken."));
+    return 1;
   }
-
-  sdata = storage->get_params(storage);
+  dt_imageio_module_data_t *sdata = storage->get_params(storage);
   if(sdata == NULL)
   {
     fprintf(stderr, "%s\n", _("failed to get parameters from storage module, aborting export ..."));
-    free(m_arg);
-    g_free(output_filename);
-    g_free(output_ext);
-    exit(1);
+    return 1;
   }
+  g_strlcpy((char *)sdata, opts->output_filename, DT_MAX_PATH_FOR_PARAMS);
+  g_free(opts->output_filename);
 
-  // and now for the really ugly hacks. don't tell your children about this one or they won't sleep at night
-  // any longer ...
-  g_strlcpy((char *)sdata, output_filename, DT_MAX_PATH_FOR_PARAMS);
-  // all is good now, the last line didn't happen.
-  g_free(output_filename);
-
-  format = dt_imageio_get_format_by_name(output_ext);
+  dt_imageio_module_format_t *format = dt_imageio_get_format_by_name(opts->output_ext);
   if(format == NULL)
   {
-    fprintf(stderr, _("unknown extension '.%s'"), output_ext);
-    fprintf(stderr, "\n");
-    free(m_arg);
-    g_free(output_ext);
-    exit(1);
+    fprintf(stderr, _("unknown extension '.%s'\n"), opts->output_ext);
+    return 1;
   }
-
-  fdata = format->get_params(format);
+  dt_imageio_module_data_t *fdata = format->get_params(format);
   if(fdata == NULL)
   {
     fprintf(stderr, "%s\n", _("failed to get parameters from format module, aborting export ..."));
-    free(m_arg);
-    g_free(output_ext);
-    exit(1);
+    return 1;
   }
 
-  uint32_t w, h, fw, fh, sw, sh;
-  fw = fh = sw = sh = 0;
+  /* Adjust dimensions */
+  uint32_t sw = 0, sh = 0, fw = 0, fh = 0, w = 0, h = 0;
   storage->dimension(storage, sdata, &sw, &sh);
   format->dimension(format, fdata, &fw, &fh);
-
-  if(sw == 0 || fw == 0)
-    w = sw > fw ? sw : fw;
-  else
-    w = sw < fw ? sw : fw;
-
-  if(sh == 0 || fh == 0)
-    h = sh > fh ? sh : fh;
-  else
-    h = sh < fh ? sh : fh;
-
-  fdata->max_width = width;
-  fdata->max_height = height;
-  fdata->max_width = (w != 0 && fdata->max_width > w) ? w : fdata->max_width;
-  fdata->max_height = (h != 0 && fdata->max_height > h) ? h : fdata->max_height;
+  w = (sw == 0 || fw == 0) ? (sw > fw ? sw : fw) : (sw < fw ? sw : fw);
+  h = (sh == 0 || fh == 0) ? (sh > fh ? sh : fh) : (sh < fh ? sh : fh);
+  fdata->max_width = (w != 0 && opts->width > w) ? w : opts->width;
+  fdata->max_height = (h != 0 && opts->height > h) ? h : opts->height;
   fdata->style[0] = '\0';
-  fdata->style_append = 1; // make append the default and override with --style-overwrite
+  fdata->style_append = 1; // default is to append
 
-  if(style)
+  if(opts->style)
   {
-    g_strlcpy((char *)fdata->style, style, DT_MAX_STYLE_NAME_LENGTH);
-    fdata->style[127] = '\0';
-    if(style_overwrite)
-      fdata->style_append = 0;
+    g_strlcpy((char *)fdata->style, opts->style, DT_MAX_STYLE_NAME_LENGTH);
+    fdata->style[DT_MAX_STYLE_NAME_LENGTH - 1] = '\0';
+    if(opts->style_overwrite) fdata->style_append = 0;
   }
 
   if(storage->initialize_store)
   {
-    storage->initialize_store(storage, sdata, &format, &fdata, &id_list, high_quality, upscale);
-
+    storage->initialize_store(storage, sdata, &format, &fdata, &id_list, opts->high_quality, opts->upscale);
     format->set_params(format, fdata, format->params_size(format));
     storage->set_params(storage, sdata, storage->params_size(storage));
   }
 
-  // TODO: add a callback to set the bpp without going through the config
-
+  /* Loop through each image and export */
   int num = 1, res = 0;
   for(GList *iter = id_list; iter; iter = g_list_next(iter), num++)
   {
     const int id = GPOINTER_TO_INT(iter->data);
-    // TODO: have a parameter in command line to get the export presets
     dt_export_metadata_t metadata;
     metadata.flags = dt_lib_export_metadata_default_flags();
     metadata.list = NULL;
-    if(storage->store(storage, sdata, id, format, fdata, num, total, high_quality, upscale, export_masks,
-                      icc_type, icc_filename, icc_intent, &metadata) != 0)
+    if(storage->store(storage, sdata, id, format, fdata, num, total, opts->high_quality, opts->upscale,
+                      opts->export_masks, opts->icc_type, opts->icc_filename, opts->icc_intent, &metadata)
+       != 0)
       res = 1;
   }
 
-  // cleanup time
   if(storage->finalize_store) storage->finalize_store(storage, sdata);
   storage->free_params(storage, sdata);
   format->free_params(format, fdata);
   g_list_free(id_list);
 
-  if(icc_filename)
-    g_free(icc_filename);
+  if(opts->icc_filename)
+    g_free(opts->icc_filename);
+
+  return res;
+}
+
+int main(int argc, char *argv[])
+{
+#ifdef __APPLE__
+  dt_osx_prepare_environment();
+#endif
+
+  dt_loc_init(NULL, NULL, NULL, NULL, NULL, NULL);
+  char localedir[PATH_MAX] = { 0 };
+  dt_loc_get_localedir(localedir, sizeof(localedir));
+  bindtextdomain(GETTEXT_PACKAGE, localedir);
+
+  if(!gtk_parse_args(&argc, &argv)) exit(1);
+
+  options_t *opts = parse_options(argc, argv);
+
+  int m_argc = 0;
+  char **m_arg = malloc(sizeof(char *) * (5 + argc - opts->last_arg_pos + 1));
+  m_arg[m_argc++] = "darktable-cli";
+  m_arg[m_argc++] = "--library";
+  m_arg[m_argc++] = ":memory:";
+  m_arg[m_argc++] = "--conf";
+  m_arg[m_argc++] = "write_sidecar_files=never";
+  for(; opts->last_arg_pos < argc; opts->last_arg_pos++) m_arg[m_argc++] = argv[opts->last_arg_pos];
+  m_arg[m_argc] = NULL;
+
+  if(dt_init(m_argc, m_arg, FALSE, opts->custom_presets, NULL))
+  {
+    free(m_arg);
+    exit(1);
+  }
+
+  int res = process_images(opts);
 
   dt_cleanup();
-
   free(m_arg);
+  g_free(opts->output_ext);
+  free(opts);
+
   exit(res);
 }
 


### PR DESCRIPTION
Refactor the darktable-cli into smaller functions for better readability.

I wanted to do some automation from the cli, where I also wanted to add an option --style-file to pick the style from a file instead of requiring to pre-import it. Anyways while attempting to make that change I found that it's hard to follow what is happening in the cli so I first refactored it a bit. Follow up PR for the other stuff may follow soon-ish.