### PR TITLE
agx: allow setting post-curve primaries from pre-curve values

### DIFF
--- a/src/iop/agx.c
+++ b/src/iop/agx.c
@@ -1870,7 +1870,7 @@ static void _update_after_primaries_visibility(const dt_iop_module_t *self)
 
   if(g && g->after_primaries_controls_vbox)
   {
-    const gboolean independent_post_primaries = !p->completely_reverse_primaries;
+    const gboolean independent_post_primaries = !p->completely_reverse_primaries && !p->disable_primaries_adjustments;
     gtk_widget_set_visible(g->after_primaries_controls_vbox, independent_post_primaries);
     gtk_widget_set_sensitive(g->after_primaries_controls_vbox, independent_post_primaries);
     if(g->set_post_tonemapping_primaries_from_pre_button)
@@ -1888,7 +1888,9 @@ static void _update_primaries_checkbox_and_sliders(const dt_iop_module_t *self)
 
   if(g && g->primaries_controls_vbox)
   {
-    gtk_widget_set_visible(g->primaries_controls_vbox, !p->disable_primaries_adjustments);
+    const gboolean primaries_enabled = !p->disable_primaries_adjustments;
+    gtk_widget_set_visible(g->primaries_controls_vbox, primaries_enabled);
+    gtk_widget_set_sensitive(g->primaries_controls_vbox, primaries_enabled);
     if(g->completely_reverse_primaries)
       gtk_widget_set_sensitive(g->completely_reverse_primaries, !p->disable_primaries_adjustments);
   }

--- a/src/iop/agx.c
+++ b/src/iop/agx.c
@@ -1243,8 +1243,6 @@ static void _apply_auto_black_exposure(const dt_iop_module_t *self)
   ++darktable.gui->reset;
   dt_bauhaus_slider_set(g->black_exposure_picker, p->range_black_relative_exposure);
   --darktable.gui->reset;
-
-  gtk_widget_queue_draw(GTK_WIDGET(g->graph_drawing_area));
 }
 
 static void _apply_auto_white_exposure(const dt_iop_module_t *self)
@@ -2726,6 +2724,7 @@ void color_picker_apply(dt_iop_module_t *self,
     --darktable.gui->reset;
   }
   gtk_widget_queue_draw(GTK_WIDGET(g->graph_drawing_area));
+  _update_curve_warnings(self);
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 

--- a/src/iop/agx.c
+++ b/src/iop/agx.c
@@ -120,7 +120,7 @@ typedef struct dt_iop_agx_params_t
   // s_p
   float curve_shoulder_power;             // $MIN: 0.f $MAX: 10.f $DEFAULT: 1.5f $DESCRIPTION: "shoulder power"
   float curve_gamma;                      // $MIN: 0.01f $MAX: 100.f $DEFAULT: 2.2f $DESCRIPTION: "curve y gamma"
-  gboolean auto_gamma;                    // $MIN: 0.f $MAX: 1.f $DEFAULT: 0.f $DESCRIPTION: "keep the pivot on the identity line"
+  gboolean auto_gamma;                    // $MIN: 0.f $MAX: 1.f $DEFAULT: 0.f $DESCRIPTION: "keep the pivot on the diagonal"
   // t_ly
   float curve_target_display_black_ratio; // $MIN: 0.f $MAX: 0.15f $DEFAULT: 0.f $DESCRIPTION: "target black"
   // s_ly
@@ -1598,7 +1598,7 @@ static gboolean _agx_draw_curve(GtkWidget *widget,
   cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(0.5));
   cairo_stroke(cr);
 
