### PR TITLE
[innosetup] Compress the installer even more, while reducing the compression time

### DIFF
--- a/packaging/windows/darktable.iss.in
+++ b/packaging/windows/darktable.iss.in
@@ -72,7 +72,19 @@ OutputBaseFilename=darktable-{#MyAppVersion}-${ARCH_STRING}-innosetup-experiment
 ; May be useful for debugging, not needed for production builds.
 ; OutputManifestFile=darktable-manifest.txt
 
+; See https://github.com/teeks99/inno-test/ for which compression parameters
+; should be set and to what values, and which are better not to touch.
+Compression=lzma2/ultra64
 SolidCompression=yes
+LZMAUseSeparateProcess=yes
+
+; Setting this parameter to 2 (default is 1) only slightly (by a few fractions
+; of a percent) increases file size, but significantly speeds up compression.
+; OTOH, saving a minute of nightly job is not that important (if at all). But
+; neither is an extra couple of hundred KB of installer file. So, really,
+; there is no strong justification for choosing the value of this parameter...
+LZMANumBlockThreads=2
+
 WizardStyle=modern
 
 ; These parameters must be set to "no" if the AppId contains constants. We use


### PR DESCRIPTION
Let's shave another 3% (or so) off the installer file size.

If you are interested, see https://github.com/teeks99/inno-test/ to learn which compression parameters should be set to what values, and which ones are better left untouched.
