### PR TITLE
Include gphoto2 driver libraries into AppImage

### DIFF
--- a/packaging/AppImage/AppRun
+++ b/packaging/AppImage/AppRun
@@ -14,6 +14,8 @@ HERE="$(dirname "$(readlink -f "${0}")")"
 
 source "$HERE"/apprun-hooks/"linuxdeploy-plugin-gtk.sh"
 
+export CAMLIBS=$HERE/usr/lib/libgphoto2/`ls -1 --group-directories-first $HERE/usr/lib/libgphoto2|head -1`
+
 if [[ ! -z $APPIMAGE ]] ; then
   BINARY_NAME=$(basename "$ARGV0")
   if [[ ! -z "$1" ]] && [[ -e "$HERE/usr/bin/$1" ]] ; then

--- a/tools/appimage-build-script.sh
+++ b/tools/appimage-build-script.sh
@@ -48,6 +48,12 @@ sed -i 's/\/usr\/bin\///' ../AppDir/usr/share/applications/org.darktable.darktab
 mkdir -p ../AppDir/usr/share/lensfun
 cp -a /var/lib/lensfun-updates/* ../AppDir/usr/share/lensfun
 
+# Include gphoto2 driver libraries. We also have to set the CAMLIBS
+# environment variable in AppRun.wrapped accordingly when starting
+# AppImage so that libgphoto2 can find these drivers.
+mkdir -p ../AppDir/usr/lib/libgphoto2
+cp -a /usr/lib/x86_64-linux-gnu/libgphoto2/* ../AppDir/usr/lib/libgphoto2
+
 # Since linuxdeploy is itself an AppImage, we don't rely on it being installed
 # on the build system, but download it every time we run this script. If that
 # doesn't suit you (for example, you want to build an AppImage without an


### PR DESCRIPTION
Previously, the libgphoto2 driver libraries (they are separate from the core library) were not included in the AppImage bundle. They are necessary for tethering, but in practice there was no problem, since very often popular DEs contain a dependency on libgphoto2 via GVFS, so the driver libraries from the host system were used.

However, the default location of these libraries contains the version number of libgphoto2. As a result, if the version in the bundle and in the host system differs, there will be a problem. AppImage is built with a fairly recent version (and the library itself does not release new versions very often), so everything will work on reasonably recent distro releases. But on older distros, tethering will be broken.