### PR TITLE
Add collection-changed event to Lua API

### DIFF
--- a/src/common/collection.c
+++ b/src/common/collection.c
@@ -41,6 +41,11 @@
 #endif
 
 
+#ifdef USE_LUA
+#include "lua/call.h"
+#include "lua/events.h"
+#endif
+
 #define SELECT_QUERY "SELECT DISTINCT * FROM %s"
 #define LIMIT_QUERY "LIMIT ?1, ?2"
 
@@ -2689,6 +2694,12 @@ void dt_collection_update_query(const dt_collection_t *collection,
     DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_COLLECTION_CHANGED,
                             query_change, changed_property,
                             list, next);
+#ifdef USE_LUA
+    dt_lua_async_call_alien(dt_lua_event_trigger_wrapper,
+        0, NULL, NULL,
+        LUA_ASYNC_TYPENAME, "const char*", "collection-changed",
+        LUA_ASYNC_DONE);
+#endif
   }
 }
 

--- a/src/lua/events.c
+++ b/src/lua/events.c
@@ -668,6 +668,11 @@ int dt_lua_init_events(lua_State *L)
   lua_pushcfunction(L, dt_lua_event_multiinstance_trigger);
   dt_lua_event_add(L, "image-group-information-changed");
 
+  lua_pushcfunction(L, dt_lua_event_multiinstance_register);
+  lua_pushcfunction(L, dt_lua_event_multiinstance_destroy);
+  lua_pushcfunction(L, dt_lua_event_multiinstance_trigger);
+  dt_lua_event_add(L, "collection-changed");
+
   return 0;
 }
 // clang-format off


### PR DESCRIPTION
While working on #18253 I realized that I needed a way to know when the collection changed, so that I could take action.

There are 2 places in `common/collection.c` where the COLLECTION_CHANGED signal is raised.  The first, which I tied the event to, fires on any rule change to collections module in lighttable.  The second place only fires when a film roll is imported and I already have a way to determine that (`post-import-film` event).

Since the event fires on any rule change the user needs to do some checking to determine if the collection really changed.  Simply monitoring the number of images in the collection is an easy way to determine change, but if necessary a script could "read" the rules if necessary to determine what the change was.

[test_collection_changed.lua.txt](https://github.com/user-attachments/files/22083669/test_collection_changed.lua.txt)
