### PR TITLE
agx: don't activate the pivot pickers until the user starts dragging the mouse

### DIFF
--- a/src/gui/color_picker_proxy.c
+++ b/src/gui/color_picker_proxy.c
@@ -206,17 +206,19 @@ static gboolean _color_picker_callback_button_press(GtkWidget *button,
     // pull picker's last recorded positions
     if(kind & DT_COLOR_PICKER_AREA)
     {
-      if(flags & DT_COLOR_PICKER_NO_AUTO)
-      {
-        // reset coordinates to 0.0f to create a zero-area box,
-        // requiring the user to drag-select manually
-        memset(self->pick_box, 0, sizeof(self->pick_box));
-      }
-      else if(   self->pick_box[0] == 0.0f && self->pick_box[1] == 0.0f
+      if(   self->pick_box[0] == 0.0f && self->pick_box[1] == 0.0f
          && self->pick_box[2] == 1.0f && self->pick_box[3] == 1.0f)
       {
-        dt_boundingbox_t reset = { 0.02f, 0.02f, 0.98f, 0.98f };
-        dt_color_picker_backtransform_box(darktable.develop, 2, reset, self->pick_box);
+        if(flags & DT_COLOR_PICKER_NO_AUTO)
+        {
+          // reset coordinates to 0.0f to create a zero-area box,
+          // requiring the user to drag-select manually
+          memset(self->pick_box, 0, sizeof(self->pick_box));
+        }
+        else {
+          dt_boundingbox_t reset = { 0.02f, 0.02f, 0.98f, 0.98f };
+          dt_color_picker_backtransform_box(darktable.develop, 2, reset, self->pick_box);
+        }
       }
       dt_lib_colorpicker_set_box_area(darktable.lib, self->pick_box);
     }
@@ -324,11 +326,6 @@ static void _iop_color_picker_pickerdata_ready_callback(gpointer instance,
   // FIXME: is this overdoing it? see #14812
   pipe->changed |= DT_DEV_PIPE_REMOVE;
   pipe->cache_obsolete = TRUE;
-
-  if((picker->flags & DT_COLOR_PICKER_CALLBACK_ONLY_WHEN_DONE) && darktable.control->button_down)
-  {
-    return;
-  }
 
   // iops only need new picker data if the pointer has moved
   if(_record_point_area(picker))

--- a/src/gui/color_picker_proxy.c
+++ b/src/gui/color_picker_proxy.c
@@ -75,7 +75,7 @@ gboolean dt_iop_color_picker_is_visible(const dt_develop_t *dev)
 
 gboolean dt_iop_color_picker_is_area_empty(const dt_pickerbox_t box)
 {
-  return (fabsf(box[2] - box[0]) < 1e-5f || fabsf(box[3] - box[1]) < 1e-5f);
+  return (fabsf(box[2] - box[0]) < 1e-3f || fabsf(box[3] - box[1]) < 1e-3f);
 }
 
 static gboolean _record_point_area(dt_iop_color_picker_t *self)
@@ -324,6 +324,11 @@ static void _iop_color_picker_pickerdata_ready_callback(gpointer instance,
   // FIXME: is this overdoing it? see #14812
   pipe->changed |= DT_DEV_PIPE_REMOVE;
   pipe->cache_obsolete = TRUE;
+
+  if((picker->flags & DT_COLOR_PICKER_CALLBACK_ONLY_WHEN_DONE) && darktable.control->button_down)
+  {
+    return;
+  }
 
   // iops only need new picker data if the pointer has moved
   if(_record_point_area(picker))

--- a/src/gui/color_picker_proxy.h
+++ b/src/gui/color_picker_proxy.h
@@ -42,7 +42,9 @@ typedef enum _iop_color_picker_flags_t
   // all pickers sample input, only ones with this flag set sample output
   DT_COLOR_PICKER_IO = 1 << 3,
   // don't auto-expand the area, wait for user selection via dragging
-  DT_COLOR_PICKER_NO_AUTO = 1 << 4
+  DT_COLOR_PICKER_NO_AUTO = 1 << 4,
+  // only invoke the callback when the user releases the button
+  DT_COLOR_PICKER_CALLBACK_ONLY_WHEN_DONE = 1 << 5
 } dt_iop_color_picker_flags_t;
 
 typedef struct dt_iop_color_picker_t

--- a/src/gui/color_picker_proxy.h
+++ b/src/gui/color_picker_proxy.h
@@ -42,9 +42,7 @@ typedef enum _iop_color_picker_flags_t
   // all pickers sample input, only ones with this flag set sample output
   DT_COLOR_PICKER_IO = 1 << 3,
   // don't auto-expand the area, wait for user selection via dragging
-  DT_COLOR_PICKER_NO_AUTO = 1 << 4,
-  // only invoke the callback when the user releases the button
-  DT_COLOR_PICKER_CALLBACK_ONLY_WHEN_DONE = 1 << 5
+  DT_COLOR_PICKER_NO_AUTO = 1 << 4
 } dt_iop_color_picker_flags_t;
 
 typedef struct dt_iop_color_picker_t

--- a/src/gui/color_picker_proxy.h
+++ b/src/gui/color_picker_proxy.h
@@ -40,7 +40,9 @@ typedef enum _iop_color_picker_flags_t
   // only works with 4-channel images
   DT_COLOR_PICKER_DENOISE = 1 << 2,
   // all pickers sample input, only ones with this flag set sample output
-  DT_COLOR_PICKER_IO = 1 << 3
+  DT_COLOR_PICKER_IO = 1 << 3,
+  // don't auto-expand the area, wait for user selection via dragging
+  DT_COLOR_PICKER_NO_AUTO = 1 << 4
 } dt_iop_color_picker_flags_t;
 
 typedef struct dt_iop_color_picker_t
@@ -70,6 +72,8 @@ typedef struct dt_iop_color_picker_t
 
 
 gboolean dt_iop_color_picker_is_visible(const dt_develop_t *dev);
+
+gboolean dt_iop_color_picker_is_area_empty(const dt_pickerbox_t box);
 
 //* reset current color picker if not keep-active or not keep */
 void dt_iop_color_picker_reset(dt_iop_module_t *module,

--- a/src/iop/agx.c
+++ b/src/iop/agx.c
@@ -1170,6 +1170,12 @@ static void _read_exposure_params_callback(GtkWidget *widget,
 // move only the pivot's relative (input) exposure, and recalculate its output based on mid-gray
 static void _apply_auto_pivot_xy(dt_iop_module_t *self, const dt_iop_order_iccprofile_info_t *profile)
 {
+  printf("_apply_auto_pivot_xy, %d\n", darktable.control->button_down);
+  // don't update while the user is dragging the mouse
+  if (darktable.control->button_down) {
+    return;
+  }
+
   dt_iop_agx_params_t *p = self->params;
   const dt_iop_agx_gui_data_t *g = self->gui_data;
 
@@ -1815,7 +1821,7 @@ static GtkWidget* _create_basic_curve_controls_box(dt_iop_module_t *self,
   dt_iop_basic_curve_controls_t *controls = &g->basic_curve_controls;
 
   // curve_pivot_x_relative_ev with picker
-  slider = dt_color_picker_new(self, DT_COLOR_PICKER_AREA | DT_COLOR_PICKER_DENOISE | DT_COLOR_PICKER_NO_AUTO | DT_COLOR_PICKER_CALLBACK_ONLY_WHEN_DONE, dt_bauhaus_slider_from_params(section, "curve_pivot_x"));
+  slider = dt_color_picker_new(self, DT_COLOR_PICKER_AREA | DT_COLOR_PICKER_DENOISE, dt_bauhaus_slider_from_params(section, "curve_pivot_x"));
   controls->curve_pivot_x = slider;
   dt_bauhaus_slider_set_format(slider, _(" EV"));
   dt_bauhaus_slider_set_digits(slider, 2);
@@ -1824,7 +1830,7 @@ static GtkWidget* _create_basic_curve_controls_box(dt_iop_module_t *self,
                                                "used to set the pivot relative to mid-gray"));
 
   // curve_pivot_y_linear
-  slider = dt_color_picker_new(self, DT_COLOR_PICKER_AREA | DT_COLOR_PICKER_DENOISE | DT_COLOR_PICKER_NO_AUTO | DT_COLOR_PICKER_CALLBACK_ONLY_WHEN_DONE, dt_bauhaus_slider_from_params(section, "curve_pivot_y_linear_output"));
+  slider = dt_color_picker_new(self, DT_COLOR_PICKER_AREA | DT_COLOR_PICKER_DENOISE | DT_COLOR_PICKER_NO_AUTO, dt_bauhaus_slider_from_params(section, "curve_pivot_y_linear_output"));
   controls->curve_pivot_y_linear = slider;
   dt_bauhaus_slider_set_format(slider, "%");
   dt_bauhaus_slider_set_digits(slider, 2);

--- a/src/iop/agx.c
+++ b/src/iop/agx.c
@@ -1815,7 +1815,7 @@ static GtkWidget* _create_basic_curve_controls_box(dt_iop_module_t *self,
   dt_iop_basic_curve_controls_t *controls = &g->basic_curve_controls;
 
   // curve_pivot_x_relative_ev with picker
-  slider = dt_color_picker_new(self, DT_COLOR_PICKER_AREA | DT_COLOR_PICKER_DENOISE, dt_bauhaus_slider_from_params(section, "curve_pivot_x"));
+  slider = dt_color_picker_new(self, DT_COLOR_PICKER_AREA | DT_COLOR_PICKER_DENOISE | DT_COLOR_PICKER_NO_AUTO, dt_bauhaus_slider_from_params(section, "curve_pivot_x"));
   controls->curve_pivot_x = slider;
   dt_bauhaus_slider_set_format(slider, _(" EV"));
   dt_bauhaus_slider_set_digits(slider, 2);
@@ -1824,7 +1824,7 @@ static GtkWidget* _create_basic_curve_controls_box(dt_iop_module_t *self,
                                                "used to set the pivot relative to mid-gray"));
 
   // curve_pivot_y_linear
-  slider = dt_color_picker_new(self, DT_COLOR_PICKER_AREA | DT_COLOR_PICKER_DENOISE, dt_bauhaus_slider_from_params(section, "curve_pivot_y_linear_output"));
+  slider = dt_color_picker_new(self, DT_COLOR_PICKER_AREA | DT_COLOR_PICKER_DENOISE | DT_COLOR_PICKER_NO_AUTO, dt_bauhaus_slider_from_params(section, "curve_pivot_y_linear_output"));
   controls->curve_pivot_y_linear = slider;
   dt_bauhaus_slider_set_format(slider, "%");
   dt_bauhaus_slider_set_digits(slider, 2);

--- a/src/iop/agx.c
+++ b/src/iop/agx.c
@@ -1815,7 +1815,7 @@ static GtkWidget* _create_basic_curve_controls_box(dt_iop_module_t *self,
   dt_iop_basic_curve_controls_t *controls = &g->basic_curve_controls;
 
   // curve_pivot_x_relative_ev with picker
-  slider = dt_color_picker_new(self, DT_COLOR_PICKER_AREA | DT_COLOR_PICKER_DENOISE | DT_COLOR_PICKER_NO_AUTO, dt_bauhaus_slider_from_params(section, "curve_pivot_x"));
+  slider = dt_color_picker_new(self, DT_COLOR_PICKER_AREA | DT_COLOR_PICKER_DENOISE | DT_COLOR_PICKER_NO_AUTO | DT_COLOR_PICKER_CALLBACK_ONLY_WHEN_DONE, dt_bauhaus_slider_from_params(section, "curve_pivot_x"));
   controls->curve_pivot_x = slider;
   dt_bauhaus_slider_set_format(slider, _(" EV"));
   dt_bauhaus_slider_set_digits(slider, 2);
@@ -1824,7 +1824,7 @@ static GtkWidget* _create_basic_curve_controls_box(dt_iop_module_t *self,
                                                "used to set the pivot relative to mid-gray"));
 
   // curve_pivot_y_linear
-  slider = dt_color_picker_new(self, DT_COLOR_PICKER_AREA | DT_COLOR_PICKER_DENOISE | DT_COLOR_PICKER_NO_AUTO, dt_bauhaus_slider_from_params(section, "curve_pivot_y_linear_output"));
+  slider = dt_color_picker_new(self, DT_COLOR_PICKER_AREA | DT_COLOR_PICKER_DENOISE | DT_COLOR_PICKER_NO_AUTO | DT_COLOR_PICKER_CALLBACK_ONLY_WHEN_DONE, dt_bauhaus_slider_from_params(section, "curve_pivot_y_linear_output"));
   controls->curve_pivot_y_linear = slider;
   dt_bauhaus_slider_set_format(slider, "%");
   dt_bauhaus_slider_set_digits(slider, 2);

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -310,6 +310,10 @@ static void _darkroom_pickers_draw(dt_view_t *self,
     // overlays are aligned with pixels for a clean look
     if(sample->size == DT_LIB_COLORPICKER_SIZE_BOX)
     {
+      // do not draw if the area is empty
+      if(dt_iop_color_picker_is_area_empty(sample->box))
+        continue;
+
       dt_boundingbox_t fbox;
       dt_color_picker_transform_box(dev, 2, sample->box, fbox, FALSE);
       x = fbox[0];

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -3550,13 +3550,24 @@ int button_pressed(dt_view_t *self,
         }
         else
         {
-          const float dx = 0.02f;
-          const float dy = dx * (float)dev->full.pipe->processed_width / (float)dev->full.pipe->processed_height;
-          const dt_boundingbox_t fbox = { zoom_x - dx,
-                                          zoom_y - dy,
-                                          zoom_x + dx,
-                                          zoom_y + dy };
-          dt_color_picker_backtransform_box(dev, 2, fbox, sample->box);
+          dt_iop_color_picker_t *picker = darktable.lib->proxy.colorpicker.picker_proxy;
+
+          if(picker && (picker->flags & DT_COLOR_PICKER_NO_AUTO))
+          {
+            // don't create a box around the starting point; the user has to explicitly select an area by dragging
+            const dt_boundingbox_t fbox = { zoom_x, zoom_y, zoom_x, zoom_y };
+            dt_color_picker_backtransform_box(dev, 2, fbox, sample->box);
+          }
+          else
+          {
+            const float dx = 0.02f;
+            const float dy = dx * (float)dev->full.pipe->processed_width / (float)dev->full.pipe->processed_height;
+            const dt_boundingbox_t fbox = { zoom_x - dx,
+                                            zoom_y - dy,
+                                            zoom_x + dx,
+                                            zoom_y + dy };
+            dt_color_picker_backtransform_box(dev, 2, fbox, sample->box);
+          }
         }
         dt_control_change_cursor(GDK_FLEUR);
       }

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -3446,6 +3446,10 @@ int button_released(dt_view_t *self,
   int handled = 0;
   if(dt_iop_color_picker_is_visible(dev) && which == GDK_BUTTON_PRIMARY)
   {
+    // force an update on release so modules can detect the finish event
+    if(darktable.lib->proxy.colorpicker.picker_proxy)
+      darktable.lib->proxy.colorpicker.picker_proxy->changed = TRUE;
+
     // only sample box picker at end, for speed
     if(darktable.lib->proxy.colorpicker.primary_sample->size == DT_LIB_COLORPICKER_SIZE_BOX)
     {
@@ -3550,24 +3554,13 @@ int button_pressed(dt_view_t *self,
         }
         else
         {
-          dt_iop_color_picker_t *picker = darktable.lib->proxy.colorpicker.picker_proxy;
-
-          if(picker && (picker->flags & DT_COLOR_PICKER_NO_AUTO))
-          {
-            // don't create a box around the starting point; the user has to explicitly select an area by dragging
-            const dt_boundingbox_t fbox = { zoom_x, zoom_y, zoom_x, zoom_y };
-            dt_color_picker_backtransform_box(dev, 2, fbox, sample->box);
-          }
-          else
-          {
-            const float dx = 0.02f;
-            const float dy = dx * (float)dev->full.pipe->processed_width / (float)dev->full.pipe->processed_height;
-            const dt_boundingbox_t fbox = { zoom_x - dx,
-                                            zoom_y - dy,
-                                            zoom_x + dx,
-                                            zoom_y + dy };
-            dt_color_picker_backtransform_box(dev, 2, fbox, sample->box);
-          }
+          const float dx = 0.02f;
+          const float dy = dx * (float)dev->full.pipe->processed_width / (float)dev->full.pipe->processed_height;
+          const dt_boundingbox_t fbox = { zoom_x - dx,
+                                          zoom_y - dy,
+                                          zoom_x + dx,
+                                          zoom_y + dy };
+          dt_color_picker_backtransform_box(dev, 2, fbox, sample->box);
         }
         dt_control_change_cursor(GDK_FLEUR);
       }


### PR DESCRIPTION
The problem I'm trying to address is that if the user uses the pivot pickers for the first time, the whole image is selected. This behaviour is desirable e.g. for black/white point, but in AgX, it does not work so well for the pivot.

1. In the initial state, the pivot is set to map 18% input to 18% output.
2. When the user activates the _pivot y output_ picker, the average of the selected area is read (initially, the picker is set to read almost the whole image, automatically), and that value is run through the current (initially: 18%->18%) curve; the pivot (x,y) are set as follows: x = the average value provided by the picker; y = f(picked average) (f being the curve). For example, if the image's 'average reading' is 25%, we'll set the pivot at (x = 0.25, y = f(0.25, with params for 18%)). This shifts the output for all pixels, except those where x is 0.25.
3. The user then selects the area they actually want to use to pick the pivot. Let's say they pick a value with average in x = 0.3; its initial output was y = f(0.3, with params for 18%). However, the y (output) value will have shifted immediately when they activated the picker (on the whole image), so at the end of picking the desired region, they end up with a pivot at (x = 0.3, y = f(0.3, with params for 25%)).
4. They can then reset the pivot x and y to 18%, and pick again from the same area. This time, y will be calculated with params for the original pivot, and they get the desired (x = 0.3, y = f(0.3, with params for 0.18)).

This PR introduces a new picker flag, `DT_COLOR_PICKER_NO_AUTO`:
- the area is not set to cover the image if the picker is used for the 1st time
- previous picked positions are not retained
- no callbacks are made until the user starts dragging the mouse.

To demonstrate, check the video below. Left: darktable master; right: the proposed code. (There is a glitch where the picker corner markers are drawn top-right to the image, I've fixed that but did not record the video again.)

https://github.com/user-attachments/assets/0fd14775-d725-433f-a32d-269657800293

- initially, the selected area on the face has L \~= 78
- \~0:20: zooming out the master code to show that the picker selects the whole image
- \~0:28: the sample taken from the face shifts to L\~= 81
- \~0:45: using this area as the pivot region in AgX maintains this L \~= ~81
- \~0:50: resetting the pivot x/y sliders restores L \~= 78
- \~0:53: picking from the same area maintains L \~= 78
- \~1:05: zooming out with the new code, activating the picker does not cause a callback (observe the glitch on the top right, that's the one mentioned above, addressed using `dt_iop_color_picker_is_area_empty`)
- \~1:20: zooming in
- \~1:25-1:29: dragging the mouse, L \~= 77.7 (managed to almost maintain L = 78; minor change because the area isn't completely homogeneous)
- \~1:33 end (the rest is just closing OBS)

Changes:
- `src/gui/color_picker_proxy.c and .h`:
  - `dt_iop_color_picker_flags_t`: added new flag `DT_COLOR_PICKER_NO_AUTO`
  - `dt_iop_color_picker_is_area_empty`: a new function to determine if the user has not selected anything, yet
  - `_color_picker_callback_button_press`: if the flag is set when creating the picker, set all coordinates to 0 instead of selecting most of the image
  - `_iop_color_picker_pickerdata_ready_callback`: don't invoke the callback if nothing is selected
- `src/views/darkroom.c`: suppress drawing is nothing is selected
- `src/iop/agx.c`: use the new flag for the pivot pickers

@jenshannoschwalm @dterrahe 