### PR TITLE
be consistent in hiding (not desensitising) irrelevant iop widgets

### DIFF
--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -1300,11 +1300,11 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
   gtk_widget_set_visible(g->demosaic_method_bayerfour, bayer4);
   gtk_widget_set_visible(g->demosaic_method_xtrans, xtrans);
 
-  gtk_widget_set_sensitive(g->cs_radius, do_capture);
-  gtk_widget_set_sensitive(g->cs_thrs, do_capture);
-  gtk_widget_set_sensitive(g->cs_boost, do_capture);
-  gtk_widget_set_sensitive(g->cs_center, do_capture && p->cs_boost);
-  gtk_widget_set_sensitive(g->cs_iter, capture_support);
+  gtk_widget_set_visible(g->cs_radius, do_capture);
+  gtk_widget_set_visible(g->cs_thrs, do_capture);
+  gtk_widget_set_visible(g->cs_boost, do_capture);
+  gtk_widget_set_visible(g->cs_center, do_capture && p->cs_boost);
+  gtk_widget_set_visible(g->cs_iter, capture_support);
 
   // we might have a wrong method dur to xtrans/bayer - mode mismatch
   if(bayer)


### PR DESCRIPTION
Yes, there is an exception (filmic; presumably because widget applicability depends on _later_ (instead of preceding) widgets, so that changing `bloom vs reconstruct` would move it upward _while being manipulated_, if it is dragged all the way to the left. Also the "enable highlight reconstruction" toggle is placed quite far from the "balance" area that it disables. Someone could have a look at reorganising/fixing this...) but that's not a good enough reason to confuse users with even more inconsistencies. To me it now looks as if there is a bug in setting the range for the disabled widgets in demosaic. _Consistency_ is the largest determinant (imvho) in how intuitive an application _eventually_ (after the learning curve) is.

