### PR TITLE
Demosaicer 5.4 improvements and maintenance

### DIFF
--- a/data/kernels/demosaic_other.cl
+++ b/data/kernels/demosaic_other.cl
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    copyright (c) 2015 LebedevRI.
+    Copyright (C) 2015-2025 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -62,8 +62,13 @@ passthrough_color (__read_only image2d_t in, __write_only image2d_t out, const i
  * and writes it to out in float4 format.
  */
 __kernel void
-clip_and_zoom_demosaic_passthrough_monochrome(__read_only image2d_t in, __write_only image2d_t out, const int width, const int height,
-    const int r_x, const int r_y, const int rin_wd, const int rin_ht, const float r_scale, const unsigned int filters)
+clip_and_zoom_demosaic_passthrough_monochrome(__read_only image2d_t in,
+                                              __write_only image2d_t out,
+                                              const int width,
+                                              const int height,
+                                              const int rin_wd,
+                                              const int rin_ht,
+                                              const float r_scale)
 {
   // global id is pixel in output image (float4)
   const int x = get_global_id(0);
@@ -79,8 +84,8 @@ clip_and_zoom_demosaic_passthrough_monochrome(__read_only image2d_t in, __write_
   // how many pixels can be sampled inside that area
   const int samples = round(px_footprint);
 
-  const float2 f = (float2)((x + r_x) * px_footprint, (y + r_y) * px_footprint);
-  int2 p = (int2)((int)f.x, (int)f.y);
+  const float2 f = (float2)(x * px_footprint, y * px_footprint);
+  const int2 p = (int2)((int)f.x, (int)f.y);
   const float2 d = (float2)(f.x - p.x, f.y - p.y);
 
   for(int j=0;j<=samples+1;j++) for(int i=0;i<=samples+1;i++)
@@ -88,10 +93,10 @@ clip_and_zoom_demosaic_passthrough_monochrome(__read_only image2d_t in, __write_
     const int xx = p.x + i;
     const int yy = p.y + j;
 
-    float xfilter = (i == 0) ? 1.0f - d.x : ((i == samples+1) ? d.x : 1.0f);
-    float yfilter = (j == 0) ? 1.0f - d.y : ((j == samples+1) ? d.y : 1.0f);
+    const float xfilter = (i == 0) ? 1.0f - d.x : ((i == samples+1) ? d.x : 1.0f);
+    const float yfilter = (j == 0) ? 1.0f - d.y : ((j == samples+1) ? d.y : 1.0f);
 
-    float px = read_imagef(in, sampleri, (int2)(xx, yy)).x;
+    const float px = read_imagef(in, sampleri, (int2)(xx, yy)).x;
     color += yfilter*xfilter*(float4)(px, px, px, 0.0f);
     weight += yfilter*xfilter;
   }

--- a/data/kernels/demosaic_ppg.cl
+++ b/data/kernels/demosaic_ppg.cl
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    copyright (c) 2009--2010 johannes hanika.
+    Copyright (C) 2009-2025 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -36,8 +36,13 @@ backtransformf (float2 p, const int r_x, const int r_y, const int r_wd, const in
 }
 
 kernel void
-green_equilibration_lavg(read_only image2d_t in, write_only image2d_t out, const int width, const int height, const unsigned int filters,
-                         const int r_x, const int r_y, const float thr, local float *buffer)
+green_equilibration_lavg(read_only image2d_t in,
+                         write_only image2d_t out,
+                         const int width,
+                         const int height,
+                         const unsigned int filters,
+                         const float thr,
+                         local float *buffer)
 {
   const int x = get_global_id(0);
   const int y = get_global_id(1);
@@ -79,11 +84,11 @@ green_equilibration_lavg(read_only image2d_t in, write_only image2d_t out, const
 
   if(x >= width || y >= height) return;
 
-  const int c = FC(y + r_y, x + r_x, filters);
+  const int c = FC(y, x, filters);
   const float maximum = 1.0f;
   float o = buffer[0];
 
-  if(c == 1 && ((y + r_y) & 1))
+  if(c == 1 && (y & 1))
   {
     const float o1_1 = buffer[-1 * stride - 1];
     const float o1_2 = buffer[-1 * stride + 1];
@@ -112,8 +117,12 @@ green_equilibration_lavg(read_only image2d_t in, write_only image2d_t out, const
 
 
 kernel void
-green_equilibration_favg_reduce_first(read_only image2d_t in, const int width, const int height,
-                                      global float2 *accu, const unsigned int filters, const int r_x, const int r_y, local float2 *buffer)
+green_equilibration_favg_reduce_first(read_only image2d_t in,
+                                      const int width,
+                                      const int height,
+                                      global float2 *accu,
+                                      const unsigned int filters,
+                                      local float2 *buffer)
 {
   const int x = get_global_id(0);
   const int y = get_global_id(1);
@@ -124,11 +133,11 @@ green_equilibration_favg_reduce_first(read_only image2d_t in, const int width, c
 
   const int l = mad24(ylid, xlsz, xlid);
 
-  const int c = FC(y + r_y, x + r_x, filters);
+  const int c = FC(y, x, filters);
 
   const int isinimage = (x < 2 * (width / 2) && y < 2 * (height / 2));
-  const int isgreen1 = (c == 1 && !((y + r_y) & 1));
-  const int isgreen2 = (c == 1 && ((y + r_y) & 1));
+  const int isgreen1 = (c == 1 && !(y & 1));
+  const int isgreen2 = (c == 1 && (y & 1));
 
   float pixel = read_imagef(in, sampleri, (int2)(x, y)).x;
 
@@ -194,8 +203,12 @@ green_equilibration_favg_reduce_second(const global float2* input, global float2
 
 
 kernel void
-green_equilibration_favg_apply(read_only image2d_t in, write_only image2d_t out, const int width, const int height, const unsigned int filters,
-                               const int r_x, const int r_y, const float gr_ratio)
+green_equilibration_favg_apply(read_only image2d_t in,
+                               write_only image2d_t out,
+                               const int width,
+                               const int height,
+                               const unsigned int filters,
+                               const float gr_ratio)
 {
   const int x = get_global_id(0);
   const int y = get_global_id(1);
@@ -204,9 +217,9 @@ green_equilibration_favg_apply(read_only image2d_t in, write_only image2d_t out,
 
   float pixel = read_imagef(in, sampleri, (int2)(x, y)).x;
 
-  const int c = FC(y + r_y, x + r_x, filters);
+  const int c = FC(y, x, filters);
 
-  const int isgreen1 = (c == 1 && !((y + r_y) & 1));
+  const int isgreen1 = (c == 1 && !(y & 1));
 
   pixel *= (isgreen1 ? gr_ratio : 1.0f);
 
@@ -461,8 +474,14 @@ clip_and_zoom(read_only image2d_t in, write_only image2d_t out, const int width,
  * resamping is done via rank-1 lattices and demosaicing using half-size interpolation.
  */
 __kernel void
-clip_and_zoom_demosaic_half_size(__read_only image2d_t in, __write_only image2d_t out, const int width, const int height,
-    const int r_x, const int r_y, const int rin_wd, const int rin_ht, const float r_scale, const unsigned int filters)
+clip_and_zoom_demosaic_half_size(__read_only image2d_t in,
+                                 __write_only image2d_t out,
+                                 const int width,
+                                 const int height,
+                                 const int rin_wd,
+                                 const int rin_ht,
+                                 const float r_scale,
+                                 const unsigned int filters)
 {
   // global id is pixel in output image (float4)
   const int x = get_global_id(0);
@@ -490,7 +509,7 @@ clip_and_zoom_demosaic_half_size(__read_only image2d_t in, __write_only image2d_
 
 
   // upper left corner:
-  const float2 f = (float2)((x + r_x) * px_footprint, (y + r_y) * px_footprint);
+  const float2 f = (float2)(x * px_footprint, y * px_footprint);
   int2 p = (int2)((int)f.x & ~1, (int)f.y & ~1);
   const float2 d = (float2)((f.x - p.x)/2.0f, (f.y - p.y)/2.0f);
 
@@ -504,14 +523,14 @@ clip_and_zoom_demosaic_half_size(__read_only image2d_t in, __write_only image2d_
 
     if(xx + 1 >= rin_wd || yy + 1 >= rin_ht) continue;
 
-    float xfilter = (i == 0) ? 1.0f - d.x : ((i == samples+1) ? d.x : 1.0f);
-    float yfilter = (j == 0) ? 1.0f - d.y : ((j == samples+1) ? d.y : 1.0f);
+    const float xfilter = (i == 0) ? 1.0f - d.x : ((i == samples+1) ? d.x : 1.0f);
+    const float yfilter = (j == 0) ? 1.0f - d.y : ((j == samples+1) ? d.y : 1.0f);
 
     // get four mosaic pattern uint16:
-    float p1 = read_imagef(in, sampleri, (int2)(xx,   yy  )).x;
-    float p2 = read_imagef(in, sampleri, (int2)(xx+1, yy  )).x;
-    float p3 = read_imagef(in, sampleri, (int2)(xx,   yy+1)).x;
-    float p4 = read_imagef(in, sampleri, (int2)(xx+1, yy+1)).x;
+    const float p1 = read_imagef(in, sampleri, (int2)(xx,   yy  )).x;
+    const float p2 = read_imagef(in, sampleri, (int2)(xx+1, yy  )).x;
+    const float p3 = read_imagef(in, sampleri, (int2)(xx,   yy+1)).x;
+    const float p4 = read_imagef(in, sampleri, (int2)(xx+1, yy+1)).x;
     color += yfilter*xfilter*(float4)(p1, (p2+p3)*0.5f, p4, 0.0f);
     weight += yfilter*xfilter;
   }
@@ -679,7 +698,7 @@ ppg_demosaic_redblue (read_only image2d_t in, write_only image2d_t out, const in
   float4 color = buffer[0];
   if(x == 0 || y == 0 || x == (width-1) || y == (height-1))
   {
-    write_imagef (out, (int2)(x, y), fmax(color, 0.0f));  
+    write_imagef (out, (int2)(x, y), fmax(color, 0.0f));
     return;
   }
 

--- a/src/iop/demosaicing/basics.c
+++ b/src/iop/demosaicing/basics.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2010-2024 darktable developers.
+    Copyright (C) 2010-2025 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -151,16 +151,14 @@ static void green_equilibration_lavg(float *out,
                                      const int width,
                                      const int height,
                                      const uint32_t filters,
-                                     const int x,
-                                     const int y,
                                      const float thr)
 {
   const float maximum = 1.0f;
 
   int oj = 2, oi = 2;
-  if(FC(oj + y, oi + x, filters) != 1) oj++;
-  if(FC(oj + y, oi + x, filters) != 1) oi++;
-  if(FC(oj + y, oi + x, filters) != 1) oj--;
+  if(FC(oj, oi, filters) != 1) oj++;
+  if(FC(oj, oi, filters) != 1) oi++;
+  if(FC(oj, oi, filters) != 1) oj--;
 
   dt_iop_image_copy_by_size(out, in, width, height, 1);
 
@@ -203,15 +201,13 @@ static void green_equilibration_favg(float *out,
                                      const float *const in,
                                      const int width,
                                      const int height,
-                                     const uint32_t filters,
-                                     const int x,
-                                     const int y)
+                                     const uint32_t filters)
 {
   int oj = 0, oi = 0;
   // const float ratio_max = 1.1f;
   double sum1 = 0.0, sum2 = 0.0, gr_ratio;
 
-  if((FC(oj + y, oi + x, filters) & 1) != 1) oi++;
+  if((FC(oj, oi, filters) & 1) != 1) oi++;
   const int g2_offset = oi ? -1 : 1;
   dt_iop_image_copy_by_size(out, in, width, height, 1);
   DT_OMP_FOR(reduction(+ : sum1, sum2) collapse(2))
@@ -387,7 +383,7 @@ static int green_equilibration_cl(const dt_iop_module_t *self,
     size_t flocal[3] = { flocopt.sizex, flocopt.sizey, 1 };
     dt_opencl_set_kernel_args(devid, gd->kernel_green_eq_favg_reduce_first, 0,
       CLARG(dev_in1), CLARG(width),
-      CLARG(height), CLARG(dev_m), CLARG(piece->pipe->dsc.filters), CLARG(roi_in->x), CLARG(roi_in->y),
+      CLARG(height), CLARG(dev_m), CLARG(piece->pipe->dsc.filters),
       CLLOCAL(sizeof(float) * 2 * flocopt.sizex * flocopt.sizey));
     err = dt_opencl_enqueue_kernel_2d_with_local(devid, gd->kernel_green_eq_favg_reduce_first, fsizes, flocal);
     if(err != CL_SUCCESS) goto error;
@@ -442,7 +438,7 @@ static int green_equilibration_cl(const dt_iop_module_t *self,
 
     err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_green_eq_favg_apply, width, height,
       CLARG(dev_in1), CLARG(dev_out1), CLARG(width), CLARG(height), CLARG(piece->pipe->dsc.filters),
-      CLARG(roi_in->x), CLARG(roi_in->y), CLARG(gr_ratio));
+      CLARG(gr_ratio));
     if(err != CL_SUCCESS) goto error;
   }
 
@@ -466,7 +462,7 @@ static int green_equilibration_cl(const dt_iop_module_t *self,
     size_t local[3] = { locopt.sizex, locopt.sizey, 1 };
     dt_opencl_set_kernel_args(devid, gd->kernel_green_eq_lavg, 0,
       CLARG(dev_in2), CLARG(dev_out2),
-      CLARG(width), CLARG(height), CLARG(piece->pipe->dsc.filters), CLARG(roi_in->x), CLARG(roi_in->y),
+      CLARG(width), CLARG(height), CLARG(piece->pipe->dsc.filters),
       CLARG(threshold), CLLOCAL(sizeof(float) * (locopt.sizex + 4) * (locopt.sizey + 4)));
     err = dt_opencl_enqueue_kernel_2d_with_local(devid, gd->kernel_green_eq_lavg, sizes, local);
     if(err != CL_SUCCESS) goto error;

--- a/src/iop/demosaicing/basics.c
+++ b/src/iop/demosaicing/basics.c
@@ -616,6 +616,28 @@ error:
   return err;
 }
 
+static int demosaic_box3_cl(dt_iop_module_t *self,
+                              dt_dev_pixelpipe_iop_t *piece,
+                              cl_mem dev_in,
+                              cl_mem dev_out,
+                              const dt_iop_roi_t *const roi)
+{
+  const dt_iop_demosaic_global_data_t *gd = self->global_data;
+  dt_dev_pixelpipe_t *const pipe = piece->pipe;
+  const int devid = pipe->devid;
+  cl_int err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
+
+  cl_mem dev_xtrans = dt_opencl_copy_host_to_device_constant(devid, sizeof(pipe->dsc.xtrans), pipe->dsc.xtrans);
+  if(!dev_xtrans) return err;
+  err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_demosaic_box3, roi->width, roi->height,
+          CLARG(dev_in), CLARG(dev_out),
+          CLARG(roi->width), CLARG(roi->height),
+          CLARG(roi->x), CLARG(roi->y),
+          CLARG(pipe->dsc.filters), CLARG(dev_xtrans));
+  dt_opencl_release_mem_object(dev_xtrans);
+  return err;
+}
+
 #endif
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py


### PR DESCRIPTION
After capture sharpening has been merged here is the first (of two) bunch of commits.

1. Removed code that hinted, we could snap to other locations than upper/left corner of sensor pattern. Not a good idea at all due to what we provide in rawprepare.
2. Remove special snapper cases for passthru modes a) to avoid expose jumps when changing demosaicers and b) it's simply not worth trying to do so.
3. As we demosaic at a snap position in all cases, the color smoothing and green averaging for bayer sensors don't require roi x/y shifts.
4. Removed unused kernel from module
5. Don't pass unused parameters for `clip_and_zoom_demosaic_passthrough_monochrome` and  `clip_and_zoom_demosaic_half_size` OpenCL kernels.
6. Some formatting constifies and copyrights updating.
7. Introduce a fast pseudo demosaicer calculating RGB data from a 3x3 CFA data box. Only used for displaying mask data generated in raw processing modules before demosaic for performance and less photosite overlaps.
8. simplify full_demosaic checks, does not change functionality compared with current code.
