### PR TITLE
continue conversion to dt_gui_box_add/_vbox/_hbox

### DIFF
--- a/src/control/crawler.c
+++ b/src/control/crawler.c
@@ -806,35 +806,19 @@ void dt_control_crawler_show_image_list(GList *images)
   gtk_widget_set_size_request(dialog, -1, DT_PIXEL_APPLY_DPI(400));
   gtk_window_set_transient_for(GTK_WINDOW(dialog), GTK_WINDOW(win));
 
-  GtkWidget *content_box = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
-  dt_gui_dialog_add(GTK_DIALOG(dialog), content_box);
 
-  GtkWidget *box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-  gtk_box_pack_start(GTK_BOX(content_box), box, FALSE, FALSE, 0);
   GtkWidget *select_all = gtk_button_new_with_label(_("select all"));
   GtkWidget *select_none = gtk_button_new_with_label(_("select none"));
   GtkWidget *select_invert = gtk_button_new_with_label(_("invert selection"));
-  gtk_box_pack_start(GTK_BOX(box), select_all, FALSE, FALSE, 0);
-  gtk_box_pack_start(GTK_BOX(box), select_none, FALSE, FALSE, 0);
-  gtk_box_pack_start(GTK_BOX(box), select_invert, FALSE, FALSE, 0);
   g_signal_connect(select_all, "clicked", G_CALLBACK(_select_all_callback), gui);
   g_signal_connect(select_none, "clicked", G_CALLBACK(_select_none_callback), gui);
   g_signal_connect(select_invert, "clicked", G_CALLBACK(_select_invert_callback), gui);
 
-  gtk_box_pack_start(GTK_BOX(content_box), scroll, TRUE, TRUE, 0);
-
-  box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-  gtk_box_pack_start(GTK_BOX(content_box), box, FALSE, FALSE, 1);
   GtkWidget *label = gtk_label_new_with_mnemonic(_("on the selection:"));
   GtkWidget *reload_button = gtk_button_new_with_label(_("keep the XMP edit"));
   GtkWidget *overwrite_button = gtk_button_new_with_label(_("keep the database edit"));
   GtkWidget *newest_button = gtk_button_new_with_label(_("keep the newest edit"));
   GtkWidget *oldest_button = gtk_button_new_with_label(_("keep the oldest edit"));
-  gtk_box_pack_start(GTK_BOX(box), label, FALSE, FALSE, 0);
-  gtk_box_pack_start(GTK_BOX(box), reload_button, FALSE, FALSE, 0);
-  gtk_box_pack_start(GTK_BOX(box), overwrite_button, FALSE, FALSE, 0);
-  gtk_box_pack_start(GTK_BOX(box), newest_button, FALSE, FALSE, 0);
-  gtk_box_pack_start(GTK_BOX(box), oldest_button, FALSE, FALSE, 0);
   g_signal_connect(reload_button, "clicked", G_CALLBACK(_reload_button_clicked), gui);
   g_signal_connect(overwrite_button, "clicked", G_CALLBACK(_overwrite_button_clicked), gui);
   g_signal_connect(newest_button, "clicked", G_CALLBACK(_newest_button_clicked), gui);
@@ -842,14 +826,9 @@ void dt_control_crawler_show_image_list(GList *images)
 
   /* Feedback spinner in case synch happens over network and stales */
   gui->spinner = gtk_spinner_new();
-  gtk_box_pack_start(GTK_BOX(box), GTK_WIDGET(gui->spinner), FALSE, FALSE, 0);
 
   /* Log report */
   gui->log = gtk_tree_view_new();
