### PR TITLE
agx: reload_defaults + auto-gamma

### DIFF
--- a/src/iop/agx.c
+++ b/src/iop/agx.c
@@ -2681,8 +2681,11 @@ void commit_params(dt_iop_module_t *self,
 
 void reload_defaults(dt_iop_module_t *self)
 {
-  dt_iop_agx_params_t *const d = self->default_params;
-  _set_scene_referred_default_params(d);
+  if(dt_is_scene_referred())
+  {
+    dt_iop_agx_params_t *const d = self->default_params;
+    _set_scene_referred_default_params(d);
+  }
 }
 
 void gui_reset(dt_iop_module_t *self)


### PR DESCRIPTION
- Set the same params in reload_default as we use for the scene-referred default preset. This is to address an issue raised here: https://discuss.pixls.us/t/blender-agx-in-darktable-proof-of-concept/48697/1963
- additionally, modify the scene-referred default (but not the blender-like) to use auto-gamma, as that is the safer setting (it no longer has a strong contrast boost as side effect, and makes sure the curve remains S-shaped if at all possible)
