### PR TITLE
Avoid control threads race condition

### DIFF
--- a/src/control/control.c
+++ b/src/control/control.c
@@ -203,6 +203,7 @@ void dt_control_init(const gboolean withgui)
   s->input_drivers = NULL;
   dt_atomic_set_int(&s->quitting, 0);
   dt_atomic_set_int(&s->pending_jobs, 0);
+  dt_atomic_set_int(&s->running_jobs, 0);
   s->cups_started = FALSE;
 
   dt_action_define_fallback(DT_ACTION_TYPE_IOP, &dt_action_def_iop);

--- a/src/control/control.h
+++ b/src/control/control.h
@@ -181,6 +181,7 @@ typedef struct dt_control_t
   dt_atomic_int running;
   dt_atomic_int quitting;
   dt_atomic_int pending_jobs;
+  dt_atomic_int running_jobs;
   gboolean cups_started;
   gboolean export_scheduled;
   dt_pthread_mutex_t queue_mutex, cond_mutex;

--- a/src/control/jobs.h
+++ b/src/control/jobs.h
@@ -82,6 +82,7 @@ double dt_control_job_get_progress(const dt_job_t *job);
 void dt_control_jobs_init(void);
 void dt_control_jobs_cleanup(void);
 int dt_control_jobs_pending(void);
+gboolean dt_control_all_running(void);
 
 gboolean dt_control_add_job(dt_job_queue_t queue_id, dt_job_t *job);
 gboolean dt_control_add_job_res(dt_job_t *job, const int32_t res);

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -1622,7 +1622,7 @@ void dt_gui_gtk_run(dt_gui_gtk_t *gui)
   dt_osx_focus_window();
 #endif
   /* start the event loop */
-  if(dt_control_running())
+  if(dt_control_all_running())
   {
     g_atomic_int_set(&darktable.gui_running, 1);
     gtk_main();


### PR DESCRIPTION
When starting the dt gui and calling `gtk_main()` we must be sure we can safely dispatch a control job. We can do so only if all control threads are running.

We achieve this by adding a control->running atomic counter which is increased whenever any of the threads code has been started. As we know the number of started threads we can check & wait (for up to 1sec) until all threads are up&running before leaving `dt_control_jobs_init()`.

The new function `gboolean dt_control_all_running()` tests for running vs requested threads and is used to test if we can finally use `gtk_main()`.

@wpferguson this would be my "proper" solution for the hypothesis, that we have a race condition as the root cause for #19992. At least: **if** we dispatch a control job either in lighttable or darkroom it could be the case that the worker for that job is not running yet and thus ends in nirvana. I have to confess i couldn't trigger it yet a single time. (but i am mostly on my slow notebook still).

Would you and others discussing in #19992 be able to compile and test (@victoryforce @gi-man)

@TurboGit code is absolutely safe to me. 
