### PR TITLE
More demosaic maintenance

### DIFF
--- a/data/kernels/common.h
+++ b/data/kernels/common.h
@@ -73,7 +73,18 @@ FC(const int row, const int col, const unsigned int filters)
 static inline int
 FCxtrans(const int row, const int col, global const unsigned char (*const xtrans)[6])
 {
-  return xtrans[row % 6][col % 6];
+  // There used to be a few cases in xtrans demosaicers in which row or col was negative.
+  // The +600 ensures a non-negative array index as in CPU code
+  return xtrans[(row + 600) % 6][(col + 600) % 6];
+}
+
+int
+fcol(const int row, const int col, const unsigned int filters, global const unsigned char (*const xtrans)[6])
+{
+  if(filters == 9)
+    return FCxtrans(row, col, xtrans);
+  else
+    return FC(row, col, filters);
 }
 
 

--- a/data/kernels/demosaic_markesteijn.cl
+++ b/data/kernels/demosaic_markesteijn.cl
@@ -36,12 +36,6 @@ hexidx4(const char2 hex, const int stride)
   return mul24(mad24(hex.y, stride, hex.x), 4);
 }
 
-float
-sqr(const float x)
-{
-  return x * x;
-}
-
 // copy image from image object to buffer.
 kernel void
 markesteijn_initial_copy(read_only image2d_t in, global float *rgb, const int width, const int height,
@@ -333,8 +327,8 @@ markesteijn_solitary_green(global float *rgb, global float *aux, const int width
     const int off = i << c;
     const float g = 2.0f * buff[1] - (buff + off)[1] - (buff - off)[1];
     color[h] = g + (buff + off)[h] + (buff - off)[h];
-    diff += (d > 1) ? sqr((buff + off)[1] - (buff - off)[1] - (buff + off)[h] + (buff - off)[h])
-                      + sqr(g)
+    diff += (d > 1) ? fsquare((buff + off)[1] - (buff - off)[1] - (buff + off)[h] + (buff - off)[h])
+                      + fsquare(g)
                     : 0.0f;
   }
 
@@ -641,9 +635,9 @@ markesteijn_differentiate(global float *yuv, global float *drv, const int width,
   const char2 p = dir[d & 3];
   const int off = 4 * mad24(p.y, stride, p.x);
 
-  drv[0] = sqr(2.0f * (buff)[0] - (buff + off)[0] - (buff - off)[0])
-           + sqr(2.0f * (buff)[1] - (buff + off)[1] - (buff - off)[1])
-           + sqr(2.0f * (buff)[2] - (buff + off)[2] - (buff - off)[2]);
+  drv[0] = fsquare(2.0f * (buff)[0] - (buff + off)[0] - (buff - off)[0])
+           + fsquare(2.0f * (buff)[1] - (buff + off)[1] - (buff - off)[1])
+           + fsquare(2.0f * (buff)[2] - (buff + off)[2] - (buff - off)[2]);
 }
 
 

--- a/data/kernels/demosaic_other.cl
+++ b/data/kernels/demosaic_other.cl
@@ -96,10 +96,10 @@ clip_and_zoom_demosaic_passthrough_monochrome(__read_only image2d_t in,
     const float xfilter = (i == 0) ? 1.0f - d.x : ((i == samples+1) ? d.x : 1.0f);
     const float yfilter = (j == 0) ? 1.0f - d.y : ((j == samples+1) ? d.y : 1.0f);
 
-    const float px = read_imagef(in, sampleri, (int2)(xx, yy)).x;
+    const float px = fmax(0.0f, read_imagef(in, sampleri, (int2)(xx, yy)).x);
     color += yfilter*xfilter*(float4)(px, px, px, 0.0f);
     weight += yfilter*xfilter;
   }
-  color = (weight > 0.0f) ? fmax(0.0f, color)/weight : (float4)0.0f;
+  color = (weight > 0.0f) ? color/weight : (float4)0.0f;
   write_imagef (out, (int2)(x, y), color);
 }

--- a/data/kernels/demosaic_vng.cl
+++ b/data/kernels/demosaic_vng.cl
@@ -18,17 +18,6 @@
 
 #include "common.h"
 
