### PR TITLE
Change of zoom in main canvas forces a pipe shutdown

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -452,6 +452,7 @@ restart:
                 problem ? "problem " : "success ",
                 shutdown == DT_DEV_PIXELPIPE_STOP_NODES ? "DT_DEV_PIXELPIPE_STOP_NODES"
                 : shutdown == DT_DEV_PIXELPIPE_STOP_HQ  ? "DT_DEV_PIXELPIPE_STOP_HQ"
+                : shutdown == DT_DEV_PIXELPIPE_STOP_ZOOMED ? "DT_DEV_PIXELPIPE_STOP_ZOOMED"
                 : shutdown == DT_DEV_PIXELPIPE_STOP_NO  ? "DT_DEV_PIXELPIPE_STOP_NO"
                 : "DT_DEV_PIXELPIPE_STOP_OTHER");
   if(problem)

--- a/src/develop/pixelpipe_hb.h
+++ b/src/develop/pixelpipe_hb.h
@@ -87,6 +87,7 @@ typedef enum dt_dev_pixelpipe_stopper_t
   DT_DEV_PIXELPIPE_STOP_NO = 0,
   DT_DEV_PIXELPIPE_STOP_NODES,
   DT_DEV_PIXELPIPE_STOP_HQ,
+  DT_DEV_PIXELPIPE_STOP_ZOOMED,
   DT_DEV_PIXELPIPE_STOP_LAST,
 } dt_dev_pixelpipe_stopper_t;
 

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -1794,6 +1794,8 @@ void dt_view_paint_surface(cairo_t *cr,
     if(port->pipe->status == DT_DEV_PIXELPIPE_VALID)
       port->pipe->status = DT_DEV_PIXELPIPE_DIRTY;
 
+    if(port->pipe->type & (DT_DEV_PIXELPIPE_FULL | DT_DEV_PIXELPIPE_PREVIEW2))
+      dt_atomic_set_int(&port->pipe->shutdown, DT_DEV_PIXELPIPE_STOP_ZOOMED);
     // draw preview
     const float wd = processed_width * dev->preview_pipe->processed_width / MAX(1, dev->full.pipe->processed_width);
     const float ht = processed_height * dev->preview_pipe->processed_width / MAX(1, dev->full.pipe->processed_width);


### PR DESCRIPTION
Since ca34bce11fe3fae88f435c2033002b7f94efd08b we support shutting down the pixelpipe and enforcing a re-run with disabled cacheline & input.

1. Let's make use of that when we use a different zoom in darkroom main views.
2. Two notorious modules taking very long are diffuse and laplacian highlights correction. Both now iterate only while there is no shutdown signal and pass the iop_order as the shutdown signal so pixelpipe processing code knows what to do.

@dterrahe and @ralfbrown this would be my part of improving UI responsiveness. To test use `-d pipe` and check logs while moving zoomed area.