### PR TITLE
RFC compile time check on signal callback signature

### DIFF
--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -673,7 +673,6 @@ static gboolean _popup_button_release(GtkWidget *widget,
 
   return TRUE;
 }
-
 static gboolean _popup_button_press(GtkWidget *widget,
                                     GdkEventButton *event,
                                     gpointer user_data)
@@ -715,10 +714,10 @@ static gboolean _popup_button_press(GtkWidget *widget,
   return TRUE;
 }
 
-static void _window_show(GtkWidget *w, gpointer user_data)
+static void _window_show(GtkWidget *w, GtkWidget *area)
 {
   // make sure combo popup handles button release
-  gtk_grab_add(GTK_WIDGET(user_data));
+  gtk_grab_add(area);
 }
 
 static void _widget_leave(GtkEventControllerMotion *controller,
@@ -892,20 +891,17 @@ void dt_bauhaus_init()
                         | GDK_KEY_PRESS_MASK | GDK_LEAVE_NOTIFY_MASK
                         | darktable.gui->scroll_mask);
 
-  GObject *window = G_OBJECT(pop->window);
-  GObject *area = G_OBJECT(pop->area);
-
   gtk_widget_realize(pop->window);
   g_signal_connect(gtk_widget_get_window(pop->window),
                    "moved-to-rect", G_CALLBACK(_window_moved_to_rect), NULL);
-  g_signal_connect(window, "show", G_CALLBACK(_window_show), area);
-  g_signal_connect(window, "motion-notify-event", G_CALLBACK(_window_motion_notify), NULL);
-  g_signal_connect(area, "draw", G_CALLBACK(_popup_draw), NULL);
-  g_signal_connect(area, "leave-notify-event", G_CALLBACK(_popup_leave_notify), NULL);
-  g_signal_connect(area, "button-press-event", G_CALLBACK(_popup_button_press), NULL);
-  g_signal_connect(area, "button-release-event", G_CALLBACK (_popup_button_release), NULL);
-  g_signal_connect(area, "key-press-event", G_CALLBACK(_popup_key_press), NULL);
-  g_signal_connect(area, "scroll-event", G_CALLBACK(_popup_scroll), NULL);
+  g_signal_connect(pop->window, "show", G_CALLBACK(_window_show), pop->area);
+  g_signal_connect(pop->window, "motion-notify-event", G_CALLBACK(_window_motion_notify), NULL);
+  g_signal_connect(pop->area, "draw", G_CALLBACK(_popup_draw), NULL);
+  g_signal_connect(pop->area, "leave-notify-event", G_CALLBACK(_popup_leave_notify), NULL);
+  g_signal_connect(pop->area, "button-press-event", G_CALLBACK(_popup_button_press), NULL);
+  g_signal_connect(pop->area, "button-release-event", G_CALLBACK (_popup_button_release), NULL);
+  g_signal_connect(pop->area, "key-press-event", G_CALLBACK(_popup_key_press), NULL);
+  g_signal_connect(pop->area, "scroll-event", G_CALLBACK(_popup_scroll), NULL);
 
   dt_action_define(&darktable.control->actions_focus, NULL, N_("sliders"),
                    NULL, &_action_def_focus_slider);

--- a/src/bauhaus/bauhaus.h
+++ b/src/bauhaus/bauhaus.h
@@ -212,7 +212,7 @@ static inline void dt_bauhaus_widget_set_quad(GtkWidget *widget,
 {
   dt_bauhaus_widget_set_quad_paint(widget, paint, 0, NULL);
   dt_bauhaus_widget_set_quad_toggle(widget, toggle);
-  g_signal_connect(G_OBJECT(widget), "quad-pressed", G_CALLBACK(callback), self);
+  g_signal_connect(widget, "quad-pressed", G_CALLBACK(callback), self);
   if(tooltip) dt_bauhaus_widget_set_quad_tooltip(widget, tooltip);
 }
 // get the tooltip for widget or quad button:

--- a/src/common/camera_control.c
+++ b/src/common/camera_control.c
@@ -1677,7 +1677,7 @@ static void _camera_build_property_menu(CameraWidget *widget,
           /* construct menu item for property */
           gp_widget_get_name(child, &sk);
           GtkMenuItem *item = GTK_MENU_ITEM(gtk_menu_item_new_with_label(sk));
-          g_signal_connect(G_OBJECT(item), "activate", item_activate, user_data);
+          g_signal_connect(item, "activate", G_CALLBACK((void(*)(GtkMenuItem*,gpointer))item_activate), user_data);
           /* add submenu item to menu */
           gtk_menu_shell_append(GTK_MENU_SHELL(menu), GTK_WIDGET(item));
         }

--- a/src/control/crawler.c
+++ b/src/control/crawler.c
@@ -348,25 +348,24 @@ static void _delete_selected_rows(dt_control_crawler_gui_t *gui)
 
 
 static void _select_all_callback(GtkButton *button,
-                                 gpointer user_data)
+                                 dt_control_crawler_gui_t *gui)
 {
-  dt_control_crawler_gui_t *gui = (dt_control_crawler_gui_t *)user_data;
   GtkTreeSelection *selection = gtk_tree_view_get_selection(gui->tree);
   gtk_tree_selection_select_all(selection);
 }
 
 
-static void _select_none_callback(GtkButton *button, gpointer user_data)
+static void _select_none_callback(GtkButton *button,
+                                 dt_control_crawler_gui_t *gui)
 {
-  dt_control_crawler_gui_t *gui = (dt_control_crawler_gui_t *)user_data;
   GtkTreeSelection *selection = gtk_tree_view_get_selection(gui->tree);
   gtk_tree_selection_unselect_all(selection);
 }
 
 
-static void _select_invert_callback(GtkButton *button, gpointer user_data)
+static void _select_invert_callback(GtkButton *button,
+                                    dt_control_crawler_gui_t *gui)
 {
-  dt_control_crawler_gui_t *gui = (dt_control_crawler_gui_t *)user_data;
   GtkTreeSelection *selection = gtk_tree_view_get_selection(gui->tree);
 
   GtkTreeIter iter;
@@ -634,9 +633,8 @@ static void sync_oldest_to_newest(GtkTreeModel *model,
 }
 
 // overwrite database with xmp
-static void _reload_button_clicked(GtkButton *button, gpointer user_data)
+static void _reload_button_clicked(GtkButton *button, dt_control_crawler_gui_t *gui)
 {
-  dt_control_crawler_gui_t *gui = (dt_control_crawler_gui_t *)user_data;
   GtkTreeSelection *selection = gtk_tree_view_get_selection(gui->tree);
   gui->rows_to_remove = NULL;
   gtk_spinner_start(GTK_SPINNER(gui->spinner));
@@ -646,9 +644,8 @@ static void _reload_button_clicked(GtkButton *button, gpointer user_data)
 }
 
 // overwrite xmp with database
-void _overwrite_button_clicked(GtkButton *button, gpointer user_data)
+void _overwrite_button_clicked(GtkButton *button, dt_control_crawler_gui_t *gui)
 {
-  dt_control_crawler_gui_t *gui = (dt_control_crawler_gui_t *)user_data;
   GtkTreeSelection *selection = gtk_tree_view_get_selection(gui->tree);
   gui->rows_to_remove = NULL;
   gtk_spinner_start(GTK_SPINNER(gui->spinner));
@@ -658,9 +655,8 @@ void _overwrite_button_clicked(GtkButton *button, gpointer user_data)
 }
 
 // overwrite the oldest with the newest
-static void _newest_button_clicked(GtkButton *button, gpointer user_data)
+static void _newest_button_clicked(GtkButton *button, dt_control_crawler_gui_t *gui)
 {
-  dt_control_crawler_gui_t *gui = (dt_control_crawler_gui_t *)user_data;
   GtkTreeSelection *selection = gtk_tree_view_get_selection(gui->tree);
   gui->rows_to_remove = NULL;
   gtk_spinner_start(GTK_SPINNER(gui->spinner));
@@ -670,9 +666,8 @@ static void _newest_button_clicked(GtkButton *button, gpointer user_data)
 }
 
 // overwrite the newest with the oldest
-static void _oldest_button_clicked(GtkButton *button, gpointer user_data)
+static void _oldest_button_clicked(GtkButton *button, dt_control_crawler_gui_t *gui)
 {
-  dt_control_crawler_gui_t *gui = (dt_control_crawler_gui_t *)user_data;
   GtkTreeSelection *selection = gtk_tree_view_get_selection(gui->tree);
   gui->rows_to_remove = NULL;
   gtk_spinner_start(GTK_SPINNER(gui->spinner));
@@ -810,19 +805,19 @@ void dt_control_crawler_show_image_list(GList *images)
   GtkWidget *select_all = gtk_button_new_with_label(_("select all"));
   GtkWidget *select_none = gtk_button_new_with_label(_("select none"));
   GtkWidget *select_invert = gtk_button_new_with_label(_("invert selection"));
-  g_signal_connect(select_all, "clicked", G_CALLBACK(_select_all_callback), gui);
-  g_signal_connect(select_none, "clicked", G_CALLBACK(_select_none_callback), gui);
-  g_signal_connect(select_invert, "clicked", G_CALLBACK(_select_invert_callback), gui);
+  g_signal_connect(GTK_BUTTON(select_all), "clicked", G_CALLBACK(_select_all_callback), gui);
+  g_signal_connect(GTK_BUTTON(select_none), "clicked", G_CALLBACK(_select_none_callback), gui);
+  g_signal_connect(GTK_BUTTON(select_invert), "clicked", G_CALLBACK(_select_invert_callback), gui);
 
   GtkWidget *label = gtk_label_new_with_mnemonic(_("on the selection:"));
   GtkWidget *reload_button = gtk_button_new_with_label(_("keep the XMP edit"));
   GtkWidget *overwrite_button = gtk_button_new_with_label(_("keep the database edit"));
   GtkWidget *newest_button = gtk_button_new_with_label(_("keep the newest edit"));
   GtkWidget *oldest_button = gtk_button_new_with_label(_("keep the oldest edit"));
-  g_signal_connect(reload_button, "clicked", G_CALLBACK(_reload_button_clicked), gui);
-  g_signal_connect(overwrite_button, "clicked", G_CALLBACK(_overwrite_button_clicked), gui);
-  g_signal_connect(newest_button, "clicked", G_CALLBACK(_newest_button_clicked), gui);
-  g_signal_connect(oldest_button, "clicked", G_CALLBACK(_oldest_button_clicked), gui);
+  g_signal_connect(GTK_BUTTON(reload_button), "clicked", G_CALLBACK(_reload_button_clicked), gui);
+  g_signal_connect(GTK_BUTTON(overwrite_button), "clicked", G_CALLBACK(_overwrite_button_clicked), gui);
+  g_signal_connect(GTK_BUTTON(newest_button), "clicked", G_CALLBACK(_newest_button_clicked), gui);
+  g_signal_connect(GTK_BUTTON(oldest_button), "clicked", G_CALLBACK(_oldest_button_clicked), gui);
 
   /* Feedback spinner in case synch happens over network and stales */
   gui->spinner = gtk_spinner_new();

--- a/src/control/signal.c
+++ b/src/control/signal.c
@@ -93,6 +93,7 @@ static void _image_geotag_destroy_callback(gpointer instance, gpointer imgs, con
     imgs = NULL;
   }
 }
+#define G_CALLBACK(f) ((GCallback) (f))
 
 static dt_signal_description _signal_description[DT_SIGNAL_COUNT] = {
   /* Global signals */
@@ -241,7 +242,7 @@ dt_control_signal_t *dt_control_signal_init()
         _signal_description[k].n_params, _signal_description[k].param_types);
     if(_signal_description[k].destructor)
     {
-      g_signal_connect_after(G_OBJECT(ctlsig->sink), _signal_description[k].name,
+      g_signal_connect_after(ctlsig->sink, _signal_description[k].name,
                              _signal_description[k].destructor, NULL);
     }
   }
@@ -394,7 +395,7 @@ void dt_control_signal_connect(const dt_control_signal_t *ctlsig, dt_signal_t si
 {
   _print_trace(signal, DT_DEBUG_SIGNAL_ACT_CONNECT, "connect");
 
-  g_signal_connect(G_OBJECT(ctlsig->sink), _signal_description[signal].name, G_CALLBACK(cb), user_data);
+  g_signal_connect_data(ctlsig->sink, _signal_description[signal].name, G_CALLBACK(cb), user_data, NULL, 0);
 }
 
 void dt_control_signal_disconnect(const struct dt_control_signal_t *ctlsig, GCallback cb, gpointer user_data)

--- a/src/develop/blend.h
+++ b/src/develop/blend.h
@@ -260,7 +260,7 @@ typedef struct dt_iop_gui_blendif_channel_t
   dt_develop_blendif_channels_t param_channels[2];
   dt_dev_pixelpipe_display_mask_t display_channel;
   void (*scale_print)(float value, float boost_factor, char *string, int n);
-  int (*altdisplay)(GtkWidget *, dt_iop_module_t *, int);
+  int (*altdisplay)(GtkDarktableGradientSlider *, dt_iop_module_t *, int);
   char *name;
 } dt_iop_gui_blendif_channel_t;
 

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -476,7 +476,7 @@ static void _header_menu_deactivate_callback(GtkMenuShell *menushell,
   dt_iop_show_hide_header_buttons(module, NULL, FALSE, FALSE);
 }
 
-static void _gui_delete_callback(GtkButton *button, dt_iop_module_t *module)
+static void _gui_delete_callback(GtkWidget *button, dt_iop_module_t *module)
 {
   dt_develop_t *dev = module->dev;
 
@@ -628,7 +628,7 @@ dt_iop_module_t *dt_iop_gui_get_next_visible_module(const dt_iop_module_t *modul
   return next;
 }
 
-static void _gui_movedown_callback(GtkButton *button, dt_iop_module_t *module)
+static void _gui_movedown_callback(GtkWidget *button, dt_iop_module_t *module)
 {
   dt_ioppr_check_iop_order(module->dev, 0, "dt_iop_gui_movedown_callback begin");
 
@@ -663,7 +663,7 @@ static void _gui_movedown_callback(GtkButton *button, dt_iop_module_t *module)
   DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_DEVELOP_MODULE_MOVED);
 }
 
-static void _gui_moveup_callback(GtkButton *button, dt_iop_module_t *module)
+static void _gui_moveup_callback(GtkWidget *button, dt_iop_module_t *module)
 {
   dt_ioppr_check_iop_order(module->dev, 0, "dt_iop_gui_moveup_callback begin");
 
@@ -795,7 +795,7 @@ dt_iop_module_t *dt_iop_gui_duplicate(dt_iop_module_t *base,
   return module;
 }
 
-static void _gui_copy_callback(GtkButton *button, dt_iop_module_t *base)
+static void _gui_copy_callback(GtkWidget *button, dt_iop_module_t *base)
 {
   dt_iop_module_t *module = dt_iop_gui_duplicate(base, FALSE);
 
@@ -806,7 +806,7 @@ static void _gui_copy_callback(GtkButton *button, dt_iop_module_t *base)
     dt_iop_gui_rename_module(module);
 }
 
-static void _gui_duplicate_callback(GtkButton *button, dt_iop_module_t *base)
+static void _gui_duplicate_callback(GtkWidget *button, dt_iop_module_t *base)
 {
   dt_iop_module_t *module = dt_iop_gui_duplicate(base, TRUE);
 
@@ -914,7 +914,7 @@ void dt_iop_gui_rename_module(dt_iop_module_t *module)
   g_signal_connect(entry, "focus-out-event",
                    G_CALLBACK(_rename_module_key_press), module);
   g_signal_connect(entry, "style-updated",
-                   G_CALLBACK(_rename_module_resize), module);
+                   G_CALLBACK((GtkCallback)_rename_module_resize), (gpointer)module);
   g_signal_connect(entry, "changed",
                    G_CALLBACK(_rename_module_resize), module);
   g_signal_connect(entry, "enter-notify-event",
@@ -927,7 +927,7 @@ void dt_iop_gui_rename_module(dt_iop_module_t *module)
   gtk_widget_grab_focus(entry);
 }
 
-static void _gui_rename_callback(GtkButton *button,
+static void _gui_rename_callback(GtkWidget *button,
                                  dt_iop_module_t *module)
 {
   dt_iop_gui_rename_module(module);
@@ -978,7 +978,7 @@ static gboolean _gui_multiinstance_callback(GtkButton *button,
   if(event && event->button == GDK_BUTTON_SECONDARY)
   {
     if(!(module->flags() & IOP_FLAGS_ONE_INSTANCE))
-      _gui_copy_callback(button, module);
+      _gui_copy_callback(NULL, module);
     return TRUE;
   }
   else if(event && event->button == GDK_BUTTON_MIDDLE)
@@ -994,46 +994,46 @@ static gboolean _gui_multiinstance_callback(GtkButton *button,
 
   item = gtk_menu_item_new_with_label(_("new instance"));
   // gtk_widget_set_tooltip_text(item, _("add a new instance of this module to the pipe"));
-  g_signal_connect(G_OBJECT(item), "activate",
+  g_signal_connect(item, "activate",
                    G_CALLBACK(_gui_copy_callback), module);
   gtk_widget_set_sensitive(item, multi_show.new);
   gtk_menu_shell_append(menu, item);
 
   item = gtk_menu_item_new_with_label(_("duplicate instance"));
   // gtk_widget_set_tooltip_text(item, _("add a copy of this instance to the pipe"));
-  g_signal_connect(G_OBJECT(item), "activate",
+  g_signal_connect(item, "activate",
                    G_CALLBACK(_gui_duplicate_callback), module);
   gtk_widget_set_sensitive(item, multi_show.new);
   gtk_menu_shell_append(menu, item);
 
   item = gtk_menu_item_new_with_label(_("move up"));
   // gtk_widget_set_tooltip_text(item, _("move this instance up"));
-  g_signal_connect(G_OBJECT(item), "activate",
+  g_signal_connect(item, "activate",
                    G_CALLBACK(_gui_moveup_callback), module);
   gtk_widget_set_sensitive(item, multi_show.up);
   gtk_menu_shell_append(menu, item);
 
   item = gtk_menu_item_new_with_label(_("move down"));
   // gtk_widget_set_tooltip_text(item, _("move this instance down"));
-  g_signal_connect(G_OBJECT(item), "activate",
+  g_signal_connect(item, "activate",
                    G_CALLBACK(_gui_movedown_callback), module);
   gtk_widget_set_sensitive(item, multi_show.down);
   gtk_menu_shell_append(menu, item);
 
   item = gtk_menu_item_new_with_label(_("delete"));
   // gtk_widget_set_tooltip_text(item, _("delete this instance"));
-  g_signal_connect(G_OBJECT(item), "activate",
+  g_signal_connect(item, "activate",
                    G_CALLBACK(_gui_delete_callback), module);
   gtk_widget_set_sensitive(item, multi_show.close);
   gtk_menu_shell_append(menu, item);
 
   gtk_menu_shell_append(GTK_MENU_SHELL(menu), gtk_separator_menu_item_new());
   item = gtk_menu_item_new_with_label(_("rename"));
-  g_signal_connect(G_OBJECT(item), "activate",
+  g_signal_connect(item, "activate",
                    G_CALLBACK(_gui_rename_callback), module);
   gtk_menu_shell_append(menu, item);
 
-  g_signal_connect(G_OBJECT(menu), "deactivate",
+  g_signal_connect(menu, "deactivate",
                    G_CALLBACK(_header_menu_deactivate_callback), module);
 
   dt_gui_menu_popup(GTK_MENU(menu), GTK_WIDGET(button),
@@ -2311,7 +2311,7 @@ static gboolean _presets_popup_callback(GtkButton *button,
 
   GtkMenu *menu = dt_gui_presets_popup_menu_show_for_module(module);
 
-  g_signal_connect(G_OBJECT(menu), "deactivate",
+  g_signal_connect(GTK_MENU_SHELL(menu), "deactivate",
                    G_CALLBACK(_header_menu_deactivate_callback), module);
 
   dt_gui_menu_popup(menu,
@@ -2531,9 +2531,8 @@ void dt_iop_gui_update_expanded(dt_iop_module_t *module)
 
 static gboolean _iop_plugin_body_button_press(GtkWidget *w,
                                               GdkEventButton *e,
-                                              gpointer user_data)
+                                              dt_iop_module_t *module)
 {
-  dt_iop_module_t *module = (dt_iop_module_t *)user_data;
   if(e->button == GDK_BUTTON_PRIMARY)
   {
     dt_iop_request_focus(module);
@@ -2550,12 +2549,10 @@ static gboolean _iop_plugin_body_button_press(GtkWidget *w,
 
 static gboolean _iop_plugin_header_button_release(GtkWidget *w,
                                                   GdkEventButton *e,
-                                                  gpointer user_data)
+                                                  dt_iop_module_t *module)
 {
   if(e->type == GDK_2BUTTON_PRESS || e->type == GDK_3BUTTON_PRESS) return TRUE;
   if(GTK_IS_BUTTON(gtk_get_event_widget((GdkEvent*)e))) return FALSE;
-
-  dt_iop_module_t *module = (dt_iop_module_t *)user_data;
 
   if(e->button == GDK_BUTTON_PRIMARY)
   {
@@ -2748,7 +2745,7 @@ gboolean dt_iop_show_hide_header_buttons(dt_iop_module_t *module,
       GtkWidget *space = gtk_drawing_area_new();
       gtk_box_pack_end(GTK_BOX(header), space, TRUE, TRUE, 0);
       gtk_widget_show(space);
-      g_signal_connect(G_OBJECT(space), "size-allocate",
+      g_signal_connect(space, "size-allocate",
                        G_CALLBACK(_header_size_callback), header);
     }
   }
@@ -2851,9 +2848,9 @@ void dt_iop_add_remove_mask_indicator(dt_iop_module_t *module, gboolean add)
   {
     module->mask_indicator = dtgtk_togglebutton_new(dtgtk_cairo_paint_showmask, 0, NULL);
     dt_gui_add_class(module->mask_indicator, "dt_transparent_background");
-    g_signal_connect(G_OBJECT(module->mask_indicator), "toggled",
+    g_signal_connect(GTK_TOGGLE_BUTTON(module->mask_indicator), "toggled",
                      G_CALLBACK(_display_mask_indicator_callback), module);
-    g_signal_connect(G_OBJECT(module->mask_indicator), "query-tooltip",
+    g_signal_connect(module->mask_indicator, "query-tooltip",
                      G_CALLBACK(_mask_indicator_tooltip), module);
     gtk_widget_set_has_tooltip(module->mask_indicator, TRUE);
     gtk_widget_set_sensitive(module->mask_indicator, module->enabled);
@@ -2901,10 +2898,8 @@ gboolean _iop_tooltip_callback(GtkWidget *widget,
                                const gint y,
                                const gboolean keyboard_mode,
                                GtkTooltip *tooltip,
-                               gpointer user_data)
+                               dt_iop_module_t *module)
 {
-  dt_iop_module_t *module = (dt_iop_module_t *)user_data;
-
   const char **des = module->description(module);
 
   if(!des) return FALSE;
@@ -2953,7 +2948,7 @@ gboolean _iop_tooltip_callback(GtkWidget *widget,
 
   gtk_box_pack_start(GTK_BOX(vbox), grid, FALSE, FALSE, 0);
 
-  g_signal_connect(G_OBJECT(vbox), "size-allocate",
+  g_signal_connect(vbox, "size-allocate",
                    G_CALLBACK(_iop_tooltip_reposition), module->header);
 
   return dt_shortcut_tooltip_callback(widget, x, y, keyboard_mode, tooltip, vbox);
@@ -2965,7 +2960,7 @@ GtkWidget *dt_iop_gui_header_button(dt_iop_module_t *module,
                                     GtkWidget *header)
 {
   GtkWidget *button;
-  gpointer callback = _gui_multiinstance_callback;
+  gboolean(*callback)(GtkButton*, GdkEventButton*, dt_iop_module_t*) = _gui_multiinstance_callback;
 
   if(element == DT_ACTION_ELEMENT_ENABLE)
   {
@@ -2981,7 +2976,7 @@ GtkWidget *dt_iop_gui_header_button(dt_iop_module_t *module,
     gtk_widget_set_tooltip_text(button, tooltip);
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(button), module->enabled);
 
-    g_signal_connect(button, "toggled", G_CALLBACK(_gui_off_callback), module);
+    g_signal_connect(GTK_TOGGLE_BUTTON(button), "toggled", G_CALLBACK(_gui_off_callback), module);
     gtk_box_pack_start(GTK_BOX(header), button, FALSE, FALSE, 0);
   }
   else
@@ -3005,7 +3000,7 @@ GtkWidget *dt_iop_gui_header_button(dt_iop_module_t *module,
   g_signal_connect(button, "enter-notify-event",
                    G_CALLBACK(_header_enter_notify_callback),
                    GINT_TO_POINTER(element));
-  g_signal_connect(button, "button-press-event", G_CALLBACK(callback), module);
+  g_signal_connect(GTK_BUTTON(button), "button-press-event", G_CALLBACK(callback), module);
   dt_action_define(&module->so->actions, NULL, NULL, button, NULL);
   gtk_widget_show(button);
 
@@ -3122,21 +3117,21 @@ void dt_iop_gui_set_expander(dt_iop_module_t *module)
   module->header = header;
 
   /* setup the header box */
-  g_signal_connect(G_OBJECT(header_evb), "button-release-event",
+  g_signal_connect(header_evb, "button-release-event",
                    G_CALLBACK(_iop_plugin_header_button_release), module);
   gtk_widget_add_events(header_evb, GDK_POINTER_MOTION_MASK);
-  g_signal_connect(G_OBJECT(header_evb), "enter-notify-event",
+  g_signal_connect(header_evb, "enter-notify-event",
                    G_CALLBACK(_header_motion_notify_show_callback), module);
-  g_signal_connect(G_OBJECT(header_evb), "leave-notify-event",
+  g_signal_connect(header_evb, "leave-notify-event",
                    G_CALLBACK(_header_motion_notify_hide_callback), module);
 
   /* connect mouse button callbacks for focus and presets */
-  g_signal_connect(G_OBJECT(body_evb), "button-press-event",
+  g_signal_connect(body_evb, "button-press-event",
                    G_CALLBACK(_iop_plugin_body_button_press), module);
   gtk_widget_add_events(body_evb, GDK_POINTER_MOTION_MASK);
-  g_signal_connect(G_OBJECT(body_evb), "enter-notify-event",
+  g_signal_connect(body_evb, "enter-notify-event",
                    G_CALLBACK(_header_motion_notify_show_callback), module);
-  g_signal_connect(G_OBJECT(body_evb), "leave-notify-event",
+  g_signal_connect(body_evb, "leave-notify-event",
                    G_CALLBACK(_header_motion_notify_hide_callback), module);
 
   /*

--- a/src/develop/imageop_gui.c
+++ b/src/develop/imageop_gui.c
@@ -268,7 +268,7 @@ GtkWidget *dt_iop_togglebutton_new(dt_iop_module_t *self, const char *section, c
                                    DTGTKCairoPaintIconFunc paint, GtkWidget *box)
 {
   GtkWidget *w = dtgtk_togglebutton_new(paint, 0, NULL);
-  g_signal_connect(G_OBJECT(w), "button-press-event", callback, self);
+  g_signal_connect(w, "button-press-event", G_CALLBACK((gboolean(*)(GtkWidget*,GdkEventButton*, dt_iop_module_t*))callback), self);
 
   if(!ctrl_label)
     gtk_widget_set_tooltip_text(w, _(label));
@@ -304,7 +304,7 @@ GtkWidget *dt_iop_button_new(dt_iop_module_t *self, const gchar *label,
     gtk_label_set_ellipsize(GTK_LABEL(gtk_bin_get_child(GTK_BIN(button))), PANGO_ELLIPSIZE_END);
   }
 
-  g_signal_connect(G_OBJECT(button), "clicked", callback, (gpointer)self);
+  g_signal_connect(button, "clicked", G_CALLBACK((GtkCallback)callback), (gpointer)self);
 
   dt_action_t *ac = dt_action_define_iop(self, NULL, label, button, &dt_action_def_button);
     dt_shortcut_register(ac, 0, 0, accel_key, mods);

--- a/src/dtgtk/culling.c
+++ b/src/dtgtk/culling.c
@@ -540,11 +540,9 @@ static void _toggle_zoom_all(dt_culling_t *table,
 }
 
 static gboolean _event_scroll(GtkWidget *widget,
-                              GdkEvent *event,
-                              gpointer user_data)
+                              GdkEventScroll *e,
+                              dt_culling_t *table)
 {
-  GdkEventScroll *e = (GdkEventScroll *)event;
-  dt_culling_t *table = (dt_culling_t *)user_data;
   int delta;
 
   if(dt_gui_get_scroll_unit_delta(e, &delta))
@@ -583,9 +581,8 @@ static gboolean _event_draw(GtkWidget *widget, cairo_t *cr, gpointer user_data)
 
 static gboolean _event_leave_notify(GtkWidget *widget,
                                     GdkEventCrossing *event,
-                                    gpointer user_data)
+                                    dt_culling_t *table)
 {
-  dt_culling_t *table = (dt_culling_t *)user_data;
   // if the leaving cause is the hide of the widget, no mouseover change
   if(!gtk_widget_is_visible(widget))
   {
@@ -607,7 +604,7 @@ static gboolean _event_leave_notify(GtkWidget *widget,
 
 static gboolean _event_enter_notify(GtkWidget *widget,
                                     GdkEventCrossing *event,
-                                    gpointer user_data)
+                                    dt_culling_t *table)
 {
   // we only handle the case where we enter thumbtable from an
   // inferior (a thumbnail) this is when the mouse enter an "empty"
@@ -620,10 +617,8 @@ static gboolean _event_enter_notify(GtkWidget *widget,
 
 static gboolean _event_button_press(GtkWidget *widget,
                                     GdkEventButton *event,
-                                    gpointer user_data)
+                                    dt_culling_t *table)
 {
-  dt_culling_t *table = (dt_culling_t *)user_data;
-
   if(event->button == GDK_BUTTON_PRIMARY && event->type == GDK_BUTTON_PRESS)
   {
     // make sure any edition field loses the focus
@@ -741,9 +736,8 @@ static gboolean _event_motion_notify(GtkWidget *widget,
 
 static gboolean _event_button_release(GtkWidget *widget,
                                       GdkEventButton *event,
-                                      gpointer user_data)
+                                      dt_culling_t *table)
 {
-  dt_culling_t *table = (dt_culling_t *)user_data;
   table->panning = FALSE;
 
   const dt_imgid_t overid = dt_control_get_mouse_over_id();
@@ -965,19 +959,19 @@ dt_culling_t *dt_culling_new(dt_culling_mode_t mode)
   gtk_widget_set_app_paintable(table->widget, TRUE);
   gtk_widget_set_can_focus(table->widget, TRUE);
 
-  g_signal_connect(G_OBJECT(table->widget), "scroll-event",
+  g_signal_connect(table->widget, "scroll-event",
                    G_CALLBACK(_event_scroll), table);
-  g_signal_connect(G_OBJECT(table->widget), "draw",
+  g_signal_connect(table->widget, "draw",
                    G_CALLBACK(_event_draw), table);
-  g_signal_connect(G_OBJECT(table->widget), "leave-notify-event",
+  g_signal_connect(table->widget, "leave-notify-event",
                    G_CALLBACK(_event_leave_notify), table);
-  g_signal_connect(G_OBJECT(table->widget), "enter-notify-event",
+  g_signal_connect(table->widget, "enter-notify-event",
                    G_CALLBACK(_event_enter_notify), table);
-  g_signal_connect(G_OBJECT(table->widget), "button-press-event",
+  g_signal_connect(table->widget, "button-press-event",
                    G_CALLBACK(_event_button_press), table);
-  g_signal_connect(G_OBJECT(table->widget), "motion-notify-event",
+  g_signal_connect(table->widget, "motion-notify-event",
                    G_CALLBACK(_event_motion_notify), table);
-  g_signal_connect(G_OBJECT(table->widget), "button-release-event",
+  g_signal_connect(table->widget, "button-release-event",
                    G_CALLBACK(_event_button_release), table);
 
   // we register globals signals

--- a/src/dtgtk/expander.c
+++ b/src/dtgtk/expander.c
@@ -167,12 +167,12 @@ static gboolean _expander_scroll(GtkWidget *widget, GdkFrameClock *frame_clock, 
   return G_SOURCE_REMOVE;
 }
 
-static void _expander_resize(GtkWidget *widget, GdkRectangle *allocation, gpointer user_data)
+static void _expander_resize(GtkWidget *widget, GdkRectangle *allocation, GtkWidget *frame)
 {
 
   if(widget == _scroll_widget ||
      _drop_widget ? widget != _drop_widget :
-     ((!(gtk_widget_get_state_flags(user_data) & GTK_STATE_FLAG_SELECTED) ||
+     ((!(gtk_widget_get_state_flags(frame) & GTK_STATE_FLAG_SELECTED) ||
        gtk_widget_get_allocated_height(widget) == _start_pos.height) &&
       (!darktable.lib->gui_module || darktable.lib->gui_module->expander != widget)))
     return;
@@ -288,7 +288,7 @@ GtkWidget *dtgtk_expander_new(GtkWidget *header, GtkWidget *body)
   g_signal_connect(expander->header_evb, "drag-begin", G_CALLBACK(_expander_drag_begin), NULL);
   g_signal_connect(expander->header_evb, "drag-end", G_CALLBACK(_expander_drag_end), NULL);
   g_signal_connect(expander, "drag-leave", G_CALLBACK(_expander_drag_leave), NULL);
-  g_signal_connect(expander, "size-allocate", G_CALLBACK(_expander_resize), frame);
+  g_signal_connect(GTK_WIDGET(expander), "size-allocate", G_CALLBACK(_expander_resize), frame);
 
   return GTK_WIDGET(expander);
 }

--- a/src/dtgtk/range.c
+++ b/src/dtgtk/range.c
@@ -115,10 +115,9 @@ typedef enum _range_signal
 } _range_signal;
 static guint _signals[LAST_SIGNAL] = { 0 };
 
-static void _dt_pref_changed(gpointer instance, gpointer user_data)
+static void _dt_pref_changed(GtkWidget *widget, GtkDarktableRangeSelect *range)
 {
-  if(!user_data) return;
-  GtkDarktableRangeSelect *range = (GtkDarktableRangeSelect *)user_data;
+  if(!range) return;
 
   GtkStyleContext *context = gtk_widget_get_style_context(GTK_WIDGET(range->band));
   GtkStateFlags state = gtk_widget_get_state_flags(range->band);
@@ -752,7 +751,7 @@ static void _popup_date_tree_row_activated(GtkTreeView *self, GtkTreePath *path,
   gtk_widget_activate(pop->ok_btn);
 }
 
-static void _popup_date_tree_selection_change(GtkTreeView *self, GtkDarktableRangeSelect *range)
+static void _popup_date_tree_selection_change(GtkTreeSelection *self, GtkDarktableRangeSelect *range)
 {
   if(!range->date_popup || range->date_popup->internal_change) return;
   _range_date_popup *pop = range->date_popup;
@@ -937,7 +936,7 @@ static void _popup_date_init(GtkDarktableRangeSelect *range)
   // the type of date selection
   pop->type = dt_bauhaus_combobox_new(NULL);
   dt_bauhaus_widget_set_label(pop->type, NULL, _("date type"));
-  g_signal_connect(G_OBJECT(pop->type), "value-changed", G_CALLBACK(_popup_date_type_changed), range);
+  g_signal_connect(pop->type, "value-changed", G_CALLBACK(_popup_date_type_changed), range);
 
   // the label to explain the reference date for relative values
   pop->relative_label = gtk_label_new("");
@@ -953,8 +952,8 @@ static void _popup_date_init(GtkDarktableRangeSelect *range)
   gtk_widget_set_no_show_all(pop->calendar, TRUE);
   gtk_widget_set_tooltip_text(pop->calendar, _("click to select date\n"
                                                "double-click to use the date directly"));
-  g_signal_connect(G_OBJECT(pop->calendar), "day_selected", G_CALLBACK(_popup_date_changed), range);
-  g_signal_connect(G_OBJECT(pop->calendar), "day_selected-double-click",
+  g_signal_connect(pop->calendar, "day_selected", G_CALLBACK(_popup_date_changed), range);
+  g_signal_connect(pop->calendar, "day_selected-double-click",
                    G_CALLBACK(_popup_date_day_selected_2click), range);
 
   // the relative date box
@@ -966,7 +965,7 @@ static void _popup_date_init(GtkDarktableRangeSelect *range)
   pop->years = gtk_entry_new();
   gtk_entry_set_width_chars(GTK_ENTRY(pop->years), 3);
   gtk_widget_set_halign(pop->years, GTK_ALIGN_START);
-  g_signal_connect(G_OBJECT(pop->years), "changed", G_CALLBACK(_popup_date_changed), range);
+  g_signal_connect(pop->years, "changed", G_CALLBACK(_popup_date_changed), range);
   gtk_grid_attach(GTK_GRID(pop->relative_date_box), pop->years, 1, 0, 1, 1);
   lb = gtk_label_new(_("months: "));
   gtk_label_set_xalign(GTK_LABEL(lb), 1.0);
@@ -974,7 +973,7 @@ static void _popup_date_init(GtkDarktableRangeSelect *range)
   pop->months = gtk_entry_new();
   gtk_entry_set_width_chars(GTK_ENTRY(pop->months), 3);
   gtk_widget_set_halign(pop->months, GTK_ALIGN_START);
-  g_signal_connect(G_OBJECT(pop->months), "changed", G_CALLBACK(_popup_date_changed), range);
+  g_signal_connect(pop->months, "changed", G_CALLBACK(_popup_date_changed), range);
   gtk_grid_attach(GTK_GRID(pop->relative_date_box), pop->months, 1, 1, 1, 1);
   lb = gtk_label_new(_("days: "));
   gtk_label_set_xalign(GTK_LABEL(lb), 1.0);
@@ -982,7 +981,7 @@ static void _popup_date_init(GtkDarktableRangeSelect *range)
   pop->days = gtk_entry_new();
   gtk_entry_set_width_chars(GTK_ENTRY(pop->days), 3);
   gtk_widget_set_halign(pop->days, GTK_ALIGN_START);
-  g_signal_connect(G_OBJECT(pop->days), "changed", G_CALLBACK(_popup_date_changed), range);
+  g_signal_connect(pop->days, "changed", G_CALLBACK(_popup_date_changed), range);
   gtk_grid_attach(GTK_GRID(pop->relative_date_box), pop->days, 1, 2, 1, 1);
   gtk_widget_show_all(pop->relative_date_box);
   gtk_widget_set_no_show_all(pop->relative_date_box, TRUE);
@@ -993,13 +992,13 @@ static void _popup_date_init(GtkDarktableRangeSelect *range)
 
   pop->hours = gtk_entry_new();
   gtk_entry_set_width_chars(GTK_ENTRY(pop->hours), 2);
-  g_signal_connect(G_OBJECT(pop->hours), "changed", G_CALLBACK(_popup_date_changed), range);
+  g_signal_connect(pop->hours, "changed", G_CALLBACK(_popup_date_changed), range);
   pop->minutes = gtk_entry_new();
   gtk_entry_set_width_chars(GTK_ENTRY(pop->minutes), 2);
-  g_signal_connect(G_OBJECT(pop->minutes), "changed", G_CALLBACK(_popup_date_changed), range);
+  g_signal_connect(pop->minutes, "changed", G_CALLBACK(_popup_date_changed), range);
   pop->seconds = gtk_entry_new();
   gtk_entry_set_width_chars(GTK_ENTRY(pop->seconds), 2);
-  g_signal_connect(G_OBJECT(pop->seconds), "changed", G_CALLBACK(_popup_date_changed), range);
+  g_signal_connect(pop->seconds, "changed", G_CALLBACK(_popup_date_changed), range);
 
   // the treeview
   GtkTreeModel *model = GTK_TREE_MODEL(gtk_tree_store_new(DATETIME_NUM_COLS, G_TYPE_STRING, G_TYPE_UINT,
@@ -1008,8 +1007,8 @@ static void _popup_date_init(GtkDarktableRangeSelect *range)
   gtk_widget_set_tooltip_text(pop->calendar, _("click to select date\n"
                                                "double-click to use the date directly"));
   gtk_tree_view_set_headers_visible(GTK_TREE_VIEW(pop->treeview), FALSE);
-  g_signal_connect(G_OBJECT(pop->treeview), "row-activated", G_CALLBACK(_popup_date_tree_row_activated), range);
-  g_signal_connect(G_OBJECT(gtk_tree_view_get_selection(GTK_TREE_VIEW(pop->treeview))), "changed",
+  g_signal_connect(pop->treeview, "row-activated", G_CALLBACK(_popup_date_tree_row_activated), range);
+  g_signal_connect(gtk_tree_view_get_selection(GTK_TREE_VIEW(pop->treeview)), "changed",
                    G_CALLBACK(_popup_date_tree_selection_change), range);
 
   GtkTreeViewColumn *col = gtk_tree_view_column_new();
@@ -1025,10 +1024,10 @@ static void _popup_date_init(GtkDarktableRangeSelect *range)
   pop->now_btn = gtk_button_new_with_label(_("now"));
   gtk_widget_set_no_show_all(pop->now_btn, TRUE);
   gtk_widget_set_tooltip_text(pop->now_btn, _("set the value to always match current datetime"));
-  g_signal_connect(G_OBJECT(pop->now_btn), "clicked", G_CALLBACK(_popup_date_now_clicked), range);
+  g_signal_connect(pop->now_btn, "clicked", G_CALLBACK(_popup_date_now_clicked), range);
   pop->ok_btn = gtk_button_new_with_label(_("apply"));
   gtk_widget_set_tooltip_text(pop->ok_btn, _("set the range bound with this value"));
-  g_signal_connect(G_OBJECT(pop->ok_btn), "clicked", G_CALLBACK(_popup_date_ok_clicked), range);
+  g_signal_connect(pop->ok_btn, "clicked", G_CALLBACK(_popup_date_ok_clicked), range);
 
   GtkWidget *time = dt_gui_hbox(pop->hours, gtk_label_new(" : "), pop->minutes, gtk_label_new(" : "), pop->seconds);
   gtk_widget_set_halign(time, GTK_ALIGN_CENTER);
@@ -1045,9 +1044,8 @@ static void _popup_date_init(GtkDarktableRangeSelect *range)
   gtk_container_add(GTK_CONTAINER(pop->popup), vbox);
 }
 
-static void _popup_item_activate(GtkWidget *w, gpointer user_data)
+static void _popup_item_activate(GtkWidget *w, GtkDarktableRangeSelect *range)
 {
-  GtkDarktableRangeSelect *range = (GtkDarktableRangeSelect *)user_data;
   // retrieve block and source values
   GtkWidget *source = GTK_WIDGET(g_object_get_data(G_OBJECT(w), "source_widget"));
   _range_block *blo = (_range_block *)g_object_get_data(G_OBJECT(w), "range_block");
@@ -1095,7 +1093,7 @@ static GtkWidget *_popup_get_numeric_menu(GtkDarktableRangeSelect *range, GtkWid
     g_free(txt);
     g_object_set_data(G_OBJECT(smt), "range_block", blo);
     g_object_set_data(G_OBJECT(smt), "source_widget", w);
-    g_signal_connect(G_OBJECT(smt), "activate", G_CALLBACK(_popup_item_activate), range);
+    g_signal_connect(smt, "activate", G_CALLBACK(_popup_item_activate), range);
 
     gtk_menu_shell_append(pop, smt);
     nb++;
@@ -1122,7 +1120,7 @@ static GtkWidget *_popup_get_numeric_menu(GtkDarktableRangeSelect *range, GtkWid
     g_free(txt);
     g_object_set_data(G_OBJECT(smt), "range_block", blo);
     g_object_set_data(G_OBJECT(smt), "source_widget", w);
-    g_signal_connect(G_OBJECT(smt), "activate", G_CALLBACK(_popup_item_activate), range);
+    g_signal_connect(smt, "activate", G_CALLBACK(_popup_item_activate), range);
 
     gtk_menu_shell_append(pop, smt);
   }
@@ -1160,9 +1158,8 @@ static void _popup_show(GtkDarktableRangeSelect *range, GtkWidget *w)
   }
 }
 
-static gboolean _event_entry_press(GtkWidget *w, GdkEventButton *e, gpointer user_data)
+static gboolean _event_entry_press(GtkWidget *w, GdkEventButton *e, GtkDarktableRangeSelect *range)
 {
-  GtkDarktableRangeSelect *range = (GtkDarktableRangeSelect *)user_data;
   if(e->button == GDK_BUTTON_SECONDARY)
   {
     _popup_show(range, w);
@@ -1171,18 +1168,17 @@ static gboolean _event_entry_press(GtkWidget *w, GdkEventButton *e, gpointer use
   return FALSE;
 }
 
-static void _event_entry_activated(GtkWidget *entry, gpointer user_data)
+static void _event_entry_activated(GtkWidget *entry, GtkDarktableRangeSelect *range)
 {
-  GtkDarktableRangeSelect *range = (GtkDarktableRangeSelect *)user_data;
   _range_bound bound = BOUND_MIN;
   if(entry == range->entry_max) bound = BOUND_MAX;
 
   _bound_change(range, gtk_entry_get_text(GTK_ENTRY(entry)), bound);
 }
 
-static gboolean _event_entry_focus_out(GtkWidget *entry, GdkEventFocus *event, gpointer user_data)
+static gboolean _event_entry_focus_out(GtkWidget *entry, GdkEventFocus *event, GtkDarktableRangeSelect *range)
 {
-  _event_entry_activated(entry, user_data);
+  _event_entry_activated(entry, range);
   return FALSE;
 }
 
@@ -1488,9 +1484,8 @@ void dtgtk_range_select_redraw(GtkDarktableRangeSelect *range)
   gtk_widget_queue_draw(range->band);
 }
 
-static gboolean _event_band_motion(GtkWidget *widget, GdkEventMotion *event, gpointer user_data)
+static gboolean _event_band_motion(GtkWidget *widget, GdkEventMotion *event, GtkDarktableRangeSelect *range)
 {
-  GtkDarktableRangeSelect *range = (GtkDarktableRangeSelect *)user_data;
   range->current_x_px = event->x - range->alloc_padding.x;
 
   // if we are outside the graph, don't go further
@@ -1538,9 +1533,8 @@ static gboolean _event_band_motion(GtkWidget *widget, GdkEventMotion *event, gpo
   return TRUE;
 }
 
-static gboolean _event_band_leave(GtkWidget *w, GdkEventCrossing *e, gpointer user_data)
+static gboolean _event_band_leave(GtkWidget *w, GdkEventCrossing *e, GtkDarktableRangeSelect *range)
 {
-  GtkDarktableRangeSelect *range = (GtkDarktableRangeSelect *)user_data;
   range->mouse_inside = HOVER_OUTSIDE;
   dt_control_change_cursor(GDK_LEFT_PTR);
   _current_hide_popup(range);
@@ -1549,9 +1543,8 @@ static gboolean _event_band_leave(GtkWidget *w, GdkEventCrossing *e, gpointer us
   return TRUE;
 }
 
-static gboolean _event_band_press(GtkWidget *w, GdkEventButton *e, gpointer user_data)
+static gboolean _event_band_press(GtkWidget *w, GdkEventButton *e, GtkDarktableRangeSelect *range)
 {
-  GtkDarktableRangeSelect *range = (GtkDarktableRangeSelect *)user_data;
   if(e->button == GDK_BUTTON_PRIMARY && e->type == GDK_2BUTTON_PRESS)
   {
     dtgtk_range_select_set_selection(range, DT_RANGE_BOUND_MIN | DT_RANGE_BOUND_MAX, range->min_r, range->max_r,
@@ -1595,9 +1588,8 @@ static gboolean _event_band_press(GtkWidget *w, GdkEventButton *e, gpointer user
   }
   return TRUE;
 }
-static gboolean _event_band_release(GtkWidget *w, GdkEventButton *e, gpointer user_data)
+static gboolean _event_band_release(GtkWidget *w, GdkEventButton *e, GtkDarktableRangeSelect *range)
 {
-  GtkDarktableRangeSelect *range = (GtkDarktableRangeSelect *)user_data;
   if(!range->set_selection) return TRUE;
   range->select_max_r = _graph_value_from_pos(range, e->x - range->alloc_padding.x, TRUE);
   const double min_pos_px = _graph_value_to_pos(range, range->select_min_r);
@@ -1667,12 +1659,12 @@ GtkWidget *dtgtk_range_select_new(const gchar *property, const gboolean show_ent
   range->band = gtk_drawing_area_new();
   gtk_widget_set_events(range->band, GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK | GDK_STRUCTURE_MASK
                                          | GDK_LEAVE_NOTIFY_MASK | GDK_POINTER_MOTION_MASK);
-  g_signal_connect(G_OBJECT(range->band), "draw", G_CALLBACK(_event_band_draw), range);
-  g_signal_connect(G_OBJECT(range->band), "button-press-event", G_CALLBACK(_event_band_press), range);
-  g_signal_connect(G_OBJECT(range->band), "button-release-event", G_CALLBACK(_event_band_release), range);
-  g_signal_connect(G_OBJECT(range->band), "motion-notify-event", G_CALLBACK(_event_band_motion), range);
-  g_signal_connect(G_OBJECT(range->band), "leave-notify-event", G_CALLBACK(_event_band_leave), range);
-  g_signal_connect(G_OBJECT(range->band), "style-updated", G_CALLBACK(_dt_pref_changed), range);
+  g_signal_connect(range->band, "draw", G_CALLBACK(_event_band_draw), range);
+  g_signal_connect(range->band, "button-press-event", G_CALLBACK(_event_band_press), range);
+  g_signal_connect(range->band, "button-release-event", G_CALLBACK(_event_band_release), range);
+  g_signal_connect(range->band, "motion-notify-event", G_CALLBACK(_event_band_motion), range);
+  g_signal_connect(range->band, "leave-notify-event", G_CALLBACK(_event_band_leave), range);
+  g_signal_connect(range->band, "style-updated", G_CALLBACK(_dt_pref_changed), range);
   gtk_widget_set_name(GTK_WIDGET(range->band), "dt-range-band");
   gtk_widget_set_can_default(range->band, TRUE);
 
@@ -1703,17 +1695,17 @@ GtkWidget *dtgtk_range_select_new(const gchar *property, const gboolean show_ent
     range->entry_min = dt_ui_entry_new(0);
     gtk_widget_set_can_default(range->entry_min, TRUE);
     _entry_set_tooltip(range->entry_min, BOUND_MIN, range->type);
-    g_signal_connect(G_OBJECT(range->entry_min), "activate", G_CALLBACK(_event_entry_activated), range);
-    g_signal_connect(G_OBJECT(range->entry_min), "focus-out-event", G_CALLBACK(_event_entry_focus_out), range);
-    g_signal_connect(G_OBJECT(range->entry_min), "button-press-event", G_CALLBACK(_event_entry_press), range);
+    g_signal_connect(range->entry_min, "activate", G_CALLBACK(_event_entry_activated), range);
+    g_signal_connect(range->entry_min, "focus-out-event", G_CALLBACK(_event_entry_focus_out), range);
+    g_signal_connect(range->entry_min, "button-press-event", G_CALLBACK(_event_entry_press), range);
 
     range->entry_max = dt_ui_entry_new(0);
     gtk_widget_set_can_default(range->entry_max, TRUE);
     gtk_entry_set_alignment(GTK_ENTRY(range->entry_max), 1.0);
     _entry_set_tooltip(range->entry_max, BOUND_MAX, range->type);
-    g_signal_connect(G_OBJECT(range->entry_max), "activate", G_CALLBACK(_event_entry_activated), range);
-    g_signal_connect(G_OBJECT(range->entry_max), "focus-out-event", G_CALLBACK(_event_entry_focus_out), range);
-    g_signal_connect(G_OBJECT(range->entry_max), "button-press-event", G_CALLBACK(_event_entry_press), range);
+    g_signal_connect(range->entry_max, "activate", G_CALLBACK(_event_entry_activated), range);
+    g_signal_connect(range->entry_max, "focus-out-event", G_CALLBACK(_event_entry_focus_out), range);
+    g_signal_connect(range->entry_max, "button-press-event", G_CALLBACK(_event_entry_press), range);
 
     dt_gui_box_add(vbox, dt_gui_hbox(dt_gui_expand(range->entry_min), dt_gui_expand(range->entry_max)));
   }

--- a/src/dtgtk/resetlabel.c
+++ b/src/dtgtk/resetlabel.c
@@ -64,7 +64,7 @@ GtkWidget *dtgtk_reset_label_new(const gchar *text, dt_iop_module_t *module, voi
   gtk_widget_set_tooltip_text(GTK_WIDGET(label), _("double-click to reset"));
   gtk_container_add(GTK_CONTAINER(label), GTK_WIDGET(label->lb));
   gtk_widget_add_events(GTK_WIDGET(label), GDK_BUTTON_PRESS_MASK);
-  g_signal_connect(G_OBJECT(label), "button-press-event", G_CALLBACK(_reset_label_callback), (gpointer)NULL);
+  g_signal_connect(label, "button-press-event", G_CALLBACK(_reset_label_callback), (gpointer)NULL);
 
   return (GtkWidget *)label;
 }

--- a/src/dtgtk/stylemenu.c
+++ b/src/dtgtk/stylemenu.c
@@ -118,7 +118,7 @@ static void _build_style_submenus(GtkMenuShell *menu,
     {
       menu_data->name = g_strdup(style_name);
       menu_data->user_data = user_data;
-      g_signal_connect_data(G_OBJECT(mi), "activate",
+      g_signal_connect_data(mi, "activate",
                             G_CALLBACK(activate_callback),
                             menu_data, (GClosureNotify)_free_menu_data, 0);
     }
@@ -130,7 +130,7 @@ static void _build_style_submenus(GtkMenuShell *menu,
     {
       menu_data->name = g_strdup(style_name);
       menu_data->user_data = user_data;
-      g_signal_connect_data(G_OBJECT(mi), "button-press-event",
+      g_signal_connect_data(mi, "button-press-event",
                             G_CALLBACK(button_callback),
                             menu_data, (GClosureNotify)_free_menu_data, 0);
     }

--- a/src/dtgtk/thumbnail.c
+++ b/src/dtgtk/thumbnail.c
@@ -411,7 +411,7 @@ static void _thumb_write_extension(dt_thumbnail_t *thumb)
 
 static gboolean _event_cursor_draw(GtkWidget *widget,
                                    cairo_t *cr,
-                                   gpointer user_data)
+                                   dt_thumbnail_t *thumb)
 {
   const double w_width  = gtk_widget_get_allocated_width(widget);
   const double w_height = gtk_widget_get_allocated_height(widget);
@@ -627,11 +627,9 @@ static void _thumb_set_image_area(dt_thumbnail_t *thumb,
 
 static gboolean _event_image_draw(GtkWidget *widget,
                                   cairo_t *cr,
-                                  gpointer user_data)
+                                  dt_thumbnail_t *thumb)
 {
-  if(!user_data)
-    return TRUE;
-  dt_thumbnail_t *thumb = (dt_thumbnail_t *)user_data;
+  if(!thumb) return TRUE;
 
   if(!dt_is_valid_imgid(thumb->imgid))
   {
@@ -967,10 +965,9 @@ static void _thumbs_show_overlays(dt_thumbnail_t *thumb)
 
 static gboolean _event_main_motion(GtkWidget *widget,
                                    GdkEventMotion *event,
-                                   gpointer user_data)
+                                   dt_thumbnail_t *thumb)
 {
-  if(!user_data) return TRUE;
-  dt_thumbnail_t *thumb = (dt_thumbnail_t *)user_data;
+  if(!thumb) return TRUE;
   // first, we hide the block overlays after a delay if the mouse hasn't move
   _thumbs_show_overlays(thumb);
 
@@ -981,16 +978,15 @@ static gboolean _event_main_motion(GtkWidget *widget,
 
 static gboolean _event_rating_press(GtkWidget *widget,
                                     GdkEventButton *event,
-                                    gpointer user_data)
+                                    dt_thumbnail_t *thumb)
 {
   return TRUE;
 }
 
 static gboolean _event_rating_release(GtkWidget *widget,
                                       GdkEventButton *event,
-                                      gpointer user_data)
+                                      dt_thumbnail_t *thumb)
 {
-  dt_thumbnail_t *thumb = (dt_thumbnail_t *)user_data;
   if(thumb->disable_actions)
     return FALSE;
   if(dtgtk_thumbnail_btn_is_hidden(widget))
@@ -1026,9 +1022,8 @@ static gboolean _event_rating_release(GtkWidget *widget,
 
 static gboolean _event_grouping_release(GtkWidget *widget,
                                         GdkEventButton *event,
-                                        gpointer user_data)
+                                        dt_thumbnail_t *thumb)
 {
-  dt_thumbnail_t *thumb = (dt_thumbnail_t *)user_data;
   if(thumb->disable_actions)
     return FALSE;
   if(dtgtk_thumbnail_btn_is_hidden(widget))
@@ -1076,9 +1071,8 @@ static gboolean _event_grouping_release(GtkWidget *widget,
 
 static gboolean _event_audio_release(GtkWidget *widget,
                                      GdkEventButton *event,
-                                     gpointer user_data)
+                                     dt_thumbnail_t *thumb)
 {
-  dt_thumbnail_t *thumb = (dt_thumbnail_t *)user_data;
   if(thumb->disable_actions)
     return FALSE;
   if(dtgtk_thumbnail_btn_is_hidden(widget))
@@ -1106,10 +1100,9 @@ static gboolean _event_audio_release(GtkWidget *widget,
 // this is called each time the images info change
 static void _dt_image_info_changed_callback(gpointer instance,
                                             const gpointer imgs,
-                                            gpointer user_data)
+                                            dt_thumbnail_t *thumb)
 {
-  if(!user_data || !imgs) return;
-  dt_thumbnail_t *thumb = (dt_thumbnail_t *)user_data;
+  if(!thumb || !imgs) return;
   for(const GList *i = imgs; i; i = g_list_next(i))
   {
     if(GPOINTER_TO_INT(i->data) == thumb->imgid)
@@ -1127,10 +1120,9 @@ static void _dt_collection_changed_callback(gpointer instance,
                                             dt_collection_properties_t changed_property,
                                             const gpointer imgs,
                                             const int next,
-                                            gpointer user_data)
+                                            dt_thumbnail_t *thumb)
 {
-  if(!user_data || !imgs) return;
-  dt_thumbnail_t *thumb = (dt_thumbnail_t *)user_data;
+  if(!thumb || !imgs) return;
   for(const GList *i = imgs; i; i = g_list_next(i))
   {
     if(GPOINTER_TO_INT(i->data) == thumb->imgid)
@@ -1162,20 +1154,17 @@ void dt_thumbnail_update_selection(dt_thumbnail_t *thumb)
 }
 
 static void _dt_selection_changed_callback(gpointer instance,
-                                           gpointer user_data)
+                                           dt_thumbnail_t *thumb)
 {
-  if(!user_data)
+  if(!thumb)
     return;
-  dt_thumbnail_update_selection((dt_thumbnail_t *)user_data);
+  dt_thumbnail_update_selection(thumb);
 }
 
 static void _dt_active_images_callback(gpointer instance,
-                                       gpointer user_data)
+                                       dt_thumbnail_t *thumb)
 {
-  if(!user_data)
-    return;
-  dt_thumbnail_t *thumb = (dt_thumbnail_t *)user_data;
-
+  if(!thumb) return;
   gboolean active = FALSE;
   for(GSList *l = darktable.view_manager->active_images;
       l;
@@ -1202,10 +1191,9 @@ static void _dt_active_images_callback(gpointer instance,
 }
 
 static void _dt_preview_updated_callback(gpointer instance,
-                                         gpointer user_data)
+                                         dt_thumbnail_t *thumb)
 {
-  if(!user_data) return;
-  dt_thumbnail_t *thumb = (dt_thumbnail_t *)user_data;
+  if(!thumb) return;
   if(!gtk_widget_is_visible(thumb->w_main)) return;
 
   if(dt_view_get_current() == DT_VIEW_DARKROOM
@@ -1221,10 +1209,9 @@ static void _dt_preview_updated_callback(gpointer instance,
 
 static void _dt_mipmaps_updated_callback(gpointer instance,
                                          const dt_imgid_t imgid,
-                                         gpointer user_data)
+                                         dt_thumbnail_t *thumb)
 {
-  if(!user_data) return;
-  dt_thumbnail_t *thumb = (dt_thumbnail_t *)user_data;
+  if(!thumb) return;
   if(dt_is_valid_imgid(imgid) && thumb->imgid != imgid) return;
 
   // we recompte the history tooltip if needed
@@ -1237,9 +1224,8 @@ static void _dt_mipmaps_updated_callback(gpointer instance,
 
 static gboolean _event_box_enter_leave(GtkWidget *widget,
                                        GdkEventCrossing *event,
-                                       gpointer user_data)
+                                       dt_thumbnail_t *thumb)
 {
-  dt_thumbnail_t *thumb = (dt_thumbnail_t *)user_data;
   // if we leave for ancestor, that means we leave for blank thumbtable area
   if(event->type == GDK_LEAVE_NOTIFY
      && event->detail == GDK_NOTIFY_ANCESTOR)
@@ -1258,10 +1244,8 @@ static gboolean _event_box_enter_leave(GtkWidget *widget,
 
 static gboolean _event_image_enter_leave(GtkWidget *widget,
                                          GdkEventCrossing *event,
-                                         gpointer user_data)
+                                         dt_thumbnail_t *thumb)
 {
-  dt_thumbnail_t *thumb = (dt_thumbnail_t *)user_data;
-
   // we ensure that the image has mouse over
   if(!thumb->mouse_over && event->type == GDK_ENTER_NOTIFY
      && !thumb->disable_mouseover)
@@ -1274,10 +1258,8 @@ static gboolean _event_image_enter_leave(GtkWidget *widget,
 
 static gboolean _event_btn_enter_leave(GtkWidget *widget,
                                        GdkEventCrossing *event,
-                                       gpointer user_data)
+                                       dt_thumbnail_t *thumb)
 {
-  dt_thumbnail_t *thumb = (dt_thumbnail_t *)user_data;
-
   darktable.control->element =
     (event->type == GDK_ENTER_NOTIFY && widget == thumb->w_reject)
     ? DT_VIEW_REJECT
@@ -1300,9 +1282,8 @@ static gboolean _event_btn_enter_leave(GtkWidget *widget,
 
 static gboolean _event_star_enter(GtkWidget *widget,
                                   GdkEventCrossing *event,
-                                  gpointer user_data)
+                                  dt_thumbnail_t *thumb)
 {
-  dt_thumbnail_t *thumb = (dt_thumbnail_t *)user_data;
   if(thumb->disable_actions) return TRUE;
   if(!thumb->mouse_over && !thumb->disable_mouseover)
     dt_control_set_mouse_over_id(thumb->imgid);
@@ -1326,9 +1307,8 @@ static gboolean _event_star_enter(GtkWidget *widget,
 }
 static gboolean _event_star_leave(GtkWidget *widget,
                                   GdkEventCrossing *event,
-                                  gpointer user_data)
+                                  dt_thumbnail_t *thumb)
 {
-  dt_thumbnail_t *thumb = (dt_thumbnail_t *)user_data;
   // if we leave for ancestor, that means we leave for blank thumbtable area
   if(event->type == GDK_LEAVE_NOTIFY
      && event->detail == GDK_NOTIFY_ANCESTOR)
@@ -1345,7 +1325,7 @@ static gboolean _event_star_leave(GtkWidget *widget,
 
 static gboolean _event_main_leave(GtkWidget *widget,
                                   GdkEventCrossing *event,
-                                  gpointer user_data)
+                                  dt_thumbnail_t *thumb)
 {
   // if we leave for ancestor, that means we leave for blank thumbtable area
   if(event->detail == GDK_NOTIFY_ANCESTOR) dt_control_set_mouse_over_id(NO_IMGID);
@@ -1358,9 +1338,9 @@ static gboolean _event_main_drag_motion(GtkWidget *widget,
                                         const gint x,
                                         const gint y,
                                         const guint time,
-                                        gpointer user_data)
+                                        dt_thumbnail_t *thumb)
 {
-  _event_main_motion(widget, NULL, user_data);
+  _event_main_motion(widget, NULL, thumb);
   return TRUE;
 }
 
@@ -1402,7 +1382,7 @@ GtkWidget *dt_thumbnail_create_widget(dt_thumbnail_t *thumb,
     // all dragging actions take place inside thumbatble.c
     gtk_drag_dest_set(thumb->w_main, GTK_DEST_DEFAULT_MOTION,
                       target_list_all, n_targets_all, GDK_ACTION_MOVE);
-    g_signal_connect(G_OBJECT(thumb->w_main), "drag-motion",
+    g_signal_connect(thumb->w_main, "drag-motion",
                      G_CALLBACK(_event_main_drag_motion), thumb);
 
     g_object_set_data(G_OBJECT(thumb->w_main), "thumb", thumb);
@@ -1421,9 +1401,9 @@ GtkWidget *dt_thumbnail_create_widget(dt_thumbnail_t *thumb,
                           | GDK_ENTER_NOTIFY_MASK | GDK_LEAVE_NOTIFY_MASK
                           | GDK_POINTER_MOTION_MASK);
     gtk_widget_set_name(thumb->w_back, "thumb-back");
-    g_signal_connect(G_OBJECT(thumb->w_back), "motion-notify-event",
+    g_signal_connect(thumb->w_back, "motion-notify-event",
                      G_CALLBACK(_event_main_motion), thumb);
-    g_signal_connect(G_OBJECT(thumb->w_back), "leave-notify-event",
+    g_signal_connect(thumb->w_back, "leave-notify-event",
                      G_CALLBACK(_event_main_leave), thumb);
     gtk_widget_show(thumb->w_back);
     gtk_container_add(GTK_CONTAINER(thumb->w_main), thumb->w_back);
@@ -1454,11 +1434,11 @@ GtkWidget *dt_thumbnail_create_widget(dt_thumbnail_t *thumb,
                           | GDK_STRUCTURE_MASK
                           | GDK_ENTER_NOTIFY_MASK | GDK_LEAVE_NOTIFY_MASK
                           | GDK_POINTER_MOTION_MASK);
-    g_signal_connect(G_OBJECT(evt_image), "motion-notify-event",
+    g_signal_connect(evt_image, "motion-notify-event",
                      G_CALLBACK(_event_main_motion), thumb);
-    g_signal_connect(G_OBJECT(evt_image), "enter-notify-event",
+    g_signal_connect(evt_image, "enter-notify-event",
                      G_CALLBACK(_event_image_enter_leave), thumb);
-    g_signal_connect(G_OBJECT(evt_image), "leave-notify-event",
+    g_signal_connect(evt_image, "leave-notify-event",
                      G_CALLBACK(_event_image_enter_leave), thumb);
     gtk_widget_show(evt_image);
     gtk_overlay_add_overlay(GTK_OVERLAY(thumb->w_image_box), evt_image);
@@ -1471,15 +1451,15 @@ GtkWidget *dt_thumbnail_create_widget(dt_thumbnail_t *thumb,
                           | GDK_BUTTON_RELEASE_MASK | GDK_STRUCTURE_MASK
                           | GDK_ENTER_NOTIFY_MASK | GDK_LEAVE_NOTIFY_MASK
                           | GDK_POINTER_MOTION_MASK);
-    g_signal_connect(G_OBJECT(thumb->w_image), "draw",
+    g_signal_connect(thumb->w_image, "draw",
                      G_CALLBACK(_event_image_draw), thumb);
-    g_signal_connect(G_OBJECT(thumb->w_image), "motion-notify-event",
+    g_signal_connect(thumb->w_image, "motion-notify-event",
                      G_CALLBACK(_event_main_motion), thumb);
-    g_signal_connect(G_OBJECT(thumb->w_image), "enter-notify-event",
+    g_signal_connect(thumb->w_image, "enter-notify-event",
                      G_CALLBACK(_event_image_enter_leave), thumb);
-    g_signal_connect(G_OBJECT(thumb->w_image), "leave-notify-event",
+    g_signal_connect(thumb->w_image, "leave-notify-event",
                      G_CALLBACK(_event_image_enter_leave), thumb);
-    g_signal_connect(G_OBJECT(thumb->w_image), "style-updated",
+    g_signal_connect(thumb->w_image, "style-updated",
                      G_CALLBACK(_event_image_style_updated), thumb);
     gtk_widget_show(thumb->w_image);
     gtk_overlay_add_overlay(GTK_OVERLAY(thumb->w_image_box), thumb->w_image);
@@ -1490,7 +1470,7 @@ GtkWidget *dt_thumbnail_create_widget(dt_thumbnail_t *thumb,
     gtk_widget_set_name(thumb->w_cursor, "thumb-cursor");
     gtk_widget_set_valign(thumb->w_cursor, GTK_ALIGN_START);
     gtk_widget_set_halign(thumb->w_cursor, GTK_ALIGN_CENTER);
-    g_signal_connect(G_OBJECT(thumb->w_cursor), "draw",
+    g_signal_connect(thumb->w_cursor, "draw",
                      G_CALLBACK(_event_cursor_draw), thumb);
     gtk_overlay_add_overlay(GTK_OVERLAY(thumb->w_main), thumb->w_cursor);
 
@@ -1502,10 +1482,10 @@ GtkWidget *dt_thumbnail_create_widget(dt_thumbnail_t *thumb,
     // the infos background
     thumb->w_bottom_eb = gtk_event_box_new();
     gtk_widget_set_name(thumb->w_bottom_eb, "thumb-bottom");
-    g_signal_connect(G_OBJECT(thumb->w_bottom_eb), "enter-notify-event",
+    g_signal_connect(thumb->w_bottom_eb, "enter-notify-event",
                      G_CALLBACK(_event_box_enter_leave),
                      thumb);
-    g_signal_connect(G_OBJECT(thumb->w_bottom_eb), "leave-notify-event",
+    g_signal_connect(thumb->w_bottom_eb, "leave-notify-event",
                      G_CALLBACK(_event_box_enter_leave),
                      thumb);
     gtk_widget_set_valign(thumb->w_bottom_eb, GTK_ALIGN_END);
@@ -1541,13 +1521,13 @@ GtkWidget *dt_thumbnail_create_widget(dt_thumbnail_t *thumb,
     gtk_widget_set_valign(thumb->w_reject, GTK_ALIGN_END);
     gtk_widget_set_halign(thumb->w_reject, GTK_ALIGN_START);
     gtk_widget_show(thumb->w_reject);
-    g_signal_connect(G_OBJECT(thumb->w_reject), "button-press-event",
+    g_signal_connect(thumb->w_reject, "button-press-event",
                      G_CALLBACK(_event_rating_press), thumb);
-    g_signal_connect(G_OBJECT(thumb->w_reject), "button-release-event",
+    g_signal_connect(thumb->w_reject, "button-release-event",
                      G_CALLBACK(_event_rating_release), thumb);
-    g_signal_connect(G_OBJECT(thumb->w_reject), "enter-notify-event",
+    g_signal_connect(thumb->w_reject, "enter-notify-event",
                      G_CALLBACK(_event_btn_enter_leave), thumb);
-    g_signal_connect(G_OBJECT(thumb->w_reject), "leave-notify-event",
+    g_signal_connect(thumb->w_reject, "leave-notify-event",
                      G_CALLBACK(_event_btn_enter_leave), thumb);
     gtk_overlay_add_overlay(GTK_OVERLAY(overlays_parent), thumb->w_reject);
 
@@ -1555,13 +1535,13 @@ GtkWidget *dt_thumbnail_create_widget(dt_thumbnail_t *thumb,
     for(int i = 0; i < MAX_STARS; i++)
     {
       thumb->w_stars[i] = dtgtk_thumbnail_btn_new(dtgtk_cairo_paint_star, 0, NULL);
-      g_signal_connect(G_OBJECT(thumb->w_stars[i]), "enter-notify-event",
+      g_signal_connect(thumb->w_stars[i], "enter-notify-event",
                        G_CALLBACK(_event_star_enter), thumb);
-      g_signal_connect(G_OBJECT(thumb->w_stars[i]), "leave-notify-event",
+      g_signal_connect(thumb->w_stars[i], "leave-notify-event",
                        G_CALLBACK(_event_star_leave), thumb);
-      g_signal_connect(G_OBJECT(thumb->w_stars[i]), "button-press-event",
+      g_signal_connect(thumb->w_stars[i], "button-press-event",
                        G_CALLBACK(_event_rating_press), thumb);
-      g_signal_connect(G_OBJECT(thumb->w_stars[i]), "button-release-event",
+      g_signal_connect(thumb->w_stars[i], "button-release-event",
                        G_CALLBACK(_event_rating_release),
                        thumb);
       gtk_widget_set_name(thumb->w_stars[i], "thumb-star");
@@ -1582,9 +1562,9 @@ GtkWidget *dt_thumbnail_create_widget(dt_thumbnail_t *thumb,
     gtk_widget_set_valign(thumb->w_color, GTK_ALIGN_END);
     gtk_widget_set_halign(thumb->w_color, GTK_ALIGN_END);
     gtk_widget_set_no_show_all(thumb->w_color, TRUE);
-    g_signal_connect(G_OBJECT(thumb->w_color), "enter-notify-event",
+    g_signal_connect(thumb->w_color, "enter-notify-event",
                      G_CALLBACK(_event_btn_enter_leave), thumb);
-    g_signal_connect(G_OBJECT(thumb->w_color), "leave-notify-event",
+    g_signal_connect(thumb->w_color, "leave-notify-event",
                      G_CALLBACK(_event_btn_enter_leave), thumb);
     gtk_overlay_add_overlay(GTK_OVERLAY(overlays_parent), thumb->w_color);
 
@@ -1595,10 +1575,10 @@ GtkWidget *dt_thumbnail_create_widget(dt_thumbnail_t *thumb,
     gtk_widget_set_valign(thumb->w_local_copy, GTK_ALIGN_START);
     gtk_widget_set_halign(thumb->w_local_copy, GTK_ALIGN_END);
     gtk_widget_set_no_show_all(thumb->w_local_copy, TRUE);
-    g_signal_connect(G_OBJECT(thumb->w_local_copy), "enter-notify-event",
+    g_signal_connect(thumb->w_local_copy, "enter-notify-event",
                      G_CALLBACK(_event_btn_enter_leave),
                      thumb);
-    g_signal_connect(G_OBJECT(thumb->w_local_copy), "leave-notify-event",
+    g_signal_connect(thumb->w_local_copy, "leave-notify-event",
                      G_CALLBACK(_event_btn_enter_leave),
                      thumb);
     gtk_overlay_add_overlay(GTK_OVERLAY(overlays_parent), thumb->w_local_copy);
@@ -1609,9 +1589,9 @@ GtkWidget *dt_thumbnail_create_widget(dt_thumbnail_t *thumb,
     gtk_widget_set_valign(thumb->w_altered, GTK_ALIGN_START);
     gtk_widget_set_halign(thumb->w_altered, GTK_ALIGN_END);
     gtk_widget_set_no_show_all(thumb->w_altered, TRUE);
-    g_signal_connect(G_OBJECT(thumb->w_altered), "enter-notify-event",
+    g_signal_connect(thumb->w_altered, "enter-notify-event",
                      G_CALLBACK(_event_btn_enter_leave), thumb);
-    g_signal_connect(G_OBJECT(thumb->w_altered), "leave-notify-event",
+    g_signal_connect(thumb->w_altered, "leave-notify-event",
                      G_CALLBACK(_event_btn_enter_leave), thumb);
     gtk_overlay_add_overlay(GTK_OVERLAY(overlays_parent), thumb->w_altered);
 
@@ -1621,20 +1601,20 @@ GtkWidget *dt_thumbnail_create_widget(dt_thumbnail_t *thumb,
     gtk_widget_set_valign(thumb->w_tags, GTK_ALIGN_START);
     gtk_widget_set_halign(thumb->w_tags, GTK_ALIGN_END);
     gtk_widget_set_no_show_all(thumb->w_tags, TRUE);
-    g_signal_connect(G_OBJECT(thumb->w_tags), "enter-notify-event",
+    g_signal_connect(thumb->w_tags, "enter-notify-event",
                      G_CALLBACK(_event_btn_enter_leave), thumb);
-    g_signal_connect(G_OBJECT(thumb->w_tags), "leave-notify-event",
+    g_signal_connect(thumb->w_tags, "leave-notify-event",
                      G_CALLBACK(_event_btn_enter_leave), thumb);
     gtk_overlay_add_overlay(GTK_OVERLAY(overlays_parent), thumb->w_tags);
 
     // the group bouton
     thumb->w_group = dtgtk_thumbnail_btn_new(dtgtk_cairo_paint_grouping, 0, NULL);
     gtk_widget_set_name(thumb->w_group, "thumb-group-audio");
-    g_signal_connect(G_OBJECT(thumb->w_group), "button-release-event",
+    g_signal_connect(thumb->w_group, "button-release-event",
                      G_CALLBACK(_event_grouping_release), thumb);
-    g_signal_connect(G_OBJECT(thumb->w_group), "enter-notify-event",
+    g_signal_connect(thumb->w_group, "enter-notify-event",
                      G_CALLBACK(_event_btn_enter_leave), thumb);
-    g_signal_connect(G_OBJECT(thumb->w_group), "leave-notify-event",
+    g_signal_connect(thumb->w_group, "leave-notify-event",
                      G_CALLBACK(_event_btn_enter_leave), thumb);
     gtk_widget_set_valign(thumb->w_group, GTK_ALIGN_START);
     gtk_widget_set_halign(thumb->w_group, GTK_ALIGN_END);
@@ -1644,11 +1624,11 @@ GtkWidget *dt_thumbnail_create_widget(dt_thumbnail_t *thumb,
     // the sound icon
     thumb->w_audio = dtgtk_thumbnail_btn_new(dtgtk_cairo_paint_audio, 0, NULL);
     gtk_widget_set_name(thumb->w_audio, "thumb-group-audio");
-    g_signal_connect(G_OBJECT(thumb->w_audio), "button-release-event",
+    g_signal_connect(thumb->w_audio, "button-release-event",
                      G_CALLBACK(_event_audio_release), thumb);
-    g_signal_connect(G_OBJECT(thumb->w_audio), "enter-notify-event",
+    g_signal_connect(thumb->w_audio, "enter-notify-event",
                      G_CALLBACK(_event_btn_enter_leave), thumb);
-    g_signal_connect(G_OBJECT(thumb->w_audio), "leave-notify-event",
+    g_signal_connect(thumb->w_audio, "leave-notify-event",
                      G_CALLBACK(_event_btn_enter_leave), thumb);
     gtk_widget_set_valign(thumb->w_audio, GTK_ALIGN_START);
     gtk_widget_set_halign(thumb->w_audio, GTK_ALIGN_END);
@@ -1657,7 +1637,7 @@ GtkWidget *dt_thumbnail_create_widget(dt_thumbnail_t *thumb,
 
     // the zoom indicator
     thumb->w_zoom_eb = gtk_event_box_new();
-    g_signal_connect(G_OBJECT(thumb->w_zoom_eb), "enter-notify-event",
+    g_signal_connect(thumb->w_zoom_eb, "enter-notify-event",
                      G_CALLBACK(_event_btn_enter_leave), thumb);
     gtk_widget_set_name(thumb->w_zoom_eb, "thumb-zoom");
     gtk_widget_set_valign(thumb->w_zoom_eb, GTK_ALIGN_START);

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -1479,7 +1479,7 @@ static gboolean _event_button_press(GtkWidget *widget,
     if(event->x < button->x && event->x > button->x - button->width
        && event->y < button->y && event->y > button->y - button->height)
     {
-      dt_gui_show_help(NULL);
+      dt_gui_show_help(NULL, NULL);
     }
 
     return TRUE;
@@ -2461,19 +2461,19 @@ dt_thumbtable_t *dt_thumbtable_new()
   g_signal_connect(table->widget, "drag-data-received",
                    G_CALLBACK(dt_thumbtable_event_dnd_received), table);
 
-  g_signal_connect(G_OBJECT(table->widget), "scroll-event",
+  g_signal_connect(table->widget, "scroll-event",
                    G_CALLBACK(_event_scroll), table);
-  g_signal_connect(G_OBJECT(table->widget), "draw",
+  g_signal_connect(table->widget, "draw",
                    G_CALLBACK(_event_draw), table);
-  g_signal_connect(G_OBJECT(table->widget), "leave-notify-event",
+  g_signal_connect(table->widget, "leave-notify-event",
                    G_CALLBACK(_event_leave_notify), table);
-  g_signal_connect(G_OBJECT(table->widget), "enter-notify-event",
+  g_signal_connect(table->widget, "enter-notify-event",
                    G_CALLBACK(_event_enter_notify), table);
-  g_signal_connect(G_OBJECT(table->widget), "button-press-event",
+  g_signal_connect(table->widget, "button-press-event",
                    G_CALLBACK(_event_button_press), table);
-  g_signal_connect(G_OBJECT(table->widget), "motion-notify-event",
+  g_signal_connect(table->widget, "motion-notify-event",
                    G_CALLBACK(_event_motion_notify), table);
-  g_signal_connect(G_OBJECT(table->widget), "button-release-event",
+  g_signal_connect(table->widget, "button-release-event",
                    G_CALLBACK(_event_button_release), table);
 
   // we register globals signals

--- a/src/dtgtk/togglebutton.c
+++ b/src/dtgtk/togglebutton.c
@@ -141,7 +141,7 @@ GtkWidget *dtgtk_togglebutton_new(DTGTKCairoPaintIconFunc paint, gint paintflags
   gtk_container_add(GTK_CONTAINER(button), button->canvas);
   dt_gui_add_class(GTK_WIDGET(button), "dt_module_btn");
   gtk_widget_set_name(GTK_WIDGET(button->canvas), "button-canvas");
-  g_signal_connect(G_OBJECT(button), "toggled", G_CALLBACK(gtk_widget_queue_draw), NULL);
+  g_signal_connect(GTK_WIDGET(button), "toggled", G_CALLBACK((GtkCallback)gtk_widget_queue_draw), NULL);
   return (GtkWidget *)button;
 }
 

--- a/src/gui/about.c
+++ b/src/gui/about.c
@@ -22,7 +22,7 @@
 #include "osx/osx.h"
 #endif
 
-void darktable_show_about_dialog()
+void darktable_show_about_dialog(void)
 {
   GtkWidget *dialog = gtk_about_dialog_new();
   gtk_widget_set_name (dialog, "about-dialog");

--- a/src/gui/about.h
+++ b/src/gui/about.h
@@ -16,4 +16,4 @@
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-void darktable_show_about_dialog();
+void darktable_show_about_dialog(void);

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -1219,7 +1219,7 @@ gboolean dt_shortcut_tooltip_callback(GtkWidget *widget,
 
   gtk_widget_show_all(vbox);
   gtk_tooltip_set_custom(tooltip, vbox);
-  g_signal_connect(G_OBJECT(vbox), "size-allocate", G_CALLBACK(_tooltip_reposition), widget);
+  g_signal_connect(vbox, "size-allocate", G_CALLBACK(_tooltip_reposition), widget);
 
   return TRUE;
 }
@@ -1779,11 +1779,9 @@ static void _element_editing_started(GtkCellRenderer *renderer,
 static void _element_changed(GtkCellRendererCombo *combo,
                              char *path_string,
                              GtkTreeIter *new_iter,
-                             gpointer data)
+                             GtkTreeModel *model)
 {
-  dt_shortcut_t *s = _find_edited_shortcut(data, path_string);
-
-  GtkTreeModel *model = NULL;
+  dt_shortcut_t *s = _find_edited_shortcut(model, path_string);
   g_object_get(combo, "model", &model, NULL);
   GtkTreePath *path = gtk_tree_model_get_path(model, new_iter);
   const gint new_index = gtk_tree_path_get_indices(path)[0];
@@ -1902,11 +1900,9 @@ static void _effect_editing_started(GtkCellRenderer *renderer,
 static void _effect_changed(GtkCellRendererCombo *combo,
                             char *path_string,
                             GtkTreeIter *new_iter,
-                            gpointer data)
+                            GtkTreeModel *model)
 {
-  dt_shortcut_t *s = _find_edited_shortcut(data, path_string);
-
-  GtkTreeModel *model = NULL;
+  dt_shortcut_t *s = _find_edited_shortcut(model, path_string);
   g_object_get(combo, "model", &model, NULL);
   GtkTreePath *path = gtk_tree_model_get_path(model, new_iter);
   const gint new_index = s->effect = gtk_tree_path_get_indices(path)[0];
@@ -1986,18 +1982,17 @@ static void _shortcut_row_activated(GtkTreeView *tree_view,
   _grab_in_tree_view(tree_view);
 }
 
-static gboolean _view_key_pressed(GtkWidget *widget,
+static gboolean _view_key_pressed(GtkTreeView *view,
                                   GdkEventKey *event,
-                                  gpointer user_data)
+                                  GtkSearchEntry *search)
 {
-  GtkTreeView *view = GTK_TREE_VIEW(widget);
   GtkTreeSelection *selection = gtk_tree_view_get_selection(view);
 
   GtkTreeIter iter;
   GtkTreeModel *model = NULL;
   if(gtk_tree_selection_get_selected(selection, &model, &iter))
   {
-    if(!strcmp(gtk_widget_get_name(widget), "actions_view"))
+    if(!strcmp(gtk_widget_get_name(GTK_WIDGET(view)), "actions_view"))
     {
       // if control key pressed, copy lua command to clipboard (CTRL+C will work)
       if(dt_modifier_is(event->state, GDK_CONTROL_MASK))
@@ -2043,7 +2038,7 @@ static gboolean _view_key_pressed(GtkWidget *widget,
     }
   }
 
-  return dt_gui_search_start(widget, event, user_data);
+  return dt_gui_search_start(GTK_WIDGET(view), event, search);
 }
 
 static void _add_shortcuts_to_tree()
@@ -2211,7 +2206,7 @@ static gboolean _shortcut_selection_function(GtkTreeSelection *selection,
 }
 
 static void _shortcut_selection_changed(GtkTreeSelection *selection,
-                                        gpointer data)
+                                        GtkTreeView *view)
 {
   GtkTreeModel *model = NULL;
   GtkTreeIter iter;
@@ -2225,7 +2220,7 @@ static void _shortcut_selection_changed(GtkTreeSelection *selection,
   else
     _selected_shortcut = NULL;
 
-  gtk_widget_queue_draw(GTK_WIDGET(data));
+  gtk_widget_queue_draw(GTK_WIDGET(view));
 }
 
 static gboolean _action_find_and_expand(GtkTreeModel *model,
@@ -2258,11 +2253,10 @@ static gboolean _action_find_and_expand(GtkTreeModel *model,
   return FALSE;
 }
 
-static gboolean _action_view_click(GtkWidget *widget,
+static gboolean _action_view_click(GtkTreeView *view,
                                    GdkEventButton *event,
-                                   gpointer data)
+                                   gpointer user_data)
 {
-  GtkTreeView *view = GTK_TREE_VIEW(widget);
   GtkTreeModel *model = gtk_tree_view_get_model(view);
 
   if(event->button == GDK_BUTTON_PRIMARY)
@@ -2289,7 +2283,7 @@ static gboolean _action_view_click(GtkWidget *widget,
         gtk_tree_view_set_cursor(view, path, NULL, FALSE);
       }
 
-      gtk_widget_grab_focus(widget);
+      gtk_widget_grab_focus(GTK_WIDGET(view));
     }
     else
       gtk_tree_selection_unselect_all(selection);
@@ -2320,7 +2314,7 @@ static gboolean _action_view_show(GtkTreeView *view,
 }
 
 static void _action_selection_changed(GtkTreeSelection *selection,
-                                      gpointer data)
+                                      GtkTreeView *shortcuts_view)
 {
   GtkTreeIter iter;
   GtkTreeModel *model = NULL;
@@ -2337,7 +2331,6 @@ static void _action_selection_changed(GtkTreeSelection *selection,
     gtk_tree_path_free(path);
   }
 
-  GtkTreeView *shortcuts_view = GTK_TREE_VIEW(data);
   gtk_tree_model_filter_refilter(GTK_TREE_MODEL_FILTER
                                  (gtk_tree_view_get_model(shortcuts_view)));
   gtk_tree_view_expand_all(shortcuts_view);
@@ -2507,12 +2500,11 @@ static void _shortcuts_load(const gchar *shortcuts_file,
                             const dt_input_device_t load_dev,
                             const gboolean clear);
 
-static void _fallbacks_toggled(GtkToggleButton *button, gpointer data)
+static void _fallbacks_toggled(GtkWidget *button, GtkTreeView *shortcuts_view)
 {
   dt_conf_set_bool("accel/enable_fallbacks",
                    (darktable.control->enable_fallbacks = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(button))));
 
-  GtkTreeView *shortcuts_view = GTK_TREE_VIEW(data);
   gtk_tree_model_filter_refilter(GTK_TREE_MODEL_FILTER
                                  (gtk_tree_view_get_model(shortcuts_view)));
 }
@@ -2570,8 +2562,8 @@ static void _restore_clicked(GtkButton *button, gpointer user_data)
   dt_shortcuts_save(NULL, FALSE);
 }
 
-static void _import_export_dev_changed(GtkComboBox *widget,
-                                       gpointer user_data)
+static void _import_export_dev_changed(GtkWidget *widget,
+                                       GtkWidget *user_data)
 {
   gint dev = gtk_combo_box_get_active(GTK_COMBO_BOX(widget));
   g_object_set_data(G_OBJECT(user_data), "device", GINT_TO_POINTER(dev));
@@ -2580,8 +2572,8 @@ static void _import_export_dev_changed(GtkComboBox *widget,
   gtk_widget_set_visible(gtk_widget_get_parent(GTK_WIDGET(user_data)), dev > 1);
 }
 
-static void _export_id_changed(GtkComboBox *widget,
-                               gpointer user_data)
+static void _export_id_changed(GtkWidget *widget,
+                               GtkWidget *user_data)
 {
   gint dev = GPOINTER_TO_INT(g_object_get_data(G_OBJECT(widget), "device"));
   gint id = dev <= 1 ? 0 :
@@ -2671,9 +2663,9 @@ static void _export_clicked(GtkButton *button, gpointer user_data)
   g_object_unref(chooser);
 }
 
-static void _import_id_changed(GtkComboBox *widget, gpointer user_data)
+static void _import_id_changed(GtkWidget *widget, GtkWidget *user_data)
 {
-  gint id = gtk_combo_box_get_active(widget);
+  gint id = gtk_combo_box_get_active(GTK_COMBO_BOX(widget));
   gtk_combo_box_set_active(GTK_COMBO_BOX(user_data), id);
 }
 
@@ -2891,14 +2883,14 @@ GtkWidget *dt_shortcuts_prefs(GtkWidget *widget)
   g_object_unref(G_OBJECT(filtered_shortcuts));
   gtk_tree_view_set_search_column(shortcuts_view, 0); // fake column for _search_func
   gtk_tree_view_set_search_equal_func(shortcuts_view, _search_func, shortcuts_view, NULL);
-  GtkWidget *search_shortcuts = gtk_search_entry_new();
+  GtkSearchEntry *search_shortcuts = GTK_SEARCH_ENTRY(gtk_search_entry_new());
   gtk_entry_set_placeholder_text(GTK_ENTRY(search_shortcuts),
                                  _("search shortcuts list"));
   gtk_widget_set_tooltip_text(GTK_WIDGET(search_shortcuts),
                               _("incrementally search the list of shortcuts\npress up or down keys to cycle through matches"));
-  g_signal_connect(G_OBJECT(search_shortcuts), "activate",
+  g_signal_connect(search_shortcuts, "activate",
                    G_CALLBACK(dt_gui_search_stop), shortcuts_view);
-  g_signal_connect(G_OBJECT(search_shortcuts), "stop-search",
+  g_signal_connect(search_shortcuts, "stop-search",
                    G_CALLBACK(dt_gui_search_stop), shortcuts_view);
   gtk_tree_view_set_search_entry(shortcuts_view, GTK_ENTRY(search_shortcuts));
 
@@ -2906,11 +2898,11 @@ GtkWidget *dt_shortcuts_prefs(GtkWidget *widget)
                                          _shortcut_selection_function, NULL, NULL);
   g_object_set(shortcuts_view, "has-tooltip", TRUE, NULL);
   gtk_widget_set_name(GTK_WIDGET(shortcuts_view), "shortcuts_view");
-  g_signal_connect(G_OBJECT(shortcuts_view), "row-activated",
+  g_signal_connect(shortcuts_view, "row-activated",
                    G_CALLBACK(_shortcut_row_activated), filtered_shortcuts);
-  g_signal_connect(G_OBJECT(shortcuts_view), "key-press-event",
+  g_signal_connect(shortcuts_view, "key-press-event",
                    G_CALLBACK(_view_key_pressed), search_shortcuts);
-  g_signal_connect(G_OBJECT(_shortcuts_store), "row-inserted",
+  g_signal_connect(_shortcuts_store, "row-inserted",
                    G_CALLBACK(_shortcut_row_inserted), shortcuts_view);
 
   // Setting up the cell renderers
@@ -2927,7 +2919,8 @@ GtkWidget *dt_shortcuts_prefs(GtkWidget *widget)
   g_object_set(renderer, "model", elements, "text-column", 0, "has-entry", FALSE, NULL);
   g_signal_connect(renderer, "editing-started" ,
                    G_CALLBACK(_element_editing_started), filtered_shortcuts);
-  g_signal_connect(renderer, "changed", G_CALLBACK(_element_changed), filtered_shortcuts);
+  g_signal_connect(GTK_CELL_RENDERER_COMBO(renderer), "changed",
+                   G_CALLBACK(_element_changed), filtered_shortcuts);
   _add_prefs_column(shortcuts_view, renderer, _("element"), SHORTCUT_VIEW_ELEMENT);
 
   renderer = gtk_cell_renderer_combo_new();
@@ -2935,7 +2928,8 @@ GtkWidget *dt_shortcuts_prefs(GtkWidget *widget)
   g_object_set(renderer, "model", effects, "text-column", 0, "has-entry", FALSE, NULL);
   g_signal_connect(renderer, "editing-started" ,
                    G_CALLBACK(_effect_editing_started), filtered_shortcuts);
-  g_signal_connect(renderer, "changed", G_CALLBACK(_effect_changed), filtered_shortcuts);
+  g_signal_connect(GTK_CELL_RENDERER_COMBO(renderer), "changed",
+                   G_CALLBACK(_effect_changed), filtered_shortcuts);
   _add_prefs_column(shortcuts_view, renderer, _("effect"), SHORTCUT_VIEW_EFFECT);
 
   renderer = gtk_cell_renderer_spin_new();
@@ -2992,29 +2986,29 @@ GtkWidget *dt_shortcuts_prefs(GtkWidget *widget)
   g_object_unref(_actions_store);
   gtk_tree_view_set_search_column(actions_view, 1); // fake column for _search_func
   gtk_tree_view_set_search_equal_func(actions_view, _search_func, actions_view, NULL);
-  GtkWidget *search_actions = gtk_search_entry_new();
+  GtkSearchEntry *search_actions = GTK_SEARCH_ENTRY(gtk_search_entry_new());
   gtk_entry_set_placeholder_text(GTK_ENTRY(search_actions),
                                  _("search actions list"));
   gtk_widget_set_tooltip_text(GTK_WIDGET(search_actions),
                               _("incrementally search the list of actions\npress up or down keys to cycle through matches"));
-  g_signal_connect(G_OBJECT(search_actions), "activate",
+  g_signal_connect(search_actions, "activate",
                    G_CALLBACK(dt_gui_search_stop), actions_view);
-  g_signal_connect(G_OBJECT(search_actions), "stop-search",
+  g_signal_connect(search_actions, "stop-search",
                    G_CALLBACK(dt_gui_search_stop), actions_view);
   gtk_tree_view_set_search_entry(actions_view, GTK_ENTRY(search_actions));
 
   g_object_set(actions_view, "has-tooltip", TRUE, NULL);
   gtk_widget_set_name(GTK_WIDGET(actions_view), "actions_view");
-  g_signal_connect(G_OBJECT(actions_view), "row-activated",
+  g_signal_connect(actions_view, "row-activated",
                    G_CALLBACK(_action_row_activated), _actions_store);
-  g_signal_connect(G_OBJECT(actions_view), "button-press-event",
-                   G_CALLBACK(_action_view_click), _actions_store);
-  g_signal_connect(G_OBJECT(actions_view), "key-press-event",
+  g_signal_connect(actions_view, "button-press-event",
+                   G_CALLBACK(_action_view_click), NULL);
+  g_signal_connect(actions_view, "key-press-event",
                    G_CALLBACK(_view_key_pressed), search_actions);
 
-  g_signal_connect(G_OBJECT(gtk_tree_view_get_selection(actions_view)), "changed",
+  g_signal_connect(gtk_tree_view_get_selection(actions_view), "changed",
                    G_CALLBACK(_action_selection_changed), shortcuts_view);
-  g_signal_connect(G_OBJECT(gtk_tree_view_get_selection(shortcuts_view)), "changed",
+  g_signal_connect(gtk_tree_view_get_selection(shortcuts_view), "changed",
                    G_CALLBACK(_shortcut_selection_changed), actions_view);
 
   renderer = gtk_cell_renderer_text_new();
@@ -3053,7 +3047,7 @@ GtkWidget *dt_shortcuts_prefs(GtkWidget *widget)
 
   const int split_position = dt_conf_get_int("shortcuts/window_split");
   if(split_position) gtk_paned_set_position(GTK_PANED(container), split_position);
-  g_signal_connect(G_OBJECT(container), "notify::position",
+  g_signal_connect(container, "notify::position",
                    G_CALLBACK(_resize_shortcuts_view), container);
 
   GtkWidget *btn_fallbacks = gtk_check_button_new_with_label(_("enable fallbacks"));
@@ -3070,20 +3064,19 @@ GtkWidget *dt_shortcuts_prefs(GtkWidget *widget)
 
   GtkWidget *btn_restore = gtk_button_new_with_label(_("restore..."));
   gtk_widget_set_tooltip_text(btn_restore, _("restore default shortcuts or previous state"));
-  g_signal_connect(btn_restore, "clicked", G_CALLBACK(_restore_clicked), NULL);
+  g_signal_connect(GTK_BUTTON(btn_restore), "clicked", G_CALLBACK(_restore_clicked), NULL);
 
   GtkWidget *btn_importx = gtk_button_new_with_label(_("import extras"));
   gtk_widget_set_tooltip_text(btn_importx, _("import extended default shortcuts"));
-  g_signal_connect(btn_importx, "clicked", G_CALLBACK(_import_extended_clicked), NULL);
+  g_signal_connect(GTK_BUTTON(btn_importx), "clicked", G_CALLBACK(_import_extended_clicked), NULL);
 
   GtkWidget *btn_import = gtk_button_new_with_label(_("import..."));
   gtk_widget_set_tooltip_text(btn_import, _("fully or partially import shortcuts from file"));
-  g_signal_connect(btn_import, "clicked", G_CALLBACK(_import_clicked), NULL);
+  g_signal_connect(GTK_BUTTON(btn_import), "clicked", G_CALLBACK(_import_clicked), NULL);
 
   GtkWidget *btn_export = gtk_button_new_with_label(_("export..."));
   gtk_widget_set_tooltip_text(btn_export, _("fully or partially export shortcuts to file"));
-  g_signal_connect(btn_export, "clicked", G_CALLBACK(_export_clicked), NULL);
-
+  g_signal_connect(GTK_BUTTON(btn_export), "clicked", G_CALLBACK(_export_clicked), NULL);
   GtkWidget *button_bar = dt_gui_hbox(search_actions, search_shortcuts, btn_fallbacks,
                                       dt_gui_align_right(btn_help), btn_export, btn_importx,
                                       btn_import, btn_restore);
@@ -4910,7 +4903,7 @@ dt_action_t *dt_action_define(dt_action_t *owner,
       }
 
       gtk_widget_set_has_tooltip(widget, TRUE);
-      g_signal_connect(G_OBJECT(widget), "leave-notify-event",
+      g_signal_connect(widget, "leave-notify-event",
                        G_CALLBACK(_reset_element_on_leave), NULL);
     }
   }
@@ -5259,7 +5252,7 @@ GtkWidget *dt_action_button_new(dt_lib_module_t *self,
   gtk_label_set_ellipsize(GTK_LABEL(gtk_bin_get_child(GTK_BIN(button))),
                           PANGO_ELLIPSIZE_END);
   if(tooltip) gtk_widget_set_tooltip_text(button, tooltip);
-  g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(callback), data);
+  g_signal_connect(button, "clicked", G_CALLBACK((GtkCallback)callback), data);
 
   if(self)
   {
@@ -5285,7 +5278,7 @@ GtkWidget *dt_action_entry_new(dt_action_t *ac,
     gtk_entry_set_text (GTK_ENTRY(entry), text);
   if(tooltip)
     gtk_widget_set_tooltip_text(entry, tooltip);
-  g_signal_connect(G_OBJECT(entry), "changed", G_CALLBACK(callback), data);
+  g_signal_connect(entry, "changed", G_CALLBACK((GtkCallback)callback), data);
 
   dt_action_define(ac, NULL, label, entry, &dt_action_def_entry);
 

--- a/src/gui/color_picker_proxy.c
+++ b/src/gui/color_picker_proxy.c
@@ -404,7 +404,7 @@ static GtkWidget *_color_picker_new(dt_iop_module_t *module,
       color_picker->picker_cst = cst;
       color_picker->fixed_cst = TRUE;
     }
-    g_signal_connect_data(G_OBJECT(button), "button-press-event",
+    g_signal_connect_data(button, "button-press-event",
                           G_CALLBACK(_color_picker_callback_button_press),
                           color_picker, (GClosureNotify)g_free, 0);
     if(w) gtk_box_pack_start(GTK_BOX(w), button, FALSE, FALSE, 0);
@@ -422,7 +422,7 @@ static GtkWidget *_color_picker_new(dt_iop_module_t *module,
       color_picker->picker_cst = cst;
       color_picker->fixed_cst = TRUE;
     }
-    g_signal_connect_data(G_OBJECT(w), "quad-pressed",
+    g_signal_connect_data(w, "quad-pressed",
                           G_CALLBACK(_color_picker_callback),
                           color_picker, (GClosureNotify)g_free, 0);
 

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -752,10 +752,10 @@ static gboolean _borders_scrolled(GtkWidget *widget,
   return TRUE;
 }
 
-static gboolean _scrollbar_changed(GtkWidget *widget,
-                                   gpointer user_data)
+static void _scrollbar_changed(GtkWidget *widget,
+                               gpointer user_data)
 {
-  if(darktable.gui->reset) return FALSE;
+  if(darktable.gui->reset) return;
 
   GtkAdjustment *adjustment_x =
     gtk_range_get_adjustment(GTK_RANGE(darktable.gui->scrollbars.hscrollbar));
@@ -766,8 +766,6 @@ static gboolean _scrollbar_changed(GtkWidget *widget,
   const gdouble value_y = gtk_adjustment_get_value(adjustment_y);
 
   dt_view_manager_scrollbar_changed(darktable.view_manager, value_x, value_y);
-
-  return TRUE;
 }
 
 gboolean _valid_window_placement(const gint saved_x,
@@ -1190,7 +1188,7 @@ static void _osx_add_view_menu_item(GtkWidget* menu,
   GtkWidget *mi = gtk_menu_item_new_with_label(label);
   gtk_menu_shell_append(GTK_MENU_SHELL(menu), mi);
   gtk_widget_show(mi);
-  g_signal_connect(G_OBJECT(mi), "activate",
+  g_signal_connect(mi, "activate",
                    G_CALLBACK(_osx_ctl_switch_mode_to), mode);
 }
 
@@ -1342,13 +1340,13 @@ int dt_gui_gtk_init(dt_gui_gtk_t *gui)
   gtk_menu_shell_append(GTK_MENU_SHELL(help_menu), help_manual);
   gtk_widget_show(help_manual);
   dt_gui_add_help_link(help_manual, "document_root");
-  g_signal_connect(G_OBJECT(help_manual), "activate",
+  g_signal_connect(help_manual, "activate",
                    G_CALLBACK(dt_gui_show_help), help_manual);
 
   GtkWidget *help_home = gtk_menu_item_new_with_label(C_("menu", "darktable Homepage"));
   gtk_menu_shell_append(GTK_MENU_SHELL(help_menu), help_home);
   gtk_widget_show(help_home);
-  g_signal_connect(G_OBJECT(help_home), "activate",
+  g_signal_connect(help_home, "activate",
                    G_CALLBACK(_open_url), "https://www.darktable.org");
 
   gtk_menu_item_set_submenu(GTK_MENU_ITEM(help_root_menu), help_menu);
@@ -1366,21 +1364,21 @@ int dt_gui_gtk_init(dt_gui_gtk_t *gui)
   // GTK automatically translates the item with index 0 so no need to localize.
   // Furthermore, the application name (darktable) is automatically appended.
   GtkWidget *mi_about = gtk_menu_item_new_with_label("About");
-  g_signal_connect(G_OBJECT(mi_about), "activate",
+  g_signal_connect(mi_about, "activate",
                    G_CALLBACK(darktable_show_about_dialog), NULL);
   gtkosx_application_insert_app_menu_item(OSXApp, mi_about, 0);
 
   GtkWidget *mi_prefs = gtk_menu_item_new_with_label(C_("menu", "Preferences"));
-  g_signal_connect(G_OBJECT(mi_prefs), "activate",
+  g_signal_connect(mi_prefs, "activate",
                    G_CALLBACK(dt_gui_preferences_show), NULL);
   gtkosx_application_insert_app_menu_item(OSXApp, mi_prefs, 1);
 
   gtkosx_application_set_window_menu(OSXApp, GTK_MENU_ITEM(window_root_menu));
   gtkosx_application_set_help_menu(OSXApp, GTK_MENU_ITEM(help_root_menu));
 
-  g_signal_connect(G_OBJECT(OSXApp), "NSApplicationBlockTermination",
+  g_signal_connect(OSXApp, "NSApplicationBlockTermination",
                    G_CALLBACK(_osx_quit_callback), NULL);
-  g_signal_connect(G_OBJECT(OSXApp), "NSApplicationOpenFile",
+  g_signal_connect(OSXApp, "NSApplicationOpenFile",
                    G_CALLBACK(_osx_openfile_callback), NULL);
 #endif
 
@@ -1431,7 +1429,7 @@ int dt_gui_gtk_init(dt_gui_gtk_t *gui)
   _init_widgets(gui);
 
   widget = dt_ui_center(darktable.gui->ui);
-  g_signal_connect(G_OBJECT(widget), "configure-event",
+  g_signal_connect(widget, "configure-event",
                   G_CALLBACK(_configure), gui);
   for(int i = 2; i; i--, widget = dt_ui_snapshot(darktable.gui->ui))
   {
@@ -1440,19 +1438,19 @@ int dt_gui_gtk_init(dt_gui_gtk_t *gui)
                           | GDK_BUTTON_RELEASE_MASK | GDK_ENTER_NOTIFY_MASK
                           | GDK_LEAVE_NOTIFY_MASK | darktable.gui->scroll_mask);
 
-    g_signal_connect(G_OBJECT(widget), "draw",
+    g_signal_connect(widget, "draw",
                     G_CALLBACK(_draw), NULL);
-    g_signal_connect(G_OBJECT(widget), "motion-notify-event",
+    g_signal_connect(widget, "motion-notify-event",
                     G_CALLBACK(_mouse_moved), gui);
-    g_signal_connect(G_OBJECT(widget), "leave-notify-event",
+    g_signal_connect(widget, "leave-notify-event",
                     G_CALLBACK(_center_leave), NULL);
-    g_signal_connect(G_OBJECT(widget), "enter-notify-event",
+    g_signal_connect(widget, "enter-notify-event",
                     G_CALLBACK(_center_enter), NULL);
-    g_signal_connect(G_OBJECT(widget), "button-press-event",
+    g_signal_connect(widget, "button-press-event",
                     G_CALLBACK(_button_pressed), NULL);
-    g_signal_connect(G_OBJECT(widget), "button-release-event",
+    g_signal_connect(widget, "button-release-event",
                     G_CALLBACK(_button_released), NULL);
-    g_signal_connect(G_OBJECT(widget), "scroll-event",
+    g_signal_connect(widget, "scroll-event",
                     G_CALLBACK(_scrolled), NULL);
   }
 
@@ -1460,11 +1458,11 @@ int dt_gui_gtk_init(dt_gui_gtk_t *gui)
   // leave-notify-event
 
   widget = darktable.gui->scrollbars.vscrollbar;
-  g_signal_connect(G_OBJECT(widget), "value-changed",
+  g_signal_connect(widget, "value-changed",
                    G_CALLBACK(_scrollbar_changed), NULL);
 
   widget = darktable.gui->scrollbars.hscrollbar;
-  g_signal_connect(G_OBJECT(widget), "value-changed",
+  g_signal_connect(widget, "value-changed",
                    G_CALLBACK(_scrollbar_changed), NULL);
 
   dt_action_t *pnl = dt_action_section(&darktable.control->actions_global, N_("panels"));
@@ -1501,7 +1499,7 @@ int dt_gui_gtk_init(dt_gui_gtk_t *gui)
   */
   // update the profile when the window is moved. resize is already handled in configure()
   widget = dt_ui_main_window(darktable.gui->ui);
-  g_signal_connect(G_OBJECT(widget), "configure-event",
+  g_signal_connect(widget, "configure-event",
                    G_CALLBACK(_window_configure), NULL);
   g_signal_override_class_handler("query-tooltip", gtk_widget_get_type(),
                                   G_CALLBACK(dt_shortcut_tooltip_callback));
@@ -1590,7 +1588,7 @@ int dt_gui_gtk_init(dt_gui_gtk_t *gui)
     dtgtk_togglebutton_new(dtgtk_cairo_paint_focus_peaking, 0, NULL);
   gtk_widget_set_tooltip_text(darktable.gui->focus_peaking_button,
                               _("toggle focus-peaking mode"));
-  g_signal_connect(G_OBJECT(darktable.gui->focus_peaking_button), "clicked",
+  g_signal_connect(darktable.gui->focus_peaking_button, "clicked",
                    G_CALLBACK(_focuspeaking_switch_button_callback), NULL);
   _update_focus_peaking_button();
 
@@ -1689,27 +1687,19 @@ void dt_configure_ppd_dpi(dt_gui_gtk_t *gui)
 }
 
 static gboolean _focus_in_out_event(GtkWidget *widget,
-                                    GdkEvent *event,
-                                    const gpointer user_data)
+                                    GdkEventFocus *event,
+                                    GtkWidget *window)
 {
-  gtk_window_set_urgency_hint(GTK_WINDOW(user_data), FALSE);
+  gtk_window_set_urgency_hint(GTK_WINDOW(window), FALSE);
   return FALSE;
 }
 
 
 static gboolean _ui_log_button_press_event(GtkWidget *widget,
                                            GdkEvent *event,
-                                           const gpointer user_data)
+                                           GtkWidget *log)
 {
-  gtk_widget_hide(GTK_WIDGET(user_data));
-  return TRUE;
-}
-
-static gboolean _ui_toast_button_press_event(GtkWidget *widget,
-                                             GdkEvent *event,
-                                             const gpointer user_data)
-{
-  gtk_widget_hide(GTK_WIDGET(user_data));
+  gtk_widget_hide(log);
   return TRUE;
 }
 
@@ -1767,11 +1757,11 @@ static void _init_widgets(dt_gui_gtk_t *gui)
   gtk_window_set_icon_name(GTK_WINDOW(widget), "darktable");
   gtk_window_set_title(GTK_WINDOW(widget), "darktable");
 
-  g_signal_connect(G_OBJECT(widget), "delete_event",
+  g_signal_connect(widget, "delete-event",
                    G_CALLBACK(_gui_quit_callback), NULL);
-  g_signal_connect(G_OBJECT(widget), "focus-in-event",
+  g_signal_connect(widget, "focus-in-event",
                    G_CALLBACK(_focus_in_out_event), widget);
-  g_signal_connect(G_OBJECT(widget), "focus-out-event",
+  g_signal_connect(widget, "focus-out-event",
                    G_CALLBACK(_focus_in_out_event), widget);
 
   container = widget;
@@ -1866,7 +1856,7 @@ static void _init_main_table(GtkWidget *container)
   /* the log message */
   GtkWidget *eb = gtk_event_box_new();
   darktable.gui->ui->log_msg = gtk_label_new("");
-  g_signal_connect(G_OBJECT(eb), "button-press-event",
+  g_signal_connect(eb, "button-press-event",
                    G_CALLBACK(_ui_log_button_press_event),
                    darktable.gui->ui->log_msg);
   gtk_label_set_ellipsize(GTK_LABEL(darktable.gui->ui->log_msg), PANGO_ELLIPSIZE_MIDDLE);
@@ -1880,11 +1870,11 @@ static void _init_main_table(GtkWidget *container)
   /* the toast message */
   eb = gtk_event_box_new();
   darktable.gui->ui->toast_msg = gtk_label_new("");
-  g_signal_connect(G_OBJECT(eb), "button-press-event",
-                   G_CALLBACK(_ui_toast_button_press_event),
+  g_signal_connect(eb, "button-press-event",
+                   G_CALLBACK(_ui_log_button_press_event),
                    darktable.gui->ui->toast_msg);
   gtk_widget_set_events(eb, GDK_BUTTON_PRESS_MASK | darktable.gui->scroll_mask);
-  g_signal_connect(G_OBJECT(eb), "scroll-event", G_CALLBACK(_scrolled), NULL);
+  g_signal_connect(eb, "scroll-event", G_CALLBACK(_scrolled), NULL);
   gtk_label_set_ellipsize(GTK_LABEL(darktable.gui->ui->toast_msg), PANGO_ELLIPSIZE_MIDDLE);
 
   PangoAttrList *attrlist = pango_attr_list_new();
@@ -2353,7 +2343,8 @@ static GtkWidget *_ui_init_panel_container_top(GtkWidget *container)
 }
 
 static gboolean _ui_init_panel_container_center_scroll_event(GtkWidget *widget,
-                                                             const GdkEventScroll *event)
+                                                             const GdkEventScroll *event,
+                                                             gpointer user_data)
 {
   // just make sure nothing happens unless ctrl-alt are pressed:
   return (((event->state & gtk_accelerator_get_default_mod_mask())
@@ -2361,7 +2352,7 @@ static gboolean _ui_init_panel_container_center_scroll_event(GtkWidget *widget,
           != dt_conf_get_bool("darkroom/ui/sidebar_scroll_default"));
 }
 
-static gboolean _on_drag_motion_drop(GtkWidget *empty, GdkDragContext *dc, const gint x, const gint y, const guint time, const gboolean drop)
+static gboolean _on_drag_motion_drop(GtkWidget *empty, GdkDragContext *dc, const gint x, const gint y, const guint time, gpointer drop)
 {
   GtkWidget *widget = gtk_widget_get_parent(empty);
   if(drop) gtk_widget_set_opacity(gtk_drag_get_source_widget(dc), 1.0);
@@ -2489,14 +2480,13 @@ static GtkWidget *_ui_init_panel_container_center(GtkWidget *container,
   gtk_scrolled_window_set_propagate_natural_width(GTK_SCROLLED_WINDOW(widget), TRUE);
 
   // we want the left/right window border to scroll the module lists
-  g_signal_connect(G_OBJECT(left
-                            ? darktable.gui->widgets.right_border
-                            : darktable.gui->widgets.left_border),
+  g_signal_connect(left ? darktable.gui->widgets.right_border
+                        : darktable.gui->widgets.left_border,
                    "scroll-event", G_CALLBACK(_borders_scrolled), widget);
 
   /* avoid scrolling with wheel, it's distracting (you'll end up over
    * a control, and scroll it's value) */
-  g_signal_connect(G_OBJECT(widget), "scroll-event",
+  g_signal_connect(widget, "scroll-event",
                    G_CALLBACK(_ui_init_panel_container_center_scroll_event),
                    NULL);
 
@@ -2532,7 +2522,7 @@ static GtkWidget *_ui_init_panel_container_bottom(GtkWidget *container)
 
 static gboolean _panel_handle_button_callback(GtkWidget *w,
                                               const GdkEventButton *e,
-                                              gpointer user_data)
+                                              GtkWidget *widget)
 {
   if(e->button == GDK_BUTTON_PRIMARY)
   {
@@ -2563,7 +2553,7 @@ static gboolean _panel_handle_button_callback(GtkWidget *w,
 }
 static gboolean _panel_handle_cursor_callback(GtkWidget *w,
                                               const GdkEventCrossing *e,
-                                              gpointer user_data)
+                                              GtkWidget *widget)
 {
   if(strcmp(gtk_widget_get_name(w), "panel-handle-bottom") == 0)
     dt_control_change_cursor((e->type == GDK_ENTER_NOTIFY)
@@ -2577,9 +2567,8 @@ static gboolean _panel_handle_cursor_callback(GtkWidget *w,
 }
 static gboolean _panel_handle_motion_callback(GtkWidget *w,
                                               const GdkEventMotion *e,
-                                              const gpointer user_data)
+                                              GtkWidget *widget)
 {
-  GtkWidget *widget = (GtkWidget *)user_data;
   if(darktable.gui->widgets.panel_handle_dragging)
   {
     gint sx = gtk_widget_get_allocated_width(widget);
@@ -2639,15 +2628,15 @@ static void _ui_init_panel_left(dt_ui_t *ui,
                         | GDK_LEAVE_NOTIFY_MASK | GDK_POINTER_MOTION_MASK);
   gtk_widget_set_name(GTK_WIDGET(handle), "panel-handle-left");
 
-  g_signal_connect(G_OBJECT(handle), "button-press-event",
+  g_signal_connect(handle, "button-press-event",
                    G_CALLBACK(_panel_handle_button_callback), handle);
-  g_signal_connect(G_OBJECT(handle), "button-release-event",
+  g_signal_connect(handle, "button-release-event",
                    G_CALLBACK(_panel_handle_button_callback), handle);
-  g_signal_connect(G_OBJECT(handle), "motion-notify-event",
+  g_signal_connect(handle, "motion-notify-event",
                    G_CALLBACK(_panel_handle_motion_callback), widget);
-  g_signal_connect(G_OBJECT(handle), "leave-notify-event",
+  g_signal_connect(handle, "leave-notify-event",
                    G_CALLBACK(_panel_handle_cursor_callback), handle);
-  g_signal_connect(G_OBJECT(handle), "enter-notify-event",
+  g_signal_connect(handle, "enter-notify-event",
                    G_CALLBACK(_panel_handle_cursor_callback), handle);
   gtk_widget_show(handle);
 
@@ -2689,15 +2678,15 @@ static void _ui_init_panel_right(dt_ui_t *ui,
                         | GDK_ENTER_NOTIFY_MASK
                         | GDK_LEAVE_NOTIFY_MASK | GDK_POINTER_MOTION_MASK);
   gtk_widget_set_name(GTK_WIDGET(handle), "panel-handle-right");
-  g_signal_connect(G_OBJECT(handle), "button-press-event",
+  g_signal_connect(handle, "button-press-event",
                    G_CALLBACK(_panel_handle_button_callback), handle);
-  g_signal_connect(G_OBJECT(handle), "button-release-event",
+  g_signal_connect(handle, "button-release-event",
                    G_CALLBACK(_panel_handle_button_callback), handle);
-  g_signal_connect(G_OBJECT(handle), "motion-notify-event",
+  g_signal_connect(handle, "motion-notify-event",
                    G_CALLBACK(_panel_handle_motion_callback), widget);
-  g_signal_connect(G_OBJECT(handle), "leave-notify-event",
+  g_signal_connect(handle, "leave-notify-event",
                    G_CALLBACK(_panel_handle_cursor_callback), handle);
-  g_signal_connect(G_OBJECT(handle), "enter-notify-event",
+  g_signal_connect(handle, "enter-notify-event",
                    G_CALLBACK(_panel_handle_cursor_callback), handle);
   gtk_widget_show(handle);
 
@@ -2776,15 +2765,15 @@ static void _ui_init_panel_bottom(dt_ui_t *ui,
                         | GDK_LEAVE_NOTIFY_MASK | GDK_POINTER_MOTION_MASK);
   gtk_widget_set_name(GTK_WIDGET(handle), "panel-handle-bottom");
 
-  g_signal_connect(G_OBJECT(handle), "button-press-event",
+  g_signal_connect(handle, "button-press-event",
                    G_CALLBACK(_panel_handle_button_callback), handle);
-  g_signal_connect(G_OBJECT(handle), "button-release-event",
+  g_signal_connect(handle, "button-release-event",
                    G_CALLBACK(_panel_handle_button_callback), handle);
-  g_signal_connect(G_OBJECT(handle), "motion-notify-event",
+  g_signal_connect(handle, "motion-notify-event",
                    G_CALLBACK(_panel_handle_motion_callback), widget);
-  g_signal_connect(G_OBJECT(handle), "leave-notify-event",
+  g_signal_connect(handle, "leave-notify-event",
                    G_CALLBACK(_panel_handle_cursor_callback), handle);
-  g_signal_connect(G_OBJECT(handle), "enter-notify-event",
+  g_signal_connect(handle, "enter-notify-event",
                    G_CALLBACK(_panel_handle_cursor_callback), handle);
   gtk_widget_show(handle);
 
@@ -3061,7 +3050,7 @@ gboolean dt_gui_show_standalone_yes_no_dialog(const char *title,
   {
     button = gtk_button_new_with_mnemonic(no_text);
     result.button_no = button;
-    g_signal_connect(G_OBJECT(button), "clicked",
+    g_signal_connect(button, "clicked",
                      G_CALLBACK(_yes_no_button_handler), &result);
     gtk_box_pack_start(GTK_BOX(hbox), button, TRUE, TRUE, 0);
   }
@@ -3070,7 +3059,7 @@ gboolean dt_gui_show_standalone_yes_no_dialog(const char *title,
   {
     button = gtk_button_new_with_mnemonic(yes_text);
     result.button_yes = button;
-    g_signal_connect(G_OBJECT(button), "clicked",
+    g_signal_connect(button, "clicked",
                      G_CALLBACK(_yes_no_button_handler), &result);
     gtk_box_pack_start(GTK_BOX(hbox), button, TRUE, TRUE, 0);
   }
@@ -3148,7 +3137,7 @@ char *dt_gui_show_standalone_string_dialog(const char *title,
   {
     button = gtk_button_new_with_label(no_text);
     result.button_no = button;
-    g_signal_connect(G_OBJECT(button), "clicked",
+    g_signal_connect(button, "clicked",
                      G_CALLBACK(_yes_no_button_handler), &result);
     gtk_box_pack_start(GTK_BOX(hbox), button, TRUE, TRUE, 0);
   }
@@ -3157,7 +3146,7 @@ char *dt_gui_show_standalone_string_dialog(const char *title,
   {
     button = gtk_button_new_with_label(yes_text);
     result.button_yes = button;
-    g_signal_connect(G_OBJECT(button), "clicked",
+    g_signal_connect(button, "clicked",
                      G_CALLBACK(_yes_no_button_handler), &result);
     gtk_box_pack_start(GTK_BOX(hbox), button, TRUE, TRUE, 0);
   }
@@ -3274,7 +3263,7 @@ static char *_get_base_url()
     return base_url;
 }
 
-void dt_gui_show_help(GtkWidget *widget)
+void dt_gui_show_help(GtkWidget *widget, gpointer user_data)
 {
   // TODO: When the widget doesn't have a help url set we should
   // probably look at the parent(s)
@@ -3603,7 +3592,7 @@ static void _reset_all_bauhaus(GtkNotebook *notebook,
 
 static void _notebook_size_callback(GtkNotebook *notebook,
                                     GdkRectangle *allocation,
-                                    gpointer *data)
+                                    gpointer data)
 {
   const int n = gtk_notebook_get_n_pages(notebook);
   g_return_if_fail(n > 0);
@@ -3820,13 +3809,13 @@ GtkWidget *dt_ui_notebook_page(GtkNotebook *notebook,
      !g_signal_handler_find(G_OBJECT(notebook),
                             G_SIGNAL_MATCH_FUNC, 0, 0, NULL, _notebook_size_callback, NULL))
   {
-    g_signal_connect(G_OBJECT(notebook), "size-allocate",
+    g_signal_connect(notebook, "size-allocate",
                      G_CALLBACK(_notebook_size_callback), NULL);
-    g_signal_connect(G_OBJECT(notebook), "motion-notify-event",
+    g_signal_connect(notebook, "motion-notify-event",
                      G_CALLBACK(_notebook_motion_notify_callback), NULL);
-    g_signal_connect(G_OBJECT(notebook), "scroll-event",
+    g_signal_connect(notebook, "scroll-event",
                      G_CALLBACK(_notebook_scroll_callback), NULL);
-    g_signal_connect(G_OBJECT(notebook), "button-press-event",
+    g_signal_connect(notebook, "button-press-event",
                      G_CALLBACK(_notebook_button_press_callback), NULL);
     gtk_widget_add_events(GTK_WIDGET(notebook), darktable.gui->scroll_mask);
   }
@@ -3915,8 +3904,8 @@ static gint _get_container_row_heigth(GtkWidget *w)
 }
 
 static gboolean _resize_wrap_draw(GtkWidget *w,
-                                  void *cr,
-                                  const char *config_str)
+                                  cairo_t *cr,
+                                  char *config_str)
 {
   GtkWidget *sw = gtk_widget_get_parent(w);
   if(GTK_IS_VIEWPORT(sw)) sw = gtk_widget_get_parent(sw);
@@ -3972,7 +3961,7 @@ static gboolean _resize_wrap_draw(GtkWidget *w,
 
 static gboolean _resize_wrap_scroll(GtkScrolledWindow *sw,
                                     GdkEventScroll *event,
-                                    const char *config_str)
+                                    char *config_str)
 {
   // no move needed
   int delta_y = 0;
@@ -4018,7 +4007,7 @@ static gboolean _resize_wrap_scroll(GtkScrolledWindow *sw,
 
 static gboolean _scroll_wrap_height(GtkWidget *w,
                                     const GdkEventScroll *event,
-                                    const char *config_str)
+                                    char *config_str)
 {
   if(dt_modifier_is(event->state, GDK_SHIFT_MASK | GDK_MOD1_MASK))
   {
@@ -4062,7 +4051,7 @@ static gboolean _resize_wrap_draw_handle(GtkWidget *w,
 
 static gboolean _resize_wrap_motion(GtkWidget *widget,
                                     const GdkEventMotion *event,
-                                    const char *config_str)
+                                    char *config_str)
 {
   if(_resize_wrap_dragging)
   {
@@ -4094,7 +4083,7 @@ static gboolean _resize_wrap_motion(GtkWidget *widget,
 
 static gboolean _resize_wrap_button(GtkWidget *widget,
                                     const GdkEventButton *event,
-                                    const char *config_str)
+                                    char *config_str)
 {
   if(_resize_wrap_dragging
      && event->type == GDK_BUTTON_RELEASE)
@@ -4113,10 +4102,9 @@ static gboolean _resize_wrap_button(GtkWidget *widget,
 
   return FALSE;
 }
-
 static gboolean _resize_wrap_enter_leave(GtkWidget *widget,
                                          const GdkEventCrossing *event,
-                                         const char *config_str)
+                                         char *config_str)
 {
   _resize_wrap_hovered =
     event->type == GDK_ENTER_NOTIFY
@@ -4147,10 +4135,9 @@ GtkWidget *dt_ui_resize_wrap(GtkWidget *w,
   {
     const float height = dt_conf_get_int(config_str);
     dtgtk_drawing_area_set_height(w, height);
-    g_signal_connect(G_OBJECT(w),
-                              "scroll-event",
-                              G_CALLBACK(_scroll_wrap_height),
-                              config_str);
+    g_signal_connect(w, "scroll-event",
+                     G_CALLBACK(_scroll_wrap_height),
+                     config_str);
   }
   else
   {
@@ -4159,9 +4146,9 @@ GtkWidget *dt_ui_resize_wrap(GtkWidget *w,
                                    GTK_POLICY_NEVER, GTK_POLICY_AUTOMATIC);
     gtk_scrolled_window_set_min_content_height
       (GTK_SCROLLED_WINDOW(sw), - DT_PIXEL_APPLY_DPI(min_size));
-    g_signal_connect(G_OBJECT(sw), "scroll-event",
+    g_signal_connect(GTK_SCROLLED_WINDOW(sw), "scroll-event",
                      G_CALLBACK(_resize_wrap_scroll), config_str);
-    g_signal_connect(G_OBJECT(w), "draw",
+    g_signal_connect(w, "draw",
                      G_CALLBACK(_resize_wrap_draw), config_str);
     gtk_widget_set_margin_bottom(sw, DT_RESIZE_HANDLE_SIZE);
     w = gtk_event_box_new();
@@ -4171,17 +4158,17 @@ GtkWidget *dt_ui_resize_wrap(GtkWidget *w,
   gtk_widget_add_events(w, GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK
                          | GDK_ENTER_NOTIFY_MASK | GDK_LEAVE_NOTIFY_MASK
                          | GDK_POINTER_MOTION_MASK | darktable.gui->scroll_mask);
-  g_signal_connect(G_OBJECT(w), "motion-notify-event",
+  g_signal_connect(w, "motion-notify-event",
                    G_CALLBACK(_resize_wrap_motion), config_str);
-  g_signal_connect(G_OBJECT(w), "button-press-event",
+  g_signal_connect(w, "button-press-event",
                    G_CALLBACK(_resize_wrap_button), config_str);
-  g_signal_connect(G_OBJECT(w), "button-release-event",
+  g_signal_connect(w, "button-release-event",
                    G_CALLBACK(_resize_wrap_button), config_str);
-  g_signal_connect(G_OBJECT(w), "enter-notify-event",
+  g_signal_connect(w, "enter-notify-event",
                    G_CALLBACK(_resize_wrap_enter_leave), config_str);
-  g_signal_connect(G_OBJECT(w), "leave-notify-event",
+  g_signal_connect(w, "leave-notify-event",
                    G_CALLBACK(_resize_wrap_enter_leave), config_str);
-  g_signal_connect_after(G_OBJECT(w), "draw",
+  g_signal_connect_after(w, "draw",
                          G_CALLBACK(_resize_wrap_draw_handle), NULL);
 
   return w;
@@ -4256,7 +4243,7 @@ void dt_gui_menu_popup(GtkMenu *menu,
 {
   gtk_widget_show_all(GTK_WIDGET(menu));
   g_object_ref_sink(G_OBJECT(menu));
-  g_signal_connect(G_OBJECT(menu), "deactivate", G_CALLBACK(g_object_unref), NULL);
+  g_signal_connect(menu, "deactivate", G_CALLBACK(g_object_unref), NULL);
 
   GdkEvent *event = gtk_get_current_event();
   if(button && event)
@@ -4310,7 +4297,7 @@ gboolean dt_gui_search_start(GtkWidget *widget,
                              GdkEventKey *event,
                              GtkSearchEntry *entry)
 {
-  if(gtk_search_entry_handle_event(entry, (GdkEvent *)event))
+  if(gtk_search_entry_handle_event(GTK_SEARCH_ENTRY(entry), (GdkEvent *)event))
   {
     gtk_entry_grab_focus_without_selecting(GTK_ENTRY(entry));
     return TRUE;
@@ -4320,27 +4307,25 @@ gboolean dt_gui_search_start(GtkWidget *widget,
 }
 
 void dt_gui_search_stop(GtkSearchEntry *entry,
-                        GtkWidget *widget)
+                        GtkTreeView *widget)
 {
-  gtk_widget_grab_focus(widget);
+  gtk_widget_grab_focus(GTK_WIDGET(widget));
 
   gtk_entry_set_text(GTK_ENTRY(entry), "");
 
-  if(GTK_IS_TREE_VIEW(widget))
+  if(widget)
   {
     GtkTreePath *path = NULL;
-    gtk_tree_view_get_cursor(GTK_TREE_VIEW(widget), &path, NULL);
+    gtk_tree_view_get_cursor(widget, &path, NULL);
     gtk_tree_selection_select_path
-      (gtk_tree_view_get_selection(GTK_TREE_VIEW(widget)), path);
+      (gtk_tree_view_get_selection(widget), path);
     gtk_tree_path_free(path);
   }
 }
 
-static void _collapse_button_changed(GtkDarktableToggleButton *widget,
-                                     const gpointer user_data)
+static void _collapse_button_changed(GtkWidget *widget,
+                                     dt_gui_collapsible_section_t *cs)
 {
-  const dt_gui_collapsible_section_t *cs = (dt_gui_collapsible_section_t *)user_data;
-
   if(cs->module && cs->module->type == DT_ACTION_TYPE_IOP_INSTANCE)
       dt_iop_request_focus((dt_iop_module_t *)cs->module);
   else if(cs->module && cs->module->type == DT_ACTION_TYPE_LIB)
@@ -4356,11 +4341,9 @@ static void _collapse_button_changed(GtkDarktableToggleButton *widget,
 
 static gboolean _collapse_expander_click(GtkWidget *widget,
                                          const GdkEventButton *e,
-                                         const gpointer user_data)
+                                         dt_gui_collapsible_section_t *cs)
 {
   if(e->button != 1) return FALSE;
-
-  const dt_gui_collapsible_section_t *cs = (dt_gui_collapsible_section_t *)user_data;
 
   const gboolean active = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(cs->toggle));
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(cs->toggle), !active);
@@ -4424,10 +4407,10 @@ void dt_gui_new_collapsible_section(dt_gui_collapsible_section_t *cs,
   dtgtk_expander_set_expanded(DTGTK_EXPANDER(cs->expander), expanded);
   gtk_widget_set_name(cs->expander, "collapse-block");
 
-  g_signal_connect(G_OBJECT(cs->toggle), "toggled",
+  g_signal_connect(cs->toggle, "toggled",
                    G_CALLBACK(_collapse_button_changed), cs);
 
-  g_signal_connect(G_OBJECT(header_evb), "button-press-event",
+  g_signal_connect(header_evb, "button-press-event",
                    G_CALLBACK(_collapse_expander_click), cs);
 }
 
@@ -4448,9 +4431,9 @@ gboolean dt_gui_long_click(const guint second,
   return second - delay > first;
 }
 
-static void _gesture_cancel(GtkGestureSingle *gesture,
+static void _gesture_cancel(GtkGesture *gesture,
                             GdkEventSequence *sequence,
-                            GtkWidget *widget)
+                            gpointer user_data)
 {
   g_signal_emit_by_name(gesture, "released", 1, .0, .0);
 }
@@ -4461,14 +4444,14 @@ GtkGestureSingle *(dt_gui_connect_click)(GtkWidget *widget,
                                          gpointer data)
 {
   GtkGesture *gesture = gtk_gesture_multi_press_new(widget);
-  g_object_weak_ref(G_OBJECT (widget), (GWeakNotify) g_object_unref, gesture);
+  g_object_weak_ref(G_OBJECT(widget), (GWeakNotify) g_object_unref, gesture);
   // GTK4 GtkGesture *gesture = gtk_gesture_click_new();
   //      gtk_widget_add_controller(widget, GTK_EVENT_CONTROLLER(gesture));
 
-  if(pressed) g_signal_connect(gesture, "pressed", pressed, data);
+  if(pressed) g_signal_connect(gesture, "pressed", G_CALLBACK(pressed), data);
   if(released)
   {
-    g_signal_connect(gesture, "released", released, data);
+    g_signal_connect(gesture, "released", G_CALLBACK(released), data);
     g_signal_connect(gesture, "cancel", G_CALLBACK(_gesture_cancel), NULL);
   }
 
@@ -4488,9 +4471,9 @@ GtkEventController *(dt_gui_connect_motion)(GtkWidget *widget,
 
   gtk_widget_add_events(widget, GDK_ENTER_NOTIFY_MASK | GDK_LEAVE_NOTIFY_MASK); // still needed for now by _main_do_event_keymap
 
-  if(motion) g_signal_connect(controller, "motion", motion, data);
-  if(enter) g_signal_connect(controller, "enter", enter, data);
-  if(leave) g_signal_connect(controller, "leave", leave, data);
+  if(motion) g_signal_connect(controller, "motion", G_CALLBACK(motion), data);
+  if(enter) g_signal_connect(controller, "enter", G_CALLBACK(enter), data);
+  if(leave) g_signal_connect(controller, "leave", G_CALLBACK(leave), data);
 
   return controller;
 }

--- a/src/gui/gtk.h
+++ b/src/gui/gtk.h
@@ -580,11 +580,52 @@ static inline GCallback G_CALLBACK(void *f) { return (GCallback)f; } // as a mac
 #define DISABLINGPREFIXG_CALLBACK
 
 #define SIGNAME(num, signal, name) !strcmp((signal), #name) ? 1 << num :
-#define RETURN_HANDLER(num, ret, instance, data, ...) ret(*)(__typeof__(instance), __VA_OPT__(__VA_ARGS__,) __typeof__(data)) : 1 << num,
+#define RETURN_HANDLER(num, ret, instance, data, ...) ret(*)(instance, __VA_OPT__(__VA_ARGS__,) data) : 1 << num,
 #define BOOL_HANDLER(num, instance, data, ...) RETURN_HANDLER(num, gboolean, instance, data, __VA_ARGS__)
 #define VOID_HANDLER(num, instance, data, ...) RETURN_HANDLER(num, void, instance, data, __VA_ARGS__)
 #define EVENT_HANDLER(num, instance, data, event) BOOL_HANDLER(num, instance, data, GdkEvent##event*) \
                                                   BOOL_HANDLER(num, instance, data, const GdkEvent##event*)
+#define MATCH_HANDLER(c_handler, instance, data) \
+  _Generic((DISABLINGPREFIX##c_handler), \
+    GCallback : 1 << 0, \
+    EVENT_HANDLER(1, instance, data, ) \
+    EVENT_HANDLER(1, instance, data, Button) \
+    EVENT_HANDLER(1, instance, data, Motion) \
+    EVENT_HANDLER(1, instance, data, Scroll) \
+    EVENT_HANDLER(1, instance, data, Key) \
+    EVENT_HANDLER(1, instance, data, Focus) \
+    EVENT_HANDLER(1, instance, data, Crossing) \
+    EVENT_HANDLER(1, instance, data, Configure) \
+    VOID_HANDLER( 2, instance, data) \
+    VOID_HANDLER( 3, instance, data, char*, GtkTreeIter*) \
+    VOID_HANDLER( 4, instance, data, GdkRectangle*, GdkRectangle*, gboolean, gboolean) \
+    VOID_HANDLER( 5, instance, data, char*) \
+    BOOL_HANDLER( 6, instance, data, gint, gint, gboolean, GtkTooltip*) \
+    BOOL_HANDLER( 7, instance, data, cairo_t*) \
+    VOID_HANDLER( 8, instance, data, GtkWidget*) \
+    VOID_HANDLER( 8, instance, data, GdkRectangle*) \
+    VOID_HANDLER( 8, instance, data, GdkEventSequence*) \
+    VOID_HANDLER( 8, instance, data, GdkDragContext*) \
+    VOID_HANDLER( 9, instance, data, GdkDragContext*, guint) \
+    VOID_HANDLER( 9, instance, data, GtkWidget*, guint) \
+    BOOL_HANDLER(10, instance, data, GdkDragContext*, const gint, const gint, const guint) \
+    VOID_HANDLER(11, instance, data, GtkTreePath*, GtkTreeViewColumn*) \
+    VOID_HANDLER(12, instance, data, gint) \
+    VOID_HANDLER(13, instance, data, GdkDragContext*, gint, gint, GtkSelectionData*, guint, guint) \
+    VOID_HANDLER(14, instance, data, GdkDragContext*, GtkSelectionData*, guint, guint) \
+    BOOL_HANDLER(15, instance, data, GdkDragContext*, GtkDragResult) \
+    VOID_HANDLER(16, instance, data, GtkCellEditable*, char*) \
+    VOID_HANDLER(17, instance, data, const gchar*, const gchar*) \
+    BOOL_HANDLER(18, instance, data, GtkDirectionType) \
+    BOOL_HANDLER(19, instance, data) \
+    VOID_HANDLER(20, instance, data, const gchar*, const gint, gint*) \
+    VOID_HANDLER(21, instance, data, GtkTreePath*, GtkTreeIter*) \
+    VOID_HANDLER(22, instance, data, GParamSpec*) \
+    VOID_HANDLER(23, instance, data, GtkTreeIter*, GtkTreePath*) \
+    BOOL_HANDLER(24, instance, data, GtkTreeModel*, GtkTreeIter*) \
+    default : 0)
+#define MATCH_HANDLER_BOTH(c_handler, instance, data) MATCH_HANDLER(c_handler, instance, data) ?: \
+                                                      MATCH_HANDLER(c_handler, instance, gpointer)
 #undef _Static_assert
 #undef  g_signal_connect
 #define g_signal_connect(instance, signal, c_handler, user_data) do { \
@@ -658,50 +699,21 @@ static inline GCallback G_CALLBACK(void *f) { return (GCallback)f; } // as a mac
     SIGNAME(23, signal, row-expanded) \
     SIGNAME(24, signal, match-selected) \
     0; \
-  const int found_signature = _Generic((DISABLINGPREFIX##c_handler), \
-    GCallback : 1 << 0, \
-    EVENT_HANDLER(1, instance, user_data, ) \
-    EVENT_HANDLER(1, instance, user_data, Button) \
-    EVENT_HANDLER(1, instance, user_data, Motion) \
-    EVENT_HANDLER(1, instance, user_data, Scroll) \
-    EVENT_HANDLER(1, instance, user_data, Key) \
-    EVENT_HANDLER(1, instance, user_data, Focus) \
-    EVENT_HANDLER(1, instance, user_data, Crossing) \
-    EVENT_HANDLER(1, instance, user_data, Configure) \
-    VOID_HANDLER( 2, instance, user_data) \
-    VOID_HANDLER( 3, instance, user_data, char*, GtkTreeIter*) \
-    VOID_HANDLER( 4, instance, user_data, GdkRectangle*, GdkRectangle*, gboolean, gboolean) \
-    VOID_HANDLER( 5, instance, user_data, char*) \
-    BOOL_HANDLER( 6, instance, user_data, gint, gint, gboolean, GtkTooltip*) \
-    BOOL_HANDLER( 7, instance, user_data, cairo_t*) \
-    VOID_HANDLER( 8, instance, user_data, GtkWidget*) \
-    VOID_HANDLER( 8, instance, user_data, GdkRectangle*) \
-    VOID_HANDLER( 8, instance, user_data, GdkEventSequence*) \
-    VOID_HANDLER( 8, instance, user_data, GdkDragContext*) \
-    VOID_HANDLER( 9, instance, user_data, GdkDragContext*, guint) \
-    VOID_HANDLER( 9, instance, user_data, GtkWidget*, guint) \
-    BOOL_HANDLER(10, instance, user_data, GdkDragContext*, const gint, const gint, const guint) \
-    VOID_HANDLER(11, instance, user_data, GtkTreePath*, GtkTreeViewColumn*) \
-    VOID_HANDLER(12, instance, user_data, gint) \
-    VOID_HANDLER(13, instance, user_data, GdkDragContext*, gint, gint, GtkSelectionData*, guint, guint) \
-    VOID_HANDLER(14, instance, user_data, GdkDragContext*, GtkSelectionData*, guint, guint) \
-    BOOL_HANDLER(15, instance, user_data, GdkDragContext*, GtkDragResult) \
-    VOID_HANDLER(16, instance, user_data, GtkCellEditable*, char*) \
-    VOID_HANDLER(17, instance, user_data, const gchar*, const gchar*) \
-    BOOL_HANDLER(18, instance, user_data, GtkDirectionType) \
-    BOOL_HANDLER(19, instance, user_data) \
-    VOID_HANDLER(20, instance, user_data, const gchar*, const gint, gint*) \
-    VOID_HANDLER(21, instance, user_data, GtkTreePath*, GtkTreeIter*) \
-    VOID_HANDLER(22, instance, user_data, GParamSpec*) \
-    VOID_HANDLER(23, instance, user_data, GtkTreeIter*, GtkTreePath*) \
-    BOOL_HANDLER(24, instance, user_data, GtkTreeModel*, GtkTreeIter*) \
-    default : 0); \
+  const int found_signature = MATCH_HANDLER_BOTH(c_handler, __typeof__(instance), __typeof__(user_data)) ?: \
+                              MATCH_HANDLER_BOTH(c_handler, GtkWidget*, __typeof__(user_data)) ?: \
+                              MATCH_HANDLER_BOTH(c_handler, GtkEntry*, __typeof__(user_data)) ?: \
+                              MATCH_HANDLER_BOTH(c_handler, GtkDrawingArea*, __typeof__(user_data)) ?: \
+                              MATCH_HANDLER_BOTH(c_handler, GtkTreeView*, __typeof__(user_data)) ?: \
+                              MATCH_HANDLER_BOTH(c_handler, GtkTextView*, __typeof__(user_data)) ?: \
+                              MATCH_HANDLER_BOTH(c_handler, GtkColorButton*, __typeof__(user_data)) ?: \
+                              MATCH_HANDLER_BOTH(c_handler, GtkToggleButton*, __typeof__(user_data)) ?: \
+                              MATCH_HANDLER_BOTH(c_handler, GtkButton*, __typeof__(user_data)); \
   if(required_signature == 0) \
     dt_print_nts_ext("%s:%d: connecting unknown signal %s\n", __FILE__, __LINE__, signal); \
   else if(!(required_signature & found_signature)) \
-    dt_print_nts_ext("%s:%d: connecting signal %s to %s with incorrect signature\n", __FILE__, __LINE__, signal, #c_handler); \
-  _Static_assert(required_signature, "unknown signal encountered: " signal ); \
-  /*_Static_assert(required_signature & found_signature, "incorrect function connected to " signal );*/ \
+    dt_print_nts_ext("%s:%d: connecting signal %s to %s with incorrect signature %d-%d\n", __FILE__, __LINE__, signal, #c_handler, required_signature, found_signature); \
+  /*_Static_assert(required_signature, "unknown signal encountered: " signal ); */\
+  /*_Static_assert(required_signature & found_signature, "incorrect function connected to " signal ); */\
   g_signal_connect_data ((instance), (signal), (c_handler), (user_data), NULL, (GConnectFlags) 0); } while(0)
 #endif // __cplusplus
 

--- a/src/gui/gtk.h
+++ b/src/gui/gtk.h
@@ -460,7 +460,7 @@ void dt_gui_add_help_link(GtkWidget *widget,
 char *dt_gui_get_help_url(GtkWidget *widget);
 void dt_gui_dialog_add_help(GtkDialog *dialog,
                             const char *topic);
-void dt_gui_show_help(GtkWidget *widget);
+void dt_gui_show_help(GtkWidget *widget, gpointer user_data);
 
 // load a CSS theme
 void dt_gui_load_theme(const char *theme); // read them and add user tweaks
@@ -521,7 +521,7 @@ gboolean dt_gui_search_start(GtkWidget *widget,
 
 // event handler for "stop-search" of GtkSearchEntry
 void dt_gui_search_stop(GtkSearchEntry *entry,
-                        GtkWidget *widget);
+                        GtkTreeView *widget);
 
 // create a collapsible section, insert in parent, return the container
 void dt_gui_new_collapsible_section(dt_gui_collapsible_section_t *cs,

--- a/src/gui/gtk.h
+++ b/src/gui/gtk.h
@@ -569,6 +569,142 @@ GtkEventController *(dt_gui_connect_motion)(GtkWidget *widget,
   ASSERT_FUNC_TYPE(leave, void(*)(GtkEventControllerMotion *, __typeof__(data))), \
   dt_gui_connect_motion(GTK_WIDGET(widget), G_CALLBACK(motion), G_CALLBACK(enter), G_CALLBACK(leave), (data)))
 
+// Enable compile-time checking of signal handler signatures
+// Uncomment the _Static_assert to stop compilation on mismatch
+// Otherwise errors will be printed at runtime, but only when the signal is connected
+// (so all dialogs, menus etc must be opened to see all errors)
+// No code is generated when the test is passed
+#if 1 && !defined(__cplusplus)
+#undef G_CALLBACK
+static inline GCallback G_CALLBACK(void *f) { return (GCallback)f; } // as a macro it gets expanded before reaching here
+#define DISABLINGPREFIXG_CALLBACK
+
+#define SIGNAME(num, signal, name) !strcmp((signal), #name) ? 1 << num :
+#define RETURN_HANDLER(num, ret, instance, data, ...) ret(*)(__typeof__(instance), __VA_OPT__(__VA_ARGS__,) __typeof__(data)) : 1 << num,
+#define BOOL_HANDLER(num, instance, data, ...) RETURN_HANDLER(num, gboolean, instance, data, __VA_ARGS__)
+#define VOID_HANDLER(num, instance, data, ...) RETURN_HANDLER(num, void, instance, data, __VA_ARGS__)
+#define EVENT_HANDLER(num, instance, data, event) BOOL_HANDLER(num, instance, data, GdkEvent##event*) \
+                                                  BOOL_HANDLER(num, instance, data, const GdkEvent##event*)
+#undef _Static_assert
+#undef  g_signal_connect
+#define g_signal_connect(instance, signal, c_handler, user_data) do { \
+  const int required_signature = \
+    SIGNAME( 0, signal, pressed) \
+    SIGNAME( 0, signal, released) \
+    SIGNAME( 0, signal, motion) \
+    SIGNAME( 0, signal, enter) \
+    SIGNAME( 0, signal, leave) \
+    SIGNAME( 1, signal, event) \
+    SIGNAME( 1, signal, button-press-event) \
+    SIGNAME( 1, signal, button-release-event) \
+    SIGNAME( 1, signal, motion-notify-event) \
+    SIGNAME( 1, signal, scroll-event) \
+    SIGNAME( 1, signal, enter-notify-event) \
+    SIGNAME( 1, signal, leave-notify-event) \
+    SIGNAME( 1, signal, key-press-event) \
+    SIGNAME( 1, signal, focus-out-event) \
+    SIGNAME( 1, signal, focus-in-event) \
+    SIGNAME( 1, signal, delete-event) \
+    SIGNAME( 1, signal, configure-event) \
+    SIGNAME( 1 | 1 << 2 | 1 << 3 , signal, changed) \
+    SIGNAME( 2 | 1 << 5, signal, toggled) \
+    SIGNAME( 2, signal, clicked) \
+    SIGNAME( 2, signal, value-changed) \
+    SIGNAME( 2, signal, value-reset) \
+    SIGNAME( 2, signal, quad-pressed) \
+    SIGNAME( 2, signal, show) \
+    SIGNAME( 2, signal, closed) \
+    SIGNAME( 2, signal, stopped) \
+    SIGNAME( 2, signal, stop-search) \
+    SIGNAME( 2, signal, day_selected) \
+    SIGNAME( 2, signal, day_selected-double-click) \
+    SIGNAME( 2, signal, selection-changed) \
+    SIGNAME( 2, signal, activate) \
+    SIGNAME( 2, signal, deactivate) \
+    SIGNAME( 2, signal, editing-done) \
+    SIGNAME( 2, signal, style-updated) \
+    SIGNAME( 2, signal, search-changed) \
+    SIGNAME( 2, signal, mounts-changed) \
+    SIGNAME( 2, signal, color-set) \
+    SIGNAME( 2, signal, font-set) \
+    SIGNAME( 2, signal, destroy) \
+    SIGNAME( 4, signal, moved-to-rect) \
+    SIGNAME( 6, signal, query-tooltip) \
+    SIGNAME( 7, signal, draw) \
+    SIGNAME( 8, signal, add) \
+    SIGNAME( 8, signal, remove) \
+    SIGNAME( 8, signal, cancel) \
+    SIGNAME( 8, signal, size-allocate) \
+    SIGNAME( 8, signal, populate-popup) \
+    SIGNAME( 8, signal, drag-begin) \
+    SIGNAME( 8, signal, drag-end) \
+    SIGNAME( 9, signal, drag-leave) \
+    SIGNAME( 9, signal, switch-page) \
+    SIGNAME(10, signal, drag-motion) \
+    SIGNAME(10, signal, drag-drop) \
+    SIGNAME(11, signal, row-activated) \
+    SIGNAME(12, signal, response) \
+    SIGNAME(13, signal, drag-data-received) \
+    SIGNAME(14, signal, drag-data-get) \
+    SIGNAME(15, signal, drag-failed) \
+    SIGNAME(16, signal, editing-started) \
+    SIGNAME(17, signal, edited) \
+    SIGNAME(18, signal, focus) \
+    SIGNAME(19, signal, popup-menu) \
+    SIGNAME(20, signal, insert-text) \
+    SIGNAME(21, signal, row-inserted) \
+    SIGNAME(22, signal, notify::position) \
+    SIGNAME(22, signal, notify::visible) \
+    SIGNAME(23, signal, row-expanded) \
+    SIGNAME(24, signal, match-selected) \
+    0; \
+  const int found_signature = _Generic((DISABLINGPREFIX##c_handler), \
+    GCallback : 1 << 0, \
+    EVENT_HANDLER(1, instance, user_data, ) \
+    EVENT_HANDLER(1, instance, user_data, Button) \
+    EVENT_HANDLER(1, instance, user_data, Motion) \
+    EVENT_HANDLER(1, instance, user_data, Scroll) \
+    EVENT_HANDLER(1, instance, user_data, Key) \
+    EVENT_HANDLER(1, instance, user_data, Focus) \
+    EVENT_HANDLER(1, instance, user_data, Crossing) \
+    EVENT_HANDLER(1, instance, user_data, Configure) \
+    VOID_HANDLER( 2, instance, user_data) \
+    VOID_HANDLER( 3, instance, user_data, char*, GtkTreeIter*) \
+    VOID_HANDLER( 4, instance, user_data, GdkRectangle*, GdkRectangle*, gboolean, gboolean) \
+    VOID_HANDLER( 5, instance, user_data, char*) \
+    BOOL_HANDLER( 6, instance, user_data, gint, gint, gboolean, GtkTooltip*) \
+    BOOL_HANDLER( 7, instance, user_data, cairo_t*) \
+    VOID_HANDLER( 8, instance, user_data, GtkWidget*) \
+    VOID_HANDLER( 8, instance, user_data, GdkRectangle*) \
+    VOID_HANDLER( 8, instance, user_data, GdkEventSequence*) \
+    VOID_HANDLER( 8, instance, user_data, GdkDragContext*) \
+    VOID_HANDLER( 9, instance, user_data, GdkDragContext*, guint) \
+    VOID_HANDLER( 9, instance, user_data, GtkWidget*, guint) \
+    BOOL_HANDLER(10, instance, user_data, GdkDragContext*, const gint, const gint, const guint) \
+    VOID_HANDLER(11, instance, user_data, GtkTreePath*, GtkTreeViewColumn*) \
+    VOID_HANDLER(12, instance, user_data, gint) \
+    VOID_HANDLER(13, instance, user_data, GdkDragContext*, gint, gint, GtkSelectionData*, guint, guint) \
+    VOID_HANDLER(14, instance, user_data, GdkDragContext*, GtkSelectionData*, guint, guint) \
+    BOOL_HANDLER(15, instance, user_data, GdkDragContext*, GtkDragResult) \
+    VOID_HANDLER(16, instance, user_data, GtkCellEditable*, char*) \
+    VOID_HANDLER(17, instance, user_data, const gchar*, const gchar*) \
+    BOOL_HANDLER(18, instance, user_data, GtkDirectionType) \
+    BOOL_HANDLER(19, instance, user_data) \
+    VOID_HANDLER(20, instance, user_data, const gchar*, const gint, gint*) \
+    VOID_HANDLER(21, instance, user_data, GtkTreePath*, GtkTreeIter*) \
+    VOID_HANDLER(22, instance, user_data, GParamSpec*) \
+    VOID_HANDLER(23, instance, user_data, GtkTreeIter*, GtkTreePath*) \
+    BOOL_HANDLER(24, instance, user_data, GtkTreeModel*, GtkTreeIter*) \
+    default : 0); \
+  if(required_signature == 0) \
+    dt_print_nts_ext("%s:%d: connecting unknown signal %s\n", __FILE__, __LINE__, signal); \
+  else if(!(required_signature & found_signature)) \
+    dt_print_nts_ext("%s:%d: connecting signal %s to %s with incorrect signature\n", __FILE__, __LINE__, signal, #c_handler); \
+  _Static_assert(required_signature, "unknown signal encountered: " signal ); \
+  /*_Static_assert(required_signature & found_signature, "incorrect function connected to " signal );*/ \
+  g_signal_connect_data ((instance), (signal), (c_handler), (user_data), NULL, (GConnectFlags) 0); } while(0)
+#endif // __cplusplus
+
 // GTK4 gtk_event_controller_get_current_event_state(GTK_EVENT_CONTROLLER(controller));
 #define dt_modifier_eq(controller, mask)\
   dt_modifier_is(dt_key_modifier_state(), mask)

--- a/src/gui/gtkentry.c
+++ b/src/gui/gtkentry.c
@@ -279,7 +279,7 @@ void dt_gtkentry_setup_variables_completion(GtkEntry *entry)
   GtkEntryCompletion *completion = gtk_entry_completion_new();
   gtk_entry_completion_set_text_column(completion, COMPL_DESCRIPTION);
   gtk_entry_set_completion(entry, completion);
-  g_signal_connect(G_OBJECT(completion), "match-selected", G_CALLBACK(_on_match_select), NULL);
+  g_signal_connect(completion, "match-selected", G_CALLBACK(_on_match_select), NULL);
 
   gtk_entry_completion_set_model(completion, GTK_TREE_MODEL(_completion_model));
   gtk_entry_completion_set_match_func(completion, _on_match_func, NULL, NULL);

--- a/src/gui/guides.c
+++ b/src/gui/guides.c
@@ -236,7 +236,7 @@ static GtkWidget *_guides_gui_grid(dt_iop_module_t *self,
   dt_bauhaus_slider_set(grid_horizontal,
                         dt_conf_key_exists(key) ? dt_conf_get_int(key) : 3);
   g_free(key);
-  g_signal_connect(G_OBJECT(grid_horizontal), "value-changed",
+  g_signal_connect(grid_horizontal, "value-changed",
                    G_CALLBACK(_grid_horizontal_changed), user_data);
 
   GtkWidget *grid_vertical = dt_bauhaus_slider_new_with_range(NULL, 0, 12, 1, 3, 0);
@@ -246,7 +246,7 @@ static GtkWidget *_guides_gui_grid(dt_iop_module_t *self,
   key = _conf_get_path("global", "grid_nbv", NULL);
   dt_bauhaus_slider_set(grid_vertical, dt_conf_key_exists(key) ? dt_conf_get_int(key) : 3);
   g_free(key);
-  g_signal_connect(G_OBJECT(grid_vertical), "value-changed",
+  g_signal_connect(grid_vertical, "value-changed",
                    G_CALLBACK(_grid_vertical_changed), user_data);
 
   GtkWidget *grid_subdiv = dt_bauhaus_slider_new_with_range(NULL, 0, 10, 1, 3, 0);
@@ -256,7 +256,7 @@ static GtkWidget *_guides_gui_grid(dt_iop_module_t *self,
   key = _conf_get_path("global", "grid_subdiv", NULL);
   dt_bauhaus_slider_set(grid_subdiv, dt_conf_key_exists(key) ? dt_conf_get_int(key) : 3);
   g_free(key);
-  g_signal_connect(G_OBJECT(grid_subdiv), "value-changed",
+  g_signal_connect(grid_subdiv, "value-changed",
                    G_CALLBACK(_grid_subdiv_changed), user_data);
 
   return dt_gui_vbox(grid_horizontal, grid_vertical, grid_subdiv);
@@ -802,7 +802,7 @@ static void _settings_colors_changed(GtkWidget *combo,
 }
 
 static void _settings_contrast_changed(GtkWidget *slider,
-                                       _guides_settings_t *gw)
+                                       gpointer user_data)
 {
   dt_conf_set_float("darkroom/ui/overlay_contrast", dt_bauhaus_slider_get(slider));
   dt_guides_set_overlay_colors();
@@ -865,7 +865,7 @@ GtkWidget *dt_guides_popover(dt_view_t *self,
      _("set the contrast between the lightest and darkest part of the guide overlays"));
   dt_bauhaus_slider_set(contrast,
                         dt_conf_get_float("darkroom/ui/overlay_contrast"));
-  g_signal_connect(G_OBJECT(contrast), "value-changed",
+  g_signal_connect(contrast, "value-changed",
                    G_CALLBACK(_settings_contrast_changed), NULL);
 
   GtkWidget *vbox = dt_gui_vbox(lb, gw->g_widgets, gw->g_flip, darktable.view_manager->guides,
@@ -984,7 +984,7 @@ void dt_guides_add_module_menuitem(void *menu,
   gchar *key = _conf_get_path(module->op, "autoshow", NULL);
   gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(mi), dt_conf_get_bool(key));
   g_free(key);
-  g_signal_connect(G_OBJECT(mi), "activate",
+  g_signal_connect(mi, "activate",
                    G_CALLBACK(_settings_autoshow_change), module);
   gtk_menu_shell_append(GTK_MENU_SHELL(menu), mi);
 }
@@ -1036,14 +1036,14 @@ void dt_guides_init_module_widget(GtkWidget *iopw,
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(cb), dt_conf_get_bool(key));
   g_free(key);
 
-  g_signal_connect(G_OBJECT(cb), "toggled",
+  g_signal_connect(cb, "toggled",
                    G_CALLBACK(_settings_autoshow_change2), module);
   gtk_widget_set_tooltip_text(cb, _("show guide overlay when this module has focus"));
   GtkWidget *ic = dtgtk_button_new(dtgtk_cairo_paint_grid, 0, NULL);
   gtk_widget_set_tooltip_text
     (ic, _("change global guide settings\nnote that these settings are applied globally "
            "and will impact any module that shows guide overlays"));
-  g_signal_connect(G_OBJECT(ic), "clicked",
+  g_signal_connect(ic, "clicked",
                    G_CALLBACK(_settings_autoshow_menu), module);
 
   GtkWidget *box = dt_gui_hbox(dt_gui_expand(cb), ic);

--- a/src/gui/hist_dialog.c
+++ b/src/gui/hist_dialog.c
@@ -143,10 +143,8 @@ static void _gui_hist_copy_response(GtkDialog *dialog,
 
 static void _gui_hist_item_toggled(GtkCellRendererToggle *cell,
                                    const gchar *path_str,
-                                   gpointer data)
+                                   dt_history_copy_item_t *d)
 {
-  dt_history_copy_item_t *d = (dt_history_copy_item_t *)data;
-
   const _styles_columns_t col =
     GPOINTER_TO_INT(g_object_get_data(G_OBJECT(cell), "column"));
 
@@ -274,7 +272,7 @@ int dt_gui_hist_dialog_new(dt_history_copy_item_t *d,
   GtkCellRenderer *renderer = gtk_cell_renderer_toggle_new();
   gtk_cell_renderer_toggle_set_activatable(GTK_CELL_RENDERER_TOGGLE(renderer), TRUE);
   g_object_set_data(G_OBJECT(renderer), "column", (gint *)DT_HIST_ITEMS_COL_ENABLED);
-  g_signal_connect(renderer, "toggled", G_CALLBACK(_gui_hist_item_toggled), d);
+  g_signal_connect(GTK_CELL_RENDERER_TOGGLE(renderer), "toggled", G_CALLBACK(_gui_hist_item_toggled), d);
 
   gtk_tree_view_insert_column_with_attributes
     (GTK_TREE_VIEW(d->items), -1, _("include"), renderer, "active",
@@ -284,7 +282,7 @@ int dt_gui_hist_dialog_new(dt_history_copy_item_t *d,
   renderer = gtk_cell_renderer_toggle_new();
   gtk_cell_renderer_toggle_set_activatable(GTK_CELL_RENDERER_TOGGLE(renderer), TRUE);
   g_object_set_data(G_OBJECT(renderer), "column", (gint *)DT_HIST_ITEMS_COL_AUTOINIT);
-  g_signal_connect(renderer, "toggled", G_CALLBACK(_gui_hist_item_toggled), d);
+  g_signal_connect(GTK_CELL_RENDERER_TOGGLE(renderer), "toggled", G_CALLBACK(_gui_hist_item_toggled), d);
 
   gtk_tree_view_insert_column_with_attributes(GTK_TREE_VIEW(d->items), -1, _("reset"),
                                               renderer, "active",
@@ -374,7 +372,7 @@ int dt_gui_hist_dialog_new(dt_history_copy_item_t *d,
   }
 
   g_signal_connect(GTK_TREE_VIEW(d->items), "row-activated",
-                   (GCallback)tree_on_row_activated, GTK_WIDGET(dialog));
+                   G_CALLBACK(tree_on_row_activated), GTK_WIDGET(dialog));
   g_object_unref(liststore);
 
   g_signal_connect(dialog, "response", G_CALLBACK(_gui_hist_copy_response), d);

--- a/src/gui/import_metadata.c
+++ b/src/gui/import_metadata.c
@@ -420,16 +420,16 @@ static void _fill_metadata_grid(dt_import_metadata_t *metadata)
     const char *str = dt_conf_get_string_const(setting);
     _set_up_entry(metadata_entry, str, metadata_name, i + DT_META_META_VALUE, metadata);
     g_free(setting);
-    g_signal_connect(GTK_ENTRY(metadata_entry), "changed",
+    g_signal_connect(metadata_entry, "changed",
                      G_CALLBACK(_import_metadata_changed), metadata);
-    g_signal_connect(GTK_EVENT_BOX(labelev), "button-press-event",
+    g_signal_connect(labelev, "button-press-event",
                      G_CALLBACK(_import_metadata_reset), metadata_entry);
 
     GtkWidget *metadata_imported = gtk_check_button_new();
     g_object_set_data(G_OBJECT(metadata_imported), "tagname", md->tagname);
     _set_up_toggle_button(metadata_imported, flag & DT_METADATA_FLAG_IMPORTED,
                           metadata_name, i + DT_META_META_VALUE, metadata);
-    g_signal_connect(GTK_TOGGLE_BUTTON(metadata_imported), "toggled",
+    g_signal_connect(metadata_imported, "toggled",
                      G_CALLBACK(_import_metadata_toggled), metadata);
     i++;
   }

--- a/src/gui/metadata_tags.c
+++ b/src/gui/metadata_tags.c
@@ -102,7 +102,7 @@ GtkWidget *dt_metadata_tags_dialog(GtkWidget *parent, gpointer metadata_activate
   gtk_entry_set_text(GTK_ENTRY(sel_entry), "");
   gtk_widget_set_tooltip_text(sel_entry, _("list filter"));
   gtk_entry_set_activates_default(GTK_ENTRY(sel_entry), TRUE);
-  g_signal_connect(G_OBJECT(sel_entry), "changed", G_CALLBACK(_tag_name_changed), NULL);
+  g_signal_connect(sel_entry, "changed", G_CALLBACK(_tag_name_changed), NULL);
 
   sel_view = GTK_TREE_VIEW(gtk_tree_view_new());
   GtkWidget *w = dt_gui_scroll_wrap(GTK_WIDGET(sel_view));
@@ -150,7 +150,7 @@ GtkWidget *dt_metadata_tags_dialog(GtkWidget *parent, gpointer metadata_activate
   gtk_tree_sortable_set_sort_column_id(GTK_TREE_SORTABLE(liststore), DT_METADATA_TAGS_COL_XMP, GTK_SORT_ASCENDING);
   gtk_tree_view_set_model(sel_view, model);
   g_object_unref(model);
-  g_signal_connect(G_OBJECT(sel_view), "row-activated", G_CALLBACK(metadata_activated_callback), user_data);
+  g_signal_connect(sel_view, "row-activated", G_CALLBACK(metadata_activated_callback), user_data);
 
   dt_gui_dialog_add(GTK_DIALOG(dialog), sel_entry, w);
   return dialog;

--- a/src/gui/preferences.c
+++ b/src/gui/preferences.c
@@ -353,8 +353,8 @@ static void init_tab_general(GtkWidget *dialog,
 
   dt_bauhaus_combobox_set(widget, darktable.l10n->selected);
   dt_bauhaus_combobox_set_default(widget, darktable.l10n->sys_default);
-  g_signal_connect(G_OBJECT(widget), "value-changed",
-                   G_CALLBACK(language_callback), 0);
+  g_signal_connect(widget, "value-changed",
+                   G_CALLBACK(language_callback), NULL);
   gtk_widget_set_tooltip_text(labelev,  _("double-click to reset to the system language"));
   gtk_event_box_set_visible_window(GTK_EVENT_BOX(labelev), FALSE);
   gtk_widget_set_tooltip_text(widget,
@@ -363,8 +363,8 @@ static void init_tab_general(GtkWidget *dialog,
                                 "(restart required)"));
   gtk_grid_attach(GTK_GRID(grid), labelev, 0, line++, 1, 1);
   gtk_grid_attach_next_to(GTK_GRID(grid), widget, labelev, GTK_POS_RIGHT, 1, 1);
-  g_signal_connect(G_OBJECT(labelev), "button-press-event",
-                   G_CALLBACK(reset_language_widget), (gpointer)widget);
+  g_signal_connect(labelev, "button-press-event",
+                   G_CALLBACK(reset_language_widget), widget);
 
   // theme
 
@@ -399,7 +399,7 @@ static void init_tab_general(GtkWidget *dialog,
 
   dt_bauhaus_combobox_set(widget, selected);
 
-  g_signal_connect(G_OBJECT(widget), "value-changed",
+  g_signal_connect(widget, "value-changed",
                    G_CALLBACK(theme_callback), 0);
   gtk_widget_set_tooltip_text(widget, _("set the theme for the user interface"));
 
@@ -426,10 +426,10 @@ static void init_tab_general(GtkWidget *dialog,
   gtk_widget_set_tooltip_text(usesysfont, _("use system font size"));
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(usesysfont),
                                dt_conf_get_bool("use_system_font"));
-  g_signal_connect(G_OBJECT(usesysfont), "toggled",
-                   G_CALLBACK(use_sys_font_callback), (gpointer)fontsize);
-  g_signal_connect(G_OBJECT(labelev), "button-press-event",
-                   G_CALLBACK(_gui_preferences_bool_click), (gpointer)usesysfont);
+  g_signal_connect(usesysfont, "toggled",
+                   G_CALLBACK(use_sys_font_callback), fontsize);
+  g_signal_connect(labelev, "button-press-event",
+                   G_CALLBACK(_gui_preferences_bool_click), usesysfont);
 
 
   //font size selector
@@ -448,7 +448,7 @@ static void init_tab_general(GtkWidget *dialog,
   gtk_grid_attach_next_to(GTK_GRID(grid), fontsize, labelev, GTK_POS_RIGHT, 1, 1);
   gtk_widget_set_tooltip_text(fontsize, _("font size in points"));
   gtk_spin_button_set_value(GTK_SPIN_BUTTON(fontsize), dt_conf_get_float("font_size"));
-  g_signal_connect(G_OBJECT(fontsize), "value_changed",
+  g_signal_connect(fontsize, "value-changed",
                    G_CALLBACK(font_size_changed_callback), 0);
 
   GtkWidget *screen_dpi_overwrite = gtk_spin_button_new_with_range(-1.0f, 360, 1.f);
@@ -469,7 +469,7 @@ static void init_tab_general(GtkWidget *dialog,
        "(restart required)"));
   gtk_spin_button_set_value(GTK_SPIN_BUTTON(screen_dpi_overwrite),
                             dt_conf_get_float("screen_dpi_overwrite"));
-  g_signal_connect(G_OBJECT(screen_dpi_overwrite), "value_changed",
+  g_signal_connect(screen_dpi_overwrite, "value-changed",
                    G_CALLBACK(dpi_scaling_changed_callback), 0);
 
   GtkWidget *panel_reset = gtk_button_new_with_label(_("reset view panels"));
@@ -494,10 +494,10 @@ static void init_tab_general(GtkWidget *dialog,
                               _("modify theme with CSS keyed below (saved to user.css)"));
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(tw->apply_toggle),
                                dt_conf_get_bool("themes/usercss"));
-  g_signal_connect(G_OBJECT(tw->apply_toggle), "toggled",
+  g_signal_connect(tw->apply_toggle, "toggled",
                    G_CALLBACK(usercss_callback), 0);
   g_signal_connect(G_OBJECT(labelev), "button-press-event",
-                   G_CALLBACK(_gui_preferences_bool_click), (gpointer)tw->apply_toggle);
+                   G_CALLBACK(_gui_preferences_bool_click), tw->apply_toggle);
 
   //scrollable textarea with save button to allow user to directly modify user.css file
   GtkWidget *usercssbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
@@ -516,9 +516,9 @@ static void init_tab_general(GtkWidget *dialog,
 
   GtkWidget *hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
   tw->save_button = gtk_button_new_with_label(C_("usercss", "save CSS and apply"));
-  g_signal_connect(G_OBJECT(tw->save_button), "clicked",
+  g_signal_connect(tw->save_button, "clicked",
                    G_CALLBACK(save_usercss_callback), tw);
-  g_signal_connect(G_OBJECT(dialog), "response",
+  g_signal_connect(dialog, "response",
                    G_CALLBACK(usercss_dialog_callback), tw);
   gtk_box_pack_end(GTK_BOX(hbox), tw->save_button, FALSE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(usercssbox), hbox, FALSE, FALSE, 0);
@@ -985,30 +985,30 @@ static void init_tab_presets(GtkWidget *stack)
   GtkWidget *hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
   gtk_widget_set_name(hbox, "preset-controls");
 
-  GtkWidget *search_presets = gtk_search_entry_new();
-  gtk_box_pack_start(GTK_BOX(hbox), search_presets, FALSE, TRUE, 0);
+  GtkSearchEntry *search_presets = GTK_SEARCH_ENTRY(gtk_search_entry_new());
+  dt_gui_box_add(hbox, search_presets);
   gtk_entry_set_placeholder_text(GTK_ENTRY(search_presets), _("search presets list"));
   gtk_widget_set_tooltip_text
     (GTK_WIDGET(search_presets),
      _("incrementally search the list of presets\n"
        "press up or down keys to cycle through matches"));
-  g_signal_connect(G_OBJECT(search_presets), "activate",
+  g_signal_connect(search_presets, "activate",
                    G_CALLBACK(dt_gui_search_stop), tree);
-  g_signal_connect(G_OBJECT(search_presets), "stop-search",
+  g_signal_connect(search_presets, "stop-search",
                    G_CALLBACK(dt_gui_search_stop), tree);
-  g_signal_connect(G_OBJECT(tree), "key-press-event",
+  g_signal_connect(tree, "key-press-event",
                    G_CALLBACK(dt_gui_search_start), search_presets);
   gtk_tree_view_set_search_entry(tree, GTK_ENTRY(search_presets));
 
   GtkWidget *button = gtk_button_new_with_label(C_("preferences", "import..."));
   gtk_box_pack_end(GTK_BOX(hbox), button, FALSE, TRUE, 0);
-  g_signal_connect(G_OBJECT(button), "clicked",
-                   G_CALLBACK(import_preset), (gpointer)model);
+  g_signal_connect(button, "clicked",
+                   G_CALLBACK(import_preset), model);
 
   button = gtk_button_new_with_label(C_("preferences", "export..."));
   gtk_box_pack_end(GTK_BOX(hbox), button, FALSE, TRUE, 0);
-  g_signal_connect(G_OBJECT(button), "clicked",
-                   G_CALLBACK(export_preset), (gpointer)model);
+  g_signal_connect(button, "clicked",
+                   G_CALLBACK(export_preset), model);
 
   button = gtk_button_new_with_label(_("?"));
   dt_gui_add_help_link(button, "presets");
@@ -1018,12 +1018,12 @@ static void init_tab_presets(GtkWidget *stack)
   // Attaching treeview signals
 
   // row-activated either expands/collapses a row or activates editing
-  g_signal_connect(G_OBJECT(tree), "row-activated",
+  g_signal_connect(tree, "row-activated",
                    G_CALLBACK(tree_row_activated_presets), NULL);
 
   // A keypress may delete preset
-  g_signal_connect(G_OBJECT(tree), "key-press-event",
-                   G_CALLBACK(tree_key_press_presets), (gpointer)model);
+  g_signal_connect(tree, "key-press-event",
+                   G_CALLBACK(tree_key_press_presets), model);
 
   // Setting up the search functionality
   gtk_tree_view_set_search_equal_func(tree, _search_func, tree, NULL);
@@ -1372,10 +1372,10 @@ GtkWidget *dt_gui_preferences_bool(GtkGrid *grid,
 
   gtk_grid_attach(GTK_GRID(grid), labelev, swap ? (col + 1) : col, line, 1, 1);
   gtk_grid_attach(GTK_GRID(grid), w, swap ? col : (col + 1), line, 1, 1);
-  g_signal_connect(G_OBJECT(w), "toggled",
+  g_signal_connect(w, "toggled",
                    G_CALLBACK(_gui_preferences_bool_callback), (gpointer)key);
-  g_signal_connect(G_OBJECT(labelev), "button-press-event",
-                   G_CALLBACK(_gui_preferences_bool_click), (gpointer)w);
+  g_signal_connect(labelev, "button-press-event",
+                   G_CALLBACK(_gui_preferences_bool_click), w);
   return w;
 }
 
@@ -1433,10 +1433,10 @@ GtkWidget *dt_gui_preferences_int(GtkGrid *grid,
   gtk_spin_button_set_value(GTK_SPIN_BUTTON(w), dt_conf_get_int(key));
   gtk_grid_attach(GTK_GRID(grid), labelev, col, line, 1, 1);
   gtk_grid_attach(GTK_GRID(grid), w, col + 1, line, 1, 1);
-  g_signal_connect(G_OBJECT(w), "value-changed",
+  g_signal_connect(w, "value-changed",
                    G_CALLBACK(_gui_preferences_int_callback), (gpointer)key);
-  g_signal_connect(G_OBJECT(labelev), "button-press-event",
-                   G_CALLBACK(_gui_preferences_int_reset), (gpointer)w);
+  g_signal_connect(labelev, "button-press-event",
+                   G_CALLBACK(_gui_preferences_int_reset), w);
   return w;
 }
 
@@ -1485,7 +1485,7 @@ GtkWidget *dt_gui_preferences_enum(dt_action_t *action,
     i++;
   }
 
-  g_signal_connect(G_OBJECT(w), "value-changed",
+  g_signal_connect(w, "value-changed",
                    G_CALLBACK(_gui_preferences_enum_callback), (gpointer)key);
   return w;
 }
@@ -1544,10 +1544,10 @@ GtkWidget *dt_gui_preferences_string(GtkGrid *grid,
 
   gtk_grid_attach(GTK_GRID(grid), labelev, col, line, 1, 1);
   gtk_grid_attach(GTK_GRID(grid), w, col + 1, line, 1, 1);
-  g_signal_connect(G_OBJECT(w), "changed",
+  g_signal_connect(w, "changed",
                    G_CALLBACK(_gui_preferences_string_callback), (gpointer)key);
-  g_signal_connect(G_OBJECT(labelev), "button-press-event",
-                   G_CALLBACK(_gui_preferences_string_reset), (gpointer)w);
+  g_signal_connect(labelev, "button-press-event",
+                   G_CALLBACK(_gui_preferences_string_reset), w);
   return w;
 }
 

--- a/src/gui/preferences.c
+++ b/src/gui/preferences.c
@@ -567,7 +567,7 @@ static void init_tab_general(GtkWidget *dialog,
 ///////////// end of gui and theme language selection
 
 
-void dt_gui_preferences_show()
+void dt_gui_preferences_show(void)
 {
   GtkWindow *win = GTK_WINDOW(dt_ui_main_window(darktable.gui->ui));
   _preferences_dialog =

--- a/src/gui/preferences.h
+++ b/src/gui/preferences.h
@@ -19,7 +19,7 @@
 #pragma once
 
 /** shows the preferences dialog and blocks until it's closed. */
-void dt_gui_preferences_show();
+void dt_gui_preferences_show(void);
 
 // return the widget for a given preference key
 GtkWidget *dt_gui_preferences_bool(GtkGrid *grid, const char *key, const guint col,

--- a/src/gui/presets.c
+++ b/src/gui/presets.c
@@ -634,9 +634,9 @@ static void _presets_show_edit_dialog(dt_gui_presets_edit_dialog_t *g,
     gtk_widget_set_sensitive(GTK_WIDGET(g->filter), TRUE);
   }
 
-  g_signal_connect(G_OBJECT(g->autoapply), "toggled",
+  g_signal_connect(g->autoapply, "toggled",
                    G_CALLBACK(_check_buttons_activated), g);
-  g_signal_connect(G_OBJECT(g->filter), "toggled",
+  g_signal_connect(g->filter, "toggled",
                    G_CALLBACK(_check_buttons_activated), g);
 
   int line = 0;
@@ -678,13 +678,13 @@ static void _presets_show_edit_dialog(dt_gui_presets_edit_dialog_t *g,
   gtk_widget_set_halign(label, GTK_ALIGN_START);
   g->iso_min = gtk_entry_new();
   gtk_widget_set_tooltip_text(g->iso_min, _("minimum ISO value"));
-  g_signal_connect(G_OBJECT(g->iso_min), "insert-text",
+  g_signal_connect(g->iso_min, "insert-text",
                    G_CALLBACK(_insert_text_event), NULL);
   g->iso_max = gtk_entry_new();
   gtk_widget_set_tooltip_text
     (g->iso_max,
      _("maximum ISO value\nif left blank, it is equivalent to no upper limit"));
-  g_signal_connect(G_OBJECT(g->iso_max), "insert-text",
+  g_signal_connect(g->iso_max, "insert-text",
                    G_CALLBACK(_insert_text_event), NULL);
   gtk_grid_attach(GTK_GRID(g->details), label, 0, line++, 1, 1);
   gtk_grid_attach_next_to(GTK_GRID(g->details), g->iso_min, label, GTK_POS_RIGHT, 2, 1);
@@ -981,7 +981,7 @@ static void _edit_preset(const char *name_in, dt_iop_module_t *module)
     name = g_strdup(name_in);
 
   dt_gui_presets_show_iop_edit_dialog
-    (name, module, (GCallback)_edit_preset_final_callback, NULL, TRUE, TRUE,
+    (name, module, G_CALLBACK(_edit_preset_final_callback), NULL, TRUE, TRUE,
      FALSE, GTK_WINDOW(dt_ui_main_window(darktable.gui->ui)));
   g_free(name);
 }
@@ -1336,13 +1336,13 @@ static void _menuitem_connect_preset(GtkWidget *mi,
   g_object_set_data_full(G_OBJECT(mi), "dt-preset-name", g_strdup(name), g_free);
   g_object_set_data(G_OBJECT(mi), "dt-preset-module", iop);
   dt_action_define(&iop->so->actions, "preset", name, mi, NULL);
-  g_signal_connect(G_OBJECT(mi), "activate",
+  g_signal_connect(mi, "activate",
                    G_CALLBACK(_menuitem_activate_preset), iop);
-  g_signal_connect(G_OBJECT(mi), "button-press-event",
+  g_signal_connect(mi, "button-press-event",
                    G_CALLBACK(_menuitem_button_preset), iop);
-  g_signal_connect(G_OBJECT(mi), "button-release-event",
+  g_signal_connect(mi, "button-release-event",
                    G_CALLBACK(_menuitem_button_preset), iop);
-  g_signal_connect(G_OBJECT(mi), "motion-notify-event",
+  g_signal_connect(mi, "motion-notify-event",
                    G_CALLBACK(_menuitem_motion_preset), iop);
   gtk_widget_set_has_tooltip(mi, TRUE);
 }
@@ -1611,7 +1611,7 @@ void dt_gui_favorite_presets_menu_show(GtkWidget *w)
   gtk_menu_shell_append(GTK_MENU_SHELL(menu), gtk_separator_menu_item_new());
   GtkMenuItem *smi_manage = (GtkMenuItem *)gtk_menu_item_new_with_label
     (_("manage quick presets list..."));
-  g_signal_connect(G_OBJECT(smi_manage), "activate",
+  g_signal_connect(smi_manage, "activate",
                    G_CALLBACK(_menuitem_manage_quick_presets), NULL);
   gtk_menu_shell_append(GTK_MENU_SHELL(menu), GTK_WIDGET(smi_manage));
 
@@ -1797,19 +1797,19 @@ GtkMenu *dt_gui_presets_popup_menu_show_for_module(dt_iop_module_t *module)
     if(active_preset >= 0 && !writeprotect)
     {
       mi = gtk_menu_item_new_with_label(_("edit this preset.."));
-      g_signal_connect(G_OBJECT(mi), "activate",
+      g_signal_connect(mi, "activate",
                        G_CALLBACK(_menuitem_edit_preset), module);
       gtk_menu_shell_append(GTK_MENU_SHELL(menu), mi);
 
       mi = gtk_menu_item_new_with_label(_("delete this preset"));
-      g_signal_connect(G_OBJECT(mi), "activate",
+      g_signal_connect(mi, "activate",
                        G_CALLBACK(_menuitem_delete_preset), module);
       gtk_menu_shell_append(GTK_MENU_SHELL(menu), mi);
     }
     else
     {
       mi = gtk_menu_item_new_with_label(_("store new preset.."));
-      g_signal_connect(G_OBJECT(mi), "activate",
+      g_signal_connect(mi, "activate",
                        G_CALLBACK(_menuitem_new_preset), module);
       gtk_menu_shell_append(GTK_MENU_SHELL(menu), mi);
 
@@ -1825,7 +1825,7 @@ GtkMenu *dt_gui_presets_popup_menu_show_for_module(dt_iop_module_t *module)
         gtk_label_set_markup(GTK_LABEL(gtk_bin_get_child(GTK_BIN(mi))), markup);
         g_object_set_data_full(G_OBJECT(mi), "dt-preset-name",
                                g_strdup(darktable.gui->last_preset), g_free);
-        g_signal_connect(G_OBJECT(mi), "activate",
+        g_signal_connect(mi, "activate",
                          G_CALLBACK(_menuitem_update_preset), module);
         gtk_menu_shell_append(GTK_MENU_SHELL(menu), mi);
         g_free(markup);

--- a/src/gui/styles_dialog.c
+++ b/src/gui/styles_dialog.c
@@ -356,10 +356,8 @@ static void _gui_styles_edit_style_response(GtkDialog *dialog,
 
 static void _gui_styles_item_toggled(GtkCellRendererToggle *cell,
                                      gchar *path_str,
-                                     gpointer data)
+                                     dt_gui_styles_dialog_t *sd)
 {
-  dt_gui_styles_dialog_t *sd = (dt_gui_styles_dialog_t *)data;
-
   GtkTreeModel *model = gtk_tree_view_get_model(GTK_TREE_VIEW(sd->items));
   GtkTreePath *path = gtk_tree_path_new_from_string(path_str);
   GtkTreeIter iter;
@@ -571,7 +569,7 @@ static gboolean _gui_styles_dialog_run(const gboolean edit,
   gtk_widget_set_tooltip_text(sd->name, _("enter a name for the new style"));
   gtk_entry_set_activates_default(GTK_ENTRY(sd->name), TRUE);
   gtk_dialog_set_response_sensitive(dialog, GTK_RESPONSE_ACCEPT, FALSE);
-  g_signal_connect(sd->name, "changed", G_CALLBACK(_name_changed), dialog);
+  g_signal_connect(GTK_ENTRY(sd->name), "changed", G_CALLBACK(_name_changed), dialog);
 
   sd->description = gtk_entry_new();
   gtk_entry_set_placeholder_text(GTK_ENTRY(sd->description), _("description"));
@@ -613,7 +611,7 @@ static gboolean _gui_styles_dialog_run(const gboolean edit,
   GtkCellRenderer *renderer = gtk_cell_renderer_toggle_new();
   gtk_cell_renderer_toggle_set_activatable(GTK_CELL_RENDERER_TOGGLE(renderer), TRUE);
   g_object_set_data(G_OBJECT(renderer), "column", (gint *)DT_STYLE_ITEMS_COL_ENABLED);
-  g_signal_connect(renderer, "toggled", G_CALLBACK(_gui_styles_item_toggled), sd);
+  g_signal_connect(GTK_CELL_RENDERER_TOGGLE(renderer), "toggled", G_CALLBACK(_gui_styles_item_toggled), sd);
   gtk_tree_view_insert_column_with_attributes(GTK_TREE_VIEW(sd->items), -1,
                                               edit ? _("keep") : _("include"),
                                               renderer, "active",
@@ -1030,7 +1028,7 @@ GtkWidget *dt_gui_style_content_dialog(char *name, const dt_imgid_t imgid)
     gtk_widget_set_app_paintable(da, TRUE);
     gtk_box_pack_start(GTK_BOX(ht), da, TRUE, TRUE, 0);
     data.first_draw = TRUE;
-    g_signal_connect(G_OBJECT(da), "draw", G_CALLBACK(_preview_draw), &data);
+    g_signal_connect(da, "draw", G_CALLBACK(_preview_draw), &data);
   }
 
   return ht;

--- a/src/gui/workspace.c
+++ b/src/gui/workspace.c
@@ -134,7 +134,7 @@ static GtkBox *_insert_button(dt_workspace_t *session, const char *label)
   GtkWidget *b = gtk_button_new_with_label(label);
   gtk_widget_set_hexpand(GTK_WIDGET(b), TRUE);
   dt_gui_box_add(box, b);
-  g_signal_connect(G_OBJECT(b), "clicked",
+  g_signal_connect(b, "clicked",
                    G_CALLBACK(_workspace_select_db), session);
   dt_gui_dialog_add(session->db_screen, box);
   return box;
@@ -215,7 +215,7 @@ void dt_workspace_create(const char *datadir)
       g_list_free(bc);
 
       GtkWidget *del = dtgtk_button_new(dtgtk_cairo_paint_remove, 0, NULL);
-      g_signal_connect(G_OBJECT(del), "clicked",
+      g_signal_connect(del, "clicked",
                        G_CALLBACK(_workspace_delete_db), session);
       g_object_set_data(G_OBJECT(del), "db", b);
       dt_gui_box_add(box, del);
@@ -235,14 +235,14 @@ void dt_workspace_create(const char *datadir)
 
   GtkBox *box = GTK_BOX(dt_gui_hbox());
   session->entry = gtk_entry_new();
-  g_signal_connect(G_OBJECT(session->entry),
+  g_signal_connect(session->entry,
                    "changed", G_CALLBACK(_workspace_entry_changed), session);
   gtk_widget_set_hexpand(session->entry, TRUE);
 
   session->create = gtk_button_new_with_label(_("create"));
   gtk_widget_set_sensitive(session->create, FALSE);
 
-  g_signal_connect(G_OBJECT(session->create), "clicked",
+  g_signal_connect(session->create, "clicked",
                    G_CALLBACK(_workspace_new_db), session);
   dt_gui_box_add(box, session->entry, session->create);
   gtk_widget_set_hexpand(GTK_WIDGET(box), TRUE);

--- a/src/imageio/format/avif.c
+++ b/src/imageio/format/avif.c
@@ -1031,15 +1031,15 @@ void gui_init(dt_imageio_module_format_t *self)
   gtk_widget_set_visible(gui->subsample, compression_type != AVIF_COMP_LOSSLESS);
   gtk_widget_set_no_show_all(gui->subsample, TRUE);
 
-  g_signal_connect(G_OBJECT(gui->bit_depth),
+  g_signal_connect(gui->bit_depth,
                    "value-changed",
                    G_CALLBACK(bit_depth_changed),
                    NULL);
-  g_signal_connect(G_OBJECT(gui->compression_type),
+  g_signal_connect(gui->compression_type,
                    "value-changed",
                    G_CALLBACK(compression_type_changed),
                    (gpointer)self);
-  g_signal_connect(G_OBJECT(gui->quality),
+  g_signal_connect(gui->quality,
                    "value-changed",
                    G_CALLBACK(quality_changed),
                    NULL);

--- a/src/imageio/format/j2k.c
+++ b/src/imageio/format/j2k.c
@@ -706,7 +706,7 @@ void gui_init(dt_imageio_module_format_t *self)
                                                   0);
   dt_bauhaus_widget_set_label(gui->quality, NULL, N_("quality"));
   dt_bauhaus_slider_set(gui->quality, quality_last);
-  g_signal_connect(G_OBJECT(gui->quality), "value-changed", G_CALLBACK(quality_changed), NULL);
+  g_signal_connect(gui->quality, "value-changed", G_CALLBACK(quality_changed), NULL);
 
   DT_BAUHAUS_COMBOBOX_NEW_FULL(gui->preset, self, NULL, N_("DCP mode"), NULL,
                                preset_last, preset_changed, self,

--- a/src/imageio/format/jpeg.c
+++ b/src/imageio/format/jpeg.c
@@ -577,7 +577,7 @@ void gui_init(dt_imageio_module_format_t *self)
 
   dt_bauhaus_widget_set_label(g->quality, NULL, N_("quality"));
   dt_bauhaus_slider_set(g->quality, dt_conf_get_int("plugins/imageio/format/jpeg/quality"));
-  g_signal_connect(G_OBJECT(g->quality), "value-changed",
+  g_signal_connect(g->quality, "value-changed",
                    G_CALLBACK(quality_changed), NULL);
 
   DT_BAUHAUS_COMBOBOX_NEW_FULL

--- a/src/imageio/format/jxl.c
+++ b/src/imageio/format/jxl.c
@@ -606,7 +606,7 @@ void gui_init(dt_imageio_module_format_t *self)
   gtk_widget_set_tooltip_text(gui->quality,
                               _("the quality of the output image\n0-29 = very lossy\n30-99 = JPEG "
                                 "quality comparable\n100 = lossless"));
-  g_signal_connect(G_OBJECT(gui->quality), "value-changed", G_CALLBACK(quality_changed), gui);
+  g_signal_connect(gui->quality, "value-changed", G_CALLBACK(quality_changed), gui);
 
   // encoding color profile combobox
   const int original = dt_conf_get_bool("plugins/imageio/format/jxl/original") & 1;
@@ -634,7 +634,7 @@ void gui_init(dt_imageio_module_format_t *self)
   gtk_widget_set_tooltip_text(gui->effort,
                               _("the effort used to encode the image, higher efforts will have "
                                 "better results at the expense of longer encoding times"));
-  g_signal_connect(G_OBJECT(gui->effort), "value-changed", G_CALLBACK(effort_changed), NULL);
+  g_signal_connect(gui->effort, "value-changed", G_CALLBACK(effort_changed), NULL);
 
   // decoding speed (tier) slider
   gui->tier = dt_bauhaus_slider_new_with_range(
@@ -645,7 +645,7 @@ void gui_init(dt_imageio_module_format_t *self)
   dt_bauhaus_widget_set_label(gui->tier, NULL, N_("decoding speed"));
   gtk_widget_set_tooltip_text(gui->tier,
                               _("the preferred decoding speed with some sacrifice of quality"));
-  g_signal_connect(G_OBJECT(gui->tier), "value-changed", G_CALLBACK(tier_changed), NULL);
+  g_signal_connect(gui->tier, "value-changed", G_CALLBACK(tier_changed), NULL);
 
   self->widget = dt_gui_vbox(gui->bpp, gui->pixel_type, gui->quality,
                              gui->original, gui->effort, gui->tier);

--- a/src/imageio/format/pdf.c
+++ b/src/imageio/format/pdf.c
@@ -641,7 +641,7 @@ void gui_init(dt_imageio_module_format_t *self)
   gtk_grid_attach(grid, GTK_WIDGET(d->dpi), 1, line, 1, 1);
   gtk_widget_set_tooltip_text(GTK_WIDGET(d->dpi), _("dpi of the images inside the PDF"));
   gtk_spin_button_set_value(d->dpi, dt_conf_get_float("plugins/imageio/format/pdf/dpi"));
-  g_signal_connect(G_OBJECT(d->dpi), "value-changed", G_CALLBACK(dpi_changed_callback), self);
+  g_signal_connect(d->dpi, "value-changed", G_CALLBACK(dpi_changed_callback), self);
 
   // rotate images yes|no
 
@@ -684,7 +684,7 @@ void gui_init(dt_imageio_module_format_t *self)
     if(_pdf_bpp[i].bpp == bpp) sel = i;
   }
   gtk_grid_attach(grid, GTK_WIDGET(d->bpp), 0, ++line, 2, 1);
-  g_signal_connect(G_OBJECT(d->bpp), "value-changed", G_CALLBACK(bpp_toggle_callback), self);
+  g_signal_connect(d->bpp, "value-changed", G_CALLBACK(bpp_toggle_callback), self);
   gtk_widget_set_tooltip_text(d->bpp, _("bits per channel of the embedded images"));
   dt_bauhaus_combobox_set(d->bpp, sel);
 

--- a/src/imageio/format/png.c
+++ b/src/imageio/format/png.c
@@ -701,7 +701,7 @@ void gui_init(dt_imageio_module_format_t *self)
      0);
   dt_bauhaus_widget_set_label(gui->compression, NULL, N_("compression"));
   dt_bauhaus_slider_set(gui->compression, compression);
-  g_signal_connect(G_OBJECT(gui->compression), "value-changed",
+  g_signal_connect(gui->compression, "value-changed",
                    G_CALLBACK(compression_level_changed), NULL);
 
   self->widget = dt_gui_vbox(gui->bit_depth, gui->compression);

--- a/src/imageio/format/tiff.c
+++ b/src/imageio/format/tiff.c
@@ -910,7 +910,7 @@ void gui_init(dt_imageio_module_format_t *self)
       dt_confgen_get_int("plugins/imageio/format/tiff/compresslevel", DT_DEFAULT), 0);
   dt_bauhaus_widget_set_label(gui->compresslevel, NULL, N_("compression level"));
   dt_bauhaus_slider_set(gui->compresslevel, compresslevel);
-  g_signal_connect(G_OBJECT(gui->compresslevel), "value-changed", G_CALLBACK(compress_level_changed), NULL);
+  g_signal_connect(gui->compresslevel, "value-changed", G_CALLBACK(compress_level_changed), NULL);
 
   gtk_widget_set_visible(gui->compresslevel, compress != 0);
   gtk_widget_set_no_show_all(gui->compresslevel, TRUE);

--- a/src/imageio/format/webp.c
+++ b/src/imageio/format/webp.c
@@ -421,7 +421,7 @@ void gui_init(dt_imageio_module_format_t *self)
                                               "for lossless, 0 is the fastest but gives larger files compared\n"
                                               "to the slowest 100."));
   dt_bauhaus_slider_set(gui->quality, quality);
-  g_signal_connect(G_OBJECT(gui->quality), "value-changed", G_CALLBACK(quality_changed), NULL);
+  g_signal_connect(gui->quality, "value-changed", G_CALLBACK(quality_changed), NULL);
 
   gtk_widget_set_visible(gui->quality, comp_type != webp_lossless);
   gtk_widget_set_no_show_all(gui->quality, TRUE);

--- a/src/imageio/storage/disk.c
+++ b/src/imageio/storage/disk.c
@@ -281,7 +281,7 @@ void gui_init(dt_imageio_module_storage_t *self)
   GtkWidget *widget = dtgtk_button_new(dtgtk_cairo_paint_directory, CPF_NONE, NULL);
   gtk_widget_set_name(widget, "non-flat");
   gtk_widget_set_tooltip_text(widget, _("select directory"));
-  g_signal_connect(G_OBJECT(widget), "clicked", G_CALLBACK(button_clicked), self);
+  g_signal_connect(widget, "clicked", G_CALLBACK(button_clicked), self);
 
   DT_BAUHAUS_COMBOBOX_NEW_FULL(d->onsave_action, self, NULL, N_("on conflict"), NULL,
                                dt_conf_get_int("plugins/imageio/storage/disk/overwrite"),

--- a/src/imageio/storage/gallery.c
+++ b/src/imageio/storage/gallery.c
@@ -205,7 +205,7 @@ void gui_init(dt_imageio_module_storage_t *self)
   GtkWidget *widget = dtgtk_button_new(dtgtk_cairo_paint_directory, CPF_NONE, NULL);
   gtk_widget_set_name(widget, "non-flat");
   gtk_widget_set_tooltip_text(widget, _("select directory"));
-  g_signal_connect(G_OBJECT(widget), "clicked", G_CALLBACK(button_clicked), self);
+  g_signal_connect(widget, "clicked", G_CALLBACK(button_clicked), self);
 
   d->title_entry =
     GTK_ENTRY(dt_action_entry_new

--- a/src/imageio/storage/latex.c
+++ b/src/imageio/storage/latex.c
@@ -191,7 +191,7 @@ void gui_init(dt_imageio_module_storage_t *self)
   GtkWidget *widget = dtgtk_button_new(dtgtk_cairo_paint_directory, CPF_NONE, NULL);
   gtk_widget_set_name(widget, "non-flat");
   gtk_widget_set_tooltip_text(widget, _("select directory"));
-  g_signal_connect(G_OBJECT(widget), "clicked", G_CALLBACK(button_clicked), self);
+  g_signal_connect(widget, "clicked", G_CALLBACK(button_clicked), self);
 
   d->title_entry = GTK_ENTRY(dt_action_entry_new(DT_ACTION(self), N_("path"), G_CALLBACK(title_changed_callback), self,
                                            _("enter the title of the book"),

--- a/src/imageio/storage/piwigo.c
+++ b/src/imageio/storage/piwigo.c
@@ -1058,7 +1058,7 @@ void gui_init(dt_imageio_module_storage_t *self)
     index++;
   }
   gtk_widget_set_hexpand(ui->account_list, TRUE);
-  g_signal_connect(G_OBJECT(ui->account_list), "value-changed",
+  g_signal_connect(ui->account_list, "value-changed",
                    G_CALLBACK(_piwigo_account_changed), (gpointer)ui);
 
   // server
@@ -1100,7 +1100,7 @@ void gui_init(dt_imageio_module_storage_t *self)
   // login button
   GtkWidget *login_button = gtk_button_new_with_label(_("login"));
   gtk_widget_set_tooltip_text(login_button, _("Piwigo login"));
-  g_signal_connect(G_OBJECT(login_button), "clicked",
+  g_signal_connect(login_button, "clicked",
                    G_CALLBACK(_piwigo_login_clicked), self);
 
   // status area
@@ -1125,13 +1125,13 @@ void gui_init(dt_imageio_module_storage_t *self)
   ui->album_list = dt_bauhaus_combobox_new_action(DT_ACTION(self)); // Available albums
   dt_bauhaus_widget_set_label(ui->album_list, NULL, N_("album"));
   gtk_widget_set_hexpand(GTK_WIDGET(ui->album_list), TRUE);
-  g_signal_connect(G_OBJECT(ui->album_list), "value-changed",
+  g_signal_connect(ui->album_list, "value-changed",
                    G_CALLBACK(_piwigo_album_changed), (gpointer)ui);
   gtk_widget_set_sensitive(ui->album_list, FALSE);
 
   GtkWidget *refresh_button = dtgtk_button_new(dtgtk_cairo_paint_refresh, CPF_NONE, NULL);
   gtk_widget_set_tooltip_text(refresh_button, _("refresh album list"));
-  g_signal_connect(G_OBJECT(refresh_button), "clicked",
+  g_signal_connect(refresh_button, "clicked",
                    G_CALLBACK(_piwigo_refresh_clicked), (gpointer)ui);
 
   // new album
@@ -1174,7 +1174,7 @@ void gui_init(dt_imageio_module_storage_t *self)
   dt_bauhaus_combobox_add(ui->conflict_action, _("skip"));
   dt_bauhaus_combobox_add(ui->conflict_action, _("update metadata"));
   dt_bauhaus_combobox_add(ui->conflict_action, _("overwrite"));
-  g_signal_connect(G_OBJECT(ui->conflict_action), "value-changed",
+  g_signal_connect(ui->conflict_action, "value-changed",
                    G_CALLBACK(_piwigo_conflict_changed), self);
   dt_bauhaus_combobox_set(ui->conflict_action, dt_conf_get_int("storage/piwigo/conflict"));
 

--- a/src/iop/agx.c
+++ b/src/iop/agx.c
@@ -1928,7 +1928,7 @@ static GtkWidget* _create_curve_graph_box(dt_iop_module_t *self,
   g_object_set_data(G_OBJECT(g->graph_drawing_area), "iop-instance", self);
   dt_action_define_iop(self, N_("curve"), N_("graph"), GTK_WIDGET(g->graph_drawing_area), NULL);
   gtk_widget_set_can_focus(GTK_WIDGET(g->graph_drawing_area), TRUE);
-  g_signal_connect(G_OBJECT(g->graph_drawing_area), "draw", G_CALLBACK(_agx_draw_curve), self);
+  g_signal_connect(g->graph_drawing_area, "draw", G_CALLBACK(_agx_draw_curve), self);
   gtk_widget_set_tooltip_text(GTK_WIDGET(g->graph_drawing_area), _("tone mapping curve"));
 
   // Pack drawing area at the top
@@ -2054,7 +2054,7 @@ static void _add_exposure_box(dt_iop_module_t *self, dt_iop_agx_gui_data_t *g, d
 
   g->btn_read_exposure = dtgtk_button_new(dtgtk_cairo_paint_camera, 0, NULL);
   gtk_widget_set_tooltip_text(g->btn_read_exposure, _("read exposure from metadata and exposure module"));
-  g_signal_connect(G_OBJECT(g->btn_read_exposure), "clicked", G_CALLBACK(_read_exposure_params_callback), real_self);
+  g_signal_connect(g->btn_read_exposure, "clicked", G_CALLBACK(_read_exposure_params_callback), real_self);
   dt_action_define_iop(real_self, N_("exposure range"), N_("read exposure"), g->btn_read_exposure, &dt_action_def_button);
   dt_gui_box_add(g->range_exposure_picker_group, g->btn_read_exposure);
 

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -5321,9 +5321,9 @@ static void cropmode_callback(GtkWidget *widget, dt_iop_module_t *self)
   _swap_shadow_crop_box(p,g);
 }
 
-static int _event_fit_v_button_clicked(GtkWidget *widget,
-                                       const GdkEventButton *event,
-                                       dt_iop_module_t *self)
+static gboolean _event_fit_v_button_clicked(GtkWidget *widget,
+                                            const GdkEventButton *event,
+                                            dt_iop_module_t *self)
 {
   if(darktable.gui->reset) return FALSE;
 
@@ -5369,9 +5369,9 @@ static int _event_fit_v_button_clicked(GtkWidget *widget,
   return FALSE;
 }
 
-static int _event_fit_h_button_clicked(GtkWidget *widget,
-                                       const GdkEventButton *event,
-                                       dt_iop_module_t *self)
+static gboolean _event_fit_h_button_clicked(GtkWidget *widget,
+                                            const GdkEventButton *event,
+                                            dt_iop_module_t *self)
 {
   if(darktable.gui->reset) return FALSE;
 
@@ -5417,9 +5417,9 @@ static int _event_fit_h_button_clicked(GtkWidget *widget,
   return FALSE;
 }
 
-static int _event_fit_both_button_clicked(GtkWidget *widget,
-                                          const GdkEventButton *event,
-                                          dt_iop_module_t *self)
+static gboolean _event_fit_both_button_clicked(GtkWidget *widget,
+                                               const GdkEventButton *event,
+                                               dt_iop_module_t *self)
 {
   if(darktable.gui->reset) return FALSE;
 
@@ -5467,9 +5467,9 @@ static int _event_fit_both_button_clicked(GtkWidget *widget,
   return FALSE;
 }
 
-static int _event_structure_auto_clicked(GtkWidget *widget,
-                                         const GdkEventButton *event,
-                                         dt_iop_module_t *self)
+static gboolean _event_structure_auto_clicked(GtkWidget *widget,
+                                              const GdkEventButton *event,
+                                              dt_iop_module_t *self)
 {
   if(darktable.gui->reset) return FALSE;
 
@@ -5856,9 +5856,9 @@ static float log2_curve(const float inval, const dt_bauhaus_curve_t dir)
   return outval;
 }
 
-static int _event_structure_quad_clicked(GtkWidget *widget,
-                                         GdkEventButton *event,
-                                         dt_iop_module_t *self)
+static gboolean _event_structure_quad_clicked(GtkWidget *widget,
+                                              GdkEventButton *event,
+                                              dt_iop_module_t *self)
 {
   dt_iop_ashift_gui_data_t *g = self->gui_data;
   if(darktable.gui->reset) return FALSE;
@@ -5884,9 +5884,9 @@ static int _event_structure_quad_clicked(GtkWidget *widget,
   return TRUE;
 }
 
-static int _event_structure_lines_clicked(GtkWidget *widget,
-                                          GdkEventButton *event,
-                                          dt_iop_module_t *self)
+static gboolean _event_structure_lines_clicked(GtkWidget *widget,
+                                               GdkEventButton *event,
+                                               dt_iop_module_t *self)
 {
   dt_iop_ashift_gui_data_t *g = self->gui_data;
   if(darktable.gui->reset) return FALSE;
@@ -5970,7 +5970,7 @@ void gui_init(dt_iop_module_t *self)
   dt_shortcut_register(ac, 0, 0, GDK_KEY_r, GDK_MOD1_MASK);
 
   g->cropmode = dt_bauhaus_combobox_from_params(self, "cropmode");
-  g_signal_connect(G_OBJECT(g->cropmode), "value-changed",
+  g_signal_connect(g->cropmode, "value-changed",
                    G_CALLBACK(cropmode_callback), self);
 
   GtkWidget *main_box = self->widget;
@@ -6111,25 +6111,25 @@ void gui_init(dt_iop_module_t *self)
     (g->structure_quad, _("manually define perspective rectangle"));
   gtk_widget_set_tooltip_text(g->structure_lines, _("manually draw structure lines"));
 
-  g_signal_connect(G_OBJECT(g->fit_v), "button-press-event",
+  g_signal_connect(g->fit_v, "button-press-event",
                    G_CALLBACK(_event_fit_v_button_clicked),
-                   (gpointer)self);
-  g_signal_connect(G_OBJECT(g->fit_h), "button-press-event",
+                   self);
+  g_signal_connect(g->fit_h, "button-press-event",
                    G_CALLBACK(_event_fit_h_button_clicked),
-                   (gpointer)self);
-  g_signal_connect(G_OBJECT(g->fit_both), "button-press-event",
+                   self);
+  g_signal_connect(g->fit_both, "button-press-event",
                    G_CALLBACK(_event_fit_both_button_clicked),
-                   (gpointer)self);
-  g_signal_connect(G_OBJECT(g->structure_quad), "button-press-event",
+                   self);
+  g_signal_connect(g->structure_quad, "button-press-event",
                    G_CALLBACK(_event_structure_quad_clicked),
-                   (gpointer)self);
-  g_signal_connect(G_OBJECT(g->structure_lines), "button-press-event",
+                   self);
+  g_signal_connect(g->structure_lines, "button-press-event",
                    G_CALLBACK(_event_structure_lines_clicked),
-                   (gpointer)self);
-  g_signal_connect(G_OBJECT(g->structure_auto), "button-press-event",
+                   self);
+  g_signal_connect(g->structure_auto, "button-press-event",
                    G_CALLBACK(_event_structure_auto_clicked),
-                   (gpointer)self);
-  g_signal_connect(G_OBJECT(self->widget), "draw", G_CALLBACK(_event_draw), self);
+                   self);
+  g_signal_connect(self->widget, "draw", G_CALLBACK(_event_draw), self);
 
   dt_action_define_iop(self, N_("fit"),
                        N_("vertical"), g->fit_v, &dt_action_def_button);

--- a/src/iop/atrous.c
+++ b/src/iop/atrous.c
@@ -1798,7 +1798,7 @@ void gui_init(dt_iop_module_t *self)
        " and chroma tabs"));
   gtk_widget_show(gtk_notebook_get_nth_page(g->channel_tabs, g->channel));
   gtk_notebook_set_current_page(g->channel_tabs, g->channel);
-  g_signal_connect(G_OBJECT(g->channel_tabs), "switch_page", G_CALLBACK(tab_switch), self);
+  g_signal_connect(g->channel_tabs, "switch-page", G_CALLBACK(tab_switch), self);
 
   // graph
   g->area = GTK_DRAWING_AREA(dt_ui_resize_wrap
@@ -1809,18 +1809,18 @@ void gui_init(dt_iop_module_t *self)
   g_object_set_data(G_OBJECT(g->area), "iop-instance", self);
   dt_action_define_iop(self, NULL, N_("graph"),
                        GTK_WIDGET(g->area), &_action_def_equalizer);
-  g_signal_connect(G_OBJECT(g->area), "draw", G_CALLBACK(area_draw), self);
-  g_signal_connect(G_OBJECT(g->area), "button-press-event",
+  g_signal_connect(g->area, "draw", G_CALLBACK(area_draw), self);
+  g_signal_connect(g->area, "button-press-event",
                    G_CALLBACK(area_button_press), self);
-  g_signal_connect(G_OBJECT(g->area), "button-release-event",
+  g_signal_connect(g->area, "button-release-event",
                    G_CALLBACK(area_button_release), self);
-  g_signal_connect(G_OBJECT(g->area), "motion-notify-event",
+  g_signal_connect(g->area, "motion-notify-event",
                    G_CALLBACK(area_motion_notify), self);
-  g_signal_connect(G_OBJECT(g->area), "leave-notify-event",
+  g_signal_connect(g->area, "leave-notify-event",
                    G_CALLBACK(area_enter_leave_notify), self);
-  g_signal_connect(G_OBJECT(g->area), "enter-notify-event",
+  g_signal_connect(g->area, "enter-notify-event",
                    G_CALLBACK(area_enter_leave_notify), self);
-  g_signal_connect(G_OBJECT(g->area), "scroll-event",
+  g_signal_connect(g->area, "scroll-event",
                    G_CALLBACK(area_scrolled), self);
 
   self->widget = dt_gui_vbox(g->channel_tabs, g->area);
@@ -1828,7 +1828,7 @@ void gui_init(dt_iop_module_t *self)
   // mix slider
   g->mix = dt_bauhaus_slider_from_params(self, N_("mix"));
   gtk_widget_set_tooltip_text(g->mix, _("make effect stronger or weaker"));
-  g_signal_connect(G_OBJECT(g->mix), "value-changed", G_CALLBACK(mix_callback), self);
+  g_signal_connect(g->mix, "value-changed", G_CALLBACK(mix_callback), self);
 }
 
 void gui_cleanup(dt_iop_module_t *self)

--- a/src/iop/basecurve.c
+++ b/src/iop/basecurve.c
@@ -2156,19 +2156,19 @@ void gui_init(dt_iop_module_t *self)
 
   g->logbase = dt_bauhaus_slider_new_with_range(self, 0.0f, 40.0f, 0, 0.0f, 2);
   dt_bauhaus_widget_set_label(g->logbase, NULL, N_("scale for graph"));
-  g_signal_connect(G_OBJECT(g->logbase), "value-changed", G_CALLBACK(logbase_callback), self);
+  g_signal_connect(g->logbase, "value-changed", G_CALLBACK(logbase_callback), self);
   dt_gui_box_add(self->widget, g->logbase);
 
   gtk_widget_add_events(GTK_WIDGET(g->area), GDK_POINTER_MOTION_MASK | darktable.gui->scroll_mask
                                            | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK
                                            | GDK_ENTER_NOTIFY_MASK | GDK_LEAVE_NOTIFY_MASK);
   gtk_widget_set_can_focus(GTK_WIDGET(g->area), TRUE);
-  g_signal_connect(G_OBJECT(g->area), "draw", G_CALLBACK(dt_iop_basecurve_draw), self);
-  g_signal_connect(G_OBJECT(g->area), "button-press-event", G_CALLBACK(dt_iop_basecurve_button_press), self);
-  g_signal_connect(G_OBJECT(g->area), "motion-notify-event", G_CALLBACK(dt_iop_basecurve_motion_notify), self);
-  g_signal_connect(G_OBJECT(g->area), "leave-notify-event", G_CALLBACK(dt_iop_basecurve_leave_notify), self);
-  g_signal_connect(G_OBJECT(g->area), "scroll-event", G_CALLBACK(_scrolled), self);
-  g_signal_connect(G_OBJECT(g->area), "key-press-event", G_CALLBACK(dt_iop_basecurve_key_press), self);
+  g_signal_connect(g->area, "draw", G_CALLBACK(dt_iop_basecurve_draw), self);
+  g_signal_connect(g->area, "button-press-event", G_CALLBACK(dt_iop_basecurve_button_press), self);
+  g_signal_connect(g->area, "motion-notify-event", G_CALLBACK(dt_iop_basecurve_motion_notify), self);
+  g_signal_connect(g->area, "leave-notify-event", G_CALLBACK(dt_iop_basecurve_leave_notify), self);
+  g_signal_connect(g->area, "scroll-event", G_CALLBACK(_scrolled), self);
+  g_signal_connect(g->area, "key-press-event", G_CALLBACK(dt_iop_basecurve_key_press), self);
 }
 
 void gui_cleanup(dt_iop_module_t *self)

--- a/src/iop/basicadj.c
+++ b/src/iop/basicadj.c
@@ -639,7 +639,7 @@ void gui_init(dt_iop_module_t *self)
                       dt_bauhaus_slider_from_params(self, "middle_grey"));
   dt_bauhaus_slider_set_format(g->sl_middle_grey, "%");
   gtk_widget_set_tooltip_text(g->sl_middle_grey, _("middle gray adjustment"));
-  g_signal_connect(G_OBJECT(g->sl_middle_grey), "quad-pressed", G_CALLBACK(_color_picker_callback), self);
+  g_signal_connect(g->sl_middle_grey, "quad-pressed", G_CALLBACK(_color_picker_callback), self);
 
   g->sl_brightness = dt_bauhaus_slider_from_params(self, N_("brightness"));
   dt_bauhaus_slider_set_soft_range(g->sl_brightness, -1.0, 1.0);
@@ -660,7 +660,7 @@ void gui_init(dt_iop_module_t *self)
                               _("apply auto exposure based on a region defined by the user\n"
                                 "click and drag to draw the area\n"
                                 "right-click to cancel"));
-  g_signal_connect(G_OBJECT(g->bt_select_region), "toggled", G_CALLBACK(_select_region_toggled_callback), self);
+  g_signal_connect(g->bt_select_region, "toggled", G_CALLBACK(_select_region_toggled_callback), self);
 
   dt_gui_box_add(self->widget, dt_gui_expand(g->bt_auto_levels), dt_gui_expand(g->bt_select_region));
 

--- a/src/iop/blurs.c
+++ b/src/iop/blurs.c
@@ -771,7 +771,7 @@ void gui_init(dt_iop_module_t *self)
   g->img_width = 0.f;
 
   g->area = GTK_DRAWING_AREA(dtgtk_drawing_area_new_with_height(0));
-  g_signal_connect(G_OBJECT(g->area), "draw", G_CALLBACK(_dt_iop_tonecurve_draw), self);
+  g_signal_connect(g->area, "draw", G_CALLBACK(_dt_iop_tonecurve_draw), self);
   self->widget = dt_gui_vbox(g->area);
 
   g->radius = dt_bauhaus_slider_from_params(self, "radius");

--- a/src/iop/borders.c
+++ b/src/iop/borders.c
@@ -854,8 +854,8 @@ void gui_changed(dt_iop_module_t *self,
   }
 }
 
-static void _colorpick_color_set(GtkColorButton *widget,
-                                dt_iop_module_t *self)
+static void _colorpick_color_set(GtkWidget *widget,
+                                 dt_iop_module_t *self)
 {
   if(darktable.gui->reset) return;
   dt_iop_borders_params_t *p = self->params;
@@ -872,7 +872,8 @@ static void _colorpick_color_set(GtkColorButton *widget,
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 
-static void _frame_colorpick_color_set(GtkColorButton *widget, dt_iop_module_t *self)
+static void _frame_colorpick_color_set(GtkWidget *widget,
+                                       dt_iop_module_t *self)
 {
   if(darktable.gui->reset) return;
   dt_iop_borders_params_t *p = self->params;
@@ -1013,7 +1014,7 @@ void gui_init(dt_iop_module_t *self)
   g->colorpick = gtk_color_button_new_with_rgba(&color);
   gtk_color_chooser_set_use_alpha(GTK_COLOR_CHOOSER(g->colorpick), FALSE);
   gtk_color_button_set_title(GTK_COLOR_BUTTON(g->colorpick), _("select border color"));
-  g_signal_connect(G_OBJECT(g->colorpick), "color-set",
+  g_signal_connect(g->colorpick, "color-set",
                    G_CALLBACK(_colorpick_color_set), self);
   g->border_picker = dt_color_picker_new(self, DT_COLOR_PICKER_POINT, NULL);
   gtk_widget_set_tooltip_text(GTK_WIDGET(g->border_picker),
@@ -1027,7 +1028,7 @@ void gui_init(dt_iop_module_t *self)
   gtk_color_chooser_set_use_alpha(GTK_COLOR_CHOOSER(g->frame_colorpick), FALSE);
   gtk_color_button_set_title(GTK_COLOR_BUTTON(g->frame_colorpick),
                              _("select frame line color"));
-  g_signal_connect(G_OBJECT(g->frame_colorpick), "color-set",
+  g_signal_connect(g->frame_colorpick, "color-set",
                    G_CALLBACK(_frame_colorpick_color_set), self);
   g->frame_picker = dt_color_picker_new(self, DT_COLOR_PICKER_POINT, NULL);
   gtk_widget_set_tooltip_text(GTK_WIDGET(g->frame_picker),

--- a/src/iop/channelmixer.c
+++ b/src/iop/channelmixer.c
@@ -612,25 +612,25 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_combobox_add(g->output_channel, _("blue"));
   dt_bauhaus_combobox_add(g->output_channel, C_("channelmixer", "gray"));
   dt_bauhaus_combobox_set(g->output_channel, CHANNEL_RED);
-  g_signal_connect(G_OBJECT(g->output_channel), "value-changed", G_CALLBACK(output_callback), self);
+  g_signal_connect(g->output_channel, "value-changed", G_CALLBACK(output_callback), self);
 
   /* red */
   g->scale_red = dt_bauhaus_slider_new_with_range(self, -2.0, 2.0, 0, p->red[CHANNEL_RED], 3);
   gtk_widget_set_tooltip_text(g->scale_red, _("amount of red channel in the output channel"));
   dt_bauhaus_widget_set_label(g->scale_red, NULL, N_("red"));
-  g_signal_connect(G_OBJECT(g->scale_red), "value-changed", G_CALLBACK(red_callback), self);
+  g_signal_connect(g->scale_red, "value-changed", G_CALLBACK(red_callback), self);
 
   /* green */
   g->scale_green = dt_bauhaus_slider_new_with_range(self, -2.0, 2.0, 0, p->green[CHANNEL_RED], 3);
   gtk_widget_set_tooltip_text(g->scale_green, _("amount of green channel in the output channel"));
   dt_bauhaus_widget_set_label(g->scale_green, NULL, N_("green"));
-  g_signal_connect(G_OBJECT(g->scale_green), "value-changed", G_CALLBACK(green_callback), self);
+  g_signal_connect(g->scale_green, "value-changed", G_CALLBACK(green_callback), self);
 
   /* blue */
   g->scale_blue = dt_bauhaus_slider_new_with_range(self, -2.0, 2.0, 0, p->blue[CHANNEL_RED], 3);
   gtk_widget_set_tooltip_text(g->scale_blue, _("amount of blue channel in the output channel"));
   dt_bauhaus_widget_set_label(g->scale_blue, NULL, N_("blue"));
-  g_signal_connect(G_OBJECT(g->scale_blue), "value-changed", G_CALLBACK(blue_callback), self);
+  g_signal_connect(g->scale_blue, "value-changed", G_CALLBACK(blue_callback), self);
 
   self->widget = dt_gui_vbox(g->output_channel, g->scale_red, g->scale_green, g->scale_blue);
 }

--- a/src/iop/clahe.c
+++ b/src/iop/clahe.c
@@ -326,9 +326,9 @@ void gui_init(dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(GTK_WIDGET(g->scale1), _("size of features to preserve"));
   gtk_widget_set_tooltip_text(GTK_WIDGET(g->scale2), _("strength of the effect"));
 
-  g_signal_connect(G_OBJECT(g->scale1), "value-changed",
+  g_signal_connect(g->scale1, "value-changed",
                    G_CALLBACK(radius_callback), self);
-  g_signal_connect(G_OBJECT(g->scale2), "value-changed",
+  g_signal_connect(g->scale2, "value-changed",
                    G_CALLBACK(slope_callback), self);
 
   self->widget = dt_gui_vbox(g->scale1, g->scale2);

--- a/src/iop/clipping.c
+++ b/src/iop/clipping.c
@@ -2105,7 +2105,7 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_combobox_add(g->hvflip, _("horizontal"));
   dt_bauhaus_combobox_add(g->hvflip, _("vertical"));
   dt_bauhaus_combobox_add(g->hvflip, _("both"));
-  g_signal_connect(G_OBJECT(g->hvflip), "value-changed", G_CALLBACK(hvflip_callback), self);
+  g_signal_connect(g->hvflip, "value-changed", G_CALLBACK(hvflip_callback), self);
   gtk_widget_set_tooltip_text(g->hvflip, _("mirror image horizontally and/or vertically"));
   dt_gui_box_add(self->widget, g->hvflip);
 
@@ -2121,7 +2121,7 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_combobox_add(g->keystone_type, _("horizontal"));
   dt_bauhaus_combobox_add(g->keystone_type, _("full"));
   gtk_widget_set_tooltip_text(g->keystone_type, _("set perspective correction for your image"));
-  g_signal_connect(G_OBJECT(g->keystone_type), "value-changed", G_CALLBACK(keystone_type_changed), self);
+  g_signal_connect(g->keystone_type, "value-changed", G_CALLBACK(keystone_type_changed), self);
   dt_gui_box_add(self->widget, g->keystone_type);
 
   g->crop_auto = dt_bauhaus_combobox_from_params(self, "crop_auto");
@@ -2236,12 +2236,12 @@ void gui_init(dt_iop_module_t *self)
 
   dt_bauhaus_combobox_set(g->aspect_presets, 0);
 
-  g_signal_connect(G_OBJECT(g->aspect_presets), "value-changed", G_CALLBACK(aspect_presets_changed), self);
+  g_signal_connect(g->aspect_presets, "value-changed", G_CALLBACK(aspect_presets_changed), self);
   gtk_widget_set_tooltip_text(g->aspect_presets, _("set the aspect ratio\n"
                                                    "the list is sorted: from most square to least square\n"
                                                    "to enter custom aspect ratio open the combobox and type ratio in x:y or decimal format"));
   dt_bauhaus_widget_set_quad_paint(g->aspect_presets, dtgtk_cairo_paint_aspectflip, 0, NULL);
-  g_signal_connect(G_OBJECT(g->aspect_presets), "quad-pressed", G_CALLBACK(aspect_flip), self);
+  g_signal_connect(g->aspect_presets, "quad-pressed", G_CALLBACK(aspect_flip), self);
   dt_gui_box_add(self->widget, g->aspect_presets);
 
   self->widget = dt_ui_notebook_page(g->notebook, _("margins"), NULL);

--- a/src/iop/colorbalance.c
+++ b/src/iop/colorbalance.c
@@ -1814,8 +1814,8 @@ static void _cycle_layout_callback(GtkWidget *label, GdkEventButton *event, dt_i
 #define HSL_CALLBACK(which)                                                             \
 static void which##_callback(GtkWidget *slider, dt_iop_module_t *self)                  \
 {                                                                                       \
-  dt_iop_colorbalance_params_t *p = self->params;       \
-  dt_iop_colorbalance_gui_data_t *g = self->gui_data; \
+  dt_iop_colorbalance_params_t *p = self->params;                                       \
+  dt_iop_colorbalance_gui_data_t *g = self->gui_data;                                   \
                                                                                         \
   if(darktable.gui->reset) return;                                                      \
                                                                                         \
@@ -1861,7 +1861,7 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_combobox_add(g->controls, _("both"));
   dt_gui_box_add(self->widget, g->controls);
   gtk_widget_set_tooltip_text(g->controls, _("color-grading mapping method"));
-  g_signal_connect(G_OBJECT(g->controls), "value-changed", G_CALLBACK(controls_callback), self);
+  g_signal_connect(g->controls, "value-changed", G_CALLBACK(controls_callback), self);
 
   const char *mode = dt_conf_get_string_const("plugins/darkroom/colorbalance/controls");
   dt_bauhaus_combobox_set(g->controls, !g_strcmp0(mode, "RGBL") ? RGBL :
@@ -1898,7 +1898,7 @@ void gui_init(dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->main_label, _("click to cycle layout"));
   GtkWidget *main_label_box = gtk_event_box_new();
   gtk_container_add(GTK_CONTAINER(main_label_box), g->main_label);
-  g_signal_connect(G_OBJECT(main_label_box), "button-release-event", G_CALLBACK(_cycle_layout_callback), self);
+  g_signal_connect(main_label_box, "button-release-event", G_CALLBACK(_cycle_layout_callback), self);
 
   g->main_box = gtk_event_box_new(); // is filled in _configure_slider_blocks
 
@@ -1944,7 +1944,7 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_slider_set_stop(g->hue_##which, 0.830f, 1.0f, 0.0f, 1.0f);     \
   dt_bauhaus_slider_set_stop(g->hue_##which, 1.0f,   1.0f, 0.0f, 0.0f);     \
   gtk_widget_set_tooltip_text(g->hue_##which, _("select the hue"));         \
-  g_signal_connect(G_OBJECT(g->hue_##which), "value-changed",               \
+  g_signal_connect(g->hue_##which, "value-changed",                         \
                    G_CALLBACK(which##_callback), self);                     \
                                                                             \
   g->sat_##which = dt_bauhaus_slider_new_with_range_and_feedback(self,      \
@@ -1955,7 +1955,7 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_slider_set_stop(g->sat_##which, 0.0f, 0.2f, 0.2f, 0.2f);       \
   dt_bauhaus_slider_set_stop(g->sat_##which, 1.0f, 1.0f, 1.0f, 1.0f);       \
   gtk_widget_set_tooltip_text(g->sat_##which, _("select the saturation"));  \
-  g_signal_connect(G_OBJECT(g->sat_##which), "value-changed",               \
+  g_signal_connect(g->sat_##which, "value-changed",                         \
                    G_CALLBACK(which##_callback), self);                     \
                                                                             \
   dt_gui_box_add(self->widget, g->hue_##which, g->sat_##which);             \

--- a/src/iop/colorbalancergb.c
+++ b/src/iop/colorbalancergb.c
@@ -1972,7 +1972,7 @@ void gui_init(dt_iop_module_t *self)
                                                "plugins/darkroom/colorbalancergb/graphheight"));
   g_object_set_data(G_OBJECT(g->area), "iop-instance", self);
   dt_action_define_iop(self, NULL, N_("graph"), GTK_WIDGET(g->area), NULL);
-  g_signal_connect(G_OBJECT(g->area), "draw", G_CALLBACK(dt_iop_tonecurve_draw), self);
+  g_signal_connect(g->area, "draw", G_CALLBACK(dt_iop_tonecurve_draw), self);
   dt_gui_box_add(self->widget, GTK_WIDGET(g->area));
 
   g->shadows_weight = dt_bauhaus_slider_from_params(self, "shadows_weight");
@@ -2011,17 +2011,17 @@ void gui_init(dt_iop_module_t *self)
   g->checker_color_1_picker = gtk_color_button_new();
   gtk_color_chooser_set_use_alpha(GTK_COLOR_CHOOSER(g->checker_color_1_picker), FALSE);
   gtk_color_button_set_title(GTK_COLOR_BUTTON(g->checker_color_1_picker), _("select color of the checkerboard from a swatch"));
-  g_signal_connect(G_OBJECT(g->checker_color_1_picker), "color-set", G_CALLBACK(checker_1_picker_callback), self);
+  g_signal_connect(g->checker_color_1_picker, "color-set", G_CALLBACK(checker_1_picker_callback), self);
 
   g->checker_color_2_picker = gtk_color_button_new();
   gtk_color_chooser_set_use_alpha(GTK_COLOR_CHOOSER(g->checker_color_2_picker), FALSE);
   gtk_color_button_set_title(GTK_COLOR_BUTTON(g->checker_color_2_picker), _("select color of the checkerboard from a swatch"));
-  g_signal_connect(G_OBJECT(g->checker_color_2_picker), "color-set", G_CALLBACK(checker_2_picker_callback), self);
+  g_signal_connect(g->checker_color_2_picker, "color-set", G_CALLBACK(checker_2_picker_callback), self);
 
   g->checker_size = dt_bauhaus_slider_new_with_range(self, 2., 32., 0, 8., 0);
   dt_bauhaus_slider_set_format(g->checker_size, _(" px"));
   dt_bauhaus_widget_set_label(g->checker_size,  NULL, _("checkerboard size"));
-  g_signal_connect(G_OBJECT(g->checker_size), "value-changed", G_CALLBACK(checker_size_callback), self);
+  g_signal_connect(g->checker_size, "value-changed", G_CALLBACK(checker_size_callback), self);
 
   dt_gui_box_add(self->widget,
     dt_gui_hbox(dt_gui_expand(dt_ui_label_new(_("checkerboard color 1"))), g->checker_color_1_picker),

--- a/src/iop/colorchecker.c
+++ b/src/iop/colorchecker.c
@@ -1537,11 +1537,11 @@ void gui_init(dt_iop_module_t *self)
                         GDK_POINTER_MOTION_MASK
                         | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK
                         | GDK_LEAVE_NOTIFY_MASK);
-  g_signal_connect(G_OBJECT(g->area), "draw",
+  g_signal_connect(g->area, "draw",
                    G_CALLBACK(checker_draw), self);
-  g_signal_connect(G_OBJECT(g->area), "button-press-event",
+  g_signal_connect(g->area, "button-press-event",
                    G_CALLBACK(checker_button_press), self);
-  g_signal_connect(G_OBJECT(g->area), "motion-notify-event",
+  g_signal_connect(g->area, "motion-notify-event",
                    G_CALLBACK(checker_motion_notify), self);
 
   g->patch = 0;
@@ -1615,17 +1615,17 @@ void gui_init(dt_iop_module_t *self)
   self->widget = dt_gui_vbox(g->area, g->combobox_patch, g->scale_L, g->scale_a,
                                       g->scale_b, g->scale_C, g->combobox_target);
 
-  g_signal_connect(G_OBJECT(g->combobox_patch), "value-changed",
+  g_signal_connect(g->combobox_patch, "value-changed",
                    G_CALLBACK(patch_callback), self);
-  g_signal_connect(G_OBJECT(g->scale_L), "value-changed",
+  g_signal_connect(g->scale_L, "value-changed",
                    G_CALLBACK(target_L_callback), self);
-  g_signal_connect(G_OBJECT(g->scale_a), "value-changed",
+  g_signal_connect(g->scale_a, "value-changed",
                    G_CALLBACK(target_a_callback), self);
-  g_signal_connect(G_OBJECT(g->scale_b), "value-changed",
+  g_signal_connect(g->scale_b, "value-changed",
                    G_CALLBACK(target_b_callback), self);
-  g_signal_connect(G_OBJECT(g->scale_C), "value-changed",
+  g_signal_connect(g->scale_C, "value-changed",
                    G_CALLBACK(target_C_callback), self);
-  g_signal_connect(G_OBJECT(g->combobox_target), "value-changed",
+  g_signal_connect(g->combobox_target, "value-changed",
                    G_CALLBACK(target_callback), self);
 }
 

--- a/src/iop/colorcorrection.c
+++ b/src/iop/colorcorrection.c
@@ -246,15 +246,15 @@ void gui_init(dt_iop_module_t *self)
                                            | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK
                                            | GDK_ENTER_NOTIFY_MASK | GDK_LEAVE_NOTIFY_MASK);
   gtk_widget_set_can_focus(GTK_WIDGET(g->area), TRUE);
-  g_signal_connect(G_OBJECT(g->area), "draw", G_CALLBACK(dt_iop_colorcorrection_draw), self);
-  g_signal_connect(G_OBJECT(g->area), "button-press-event", G_CALLBACK(dt_iop_colorcorrection_button_press),
+  g_signal_connect(g->area, "draw", G_CALLBACK(dt_iop_colorcorrection_draw), self);
+  g_signal_connect(g->area, "button-press-event", G_CALLBACK(dt_iop_colorcorrection_button_press),
                    self);
-  g_signal_connect(G_OBJECT(g->area), "motion-notify-event", G_CALLBACK(dt_iop_colorcorrection_motion_notify),
+  g_signal_connect(g->area, "motion-notify-event", G_CALLBACK(dt_iop_colorcorrection_motion_notify),
                    self);
-  g_signal_connect(G_OBJECT(g->area), "leave-notify-event", G_CALLBACK(dt_iop_colorcorrection_leave_notify),
+  g_signal_connect(g->area, "leave-notify-event", G_CALLBACK(dt_iop_colorcorrection_leave_notify),
                    self);
-  g_signal_connect(G_OBJECT(g->area), "scroll-event", G_CALLBACK(dt_iop_colorcorrection_scrolled), self);
-  g_signal_connect(G_OBJECT(g->area), "key-press-event", G_CALLBACK(dt_iop_colorcorrection_key_press), self);
+  g_signal_connect(g->area, "scroll-event", G_CALLBACK(dt_iop_colorcorrection_scrolled), self);
+  g_signal_connect(g->area, "key-press-event", G_CALLBACK(dt_iop_colorcorrection_key_press), self);
 
   self->widget = dt_gui_vbox(g->area);
   g->slider = dt_bauhaus_slider_from_params(self, N_("saturation"));

--- a/src/iop/colorequal.c
+++ b/src/iop/colorequal.c
@@ -3005,7 +3005,7 @@ void gui_init(dt_iop_module_t *self)
   static dt_action_def_t notebook_def = { };
   g->notebook = dt_ui_notebook_new(&notebook_def);
   dt_action_define_iop(self, NULL, N_("page"), GTK_WIDGET(g->notebook), &notebook_def);
-  g_signal_connect(G_OBJECT(g->notebook), "switch_page",
+  g_signal_connect(g->notebook, "switch-page",
                    G_CALLBACK(_channel_tabs_switch_callback), self);
 
   // graph
@@ -3024,16 +3024,16 @@ void gui_init(dt_iop_module_t *self)
                         | GDK_BUTTON_RELEASE_MASK
                         | GDK_SCROLL_MASK
                         | GDK_SMOOTH_SCROLL_MASK);
-  g_signal_connect(G_OBJECT(g->area), "draw", G_CALLBACK(_iop_colorequalizer_draw), self);
-  g_signal_connect(G_OBJECT(g->area), "button-press-event",
+  g_signal_connect(g->area, "draw", G_CALLBACK(_iop_colorequalizer_draw), self);
+  g_signal_connect(g->area, "button-press-event",
                    G_CALLBACK(_area_button_press_callback), self);
-  g_signal_connect(G_OBJECT(g->area), "button-release-event",
+  g_signal_connect(g->area, "button-release-event",
                    G_CALLBACK(_area_button_release_callback), self);
-  g_signal_connect(G_OBJECT(g->area), "motion-notify-event",
+  g_signal_connect(g->area, "motion-notify-event",
                    G_CALLBACK(_area_motion_notify_callback), self);
-  g_signal_connect(G_OBJECT(g->area), "scroll-event",
+  g_signal_connect(g->area, "scroll-event",
                    G_CALLBACK(_area_scrolled_callback), self);
-  g_signal_connect(G_OBJECT(g->area), "size_allocate",
+  g_signal_connect(g->area, "size-allocate",
                    G_CALLBACK(_area_size_callback), self);
 
   GtkWidget *box = self->widget = dt_gui_vbox(g->notebook, g->area);

--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -2052,10 +2052,10 @@ void gui_init(dt_iop_module_t *self)
     g_free(tooltip);
   }
 
-  g_signal_connect(G_OBJECT(g->profile_combobox), "value-changed",
-                   G_CALLBACK(_profile_changed), (gpointer)self);
-  g_signal_connect(G_OBJECT(g->work_combobox), "value-changed",
-                   G_CALLBACK(_workicc_changed), (gpointer)self);
+  g_signal_connect(g->profile_combobox, "value-changed",
+                   G_CALLBACK(_profile_changed), self);
+  g_signal_connect(g->work_combobox, "value-changed",
+                   G_CALLBACK(_workicc_changed), self);
 
   g->clipping_combobox = dt_bauhaus_combobox_from_params(self, "normalize");
   gtk_widget_set_tooltip_text(g->clipping_combobox,

--- a/src/iop/colormapping.c
+++ b/src/iop/colormapping.c
@@ -992,10 +992,10 @@ void gui_init(dt_iop_module_t *self)
   g->buffer = NULL;
 
   g->source_area = dtgtk_drawing_area_new_with_aspect_ratio(1.0 / 3.0);
-  g_signal_connect(G_OBJECT(g->source_area), "draw", G_CALLBACK(cluster_preview_draw), self);
+  g_signal_connect(g->source_area, "draw", G_CALLBACK(cluster_preview_draw), self);
 
   g->target_area = dtgtk_drawing_area_new_with_aspect_ratio(1.0 / 3.0);
-  g_signal_connect(G_OBJECT(g->target_area), "draw", G_CALLBACK(cluster_preview_draw), self);
+  g_signal_connect(g->target_area, "draw", G_CALLBACK(cluster_preview_draw), self);
 
   GtkWidget *box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 5);
 

--- a/src/iop/colorout.c
+++ b/src/iop/colorout.c
@@ -862,7 +862,7 @@ void gui_init(dt_iop_module_t *self)
 
   self->widget = dt_gui_vbox(g->output_intent, g->output_profile);
 
-  g_signal_connect(G_OBJECT(g->output_profile), "value-changed",
+  g_signal_connect(g->output_profile, "value-changed",
                    G_CALLBACK(output_profile_changed), (gpointer)self);
 
   // reload the profiles when the display or softproof profile changed!

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -2628,7 +2628,7 @@ void gui_init(dt_iop_module_t *self)
 
   gtk_widget_show(gtk_notebook_get_nth_page(g->channel_tabs, g->channel));
   gtk_notebook_set_current_page(g->channel_tabs, g->channel);
-  g_signal_connect(G_OBJECT(g->channel_tabs), "switch_page",
+  g_signal_connect(g->channel_tabs, "switch-page",
                    G_CALLBACK(_channel_tabs_switch_callback), self);
 
   // color pickers
@@ -2674,14 +2674,14 @@ void gui_init(dt_iop_module_t *self)
                           PANGO_ELLIPSIZE_START);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->chk_edit_by_area), g->edit_by_area);
   gtk_widget_set_tooltip_text(g->chk_edit_by_area, _("edit the curve nodes by area"));
-  g_signal_connect(G_OBJECT(g->chk_edit_by_area), "toggled",
+  g_signal_connect(g->chk_edit_by_area, "toggled",
                    G_CALLBACK(_edit_by_area_callback), self);
 
   // display selection
   g->bt_showmask = dtgtk_togglebutton_new(dtgtk_cairo_paint_showmask, 0, NULL);
   dt_gui_add_class(g->bt_showmask, "dt_transparent_background");
   gtk_widget_set_tooltip_text(g->bt_showmask, _("display selection"));
-  g_signal_connect(G_OBJECT(g->bt_showmask), "toggled",
+  g_signal_connect(g->bt_showmask, "toggled",
                    G_CALLBACK(_display_mask_callback), self);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_showmask), FALSE);
 
@@ -2707,25 +2707,25 @@ void gui_init(dt_iop_module_t *self)
   g_object_set_data(G_OBJECT(g->area), "iop-instance", self);
   dt_action_define_iop(self, NULL, N_("graph"), GTK_WIDGET(g->area), &_action_def_zones);
   gtk_widget_set_can_focus(GTK_WIDGET(g->area), TRUE);
-  g_signal_connect(G_OBJECT(g->area), "draw",
+  g_signal_connect(g->area, "draw",
                    G_CALLBACK(_area_draw_callback), self);
-  g_signal_connect(G_OBJECT(g->area), "button-press-event",
+  g_signal_connect(g->area, "button-press-event",
                    G_CALLBACK(_area_button_press_callback), self);
-  g_signal_connect(G_OBJECT(g->area), "button-release-event",
+  g_signal_connect(g->area, "button-release-event",
                    G_CALLBACK(_area_button_release_callback), self);
-  g_signal_connect(G_OBJECT(g->area), "motion-notify-event",
+  g_signal_connect(g->area, "motion-notify-event",
                    G_CALLBACK(_area_motion_notify_callback), self);
-  g_signal_connect(G_OBJECT(g->area), "leave-notify-event",
+  g_signal_connect(g->area, "leave-notify-event",
                    G_CALLBACK(_area_leave_notify_callback), self);
-  g_signal_connect(G_OBJECT(g->area), "scroll-event",
+  g_signal_connect(g->area, "scroll-event",
                    G_CALLBACK(_area_scrolled_callback), self);
-  g_signal_connect(G_OBJECT(g->area), "key-press-event",
+  g_signal_connect(g->area, "key-press-event",
                    G_CALLBACK(_area_key_press_callback), self);
 
   gtk_widget_add_events(GTK_WIDGET(g->bottom_area), GDK_BUTTON_PRESS_MASK);
-  g_signal_connect(G_OBJECT(g->bottom_area), "draw",
+  g_signal_connect(g->bottom_area, "draw",
                    G_CALLBACK(_bottom_area_draw_callback), self);
-  g_signal_connect(G_OBJECT(g->bottom_area), "button-press-event",
+  g_signal_connect(g->bottom_area, "button-press-event",
                    G_CALLBACK(_bottom_area_button_press_callback),
                    self);
 
@@ -2736,7 +2736,7 @@ void gui_init(dt_iop_module_t *self)
         "- cubic spline is better to produce smooth curves but oscillates when nodes are too close\n"
         "- centripetal is better to avoids cusps and oscillations with close nodes but is less smooth\n"
         "- monotonic is better for accuracy of pure analytical functions (log, gamma, exp)"));
-  g_signal_connect(G_OBJECT(g->interpolator), "value-changed",
+  g_signal_connect(g->interpolator, "value-changed",
                    G_CALLBACK(_interpolator_callback), self);
 }
 

--- a/src/iop/crop.c
+++ b/src/iop/crop.c
@@ -1269,7 +1269,7 @@ void gui_init(dt_iop_module_t *self)
 
   dt_bauhaus_combobox_set(g->aspect_presets, 0);
 
-  g_signal_connect(G_OBJECT(g->aspect_presets), "value-changed",
+  g_signal_connect(g->aspect_presets, "value-changed",
                    G_CALLBACK(_event_aspect_presets_changed), self);
   gtk_widget_set_tooltip_text
     (g->aspect_presets,

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -3774,13 +3774,13 @@ void gui_init(dt_iop_module_t *self)
   dt_ui_notebook_page(g->channel_tabs, N_("R"), NULL);
   dt_ui_notebook_page(g->channel_tabs, N_("G"), NULL);
   dt_ui_notebook_page(g->channel_tabs, N_("B"), NULL);
-  g_signal_connect(G_OBJECT(g->channel_tabs), "switch_page",
+  g_signal_connect(g->channel_tabs, "switch-page",
                    G_CALLBACK(denoiseprofile_tab_switch), self);
 
   g->channel_tabs_Y0U0V0 = GTK_NOTEBOOK(gtk_notebook_new());
   dt_ui_notebook_page(g->channel_tabs_Y0U0V0, N_("Y0"), NULL);
   dt_ui_notebook_page(g->channel_tabs_Y0U0V0, N_("U0V0"), NULL);
-  g_signal_connect(G_OBJECT(g->channel_tabs_Y0U0V0), "switch_page",
+  g_signal_connect(g->channel_tabs_Y0U0V0, "switch-page",
                    G_CALLBACK(denoiseprofile_tab_switch), self);
 
   const int ch = (int)g->channel;
@@ -3802,16 +3802,16 @@ void gui_init(dt_iop_module_t *self)
                                                "plugins/darkroom/denoiseprofile/graphheight"));
   dt_action_define_iop(self, NULL, N_("graph"), GTK_WIDGET(g->area), NULL);
 
-  g_signal_connect(G_OBJECT(g->area), "draw", G_CALLBACK(denoiseprofile_draw), self);
-  g_signal_connect(G_OBJECT(g->area), "button-press-event",
+  g_signal_connect(GTK_WIDGET(g->area), "draw", G_CALLBACK(denoiseprofile_draw), self);
+  g_signal_connect(GTK_WIDGET(g->area), "button-press-event",
                    G_CALLBACK(denoiseprofile_button_press), self);
-  g_signal_connect(G_OBJECT(g->area), "button-release-event",
+  g_signal_connect(GTK_WIDGET(g->area), "button-release-event",
                    G_CALLBACK(denoiseprofile_button_release), self);
-  g_signal_connect(G_OBJECT(g->area), "motion-notify-event",
+  g_signal_connect(GTK_WIDGET(g->area), "motion-notify-event",
                    G_CALLBACK(denoiseprofile_motion_notify), self);
-  g_signal_connect(G_OBJECT(g->area), "leave-notify-event",
+  g_signal_connect(GTK_WIDGET(g->area), "leave-notify-event",
                    G_CALLBACK(denoiseprofile_leave_notify), self);
-  g_signal_connect(G_OBJECT(g->area), "scroll-event",
+  g_signal_connect(GTK_WIDGET(g->area), "scroll-event",
                    G_CALLBACK(denoiseprofile_scrolled), self);
 
   dt_gui_box_add(g->box_wavelets, g->channel_tabs, g->channel_tabs_Y0U0V0, g->area);
@@ -3839,14 +3839,14 @@ void gui_init(dt_iop_module_t *self)
                                 dt_gui_hbox(dt_ui_label_new(_("variance green: ")), g->label_var_G),
                                 dt_gui_hbox(dt_ui_label_new(_("variance blue: ")), g->label_var_B));
 
-  g_signal_connect(G_OBJECT(g->box_variance), "draw",
+  g_signal_connect(g->box_variance, "draw",
                    G_CALLBACK(denoiseprofile_draw_variance), self);
 
   // start building top level widget
 
   g->profile = dt_bauhaus_combobox_new(self);
   dt_bauhaus_widget_set_label(g->profile, NULL, N_("profile"));
-  g_signal_connect(G_OBJECT(g->profile), "value-changed",
+  g_signal_connect(g->profile, "value-changed",
                    G_CALLBACK(profile_callback), self);
   self->widget = dt_gui_vbox(g->profile);
 

--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -1295,7 +1295,7 @@ void gui_init(dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(GTK_WIDGET(g->origin_spot),
                               _("the input color that should be mapped to the target"));
 
-  g_signal_connect(G_OBJECT(g->origin_spot), "draw", G_CALLBACK(_origin_color_draw), self);
+  g_signal_connect(g->origin_spot, "draw", G_CALLBACK(_origin_color_draw), self);
 
   g->Lch_origin = gtk_label_new(_("L : \tN/A"));
   gtk_widget_set_tooltip_text
@@ -1309,12 +1309,12 @@ void gui_init(dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(GTK_WIDGET(g->target_spot),
                               _("the desired target exposure after mapping"));
 
-  g_signal_connect(G_OBJECT(g->target_spot), "draw", G_CALLBACK(_target_color_draw), self);
+  g_signal_connect(g->target_spot, "draw", G_CALLBACK(_target_color_draw), self);
 
   g->lightness_spot = dt_bauhaus_slider_new_with_range(self, 0., 100., 0, 50.f, 1);
   dt_bauhaus_widget_set_label(g->lightness_spot, NULL, N_("lightness"));
   dt_bauhaus_slider_set_format(g->lightness_spot, "%");
-  g_signal_connect(G_OBJECT(g->lightness_spot), "value-changed",
+  g_signal_connect(g->lightness_spot, "value-changed",
                    G_CALLBACK(_spot_settings_changed_callback), self);
 
   dt_gui_box_add(g->cs.container,

--- a/src/iop/filmic.c
+++ b/src/iop/filmic.c
@@ -1459,7 +1459,7 @@ void gui_init(dt_iop_module_t *self)
   // don't make the area square to safe some vertical space -- it's not interactive anyway
   g->area = GTK_DRAWING_AREA(dtgtk_drawing_area_new_with_aspect_ratio(0.618));
   gtk_widget_set_tooltip_text(GTK_WIDGET(g->area), _("read-only graph, use the parameters below to set the nodes"));
-  g_signal_connect(G_OBJECT(g->area), "draw", G_CALLBACK(dt_iop_tonecurve_draw), self);
+  g_signal_connect(g->area, "draw", G_CALLBACK(dt_iop_tonecurve_draw), self);
 
   // grey_point_source slider
   g->grey_point_source = dt_bauhaus_slider_new_with_range(self, 0.0, 100., 0, p->grey_point_source, 2);
@@ -1468,7 +1468,7 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_slider_set_format(g->grey_point_source, "%");
   gtk_widget_set_tooltip_text(g->grey_point_source, _("adjust to match the average luminance of the subject.\n"
                                                       "except in back-lighting situations, this should be around 18%."));
-  g_signal_connect(G_OBJECT(g->grey_point_source), "value-changed", G_CALLBACK(grey_point_source_callback), self);
+  g_signal_connect(g->grey_point_source, "value-changed", G_CALLBACK(grey_point_source_callback), self);
   dt_color_picker_new(self, DT_COLOR_PICKER_AREA | DT_COLOR_PICKER_DENOISE,
                       g->grey_point_source);
 
@@ -1480,7 +1480,7 @@ void gui_init(dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->white_point_source, _("number of stops between middle gray and pure white.\n"
                                                        "this is a reading a lightmeter would give you on the scene.\n"
                                                        "adjust so highlights clipping is avoided"));
-  g_signal_connect(G_OBJECT(g->white_point_source), "value-changed", G_CALLBACK(white_point_source_callback), self);
+  g_signal_connect(g->white_point_source, "value-changed", G_CALLBACK(white_point_source_callback), self);
   dt_color_picker_new(self, DT_COLOR_PICKER_AREA | DT_COLOR_PICKER_DENOISE,
                       g->white_point_source);
 
@@ -1492,7 +1492,7 @@ void gui_init(dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->black_point_source, _("number of stops between middle gray and pure black.\n"
                                                        "this is a reading a lightmeter would give you on the scene.\n"
                                                        "increase to get more contrast.\ndecrease to recover more details in low-lights."));
-  g_signal_connect(G_OBJECT(g->black_point_source), "value-changed", G_CALLBACK(black_point_source_callback), self);
+  g_signal_connect(g->black_point_source, "value-changed", G_CALLBACK(black_point_source_callback), self);
   dt_color_picker_new(self, DT_COLOR_PICKER_AREA | DT_COLOR_PICKER_DENOISE,
                       g->black_point_source);
 
@@ -1502,7 +1502,7 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_slider_set_format(g->security_factor, "%");
   gtk_widget_set_tooltip_text(g->security_factor, _("increase or decrease the computed dynamic range.\n"
                                                     "useful in conjunction with \"auto tune levels\"."));
-  g_signal_connect(G_OBJECT(g->security_factor), "value-changed", G_CALLBACK(security_threshold_callback), self);
+  g_signal_connect(g->security_factor, "value-changed", G_CALLBACK(security_threshold_callback), self);
 
   // Auto tune slider
   g->auto_button = dt_bauhaus_combobox_new(self);
@@ -1519,7 +1519,7 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_widget_set_label(g->contrast, NULL, N_("contrast"));
   gtk_widget_set_tooltip_text(g->contrast, _("slope of the linear part of the curve\n"
                                              "affects mostly the mid-tones"));
-  g_signal_connect(G_OBJECT(g->contrast), "value-changed", G_CALLBACK(contrast_callback), self);
+  g_signal_connect(g->contrast, "value-changed", G_CALLBACK(contrast_callback), self);
 
   // latitude slider
   g->latitude_stops = dt_bauhaus_slider_new_with_range(self, 0.01, 16.0, 0, p->latitude_stops, 3);
@@ -1529,7 +1529,7 @@ void gui_init(dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->latitude_stops, _("width of the linear domain in the middle of the curve.\n"
                                                    "increase to get more contrast at the extreme luminances.\n"
                                                    "this has no effect on mid-tones."));
-  g_signal_connect(G_OBJECT(g->latitude_stops), "value-changed", G_CALLBACK(latitude_stops_callback), self);
+  g_signal_connect(g->latitude_stops, "value-changed", G_CALLBACK(latitude_stops_callback), self);
 
   // balance slider
   g->balance = dt_bauhaus_slider_new_with_range(self, -50., 50., 0, p->balance, 2);
@@ -1537,7 +1537,7 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_slider_set_format(g->balance, "%");
   gtk_widget_set_tooltip_text(g->balance, _("slides the latitude along the slope\nto give more room to shadows or highlights.\n"
                                             "use it if you need to protect the details\nat one extremity of the histogram."));
-  g_signal_connect(G_OBJECT(g->balance), "value-changed", G_CALLBACK(balance_callback), self);
+  g_signal_connect(g->balance, "value-changed", G_CALLBACK(balance_callback), self);
 
   // saturation slider
   g->global_saturation = dt_bauhaus_slider_new_with_range(self, 0., 1000., 0, p->global_saturation, 2);
@@ -1546,7 +1546,7 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_slider_set_format(g->global_saturation, "%");
   gtk_widget_set_tooltip_text(g->global_saturation, _("desaturates the input of the module globally.\n"
                                                       "you need to set this value below 100%\nif the chrominance preservation is enabled."));
-  g_signal_connect(G_OBJECT(g->global_saturation), "value-changed", G_CALLBACK(global_saturation_callback), self);
+  g_signal_connect(g->global_saturation, "value-changed", G_CALLBACK(global_saturation_callback), self);
 
   // saturation slider
   g->saturation = dt_bauhaus_slider_new_with_range(self, 0., 1000., 0, (powf(10.0f, p->saturation/100.0f) - 1.0f) / 9.0f *100.0f, 2);
@@ -1555,7 +1555,7 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_slider_set_format(g->saturation, "%");
   gtk_widget_set_tooltip_text(g->saturation, _("desaturates the output of the module\nspecifically at extreme luminances.\n"
                                                "decrease if shadows and/or highlights are over-saturated."));
-  g_signal_connect(G_OBJECT(g->saturation), "value-changed", G_CALLBACK(saturation_callback), self);
+  g_signal_connect(g->saturation, "value-changed", G_CALLBACK(saturation_callback), self);
 
     /* From src/common/curve_tools.h :
     #define CUBIC_SPLINE 0
@@ -1569,7 +1569,7 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_combobox_add(g->interpolator, _("linear")); // monotonic spline
   dt_bauhaus_combobox_add(g->interpolator, _("optimized")); // monotonic spline
   gtk_widget_set_tooltip_text(g->interpolator, _("change this method if you see reversed contrast or faded blacks"));
-  g_signal_connect(G_OBJECT(g->interpolator), "value-changed", G_CALLBACK(interpolator_callback), self);
+  g_signal_connect(g->interpolator, "value-changed", G_CALLBACK(interpolator_callback), self);
 
   // Preserve color
   g->preserve_color = gtk_check_button_new_with_label(_("preserve the chrominance"));
@@ -1577,7 +1577,7 @@ void gui_init(dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->preserve_color, _("ensure the original color are preserved.\n"
                                                    "may reinforce chromatic aberrations.\n"
                                                    "you need to manually tune the saturation when using this mode."));
-  g_signal_connect(G_OBJECT(g->preserve_color), "toggled", G_CALLBACK(preserve_color_callback), self);
+  g_signal_connect(g->preserve_color, "toggled", G_CALLBACK(preserve_color_callback), self);
 
   // Black slider
   g->black_point_target = dt_bauhaus_slider_new_with_range(self, 0.0, 100.0, 0, p->black_point_target, 2);
@@ -1585,7 +1585,7 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_slider_set_format(g->black_point_target, "%");
   gtk_widget_set_tooltip_text(g->black_point_target, _("luminance of output pure black, "
                                                         "this should be 0%\nexcept if you want a faded look"));
-  g_signal_connect(G_OBJECT(g->black_point_target), "value-changed", G_CALLBACK(black_point_target_callback), self);
+  g_signal_connect(g->black_point_target, "value-changed", G_CALLBACK(black_point_target_callback), self);
 
   // grey_point_source slider
   g->grey_point_target = dt_bauhaus_slider_new_with_range(self, 0.1, 50., 0, p->grey_point_target, 2);
@@ -1593,7 +1593,7 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_slider_set_format(g->grey_point_target, "%");
   gtk_widget_set_tooltip_text(g->grey_point_target, _("middle gray value of the target display or color space.\n"
                                                       "you should never touch that unless you know what you are doing."));
-  g_signal_connect(G_OBJECT(g->grey_point_target), "value-changed", G_CALLBACK(grey_point_target_callback), self);
+  g_signal_connect(g->grey_point_target, "value-changed", G_CALLBACK(grey_point_target_callback), self);
 
   // White slider
   g->white_point_target = dt_bauhaus_slider_new_with_range(self, 0.0, 100.0, 0, p->white_point_target, 2);
@@ -1601,18 +1601,18 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_slider_set_format(g->white_point_target, "%");
   gtk_widget_set_tooltip_text(g->white_point_target, _("luminance of output pure white, "
                                                         "this should be 100%\nexcept if you want a faded look"));
-  g_signal_connect(G_OBJECT(g->white_point_target), "value-changed", G_CALLBACK(white_point_target_callback), self);
+  g_signal_connect(g->white_point_target, "value-changed", G_CALLBACK(white_point_target_callback), self);
 
   // power/gamma slider
   g->output_power = dt_bauhaus_slider_new_with_range(self, 1.0, 2.4, 0, p->output_power, 2);
   dt_bauhaus_widget_set_label(g->output_power, NULL, N_("target gamma"));
   gtk_widget_set_tooltip_text(g->output_power, _("power or gamma of the transfer function\nof the display or color space.\n"
                                                  "you should never touch that unless you know what you are doing."));
-  g_signal_connect(G_OBJECT(g->output_power), "value-changed", G_CALLBACK(output_power_callback), self);
+  g_signal_connect(g->output_power, "value-changed", G_CALLBACK(output_power_callback), self);
 
   // add collapsible section for those extra options that are generally not to be used
   g->extra_toggle = dtgtk_togglebutton_new(dtgtk_cairo_paint_solid_arrow, CPF_DIRECTION_LEFT, NULL);
-  g_signal_connect(G_OBJECT(g->extra_toggle), "toggled", G_CALLBACK(_extra_options_button_changed),  (gpointer)self);
+  g_signal_connect(g->extra_toggle, "toggled", G_CALLBACK(_extra_options_button_changed),  (gpointer)self);
   g->extra_expander = dtgtk_expander_new(dt_gui_hbox(dt_ui_section_label_new(C_("section", "destination/display")), 
                                                      g->extra_toggle), 
                                          dt_gui_vbox(g->black_point_target,

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -4367,11 +4367,11 @@ void gui_init(dt_iop_module_t *self)
   dt_action_define_iop(self, NULL, N_("graph"), GTK_WIDGET(g->area), NULL);
 
   gtk_widget_set_can_focus(GTK_WIDGET(g->area), TRUE);
-  g_signal_connect(G_OBJECT(g->area), "draw", G_CALLBACK(dt_iop_tonecurve_draw), self);
-  g_signal_connect(G_OBJECT(g->area), "button-press-event", G_CALLBACK(area_button_press), self);
-  g_signal_connect(G_OBJECT(g->area), "leave-notify-event", G_CALLBACK(area_enter_leave_notify), self);
-  g_signal_connect(G_OBJECT(g->area), "enter-notify-event", G_CALLBACK(area_enter_leave_notify), self);
-  g_signal_connect(G_OBJECT(g->area), "motion-notify-event", G_CALLBACK(area_motion_notify), self);
+  g_signal_connect(g->area, "draw", G_CALLBACK(dt_iop_tonecurve_draw), self);
+  g_signal_connect(g->area, "button-press-event", G_CALLBACK(area_button_press), self);
+  g_signal_connect(g->area, "leave-notify-event", G_CALLBACK(area_enter_leave_notify), self);
+  g_signal_connect(g->area, "enter-notify-event", G_CALLBACK(area_enter_leave_notify), self);
+  g_signal_connect(g->area, "motion-notify-event", G_CALLBACK(area_motion_notify), self);
 
   // Init GTK notebook
   static struct dt_action_def_t notebook_def = { };

--- a/src/iop/hotpixels.c
+++ b/src/iop/hotpixels.c
@@ -437,7 +437,7 @@ void gui_init(dt_iop_module_t *self)
   g->pixels_fixed = -1;
 
   GtkWidget *box_raw = self->widget = dt_gui_vbox();
-  g_signal_connect(G_OBJECT(box_raw), "draw", G_CALLBACK(draw), self);
+  g_signal_connect(box_raw, "draw", G_CALLBACK(draw), self);
 
   g->threshold = dt_bauhaus_slider_from_params(self, N_("threshold"));
   dt_bauhaus_slider_set_digits(g->threshold, 4);

--- a/src/iop/invert.c
+++ b/src/iop/invert.c
@@ -493,7 +493,7 @@ void gui_init(dt_iop_module_t *self)
   dt_action_define(DT_ACTION(self), NULL, N_("pick color of film material from image"), g->colorpicker, &dt_action_def_button);
   gtk_color_chooser_set_use_alpha(GTK_COLOR_CHOOSER(g->colorpicker), FALSE);
   gtk_color_button_set_title(GTK_COLOR_BUTTON(g->colorpicker), _("select color of film material"));
-  g_signal_connect(G_OBJECT(g->colorpicker), "color-set", G_CALLBACK(colorpicker_callback), self);
+  g_signal_connect(g->colorpicker, "color-set", G_CALLBACK(colorpicker_callback), self);
 
   g->picker = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, NULL);
 

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -3815,7 +3815,7 @@ static GtkMenu *camera_menu_fill(dt_iop_module_t *self,
     }
     gtk_widget_show(item);
     g_object_set_data(G_OBJECT(item), "lfCamera", (void *)camlist[i]);
-    g_signal_connect(G_OBJECT(item), "activate",
+    g_signal_connect(item, "activate",
                      G_CALLBACK(_camera_menu_select), self);
     gtk_menu_shell_append(GTK_MENU_SHELL(submenu), item);
   }
@@ -4145,7 +4145,7 @@ static GtkMenu *_lens_menu_fill(dt_iop_module_t *self,
     item = gtk_menu_item_new_with_label(lf_mlstr_get(lenslist[i]->Model));
     gtk_widget_show(item);
     g_object_set_data(G_OBJECT(item), "lfLens", (void *)lenslist[i]);
-    g_signal_connect(G_OBJECT(item), "activate",
+    g_signal_connect(item, "activate",
                      G_CALLBACK(_lens_menu_select), self);
     gtk_menu_shell_append(GTK_MENU_SHELL(submenu), item);
   }
@@ -4408,21 +4408,21 @@ void gui_init(dt_iop_module_t *self)
   g->focal_length = dt_gui_expand(dt_bauhaus_combobox_new(self));
   dt_bauhaus_widget_set_label(g->focal_length, NULL, N_("focal length"));
   gtk_widget_set_tooltip_text(g->focal_length, _("focal length (mm)"));
-  g_signal_connect(G_OBJECT(g->focal_length), "value-changed",
+  g_signal_connect(g->focal_length, "value-changed",
                    G_CALLBACK(_lens_comboentry_focal_update), self);
   dt_bauhaus_combobox_set_editable(g->focal_length, 1);
 
   g->aperture = dt_gui_expand(dt_bauhaus_combobox_new(self));
   dt_bauhaus_widget_set_label(g->aperture, NULL, N_("aperture"));
   gtk_widget_set_tooltip_text(g->aperture, _("f-number (aperture)"));
-  g_signal_connect(G_OBJECT(g->aperture), "value-changed",
+  g_signal_connect(g->aperture, "value-changed",
                    G_CALLBACK(_lens_comboentry_aperture_update), self);
   dt_bauhaus_combobox_set_editable(g->aperture, 1);
 
   g->distance = dt_gui_expand(dt_bauhaus_combobox_new(self));
   dt_bauhaus_widget_set_label(g->distance, NULL, N_("distance"));
   gtk_widget_set_tooltip_text(g->distance, _("distance to subject"));
-  g_signal_connect(G_OBJECT(g->distance), "value-changed",
+  g_signal_connect(g->distance, "value-changed",
                    G_CALLBACK(_lens_comboentry_distance_update), self);
   dt_bauhaus_combobox_set_editable(g->distance, 1);
 
@@ -4492,7 +4492,7 @@ void gui_init(dt_iop_module_t *self)
        "once enabled, you won't be able to\n"
        "return back to old algorithm."));
   GtkWidget *box_md = dt_gui_vbox(g->use_latest_md_algo);
-  g_signal_connect(G_OBJECT(g->use_latest_md_algo), "toggled",
+  g_signal_connect(g->use_latest_md_algo, "toggled",
                    G_CALLBACK(_use_latest_md_algo_callback), self);
 
   // we put fine-tuning values under an expander

--- a/src/iop/levels.c
+++ b/src/iop/levels.c
@@ -51,7 +51,7 @@ static gboolean dt_iop_levels_button_press(GtkWidget *widget, GdkEventButton *ev
 static gboolean dt_iop_levels_button_release(GtkWidget *widget, GdkEventButton *event, dt_iop_module_t *self);
 static gboolean dt_iop_levels_leave_notify(GtkWidget *widget, GdkEventCrossing *event, dt_iop_module_t *self);
 static gboolean dt_iop_levels_scroll(GtkWidget *widget, GdkEventScroll *event, dt_iop_module_t *self);
-static void dt_iop_levels_autoadjust_callback(GtkRange *range, dt_iop_module_t *self);
+static void dt_iop_levels_autoadjust_callback(GtkWidget *range, dt_iop_module_t *self);
 //static void dt_iop_levels_mode_callback(GtkWidget *combo, gpointer user_data);
 //static void dt_iop_levels_percentiles_callback(GtkWidget *slider, gpointer user_data);
 
@@ -635,16 +635,16 @@ void gui_init(dt_iop_module_t *self)
                                                     "operates on L channel."));
   dt_action_define_iop(self, NULL, N_("levels"), GTK_WIDGET(g->area), NULL);
 
-  g_signal_connect(G_OBJECT(g->area), "draw", G_CALLBACK(dt_iop_levels_area_draw), self);
-  g_signal_connect(G_OBJECT(g->area), "button-press-event", G_CALLBACK(dt_iop_levels_button_press), self);
-  g_signal_connect(G_OBJECT(g->area), "button-release-event", G_CALLBACK(dt_iop_levels_button_release), self);
-  g_signal_connect(G_OBJECT(g->area), "motion-notify-event", G_CALLBACK(dt_iop_levels_motion_notify), self);
-  g_signal_connect(G_OBJECT(g->area), "leave-notify-event", G_CALLBACK(dt_iop_levels_leave_notify), self);
-  g_signal_connect(G_OBJECT(g->area), "scroll-event", G_CALLBACK(dt_iop_levels_scroll), self);
+  g_signal_connect(g->area, "draw", G_CALLBACK(dt_iop_levels_area_draw), self);
+  g_signal_connect(g->area, "button-press-event", G_CALLBACK(dt_iop_levels_button_press), self);
+  g_signal_connect(g->area, "button-release-event", G_CALLBACK(dt_iop_levels_button_release), self);
+  g_signal_connect(g->area, "motion-notify-event", G_CALLBACK(dt_iop_levels_motion_notify), self);
+  g_signal_connect(g->area, "leave-notify-event", G_CALLBACK(dt_iop_levels_leave_notify), self);
+  g_signal_connect(g->area, "scroll-event", G_CALLBACK(dt_iop_levels_scroll), self);
 
   GtkWidget *autobutton = gtk_button_new_with_label(_("auto"));
   gtk_widget_set_tooltip_text(autobutton, _("apply auto levels"));
-  g_signal_connect(G_OBJECT(autobutton), "clicked", G_CALLBACK(dt_iop_levels_autoadjust_callback), self);
+  g_signal_connect(autobutton, "clicked", G_CALLBACK(dt_iop_levels_autoadjust_callback), self);
 
   g->blackpick = dt_color_picker_new(self, DT_COLOR_PICKER_POINT, NULL);
   gtk_widget_set_tooltip_text(g->blackpick, _("pick black point from image"));
@@ -976,7 +976,7 @@ static gboolean dt_iop_levels_scroll(GtkWidget *widget, GdkEventScroll *event, d
   return TRUE; // Ensure that scrolling the widget cannot move side panel
 }
 
-static void dt_iop_levels_autoadjust_callback(GtkRange *range, dt_iop_module_t *self)
+static void dt_iop_levels_autoadjust_callback(GtkWidget *range, dt_iop_module_t *self)
 {
   if(darktable.gui->reset) return;
   dt_iop_levels_params_t *p = self->params;

--- a/src/iop/lowlight.c
+++ b/src/iop/lowlight.c
@@ -807,12 +807,12 @@ void gui_init(dt_iop_module_t *self)
   dt_action_define_iop(self, NULL, N_("graph"), GTK_WIDGET(g->area), NULL);
   self->widget = dt_gui_vbox(g->area);
 
-  g_signal_connect(G_OBJECT(g->area), "draw", G_CALLBACK(lowlight_draw), self);
-  g_signal_connect(G_OBJECT(g->area), "button-press-event", G_CALLBACK(lowlight_button_press), self);
-  g_signal_connect(G_OBJECT(g->area), "button-release-event", G_CALLBACK(lowlight_button_release), self);
-  g_signal_connect(G_OBJECT(g->area), "motion-notify-event", G_CALLBACK(lowlight_motion_notify), self);
-  g_signal_connect(G_OBJECT(g->area), "leave-notify-event", G_CALLBACK(lowlight_leave_notify), self);
-  g_signal_connect(G_OBJECT(g->area), "scroll-event", G_CALLBACK(lowlight_scrolled), self);
+  g_signal_connect(g->area, "draw", G_CALLBACK(lowlight_draw), self);
+  g_signal_connect(g->area, "button-press-event", G_CALLBACK(lowlight_button_press), self);
+  g_signal_connect(g->area, "button-release-event", G_CALLBACK(lowlight_button_release), self);
+  g_signal_connect(g->area, "motion-notify-event", G_CALLBACK(lowlight_motion_notify), self);
+  g_signal_connect(g->area, "leave-notify-event", G_CALLBACK(lowlight_leave_notify), self);
+  g_signal_connect(g->area, "scroll-event", G_CALLBACK(lowlight_scrolled), self);
 
   g->scale_blueness = dt_bauhaus_slider_from_params(self, "blueness");
   dt_bauhaus_slider_set_format(g->scale_blueness, "%");

--- a/src/iop/lut3d.c
+++ b/src/iop/lut3d.c
@@ -1700,8 +1700,8 @@ void gui_init(dt_iop_module_t *self)
     _("the file path (relative to LUT folder) is saved with image (and not the LUT data themselves)"));
 #endif // HAVE_GMIC
   self->widget = dt_gui_vbox(dt_gui_hbox(g->button, dt_gui_expand(g->filepath)));
-  g_signal_connect(G_OBJECT(g->button), "clicked", G_CALLBACK(_button_clicked), self);
-  g_signal_connect(G_OBJECT(g->filepath), "value-changed", G_CALLBACK(_filepath_callback), self);
+  g_signal_connect(g->button, "clicked", G_CALLBACK(_button_clicked), self);
+  g_signal_connect(g->filepath, "value-changed", G_CALLBACK(_filepath_callback), self);
 
 #ifdef HAVE_GMIC
   // text entry
@@ -1730,11 +1730,11 @@ void gui_init(dt_iop_module_t *self)
   gtk_tree_view_append_column((GtkTreeView *)g->lutname, col);
   GtkTreeSelection *selection = gtk_tree_view_get_selection((GtkTreeView *)g->lutname);
   gtk_tree_selection_set_mode(selection, GTK_SELECTION_SINGLE);
-  g->lutname_handler_id = g_signal_connect(G_OBJECT(selection), "changed", G_CALLBACK(_lutname_callback), self);
+  g->lutname_handler_id = g_signal_connect_data(selection, "changed", G_CALLBACK(_lutname_callback), self, NULL, 0);
   dt_gui_box_add(self->widget, g->lutwindow);
 
-  g_signal_connect(G_OBJECT(g->lutentry), "changed", G_CALLBACK(_entry_callback), self);
-  g_signal_connect(G_OBJECT((GtkTreeView *)g->lutname), "scroll-event", G_CALLBACK(_mouse_scroll), (gpointer)self);
+  g_signal_connect(g->lutentry, "changed", G_CALLBACK(_entry_callback), self);
+  g_signal_connect(g->lutname, "scroll-event", G_CALLBACK(_mouse_scroll), self);
 #endif // HAVE_GMIC
 
   g->colorspace = dt_bauhaus_combobox_from_params(self, "colorspace");

--- a/src/iop/monochrome.c
+++ b/src/iop/monochrome.c
@@ -562,14 +562,14 @@ void gui_init(dt_iop_module_t *self)
   gtk_widget_add_events(GTK_WIDGET(g->area), GDK_POINTER_MOTION_MASK
                                              | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK
                                              | GDK_LEAVE_NOTIFY_MASK | darktable.gui->scroll_mask);
-  g_signal_connect(G_OBJECT(g->area), "draw", G_CALLBACK(_monochrome_draw), self);
-  g_signal_connect(G_OBJECT(g->area), "button-press-event", G_CALLBACK(_monochrome_button_press), self);
-  g_signal_connect(G_OBJECT(g->area), "button-release-event", G_CALLBACK(_monochrome_button_release),
+  g_signal_connect(g->area, "draw", G_CALLBACK(_monochrome_draw), self);
+  g_signal_connect(g->area, "button-press-event", G_CALLBACK(_monochrome_button_press), self);
+  g_signal_connect(g->area, "button-release-event", G_CALLBACK(_monochrome_button_release),
                    self);
-  g_signal_connect(G_OBJECT(g->area), "motion-notify-event", G_CALLBACK(_monochrome_motion_notify),
+  g_signal_connect(g->area, "motion-notify-event", G_CALLBACK(_monochrome_motion_notify),
                    self);
-  g_signal_connect(G_OBJECT(g->area), "leave-notify-event", G_CALLBACK(_monochrome_leave_notify), self);
-  g_signal_connect(G_OBJECT(g->area), "scroll-event", G_CALLBACK(_monochrome_scrolled), self);
+  g_signal_connect(g->area, "leave-notify-event", G_CALLBACK(_monochrome_leave_notify), self);
+  g_signal_connect(g->area, "scroll-event", G_CALLBACK(_monochrome_scrolled), self);
 
   g->highlights
       = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, dt_bauhaus_slider_from_params(self, N_("highlights")));

--- a/src/iop/negadoctor.c
+++ b/src/iop/negadoctor.c
@@ -843,7 +843,7 @@ void gui_init(dt_iop_module_t *self)
   g->Dmin_picker = gtk_color_button_new();
   gtk_color_chooser_set_use_alpha(GTK_COLOR_CHOOSER(g->Dmin_picker), FALSE);
   gtk_color_button_set_title(GTK_COLOR_BUTTON(g->Dmin_picker), _("select color of film material from a swatch"));
-  g_signal_connect(G_OBJECT(g->Dmin_picker), "color-set", G_CALLBACK(Dmin_picker_callback), self);
+  g_signal_connect(g->Dmin_picker, "color-set", G_CALLBACK(Dmin_picker_callback), self);
 
   g->Dmin_sampler = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, NULL);
   gtk_widget_set_tooltip_text(g->Dmin_sampler , _("pick color of film material from image"));
@@ -905,7 +905,7 @@ void gui_init(dt_iop_module_t *self)
   g->WB_low_picker = gtk_color_button_new();
   gtk_color_chooser_set_use_alpha(GTK_COLOR_CHOOSER(g->WB_low_picker), FALSE);
   gtk_color_button_set_title(GTK_COLOR_BUTTON(g->WB_low_picker), _("select color of shadows from a swatch"));
-  g_signal_connect(G_OBJECT(g->WB_low_picker), "color-set", G_CALLBACK(WB_low_picker_callback), self);
+  g_signal_connect(g->WB_low_picker, "color-set", G_CALLBACK(WB_low_picker_callback), self);
 
   g->WB_low_sampler = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, NULL);
   gtk_widget_set_tooltip_text(g->WB_low_sampler, _("pick shadows color from image"));
@@ -939,7 +939,7 @@ void gui_init(dt_iop_module_t *self)
   g->WB_high_picker = gtk_color_button_new();
   gtk_color_chooser_set_use_alpha(GTK_COLOR_CHOOSER(g->WB_high_picker), FALSE);
   gtk_color_button_set_title(GTK_COLOR_BUTTON(g->WB_high_picker), _("select color of illuminant from a swatch"));
-  g_signal_connect(G_OBJECT(g->WB_high_picker), "color-set", G_CALLBACK(WB_high_picker_callback), self);
+  g_signal_connect(g->WB_high_picker, "color-set", G_CALLBACK(WB_high_picker_callback), self);
 
   g->WB_high_sampler = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, NULL);
   gtk_widget_set_tooltip_text(g->WB_high_sampler , _("pick illuminant color from image"));

--- a/src/iop/overlay.c
+++ b/src/iop/overlay.c
@@ -809,7 +809,7 @@ static void _draw_thumb(GtkWidget *area,
   }
 }
 
-static void _alignment_callback(const GtkWidget *tb, dt_iop_module_t *self)
+static void _alignment_callback(GtkWidget *tb, dt_iop_module_t *self)
 {
   const dt_iop_overlay_gui_data_t *g = self->gui_data;
 
@@ -1048,9 +1048,9 @@ static void _drag_and_drop_received(GtkWidget *widget,
 
 static gboolean _on_drag_motion(GtkWidget *widget,
                                 GdkDragContext *dc,
-                                gint x,
-                                gint y,
-                                guint time,
+                                const gint x,
+                                const gint y,
+                                const guint time,
                                 const dt_iop_module_t *self)
 {
   dt_iop_overlay_gui_data_t *g = self->gui_data;
@@ -1082,7 +1082,7 @@ void gui_init(dt_iop_module_t *self)
   int line = 0;
 
   g->area = GTK_DRAWING_AREA(dtgtk_drawing_area_new_with_height(0));
-  g_signal_connect(G_OBJECT(g->area), "draw", G_CALLBACK(_draw_thumb), self);
+  g_signal_connect(g->area, "draw", G_CALLBACK(_draw_thumb), self);
   gtk_widget_set_size_request(GTK_WIDGET(g->area), 150, 150);
   gtk_grid_attach(grid, GTK_WIDGET(g->area), 0, line++, 1, 2);
 
@@ -1155,7 +1155,7 @@ void gui_init(dt_iop_module_t *self)
     g->align[i] = dtgtk_togglebutton_new(dtgtk_cairo_paint_alignment,
                                          (CPF_SPECIAL_FLAG << i), NULL);
     gtk_grid_attach(GTK_GRID(bat), GTK_WIDGET(g->align[i]), 1 + i%3, i/3, 1, 1);
-    g_signal_connect(G_OBJECT(g->align[i]), "toggled",
+    g_signal_connect(g->align[i], "toggled",
                      G_CALLBACK(_alignment_callback), self);
   }
 

--- a/src/iop/rasterfile.c
+++ b/src/iop/rasterfile.c
@@ -594,12 +594,12 @@ void gui_init(dt_iop_module_t *self)
   gtk_widget_set_name(g->fbutton, "non-flat");
   gtk_widget_set_tooltip_text(g->fbutton, _("select the PFM file recorded as a raster mask,\n"
       "CAUTION: path must be set in preferences/processing before choosing"));
-  g_signal_connect(G_OBJECT(g->fbutton), "clicked", G_CALLBACK(_fbutton_clicked), self);
+  g_signal_connect(g->fbutton, "clicked", G_CALLBACK(_fbutton_clicked), self);
 
   g->file = dt_bauhaus_combobox_new(self);
   dt_bauhaus_combobox_set_entries_ellipsis(g->file, PANGO_ELLIPSIZE_MIDDLE);
   gtk_widget_set_tooltip_text(g->file, _("the mask file path is saved with the image history"));
-  g_signal_connect(G_OBJECT(g->file), "value-changed", G_CALLBACK(_file_callback), self);
+  g_signal_connect(g->file, "value-changed", G_CALLBACK(_file_callback), self);
 
   dt_gui_box_add(self->widget, dt_gui_hbox(g->fbutton, dt_gui_expand(g->file)));
 }

--- a/src/iop/rawdenoise.c
+++ b/src/iop/rawdenoise.c
@@ -886,7 +886,7 @@ void gui_init(dt_iop_module_t *self)
 
   gtk_widget_show(gtk_notebook_get_nth_page(g->channel_tabs, g->channel));
   gtk_notebook_set_current_page(g->channel_tabs, g->channel);
-  g_signal_connect(G_OBJECT(g->channel_tabs), "switch_page", G_CALLBACK(rawdenoise_tab_switch), self);
+  g_signal_connect(g->channel_tabs, "switch-page", G_CALLBACK(rawdenoise_tab_switch), self);
 
   const int ch = (int)g->channel;
   g->transition_curve = dt_draw_curve_new(0.0, 1.0, CATMULL_ROM);
@@ -909,12 +909,12 @@ void gui_init(dt_iop_module_t *self)
 
   GtkWidget *box_raw = self->widget = dt_gui_vbox(g->channel_tabs, g->area);
 
-  g_signal_connect(G_OBJECT(g->area), "draw", G_CALLBACK(rawdenoise_draw), self);
-  g_signal_connect(G_OBJECT(g->area), "button-press-event", G_CALLBACK(rawdenoise_button_press), self);
-  g_signal_connect(G_OBJECT(g->area), "button-release-event", G_CALLBACK(rawdenoise_button_release), self);
-  g_signal_connect(G_OBJECT(g->area), "motion-notify-event", G_CALLBACK(rawdenoise_motion_notify), self);
-  g_signal_connect(G_OBJECT(g->area), "leave-notify-event", G_CALLBACK(rawdenoise_leave_notify), self);
-  g_signal_connect(G_OBJECT(g->area), "scroll-event", G_CALLBACK(rawdenoise_scrolled), self);
+  g_signal_connect(GTK_WIDGET(g->area), "draw", G_CALLBACK(rawdenoise_draw), self);
+  g_signal_connect(GTK_WIDGET(g->area), "button-press-event", G_CALLBACK(rawdenoise_button_press), self);
+  g_signal_connect(GTK_WIDGET(g->area), "button-release-event", G_CALLBACK(rawdenoise_button_release), self);
+  g_signal_connect(GTK_WIDGET(g->area), "motion-notify-event", G_CALLBACK(rawdenoise_motion_notify), self);
+  g_signal_connect(GTK_WIDGET(g->area), "leave-notify-event", G_CALLBACK(rawdenoise_leave_notify), self);
+  g_signal_connect(GTK_WIDGET(g->area), "scroll-event", G_CALLBACK(rawdenoise_scrolled), self);
 
   g->threshold = dt_bauhaus_slider_from_params(self, "threshold");
   dt_bauhaus_slider_set_soft_max(g->threshold, 0.1);

--- a/src/iop/relight.c
+++ b/src/iop/relight.c
@@ -256,7 +256,7 @@ void gui_init(dt_iop_module_t *self)
 
   g->center = DTGTK_GRADIENT_SLIDER(dtgtk_gradient_slider_new_with_color_and_name(_gradient_L[0], _gradient_L[1], "gslider-relight"));
   gtk_widget_set_tooltip_text(GTK_WIDGET(g->center), _("select the center of fill-light\nctrl+click to select an area"));
-  g_signal_connect(G_OBJECT(g->center), "value-changed", G_CALLBACK(center_callback), self);
+  g_signal_connect(g->center, "value-changed", G_CALLBACK(center_callback), self);
   g->colorpicker = dt_color_picker_new(self, DT_COLOR_PICKER_POINT_AREA, NULL);
   gtk_widget_set_tooltip_text(GTK_WIDGET(g->colorpicker), _("toggle tool for picking median lightness in image"));
   dt_gui_box_add(self->widget, dt_gui_hbox(dt_gui_expand(g->center), g->colorpicker));

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -2531,17 +2531,17 @@ void gui_init(dt_iop_module_t *self)
        "top line indicates that the scale is visible at current zoom level\n"
        "bottom line indicates that the scale has shapes on it"));
 
-  g_signal_connect(G_OBJECT(g->wd_bar), "draw",
+  g_signal_connect(g->wd_bar, "draw",
                    G_CALLBACK(rt_wdbar_draw), self);
-  g_signal_connect(G_OBJECT(g->wd_bar), "motion-notify-event",
+  g_signal_connect(g->wd_bar, "motion-notify-event",
                    G_CALLBACK(rt_wdbar_motion_notify), self);
-  g_signal_connect(G_OBJECT(g->wd_bar), "leave-notify-event",
+  g_signal_connect(g->wd_bar, "leave-notify-event",
                    G_CALLBACK(rt_wdbar_leave_notify), self);
-  g_signal_connect(G_OBJECT(g->wd_bar), "button-press-event",
+  g_signal_connect(g->wd_bar, "button-press-event",
                    G_CALLBACK(rt_wdbar_button_press), self);
-  g_signal_connect(G_OBJECT(g->wd_bar), "button-release-event",
+  g_signal_connect(g->wd_bar, "button-release-event",
                    G_CALLBACK(rt_wdbar_button_release), self);
-  g_signal_connect(G_OBJECT(g->wd_bar), "scroll-event",
+  g_signal_connect(g->wd_bar, "scroll-event",
                    G_CALLBACK(rt_wdbar_scrolled), self);
   gtk_widget_add_events(GTK_WIDGET(g->wd_bar),
                         GDK_POINTER_MOTION_MASK
@@ -2606,7 +2606,7 @@ void gui_init(dt_iop_module_t *self)
   dtgtk_gradient_slider_multivalue_set_resetvalues(gslider, vdefault);
   (gslider)->markers_type = PROPORTIONAL_MARKERS;
   (gslider)->min_spacing = 0.05;
-  g_signal_connect(G_OBJECT(gslider), "value-changed",
+  g_signal_connect(gslider, "value-changed",
                    G_CALLBACK(rt_gslider_changed), self);
 
   // auto-levels button
@@ -2645,7 +2645,7 @@ void gui_init(dt_iop_module_t *self)
   gtk_color_chooser_set_use_alpha(GTK_COLOR_CHOOSER(g->colorpick), FALSE);
   gtk_color_button_set_title(GTK_COLOR_BUTTON(g->colorpick), _("select fill color"));
   gtk_widget_set_tooltip_text(g->colorpick, _("select fill color"));
-  g_signal_connect(G_OBJECT(g->colorpick), "color-set",
+  g_signal_connect(g->colorpick, "color-set",
                    G_CALLBACK(rt_colorpick_color_set_callback), self);
 
   g->colorpicker = dt_color_picker_new
@@ -2683,7 +2683,7 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_slider_set_format(g->sl_mask_opacity, "%");
   gtk_widget_set_tooltip_text(g->sl_mask_opacity,
                               _("set the opacity on the selected shape"));
-  g_signal_connect(G_OBJECT(g->sl_mask_opacity), "value-changed",
+  g_signal_connect(g->sl_mask_opacity, "value-changed",
                    G_CALLBACK(rt_mask_opacity_callback), self);
 
   // start building top level widget

--- a/src/iop/rgbcurve.c
+++ b/src/iop/rgbcurve.c
@@ -1489,7 +1489,7 @@ void gui_init(dt_iop_module_t *self)
   dt_ui_notebook_page(g->channel_tabs, N_("R"), _("curve nodes for r channel"));
   dt_ui_notebook_page(g->channel_tabs, N_("G"), _("curve nodes for g channel"));
   dt_ui_notebook_page(g->channel_tabs, N_("B"), _("curve nodes for b channel"));
-  g_signal_connect(G_OBJECT(g->channel_tabs), "switch_page",
+  g_signal_connect(g->channel_tabs, "switch-page",
                    G_CALLBACK(tab_switch_callback), self);
 
   // color pickers
@@ -1532,17 +1532,17 @@ void gui_init(dt_iop_module_t *self)
                         | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK
                         | GDK_ENTER_NOTIFY_MASK | GDK_LEAVE_NOTIFY_MASK);
   gtk_widget_set_can_focus(GTK_WIDGET(g->area), TRUE);
-  g_signal_connect(G_OBJECT(g->area), "draw",
+  g_signal_connect(g->area, "draw",
                    G_CALLBACK(_area_draw_callback), self);
-  g_signal_connect(G_OBJECT(g->area), "button-press-event",
+  g_signal_connect(g->area, "button-press-event",
                    G_CALLBACK(_area_button_press_callback), self);
-  g_signal_connect(G_OBJECT(g->area), "motion-notify-event",
+  g_signal_connect(g->area, "motion-notify-event",
                    G_CALLBACK(_area_motion_notify_callback), self);
-  g_signal_connect(G_OBJECT(g->area), "leave-notify-event",
+  g_signal_connect(g->area, "leave-notify-event",
                    G_CALLBACK(_area_leave_notify_callback), self);
-  g_signal_connect(G_OBJECT(g->area), "scroll-event",
+  g_signal_connect(g->area, "scroll-event",
                    G_CALLBACK(_area_scrolled_callback), self);
-  g_signal_connect(G_OBJECT(g->area), "key-press-event",
+  g_signal_connect(g->area, "key-press-event",
                    G_CALLBACK(_area_key_press_callback), self);
 
   g->interpolator = dt_bauhaus_combobox_new_interpolation(self);
@@ -1551,7 +1551,7 @@ void gui_init(dt_iop_module_t *self)
         "- cubic spline is better to produce smooth curves but oscillates when nodes are too close\n"
         "- centripetal is better to avoids cusps and oscillations with close nodes but is less smooth\n"
         "- monotonic is better for accuracy of pure analytical functions (log, gamma, exp)"));
-  g_signal_connect(G_OBJECT(g->interpolator), "value-changed",
+  g_signal_connect(g->interpolator, "value-changed",
                    G_CALLBACK(interpolator_callback), self);
 
   dt_gui_box_add(self->widget, dt_gui_hbox(dt_gui_expand(g->channel_tabs),

--- a/src/iop/rgblevels.c
+++ b/src/iop/rgblevels.c
@@ -1039,7 +1039,7 @@ void gui_init(dt_iop_module_t *self)
   dt_ui_notebook_page(g->channel_tabs, N_("R"), _("curve nodes for r channel"));
   dt_ui_notebook_page(g->channel_tabs, N_("G"), _("curve nodes for g channel"));
   dt_ui_notebook_page(g->channel_tabs, N_("B"), _("curve nodes for b channel"));
-  g_signal_connect(G_OBJECT(g->channel_tabs), "switch_page",
+  g_signal_connect(g->channel_tabs, "switch-page",
                    G_CALLBACK(_tab_switch_callback), self);
 
   g->area = GTK_DRAWING_AREA(dt_ui_resize_wrap(NULL,
@@ -1052,17 +1052,17 @@ void gui_init(dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(GTK_WIDGET(g->area),
                               _("drag handles to set black, gray, and white points. "
                                 "operates on L channel."));
-  g_signal_connect(G_OBJECT(g->area), "draw",
+  g_signal_connect(g->area, "draw",
                    G_CALLBACK(_area_draw_callback), self);
-  g_signal_connect(G_OBJECT(g->area), "button-press-event",
+  g_signal_connect(g->area, "button-press-event",
                    G_CALLBACK(_area_button_press_callback), self);
-  g_signal_connect(G_OBJECT(g->area), "button-release-event",
+  g_signal_connect(g->area, "button-release-event",
                    G_CALLBACK(_area_button_release_callback), self);
-  g_signal_connect(G_OBJECT(g->area), "motion-notify-event",
+  g_signal_connect(g->area, "motion-notify-event",
                    G_CALLBACK(_area_motion_notify_callback), self);
-  g_signal_connect(G_OBJECT(g->area), "leave-notify-event",
+  g_signal_connect(g->area, "leave-notify-event",
                    G_CALLBACK(_area_leave_notify_callback), self);
-  g_signal_connect(G_OBJECT(g->area), "scroll-event",
+  g_signal_connect(g->area, "scroll-event",
                    G_CALLBACK(_area_scroll_callback), self);
 
 #define PICKER_SETUP(color, name, tooltip)                                 \
@@ -1096,9 +1096,9 @@ void gui_init(dt_iop_module_t *self)
                  dt_gui_hbox(g->blackpick, g->greypick, g->whitepick),
                  dt_gui_hbox(dt_gui_expand(g->bt_auto_levels), dt_gui_expand(g->bt_select_region)));
 
-  g_signal_connect(G_OBJECT(g->bt_auto_levels), "clicked",
+  g_signal_connect(g->bt_auto_levels, "clicked",
                    G_CALLBACK(_auto_levels_callback), self);
-  g_signal_connect(G_OBJECT(g->bt_select_region), "toggled",
+  g_signal_connect(g->bt_select_region, "toggled",
                    G_CALLBACK(_select_region_toggled_callback), self);
 
   g->cmb_preserve_colors = dt_bauhaus_combobox_from_params(self, "preserve_colors");

--- a/src/iop/splittoning.c
+++ b/src/iop/splittoning.c
@@ -475,7 +475,7 @@ static inline void gui_init_section(dt_iop_module_t *self,
   *picker = gtk_color_button_new();
   gtk_color_chooser_set_use_alpha(GTK_COLOR_CHOOSER(*picker), FALSE);
   gtk_color_button_set_title(GTK_COLOR_BUTTON(*picker), _("select tone color"));
-  g_signal_connect(G_OBJECT(*picker), "color-set", G_CALLBACK(colorpick_callback), self);
+  g_signal_connect(*picker, "color-set", G_CALLBACK(colorpick_callback), self);
 
   dt_gui_box_add(self->widget, dt_ui_section_label_new(Q_(section)),
                  dt_gui_hbox(dt_gui_expand(slider_box), *picker));

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -2145,7 +2145,7 @@ void gui_init(dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->temp_label, _("click to cycle color mode on sliders"));
   gtk_container_add(GTK_CONTAINER(temp_label_box), g->temp_label);
 
-  g_signal_connect(G_OBJECT(temp_label_box), "button-release-event",
+  g_signal_connect(temp_label_box, "button-release-event",
                    G_CALLBACK(temp_label_click), self);
 
   //Match UI order: temp first, then tint (like every other app ever)
@@ -2190,14 +2190,14 @@ void gui_init(dt_iop_module_t *self)
 
   gtk_widget_set_no_show_all(g->scale_y, TRUE);
 
-  g_signal_connect(G_OBJECT(g->scale_k), "value-changed",
+  g_signal_connect(g->scale_k, "value-changed",
                    G_CALLBACK(_temp_tint_callback), self);
-  g_signal_connect(G_OBJECT(g->scale_tint), "value-changed",
+  g_signal_connect(g->scale_tint, "value-changed",
                    G_CALLBACK(_temp_tint_callback), self);
 
-  g_signal_connect(G_OBJECT(g->presets), "value-changed",
+  g_signal_connect(g->presets, "value-changed",
                    G_CALLBACK(_preset_tune_callback), self);
-  g_signal_connect(G_OBJECT(g->finetune), "value-changed",
+  g_signal_connect(g->finetune, "value-changed",
                    G_CALLBACK(_preset_tune_callback), self);
 
   // update the gui when the preferences changed (i.e. colored sliders stuff)

--- a/src/iop/tonecurve.c
+++ b/src/iop/tonecurve.c
@@ -1270,7 +1270,7 @@ void gui_init(dt_iop_module_t *self)
   dt_ui_notebook_page(g->channel_tabs, N_("L"), _("tonecurve for L channel"));
   dt_ui_notebook_page(g->channel_tabs, N_("a"), _("tonecurve for a channel"));
   dt_ui_notebook_page(g->channel_tabs, N_("b"), _("tonecurve for b channel"));
-  g_signal_connect(G_OBJECT(g->channel_tabs), "switch_page", G_CALLBACK(tab_switch), self);
+  g_signal_connect(g->channel_tabs, "switch-page", G_CALLBACK(tab_switch), self);
 
   g->colorpicker = dt_color_picker_new(self,
                                        DT_COLOR_PICKER_POINT_AREA | DT_COLOR_PICKER_IO,
@@ -1294,16 +1294,16 @@ void gui_init(dt_iop_module_t *self)
                                            | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK
                                            | GDK_ENTER_NOTIFY_MASK | GDK_LEAVE_NOTIFY_MASK);
   gtk_widget_set_can_focus(GTK_WIDGET(g->area), TRUE);
-  g_signal_connect(G_OBJECT(g->area), "draw", G_CALLBACK(dt_iop_tonecurve_draw), self);
-  g_signal_connect(G_OBJECT(g->area), "button-press-event",
+  g_signal_connect(g->area, "draw", G_CALLBACK(dt_iop_tonecurve_draw), self);
+  g_signal_connect(g->area, "button-press-event",
                    G_CALLBACK(dt_iop_tonecurve_button_press), self);
-  g_signal_connect(G_OBJECT(g->area), "motion-notify-event",
+  g_signal_connect(g->area, "motion-notify-event",
                    G_CALLBACK(dt_iop_tonecurve_motion_notify), self);
-  g_signal_connect(G_OBJECT(g->area), "leave-notify-event",
+  g_signal_connect(g->area, "leave-notify-event",
                    G_CALLBACK(dt_iop_tonecurve_leave_notify), self);
-  g_signal_connect(G_OBJECT(g->area), "scroll-event",
+  g_signal_connect(g->area, "scroll-event",
                    G_CALLBACK(_scrolled), self);
-  g_signal_connect(G_OBJECT(g->area), "key-press-event",
+  g_signal_connect(g->area, "key-press-event",
                    G_CALLBACK(dt_iop_tonecurve_key_press), self);
 
   g->interpolator = dt_bauhaus_combobox_new_interpolation(self);
@@ -1313,7 +1313,7 @@ void gui_init(dt_iop_module_t *self)
        "- cubic spline is better to produce smooth curves but oscillates when nodes are too close\n"
        "- centripetal is better to avoids cusps and oscillations with close nodes but is less smooth\n"
        "- monotonic is better for accuracy of pure analytical functions (log, gamma, exp)"));
-  g_signal_connect(G_OBJECT(g->interpolator), "value-changed",
+  g_signal_connect(g->interpolator, "value-changed",
                    G_CALLBACK(interpolator_callback), self);
 
   dt_gui_box_add(self->widget, g->area, g->interpolator);
@@ -1325,7 +1325,7 @@ void gui_init(dt_iop_module_t *self)
   g->logbase = dt_bauhaus_slider_new_with_range(self, 0.0f, 40.0f, 0, 0.0f, 2);
   dt_bauhaus_widget_set_label(g->logbase, NULL, N_("scale for graph"));
   dt_gui_box_add(self->widget, g->logbase);
-  g_signal_connect(G_OBJECT(g->logbase), "value-changed",
+  g_signal_connect(g->logbase, "value-changed",
                    G_CALLBACK(logbase_callback), self);
 
   g->sizegroup = GTK_SIZE_GROUP(gtk_size_group_new(GTK_SIZE_GROUP_HORIZONTAL));

--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -3284,18 +3284,18 @@ void gui_init(dt_iop_module_t *self)
                         | GDK_ENTER_NOTIFY_MASK | GDK_LEAVE_NOTIFY_MASK);
   gtk_widget_set_vexpand(GTK_WIDGET(g->area), TRUE);
   gtk_widget_set_can_focus(GTK_WIDGET(g->area), TRUE);
-  g_signal_connect(G_OBJECT(g->area), "draw", G_CALLBACK(area_draw), self);
-  g_signal_connect(G_OBJECT(g->area), "button-press-event",
+  g_signal_connect(g->area, "draw", G_CALLBACK(area_draw), self);
+  g_signal_connect(g->area, "button-press-event",
                    G_CALLBACK(area_button_press), self);
-  g_signal_connect(G_OBJECT(g->area), "button-release-event",
+  g_signal_connect(g->area, "button-release-event",
                    G_CALLBACK(area_button_release), self);
-  g_signal_connect(G_OBJECT(g->area), "leave-notify-event",
+  g_signal_connect(g->area, "leave-notify-event",
                    G_CALLBACK(area_enter_leave_notify), self);
-  g_signal_connect(G_OBJECT(g->area), "enter-notify-event",
+  g_signal_connect(g->area, "enter-notify-event",
                    G_CALLBACK(area_enter_leave_notify), self);
-  g_signal_connect(G_OBJECT(g->area), "motion-notify-event",
+  g_signal_connect(g->area, "motion-notify-event",
                    G_CALLBACK(area_motion_notify), self);
-  g_signal_connect(G_OBJECT(g->area), "scroll-event",
+  g_signal_connect(g->area, "scroll-event",
                    G_CALLBACK(area_scroll), self);
   gtk_widget_set_tooltip_text(GTK_WIDGET(g->area), _("double-click to reset the curve"));
 
@@ -3308,7 +3308,7 @@ void gui_init(dt_iop_module_t *self)
        "but the curve might become oscillatory in some settings.\n"
        "negative values will avoid oscillations and behave more robustly\n"
        "but may produce brutal tone transitions and damage local contrast."));
-  g_signal_connect(G_OBJECT(g->smoothing), "value-changed",
+  g_signal_connect(g->smoothing, "value-changed",
                    G_CALLBACK(smoothing_callback), self);
   dt_gui_box_add(self->widget, wrapper, g->smoothing);
   
@@ -3396,7 +3396,7 @@ void gui_init(dt_iop_module_t *self)
   gtk_widget_show(gtk_notebook_get_nth_page(g->notebook, active_page));
   gtk_notebook_set_current_page(g->notebook, active_page);
 
-  g_signal_connect(G_OBJECT(g->notebook), "button-press-event",
+  g_signal_connect(g->notebook, "button-press-event",
                    G_CALLBACK(notebook_button_press), self);
 
   g->show_luminance_mask = dt_iop_togglebutton_new

--- a/src/iop/useless.c
+++ b/src/iop/useless.c
@@ -688,7 +688,7 @@ void gui_init(dt_iop_module_t *self)
   g->extra = dt_bauhaus_slider_new_with_range(self, -0.5, 0.5, 0, 0, 2);
   dt_bauhaus_widget_set_label(g->extra, NULL, N_("extra"));
   dt_gui_box_add(self->widget, g->extra);
-  g_signal_connect(G_OBJECT(g->extra), "value-changed", G_CALLBACK(extra_callback), self);
+  g_signal_connect(g->extra, "value-changed", G_CALLBACK(extra_callback), self);
 }
 
 void gui_cleanup(dt_iop_module_t *self)

--- a/src/iop/watermark.c
+++ b/src/iop/watermark.c
@@ -1124,7 +1124,7 @@ static void _refresh_callback(GtkWidget *tb, dt_iop_module_t *self)
   _refresh_watermarks(self);
 }
 
-static void _alignment_callback(const GtkWidget *tb, dt_iop_module_t *self)
+static void _alignment_callback(GtkWidget *tb, dt_iop_module_t *self)
 {
   int index = -1;
   const dt_iop_watermark_gui_data_t *g = self->gui_data;
@@ -1410,7 +1410,7 @@ void gui_init(dt_iop_module_t *self)
   {
     g->align[i] = dtgtk_togglebutton_new(dtgtk_cairo_paint_alignment, (CPF_SPECIAL_FLAG << i), NULL);
     gtk_grid_attach(GTK_GRID(bat), GTK_WIDGET(g->align[i]), 1 + i%3, i/3, 1, 1);
-    g_signal_connect(G_OBJECT(g->align[i]), "toggled", G_CALLBACK(_alignment_callback), self);
+    g_signal_connect(g->align[i], "toggled", G_CALLBACK(_alignment_callback), self);
   }
 
   dt_gui_box_add(self->widget, bat);
@@ -1428,10 +1428,10 @@ void gui_init(dt_iop_module_t *self)
 
   _refresh_watermarks(self);
 
-  g_signal_connect(G_OBJECT(g->watermarks), "value-changed", G_CALLBACK(_watermark_callback), self);
-  g_signal_connect(G_OBJECT(g->refresh), "clicked", G_CALLBACK(_refresh_callback), self);
-  g_signal_connect(G_OBJECT(g->colorpick), "color-set", G_CALLBACK(_colorpick_color_set), self);
-  g_signal_connect(G_OBJECT(g->fontsel), "font-set", G_CALLBACK(_fontsel_callback), self);
+  g_signal_connect(g->watermarks, "value-changed", G_CALLBACK(_watermark_callback), self);
+  g_signal_connect(g->refresh, "clicked", G_CALLBACK(_refresh_callback), self);
+  g_signal_connect(g->colorpick, "color-set", G_CALLBACK(_colorpick_color_set), self);
+  g_signal_connect(g->fontsel, "font-set", G_CALLBACK(_fontsel_callback), self);
 }
 
 void gui_cleanup(dt_iop_module_t *self)

--- a/src/iop/zonesystem.c
+++ b/src/iop/zonesystem.c
@@ -430,8 +430,8 @@ void gui_init(dt_iop_module_t *self)
   g->mouse_over_output_zones = FALSE;
 
   g->preview = dtgtk_drawing_area_new_with_height(0);
-  g_signal_connect(G_OBJECT(g->preview), "size-allocate", G_CALLBACK(size_allocate_callback), self);
-  g_signal_connect(G_OBJECT(g->preview), "draw", G_CALLBACK(dt_iop_zonesystem_preview_draw), self);
+  g_signal_connect(g->preview, "size-allocate", G_CALLBACK(size_allocate_callback), self);
+  g_signal_connect(g->preview, "draw", G_CALLBACK(dt_iop_zonesystem_preview_draw), self);
   gtk_widget_add_events(GTK_WIDGET(g->preview), GDK_POINTER_MOTION_MASK
                                                 | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK
                                                 | GDK_LEAVE_NOTIFY_MASK);
@@ -441,16 +441,16 @@ void gui_init(dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->zones, _("lightness zones\nuse mouse scrollwheel to change the number of zones\n"
                                           "left-click on a border to create a marker\n"
                                           "right-click on a marker to delete it"));
-  g_signal_connect(G_OBJECT(g->zones), "draw", G_CALLBACK(dt_iop_zonesystem_bar_draw), self);
-  g_signal_connect(G_OBJECT(g->zones), "motion-notify-event", G_CALLBACK(dt_iop_zonesystem_bar_motion_notify),
+  g_signal_connect(g->zones, "draw", G_CALLBACK(dt_iop_zonesystem_bar_draw), self);
+  g_signal_connect(g->zones, "motion-notify-event", G_CALLBACK(dt_iop_zonesystem_bar_motion_notify),
                    self);
-  g_signal_connect(G_OBJECT(g->zones), "leave-notify-event", G_CALLBACK(dt_iop_zonesystem_bar_leave_notify),
+  g_signal_connect(g->zones, "leave-notify-event", G_CALLBACK(dt_iop_zonesystem_bar_leave_notify),
                    self);
-  g_signal_connect(G_OBJECT(g->zones), "button-press-event", G_CALLBACK(dt_iop_zonesystem_bar_button_press),
+  g_signal_connect(g->zones, "button-press-event", G_CALLBACK(dt_iop_zonesystem_bar_button_press),
                    self);
-  g_signal_connect(G_OBJECT(g->zones), "button-release-event",
+  g_signal_connect(g->zones, "button-release-event",
                    G_CALLBACK(dt_iop_zonesystem_bar_button_release), self);
-  g_signal_connect(G_OBJECT(g->zones), "scroll-event", G_CALLBACK(dt_iop_zonesystem_bar_scrolled), self);
+  g_signal_connect(g->zones, "scroll-event", G_CALLBACK(dt_iop_zonesystem_bar_scrolled), self);
   gtk_widget_add_events(GTK_WIDGET(g->zones), GDK_POINTER_MOTION_MASK
                                               | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK
                                               | GDK_LEAVE_NOTIFY_MASK | darktable.gui->scroll_mask);

--- a/src/libs/backgroundjobs.c
+++ b/src/libs/backgroundjobs.c
@@ -239,7 +239,7 @@ static gboolean _cancellable_gui_thread(gpointer user_data)
 
   GtkBox *hbox = GTK_BOX(params->instance->hbox);
   GtkWidget *button = dtgtk_button_new(dtgtk_cairo_paint_cancel, 0, NULL);
-  g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(_lib_backgroundjobs_cancel_callback_new), params->progress);
+  g_signal_connect(button, "clicked", G_CALLBACK(_lib_backgroundjobs_cancel_callback_new), params->progress);
   gtk_box_pack_start(hbox, GTK_WIDGET(button), FALSE, FALSE, 0);
   gtk_widget_show_all(button);
 

--- a/src/libs/camera.c
+++ b/src/libs/camera.c
@@ -144,7 +144,7 @@ static dt_lib_camera_property_t *_lib_property_add_new(dt_lib_camera_t *lib,
       lib->gui.properties = g_list_append(lib->gui.properties, prop);
 
       // Does dead lock!!!
-      g_signal_connect(G_OBJECT(prop->values), "value-changed", G_CALLBACK(property_changed_callback),
+      g_signal_connect(prop->values, "value-changed", G_CALLBACK(property_changed_callback),
                        (gpointer)prop);
       return prop;
     }
@@ -263,7 +263,7 @@ static void _lib_property_add_to_gui(dt_lib_camera_property_t *prop, dt_lib_came
   gtk_box_pack_start(GTK_BOX(hbox), GTK_WIDGET(prop->osd), FALSE, FALSE, 0);
   gtk_grid_insert_row(lib->gui.main_grid, lib->gui.prop_end); // make space for the new row
   gtk_grid_attach(lib->gui.main_grid, GTK_WIDGET(hbox), 0, lib->gui.prop_end, 2, 1);
-  g_signal_connect(G_OBJECT(prop->osd), "clicked", G_CALLBACK(_osd_button_clicked), prop);
+  g_signal_connect(prop->osd, "clicked", G_CALLBACK(_osd_button_clicked), prop);
   gtk_widget_show_all(GTK_WIDGET(hbox));
   lib->gui.rows++;
   lib->gui.prop_end++;
@@ -494,9 +494,9 @@ void gui_init(dt_lib_module_t *self)
                _("the amount of steps per bracket, steps is camera configurable and usually 3 steps per "
                  "stop\nwith other words, 3 steps is 1EV exposure step between brackets"));
 
-  g_signal_connect(G_OBJECT(lib->gui.toggle_timer), "clicked", G_CALLBACK(_toggle_capture_mode_clicked), lib);
-  g_signal_connect(G_OBJECT(lib->gui.toggle_sequence), "clicked", G_CALLBACK(_toggle_capture_mode_clicked), lib);
-  g_signal_connect(G_OBJECT(lib->gui.toggle_bracket), "clicked", G_CALLBACK(_toggle_capture_mode_clicked), lib);
+  g_signal_connect(lib->gui.toggle_timer, "clicked", G_CALLBACK(_toggle_capture_mode_clicked), lib);
+  g_signal_connect(lib->gui.toggle_sequence, "clicked", G_CALLBACK(_toggle_capture_mode_clicked), lib);
+  g_signal_connect(lib->gui.toggle_bracket, "clicked", G_CALLBACK(_toggle_capture_mode_clicked), lib);
 
   gtk_widget_set_sensitive(GTK_WIDGET(lib->gui.timer), FALSE);
   gtk_widget_set_sensitive(GTK_WIDGET(lib->gui.count), FALSE);
@@ -527,7 +527,7 @@ void gui_init(dt_lib_module_t *self)
   label = gtk_label_new(_("property"));
   gtk_widget_set_halign(label, GTK_ALIGN_START);
   GtkWidget *widget = gtk_button_new_with_label("O");
-  g_signal_connect(G_OBJECT(widget), "clicked", G_CALLBACK(_show_property_popupmenu_clicked), lib);
+  g_signal_connect(widget, "clicked", G_CALLBACK(_show_property_popupmenu_clicked), lib);
   lib->gui.pname = dt_ui_entry_new(0);
   gtk_box_pack_start(hbox, GTK_WIDGET(lib->gui.pname), TRUE, TRUE, 0);
   gtk_box_pack_start(hbox, GTK_WIDGET(widget), FALSE, FALSE, 0);
@@ -536,7 +536,7 @@ void gui_init(dt_lib_module_t *self)
 
 
   widget = gtk_button_new_with_label(_("add user property"));
-  g_signal_connect(G_OBJECT(widget), "clicked", G_CALLBACK(_add_property_button_clicked), lib);
+  g_signal_connect(widget, "clicked", G_CALLBACK(_add_property_button_clicked), lib);
   gtk_widget_show(widget);
   gtk_grid_attach(GTK_GRID(self->widget), GTK_WIDGET(widget), 0, lib->gui.rows++, 2, 1);
 }

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -136,7 +136,7 @@ static void _lib_collect_gui_update(dt_lib_module_t *self);
 
 static void _lib_folders_update_collection(const gchar *filmroll);
 
-static void entry_changed(GtkEntry *entry, dt_lib_collect_rule_t *dr);
+static void entry_changed(GtkWidget *entry, dt_lib_collect_rule_t *dr);
 
 static void collection_updated(gpointer instance,
                                dt_collection_change_t query_change,
@@ -406,9 +406,8 @@ uint32_t container(dt_lib_module_t *self)
 }
 
 static void view_popup_menu_onSearchFilmroll(GtkWidget *menuitem,
-                                             gpointer userdata)
+                                             GtkTreeView *treeview)
 {
-  GtkTreeView *treeview = GTK_TREE_VIEW(userdata);
   GtkWidget *win = dt_ui_main_window(darktable.gui->ui);
 
   GtkTreeSelection *selection;
@@ -588,13 +587,13 @@ static void view_popup_menu(GtkWidget *treeview,
 
   menuitem = gtk_menu_item_new_with_label(_("update path to files..."));
   g_signal_connect(menuitem, "activate",
-                   (GCallback)view_popup_menu_onSearchFilmroll, treeview);
+                   G_CALLBACK(view_popup_menu_onSearchFilmroll), treeview);
   gtk_menu_shell_append(GTK_MENU_SHELL(menu), menuitem);
 
   menuitem = gtk_menu_item_new_with_label(_("remove..."));
   gtk_menu_shell_append(GTK_MENU_SHELL(menu), menuitem);
   g_signal_connect(menuitem, "activate",
-                   (GCallback)view_popup_menu_onRemove, treeview);
+                   G_CALLBACK(view_popup_menu_onRemove), treeview);
 
   gtk_widget_show_all(GTK_WIDGET(menu));
 
@@ -2900,7 +2899,7 @@ static void entry_activated(GtkWidget *entry,
   dt_control_queue_redraw_center();
 }
 
-static void entry_changed(GtkEntry *entry,
+static void entry_changed(GtkWidget *entry,
                           dt_lib_collect_rule_t *dr)
 {
   dr->typing = TRUE;
@@ -3247,7 +3246,7 @@ static gboolean popup_button_callback(GtkWidget *widget,
 
   mi = gtk_menu_item_new_with_label(_("clear this rule"));
   gtk_menu_shell_append(GTK_MENU_SHELL(menu), mi);
-  g_signal_connect(G_OBJECT(mi), "activate", G_CALLBACK(menuitem_clear), d);
+  g_signal_connect(mi, "activate", G_CALLBACK(menuitem_clear), d);
 
   if(d->num == active - 1)
   {
@@ -3255,21 +3254,21 @@ static gboolean popup_button_callback(GtkWidget *widget,
     g_object_set_data(G_OBJECT(mi), "menuitem_mode",
                       GINT_TO_POINTER(DT_LIB_COLLECT_MODE_AND));
     gtk_menu_shell_append(GTK_MENU_SHELL(menu), mi);
-    g_signal_connect(G_OBJECT(mi), "activate",
+    g_signal_connect(mi, "activate",
                      G_CALLBACK(menuitem_mode), d);
 
     mi = gtk_menu_item_new_with_label(_("add more images"));
     g_object_set_data(G_OBJECT(mi), "menuitem_mode",
                       GINT_TO_POINTER(DT_LIB_COLLECT_MODE_OR));
     gtk_menu_shell_append(GTK_MENU_SHELL(menu), mi);
-    g_signal_connect(G_OBJECT(mi), "activate",
+    g_signal_connect(mi, "activate",
                      G_CALLBACK(menuitem_mode), d);
 
     mi = gtk_menu_item_new_with_label(_("exclude images"));
     g_object_set_data(G_OBJECT(mi), "menuitem_mode",
                       GINT_TO_POINTER(DT_LIB_COLLECT_MODE_AND_NOT));
     gtk_menu_shell_append(GTK_MENU_SHELL(menu), mi);
-    g_signal_connect(G_OBJECT(mi), "activate",
+    g_signal_connect(mi, "activate",
                      G_CALLBACK(menuitem_mode), d);
   }
   else if(d->num < active - 1)
@@ -3278,21 +3277,21 @@ static gboolean popup_button_callback(GtkWidget *widget,
     g_object_set_data(G_OBJECT(mi), "menuitem_mode",
                       GINT_TO_POINTER(DT_LIB_COLLECT_MODE_AND));
     gtk_menu_shell_append(GTK_MENU_SHELL(menu), mi);
-    g_signal_connect(G_OBJECT(mi), "activate",
+    g_signal_connect(mi, "activate",
                      G_CALLBACK(menuitem_mode_change), d);
 
     mi = gtk_menu_item_new_with_label(_("change to: or"));
     g_object_set_data(G_OBJECT(mi), "menuitem_mode",
                       GINT_TO_POINTER(DT_LIB_COLLECT_MODE_OR));
     gtk_menu_shell_append(GTK_MENU_SHELL(menu), mi);
-    g_signal_connect(G_OBJECT(mi), "activate",
+    g_signal_connect(mi, "activate",
                      G_CALLBACK(menuitem_mode_change), d);
 
     mi = gtk_menu_item_new_with_label(_("change to: except"));
     g_object_set_data(G_OBJECT(mi), "menuitem_mode",
                       GINT_TO_POINTER(DT_LIB_COLLECT_MODE_AND_NOT));
     gtk_menu_shell_append(GTK_MENU_SHELL(menu), mi);
-    g_signal_connect(G_OBJECT(mi), "activate",
+    g_signal_connect(mi, "activate",
                      G_CALLBACK(menuitem_mode_change), d);
   }
 
@@ -3401,7 +3400,7 @@ void set_preferences(void *menu,
                      dt_lib_module_t *self)
 {
   GtkWidget *mi = gtk_menu_item_new_with_label(_("preferences..."));
-  g_signal_connect(G_OBJECT(mi), "activate", G_CALLBACK(_menuitem_preferences), self);
+  g_signal_connect(mi, "activate", G_CALLBACK(_menuitem_preferences), self);
   gtk_menu_shell_append(GTK_MENU_SHELL(menu), mi);
 }
 
@@ -3590,7 +3589,7 @@ static void _history_show(GtkWidget *widget,
       GtkWidget *child = gtk_bin_get_child(GTK_BIN(smt));
       gtk_label_set_use_markup(GTK_LABEL(child), TRUE);
       g_object_set_data(G_OBJECT(smt), "history", GINT_TO_POINTER(i));
-      g_signal_connect(G_OBJECT(smt), "activate", G_CALLBACK(_history_apply), self);
+      g_signal_connect(smt, "activate", G_CALLBACK(_history_apply), self);
       gtk_menu_shell_append(pop, smt);
     }
     else
@@ -3643,7 +3642,7 @@ GtkWidget *gui_tool_box(dt_lib_module_t *self)
   gtk_widget_set_tooltip_text(sortb, _("toggle collection sort order ascending/descending"));
   dt_gui_add_class(sortb, "dt_ignore_fg_state");
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(sortb), sort_descend);
-  g_signal_connect(G_OBJECT(sortb),
+  g_signal_connect(DTGTK_TOGGLEBUTTON(sortb),
                    "toggled",
                    G_CALLBACK(_sort_reverse_changed), self);
   return sortb;
@@ -3674,21 +3673,21 @@ void gui_init(dt_lib_module_t *self)
     dt_bauhaus_combobox_mute_scrolling(w);
     if(_combo_get_active_collection(w) == DT_COLLECTION_PROP_MODULE)
       has_iop_name_rule = TRUE;
-    g_signal_connect(G_OBJECT(w), "value-changed",
+    g_signal_connect(w, "value-changed",
                      G_CALLBACK(combo_changed), d->rule + i);
 
     d->rule[i].text = w = dt_ui_entry_new(10);
     gtk_widget_add_events(w, GDK_FOCUS_CHANGE_MASK | GDK_KEY_PRESS_MASK);
-    g_signal_connect(G_OBJECT(w), "focus-in-event",
+    g_signal_connect(w, "focus-in-event",
                      G_CALLBACK(entry_focus_in_callback), d->rule + i);
-    g_signal_connect(G_OBJECT(w), "changed", G_CALLBACK(entry_changed), d->rule + i);
-    g_signal_connect(G_OBJECT(w), "activate", G_CALLBACK(entry_activated), d->rule + i);
+    g_signal_connect(w, "changed", G_CALLBACK(entry_changed), d->rule + i);
+    g_signal_connect(w, "activate", G_CALLBACK(entry_activated), d->rule + i);
     gtk_entry_set_width_chars(GTK_ENTRY(w), 5);
 
     d->rule[i].button = w = dtgtk_button_new(dtgtk_cairo_paint_presets, 0, NULL);
     dt_gui_add_class(GTK_WIDGET(w), "dt_big_btn_canvas");
     gtk_widget_set_events(w, GDK_BUTTON_PRESS_MASK);
-    g_signal_connect(G_OBJECT(w), "button-press-event",
+    g_signal_connect(w, "button-press-event",
                      G_CALLBACK(popup_button_callback), d->rule + i);
 
     d->rule[i].hbox = dt_gui_hbox(d->rule[i].combo, dt_gui_expand(d->rule[i].text), d->rule[i].button);
@@ -3700,9 +3699,9 @@ void gui_init(dt_lib_module_t *self)
   d->view_rule = -1;
   d->view = view;
   gtk_tree_view_set_headers_visible(view, FALSE);
-  g_signal_connect(G_OBJECT(view), "button-press-event",
+  g_signal_connect(view, "button-press-event",
                    G_CALLBACK(view_onButtonPressed), d);
-  g_signal_connect(G_OBJECT(view), "popup-menu", G_CALLBACK(view_onPopupMenu), d);
+  g_signal_connect(view, "popup-menu", G_CALLBACK(view_onPopupMenu), d);
 
   GtkTreeViewColumn *col = gtk_tree_view_column_new();
   gtk_tree_view_append_column(view, col);
@@ -3765,13 +3764,13 @@ void gui_init(dt_lib_module_t *self)
 
 #ifdef _WIN32
   d->vmonitor = g_volume_monitor_get();
-  g_signal_connect(G_OBJECT(d->vmonitor), "mount-changed",
+  g_signal_connect(d->vmonitor, "mount-changed",
                    G_CALLBACK(_mount_changed), self);
-  g_signal_connect(G_OBJECT(d->vmonitor), "mount-added",
+  g_signal_connect(d->vmonitor, "mount-added",
                    G_CALLBACK(_mount_changed), self);
 #else
   d->vmonitor = g_unix_mount_monitor_get();
-  g_signal_connect(G_OBJECT(d->vmonitor), "mounts-changed",
+  g_signal_connect(d->vmonitor, "mounts-changed",
                    G_CALLBACK(_mount_changed), self);
 #endif
 

--- a/src/libs/colorpicker.c
+++ b/src/libs/colorpicker.c
@@ -405,7 +405,7 @@ static gboolean _sample_tooltip_callback(GtkWidget *widget,
     view = gtk_text_view_new();
     dt_gui_add_class(view, "dt_transparent_background");
     dt_gui_add_class(view, "dt_monospace");
-    g_signal_connect(G_OBJECT(view), "destroy",
+    g_signal_connect(view, "destroy",
                      G_CALLBACK(gtk_widget_destroyed), &view);
   }
 
@@ -617,9 +617,9 @@ static void _add_sample(GtkButton *widget,
   sample->container = gtk_event_box_new();
   gtk_widget_add_events(sample->container,
                         GDK_ENTER_NOTIFY_MASK | GDK_LEAVE_NOTIFY_MASK);
-  g_signal_connect(G_OBJECT(sample->container), "enter-notify-event",
+  g_signal_connect(sample->container, "enter-notify-event",
                    G_CALLBACK(_sample_enter_callback), sample);
-  g_signal_connect(G_OBJECT(sample->container), "leave-notify-event",
+  g_signal_connect(sample->container, "leave-notify-event",
                    G_CALLBACK(_sample_leave_callback), sample);
 
   sample->color_patch = gtk_drawing_area_new();
@@ -629,9 +629,9 @@ static void _add_sample(GtkButton *widget,
      _("hover to highlight sample on canvas,\n"
        "click to lock sample,\n"
        "right-click to load sample area into active color picker"));
-  g_signal_connect(G_OBJECT(sample->color_patch), "button-press-event",
+  g_signal_connect(sample->color_patch, "button-press-event",
                    G_CALLBACK(_live_sample_button), sample);
-  g_signal_connect(G_OBJECT(sample->color_patch), "draw",
+  g_signal_connect(sample->color_patch, "draw",
                    G_CALLBACK(_sample_draw_callback), sample);
 
   GtkWidget *color_patch_wrapper = dt_gui_hbox(dt_gui_expand(sample->color_patch));
@@ -642,13 +642,13 @@ static void _add_sample(GtkButton *widget,
   gtk_label_set_ellipsize(GTK_LABEL(sample->output_label), PANGO_ELLIPSIZE_START);
   gtk_label_set_selectable(GTK_LABEL(sample->output_label), TRUE);
   gtk_widget_set_has_tooltip(sample->output_label, TRUE);
-  g_signal_connect(G_OBJECT(sample->output_label), "query-tooltip",
+  g_signal_connect(sample->output_label, "query-tooltip",
                    G_CALLBACK(_sample_tooltip_callback), sample);
-  g_signal_connect(G_OBJECT(sample->output_label), "size-allocate",
+  g_signal_connect(sample->output_label, "size-allocate",
                    G_CALLBACK(_label_size_allocate_callback), sample);
 
   GtkWidget *delete_button = dtgtk_togglebutton_new(dtgtk_cairo_paint_remove, 0, NULL);
-  g_signal_connect(G_OBJECT(delete_button), "clicked",
+  g_signal_connect(delete_button, "clicked",
                    G_CALLBACK(_remove_sample_cb), sample);
 
   gtk_container_add(GTK_CONTAINER(sample->container),
@@ -734,13 +734,13 @@ void gui_init(dt_lib_module_t *self)
                         GDK_BUTTON_PRESS_MASK
                         | GDK_ENTER_NOTIFY_MASK
                         | GDK_LEAVE_NOTIFY_MASK);
-  g_signal_connect(G_OBJECT(color_patch), "draw",
+  g_signal_connect(color_patch, "draw",
                    G_CALLBACK(_sample_draw_callback), &data->primary_sample);
-  g_signal_connect(G_OBJECT(color_patch), "button-press-event",
+  g_signal_connect(color_patch, "button-press-event",
                    G_CALLBACK(_large_patch_toggle), data);
-  g_signal_connect(G_OBJECT(color_patch), "enter-notify-event",
+  g_signal_connect(color_patch, "enter-notify-event",
                    G_CALLBACK(_sample_enter_callback), &data->primary_sample);
-  g_signal_connect(G_OBJECT(color_patch), "leave-notify-event",
+  g_signal_connect(color_patch, "leave-notify-event",
                    G_CALLBACK(_sample_leave_callback), &data->primary_sample);
   GtkWidget *color_patch_wrapper = dt_gui_hbox(dt_gui_expand(color_patch));
   gtk_widget_set_name(GTK_WIDGET(color_patch_wrapper), "color-picker-area");
@@ -774,7 +774,7 @@ void gui_init(dt_lib_module_t *self)
     (data->picker_button,
      _("turn on color picker\nctrl+click or right-click to select an area"));
   gtk_widget_set_name(GTK_WIDGET(data->picker_button), "color-picker-button");
-  g_signal_connect(G_OBJECT(data->picker_button), "toggled",
+  g_signal_connect(data->picker_button, "toggled",
                    G_CALLBACK(_picker_button_toggled), data);
   dt_action_define(DT_ACTION(self), NULL, N_("pick color"),
                    data->picker_button, &dt_action_def_toggle);
@@ -782,17 +782,17 @@ void gui_init(dt_lib_module_t *self)
   // The small sample, label and add button
   GtkWidget *sample_row_events = gtk_event_box_new();
   gtk_widget_add_events(sample_row_events, GDK_ENTER_NOTIFY_MASK | GDK_LEAVE_NOTIFY_MASK);
-  g_signal_connect(G_OBJECT(sample_row_events), "enter-notify-event",
+  g_signal_connect(sample_row_events, "enter-notify-event",
                    G_CALLBACK(_sample_enter_callback), &data->primary_sample);
-  g_signal_connect(G_OBJECT(sample_row_events), "leave-notify-event",
+  g_signal_connect(sample_row_events, "leave-notify-event",
                    G_CALLBACK(_sample_leave_callback), &data->primary_sample);
 
   data->primary_sample.color_patch = color_patch = gtk_drawing_area_new();
   gtk_widget_set_tooltip_text(color_patch, _("click to (un)hide large color patch"));
   gtk_widget_set_events(color_patch, GDK_BUTTON_PRESS_MASK);
-  g_signal_connect(G_OBJECT(color_patch), "button-press-event",
+  g_signal_connect(color_patch, "button-press-event",
                    G_CALLBACK(_large_patch_toggle), data);
-  g_signal_connect(G_OBJECT(color_patch), "draw",
+  g_signal_connect(color_patch, "draw",
                    G_CALLBACK(_sample_draw_callback), &data->primary_sample);
 
   GtkWidget *sample_patch_wrapper = dt_gui_hbox(dt_gui_expand(color_patch));
@@ -804,14 +804,14 @@ void gui_init(dt_lib_module_t *self)
   gtk_label_set_selectable(GTK_LABEL(label), TRUE);
   dt_gui_add_class(label, "dt_monospace");
   gtk_widget_set_has_tooltip(label, TRUE);
-  g_signal_connect(G_OBJECT(label), "query-tooltip",
+  g_signal_connect(label, "query-tooltip",
                    G_CALLBACK(_sample_tooltip_callback), &data->primary_sample);
-  g_signal_connect(G_OBJECT(label), "size-allocate",
+  g_signal_connect(label, "size-allocate",
                    G_CALLBACK(_label_size_allocate_callback), &data->primary_sample);
 
   data->add_sample_button = dtgtk_button_new(dtgtk_cairo_paint_square_plus, 0, NULL);
   gtk_widget_set_sensitive(data->add_sample_button, FALSE);
-  g_signal_connect(G_OBJECT(data->add_sample_button), "clicked",
+  g_signal_connect(data->add_sample_button, "clicked",
                    G_CALLBACK(_add_sample), self);
   dt_action_define(DT_ACTION(self), NULL, N_("add sample"),
                    data->add_sample_button, &dt_action_def_button);
@@ -832,7 +832,7 @@ void gui_init(dt_lib_module_t *self)
      PANGO_ELLIPSIZE_MIDDLE);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(data->display_samples_check_box),
                                dt_conf_get_bool("ui_last/colorpicker_display_samples"));
-  g_signal_connect(G_OBJECT(data->display_samples_check_box), "toggled",
+  g_signal_connect(data->display_samples_check_box, "toggled",
                    G_CALLBACK(_display_samples_changed), NULL);
 
   GtkWidget *restrict_button =
@@ -845,7 +845,7 @@ void gui_init(dt_lib_module_t *self)
   gboolean restrict_histogram = dt_conf_get_bool("ui_last/colorpicker_restrict_histogram");
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(restrict_button), restrict_histogram);
   darktable.lib->proxy.colorpicker.restrict_histogram = restrict_histogram;
-  g_signal_connect(G_OBJECT(restrict_button), "toggled",
+  g_signal_connect(restrict_button, "toggled",
                    G_CALLBACK(_restrict_histogram_changed), NULL);
 
   // Setting up the GUI

--- a/src/libs/duplicate.c
+++ b/src/libs/duplicate.c
@@ -124,7 +124,7 @@ static void _lib_duplicate_duplicate_clicked_callback(GtkWidget *widget,
   DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_VIEWMANAGER_THUMBTABLE_ACTIVATE, newid);
 }
 
-static void _lib_duplicate_delete(GtkButton *button, dt_lib_module_t *self)
+static void _lib_duplicate_delete(GtkWidget *button, dt_lib_module_t *self)
 {
   dt_lib_duplicate_t *d = self->data;
   const dt_imgid_t imgid = GPOINTER_TO_INT(g_object_get_data(G_OBJECT(button), "imgid"));
@@ -157,9 +157,9 @@ static void _lib_duplicate_delete(GtkButton *button, dt_lib_module_t *self)
                              g_list_prepend(NULL, GINT_TO_POINTER(imgid)));
 }
 
-static void _lib_duplicate_thumb_press_callback(GtkWidget *widget,
-                                                GdkEventButton *event,
-                                                dt_lib_module_t *self)
+static gboolean _lib_duplicate_thumb_press_callback(GtkWidget *widget,
+                                                    GdkEventButton *event,
+                                                    dt_lib_module_t *self)
 {
   dt_lib_duplicate_t *d = self->data;
   dt_thumbnail_t *thumb = (dt_thumbnail_t *)g_object_get_data(G_OBJECT(widget), "thumb");
@@ -178,16 +178,18 @@ static void _lib_duplicate_thumb_press_callback(GtkWidget *widget,
       DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_VIEWMANAGER_THUMBTABLE_ACTIVATE, imgid);
     }
   }
+  return TRUE;
 }
 
-static void _lib_duplicate_thumb_release_callback(GtkWidget *widget,
-                                                  GdkEventButton *event,
-                                                  dt_lib_module_t *self)
+static gboolean _lib_duplicate_thumb_release_callback(GtkWidget *widget,
+                                                      GdkEventButton *event,
+                                                      dt_lib_module_t *self)
 {
   dt_lib_duplicate_t *d = self->data;
 
   d->imgid = NO_IMGID;
   dt_control_queue_redraw_center();
+  return TRUE;
 }
 
 void view_leave(struct dt_lib_module_t *self,
@@ -304,9 +306,9 @@ static void _lib_duplicate_init_callback(gpointer instance, dt_lib_module_t *sel
 
     if(imgid != dev->image_storage.id)
     {
-      g_signal_connect(G_OBJECT(thumb->w_main), "button-press-event",
+      g_signal_connect(thumb->w_main, "button-press-event",
                        G_CALLBACK(_lib_duplicate_thumb_press_callback), self);
-      g_signal_connect(G_OBJECT(thumb->w_main), "button-release-event",
+      g_signal_connect(thumb->w_main, "button-release-event",
                        G_CALLBACK(_lib_duplicate_thumb_release_callback), self);
     }
 
@@ -319,7 +321,7 @@ static void _lib_duplicate_init_callback(gpointer instance, dt_lib_module_t *sel
     gtk_widget_set_hexpand(tb, TRUE);
     g_object_set_data (G_OBJECT(tb), "imgid", GINT_TO_POINTER(imgid));
     gtk_widget_add_events(tb, GDK_FOCUS_CHANGE_MASK);
-    g_signal_connect(G_OBJECT(tb), "focus-out-event",
+    g_signal_connect(tb, "focus-out-event",
                      G_CALLBACK(_lib_duplicate_caption_out_callback), self);
     GtkWidget *lb = gtk_label_new (g_strdup(chl));
     gtk_widget_set_hexpand(lb, TRUE);
@@ -327,7 +329,7 @@ static void _lib_duplicate_init_callback(gpointer instance, dt_lib_module_t *sel
     gtk_widget_set_tooltip_text(bt, _("delete this duplicate"));
     //    gtk_widget_set_halign(bt, GTK_ALIGN_END);
     g_object_set_data(G_OBJECT(bt), "imgid", GINT_TO_POINTER(imgid));
-    g_signal_connect(G_OBJECT(bt), "clicked", G_CALLBACK(_lib_duplicate_delete), self);
+    g_signal_connect(bt, "clicked", G_CALLBACK(_lib_duplicate_delete), self);
 
     gtk_grid_attach(GTK_GRID(hb), thumb->w_main, 0, 0, 1, 2);
     gtk_grid_attach(GTK_GRID(hb), bt, 2, 0, 1, 1);

--- a/src/libs/export_metadata.c
+++ b/src/libs/export_metadata.c
@@ -195,7 +195,7 @@ char *dt_lib_export_metadata_configuration_dialog(char *metadata_presets, const 
 
   GtkWidget *dttag = gtk_check_button_new_with_label(_("tags"));
   gtk_widget_set_tooltip_text(dttag, _("export tags (to Xmp.dc.Subject)"));
-  g_signal_connect(G_OBJECT(dttag), "clicked", G_CALLBACK(_tags_toggled), (gpointer)d);
+  g_signal_connect(dttag, "clicked", G_CALLBACK(_tags_toggled), (gpointer)d);
 
   d->private = gtk_check_button_new_with_label(_("private tags"));
   gtk_widget_set_tooltip_text(d->private, _("export private tags"));
@@ -220,7 +220,7 @@ char *dt_lib_export_metadata_configuration_dialog(char *metadata_presets, const 
   gtk_tree_view_append_column(view, col);
   renderer = gtk_cell_renderer_text_new();
   g_object_set(renderer, "editable", TRUE, NULL);
-  g_signal_connect(G_OBJECT(renderer), "edited", G_CALLBACK(_formula_edited), (gpointer)d);
+  g_signal_connect(renderer, "edited", G_CALLBACK(_formula_edited), (gpointer)d);
   dt_gui_commit_on_focus_loss(renderer, &active_editable);
   col = gtk_tree_view_column_new_with_attributes(_("formula"), renderer, "text", 2, NULL);
   gtk_tree_view_append_column(view, col);
@@ -232,7 +232,7 @@ char *dt_lib_export_metadata_configuration_dialog(char *metadata_presets, const 
                 "otherwise the corresponding metadata is calculated and added to exported file\n"
                 "click on formula cell to edit\n"
                 "type '$(' to activate the completion and see the list of variables"));
-  g_signal_connect(G_OBJECT(view), "key_press_event", G_CALLBACK(_key_press_on_list), (gpointer)d);
+  g_signal_connect(view, "key-press-event", G_CALLBACK(_key_press_on_list), (gpointer)d);
 
   GtkListStore *liststore = gtk_list_store_new(3, G_TYPE_STRING, G_TYPE_STRING, G_TYPE_STRING);
   d->liststore = liststore;
@@ -278,11 +278,11 @@ char *dt_lib_export_metadata_configuration_dialog(char *metadata_presets, const 
 
   GtkWidget *plus = dtgtk_button_new(dtgtk_cairo_paint_plus_simple, 0, NULL);
   gtk_widget_set_tooltip_text(plus, _("add an output metadata tag"));
-  g_signal_connect(G_OBJECT(plus), "clicked", G_CALLBACK(_add_tag_button_clicked), (gpointer)d);
+  g_signal_connect(plus, "clicked", G_CALLBACK(_add_tag_button_clicked), (gpointer)d);
 
   GtkWidget *minus = dtgtk_button_new(dtgtk_cairo_paint_minus_simple, 0, NULL);
   gtk_widget_set_tooltip_text(minus, _("delete metadata tag"));
-  g_signal_connect(G_OBJECT(minus), "clicked", G_CALLBACK(_delete_tag_button_clicked), (gpointer)d);
+  g_signal_connect(minus, "clicked", G_CALLBACK(_delete_tag_button_clicked), (gpointer)d);
 
 #ifdef GDK_WINDOWING_QUARTZ
   dt_osx_disallow_fullscreen(dialog);

--- a/src/libs/filtering.c
+++ b/src/libs/filtering.c
@@ -736,7 +736,7 @@ static void _range_widget_add_to_rule(dt_lib_filtering_rule_t *rule, _widgets_ra
 
   gtk_box_pack_start(GTK_BOX((top) ? rule->w_special_box_top : rule->w_special_box), special->range_select, TRUE,
                      TRUE, 0);
-  g_signal_connect(G_OBJECT(special->range_select), "value-changed", G_CALLBACK(_range_changed), special);
+  g_signal_connect(special->range_select, "value-changed", G_CALLBACK(_range_changed), special);
   if(top)
   {
     dt_gui_add_class(gtk_bin_get_child(GTK_BIN(special->range_select)), "dt_quick_filter");
@@ -867,7 +867,7 @@ static void _popup_add_item(GtkMenuShell *pop, const gchar *name, const int id, 
     g_object_set_data(G_OBJECT(smt), "collect_id", GINT_TO_POINTER(id));
     g_object_set_data(G_OBJECT(smt), "topbar", GINT_TO_POINTER(0));
     if(data) g_object_set_data(G_OBJECT(smt), "collect_data", data);
-    g_signal_connect(G_OBJECT(smt), "activate", callback, self);
+    g_signal_connect(smt, "activate", G_CALLBACK(callback), self);
   }
   gtk_menu_shell_append(pop, smt);
 }
@@ -1081,7 +1081,7 @@ static void _topbar_update(dt_lib_module_t *self)
         GtkWidget *evtb = gtk_event_box_new();
         GtkWidget *label = gtk_label_new(C_("quickfilter", "filter"));
         gtk_container_add(GTK_CONTAINER(evtb), label);
-        g_signal_connect(G_OBJECT(evtb), "button-press-event", G_CALLBACK(_topbar_label_press), self);
+        g_signal_connect(evtb, "button-press-event", G_CALLBACK(_topbar_label_press), self);
         gtk_box_pack_start(GTK_BOX(fbox), evtb, TRUE, TRUE, 0);
         gtk_widget_show_all(evtb);
       }
@@ -1253,7 +1253,7 @@ static gboolean _widget_init(dt_lib_filtering_rule_t *rule, const dt_collection_
     dt_bauhaus_combobox_set_selected_text_align(rule->w_operator, DT_BAUHAUS_COMBOBOX_ALIGN_LEFT);
     gtk_widget_set_tooltip_text(rule->w_operator, _("define how this rule should interact with the previous one"));
     gtk_box_pack_start(GTK_BOX(hbox), rule->w_operator, FALSE, FALSE, 0);
-    g_signal_connect(G_OBJECT(rule->w_operator), "value-changed", G_CALLBACK(_event_rule_changed), rule);
+    g_signal_connect(rule->w_operator, "value-changed", G_CALLBACK(_event_rule_changed), rule);
   }
 
   dt_bauhaus_combobox_set(rule->w_operator, mode);
@@ -1268,7 +1268,7 @@ static gboolean _widget_init(dt_lib_filtering_rule_t *rule, const dt_collection_
     _rule_populate_prop_combo(rule);
     g_object_set_data(G_OBJECT(rule->w_prop), "rule", rule);
     dt_bauhaus_combobox_set_from_value(rule->w_prop, prop);
-    g_signal_connect(G_OBJECT(rule->w_prop), "value-changed", G_CALLBACK(_event_rule_change_type), self);
+    g_signal_connect(rule->w_prop, "value-changed", G_CALLBACK(_event_rule_change_type), self);
     gtk_box_pack_start(GTK_BOX(hbox), rule->w_prop, TRUE, TRUE, 0);
   }
   else if(newprop)
@@ -1286,14 +1286,14 @@ static gboolean _widget_init(dt_lib_filtering_rule_t *rule, const dt_collection_
     rule->w_off = dtgtk_togglebutton_new(dtgtk_cairo_paint_switch, 0, NULL);
     dt_gui_add_class(rule->w_off, "dt_transparent_background");
     g_object_set_data(G_OBJECT(rule->w_off), "rule", rule);
-    g_signal_connect(G_OBJECT(rule->w_off), "toggled", G_CALLBACK(_event_rule_disable), rule);
+    g_signal_connect(rule->w_off, "toggled", G_CALLBACK(_event_rule_disable), rule);
     gtk_box_pack_end(GTK_BOX(rule->w_btn_box), rule->w_off, FALSE, FALSE, 0);
 
     // pin button
     rule->w_pin = dtgtk_togglebutton_new(dtgtk_cairo_paint_pin, 0, NULL);
     dt_gui_add_class(rule->w_pin, "dt_transparent_background");
     g_object_set_data(G_OBJECT(rule->w_pin), "rule", rule);
-    g_signal_connect(G_OBJECT(rule->w_pin), "toggled", G_CALLBACK(_rule_topbar_toggle), self);
+    g_signal_connect(rule->w_pin, "toggled", G_CALLBACK(_rule_topbar_toggle), self);
     dt_gui_add_class(rule->w_pin, "dt_dimmed");
     gtk_box_pack_end(GTK_BOX(rule->w_btn_box), rule->w_pin, FALSE, FALSE, 0);
     gtk_widget_set_no_show_all(rule->w_pin, TRUE);
@@ -1301,7 +1301,7 @@ static gboolean _widget_init(dt_lib_filtering_rule_t *rule, const dt_collection_
     // remove button
     rule->w_close = dtgtk_button_new(dtgtk_cairo_paint_remove, 0, NULL);
     g_object_set_data(G_OBJECT(rule->w_close), "rule", rule);
-    g_signal_connect(G_OBJECT(rule->w_close), "button-press-event", G_CALLBACK(_event_rule_close), self);
+    g_signal_connect(rule->w_close, "button-press-event", G_CALLBACK(_event_rule_close), self);
     gtk_box_pack_end(GTK_BOX(rule->w_btn_box), rule->w_close, FALSE, FALSE, 0);
   }
 
@@ -1569,7 +1569,7 @@ static void _event_history_show(GtkWidget *widget, dt_lib_module_t *self)
       GtkWidget *child = gtk_bin_get_child(GTK_BIN(smt));
       gtk_label_set_use_markup(GTK_LABEL(child), TRUE);
       g_object_set_data(G_OBJECT(smt), "history", GINT_TO_POINTER(i));
-      g_signal_connect(G_OBJECT(smt), "activate", G_CALLBACK(_event_history_apply), self);
+      g_signal_connect(smt, "activate", G_CALLBACK(_event_history_apply), self);
       gtk_menu_shell_append(pop, smt);
       g_free(line);
     }
@@ -1687,7 +1687,7 @@ static GtkWidget *_topbar_menu_new_rule(dt_lib_filtering_rule_t *rule, dt_lib_mo
   gtk_box_pack_start(GTK_BOX(hb), lb, TRUE, TRUE, 0);
   GtkWidget *btr = dtgtk_button_new(dtgtk_cairo_paint_remove, 0, NULL);
   g_object_set_data(G_OBJECT(btr), "rule", rule);
-  g_signal_connect(G_OBJECT(btr), "button-press-event", G_CALLBACK(_topbar_rule_remove), self);
+  g_signal_connect(btr, "button-press-event", G_CALLBACK(_topbar_rule_remove), self);
   gtk_box_pack_start(GTK_BOX(hb), btr, FALSE, TRUE, 0);
   return hb;
 }
@@ -1753,7 +1753,7 @@ static void _topbar_show_pref_menu(dt_lib_module_t *self, GtkWidget *bt)
   dt_bauhaus_combobox_mute_scrolling(nr);
   dt_bauhaus_widget_set_label(nr, NULL, _("new filter"));
   _topbar_populate_rules_combo(nr, d);
-  g_signal_connect(G_OBJECT(nr), "value-changed", G_CALLBACK(_topbar_rule_add), self);
+  g_signal_connect(nr, "value-changed", G_CALLBACK(_topbar_rule_add), self);
   gtk_box_pack_end(GTK_BOX(vbox2), nr, TRUE, TRUE, 0);
 
   gtk_box_pack_start(GTK_BOX(vbox), vbox2, TRUE, TRUE, 0);
@@ -1763,7 +1763,7 @@ static void _topbar_show_pref_menu(dt_lib_module_t *self, GtkWidget *bt)
   gtk_box_pack_start(GTK_BOX(vbox), lb, TRUE, TRUE, 0);
   GtkWidget *btr = gtk_button_new_with_label(_("reset quickfilters"));
   dt_gui_add_class(btr, "dt_transparent_background");
-  g_signal_connect(G_OBJECT(btr), "button-press-event", G_CALLBACK(_topbar_reset_press), self);
+  g_signal_connect(btr, "button-press-event", G_CALLBACK(_topbar_reset_press), self);
   gtk_box_pack_start(GTK_BOX(vbox), btr, TRUE, TRUE, 0);
 
   // show the popover
@@ -1938,7 +1938,7 @@ static gboolean _sort_init(_widgets_sort_t *sort, const dt_collection_sort_t sor
     dt_bauhaus_widget_hide_label(sort->sort);
     dt_bauhaus_combobox_mute_scrolling(sort->sort);
     gtk_widget_set_tooltip_text(sort->sort, _("determine the sort order of shown images"));
-    g_signal_connect(G_OBJECT(sort->sort), "value-changed", G_CALLBACK(_sort_combobox_changed), sort);
+    g_signal_connect(sort->sort, "value-changed", G_CALLBACK(_sort_combobox_changed), sort);
     gtk_box_pack_start(GTK_BOX(sort->box), sort->sort, TRUE, TRUE, 0);
 
     dt_bauhaus_combobox_add_section(sort->sort, _("files"));
@@ -1954,7 +1954,7 @@ static gboolean _sort_init(_widgets_sort_t *sort, const dt_collection_sort_t sor
     sort->direction = dtgtk_togglebutton_new(dtgtk_cairo_paint_sortby, CPF_DIRECTION_UP, NULL);
     gtk_widget_set_halign(sort->direction, GTK_ALIGN_START);
     gtk_box_pack_start(GTK_BOX(sort->box), sort->direction, FALSE, TRUE, 0);
-    g_signal_connect(G_OBJECT(sort->direction), "toggled", G_CALLBACK(_sort_reverse_changed), sort);
+    g_signal_connect(DTGTK_TOGGLEBUTTON(sort->direction), "toggled", G_CALLBACK(_sort_reverse_changed), sort);
     dt_gui_add_class(sort->direction, "dt_ignore_fg_state");
     if(num == 0)
       dt_action_define(DT_ACTION(self), NULL, _("sort direction"), sort->direction, &dt_action_def_toggle);
@@ -1963,7 +1963,7 @@ static gboolean _sort_init(_widgets_sort_t *sort, const dt_collection_sort_t sor
     gtk_widget_set_no_show_all(sort->close, TRUE);
     g_object_set_data(G_OBJECT(sort->close), "sort", sort);
     gtk_widget_set_tooltip_text(sort->close, _("remove this sort order"));
-    g_signal_connect(G_OBJECT(sort->close), "button-press-event", G_CALLBACK(_sort_close), self);
+    g_signal_connect(sort->close, "button-press-event", G_CALLBACK(_sort_close), self);
     gtk_box_pack_start(GTK_BOX(sort->box), sort->close, FALSE, FALSE, 0);
   }
 
@@ -2154,7 +2154,7 @@ static void _sort_history_show(GtkWidget *widget, dt_lib_module_t *self)
       GtkWidget *smt = gtk_menu_item_new_with_label(str);
       gtk_widget_set_tooltip_text(smt, str);
       g_object_set_data(G_OBJECT(smt), "history", GINT_TO_POINTER(i));
-      g_signal_connect(G_OBJECT(smt), "activate", G_CALLBACK(_sort_history_apply), self);
+      g_signal_connect(smt, "activate", G_CALLBACK(_sort_history_apply), self);
       gtk_menu_shell_append(pop, smt);
       g_free(line);
     }

--- a/src/libs/filters/colors.c
+++ b/src/libs/filters/colors.c
@@ -295,8 +295,8 @@ static void _colors_widget_init(dt_lib_filtering_rule_t *rule, const dt_collecti
                                                      "\nclick to toggle the color label selection"
                                                      "\nctrl+click to exclude the color label"
                                                      "\nthe gray button affects all color labels"));
-    g_signal_connect(G_OBJECT(colors->colors[k]), "button-press-event", G_CALLBACK(_colors_clicked), colors);
-    g_signal_connect(G_OBJECT(colors->colors[k]), "enter-notify-event", G_CALLBACK(_colors_enter_notify),
+    g_signal_connect(colors->colors[k], "button-press-event", G_CALLBACK(_colors_clicked), colors);
+    g_signal_connect(colors->colors[k], "enter-notify-event", G_CALLBACK(_colors_enter_notify),
                      GINT_TO_POINTER(k));
     dt_action_define(DT_ACTION(self), N_("rules"), N_("color label"), colors->colors[k], &dt_action_def_colors_rule);
   }
@@ -306,8 +306,8 @@ static void _colors_widget_init(dt_lib_filtering_rule_t *rule, const dt_collecti
                               _("filter by images color label"
                                 "\nintersection: images having all selected color labels"
                                 "\nunion: images with at least one of the selected color labels"));
-  g_signal_connect(G_OBJECT(colors->operator), "clicked", G_CALLBACK(_colors_operator_clicked), colors);
-  g_signal_connect(G_OBJECT(colors->operator), "enter-notify-event", G_CALLBACK(_colors_enter_notify),
+  g_signal_connect(colors->operator, "clicked", G_CALLBACK(_colors_operator_clicked), colors);
+  g_signal_connect(colors->operator, "enter-notify-event", G_CALLBACK(_colors_enter_notify),
                    GINT_TO_POINTER(-1));
   dt_action_t *ac = dt_action_define(DT_ACTION(self), N_("rules"), N_("color label"), colors->operator, &dt_action_def_colors_rule);
 

--- a/src/libs/filters/filename.c
+++ b/src/libs/filters/filename.c
@@ -369,9 +369,9 @@ static void _filename_widget_init(dt_lib_filtering_rule_t *rule, const dt_collec
                                                 "multiple values can be separated by ','\n"
                                                 "\nright-click to get existing filenames"));
   gtk_box_pack_start(GTK_BOX(hb), filename->name, TRUE, TRUE, 0);
-  g_signal_connect(G_OBJECT(filename->name), "activate", G_CALLBACK(_filename_changed), filename);
-  g_signal_connect(G_OBJECT(filename->name), "focus-out-event", G_CALLBACK(_filename_focus_out), filename);
-  g_signal_connect(G_OBJECT(filename->name), "button-press-event", G_CALLBACK(_filename_press), filename);
+  g_signal_connect(filename->name, "activate", G_CALLBACK(_filename_changed), filename);
+  g_signal_connect(filename->name, "focus-out-event", G_CALLBACK(_filename_focus_out), filename);
+  g_signal_connect(filename->name, "button-press-event", G_CALLBACK(_filename_press), filename);
 
   filename->ext = dt_ui_entry_new(top ? 5 : 0);
   gtk_widget_set_can_default(filename->ext, TRUE);
@@ -381,9 +381,9 @@ static void _filename_widget_init(dt_lib_filtering_rule_t *rule, const dt_collec
                                                "handled keywords: 'RAW', 'NOT RAW', 'LDR', 'HDR'\n"
                                                "\nright-click to get existing extensions"));
   gtk_box_pack_start(GTK_BOX(hb), filename->ext, TRUE, TRUE, 0);
-  g_signal_connect(G_OBJECT(filename->ext), "activate", G_CALLBACK(_filename_changed), filename);
-  g_signal_connect(G_OBJECT(filename->ext), "focus-out-event", G_CALLBACK(_filename_focus_out), filename);
-  g_signal_connect(G_OBJECT(filename->ext), "button-press-event", G_CALLBACK(_filename_press), filename);
+  g_signal_connect(filename->ext, "activate", G_CALLBACK(_filename_changed), filename);
+  g_signal_connect(filename->ext, "focus-out-event", G_CALLBACK(_filename_focus_out), filename);
+  g_signal_connect(filename->ext, "button-press-event", G_CALLBACK(_filename_press), filename);
   if(top)
   {
     dt_gui_add_class(hb, "dt_quick_filter");
@@ -392,7 +392,7 @@ static void _filename_widget_init(dt_lib_filtering_rule_t *rule, const dt_collec
   // the popup
   filename->pop = gtk_popover_new(filename->name);
   gtk_widget_set_size_request(filename->pop, 250, 400);
-  g_signal_connect(G_OBJECT(filename->pop), "closed", G_CALLBACK(_filename_popup_closed), filename);
+  g_signal_connect(filename->pop, "closed", G_CALLBACK(_filename_popup_closed), filename);
   hb = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
   gtk_container_add(GTK_CONTAINER(filename->pop), hb);
 
@@ -406,9 +406,9 @@ static void _filename_widget_init(dt_lib_filtering_rule_t *rule, const dt_collec
   gtk_tree_view_set_headers_visible(GTK_TREE_VIEW(filename->name_tree), FALSE);
   GtkTreeSelection *sel = gtk_tree_view_get_selection(GTK_TREE_VIEW(filename->name_tree));
   gtk_tree_selection_set_mode(sel, GTK_SELECTION_MULTIPLE);
-  g_signal_connect(G_OBJECT(filename->name_tree), "row-activated", G_CALLBACK(_filename_tree_row_activated),
+  g_signal_connect(filename->name_tree, "row-activated", G_CALLBACK(_filename_tree_row_activated),
                    filename);
-  g_signal_connect(G_OBJECT(sel), "changed", G_CALLBACK(_filename_tree_selection_change), filename);
+  g_signal_connect(sel, "changed", G_CALLBACK(_filename_tree_selection_change), filename);
 
   GtkTreeViewColumn *col = gtk_tree_view_column_new();
   gtk_tree_view_append_column(GTK_TREE_VIEW(filename->name_tree), col);
@@ -432,9 +432,9 @@ static void _filename_widget_init(dt_lib_filtering_rule_t *rule, const dt_collec
   gtk_tree_view_set_headers_visible(GTK_TREE_VIEW(filename->ext_tree), FALSE);
   sel = gtk_tree_view_get_selection(GTK_TREE_VIEW(filename->ext_tree));
   gtk_tree_selection_set_mode(sel, GTK_SELECTION_MULTIPLE);
-  g_signal_connect(G_OBJECT(filename->name_tree), "row-activated", G_CALLBACK(_filename_tree_row_activated),
+  g_signal_connect(filename->name_tree, "row-activated", G_CALLBACK(_filename_tree_row_activated),
                    filename);
-  g_signal_connect(G_OBJECT(sel), "changed", G_CALLBACK(_filename_tree_selection_change), filename);
+  g_signal_connect(sel, "changed", G_CALLBACK(_filename_tree_selection_change), filename);
 
   col = gtk_tree_view_column_new();
   gtk_tree_view_append_column(GTK_TREE_VIEW(filename->ext_tree), col);
@@ -451,7 +451,7 @@ static void _filename_widget_init(dt_lib_filtering_rule_t *rule, const dt_collec
   // the button to close the popup
   GtkWidget *btn = gtk_button_new_with_label(_("ok"));
   gtk_box_pack_start(GTK_BOX(hb), btn, FALSE, TRUE, 0);
-  g_signal_connect(G_OBJECT(btn), "clicked", G_CALLBACK(_filename_ok_clicked), filename);
+  g_signal_connect(btn, "clicked", G_CALLBACK(_filename_ok_clicked), filename);
 
   if(top)
     rule->w_specific_top = filename;

--- a/src/libs/filters/misc.c
+++ b/src/libs/filters/misc.c
@@ -457,9 +457,9 @@ static void _misc_widget_init(dt_lib_filtering_rule_t *rule,
   g_free(name);
 
   gtk_box_pack_start(GTK_BOX(hb), misc->name, TRUE, TRUE, 0);
-  g_signal_connect(G_OBJECT(misc->name), "activate", G_CALLBACK(_misc_changed), misc);
-  g_signal_connect(G_OBJECT(misc->name), "focus-out-event", G_CALLBACK(_misc_focus_out), misc);
-  g_signal_connect(G_OBJECT(misc->name), "button-press-event", G_CALLBACK(_misc_press), misc);
+  g_signal_connect(misc->name, "activate", G_CALLBACK(_misc_changed), misc);
+  g_signal_connect(misc->name, "focus-out-event", G_CALLBACK(_misc_focus_out), misc);
+  g_signal_connect(misc->name, "button-press-event", G_CALLBACK(_misc_press), misc);
 
   if(top)
   {
@@ -469,7 +469,7 @@ static void _misc_widget_init(dt_lib_filtering_rule_t *rule,
   // the popup
   misc->pop = gtk_popover_new(misc->name);
   gtk_widget_set_size_request(misc->pop, 250, 400);
-  g_signal_connect(G_OBJECT(misc->pop), "closed", G_CALLBACK(_misc_popup_closed), misc);
+  g_signal_connect(misc->pop, "closed", G_CALLBACK(_misc_popup_closed), misc);
   hb = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
   gtk_container_add(GTK_CONTAINER(misc->pop), hb);
 
@@ -483,8 +483,8 @@ static void _misc_widget_init(dt_lib_filtering_rule_t *rule,
   gtk_tree_view_set_headers_visible(GTK_TREE_VIEW(misc->name_tree), FALSE);
   GtkTreeSelection *sel = gtk_tree_view_get_selection(GTK_TREE_VIEW(misc->name_tree));
   gtk_tree_selection_set_mode(sel, GTK_SELECTION_MULTIPLE);
-  g_signal_connect(G_OBJECT(misc->name_tree), "row-activated", G_CALLBACK(_misc_tree_row_activated), misc);
-  g_signal_connect(G_OBJECT(sel), "changed", G_CALLBACK(_misc_tree_selection_changed), misc);
+  g_signal_connect(misc->name_tree, "row-activated", G_CALLBACK(_misc_tree_row_activated), misc);
+  g_signal_connect(sel, "changed", G_CALLBACK(_misc_tree_selection_changed), misc);
 
   GtkTreeViewColumn *col = gtk_tree_view_column_new();
   gtk_tree_view_append_column(GTK_TREE_VIEW(misc->name_tree), col);
@@ -500,7 +500,7 @@ static void _misc_widget_init(dt_lib_filtering_rule_t *rule,
   // the button to close the popup
   GtkWidget *btn = gtk_button_new_with_label(_("ok"));
   gtk_box_pack_start(GTK_BOX(hb), btn, FALSE, TRUE, 0);
-  g_signal_connect(G_OBJECT(btn), "clicked", G_CALLBACK(_misc_ok_clicked), misc);
+  g_signal_connect(btn, "clicked", G_CALLBACK(_misc_ok_clicked), misc);
 
   if(top)
     rule->w_specific_top = misc;

--- a/src/libs/filters/search.c
+++ b/src/libs/filters/search.c
@@ -170,8 +170,8 @@ static void _search_widget_init(dt_lib_filtering_rule_t *rule, const dt_collecti
     gtk_box_pack_start(GTK_BOX(rule->w_special_box), hbox, TRUE, TRUE, 0);
   search->text = gtk_search_entry_new();
   gtk_drag_dest_unset(search->text);
-  g_signal_connect(G_OBJECT(search->text), "search-changed", G_CALLBACK(_search_changed), search);
-  g_signal_connect(G_OBJECT(search->text), "stop-search", G_CALLBACK(_search_reset_text_entry), rule);
+  g_signal_connect(search->text, "search-changed", G_CALLBACK(_search_changed), search);
+  g_signal_connect(search->text, "stop-search", G_CALLBACK(_search_reset_text_entry), rule);
   if(top)
     gtk_entry_set_max_width_chars(GTK_ENTRY(search->text), 20);
   gtk_entry_set_width_chars(GTK_ENTRY(search->text), 0);

--- a/src/libs/geotagging.c
+++ b/src/libs/geotagging.c
@@ -570,7 +570,7 @@ static gboolean _click_for_entire_track(GtkEntry *spin, GdkEventButton *event, d
   return FALSE;
 }
 
-static void _track_seg_toggled(GtkCellRendererToggle *cell_renderer, gchar *path_str, dt_lib_module_t *self)
+static void _track_seg_toggled(GtkCellRenderer *cell_renderer, gchar *path_str, dt_lib_module_t *self)
 {
   dt_lib_geotagging_t *d = self->data;
   GtkTreeModel *model = gtk_tree_view_get_model(GTK_TREE_VIEW(d->map.gpx_view));
@@ -1795,7 +1795,7 @@ void gui_init(dt_lib_module_t *self)
   d->lock_offset = dtgtk_togglebutton_new(dtgtk_cairo_paint_lock, 0, NULL);
   gtk_widget_set_tooltip_text(d->lock_offset, _("lock date/time offset value to apply it onto another selection"));
   gtk_widget_set_halign(d->lock_offset, GTK_ALIGN_START);
-  g_signal_connect(G_OBJECT(d->lock_offset), "clicked", G_CALLBACK(_toggle_lock_button_callback), (gpointer)self);
+  g_signal_connect(d->lock_offset, "clicked", G_CALLBACK(_toggle_lock_button_callback), self);
 
   box = _gui_init_datetime(_("date/time offset"), &d->of, 2, self, group, d->lock_offset,
                            _("offset or difference ([-]dd hh:mm:ss[.sss])"));
@@ -1853,8 +1853,8 @@ void gui_init(dt_lib_module_t *self)
   gtk_entry_completion_set_match_func(completion, _completion_match_func, NULL, NULL);
   gtk_entry_completion_set_minimum_key_length(completion, 0);
   gtk_entry_set_completion(GTK_ENTRY(d->timezone), completion);
-  g_signal_connect(G_OBJECT(d->timezone), "key-press-event", G_CALLBACK(_timezone_key_pressed), self);
-  g_signal_connect(G_OBJECT(d->timezone), "focus-out-event", G_CALLBACK(_timezone_focus_out), self);
+  g_signal_connect(d->timezone, "key-press-event", G_CALLBACK(_timezone_key_pressed), self);
+  g_signal_connect(d->timezone, "focus-out-event", G_CALLBACK(_timezone_focus_out), self);
 
   // gpx
   d->gpx_button = dt_action_button_new(self, N_("apply GPX track file..."), _choose_gpx_callback, self,
@@ -1878,7 +1878,7 @@ void gui_init(dt_lib_module_t *self)
   gtk_widget_set_name(d->map.gpx_button, "non-flat");
   gtk_widget_set_tooltip_text(d->map.gpx_button, _("select a GPX track file..."));
   gtk_grid_attach(grid, d->map.gpx_button, 0, line, 1, 1);
-  g_signal_connect(G_OBJECT(d->map.gpx_button), "clicked", G_CALLBACK(_choose_gpx_callback), self);
+  g_signal_connect(d->map.gpx_button, "clicked", G_CALLBACK(_choose_gpx_callback), self);
 
   d->map.gpx_file = dt_ui_label_new("");
   gtk_label_set_ellipsize(GTK_LABEL(d->map.gpx_file ), PANGO_ELLIPSIZE_MIDDLE);
@@ -1919,8 +1919,8 @@ void gui_init(dt_lib_module_t *self)
   gtk_tree_view_append_column(GTK_TREE_VIEW(d->map.gpx_view), column);
 
   g_object_set(G_OBJECT(d->map.gpx_view), "has-tooltip", TRUE, NULL);
-  g_signal_connect(G_OBJECT(d->map.gpx_view), "query-tooltip", G_CALLBACK(_row_tooltip_setup), self);
-  g_signal_connect(G_OBJECT(d->map.gpx_view), "button-press-event", G_CALLBACK(_click_for_entire_track), self);
+  g_signal_connect(d->map.gpx_view, "query-tooltip", G_CALLBACK(_row_tooltip_setup), self);
+  g_signal_connect(d->map.gpx_view, "button-press-event", G_CALLBACK(_click_for_entire_track), self);
 
   // avoid ugly console pixman messages due to headers
   gtk_tree_view_set_headers_visible(GTK_TREE_VIEW(d->map.gpx_view), FALSE);

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -2151,11 +2151,10 @@ static gboolean _color_harmony_clicked(GtkWidget *button,
   return TRUE;
 }
 
-static gboolean _color_harmony_enter_notify_callback(const GtkWidget *widget,
+static gboolean _color_harmony_enter_notify_callback(GtkWidget *widget,
                                                      GdkEventCrossing *event,
-                                                     const gpointer user_data)
+                                                     dt_lib_histogram_t *d)
 {
-  dt_lib_histogram_t *d = (dt_lib_histogram_t *)user_data;
   // find positions of entered button
 
   d->color_harmony_old = d->harmony_guide.type;
@@ -2173,9 +2172,8 @@ static gboolean _color_harmony_enter_notify_callback(const GtkWidget *widget,
 
 static gboolean _color_harmony_leave_notify_callback(GtkWidget *widget,
                                                      GdkEventCrossing *event,
-                                                     const gpointer user_data)
+                                                     dt_lib_histogram_t *d)
 {
-  dt_lib_histogram_t *d = (dt_lib_histogram_t *)user_data;
   d->harmony_guide.type = d->color_harmony_old;
   gtk_widget_queue_draw(d->scope_draw);
   return FALSE;
@@ -2584,7 +2582,7 @@ void gui_init(dt_lib_module_t *self)
     dt_action_define(dark, N_("modes"), dt_lib_histogram_scope_type_names[i],
                      d->scope_type_button[i], &dt_action_def_toggle);
     gtk_box_pack_start(GTK_BOX(box_left), d->scope_type_button[i], FALSE, FALSE, 0);
-    g_signal_connect(G_OBJECT(d->scope_type_button[i]), "button-press-event",
+    g_signal_connect(d->scope_type_button[i], "button-press-event",
                      G_CALLBACK(_scope_histogram_mode_clicked), d);
   }
   gtk_toggle_button_set_active
@@ -2649,11 +2647,11 @@ void gui_init(dt_lib_module_t *self)
                                            &(dt_color_harmonies[i]));
     dt_action_define(dark, N_("color harmonies"),
                      dt_color_harmonies[i].name, rb, &dt_action_def_toggle);
-    g_signal_connect(G_OBJECT(rb), "button-press-event",
+    g_signal_connect(rb, "button-press-event",
                      G_CALLBACK(_color_harmony_clicked), d);
-    g_signal_connect(G_OBJECT(rb), "enter-notify-event",
+    g_signal_connect(rb, "enter-notify-event",
                      G_CALLBACK(_color_harmony_enter_notify_callback), d);
-    g_signal_connect(G_OBJECT(rb), "leave-notify-event",
+    g_signal_connect(rb, "leave-notify-event",
                      G_CALLBACK(_color_harmony_leave_notify_callback), d);
 
     gtk_box_pack_start(GTK_BOX(d->color_harmony_box), rb, FALSE, FALSE, 0);
@@ -2701,22 +2699,22 @@ void gui_init(dt_lib_module_t *self)
   gtk_widget_set_name(self->widget, "main-histogram");
 
   /* connect callbacks */
-  g_signal_connect(G_OBJECT(d->scope_view_button), "clicked",
+  g_signal_connect(d->scope_view_button, "clicked",
                    G_CALLBACK(_scope_view_clicked), d);
-  g_signal_connect(G_OBJECT(d->colorspace_button), "clicked",
+  g_signal_connect(d->colorspace_button, "clicked",
                    G_CALLBACK(_colorspace_clicked), d);
 
-  g_signal_connect(G_OBJECT(d->red_channel_button), "toggled",
+  g_signal_connect(d->red_channel_button, "toggled",
                    G_CALLBACK(_red_channel_toggle), d);
-  g_signal_connect(G_OBJECT(d->green_channel_button), "toggled",
+  g_signal_connect(d->green_channel_button, "toggled",
                    G_CALLBACK(_green_channel_toggle), d);
-  g_signal_connect(G_OBJECT(d->blue_channel_button), "toggled",
+  g_signal_connect(d->blue_channel_button, "toggled",
                    G_CALLBACK(_blue_channel_toggle), d);
 
   gtk_widget_add_events(d->scope_draw, GDK_LEAVE_NOTIFY_MASK | GDK_POINTER_MOTION_MASK
                                      | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK);
   // FIXME: why does cursor motion over buttons trigger multiple draw callbacks?
-  g_signal_connect(G_OBJECT(d->scope_draw), "draw", G_CALLBACK(_drawable_draw_callback), d);
+  g_signal_connect(d->scope_draw, "draw", G_CALLBACK(_drawable_draw_callback), d);
   dt_gui_connect_click_all(d->scope_draw, _drawable_button_press,
                                           _drawable_button_release, d);
   dt_gui_connect_motion(d->scope_draw, _drawable_motion, NULL,
@@ -2726,13 +2724,13 @@ void gui_init(dt_lib_module_t *self)
     (eventbox,
      GDK_LEAVE_NOTIFY_MASK | GDK_ENTER_NOTIFY_MASK
      | GDK_POINTER_MOTION_MASK | darktable.gui->scroll_mask);
-  g_signal_connect(G_OBJECT(eventbox), "scroll-event",
+  g_signal_connect(eventbox, "scroll-event",
                    G_CALLBACK(_eventbox_scroll_callback), d);
-  g_signal_connect(G_OBJECT(eventbox), "enter-notify-event",
+  g_signal_connect(eventbox, "enter-notify-event",
                    G_CALLBACK(_eventbox_enter_notify_callback), d);
-  g_signal_connect(G_OBJECT(eventbox), "leave-notify-event",
+  g_signal_connect(eventbox, "leave-notify-event",
                    G_CALLBACK(_eventbox_leave_notify_callback), d);
-  g_signal_connect(G_OBJECT(eventbox), "motion-notify-event",
+  g_signal_connect(eventbox, "motion-notify-event",
                    G_CALLBACK(_eventbox_motion_notify_callback), d);
 
   gtk_widget_show_all(self->widget);

--- a/src/libs/history.c
+++ b/src/libs/history.c
@@ -140,12 +140,12 @@ void gui_init(dt_lib_module_t *self)
     (self, N_("compress history stack"), _lib_history_compress_clicked_callback, self,
      _("create a minimal history stack which produces the same image\n"
        "ctrl+click to truncate history to the selected item"), 0, 0);
-  g_signal_connect(G_OBJECT(d->compress_button), "button-press-event",
+  g_signal_connect(d->compress_button, "button-press-event",
                    G_CALLBACK(_lib_history_compress_pressed_callback), self);
 
   /* add toolbar button for creating style */
   d->create_button = dtgtk_button_new(dtgtk_cairo_paint_styles, CPF_NONE, NULL);
-  g_signal_connect(G_OBJECT(d->create_button), "clicked",
+  g_signal_connect(d->create_button, "clicked",
                    G_CALLBACK(_lib_history_create_style_button_clicked_callback), NULL);
   gtk_widget_set_name(d->create_button, "non-flat");
   gtk_widget_set_tooltip_text(d->create_button,
@@ -236,7 +236,7 @@ static GtkWidget *_lib_history_create_button(dt_lib_module_t *self,
   if(selected) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), TRUE);
 
   /* set callback when clicked */
-  g_signal_connect(G_OBJECT(widget), "button-press-event",
+  g_signal_connect(widget, "button-press-event",
                    G_CALLBACK(_lib_history_button_clicked_callback), self);
 
   /* associate the history number */
@@ -881,7 +881,7 @@ static gboolean _changes_tooltip_callback(GtkWidget *widget,
                                           const gint y,
                                           const gboolean keyboard_mode,
                                           GtkTooltip *tooltip,
-                                          const dt_dev_history_item_t *hitem)
+                                          dt_dev_history_item_t *hitem)
 {
   dt_iop_params_t *old_params = hitem->module->default_params;
   dt_develop_blend_params_t *old_blend = hitem->module->default_blendop_params;
@@ -1039,7 +1039,7 @@ static gboolean _changes_tooltip_callback(GtkWidget *widget,
       view = gtk_text_view_new();
       dt_gui_add_class(view, "dt_transparent_background");
       dt_gui_add_class(view, "dt_monospace");
-      g_signal_connect(G_OBJECT(view), "destroy", G_CALLBACK(gtk_widget_destroyed), &view);
+      g_signal_connect(view, "destroy", G_CALLBACK(gtk_widget_destroyed), &view);
     }
 
     // find tabs to align columns and decimals
@@ -1150,7 +1150,7 @@ void gui_update(dt_lib_module_t *self)
       history;
       history = g_list_next(history))
   {
-    const dt_dev_history_item_t *hitem = history->data;
+    dt_dev_history_item_t *hitem = history->data;
     gchar *label = _lib_history_button_label(hitem);
 
     const gboolean selected = (num == darktable.develop->history_end - 1);
@@ -1164,8 +1164,8 @@ void gui_update(dt_lib_module_t *self)
     g_free(label);
 
     gtk_widget_set_has_tooltip(widget, TRUE);
-    g_signal_connect(G_OBJECT(widget), "query-tooltip",
-                     G_CALLBACK(_changes_tooltip_callback), (void *)hitem);
+    g_signal_connect(widget, "query-tooltip",
+                     G_CALLBACK(_changes_tooltip_callback), hitem);
 
     gtk_box_pack_end(GTK_BOX(d->history_box), widget, FALSE, FALSE, 0);
     num++;

--- a/src/libs/image.c
+++ b/src/libs/image.c
@@ -550,7 +550,7 @@ void gui_init(dt_lib_module_t *self)
   gtk_widget_set_tooltip_text(d->rotate_ccw_button,
                               _("rotate selected images 90 degrees CCW"));
   gtk_grid_attach(grid, d->rotate_ccw_button, 0, line, 1, 1);
-  g_signal_connect(G_OBJECT(d->rotate_ccw_button), "clicked",
+  g_signal_connect(d->rotate_ccw_button, "clicked",
                    G_CALLBACK(button_clicked), GINT_TO_POINTER(4));
   dt_action_define(DT_ACTION(self), NULL,
                    N_("rotate selected images 90 degrees CCW"),
@@ -561,7 +561,7 @@ void gui_init(dt_lib_module_t *self)
   gtk_widget_set_tooltip_text(d->rotate_cw_button,
                               _("rotate selected images 90 degrees CW"));
   gtk_grid_attach(grid, d->rotate_cw_button, 1, line, 1, 1);
-  g_signal_connect(G_OBJECT(d->rotate_cw_button), "clicked",
+  g_signal_connect(d->rotate_cw_button, "clicked",
                    G_CALLBACK(button_clicked), GINT_TO_POINTER(5));
   dt_action_define(DT_ACTION(self), NULL,
                    N_("rotate selected images 90 degrees CW"),
@@ -614,7 +614,7 @@ void gui_init(dt_lib_module_t *self)
     dt_conf_get_bool("plugins/lighttable/copy_metadata/" #item)); \
   dt_action_define(DT_ACTION(meta), N_("flags"),                  \
                    label, flag, &dt_action_def_toggle);           \
-  g_signal_connect(G_OBJECT(flag), "clicked",                     \
+  g_signal_connect(flag, "clicked",                     \
                    G_CALLBACK(_##item##_flag_callback), self); }
 
   META_FLAG_BUTTON(N_("ratings"),  rating,   0, _("select ratings metadata"));
@@ -628,7 +628,7 @@ void gui_init(dt_lib_module_t *self)
      _copy_metadata_callback, self,
      _("set the selected image as source of metadata"), 0, 0);
   gtk_grid_attach(grid, d->copy_metadata_button, 0, ++line, 2, 1);
-  g_signal_connect(G_OBJECT(d->copy_metadata_button), "clicked",
+  g_signal_connect(d->copy_metadata_button, "clicked",
                    G_CALLBACK(_copy_metadata_callback), self);
 
   d->paste_metadata_button = dt_action_button_new
@@ -762,8 +762,8 @@ static int lua_register_action(lua_State *L)
   lua_callback_data * data = malloc(sizeof(lua_callback_data));
   data->key = strdup(name);
   data->self = self;
-  const gulong s = g_signal_connect(G_OBJECT(button), "clicked",
-                                    G_CALLBACK(lua_button_clicked), data);
+  const gulong s = g_signal_connect_data(button, "clicked",
+                                         G_CALLBACK(lua_button_clicked), data, NULL, 0);
 
   // save the signal connection in case we need to destroy it later
   dt_lua_module_entry_push(L, "lib", self->plugin_name);

--- a/src/libs/import.c
+++ b/src/libs/import.c
@@ -299,7 +299,7 @@ void _lib_import_ui_devices_update(dt_lib_module_t *self)
                                 PANGO_ELLIPSIZE_END);
         d->import_camera = GTK_BUTTON(ib);
         d->camera = camera;
-        g_signal_connect(G_OBJECT(ib), "clicked",
+        g_signal_connect(ib, "clicked",
                          G_CALLBACK(_lib_import_from_camera_callback), self);
         gtk_widget_set_halign(gtk_bin_get_child(GTK_BIN(ib)), GTK_ALIGN_CENTER);
         dt_gui_add_help_link(ib, "import_camera");
@@ -310,7 +310,7 @@ void _lib_import_ui_devices_update(dt_lib_module_t *self)
                            (tb = gtk_button_new_with_label(_("tethered shoot"))),
                            FALSE, FALSE, 0);
         d->tethered_shoot = GTK_BUTTON(tb);
-        g_signal_connect(G_OBJECT(tb), "clicked",
+        g_signal_connect(tb, "clicked",
                          G_CALLBACK(_lib_import_tethered_callback), camera);
         gtk_widget_set_halign(gtk_bin_get_child(GTK_BIN(tb)), GTK_ALIGN_CENTER);
         dt_gui_add_help_link(tb, "import_camera");
@@ -320,7 +320,7 @@ void _lib_import_ui_devices_update(dt_lib_module_t *self)
                          (um = gtk_button_new_with_label(_("unmount camera"))),
                          FALSE, FALSE, 0);
       d->unmount_camera = GTK_BUTTON(um);
-      g_signal_connect(G_OBJECT(um), "clicked",
+      g_signal_connect(um, "clicked",
                        G_CALLBACK(_lib_import_unmount_callback), camera);
       gtk_widget_set_halign(gtk_bin_get_child(GTK_BIN(um)), GTK_ALIGN_CENTER);
       dt_gui_add_help_link(um, "mount_camera");
@@ -357,7 +357,7 @@ void _lib_import_ui_devices_update(dt_lib_module_t *self)
                               PANGO_ELLIPSIZE_END);
       d->mount_camera = GTK_BUTTON(im);
 
-      g_signal_connect(G_OBJECT(im), "clicked",
+      g_signal_connect(im, "clicked",
                        G_CALLBACK(_lib_import_mount_callback), camera);
       gtk_widget_set_halign(gtk_bin_get_child(GTK_BIN(im)), GTK_ALIGN_CENTER);
       dt_gui_add_help_link(im, "mount_camera");
@@ -1494,7 +1494,7 @@ static void _set_places_list(GtkWidget *places_paned,
   gtk_paned_pack1(GTK_PANED(places_paned), places_top_box, TRUE, TRUE);
 
 
-  g_signal_connect(G_OBJECT(d->placesView), "button-press-event",
+  g_signal_connect(d->placesView, "button-press-event",
                    G_CALLBACK(_places_button_press), self);
 }
 
@@ -1519,7 +1519,7 @@ static void _set_folders_list(GtkWidget *places_paned, dt_lib_module_t* self)
   gtk_tree_view_column_set_resizable(column, TRUE);
   gtk_tree_view_set_expander_column(d->from.folderview, column);
   g_signal_connect(d->from.folderview, "row-expanded", G_CALLBACK(_row_expanded), self);
-  g_signal_connect(G_OBJECT(d->from.folderview), "button-press-event",
+  g_signal_connect(d->from.folderview, "button-press-event",
                    G_CALLBACK(_folders_button_press), self);
   gtk_tree_view_column_set_sort_column_id(column, DT_FOLDER_PATH);
   gtk_tree_sortable_set_sort_column_id(GTK_TREE_SORTABLE(store), DT_FOLDER_PATH,
@@ -1930,12 +1930,12 @@ static void _set_files_list(GtkWidget *rbox, dt_lib_module_t* self)
   gtk_tree_view_column_set_clickable(column, TRUE);
   gtk_tree_view_column_set_min_width(column, DT_PIXEL_APPLY_DPI(128));
   d->from.pixcol = column;
-  g_signal_connect(G_OBJECT(d->from.treeview), "button-press-event",
+  g_signal_connect(d->from.treeview, "button-press-event",
                    G_CALLBACK(_files_button_press), self);
 
   GtkTreeSelection *selection = gtk_tree_view_get_selection(d->from.treeview);
   gtk_tree_selection_set_mode(selection, GTK_SELECTION_MULTIPLE);
-  g_signal_connect(G_OBJECT(selection), "changed",
+  g_signal_connect(selection, "changed",
                    G_CALLBACK(_import_from_selection_changed), self);
 
   gtk_tree_view_set_model(d->from.treeview, GTK_TREE_MODEL(d->from.store));
@@ -2015,7 +2015,7 @@ static void _set_expander_content(GtkWidget *rbox,
   gtk_widget_set_tooltip_text(browsedir, _("select directory"));
 
   gtk_box_pack_start(GTK_BOX(hbox), browsedir, FALSE, FALSE, 0);
-  g_signal_connect(G_OBJECT(browsedir), "clicked", G_CALLBACK(_browse_basedir_clicked),
+  g_signal_connect(browsedir, "clicked", G_CALLBACK(_browse_basedir_clicked),
                    basedir);
   gtk_grid_attach_next_to(grid, hbox, gtk_grid_get_child_at(grid, 0, line - 1),
                           GTK_POS_RIGHT, 1, 1);
@@ -2105,7 +2105,7 @@ static void _import_from_dialog_new(dt_lib_module_t* self)
   d->import_new = dt_gui_preferences_bool(grid, "ui_last/import_select_new", col++,
                                           line, TRUE);
   gtk_widget_set_hexpand(gtk_grid_get_child_at(grid, col++, line), TRUE);
-  g_signal_connect(G_OBJECT(d->import_new), "toggled",
+  g_signal_connect(d->import_new, "toggled",
                    G_CALLBACK(_import_new_toggled), self);
 
   if(d->import_case != DT_IMPORT_CAMERA)
@@ -2113,13 +2113,13 @@ static void _import_from_dialog_new(dt_lib_module_t* self)
     d->recursive = dt_gui_preferences_bool(grid, "ui_last/import_recursive", col++,
                                            line, TRUE);
     gtk_widget_set_hexpand(gtk_grid_get_child_at(grid, col++, line), TRUE);
-    g_signal_connect(G_OBJECT(d->recursive), "toggled",
+    g_signal_connect(d->recursive, "toggled",
                      G_CALLBACK(_recursive_toggled), self);
   }
   GtkWidget *ignore_nonraws =
     dt_gui_preferences_bool(grid, "ui_last/import_ignore_nonraws", col++, line, TRUE);
   gtk_widget_set_hexpand(gtk_grid_get_child_at(grid, col++, line++), TRUE);
-  g_signal_connect(G_OBJECT(ignore_nonraws), "toggled",
+  g_signal_connect(ignore_nonraws, "toggled",
                    G_CALLBACK(_ignore_nonraws_toggled), self);
   gtk_box_pack_start(GTK_BOX(rbox), GTK_WIDGET(grid), FALSE, FALSE, 8);
 

--- a/src/libs/live_view.c
+++ b/src/libs/live_view.c
@@ -318,7 +318,7 @@ void gui_init(dt_lib_module_t *self)
   button = dtgtk_##type##button_new(paint, direction, NULL);                 \
   gtk_widget_set_tooltip_text(button, action);                               \
   gtk_box_pack_start(GTK_BOX(box), button, TRUE, TRUE, 0);                   \
-  g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(callback), data); \
+  g_signal_connect(button, "clicked", G_CALLBACK(callback), data); \
   dt_action_define(DT_ACTION(self), NULL, action, button, *(#type)?&dt_action_def_toggle:&dt_action_def_button);
 
   lib->live_view = NEW_BUTTON(toggle, dtgtk_cairo_paint_eye, 0,
@@ -370,7 +370,7 @@ void gui_init(dt_lib_module_t *self)
   dt_bauhaus_combobox_add(lib->overlay, _("selected image"));
   dt_bauhaus_combobox_add(lib->overlay, _("id"));
   gtk_widget_set_tooltip_text(lib->overlay, _("overlay another image over the live view"));
-  g_signal_connect(G_OBJECT(lib->overlay), "value-changed",
+  g_signal_connect(lib->overlay, "value-changed",
                    G_CALLBACK(overlay_changed), lib);
   gtk_box_pack_start(GTK_BOX(self->widget), lib->overlay, TRUE, TRUE, 0);
 
@@ -381,7 +381,7 @@ void gui_init(dt_lib_module_t *self)
   gtk_spin_button_set_digits(GTK_SPIN_BUTTON(lib->overlay_id), 0);
   gtk_widget_set_tooltip_text(lib->overlay_id,
                               _("enter image id of the overlay manually"));
-  g_signal_connect(G_OBJECT(lib->overlay_id), "value-changed",
+  g_signal_connect(lib->overlay_id, "value-changed",
                    G_CALLBACK(_overlay_id_changed), lib);
   gtk_spin_button_set_value(GTK_SPIN_BUTTON(lib->overlay_id),
                             dt_conf_get_int("plugins/lighttable/live_view/overlay_imgid"));
@@ -415,7 +415,7 @@ void gui_init(dt_lib_module_t *self)
   gtk_widget_set_tooltip_text(lib->overlay_mode, _("mode of the overlay"));
   dt_bauhaus_combobox_set(lib->overlay_mode,
                           dt_conf_get_int("plugins/lighttable/live_view/overlay_mode"));
-  g_signal_connect(G_OBJECT(lib->overlay_mode), "value-changed",
+  g_signal_connect(lib->overlay_mode, "value-changed",
                    G_CALLBACK(_overlay_mode_changed), lib);
   gtk_box_pack_start(GTK_BOX(self->widget), lib->overlay_mode, TRUE, TRUE, 0);
 
@@ -426,7 +426,7 @@ void gui_init(dt_lib_module_t *self)
   gtk_widget_set_tooltip_text(lib->overlay_splitline, _("only draw part of the overlay"));
   dt_bauhaus_combobox_set(lib->overlay_splitline,
                           dt_conf_get_int("plugins/lighttable/live_view/splitline"));
-  g_signal_connect(G_OBJECT(lib->overlay_splitline), "value-changed",
+  g_signal_connect(lib->overlay_splitline, "value-changed",
                    G_CALLBACK(_overlay_splitline_changed),
                    lib);
   gtk_box_pack_start(GTK_BOX(self->widget), lib->overlay_splitline, TRUE, TRUE, 0);

--- a/src/libs/location.c
+++ b/src/libs/location.c
@@ -140,9 +140,9 @@ void gui_init(dt_lib_module_t *self)
 
   /* add search box */
   lib->search = GTK_ENTRY(dt_ui_entry_new(0));
-  g_signal_connect(G_OBJECT(lib->search), "activate",
+  g_signal_connect(lib->search, "activate",
                    G_CALLBACK(_lib_location_entry_activated),
-                   (gpointer)self);
+                   self);
 
   /* add result vbox */
   lib->result = dt_gui_vbox();
@@ -173,9 +173,9 @@ static GtkWidget *_lib_location_place_widget_new(dt_lib_location_t *lib,
   GtkWidget *eb, *vb, *w;
   eb = gtk_event_box_new();
   gtk_widget_set_name(eb, "dt-map-location");
-  g_signal_connect(G_OBJECT(eb), "enter-notify-event",
+  g_signal_connect(eb, "enter-notify-event",
                    G_CALLBACK(_event_box_enter_leave), NULL);
-  g_signal_connect(G_OBJECT(eb), "leave-notify-event",
+  g_signal_connect(eb, "leave-notify-event",
                    G_CALLBACK(_event_box_enter_leave), NULL);
 
   vb = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
@@ -211,7 +211,7 @@ static GtkWidget *_lib_location_place_widget_new(dt_lib_location_t *lib,
     lib->callback_params = g_list_append(lib->callback_params, param);
     param->lib = lib;
     param->result = place;
-    g_signal_connect(G_OBJECT(eb), "button-press-event",
+    g_signal_connect(eb, "button-press-event",
                      G_CALLBACK(_lib_location_result_item_activated),
                      (gpointer)param);
   }

--- a/src/libs/map_locations.c
+++ b/src/libs/map_locations.c
@@ -622,7 +622,7 @@ static void _name_start_editing(GtkCellRenderer *renderer, GtkCellEditable *edit
     }
     gtk_tree_path_free(new_path);
 
-    g_signal_connect(G_OBJECT(editable), "editing-done", G_CALLBACK(_name_editing_done), self);
+    g_signal_connect(editable, "editing-done", G_CALLBACK(_name_editing_done), self);
   }
 }
 
@@ -774,10 +774,10 @@ static void _pop_menu_view(GtkWidget *view, GdkEventButton *event, dt_lib_module
     const gboolean children = gtk_tree_model_iter_children(model, &child, &parent);
 
     menuitem = gtk_menu_item_new_with_label(_("edit location"));
-    g_signal_connect(menuitem, "activate", (GCallback)_pop_menu_edit_location, self);
+    g_signal_connect(menuitem, "activate", G_CALLBACK(_pop_menu_edit_location), self);
     gtk_menu_shell_append(GTK_MENU_SHELL(menu), menuitem);
     menuitem = gtk_menu_item_new_with_label(_("delete location"));
-    g_signal_connect(menuitem, "activate", (GCallback)_pop_menu_delete_location, self);
+    g_signal_connect(menuitem, "activate", G_CALLBACK(_pop_menu_delete_location), self);
     gtk_menu_shell_append(GTK_MENU_SHELL(menu), menuitem);
     if(children)
     {
@@ -792,10 +792,10 @@ static void _pop_menu_view(GtkWidget *view, GdkEventButton *event, dt_lib_module
     {
       gtk_widget_set_sensitive(menuitem, FALSE);
     }
-    g_signal_connect(menuitem, "activate", (GCallback)_pop_menu_update_filmstrip, self);
+    g_signal_connect(menuitem, "activate", G_CALLBACK(_pop_menu_update_filmstrip), self);
     menuitem = gtk_menu_item_new_with_label(_("go to collection (lighttable)"));
     gtk_menu_shell_append(GTK_MENU_SHELL(menu), menuitem);
-    g_signal_connect(menuitem, "activate", (GCallback)_pop_menu_goto_collection, self);
+    g_signal_connect(menuitem, "activate", G_CALLBACK(_pop_menu_goto_collection), self);
     if(!locid)
     {
       gtk_widget_set_sensitive(menuitem, FALSE);
@@ -912,7 +912,7 @@ void gui_init(dt_lib_module_t *self)
   gtk_tree_view_column_add_attribute(col, renderer, "text", DT_MAP_LOCATION_COL_TAG);
   gtk_tree_view_column_set_cell_data_func(col, renderer, _tree_name_show, (gpointer)self, NULL);
 //  g_object_set(renderer, "editable", TRUE, NULL);
-  g_signal_connect(G_OBJECT(renderer), "editing-started", G_CALLBACK(_name_start_editing), self);
+  g_signal_connect(renderer, "editing-started", G_CALLBACK(_name_start_editing), self);
   d->renderer = renderer;
 
   GtkTreeSelection *selection = gtk_tree_view_get_selection(view);
@@ -920,7 +920,7 @@ void gui_init(dt_lib_module_t *self)
   gtk_tree_selection_set_mode(selection, GTK_SELECTION_SINGLE);
   gtk_tree_view_set_model(view, GTK_TREE_MODEL(treestore));
   g_object_unref(treestore);
-  g_signal_connect(G_OBJECT(view), "button-press-event", G_CALLBACK(_click_on_view), self);
+  g_signal_connect(view, "button-press-event", G_CALLBACK(_click_on_view), self);
   gtk_widget_set_tooltip_text(GTK_WIDGET(view),
                               _("list of user locations,"
                                 "\nclick to show or hide a location on the map:"
@@ -945,8 +945,8 @@ void gui_init(dt_lib_module_t *self)
   }
   d->shape_button = dtgtk_togglebutton_new(location_shapes[shape], 0, NULL);
   gtk_box_pack_start(hbox, d->shape_button, FALSE, TRUE, 0);
-  d->shape_button_handler = g_signal_connect(G_OBJECT(d->shape_button), "clicked",
-                                             G_CALLBACK(_shape_button_clicked), self);
+  d->shape_button_handler = g_signal_connect_data(d->shape_button, "clicked",
+                                                  G_CALLBACK(_shape_button_clicked), self, NULL, 0);
   gtk_widget_set_tooltip_text(GTK_WIDGET(d->shape_button ),
                               _("select the shape of the location\'s limits on the map, circle or rectangle"
                                 "\nor even polygon if available (select first a polygon place in 'find location' module)"));
@@ -961,14 +961,14 @@ void gui_init(dt_lib_module_t *self)
   gtk_widget_set_tooltip_text(d->show_all_button,
                               _("show all locations which are on the visible map"));
   gtk_box_pack_end(hbox, d->show_all_button, FALSE, FALSE, 8);
-  g_signal_connect(G_OBJECT(d->show_all_button), "clicked", G_CALLBACK(_show_all_button_clicked), self);
+  g_signal_connect(d->show_all_button, "clicked", G_CALLBACK(_show_all_button_clicked), self);
 
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(hbox), FALSE, TRUE, 0);
 
   _locations_tree_update(self,0);
   _display_buttons(self);
 
-  g_signal_connect(G_OBJECT(selection), "changed", G_CALLBACK(_selection_changed), self);
+  g_signal_connect(selection, "changed", G_CALLBACK(_selection_changed), self);
 
   // connect geotag changed signal
   DT_CONTROL_SIGNAL_HANDLE(DT_SIGNAL_GEOTAG_CHANGED, _view_map_geotag_changed);

--- a/src/libs/map_settings.c
+++ b/src/libs/map_settings.c
@@ -104,7 +104,7 @@ void gui_init(dt_lib_module_t *self)
     }
   }
   dt_bauhaus_combobox_set(d->map_source_dropdown, selection);
-  g_signal_connect(G_OBJECT(d->map_source_dropdown), "value-changed", G_CALLBACK(_map_source_changed), NULL);
+  g_signal_connect(d->map_source_dropdown, "value-changed", G_CALLBACK(_map_source_changed), NULL);
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(d->map_source_dropdown), FALSE, TRUE, 0);
 
   GtkGrid *grid = GTK_GRID(gtk_grid_new());
@@ -113,25 +113,25 @@ void gui_init(dt_lib_module_t *self)
   int line = 0;
   d->max_outline_nodes = dt_gui_preferences_int(grid, "plugins/map/max_outline_nodes", 0, line++);
   d->show_osd_checkbutton = dt_gui_preferences_bool(grid, "plugins/map/show_map_osd", 0, line++, FALSE);
-  g_signal_connect(G_OBJECT(d->show_osd_checkbutton), "toggled", G_CALLBACK(_show_osd_toggled), NULL);
+  g_signal_connect(d->show_osd_checkbutton, "toggled", G_CALLBACK(_show_osd_toggled), NULL);
   d->filtered_images_checkbutton = dt_gui_preferences_bool(grid, "plugins/map/filter_images_drawn", 0, line++, FALSE);
-  g_signal_connect(G_OBJECT(d->filtered_images_checkbutton), "toggled", G_CALLBACK(_parameter_changed), NULL);
+  g_signal_connect(d->filtered_images_checkbutton, "toggled", G_CALLBACK(_parameter_changed), NULL);
   dt_shortcut_register(dt_action_define(DT_ACTION(self), NULL, N_("filtered images"),
                                         d->filtered_images_checkbutton, &dt_action_def_button),
                        0, 0, GDK_KEY_s, GDK_CONTROL_MASK);
   d->max_images_entry = dt_gui_preferences_int(grid, "plugins/map/max_images_drawn", 0, line++);
-  g_signal_connect(G_OBJECT(d->max_images_entry), "value-changed", G_CALLBACK(_parameter_changed), self);
+  g_signal_connect(d->max_images_entry, "value-changed", G_CALLBACK(_parameter_changed), self);
   d->epsilon_factor = dt_gui_preferences_int(grid, "plugins/map/epsilon_factor", 0, line++);
-  g_signal_connect(G_OBJECT(d->epsilon_factor), "value-changed", G_CALLBACK(_parameter_changed), self);
+  g_signal_connect(d->epsilon_factor, "value-changed", G_CALLBACK(_parameter_changed), self);
   d->min_images = dt_gui_preferences_int(grid, "plugins/map/min_images_per_group", 0, line++);
-  g_signal_connect(G_OBJECT(d->min_images), "value-changed", G_CALLBACK(_parameter_changed), self);
+  g_signal_connect(d->min_images, "value-changed", G_CALLBACK(_parameter_changed), self);
 
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(grid), FALSE, TRUE, 0);
 
   d->images_thumb = dt_gui_preferences_enum(DT_ACTION(self), "plugins/map/images_thumbnail");
   dt_action_t *ac = dt_bauhaus_widget_set_label(d->images_thumb, NULL, dt_confgen_get_label("plugins/map/images_thumbnail"));
   dt_shortcut_register(ac, 0, 0, GDK_KEY_s, GDK_SHIFT_MASK);
-  g_signal_connect(G_OBJECT(d->images_thumb), "value-changed", G_CALLBACK(_parameter_changed), self);
+  g_signal_connect(d->images_thumb, "value-changed", G_CALLBACK(_parameter_changed), self);
   gtk_box_pack_start(GTK_BOX(self->widget), d->images_thumb, FALSE, TRUE, 0);
 }
 

--- a/src/libs/metadata.c
+++ b/src/libs/metadata.c
@@ -560,7 +560,7 @@ static void _populate_popup_multi(GtkTextView *textview,
   for(GList *item = texts; item; item = item->next)
   {
     GtkWidget *new_line = gtk_menu_item_new_with_label(item->data);
-    g_signal_connect(G_OBJECT(new_line), "activate", G_CALLBACK(_menu_line_activated), textview);
+    g_signal_connect(new_line, "activate", G_CALLBACK(_menu_line_activated), textview);
     gtk_menu_shell_append(GTK_MENU_SHELL(popup), new_line);
   }
   gtk_widget_show_all(popup);
@@ -890,7 +890,7 @@ static void _menuitem_preferences(GtkMenuItem *menuitem,
     (_("display name"), renderer,
      "text", DT_METADATA_PREF_COL_NAME, NULL);
   g_object_set(renderer, "editable", TRUE, NULL);
-  g_signal_connect(G_OBJECT(renderer), "edited", G_CALLBACK(_display_name_edited_callback), store);
+  g_signal_connect(renderer, "edited", G_CALLBACK(_display_name_edited_callback), store);
   dt_gui_commit_on_focus_loss(renderer, &active_editable);
   gtk_tree_view_column_set_expand(column, TRUE);
   gtk_tree_view_append_column(GTK_TREE_VIEW(view), column);
@@ -908,7 +908,7 @@ static void _menuitem_preferences(GtkMenuItem *menuitem,
 
   // drag & drop
   gtk_tree_view_set_reorderable(GTK_TREE_VIEW(view), TRUE);
-  g_signal_connect(G_OBJECT(model), "row-inserted", G_CALLBACK(_drag_data_inserted), d);
+  g_signal_connect(model, "row-inserted", G_CALLBACK(_drag_data_inserted), d);
 
   GtkWidget *header = gtk_tree_view_column_get_button(column);
   gtk_widget_set_tooltip_text(header,
@@ -932,11 +932,11 @@ static void _menuitem_preferences(GtkMenuItem *menuitem,
 
   GtkWidget *plus = dtgtk_button_new(dtgtk_cairo_paint_plus_simple, 0, NULL);
   gtk_widget_set_tooltip_text(plus, _("add metadata tags"));
-  g_signal_connect(G_OBJECT(plus), "clicked", G_CALLBACK(_add_tag_button_clicked), (gpointer)d);
+  g_signal_connect(plus, "clicked", G_CALLBACK(_add_tag_button_clicked), (gpointer)d);
 
   GtkWidget *minus = dtgtk_button_new(dtgtk_cairo_paint_minus_simple, 0, NULL);
   gtk_widget_set_tooltip_text(minus, _("delete metadata tag"));
-  g_signal_connect(G_OBJECT(minus), "clicked", G_CALLBACK(_delete_tag_button_clicked), (gpointer)d);
+  g_signal_connect(minus, "clicked", G_CALLBACK(_delete_tag_button_clicked), (gpointer)d);
   d->delete_button = minus;
 
 #ifdef GDK_WINDOWING_QUARTZ
@@ -1119,7 +1119,7 @@ finish:
 void set_preferences(void *menu, dt_lib_module_t *self)
 {
   GtkWidget *mi = gtk_menu_item_new_with_label(_("preferences..."));
-  g_signal_connect(G_OBJECT(mi), "activate", G_CALLBACK(_menuitem_preferences), self);
+  g_signal_connect(mi, "activate", G_CALLBACK(_menuitem_preferences), self);
   gtk_menu_shell_append(GTK_MENU_SHELL(menu), mi);
 }
 

--- a/src/libs/metadata_view.c
+++ b/src/libs/metadata_view.c
@@ -1203,7 +1203,7 @@ static void _lib_metadata_refill_grid(dt_lib_module_t *self)
       // film roll jump to:
       if(d->filmroll_event && GTK_IS_WIDGET(d->filmroll_event))
         g_signal_handlers_disconnect_by_func(d->filmroll_event, G_CALLBACK(_filmroll_clicked), NULL);
-      g_signal_connect(G_OBJECT(w_value), "button-press-event", G_CALLBACK(_filmroll_clicked), NULL);
+      g_signal_connect(w_value, "button-press-event", G_CALLBACK(_filmroll_clicked), NULL);
       d->filmroll_event = G_OBJECT(w_value);
     }
 
@@ -1476,7 +1476,7 @@ void _menuitem_preferences(GtkMenuItem *menuitem, dt_lib_module_t *self)
 
   // drag & drop
   gtk_tree_view_set_reorderable(GTK_TREE_VIEW(view), TRUE);
-  g_signal_connect(G_OBJECT(model), "row-inserted", G_CALLBACK(_drag_data_inserted), NULL);
+  g_signal_connect(model, "row-inserted", G_CALLBACK(_drag_data_inserted), NULL);
   GtkWidget *w = dt_gui_scroll_wrap(view);
   gtk_widget_set_size_request(w, -1, DT_PIXEL_APPLY_DPI(600));
   gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(w), GTK_POLICY_NEVER, GTK_POLICY_ALWAYS);
@@ -1541,7 +1541,7 @@ void _menuitem_preferences(GtkMenuItem *menuitem, dt_lib_module_t *self)
 void set_preferences(void *menu, dt_lib_module_t *self)
 {
   GtkWidget *mi = gtk_menu_item_new_with_label(_("preferences..."));
-  g_signal_connect(G_OBJECT(mi), "activate", G_CALLBACK(_menuitem_preferences), self);
+  g_signal_connect(mi, "activate", G_CALLBACK(_menuitem_preferences), self);
   gtk_menu_shell_append(GTK_MENU_SHELL(menu), mi);
 }
 

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -468,7 +468,7 @@ static void _basics_add_widget(dt_lib_module_t *self, dt_lib_modulegroups_basic_
       gtk_label_set_xalign(GTK_LABEL(lb), 0.0);
       gtk_widget_set_name(lb, "basics-iop_name");
       gtk_container_add(GTK_CONTAINER(evb), lb);
-      g_signal_connect(G_OBJECT(evb), "button-press-event", G_CALLBACK(_basics_on_off_label_callback), btn);
+      g_signal_connect(evb, "button-press-event", G_CALLBACK(_basics_on_off_label_callback), btn);
       gtk_box_pack_start(GTK_BOX(item->box), evb, FALSE, TRUE, 0);
 
       // disable widget if needed (multiinstance)
@@ -576,7 +576,7 @@ static void _basics_add_widget(dt_lib_module_t *self, dt_lib_modulegroups_basic_
     g_signal_connect(item->widget      , "notify::visible", G_CALLBACK(_sync_visibility), item);
     g_signal_connect(item->old_parent  , "notify::visible", G_CALLBACK(_sync_visibility), item);
     g_signal_connect(item->temp_widget , "notify::visible", G_CALLBACK(_sync_visibility), item);
-    g_signal_connect(G_OBJECT(item->temp_widget), "destroy", G_CALLBACK(gtk_widget_destroyed), &item->temp_widget);
+    g_signal_connect(item->temp_widget, "destroy", G_CALLBACK(gtk_widget_destroyed), &item->temp_widget);
     g_signal_connect_swapped(G_OBJECT(item->temp_widget), "destroy", G_CALLBACK(_basics_remove_widget), item);
 
     _sync_visibility(item->widget, NULL, item);
@@ -612,7 +612,7 @@ static void _basics_add_widget(dt_lib_module_t *self, dt_lib_modulegroups_basic_
     gtk_widget_set_name(wbt, "basics-link");
     gtk_widget_set_valign(wbt, GTK_ALIGN_CENTER);
     g_free(tt);
-    g_signal_connect(G_OBJECT(wbt), "button-press-event", G_CALLBACK(_basics_goto_module), item->module);
+    g_signal_connect(wbt, "button-press-event", G_CALLBACK(_basics_goto_module), item->module);
     gtk_box_pack_end(GTK_BOX(compact_ui ? hbox_basic : header_box), wbt, FALSE, FALSE, 0);
 
     // we create a button to open the presets menu
@@ -2006,7 +2006,7 @@ static void _manage_editor_basics_update_list(dt_lib_module_t *self)
 
             gtk_widget_set_tooltip_text(btn, _("remove this widget"));
             g_object_set_data(G_OBJECT(btn), "widget_id", item->id);
-            g_signal_connect(G_OBJECT(btn), "button-press-event",
+            g_signal_connect(btn, "button-press-event",
                              G_CALLBACK(_manage_editor_basics_remove), self);
             gtk_box_pack_end(GTK_BOX(hb), btn, FALSE, TRUE, 0);
           }
@@ -2130,7 +2130,7 @@ static void _manage_editor_module_update_list(dt_lib_module_t *self,
           gtk_widget_set_tooltip_text(btn, _("remove this module"));
           g_object_set_data(G_OBJECT(btn), "module_name", module->op);
           g_object_set_data(G_OBJECT(btn), "group", gr);
-          g_signal_connect(G_OBJECT(btn), "button-press-event",
+          g_signal_connect(btn, "button-press-event",
                            G_CALLBACK(_manage_editor_module_remove), self);
           gtk_box_pack_end(GTK_BOX(hb), btn, FALSE, TRUE, 0);
         }
@@ -2376,7 +2376,7 @@ static void _manage_module_add_popup(GtkWidget *widget,
           gtk_widget_set_tooltip_text(GTK_WIDGET(smir), _("add this module"));
           g_object_set_data(G_OBJECT(smir), "module_op", module->op);
           g_object_set_data(G_OBJECT(smir), "group", gr);
-          g_signal_connect(G_OBJECT(smir), "activate", callback, data);
+          g_signal_connect(smir, "activate", G_CALLBACK(callback), data);
           gtk_menu_shell_insert(GTK_MENU_SHELL(pop), GTK_WIDGET(smir), nba);
         }
         GtkMenuItem *smi = (GtkMenuItem *)gtk_menu_item_new_with_label(module->name());
@@ -2384,7 +2384,7 @@ static void _manage_module_add_popup(GtkWidget *widget,
         gtk_widget_set_tooltip_text(GTK_WIDGET(smi), _("add this module"));
         g_object_set_data(G_OBJECT(smi), "module_op", module->op);
         g_object_set_data(G_OBJECT(smi), "group", gr);
-        g_signal_connect(G_OBJECT(smi), "activate", callback, data);
+        g_signal_connect(smi, "activate", G_CALLBACK(callback), data);
         gtk_menu_shell_prepend(GTK_MENU_SHELL(sm_all), GTK_WIDGET(smi));
       }
       else if(toggle)
@@ -2394,7 +2394,7 @@ static void _manage_module_add_popup(GtkWidget *widget,
         gtk_widget_set_tooltip_text(GTK_WIDGET(smi), _("remove this module"));
         g_object_set_data(G_OBJECT(smi), "module_op", module->op);
         g_object_set_data(G_OBJECT(smi), "group", gr);
-        g_signal_connect(G_OBJECT(smi), "activate", callback, data);
+        g_signal_connect(smi, "activate", G_CALLBACK(callback), data);
         gtk_menu_shell_insert(GTK_MENU_SHELL(pop), GTK_WIDGET(smi), 0);
         nba++;
       }
@@ -2548,7 +2548,7 @@ static GtkWidget *_build_menu_from_actions(dt_action_t *actions,
             gtk_widget_set_tooltip_text(item_top, _("remove this widget"));
             gtk_widget_set_name(item_top, "modulegroups-popup-item");
             g_object_set_data(G_OBJECT(item_top), "widget_id", action);
-            g_signal_connect(G_OBJECT(item_top), "activate", callback, self);
+            g_signal_connect(item_top, "activate", G_CALLBACK(callback), self);
             gtk_menu_shell_insert(GTK_MENU_SHELL(base_menu), item_top, *num_selected);
             ++*num_selected;
           }
@@ -2565,7 +2565,7 @@ static GtkWidget *_build_menu_from_actions(dt_action_t *actions,
             gtk_widget_set_tooltip_text(item_top, _("add this widget"));
             gtk_widget_set_name(item_top, "modulegroups-popup-item");
             g_object_set_data(G_OBJECT(item_top), "widget_id", action);
-            g_signal_connect(G_OBJECT(item_top), "activate", callback, self);
+            g_signal_connect(item_top, "activate", G_CALLBACK(callback), self);
             gtk_menu_shell_append(GTK_MENU_SHELL(base_menu), item_top);
           }
           g_free(delimited_id);
@@ -2583,7 +2583,7 @@ static GtkWidget *_build_menu_from_actions(dt_action_t *actions,
         }
 
         g_object_set_data(G_OBJECT(item), "widget_id", action);
-        g_signal_connect(G_OBJECT(item), "activate", callback, self);
+        g_signal_connect(item, "activate", G_CALLBACK(callback), self);
         g_free(action_id);
       }
       g_free(action_label);
@@ -2743,7 +2743,7 @@ static gboolean _manage_direct_active_popup(GtkWidget *widget,
           " regardless of whether or not they are currently enabled"));
     gtk_widget_set_name(smt, "modulegroups-popup-item");
     gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(smt), d->full_active);
-    g_signal_connect(G_OBJECT(smt), "toggled",
+    g_signal_connect(smt, "toggled",
                      G_CALLBACK(_manage_direct_full_active_toggled), self);
     gtk_menu_shell_append(GTK_MENU_SHELL(pop), smt);
 
@@ -2919,10 +2919,10 @@ void gui_init(dt_lib_module_t *self)
   dt_action_define(&darktable.view_manager->proxy.darkroom.view->actions, NULL, N_("search modules"), d->text_entry, &dt_action_def_entry);
   gtk_entry_set_placeholder_text(GTK_ENTRY(d->text_entry),
                                  _("search modules by name or tag"));
-  g_signal_connect(G_OBJECT(d->text_entry), "search-changed",
+  g_signal_connect(d->text_entry, "search-changed",
                    G_CALLBACK(_text_entry_changed_callback), self);
-  g_signal_connect(G_OBJECT(d->text_entry), "stop-search",
-                   G_CALLBACK(dt_gui_search_stop), dt_ui_center(darktable.gui->ui));
+  g_signal_connect(GTK_SEARCH_ENTRY(d->text_entry), "stop-search",
+                   G_CALLBACK(dt_gui_search_stop), (GtkTreeView*)dt_ui_center(darktable.gui->ui));
   g_signal_connect_data(G_OBJECT(d->text_entry), "focus-in-event",
                         G_CALLBACK(gtk_widget_show),
                         d->hbox_search_box, NULL, G_CONNECT_AFTER | G_CONNECT_SWAPPED);
@@ -3199,7 +3199,7 @@ static void _manage_editor_group_icon_popup(GtkWidget *btn,
   gtk_box_pack_start(GTK_BOX(hb), ic, FALSE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(hb), gtk_label_new(_("basic icon")), TRUE, TRUE, 0);
   g_object_set_data(G_OBJECT(eb), "ic_name", "basic");
-  g_signal_connect(G_OBJECT(eb), "button-press-event",
+  g_signal_connect(eb, "button-press-event",
                    G_CALLBACK(_manage_editor_group_icon_changed), gr);
   gtk_container_add(GTK_CONTAINER(eb), hb);
   gtk_box_pack_start(GTK_BOX(vb), eb, FALSE, TRUE, 0);
@@ -3210,7 +3210,7 @@ static void _manage_editor_group_icon_popup(GtkWidget *btn,
   gtk_box_pack_start(GTK_BOX(hb), ic, FALSE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(hb), gtk_label_new(_("active icon")), TRUE, TRUE, 0);
   g_object_set_data(G_OBJECT(eb), "ic_name", "active");
-  g_signal_connect(G_OBJECT(eb), "button-press-event",
+  g_signal_connect(eb, "button-press-event",
                    G_CALLBACK(_manage_editor_group_icon_changed), gr);
   gtk_container_add(GTK_CONTAINER(eb), hb);
   gtk_box_pack_start(GTK_BOX(vb), eb, FALSE, TRUE, 0);
@@ -3221,7 +3221,7 @@ static void _manage_editor_group_icon_popup(GtkWidget *btn,
   gtk_box_pack_start(GTK_BOX(hb), ic, FALSE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(hb), gtk_label_new(_("color icon")), TRUE, TRUE, 0);
   g_object_set_data(G_OBJECT(eb), "ic_name", "color");
-  g_signal_connect(G_OBJECT(eb), "button-press-event",
+  g_signal_connect(eb, "button-press-event",
                    G_CALLBACK(_manage_editor_group_icon_changed), gr);
   gtk_container_add(GTK_CONTAINER(eb), hb);
   gtk_box_pack_start(GTK_BOX(vb), eb, FALSE, TRUE, 0);
@@ -3232,7 +3232,7 @@ static void _manage_editor_group_icon_popup(GtkWidget *btn,
   gtk_box_pack_start(GTK_BOX(hb), ic, FALSE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(hb), gtk_label_new(_("correct icon")), TRUE, TRUE, 0);
   g_object_set_data(G_OBJECT(eb), "ic_name", "correct");
-  g_signal_connect(G_OBJECT(eb), "button-press-event",
+  g_signal_connect(eb, "button-press-event",
                    G_CALLBACK(_manage_editor_group_icon_changed), gr);
   gtk_container_add(GTK_CONTAINER(eb), hb);
   gtk_box_pack_start(GTK_BOX(vb), eb, FALSE, TRUE, 0);
@@ -3243,7 +3243,7 @@ static void _manage_editor_group_icon_popup(GtkWidget *btn,
   gtk_box_pack_start(GTK_BOX(hb), ic, FALSE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(hb), gtk_label_new(_("effect icon")), TRUE, TRUE, 0);
   g_object_set_data(G_OBJECT(eb), "ic_name", "effect");
-  g_signal_connect(G_OBJECT(eb), "button-press-event",
+  g_signal_connect(eb, "button-press-event",
                    G_CALLBACK(_manage_editor_group_icon_changed), gr);
   gtk_container_add(GTK_CONTAINER(eb), hb);
   gtk_box_pack_start(GTK_BOX(vb), eb, FALSE, TRUE, 0);
@@ -3254,7 +3254,7 @@ static void _manage_editor_group_icon_popup(GtkWidget *btn,
   gtk_box_pack_start(GTK_BOX(hb), ic, FALSE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(hb), gtk_label_new(_("favorites icon")), TRUE, TRUE, 0);
   g_object_set_data(G_OBJECT(eb), "ic_name", "favorites");
-  g_signal_connect(G_OBJECT(eb), "button-press-event",
+  g_signal_connect(eb, "button-press-event",
                    G_CALLBACK(_manage_editor_group_icon_changed), gr);
   gtk_container_add(GTK_CONTAINER(eb), hb);
   gtk_box_pack_start(GTK_BOX(vb), eb, FALSE, TRUE, 0);
@@ -3265,7 +3265,7 @@ static void _manage_editor_group_icon_popup(GtkWidget *btn,
   gtk_box_pack_start(GTK_BOX(hb), ic, FALSE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(hb), gtk_label_new(_("tone icon")), TRUE, TRUE, 0);
   g_object_set_data(G_OBJECT(eb), "ic_name", "tone");
-  g_signal_connect(G_OBJECT(eb), "button-press-event",
+  g_signal_connect(eb, "button-press-event",
                    G_CALLBACK(_manage_editor_group_icon_changed), gr);
   gtk_container_add(GTK_CONTAINER(eb), hb);
   gtk_box_pack_start(GTK_BOX(vb), eb, FALSE, TRUE, 0);
@@ -3276,7 +3276,7 @@ static void _manage_editor_group_icon_popup(GtkWidget *btn,
   gtk_box_pack_start(GTK_BOX(hb), ic, FALSE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(hb), gtk_label_new(_("grading icon")), TRUE, TRUE, 0);
   g_object_set_data(G_OBJECT(eb), "ic_name", "grading");
-  g_signal_connect(G_OBJECT(eb), "button-press-event",
+  g_signal_connect(eb, "button-press-event",
                    G_CALLBACK(_manage_editor_group_icon_changed), gr);
   gtk_container_add(GTK_CONTAINER(eb), hb);
   gtk_box_pack_start(GTK_BOX(vb), eb, FALSE, TRUE, 0);
@@ -3287,7 +3287,7 @@ static void _manage_editor_group_icon_popup(GtkWidget *btn,
   gtk_box_pack_start(GTK_BOX(hb), ic, FALSE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(hb), gtk_label_new(_("technical icon")), TRUE, TRUE, 0);
   g_object_set_data(G_OBJECT(eb), "ic_name", "technical");
-  g_signal_connect(G_OBJECT(eb), "button-press-event",
+  g_signal_connect(eb, "button-press-event",
                    G_CALLBACK(_manage_editor_group_icon_changed), gr);
   gtk_container_add(GTK_CONTAINER(eb), hb);
   gtk_box_pack_start(GTK_BOX(vb), eb, FALSE, TRUE, 0);
@@ -3345,7 +3345,7 @@ static GtkWidget *_manage_editor_group_init_basics_box(dt_lib_module_t *self)
                                      CPF_DIRECTION_LEFT, NULL);
     gtk_widget_set_tooltip_text(bt, _("add widget to the quick access panel"));
     gtk_widget_set_name(bt, "modulegroups-btn");
-    g_signal_connect(G_OBJECT(bt), "button-press-event",
+    g_signal_connect(bt, "button-press-event",
                      G_CALLBACK(_manage_editor_basics_add_popup), self);
     gtk_widget_set_halign(hb4, GTK_ALIGN_CENTER);
     gtk_box_pack_start(GTK_BOX(hb4), bt, FALSE, FALSE, 0);
@@ -3378,7 +3378,7 @@ static GtkWidget *_manage_editor_group_init_modules_box(dt_lib_module_t *self,
   gtk_widget_set_name(btn, "modulegroups-group-icon");
   gtk_widget_set_tooltip_text(btn, _("group icon"));
   gtk_widget_set_sensitive(btn, !d->edit_ro);
-  g_signal_connect(G_OBJECT(btn), "button-press-event",
+  g_signal_connect(btn, "button-press-event",
                    G_CALLBACK(_manage_editor_group_icon_popup), self);
   g_object_set_data(G_OBJECT(btn), "group", gr);
   gtk_box_pack_start(GTK_BOX(hb3), btn, FALSE, TRUE, 0);
@@ -3389,7 +3389,7 @@ static GtkWidget *_manage_editor_group_init_modules_box(dt_lib_module_t *self,
   gtk_widget_set_tooltip_text(tb, _("group name"));
   g_object_set_data(G_OBJECT(tb), "group", gr);
   gtk_widget_set_sensitive(tb, !d->edit_ro);
-  g_signal_connect(G_OBJECT(tb), "changed",
+  g_signal_connect(tb, "changed",
                    G_CALLBACK(_manage_editor_group_name_changed), self);
   gtk_entry_set_text(GTK_ENTRY(tb), gr->name);
   gtk_box_pack_start(GTK_BOX(hb3), tb, TRUE, TRUE, 0);
@@ -3400,7 +3400,7 @@ static GtkWidget *_manage_editor_group_init_modules_box(dt_lib_module_t *self,
     btn = dtgtk_button_new(dtgtk_cairo_paint_remove, 0, NULL);
     gtk_widget_set_tooltip_text(btn, _("remove group"));
     g_object_set_data(G_OBJECT(btn), "group", gr);
-    g_signal_connect(G_OBJECT(btn), "button-press-event",
+    g_signal_connect(btn, "button-press-event",
                      G_CALLBACK(_manage_editor_group_remove), self);
     gtk_box_pack_end(GTK_BOX(hb3), btn, FALSE, TRUE, 0);
   }
@@ -3428,7 +3428,7 @@ static GtkWidget *_manage_editor_group_init_modules_box(dt_lib_module_t *self,
     gtk_widget_set_name(btn, "modulegroups-btn");
     gtk_widget_set_tooltip_text(btn, _("move group to the left"));
     g_object_set_data(G_OBJECT(btn), "group", gr);
-    g_signal_connect(G_OBJECT(btn), "button-press-event",
+    g_signal_connect(btn, "button-press-event",
                      G_CALLBACK(_manage_editor_group_move_left), self);
     gtk_box_pack_start(GTK_BOX(hb4), btn, FALSE, FALSE, 2);
 
@@ -3439,7 +3439,7 @@ static GtkWidget *_manage_editor_group_init_modules_box(dt_lib_module_t *self,
     gtk_widget_set_tooltip_text(bt, _("add module to the group"));
     gtk_widget_set_name(bt, "modulegroups-btn");
     g_object_set_data(G_OBJECT(bt), "group", gr);
-    g_signal_connect(G_OBJECT(bt), "button-press-event",
+    g_signal_connect(bt, "button-press-event",
                      G_CALLBACK(_manage_editor_module_add_popup), self);
     gtk_widget_set_halign(plusbox, GTK_ALIGN_CENTER);
     gtk_box_pack_start(GTK_BOX(plusbox), bt, FALSE, FALSE, 0);
@@ -3450,7 +3450,7 @@ static GtkWidget *_manage_editor_group_init_modules_box(dt_lib_module_t *self,
     gtk_widget_set_name(btn, "modulegroups-btn");
     gtk_widget_set_tooltip_text(btn, _("move group to the right"));
     g_object_set_data(G_OBJECT(btn), "group", gr);
-    g_signal_connect(G_OBJECT(btn), "button-press-event",
+    g_signal_connect(btn, "button-press-event",
                      G_CALLBACK(_manage_editor_group_move_right), self);
     gtk_box_pack_end(GTK_BOX(hb4), btn, FALSE, FALSE, 2);
 
@@ -3653,7 +3653,7 @@ static void _manage_editor_preset_action(GtkWidget *btn,
                             10 + g_utf8_strlen(gtk_window_get_title(GTK_WINDOW(dialog)),
                                                -1));
   gpointer verify_params[] = {dialog, names, lb};
-  g_signal_connect(G_OBJECT(tb), "changed",
+  g_signal_connect(tb, "changed",
                    G_CALLBACK(_manage_editor_preset_name_verify), verify_params);
   dt_gui_dialog_add(GTK_DIALOG(dialog), gtk_label_new(_("new preset name:")), tb, lb);
   gtk_widget_show_all(dialog);
@@ -3985,7 +3985,7 @@ static void _manage_show_window(dt_lib_module_t *self)
   GtkWidget *hb2 = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
   gtk_box_pack_start(GTK_BOX(hb2), gtk_label_new(_("preset: ")), FALSE, TRUE, 2);
   d->presets_combo = gtk_combo_box_text_new();
-  g_signal_connect(G_OBJECT(d->presets_combo), "changed",
+  g_signal_connect(d->presets_combo, "changed",
                    G_CALLBACK(_manage_preset_change), self);
   gtk_box_pack_start(GTK_BOX(hb2), d->presets_combo, TRUE, TRUE, 2);
   gtk_box_pack_start(GTK_BOX(vb), hb2, FALSE, TRUE, 2);
@@ -4014,11 +4014,11 @@ static void _manage_show_window(dt_lib_module_t *self)
   vb = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
   gtk_widget_set_name(vb, "modulegroups-top-boxes");
   d->edit_search_cb = gtk_check_button_new_with_label(_("show search line"));
-  g_signal_connect(G_OBJECT(d->edit_search_cb), "toggled",
+  g_signal_connect(d->edit_search_cb, "toggled",
                    G_CALLBACK(_manage_editor_search_toggle), self);
   gtk_box_pack_start(GTK_BOX(vb), d->edit_search_cb, FALSE, TRUE, 0);
   d->basics_chkbox = gtk_check_button_new_with_label(_("show quick access panel"));
-  g_signal_connect(G_OBJECT(d->basics_chkbox), "toggled",
+  g_signal_connect(d->basics_chkbox, "toggled",
                    G_CALLBACK(_manage_editor_basics_toggle), self);
   gtk_box_pack_start(GTK_BOX(vb), d->basics_chkbox, FALSE, TRUE, 0);
   d->edit_full_active_cb =
@@ -4027,7 +4027,7 @@ static void _manage_show_window(dt_lib_module_t *self)
       d->edit_full_active_cb,
       _("show modules that are present in the history stack,"
         " regardless of whether or not they are currently enabled"));
-  g_signal_connect(G_OBJECT(d->edit_full_active_cb), "toggled",
+  g_signal_connect(d->edit_full_active_cb, "toggled",
                    G_CALLBACK(_manage_editor_full_active_toggle),
                    self);
   gtk_box_pack_start(GTK_BOX(vb), d->edit_full_active_cb, FALSE, TRUE, 0);
@@ -4040,7 +4040,7 @@ static void _manage_show_window(dt_lib_module_t *self)
   gtk_widget_set_sensitive(d->edit_autoapply_chkbox, FALSE); // always readonly. change are done with the button...
   gtk_box_pack_start(GTK_BOX(hb2), d->edit_autoapply_chkbox, FALSE, TRUE, 0);
   d->edit_autoapply_btn = dtgtk_button_new(dtgtk_cairo_paint_preferences, 0, NULL);
-  g_signal_connect(G_OBJECT(d->edit_autoapply_btn), "clicked",
+  g_signal_connect(d->edit_autoapply_btn, "clicked",
                    G_CALLBACK(_preset_autoapply_edit), self);
   gtk_widget_set_name(d->edit_autoapply_btn, "modulegroups-autoapply-btn");
   gtk_box_pack_start(GTK_BOX(hb2), d->edit_autoapply_btn, FALSE, FALSE, 2);
@@ -4055,7 +4055,7 @@ static void _manage_show_window(dt_lib_module_t *self)
   gtk_box_pack_start(GTK_BOX(hb), gtk_label_new(_("module groups")), FALSE, TRUE, 0);
   d->preset_btn_add_group = dtgtk_button_new(dtgtk_cairo_paint_square_plus,
                                              CPF_DIRECTION_LEFT, NULL);
-  g_signal_connect(G_OBJECT(d->preset_btn_add_group), "button-press-event",
+  g_signal_connect(d->preset_btn_add_group, "button-press-event",
                    G_CALLBACK(_manage_editor_group_add),
                    self);
   gtk_box_pack_start(GTK_BOX(hb), d->preset_btn_add_group, FALSE, FALSE, 0);
@@ -4080,7 +4080,7 @@ static void _manage_show_window(dt_lib_module_t *self)
   hb2 = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
 
   d->preset_reset_btn = gtk_button_new_with_label(_("reset"));
-  g_signal_connect(G_OBJECT(d->preset_reset_btn), "button-press-event",
+  g_signal_connect(d->preset_reset_btn, "button-press-event",
                    G_CALLBACK(_manage_editor_reset), self);
   gtk_box_pack_end(GTK_BOX(hb2), d->preset_reset_btn, FALSE, TRUE, 0);
 

--- a/src/libs/navigation.c
+++ b/src/libs/navigation.c
@@ -214,17 +214,17 @@ void gui_init(dt_lib_module_t *self)
 
   /* connect callbacks */
   gtk_widget_set_app_paintable(thumbnail, TRUE);
-  g_signal_connect(G_OBJECT(thumbnail), "draw",
+  g_signal_connect(thumbnail, "draw",
                    G_CALLBACK(_lib_navigation_draw_callback), self);
-  g_signal_connect(G_OBJECT(thumbnail), "button-press-event",
+  g_signal_connect(thumbnail, "button-press-event",
                    G_CALLBACK(_lib_navigation_button_press_callback), self);
-  g_signal_connect(G_OBJECT(thumbnail), "scroll-event",
+  g_signal_connect(thumbnail, "scroll-event",
                    G_CALLBACK(_lib_navigation_button_press_callback), self);
-  g_signal_connect(G_OBJECT(thumbnail), "button-release-event",
+  g_signal_connect(thumbnail, "button-release-event",
                    G_CALLBACK(_lib_navigation_button_release_callback), self);
-  g_signal_connect(G_OBJECT(thumbnail), "motion-notify-event",
+  g_signal_connect(thumbnail, "motion-notify-event",
                    G_CALLBACK(_lib_navigation_motion_notify_callback), self);
-  g_signal_connect(G_OBJECT(thumbnail), "leave-notify-event",
+  g_signal_connect(thumbnail, "leave-notify-event",
                    G_CALLBACK(_lib_navigation_leave_notify_callback), self);
 
   /* set size of navigation draw area */

--- a/src/libs/print_settings.c
+++ b/src/libs/print_settings.c
@@ -1021,7 +1021,7 @@ _lock_callback(GtkWidget *button, dt_lib_module_t *self)
 }
 
 static void
-_alignment_callback(GtkWidget *tb, dt_lib_module_t *self)
+_alignment_callback(GtkDarktableToggleButton *tb, dt_lib_module_t *self)
 {
   if(darktable.gui->reset) return;
 
@@ -1033,7 +1033,7 @@ _alignment_callback(GtkWidget *tb, dt_lib_module_t *self)
     /* block signal handler */
     g_signal_handlers_block_by_func(ps->dtba[i],_alignment_callback, self);
 
-    if(GTK_WIDGET(ps->dtba[i]) == tb)
+    if(ps->dtba[i] == tb)
     {
       gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(ps->dtba[i]), TRUE);
       index=i;
@@ -2484,7 +2484,7 @@ void gui_init(dt_lib_module_t *self)
   d->printers = dt_bauhaus_combobox_new_action(DT_ACTION(self));
 
   gtk_box_pack_start(GTK_BOX(self->widget), d->printers, TRUE, TRUE, 0);
-  g_signal_connect(G_OBJECT(d->printers), "value-changed",
+  g_signal_connect(d->printers, "value-changed",
                    G_CALLBACK(_printer_changed), self);
 
   //// media
@@ -2493,7 +2493,7 @@ void gui_init(dt_lib_module_t *self)
 
   dt_bauhaus_widget_set_label(d->media, N_("printer"), N_("media"));
 
-  g_signal_connect(G_OBJECT(d->media), "value-changed",
+  g_signal_connect(d->media, "value-changed",
                    G_CALLBACK(_media_changed), self);
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(d->media), TRUE, TRUE, 0);
 
@@ -2549,8 +2549,8 @@ void gui_init(dt_lib_module_t *self)
   gtk_widget_set_tooltip_markup(d->pprofile, tooltip);
   g_free(tooltip);
 
-  g_signal_connect(G_OBJECT(d->pprofile), "value-changed",
-                   G_CALLBACK(_printer_profile_changed), (gpointer)self);
+  g_signal_connect(d->pprofile, "value-changed",
+                   G_CALLBACK(_printer_profile_changed), self);
 
   //  Add printer intent combo
 
@@ -2570,7 +2570,7 @@ void gui_init(dt_lib_module_t *self)
   gtk_box_pack_start(GTK_BOX(self->widget),
                      GTK_WIDGET(d->black_point_compensation), TRUE, FALSE, 0);
   g_signal_connect(d->black_point_compensation, "toggled",
-                   G_CALLBACK(_printer_bpc_callback), (gpointer)self);
+                   G_CALLBACK(_printer_bpc_callback), self);
 
   d->v_black_point_compensation =
     dt_conf_get_bool(PRINT_CONFIG_PREFIX "black_point_compensation");
@@ -2594,7 +2594,7 @@ void gui_init(dt_lib_module_t *self)
 
   dt_bauhaus_widget_set_label(d->papers, NULL, N_("paper size"));
 
-  g_signal_connect(G_OBJECT(d->papers), "value-changed", G_CALLBACK(_paper_changed), self);
+  g_signal_connect(d->papers, "value-changed", G_CALLBACK(_paper_changed), self);
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(d->papers), TRUE, TRUE, 0);
 
   //// portrait / landscape
@@ -2677,15 +2677,15 @@ void gui_init(dt_lib_module_t *self)
   gtk_spin_button_set_value(GTK_SPIN_BUTTON(d->b_left), left_b);
   gtk_spin_button_set_value(GTK_SPIN_BUTTON(d->b_right), right_b);
 
-  g_signal_connect(G_OBJECT (d->b_top), "value-changed",
+  g_signal_connect(d->b_top, "value-changed",
                    G_CALLBACK (_top_border_callback), self);
-  g_signal_connect(G_OBJECT (d->b_bottom), "value-changed",
+  g_signal_connect(d->b_bottom, "value-changed",
                    G_CALLBACK (_bottom_border_callback), self);
-  g_signal_connect(G_OBJECT (d->b_left), "value-changed",
+  g_signal_connect(d->b_left, "value-changed",
                    G_CALLBACK (_left_border_callback), self);
-  g_signal_connect(G_OBJECT (d->b_right), "value-changed",
+  g_signal_connect(d->b_right, "value-changed",
                    G_CALLBACK (_right_border_callback), self);
-  g_signal_connect(G_OBJECT(d->lock_button), "toggled",
+  g_signal_connect(d->lock_button, "toggled",
                    G_CALLBACK(_lock_callback), self);
 
   gtk_widget_set_halign(GTK_WIDGET(hboxdim), GTK_ALIGN_CENTER);
@@ -2715,12 +2715,12 @@ void gui_init(dt_lib_module_t *self)
 
     gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(vbox), TRUE, TRUE, 0);
 
-    g_signal_connect(G_OBJECT(d->grid_size), "value-changed",
+    g_signal_connect(d->grid_size, "value-changed",
                      G_CALLBACK(_grid_size_changed), self);
-    g_signal_connect(G_OBJECT(d->grid), "toggled",
+    g_signal_connect(d->grid, "toggled",
                      G_CALLBACK(_grid_callback), self);
     g_signal_connect(d->snap_grid, "toggled",
-                     G_CALLBACK(_snap_grid_callback), (gpointer)self);
+                     G_CALLBACK(_snap_grid_callback), self);
   }
 
   d->borderless = gtk_check_button_new_with_label(_("borderless mode required"));
@@ -2752,8 +2752,8 @@ void gui_init(dt_lib_module_t *self)
         = DTGTK_TOGGLEBUTTON(dtgtk_togglebutton_new(dtgtk_cairo_paint_alignment,
                                                     (CPF_SPECIAL_FLAG << i), NULL));
     gtk_grid_attach (GTK_GRID (bat), GTK_WIDGET (d->dtba[i]), (i%3), i/3, 1, 1);
-    g_signal_connect (G_OBJECT (d->dtba[i]), "toggled",
-                      G_CALLBACK (_alignment_callback), self);
+    g_signal_connect(d->dtba[i], "toggled",
+                     G_CALLBACK (_alignment_callback), self);
   }
 
   GtkWidget *hbox22 = gtk_box_new(GTK_ORIENTATION_HORIZONTAL,0);
@@ -2838,14 +2838,14 @@ void gui_init(dt_lib_module_t *self)
   gtk_widget_add_events(d->b_width, GDK_BUTTON_PRESS_MASK);
   gtk_widget_add_events(d->b_height, GDK_BUTTON_PRESS_MASK);
 
-  g_signal_connect(G_OBJECT(d->b_x), "value-changed",
-                   G_CALLBACK(_x_changed), (gpointer)d);
-  g_signal_connect(G_OBJECT(d->b_y), "value-changed",
-                   G_CALLBACK(_y_changed), (gpointer)d);
-  g_signal_connect(G_OBJECT(d->b_width), "value-changed",
-                   G_CALLBACK(_width_changed), (gpointer)d);
-  g_signal_connect(G_OBJECT(d->b_height), "value-changed",
-                   G_CALLBACK(_height_changed), (gpointer)d);
+  g_signal_connect(d->b_x, "value-changed",
+                   G_CALLBACK(_x_changed), d);
+  g_signal_connect(d->b_y, "value-changed",
+                   G_CALLBACK(_y_changed), d);
+  g_signal_connect(d->b_width, "value-changed",
+                   G_CALLBACK(_width_changed), d);
+  g_signal_connect(d->b_height, "value-changed",
+                   G_CALLBACK(_height_changed), d);
 
   ////////////////////////// PRINT SETTINGS
 
@@ -2897,8 +2897,8 @@ void gui_init(dt_lib_module_t *self)
   gtk_widget_set_tooltip_markup(d->profile, tooltip);
   g_free(tooltip);
 
-  g_signal_connect(G_OBJECT(d->profile), "value-changed",
-                   G_CALLBACK(_profile_changed), (gpointer)self);
+  g_signal_connect(d->profile, "value-changed",
+                   G_CALLBACK(_profile_changed), self);
 
   //  Add export intent combo
 
@@ -2918,7 +2918,7 @@ void gui_init(dt_lib_module_t *self)
 
   GtkWidget *styles_button = dtgtk_button_new(dtgtk_cairo_paint_styles, 0, NULL);
   gtk_widget_set_halign(styles_button,GTK_ALIGN_END);
-  g_signal_connect(G_OBJECT(styles_button), "clicked", G_CALLBACK(_style_popupmenu_callback), (gpointer)d);
+  g_signal_connect(styles_button, "clicked", G_CALLBACK(_style_popupmenu_callback), d);
   gtk_widget_set_tooltip_text(styles_button, _("select style to be applied on printing"));
   GtkBox *style_box = (GtkBox*)gtk_box_new(GTK_ORIENTATION_HORIZONTAL,0);
   gtk_widget_set_tooltip_text(GTK_WIDGET(style_box), _("temporary style to use while printing"));

--- a/src/libs/recentcollect.c
+++ b/src/libs/recentcollect.c
@@ -278,7 +278,7 @@ void _menuitem_preferences(GtkMenuItem *menuitem, dt_lib_module_t *self)
           d->items = g_list_append(d->items, item);
           item->button = gtk_button_new();
           gtk_box_pack_start(GTK_BOX(box), item->button, FALSE, TRUE, 0);
-          g_signal_connect(G_OBJECT(item->button), "clicked", G_CALLBACK(_button_pressed), (gpointer)self);
+          g_signal_connect(item->button, "clicked", G_CALLBACK(_button_pressed), (gpointer)self);
           gtk_widget_set_no_show_all(item->button, TRUE);
           gtk_widget_set_name(GTK_WIDGET(item->button), "recent-collection-button");
           gtk_widget_set_visible(item->button, FALSE);
@@ -295,7 +295,7 @@ void _menuitem_preferences(GtkMenuItem *menuitem, dt_lib_module_t *self)
 void set_preferences(void *menu, dt_lib_module_t *self)
 {
   GtkWidget *mi = gtk_menu_item_new_with_label(_("preferences..."));
-  g_signal_connect(G_OBJECT(mi), "activate", G_CALLBACK(_menuitem_preferences), self);
+  g_signal_connect(mi, "activate", G_CALLBACK(_menuitem_preferences), self);
   gtk_menu_shell_append(GTK_MENU_SHELL(menu), mi);
 }
 
@@ -333,7 +333,7 @@ void gui_init(dt_lib_module_t *self)
     d->items = g_list_append(d->items, item);
     item->button = gtk_button_new();
     gtk_box_pack_start(GTK_BOX(box), item->button, FALSE, TRUE, 0);
-    g_signal_connect(G_OBJECT(item->button), "clicked", G_CALLBACK(_button_pressed), (gpointer)self);
+    g_signal_connect(GTK_BUTTON(item->button), "clicked", G_CALLBACK(_button_pressed), self);
     gtk_widget_set_no_show_all(item->button, TRUE);
     dt_gui_add_class(GTK_WIDGET(item->button), "dt_transparent_background");
     gtk_widget_set_name(GTK_WIDGET(item->button), "recent-collection-button");

--- a/src/libs/select.c
+++ b/src/libs/select.c
@@ -259,7 +259,7 @@ static int lua_register_selection(lua_State *L)
   lua_callback_data * data = malloc(sizeof(lua_callback_data));
   data->key = strdup(name);
   data->self = self;
-  gulong s = g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(lua_button_clicked), data);
+  gulong s = g_signal_connect_data(button, "clicked", G_CALLBACK(lua_button_clicked), data, NULL, 0);
 
   dt_lua_module_entry_push(L, "lib", self->plugin_name);
   lua_getiuservalue(L, -1, 1);

--- a/src/libs/session.c
+++ b/src/libs/session.c
@@ -107,7 +107,7 @@ void gui_init(dt_lib_module_t *self)
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(hbox), TRUE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(lib->gui.button1), TRUE, TRUE, 0);
 
-  g_signal_connect(G_OBJECT(lib->gui.button1), "clicked", G_CALLBACK(create_callback), self);
+  g_signal_connect(lib->gui.button1, "clicked", G_CALLBACK(create_callback), self);
 
   const char *str = dt_conf_get_string_const("plugins/session/jobcode");
   gtk_entry_set_text(lib->gui.entry1, str);

--- a/src/libs/snapshots.c
+++ b/src/libs/snapshots.c
@@ -577,9 +577,9 @@ static void _init_snapshot_entry(dt_lib_module_t *self,
   /* create snapshot button */
   s->button = gtk_toggle_button_new();
   gtk_widget_set_name(s->button, "snapshot-button");
-  g_signal_connect(G_OBJECT(s->button), "toggled",
+  g_signal_connect(s->button, "toggled",
                    G_CALLBACK(_lib_snapshots_toggled_callback), self);
-  g_signal_connect(G_OBJECT(s->button), "button-press-event",
+  g_signal_connect(s->button, "button-press-event",
                    G_CALLBACK(_lib_button_button_pressed_callback), self);
 
   s->num = gtk_label_new("");
@@ -595,14 +595,14 @@ static void _init_snapshot_entry(dt_lib_module_t *self,
 
   s->entry = gtk_entry_new();
   gtk_widget_set_halign(s->entry, GTK_ALIGN_FILL);
-  g_signal_connect(G_OBJECT(s->entry), "activate",
+  g_signal_connect(s->entry, "activate",
                    G_CALLBACK(_entry_activated_callback), self);
 
   s->restore_button = dtgtk_button_new(dtgtk_cairo_paint_snapshots_restore, CPF_NONE, NULL);
   gtk_widget_set_name(s->restore_button, "non-flat");
   gtk_widget_set_tooltip_text(s->restore_button,
                               _("restore snapshot into current history"));
-  g_signal_connect(G_OBJECT(s->restore_button), "clicked",
+  g_signal_connect(s->restore_button, "clicked",
                    G_CALLBACK(_lib_snapshots_restore_callback), self);
 }
 
@@ -865,7 +865,7 @@ void gui_init(dt_lib_module_t *self)
   gtk_box_pack_start(GTK_BOX(hbox), d->take_button, TRUE, TRUE, 0);
   d->sidebyside_button = dtgtk_togglebutton_new(dtgtk_cairo_paint_lt_mode_culling_dynamic, 0, NULL);
   gtk_box_pack_start(GTK_BOX(hbox), d->sidebyside_button, FALSE, TRUE, 0);
-  g_signal_connect(G_OBJECT(d->sidebyside_button), "clicked",
+  g_signal_connect(d->sidebyside_button, "clicked",
                    G_CALLBACK(_sidebyside_button_clicked), self);
   gtk_widget_set_tooltip_text(GTK_WIDGET(d->sidebyside_button),
                               _("place the snapshot side-by-side / above-below the current image instead of overlaying"));

--- a/src/libs/styles.c
+++ b/src/libs/styles.c
@@ -734,13 +734,12 @@ static void _import_clicked(GtkWidget *w, dt_lib_styles_t *d)
   g_object_unref(filechooser);
 }
 
-static gboolean _entry_callback(GtkEntry *entry, dt_lib_styles_t *d)
+static void _entry_callback(GtkEntry *entry, dt_lib_styles_t *d)
 {
   _gui_styles_update_view(d);
-  return FALSE;
 }
 
-static gboolean _entry_activated(GtkEntry *entry, dt_lib_styles_t *d)
+static void _entry_activated(GtkEntry *entry, dt_lib_styles_t *d)
 {
   const gchar *name = gtk_entry_get_text(d->entry);
   if(name)
@@ -753,15 +752,12 @@ static gboolean _entry_activated(GtkEntry *entry, dt_lib_styles_t *d)
       dt_control_apply_styles(imgs, styles, duplicate);
     }
   }
-
-  return FALSE;
 }
 
-static gboolean _duplicate_callback(GtkEntry *entry, dt_lib_styles_t *d)
+static void _duplicate_callback(GtkWidget *entry, dt_lib_styles_t *d)
 {
   dt_conf_set_bool("ui_last/styles_create_duplicate",
                    gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(d->duplicate)));
-  return FALSE;
 }
 
 static void _applymode_combobox_changed(GtkWidget *widget, gpointer user_data)

--- a/src/libs/tagging.c
+++ b/src/libs/tagging.c
@@ -1414,7 +1414,7 @@ static void _pop_menu_attached(GtkWidget *treeview,
     {
       menuitem = gtk_menu_item_new_with_label(_("attach tag to all"));
       g_signal_connect(menuitem, "activate",
-                       (GCallback)_pop_menu_attached_attach_to_all, self);
+                       G_CALLBACK(_pop_menu_attached_attach_to_all), self);
       gtk_menu_shell_append(GTK_MENU_SHELL(menu), menuitem);
       menuitem = gtk_separator_menu_item_new();
       gtk_menu_shell_append(GTK_MENU_SHELL(menu), menuitem);
@@ -1423,15 +1423,15 @@ static void _pop_menu_attached(GtkWidget *treeview,
 
   menuitem = gtk_menu_item_new_with_label(_("detach tag"));
   gtk_menu_shell_append(GTK_MENU_SHELL(menu), menuitem);
-  g_signal_connect(menuitem, "activate", (GCallback)_pop_menu_attached_detach, self);
+  g_signal_connect(menuitem, "activate", G_CALLBACK(_pop_menu_attached_detach), self);
 
   menuitem = gtk_menu_item_new_with_label(_("find tag"));
   gtk_menu_shell_append(GTK_MENU_SHELL(menu), menuitem);
-  g_signal_connect(menuitem, "activate", (GCallback)_pop_menu_attached_find, self);
+  g_signal_connect(menuitem, "activate", G_CALLBACK(_pop_menu_attached_find), self);
 
   menuitem = gtk_menu_item_new_with_label(_("copy to clipboard"));
   gtk_menu_shell_append(GTK_MENU_SHELL(menu), menuitem);
-  g_signal_connect(menuitem, "activate", (GCallback)_pop_menu_attached_clipboard, self);
+  g_signal_connect(menuitem, "activate", G_CALLBACK(_pop_menu_attached_clipboard), self);
 
   gtk_widget_show_all(GTK_WIDGET(menu));
 
@@ -2494,12 +2494,12 @@ static void _pop_menu_dictionary(GtkWidget *treeview,
     {
       menuitem = gtk_menu_item_new_with_label(_("attach tag"));
       g_signal_connect(menuitem, "activate",
-                       (GCallback)_pop_menu_dictionary_attach_tag, self);
+                       G_CALLBACK(_pop_menu_dictionary_attach_tag), self);
       gtk_menu_shell_append(GTK_MENU_SHELL(menu), menuitem);
 
       menuitem = gtk_menu_item_new_with_label(_("detach tag"));
       g_signal_connect(menuitem, "activate",
-                       (GCallback)_pop_menu_dictionary_detach_tag, self);
+                       G_CALLBACK(_pop_menu_dictionary_detach_tag), self);
       gtk_menu_shell_append(GTK_MENU_SHELL(menu), menuitem);
 
       menuitem = gtk_separator_menu_item_new();
@@ -2510,14 +2510,14 @@ static void _pop_menu_dictionary(GtkWidget *treeview,
       menuitem = gtk_menu_item_new_with_label(_("create tag..."));
       gtk_menu_shell_append(GTK_MENU_SHELL(menu), menuitem);
       g_signal_connect(menuitem, "activate",
-                       (GCallback)_pop_menu_dictionary_create_tag, self);
+                       G_CALLBACK(_pop_menu_dictionary_create_tag), self);
 
       if(tagid)
       {
         menuitem = gtk_menu_item_new_with_label(_("delete tag"));
         gtk_menu_shell_append(GTK_MENU_SHELL(menu), menuitem);
         g_signal_connect(menuitem, "activate",
-                         (GCallback)_pop_menu_dictionary_delete_tag, self);
+                         G_CALLBACK(_pop_menu_dictionary_delete_tag), self);
       }
 
       if(gtk_tree_model_iter_children(model, &child, &iter))
@@ -2525,13 +2525,13 @@ static void _pop_menu_dictionary(GtkWidget *treeview,
         menuitem = gtk_menu_item_new_with_label(_("delete node"));
         gtk_menu_shell_append(GTK_MENU_SHELL(menu), menuitem);
         g_signal_connect(menuitem, "activate",
-                         (GCallback)_pop_menu_dictionary_delete_node, self);
+                         G_CALLBACK(_pop_menu_dictionary_delete_node), self);
       }
 
       menuitem = gtk_menu_item_new_with_label(_("edit..."));
       gtk_menu_shell_append(GTK_MENU_SHELL(menu), menuitem);
       g_signal_connect(menuitem, "activate",
-                       (GCallback)_pop_menu_dictionary_edit_tag, self);
+                       G_CALLBACK(_pop_menu_dictionary_edit_tag), self);
     }
 
     if(d->tree_flag)
@@ -2539,7 +2539,7 @@ static void _pop_menu_dictionary(GtkWidget *treeview,
       menuitem = gtk_menu_item_new_with_label(_("change path..."));
       gtk_menu_shell_append(GTK_MENU_SHELL(menu), menuitem);
       g_signal_connect(menuitem, "activate",
-                       (GCallback)_pop_menu_dictionary_change_path, self);
+                       G_CALLBACK(_pop_menu_dictionary_change_path), self);
     }
 
     if(d->tree_flag && !tagid)
@@ -2550,7 +2550,7 @@ static void _pop_menu_dictionary(GtkWidget *treeview,
       menuitem = gtk_menu_item_new_with_label(_("set as a tag"));
       gtk_menu_shell_append(GTK_MENU_SHELL(menu), menuitem);
       g_signal_connect(menuitem, "activate",
-                       (GCallback)_pop_menu_dictionary_set_as_tag, self);
+                       G_CALLBACK(_pop_menu_dictionary_set_as_tag), self);
     }
 
     if(!d->suggestion_flag)
@@ -2561,13 +2561,13 @@ static void _pop_menu_dictionary(GtkWidget *treeview,
 
     menuitem = gtk_menu_item_new_with_label(_("copy to entry"));
     g_signal_connect(menuitem, "activate",
-                     (GCallback)_pop_menu_dictionary_copy_tag, self);
+                     G_CALLBACK(_pop_menu_dictionary_copy_tag), self);
     gtk_menu_shell_append(GTK_MENU_SHELL(menu), menuitem);
 
     menuitem = gtk_menu_item_new_with_label(_("copy to clipboard"));
     gtk_menu_shell_append(GTK_MENU_SHELL(menu), menuitem);
     g_signal_connect(menuitem, "activate",
-                     (GCallback)_pop_menu_dictionary_clipboard, self);
+                     G_CALLBACK(_pop_menu_dictionary_clipboard), self);
 
     if(d->collection[0])
     {
@@ -2587,14 +2587,14 @@ static void _pop_menu_dictionary(GtkWidget *treeview,
       {
         menuitem = gtk_menu_item_new_with_label(_("go to tag collection"));
         g_signal_connect(menuitem, "activate",
-                         (GCallback)_pop_menu_dictionary_goto_tag_collection, self);
+                         G_CALLBACK(_pop_menu_dictionary_goto_tag_collection), self);
         gtk_menu_shell_append(GTK_MENU_SHELL(menu), menuitem);
       }
       if(d->collection[0])
       {
         menuitem = gtk_menu_item_new_with_label(_("go back to work"));
         g_signal_connect(menuitem, "activate",
-                         (GCallback)_pop_menu_dictionary_goto_collection_back, self);
+                         G_CALLBACK(_pop_menu_dictionary_goto_collection_back), self);
         gtk_menu_shell_append(GTK_MENU_SHELL(menu), menuitem);
       }
     }
@@ -3470,8 +3470,8 @@ void gui_init(dt_lib_module_t *self)
      DT_TAG_SORT_COUNT_ID, (GtkTreeIterCompareFunc)_sort_tree_count_func, self, NULL);
   d->attached_liststore = liststore;
   g_object_set(G_OBJECT(view), "has-tooltip", TRUE, NULL);
-  g_signal_connect(G_OBJECT(view), "query-tooltip",
-                   G_CALLBACK(_row_tooltip_setup), (gpointer)self);
+  g_signal_connect(view, "query-tooltip",
+                   G_CALLBACK(_row_tooltip_setup), self);
 
   col = gtk_tree_view_column_new();
   gtk_tree_view_append_column(view, col);
@@ -3487,7 +3487,7 @@ void gui_init(dt_lib_module_t *self)
   gtk_tree_view_column_pack_start(col, renderer, TRUE);
   gtk_tree_view_column_set_cell_data_func(col, renderer,
                                           _tree_tagname_show_attached,
-                                          (gpointer)self, NULL);
+                                          self, NULL);
 
   gtk_tree_selection_set_mode(gtk_tree_view_get_selection(view), GTK_SELECTION_SINGLE);
   gtk_tree_view_set_model(view, GTK_TREE_MODEL(liststore));
@@ -3498,10 +3498,10 @@ void gui_init(dt_lib_module_t *self)
        "\npress Delete or double-click to detach"
        "\nright-click for other actions on attached tag,"
        "\nTab to give the focus to entry"));
-  g_signal_connect(G_OBJECT(view), "button-press-event",
-                   G_CALLBACK(_click_on_view_attached), (gpointer)self);
-  g_signal_connect(G_OBJECT(view), "key-press-event",
-                   G_CALLBACK(_attached_key_pressed), (gpointer)self);
+  g_signal_connect(view, "button-press-event",
+                   G_CALLBACK(_click_on_view_attached), self);
+  g_signal_connect(view, "key-press-event",
+                   G_CALLBACK(_attached_key_pressed), self);
   g_signal_connect(gtk_tree_view_get_selection(view), "changed",
                    G_CALLBACK(_tree_selection_changed), self);
 
@@ -3524,7 +3524,7 @@ void gui_init(dt_lib_module_t *self)
   button = dtgtk_togglebutton_new(paint, 0, NULL);                           \
   gtk_widget_set_tooltip_text(button, tooltip);                              \
   gtk_box_pack_end(hbox, button, FALSE, TRUE, 0);                            \
-  g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(callback), self); \
+  g_signal_connect(button, "clicked", G_CALLBACK(callback), self);           \
   dt_action_define(toggle, NULL, action, button, &dt_action_def_toggle);
 
   d->toggle_hide_button = NEW_TOGGLE_BUTTON
@@ -3558,17 +3558,17 @@ void gui_init(dt_lib_module_t *self)
        "\npress shift+Tab to select the first attached user tag"));
   gtk_box_pack_start(hbox, w, TRUE, TRUE, 0);
   gtk_widget_add_events(GTK_WIDGET(w), GDK_KEY_RELEASE_MASK);
-  g_signal_connect(G_OBJECT(w), "changed",
-                   G_CALLBACK(_tag_name_changed), (gpointer)self);
-  g_signal_connect(G_OBJECT(w), "key-press-event",
-                   G_CALLBACK(_enter_key_pressed), (gpointer)self);
+  g_signal_connect(w, "changed",
+                   G_CALLBACK(_tag_name_changed), self);
+  g_signal_connect(w, "key-press-event",
+                   G_CALLBACK(_enter_key_pressed), self);
   d->entry = GTK_ENTRY(w);
 
   button = dtgtk_button_new(dtgtk_cairo_paint_multiply_small, 0, NULL);
   gtk_widget_set_tooltip_text(button, _("clear entry"));
   gtk_box_pack_end(hbox, button, FALSE, TRUE, 0);
-  g_signal_connect(G_OBJECT(button), "clicked",
-                   G_CALLBACK(_clear_entry_button_callback), (gpointer)self);
+  g_signal_connect(button, "clicked",
+                   G_CALLBACK(_clear_entry_button_callback), self);
   gtk_box_pack_start(box, GTK_WIDGET(hbox), FALSE, TRUE, 0);
   dt_gui_add_class(GTK_WIDGET(box), "dt_spacing_sw");
   d->clear_button = button;
@@ -3625,7 +3625,7 @@ void gui_init(dt_lib_module_t *self)
   g_object_set(renderer, "ellipsize", PANGO_ELLIPSIZE_MIDDLE, (gchar *)0);
   gtk_tree_view_column_pack_start(col, renderer, TRUE);
   gtk_tree_view_column_set_cell_data_func(col, renderer,
-                                          _tree_tagname_show_dictionary, (gpointer)self, NULL);
+                                          _tree_tagname_show_dictionary, self, NULL);
   gtk_tree_view_set_expander_column(view, col);
 
   gtk_tree_selection_set_mode(gtk_tree_view_get_selection(view), GTK_SELECTION_SINGLE);
@@ -3638,15 +3638,15 @@ void gui_init(dt_lib_module_t *self)
        "\nright-click for other actions on selected tag"
        "\nshift+Tab to give the focus to entry"));
 
-  g_signal_connect(G_OBJECT(view), "button-press-event",
-                   G_CALLBACK(_click_on_view_dictionary), (gpointer)self);
-  g_signal_connect(G_OBJECT(view), "key-press-event",
-                   G_CALLBACK(_dictionary_key_pressed), (gpointer)self);
+  g_signal_connect(view, "button-press-event",
+                   G_CALLBACK(_click_on_view_dictionary), self);
+  g_signal_connect(view, "key-press-event",
+                   G_CALLBACK(_dictionary_key_pressed), self);
   gtk_tree_view_set_model(view, GTK_TREE_MODEL(d->dictionary_listfilter));
   g_object_unref(d->dictionary_listfilter);
   g_object_set(G_OBJECT(view), "has-tooltip", TRUE, NULL);
-  g_signal_connect(G_OBJECT(view), "query-tooltip",
-                   G_CALLBACK(_row_tooltip_setup), (gpointer)self);
+  g_signal_connect(view, "query-tooltip",
+                   G_CALLBACK(_row_tooltip_setup), self);
   g_signal_connect(gtk_tree_view_get_selection(view), "changed",
                    G_CALLBACK(_tree_selection_changed), self);
 
@@ -3848,7 +3848,7 @@ static void _lib_tagging_tag_show(dt_action_t *action)
   gtk_entry_completion_set_text_column(completion, DT_LIB_TAGGING_COL_PATH);
   gtk_entry_completion_set_inline_completion(completion, TRUE);
   gtk_entry_completion_set_popup_set_width(completion, FALSE);
-  g_signal_connect(G_OBJECT(completion), "match-selected",
+  g_signal_connect(completion, "match-selected",
                    G_CALLBACK(_match_selected_func), self);
   gtk_entry_completion_set_match_func(completion, _completion_match_func, NULL, NULL);
   gtk_entry_set_completion(GTK_ENTRY(entry), completion);
@@ -3967,7 +3967,7 @@ void _menuitem_preferences(GtkMenuItem *menuitem,
 void set_preferences(void *menu, dt_lib_module_t *self)
 {
   GtkWidget *mi = gtk_menu_item_new_with_label(_("preferences..."));
-  g_signal_connect(G_OBJECT(mi), "activate", G_CALLBACK(_menuitem_preferences), self);
+  g_signal_connect(mi, "activate", G_CALLBACK(_menuitem_preferences), self);
   gtk_menu_shell_append(GTK_MENU_SHELL(menu), mi);
 }
 

--- a/src/libs/tools/colorlabels.c
+++ b/src/libs/tools/colorlabels.c
@@ -44,9 +44,9 @@ typedef struct dt_lib_colorlabels_t
 } dt_lib_colorlabels_t;
 
 /* callback when a colorlabel button is clicked */
-static void _lib_colorlabels_button_clicked_callback(GtkWidget *w,
-                                                     GdkEventButton *event,
-                                                     dt_lib_module_t *self);
+static gboolean _lib_colorlabels_button_clicked_callback(GtkWidget *w,
+                                                         GdkEventButton *event,
+                                                         dt_lib_module_t *self);
 
 gint _get_colorlabel(dt_lib_module_t *self, GtkWidget *w)
 {
@@ -136,10 +136,10 @@ void gui_init(dt_lib_module_t *self)
     gtk_widget_set_tooltip_markup(button, tooltip);
     g_free(tooltip);
     gtk_box_pack_start(GTK_BOX(self->widget), button, TRUE, TRUE, 0);
-    g_signal_connect(G_OBJECT(button), "button-press-event",
+    g_signal_connect(button, "button-press-event",
                      G_CALLBACK(_lib_colorlabels_button_clicked_callback),
                      self);
-    g_signal_connect(G_OBJECT(button), "enter-notify-event",
+    g_signal_connect(button, "enter-notify-event",
                      G_CALLBACK(_lib_colorlabels_enter_notify_callback),
                      self);
     ac = dt_action_define(&darktable.control->actions_thumb, NULL,
@@ -267,9 +267,9 @@ static void _lib_colorlabels_edit(dt_lib_module_t *self,
   }
 }
 
-static void _lib_colorlabels_button_clicked_callback(GtkWidget *w,
-                                                     GdkEventButton *event,
-                                                     dt_lib_module_t *self)
+static gboolean _lib_colorlabels_button_clicked_callback(GtkWidget *w,
+                                                         GdkEventButton *event,
+                                                         dt_lib_module_t *self)
 {
   dt_lib_colorlabels_t *d = self->data;
 
@@ -290,6 +290,7 @@ static void _lib_colorlabels_button_clicked_callback(GtkWidget *w,
                                DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_COLORLABEL,
                                imgs);
   }
+  return TRUE;
 }
 
 // clang-format off

--- a/src/libs/tools/darktable.c
+++ b/src/libs/tools/darktable.c
@@ -94,9 +94,9 @@ void gui_init(dt_lib_module_t *self)
   self->widget = gtk_event_box_new();
 
   /* connect callbacks */
-  g_signal_connect(G_OBJECT(self->widget), "draw",
+  g_signal_connect(self->widget, "draw",
                    G_CALLBACK(_lib_darktable_draw_callback), self);
-  g_signal_connect(G_OBJECT(self->widget), "button-press-event",
+  g_signal_connect(self->widget, "button-press-event",
                    G_CALLBACK(_lib_darktable_button_press_callback), self);
 
   /* create a cairo surface of dt icon */

--- a/src/libs/tools/filmstrip.c
+++ b/src/libs/tools/filmstrip.c
@@ -91,7 +91,7 @@ void gui_init(dt_lib_module_t *self)
   self->widget = gtk_event_box_new();
 
   /* connect callbacks */
-  g_signal_connect(G_OBJECT(self->widget), "draw",
+  g_signal_connect(self->widget, "draw",
                    G_CALLBACK(_lib_filmstrip_draw_callback), self);
 
   /* initialize view manager proxy */

--- a/src/libs/tools/filter.c
+++ b/src/libs/tools/filter.c
@@ -102,7 +102,7 @@ void gui_init(dt_lib_module_t *self)
 
   GtkWidget *bt = dtgtk_button_new(dtgtk_cairo_paint_filtering_menu, 0, NULL);
   gtk_widget_set_tooltip_text(bt, _("filter preferences"));
-  g_signal_connect(G_OBJECT(bt), "button-press-event", G_CALLBACK(_pref_show), self);
+  g_signal_connect(bt, "button-press-event", G_CALLBACK(_pref_show), self);
   gtk_box_pack_start(GTK_BOX(self->widget), bt, FALSE, TRUE, 0);
 
   d->filter_box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);

--- a/src/libs/tools/global_toolbox.c
+++ b/src/libs/tools/global_toolbox.c
@@ -393,7 +393,7 @@ void gui_init(dt_lib_module_t *self)
   else
     gtk_widget_set_tooltip_text(d->grouping_button, _("collapse grouped images"));
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->grouping_button), darktable.gui->grouping);
-  g_signal_connect(G_OBJECT(d->grouping_button), "clicked", G_CALLBACK(_lib_filter_grouping_button_clicked),
+  g_signal_connect(d->grouping_button, "clicked", G_CALLBACK(_lib_filter_grouping_button_clicked),
                    NULL);
 
   /* create the "show/hide overlays" button */
@@ -403,18 +403,18 @@ void gui_init(dt_lib_module_t *self)
   d->over_popup = gtk_popover_new(d->overlays_button);
   gtk_widget_set_size_request(d->over_popup, 350, -1);
   g_object_set(G_OBJECT(d->over_popup), "transitions-enabled", FALSE, NULL);
-  g_signal_connect(G_OBJECT(d->overlays_button), "clicked", G_CALLBACK(_overlays_show_popup), self);
+  g_signal_connect(d->overlays_button, "clicked", G_CALLBACK(_overlays_show_popup), self);
   // we register size of overlay icon to keep in sync thumbtable overlays
-  g_signal_connect(G_OBJECT(d->overlays_button), "size-allocate", G_CALLBACK(_main_icons_register_size), NULL);
+  g_signal_connect(d->overlays_button, "size-allocate", G_CALLBACK(_main_icons_register_size), NULL);
 
   GtkWidget *vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
 
   gtk_container_add(GTK_CONTAINER(d->over_popup), vbox);
 
-#define NEW_RADIO(widget, box, callback, label)                                               \
+#define NEW_RADIO(widget, box, callback, label)                                     \
   rb = gtk_radio_button_new_with_label_from_widget(GTK_RADIO_BUTTON(rb), _(label)); \
   dt_action_define(ac, NULL, label, rb, &dt_action_def_button);                     \
-  g_signal_connect(G_OBJECT(rb), "clicked", G_CALLBACK(callback), self);            \
+  g_signal_connect(rb, "clicked", G_CALLBACK(callback), self);                      \
   gtk_box_pack_start(GTK_BOX(box), rb, TRUE, TRUE, 0);                              \
   widget = rb;
 
@@ -437,11 +437,11 @@ void gui_init(dt_lib_module_t *self)
   NEW_RADIO(d->over_r6, hbox, _overlays_toggle_button, N_("overlays block on mouse hover"));
   gtk_box_pack_start(GTK_BOX(hbox), gtk_label_new(_("during (s)")), FALSE, FALSE, 0);
   d->over_timeout = gtk_spin_button_new_with_range(-1, 99, 1);
-  g_signal_connect(G_OBJECT(d->over_timeout), "value-changed", G_CALLBACK(_overlays_timeout_changed), self);
+  g_signal_connect(d->over_timeout, "value-changed", G_CALLBACK(_overlays_timeout_changed), self);
   gtk_box_pack_start(GTK_BOX(hbox), d->over_timeout, TRUE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(d->thumbnails_box), hbox, TRUE, TRUE, 0);
   d->over_tt = gtk_check_button_new_with_label(_("show tooltip"));
-  g_signal_connect(G_OBJECT(d->over_tt), "toggled", G_CALLBACK(_overlays_toggle_button), self);
+  g_signal_connect(d->over_tt, "toggled", G_CALLBACK(_overlays_toggle_button), self);
   gtk_widget_set_name(d->over_tt, "show-tooltip");
   gtk_box_pack_start(GTK_BOX(d->thumbnails_box), d->over_tt, TRUE, TRUE, 0);
 
@@ -463,11 +463,11 @@ void gui_init(dt_lib_module_t *self)
   NEW_RADIO(d->over_culling_r6, hbox, _overlays_toggle_culling_button, N_("overlays block on mouse hover"));
   gtk_box_pack_start(GTK_BOX(hbox), gtk_label_new(_("during (s)")), FALSE, FALSE, 0);
   d->over_culling_timeout = gtk_spin_button_new_with_range(-1, 99, 1);
-  g_signal_connect(G_OBJECT(d->over_culling_timeout), "value-changed", G_CALLBACK(_overlays_timeout_changed), self);
+  g_signal_connect(d->over_culling_timeout, "value-changed", G_CALLBACK(_overlays_timeout_changed), self);
   gtk_box_pack_start(GTK_BOX(hbox), d->over_culling_timeout, TRUE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(d->culling_box), hbox, TRUE, TRUE, 0);
   d->over_culling_tt = gtk_check_button_new_with_label(_("show tooltip"));
-  g_signal_connect(G_OBJECT(d->over_culling_tt), "toggled", G_CALLBACK(_overlays_toggle_culling_button), self);
+  g_signal_connect(d->over_culling_tt, "toggled", G_CALLBACK(_overlays_toggle_culling_button), self);
   gtk_widget_set_name(d->over_culling_tt, "show-tooltip");
   gtk_box_pack_start(GTK_BOX(d->culling_box), d->over_culling_tt, TRUE, TRUE, 0);
 
@@ -480,7 +480,7 @@ void gui_init(dt_lib_module_t *self)
   d->help_button = dtgtk_togglebutton_new(dtgtk_cairo_paint_help, 0, NULL);
   dt_action_define(&darktable.control->actions_global, NULL, N_("help"), d->help_button, &dt_action_def_toggle);
   gtk_widget_set_tooltip_text(d->help_button, _("enable this, then click on a control element to see its online help"));
-  g_signal_connect(G_OBJECT(d->help_button), "clicked", G_CALLBACK(_lib_help_button_clicked), d);
+  g_signal_connect(d->help_button, "clicked", G_CALLBACK(_lib_help_button_clicked), d);
 
   /* create the shortcuts button */
   d->keymap_button = dtgtk_togglebutton_new(dtgtk_cairo_paint_shortcut, 0, NULL);
@@ -500,9 +500,9 @@ void gui_init(dt_lib_module_t *self)
                                                   "dialog for more detailed configuration\n"
                                                   "\n"
                                                   "right-click to exit mapping mode"));
-  g_signal_connect(G_OBJECT(d->keymap_button), "clicked", G_CALLBACK(_lib_keymap_button_clicked), d);
-  g_signal_connect(G_OBJECT(d->keymap_button), "button-press-event", G_CALLBACK(_lib_keymap_button_press_release), d);
-  g_signal_connect(G_OBJECT(d->keymap_button), "button-release-event", G_CALLBACK(_lib_keymap_button_press_release), d);
+  g_signal_connect(d->keymap_button, "clicked", G_CALLBACK(_lib_keymap_button_clicked), d);
+  g_signal_connect(d->keymap_button, "button-press-event", G_CALLBACK(_lib_keymap_button_press_release), d);
+  g_signal_connect(d->keymap_button, "button-release-event", G_CALLBACK(_lib_keymap_button_press_release), d);
 
   // the rest of these is added in reverse order as they are always put at the end of the container.
   // that's done so that buttons added via Lua will come first.
@@ -511,7 +511,7 @@ void gui_init(dt_lib_module_t *self)
   d->preferences_button = dtgtk_button_new(dtgtk_cairo_paint_preferences, 0, NULL);
   ac = dt_action_define(&darktable.control->actions_global, NULL, N_("preferences"), d->preferences_button, &dt_action_def_button);
   gtk_widget_set_tooltip_text(d->preferences_button, _("show global preferences"));
-  g_signal_connect(G_OBJECT(d->preferences_button), "clicked", G_CALLBACK(_lib_preferences_button_clicked),
+  g_signal_connect(d->preferences_button, "clicked", G_CALLBACK(_lib_preferences_button_clicked),
                    NULL);
 
   // Register CMD+, for preferences (this is standard on macOS)
@@ -573,7 +573,7 @@ static void _main_do_event_help(GdkEvent *event, gpointer data)
         if(event_widget == d->help_button)
           break;
 
-        dt_gui_show_help(event_widget);
+        dt_gui_show_help(event_widget, NULL);
       }
       handled = TRUE;
       break;
@@ -670,7 +670,7 @@ static void _show_shortcuts_prefs(GtkWidget *w)
     gtk_window_move(GTK_WINDOW(shortcuts_dialog), _shortcuts_dialog_posize.x, _shortcuts_dialog_posize.y);
     gtk_window_resize(GTK_WINDOW(shortcuts_dialog), _shortcuts_dialog_posize.w, _shortcuts_dialog_posize.h);
   }
-  g_signal_connect(G_OBJECT(shortcuts_dialog), "configure-event", G_CALLBACK(_resize_shortcuts_dialog), NULL);
+  g_signal_connect(shortcuts_dialog, "configure-event", G_CALLBACK(_resize_shortcuts_dialog), NULL);
 
   //grab the content area of the dialog
   dt_gui_dialog_add(GTK_DIALOG(shortcuts_dialog), dt_shortcuts_prefs(w));

--- a/src/libs/tools/lighttable.c
+++ b/src/libs/tools/lighttable.c
@@ -461,7 +461,7 @@ void gui_init(dt_lib_module_t *self)
   dt_action_register(ac, NULL, _lib_lighttable_key_accel_toggle_filemanager, 0, 0);
   dt_gui_add_help_link(d->layout_filemanager, "layout_filemanager");
   gtk_widget_set_tooltip_text(d->layout_filemanager, _("click to enter filemanager layout."));
-  g_signal_connect(G_OBJECT(d->layout_filemanager), "button-release-event",
+  g_signal_connect(d->layout_filemanager, "button-release-event",
                    G_CALLBACK(_lib_lighttable_layout_btn_release), self);
 
   d->layout_zoomable = dtgtk_togglebutton_new(dtgtk_cairo_paint_lt_mode_zoom, 0, NULL);
@@ -469,7 +469,7 @@ void gui_init(dt_lib_module_t *self)
   dt_action_register(ac, NULL, _lib_lighttable_key_accel_toggle_zoomable, 0, 0);
   dt_gui_add_help_link(d->layout_zoomable, "layout_zoomable");
   gtk_widget_set_tooltip_text(d->layout_zoomable, _("click to enter zoomable lighttable layout."));
-  g_signal_connect(G_OBJECT(d->layout_zoomable), "button-release-event",
+  g_signal_connect(d->layout_zoomable, "button-release-event",
                    G_CALLBACK(_lib_lighttable_layout_btn_release), self);
 
   d->layout_culling_fix = dtgtk_togglebutton_new(dtgtk_cairo_paint_lt_mode_culling_fixed, 0, NULL);
@@ -477,14 +477,14 @@ void gui_init(dt_lib_module_t *self)
   dt_shortcut_register(ac, DT_ACTION_ELEMENT_DEFAULT, DT_ACTION_EFFECT_HOLD_TOGGLE, GDK_KEY_x, 0);
   dt_shortcut_register(ac, DT_ACTION_ELEMENT_CULLING_NO_RESTRICTION, DT_ACTION_EFFECT_HOLD_TOGGLE, GDK_KEY_x, GDK_SHIFT_MASK);
   dt_gui_add_help_link(d->layout_culling_fix, "layout_culling");
-  g_signal_connect(G_OBJECT(d->layout_culling_fix), "button-release-event",
+  g_signal_connect(d->layout_culling_fix, "button-release-event",
                    G_CALLBACK(_lib_lighttable_layout_btn_release), self);
 
   d->layout_culling_dynamic = dtgtk_togglebutton_new(dtgtk_cairo_paint_lt_mode_culling_dynamic, 0, NULL);
   ac = dt_action_define(ltv, NULL, N_("toggle culling dynamic mode"), d->layout_culling_dynamic, NULL);
   dt_action_register(ac, NULL, _lib_lighttable_key_accel_toggle_culling_dynamic_mode, GDK_KEY_x, GDK_CONTROL_MASK);
   dt_gui_add_help_link(d->layout_culling_dynamic, "layout_culling");
-  g_signal_connect(G_OBJECT(d->layout_culling_dynamic), "button-release-event",
+  g_signal_connect(d->layout_culling_dynamic, "button-release-event",
                    G_CALLBACK(_lib_lighttable_layout_btn_release), self);
 
   d->layout_preview = dtgtk_togglebutton_new(dtgtk_cairo_paint_lt_mode_fullpreview, 0, NULL);
@@ -494,7 +494,7 @@ void gui_init(dt_lib_module_t *self)
   dt_shortcut_register(ac, DT_ACTION_ELEMENT_DEFAULT, DT_ACTION_EFFECT_HOLD, GDK_KEY_w, 0);
   dt_shortcut_register(ac, DT_ACTION_ELEMENT_PREVIEW_FOCUS_DETECT, DT_ACTION_EFFECT_HOLD, GDK_KEY_w, GDK_CONTROL_MASK);
   dt_gui_add_help_link(d->layout_preview, "layout_preview");
-  g_signal_connect(G_OBJECT(d->layout_preview), "button-release-event",
+  g_signal_connect(d->layout_preview, "button-release-event",
                    G_CALLBACK(_lib_lighttable_layout_btn_release), self);
 
   d->layout_box = dt_gui_hbox(d->layout_filemanager, d->layout_zoomable,
@@ -516,14 +516,14 @@ void gui_init(dt_lib_module_t *self)
   dt_action_register(ac, NULL, _lib_lighttable_key_accel_toggle_restricted_mode, GDK_KEY_r, GDK_CONTROL_MASK);
   dt_gui_add_help_link(d->layout_culling_restricted, "layout_culling");
   gtk_widget_set_no_show_all(d->layout_culling_restricted, TRUE);
-  g_signal_connect(G_OBJECT(d->layout_culling_restricted), "button-release-event",
+  g_signal_connect(d->layout_culling_restricted, "button-release-event",
                    G_CALLBACK(_lib_lighttable_restricted_btn_release), self);
 
   self->widget = dt_gui_hbox(d->layout_box, d->zoom, d->layout_culling_restricted);
 
   _lib_lighttable_update_btn(self);
 
-  g_signal_connect(G_OBJECT(d->zoom), "value-changed", G_CALLBACK(_lib_lighttable_zoom_slider_changed), self);
+  g_signal_connect(d->zoom, "value-changed", G_CALLBACK(_lib_lighttable_zoom_slider_changed), self);
 
   darktable.view_manager->proxy.lighttable.module = self;
   darktable.view_manager->proxy.lighttable.set_zoom = _lib_lighttable_set_zoom;

--- a/src/libs/tools/ratings.c
+++ b/src/libs/tools/ratings.c
@@ -96,12 +96,12 @@ void gui_init(dt_lib_module_t *self)
   /* connect callbacks */
   gtk_widget_set_tooltip_text(drawing, _("set star rating for selected images"));
   gtk_widget_set_app_paintable(drawing, TRUE);
-  g_signal_connect(G_OBJECT(drawing), "draw", G_CALLBACK(_lib_ratings_draw_callback), self);
-  g_signal_connect(G_OBJECT(drawing), "button-press-event", G_CALLBACK(_lib_ratings_button_press_callback), self);
-  g_signal_connect(G_OBJECT(drawing), "button-release-event", G_CALLBACK(_lib_ratings_button_release_callback),
+  g_signal_connect(drawing, "draw", G_CALLBACK(_lib_ratings_draw_callback), self);
+  g_signal_connect(drawing, "button-press-event", G_CALLBACK(_lib_ratings_button_press_callback), self);
+  g_signal_connect(drawing, "button-release-event", G_CALLBACK(_lib_ratings_button_release_callback),
                    self);
-  g_signal_connect(G_OBJECT(drawing), "motion-notify-event", G_CALLBACK(_lib_ratings_motion_notify_callback), self);
-  g_signal_connect(G_OBJECT(drawing), "leave-notify-event", G_CALLBACK(_lib_ratings_leave_notify_callback), self);
+  g_signal_connect(drawing, "motion-notify-event", G_CALLBACK(_lib_ratings_motion_notify_callback), self);
+  g_signal_connect(drawing, "leave-notify-event", G_CALLBACK(_lib_ratings_leave_notify_callback), self);
 
   gtk_box_pack_start(GTK_BOX(self->widget), drawing, TRUE, TRUE, 0);
 

--- a/src/libs/tools/timeline.c
+++ b/src/libs/tools/timeline.c
@@ -1399,15 +1399,15 @@ void gui_init(dt_lib_module_t *self)
                                          | GDK_BUTTON_RELEASE_MASK | darktable.gui->scroll_mask
                                          | GDK_LEAVE_NOTIFY_MASK);
 
-  g_signal_connect(G_OBJECT(d->timeline), "draw", G_CALLBACK(_lib_timeline_draw_callback), self);
-  g_signal_connect(G_OBJECT(d->timeline), "button-press-event", G_CALLBACK(_lib_timeline_button_press_callback),
+  g_signal_connect(d->timeline, "draw", G_CALLBACK(_lib_timeline_draw_callback), self);
+  g_signal_connect(d->timeline, "button-press-event", G_CALLBACK(_lib_timeline_button_press_callback),
                    self);
-  g_signal_connect(G_OBJECT(d->timeline), "button-release-event",
+  g_signal_connect(d->timeline, "button-release-event",
                    G_CALLBACK(_lib_timeline_button_release_callback), self);
-  g_signal_connect(G_OBJECT(d->timeline), "scroll-event", G_CALLBACK(_lib_timeline_scroll_callback), self);
-  g_signal_connect(G_OBJECT(d->timeline), "motion-notify-event", G_CALLBACK(_lib_timeline_motion_notify_callback),
+  g_signal_connect(d->timeline, "scroll-event", G_CALLBACK(_lib_timeline_scroll_callback), self);
+  g_signal_connect(d->timeline, "motion-notify-event", G_CALLBACK(_lib_timeline_motion_notify_callback),
                    self);
-  g_signal_connect(G_OBJECT(d->timeline), "leave-notify-event", G_CALLBACK(_lib_timeline_mouse_leave_callback),
+  g_signal_connect(d->timeline, "leave-notify-event", G_CALLBACK(_lib_timeline_mouse_leave_callback),
                    self);
 
   gtk_box_pack_start(GTK_BOX(self->widget), d->timeline, TRUE, TRUE, 0);

--- a/src/libs/tools/viewswitcher.c
+++ b/src/libs/tools/viewswitcher.c
@@ -82,7 +82,7 @@ int position(const dt_lib_module_t *self)
 
 #define SHORTCUT_TOOLTIP(v, w) dt_action_define(&darktable.control->actions_global, "switch views", v->module_name, w, NULL);
 
-static void _dropdown_changed(GtkComboBox *widget, dt_lib_viewswitcher_t *d)
+static void _dropdown_changed(GtkWidget *widget, dt_lib_viewswitcher_t *d)
 {
   GtkTreeIter iter;
   if(gtk_combo_box_get_active_iter(GTK_COMBO_BOX(d->dropdown), &iter))
@@ -151,7 +151,7 @@ void gui_init(dt_lib_module_t *self)
         gtk_list_store_insert_with_values(model, NULL, -1, TEXT_COLUMN, _("other"), VIEW_COLUMN, NULL, SENSITIVE_COLUMN, 0, -1);
 
         gtk_box_pack_start(GTK_BOX(self->widget), d->dropdown, FALSE, FALSE, 0);
-        g_signal_connect(G_OBJECT(d->dropdown), "changed", G_CALLBACK(_dropdown_changed), d);
+        g_signal_connect(d->dropdown, "changed", G_CALLBACK(_dropdown_changed), d);
       }
 
       gtk_list_store_insert_with_values(model, NULL, -1, TEXT_COLUMN, view->name(view), VIEW_COLUMN, view, SENSITIVE_COLUMN, gimping ? 0 : 1, -1);
@@ -258,13 +258,13 @@ static GtkWidget *_lib_viewswitcher_create_label(dt_view_t *view)
   gtk_widget_set_state_flags(b, GTK_STATE_FLAG_NORMAL, TRUE);
 
   /* connect button press handler */
-  g_signal_connect(G_OBJECT(eb), "button-press-event", G_CALLBACK(_lib_viewswitcher_button_press_callback), view);
+  g_signal_connect(eb, "button-press-event", G_CALLBACK(_lib_viewswitcher_button_press_callback), view);
 
   /* set enter/leave notify events and connect signals */
   gtk_widget_add_events(GTK_WIDGET(eb), GDK_ENTER_NOTIFY_MASK | GDK_LEAVE_NOTIFY_MASK);
 
-  g_signal_connect(G_OBJECT(eb), "enter-notify-event", G_CALLBACK(_lib_viewswitcher_enter_leave_notify_callback), b);
-  g_signal_connect(G_OBJECT(eb), "leave-notify-event", G_CALLBACK(_lib_viewswitcher_enter_leave_notify_callback), b);
+  g_signal_connect(eb, "enter-notify-event", G_CALLBACK(_lib_viewswitcher_enter_leave_notify_callback), b);
+  g_signal_connect(eb, "leave-notify-event", G_CALLBACK(_lib_viewswitcher_enter_leave_notify_callback), b);
 
   return eb;
 }

--- a/src/lua/preferences.c
+++ b/src/lua/preferences.c
@@ -501,8 +501,8 @@ static void update_widget_enum(pref_element* cur_elt, GtkWidget* dialog, GtkWidg
 {
   char pref_name[1024];
   get_pref_name(pref_name, sizeof(pref_name), cur_elt->script, cur_elt->name);
-  g_signal_connect(G_OBJECT(labelev), "button-press-event", G_CALLBACK(reset_widget_enum), cur_elt);
-  g_signal_connect(G_OBJECT(dialog), "response", G_CALLBACK(response_callback_enum), cur_elt);
+  g_signal_connect(labelev, "button-press-event", G_CALLBACK(reset_widget_enum), cur_elt);
+  g_signal_connect(dialog, "response", G_CALLBACK(response_callback_enum), cur_elt);
   gtk_combo_box_set_active(GTK_COMBO_BOX(cur_elt->widget), 0);
   const char *value = dt_conf_get_string_const(pref_name);
   do {
@@ -533,8 +533,8 @@ static void update_widget_dir(pref_element* cur_elt, GtkWidget* dialog, GtkWidge
   get_pref_name(pref_name, sizeof(pref_name), cur_elt->script, cur_elt->name);
   const char *str = dt_conf_get_string_const(pref_name);
   gtk_file_chooser_set_filename(GTK_FILE_CHOOSER(cur_elt->widget), str);
-  g_signal_connect(G_OBJECT(labelev), "button-press-event", G_CALLBACK(reset_widget_dir), cur_elt);
-  g_signal_connect(G_OBJECT(dialog), "response", G_CALLBACK(response_callback_dir), cur_elt);
+  g_signal_connect(labelev, "button-press-event", G_CALLBACK(reset_widget_dir), cur_elt);
+  g_signal_connect(dialog, "response", G_CALLBACK(response_callback_dir), cur_elt);
 }
 
 
@@ -544,8 +544,8 @@ static void update_widget_file(pref_element* cur_elt, GtkWidget* dialog, GtkWidg
   get_pref_name(pref_name, sizeof(pref_name), cur_elt->script, cur_elt->name);
   const char *str = dt_conf_get_string_const(pref_name);
   gtk_file_chooser_set_filename(GTK_FILE_CHOOSER(cur_elt->widget), str);
-  g_signal_connect(G_OBJECT(labelev), "button-press-event", G_CALLBACK(reset_widget_file), cur_elt);
-  g_signal_connect(G_OBJECT(dialog), "response", G_CALLBACK(response_callback_file), cur_elt);
+  g_signal_connect(labelev, "button-press-event", G_CALLBACK(reset_widget_file), cur_elt);
+  g_signal_connect(dialog, "response", G_CALLBACK(response_callback_file), cur_elt);
 }
 
 
@@ -553,8 +553,8 @@ static void update_widget_string(pref_element* cur_elt, GtkWidget* dialog, GtkWi
 {
   char pref_name[1024];
   get_pref_name(pref_name, sizeof(pref_name), cur_elt->script, cur_elt->name);
-  g_signal_connect(G_OBJECT(labelev), "button-press-event", G_CALLBACK(reset_widget_string), cur_elt);
-  g_signal_connect(G_OBJECT(dialog), "response", G_CALLBACK(response_callback_string), cur_elt);
+  g_signal_connect(labelev, "button-press-event", G_CALLBACK(reset_widget_string), cur_elt);
+  g_signal_connect(dialog, "response", G_CALLBACK(response_callback_string), cur_elt);
   const char *str = dt_conf_get_string_const(pref_name);
   gtk_entry_set_text(GTK_ENTRY(cur_elt->widget), str);
 }
@@ -564,8 +564,8 @@ static void update_widget_bool(pref_element* cur_elt, GtkWidget* dialog, GtkWidg
 {
   char pref_name[1024];
   get_pref_name(pref_name, sizeof(pref_name), cur_elt->script, cur_elt->name);
-  g_signal_connect(G_OBJECT(labelev), "button-press-event", G_CALLBACK(click_widget_bool), cur_elt);
-  g_signal_connect(G_OBJECT(dialog), "response", G_CALLBACK(response_callback_bool), cur_elt);
+  g_signal_connect(labelev, "button-press-event", G_CALLBACK(click_widget_bool), cur_elt);
+  g_signal_connect(dialog, "response", G_CALLBACK(response_callback_bool), cur_elt);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(cur_elt->widget), dt_conf_get_bool(pref_name));
 }
 
@@ -575,8 +575,8 @@ static void update_widget_int(pref_element* cur_elt, GtkWidget* dialog, GtkWidge
   char pref_name[1024];
   get_pref_name(pref_name, sizeof(pref_name), cur_elt->script, cur_elt->name);
   gtk_spin_button_set_value(GTK_SPIN_BUTTON(cur_elt->widget), dt_conf_get_int(pref_name));
-  g_signal_connect(G_OBJECT(labelev), "button-press-event", G_CALLBACK(reset_widget_int), cur_elt);
-  g_signal_connect(G_OBJECT(dialog), "response", G_CALLBACK(response_callback_int), cur_elt);
+  g_signal_connect(labelev, "button-press-event", G_CALLBACK(reset_widget_int), cur_elt);
+  g_signal_connect(dialog, "response", G_CALLBACK(response_callback_int), cur_elt);
 }
 
 
@@ -585,8 +585,8 @@ static void update_widget_float(pref_element* cur_elt, GtkWidget* dialog, GtkWid
   char pref_name[1024];
   get_pref_name(pref_name, sizeof(pref_name), cur_elt->script, cur_elt->name);
   gtk_spin_button_set_value(GTK_SPIN_BUTTON(cur_elt->widget), dt_conf_get_float(pref_name));
-  g_signal_connect(G_OBJECT(labelev), "button-press-event", G_CALLBACK(reset_widget_float), cur_elt);
-  g_signal_connect(G_OBJECT(dialog), "response", G_CALLBACK(response_callback_float), cur_elt);
+  g_signal_connect(labelev, "button-press-event", G_CALLBACK(reset_widget_float), cur_elt);
+  g_signal_connect(dialog, "response", G_CALLBACK(response_callback_float), cur_elt);
 }
 
 
@@ -599,8 +599,8 @@ static void update_widget_lua(pref_element* cur_elt, GtkWidget* dialog, GtkWidge
   lua_pushstring(L, "reset");
   lua_call(L, 2, 0);
   dt_lua_unlock();
-  g_signal_connect(G_OBJECT(labelev), "button-press-event", G_CALLBACK(reset_widget_lua), cur_elt);
-  g_signal_connect(G_OBJECT(dialog), "response", G_CALLBACK(response_callback_lua), cur_elt);
+  g_signal_connect(labelev, "button-press-event", G_CALLBACK(reset_widget_lua), cur_elt);
+  g_signal_connect(dialog, "response", G_CALLBACK(response_callback_lua), cur_elt);
 }
 
 

--- a/src/lua/widget/container.c
+++ b/src/lua/widget/container.c
@@ -49,7 +49,7 @@ static int container_reset(lua_State* L)
   return 0;
 }
 
-static void on_child_added(GtkContainer *container,GtkWidget *child,lua_container user_data)
+static void on_child_added(GtkWidget *container,GtkWidget *child,lua_container user_data)
 {
   dt_lua_async_call_alien(dt_lua_widget_trigger_callback,
       0,NULL,NULL,
@@ -59,7 +59,7 @@ static void on_child_added(GtkContainer *container,GtkWidget *child,lua_containe
       LUA_ASYNC_DONE);
 }
 
-static void on_child_removed(GtkContainer *container,GtkWidget *child,lua_container user_data)
+static void on_child_removed(GtkWidget *container,GtkWidget *child,lua_container user_data)
 {
   dt_lua_async_call_alien(dt_lua_widget_trigger_callback,
       0,NULL,NULL,

--- a/src/lua/widget/widget.c
+++ b/src/lua/widget/widget.c
@@ -107,7 +107,7 @@ static int get_widget_params(lua_State *L)
   lua_pushnil(L); /* first key */
   while(lua_next(L, -2) != 0)
   {
-    g_signal_connect(widget->widget, lua_tostring(L,-2), G_CALLBACK(lua_touserdata(L,-1)), widget);
+    g_signal_connect_data(widget->widget, lua_tostring(L,-2), G_CALLBACK(lua_touserdata(L,-1)), widget, NULL, 0);
     lua_pop(L,1);
   }
   lua_pop(L,1);

--- a/src/osx/osx.mm
+++ b/src/osx/osx.mm
@@ -86,7 +86,7 @@ void dt_osx_disallow_fullscreen(GtkWidget *widget)
   if(gtk_widget_get_realized(widget))
     dt_osx_disable_fullscreen(widget);
   else
-    g_signal_connect(G_OBJECT(widget), "realize", G_CALLBACK(dt_osx_disable_fullscreen), NULL);
+    g_signal_connect(widget, "realize", G_CALLBACK(dt_osx_disable_fullscreen), NULL);
 #endif
 #endif
 }

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -2456,7 +2456,7 @@ void gui_init(dt_view_t *self)
   dt_action_define(sa, NULL, N_("quick access to presets"),
                    favorite_presets, &dt_action_def_button);
   gtk_widget_set_tooltip_text(favorite_presets, _("quick access to presets"));
-  g_signal_connect(G_OBJECT(favorite_presets), "clicked",
+  g_signal_connect(favorite_presets, "clicked",
                    G_CALLBACK(_darkroom_ui_favorite_presets_popupmenu),
                    NULL);
   dt_gui_add_help_link(favorite_presets, "favorite_presets");
@@ -2466,7 +2466,7 @@ void gui_init(dt_view_t *self)
   /* create quick styles popup menu tool */
   GtkWidget *styles = dtgtk_button_new(dtgtk_cairo_paint_styles, 0, NULL);
   dt_action_define(sa, NULL, N_("quick access to styles"), styles, &dt_action_def_button);
-  g_signal_connect(G_OBJECT(styles), "clicked",
+  g_signal_connect(styles, "clicked",
                    G_CALLBACK(_darkroom_ui_apply_style_popupmenu), NULL);
   gtk_widget_set_tooltip_text(styles, _("quick access for applying any of your styles"));
   dt_gui_add_help_link(styles, "bottom_panel_styles");
@@ -2477,7 +2477,7 @@ void gui_init(dt_view_t *self)
   dev->second_wnd_button = dtgtk_togglebutton_new(dtgtk_cairo_paint_display2, 0, NULL);
   dt_action_define(sa, NULL, N_("second window"),
                    dev->second_wnd_button, &dt_action_def_toggle);
-  g_signal_connect(G_OBJECT(dev->second_wnd_button), "clicked",
+  g_signal_connect(dev->second_wnd_button, "clicked",
                    G_CALLBACK(_second_window_quickbutton_clicked),dev);
   gtk_widget_set_tooltip_text(dev->second_wnd_button,
                               _("display a second darkroom image window"));
@@ -2492,7 +2492,7 @@ void gui_init(dt_view_t *self)
                           &dt_action_def_toggle);
     gtk_widget_set_tooltip_text(dev->color_assessment.button, _("toggle color assessment conditions\nright-click for options"));
     dt_shortcut_register(ac, 0, 0, GDK_KEY_b, GDK_CONTROL_MASK);
-    g_signal_connect(G_OBJECT(dev->color_assessment.button), "toggled",
+    g_signal_connect(dev->color_assessment.button, "toggled",
                      G_CALLBACK(_full_color_assessment_callback), dev);
 
     dt_view_manager_module_toolbox_add(darktable.view_manager, dev->color_assessment.button, DT_VIEW_DARKROOM);
@@ -2511,7 +2511,7 @@ void gui_init(dt_view_t *self)
     gtk_widget_set_tooltip_text(border_width_slider,
                                 _("total border width in relation to the screen size for the assessment mode.\n"
                                   "this includes the outer gray part plus the inner white frame."));
-    g_signal_connect(G_OBJECT(border_width_slider), "value-changed",
+    g_signal_connect(border_width_slider, "value-changed",
                      G_CALLBACK(_color_assessment_border_width_callback), dev);
     gtk_box_pack_start(GTK_BOX(vbox), GTK_WIDGET(border_width_slider), TRUE, TRUE, 0);
 
@@ -2523,7 +2523,7 @@ void gui_init(dt_view_t *self)
     dt_bauhaus_widget_set_label(border_ratio_slider, N_("color_assessment"), N_("white border ratio"));
     gtk_widget_set_tooltip_text(border_ratio_slider,
                                 _("the border ratio specifies the fraction of the white part of the border."));
-    g_signal_connect(G_OBJECT(border_ratio_slider), "value-changed",
+    g_signal_connect(border_ratio_slider, "value-changed",
                      G_CALLBACK(_color_assessment_border_white_ratio_callback), dev);
     gtk_box_pack_start(GTK_BOX(vbox), GTK_WIDGET(border_ratio_slider), TRUE, TRUE, 0);
 
@@ -2539,7 +2539,7 @@ void gui_init(dt_view_t *self)
     (dev->late_scaling.button,
      _("toggle high quality processing."
        " if activated darktable processes image data as it does while exporting"));
-  g_signal_connect(G_OBJECT(dev->late_scaling.button), "clicked",
+  g_signal_connect(dev->late_scaling.button, "clicked",
                    G_CALLBACK(_latescaling_quickbutton_clicked), dev);
   dt_view_manager_module_toolbox_add(darktable.view_manager,
                                      dev->late_scaling.button, DT_VIEW_DARKROOM);
@@ -2557,7 +2557,7 @@ void gui_init(dt_view_t *self)
     dt_shortcut_register(ac, 0, 0, GDK_KEY_o, GDK_SHIFT_MASK);
     gtk_widget_set_tooltip_text(dev->rawoverexposed.button,
                                 _("toggle indication of raw overexposure\nright-click for options"));
-    g_signal_connect(G_OBJECT(dev->rawoverexposed.button), "clicked",
+    g_signal_connect(dev->rawoverexposed.button, "clicked",
                      G_CALLBACK(_rawoverexposed_quickbutton_clicked), dev);
     dt_view_manager_module_toolbox_add(darktable.view_manager,
                                        dev->rawoverexposed.button, DT_VIEW_DARKROOM);
@@ -2605,7 +2605,7 @@ void gui_init(dt_view_t *self)
                                 N_("clipping threshold"));
     gtk_widget_set_tooltip_text(
         threshold, _("threshold of what shall be considered overexposed\n1.0 - white level\n0.0 - black level"));
-    g_signal_connect(G_OBJECT(threshold), "value-changed",
+    g_signal_connect(threshold, "value-changed",
                      G_CALLBACK(_rawoverexposed_threshold_callback), dev);
     gtk_box_pack_start(GTK_BOX(vbox), GTK_WIDGET(threshold), TRUE, TRUE, 0);
 
@@ -2624,7 +2624,7 @@ void gui_init(dt_view_t *self)
     dt_shortcut_register(ac, 0, 0, GDK_KEY_o, 0);
     gtk_widget_set_tooltip_text(dev->overexposed.button,
                                 _("toggle clipping indication\nright-click for options"));
-    g_signal_connect(G_OBJECT(dev->overexposed.button), "clicked",
+    g_signal_connect(dev->overexposed.button, "clicked",
                      G_CALLBACK(_overexposed_quickbutton_clicked), dev);
     dt_view_manager_module_toolbox_add(darktable.view_manager,
                                        dev->overexposed.button, DT_VIEW_DARKROOM);
@@ -2680,7 +2680,7 @@ void gui_init(dt_view_t *self)
                                          "typical color glossy prints produce black at -8.00 EV,\n"
                                          "typical B&W glossy prints produce black at -9.00 EV."
                                          ));
-    g_signal_connect(G_OBJECT(lower), "value-changed",
+    g_signal_connect(lower, "value-changed",
                      G_CALLBACK(_lower_callback), dev);
     gtk_box_pack_start(GTK_BOX(vbox), GTK_WIDGET(lower), TRUE, TRUE, 0);
 
@@ -2692,7 +2692,7 @@ void gui_init(dt_view_t *self)
     /* xgettext:no-c-format */
     gtk_widget_set_tooltip_text(upper, _("clipping threshold for the white point.\n"
                                          "100% is peak medium luminance."));
-    g_signal_connect(G_OBJECT(upper), "value-changed", G_CALLBACK(_upper_callback), dev);
+    g_signal_connect(upper, "value-changed", G_CALLBACK(_upper_callback), dev);
     gtk_box_pack_start(GTK_BOX(vbox), GTK_WIDGET(upper), TRUE, TRUE, 0);
 
     gtk_widget_show_all(vbox);
@@ -2707,7 +2707,7 @@ void gui_init(dt_view_t *self)
     dt_shortcut_register(ac, 0, 0, GDK_KEY_s, GDK_CONTROL_MASK);
     gtk_widget_set_tooltip_text(dev->profile.softproof_button,
                                 _("toggle softproofing\nright-click for profile options"));
-    g_signal_connect(G_OBJECT(dev->profile.softproof_button), "clicked",
+    g_signal_connect(dev->profile.softproof_button, "clicked",
                      G_CALLBACK(_softproof_quickbutton_clicked), dev);
     dt_view_manager_module_toolbox_add(darktable.view_manager,
                                        dev->profile.softproof_button, DT_VIEW_DARKROOM);
@@ -2720,7 +2720,7 @@ void gui_init(dt_view_t *self)
     dt_shortcut_register(ac, 0, 0, GDK_KEY_g, GDK_CONTROL_MASK);
     gtk_widget_set_tooltip_text(dev->profile.gamut_button,
                  _("toggle gamut checking\nright-click for profile options"));
-    g_signal_connect(G_OBJECT(dev->profile.gamut_button), "clicked",
+    g_signal_connect(dev->profile.gamut_button, "clicked",
                      G_CALLBACK(_gamut_quickbutton_clicked), dev);
     dt_view_manager_module_toolbox_add(darktable.view_manager,
                                        dev->profile.gamut_button, DT_VIEW_DARKROOM);
@@ -2854,15 +2854,15 @@ void gui_init(dt_view_t *self)
     gtk_widget_set_tooltip_markup(histogram_profile, tooltip);
     g_free(tooltip);
 
-    g_signal_connect(G_OBJECT(display_profile), "value-changed",
+    g_signal_connect(display_profile, "value-changed",
                      G_CALLBACK(_display_profile_callback), dev);
-    g_signal_connect(G_OBJECT(display2_profile), "value-changed",
+    g_signal_connect(display2_profile, "value-changed",
                      G_CALLBACK(_display2_profile_callback), dev);
-    g_signal_connect(G_OBJECT(display2_color_assessment), "toggled",
+    g_signal_connect(display2_color_assessment, "toggled",
                      G_CALLBACK(_display2_color_assessment_callback), dev);
-    g_signal_connect(G_OBJECT(softproof_profile), "value-changed",
+    g_signal_connect(softproof_profile, "value-changed",
                      G_CALLBACK(_softproof_profile_callback), dev);
-    g_signal_connect(G_OBJECT(histogram_profile), "value-changed",
+    g_signal_connect(histogram_profile, "value-changed",
                      G_CALLBACK(_histogram_profile_callback), dev);
 
     _update_softproof_gamut_checking(dev);
@@ -2903,7 +2903,7 @@ void gui_init(dt_view_t *self)
     darktable.view_manager->guides_popover =
       dt_guides_popover(self, darktable.view_manager->guides_toggle);
     g_object_ref(darktable.view_manager->guides_popover);
-    g_signal_connect(G_OBJECT(darktable.view_manager->guides_toggle), "clicked",
+    g_signal_connect(darktable.view_manager->guides_toggle, "clicked",
                      G_CALLBACK(_guides_quickbutton_clicked), dev);
     connect_button_press_release(darktable.view_manager->guides_toggle,
                                  darktable.view_manager->guides_popover);
@@ -4016,24 +4016,24 @@ static void _darkroom_display_second_window(dt_develop_t *dev)
                           | darktable.gui->scroll_mask);
 
     /* connect callbacks */
-    g_signal_connect(G_OBJECT(dev->preview2.widget), "draw",
+    g_signal_connect(dev->preview2.widget, "draw",
                      G_CALLBACK(_second_window_draw_callback), dev);
-    g_signal_connect(G_OBJECT(dev->preview2.widget), "scroll-event",
+    g_signal_connect(dev->preview2.widget, "scroll-event",
                      G_CALLBACK(_second_window_scrolled_callback), dev);
-    g_signal_connect(G_OBJECT(dev->preview2.widget), "button-press-event",
+    g_signal_connect(dev->preview2.widget, "button-press-event",
                      G_CALLBACK(_second_window_button_pressed_callback), dev);
-    g_signal_connect(G_OBJECT(dev->preview2.widget), "button-release-event",
+    g_signal_connect(dev->preview2.widget, "button-release-event",
                      G_CALLBACK(_second_window_button_released_callback), dev);
-    g_signal_connect(G_OBJECT(dev->preview2.widget), "motion-notify-event",
+    g_signal_connect(dev->preview2.widget, "motion-notify-event",
                      G_CALLBACK(_second_window_mouse_moved_callback), dev);
-    g_signal_connect(G_OBJECT(dev->preview2.widget), "leave-notify-event",
+    g_signal_connect(dev->preview2.widget, "leave-notify-event",
                      G_CALLBACK(_second_window_leave_callback), dev);
-    g_signal_connect(G_OBJECT(dev->preview2.widget), "configure-event",
+    g_signal_connect(dev->preview2.widget, "configure-event",
                      G_CALLBACK(_second_window_configure_callback), dev);
 
-    g_signal_connect(G_OBJECT(dev->second_wnd), "delete-event",
+    g_signal_connect(dev->second_wnd, "delete-event",
                      G_CALLBACK(_second_window_delete_callback), dev);
-    g_signal_connect(G_OBJECT(dev->second_wnd), "event",
+    g_signal_connect(dev->second_wnd, "event",
                      G_CALLBACK(dt_shortcut_dispatcher), NULL);
 
     _darkroom_ui_second_window_init(dev->second_wnd, dev);

--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -1243,7 +1243,7 @@ void gui_init(dt_view_t *self)
   lib->profile_floating_window = gtk_popover_new(profile_button);
 
   g_object_set(G_OBJECT(lib->profile_floating_window), "transitions-enabled", FALSE, NULL);
-  g_signal_connect_swapped(G_OBJECT(profile_button), "button-press-event",
+  g_signal_connect_swapped(profile_button, "button-press-event",
                            G_CALLBACK(gtk_widget_show_all), lib->profile_floating_window);
 
   GtkWidget *vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
@@ -1310,9 +1310,9 @@ void gui_init(dt_view_t *self)
   gtk_widget_set_tooltip_markup(display2_profile, tooltip);
   g_free(tooltip);
 
-  g_signal_connect(G_OBJECT(display_profile), "value-changed", G_CALLBACK(_profile_display_profile_callback), NULL);
+  g_signal_connect(display_profile, "value-changed", G_CALLBACK(_profile_display_profile_callback), NULL);
 
-  g_signal_connect(G_OBJECT(display2_profile), "value-changed", G_CALLBACK(_profile_display2_profile_callback),
+  g_signal_connect(display2_profile, "value-changed", G_CALLBACK(_profile_display2_profile_callback),
                    NULL);
 
   // update the gui when profiles change

--- a/src/views/map.c
+++ b/src/views/map.c
@@ -777,14 +777,14 @@ void init(dt_view_t *self)
 
     g_signal_connect(GTK_WIDGET(lib->map), "changed",
                      G_CALLBACK(_view_map_changed_callback), self);
-    g_signal_connect_after(G_OBJECT(lib->map), "button-press-event",
+    g_signal_connect_after(lib->map, "button-press-event",
                            G_CALLBACK(_view_map_button_press_callback), self);
-    g_signal_connect_after(G_OBJECT(lib->map), "button-release-event",
+    g_signal_connect_after(lib->map, "button-release-event",
                           G_CALLBACK(_view_map_button_release_callback), self);
-    g_signal_connect(G_OBJECT(lib->map), "motion-notify-event",
+    g_signal_connect(lib->map, "motion-notify-event",
                      G_CALLBACK(_view_map_motion_notify_callback),
                      self);
-    g_signal_connect(G_OBJECT(lib->map), "drag-motion",
+    g_signal_connect(lib->map, "drag-motion",
                      G_CALLBACK(_view_map_drag_motion_callback),
                      self);
   }

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -1501,7 +1501,7 @@ void dt_view_accels_show(dt_view_manager_t *vm)
   vm->accels_window.sticky_btn = dtgtk_button_new(dtgtk_cairo_paint_multiinstance, 0, NULL);
   gtk_widget_set_tooltip_text(vm->accels_window.sticky_btn,
                               _("switch to a classic window which will stay open after key release"));
-  g_signal_connect(G_OBJECT(vm->accels_window.sticky_btn), "button-press-event",
+  g_signal_connect(vm->accels_window.sticky_btn, "button-press-event",
                    G_CALLBACK(_accels_window_sticky),
                    vm);
   dt_gui_add_class(vm->accels_window.sticky_btn, "dt_accels_stick");

--- a/tools/generate_prefs.xsl
+++ b/tools/generate_prefs.xsl
@@ -188,7 +188,7 @@ static void wrapup_pref(const gchar *name,
   gtk_grid_attach(GTK_GRID(grid), labdef, 1, *line, 1, 1);
   gtk_grid_attach(GTK_GRID(grid), widget, 2, (*line)++, 1, 1);
   gtk_label_set_mnemonic_widget(GTK_LABEL(label), widget);
-  g_signal_connect(G_OBJECT(labelev), "button-press-event", G_CALLBACK(callback), (gpointer)widget);
+  g_signal_connect(labelev, "button-press-event", G_CALLBACK(callback), widget);
 }
 
 static gboolean click_widget_label(GtkWidget *label, GdkEventButton *event, GtkWidget *widget)
@@ -302,14 +302,14 @@ gboolean restart_required = FALSE;
   <!-- restart callbacks (on change) -->
 
   <xsl:for-each select="./dtconfiglist/dtconfig[@prefs or @dialog]">
-    <xsl:text>static void&#xA;preferences_changed_callback_</xsl:text><xsl:value-of select="generate-id(.)"/><xsl:text> (GtkWidget *widget, gpointer user_data)&#xA;{&#xA;</xsl:text>
+    <xsl:text>static void&#xA;preferences_changed_callback_</xsl:text><xsl:value-of select="generate-id(.)"/><xsl:text> (GtkWidget *widget, GtkWidget *label)&#xA;{&#xA;</xsl:text>
     <xsl:if test="@restart">
       <xsl:text>  restart_required = TRUE;&#xA;</xsl:text>
     </xsl:if>
     <xsl:apply-templates select="type" mode="factor"/>
     <xsl:text>
   set_widget_label_default(widget, "</xsl:text>
-    <xsl:value-of select="name"/><xsl:text>", GTK_WIDGET(user_data), factor);</xsl:text>
+    <xsl:value-of select="name"/><xsl:text>", label, factor);</xsl:text>
     <xsl:text>&#xA;}&#xA;&#xA;</xsl:text>
   </xsl:for-each>
 
@@ -561,8 +561,8 @@ static void init_tab_generated(GtkWidget *dialog, GtkWidget *stack)
     gchar *setting = dt_conf_get_string("</xsl:text><xsl:value-of select="name"/><xsl:text>");
     gtk_text_buffer_set_text(buffer, setting, strlen(setting));
     g_free(setting);
-    g_signal_connect(G_OBJECT(dialog), "response", G_CALLBACK(preferences_response_callback_</xsl:text><xsl:value-of select="generate-id(.)"/><xsl:text>), widget);
-    g_signal_connect(G_OBJECT(widget), "key-press-event", G_CALLBACK(handle_enter_key), NULL);
+    g_signal_connect(dialog, "response", G_CALLBACK(preferences_response_callback_</xsl:text><xsl:value-of select="generate-id(.)"/><xsl:text>), widget);
+    g_signal_connect(widget, "key-press-event", G_CALLBACK(handle_enter_key), NULL);
     snprintf(tooltip, 1024, _("double click to reset to `%s'"), "</xsl:text><xsl:value-of select="default"/><xsl:text>");
     gtk_widget_set_tooltip_text(labelev, tooltip);</xsl:text>
   </xsl:template>
@@ -575,8 +575,8 @@ static void init_tab_generated(GtkWidget *dialog, GtkWidget *stack)
     gtk_entry_set_text(GTK_ENTRY(widget), setting);
     g_free(setting);
     gtk_label_set_mnemonic_widget(GTK_LABEL(label), widget);
-    g_signal_connect(G_OBJECT(widget), "changed", G_CALLBACK(preferences_changed_callback_</xsl:text><xsl:value-of select="generate-id(.)"/><xsl:text>), labdef);
-    g_signal_connect(G_OBJECT(dialog), "response", G_CALLBACK(preferences_response_callback_</xsl:text><xsl:value-of select="generate-id(.)"/><xsl:text>), widget);
+    g_signal_connect(widget, "changed", G_CALLBACK(preferences_changed_callback_</xsl:text><xsl:value-of select="generate-id(.)"/><xsl:text>), labdef);
+    g_signal_connect(dialog, "response", G_CALLBACK(preferences_response_callback_</xsl:text><xsl:value-of select="generate-id(.)"/><xsl:text>), widget);
     snprintf(tooltip, 1024, _("double click to reset to `%s'"), "</xsl:text><xsl:value-of select="default"/><xsl:text>");
     gtk_widget_set_tooltip_text(labelev,  tooltip);</xsl:text>
   </xsl:template>
@@ -590,8 +590,8 @@ static void init_tab_generated(GtkWidget *dialog, GtkWidget *stack)
     gchar *setting = dt_conf_get_string("</xsl:text><xsl:value-of select="name"/><xsl:text>");
     gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(widget), setting);
     g_free(setting);
-    g_signal_connect(G_OBJECT(widget), "selection-changed", G_CALLBACK(preferences_changed_callback_</xsl:text><xsl:value-of select="generate-id(.)"/><xsl:text>), labdef);
-    g_signal_connect(G_OBJECT(dialog), "response", G_CALLBACK(preferences_response_callback_</xsl:text><xsl:value-of select="generate-id(.)"/><xsl:text>), widget);
+    g_signal_connect(widget, "selection-changed", G_CALLBACK(preferences_changed_callback_</xsl:text><xsl:value-of select="generate-id(.)"/><xsl:text>), labdef);
+    g_signal_connect(dialog, "response", G_CALLBACK(preferences_response_callback_</xsl:text><xsl:value-of select="generate-id(.)"/><xsl:text>), widget);
     gchar *default_path = dt_conf_expand_default_dir("</xsl:text><xsl:value-of select="default"/><xsl:text>");
     snprintf(tooltip, 1024, _("double click to reset to `%s'"), default_path);
     g_free(default_path);
@@ -613,8 +613,8 @@ static void init_tab_generated(GtkWidget *dialog, GtkWidget *stack)
     gtk_size_group_add_widget(widget_group, widget);
     gtk_spin_button_set_digits(GTK_SPIN_BUTTON(widget), 0);
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(widget), dt_conf_get_int("</xsl:text><xsl:value-of select="name"/><xsl:text>") * factor);
-    g_signal_connect(G_OBJECT(widget), "value-changed", G_CALLBACK(preferences_changed_callback_</xsl:text><xsl:value-of select="generate-id(.)"/><xsl:text>), labdef);
-    g_signal_connect(G_OBJECT(dialog), "response", G_CALLBACK(preferences_response_callback_</xsl:text><xsl:value-of select="generate-id(.)"/><xsl:text>), widget);
+    g_signal_connect(widget, "value-changed", G_CALLBACK(preferences_changed_callback_</xsl:text><xsl:value-of select="generate-id(.)"/><xsl:text>), labdef);
+    g_signal_connect(dialog, "response", G_CALLBACK(preferences_response_callback_</xsl:text><xsl:value-of select="generate-id(.)"/><xsl:text>), widget);
     snprintf(tooltip, 1024, _("double click to reset to `%d'"), (int)(</xsl:text><xsl:value-of select="default"/><xsl:text> * factor));
     gtk_widget_set_tooltip_text(labelev, tooltip);</xsl:text>
   </xsl:template>
@@ -632,8 +632,8 @@ static void init_tab_generated(GtkWidget *dialog, GtkWidget *stack)
     gtk_size_group_add_widget(widget_group, widget);
     gtk_spin_button_set_digits(GTK_SPIN_BUTTON(widget), 0);
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(widget), dt_conf_get_int64("</xsl:text><xsl:value-of select="name"/><xsl:text>") * factor);
-    g_signal_connect(G_OBJECT(widget), "value-changed", G_CALLBACK(preferences_changed_callback_</xsl:text><xsl:value-of select="generate-id(.)"/><xsl:text>), labdef);
-    g_signal_connect(G_OBJECT(dialog), "response", G_CALLBACK(preferences_response_callback_</xsl:text><xsl:value-of select="generate-id(.)"/><xsl:text>), widget);
+    g_signal_connect(widget, "value-changed", G_CALLBACK(preferences_changed_callback_</xsl:text><xsl:value-of select="generate-id(.)"/><xsl:text>), labdef);
+    g_signal_connect(dialog, "response", G_CALLBACK(preferences_response_callback_</xsl:text><xsl:value-of select="generate-id(.)"/><xsl:text>), widget);
     char value[100];
     snprintf(value, 100, "%"G_GINT64_FORMAT"",(gint64)(</xsl:text><xsl:value-of select="default"/><xsl:text> * factor));
     snprintf(tooltip, 1024, _("double click to reset to `%s'"), value);
@@ -651,8 +651,8 @@ static void init_tab_generated(GtkWidget *dialog, GtkWidget *stack)
     widget = gtk_spin_button_new_with_range(min, max, 0.001f);
     gtk_spin_button_set_digits(GTK_SPIN_BUTTON(widget), 5);
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(widget), dt_conf_get_float("</xsl:text><xsl:value-of select="name"/><xsl:text>") * factor);
-    g_signal_connect(G_OBJECT(widget), "value-changed", G_CALLBACK(preferences_changed_callback_</xsl:text><xsl:value-of select="generate-id(.)"/><xsl:text>), labdef);
-    g_signal_connect(G_OBJECT(dialog), "response", G_CALLBACK(preferences_response_callback_</xsl:text><xsl:value-of select="generate-id(.)"/><xsl:text>), widget);
+    g_signal_connect(widget, "value-changed", G_CALLBACK(preferences_changed_callback_</xsl:text><xsl:value-of select="generate-id(.)"/><xsl:text>), labdef);
+    g_signal_connect(dialog, "response", G_CALLBACK(preferences_response_callback_</xsl:text><xsl:value-of select="generate-id(.)"/><xsl:text>), widget);
     snprintf(tooltip, 1024, _("double click to reset to `%.03f'"), </xsl:text><xsl:value-of select="default"/><xsl:text> * factor);
     gtk_widget_set_tooltip_text(labelev, tooltip);</xsl:text>
   </xsl:template>
@@ -661,8 +661,8 @@ static void init_tab_generated(GtkWidget *dialog, GtkWidget *stack)
     <xsl:text>
     widget = gtk_check_button_new();
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), dt_conf_get_bool("</xsl:text><xsl:value-of select="name"/><xsl:text>"));
-    g_signal_connect(G_OBJECT(widget), "toggled", G_CALLBACK(preferences_changed_callback_</xsl:text><xsl:value-of select="generate-id(.)"/><xsl:text>), labdef);
-    g_signal_connect(G_OBJECT(dialog), "response", G_CALLBACK(preferences_response_callback_</xsl:text><xsl:value-of select="generate-id(.)"/><xsl:text>), widget);
+    g_signal_connect(widget, "toggled", G_CALLBACK(preferences_changed_callback_</xsl:text><xsl:value-of select="generate-id(.)"/><xsl:text>), labdef);
+    g_signal_connect(dialog, "response", G_CALLBACK(preferences_response_callback_</xsl:text><xsl:value-of select="generate-id(.)"/><xsl:text>), widget);
     snprintf(tooltip, 1024, _("double click to reset to `%s'"), C_("preferences", "</xsl:text><xsl:value-of select="translate(default, $lowercase, $uppercase)"/><xsl:text>"));
     gtk_widget_set_tooltip_text(labelev, tooltip);</xsl:text>
   </xsl:template>
@@ -681,8 +681,8 @@ static void init_tab_generated(GtkWidget *dialog, GtkWidget *stack)
     <xsl:text>
     gtk_widget_set_halign(widget, GTK_ALIGN_START);
     gtk_size_group_add_widget(widget_group, widget);
-    g_signal_connect(G_OBJECT(widget), "value-changed", G_CALLBACK(preferences_changed_callback_</xsl:text><xsl:value-of select="generate-id(.)"/><xsl:text>), labdef);
-    g_signal_connect(G_OBJECT(dialog), "response", G_CALLBACK(preferences_response_callback_</xsl:text><xsl:value-of select="generate-id(.)"/><xsl:text>), widget);
+    g_signal_connect(widget, "value-changed", G_CALLBACK(preferences_changed_callback_</xsl:text><xsl:value-of select="generate-id(.)"/><xsl:text>), labdef);
+    g_signal_connect(dialog, "response", G_CALLBACK(preferences_response_callback_</xsl:text><xsl:value-of select="generate-id(.)"/><xsl:text>), widget);
     snprintf(tooltip, 1024, _("double click to reset to `%s'"), C_("preferences", "</xsl:text><xsl:value-of select="default"/><xsl:text>"));
     gtk_widget_set_tooltip_text(labelev, tooltip);</xsl:text>
   </xsl:template>


### PR DESCRIPTION
We sometimes find elusive bugs caused by signals being connected to handlers that don't provide the correct return value, i.e. void instead of gboolean. GTK/GObject don't have built-in signature checking when connecting signals, as this is not really natively supported in c. This PR adds such checking by extensively using the `_Generic` construct. For this it is necessary to separately provide the expected handler signatures for each type of signal (see the second commit which adds this to `gtk.h`). Since some signals expect different handlers depending on which type of object they are sent for, there is _some_ loss of specificity, but for the common cases, for example `button-press` and `clicked`, this has already helped me find a couple of mismatches (that are now well-hidden in this rather large PR).

It is common practice to send objects as `user_data` that are implicitly converted to `gpointer` and then upon receipt in the handler explicitly converted back to the real type (obviously without any type checking happening). These now need to be declared as their real type in the handler prototype or they'll throw an error.  Similarly, generic objects (like widgets) that get a signal connected are often declared as their real type (for example button) in the handler prototype. These implicit conversions now need to be made explicit (either when connecting or when receiving the signal).

So for the moment many errors are generated. Until these are largely resolved, it is easier to ignore them at compile time (so the compile is allowed to finish) and only print them at runtime. With a decent IDE it is then faster to fix a number of them at the same time. Obviously this has the drawback that one actually has to activate all the `signal_connect`s (by opening all dialogs etc) otherwise the type mismatch will still be ignored.

Eventually, when all existing mismatches are resolved, this can be made into a compile time fail (so that CI will also catch it) by uncommenting the `_Static_assert`. All the checks are already done at compile time only and don't generate any code, except when an error needs to be printed.

Obviously this PR is already rather large. Every signal_connect needs to be touched, because the unnecessary casts to G_OBJECT used to hide the real object type making it impossible to check for a signature with it as the first parameter in `_Generic`. It may not be too useful to complete the whole exercise before GTK4, although getting rid of all the remaining false positives before the end of porting may help find real issues.