-int
-fcol(const int row, const int col, const unsigned int filters, global const unsigned char (*const xtrans)[6])
-{
-  if(filters == 9)
-    // There are a few cases in VNG demosaic in which row or col is -1
-    // or -2. The +6 ensures a non-negative array index.
-    return FCxtrans(row + 6, col + 6, xtrans);
-  else
-    return FC(row, col, filters);
-}
-
 kernel void
 vng_border_interpolate(read_only image2d_t in,
                        write_only image2d_t out,

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -1483,13 +1483,26 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
   gtk_widget_set_sensitive(g->cs_center, do_capture && p->cs_boost);
   gtk_widget_set_sensitive(g->cs_iter, capture_support);
 
-  // we might have a wrong method dur to xtrans/bayer - mode mismatch
-  if(bayer)
-    dt_bauhaus_combobox_set_from_value(g->demosaic_method_bayer, use_method);
-  else if(xtrans)
-    dt_bauhaus_combobox_set_from_value(g->demosaic_method_xtrans, use_method);
-  else
-    dt_bauhaus_combobox_set_from_value(g->demosaic_method_bayerfour, use_method);
+  // we might have a wrong method due to xtrans/bayer - mode mismatch
+  const gboolean method_mismatch = use_method != p->demosaicing_method;
+  if(method_mismatch)
+  {
+    if(bayer)
+      dt_bauhaus_combobox_set_from_value(g->demosaic_method_bayer, use_method);
+    else if(xtrans)
+      dt_bauhaus_combobox_set_from_value(g->demosaic_method_xtrans, use_method);
+    else
+      dt_bauhaus_combobox_set_from_value(g->demosaic_method_bayerfour, use_method);
+
+    /*  If auto-applied from a preset/style from a different sensor type it's demosaicer
+        method was added to the current sensor specific demosaicer combobox.
+        As we know the bad method here, we can remove it from the combobox by testing for it's position.
+    */
+    GtkWidget *demosaicers =  bayer  ? g->demosaic_method_bayer :
+                              xtrans ? g->demosaic_method_xtrans : g->demosaic_method_bayerfour;
+    const int pos = dt_bauhaus_combobox_get_from_value(demosaicers, p->demosaicing_method);
+    if(pos >= 0) dt_bauhaus_combobox_remove_at(demosaicers, pos);
+  }
 
   p->demosaicing_method = use_method;
 

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -1102,8 +1102,7 @@ int process_cl(dt_iop_module_t *self,
         if(err != CL_SUCCESS) goto finish;
       }
     }
-    dt_opencl_finish_sync_pipe(devid, pipe->type);
-   }
+  }
 
   if(greens)  // release early for less cl memory load
   {

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -80,7 +80,7 @@ typedef enum dt_iop_demosaic_method_t
   DT_IOP_DEMOSAIC_PASSTHR_COLORX = DT_DEMOSAIC_XTRANS | 5, // $DESCRIPTION: "photosite color (debug)"
 } dt_iop_demosaic_method_t;
 
