### PR TITLE
Fix main window growing on Wayland after each restart

### DIFF
--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -850,14 +850,17 @@ int dt_gui_gtk_write_config()
   dt_pthread_mutex_lock(&darktable.gui->mutex);
 
   GtkWidget *widget = dt_ui_main_window(darktable.gui->ui);
-  GtkAllocation allocation;
-  gtk_widget_get_allocation(widget, &allocation);
-  gint x, y;
+  gint x, y, width, height;
+  // Use gtk_window_get_size() instead of gtk_widget_get_allocation() to get
+  // the content size without window decorations. This is especially important
+  // on Wayland where CSD (Client-Side Decorations) are included in allocation
+  // but not in the size set by gtk_window_resize().
+  gtk_window_get_size(GTK_WINDOW(widget), &width, &height);
   gtk_window_get_position(GTK_WINDOW(widget), &x, &y);
   dt_conf_set_int("ui_last/window_x", x);
   dt_conf_set_int("ui_last/window_y", y);
-  dt_conf_set_int("ui_last/window_w", allocation.width);
-  dt_conf_set_int("ui_last/window_h", allocation.height);
+  dt_conf_set_int("ui_last/window_w", width);
+  dt_conf_set_int("ui_last/window_h", height);
   dt_conf_set_bool("ui_last/maximized",
                    (gdk_window_get_state(gtk_widget_get_window(widget))
                     & GDK_WINDOW_STATE_MAXIMIZED));
@@ -1739,6 +1742,9 @@ static void _init_widgets(dt_gui_gtk_t *gui)
 #ifdef GDK_WINDOWING_WAYLAND
   if(dt_gui_get_session_type() == DT_GUI_SESSION_WAYLAND)
   {
+    // On Wayland, use NORMAL hint to allow proper window resizing
+    gtk_window_set_type_hint(GTK_WINDOW(widget), GDK_WINDOW_TYPE_HINT_NORMAL);
+
     GtkWidget *header_bar = gtk_header_bar_new();
     gtk_header_bar_set_title(GTK_HEADER_BAR(header_bar), "darktable");
     gtk_header_bar_set_show_close_button(GTK_HEADER_BAR(header_bar), TRUE);


### PR DESCRIPTION
On Wayland with CSD (Client-Side Decorations), the main window was growing by the size of decorations after each restart. This happened because gtk_widget_get_allocation() returns the size including window decorations, while gtk_window_resize() expects size without decorations.

This commit fixes two issues:

1. Use gtk_window_get_size() instead of gtk_widget_get_allocation() in dt_gui_gtk_write_config() to save window size without decorations. This matches the behavior of gtk_window_resize() used in dt_gui_gtk_load_config().

2. Set GTK_WINDOW_TYPE_HINT_NORMAL for the main window on Wayland to ensure proper window resize behavior.

Fixes: #19734