### PR TITLE
fix include paths for noiseprofile

### DIFF
--- a/tools/noise/CMakeLists.txt
+++ b/tools/noise/CMakeLists.txt
@@ -1,5 +1,9 @@
 # Only build on real *nix system or MSYS2 installation
 if ((NOT WIN32) OR BUILD_MSYS2_INSTALL)
+    find_package(PkgConfig)
+    pkg_check_modules(GMODULE REQUIRED gmodule-2.0)
+    include_directories(${GMODULE_INCLUDE_DIRS})
+
     add_executable(darktable-noiseprofile noiseprofile.c)
     target_link_libraries(darktable-noiseprofile m)
 


### PR DESCRIPTION
The compilation of `noiseprofile.c` fails because GMODULE is now required in the include paths.

This is not detected by CI but it breaks the nightly builds