### PR TITLE
allow Xmp.dwc tags in metadata editor

### DIFF
--- a/src/gui/metadata_tags.c
+++ b/src/gui/metadata_tags.c
@@ -133,6 +133,7 @@ GtkWidget *dt_metadata_tags_dialog(GtkWidget *parent,
       "Xmp.dc.",
       "Xmp.acdsee.",
       "Xmp.iptc.",
+      "Xmp.dwc.",
       "Iptc."
     };
 


### PR DESCRIPTION
Xmp.dwc.* are clearly user editable fields, so we add it to the list of allowed tags for the metadata editor.

fixes #20264

@TurboGit : This is a minimal change, should be good for 5.4.1 if its not too late.
No additional release notes entry required.

