### PR TITLE
fix: scroll to correct module when navigating from Quick Access Panel

### DIFF
--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -405,8 +405,13 @@ static gboolean _basics_goto_module(GtkWidget *w, GdkEventButton *e, gpointer us
 {
   dt_iop_module_t *module = (dt_iop_module_t *)(user_data);
   dt_dev_modulegroups_switch(darktable.develop, module);
-  dt_iop_gui_set_expanded(module, TRUE, TRUE);
-  dt_iop_gui_set_expanded(module, TRUE, FALSE);
+  const gboolean single = dt_conf_get_bool("darkroom/ui/single_module");
+  dt_iop_gui_set_expanded(module, TRUE, single);
+  // when single_module is on, the first call with collapse_others=TRUE
+  // may toggle the module closed if all others were already closed;
+  // this second call ensures the module ends up expanded.
+  if(single)
+    dt_iop_gui_set_expanded(module, TRUE, FALSE);
   return TRUE;
 }
 
@@ -1023,7 +1028,7 @@ static gboolean _lib_modulegroups_set_gui_thread(gpointer user_data)
   _lib_modulegroups_update_iop_visibility(params->self);
 
   free(params);
-  return FALSE;
+  return G_SOURCE_REMOVE;
 }
 
 static gboolean _lib_modulegroups_upd_gui_thread(gpointer user_data)
@@ -1033,7 +1038,7 @@ static gboolean _lib_modulegroups_upd_gui_thread(gpointer user_data)
   _lib_modulegroups_update_iop_visibility(params->self);
 
   free(params);
-  return FALSE;
+  return G_SOURCE_REMOVE;
 }
 
 /* this is a proxy function so it might be called from another thread */


### PR DESCRIPTION
When clicking 'go to full version' in the Quick Access Panel, the view would sometimes scroll to a wrong module (though the correct tab was always selected). This happened because dtgtk_expander_set_expanded() was a no-op when the target module was already expanded, leaving stale _last_expanded and _start_pos values from a previous expansion. The _expander_resize callback would then either skip scrolling or scroll to the wrong widget.

Add an 'else if(expanded)' branch that updates scroll tracking even when the expander state hasn't changed. Setting _start_pos.height to 0 ensures _expander_resize detects a size change and triggers scrolling.

Fixes: https://github.com/darktable-org/darktable/issues/19692