### PR TITLE
Fix race-condition corruption of XMP files during large import

### DIFF
--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -5320,6 +5320,7 @@ char *dt_exif_xmp_read_string(const dt_imgid_t imgid)
 {
   try
   {
+    Lock lock;
     char input_filename[PATH_MAX] = { 0 };
     dt_image_full_path(imgid, input_filename, sizeof(input_filename), NULL);
 
@@ -5714,6 +5715,7 @@ gboolean dt_exif_xmp_attach_export(const dt_imgid_t imgid,
     g_strlcat(input_filename, ".xmp", sizeof(input_filename));
     if(g_file_test(input_filename, G_FILE_TEST_EXISTS))
     {
+      Lock lock;
       Exiv2::XmpData sidecarXmpData;
       std::string xmpPacket;
 
@@ -5982,6 +5984,7 @@ gboolean dt_exif_xmp_write(const dt_imgid_t imgid,
 
   try
   {
+    Lock lock;
     Exiv2::XmpData xmpData;
     std::string xmpPacket;
     char *checksum_old = NULL;


### PR DESCRIPTION
When importing a 600+ file folder that contains raws and sidecars, darktable (tested with 5.2.1) will randomly corrupt a few of the sidecars during import, and replace them with empty edit stacks.

This is due to running two parallel threads that read and write different XMP files, causing exiv2 to mess up its namespace maps. This PR fixes the issue by extending the `Lock` in the exif code to also guard metadata writes and XMP operations.

I only tested the implications on `dt_exif_xmp_write()` which was running into the corruption issue for me. I'm not 100% sure how to trigger the other places I changed ;-)

Original issue description: https://discuss.pixls.us/t/exiv2-data-corruption-when-importing-a-folder-with-xmps/52800