### PR TITLE
Make it easier to select feather points close to path points

### DIFF
--- a/src/develop/masks.h
+++ b/src/develop/masks.h
@@ -387,6 +387,7 @@ typedef struct dt_masks_form_gui_t
   gboolean border_selected;
   gboolean source_selected;
   gboolean pivot_selected;
+  gboolean select_only_border;
   dt_masks_edit_mode_t edit_mode;
   int point_selected;
   int point_edited;

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -622,15 +622,13 @@ static int _circle_events_mouse_moved(dt_iop_module_t *module,
       const float dist_b = sqf(x - gpt->border[2]) + sqf(y - gpt->border[3]);
       const float dist_p = sqf(x - gpt->points[2]) + sqf(y - gpt->points[3]);
 
-      // prefer border point over shape itself in case of near overlap
-      // for ease of pickup
-      if(dist_b < as2)
-      {
-        gui->point_border_selected = 1;
-      }
-      else if(dist_p < as2)
+      if(!gui->select_only_border && dist_p < as2)
       {
         gui->point_selected = 1;
+      }
+      else if(dist_b < as2)
+      {
+        gui->point_border_selected = 1;
       }
     }
 

--- a/src/develop/masks/ellipse.c
+++ b/src/develop/masks/ellipse.c
@@ -577,7 +577,7 @@ static int _ellipse_events_button_pressed(dt_iop_module_t *module,
     dt_masks_form_gui_points_t *gpt = g_list_nth_data(gui->points, index);
     if(!gpt) return 0;
 
-    if(gui->form_selected && dt_modifier_is(state, GDK_SHIFT_MASK))
+    if(gui->form_selected && dt_modifier_is(state, GDK_MOD1_MASK))
     {
       gui->border_toggling = TRUE;
       return 1;
@@ -1185,16 +1185,14 @@ static int _ellipse_events_mouse_moved(dt_iop_module_t *module,
         const float dist_b = sqf(x - gpt->border[i * 2]) + sqf(y - gpt->border[i * 2 +1]);
         const float dist_p = sqf(x - gpt->points[i * 2]) + sqf(y - gpt->points[i * 2 + 1]);
 
-        // prefer border points over shape itself in case of near
-        // overlap for ease of pickup
+        if(!gui->select_only_border && dist_p < as2)
+        {
+          gui->point_selected = i;
+          break;
+        }
         if(dist_b < as2)
         {
           gui->point_border_selected = i;
-          break;
-        }
-        if(dist_p < as2)
-        {
-          gui->point_selected = i;
           break;
         }
       }

--- a/src/develop/masks/group.c
+++ b/src/develop/masks/group.c
@@ -87,8 +87,20 @@ static int _group_events_button_pressed(dt_iop_module_t *module,
     dt_masks_form_t *sel = dt_masks_get_from_id(darktable.develop, fpt->formid);
     if(!sel) return 0;
     if(sel->functions)
+    {
+      // did we asked for feather only?
+      if(dt_modifier_is(state, GDK_SHIFT_MASK) ^ gui->select_only_border)
+      {
+        // then make sure we try to select the feather point
+        gui->select_only_border = dt_modifier_is(state, GDK_SHIFT_MASK);
+        sel->functions->mouse_moved(module, pzx, pzy, pressure,
+                                    which, dt_dev_get_zoom_scale_full(), sel, fpt->parentid,
+                                    gui, gui->group_edited);
+      }
+
       return sel->functions->button_pressed(module, pzx, pzy, pressure, which, type, state, sel,
                                            fpt->parentid, gui, gui->group_edited);
+    }
   }
   return 0;
 }
@@ -180,6 +192,7 @@ static int _group_events_mouse_moved(dt_iop_module_t *module,
   gui->seg_selected = -1;
   gui->point_border_selected = -1;
   gui->group_edited = gui->group_selected = -1;
+  gui->select_only_border = dt_modifier_is(which, GDK_SHIFT_MASK);
 
   dt_masks_form_t *sel = NULL;
   dt_masks_point_group_t *sel_fpt = NULL;

--- a/src/develop/masks/path.c
+++ b/src/develop/masks/path.c
@@ -2749,7 +2749,8 @@ static int _path_events_mouse_moved(dt_iop_module_t *module,
   for(int k = 0; k < nb; k++)
   {
     // corner ??
-    if(pzx - gpt->points[k * 6 + 2] > -as
+    if(!gui->select_only_border
+       && pzx - gpt->points[k * 6 + 2] > -as
        && pzx - gpt->points[k * 6 + 2] < as
        && pzy - gpt->points[k * 6 + 3] > -as
        && pzy - gpt->points[k * 6 + 3] < as)
@@ -2776,7 +2777,7 @@ static int _path_events_mouse_moved(dt_iop_module_t *module,
   int near = 0;
   float dist = 0;
   _path_get_distance(pzx, pzy, as, gui, index, nb, &in, &inb, &near, &ins, &dist);
-  gui->seg_selected = dist < sqf(as) ? near : -1;
+  gui->seg_selected = !gui->select_only_border && dist < sqf(as) ? near : -1;
 
   // no segment selected, set form or source selection
   if(near < 0)


### PR DESCRIPTION
paths: Use SHIFT modifier to select only feather points.
    
When the border and the feather are very close from each other it is
difficult to select a specific point. The default are the border points,
when using SHIFT modifier only the feather points are selectable.
    
Note that for the ellipse the change of the feather mode (equidistant or
proportional) is now controlled by the ALT key. This change seems ok as
the feature is less frequent and SHIFT is the current key to resize
the feather for all masks.
