### PR TITLE
RFC: Gamma corrected pipe input scaling for rgb images

### DIFF
--- a/data/kernels/colorspaces.cl
+++ b/data/kernels/colorspaces.cl
@@ -81,3 +81,15 @@ colorspaces_transform_rgb_matrix_to_rgb(read_only image2d_t in, write_only image
 
   write_imagef(out, (int2)(x, y), pixel);
 }
+
+kernel void
+colorspaces_transform_gamma(read_only image2d_t in, write_only image2d_t out, const int width, const int height, const float gamma)
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+
+  if(x >= width || y >= height) return;
+
+  const float4 pixel = fmax(0.0f, read_imagef(in, sampleri, (int2)(x, y)) );
+  write_imagef(out, (int2)(x, y), dtcl_pow(pixel, gamma));
+}

--- a/src/common/image.h
+++ b/src/common/image.h
@@ -107,7 +107,8 @@ typedef enum dt_image_colorspace_t
 {
   DT_IMAGE_COLORSPACE_NONE,
   DT_IMAGE_COLORSPACE_SRGB,
-  DT_IMAGE_COLORSPACE_ADOBE_RGB
+  DT_IMAGE_COLORSPACE_ADOBE_RGB,
+  DT_IMAGE_COLORSPACE_USER_RGB
 } dt_image_colorspace_t;
 
 typedef struct dt_image_raw_parameters_t

--- a/src/common/iop_profile.h
+++ b/src/common/iop_profile.h
@@ -181,6 +181,7 @@ typedef struct dt_colorspaces_cl_global_t
   int kernel_colorspaces_transform_lab_to_rgb_matrix;
   int kernel_colorspaces_transform_rgb_matrix_to_lab;
   int kernel_colorspaces_transform_rgb_matrix_to_rgb;
+  int kernel_colorspaces_gamma;
 } dt_colorspaces_cl_global_t;
 
 // must be in synch with colorspaces.cl dt_colorspaces_iccprofile_info_cl_t

--- a/src/common/mipmap_cache.c
+++ b/src/common/mipmap_cache.c
@@ -1448,10 +1448,12 @@ static void _init_f(dt_mipmap_buffer_t *mipmap_buf,
   }
   else
   {
-    // downsample
+    // scale
+    const gboolean gamma = image->colorspace != DT_IMAGE_COLORSPACE_NONE;
     dt_print_pipe(DT_DEBUG_PIPE,
-      "mipmap clip and zoom", NULL, NULL, DT_DEVICE_CPU, &roi_in, &roi_out);
-    dt_iop_clip_and_zoom(out, (const float *)buf.buf, &roi_out, &roi_in);
+      "mipmap clip&zoom", NULL, NULL, DT_DEVICE_NONE, &roi_in, &roi_out, "%s",
+          gamma ? "gamma corrected" : "");
+    dt_iop_clip_and_zoom(out, (const float *)buf.buf, &roi_out, &roi_in, gamma);
   }
 
   dt_mipmap_cache_release(&buf);

--- a/src/develop/imageop_math.c
+++ b/src/develop/imageop_math.c
@@ -144,15 +144,35 @@ void dt_iop_clip_and_zoom_8(const uint8_t *i,
   }
 }
 
-// apply clip and zoom on parts of a supplied full image.
-// roi_in and roi_out define which part to work on.
+/* apply clip and zoom on parts of a supplied full image, roi_in and roi_out define which part to work on.
+    gamma correction around scaling supported.
+    We don't do full RGB->linear and transformation but only use a gamma as that is fully sufficient
+    for scaling.
+*/
 void dt_iop_clip_and_zoom(float *out,
                           const float *const in,
                           const dt_iop_roi_t *const roi_out,
-                          const dt_iop_roi_t *const roi_in)
+                          const dt_iop_roi_t *const roi_in,
+                          const gboolean gamma)
 {
   const dt_interpolation_t *itor = dt_interpolation_new(DT_INTERPOLATION_USERPREF);
-  dt_interpolation_resample(itor, out, roi_out, in, roi_in);
+  float *linear = gamma ? dt_alloc_align_float((size_t)roi_in->width * roi_in->height * 4) : NULL;
+  if(!linear)
+    return dt_interpolation_resample(itor, out, roi_out, in, roi_in);
+
+  static const dt_aligned_pixel_t two_point_four = { 2.4f, 2.4f, 2.4f, 2.4f };
+  static const dt_aligned_pixel_t rev_two_point_four = { 1.0f / 2.4f, 1.0f / 2.4f, 1.0f / 2.4f, 1.0f / 2.4f };
+
+  DT_OMP_SIMD(aligned(in, linear : 16))
+  for(size_t k = 0; k < (size_t)roi_in->width * roi_in->height*4; k += 4)
+    dt_vector_powf(&in[k], two_point_four, &linear[k]);
+
+  dt_interpolation_resample(itor, out, roi_out, linear, roi_in);
+  dt_free_align(linear);
+
+  DT_OMP_SIMD(aligned(out : 16))
+  for(size_t k = 0; k < (size_t)roi_out->width * roi_out->height * 4; k += 4)
+    dt_vector_powf(&out[k], rev_two_point_four, &out[k]);
 }
 
 // apply clip and zoom on the image region supplied in the input buffer.

