### PR TITLE
jxl: Support fine-grained metadata filtering instead of all-or-nothing by filtering Exif data in memory

### DIFF
--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -2629,6 +2629,27 @@ gboolean dt_exif_read(dt_image_t *img,
   }
 }
 
+int dt_exif_write_exv(uint8_t *blob,
+                       uint32_t size,
+                       const char *path,
+                       const int compressed)
+{
+  try
+  {
+    std::unique_ptr<Exiv2::Image> image(Exiv2::ImageFactory::create(Exiv2::ImageType::exv, WIDEN(path)));
+    image->writeMetadata();
+  }
+  catch(const Exiv2::AnyError &e)
+  {
+    dt_print(DT_DEBUG_IMAGEIO,
+             "[exiv2 dt_exif_write_blob] %s: %s",
+             path,
+             e.what());
+    return 0;
+  }
+  return 1;
+}
+
 int dt_exif_write_blob(uint8_t *blob,
                        uint32_t size,
                        const char *path,

--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -2629,27 +2629,6 @@ gboolean dt_exif_read(dt_image_t *img,
   }
 }
 
-int dt_exif_write_exv(uint8_t *blob,
-                       uint32_t size,
-                       const char *path,
-                       const int compressed)
-{
-  try
-  {
-    std::unique_ptr<Exiv2::Image> image(Exiv2::ImageFactory::create(Exiv2::ImageType::exv, WIDEN(path)));
-    image->writeMetadata();
-  }
-  catch(const Exiv2::AnyError &e)
-  {
-    dt_print(DT_DEBUG_IMAGEIO,
-             "[exiv2 dt_exif_write_blob] %s: %s",
-             path,
-             e.what());
-    return 0;
-  }
-  return 1;
-}
-
 // Filter unwanted Exif tags for export (thumbnails and pixel dimensions for non-compressed)
 static void _filter_exif_for_export(Exiv2::ExifData &exifData, const int compressed)
 {

--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -2650,6 +2650,37 @@ int dt_exif_write_exv(uint8_t *blob,
   return 1;
 }
 
+// Filter unwanted Exif tags for export (thumbnails and pixel dimensions for non-compressed)
+static void _filter_exif_for_export(Exiv2::ExifData &exifData, const int compressed)
+{
+  // Remove thumbnail
+  {
+    static const char *keys[] = {
+      "Exif.Thumbnail.Compression",
+      "Exif.Thumbnail.XResolution",
+      "Exif.Thumbnail.YResolution",
+      "Exif.Thumbnail.ResolutionUnit",
+      "Exif.Thumbnail.JPEGInterchangeFormat",
+      "Exif.Thumbnail.JPEGInterchangeFormatLength"
+    };
+    static const guint n_keys = G_N_ELEMENTS(keys);
+    _remove_exif_keys(exifData, keys, n_keys);
+  }
+
+  // Only compressed images may set PixelXDimension and PixelYDimension
+  if(!compressed)
+  {
+    static const char *keys[] = {
+      "Exif.Photo.PixelXDimension",
+      "Exif.Photo.PixelYDimension"
+    };
+    static const guint n_keys = G_N_ELEMENTS(keys);
+    _remove_exif_keys(exifData, keys, n_keys);
+  }
+
+  exifData.sortByTag();
+}
+
 int dt_exif_write_blob(uint8_t *blob,
                        uint32_t size,
                        const char *path,
@@ -2674,32 +2705,7 @@ int dt_exif_write_blob(uint8_t *blob,
       imgExifData.add(Exiv2::ExifKey(i->key()), &i->value());
     }
 
-    {
-      // Remove thumbnail
-      static const char *keys[] = {
-        "Exif.Thumbnail.Compression",
-        "Exif.Thumbnail.XResolution",
-        "Exif.Thumbnail.YResolution",
-        "Exif.Thumbnail.ResolutionUnit",
-        "Exif.Thumbnail.JPEGInterchangeFormat",
-        "Exif.Thumbnail.JPEGInterchangeFormatLength"
-      };
-      static const guint n_keys = G_N_ELEMENTS(keys);
-      _remove_exif_keys(imgExifData, keys, n_keys);
-    }
-
-    // Only compressed images may set PixelXDimension and PixelYDimension.
-    if(!compressed)
-    {
-      static const char *keys[] = {
-        "Exif.Photo.PixelXDimension",
-        "Exif.Photo.PixelYDimension"
-      };
-      static const guint n_keys = G_N_ELEMENTS(keys);
-      _remove_exif_keys(imgExifData, keys, n_keys);
-    }
-
-    imgExifData.sortByTag();
+    _filter_exif_for_export(imgExifData, compressed);
     write_metadata_threadsafe(image);
   }
   catch(const Exiv2::AnyError &e)
@@ -2711,6 +2717,50 @@ int dt_exif_write_blob(uint8_t *blob,
     return 0;
   }
   return 1;
+}
+
+int dt_exif_write_blob_to_buffer(uint8_t *input_blob,
+                                  uint32_t input_size,
+                                  uint8_t **output_blob,
+                                  const int compressed)
+{
+  *output_blob = NULL;
+
+  try
+  {
+    // Decode input Exif blob into memory
+    Exiv2::ExifData exifData;
+    Exiv2::ExifParser::decode(exifData, input_blob, input_size);
+
+    _filter_exif_for_export(exifData, compressed);
+
+    // Encode to buffer
+    Exiv2::Blob blob;
+    Exiv2::ExifParser::encode(blob, Exiv2::bigEndian, exifData);
+
+    const size_t output_size = blob.size();
+    *output_blob = (uint8_t *)g_malloc(output_size);
+    if(!*output_blob)
+    {
+      dt_print(DT_DEBUG_IMAGEIO, "[exif] could not allocate output buffer of size %zu", output_size);
+      return 0;
+    }
+
+    memcpy(*output_blob, blob.data(), output_size);
+    return (int)output_size;
+  }
+  catch(const Exiv2::AnyError &e)
+  {
+    dt_print(DT_DEBUG_IMAGEIO,
+             "[exiv2 dt_exif_write_blob_to_buffer] %s",
+             e.what());
+    if(*output_blob)
+    {
+      g_free(*output_blob);
+      *output_blob = NULL;
+    }
+    return 0;
+  }
 }
 
 static void _remove_exif_geotag(Exiv2::ExifData &exifData)

