### PR TITLE
CI: add Windows on ARM64 nightly build

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -177,7 +177,7 @@ jobs:
   Windows:
     if: github.repository == 'darktable-org/darktable' || github.event_name == 'workflow_dispatch'
     name: Nightly darktable Windows
-    runs-on: windows-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: true
       matrix:
@@ -185,11 +185,17 @@ jobs:
           - Release
         msystem:
           - UCRT64
+          - CLANGARM64
         target:
           - skiptest
         generator:
           - Ninja
         eco: [-DBINARY_PACKAGE_BUILD=ON]
+        include:
+          - msystem: UCRT64
+            os: windows-latest
+          - msystem: CLANGARM64
+            os: windows-11-arm
     defaults:
       run:
         shell: msys2 {0}
@@ -214,7 +220,6 @@ jobs:
             cmake:p
             libxslt:p
             ninja:p
-            nsis:p
             python-jsonschema:p
             curl:p
             drmingw:p
@@ -304,7 +309,9 @@ jobs:
           iscc "darktable.iss"
           mv Output/*.exe ${{ env.BUILD_DIR }}/
       - name: Create NSIS installer
+        if: runner.arch != 'ARM64'
         run: |
+          pacboy --noconfirm -S --needed nsis:p
           cd "${BUILD_DIR}"
           cmake --build "${BUILD_DIR}" --target package
       - name: Get version info
@@ -432,7 +439,7 @@ jobs:
 
             The `*.AppImage.zsync` file is not intended to be downloaded and used locally. Just ignore it. This file contains technical information required by AppImage auto-updaters such as [AppImageUpdate](https://appimage.github.io/AppImageUpdate/).
 
-            The Windows package requires Windows with UCRT (Universal C Runtime), which is shipped with Windows 10+. Darktable should also work on Windows 8.1 [on condition that you install this runtime yourself](https://support.microsoft.com/en-us/topic/update-for-universal-c-runtime-in-windows-c0514201-7fe6-95a3-b0a5-287930f3560c).
+            The Windows package `*-win64.exe` requires Windows with UCRT (Universal C Runtime), which is shipped with Windows 10+. Darktable should also work on Windows 8.1 [on condition that you install this runtime yourself](https://support.microsoft.com/en-us/topic/update-for-universal-c-runtime-in-windows-c0514201-7fe6-95a3-b0a5-287930f3560c). The `*-woa64.exe` package requires at least Windows 11.
 
             The macOS package `*-arm64.dmg` requires at least macOS 14.0 (Sonoma). The `*-x86_64.dmg` package requires at least macOS 15.0 (Sequoia).
 


### PR DESCRIPTION
See https://www.msys2.org/news/#2025-04-18-hosted-windows-arm64-runners-on-github-actions