### PR TITLE
Some OpenCL and interpolation maintenance 

### DIFF
--- a/data/kernels/basecurve.cl
+++ b/data/kernels/basecurve.cl
@@ -1,7 +1,6 @@
 /*
     This file is part of darktable,
-    copyright (c) 2016 johannes hanika.
-    copyright (c) 2016 Ulrich Pegelow.
+    copyright (c) 2016-2025 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -104,17 +103,17 @@ basecurve_compute_features(read_only image2d_t in, write_only image2d_t out, con
 
   float4 value = read_imagef(in, sampleri, (int2)(x, y));
 
-  const float ma = max(value.x, max(value.y, value.z));
-  const float mi = min(value.x, min(value.y, value.z));
+  const float ma = fmax(value.x, fmax(value.y, value.z));
+  const float mi = fmin(value.x, fmin(value.y, value.z));
 
-  const float sat = 0.1f + 0.1f * (ma - mi) / max(1.0e-4f, ma);
+  const float sat = 0.1f + 0.1f * (ma - mi) / fmax(1.0e-4f, ma);
   value.w = sat;
 
   const float c = 0.54f;
 
   float v = fabs(value.x - c);
-  v = max(fabs(value.y - c), v);
-  v = max(fabs(value.z - c), v);
+  v = fmax(fabs(value.y - c), v);
+  v = fmax(fabs(value.z - c), v);
 
   const float var = 0.5f;
   const float e = 0.2f + dt_fast_expf(-v * v / (var * var));

--- a/data/kernels/basic.cl
+++ b/data/kernels/basic.cl
@@ -1,9 +1,6 @@
 /*
     This file is part of darktable,
-    copyright (c) 2009-2013 johannes hanika.
-    copyright (c) 2014 Ulrich Pegelow.
-    copyright (c) 2014 LebedevRI.
-    Copyright (C) 2022-2024 darktable developers.
+    Copyright (C) 2009-2025 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -597,8 +594,8 @@ highlights_1f_lch_bayer (read_only image2d_t in, write_only image2d_t out, const
           R = val;
           break;
         case 1:
-          Gmin = min(Gmin, val);
-          Gmax = max(Gmax, val);
+          Gmin = fmin(Gmin, val);
+          Gmax = fmax(Gmax, val);
           break;
         case 2:
           B = val;
@@ -609,9 +606,9 @@ highlights_1f_lch_bayer (read_only image2d_t in, write_only image2d_t out, const
 
   if(clipped)
   {
-    const float Ro = min(R, clip);
-    const float Go = min(Gmin, clip);
-    const float Bo = min(B, clip);
+    const float Ro = fmin(R, clip);
+    const float Go = fmin(Gmin, clip);
+    const float Bo = fmin(B, clip);
 
     const float L = (R + Gmax + B) / 3.0f;
 
@@ -696,7 +693,7 @@ highlights_1f_lch_xtrans (read_only image2d_t in, write_only image2d_t out, cons
   if(x < 2 || x > width - 3 || y < 2 || y > height - 3)
   {
     // fast path for border
-    pixel = min(clip, buffer[0]);
+    pixel = fmin(clip, buffer[0]);
   }
   else
   {
@@ -746,13 +743,13 @@ highlights_1f_lch_xtrans (read_only image2d_t in, write_only image2d_t out, cons
           const int c = FCxtrans(y + jj + ry, x + ii + rx, xtrans);
           mean[c] += val;
           cnt[c]++;
-          RGBmax[c] = max(RGBmax[c], val);
+          RGBmax[c] = fmax(RGBmax[c], val);
         }
       }
 
-      const float Ro = min(mean[0]/cnt[0], clip);
-      const float Go = min(mean[1]/cnt[1], clip);
-      const float Bo = min(mean[2]/cnt[2], clip);
+      const float Ro = fmin(mean[0]/cnt[0], clip);
+      const float Go = fmin(mean[1]/cnt[1], clip);
+      const float Bo = fmin(mean[2]/cnt[2], clip);
 
       const float R = RGBmax[0];
       const float G = RGBmax[1];
@@ -1063,14 +1060,8 @@ guide_laplacians(read_only image2d_t HF,
   if(alpha > 0.f) // reconstruct
   {
     // non-local neighbours coordinates
-    const int j_neighbours[3] = {
-      max(x - mult, 0),
-      x,
-      min(x + mult, width - 1) };
-    const int i_neighbours[3] = {
-      max(y - mult, 0),
-      y,
-      min(y + mult, height - 1) };
+    const int j_neighbours[3] = { max(x - mult, 0), x, min(x + mult, width - 1) };
+    const int i_neighbours[3] = { max(y - mult, 0), y, min(y + mult, height - 1) };
 
     // fetch non-local pixels and store them locally and contiguously
     float4 neighbour_pixel_HF[9];
@@ -1253,14 +1244,8 @@ diffuse_color(read_only image2d_t HF,
   if(alpha.w > 0.f) // reconstruct
   {
     // non-local neighbours coordinates
-    const int j_neighbours[3] = {
-      max(x - mult, 0),
-      x,
-      min(x + mult, width - 1) };
-    const int i_neighbours[3] = {
-      max(y - mult, 0),
-      y,
-      min(y + mult, height - 1) };
+    const int j_neighbours[3] = { max(x - mult, 0), x, min(x + mult, width - 1) };
+    const int i_neighbours[3] = { max(y - mult, 0), y, min(y + mult, height - 1) };
 
     // fetch non-local pixels and store them locally and contiguously
     float4 neighbour_pixel_HF[9];
@@ -2786,7 +2771,7 @@ kernel void lens_man_vignette(read_only image2d_t in,
   const float dx = ((float)(roix + x) - w2);
   const float dy = ((float)(roiy + y) - h2);
   const float radius = sqrt(dx*dx + dy*dy) * inv_maxr;
-  const float4 val = max(0.0f, intensity * _calc_vignette_spline(radius, spline, splinesize));
+  const float4 val = fmax(0.0f, intensity * _calc_vignette_spline(radius, spline, splinesize));
 
   float4 pixel  = read_imagef(in, samplerA, (int2)(x, y));
   const float mask = pixel.w;

--- a/data/kernels/bilateral.cl
+++ b/data/kernels/bilateral.cl
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    copyright (c) 2012 johannes hanika.
+    copyright (c) 2012-2025 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -21,7 +21,7 @@
 float4
 image_to_grid(
     const float4 p,
-    const int4   size,
+    const int4 size,
     const float4 sigma)
 {
   return (float4)(
@@ -326,7 +326,7 @@ slice_to_output(
         grid[gi+ox+oz]    * (       fx) * (1.0f - fy) * (       fz) +
         grid[gi+oy+oz]    * (1.0f - fx) * (       fy) * (       fz) +
         grid[gi+ox+oy+oz] * (       fx) * (       fy) * (       fz);
-  pixel2.x = max(0.0f, pixel2.x + norm * Ldiff);
+  pixel2.x = fmax(0.0f, pixel2.x + norm * Ldiff);
   write_imagef (out, (int2)(x, y), pixel2);
 }
 
@@ -378,7 +378,7 @@ slice(
         grid[gi+ox+oz]    * (       fx) * (1.0f - fy) * (       fz) +
         grid[gi+oy+oz]    * (1.0f - fx) * (       fy) * (       fz) +
         grid[gi+ox+oy+oz] * (       fx) * (       fy) * (       fz);
-  pixel.x = max(0.0f, L + norm * Ldiff);
+  pixel.x = fmax(0.0f, L + norm * Ldiff);
   write_imagef (out, (int2)(x, y), pixel);
 }
 

--- a/data/kernels/denoiseprofile.cl
+++ b/data/kernels/denoiseprofile.cl
@@ -1,7 +1,6 @@
 /*
     This file is part of darktable,
-    copyright (c) 2011 johannes hanika.
-    copyright (c) 2012--2013 Ulrich Pegelow.
+    copyright (c) 2011-2025 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/data/kernels/filmic.cl
+++ b/data/kernels/filmic.cl
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    copyright (c) 2018-2020 darktable developers.
+    copyright (c) 2018-2025 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -94,7 +94,7 @@ filmic (read_only image2d_t in, write_only image2d_t out, int width, int height,
   {
 
     // Save the ratios
-    float maxRGB = max(max(o.x, o.y), o.z);
+    float maxRGB = fmax(fmax(o.x, o.y), o.z);
     const float4 ratios = o / (float4)maxRGB;
 
     // Log profile

--- a/data/kernels/gaussian.cl
+++ b/data/kernels/gaussian.cl
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    copyright (c) 2011-2024 darktable developer.
+    copyright (c) 2011-2025 darktable developer.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/data/kernels/hazeremoval.cl
+++ b/data/kernels/hazeremoval.cl
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    copyright (c) 2019-2024 darktable developers.
+    copyright (c) 2019-2025 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -34,9 +34,9 @@ kernel void hazeremoval_box_min_x(const int width, const int height, read_only i
     {
       m = INFINITY;
       for(int j = max(i - w + 1, 0), j_end = min(i + w + 2, width); j < j_end; ++j)
-        m = min(read_imagef(in, sampleri, (int2)(j, y)).x, m);
+        m = fmin(read_imagef(in, sampleri, (int2)(j, y)).x, m);
     }
-    if(i + w + 1 < width) m = min(read_imagef(in, sampleri, (int2)(i + w + 1, y)).x, m);
+    if(i + w + 1 < width) m = fmin(read_imagef(in, sampleri, (int2)(i + w + 1, y)).x, m);
   }
 }
 
@@ -48,7 +48,8 @@ kernel void hazeremoval_box_min_y(const int width, const int height, read_only i
   if(x >= width) return;
 
   float m = INFINITY;
-  for(int i = 0, i_end = min(w + 1, height); i < i_end; ++i) m = min(read_imagef(in, sampleri, (int2)(x, i)).x, m);
+  for(int i = 0, i_end = min(w + 1, height); i < i_end; ++i)
+    m = fmin(read_imagef(in, sampleri, (int2)(x, i)).x, m);
   for(int i = 0; i < height; i++)
   {
     write_imagef(out, (int2)(x, i), (float4)(m, 0.f, 0.f, 0.f));
@@ -56,9 +57,9 @@ kernel void hazeremoval_box_min_y(const int width, const int height, read_only i
     {
       m = INFINITY;
       for(int j = max(i - w + 1, 0), j_end = min(i + w + 2, height); j < j_end; ++j)
-        m = min(read_imagef(in, sampleri, (int2)(x, j)).x, m);
+        m = fmin(read_imagef(in, sampleri, (int2)(x, j)).x, m);
     }
-    if(i + w + 1 < height) m = min(read_imagef(in, sampleri, (int2)(x, i + w + 1)).x, m);
+    if(i + w + 1 < height) m = fmin(read_imagef(in, sampleri, (int2)(x, i + w + 1)).x, m);
   }
 }
 
@@ -70,7 +71,8 @@ kernel void hazeremoval_box_max_x(const int width, const int height, read_only i
   if(y >= height) return;
 
   float m = -(INFINITY);
-  for(int i = 0, i_end = min(w + 1, width); i < i_end; ++i) m = max(read_imagef(in, sampleri, (int2)(i, y)).x, m);
+  for(int i = 0, i_end = min(w + 1, width); i < i_end; ++i)
+    m = fmax(read_imagef(in, sampleri, (int2)(i, y)).x, m);
   for(int i = 0; i < width; i++)
   {
     write_imagef(out, (int2)(i, y), (float4)(m, 0.f, 0.f, 0.f));
@@ -78,9 +80,9 @@ kernel void hazeremoval_box_max_x(const int width, const int height, read_only i
     {
       m = -(INFINITY);
       for(int j = max(i - w + 1, 0), j_end = min(i + w + 2, width); j < j_end; ++j)
-        m = max(read_imagef(in, sampleri, (int2)(j, y)).x, m);
+        m = fmax(read_imagef(in, sampleri, (int2)(j, y)).x, m);
     }
-    if(i + w + 1 < width) m = max(read_imagef(in, sampleri, (int2)(i + w + 1, y)).x, m);
+    if(i + w + 1 < width) m = fmax(read_imagef(in, sampleri, (int2)(i + w + 1, y)).x, m);
   }
 }
 
@@ -92,7 +94,8 @@ kernel void hazeremoval_box_max_y(const int width, const int height, read_only i
   if(x >= width) return;
 
   float m = -(INFINITY);
-  for(int i = 0, i_end = min(w + 1, height); i < i_end; ++i) m = max(read_imagef(in, sampleri, (int2)(x, i)).x, m);
+  for(int i = 0, i_end = min(w + 1, height); i < i_end; ++i)
+    m = fmax(read_imagef(in, sampleri, (int2)(x, i)).x, m);
   for(int i = 0; i < height; i++)
   {
     write_imagef(out, (int2)(x, i), (float4)(m, 0.f, 0.f, 0.f));
@@ -100,9 +103,9 @@ kernel void hazeremoval_box_max_y(const int width, const int height, read_only i
     {
       m = -(INFINITY);
       for(int j = max(i - w + 1, 0), j_end = min(i + w + 2, height); j < j_end; ++j)
-        m = max(read_imagef(in, sampleri, (int2)(x, j)).x, m);
+        m = fmax(read_imagef(in, sampleri, (int2)(x, j)).x, m);
     }
-    if(i + w + 1 < height) m = max(read_imagef(in, sampleri, (int2)(x, i + w + 1)).x, m);
+    if(i + w + 1 < height) m = fmax(read_imagef(in, sampleri, (int2)(x, i + w + 1)).x, m);
   }
 }
 
@@ -117,8 +120,8 @@ kernel void hazeremoval_transision_map(const int width, const int height, read_o
 
   const float4 pixel = read_imagef(in, sampleri, (int2)(x, y));
   float m = pixel.x / A0_r;
-  m = min(pixel.y / A0_g, m);
-  m = min(pixel.z / A0_b, m);
+  m = fmin(pixel.y / A0_g, m);
+  m = fmin(pixel.z / A0_b, m);
   write_imagef(out, (int2)(x, y), (float4)(1.f - m * strength, 0.f, 0.f, 0.f));
 }
 
@@ -132,7 +135,7 @@ kernel void hazeremoval_dehaze(const int width, const int height, read_only imag
   if(x >= width || y >= height) return;
 
   const float4 pixel = read_imagef(in, sampleri, (int2)(x, y));
-  const float t = max(read_imagef(trans_map, sampleri, (int2)(x, y)).x, t_min);
+  const float t = fmax(read_imagef(trans_map, sampleri, (int2)(x, y)).x, t_min);
   write_imagef(
       out, (int2)(x, y),
       (float4)((pixel.x - A0_r) / t + A0_r, (pixel.y - A0_g) / t + A0_g, (pixel.z - A0_b) / t + A0_b, pixel.w));

--- a/data/kernels/lut3d.cl
+++ b/data/kernels/lut3d.cl
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    copyright (c) 2019 philippe weyland.
+    copyright (c) 2019-2025 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/data/kernels/rgb_norms.h
+++ b/data/kernels/rgb_norms.h
@@ -1,6 +1,6 @@
 /*
  *    This file is part of darktable,
- *    Copyright (C) 2019-2020 darktable developers.
+ *    Copyright (C) 2019-2025 darktable developers.
  *
  *    darktable is free software: you can redistribute it and/or modify
  *    it under the terms of the GNU General Public License as published by
@@ -37,7 +37,7 @@ dt_rgb_norm(const float4 in, const int norm, const int work_profile,
   }
   else if (norm == DT_RGB_NORM_MAX)
   {
-    return max(in.x, max(in.y, in.z));
+    return fmax(in.x, fmax(in.y, in.z));
   }
   else if (norm == DT_RGB_NORM_AVERAGE)
   {

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -1134,10 +1134,9 @@ void distort_mask(dt_iop_module_t *self,
       pin[1] -= roi_in->y;
 
       // get output values by interpolation from input image
-      _out[i] = MIN(1.0f, dt_interpolation_compute_sample(interpolation, in,
-                                                pin[0], pin[1],
-                                                roi_in->width, roi_in->height,
-                                                1, roi_in->width));
+      _out[i] = CLIP(dt_interpolation_compute_sample(interpolation, in,
+                                                     pin[0], pin[1],
+                                                     roi_in->width, roi_in->height, 1, roi_in->width));
     }
   }
 }

--- a/src/iop/clipping.c
+++ b/src/iop/clipping.c
@@ -672,8 +672,9 @@ void distort_mask(dt_iop_module_t *self,
         po[0] -= roi_in->x + 0.5f;
         po[1] -= roi_in->y + 0.5f;
 
-        _out[i] = MIN(1.0f, dt_interpolation_compute_sample(interpolation, in, po[0], po[1], roi_in->width, roi_in->height, 1,
-                                                  roi_in->width));
+        _out[i] = CLIP(dt_interpolation_compute_sample(interpolation, in,
+                                                       po[0], po[1],
+                                                       roi_in->width, roi_in->height, 1, roi_in->width));
       }
     }
   }

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -1125,9 +1125,9 @@ static void _process_lf(dt_iop_module_t *self,
             const float pi1 = fmaxf(fminf(bufptr[c * 2 + 1] - roi_in->y,
                                           roi_in->height - 1.0f),
                                     0.0f);
-            out[c] = dt_interpolation_compute_sample
-              (interpolation, inptr, pi0, pi1, roi_in->width,
-               roi_in->height, ch, ch_width);
+            out[c] = dt_interpolation_compute_sample(interpolation, inptr,
+                                                     pi0, pi1,
+                                                     roi_in->width, roi_in->height, ch, ch_width);
           }
 
           if(mask_display & DT_DEV_PIXELPIPE_DISPLAY_MASK)
@@ -1148,9 +1148,9 @@ static void _process_lf(dt_iop_module_t *self,
             const float pi1 = fmaxf(fminf(bufptr[3] - roi_in->y,
                                           roi_in->height - 1.0f),
                                     0.0f);
-            out[3] = dt_interpolation_compute_sample
-              (interpolation, inptr, pi0, pi1, roi_in->width,
-               roi_in->height, ch, ch_width);
+            out[3] = dt_interpolation_compute_sample(interpolation, inptr,
+                                                     pi0, pi1,
+                                                     roi_in->width, roi_in->height, ch, ch_width);
           }
         }
       }
@@ -1235,11 +1235,9 @@ static void _process_lf(dt_iop_module_t *self,
                                           roi_in->width - 1.0f), 0.0f);
             const float pi1 = fmaxf(fminf(buf2ptr[c * 2 + 1] - roi_in->y,
                                           roi_in->height - 1.0f), 0.0f);
-            out[c] = dt_interpolation_compute_sample(interpolation,
-                                                     bufptr, pi0, pi1,
-                                                     roi_in->width,
-                                                     roi_in->height, ch,
-                                                     ch_width);
+            out[c] = dt_interpolation_compute_sample(interpolation, bufptr,
+                                                     pi0, pi1,
+                                                     roi_in->width, roi_in->height, ch, ch_width);
           }
 
           if(mask_display & DT_DEV_PIXELPIPE_DISPLAY_MASK)
@@ -1687,9 +1685,9 @@ static void _distort_mask_lf(dt_iop_module_t *self,
       // take green channel distortion also for alpha channel
       const float pi0 = bufptr[2] - roi_in->x;
       const float pi1 = bufptr[3] - roi_in->y;
-      *_out = MIN(1.0f, dt_interpolation_compute_sample(interpolation, in, pi0, pi1,
-                                              roi_in->width, roi_in->height, 1,
-                                              roi_in->width));
+      *_out = CLIP(dt_interpolation_compute_sample(interpolation, in,
+                                                   pi0, pi1,
+                                                   roi_in->width, roi_in->height, 1, roi_in->width));
     }
   }
   dt_free_align(buf);
@@ -2729,11 +2727,9 @@ static void _distort_mask_md(dt_iop_module_t *self,
                                    d->nc, r*sqrtf(cx*cx + cy*cy));
       const float xs = CLAMP(dr*cx + w2 - roi_in->x, 0.0f, limw);
       const float ys = CLAMP(dr*cy + h2 - roi_in->y, 0.0f, limh);
-      out[y * roi_out->width + x] =
-        MIN(1.0f, dt_interpolation_compute_sample(interpolation, in, xs, ys,
-                                        roi_in->width,
-                                        roi_in->height,
-                                        1, roi_in->width));
+      out[y * roi_out->width + x] = CLIP(dt_interpolation_compute_sample(interpolation, in,
+                                                                         xs, ys,
+                                                                         roi_in->width, roi_in->height, 1, roi_in->width));
     }
   }
 }
@@ -2814,9 +2810,9 @@ static void _process_md(dt_iop_module_t *self,
           _interpolate_linear_spline(d->knots_dist, d->cor_rgb[plane], d->nc, radius);
         const float xs = CLAMP(dr*cx + w2 - roi_in->x, 0.0f, limw);
         const float ys = CLAMP(dr*cy + h2 - roi_in->y, 0.0f, limh);
-        out[odx+c] = dt_interpolation_compute_sample
-          (interpolation, buf + c, xs, ys, roi_in->width,
-           roi_in->height, 4, 4*roi_in->width);
+        out[odx+c] = dt_interpolation_compute_sample(interpolation, buf + c,
+                                                     xs, ys,
+                                                     roi_in->width, roi_in->height, 4, 4*roi_in->width);
       }
     }
   }

--- a/src/iop/liquify.c
+++ b/src/iop/liquify.c
@@ -1039,14 +1039,9 @@ static void _apply_global_distortion_map(dt_iop_module_t *self,
       if(*row != 0) // point actually warped?
       {
         if(ch == 1) // handle masks
-          out_sample[x] = MIN(1.0f, dt_interpolation_compute_sample(interpolation,
-                                                          in,
-                                                          x + crealf(*row) - roi_in->x,
-                                                          y + cimagf(*row) - roi_in->y,
-                                                          roi_in->width,
-                                                          roi_in->height,
-                                                          ch,
-                                                          ch_width));
+          out_sample[x] = CLIP(dt_interpolation_compute_sample(interpolation, in,
+                                                               x + crealf(*row) - roi_in->x, y + cimagf(*row) - roi_in->y,
+                                                               roi_in->width, roi_in->height, 1, ch_width));
         else
           dt_interpolation_compute_pixel4c(
             interpolation,


### PR DESCRIPTION
Some OpenCL maintenance

1. Updated copyrights to darktable developers
2. If using floats it's better to use `fmin()` `fmax()` instead of `min()` `max()` to safely handle NaN.
   Otherwise the returned value would be undefined - depending on compiler.
   (This could possibly fix issues with some drivers)

_________________________________________________________________________________________
Make sure distorted mask data stay inside the 0->1 range

Interpolators could possibly also produce undershoots so masks could get out of bounds