### PR TITLE
Collection module: Separate expanding/collapsing from selecting

### DIFF
--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -48,6 +48,7 @@ DT_MODULE(3)
 #define MAX_RULES 10
 
 #define PARAM_STRING_SIZE 256 // FIXME: is this enough !?
+#define DEFAULT_EXPANDER_SIZE 20
 
 typedef struct _datetime_range_t
 {
@@ -608,49 +609,19 @@ static gboolean view_onButtonPressed(GtkWidget *treeview,
   /* Get tree path for row that was clicked */
   GtkTreePath *path = NULL;
   gint cell_x;
-/*   gint bin_x, bin_y;
-  GtkTreeViewColumn *clickedCol = NULL;
-  GList *columns = gtk_tree_view_get_columns(GTK_TREE_VIEW(treeview));
-  gtk_tree_view_convert_widget_to_bin_window_coords(GTK_TREE_VIEW(treeview), event->x, event->y, &bin_x, &bin_y);  */ 
- 
   const gboolean get_path = gtk_tree_view_get_path_at_pos(GTK_TREE_VIEW(treeview),
-                                                         (gint)event->x, (gint)event->y,
-//                                                          bin_x, bin_y,
-                                                          &path, NULL, &cell_x, NULL);
-/*   gint col_index = g_list_index(columns, (gpointer)clickedCol);
-  g_print("clicked column: %d\n", col_index);               
-  g_list_free(columns); //required */                                        
-/*   GtkTreeViewColumn *expander = gtk_tree_view_get_expander_column(GTK_TREE_VIEW(treeview));
-  const gint expander_width = gtk_tree_view_column_get_width(expander);
-  g_print("expander column width: %d\n", expander_width); */
-  g_print("cell_x of click: %d\n", cell_x);
-  g_print("event->x: %d\n", (gint)event->x);
-/*   g_print("bin_x: %d\n\n", bin_x); */
-
-  gint depth = gtk_tree_path_get_depth(path);
-  g_print("Depth=%d, cell_x=%d\n\n", depth, cell_x);
-  gint base_indent = gtk_tree_view_get_level_indentation(GTK_TREE_VIEW(treeview));  // Extra pixels/level
-  gint total_indent = depth * (16 + base_indent); 
-  g_print("indent is: %d\n", total_indent);
-  GtkStyleContext *context = gtk_widget_get_style_context(GTK_WIDGET(treeview));
-  GValue value = G_VALUE_INIT;
-  gtk_style_context_get_property(context, "-GtkTreeView-expander-size", GTK_STATE_FLAG_NORMAL, &value);
-  gint expander_size = g_value_get_int(&value);  // e.g., 16
-  g_value_unset(&value);
-  g_print("expander size: %d\n", expander_size);
-
-  // exit if only clicked on expander
-  if(cell_x <= total_indent) return FALSE; 
+                                                          (gint)event->x, (gint)event->y,
+                                                          &path, NULL, NULL, NULL);
 
   if(event->type == GDK_DOUBLE_BUTTON_PRESS || d->singleclick)
   {
-    if(event->state == last_state && path)
+/*     if(event->state == last_state && path)
     {
       if(gtk_tree_view_row_expanded(GTK_TREE_VIEW(treeview), path))
         gtk_tree_view_collapse_row(GTK_TREE_VIEW(treeview), path);
       else
         gtk_tree_view_expand_row(GTK_TREE_VIEW(treeview), path, FALSE);
-    }
+    } */
     last_state = event->state;
   }
 

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -607,9 +607,40 @@ static gboolean view_onButtonPressed(GtkWidget *treeview,
 {
   /* Get tree path for row that was clicked */
   GtkTreePath *path = NULL;
+  gint cell_x;
+/*   gint bin_x, bin_y;
+  GtkTreeViewColumn *clickedCol = NULL;
+  GList *columns = gtk_tree_view_get_columns(GTK_TREE_VIEW(treeview));
+  gtk_tree_view_convert_widget_to_bin_window_coords(GTK_TREE_VIEW(treeview), event->x, event->y, &bin_x, &bin_y);  */ 
+ 
   const gboolean get_path = gtk_tree_view_get_path_at_pos(GTK_TREE_VIEW(treeview),
-                                                          (gint)event->x, (gint)event->y,
-                                                          &path, NULL, NULL, NULL);
+                                                         (gint)event->x, (gint)event->y,
+//                                                          bin_x, bin_y,
+                                                          &path, NULL, &cell_x, NULL);
+/*   gint col_index = g_list_index(columns, (gpointer)clickedCol);
+  g_print("clicked column: %d\n", col_index);               
+  g_list_free(columns); //required */                                        
+/*   GtkTreeViewColumn *expander = gtk_tree_view_get_expander_column(GTK_TREE_VIEW(treeview));
+  const gint expander_width = gtk_tree_view_column_get_width(expander);
+  g_print("expander column width: %d\n", expander_width); */
+  g_print("cell_x of click: %d\n", cell_x);
+  g_print("event->x: %d\n", (gint)event->x);
+/*   g_print("bin_x: %d\n\n", bin_x); */
+
+  gint depth = gtk_tree_path_get_depth(path);
+  g_print("Depth=%d, cell_x=%d\n\n", depth, cell_x);
+  gint base_indent = gtk_tree_view_get_level_indentation(GTK_TREE_VIEW(treeview));  // Extra pixels/level
+  gint total_indent = depth * (16 + base_indent); 
+  g_print("indent is: %d\n", total_indent);
+  GtkStyleContext *context = gtk_widget_get_style_context(GTK_WIDGET(treeview));
+  GValue value = G_VALUE_INIT;
+  gtk_style_context_get_property(context, "-GtkTreeView-expander-size", GTK_STATE_FLAG_NORMAL, &value);
+  gint expander_size = g_value_get_int(&value);  // e.g., 16
+  g_value_unset(&value);
+  g_print("expander size: %d\n", expander_size);
+
+  // exit if only clicked on expander
+  if(cell_x <= total_indent) return FALSE; 
 
   if(event->type == GDK_DOUBLE_BUTTON_PRESS || d->singleclick)
   {
@@ -3704,6 +3735,10 @@ void gui_init(dt_lib_module_t *self)
                    G_CALLBACK(view_onButtonPressed), d);
   g_signal_connect(G_OBJECT(view), "popup-menu", G_CALLBACK(view_onPopupMenu), d);
 
+/*   GtkTreeViewColumn *exp = gtk_tree_view_column_new();
+  // gtk_tree_view_column_set_fixed_width(exp, 30);
+  gtk_tree_view_column_set_sizing(exp, GTK_TREE_VIEW_COLUMN_AUTOSIZE); 
+  gtk_tree_view_append_column(view, exp); */
   GtkTreeViewColumn *col = gtk_tree_view_column_new();
   gtk_tree_view_append_column(view, col);
   GtkCellRenderer *renderer = gtk_cell_renderer_text_new();

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -48,7 +48,7 @@ DT_MODULE(3)
 #define MAX_RULES 10
 
 #define PARAM_STRING_SIZE 256 // FIXME: is this enough !?
-#define DEFAULT_EXPANDER_SIZE 20
+#define DEFAULT_EXPANDER_SIZE 20 //FIXME: estimated value. How to get the actual?
 
 typedef struct _datetime_range_t
 {
@@ -610,20 +610,18 @@ static gboolean view_onButtonPressed(GtkWidget *treeview,
   GtkTreePath *path = NULL;
   gint cell_x;
   const gboolean get_path = gtk_tree_view_get_path_at_pos(GTK_TREE_VIEW(treeview),
-                                                          (gint)event->x, (gint)event->y,
-                                                          &path, NULL, NULL, NULL);
+                                                         (gint)event->x, (gint)event->y,
+                                                          &path, NULL, &cell_x, NULL);
 
-  if(event->type == GDK_DOUBLE_BUTTON_PRESS || d->singleclick)
-  {
-/*     if(event->state == last_state && path)
-    {
-      if(gtk_tree_view_row_expanded(GTK_TREE_VIEW(treeview), path))
-        gtk_tree_view_collapse_row(GTK_TREE_VIEW(treeview), path);
-      else
-        gtk_tree_view_expand_row(GTK_TREE_VIEW(treeview), path, FALSE);
-    } */
-    last_state = event->state;
-  }
+  // calculate the approximate indentation in pixels for the lower hierarchy levels.
+  // Then we can estimate, if the expander was clicked or the text in the row.
+  gint depth = gtk_tree_path_get_depth(path);
+  gint base_indent = gtk_tree_view_get_level_indentation(GTK_TREE_VIEW(treeview));
+  gint total_indent = depth * (DEFAULT_EXPANDER_SIZE + base_indent); 
+  // exit if only clicked on expander
+  if(cell_x <= total_indent) return FALSE; 
+
+  last_state = event->state;
 
   // case of a range selection
   GtkTreeSelection *selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(treeview));


### PR DESCRIPTION
This is a proposal for issue #19452.
In the collection module, clicking on a row both selects all images in the clicked hierarchy branch and expands/collapses the hierarchy tree. As a consequence, when navigating to a row deep down in the hierarchy, all images in the hierarchy above are unnecessarily loaded to the light table, especially when the setting "use single click in the collections module" is active. The expected behavior is that expanding and selecting are separated: Clicking the expander triangle only expands/collapses the level, and clicking on the row text only selects the images.

The idea in this fix is to determine from the click position, if the click was on the expander or anywhere else in the row. 
Due to the indentation of lower hierarchy levels, the expander area in a row is not fixed. Thus, the indentation is calculated from the hierarchy depth and the basic indentation.

The behavior changes as follows:
- Expanding/collapsing only happens when clicking on the expander triangle
- Images are only selected for display when clicking on the row text.
- clicking left of the expander does no longer select or expand/collapse.

For the calculation of the indentation I assume a hard-coded expander width in pixels. I do not know if this value could be determined at runtime, as it may be changed by css customization.

closes #19452  
