### PR TITLE
control_log if export size is reduced because of memory restrictions

### DIFF
--- a/src/imageio/imageio.c
+++ b/src/imageio/imageio.c
@@ -1294,6 +1294,10 @@ gboolean dt_imageio_export_with_flags(const dt_imgid_t imgid,
 
   const int processed_width = floor(scale * pipe.processed_width);
   const int processed_height = floor(scale * pipe.processed_height);
+  if(scale == max_scale && !thumbnail_export)
+    dt_control_log(_("export reduced to %dx%d because of memory restrictions"),
+            processed_width, processed_height);
+
   const gboolean size_warning = processed_width < 1 || processed_height < 1;
   dt_print(DT_DEBUG_IMAGEIO,
            "[dt_imageio_export] %s%s imgid %d, %ix%i --> %ix%i (scale=%.4f, maxscale=%.4f)."


### PR DESCRIPTION
Fixes #19926