### PR TITLE
Usability of aspects ratio in database and image structs

### DIFF
--- a/src/common/image.h
+++ b/src/common/image.h
@@ -492,8 +492,8 @@ gboolean dt_image_altered(const dt_imgid_t imgid);
 gboolean dt_image_basic(const dt_imgid_t imgid);
 /** set the image final/cropped aspect ratio */
 float dt_image_set_aspect_ratio(const dt_imgid_t imgid, const gboolean raise);
-/** set the image raw aspect ratio */
-void dt_image_set_raw_aspect_ratio(const dt_imgid_t imgid);
+/** calculate a more meaningful aspect ratio from a given aspect */
+float dt_usable_aspect(const float aspect);
 /** set the image final/cropped aspect ratio */
 void dt_image_set_aspect_ratio_to(const dt_imgid_t imgid,
                                   const float aspect_ratio,

--- a/src/common/image_cache.c
+++ b/src/common/image_cache.c
@@ -329,6 +329,8 @@ void dt_image_cache_write_release_info(dt_image_t *img,
       img->aspect_ratio = (float )img->height / (float )(MAX(1, img->width));
   }
 
+  img->aspect_ratio = dt_usable_aspect(img->aspect_ratio);
+
   sqlite3_stmt *stmt;
   // clang-format off
   DT_DEBUG_SQLITE3_PREPARE_V2
@@ -341,7 +343,7 @@ void dt_image_cache_write_release_info(dt_image_t *img,
      "     crop = ?15, orientation = ?16, raw_parameters = ?17, group_id = ?18,"
      "     longitude = ?19, latitude = ?20, altitude = ?21, color_matrix = ?22,"
      "     colorspace = ?23, raw_black = ?24, raw_maximum = ?25,"
-     "     aspect_ratio = ROUND(?26,1), exposure_bias = ?27,"
+     "     aspect_ratio = ?26, exposure_bias = ?27,"
      "     import_timestamp = ?28, change_timestamp = ?29, export_timestamp = ?30,"
      "     print_timestamp = ?31, output_width = ?32, output_height = ?33,"
      "     whitebalance_id = ?36, flash_id = ?37,"
@@ -424,17 +426,17 @@ void dt_image_cache_write_release_info(dt_image_t *img,
   sqlite3_finalize(stmt);
 
   if(mode == DT_IMAGE_CACHE_SAFE)
-  {
     dt_image_synch_xmp(img->id);
-    if(info)
-    {
-      const double spent = dt_get_debug_wtime() - start;
-      dt_print(DT_DEBUG_CACHE,
+
+  dt_cache_release(&cache->cache, img->cache_entry);
+
+  if(info)
+  {
+    const double spent = dt_get_debug_wtime() - start;
+    dt_print(DT_DEBUG_CACHE,
                "[image_cache_write_release] from `%s', imgid=%i took %.3fs",
                info, img->id, spent);
-    }
   }
-  dt_cache_release(&cache->cache, img->cache_entry);
 }
 
 void dt_image_cache_write_release(dt_image_t *img, const dt_image_cache_write_mode_t mode)

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -1933,11 +1933,11 @@ static void _list_view(dt_lib_collect_rule_t *dr)
       case DT_COLLECTION_PROP_ASPECT_RATIO: // aspect ratio, 3 hardcoded alternatives
         // clang-format off
         g_snprintf(query, sizeof(query),
-                   "SELECT ROUND(aspect_ratio,1), 1, COUNT(*) AS count"
+                   "SELECT ROUND(aspect_ratio,2), 1, COUNT(*) AS count"
                    " FROM main.images AS mi "
                    " WHERE %s"
-                   " GROUP BY ROUND(aspect_ratio,1)"
-                   " ORDER BY ROUND(aspect_ratio,1) %s",
+                   " GROUP BY ROUND(aspect_ratio,2)"
+                   " ORDER BY ROUND(aspect_ratio,2) %s",
                    where_ext,
                    sort_descending ? "DESC" : "ASC");
         // clang-format on

--- a/src/libs/filters/ratio.c
+++ b/src/libs/filters/ratio.c
@@ -37,10 +37,10 @@ static gboolean _ratio_update(dt_lib_filtering_rule_t *rule)
   char query[1024] = { 0 };
   // clang-format off
   g_snprintf(query, sizeof(query),
-             "SELECT ROUND(aspect_ratio,3), COUNT(*) AS count"
+             "SELECT ROUND(aspect_ratio,2), COUNT(*) AS count"
              " FROM main.images AS mi"
              " WHERE %s"
-             " GROUP BY ROUND(aspect_ratio,3)",
+             " GROUP BY ROUND(aspect_ratio,2)",
              d->last_where_ext);
   // clang-format on
   sqlite3_stmt *stmt;

--- a/src/libs/image.c
+++ b/src/libs/image.c
@@ -477,8 +477,8 @@ static void _tags_flag_callback(GtkWidget *widget,
   dt_conf_set_bool("plugins/lighttable/copy_metadata/tags", flag);
 }
 
-static void pastemode_combobox_changed(GtkWidget *widget,
-                                       gpointer user_data)
+static void _pastemode_combobox_changed(GtkWidget *widget,
+                                        gpointer user_data)
 {
   const int mode = dt_bauhaus_combobox_get(widget);
   dt_conf_set_int("plugins/lighttable/copy_metadata/pastemode", mode);
@@ -643,7 +643,7 @@ void gui_init(dt_lib_module_t *self)
     (pastemode, meta, NULL, N_("mode"),
      _("how to handle existing metadata"),
      dt_conf_get_int("plugins/lighttable/copy_metadata/pastemode"),
-     pastemode_combobox_changed, self,
+     _pastemode_combobox_changed, self,
      N_("merge"), N_("overwrite"));
   gtk_grid_attach(grid, pastemode, 0, line++, 6, 1);
 

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -996,8 +996,8 @@ static void _dev_change_image(dt_develop_t *dev,
   if(dev->preview_pipe->backbuf
      && dev->preview_pipe->status == DT_DEV_PIXELPIPE_VALID)
   {
-    const double aspect_ratio =
-      (double)dev->preview_pipe->backbuf_width / (double)dev->preview_pipe->backbuf_height;
+    const float aspect_ratio =
+      (float)dev->preview_pipe->backbuf_width / (float)dev->preview_pipe->backbuf_height;
     dt_image_set_aspect_ratio_to(dev->preview_pipe->image.id, aspect_ratio, TRUE);
   }
   else
@@ -3168,8 +3168,8 @@ void leave(dt_view_t *self)
   // update aspect ratio
   if(dev->preview_pipe->backbuf && dev->preview_pipe->status == DT_DEV_PIXELPIPE_VALID)
   {
-    const double aspect_ratio =
-      (double)dev->preview_pipe->backbuf_width / (double)dev->preview_pipe->backbuf_height;
+    const float aspect_ratio =
+      (float)dev->preview_pipe->backbuf_width / (float)dev->preview_pipe->backbuf_height;
     dt_image_set_aspect_ratio_to(dev->preview_pipe->image.id, aspect_ratio, FALSE);
   }
   else


### PR DESCRIPTION
Edited from latest commit:
______________________________________________
We have a number of functions setting the image's aspect ratio, it's content is mainly used for collections looking for it, another code place is culling where we use the aspect for determining how images are placed.

When calculating the aspect ratio there were rounding errors, imprecise calculations based on preview pipe dimension or sensors requiring some cropping in rawprepare, this leads to undesired values for aspect_ratio.
Another problem has been reported in #19252 where clearly different aspects could lead to the same value in the database (0.7 both for 3:2 or 4:3)

This commit implements `float dt_usable_aspect(const float img_aspect)`

It returns a more stable aspect by checking for an aspect being in a +-0.5% range of predefined aspects either provided by common sensor dimensions or the crop module.
If the tested aspects doesn't fit into one of these it returns values in 0.05 steps for portraits and 0.1 for landscapes to avoid a possibly "exploding" list of values in collections filter.
All ratio-setting functions use above.
Also we test with a very small range in the collection filter for an exact match.

Also: some code refactoring, code style modifications and some floats instead of doubles as not required.
_______________________________________________________________________________
@TurboGit this would be my proposal to handle issue #19252
@gywm TIA