### PR TITLE
styles module: hide option to create duplicate in darkroom view

### DIFF
--- a/src/libs/styles.c
+++ b/src/libs/styles.c
@@ -829,8 +829,12 @@ void view_enter(struct dt_lib_module_t *self,
   dt_lib_styles_t *d = self->data;
   if(new_view->view(new_view) == DT_VIEW_DARKROOM)
   {
+    // keep current checkbox state, so we can restore it after switching off,
+    // otherwise it will always be unchecked when returning to lighttable.
+    const gboolean old_state = dt_conf_get_bool("ui_last/styles_create_duplicate");
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->duplicate), FALSE);
     gtk_widget_hide(d->duplicate);
+    dt_conf_set_bool("ui_last/styles_create_duplicate", old_state);
   }
   else
   {

--- a/src/libs/styles.c
+++ b/src/libs/styles.c
@@ -826,7 +826,7 @@ static void _view_changed_callback(gpointer instance,
                                    dt_view_t *new_view,
                                    dt_lib_module_t *self)
 {
-  //In darkroom switch off duplicate creation and hide checkbox
+  // In darkroom switch off duplicate creation and hide checkbox
   dt_lib_styles_t *d = self->data;
   if (dt_view_get_current() == DT_VIEW_DARKROOM)
   {
@@ -883,15 +883,14 @@ void gui_init(dt_lib_module_t *self)
 
   d->duplicate = gtk_check_button_new_with_label(_("create duplicate"));
   dt_action_define(DT_ACTION(self), NULL, N_("create duplicate"),
-                    d->duplicate, &dt_action_def_toggle);
+                   d->duplicate, &dt_action_def_toggle);
   gtk_label_set_ellipsize(GTK_LABEL(gtk_bin_get_child(GTK_BIN(d->duplicate))), PANGO_ELLIPSIZE_START);
   g_signal_connect(d->duplicate, "toggled", G_CALLBACK(_duplicate_callback), d);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->duplicate),
-                                dt_conf_get_bool("ui_last/styles_create_duplicate"));
+                               dt_conf_get_bool("ui_last/styles_create_duplicate"));
   gtk_widget_set_tooltip_text(d->duplicate,
                               _("creates a duplicate of the image before applying style"));
 
-  
   DT_BAUHAUS_COMBOBOX_NEW_FULL(d->applymode, self, NULL, N_("mode"),
                                _("how to handle existing history"),
                                dt_conf_get_int("plugins/lighttable/style/applymode"),

--- a/src/libs/styles.c
+++ b/src/libs/styles.c
@@ -821,6 +821,26 @@ static void _mouse_over_image_callback(gpointer instance, dt_lib_module_t *self)
   dt_lib_gui_queue_update(self);
 }
 
+static void _view_changed_callback(gpointer instance,
+                                   dt_view_t *old_view,
+                                   dt_view_t *new_view,
+                                   dt_lib_module_t *self)
+{
+  //In darkroom switch off duplicate creation and hide checkbox
+  dt_lib_styles_t *d = self->data;
+  if (dt_view_get_current() == DT_VIEW_DARKROOM)
+  {
+    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->duplicate), FALSE);
+    gtk_widget_hide(d->duplicate);
+  }
+  else
+  {
+    gtk_widget_show(d->duplicate);
+    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->duplicate),
+                                 dt_conf_get_bool("ui_last/styles_create_duplicate"));
+  }
+}
+
 static void _tree_selection_changed(GtkTreeSelection *treeselection, gpointer data)
 {
   dt_lib_gui_queue_update((dt_lib_module_t *)data);
@@ -861,17 +881,17 @@ void gui_init(dt_lib_module_t *self)
   g_signal_connect(d->entry, "changed", G_CALLBACK(_entry_callback), d);
   g_signal_connect(d->entry, "activate", G_CALLBACK(_entry_activated), d);
 
-
   d->duplicate = gtk_check_button_new_with_label(_("create duplicate"));
   dt_action_define(DT_ACTION(self), NULL, N_("create duplicate"),
-                   d->duplicate, &dt_action_def_toggle);
+                    d->duplicate, &dt_action_def_toggle);
   gtk_label_set_ellipsize(GTK_LABEL(gtk_bin_get_child(GTK_BIN(d->duplicate))), PANGO_ELLIPSIZE_START);
   g_signal_connect(d->duplicate, "toggled", G_CALLBACK(_duplicate_callback), d);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->duplicate),
