### PR TITLE
agx: Remove migration of test (pre-7) versions

### DIFF
--- a/src/iop/agx.c
+++ b/src/iop/agx.c
@@ -38,9 +38,7 @@
 #include <pango/pangocairo.h>
 #include <stdlib.h>
 
-#define AGX_VERSION 7
-
-DT_MODULE_INTROSPECTION(AGX_VERSION, dt_iop_agx_params_t)
+DT_MODULE_INTROSPECTION(7, dt_iop_agx_params_t)
 
 const char *name()
 {
@@ -291,12 +289,12 @@ int legacy_params(dt_iop_module_t *self,
     _set_scene_referred_default_params(np);
     *new_params = np;
     *new_params_size = sizeof(dt_iop_agx_params_t);
-    *new_version = AGX_VERSION; // SPECIAL CASE: test versions jump directly to latest
+    *new_version = self->so->version(); // SPECIAL CASE: jump directly to latest version
 
     return 0;
   }
 
-  return 1; // no other conversion possible
+  return 1;
 }
 
 static inline dt_colorspaces_color_profile_type_t


### PR DESCRIPTION
We don't want to maintain the migration code for the 6 test versions made before darktable 5.4 is officially released with AgX. In order to avoid crashes, we'll simply overwrite old versions with whatever the defaults of the currently latest version of darktable are.
Since this is a special case (sorry for breaking the rules -- I never thought it would get so badly out of hand), there are some repeated, screaming comments regarding the SPECIAL CASE. :-/

[Announcement on pixls](https://discuss.pixls.us/t/heads-up-agx-backwards-compatibility-change-coming/54211)

In draft for a few days, so users can migrate their images before this gets released with a nightly. This comment will be removed when the PR is taken out of draft.