### PR TITLE
Add more integrations to innosetup based installer

### DIFF
--- a/packaging/windows/darktable.iss.in
+++ b/packaging/windows/darktable.iss.in
@@ -37,13 +37,15 @@ DefaultGroupName={#MyAppName}
 AllowNoIcons=yes
 LicenseFile=share\doc\darktable\LICENSE
 
-; Uncomment the following line to run in non administrative install mode (install for current user only).
-;PrivilegesRequired=lowest
+; Uncomment the following line to run in non administrative install mode
+; (install for current user only).
+; PrivilegesRequired=lowest
 
 PrivilegesRequiredOverridesAllowed=dialog
 OutputBaseFilename=darktable-{#MyAppVersion}-${ARCH_STRING}
 
-; When this directive is set, the compiler will create a manifest file detailing information about the files compiled into Setup. The file will be created in the output directory unless a path is included.
+; When this directive is set, the compiler will create a manifest file
+; detailing information about the files compiled into Setup.
 OutputManifestFile=darktable-manifest.txt
 
 SolidCompression=yes
@@ -54,11 +56,9 @@ Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{
 Name: "quicklaunchicon"; Description: "{cm:CreateQuickLaunchIcon}"; Flags: unchecked
 
 [Files]
-; Source: "bin\{#MyAppExeName}"; DestDir: "{app}\bin"; Flags: ignoreversion
 Source: "bin\*"; DestDir: "{app}\bin"; Flags: ignoreversion recursesubdirs createallsubdirs
 Source: "lib\*"; DestDir: "{app}\lib"; Flags: ignoreversion recursesubdirs createallsubdirs
 Source: "share\*"; DestDir: "{app}\share"; Flags: ignoreversion recursesubdirs createallsubdirs
-; NOTE: Don't use "Flags: ignoreversion" on any shared system files
 
 [Registry]
 ; To open a file from the "Open with" menu, Windows needs to know the exact command to execute
@@ -68,8 +68,15 @@ Root: HKA; Subkey: "Software\Classes\Applications\{#MyAppExeName}\shell\open\com
 
 ${CMAKE_ADD_DARKTABLE_TO_OPENWITHLIST}
 
-Root: HKA; Subkey: "SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\{#MyAppExeName}"; ValueType: string; ValueData: "{app}\bin\{#MyAppExeName}"; Flags: uninsdeletekey
-Root: HKA; Subkey: "SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\{#MyAppCliExeName}"; ValueType: string; ValueData: "{app}\bin\{#MyAppCliExeName}"; Flags: uninsdeletekey
+Root: HKA; Subkey: "SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\{#MyAppExeName}"; \
+  ValueType: string; \
+  ValueData: "{app}\bin\{#MyAppExeName}"; \
+  Flags: uninsdeletekey
+
+Root: HKA; Subkey: "SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\{#MyAppCliExeName}"; \
+  ValueType: string; \
+  ValueData: "{app}\bin\{#MyAppCliExeName}"; \
+  Flags: uninsdeletekey
 
 [Icons]
 Name: "{group}\{#MyAppName}"; Filename: "{app}\bin\{#MyAppExeName}"
@@ -79,4 +86,6 @@ Name: "{userappdata}\Microsoft\Internet Explorer\Quick Launch\{#MyAppName}"; \
   Filename: "{app}\bin\{#MyAppName}"; WorkingDir: "{app}"; Tasks: quicklaunchicon
 
 [Run]
-Filename: "{app}\bin\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#StringChange(MyAppName, '&', '&&')}}"; Flags: nowait postinstall skipifsilent
+Filename: "{app}\bin\{#MyAppExeName}"; \
+  Description: "{cm:LaunchProgram,{#StringChange(MyAppName, '&', '&&')}}"; \
+  Flags: nowait postinstall skipifsilent

--- a/packaging/windows/darktable.iss.in
+++ b/packaging/windows/darktable.iss.in
@@ -60,6 +60,11 @@ Source: "share\*"; DestDir: "{app}\share"; Flags: ignoreversion recursesubdirs c
 ; NOTE: Don't use "Flags: ignoreversion" on any shared system files
 
 [Registry]
+; To open a file from the "Open with" menu, Windows needs to know the exact command to execute
+Root: HKA; Subkey: "Software\Classes\Applications\{#MyAppExeName}\shell\open\command"; \
+  ValueType: string; Flags: uninsdeletevalue; \
+  ValueData: """{app}\bin\{#MyAppExeName}"" ""%1"""
+
 ${CMAKE_ADD_DARKTABLE_TO_OPENWITHLIST}
 
 Root: HKA; Subkey: "SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\{#MyAppExeName}"; ValueType: string; ValueData: "{app}\bin\{#MyAppExeName}"; Flags: uninsdeletekey

--- a/packaging/windows/darktable.iss.in
+++ b/packaging/windows/darktable.iss.in
@@ -51,6 +51,7 @@ WizardStyle=modern
 
 [Tasks]
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
+Name: "quicklaunchicon"; Description: "{cm:CreateQuickLaunchIcon}"; Flags: unchecked
 
 [Files]
 ; Source: "bin\{#MyAppExeName}"; DestDir: "{app}\bin"; Flags: ignoreversion
@@ -74,6 +75,8 @@ Root: HKA; Subkey: "SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\{#MyAppC
 Name: "{group}\{#MyAppName}"; Filename: "{app}\bin\{#MyAppExeName}"
 Name: "{group}\{cm:UninstallProgram,{#MyAppName}}"; Filename: "{uninstallexe}"
 Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\bin\{#MyAppExeName}"; Tasks: desktopicon
+Name: "{userappdata}\Microsoft\Internet Explorer\Quick Launch\{#MyAppName}"; \
+  Filename: "{app}\bin\{#MyAppName}"; WorkingDir: "{app}"; Tasks: quicklaunchicon
 
 [Run]
 Filename: "{app}\bin\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#StringChange(MyAppName, '&', '&&')}}"; Flags: nowait postinstall skipifsilent


### PR DESCRIPTION
This PR supports adding darktable to the menu of Quick Launch toolbar. This toolbar is not directly available in Windows 11 as it was phased out by Microsoft. But even in Windows 11, the user can use third-party programs like Explorer Patcher, which bring back removed features, including the Quick Launch toolbar.

Also fixed adding to the "Open with" menu. Now it works.
