### PR TITLE
RFC(?): Hide `rotate pixels` module in the modules panel

### DIFF
--- a/src/iop/rotatepixels.c
+++ b/src/iop/rotatepixels.c
@@ -349,26 +349,6 @@ void reload_defaults(dt_iop_module_t *self)
   *d = (dt_iop_rotatepixels_params_t){ .rx = 0u, .ry = image->fuji_rotation_pos, .angle = -45.0f };
 
   self->default_enabled = ((d->rx != 0u) || (d->ry != 0u));
-
-  // FIXME: does not work.
-  self->hide_enable_button = !self->default_enabled;
-
-  if(self->widget)
-    gtk_label_set_text(GTK_LABEL(self->widget), self->default_enabled
-                       ? _("automatic pixel rotation")
-                       : _("automatic pixel rotation\nonly works for the sensors that need it."));
-}
-
-void gui_update(dt_iop_module_t *self)
-{
-}
-void gui_init(dt_iop_module_t *self)
-{
-  IOP_GUI_ALLOC(rotatepixels);
-
-  self->widget = dt_ui_label_new("");
-  gtk_label_set_line_wrap(GTK_LABEL(self->widget), TRUE);
-
 }
 
 // clang-format off

--- a/src/iop/rotatepixels.c
+++ b/src/iop/rotatepixels.c
@@ -70,7 +70,7 @@ const char *name()
 int flags()
 {
   return IOP_FLAGS_ALLOW_TILING | IOP_FLAGS_TILING_FULL_ROI | IOP_FLAGS_ONE_INSTANCE
-    | IOP_FLAGS_UNSAFE_COPY;
+    | IOP_FLAGS_UNSAFE_COPY | IOP_FLAGS_HIDDEN;
 }
 
 int default_group()
@@ -376,4 +376,3 @@ void gui_init(dt_iop_module_t *self)
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-


### PR DESCRIPTION
CONS:

- We lose the ability to turn off this module in the modules panel and see the image from the Super-CCD camera in the form of a _beautiful_ rectangle standing on the corner.

PROS:

- More screen real estate in standard module layouts, as a result of removing the module header from the panel.
- A module with no controls, but which can nevertheless be selected and expanded, is at least surprising, if not annoying, because of its absolute lack of usefulness.
- The era of Super-CCD models from one camera manufacturer has passed so long ago that probably 99.9% of users (if not more) don't even understand what we are talking about. For them, this module in the modules panel is just a rectangle that takes up space there for no clear reason and therefore adds to their anxiety because they cannot understand what purpose this module is there for.