### PR TITLE
RustiCL deserves better kernel compilation

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -2553,7 +2553,7 @@ void dt_configure_runtime_performance(const int old, char *info)
     g_strlcat(info, "\n\n", DT_PERF_INFOSIZE);
   }
 
-  else if(old < 16)
+  else if(old < 16 || old == 17)
   {
     g_strlcat(info, INFO_HEADER, DT_PERF_INFOSIZE);
     g_strlcat(info, _("OpenCL 'per device' compiler settings might have been updated.\n\n"), DT_PERF_INFOSIZE);

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -192,7 +192,7 @@ typedef int32_t dt_mask_id_t;
 // version of current performance configuration version
 // if you want to run an updated version of the performance configuration later
 // bump this number and make sure you have an updated logic in dt_configure_runtime_performance()
-#define DT_CURRENT_PERFORMANCE_CONFIGURE_VERSION 17
+#define DT_CURRENT_PERFORMANCE_CONFIGURE_VERSION 18
 #define DT_PERF_INFOSIZE 4096
 
 // every module has to define this:

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -953,7 +953,7 @@ static gboolean _opencl_device_init(dt_opencl_t *cl,
   const char* compile_opt = NULL;
 
   if(dt_conf_key_exists(compile_option_name_cname)
-     && (dt_conf_get_int("performance_configuration_version_completed") > 15))
+     && (dt_conf_get_int("performance_configuration_version_completed") > 17))
     compile_opt = dt_conf_get_string_const(compile_option_name_cname);
   else
   {
@@ -962,6 +962,8 @@ static gboolean _opencl_device_init(dt_opencl_t *cl,
     else if(!strcmp("apple", pname))
       compile_opt = DT_OPENCL_DEFAULT_COMPILE_OPTI;
     else if(!strcmp("amdacceleratedparallelprocessing", pname))
+      compile_opt = DT_OPENCL_DEFAULT_COMPILE_OPTI;
+    else if(!strncmp("rusticl", pname, 7))
       compile_opt = DT_OPENCL_DEFAULT_COMPILE_OPTI;
     else
       compile_opt = DT_OPENCL_DEFAULT_COMPILE_DEFAULT;


### PR DESCRIPTION
We test for RustiCl and use `-cl-fast-relaxed-math` as we do for nvidia and amd

Relase note: Use default optimizing OpenCL  compiler flags also for RustiCl 