### PR TITLE
typedef struct dt_interpolation_t

### DIFF
--- a/src/common/interpolation.c
+++ b/src/common/interpolation.c
@@ -1,6 +1,6 @@
 /* --------------------------------------------------------------------------
     This file is part of darktable,
-    Copyright (C) 2012-2024 darktable developers.
+    Copyright (C) 2012-2025 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -392,7 +392,7 @@ static float _maketaps_lanczos(float *taps,
  * of this filter list. Otherwise bad things will happen
  * !!! !!! !!!
  */
-static const struct dt_interpolation dt_interpolator[] = {
+static const dt_interpolation_t dt_interpolator[] = {
   {.id = DT_INTERPOLATION_BILINEAR,
    .name = "bilinear",
    .width = 1,
@@ -419,7 +419,7 @@ static const struct dt_interpolation dt_interpolator[] = {
  * Kernel utility methods
  * ------------------------------------------------------------------------*/
 
-static inline float _compute_upsampling_kernel(const struct dt_interpolation *itor,
+static inline float _compute_upsampling_kernel(const dt_interpolation_t *itor,
                                                float *kernel,
                                                int *first,
                                                float t)
@@ -454,7 +454,7 @@ static inline float _compute_upsampling_kernel(const struct dt_interpolation *it
  * @param first [out] index of the first sample for which the kernel is to be applied
  * @param outoinratio [in] "out samples" over "in samples" ratio
  * @param xout [in] Output coordinate */
-static inline void _compute_downsampling_kernel(const struct dt_interpolation *itor,
+static inline void _compute_downsampling_kernel(const dt_interpolation_t *itor,
                                                 int *taps,
                                                 int *first,
                                                 float *kernel,
@@ -495,7 +495,7 @@ static inline void _compute_downsampling_kernel(const struct dt_interpolation *i
 
 #define MAX_KERNEL_REQ ((2 * (MAX_HALF_FILTER_WIDTH) + 3) & (~3))
 
-float dt_interpolation_compute_sample(const struct dt_interpolation *itor,
+float dt_interpolation_compute_sample(const dt_interpolation_t *itor,
                                       const float *in,
                                       const float x,
                                       const float y,
@@ -594,7 +594,7 @@ float dt_interpolation_compute_sample(const struct dt_interpolation *itor,
  * Pixel interpolation function (see usage in iop/lens.c and iop/clipping.c)
  * ------------------------------------------------------------------------*/
 
-void dt_interpolation_compute_pixel4c(const struct dt_interpolation *itor,
+void dt_interpolation_compute_pixel4c(const dt_interpolation_t *itor,
                                       const float *in,
                                       float *out,
                                       const float x,
@@ -713,9 +713,9 @@ void dt_interpolation_compute_pixel4c(const struct dt_interpolation *itor,
  * Interpolation factory
  * ------------------------------------------------------------------------*/
 
-const struct dt_interpolation *dt_interpolation_new(enum dt_interpolation_type type)
+const dt_interpolation_t *dt_interpolation_new(enum dt_interpolation_type type)
 {
-  const struct dt_interpolation *itor = NULL;
+  const dt_interpolation_t *itor = NULL;
 
   if(type == DT_INTERPOLATION_USERPREF)
   {
@@ -823,7 +823,7 @@ const struct dt_interpolation *dt_interpolation_new(enum dt_interpolation_type t
  * out position meta[3*out]
  * @return FALSE for success, TRUE for failure
  */
-static gboolean _prepare_resampling_plan(const struct dt_interpolation *itor,
+static gboolean _prepare_resampling_plan(const dt_interpolation_t *itor,
                                          const int in,
                                          const int in_x0,
                                          const int out,
@@ -1007,7 +1007,7 @@ static gboolean _prepare_resampling_plan(const struct dt_interpolation *itor,
   return FALSE;
 }
 
-static void _interpolation_resample_plain(const struct dt_interpolation *itor,
+static void _interpolation_resample_plain(const dt_interpolation_t *itor,
                                           float *out,
                                           const dt_iop_roi_t *const roi_out,
                                           const float *const in,
@@ -1149,7 +1149,7 @@ exit:
 /** Applies resampling (re-scaling) on *full* input and output buffers.
  *  roi_in and roi_out define the part of the buffers that is affected.
  */
-void dt_interpolation_resample(const struct dt_interpolation *itor,
+void dt_interpolation_resample(const dt_interpolation_t *itor,
                                float *out,
                                const dt_iop_roi_t *const roi_out,
                                const float *const in,
@@ -1169,7 +1169,7 @@ void dt_interpolation_resample(const struct dt_interpolation *itor,
  *  roi's. roi_in and roi_out define the relative positions of the
  *  roi's within the full input and output image, respectively.
  */
-void dt_interpolation_resample_roi(const struct dt_interpolation *itor,
+void dt_interpolation_resample_roi(const dt_interpolation_t *itor,
                                    float *out,
                                    const dt_iop_roi_t *const roi_out,
                                    const float *const in,
@@ -1218,7 +1218,7 @@ static uint32_t roundToNextPowerOfTwo(uint32_t x)
 /** Applies resampling (re-scaling) on *full* input and output buffers.
  *  roi_in and roi_out define the part of the buffers that is affected.
  */
-int dt_interpolation_resample_cl(const struct dt_interpolation *itor,
+int dt_interpolation_resample_cl(const dt_interpolation_t *itor,
                                  const int devid,
                                  cl_mem dev_out,
                                  const dt_iop_roi_t *const roi_out,
@@ -1404,7 +1404,7 @@ error:
  *  roi's. roi_in and roi_out define the relative positions of the
  *  roi's within the full input and output image, respectively.
  */
-int dt_interpolation_resample_roi_cl(const struct dt_interpolation *itor,
+int dt_interpolation_resample_roi_cl(const dt_interpolation_t *itor,
                                      const int devid,
                                      cl_mem dev_out,
                                      const dt_iop_roi_t *const roi_out,
@@ -1421,7 +1421,7 @@ int dt_interpolation_resample_roi_cl(const struct dt_interpolation *itor,
 }
 #endif
 
-static void _interpolation_resample_1c_plain(const struct dt_interpolation *itor,
+static void _interpolation_resample_1c_plain(const dt_interpolation_t *itor,
                                              float *out,
                                              const dt_iop_roi_t *const roi_out,
                                              const float *const in,
@@ -1565,7 +1565,7 @@ static void _interpolation_resample_1c_plain(const struct dt_interpolation *itor
 /** Applies resampling (re-scaling) on *full* input and output buffers.
  *  roi_in and roi_out define the part of the buffers that is affected.
  */
-void dt_interpolation_resample_1c(const struct dt_interpolation *itor,
+void dt_interpolation_resample_1c(const dt_interpolation_t *itor,
                                   float *out,
                                   const dt_iop_roi_t *const roi_out,
                                   const float *const in,
@@ -1578,7 +1578,7 @@ void dt_interpolation_resample_1c(const struct dt_interpolation *itor,
  *  and output buffers hold exactly those roi's. roi_in and roi_out define the relative
  *  positions of the roi's within the full input and output image, respectively.
  */
-void dt_interpolation_resample_roi_1c(const struct dt_interpolation *itor,
+void dt_interpolation_resample_roi_1c(const dt_interpolation_t *itor,
                                       float *out,
                                       const dt_iop_roi_t *const roi_out,
                                       const float *const in,

--- a/src/common/interpolation.h
+++ b/src/common/interpolation.h
@@ -1,6 +1,6 @@
 /* --------------------------------------------------------------------------
     This file is part of darktable,
-    Copyright (C) 2012-2023 darktable developers.
+    Copyright (C) 2012-2025 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -46,13 +46,13 @@ typedef float (*dt_interpolation_func)(float *taps,
                                        float interval);
 
 /** Interpolation structure */
-struct dt_interpolation
+typedef struct dt_interpolation_t
 {
   enum dt_interpolation_type id;     /**< Id such as defined by the dt_interpolation_type */
   const char *name;                  /**< internal name  */
   size_t width;                      /**< Half width of its kernel support */
   dt_interpolation_func maketaps;    /**< Kernel function */
-};
+} dt_interpolation_t;
 
 /** Compute a single interpolated sample.
  *
@@ -74,7 +74,7 @@ struct dt_interpolation
  *
  * @return computed sample
  */
-float dt_interpolation_compute_sample(const struct dt_interpolation *itor, const float *in, const float x,
+float dt_interpolation_compute_sample(const dt_interpolation_t *itor, const float *in, const float x,
                                       const float y, const int width, const int height,
                                       const int samplestride, const int linestride);
 
@@ -97,7 +97,7 @@ float dt_interpolation_compute_sample(const struct dt_interpolation *itor, const
  * @param linestride Stride in bytes for complete line
  *
  */
-void dt_interpolation_compute_pixel4c(const struct dt_interpolation *itor, const float *in, float *out,
+void dt_interpolation_compute_pixel4c(const dt_interpolation_t *itor, const float *in, float *out,
                                       const float x, const float y, const int width, const int height,
                                       const int linestride);
 
@@ -105,7 +105,7 @@ void dt_interpolation_compute_pixel4c(const struct dt_interpolation *itor, const
  * @param type Interpolator to search for
  * @return requested interpolator or default if not found (this function can't fail)
  */
-const struct dt_interpolation *dt_interpolation_new(enum dt_interpolation_type type);
+const dt_interpolation_t *dt_interpolation_new(enum dt_interpolation_type type);
 
 /** Image resampler.
  *
@@ -128,11 +128,11 @@ const struct dt_interpolation *dt_interpolation_new(enum dt_interpolation_type t
  * @param roi_in [in] Region of interest of the original image
  * @param in_stride [in] Input line stride in <strong>bytes</strong>
  */
-void dt_interpolation_resample(const struct dt_interpolation *itor, float *out,
+void dt_interpolation_resample(const dt_interpolation_t *itor, float *out,
                                const dt_iop_roi_t *const roi_out,
                                const float *const in, const dt_iop_roi_t *const roi_in);
 
-void dt_interpolation_resample_roi(const struct dt_interpolation *itor, float *out,
+void dt_interpolation_resample_roi(const dt_interpolation_t *itor, float *out,
                                    const dt_iop_roi_t *const roi_out,
                                    const float *const in, const dt_iop_roi_t *const roi_in);
 
@@ -169,20 +169,20 @@ void dt_interpolation_free_cl_global(dt_interpolation_cl_global_t *g);
  * @param roi_in [in] Region of interest of the original image
  * @param in_stride [in] Input line stride in <strong>bytes</strong>
  */
-int dt_interpolation_resample_cl(const struct dt_interpolation *itor, int devid, cl_mem dev_out,
+int dt_interpolation_resample_cl(const dt_interpolation_t *itor, int devid, cl_mem dev_out,
                                  const dt_iop_roi_t *const roi_out, cl_mem dev_in,
                                  const dt_iop_roi_t *const roi_in);
 
-int dt_interpolation_resample_roi_cl(const struct dt_interpolation *itor, int devid, cl_mem dev_out,
+int dt_interpolation_resample_roi_cl(const dt_interpolation_t *itor, int devid, cl_mem dev_out,
                                      const dt_iop_roi_t *const roi_out, cl_mem dev_in,
                                      const dt_iop_roi_t *const roi_in);
 #endif
 
-void dt_interpolation_resample_1c(const struct dt_interpolation *itor,
+void dt_interpolation_resample_1c(const dt_interpolation_t *itor,
                                   float *out, const dt_iop_roi_t *const roi_out,
                                   const float *const in, const dt_iop_roi_t *const roi_in);
 
-void dt_interpolation_resample_roi_1c(const struct dt_interpolation *itor,
+void dt_interpolation_resample_roi_1c(const dt_interpolation_t *itor,
                                       float *out, const dt_iop_roi_t *const roi_out,
                                       const float *const in, const dt_iop_roi_t *const roi_in);
 

--- a/src/develop/imageop_math.c
+++ b/src/develop/imageop_math.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2016-2024 darktable developers.
+    Copyright (C) 2016-2025 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -151,7 +151,7 @@ void dt_iop_clip_and_zoom(float *out,
                           const dt_iop_roi_t *const roi_out,
                           const dt_iop_roi_t *const roi_in)
 {
-  const struct dt_interpolation *itor = dt_interpolation_new(DT_INTERPOLATION_USERPREF);
+  const dt_interpolation_t *itor = dt_interpolation_new(DT_INTERPOLATION_USERPREF);
   dt_interpolation_resample(itor, out, roi_out, in, roi_in);
 }
 
@@ -162,7 +162,7 @@ void dt_iop_clip_and_zoom_roi(float *out,
                               const dt_iop_roi_t *const roi_out,
                               const dt_iop_roi_t *const roi_in)
 {
-  const struct dt_interpolation *itor = dt_interpolation_new(DT_INTERPOLATION_USERPREF);
+  const dt_interpolation_t *itor = dt_interpolation_new(DT_INTERPOLATION_USERPREF);
   dt_interpolation_resample_roi(itor, out, roi_out, in, roi_in);
 }
 
@@ -175,7 +175,7 @@ int dt_iop_clip_and_zoom_cl(int devid,
                             const dt_iop_roi_t *const roi_out,
                             const dt_iop_roi_t *const roi_in)
 {
-  const struct dt_interpolation *itor = dt_interpolation_new(DT_INTERPOLATION_USERPREF);
+  const dt_interpolation_t *itor = dt_interpolation_new(DT_INTERPOLATION_USERPREF);
   return dt_interpolation_resample_cl(itor, devid, dev_out, roi_out, dev_in, roi_in);
 }
 
@@ -187,7 +187,7 @@ int dt_iop_clip_and_zoom_roi_cl(int devid,
                                 const dt_iop_roi_t *const roi_out,
                                 const dt_iop_roi_t *const roi_in)
 {
-  const struct dt_interpolation *itor = dt_interpolation_new(DT_INTERPOLATION_USERPREF);
+  const dt_interpolation_t *itor = dt_interpolation_new(DT_INTERPOLATION_USERPREF);
   cl_int err = dt_interpolation_resample_roi_cl(itor, devid, dev_out,
                                                 roi_out, dev_in, roi_in);
   if(err == CL_INVALID_WORK_GROUP_SIZE)

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -1092,8 +1092,7 @@ void distort_mask(dt_iop_module_t *self,
     return;
   }
 
-  const struct dt_interpolation *interpolation =
-    dt_interpolation_new(DT_INTERPOLATION_USERPREF_WARP);
+  const dt_interpolation_t *interpolation = dt_interpolation_new(DT_INTERPOLATION_USERPREF_WARP);
 
   float DT_ALIGNED_ARRAY ihomograph[3][3];
   _homography((float *)ihomograph, data->rotation, data->lensshift_v, data->lensshift_h,
@@ -1271,8 +1270,7 @@ void modify_roi_in(dt_iop_module_t *self,
     }
   }
 
-  const struct dt_interpolation *interpolation =
-    dt_interpolation_new(DT_INTERPOLATION_USERPREF_WARP);
+  const dt_interpolation_t *interpolation = dt_interpolation_new(DT_INTERPOLATION_USERPREF_WARP);
 
   const float iw1 = interpolation->width;
   const float iw2 = 2.0f * iw1;
@@ -3525,8 +3523,7 @@ void process(dt_iop_module_t *self,
     return;
   }
 
-  const struct dt_interpolation *interpolation =
-    dt_interpolation_new(DT_INTERPOLATION_USERPREF_WARP);
+  const dt_interpolation_t *interpolation = dt_interpolation_new(DT_INTERPOLATION_USERPREF_WARP);
 
   float DT_ALIGNED_ARRAY ihomograph[3][3];
   _homography((float *)ihomograph, data->rotation, data->lensshift_v, data->lensshift_h,
@@ -3688,8 +3685,7 @@ int process_cl(dt_iop_module_t *self,
   const float clip[2] = { cx, cy };
 
 
-  const struct dt_interpolation *interpolation =
-    dt_interpolation_new(DT_INTERPOLATION_USERPREF_WARP);
+  const dt_interpolation_t *interpolation = dt_interpolation_new(DT_INTERPOLATION_USERPREF_WARP);
 
   int ldkernel = -1;
 

--- a/src/iop/clipping.c
+++ b/src/iop/clipping.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2009-2024 darktable developers.
+    Copyright (C) 2009-2025 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -626,7 +626,7 @@ void distort_mask(dt_iop_module_t *self,
   }
   else
   {
-    const struct dt_interpolation *interpolation = dt_interpolation_new(DT_INTERPOLATION_USERPREF_WARP);
+    const dt_interpolation_t *interpolation = dt_interpolation_new(DT_INTERPOLATION_USERPREF_WARP);
     const float rx = piece->buf_in.width * roi_in->scale;
     const float ry = piece->buf_in.height * roi_in->scale;
     const dt_boundingbox_t k_space =
@@ -1013,7 +1013,7 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
   }
   else
   {
-    const struct dt_interpolation *interpolation = dt_interpolation_new(DT_INTERPOLATION_USERPREF_WARP);
+    const dt_interpolation_t *interpolation = dt_interpolation_new(DT_INTERPOLATION_USERPREF_WARP);
     const float rx = piece->buf_in.width * roi_in->scale;
     const float ry = piece->buf_in.height * roi_in->scale;
     const dt_boundingbox_t k_space =
@@ -1094,7 +1094,7 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
   {
     int crkernel = -1;
 
-    const struct dt_interpolation *interpolation = dt_interpolation_new(DT_INTERPOLATION_USERPREF_WARP);
+    const dt_interpolation_t *interpolation = dt_interpolation_new(DT_INTERPOLATION_USERPREF_WARP);
 
     switch(interpolation->id)
     {
@@ -1441,7 +1441,7 @@ static float _ratio_get_aspect(dt_iop_module_t *self, GtkWidget *combo)
     }
     else
     {
-      const struct dt_interpolation *interpolation = dt_interpolation_new(DT_INTERPOLATION_USERPREF_WARP);
+      const dt_interpolation_t *interpolation = dt_interpolation_new(DT_INTERPOLATION_USERPREF_WARP);
       const float whratio = ((float)(iwd - 2 * interpolation->width) * (fabsf(p->cw) - p->cx))
                             / ((float)(iht - 2 * interpolation->width) * (fabsf(p->ch) - p->cy));
       const float ri = (float)iwd / (float)iht;

--- a/src/iop/crop.c
+++ b/src/iop/crop.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2021-2024 darktable developers.
+    Copyright (C) 2021-2025 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -541,8 +541,7 @@ static float _aspect_ratio_get(dt_iop_module_t *self, GtkWidget *combo)
     }
     else
     {
-      const struct dt_interpolation *interpolation =
-        dt_interpolation_new(DT_INTERPOLATION_USERPREF_WARP);
+      const dt_interpolation_t *interpolation = dt_interpolation_new(DT_INTERPOLATION_USERPREF_WARP);
       const float whratio = ((float)(iwd - 2 * interpolation->width) * (p->cw - p->cx))
                             / ((float)(iht - 2 * interpolation->width) * (p->ch - p->cy));
       const float ri = (float)iwd / (float)iht;

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -399,8 +399,13 @@ void distort_mask(dt_iop_module_t *self,
                   const dt_iop_roi_t *const roi_in,
                   const dt_iop_roi_t *const roi_out)
 {
-  const struct dt_interpolation *itor = dt_interpolation_new(DT_INTERPOLATION_USERPREF_WARP);
-  dt_interpolation_resample_roi_1c(itor, out, roi_out, in, roi_in);
+  if(roi_out->scale != roi_in->scale)
+  {
+    const dt_interpolation_t *itor = dt_interpolation_new(DT_INTERPOLATION_USERPREF_WARP);
+    dt_interpolation_resample_roi_1c(itor, out, roi_out, in, roi_in);
+  }
+  else
+    dt_iop_copy_image_roi(out, in, 1, roi_in, roi_out);
 }
 
 void modify_roi_out(dt_iop_module_t *self,

--- a/src/iop/finalscale.c
+++ b/src/iop/finalscale.c
@@ -140,8 +140,7 @@ void distort_mask(dt_iop_module_t *self,
                   const dt_iop_roi_t *const roi_in,
                   const dt_iop_roi_t *const roi_out)
 {
-  const struct dt_interpolation *itor =
-    dt_interpolation_new(DT_INTERPOLATION_USERPREF);
+  const dt_interpolation_t *itor = dt_interpolation_new(DT_INTERPOLATION_USERPREF);
   dt_interpolation_resample_1c(itor, out, roi_out, in, roi_in);
 }
 

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -332,7 +332,7 @@ void distort_mask(dt_iop_module_t *self,
 {
   if(roi_out->scale != roi_in->scale)
   {
-    const struct dt_interpolation *itor = dt_interpolation_new(DT_INTERPOLATION_USERPREF_WARP);
+    const dt_interpolation_t *itor = dt_interpolation_new(DT_INTERPOLATION_USERPREF_WARP);
     dt_interpolation_resample_roi_1c(itor, out, roi_out, in, roi_in);
   }
   else

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -1082,8 +1082,7 @@ static void _process_lf(dt_iop_module_t *self,
 
   dt_pthread_mutex_unlock(&darktable.plugin_threadsafe);
 
-  const struct dt_interpolation *const interpolation =
-    dt_interpolation_new(DT_INTERPOLATION_USERPREF_WARP);
+  const dt_interpolation_t *const interpolation = dt_interpolation_new(DT_INTERPOLATION_USERPREF_WARP);
 
   if(d->inverse)
   {
@@ -1332,8 +1331,7 @@ static int _process_cl_lf(dt_iop_module_t *self,
 
   int modflags;
   int ldkernel = -1;
-  const struct dt_interpolation *interpolation =
-    dt_interpolation_new(DT_INTERPOLATION_USERPREF_WARP);
+  const dt_interpolation_t *interpolation = dt_interpolation_new(DT_INTERPOLATION_USERPREF_WARP);
 
   if(!d->lens || !d->lens->Maker || d->crop <= 0.0f)
     return dt_opencl_enqueue_copy_image(devid, dev_in, dev_out,
@@ -1662,8 +1660,7 @@ static void _distort_mask_lf(dt_iop_module_t *self,
     return;
   }
 
-  const struct dt_interpolation *const interpolation =
-    dt_interpolation_new(DT_INTERPOLATION_USERPREF_WARP);
+  const dt_interpolation_t *const interpolation = dt_interpolation_new(DT_INTERPOLATION_USERPREF_WARP);
 
   // acquire temp memory for distorted pixel coords
   const size_t bufsize = (size_t)roi_out->width * 2 * 3;
@@ -1792,8 +1789,7 @@ DT_OMP_PRAGMA(barrier)
     if(!isfinite(yM) || !(1 <= yM && yM < orig_h))
       yM = orig_h;
 
-    const struct dt_interpolation *interpolation =
-      dt_interpolation_new(DT_INTERPOLATION_USERPREF_WARP);
+    const dt_interpolation_t *interpolation = dt_interpolation_new(DT_INTERPOLATION_USERPREF_WARP);
     roi_in->x = MAX(0.0f, xm - interpolation->width);
     roi_in->y = MAX(0.0f, ym - interpolation->width);
     roi_in->width = MIN(orig_w - roi_in->x,  xM - roi_in->x + interpolation->width);
@@ -2719,8 +2715,7 @@ static void _distort_mask_md(dt_iop_module_t *self,
   const float limw = roi_in->width - 1;
   const float limh = roi_in->height - 1;
 
-  const struct dt_interpolation *interpolation =
-    dt_interpolation_new(DT_INTERPOLATION_USERPREF_WARP);
+  const dt_interpolation_t *interpolation = dt_interpolation_new(DT_INTERPOLATION_USERPREF_WARP);
 
   DT_OMP_FOR(collapse(2))
   for(int y = 0; y < roi_out->height; y++)
@@ -2762,7 +2757,7 @@ static void _process_md(dt_iop_module_t *self,
   const float h2 = 0.5f * roi_in->scale * piece->buf_in.height;
   const float r = 1.0f / sqrtf(w2*w2 + h2*h2);
 
-  const struct dt_interpolation *interpolation = dt_interpolation_new(DT_INTERPOLATION_USERPREF_WARP);
+  const dt_interpolation_t *interpolation = dt_interpolation_new(DT_INTERPOLATION_USERPREF_WARP);
   const gboolean pass_mode = piece->pipe->mask_display == DT_DEV_PIXELPIPE_DISPLAY_PASSTHRU;
 
   // Allocate temporary storage if we haven't got that from manual vignette
@@ -2856,7 +2851,7 @@ static int _process_cl_md(dt_iop_module_t *self,
   const float r = 1.0f / sqrtf(w2*w2 + h2*h2);
   const int knots = d->nc;
 
-  const struct dt_interpolation *itor = dt_interpolation_new(DT_INTERPOLATION_USERPREF_WARP);
+  const dt_interpolation_t *itor = dt_interpolation_new(DT_INTERPOLATION_USERPREF_WARP);
   const int itor_width = itor->width;
   const int pass_mode = piece->pipe->mask_display == DT_DEV_PIXELPIPE_DISPLAY_PASSTHRU;
 
@@ -2983,8 +2978,7 @@ static void _modify_roi_in_md(dt_iop_module_t *self,
     }
   }
 
-  const struct dt_interpolation *interpolation =
-    dt_interpolation_new(DT_INTERPOLATION_USERPREF_WARP);
+  const dt_interpolation_t *interpolation = dt_interpolation_new(DT_INTERPOLATION_USERPREF_WARP);
 
   const float iw1 = interpolation->width;
   const float iw2 = 2.0f * iw1;

--- a/src/iop/liquify.c
+++ b/src/iop/liquify.c
@@ -1022,8 +1022,7 @@ static void _apply_global_distortion_map(dt_iop_module_t *self,
 {
   const int ch = piece->colors;
   const int ch_width = ch * roi_in->width;
-  const struct dt_interpolation * const interpolation =
-    dt_interpolation_new(DT_INTERPOLATION_USERPREF_WARP);
+  const dt_interpolation_t *const interpolation = dt_interpolation_new(DT_INTERPOLATION_USERPREF_WARP);
 
   const size_t min_y = MAX(roi_out->y, extent->y);
   const size_t max_y = MIN(roi_out->y + roi_out->height, extent->y + extent->height);
@@ -1468,8 +1467,7 @@ static cl_int_t _apply_global_distortion_map_cl(dt_iop_module_t *self,
   dt_iop_liquify_global_data_t *gd = self->global_data;
   const int devid = piece->pipe->devid;
 
-  const struct dt_interpolation* interpolation =
-    dt_interpolation_new(DT_INTERPOLATION_USERPREF_WARP);
+  const dt_interpolation_t *interpolation = dt_interpolation_new(DT_INTERPOLATION_USERPREF_WARP);
   dt_liquify_kernel_descriptor_t kdesc = { .size = 0, .resolution = 100 };
   float *k = NULL;
 

--- a/src/iop/rotatepixels.c
+++ b/src/iop/rotatepixels.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2014-2024 darktable developers.
+    Copyright (C) 2014-2025 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -220,7 +220,7 @@ void modify_roi_out(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, dt_iop
   const float y = sqrtf(2.0f * T * T),
               x = sqrtf(2.0f * ((float)roi_in->width - T) * ((float)roi_in->width - T));
 
-  const struct dt_interpolation *interpolation = dt_interpolation_new(DT_INTERPOLATION_USERPREF);
+  const dt_interpolation_t *interpolation = dt_interpolation_new(DT_INTERPOLATION_USERPREF);
   const float IW = (float)interpolation->width * scale;
 
   roi_out->width = y - IW;
@@ -254,7 +254,7 @@ void modify_roi_in(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const d
     adjust_aabb(o, aabb_in);
   }
 
-  const struct dt_interpolation *interpolation = dt_interpolation_new(DT_INTERPOLATION_USERPREF);
+  const dt_interpolation_t *interpolation = dt_interpolation_new(DT_INTERPOLATION_USERPREF);
   const float IW = (float)interpolation->width * scale;
 
   const float orig_w = roi_in->scale * piece->buf_in.width, orig_h = roi_in->scale * piece->buf_in.height;
@@ -284,7 +284,7 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
 
   assert(ch == 4);
 
-  const struct dt_interpolation *interpolation = dt_interpolation_new(DT_INTERPOLATION_USERPREF);
+  const dt_interpolation_t *interpolation = dt_interpolation_new(DT_INTERPOLATION_USERPREF);
 
   DT_OMP_FOR()
   // (slow) point-by-point transformation.

--- a/src/iop/scalepixels.c
+++ b/src/iop/scalepixels.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2014-2024 darktable developers.
+    Copyright (C) 2014-2025 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -205,7 +205,7 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
 {
   const int ch = piece->colors;
   const int ch_width = ch * roi_in->width;
-  const struct dt_interpolation *interpolation = dt_interpolation_new(DT_INTERPOLATION_USERPREF);
+  const dt_interpolation_t *interpolation = dt_interpolation_new(DT_INTERPOLATION_USERPREF);
   const dt_iop_scalepixels_data_t * const d = piece->data;
 
   DT_OMP_FOR()


### PR DESCRIPTION
1. clearer code and avoid struct casts
2. In demosaic take the faster dt_iop_copy_image_roi() if no scaling is requested