### PR TITLE
Use relative links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,11 +339,11 @@ sudo cmake --install .
 
 ##### macOS
 
-See [Homebrew](https://github.com/darktable-org/darktable/blob/master/packaging/macosx/BUILD_hb.txt) or [MacPorts](https://github.com/darktable-org/darktable/blob/master/packaging/macosx/BUILD.txt) instructions.
+See [Homebrew](packaging/macosx/BUILD_hb.txt) or [MacPorts](packaging/macosx/BUILD.txt) instructions.
 
 ##### Windows
 
-See [these instructions](https://github.com/darktable-org/darktable/tree/master/packaging/windows).
+See [these instructions](packaging/windows/README.md).
 
 ### Using
 


### PR DESCRIPTION
Relative links allow to navigate the README file locally in an editor. Relative links play nicer with branches --- following a relative link in a branch will go to a file from this branch not the one from master.