### PR TITLE
Capture sharpen radius calculations improvements

### DIFF
--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -735,7 +735,7 @@ void process(dt_iop_module_t *self,
     if(_noise_requested(self, piece))
       _capture_noise(self, piece);
     if(_radius_requested(self, piece))
-      _capture_radius(self, piece, in, width, height, xtrans, filters);
+      _capture_radius(self, piece, in, roi_in, xtrans, filters);
   }
 
   int overlap = 0;
@@ -1028,7 +1028,7 @@ int process_cl(dt_iop_module_t *self,
     if(_noise_requested(self, piece))
       _capture_noise(self, piece);
     if(_radius_requested(self, piece))
-      _capture_radius_cl(self, piece, dev_in, iwidth, iheight, xtrans, filters, true_monochrome);
+      _capture_radius_cl(self, piece, dev_in, roi_in, xtrans, filters, true_monochrome);
   }
 
   gboolean tiling = FALSE;


### PR DESCRIPTION
1. The calculation of the capture radius should be done using data from the image center. We check for the provided roi and restrict the possible area leaving out 20% at each border. Report the used area in the logs.
2. Increased the radius difference assumed to be equal.
3. Lots of testing proved that for xtrans sensors the radius of default sharpening can/should be slightly increased, tests show that 0.2 is safe for all xtrans demosaicers.
4. Simplified monochrome radius calculation.
5. More minor log corrections