### PR TITLE
[README.md] Remove section on dealing with missing build dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,19 +239,6 @@ sudo rm /etc/apt/sources.list.d/darktable-sources-tmp.list
 sudo apt-get build-dep darktable
 ```
 
-#### Install missing dependencies
-
-If mandatory dependencies are missing on your system, the software build will fail with
-errors like `Package XXX has not been found` or `Command YYY has no provider on this system`.
-If you see one of these errors you should find out which package provides the missing package/command in your distribution,
-then install it. This can usually be done in your package manager (not the application manager
-customarily provided by default in your distribution) or from the internet with a search engine.
-You may need to install a package manager first (like APT on Debian/Ubuntu, or DNF on Fedora/RHEL).
-
-This process might be tedious but you only need to do it once. See
-[this page on building darktable](https://github.com/darktable-org/darktable/wiki/Building-darktable)
-for one-line commands that will install most dependencies on the most common Linux distributions.
-
 ### Get the source
 
 #### Master branch (unstable)


### PR DESCRIPTION
This text is so shoddy (and contains factual errors) that it is better to remove it completely:

- It mentions "package manager" and "application manager" without explaining what they are and how they differ (let's not forget, the text is aimed at beginners who do not know how to work with packages on their system). Actually, I don't know what the author (AP) meant by the term "application manager" either.

- The phrase `has no provider on this system', which is mentioned here, can be found on the net only in this README and nowhere else.

- The phrase that "You may need to install a package manager first" describes an extremely hypothetical situation that you will not encounter in practice. For example, talking about Debian:
While technically possible to bootstrap a Debian system without apt initially present (it would still need dpkg), it bypasses the standard installation procedures and results in a system that is extremely difficult to manage. The standard Debian installer always includes apt as part of the base system because it is the cornerstone of Debian's user-friendly package management. For any practical purpose, a Debian installation includes apt from the start.

- The advice to try to install a package somehow if you see the message "package not found" is one of the least useful pieces of advice I have come across in my life.

- Yes, there is a link to a wiki page that should contain specific advice for popular distributions. But this page is hopelessly outdated, no one updates it, and it talks about releases of distributions that are many years old.

- I also doubt that anyone would want to spend their time keeping this wiki page up to date.

- Since we started publishing nightly builds to give users a glimpse into the current state of development (as well as AppImages and OBS builds of stable versions for distributions that update late), there is no real need for users to build the program themselves. So such a text for newbie users who want to build darktable themselves is losing relevance.
