### PR TITLE
clarify drop of support for Intel Macs

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -155,8 +155,8 @@ changes (where available).
   metadata fields unless the user selects all of the checkboxes in the
   export module's preference options.
 
-- Starting with release 5.4, macOS versions older than 14.0 are not
-  supported.
+- Starting with release 5.4, Intel Macs and macOS versions older than 14.0
+  are no longer supported.
 
 ## Changed Dependencies
 


### PR DESCRIPTION
With macOS 26 now released, Apple has dropped support for Macs with
Intel CPUs.

With no one in the team owning such a Mac we need to clarify this in
the RELEASE_NOTES. 