### PR TITLE
Fix Wayland session.

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1536,13 +1536,6 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
   // however after gtk_disable_setlocale
   if(init_gui)
   {
-#ifdef GDK_WINDOWING_WAYLAND
-    // There are currently bad interactions with Wayland (drop-downs
-    // are very narrow, scroll events lost). Until this is fixed, give
-    // priority to the XWayland backend for Wayland users.
-    // See also https://github.com/darktable-org/darktable/issues/13180
-    gdk_set_allowed_backends("x11,*");
-#endif
     gtk_init(&argc, &argv);
 
     darktable.themes = NULL;


### PR DESCRIPTION
Now that GNOME 49 is out and that most distributions are removing support for X11 use the standard Wayland session. The XWayland seems to make Darktable non working (no events, freeze...).

Closes #19511 
Closes #19441
