### PR TITLE
Add help URL for AgX module

### DIFF
--- a/src/common/usermanual_url.c
+++ b/src/common/usermanual_url.c
@@ -101,6 +101,7 @@ dt_help_url urls_db[] =
   {"preset_dialog",              "darkroom/processing-modules/presets/#creating-and-editing-presets"},
 
   // iop links
+  {"agx",                        "module-reference/processing-modules/agx/"},
   {"ashift",                     "module-reference/processing-modules/rotate-perspective/"},
   {"atrous",                     "module-reference/processing-modules/contrast-equalizer/"},
   {"basecurve",                  "module-reference/processing-modules/base-curve/"},


### PR DESCRIPTION
For 5.4.1, as we definitely don't want to delay the in-app help for the module until 5.6.