### PR TITLE
Use a switch statement in dt_masks_create

### DIFF
--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -840,18 +840,31 @@ dt_masks_form_t *dt_masks_create(const dt_masks_type_t type)
   form->version = dt_masks_version();
   form->formid = time(NULL) + form_id++;
 
-  if(type & DT_MASKS_CIRCLE)
-    form->functions = &dt_masks_functions_circle;
-  else if(type & DT_MASKS_ELLIPSE)
-    form->functions = &dt_masks_functions_ellipse;
-  else if(type & DT_MASKS_BRUSH)
-    form->functions = &dt_masks_functions_brush;
-  else if(type & DT_MASKS_PATH)
-    form->functions = &dt_masks_functions_path;
-  else if(type & DT_MASKS_GRADIENT)
-    form->functions = &dt_masks_functions_gradient;
-  else if(type & DT_MASKS_GROUP)
-    form->functions = &dt_masks_functions_group;
+  switch (type)
+  {
+      case DT_MASKS_CIRCLE:
+        form->functions = &dt_masks_functions_circle;
+        break;
+      case DT_MASKS_ELLIPSE:
+        form->functions = &dt_masks_functions_ellipse;
+        break;
+      case DT_MASKS_BRUSH:
+        form->functions = &dt_masks_functions_brush;
+        break;
+      case DT_MASKS_PATH:
+        form->functions = &dt_masks_functions_path;
+        break;
+      case DT_MASKS_GRADIENT:
+        form->functions = &dt_masks_functions_gradient;
+        break;
+      case DT_MASKS_GROUP:
+        form->functions = &dt_masks_functions_group;
+        break;
+      case DT_MASKS_NONE:
+      case DT_MASKS_CLONE:
+      case DT_MASKS_NON_CLONE:
+        dt_unreachable_codepath();
+  }
 
   if(form->functions && form->functions->sanitize_config)
     form->functions->sanitize_config(type);


### PR DESCRIPTION
`dt_masks_create` takes a dt_masks_type_t enum as input and returns a dt_masks_form_t as output.  Before this commit, the mask type was tested via cascading `if/else if` branches, this commit changes the tests to use a switch/case statement.

The functionality should be the same, but the advantage of using the switch/case statement is that if the dt_masks_type_t enum is ever changed, the compiler will give us a warning.  For example, the cascading `if/else if` didn't handle DT_MASKS_NONE/CLONE/NON_CLONE and the compiler will emit a warning like this:

```
/Users/aaron/git/darktable/src/develop/masks/masks.c:843:11: fatal error: enumeration values 'DT_MASKS_NONE', 'DT_MASKS_CLONE', and 'DT_MASKS_NON_CLONE' not handled in switch [-Wswitch]
  843 |   switch (type)
      |           ^~~~
/Users/aaron/git/darktable/src/develop/masks/masks.c:843:11: note: add missing switch cases
  843 |   switch (type)
      |           ^
1 error generated.
```

As far as I can tell, those values shouldn't be passed to this factory method, so we can use the opportunity to flag those branches as `dt_unreachable_codepath()`.