### PR TITLE
mipmap: better check for not writing error images to disk cache

### DIFF
--- a/src/common/mipmap_cache.c
+++ b/src/common/mipmap_cache.c
@@ -57,7 +57,8 @@
 // the number of pixels in the largest static image is the smallest number of pixels we
 // can allocate for the mipmap buffer, since that gets filled in after we attempt to read
 // from the image file on disk
-#define MIN_IMG_PIXELS  (29*29)
+#define ERR_IMG_MAX_DIM 29
+#define MIN_IMG_PIXELS  (ERR_IMG_MAX_DIM * ERR_IMG_MAX_DIM)
 
 typedef enum dt_mipmap_buffer_dsc_flags
 {
@@ -618,7 +619,7 @@ static void _mipmap_cache_deallocate_dynamic(void *data,
   {
     dt_mipmap_buffer_dsc_t *dsc = (dt_mipmap_buffer_dsc_t *)entry->data;
     // don't write skulls:
-    if(dsc->width * dsc->height > MIN_IMG_PIXELS)
+    if(dsc->width > ERR_IMG_MAX_DIM || dsc->height > ERR_IMG_MAX_DIM)
     {
       if(dsc->flags & DT_MIPMAP_BUFFER_DSC_FLAG_INVALIDATE)
       {


### PR DESCRIPTION
In order not to store error images in the disk cache, current code skips mipmaps with an area <= the maximum error images dimensions (29x29=841 pixels). But a very elongated image would trigger a false positive. For example, a mip0 (max size is 180x110) of an image with a 1:15 aspect ratio could be 7x110 mip0 (770 pixels) and never be cached.

This is very much an edge case. But you can verify this by:

1. In a fresh darktable install, import an image
2. In darkroom, crop the image to 1:15 ratio vertically
3. In lighttable, set to 25 thumbnails/row (smallest thumbnail size) on a lodpi display, to ensure showing mip0 thumbnail
4. Quit darktable
5. Move the imported image from its current path on the filesystem
6. Start darktable again

Before this PR, the image thumbnail will display as a skull. With this PR, the cached image thumbnail will appear.

Improves: #20227