### PR TITLE
[GUI] `AgX` should not be written in lowercase letters

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -3614,7 +3614,7 @@
       <enum>
         <option>scene-referred (sigmoid)</option>
         <option>scene-referred (filmic)</option>
-        <option>scene-referred (agx)</option>
+        <option>scene-referred (AgX)</option>
         <option>display-referred (legacy)</option>
         <option>none</option>
       </enum>

--- a/src/iop/agx.c
+++ b/src/iop/agx.c
@@ -41,7 +41,7 @@ DT_MODULE_INTROSPECTION(6, dt_iop_agx_params_t)
 
 const char *name()
 {
-  return _("agx");
+  return _("AgX");
 }
 
 const char *aliases()


### PR DESCRIPTION
This name is taken for the new tonemapper from pseudo-chemical notation, where it is written as AgX. This is quite different from, for example, the name "sigmoid", which is originally just an adjective, so it can easily obey our style. AgX forced into lowercase looks extremely strange.