### PR TITLE
[innosetup] Add option to open the user manual in post-install

### DIFF
--- a/packaging/windows/darktable.iss.in
+++ b/packaging/windows/darktable.iss.in
@@ -119,6 +119,10 @@ Name: "{userappdata}\Microsoft\Internet Explorer\Quick Launch\{#MyAppName}"; \
   Filename: "{app}\bin\{#MyAppName}"; WorkingDir: "{app}"; Tasks: quicklaunchicon
 
 [Run]
+Filename: "https://docs.darktable.org/usermanual/development/"; \
+  Description: "Open darktable user manual"; \
+  Flags: postinstall shellexec runasoriginaluser
+
 Filename: "{app}\bin\{#MyAppExeName}"; \
   Description: "{cm:LaunchProgram,{#StringChange(MyAppName, '&', '&&')}}"; \
   Flags: nowait postinstall skipifsilent


### PR DESCRIPTION
This increases the visibility of the user manual, as some users may not realize that the manual is available from the application interface. Especially since we don't have a menu that users are used to and where a link to the manual would be visible.