### PR TITLE
Fix darktable.gui initializing and cleanup

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1872,6 +1872,8 @@ int dt_init(int argc,
     {
       dt_print(DT_DEBUG_ALWAYS, "[dt_init] ERROR: can't init gui, aborting.");
       darktable_splash_screen_destroy();
+      free(darktable.gui);
+      darktable.gui = NULL;
       return 1;
     }
     dt_bauhaus_init();
@@ -1882,9 +1884,7 @@ int dt_init(int argc,
         && dt_get_num_threads() >= 4
         && !(dbfilename_from_command && !strcmp(dbfilename_from_command, ":memory:"));
   }
-  else
-    darktable.gui = NULL;
-
+ 
   darktable.view_manager = (dt_view_manager_t *)calloc(1, sizeof(dt_view_manager_t));
   dt_view_manager_init(darktable.view_manager);
 
@@ -2171,8 +2171,11 @@ void dt_cleanup()
     dt_control_cleanup(TRUE);
     dt_undo_cleanup(darktable.undo);
     darktable.undo = NULL;
-    free(darktable.gui);
-    darktable.gui = NULL;
+    if(darktable.gui)
+    {
+      free(darktable.gui);
+      darktable.gui = NULL;
+    }
   }
   else
     dt_control_cleanup(FALSE);

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -204,10 +204,7 @@ static void _toggle_tooltip_visibility(dt_action_t *action)
 static inline void _update_focus_peaking_button()
 {
   // read focus peaking global state and update toggle button accordingly
-  dt_pthread_mutex_lock(&darktable.gui->mutex);
   const gboolean state = darktable.gui->show_focus_peaking;
-  dt_pthread_mutex_unlock(&darktable.gui->mutex);
-
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(darktable.gui->focus_peaking_button),
                                state);
 }
@@ -216,17 +213,12 @@ static void _focuspeaking_switch_button_callback(GtkWidget *button,
                                                  gpointer user_data)
 {
   // button method
-  dt_pthread_mutex_lock(&darktable.gui->mutex);
   const gboolean state_memory = darktable.gui->show_focus_peaking;
-  dt_pthread_mutex_unlock(&darktable.gui->mutex);
-
   const gboolean state_new = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(button));
 
   if(state_memory == state_new) return; // nothing to change, bypass
 
-  dt_pthread_mutex_lock(&darktable.gui->mutex);
   darktable.gui->show_focus_peaking = state_new;
-  dt_pthread_mutex_unlock(&darktable.gui->mutex);
 
   gtk_widget_queue_draw(button);
 
@@ -811,8 +803,6 @@ gboolean _valid_window_placement(const gint saved_x,
 
 int dt_gui_gtk_load_config()
 {
-  dt_pthread_mutex_lock(&darktable.gui->mutex);
-
   GtkWidget *widget = dt_ui_main_window(darktable.gui->ui);
   const int width = dt_conf_get_int("ui_last/window_w");
   const int height = dt_conf_get_int("ui_last/window_h");
@@ -843,15 +833,11 @@ int dt_gui_gtk_load_config()
   else
     darktable.gui->show_focus_peaking = FALSE;
 
-  dt_pthread_mutex_unlock(&darktable.gui->mutex);
-
   return 0;
 }
 
 int dt_gui_gtk_write_config()
 {
-  dt_pthread_mutex_lock(&darktable.gui->mutex);
-
   GtkWidget *widget = dt_ui_main_window(darktable.gui->ui);
   gint x, y, width, height;
   // Use gtk_window_get_size() instead of gtk_widget_get_allocation() to get
@@ -871,8 +857,6 @@ int dt_gui_gtk_write_config()
                    (gdk_window_get_state(gtk_widget_get_window(widget))
                     & GDK_WINDOW_STATE_FULLSCREEN));
   dt_conf_set_bool("ui/show_focus_peaking", darktable.gui->show_focus_peaking);
-
-  dt_pthread_mutex_unlock(&darktable.gui->mutex);
 
   return 0;
 }
@@ -1276,12 +1260,11 @@ int dt_gui_theme_init(dt_gui_gtk_t *gui)
   return 1;
 }
 
-int dt_gui_gtk_init(dt_gui_gtk_t *gui)
+gboolean dt_gui_gtk_init(dt_gui_gtk_t *gui)
 {
-  /* lets zero mem */
-  memset(gui, 0, sizeof(dt_gui_gtk_t));
-
-  dt_pthread_mutex_init(&gui->mutex, NULL);
+  /* *gui might have some data set already, let's keep that.
+    memset(gui, 0, sizeof(dt_gui_gtk_t));
+  */
 
   // force gtk3 to use normal scroll bars instead of the popup
   // thing. they get in the way of controls the alternative would be
@@ -1603,7 +1586,7 @@ int dt_gui_gtk_init(dt_gui_gtk_t *gui)
                         darktable.gui->focus_peaking_button, &dt_action_def_toggle);
   dt_shortcut_register(ac, 0, 0, GDK_KEY_f, GDK_CONTROL_MASK | GDK_SHIFT_MASK);
 
-  return 0;
+  return FALSE;
 }
 
 void dt_gui_gtk_run(dt_gui_gtk_t *gui)

--- a/src/gui/gtk.h
+++ b/src/gui/gtk.h
@@ -146,8 +146,6 @@ typedef struct dt_gui_gtk_t
   guint sidebar_scroll_mask;
 
   cairo_filter_t filter_image;    // filtering used to scale images to screen
-
-  dt_pthread_mutex_t mutex;
 } dt_gui_gtk_t;
 
 typedef struct _gui_collapsible_section_t
@@ -203,7 +201,7 @@ void dt_gui_remove_class(GtkWidget *widget, const gchar *class_name);
 
 void dt_open_url(const char *url);
 int dt_gui_theme_init(dt_gui_gtk_t *gui);
-int dt_gui_gtk_init(dt_gui_gtk_t *gui);
+gboolean dt_gui_gtk_init(dt_gui_gtk_t *gui);
 void dt_gui_gtk_run(dt_gui_gtk_t *gui);
 void dt_gui_gtk_cleanup(dt_gui_gtk_t *gui);
 void dt_gui_gtk_quit();


### PR DESCRIPTION
1. We don't want to clear darktable.gui in dt_gui_gtk_init() as we did that via calloc very early. Some things have been set up so far, one example is the last module group in darkroom.
2. Initialize the mutex early so we can't run into undefined mutex lock/unlock, make sure we destroy it whenever we cleanup.
3. Avoid darktable.gui memleaks

@wpferguson you might also want to check :-)