--- a/src/common/exif.h
+++ b/src/common/exif.h
@@ -92,6 +92,12 @@ int dt_exif_read_blob(uint8_t **blob, const char *path, const dt_imgid_t imgid, 
 /** Reads exif tags that are not cached in the database */
 void dt_exif_img_check_additional_tags(dt_image_t *img, const char *filename);
 
+/** create empty metadata file */
+int dt_exif_write_exv(uint8_t *blob,
+                       uint32_t size,
+                       const char *path,
+                       const int compressed);
+
 /** write blob to file exif. merges with existing exif information.*/
 int dt_exif_write_blob(uint8_t *blob, uint32_t size, const char *path, const int compressed);
 

--- a/src/common/exif.h
+++ b/src/common/exif.h
@@ -101,6 +101,11 @@ int dt_exif_write_exv(uint8_t *blob,
 /** write blob to file exif. merges with existing exif information.*/
 int dt_exif_write_blob(uint8_t *blob, uint32_t size, const char *path, const int compressed);
 
+/** write filtered exif blob to memory buffer (in-memory filtering, no temporary files).
+ * caller must free output_blob with g_free().
+ * returns size of output buffer, or 0 on error. */
+int dt_exif_write_blob_to_buffer(uint8_t *input_blob, uint32_t input_size, uint8_t **output_blob, const int compressed);
+
 /** write xmp sidecar file. */
 /** if force_write is FALSE, the current contents of the sidecar file are compared against what
     would be written, and the write is skipped if they are the same.  This preserves the sidecar

--- a/src/common/exif.h
+++ b/src/common/exif.h
@@ -92,12 +92,6 @@ int dt_exif_read_blob(uint8_t **blob, const char *path, const dt_imgid_t imgid, 
 /** Reads exif tags that are not cached in the database */
 void dt_exif_img_check_additional_tags(dt_image_t *img, const char *filename);
 
-/** create empty metadata file */
-int dt_exif_write_exv(uint8_t *blob,
-                       uint32_t size,
-                       const char *path,
-                       const int compressed);
-
 /** write blob to file exif. merges with existing exif information.*/
 int dt_exif_write_blob(uint8_t *blob, uint32_t size, const char *path, const int compressed);
 

--- a/src/imageio/format/jxl.c
+++ b/src/imageio/format/jxl.c
@@ -319,8 +319,8 @@ int write_image(struct dt_imageio_module_data_t *data,
     if(!exif_buf)
       JXL_FAIL("could not allocate Exif buffer of size %zu", (size_t)(exif_len + 4));
     memmove(exif_buf + 4, exif, exif_len);
-    // Exiv2 < 0.28 doesn't support Brotli compressed boxes
-    LIBJXL_ASSERT(JxlEncoderAddBox(encoder, "Exif", exif_buf, exif_len + 4, JXL_FALSE));
+    // Exiv2 >= 0.28 (released 2023-05-08) supports Brotli compressed boxes
+    LIBJXL_ASSERT(JxlEncoderAddBox(encoder, "Exif", exif_buf, exif_len + 4, JXL_TRUE));
   }
 
   /* TODO: workaround; remove when exiv2 implements JXL BMFF write support and update flags() */
@@ -332,9 +332,9 @@ int write_image(struct dt_imageio_module_data_t *data,
     if(xmp_string
        && (xmp_len = strlen(xmp_string)) > 0)
     {
-      // Exiv2 < 0.28 doesn't support Brotli compressed boxes
+      // Exiv2 >= 0.28 (released 2023-05-08) supports Brotli compressed boxes
       LIBJXL_ASSERT(JxlEncoderAddBox(encoder, "xml ",
-                                     (const uint8_t *)xmp_string, xmp_len, JXL_FALSE));
+                                     (const uint8_t *)xmp_string, xmp_len, JXL_TRUE));
     }
   }
 

