### PR TITLE
Add support for extracting, storing, and filtering on Fujifilm Film Modes

### DIFF
--- a/src/common/collection.h
+++ b/src/common/collection.h
@@ -121,6 +121,7 @@ typedef enum dt_collection_properties_t
 
   // all new collection types need to be added before DT_COLLECTION_PROP_LAST,
   // which separates actual collection types from special flag values
+  DT_COLLECTION_PROP_FILM_MODE,
   DT_COLLECTION_PROP_LAST,
 
   DT_COLLECTION_PROP_UNDEF,

--- a/src/common/database.c
+++ b/src/common/database.c
@@ -51,7 +51,7 @@
 #define LAST_FULL_DATABASE_VERSION_DATA    10
 
 // You HAVE TO bump THESE versions whenever you add an update branches to _upgrade_*_schema_step()!
-#define CURRENT_DATABASE_VERSION_LIBRARY 57
+#define CURRENT_DATABASE_VERSION_LIBRARY 58
 #define CURRENT_DATABASE_VERSION_DATA    13
 
 #define USE_NESTED_TRANSACTIONS
@@ -2966,6 +2966,21 @@ static int _upgrade_library_schema_step(dt_database_t *db,
     TRY_EXEC("ALTER TABLE main.images ADD COLUMN flash_tagvalue INTEGER DEFAULT -1",
              "[init] can't add `flash_tagvalue' column to images table in database\n");
     new_version = 57;
+  }
+  else if(version == 57)
+  {
+
+    TRY_EXEC("CREATE TABLE film_mode"
+             " (id INTEGER PRIMARY KEY AUTOINCREMENT,"
+             "  name VARCHAR)",
+             "can't create table film_mode");
+    TRY_EXEC("CREATE UNIQUE INDEX film_mode_name ON film_mode (name)",
+             "can't create index `film_mode_name' on table `film_mode'");
+
+    TRY_EXEC("ALTER TABLE main.images ADD COLUMN film_mode_id INTEGER REFERENCES film_mode (id) ON DELETE "
+             "RESTRICT ON UPDATE CASCADE",
+             "[init] can't add `film_mode' column to images table in database\n");
+    new_version = 58;
   }
   else
     new_version = version; // should be the fallback so that calling code sees that we are in an infinite loop

--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -2335,6 +2335,21 @@ static bool _exif_decode_exif_data(dt_image_t *img, Exiv2::ExifData &exifData)
       }
     };
 
