### PR TITLE
Let's blacklist AMD-APP OpenCL driver

### DIFF
--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -211,8 +211,6 @@ const char *cl_errstr(cl_int error)
       return "DT_OPENCL_PROCESS_CL";
     case DT_OPENCL_NODEVICE:
       return "DT_OPENCL_NODEVICE";
-    case DT_OPENCL_DT_EXCEPTION:
-      return "DT_OPENCL_DT_EXCEPTION";
     default:
       return "Unknown OpenCL error";
   }
@@ -357,7 +355,7 @@ void dt_opencl_write_device_config(const int devid)
            "\n[dt_opencl_write_device_config] writing data '%s' for '%s'\n", dat, key);
   dt_conf_set_string(key, dat);
   setlocale(LC_NUMERIC, locale);
-  
+
   // Also take care of extended device data, these are not only device
   // specific but also depend on the devid to support systems with two
   // similar cards.
@@ -877,7 +875,7 @@ static gboolean _opencl_device_init(dt_opencl_t *cl,
                "   MAX WORK GROUP SIZE:      %zu (%zu)\n",
                cl->dev[dev].workgroup_size, cl->dev[dev].workgroup_size_rec);
 
-  cl_uint max_item_dimension = 0;  
+  cl_uint max_item_dimension = 0;
   (cl->dlocl->symbols->dt_clGetDeviceInfo)(devid, CL_DEVICE_MAX_WORK_ITEM_DIMENSIONS,
                                            sizeof(max_item_dimension), &max_item_dimension, NULL);
   dt_print_nts(DT_DEBUG_OPENCL,
@@ -1027,8 +1025,6 @@ static gboolean _opencl_device_init(dt_opencl_t *cl,
 
   dt_print_nts(DT_DEBUG_OPENCL, "   CL COMPILER OPTION:       %s\n", my_option);
   dt_print_nts(DT_DEBUG_OPENCL, "   CL COMPILER COMMAND:      %s\n", cl->dev[dev].options);
-
-  _write_test_exceptions(&cl->dev[dev]);
 
   g_free(compile_option_name_cname);
   g_free(my_option);
@@ -3637,12 +3633,6 @@ gboolean dt_opencl_is_enabled(void)
 gboolean dt_opencl_running(void)
 {
   return _cl_running();
-}
-
-gboolean dt_opencl_exception(const int devid, const uint32_t mask)
-{
-  if(!_cldev_running(devid)) return FALSE;
-  return (darktable.opencl->dev[devid].exceptions & mask) != 0;
 }
 
 /** update enabled flag and profile with value from preferences */

--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -37,12 +37,6 @@
 #define DT_OPENCL_SYSMEM_ALLOCATION -998
 #define DT_OPENCL_PROCESS_CL -997
 #define DT_OPENCL_NODEVICE -996
-#define DT_OPENCL_DT_EXCEPTION -995
-
-/* exceptions */
-#define DT_OPENCL_AMD_APP 1
-#define DT_OPENCL_ONLY_CUDA 2
-
 
 #include "common/darktable.h"
 
@@ -213,9 +207,6 @@ typedef struct dt_opencl_device_t
 
   // lets keep the vendor for runtime checks
   int vendor_id;
-
-  // exceptions bit mask
-  uint32_t exceptions;
 
   float advantage;
 } dt_opencl_device_t;
@@ -583,9 +574,6 @@ void dt_opencl_check_tuning(const int devid);
 
 /** get size of allocatable single buffer */
 cl_ulong dt_opencl_get_device_memalloc(const int devid);
-
-/** checks for a detected OpenCL runtime exception */
-gboolean dt_opencl_exception(const int devid, const uint32_t mask);
 
 /** round size to a multiple of the value given in the device specifig
  * config parameter for opencl_size_roundup */

--- a/src/common/opencl_drivers_blacklist.h
+++ b/src/common/opencl_drivers_blacklist.h
@@ -29,6 +29,7 @@ static const gchar *bad_opencl_drivers[] =
   "beignet",
   "pocl",
   "clover",
+  "amd-app",
 /*
   Neo was originally blacklisted due to improper cache invalidation, but this has been fixed.
   Per Issue 20104, enabling neo for Windows.
@@ -58,34 +59,6 @@ static gboolean _opencl_check_driver_blacklist(const char *device_version)
   // did not find in the black list, guess it's ok.
   g_free(device);
   return FALSE;
-}
-
-/*
-   darktable OpenCL runtime exceptions
-   1. We test for a number of problematic or advantage situations and leave a flag about that
-      in the dt_opencl_device_t struct
-   2. gboolean dt_opencl_exception(const int devid, const uint32_t mask)
-      allows to check for such conditions while processing the pixelpipe and
-      possibly using different code or fallbacks
-   3. An example can be found in demosaic testing for DT_OPENCL_AMD_APP while using the
-      DT_IOP_DEMOSAIC_PPG demosaicer, as that OpenCL code fails for unknown reasons we do
-      a fallback to DT_IOP_DEMOSAIC_RCD (which is better anyway).
-   4. We could also fallback to CPU code path in such exceptions, in that case we should return
-      with DT_OPENCL_DT_EXCEPTION as the error code, that would be reported in the -d opencl log
-*/
-
-static void _write_test_exceptions(dt_opencl_device_t *device)
-{
-  if(!strncasecmp(device->device_version, "OpenCL 2.0 AMD-APP", 18))
-  {
-    device->exceptions |= DT_OPENCL_AMD_APP;
-    dt_print_nts(DT_DEBUG_OPENCL, "   CL EXCEPTION:             DT_OPENCL_AMD_APP\n");
-  }
-  if(!strncasecmp(device->platform, "NVIDIA CUDA", 11))
-  {
-    device->exceptions |= DT_OPENCL_ONLY_CUDA;
-    dt_print_nts(DT_DEBUG_OPENCL, "   CL EXCEPTION:             DT_OPENCL_ONLY_CUDA\n");
-  }
 }
 
 // clang-format off

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -941,12 +941,6 @@ int process_cl(dt_iop_module_t *self,
   const int demosaicing_method = d->demosaicing_method;
   int method = demosaicing_method & ~DT_DEMOSAIC_DUAL;
 
-  // We do a PPG to RCD demosaicer fallback here as the used driver is known to fail.
-  // Also could "return DT_OPENCL_DT_EXCEPTION" for a cpu fallback
-  if(method == DT_IOP_DEMOSAIC_PPG
-     && dt_opencl_exception(pipe->devid, DT_OPENCL_AMD_APP))
-    method = DT_IOP_DEMOSAIC_RCD;
-
   const int iwidth = roi_in->width;
   const int iheight = roi_in->height;
 


### PR DESCRIPTION
1. It's not supported any more by AMD by any means
2. latest version is 10yrs old
3. if someone really wants/needs this, override the blacklist but not generally supported any more.
4. removed that extra feature-stuff as we don't need it for cuda as we now handle this otherwise and AMD-APP should either work or not.

Release note: blacklisted unsupported AMD-APP OpenCL driver