### PR TITLE
Update #iop-module-name font-family for Windows user readability

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -620,7 +620,8 @@ dialog .sidebar row:selected:hover label,
 #snapshot-button entry,
 #iop-module-name
 {
-  font-weight: lighter;
+  color: @grey_70;
+  font-weight: normal;
   font-family: "Roboto Light", "Roboto",                  /* best case scenario */
                "Segoe UI Variable",                       /* Windows 11 default */
                "Segoe UI",                                /* Windows 10 default */
@@ -630,7 +631,7 @@ dialog .sidebar row:selected:hover label,
                "Adwaita Sans", "Cantarell",               /* Gnome default new */
                "Lucida Sans Unicode", "Arial Unicode MS", /* Unicode glyphs */
                 sans-serif;                               /* default default */
-  font-size: 0.85em;
+  font-size: 0.80em;
 }
 
 #iop-module-name-error


### PR DESCRIPTION
A number of Windows user shared that the font is barely legible. This commits tries to find a compromise without making the font too large or bright. 

Add more font family names to address rendering issues on Windows with the small font size

Increase from 0.8em to 0.85em

This is only a bug fix for 5.4.1. While investigating this, I noticed inconsistencies in how we are declaring the font-family that I will address in 5.6. Some of these include: "Arial Unicode MS" is no longer available in Windows, the sans-serif should be the last item in the list so it is a fallback instead of the first. 