### PR TITLE
change auto-login tooltip description

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -2860,7 +2860,7 @@
     <type>bool</type>
     <default>false</default>
     <shortdescription>auto login to storage server</shortdescription>
-    <longdescription>automatically login to last used storage server. this requires that a password storage backend is set.</longdescription>
+    <longdescription>automatically login to the configured storage server. this requires that a password storage backend is set.</longdescription>
   </dtconfig>
   <dtconfig>
     <name>plugins/lighttable/export/icctype</name>


### PR DESCRIPTION
Changed the tooltip description from "_last used storage server_" to "_configured storage server_"

This should match both cases: Module configuration or preset.