### PR TITLE
Raster Mask: PNG support and image folder

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -3616,13 +3616,6 @@
     <longdescription>this folder (and sub-folders) contains PFM files used by the raster mask import module. (restart required)</longdescription>
   </dtconfig>
   <dtconfig prefs="processing" section="general">
-    <name>plugins/darkroom/segments/use_image_folder</name>
-    <type>bool</type>
-    <default>false</default>
-    <shortdescription>use image folder for raster masks</shortdescription>
-    <longdescription>when enabled, the raster mask file chooser defaults to the current image's folder and restricts selections to it, ignoring the raster mask root folder setting</longdescription>
-  </dtconfig>
-  <dtconfig prefs="processing" section="general">
     <name>plugins/darkroom/workflow</name>
     <type>
       <enum>


### PR DESCRIPTION
- Added support for PNG raster masks (8/16-bit)
- Added image folder chooser override for raster masks (can be set in the preferences). 
- Added relative path when using the image folder override.

The png support fixes issue https://github.com/darktable-org/darktable/issues/19667 and part of issue https://github.com/darktable-org/darktable/issues/19829. 

The image folder possibly fix https://github.com/darktable-org/darktable/issues/19689 

The relative path fixes issue https://github.com/darktable-org/darktable/issues/20088

