### PR TITLE
Rework the popover to avoid double border on start filtering.

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -927,15 +927,20 @@ popover separator
   background-color: @selected_bg_color;
 }
 
-/* the tag completion popover */
-popover box
-{
-  border : 1px solid @button_border;
-}
-
 popover *
 {
-  background-color: @bg_color;
+  background-color: @tooltip_bg_color;
+}
+
+#tag-completion *
+{
+  background-color: @tooltip_bg_color;
+}
+
+#tag-completion box
+{
+  background-color: @tooltip_bg_color;
+  border : 1px solid @button_border;
 }
 
 combobox separator

--- a/src/libs/tagging.c
+++ b/src/libs/tagging.c
@@ -3852,6 +3852,7 @@ static void _lib_tagging_tag_show(dt_action_t *action)
                    G_CALLBACK(_match_selected_func), self);
   gtk_entry_completion_set_match_func(completion, _completion_match_func, NULL, NULL);
   gtk_entry_set_completion(GTK_ENTRY(entry), completion);
+  gtk_widget_set_name(entry, "tag-completion");
 
   gtk_editable_select_region(GTK_EDITABLE(entry), 0, -1);
   gtk_container_add(GTK_CONTAINER(d->floating_tag_window), entry);


### PR DESCRIPTION
The trick here is to differenciate the tag completion form the tooltip over the stars (toolbar top of lighttable). This fixes on this later named tooltip a double border.