### PR TITLE
Picker and blending support for some rgb profiles

### DIFF
--- a/src/common/dttypes.h
+++ b/src/common/dttypes.h
@@ -194,6 +194,10 @@ static inline void pack_3xSSE_to_3x3(const dt_colormatrix_t input, float output[
   output[8] = input[2][2];
 }
 
+static const dt_colormatrix_t identity_matrix = { { 1.0f, 0.0f, 0.0f, 0.0f },
+                                                  { 0.0f, 1.0f, 0.0f, 0.0f },
+                                                  { 0.0f, 0.0f, 1.0f, 0.0f } };
+
 static inline void dt_colormatrix_copy(dt_colormatrix_t out, const dt_colormatrix_t in)
 {
   for(size_t i = 0; i < 4; i++)

--- a/src/common/iop_profile.h
+++ b/src/common/iop_profile.h
@@ -131,8 +131,7 @@ dt_ioppr_get_pipe_output_profile_info(const struct dt_dev_pixelpipe_t *pipe);
 /** Get the relevant RGB -> XYZ profile at the position of current module */
 dt_iop_order_iccprofile_info_t *
 dt_ioppr_get_pipe_current_profile_info(const struct dt_iop_module_t *module,
-                                       struct dt_dev_pixelpipe_t *pipe);
-
+                                       const struct dt_dev_pixelpipe_t *pipe);
 /** returns the current setting of the work profile on colorin iop */
 void dt_ioppr_get_work_profile_type(struct dt_develop_t *dev,
                                     dt_colorspaces_color_profile_type_t *profile_type,


### PR DESCRIPTION
See #19724 for .icc file and issue description.

dt expects a "working matrix" when used for pickers or blending, possibly .icc files don't provide them leading to issues in modules before colorin in the pipe,
- module pickers and blending does not work for IOP_CS_JZCZHZ.

If a rgb profile file is added to the list we check for missing matrixes, if that is the case we insert a "pass matrix" and report that in the log.

Some maintainance and improved logs while being here.

@wpferguson you commented on #19724 also @TurboGit and @ralfbrown

I tried to find specs about .icc files and requirements for matrixes but couldn't find any (yet) 