### PR TITLE
thumbnail: makes the filmstrip cursor higher (more visible).

### DIFF
--- a/src/dtgtk/thumbnail.c
+++ b/src/dtgtk/thumbnail.c
@@ -413,23 +413,24 @@ static gboolean _event_cursor_draw(GtkWidget *widget,
                                    cairo_t *cr,
                                    gpointer user_data)
 {
-  if(!user_data || !widget) return TRUE;
-  dt_thumbnail_t *thumb = (dt_thumbnail_t *)user_data;
-
-  GtkStateFlags state = gtk_widget_get_state_flags(thumb->w_cursor);
-  GtkStyleContext *context = gtk_widget_get_style_context(thumb->w_cursor);
-  GdkRGBA col;
-  gtk_style_context_get_color(context, state, &col);
+  if(!widget) return TRUE;
 
   const double w_width  = gtk_widget_get_allocated_width(widget);
   const double w_height = gtk_widget_get_allocated_height(widget);
 
-  cairo_set_source_rgba(cr, col.red, col.green, col.blue, col.alpha);
+  dt_gui_gtk_set_source_rgb(cr, DT_GUI_COLOR_DARKROOM_BG);
   cairo_line_to(cr, w_width, 0);
   cairo_line_to(cr, w_width / 2, w_height);
   cairo_line_to(cr, 0, 0);
   cairo_close_path(cr);
   cairo_fill(cr);
+
+  dt_gui_gtk_set_source_rgb(cr, DT_GUI_COLOR_THUMBNAIL_SELECTED_BG);
+  cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(2));
+  cairo_line_to(cr, w_width, 0);
+  cairo_line_to(cr, w_width / 2, w_height);
+  cairo_line_to(cr, 0, 0);
+  cairo_stroke(cr);
 
   return TRUE;
 }


### PR DESCRIPTION
It is always a bit difficult to see the thumb filmstrip cursor. As this flags the currently opened in darkroom picture it is not an issue to draw a bit more over the thumb.

Before:

<img width="983" height="260" alt="image" src="https://github.com/user-attachments/assets/988ee8d1-5f79-477a-a1d8-94aac9ca2b7c" />


After:

<img width="983" height="260" alt="image" src="https://github.com/user-attachments/assets/961191b5-69ba-4b60-a032-b147511c7f6c" />
