### PR TITLE
improve accuracy in display rotation calculation

### DIFF
--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -3019,7 +3019,7 @@ gboolean dt_dev_pixelpipe_process(dt_dev_pixelpipe_t *pipe,
   pipe->final_height = height;
 
   float zx = (x + 0.5f * width) / scale, zy = (y + 0.5f * height) / scale;
-  dt_dev_zoom_pos_t pts = { zx, zy, zx + 1.f, zy, zx, zy + 1.f };
+  dt_dev_zoom_pos_t pts = { zx, zy, zx + 1000.f, zy, zx, zy + 1000.f };
   dt_dev_distort_backtransform_plus(dev, pipe, 0.0f, DT_DEV_TRANSFORM_DIR_ALL_GEOMETRY, pts, 3);
 
   // get a snapshot of mask list


### PR DESCRIPTION
Fixes #19287

This increases the distance away from the center of the image of the two additional points that are stored in transformed form to later calculate the change in rotation between the stored calculated buffer image and the image to be displayed on the screen (as introduced in #19229). This seems to reduce rounding errors in the lensfun transformations.

However, there could be a risk that these points now end up outside of the final image boundaries. This is fine as long as the transformations don't care (and don't, for example, CLAMP the coordinates to the actual image or to positive RAW locations).

My limited testing suggests that the orientation, crop and perspective modules are tolerant. But more testing would be required.