### PR TITLE
Ensure that we keep the darktablerc database setting.

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1534,6 +1534,8 @@ int dt_init(int argc,
   const int last_configure_version =
     dt_conf_get_int("performance_configuration_version_completed");
 
+  gboolean has_workspace = FALSE;
+
   // we need this REALLY early so that error messages can be shown,
   // however after gtk_disable_setlocale
   if(init_gui)
@@ -1576,7 +1578,7 @@ int dt_init(int argc,
     }
 
     // select database
-    dt_workspace_create(datadir);
+    has_workspace = dt_workspace_create(datadir);
   }
 
   // now load darktablerc for the given library. Either darktablerc
@@ -1586,7 +1588,7 @@ int dt_init(int argc,
   const char *dblabel = dt_conf_get_string("workspace/label");
   const gboolean multiple_db = dt_conf_get_bool("database/multiple_workspace");
 
-  const gboolean default_dbname = strcmp(dblabel, "") == 0;
+  const gboolean default_dbname = !has_workspace || strcmp(dblabel, "") == 0;
 
   char darktablerc[PATH_MAX] = { 0 };
   snprintf(darktablerc, sizeof(darktablerc),
@@ -1598,14 +1600,17 @@ int dt_init(int argc,
 
   g_slist_free_full(config_override, g_free);
 
-  // restore dbname & label (as set in call dt_dbsession_create) to
-  // the one selected on the dialog ensuring that if the
-  // darktablerc-* is not yet preset we won't store the default
-  // values from confgen.
+  if(has_workspace)
+  {
+    // restore dbname & label (as set in call dt_workspace_create) to
+    // the one selected on the dialog ensuring that if the
+    // darktablerc-* is not yet present we won't store the default
+    // values from confgen.
 
-  dt_conf_set_string("database", dbname);
-  dt_conf_set_string("workspace/label", dblabel);
-  dt_conf_set_bool("database/multiple_workspace", multiple_db);
+    dt_conf_set_string("database", dbname);
+    dt_conf_set_string("workspace/label", dblabel);
+    dt_conf_set_bool("database/multiple_workspace", multiple_db);
+  }
 
   if(init_gui)
   {

--- a/src/gui/workspace.c
+++ b/src/gui/workspace.c
@@ -140,13 +140,13 @@ static GtkBox *_insert_button(dt_workspace_t *session, const char *label)
   return box;
 }
 
-void dt_workspace_create(const char *datadir)
+gboolean dt_workspace_create(const char *datadir)
 {
   if(dt_check_gimpmode("file")
      || dt_check_gimpmode("thumb")
      || !dt_conf_get_bool("database/multiple_workspace"))
   {
-    return;
+    return FALSE;
   }
 
   dt_workspace_t *session = g_malloc(sizeof(dt_workspace_t));
@@ -257,6 +257,8 @@ void dt_workspace_create(const char *datadir)
 
   _workspace_screen_destroy(session);
   g_free(session);
+
+  return TRUE;
 }
 
 // clang-format off

--- a/src/gui/workspace.h
+++ b/src/gui/workspace.h
@@ -16,7 +16,8 @@
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-void dt_workspace_create(const char *datadir);
+/* returns TRUE if a workspace is active/created and FALSE otherwise */
+gboolean dt_workspace_create(const char *datadir);
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py


### PR DESCRIPTION
A regression introduced when adding the multiple workspace support. We restore the database (file, label) only if multiple workspaces option is active.

Closes #19860