### PR TITLE
Include libgphoto2 port libraries into AppImage

### DIFF
--- a/packaging/AppImage/AppRun
+++ b/packaging/AppImage/AppRun
@@ -16,6 +16,8 @@ source "$HERE"/apprun-hooks/"linuxdeploy-plugin-gtk.sh"
 
 export CAMLIBS=$HERE/usr/lib/libgphoto2/`ls -1 --group-directories-first $HERE/usr/lib/libgphoto2|head -1`
 
+export IOLIBS=$HERE/usr/lib/libgphoto2_port/`ls -1 --group-directories-first $HERE/usr/lib/libgphoto2_port|head -1`
+
 export GIO_EXTRA_MODULES=$HERE/usr/lib/gio/modules
 
 if [[ ! -z $APPIMAGE ]] ; then

--- a/tools/appimage-build-script.sh
+++ b/tools/appimage-build-script.sh
@@ -54,6 +54,12 @@ cp -a /var/lib/lensfun-updates/* ../AppDir/usr/share/lensfun
 mkdir -p ../AppDir/usr/lib/libgphoto2
 cp -a /usr/lib/x86_64-linux-gnu/libgphoto2/* ../AppDir/usr/lib/libgphoto2
 
+# Include gphoto2 port libraries. We also have to set the IOLIBS
+# environment variable in AppRun.wrapped accordingly when starting
+# AppImage so that libgphoto2 can find these drivers.
+mkdir -p ../AppDir/usr/lib/libgphoto2_port
+cp -a /usr/lib/x86_64-linux-gnu/libgphoto2_port/* ../AppDir/usr/lib/libgphoto2_port
+
 # Include networking related GIO modules. We also have to set the GIO_EXTRA_MODULES
 # environment variable in AppRun.wrapped accordingly when starting AppImage
 # for the GLib's GIO subsystem to use these modules from our bundle.


### PR DESCRIPTION
An addition to a similar PR (#19219) that added driver libraries. It turns out that among the supported distribution releases, the port libraries also had different versions, so there is a need to include them in the bundle.

This should resolve #19159.
