### PR TITLE
**RFC**: Change some processing modules widgets sensitivity to visibility for consistency

### DIFF
--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -694,8 +694,8 @@ void gui_update(dt_iop_module_t *self)
     (GTK_LABEL(gtk_bin_get_child(GTK_BIN(g->compensate_hilite_preserv))),
      PANGO_ELLIPSIZE_MIDDLE);
   g_free(label);
-  gtk_widget_set_sensitive(GTK_WIDGET(g->compensate_hilite_preserv), hlbias > 0.0f);
-  
+  gtk_widget_set_visible(GTK_WIDGET(g->compensate_hilite_preserv), hlbias > 0.0f);
+
   g->spot_RGB[0] = 0.f;
   g->spot_RGB[1] = 0.f;
   g->spot_RGB[2] = 0.f;


### PR DESCRIPTION
Having checked how we handle non-applicable processing modules widgets, do we make them insensitive or hide them. In the vast majority of cases there are hidden.

I checked all cases in src/iop and ran into these cases where i think the widgets should be hidden instead of made insensitive for consistency, the other cases should be kept as they are as hiding the widget would hide valuable information. I ignored filmicrgb and deprecated modules intentionally  ...

See also #19389

____________________________________________________________
   
**channelmixerrgb**
It makes no sense to show adaptation mode when using illuminant as-shot-in-camera so let's hide it.

**exposure**
If there is no provided preservation data we should not show this entry, not only because it's not applicable but also as it might confuse the user and the tooltip is worthless.

**ashift**
Only show the fit actions if structure data is provided.
