### PR TITLE
Make the dropdown menu insensitive when empty

### DIFF
--- a/src/iop/rasterfile.c
+++ b/src/iop/rasterfile.c
@@ -209,8 +209,13 @@ static void _update_filepath(dt_iop_module_t *self)
   if(!p->path[0] || !p->file[0])
   {
     dt_bauhaus_combobox_clear(g->file);
+    // Making the empty widget insensitive is very important, because
+    // attempts to interact with it trigger a bug in GTK (as of 3.24.49)
+    // that disables the display of tooltips
+    gtk_widget_set_sensitive(g->file, FALSE);
     return;
   }
+  gtk_widget_set_sensitive(g->file, TRUE);
 
   if(!dt_bauhaus_combobox_set_from_text(g->file, p->file))
   {


### PR DESCRIPTION
Of course, a widget that cannot be interacted with should be insensitive. But this is not just a matter of polished UI. It turns out that interacting with an empty dropdown widget triggers a bug in GTK. Steps to reproduce the bug:

- Open an arbitrary image in a darkroom.
- Go to the `external raster masks` module.
- Check that you have tooltips enabled.
- Click on the "chevron downwards" handle (located on the right edge in the second line of the module body). This is the handle for opening a drop-down menu with a list of pfm files in the same folder as the selected file, but since the menu is currently empty, we only see this handle ("chevron").
- After that, 100% reproducible the tooltips are no longer displayed.
