### PR TITLE
Fix OpenCL liquify

### DIFF
--- a/src/iop/liquify.c
+++ b/src/iop/liquify.c
@@ -1494,7 +1494,7 @@ static cl_int_t _apply_global_distortion_map_cl(const dt_iop_module_t *self,
          k[i] = lanczos(3, (float) i / kdesc.resolution);
        break;
      default:
-       return FALSE;
+       return DT_OPENCL_PROCESS_CL;
   }
 
   const cl_mem_t dev_roi_in = dt_opencl_copy_host_to_device_constant


### PR DESCRIPTION
1. There was a bug introduced in 872e4b835c7d67bf8b48c7a9f5281062456a370f, we should just make sure we don't read NaN from the pipe.
2. If we use an unsupported interpolator we should return an error code instead of false.

Fixes #19555