### PR TITLE
update macOS libsoup base installation

### DIFF
--- a/packaging/macosx/1_install_hb_dependencies.sh
+++ b/packaging/macosx/1_install_hb_dependencies.sh
@@ -102,4 +102,4 @@ fi
 
 # link keg-only packages
 brew link --force libomp
-brew link --force libsoup@2
+brew link --force libsoup


### PR DESCRIPTION
in addition to #19182 

This is for the base package installation on macOS for users who want to self-compile dt.