### PR TITLE
Silence libheif warnings

### DIFF
--- a/cmake/compiler-warnings.cmake
+++ b/cmake/compiler-warnings.cmake
@@ -38,6 +38,9 @@ CHECK_COMPILER_FLAG_AND_ENABLE_IT(-Wno-format-truncation)
 # clang-4.0 bug https://llvm.org/bugs/show_bug.cgi?id=28115#c7
 CHECK_COMPILER_FLAG_AND_ENABLE_IT(-Wno-error=address-of-packed-member)
 
+# needed to deal with warnings in libheif
+CHECK_C_COMPILER_FLAG_AND_ENABLE_IT(-Wno-typedef-redefinition)
+
 # minimal main thread's stack/frame stack size.
 # 2 MiB seems to work.
 # 1 MiB does NOT work with gmic support enabled.


### PR DESCRIPTION
This regression is in libheif v1.20.0:
```
/usr/local/include/libheif/heif_image.h:107:34: fatal error: redefinition of typedef 'heif_image_handle' is a C11 feature [-Wtypedef-redefinition]
typedef struct heif_image_handle heif_image_handle;
                                 ^
/usr/local/include/libheif/heif_library.h:95:34: note: previous definition is here
typedef struct heif_image_handle heif_image_handle;
```