### PR TITLE
jxl: do not get and set now unused params.

### DIFF
--- a/src/imageio/format/jxl.c
+++ b/src/imageio/format/jxl.c
@@ -476,7 +476,8 @@ void *get_params(dt_imageio_module_format_t *self)
   d->bpp = dt_conf_get_int("plugins/imageio/format/jxl/bpp");
   d->pixel_type = dt_conf_get_bool("plugins/imageio/format/jxl/pixel_type") & 1;
   d->quality = dt_conf_get_int("plugins/imageio/format/jxl/quality");
-  d->original = dt_conf_get_bool("plugins/imageio/format/jxl/original") & 1;
+  /* (see below)
+    d->original = dt_conf_get_bool("plugins/imageio/format/jxl/original") & 1; */
   d->effort = dt_conf_get_int("plugins/imageio/format/jxl/effort");
   d->tier = dt_conf_get_int("plugins/imageio/format/jxl/tier");
 
@@ -498,7 +499,8 @@ int set_params(dt_imageio_module_format_t *self, const void *params, const int s
   dt_bauhaus_combobox_set(g->bpp, _bpp_to_enum(d->bpp));
   dt_bauhaus_combobox_set(g->pixel_type, d->pixel_type & 1);
   dt_bauhaus_slider_set(g->quality, d->quality);
-  dt_bauhaus_combobox_set(g->original, d->original & 1);
+  /* (see below)
+    dt_bauhaus_combobox_set(g->original, d->original & 1); */
   dt_bauhaus_slider_set(g->effort, d->effort);
   dt_bauhaus_slider_set(g->tier, d->tier);
 


### PR DESCRIPTION
Closes #20129 

Darktable still segfaults when using a preset for the export module when recalling "JPEG XL" for "file format".
With this change darktable does not segfault anymore on my machine. I hope this is the correct approch.
