### PR TITLE
Remove local guides widget from orientation module

### DIFF
--- a/src/iop/flip.c
+++ b/src/iop/flip.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2011-2024 darktable developers.
+    Copyright (C) 2011-2025 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+
 #include <assert.h>
 #include <gdk/gdkkeysyms.h>
 #include <gtk/gtk.h>
@@ -91,7 +92,7 @@ int operation_tags()
 int flags()
 {
   return IOP_FLAGS_ALLOW_TILING | IOP_FLAGS_TILING_FULL_ROI
-    | IOP_FLAGS_ONE_INSTANCE | IOP_FLAGS_UNSAFE_COPY | IOP_FLAGS_GUIDES_WIDGET;
+    | IOP_FLAGS_ONE_INSTANCE | IOP_FLAGS_UNSAFE_COPY;
 }
 
 dt_iop_colorspace_type_t default_colorspace(dt_iop_module_t *self,


### PR DESCRIPTION
In addition to the global guides widget and keyboard accelerator toggling guides, we also have local guides widget in the interface of those modules where they make sense. This is convenient for users who prefer mouse control and don't like to remember keyboard shortcuts, and it shortens the distance the mouse has to travel. If you do not need this and you value screen real estate, local module widgets can be disabled in the global settings.

But if I open the orientation module, all I need is a specific operation on the image, such as rotating it 90º or mirroring. Nothing more. Seeing the guides on the image while doing this is of no use. So it makes no sense to place a local guides widget in this module.