-  scroll = dt_gui_scroll_wrap(gui->log);
-  gtk_box_pack_start(GTK_BOX(content_box), scroll, TRUE, TRUE, 0);
-  gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(scroll),
-                                 GTK_POLICY_NEVER, GTK_POLICY_AUTOMATIC);
 
   gtk_tree_view_insert_column_with_attributes
     (GTK_TREE_VIEW(gui->log), -1,
@@ -861,6 +840,11 @@ void dt_control_crawler_show_image_list(GList *images)
   gtk_tree_view_set_model(GTK_TREE_VIEW(gui->log), model_log);
   g_object_unref(model_log);
 
+  dt_gui_dialog_add(GTK_DIALOG(dialog),
+    dt_gui_hbox(select_all, select_none, select_invert),
+    scroll,
+    dt_gui_hbox(label, reload_button, overwrite_button, newest_button, oldest_button, gui->spinner),
+    dt_gui_scroll_wrap(gui->log));
   gtk_widget_show_all(dialog);
 
   g_signal_connect(dialog, "response",

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -62,7 +62,8 @@ typedef enum dt_dev_overlay_colors_t
   DT_DEV_OVERLAY_GREEN = 2,
   DT_DEV_OVERLAY_YELLOW = 3,
   DT_DEV_OVERLAY_CYAN = 4,
-  DT_DEV_OVERLAY_MAGENTA = 5
+  DT_DEV_OVERLAY_MAGENTA = 5,
+  DT_DEV_OVERLAY_LAST
 } dt_dev_overlay_colors_t;
 
 typedef enum dt_dev_rawoverexposed_mode_t {

--- a/src/dtgtk/expander.c
+++ b/src/dtgtk/expander.c
@@ -283,8 +283,7 @@ GtkWidget *dtgtk_expander_new(GtkWidget *header, GtkWidget *body)
   gtk_revealer_set_reveal_child(GTK_REVEALER(expander->frame), TRUE);
   gtk_container_add(GTK_CONTAINER(expander->frame), frame);
 
-  gtk_box_pack_start(GTK_BOX(expander), expander->header_evb, TRUE, FALSE, 0);
-  gtk_box_pack_start(GTK_BOX(expander), expander->frame, TRUE, FALSE, 0);
+  dt_gui_box_add(expander, expander->header_evb, expander->frame);
 
   g_signal_connect(expander->header_evb, "drag-begin", G_CALLBACK(_expander_drag_begin), NULL);
   g_signal_connect(expander->header_evb, "drag-end", G_CALLBACK(_expander_drag_end), NULL);

--- a/src/dtgtk/range.c
+++ b/src/dtgtk/range.c
@@ -603,7 +603,6 @@ static void _current_show_popup(GtkDarktableRangeSelect *range)
   gtk_popover_set_modal(GTK_POPOVER(range->cur_window), FALSE);
   gtk_popover_set_position(GTK_POPOVER(range->cur_window), GTK_POS_BOTTOM);
 
-  GtkWidget *vb = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
   // the label for the current value / selection
   range->cur_label = gtk_label_new("");
   dt_gui_add_class(range->cur_label, "dt_transparent_background");
@@ -613,14 +612,12 @@ static void _current_show_popup(GtkDarktableRangeSelect *range)
   gtk_label_set_attributes(GTK_LABEL(range->cur_label), attrlist);
   pango_attr_list_unref(attrlist);
   _current_set_text(range, 0);
-  gtk_box_pack_start(GTK_BOX(vb), range->cur_label, FALSE, TRUE, 0);
 
   // the label for the static infos
   GtkWidget *lb = gtk_label_new("");
   gtk_label_set_xalign(GTK_LABEL(lb), 0.0);
   if(range->cur_help) gtk_label_set_markup(GTK_LABEL(lb), range->cur_help);
-  gtk_box_pack_start(GTK_BOX(vb), lb, FALSE, TRUE, 0);
-  gtk_container_add(GTK_CONTAINER(range->cur_window), vb);
+  gtk_container_add(GTK_CONTAINER(range->cur_window), dt_gui_vbox(range->cur_label, lb));
   gtk_widget_show_all(range->cur_window);
 }
 
@@ -936,31 +933,20 @@ static void _popup_date_init(GtkDarktableRangeSelect *range)
   _range_date_popup *pop = g_malloc0(sizeof(_range_date_popup));
   range->date_popup = pop;
   pop->popup = gtk_popover_new(range->band);
-  GtkWidget *vbox0 = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
-  gtk_widget_set_name(vbox0, "dt-range-date-popup");
-  GtkWidget *hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-  gtk_box_set_homogeneous(GTK_BOX(hbox), TRUE);
-  gtk_box_pack_start(GTK_BOX(vbox0), hbox, FALSE, TRUE, 0);
-  gtk_container_add(GTK_CONTAINER(pop->popup), vbox0);
-  GtkWidget *vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
-  gtk_box_pack_start(GTK_BOX(hbox), vbox, FALSE, TRUE, 0);
 
   // the type of date selection
   pop->type = dt_bauhaus_combobox_new(NULL);
   dt_bauhaus_widget_set_label(pop->type, NULL, _("date type"));
   g_signal_connect(G_OBJECT(pop->type), "value-changed", G_CALLBACK(_popup_date_type_changed), range);
-  gtk_box_pack_start(GTK_BOX(vbox), pop->type, FALSE, TRUE, 0);
 
   // the label to explain the reference date for relative values
   pop->relative_label = gtk_label_new("");
   gtk_label_set_line_wrap(GTK_LABEL(pop->relative_label), TRUE);
   gtk_widget_set_no_show_all(pop->relative_label, TRUE);
-  gtk_box_pack_start(GTK_BOX(vbox), pop->relative_label, FALSE, TRUE, 0);
 
   // the date section
-  GtkWidget *lb = gtk_label_new(_("date"));
-  dt_gui_add_class(lb, "dt_section_label");
-  gtk_box_pack_start(GTK_BOX(vbox), lb, FALSE, TRUE, 0);
+  GtkWidget *lb_date = gtk_label_new(_("date"));
+  dt_gui_add_class(lb_date, "dt_section_label");
 
   // the calendar
   pop->calendar = gtk_calendar_new();
@@ -970,13 +956,11 @@ static void _popup_date_init(GtkDarktableRangeSelect *range)
   g_signal_connect(G_OBJECT(pop->calendar), "day_selected", G_CALLBACK(_popup_date_changed), range);
   g_signal_connect(G_OBJECT(pop->calendar), "day_selected-double-click",
                    G_CALLBACK(_popup_date_day_selected_2click), range);
-  gtk_box_pack_start(GTK_BOX(vbox), pop->calendar, FALSE, TRUE, 0);
 
   // the relative date box
   pop->relative_date_box = gtk_grid_new();
   gtk_grid_set_column_homogeneous(GTK_GRID(pop->relative_date_box), TRUE);
-  gtk_box_pack_start(GTK_BOX(vbox), pop->relative_date_box, FALSE, TRUE, 0);
-  lb = gtk_label_new(_("years: "));
+  GtkWidget *lb = gtk_label_new(_("years: "));
   gtk_label_set_xalign(GTK_LABEL(lb), 1.0);
   gtk_grid_attach(GTK_GRID(pop->relative_date_box), lb, 0, 0, 1, 1);
   pop->years = gtk_entry_new();
@@ -1004,27 +988,18 @@ static void _popup_date_init(GtkDarktableRangeSelect *range)
   gtk_widget_set_no_show_all(pop->relative_date_box, TRUE);
 
   // the time section
-  lb = gtk_label_new(_("time"));
-  dt_gui_add_class(lb, "dt_section_label");
-  gtk_box_pack_start(GTK_BOX(vbox), lb, FALSE, TRUE, 0);
+  GtkWidget *lb_time = gtk_label_new(_("time"));
+  dt_gui_add_class(lb_time, "dt_section_label");
 
-  GtkWidget *hbox2 = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-  gtk_widget_set_halign(hbox2, GTK_ALIGN_CENTER);
-  gtk_box_pack_start(GTK_BOX(vbox), hbox2, FALSE, FALSE, 0);
   pop->hours = gtk_entry_new();
   gtk_entry_set_width_chars(GTK_ENTRY(pop->hours), 2);
   g_signal_connect(G_OBJECT(pop->hours), "changed", G_CALLBACK(_popup_date_changed), range);
-  gtk_box_pack_start(GTK_BOX(hbox2), pop->hours, FALSE, TRUE, 0);
-  gtk_box_pack_start(GTK_BOX(hbox2), gtk_label_new(" : "), FALSE, TRUE, 0);
   pop->minutes = gtk_entry_new();
   gtk_entry_set_width_chars(GTK_ENTRY(pop->minutes), 2);
   g_signal_connect(G_OBJECT(pop->minutes), "changed", G_CALLBACK(_popup_date_changed), range);
-  gtk_box_pack_start(GTK_BOX(hbox2), pop->minutes, FALSE, TRUE, 0);
-  gtk_box_pack_start(GTK_BOX(hbox2), gtk_label_new(" : "), FALSE, TRUE, 0);
   pop->seconds = gtk_entry_new();
   gtk_entry_set_width_chars(GTK_ENTRY(pop->seconds), 2);
   g_signal_connect(G_OBJECT(pop->seconds), "changed", G_CALLBACK(_popup_date_changed), range);
-  gtk_box_pack_start(GTK_BOX(hbox2), pop->seconds, FALSE, TRUE, 0);
 
   // the treeview
   GtkTreeModel *model = GTK_TREE_MODEL(gtk_tree_store_new(DATETIME_NUM_COLS, G_TYPE_STRING, G_TYPE_UINT,
@@ -1044,25 +1019,30 @@ static void _popup_date_init(GtkDarktableRangeSelect *range)
   gtk_tree_view_column_set_cell_data_func(col, renderer, _date_tree_count_func, NULL, NULL);
   gtk_tree_view_set_tooltip_column(GTK_TREE_VIEW(pop->treeview), DATETIME_COL_TOOLTIP);
 
-  GtkWidget *sw = dt_gui_scroll_wrap(pop->treeview);
-  gtk_box_pack_start(GTK_BOX(hbox), sw, FALSE, TRUE, 0);
-
   // the select line
-  hbox2 = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-  gtk_box_pack_start(GTK_BOX(vbox0), hbox2, FALSE, TRUE, 0);
-  gtk_box_pack_start(GTK_BOX(hbox2), gtk_label_new(_("current date: ")), FALSE, TRUE, 0);
   pop->selection = gtk_entry_new();
-  gtk_entry_set_alignment(GTK_ENTRY(pop->selection), 0.5);
-  gtk_box_pack_start(GTK_BOX(hbox2), pop->selection, TRUE, TRUE, 0);
+  gtk_entry_set_alignment(GTK_ENTRY(dt_gui_expand(pop->selection)), 0.5);
   pop->now_btn = gtk_button_new_with_label(_("now"));
   gtk_widget_set_no_show_all(pop->now_btn, TRUE);
   gtk_widget_set_tooltip_text(pop->now_btn, _("set the value to always match current datetime"));
   g_signal_connect(G_OBJECT(pop->now_btn), "clicked", G_CALLBACK(_popup_date_now_clicked), range);
-  gtk_box_pack_start(GTK_BOX(hbox2), pop->now_btn, FALSE, TRUE, 0);
   pop->ok_btn = gtk_button_new_with_label(_("apply"));
   gtk_widget_set_tooltip_text(pop->ok_btn, _("set the range bound with this value"));
   g_signal_connect(G_OBJECT(pop->ok_btn), "clicked", G_CALLBACK(_popup_date_ok_clicked), range);
-  gtk_box_pack_start(GTK_BOX(hbox2), pop->ok_btn, FALSE, TRUE, 0);
+
+  GtkWidget *time = dt_gui_hbox(pop->hours, gtk_label_new(" : "), pop->minutes, gtk_label_new(" : "), pop->seconds);
+  gtk_widget_set_halign(time, GTK_ALIGN_CENTER);
+  GtkWidget *calendar_and_tree = dt_gui_hbox(dt_gui_vbox(
+    pop->type, pop->relative_label, lb_date, pop->calendar, pop->relative_date_box, lb_time, time),
+    dt_gui_scroll_wrap(pop->treeview));
+  gtk_box_set_homogeneous(GTK_BOX(calendar_and_tree), TRUE);
+  GtkWidget *vbox = dt_gui_vbox(
+    calendar_and_tree,
+    dt_gui_hbox(gtk_label_new(_("current date: ")), pop->selection, pop->now_btn, pop->ok_btn));
+
+  gtk_widget_set_name(vbox, "dt-range-date-popup");
+
+  gtk_container_add(GTK_CONTAINER(pop->popup), vbox);
 }
 
 static void _popup_item_activate(GtkWidget *w, gpointer user_data)
@@ -1683,9 +1663,6 @@ GtkWidget *dtgtk_range_select_new(const gchar *property, const gboolean show_ent
   range->current_bounds = dtgtk_range_select_get_bounds_pretty;
   range->allow_resize = TRUE;
 
-  // the boxes widgets
-  GtkWidget *vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
-
   // the graph band
   range->band = gtk_drawing_area_new();
   gtk_widget_set_events(range->band, GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK | GDK_STRUCTURE_MASK
@@ -1698,31 +1675,30 @@ GtkWidget *dtgtk_range_select_new(const gchar *property, const gboolean show_ent
   g_signal_connect(G_OBJECT(range->band), "style-updated", G_CALLBACK(_dt_pref_changed), range);
   gtk_widget_set_name(GTK_WIDGET(range->band), "dt-range-band");
   gtk_widget_set_can_default(range->band, TRUE);
-  gtk_box_pack_start(GTK_BOX(vbox), range->band, TRUE, TRUE, 0);
 
   // always hidden widgets used to retrieve drawing colors
   range->band_graph = gtk_drawing_area_new();
   gtk_widget_set_name(GTK_WIDGET(range->band_graph), "dt-range-band-graph");
   gtk_widget_set_no_show_all(range->band_graph, TRUE);
-  gtk_box_pack_start(GTK_BOX(vbox), range->band_graph, FALSE, FALSE, 0);
   range->band_selection = gtk_drawing_area_new();
   gtk_widget_set_name(GTK_WIDGET(range->band_selection), "dt-range-band-selection");
   gtk_widget_set_no_show_all(range->band_selection, TRUE);
-  gtk_box_pack_start(GTK_BOX(vbox), range->band_selection, FALSE, FALSE, 0);
   range->band_icons = gtk_drawing_area_new();
   gtk_widget_set_name(GTK_WIDGET(range->band_icons), "dt-range-band-icons");
   gtk_widget_set_no_show_all(range->band_icons, TRUE);
-  gtk_box_pack_start(GTK_BOX(vbox), range->band_icons, FALSE, FALSE, 0);
   range->band_cursor = gtk_drawing_area_new();
   gtk_widget_set_name(GTK_WIDGET(range->band_cursor), "dt-range-band-cursor");
   gtk_widget_set_no_show_all(range->band_cursor, TRUE);
-  gtk_box_pack_start(GTK_BOX(vbox), range->band_cursor, FALSE, FALSE, 0);
+
+  // the boxes widgets
+  GtkWidget *vbox = dt_gui_vbox(range->band,
+                                range->band_graph,
+                                range->band_selection,
+                                range->band_icons,
+                                range->band_cursor);
 
   if(range->show_entries)
   {
-    GtkWidget *hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-    gtk_box_pack_start(GTK_BOX(vbox), hbox, TRUE, TRUE, 0);
-
     // the entries
     range->entry_min = dt_ui_entry_new(0);
     gtk_widget_set_can_default(range->entry_min, TRUE);
@@ -1730,7 +1706,6 @@ GtkWidget *dtgtk_range_select_new(const gchar *property, const gboolean show_ent
     g_signal_connect(G_OBJECT(range->entry_min), "activate", G_CALLBACK(_event_entry_activated), range);
     g_signal_connect(G_OBJECT(range->entry_min), "focus-out-event", G_CALLBACK(_event_entry_focus_out), range);
     g_signal_connect(G_OBJECT(range->entry_min), "button-press-event", G_CALLBACK(_event_entry_press), range);
-    gtk_box_pack_start(GTK_BOX(hbox), range->entry_min, TRUE, TRUE, 0);
 
     range->entry_max = dt_ui_entry_new(0);
     gtk_widget_set_can_default(range->entry_max, TRUE);
@@ -1739,7 +1714,8 @@ GtkWidget *dtgtk_range_select_new(const gchar *property, const gboolean show_ent
     g_signal_connect(G_OBJECT(range->entry_max), "activate", G_CALLBACK(_event_entry_activated), range);
     g_signal_connect(G_OBJECT(range->entry_max), "focus-out-event", G_CALLBACK(_event_entry_focus_out), range);
     g_signal_connect(G_OBJECT(range->entry_max), "button-press-event", G_CALLBACK(_event_entry_press), range);
-    gtk_box_pack_end(GTK_BOX(hbox), range->entry_max, TRUE, TRUE, 0);
+
+    dt_gui_box_add(vbox, dt_gui_hbox(dt_gui_expand(range->entry_min), dt_gui_expand(range->entry_max)));
   }
 
   gtk_container_add(GTK_CONTAINER(range), vbox);

--- a/src/dtgtk/sidepanel.c
+++ b/src/dtgtk/sidepanel.c
@@ -51,6 +51,7 @@ static void dtgtk_side_panel_class_init(GtkDarktableSidePanelClass *class)
 static void dtgtk_side_panel_init(GtkDarktableSidePanel *panel)
 {
   gtk_widget_set_vexpand(GTK_WIDGET(panel), TRUE);
+  gtk_widget_set_hexpand(GTK_WIDGET(panel), FALSE);
 }
 
 // public functions

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -1227,7 +1227,7 @@ gboolean dt_shortcut_tooltip_callback(GtkWidget *widget,
     g_free(description);
 
     if(vbox)
-      gtk_box_pack_start(GTK_BOX(vbox), label, FALSE, FALSE, 0);
+      dt_gui_box_add(vbox, label);
     else
       vbox = label;
   }
@@ -3011,44 +3011,38 @@ GtkWidget *dt_shortcuts_prefs(GtkWidget *widget)
   g_signal_connect(G_OBJECT(container), "notify::position",
                    G_CALLBACK(_resize_shortcuts_view), container);
 
-  GtkWidget *button_bar = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0), *button = NULL;
-  gtk_widget_set_name(button_bar, "shortcut-controls");
-  gtk_box_pack_start(GTK_BOX(button_bar), search_actions, FALSE, FALSE, 0);
-  gtk_box_pack_start(GTK_BOX(button_bar), search_shortcuts, FALSE, FALSE, 0);
-
-  button = gtk_check_button_new_with_label(_("enable fallbacks"));
-  gtk_widget_set_tooltip_text(button, _("enables default meanings for additional buttons, modifiers or moves\n"
-                                        "when used in combination with a base shortcut"));
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(button),
+  GtkWidget *btn_fallbacks = gtk_check_button_new_with_label(_("enable fallbacks"));
+  gtk_widget_set_tooltip_text(btn_fallbacks, _("enables default meanings for additional buttons, modifiers or moves\n"
+                                               "when used in combination with a base shortcut"));
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(btn_fallbacks),
                                darktable.control->enable_fallbacks);
-  g_signal_connect(button, "toggled", G_CALLBACK(_fallbacks_toggled), shortcuts_view);
-  gtk_box_pack_start(GTK_BOX(button_bar), button, TRUE, FALSE, 0);
+  g_signal_connect(btn_fallbacks, "toggled", G_CALLBACK(_fallbacks_toggled), shortcuts_view);
 
-  button = gtk_button_new_with_label(_("?"));
-  gtk_widget_set_tooltip_text(button, _("open help page for shortcuts"));
-  dt_gui_add_help_link(button, "shortcuts");
-  g_signal_connect(button, "clicked", G_CALLBACK(dt_gui_show_help), NULL);
-  gtk_box_pack_start(GTK_BOX(button_bar), button, FALSE, FALSE, 0);
+  GtkWidget *btn_help = gtk_button_new_with_label(_("?"));
+  gtk_widget_set_tooltip_text(btn_help, _("open help page for shortcuts"));
+  dt_gui_add_help_link(btn_help, "shortcuts");
+  g_signal_connect(btn_help, "clicked", G_CALLBACK(dt_gui_show_help), NULL);
 
-  button = gtk_button_new_with_label(_("restore..."));
-  gtk_widget_set_tooltip_text(button, _("restore default shortcuts or previous state"));
-  g_signal_connect(button, "clicked", G_CALLBACK(_restore_clicked), NULL);
-  gtk_box_pack_end(GTK_BOX(button_bar), button, FALSE, FALSE, 0);
+  GtkWidget *btn_restore = gtk_button_new_with_label(_("restore..."));
+  gtk_widget_set_tooltip_text(btn_restore, _("restore default shortcuts or previous state"));
+  g_signal_connect(btn_restore, "clicked", G_CALLBACK(_restore_clicked), NULL);
 
-  button = gtk_button_new_with_label(_("import..."));
-  gtk_widget_set_tooltip_text(button, _("fully or partially import shortcuts from file"));
-  g_signal_connect(button, "clicked", G_CALLBACK(_import_clicked), NULL);
-  gtk_box_pack_end(GTK_BOX(button_bar), button, FALSE, FALSE, 0);
+  GtkWidget *btn_import = gtk_button_new_with_label(_("import..."));
+  gtk_widget_set_tooltip_text(btn_import, _("fully or partially import shortcuts from file"));
+  g_signal_connect(btn_import, "clicked", G_CALLBACK(_import_clicked), NULL);
 
-  button = gtk_button_new_with_label(_("export..."));
-  gtk_widget_set_tooltip_text(button, _("fully or partially export shortcuts to file"));
-  g_signal_connect(button, "clicked", G_CALLBACK(_export_clicked), NULL);
-  gtk_box_pack_end(GTK_BOX(button_bar), button, FALSE, FALSE, 0);
+  GtkWidget *btn_export = gtk_button_new_with_label(_("export..."));
+  gtk_widget_set_tooltip_text(btn_export, _("fully or partially export shortcuts to file"));
+  g_signal_connect(btn_export, "clicked", G_CALLBACK(_export_clicked), NULL);
 
-  GtkWidget *top_level = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
+  GtkWidget *button_bar = dt_gui_hbox(search_actions, search_shortcuts, btn_fallbacks,
+                                      dt_gui_align_right(btn_help), btn_export, btn_import, btn_restore);
+  gtk_widget_set_name(button_bar, "shortcut-controls");
+
+  GtkWidget *top_level = dt_gui_vbox();
   if(!dt_conf_get_bool("accel/hide_notice"))
   {
-    button = gtk_button_new_with_label(
+    GtkWidget *button = gtk_button_new_with_label(
       _("the recommended way to assign shortcuts to visual elements is the <b>visual shortcut mapping</b> mode.\n"
         "this is switched on by toggling the <i>\"keyboard\"</i> button next to preferences in the top panel. "
         "in this mode, clicking on a widget or area will open this dialog with the appropriate selection for advanced configuration.\n\n"
@@ -3063,10 +3057,9 @@ GtkWidget *dt_shortcuts_prefs(GtkWidget *widget)
     gtk_label_set_line_wrap(label, TRUE);
     gtk_label_set_xalign(label, 0);
     g_signal_connect(button, "clicked", G_CALLBACK(_notice_clicked), NULL);
-    gtk_box_pack_start(GTK_BOX(top_level), button, FALSE, FALSE, 0);
+    dt_gui_box_add(top_level, button);
   }
-  gtk_box_pack_start(GTK_BOX(top_level), container, TRUE, TRUE, 0);
-  gtk_box_pack_start(GTK_BOX(top_level), button_bar, FALSE, FALSE, 0);
+  dt_gui_box_add(top_level, container, button_bar);
 
   return top_level;
 }

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -4491,13 +4491,14 @@ void dt_gui_simulate_button_event(GtkWidget *widget,
 GtkWidget *(dt_gui_box_add)(const char *file, const int line, const char *function, GtkBox *box, gpointer list[])
 {
   if(!GTK_IS_BOX(box)) dt_print(DT_DEBUG_ALWAYS, "%s:%d %s: trying to add widgets to non-box container using dt_gui_box_add", file, line, function);
-  int i = 1;
-  for(; *list != (gpointer)-1; list++, i++)
+  for(int i = 1; *list != (gpointer)-1; list++, i++)
   {
-    if(GTK_IS_WIDGET(*list))
-      gtk_container_add(GTK_CONTAINER(box), GTK_WIDGET(*list));
-    else
+    if(!GTK_IS_WIDGET(*list))
       dt_print(DT_DEBUG_ALWAYS, "%s:%d %s: trying to add invalid widget to box (#%d)", file, line, function, i);
+    else if(gtk_widget_get_parent(*list))
+      dt_print(DT_DEBUG_ALWAYS, "%s:%d %s: trying to add widget that already has a parent to box (#%d)", file, line, function, i);
+    else
+      gtk_container_add(GTK_CONTAINER(box), GTK_WIDGET(*list));
   }
 
   return GTK_WIDGET(box);

--- a/src/gui/gtk.h
+++ b/src/gui/gtk.h
@@ -26,8 +26,6 @@
 
 G_BEGIN_DECLS
 
-#define DT_GUI_IOP_MODULE_CONTROL_SPACING 0
-
 #define DT_GUI_THUMBSIZE_REDUCE 0.7f
 
 /* helper macro that applies the DPI transformation to fixed pixel values. input should be defaulting to 96

--- a/src/iop/agx.c
+++ b/src/iop/agx.c
@@ -1840,7 +1840,6 @@ static GtkWidget* _create_basic_curve_controls_box(dt_iop_module_t *self,
   _add_basic_curve_controls(self, &g->basic_curve_controls, section_name);
 
   self->widget = parent;
-
   return box;
 }
 
@@ -1888,10 +1887,8 @@ static void _add_look_box(dt_iop_module_t *self,
                           dt_iop_agx_gui_data_t *g)
 {
   const gboolean look_always_visible = dt_conf_get_bool("plugins/darkroom/agx/look_always_visible");
-  GtkWidget *parent = self->widget;
 
-  GtkWidget *look_box = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
-  self->widget = look_box;
+  GtkWidget *look_box = dt_gui_vbox();
 
   gchar *section_name = NC_("section", "look");
   if(look_always_visible)
@@ -1907,21 +1904,16 @@ static void _add_look_box(dt_iop_module_t *self,
     _add_look_sliders(self, GTK_WIDGET(g->look_section.container), section_name);
   }
 
-  self->widget = parent;
-  gtk_box_pack_start(GTK_BOX(parent), look_box, FALSE, FALSE, 0);
+  dt_gui_box_add(self->widget, look_box);
 }
 
 static GtkWidget* _create_curve_graph_box(dt_iop_module_t *self,
                                           dt_iop_agx_gui_data_t *g)
 {
-  GtkWidget *parent = self->widget;
-
-  GtkWidget *graph_box = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
-  self->widget = graph_box;
+  GtkWidget *graph_box = dt_gui_vbox();
 
   dt_gui_new_collapsible_section(&g->graph_section, "plugins/darkroom/agx/expand_curve_graph",
                                  _("show curve"), GTK_BOX(graph_box), DT_ACTION(self));
-  GtkWidget *graph_container = GTK_WIDGET(g->graph_section.container);
   g->graph_drawing_area =
       GTK_DRAWING_AREA(dt_ui_resize_wrap(NULL, 0, "plugins/darkroom/agx/curve_graph_height"));
   g_object_set_data(G_OBJECT(g->graph_drawing_area), "iop-instance", self);
@@ -1931,9 +1923,7 @@ static GtkWidget* _create_curve_graph_box(dt_iop_module_t *self,
   gtk_widget_set_tooltip_text(GTK_WIDGET(g->graph_drawing_area), _("tone mapping curve"));
 
   // Pack drawing area at the top
-  gtk_box_pack_start(GTK_BOX(graph_container), GTK_WIDGET(g->graph_drawing_area), TRUE, TRUE, 0);
-
-  self->widget = parent;
+  dt_gui_box_add(g->graph_section.container, g->graph_drawing_area);
 
   return graph_box;
 }
@@ -1943,8 +1933,7 @@ static GtkWidget* _create_advanced_box(dt_iop_module_t *self,
 {
   GtkWidget *parent = self->widget;
 
-  GtkWidget *advanced_box = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
-  self->widget = advanced_box;
+  GtkWidget *advanced_box = dt_gui_vbox();
 
   gchar *section_name = NC_("section", "advanced curve parameters");
   dt_gui_new_collapsible_section(&g->advanced_section,
@@ -2022,10 +2011,8 @@ static void _add_exposure_box(dt_iop_module_t *self, dt_iop_agx_gui_data_t *g)
 {
   GtkWidget *parent = self->widget;
 
-  self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
-
   gchar *section_name = NC_("section", "input exposure range");
-  dt_gui_box_add(self->widget, dt_ui_section_label_new(section_name));
+  self->widget = dt_gui_vbox(dt_ui_section_label_new(Q_(section_name)));
   dt_iop_module_t *section = DT_IOP_SECTION_FOR_PARAMS(self, section_name);
 
   g->white_exposure_picker =
@@ -2058,10 +2045,9 @@ static void _add_exposure_box(dt_iop_module_t *self, dt_iop_agx_gui_data_t *g)
   dt_bauhaus_widget_set_label(g->range_exposure_picker, section_name, N_("auto tune levels"));
   gtk_widget_set_tooltip_text(g->range_exposure_picker,
                               _("pick image area to automatically set black and white exposure"));
-  gtk_box_pack_start(GTK_BOX(self->widget), g->range_exposure_picker, FALSE, FALSE, 0);
+  dt_gui_box_add(self->widget, g->range_exposure_picker);
 
-  gtk_box_pack_start(GTK_BOX(parent), self->widget, FALSE, FALSE, 0);
-
+  dt_gui_box_add(parent, self->widget);
   self->widget = parent;
 }
 
@@ -2232,8 +2218,7 @@ static GtkWidget *_add_primaries_box(dt_iop_module_t *self)
   dt_iop_agx_gui_data_t *g = self->gui_data;
   GtkWidget *main_box = self->widget;
 
-  GtkWidget *primaries_box = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
-  self->widget = primaries_box;
+  GtkWidget *primaries_box = self->widget = dt_gui_vbox();
   dt_iop_module_t *section = DT_IOP_SECTION_FOR_PARAMS(self, N_("primaries"));
 
   g->disable_primaries_adjustments =
@@ -2247,16 +2232,12 @@ static GtkWidget *_add_primaries_box(dt_iop_module_t *self)
        "especially with bright, saturated lights (e.g. LEDs).\n"
        "mainly intended to be used for experimenting."));
 
-  g->primaries_controls_vbox = self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
-  gtk_box_pack_start(GTK_BOX(primaries_box), self->widget, FALSE, FALSE, 0);
-
-  GtkWidget *preset_hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, DT_BAUHAUS_SPACE);
-  gtk_box_pack_start(GTK_BOX(g->primaries_controls_vbox), preset_hbox, FALSE, FALSE, 0);
+  g->primaries_controls_vbox = self->widget = dt_gui_vbox();
+  dt_gui_box_add(primaries_box, g->primaries_controls_vbox);
 
   g->primaries_preset_combo = GTK_COMBO_BOX_TEXT(gtk_combo_box_text_new());
   gtk_widget_set_tooltip_text(GTK_WIDGET(g->primaries_preset_combo),
                               _("load primaries settings from a preset"));
-  gtk_box_pack_start(GTK_BOX(preset_hbox), GTK_WIDGET(g->primaries_preset_combo), TRUE, TRUE, 0);
 
   _populate_primaries_presets_combobox(self);
   g->primaries_preset_apply_button = gtk_button_new_with_label(_("apply"));
@@ -2264,7 +2245,9 @@ static GtkWidget *_add_primaries_box(dt_iop_module_t *self)
                               _("apply primaries settings from the selected preset"));
   g_signal_connect(g->primaries_preset_apply_button, "clicked",
                    G_CALLBACK(_apply_primaries_from_preset_callback), self);
-  gtk_box_pack_start(GTK_BOX(preset_hbox), g->primaries_preset_apply_button, FALSE, FALSE, 0);
+
+  dt_gui_box_add(g->primaries_controls_vbox, dt_gui_hbox(dt_gui_expand(g->primaries_preset_combo),
+                                             g->primaries_preset_apply_button));
 
   GtkWidget *base_primaries_combo = dt_bauhaus_combobox_from_params(section, "base_primaries");
   gtk_widget_set_tooltip_text(base_primaries_combo,
@@ -2361,7 +2344,7 @@ static void _notebook_page_changed(GtkNotebook *notebook,
       }
 
       // pack to new parent
-      gtk_box_pack_start(GTK_BOX(vbox), g->curve_basic_controls_box, FALSE, FALSE, 0);
+      dt_gui_box_add(vbox, g->curve_basic_controls_box);
 
       // On the 'settings' page, move to second last position (before look box)
       if(page_num == 0)
@@ -2391,27 +2374,22 @@ static void _notebook_page_changed(GtkNotebook *notebook,
 static void _create_primaries_page(dt_iop_module_t *self,
                                    const dt_iop_agx_gui_data_t *g)
 {
-  GtkWidget *parent = self->widget;
-
   GtkWidget *page_primaries =
     dt_ui_notebook_page(g->notebook, N_("primaries"), _("color primaries adjustments"));
   GtkWidget *primaries_box = _add_primaries_box(self);
-  gtk_box_pack_start(GTK_BOX(page_primaries), primaries_box, FALSE, FALSE, 0);
-
-  self->widget = parent;
+  dt_gui_box_add(page_primaries, primaries_box);
 }
 
 void gui_init(dt_iop_module_t *self)
 {
   dt_iop_agx_gui_data_t *g = IOP_GUI_ALLOC(agx);
-  GtkWidget *main_vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
-  self->widget = main_vbox;
+  GtkWidget *main_vbox = self->widget = dt_gui_vbox();
 
   static dt_action_def_t notebook_def = {};
   g->notebook = dt_ui_notebook_new(&notebook_def);
   GtkWidget *notebook_widget = GTK_WIDGET(g->notebook);
   dt_action_define_iop(self, NULL, N_("page"), notebook_widget, &notebook_def);
-  gtk_box_pack_start(GTK_BOX(main_vbox), notebook_widget, TRUE, TRUE, 0);
+  dt_gui_box_add(main_vbox, notebook_widget);
 
   g->curve_basic_controls_box = _create_basic_curve_controls_box(self, g);
   g->curve_graph_box = _create_curve_graph_box(self, g);
@@ -2431,8 +2409,8 @@ void gui_init(dt_iop_module_t *self)
                                                 N_("curve"),
                                                 _("detailed curve settings"));
     self->widget = curve_page;
-    gtk_box_pack_start(GTK_BOX(curve_page), g->curve_graph_box, FALSE, FALSE, 0);
-    gtk_box_pack_start(GTK_BOX(curve_page), g->curve_advanced_controls_box, FALSE, FALSE, 0);
+    dt_gui_box_add(curve_page, g->curve_graph_box,
+                               g->curve_advanced_controls_box);
 
     // reparent on tab switch
     g_signal_connect(g->notebook, "switch-page", G_CALLBACK(_notebook_page_changed), self);
@@ -2447,9 +2425,9 @@ void gui_init(dt_iop_module_t *self)
                                                    _("main look and curve settings"));
     self->widget = settings_page;
     _add_exposure_box(self, g);
-    gtk_box_pack_start(GTK_BOX(settings_page), g->curve_basic_controls_box, FALSE, FALSE, 0);
-    gtk_box_pack_start(GTK_BOX(settings_page), g->curve_graph_box, FALSE, FALSE, 0);
-    gtk_box_pack_start(GTK_BOX(settings_page), g->curve_advanced_controls_box, FALSE, FALSE, 0);
+    dt_gui_box_add(settings_page, g->curve_basic_controls_box,
+                                  g->curve_graph_box,
+                                  g->curve_advanced_controls_box);
     _add_look_box(self, g);
   }
 

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -5991,7 +5991,8 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_slider_set_soft_range(g->shear, -SHEAR_RANGE, SHEAR_RANGE);
 
   g->mode = dt_bauhaus_combobox_from_params(self, "mode");
-  self->widget = g->specifics = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
+
+  self->widget = g->specifics = dt_gui_vbox();
 
   g->f_length = dt_bauhaus_slider_from_params(self, "f_length");
   dt_bauhaus_slider_set_soft_range(g->f_length, 10.0f, 1000.0f);
@@ -6014,7 +6015,7 @@ void gui_init(dt_iop_module_t *self)
   g->aspect = dt_bauhaus_slider_from_params(self, "aspect");
   dt_bauhaus_slider_set_curve(g->aspect, log2_curve);
 
-  gtk_box_pack_start(GTK_BOX(g->cs.container), g->specifics, TRUE, TRUE, 0);
+  dt_gui_box_add(g->cs.container, g->specifics);
 
   self->widget = main_box;
 

--- a/src/iop/basicadj.c
+++ b/src/iop/basicadj.c
@@ -611,8 +611,6 @@ void gui_init(dt_iop_module_t *self)
 
   change_image(self);
 
-  self->widget = GTK_WIDGET(gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE));
-
   g->sl_black_point = dt_bauhaus_slider_from_params(self, "black_point");
   dt_bauhaus_slider_set_soft_range(g->sl_black_point, -0.1, 0.1);
   dt_bauhaus_slider_set_digits(g->sl_black_point, 4);
@@ -653,11 +651,8 @@ void gui_init(dt_iop_module_t *self)
   g->sl_vibrance = dt_bauhaus_slider_from_params(self, N_("vibrance"));
   gtk_widget_set_tooltip_text(g->sl_vibrance, _("vibrance adjustment"));
 
-  GtkWidget *autolevels_box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, DT_PIXEL_APPLY_DPI(10));
-
   g->bt_auto_levels = dt_action_button_new(NULL, N_("auto"), _auto_levels_callback, self, _("apply auto exposure based on the entire image"), 0, 0);
   gtk_widget_set_size_request(g->bt_auto_levels, -1, DT_PIXEL_APPLY_DPI(24));
-  gtk_box_pack_start(GTK_BOX(autolevels_box), g->bt_auto_levels, TRUE, TRUE, 0);
 
   g->bt_select_region = dtgtk_togglebutton_new(dtgtk_cairo_paint_colorpicker, 0, NULL);
   dt_gui_add_class(g->bt_select_region, "dt_transparent_background");
@@ -666,9 +661,8 @@ void gui_init(dt_iop_module_t *self)
                                 "click and drag to draw the area\n"
                                 "right-click to cancel"));
   g_signal_connect(G_OBJECT(g->bt_select_region), "toggled", G_CALLBACK(_select_region_toggled_callback), self);
-  gtk_box_pack_start(GTK_BOX(autolevels_box), g->bt_select_region, TRUE, TRUE, 0);
 
-  gtk_box_pack_start(GTK_BOX(self->widget), autolevels_box, TRUE, TRUE, 0);
+  dt_gui_box_add(self->widget, dt_gui_expand(g->bt_auto_levels), dt_gui_expand(g->bt_select_region));
 
   g->sl_clip = dt_bauhaus_slider_from_params(self, N_("clip"));
   dt_bauhaus_slider_set_digits(g->sl_clip, 3);

--- a/src/iop/borders.c
+++ b/src/iop/borders.c
@@ -1009,40 +1009,32 @@ void gui_init(dt_iop_module_t *self)
                                   .blue = dp->frame_color[2],
                                   .alpha = 1.0 };
 
-  GtkWidget *label, *box;
-
-  box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-  label = dtgtk_reset_label_new(_("border color"), self, &p->color, 3 * sizeof(float));
-  gtk_box_pack_start(GTK_BOX(box), label, TRUE, TRUE, 0);
+  GtkWidget *label = dtgtk_reset_label_new(_("border color"), self, &p->color, 3 * sizeof(float));
   g->colorpick = gtk_color_button_new_with_rgba(&color);
   gtk_color_chooser_set_use_alpha(GTK_COLOR_CHOOSER(g->colorpick), FALSE);
   gtk_color_button_set_title(GTK_COLOR_BUTTON(g->colorpick), _("select border color"));
   g_signal_connect(G_OBJECT(g->colorpick), "color-set",
                    G_CALLBACK(_colorpick_color_set), self);
-  gtk_box_pack_start(GTK_BOX(box), GTK_WIDGET(g->colorpick), FALSE, TRUE, 0);
-  g->border_picker = dt_color_picker_new(self, DT_COLOR_PICKER_POINT, box);
+  g->border_picker = dt_color_picker_new(self, DT_COLOR_PICKER_POINT, NULL);
   gtk_widget_set_tooltip_text(GTK_WIDGET(g->border_picker),
                               _("pick border color from image"));
   dt_action_define_iop(self, N_("pickers"), N_("border color"),
                        g->border_picker, &dt_action_def_toggle);
-  dt_gui_box_add(self->widget, box);
+  dt_gui_box_add(self->widget, dt_gui_hbox(dt_gui_expand(label), g->colorpick, g->border_picker));
 
-  box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
   label = dtgtk_reset_label_new(_("frame line color"), self, &p->frame_color, 3 * sizeof(float));
-  gtk_box_pack_start(GTK_BOX(box), label, TRUE, TRUE, 0);
   g->frame_colorpick = gtk_color_button_new_with_rgba(&frame_color);
   gtk_color_chooser_set_use_alpha(GTK_COLOR_CHOOSER(g->frame_colorpick), FALSE);
   gtk_color_button_set_title(GTK_COLOR_BUTTON(g->frame_colorpick),
                              _("select frame line color"));
   g_signal_connect(G_OBJECT(g->frame_colorpick), "color-set",
                    G_CALLBACK(_frame_colorpick_color_set), self);
-  gtk_box_pack_start(GTK_BOX(box), GTK_WIDGET(g->frame_colorpick), FALSE, TRUE, 0);
-  g->frame_picker = dt_color_picker_new(self, DT_COLOR_PICKER_POINT, box);
+  g->frame_picker = dt_color_picker_new(self, DT_COLOR_PICKER_POINT, NULL);
   gtk_widget_set_tooltip_text(GTK_WIDGET(g->frame_picker),
                               _("pick frame line color from image"));
   dt_action_define_iop(self, N_("pickers"), N_("frame line color"),
                        g->frame_picker, &dt_action_def_toggle);
-  dt_gui_box_add(self->widget, box);
+  dt_gui_box_add(self->widget, dt_gui_hbox(dt_gui_expand(label), g->frame_colorpick, g->frame_picker));
 }
 
 // clang-format off

--- a/src/iop/cacorrect.c
+++ b/src/iop/cacorrect.c
@@ -1302,8 +1302,6 @@ void gui_init(dt_iop_module_t *self)
 {
   dt_iop_cacorrect_gui_data_t *g = IOP_GUI_ALLOC(cacorrect);
 
-  GtkWidget *box_raw = self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
-
   g->iterations = dt_bauhaus_combobox_from_params(self, "iterations");
   gtk_widget_set_tooltip_text(g->iterations, _("iteration runs, default is twice"));
 
@@ -1311,6 +1309,7 @@ void gui_init(dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->avoidshift, _("activate colorshift correction for blue & red channels"));
 
   // start building top level widget
+  GtkWidget *box_raw = self->widget;
   self->widget = gtk_stack_new();
   gtk_stack_set_homogeneous(GTK_STACK(self->widget), FALSE);
   gtk_stack_add_named(GTK_STACK(self->widget), box_raw, "bayer");

--- a/src/iop/cacorrectrgb.c
+++ b/src/iop/cacorrectrgb.c
@@ -713,7 +713,7 @@ void reload_defaults(dt_iop_module_t *self)
 void gui_init(dt_iop_module_t *self)
 {
   dt_iop_cacorrectrgb_gui_data_t *g = IOP_GUI_ALLOC(cacorrectrgb);
-  self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
+
   g->guide_channel = dt_bauhaus_combobox_from_params(self, "guide_channel");
   gtk_widget_set_tooltip_text(g->guide_channel, _("channel used as a reference to\n"
                                            "correct the other channels.\n"
@@ -729,7 +729,7 @@ void gui_init(dt_iop_module_t *self)
                                              "high values can lead to overshooting\n"
                                              "and edge bleeding."));
 
-  gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(C_("section", "advanced parameters")), TRUE, TRUE, 0);
+  dt_gui_box_add(self->widget, dt_ui_section_label_new(C_("section", "advanced parameters")));
   g->mode = dt_bauhaus_combobox_from_params(self, "mode");
   gtk_widget_set_tooltip_text(g->mode, _("correction mode to use.\n"
                                          "can help with multiple\n"

--- a/src/iop/channelmixer.c
+++ b/src/iop/channelmixer.c
@@ -601,8 +601,6 @@ void gui_init(dt_iop_module_t *self)
   dt_iop_channelmixer_gui_data_t *g = IOP_GUI_ALLOC(channelmixer);
   const dt_iop_channelmixer_params_t *const p = self->default_params;
 
-  self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
-
   /* output */
   g->output_channel = dt_bauhaus_combobox_new(self);
   dt_bauhaus_widget_set_label(g->output_channel, NULL, N_("destination"));
@@ -634,12 +632,7 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_widget_set_label(g->scale_blue, NULL, N_("blue"));
   g_signal_connect(G_OBJECT(g->scale_blue), "value-changed", G_CALLBACK(blue_callback), self);
 
-
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->output_channel), TRUE, TRUE, 0);
-
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->scale_red), TRUE, TRUE, 0);
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->scale_green), TRUE, TRUE, 0);
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->scale_blue), TRUE, TRUE, 0);
+  self->widget = dt_gui_vbox(g->output_channel, g->scale_red, g->scale_green, g->scale_blue);
 }
 
 void init_presets(dt_iop_module_so_t *self)

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -4435,10 +4435,7 @@ void gui_init(dt_iop_module_t *self)
        "• XYZ is a simple scaling in XYZ space. It is not recommended in general.\n"
        "• none disables any adaptation and uses pipeline working RGB."));
 
