### PR TITLE
Preferences: add AgX in long description of workflow default setting

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -3621,7 +3621,7 @@
     </type>
     <default>scene-referred (sigmoid)</default>
     <shortdescription>auto-apply pixel workflow defaults</shortdescription>
-    <longdescription>scene-referred workflow is based on linear modules and will auto-apply filmic or sigmoid, color calibration and exposure,\ndisplay-referred workflow is based on Lab modules and will auto-apply base curve, white balance and the legacy module pipe order.</longdescription>
+    <longdescription>scene-referred workflow is based on linear modules and will auto-apply the corresponding tone mapper (shown in parenthesis), color calibration and exposure,\ndisplay-referred workflow is based on Lab modules and will auto-apply base curve, white balance and the legacy module pipe order.</longdescription>
   </dtconfig>
   <dtconfig prefs="processing" section="general">
     <name>plugins/darkroom/basecurve/auto_apply_percamera_presets</name>


### PR DESCRIPTION
The long description (mouse over) of the preferences setting "auto-apply pixel workflow defaults" only mentions Sigmoid and Filmic. I suggest to make the text more general, so that further additions of new tone mappers do not require a change here.