### PR TITLE
Add backward compatibility for AVIF chroma subsampling feature

### DIFF
--- a/src/imageio/format/avif.c
+++ b/src/imageio/format/avif.c
@@ -743,8 +743,12 @@ void *legacy_params(dt_imageio_module_format_t *self,
       uint32_t tiling;
     } dt_imageio_avif_v1_t;
 
+    if(old_params_size != sizeof(dt_imageio_avif_v1_t)) return NULL;
+
     const dt_imageio_avif_v1_t *o = (dt_imageio_avif_v1_t *)old_params;
     dt_imageio_avif_t *n = (dt_imageio_avif_t *)malloc(sizeof(dt_imageio_avif_t));
+    
+    if(!n) return NULL;
 
     n->global = o->global;
     n->bit_depth = o->bit_depth;


### PR DESCRIPTION
This PR adds the missing backward compatibility handling for the AVIF chroma subsampling feature that was recently merged in #19595. Thanks to @victoryforce for [noticing this](https://github.com/darktable-org/darktable/pull/19595#issuecomment-3492960578).

### Problem

The previous PR added a new `subsample` field to the `dt_imageio_avif_t` structure but did not include:
1. Module version increment
2. Legacy parameter migration function

This could cause issues for users upgrading from older versions who have saved AVIF export presets.

### Solution

This PR implements the required backward compatibility mechanisms:

1. **Incremented module version** from `DT_MODULE(1)` to `DT_MODULE(2)`
2. **Added `legacy_params()` function** to handle migration from version 1 (without `subsample`) to version 2 (with `subsample`)

Old export presets are automatically migrated with `subsample` set to `AVIF_SUBSAMPLE_AUTO`, which preserves the original quality-based chroma subsampling behavior.

### Testing

Tested the migration path as follows:

1. **Built and tested version 1** (parent commit c7b5d6f, before chroma subsampling feature 6cd1733):
   - Built AppImage with devcontainer #19597
   - Created fresh config directory
   - Exported sample image to verify AVIF export works
   - Confirmed auto chroma subsampling based on quality thresholds

2. **Built and tested version 2** (current commit with backward compatibility):
   - Cleaned build artifacts
   - Built AppImage with devcontainer
   - Launched with config directory from version 1
   - **Verified**: Chroma subsampling combobox appears in UI and defaults to "auto"
   - **Verified**: Export still works correctly with migrated settings
   - **Verified**: No errors or crashes during migration

### Changes

- `src/imageio/format/avif.c`:
  - Module version: `DT_MODULE(1)` → `DT_MODULE(2)`
  - Added `legacy_params()` function to migrate v1 parameters to v2
  - Default value for migrated presets: `AVIF_SUBSAMPLE_AUTO`

### Related

Follow-up to the AVIF chroma subsampling feature PR #19595 that was recently merged.