### PR TITLE
Fix auto applied presets for sraws and true monochromes

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -1490,7 +1490,7 @@ static gboolean _dev_auto_apply_presets(dt_develop_t *dev)
   dt_image_t *image = dt_image_cache_get(imgid, 'w');
   if(!(image->flags & DT_IMAGE_AUTO_PRESETS_APPLIED)) run = TRUE;
 
-  const gboolean is_raw = dt_image_is_raw(image);
+  const gboolean is_raw = dt_image_is_rawprepare_supported(image);
   const gboolean is_modern_chroma = dt_is_scene_referred();
 
   // flag was already set? only apply presets once in the lifetime of
@@ -1569,7 +1569,7 @@ static gboolean _dev_auto_apply_presets(dt_develop_t *dev)
   //  set filters
 
   int iformat = 0;
-  if(dt_image_is_raw(image))
+  if(is_raw)
     iformat |= FOR_RAW;
   else
     iformat |= FOR_LDR;


### PR DESCRIPTION
We use `dt_image_is_rawprepare_supported()` instead of `dt_image_is_raw()` in presets and modulegroups and should also do so while auto apply of modules for a fresh history.

This fixes for example exposure not being applied correctly in sraws and true monochromes, clicking for reset to defaults worked as intended.

This leaves out the current scene-referred tone mappers, they all auto-apply also for monochromes which i think is correct. If not they all should only have `FOR_MATRIX` instead.