### PR TITLE
Better calculation of cropped UI output dimension

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -2475,21 +2475,21 @@ gboolean dt_dev_get_preview_size(const dt_develop_t *dev,
   return *wd >= 1.f && *ht >= 1.f;
 }
 
-void dt_dev_get_processed_size(dt_dev_viewport_t *port,
-                               int *procw,
-                               int *proch)
+gboolean dt_dev_get_processed_size(dt_dev_viewport_t *port,
+                                  int *procw,
+                                  int *proch)
 {
   // no processed pipes, lets return 0 size
   *procw = *proch = 0;
 
-  if(!port) return;
+  if(!port) return FALSE;
 
   // if pipe is processed, lets return its size
   if(port->pipe && port->pipe->processed_width)
   {
     *procw = port->pipe->processed_width;
     *proch = port->pipe->processed_height;
-    return;
+    return TRUE;
   }
 
   dt_develop_t *dev = darktable.develop;
@@ -2501,6 +2501,7 @@ void dt_dev_get_processed_size(dt_dev_viewport_t *port,
     *procw = scale * dev->preview_pipe->processed_width;
     *proch = scale * dev->preview_pipe->processed_height;
   }
+  return FALSE;
 }
 
 static float _calculate_new_scroll_zoom_tscale(const int up,

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -420,9 +420,10 @@ void dt_dev_reprocess_preview(dt_develop_t *dev);
 gboolean dt_dev_get_preview_size(const dt_develop_t *dev,
                                  float *wd,
                                  float *ht);
-void dt_dev_get_processed_size(dt_dev_viewport_t *port,
-                               int *procw,
-                               int *proch);
+// return TRUE in case we got it from current port instead of preview
+gboolean dt_dev_get_processed_size(dt_dev_viewport_t *port,
+                                   int *procw,
+                                   int *proch);
 gboolean dt_dev_get_zoom_bounds(dt_dev_viewport_t *port,
                                 float *zoom_x,
                                 float *zoom_y,


### PR DESCRIPTION
While setting the crops we get a feedback about it's resulting width & height.

In `modify_roi_out()` and `modify_roi_in()` the position and width are set to the floored values to guarantee we stay inside available data range.

Let's report the floored value in expose instead of what we did, also via -d verbose log.

Related to #18781

Also see #18784