### PR TITLE
Report allowed mem usage when starting pipe

### DIFF
--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -2967,9 +2967,6 @@ static gboolean _dev_pixelpipe_process_rec_and_backcopy(dt_dev_pixelpipe_t *pipe
                                                         const int pos)
 {
   dt_pthread_mutex_lock(&pipe->busy_mutex);
-#ifdef HAVE_OPENCL
-  dt_opencl_check_tuning(pipe->devid);
-#endif
   gboolean ret = _dev_pixelpipe_process_rec(pipe, dev, output,
                                             cl_mem_output, out_format, roi_out,
                                             modules, pieces, pos);
@@ -3071,9 +3068,10 @@ restart:
   dt_iop_buffer_dsc_t *out_format = &_out_format;
 
 #ifdef HAVE_OPENCL
+  dt_opencl_check_tuning(pipe->devid);
   if(pipe->devid > DT_DEVICE_CPU)
     dt_print_pipe(DT_DEBUG_PIPE, "pipe starting",
-                  pipe, NULL, pipe->devid, &roi, &roi, "'%s' ID=%i, %s %luMB%s%s",
+                  pipe, NULL, pipe->devid, &roi, &roi, "'%s' ID=%i, %s using %luMB%s%s",
                   pipe->image.filename, pipe->image.id,
                   darktable.opencl->dev[pipe->devid].cname,
                   darktable.opencl->dev[pipe->devid].used_available / DT_MEGA,
@@ -3081,12 +3079,12 @@ restart:
                   darktable.opencl->dev[pipe->devid].pinned_memory ? ", pinned": "");
   else
     dt_print_pipe(DT_DEBUG_PIPE, "pipe starting",
-                  pipe, NULL, pipe->devid, &roi, &roi, "'%s' ID=%i",
-                  pipe->image.filename, pipe->image.id);
+                  pipe, NULL, pipe->devid, &roi, &roi, "'%s' ID=%i using %luMB",
+                  pipe->image.filename, pipe->image.id, dt_get_available_mem() / DT_MEGA);
 #else
   dt_print_pipe(DT_DEBUG_PIPE, "pipe starting",
-                pipe, NULL, pipe->devid, &roi, &roi, "'%s' ID=%i",
-                pipe->image.filename, pipe->image.id);
+                pipe, NULL, pipe->devid, &roi, &roi, "'%s' ID=%i using %luMB",
+                pipe->image.filename, pipe->image.id, dt_get_available_mem() / DT_MEGA);
 #endif
   dt_print_mem_usage("before pixelpipe process");
 


### PR DESCRIPTION
Both below work with -d pipe
1. For OpenCL this didn't work for the first run on that device
2. While being here, also report that for cpu bound pipe runs