### PR TITLE
[innosetup] Add .txt extension to text files for easier opening in File Explorer

### DIFF
--- a/packaging/windows/darktable.iss.in
+++ b/packaging/windows/darktable.iss.in
@@ -112,8 +112,8 @@ Name: "quicklaunchicon"; Description: "{cm:CreateQuickLaunchIcon}"; OnlyBelowVer
 Source: "bin\*"; DestDir: "{app}\bin"; Flags: ignoreversion recursesubdirs createallsubdirs
 Source: "lib\*"; DestDir: "{app}\lib"; Flags: ignoreversion recursesubdirs createallsubdirs
 Source: "share\*"; DestDir: "{app}\share"; Flags: ignoreversion recursesubdirs createallsubdirs
-Source: "AUTHORS";  DestDir: "{app}"; Flags: ignoreversion
-Source: "LICENSE";  DestDir: "{app}"; Flags: ignoreversion
+Source: "AUTHORS";  DestDir: "{app}"; DestName: "AUTHORS.txt"; Flags: ignoreversion
+Source: "LICENSE";  DestDir: "{app}"; DestName: "LICENSE.txt"; Flags: ignoreversion
 
 [Registry]
 ; To open a file from the "Open with" menu, Windows needs to know the exact command to execute


### PR DESCRIPTION
File Explorer relies solely on file extensions to determine which program to use to open them. If there is no extension, we will first have to select the app from the list. Moreover, we will have to do this every time, since due to the lack of an extension, Explorer will have nothing to link the association with, so it will not be able to remember it.
