### PR TITLE
Various work on demosaic

### DIFF
--- a/src/develop/imageop_math.h
+++ b/src/develop/imageop_math.h
@@ -198,12 +198,26 @@ static inline int FCxtrans(const int row, const int col, const dt_iop_roi_t *con
   return xtrans[irow % 6][icol % 6];
 }
 
+/** Calculate the xtrans pattern color from the row and column **/
+static inline int FCNxtrans(const int row, const int col, const uint8_t (*const xtrans)[6])
+{
+  // Add +600 (which must be a multiple of CFA width 6) as offset can
+  // be negative and need to ensure a non-negative array index. The
+  // negative offsets in current code come from the demosaic iop:
+  // Markesteijn 1-pass (-12), Markesteijn 3-pass (-17), and VNG (-2).
+  const int irow = row + 600;
+  const int icol = col + 600;
+  assert(irow >= 0 && icol >= 0);
+
+  return xtrans[irow % 6][icol % 6];
+}
+
 
 DT_OMP_DECLARE_SIMD()
 static inline int fcol(const int row, const int col, const uint32_t filters, const uint8_t (*const xtrans)[6])
 {
   if(filters == 9)
-    return FCxtrans(row, col, NULL, xtrans);
+    return FCNxtrans(row, col, xtrans);
   else
     return FC(row, col, filters);
 }

