### PR TITLE
[imageio] Enable CMYK TIFF support in ImageMagick fallback loader

### DIFF
--- a/src/imageio/imageio_im.c
+++ b/src/imageio/imageio_im.c
@@ -75,7 +75,7 @@ dt_imageio_retval_t dt_imageio_open_im(dt_image_t *img,
                                        const char *filename,
                                        dt_mipmap_buffer_t *mbuf)
 {
-  int err = DT_IMAGEIO_LOAD_FAILED;
+  dt_imageio_retval_t err = DT_IMAGEIO_LOAD_FAILED;
 
   if(!_supported_image(filename))
     return DT_IMAGEIO_LOAD_FAILED;


### PR DESCRIPTION
This completes the addition of CMYK TIFF support started at https://github.com/darktable-org/darktable/pull/18841. Code similar to that added in GraphicsMagick, this PR adds to the alternative ImageMagick loader used in the macOS build.

While being here some maintenance for readability (code reformatting, enumerated type instead of int).