### PR TITLE
Fixes toneequalizer nuisances

### DIFF
--- a/src/iop/colorequal.c
+++ b/src/iop/colorequal.c
@@ -1713,7 +1713,7 @@ static inline void _periodic_RBF_interpolate(float nodes[NODES],
     }
 
   // Solve A * x = y for lambdas
-  pseudo_solve((float *)A, nodes, NODES, NODES, FALSE);
+  pseudo_solve((float *)A, nodes, NODES, NODES, TRUE);
 
   // Interpolate data for all x : generate the LUT
   // WARNING: the LUT spans from [-pi; pi[ for consistency with the output of atan2f()


### PR DESCRIPTION
- the choleski solver should always run in validation mode making sure the resulting data are safe or not. The performance difference - as suggestested by naming - is neglectable
- in toneequalizer we now have always tested results - if gui data are provided or not - so old edits are tested and can show if the solver produced valid results
- when updating the graphs in advanced tab we visualize bad solver results by coloring as we do in agx, filmic ...


After "never ending discussions" this would be my simple proposal for now :-)

@TurboGit no strings involved 

and to the obvious @wpferguson @paperdigits @elstoc @jade-nl @SoupyGit @da-phil

Related to #20230