### PR TITLE
fix regression in darkroom switching between images

### DIFF
--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -657,6 +657,9 @@ void expose(dt_view_t *self,
     }
     else
     {
+      // repaint the image we are switching away from, to avoid a
+      // flash of the background color
+      _view_paint_surface(cri, width, height, port, DT_WINDOW_MAIN);
       dt_toast_log("%s", load_txt);
     }
     g_free(load_txt);


### PR DESCRIPTION
Commit 89764470fd2f10c4fa74ba0b6605b5b7765b1d94 "remove unnecessary double buffering" introduced a regression when the loading screen is disabled.  Instead of leaving up the previous image until the next one has been rendered, it displays the center view filled with the current theme's background color.  The associated blink while switching images is quite annoying....

This commit fixes the regression by forcing the rendered image to be re-copied to the display during the loading interval.  I tried caching the Cairo surface created by the previous screen update, but was never able to get it to display in the proper position and size.

Steps to induce the regression:
1. uncheck the "show loading screen between images" option in preference|darkroom
2. switch to darkroom view
3. advance to the next image
4. observe that the center view goes blank until the next image is rendered
