### PR TITLE
Expose darktable share and data directories to Lua

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -129,17 +129,28 @@ changes (where available).
 - Make sure we always fill the complete main darkroom canvas while
   zooming at large scales.
 
+- Make sure image changed_timestamp is updated when a sidecar file
+  is applied.
+
 ## Lua
 
 ### API Version
 
-- API version is now 9.5.0
+- API version is now 9.6.0
 
 ### New Features
 
-- ???
+- Added darktable.query_event() to check if an event is registered.
+
+- Added collection-changed event that fires when the collection changes.
+
+- Added darktable.configuration.share_dir and darktable.configuration.data_dir
+  to expose the darktable data and share directories.
 
 ### Bug Fixes
+
+- Check added to ensure view has changed before processing GUI events
+  preventing hang on start.
 
 ### Add action support for Lua
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -123,6 +123,12 @@ changes (where available).
 - Fixed corruption of sidecars during large imports of images with XMP
   sidecars.
 
+- Fixed a bug where changing the image scaling in the export module
+  influences the result of a running export job.
+
+- Make sure we always fill the complete main darkroom canvas while
+  zooming at large scales.
+
 ## Lua
 
 ### API Version
@@ -134,12 +140,6 @@ changes (where available).
 - ???
 
 ### Bug Fixes
-
-- Fixed a bug where changing the image scaling in the export module
-  influences the result of a running export job.
-
-- Make sure we always fill the complete main darkroom canvas while
-  zooming at large scales.
 
 ### Add action support for Lua
 

--- a/src/lua/configuration.c
+++ b/src/lua/configuration.c
@@ -109,6 +109,16 @@ int dt_lua_init_configuration(lua_State *L)
   lua_pushstring(L, tmp_path);
   lua_settable(L, -3);
 
+  lua_pushstring(L, "share_dir");
+  dt_loc_get_sharedir(tmp_path, sizeof(tmp_path));
+  lua_pushstring(L, tmp_path);
+  lua_settable(L, -3);
+
+  lua_pushstring(L, "data_dir");
+  dt_loc_get_datadir(tmp_path, sizeof(tmp_path));
+  lua_pushstring(L, tmp_path);
+  lua_settable(L, -3);
+
   lua_pushstring(L, "version");
   lua_pushstring(L, darktable_package_version);
   lua_settable(L, -3);


### PR DESCRIPTION
While working with others on moving the website gallery functions from darktable to the Lua scripts we realized we needed access to some darktable assets, such as photoswipe.  In order to access the assets we need to know the installed path to them.

Filled in the Lua section of RELEASE_NOTES