### PR TITLE
Packaging into an AppImage bundle and using network related GIO modules from there

### DIFF
--- a/packaging/AppImage/AppRun
+++ b/packaging/AppImage/AppRun
@@ -16,6 +16,8 @@ source "$HERE"/apprun-hooks/"linuxdeploy-plugin-gtk.sh"
 
 export CAMLIBS=$HERE/usr/lib/libgphoto2/`ls -1 --group-directories-first $HERE/usr/lib/libgphoto2|head -1`
 
+export GIO_EXTRA_MODULES=$HERE/usr/lib/gio/modules
+
 if [[ ! -z $APPIMAGE ]] ; then
   BINARY_NAME=$(basename "$ARGV0")
   if [[ ! -z "$1" ]] && [[ -e "$HERE/usr/bin/$1" ]] ; then

--- a/tools/appimage-build-script.sh
+++ b/tools/appimage-build-script.sh
@@ -54,6 +54,15 @@ cp -a /var/lib/lensfun-updates/* ../AppDir/usr/share/lensfun
 mkdir -p ../AppDir/usr/lib/libgphoto2
 cp -a /usr/lib/x86_64-linux-gnu/libgphoto2/* ../AppDir/usr/lib/libgphoto2
 
+# Include networking related GIO modules. We also have to set the GIO_EXTRA_MODULES
+# environment variable in AppRun.wrapped accordingly when starting AppImage
+# for the GLib's GIO subsystem to use these modules from our bundle.
+# Although these modules should also be on the host system, it seems that there
+# may be incompatibility issues with different versions of glib in the bundle and
+# on the host system, see https://github.com/darktable-org/darktable/issues/19266
+mkdir -p ../AppDir/usr/lib/gio
+cp -a /usr/lib/x86_64-linux-gnu/gio/* ../AppDir/usr/lib/gio
+
 # Since linuxdeploy is itself an AppImage, we don't rely on it being installed
 # on the build system, but download it every time we run this script. If that
 # doesn't suit you (for example, you want to build an AppImage without an


### PR DESCRIPTION
Resolves #19266.

Although these modules should also be on the host system, it seems that there may be incompatibility issues with different versions of GLib in the bundle and on the host system, see the issue linked above.