### PR TITLE
More fixes for Inno Setup based installer

### DIFF
--- a/packaging/windows/darktable.iss.in
+++ b/packaging/windows/darktable.iss.in
@@ -20,7 +20,7 @@ AppPublisherURL={#MyAppURL}
 AppSupportURL={#MyAppURL}
 AppUpdatesURL={#MyAppURL}
 DefaultDirName={autopf}\{#MyAppName}
-UninstallDisplayIcon={uninstallexe}
+UninstallDisplayIcon={app}\bin\{#MyAppExeName}
 
 ; "ArchitecturesAllowed=x64compatible" specifies that Setup cannot run
 ; on anything but x64 and Windows 11 on Arm.


### PR DESCRIPTION
This PR:
- Fixes icon in the list of Windows apps. Now it's the darktable icon, not the generic installer icon.
- Adds environment variables needed by libgphoto2 to work properly. They point to the location of additional libraries that libgphoto2 loads at runtime.

At this point, it seems that the Inno Setup based installer is now installing a correctly working program. I don't use tethering, so I haven't tested libgphoto2 for correct operation, I've only compared the registry entries from the new installer with those created by the old installer.

I'll try to find Windows users who will volunteer to help with further testing. The next step could probably be to start publishing a nightly build (perhaps initially in parallel with the old installer).

After that we can move on to start testing the build and publishing the darktable installer for Windows on Arm users.
