### PR TITLE
fix(gtk): amend build against X11-enabled GTK

### DIFF
--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -51,6 +51,9 @@
 #ifdef GDK_WINDOWING_WAYLAND
 #include <gdk/gdkwayland.h>
 #endif
+#ifdef GDK_WINDOWING_X11
+#include <gdk/gdkx.h>
+#endif
 #include <gtk/gtk.h>
 #include <math.h>
 #include <stdlib.h>
@@ -995,7 +998,7 @@ dt_gui_session_type_t dt_gui_get_session_type(void)
     : DT_GUI_SESSION_X11;
 #elif defined(GDK_WINDOWING_X11)
   GdkDisplay* disp = gdk_display_get_default();
-  retun G_TYPE_CHECK_INSTANCE_TYPE(disp, GDK_TYPE_X11_DISPLAY)
+  return G_TYPE_CHECK_INSTANCE_TYPE(disp, GDK_TYPE_X11_DISPLAY)
     ? DT_GUI_SESSION_X11
     : DT_GUI_SESSION_WAYLAND;
 #else


### PR DESCRIPTION
Build of 5.4.0 was failing at X11-based Gentoo with:

```text
darktable-5.4.0/src/gui/gtk.c:998:43: error: ‘GDK_TYPE_X11_DISPLAY’ undeclared (first use in this function); did you mean ‘GDK_TYPE_DISPLAY’?                                                                       
  998 |   return G_TYPE_CHECK_INSTANCE_TYPE(disp, GDK_TYPE_X11_DISPLAY)
      |                                           ^~~~~~~~~~~~~~~~~~~~
```

This patch fixed the build.

---

* Build failed at missing `GDK_TYPE_X11_DISPLAY`
* Corrected a typo

