### PR TITLE
fix darktable-cli don't export synonyms of tags to jpeg and png #19538

### DIFF
--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -808,10 +808,19 @@ int main(int argc, char *arg[])
   for(GList *iter = id_list; iter; iter = g_list_next(iter), num++)
   {
     const int id = GPOINTER_TO_INT(iter->data);
-    // TODO: have a parameter in command line to get the export presets
     dt_export_metadata_t metadata;
-    metadata.flags = dt_lib_export_metadata_default_flags();
-    metadata.list = NULL;
+    // TODO: have a parameter in command line to get the export presets
+    if(custom_presets)
+    {
+      metadata.flags = dt_lib_export_metadata_get_conf_flags();
+      metadata.list = dt_util_str_to_glist("\1", dt_lib_export_metadata_get_conf());
+      metadata.list = g_list_remove(metadata.list, metadata.list->data);
+    }
+    else
+    {
+      metadata.flags = dt_lib_export_metadata_default_flags();
+      metadata.list = NULL;
+    }
     if(storage->store(storage, sdata, id, format, fdata, num, total, high_quality,
                       upscale, FALSE, 1.0, export_masks,
                       icc_type, icc_filename, icc_intent, &metadata) != 0)


### PR DESCRIPTION
Fix "darktable-cli don't export synonyms of tags to jpeg and png" #19538