### PR TITLE
Support RAW+JPEG imports using JPEG for mipmap cache

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -274,6 +274,13 @@
     <longdescription>if enabled, cached thumbnails will be color managed so that lighttable and filmstrip can show correct colors. otherwise the results may look wrong once the display profile gets changed.</longdescription>
   </dtconfig>
   <dtconfig>
+    <name>cache/import_raw_jpeg_optimization</name>
+    <type>bool</type>
+    <default>true</default>
+    <shortdescription>optimize RAW+JPEG import using JPEG for thumbnails</shortdescription>
+    <longdescription>when enabled and both RAW and JPEG files are imported together, the JPEG file will be used to quickly populate the mipmap cache instead of expensive RAW demosaicing. this significantly speeds up thumbnail generation. the feature is only active when companion JPEG files are found during RAW import.</longdescription>
+  </dtconfig>
+  <dtconfig>
     <name>opencl_device_priority</name>
     <type>string</type>
     <default>*/!0,*/*/*/!0,*</default>

--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -569,7 +569,8 @@ int main(int argc, char *arg[])
           if(!g_file_test(fullname, G_FILE_TEST_IS_DIR) && dt_supported_image(fname))
           {
             // Import each supported image file directly
-            const dt_imgid_t imgid = dt_image_import(filmid, fullname, TRUE, TRUE);
+            const dt_imgid_t imgid =
+                dt_image_import(filmid, fullname, NULL, TRUE, TRUE);
             if(dt_is_valid_imgid(imgid))
             {
               id_list = g_list_append(id_list, GINT_TO_POINTER(imgid));
@@ -598,7 +599,7 @@ int main(int argc, char *arg[])
 
       gchar *directory = g_path_get_dirname(input);
       filmid = dt_film_new(&film, directory);
-      const dt_imgid_t id = dt_image_import(filmid, input, TRUE, TRUE);
+      const dt_imgid_t id = dt_image_import(filmid, input, NULL, TRUE, TRUE);
       g_free(directory);
       if(!dt_is_valid_imgid(id))
       {

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -447,7 +447,7 @@ dt_imgid_t dt_load_from_string(const gchar *input,
     gchar *directory = g_path_get_dirname((const gchar *)filename);
     dt_film_t film;
     const dt_filmid_t filmid = dt_film_new(&film, directory);
-    imgid = dt_image_import(filmid, filename, TRUE, TRUE);
+    imgid = dt_image_import(filmid, filename, NULL, TRUE, TRUE);
     g_free(directory);
     if(dt_is_valid_imgid(imgid))
     {

--- a/src/common/image.h
+++ b/src/common/image.h
@@ -444,14 +444,14 @@ dt_imgid_t dt_image_get_id_full_path(const gchar *filename);
 dt_imgid_t dt_image_get_id(const dt_filmid_t film_id,
                            const gchar *filename);
 /** imports a new image from raw/etc file and adds it to the data base and image cache. Use from threads other than lua.*/
-dt_imgid_t dt_image_import(dt_filmid_t film_id,
-                           const char *filename,
+dt_imgid_t dt_image_import(dt_filmid_t film_id, const char *filename,
+                           const char *preview_jpeg_filepath,
                            const gboolean override_ignore_nonraws,
                            const gboolean raise_signals);
 /** imports a new image from raw/etc file and adds it to the data base
  * and image cache. Use from lua thread.*/
-dt_imgid_t dt_image_import_lua(const dt_filmid_t film_id,
-                               const char *filename,
+dt_imgid_t dt_image_import_lua(const dt_filmid_t film_id, const char *filename,
+                               const char *preview_jpeg_filepath,
                                const gboolean override_ignore_nonraws);
 /** removes the given image from the database. */
 void dt_image_remove(const dt_imgid_t imgid);

--- a/src/common/import_session.c
+++ b/src/common/import_session.c
@@ -187,7 +187,8 @@ void dt_import_session_unref(dt_import_session_t *self)
 
 void dt_import_session_import(dt_import_session_t *self)
 {
-  const dt_imgid_t imgid = dt_image_import(self->film->id, self->current_filename, TRUE, TRUE);
+  const dt_imgid_t imgid =
+      dt_image_import(self->film->id, self->current_filename, NULL, TRUE, TRUE);
   if(dt_is_valid_imgid(imgid))
   {
     DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_VIEWMANAGER_THUMBTABLE_ACTIVATE, imgid);

--- a/src/common/mipmap_cache.h
+++ b/src/common/mipmap_cache.h
@@ -156,6 +156,13 @@ void dt_mipmap_cache_copy_thumbnails(const dt_imgid_t dst_imgid, const dt_imgid_
 // return the mipmap corresponding to text value saved in prefs
 dt_mipmap_size_t dt_mipmap_cache_get_min_mip_from_pref(const char *value);
 
+// optimize RAW+JPEG import by extracting embedded JPEG and using it as base for
+// mipmap cache. extracts JPEG from RAW file, writes to mipmap level 8, then
+// downscales to create all mipmap tiers. returns TRUE if optimization was
+// applied, FALSE if JPEG extraction failed or feature disabled.
+gboolean dt_mipmap_cache_import_jpeg_to_mips(const dt_imgid_t imgid,
+                                             const char *filename);
+
 G_END_DECLS
 
 // clang-format off

--- a/src/control/jobs/film_jobs.c
+++ b/src/control/jobs/film_jobs.c
@@ -333,7 +333,8 @@ static void _film_import1(dt_job_t *job, dt_film_t *film, GList *images)
     g_free(cdn);
 
     /* import image */
-    const dt_imgid_t imgid = dt_image_import(cfr->id, (const gchar *)image->data, FALSE, FALSE);
+    const dt_imgid_t imgid = dt_image_import(
+        cfr->id, (const gchar *)image->data, NULL, FALSE, FALSE);
     pending++;  // we have another image which hasn't been reported yet
     fraction += 1.0 / total;
     dt_control_job_set_progress(job, fraction);

--- a/src/control/jobs/image_jobs.c
+++ b/src/control/jobs/image_jobs.c
@@ -74,7 +74,8 @@ static int32_t _image_import_job_run(dt_job_t *job)
 
   dt_control_job_set_progress_message(job, _("importing image %s"), params->filename);
 
-  const dt_imgid_t id = dt_image_import(params->film_id, params->filename, TRUE, TRUE);
+  const dt_imgid_t id =
+      dt_image_import(params->film_id, params->filename, NULL, TRUE, TRUE);
   if(dt_is_valid_imgid(id))
   {
     DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_VIEWMANAGER_THUMBTABLE_ACTIVATE, id);

--- a/src/imageio/imageio_common.h
+++ b/src/imageio/imageio_common.h
@@ -58,6 +58,12 @@ typedef enum dt_imageio_levels_t
 
 // Check that the image is raw by file extension
 gboolean dt_imageio_is_raw_by_extension(const char *extension);
+// Check that the image is raw preview by file extension
+gboolean dt_imageio_is_raw_preview_by_extension(const char *extension);
+// Find a companion JPEG (same basename, .jpg/.jpeg) in the same directory as
+// `filepath`. Returns a newly-allocated string with the full path, or NULL if
+// not found.
+char *dt_imageio_find_companion_jpeg(const char *filepath);
 // Checks that the image is indeed an ldr image
 gboolean dt_imageio_is_ldr(const char *filename);
 // checks that the image has a monochrome preview attached

--- a/src/lua/database.c
+++ b/src/lua/database.c
@@ -168,7 +168,7 @@ static int import_images(lua_State *L)
       return luaL_error(L, "error while importing");
     }
 
-    result = dt_image_import_lua(new_film.id, full_name, TRUE);
+    result = dt_image_import_lua(new_film.id, full_name, NULL, TRUE);
     if(dt_film_is_empty(new_film.id)) dt_film_remove(new_film.id);
     dt_film_cleanup(&new_film);
     if(!dt_is_valid_filmid(result))


### PR DESCRIPTION
This resolves issue #19470. When a user import a RAW+JPEG pair with the same file name, the JPEG will be used to build the mipmap cache for the RAW file