### PR TITLE
fix When darktable-cli exports a duplicate to jpeg and png, the tags attached to the original image are used. #19539

### DIFF
--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -634,7 +634,7 @@ int main(int argc, char *arg[])
     {
       int id = GPOINTER_TO_INT(iter->data);
       dt_image_t *image = dt_image_cache_get(id, 'w');
-      if(dt_exif_xmp_read(image, xmp_filename, 0))
+      if(dt_exif_xmp_read(image, xmp_filename, FALSE))
       {
         fprintf(stderr, _("error: can't open XMP file %s"), xmp_filename);
         fprintf(stderr, "\n");

--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -3997,7 +3997,7 @@ static gboolean _image_altered_deprecated(const dt_imgid_t imgid)
 // Need a write lock on *img (non-const) to write stars (and soon color labels).
 gboolean dt_exif_xmp_read(dt_image_t *img,
                           const char *filename,
-                          const int history_only)
+                          const gboolean history_only)
 {
   if(!img)
   {

--- a/src/common/exif.h
+++ b/src/common/exif.h
@@ -110,7 +110,7 @@ gboolean dt_exif_xmp_attach_export(const dt_imgid_t imgid, const char *filename,
 char *dt_exif_xmp_read_string(const dt_imgid_t imgid);
 
 /** read xmp sidecar file. Returns TRUE in case of any error*/
-gboolean dt_exif_xmp_read(dt_image_t *img, const char *filename, const int history_only);
+gboolean dt_exif_xmp_read(dt_image_t *img, const char *filename, const gboolean history_only);
 
 /** apply default import metadata */
 void dt_exif_apply_default_metadata(dt_image_t *img);

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -1724,7 +1724,7 @@ static int _image_read_duplicates(const uint32_t id,
     dt_image_t *img = dt_image_cache_get(newid, 'w');
     if(img)
     {
-      dt_exif_xmp_read(img, xmpfilename, 0);
+      dt_exif_xmp_read(img, xmpfilename, FALSE);
       img->version = version;
     }
     dt_image_cache_write_release(img, DT_IMAGE_CACHE_RELAXED);
@@ -1980,7 +1980,7 @@ static dt_imgid_t _image_import_internal(const dt_filmid_t film_id,
     // dt_image_path_append_version(id, dtfilename, sizeof(dtfilename));
     g_strlcat(dtfilename, ".xmp", sizeof(dtfilename));
 
-    res = dt_exif_xmp_read(img, dtfilename, 0);
+    res = dt_exif_xmp_read(img, dtfilename, FALSE);
   }
   // write through to db, but not to xmp.
   dt_image_cache_write_release(img, DT_IMAGE_CACHE_RELAXED);


### PR DESCRIPTION
fix When darktable-cli exports a duplicate to jpeg and png, the tags attached to the original image are used. #19539