### PR TITLE
avoid crashes by negative height in drawingarea.c

### DIFF
--- a/src/dtgtk/drawingarea.c
+++ b/src/dtgtk/drawingarea.c
@@ -91,7 +91,7 @@ void dtgtk_drawing_area_set_height(GtkWidget *widget, int height)
 {
   GtkDarktableDrawingArea *da = DTGTK_DRAWING_AREA(widget);
   da->aspect = 1.0f; // not used
-  da->height = height;
+  da->height = height < 0 ? 0 : height;
   gtk_widget_queue_resize(widget);
 }
 


### PR DESCRIPTION
if not properly checked earlier, then dtgtk_drawing_area_set_height(GtkWidget *widget, int height) can cause a crash if height becomes negative. 

as a last line of defense the height is set to 0 if a negative height is used to call the function.