### PR TITLE
[macOS]: make package build independent from git

### DIFF
--- a/packaging/macosx/3_make_hb_darktable_package.sh
+++ b/packaging/macosx/3_make_hb_darktable_package.sh
@@ -25,6 +25,13 @@ dtExecDir="$dtWorkingDir"/Contents/MacOS
 dtExecutables=$(echo "$dtExecDir"/darktable{,-chart,-cli,-cltest,-generate-cache,-rs-identify,-curve-tool,-noiseprofile})
 homebrewHome=$(brew --prefix)
 
+# Extract darktable version number and commit
+dt_version_full=$(cat ../../build/bin/version_gen.c | grep darktable_package_version | cut -d'"' -f2)
+dt_version=$(echo $dt_version_full | cut -d'+' -f1)
+dt_commit=$(echo $dt_version_full | cut -d'+' -f2 | cut -d'~' -f1)
+if [[ "$dt_version" = "$dt_commit" ]]; then
+  dt_commit="0"
+fi
 
 # Install direct and transitive dependencies
 function install_dependencies {
@@ -206,8 +213,8 @@ echo "APPL$dtAppName" >>"$dtWorkingDir"/Contents/PkgInfo
 cp Icons.icns "$dtResourcesDir"/
 
 # Set version information
-sed -i '' 's|{VERSION}|'$(git describe --tags --long --match '*[0-9.][0-9.][0-9]' | cut -d- -f2 | sed 's/^\([0-9]*\.[0-9]*\)$/\1.0/')'|' "$dtWorkingDir"/Contents/Info.plist
-sed -i '' 's|{COMMITS}|'$(git describe --tags --long --match '*[0-9.][0-9.][0-9]' | cut -d- -f3)'|' "$dtWorkingDir"/Contents/Info.plist
+sed -i '' 's|{VERSION}|'$(echo $dt_version)'|' "$dtWorkingDir"/Contents/Info.plist
+sed -i '' 's|{COMMITS}|'$(echo $dt_commit)'|' "$dtWorkingDir"/Contents/Info.plist
 
 # Generate settings.ini
 echo "[Settings]


### PR DESCRIPTION
Extract darktable version and commit count from `version_gen.c` to make it independent from git.

This allows the full package build from a source tarball.