### PR TITLE
Better capture sharpen defaults and radius calc bugfix

### DIFF
--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -115,7 +115,7 @@ typedef struct dt_iop_demosaic_params_t
   dt_iop_demosaic_lmmse_t lmmse_refine;         // $DEFAULT: DT_LMMSE_REFINE_1 $DESCRIPTION: "LMMSE refine"
   float dual_thrs;                              // $MIN: 0.0 $MAX: 1.0 $DEFAULT: 0.2 $DESCRIPTION: "dual threshold"
   float cs_radius;                              // $MIN: 0.0 $MAX: 1.5 $DEFAULT: 0.0 $DESCRIPTION: "radius"
-  float cs_thrs;                                // $MIN: 0.0 $MAX: 1.0 $DEFAULT: 0.40 $DESCRIPTION: "edge sensitivity"
+  float cs_thrs;                                // $MIN: 0.0 $MAX: 1.0 $DEFAULT: 0.40 $DESCRIPTION: "contrast sensitivity"
   float cs_boost;                               // $MIN: 0.0 $MAX: 1.5 $DEFAULT: 0.0 $DESCRIPTION: "corner boost"
   int cs_iter;                                  // $MIN: 0 $MAX: 25 $DEFAULT: 0 $DESCRIPTION: "sharpen"
   float cs_center;                              // $MIN: 0.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "sharp center"
@@ -382,7 +382,7 @@ int legacy_params(dt_iop_module_t *self,
     dt_iop_demosaic_params_v5_t *n = malloc(sizeof(dt_iop_demosaic_params_v5_t));
     memcpy(n, o, sizeof *o);
     n->cs_radius = 0.0f;
-    n->cs_thrs = 0.4f;
+    n->cs_thrs = _get_variance_threshold(self);
     n->cs_boost = 0.0f;
     n->cs_iter = 0;
     n->cs_center = 0.0f;
@@ -1254,6 +1254,8 @@ void reload_defaults(dt_iop_module_t *self)
     d->demosaicing_method = self->dev->image_storage.flags & DT_IMAGE_4BAYER
                             ? DT_IOP_DEMOSAIC_VNG4
                             : DT_IOP_DEMOSAIC_RCD;
+
+  d->cs_thrs = _get_variance_threshold(self);
 
   self->hide_enable_button = TRUE;
 


### PR DESCRIPTION
EDIT:
1. We should do the radius calculation on non-temperature-corrected sensor data to safely avoid very low or high signals for resistance against clipping and hot/cold photosites.
2. For >= 14bit raws or low-ISO images the default of 0.4 for the variance threshold was definitely too high as only the "edges" were corrected and contrasty darker parts of the image were left out from CS correction without reason.
   We now check for sensor precision and exif ISO and possibly use a lower threshold.
   There is no precise math behind the threshold lowering but just testing a huge amount of images to give a better default as a starting point.
3. The control name of "edge sensitivity" has been changed to "contrast sensitivity" as this is not about edge detection but local variance/contrast.
4. There are images with a correctly calculated radius of > 1.0 so let's use that.
5. Minor tooltip fix
