### PR TITLE
CI: restore nightlies for macOS on Intel

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -321,7 +321,8 @@ jobs:
       fail-fast: true
       matrix:
         build:
-          - { os: macos-14, xcode: 16.2, deployment: 14.0 } # LLVM16, arm64
+          - { os: macos-14,       xcode: 16.2,   deployment: 14.0 } # AppleClang 16, arm64
+          - { os: macos-15-intel, xcode: 26.1.1, deployment: 15.0 } # AppleClang 17, x86_64
         compiler:
           - { compiler: XCode,   CC: cc, CXX: c++ }
         btype: [ Release ]
@@ -427,7 +428,7 @@ jobs:
 
             The Windows package requires Windows with UCRT (Universal C Runtime), which is shipped with Windows 10+. Darktable should also work on Windows 8.1 [on condition that you install this runtime yourself](https://support.microsoft.com/en-us/topic/update-for-universal-c-runtime-in-windows-c0514201-7fe6-95a3-b0a5-287930f3560c).
 
-            The macOS package `*-arm64.dmg` requires at least macOS 14.0 (Sonoma).
+            The macOS package `*-arm64.dmg` requires at least macOS 14.0 (Sonoma). The `*-x86_64.dmg` package requires at least macOS 15.0 (Sequoia).
 
             __Please help us improve Darktable by reporting any issues you encounter!__ :wink:
           files: |


### PR DESCRIPTION
macOS 15 Intel runners are the only option available (probably [until 2027 Q4](https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/#notice-of-macos-x86_64-intel-architecture-deprecation)) since dropping macOS 13 ones (x-ref #19341). A couple of more dt releases should be doable (w/ minimal requirements).