### PR TITLE
Attempt to enable folder creation in file chooser dialogs on macOS

### DIFF
--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -2153,6 +2153,8 @@ void dt_control_move_images()
         _("select directory"), GTK_WINDOW(win), GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER,
         _("_select as destination"), _("_cancel"));
 
+  gtk_file_chooser_set_create_folders(GTK_FILE_CHOOSER(filechooser), TRUE);
+
   dt_conf_get_folder_to_file_chooser("ui_last/move_path", GTK_FILE_CHOOSER(filechooser));
   if(gtk_native_dialog_run(GTK_NATIVE_DIALOG(filechooser)) == GTK_RESPONSE_ACCEPT)
   {
@@ -2210,6 +2212,8 @@ void dt_control_copy_images()
                                 GTK_WINDOW(win), GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER,
                                 _("_select as destination"),
                                 _("_cancel"));
+
+  gtk_file_chooser_set_create_folders(GTK_FILE_CHOOSER(filechooser), TRUE);
 
   dt_conf_get_folder_to_file_chooser("ui_last/copy_path",
                                      GTK_FILE_CHOOSER(filechooser));

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -2682,6 +2682,7 @@ static void _export_clicked(GtkButton *button, gpointer user_data)
         _("select file to export"), GTK_WINDOW(win), GTK_FILE_CHOOSER_ACTION_SAVE,
         _("_export"), _("_cancel"));
 
+  gtk_file_chooser_set_create_folders(GTK_FILE_CHOOSER(chooser), TRUE);
   gtk_file_chooser_set_do_overwrite_confirmation(GTK_FILE_CHOOSER(chooser), TRUE);
   dt_conf_get_folder_to_file_chooser("ui_last/export_path", GTK_FILE_CHOOSER(chooser));
   gtk_file_chooser_set_current_name(GTK_FILE_CHOOSER(chooser), "shortcutsrc");

--- a/src/gui/preferences.c
+++ b/src/gui/preferences.c
@@ -1267,6 +1267,8 @@ static void export_preset(GtkButton *button,
         _("select directory"), GTK_WINDOW(win), GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER,
         _("_save"), _("_cancel"));
 
+  gtk_file_chooser_set_create_folders(GTK_FILE_CHOOSER(filechooser), TRUE);
+
   dt_conf_get_folder_to_file_chooser("ui_last/export_path", GTK_FILE_CHOOSER(filechooser));
 
   if(gtk_native_dialog_run(GTK_NATIVE_DIALOG(filechooser)) == GTK_RESPONSE_ACCEPT)

