### PR TITLE
Set darktable.control after initializing dt_control_t

### DIFF
--- a/src/control/control.h
+++ b/src/control/control.h
@@ -175,7 +175,6 @@ typedef struct dt_control_t
 
   // gui settings
   dt_pthread_mutex_t global_mutex, image_mutex;
-  double last_expose_time;
 
   // job management
   dt_atomic_int running;
@@ -249,7 +248,20 @@ void dt_control_cleanup(const gboolean withgui);
 void dt_control_quit(void);
 
 /** get threadsafe running state. */
-gboolean dt_control_running(void);
+#define dt_control_running() _control_running_with_caller(__FILE__, __LINE__, __FUNCTION__)
+static inline gboolean _control_running_with_caller(const char *file,
+                                                    const int line,
+                                                    const char *function)
+{
+  dt_control_t *c = darktable.control;
+  if(!c)
+  {
+    dt_print(DT_DEBUG_ALWAYS, "undefined control in '%s': `%s:%d`", function, file, line);
+    return FALSE;
+  }
+  else
+    return dt_atomic_get_int(&c->running) == DT_CONTROL_STATE_RUNNING;
+}
 
 // thread-safe interface between core and gui.
 // is the locking really needed?

--- a/src/control/jobs.c
+++ b/src/control/jobs.c
@@ -612,9 +612,8 @@ double dt_control_job_get_progress(const dt_job_t *job)
 
 
 // moved out of control.c to be able to make some helper functions static
-void dt_control_jobs_init()
+void dt_control_jobs_init(dt_control_t *control)
 {
-  dt_control_t *control = darktable.control;
   // start threads
   control->num_threads = dt_worker_threads();
   control->thread = (pthread_t *)calloc(control->num_threads, sizeof(pthread_t));
@@ -682,15 +681,6 @@ gboolean dt_control_all_running()
   dt_control_t *control = darktable.control;
   const int requested = control->num_threads + 1 + DT_CTL_WORKER_RESERVED;
   return dt_atomic_get_int(&control->running_jobs) == requested;
-}
-
-void dt_control_jobs_cleanup()
-{
-  dt_control_t *control = darktable.control;
-  free(control->job);
-  control->job = NULL;
-  free(control->thread);
-  control->thread = NULL;
 }
 
 int dt_control_jobs_pending()

--- a/src/control/jobs.h
+++ b/src/control/jobs.h
@@ -79,8 +79,7 @@ void dt_control_job_set_progress_message(dt_job_t *job, const char *message, ...
 void dt_control_job_set_progress(dt_job_t *job, const double value);
 double dt_control_job_get_progress(const dt_job_t *job);
 
-void dt_control_jobs_init(void);
-void dt_control_jobs_cleanup(void);
+void dt_control_jobs_init(struct dt_control_t *control);
 int dt_control_jobs_pending(void);
 gboolean dt_control_all_running(void);
 

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -1627,9 +1627,11 @@ void dt_gui_gtk_run(dt_gui_gtk_t *gui)
   /* start the event loop */
   if(dt_control_all_running())
   {
+    dt_print(DT_DEBUG_CONTROL, "gtk_main() started");
     g_atomic_int_set(&darktable.gui_running, 1);
     gtk_main();
     g_atomic_int_set(&darktable.gui_running, 0);
+    dt_print(DT_DEBUG_CONTROL, "gtk_main() stopped");
   }
   if(darktable.gui->surface)
   {


### PR DESCRIPTION
We don't want the global control struct to be exposed before all internal stuff like mutexes has been set up.