### PR TITLE
Fix a few capture UI irritations

### DIFF
--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -1782,8 +1782,8 @@ void gui_init(dt_iop_module_t *self)
                                               "ringing especially when used with a large 'iterations' setting.\n\n"
                                               "Note: a radius set to zero will be recalculated automatically the next run. use for presets"));
   dt_bauhaus_widget_set_quad(g->cs_radius, self, dtgtk_cairo_paint_reset, FALSE, _cs_radius_callback,
-    _("calculate the capture sharpen radius from sensor data.\n"
-      "this should be done in zoomed out darkroom"));
+                                            _("calculate the capture sharpen radius from available raw sensor data.\n"
+                                              "for best results avoid cropping or darkroom zooming in"));
 
   g->cs_thrs = dt_bauhaus_slider_from_params(self, "cs_thrs");
   gtk_widget_set_tooltip_text(g->cs_thrs, _("restrict capture sharpening to areas with high local contrast,\n"


### PR DESCRIPTION
1. As the radius calculating algorithm has been verified for good results for some time now we don't need the "validation" any more and trust returned data to be in the 0.0 -> 1.5 range.
2. Fixed a subtle autoradius-once-in-UI flag issue.
3. Instead of avoiding the radius calculation we accept to do so also while being zoomed in or with active cropping but leave a control log notice about imprecise results, also modified the tooltip for clearer information.
4. Also evaluated: if a radius calculation is requested we expand roi_in to full image and calculate radius on those data before restarting pipe with current roi. There are definitely differences - especially if being zoomed/cropped at image borders - for the calculated radius but those are pretty small (mostly <0.05) so it's not worth to do so.