### PR TITLE
Avoid crash in dt_database_show_error()

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1577,7 +1577,7 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
       if(connection) g_object_unref(connection);
     }
     darktable_splash_screen_destroy(); // dismiss splash screen before potentially showing error dialog
-    if(!image_loaded_elsewhere) dt_database_show_error(darktable.db);
+    if(!image_loaded_elsewhere && init_gui) dt_database_show_error(darktable.db);
 
     dt_print(DT_DEBUG_ALWAYS, "ERROR: can't acquire database lock, aborting.");
     return 1;


### PR DESCRIPTION
This later calls dt_gui_show_standalone_yes_no_dialog() but should only be called if we are running in gui mode.

Fixes #18822

Release note: Fixed darktable-cli crashing if the darktable database is locked.