-  // identity line (y=x)
+  // diagonal (y=x)
   cairo_save(cr);
   cairo_set_source_rgba(cr,
                         darktable.bauhaus->graph_border.red,

--- a/src/iop/agx.c
+++ b/src/iop/agx.c
@@ -1963,7 +1963,7 @@ static void _add_basic_curve_controls(dt_iop_module_t *self,
   slider = dt_bauhaus_slider_from_params(section, "curve_contrast_around_pivot");
   controls->curve_contrast_around_pivot = slider;
   dt_bauhaus_slider_set_soft_range(slider, 0.1f, 5.f);
-  gtk_widget_set_tooltip_text(slider, _("slope of the linear section"));
+  gtk_widget_set_tooltip_text(slider, _("slope of the linear section around the pivot"));
 
   GtkWidget *parent_vbox = self->widget;
 
@@ -2407,7 +2407,9 @@ static GtkWidget *_add_primaries_box(dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->completely_reverse_primaries, _("completely restore purity and undo all rotations"));
 
   g->set_post_curve_primaries_from_pre_button = gtk_button_new_with_label(_("set from above"));
-  gtk_widget_set_tooltip_text(g->set_post_curve_primaries_from_pre_button, _("set parameters to completely reverse primaries modifications, but allow subsequent editing"));
+  gtk_widget_set_tooltip_text(g->set_post_curve_primaries_from_pre_button,
+                              _("set parameters to completely reverse primaries modifications,\n"
+                                  "but allow subsequent editing"));
   g_signal_connect(g->set_post_curve_primaries_from_pre_button, "clicked", G_CALLBACK(_set_post_curve_primaries_from_pre_callback), self);
   gtk_box_pack_end(GTK_BOX(reversal_hbox), g->set_post_curve_primaries_from_pre_button, FALSE, FALSE, 5);
 

--- a/src/iop/agx.c
+++ b/src/iop/agx.c
@@ -190,8 +190,8 @@ typedef struct dt_iop_agx_gui_data_t
   GtkWidget *disable_primaries_adjustments;
   GtkWidget *primaries_controls_vbox;
   GtkWidget *completely_reverse_primaries;
-  GtkWidget *after_primaries_controls_vbox;
-  GtkWidget *set_post_tonemapping_primaries_from_pre_button;
+  GtkWidget *post_curve_primaries_controls_vbox;
+  GtkWidget *set_post_curve_primaries_from_pre_button;
 } dt_iop_agx_gui_data_t;
 
 typedef struct tone_mapping_params_t
@@ -1861,20 +1861,19 @@ static void _update_curve_warnings(dt_iop_module_t *self)
                            params.need_concave_shoulder && warnings_enabled);
 }
 
-static void _update_after_primaries_visibility(const dt_iop_module_t *self)
+static void _update_post_curve_primaries_visibility(const dt_iop_module_t *self)
 {
   const dt_iop_agx_gui_data_t *g = self->gui_data;
   const dt_iop_agx_params_t *p = self->params;
 
-  if(g && g->after_primaries_controls_vbox)
+  if(g && g->post_curve_primaries_controls_vbox)
   {
-    const gboolean independent_post_primaries = !p->completely_reverse_primaries && !p->disable_primaries_adjustments;
-    gtk_widget_set_visible(g->after_primaries_controls_vbox, independent_post_primaries);
-    gtk_widget_set_sensitive(g->after_primaries_controls_vbox, independent_post_primaries);
-    if(g->set_post_tonemapping_primaries_from_pre_button)
+    const gboolean post_curve_primaries_available = !p->completely_reverse_primaries && !p->disable_primaries_adjustments;
+    gtk_widget_set_visible(g->post_curve_primaries_controls_vbox, post_curve_primaries_available);
+    gtk_widget_set_sensitive(g->post_curve_primaries_controls_vbox, post_curve_primaries_available);
+    if(g->set_post_curve_primaries_from_pre_button)
     {
-      gtk_widget_set_visible(g->set_post_tonemapping_primaries_from_pre_button, independent_post_primaries);
-      gtk_widget_set_sensitive(g->set_post_tonemapping_primaries_from_pre_button, independent_post_primaries);
+      gtk_widget_set_sensitive(g->set_post_curve_primaries_from_pre_button, post_curve_primaries_available);
     }
   }
 }
