### PR TITLE
Implement and use a collapsible section with an enabled button

### DIFF
--- a/src/develop/imageop_gui.h
+++ b/src/develop/imageop_gui.h
@@ -28,6 +28,8 @@ GtkWidget *dt_bauhaus_combobox_from_params(dt_iop_module_t *self, const char *pa
 
 GtkWidget *dt_bauhaus_toggle_from_params(dt_iop_module_t *self, const char *param);
 
+GtkWidget *dt_bauhaus_plain_toggle_from_params(dt_iop_module_t *self, const char *param);
+
 typedef struct dt_iop_module_section_t
 {
   dt_action_type_t actions; // !!! NEEDS to be FIRST (to be able to cast convert)

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -4379,6 +4379,54 @@ void dt_gui_new_collapsible_section(dt_gui_collapsible_section_t *cs,
                    G_CALLBACK(_collapse_expander_click), cs);
 }
 
+void dt_gui_new_collapsible_toggle_section(dt_gui_collapsible_section_t *cs,
+                                           const char *confname,
+                                           const char *label,
+                                           GtkBox *parent,
+                                           dt_action_t *module,
+                                           GtkWidget *enable)
+{
+  const gboolean expanded = dt_conf_get_bool(confname);
+
+  cs->confname = g_strdup(confname);
+  cs->parent = parent;
+  cs->module = module;
+
+  // collapsible section header
+  GtkWidget *destdisp_head = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, DT_BAUHAUS_SPACE);
+  GtkWidget *header_evb = gtk_event_box_new();
+  GtkWidget *destdisp = dt_ui_section_label_new(label);
+  cs->label = destdisp;
+  dt_gui_add_class(destdisp_head, "dt_section_expander"); // toggle button has left margin
+  gtk_container_add(GTK_CONTAINER(header_evb), destdisp);
+
+  cs->toggle = dtgtk_togglebutton_new(dtgtk_cairo_paint_solid_arrow,
+                                      (expanded
+                                       ? CPF_DIRECTION_DOWN
+                                       : CPF_DIRECTION_LEFT),
+                                      NULL);
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(cs->toggle), expanded);
+  dt_gui_add_class(cs->toggle, "dt_ignore_fg_state");
+  dt_gui_add_class(cs->toggle, "dt_transparent_background");
+
+  cs->container = GTK_BOX(gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE));
+  gtk_widget_set_name(GTK_WIDGET(cs->container), "collapsible");
+  gtk_box_pack_start(GTK_BOX(destdisp_head), enable, FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(destdisp_head), header_evb, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(destdisp_head), cs->toggle, FALSE, FALSE, 0);
+
+  cs->expander = dtgtk_expander_new(destdisp_head, GTK_WIDGET(cs->container));
+  gtk_box_pack_end(cs->parent, cs->expander, FALSE, FALSE, 0);
+  dtgtk_expander_set_expanded(DTGTK_EXPANDER(cs->expander), expanded);
+  gtk_widget_set_name(cs->expander, "collapse-block");
+
+  g_signal_connect(G_OBJECT(cs->toggle), "toggled",
+                   G_CALLBACK(_collapse_button_changed), cs);
+
+  g_signal_connect(G_OBJECT(header_evb), "button-press-event",
+                   G_CALLBACK(_collapse_expander_click), cs);
+}
+
 void dt_gui_collapsible_section_set_label(dt_gui_collapsible_section_t *cs,
                                           const char *label)
 {

--- a/src/gui/gtk.h
+++ b/src/gui/gtk.h
@@ -520,6 +520,12 @@ void dt_gui_new_collapsible_section(dt_gui_collapsible_section_t *cs,
                                     const char *label,
                                     GtkBox *parent,
                                     struct dt_action_t *module);
+void dt_gui_new_collapsible_toggle_section(dt_gui_collapsible_section_t *cs,
+                                                 const char *confname,
+                                                 const char *label,
+                                                 GtkBox *parent,
+                                                 struct dt_action_t *module,
+                                                 GtkWidget *enabler);
 // update the collapsible section's label text
 void dt_gui_collapsible_section_set_label(dt_gui_collapsible_section_t *cs,
                                           const char *label);

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -1538,8 +1538,7 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
   gtk_widget_set_visible(g->cs_iter, do_capture);
 
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->cs_enabled), p->cs_enabled);
-  gtk_widget_set_visible(g->cs_enabled, capture_support);
-  gtk_widget_set_visible(GTK_WIDGET(g->capture.expander), do_capture);
+  gtk_widget_set_visible(GTK_WIDGET(g->capture.expander), capture_support);
 
   // we might have a wrong method due to xtrans/bayer - mode mismatch
   const gboolean method_mismatch = use_method != p->demosaicing_method;
@@ -1749,13 +1748,13 @@ void gui_init(dt_iop_module_t *self)
   g->greeneq = dt_bauhaus_combobox_from_params(self, "green_eq");
   gtk_widget_set_tooltip_text(g->greeneq, _("green channels matching method"));
 
-  g->cs_enabled = dt_bauhaus_toggle_from_params(self, "cs_enabled");
+  g->cs_enabled = dt_bauhaus_plain_toggle_from_params(self, "cs_enabled");
   gtk_widget_set_tooltip_text(g->cs_enabled, _("capture sharpen recovers details lost due to in-camera blurring\n"
                                             "which can be caused by diffraction, the anti-aliasing filter or other\n"
                                             "sources of gaussian-type blur"));
 
-  dt_gui_new_collapsible_section(&g->capture, "plugins/darkroom/demosaic/expand_capture",
-                                 _("capture sharpen controls"), GTK_BOX(box_raw), DT_ACTION(self));
+  dt_gui_new_collapsible_toggle_section(&g->capture, "plugins/darkroom/demosaic/expand_capture",
+                                 _("capture sharpen"), GTK_BOX(box_raw), DT_ACTION(self), g->cs_enabled);
   self->widget = GTK_WIDGET(g->capture.container);
 
   g->cs_iter = dt_bauhaus_slider_from_params(self, "cs_iter");


### PR DESCRIPTION
In some cases of processing modules we might want to have a toggle button enabling a feature and would want to hide more controls for that feature in a collapsible section possibly leading to a cleaner interface also with less UI jumping.

This implements two functions

1. `GtkWidget *dt_bauhaus_plain_toggle_from_params(dt_iop_module_t *self, const char *param)`, there is no visible text after the button and it's not sorted into the self->widget.

2. `dt_gui_new_collapsible_toggle_section(dt_gui_collapsible_section_t *cs, const char *confname, const char *label, GtkBox *parent, dt_action_t *module, GtkWidget *enable)` is a variant of `dt_gui_new_collapsible_section()` adding the toggle button to the left of the collapsible header.

3. capture sharpen in demosaic module makes use of this.
<img width="280" height="178" alt="Bildschirmfoto vom 2025-10-06 12-40-50" src="https://github.com/user-attachments/assets/ee02034d-2927-458a-aa7f-e53c61bad2e7" />

<img width="280" height="267" alt="Bildschirmfoto vom 2025-10-06 12-41-20" src="https://github.com/user-attachments/assets/504648b4-6bd5-4bbc-968b-c6434b279f74" />


@TurboGit you commented some time ago about a generic UI for such cases, would this be as you thought?

@dterrahe would this be ok with your big gtk4 stuff? I intentionally did not do any refactoring / api changing of the old functions to keep changes local. 

Any better idea? 

