### PR TITLE
use full metadata tag name for variable substitution

### DIFF
--- a/src/common/variables.c
+++ b/src/common/variables.c
@@ -953,9 +953,8 @@ static char *_get_base_value(dt_variables_params_t *params, char **variable)
     for(GList* iter = dt_metadata_get_list(); iter; iter = iter->next)
     {
       dt_metadata_t *metadata = (dt_metadata_t *)iter->data;
-      gchar *prefix = g_utf8_strup(dt_metadata_get_tag_subkey(metadata->tagname), -1);
       gboolean found = FALSE;
-      if(_has_prefix(variable, prefix))
+      if(_has_prefix(variable, metadata->tagname))
       {
         GList *res = dt_metadata_get(params->imgid, metadata->tagname, NULL);
         if(res != NULL)
@@ -963,7 +962,6 @@ static char *_get_base_value(dt_variables_params_t *params, char **variable)
         g_list_free_full(res, g_free);
         found = TRUE;
       }
-      g_free(prefix);
       if(found) break;
     }
     dt_pthread_mutex_unlock(&darktable.metadata_threadsafe);

--- a/src/gui/gtkentry.c
+++ b/src/gui/gtkentry.c
@@ -291,7 +291,7 @@ void dt_gtkentry_variables_add_metadata(dt_metadata_t *metadata)
 {
   GtkTreeIter iter;
 
-  gchar *varname = g_utf8_strup(dt_metadata_get_tag_subkey(metadata->tagname), -1);
+  gchar *varname = g_strdup(metadata->tagname);
   gchar *description = g_strdup_printf("$(%s) - %s", varname, _("from metadata"));
   gtk_list_store_append(_completion_model, &iter);
   gtk_list_store_set(_completion_model, &iter,


### PR DESCRIPTION
It turned out that using only the last part of the metadata tag name is not sufficient and in some cases it can be ambiguous.

In #18976 it breaks watermark settings for old edits.

Solution is to use the full metadata tag name for the variable name:

<img width="291" alt="Bildschirmfoto 2025-06-23 um 13 28 54" src="https://github.com/user-attachments/assets/b37498a1-a80b-4725-85cf-82669fe429dc" />

This requires a documentation change as well, I will provide a PR on dtdocs for that.


fixes #18976 