### PR TITLE
Fix thread joining in dt_control_shutdown()

### DIFF
--- a/src/control/control.c
+++ b/src/control/control.c
@@ -354,7 +354,7 @@ void dt_control_shutdown()
   err = dt_pthread_join(s->kick_on_workers_thread);
   dt_print(DT_DEBUG_CONTROL, "[dt_control_shutdown] joined kicker%s", err ? ", error" : "");
 
-  for(int k = 0; k < s->num_threads-1; k++)
+  for(int k = 0; k < s->num_threads; k++)
   {
     err = dt_pthread_join(s->thread[k]);
     dt_print(DT_DEBUG_CONTROL, "[dt_control_shutdown] joined num_thread %i%s", k, err ? ", error" : "");


### PR DESCRIPTION
The last thread of num_threads clearly missed joining. Introduced in 77bed883ba018ba1f5220216668a831bdcd060aa

@dterrahe hinted to this in #20002, i can't remember how that happened in  77bed883ba018ba1f5220216668a831bdcd060aa and if/how i oversaw the mentioned discussion.