-  GtkWidget *hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-
   g->approx_cct = dt_ui_label_new("CCT:");
-  gtk_box_pack_start(GTK_BOX(hbox), g->approx_cct, FALSE, FALSE, 0);
 
   g->illum_color = GTK_WIDGET(gtk_drawing_area_new());
   gtk_widget_set_size_request
@@ -4451,14 +4448,13 @@ void gui_init(dt_iop_module_t *self)
 
   g_signal_connect(G_OBJECT(g->illum_color), "draw",
                    G_CALLBACK(_illuminant_color_draw), self);
-  gtk_box_pack_start(GTK_BOX(hbox), g->illum_color, TRUE, TRUE, 0);
 
-  g->color_picker = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, hbox);
+  g->color_picker = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, NULL);
   dt_action_define_iop(self, NULL, N_("picker"), g->color_picker, &dt_action_def_toggle);
   gtk_widget_set_tooltip_text(g->color_picker,
                               _("set white balance to detected from area"));
 
-  dt_gui_box_add(self->widget, hbox);
+  dt_gui_box_add(self->widget, dt_gui_hbox(g->approx_cct, dt_gui_expand(g->illum_color), g->color_picker));
 
   g->illuminant = dt_bauhaus_combobox_from_params(self, N_("illuminant"));
 

--- a/src/iop/clahe.c
+++ b/src/iop/clahe.c
@@ -46,8 +46,6 @@ typedef struct dt_iop_rlce_params_t
 
 typedef struct dt_iop_rlce_gui_data_t
 {
-  GtkBox *vbox1, *vbox2;
-  GtkWidget *label1, *label2;
   GtkWidget *scale1, *scale2; // radie pixels, slope
 } dt_iop_rlce_gui_data_t;
 
@@ -321,26 +319,10 @@ void gui_init(dt_iop_module_t *self)
   dt_iop_rlce_gui_data_t *g = IOP_GUI_ALLOC(rlce);
   dt_iop_rlce_params_t *p = self->default_params;
 
-  self->widget = GTK_WIDGET(gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0));
-
-  g->vbox1 = GTK_BOX(gtk_box_new(GTK_ORIENTATION_VERTICAL,
-                                 DT_GUI_IOP_MODULE_CONTROL_SPACING));
-  g->vbox2 = GTK_BOX(gtk_box_new(GTK_ORIENTATION_VERTICAL,
-                                 DT_GUI_IOP_MODULE_CONTROL_SPACING));
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->vbox1), FALSE, FALSE, 0);
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->vbox2), TRUE, TRUE, 0);
-
-  g->label1 = dtgtk_reset_label_new(_("radius"), self, &p->radius, sizeof(float));
-  gtk_box_pack_start(GTK_BOX(g->vbox1), g->label1, TRUE, TRUE, 0);
-  g->label2 = dtgtk_reset_label_new(_("amount"), self, &p->slope, sizeof(float));
-  gtk_box_pack_start(GTK_BOX(g->vbox1), g->label2, TRUE, TRUE, 0);
-
   g->scale1 = dt_bauhaus_slider_new_with_range(NULL, 0.0, 256.0, 0, p->radius, 0);
   g->scale2 = dt_bauhaus_slider_new_with_range(NULL, 1.0, 3.0, 0, p->slope, 2);
-  // dtgtk_slider_set_format_type(g->scale2,DARKTABLE_SLIDER_FORMAT_PERCENT);
-
-  gtk_box_pack_start(GTK_BOX(g->vbox2), GTK_WIDGET(g->scale1), TRUE, TRUE, 0);
-  gtk_box_pack_start(GTK_BOX(g->vbox2), GTK_WIDGET(g->scale2), TRUE, TRUE, 0);
+  dt_bauhaus_widget_set_label(g->scale1, NULL, _("radius"));
+  dt_bauhaus_widget_set_label(g->scale2, NULL, _("amount"));
   gtk_widget_set_tooltip_text(GTK_WIDGET(g->scale1), _("size of features to preserve"));
   gtk_widget_set_tooltip_text(GTK_WIDGET(g->scale2), _("strength of the effect"));
 
@@ -348,6 +330,8 @@ void gui_init(dt_iop_module_t *self)
                    G_CALLBACK(radius_callback), self);
   g_signal_connect(G_OBJECT(g->scale2), "value-changed",
                    G_CALLBACK(slope_callback), self);
+
+  self->widget = dt_gui_vbox(g->scale1, g->scale2);
 }
 
 // clang-format off

--- a/src/iop/clipping.c
+++ b/src/iop/clipping.c
@@ -2107,7 +2107,7 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_combobox_add(g->hvflip, _("both"));
   g_signal_connect(G_OBJECT(g->hvflip), "value-changed", G_CALLBACK(hvflip_callback), self);
   gtk_widget_set_tooltip_text(g->hvflip, _("mirror image horizontally and/or vertically"));
-  gtk_box_pack_start(GTK_BOX(self->widget), g->hvflip, TRUE, TRUE, 0);
+  dt_gui_box_add(self->widget, g->hvflip);
 
   g->angle = dt_bauhaus_slider_from_params(self, N_("angle"));
   dt_bauhaus_slider_set_factor(g->angle, -1.0);
@@ -2122,7 +2122,7 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_combobox_add(g->keystone_type, _("full"));
   gtk_widget_set_tooltip_text(g->keystone_type, _("set perspective correction for your image"));
   g_signal_connect(G_OBJECT(g->keystone_type), "value-changed", G_CALLBACK(keystone_type_changed), self);
-  gtk_box_pack_start(GTK_BOX(self->widget), g->keystone_type, TRUE, TRUE, 0);
+  dt_gui_box_add(self->widget, g->keystone_type);
 
   g->crop_auto = dt_bauhaus_combobox_from_params(self, "crop_auto");
   gtk_widget_set_tooltip_text(g->crop_auto, _("automatically crop to avoid black edges"));
@@ -2242,7 +2242,7 @@ void gui_init(dt_iop_module_t *self)
                                                    "to enter custom aspect ratio open the combobox and type ratio in x:y or decimal format"));
   dt_bauhaus_widget_set_quad_paint(g->aspect_presets, dtgtk_cairo_paint_aspectflip, 0, NULL);
   g_signal_connect(G_OBJECT(g->aspect_presets), "quad-pressed", G_CALLBACK(aspect_flip), self);
-  gtk_box_pack_start(GTK_BOX(self->widget), g->aspect_presets, TRUE, TRUE, 0);
+  dt_gui_box_add(self->widget, g->aspect_presets);
 
   self->widget = dt_ui_notebook_page(g->notebook, _("margins"), NULL);
 

--- a/src/iop/colorbalance.c
+++ b/src/iop/colorbalance.c
@@ -1737,7 +1737,7 @@ static void _configure_slider_blocks(gpointer instance, dt_iop_module_t *self)
 
   if(!g_strcmp0(layout, "list"))
   {
-    new_container = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
+    new_container = dt_gui_vbox();
 
     for(int i=0; i<3; i++)
     {
@@ -1847,7 +1847,7 @@ void gui_init(dt_iop_module_t *self)
     g->luma_patches_flags[k] = INVALID;
   }
 
-  GtkWidget *mode_box = self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
+  GtkWidget *mode_box = self->widget = dt_gui_vbox();
 
   // mode choice
   g->mode = dt_bauhaus_combobox_from_params(self, N_("mode"));
@@ -1859,7 +1859,7 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_combobox_add(g->controls, _("HSL"));
   dt_bauhaus_combobox_add(g->controls, _("RGBL"));
   dt_bauhaus_combobox_add(g->controls, _("both"));
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->controls), TRUE, TRUE, 0);
+  dt_gui_box_add(self->widget, g->controls);
   gtk_widget_set_tooltip_text(g->controls, _("color-grading mapping method"));
   g_signal_connect(G_OBJECT(g->controls), "value-changed", G_CALLBACK(controls_callback), self);
 
@@ -1867,9 +1867,7 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_combobox_set(g->controls, !g_strcmp0(mode, "RGBL") ? RGBL :
                                        !g_strcmp0(mode, "BOTH") ? BOTH : HSL);
 
-  g->master_box = self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
-
-  gtk_box_pack_start(GTK_BOX(g->master_box), dt_ui_section_label_new(C_("section", "master")), FALSE, FALSE, 0);
+  g->master_box = self->widget = dt_gui_vbox(dt_ui_section_label_new(C_("section", "master")));
 
   g->saturation = dt_bauhaus_slider_from_params(self, "saturation");
   dt_bauhaus_slider_set_soft_range(g->saturation, 0.5f, 1.5f);
@@ -1896,53 +1894,6 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_slider_set_format(g->contrast, "%");
   gtk_widget_set_tooltip_text(g->contrast, _("contrast"));
 
-#ifdef SHOW_COLOR_WHEELS
-  GtkWidget *hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, DT_BAUHAUS_SPACE);
-  gtk_box_pack_start(GTK_BOX(self->widget), hbox, FALSE, FALSE, 0);
-
-  GtkWidget *area = dtgtk_drawing_area_new_with_height(0);
-  gtk_box_pack_start(GTK_BOX(hbox), area, TRUE, TRUE, 0);
-
-  //   gtk_widget_add_events(g->area,
-  //                         GDK_POINTER_MOTION_MASK |
-  //                         GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK | GDK_LEAVE_NOTIFY_MASK);
-  g_signal_connect(G_OBJECT(area), "draw", G_CALLBACK(dt_iop_area_draw), self);
-  //   g_signal_connect (G_OBJECT (area), "button-press-event",
-  //                     G_CALLBACK (dt_iop_colorbalance_button_press), self);
-  //   g_signal_connect (G_OBJECT (area), "motion-notify-event",
-  //                     G_CALLBACK (dt_iop_colorbalance_motion_notify), self);
-  //   g_signal_connect (G_OBJECT (area), "leave-notify-event",
-  //                     G_CALLBACK (dt_iop_colorbalance_leave_notify), self);
-
-  area = dtgtk_drawing_area_new_with_height(0);
-  gtk_box_pack_start(GTK_BOX(hbox), area, TRUE, TRUE, 0);
-
-  //   gtk_widget_add_events(g->area,
-  //                         GDK_POINTER_MOTION_MASK |
-  //                         GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK | GDK_LEAVE_NOTIFY_MASK);
-  g_signal_connect(G_OBJECT(area), "draw", G_CALLBACK(dt_iop_area_draw), self);
-  //   g_signal_connect (G_OBJECT (area), "button-press-event",
-  //                     G_CALLBACK (dt_iop_colorbalance_button_press), self);
-  //   g_signal_connect (G_OBJECT (area), "motion-notify-event",
-  //                     G_CALLBACK (dt_iop_colorbalance_motion_notify), self);
-  //   g_signal_connect (G_OBJECT (area), "leave-notify-event",
-  //                     G_CALLBACK (dt_iop_colorbalance_leave_notify), self);
-
-  area = dtgtk_drawing_area_new_with_height(0);
-  gtk_box_pack_start(GTK_BOX(hbox), area, TRUE, TRUE, 0);
-
-  //   gtk_widget_add_events(g->area,
-  //                         GDK_POINTER_MOTION_MASK |
-  //                         GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK | GDK_LEAVE_NOTIFY_MASK);
-  g_signal_connect(G_OBJECT(area), "draw", G_CALLBACK(dt_iop_area_draw), self);
-//   g_signal_connect (G_OBJECT (area), "button-press-event",
-//                     G_CALLBACK (dt_iop_colorbalance_button_press), self);
-//   g_signal_connect (G_OBJECT (area), "motion-notify-event",
-//                     G_CALLBACK (dt_iop_colorbalance_motion_notify), self);
-//   g_signal_connect (G_OBJECT (area), "leave-notify-event",
-//                     G_CALLBACK (dt_iop_colorbalance_leave_notify), self);
-#endif
-
   g->main_label = dt_ui_section_label_new(""); // is set in _configure_slider_blocks
   gtk_widget_set_tooltip_text(g->main_label, _("click to cycle layout"));
   GtkWidget *main_label_box = gtk_event_box_new();
@@ -1964,7 +1915,7 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_widget_set_label(g->which##_##c, section, #n);                 \
 
 #define ADD_BLOCK(blk, which, section, text, span, satspan)                 \
-  g->blocks[blk] = self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0); \
+  g->blocks[blk] = self->widget = dt_gui_vbox();                            \
                                                                             \
   sprintf(field_name, "%s[%d]", #which, CHANNEL_FACTOR);                    \
   g->which##_factor = dt_color_picker_new(self, DT_COLOR_PICKER_AREA,       \
@@ -1995,7 +1946,6 @@ void gui_init(dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->hue_##which, _("select the hue"));         \
   g_signal_connect(G_OBJECT(g->hue_##which), "value-changed",               \
                    G_CALLBACK(which##_callback), self);                     \
-  gtk_box_pack_start(GTK_BOX(self->widget), g->hue_##which, TRUE, TRUE, 0); \
                                                                             \
   g->sat_##which = dt_bauhaus_slider_new_with_range_and_feedback(self,      \
                    0.0f, 100.0f, 0, 0.0f, 2, 0);                            \
@@ -2007,7 +1957,8 @@ void gui_init(dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->sat_##which, _("select the saturation"));  \
   g_signal_connect(G_OBJECT(g->sat_##which), "value-changed",               \
                    G_CALLBACK(which##_callback), self);                     \
-  gtk_box_pack_start(GTK_BOX(self->widget), g->sat_##which, TRUE, TRUE, 0); \
+                                                                            \
+  dt_gui_box_add(self->widget, g->hue_##which, g->sat_##which);             \
                                                                             \
   ADD_CHANNEL(which, section, r, red, RED, text, span)                      \
   dt_bauhaus_slider_set_stop(g->which##_r, 0.0, 0.0, 1.0, 1.0);             \
@@ -2045,30 +1996,25 @@ void gui_init(dt_iop_module_t *self)
   ADD_BLOCK(2, gain,  N_("highlights"), gain_messages,  0.5f, 25.0f)
   _configure_slider_blocks(NULL, self);
 
-  g->optimizer_box = self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
-
-  gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(C_("section", "auto optimizers")), FALSE, FALSE, 0);
-
   g->auto_luma = dt_color_picker_new(self, DT_COLOR_PICKER_AREA,
                  dt_bauhaus_combobox_new(self));
   dt_bauhaus_widget_set_label(g->auto_luma, NULL, N_("optimize luma"));
   gtk_widget_set_tooltip_text(g->auto_luma, _("fit the whole histogram and center the average luma"));
-  gtk_box_pack_start(GTK_BOX(self->widget), g->auto_luma, FALSE, FALSE, 0);
 
   g->auto_color = dt_color_picker_new(self, DT_COLOR_PICKER_AREA,
                   dt_bauhaus_combobox_new(self));
   dt_bauhaus_widget_set_label(g->auto_color, NULL, N_("neutralize colors"));
   gtk_widget_set_tooltip_text(g->auto_color, _("optimize the RGB curves to remove color casts"));
-  gtk_box_pack_start(GTK_BOX(self->widget), g->auto_color, FALSE, FALSE, 0);
+
+  g->optimizer_box = dt_gui_vbox(dt_ui_section_label_new(C_("section", "auto optimizers")),
+                                 g->auto_luma, g->auto_color);
 
   // start building top level widget
-  self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
-
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(mode_box), TRUE, TRUE, 0);
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->master_box), TRUE, TRUE, 0);
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(main_label_box), TRUE, TRUE, 0);
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->main_box), TRUE, TRUE, 0);
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->optimizer_box), TRUE, TRUE, 0);
+  self->widget = dt_gui_vbox(mode_box,
+                             g->master_box,
+                             main_label_box,
+                             g->main_box,
+                             g->optimizer_box);
 
   DT_CONTROL_SIGNAL_HANDLE(DT_SIGNAL_PREFERENCES_CHANGE, _configure_slider_blocks);
 }

--- a/src/iop/colorcorrection.c
+++ b/src/iop/colorcorrection.c
@@ -236,16 +236,12 @@ void gui_init(dt_iop_module_t *self)
 
   g->selected = 0;
 
-  self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
-
   g->area = GTK_DRAWING_AREA(dtgtk_drawing_area_new_with_height(0));
   g_object_set_data(G_OBJECT(g->area), "iop-instance", self);
   dt_action_define_iop(self, NULL, N_("grid"), GTK_WIDGET(g->area), NULL);
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->area), TRUE, TRUE, 0);
   gtk_widget_set_tooltip_text(GTK_WIDGET(g->area), _("drag the line for split-toning. "
                                                      "bright means highlights, dark means shadows. "
                                                      "use mouse wheel to change saturation."));
-
   gtk_widget_add_events(GTK_WIDGET(g->area), GDK_POINTER_MOTION_MASK | darktable.gui->scroll_mask
                                            | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK
                                            | GDK_ENTER_NOTIFY_MASK | GDK_LEAVE_NOTIFY_MASK);
@@ -260,6 +256,7 @@ void gui_init(dt_iop_module_t *self)
   g_signal_connect(G_OBJECT(g->area), "scroll-event", G_CALLBACK(dt_iop_colorcorrection_scrolled), self);
   g_signal_connect(G_OBJECT(g->area), "key-press-event", G_CALLBACK(dt_iop_colorcorrection_key_press), self);
 
+  self->widget = dt_gui_vbox(g->area);
   g->slider = dt_bauhaus_slider_from_params(self, N_("saturation"));
   gtk_widget_set_tooltip_text(g->slider, _("set the global saturation"));
 

--- a/src/iop/colorequal.c
+++ b/src/iop/colorequal.c
@@ -3059,7 +3059,7 @@ void gui_init(dt_iop_module_t *self)
   dt_iop_module_t *sect = NULL;
 #define GROUP_SLIDERS(num, page, tooltip)                  \
   dt_ui_notebook_page(g->notebook, page, tooltip);         \
-  self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0); \
+  self->widget = dt_gui_vbox();                            \
   gtk_stack_add_named(g->stack, self->widget, num);        \
   sect = DT_IOP_SECTION_FOR_PARAMS(self, page);
 
@@ -3117,7 +3117,7 @@ void gui_init(dt_iop_module_t *self)
   g->bright_sliders[7] = g->bright_magenta =
     dt_bauhaus_slider_from_params(sect, "bright_magenta");
 