-static const char *_method_str(int method)
+static const char *_method_str(const int method)
 {
   switch(method)
   {
@@ -675,7 +675,7 @@ void process(dt_iop_module_t *self,
   const gboolean passthru = method == DT_IOP_DEMOSAIC_PASSTHROUGH_MONOCHROME
                          || method == DT_IOP_DEMOSAIC_PASSTHROUGH_COLOR;
   const gboolean do_capture = !passthru &&  !is_4bayer && !show_dual && !run_fast && d->cs_iter;
-  const gboolean greens = is_bayer && d->green_eq != DT_IOP_GREEN_EQ_NO && no_masking;
+  const gboolean greens = is_bayer && d->green_eq != DT_IOP_GREEN_EQ_NO && no_masking && !run_fast;
 
   const float procmax = dt_iop_get_processed_maximum(piece);
   const float procmin = dt_iop_get_processed_minimum(piece);
@@ -836,7 +836,7 @@ void process(dt_iop_module_t *self,
   if(pipe->want_detail_mask)
     dt_dev_write_scharr_mask(piece, out, roi_in, TRUE);
 
-  if(d->color_smoothing != DT_DEMOSAIC_SMOOTH_OFF && no_masking)
+  if(d->color_smoothing != DT_DEMOSAIC_SMOOTH_OFF && no_masking && !run_fast)
     color_smoothing(out, width, height, d->color_smoothing);
 
   if(!direct)
@@ -962,7 +962,7 @@ int process_cl(dt_iop_module_t *self,
   const gboolean passthru = method == DT_IOP_DEMOSAIC_PASSTHROUGH_MONOCHROME
                          || method == DT_IOP_DEMOSAIC_PASSTHROUGH_COLOR;
   const gboolean do_capture = !passthru && !run_fast && !show_dual && d->cs_iter;
-  const gboolean greens = is_bayer && d->green_eq != DT_IOP_GREEN_EQ_NO && no_masking;
+  const gboolean greens = is_bayer && d->green_eq != DT_IOP_GREEN_EQ_NO && no_masking && !run_fast;
 
   if(do_capture)
     _capture_radius_cl(self, piece, dev_in, iwidth, iheight, xtrans, filters);
@@ -1132,7 +1132,7 @@ int process_cl(dt_iop_module_t *self,
     if(err != CL_SUCCESS) goto finish;
   }
 
-  if(d->color_smoothing != DT_DEMOSAIC_SMOOTH_OFF && no_masking)
+  if(d->color_smoothing != DT_DEMOSAIC_SMOOTH_OFF && no_masking && !run_fast)
   {
     err = color_smoothing_cl(self, piece, out_image, out_image, iwidth, iheight, d->color_smoothing);
     if(err != CL_SUCCESS) goto finish;
@@ -1552,7 +1552,7 @@ void gui_update(dt_iop_module_t *self)
   g->autoradius = FALSE;
 }
 
-static void _dual_quad_callback(GtkWidget *quad, dt_iop_module_t *self)
+static void _dual_thrs_callback(GtkWidget *quad, dt_iop_module_t *self)
 {
   if(darktable.gui->reset) return;
   dt_iop_demosaic_gui_data_t *g = self->gui_data;
@@ -1567,7 +1567,7 @@ static void _dual_quad_callback(GtkWidget *quad, dt_iop_module_t *self)
   dt_dev_reprocess_center(self->dev);
 }
 
-static void _cs_quad_callback(GtkWidget *quad, dt_iop_module_t *self)
+static void _cs_thrs_callback(GtkWidget *quad, dt_iop_module_t *self)
 {
   if(darktable.gui->reset) return;
   dt_iop_demosaic_gui_data_t *g = self->gui_data;
@@ -1595,7 +1595,7 @@ static void _cs_boost_callback(GtkWidget *quad, dt_iop_module_t *self)
   dt_dev_reprocess_center(self->dev);
 }
 
-static void _cs_autoradius_callback(GtkWidget *quad, dt_iop_module_t *self)
+static void _cs_radius_callback(GtkWidget *quad, dt_iop_module_t *self)
 {
   if(darktable.gui->reset) return;
   dt_iop_demosaic_gui_data_t *g = self->gui_data;
@@ -1603,7 +1603,7 @@ static void _cs_autoradius_callback(GtkWidget *quad, dt_iop_module_t *self)
   dt_dev_reprocess_center(self->dev);
 }
 
-static void _check_autoradius(gpointer instance, dt_iop_module_t *self)
+static void _ui_pipe_done(gpointer instance, dt_iop_module_t *self)
 {
   dt_iop_demosaic_gui_data_t *g = self->gui_data;
   if(g && g->autoradius)
@@ -1615,7 +1615,7 @@ static void _check_autoradius(gpointer instance, dt_iop_module_t *self)
   }
 }
 
-void gui_focus(dt_iop_module_t *self, gboolean in)
+void gui_focus(dt_iop_module_t *self, const gboolean in)
 {
   dt_iop_demosaic_gui_data_t *g = self->gui_data;
   if(!in)
@@ -1659,7 +1659,7 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_slider_set_digits(g->dual_thrs, 2);
   gtk_widget_set_tooltip_text(g->dual_thrs, _("contrast threshold for dual demosaic.\nset to 0.0 for high frequency content\n"
                                                 "set to 1.0 for flat content"));
-  dt_bauhaus_widget_set_quad(g->dual_thrs, self, dtgtk_cairo_paint_showmask, TRUE, _dual_quad_callback,
+  dt_bauhaus_widget_set_quad(g->dual_thrs, self, dtgtk_cairo_paint_showmask, TRUE, _dual_thrs_callback,
                              _("toggle mask visualization"));
 
   g->median_thrs = dt_bauhaus_slider_from_params(self, "median_thrs");
@@ -1692,8 +1692,7 @@ void gui_init(dt_iop_module_t *self)
                                               "of the camera sensor, possibly the anti-aliasing filter and the lens.\n"
                                               "increasing this too far will soon lead to artifacts like halos and\n"
                                               "ringing especially when used with a large 'sharpen' setting"));
-  dt_bauhaus_slider_set_hard_min(g->cs_radius, 0.01f);
-  dt_bauhaus_widget_set_quad(g->cs_radius, self, dtgtk_cairo_paint_reset, FALSE, _cs_autoradius_callback,
+  dt_bauhaus_widget_set_quad(g->cs_radius, self, dtgtk_cairo_paint_reset, FALSE, _cs_radius_callback,
     _("calculate the capture sharpen radius from sensor data.\n"
       "this should be done in zoomed out darkroom"));
   g->autoradius = FALSE;
@@ -1702,7 +1701,7 @@ void gui_init(dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->cs_thrs, _("restrict capture sharpening to areas with high local contrast,\n"
                                             "increase to exclude flat areas in very dark or noisy images,\n"
                                             "decrease for well exposed and low noise images"));
-  dt_bauhaus_widget_set_quad(g->cs_thrs, self, dtgtk_cairo_paint_showmask, TRUE, _cs_quad_callback, _("visualize sharpened areas"));
+  dt_bauhaus_widget_set_quad(g->cs_thrs, self, dtgtk_cairo_paint_showmask, TRUE, _cs_thrs_callback, _("visualize sharpened areas"));
 
   g->cs_boost = dt_bauhaus_slider_from_params(self, "cs_boost");
   dt_bauhaus_slider_set_digits(g->cs_boost, 2);
@@ -1725,7 +1724,7 @@ void gui_init(dt_iop_module_t *self)
 
   gtk_stack_add_named(GTK_STACK(self->widget), label_non_raw, "non_raw");
   gtk_stack_add_named(GTK_STACK(self->widget), box_raw, "raw");
-  DT_CONTROL_SIGNAL_HANDLE(DT_SIGNAL_DEVELOP_UI_PIPE_FINISHED, _check_autoradius);
+  DT_CONTROL_SIGNAL_HANDLE(DT_SIGNAL_DEVELOP_UI_PIPE_FINISHED, _ui_pipe_done);
 }
 
 // clang-format off

--- a/src/iop/demosaicing/capture.c
+++ b/src/iop/demosaicing/capture.c
@@ -183,12 +183,12 @@ static float _calcRadiusBayer(const float *in,
             { // check for influence by clipped green in neighborhood
               if(MAX(MAX(cfa[-width-1], cfa[-width+1]), val1p1) >= upperLimit)
                 continue;
-             }
+            }
             else
             { // check for influence by clipped green in neighborhood
               if(MAX(MAX(MAX(val00, cfa[2]), cfa[2*width]), cfa[2*width+2]) >= upperLimit)
                 continue;
-             }
+            }
             maxRatio = maxVal1 / minVal;
           }
         }


### PR DESCRIPTION
**Fix bad demosaicer when preset/style/copied history don't match**

If auto-applied from a preset/style from a different sensor type it's demosaicer method was added to the current sensor specific demosaicer combobox.
As we know the bad method here, we can and should remove it from the combobox by testing for it's position.

_______________________________________________________
**Some OpenCL demosaicer maintenance**

- removed the dt_opencl_finish_sync_pipe() call while tiling as there were crashes and not helping.
- Constify and deduplications.

_________________________________________________________
**Demosaicer fast pipe performance**

If a pipe is running in fast mode or it's a preview pipe we don't want green equilibration and color smoothing for performance.

Some constify and function renaming for readability