### PR TITLE
CI: enable exiv2 unicode for Windows nightlies

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -141,7 +141,6 @@ jobs:
             -DBUILD_SHARED_LIBS=ON \
             -DEXIV2_ENABLE_NLS=ON \
             -DEXIV2_ENABLE_VIDEO=OFF \
-            -DEXIV2_ENABLE_WIN_UNICODE=ON \
             -DCMAKE_INSTALL_PREFIX=/usr
           cmake --build build
           sudo cmake --install build
@@ -260,6 +259,7 @@ jobs:
             -DEXIV2_ENABLE_BMFF=ON \
             -DEXIV2_ENABLE_NLS=ON \
             -DEXIV2_ENABLE_VIDEO=OFF \
+            -DEXIV2_ENABLE_WIN_UNICODE=ON \
             -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX}
           cmake --build build
           cmake --install build


### PR DESCRIPTION
Fixes https://github.com/darktable-org/darktable/issues/19572