### PR TITLE
Fix dt_dev_is_D65_chroma() checks

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -3527,21 +3527,9 @@ void dt_dev_image(const dt_imgid_t imgid,
 
 gboolean dt_dev_equal_chroma(const float *f, const double *d)
 {
-  return feqf(f[0], (float)d[0], 0.00001)
-      && feqf(f[1], (float)d[1], 0.00001)
-      && feqf(f[2], (float)d[2], 0.00001);
-}
-
-gboolean dt_dev_is_D65_chroma(const dt_develop_t *dev)
-{
-  const dt_dev_chroma_t *chr = &dev->chroma;
-  const float wb_coeffs[4] = { chr->wb_coeffs[0],
-                               chr->wb_coeffs[1],
-                               chr->wb_coeffs[2],
-                               chr->wb_coeffs[3] };
-  return chr->late_correction
-    ? dt_dev_equal_chroma(wb_coeffs, chr->as_shot)
-    : dt_dev_equal_chroma(wb_coeffs, chr->D65coeffs);
+  return feqf(f[0], (float)d[0], 0.00001f)
+      && feqf(f[1], (float)d[1], 0.00001f)
+      && feqf(f[2], (float)d[2], 0.00001f);
 }
 
 void dt_dev_clear_chroma_troubles(dt_develop_t *dev)
@@ -3565,7 +3553,7 @@ void dt_dev_reset_chroma(dt_develop_t *dev)
   chr->adaptation = NULL;
   chr->temperature = NULL;
   for_four_channels(c)
-    chr->wb_coeffs[c] = 1.0;
+    chr->wb_coeffs[c] = 1.0f;
 }
 
 void dt_dev_init_chroma(dt_develop_t *dev)

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -148,7 +148,7 @@ typedef struct dt_dev_chroma_t
   struct dt_iop_module_t *temperature;  // always available for GUI reports
   struct dt_iop_module_t *adaptation;   // set if one module is processing this without blending
 
-  double wb_coeffs[4];                  // data actually used by the pipe
+  dt_aligned_pixel_t wb_coeffs;         // coeffs actually set by temperature
   double D65coeffs[4];                  // both read from exif data or "best guess"
   double as_shot[4];
   gboolean late_correction;
@@ -619,7 +619,6 @@ void dt_dev_image(const dt_imgid_t imgid,
 
 
 gboolean dt_dev_equal_chroma(const float *f, const double *d);
-gboolean dt_dev_is_D65_chroma(const dt_develop_t *dev);
 void dt_dev_reset_chroma(dt_develop_t *dev);
 void dt_dev_init_chroma(dt_develop_t *dev);
 void dt_dev_clear_chroma_troubles(dt_develop_t *dev);

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -590,6 +590,14 @@ void init_presets(dt_iop_module_so_t *self)
                              self->version(), &p, sizeof(p), TRUE, DEVELOP_BLEND_CS_RGB_SCENE);
 }
 
+static gboolean _dev_is_D65_chroma(const dt_develop_t *dev)
+{
+  const dt_dev_chroma_t *chr = &dev->chroma;
+  return chr->late_correction
+    ? dt_dev_equal_chroma(chr->wb_coeffs, chr->as_shot)
+    : dt_dev_equal_chroma(chr->wb_coeffs, chr->D65coeffs);
+}
+
 static gboolean _area_mapping_active(const dt_iop_channelmixer_rgb_gui_data_t *g)
 {
   return g  && g->spot_mode
@@ -616,21 +624,21 @@ static gboolean _get_white_balance_coeff(const dt_iop_module_t *self,
     return TRUE;
 
   // If we use D65 there are unchanged corrections
-  if(dt_dev_is_D65_chroma(self->dev))
+  if(_dev_is_D65_chroma(self->dev))
     return FALSE;
 
   const gboolean valid_chroma =
     chr->D65coeffs[0] > 0.0 && chr->D65coeffs[1] > 0.0 && chr->D65coeffs[2] > 0.0;
 
   const gboolean changed_chroma =
-    chr->wb_coeffs[0] > 1.0 || chr->wb_coeffs[1] > 1.0 || chr->wb_coeffs[2] > 1.0;
+    chr->wb_coeffs[0] > 1.0f || chr->wb_coeffs[1] > 1.0f || chr->wb_coeffs[2] > 1.0f;
 
   // Otherwise - for example because the user made a correct preset, find the
   // WB adaptation ratio
   if(valid_chroma && changed_chroma)
   {
     for_four_channels(k)
-      custom_wb[k] = chr->D65coeffs[k] / chr->wb_coeffs[k];
+      custom_wb[k] = (float)chr->D65coeffs[k] / chr->wb_coeffs[k];
   }
   return FALSE;
 }
@@ -2008,7 +2016,7 @@ static void _set_trouble_messages(dt_iop_module_t *self)
   const gboolean problem1 = valid
                             && chr->adaptation == self
                             && temperature_enabled
-                            && !dt_dev_is_D65_chroma(dev);
+                            && !_dev_is_D65_chroma(dev);
 
   // our second biggest problem : another channelmixerrgb instance is doing CAT
   // earlier in the pipe and we don't use masking here.
@@ -2034,7 +2042,7 @@ static void _set_trouble_messages(dt_iop_module_t *self)
       problem1 ? "white balance applied twice, " : "",
       problem2 ? "double CAT applied, " : "",
       problem3 ? "white balance missing, " : "",
-      dt_dev_is_D65_chroma(dev) ? "YES" : "NO",
+      _dev_is_D65_chroma(dev) ? "YES" : "NO",
       chr->D65coeffs[0], chr->D65coeffs[1], chr->D65coeffs[2],
       chr->as_shot[0], chr->as_shot[1], chr->as_shot[2],
       img->filename, img->id);

