### PR TITLE
Rework the backthumbs crawler

### DIFF
--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -336,10 +336,8 @@ typedef struct dt_backthumb_t
 {
   double time;
   double idle;
-  gboolean service;
-  gboolean running;
+  int32_t state;
   gboolean capable;
-  int32_t mipsize;
 } dt_backthumb_t;
 
 typedef struct dt_gimp_t
@@ -882,8 +880,9 @@ static inline gboolean dt_slist_length_equal(GSList *l1, GSList *l2)
 // checks internally for DT_DEBUG_MEMORY
 void dt_print_mem_usage(char *info);
 
-// try to start the backthumbs crawler
-void dt_start_backtumbs_crawler();
+// start/stop the backthumbs crawler
+void dt_start_backthumbs_crawler(void);
+void dt_stop_backthumbs_crawler(const gboolean wait);
 
 void dt_configure_runtime_performance(const int version, char *config_info);
 // helper function which loads whatever image_to_load points to:

--- a/src/common/history.c
+++ b/src/common/history.c
@@ -217,6 +217,7 @@ gboolean dt_history_load_and_apply(const dt_imgid_t imgid,
 gboolean dt_history_load_and_apply_on_list(gchar *filename,
                                            const GList *list)
 {
+  dt_stop_backthumbs_crawler(FALSE);
   gboolean res = FALSE;
   dt_undo_start_group(darktable.undo, DT_UNDO_LT_HISTORY);
   for(GList *l = (GList *)list; l; l = g_list_next(l))
@@ -226,6 +227,7 @@ gboolean dt_history_load_and_apply_on_list(gchar *filename,
       res = TRUE;
   }
   dt_undo_end_group(darktable.undo);
+  dt_start_backthumbs_crawler();
   return res;
 }
 

--- a/src/control/jobs.c
+++ b/src/control/jobs.c
@@ -664,7 +664,7 @@ int dt_control_jobs_pending()
   if(!control) return 0;
 
   int pending = dt_atomic_get_int(&control->pending_jobs);
-  if(darktable.backthumbs.running)
+  if(darktable.backthumbs.state == DT_JOB_STATE_RUNNING)
     pending--;
   return pending;
 }

--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -1509,6 +1509,7 @@ static int32_t _control_local_copy_images_job_run(dt_job_t *job)
 
 static int32_t _control_refresh_exif_run(dt_job_t *job)
 {
+  dt_stop_backthumbs_crawler(FALSE);
   dt_control_image_enumerator_t *params = dt_control_job_get_params(job);
   GList *t = params->index;
   GList *imgs = g_list_copy(t);
@@ -1553,6 +1554,8 @@ static int32_t _control_refresh_exif_run(dt_job_t *job)
   DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_TAG_CHANGED);
   DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_IMAGE_INFO_CHANGED, imgs);
   dt_control_queue_redraw_center();
+
+  dt_start_backthumbs_crawler();
   return 0;
 }
 
@@ -1569,6 +1572,7 @@ static inline gboolean _safe_history_job_on_imgid(dt_job_t *job, const dt_imgid_
 
 static int32_t _control_paste_history_job_run(dt_job_t *job)
 {
+  dt_stop_backthumbs_crawler(FALSE);
   dt_control_image_enumerator_t *params =
     (dt_control_image_enumerator_t *)dt_control_job_get_params(job);
   GList *t = params->data;
@@ -1623,6 +1627,7 @@ static int32_t _control_paste_history_job_run(dt_job_t *job)
     dt_image_synch_xmps(to_synch);
     g_list_free(to_synch);
   }
+  dt_start_backthumbs_crawler();
   return 0;
 }
 
@@ -1667,6 +1672,7 @@ static int32_t _control_compress_history_job_run(dt_job_t *job)
 
 static int32_t _control_discard_history_job_run(dt_job_t *job)
 {
+  dt_stop_backthumbs_crawler(FALSE);
   dt_control_image_enumerator_t *params =
     (dt_control_image_enumerator_t *)dt_control_job_get_params(job);
   GList *t = params->data;
@@ -1696,6 +1702,7 @@ static int32_t _control_discard_history_job_run(dt_job_t *job)
                              DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_UNDEF,
                              (GList*)params->data); // frees list of images
   params->data = NULL;
+  dt_start_backthumbs_crawler();
   dt_control_queue_redraw_center();
   return 0;
 }
@@ -1707,6 +1714,8 @@ static int32_t _control_apply_styles_job_run(dt_job_t *job)
   _apply_styles_data_t *style_data = params->data;
   if(!style_data)
     return 0;
+
+  dt_stop_backthumbs_crawler(FALSE);
   GList *imgs = style_data->imgs;
   GList *styles = style_data->styles;
   gboolean duplicate = style_data->duplicate;
