### PR TITLE
scopes: remove shortcut to cycle through modes/options

### DIFF
--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -2236,13 +2236,6 @@ static void _lib_histogram_collapse_callback(dt_action_t *action)
   dt_lib_set_visible(self, !visible);
 }
 
-static void _lib_histogram_change_type_callback(dt_action_t *action)
-{
-  const dt_lib_module_t *self = darktable.lib->proxy.histogram.module;
-  dt_lib_histogram_t *d = self->data;
-  _scope_view_clicked(d->scope_view_button, d);
-}
-
 static void _lib_histogram_cycle_harmony_callback(dt_action_t *action)
 {
   const dt_lib_module_t *self = darktable.lib->proxy.histogram.module;
@@ -2499,8 +2492,6 @@ void gui_init(dt_lib_module_t *self)
     dt_action_register(teth, N_("hide histogram"),
                        _lib_histogram_collapse_callback,
                        GDK_KEY_H, GDK_CONTROL_MASK | GDK_SHIFT_MASK);
-    dt_action_register(teth, N_("switch histogram view"),
-                       _lib_histogram_change_type_callback, 0, 0);
   }
 
   // red/green/blue channel on/off


### PR DESCRIPTION
Remove the action to cycle through each histogram mode (histogram, waveform, RGB parade, vectorscope), and within each mode to cycle through options (logarithmic/linear, horizontal/vertical, u*v*/AzBz).

Rationale:

1) This action is not bound to a shortcut, and presumably is rarely/never used.
2) The implementation is nearly 100 LoC and is pretty finicky.
3) This appears to be a relic of when there were fewer scopes (initially just histogram and waveform), and there was a single button to cycle through the available scopes. Now that there are multiple buttons to choose scopes and a nice shortcut system to flip between scopes directly, it doesn't make sense to implement a slow cycle behavior.
4) It makes sense to simplify libs/histogram.c to ease improvements, e.g. #20338.
5) The sequence in which this cycles through scopes no longer matches the order of the scopes buttons in the GUI.
6) The sequence of options cycled through is incomplete. It omits RYB mode (and its linear/logarithmic suboptions) in vectorscope.

I know that removing options isn't the norm, and that a deprecation period is often preferable. But throwing this commit out there for consideration, as this bit of code appears to vestigial cruft, verging on demoware...