### PR TITLE
simplify agx gui_init etc

### DIFF
--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -1458,6 +1458,7 @@ GtkWidget *dt_bauhaus_slider_from_widget(dt_bauhaus_widget_t* w,
                                          const int feedback)
 {
   w->type = DT_BAUHAUS_SLIDER;
+  DT_IOP_SECTION_FOR_PARAMS_UNWIND(self);
   w->module = DT_ACTION(self);
   dt_bauhaus_slider_data_t *d = &w->slider;
   d->min = d->soft_min = d->hard_min = min;
@@ -1524,6 +1525,7 @@ GtkWidget *dt_bauhaus_combobox_from_widget(dt_bauhaus_widget_t* w,
                                            dt_iop_module_t *self)
 {
   w->type = DT_BAUHAUS_COMBOBOX;
+  DT_IOP_SECTION_FOR_PARAMS_UNWIND(self);
   w->module = DT_ACTION(self);
   dt_bauhaus_combobox_data_t *d = &w->combobox;
   d->entries = g_ptr_array_new_full(4, _free_combobox_entry);

--- a/src/bauhaus/bauhaus.h
+++ b/src/bauhaus/bauhaus.h
@@ -420,6 +420,9 @@ static inline void set_color(cairo_t *cr, GdkRGBA color)
   cairo_set_source_rgba(cr, color.red, color.green, color.blue, color.alpha);
 }
 
+#define DT_IOP_SECTION_FOR_PARAMS_UNWIND(self) \
+  while(self && self->actions==DT_ACTION_TYPE_IOP_SECTION) self = (dt_iop_module_t *)self->module
+
 G_END_DECLS
 
 // clang-format off

--- a/src/common/introspection.h
+++ b/src/common/introspection.h
@@ -243,7 +243,6 @@ typedef struct dt_introspection_t
   dt_introspection_field_t           *field;           // the type of the params. should always be a DT_INTROSPECTION_TYPE_STRUCT
   size_t                              self_size;       // size of dt_iop_module_t. useful to not need dt headers
   size_t                              default_params;  // offset of the default_params in dt_iop_module_t. useful to not need dt headers
-  GHashTable                         *sections;        // section names associated with parameter offsets
 } dt_introspection_t;
 
 // clang-format on

