### PR TITLE
fix: libcurl 8.16 curl_easy_setopt  no longer accepts integer parameters

### DIFF
--- a/src/common/curl_tools.c
+++ b/src/common/curl_tools.c
@@ -39,7 +39,7 @@ void dt_curl_init(CURL *curl, gboolean verbose)
   curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
 
   if(verbose)
-    curl_easy_setopt(curl, CURLOPT_VERBOSE, 1);
+    curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);
 }
 
 // clang-format off

--- a/src/imageio/storage/piwigo.c
+++ b/src/imageio/storage/piwigo.c
@@ -406,7 +406,7 @@ static int _piwigo_api_post_internal(_piwigo_api_context_t *ctx,
   dt_curl_init(ctx->curl_ctx, piwigo_EXTRA_VERBOSE);
 
   curl_easy_setopt(ctx->curl_ctx, CURLOPT_URL, url->str);
-  curl_easy_setopt(ctx->curl_ctx, CURLOPT_POST, 1);
+  curl_easy_setopt(ctx->curl_ctx, CURLOPT_POST, 1L);
   curl_easy_setopt(ctx->curl_ctx, CURLOPT_WRITEFUNCTION, curl_write_data_cb);
   curl_easy_setopt(ctx->curl_ctx, CURLOPT_WRITEDATA, response);
 


### PR DESCRIPTION
Since my system upgraded to libcurl 8.16 my darktable master builds fail.

The following curl_easy_setopt require long parameters.
https://curl.se/libcurl/c/CURLOPT_VERBOSE.html
https://curl.se/libcurl/c/CURLOPT_POST.html