### PR TITLE
Fix build with clang-21

### DIFF
--- a/data/kernels/CMakeLists.txt
+++ b/data/kernels/CMakeLists.txt
@@ -15,7 +15,7 @@ macro (testcompile_opencl_kernel IN)
 
   add_custom_command(
     OUTPUT  ${TOUCH}
-    COMMAND ${CLANG_OPENCL_COMPILER} -cc1 -cl-std=CL1.2 -isystem ${CLANG_OPENCL_INCLUDE_DIR} -finclude-default-header -I${CMAKE_CURRENT_SOURCE_DIR} ${IN}
+    COMMAND ${CLANG_OPENCL_COMPILER} -cc1 -cl-std=CL1.2 -isystem ${CLANG_OPENCL_INCLUDE_DIR} -D__IMAGE_SUPPORT__=1 -finclude-default-header -I${CMAKE_CURRENT_SOURCE_DIR} ${IN}
     COMMAND ${CMAKE_COMMAND} -E touch ${TOUCH} # will be empty!
     DEPENDS ${IN}
     COMMENT "Test-compiling OpenCL program ${KERNAME}"


### PR DESCRIPTION
Error Message:

darktable-5.2.0/data/kernels/soften.cl:33:18: error: use of undeclared identifier 'read_imagef'
   33 |   float4 pixel = read_imagef(in, sampleri, (int2)(x, y));
      |                  ^~~~~~~~~~~

https://github.com/llvm/llvm-project/commit/c1aebd495be0e468044f716a3a0ff98fccccb2be wrapped all the image function declarations in the __IMAGE_SUPPORT__ macro, so darktable needs to define this macro in order to use these functions.