-  GtkWidget *options = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
+  GtkWidget *options = dt_gui_vbox();
   gtk_stack_add_named(g->stack, options, "3");
   dt_gui_new_collapsible_section
     (&g->cs,

--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -2055,15 +2055,13 @@ void gui_init(dt_iop_module_t *self)
 
   g->image_profiles = NULL;
 
-  self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
-
   g->profile_combobox = dt_bauhaus_combobox_new(self);
   dt_bauhaus_widget_set_label(g->profile_combobox, NULL, N_("input profile"));
-  gtk_box_pack_start(GTK_BOX(self->widget), g->profile_combobox, TRUE, TRUE, 0);
 
   g->work_combobox = dt_bauhaus_combobox_new(self);
   dt_bauhaus_widget_set_label(g->work_combobox, NULL, N_("working profile"));
-  gtk_box_pack_start(GTK_BOX(self->widget), g->work_combobox, TRUE, TRUE, 0);
+
+  self->widget = dt_gui_vbox(g->profile_combobox, g->work_combobox);
 
   dt_bauhaus_combobox_set(g->profile_combobox, 0);
   // We do not set the tooltip for the input profile widget because

--- a/src/iop/colorout.c
+++ b/src/iop/colorout.c
@@ -834,8 +834,6 @@ void gui_init(dt_iop_module_t *self)
 
   dt_iop_colorout_gui_data_t *g = IOP_GUI_ALLOC(colorout);
 
-  self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
-
   DT_BAUHAUS_COMBOBOX_NEW_FULL(g->output_intent, self, NULL, N_("output intent"),
                                _("rendering intent"),
                                0, intent_changed, self,
@@ -843,7 +841,6 @@ void gui_init(dt_iop_module_t *self)
                                N_("relative colorimetric"),
                                NC_("rendering intent", "saturation"),
                                N_("absolute colorimetric"));
-  gtk_box_pack_start(GTK_BOX(self->widget), g->output_intent, TRUE, TRUE, 0);
 
   if(!force_lcms2)
   {
@@ -853,7 +850,6 @@ void gui_init(dt_iop_module_t *self)
 
   g->output_profile = dt_bauhaus_combobox_new(self);
   dt_bauhaus_widget_set_label(g->output_profile, NULL, N_("export profile"));
-  gtk_box_pack_start(GTK_BOX(self->widget), g->output_profile, TRUE, TRUE, 0);
   for(GList *l = darktable.color_profiles->profiles; l; l = g_list_next(l))
   {
     dt_colorspaces_color_profile_t *prof = l->data;
@@ -863,6 +859,8 @@ void gui_init(dt_iop_module_t *self)
   char *tooltip = dt_ioppr_get_location_tooltip("out", _("export ICC profiles"));
   gtk_widget_set_tooltip_markup(g->output_profile, tooltip);
   g_free(tooltip);
+
+  self->widget = dt_gui_vbox(g->output_intent, g->output_profile);
 
   g_signal_connect(G_OBJECT(g->output_profile), "value-changed",
                    G_CALLBACK(output_profile_changed), (gpointer)self);

--- a/src/iop/colorreconstruction.c
+++ b/src/iop/colorreconstruction.c
@@ -1224,7 +1224,7 @@ void gui_init(dt_iop_module_t *self)
   g->can = NULL;
   g->hash = DT_INVALID_HASH;
 
-  GtkWidget *box_enabled = self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
+  GtkWidget *box_enabled = self->widget = dt_gui_vbox();
 
   g->threshold = dt_bauhaus_slider_from_params(self, N_("threshold"));
   g->spatial = dt_bauhaus_slider_from_params(self, N_("spatial"));

--- a/src/iop/crop.c
+++ b/src/iop/crop.c
@@ -1147,8 +1147,6 @@ void gui_init(dt_iop_module_t *self)
   g->ctrl_hold = FALSE;
   g->preview_ready = FALSE;
 
-  GtkWidget *box_enabled = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
-
   dt_iop_crop_aspect_t aspects[] = {
     { _("freehand"), 0, 0 },
     { _("original image"), 1, 0 },
@@ -1280,7 +1278,8 @@ void gui_init(dt_iop_module_t *self)
        "to enter custom aspect ratio open the combobox and type ratio in x:y"
        " or decimal format"));
   dt_bauhaus_widget_set_quad(g->aspect_presets, self, dtgtk_cairo_paint_aspectflip, FALSE, _event_aspect_flip, NULL);
-  gtk_box_pack_start(GTK_BOX(box_enabled), g->aspect_presets, TRUE, TRUE, 0);
+
+  GtkWidget *box_enabled = dt_gui_vbox(g->aspect_presets);
 
   // we put margins values under an expander
   dt_gui_new_collapsible_section

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -1636,7 +1636,7 @@ void gui_init(dt_iop_module_t *self)
 {
   dt_iop_demosaic_gui_data_t *g = IOP_GUI_ALLOC(demosaic);
 
-  GtkWidget *box_raw = self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
+  GtkWidget *box_raw = self->widget = dt_gui_vbox();
 
   g->demosaic_method_bayer = dt_bauhaus_combobox_from_params(self, "demosaicing_method");
 

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -3648,7 +3648,7 @@ void gui_init(dt_iop_module_t *self)
   g->channel = 0;
 
   // First build sub-level boxes
-  g->box_nlm = self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
+  g->box_nlm = self->widget = dt_gui_vbox();
 
   g->radius = dt_bauhaus_slider_from_params(self, "radius");
   dt_bauhaus_slider_set_soft_range(g->radius, 0.0, 8.0);
@@ -3660,7 +3660,7 @@ void gui_init(dt_iop_module_t *self)
   g->central_pixel_weight = dt_bauhaus_slider_from_params(self, "central_pixel_weight");
   dt_bauhaus_slider_set_soft_max(g->central_pixel_weight, 1.0f);
 
-  g->box_wavelets = self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
+  g->box_wavelets = self->widget = dt_gui_vbox();
 
   g->wavelet_color_mode = dt_bauhaus_combobox_from_params(self, "wavelet_color_mode");
 

--- a/src/iop/dither.c
+++ b/src/iop/dither.c
@@ -81,7 +81,6 @@ typedef struct dt_iop_dither_params_t
 typedef struct dt_iop_dither_gui_data_t
 {
   GtkWidget *dither_type;
-  GtkWidget *random;
   GtkWidget *radius;
   GtkWidget *range;
   GtkWidget *range_label;
@@ -684,34 +683,9 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
 
   if(w == g->dither_type)
   {
-    gtk_widget_set_visible(g->random, p->dither_type == DITHER_RANDOM);
+    gtk_widget_set_visible(g->damping, p->dither_type == DITHER_RANDOM);
   }
 }
-
-#if 0
-static void
-_radius_callback (GtkWidget *slider, dt_iop_module_t *self)
-{
-  if(darktable.gui->reset) return;
-  dt_iop_dither_params_t *p = self->params;
-  p->random.radius = dt_bauhaus_slider_get(slider);
-  dt_dev_add_history_item(darktable.develop, self, TRUE);
-}
-#endif
-
-#if 0
-static void
-_range_callback (GtkWidget *slider, dt_iop_module_t *self)
-{
-  if(darktable.gui->reset) return;
-  dt_iop_dither_params_t *p = self->params;
-  p->random.range[0] = dtgtk_gradient_slider_multivalue_get_value(DTGTK_GRADIENT_SLIDER(slider), 0);
-  p->random.range[1] = dtgtk_gradient_slider_multivalue_get_value(DTGTK_GRADIENT_SLIDER(slider), 1);
-  p->random.range[2] = dtgtk_gradient_slider_multivalue_get_value(DTGTK_GRADIENT_SLIDER(slider), 2);
-  p->random.range[3] = dtgtk_gradient_slider_multivalue_get_value(DTGTK_GRADIENT_SLIDER(slider), 3);
-  dt_dev_add_history_item(darktable.develop, self, TRUE);
-}
-#endif
 
 void commit_params(
         dt_iop_module_t *self,
@@ -753,60 +727,19 @@ void gui_update(dt_iop_module_t *self)
   dtgtk_gradient_slider_multivalue_set_value(DTGTK_GRADIENT_SLIDER(g->range), p->random.range[3], 3);
 #endif
 
-  gtk_widget_set_visible(g->random, p->dither_type == DITHER_RANDOM);
+  gtk_widget_set_visible(g->damping, p->dither_type == DITHER_RANDOM);
 }
 
 void gui_init(dt_iop_module_t *self)
 {
   dt_iop_dither_gui_data_t *g = IOP_GUI_ALLOC(dither);
 
-  g->random = self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
-
-#if 0
-  g->radius = dt_bauhaus_slider_new_with_range(self, 0.0, 200.0, 0.1, p->random.radius, 2);
-  gtk_widget_set_tooltip_text(g->radius, _("radius for blurring step"));
-  dt_bauhaus_widget_set_label(g->radius, NULL, N_("radius"));
-
-  g->range = dtgtk_gradient_slider_multivalue_new(4);
-  dtgtk_gradient_slider_multivalue_set_marker(DTGTK_GRADIENT_SLIDER(g->range), GRADIENT_SLIDER_MARKER_LOWER_OPEN_BIG, 0);
-  dtgtk_gradient_slider_multivalue_set_marker(DTGTK_GRADIENT_SLIDER(g->range), GRADIENT_SLIDER_MARKER_UPPER_FILLED_BIG, 1);
-  dtgtk_gradient_slider_multivalue_set_marker(DTGTK_GRADIENT_SLIDER(g->range), GRADIENT_SLIDER_MARKER_UPPER_FILLED_BIG, 2);
-  dtgtk_gradient_slider_multivalue_set_marker(DTGTK_GRADIENT_SLIDER(g->range), GRADIENT_SLIDER_MARKER_LOWER_OPEN_BIG, 3);
-  dtgtk_gradient_slider_multivalue_set_value(DTGTK_GRADIENT_SLIDER(g->range), p->random.range[0], 0);
-  dtgtk_gradient_slider_multivalue_set_value(DTGTK_GRADIENT_SLIDER(g->range), p->random.range[1], 1);
-  dtgtk_gradient_slider_multivalue_set_value(DTGTK_GRADIENT_SLIDER(g->range), p->random.range[2], 2);
-  dtgtk_gradient_slider_multivalue_set_value(DTGTK_GRADIENT_SLIDER(g->range), p->random.range[3], 3);
-  gtk_widget_set_tooltip_text(g->range, _("the gradient range where to apply random dither"));
-  g->range_label = gtk_label_new(_("gradient range"));
-
-  GtkWidget *rlabel = gtk_box_new(GTK_ORIENTATION_HORIZONTAL,0);
-  gtk_box_pack_start(GTK_BOX(rlabel), GTK_WIDGET(g->range_label), FALSE, FALSE, 0);
-#endif
-
   g->damping = dt_bauhaus_slider_from_params(self, "random.damping");
-
   gtk_widget_set_tooltip_text(g->damping, _("damping level of random dither"));
   dt_bauhaus_slider_set_digits(g->damping, 3);
   dt_bauhaus_slider_set_format(g->damping, " dB");
 
-#if 0
-  gtk_box_pack_start(GTK_BOX(g->random), g->radius, TRUE, TRUE, 0);
-  gtk_box_pack_start(GTK_BOX(g->random), rlabel, TRUE, TRUE, 0);
-  gtk_box_pack_start(GTK_BOX(g->random), g->range, TRUE, TRUE, 0);
-#endif
-
-  self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
-
   g->dither_type = dt_bauhaus_combobox_from_params(self, "dither_type");
-
-  gtk_box_pack_start(GTK_BOX(self->widget), g->random, TRUE, TRUE, 0);
-
-#if 0
-  g_signal_connect (G_OBJECT (g->radius), "value-changed",
-                    G_CALLBACK (_radius_callback), self);
-  g_signal_connect (G_OBJECT (g->range), "value-changed",
-                    G_CALLBACK (_range_callback), self);
-#endif
 }
 
 // clang-format off

--- a/src/iop/enlargecanvas.c
+++ b/src/iop/enlargecanvas.c
@@ -411,8 +411,6 @@ void gui_init(dt_iop_module_t *self)
 {
   dt_iop_enlargecanvas_gui_data_t *g = IOP_GUI_ALLOC(enlargecanvas);
 
-  self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
-
   g->percent_left = dt_bauhaus_slider_from_params(self, "percent_left");
   dt_bauhaus_slider_set_format(g->percent_left, "%");
   gtk_widget_set_tooltip_text(g->percent_left,

--- a/src/iop/filmic.c
+++ b/src/iop/filmic.c
@@ -1456,21 +1456,15 @@ void gui_init(dt_iop_module_t *self)
   dt_iop_filmic_gui_data_t *g = IOP_GUI_ALLOC(filmic);
   const dt_iop_filmic_params_t *const p = self->default_params;
 
-  self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
-
   // don't make the area square to safe some vertical space -- it's not interactive anyway
   g->area = GTK_DRAWING_AREA(dtgtk_drawing_area_new_with_aspect_ratio(0.618));
   gtk_widget_set_tooltip_text(GTK_WIDGET(g->area), _("read-only graph, use the parameters below to set the nodes"));
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->area), TRUE, TRUE, 0);
   g_signal_connect(G_OBJECT(g->area), "draw", G_CALLBACK(dt_iop_tonecurve_draw), self);
-
-  gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(C_("section", "logarithmic shaper")), FALSE, FALSE, 0);
 
   // grey_point_source slider
   g->grey_point_source = dt_bauhaus_slider_new_with_range(self, 0.0, 100., 0, p->grey_point_source, 2);
   dt_bauhaus_slider_set_soft_range(g->grey_point_source, 0.1, 36.0);
   dt_bauhaus_widget_set_label(g->grey_point_source, NULL, N_("middle gray luminance"));
-  gtk_box_pack_start(GTK_BOX(self->widget), g->grey_point_source, TRUE, TRUE, 0);
   dt_bauhaus_slider_set_format(g->grey_point_source, "%");
   gtk_widget_set_tooltip_text(g->grey_point_source, _("adjust to match the average luminance of the subject.\n"
                                                       "except in back-lighting situations, this should be around 18%."));
@@ -1482,7 +1476,6 @@ void gui_init(dt_iop_module_t *self)
   g->white_point_source = dt_bauhaus_slider_new_with_range(self, 0.0, 16.0, 0, p->white_point_source, 2);
   dt_bauhaus_slider_set_soft_range(g->white_point_source, 2.0, 8.0);
   dt_bauhaus_widget_set_label(g->white_point_source, NULL, N_("white relative exposure"));
-  gtk_box_pack_start(GTK_BOX(self->widget), g->white_point_source, TRUE, TRUE, 0);
   dt_bauhaus_slider_set_format(g->white_point_source, _(" EV"));
   gtk_widget_set_tooltip_text(g->white_point_source, _("number of stops between middle gray and pure white.\n"
                                                        "this is a reading a lightmeter would give you on the scene.\n"
@@ -1495,7 +1488,6 @@ void gui_init(dt_iop_module_t *self)
   g->black_point_source = dt_bauhaus_slider_new_with_range(self, -16.0, -0.1, 0, p->black_point_source, 2);
   dt_bauhaus_slider_set_soft_range(g->black_point_source, -14.0, -3.0);
   dt_bauhaus_widget_set_label(g->black_point_source, NULL, N_("black relative exposure"));
-  gtk_box_pack_start(GTK_BOX(self->widget), g->black_point_source, TRUE, TRUE, 0);
   dt_bauhaus_slider_set_format(g->black_point_source, _(" EV"));
   gtk_widget_set_tooltip_text(g->black_point_source, _("number of stops between middle gray and pure black.\n"
                                                        "this is a reading a lightmeter would give you on the scene.\n"
@@ -1507,7 +1499,6 @@ void gui_init(dt_iop_module_t *self)
   // Security factor
   g->security_factor = dt_bauhaus_slider_new_with_range(self, -50., 50., 0, p->security_factor, 2);
   dt_bauhaus_widget_set_label(g->security_factor, NULL, N_("safety factor"));
-  gtk_box_pack_start(GTK_BOX(self->widget), g->security_factor, TRUE, TRUE, 0);
   dt_bauhaus_slider_set_format(g->security_factor, "%");
   gtk_widget_set_tooltip_text(g->security_factor, _("increase or decrease the computed dynamic range.\n"
                                                     "useful in conjunction with \"auto tune levels\"."));
@@ -1521,15 +1512,11 @@ void gui_init(dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->auto_button, _("try to optimize the settings with some guessing.\n"
                                                 "this will fit the luminance range inside the histogram bounds.\n"
                                                 "works better for landscapes and evenly-lit images\nbut fails for high-keys and low-keys." ));
-  gtk_box_pack_start(GTK_BOX(self->widget), g->auto_button, TRUE, TRUE, 0);
-
-  gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(C_("section", "filmic S curve")), FALSE, FALSE, 0);
 
   // contrast slider
   g->contrast = dt_bauhaus_slider_new_with_range(self, 0., 5., 0, p->contrast, 3);
   dt_bauhaus_slider_set_soft_range(g->contrast, 1.0, 2.0);
   dt_bauhaus_widget_set_label(g->contrast, NULL, N_("contrast"));
-  gtk_box_pack_start(GTK_BOX(self->widget), g->contrast, TRUE, TRUE, 0);
   gtk_widget_set_tooltip_text(g->contrast, _("slope of the linear part of the curve\n"
                                              "affects mostly the mid-tones"));
   g_signal_connect(G_OBJECT(g->contrast), "value-changed", G_CALLBACK(contrast_callback), self);
@@ -1539,7 +1526,6 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_slider_set_soft_range(g->latitude_stops, 2, 8.0);
   dt_bauhaus_widget_set_label(g->latitude_stops, NULL, N_("latitude"));
   dt_bauhaus_slider_set_format(g->latitude_stops, _(" EV"));
-  gtk_box_pack_start(GTK_BOX(self->widget), g->latitude_stops, TRUE, TRUE, 0);
   gtk_widget_set_tooltip_text(g->latitude_stops, _("width of the linear domain in the middle of the curve.\n"
                                                    "increase to get more contrast at the extreme luminances.\n"
                                                    "this has no effect on mid-tones."));
@@ -1548,7 +1534,6 @@ void gui_init(dt_iop_module_t *self)
   // balance slider
   g->balance = dt_bauhaus_slider_new_with_range(self, -50., 50., 0, p->balance, 2);
   dt_bauhaus_widget_set_label(g->balance, NULL, N_("shadows/highlights balance"));
-  gtk_box_pack_start(GTK_BOX(self->widget), g->balance, TRUE, TRUE, 0);
   dt_bauhaus_slider_set_format(g->balance, "%");
   gtk_widget_set_tooltip_text(g->balance, _("slides the latitude along the slope\nto give more room to shadows or highlights.\n"
                                             "use it if you need to protect the details\nat one extremity of the histogram."));
@@ -1559,7 +1544,6 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_widget_set_label(g->global_saturation, NULL, N_("global saturation"));
   dt_bauhaus_slider_set_soft_range(g->global_saturation, 0.0, 200.0);
   dt_bauhaus_slider_set_format(g->global_saturation, "%");
-  gtk_box_pack_start(GTK_BOX(self->widget), g->global_saturation, TRUE, TRUE, 0);
   gtk_widget_set_tooltip_text(g->global_saturation, _("desaturates the input of the module globally.\n"
                                                       "you need to set this value below 100%\nif the chrominance preservation is enabled."));
   g_signal_connect(G_OBJECT(g->global_saturation), "value-changed", G_CALLBACK(global_saturation_callback), self);
@@ -1569,7 +1553,6 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_widget_set_label(g->saturation, NULL, N_("extreme luminance saturation"));
   dt_bauhaus_slider_set_soft_range(g->saturation, 0.0, 200.0);
   dt_bauhaus_slider_set_format(g->saturation, "%");
-  gtk_box_pack_start(GTK_BOX(self->widget), g->saturation, TRUE, TRUE, 0);
   gtk_widget_set_tooltip_text(g->saturation, _("desaturates the output of the module\nspecifically at extreme luminances.\n"
                                                "decrease if shadows and/or highlights are over-saturated."));
   g_signal_connect(G_OBJECT(g->saturation), "value-changed", G_CALLBACK(saturation_callback), self);
@@ -1585,7 +1568,6 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_combobox_add(g->interpolator, _("faded")); // centripetal spline
   dt_bauhaus_combobox_add(g->interpolator, _("linear")); // monotonic spline
   dt_bauhaus_combobox_add(g->interpolator, _("optimized")); // monotonic spline
-  gtk_box_pack_start(GTK_BOX(self->widget), g->interpolator , TRUE, TRUE, 0);
   gtk_widget_set_tooltip_text(g->interpolator, _("change this method if you see reversed contrast or faded blacks"));
   g_signal_connect(G_OBJECT(g->interpolator), "value-changed", G_CALLBACK(interpolator_callback), self);
 
@@ -1595,30 +1577,11 @@ void gui_init(dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->preserve_color, _("ensure the original color are preserved.\n"
                                                    "may reinforce chromatic aberrations.\n"
                                                    "you need to manually tune the saturation when using this mode."));
-  gtk_box_pack_start(GTK_BOX(self->widget), g->preserve_color , TRUE, TRUE, 0);
   g_signal_connect(G_OBJECT(g->preserve_color), "toggled", G_CALLBACK(preserve_color_callback), self);
-
-
-  // add collapsible section for those extra options that are generally not to be used
-
-  GtkWidget *destdisp_head = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, DT_BAUHAUS_SPACE);
-  GtkWidget *destdisp = dt_ui_section_label_new(C_("section", "destination/display"));
-  g->extra_toggle = dtgtk_togglebutton_new(dtgtk_cairo_paint_solid_arrow, CPF_DIRECTION_LEFT, NULL);
-  GtkWidget *extra_options = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
-  gtk_box_pack_start(GTK_BOX(destdisp_head), destdisp, TRUE, TRUE, 0);
-  gtk_box_pack_start(GTK_BOX(destdisp_head), g->extra_toggle, FALSE, FALSE, 0);
-  gtk_widget_set_visible(extra_options, FALSE);
-  g->extra_expander = dtgtk_expander_new(destdisp_head, extra_options);
-  dtgtk_expander_set_expanded(DTGTK_EXPANDER(g->extra_expander), TRUE);
-  gtk_box_pack_start(GTK_BOX(self->widget), g->extra_expander, FALSE, FALSE, 0);
-  dt_gui_add_class(self->widget, "dt_transparent_background");
-
-  g_signal_connect(G_OBJECT(g->extra_toggle), "toggled", G_CALLBACK(_extra_options_button_changed),  (gpointer)self);
 
   // Black slider
   g->black_point_target = dt_bauhaus_slider_new_with_range(self, 0.0, 100.0, 0, p->black_point_target, 2);
   dt_bauhaus_widget_set_label(g->black_point_target, NULL, N_("target black luminance"));
-  gtk_box_pack_start(GTK_BOX(extra_options), g->black_point_target, FALSE, FALSE, 0);
   dt_bauhaus_slider_set_format(g->black_point_target, "%");
   gtk_widget_set_tooltip_text(g->black_point_target, _("luminance of output pure black, "
                                                         "this should be 0%\nexcept if you want a faded look"));
@@ -1627,7 +1590,6 @@ void gui_init(dt_iop_module_t *self)
   // grey_point_source slider
   g->grey_point_target = dt_bauhaus_slider_new_with_range(self, 0.1, 50., 0, p->grey_point_target, 2);
   dt_bauhaus_widget_set_label(g->grey_point_target, NULL, N_("target middle gray"));
-  gtk_box_pack_start(GTK_BOX(extra_options), g->grey_point_target, FALSE, FALSE, 0);
   dt_bauhaus_slider_set_format(g->grey_point_target, "%");
   gtk_widget_set_tooltip_text(g->grey_point_target, _("middle gray value of the target display or color space.\n"
                                                       "you should never touch that unless you know what you are doing."));
@@ -1636,7 +1598,6 @@ void gui_init(dt_iop_module_t *self)
   // White slider
   g->white_point_target = dt_bauhaus_slider_new_with_range(self, 0.0, 100.0, 0, p->white_point_target, 2);
   dt_bauhaus_widget_set_label(g->white_point_target, NULL, N_("target white luminance"));
-  gtk_box_pack_start(GTK_BOX(extra_options), g->white_point_target, FALSE, FALSE, 0);
   dt_bauhaus_slider_set_format(g->white_point_target, "%");
   gtk_widget_set_tooltip_text(g->white_point_target, _("luminance of output pure white, "
                                                         "this should be 100%\nexcept if you want a faded look"));
@@ -1645,10 +1606,38 @@ void gui_init(dt_iop_module_t *self)
   // power/gamma slider
   g->output_power = dt_bauhaus_slider_new_with_range(self, 1.0, 2.4, 0, p->output_power, 2);
   dt_bauhaus_widget_set_label(g->output_power, NULL, N_("target gamma"));
-  gtk_box_pack_start(GTK_BOX(extra_options), g->output_power, FALSE, FALSE, 0);
   gtk_widget_set_tooltip_text(g->output_power, _("power or gamma of the transfer function\nof the display or color space.\n"
                                                  "you should never touch that unless you know what you are doing."));
   g_signal_connect(G_OBJECT(g->output_power), "value-changed", G_CALLBACK(output_power_callback), self);
+
+  // add collapsible section for those extra options that are generally not to be used
+  g->extra_toggle = dtgtk_togglebutton_new(dtgtk_cairo_paint_solid_arrow, CPF_DIRECTION_LEFT, NULL);
+  g_signal_connect(G_OBJECT(g->extra_toggle), "toggled", G_CALLBACK(_extra_options_button_changed),  (gpointer)self);
+  g->extra_expander = dtgtk_expander_new(dt_gui_hbox(dt_ui_section_label_new(C_("section", "destination/display")), 
+                                                     g->extra_toggle), 
+                                         dt_gui_vbox(g->black_point_target,
+                                                     g->grey_point_target,
+                                                     g->white_point_target,
+                                                     g->output_power));
+  dtgtk_expander_set_expanded(DTGTK_EXPANDER(g->extra_expander), TRUE);
+
+  self->widget = dt_gui_vbox(g->area,
+                             dt_ui_section_label_new(C_("section", "logarithmic shaper")),
+                             g->grey_point_source,
+                             g->white_point_source,
+                             g->black_point_source,
+                             g->security_factor,
+                             g->auto_button,
+                             dt_ui_section_label_new(C_("section", "filmic S curve")),
+                             g->contrast,
+                             g->latitude_stops,
+                             g->balance,
+                             g->global_saturation,
+                             g->saturation,
+                             g->interpolator,
+                             g->preserve_color,
+                             g->extra_expander);
+  dt_gui_add_class(self->widget, "dt_transparent_background");
 }
 
 

--- a/src/iop/flip.c
+++ b/src/iop/flip.c
@@ -598,11 +598,9 @@ void gui_init(dt_iop_module_t *self)
   self->gui_data = NULL;
   dt_iop_flip_params_t *p = self->params;
 
-  self->widget = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-
   GtkWidget *label = dtgtk_reset_label_new(_("transform"),
                                            self, &p->orientation, sizeof(int32_t));
-  gtk_box_pack_start(GTK_BOX(self->widget), label, TRUE, TRUE, 0);
+  self->widget = dt_gui_hbox(label);
 
   dt_iop_button_new(self, N_("rotate 90 degrees CCW"),
                     G_CALLBACK(rotate_ccw), FALSE, GDK_KEY_bracketleft, 0,

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -1296,7 +1296,7 @@ void gui_focus(dt_iop_module_t *self, gboolean in)
 void gui_init(dt_iop_module_t *self)
 {
   dt_iop_highlights_gui_data_t *g = IOP_GUI_ALLOC(highlights);
-  GtkWidget *box_raw = self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
+  GtkWidget *box_raw = self->widget = dt_gui_vbox();
 
   g->mode = dt_bauhaus_combobox_from_params(self, "mode");
   gtk_widget_set_tooltip_text(g->mode, _("highlight reconstruction method"));

--- a/src/iop/hotpixels.c
+++ b/src/iop/hotpixels.c
@@ -436,7 +436,7 @@ void gui_init(dt_iop_module_t *self)
 
   g->pixels_fixed = -1;
 
-  GtkWidget *box_raw = self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
+  GtkWidget *box_raw = self->widget = dt_gui_vbox();
   g_signal_connect(G_OBJECT(box_raw), "draw", G_CALLBACK(draw), self);
 
   g->threshold = dt_bauhaus_slider_from_params(self, N_("threshold"));
@@ -451,11 +451,11 @@ void gui_init(dt_iop_module_t *self)
   g->permissive = GTK_TOGGLE_BUTTON(dt_bauhaus_toggle_from_params(self, "permissive"));
 
   // mark fixed pixels
-  GtkWidget *hbox = self->widget = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
+  GtkWidget *hbox = self->widget = dt_gui_hbox();
   g->markfixed = GTK_TOGGLE_BUTTON(dt_bauhaus_toggle_from_params(self, "markfixed"));
   g->message = GTK_LABEL(gtk_label_new("")); // This gets filled in by process
-  gtk_box_pack_start(GTK_BOX(hbox), GTK_WIDGET(g->message), TRUE, TRUE, 0);
-  gtk_box_pack_start(GTK_BOX(box_raw), hbox, TRUE, TRUE, 0);
+  dt_gui_box_add(hbox, g->message);
+  dt_gui_box_add(box_raw, hbox);
 
   // start building top level widget
   self->widget = gtk_stack_new();

--- a/src/iop/invert.c
+++ b/src/iop/invert.c
@@ -40,7 +40,6 @@ typedef struct dt_iop_invert_gui_data_t
 {
   GtkWidget *colorpicker;
   GtkDarktableResetLabel *label;
-  GtkBox *pickerbuttons;
   GtkWidget *picker;
   double RGB_to_CAM[4][3];
   double CAM_to_RGB[3][4];
@@ -487,12 +486,7 @@ void gui_init(dt_iop_module_t *self)
   dt_iop_invert_gui_data_t *g = IOP_GUI_ALLOC(invert);
   dt_iop_invert_params_t *p = self->params;
 
-  self->widget = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
   g->label = DTGTK_RESET_LABEL(dtgtk_reset_label_new("", self, &p->color, sizeof(float) * 4));
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->label), TRUE, TRUE, 0);
-
-  g->pickerbuttons = GTK_BOX(gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0));
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->pickerbuttons), TRUE, TRUE, 0);
 
   GdkRGBA color = (GdkRGBA){.red = p->color[0], .green = p->color[1], .blue = p->color[2], .alpha = 1.0 };
   g->colorpicker = gtk_color_button_new_with_rgba(&color);
@@ -500,9 +494,10 @@ void gui_init(dt_iop_module_t *self)
   gtk_color_chooser_set_use_alpha(GTK_COLOR_CHOOSER(g->colorpicker), FALSE);
   gtk_color_button_set_title(GTK_COLOR_BUTTON(g->colorpicker), _("select color of film material"));
   g_signal_connect(G_OBJECT(g->colorpicker), "color-set", G_CALLBACK(colorpicker_callback), self);
-  gtk_box_pack_start(GTK_BOX(g->pickerbuttons), GTK_WIDGET(g->colorpicker), TRUE, TRUE, 0);
 
-  g->picker = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, GTK_WIDGET(g->pickerbuttons));
+  g->picker = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, NULL);
+
+  self->widget = dt_gui_hbox(dt_gui_expand(g->label), dt_gui_expand(g->colorpicker), g->picker);
 }
 
 // clang-format off

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -4072,7 +4072,7 @@ static void _lens_set(dt_iop_module_t *self,
   }
   g_signal_connect(G_OBJECT(w), "value-changed",
                    G_CALLBACK(_lens_comboentry_focal_update), self);
