### PR TITLE
set minimum content height for history selective copy dialog

### DIFF
--- a/src/gui/hist_dialog.c
+++ b/src/gui/hist_dialog.c
@@ -234,6 +234,8 @@ int dt_gui_hist_dialog_new(dt_history_copy_item_t *d,
   /* create the list of items */
   d->items = GTK_TREE_VIEW(gtk_tree_view_new());
   GtkWidget *scroll = dt_gui_scroll_wrap(GTK_WIDGET(d->items));
+  gtk_scrolled_window_set_min_content_height(GTK_SCROLLED_WINDOW(scroll),
+                                             DT_PIXEL_APPLY_DPI(450));
   gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(scroll),
                                  GTK_POLICY_NEVER, GTK_POLICY_AUTOMATIC);
   dt_gui_dialog_add(GTK_DIALOG(dialog), scroll);


### PR DESCRIPTION
I think @dterrahe has accidantally deleted the line for setting the minimum content height
in #19118. This leaves the selective copy history dialog in an unusable state.

fixes #19303