--- a/src/develop/imageop_gui.h
+++ b/src/develop/imageop_gui.h
@@ -28,19 +28,22 @@ GtkWidget *dt_bauhaus_combobox_from_params(dt_iop_module_t *self, const char *pa
 
 GtkWidget *dt_bauhaus_toggle_from_params(dt_iop_module_t *self, const char *param);
 
-typedef struct dt_iop_module_section_t
-{
-  dt_action_type_t actions; // !!! NEEDS to be FIRST (to be able to cast convert)
-  dt_iop_module_t *self;
-  gchar *section;
-} dt_iop_module_section_t;
-
-/*
- * package dt_iop_module_t pointer and section name to pass to a _from_params function
- * it will then create a widget action in a section, rather than top level in the module
- */
-#define DT_IOP_SECTION_FOR_PARAMS(self, section) \
-    (dt_iop_module_t *)&(dt_iop_module_section_t){DT_ACTION_TYPE_IOP_SECTION, self, section}
+// package dt_iop_module_t pointer and section name to pass to a _from_params function
+// it will then create a widget action in a section, rather than top level in the module
+// optionally pass a box to add the widgets to
+#define DT_IOP_SECTION_FOR_PARAMS_DECL(self, section, ...) \
+  (dt_iop_module_t){.actions  = DT_ACTION_TYPE_IOP_SECTION,\
+                    .get_f   = self->get_f,                \
+                    .module   = (GModule*)self,            \
+                    .params   = self->params,              \
+                    .default_params = self->default_params,\
+                    .gui_data = self->gui_data,            \
+                    .data     = (void*)section,            \
+                    .widget   = __VA_OPT__(TRUE            \
+                                ?  GTK_WIDGET(__VA_ARGS__) \
+                                :) self->widget }
+#define DT_IOP_SECTION_FOR_PARAMS(...)                     \
+       &DT_IOP_SECTION_FOR_PARAMS_DECL(__VA_ARGS__)
 
 GtkWidget *dt_iop_togglebutton_new(dt_iop_module_t *self, const char *section, const gchar *label, const gchar *ctrl_label,
                                    GCallback callback, gboolean local, guint accel_key, GdkModifierType mods,

--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -2386,7 +2386,7 @@ void dtgtk_cairo_paint_rawoverexposed(cairo_t *cr, const gint x, const gint y, c
   FINISH
 }
 
-void dtgtk_cairo_paint_gamut_check(cairo_t *cr, const gint x, const gint y, const gint w, const gint h, gint flags, void *data)
+void dtgtk_cairo_paint_warning(cairo_t *cr, const gint x, const gint y, const gint w, const gint h, gint flags, void *data)
 {
   PREAMBLE(1.15, 1, 0, -0.05)
 

--- a/src/dtgtk/paint.h
+++ b/src/dtgtk/paint.h
@@ -185,8 +185,8 @@ void dtgtk_cairo_paint_rawoverexposed(cairo_t *cr, gint x, gint y, gint w, gint 
 void dtgtk_cairo_paint_bulb(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 /** paint a modified light bulb */
 void dtgtk_cairo_paint_bulb_mod(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
-/** paint a gamut check icon */
-void dtgtk_cairo_paint_gamut_check(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
+/** paint a warning triangle */
+void dtgtk_cairo_paint_warning(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 /** paint a soft proofing icon */
 void dtgtk_cairo_paint_softproof(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 /** paint a display icon */

--- a/src/gui/color_picker_proxy.c
+++ b/src/gui/color_picker_proxy.c
@@ -139,6 +139,8 @@ static void _init_picker(dt_iop_color_picker_t *picker,
                          const dt_iop_color_picker_flags_t flags,
                          GtkWidget *button)
 {
+  DT_IOP_SECTION_FOR_PARAMS_UNWIND(module);
+
   // module is NULL if primary colorpicker
   picker->module     = module;
   picker->flags      = flags;

--- a/src/iop/agx.c
+++ b/src/iop/agx.c
@@ -156,8 +156,6 @@ typedef struct dt_iop_basic_curve_controls_t
   GtkWidget *curve_contrast_around_pivot;
   GtkWidget *curve_toe_power;
   GtkWidget *curve_shoulder_power;
-  GtkWidget *toe_warning_icon;
-  GtkWidget *shoulder_warning_icon;
 } dt_iop_basic_curve_controls_t;
 
 typedef struct dt_iop_agx_gui_data_t
@@ -1932,55 +1930,12 @@ static void _update_curve_warnings(dt_iop_module_t *self)
   const gboolean warnings_enabled = dt_conf_get_bool("plugins/darkroom/agx/enable_curve_warnings");
   const tone_mapping_params_t params = _calculate_tone_mapping_params(p);
 
-  if (g->basic_curve_controls.toe_warning_icon)
-    gtk_widget_set_visible(g->basic_curve_controls.toe_warning_icon,
-                           params.need_convex_toe && warnings_enabled);
-  if (g->basic_curve_controls.shoulder_warning_icon)
-    gtk_widget_set_visible(g->basic_curve_controls.shoulder_warning_icon,
-                           params.need_concave_shoulder && warnings_enabled);
-}
-
-static void _update_gamma_slider_sensitivity(const dt_iop_module_t *self)
-{
-  const dt_iop_agx_gui_data_t *g = self->gui_data;
-  const dt_iop_agx_params_t *p = self->params;
-
-  if(g && g->curve_gamma)
-  {
-    gtk_widget_set_sensitive(g->curve_gamma, !p->auto_gamma);
-  }
-}
-
-static void _update_post_curve_primaries_visibility(const dt_iop_module_t *self)
-{
-  const dt_iop_agx_gui_data_t *g = self->gui_data;
-  const dt_iop_agx_params_t *p = self->params;
-
-  if(g && g->post_curve_primaries_controls_vbox)
-  {
-    const gboolean post_curve_primaries_available = !p->completely_reverse_primaries && !p->disable_primaries_adjustments;
-    gtk_widget_set_visible(g->post_curve_primaries_controls_vbox, post_curve_primaries_available);
-    gtk_widget_set_sensitive(g->post_curve_primaries_controls_vbox, post_curve_primaries_available);
-    if(g->set_post_curve_primaries_from_pre_button)
-    {
-      gtk_widget_set_sensitive(g->set_post_curve_primaries_from_pre_button, post_curve_primaries_available);
-    }
-  }
-}
-
-static void _update_primaries_checkbox_and_sliders(const dt_iop_module_t *self)
-{
-  const dt_iop_agx_gui_data_t *g = self->gui_data;
-  const dt_iop_agx_params_t *p = self->params;
-
-  if(g && g->primaries_controls_vbox)
-  {
-    const gboolean primaries_enabled = !p->disable_primaries_adjustments;
-    gtk_widget_set_visible(g->primaries_controls_vbox, primaries_enabled);
-    gtk_widget_set_sensitive(g->primaries_controls_vbox, primaries_enabled);
-    if(g->completely_reverse_primaries)
-      gtk_widget_set_sensitive(g->completely_reverse_primaries, !p->disable_primaries_adjustments);
-  }
+  dt_bauhaus_widget_set_quad_paint(g->basic_curve_controls.curve_toe_power,
+                                    params.need_convex_toe && warnings_enabled
+                                    ? dtgtk_cairo_paint_warning : NULL, CPF_ACTIVE, NULL);
+  dt_bauhaus_widget_set_quad_paint(g->basic_curve_controls.curve_shoulder_power,
+                                    params.need_concave_shoulder && warnings_enabled
+                                    ? dtgtk_cairo_paint_warning : NULL, CPF_ACTIVE, NULL);
 }
 
 void gui_changed(dt_iop_module_t *self,
@@ -2004,16 +1959,16 @@ void gui_changed(dt_iop_module_t *self,
     darktable.gui->reset--;
   }
 
-  _update_gamma_slider_sensitivity(self);
-  _update_primaries_checkbox_and_sliders(self);
+  gtk_widget_set_visible(g->curve_gamma, !p->auto_gamma);
+  gtk_widget_set_visible(g->primaries_controls_vbox, !p->disable_primaries_adjustments);
+  const gboolean post_curve_primaries_available = !p->completely_reverse_primaries && !p->disable_primaries_adjustments;
+  gtk_widget_set_visible(g->post_curve_primaries_controls_vbox, post_curve_primaries_available);
+  gtk_widget_set_sensitive(g->set_post_curve_primaries_from_pre_button, post_curve_primaries_available);
+
   _update_curve_warnings(self);
-  _update_post_curve_primaries_visibility(self);
 
   // Trigger redraw when any parameter changes
-  if(g && g->graph_drawing_area)
-  {
-    gtk_widget_queue_draw(GTK_WIDGET(g->graph_drawing_area));
-  }
+  gtk_widget_queue_draw(GTK_WIDGET(g->graph_drawing_area));
 
   if(g && p->auto_gamma)
   {
@@ -2024,12 +1979,13 @@ void gui_changed(dt_iop_module_t *self,
   }
 }
 
-static void _add_basic_curve_controls(dt_iop_module_t *self,
-                                      dt_iop_basic_curve_controls_t *controls,
-                                      gchar *section_name)
+static GtkWidget* _create_basic_curve_controls_box(dt_iop_module_t *self,
+                                                   dt_iop_agx_gui_data_t *g)
 {
+  GtkWidget *box = dt_gui_vbox(dt_ui_section_label_new(C_("section", "basic curve parameters")));
   GtkWidget *slider = NULL;
-  dt_iop_module_t *section = DT_IOP_SECTION_FOR_PARAMS(self, NC_("section", "curve"));
+  dt_iop_module_t *section = DT_IOP_SECTION_FOR_PARAMS(self, NC_("section", "curve"), box);
+  dt_iop_basic_curve_controls_t *controls = &g->basic_curve_controls;
 
   // curve_pivot_x_shift with picker
   slider = dt_color_picker_new(self, DT_COLOR_PICKER_AREA | DT_COLOR_PICKER_DENOISE,
@@ -2056,24 +2012,14 @@ static void _add_basic_curve_controls(dt_iop_module_t *self,
   dt_bauhaus_slider_set_soft_range(slider, 0.1f, 5.f);
   gtk_widget_set_tooltip_text(slider, _("slope of the linear section around the pivot"));
 
-  GtkWidget *parent_vbox = self->widget;
-
   // curve_toe_power
-  GtkWidget *toe_hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 2);
-  self->widget = toe_hbox;
   slider = dt_bauhaus_slider_from_params(section, "curve_toe_power");
   controls->curve_toe_power = slider;
-  gtk_widget_set_hexpand(slider, TRUE);
-  self->widget = parent_vbox;
-  dt_gui_box_add(self->widget, toe_hbox);
-
   dt_bauhaus_slider_set_soft_range(slider, 1.f, 5.f);
   gtk_widget_set_tooltip_text(slider, _("contrast in shadows\n"
                                         "higher values keep the slope nearly constant for longer,\n"
                                         "at the cost of a more sudden drop near black"));
-  controls->toe_warning_icon =
-      gtk_image_new_from_icon_name("dialog-warning-symbolic", GTK_ICON_SIZE_SMALL_TOOLBAR);
-  gtk_widget_set_tooltip_text(controls->toe_warning_icon,
+  dt_bauhaus_widget_set_quad_tooltip(slider,
                               _("the curve has lost its 'S' shape, toe power cannot be applied.\n"
                                 "target black cannot be reached with the selected contrast and pivot position.\n"
                                 "increase contrast, move the pivot lower (reduce the pivot target output or\n"
@@ -2081,25 +2027,15 @@ static void _add_basic_curve_controls(dt_iop_module_t *self,
                                 "(increase the pivot shift, move the black point farther from the pivot by raising\n"
                                 "the relative black exposure or move the white point closer to the pivot\n"
                                 "by decreasing relative white exposure)."));
-  gtk_widget_set_no_show_all(controls->toe_warning_icon, TRUE);
-  gtk_box_pack_start(GTK_BOX(toe_hbox), controls->toe_warning_icon, FALSE, FALSE, 0);
 
   // curve_shoulder_power
-  GtkWidget *shoulder_hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 2);
-  self->widget = shoulder_hbox;
   slider = dt_bauhaus_slider_from_params(section, "curve_shoulder_power");
   controls->curve_shoulder_power = slider;
-  gtk_widget_set_hexpand(slider, TRUE);
-  self->widget = parent_vbox;
-  dt_gui_box_add(self->widget, shoulder_hbox);
-
   dt_bauhaus_slider_set_soft_range(slider, 1.f, 5.f);
   gtk_widget_set_tooltip_text(slider, _("contrast in highlights\n"
                                         "higher values keep the slope nearly constant for longer,\n"
                                         "at the cost of a more sudden drop near white"));
-  controls->shoulder_warning_icon =
-      gtk_image_new_from_icon_name("dialog-warning-symbolic", GTK_ICON_SIZE_SMALL_TOOLBAR);
-  gtk_widget_set_tooltip_text(controls->shoulder_warning_icon,
+  dt_bauhaus_widget_set_quad_tooltip(slider,
                               _("the curve has lost its 'S' shape, shoulder power cannot be applied.\n"
                                 "target white cannot be reached with the selected contrast and pivot position.\n"
                                 "increase contrast, move the pivot higher (increase pivot target output\n"
@@ -2108,30 +2044,11 @@ static void _add_basic_curve_controls(dt_iop_module_t *self,
                                 "increasing relative white exposure or move the black point closer to the pivot\n"
                                 "by lowering relative black exposure)."));
 
-  gtk_widget_set_no_show_all(controls->shoulder_warning_icon, TRUE);
-  gtk_box_pack_start(GTK_BOX(shoulder_hbox), controls->shoulder_warning_icon, FALSE, FALSE, 0);
-}
-
-static GtkWidget* _create_basic_curve_controls_box(dt_iop_module_t *self,
-                                                   dt_iop_agx_gui_data_t *g)
-{
-  GtkWidget *parent = self->widget;
-  gchar *section_name = NC_("section", "basic curve parameters");
-  GtkWidget *box = self->widget = dt_gui_vbox(dt_ui_section_label_new(Q_(section_name)));
-
-  _add_basic_curve_controls(self, &g->basic_curve_controls, section_name);
-
-  self->widget = parent;
   return box;
 }
 
-static void _add_look_sliders(dt_iop_module_t *self, GtkWidget *parent_widget, gchar *section_name)
+static void _add_look_sliders(dt_iop_module_t *section)
 {
-  GtkWidget *original_self_widget = self->widget;
-  self->widget = parent_widget;
-
-  dt_iop_module_t *section = DT_IOP_SECTION_FOR_PARAMS(self, section_name);
-
   // Reuse the slider variable for all sliders instead of creating new ones in each scope
   GtkWidget *slider = NULL;
 
@@ -2161,8 +2078,6 @@ static void _add_look_sliders(dt_iop_module_t *self, GtkWidget *parent_widget, g
   dt_bauhaus_slider_set_factor(slider, 100.f);
   dt_bauhaus_slider_set_soft_range(slider, 0.f, 1.f);
   gtk_widget_set_tooltip_text(slider, _("increase to bring hues closer to the original"));
-
-  self->widget = original_self_widget;
 }
 
 static void _add_look_box(dt_iop_module_t *self,
@@ -2176,14 +2091,14 @@ static void _add_look_box(dt_iop_module_t *self,
   if(look_always_visible)
   {
     dt_gui_box_add(look_box, dt_ui_section_label_new(Q_(section_name)));
-    _add_look_sliders(self, look_box, section_name);
+    _add_look_sliders(DT_IOP_SECTION_FOR_PARAMS(self, section_name, look_box));
   }
   else
   {
     dt_gui_new_collapsible_section(&g->look_section,
                                    "plugins/darkroom/agx/expand_look_params", Q_(section_name),
                                    GTK_BOX(look_box), DT_ACTION(self));
-    _add_look_sliders(self, GTK_WIDGET(g->look_section.container), section_name);
+    _add_look_sliders(DT_IOP_SECTION_FOR_PARAMS(self, section_name, g->look_section.container));
   }
 
   dt_gui_box_add(self->widget, look_box);
@@ -2213,8 +2128,6 @@ static GtkWidget* _create_curve_graph_box(dt_iop_module_t *self,
 static GtkWidget* _create_advanced_box(dt_iop_module_t *self,
                                        dt_iop_agx_gui_data_t *g)
 {
-  GtkWidget *parent = self->widget;
-
   GtkWidget *advanced_box = dt_gui_vbox();
 
   const gchar *section_name = NC_("section", "advanced curve parameters");
@@ -2222,8 +2135,8 @@ static GtkWidget* _create_advanced_box(dt_iop_module_t *self,
                                  "plugins/darkroom/agx/expand_curve_advanced",
                                  Q_(section_name),
                                  GTK_BOX(advanced_box), DT_ACTION(self));
-  self->widget = GTK_WIDGET(g->advanced_section.container);
-  dt_iop_module_t *section = DT_IOP_SECTION_FOR_PARAMS(self, NC_("section", "curve"));
+  dt_iop_module_t *section = DT_IOP_SECTION_FOR_PARAMS(self, NC_("section", "curve"),
+                                                             g->advanced_section.container);
 
   // Reuse the slider variable for all sliders
   GtkWidget *slider = NULL;
@@ -2283,17 +2196,13 @@ static GtkWidget* _create_advanced_box(dt_iop_module_t *self,
        "but shadows and highlights are; you may have to counteract it\n"
        "with the contrast slider or with toe / shoulder controls."));
 
-  self->widget = parent;
-
   return advanced_box;
 }
 
 static void _add_exposure_box(dt_iop_module_t *self, dt_iop_agx_gui_data_t *g)
 {
-  GtkWidget *parent = self->widget;
-
   gchar *section_name = NC_("section", "input exposure range");
-  self->widget = dt_gui_vbox(dt_ui_section_label_new(Q_(section_name)));
+  dt_gui_box_add(self->widget, dt_ui_section_label_new(Q_(section_name)));
 
   g->white_exposure_picker =
       dt_color_picker_new(self, DT_COLOR_PICKER_AREA | DT_COLOR_PICKER_DENOISE,
@@ -2327,8 +2236,6 @@ static void _add_exposure_box(dt_iop_module_t *self, dt_iop_agx_gui_data_t *g)
                               _("pick image area to automatically set black and white exposure"));
   dt_gui_box_add(self->widget, g->range_exposure_picker);
 
-  dt_gui_box_add(parent, self->widget);
-  self->widget = parent;
 }
 
 static void _apply_primaries_from_menu_callback(GtkMenuItem *menuitem, dt_iop_module_t *self)
@@ -2392,44 +2299,26 @@ void gui_update(dt_iop_module_t *self)
   const dt_iop_agx_gui_data_t *g = self->gui_data;
   const dt_iop_agx_params_t *p = self->params;
 
-  if(g)
-  {
-    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->auto_gamma), p->auto_gamma);
-    if(p->auto_gamma)
-    {
-      tone_mapping_params_t tone_mapping_params;
-      _set_log_mapping_params(self->params, &tone_mapping_params);
-      _adjust_pivot(self->params, &tone_mapping_params);
-      dt_bauhaus_slider_set(g->curve_gamma, tone_mapping_params.curve_gamma);
-    }
-  }
-
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->auto_gamma),
+                               p->auto_gamma);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->disable_primaries_adjustments),
                                p->disable_primaries_adjustments);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->completely_reverse_primaries),
                                p->completely_reverse_primaries);
 
-  _update_gamma_slider_sensitivity(self);
-  _update_primaries_checkbox_and_sliders(self);
-  _update_curve_warnings(self);
-  _update_post_curve_primaries_visibility(self);
-
-  // Ensure the graph is drawn initially
-  if(g && g->graph_drawing_area)
-  {
-    gtk_widget_queue_draw(GTK_WIDGET(g->graph_drawing_area));
-  }
+  gui_changed(self, NULL, NULL);
 }
 
-static GtkWidget *_add_primaries_box(dt_iop_module_t *self)
+static void _create_primaries_page(dt_iop_module_t *main,
+                                   dt_iop_agx_gui_data_t *g)
 {
-  dt_iop_agx_gui_data_t *g = self->gui_data;
-  GtkWidget *main_box = self->widget;
+  GtkWidget *page_primaries =
+    dt_ui_notebook_page(g->notebook, N_("primaries"), _("color primaries adjustments"));
 
-  GtkWidget *primaries_box = self->widget = dt_gui_vbox();
+  dt_iop_module_t *page = DT_IOP_SECTION_FOR_PARAMS(main, NULL, page_primaries);
 
   g->disable_primaries_adjustments =
-    dt_bauhaus_toggle_from_params(self, "disable_primaries_adjustments");
+    dt_bauhaus_toggle_from_params(page, "disable_primaries_adjustments");
 
   gtk_widget_set_tooltip_text
     (g->disable_primaries_adjustments,
@@ -2439,17 +2328,16 @@ static GtkWidget *_add_primaries_box(dt_iop_module_t *self)
        "especially with bright, saturated lights (e.g. LEDs).\n"
        "mainly intended to be used for experimenting."));
 
-  g->primaries_controls_vbox = self->widget = dt_gui_vbox();
-  dt_gui_box_add(primaries_box, g->primaries_controls_vbox);
 
-  GtkWidget *primaries_hbox = dt_gui_hbox();
-  GtkWidget *primaries_label = gtk_label_new(_("reset primaries"));
   GtkWidget *primaries_button = dtgtk_button_new(dtgtk_cairo_paint_styles, 0, NULL);
   gtk_widget_set_tooltip_text(primaries_button, _("reset primaries to a predefined configuration"));
-  g_signal_connect(primaries_button, "clicked", G_CALLBACK(_primaries_popupmenu_callback), self);
+  g_signal_connect(primaries_button, "clicked", G_CALLBACK(_primaries_popupmenu_callback), main);
 
-  gtk_box_pack_start(GTK_BOX(primaries_hbox), primaries_label, FALSE, FALSE, 0);
-  gtk_box_pack_end(GTK_BOX(primaries_hbox), primaries_button, FALSE, FALSE, 0);  dt_gui_box_add(g->primaries_controls_vbox, primaries_hbox);
+  g->primaries_controls_vbox = dt_gui_vbox(dt_gui_hbox(gtk_label_new(_("reset primaries")),
+                                                       dt_gui_align_right(primaries_button)));
+  dt_gui_box_add(page_primaries, g->primaries_controls_vbox);
+
+  dt_iop_module_t *self = DT_IOP_SECTION_FOR_PARAMS(main, NULL, g->primaries_controls_vbox);
 
   GtkWidget *base_primaries_combo = dt_bauhaus_combobox_from_params(self, "base_primaries");
   gtk_widget_set_tooltip_text(base_primaries_combo,
@@ -2489,17 +2377,13 @@ static GtkWidget *_add_primaries_box(dt_iop_module_t *self)
                     "_rotation",
                     _("shift the blue primary towards magenta (+) or cyan (-)"));
 
-  dt_gui_box_add(self->widget, dt_ui_section_label_new(C_("section", "after tone mapping")));
-
-  GtkWidget *parent_vbox = self->widget;
-
   GtkWidget *reversal_hbox = dt_gui_hbox();
-  dt_gui_box_add(parent_vbox, reversal_hbox);
+  g->post_curve_primaries_controls_vbox = dt_gui_vbox();
+  dt_gui_box_add(self->widget, dt_ui_section_label_new(C_("section", "after tone mapping")),
+                               reversal_hbox, g->post_curve_primaries_controls_vbox);
 
   self->widget = reversal_hbox;
   g->completely_reverse_primaries = dt_bauhaus_toggle_from_params(self, "completely_reverse_primaries");
-  self->widget = parent_vbox;
-
   gtk_widget_set_tooltip_text(g->completely_reverse_primaries, _("completely restore purity, undo all rotations, and hide\n"
                                                                  "the controls below. uncheck to restore the previous state."));
 
@@ -2507,12 +2391,10 @@ static GtkWidget *_add_primaries_box(dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->set_post_curve_primaries_from_pre_button,
                               _("set parameters to completely reverse primaries modifications,\n"
                                   "but allow subsequent editing"));
-  g_signal_connect(g->set_post_curve_primaries_from_pre_button, "clicked", G_CALLBACK(_set_post_curve_primaries_from_pre_callback), self);
-  gtk_box_pack_end(GTK_BOX(reversal_hbox), g->set_post_curve_primaries_from_pre_button, FALSE, FALSE, 5);
+  g_signal_connect(g->set_post_curve_primaries_from_pre_button, "clicked", G_CALLBACK(_set_post_curve_primaries_from_pre_callback), main);
+  dt_gui_box_add(reversal_hbox, dt_gui_align_right(g->set_post_curve_primaries_from_pre_button));
 
-  GtkWidget *vbox_to_add_to = parent_vbox;
-  g->post_curve_primaries_controls_vbox = self->widget = dt_gui_vbox();
-  dt_gui_box_add(vbox_to_add_to, g->post_curve_primaries_controls_vbox);
+  self->widget = g->post_curve_primaries_controls_vbox;
 
   slider = dt_bauhaus_slider_from_params(self, "master_outset_ratio");
   dt_bauhaus_slider_set_format(slider, "%");
@@ -2539,126 +2421,74 @@ static GtkWidget *_add_primaries_box(dt_iop_module_t *self)
                     "_unrotation",
                     _("reverse the color shift in blues"));
 #undef SETUP_COLOR_COMBO
-
-  self->widget = main_box;
-  return primaries_box;
 }
 
 static void _notebook_page_changed(GtkNotebook *notebook,
-                                   GtkWidget *page, const guint page_num,
+                                   GtkWidget *page,
+                                   const guint page_num,
                                    dt_iop_module_t *self)
 {
   dt_iop_agx_gui_data_t *g = self->gui_data;
+  GtkWidget *basics = g->curve_basic_controls_box;
 
   // 'settings' or 'curve' page only
-  if(page_num == 0 || page_num == 1)
+  if(page_num <= 1)
   {
-    // the GtkBox container for the tab
-    GtkWidget *vbox = page;
+    // prevent the widget from being destroyed when removed from its parent
+    g_object_ref(basics);
 
-    GtkWidget *current_parent = gtk_widget_get_parent(g->curve_basic_controls_box);
+    // remove from the page it was on
+    gtk_container_remove(GTK_CONTAINER(gtk_widget_get_parent(basics)), basics);
 
-    if(current_parent != vbox)
+    // pack to the now showing notebook page
+    dt_gui_box_add(page, basics);
+
+    int position = -1;
+    if(page_num == 0)
     {
-      // prevent the widget from being destroyed when removed from its parent
-      g_object_ref(g->curve_basic_controls_box);
-
-      if(current_parent)
-      {
-        gtk_container_remove(GTK_CONTAINER(current_parent), g->curve_basic_controls_box);
-      }
-
-      // pack to new parent
-      dt_gui_box_add(vbox, g->curve_basic_controls_box);
-
-      // On the 'settings' page, move to second last position (before look box)
-      if(page_num == 0)
-      {
-        // Get all children of the vbox
-        GList *children = gtk_container_get_children(GTK_CONTAINER(vbox));
-        const guint num_children = g_list_length(children);
-        g_list_free(children);
-
-        // Move to the position before the last one (before look box)
-        if(num_children > 1)
-        {
-          gtk_box_reorder_child(GTK_BOX(vbox), g->curve_basic_controls_box, num_children - 2);
-        }
-      }
-      // on the 'curve' page, move to top
-      else if(page_num == 1)
-      {
-        gtk_box_reorder_child(GTK_BOX(vbox), g->curve_basic_controls_box, 0);
-      }
-
-      g_object_unref(g->curve_basic_controls_box);
+      // on settings page, place after "auto tune levels" picker
+      gtk_container_child_get(GTK_CONTAINER(page), g->range_exposure_picker,
+                            "position", &position, NULL);
     }
-  }
-}
+    gtk_box_reorder_child(GTK_BOX(page), basics, ++position);
 
-static void _create_primaries_page(dt_iop_module_t *self,
-                                   const dt_iop_agx_gui_data_t *g)
-{
-  GtkWidget *page_primaries =
-    dt_ui_notebook_page(g->notebook, N_("primaries"), _("color primaries adjustments"));
-  GtkWidget *primaries_box = _add_primaries_box(self);
-  dt_gui_box_add(page_primaries, primaries_box);
+    g_object_unref(basics);
+  }
 }
 
 void gui_init(dt_iop_module_t *self)
 {
   dt_iop_agx_gui_data_t *g = IOP_GUI_ALLOC(agx);
-  GtkWidget *main_vbox = self->widget = dt_gui_vbox();
 
   static dt_action_def_t notebook_def = {};
   g->notebook = dt_ui_notebook_new(&notebook_def);
-  GtkWidget *notebook_widget = GTK_WIDGET(g->notebook);
-  dt_action_define_iop(self, NULL, N_("page"), notebook_widget, &notebook_def);
-  dt_gui_box_add(main_vbox, notebook_widget);
+  self->widget = GTK_WIDGET(g->notebook);
+  dt_action_define_iop(self, NULL, N_("page"), GTK_WIDGET(g->notebook), &notebook_def);
 
   g->curve_basic_controls_box = _create_basic_curve_controls_box(self, g);
   g->curve_graph_box = _create_curve_graph_box(self, g);
   g->curve_advanced_controls_box = _create_advanced_box(self, g);
 
+  GtkWidget *current_page = dt_ui_notebook_page(g->notebook,
+                                                N_("settings"),
+                                                _("main look and curve settings"));
+  dt_iop_module_t *settings_section = DT_IOP_SECTION_FOR_PARAMS(self, NULL, current_page);
+  _add_exposure_box(settings_section, g);
+  dt_gui_box_add(settings_section->widget, g->curve_basic_controls_box);
   if(dt_conf_get_bool("plugins/darkroom/agx/enable_curve_tab"))
   {
-    GtkWidget *settings_page = dt_ui_notebook_page(g->notebook,
-                                                   N_("settings"),
-                                                   _("main look and curve settings"));
-    self->widget = settings_page;
-    _add_exposure_box(self, g);
-    // we'll trigger a 'reparenting' to get the basic curve params here
-    _add_look_box(self, g);
-
-    GtkWidget *curve_page = dt_ui_notebook_page(g->notebook,
-                                                N_("curve"),
-                                                _("detailed curve settings"));
-    self->widget = curve_page;
-    dt_gui_box_add(curve_page, g->curve_graph_box,
-                               g->curve_advanced_controls_box);
-
+    current_page = dt_ui_notebook_page(g->notebook,
+                                       N_("curve"),
+                                       _("detailed curve settings"));
     // reparent on tab switch
     g_signal_connect(g->notebook, "switch-page", G_CALLBACK(_notebook_page_changed), self);
-
-    // initial 'reparenting' to the settings page
-    _notebook_page_changed(g->notebook, gtk_notebook_get_nth_page(g->notebook, 0), 0, self);
   }
-  else
-  {
-    GtkWidget *settings_page = dt_ui_notebook_page(g->notebook,
-                                                   N_("settings"),
-                                                   _("main look and curve settings"));
-    self->widget = settings_page;
-    _add_exposure_box(self, g);
-    dt_gui_box_add(settings_page, g->curve_basic_controls_box,
-                                  g->curve_graph_box,
-                                  g->curve_advanced_controls_box);
-    _add_look_box(self, g);
-  }
+  dt_gui_box_add(current_page, g->curve_graph_box,
+                               g->curve_advanced_controls_box);
 
+  _add_look_box(settings_section, g);
   _create_primaries_page(self, g);
 
-  self->widget = main_vbox;
   gui_update(self);
 }
 

--- a/src/iop/colorequal.c
+++ b/src/iop/colorequal.c
@@ -3057,11 +3057,10 @@ void gui_init(dt_iop_module_t *self)
   // not a requirement here
 
   dt_iop_module_t *sect = NULL;
-#define GROUP_SLIDERS(num, page, tooltip)                  \
-  dt_ui_notebook_page(g->notebook, page, tooltip);         \
-  self->widget = dt_gui_vbox();                            \
-  gtk_stack_add_named(g->stack, self->widget, num);        \
-  sect = DT_IOP_SECTION_FOR_PARAMS(self, page);
+#define GROUP_SLIDERS(num, page, tooltip)                      \
+  dt_ui_notebook_page(g->notebook, page, tooltip);             \
+  sect = DT_IOP_SECTION_FOR_PARAMS(self, page, dt_gui_vbox()); \
+  gtk_stack_add_named(g->stack, sect->widget, num);
 
   GROUP_SLIDERS("0", N_("hue"), _("change hue hue-wise"))
   g->hue_sliders[0] = g->hue_red =

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -4510,12 +4510,9 @@ void gui_init(dt_iop_module_t *self)
      GTK_BOX(self->widget),
      DT_ACTION(self));
   self->widget = GTK_WIDGET(g->fine_tune.container);
-  // DT_IOP_SECTION_FOR_PARAMS doesn't work in C++ so create section
-  // module manually
-  dt_iop_module_section_t sect_mod = {DT_ACTION_TYPE_IOP_SECTION,
-                                      self,
-                                      (gchar *)N_("fine-tune")};
-  dt_iop_module_t *sect = (dt_iop_module_t *)&sect_mod;
+  // DT_IOP_SECTION_FOR_PARAMS doesn't work in C++ so declare local first
+  dt_iop_module_t sect_mod = DT_IOP_SECTION_FOR_PARAMS_DECL(self, N_("fine-tune"));
+  dt_iop_module_t *sect = &sect_mod;
 
   g->cor_dist_ft = dt_bauhaus_slider_from_params(sect, "cor_dist_ft");
   dt_bauhaus_slider_set_digits(g->cor_dist_ft, 3);
@@ -4591,7 +4588,7 @@ void gui_init(dt_iop_module_t *self)
       _("additional manually controlled optical vignetting correction"));
 
   self->widget = GTK_WIDGET(g->vignette.container);
-  sect_mod.section = (gchar *)N_("vignette");
+  sect_mod.data = (gpointer)N_("vignette");
 
   g->v_strength = dt_bauhaus_slider_from_params(sect, "v_strength");
   gtk_widget_set_tooltip_text(g->v_strength,

--- a/src/iop/splittoning.c
+++ b/src/iop/splittoning.c
@@ -485,31 +485,29 @@ void gui_init(dt_iop_module_t *self)
 {
   dt_iop_splittoning_gui_data_t *g = IOP_GUI_ALLOC(splittoning);
 
-  dt_iop_module_t *sect = DT_IOP_SECTION_FOR_PARAMS(self, N_("shadows"));
-  GtkWidget *shadows_box = self->widget = dt_gui_vbox();
-  g->shadow_hue_gslider = dt_bauhaus_slider_from_params(sect, "shadow_hue");
+  dt_iop_module_t *shad = DT_IOP_SECTION_FOR_PARAMS(self, N_("shadows"));
+  g->shadow_hue_gslider = dt_bauhaus_slider_from_params(shad, "shadow_hue");
   dt_bauhaus_slider_set_factor(g->shadow_hue_gslider, 360.0f);
   dt_bauhaus_slider_set_format(g->shadow_hue_gslider, "°");
-  g->shadow_sat_gslider = dt_bauhaus_slider_from_params(sect, "shadow_saturation");
+  g->shadow_sat_gslider = dt_bauhaus_slider_from_params(shad, "shadow_saturation");
 
-  sect = DT_IOP_SECTION_FOR_PARAMS(self, N_("highlights"));
-  GtkWidget *highlights_box = self->widget = dt_gui_vbox();
-  g->highlight_hue_gslider = dt_bauhaus_slider_from_params(sect, "highlight_hue");
+  dt_iop_module_t *high = DT_IOP_SECTION_FOR_PARAMS(self, N_("highlights"));
+  g->highlight_hue_gslider = dt_bauhaus_slider_from_params(high, "highlight_hue");
   dt_bauhaus_slider_set_factor(g->highlight_hue_gslider, 360.0f);
   dt_bauhaus_slider_set_format(g->highlight_hue_gslider, "°");
-  g->highlight_sat_gslider = dt_bauhaus_slider_from_params(sect, "highlight_saturation");
+  g->highlight_sat_gslider = dt_bauhaus_slider_from_params(high, "highlight_saturation");
 
   // start building top level widget
   self->widget = dt_gui_vbox();
 
   gui_init_section(self, NC_("section", "shadows"),
-                   shadows_box,
+                   shad->widget,
                    g->shadow_hue_gslider,
                    g->shadow_sat_gslider,
                    &g->shadow_colorpick, TRUE);
 
   gui_init_section(self, NC_("section", "highlights"),
-                   highlights_box,
+                   high->widget,
                    g->highlight_hue_gslider,
                    g->highlight_sat_gslider,
                    &g->highlight_colorpick, FALSE);

--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -2812,7 +2812,7 @@ static gboolean area_draw(GtkWidget *widget,
       // histogram overflows controls in highlights : display warning
       cairo_save(g->cr);
       cairo_set_source_rgb(g->cr, 0.75, 0.50, 0.);
-      dtgtk_cairo_paint_gamut_check
+      dtgtk_cairo_paint_warning
         (g->cr,
          g->graph_width - 2.5 * g->line_height, 0.5 * g->line_height,
          2.0 * g->line_height, 2.0 * g->line_height, 0, NULL);
@@ -2824,7 +2824,7 @@ static gboolean area_draw(GtkWidget *widget,
       // histogram overflows controls in lowlights : display warning
       cairo_save(g->cr);
       cairo_set_source_rgb(g->cr, 0.75, 0.50, 0.);
-      dtgtk_cairo_paint_gamut_check
+      dtgtk_cairo_paint_warning
         (g->cr,
          0.5 * g->line_height, 0.5 * g->line_height,
          2.0 * g->line_height, 2.0 * g->line_height, 0, NULL);

--- a/src/libs/history.c
+++ b/src/libs/history.c
@@ -695,14 +695,19 @@ static gchar *_lib_history_bauhaus_text(gpointer bhfield,
 {
   for(GSList *w = module->widget_list_bh; w; w = g_slist_next(w))
   {
-    GtkWidget *widget = ((dt_action_target_t *)w->data)->target;
+    dt_action_target_t *at = w->data;
+    GtkWidget *widget = at->target;
     if(dt_bauhaus_widget_get_field(widget) == bhfield)
     {
+      dt_action_t *as = at->action->owner;
+      gchar *s = as && as->type == DT_ACTION_TYPE_SECTION
+                 ? g_strdup_printf("%s/%s", as->label, d) : NULL;
       gchar *old_text = dt_bauhaus_slider_get_text(widget, oval);
       gchar *new_text = dt_bauhaus_slider_get_text(widget, pval);
-      gchar *ret_text = CHG_STR(%s, d, old_text, new_text);
+      gchar *ret_text = CHG_STR(%s, s ? s : d, old_text, new_text);
       g_free(old_text);
       g_free(new_text);
+      g_free(s);
       return ret_text;
     }
   }
@@ -741,21 +746,8 @@ static gchar *_lib_history_change_text(dt_introspection_field_t *field,
 
         if(d) description = g_strdup_printf("%s.%s", d, description);
 
-        gchar *part, *sect = NULL;
-        if((part = _lib_history_change_text(entry, description, module, params, oldpar)))
-        {
-          GHashTable *sections = field->header.so->get_introspection()->sections;
-          if(sections
-             && (sect = g_hash_table_lookup(sections,
-                                            GINT_TO_POINTER(entry->header.offset))))
-          {
-            sect = g_strdup_printf("%s/%s", Q_(sect), part);
-            g_free(part);
-            part = sect;
-          }
-
-          change_parts[num_parts++] = part;
-        }
+        gchar *part = _lib_history_change_text(entry, description, module, params, oldpar);
+        if(part) change_parts[num_parts++] = part;
 
         if(d) g_free(description);
       }

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -2705,7 +2705,7 @@ void gui_init(dt_view_t *self)
     dt_gui_add_help_link(dev->profile.softproof_button, "softproof");
 
     // the gamut check button
-    dev->profile.gamut_button = dtgtk_togglebutton_new(dtgtk_cairo_paint_gamut_check, 0, NULL);
+    dev->profile.gamut_button = dtgtk_togglebutton_new(dtgtk_cairo_paint_warning, 0, NULL);
     ac = dt_action_define(sa, NULL, N_("gamut check"),
                           dev->profile.gamut_button, &dt_action_def_toggle);
     dt_shortcut_register(ac, 0, 0, GDK_KEY_g, GDK_CONTROL_MASK);


### PR DESCRIPTION
fixes #19518
This was caused by a bug in QAP where temporarily removing a widget from an hbox to put it into QAP and then later putting it back doesn't seem to correctly restore hexpand. But anyway using an hbox with a sometimes visible image next to a slider means that the slider will be slightly shortened when the warning icon is visible, which is not consistent with how we do it elsewhere. So I've now placed the warning triangle into the quad space of the bauhaus widgets so the hbox is no longer needed. This also has the advantage (?) that the warnings will appear in QAP as well when the sliders are there. The same thing could (should?) be done with the _reset primaries_ button; rather than have gtklabel+dtgtk_button, this could be an empty combobox (with no items ) and a button created with `dt_bauhaus_widget_set_quad`.

I used the opportunity to somewhat rigorously clean up the setup of the agx gui. @kofa73  I hope I didn't break anything. I have to admit I haven't tested much with the  separate curve tab. Please let me know your thoughts.

One of the simplifications also useable elsewhere is that DT_IOP_SECTION_FOR_PARAMS has been extended so that one can optionally specify a box to add params widgets to, which then overrides self->widget, so it does not have to be saved and restored. If you _just_ want to override self->widget you can leave sector = NULL.