--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -652,7 +652,7 @@ int process_cl(dt_iop_module_t *self,
   }
 
   const dt_dev_chroma_t *chr = &self->dev->chroma;
-  const gboolean corrected = dt_dev_is_D65_chroma(self->dev) && chr->late_correction;
+  const gboolean corrected = chr->late_correction;
   dt_aligned_pixel_t coeffs = { corrected ? chr->D65coeffs[0] / chr->as_shot[0] : 1.0f,
                                 corrected ? chr->D65coeffs[1] / chr->as_shot[1] : 1.0f,
                                 corrected ? chr->D65coeffs[2] / chr->as_shot[2] : 1.0f,
@@ -1198,9 +1198,7 @@ void process(dt_iop_module_t *self,
 
   const dt_dev_chroma_t *chr = &self->dev->chroma;
   const dt_iop_colorin_data_t *const d = piece->data;
-  const gboolean corrected = dt_dev_is_D65_chroma(self->dev)
-    && chr->late_correction
-    && d->type != DT_COLORSPACE_LAB;
+  const gboolean corrected = chr->late_correction && d->type != DT_COLORSPACE_LAB;
   const dt_aligned_pixel_t coeffs = { corrected ? chr->D65coeffs[0] / chr->as_shot[0] : 1.0f,
                                       corrected ? chr->D65coeffs[1] / chr->as_shot[1] : 1.0f,
                                       corrected ? chr->D65coeffs[2] / chr->as_shot[2] : 1.0f,

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -560,7 +560,7 @@ int process_cl(dt_iop_module_t *self,
 
   gboolean announce = dt_iop_piece_is_raster_mask_used(piece, BLEND_RASTER_ID);
 
-  cl_int err = DT_OPENCL_DEFAULT_ERROR;
+  cl_int err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
   cl_mem dev_xtrans = NULL;
   cl_mem dev_clips = NULL;
 
@@ -663,7 +663,7 @@ int process_cl(dt_iop_module_t *self,
   {
     const dt_dev_chroma_t *chr = &self->dev->chroma;
     dt_aligned_pixel_t clips = { clip, clip, clip, clip};
-    if(dt_dev_is_D65_chroma(self->dev) && chr->late_correction)
+    if(chr->late_correction)
     for_each_channel(c)
       clips[c] *= chr->as_shot[c] / chr->D65coeffs[c];
     dev_clips = dt_opencl_copy_host_to_device_constant(devid, 4 * sizeof(float), clips);
@@ -744,7 +744,7 @@ static void process_clip(dt_iop_module_t *self,
 
     const dt_dev_chroma_t *chr = &self->dev->chroma;
     dt_aligned_pixel_t clips = { clip, clip, clip, clip};
-    if(dt_dev_is_D65_chroma(self->dev) && chr->late_correction)
+    if(chr->late_correction)
     {
       for_each_channel(c) clips[c] *= chr->as_shot[c] / chr->D65coeffs[c];
     }

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -702,14 +702,14 @@ void commit_params(dt_iop_module_t *self,
   if(self->hide_enable_button)
   {
     for_four_channels(k)
-      chr->wb_coeffs[k] = 1.0;
+      chr->wb_coeffs[k] = 1.0f;
     return;
   }
 
   for_four_channels(k)
   {
     d->coeffs[k] = tcoeffs[k];
-    chr->wb_coeffs[k] = piece->enabled ? d->coeffs[k] : 1.0;
+    chr->wb_coeffs[k] = piece->enabled ? d->coeffs[k] : 1.0f;
   }
 
   // 4Bayer images not implemented in OpenCL yet


### PR DESCRIPTION
1. This is only necessary in color calibration module for checks
2. In colorin and highlights we only have to test for late_correction
3. As dt_dev_is_D65_chroma() is now local in channelmixerrgb it has been moved there from develop.c

@gi-man would you be able to test this, hopefully fixing #18693 ?

If not, i would appreciate a fresh log `-d pipe -d picker` would be perfect