### PR TITLE
Maintenance of imageio code

### DIFF
--- a/src/imageio/imageio.c
+++ b/src/imageio/imageio.c
@@ -31,41 +31,50 @@
 #include "develop/imageop.h"
 #include "imageio/imageio_common.h"
 #include "imageio/imageio_module.h"
+
 #ifdef HAVE_OPENEXR
 #include "imageio/imageio_exr.h"
 #endif
+
 #ifdef HAVE_OPENJPEG
 #include "imageio/imageio_j2k.h"
 #endif
+
 #ifdef HAVE_LIBJXL
 #include "imageio/imageio_jpegxl.h"
 #endif
-#include "imageio/imageio_gm.h"
-#include "imageio/imageio_im.h"
+
 #include "imageio/imageio_jpeg.h"
 #include "imageio/imageio_pfm.h"
 #include "imageio/imageio_png.h"
 #include "imageio/imageio_pnm.h"
 #include "imageio/imageio_qoi.h"
 #include "imageio/imageio_rawspeed.h"
-#include "imageio/imageio_libraw.h"
 #include "imageio/imageio_rgbe.h"
 #include "imageio/imageio_tiff.h"
+
 #ifdef HAVE_LIBAVIF
 #include "imageio/imageio_avif.h"
 #endif
+
 #ifdef HAVE_LIBHEIF
 #include "imageio/imageio_heif.h"
 #endif
+
 #ifdef HAVE_WEBP
 #include "imageio/imageio_webp.h"
 #endif
+
+#ifdef HAVE_LIBRAW
 #include "imageio/imageio_libraw.h"
+#endif
 
 #ifdef HAVE_GRAPHICSMAGICK
+#include "imageio/imageio_gm.h"
 #include <magick/api.h>
 #include <magick/blob.h>
 #elif defined HAVE_IMAGEMAGICK
+#include "imageio/imageio_im.h"
   #ifdef HAVE_IMAGEMAGICK7
   #include <MagickWand/MagickWand.h>
   #else
@@ -1652,6 +1661,8 @@ gboolean dt_imageio_lookup_makermodel(const char *maker,
                                                  mk, mk_len,
                                                  md, md_len,
                                                  al, al_len);
+
+#ifdef HAVE_LIBRAW
   if(found == FALSE)
   {
     // Special handling for CR3 raw files via libraw
@@ -1660,6 +1671,8 @@ gboolean dt_imageio_lookup_makermodel(const char *maker,
                                         md, md_len,
                                         al, al_len);
   }
+#endif
+
   return found;
 }
 

--- a/src/imageio/imageio_gm.h
+++ b/src/imageio/imageio_gm.h
@@ -21,7 +21,9 @@
 #include "common/image.h"
 #include "common/mipmap_cache.h"
 
-dt_imageio_retval_t dt_imageio_open_gm(dt_image_t *img, const char *filename, dt_mipmap_buffer_t *buf);
+dt_imageio_retval_t dt_imageio_open_gm(dt_image_t *img,
+                                       const char *filename,
+                                       dt_mipmap_buffer_t *buf);
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/imageio/imageio_gm.h
+++ b/src/imageio/imageio_gm.h
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2012-2020 darktable developers.
+    Copyright (C) 2012-2025 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -21,19 +21,10 @@
 #include "common/image.h"
 #include "common/mipmap_cache.h"
 
-#ifdef HAVE_GRAPHICSMAGICK
 dt_imageio_retval_t dt_imageio_open_gm(dt_image_t *img, const char *filename, dt_mipmap_buffer_t *buf);
-#else
-inline dt_imageio_retval_t dt_imageio_open_gm(dt_image_t *img, const char *filename,
-                                              dt_mipmap_buffer_t *buf)
-{
-  return DT_IMAGEIO_FILE_NOT_FOUND;
-}
-#endif
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/imageio/imageio_im.h
+++ b/src/imageio/imageio_im.h
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2020 darktable developers.
+    Copyright (C) 2020-2025 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -21,15 +21,7 @@
 #include "common/image.h"
 #include "common/mipmap_cache.h"
 
-#ifdef HAVE_IMAGEMAGICK
 dt_imageio_retval_t dt_imageio_open_im(dt_image_t *img, const char *filename, dt_mipmap_buffer_t *buf);
-#else
-inline dt_imageio_retval_t dt_imageio_open_im(dt_image_t *img, const char *filename,
-                                              dt_mipmap_buffer_t *buf)
-{
-  return DT_IMAGEIO_FILE_NOT_FOUND;
-}
-#endif
 
 #endif
 // clang-format off
