### PR TITLE
[innosetup] Add darktable logo to the wizard pages

### DIFF
--- a/packaging/windows/darktable.iss.in
+++ b/packaging/windows/darktable.iss.in
@@ -31,7 +31,10 @@ AppPublisherURL={#MyAppURL}
 AppSupportURL={#MyAppURL}
 AppUpdatesURL={#MyAppURL}
 DefaultDirName={autopf}\{#MyAppName}{code:SuffixIfNotRelease}
+
 UninstallDisplayIcon={app}\bin\{#MyAppExeName}
+
+WizardSmallImageFile=${CMAKE_SOURCE_DIR}\data\pixmaps\256x256\darktable.png
 
 ; This file is not in the source tree, it is expected to be created in
 ; the installer build environment before compiling this script as:


### PR DESCRIPTION
Before this PR:

<img width="449" height="339" alt="installer with default wizard pages icon" src="https://github.com/user-attachments/assets/a5c3e5f0-1823-46ee-95be-ede9d538fcad" />

After this PR:

<img width="449" height="339" alt="installer with darktable logo on the wizard pages" src="https://github.com/user-attachments/assets/d805d2e2-5c6d-4285-8590-9dde31ee5470" />
