### PR TITLE
Add query_event to the Lua API

### DIFF
--- a/src/lua/configuration.h
+++ b/src/lua/configuration.h
@@ -42,10 +42,11 @@
 // 4.8.0 was 9.3.0 (added button and box widget enhancements)
 // 5.0.0 was 9.4.0 (added group events and uuid)
 // 5.2.0 was 9.5.0 (added apply_sidecar to image)
+// 5.4.0 was 9.6.0 (added event querying)
 /* incompatible API change */
 #define LUA_API_VERSION_MAJOR 9
 /* backward compatible API change */
-#define LUA_API_VERSION_MINOR 5
+#define LUA_API_VERSION_MINOR 6
 /* bugfixes that should not change anything to the API */
 #define LUA_API_VERSION_PATCH 0
 /* suffix for unstable version */

--- a/src/lua/events.c
+++ b/src/lua/events.c
@@ -724,6 +724,11 @@ int dt_lua_init_events(lua_State *L)
   lua_pushcfunction(L, dt_lua_event_multiinstance_register);
   lua_pushcfunction(L, dt_lua_event_multiinstance_destroy);
   lua_pushcfunction(L, dt_lua_event_multiinstance_trigger);
+  dt_lua_event_add(L, "darkroom-image-loaded");
+  
+  lua_pushcfunction(L, dt_lua_event_multiinstance_register);
+  lua_pushcfunction(L, dt_lua_event_multiinstance_destroy);
+  lua_pushcfunction(L, dt_lua_event_multiinstance_trigger);
   dt_lua_event_add(L, "darkroom-image-history-changed");
 
   lua_pushcfunction(L, dt_lua_event_multiinstance_register);

--- a/src/lua/events.c
+++ b/src/lua/events.c
@@ -541,7 +541,72 @@ static int lua_destroy_event(lua_State *L)
   return 0;
 }
 
+static int lua_query_event(lua_State *L)
+{
+  // 1 is the index name
+  // 2 is event name
+  const char *evt_name = luaL_checkstring(L, 2);
 
+  // get the event list
+  lua_getfield(L, LUA_REGISTRYINDEX, "dt_lua_event_list");
+
+  // get the table for this event and check to make sure it exists
+  lua_getfield(L, -1, evt_name);
+  if(lua_isnil(L, -1))
+  {
+    // event table not found, so it's a nonexistent event
+    lua_pop(L, 2);
+    lua_pushboolean(L, false);
+  }
+  else
+  {
+    // add the index table to the stack
+    lua_getfield(L, 4, "index");
+
+    if(strcmp(luaL_checkstring(L, 2), "shortcut") == 0) // shortcut event
+    {
+      // lookup the value (tooltip) for the key (index name)
+      lua_getfield(L, 5, luaL_checkstring(L, 1));
+
+      // check to make sure the key was found
+      if(lua_isnoneornil(L, -1))
+      {
+        // not found, return false
+        lua_pop(L, 5);
+        lua_pushboolean(L, false);
+      }
+      else
+      {
+        // found, return true
+        lua_pop(L, 6);
+        lua_pushboolean(L, true);
+      }
+    }
+    else  // multi instance event
+    { 
+      // loop through the index table trying for a match on index name
+      for(int i = 1; i <= luaL_len(L, 5); i++)
+      {
+        lua_rawgeti(L, 5, i);
+        if(strcmp(luaL_checkstring(L, -1), luaL_checkstring(L, 1)) == 0)
+        {
+          // found the index name
+          lua_pop(L, 6);
+          lua_pushboolean(L, true);
+          break;
+        }
+      }
+    }
+    if(lua_gettop(L) > 1)
+    {
+      // didn't find the event
+      lua_pop(L, 5);
+      lua_pushboolean(L, false);
+    }
+  }
+
+  return 1;
+}
 
 int dt_lua_init_early_events(lua_State *L)
 {
@@ -555,6 +620,9 @@ int dt_lua_init_early_events(lua_State *L)
   lua_settable(L, -3);
   lua_pushstring(L, "destroy_event");
   lua_pushcfunction(L, &lua_destroy_event);
+  lua_settable(L, -3);
+  lua_pushstring(L, "query_event");
+  lua_pushcfunction(L, &lua_query_event);
   lua_settable(L, -3);
   lua_pop(L, 1);
   return 0;

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -167,11 +167,6 @@ void init(dt_view_t *self)
   dt_lua_gtk_wrap(L);
   lua_pushcclosure(L, dt_lua_type_member_common, 1);
   dt_lua_type_register_const_type(L, my_type, "display_image");
-
-  lua_pushcfunction(L, dt_lua_event_multiinstance_register);
-  lua_pushcfunction(L, dt_lua_event_multiinstance_destroy);
-  lua_pushcfunction(L, dt_lua_event_multiinstance_trigger);
-  dt_lua_event_add(L, "darkroom-image-loaded");
 #endif
 }
 


### PR DESCRIPTION
**Problem**

Scripts create events to communicate with darktable and invoke actions.  These events can be destroyed by the script when it exits and then recreated when it restarts.

When shortcut events are removed, their key mapping is lost.  If you stop a script with a shortcut and the shortcut event is removed, the user has to remap the shortcut when the script is restarted.

**Work Around**

Currently most scripts are set to destroy all events except shortcuts when they are stopped, so that key mappings are preserved.  If you restart a script then the script crashes because the shortcut event tries to get registered a second time.

**Solution**

Add a function to see if the event is already registered, then wrap the shortcut event registration in a test to see if the event exists.

---

Bumped API to 9.6.0

---

While testing I found a bug where the `darkroom-image-loaded` event is not initialized early enough.  Moved the initialization to lua/events.c so that it get's initialized on time.