### PR TITLE
Update CONTRIBUTING.md with more up to date contact info

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,8 +16,8 @@ more information.
 
 Before you spend a lot of time working on a new feature, it's always best to
 discuss your proposed changes with us first.  The best place to do that is in
-our IRC channel on **ircs://irc.oftc.net:6697**, channel **#darktable** or the
-development mailing list, [see here for more
+our dev support [matrix channel](https://matrix.to/#/#darktable-dev:matrix.org), 
+or just create a Github Issue. For more places to discuss darktable, [see here for more
 information](https://www.darktable.org/contact/).  This will dramatically
 improve your chances of having your code merged, especially if we think you'll
 hang around to maintain it.


### PR DESCRIPTION
Based on details from the website and a brief discussion on IRC, it seems like the IRC channel is no longer considered a primary point of contact, and the mailing list has been removed entirely in favor of Github's systems. I think the repo's info should be up to date.