### PR TITLE
[Nightly] Bump libheif version to the latest for AppImage build

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -113,6 +113,7 @@ jobs:
             libopenjp2-7-dev \
             libsharpyuv-dev \
             libx265-dev \
+            libwebm-dev \
             x11proto-dev \
             libxfixes-dev
       - name: Build and install fresh libheif with built-in decoders


### PR DESCRIPTION
The success of the build was tested by running nightly in my fork. To successfully build this version of libheif, it turned out that two more dependency packages, `aom-tools` and `libwebm-dev`, needed to be installed. The commits adding these dependencies could probably be squashed during merging, I think...