--- a/src/imageio/format/jxl.c
+++ b/src/imageio/format/jxl.c
@@ -309,34 +309,34 @@ int write_image(struct dt_imageio_module_data_t *data,
   if(exif && exif_len > 0)
     LIBJXL_ASSERT(JxlEncoderUseBoxes(encoder));
 
-  /* TODO: workaround; remove when exiv2 implements JXL BMFF write support and use dt_exif_write_blob() after
-   * closing file instead */
-  if(exif && exif_len > 0)
-  {
-    // Prepend the 4 byte (zero) offset to the blob before writing
-    // (as required in the equivalent HEIF/JPEG XS Exif box specs)
-    exif_buf = g_try_malloc0(exif_len + 4);
-    if(!exif_buf)
-      JXL_FAIL("could not allocate Exif buffer of size %zu", (size_t)(exif_len + 4));
-    memmove(exif_buf + 4, exif, exif_len);
-    // Exiv2 >= 0.28 (released 2023-05-08) supports Brotli compressed boxes
-    LIBJXL_ASSERT(JxlEncoderAddBox(encoder, "Exif", exif_buf, exif_len + 4, JXL_TRUE));
-  }
+  // /* TODO: workaround; remove when exiv2 implements JXL BMFF write support and use dt_exif_write_blob() after
+  //  * closing file instead */
+  // if(exif && exif_len > 0)
+  // {
+  //   // Prepend the 4 byte (zero) offset to the blob before writing
+  //   // (as required in the equivalent HEIF/JPEG XS Exif box specs)
+  //   exif_buf = g_try_malloc0(exif_len + 4);
+  //   if(!exif_buf)
+  //     JXL_FAIL("could not allocate Exif buffer of size %zu", (size_t)(exif_len + 4));
+  //   memmove(exif_buf + 4, exif, exif_len);
+  //   // Exiv2 >= 0.28 (released 2023-05-08) supports Brotli compressed boxes
+  //   LIBJXL_ASSERT(JxlEncoderAddBox(encoder, "Exif", exif_buf, exif_len + 4, JXL_TRUE));
+  // }
 
-  /* TODO: workaround; remove when exiv2 implements JXL BMFF write support and update flags() */
-  /* TODO: workaround; uses valid exif as a way to indicate ALL metadata was requested */
-  if(exif && exif_len > 0)
-  {
-    xmp_string = dt_exif_xmp_read_string(imgid);
-    size_t xmp_len;
-    if(xmp_string
-       && (xmp_len = strlen(xmp_string)) > 0)
-    {
-      // Exiv2 >= 0.28 (released 2023-05-08) supports Brotli compressed boxes
-      LIBJXL_ASSERT(JxlEncoderAddBox(encoder, "xml ",
-                                     (const uint8_t *)xmp_string, xmp_len, JXL_TRUE));
-    }
-  }
+  // /* TODO: workaround; remove when exiv2 implements JXL BMFF write support and update flags() */
+  // /* TODO: workaround; uses valid exif as a way to indicate ALL metadata was requested */
+  // if(exif && exif_len > 0)
+  // {
+  //   xmp_string = dt_exif_xmp_read_string(imgid);
+  //   size_t xmp_len;
+  //   if(xmp_string
+  //      && (xmp_len = strlen(xmp_string)) > 0)
+  //   {
+  //     // Exiv2 >= 0.28 (released 2023-05-08) supports Brotli compressed boxes
+  //     LIBJXL_ASSERT(JxlEncoderAddBox(encoder, "xml ",
+  //                                    (const uint8_t *)xmp_string, xmp_len, JXL_TRUE));
+  //   }
+  // }
 
   JxlPixelFormat pixel_format = { 3, JXL_TYPE_FLOAT, JXL_NATIVE_ENDIAN, 0 };
 
@@ -423,6 +423,29 @@ end:
   g_free(exif_buf);
   g_free(xmp_string);
   g_free(out_buf);
+
+  // #ifdef EXV_ENABLE_BMPP (exiv can read from, but not write to bmpp)s
+  // #ifdef EXV_HAVE_BROTLI (exiv supports brotli compression
+
+  // move this before the image is written in imageio.c, then do all metadata
+  // processing on exv, then send final metadata to jxl codec.
+  char* exv_filename = g_malloc(strlen(filename) + 5);
+  snprintf(exv_filename, strlen(filename) + 5, "%s%s", filename, ".exv");
+
+  // empty metadata file (call write_blob inside there for us)
+  dt_exif_write_exv(exif, exif_len, exv_filename, 1);
+
+  if(exif) {
+    dt_print(DT_DEBUG_ALWAYS,
+             "[jxl] exif_write_blob");
+     dt_exif_write_blob(exif, exif_len, exv_filename, 1);
+  } else {
+    dt_print(DT_DEBUG_ALWAYS,
+             "[jxl] no exif_write_blob");
+  }
+
+  g_free(exv_filename);
+  // now read from exv, include exif blob in jxl
 
   return ret;
 }

