### PR TITLE
[imageio] Fix loading of RAW files misidentified as TIFF and TIFF files misidentified as RAW

### DIFF
--- a/src/imageio/imageio_rawspeed.cc
+++ b/src/imageio/imageio_rawspeed.cc
@@ -454,7 +454,12 @@ dt_imageio_retval_t dt_imageio_open_rawspeed(dt_image_t *img,
     else
     {
       dt_print(DT_DEBUG_ALWAYS, "[rawspeed] %s corrupt: %s", img->filename, exc.what());
-      return DT_IMAGEIO_FILE_CORRUPTED;
+      // We can end up here if the loader is called on what is actually
+      // a TIFF file, which mistakenly contains the signature of a raw
+      // format in a TIFF container. So it is very important that the
+      // return code from here directs the execution path through the
+      // fallback loader chain.
+      return DT_IMAGEIO_UNSUPPORTED_FORMAT;
     }
   }
   catch(const rawspeed::RawParserException &exc)


### PR DESCRIPTION
We have two "opposite" problems with incorrect identification of file formats:

1. Files that are actually raw files from cameras, but due to a strange decision of the manufacturer have the extension .tiff and can be read as TIFF files. In this case, we will read a small thumbnail of the actual shot from the camera. Example: #19046

1. Files that are actually TIFF files (created from raw files), but due to oversight of the programs that create these files, they leave bytes from input files there, which when matching signatures force us to mistakenly decide that this is a raw file. Example: #17738

This PR reverts the previous fix for the second problem, since the regression from this fix (#17742) led to the first problem. After that, the second problem is solved in a different way (by changing the return code to call the fallback loader).
