### PR TITLE
Adds the ability to pin the currently developed photo to the 2nd darkroom window

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -1098,6 +1098,28 @@ treeview header label
 }
 
 /*-------------------------------------
+  - 2nd darkroom window options       -
+  -------------------------------------*/
+
+#dt_window2_on_top_button,
+#dt_window2_pin_button {
+  background-color: @button_bg;
+  border: 0.08em solid transparent;
+}
+
+#dt_window2_on_top_button:hover,
+#dt_window2_pin_button:hover {
+  background-color: alpha(@button_hover_bg, 0.5);
+  border-color: transparent;
+  color: shade(@fg_color, 1.15);
+}
+
+#dt_window2_on_top_button:checked,
+#dt_window2_pin_button:checked {
+  border: 0.08em solid @button_fg;
+}
+
+/*-------------------------------------
   - Preferences dialog window options -
   -------------------------------------*/
 #preferences-box,

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -1101,20 +1101,16 @@ treeview header label
   - 2nd darkroom window options       -
   -------------------------------------*/
 
-#dt_window2_on_top_button,
 #dt_window2_pin_button {
   background-color: @button_bg;
   border: 0.08em solid transparent;
 }
 
-#dt_window2_on_top_button:hover,
 #dt_window2_pin_button:hover {
   background-color: alpha(@button_hover_bg, 0.5);
   border-color: transparent;
-  color: shade(@fg_color, 1.15);
 }
 
-#dt_window2_on_top_button:checked,
 #dt_window2_pin_button:checked {
   border: 0.08em solid @button_fg;
 }

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -460,7 +460,7 @@ static void _init_pinned_dev(dt_develop_t *pinned_dev, dt_develop_t *main_dev,
   dt_unlock_image(imgid);
 }
 
-void _pin_image(dt_develop_t *dev)
+static void _pin_image(dt_develop_t *dev)
 {
   const dt_imgid_t pinned_imgid = dev->image_storage.id;
   if(dev->preview2_pinned_dev)
@@ -484,7 +484,7 @@ void _pin_image(dt_develop_t *dev)
   dt_toast_log(_("image pinned"));
 }
 
-void _unpin_image(dt_develop_t *dev)
+static void _unpin_image(dt_develop_t *dev)
 {
   if(dev->preview2_pinned_dev)
   {

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -107,6 +107,7 @@ typedef struct dt_dev_proxy_exposure_t
 } dt_dev_proxy_exposure_t;
 
 struct dt_dev_pixelpipe_t;
+struct dt_develop_t;
 typedef struct dt_dev_viewport_t
 {
   GtkWidget *widget; // TODO (#18559): remove gtk stuff from here
@@ -126,6 +127,12 @@ typedef struct dt_dev_viewport_t
 
   // image processing pipeline with caching
   struct dt_dev_pixelpipe_t *pipe;
+  
+  // Pin button for the second window
+  GtkWidget *pin_button;
+  
+  // Back-pointer to the owning develop structure
+  struct dt_develop_t *dev;
 } dt_dev_viewport_t;
 
 /* keep track on what and where we do chromatic adaptation, used
@@ -352,6 +359,11 @@ typedef struct dt_develop_t
   gboolean darkroom_mouse_in_center_area; // TRUE if the mouse cursor is in center area
 
   GList *module_filter_out;
+  
+  // Pinned image for second window: a separate develop structure for the pinned image
+  // When pinned, this holds its own image, history, iop modules, and pipeline
+  gboolean preview2_pinned;                       // Whether the second window is pinned to a specific image
+  struct dt_develop_t *preview2_pinned_dev;       // Separate develop for pinned image (NULL when not pinned)
 } dt_develop_t;
 
 void dt_dev_init(dt_develop_t *dev, gboolean gui_attached);
@@ -412,9 +424,16 @@ void dt_dev_invalidate_history_module(GList *list,
 
 void dt_dev_invalidate(dt_develop_t *dev);
 // also invalidates preview (which is unaffected by resize/zoom/pan)
+void dt_dev_invalidate_preview(dt_develop_t *dev);
 void dt_dev_invalidate_all(dt_develop_t *dev);
 void dt_dev_pipe_synch_all(dt_develop_t *dev);
-void dt_dev_set_histogram(dt_develop_t *dev);
+
+/**
+ * Toggle the pinned state of the second preview window.
+ * When pinned, the second window will continue to show the current image
+ * even when the user navigates to other images.
+ */
+void dt_dev_toggle_preview2_pinned(dt_develop_t *dev);
 void dt_dev_set_histogram_pre(dt_develop_t *dev);
 void dt_dev_reprocess_all(dt_develop_t *dev);
 void dt_dev_reprocess_center(dt_develop_t *dev);


### PR DESCRIPTION
This change adds two buttons to the 2nd darkroom window, making this functionality more generally useful:

1. A "pin" button to keep the 2nd window focused on the currently developed images. Changing images in the darktable main window does not affect the content of the 2nd window. This is useful to use the 2nd window as a reference, e.g., for style matching or color grading.

2. A "keep on top" button, which keeps the 2nd window on top of the main one. This is especially useful for macOS users, as the OS does not implement this functionality natively.

The two changes are bundled together because on macOS pinning the image without being able to keep it in on top greatly reduces its usefulness. Additionally, the code footprint of (2) is negligible.

The change was proposed and discussed on [Pixls](https://discuss.pixls.us/t/new-feature-display-different-image-in-second-darkroom-window/54633), and the community seemed to welcome it.

The implementation discussed on Pixls was taking a full-size snapshot of the image. Following @dterrahe's suggestions, I reimplemented it to use a separate pixelpipe for the 2nd window.

When the image is pinned, the current pipe is duplicated and the view of 2nd window updated to point to insist on the new pipe. When the image is unpinned, the 2nd pipe is destroyed and the main darkroom pipe is restored.

See demo video below:

https://github.com/user-attachments/assets/01218baa-d8b8-4c06-8837-6be2cd846a7d

You will see a lot of examples with composite (overlay) and watermark, as the changes introduced in develop.c to be able to reuse the pipe had broken that functionality. It took me quite a bit to track down the issue and fix it. The problematic bit is documented in the code.

I tested extensively opening and closing the 2nd window, pinning and unpinning repeatedly while the main image is still being rendered, which led me to fix some issues with the 2nd window cleanup code.

I am quite confident that the logic is sound now, but I am not familiar with the pixelpipe code so a close inspection from more expert eyes is very welcome. Everything seems to work as expected, but you never know.
