### PR TITLE
Fix tiled OpenCL path for true monochromes

### DIFF
--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -1090,8 +1090,9 @@ int process_cl(dt_iop_module_t *self,
     goto finish;
   }
 
+  const int in_channels = true_monochrome ? 4 : 1;
   out_image = direct ? dev_out : dt_opencl_alloc_device(devid, iwidth, iheight, sizeof(float) * 4);
-  t_in = tiling  ? dt_opencl_alloc_device(devid, iwidth, tile_height, sizeof(float)) : in_image;
+  t_in = tiling  ? dt_opencl_alloc_device(devid, iwidth, tile_height, sizeof(float) * in_channels) : in_image;
   t_out = tiling ? dt_opencl_alloc_device(devid, iwidth, tile_height, sizeof(float) * 4) : out_image;
   t_high = dual  ? dt_opencl_alloc_device(devid, iwidth, tile_height, sizeof(float) * 4) : t_out;
   t_low = dual   ? dt_opencl_alloc_device(devid, iwidth, tile_height, sizeof(float) * 4) : NULL;


### PR DESCRIPTION
These sraw files present 4 channels to the demosaicer, when we have to tile we must allocate a cl_mem with 4 channels.

Fixes #20114