### PR TITLE
add apply_sidecar function to dt_lua_image_t

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -183,11 +183,12 @@ changes (where available).
 
 ### API Version
 
-- API version is now 9.4.0
+- API version is now 9.5.0
 
 ### New Features
 
-- N/A
+- Added apply_sidecar to dt_lua_image_t so that a sidecar file can be loaded
+  and applied to an image in lighttable.
 
 ### Bug Fixes
 

--- a/src/lua/configuration.h
+++ b/src/lua/configuration.h
@@ -41,10 +41,11 @@
 // 4.6.0 was 9.2.0 (added change_timestamp to dt_image_t)
 // 4.8.0 was 9.3.0 (added button and box widget enhancements)
 // 5.0.0 was 9.4.0 (added group events and uuid)
+// 5.2.0 was 9.5.0 (added apply_sidecar to image)
 /* incompatible API change */
 #define LUA_API_VERSION_MAJOR 9
 /* backward compatible API change */
-#define LUA_API_VERSION_MINOR 4
+#define LUA_API_VERSION_MINOR 5
 /* bugfixes that should not change anything to the API */
 #define LUA_API_VERSION_PATCH 0
 /* suffix for unstable version */

--- a/src/lua/image.c
+++ b/src/lua/image.c
@@ -93,6 +93,18 @@ static int history_delete(lua_State *L)
   return 0;
 }
 
+static int apply_sidecar(lua_State *L)
+{
+  dt_lua_image_t imgid = NO_IMGID;
+  gchar filename[PATH_MAX] = { 0 };
+  luaA_to(L, dt_lua_image_t, &imgid, 1);
+  const char *sidecar = luaL_checkstring(L, 2);
+  g_strlcpy(filename, sidecar, PATH_MAX);
+  gboolean result = dt_history_load_and_apply(imgid, filename, 0);
+  lua_pushboolean(L, !result);
+  return 1;
+}
+
 static int drop_cache(lua_State *L)
 {
   dt_lua_image_t imgid = NO_IMGID;
@@ -666,6 +678,9 @@ int dt_lua_init_image(lua_State *L)
   lua_pushcfunction(L, generate_cache);
   lua_pushcclosure(L, dt_lua_type_member_common, 1);
   dt_lua_type_register_const(L, dt_lua_image_t, "generate_cache");
+  lua_pushcfunction(L, apply_sidecar);
+  lua_pushcclosure(L, dt_lua_type_member_common, 1);
+  dt_lua_type_register_const(L, dt_lua_image_t, "apply_sidecar");
   lua_pushcfunction(L, image_tostring);
   dt_lua_type_setmetafield(L,dt_lua_image_t,"__tostring");
 


### PR DESCRIPTION
apply_sidecar allows a sidecar file to be applied from a Lua script.

Fixes #16599.

Bumped API version to 9.5.0

Added Lua section to RELEASE_NOTES.md