### PR TITLE
Fix FTBFS with GCC 16 due to 'variable set but not used'

### DIFF
--- a/src/iop/demosaicing/lmmse.c
+++ b/src/iop/demosaicing/lmmse.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2021-2024 darktable developers.
+    Copyright (C) 2021-2026 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -188,9 +188,9 @@ static void lmmse_demosaic(float *const restrict out,
         {
           float *cfa = qix[5] + rrr * DT_LMMSE_TILESIZE + BORDER_AROUND;
           int idx = row * width + colStart;
-          for(int ccc = BORDER_AROUND, col = colStart;
+          for(int ccc = BORDER_AROUND;
               ccc < tileCols + BORDER_AROUND;
-              ccc++, col++, cfa++, idx++)
+              ccc++, cfa++, idx++)
           {
             cfa[0] = _calc_gamma(revscaler * in[idx], lmmse_gamma_in);
           }


### PR DESCRIPTION
Compilation with GCC 16 fails because of:
```
/__w/darktable/darktable/src/src/iop/demosaicing/lmmse.c: In function 'lmmse_demosaic':
/__w/darktable/darktable/src/src/iop/demosaicing/lmmse.c:191:40: error: variable 'col' set but not used [-Werror=unused-but-set-variable=]
  191 |           for(int ccc = BORDER_AROUND, col = colStart;
      |                                        ^~~
compilation terminated due to -Wfatal-errors.
cc1: all warnings being treated as errors
```
The fix removes this variable as declared and set without a real need.

@jenshannoschwalm tagging you JFYI, since the fix is in the demosaicing code, so your domain.