### PR TITLE
mipmaps to cover higher resolution screeens and increased mipf resolution

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -1349,6 +1349,8 @@
         <option>WQXGA</option>
         <option>4K</option>
         <option>5K</option>
+        <option>6K</option>
+        <option>8K</option>
         <option>never</option>
       </enum>
     </type>
@@ -1368,6 +1370,8 @@
         <option>WQXGA</option>
         <option>4K</option>
         <option>5K</option>
+        <option>6K</option>
+        <option>8K</option>
         <option>never</option>
       </enum>
     </type>
@@ -1408,6 +1412,8 @@
         <option>WQXGA</option>
         <option>4K</option>
         <option>5K</option>
+        <option>6K</option>
+        <option>8K</option>
       </enum>
     </type>
     <default>never</default>

--- a/src/common/mipmap_cache.c
+++ b/src/common/mipmap_cache.c
@@ -734,10 +734,10 @@ void dt_mipmap_cache_init()
     { 7680, 4320 },           // mip9 - covers 8K
     { 999999999, 999999999 }, // mip10 - used for full preview at full size
   };
-  // Set mipf to mip2 size as at most the user will be using an 8K screen and
+  // Set mipf to mip3 size assuming the user will be using an 6K screen and
   // have a preview that's ~4x smaller
-  cache->max_width[DT_MIPMAP_F] = mipsizes[DT_MIPMAP_2][0];
-  cache->max_height[DT_MIPMAP_F] = mipsizes[DT_MIPMAP_2][1];
+  cache->max_width[DT_MIPMAP_F] = mipsizes[DT_MIPMAP_3][0];
+  cache->max_height[DT_MIPMAP_F] = mipsizes[DT_MIPMAP_3][1];
   for(int k = DT_MIPMAP_LDR_MAX; k >= 0; k--)
   {
     cache->max_width[k]  = mipsizes[k][0];

--- a/src/common/mipmap_cache.c
+++ b/src/common/mipmap_cache.c
@@ -729,8 +729,10 @@ void dt_mipmap_cache_init()
     { 1920, 1200 },           // mip4 - covers 1080p and 1600x1200
     { 2560, 1600 },           // mip5 - covers 2560x1440
     { 4096, 2560 },           // mip6 - covers 4K and UHD
-    { 5120, 3200 },           // mip7 - covers 5120x2880 panels
-    { 999999999, 999999999 }, // mip8 - used for full preview at full size
+    { 5120, 3200 },           // mip7 - covers 5K
+    { 6144, 3456 },           // mip8 - covers 6K
+    { 7680, 4320 },           // mip9 - covers 8K
+    { 999999999, 999999999 }, // mip10 - used for full preview at full size
   };
   // Set mipf to mip2 size as at most the user will be using an 8K screen and
   // have a preview that's ~4x smaller
@@ -1266,6 +1268,8 @@ dt_mipmap_size_t dt_mipmap_cache_get_min_mip_from_pref(const char *value)
   if(strcmp(value, "WQXGA") == 0)  return DT_MIPMAP_5;
   if(strcmp(value, "4K") == 0)     return DT_MIPMAP_6;
   if(strcmp(value, "5K") == 0)     return DT_MIPMAP_7;
+  if(strcmp(value, "6K") == 0)     return DT_MIPMAP_8;
+  if(strcmp(value, "8K") == 0)     return DT_MIPMAP_9;
   return DT_MIPMAP_NONE;
 }
 

