### PR TITLE
Remove preview downsampling which was deprecated since Feb 2025.

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -2515,20 +2515,6 @@
     <shortdescription>whether to show the compute variance mode in denoiseprofile</shortdescription>
     <longdescription>adds a mode in denoiseprofile that allows to compute the variance after the generalized anscombe transform is performed</longdescription>
   </dtconfig>
-  <dtconfig>
-    <name>preview_downsampling</name>
-    <type>
-      <enum>
-        <option>original</option>
-        <option>to 1/2</option>
-        <option>to 1/3</option>
-        <option>to 1/4</option>
-      </enum>
-    </type>
-    <default>original</default>
-    <shortdescription>reduce resolution of preview image</shortdescription>
-    <longdescription>decrease to speed up preview rendering, hinders accurate masking, pickers and some module algorithm</longdescription>
-  </dtconfig>
   <dtconfig prefs="darkroom" section="general">
     <name>darkroom/ui/loading_screen</name>
     <type>bool</type>

--- a/src/common/mipmap_cache.c
+++ b/src/common/mipmap_cache.c
@@ -710,13 +710,8 @@ void dt_mipmap_cache_init()
   };
   // Set mipf to mip2 size as at most the user will be using an 8K screen and
   // have a preview that's ~4x smaller
-  const char *preview_downsample = dt_conf_get_string_const("preview_downsampling");
-  const float downsample = (!g_strcmp0(preview_downsample, "original")) ? 1.0f
-                         : (!g_strcmp0(preview_downsample, "to 1/2")) ? 0.5f
-                         : (!g_strcmp0(preview_downsample, "to 1/3")) ? 1/3.0f
-                         : 0.25f;
-  cache->max_width[DT_MIPMAP_F] = mipsizes[DT_MIPMAP_2][0] * downsample;
-  cache->max_height[DT_MIPMAP_F] = mipsizes[DT_MIPMAP_2][1] * downsample;
+  cache->max_width[DT_MIPMAP_F] = mipsizes[DT_MIPMAP_2][0];
+  cache->max_height[DT_MIPMAP_F] = mipsizes[DT_MIPMAP_2][1];
   for(int k = DT_MIPMAP_F-1; k >= 0; k--)
   {
     cache->max_width[k]  = mipsizes[k][0];

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -357,7 +357,6 @@ typedef struct dt_develop_t
 void dt_dev_init(dt_develop_t *dev, gboolean gui_attached);
 void dt_dev_cleanup(dt_develop_t *dev);
 
-float dt_dev_get_preview_downsampling();
 void dt_dev_process_image_job(dt_develop_t *dev,
                               dt_dev_viewport_t *port,
                               struct dt_dev_pixelpipe_t *pipe,


### PR DESCRIPTION
Closes #20207