-  gtk_box_pack_start(GTK_BOX(g->lens_param_box), w, TRUE, TRUE, 0);
+  dt_gui_box_add(g->lens_param_box, dt_gui_expand(w));
   dt_bauhaus_combobox_set_editable(w, 1);
   g->cbe[0] = w;
 
@@ -4102,7 +4102,7 @@ static void _lens_set(dt_iop_module_t *self,
   }
   g_signal_connect(G_OBJECT(w), "value-changed",
                    G_CALLBACK(_lens_comboentry_aperture_update), self);
-  gtk_box_pack_start(GTK_BOX(g->lens_param_box), w, TRUE, TRUE, 0);
+  dt_gui_box_add(g->lens_param_box, dt_gui_expand(w));
   dt_bauhaus_combobox_set_editable(w, 1);
   g->cbe[1] = w;
 
@@ -4123,7 +4123,7 @@ static void _lens_set(dt_iop_module_t *self,
   }
   g_signal_connect(G_OBJECT(w), "value-changed",
                    G_CALLBACK(_lens_comboentry_distance_update), self);
-  gtk_box_pack_start(GTK_BOX(g->lens_param_box), w, TRUE, TRUE, 0);
+  dt_gui_box_add(g->lens_param_box, dt_gui_expand(w));
   dt_bauhaus_combobox_set_editable(w, 1);
   g->cbe[2] = w;
 
@@ -4405,44 +4405,40 @@ void gui_init(dt_iop_module_t *self)
   dt_iop_gui_leave_critical_section(self);
 
   /* Lensfun widget */
-  // _from_params methods assign widgets to self->widget, so
-  // temporarily set self->widget to our widget
-  GtkWidget *box_lf = self->widget =
-    gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
 
   // camera selector
-  GtkWidget *hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
   g->camera_model = dt_iop_button_new(self, N_("camera model"),
                                       G_CALLBACK(_camera_menusearch_clicked),
                                       FALSE, 0, (GdkModifierType)0,
-                                      NULL, 0, hbox);
+                                      NULL, 0, NULL);
   g->find_camera_button = dt_iop_button_new
     (self, N_("find camera"),
      G_CALLBACK(_camera_autosearch_clicked),
      FALSE, 0, (GdkModifierType)0,
      dtgtk_cairo_paint_solid_arrow, CPF_DIRECTION_DOWN, NULL);
   dt_gui_add_class(g->find_camera_button, "dt_big_btn_canvas");
-  gtk_box_pack_start(GTK_BOX(hbox), g->find_camera_button, FALSE, FALSE, 0);
-  gtk_box_pack_start(GTK_BOX(box_lf), hbox, TRUE, TRUE, 0);
 
   // lens selector
-  hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
   g->lens_model = dt_iop_button_new(self, N_("lens model"),
                                     G_CALLBACK(_lens_menusearch_clicked),
                                     FALSE, 0, (GdkModifierType)0,
-                                    NULL, 0, hbox);
+                                    NULL, 0, NULL);
   g->find_lens_button = dt_iop_button_new
     (self, N_("find lens"),
      G_CALLBACK(_lens_autosearch_clicked),
      FALSE, 0, (GdkModifierType)0,
      dtgtk_cairo_paint_solid_arrow, CPF_DIRECTION_DOWN, NULL);
   dt_gui_add_class(g->find_lens_button, "dt_big_btn_canvas");
-  gtk_box_pack_start(GTK_BOX(hbox), g->find_lens_button, FALSE, FALSE, 0);
-  gtk_box_pack_start(GTK_BOX(box_lf), hbox, TRUE, TRUE, 0);
 
   // lens properties
-  g->lens_param_box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-  gtk_box_pack_start(GTK_BOX(box_lf), g->lens_param_box, TRUE, TRUE, 0);
+  g->lens_param_box = dt_gui_hbox();
+
+  // _from_params methods assign widgets to self->widget, so
+  // temporarily set self->widget to our widget
+  GtkWidget *box_lf = self->widget = dt_gui_vbox(
+    dt_gui_hbox(dt_gui_expand(g->camera_model), g->find_camera_button),
+    dt_gui_hbox(dt_gui_expand(g->lens_model), g->find_lens_button),
+    g->lens_param_box);
 
 #if 0
   // if unambiguous info is there, use it.
@@ -4492,13 +4488,9 @@ void gui_init(dt_iop_module_t *self)
                               _("transversal chromatic aberration blue"));
 
   /* empty correction mode widget */
-  GtkWidget *only_vig = self->widget =
-    gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
+  GtkWidget *only_vig = dt_gui_vbox();
 
   /* embedded metadata widgets */
-  GtkWidget *box_md = self->widget =
-    gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
-
   g->use_latest_md_algo =
     gtk_check_button_new_with_label(_("use latest algorithm"));
   gtk_widget_set_tooltip_text
@@ -4506,7 +4498,7 @@ void gui_init(dt_iop_module_t *self)
      _("you're using an old version of the algorithm.\n"
        "once enabled, you won't be able to\n"
        "return back to old algorithm."));
-  gtk_box_pack_start(GTK_BOX(box_md), g->use_latest_md_algo, TRUE, TRUE, 0);
+  GtkWidget *box_md = self->widget = dt_gui_vbox(g->use_latest_md_algo);
   g_signal_connect(G_OBJECT(g->use_latest_md_algo), "toggled",
                    G_CALLBACK(_use_latest_md_algo_callback), self);
 
@@ -4553,8 +4545,7 @@ void gui_init(dt_iop_module_t *self)
                              _("automatic scale to available image size"));
 
   // main widget
-  GtkWidget *main_box = self->widget =
-    gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
+  GtkWidget *main_box = self->widget = dt_gui_vbox();
   gtk_widget_set_name(self->widget, "lens-module");
 
   // selector for correction method
@@ -4573,20 +4564,17 @@ void gui_init(dt_iop_module_t *self)
   // message box to inform user what corrections have been done. this
   // is useful as depending on Lensfun's profile only some of the lens
   // flaws can be corrected
-  g->hbox1 = GTK_BOX(gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0));
   GtkWidget *label = gtk_label_new(_("corrections done: "));
   gtk_label_set_ellipsize(GTK_LABEL(label), PANGO_ELLIPSIZE_MIDDLE);
   gtk_widget_set_tooltip_text(label,
                               _("which corrections have actually been done"));
-  gtk_box_pack_start(GTK_BOX(g->hbox1), label, FALSE, FALSE, 0);
   g->message = GTK_LABEL(gtk_label_new("")); // This gets filled in by process
   gtk_label_set_ellipsize(GTK_LABEL(g->message), PANGO_ELLIPSIZE_MIDDLE);
-  gtk_box_pack_start(GTK_BOX(g->hbox1), GTK_WIDGET(g->message), FALSE, FALSE, 0);
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->hbox1), TRUE, TRUE, 0);
+  g->hbox1 = GTK_BOX(dt_gui_hbox(label, g->message));
 
   g->methods = gtk_stack_new();
   gtk_stack_set_homogeneous(GTK_STACK(g->methods), FALSE);
-  gtk_box_pack_start(GTK_BOX(self->widget), g->methods, TRUE, TRUE, 0);
+  dt_gui_box_add(self->widget, g->hbox1, g->methods);
 
   gtk_stack_add_named(GTK_STACK(g->methods), box_lf, "lensfun");
   gtk_stack_add_named(GTK_STACK(g->methods), box_md, "metadata");

--- a/src/iop/levels.c
+++ b/src/iop/levels.c
@@ -631,9 +631,6 @@ void gui_init(dt_iop_module_t *self)
   g->area = GTK_DRAWING_AREA(dt_ui_resize_wrap(NULL,
                                                0,
                                                "plugins/darkroom/levels/graphheight"));
-  GtkWidget *vbox_manual = GTK_WIDGET(gtk_box_new(GTK_ORIENTATION_VERTICAL, 0));
-  gtk_box_pack_start(GTK_BOX(vbox_manual), GTK_WIDGET(g->area), TRUE, TRUE, 0);
-
   gtk_widget_set_tooltip_text(GTK_WIDGET(g->area),_("drag handles to set black, gray, and white points. "
                                                     "operates on L channel."));
   dt_action_define_iop(self, NULL, N_("levels"), GTK_WIDGET(g->area), NULL);
@@ -644,8 +641,6 @@ void gui_init(dt_iop_module_t *self)
   g_signal_connect(G_OBJECT(g->area), "motion-notify-event", G_CALLBACK(dt_iop_levels_motion_notify), self);
   g_signal_connect(G_OBJECT(g->area), "leave-notify-event", G_CALLBACK(dt_iop_levels_leave_notify), self);
   g_signal_connect(G_OBJECT(g->area), "scroll-event", G_CALLBACK(dt_iop_levels_scroll), self);
-
-  GtkWidget *box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
 
   GtkWidget *autobutton = gtk_button_new_with_label(_("auto"));
   gtk_widget_set_tooltip_text(autobutton, _("apply auto levels"));
@@ -663,15 +658,15 @@ void gui_init(dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->whitepick, _("pick white point from image"));
   gtk_widget_set_name(GTK_WIDGET(g->whitepick), "picker-white");
 
-  gtk_box_pack_start(GTK_BOX(box), GTK_WIDGET(autobutton  ), TRUE, TRUE, 0);
-  gtk_box_pack_start(GTK_BOX(box), GTK_WIDGET(g->blackpick), TRUE, TRUE, 0);
-  gtk_box_pack_start(GTK_BOX(box), GTK_WIDGET(g->greypick ), TRUE, TRUE, 0);
-  gtk_box_pack_start(GTK_BOX(box), GTK_WIDGET(g->whitepick), TRUE, TRUE, 0);
-  gtk_box_pack_start(GTK_BOX(vbox_manual), box, TRUE, TRUE, 0);
+  GtkWidget *vbox_manual = dt_gui_vbox(g->area,
+                                       dt_gui_hbox(dt_gui_expand(autobutton  ),
+                                                   dt_gui_expand(g->blackpick),
+                                                   dt_gui_expand(g->greypick ),
+                                                   dt_gui_expand(g->whitepick)));
 
   gtk_stack_add_named(GTK_STACK(g->mode_stack), vbox_manual, "manual");
 
-  GtkWidget *vbox_automatic = self->widget = GTK_WIDGET(gtk_box_new(GTK_ORIENTATION_VERTICAL, 0));
+  GtkWidget *vbox_automatic = self->widget = dt_gui_vbox();
 
   g->percentile_black = dt_bauhaus_slider_from_params(self, N_("black"));
   gtk_widget_set_tooltip_text(g->percentile_black, _("black percentile"));
@@ -688,11 +683,11 @@ void gui_init(dt_iop_module_t *self)
   gtk_stack_add_named(GTK_STACK(g->mode_stack), vbox_automatic, "automatic");
 
   // start building top level widget
-  self->widget = GTK_WIDGET(gtk_box_new(GTK_ORIENTATION_VERTICAL, 5));
+  self->widget = dt_gui_vbox();
 
   g->mode = dt_bauhaus_combobox_from_params(self, N_("mode"));
 
-  gtk_box_pack_start(GTK_BOX(self->widget), g->mode_stack, TRUE, TRUE, 0);
+  dt_gui_box_add(self->widget, g->mode_stack);
 }
 
 void gui_cleanup(dt_iop_module_t *self)

--- a/src/iop/liquify.c
+++ b/src/iop/liquify.c
@@ -3614,21 +3614,15 @@ void gui_init(dt_iop_module_t *self)
   g->last_hit = NOWHERE;
   g->node_index = 0;
 
-  self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
-
-  GtkWidget *hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-  gtk_widget_set_tooltip_text
-    (hbox,
-     _("use a tool to add warps\n<b>remove a warp</b>: right-click"));
-  gtk_box_pack_start(GTK_BOX(self->widget), hbox, TRUE, TRUE, 0);
-
   GtkWidget *label = dt_ui_label_new(_("warps|nodes count:"));
-  gtk_box_pack_start(GTK_BOX(hbox), label, FALSE, TRUE, 0);
   g->label = GTK_LABEL(dt_ui_label_new("-"));
-  gtk_box_pack_start(GTK_BOX(hbox), GTK_WIDGET(g->label), FALSE, TRUE, 0);
+  GtkWidget *count = dt_gui_hbox(label, g->label);
+  gtk_widget_set_tooltip_text
+    (count,
+     _("use a tool to add warps\n<b>remove a warp</b>: right-click"));
 
-  hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-  gtk_box_pack_start(GTK_BOX(self->widget), hbox, TRUE, TRUE, 0);
+  GtkWidget *hbox = dt_gui_hbox();
+  self->widget = dt_gui_vbox(count, hbox);
 
   g->btn_node_tool = GTK_TOGGLE_BUTTON(dt_iop_togglebutton_new
                                        (self, NULL, N_("edit, add and delete nodes"), NULL,

--- a/src/iop/lowlight.c
+++ b/src/iop/lowlight.c
@@ -800,14 +800,12 @@ void gui_init(dt_iop_module_t *self)
   g->x_move = -1;
   g->mouse_radius = 1.0 / DT_IOP_LOWLIGHT_BANDS;
 
-  self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
-
   g->area = GTK_DRAWING_AREA(dt_ui_resize_wrap(NULL,
                                                0,
                                                "plugins/darkroom/lowlight/graphheight"));
   g_object_set_data(G_OBJECT(g->area), "iop-instance", self);
   dt_action_define_iop(self, NULL, N_("graph"), GTK_WIDGET(g->area), NULL);
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->area), FALSE, FALSE, 0);
+  self->widget = dt_gui_vbox(g->area);
 
   g_signal_connect(G_OBJECT(g->area), "draw", G_CALLBACK(lowlight_draw), self);
   g_signal_connect(G_OBJECT(g->area), "button-press-event", G_CALLBACK(lowlight_button_press), self);

