### PR TITLE
speed up initial import of default styles

### DIFF
--- a/src/common/styles.c
+++ b/src/common/styles.c
@@ -1821,6 +1821,9 @@ void dt_import_default_styles(const char *folder)
 {
   struct dirent **entries;
   const int numentries = scandir(folder, &entries, _check_extension, alphasort);
+  if(numentries < 0)
+    return;
+  dt_database_start_transaction(darktable.db);
   for(int i = 0; i < numentries; i++)
   {
     char *filename = g_build_filename(folder, entries[i]->d_name, NULL);
@@ -1836,8 +1839,8 @@ void dt_import_default_styles(const char *folder)
     g_free(filename);
     free(entries[i]);
   }
-  if(numentries != -1)
-    free(entries);
+  dt_database_release_transaction(darktable.db);
+  free(entries);
 }
 
 // clang-format off


### PR DESCRIPTION
Wrap the import of the supplied styles in a database transaction to avoid flushing to disk after every single style is imported.  This reduces the import time when the configdir is located on a HDD from about three minutes to less than two seconds (and correspondingly speeds up the first startup of a new installation).  Initial import takes less than a second on an SSD even without the transaction, so users with such a configuration won't notice any difference.

Pointed out by comment on #19881.
