### PR TITLE
overlay: Reprocess the center area when module are reordered.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -244,6 +244,9 @@ changes (where available).
 - Fixed a bug in xtrans demosaicers that could feed NaNs into the
   pixelpipe.
 
+- Fixed display of image using a composite module when the modules are
+  reordered.
+
 ## Lua
 
 ### API Version

--- a/src/iop/overlay.c
+++ b/src/iop/overlay.c
@@ -977,6 +977,14 @@ static void _signal_image_changed(gpointer instance, dt_iop_module_t *self)
     _clear_cache_entry(self, k);
 }
 
+static void _signal_module_moved(gpointer instance, dt_iop_module_t *self)
+{
+  if(!self) return;
+
+  _clear_cache_entry(self, self->multi_priority);
+  dt_dev_reprocess_all(self->dev);
+}
+
 static void _drag_and_drop_received(GtkWidget *widget,
                                     GdkDragContext *context,
                                     gint x,
@@ -1167,8 +1175,8 @@ void gui_init(dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->rotate, _("the rotation of the overlay"));
 
   DT_CONTROL_SIGNAL_HANDLE(DT_SIGNAL_DEVELOP_MODULE_REMOVE, _module_remove_callback);
-
   DT_CONTROL_SIGNAL_HANDLE(DT_SIGNAL_DEVELOP_IMAGE_CHANGED, _signal_image_changed);
+  DT_CONTROL_SIGNAL_HANDLE(DT_SIGNAL_DEVELOP_MODULE_MOVED, _signal_module_moved);
 }
 
 // clang-format off


### PR DESCRIPTION
Ensure that the center area is reprocessed when modules are reordered. This is needed to include/exclude modules from the overlay image as required by it's position on the pipe.

Motivated by #18947.