### PR TITLE
Fix rated image undo of previously rejected image

### DIFF
--- a/src/common/ratings.c
+++ b/src/common/ratings.c
@@ -57,22 +57,19 @@ int dt_ratings_get(const dt_imgid_t imgid)
 
 static void _ratings_apply_to_image(const dt_imgid_t imgid, const int rating)
 {
-  int new_rating = rating;
   dt_image_t *image = dt_image_cache_get(imgid, 'w');
 
   if(image)
   {
     // apply or remove rejection
-    if(new_rating == DT_VIEW_REJECT) // handle undo
-      new_rating = DT_RATINGS_REJECT;
-    if(new_rating == DT_RATINGS_REJECT)
+     if(rating == DT_RATINGS_REJECT || rating == DT_VIEW_REJECT)
       image->flags = (image->flags | DT_IMAGE_REJECTED);
-    else if(new_rating == DT_RATINGS_UNREJECT)
+    else if(rating == DT_RATINGS_UNREJECT)
       image->flags = (image->flags & ~DT_IMAGE_REJECTED);
     else
     {
       image->flags = (image->flags & ~(DT_IMAGE_REJECTED | DT_VIEW_RATINGS_MASK))
-        | (DT_VIEW_RATINGS_MASK & new_rating);
+        | (DT_VIEW_RATINGS_MASK & rating);
     }
     // synch through:
     dt_image_cache_write_release_info(image, DT_IMAGE_CACHE_SAFE, "_ratings_apply_to_image");


### PR DESCRIPTION
Test for new rating of DT_VIEW_REJECT(6), which  is not valid and change it to DT_RATINGS_REJECT(-3) so that the correct rating flags are changed.  This problem only appears when taking a previously rejected image then applying a rating, then using CTRL-Z to undo.

Fixes #19749 