### PR TITLE
[imageio] TIFF loader: Invert grayscale images with min-is-white interpretation

### DIFF
--- a/src/imageio/imageio_tiff.c
+++ b/src/imageio/imageio_tiff.c
@@ -85,8 +85,10 @@ static inline float _half_to_float(uint16_t h)
 }
 #endif
 
-static inline int _read_chunky_8(tiff_t *t)
+static inline int _read_chunky_8(tiff_t *t, uint16_t photometric)
 {
+  gboolean need_invert = (photometric == PHOTOMETRIC_MINISWHITE);
+
   for(uint32_t row = 0; row < t->height; row++)
   {
     uint8_t *in = ((uint8_t *)t->buf);
@@ -98,7 +100,9 @@ static inline int _read_chunky_8(tiff_t *t)
     for(uint32_t i = 0; i < t->width; i++, in += t->spp, out += 4)
     {
       /* set rgb to first sample from scanline */
-      out[0] = ((float)in[0]) * (1.0f / 255.0f);
+      out[0] = need_invert
+               ? 1.0f - ((float)in[0]) * (1.0f / 255.0f)
+               :        ((float)in[0]) * (1.0f / 255.0f);
 
       if(t->spp < 3)  // mono, maybe plus alpha channel
       {
@@ -508,7 +512,7 @@ dt_imageio_retval_t dt_imageio_open_tiff(dt_image_t *img,
   }
   else if(t.bpp == 8 && t.sampleformat == SAMPLEFORMAT_UINT)
   {
-    ok = _read_chunky_8(&t);
+    ok = _read_chunky_8(&t, photometric);
   }
   else if(t.bpp == 16 && t.sampleformat == SAMPLEFORMAT_UINT)
   {


### PR DESCRIPTION
Grayscale TIFF images can have from 1 to 8 bits per sample (bps). Images with < 8 bps are offloaded to a fallback (*Magick) loader, 8 bps is handled by the native loader itself. But so far we have not taken into account that with photometric interpretation `PHOTOMETRIC_MINISWHITE` we need to invert the pixel values.

For testing, you can use, for example, [this file](https://github.com/mike-lischke/GraphicEx/blob/master/TestSuite%20original/TIFF/Official%20test%20images/cramps.tif)
