### PR TITLE
[innosetup] GPL is not an EULA, let's not force users to accept it

### DIFF
--- a/packaging/windows/darktable.iss.in
+++ b/packaging/windows/darktable.iss.in
@@ -51,7 +51,12 @@ ArchitecturesInstallIn64BitMode=x64compatible
 ChangesAssociations=yes
 DefaultGroupName={#MyAppName}{code:SuffixIfNotRelease}
 AllowNoIcons=yes
-LicenseFile=share\doc\darktable\LICENSE
+
+; For potential future contributors:
+; Please do not set the LicenseFile directive, as it effectively sets a step
+; to accept the EULA. The darktable license is GPL, and GPL is not an EULA.
+; Users are not required to agree to anything to merely use GPLed software.
+; LicenseFile=share\doc\darktable\LICENSE
 
 ; Uncomment the following line to run in non administrative install mode
 ; (install for current user only).


### PR DESCRIPTION
As the GNU Licenses FAQ (https://www.gnu.org/licenses/gpl-faq.html#ClickThrough) explains:

> Merely agreeing to the GPL doesn't place any obligations on you. You are not required to agree to anything to merely use software which is licensed under the GPL. You only have obligations if you modify or distribute the software. If it really bothers you to click through the GPL, nothing stops you from hacking the GPLed software to bypass this.

So let's not annoy users and stop this nonsense by skipping the EULA acceptance page in the installer.