### PR TITLE
Do not display the cursor when in culling view.

### DIFF
--- a/src/dtgtk/thumbnail.c
+++ b/src/dtgtk/thumbnail.c
@@ -891,19 +891,23 @@ static void _thumb_update_icons(dt_thumbnail_t *thumb)
   gtk_widget_show(thumb->w_ext);
 
   // show cursor (filmstrip current-image arrow) only for the active image
-  gboolean show_cursor = thumb->active;
-  if(show_cursor && darktable.view_manager->active_images)
+  // and when in darkroom.
+  gboolean show_active = thumb->active;
+  if(show_active && darktable.view_manager->active_images)
   {
     const int activeid = GPOINTER_TO_INT(darktable.view_manager->active_images->data);
-    show_cursor = (thumb->imgid == activeid);
+    show_active = (thumb->imgid == activeid);
   }
+  const gboolean show_cursor = show_active
+    && !(thumb->container == DT_THUMBNAIL_CONTAINER_CULLING)
+    && (dt_view_get_current() == DT_VIEW_DARKROOM);
   gtk_widget_set_visible(thumb->w_cursor, show_cursor);
 
   for(int i = 0; i < MAX_STARS; i++)
     gtk_widget_show(thumb->w_stars[i]);
 
   _set_flag(thumb->w_main, GTK_STATE_FLAG_PRELIGHT, thumb->mouse_over);
-  _set_flag(thumb->w_main, GTK_STATE_FLAG_ACTIVE, show_cursor);
+  _set_flag(thumb->w_main, GTK_STATE_FLAG_ACTIVE, show_active);
 
   _set_flag(thumb->w_reject, GTK_STATE_FLAG_ACTIVE, (thumb->rating == DT_VIEW_REJECT));
 


### PR DESCRIPTION
When don't want the cursor on the culling main view and also on the bottom filmstrip when in culling mode as this makes no sense here.

Strange but this seems to happen only under Wayland.

Note that we cannot safely use active_images as the refresh of the thumb here in _thumb_update_icons is done asynchronous using Gtk events. It may be the case that active_images is reset when scrolling fast on the culling view. Note sure if this is the case when in darkroom.

Rework fix #19772