### PR TITLE
Genuine monochrome images get some pixelpipe processing improvements.

### DIFF
--- a/src/common/image.c
+++ b/src/common/image.c
@@ -176,6 +176,12 @@ gboolean dt_image_is_monochrome(const dt_image_t *img)
   return (img->flags & (DT_IMAGE_MONOCHROME | DT_IMAGE_MONOCHROME_BAYER)) ? TRUE : FALSE;
 }
 
+gboolean dt_image_is_mono_sraw(const dt_image_t *img)
+{
+  const uint32_t test = DT_IMAGE_MONOCHROME | DT_IMAGE_S_RAW;
+  return ((img->flags & test) == test);
+}
+
 gboolean dt_image_is_bayerRGB(const dt_image_t *img)
 {
   return dt_image_is_raw(img)
@@ -2216,8 +2222,8 @@ gboolean _move_extra_file(const gchar *oldFilePath, const gchar *newFolder, cons
   g_free(oldFilename);
   g_free(oldExtension);
   g_object_unref(oldFile);
-  g_object_unref(newFile);      
-  return moveSuccess;    
+  g_object_unref(newFile);
+  return moveSuccess;
 }
 
 gboolean dt_image_rename(const dt_imgid_t imgid,
@@ -2410,9 +2416,9 @@ gboolean dt_image_rename(const dt_imgid_t imgid,
         }
         if(oldAudioFilePath != NULL)
         {
-          _move_extra_file(oldAudioFilePath, newFolder, newBasename);       
-        }    
-        g_free(newPath);    
+          _move_extra_file(oldAudioFilePath, newFolder, newBasename);
+        }
+        g_free(newPath);
         g_free(newImgBasename);
         g_free(newBasename);
       }

--- a/src/common/image.h
+++ b/src/common/image.h
@@ -377,11 +377,13 @@ void dt_image_refresh_makermodel(dt_image_t *img);
 gboolean dt_image_is_ldr(const dt_image_t *img);
 /** returns TRUE if the image contains mosaic data. */
 gboolean dt_image_is_raw(const dt_image_t *img);
+/** returns TRUE if image contains data from a monochrome SRAW */
+gboolean dt_image_is_mono_sraw(const dt_image_t *img);
 /** returns TRUE if the image contains float data. */
 gboolean dt_image_is_hdr(const dt_image_t *img);
 /** set the monochrome flags if monochrome is TRUE and clear it otherwise */
 void dt_image_set_monochrome_flag(const dt_imgid_t imgid, const gboolean monochrome);
-/** returns TRUE if this image was taken using a monochrome camera */
+/** returns TRUE if this image was taken using a monochrome camera either by vendor or debayered */
 gboolean dt_image_is_monochrome(const dt_image_t *img);
 /** returns TRUE is image has a raw bayer sensor with RGB data */
 gboolean dt_image_is_bayerRGB(const dt_image_t *img);

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -3548,7 +3548,7 @@ float *dt_dev_distort_detail_mask(dt_dev_pixelpipe_iop_t *piece,
 
   dt_dev_pixelpipe_t *pipe = piece->pipe;
   gboolean valid = FALSE;
-  const gboolean raw_img = dt_image_is_raw(&pipe->image);
+  const gboolean raw_img = dt_image_is_raw(&pipe->image) || dt_image_is_mono_sraw(&pipe->image);
 
   GList *source_iter;
   for(source_iter = pipe->nodes; source_iter; source_iter = g_list_next(source_iter))

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -77,6 +77,8 @@ typedef enum dt_iop_demosaic_method_t
   DT_IOP_DEMOSAIC_MARKEST3_DUAL = DT_DEMOSAIC_DUAL | DT_IOP_DEMOSAIC_MARKESTEIJN_3, // $DESCRIPTION: "Markesteijn 3-pass (dual)"
   DT_IOP_DEMOSAIC_PASSTHR_MONOX = DT_DEMOSAIC_XTRANS | 3, // $DESCRIPTION: "passthrough (monochrome)"
   DT_IOP_DEMOSAIC_PASSTHR_COLORX = DT_DEMOSAIC_XTRANS | 5, // $DESCRIPTION: "photosite color (debug)"
+  // dummy for true monochromes
+  DT_IOP_DEMOSAIC_MONO = 7,                                // $DESCRIPTION: "Monochrome"
 } dt_iop_demosaic_method_t;
 
 static const char *_method_str(const int method)
