### PR TITLE
Keep applied preset name marked with asterix after changes

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -798,11 +798,22 @@ static void _dev_auto_module_label(dt_develop_t *dev,
     if(preset_name)
       snprintf(module->multi_name,
                sizeof(module->multi_name), "%s", preset_name);
+    else if(strlen(module->multi_name) > strspn(module->multi_name, "0123456789"))
+    {
+      if(module->multi_name[0] != '*')
+      {
+        // prepend asterisk to indicate changed from preset
+        int len = MIN(strlen(module->multi_name), sizeof(module->multi_name) - 2);
+        memmove(module->multi_name + 1, module->multi_name, len);
+        module->multi_name[0] = '*';
+        module->multi_name[len + 1] = '\0';
+      }
+    }
     else if(module->multi_priority != 0)
       snprintf(module->multi_name,
                sizeof(module->multi_name), "%d", module->multi_priority);
     else
-      g_strlcpy(module->multi_name, "", sizeof(module->multi_name));
+      module->multi_name[0] = '\0';
 
     g_free(preset_name);
 

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -2293,6 +2293,9 @@ static gboolean _gui_reset_callback(GtkButton *button,
     dt_iop_reload_defaults(module);
     dt_iop_commit_blend_params(module, module->default_blendop_params);
 
+    if(!module->multi_name_hand_edited)
+      module->multi_name[0] = '\0';
+
     /* reset ui to its defaults */
     dt_iop_gui_reset(module);
 


### PR DESCRIPTION
Implements suggestion in https://discuss.pixls.us/t/small-improvement-in-modules-instance-naming/54795/4

When a preset is applied to a module, it's name is added as the instance name to the module (if one wasn't set manually). Then when _any_ change is made, the instance name is reset to empty, This PR _keeps_ the name of the last applied preset as the instance name, but marks it with an asterix if any further changes are made.

Other ways of marking (different prefix or postfix characters) can be easily implemented in `dt_util_localize_segmented_name` even when internally keeping the "*" prefix (which doesn't conflict with translation markers; postfix markers would be more complicated to deal with internally).

This also includes the simplifications of `dt_util_localize_segmented_name` suggested here https://github.com/darktable-org/darktable/pull/19459#issuecomment-3368364195