### PR TITLE
AgX refactoring and preset changes

### DIFF
--- a/src/iop/agx.c
+++ b/src/iop/agx.c
@@ -2248,6 +2248,8 @@ void gui_update(dt_iop_module_t *self)
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->completely_reverse_primaries),
                                p->completely_reverse_primaries);
 
+  _update_redraw_dynamic_gui(self, g, p);
+
   gui_changed(self, NULL, NULL);
 }
 

--- a/src/iop/agx.c
+++ b/src/iop/agx.c
@@ -115,15 +115,15 @@ typedef struct dt_iop_agx_params_t
   // Corresponds to p_y, but not directly -- needs application of gamma
   float curve_pivot_y_linear_output;      // $MIN: 0.f $MAX: 1.f $DEFAULT: 0.18f $DESCRIPTION: "pivot target output"
   // P_slope
-  float curve_contrast_around_pivot;      // $MIN: 0.1f $MAX: 10.f $DEFAULT: 2.8f $DESCRIPTION: "contrast"
+  float curve_contrast_around_pivot;      // $MIN: 0.1f $MAX: 10.f $DEFAULT: 3.0f $DESCRIPTION: "contrast"
   // related to P_tlength; the number expresses the portion of the y range below the pivot
   float curve_linear_ratio_below_pivot;   // $MIN: 0.f $MAX: 1.f $DEFAULT: 0.f $DESCRIPTION: "toe start"
   // related to P_slength; the number expresses the portion of the y range below the pivot
   float curve_linear_ratio_above_pivot;   // $MIN: 0.f $MAX: 1.f $DEFAULT: 0.f $DESCRIPTION: "shoulder start"
   // t_p
-  float curve_toe_power;                  // $MIN: 0.f $MAX: 10.f $DEFAULT: 1.55f $DESCRIPTION: "toe power"
+  float curve_toe_power;                  // $MIN: 0.f $MAX: 10.f $DEFAULT: 1.5f $DESCRIPTION: "toe power"
   // s_p
-  float curve_shoulder_power;             // $MIN: 0.f $MAX: 10.f $DEFAULT: 1.55f $DESCRIPTION: "shoulder power"
+  float curve_shoulder_power;             // $MIN: 0.f $MAX: 10.f $DEFAULT: 3.3f $DESCRIPTION: "shoulder power"
   float curve_gamma;                      // $MIN: 0.01f $MAX: 100.f $DEFAULT: 2.2f $DESCRIPTION: "curve y gamma"
   gboolean auto_gamma;                    // $DEFAULT: FALSE $DESCRIPTION: "keep the pivot on the diagonal"
   // t_ly

--- a/src/iop/agx.c
+++ b/src/iop/agx.c
@@ -101,7 +101,7 @@ typedef struct dt_iop_agx_params_t
   float look_slope;                  // $MIN: 0.f $MAX: 10.f $DEFAULT: 1.f $DESCRIPTION: "slope"
   float look_brightness;             // $MIN: 0.f $MAX: 100.f $DEFAULT: 1.f $DESCRIPTION: "brightness"
   float look_saturation;             // $MIN: 0.f $MAX: 10.f $DEFAULT: 1.f $DESCRIPTION: "saturation"
-  float look_original_hue_mix_ratio; // $MIN: 0.f $MAX: 1.f $DEFAULT: 0.f $DESCRIPTION: "preserve hue"
+  float look_original_hue_mix_ratio; // $MIN: 0.f $MAX: 1.f $DEFAULT: 0.6f $DESCRIPTION: "preserve hue"
 
   // log mapping
   float range_black_relative_ev;  // $MIN: -20.f $MAX: -0.1f  $DEFAULT: -10.f $DESCRIPTION: "black relative exposure"
@@ -2487,9 +2487,8 @@ static void _set_default_curve_and_look_params(dt_iop_agx_params_t *p)
   p->look_lift = 0.f;
   p->look_saturation = 1.f;
   // In Blender, a related param is set to 40%, but is actually used as 1 - param,
-  // so 60% would give almost identical results; however, Eary_Chow suggested
-  // that we leave this as 0, based on feedback he had received
-  p->look_original_hue_mix_ratio = 0.f;
+  // so 60% would give almost identical results
+  p->look_original_hue_mix_ratio = 0.6f;
 
   p->range_black_relative_ev = -10.f;
   p->range_white_relative_ev = 6.5f;
@@ -2526,7 +2525,6 @@ void _set_smooth_params(dt_iop_agx_params_t *p)
 static void _set_blenderlike_params(dt_iop_agx_params_t *p)
 {
   _set_default_curve_and_look_params(p);
-  p->look_original_hue_mix_ratio = 0.6f; // Blender's default
   _set_blenderlike_primaries(p);
 
   // restore the original Blender settings


### PR DESCRIPTION
Defaults and presets
- based on own experience and user feedback (https://discuss.pixls.us/t/more-punchy-contrasted-look-in-agx-by-default/55279/), I've made the defaults more contrasty; the new default contrast and toe/shoulder power are now similar to the 'sigmoid look' that people have grown accustomed to.
- added 'sigmoid-like' presets that very closely exactly match the tone curve of sigmoid with its default params and the 'smooth' preset. For 'sigmoid-like|smooth', hue preservation is set to 100% (like in sigmoid's own 'smooth' preset), and primaries are set like in sigmoid (using the 'smooth' set). For 'sigmoid-like|default', hue preservation remains at 0% (like in sigmoid), however, unlike sigmoid (which uses unmodified primaries), Blender-like primaries are used (we don't want to disable the core feature).
- I only kept 'punchy' for Blender, as the other presets are quite contrasty already.

UI:
- primaries selection remains visible even when "disable adjustments" is checked (disable adjustments is about rotations and in/outset, not about the base primary)

Minor:
- removed soft limits that matched hard ones
- gboolean defaults shouldn't be 0.f and 1.f and min/max make no sense
- colour -> color

This PR replaces #19745