--- a/src/common/mipmap_cache.c
+++ b/src/common/mipmap_cache.c
@@ -473,7 +473,7 @@ static void _mipmap_cache_allocate_dynamic(void *data,
   // alloc mere minimum for the header + broken image buffer:
   if(!dsc)
   {
-    if(mip == DT_MIPMAP_8)
+    if(mip == DT_MIPMAP_LDR_MAX)
     {
       int imgfw= 0, imgfh= 0;
       // be sure that we have the right size values
@@ -523,11 +523,11 @@ static void _mipmap_cache_allocate_dynamic(void *data,
   assert(dsc->size >= sizeof(*dsc));
 
   int loaded_from_disk = 0;
-  if(mip < DT_MIPMAP_F)
+  if(mip <= DT_MIPMAP_LDR_MAX)
   {
     if(cache->cachedir[0]
-       && ((dt_conf_get_bool("cache_disk_backend") && mip < DT_MIPMAP_8)
-           || (dt_conf_get_bool("cache_disk_backend_full") && mip == DT_MIPMAP_8)))
+       && ((dt_conf_get_bool("cache_disk_backend") && mip < DT_MIPMAP_LDR_MAX)
+           || (dt_conf_get_bool("cache_disk_backend_full") && mip == DT_MIPMAP_LDR_MAX)))
     {
       // try and load from disk, if successful set flag
       char filename[PATH_MAX] = {0};
@@ -586,7 +586,7 @@ read_error:
   // to make sure quota is meaningful.
   if(mip >= DT_MIPMAP_F)
     entry->cost = 1;
-  else if(mip == DT_MIPMAP_8)
+  else if(mip == DT_MIPMAP_LDR_MAX)
     entry->cost = entry->data_size;
   else
     entry->cost = cache->buffer_size[mip];
@@ -615,7 +615,7 @@ static void _mipmap_cache_deallocate_dynamic(void *data,
 {
   dt_mipmap_cache_t *cache = (dt_mipmap_cache_t *)data;
   const dt_mipmap_size_t mip = _get_size(entry->key);
-  if(mip < DT_MIPMAP_F)
+  if(mip <= DT_MIPMAP_LDR_MAX)
   {
     dt_mipmap_buffer_dsc_t *dsc = (dt_mipmap_buffer_dsc_t *)entry->data;
     // don't write skulls:
@@ -627,9 +627,9 @@ static void _mipmap_cache_deallocate_dynamic(void *data,
       }
       else if(cache->cachedir[0]
               && ((dt_conf_get_bool("cache_disk_backend")
-                   && mip < DT_MIPMAP_8)
+                   && mip < DT_MIPMAP_LDR_MAX)
                   || (dt_conf_get_bool("cache_disk_backend_full")
-                      && mip == DT_MIPMAP_8)))
+                      && mip == DT_MIPMAP_LDR_MAX)))
       {
         // serialize to disk
         char filename[PATH_MAX] = {0};
@@ -736,13 +736,13 @@ void dt_mipmap_cache_init()
   // have a preview that's ~4x smaller
   cache->max_width[DT_MIPMAP_F] = mipsizes[DT_MIPMAP_2][0];
   cache->max_height[DT_MIPMAP_F] = mipsizes[DT_MIPMAP_2][1];
-  for(int k = DT_MIPMAP_F-1; k >= 0; k--)
+  for(int k = DT_MIPMAP_LDR_MAX; k >= 0; k--)
   {
     cache->max_width[k]  = mipsizes[k][0];
     cache->max_height[k] = mipsizes[k][1];
   }
-    // header + buffer
-  for(int k = DT_MIPMAP_F-1; k >= 0; k--)
+  // header + buffer
+  for(int k = DT_MIPMAP_LDR_MAX; k >= 0; k--)
     cache->buffer_size[k] = sizeof(dt_mipmap_buffer_dsc_t)
                                 + (size_t)cache->max_width[k] * cache->max_height[k] * 4;
 
@@ -1103,7 +1103,7 @@ void dt_mipmap_cache_get_with_caller(dt_mipmap_buffer_t *buf,
       dt_image_cache_read_release(img);
       dt_print(DT_DEBUG_PIPE,
                "[mipmap cache get] got a zero-sized ID=%d mip %d!", imgid, mip);
-      if(mip < DT_MIPMAP_F)
+      if(mip <= DT_MIPMAP_LDR_MAX)
       {
         switch(ret)
         {
@@ -1176,7 +1176,7 @@ void dt_mipmap_cache_get_with_caller(dt_mipmap_buffer_t *buf,
     }
     // couldn't find a smaller thumb, try larger ones only now (these
     // will be slightly slower due to cairo rescaling):
-    const dt_mipmap_size_t max_mip = (mip >= DT_MIPMAP_F) ? mip : DT_MIPMAP_F-1;
+    const dt_mipmap_size_t max_mip = (mip >= DT_MIPMAP_F) ? mip : DT_MIPMAP_LDR_MAX;
     for(int k = mip+1; k <= max_mip; k++)
     {
       // already loaded?
@@ -1247,7 +1247,7 @@ dt_mipmap_size_t dt_mipmap_cache_get_matching_size(const int32_t width,
   dt_mipmap_cache_t *cache = darktable.mipmap_cache;
   dt_mipmap_size_t best = DT_MIPMAP_NONE;
   assert(cache);
-  for(int k = DT_MIPMAP_0; k < DT_MIPMAP_F; k++)
+  for(int k = DT_MIPMAP_0; k <= DT_MIPMAP_LDR_MAX; k++)
   {
     best = k;
     if((cache->max_width[k] >= width) && (cache->max_height[k] >= height))
@@ -1274,7 +1274,7 @@ void dt_mipmap_cache_remove_at_size(const dt_imgid_t imgid,
 {
   dt_mipmap_cache_t *cache = darktable.mipmap_cache;
   assert(cache);
-  if(!cache || mip > DT_MIPMAP_8 || mip < DT_MIPMAP_0) return;
+  if(!cache || mip > DT_MIPMAP_LDR_MAX || mip < DT_MIPMAP_0) return;
   // get rid of all ldr thumbnails:
   const uint32_t key = _get_key(imgid, mip);
   dt_cache_entry_t *entry = dt_cache_testget(&_get_cache(cache, mip)->cache, key, 'w');
@@ -1298,7 +1298,7 @@ void dt_mipmap_cache_remove_at_size(const dt_imgid_t imgid,
 
 void dt_mipmap_cache_remove(const dt_imgid_t imgid)
 {
-  for(dt_mipmap_size_t k = DT_MIPMAP_0; k < DT_MIPMAP_F; k++)
+  for(dt_mipmap_size_t k = DT_MIPMAP_0; k <= DT_MIPMAP_LDR_MAX; k++)
   {
     dt_mipmap_cache_remove_at_size(imgid, k);
   }
@@ -1318,7 +1318,7 @@ void dt_mipmap_cache_evict_at_size(const dt_imgid_t imgid,
 void dt_mipmap_cache_evict(const dt_imgid_t imgid)
 {
   dt_mipmap_cache_t *cache = darktable.mipmap_cache;
-  for(dt_mipmap_size_t k = DT_MIPMAP_0; k < DT_MIPMAP_F; k++)
+  for(dt_mipmap_size_t k = DT_MIPMAP_0; k <= DT_MIPMAP_LDR_MAX; k++)
   {
     const uint32_t key = _get_key(imgid, k);
 
@@ -1602,7 +1602,7 @@ static void _init_8(uint8_t *buf,
   if(res)
   {
     //try to generate mip from larger mip
-    for(dt_mipmap_size_t k = size + 1; k < DT_MIPMAP_F; k++)
+    for(dt_mipmap_size_t k = size + 1; k <= DT_MIPMAP_LDR_MAX; k++)
     {
       dt_mipmap_buffer_t tmp;
       dt_mipmap_cache_get(&tmp, imgid, k, DT_MIPMAP_TESTLOCK, 'r');
@@ -1692,7 +1692,7 @@ void dt_mipmap_cache_copy_thumbnails(const dt_imgid_t dst_imgid,
     && dt_is_valid_imgid(src_imgid)
     && dt_is_valid_imgid(dst_imgid))
   {
-    for(dt_mipmap_size_t mip = DT_MIPMAP_0; mip < DT_MIPMAP_F; mip++)
+    for(dt_mipmap_size_t mip = DT_MIPMAP_0; mip <= DT_MIPMAP_LDR_MAX; mip++)
     {
       // try and load from disk, if successful set flag
       char srcpath[PATH_MAX] = {0};

--- a/src/common/mipmap_cache.h
+++ b/src/common/mipmap_cache.h
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2011-2025 darktable developers.
+    Copyright (C) 2011-2026 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -26,6 +26,7 @@ G_BEGIN_DECLS
 
 // sizes stored in the mipmap cache, set to fixed values in mipmap_cache.c
 typedef enum dt_mipmap_size_t {
+  // 8 bit, downscaled, for lighttable thumbnails
   DT_MIPMAP_0 = 0,
   DT_MIPMAP_1,
   DT_MIPMAP_2,
@@ -34,11 +35,16 @@ typedef enum dt_mipmap_size_t {
   DT_MIPMAP_5,
   DT_MIPMAP_6,
   DT_MIPMAP_7,
+  // 8 bit, full resolution, for zoomed in thumbnail
   DT_MIPMAP_8,
+  // float, downscaled, for preview pixelpipe
   DT_MIPMAP_F,
+  // float, full resolution, for full/export pixelpipe
   DT_MIPMAP_FULL,
   DT_MIPMAP_NONE
 } dt_mipmap_size_t;
+
+static const dt_mipmap_size_t DT_MIPMAP_LDR_MAX = DT_MIPMAP_8;
 
 // type to be passed to getter functions
 typedef enum dt_mipmap_get_flags_t

--- a/src/common/mipmap_cache.h
+++ b/src/common/mipmap_cache.h
@@ -35,8 +35,10 @@ typedef enum dt_mipmap_size_t {
   DT_MIPMAP_5,
   DT_MIPMAP_6,
   DT_MIPMAP_7,
-  // 8 bit, full resolution, for zoomed in thumbnail
   DT_MIPMAP_8,
+  DT_MIPMAP_9,
+  // 8 bit, full resolution, for zoomed in thumbnail
+  DT_MIPMAP_10,
   // float, downscaled, for preview pixelpipe
   DT_MIPMAP_F,
   // float, full resolution, for full/export pixelpipe
@@ -44,7 +46,7 @@ typedef enum dt_mipmap_size_t {
   DT_MIPMAP_NONE
 } dt_mipmap_size_t;
 
-static const dt_mipmap_size_t DT_MIPMAP_LDR_MAX = DT_MIPMAP_8;
+static const dt_mipmap_size_t DT_MIPMAP_LDR_MAX = DT_MIPMAP_10;
 
 // type to be passed to getter functions
 typedef enum dt_mipmap_get_flags_t

--- a/src/control/crawler.c
+++ b/src/control/crawler.c
@@ -862,7 +862,7 @@ static inline gboolean _lighttable_silent(void)
 
 static inline gboolean _valid_mip(dt_mipmap_size_t mip)
 {
-  return mip > DT_MIPMAP_0 && mip < DT_MIPMAP_8;
+  return mip > DT_MIPMAP_0 && mip < DT_MIPMAP_LDR_MAX;
 }
 
 static inline gboolean _still_thumbing(void)
@@ -991,7 +991,7 @@ void dt_update_thumbs_thread(void *p)
   }
 
   // return if any thumbcache dir is not writable
-  for(dt_mipmap_size_t k = DT_MIPMAP_1; k <= DT_MIPMAP_7; k++)
+  for(dt_mipmap_size_t k = DT_MIPMAP_1; k <= DT_MIPMAP_LDR_MAX-1; k++)
   {
     char dirname[PATH_MAX] = { 0 };
     snprintf(dirname, sizeof(dirname), "%s.d/%d", darktable.mipmap_cache->cachedir, k);

--- a/src/dtgtk/thumbnail.c
+++ b/src/dtgtk/thumbnail.c
@@ -467,7 +467,7 @@ static void _get_dimensions_for_img_to_fit(const dt_thumbnail_t *thumb,
   // decimal, so not enough accurate so we compute it from the larger
   // available mipmap
   float ar = 0.0f;
-  for(int k = DT_MIPMAP_7; k >= DT_MIPMAP_0; k--)
+  for(int k = DT_MIPMAP_LDR_MAX; k >= DT_MIPMAP_0; k--)
   {
     dt_mipmap_buffer_t tmp;
     dt_mipmap_cache_get(&tmp, thumb->imgid, k, DT_MIPMAP_TESTLOCK, 'r');

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -1683,8 +1683,8 @@ static void _thumbs_ask_for_discard(dt_thumbtable_t *table)
 
   dt_mipmap_size_t embeddedl = dt_mipmap_cache_get_min_mip_from_pref(embedded);
 
-  int min_level = 8;
-  int max_level = 0;
+  int min_level = DT_MIPMAP_LDR_MAX;
+  int max_level = DT_MIPMAP_0;
   if(hql != table->pref_hq)
   {
     min_level = MIN(table->pref_hq, hql);
@@ -1703,9 +1703,9 @@ static void _thumbs_ask_for_discard(dt_thumbtable_t *table)
     gchar *txt =
       g_strdup(_("you have changed the settings related to"
                  " how thumbnails are generated.\n"));
-    if(max_level >= DT_MIPMAP_8 && min_level == DT_MIPMAP_0)
+    if(max_level >= DT_MIPMAP_LDR_MAX && min_level == DT_MIPMAP_0)
       dt_util_str_cat(&txt, _("all cached thumbnails need to be invalidated.\n\n"));
-    else if(max_level >= DT_MIPMAP_8)
+    else if(max_level >= DT_MIPMAP_LDR_MAX)
       dt_util_str_cat
         (&txt,
          _("cached thumbnails starting from level %d need to be invalidated.\n\n"),

--- a/src/generate-cache/main.c
+++ b/src/generate-cache/main.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2015-2024 darktable developers.
+    Copyright (C) 2015-2026 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -181,12 +181,12 @@ int main(int argc, char *arg[])
     else if((!strcmp(arg[k], "-m") || !strcmp(arg[k], "--max-mip")) && argc > k + 1)
     {
       k++;
-      max_mip = (dt_mipmap_size_t)MIN(MAX(atoi(arg[k]), DT_MIPMAP_0), DT_MIPMAP_8);
+      max_mip = (dt_mipmap_size_t)MIN(MAX(atoi(arg[k]), DT_MIPMAP_0), DT_MIPMAP_LDR_MAX);
     }
     else if(!strcmp(arg[k], "--min-mip") && argc > k + 1)
     {
       k++;
-      min_mip = (dt_mipmap_size_t)MIN(MAX(atoi(arg[k]), DT_MIPMAP_0), DT_MIPMAP_8);
+      min_mip = (dt_mipmap_size_t)MIN(MAX(atoi(arg[k]), DT_MIPMAP_0), DT_MIPMAP_LDR_MAX);
     }
     else if(!strcmp(arg[k], "--min-imgid") && argc > k + 1)
     {
@@ -231,7 +231,7 @@ int main(int argc, char *arg[])
     exit(EXIT_FAILURE);
   }
 
-  if(max_mip == 8 && !dt_conf_get_bool("cache_disk_backend_full"))
+  if(max_mip == DT_MIPMAP_LDR_MAX && !dt_conf_get_bool("cache_disk_backend_full"))
   {
     fprintf(stderr,
             _("warning: disk backend for full preview cache is disabled (cache_disk_backend_full).\nif you want "


### PR DESCRIPTION
- Update/add higher resolution mipmaps:
  - New mip8 to cover 6K displays
  - New mip9 to cover 8K displays
  - New mip10 for full-sized 8-bit mipmaps (previously these were mip8)
- Increase mipf resolution from mip2 to mip3 dimensions, as per suggestion from @jenshannoschwalm.
- Add an alias `DT_MIPMAP_LDR_MAX` for the full-sized 8 bit mipmap, to ease any future mipmap size adjustments.

Adding higher resolution mipmaps both covers higher resolution displays and should allow for less jumpy zooming in on high megapixel files. Increasing the mipf resolution should produce better preview pipe data.

In `_get_dimensions_for_img_to_fit()`, prior code looked at mip7 or smaller. This code looks at the full-sized 8 bit mipmap or smaller, which should produce more accurate results without a slowdown.

In the crawler, I noticed that the code never creates a full-sized 8 bit mipmap, nor a mip0. I left that behavior unchanged.

Closes #20178.