--- a/src/imageio/format/jxl.c
+++ b/src/imageio/format/jxl.c
@@ -311,34 +311,34 @@ int write_image(struct dt_imageio_module_data_t *data,
 
   // /* TODO: workaround; remove when exiv2 implements JXL BMFF write support and use dt_exif_write_blob() after
   //  * closing file instead */
-  // if(exif && exif_len > 0)
-  // {
-  //   // Prepend the 4 byte (zero) offset to the blob before writing
-  //   // (as required in the equivalent HEIF/JPEG XS Exif box specs)
-  //   exif_buf = g_try_malloc0(exif_len + 4);
-  //   if(!exif_buf)
-  //     JXL_FAIL("could not allocate Exif buffer of size %zu", (size_t)(exif_len + 4));
-  //   memmove(exif_buf + 4, exif, exif_len);
-  //   // Exiv2 >= 0.28 (released 2023-05-08) supports Brotli compressed boxes
-  //   LIBJXL_ASSERT(JxlEncoderAddBox(encoder, "Exif", exif_buf, exif_len + 4, JXL_TRUE));
-  // }
+  if(exif && exif_len > 0)
+  {
+    // Prepend the 4 byte (zero) offset to the blob before writing
+    // (as required in the equivalent HEIF/JPEG XS Exif box specs)
+    exif_buf = g_try_malloc0(exif_len + 4);
+    if(!exif_buf)
+      JXL_FAIL("could not allocate Exif buffer of size %zu", (size_t)(exif_len + 4));
+    memmove(exif_buf + 4, exif, exif_len);
+    // Exiv2 >= 0.28 (released 2023-05-08) supports Brotli compressed boxes
+    LIBJXL_ASSERT(JxlEncoderAddBox(encoder, "Exif", exif_buf, exif_len + 4, JXL_TRUE));
+  }
 
-  // /* TODO: workaround; remove when exiv2 implements JXL BMFF write support and update flags() */
-  // /* TODO: workaround; uses valid exif as a way to indicate ALL metadata was requested */
-  // if(exif && exif_len > 0)
-  // {
-  //   xmp_string = dt_exif_xmp_read_string(imgid);
-  //   size_t xmp_len;
-  //   if(xmp_string
-  //      && (xmp_len = strlen(xmp_string)) > 0)
-  //   {
-  //     // Exiv2 >= 0.28 (released 2023-05-08) supports Brotli compressed boxes
-  //     LIBJXL_ASSERT(JxlEncoderAddBox(encoder, "xml ",
-  //                                    (const uint8_t *)xmp_string, xmp_len, JXL_TRUE));
-  //   }
-  // }
+  /* TODO: workaround; remove when exiv2 implements JXL BMFF write support and update flags() */
+  /* TODO: workaround; uses valid exif as a way to indicate ALL metadata was requested */
+  if(exif && exif_len > 0)
+  {
+    xmp_string = dt_exif_xmp_read_string(imgid);
+    size_t xmp_len;
+    if(xmp_string
+       && (xmp_len = strlen(xmp_string)) > 0)
+    {
+      // Exiv2 >= 0.28 (released 2023-05-08) supports Brotli compressed boxes
+      LIBJXL_ASSERT(JxlEncoderAddBox(encoder, "xml ",
+                                     (const uint8_t *)xmp_string, xmp_len, JXL_TRUE));
+    }
+  }
 
-  JxlPixelFormat pixel_format = { 3, JXL_TYPE_FLOAT, JXL_NATIVE_ENDIAN, 0 };
+f  JxlPixelFormat pixel_format = { 3, JXL_TYPE_FLOAT, JXL_NATIVE_ENDIAN, 0 };
 
   // Fix pixel stride
   const size_t pixels_size = width * height * 3 * sizeof(float);
@@ -423,29 +423,6 @@ end:
   g_free(exif_buf);
   g_free(xmp_string);
   g_free(out_buf);
-
-  // #ifdef EXV_ENABLE_BMPP (exiv can read from, but not write to bmpp)s
-  // #ifdef EXV_HAVE_BROTLI (exiv supports brotli compression
-
-  // move this before the image is written in imageio.c, then do all metadata
-  // processing on exv, then send final metadata to jxl codec.
-  char* exv_filename = g_malloc(strlen(filename) + 5);
-  snprintf(exv_filename, strlen(filename) + 5, "%s%s", filename, ".exv");
-
-  // empty metadata file (call write_blob inside there for us)
-  dt_exif_write_exv(exif, exif_len, exv_filename, 1);
-
-  if(exif) {
-    dt_print(DT_DEBUG_ALWAYS,
-             "[jxl] exif_write_blob");
-     dt_exif_write_blob(exif, exif_len, exv_filename, 1);
-  } else {
-    dt_print(DT_DEBUG_ALWAYS,
-             "[jxl] no exif_write_blob");
-  }
-
-  g_free(exv_filename);
-  // now read from exv, include exif blob in jxl
 
   return ret;
 }

