### PR TITLE
Fix filmstrip showing incorrect selection highlights for processed image

### DIFF
--- a/src/dtgtk/thumbnail.c
+++ b/src/dtgtk/thumbnail.c
@@ -901,7 +901,7 @@ static void _thumb_update_icons(dt_thumbnail_t *thumb)
     gtk_widget_show(thumb->w_stars[i]);
 
   _set_flag(thumb->w_main, GTK_STATE_FLAG_PRELIGHT, thumb->mouse_over);
-  _set_flag(thumb->w_main, GTK_STATE_FLAG_ACTIVE, thumb->active);
+  _set_flag(thumb->w_main, GTK_STATE_FLAG_ACTIVE, show_cursor);
 
   _set_flag(thumb->w_reject, GTK_STATE_FLAG_ACTIVE, (thumb->rating == DT_VIEW_REJECT));
 


### PR DESCRIPTION
This is a follow-up fix for 0237a52c5cbaccfedeed072d1fd9ebff933bd074. There, the issue that the black arrow indicating the processed image was being shown on multiple images was fixed.

However, the processed image is also being highlit, similarly to how selected images are being highlit. The highlight is still present on multiple images even after the aforementioned commit.

This commit also removes the incorrect highlight.

In context of #19772.