@@ -109,6 +111,8 @@ static const char *_method_str(const int method)
       return "PASSTHROUGH_MONOCHROME";
     case DT_IOP_DEMOSAIC_PASSTHR_COLORX:
       return "PASSTHROUGH_COLOR";
+    case DT_IOP_DEMOSAIC_MONO:
+      return "DT_IOP_DEMOSAIC_MONO";
     default:
       return "UNKNOWN";
   }
@@ -165,6 +169,7 @@ typedef struct dt_iop_demosaic_gui_data_t
   GtkWidget *demosaic_method_bayer;
   GtkWidget *demosaic_method_xtrans;
   GtkWidget *demosaic_method_bayerfour;
+  GtkWidget *demosaic_method_mono;
   GtkWidget *dual_thrs;
   GtkWidget *lmmse_refine;
   GtkWidget *cs_thrs;
@@ -280,6 +285,7 @@ static gboolean _demosaic_full(const dt_dev_pixelpipe_iop_t *const piece,
                                const dt_iop_roi_t *const roi_out)
 {
   if((img->flags & DT_IMAGE_4BAYER)   // half_size_f doesn't support 4bayer images
+      || dt_image_is_mono_sraw(img)
       || piece->pipe->want_detail_mask)
     return TRUE;
 
@@ -473,7 +479,7 @@ dt_iop_colorspace_type_t input_colorspace(dt_iop_module_t *self,
                                           dt_dev_pixelpipe_t *pipe,
                                           dt_dev_pixelpipe_iop_t *piece)
 {
-  return IOP_CS_RAW;
+  return dt_image_is_mono_sraw(&self->dev->image_storage) ? IOP_CS_RGB : IOP_CS_RAW;
 }
 
 dt_iop_colorspace_type_t output_colorspace(dt_iop_module_t *self,
@@ -592,6 +598,11 @@ static gboolean _tiling_requirements(dt_iop_module_t *self,
       border = 6;
       break;
 
+    case DT_IOP_DEMOSAIC_MONO:
+      perpix = 1;
+      border = 0;
+      break;
+
     default:
       perpix = 4;
       border = 8;
@@ -657,7 +668,8 @@ void process(dt_iop_module_t *self,
   const gboolean fullscale = _demosaic_full(piece, img, roi_out);
   const gboolean is_xtrans = filters == 9u;
   const gboolean is_4bayer = img->flags & DT_IMAGE_4BAYER;
-  const gboolean is_bayer = !is_xtrans && filters != 0;
+  const gboolean is_bayer = !is_4bayer && !is_xtrans && filters != 0;
+  const gboolean true_monochrome = dt_image_is_mono_sraw(img);
 
   const int demosaicing_method = d->demosaicing_method;
   int method = demosaicing_method & ~DT_DEMOSAIC_DUAL;
@@ -711,7 +723,7 @@ void process(dt_iop_module_t *self,
   const gboolean passthru = method == DT_IOP_DEMOSAIC_PASSTHROUGH_MONOCHROME
                          || method == DT_IOP_DEMOSAIC_PASSTHROUGH_COLOR;
   const gboolean do_capture = !passthru &&  !is_4bayer && !show_dual && !run_fast && d->cs_enabled;
-  const gboolean greens = is_bayer && d->green_eq != DT_IOP_GREEN_EQ_NO && no_masking && !run_fast;
+  const gboolean greens = is_bayer && d->green_eq != DT_IOP_GREEN_EQ_NO && no_masking && !run_fast && !true_monochrome;
 
   const float procmax = dt_iop_get_processed_maximum(piece);
   const float procmin = dt_iop_get_processed_minimum(piece);
@@ -809,6 +821,7 @@ void process(dt_iop_module_t *self,
     return;
   }
 
+  const int ch = true_monochrome ? 4 : 1;
   for(int tile = 0; tile < num_tiles; tile++)
   {
     const int top_overlap = tile == 0 ? 0 : overlap;
@@ -824,10 +837,12 @@ void process(dt_iop_module_t *self,
         dt_print(DT_DEBUG_TILING, "tile=%.3d/%.3d, group=%.5d first=%.5d last=%.5d rows=%.4d",
                tile, num_tiles, group, first, last, t_rows);
 
-      float *t_in = in + width * first;
+      float *t_in = in + width * first * ch;
 
       if(demosaic_mask)
         demosaic_box3(t_out, t_in, width, t_rows, filters, xtrans);
+      else if(method == DT_IOP_DEMOSAIC_MONO)
+        dt_iop_image_copy_by_size(t_out, t_in, width, t_rows, 4);
       else if(method == DT_IOP_DEMOSAIC_PASSTHROUGH_MONOCHROME)
         passthrough_monochrome(t_out, t_in, width, t_rows);
       else if(method == DT_IOP_DEMOSAIC_PASSTHROUGH_COLOR)
@@ -902,6 +917,7 @@ int process_cl(dt_iop_module_t *self,
   dt_dev_pixelpipe_t *const pipe = piece->pipe;
   const gboolean run_fast = pipe->type & (DT_DEV_PIXELPIPE_FAST | DT_DEV_PIXELPIPE_PREVIEW);
   const gboolean fullpipe = pipe->type & DT_DEV_PIXELPIPE_FULL;
+  const gboolean true_monochrome = dt_image_is_mono_sraw(img);
 
   uint8_t xtrans[6][6];
   for(int ii = 0; ii < 6; ++ii)
@@ -916,7 +932,7 @@ int process_cl(dt_iop_module_t *self,
   const uint32_t filters = dt_rawspeed_crop_dcraw_filters(pipe->dsc.filters, roi_in->x, roi_in->y);
   const gboolean fullscale = _demosaic_full(piece, img, roi_out);
   const gboolean is_xtrans = filters == 9u;
-  const gboolean is_bayer = !is_xtrans && filters != 0;
+  const gboolean is_bayer = !is_xtrans && filters != 0 && !true_monochrome;
 
   dt_dev_clear_scharr_mask(pipe);
 
@@ -938,7 +954,8 @@ int process_cl(dt_iop_module_t *self,
 
   if((iwidth < 16 || iheight < 16)
     &&  (method != DT_IOP_DEMOSAIC_PASSTHROUGH_MONOCHROME
-      && method != DT_IOP_DEMOSAIC_PASSTHROUGH_COLOR))
+      && method != DT_IOP_DEMOSAIC_PASSTHROUGH_COLOR
+      && method != DT_IOP_DEMOSAIC_MONO))
     method = is_xtrans ? DT_IOP_DEMOSAIC_VNG : DT_IOP_DEMOSAIC_VNG4;
 
   gboolean show_dual = FALSE;
@@ -1006,7 +1023,7 @@ int process_cl(dt_iop_module_t *self,
   const gboolean passthru = method == DT_IOP_DEMOSAIC_PASSTHROUGH_MONOCHROME
                          || method == DT_IOP_DEMOSAIC_PASSTHROUGH_COLOR;
   const gboolean do_capture = !passthru && !run_fast && !show_dual && d->cs_enabled;
-  const gboolean greens = is_bayer && d->green_eq != DT_IOP_GREEN_EQ_NO && no_masking && !run_fast;
+  const gboolean greens = is_bayer && d->green_eq != DT_IOP_GREEN_EQ_NO && no_masking && !run_fast && !true_monochrome;
 
   if(do_capture)
   {
@@ -1115,6 +1132,13 @@ int process_cl(dt_iop_module_t *self,
 
       if(demosaic_mask)
         err = demosaic_box3_cl(self, piece, t_in, t_high, dev_xtrans, iwidth, t_rows, filters);
+      else if(method == DT_IOP_DEMOSAIC_MONO)
+      {
+        size_t insrc[]  = { 0, 0, 0 };
+        size_t tdest[]  = { 0, 0, 0 };
+        size_t iarea[]  = { iwidth, t_rows, 1 };
+        err = dt_opencl_enqueue_copy_image(devid, t_in, t_high, insrc, tdest, iarea);
+      }
       else if(passthru || method == DT_IOP_DEMOSAIC_PPG)
         err = process_default_cl(self, piece, t_in, t_high, dev_xtrans, iwidth, t_rows, method, filters);
       else if(method == DT_IOP_DEMOSAIC_RCD)
@@ -1365,8 +1389,9 @@ void commit_params(dt_iop_module_t *self,
 {
   const dt_iop_demosaic_params_t *const p = (dt_iop_demosaic_params_t *)params;
   dt_iop_demosaic_data_t *d = piece->data;
-
-  if(!dt_image_is_raw(&pipe->image))
+  const dt_image_t *img = &pipe->image;
+  const gboolean true_monochrome = dt_image_is_mono_sraw(img);
+  if(!(dt_image_is_raw(img) || true_monochrome))
     piece->enabled = FALSE;
   d->green_eq = p->green_eq;
   d->color_smoothing = p->color_smoothing;
@@ -1384,7 +1409,7 @@ void commit_params(dt_iop_module_t *self,
   const gboolean xmethod = use_method & DT_DEMOSAIC_XTRANS;
   const gboolean is_dual = use_method & DT_DEMOSAIC_DUAL;
   const gboolean bayer4  = self->dev->image_storage.flags & DT_IMAGE_4BAYER;
-  const gboolean bayer   = self->dev->image_storage.buf_dsc.filters != 9u && !bayer4;
+  const gboolean bayer   = self->dev->image_storage.buf_dsc.filters != 9u && !bayer4 && !true_monochrome;
   const gboolean xtrans  = self->dev->image_storage.buf_dsc.filters == 9u;
   const gboolean passing = use_method == DT_IOP_DEMOSAIC_PASSTHROUGH_MONOCHROME
                         || use_method == DT_IOP_DEMOSAIC_PASSTHROUGH_COLOR;
@@ -1396,6 +1421,8 @@ void commit_params(dt_iop_module_t *self,
     use_method = is_dual ? DT_IOP_DEMOSAIC_MARKEST3_DUAL : DT_IOP_DEMOSAIC_MARKESTEIJN;
   if(bayer4 && !passing)
     use_method = DT_IOP_DEMOSAIC_VNG4;
+  if(true_monochrome)
+    use_method = DT_IOP_DEMOSAIC_MONO;
 
   if(use_method == DT_IOP_DEMOSAIC_PASSTHR_MONOX)
     use_method = DT_IOP_DEMOSAIC_PASSTHROUGH_MONOCHROME;
@@ -1405,7 +1432,7 @@ void commit_params(dt_iop_module_t *self,
   if(use_method != DT_IOP_DEMOSAIC_PPG)
     d->median_thrs = 0.0f;
 
-  if(passing || bayer4)
+  if(passing || bayer4 || true_monochrome)
   {
     d->green_eq = DT_IOP_GREEN_EQ_NO;
     d->color_smoothing = DT_DEMOSAIC_SMOOTH_OFF;
@@ -1470,7 +1497,7 @@ void reload_defaults(dt_iop_module_t *self)
   const dt_image_t *img = &self->dev->image_storage;
 
   if(dt_image_is_monochrome(img))
-    d->demosaicing_method = DT_IOP_DEMOSAIC_PASSTHROUGH_MONOCHROME;
+    d->demosaicing_method = dt_image_is_mono_sraw(img) ? DT_IOP_DEMOSAIC_MONO : DT_IOP_DEMOSAIC_PASSTHROUGH_MONOCHROME;
   else if(img->buf_dsc.filters == 9u)
     d->demosaicing_method = DT_IOP_DEMOSAIC_MARKESTEIJN;
   else if(img->flags & DT_IMAGE_4BAYER)
@@ -1482,7 +1509,7 @@ void reload_defaults(dt_iop_module_t *self)
 
   self->hide_enable_button = TRUE;
 
-  self->default_enabled = dt_image_is_raw(img);
+  self->default_enabled = dt_image_is_raw(img) || dt_image_is_mono_sraw(img);
   if(self->widget)
     gtk_stack_set_visible_child_name(GTK_STACK(self->widget), self->default_enabled ? "raw" : "non_raw");
 
@@ -1499,8 +1526,9 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
   dt_iop_demosaic_params_t *p = self->params;
 
   const dt_image_t *oimg = &self->dev->image_storage;
+  const gboolean true_monochrome = dt_image_is_mono_sraw(oimg);
   const gboolean bayer4 = oimg->flags & DT_IMAGE_4BAYER;
-  const gboolean bayer  = oimg->buf_dsc.filters != 9u && !bayer4;
+  const gboolean bayer  = oimg->buf_dsc.filters != 9u && !bayer4 && !true_monochrome;
   const gboolean xtrans = oimg->buf_dsc.filters == 9u;
 
   dt_iop_demosaic_method_t use_method = p->demosaicing_method;
@@ -1511,6 +1539,8 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
     use_method = is_dual ? DT_IOP_DEMOSAIC_RCD_DUAL : DT_IOP_DEMOSAIC_RCD;
   if(xtrans && !xmethod)
     use_method = is_dual ? DT_IOP_DEMOSAIC_MARKEST3_DUAL : DT_IOP_DEMOSAIC_MARKESTEIJN;
+  if(true_monochrome)
+    use_method = DT_IOP_DEMOSAIC_MONO;
 
   const gboolean bayerpassing =
       use_method == DT_IOP_DEMOSAIC_PASSTHROUGH_MONOCHROME
@@ -1520,7 +1550,7 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
     use_method = DT_IOP_DEMOSAIC_VNG4;
 
   const gboolean isppg = use_method == DT_IOP_DEMOSAIC_PPG;
-  const gboolean isdual = (use_method & DT_DEMOSAIC_DUAL) && !bayer4;
+  const gboolean isdual = (use_method & DT_DEMOSAIC_DUAL) && !bayer4 && !true_monochrome;
   const gboolean islmmse = use_method == DT_IOP_DEMOSAIC_LMMSE;
   const gboolean passing = bayerpassing
     || use_method == DT_IOP_DEMOSAIC_PASSTHR_MONOX
@@ -1532,6 +1562,7 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
   gtk_widget_set_visible(g->demosaic_method_bayer, bayer);
   gtk_widget_set_visible(g->demosaic_method_bayerfour, bayer4);
   gtk_widget_set_visible(g->demosaic_method_xtrans, xtrans);
+  gtk_widget_set_visible(g->demosaic_method_mono, true_monochrome);
 
   gtk_widget_set_visible(g->cs_radius, do_capture);
   gtk_widget_set_visible(g->cs_thrs, do_capture);
@@ -1551,15 +1582,18 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
       dt_bauhaus_combobox_set_from_value(g->demosaic_method_bayer, use_method);
     else if(xtrans)
       dt_bauhaus_combobox_set_from_value(g->demosaic_method_xtrans, use_method);
-    else
+    else if(bayer4)
       dt_bauhaus_combobox_set_from_value(g->demosaic_method_bayerfour, use_method);
+    else
+      dt_bauhaus_combobox_set_from_value(g->demosaic_method_mono, use_method);
 
     /*  If auto-applied from a preset/style from a different sensor type it's demosaicer
         method was added to the current sensor specific demosaicer combobox.
         As we know the bad method here, we can remove it from the combobox by testing for it's position.
     */
     GtkWidget *demosaicers =  bayer  ? g->demosaic_method_bayer :
-                              xtrans ? g->demosaic_method_xtrans : g->demosaic_method_bayerfour;
+                              xtrans ? g->demosaic_method_xtrans :
+                              bayer4 ? g->demosaic_method_bayerfour : g->demosaic_method_mono;
     const int pos = dt_bauhaus_combobox_get_from_value(demosaicers, p->demosaicing_method);
     if(pos >= 0) dt_bauhaus_combobox_remove_at(demosaicers, pos);
   }
@@ -1567,8 +1601,8 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
   p->demosaicing_method = use_method;
 
   gtk_widget_set_visible(g->median_thrs, bayer && isppg);
-  gtk_widget_set_visible(g->greeneq, !passing && !bayer4 && !xtrans);
-  gtk_widget_set_visible(g->color_smoothing, !passing && !bayer4 && !isdual);
+  gtk_widget_set_visible(g->greeneq, !passing && !bayer4 && !xtrans && !true_monochrome);
+  gtk_widget_set_visible(g->color_smoothing, !passing && !bayer4 && !isdual && !true_monochrome);
   gtk_widget_set_visible(g->dual_thrs, isdual);
   gtk_widget_set_visible(g->lmmse_refine, islmmse);
 
@@ -1727,18 +1761,24 @@ void gui_init(dt_iop_module_t *self)
 
   const int xtranspos = dt_bauhaus_combobox_get_from_value(g->demosaic_method_bayer, DT_DEMOSAIC_XTRANS);
 
-  for(int i=0;i<7;i++) dt_bauhaus_combobox_remove_at(g->demosaic_method_bayer, xtranspos);
+  for(int i=0;i<8;i++) dt_bauhaus_combobox_remove_at(g->demosaic_method_bayer, xtranspos);
   gtk_widget_set_tooltip_text(g->demosaic_method_bayer, _("Bayer sensor demosaicing method, PPG and RCD are fast, AMaZE and LMMSE are slow.\nLMMSE is suited best for high ISO images.\ndual demosaicers increase processing time by blending a VNG variant in a second pass."));
 
   g->demosaic_method_xtrans = dt_bauhaus_combobox_from_params(self, "demosaicing_method");
   for(int i=0;i<xtranspos;i++) dt_bauhaus_combobox_remove_at(g->demosaic_method_xtrans, 0);
+  dt_bauhaus_combobox_remove_at(g->demosaic_method_xtrans, 7);
   gtk_widget_set_tooltip_text(g->demosaic_method_xtrans, _("X-Trans sensor demosaicing method, Markesteijn 3-pass and frequency domain chroma are slow.\ndual demosaicers increase processing time by blending a VNG variant in a second pass."));
 
   g->demosaic_method_bayerfour = dt_bauhaus_combobox_from_params(self, "demosaicing_method");
-  for(int i=0;i<7;i++) dt_bauhaus_combobox_remove_at(g->demosaic_method_bayerfour, xtranspos);
+  for(int i=0;i<8;i++) dt_bauhaus_combobox_remove_at(g->demosaic_method_bayerfour, xtranspos);
   for(int i=0;i<2;i++) dt_bauhaus_combobox_remove_at(g->demosaic_method_bayerfour, 0);
   for(int i=0;i<4;i++) dt_bauhaus_combobox_remove_at(g->demosaic_method_bayerfour, 1);
   gtk_widget_set_tooltip_text(g->demosaic_method_bayerfour, _("Bayer4 sensor demosaicing methods."));
+
+  g->demosaic_method_mono = dt_bauhaus_combobox_from_params(self, "demosaicing_method");
+  for(int i=0;i<7;i++) dt_bauhaus_combobox_remove_at(g->demosaic_method_mono, xtranspos);
+  for(int i=0;i<xtranspos;i++) dt_bauhaus_combobox_remove_at(g->demosaic_method_mono, 0);
+  gtk_widget_set_tooltip_text(g->demosaic_method_mono, _("monochrome sensor demosaicing methods."));
 
   g->dual_thrs = dt_bauhaus_slider_from_params(self, "dual_thrs");
   dt_bauhaus_slider_set_digits(g->dual_thrs, 2);

--- a/src/iop/rawprepare.c
+++ b/src/iop/rawprepare.c
@@ -440,7 +440,8 @@ void process(dt_iop_module_t *self,
     }
   }
 
-  if(!dt_image_is_raw(&piece->pipe->image) && piece->pipe->want_detail_mask)
+  const gboolean color_sraw = !(dt_image_is_raw(&piece->pipe->image) ||  dt_image_is_mono_sraw(&piece->pipe->image));
+  if(color_sraw && piece->pipe->want_detail_mask)
     dt_dev_write_scharr_mask(piece, out, roi_out, FALSE);
 
   for(int k = 0; k < 4; k++) piece->pipe->dsc.processed_maximum[k] = 1.0f;
@@ -556,7 +557,8 @@ finish:
       _adjust_xtrans_filters(piece->pipe, csx, csy);
     }
     for(int k = 0; k < 4; k++) piece->pipe->dsc.processed_maximum[k] = 1.0f;
-    if(!dt_image_is_raw(&piece->pipe->image) && piece->pipe->want_detail_mask)
+    const gboolean color_sraw = !(dt_image_is_raw(&piece->pipe->image) ||  dt_image_is_mono_sraw(&piece->pipe->image));
+    if(color_sraw && piece->pipe->want_detail_mask)
       err = dt_dev_write_scharr_mask_cl(piece, dev_out, roi_out, FALSE);
   }
 


### PR DESCRIPTION
1. True monochrome images are understood as raw files and are passed through the demosaicer module even if the is no real demosaicing.
2. By doing so we can capture sharpen those images as other raws with all features supported including the automatic radius calculation.
3. By calculating the scharr mask (used for for blend details threshold) in demosaic it is distorted properly depending on roi.
4. Added a check for true-monochrome images `dt_image_is_mono_sraw()` and make use of it

Release Note: Images from monochrome cameras get improved processing support. Capture sharpen is available via the demosaic module as for raw files. Details mask for monochromes has been fixed.