### PR TITLE
add busy indicators for applying GPX files

### DIFF
--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -1375,6 +1375,9 @@ static int32_t _control_gpx_apply_job_run(dt_job_t *job)
   const dt_control_gpx_apply_t *d = params->data;
   const gchar *filename = d->filename;
   const gchar *tz = d->tz;
+  char message[512] = { 0 };
+  double fraction = 0;
+
   /* do we have any selected images */
   if(!t) goto bail_out;
 
@@ -1388,6 +1391,13 @@ static int32_t _control_gpx_apply_job_run(dt_job_t *job)
 
   GTimeZone *tz_camera = (tz == NULL) ? g_time_zone_new_utc() : g_time_zone_new(tz);
   if(!tz_camera) goto bail_out;
+
+  const guint total = g_list_length(t);
+  double prev_time = 0;
+  g_snprintf(message, sizeof(message),
+             ngettext("setting GPS information", "setting GPS information for %u images", total),
+             total);
+  dt_control_job_set_progress_message(job, message);
 
   GList *imgs = NULL;
   GArray *gloc = g_array_new(FALSE, FALSE, sizeof(dt_image_geoloc_t));
@@ -1424,6 +1434,7 @@ static int32_t _control_gpx_apply_job_run(dt_job_t *job)
       g_list_free(grps);
     }
     g_date_time_unref(utc_time);
+    _update_progress(job, fraction, &prev_time);
   } while((t = g_list_next(t)) != NULL);
   imgs = g_list_reverse(imgs);
 

--- a/src/libs/geotagging.c
+++ b/src/libs/geotagging.c
@@ -299,6 +299,7 @@ static void _remove_images_from_map(dt_lib_module_t *self)
 
 static void _refresh_images_displayed_on_track(const int segid, const gboolean active, dt_lib_module_t *self)
 {
+  dt_gui_cursor_set_busy();
   dt_lib_geotagging_t *d = self->data;
   for(GList *i = d->imgs; i; i = g_list_next(i))
   {
@@ -342,6 +343,7 @@ static void _refresh_images_displayed_on_track(const int segid, const gboolean a
       }
     }
   }
+  dt_gui_cursor_clear_busy();
 }
 
 static void _update_nb_images(dt_lib_module_t *self)


### PR DESCRIPTION
Displaying a GPX track preview can take tens of seconds if there are many images and their thumbnails are not cached.  During this time, the GUI is frozen, so enable the busy cursor.

Also add a progress bar when applying the GPX track to images, though this is a far faster operation.