### PR TITLE
[GUI] Sigmoid module description grammar/style fixes

### DIFF
--- a/src/iop/sigmoid.c
+++ b/src/iop/sigmoid.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2020-2024 darktable developers.
+    Copyright (C) 2020-2025 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -199,7 +199,7 @@ const char *aliases()
 const char **description(dt_iop_module_t *self)
 {
   return dt_iop_set_description(self,
-                                _("apply a view transform to make a image displayable\n"
+                                _("apply a view transform to make an image displayable\n"
                                   "on a screen or print. uses a robust and smooth\n"
                                   "tone curve with optional color preservation methods."),
                                 _("corrective and creative"), _("linear, RGB, scene-referred"),

--- a/src/iop/sigmoid.c
+++ b/src/iop/sigmoid.c
@@ -200,8 +200,8 @@ const char **description(dt_iop_module_t *self)
 {
   return dt_iop_set_description(self,
                                 _("apply a view transform to make an image displayable\n"
-                                  "on a screen or print. uses a robust and smooth\n"
-                                  "tone curve with optional color preservation methods."),
+                                  "on a screen or print using a robust and smooth\n"
+                                  "tone curve with optional color preservation methods"),
                                 _("corrective and creative"), _("linear, RGB, scene-referred"),
                                 _("non-linear, RGB"), _("linear, RGB, display-referred"));
 }


### PR DESCRIPTION
The description contained a grammatically incorrect variant of an indefinite article (a instead of an).

I also changed the description to be one sentence. Sigmoid is the only exception where the description contained more than one sentence (I mean only the description of the module's functionality, not counting the additional warnings in the tooltips of certain modules).