### PR TITLE
Update lighttable image information when crop changes in darkroom

### DIFF
--- a/src/dtgtk/thumbnail.c
+++ b/src/dtgtk/thumbnail.c
@@ -1119,7 +1119,12 @@ static void _dt_image_info_changed_callback(gpointer instance,
   {
     if(GPOINTER_TO_INT(i->data) == thumb->imgid)
     {
-      dt_thumbnail_update_infos(thumb);
+      if(thumb->over == DT_THUMBNAIL_OVERLAYS_HOVER_EXTENDED
+        || thumb->over == DT_THUMBNAIL_OVERLAYS_ALWAYS_EXTENDED
+        || thumb->over == DT_THUMBNAIL_OVERLAYS_MIXED)
+        dt_thumbnail_reload_infos(thumb);
+      else
+        dt_thumbnail_update_infos(thumb);
       break;
     }
   }

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -2745,8 +2745,7 @@ void dt_thumbtable_full_redraw(dt_thumbtable_t *table,
         {
           dt_gui_add_class(th->w_main, "dt_last_active");
           th->active = FALSE;
-          // force reload of information to get latest from darkroom
-          dt_thumbnail_reload_infos(th);
+          dt_thumbnail_update_infos(th);
         }
       }
       g_slist_free(darktable.view_manager->active_images);

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -1114,7 +1114,7 @@ static gboolean _dev_load_requested_image(gpointer user_data)
         LUA_ASYNC_DONE);
 #endif
     // update the lighttable metadata_view with any changes
-    DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_METADATA_UPDATE);
+    DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_METADATA_CHANGED);
   }
 
   // clean the undo list
@@ -3203,7 +3203,7 @@ void leave(dt_view_t *self)
         LUA_ASYNC_DONE);
 #endif
     // update the lighttable metadata_view with any changes
-    DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_METADATA_UPDATE);
+    DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_METADATA_CHANGED);
   }
   else
     dt_image_synch_xmp(imgid);


### PR DESCRIPTION
Update the lighttable image information when the crop changes in darkroom.

Fixes pixls discussion https://discuss.pixls.us/t/strange-erroneous-behavior-in-file-names-upon-export-using-dimensions