### PR TITLE
[appimage] Enable all format decoders in our libheif build

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -125,6 +125,8 @@ jobs:
             -DWITH_AOM_DECODER=ON \
             -DWITH_AOM_ENCODER=ON \
             -DWITH_OpenH264_DECODER=ON \
+            -DWITH_JPEG_DECODER=ON \
+            -DWITH_OpenJPEG_DECODER=ON \
             -DWITH_LIBSHARPYUV=ON \
             -DCMAKE_INSTALL_PREFIX=/usr
           ninja -C build


### PR DESCRIPTION
While the vast majority of HEIF files are H.265 encoded, let's not limit AppImage's ability to read other types.