### PR TITLE
po/fix presets localization

### DIFF
--- a/src/common/presets.c
+++ b/src/common/presets.c
@@ -471,9 +471,14 @@ GtkWidget *dt_insert_preset_in_menu_hierarchy(const char *name,
                                               GtkWidget *mainmenu,
                                               GtkWidget **submenu,
                                               gchar ***prev_split,
-                                              gboolean isdefault)
+                                              gboolean isdefault,
+                                              gboolean writeprotect)
 {
-  gchar *local_name = dt_util_localize_segmented_name(name, FALSE);
+  gchar *local_name =
+    writeprotect ?
+    dt_util_localize_segmented_name(name, FALSE)
+    : g_strdup(name);
+
   gchar **split = g_strsplit(local_name, "|", -1);
   gchar **s = split;
   gchar **p = *prev_split;

--- a/src/common/presets.h
+++ b/src/common/presets.h
@@ -55,7 +55,8 @@ GtkWidget *dt_insert_preset_in_menu_hierarchy(const char *name,
                                               GtkWidget *mainmenu,
                                               GtkWidget **submenu,
                                               gchar ***prev_split,
-                                              gboolean isdefault);
+                                              gboolean isdefault,
+                                              gboolean writeprotect);
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/libs/lib.c
+++ b/src/libs/lib.c
@@ -491,7 +491,9 @@ static void dt_lib_presets_popup_menu_show(dt_lib_module_info_t *minfo,
     if(darktable.gui->last_preset && strcmp(darktable.gui->last_preset, name) == 0)
       found = TRUE;
 
-    mi = dt_insert_preset_in_menu_hierarchy(name, &menu_path, mainmenu, &submenu, &prev_split, FALSE);
+    mi = dt_insert_preset_in_menu_hierarchy(name,
+                                            &menu_path, mainmenu, &submenu, &prev_split,
+                                            FALSE, writeprotect);
 
     // selected in bold:
     // printf("comparing %d bytes to %d\n", op_params_size, minfo->params_size);


### PR DESCRIPTION
Two fixes:

1. Never localize a user's defined preset name.
2. Properly localize the module name for the dialog's title.
