### PR TITLE
Ensure safe data in _pixelpipe_picker_cl()

### DIFF
--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -940,19 +940,18 @@ static void _pixelpipe_picker_cl(const int devid,
 {
   int box[4] = { 0 };
 
+  // make sure we return safe data in case of errors
+  for_four_channels(k)
+  {
+    picked_color_min[k] = FLT_MAX;
+    picked_color_max[k] = -FLT_MAX;
+    picked_color[k] = 0.0f;
+  }
+
   if(dt_color_picker_box(module, roi,
                          darktable.lib->proxy.colorpicker.primary_sample,
                          picker_source, box))
-  {
-    for_four_channels(k)
-    {
-      picked_color_min[k] = FLT_MAX;
-      picked_color_max[k] = -FLT_MAX;
-      picked_color[k] = 0.0f;
-    }
-
     return;
-  }
 
   const size_t origin[3] = { box[0], box[1], 0 };
   const size_t region[3] = { box[2] - box[0], box[3] - box[1], 1 };
@@ -981,7 +980,7 @@ static void _pixelpipe_picker_cl(const int devid,
                   ? "pixelpipe IN picker CL"
                   : "pixelpipe OUT picker CL",
                   piece->pipe, module, devid, roi, NULL, "Couldn't read picker data");
-    goto error;    
+    goto error;
   }
 
   dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_PICKER,


### PR DESCRIPTION
Make sure we write meaningfull data to the picker results if for some reason the picker data could not be calculated.