### PR TITLE
Add crop factor for Canon EOS 6D Mark II

### DIFF
--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -91,6 +91,9 @@ static const struct dt_model_cropfactor dt_cropfactors[] = {
   {.model = "Canon EOS 5D Mark IV", // tags contain incorrect data, so formula gives us incorrect result
    .cropfactor = 1.0f
   },
+  {.model = "Canon EOS 6D Mark II", // tags contain incorrect data, so formula gives us incorrect result
+   .cropfactor = 1.0f
+  },
   {.model = "FinePix SL1000", // exiv2 doesn't yet read the tags we need to calculate correctly
    .cropfactor = 5.6f
   },


### PR DESCRIPTION
The Canon EOS 6D Mark II is a full-frame camera with crop factor 1.0.

Similar to Canon EOS 5D Mark IV, the EXIF tags contain incorrect data, so we need to specify the crop factor explicitly in the dt_cropfactors array.

Issue #19941