### PR TITLE
Fix filmstrip double marker issue (#19772)

### DIFF
--- a/src/dtgtk/thumbnail.c
+++ b/src/dtgtk/thumbnail.c
@@ -885,7 +885,15 @@ static void _thumb_update_icons(dt_thumbnail_t *thumb)
   gtk_widget_show(thumb->w_bottom_eb);
   gtk_widget_show(thumb->w_reject);
   gtk_widget_show(thumb->w_ext);
-  gtk_widget_show(thumb->w_cursor);
+
+  // show cursor (filmstrip current-image arrow) only for the active image
+  gboolean show_cursor = thumb->active;
+  if(show_cursor && darktable.view_manager->active_images)
+  {
+    const int activeid = GPOINTER_TO_INT(darktable.view_manager->active_images->data);
+    show_cursor = (thumb->imgid == activeid);
+  }
+  gtk_widget_set_visible(thumb->w_cursor, show_cursor);
 
   for(int i = 0; i < MAX_STARS; i++)
     gtk_widget_show(thumb->w_stars[i]);


### PR DESCRIPTION
The filmstrip current-image marker (black arrow) was appearing on multiple thumbnails spaced by the number of visible items in the filmstrip. This occurred because the w_cursor widget visibility was tied only to thumb->active flag, which could be set on multiple thumbnails during scrolling and thumbnail reuse.

The fix adds a double-check in _thumb_update_icons() to ensure the cursor arrow is shown only when both conditions are met:
- thumb->active is TRUE
- thumb->imgid matches the first entry in active_images list

This ensures only the actual current/active image displays the marker, eliminating visual confusion between selection highlight and current-image indicator.

Fixes #19772