--- a/src/iop/lut3d.c
+++ b/src/iop/lut3d.c
@@ -1678,8 +1678,6 @@ void gui_init(dt_iop_module_t *self)
 {
   dt_iop_lut3d_gui_data_t *g = IOP_GUI_ALLOC(lut3d);
 
-  self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
-
   g->button = dtgtk_button_new(dtgtk_cairo_paint_directory, CPF_NONE, NULL);
   gtk_widget_set_name(g->button, "non-flat");
 #ifdef HAVE_GMIC
@@ -1701,7 +1699,7 @@ void gui_init(dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->filepath,
     _("the file path (relative to LUT folder) is saved with image (and not the LUT data themselves)"));
 #endif // HAVE_GMIC
-  dt_gui_box_add(self->widget, dt_gui_hbox(g->button, dt_gui_expand(g->filepath)));
+  self->widget = dt_gui_vbox(dt_gui_hbox(g->button, dt_gui_expand(g->filepath)));
   g_signal_connect(G_OBJECT(g->button), "clicked", G_CALLBACK(_button_clicked), self);
   g_signal_connect(G_OBJECT(g->filepath), "value-changed", G_CALLBACK(_filepath_callback), self);
 

--- a/src/iop/monochrome.c
+++ b/src/iop/monochrome.c
@@ -554,10 +554,8 @@ void gui_init(dt_iop_module_t *self)
 
   g->dragging = 0;
 
-  self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
-
   g->area = GTK_DRAWING_AREA(dtgtk_drawing_area_new_with_height(0));
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->area), TRUE, TRUE, 0);
+  self->widget = dt_gui_vbox(g->area);
   gtk_widget_set_tooltip_text(GTK_WIDGET(g->area), _("drag and scroll mouse wheel to adjust the virtual color filter"));
   dt_action_define_iop(self, NULL, N_("grid"), GTK_WIDGET(g->area), NULL);
 

--- a/src/iop/negadoctor.c
+++ b/src/iop/negadoctor.c
@@ -840,22 +840,17 @@ void gui_init(dt_iop_module_t *self)
   GtkWidget *page1 = self->widget = dt_ui_notebook_page(g->notebook, N_("film properties"), NULL);
 
   // Dmin
-
-  gtk_box_pack_start(GTK_BOX(page1), dt_ui_section_label_new(C_("section", "color of the film base")), FALSE, FALSE, 0);
-
-  GtkWidget *row1 = GTK_WIDGET(gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0));
-
   g->Dmin_picker = gtk_color_button_new();
   gtk_color_chooser_set_use_alpha(GTK_COLOR_CHOOSER(g->Dmin_picker), FALSE);
   gtk_color_button_set_title(GTK_COLOR_BUTTON(g->Dmin_picker), _("select color of film material from a swatch"));
-  gtk_box_pack_start(GTK_BOX(row1), GTK_WIDGET(g->Dmin_picker), TRUE, TRUE, 0);
   g_signal_connect(G_OBJECT(g->Dmin_picker), "color-set", G_CALLBACK(Dmin_picker_callback), self);
 
-  g->Dmin_sampler = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, row1);
+  g->Dmin_sampler = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, NULL);
   gtk_widget_set_tooltip_text(g->Dmin_sampler , _("pick color of film material from image"));
   dt_action_define_iop(self, N_("pickers"), N_("film material"), g->Dmin_sampler, &dt_action_def_toggle);
 
-  gtk_box_pack_start(GTK_BOX(page1), GTK_WIDGET(row1), FALSE, FALSE, 0);
+  dt_gui_box_add(page1, dt_ui_section_label_new(C_("section", "color of the film base")),
+                        dt_gui_hbox(dt_gui_expand(g->Dmin_picker), g->Dmin_sampler));
 
   g->Dmin_R = dt_bauhaus_slider_from_params(self, "Dmin[0]");
   dt_bauhaus_slider_set_digits(g->Dmin_R, 4);
@@ -888,8 +883,7 @@ void gui_init(dt_iop_module_t *self)
                                            "and the scanner white balance."));
 
   // D max and scanner bias
-
-  gtk_box_pack_start(GTK_BOX(page1), dt_ui_section_label_new(C_("section", "dynamic range of the film")), FALSE, FALSE, 0);
+  dt_gui_box_add(page1, dt_ui_section_label_new(C_("section", "dynamic range of the film")));
 
   g->D_max = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, dt_bauhaus_slider_from_params(self, "D_max"));
   dt_bauhaus_slider_set_format(g->D_max, " dB");
@@ -897,7 +891,7 @@ void gui_init(dt_iop_module_t *self)
                                           "this value depends on the film specifications, the developing process,\n"
                                           "the dynamic range of the scene and the scanner exposure settings."));
 
-  gtk_box_pack_start(GTK_BOX(page1), dt_ui_section_label_new(C_("section", "scanner exposure settings")), FALSE, FALSE, 0);
+  dt_gui_box_add(page1, dt_ui_section_label_new(C_("section", "scanner exposure settings")));
 
   g->offset = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, dt_bauhaus_slider_from_params(self, "offset"));
   dt_bauhaus_slider_set_format(g->offset, " dB");
@@ -908,21 +902,17 @@ void gui_init(dt_iop_module_t *self)
   GtkWidget *page2 = self->widget = dt_ui_notebook_page(g->notebook, N_("corrections"), NULL);
 
   // WB shadows
-  gtk_box_pack_start(GTK_BOX(page2), dt_ui_section_label_new(C_("section", "shadows color cast")), FALSE, FALSE, 0);
-
-  GtkWidget *row3 = GTK_WIDGET(gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0));
-
   g->WB_low_picker = gtk_color_button_new();
   gtk_color_chooser_set_use_alpha(GTK_COLOR_CHOOSER(g->WB_low_picker), FALSE);
   gtk_color_button_set_title(GTK_COLOR_BUTTON(g->WB_low_picker), _("select color of shadows from a swatch"));
-  gtk_box_pack_start(GTK_BOX(row3), GTK_WIDGET(g->WB_low_picker), TRUE, TRUE, 0);
   g_signal_connect(G_OBJECT(g->WB_low_picker), "color-set", G_CALLBACK(WB_low_picker_callback), self);
 
-  g->WB_low_sampler = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, row3);
+  g->WB_low_sampler = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, NULL);
   gtk_widget_set_tooltip_text(g->WB_low_sampler, _("pick shadows color from image"));
   dt_action_define_iop(self, N_("pickers"), N_("shadows"), g->WB_low_sampler, &dt_action_def_toggle);
 
-  gtk_box_pack_start(GTK_BOX(page2), GTK_WIDGET(row3), FALSE, FALSE, 0);
+  dt_gui_box_add(page2, dt_ui_section_label_new(C_("section", "shadows color cast")),
+                        dt_gui_hbox(dt_gui_expand(g->WB_low_picker), g->WB_low_sampler));
 
   g->wb_low_R = dt_bauhaus_slider_from_params(self, "wb_low[0]");
   dt_bauhaus_widget_set_label(g->wb_low_R, NULL, N_("shadows red offset"));
@@ -946,21 +936,17 @@ void gui_init(dt_iop_module_t *self)
                                              "recovering the global white balance in difficult cases."));
 
   // WB highlights
-  gtk_box_pack_start(GTK_BOX(page2), dt_ui_section_label_new(C_("section", "highlights white balance")), FALSE, FALSE, 0);
-
-  GtkWidget *row2 = GTK_WIDGET(gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0));
-
   g->WB_high_picker = gtk_color_button_new();
   gtk_color_chooser_set_use_alpha(GTK_COLOR_CHOOSER(g->WB_high_picker), FALSE);
   gtk_color_button_set_title(GTK_COLOR_BUTTON(g->WB_high_picker), _("select color of illuminant from a swatch"));
-  gtk_box_pack_start(GTK_BOX(row2), GTK_WIDGET(g->WB_high_picker), TRUE, TRUE, 0);
   g_signal_connect(G_OBJECT(g->WB_high_picker), "color-set", G_CALLBACK(WB_high_picker_callback), self);
 
-  g->WB_high_sampler = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, row2);
+  g->WB_high_sampler = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, NULL);
   gtk_widget_set_tooltip_text(g->WB_high_sampler , _("pick illuminant color from image"));
   dt_action_define_iop(self, N_("pickers"), N_("illuminant"), g->WB_high_sampler, &dt_action_def_toggle);
 
-  gtk_box_pack_start(GTK_BOX(page2), GTK_WIDGET(row2), FALSE, FALSE, 0);
+  dt_gui_box_add(page2, dt_ui_section_label_new(C_("section", "highlights white balance")),
+                        dt_gui_hbox(dt_gui_expand(g->WB_high_picker), g->WB_high_sampler));
 
   g->wb_high_R = dt_bauhaus_slider_from_params(self, "wb_high[0]");
   dt_bauhaus_widget_set_label(g->wb_high_R, NULL, N_("illuminant red gain"));
@@ -987,7 +973,7 @@ void gui_init(dt_iop_module_t *self)
   GtkWidget *page3 = self->widget = dt_ui_notebook_page(g->notebook, N_("print properties"), NULL);
 
   // print corrections
-  gtk_box_pack_start(GTK_BOX(page3), dt_ui_section_label_new(C_("section", "virtual paper properties")), FALSE, FALSE, 0);
+  dt_gui_box_add(page3, dt_ui_section_label_new(C_("section", "virtual paper properties")));
 
   g->black = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, dt_bauhaus_slider_from_params(self, "black"));
   dt_bauhaus_slider_set_digits(g->black, 4);
@@ -1010,7 +996,7 @@ void gui_init(dt_iop_module_t *self)
                                               "to avoid clipping while pushing the exposure for mid-tones.\n"
                                               "this somewhat reproduces the behavior of matte paper."));
 
-  gtk_box_pack_start(GTK_BOX(page3), dt_ui_section_label_new(C_("section", "virtual print emulation")), FALSE, FALSE, 0);
+  dt_gui_box_add(page3, dt_ui_section_label_new(C_("section", "virtual print emulation")));
 
   g->exposure = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, dt_bauhaus_slider_from_params(self, "exposure"));
   dt_bauhaus_slider_set_hard_min(g->exposure, -1.0);
@@ -1021,13 +1007,13 @@ void gui_init(dt_iop_module_t *self)
                                              "the global contrast and avoid clipping highlights."));
 
   // start building top level widget
-  self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
+  self->widget = dt_gui_vbox();
 
   // Film emulsion
   g->film_stock = dt_bauhaus_combobox_from_params(self, "film_stock");
   gtk_widget_set_tooltip_text(g->film_stock, _("toggle on or off the color controls"));
 
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->notebook), FALSE, FALSE, 0);
+  dt_gui_box_add(self->widget, g->notebook);
 }
 
 

--- a/src/iop/overlay.c
+++ b/src/iop/overlay.c
@@ -1076,8 +1076,6 @@ void gui_init(dt_iop_module_t *self)
   dt_iop_overlay_gui_data_t *g = IOP_GUI_ALLOC(overlay);
   dt_iop_overlay_params_t *p = self->params;
 
-  self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
-
   GtkGrid *grid = GTK_GRID(gtk_grid_new());
   gtk_grid_set_row_spacing(grid, DT_BAUHAUS_SPACE);
   gtk_grid_set_column_spacing(grid, DT_PIXEL_APPLY_DPI(10));
@@ -1105,14 +1103,13 @@ void gui_init(dt_iop_module_t *self)
   g_signal_connect(GTK_WIDGET(g->area),
                    "drag-leave", G_CALLBACK(_on_drag_leave), self);
 
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(grid), TRUE, TRUE, 0);
+  self->widget = dt_gui_vbox(grid);
 
   // Add opacity/scale sliders to table
   g->opacity = dt_bauhaus_slider_from_params(self, N_("opacity"));
   dt_bauhaus_slider_set_format(g->opacity, "%");
 
-  gtk_box_pack_start(GTK_BOX(self->widget),
-                     dt_ui_section_label_new(C_("section", "placement")), TRUE, TRUE, 0);
+  dt_gui_box_add(self->widget, dt_ui_section_label_new(C_("section", "placement")));
 
   // rotate
   g->rotate = dt_bauhaus_slider_from_params(self, "rotate");
@@ -1161,7 +1158,7 @@ void gui_init(dt_iop_module_t *self)
                      G_CALLBACK(_alignment_callback), self);
   }
 
-  gtk_box_pack_start(GTK_BOX(self->widget), bat, FALSE, FALSE, 0);
+  dt_gui_box_add(self->widget, bat);
 
   // x/y offset
   g->x_offset = dt_bauhaus_slider_from_params(self, "xoffset");

--- a/src/iop/profile_gamma.c
+++ b/src/iop/profile_gamma.c
@@ -602,7 +602,7 @@ void gui_init(dt_iop_module_t *self)
 
   /**** GAMMA MODE ***/
 
-  GtkWidget *vbox_gamma = self->widget = GTK_WIDGET(gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE));
+  GtkWidget *vbox_gamma = self->widget = dt_gui_vbox();
 
   g->linear = dt_bauhaus_slider_from_params(self, N_("linear"));
   dt_bauhaus_slider_set_digits(g->linear, 4);
@@ -616,7 +616,7 @@ void gui_init(dt_iop_module_t *self)
 
   /**** LOG MODE ****/
 
-  GtkWidget *vbox_log = self->widget = GTK_WIDGET(gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE));
+  GtkWidget *vbox_log = self->widget = dt_gui_vbox();
 
   g->grey_point
       = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, dt_bauhaus_slider_from_params(self, "grey_point"));
@@ -635,7 +635,7 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_slider_set_format(g->dynamic_range, _(" EV"));
   gtk_widget_set_tooltip_text(g->dynamic_range, _("number of stops between pure black and pure white\nthis is a reading a light meter would give you on the scene"));
 
-  gtk_box_pack_start(GTK_BOX(vbox_log), dt_ui_section_label_new(C_("section", "optimize automatically")), FALSE, FALSE, 0);
+  dt_gui_box_add(vbox_log, dt_ui_section_label_new(C_("section", "optimize automatically")));
 
   g->security_factor = dt_bauhaus_slider_from_params(self, "security_factor");
   dt_bauhaus_slider_set_format(g->security_factor, "%");
@@ -644,17 +644,17 @@ void gui_init(dt_iop_module_t *self)
   g->auto_button = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, dt_bauhaus_combobox_new(self));
   dt_bauhaus_widget_set_label(g->auto_button, NULL, N_("auto tune levels"));
   gtk_widget_set_tooltip_text(g->auto_button, _("make an optimization with some guessing"));
-  gtk_box_pack_start(GTK_BOX(vbox_log), g->auto_button, TRUE, TRUE, 0);
+  dt_gui_box_add(vbox_log, g->auto_button);
 
   gtk_stack_add_named(GTK_STACK(g->mode_stack), vbox_log, "log");
 
   // start building top level widget
-  self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
+  self->widget = dt_gui_vbox();
 
   g->mode = dt_bauhaus_combobox_from_params(self, N_("mode"));
   gtk_widget_set_tooltip_text(g->mode, _("tone mapping method"));
 
-  gtk_box_pack_start(GTK_BOX(self->widget), g->mode_stack, TRUE, TRUE, 0);
+  dt_gui_box_add(self->widget, g->mode_stack);
 }
 
 

--- a/src/iop/rawdenoise.c
+++ b/src/iop/rawdenoise.c
@@ -901,16 +901,13 @@ void gui_init(dt_iop_module_t *self)
   g->x_move = -1;
   g->mouse_radius = 1.0 / (DT_IOP_RAWDENOISE_BANDS * 2);
 
-  GtkWidget *box_raw = self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
-
   g->area = GTK_DRAWING_AREA(dt_ui_resize_wrap(NULL,
                                                0,
                                                "plugins/darkroom/rawdenoise/graphheight"));
   g_object_set_data(G_OBJECT(g->area), "iop-instance", self);
   dt_action_define_iop(self, NULL, N_("graph"), GTK_WIDGET(g->area), NULL);
 
-  gtk_box_pack_start(GTK_BOX(box_raw), GTK_WIDGET(g->channel_tabs), FALSE, FALSE, 0);
-  gtk_box_pack_start(GTK_BOX(box_raw), GTK_WIDGET(g->area), FALSE, FALSE, 0);
+  GtkWidget *box_raw = self->widget = dt_gui_vbox(g->channel_tabs, g->area);
 
   g_signal_connect(G_OBJECT(g->area), "draw", G_CALLBACK(rawdenoise_draw), self);
   g_signal_connect(G_OBJECT(g->area), "button-press-event", G_CALLBACK(rawdenoise_button_press), self);

--- a/src/iop/rawprepare.c
+++ b/src/iop/rawprepare.c
@@ -881,7 +881,7 @@ void gui_init(dt_iop_module_t *self)
 {
   dt_iop_rawprepare_gui_data_t *g = IOP_GUI_ALLOC(rawprepare);
 
-  GtkWidget *box_raw = self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
+  GtkWidget *box_raw = self->widget = dt_gui_vbox();;
 
   for(int i = 0; i < 4; i++)
   {
@@ -906,8 +906,7 @@ void gui_init(dt_iop_module_t *self)
 
   if(dt_conf_get_bool("plugins/darkroom/rawprepare/allow_editing_crop"))
   {
-    gtk_box_pack_start(GTK_BOX(self->widget),
-                       dt_ui_section_label_new(C_("section", "crop")), FALSE, FALSE, 0);
+    dt_gui_box_add(self->widget, dt_ui_section_label_new(C_("section", "crop")));
 
     g->left = dt_bauhaus_slider_from_params(self, "left");
     gtk_widget_set_tooltip_text(g->left, _("crop left border"));

--- a/src/iop/relight.c
+++ b/src/iop/relight.c
@@ -250,7 +250,6 @@ void gui_init(dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->exposure, _("the fill-light in EV"));
 
   /* lightnessslider */
-  GtkBox *sliderbox = GTK_BOX(gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0));
 #define NEUTRAL_GRAY 0.5
   static const GdkRGBA _gradient_L[]
       = { { 0, 0, 0, 1.0 }, { NEUTRAL_GRAY, NEUTRAL_GRAY, NEUTRAL_GRAY, 1.0 } };
@@ -258,10 +257,9 @@ void gui_init(dt_iop_module_t *self)
   g->center = DTGTK_GRADIENT_SLIDER(dtgtk_gradient_slider_new_with_color_and_name(_gradient_L[0], _gradient_L[1], "gslider-relight"));
   gtk_widget_set_tooltip_text(GTK_WIDGET(g->center), _("select the center of fill-light\nctrl+click to select an area"));
   g_signal_connect(G_OBJECT(g->center), "value-changed", G_CALLBACK(center_callback), self);
-  gtk_box_pack_start(sliderbox, GTK_WIDGET(g->center), TRUE, TRUE, 0);
-  g->colorpicker = dt_color_picker_new(self, DT_COLOR_PICKER_POINT_AREA, GTK_WIDGET(sliderbox));
+  g->colorpicker = dt_color_picker_new(self, DT_COLOR_PICKER_POINT_AREA, NULL);
   gtk_widget_set_tooltip_text(GTK_WIDGET(g->colorpicker), _("toggle tool for picking median lightness in image"));
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(sliderbox), TRUE, FALSE, 0);
+  dt_gui_box_add(self->widget, dt_gui_hbox(dt_gui_expand(g->center), g->colorpicker));
 
   g->width = dt_bauhaus_slider_from_params(self, N_("width"));
   gtk_widget_set_tooltip_text(g->width, _("width of fill-light area defined in zones"));

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -2428,12 +2428,8 @@ void gui_init(dt_iop_module_t *self)
   change_image(self);
 
   // shapes toolbar
-  GtkWidget *hbox_shapes = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-
-  gtk_box_pack_start(GTK_BOX(hbox_shapes), dt_ui_label_new(_("shapes:")), FALSE, TRUE, 0);
   g->label_form = GTK_LABEL(gtk_label_new("-1"));
-  gtk_box_pack_start(GTK_BOX(hbox_shapes),
-                     GTK_WIDGET(g->label_form), FALSE, TRUE, DT_PIXEL_APPLY_DPI(5));
+  GtkWidget *hbox_shapes = dt_gui_hbox(dt_ui_label_new(_("shapes:")), g->label_form);
   gtk_widget_set_tooltip_text
     (hbox_shapes,
      _("to add a shape select an algorithm and a shape type and click on the image.\n"
@@ -2468,51 +2464,36 @@ void gui_init(dt_iop_module_t *self)
      dtgtk_cairo_paint_masks_circle, hbox_shapes);
 
   // algorithm toolbar
-  GtkWidget *hbox_algo = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-
-  gtk_box_pack_start(GTK_BOX(hbox_algo),
-                     dt_ui_label_new(_("algorithms:")), FALSE, TRUE, 0);
+  GtkWidget *hbox_algo = dt_gui_hbox(dt_ui_label_new(_("algorithms:")));
 
   g->bt_blur = dt_iop_togglebutton_new(
-      self, N_("tools"), N_("activate blur tool"),
-      N_("change algorithm for current form"),
+      self, N_("tools"), N_("activate blur tool"), NULL,
       G_CALLBACK(rt_select_algorithm_callback),
       TRUE, 0, 0, dtgtk_cairo_paint_tool_blur, hbox_algo);
 
   g->bt_fill = dt_iop_togglebutton_new(
-      self, N_("tools"), N_("activate fill tool"),
-      N_("change algorithm for current form"),
+      self, N_("tools"), N_("activate fill tool"), NULL,
       G_CALLBACK(rt_select_algorithm_callback),
       TRUE, 0, 0, dtgtk_cairo_paint_tool_fill, hbox_algo);
 
   g->bt_clone = dt_iop_togglebutton_new(
-      self, N_("tools"), N_("activate cloning tool"),
-      N_("change algorithm for current form"),
+      self, N_("tools"), N_("activate cloning tool"), NULL,
       G_CALLBACK(rt_select_algorithm_callback),
       TRUE, 0, 0, dtgtk_cairo_paint_tool_clone, hbox_algo);
 
   g->bt_heal = dt_iop_togglebutton_new(
-      self, N_("tools"), N_("activate healing tool"),
-      N_("change algorithm for current form"),
+      self, N_("tools"), N_("activate healing tool"), NULL,
       G_CALLBACK(rt_select_algorithm_callback),
       TRUE, 0, 0, dtgtk_cairo_paint_tool_heal, hbox_algo);
 
   // overwrite tooltip ourself to handle shift+click
-  gchar *tt2 = g_strdup_printf("%s\n%s", _("ctrl+click to change tool for current form"),
-                               _("shift+click to set the tool as default"));
-  gchar *tt = g_strdup_printf("%s\n%s", _("activate blur tool"), tt2);
-  gtk_widget_set_tooltip_text(g->bt_blur, tt);
-  g_free(tt);
-  tt = g_strdup_printf("%s\n%s", _("activate fill tool"), tt2);
-  gtk_widget_set_tooltip_text(g->bt_fill, tt);
-  g_free(tt);
-  tt = g_strdup_printf("%s\n%s", _("activate cloning tool"), tt2);
-  gtk_widget_set_tooltip_text(g->bt_clone, tt);
-  g_free(tt);
-  tt = g_strdup_printf("%s\n%s", _("activate healing tool"), tt2);
-  gtk_widget_set_tooltip_text(g->bt_heal, tt);
-  g_free(tt);
-  g_free(tt2);
+  gchar b[1000];
+  gchar *c = _("ctrl+click to change tool for current form");
+  gchar *s = _("shift+click to set the tool as default");
+  gtk_widget_set_tooltip_text(g->bt_blur , dt_buf_printf(b, "%s\n%s\n%s", _("activate blur tool"), c, s));
+  gtk_widget_set_tooltip_text(g->bt_fill , dt_buf_printf(b, "%s\n%s\n%s", _("activate fill tool"), c, s));
+  gtk_widget_set_tooltip_text(g->bt_clone, dt_buf_printf(b, "%s\n%s\n%s", _("activate cloning tool"), c, s));
+  gtk_widget_set_tooltip_text(g->bt_heal , dt_buf_printf(b, "%s\n%s\n%s", _("activate healing tool"), c, s));
 
   // wavelet decompose bar labels
   GtkWidget *grid_wd_labels = gtk_grid_new();
@@ -2569,103 +2550,85 @@ void gui_init(dt_iop_module_t *self)
   gtk_widget_set_size_request(g->wd_bar, -1, DT_PIXEL_APPLY_DPI(40));
 
   // toolbar display current scale / cut&paste / suppress&display masks
-  GtkWidget *hbox_scale = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 5);
 
   // display & suppress masks
+  GtkWidget *scale_end = dt_gui_hbox();
   g->bt_showmask = dt_iop_togglebutton_new
     (self, N_("editing"), N_("display masks"), NULL,
      G_CALLBACK(rt_showmask_callback), TRUE, 0, 0,
-     dtgtk_cairo_paint_showmask, hbox_scale);
+     dtgtk_cairo_paint_showmask, scale_end);
   dt_gui_add_class(g->bt_showmask, "dt_transparent_background");
 
   g->bt_suppress = dt_iop_togglebutton_new
     (self, N_("editing"), N_("temporarily switch off shapes"), NULL,
      G_CALLBACK(rt_suppress_callback), TRUE, 0, 0,
-     dtgtk_cairo_paint_eye_toggle, hbox_scale);
+     dtgtk_cairo_paint_eye_toggle, scale_end);
   dt_gui_add_class(g->bt_suppress, "dt_transparent_background");
