### PR TITLE
add agx to default quick-access panel when workflow set to agx

### DIFF
--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -1484,6 +1484,17 @@ static void _preset_from_string(dt_lib_module_t *self, gchar *txt, gboolean edit
         AM("sigmoid/contrast");											  \
         AM("sigmoid/skew");											  \
       } 													  \
+      else if(wf_agx)												  \
+      {														  \
+        /*AM("agx/white relative exposure");*/						                          \
+        /*AM("agx/black relative exposure");*/						                          \
+        AM("agx/auto tune levels");                                                                               \
+        AM("agx/curve/contrast");                                                                                 \
+        AM("agx/curve/shoulder power");                                                                           \
+        AM("agx/curve/toe power");	                                                                          \
+        AM("agx/look/saturation");	                                                                          \
+        AM("agx/look/preserve hue");	                                                                          \
+      }														  \
       AM("channelmixerrgb/temperature");                                                                          \
       AM("channelmixerrgb/chroma");                                                                               \
       AM("channelmixerrgb/hue");                                                                                  \


### PR DESCRIPTION
While AgX is being added to the appropriate default module groups for various presets, it hadn't yet been added to the QAP (unlike filmicrgb and sigmoid).  This PR adds it to the QAP when workflow is set to "scene-referred (agx)".

The QAP AgX section got a bit overloaded with sliders, so I've commented out the relative exposure sliders, leaving only the auto-tune picker in the QAP for setting overall dynamic range.  I can uncomment them if desired.

We add "auto tune levels" to set overall dynamic range, "contrast", "shoulder power", and "toe power" for midtone/highlight/shadows contrast adjustment, and "saturation"/"preserve hue" for color control.
