### PR TITLE
Remove dead code in crop module

### DIFF
--- a/src/iop/crop.c
+++ b/src/iop/crop.c
@@ -602,90 +602,6 @@ static float _aspect_ratio_get(dt_iop_module_t *self, GtkWidget *combo)
 
   const int iwd = piece->buf_in.width, iht = piece->buf_in.height;
 
-  // if we do not have yet computed the aspect ratio, let's do it now
-  if(p->ratio_d == -2 && p->ratio_n == -2)
-  {
-    if(p->cw == 1.0f && p->cx == 0.0f && p->ch == 1.0f && p->cy == 0.0f)
-    {
-      p->ratio_d = -1;
-      p->ratio_n = -1;
-    }
-    else
-    {
-      const dt_interpolation_t *interpolation = dt_interpolation_new(DT_INTERPOLATION_USERPREF_WARP);
-      const float whratio = ((float)(iwd - 2 * interpolation->width) * (p->cw - p->cx))
-                            / ((float)(iht - 2 * interpolation->width) * (p->ch - p->cy));
-      const float ri = (float)iwd / (float)iht;
-
-      const float prec = 0.0003f;
-      if(fabsf(whratio - 3.0f / 2.0f) < prec)
-      {
-        p->ratio_d = 3;
-        p->ratio_n = 2;
-      }
-      else if(fabsf(whratio - 2.0f / 1.0f) < prec)
-      {
-        p->ratio_d = 2;
-        p->ratio_n = 1;
-      }
-      else if(fabsf(whratio - 7.0f / 5.0f) < prec)
-      {
-        p->ratio_d = 7;
-        p->ratio_n = 5;
-      }
-      else if(fabsf(whratio - 4.0f / 3.0f) < prec)
-      {
-        p->ratio_d = 4;
-        p->ratio_n = 3;
-      }
-      else if(fabsf(whratio - 5.0f / 4.0f) < prec)
-      {
-        p->ratio_d = 5;
-        p->ratio_n = 4;
-      }
-      else if(fabsf(whratio - 1.0f / 1.0f) < prec)
-      {
-        p->ratio_d = 1;
-        p->ratio_n = 1;
-      }
-      else if(fabsf(whratio - 16.0f / 9.0f) < prec)
-      {
-        p->ratio_d = 16;
-        p->ratio_n = 9;
-      }
-      else if(fabsf(whratio - 16.0f / 10.0f) < prec)
-      {
-        p->ratio_d = 16;
-        p->ratio_n = 10;
-      }
-      else if(fabsf(whratio - 244.5f / 203.2f) < prec)
-      {
-        p->ratio_d = 2445;
-        p->ratio_n = 2032;
-      }
-      else if(fabsf(whratio - sqrtf(2.0f)) < prec)
-      {
-        p->ratio_d = 14142136;
-        p->ratio_n = 10000000;
-      }
-      else if(fabsf(whratio - PHI) < prec)
-      {
-        p->ratio_d = 16180340;
-        p->ratio_n = 10000000;
-      }
-      else if(fabsf(whratio - ri) < prec)
-      {
-        p->ratio_d = 1;
-        p->ratio_n = 0;
-      }
-      else
-      {
-        p->ratio_d = 0;
-        p->ratio_n = 0;
-      }
-    }
-  }
-
   if(p->ratio_d == 0 && p->ratio_n == 0) return -1.0f;
   float d = 1.0f, n = 1.0f;
   if(p->ratio_n == 0)
@@ -1073,12 +989,6 @@ void gui_update(dt_iop_module_t *self)
 {
   dt_iop_crop_gui_data_t *g = self->gui_data;
   dt_iop_crop_params_t *p = self->params;
-
-  //  set aspect ratio based on the current image, if not found let's default
-  //  to free aspect.
-
-  if(p->ratio_d == -2 && p->ratio_n == -2)
-    _aspect_ratio_get(self, g->aspect_presets);
 
   if(p->ratio_d == -1 && p->ratio_n == -1)
   {


### PR DESCRIPTION
At two code parts we tested for `p->ratio_d == -2 && p->ratio_n == -2`. Reading the code and trying to understand these tests and if() actions, it's simply a leftover from clipping module while we stripped down that code. There it was used for a version bump enforcing recalculation of the ratio.