### PR TITLE
Fix xtrans demosaicers pushing NaN to the pipe

### DIFF
--- a/data/kernels/demosaic_markesteijn.cl
+++ b/data/kernels/demosaic_markesteijn.cl
@@ -929,6 +929,6 @@ markesteijn_final(read_only image2d_t in, write_only image2d_t out, const int wi
   pixel = (pixel.w > 0.0f) ? pixel/pixel.w : (float4)0.0f;
   pixel.w = 0.0f;
 
-  write_imagef(out, (int2)(x, y), pixel);
+  write_imagef(out, (int2)(x, y), fmax(0.0f, pixel));
 }
 

--- a/data/kernels/demosaic_vng.cl
+++ b/data/kernels/demosaic_vng.cl
@@ -355,9 +355,9 @@ clip_and_zoom_demosaic_third_size_xtrans(read_only image2d_t in, write_only imag
     }
 
   // X-Trans RGB weighting averages to 2:5:2 for each 3x3 cell
-  col[0] /= (num * 2);
-  col[1] /= (num * 5);
-  col[2] /= (num * 2);
+  col[0] = fmax(0.0f, col[0] / (num * 2));
+  col[1] = fmax(0.0f, col[1] / (num * 5));
+  col[2] = fmax(0.0f, col[1] / (num * 2));
 
   write_imagef(out, (int2)(x, y), (float4)(col[0], col[1], col[2], 0.0f));
 }

--- a/src/iop/demosaicing/xtrans.c
+++ b/src/iop/demosaicing/xtrans.c
@@ -504,7 +504,7 @@ static void xtrans_markesteijn_interpolate(float *out,
             }
           }
           for(int c = 0; c < 3; c++)
-            out[4 * (width * (row + top) + col + left) + c] = avg[c]/avg[3];
+            out[4 * (width * (row + top) + col + left) + c] = MAX(0.0f, avg[c]/avg[3]);
         }
     }
   }
@@ -1619,7 +1619,7 @@ static void xtrans_fdc_interpolate(const dt_iop_module_t *self,
           rgbpix[0] = y + 1.474600014746f * uv[1];
           rgbpix[1] = y - 0.15498578286403f * uv[0] - 0.571353132557189f * uv[1];
           rgbpix[2] = y + 1.77201282937288f * uv[0];
-          for(int c = 0; c < 3; c++) out[4 * (width * (row + top) + col + left) + c] = rgbpix[c];
+          for(int c = 0; c < 3; c++) out[4 * (width * (row + top) + col + left) + c] = MAX(0.0f, rgbpix[c]);
         }
     }
   }


### PR DESCRIPTION
Under certain conditions - high ISO and low exposure - both markesteijn and fdc demosicers can push nan to the pipe possibly leading to artifacts.
We have had several issues like this, the AMD OpenCL is especially prone to this but also box filters or gaussians get crazy if NaN are fed into the algo.

Can't find the issue right now but we have had reports exactly about this issue. Stumbled across this while investigating  capture sharpen issues on such images.One might argue it's a blackpoint issue but the demosaicer should never write garbage.
