### PR TITLE
Move history stack paste mode (append / overwrite) into GUI dialog.

### DIFF
--- a/src/common/history.h
+++ b/src/common/history.h
@@ -53,13 +53,21 @@ typedef struct dt_history_hash_values_t
   int current_len;
 } dt_history_hash_values_t;
 
+typedef enum dt_history_copy_mode_t
+{
+  DT_HISTORY_COPY_APPEND    = 0,
+  DT_HISTORY_COPY_OVERWRITE = 1
+} dt_history_copy_mode_t;
+
 typedef struct dt_history_copy_item_t
 {
   GList *selops;
   GtkTreeView *items;
+  GtkWidget *overwrite;
   dt_imgid_t copied_imageid;
   gboolean full_copy;
   gboolean copy_iop_order;
+  gboolean is_overwrite_set;
 } dt_history_copy_item_t;
 
 /** helper function to free a GList of dt_history_item_t */

--- a/src/libs/copy_history.c
+++ b/src/libs/copy_history.c
@@ -40,20 +40,12 @@
 
 DT_MODULE(1)
 
-typedef enum dt_history_copy_mode_t
-{
-  DT_COPY_HISTORY_APPEND    = 0,
-  DT_COPY_HISTORY_OVERWRITE = 1
-} dt_history_copy_mode_t;
-
 typedef struct dt_lib_copy_history_t
 {
-  GtkWidget *pastemode;
   GtkWidget *paste, *paste_parts;
   GtkWidget *copy_button, *discard_button, *load_button, *write_button;
   GtkWidget *copy_parts_button;
   GtkWidget *compress_button;
-  gboolean is_full_copy;
 } dt_lib_copy_history_t;
 
 const char *name(dt_lib_module_t *self)
@@ -208,26 +200,20 @@ static void compress_button_clicked(GtkWidget *widget, gpointer user_data)
 
 static void copy_button_clicked(GtkWidget *widget, dt_lib_module_t *self)
 {
-  dt_lib_copy_history_t *d = self->data;
-
   const dt_imgid_t id = dt_act_on_get_main_image();
 
   if(dt_is_valid_imgid(id) && dt_history_copy(id))
   {
-    d->is_full_copy = TRUE;
     dt_lib_gui_queue_update(self);
   }
 }
 
 static void copy_parts_button_clicked(GtkWidget *widget, dt_lib_module_t *self)
 {
-  dt_lib_copy_history_t *d = self->data;
-
   const dt_imgid_t id = dt_act_on_get_main_image();
 
   if(dt_is_valid_imgid(id) && dt_history_copy_parts(id))
   {
-    d->is_full_copy = FALSE;
     dt_lib_gui_queue_update(self);
   }
 }
@@ -256,23 +242,9 @@ static void discard_button_clicked(GtkWidget *widget, gpointer user_data)
 
 static void paste_button_clicked(GtkWidget *widget, dt_lib_module_t *self)
 {
-  dt_lib_copy_history_t *d = self->data;
-
-  const int current_mode = dt_bauhaus_combobox_get(d->pastemode);
-
-  /* get paste mode and store, overwrite / merge */
-  const int mode = d->is_full_copy
-    ? DT_COPY_HISTORY_OVERWRITE
-    : current_mode;
-
-  dt_conf_set_int("plugins/lighttable/copy_history/pastemode", mode);
-
   /* copy history from previously copied image and paste onto selection */
   GList *imgs = dt_act_on_get_images(TRUE, TRUE, FALSE);
   dt_control_paste_history(imgs);
-
-  // restore mode
-  dt_conf_set_int("plugins/lighttable/copy_history/pastemode", current_mode);
 }
 
 static void paste_parts_button_clicked(GtkWidget *widget, gpointer user_data)
@@ -280,14 +252,6 @@ static void paste_parts_button_clicked(GtkWidget *widget, gpointer user_data)
   /* copy history from previously copied image and paste onto selection */
   GList *imgs = dt_act_on_get_images(TRUE, TRUE, FALSE);
   dt_control_paste_parts_history(imgs);
-}
-
-static void pastemode_combobox_changed(GtkWidget *widget, gpointer user_data)
-{
-  const int mode = dt_bauhaus_combobox_get(widget);
-  dt_conf_set_int("plugins/lighttable/copy_history/pastemode", mode);
-
-  dt_lib_gui_queue_update((dt_lib_module_t *)user_data);
 }
 
 static void _image_selection_changed_callback(gpointer instance, dt_lib_module_t *self)
@@ -365,16 +329,6 @@ void gui_init(dt_lib_module_t *self)
     (self, N_("discard history"), discard_button_clicked, self,
      _("discard history stack of\nall selected images"), 0, 0);
   gtk_grid_attach(grid, d->discard_button, 3, line++, 3, 1);
-
-  DT_BAUHAUS_COMBOBOX_NEW_FULL
-    (d->pastemode, self, NULL, N_("mode"),
-     _("how to handle existing history"),
-     dt_conf_get_int("plugins/lighttable/copy_history/pastemode"),
-     pastemode_combobox_changed, self,
-     N_("append"),     // DT_COPY_HISTORY_APPEND
-     N_("overwrite")); // DT_COPY_HISTORY_OVERWRITE
-  dt_gui_add_help_link(d->pastemode, "history");
-  gtk_grid_attach(grid, d->pastemode, 0, line++, 6, 1);
 
   d->load_button = dt_action_button_new
     (self, N_("load sidecar file..."), load_button_clicked, self,


### PR DESCRIPTION
The default mode is now the append mode.

To use the overwrite mode (rarely used) one need now to do a selective
paste. A button in the dialog can be ticked to use the overwrite
paste mode.
    
As for the style the overwrite vs append mode status is now taken once
and used for the whole paste session. It was possible previously
possible to change the mode while a paste session was active in
background.
    
Closes #19510.
