### PR TITLE
Exiv2 inability to open a file is a critical error and should always be logged

### DIFF
--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -2586,7 +2586,7 @@ gboolean dt_exif_read(dt_image_t *img,
   }
   catch(const Exiv2::AnyError &e)
   {
-    dt_print(DT_DEBUG_IMAGEIO,
+    dt_print(DT_DEBUG_ALWAYS,
              "[exiv2 dt_exif_read] %s: %s",
              path,
              e.what());


### PR DESCRIPTION
Critical errors, which should not occur when the program is working correctly, should always be logged, not just when debugging channel is activated.

This is certainly not a bugfix, but IMO it's better to merge it before release, as it's obviously a completely safe change and it will make it easier for inexperienced users to report bugs.