### PR TITLE
Safe gphoto backthread starting

### DIFF
--- a/src/common/camera_control.c
+++ b/src/common/camera_control.c
@@ -1057,6 +1057,7 @@ static gboolean _camctl_update_cameras(const dt_camctl_t *c)
 void *dt_update_cameras_thread(void *ptr)
 {
   dt_pthread_setname("gphoto_update");
+  dt_atomic_add_int(&darktable.control->running_jobs, 1);
   /* wait until dt_camctl_new() has created darktable.camctl
       This might take some time depending on initial work like updating xmp / splash
   */


### PR DESCRIPTION
Following 6d501992122a48f8592df704f79424032f15ff71. We start the gphoto thread after all job threads are up&running and continue in `dt_control_jobs_init()` after the photothread is up&running.

@wpferguson this is fixing a second potential cause of race conditions related to back threads.
@TurboGit for me again a safe one.