### PR TITLE
Use lightweight ubuntu-slim runner for stale bot

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -21,7 +21,7 @@ jobs:
     permissions:
       issues: write  # for actions/stale to close stale issues
       pull-requests: write  # for actions/stale to close stale PRs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
 
     steps:
     - uses: actions/stale@v10


### PR DESCRIPTION
This does not improve anything for darktable, this replacement just allows us to not use a sledgehammer to crack a nut. We don't need powerful runners from Github when we can work with a lightweight one.

See https://github.blog/changelog/2026-01-22-1-vcpu-linux-runner-now-generally-available-in-github-actions/ for details.