### PR TITLE
Don't save style files with an empty name

### DIFF
--- a/src/common/styles.c
+++ b/src/common/styles.c
@@ -1470,7 +1470,14 @@ static void dt_styles_style_text_handler(GMarkupParseContext *context,
 
   if(g_ascii_strcasecmp(elt, "name") == 0)
   {
-    g_string_append_len(style->info->name, text, text_len);
+    if (text_len == 0)
+    {
+      g_string_append(style->info->name, _("imported-style"));
+    }
+    else
+    {
+      g_string_append_len(style->info->name, text, text_len);
+    }
   }
   else if(g_ascii_strcasecmp(elt, "description") == 0)
   {
@@ -1781,6 +1788,16 @@ gchar *dt_get_style_name(const char *filename)
   if(!bname){
     dt_print(DT_DEBUG_CONTROL,
              "[styles] file %s is a malformed style file", filename);
+  }
+  else
+  {
+    if(strlen(bname) == 0)
+    {
+      dt_print(DT_DEBUG_CONTROL,
+             "[styles] file %s is a malformed style file (with an empty name)", filename);
+      g_free(bname);
+      bname = g_strdup(_("imported-style"));
+    }
   }
   return bname;
 }


### PR DESCRIPTION
If a dtstyle file has a name tag with an empty string, like `<name></name>`, we don't want to allow that file to be imported.

This commit changes `dt_get_style_name` so that if there is a name tag, but the name tag is empty, it will return NULL for the style name.  The `_import_clicked` routine for style importing will simply ignore the file if it returns a NULL name, thus not allowing the style to be imported:

  https://github.com/darktable-org/darktable/blob/f552cf75c6b0dba298e04bba071a99daaa3951d0/src/libs/styles.c#L616-L619

Related to #19431

This patch works on my machine.  I'm pretty new to this codebase, so I'm not sure how tests are implemented (or if this needs one).

An odd thing though is that I always get an error when the import dialog rejects a file (expand the details to see error info):

<details>

```
/Users/aaron/Downloads/calibrite-PROFILER-2.0.0.dmg:1: parser error : Start tag expected, '<' not found
BZh11AY&SY?ԛ?
^
    40.9359 [styles] file /Users/aaron/Downloads/calibrite-PROFILER-2.0.0.dmg is not a style file

(darktable:59292): GLib-GIO-ERROR **: 11:33:38.436: No GSettings schemas are installed on the system
Process 59292 stopped
* thread #1, queue = 'com.apple.main-thread', stop reason = EXC_BREAKPOINT (code=1, subcode=0x101ebbcf0)
    frame #0: 0x0000000101ebbcf0 libglib-2.0.0.dylib`_g_log_abort + 40
libglib-2.0.0.dylib`_g_log_abort:
->  0x101ebbcf0 <+40>: brk    #0x1

libglib-2.0.0.dylib`g_log_structured:
    0x101ebbcf4 <+0>:  stp    x28, x27, [sp, #-0x60]!
    0x101ebbcf8 <+4>:  stp    x26, x25, [sp, #0x10]
    0x101ebbcfc <+8>:  stp    x24, x23, [sp, #0x20]
Target 0: (darktable) stopped.
(lldb) bt
* thread #1, queue = 'com.apple.main-thread', stop reason = EXC_BREAKPOINT (code=1, subcode=0x101ebbcf0)
  * frame #0: 0x0000000101ebbcf0 libglib-2.0.0.dylib`_g_log_abort + 40
    frame #1: 0x0000000101ebc060 libglib-2.0.0.dylib`g_log_structured_array + 228
    frame #2: 0x0000000101ebbb3c libglib-2.0.0.dylib`g_log_default_handler + 204
    frame #3: 0x0000000101ebb738 libglib-2.0.0.dylib`g_logv + 836
    frame #4: 0x0000000101ebb3b4 libglib-2.0.0.dylib`g_log + 28
    frame #5: 0x00000001023a4550 libgio-2.0.0.dylib`g_settings_set_property + 268
    frame #6: 0x00000001008d8870 libgobject-2.0.0.dylib`object_set_property + 196
    frame #7: 0x00000001008d8260 libgobject-2.0.0.dylib`g_object_new_internal + 288
    frame #8: 0x00000001008d7f6c libgobject-2.0.0.dylib`g_object_new_valist + 1076
    frame #9: 0x00000001008d78f8 libgobject-2.0.0.dylib`g_object_new + 32
    frame #10: 0x00000001023a1758 libgio-2.0.0.dylib`g_settings_new + 44
    frame #11: 0x00000001027dd784 libgtk-3.0.dylib`_gtk_file_chooser_get_settings_for_widget + 112
    frame #12: 0x00000001027e78bc libgtk-3.0.dylib`gtk_file_chooser_widget_get_default_size + 48
    frame #13: 0x00000001027d9704 libgtk-3.0.dylib`file_chooser_widget_default_size_changed + 112
    frame #14: 0x00000001008d2500 libgobject-2.0.0.dylib`g_closure_invoke + 192
    frame #15: 0x00000001008e70c8 libgobject-2.0.0.dylib`signal_emit_unlocked_R + 1284
    frame #16: 0x00000001008e62f0 libgobject-2.0.0.dylib`signal_emit_valist_unlocked + 1812
    frame #17: 0x00000001008e67d0 libgobject-2.0.0.dylib`g_signal_emit_by_name + 240
    frame #18: 0x00000001008d56b0 libgobject-2.0.0.dylib`g_cclosure_marshal_VOID__OBJECTv + 100
    frame #19: 0x00000001008d26e0 libgobject-2.0.0.dylib`_g_closure_invoke_va + 204
    frame #20: 0x00000001008e5f38 libgobject-2.0.0.dylib`signal_emit_valist_unlocked + 860
    frame #21: 0x00000001008e5bb0 libgobject-2.0.0.dylib`g_signal_emit_valist + 64
    frame #22: 0x00000001008e66d4 libgobject-2.0.0.dylib`g_signal_emit + 28
    frame #23: 0x000000010297ab38 libgtk-3.0.dylib`do_screen_change + 140
    frame #24: 0x00000001029709b4 libgtk-3.0.dylib`gtk_widget_propagate_hierarchy_changed_recurse + 256
    frame #25: 0x0000000102738ad8 libgtk-3.0.dylib`gtk_box_forall + 72
    frame #26: 0x00000001029709f0 libgtk-3.0.dylib`gtk_widget_propagate_hierarchy_changed_recurse + 316
    frame #27: 0x0000000102969e74 libgtk-3.0.dylib`_gtk_widget_propagate_hierarchy_changed + 156
    frame #28: 0x00000001029699d4 libgtk-3.0.dylib`gtk_widget_unparent + 516
    frame #29: 0x0000000102734530 libgtk-3.0.dylib`gtk_bin_remove + 60
    frame #30: 0x00000001008d56b0 libgobject-2.0.0.dylib`g_cclosure_marshal_VOID__OBJECTv + 100
    frame #31: 0x00000001008d26e0 libgobject-2.0.0.dylib`_g_closure_invoke_va + 204
    frame #32: 0x00000001008e5f38 libgobject-2.0.0.dylib`signal_emit_valist_unlocked + 860
    frame #33: 0x00000001008e5bb0 libgobject-2.0.0.dylib`g_signal_emit_valist + 64
    frame #34: 0x00000001008e66d4 libgobject-2.0.0.dylib`g_signal_emit + 28
    frame #35: 0x000000010277cdc8 libgtk-3.0.dylib`gtk_container_remove + 152
    frame #36: 0x0000000102978a40 libgtk-3.0.dylib`gtk_widget_dispose + 40
    frame #37: 0x00000001008d6ec8 libgobject-2.0.0.dylib`g_object_run_dispose + 72
    frame #38: 0x000000010298aa68 libgtk-3.0.dylib`gtk_window_forall + 108
    frame #39: 0x000000010277eb40 libgtk-3.0.dylib`gtk_container_destroy + 88
    frame #40: 0x00000001008d2500 libgobject-2.0.0.dylib`g_closure_invoke + 192
    frame #41: 0x00000001008e74cc libgobject-2.0.0.dylib`signal_emit_unlocked_R + 2312
    frame #42: 0x00000001008e62f0 libgobject-2.0.0.dylib`signal_emit_valist_unlocked + 1812
    frame #43: 0x00000001008e5bb0 libgobject-2.0.0.dylib`g_signal_emit_valist + 64
    frame #44: 0x00000001008e66d4 libgobject-2.0.0.dylib`g_signal_emit + 28
    frame #45: 0x0000000102978a98 libgtk-3.0.dylib`gtk_widget_dispose + 128
    frame #46: 0x0000000102988424 libgtk-3.0.dylib`gtk_window_dispose + 88
    frame #47: 0x00000001008d6ec8 libgobject-2.0.0.dylib`g_object_run_dispose + 72
    frame #48: 0x00000001027db96c libgtk-3.0.dylib`gtk_file_chooser_native_finalize + 104
    frame #49: 0x00000001008d7354 libgobject-2.0.0.dylib`g_object_unref + 644
    frame #50: 0x000000012296e23c libstyles.so`_import_clicked(w=0x0000000137b38020, d=0x00006000006e8b90) at styles.c:731:3
    frame #51: 0x00000001008d26e0 libgobject-2.0.0.dylib`_g_closure_invoke_va + 204
    frame #52: 0x00000001008e5f38 libgobject-2.0.0.dylib`signal_emit_valist_unlocked + 860
    frame #53: 0x00000001008e5bb0 libgobject-2.0.0.dylib`g_signal_emit_valist + 64
    frame #54: 0x00000001008e66d4 libgobject-2.0.0.dylib`g_signal_emit + 28
    frame #55: 0x000000010274695c libgtk-3.0.dylib`gtk_real_button_released + 240
    frame #56: 0x00000001008d26e0 libgobject-2.0.0.dylib`_g_closure_invoke_va + 204
    frame #57: 0x00000001008e5f38 libgobject-2.0.0.dylib`signal_emit_valist_unlocked + 860
    frame #58: 0x00000001008e5bb0 libgobject-2.0.0.dylib`g_signal_emit_valist + 64
    frame #59: 0x00000001008e66d4 libgobject-2.0.0.dylib`g_signal_emit + 28
    frame #60: 0x0000000102746e70 libgtk-3.0.dylib`multipress_released_cb + 48
    frame #61: 0x0000000102709f04 libgtk-3.0.dylib`_gtk_marshal_VOID__INT_DOUBLE_DOUBLEv + 80
    frame #62: 0x00000001008d26e0 libgobject-2.0.0.dylib`_g_closure_invoke_va + 204
    frame #63: 0x00000001008e5f38 libgobject-2.0.0.dylib`signal_emit_valist_unlocked + 860
    frame #64: 0x00000001008e5bb0 libgobject-2.0.0.dylib`g_signal_emit_valist + 64
    frame #65: 0x00000001008e66d4 libgobject-2.0.0.dylib`g_signal_emit + 28
    frame #66: 0x0000000102802498 libgtk-3.0.dylib`gtk_gesture_multi_press_end + 128
    frame #67: 0x00000001008d548c libgobject-2.0.0.dylib`g_cclosure_marshal_VOID__BOXEDv + 112
    frame #68: 0x00000001008d26e0 libgobject-2.0.0.dylib`_g_closure_invoke_va + 204
    frame #69: 0x00000001008e5f38 libgobject-2.0.0.dylib`signal_emit_valist_unlocked + 860
    frame #70: 0x00000001008e5bb0 libgobject-2.0.0.dylib`g_signal_emit_valist + 64
    frame #71: 0x00000001008e66d4 libgobject-2.0.0.dylib`g_signal_emit + 28
    frame #72: 0x0000000102800fec libgtk-3.0.dylib`_gtk_gesture_set_recognized + 88
    frame #73: 0x00000001027feea4 libgtk-3.0.dylib`_gtk_gesture_check_recognized + 68
    frame #74: 0x00000001028007d0 libgtk-3.0.dylib`gtk_gesture_handle_event + 248
    frame #75: 0x0000000102803d48 libgtk-3.0.dylib`gtk_gesture_single_handle_event + 368
    frame #76: 0x00000001027cdde0 libgtk-3.0.dylib`gtk_event_controller_handle_event + 124
    frame #77: 0x000000010296dbc8 libgtk-3.0.dylib`_gtk_widget_run_controllers + 124
    frame #78: 0x00000001027056ec libgtk-3.0.dylib`_gtk_marshal_BOOLEAN__BOXEDv + 124
    frame #79: 0x00000001008d26e0 libgobject-2.0.0.dylib`_g_closure_invoke_va + 204
    frame #80: 0x00000001008e5f38 libgobject-2.0.0.dylib`signal_emit_valist_unlocked + 860
    frame #81: 0x00000001008e5bb0 libgobject-2.0.0.dylib`g_signal_emit_valist + 64
    frame #82: 0x00000001008e66d4 libgobject-2.0.0.dylib`g_signal_emit + 28
    frame #83: 0x000000010296d7f0 libgtk-3.0.dylib`gtk_widget_event_internal + 300
    frame #84: 0x000000010284640c libgtk-3.0.dylib`propagate_event + 388
    frame #85: 0x0000000102845830 libgtk-3.0.dylib`gtk_main_do_event + 1048
    frame #86: 0x00000001007d65a8 libgdk-3.0.dylib`_gdk_event_emit + 64
    frame #87: 0x00000001007fa1c8 libgdk-3.0.dylib`gdk_event_dispatch + 52
    frame #88: 0x0000000101eb549c libglib-2.0.0.dylib`g_main_context_dispatch_unlocked + 236
    frame #89: 0x0000000101eb57ac libglib-2.0.0.dylib`g_main_context_iterate_unlocked + 484
    frame #90: 0x0000000101eb59d0 libglib-2.0.0.dylib`g_main_loop_run + 120
    frame #91: 0x00000001028452b4 libgtk-3.0.dylib`gtk_main + 92
    frame #92: 0x00000001010f5864 libdarktable.dylib`dt_gui_gtk_run(gui=0x0000000133048200) at gtk.c:1594:5
    frame #93: 0x0000000101168bf4 libdarktable.dylib`apple_main(argc=3, argv=0x0000600002519820) at main.c:158:5
    frame #94: 0x00000001011662f8 libdarktable.dylib`-[AppDelegate applicationDidFinishLaunching:](self=0x0000600002506920, _cmd="applicationDidFinishLaunching:", aNotification="NSApplicationDidFinishLaunchingNotification") at osx.mm:361:5
    frame #95: 0x000000019d69b46c CoreFoundation`__CFNOTIFICATIONCENTER_IS_CALLING_OUT_TO_AN_OBSERVER__ + 148
    frame #96: 0x000000019d72ab28 CoreFoundation`___CFXRegistrationPost_block_invoke + 92
    frame #97: 0x000000019d72aa6c CoreFoundation`_CFXRegistrationPost + 436
    frame #98: 0x000000019d66a8b8 CoreFoundation`_CFXNotificationPost + 740
    frame #99: 0x000000019ec24680 Foundation`-[NSNotificationCenter postNotificationName:object:userInfo:] + 88
    frame #100: 0x00000001a15d21bc AppKit`-[NSApplication _postDidFinishNotification] + 284
    frame #101: 0x00000001a15d1f6c AppKit`-[NSApplication _sendFinishLaunchingNotification] + 172
    frame #102: 0x00000001a15d0568 AppKit`-[NSApplication(NSAppleEventHandling) _handleAEOpenEvent:] + 488
    frame #103: 0x00000001a15d017c AppKit`-[NSApplication(NSAppleEventHandling) _handleCoreEvent:withReplyEvent:] + 488
    frame #104: 0x000000019ec4ce40 Foundation`-[NSAppleEventManager dispatchRawAppleEvent:withRawReply:handlerRefCon:] + 316
    frame #105: 0x000000019ec4cc38 Foundation`_NSAppleEventManagerGenericHandler + 80
    frame #106: 0x00000001a509f13c AE`___lldb_unnamed_symbol872 + 1600
    frame #107: 0x00000001a509ea7c AE`___lldb_unnamed_symbol871 + 44
    frame #108: 0x00000001a5098044 AE`aeProcessAppleEvent + 484
    frame #109: 0x00000001a909a828 HIToolbox`AEProcessAppleEvent + 68
    frame #110: 0x00000001a15c9d38 AppKit`_DPSNextEvent + 1456
    frame #111: 0x00000001a1f68940 AppKit`-[NSApplication(NSEventRouting) _nextEventMatchingEventMask:untilDate:inMode:dequeue:] + 688
    frame #112: 0x00000001a15bcbe4 AppKit`-[NSApplication run] + 480
    frame #113: 0x0000000101166e78 libdarktable.dylib`main(argc=3, argv=0x000000016fdff518) at osx.mm:382:9
    frame #114: 0x000000019d21ab98 dyld`start + 6076
```

</details>

I don't think this error is related to my change because it happens when I just try to import any random file. In the stack trace above, I tried to have the style dialogue import a random DMG file in my downloads folder and it crashes.  It feels like something macOS specific, but I haven't tested on Linux.