### PR TITLE
[GUI] Use 'delete' instead of 'cleanup'

### DIFF
--- a/src/libs/masks.c
+++ b/src/libs/masks.c
@@ -1147,7 +1147,7 @@ static int _tree_button_pressed(GtkWidget *treeview,
     }
 
     gtk_menu_shell_append(menu, gtk_separator_menu_item_new());
-    item = gtk_menu_item_new_with_label(_("cleanup unused shapes"));
+    item = gtk_menu_item_new_with_label(_("delete unused shapes"));
     g_signal_connect(item, "activate", (GCallback)_tree_cleanup, self);
     gtk_menu_shell_append(menu, item);
 


### PR DESCRIPTION
`Cleanup` is a slightly unfocused/imprecise term, `delete` has a clearer meaning and is better here. This is an implementation of a suggestion from https://github.com/darktable-org/darktable/issues/12656#issuecomment-1642494929