### PR TITLE
Fix jumping to new collection.

### DIFF
--- a/src/common/collection.c
+++ b/src/common/collection.c
@@ -2349,6 +2349,50 @@ void dt_collection_sort_serialize(char *buf, int bufsize)
   }
 }
 
+char *dt_collection_checksum(const gboolean filtering)
+{
+  const char *plugin_name = filtering
+    ? "plugins/lighttable/filtering"
+    : "plugins/lighttable/collect";
+  char confname[200];
+
+  snprintf(confname, sizeof(confname), "%s/num_rules", plugin_name);
+  const int num_rules = dt_conf_get_int(confname);
+
+  GChecksum *checksum = g_checksum_new(G_CHECKSUM_MD5);
+  g_checksum_update(checksum, (const guchar *)&num_rules, sizeof(int));
+
+  for(int k = 0; k < num_rules; k++)
+  {
+    snprintf(confname, sizeof(confname), "%s/mode%1d", plugin_name, k);
+    const int mode = dt_conf_get_int(confname);
+    g_checksum_update(checksum, (const guchar *)&mode, sizeof(int));
+
+    snprintf(confname, sizeof(confname), "%s/item%1d", plugin_name, k);
+    const int item = dt_conf_get_int(confname);
+    g_checksum_update(checksum, (const guchar *)&item, sizeof(int));
+
+    if(filtering)
+    {
+      snprintf(confname, sizeof(confname), "%s/off%1d", plugin_name, k);
+      const int off = dt_conf_get_int(confname);
+      g_checksum_update(checksum, (const guchar *)&off, sizeof(int));
+
+      snprintf(confname, sizeof(confname), "%s/top%1d", plugin_name, k);
+      const int top = dt_conf_get_int(confname);
+      g_checksum_update(checksum, (const guchar *)&top, sizeof(int));
+    }
+
+    snprintf(confname, sizeof(confname), "%s/string%1d", plugin_name, k);
+    const char *str = dt_conf_get_string_const(confname);
+    g_checksum_update(checksum, (const guchar *)str, strlen(str));
+  }
+
+  char *chk = g_strdup(g_checksum_get_string(checksum));
+  g_checksum_free(checksum);
+  return chk;
+}
+
 int dt_collection_serialize(char *buf, int bufsize,
                             const gboolean filtering)
 {

--- a/src/common/collection.c
+++ b/src/common/collection.c
@@ -2397,12 +2397,12 @@ int dt_collection_serialize(char *buf, int bufsize,
                             const gboolean filtering)
 {
   const char *plugin_name = filtering
-    ? "plugins/lighttable/filtering" : "plugins/lighttable/collect";
+    ? "plugins/lighttable/filtering"
+    : "plugins/lighttable/collect";
   char confname[200];
-  int c;
   snprintf(confname, sizeof(confname), "%s/num_rules", plugin_name);
   const int num_rules = dt_conf_get_int(confname);
-  c = snprintf(buf, bufsize, "%d:", num_rules);
+  int c = snprintf(buf, bufsize, "%d:", num_rules);
   buf += c;
   bufsize -= c;
   for(int k = 0; k < num_rules; k++)
@@ -2445,7 +2445,8 @@ int dt_collection_serialize(char *buf, int bufsize,
 void dt_collection_deserialize(const char *buf, const gboolean filtering)
 {
   const char *plugin_name = filtering
-    ? "plugins/lighttable/filtering" : "plugins/lighttable/collect";
+    ? "plugins/lighttable/filtering"
+    : "plugins/lighttable/collect";
   char confname[200];
   int num_rules = 0;
   sscanf(buf, "%d", &num_rules);

--- a/src/common/collection.h
+++ b/src/common/collection.h
@@ -248,6 +248,8 @@ int dt_collection_image_offset(dt_imgid_t imgid);
 /* serialize and deserialize into a string. */
 void dt_collection_deserialize(const char *buf, gboolean filtering);
 int dt_collection_serialize(char *buf, int bufsize, gboolean filtering);
+/* get a checksum for the current collection */
+char * dt_collection_checksum(const gboolean filtering);
 
 /* splits an input string into a number part and an optional operator part */
 void dt_collection_split_operator_number(const gchar *input,

--- a/src/common/collection.h
+++ b/src/common/collection.h
@@ -246,8 +246,8 @@ void dt_collection_hint_message(const dt_collection_t *collection);
 int dt_collection_image_offset(dt_imgid_t imgid);
 
 /* serialize and deserialize into a string. */
-void dt_collection_deserialize(const char *buf, gboolean filtering);
-int dt_collection_serialize(char *buf, int bufsize, gboolean filtering);
+void dt_collection_deserialize(const char *buf, const gboolean filtering);
+int dt_collection_serialize(char *buf, int bufsize, const gboolean filtering);
 /* get a checksum for the current collection */
 char * dt_collection_checksum(const gboolean filtering);
 

--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -230,10 +230,12 @@ static int32_t _generic_dt_control_fileop_images_job_run
     dt_collection_deserialize(collect, FALSE);
   }
   dt_film_remove_empty();
+
   DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_FILMROLLS_CHANGED);
   dt_collection_update_query(darktable.collection,
                              DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_UNDEF,
                              g_list_copy(params->index));
+
   dt_control_queue_redraw_center();
   return 0;
 }


### PR DESCRIPTION
    
When moving pictures, we now jump to the new collection only if:
- We did not moved manually to another collection.
- The current collection still have some pictures.

When copying pictures:
- We also jump to new collection only if we did not switch manually to another collection.
    
Closes #19894.
