### PR TITLE
Change the reverse ordering of the contributors list in GUI to forward

### DIFF
--- a/tools/authors_h.sh
+++ b/tools/authors_h.sh
@@ -44,7 +44,7 @@ function print_section()
     if [ -n "${CONTENT}" ]; then
         echo "static const char *section${SECTIONS}[] = {" >> "$H_FILE"
         echo "$CONTENT" >> "$H_FILE"
-        echo "  NULL };" >> "$H_FILE"
+        echo ",NULL };" >> "$H_FILE"
         echo "gtk_about_dialog_add_credit_section (GTK_ABOUT_DIALOG(dialog), _(\"${SECTION}\"), section${SECTIONS});" >> "$H_FILE"
         echo "" >> "$H_FILE"
     fi
@@ -71,7 +71,7 @@ while IFS="" read -r p || [ -n "$p" ]; do
 
       #on some weird configs read doesn't remove new line, remove it here just to be sure
       LINE=$(echo -n "$p" | tr -d '[:cntrl:]')
-      CONTENT="\"$LINE\",$CONTENT"
+      CONTENT+="${CONTENT:+,}\"$LINE\""
   fi
 done < "$AUTHORS"
 


### PR DESCRIPTION
It seems like the list in reverse order was done knowingly, this order made the code a little simpler and allowed the bash script to be a few lines shorter. But this order generally makes those contributors who made the smallest contributions more visible, while those who made the largest contributions end up at the very end of the list.

This PR makes the contributors list in "Credits" in the "About" window the same order as in the AUTHORS file.