--- a/src/gui/presets.c
+++ b/src/gui/presets.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2010-2024 darktable developers.
+    Copyright (C) 2010-2025 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -423,6 +423,9 @@ static void _edit_preset_response(GtkDialog *dialog,
     GtkFileChooserNative *filechooser = gtk_file_chooser_native_new(
           _("select directory"), GTK_WINDOW(dialog), GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER,
           _("_select as output destination"), _("_cancel"));
+
+    gtk_file_chooser_set_create_folders(GTK_FILE_CHOOSER(filechooser), TRUE);
+
     dt_conf_get_folder_to_file_chooser("ui_last/export_path",
                                        GTK_FILE_CHOOSER(filechooser));
 

--- a/src/imageio/storage/disk.c
+++ b/src/imageio/storage/disk.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2010-2024 darktable developers.
+    Copyright (C) 2010-2025 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -196,6 +196,8 @@ static void button_clicked(GtkWidget *widget,
   GtkFileChooserNative *filechooser = gtk_file_chooser_native_new(
         _("select directory"), GTK_WINDOW(win), GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER,
         _("_select as output destination"), _("_cancel"));
+
+  gtk_file_chooser_set_create_folders(GTK_FILE_CHOOSER(filechooser), TRUE);
 
   gchar *old = g_strdup(gtk_entry_get_text(d->entry));
   gchar *dirname;

--- a/src/imageio/storage/gallery.c
+++ b/src/imageio/storage/gallery.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2011-2024 darktable developers.
+    Copyright (C) 2011-2025 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -147,6 +147,8 @@ static void button_clicked(GtkWidget *widget,
   GtkFileChooserNative *filechooser = gtk_file_chooser_native_new(
          _("select directory"), GTK_WINDOW(win), GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER,
          _("_select as output destination"), _("_cancel"));
+
+  gtk_file_chooser_set_create_folders(GTK_FILE_CHOOSER(filechooser), TRUE);
 
   gchar *old = g_strdup(gtk_entry_get_text(d->entry));
   char *c = g_strstr_len(old, -1, "$");

--- a/src/imageio/storage/latex.c
+++ b/src/imageio/storage/latex.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2012-2024 darktable developers.
+    Copyright (C) 2012-2025 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -143,6 +143,8 @@ static void button_clicked(GtkWidget *widget, dt_imageio_module_storage_t *self)
   GtkFileChooserNative *filechooser = gtk_file_chooser_native_new(
         _("select directory"), GTK_WINDOW(win), GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER,
         _("_select as output destination"), _("_cancel"));
+
+  gtk_file_chooser_set_create_folders(GTK_FILE_CHOOSER(filechooser), TRUE);
 
   gchar *old = g_strdup(gtk_entry_get_text(d->entry));
   char *c = g_strstr_len(old, -1, "$");

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -432,6 +432,8 @@ static void view_popup_menu_onSearchFilmroll(GtkWidget *menuitem,
      GTK_WINDOW(win), GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER,
      _("_open"), _("_cancel"));
 
+  gtk_file_chooser_set_create_folders(GTK_FILE_CHOOSER(filechooser), TRUE);
+
   if(tree_path != NULL)
     gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(filechooser), tree_path);
   else

--- a/src/libs/import.c
+++ b/src/libs/import.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2011-2024 darktable developers.
+    Copyright (C) 2011-2025 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -1862,6 +1862,8 @@ static void _lib_import_select_folder(GtkWidget *widget,
       _("select directory"), GTK_WINDOW(win),
       GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER, _("_open"), _("_cancel"));
 
+  gtk_file_chooser_set_create_folders(GTK_FILE_CHOOSER(filechooser), TRUE);
+
   // run the native dialog
   dt_conf_get_folder_to_file_chooser("ui_last/import_last_place",
                                      GTK_FILE_CHOOSER(filechooser));
@@ -1974,6 +1976,8 @@ static void _browse_basedir_clicked(GtkWidget *widget,
   GtkFileChooserNative *filechooser = gtk_file_chooser_native_new(
       _("select directory"), GTK_WINDOW(topwindow),
       GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER, _("_open"), _("_cancel"));
+
+  gtk_file_chooser_set_create_folders(GTK_FILE_CHOOSER(filechooser), TRUE);
 
   gchar *old = g_strdup(gtk_entry_get_text(basedir));
   char *c = g_strstr_len(old, -1, "$");

--- a/src/libs/styles.c
+++ b/src/libs/styles.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2010-2024 darktable developers.
+    Copyright (C) 2010-2025 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -450,6 +450,8 @@ static void _export_clicked(GtkWidget *w, dt_lib_styles_t *d)
   GtkFileChooserNative *filechooser = gtk_file_chooser_native_new(
         _("select directory"), GTK_WINDOW(win), GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER,
         _("_save"), _("_cancel"));
+
+  gtk_file_chooser_set_create_folders(GTK_FILE_CHOOSER(filechooser), TRUE);
 
   dt_conf_get_folder_to_file_chooser("ui_last/export_path", GTK_FILE_CHOOSER(filechooser));
   gtk_file_chooser_set_select_multiple(GTK_FILE_CHOOSER(filechooser), FALSE);

--- a/src/libs/tagging.c
+++ b/src/libs/tagging.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2010-2024 darktable developers.
+    Copyright (C) 2010-2025 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -2627,6 +2627,8 @@ static void _export_button_clicked(GtkButton *button, dt_lib_module_t *self)
   GtkFileChooserNative *filechooser = gtk_file_chooser_native_new(
         _("select file to export to"), GTK_WINDOW(win), GTK_FILE_CHOOSER_ACTION_SAVE,
         _("_export"), _("_cancel"));
+
+  gtk_file_chooser_set_create_folders(GTK_FILE_CHOOSER(filechooser), TRUE);
 
   gtk_file_chooser_set_do_overwrite_confirmation(GTK_FILE_CHOOSER(filechooser), TRUE);
   gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(filechooser), last_dirname);


### PR DESCRIPTION
This is certainly not needed for Linux and Windows, where even without this setting, the native dialogs offer folder creation functionality. I don't have macOS devices, so I need this PR to be tested by macOS users to see if it will _actually_ enable the ability to create folders, which is disabled by default.

attn: @MStraeten @zisoft 
