### PR TITLE
[GUI] No need for empty line output in splash screen progress area

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1849,8 +1849,6 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
   // after the following Lua startup call, we can no longer use dt_gui_process_events() or we hang;
   // this also means no more calls to darktable_splash_screen_set_progress()
   dt_lua_init(darktable.lua_state.state, lua_command);
-#else
-  darktable_splash_screen_set_progress(_(""));
 #endif
 
   if(init_gui)


### PR DESCRIPTION
Actually what first caught my attention was that the empty string is being passed through l10n (`_("")`). It didn't make sense to do that. But looking at the context it became obvious that there is no point in this call that outputs an empty line to the progress area of the splash screen. This causes the text to disappear for a short (but noticeable to the user) time before either closing the splash window or displaying the final message about importing the image. It looks somewhat unexpected and unnatural.