### PR TITLE
force immediate redraw of splash screen updates

### DIFF
--- a/src/gui/splash.c
+++ b/src/gui/splash.c
@@ -253,6 +253,7 @@ void darktable_splash_screen_set_progress(const char *msg)
       showing_remaining = FALSE;
     }
     _process_all_gui_events();
+    gdk_display_sync(gdk_display_get_default());
   }
 }
 


### PR DESCRIPTION
Notice when adding sleeps (or presumably other lengthy operations) at the different phases of dt_init the splash screen will not always reflect the latest progress message. This forces a screen redraw to stay up to date, which may be useful in diagnostics.