### PR TITLE
[innosetup] Do not offer Quick Launch on Windows 11

### DIFF
--- a/packaging/windows/darktable.iss.in
+++ b/packaging/windows/darktable.iss.in
@@ -53,7 +53,9 @@ WizardStyle=modern
 
 [Tasks]
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
-Name: "quicklaunchicon"; Description: "{cm:CreateQuickLaunchIcon}"; Flags: unchecked
+
+; We don't offer Quick Launch for Windows 11 (initial build number 10.0.22000) where it's not supported
+Name: "quicklaunchicon"; Description: "{cm:CreateQuickLaunchIcon}"; OnlyBelowVersion: 10.0.22000
 
 [Files]
 Source: "bin\*"; DestDir: "{app}\bin"; Flags: ignoreversion recursesubdirs createallsubdirs


### PR DESCRIPTION
We should not offer to add an icon to Quick Launch on Windows 11 where it is not supported.
