### PR TITLE
denoiseprofile: handle images w/o highlight preservation metadata better

### DIFF
--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -2856,7 +2856,9 @@ void reload_defaults(dt_iop_module_t *self)
   d->fix_anscombe_and_nlmeans_norm = TRUE;
   d->use_new_vst = TRUE;
   d->wavelet_color_mode = MODE_Y0U0V0;
-  d->compensate_hilite_pres = TRUE;
+
+  const int iso_shift = _get_iso_highlight_preservation_shift(&self->dev->image_storage);
+  d->compensate_hilite_pres = iso_shift > 0;
 
   GList *profiles = dt_noiseprofile_get_matching(&self->dev->image_storage);
   char name[512];


### PR DESCRIPTION
This:

- hides the checkbox if no highlight preservation metadata is detected
- disables the highlight preservation compensation altogether if no highlight preservation metadata is detected

The last bit is important to not break edits when we add support for new highlight preservation modes. See commit messages for details.