--- a/src/imageio/format/jxl.c
+++ b/src/imageio/format/jxl.c
@@ -434,14 +434,9 @@ int levels(dt_imageio_module_data_t *data)
 
 int flags(dt_imageio_module_data_t *data)
 {
-  /*
-   * As of exiv2 0.27.5 there is no write support for the JXL BMFF format,
-   * so we do not return the XMP supported flag currently.
-   * Once exiv2 write support is there, the flag can be returned, and the
-   * direct XMP embedding workaround using JxlEncoderAddBox("xml ") above
-   * can be removed.
-   */
-  return 0; /* FORMAT_FLAGS_SUPPORT_XMP; */
+  // exiv2 >= 0.28 supports JXL BMFF format for metadata, allowing
+  // fine-grained metadata control like other formats
+  return FORMAT_FLAGS_SUPPORT_XMP;
 }
 
 static inline int _bpp_to_enum(int bpp)

--- a/src/imageio/format/jxl.c
+++ b/src/imageio/format/jxl.c
@@ -324,6 +324,18 @@ int write_image(struct dt_imageio_module_data_t *data,
     LIBJXL_ASSERT(JxlEncoderAddBox(encoder, "Exif", exif_buf, exif_len + 4, JXL_TRUE));
   }
 
+  if(exif && exif_len > 0) // TODO separate signal for "include XMP"
+  {
+    xmp_string = dt_exif_xmp_read_string(imgid);
+    size_t xmp_len;
+    if(xmp_string
+       && (xmp_len = strlen(xmp_string)) > 0)
+    {
+      LIBJXL_ASSERT(JxlEncoderAddBox(encoder, "xml ",
+                                     (const uint8_t *)xmp_string, xmp_len, JXL_FALSE));
+    }
+  }
+
   JxlPixelFormat pixel_format = { 3, JXL_TYPE_FLOAT, JXL_NATIVE_ENDIAN, 0 };
 
   // Fix pixel stride

