### PR TITLE
Demosaic maintenance, fast-math

### DIFF
--- a/src/iop/demosaicing/lmmse.c
+++ b/src/iop/demosaicing/lmmse.c
@@ -52,7 +52,7 @@
 
 #ifdef __GNUC__
   #pragma GCC push_options
-  #pragma GCC optimize ("fast-math", "fp-contract=fast", "finite-math-only", "no-math-errno")
+  #pragma GCC optimize ("fp-contract=fast", "finite-math-only", "no-math-errno")
 #endif
 
 #define LMMSE_OVERLAP 8

--- a/src/iop/demosaicing/rcd.c
+++ b/src/iop/demosaicing/rcd.c
@@ -62,7 +62,7 @@
 
 #ifdef __GNUC__
   #pragma GCC push_options
-  #pragma GCC optimize ("fast-math", "fp-contract=fast", "finite-math-only", "no-math-errno")
+  #pragma GCC optimize ("fp-contract=fast", "finite-math-only", "no-math-errno")
 #endif
 
 #define RCD_BORDER 9          // avoid tile-overlap errors


### PR DESCRIPTION
LMMSE and RCD demosaicers enforced a "fast-math" compiler flag, this possibly leads to differences between OpenCL and CPU code in a non-predictable way.
Removing that flag does not lead to a measurable performance drop so good to go.

@TurboGit with gcc 15 on fedora i couldn't find any significant difference in output but i think we should go for it. Safe for master and 5.2.1 