### PR TITLE
More verbose log related to picker data

### DIFF
--- a/src/develop/pixelpipe_cache.c
+++ b/src/develop/pixelpipe_cache.c
@@ -307,8 +307,9 @@ gboolean dt_dev_pixelpipe_cache_get(dt_dev_pixelpipe_t *pipe,
     const dt_iop_buffer_dsc_t *cdsc = *dsc;
     dt_print_pipe(DT_DEBUG_PIPE, "cache HIT",
           pipe, module, DT_DEVICE_NONE, NULL, NULL,
-          "%s, hash=%" PRIx64,
-          dt_iop_colorspace_to_name(cdsc->cst), hash);
+          "%s %.3f %.3f %.3f, hash=%" PRIx64,
+          dt_iop_colorspace_to_name(cdsc->cst), cdsc->temperature.coeffs[0], cdsc->temperature.coeffs[1], cdsc->temperature.coeffs[2],
+          hash);
     return FALSE;
   }
   // We need a fresh buffer as there was no hit.

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -888,8 +888,10 @@ static void _pixelpipe_picker(dt_iop_module_t *module,
                   picker_source == PIXELPIPE_PICKER_INPUT
                     ? "pixelpipe IN picker"
                     : "pixelpipe OUT picker",
-                  piece->pipe, module, DT_DEVICE_CPU, roi,
-                  NULL, " %s -> %s, %sbox %i/%i -- %i/%i",
+                  piece->pipe, module, DT_DEVICE_CPU, roi, NULL,
+                  "%s (%.3f %.3f %.3f) -> %s (%s), %sbox %i/%i -- %i/%i",
+                  dt_iop_colorspace_to_name(dsc->cst),
+                  dsc->temperature.coeffs[0], dsc->temperature.coeffs[1], dsc->temperature.coeffs[2],
                   dt_iop_colorspace_to_name(image_cst),
                   dt_iop_colorspace_to_name(dt_iop_color_picker_get_active_cst(module)),
                   darktable.lib->proxy.colorpicker.primary_sample->denoise
@@ -980,7 +982,10 @@ static void _pixelpipe_picker_cl(const int devid,
                 picker_source == PIXELPIPE_PICKER_INPUT
                   ? "pixelpipe IN picker CL"
                   : "pixelpipe OUT picker CL",
-                piece->pipe, module, devid, roi, NULL, " %s -> %s, %sbox %i/%i -- %i/%i",
+                piece->pipe, module, devid, roi, NULL,
+                "%s (%.3f %.3f %.3f) -> %s (%s), %sbox %i/%i -- %i/%i",
+                dt_iop_colorspace_to_name(dsc->cst),
+                dsc->temperature.coeffs[0], dsc->temperature.coeffs[1], dsc->temperature.coeffs[2],
                 dt_iop_colorspace_to_name(image_cst),
                 dt_iop_colorspace_to_name(dt_iop_color_picker_get_active_cst(module)),
                 darktable.lib->proxy.colorpicker.primary_sample->denoise
@@ -1070,13 +1075,13 @@ static void _pixelpipe_pick_samples(dt_develop_t *dev,
       // padding, e.g. is equivalent to float[x*4], and that on failure
       // it's OK not to touch output
       int converted_cst;
-      dt_ioppr_transform_image_colorspace(module, sample->display[0], sample->lab[0],
-                                          3, 1, IOP_CS_RGB, IOP_CS_LAB,
-                                          &converted_cst, display_profile);
+      dt_ioppr_transform_image_colorspace(module, sample->display[0], sample->lab[0], 3, 1,
+                                          IOP_CS_RGB, IOP_CS_LAB, &converted_cst,
+                                          display_profile);
       if(display_profile && histogram_profile)
-        dt_ioppr_transform_image_colorspace_rgb
-          (sample->display[0], sample->scope[0], 3, 1,
-           display_profile, histogram_profile, "primary picker");
+        dt_ioppr_transform_image_colorspace_rgb(sample->display[0], sample->scope[0], 3, 1,
+                                                display_profile, histogram_profile,
+                                                "primary picker");
     }
     samples = g_slist_next(samples);
   }
@@ -1284,9 +1289,10 @@ static gboolean _pixelpipe_process_on_CPU(dt_dev_pixelpipe_t *pipe,
   }
 
   // transform to module input colorspace
-  dt_ioppr_transform_image_colorspace
-    (module, input, input, roi_in->width, roi_in->height, cst_from,
-     cst_to, &input_format->cst, work_profile);
+  dt_ioppr_transform_image_colorspace(module, input, input,
+                                      roi_in->width, roi_in->height,
+                                      cst_from, cst_to, &input_format->cst,
+                                      work_profile);
 
   if(dt_pipe_shutdown(pipe))
     return TRUE;
@@ -1470,7 +1476,8 @@ static gboolean _pixelpipe_process_on_CPU(dt_dev_pixelpipe_t *pipe,
   // blend needs input/output images with default colorspace
   if(_transform_for_blend(module, piece))
   {
-    dt_ioppr_transform_image_colorspace(module, input, input, roi_in->width, roi_in->height,
+    dt_ioppr_transform_image_colorspace(module, input, input,
+                                        roi_in->width, roi_in->height,
                                         input_format->cst, blend_cst, &input_format->cst,
                                         work_profile);
     dt_ioppr_transform_image_colorspace(module, *output, *output,
@@ -2029,14 +2036,11 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
                           dt_iop_colorspace_to_name(cst_to),
                           work_profile ? dt_colorspaces_get_name(work_profile->type, work_profile->filename) : "no work profile");
 
-          success_opencl = dt_ioppr_transform_image_colorspace_cl
-            (module, pipe->devid,
-             cl_mem_input, cl_mem_input,
-             roi_in.width, roi_in.height,
-             input_cst_cl,
-             cst_to,
-             &input_cst_cl,
-             work_profile);
+          success_opencl = dt_ioppr_transform_image_colorspace_cl(module, pipe->devid,
+                                                                  cl_mem_input, cl_mem_input,
+                                                                  roi_in.width, roi_in.height,
+                                                                  input_cst_cl, cst_to, &input_cst_cl,
+                                                                  work_profile);
         }
 
         // histogram collection for module
@@ -2238,8 +2242,7 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
           return TRUE;
         }
 
-        dt_iop_colorspace_type_t blend_cst =
-          dt_develop_blend_colorspace(piece, pipe->dsc.cst);
+        const dt_iop_colorspace_type_t blend_cst = dt_develop_blend_colorspace(piece, pipe->dsc.cst);
         const gboolean blend_picking = _request_color_pick(pipe, dev, module)
                                     && _transform_for_blend(module, piece)
                                     && blend_cst != cst_to;
@@ -2276,16 +2279,17 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
            && _transform_for_blend(module, piece))
         {
 
-          success_opencl = dt_ioppr_transform_image_colorspace_cl
-            (module, pipe->devid, cl_mem_input, cl_mem_input,
-             roi_in.width, roi_in.height,
-             input_cst_cl, blend_cst, &input_cst_cl, work_profile);
+          success_opencl = dt_ioppr_transform_image_colorspace_cl(module, pipe->devid,
+                                                                  cl_mem_input, cl_mem_input,
+                                                                  roi_in.width, roi_in.height,
+                                                                  input_cst_cl, blend_cst, &input_cst_cl,
+                                                                  work_profile);
 
-          success_opencl &= dt_ioppr_transform_image_colorspace_cl
-            (module, pipe->devid, *cl_mem_output, *cl_mem_output,
-             roi_out->width, roi_out->height,
-             pipe->dsc.cst, blend_cst, &pipe->dsc.cst, work_profile);
-
+          success_opencl &= dt_ioppr_transform_image_colorspace_cl(module, pipe->devid,
+                                                                   *cl_mem_output, *cl_mem_output,
+                                                                   roi_out->width, roi_out->height,
+                                                                   pipe->dsc.cst, blend_cst, &pipe->dsc.cst,
+                                                                   work_profile);
           if(success_opencl && blend_picking)
           {
             _pixelpipe_picker_cl(pipe->devid, module, piece, &piece->dsc_in,
@@ -2368,10 +2372,10 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
                           pipe, module, pipe->devid, &roi_in, NULL, "%s -> %s",
                           dt_iop_colorspace_to_name(cst_from),
                           dt_iop_colorspace_to_name(cst_to));
-          dt_ioppr_transform_image_colorspace
-            (module, input, input, roi_in.width, roi_in.height,
-             input_format->cst, cst_to,
-             &input_format->cst, work_profile);
+          dt_ioppr_transform_image_colorspace(module, input, input,
+                                              roi_in.width, roi_in.height,
+                                              input_format->cst, cst_to, &input_format->cst,
+                                              work_profile);
         }
 
         if(dt_pipe_shutdown(pipe))
@@ -2481,8 +2485,7 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
         {
           dt_ioppr_transform_image_colorspace(module, input, input,
                                               roi_in.width, roi_in.height,
-                                              input_format->cst, blend_cst,
-                                              &input_format->cst,
+                                              input_format->cst, blend_cst, &input_format->cst,
                                               work_profile);
           dt_ioppr_transform_image_colorspace(module, *output, *output,
                                               roi_out->width, roi_out->height,

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -2030,16 +2030,14 @@ static void _set_trouble_messages(dt_iop_module_t *self)
   const dt_image_t *img = &dev->image_storage;
   dt_print_pipe(DT_DEBUG_PIPE, anyproblem ? "chroma trouble" : "chroma data",
       NULL, self, DT_DEVICE_NONE, NULL, NULL,
-      "%s%s%sD65=%s.  NOW %.3f %.3f %.3f, D65 %.3f %.3f %.3f, AS-SHOT %.3f %.3f %.3f File `%s' ID=%i",
+      "%s%s%sD65=%s.  D65 %.3f %.3f %.3f, AS-SHOT %.3f %.3f %.3f File `%s' ID=%i",
       problem1 ? "white balance applied twice, " : "",
       problem2 ? "double CAT applied, " : "",
       problem3 ? "white balance missing, " : "",
       dt_dev_is_D65_chroma(dev) ? "YES" : "NO",
-      chr->wb_coeffs[0], chr->wb_coeffs[1], chr->wb_coeffs[2],
       chr->D65coeffs[0], chr->D65coeffs[1], chr->D65coeffs[2],
       chr->as_shot[0], chr->as_shot[1], chr->as_shot[2],
-      img->filename,
-      img->id);
+      img->filename, img->id);
 
   if(problem2)
   {


### PR DESCRIPTION
No functional changes, some formatting for editor syntax / readability.

Trying to track issue #18693

@gi-man @wpferguson @bastibe back on nvidia OpenCL, i still couldn't reproduce this a single time so just source reading based on the hypothesis we have bad data/cst/coeffs fed from cache to pipe if there was a hit. This PR provides some more debug info, maybe you can trigger again ... might still be something completely different.

Fresh `-d pipe` logs from master including this pr would be welcome.

Also more information what exactly you do to trigger might help. maybe a video while logging ?

Any observed issue with opencl==off?