### PR TITLE
[imageio] Avoid TIFF loader crash on files with missing SAMPLESPERPIXEL tag

### DIFF
--- a/src/imageio/imageio_tiff.c
+++ b/src/imageio/imageio_tiff.c
@@ -416,7 +416,7 @@ dt_imageio_retval_t dt_imageio_open_tiff(dt_image_t *img,
   TIFFGetField(t.tiff, TIFFTAG_IMAGEWIDTH, &t.width);
   TIFFGetField(t.tiff, TIFFTAG_IMAGELENGTH, &t.height);
   TIFFGetField(t.tiff, TIFFTAG_BITSPERSAMPLE, &t.bpp);
-  TIFFGetField(t.tiff, TIFFTAG_SAMPLESPERPIXEL, &t.spp);
+  TIFFGetFieldDefaulted(t.tiff, TIFFTAG_SAMPLESPERPIXEL, &t.spp);
   TIFFGetFieldDefaulted(t.tiff, TIFFTAG_SAMPLEFORMAT, &t.sampleformat);
   TIFFGetField(t.tiff, TIFFTAG_PLANARCONFIG, &config);
   TIFFGetField(t.tiff, TIFFTAG_PHOTOMETRIC, &photometric);


### PR DESCRIPTION
TIFFTAG_SAMPLESPERPIXEL may be missing, if so, take the default value using TIFFGetFieldDefaulted. TIFFGetField does nothing if the tag is missing, leaving the output argument uninitialized, whose garbage value causes a crash.

Resolves #18867.
