### PR TITLE
Various fixes & improves

### DIFF
--- a/src/common/iop_profile.c
+++ b/src/common/iop_profile.c
@@ -817,7 +817,7 @@ dt_ioppr_add_profile_info_to_list(struct dt_develop_t *dev,
   return profile_info;
 }
 
-dt_iop_order_iccprofile_info_t *dt_ioppr_get_iop_work_profile_info(struct dt_iop_module_t *module,
+dt_iop_order_iccprofile_info_t *dt_ioppr_get_iop_work_profile_info(const struct dt_iop_module_t *module,
                                                                    GList *iop_list)
 {
   dt_iop_order_iccprofile_info_t *profile = NULL;
@@ -960,22 +960,22 @@ dt_iop_order_iccprofile_info_t *dt_ioppr_get_histogram_profile_info(struct dt_de
                                            DT_INTENT_RELATIVE_COLORIMETRIC);
 }
 
-dt_iop_order_iccprofile_info_t *dt_ioppr_get_pipe_work_profile_info(struct dt_dev_pixelpipe_t *pipe)
+dt_iop_order_iccprofile_info_t *dt_ioppr_get_pipe_work_profile_info(const struct dt_dev_pixelpipe_t *pipe)
 {
   return pipe->work_profile_info;
 }
 
-dt_iop_order_iccprofile_info_t *dt_ioppr_get_pipe_input_profile_info(struct dt_dev_pixelpipe_t *pipe)
+dt_iop_order_iccprofile_info_t *dt_ioppr_get_pipe_input_profile_info(const struct dt_dev_pixelpipe_t *pipe)
 {
   return pipe->input_profile_info;
 }
 
-dt_iop_order_iccprofile_info_t *dt_ioppr_get_pipe_output_profile_info(struct dt_dev_pixelpipe_t *pipe)
+dt_iop_order_iccprofile_info_t *dt_ioppr_get_pipe_output_profile_info(const struct dt_dev_pixelpipe_t *pipe)
 {
   return pipe->output_profile_info;
 }
 
-dt_iop_order_iccprofile_info_t *dt_ioppr_get_pipe_current_profile_info(dt_iop_module_t *module,
+dt_iop_order_iccprofile_info_t *dt_ioppr_get_pipe_current_profile_info(const dt_iop_module_t *module,
                                                                        struct dt_dev_pixelpipe_t *pipe)
 {
   dt_iop_order_iccprofile_info_t *restrict color_profile;

--- a/src/common/iop_profile.h
+++ b/src/common/iop_profile.h
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2020-2023 darktable developers.
+    Copyright (C) 2020-2025 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU Lesser General Public License as published by
@@ -83,10 +83,10 @@ dt_ioppr_add_profile_info_to_list(struct dt_develop_t *dev,
  * work profile must not be cleanup()
  */
 dt_iop_order_iccprofile_info_t *
-dt_ioppr_get_iop_work_profile_info(struct dt_iop_module_t *module,
+dt_ioppr_get_iop_work_profile_info(const struct dt_iop_module_t *module,
                                    GList *iop_list);
 dt_iop_order_iccprofile_info_t *
-dt_ioppr_get_iop_input_profile_info(struct dt_iop_module_t *module,
+dt_ioppr_get_iop_input_profile_info(const struct dt_iop_module_t *module,
                                     GList *iop_list);
 
 /** set the work profile (type, filename) on the pipe, should be called on process*()
@@ -122,15 +122,15 @@ dt_ioppr_get_histogram_profile_info(struct dt_develop_t *dev);
 
 /** returns the active work/input/output profile on the pipe */
 dt_iop_order_iccprofile_info_t *
-dt_ioppr_get_pipe_work_profile_info(struct dt_dev_pixelpipe_t *pipe);
+dt_ioppr_get_pipe_work_profile_info(const struct dt_dev_pixelpipe_t *pipe);
 dt_iop_order_iccprofile_info_t *
-dt_ioppr_get_pipe_input_profile_info(struct dt_dev_pixelpipe_t *pipe);
+dt_ioppr_get_pipe_input_profile_info(const struct dt_dev_pixelpipe_t *pipe);
 dt_iop_order_iccprofile_info_t *
-dt_ioppr_get_pipe_output_profile_info(struct dt_dev_pixelpipe_t *pipe);
+dt_ioppr_get_pipe_output_profile_info(const struct dt_dev_pixelpipe_t *pipe);
 
 /** Get the relevant RGB -> XYZ profile at the position of current module */
 dt_iop_order_iccprofile_info_t *
-dt_ioppr_get_pipe_current_profile_info(struct dt_iop_module_t *module,
+dt_ioppr_get_pipe_current_profile_info(const struct dt_iop_module_t *module,
                                        struct dt_dev_pixelpipe_t *pipe);
 
 /** returns the current setting of the work profile on colorin iop */

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -472,6 +472,7 @@ static gboolean _opencl_device_init(dt_opencl_t *cl,
   cl->dev[dev].summary = CL_COMPLETE;
   cl->dev[dev].used_global_mem = 0;
   cl->dev[dev].max_mem_constant = 0;
+  cl->dev[dev].alignsize = 0;
   cl->dev[dev].nvidia_sm_20 = FALSE;
   cl->dev[dev].fullname = NULL;
   cl->dev[dev].platform = NULL;

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -2038,14 +2038,14 @@ static void _set_trouble_messages(dt_iop_module_t *self)
   const dt_image_t *img = &dev->image_storage;
   dt_print_pipe(DT_DEBUG_PIPE, anyproblem ? "chroma trouble" : "chroma data",
       NULL, self, DT_DEVICE_NONE, NULL, NULL,
-      "%s%s%sD65=%s.  D65 %.3f %.3f %.3f, AS-SHOT %.3f %.3f %.3f File `%s' ID=%i",
+      "%s%s%sD65=%s.  D65 %.3f %.3f %.3f, AS-SHOT %.3f %.3f %.3f ID=%i",
       problem1 ? "white balance applied twice, " : "",
       problem2 ? "double CAT applied, " : "",
       problem3 ? "white balance missing, " : "",
       _dev_is_D65_chroma(dev) ? "YES" : "NO",
       chr->D65coeffs[0], chr->D65coeffs[1], chr->D65coeffs[2],
       chr->as_shot[0], chr->as_shot[1], chr->as_shot[2],
-      img->filename, img->id);
+      img->id);
 
   if(problem2)
   {


### PR DESCRIPTION
- some constify in iop_profile
- add a forgotten initialize in opencl device init
- a leading underscore for a static function
- improved logs for OpenCL reading picker and histogram data in the pixelpipe
- adding filename to logs when starting/closing pipe for improved debugging