### PR TITLE
Add geometry-only transform functions to module API

### DIFF
--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -559,6 +559,13 @@ gboolean dt_dev_distort_backtransform_plus
    float *points,
    const size_t points_count);
 
+/** apply all geometry transforms to the specified points; fall back to applying distort_transform
+ * for modules without a geometry_transform function */
+gboolean dt_dev_geometry_transform(dt_develop_t *dev,
+                                   struct dt_dev_pixelpipe_t *pipe, // struct not declared until later
+                                   float *points,
+                                   const size_t points_count);
+
 /** get the iop_pixelpipe instance corresponding to the iop in the given pipe */
 struct dt_dev_pixelpipe_iop_t *dt_dev_distort_get_iop_pipe(dt_develop_t *dev,
                                                            struct dt_dev_pixelpipe_t *pipe,

--- a/src/iop/iop_api.h
+++ b/src/iop/iop_api.h
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2016-2023 darktable developers.
+    Copyright (C) 2016-2025 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU Lesser General Public License as published by
@@ -310,6 +310,15 @@ OPTIONAL(void, distort_mask, struct dt_iop_module_t *self,
                              float *const out,
                              const struct dt_iop_roi_t *const roi_in,
                              const struct dt_iop_roi_t *const roi_out);
+
+// The following function is used like distort_transform, but based on
+// the overall geometric distortion (as produced by e.g. rotate and perspective)
+// without regard for any local distortions such as liquify's warps.
+// If not provided by a module, distort_transform will be called instead.
+OPTIONAL(gboolean, geometry_transform, struct dt_iop_module_t *self,
+                                       struct dt_dev_pixelpipe_iop_t *piece,
+                                       float *points,
+                                       size_t points_count);
 
 // introspection related callbacks, will be auto-implemented if
 // DT_MODULE_INTROSPECTION() is used,

--- a/src/iop/iop_api.h
+++ b/src/iop/iop_api.h
@@ -320,6 +320,15 @@ OPTIONAL(gboolean, geometry_transform, struct dt_iop_module_t *self,
                                        float *points,
                                        size_t points_count);
 
+// The following function is used like distort_backtransform, but based on
+// the overall geometric distortion (as produced by e.g. rotate and perspective)
+// without regard for any local distortions such as liquify's warps.
+// If not provided by a module, distort_backtransform will be called instead.
+OPTIONAL(gboolean, geometry_backtransform, struct dt_iop_module_t *self,
+                                           struct dt_dev_pixelpipe_iop_t *piece,
+                                           float *points,
+                                           size_t points_count);
+
 // introspection related callbacks, will be auto-implemented if
 // DT_MODULE_INTROSPECTION() is used,
 OPTIONAL(int, introspection_init, struct dt_iop_module_so_t *self, int api_version);

--- a/src/iop/liquify.c
+++ b/src/iop/liquify.c
@@ -1356,6 +1356,18 @@ gboolean distort_backtransform(dt_iop_module_t *self,
   return _distort_xtransform(self, piece, points, points_count, FALSE);
 }
 
+gboolean geometry_transform(dt_iop_module_t *self,
+                            dt_dev_pixelpipe_iop_t *piece,
+                            float *const restrict points,
+                            const size_t points_count)
+{
+  // liquify does not apply any geometric transformation to the image
+  // coordinates, only local warping, so this function is a no-op and
+  // overrides distort_transform when the viewport coordinates are
+  // determined
+  return TRUE;
+}
+
 void distort_mask(dt_iop_module_t *self,
                   dt_dev_pixelpipe_iop_t *piece,
                   const float *const in,
@@ -2800,6 +2812,8 @@ int mouse_moved(dt_iop_module_t *self,
                 const int which,
                 const float zoom_scale)
 {
+  if(!self->enabled)
+    return FALSE;
   dt_iop_liquify_gui_data_t *g = self->gui_data;
   const gboolean layer_display = _layers_showing(g);
   if(!self->enabled && !layer_display)

--- a/src/iop/liquify.c
+++ b/src/iop/liquify.c
@@ -1368,6 +1368,18 @@ gboolean geometry_transform(dt_iop_module_t *self,
   return TRUE;
 }
 
+gboolean geometry_backtransform(dt_iop_module_t *self,
+                                dt_dev_pixelpipe_iop_t *piece,
+                                float *const restrict points,
+                                const size_t points_count)
+{
+  // liquify does not apply any geometric transformation to the image
+  // coordinates, only local warping, so this function is a no-op and
+  // overrides distort_backtransform when the viewport coordinates are
+  // determined
+  return TRUE;
+}
+
 void distort_mask(dt_iop_module_t *self,
                   dt_dev_pixelpipe_iop_t *piece,
                   const float *const in,

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -1714,7 +1714,7 @@ void dt_view_paint_surface(cairo_t *cr,
   float pts[] = { buf_zoom_x, buf_zoom_y,
                   dev->preview_pipe->backbuf_zoom_x, dev->preview_pipe->backbuf_zoom_y,
                   port->zoom_x, port->zoom_y };
-  dt_dev_distort_transform_plus(dev, port->pipe, 0.0f, DT_DEV_TRANSFORM_DIR_ALL, pts, 3);
+  dt_dev_geometry_transform(dev, port->pipe, pts, 3);
 
   const float offset_x  = pts[0] / processed_width  - 0.5f;
   const float offset_y  = pts[1] / processed_height - 0.5f;
@@ -1791,6 +1791,8 @@ void dt_view_paint_surface(cairo_t *cr,
      && (port == &dev->full || port == &dev->preview2))
   {
     port->pipe->changed |= DT_DEV_PIPE_ZOOMED;
+    // setting the dirty flag causes an infinite refresh cycle, but if we don't set it, we don't get
+    // full-resolution display on zooming in....
     if(port->pipe->status == DT_DEV_PIXELPIPE_VALID)
       port->pipe->status = DT_DEV_PIXELPIPE_DIRTY;
 


### PR DESCRIPTION
The distort_transform and distort_backtransform functions get calls from a variety of places in the code, including the darkroom expose() function.  For most modules, these functions are very fast, but a large warp in the liquify module can take 100+ms to compute, which needs to be done every time the distort functions are called.  And is mostly unnecessary, since the calls are mainly to determine the viewport position and size, which only needs global transforms, not liquify's local warping.

So this PR introduces separate API functions geometry_transform and geometry_backtransform which ignore local warping of the image.  The liquify module implements these, all others fall back to using distort_* when geometry_* is called.

I haven't figured out yet why the new functions result in an infinite refresh loop (using ~180% CPU) when an instance of liquify with a large warp is active, but I have been able to trigger the same with the previous distort_* functions, so it doesn't seem to be a new issue, just one that is far more likely to happen (?because the viewport computation is so much faster now?).
