### PR TITLE
Avoid double "local contrast" module naming

### DIFF
--- a/src/iop/clahe.c
+++ b/src/iop/clahe.c
@@ -58,7 +58,7 @@ typedef struct dt_iop_rlce_data_t
 
 const char *name()
 {
-  return _("local contrast");
+  return _("old local contrast");
 }
 
 int default_group()


### PR DESCRIPTION
The old clahe module alse had name() as "local contrast" possibly leading to a confusing history if both modules were used.