### PR TITLE
skip liquify transforms for viewport changes

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -2595,13 +2595,13 @@ static char *_transform_type(const dt_dev_transform_direction_t transf_direction
 {
   switch(transf_direction)
   {
-    case DT_DEV_TRANSFORM_DIR_ALL:        return "all included";
-    case DT_DEV_TRANSFORM_DIR_FORW_INCL:  return "forward inclusive";
-    case DT_DEV_TRANSFORM_DIR_FORW_EXCL:  return "forward exclusive";
-    case DT_DEV_TRANSFORM_DIR_BACK_INCL:  return "backward inclusive";
-    case DT_DEV_TRANSFORM_DIR_BACK_EXCL:  return "backward exclusive";
-    case DT_DEV_TRANSFORM_DIR_GEOMETRY:   return "all except nogeometry";
-    default:                              return "no transform";
+    case DT_DEV_TRANSFORM_DIR_ALL:          return "all included";
+    case DT_DEV_TRANSFORM_DIR_FORW_INCL:    return "forward inclusive";
+    case DT_DEV_TRANSFORM_DIR_FORW_EXCL:    return "forward exclusive";
+    case DT_DEV_TRANSFORM_DIR_BACK_INCL:    return "backward inclusive";
+    case DT_DEV_TRANSFORM_DIR_BACK_EXCL:    return "backward exclusive";
+    case DT_DEV_TRANSFORM_DIR_ALL_GEOMETRY: return "all except geometry";
+    default:                                return "no transform";
   }
 }
 
@@ -2632,8 +2632,8 @@ static gboolean _dev_distort_transform_locked(dt_develop_t *dev,
        && transform
        && piece->data
        && ((transf_direction == DT_DEV_TRANSFORM_DIR_ALL)
-           || (transf_direction == DT_DEV_TRANSFORM_DIR_GEOMETRY
-               && !(module->operation_tags() & IOP_TAG_NOGEOMETRY))
+           || (transf_direction == DT_DEV_TRANSFORM_DIR_ALL_GEOMETRY
+               && !(module->operation_tags() & IOP_TAG_GEOMETRY))
            || (transf_direction == DT_DEV_TRANSFORM_DIR_FORW_INCL
                && module->iop_order >= iop_order)
            || (transf_direction == DT_DEV_TRANSFORM_DIR_FORW_EXCL
@@ -2684,7 +2684,7 @@ void dt_dev_zoom_move(dt_dev_viewport_t *port,
   dt_pthread_mutex_lock(&dev->history_mutex);
 
   float pts[2] = { port->zoom_x, port->zoom_y };
-  _dev_distort_transform_locked(darktable.develop, port->pipe, FALSE, 0.0f, DT_DEV_TRANSFORM_DIR_GEOMETRY, pts, 1);
+  _dev_distort_transform_locked(darktable.develop, port->pipe, FALSE, 0.0f, DT_DEV_TRANSFORM_DIR_ALL_GEOMETRY, pts, 1);
 
   const float old_pts0 = pts[0];
   const float old_pts1 = pts[1];
@@ -2830,7 +2830,7 @@ void dt_dev_zoom_move(dt_dev_viewport_t *port,
     || (zoom == DT_ZOOM_MOVE && (x || y));
   if(has_moved)
   {
-    _dev_distort_transform_locked(dev, port->pipe, TRUE, 0.0f, DT_DEV_TRANSFORM_DIR_GEOMETRY, pts, 1);
+    _dev_distort_transform_locked(dev, port->pipe, TRUE, 0.0f, DT_DEV_TRANSFORM_DIR_ALL_GEOMETRY, pts, 1);
     port->zoom_x = pts[0];
     port->zoom_y = pts[1];
   }
@@ -2915,7 +2915,7 @@ void dt_dev_get_viewport_params(dt_dev_viewport_t *port,
   {
     float pts[2] = { port->zoom_x, port->zoom_y };
     dt_dev_distort_transform_plus(darktable.develop, port->pipe,
-                                  0.0f, DT_DEV_TRANSFORM_DIR_GEOMETRY, pts, 1);
+                                  0.0f, DT_DEV_TRANSFORM_DIR_ALL_GEOMETRY, pts, 1);
     *x = pts[0] / port->pipe->processed_width - 0.5f;
     *y = pts[1] / port->pipe->processed_height - 0.5f;
   }

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -85,7 +85,7 @@ typedef enum dt_dev_transform_direction_t
   DT_DEV_TRANSFORM_DIR_FORW_EXCL = 2,
   DT_DEV_TRANSFORM_DIR_BACK_INCL = 3,
   DT_DEV_TRANSFORM_DIR_BACK_EXCL = 4,
-  DT_DEV_TRANSFORM_DIR_GEOMETRY = 5,
+  DT_DEV_TRANSFORM_DIR_ALL_GEOMETRY = 5,
 } dt_dev_transform_direction_t;
 
 typedef enum dt_clipping_preview_mode_t

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -73,7 +73,7 @@ typedef enum dt_iop_tags_t
   IOP_TAG_DISTORT = 1 << 0,
   IOP_TAG_DECORATION = 1 << 1,
   IOP_TAG_CROPPING = 1 << 2,
-  IOP_TAG_NOGEOMETRY = 1 << 3,
+  IOP_TAG_GEOMETRY = 1 << 3,
 
   // might be some other filters togglable by user?
   // IOP_TAG_SLOW       = 1<<3,

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -3020,7 +3020,7 @@ gboolean dt_dev_pixelpipe_process(dt_dev_pixelpipe_t *pipe,
 
   float zx = (x + 0.5f * width) / scale, zy = (y + 0.5f * height) / scale;
   dt_dev_zoom_pos_t pts = { zx, zy, zx + 1.f, zy, zx, zy + 1.f };
-  dt_dev_distort_backtransform_plus(dev, pipe, 0.0f, DT_DEV_TRANSFORM_DIR_GEOMETRY, pts, 3);
+  dt_dev_distort_backtransform_plus(dev, pipe, 0.0f, DT_DEV_TRANSFORM_DIR_ALL_GEOMETRY, pts, 3);
 
   // get a snapshot of mask list
   if(pipe->forms) g_list_free_full(pipe->forms, (void (*)(void *))dt_masks_free_form);

--- a/src/iop/liquify.c
+++ b/src/iop/liquify.c
@@ -310,7 +310,7 @@ int flags()
 
 int operation_tags()
 {
-   return IOP_TAG_DISTORT | IOP_TAG_NOGEOMETRY;
+   return IOP_TAG_DISTORT | IOP_TAG_GEOMETRY;
 }
 
 int operation_tags_filter()

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -1741,7 +1741,7 @@ void dt_view_paint_surface(cairo_t *cr,
   memcpy(pts, buf_zoom_pos, sizeof(dt_dev_zoom_pos_t));
   memcpy(pts + 6, pp->backbuf_zoom_pos, sizeof(dt_dev_zoom_pos_t));
   pts[12] = port->zoom_x; pts[13] = port->zoom_y;
-  dt_dev_distort_transform_plus(dev, port->pipe, 0.0f, DT_DEV_TRANSFORM_DIR_GEOMETRY, pts, 7);
+  dt_dev_distort_transform_plus(dev, port->pipe, 0.0f, DT_DEV_TRANSFORM_DIR_ALL_GEOMETRY, pts, 7);
 
   const float offset_x  = pts[0] / processed_width  - 0.5f;
   const float offset_y  = pts[1] / processed_height - 0.5f;


### PR DESCRIPTION
Simpler alternative to #19243

I believe this also fixes the infinite refresh loop you got because `dt_dev_pixelpipe_process` would store a transformed location and  `dt_view_paint_surface` would compare it to the untransformed one it requested and immediately rerequest it.

Also dedupped (most of) `_dev_distort_back/transform_locked`