### PR TITLE
Fix building with -Wfatal-errors on aarch64

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -917,7 +917,9 @@ int dt_init(int argc,
 #endif
 
   // make everything go a lot faster.
+#ifdef __SSE2__
   dt_mm_enable_flush_zero();
+#endif
 
   dt_set_signal_handlers();
 


### PR DESCRIPTION
Otherwise fails with:
```
/home/runner/work/darktable/darktable/src/src/common/darktable.c: In function ‘dt_init’:
/home/runner/work/darktable/darktable/src/src/develop/imageop.h:662:35: error: statement with no effect [-Werror=unused-value]
  662 | #define dt_mm_enable_flush_zero() 0
      |                                   ^
/home/runner/work/darktable/darktable/src/src/common/darktable.c:920:3: note: in expansion of macro ‘dt_mm_enable_flush_zero’
  920 |   dt_mm_enable_flush_zero();
      |   ^~~~~~~~~~~~~~~~~~~~~~~
compilation terminated due to -Wfatal-errors.
```
@TurboGit Hopefully you can squeeze it in? ;)