### PR TITLE
Allow shortcut setting in duplicate and snapshots

### DIFF
--- a/src/libs/duplicate.c
+++ b/src/libs/duplicate.c
@@ -402,10 +402,10 @@ void gui_init(dt_lib_module_t *self)
                                       "plugins/darkroom/duplicate/windowheight"),
                     dt_gui_hbox
                       (dt_action_button_new
-                         (NULL, N_("duplicate"), _lib_duplicate_duplicate_clicked_callback, self,
+                         (self, N_("duplicate"), _lib_duplicate_duplicate_clicked_callback, self,
                           _("create a duplicate of the image with same history stack"), 0, 0),
                        dt_action_button_new
-                         (NULL, N_("original"),
+                         (self, N_("original"),
                           _lib_duplicate_new_clicked_callback, self,
                           _("create a 'virgin' duplicate of the image without any development"), 0, 0)));
   dt_gui_add_class(self->widget, "dt_duplicate_ui");

--- a/src/libs/snapshots.c
+++ b/src/libs/snapshots.c
@@ -864,6 +864,8 @@ void gui_init(dt_lib_module_t *self)
   GtkWidget *hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
   gtk_box_pack_start(GTK_BOX(hbox), d->take_button, TRUE, TRUE, 0);
   d->sidebyside_button = dtgtk_togglebutton_new(dtgtk_cairo_paint_lt_mode_culling_dynamic, 0, NULL);
+  dt_action_define(DT_ACTION(self), NULL, N_("side-by-side"),
+                   d->sidebyside_button, &dt_action_def_toggle);
   gtk_box_pack_start(GTK_BOX(hbox), d->sidebyside_button, FALSE, TRUE, 0);
   g_signal_connect(G_OBJECT(d->sidebyside_button), "clicked",
                    G_CALLBACK(_sidebyside_button_clicked), self);


### PR DESCRIPTION
There were a few buttons which could not have shortcuts set, and this PR attempts to fix that.

This follows [a pixls.us discussion](https://discuss.pixls.us/t/cant-assign-shortcut-to-button/54135/4?u=phemisters), where a solution for the side-by-side button in `snapshots.c` was suggested.

I don't see anyone else attempting this, so I've tried the suggestion (which works for me) and created this PR.

While working on it, I noticed two buttons in the _darkroom duplicate manager_ module also appeared to have no shortcut setting ability. This appears to be a different type of button set-up, so I have attempted to copy what I see in other places (using _self_ instead of _NULL_). This seems to work when I tested it, but may be the wrong approach. I can easily remove the` duplicate.c` change.