### PR TITLE
ensure dt window icon is used on Plasma/Wayland

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1473,6 +1473,10 @@ int dt_init(int argc,
     g_free(new_xdg_data_dirs);
   }
 
+  // desktop entry name required for mapping application icon to
+  // window for KDE/Plasma on Wayland under GTK 3
+  g_set_prgname("org.darktable.darktable");
+
   setlocale(LC_ALL, "");
   char localedir[PATH_MAX] = { 0 };
   dt_loc_get_localedir(localedir, sizeof(localedir));


### PR DESCRIPTION
Setting the program name to match our desktop file allows for the icon to come from that file.

Fixes #19946.

Note that this fixes a Wayland/Plasma interaction under GTK 3. A different solution will be necessary for GTK 4 (see #19448), apparently via setting the desktop file basename via `gtk_application_new()`.