### PR TITLE
darktable.css: Use a darker shade for non active modules.

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -409,10 +409,14 @@ header button,
   margin: 0.07em;
 }
 
-.dt_module_btn,
 .dt_ignore_fg_state:checked
 {
   color: @button_fg;
+}
+
+.dt_module_btn:first-child
+{
+  color: shade(@disabled_fg_color, 0.9);
 }
 
 spinbutton > button,
@@ -1642,10 +1646,14 @@ progressbar progress
 }
 
 /* deactivated switch buttons, make them less visible */
-.dt_history_switch_off,
-.dt_history_switch_off:disabled
+.dt_history_switch_off
 {
   color: @disabled_fg_color;
+}
+
+.dt_history_switch_off:disabled
+{
+  color: shade(@disabled_fg_color, 0.9);
 }
 
 #dt-metadata-changed


### PR DESCRIPTION
People have said multiple time that the on/off buttons are hard to distinguidh. Some colored CSS theme have been created based on that.

What about a darker button when not active?

Before:

<img width="373" height="459" alt="image" src="https://github.com/user-attachments/assets/adc70531-220c-40d1-829c-d07f3cd25014" />

After:

<img width="373" height="459" alt="image" src="https://github.com/user-attachments/assets/d8cd5200-0a3a-418f-b84b-857b19733458" />

Tested on dark, darker and gray themes.
