### PR TITLE
add description and link for dt on macOS Intel

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ you can build the software yourself following the instructions [below](#building
 
 * [Download package for Windows](https://github.com/darktable-org/darktable/releases/download/release-5.4.1/darktable-5.4.1-win64.exe)
 * [Download disk image for macOS on Apple Silicon](https://github.com/darktable-org/darktable/releases/download/release-5.4.1/darktable-5.4.1-arm64.dmg)
-* [Download disk image for macOS on Apple Intel](https://github.com/darktable-org/darktable/releases/download/release-5.4.1/darktable-5.4.1-x86_64.dmg)
+* [Download disk image for macOS on Intel](https://github.com/darktable-org/darktable/releases/download/release-5.4.1/darktable-5.4.1-x86_64.dmg)
 * [Download AppImage for Linux](https://github.com/darktable-org/darktable/releases/download/release-5.4.1/Darktable-5.4.1-x86_64.AppImage)
 * [Install native packages or add a third-party repository for Linux distros](https://software.opensuse.org/download.html?project=graphics:darktable:stable&package=darktable)
 * [Install Flatpak package for Linux](https://flathub.org/apps/details/org.darktable.Darktable)


### PR DESCRIPTION
with 5.4.1 we support darktable on Intel Macs again.

I have added the descriptive text and the link (version number needs to be updated as with all other links).