### PR TITLE
Fix zoomable layout when starting dt.

### DIFF
--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -633,6 +633,9 @@ static void _preview_set_state(dt_view_t *self,
 void init(dt_view_t *self)
 {
   self->data = calloc(1, sizeof(dt_library_t));
+  dt_library_t *lib = self->data;
+
+  lib->current_layout = DT_LIGHTTABLE_LAYOUT_FIRST;
 
   darktable.view_manager->proxy.lighttable.get_preview_state = _preview_get_state;
   darktable.view_manager->proxy.lighttable.set_preview_state = _preview_set_state;


### PR DESCRIPTION
We need to initialize the current layout to something different than O which is the value for DT_LIGHTTABLE_LAYOUT_ZOOMABLE.

Closes #19004.