### PR TITLE
Fix rawdenoise for gcc 15

### DIFF
--- a/src/iop/rawdenoise.c
+++ b/src/iop/rawdenoise.c
@@ -226,7 +226,7 @@ static void wavelet_denoise(const float *const restrict in, float *const restric
       const float *const restrict inp = in + (size_t)row * roi->width + offset;
       const int senselwidth = (roi->width-offset+1)/2;
       for(int col = 0; col < senselwidth; col++)
-        fimgp[col] = sqrtf(MAX(0.0f, inp[2*col]));
+        fimgp[col] = sqrtf(fmaxf(0.0f, inp[2*col]));
     }
 
     // perform the wavelet decomposition and denoising
@@ -298,7 +298,7 @@ static void wavelet_denoise(const float *const restrict in, float *const restric
 
 static inline float vstransform(const float value)
 {
-  return sqrtf(MAX(0.0f, value));
+  return sqrtf(fmaxf(0.0f, value));
 }
 
 static void wavelet_denoise_xtrans(const float *const restrict in, float *const restrict out,


### PR DESCRIPTION
When using rawdenoise on fedora 42 / gcc 15.1 it fails with this message
 `rawdenoise': /usr/lib64/darktable/plugins/librawdenoise.so: undefined symbol: _ZGVbM4v_sqrtf
Can be avoided by using fmaxf() instead of MAX().

See #18729 

This is just a simple fix, not sure about the implications of the other options ...