--- a/src/imageio/format/jxl.c
+++ b/src/imageio/format/jxl.c
@@ -309,8 +309,8 @@ int write_image(struct dt_imageio_module_data_t *data,
   if(exif && exif_len > 0)
     LIBJXL_ASSERT(JxlEncoderUseBoxes(encoder));
 
-  // /* TODO: workaround; remove when exiv2 implements JXL BMFF write support and use dt_exif_write_blob() after
-  //  * closing file instead */
+  // Filter and embed metadata into JXL BMFF container
+  // Note: exif is already filtered by imageio.c via the .exv file workflow
   if(exif && exif_len > 0)
   {
     // Prepend the 4 byte (zero) offset to the blob before writing
@@ -318,24 +318,10 @@ int write_image(struct dt_imageio_module_data_t *data,
     exif_buf = g_try_malloc0(exif_len + 4);
     if(!exif_buf)
       JXL_FAIL("could not allocate Exif buffer of size %zu", (size_t)(exif_len + 4));
+    
     memmove(exif_buf + 4, exif, exif_len);
     // Exiv2 >= 0.28 (released 2023-05-08) supports Brotli compressed boxes
     LIBJXL_ASSERT(JxlEncoderAddBox(encoder, "Exif", exif_buf, exif_len + 4, JXL_TRUE));
-  }
-
-  /* TODO: workaround; remove when exiv2 implements JXL BMFF write support and update flags() */
-  /* TODO: workaround; uses valid exif as a way to indicate ALL metadata was requested */
-  if(exif && exif_len > 0)
-  {
-    xmp_string = dt_exif_xmp_read_string(imgid);
-    size_t xmp_len;
-    if(xmp_string
-       && (xmp_len = strlen(xmp_string)) > 0)
-    {
-      // Exiv2 >= 0.28 (released 2023-05-08) supports Brotli compressed boxes
-      LIBJXL_ASSERT(JxlEncoderAddBox(encoder, "xml ",
-                                     (const uint8_t *)xmp_string, xmp_len, JXL_TRUE));
-    }
   }
 
   JxlPixelFormat pixel_format = { 3, JXL_TYPE_FLOAT, JXL_NATIVE_ENDIAN, 0 };

--- a/src/imageio/format/jxl.c
+++ b/src/imageio/format/jxl.c
@@ -318,7 +318,7 @@ int write_image(struct dt_imageio_module_data_t *data,
     exif_buf = g_try_malloc0(exif_len + 4);
     if(!exif_buf)
       JXL_FAIL("could not allocate Exif buffer of size %zu", (size_t)(exif_len + 4));
-    
+
     memmove(exif_buf + 4, exif, exif_len);
     // Exiv2 >= 0.28 (released 2023-05-08) supports Brotli compressed boxes
     LIBJXL_ASSERT(JxlEncoderAddBox(encoder, "Exif", exif_buf, exif_len + 4, JXL_TRUE));
@@ -420,9 +420,12 @@ int levels(dt_imageio_module_data_t *data)
 
 int flags(dt_imageio_module_data_t *data)
 {
-  // exiv2 >= 0.28 supports JXL BMFF format for metadata, allowing
-  // fine-grained metadata control like other formats
+#if defined(EXV_ENABLE_BMFF) && defined(EXV_HAVE_BROTLI)
+  // exiv2 >= 0.28 with JXL BMFF format and Brotli compression
   return FORMAT_FLAGS_SUPPORT_XMP;
+#else
+  return 0;
+#endif
 }
 
 static inline int _bpp_to_enum(int bpp)

--- a/src/imageio/format/jxl.c
+++ b/src/imageio/format/jxl.c
@@ -338,7 +338,7 @@ int write_image(struct dt_imageio_module_data_t *data,
     }
   }
 
-f  JxlPixelFormat pixel_format = { 3, JXL_TYPE_FLOAT, JXL_NATIVE_ENDIAN, 0 };
+  JxlPixelFormat pixel_format = { 3, JXL_TYPE_FLOAT, JXL_NATIVE_ENDIAN, 0 };
 
   // Fix pixel stride
   const size_t pixels_size = width * height * 3 * sizeof(float);

--- a/src/imageio/imageio.c
+++ b/src/imageio/imageio.c
@@ -1496,47 +1496,34 @@ gboolean dt_imageio_export_with_flags(const dt_imgid_t imgid,
   gboolean from_cache = TRUE;
   dt_image_full_path(imgid, pathname, sizeof(pathname), &from_cache);
 
-  // last param is dng mode, it's false here
+  // Read unfiltered exif from source image
+  uint8_t *exif_profile0 = NULL;
   const int length0 = dt_exif_read_blob(&exif_profile0, pathname, imgid, sRGB,
                                         processed_width, processed_height, FALSE);
 
-  char* exv_filename = g_malloc(strlen(filename) + 5);
-  snprintf(exv_filename, strlen(filename) + 5, "%s%s", filename, ".exv");
-
-  // empty metadata file (XXX call write_blob inside there for us)
-  dt_exif_write_exv(exif_profile0, length0, exv_filename, 1);
-
-  // write data into metadata file
-  dt_exif_write_blob(exif_profile0, length0, exv_filename, 1);
-
+  // Filter metadata in-memory (no temporary files needed)
+  uint8_t *filtered_exif = NULL;
+  int filtered_exif_len = 0;
+  if(!ignore_exif && md_flags_set && exif_profile0 && length0 > 0)
+  {
+    filtered_exif_len = dt_exif_write_blob_to_buffer(exif_profile0, length0, &filtered_exif, 1);
+  }
   free(exif_profile0);
 
-  /* now write xmp into that container, if possible */
+  // For formats that support XMP, attach it if requested
   if(copy_metadata
      && (format->flags(format_params) & FORMAT_FLAGS_SUPPORT_XMP))
   {
-    dt_exif_xmp_attach_export(imgid, exv_filename, metadata, &dev, &pipe);
-    // no need to cancel the export if this fail
+    // TODO: Attach XMP to filtered_exif if needed
+    // dt_exif_xmp_attach_export(imgid, ..., metadata, &dev, &pipe);
   }
 
-  // write image including filtered metadata from .exv
-  if(!ignore_exif && md_flags_set)
+  // write image with filtered metadata
+  if(!ignore_exif && md_flags_set && filtered_exif_len > 0)
   {
-    uint8_t *exif_profile = NULL; // Exif data should be 65536 bytes
-                                  // max, but if original size is
-                                  // close to that, adding new tags
-                                  // could make it go over that... so
-                                  // let it be and see what happens
-                                  // when we write the image
-    // last param is dng mode, it's false here
-    const int length = dt_exif_read_blob(&exif_profile, exv_filename, imgid, sRGB,
-                                         processed_width, processed_height, FALSE);
-
     res = (format->write_image(format_params, filename, outbuf, icc_type,
-                              icc_filename, exif_profile, length, imgid,
+                              icc_filename, filtered_exif, filtered_exif_len, imgid,
                               num, total, &pipe, export_masks)) != 0;
-
-    free(exif_profile);
   }
   else
   {
@@ -1544,8 +1531,8 @@ gboolean dt_imageio_export_with_flags(const dt_imgid_t imgid,
                               icc_filename, NULL, 0, imgid, num, total,
                               &pipe, export_masks)) != 0;
   }
-
-  g_free(exv_filename);
+  
+  g_free(filtered_exif);
 
   if(res)
     goto error;

--- a/src/imageio/imageio.c
+++ b/src/imageio/imageio.c
@@ -1487,6 +1487,40 @@ gboolean dt_imageio_export_with_flags(const dt_imgid_t imgid,
     md_flags_set = metadata ? (metadata->flags & meta_all) == meta_all : FALSE;
   }
 
+  uint8_t *exif_profile0 = NULL; // Exif data should be 65536 bytes
+                                // max, but if original size is
+                                // close to that, adding new tags
+                                // could make it go over that... so
+                                // let it be and see what happens
+                                // when we write the image
+  char pathname[PATH_MAX] = { 0 };
+  gboolean from_cache = TRUE;
+  dt_image_full_path(imgid, pathname, sizeof(pathname), &from_cache);
+
+  // last param is dng mode, it's false here
+  const int length0 = dt_exif_read_blob(&exif_profile0, pathname, imgid, sRGB,
+                                        processed_width, processed_height, FALSE);
+
+  char* exv_filename = g_malloc(strlen(filename) + 5);
+  snprintf(exv_filename, strlen(filename) + 5, "%s%s", filename, ".exv");
+
+  // empty metadata file (XXX call write_blob inside there for us)
+  dt_exif_write_exv(exif_profile0, length0, exv_filename, 1);
+
+  // write data into metadata file
+  dt_exif_write_blob(exif_profile0, length0, exv_filename, 1);
+
+  free(exif_profile0);
+
+  /* now write xmp into that container, if possible */
+  if(copy_metadata
+     && (format->flags(format_params) & FORMAT_FLAGS_SUPPORT_XMP))
+  {
+    dt_exif_xmp_attach_export(imgid, exv_filename, metadata, &dev, &pipe);
+    // no need to cancel the export if this fail
+  }
+
+  // write image including filtered metadata from .exv
   if(!ignore_exif && md_flags_set)
   {
     uint8_t *exif_profile = NULL; // Exif data should be 65536 bytes
@@ -1495,12 +1529,8 @@ gboolean dt_imageio_export_with_flags(const dt_imgid_t imgid,
                                   // could make it go over that... so
                                   // let it be and see what happens
                                   // when we write the image
-    char pathname[PATH_MAX] = { 0 };
-    gboolean from_cache = TRUE;
-    dt_image_full_path(imgid, pathname, sizeof(pathname), &from_cache);
-
     // last param is dng mode, it's false here
-    const int length = dt_exif_read_blob(&exif_profile, pathname, imgid, sRGB,
+    const int length = dt_exif_read_blob(&exif_profile, exv_filename, imgid, sRGB,
                                          processed_width, processed_height, FALSE);
 
     res = (format->write_image(format_params, filename, outbuf, icc_type,
@@ -1516,16 +1546,11 @@ gboolean dt_imageio_export_with_flags(const dt_imgid_t imgid,
                               &pipe, export_masks)) != 0;
   }
 
+  g_free(exv_filename);
+
   if(res)
     goto error;
 
-  /* now write xmp into that container, if possible */
-  if(copy_metadata
-     && (format->flags(format_params) & FORMAT_FLAGS_SUPPORT_XMP))
-  {
-    dt_exif_xmp_attach_export(imgid, filename, metadata, &dev, &pipe);
-    // no need to cancel the export if this fail
-  }
 
   dt_dev_pixelpipe_cleanup(&pipe);
   dt_dev_cleanup(&dev);

--- a/src/imageio/imageio.c
+++ b/src/imageio/imageio.c
@@ -1510,14 +1510,6 @@ gboolean dt_imageio_export_with_flags(const dt_imgid_t imgid,
   }
   free(exif_profile0);
 
-  // For formats that support XMP, attach it if requested
-  if(copy_metadata
-     && (format->flags(format_params) & FORMAT_FLAGS_SUPPORT_XMP))
-  {
-    // TODO: Attach XMP to filtered_exif if needed
-    // dt_exif_xmp_attach_export(imgid, ..., metadata, &dev, &pipe);
-  }
-
   // write image with filtered metadata
   if(!ignore_exif && md_flags_set && filtered_exif_len > 0)
   {
@@ -1536,6 +1528,14 @@ gboolean dt_imageio_export_with_flags(const dt_imgid_t imgid,
 
   if(res)
     goto error;
+
+  /* now write xmp into that container, if possible */
+  if(copy_metadata
+     && (format->flags(format_params) & FORMAT_FLAGS_SUPPORT_XMP))
+  {
+    dt_exif_xmp_attach_export(imgid, filename, metadata, &dev, &pipe);
+    // no need to cancel the export if this fail
+  }
 
 
   dt_dev_pixelpipe_cleanup(&pipe);

--- a/src/imageio/imageio.c
+++ b/src/imageio/imageio.c
@@ -1464,7 +1464,7 @@ gboolean dt_imageio_export_with_flags(const dt_imgid_t imgid,
   format_params->width = processed_width;
   format_params->height = processed_height;
 
-  // Check if all the metadata export flags are set for AVIF/EXR/HEIF/JPEG XL/XCF (opt-in)
+  // Check if all the metadata export flags are set for AVIF/EXR/HEIF/XCF (opt-in)
   //
   // TODO: this is a workaround as these formats do not support fine
   // grained metadata control through dt_exif_xmp_attach_export()
@@ -1477,7 +1477,6 @@ gboolean dt_imageio_export_with_flags(const dt_imgid_t imgid,
      && (!strcmp(format->mime(NULL), "image/avif")
          || !strcmp(format->mime(NULL), "image/heif")
          || !strcmp(format->mime(NULL), "image/x-exr")
-        //  || !strcmp(format->mime(NULL), "image/jxl")
          || !strcmp(format->mime(NULL), "image/x-xcf")))
   {
     const int32_t meta_all =

--- a/src/imageio/imageio.c
+++ b/src/imageio/imageio.c
@@ -1477,7 +1477,7 @@ gboolean dt_imageio_export_with_flags(const dt_imgid_t imgid,
      && (!strcmp(format->mime(NULL), "image/avif")
          || !strcmp(format->mime(NULL), "image/heif")
          || !strcmp(format->mime(NULL), "image/x-exr")
-         || !strcmp(format->mime(NULL), "image/jxl")
+        //  || !strcmp(format->mime(NULL), "image/jxl")
          || !strcmp(format->mime(NULL), "image/x-xcf")))
   {
     const int32_t meta_all =


### PR DESCRIPTION
Add `dt_exif_write_blob_to_buffer()` so we can send `jxl.c` exactly the metadata it should write, instead of handling metadata after the fact. Update `jxl.c` to support this mode of operation, guarded by Exiv2 version checks.

For .jpeg, `dt_exif_write_blob()` adds metadata **after** the compressed image has been written:

```c
jpeg_write_image(...); 
dt_exif_write_blob(..., filename); // Add metadata to file
```

Exiv2 is able to add metadata to .jpeg after the fact, but jpeg-xl expects it to be added by the encoder, and the Exif data comes before the image codestream. By filtering the included metadata in memory, we can pass that to the encoder; solving the all-or-nothing implementation.

Working through some noise in the PR.

AI-assisted.