### PR TITLE
[geotagging]: remove gpx track on module reset

### DIFF
--- a/src/libs/geotagging.c
+++ b/src/libs/geotagging.c
@@ -1763,6 +1763,15 @@ void gui_reset(dt_lib_module_t *self)
   dt_lib_geotagging_t *d = self->data;
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->lock_offset), false);
   _refresh_image_datetime(self);
+
+#ifdef HAVE_MAP
+  if(d->map.view)
+  {
+    gtk_label_set_text(GTK_LABEL(d->map.gpx_file), "");
+    _remove_tracks_from_map(self);
+    gtk_widget_set_visible(d->map.gpx_view, FALSE);
+  }
+#endif
 }
 
 void gui_init(dt_lib_module_t *self)


### PR DESCRIPTION
Remove a loaded gpx track on module reset.

See https://github.com/darktable-org/darktable/pull/18706#issuecomment-2820146620