### PR TITLE
snapshots: eliminate unnecessary redraws

### DIFF
--- a/src/libs/snapshots.c
+++ b/src/libs/snapshots.c
@@ -469,8 +469,8 @@ int mouse_moved(dt_lib_module_t *self,
     {
       d->vp_xpointer = xp;
       d->vp_ypointer = yp;
+      dt_control_queue_redraw_center();
     }
-    dt_control_queue_redraw_center();
     return 1;
   }
 


### PR DESCRIPTION
When active, the snapshots module was issuing a redraw request on the center view for every mouse move in split-view mode, even when those had no effect on the display.  This commit reduces the requests to only happen when the split line is moved.

This reduces CPU usage when merely moving the mouse over the image and eliminates the constant flickering of the "working..." message which occurred under some conditions.

This is a small enough change that it might still be a candidate for 5.2.1.