+    if(FIND_EXIF_TAG("Exif.Fujifilm.FilmMode"))
+    {
+      const int value = pos->toLong();
+      _exif_value_str(value, img->exif_film_mode, sizeof(img->exif_film_mode), pos, exifData);
+    }
+    else if(FIND_EXIF_TAG("Exif.Fujifilm.Color"))
+    {
+      // Exif.Fujifilm.Color contains the monochrome mode (sepia, normal b&w,
+      // color filters, acros) if FilmMode is not set.
+      // In the camera UI, those are all in the same menu, so it makes sense to
+      // merge them into the same tag in darktable.
+      const int value = pos->toLong();
+      _exif_value_str(value, img->exif_film_mode, sizeof(img->exif_film_mode), pos, exifData);
+    }
+
     img->exif_inited = TRUE;
     return true;
   }

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -1318,7 +1318,7 @@ static dt_imgid_t _image_duplicate_with_version_ext(const dt_imgid_t imgid,
      "   orientation, longitude, latitude, altitude, color_matrix,"
      "   colorspace, version, max_version,"
      "   history_end, position, aspect_ratio, exposure_bias, import_timestamp,"
-     "   whitebalance_id, flash_id, exposure_program_id, metering_mode_id, flash_tagvalue)"
+     "   whitebalance_id, flash_id, exposure_program_id, metering_mode_id, flash_tagvalue, film_mode_id)"
      " SELECT NULL, group_id, film_id, width, height, filename,"
      "        maker_id, model_id, camera_id, lens_id,"
      "        exposure, aperture, iso, focal_length, focus_distance, datetime_taken,"
@@ -1326,7 +1326,7 @@ static dt_imgid_t _image_duplicate_with_version_ext(const dt_imgid_t imgid,
      "        raw_black, raw_maximum, orientation,"
      "        longitude, latitude, altitude, color_matrix, colorspace, NULL, NULL, 0, ?1,"
      "        aspect_ratio, exposure_bias, import_timestamp,"
-     "        whitebalance_id, flash_id, exposure_program_id, metering_mode_id, flash_tagvalue"
+     "        whitebalance_id, flash_id, exposure_program_id, metering_mode_id, flash_tagvalue, film_mode_id"
      " FROM main.images WHERE id = ?2",
      -1, &stmt, NULL);
   // clang-format on
@@ -2141,6 +2141,7 @@ void dt_image_init(dt_image_t *img)
   memset(img->exif_flash, 0, sizeof(img->exif_flash));
   memset(img->exif_exposure_program, 0, sizeof(img->exif_exposure_program));
   memset(img->exif_metering_mode, 0, sizeof(img->exif_metering_mode));
+  memset(img->exif_film_mode, 0, sizeof(img->exif_metering_mode));
   memset(&img->exif_datetime_taken, 0, sizeof(img->exif_datetime_taken));
   memset(img->camera_maker, 0, sizeof(img->camera_maker));
   memset(img->camera_model, 0, sizeof(img->camera_model));
@@ -2548,7 +2549,7 @@ dt_imgid_t dt_image_copy_rename(const dt_imgid_t imgid,
          "   raw_black, raw_maximum, orientation,"
          "   longitude, latitude, altitude, color_matrix, colorspace, version, max_version,"
          "   position, aspect_ratio, exposure_bias,"
-         "   whitebalance_id, flash_id, exposure_program_id, metering_mode_id, flash_tagvalue)"
+         "   whitebalance_id, flash_id, exposure_program_id, metering_mode_id, flash_tagvalue, film_mode_id)"
          " SELECT NULL, group_id, ?1 as film_id, width, height, ?2 as filename,"
          "        maker_id, model_id, lens_id,"
          "        exposure, aperture, iso, focal_length, focus_distance, datetime_taken,"
@@ -2556,7 +2557,7 @@ dt_imgid_t dt_image_copy_rename(const dt_imgid_t imgid,
          "        orientation, longitude, latitude, altitude,"
          "        color_matrix, colorspace, -1, -1,"
          "        ?3, aspect_ratio, exposure_bias,"
-         "        whitebalance_id, flash_id, exposure_program_id, metering_mode_id, flash_tagvalue"
+         "        whitebalance_id, flash_id, exposure_program_id, metering_mode_id, flash_tagvalue, film_mode_id"
          " FROM main.images"
          " WHERE id = ?4",
         -1, &stmt, NULL);
@@ -3347,6 +3348,11 @@ int32_t dt_image_get_exposure_program_id(const char *name)
 int32_t dt_image_get_metering_mode_id(const char *name)
 {
   return _image_get_set_name_id("metering_mode", name);
+}
+
+int32_t dt_image_get_film_mode_id(const char *name)
+{
+  return _image_get_set_name_id("film_mode", name);
 }
 
 int32_t dt_image_get_camera_id(const char *maker, const char *model)

--- a/src/common/image.h
+++ b/src/common/image.h
@@ -271,6 +271,7 @@ typedef struct dt_image_t
   char exif_flash[64];
   char exif_exposure_program[64];
   char exif_metering_mode[64];
+  char exif_film_mode[64];
   GTimeSpan exif_datetime_taken;
 
   dt_image_correction_type_t exif_correction_type;
@@ -636,6 +637,7 @@ int32_t dt_image_get_whitebalance_id(const char *name);
 int32_t dt_image_get_flash_id(const char *name);
 int32_t dt_image_get_exposure_program_id(const char *name);
 int32_t dt_image_get_metering_mode_id(const char *name);
+int32_t dt_image_get_film_mode_id(const char *name);
 int32_t dt_image_get_camera_id(const char *maker, const char *model);
 
 G_END_DECLS

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -2104,6 +2104,19 @@ static void _list_view(dt_lib_collect_rule_t *dr)
         // clang-format on
         break;
 
+      case DT_COLLECTION_PROP_FILM_MODE: // lens
+        // clang-format off
+        g_snprintf(query, sizeof(query),
+                   "SELECT fm.name AS film_mode, 1, COUNT(*) AS count"
+                   "  FROM main.images AS mi, main.film_mode AS fm"
+                   "  WHERE mi.film_mode_id = fm.id"
+                   "    AND %s"
+                   "  GROUP BY LOWER(film_mode)"
+                   "  ORDER BY LOWER(film_mode) %s", where_ext,
+                   sort_descending ? "DESC" : "ASC");
+        // clang-format on
+        break;
+
       case DT_COLLECTION_PROP_FILENAME: // filename
         // clang-format off
         g_snprintf(query, sizeof(query),
@@ -2375,17 +2388,12 @@ static void _list_view(dt_lib_collect_rule_t *dr)
 
   // if needed, we restrict the tree to matching entries
   if(dr->typing
-     && (property == DT_COLLECTION_PROP_CAMERA
-         || property == DT_COLLECTION_PROP_FILENAME
-         || property == DT_COLLECTION_PROP_FILMROLL
-         || property == DT_COLLECTION_PROP_LENS
-         || property == DT_COLLECTION_PROP_APERTURE
-         || property == DT_COLLECTION_PROP_FOCAL_LENGTH
-         || property == DT_COLLECTION_PROP_ISO
-         || property == DT_COLLECTION_PROP_MODULE
-         || property == DT_COLLECTION_PROP_ORDER
-         || property == DT_COLLECTION_PROP_RATING
-         || property >= DT_COLLECTION_PROP_METADATA_OFFSET))
+     && (property == DT_COLLECTION_PROP_CAMERA || property == DT_COLLECTION_PROP_FILENAME
+         || property == DT_COLLECTION_PROP_FILMROLL || property == DT_COLLECTION_PROP_LENS
+         || property == DT_COLLECTION_PROP_APERTURE || property == DT_COLLECTION_PROP_FOCAL_LENGTH
+         || property == DT_COLLECTION_PROP_ISO || property == DT_COLLECTION_PROP_MODULE
+         || property == DT_COLLECTION_PROP_ORDER || property == DT_COLLECTION_PROP_RATING
+         || property >= DT_COLLECTION_PROP_METADATA_OFFSET || property == DT_COLLECTION_PROP_FILM_MODE))
   {
     gchar *needle = g_utf8_strdown(gtk_entry_get_text(GTK_ENTRY(dr->text)), -1);
     if(g_str_has_suffix(needle, "%"))
@@ -3360,6 +3368,7 @@ static void _populate_collect_combo(GtkWidget *w)
     ADD_COLLECT_ENTRY(DT_COLLECTION_PROP_FLASH);
     ADD_COLLECT_ENTRY(DT_COLLECTION_PROP_EXPOSURE_PROGRAM);
     ADD_COLLECT_ENTRY(DT_COLLECTION_PROP_METERING_MODE);
+    ADD_COLLECT_ENTRY(DT_COLLECTION_PROP_FILM_MODE);
 
     dt_bauhaus_combobox_add_section(w, _("darktable"));
     ADD_COLLECT_ENTRY(DT_COLLECTION_PROP_GROUP_ID);
@@ -4004,6 +4013,7 @@ void init(struct dt_lib_module_t *self)
   luaA_enum_value(L, dt_collection_properties_t, DT_COLLECTION_PROP_ASPECT_RATIO);
   luaA_enum_value(L, dt_collection_properties_t, DT_COLLECTION_PROP_EXPOSURE);
   luaA_enum_value(L, dt_collection_properties_t, DT_COLLECTION_PROP_EXPOSURE_BIAS);
+  luaA_enum_value(L, dt_collection_properties_t, DT_COLLECTION_PROP_FILM_MODE);
   luaA_enum_value(L, dt_collection_properties_t, DT_COLLECTION_PROP_FILENAME);
   luaA_enum_value(L, dt_collection_properties_t, DT_COLLECTION_PROP_GEOTAGGING);
   luaA_enum_value(L, dt_collection_properties_t, DT_COLLECTION_PROP_LOCAL_COPY);

--- a/src/libs/filtering.c
+++ b/src/libs/filtering.c
@@ -248,7 +248,8 @@ static _filter_t filters[]
         { DT_COLLECTION_PROP_WHITEBALANCE, _misc_widget_init, _misc_update },
         { DT_COLLECTION_PROP_FLASH, _misc_widget_init, _misc_update },
         { DT_COLLECTION_PROP_EXPOSURE_PROGRAM, _misc_widget_init, _misc_update },
-        { DT_COLLECTION_PROP_METERING_MODE, _misc_widget_init, _misc_update } };
+        { DT_COLLECTION_PROP_METERING_MODE, _misc_widget_init, _misc_update },
+        { DT_COLLECTION_PROP_FILM_MODE, _misc_widget_init, _misc_update } };
 
 static _filter_t *_filters_get(const dt_collection_properties_t prop)
 {

--- a/src/libs/filters/misc.c
+++ b/src/libs/filters/misc.c
@@ -113,6 +113,11 @@ void _misc_tree_update(_widgets_misc_t *misc)
     table = g_strdup("metering_mode");
     tooltip = g_strdup(_("no metering mode defined"));
   }
+  else if(misc->prop == DT_COLLECTION_PROP_FILM_MODE)
+  {
+    table = g_strdup("film_mode");
+    tooltip = g_strdup(_("no film mode defined"));
+  }
 
   // SQL
   if(misc->prop == DT_COLLECTION_PROP_CAMERA)

--- a/src/libs/metadata_view.c
+++ b/src/libs/metadata_view.c
@@ -106,6 +106,7 @@ enum
   md_exif_datetime,
   md_exif_width,
   md_exif_height,
+  md_exif_film_mode,
 
   /* size of final image */
   md_width,
@@ -121,7 +122,7 @@ enum
   md_categories,
 
   /* xmp */
-  md_xmp_metadata   // keep this at last position!
+  md_xmp_metadata // keep this at last position!
 };
 
 // We have to maintain the correspondence between the displayed metadata list
