### PR TITLE
Better visibility of bauhaus sliders.

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -140,11 +140,11 @@ Why that? Just because it's a developer choice and most classes use underscore i
 @define-color collapsible_bg_color @grey_25;
 
 /* Modules controls (sliders and comboboxes) */
-@define-color bauhaus_bg alpha(@bg_color, 0.55);
+@define-color bauhaus_bg shade(@plugin_bg_color,0.75);
+@define-color bauhaus_fill shade(@plugin_label_color,0.95);
 @define-color bauhaus_fg @fg_color;       /* needed to correctly display color pickers in all states, even if they inherit @fg_color by default */
 @define-color bauhaus_border shade(@plugin_bg_color, 0.5);
 @define-color bauhaus_indicator_border @grey_20;
-@define-color bauhaus_fill @grey_40;
 @define-color bauhaus_bg_hover @grey_60;
 @define-color bauhaus_fg_hover @grey_90;
 @define-color bauhaus_fg_selected @grey_80;
@@ -881,7 +881,7 @@ menuitem > arrow
 /* then spacing around bauhaus widgets */
 .dt_bauhaus
 {
-  margin: 0.14em 0;
+  margin: 0.2em 0;
 }
 
 /* and set menuitem related to sort of combobox like metadata presets in import module */

--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -845,9 +845,9 @@ void dt_bauhaus_load_theme()
   bh->quad_width = bh->line_height;
 
   // absolute size in Cairo unit:
-  bh->baseline_size = bh->line_height / 2.5f;
+  bh->baseline_size = bh->line_height / 3.0f;
   bh->border_width = 2.0f; // absolute size in Cairo unit
-  bh->marker_size = (bh->baseline_size + bh->border_width) * 0.9f;
+  bh->marker_size = (bh->baseline_size + bh->border_width) * 0.95f;
 
   const char *shape = dt_conf_get_string_const("bauhaus/marker_shape");
   bh->marker_shape = !g_strcmp0(shape, "circle") ? DT_BAUHAUS_MARKER_CIRCLE


### PR DESCRIPTION
Taken from a discussion on Pixlus.

Before:

<img width="411" height="677" alt="image" src="https://github.com/user-attachments/assets/22cea490-180e-4cae-bebf-81ee57f4c21e" />

After:

<img width="411" height="677" alt="image" src="https://github.com/user-attachments/assets/e5049abf-bf31-4965-88e5-c85863a50bee" />

Theme Dark:

<img width="411" height="677" alt="image" src="https://github.com/user-attachments/assets/5d86bee3-f3d8-4360-ba73-7f6857913f7c" />

Theme Darker:

<img width="411" height="677" alt="image" src="https://github.com/user-attachments/assets/a2d6bf6f-97ca-42d5-8492-2cf44d14c313" />
