### PR TITLE
RustiCL is not unstable any more

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -419,8 +419,8 @@
     <name>clplatform_rusticl</name>
     <type>bool</type>
     <default>false</default>
-    <shortdescription>RustiCL (experimental)</shortdescription>
-    <longdescription>RustiCL Mesa OpenCL, still unstable. if you want to use this, you should disable the vendor driver</longdescription>
+    <shortdescription>RustiCL</shortdescription>
+    <longdescription>RustiCL Mesa OpenCL. if you want to use this, you should disable the vendor driver</longdescription>
   </dtconfig>
   <dtconfig prefs="processing" section="platform" capability="apple" restart="true">
     <name>clplatform_apple</name>


### PR DESCRIPTION
As RustiCL
- made great progress
- is available with regular updates for all distributions
- is pretty performant
- cares about dt problems using it

we should not discourage people using it.