### PR TITLE
show crop aspect ratio in crop preview

### DIFF
--- a/src/iop/crop.c
+++ b/src/iop/crop.c
@@ -1564,7 +1564,15 @@ void gui_post_expose(dt_iop_module_t *self,
     pango_layout_set_font_description(layout, desc);
 
     char dimensions[64] = { '\0' };
-    snprintf(dimensions, sizeof(dimensions), "%d x %d", width - diff_w, height - diff_h);
+    const double ratio = (double)(width - diff_w)/(height - diff_h);
+    char ratio_str[15] = { '\0' };
+    if(ratio<1)
+      snprintf(ratio_str, sizeof(ratio_str), "(1 : %.2f)", (double)1/ratio);
+    else if(ratio>1)
+      snprintf(ratio_str, sizeof(ratio_str), "(%.2f : 1)", ratio);
+    else
+      snprintf(ratio_str, sizeof(ratio_str), "(1 : 1)");
+    snprintf(dimensions, sizeof(dimensions), "%d x %d %s", width - diff_w, height - diff_h, ratio_str);
 
     pango_layout_set_text(layout, dimensions, -1);
     pango_layout_get_pixel_extents(layout, NULL, &ext);


### PR DESCRIPTION
This enhancement proposal originated from a suggestion on the pixls.us forum by user elGordo ([Displaying freeform crop aspect ratio](https://discuss.pixls.us/t/displaying-freeform-crop-aspect-ratio/55620)). See also feature request https://github.com/darktable-org/darktable/issues/20192
In the crop module when adjusting the crop, the dimension of the crop area are displayed as <width> x <height> in the middle of the frame. The proposal is to also show the aspect ratio of the crop area, as shown in the screenshot:
<img width="565" height="323" alt="image" src="https://github.com/user-attachments/assets/7d6e05ab-82d8-4992-9d59-181b5bc121e5" />