@@ -1917,11 +1916,7 @@ void gui_changed(dt_iop_module_t *self,
 
   _update_primaries_checkbox_and_sliders(self);
   _update_curve_warnings(self);
-  _update_after_primaries_visibility(self);
-
-  // Test which widget was changed.
-  // If allowing w == NULL, this can be called from gui_update, so that
-  // gui configuration adjustments only need to be dealt with once, here.
+  _update_post_curve_primaries_visibility(self);
 
   // Trigger redraw when any parameter changes
   if(g && g->graph_drawing_area)
@@ -2278,7 +2273,7 @@ static void _primaries_popupmenu_callback(GtkWidget *button, dt_iop_module_t *se
   dt_gui_menu_popup(GTK_MENU(menu), button, GDK_GRAVITY_SOUTH_WEST, GDK_GRAVITY_NORTH_WEST);
 }
 
-static void _set_post_tonemapping_primaries_from_pre_callback(GtkWidget *widget, dt_iop_module_t *self)
+static void _set_post_curve_primaries_from_pre_callback(GtkWidget *widget, dt_iop_module_t *self)
 {
   dt_iop_agx_params_t *p = self->params;
 
@@ -2321,7 +2316,7 @@ void gui_update(dt_iop_module_t *self)
 
   _update_primaries_checkbox_and_sliders(self);
   _update_curve_warnings(self);
-  _update_after_primaries_visibility(self);
+  _update_post_curve_primaries_visibility(self);
 
   // Ensure the graph is drawn initially
   if(g && g->graph_drawing_area)
@@ -2411,14 +2406,14 @@ static GtkWidget *_add_primaries_box(dt_iop_module_t *self)
 
   gtk_widget_set_tooltip_text(g->completely_reverse_primaries, _("completely restore purity and undo all rotations"));
 
-  g->set_post_tonemapping_primaries_from_pre_button = gtk_button_new_with_label(_("set from above"));
-  gtk_widget_set_tooltip_text(g->set_post_tonemapping_primaries_from_pre_button, _("set parameters to completely reverse primaries modifications, but allow subsequent editing"));
-  g_signal_connect(g->set_post_tonemapping_primaries_from_pre_button, "clicked", G_CALLBACK(_set_post_tonemapping_primaries_from_pre_callback), self);
-  gtk_box_pack_end(GTK_BOX(reversal_hbox), g->set_post_tonemapping_primaries_from_pre_button, FALSE, FALSE, 5);
+  g->set_post_curve_primaries_from_pre_button = gtk_button_new_with_label(_("set from above"));
+  gtk_widget_set_tooltip_text(g->set_post_curve_primaries_from_pre_button, _("set parameters to completely reverse primaries modifications, but allow subsequent editing"));
+  g_signal_connect(g->set_post_curve_primaries_from_pre_button, "clicked", G_CALLBACK(_set_post_curve_primaries_from_pre_callback), self);
+  gtk_box_pack_end(GTK_BOX(reversal_hbox), g->set_post_curve_primaries_from_pre_button, FALSE, FALSE, 5);
 
   GtkWidget *vbox_to_add_to = parent_vbox;
-  g->after_primaries_controls_vbox = self->widget = dt_gui_vbox();
-  dt_gui_box_add(vbox_to_add_to, g->after_primaries_controls_vbox);
+  g->post_curve_primaries_controls_vbox = self->widget = dt_gui_vbox();
+  dt_gui_box_add(vbox_to_add_to, g->post_curve_primaries_controls_vbox);
 
   slider = dt_bauhaus_slider_from_params(self, "master_outset_ratio");
   dt_bauhaus_slider_set_format(slider, "%");


### PR DESCRIPTION
- Added the 'reverse all' checkbox, based on a suggestion from @Eary_Chow. When ticked, the _master reversal_ sliders, as well as the individual post-tonemapping (post-curve) RGB sliders are hidden. The post-curve adjustments will automatically completely reverse the pre-curve ones, behaving as if the _master_ sliders were set to 100%, and the individual post-curve RGB sliders were set to the values of the corresponding pre-curve sliders. If the checkbox is subsequently unticked, the controls will be restored, and the sliders will show the same values as before.
- to complement that functionality, an additional button has been added, labelled _set from above_. When clicked, the button will set the post-curve RGB sliders to the pre-curve values and reset the master controls to 100%, allowing the user to start from the _complete reversal_ look, but alter parameters
- additionally, some simplification of terminology, replacing _identity line_ with _diagonal_ and _contrast around the pivot_ with _contrast_, relying on the tooltip + documentation to explain that the contrast is meant around the pivot
- a bugfix, where the toe/shoulder 'inversion' warnings were not visible immediately after using colour pickers that alter the curve (exposure, pivot shift)
- a restructuring of the logical (not the on-screen) arrangement (grouping) of controls. We used to have almost all controls in 'sections', but the QAP displays the names of controls prefixed with the name of the section. Certain section names were rather long, and combined with the name of the control, would not properly fit on the screen. Therefore, the logical sections _basic curve parameters_ and _advanced curve parameters_ have been combined into _curve_. The exposure and primaries controls have been moved directly under the root of the module (not placed in sections) so they would fit on the screen.