### PR TITLE
Fix images added to group when grouping not active

### DIFF
--- a/src/libs/image.c
+++ b/src/libs/image.c
@@ -89,7 +89,7 @@ uint32_t container(dt_lib_module_t *self)
  * one will be created. */
 static void _group_helper_function(void)
 {
-  dt_imgid_t new_group_id = darktable.gui->expanded_group_id 
+  dt_imgid_t new_group_id = darktable.gui->grouping
   ? darktable.gui->expanded_group_id 
   : NO_IMGID;
 


### PR DESCRIPTION
Added check to see if grouping is active before using expanded group id when creating a group.

@TurboGit it turns out the easy fix with an added test is the correct fix :smile:

Tested creating a 2nd group with an expanded group with a changed group leader and the groups remained separate

Tested grouping active, expand a group, select more images and hit group button and they are added to the expanded group.

Fixes #19693.