### PR TITLE
[GUI] Use a plus sign in the description of the shortcut with the ctrl modifier

### DIFF
--- a/src/libs/geotagging.c
+++ b/src/libs/geotagging.c
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+
 #include "common/debug.h"
 #include "common/file_location.h"
 #include "common/image_cache.h"
@@ -375,7 +376,7 @@ static void _update_buttons(dt_lib_module_t *self)
                                                  : _("apply geo-location"));
   gtk_widget_set_tooltip_text(d->map.apply_gpx_button,
                               d->offset ? _("apply offset and geo-location to matching images"
-                                            "\ndouble operation: two ctrl-z to undo")
+                                            "\ndouble operation: two ctrl+z to undo")
                                         : _("apply geo-location to matching images"));
   gtk_widget_set_sensitive(d->map.apply_gpx_button, d->map.nb_imgs);
   gtk_widget_set_sensitive(d->map.select_button,


### PR DESCRIPTION
In the GUI, we use the notation "сtrl plus letter". Most of the cases are in the accelerators help window and in the shortcut section of the global settings. There is only one case of using Ctrl with a letter in the tooltip, and that's where a dash is used. This PR replaces it with a plus for consistency.