### PR TITLE
Fix scharr writing in rawprepare

### DIFF
--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -3634,6 +3634,11 @@ float *dt_dev_distort_detail_mask(dt_dev_pixelpipe_iop_t *piece,
     resmask = NULL;
   }
 
+  if(src && src == resmask)
+  {
+    resmask = dt_iop_image_alloc(pipe->scharr.roi.width, pipe->scharr.roi.height, 1);
+    dt_iop_image_copy(resmask, src, pipe->scharr.roi.width * pipe->scharr.roi.height);
+  }
   return resmask;
 }
 


### PR DESCRIPTION
We can always prepare the mask from roi_out data for performance and avoid the mask distortion step as this module only crops and doesn't scale.

As reported in https://discuss.pixls.us/t/darktable-boomed-out/52112 darktable crashes with details mask refinement when using with monochrome raw images.

This PR fixes the crash and makes is "working", unfortunately there is a design flaw that makes the mask not-roi-scale- aware as we scale at the initial part of the pipe. This also is true for sraws, there it probably got unnoticed as we have opposed highlights on per default thus we crop to required roi there.

I am planning to add true monochromes to the demosaicer module so it can get capture sharpening later but still for 5.4 so let's got with this for now as a bugfix. 