### PR TITLE
Make OpenCL compute_units and max_workgroup_size available at runtime

### DIFF
--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -116,6 +116,8 @@ typedef struct dt_opencl_device_t
   cl_ulong used_global_mem;
   cl_ulong max_mem_constant;
   cl_uint alignsize; 
+  cl_uint compute_units;
+  size_t workgroup_size;  
   cl_program program[DT_OPENCL_MAX_PROGRAMS];
   cl_kernel kernel[DT_OPENCL_MAX_KERNELS];
   gboolean program_used[DT_OPENCL_MAX_PROGRAMS];
@@ -636,7 +638,7 @@ cl_int dt_opencl_events_flush(const int devid,
 
 /** utility function to calculate optimal work group dimensions for a
  * given kernel */
-int dt_opencl_local_buffer_opt(const int devid,
+gboolean dt_opencl_local_buffer_opt(const int devid,
                                const int kernel,
                                dt_opencl_local_buffer_t *factors);
 


### PR DESCRIPTION
We need both informations at runtime for some OpenCL codepath optimizings.

As `dt_opencl_local_buffer_opt()` returns an `int` we should do so for clarity.