### PR TITLE
Make sure about a valid dt_get_num_procs()

### DIFF
--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -706,8 +706,7 @@ static inline size_t dt_get_num_threads()
 static inline size_t dt_get_num_procs()
 {
 #ifdef _OPENMP
-  // we can safely assume omp_get_num_procs is > 0
-  return (size_t)omp_get_num_procs();
+  return (size_t)MAX(1, omp_get_num_procs());
 #else
   return 1;
 #endif

--- a/src/common/imagebuf.c
+++ b/src/common/imagebuf.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2016-2024 darktable developers.
+    Copyright (C) 2016-2025 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -446,34 +446,6 @@ void dt_iop_image_mul_const(float *const buf,
   DT_OMP_SIMD(aligned(buf:16))
   for(size_t k = 0; k < nfloats; k++)
     buf[k] *= mul_value;
-}
-
-void dt_iop_image_div_const(float *const buf,
-                            const float div_value,
-                            const size_t width,
-                            const size_t height,
-                            const size_t ch)
-{
-  const size_t nfloats = width * height * ch;
-#ifdef _OPENMP
-  if(nfloats > parallel_imgop_minimum)	// is the copy big enough to outweigh threading overhead?
-  {
-    // we can gain a little by using a small number of threads in
-    // parallel, but not much since the memory bus quickly saturates
-    // (basically, each core can saturate a memory channel, so a
-    // system with quad-channel memory won't be able to take advantage
-    // of more than four cores).
-    const int nthreads = MIN(darktable.num_openmp_threads,parallel_imgop_maxthreads);
-    DT_OMP_FOR_SIMD(num_threads(nthreads) aligned(buf:16))
-    for(size_t k = 0; k < nfloats; k++)
-      buf[k] /= div_value;
-    return;
-  }
-#endif // _OPENMP
-  // no OpenMP, or image too small to bother parallelizing
-  DT_OMP_SIMD(aligned(buf:16))
-  for(size_t k = 0; k < nfloats; k++)
-    buf[k] /= div_value;
 }
 
 // elementwise: buf = lammda*buf + (1-lambda)*other

--- a/src/common/imagebuf.h
+++ b/src/common/imagebuf.h
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2016-2023 darktable developers.
+    Copyright (C) 2016-2025 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -153,13 +153,6 @@ void dt_iop_image_invert(float *const buf,
 // Multiply every element of the image buffer by a specified constant value
 void dt_iop_image_mul_const(float *const buf,
                             const float mul_value,
-                            const size_t width,
-                            const size_t height,
-                            const size_t ch);
-
-// Divide every element of the image buffer by a specified constant value
-void dt_iop_image_div_const(float *const buf,
-                            const float div_value,
                             const size_t width,
                             const size_t height,
                             const size_t ch);


### PR DESCRIPTION
The OpenMP omp_get_num_procs() does not gaurantee the returned value is > 0 so et's make sure.

dt_iop_image_div_const() is a) not used at all and b) had a bad check for available openmp procs so let's get rid of it.