### PR TITLE
Avoid possible crash after metadata update

### DIFF
--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -1806,8 +1806,9 @@ static void _dt_metadata_change_callback(gpointer instance,
   for(const GList *l = imgs; l; l = g_list_next(l))
   {
     const dt_imgid_t imgid = GPOINTER_TO_INT(l->data);
-    dt_thumbnail_t *th = _thumbtable_get_thumb(table, imgid);
-    dt_thumbnail_reload_infos(th);
+    dt_thumbnail_t *thumb = _thumbtable_get_thumb(table, imgid);
+    if(thumb)
+      dt_thumbnail_reload_infos(thumb);
   }
 
   g_list_free(imgs);


### PR DESCRIPTION
The thumbnail for the image for which we are updating metadata may be in the undisplayed part of the thumbnail table. In this case, the function that returns the image thumbnail data in the thumbnail table will return NULL. We have to check for this to avoid NULL dereferencing.

Fixes #20199.