### PR TITLE
Deactivate deprecated modules group for now

### DIFF
--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2011-2024 darktable developers.
+    Copyright (C) 2011-2025 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -1780,6 +1780,7 @@ void init_presets(dt_lib_module_t *self)
   dt_lib_presets_add(_("search only"),
                      self->plugin_name, self->version(), tx, strlen(tx), TRUE, 0);
 
+#if 0
   // this is a special preset for all newly deprecated modules
   // so users still have a chance to access them until next release (with warning messages)
   // this modules are deprecated in 3.4 and should be removed from this group in 3.8 (1 year later)
@@ -1791,6 +1792,7 @@ void init_presets(dt_lib_module_t *self)
 
   dt_lib_presets_add(_(DEPRECATED_PRESET_NAME),
                      self->plugin_name, self->version(), tx, strlen(tx), TRUE, 0);
+#endif
 
   g_free(tx);
 

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -1780,10 +1780,16 @@ void init_presets(dt_lib_module_t *self)
   dt_lib_presets_add(_("search only"),
                      self->plugin_name, self->version(), tx, strlen(tx), TRUE, 0);
 
+  // There is no need for the deprecated modules group now, as there have been
+  // no new module deprecations for a long time. The group is not for access
+  // to all once deprecated modules, it should only contain deprecated modules
+  // temporarily (planned for 1 year) to prepare users of these modules for
+  // the need to learn the replacement modules.
+  // We are not removing the following code, just commenting it out for possible
+  // updating if we decide to deprecate any modules again in the future.
 #if 0
-  // this is a special preset for all newly deprecated modules
-  // so users still have a chance to access them until next release (with warning messages)
-  // this modules are deprecated in 3.4 and should be removed from this group in 3.8 (1 year later)
+  // This is a special preset for all newly deprecated modules, so users still
+  // have a chance to access them until next release (with warning messages)
   SNQA();
   SMG(C_("modulegroup", "deprecated"), "basic");
   // these modules are deprecated in 4.4 and should be removed in 4.8 (1 year later)


### PR DESCRIPTION
The last module deprecation was done in February 2023 in #13497. We were going to keep such modules in the deprecated modules group for a year (like, enough time for the user to learn the replacement modules). However, with the last deprecated modules we forgot about that and they have been there for two and a half years. It is time to remove them completely. But since then there has been no module deprecation, so there is no point in having an empty group.