### PR TITLE
Update text for ellipse feather mode

### DIFF
--- a/src/develop/masks/ellipse.c
+++ b/src/develop/masks/ellipse.c
@@ -2018,7 +2018,7 @@ static void _ellipse_set_hint_message(const dt_masks_form_gui_t *const gui,
     g_strlcat(msgbuf, _("<b>rotate</b>: ctrl+drag"), msgbuf_len);
   else if(gui->form_selected)
     g_snprintf(msgbuf, msgbuf_len,
-               _("<b>feather mode</b>: shift+click, <b>rotate</b>: ctrl+drag\n"
+               _("<b>feather mode</b>: alt+click, <b>rotate</b>: ctrl+drag\n"
                  "<b>size</b>: scroll, <b>feather size</b>: shift+scroll,"
                  " <b>opacity</b>: ctrl+scroll (%d%%)"), opacity);
 }


### PR DESCRIPTION
This is my first ever darktable PR, so please do tell me of anything not quite right.

A [previous change](https://github.com/darktable-org/darktable/pull/18896/changes#diff-5b23220ce7278641e996933ece24534faf2ef42692df2fa718adef31a3e5a715) (for using shift to select feather nodes) altered the modifier for the ellipse mask _proportional feather mode_ form shift to alt, but the help text (displayed at the top of the screen when an ellipse mask is selected) was not updated. This PR updates the text.

I was going to raise an issue but it is such a small change a PR seemed quicker - let me know if you'd prefer an issue.