### PR TITLE
Try linking from gphoto2 from package config

### DIFF
--- a/cmake/modules/FindGphoto2.cmake
+++ b/cmake/modules/FindGphoto2.cmake
@@ -32,6 +32,11 @@ mark_as_advanced(Gphoto2_PORT_LIBRARY)
 # Detect libgphoto2 version
 libfind_pkg_check_modules(Gphoto2_PKGCONF libgphoto2)
 if(Gphoto2_PKGCONF_FOUND)
+  if(NOT ${Gphoto2_INCLUDE_DIR} STREQUAL "GPhoto2_INCLUDE_DIR-NOTFOUND")
+    find_path(Gphoto2_INCLUDE_DIR gphoto2/gphoto2.h PATHS ${Gphoto2_PKGCONF_INCLUDE_DIRS} )
+    find_library(Gphoto2_LIBRARY NAMES ${Gphoto2_NAMES} PATHS ${Gphoto2_PKGCONF_LIBRARY_DIRS} )
+    find_library(Gphoto2_PORT_LIBRARY NAMES ${Gphoto2_PORT_NAMES} PATHS ${Gphoto2_PKGCONF_LIBRARY_DIRS} )
+  endif()
   set(Gphoto2_VERSION_STRING "${Gphoto2_PKGCONF_VERSION}")
 endif()
 


### PR DESCRIPTION
If gphoto2 was found in package config, but was _not_ found via the normal `find_path` / `find_library` calls, try looking again but with the paths supplied by pkg-config

This is probably a niche usecase, but tethering wasn't working with my OM-1 Mkii. I tracked the problem to [a bug in libgphoto2](https://github.com/gphoto/libgphoto2/issues/969), and sent [a PR](https://github.com/gphoto/libgphoto2/pull/1123) to fix libgphoto2.  I was able to confirm that gphoto2 could control my camera, but I wanted to test darktable integration.  I installed a development version of libgphoto2 to a special directory, and even though I could get CMake to find my pkg-config files, it wouldn't compile / link against them.  I added the code in this PR to try compiling and linking against gphoto2 found in pkg-config so I could verify my changes fixed darktable too.

Here's a screenshot of darktable tethering with my OM-1 Mkii:

<img width="1969" alt="Screenshot 2025-05-23 at 2 49 57 PM" src="https://github.com/user-attachments/assets/808faa92-4c5a-4eda-9f24-075c196422b8" />

I know this is a niche usecase, so it's fine if my PR is rejected. But I wanted to send it in case someone else is trying to test edge versions of dependencies (or maybe there's an easier way I don't know).

Thanks!