### PR TITLE
restrict metadata tag list in metadata editor

### DIFF
--- a/src/gui/metadata_tags.h
+++ b/src/gui/metadata_tags.h
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2025 darktable developers.
+    Copyright (C) 2026 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -17,7 +17,7 @@
 */
 
 gchar *dt_metadata_tags_get_selected();
-GtkWidget *dt_metadata_tags_dialog(GtkWidget *parent, gpointer metadata_activated_callback, gpointer user_data);
+GtkWidget *dt_metadata_tags_dialog(GtkWidget *parent, const gboolean user_editable_only, gpointer metadata_activated_callback, gpointer user_data);
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/libs/export_metadata.c
+++ b/src/libs/export_metadata.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2019-2025 darktable developers.
+    Copyright (C) 2019-2026 darktable developers.
 
 
     darktable is free software: you can redistribute it and/or modify
@@ -98,7 +98,7 @@ static void _metadata_activated(GtkTreeView *tree_view,
 // dialog to add metadata tag into the formula list
 static void _add_tag_button_clicked(GtkButton *button, dt_lib_export_metadata_t *d)
 {
-  GtkWidget *dialog = dt_metadata_tags_dialog(d->dialog, _metadata_activated, d);
+  GtkWidget *dialog = dt_metadata_tags_dialog(d->dialog, FALSE, _metadata_activated, d);
 
 #ifdef GDK_WINDOWING_QUARTZ
   dt_osx_disallow_fullscreen(dialog);

--- a/src/libs/metadata.c
+++ b/src/libs/metadata.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2010-2025 darktable developers.
+    Copyright (C) 2010-2026 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -743,7 +743,7 @@ static void _metadata_activated(GtkTreeView *tree_view,
 // dialog to add metadata tag into the formula list
 static void _add_tag_button_clicked(GtkButton *button, dt_lib_metadata_t *d)
 {
-  GtkWidget *dialog = dt_metadata_tags_dialog(d->dialog, _metadata_activated, d);
+  GtkWidget *dialog = dt_metadata_tags_dialog(d->dialog, TRUE, _metadata_activated, d);
 
 #ifdef GDK_WINDOWING_QUARTZ
   dt_osx_disallow_fullscreen(dialog);


### PR DESCRIPTION
The metadata editor should only allow to edit tags which are supposed to be user-editable.

Some users add exif tags to the metadata editor which leads to some confusion as it does not work as the user expects.
See #19973, #19366

This PR restricts the list of allowed metadata tags in the metadata editor preferences dialog to:
- Xmp.dc.*
- Xmp.acdsee.*
- Xmp.iptc.*
- Iptc.*

@wpferguson : please decide if #19973 can be closed with this change.