### PR TITLE
[GUI] Use a more suitable verb

### DIFF
--- a/src/iop/rasterfile.c
+++ b/src/iop/rasterfile.c
@@ -16,7 +16,6 @@
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -588,7 +587,7 @@ void gui_init(dt_iop_module_t *self)
 
   g->fbutton = dtgtk_button_new(dtgtk_cairo_paint_directory, CPF_NONE, NULL);
   gtk_widget_set_name(g->fbutton, "non-flat");
-  gtk_widget_set_tooltip_text(g->fbutton, _("select a PFM file to be advertized as a raster mask,\n"
+  gtk_widget_set_tooltip_text(g->fbutton, _("select the PFM file to be treated as a raster mask,\n"
       "CAUTION: path must be set in preferences/processing before choosing"));
   g_signal_connect(G_OBJECT(g->fbutton), "clicked", G_CALLBACK(_fbutton_clicked), self);
 


### PR DESCRIPTION
At first, the spelling `advertize` seemed unusual to me. And indeed, it turned out that this is the case when -ize instead of -ise does not mean the American version: https://english.stackexchange.com/questions/341707/should-advertised-be-spelled-with-a-z-in-american-english

But then I realized that talking about advertising here is not appropriate. If we advertise, there is always a recipient, there is always someone to whom the advertisement is directed. In the context where this word was used, it is better to say that we are _treating_ the contents of the file as a raster mask. Alternatively, "to be used as" instead of "to be treated as" is also possible. I don't know which is perceived as a clearer word here, but I just chose one of the options.
