### PR TITLE
Increase css decoration margin for better access

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -341,7 +341,7 @@ undershoot,
 /* Allow to resize all windows */
 decoration
 {
-  margin: 1px; /* need to remains as px as just minimum size needed, no need to be scalable */
+  margin: 5px; /* need to remains as px as just minimum size needed, no need to be scalable */
 }
 
 /* Default Gtk buttons and other entries */


### PR DESCRIPTION
On wayland gnome it's very difficult to grap a border/corner to resize the window. Make this a bit easier ...

First time i ever touched any dt css part as far as i can remember. Would this be the correct way?
With current master it's pretty annoying to grab a window border ...