### PR TITLE
[GUI] "Inaccessible" is the most common term

### DIFF
--- a/src/common/film.c
+++ b/src/common/film.c
@@ -1,6 +1,6 @@
 /*
    This file is part of darktable,
-   Copyright (C) 2009-2024 darktable developers.
+   Copyright (C) 2009-2025 darktable developers.
 
    darktable is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -467,7 +467,7 @@ void dt_film_remove(const dt_filmid_t id)
   if(!remove_ok)
   {
     dt_control_log(_("cannot remove film roll having local copies with"
-                     " non accessible originals"));
+                     " inaccessible originals"));
     return;
   }
 


### PR DESCRIPTION
"Inaccessible" is the most common and standard term, other options are used much less frequently. See [statistics](https://books.google.com/ngrams/graph?content=inaccessible%2Cnon-accessible%2Cnot+accessible%2C+non+accessible&year_start=1800&year_end=2022&corpus=en&smoothing=3). The form currently used ("non accessible") is not only the least used, but also grammatically incorrect. "Non" is not used as an independent word, it can either be fully attached to the word it modifies, or attached with a hyphen. The ONLY exceptions is certain Latin phrases, such as "persona non grata".