### PR TITLE
Avoid two warnings about vectorising not possible

### DIFF
--- a/src/iop/agx.c
+++ b/src/iop/agx.c
@@ -1732,7 +1732,7 @@ void process(dt_iop_module_t *self,
 
   const gboolean base_working_same_profile = pipe_work_profile == base_profile;
 
-  DT_OMP_FOR_SIMD()
+  DT_OMP_FOR()
   for(size_t k = 0; k < 4 * n_pixels; k += 4)
   {
     const float *const restrict pix_in = in + k;


### PR DESCRIPTION
Clang builds throw warnings about vectorising not possible in agx.c and blurs.c

In both cases that indeed makes no sense to try so we use the simple DT_OMP_FOR() variant instead. While being here some code style fixes in blurs.

Fixes #19794