### PR TITLE
lua/preferences.c - Expanded width of input fields

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -243,6 +243,8 @@ changes (where available).
 
 ### Bug Fixes
 
+- Expanded width of preference boxes Lua Options so that long input is visible.
+
 - N/A
 
 ### Add action support for Lua

--- a/src/lua/preferences.c
+++ b/src/lua/preferences.c
@@ -692,6 +692,7 @@ static int register_pref_sub(lua_State *L)
         dt_conf_set_string(pref_name, built_elt->type_data.string_data.default_value);
 
       built_elt->widget = gtk_entry_new();
+      gtk_widget_set_hexpand(built_elt->widget, TRUE);
       built_elt->tooltip_reset= g_strdup_printf( _("double-click to reset to `%s'"),
           built_elt->type_data.string_data.default_value);
       g_object_ref_sink(G_OBJECT(built_elt->widget));


### PR DESCRIPTION
Expanded width of input fields so that more  input is visible.

Fixes #18832.