### PR TITLE
[appimage] Add our plugin-free libheif build instead of using the packaged version

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -100,16 +100,36 @@ jobs:
       - name: Install extra dependencies
         run: |
           sudo apt-get -y install \
+            libaom-dev \
             libavif-dev \
             libgphoto2-dev \
-            libheif-dev \
+            libde265-dev \
             libimath-dev \
             libjpeg-turbo8-dev \
             libjxl-dev \
             libopenexr-dev \
+            libopenh264-dev \
             libopenjp2-7-dev \
+            libsharpyuv-dev \
+            libx265-dev \
             x11proto-dev \
             libxfixes-dev
+      - name: Build and install fresh libheif with built-in decoders
+        run: |
+          git clone --branch v1.20.1 --depth 1 https://github.com/strukturag/libheif src-libheif
+          cd src-libheif
+          cmake -S . -B build -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DENABLE_PLUGIN_LOADING=OFF \
+            -DWITH_LIBDE265=ON \
+            -DWITH_AOM_DECODER=ON \
+            -DWITH_AOM_ENCODER=ON \
+            -DWITH_OpenH264_DECODER=ON \
+            -DWITH_LIBSHARPYUV=ON \
+            -DCMAKE_INSTALL_PREFIX=/usr
+          ninja -C build
+          sudo ninja -C build install
+          cd ..
       - name: Build and install a more recent version of exiv2
         run: |
           git clone --branch v0.28.7 --depth 1 https://github.com/Exiv2/exiv2 src-exiv2


### PR DESCRIPTION
I accidentally came across a description of an issue with decoding heif files in the darktable appimage package on [pixls forum](https://discuss.pixls.us/t/partly-solved-how-about-heic-now/53131). It turned out that the problem was that Ubuntu builds libheif with plugins instead of embedding decoders into the library itself. As a result, these plugins (and the corresponding decoder libraries) must be installed on the host system, because libheif tries to load them in the locations of the host system. That's not good, it needs to be fixed.

I have already fixed similar issues with libgphoto2 and GIO modules by bundling the necessary files manually in the build script and setting environment variables so that the loaded files were taken from the correct location in the mounted appimage.

It would be possible to go the same way, but on the other hand libheif compiles very quickly, so I think it is better to build the latest release in github action (the PPA is still a bit behind) with built-in decoders, this will fix the issue as well.

I tested the fix on the file from the forum post, it loads successfully.
