### PR TITLE
Reset final_width/height when doing flip in lighttable.

### DIFF
--- a/src/common/image.c
+++ b/src/common/image.c
@@ -863,6 +863,18 @@ void dt_image_update_final_size(const dt_imgid_t imgid)
       }
     }
   }
+  else
+  {
+    // on lighttable, cannot run a pipe, reset to force proper values to be recomputed
+    // later.
+    dt_image_t *imgtmp = dt_image_cache_get(imgid, 'w');
+    if(imgtmp)
+    {
+      imgtmp->final_width = 0;
+      imgtmp->final_height = 0;
+      dt_image_cache_write_release(imgtmp, DT_IMAGE_CACHE_RELAXED);
+    }
+  }
 }
 
 gboolean dt_image_get_final_size(const dt_imgid_t imgid, int *width, int *height)


### PR DESCRIPTION
Reset the final_width/height to 0 to force recomputation when needed.

Fixes #17680.