### PR TITLE
[innosetup] Correctly set environment variables during installation only for the current user

### DIFF
--- a/packaging/windows/darktable.iss.in
+++ b/packaging/windows/darktable.iss.in
@@ -78,13 +78,13 @@ Root: HKA; Subkey: "SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\{#MyAppC
   ValueData: "{app}\bin\{#MyAppCliExeName}"; \
   Flags: uninsdeletekey
 
-Root: HKLM; Subkey: "SYSTEM\CurrentControlSet\Control\Session Manager\Environment"; \
+Root: HKA; Subkey: "{code:EnvironmentKey}"; \
   ValueType: string; \
   ValueName: "CAMLIBS"; \
   ValueData: "{app}\lib\libgphoto2\${CPACK_NSIS_GPHOTO2_VERSION}"; \
   Flags: uninsdeletevalue
 
-Root: HKLM; Subkey: "SYSTEM\CurrentControlSet\Control\Session Manager\Environment"; \
+Root: HKA; Subkey: "{code:EnvironmentKey}"; \
   ValueType: string; \
   ValueName: "IOLIBS"; \
   ValueData: "{app}\lib\libgphoto2_port\${CPACK_NSIS_GPHOTO2_PORT_VERSION}"; \
@@ -101,3 +101,12 @@ Name: "{userappdata}\Microsoft\Internet Explorer\Quick Launch\{#MyAppName}"; \
 Filename: "{app}\bin\{#MyAppExeName}"; \
   Description: "{cm:LaunchProgram,{#StringChange(MyAppName, '&', '&&')}}"; \
   Flags: nowait postinstall skipifsilent
+
+[Code]
+function EnvironmentKey(Param: String): String;
+begin
+  if IsAdminInstallMode then
+    Result := 'SYSTEM\CurrentControlSet\Control\Session Manager\Environment'
+  else
+    Result := 'Environment'
+end;


### PR DESCRIPTION
The Inno Setup-based installer supports installation only for the current user, unlike the old NSIS installer. We need to take this into account. In this case, we will not be able to write environment variables to the all-user branch (HKEY_LOCAL_MACHINE), because the installer will run without using administrative privileges.

P.S. Yes, I know, CMake variables with the "CPACK_NSIS" part of the name are still used. This will be polished later. For now, I'm focusing on the correctness of the installer's functioning.
