### PR TITLE
Avoid crash at exit due to race condition

### DIFF
--- a/src/control/control.c
+++ b/src/control/control.c
@@ -285,7 +285,7 @@ void dt_control_change_cursor(dt_cursor_t curs)
 
 gboolean dt_control_running()
 {
-  return dt_atomic_get_int(&darktable.control->running) == DT_CONTROL_STATE_RUNNING;
+  return darktable.control && dt_atomic_get_int(&darktable.control->running) == DT_CONTROL_STATE_RUNNING;
 }
 
 void dt_control_quit()
@@ -383,8 +383,8 @@ void dt_control_cleanup(const gboolean withgui)
     if(s->shortcuts) g_sequence_free(s->shortcuts);
     if(s->input_drivers) g_slist_free_full(s->input_drivers, g_free);
   }
-  free(s);
   darktable.control = NULL;
+  free(s);
 }
 
 


### PR DESCRIPTION
It is possible to get a crash in a background job such as `_control_write_sidecars_job_run` on exit due to an attempt by the job to check whether the control system is still running with dt_control_running() *after* darktable.control has been freed.  I've experienced this twice since switching my production copy from 5.2.1 to master about three weeks ago.

While this commit is not a total fix, it reduces the vulnerable time window from milliseconds to nanoseconds.
