### PR TITLE
po/minor UI tweak

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -584,7 +584,7 @@ dialog .sidebar row:selected:hover label,
 /* Set modules name header */
 #module-header
 {
-  border-bottom: 1px solid @plugin_bg_color;
+  border-bottom: 1px solid shade(@plugin_bg_color, 1.05);
   padding: 0.5em;
 }
 


### PR DESCRIPTION
Two minor UI tweak that I'm using since some time.

**- More visible module separator**

Before:

<img width="398" height="347" alt="image" src="https://github.com/user-attachments/assets/d324d2d5-3a29-4108-971e-cc9b9dafb7ec" />

After:

<img width="398" height="347" alt="image" src="https://github.com/user-attachments/assets/26274d96-c391-4621-b66e-118c8e3630a6" />

**- Some spaces on the right of check-buttons**

Before:

<img width="368" height="127" alt="image" src="https://github.com/user-attachments/assets/006fab70-1757-4544-80d0-0c361de6da7b" />

<img width="491" height="204" alt="image" src="https://github.com/user-attachments/assets/d45ecee9-4e5d-43d6-ab41-6c8e85317922" />

After:

<img width="368" height="127" alt="image" src="https://github.com/user-attachments/assets/fe60560b-cf31-4c52-902d-02ce4d67cc9f" />

<img width="491" height="204" alt="image" src="https://github.com/user-attachments/assets/e7229b33-0a56-480a-b13f-3386d0146cd1" />
