### PR TITLE
[GUI] Make module tooltips not so wide

### DIFF
--- a/src/iop/bilateral.cc
+++ b/src/iop/bilateral.cc
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2010-2024 darktable developers.
+    Copyright (C) 2010-2025 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -97,7 +97,9 @@ dt_iop_colorspace_type_t default_colorspace(dt_iop_module_t *self,
 const char **description(dt_iop_module_t *self)
 {
   return dt_iop_set_description
-    (self, _("apply edge-aware surface blur to denoise or smoothen textures"),
+    (self,
+     _("apply edge-aware surface blur\n"
+       "to denoise or smoothen textures"),
      _("corrective and creative"),
      _("linear, RGB, scene-referred"),
      _("linear, RGB"),

--- a/src/iop/colorequal.c
+++ b/src/iop/colorequal.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2022-2024 darktable developers.
+    Copyright (C) 2022-2025 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -209,7 +209,9 @@ const char *aliases()
 const char **description(dt_iop_module_t *self)
 {
   return dt_iop_set_description
-    (self, _("change saturation, hue and brightness depending on local hue"),
+    (self,
+     _("change saturation, hue and brightness\n"
+       "depending on local hue"),
      _("corrective and creative"),
      _("linear, RGB, scene-referred"),
      _("quasi-linear, RGB"),

--- a/src/iop/colormapping.c
+++ b/src/iop/colormapping.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2013-2024 darktable developers.
+    Copyright (C) 2013-2025 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+
 #include "bauhaus/bauhaus.h"
 #include "common/bilateral.h"
 #include "common/bilateralcl.h"
@@ -146,7 +147,8 @@ const char *name()
 
 const char **description(dt_iop_module_t *self)
 {
-  return dt_iop_set_description(self, _("transfer a color palette and tonal repartition from one image to another"),
+  return dt_iop_set_description(self, _("transfer a color palette and tonal repartition\n"
+                                        "from one image to another"),
                                       _("creative"),
                                       _("linear or non-linear, Lab, display-referred"),
                                       _("non-linear, Lab"),

--- a/src/iop/hotpixels.c
+++ b/src/iop/hotpixels.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2011-2024 darktable developers.
+    Copyright (C) 2011-2025 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -68,7 +68,8 @@ const char *name()
 
 const char **description(dt_iop_module_t *self)
 {
-  return dt_iop_set_description(self, _("remove abnormally bright pixels by dampening them with neighbors"),
+  return dt_iop_set_description(self, _("remove abnormally bright pixels\n"
+                                        "by dampening them with neighbors"),
                                       _("corrective"),
                                       _("linear, raw, scene-referred"),
                                       _("reconstruction, raw"),

--- a/src/iop/monochrome.c
+++ b/src/iop/monochrome.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2009-2024 darktable developers.
+    Copyright (C) 2009-2025 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+
 #include "bauhaus/bauhaus.h"
 #include "common/bilateral.h"
 #include "common/bilateralcl.h"
@@ -93,7 +94,8 @@ dt_iop_colorspace_type_t default_colorspace(dt_iop_module_t *self,
 
 const char **description(dt_iop_module_t *self)
 {
-  return dt_iop_set_description(self, _("quickly convert an image to black & white using a variable color filter"),
+  return dt_iop_set_description(self, _("quickly convert an image to black & white\n"
+                                        "using a variable color filter"),
                                       _("creative"),
                                       _("linear or non-linear, Lab, display-referred"),
                                       _("non-linear, Lab"),

--- a/src/iop/nlmeans.c
+++ b/src/iop/nlmeans.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2011-2024 darktable developers.
+    Copyright (C) 2011-2025 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -82,7 +82,8 @@ const char *aliases()
 
 const char **description(dt_iop_module_t *self)
 {
-  return dt_iop_set_description(self, _("apply a poisson noise removal best suited for astrophotography"),
+  return dt_iop_set_description(self, _("apply a poisson noise removal\n"
+                                        "best suited for astrophotography"),
                                       _("corrective"),
                                       _("non-linear, Lab, display-referred"),
                                       _("non-linear, Lab"),

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2017-2024 darktable developers.
+    Copyright (C) 2017-2025 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -202,7 +202,8 @@ const char *aliases()
 
 const char **description(dt_iop_module_t *self)
 {
-  return dt_iop_set_description(self, _("remove and clone spots, perform split-frequency skin editing"),
+  return dt_iop_set_description(self, _("remove and clone spots,\n"
+                                        "perform split-frequency skin editing"),
                                       _("corrective"),
                                       _("linear, RGB, scene-referred"),
                                       _("geometric and frequential, RGB"),

--- a/src/iop/scalepixels.c
+++ b/src/iop/scalepixels.c
@@ -80,7 +80,8 @@ const char **description(dt_iop_module_t *self)
 {
   return dt_iop_set_description(self,
                                 _("module for setting pixel aspect ratio\n\n"
-                                "useful for certain sensor types and anamorphic desqueeze"),
+                                "useful for certain sensor types\n"
+                                "and anamorphic desqueeze"),
                                 _("corrective"),
                                 _("linear, RGB, scene-referred"),
                                 _("linear, RGB"),

--- a/src/iop/velvia.c
+++ b/src/iop/velvia.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2010-2024 darktable developers.
+    Copyright (C) 2010-2025 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+
 #include <assert.h>
 #include <math.h>
 #include <stdlib.h>
@@ -91,7 +92,8 @@ dt_iop_colorspace_type_t default_colorspace(dt_iop_module_t *self,
 
 const char **description(dt_iop_module_t *self)
 {
-  return dt_iop_set_description(self, _("resaturate giving more weight to blacks, whites and low-saturation pixels"),
+  return dt_iop_set_description(self, _("resaturate giving more weight to blacks,\n"
+                                        "whites and low-saturation pixels"),
                                       _("creative"),
                                       _("linear, RGB, scene-referred"),
                                       _("linear, RGB"),


### PR DESCRIPTION
The bottom part of the module tooltip contains a block of technical information, such as the module's purpose, input and output color space. My perception is that if the module description text makes the tooltip width _more than twice_ the width of the block (so the tooltip will contain a large rectangle of empty space), it looks bad and makes the user want to shrink the tooltip. If the width of the tooltip is about twice the width of the technical info block, it is on the verge of acceptable perception. But if the description text can be logically split into two lines so that it doesn't make the tooltip wider, that would be ideal.

The PR contains separate commits for each module for easy cherry-picking. Feel free to squash commits if you accept all changes.
