### PR TITLE
[exif] add guard when accesssing fourth element of Exif.Olympus*.Gradation tags

### DIFF
--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -1216,7 +1216,7 @@ static void _check_highlight_preservation(Exiv2::ExifData &exifData,
       const long state1 = pos->toLong(0);
       const long state2 = pos->toLong(1);
       const long state3 = pos->toLong(2);
-      const long state4 = pos->size() > (int)(3*sizeof(short)) ? pos->toLong(3) : 0;
+      const long state4 = pos->count() > 3 ? pos->toLong(3) : 0;
       if(state4 == 1) // Auto mode is reported to apply a -0.3EV exposure compensation
 	 img->exif_highlight_preservation = 0.33f;
       else if(state1 == -1 && state2 == -1 && state3 == 1) // low key, reported -1.0EV exposure compensation


### PR DESCRIPTION
It turns out that Olympus' Gradation info can consist of either three or four integers.  Avoid crashing when there are only three....

Should fix #20011, though I haven't had a chance to test yet.
