### PR TITLE
Fix lock file deletion on Windows

### DIFF
--- a/src/common/database.c
+++ b/src/common/database.c
@@ -4002,8 +4002,8 @@ lock_again:
       fd = g_open(*lockfile, O_RDWR | O_CREAT, 0666);
       if(fd != -1)
       {
-        int foo;
-        if((foo = read(fd, buf, sizeof(buf) - 1)) > 0)
+        int bytes_read = read(fd, buf, sizeof(buf) - 1);
+        if(bytes_read > 0)
         {
           db->error_other_pid = atoi(buf);
           if(!pid_is_alive(db->error_other_pid))


### PR DESCRIPTION
Quote from the docs on the `g_unlink` function: "Note that on Windows, it is in general not possible to delete files that are open to some process".

This is exactly what was happening on Windows as we didn't close the file before unlinking, and I verified this under the debugger. Attempts to delete the lock file were in vain. And since the `g_unlink` error code was not checked, it went unnoticed. The logic was that there should be no problems in this branch of execution, so although we did not acquire the lock, we did not assign the values ​​of the variables that would allow us to later detect failure and delete the lock from the dialog window.

After this fix, we will successfully delete the lock file if we make sure it contains the pid of a process that no longer exists. This way, when starting darktable after a previous crash, we will delete the lock file and acquire the lock ourselves even without user interaction.