### PR TITLE
Improved debugging support for colorin profile

### DIFF
--- a/src/common/chromatic_adaptation.h
+++ b/src/common/chromatic_adaptation.h
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2020 darktable developers.
+    Copyright (C) 2020-2025 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -59,7 +59,7 @@ static const dt_colormatrix_t Bradford_LMS_to_XYZ_trans =
 DT_OMP_DECLARE_SIMD(aligned(XYZ, LMS:16))
 static inline void convert_XYZ_to_bradford_LMS(const dt_aligned_pixel_t XYZ, dt_aligned_pixel_t LMS)
 {
-  // Warning : needs XYZ normalized with Y - you need to downscale before
+  // Warning : needs XYZ normalized with Y - you need to downscale before
   dt_apply_transposed_color_matrix(XYZ, XYZ_to_Bradford_LMS_trans, LMS);
 }
 
@@ -71,7 +71,7 @@ static inline void make_RGB_to_Bradford_LMS(const dt_colormatrix_t rgb, dt_color
 DT_OMP_DECLARE_SIMD(aligned(XYZ, LMS:16))
 static inline void convert_bradford_LMS_to_XYZ(const dt_aligned_pixel_t LMS, dt_aligned_pixel_t XYZ)
 {
-  // Warning : output XYZ normalized with Y - you need to upscale later
+  // Warning : output XYZ normalized with Y - you need to upscale later
   dt_apply_transposed_color_matrix(LMS, Bradford_LMS_to_XYZ_trans, XYZ);
 }
 
@@ -110,7 +110,7 @@ static const dt_colormatrix_t CAT16_LMS_to_XYZ_trans =
 DT_OMP_DECLARE_SIMD(aligned(XYZ, LMS:16))
 static inline void convert_XYZ_to_CAT16_LMS(const dt_aligned_pixel_t XYZ, dt_aligned_pixel_t LMS)
 {
-  // Warning : needs XYZ normalized with Y - you need to downscale before
+  // Warning : needs XYZ normalized with Y - you need to downscale before
   dt_apply_transposed_color_matrix(XYZ, XYZ_to_CAT16_LMS_trans, LMS);
 }
 
@@ -122,7 +122,7 @@ static inline void make_RGB_to_CAT16_LMS(const dt_colormatrix_t rgb, dt_colormat
 DT_OMP_DECLARE_SIMD(aligned(XYZ, LMS:16))
 static inline void convert_CAT16_LMS_to_XYZ(const dt_aligned_pixel_t LMS, dt_aligned_pixel_t XYZ)
 {
-  // Warning : output XYZ normalized with Y - you need to upscale later
+  // Warning : output XYZ normalized with Y - you need to upscale later
   dt_apply_transposed_color_matrix(LMS, CAT16_LMS_to_XYZ_trans, XYZ);
 }
 

--- a/src/common/iop_profile.c
+++ b/src/common/iop_profile.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2020-2024 darktable developers.
+    Copyright (C) 2020-2025 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -976,20 +976,26 @@ dt_iop_order_iccprofile_info_t *dt_ioppr_get_pipe_output_profile_info(const stru
 }
 
 dt_iop_order_iccprofile_info_t *dt_ioppr_get_pipe_current_profile_info(const dt_iop_module_t *module,
-                                                                       struct dt_dev_pixelpipe_t *pipe)
+                                                                       const struct dt_dev_pixelpipe_t *pipe)
 {
   dt_iop_order_iccprofile_info_t *restrict color_profile;
 
   const int colorin_order = dt_ioppr_get_iop_order(module->dev->iop_order_list, "colorin", 0);
   const int colorout_order = dt_ioppr_get_iop_order(module->dev->iop_order_list, "colorout", 0);
-  const int current_module_order = module->iop_order;
 
-  if(current_module_order < colorin_order)
+  if(module->iop_order < colorin_order)
     color_profile = dt_ioppr_get_pipe_input_profile_info(pipe);
-  else if(current_module_order < colorout_order)
+  else if(module->iop_order < colorout_order)
     color_profile = dt_ioppr_get_pipe_work_profile_info(pipe);
   else
     color_profile = dt_ioppr_get_pipe_output_profile_info(pipe);
+
+  if(color_profile
+      && color_profile->filename[0]
+      && (!dt_is_valid_colormatrix(color_profile->matrix_in[0][0])
+          || !dt_is_valid_colormatrix(color_profile->matrix_out[0][0])))
+    dt_print_pipe(DT_DEBUG_PIPE, "current pipe profile", pipe, module, DT_DEVICE_NONE, NULL, NULL,
+     "no matrix in '%s'", color_profile->filename);
 
   return color_profile;
 }

--- a/src/common/iop_profile.h
+++ b/src/common/iop_profile.h
@@ -131,7 +131,7 @@ dt_ioppr_get_pipe_output_profile_info(const struct dt_dev_pixelpipe_t *pipe);
 /** Get the relevant RGB -> XYZ profile at the position of current module */
 dt_iop_order_iccprofile_info_t *
 dt_ioppr_get_pipe_current_profile_info(const struct dt_iop_module_t *module,
-                                       struct dt_dev_pixelpipe_t *pipe);
+                                       const struct dt_dev_pixelpipe_t *pipe);
 
 /** returns the current setting of the work profile on colorin iop */
 void dt_ioppr_get_work_profile_type(struct dt_develop_t *dev,


### PR DESCRIPTION
We might set a profile in colorin that does not include in&out matrixes.

This is not relevant in most cases as we do a fallback to lcms2 when changing the module's colorspace.

But it becomes relevant for blending and picker reading if the module is before colorin in the pipe. Both mentioned algos currently rely on a matrix and thus fail is sucha profile has been selected.

At least we should provide information via the log and control_log so the user knows why that fails and we can further investigate,

Related to #19724 
Not sure yet how to fix that properly so maybe we can take this to give at least a chance for testing and reports.