--- a/src/develop/imageop_math.h
+++ b/src/develop/imageop_math.h
@@ -34,7 +34,7 @@ void dt_iop_flip_and_zoom_8(const uint8_t *in, int32_t iw, int32_t ih, uint8_t *
 
 /** for homebrew pixel pipe: zoom pixel array. */
 void dt_iop_clip_and_zoom(float *out, const float *const in, const struct dt_iop_roi_t *const roi_out,
-                          const struct dt_iop_roi_t *const roi_in);
+                          const struct dt_iop_roi_t *const roi_in, const gboolean gamma);
 
 /** zoom pixel array for roi buffers. */
 void dt_iop_clip_and_zoom_roi(float *out, const float *const in, const struct dt_iop_roi_t *const roi_out,

--- a/src/iop/finalscale.c
+++ b/src/iop/finalscale.c
@@ -186,7 +186,7 @@ void process(dt_iop_module_t *self,
   if(exporting)
     dt_iop_clip_and_zoom_roi((float *)ovoid, (float *)ivoid, roi_out, roi_in);
   else
-    dt_iop_clip_and_zoom((float *)ovoid, (float *)ivoid, roi_out, roi_in);
+    dt_iop_clip_and_zoom((float *)ovoid, (float *)ivoid, roi_out, roi_in, FALSE);
 }
 
 void commit_params(dt_iop_module_t *self,


### PR DESCRIPTION
Non-raw images can have gamma corrected data as input possibly leading to bad results while we do the initial scaling. This scaling happens when generating the mipmap via `_init_f` and when inserting data into the pixelpipes.

What we do now:
- we test for the image having exif data as sRGB or AdobeRGB.
- the colorin module does a much better check than exif data and possibly sets the profile type to any RGB mode. We keep track on this when setting the input profile and possibly change the image->colorspace (making sure to leave the exif checked data as they are).
- dt_iop_clip_and_zoom() got an extra gboolean parameter `gamma`, if that is true the interpolation is encapsulated in rgb->linear and linear->rgb conversions.

This results in improved data visualizing for all pipes and data taken from the preview pipe.

Reminder:
1. As this is only effective for non-raw images we should likely stay in linear space and let colorin module handle this.
2. Should we avoid the conversions for upscaling?

__________________________________________________________________________________________
This has been itching me for quite a while - since #13682 #13335 and #13682. One part of those issues has been solved by 6b18bae34db28b1fa0f8fa2af8a3c1aa37b8be19 having final-scaling still in linear space.

The second problem discussed and demonstrated in the old issues is the initial feeding of non-linear data into the pipes.
Here are some images to be tested:

<img width="900" height="506" alt="mtlc_checker-col_green-magenta_v20230106" src="https://github.com/user-attachments/assets/ee716c32-7d2b-4e7c-b184-f9626da465ec" />
<img width="1280" height="720" alt="212782791-18d92c3d-db66-4430-8136-d0cf1c13c791" src="https://github.com/user-attachments/assets/5e659261-0c66-4196-8cc1-d7e9a12b11ea" />

or the large nasa image https://commons.wikimedia.org/wiki/File:Earth%27s_City_Lights_by_DMSP,_1994-1995_(full).jpg (scroll down a bit and choose full image).

For me this is the first part of color-related stuff for 5.6.  @kofa73 is likely working on improving white balance and i will take further care on colorin ...

@mediatechnologic started the discussion (i hope you are still reading and would be able to compile & test) @TurboGit as pening #13682 