-
-  gtk_box_pack_end(GTK_BOX(hbox_scale), gtk_grid_new(), TRUE, TRUE, 0);
-
+  
   // copy/paste shapes
+  GtkWidget *scale_middle = dt_gui_hbox();
   g->bt_paste_scale = dt_iop_togglebutton_new
     (self, N_("editing"), N_("paste cut shapes to current scale"), NULL,
      G_CALLBACK(rt_copypaste_scale_callback), TRUE, 0, 0,
-     dtgtk_cairo_paint_paste_forms, hbox_scale);
+     dtgtk_cairo_paint_paste_forms, scale_middle);
 
   g->bt_copy_scale = dt_iop_togglebutton_new
     (self, N_("editing"), N_("cut shapes from current scale"), NULL,
      G_CALLBACK(rt_copypaste_scale_callback), TRUE, 0, 0,
-     dtgtk_cairo_paint_cut_forms, hbox_scale);
-
-  gtk_box_pack_end(GTK_BOX(hbox_scale), gtk_grid_new(), TRUE, TRUE, 0);
+     dtgtk_cairo_paint_cut_forms, scale_middle);
 
   // display final image/current scale
+  GtkWidget *scale_start = dt_gui_hbox();
   g->bt_display_wavelet_scale = dt_iop_togglebutton_new
     (self, N_("editing"), N_("display wavelet scale"), NULL,
      G_CALLBACK(rt_display_wavelet_scale_callback), TRUE, 0, 0,
-     dtgtk_cairo_paint_display_wavelet_scale, hbox_scale);
+     dtgtk_cairo_paint_display_wavelet_scale, scale_start);
   dt_gui_add_class(g->bt_display_wavelet_scale, "dt_transparent_background");
 
   // preview single scale
-  g->vbox_preview_scale = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
-
-  GtkWidget *lbl_psc = dt_ui_section_label_new(C_("section", "preview single scale"));
-  gtk_box_pack_start(GTK_BOX(g->vbox_preview_scale), lbl_psc, FALSE, TRUE, 0);
-
-  GtkWidget *prev_lvl = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-
   // gradient slider
   #define NEUTRAL_GRAY 0.5
   static const GdkRGBA _gradient_L[]
       = { { 0, 0, 0, 1.0 }, { NEUTRAL_GRAY, NEUTRAL_GRAY, NEUTRAL_GRAY, 1.0 } };
-  g->preview_levels_gslider =
+  GtkDarktableGradientSlider *gslider = g->preview_levels_gslider =
     DTGTK_GRADIENT_SLIDER_MULTIVALUE
     (dtgtk_gradient_slider_multivalue_new_with_color_and_name
      (_gradient_L[0], _gradient_L[1], 3, "preview-levels"));
-  gtk_widget_set_tooltip_text(GTK_WIDGET(g->preview_levels_gslider),
-                              _("adjust preview levels"));
-  dtgtk_gradient_slider_multivalue_set_marker(g->preview_levels_gslider,
-                                              GRADIENT_SLIDER_MARKER_LOWER_OPEN_BIG, 0);
-  dtgtk_gradient_slider_multivalue_set_marker(g->preview_levels_gslider,
-                                              GRADIENT_SLIDER_MARKER_LOWER_FILLED_BIG, 1);
-  dtgtk_gradient_slider_multivalue_set_marker(g->preview_levels_gslider,
-                                              GRADIENT_SLIDER_MARKER_LOWER_OPEN_BIG, 2);
-  (g->preview_levels_gslider)->scale_callback = rt_gslider_scale_callback;
+  gtk_widget_set_tooltip_text(GTK_WIDGET(gslider), _("adjust preview levels"));
+  dtgtk_gradient_slider_multivalue_set_marker(gslider, GRADIENT_SLIDER_MARKER_LOWER_OPEN_BIG, 0);
+  dtgtk_gradient_slider_multivalue_set_marker(gslider, GRADIENT_SLIDER_MARKER_LOWER_FILLED_BIG, 1);
+  dtgtk_gradient_slider_multivalue_set_marker(gslider, GRADIENT_SLIDER_MARKER_LOWER_OPEN_BIG, 2);
+  (gslider)->scale_callback = rt_gslider_scale_callback;
   double vdefault[3] = {RETOUCH_PREVIEW_LVL_MIN,
                         (RETOUCH_PREVIEW_LVL_MIN + RETOUCH_PREVIEW_LVL_MAX) / 2.0,
                         RETOUCH_PREVIEW_LVL_MAX};
-  dtgtk_gradient_slider_multivalue_set_values(g->preview_levels_gslider, vdefault);
-  dtgtk_gradient_slider_multivalue_set_resetvalues(g->preview_levels_gslider, vdefault);
-  (g->preview_levels_gslider)->markers_type = PROPORTIONAL_MARKERS;
-  (g->preview_levels_gslider)->min_spacing = 0.05;
-  g_signal_connect(G_OBJECT(g->preview_levels_gslider), "value-changed",
+  dtgtk_gradient_slider_multivalue_set_values(gslider, vdefault);
+  dtgtk_gradient_slider_multivalue_set_resetvalues(gslider, vdefault);
+  (gslider)->markers_type = PROPORTIONAL_MARKERS;
+  (gslider)->min_spacing = 0.05;
+  g_signal_connect(G_OBJECT(gslider), "value-changed",
                    G_CALLBACK(rt_gslider_changed), self);
-
-  gtk_box_pack_start(GTK_BOX(prev_lvl),
-                     GTK_WIDGET(g->preview_levels_gslider), TRUE, TRUE, 0);
 
   // auto-levels button
   g->bt_auto_levels = dt_iop_togglebutton_new
     (self, N_("editing"), N_("auto levels"), NULL,
      G_CALLBACK(rt_auto_levels_callback), TRUE, 0, 0,
-     dtgtk_cairo_paint_auto_levels, prev_lvl);
+     dtgtk_cairo_paint_auto_levels, NULL);
 
-  gtk_box_pack_start(GTK_BOX(g->vbox_preview_scale), prev_lvl, TRUE, TRUE, 0);
+  g->vbox_preview_scale = dt_gui_vbox(dt_ui_section_label_new(C_("section", "preview single scale")),
+                                      dt_gui_hbox(dt_gui_expand(gslider), g->bt_auto_levels));
 
   // shapes selected (label)
-  GtkWidget *hbox_shape_sel = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
   GtkWidget *label1 = gtk_label_new(_("shape selected:"));
   gtk_label_set_ellipsize(GTK_LABEL(label1), PANGO_ELLIPSIZE_START);
-  gtk_box_pack_start(GTK_BOX(hbox_shape_sel), label1, FALSE, TRUE, 0);
   g->label_form_selected = GTK_LABEL(gtk_label_new("-1"));
+  GtkWidget *hbox_shape_sel = dt_gui_hbox(label1, g->label_form_selected);
   gtk_widget_set_tooltip_text
     (hbox_shape_sel,
      _("click on a shape to select it,\nto unselect click on an empty space"));
-  gtk_box_pack_start(GTK_BOX(hbox_shape_sel),
-                     GTK_WIDGET(g->label_form_selected), FALSE, TRUE, 0);
 
   // fill properties
-  g->vbox_fill = self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
+  g->vbox_fill = self->widget = dt_gui_vbox();
 
   g->cmb_fill_mode = dt_bauhaus_combobox_from_params(self, "fill_mode");
   gtk_widget_set_tooltip_text
@@ -2678,28 +2641,24 @@ void gui_init(dt_iop_module_t *self)
                   .blue  = p->fill_color[2],
                   .alpha = 1.0 };
 
-  g->hbox_color_pick = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-  GtkWidget *lbl_fill_color = dt_ui_label_new(_("fill color: "));
-  gtk_box_pack_start(GTK_BOX(g->hbox_color_pick), lbl_fill_color, FALSE, TRUE, 0);
-
   g->colorpick = gtk_color_button_new_with_rgba(&color);
   gtk_color_chooser_set_use_alpha(GTK_COLOR_CHOOSER(g->colorpick), FALSE);
   gtk_color_button_set_title(GTK_COLOR_BUTTON(g->colorpick), _("select fill color"));
   gtk_widget_set_tooltip_text(g->colorpick, _("select fill color"));
   g_signal_connect(G_OBJECT(g->colorpick), "color-set",
                    G_CALLBACK(rt_colorpick_color_set_callback), self);
-  gtk_box_pack_start(GTK_BOX(g->hbox_color_pick),
-                     GTK_WIDGET(g->colorpick), TRUE, TRUE, 0);
 
   g->colorpicker = dt_color_picker_new
     (self,
      DT_COLOR_PICKER_POINT | DT_COLOR_PICKER_IO,
-     g->hbox_color_pick);
+     NULL);
   gtk_widget_set_tooltip_text(g->colorpicker, _("pick fill color from image"));
   dt_action_define_iop(self, NULL, N_("pick fill color"),
                        g->colorpicker, &dt_action_def_toggle);
 
-  gtk_box_pack_start(GTK_BOX(g->vbox_fill), g->hbox_color_pick, TRUE, TRUE, 0);
+  g->hbox_color_pick = dt_gui_hbox(dt_ui_label_new(_("fill color: ")),
+                                   dt_gui_expand(g->colorpick), g->colorpicker);
+  dt_gui_box_add(g->vbox_fill, g->hbox_color_pick);
 
   g->sl_fill_brightness = dt_bauhaus_slider_from_params(self, "fill_brightness");
   dt_bauhaus_slider_set_digits(g->sl_fill_brightness, 4);
@@ -2709,7 +2668,7 @@ void gui_init(dt_iop_module_t *self)
      _("adjusts color brightness to fine-tune it. works with erase as well"));
 
   // blur properties
-  g->vbox_blur = self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, 5);
+  g->vbox_blur = self->widget = dt_gui_vbox();
 
   g->cmb_blur_type = dt_bauhaus_combobox_from_params(self, "blur_type");
   gtk_widget_set_tooltip_text(g->cmb_blur_type, _("type for the blur algorithm"));
@@ -2732,7 +2691,9 @@ void gui_init(dt_iop_module_t *self)
     (dt_ui_section_label_new(C_("section", "retouch tools")),
      hbox_shapes, hbox_algo,
      dt_ui_section_label_new(C_("section", "wavelet decompose")),
-     grid_wd_labels, g->wd_bar, hbox_scale, g->vbox_preview_scale,
+     grid_wd_labels, g->wd_bar,
+     dt_gui_hbox(scale_start, dt_gui_expand(scale_middle), dt_gui_expand(scale_end)),
+     g->vbox_preview_scale,
      dt_ui_section_label_new(C_("section", "shapes")),
      hbox_shape_sel, g->vbox_blur, g->vbox_fill, g->sl_mask_opacity);
 

--- a/src/iop/sigmoid.c
+++ b/src/iop/sigmoid.c
@@ -896,7 +896,6 @@ void gui_update(dt_iop_module_t *self)
 void gui_init(dt_iop_module_t *self)
 {
   dt_iop_sigmoid_gui_data_t *g = IOP_GUI_ALLOC(sigmoid);
-  self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
 
   // Look controls
   GtkWidget *slider = dt_bauhaus_slider_from_params(self, "middle_grey_contrast");

--- a/src/iop/splittoning.c
+++ b/src/iop/splittoning.c
@@ -457,10 +457,6 @@ static inline void gui_init_section(dt_iop_module_t *self,
                                     GtkWidget **picker,
                                     gboolean top)
 {
-  GtkWidget *label = dt_ui_section_label_new(Q_(section));
-
-  gtk_box_pack_start(GTK_BOX(self->widget), label, FALSE, FALSE, 0);
-
   dt_bauhaus_slider_set_feedback(hue, 0);
   dt_bauhaus_slider_set_stop(hue, 0.0f  , 1.0f, 0.0f, 0.0f);
   dt_bauhaus_slider_set_stop(hue, 0.166f, 1.0f, 1.0f, 0.0f);
@@ -481,10 +477,8 @@ static inline void gui_init_section(dt_iop_module_t *self,
   gtk_color_button_set_title(GTK_COLOR_BUTTON(*picker), _("select tone color"));
   g_signal_connect(G_OBJECT(*picker), "color-set", G_CALLBACK(colorpick_callback), self);
 
-  GtkWidget *hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-  gtk_box_pack_start(GTK_BOX(hbox), slider_box, TRUE, TRUE, 0);
-  gtk_box_pack_end(GTK_BOX(hbox), *picker, FALSE, FALSE, 0);
-  gtk_box_pack_start(GTK_BOX(self->widget), hbox, FALSE, FALSE, 0);
+  dt_gui_box_add(self->widget, dt_ui_section_label_new(Q_(section)),
+                 dt_gui_hbox(dt_gui_expand(slider_box), *picker));
 }
 
 void gui_init(dt_iop_module_t *self)
@@ -492,21 +486,21 @@ void gui_init(dt_iop_module_t *self)
   dt_iop_splittoning_gui_data_t *g = IOP_GUI_ALLOC(splittoning);
 
   dt_iop_module_t *sect = DT_IOP_SECTION_FOR_PARAMS(self, N_("shadows"));
-  GtkWidget *shadows_box = self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
+  GtkWidget *shadows_box = self->widget = dt_gui_vbox();
   g->shadow_hue_gslider = dt_bauhaus_slider_from_params(sect, "shadow_hue");
   dt_bauhaus_slider_set_factor(g->shadow_hue_gslider, 360.0f);
   dt_bauhaus_slider_set_format(g->shadow_hue_gslider, "°");
   g->shadow_sat_gslider = dt_bauhaus_slider_from_params(sect, "shadow_saturation");
 
   sect = DT_IOP_SECTION_FOR_PARAMS(self, N_("highlights"));
-  GtkWidget *highlights_box = self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
+  GtkWidget *highlights_box = self->widget = dt_gui_vbox();
   g->highlight_hue_gslider = dt_bauhaus_slider_from_params(sect, "highlight_hue");
   dt_bauhaus_slider_set_factor(g->highlight_hue_gslider, 360.0f);
   dt_bauhaus_slider_set_format(g->highlight_hue_gslider, "°");
   g->highlight_sat_gslider = dt_bauhaus_slider_from_params(sect, "highlight_saturation");
 
   // start building top level widget
-  self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
+  self->widget = dt_gui_vbox();
 
   gui_init_section(self, NC_("section", "shadows"),
                    shadows_box,
@@ -521,7 +515,7 @@ void gui_init(dt_iop_module_t *self)
                    &g->highlight_colorpick, FALSE);
 
   // Additional parameters
-  gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(C_("section", "properties")), FALSE, FALSE, 0);
+  dt_gui_box_add(self->widget, dt_ui_section_label_new(C_("section", "properties")));
 
   g->balance_scale = dt_bauhaus_slider_from_params(self, N_("balance"));
   dt_bauhaus_slider_set_feedback(g->balance_scale, 0);

--- a/src/iop/spots.c
+++ b/src/iop/spots.c
@@ -862,37 +862,31 @@ void gui_init(dt_iop_module_t *self)
 {
   dt_iop_spots_gui_data_t *g = IOP_GUI_ALLOC(spots);
 
-  self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
-
-  GtkWidget *hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-  gtk_box_pack_start(GTK_BOX(hbox), dt_ui_label_new(_("number of strokes:")),
-                     FALSE, TRUE, 0);
   g->label = GTK_LABEL(dt_ui_label_new("-1"));
-  gtk_widget_set_tooltip_text(hbox,
+  self->widget = dt_gui_hbox(dt_ui_label_new(_("number of strokes:")), g->label);
+
+  gtk_widget_set_tooltip_text(self->widget,
                               _("click on a shape and drag on canvas.\nuse the mouse wheel "
                                 "to adjust size.\nright-click to remove a shape."));
 
   g->bt_edit_masks = dt_iop_togglebutton_new(self, NULL, N_("show and edit shapes"), NULL,
                                              G_CALLBACK(_edit_masks), TRUE, 0, 0,
-                                             dtgtk_cairo_paint_masks_eye, hbox);
+                                             dtgtk_cairo_paint_masks_eye, self->widget);
 
   g->bt_path = dt_iop_togglebutton_new(self, N_("shapes"),
                                        N_("add path"), N_("add multiple paths"),
                                        G_CALLBACK(_add_shape_callback), TRUE, 0, 0,
-                                       dtgtk_cairo_paint_masks_path, hbox);
+                                       dtgtk_cairo_paint_masks_path, self->widget);
 
   g->bt_ellipse = dt_iop_togglebutton_new(self, N_("shapes"),
                                           N_("add ellipse"), N_("add multiple ellipses"),
                                           G_CALLBACK(_add_shape_callback), TRUE, 0, 0,
-                                          dtgtk_cairo_paint_masks_ellipse, hbox);
+                                          dtgtk_cairo_paint_masks_ellipse, self->widget);
 
   g->bt_circle = dt_iop_togglebutton_new(self, N_("shapes"),
                                          N_("add circle"), N_("add multiple circles"),
                                          G_CALLBACK(_add_shape_callback), TRUE, 0, 0,
-                                         dtgtk_cairo_paint_masks_circle, hbox);
-
-  gtk_box_pack_start(GTK_BOX(hbox), GTK_WIDGET(g->label), FALSE, TRUE, 0);
-  gtk_box_pack_start(GTK_BOX(self->widget), hbox, TRUE, TRUE, 0);
+                                         dtgtk_cairo_paint_masks_circle, self->widget);
 }
 
 void gui_reset(dt_iop_module_t *self)

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -2088,8 +2088,6 @@ void gui_init(dt_iop_module_t *self)
   const gboolean feedback = g->colored_sliders ? FALSE : TRUE;
   g->button_bar_visible = dt_conf_get_bool("plugins/darkroom/temperature/button_bar");
 
-  GtkBox *box_enabled = GTK_BOX(gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE));
-
   g->btn_asshot = dt_iop_togglebutton_new(self, N_("settings"), N_("as shot"), NULL,
                                           G_CALLBACK(_btn_toggled), FALSE, 0, 0,
                                           dtgtk_cairo_paint_camera, NULL);
@@ -2133,28 +2131,24 @@ void gui_init(dt_iop_module_t *self)
      _("set white balance to as shot and later correct to camera reference point,\nin most cases it should be D65"));
 
   // put buttons at top. fill later.
-  g->buttonbar = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
+  g->buttonbar = dt_gui_hbox(dt_gui_expand(g->btn_asshot),
+                             dt_gui_expand(g->colorpicker),
+                             dt_gui_expand(g->btn_user),
+                             dt_gui_expand(g->btn_d65),
+                             dt_gui_expand(g->btn_d65_late));
   dt_gui_add_class(g->buttonbar, "dt_iop_toggle");
-  gtk_box_pack_end(GTK_BOX(g->buttonbar), g->btn_d65_late, TRUE, TRUE, 0);
-  gtk_box_pack_end(GTK_BOX(g->buttonbar), g->btn_d65, TRUE, TRUE, 0);
-  gtk_box_pack_end(GTK_BOX(g->buttonbar), g->btn_user, TRUE, TRUE, 0);
-  gtk_box_pack_end(GTK_BOX(g->buttonbar), g->colorpicker, TRUE, TRUE, 0);
-  gtk_box_pack_end(GTK_BOX(g->buttonbar), g->btn_asshot, TRUE, TRUE, 0);
-  gtk_box_pack_start(box_enabled, g->buttonbar, TRUE, TRUE, 0);
 
   g->presets = dt_bauhaus_combobox_new(self);
   // relabel to settings to remove confusion between module presets
   // and white balance settings
   dt_bauhaus_widget_set_label(g->presets, N_("settings"), N_("settings"));
   gtk_widget_set_tooltip_text(g->presets, _("choose white balance setting"));
-  gtk_box_pack_start(box_enabled, g->presets, TRUE, TRUE, 0);
 
   g->finetune = dt_bauhaus_slider_new_with_range_and_feedback
     (self, -9.0, 9.0, 0, 0.0, 0, feedback);
   dt_bauhaus_widget_set_label(g->finetune, NULL, N_("finetune"));
   dt_bauhaus_slider_set_format(g->finetune, " mired");
   gtk_widget_set_tooltip_text(g->finetune, _("fine tune camera's white balance setting"));
-  gtk_box_pack_start(box_enabled, g->finetune, TRUE, TRUE, 0);
 
   g->mod_temp = -FLT_MAX;
   for_four_channels(k)
