### PR TITLE
[CI] Avoid faulty Ubuntu repo servers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,7 @@ jobs:
         env:
           DEBIAN_FRONTEND: noninteractive
         run: |
+          sed -i 's/archive\.ubuntu/azure\.archive\.ubuntu/' /etc/apt/sources.list.d/ubuntu.sources
           set -xe
           rm -rf /var/lib/apt/lists/*
           apt-get --yes update


### PR DESCRIPTION
For over a day, the standard Ubuntu package repository servers have been throwing errors, causing CI pipelines to fail. This PR replaces these servers with an azure mirror, which is now functioning stably.

BTW, Azure is the default apt mirror for at least "ubuntu-latest" runners (we are, however, using a docker image of a more recent release with default package server settings).
