### PR TITLE
Update RELEASE_NOTES.md for Neo drivers removal from Windows blacklist. 

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -73,6 +73,8 @@ changes (where available).
 
 - Added PNG support (8/16-bit) for external raster masks.
 
+- Removed `Neo` Intel GPU from the Windows blacklist.
+
 ## Bug Fixes
 
 - Properly apply the iop-order when applying a style at export


### PR DESCRIPTION
Added a release note for the removal of the Neo drivers from the windows blacklist.

Cross reference: https://github.com/darktable-org/darktable/pull/20298