@@ -2168,8 +2162,6 @@ void gui_init(dt_iop_module_t *self)
   g_signal_connect(G_OBJECT(temp_label_box), "button-release-event",
                    G_CALLBACK(temp_label_click), self);
 
-  gtk_box_pack_start(box_enabled, temp_label_box, TRUE, TRUE, 0);
-
   //Match UI order: temp first, then tint (like every other app ever)
   g->scale_k = dt_bauhaus_slider_new_with_range_and_feedback
     (self, DT_IOP_LOWEST_TEMPERATURE, DT_IOP_HIGHEST_TEMPERATURE,
@@ -2177,7 +2169,6 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_slider_set_format(g->scale_k, " K");
   dt_bauhaus_widget_set_label(g->scale_k, NULL, N_("temperature"));
   gtk_widget_set_tooltip_text(g->scale_k, _("color temperature (in Kelvin)"));
-  gtk_box_pack_start(box_enabled, g->scale_k, TRUE, TRUE, 0);
 
   g->scale_tint = dt_bauhaus_slider_new_with_range_and_feedback
     (self, DT_IOP_LOWEST_TINT, DT_IOP_HIGHEST_TINT,
@@ -2186,8 +2177,13 @@ void gui_init(dt_iop_module_t *self)
   gtk_widget_set_tooltip_text
     (g->scale_tint,
      _("color tint of the image, from magenta (value < 1) to green (value > 1)"));
-  gtk_box_pack_start(box_enabled, g->scale_tint, TRUE, TRUE, 0);
 
+  GtkWidget *box_enabled = dt_gui_vbox(g->buttonbar,
+                                       g->presets,
+                                       g->finetune,
+                                       temp_label_box,
+                                       g->scale_k,
+                                       g->scale_tint);
   dt_gui_new_collapsible_section
     (&g->cs,
      "plugins/darkroom/temperature/expand_coefficients",

--- a/src/iop/tonecurve.c
+++ b/src/iop/tonecurve.c
@@ -110,7 +110,6 @@ typedef struct dt_iop_tonecurve_gui_data_t
   dt_draw_curve_t *minmax_curve[3]; // curves for gui to draw
   int minmax_curve_nodes[3];
   int minmax_curve_type[3];
-  GtkBox *hbox;
   GtkDrawingArea *area;
   GtkSizeGroup *sizegroup;
   GtkWidget *autoscale_ab;
@@ -1263,7 +1262,6 @@ void gui_init(dt_iop_module_t *self)
                         "not displayed. chroma values (a and b) of each pixel are "
                         "then adjusted based on L curve data. auto XYZ is similar "
                         "but applies the saturation changes in XYZ space."));
-  GtkWidget *hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
 
   static dt_action_def_t notebook_def = { };
   g->channel_tabs = dt_ui_notebook_new(&notebook_def);
@@ -1273,23 +1271,21 @@ void gui_init(dt_iop_module_t *self)
   dt_ui_notebook_page(g->channel_tabs, N_("a"), _("tonecurve for a channel"));
   dt_ui_notebook_page(g->channel_tabs, N_("b"), _("tonecurve for b channel"));
   g_signal_connect(G_OBJECT(g->channel_tabs), "switch_page", G_CALLBACK(tab_switch), self);
-  gtk_box_pack_start(GTK_BOX(hbox), GTK_WIDGET(g->channel_tabs), TRUE, TRUE, 0);
-  gtk_box_pack_start(GTK_BOX(hbox), gtk_grid_new(), TRUE, TRUE, 0);
 
   g->colorpicker = dt_color_picker_new(self,
                                        DT_COLOR_PICKER_POINT_AREA | DT_COLOR_PICKER_IO,
-                                       hbox);
+                                       NULL);
   gtk_widget_set_tooltip_text
     (g->colorpicker,
      _("pick GUI color from image\nctrl+click or right-click to select an area"));
   dt_action_define_iop(self, NULL, N_("pick color"), g->colorpicker, &dt_action_def_toggle);
 
-  gtk_box_pack_start(GTK_BOX(self->widget), hbox, FALSE, FALSE, 0);
+  dt_gui_box_add(self->widget, dt_gui_hbox(dt_gui_expand(g->channel_tabs), 
+                                           dt_gui_align_right(g->colorpicker)));
 
   g->area = GTK_DRAWING_AREA(dtgtk_drawing_area_new_with_height(0));
   g_object_set_data(G_OBJECT(g->area), "iop-instance", self);
   dt_action_define_iop(self, NULL, N_("curve"), GTK_WIDGET(g->area), NULL);
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->area), TRUE, TRUE, 0);
 
   // FIXME: that tooltip goes in the way of the numbers when you hover a node to get a reading
   //gtk_widget_set_tooltip_text(GTK_WIDGET(g->area), _("double click to reset curve"));
@@ -1320,7 +1316,6 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_combobox_add(g->interpolator, _("cubic spline"));
   dt_bauhaus_combobox_add(g->interpolator, _("centripetal spline"));
   dt_bauhaus_combobox_add(g->interpolator, _("monotonic spline"));
-  gtk_box_pack_start(GTK_BOX(self->widget), g->interpolator , TRUE, TRUE, 0);
   gtk_widget_set_tooltip_text
     (g->interpolator,
      _("change this method if you see oscillations or cusps in the curve\n"
@@ -1330,13 +1325,15 @@ void gui_init(dt_iop_module_t *self)
   g_signal_connect(G_OBJECT(g->interpolator), "value-changed",
                    G_CALLBACK(interpolator_callback), self);
 
+  dt_gui_box_add(self->widget, g->area, g->interpolator);
+
   g->preserve_colors = dt_bauhaus_combobox_from_params(self, "preserve_colors");
   gtk_widget_set_tooltip_text(g->preserve_colors,
                               _("method to preserve colors when applying contrast"));
 
   g->logbase = dt_bauhaus_slider_new_with_range(self, 0.0f, 40.0f, 0, 0.0f, 2);
   dt_bauhaus_widget_set_label(g->logbase, NULL, N_("scale for graph"));
-  gtk_box_pack_start(GTK_BOX(self->widget), g->logbase , TRUE, TRUE, 0);
+  dt_gui_box_add(self->widget, g->logbase);
   g_signal_connect(G_OBJECT(g->logbase), "value-changed",
                    G_CALLBACK(logbase_callback), self);
 

--- a/src/iop/useless.c
+++ b/src/iop/useless.c
@@ -647,7 +647,7 @@ void gui_init(dt_iop_module_t *self)
   // If the first widget is created using a _from_params call,
   // self->widget does not have to be explicitly initialised, as a new
   // vertical box will be created automatically.
-  self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
+  self->widget = dt_gui_vbox();
 
   // Linking a slider to an integer will make it take only whole
   // numbers (step=1).  The new slider is added to self->widget
@@ -687,7 +687,7 @@ void gui_init(dt_iop_module_t *self)
   // "value-changed" signal.
   g->extra = dt_bauhaus_slider_new_with_range(self, -0.5, 0.5, 0, 0, 2);
   dt_bauhaus_widget_set_label(g->extra, NULL, N_("extra"));
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->extra), TRUE, TRUE, 0);
+  dt_gui_box_add(self->widget, g->extra);
   g_signal_connect(G_OBJECT(g->extra), "value-changed", G_CALLBACK(extra_callback), self);
 }
 

--- a/src/iop/vignette.c
+++ b/src/iop/vignette.c
@@ -1045,9 +1045,7 @@ void gui_init(dt_iop_module_t *self)
   g->brightness = dt_bauhaus_slider_from_params(self, N_("brightness"));
   g->saturation = dt_bauhaus_slider_from_params(self, N_("saturation"));
 
-  gtk_box_pack_start(GTK_BOX(self->widget),
-                     dt_ui_section_label_new(C_("section", "position / form")),
-                     FALSE, FALSE, 0);
+  dt_gui_box_add(self->widget, dt_ui_section_label_new(C_("section", "position / form"))),
 
   g->center_x = dt_bauhaus_slider_from_params(self, "center.x");
   g->center_y = dt_bauhaus_slider_from_params(self, "center.y");

--- a/src/iop/watermark.c
+++ b/src/iop/watermark.c
@@ -1298,8 +1298,6 @@ void gui_init(dt_iop_module_t *self)
   dt_iop_watermark_gui_data_t *g = IOP_GUI_ALLOC(watermark);
   dt_iop_watermark_params_t *p = self->params;
 
-  self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
-
   GtkGrid *grid = GTK_GRID(gtk_grid_new());
   gtk_grid_set_row_spacing(grid, DT_BAUHAUS_SPACE);
   gtk_grid_set_column_spacing(grid, DT_PIXEL_APPLY_DPI(10));
@@ -1366,13 +1364,13 @@ void gui_init(dt_iop_module_t *self)
   gtk_grid_attach_next_to(grid, g->colorpick, label, GTK_POS_RIGHT, 1, 1);
   gtk_grid_attach_next_to(grid, g->color_picker_button, g->colorpick, GTK_POS_RIGHT, 1, 1);
 
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(grid), TRUE, TRUE, 0);
+  self->widget = dt_gui_vbox(grid);
 
   // Add opacity/scale sliders to table
   g->opacity = dt_bauhaus_slider_from_params(self, N_("opacity"));
   dt_bauhaus_slider_set_format(g->opacity, "%");
 
-  gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(C_("section", "placement")), TRUE, TRUE, 0);
+  dt_gui_box_add(self->widget, dt_ui_section_label_new(C_("section", "placement")));
 
   // rotate
   g->rotate = dt_bauhaus_slider_from_params(self, "rotate");
@@ -1414,7 +1412,7 @@ void gui_init(dt_iop_module_t *self)
     g_signal_connect(G_OBJECT(g->align[i]), "toggled", G_CALLBACK(_alignment_callback), self);
   }
 
-  gtk_box_pack_start(GTK_BOX(self->widget), bat, FALSE, FALSE, 0);
+  dt_gui_box_add(self->widget, bat);
 
   // x/y offset
   g->x_offset = dt_bauhaus_slider_from_params(self, "xoffset");

--- a/src/iop/zonesystem.c
+++ b/src/iop/zonesystem.c
@@ -429,8 +429,6 @@ void gui_init(dt_iop_module_t *self)
   g->preview_width = g->preview_height = 0;
   g->mouse_over_output_zones = FALSE;
 
-  self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_IOP_MODULE_CONTROL_SPACING);
-
   g->preview = dtgtk_drawing_area_new_with_height(0);
   g_signal_connect(G_OBJECT(g->preview), "size-allocate", G_CALLBACK(size_allocate_callback), self);
   g_signal_connect(G_OBJECT(g->preview), "draw", G_CALLBACK(dt_iop_zonesystem_preview_draw), self);
@@ -458,12 +456,10 @@ void gui_init(dt_iop_module_t *self)
                                               | GDK_LEAVE_NOTIFY_MASK | darktable.gui->scroll_mask);
   gtk_widget_set_size_request(g->zones, -1, DT_PIXEL_APPLY_DPI(40));
 
-  gtk_box_pack_start(GTK_BOX(self->widget), g->preview, TRUE, TRUE, 0);
-  gtk_box_pack_start(GTK_BOX(self->widget), g->zones, TRUE, TRUE, 0);
+  self->widget = dt_gui_vbox(g->preview, g->zones);
 
   /* add signal handler for preview pipe finish to redraw the preview */
   DT_CONTROL_SIGNAL_HANDLE(DT_SIGNAL_DEVELOP_PREVIEW_PIPE_FINISHED, _iop_zonesystem_redraw_preview_callback);
-
 
   g->image = NULL;
   g->image_buffer = NULL;

--- a/src/libs/duplicate.c
+++ b/src/libs/duplicate.c
@@ -336,7 +336,7 @@ static void _lib_duplicate_init_callback(gpointer instance, dt_lib_module_t *sel
 
     gtk_widget_show_all(hb);
 
-    gtk_box_pack_start(GTK_BOX(d->duplicate_box), hb, FALSE, FALSE, 0);
+    dt_gui_box_add(d->duplicate_box, hb);
     d->thumbs = g_list_append(d->thumbs, thumb);
     count++;
   }
@@ -387,39 +387,26 @@ static void _lib_duplicate_preview_updated_callback(gpointer instance,
 void gui_init(dt_lib_module_t *self)
 {
   /* initialize ui widgets */
-  dt_lib_duplicate_t *d = g_malloc0(sizeof(dt_lib_duplicate_t));
-  self->data = (void *)d;
+  dt_lib_duplicate_t *d = self->data = g_malloc0(sizeof(dt_lib_duplicate_t));
 
   d->imgid = NO_IMGID;
   d->buf = NULL;
   d->view_ctx = 0;
 
-  self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
+  d->duplicate_box = dt_gui_vbox();
+  self->widget = dt_gui_vbox
+                   (dt_ui_resize_wrap(d->duplicate_box, 1,
+                                      "plugins/darkroom/duplicate/windowheight"),
+                    dt_gui_hbox
+                      (dt_action_button_new
+                         (NULL, N_("duplicate"), _lib_duplicate_duplicate_clicked_callback, self,
+                          _("create a duplicate of the image with same history stack"), 0, 0),
+                       dt_action_button_new
+                         (NULL, N_("original"),
+                          _lib_duplicate_new_clicked_callback, self,
+                          _("create a 'virgin' duplicate of the image without any development"), 0, 0)));
   dt_gui_add_class(self->widget, "dt_duplicate_ui");
   dt_act_on_set_class(self->widget);
-
-  d->duplicate_box = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
-
-  GtkWidget *hb = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-  GtkWidget *bt = dt_action_button_new
-    (NULL, N_("original"),
-     _lib_duplicate_new_clicked_callback, self,
-     _("create a 'virgin' duplicate of the image without any development"), 0, 0);
-
-  gtk_box_pack_end(GTK_BOX(hb), bt, TRUE, TRUE, 0);
-  bt = dt_action_button_new
-    (NULL, N_("duplicate"), _lib_duplicate_duplicate_clicked_callback, self,
-     _("create a duplicate of the image with same history stack"), 0, 0);
-
-  gtk_box_pack_end(GTK_BOX(hb), bt, TRUE, TRUE, 0);
-
-  /* add duplicate list and buttonbox to widget */
-  gtk_box_pack_start(GTK_BOX(self->widget),
-                     dt_ui_resize_wrap
-                       (d->duplicate_box, 1,
-                        "plugins/darkroom/duplicate/windowheight"), TRUE, TRUE, 0);
-  gtk_box_pack_start(GTK_BOX(self->widget), hb, TRUE, TRUE, 0);
-
   gtk_widget_show_all(self->widget);
 
   DT_CONTROL_SIGNAL_HANDLE(DT_SIGNAL_DEVELOP_IMAGE_CHANGED, _lib_duplicate_init_callback);

--- a/src/libs/import.c
+++ b/src/libs/import.c
@@ -2415,18 +2415,14 @@ void gui_init(dt_lib_module_t *self)
   /* initialize ui widgets */
   dt_lib_import_t *d = g_malloc0(sizeof(dt_lib_import_t));
   self->data = (void *)d;
-  self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
 
   // add import buttons
-  GtkWidget *hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-
   GtkWidget *widget = dt_action_button_new(self, N_("add to library..."),
                                            _lib_import_from_callback, self,
                                            _("add existing images to the library"), 0, 0);
   d->import_inplace = GTK_BUTTON(widget);
   gtk_widget_set_can_focus(widget, TRUE);
   gtk_widget_set_receives_default(widget, TRUE);
-  gtk_box_pack_start(GTK_BOX(hbox), widget, TRUE, TRUE, 0);
 
   widget = dt_action_button_new
     (self, N_("copy & import..."),
@@ -2437,14 +2433,13 @@ void gui_init(dt_lib_module_t *self)
   d->import_copy = GTK_BUTTON(widget);
   gtk_widget_set_can_focus(widget, TRUE);
   gtk_widget_set_receives_default(widget, TRUE);
-  gtk_box_pack_start(GTK_BOX(hbox), widget, TRUE, TRUE, 0);
 
-  gtk_box_pack_start(GTK_BOX(self->widget), hbox, TRUE, TRUE, 0);
-
+  self->widget = dt_gui_vbox(dt_gui_hbox(d->import_inplace, d->import_copy));
+  
 #ifdef HAVE_GPHOTO2
   /* add devices container for cameras */
-  d->devices = GTK_BOX(gtk_box_new(GTK_ORIENTATION_VERTICAL, 0));
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(d->devices), FALSE, FALSE, 0);
+  d->devices = GTK_BOX(dt_gui_vbox());
+  dt_gui_box_add(self->widget, d->devices);
 
   _lib_import_ui_devices_update(self);
 
@@ -2465,7 +2460,7 @@ void gui_init(dt_lib_module_t *self)
   d->apply_metadata = dt_gui_preferences_bool(grid, "ui_last/import_apply_metadata", 0,
                                               line++, FALSE);
   d->metadata.apply_metadata = d->apply_metadata;
-  gtk_box_pack_start(GTK_BOX(d->cs.container), GTK_WIDGET(grid), FALSE, FALSE, 0);
+  dt_gui_box_add(d->cs.container, grid);
   d->metadata.box = GTK_WIDGET(d->cs.container);
   dt_import_metadata_init(&d->metadata);
 
@@ -2473,7 +2468,7 @@ void gui_init(dt_lib_module_t *self)
   /* initialize the lua area and make sure it survives its parent's destruction*/
   d->extra_lua_widgets = gtk_box_new(GTK_ORIENTATION_VERTICAL,5);
   g_object_ref_sink(d->extra_lua_widgets);
-  gtk_box_pack_start(GTK_BOX(d->cs.container), d->extra_lua_widgets, FALSE, FALSE, 0);
+  dt_gui_box_add(d->cs.container, d->extra_lua_widgets);
   gtk_container_foreach(GTK_CONTAINER(d->extra_lua_widgets), reset_child, NULL);
 #endif
 

--- a/src/libs/location.c
+++ b/src/libs/location.c
@@ -138,19 +138,15 @@ void gui_init(dt_lib_module_t *self)
   dt_lib_location_t *lib = self->data;
   if(!lib) return;
 
-  self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
-
   /* add search box */
   lib->search = GTK_ENTRY(dt_ui_entry_new(0));
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(lib->search), FALSE, FALSE, 0);
-
   g_signal_connect(G_OBJECT(lib->search), "activate",
                    G_CALLBACK(_lib_location_entry_activated),
                    (gpointer)self);
 
   /* add result vbox */
-  lib->result = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(lib->result), TRUE, FALSE, 0);
+  lib->result = dt_gui_vbox();
+  self->widget = dt_gui_vbox(lib->search,lib->result);
 }
 
 void gui_cleanup(dt_lib_module_t *self)

--- a/src/libs/metadata.c
+++ b/src/libs/metadata.c
@@ -1128,8 +1128,6 @@ void gui_init(dt_lib_module_t *self)
   dt_lib_metadata_t *d = calloc(1, sizeof(dt_lib_metadata_t));
   self->data = (void *)d;
 
-  self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
-
   d->metadata_texts = g_hash_table_new(NULL, NULL);
   d->metadata_counts = g_hash_table_new(NULL, NULL);
   d->metadata_to_delete = NULL;
@@ -1138,15 +1136,14 @@ void gui_init(dt_lib_module_t *self)
   d->grid = grid;
   gtk_grid_set_row_spacing(GTK_GRID(grid), DT_PIXEL_APPLY_DPI(0));
   gtk_grid_set_column_spacing(GTK_GRID(grid), DT_PIXEL_APPLY_DPI(10));
-  gtk_container_add(GTK_CONTAINER(self->widget), grid);
-  _fill_grid(self);
 
   d->apply_button = dt_action_button_new(self, N_("apply"), _apply_button_clicked, self,
                                          _("write metadata for selected images"), 0, 0);
   d->cancel_button = dt_action_button_new(self, N_("cancel"), _cancel_button_clicked, self,
                                          _("ignore changed metadata"), 0, 0);
   d->button_box = dt_gui_hbox(d->apply_button, d->cancel_button);
-  gtk_container_add(GTK_CONTAINER(self->widget), d->button_box);
+  self->widget = dt_gui_vbox(grid, d->button_box);
+  _fill_grid(self);
 
   /* lets signup for mouse over image change signals */
   DT_CONTROL_SIGNAL_HANDLE(DT_SIGNAL_MOUSE_OVER_IMAGE_CHANGE, _image_selection_changed_callback);

--- a/src/libs/metadata_view.c
+++ b/src/libs/metadata_view.c
@@ -1584,13 +1584,10 @@ void gui_init(dt_lib_module_t *self)
 
   _lib_metadata_init_queue(self);
 
-  GtkWidget *child_grid_window = gtk_grid_new();
-  d->grid = child_grid_window;
-  gtk_grid_set_column_spacing(GTK_GRID(child_grid_window), DT_PIXEL_APPLY_DPI(5));
+  d->grid = gtk_grid_new();
+  gtk_grid_set_column_spacing(GTK_GRID(d->grid), DT_PIXEL_APPLY_DPI(5));
 
-  self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
-  gtk_container_add(GTK_CONTAINER(self->widget),
-                    dt_ui_resize_wrap(child_grid_window, 200, "plugins/lighttable/metadata_view/windowheight"));
+  self->widget = dt_gui_vbox(dt_ui_resize_wrap(d->grid, 200, "plugins/lighttable/metadata_view/windowheight"));
 
   gtk_widget_show_all(d->grid);
   gtk_widget_set_no_show_all(d->grid, TRUE);

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -2155,7 +2155,7 @@ static void _brush_opacity_down_callback(dt_action_t *action)
 static void _overlay_cycle_callback(dt_action_t *action)
 {
   const int currentval = dt_conf_get_int("darkroom/ui/overlay_color");
-  const int nextval = (currentval + 1) % 6; // colors can go from 0 to 5
+  const int nextval = (currentval + 1) % DT_DEV_OVERLAY_LAST; // colors can go from 0 to DT_DEV_OVERLAY_LAST-1
   dt_conf_set_int("darkroom/ui/overlay_color", nextval);
   dt_guides_set_overlay_colors();
   dt_control_queue_redraw_center();


### PR DESCRIPTION
Following up on #18273 and #19118

New work often gets copy/pasted from existing code so the longer the old pattern exists the more needs to be converted in the end.

This PR finishes all of iop and converts some libs. It does _not_ attempt to convert all dialogs at this point, since some of those (modulegroups/print) are probably better served with a partial redesign/rewrite when porting to gtk4.

Some more of the libs panel code could be done now, if somebody wants to step up. Please coordinate here if you plan to help out, so we don't do double work and I can review and comment early.

As usual this is partly tedious application of similar patterns, so the mental energy left for testing was very limited. This _especially_ applies to deprecated modules. A thorough review would be nice. And if someone went to hunt for newly introduced memory leaks, I'd be surprised if they didn't find any.