--- a/src/iop/demosaicing/basics.c
+++ b/src/iop/demosaicing/basics.c
@@ -241,14 +241,13 @@ static int color_smoothing_cl(const dt_iop_module_t *self,
                               const dt_dev_pixelpipe_iop_t *piece,
                               cl_mem dev_in,
                               cl_mem dev_out,
-                              const dt_iop_roi_t *const roi,
+                              const int width,
+                              const int height,
                               const int passes)
 {
   const dt_iop_demosaic_global_data_t *gd = self->global_data;
 
   const int devid = piece->pipe->devid;
-  const int width = roi->width;
-  const int height = roi->height;
 
   cl_int err = DT_OPENCL_DEFAULT_ERROR;
 
@@ -484,7 +483,8 @@ static int process_default_cl(const dt_iop_module_t *self,
                               cl_mem dev_in,
                               cl_mem dev_out,
                               cl_mem dev_xtrans,
-                              const dt_iop_roi_t *const roi_in,
+                              const int width,
+                              const int height,
                               const int demosaicing_method,
                               const uint32_t filters)
 {
@@ -497,10 +497,7 @@ static int process_default_cl(const dt_iop_module_t *self,
   cl_mem dev_med = NULL;
   cl_int err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
 
-  const int width = roi_in->width;
-  const int height = roi_in->height;
-
-     if(demosaicing_method == DT_IOP_DEMOSAIC_PASSTHROUGH_MONOCHROME)
+    if(demosaicing_method == DT_IOP_DEMOSAIC_PASSTHROUGH_MONOCHROME)
     {
       err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_passthrough_monochrome, width, height,
         CLARG(dev_in), CLARG(dev_out), CLARG(width), CLARG(height));
@@ -620,15 +617,14 @@ static int demosaic_box3_cl(dt_iop_module_t *self,
                               cl_mem dev_in,
                               cl_mem dev_out,
                               cl_mem dev_xtrans,
-                              const dt_iop_roi_t *const roi,
+                              const int width,
+                              const int height,
                               const uint32_t filters)
 {
   const dt_iop_demosaic_global_data_t *gd = self->global_data;
-//  dt_dev_pixelpipe_t *const pipe = piece->pipe;
-//  const int devid = pipe->devid;
-  return dt_opencl_enqueue_kernel_2d_args(piece->pipe->devid, gd->kernel_demosaic_box3, roi->width, roi->height,
+  return dt_opencl_enqueue_kernel_2d_args(piece->pipe->devid, gd->kernel_demosaic_box3, width, height,
           CLARG(dev_in), CLARG(dev_out),
-          CLARG(roi->width), CLARG(roi->height),
+          CLARG(width), CLARG(height),
           CLARG(filters), CLARG(dev_xtrans));
 }
 

--- a/src/iop/demosaicing/dual.c
+++ b/src/iop/demosaicing/dual.c
@@ -80,12 +80,11 @@ int dual_demosaic_cl(const dt_iop_module_t *self,
                      cl_mem high_image,
                      cl_mem low_image,
                      cl_mem out,
-                     const dt_iop_roi_t *const roi_in,
+                     const int width,
+                     const int height,
                      const int dual_mask)
 {
   const int devid = piece->pipe->devid;
-  const int width = roi_in->width;
-  const int height = roi_in->height;
 
   dt_iop_demosaic_data_t *data = piece->data;
   const dt_iop_demosaic_global_data_t *gd = self->global_data;

--- a/src/iop/demosaicing/passthrough.c
+++ b/src/iop/demosaicing/passthrough.c
@@ -71,7 +71,7 @@ static void passthrough_color(float *out,
       {
         const float val = in[(size_t)col + row * width];
         const size_t offset = (size_t)4 * ((size_t)row * width + col);
-        const size_t ch = FCxtrans(row, col, NULL, xtrans);
+        const size_t ch = FCNxtrans(row, col, xtrans);
 
         out[offset] = out[offset + 1] = out[offset + 2] = 0.0f;
         out[offset + ch] = val;

--- a/src/iop/demosaicing/rcd.c
+++ b/src/iop/demosaicing/rcd.c
@@ -290,7 +290,7 @@ static void demosaic_box3(dt_dev_pixelpipe_iop_t *piece,
         {
           if(x >= 0 && y >= 0 && x < width && y < height)
           {
-            const int color = (filters == 9u) ? FCxtrans(y, x, NULL, xtrans) : FC(y, x, filters);
+            const int color = (filters == 9u) ? FCNxtrans(y, x, xtrans) : FC(y, x, filters);
             sum[color] += MAX(0.0f, in[(size_t)width*y +x]);
             cnt[color] += 1.0f;
           }
@@ -596,7 +596,8 @@ static cl_int process_rcd_cl(dt_iop_module_t *self,
                              dt_dev_pixelpipe_iop_t *piece,
                              cl_mem dev_in,
                              cl_mem dev_out,
-                             const dt_iop_roi_t *const roi_in,
+                             const int width,
+                             const int height,
                              const uint32_t filters)
 {
   const dt_iop_demosaic_global_data_t *gd = self->global_data;
@@ -615,125 +616,123 @@ static cl_int process_rcd_cl(dt_iop_module_t *self,
 
   cl_int err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
 
-    const int width = roi_in->width;
-    const int height = roi_in->height;
 
-    dev_tmp = dt_opencl_alloc_device(devid, roi_in->width, roi_in->height, sizeof(float) * 4);
-    if(dev_tmp == NULL) goto error;
+  dev_tmp = dt_opencl_alloc_device(devid, width, height, sizeof(float) * 4);
+  if(dev_tmp == NULL) goto error;
 
-    int myborder = 3;
-    err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_border_interpolate, width, height,
+  int myborder = 3;
+  err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_border_interpolate, width, height,
         CLARG(dev_in), CLARG(dev_tmp), CLARG(width), CLARG(height), CLARG(filters), CLARG(myborder));
-    if(err != CL_SUCCESS) goto error;
+  if(err != CL_SUCCESS) goto error;
 
-    {
-      dt_opencl_local_buffer_t locopt
+  {
+    dt_opencl_local_buffer_t locopt
         = (dt_opencl_local_buffer_t){ .xoffset = 2*3, .xfactor = 1, .yoffset = 2*3, .yfactor = 1,
                                       .cellsize = sizeof(float) * 1, .overhead = 0,
                                       .sizex = 64, .sizey = 64 };
 
-      if(!dt_opencl_local_buffer_opt(devid, gd->kernel_rcd_border_green, &locopt))
-      {
-        err = CL_INVALID_WORK_DIMENSION;
-        goto error;
-      }
-      myborder = 32;
-      size_t sizes[3] = { ROUNDUP(width, locopt.sizex), ROUNDUP(height, locopt.sizey), 1 };
-      size_t local[3] = { locopt.sizex, locopt.sizey, 1 };
-      dt_opencl_set_kernel_args(devid, gd->kernel_rcd_border_green, 0, CLARG(dev_in), CLARG(dev_tmp),
+    if(!dt_opencl_local_buffer_opt(devid, gd->kernel_rcd_border_green, &locopt))
+    {
+      err = CL_INVALID_WORK_DIMENSION;
+      goto error;
+    }
+    myborder = 32;
+    size_t sizes[3] = { ROUNDUP(width, locopt.sizex), ROUNDUP(height, locopt.sizey), 1 };
+    size_t local[3] = { locopt.sizex, locopt.sizey, 1 };
+    dt_opencl_set_kernel_args(devid, gd->kernel_rcd_border_green, 0, CLARG(dev_in), CLARG(dev_tmp),
         CLARG(width), CLARG(height), CLARG(filters), CLLOCAL(sizeof(float) * (locopt.sizex + 2*3) * (locopt.sizey + 2*3)),
         CLARG(myborder));
-      err = dt_opencl_enqueue_kernel_2d_with_local(devid, gd->kernel_rcd_border_green, sizes, local);
-      if(err != CL_SUCCESS) goto error;
-    }
+    err = dt_opencl_enqueue_kernel_2d_with_local(devid, gd->kernel_rcd_border_green, sizes, local);
+    if(err != CL_SUCCESS) goto error;
+  }
 
-    {
-      dt_opencl_local_buffer_t locopt
+  {
+    dt_opencl_local_buffer_t locopt
         = (dt_opencl_local_buffer_t){ .xoffset = 2*1, .xfactor = 1, .yoffset = 2*1, .yfactor = 1,
                                       .cellsize = 4 * sizeof(float), .overhead = 0,
                                       .sizex = 64, .sizey = 64 };
 
-      if(!dt_opencl_local_buffer_opt(devid, gd->kernel_rcd_border_redblue, &locopt))
-      {
-        err = CL_INVALID_WORK_DIMENSION;
-        goto error;
-      }
-      myborder = 16;
-      size_t sizes[3] = { ROUNDUP(width, locopt.sizex), ROUNDUP(height, locopt.sizey), 1 };
-      size_t local[3] = { locopt.sizex, locopt.sizey, 1 };
-      dt_opencl_set_kernel_args(devid, gd->kernel_rcd_border_redblue, 0, CLARG(dev_tmp), CLARG(dev_out),
-        CLARG(width), CLARG(height), CLARG(filters), CLLOCAL(sizeof(float) * 4 * (locopt.sizex + 2) * (locopt.sizey + 2)),
-        CLARG(myborder));
-      err = dt_opencl_enqueue_kernel_2d_with_local(devid, gd->kernel_rcd_border_redblue, sizes, local);
-      if(err != CL_SUCCESS) goto error;
-    }
-    dt_opencl_release_mem_object(dev_tmp);
-    dev_tmp = NULL;
-
-    const size_t bsize = sizeof(float) * width * height;
-    err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
-    cfa = dt_opencl_alloc_device_buffer(devid, bsize);
-    VH_dir = dt_opencl_alloc_device_buffer(devid, bsize);
-    PQ_dir = dt_opencl_alloc_device_buffer(devid, bsize);
-    VP_diff = dt_opencl_alloc_device_buffer(devid, bsize);
-    HQ_diff = dt_opencl_alloc_device_buffer(devid, bsize);
-    rgb0 = dt_opencl_alloc_device_buffer(devid, bsize);
-    rgb1 = dt_opencl_alloc_device_buffer(devid, bsize);
-    rgb2 = dt_opencl_alloc_device_buffer(devid, bsize);
-    if(cfa == NULL || VH_dir == NULL || PQ_dir == NULL || VP_diff == NULL || HQ_diff == NULL || rgb0 == NULL || rgb1 == NULL || rgb2 == NULL)
+    if(!dt_opencl_local_buffer_opt(devid, gd->kernel_rcd_border_redblue, &locopt))
+    {
+      err = CL_INVALID_WORK_DIMENSION;
       goto error;
+    }
+    myborder = 16;
+    size_t sizes[3] = { ROUNDUP(width, locopt.sizex), ROUNDUP(height, locopt.sizey), 1 };
+    size_t local[3] = { locopt.sizex, locopt.sizey, 1 };
+    dt_opencl_set_kernel_args(devid, gd->kernel_rcd_border_redblue, 0, CLARG(dev_tmp), CLARG(dev_out),
+      CLARG(width), CLARG(height), CLARG(filters), CLLOCAL(sizeof(float) * 4 * (locopt.sizex + 2) * (locopt.sizey + 2)),
+      CLARG(myborder));
+    err = dt_opencl_enqueue_kernel_2d_with_local(devid, gd->kernel_rcd_border_redblue, sizes, local);
+    if(err != CL_SUCCESS) goto error;
+  }
+  dt_opencl_release_mem_object(dev_tmp);
+  dev_tmp = NULL;
 
-    // populate data
-    float scaler = 1.0f / dt_iop_get_processed_maximum(piece);
-    err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_rcd_populate, width, height,
+  const size_t bsize = sizeof(float) * width * height;
+  err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
+  cfa = dt_opencl_alloc_device_buffer(devid, bsize);
+  VH_dir = dt_opencl_alloc_device_buffer(devid, bsize);
+  PQ_dir = dt_opencl_alloc_device_buffer(devid, bsize);
+  VP_diff = dt_opencl_alloc_device_buffer(devid, bsize);
+  HQ_diff = dt_opencl_alloc_device_buffer(devid, bsize);
+  rgb0 = dt_opencl_alloc_device_buffer(devid, bsize);
+  rgb1 = dt_opencl_alloc_device_buffer(devid, bsize);
+  rgb2 = dt_opencl_alloc_device_buffer(devid, bsize);
+  if(cfa == NULL || VH_dir == NULL || PQ_dir == NULL || VP_diff == NULL || HQ_diff == NULL || rgb0 == NULL || rgb1 == NULL || rgb2 == NULL)
+    goto error;
+
+  // populate data
+  float scaler = 1.0f / dt_iop_get_processed_maximum(piece);
+  err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_rcd_populate, width, height,
         CLARG(dev_in), CLARG(cfa), CLARG(rgb0), CLARG(rgb1), CLARG(rgb2), CLARG(width), CLARG(height),
         CLARG(filters), CLARG(scaler));
-    if(err != CL_SUCCESS) goto error;
+  if(err != CL_SUCCESS) goto error;
 
-    // Step 1.1: Calculate a squared vertical and horizontal high pass filter on color differences
-    err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_rcd_step_1_1, width, height,
+  // Step 1.1: Calculate a squared vertical and horizontal high pass filter on color differences
+  err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_rcd_step_1_1, width, height,
         CLARG(cfa), CLARG(VP_diff), CLARG(HQ_diff), CLARG(width), CLARG(height));
-    if(err != CL_SUCCESS) goto error;
+  if(err != CL_SUCCESS) goto error;
 
-    // Step 1.2: Calculate vertical and horizontal local discrimination
-    err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_rcd_step_1_2, width, height,
+  // Step 1.2: Calculate vertical and horizontal local discrimination
+  err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_rcd_step_1_2, width, height,
         CLARG(VH_dir), CLARG(VP_diff), CLARG(HQ_diff), CLARG(width), CLARG(height));
-    if(err != CL_SUCCESS) goto error;
+  if(err != CL_SUCCESS) goto error;
 
-    // Step 2.1: Low pass filter incorporating green, red and blue local samples from the raw data
-    err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_rcd_step_2_1, width / 2, height,
+  // Step 2.1: Low pass filter incorporating green, red and blue local samples from the raw data
+  err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_rcd_step_2_1, width / 2, height,
         CLARG(PQ_dir), CLARG(cfa), CLARG(width), CLARG(height), CLARG(filters));
-    if(err != CL_SUCCESS) goto error;
+  if(err != CL_SUCCESS) goto error;
 
-    // Step 3.1: Populate the green channel at blue and red CFA positions
-    err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_rcd_step_3_1, width / 2, height,
+  // Step 3.1: Populate the green channel at blue and red CFA positions
+  err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_rcd_step_3_1, width / 2, height,
       CLARG(PQ_dir), CLARG(cfa), CLARG(rgb1), CLARG(VH_dir), CLARG(width), CLARG(height), CLARG(filters));
-    if(err != CL_SUCCESS) goto error;
+  if(err != CL_SUCCESS) goto error;
 
     // Step 4.1: Calculate a squared P/Q diagonals high pass filter on color differences
-    err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_rcd_step_4_1, width / 2, height,
+  err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_rcd_step_4_1, width / 2, height,
       CLARG(cfa), CLARG(VP_diff), CLARG(HQ_diff), CLARG(width), CLARG(height), CLARG(filters));
-    if(err != CL_SUCCESS) goto error;
+  if(err != CL_SUCCESS) goto error;
 
     // Step 4.2: Calculate P/Q diagonal local discrimination
-    err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_rcd_step_4_2, width / 2, height,
+  err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_rcd_step_4_2, width / 2, height,
         CLARG(PQ_dir), CLARG(VP_diff), CLARG(HQ_diff), CLARG(width), CLARG(height), CLARG(filters));
-    if(err != CL_SUCCESS) goto error;
+  if(err != CL_SUCCESS) goto error;
 
-    // Step 4.3: Populate the red and blue channels at blue and red CFA positions
-    err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_rcd_step_5_1, width / 2, height,
+  // Step 4.3: Populate the red and blue channels at blue and red CFA positions
+  err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_rcd_step_5_1, width / 2, height,
         CLARG(PQ_dir), CLARG(rgb0), CLARG(rgb1), CLARG(rgb2), CLARG(width), CLARG(height), CLARG(filters));
-    if(err != CL_SUCCESS) goto error;
+  if(err != CL_SUCCESS) goto error;
 
-    // Step 5.2: Populate the red and blue channels at green CFA positions
-    err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_rcd_step_5_2, width / 2, height,
+  // Step 5.2: Populate the red and blue channels at green CFA positions
+  err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_rcd_step_5_2, width / 2, height,
         CLARG(VH_dir), CLARG(rgb0), CLARG(rgb1), CLARG(rgb2), CLARG(width), CLARG(height), CLARG(filters));
-    if(err != CL_SUCCESS) goto error;
+  if(err != CL_SUCCESS) goto error;
 
-    scaler = dt_iop_get_processed_maximum(piece);
-    // write output
-    myborder = RCD_MARGIN;
-    err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_rcd_write_output, width, height,
+  scaler = dt_iop_get_processed_maximum(piece);
+  // write output
+  myborder = RCD_MARGIN;
+  err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_rcd_write_output, width, height,
         CLARG(dev_out), CLARG(rgb0), CLARG(rgb1), CLARG(rgb2), CLARG(width), CLARG(height), CLARG(scaler), CLARG(myborder));
 
 error:

--- a/src/iop/demosaicing/vng.c
+++ b/src/iop/demosaicing/vng.c
@@ -323,7 +323,8 @@ static cl_int process_vng_cl(const dt_iop_module_t *self,
                              cl_mem dev_out,
                              cl_mem dev_xtrans,
                              const uint8_t (*const xtrans)[6],
-                             const dt_iop_roi_t *const roi_in,
+                             const int width,
+                             const int height,
                              const uint32_t filters,
                              const gboolean only_vng_linear)
 {
@@ -479,9 +480,6 @@ static cl_int process_vng_cl(const dt_iop_module_t *self,
 
     dev_ips = dt_opencl_copy_host_to_device_constant(devid, ips_size, ips);
     if(dev_ips == NULL) goto finish;
-
-    int width = roi_in->width;
-    int height = roi_in->height;
 
     // need to reserve scaled auxiliary buffer or use dev_out
     err = CL_MEM_OBJECT_ALLOCATION_FAILURE;

--- a/src/iop/demosaicing/xtrans.c
+++ b/src/iop/demosaicing/xtrans.c
@@ -73,8 +73,8 @@ static void xtrans_markesteijn_interpolate(float *out,
     for(int col = 0; col < 3; col++)
       for(int ng = 0, d = 0; d < 10; d += 2)
       {
-        const int g = FCxtrans(row, col, NULL, xtrans) == 1;
-        if(FCxtrans(row + orth[d], col + orth[d + 2], NULL, xtrans) == 1)
+        const int g = FCNxtrans(row, col, xtrans) == 1;
+        if(FCNxtrans(row + orth[d], col + orth[d + 2], xtrans) == 1)
           ng = 0;
         else
           ng++;
@@ -135,7 +135,7 @@ static void xtrans_markesteijn_interpolate(float *out,
           float(*const pix) = rgb[0][row - top][col - left];
           if((col >= 0) && (row >= 0) && (col < width) && (row < height))
           {
-            const int f = FCxtrans(row, col, NULL, xtrans);
+            const int f = FCNxtrans(row, col, xtrans);
             for(int c = 0; c < 3; c++) pix[c] = (c == f) ? in[roi_in->width * row + col] : 0.f;
           }
           else
@@ -150,7 +150,7 @@ static void xtrans_markesteijn_interpolate(float *out,
               {
 #define TRANSLATE(n, size) ((n >= size) ? (2 * size - n - 2) : abs(n))
                 const int cy = TRANSLATE(row, height), cx = TRANSLATE(col, width);
-                if(c == FCxtrans(cy, cx, NULL, xtrans))
+                if(c == FCNxtrans(cy, cx, xtrans))
                   pix[c] = in[roi_in->width * cy + cx];
                 else
                 {
@@ -161,7 +161,7 @@ static void xtrans_markesteijn_interpolate(float *out,
                     for(int x = col - 1; x <= col + 1; x++)
                     {
                       const int yy = TRANSLATE(y, height), xx = TRANSLATE(x, width);
-                      const int ff = FCxtrans(yy, xx, NULL, xtrans);
+                      const int ff = FCNxtrans(yy, xx, xtrans);
                       if(ff == c)
                       {
                         sum += in[roi_in->width * yy + xx];
@@ -245,7 +245,7 @@ static void xtrans_markesteijn_interpolate(float *out,
         for(int col = left + pad_g_interp; col < mcol - pad_g_interp; col++)
         {
           float color[8];
-          const int f = FCxtrans(row, col, NULL, xtrans);
+          const int f = FCNxtrans(row, col, xtrans);
           if(f == 1) continue;
           float (*const pix)[3] = &rgb[0][row - top][col - left];
           const short *const hex = _hexmap(row,col,allhex);
@@ -280,7 +280,7 @@ static void xtrans_markesteijn_interpolate(float *out,
           for(int row = top + pad_g_recalc; row < mrow - pad_g_recalc; row++)
             for(int col = left + pad_g_recalc; col < mcol - pad_g_recalc; col++)
             {
-              const int f = FCxtrans(row, col, NULL, xtrans);
+              const int f = FCNxtrans(row, col, xtrans);
               if(f == 1) continue;
               const short *const hex = _hexmap(row,col,allhex);
               for(int d = 3; d < 6; d++)
@@ -351,7 +351,7 @@ static void xtrans_markesteijn_interpolate(float *out,
         for(int row = top + pad_rb_br; row < mrow - pad_rb_br; row++)
           for(int col = left + pad_rb_br; col < mcol - pad_rb_br; col++)
           {
-            const int f = 2 - FCxtrans(row, col, NULL, xtrans);
+            const int f = 2 - FCNxtrans(row, col, xtrans);
             if(f == 1) continue;
             float(*rfx)[3] = &rgb[0][row - top][col - left];
             const int c = (row - sgrow) % 3 ? TS : 1;
@@ -1075,8 +1075,8 @@ static void xtrans_fdc_interpolate(const dt_iop_module_t *self,
     for(int col = 0; col < 3; col++)
       for(int ng = 0, d = 0; d < 10; d += 2)
       {
-        int g = FCxtrans(row, col, NULL, xtrans) == 1;
-        if(FCxtrans(row + orth[d], col + orth[d + 2], NULL, xtrans) == 1)
+        int g = FCNxtrans(row, col, xtrans) == 1;
+        if(FCNxtrans(row + orth[d], col + orth[d + 2], xtrans) == 1)
           ng = 0;
         else
           ng++;
@@ -1109,7 +1109,7 @@ static void xtrans_fdc_interpolate(const dt_iop_module_t *self,
     {
       for(int col = 0; col < 6; col++)
       {
-        if(!((col - sgcol) % 3) && (FCxtrans(row, col + 1, NULL, xtrans) == 0))
+        if(!((col - sgcol) % 3) && (FCNxtrans(row, col + 1, xtrans) == 0))
         {
           rowoffset = 37 - row - pad_tile; // 1 plus a generous multiple of 6
           coloffset = 37 - col - pad_tile; // to avoid that this value gets negative
@@ -1175,7 +1175,7 @@ static void xtrans_fdc_interpolate(const dt_iop_module_t *self,
           float(*const pix) = rgb[0][row - top][col - left];
           if((col >= 0) && (row >= 0) && (col < width) && (row < height))
           {
-            const int f = FCxtrans(row, col, NULL, xtrans);
+            const int f = FCNxtrans(row, col, xtrans);
             for(int c = 0; c < 3; c++) pix[c] = (c == f) ? in[roi_in->width * row + col] : 0.f;
             *(i_src + TS * (row - top) + (col - left)) = in[roi_in->width * row + col];
           }
@@ -1190,7 +1190,7 @@ static void xtrans_fdc_interpolate(const dt_iop_module_t *self,
               {
 #define TRANSLATE(n, size) ((n >= size) ? (2 * size - n - 2) : abs(n))
                 const int cy = TRANSLATE(row, height), cx = TRANSLATE(col, width);
-                if(c == FCxtrans(cy, cx, NULL, xtrans))
+                if(c == FCNxtrans(cy, cx, xtrans))
                 {
                   pix[c] = in[roi_in->width * cy + cx];
                   *(i_src + TS * (row - top) + (col - left)) = in[roi_in->width * cy + cx];
@@ -1204,7 +1204,7 @@ static void xtrans_fdc_interpolate(const dt_iop_module_t *self,
                     for(int x = col - 1; x <= col + 1; x++)
                     {
                       const int yy = TRANSLATE(y, height), xx = TRANSLATE(x, width);
-                      const int ff = FCxtrans(yy, xx, NULL, xtrans);
+                      const int ff = FCNxtrans(yy, xx, xtrans);
                       if(ff == c)
                       {
                         sum += in[roi_in->width * yy + xx];
@@ -1242,7 +1242,7 @@ static void xtrans_fdc_interpolate(const dt_iop_module_t *self,
           // if in row of horizontal red & blue pairs (or processing
           // vertical red & blue pairs near image bottom), reset min/max
           // between each pair
-          if(FCxtrans(row, col, NULL, xtrans) == 1)
+          if(FCNxtrans(row, col, xtrans) == 1)
           {
             min = FLT_MAX, max = 0.0f;
             continue;
@@ -1288,7 +1288,7 @@ static void xtrans_fdc_interpolate(const dt_iop_module_t *self,
         for(int col = left + pad_g_interp; col < mcol - pad_g_interp; col++)
         {
           float color[8];
-          int f = FCxtrans(row, col, NULL, xtrans);
+          int f = FCNxtrans(row, col, xtrans);
           if(f == 1) continue;
           float (*const pix)[3] = &rgb[0][row - top][col - left];
           const short *const hex = _hexmap(row, col, allhex);
@@ -1312,7 +1312,7 @@ static void xtrans_fdc_interpolate(const dt_iop_module_t *self,
         for(int col = (left - sgcol + pad_rb_g + 2) / 3 * 3 + sgcol; col < mcol - pad_rb_g; col += 3)
         {
           float(*rfx)[3] = &rgb[0][row - top][col - left];
-          int h = FCxtrans(row, col + 1, NULL, xtrans);
+          int h = FCNxtrans(row, col + 1, xtrans);
           float diff[6] = { 0.0f };
           float color[3][8];
           for(int i = 1, d = 0; d < 6; d++, i ^= TS ^ 1, h ^= 2)
@@ -1340,7 +1340,7 @@ static void xtrans_fdc_interpolate(const dt_iop_module_t *self,
       for(int row = top + pad_rb_br; row < mrow - pad_rb_br; row++)
         for(int col = left + pad_rb_br; col < mcol - pad_rb_br; col++)
         {
-          int f = 2 - FCxtrans(row, col, NULL, xtrans);
+          int f = 2 - FCNxtrans(row, col, xtrans);
           if(f == 1) continue;
           float(*rfx)[3] = &rgb[0][row - top][col - left];
           int c = (row - sgrow) % 3 ? TS : 1;
@@ -1638,13 +1638,14 @@ static cl_int process_markesteijn_cl(const dt_iop_module_t *self,
                                      cl_mem dev_out,
                                      cl_mem dev_xtrans,
                                      const uint8_t(*const xtrans)[6],
-                                     const dt_iop_roi_t *const roi_in,
+                                     const int width,
+                                     const int height,
                                      const uint32_t filters)
 {
   const dt_iop_demosaic_data_t *data = piece->data;
   const dt_iop_demosaic_global_data_t *gd = self->global_data;
 
-  process_vng_cl(self, piece, dev_in, dev_out, dev_xtrans, xtrans, roi_in, filters, FALSE);
+  process_vng_cl(self, piece, dev_in, dev_out, dev_xtrans, xtrans, width, height, filters, FALSE);
   const int devid = piece->pipe->devid;
 
   cl_mem dev_tmptmp = NULL;
@@ -1659,8 +1660,6 @@ static cl_int process_markesteijn_cl(const dt_iop_module_t *self,
 
   cl_mem *dev_rgb = dev_rgbv;
 
-    const int width = roi_in->width;
-    const int height = roi_in->height;
     const int passes = ((data->demosaicing_method & ~DT_DEMOSAIC_DUAL) == DT_IOP_DEMOSAIC_MARKESTEIJN_3) ? 3 : 1;
     const int ndir = passes > 1 ? 8 : 4 ;
     const int pad_tile = (passes == 1) ? 12 : 17;


### PR DESCRIPTION
1. Fixed OpenCL dual demosaicing not working with capture sharpen
2. All FCxtrans calls in demosaicer code doe not require the roi any more, defined FCNxtrans(const int row, const int col, const uint8_t (*const xtrans)[6]) and using that instead if appropriate of the more costly FCxtrans() leads to a slight performance gain and simplifies code.
3. The OpenCL demosaicers get the width and height instead of roi as parameters, more clear (and a preparation for internal tiling)
4. Some minor formatting

@TurboGit it might be good to add a test for dual-demosaic plus capture?