@@ -37,4 +29,3 @@ inline dt_imageio_retval_t dt_imageio_open_im(dt_image_t *img, const char *filen
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/imageio/imageio_im.h
+++ b/src/imageio/imageio_im.h
@@ -21,7 +21,9 @@
 #include "common/image.h"
 #include "common/mipmap_cache.h"
 
-dt_imageio_retval_t dt_imageio_open_im(dt_image_t *img, const char *filename, dt_mipmap_buffer_t *buf);
+dt_imageio_retval_t dt_imageio_open_im(dt_image_t *img,
+                                       const char *filename,
+                                       dt_mipmap_buffer_t *buf);
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/imageio/imageio_im.h
+++ b/src/imageio/imageio_im.h
@@ -15,15 +15,14 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
-#ifndef DT_IMAGEIO_IM_H
-#define DT_IMAGEIO_IM_H
+
+#pragma once
 
 #include "common/image.h"
 #include "common/mipmap_cache.h"
 
 dt_imageio_retval_t dt_imageio_open_im(dt_image_t *img, const char *filename, dt_mipmap_buffer_t *buf);
 
-#endif
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/imageio/imageio_libraw.h
+++ b/src/imageio/imageio_libraw.h
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2021 darktable developers.
+    Copyright (C) 2021-2025 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -22,27 +22,11 @@
 #include "common/image.h"
 #include "common/mipmap_cache.h"
 
-#ifdef HAVE_LIBRAW
 gboolean dt_libraw_lookup_makermodel(const char *maker, const char *model,
                                      char *mk, int mk_len, char *md, int md_len,
                                      char *al, int al_len);
 
 dt_imageio_retval_t dt_imageio_open_libraw(dt_image_t *img, const char *filename, dt_mipmap_buffer_t *buf);
-#else
-inline gboolean dt_libraw_lookup_makermodel(const char *maker, const char *model,
-                                          char *mk, int mk_len, char *md, int md_len,
-                                           char *al, int al_len)
-{
-  return FALSE;
-}
-
-inline dt_imageio_retval_t dt_imageio_open_libraw(dt_image_t *img, const char *filename,
-                                                  dt_mipmap_buffer_t *buf)
-{
-  return DT_IMAGEIO_FILE_NOT_FOUND;
-}
-
-#endif
 
 #endif
 // clang-format off
@@ -50,4 +34,3 @@ inline dt_imageio_retval_t dt_imageio_open_libraw(dt_image_t *img, const char *f
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/imageio/imageio_libraw.h
+++ b/src/imageio/imageio_libraw.h
@@ -21,11 +21,15 @@
 #include "common/image.h"
 #include "common/mipmap_cache.h"
 
-gboolean dt_libraw_lookup_makermodel(const char *maker, const char *model,
-                                     char *mk, int mk_len, char *md, int md_len,
+gboolean dt_libraw_lookup_makermodel(const char *maker,
+                                     const char *model,
+                                     char *mk, int mk_len,
+                                     char *md, int md_len,
                                      char *al, int al_len);
 
-dt_imageio_retval_t dt_imageio_open_libraw(dt_image_t *img, const char *filename, dt_mipmap_buffer_t *buf);
+dt_imageio_retval_t dt_imageio_open_libraw(dt_image_t *img,
+                                           const char *filename,
+                                           dt_mipmap_buffer_t *buf);
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/imageio/imageio_libraw.h
+++ b/src/imageio/imageio_libraw.h
@@ -16,8 +16,7 @@
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef DT_IMAGEIO_LIBRAW_H
-#define DT_IMAGEIO_LIBRAW_H
+#pragma once
 
 #include "common/image.h"
 #include "common/mipmap_cache.h"
@@ -28,7 +27,6 @@ gboolean dt_libraw_lookup_makermodel(const char *maker, const char *model,
 
 dt_imageio_retval_t dt_imageio_open_libraw(dt_image_t *img, const char *filename, dt_mipmap_buffer_t *buf);
 
-#endif
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
 // vim: shiftwidth=2 expandtab tabstop=2 cindent


### PR DESCRIPTION
What was done in the code (mainly in the headers) of imageio:

- Removed conditional provision of dummy implementations in header files if darktable is not built with the corresponding functionality. These dummy loader functions are simply no longer used, as we do the same in imageio.c after rewriting to a signature-based architecture.

- Instead of using `#ifdef HAVE_somefeature` in header files, we now guarantee that the header will not be included if the corresponding functionality is not built.

- Wrapped the call to `dt_libraw_lookup_makermodel` in an #ifdef instead of always calling the function with that name, but providing a dummy implementation if darktable is built without libraw.

- Removed duplicate include of `imageio_libraw.h`.

- Replaced include guards with `#pragma once`.

