### PR TITLE
CMake: prefer placeholders to variables in InnoSetup template

### DIFF
--- a/cmake/darktable-packaging.cmake
+++ b/cmake/darktable-packaging.cmake
@@ -45,31 +45,13 @@ endif(UNIX)
 
 # Set package peoperties for Windows
 if(WIN32)
-  # we want an arch string to distinguish installer artifact filenames
-  if(CMAKE_SYSTEM_PROCESSOR MATCHES "(x86_64)|(AMD64|amd64)|(X86|x86)|(^i.86$)")
-    set(ARCH_STRING "win64")
-  else()
-    set(ARCH_STRING "woa64")
-  endif()
-
-  # add darktable association with all supported image file types for Inno Setup
-  foreach(EXTENSION ${DT_SUPPORTED_EXTENSIONS})
-    SET(CMAKE_ADD_DARKTABLE_TO_OPENWITHLIST "${CMAKE_ADD_DARKTABLE_TO_OPENWITHLIST}
-      Root:HKA; Subkey: \"Software\\Classes\\.${EXTENSION}\\OpenWithList\\darktable.exe\"; Flags: uninsdeletekey
-    ")
-  endforeach(EXTENSION)
-
-  configure_file(
-    ${CMAKE_SOURCE_DIR}/packaging/windows/darktable.iss.in
-    ${CMAKE_BINARY_DIR}/darktable.iss
-  )
-
   if(CMAKE_SYSTEM_PROCESSOR MATCHES "ARM64")
     # CPack currently sets this to "win64" regardless of architecture
     set(CPACK_SYSTEM_NAME woa64)
-	# Native NSIS is currently unavailable, just create an archive
+    # Native NSIS is currently unavailable, just create an archive
     set(CPACK_GENERATOR "ZIP")
   else()
+    set(CPACK_SYSTEM_NAME win64)
     set(CPACK_GENERATOR "NSIS")
     set(CPACK_PACKAGE_EXECUTABLES "darktable" "darktable")
     set(CPACK_PACKAGE_INSTALL_DIRECTORY "${CMAKE_PROJECT_NAME}")
@@ -109,6 +91,19 @@ if(WIN32)
       ")
     endforeach(EXTENSION)
   endif()
+
+  # add darktable association with all supported image file types for Inno Setup
+  foreach(EXTENSION ${DT_SUPPORTED_EXTENSIONS})
+    SET(CMAKE_ADD_DARKTABLE_TO_OPENWITHLIST "${CMAKE_ADD_DARKTABLE_TO_OPENWITHLIST}
+      Root:HKA; Subkey: \"Software\\Classes\\.${EXTENSION}\\OpenWithList\\darktable.exe\"; Flags: uninsdeletekey
+    ")
+  endforeach(EXTENSION)
+
+  configure_file(
+    ${CMAKE_SOURCE_DIR}/packaging/windows/darktable.iss.in
+    ${CMAKE_BINARY_DIR}/darktable.iss
+    @ONLY
+  )
 endif(WIN32)
 
 include(CPack)

--- a/cmake/modules/NSIS.template.in
+++ b/cmake/modules/NSIS.template.in
@@ -723,8 +723,8 @@ Section "-Core installation"
    !define env_hklm 'HKLM "SYSTEM\CurrentControlSet\Control\Session Manager\Environment"'
    !define env_hkcu 'HKCU "Environment"'
    ; set variable for local machine
-   WriteRegExpandStr ${env_hklm} CAMLIBS "$INSTDIR\lib\libgphoto2\@CPACK_NSIS_GPHOTO2_VERSION@"
-   WriteRegExpandStr ${env_hklm} IOLIBS "$INSTDIR\lib\libgphoto2_port\@CPACK_NSIS_GPHOTO2_PORT_VERSION@"
+   WriteRegExpandStr ${env_hklm} CAMLIBS "$INSTDIR\lib\libgphoto2\@CPACK_GPHOTO2_VERSION@"
+   WriteRegExpandStr ${env_hklm} IOLIBS "$INSTDIR\lib\libgphoto2_port\@CPACK_GPHOTO2_PORT_VERSION@"
 
   !insertmacro MUI_STARTMENU_WRITE_END
 

--- a/packaging/windows/darktable.iss.in
+++ b/packaging/windows/darktable.iss.in
@@ -1,6 +1,6 @@
 
 #define MyAppName "darktable"
-#define MyAppVersion "${PROJECT_VERSION}"
+#define MyAppVersion "@PROJECT_VERSION@"
 #define MyAppCopyright "Copyright © 2009-2025 darktable developers"
 #define MyAppPublisher "darktable team"
 #define MyAppURL "https://darktable.org/"
@@ -42,7 +42,7 @@ LicenseFile=share\doc\darktable\LICENSE
 ; PrivilegesRequired=lowest
 
 PrivilegesRequiredOverridesAllowed=dialog
-OutputBaseFilename=darktable-{#MyAppVersion}-${ARCH_STRING}
+OutputBaseFilename=darktable-{#MyAppVersion}-@CPACK_SYSTEM_NAME@
 
 ; When this directive is set, the compiler will create a manifest file
 ; detailing information about the files compiled into Setup.
@@ -66,7 +66,7 @@ Root: HKA; Subkey: "Software\Classes\Applications\{#MyAppExeName}\shell\open\com
   ValueType: string; Flags: uninsdeletevalue; \
   ValueData: """{app}\bin\{#MyAppExeName}"" ""%1"""
 
-${CMAKE_ADD_DARKTABLE_TO_OPENWITHLIST}
+@CMAKE_ADD_DARKTABLE_TO_OPENWITHLIST@
 
 Root: HKA; Subkey: "SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\{#MyAppExeName}"; \
   ValueType: string; \
@@ -81,13 +81,13 @@ Root: HKA; Subkey: "SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\{#MyAppC
 Root: HKLM; Subkey: "SYSTEM\CurrentControlSet\Control\Session Manager\Environment"; \
   ValueType: string; \
   ValueName: "CAMLIBS"; \
-  ValueData: "{app}\lib\libgphoto2\${CPACK_NSIS_GPHOTO2_VERSION}"; \
+  ValueData: "{app}\lib\libgphoto2\@CPACK_GPHOTO2_VERSION@"; \
   Flags: uninsdeletevalue
 
 Root: HKLM; Subkey: "SYSTEM\CurrentControlSet\Control\Session Manager\Environment"; \
   ValueType: string; \
   ValueName: "IOLIBS"; \
-  ValueData: "{app}\lib\libgphoto2_port\${CPACK_NSIS_GPHOTO2_PORT_VERSION}"; \
+  ValueData: "{app}\lib\libgphoto2_port\@CPACK_GPHOTO2_PORT_VERSION@"; \
   Flags: uninsdeletevalue
 
 [Icons]

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -316,8 +316,8 @@ if(USE_CAMERA_SUPPORT)
     # CPack ignores variables you define in your CMakeLists.txt file,
     # and only variables ${CPACK_*} are correctly used.
     # so this needs to be saved by adding another variable with a name beginning with CPACK
-    set(CPACK_NSIS_GPHOTO2_VERSION ${Gphoto2_VERSION_STRING} CACHE STRING "Gphoto2 version string")
-    set(CPACK_NSIS_GPHOTO2_PORT_VERSION ${Gphoto2_PORT_VERSION_STRING} CACHE STRING "Gphoto2 port version string")
+    set(CPACK_GPHOTO2_VERSION ${Gphoto2_VERSION_STRING} CACHE STRING "Gphoto2 version string")
+    set(CPACK_GPHOTO2_PORT_VERSION ${Gphoto2_PORT_VERSION_STRING} CACHE STRING "Gphoto2 port version string")
   endif()
 endif(USE_CAMERA_SUPPORT)
 


### PR DESCRIPTION
Also reuse the CPACK_SYSTEM_NAME variable and rename GPHOTO2 ones, they're not NSIS specific any more.