### PR TITLE
[imageio] TIFF loader: offload tiled image to the fallback loader explicitly

### DIFF
--- a/src/imageio/imageio_tiff.c
+++ b/src/imageio/imageio_tiff.c
@@ -396,6 +396,19 @@ dt_imageio_retval_t dt_imageio_open_tiff(dt_image_t *img,
 
   if(t.tiff == NULL) return DT_IMAGEIO_LOAD_FAILED;
 
+  // This loader does not implement reading of tiled files, so we explicitly
+  // offload them to the fallback (Graphics/Image)Magic loader ASAP instead
+  // of going as far as trying to read the scanline and exiting the loader
+  // due to TIFFReadScanline failure.
+  if(TIFFIsTiled(t.tiff))
+  {
+    dt_print(DT_DEBUG_ALWAYS,
+             "[tiff_open] error: tiled TIFF is not supported in '%s'",
+             filename);
+    TIFFClose(t.tiff);
+    return DT_IMAGEIO_LOAD_FAILED;
+  }
+
   TIFFGetField(t.tiff, TIFFTAG_IMAGEWIDTH, &t.width);
   TIFFGetField(t.tiff, TIFFTAG_IMAGELENGTH, &t.height);
   TIFFGetField(t.tiff, TIFFTAG_BITSPERSAMPLE, &t.bpp);


### PR DESCRIPTION
We won't get any noticeable acceleration from this PR, although we avoid unnecessary code execution up to the point of trying to read the scanline, which will fail for tiled TIFF.

This PR is more about reducing the cognitive complexity of the data-driven execution flow of this loader (well, real complexity, not what static code analyzers can measure). Now when reading the code, we immediately see what happens when trying to load a tiled TIFF, there is no need to read almost the entire code and know for sure that the scanline reading interface will not work with tiled TIFFs...