@@ -162,6 +163,7 @@ static const char *_labels[] = {
   N_("datetime"),
   N_("width"),
   N_("height"),
+  N_("film mode"),
   N_("export width"),
   N_("export height"),
 
@@ -594,6 +596,7 @@ void gui_update(dt_lib_module_t *self)
                                          "COUNT(DISTINCT datetime_taken), "
                                          "COUNT(DISTINCT width), "
                                          "COUNT(DISTINCT height), "
+                                         "COUNT(DISTINCT IFNULL(film_mode_id, '')), "
                                          "COUNT(DISTINCT IFNULL(output_width, '')), " //exported width
                                          "COUNT(DISTINCT IFNULL(output_height, '')), " //exported height
                                          "COUNT(DISTINCT IFNULL(latitude, '')), "
@@ -899,6 +902,11 @@ void gui_update(dt_lib_module_t *self)
           (void)g_snprintf(text, sizeof(text), "%d", img->height);
           _metadata_update_value(md_exif_height, text, self);
         }
+        break;
+
+      case md_exif_film_mode:
+        (void)g_snprintf(text, sizeof(text), "%s", img->exif_film_mode);
+        _metadata_update_value(md_exif_film_mode, text, self);
         break;
 
       case md_width:

--- a/src/lua/image.c
+++ b/src/lua/image.c
@@ -540,6 +540,7 @@ int dt_lua_init_image(lua_State *L)
   luaA_struct_member(L, dt_image_t, exif_flash, char_64);
   luaA_struct_member(L, dt_image_t, exif_exposure_program, char_64);
   luaA_struct_member(L, dt_image_t, exif_metering_mode, char_64);
+  luaA_struct_member(L, dt_image_t, exif_film_mode, char_64);
   luaA_struct_member(L, dt_image_t, filename, const char_filename_length);
   luaA_struct_member(L, dt_image_t, width, const int32_t);
   luaA_struct_member(L, dt_image_t, height, const int32_t);


### PR DESCRIPTION
Fujifilm cameras of the X and GF series have support for so-called
Film Simulation Modes. These are said to mimic the look of certain types
of analogue film.

I have wished for the ability to filter on film sim mode for quite a
while. In addition, I would like to, in the future, add specific
dtstyles for the various modes and allow to apply them by default via
apply_camera_style.

This commits provides the foundation for that. It adds the ability to
filter by and view the film mode in the UI. It also exports the film
mode to Lua, so that apply_camera_style could in the future use that.