@@ -1758,11 +1767,13 @@ static int32_t _control_apply_styles_job_run(dt_job_t *job)
   g_free(params->data);
   params->data = NULL;
   dt_control_queue_redraw_center();
+  dt_start_backthumbs_crawler();
   return 0;
 }
 
 static int32_t _control_export_job_run(dt_job_t *job)
 {
+  dt_stop_backthumbs_crawler(FALSE);
   dt_control_image_enumerator_t *params = dt_control_job_get_params(job);
   dt_control_export_t *settings = params->data;
   dt_imageio_module_format_t *mformat = dt_imageio_get_format_by_index(settings->format_index);
@@ -1923,6 +1934,7 @@ end:
   dt_ui_notify_user();
 
   if(tag_change) DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_TAG_CHANGED);
+  dt_start_backthumbs_crawler();
   return 0;
 }
 

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -1755,17 +1755,13 @@ static void _dt_pref_change_callback(gpointer instance, dt_thumbtable_t *table)
   if(!table)
     return;
 
+  dt_stop_backthumbs_crawler(FALSE);
   // adjust the act_on algo class if needed
   dt_act_on_set_class(table->widget);
 
   dt_get_sysresource_level();
   dt_opencl_update_settings();
   dt_configure_ppd_dpi(darktable.gui);
-
-  /* let's idle the backthumb crawler now to avoid fighting
-      updating vs removal of thumbs
-  */
-  dt_set_backthumb_time(1000.0);
 
   _thumbs_ask_for_discard(table);
 
@@ -1777,15 +1773,7 @@ static void _dt_pref_change_callback(gpointer instance, dt_thumbtable_t *table)
     dt_thumbnail_reload_infos(th);
     dt_thumbnail_resize(th, th->width, th->height, TRUE, IMG_TO_FIT);
   }
-
-  const char *mipsize = dt_conf_get_string_const("backthumbs_mipsize");
-  darktable.backthumbs.mipsize = dt_mipmap_cache_get_min_mip_from_pref(mipsize);
-  darktable.backthumbs.service = dt_conf_get_bool("backthumbs_initialize");
-  if(darktable.backthumbs.mipsize != DT_MIPMAP_NONE
-        && !darktable.backthumbs.running)
-    dt_start_backtumbs_crawler();
-  else
-    dt_set_backthumb_time(10.0);
+  dt_start_backthumbs_crawler();
 }
 
 static void _dt_profile_change_callback(gpointer instance,

--- a/src/libs/styles.c
+++ b/src/libs/styles.c
@@ -305,6 +305,7 @@ static void _apply_clicked(GtkWidget *w, dt_lib_styles_t *d)
   }
   else
   {
+    dt_stop_backthumbs_crawler(FALSE);
     GList *imgs = dt_act_on_get_images(TRUE, TRUE, FALSE);
     if(!g_list_is_empty(imgs))
     {
@@ -314,6 +315,8 @@ static void _apply_clicked(GtkWidget *w, dt_lib_styles_t *d)
     }
     else
       g_list_free_full(style_names, g_free);
+
+    dt_start_backthumbs_crawler();
   }
 }
 

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -867,6 +867,9 @@ gboolean try_enter(dt_view_t *self)
     return TRUE;
   }
 
+  // we want to wait for terminated backthumbs crawler for pipeline memory
+  dt_stop_backthumbs_crawler(TRUE);
+
   // this loads the image from db if needed:
   const dt_image_t *img = dt_image_cache_get(imgid, 'r');
   // get image and check if it has been deleted from disk first!

--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -485,6 +485,7 @@ void enter(dt_view_t *self)
   const dt_lighttable_layout_t layout =
     dt_view_lighttable_get_layout(darktable.view_manager);
 
+  dt_start_backthumbs_crawler();
   // enable culling proxy
   darktable.view_manager->proxy.lighttable.culling_preview_refresh =
     _culling_preview_refresh;
@@ -635,6 +636,7 @@ void init(dt_view_t *self)
 
 void leave(dt_view_t *self)
 {
+  dt_stop_backthumbs_crawler(FALSE);
   dt_library_t *lib = self->data;
 
   // disable culling proxy


### PR DESCRIPTION
1. Make sure we can start/stop the background thumbnail update crawler in a safe way.
2. Possibly start the crawler when entering lighttable view mode and stop it when leaving instead of doing this in main darktable.
3. Checked for background jobs with heavy processing / database load and do that work between stop/start of the crawler.
4. We can modify/relax the 'capable' restrictions to more sensible criteria now allowing the crawler to work also on 8GB systems with a >= 4 threads CPU.
5. The crawler struct was simplified using a tri-state check for status instead of gbooleans.
6. Some typo corrections.

Second commit:
Don't use some system memory for dt on small systems

1. To avoid out-of-memory kills while dt processing on small systems (<8GB) we leave 1GB to system.
2. Define DT_MEGA and make use of it for code deduplication.