### PR TITLE
Rework the paste part dialog.

### DIFF
--- a/src/common/history.h
+++ b/src/common/history.h
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2010-2024 darktable developers.
+    Copyright (C) 2010-2025 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -63,11 +63,10 @@ typedef struct dt_history_copy_item_t
 {
   GList *selops;
   GtkTreeView *items;
-  GtkWidget *overwrite;
   dt_imgid_t copied_imageid;
   gboolean full_copy;
   gboolean copy_iop_order;
-  gboolean is_overwrite_set;
+  dt_history_copy_mode_t paste_mode;
 } dt_history_copy_item_t;
 
 /** helper function to free a GList of dt_history_item_t */

--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -2417,7 +2417,8 @@ void dt_control_paste_parts_history(GList *imgs)
     (&(darktable.view_manager->copy_paste),
      darktable.view_manager->copy_paste.copied_imageid, FALSE);
 
-  if(res == GTK_RESPONSE_OK)
+  if(res == GTK_RESPONSE_OK
+     || res == GTK_RESPONSE_APPLY)
   {
     _images_job_data_t *images_job_data = g_malloc(sizeof(_images_job_data_t));
     if(images_job_data)
@@ -2425,7 +2426,8 @@ void dt_control_paste_parts_history(GList *imgs)
       images_job_data->imgs = imgs;
       images_job_data->styles = NULL;
       images_job_data->duplicate = FALSE;
-      images_job_data->overwrite = darktable.view_manager->copy_paste.is_overwrite_set;
+      images_job_data->overwrite =
+        darktable.view_manager->copy_paste.paste_mode == DT_HISTORY_COPY_OVERWRITE;
 
       _add_history_job_data(N_("paste history"),
                             &_control_paste_history_job_run, images_job_data);

--- a/src/gui/hist_dialog.c
+++ b/src/gui/hist_dialog.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2012-2023 darktable developers.
+    Copyright (C) 2012-2025 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -130,10 +130,13 @@ static void _gui_hist_copy_response(GtkDialog *dialog,
     case GTK_RESPONSE_OK:
       g->selops = _gui_hist_get_active_items(g);
       g->copy_iop_order = _gui_hist_is_copy_module_order_set(g);
-      if(g->overwrite)
-      {
-        g->is_overwrite_set = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(g->overwrite));
-      }
+      g->paste_mode = DT_HISTORY_COPY_APPEND;
+      break;
+
+    case GTK_RESPONSE_APPLY:
+      g->selops = _gui_hist_get_active_items(g);
+      g->copy_iop_order = _gui_hist_is_copy_module_order_set(g);
+      g->paste_mode = DT_HISTORY_COPY_OVERWRITE;
       break;
   }
 }
@@ -213,13 +216,6 @@ void tree_on_row_activated(GtkTreeView       *treeview,
   }
 }
 
-static void _overwrite_mode_clicked_callback(GtkWidget *widget,
-                                             dt_history_copy_item_t *d)
-{
-  const gboolean flag = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(d->overwrite));
-  dt_conf_set_bool("ui_last/history_overwrite", flag);
-}
-
 int dt_gui_hist_dialog_new(dt_history_copy_item_t *d,
                            const dt_imgid_t imgid,
                            const gboolean iscopy)
@@ -227,15 +223,34 @@ int dt_gui_hist_dialog_new(dt_history_copy_item_t *d,
   int res;
   GtkWidget *window = dt_ui_main_window(darktable.gui->ui);
 
-  GtkDialog *dialog = GTK_DIALOG
-    (gtk_dialog_new_with_buttons(
-      iscopy ? _("select parts to copy") : _("select parts to paste"),
-      GTK_WINDOW(window), GTK_DIALOG_MODAL | GTK_DIALOG_DESTROY_WITH_PARENT,
-      _("select _all"),  GTK_RESPONSE_YES,
-      _("select _none"), GTK_RESPONSE_NONE,
-      _("_cancel"),      GTK_RESPONSE_CANCEL,
-      _("_ok"),          GTK_RESPONSE_OK,
-      NULL));
+  GtkDialog *dialog = NULL;
+
+  if(iscopy)
+  {
+    dialog = GTK_DIALOG
+      (gtk_dialog_new_with_buttons(
+        _("select parts to copy"),
+        GTK_WINDOW(window), GTK_DIALOG_MODAL | GTK_DIALOG_DESTROY_WITH_PARENT,
+        _("select _all"),  GTK_RESPONSE_YES,
+        _("select _none"), GTK_RESPONSE_NONE,
+        _("_cancel"),      GTK_RESPONSE_CANCEL,
+        _("_ok"),          GTK_RESPONSE_OK,
+        NULL));
+  }
+  else
+  {
+    dialog = GTK_DIALOG
+      (gtk_dialog_new_with_buttons(
+        _("select parts to paste"),
+        GTK_WINDOW(window), GTK_DIALOG_MODAL | GTK_DIALOG_DESTROY_WITH_PARENT,
+        _("select _all"),  GTK_RESPONSE_YES,
+        _("select _none"), GTK_RESPONSE_NONE,
+        _("_cancel"),      GTK_RESPONSE_CANCEL,
+        _("_overwite"),    GTK_RESPONSE_APPLY,
+        _("appen_d"),      GTK_RESPONSE_OK,
+        NULL));
+  }
+
   dt_gui_dialog_add_help(dialog, "copy_history");
   dt_gui_dialog_restore_size(dialog, "copy_history");
 
@@ -358,24 +373,6 @@ int dt_gui_hist_dialog_new(dt_history_copy_item_t *d,
     return GTK_RESPONSE_CANCEL;
   }
 
-  /* overwrite/append mode */
-
-  if(!iscopy)
-  {
-    d->overwrite = gtk_check_button_new_with_label(_("overwrite mode"));
-    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->overwrite),
-                                 dt_conf_get_bool("ui_last/history_overwrite"));
-    gtk_widget_set_tooltip_text(d->overwrite,
-                                _("clear history stack before pasting the copied history.\n"
-                                  "required modules will be added with default values."));
-    g_signal_connect(G_OBJECT(d->overwrite), "clicked",                 \
-                     G_CALLBACK(_overwrite_mode_clicked_callback), d);
-
-    dt_gui_dialog_add(GTK_DIALOG(dialog), d->overwrite);
-  }
-  else
-    d->overwrite = NULL;
-
   g_signal_connect(GTK_TREE_VIEW(d->items), "row-activated",
                    (GCallback)tree_on_row_activated, GTK_WIDGET(dialog));
   g_object_unref(liststore);
@@ -389,7 +386,8 @@ int dt_gui_hist_dialog_new(dt_history_copy_item_t *d,
     res = gtk_dialog_run(GTK_DIALOG(dialog));
     if(res == GTK_RESPONSE_CANCEL
        || res == GTK_RESPONSE_DELETE_EVENT
-       || res == GTK_RESPONSE_OK) break;
+       || res == GTK_RESPONSE_OK
+       || res == GTK_RESPONSE_APPLY) break;
   }
 
   gtk_widget_destroy(GTK_WIDGET(dialog));


### PR DESCRIPTION
Instead of having a select box to change the mode it is actually faster to use a dedicated button to either paste in append mode or in overwrite mode.

Closes #19715.