### PR TITLE
[CI/CD] Fix builds on macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -353,7 +353,7 @@ jobs:
           brew bundle --verbose || true
           # handle keg-only libs
           brew link --force libomp
-          brew link --force libsoup@2
+          brew link --force libsoup
       - name: Build and Install
         run: |
           cmake -E make_directory "${BUILD_DIR}";

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -329,7 +329,7 @@ jobs:
           brew bundle --verbose || true
           # handle keg-only libs
           brew link --force libomp
-          brew link --force libsoup@2
+          brew link --force libsoup
       - name: Cancel workflow if job fails
         if: ${{ failure() }}
         uses: andymckay/cancel-action@0.5


### PR DESCRIPTION
Apparently, homebrew finished rebuilding the package base with libsoup3 (which packaged as just libsoup), so our command that specifically pointed to libsoup2 (libsoup@2) started to fail.
