### PR TITLE
Replace dt_opencl_read_host_from_device() by dt_opencl_copy_device_to…

### DIFF
--- a/src/common/guided_filter.c
+++ b/src/common/guided_filter.c
@@ -597,9 +597,9 @@ static int _guided_filter_cl_fallback(int devid,
   if(!guide_host || !in_host || !out_host)
     goto error;
 
-  err = dt_opencl_read_host_from_device(devid, guide_host, guide, width, height, ch * sizeof(float));
+  err = dt_opencl_copy_device_to_host(devid, guide_host, guide, width, height, ch * sizeof(float));
   if(err != CL_SUCCESS) goto error;
-  err = dt_opencl_read_host_from_device(devid, in_host, in, width, height, sizeof(float));
+  err = dt_opencl_copy_device_to_host(devid, in_host, in, width, height, sizeof(float));
   if(err != CL_SUCCESS) goto error;
 
   guided_filter(guide_host, in_host, out_host, width, height, ch, w, sqrt_eps, guide_weight, min, max);

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -2811,16 +2811,6 @@ int dt_opencl_copy_device_to_host(const int devid,
                                   const int height,
                                   const int bpp)
 {
-  return dt_opencl_read_host_from_device(devid, host, device, width, height, bpp);
-}
-
-int dt_opencl_read_host_from_device(const int devid,
-                                    void *host,
-                                    void *device,
-                                    const int width,
-                                    const int height,
-                                    const int bpp)
-{
   return dt_opencl_read_host_from_device_rowpitch(devid, host, device,
                                                   width, height, bpp * width);
 }
@@ -3506,9 +3496,7 @@ void dt_opencl_dump_pipe_pfm(const char* mod,
   float *data = dt_alloc_aligned((size_t)width * height * element_size);
   if(data)
   {
-    const cl_int err =
-      dt_opencl_read_host_from_device(devid, data, img, width, height, element_size);
-    if(err == CL_SUCCESS)
+    if(dt_opencl_copy_device_to_host(devid, data, img, width, height, element_size) == CL_SUCCESS)
       dt_dump_pfm_file(pipe, data, width, height, element_size, mod,
                        "[dt_opencl_dump_pipe_pfm]", input, !input, FALSE);
 

--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -421,13 +421,6 @@ int dt_opencl_copy_device_to_host(const int devid,
                                   const int height,
                                   const int bpp);
 
-int dt_opencl_read_host_from_device(const int devid,
-                                    void *host,
-                                    void *device,
-                                    const int width,
-                                    const int height,
-                                    const int bpp);
-
 int dt_opencl_read_host_from_device_rowpitch(const int devid,
                                              void *host,
                                              void *device,

--- a/src/develop/imageop_math.c
+++ b/src/develop/imageop_math.c
@@ -198,8 +198,7 @@ int dt_iop_clip_and_zoom_roi_cl(int devid,
     float *out = dt_alloc_align_float((size_t)roi_out->width * roi_out->height * 4);
     if(out && in)
     {
-      err = dt_opencl_read_host_from_device
-            (devid, in, dev_in, roi_in->width, roi_in->height, 4 * sizeof(float));
+      err = dt_opencl_copy_device_to_host(devid, in, dev_in, roi_in->width, roi_in->height, 4 * sizeof(float));
       if(err == CL_SUCCESS)
       {
         dt_iop_clip_and_zoom_roi(out, in, roi_out, roi_in);

--- a/src/iop/hazeremoval.c
+++ b/src/iop/hazeremoval.c
@@ -715,7 +715,7 @@ static float _ambient_light_cl(dt_iop_module_t *self,
   const int height = dt_opencl_get_image_height(img);
   const int element_size = dt_opencl_get_image_element_size(img);
   float *in = dt_alloc_aligned((size_t)width * height * element_size);
-  cl_int err = dt_opencl_read_host_from_device(devid, in, img, width, height, element_size);
+  cl_int err = dt_opencl_copy_device_to_host(devid, in, img, width, height, element_size);
   if(err != CL_SUCCESS) goto error;
 
   const const_rgb_image img_in = (const_rgb_image) {in, width, height, element_size / sizeof(float)};


### PR DESCRIPTION
…_host()

Both functions did the same, let's only use dt_opencl_copy_device_to_host() Report correct cache backcopy only in -d verbose mode