### PR TITLE
[GUI] Fix typo in AgX tooltip

### DIFF
--- a/src/iop/agx.c
+++ b/src/iop/agx.c
@@ -2414,7 +2414,7 @@ static void _add_exposure_box(dt_iop_module_t *self, dt_iop_agx_gui_data_t *g, d
   GtkWidget *auto_tune_box = dt_gui_hbox();
   GtkWidget *auto_tune_label = dt_ui_label_new(_("auto tune levels"));
   g->range_exposure_picker = dt_color_picker_new(self, DT_COLOR_PICKER_AREA | DT_COLOR_PICKER_DENOISE, NULL);
-  gtk_widget_set_tooltip_text(g->range_exposure_picker, _("set back and white relative exposure using the selected area"));
+  gtk_widget_set_tooltip_text(g->range_exposure_picker, _("set black and white relative exposure using the selected area"));
   dt_action_define_iop(real_self, N_("exposure range"), N_("auto tune levels"), g->range_exposure_picker, &dt_action_def_toggle);
   dt_gui_box_add(auto_tune_box, dt_gui_expand(auto_tune_label), g->range_exposure_picker);
   dt_gui_box_add(g->range_exposure_picker_group, auto_tune_box);


### PR DESCRIPTION
Black, not back. I only noticed this when I started playing with the module. It's interesting how when you translate, your brain sees what it expects - these are mild human hallucinations, which are somewhat different from AI hallucinations. 🤣 
