### PR TITLE
bugfix: properly initialize collection filters defaults

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -577,9 +577,16 @@
     <longdescription></longdescription>
   </dtconfig>
   <dtconfig>
+    <name>plugins/lighttable/filtering/sortorder0</name>
+    <type>int</type>
+    <default>0</default>
+    <shortdescription>first sort order</shortdescription>
+    <longdescription></longdescription>
+  </dtconfig>
+  <dtconfig>
     <name>plugins/lighttable/filtering/string0</name>
     <type>string</type>
-    <default>%</default>
+    <default></default>
     <shortdescription>first filter</shortdescription>
     <longdescription></longdescription>
   </dtconfig>
@@ -649,7 +656,7 @@
   <dtconfig>
     <name>plugins/lighttable/filtering/string2</name>
     <type>string</type>
-    <default>%%</default>
+    <default></default>
     <shortdescription>third filter</shortdescription>
     <longdescription></longdescription>
   </dtconfig>


### PR DESCRIPTION
Make conf defaults for collection filters match how they are reset via `_filtering_rest(_PRESET_FILTERS)`.

This fixes a disappearing images bug which manifests when darktable is invoked for the first time with image files/directories on the command line. Images disappeared in lighttable once they had been brought into darkroom view. No images were visible in lighttable if the user exited then reopened darktable.

Fixes #20106