### PR TITLE
[GUI] Camera maker not manufacturer

### DIFF
--- a/src/iop/basecurve.c
+++ b/src/iop/basecurve.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2010-2024 darktable developers.
+    Copyright (C) 2010-2025 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -367,7 +367,7 @@ const char **description(dt_iop_module_t *self)
 {
   return dt_iop_set_description
     (self,
-     _("apply a view transform based on personal or camera manufacturer look,\n"
+     _("apply a view transform based on personal or camera maker look,\n"
        "for corrective purposes, to prepare images for display"),
      _("corrective"),
      _("linear, RGB, display-referred"),

--- a/tools/basecurve/darktable-curve-tool-helper
+++ b/tools/basecurve/darktable-curve-tool-helper
@@ -119,7 +119,7 @@ extract_jpeg_from_raw()
         exiftool -b -PreviewImage "$_src" > "$_dst"
         ;;
     *)
-        printf "unknown camera manufacturer %s, please provide a sample file to darktable developers to see if an embedded JPEG could be used" "$_make"
+        printf "unknown camera maker %s, please provide a sample file to darktable developers to see if an embedded JPEG could be used" "$_make"
         ;;
     esac
 }


### PR DESCRIPTION
Why is it preferable to use the term `camera maker`:

- It is used in the context of working with digital images. This is the name of the field in the Exif data.
- The term camera manufacturer has a slightly different focus, it refers to the company that is engaged in the physical production of cameras, this is not relevant in our context. Also, the manufacturer is not necessarily the same as the maker, although in most cases it is. For example, Google Nexus devices were manufactured by different companies (HTC, LG, Motorola, etc.), but their maker is Google.
- In the GUI, camera maker is used more often, we make the terminology consistent.

It is also shorter, so as an added bonus, replacing manufacturer with maker makes the lengths of the description lines in the module tooltip more balanced and reduces the width of the tooltip.