### PR TITLE
[imageio] TIFF loader: a fallback loader must be called for unsupported features

### DIFF
--- a/src/imageio/imageio_tiff.c
+++ b/src/imageio/imageio_tiff.c
@@ -417,7 +417,7 @@ dt_imageio_retval_t dt_imageio_open_tiff(dt_image_t *img,
              "[tiff_open] error: unsupported CMYK (or multi-ink) in '%s'",
              filename);
     TIFFClose(t.tiff);
-    return DT_IMAGEIO_UNSUPPORTED_FEATURE;
+    return DT_IMAGEIO_UNSUPPORTED_FORMAT;
   }
 
   if(TIFFRasterScanlineSize(t.tiff) != TIFFScanlineSize(t.tiff))
@@ -439,7 +439,7 @@ dt_imageio_retval_t dt_imageio_open_tiff(dt_image_t *img,
     dt_print(DT_DEBUG_ALWAYS,
              "[tiff_open] error: unsupported bit depth other than 8, 16 or 32 in '%s'",
              filename);
-    return DT_IMAGEIO_UNSUPPORTED_FEATURE;
+    return DT_IMAGEIO_UNSUPPORTED_FORMAT;
   }
 
   /* don't depend on planar config if spp == 1 */
@@ -449,7 +449,7 @@ dt_imageio_retval_t dt_imageio_open_tiff(dt_image_t *img,
              "[tiff_open] error: unsupported non-chunky PlanarConfiguration in '%s'",
              filename);
     TIFFClose(t.tiff);
-    return DT_IMAGEIO_UNSUPPORTED_FEATURE;
+    return DT_IMAGEIO_UNSUPPORTED_FORMAT;
   }
 
   /* initialize cached image buffer */
@@ -528,7 +528,7 @@ dt_imageio_retval_t dt_imageio_open_tiff(dt_image_t *img,
              "[tiff_open] error: unsupported TIFF format feature in '%s'",
              filename);
     ok = 0;
-    ret = DT_IMAGEIO_UNSUPPORTED_FEATURE;
+    ret = DT_IMAGEIO_UNSUPPORTED_FORMAT;
   }
 
   _TIFFfree(t.buf);


### PR DESCRIPTION
With the re-architecting of imageio in dt 5.0, an additional return code `DT_IMAGEIO_UNSUPPORTED_FEATURE` was introduced.

The idea was to give the user additional information about the reason for the failure. Indeed, it would be nice to see that the file is not, say, irretrievably corrupted, but simply contains format features that we cannot handle.

However, to preserve this information about the cause of failure, we did not call the fallback loaders when such a code was returned.

Our native libtiff-based loader can read and interpret the most common variations of the format, but not all possible ones. At the same time, the fallback loaders (GraphicsMagick or ImageMagick) support all possible variations of the format. Thus, returning DT_IMAGEIO_UNSUPPORTED_FEATURE in the native TIFF loader is a mistake, as it causes the read to fail, although the fallback loader would have been able to read such a file successfully.

Because of this, we lost the ability to read more exotic variations of the TIFF format that we did not support in the native loader.
These are, for example:
- files with less common bits per sample values (such as 12 or 14 bits, or less than 8)
- files with a planar layout (when not all channels of one pixel are located next to each other, but all data from one channel)
- files where tiles are encoded instead of consecutive image lines

This PR changes DT_IMAGEIO_UNSUPPORTED_FEATURE return code to one that causes the fallback loader to be called.
