### PR TITLE
[innosetup] Remove the word "version" between "darktable" and its version number

### DIFF
--- a/packaging/windows/darktable.iss.in
+++ b/packaging/windows/darktable.iss.in
@@ -14,6 +14,12 @@
 AppId={#MyAppName}{#MyAppVersion}
 AppName={#MyAppName}
 AppVersion={#MyAppVersion}
+
+; By default AppVername (and UninstallDisplayName) contains the word "version"
+; between the app name and the version number. We don't want it, the presence
+; of this word doesn't improve anything, it's just not needed.
+AppVerName={#MyAppName} {#MyAppVersion}
+
 AppCopyright={#MyAppCopyright}
 AppPublisher={#MyAppPublisher}
 AppPublisherURL={#MyAppURL}


### PR DESCRIPTION
This is a minor cosmetic fix.

By default AppVername (and UninstallDisplayName) contains the word "version" between the app name and the version number.

This is shown in the Windows list of installed apps. We want to show the version of the app there to distinguish between multiple installations, as we expect some users to install different versions of darktable (such as a release version and a fresh development snapshot). This is displayed also in the Welcome page of the Setup wizard if it is enabled, and in the title bar of the wizard window if not.

We don't want the word "version" itself, the presence of this word doesn't improve anything, it's just not needed.
