### PR TITLE
[CI macOS]: bump xcode version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -311,7 +311,7 @@ jobs:
       fail-fast: true
       matrix:
         build:
-          - { os: macos-15,    xcode: 16.3,   deployment: 15.0 } # AppleClang 17, arm64
+          - { os: macos-15,    xcode: 26.2,   deployment: 15.0 } # AppleClang 17, arm64
         compiler:
           - { compiler: XCode,   CC: cc, CXX: c++ }
         btype: [ Release ]


### PR DESCRIPTION
Bump Xcode to 26.2 for CI
