### PR TITLE
Agx terminology: look->power to brightness, offset to lift

### DIFF
--- a/src/iop/agx.c
+++ b/src/iop/agx.c
@@ -2703,7 +2703,7 @@ static void _set_blenderlike_params(dt_iop_agx_params_t *p)
   // restore the original Blender settings
   p->curve_shoulder_power = 1.5f;
   p->curve_toe_power = 1.5f;
-  p->curve_gamma = 2.4;
+  p->curve_gamma = 2.4f;
   // our default gamma is 2.2, and the gamma compensation logic will be applied
   // later to scale the contrast calculated here, to finally arrive at
   // blender's default contrast, which is 2.4. If we simply set 2.4 here, the compensation
@@ -2723,7 +2723,8 @@ static void _set_scene_referred_default_params(dt_iop_agx_params_t *p)
 
 static void _make_punchy(dt_iop_agx_params_t * p)
 {
-  // from Blender; 'power' is 1.35
+  // from Blender; 'power' is 1.35; darkening brightness adjustments (value < 1)
+  // are dampened using sqrt in UI 'brightness' param -> algorithmic 'power' param conversion
   p->look_brightness = 1.f / (1.35f * 1.35f);
   p->look_lift = 0.f;
   p->look_saturation = 1.4f;


### PR DESCRIPTION
Replaced look->power with brightness, honouring users' request (more intuitive); replaced "offset" with "lift", as that is what the effect is called.
I've noticed that Blender actually uses gamma 2.4, not 2.2 internally. I did not want to influence all edits by changing our default gamma, so redefined the blender-like presets only (so people who really want what Blender does can have it). This required scaling the contrast, as we have logic in place, that normalises contrast in response to gamma changes, using gamma 2.2 as base. That compensation means that if we shipped the 'blender-like' presets with contrast of 2.4 and gamma 2.4, the contrast would actually be rescaled (reduced) in darktable. I compensated for that, so the displayed contrast value will be 2.45, but the effective contrast will be 2.4, just like with Blender.
Other preset change: extracted 'make_punchy' to avoid code repetition; the 'blender-like' primaries settings now ship with ready-to-use complete rotation reversal, but the the master rotation reversal slider set to 0. This means no effect in the look compared to the previous default primaries, but users can use a single slider to gradually reverse rotations if they wish.