-                               dt_conf_get_bool("ui_last/styles_create_duplicate"));
+                                dt_conf_get_bool("ui_last/styles_create_duplicate"));
   gtk_widget_set_tooltip_text(d->duplicate,
                               _("creates a duplicate of the image before applying style"));
 
+  
   DT_BAUHAUS_COMBOBOX_NEW_FULL(d->applymode, self, NULL, N_("mode"),
                                _("how to handle existing history"),
                                dt_conf_get_int("plugins/lighttable/style/applymode"),
@@ -938,6 +958,7 @@ void gui_init(dt_lib_module_t *self)
   DT_CONTROL_SIGNAL_HANDLE(DT_SIGNAL_SELECTION_CHANGED, _image_selection_changed_callback);
   DT_CONTROL_SIGNAL_HANDLE(DT_SIGNAL_MOUSE_OVER_IMAGE_CHANGE, _mouse_over_image_callback);
   DT_CONTROL_SIGNAL_HANDLE(DT_SIGNAL_COLLECTION_CHANGED, _collection_updated_callback);
+  DT_CONTROL_SIGNAL_HANDLE(DT_SIGNAL_VIEWMANAGER_VIEW_CHANGED, _view_changed_callback);
 }
 
 void gui_cleanup(dt_lib_module_t *self)

--- a/src/libs/styles.c
+++ b/src/libs/styles.c
@@ -821,14 +821,13 @@ static void _mouse_over_image_callback(gpointer instance, dt_lib_module_t *self)
   dt_lib_gui_queue_update(self);
 }
 
-static void _view_changed_callback(gpointer instance,
-                                   dt_view_t *old_view,
-                                   dt_view_t *new_view,
-                                   dt_lib_module_t *self)
+void view_enter(struct dt_lib_module_t *self,
+                struct dt_view_t *old_view,
+                struct dt_view_t *new_view)
 {
   // In darkroom switch off duplicate creation and hide checkbox
   dt_lib_styles_t *d = self->data;
-  if (dt_view_get_current() == DT_VIEW_DARKROOM)
+  if(new_view->view(new_view) == DT_VIEW_DARKROOM)
   {
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->duplicate), FALSE);
     gtk_widget_hide(d->duplicate);
@@ -890,6 +889,7 @@ void gui_init(dt_lib_module_t *self)
                                dt_conf_get_bool("ui_last/styles_create_duplicate"));
   gtk_widget_set_tooltip_text(d->duplicate,
                               _("creates a duplicate of the image before applying style"));
+  gtk_widget_set_no_show_all(d->duplicate, TRUE);                              
 
   DT_BAUHAUS_COMBOBOX_NEW_FULL(d->applymode, self, NULL, N_("mode"),
                                _("how to handle existing history"),
@@ -957,7 +957,6 @@ void gui_init(dt_lib_module_t *self)
   DT_CONTROL_SIGNAL_HANDLE(DT_SIGNAL_SELECTION_CHANGED, _image_selection_changed_callback);
   DT_CONTROL_SIGNAL_HANDLE(DT_SIGNAL_MOUSE_OVER_IMAGE_CHANGE, _mouse_over_image_callback);
   DT_CONTROL_SIGNAL_HANDLE(DT_SIGNAL_COLLECTION_CHANGED, _collection_updated_callback);
-  DT_CONTROL_SIGNAL_HANDLE(DT_SIGNAL_VIEWMANAGER_VIEW_CHANGED, _view_changed_callback);
 }
 
 void gui_cleanup(dt_lib_module_t *self)


### PR DESCRIPTION
Proposal for issue [#20173](https://github.com/darktable-org/darktable/issues/20173.):
Due to a recent change it is now possible to add styles module to the darkroom view. However, the option to create a duplicate before the application of the style does not work there. 
Therefore, I propose to deactivate and hide the checkbox in the darkroom view.

Of course, it could be discussed, why this module can be used in darkroom, at all, as there is already the possibility to apply styles in the darkroom view via the quick access.