### PR TITLE
Fix the check for skipping mouse events on the darkroom.

### DIFF
--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -1126,7 +1126,8 @@ gboolean dt_masks_events_mouse_moved(dt_iop_module_t *module,
     2. the mask manager and it is not expanded
 */
   const gboolean skipped = (module && !module->enabled)
-                        || (!module && !dt_lib_gui_get_expanded(dt_lib_get_module("masks")));
+                        && !dt_lib_gui_get_expanded(dt_lib_get_module("masks"));
+
   dt_print(DT_DEBUG_VERBOSE,
     "[dt_masks_events_mouse_moved] %s %s",
     module ? module->so->op : "mask manager",


### PR DESCRIPTION
This fix the issue when creating a circle or ellipse from the mask manager the initial form did not follow the mouse moves. The form just stayed on the center of the Darkroom.

To reproduce at least one processing module must be expanded.

The check for skipping events is now:
- We have a module and it is not enabled
- And we don't have the mask manager expanded.

Closes #20289