### PR TITLE
Fix iop label editing

### DIFF
--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -829,14 +829,17 @@ static gboolean _rename_module_key_press(GtkWidget *entry,
   {
     if(gtk_entry_get_text_length(GTK_ENTRY(entry)) > 0)
     {
-      // name is not empty, set new multi_name
+      // name is not empty, set new multi_name only if changed
+      // ensure we keep the built-in as-is
 
        const gchar *name = gtk_entry_get_text(GTK_ENTRY(entry));
+       gchar *current_name = dt_util_localize_segmented_name(module->multi_name, FALSE);
 
-      if(g_strcmp0(module->multi_name, name) != 0)
+      if(g_strcmp0(current_name, name) != 0)
       {
         dt_iop_update_multi_name(module, name, TRUE, TRUE, TRUE);
       }
+      g_free(current_name);
     }
     else
     {
@@ -898,12 +901,15 @@ void dt_iop_gui_rename_module(dt_iop_module_t *module)
   gtk_widget_set_name(entry, "iop-panel-label");
   gtk_entry_set_width_chars(GTK_ENTRY(entry), 0);
   gtk_entry_set_max_length(GTK_ENTRY(entry), sizeof(module->multi_name) - 1);
+
+  gchar *name = dt_util_localize_segmented_name(module->multi_name, FALSE);
   gtk_entry_set_text(GTK_ENTRY(entry),
                      strcmp(module->multi_name, "0")
                      || module->multi_priority > 0
                      || module->multi_name_hand_edited
-                       ? module->multi_name
+                       ? name
                        : "");
+  g_free(name);
 
   //  hide module instance name as we need the space for the entry
   gtk_widget_hide(module->instance_name);


### PR DESCRIPTION
Ensure that when editing we are displaying the localized name and not the internal "_builtin_scene-referred default" for example. So we compare the current translated multi_name to the actual entry text to check if the value has changed.

This issue has bothered me since some time now, with current master, if you edit Exposure iop label:

<img width="376" height="85" alt="image" src="https://github.com/user-attachments/assets/89421ee5-9226-4339-b150-69b0eaad2014" />


With this patch:

<img width="379" height="73" alt="image" src="https://github.com/user-attachments/assets/a507f1e5-43f1-4c41-b1df-d59b406d20c8" />
