### PR TITLE
[imageio] Update QOI format implementation code from upstream

### DIFF
--- a/src/imageio/qoi.h
+++ b/src/imageio/qoi.h
@@ -427,7 +427,7 @@ void *qoi_encode(const void *data, const qoi_desc *desc, int *out_len) {
 				run = 0;
 			}
 
-			index_pos = QOI_COLOR_HASH(px) % 64;
+			index_pos = QOI_COLOR_HASH(px) & (64 - 1);
 
 			if (index[index_pos].v == px.v) {
 				bytes[p++] = QOI_OP_INDEX | index_pos;
@@ -574,7 +574,7 @@ void *qoi_decode(const void *data, int size, qoi_desc *desc, int channels) {
 				run = (b1 & 0x3f);
 			}
 
-			index[QOI_COLOR_HASH(px) % 64] = px;
+			index[QOI_COLOR_HASH(px) & (64 - 1)] = px;
 		}
 
 		pixels[px_pos + 0] = px.rgba.r;


### PR DESCRIPTION
This PR updates the single-header implementation of QOI format (we use an upstream copy in our source tree) to the current version. The author of the upstream enhancement claims that it makes QOI _encoding_ 1.4% faster by replacing modulo with mask. We don't use encoding because we don't export to that format, but an identical change was made to the decoding code as well, so we can expect decoding to be faster by a comparable amount.
