### PR TITLE
Fix build for fedora 42

### DIFF
--- a/src/imageio/imageio_exr.hh
+++ b/src/imageio/imageio_exr.hh
@@ -19,7 +19,7 @@
 #pragma once
 
 #include <cinttypes>
-#include <ciso646>
+#include <version>
 #include <memory>
 
 #include <OpenEXR/ImfChannelList.h>


### PR DESCRIPTION
As suggested while compiling <ciso646> is deprecated and should be replaced by <version>