### PR TITLE
[imageio] Enable CMYK TIFF support in GraphicsMagick fallback loader

### DIFF
--- a/src/imageio/imageio_gm.c
+++ b/src/imageio/imageio_gm.c
@@ -114,12 +114,18 @@ dt_imageio_retval_t dt_imageio_open_gm(dt_image_t *img,
     goto error;
   }
 
+  char *colormap;
+  if(IsCMYKColorspace(image->colorspace))
+    colormap = "CMYK";
+  else
+    colormap = "RGBP";
+
   int ret = DispatchImage(image,
                           0,
                           0,
                           img->width,
                           img->height,
-                          "RGBP",
+                          colormap,
                           FloatPixel,
                           mipbuf,
                           &exception);
@@ -134,6 +140,18 @@ dt_imageio_retval_t dt_imageio_open_gm(dt_image_t *img,
              img->filename);
     err = DT_IMAGEIO_LOAD_FAILED;
     goto error;
+  }
+
+  // If the image in CMYK color space convert it to linear RGB
+  if(IsCMYKColorspace(image->colorspace))
+  {
+    for(size_t index = 0; index < img->width * img->height * 4; index += 4)
+    {
+      float black = mipbuf[index + 3];
+      mipbuf[index]     = (1.f - black) * (1.f - mipbuf[index]);
+      mipbuf[index + 1] = (1.f - black) * (1.f - mipbuf[index + 1]);
+      mipbuf[index + 2] = (1.f - black) * (1.f - mipbuf[index + 2]);
+    }
   }
 
   size_t profile_length;

--- a/src/imageio/imageio_gm.c
+++ b/src/imageio/imageio_gm.c
@@ -98,14 +98,6 @@ dt_imageio_retval_t dt_imageio_open_gm(dt_image_t *img,
            "[GraphicsMagick_open] image '%s' loading",
            img->filename);
 
-  if(IsCMYKColorspace(image->colorspace))
-  {
-    dt_print(DT_DEBUG_ALWAYS,
-             "[GraphicsMagick_open] error: CMYK images are not supported");
-    err =  DT_IMAGEIO_LOAD_FAILED;
-    goto error;
-  }
-
   img->width = image->columns;
   img->height = image->rows;
 

--- a/src/imageio/imageio_tiff.c
+++ b/src/imageio/imageio_tiff.c
@@ -428,10 +428,10 @@ dt_imageio_retval_t dt_imageio_open_tiff(dt_image_t *img,
   if(t.sampleformat == SAMPLEFORMAT_VOID)
     t.sampleformat = SAMPLEFORMAT_UINT;
 
-  if(inkset == INKSET_CMYK || inkset == INKSET_MULTIINK)
+  if(photometric == PHOTOMETRIC_SEPARATED)
   {
     dt_print(DT_DEBUG_ALWAYS,
-             "[tiff_open] error: unsupported CMYK (or multi-ink) in '%s'",
+             "[tiff_open] error: CMYK colorspace not supported in '%s'",
              filename);
     TIFFClose(t.tiff);
     return DT_IMAGEIO_UNSUPPORTED_FORMAT;


### PR DESCRIPTION
This PR adds proper CMYK support to the GraphicsMagick loader for now (I plan to add it to the alternative ImageMagick fallback loader in the next PR, to make review and testing easier).

No one forces a user to edit CMYK TIFF. If an image is imported, it doesn't mean that the only purpose is to edit it.
darktable is as much a DAM as a raw processor and image editor. So I'm sure [disabling CMYK TIFF reading](https://github.com/darktable-org/darktable/pull/7342) in response to an [issue with such a proposal](https://github.com/darktable-org/darktable/issues/3560) was a mistake. Yes, the black channel was ignored in CMYK TIFF, and the color channels looked as if they were inverted. The reason for this is that there was no CMYK color space detection and conversion back then, so such files were interpreted as RGB. But this should have been fixed with proper CMYK support, not by banning it.

What this PR does:

- Fixes a bug in CMYK detection in the native loader. The INKSET tag is not mandatory for CMYK TIFF, so checking the value of this tag could not detect CMYK files, which, if the native loader supported other format parameters of the file, were eventually processed as RGB and looked like "inverted". Now the native loader will reject all CMYK TIFFs, and the fallback loader will do the CMYK -> RGB conversion.

- Removes the ban on reading an image in the CMYK color space in the GraphicsMagick loader and if the image is in CMYK, converts it to linear RGB.

Note that we keep the ban on CMYK TIFF in the native loader, relying entirely on the fallback loader. The native loader doesn't support all format variations anyway (for example, it can't read tiled files and files with separate planes), so the CMYK->RGB conversion needs to be added to fallback loaders anyway.

Files that can be used to test this PR:

- The file MARBLES-CMYK.TIF from the attachment at https://github.com/darktable-org/darktable/issues/3560

- The `Full (LZW) CMYK 16.tif`, `Full (LZW) CMYK.tif`, `Full (no compression) CMYK.tif` files from https://gitlab.gnome.org/Infrastructure/gimp-test-images/-/tree/main/graphicex/TIFF/True%20color

- The `tiff_strip_cmyk_16l_jpeg.tif`, `tiff_strip_cmyk_jpeg.tif`, `tiff_tiled_cmyk_jpeg.tif` files from https://gitlab.gnome.org/Infrastructure/gimp-test-images/-/tree/main/pillow
- The `cs5.5-cmyk.tif` file from https://github.com/nomacs/formats_testset/tree/main/TIFF
- The `scmyk.tif`, `scmyka.tif`, `scmyka16.tif`, `scmykaa.tif` files from https://github.com/tonycoz/imager/tree/master/TIFF/testimg
