### PR TITLE
Fix build failing when path contains space

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -371,8 +371,8 @@ if [ $ADDRESS_SANITIZER -ne 0 ] ; then
 fi
 
 
-cmd_config="${ASAN_FLAGS}cmake -G \"$BUILD_GENERATOR\" -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} -DCMAKE_BUILD_TYPE=${BUILD_TYPE} ${CMAKE_MORE_OPTIONS} ${CMAKE_OPTIONS_FROM_CMDLINE} \"$DT_SRC_DIR\""
-cmd_build="cmake --build "$BUILD_DIR" -- -j$MAKE_TASKS"
+cmd_config="${ASAN_FLAGS}cmake -G \"$BUILD_GENERATOR\" -DCMAKE_INSTALL_PREFIX=\"${INSTALL_PREFIX}\" -DCMAKE_BUILD_TYPE=${BUILD_TYPE} ${CMAKE_MORE_OPTIONS} ${CMAKE_OPTIONS_FROM_CMDLINE} \"$DT_SRC_DIR\""
+cmd_build="cmake --build \"$BUILD_DIR\" -- -j$MAKE_TASKS"
 cmd_install="${SUDO}cmake --build \"$BUILD_DIR\" --target install -- -j$MAKE_TASKS"
 
 

--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -73,7 +73,7 @@ if(NOT WIN32)
   file(GLOB PO_FILES "${CMAKE_CURRENT_SOURCE_DIR}/../po/*.po")
   add_custom_command(
     OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/org.darktable.darktable.desktop
-    COMMAND sh -c "${intltool_merge_BIN} --desktop-style ${CMAKE_CURRENT_SOURCE_DIR}/../po ${CMAKE_CURRENT_BINARY_DIR}/org.darktable.darktable.desktop.in ${CMAKE_CURRENT_BINARY_DIR}/org.darktable.darktable.desktop"
+    COMMAND sh -c "${intltool_merge_BIN} --desktop-style \"${CMAKE_CURRENT_SOURCE_DIR}/../po\" \"${CMAKE_CURRENT_BINARY_DIR}/org.darktable.darktable.desktop.in\" \"${CMAKE_CURRENT_BINARY_DIR}/org.darktable.darktable.desktop\""
     MAIN_DEPENDENCY ${CMAKE_CURRENT_BINARY_DIR}/org.darktable.darktable.desktop.in
     DEPENDS ${PO_FILES}
     )
@@ -95,7 +95,7 @@ if(NOT WIN32)
       OUTPUT ${DARKTABLE_SHAREDIR}/metainfo/org.darktable.darktable.appdata.xml
       SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/org.darktable.darktable.appdata.xml.in
       COMMAND ${CMAKE_COMMAND} -E make_directory ${DARKTABLE_SHAREDIR}/metainfo
-      COMMAND sh -c "${intltool_merge_BIN} --xml-style ${CMAKE_CURRENT_SOURCE_DIR}/../po ${CMAKE_CURRENT_SOURCE_DIR}/org.darktable.darktable.appdata.xml.in ${DARKTABLE_SHAREDIR}/metainfo/org.darktable.darktable.appdata.xml"
+      COMMAND sh -c "${intltool_merge_BIN} --xml-style \"${CMAKE_CURRENT_SOURCE_DIR}/../po\" \"${CMAKE_CURRENT_SOURCE_DIR}/org.darktable.darktable.appdata.xml.in\" \"${DARKTABLE_SHAREDIR}/metainfo/org.darktable.darktable.appdata.xml\""
       COMMAND ${appstream_util_BIN} validate --nonet ${DARKTABLE_SHAREDIR}/metainfo/org.darktable.darktable.appdata.xml
       MAIN_DEPENDENCY ${CMAKE_CURRENT_SOURCE_DIR}/org.darktable.darktable.appdata.xml.in
       DEPENDS ${PO_FILES}
@@ -104,7 +104,7 @@ if(NOT WIN32)
     add_custom_command(
       OUTPUT ${DARKTABLE_SHAREDIR}/metainfo/org.darktable.darktable.appdata.xml
       COMMAND ${CMAKE_COMMAND} -E make_directory ${DARKTABLE_SHAREDIR}/metainfo
-      COMMAND sh -c "${intltool_merge_BIN} --xml-style ${CMAKE_CURRENT_SOURCE_DIR}/../po ${CMAKE_CURRENT_SOURCE_DIR}/org.darktable.darktable.appdata.xml.in ${DARKTABLE_SHAREDIR}/metainfo/org.darktable.darktable.appdata.xml"
+      COMMAND sh -c "${intltool_merge_BIN} --xml-style \"${CMAKE_CURRENT_SOURCE_DIR}/../po\" \"${CMAKE_CURRENT_SOURCE_DIR}/org.darktable.darktable.appdata.xml.in\" \"${DARKTABLE_SHAREDIR}/metainfo/org.darktable.darktable.appdata.xml\""
       MAIN_DEPENDENCY ${CMAKE_CURRENT_SOURCE_DIR}/org.darktable.darktable.appdata.xml.in
       DEPENDS ${PO_FILES}
     )


### PR DESCRIPTION
Some build script is not escaped correctly causing build to fail when darktable source is placed in a path that contains space. If you clone on macOS, where the path starts with `/Volumes/Macintosh HD/`, build will be guaranteed to fail.