### PR TITLE
Consistently use gtk_list_store_insert_with_values

### DIFF
--- a/src/chart/main.c
+++ b/src/chart/main.c
@@ -1437,8 +1437,6 @@ static void get_Lab_from_box(box_t *box, float *Lab)
 
 static void init_table(dt_lut_t *self)
 {
-  GtkTreeIter iter;
-
   gtk_list_store_clear(GTK_LIST_STORE(self->model));
 
   if(!self->chart) return;
@@ -1447,8 +1445,8 @@ static void init_table(dt_lut_t *self)
   patch_names = g_list_sort(patch_names, (GCompareFunc)g_strcmp0);
   for(GList *name = patch_names; name; name = g_list_next(name))
   {
-    gtk_list_store_append(GTK_LIST_STORE(self->model), &iter);
-    gtk_list_store_set(GTK_LIST_STORE(self->model), &iter, COLUMN_NAME, (char *)name->data, -1);
+    gtk_list_store_insert_with_values(GTK_LIST_STORE(self->model), NULL, -1,
+                                      COLUMN_NAME, (char *)name->data, -1);
   }
   g_list_free(patch_names);
 

--- a/src/common/film.c
+++ b/src/common/film.c
@@ -352,9 +352,7 @@ static gboolean ask_and_delete(gpointer user_data)
 
   for(GList *list_iter = empty_dirs; list_iter; list_iter = g_list_next(list_iter))
   {
-    GtkTreeIter iter;
-    gtk_list_store_append(store, &iter);
-    gtk_list_store_set(store, &iter, 0, list_iter->data, -1);
+    gtk_list_store_insert_with_values(store, NULL, -1, 0, list_iter->data, -1);
   }
 
   GtkWidget *tree = gtk_tree_view_new_with_model(GTK_TREE_MODEL(store));

--- a/src/control/crawler.c
+++ b/src/control/crawler.c
@@ -429,12 +429,8 @@ static void _log_synchronization(dt_control_crawler_gui_t *gui,
   gchar *message = g_markup_printf_escaped(pattern, filepath ? filepath : "");
 
   // add a new line in the log TreeView
-  GtkTreeIter iter_log;
   GtkTreeModel *model_log = gtk_tree_view_get_model(GTK_TREE_VIEW(gui->log));
-  gtk_list_store_append(GTK_LIST_STORE(model_log), &iter_log);
-  gtk_list_store_set(GTK_LIST_STORE(model_log), &iter_log,
-                     0, message,
-                     -1);
+  gtk_list_store_insert_with_values(GTK_LIST_STORE(model_log), NULL, -1, 0, message, -1);
 
   g_free(message);
 }
@@ -726,7 +722,6 @@ void dt_control_crawler_show_image_list(GList *images)
 
   for(GList *list_iter = images; list_iter; list_iter = g_list_next(list_iter))
   {
-    GtkTreeIter iter;
     dt_control_crawler_result_t *item = list_iter->data;
     char timestamp_db[64], timestamp_xmp[64];
     struct tm tm_stamp;
@@ -738,9 +733,7 @@ void dt_control_crawler_show_image_list(GList *images)
     const time_t time_delta = llabs(item->timestamp_db - item->timestamp_xmp);
     gchar *timestamp_delta = str_time_delta(time_delta);
 
-    gtk_list_store_append(store, &iter);
-    gtk_list_store_set
-      (store, &iter,
+    gtk_list_store_insert_with_values(store, NULL, -1,
        DT_CONTROL_CRAWLER_COL_ID, item->id,
        DT_CONTROL_CRAWLER_COL_IMAGE_PATH, item->image_path,
        DT_CONTROL_CRAWLER_COL_XMP_PATH, item->xmp_path,

--- a/src/gui/gtkentry.c
+++ b/src/gui/gtkentry.c
@@ -249,13 +249,10 @@ static void _init_completion_model()
                                          G_TYPE_INT,
                                          G_TYPE_STRING,
                                          G_TYPE_STRING);
-  GtkTreeIter iter;
-
   /* Populate the completion database. */
   for(const dt_gtkentry_completion_spec *l = _default_path_compl_list; l && l->varname; l++)
   {
-    gtk_list_store_append(_completion_model, &iter);
-    gtk_list_store_set(_completion_model, &iter,
+    gtk_list_store_insert_with_values(_completion_model, NULL, -1,
                        COMPL_ID, -1,  // -1 = internal
                        COMPL_VARNAME, l->varname,
                        COMPL_DESCRIPTION, _(l->description),
@@ -289,12 +286,9 @@ void dt_gtkentry_setup_variables_completion(GtkEntry *entry)
 
 void dt_gtkentry_variables_add_metadata(dt_metadata_t *metadata)
 {
-  GtkTreeIter iter;
-
   gchar *varname = g_strdup(metadata->tagname);
   gchar *description = g_strdup_printf("$(%s) - %s", varname, _("from metadata"));
-  gtk_list_store_append(_completion_model, &iter);
-  gtk_list_store_set(_completion_model, &iter,
+  gtk_list_store_insert_with_values(_completion_model, NULL, -1,
                       COMPL_ID, metadata->key,
                       COMPL_VARNAME, varname,
                       COMPL_DESCRIPTION, description,

--- a/src/gui/hist_dialog.c
+++ b/src/gui/hist_dialog.c
@@ -306,8 +306,6 @@ int dt_gui_hist_dialog_new(dt_history_copy_item_t *d,
   GList *items = dt_history_get_items(imgid, FALSE, TRUE, TRUE);
   if(items)
   {
-    GtkTreeIter iter;
-
     for(const GList *items_iter = items; items_iter; items_iter = g_list_next(items_iter))
     {
       const dt_history_item_t *item = items_iter->data;
@@ -315,9 +313,7 @@ int dt_gui_hist_dialog_new(dt_history_copy_item_t *d,
 
       if(!(flags & IOP_FLAGS_HIDDEN))
       {
-        gtk_list_store_append(GTK_LIST_STORE(liststore), &iter);
-        gtk_list_store_set
-          (GTK_LIST_STORE(liststore), &iter,
+        gtk_list_store_insert_with_values(liststore, NULL, -1,
            DT_HIST_ITEMS_COL_ENABLED, iscopy ? FALSE : _gui_is_set(d->selops, item->num),
            DT_HIST_ITEMS_COL_AUTOINIT, FALSE,
            DT_HIST_ITEMS_COL_ISACTIVE, item->enabled ? is_active_pb : is_inactive_pb,
@@ -335,8 +331,7 @@ int dt_gui_hist_dialog_new(dt_history_copy_item_t *d,
       const dt_iop_order_t order = dt_ioppr_get_iop_order_version(imgid);
       char *label = g_strdup_printf("%s (%s)", _("module order"),
                                     dt_iop_order_string(order));
-      gtk_list_store_append(GTK_LIST_STORE(liststore), &iter);
-      gtk_list_store_set(GTK_LIST_STORE(liststore), &iter,
+      gtk_list_store_insert_with_values(liststore, NULL, -1,
                          DT_HIST_ITEMS_COL_ENABLED, d->copy_iop_order,
                          DT_HIST_ITEMS_COL_ISACTIVE, is_active_pb,
                          DT_HIST_ITEMS_COL_NAME, label,
@@ -371,6 +366,7 @@ int dt_gui_hist_dialog_new(dt_history_copy_item_t *d,
 
   g_object_unref(is_active_pb);
   g_object_unref(is_inactive_pb);
+  g_object_unref(mask);
   return res;
 }
 

--- a/src/gui/import_metadata.c
+++ b/src/gui/import_metadata.c
@@ -234,7 +234,6 @@ static void _import_metadata_presets_changed(GtkWidget *widget, dt_import_metada
 static void _import_metadata_presets_update(dt_import_metadata_t *metadata)
 {
   gtk_list_store_clear(metadata->m_model);
-  GtkTreeIter iter;
   sqlite3_stmt *stmt;
   // clang-format off
   DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
@@ -265,9 +264,7 @@ static void _import_metadata_presets_update(dt_import_metadata_t *metadata)
 
     if(op_params_size == pos)
     {
-      gtk_list_store_append(metadata->m_model, &iter);
-      gtk_list_store_set(metadata->m_model,
-                         &iter,
+      gtk_list_store_insert_with_values(metadata->m_model, NULL, -1,
                          0, (char *)sqlite3_column_text(stmt, 0),
                          1, metadata_kv,
                          -1);
@@ -297,7 +294,6 @@ static void _import_tags_presets_changed(GtkWidget *widget, dt_import_metadata_t
 static void _import_tags_presets_update(dt_import_metadata_t *metadata)
 {
   gtk_list_store_clear(metadata->t_model);
-  GtkTreeIter iter;
   sqlite3_stmt *stmt;
   // clang-format off
   DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
@@ -328,8 +324,7 @@ static void _import_tags_presets_update(dt_import_metadata_t *metadata)
         if(tags)
           tags[strlen(tags) - 1] = '\0';
         g_strfreev(tokens);
-        gtk_list_store_append(metadata->t_model, &iter);
-        gtk_list_store_set(metadata->t_model, &iter,
+        gtk_list_store_insert_with_values(metadata->t_model, NULL, -1,
                            0, (char *)sqlite3_column_text(stmt, 0),
                            1, tags, -1);
         g_free(tags);

--- a/src/gui/metadata_tags.c
+++ b/src/gui/metadata_tags.c
@@ -125,8 +125,6 @@ GtkWidget *dt_metadata_tags_dialog(GtkWidget *parent, gpointer metadata_activate
 
   for(GList *tag = taglist; tag; tag = g_list_next(tag))
   {
-    GtkTreeIter iter;
-    gtk_list_store_append(liststore, &iter);
     const char *tagname = tag->data;
     char *type = g_strstr_len(tagname, -1, ",");
     if(type)
@@ -135,8 +133,7 @@ GtkWidget *dt_metadata_tags_dialog(GtkWidget *parent, gpointer metadata_activate
       type++;
     }
 
-    gtk_list_store_set(liststore,
-                       &iter,
+    gtk_list_store_insert_with_values(liststore, NULL, -1,
                        DT_METADATA_TAGS_COL_XMP, tagname,
                        DT_METADATA_TAGS_COL_TYPE, type,
                        DT_METADATA_TAGS_COL_VISIBLE, TRUE,

--- a/src/gui/presets.c
+++ b/src/gui/presets.c
@@ -1461,15 +1461,14 @@ static void _menuitem_manage_quick_presets(GtkMenuItem *menuitem,
   for(const GList *modules = m2; modules; modules = g_list_next(modules))
   {
     dt_iop_module_so_t *iop = modules->data;
-    GtkTreeIter toplevel, child;
+    GtkTreeIter toplevel;
 
     /* check if module is visible in current layout */
     if(dt_dev_modulegroups_is_visible(darktable.develop, iop->op))
     {
       // create top entry
-      gtk_tree_store_append(treestore, &toplevel, NULL);
       gchar *iopname = g_markup_escape_text(iop->name(), -1);
-      gtk_tree_store_set(treestore, &toplevel, 0, iopname, 1, FALSE, 2, FALSE, -1);
+      gtk_tree_store_insert_with_values(treestore, &toplevel, NULL, -1, 0, iopname, 1, FALSE, 2, FALSE, -1);
       g_free(iopname);
 
       /* query presets for module */
@@ -1493,9 +1492,9 @@ static void _menuitem_manage_quick_presets(GtkMenuItem *menuitem,
         gchar *txt = g_strdup_printf("ꬹ%s|%sꬹ", iop->op, name);
         const gboolean inlist = (config && strstr(config, txt));
         g_free(txt);
-        gtk_tree_store_append(treestore, &child, &toplevel);
-        gtk_tree_store_set(treestore, &child, 0, presetname, 1,
-                           inlist, 2, TRUE, 3, iop->op, 4, name, -1);
+        gtk_tree_store_insert_with_values(treestore, NULL, &toplevel, -1,
+                                          0, presetname, 1, inlist, 2, TRUE,
+                                          3, iop->op, 4, name, -1);
         g_free(presetname);
       }
 

--- a/src/gui/styles_dialog.c
+++ b/src/gui/styles_dialog.c
@@ -737,11 +737,9 @@ static void _gui_styles_dialog_run(gboolean edit,
     dt_draw_paint_to_pixbuf(GTK_WIDGET(dialog), 10, 0, dtgtk_cairo_paint_showmask);
 
   /* fill list with history items */
-  GtkTreeIter iter;
   if(edit)
   {
-    gtk_list_store_append(GTK_LIST_STORE(liststore), &iter);
-    gtk_list_store_set(GTK_LIST_STORE(liststore), &iter,
+    gtk_list_store_insert_with_values(liststore, NULL, -1,
                        DT_STYLE_ITEMS_COL_ENABLED,  dt_styles_has_module_order(name),
                        DT_STYLE_ITEMS_COL_ISACTIVE, is_active_pb,
                        DT_STYLE_ITEMS_COL_NAME,     _("module order"),
@@ -758,8 +756,7 @@ static void _gui_styles_dialog_run(gboolean edit,
 
         if(item->num != -1 && item->selimg_num != -1) // defined in style and image
         {
-          gtk_list_store_append(GTK_LIST_STORE(liststore), &iter);
-          gtk_list_store_set(GTK_LIST_STORE(liststore), &iter,
+          gtk_list_store_insert_with_values(liststore, NULL, -1,
                              DT_STYLE_ITEMS_COL_ENABLED,    TRUE,
                              DT_STYLE_ITEMS_COL_AUTOINIT,   FALSE,
                              DT_STYLE_ITEMS_COL_UPDATE,     FALSE,
@@ -774,8 +771,7 @@ static void _gui_styles_dialog_run(gboolean edit,
         else if(item->num != -1
                 || item->selimg_num != -1) // defined in one or the other, let a way to select it or not
         {
-          gtk_list_store_append(GTK_LIST_STORE(liststore_new), &iter);
-          gtk_list_store_set(GTK_LIST_STORE(liststore_new), &iter,
+          gtk_list_store_insert_with_values(liststore_new, NULL, -1,
                              DT_STYLE_ITEMS_COL_ENABLED,    item->num != -1 ? TRUE : FALSE,
                              DT_STYLE_ITEMS_COL_AUTOINIT,   FALSE,
                              DT_STYLE_ITEMS_COL_ISACTIVE,   item->enabled ? is_active_pb : is_inactive_pb,
@@ -794,8 +790,7 @@ static void _gui_styles_dialog_run(gboolean edit,
   {
     const dt_iop_order_t order = dt_ioppr_get_iop_order_version(imgid);
     char *label = g_strdup_printf("%s (%s)", _("module order"), dt_iop_order_string(order));
-    gtk_list_store_append(GTK_LIST_STORE(liststore), &iter);
-    gtk_list_store_set(GTK_LIST_STORE(liststore), &iter,
+    gtk_list_store_insert_with_values(liststore, NULL, -1,
                        DT_STYLE_ITEMS_COL_ENABLED,  TRUE,
                        DT_STYLE_ITEMS_COL_ISACTIVE, is_active_pb,
                        DT_STYLE_ITEMS_COL_NAME,     label,
@@ -825,9 +820,7 @@ static void _gui_styles_dialog_run(gboolean edit,
           }
         }
 
-        gtk_list_store_append(GTK_LIST_STORE(liststore), &iter);
-        gtk_list_store_set
-          (GTK_LIST_STORE(liststore), &iter,
+        gtk_list_store_insert_with_values(liststore, NULL, -1,
            DT_STYLE_ITEMS_COL_ENABLED,  enabled,
            DT_STYLE_ITEMS_COL_AUTOINIT, FALSE,
            DT_STYLE_ITEMS_COL_ISACTIVE, item->enabled ? is_active_pb : is_inactive_pb,

--- a/src/iop/lut3d.c
+++ b/src/iop/lut3d.c
@@ -1229,9 +1229,8 @@ void _lut3d_add_lutname_to_list(void *gv, const char *const lutname)
   dt_iop_lut3d_gui_data_t *g = (dt_iop_lut3d_gui_data_t *)gv;
   GtkTreeModel *modelf = gtk_tree_view_get_model((GtkTreeView *)g->lutname);
   GtkTreeModel *model = gtk_tree_model_filter_get_model(GTK_TREE_MODEL_FILTER(modelf));
-  GtkTreeIter iter;
-  gtk_list_store_append((GtkListStore *)model, &iter);
-  gtk_list_store_set((GtkListStore *)model, &iter, DT_LUT3D_COL_NAME, lutname, DT_LUT3D_COL_VISIBLE, TRUE, -1);
+  gtk_list_store_insert_with_values((GtkListStore *)model, NULL, -1,
+                                     DT_LUT3D_COL_NAME, lutname, DT_LUT3D_COL_VISIBLE, TRUE, -1);
 }
 
 void _lut3d_clear_lutname_list(void *gv)

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -1854,7 +1854,6 @@ static void _list_view(dt_lib_collect_rule_t *dr)
     const gboolean sort_descending = dt_conf_get_bool("plugins/collect/descending");
 
     sqlite3_stmt *stmt;
-    GtkTreeIter iter;
     g_object_unref(d->listfilter);
     g_object_ref(model);
     gtk_tree_view_set_model(GTK_TREE_VIEW(d->view), NULL);
@@ -2268,7 +2267,6 @@ static void _list_view(dt_lib_collect_rule_t *dr)
 
         if(folder == NULL) continue; // safeguard against degenerated db entries
 
-        gtk_list_store_append(GTK_LIST_STORE(model), &iter);
         int status = 0;
 
         if(property == DT_COLLECTION_PROP_FILMROLL)
@@ -2331,7 +2329,7 @@ static void _list_view(dt_lib_collect_rule_t *dr)
 
         gchar *escaped_text = g_markup_escape_text(text, -1);
 
-        gtk_list_store_set(GTK_LIST_STORE(model), &iter,
+        gtk_list_store_insert_with_values(GTK_LIST_STORE(model), NULL, -1,
                            DT_LIB_COLLECT_COL_TEXT, folder,
                            DT_LIB_COLLECT_COL_ID, sqlite3_column_int(stmt, 1),
                            DT_LIB_COLLECT_COL_TOOLTIP, escaped_text,

--- a/src/libs/export.c
+++ b/src/libs/export.c
@@ -1363,8 +1363,7 @@ static void _fill_batch_export_list(dt_lib_module_t *self)
     gboolean active = dt_conf_get_bool(setting);
     g_free(setting);
 
-    gtk_list_store_append(GTK_LIST_STORE(model), &iter);
-    gtk_list_store_set(GTK_LIST_STORE(model), &iter,
+    gtk_list_store_insert_with_values(GTK_LIST_STORE(model), NULL, -1,
                         DT_EXPORT_BATCH_COL_ACTIVE, active,
                         DT_EXPORT_BATCH_COL_NAME, name,
                         -1);

--- a/src/libs/export_metadata.c
+++ b/src/libs/export_metadata.c
@@ -75,9 +75,7 @@ static void _add_selected_metadata(gchar *tagname, dt_lib_export_metadata_t *d)
   GtkTreeIter iter;
   if(!_find_metadata_iter_per_text(GTK_TREE_MODEL(d->liststore), NULL, DT_LIB_EXPORT_METADATA_COL_XMP, tagname))
   {
-    gtk_list_store_append(d->liststore, &iter);
-    gtk_list_store_set(d->liststore,
-                       &iter,
+    gtk_list_store_insert_with_values(d->liststore, &iter, -1,
                        DT_LIB_EXPORT_METADATA_COL_XMP, tagname,
                        DT_LIB_EXPORT_METADATA_COL_FORMULA, "",
                        -1);
@@ -253,13 +251,12 @@ char *dt_lib_export_metadata_configuration_dialog(char *metadata_presets, const 
     {
       for(GList *tags = list; tags; tags = g_list_next(tags))
       {
-        GtkTreeIter iter;
         const char *tagname = (char *)tags->data;
         tags = g_list_next(tags);
         if(!tags) break;
         const char *formula = (char *)tags->data;
-        gtk_list_store_append(d->liststore, &iter);
-        gtk_list_store_set(d->liststore, &iter, DT_LIB_EXPORT_METADATA_COL_XMP, tagname,
+        gtk_list_store_insert_with_values(d->liststore, NULL, -1,
+          DT_LIB_EXPORT_METADATA_COL_XMP, tagname,
           DT_LIB_EXPORT_METADATA_COL_FORMULA, formula, -1);
       }
     }

--- a/src/libs/filters/filename.c
+++ b/src/libs/filters/filename.c
@@ -99,7 +99,6 @@ void _filename_tree_update(_widgets_filename_t *filename)
   int nb_ldr = 0;
   int nb_hdr = 0;
 
-  GtkTreeIter iter;
   GtkTreeModel *name_model = gtk_tree_view_get_model(GTK_TREE_VIEW(filename->name_tree));
   gtk_list_store_clear(GTK_LIST_STORE(name_model));
   GtkTreeModel *ext_model = gtk_tree_view_get_model(GTK_TREE_VIEW(filename->ext_tree));
@@ -130,8 +129,8 @@ void _filename_tree_update(_widgets_filename_t *filename)
     if(name == NULL) continue; // safeguard against degenerated db entries
     const int count = sqlite3_column_int(stmt, 1);
 
-    gtk_list_store_append(GTK_LIST_STORE(name_model), &iter);
-    gtk_list_store_set(GTK_LIST_STORE(name_model), &iter, TREE_COL_TEXT, name, TREE_COL_TOOLTIP, name,
+    gtk_list_store_insert_with_values(GTK_LIST_STORE(name_model), NULL, -1,
+                       TREE_COL_TEXT, name, TREE_COL_TOOLTIP, name,
                        TREE_COL_PATH, name, TREE_COL_COUNT, count, -1);
   }
   sqlite3_finalize(stmt);
@@ -154,8 +153,8 @@ void _filename_tree_update(_widgets_filename_t *filename)
     const int count = sqlite3_column_int(stmt, 1);
     const int flags = sqlite3_column_int(stmt, 2);
 
-    gtk_list_store_append(GTK_LIST_STORE(ext_model), &iter);
-    gtk_list_store_set(GTK_LIST_STORE(ext_model), &iter, TREE_COL_TEXT, name, TREE_COL_TOOLTIP, name,
+    gtk_list_store_insert_with_values(GTK_LIST_STORE(ext_model), NULL, -1,
+                       TREE_COL_TEXT, name, TREE_COL_TOOLTIP, name,
                        TREE_COL_PATH, name, TREE_COL_COUNT, count, -1);
 
     if(flags & DT_IMAGE_RAW)
@@ -168,21 +167,21 @@ void _filename_tree_update(_widgets_filename_t *filename)
   sqlite3_finalize(stmt);
 
   // and we insert the predefined extensions
-  gtk_list_store_insert(GTK_LIST_STORE(ext_model), &iter, 0);
-  gtk_list_store_set(GTK_LIST_STORE(ext_model), &iter, TREE_COL_TEXT, "", TREE_COL_TOOLTIP, "", TREE_COL_PATH, "",
-                     TREE_COL_COUNT, 0, -1);
-  gtk_list_store_insert(GTK_LIST_STORE(ext_model), &iter, 0);
-  gtk_list_store_set(GTK_LIST_STORE(ext_model), &iter, TREE_COL_TEXT, "HDR", TREE_COL_TOOLTIP,
-                     "high dynamic range files", TREE_COL_PATH, "HDR", TREE_COL_COUNT, nb_hdr, -1);
-  gtk_list_store_insert(GTK_LIST_STORE(ext_model), &iter, 0);
-  gtk_list_store_set(GTK_LIST_STORE(ext_model), &iter, TREE_COL_TEXT, "LDR", TREE_COL_TOOLTIP,
-                     "low dynamic range files", TREE_COL_PATH, "LDR", TREE_COL_COUNT, nb_ldr, -1);
-  gtk_list_store_insert(GTK_LIST_STORE(ext_model), &iter, 0);
-  gtk_list_store_set(GTK_LIST_STORE(ext_model), &iter, TREE_COL_TEXT, "NOT RAW", TREE_COL_TOOLTIP,
-                     "all except RAW files", TREE_COL_PATH, "NOT RAW", TREE_COL_COUNT, nb_not_raw, -1);
-  gtk_list_store_insert(GTK_LIST_STORE(ext_model), &iter, 0);
-  gtk_list_store_set(GTK_LIST_STORE(ext_model), &iter, TREE_COL_TEXT, "RAW", TREE_COL_TOOLTIP, "RAW files",
-                     TREE_COL_PATH, "RAW", TREE_COL_COUNT, nb_raw, -1);
+  gtk_list_store_insert_with_values(GTK_LIST_STORE(ext_model), NULL, 0,
+                                    TREE_COL_TEXT, "", TREE_COL_TOOLTIP, "",
+                                    TREE_COL_PATH, "", TREE_COL_COUNT, 0, -1);
+  gtk_list_store_insert_with_values(GTK_LIST_STORE(ext_model), NULL, 0,
+                                    TREE_COL_TEXT, "HDR", TREE_COL_TOOLTIP, "high dynamic range files",
+                                    TREE_COL_PATH, "HDR", TREE_COL_COUNT, nb_hdr, -1);
+  gtk_list_store_insert_with_values(GTK_LIST_STORE(ext_model), NULL, 0,
+                                    TREE_COL_TEXT, "LDR", TREE_COL_TOOLTIP, "low dynamic range files",
+                                    TREE_COL_PATH, "LDR", TREE_COL_COUNT, nb_ldr, -1);
+  gtk_list_store_insert_with_values(GTK_LIST_STORE(ext_model), NULL, 0,
+                                    TREE_COL_TEXT, "NOT RAW", TREE_COL_TOOLTIP, "all except RAW files",
+                                    TREE_COL_PATH, "NOT RAW", TREE_COL_COUNT, nb_not_raw, -1);
+  gtk_list_store_insert_with_values(GTK_LIST_STORE(ext_model), NULL, 0,
+                                    TREE_COL_TEXT, "RAW", TREE_COL_TOOLTIP, "RAW files",
+                                    TREE_COL_PATH, "RAW", TREE_COL_COUNT, nb_raw, -1);
 
   filename->tree_ok = TRUE;
 }

--- a/src/libs/filters/misc.c
+++ b/src/libs/filters/misc.c
@@ -75,7 +75,6 @@ void _misc_tree_update(_widgets_misc_t *misc)
 
   char query[1024] = { 0 };
 
-  GtkTreeIter iter;
   GtkTreeModel *name_model = gtk_tree_view_get_model(GTK_TREE_VIEW(misc->name_tree));
   gtk_list_store_clear(GTK_LIST_STORE(name_model));
 
@@ -190,8 +189,7 @@ void _misc_tree_update(_widgets_misc_t *misc)
     else
     {
       gchar *value_path = g_strdup_printf("\"%s\"", name);
-      gtk_list_store_append(GTK_LIST_STORE(name_model), &iter);
-      gtk_list_store_set(GTK_LIST_STORE(name_model), &iter,
+      gtk_list_store_insert_with_values(GTK_LIST_STORE(name_model), NULL, -1,
                          TREE_COL_TEXT, name,
                          TREE_COL_TOOLTIP, name,
                          TREE_COL_PATH, value_path,
@@ -204,8 +202,7 @@ void _misc_tree_update(_widgets_misc_t *misc)
   // we add the unset entry if any
   if(unset > 0)
   {
-    gtk_list_store_append(GTK_LIST_STORE(name_model), &iter);
-    gtk_list_store_set(GTK_LIST_STORE(name_model), &iter,
+    gtk_list_store_insert_with_values(GTK_LIST_STORE(name_model), NULL, -1,
                        TREE_COL_TEXT, _("unnamed"),
                        TREE_COL_TOOLTIP, tooltip,
                        TREE_COL_PATH, _("unnamed"),

--- a/src/libs/geotagging.c
+++ b/src/libs/geotagging.c
@@ -701,15 +701,13 @@ static void _show_gpx_tracks(dt_lib_module_t *self)
   int segid = 0;
   const gboolean active = gtk_toggle_button_get_active(
                           GTK_TOGGLE_BUTTON(gtk_tree_view_column_get_widget(d->map.sel_tracks)));
-  GtkTreeIter iter;
   for(GList *ts = trkseg; ts; ts = g_list_next(ts))
   {
     dt_gpx_track_segment_t *t = ts->data;
     gchar *dts = _utc_timeval_to_localtime_text(t->start_dt, d->tz_camera, TRUE);
     gchar *tooltip = _datetime_tooltip(t->start_dt, t->end_dt, d->tz_camera);
     const int nb_imgs = _count_images_per_track(t, ts->next ? ts->next->data : NULL, self);
-    gtk_list_store_append(GTK_LIST_STORE(model), &iter);
-    gtk_list_store_set(GTK_LIST_STORE(model), &iter,
+    gtk_list_store_insert_with_values(GTK_LIST_STORE(model), NULL, -1,
                        DT_GEO_TRACKS_ACTIVE, active,
                        DT_GEO_TRACKS_DATETIME, dts,
                        DT_GEO_TRACKS_POINTS, t->nb_trkpt,
@@ -1829,7 +1827,6 @@ void gui_init(dt_lib_module_t *self)
   gtk_grid_attach(grid, timezone_box, 2, line++, 2, 1);
 
   GtkCellRenderer *renderer;
-  GtkTreeIter tree_iter;
   GtkListStore *model = gtk_list_store_new(2, G_TYPE_STRING /*display*/, G_TYPE_STRING /*name*/);
   GtkWidget *tz_selection = gtk_combo_box_new_with_model(GTK_TREE_MODEL(model));
   renderer = gtk_cell_renderer_text_new();
@@ -1841,8 +1838,7 @@ void gui_init(dt_lib_module_t *self)
   for(GList *iter = d->timezones; iter; iter = g_list_next(iter))
   {
     tz_tuple_t *tz_tuple = (tz_tuple_t *)iter->data;
-    gtk_list_store_append(model, &tree_iter);
-    gtk_list_store_set(model, &tree_iter, 0, tz_tuple->display, 1, tz_tuple->name, -1);
+    gtk_list_store_insert_with_values(model, NULL, -1, 0, tz_tuple->display, 1, tz_tuple->name, -1);
     if(!strcmp(tz_tuple->name, tz))
       gtk_entry_set_text(GTK_ENTRY(d->timezone), tz_tuple->display);
   }

--- a/src/libs/import.c
+++ b/src/libs/import.c
@@ -410,9 +410,7 @@ static guint _import_from_camera_set_file_list(dt_lib_module_t *self)
       dt_datetime_unix_to_exif(dtid, sizeof(dtid), &datetime);
       const gboolean already_imported = dt_metadata_already_imported(basename, dtid);
       g_free(basename);
-      GtkTreeIter iter;
-      gtk_list_store_append(d->from.store, &iter);
-      gtk_list_store_set(d->from.store, &iter,
+      gtk_list_store_insert_with_values(d->from.store, NULL, -1,
                          DT_IMPORT_UI_EXISTS, already_imported ? "✔" : " ",
                          DT_IMPORT_UI_FILENAME, file->filename,
                          DT_IMPORT_FILENAME, file->filename,
@@ -886,9 +884,7 @@ static void _import_add_file_callback(GObject *direnum,
           GDateTime *dt_datetime = g_date_time_new_from_unix_local(datetime);
           gchar *dt_txt = g_date_time_format(dt_datetime, "%x %X");
 
-          GtkTreeIter iter;
-          gtk_list_store_append(d->from.store, &iter);
-          gtk_list_store_set(d->from.store, &iter,
+          gtk_list_store_insert_with_values(d->from.store, NULL, -1,
                              DT_IMPORT_UI_EXISTS, already_imported ? "✔" : " ",
                              DT_IMPORT_UI_FILENAME, &fullname[offset],
                              DT_IMPORT_FILENAME, fullname,
@@ -1187,13 +1183,13 @@ static void _get_folders_list(GtkTreeStore *store,
   if(!parent)
   {
     gchar *basename = g_path_get_basename(folder);
-    gtk_tree_store_append(store, &parent2, NULL);
-    gtk_tree_store_set(store, &parent2, DT_FOLDER_NAME, basename,
-                                     DT_FOLDER_PATH, folder,
-                                     DT_FOLDER_EXPANDED, FALSE, -1);
+    gtk_tree_store_insert_with_values(store, &parent2, NULL, -1,
+                                      DT_FOLDER_NAME, basename,
+                                      DT_FOLDER_PATH, folder,
+                                      DT_FOLDER_EXPANDED, FALSE, -1);
     // fake child
-    gtk_tree_store_append(store, &iter, &parent2);
-    gtk_tree_store_set(store, &iter, DT_FOLDER_EXPANDED, FALSE, -1);
+    gtk_tree_store_insert_with_values(store, &iter, &parent2, -1,
+                                      DT_FOLDER_EXPANDED, FALSE, -1);
     g_free(basename);
   }
   else

--- a/src/libs/map_locations.c
+++ b/src/libs/map_locations.c
@@ -173,8 +173,7 @@ static void _locations_tree_update(dt_lib_module_t *self, const guint locid)
           dt_util_str_cat(&pth, "%s|", *token);
           gchar *pth2 = g_strdup(pth);
           pth2[strlen(pth2) - 1] = '\0';
-          gtk_tree_store_insert(GTK_TREE_STORE(model), &iter, common_length > 0 ? &parent : NULL, -1);
-          gtk_tree_store_set(GTK_TREE_STORE(model), &iter,
+          gtk_tree_store_insert_with_values(GTK_TREE_STORE(model), &iter, common_length > 0 ? &parent : NULL, -1,
                             DT_MAP_LOCATION_COL_TAG, *token,
                             DT_MAP_LOCATION_COL_ID, (token == &tokens[tokens_length-1]) ?
                                                      ((dt_map_location_t *)stag->data)->id : 0,
@@ -293,8 +292,7 @@ static void _new_button_clicked(GtkButton *button, dt_lib_module_t *self)
   }
 
   // add the new record to the tree
-  gtk_tree_store_insert(GTK_TREE_STORE(model), &iter, path ? &parent : NULL, -1);
-  gtk_tree_store_set(GTK_TREE_STORE(model), &iter,
+  gtk_tree_store_insert_with_values(GTK_TREE_STORE(model), &iter, path ? &parent : NULL, -1,
                      DT_MAP_LOCATION_COL_TAG, &new_name[base_len],
                      DT_MAP_LOCATION_COL_ID, -1,
                      DT_MAP_LOCATION_COL_PATH, new_name,

--- a/src/libs/metadata.c
+++ b/src/libs/metadata.c
@@ -717,8 +717,7 @@ static void _add_selected_metadata(gchar *tagname, dt_lib_metadata_t *d)
   GtkTreeIter iter;
   if(!_find_metadata_iter_per_text(GTK_TREE_MODEL(d->liststore), NULL, DT_METADATA_PREF_COL_TAGNAME, tagname))
   {
-    gtk_list_store_append(d->liststore, &iter);
-    gtk_list_store_set(d->liststore, &iter,
+    gtk_list_store_insert_with_values(d->liststore, &iter, -1,
                        DT_METADATA_PREF_COL_KEY, -1,  // -1 indicates a new entry
                        DT_METADATA_PREF_COL_TAGNAME, tagname,
                        DT_METADATA_PREF_COL_NAME, dt_metadata_get_tag_subkey(tagname),
@@ -866,8 +865,7 @@ static void _menuitem_preferences(GtkMenuItem *menuitem,
     dt_metadata_t *metadata = (dt_metadata_t *)metadata_iter->data;
     if(!metadata->internal)
     {
-      gtk_list_store_append(store, &iter);
-      gtk_list_store_set(store, &iter,
+      gtk_list_store_insert_with_values(store, NULL, -1,
                          DT_METADATA_PREF_COL_KEY, metadata->key,
                          DT_METADATA_PREF_COL_TAGNAME, metadata->tagname,
                          DT_METADATA_PREF_COL_NAME, metadata->name,

--- a/src/libs/metadata_view.c
+++ b/src/libs/metadata_view.c
@@ -1446,8 +1446,7 @@ void _menuitem_preferences(GtkMenuItem *menuitem, dt_lib_module_t *self)
   for(GList *meta = d->metadata; meta; meta = g_list_next(meta))
   {
     dt_lib_metadata_info_t *m = meta->data;
-    gtk_list_store_append(store, &iter);
-    gtk_list_store_set(store, &iter,
+    gtk_list_store_insert_with_values(store, NULL, -1,
                        DT_METADATA_PREF_COL_INDEX, m->index,
                        DT_METADATA_PREF_COL_NAME_L, _(m->name),
                        DT_METADATA_PREF_COL_VISIBLE, m->visible,

--- a/src/libs/tagging.c
+++ b/src/libs/tagging.c
@@ -451,8 +451,7 @@ static void _init_treeview(dt_lib_module_t *self, const int which)
             dt_util_str_cat(&pth, "%s|", *token);
             gchar *pth2 = g_strdup(pth);
             pth2[strlen(pth2) - 1] = '\0';
-            gtk_tree_store_insert(GTK_TREE_STORE(store), &iter, common_length > 0 ? &parent : NULL, -1);
-            gtk_tree_store_set(GTK_TREE_STORE(store), &iter,
+            gtk_tree_store_insert_with_values(GTK_TREE_STORE(store), &iter, common_length > 0 ? &parent : NULL, -1,
                               DT_LIB_TAGGING_COL_TAG, *token,
                               DT_LIB_TAGGING_COL_ID, (token == &tokens[tokens_length-1]) ?
                                                      ((dt_tag_t *)taglist->data)->id : 0,
@@ -498,8 +497,7 @@ static void _init_treeview(dt_lib_module_t *self, const int which)
       for(GList *tag = tags; tag; tag = g_list_next(tag))
       {
         const char *subtag = g_strrstr(((dt_tag_t *)tag->data)->tag, "|");
-        gtk_list_store_append(GTK_LIST_STORE(store), &iter);
-        gtk_list_store_set(GTK_LIST_STORE(store), &iter,
+        gtk_list_store_insert_with_values(GTK_LIST_STORE(store), NULL, -1,
                           DT_LIB_TAGGING_COL_TAG, !subtag ? ((dt_tag_t *)tag->data)->tag : subtag + 1,
                           DT_LIB_TAGGING_COL_ID, ((dt_tag_t *)tag->data)->id,
                           DT_LIB_TAGGING_COL_PATH, ((dt_tag_t *)tag->data)->tag,

--- a/src/libs/tagging.c
+++ b/src/libs/tagging.c
@@ -1534,7 +1534,6 @@ static void _pop_menu_dictionary_delete_tag(GtkWidget *menuitem, dt_lib_module_t
                                                     _("_cancel"), GTK_RESPONSE_NONE,
                                                     _("_delete"), GTK_RESPONSE_YES, NULL);
     gtk_dialog_set_default_response(GTK_DIALOG(dialog), GTK_RESPONSE_NONE);
-    gtk_window_set_default_size(GTK_WINDOW(dialog), 300, -1);
 
     text = g_strdup_printf(_("selected: %s"), tagname);
     GtkWidget *label1 = gtk_label_new(text);
@@ -1618,7 +1617,6 @@ static void _pop_menu_dictionary_delete_node(GtkWidget *menuitem, dt_lib_module_
                                                   _("_cancel"), GTK_RESPONSE_NONE,
                                                   _("_delete"), GTK_RESPONSE_YES, NULL);
   gtk_dialog_set_default_response(GTK_DIALOG(dialog), GTK_RESPONSE_NONE);
-  gtk_window_set_default_size(GTK_WINDOW(dialog), 300, -1);
 
   text = g_strdup_printf(_("selected: %s"), tagname);
   GtkWidget *label1 = gtk_label_new(text);
@@ -1702,7 +1700,6 @@ static void _pop_menu_dictionary_create_tag(GtkWidget *menuitem, dt_lib_module_t
                                                   _("_cancel"), GTK_RESPONSE_NONE,
                                                   _("_save"), GTK_RESPONSE_YES, NULL);
   gtk_dialog_set_default_response(GTK_DIALOG(dialog), GTK_RESPONSE_YES);
-  gtk_window_set_default_size(GTK_WINDOW(dialog), 300, -1);
 
   GtkWidget *entry = gtk_entry_new();
   gtk_entry_set_activates_default(GTK_ENTRY(entry), TRUE);
@@ -1821,7 +1818,6 @@ static void _pop_menu_dictionary_edit_tag(GtkWidget *menuitem, dt_lib_module_t *
                                                   _("_cancel"), GTK_RESPONSE_NONE,
                                                   _("_save"), GTK_RESPONSE_YES, NULL);
   gtk_dialog_set_default_response(GTK_DIALOG(dialog), GTK_RESPONSE_YES);
-  gtk_window_set_default_size(GTK_WINDOW(dialog), 300, -1);
 
   text = g_strdup_printf(_("selected: %s"), tagname);
   GtkWidget *label1 = gtk_label_new(text);
@@ -2089,7 +2085,6 @@ static void _pop_menu_dictionary_change_path(GtkWidget *menuitem, dt_lib_module_
                                                   _("_cancel"), GTK_RESPONSE_NONE,
                                                   _("_save"), GTK_RESPONSE_YES, NULL);
   gtk_dialog_set_default_response(GTK_DIALOG(dialog), GTK_RESPONSE_YES);
-  gtk_window_set_default_size(GTK_WINDOW(dialog), 300, -1);
 
   text = g_strdup_printf(_("selected: %s"), tagname);
   GtkWidget *label1 = gtk_label_new(text);

--- a/src/libs/tools/viewswitcher.c
+++ b/src/libs/tools/viewswitcher.c
@@ -103,7 +103,6 @@ void gui_init(dt_lib_module_t *self)
 
   self->widget = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
   d->dropdown = NULL;
-  GtkTreeIter tree_iter;
   GtkListStore *model = NULL;
 
   for(GList *view_iter = darktable.view_manager->views; view_iter; view_iter = g_list_next(view_iter))
@@ -145,15 +144,13 @@ void gui_init(dt_lib_module_t *self)
         gtk_cell_layout_set_attributes(GTK_CELL_LAYOUT(d->dropdown), renderer, "markup", TEXT_COLUMN,
                                         "sensitive", SENSITIVE_COLUMN, NULL);
 
-        gtk_list_store_append(model, &tree_iter);
-        gtk_list_store_set(model, &tree_iter, TEXT_COLUMN, _("other"), VIEW_COLUMN, NULL, SENSITIVE_COLUMN, 0, -1);
+        gtk_list_store_insert_with_values(model, NULL, -1, TEXT_COLUMN, _("other"), VIEW_COLUMN, NULL, SENSITIVE_COLUMN, 0, -1);
 
         gtk_box_pack_start(GTK_BOX(self->widget), d->dropdown, FALSE, FALSE, 0);
         g_signal_connect(G_OBJECT(d->dropdown), "changed", G_CALLBACK(_dropdown_changed), d);
       }
 
-      gtk_list_store_append(model, &tree_iter);
-      gtk_list_store_set(model, &tree_iter, TEXT_COLUMN, view->name(view), VIEW_COLUMN, view, SENSITIVE_COLUMN, 1, -1);
+      gtk_list_store_insert_with_values(model, NULL, -1, TEXT_COLUMN, view->name(view), VIEW_COLUMN, view, SENSITIVE_COLUMN, 1, -1);
     }
   }
 


### PR DESCRIPTION
Instead of separate calls to append and set. It is simpler, faster and doesn't require (generally) an `iter` variable so it is easier for people to copy/paste(/understand?) the pattern when adding similar functionality.