### PR TITLE
Update BUILD.txt for pango dependency installation

### DIFF
--- a/packaging/macosx/BUILD.txt
+++ b/packaging/macosx/BUILD.txt
@@ -9,7 +9,7 @@ How to make disk image with darktable application bundle (64 bit Intel only):
     Install required dependencies:
 
      since recent pango 1.55 breaks font dialog access the previous version 1.52.2 needs to be used.
-     $ mkdir -p ~/ports/devel/x11/files
+     $ mkdir -p ~/ports/devel/x11/pango/files
      $ curl -Lo ~/ports/x11/pango/Portfile https://github.com/macports/macports-ports/raw/26241fac142ac2bbe2a9071918ff20b301c66f4b/x11/pango/Portfile
      $ curl -Lo ~/ports/x11/pango/files/patch-meson-examples-tests.diff https://github.com/macports/macports-ports/raw/26241fac142ac2bbe2a9071918ff20b301c66f4b/x11/pango/files/patch-meson-examples-tests.diff
      $ portindex ~/ports


### PR DESCRIPTION
current (Nov 2025) pango version in macports (1.55.0) breaks font choosing dialog (causes a crash) so using the previous available version (1.52.2) is a workaround until macports updates to latest pango version.