### PR TITLE
Demosaic internal tiling

### DIFF
--- a/src/iop/demosaicing/basics.c
+++ b/src/iop/demosaicing/basics.c
@@ -621,10 +621,13 @@ static int demosaic_box3_cl(dt_iop_module_t *self,
                             const uint32_t filters)
 {
   const dt_iop_demosaic_global_data_t *gd = self->global_data;
-  return dt_opencl_enqueue_kernel_2d_args(piece->pipe->devid, gd->kernel_demosaic_box3, width, height,
-          CLARG(dev_in), CLARG(dev_out),
-          CLARG(width), CLARG(height),
-          CLARG(filters), CLARG(dev_xtrans));
+  const cl_int err = dt_opencl_enqueue_kernel_2d_args(piece->pipe->devid, gd->kernel_demosaic_box3, width, height,
+                      CLARG(dev_in), CLARG(dev_out),
+                      CLARG(width), CLARG(height),
+                      CLARG(filters), CLARG(dev_xtrans));
+  if(err != CL_SUCCESS)
+    dt_print(DT_DEBUG_OPENCL, "[opencl_demosaic] box3 problem '%s'", cl_errstr(err));
+  return err;
 }
 
 #endif

--- a/src/iop/demosaicing/dual.c
+++ b/src/iop/demosaicing/dual.c
@@ -105,13 +105,11 @@ int dual_demosaic_cl(const dt_iop_module_t *self,
   const float contrastf = _slider2contrast(data->dual_thrs);
 
   cl_int err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
-  cl_mem mask = NULL;
-  cl_mem tmp = NULL;
   const size_t bsize = sizeof(float) * width * height;
 
-  tmp = dt_opencl_alloc_device_buffer(devid, bsize);
-  mask = dt_opencl_alloc_device_buffer(devid, bsize);
-  if(mask == NULL || tmp == NULL) goto finish;
+  cl_mem tmp = dt_opencl_alloc_device_buffer(devid, bsize);
+  cl_mem mask = dt_opencl_alloc_device_buffer(devid, bsize);
+  if(!mask || !tmp) goto finish;
 
   const gboolean wboff = !p->dsc.temperature.enabled;
   const dt_aligned_pixel_t wb =
@@ -140,6 +138,10 @@ int dual_demosaic_cl(const dt_iop_module_t *self,
       CLARG(high_image), CLARG(low_image), CLARG(out), CLARG(width), CLARG(height), CLARG(tmp), CLARG(dual_mask));
 
   finish:
+
+  if(err != CL_SUCCESS)
+    dt_print_pipe(DT_DEBUG_ALWAYS, "dual demosaic", p, self, devid, NULL, NULL, "Error: %s", cl_errstr(err));
+
   dt_opencl_release_mem_object(mask);
   dt_opencl_release_mem_object(tmp);
   return err;

--- a/src/iop/demosaicing/xtrans.c
+++ b/src/iop/demosaicing/xtrans.c
@@ -2080,7 +2080,8 @@ error:
   dt_opencl_release_mem_object(dev_allhex);
   dt_opencl_release_mem_object(dev_aux);
   if(err != CL_SUCCESS)
-    dt_print(DT_DEBUG_OPENCL, "[opencl_demosaic] markesteijn problem '%s'", cl_errstr(err));
+    dt_print(DT_DEBUG_OPENCL, "[opencl_demosaic] markesteijn%s problem '%s'",
+      passes == 3 ? "_3" : "", cl_errstr(err));
   return err;
 }
 


### PR DESCRIPTION
EDIT 2:
Last part of demosaicer changes for 5.4 after preliminary work has been done.

1. a) Dual demosaicing, b) preparing the data required for details threshold in mask blending and c) full green equilibration  required the demosaicer to run in non-tiled mode until now. Especially on systems with restricted OpenCL memory or when using large xtrans images this resulted in fallbacks to CPU code with consecutive bad performance.
2. If tiling was possible we had to use the slower `_default_process_tiling_roi()` variants with much larger overlaps because of demosaic doing the scaling. Stitching the tiled output was quite costly especially for OpenCL as that takes place on main memory.

We now always run demosaic in untiled mode and do the tiling internally. The internal tiles are horizontal "bars" over full width so on CPU code we can process each tile from original raw data and the stitching is just a plain copy, on OpenCL the copy of in/out data is very fast as full width is used. 

Overall
1. the performance does not change if there is no tiling
2. if we must tile the performance is always better
3. dual demosaicing, details mask and green equilibration are handled internally
4. Latest commits include OpenCL internal tiling