### PR TITLE
Enable shortcuts for more AgX buttons

### DIFF
--- a/src/iop/agx.c
+++ b/src/iop/agx.c
@@ -2346,7 +2346,7 @@ static void _create_primaries_page(dt_iop_module_t *main,
                               _("set parameters to completely reverse primaries modifications,\n"
                                   "but allow subsequent editing"));
   g_signal_connect(g->set_post_curve_primaries_from_pre_button, "clicked", G_CALLBACK(_set_post_curve_primaries_from_pre_callback), main);
-  dt_action_define_iop(main, NULL, N_("set post-mapping to reverse pre-mapping primaries"),
+  dt_action_define_iop(main, NULL, N_("reverse pre-mapping primaries"),
                        g->set_post_curve_primaries_from_pre_button, &dt_action_def_button);
   dt_gui_box_add(reversal_hbox, dt_gui_align_right(g->set_post_curve_primaries_from_pre_button));
 


### PR DESCRIPTION
I noticed two buttons in AgX which didn't allow me to assign shortcuts.

I have attempted to fix that in this PR, but note a couple of things I'm not confident about:

* _reset primaries_ should maybe have _dropdown_ as the shortcut type, but I used _button_ for the type as the widget is not from the bauhaus code
* I have no idea about some of the new strings (calling a shortcut "_set from above_" didn't seem sensible out of its context, but maybe I went too far with the longer text)

Let me know if you want an issue raised for this.