### PR TITLE
scopes: add waveform/vectorscope split mode

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -3192,6 +3192,7 @@
       <enum>
         <option>vectorscope</option>
         <option>waveform</option>
+        <option>waveform/vectorscope</option>
         <option>RGB parade</option>
         <option>histogram</option>
       </enum>

--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -1163,6 +1163,49 @@ void dtgtk_cairo_paint_vectorscope(cairo_t *cr, const gint x, const gint y, cons
   FINISH
 }
 
+void dtgtk_cairo_paint_split_waveform_vectorscope(cairo_t *cr, const gint x, const gint y, const gint w, const gint h, gint flags, void *data)
+{
+  PREAMBLE(1, 1, 0, 0)
+
+  double r, g, b, a;
+  if(cairo_pattern_get_rgba(cairo_get_source(cr), &r, &g, &b, &a) != CAIRO_STATUS_SUCCESS)
+    goto final;
+
+  cairo_pattern_t *pat = cairo_pattern_create_linear(0.0, 0.0, 0.0, 1.0);
+
+  cairo_pattern_add_color_stop_rgba(pat, 0.0, r, g, b, a * 0.0);
+  cairo_pattern_add_color_stop_rgba(pat, 0.2, r, g, b, a * 0.1);
+  cairo_pattern_add_color_stop_rgba(pat, 0.5, r, g, b, a * 1.0);
+  cairo_pattern_add_color_stop_rgba(pat, 0.6, r, g, b, a * 1.0);
+  cairo_pattern_add_color_stop_rgba(pat, 1.0, r, g, b, a * 0.1);
+
+  cairo_rectangle(cr, 0.0, 0.0, 0.125, 0.8);
+  cairo_set_source(cr, pat);
+  cairo_fill(cr);
+
+  cairo_save(cr);
+  cairo_scale(cr, 1.0, -1.0);
+  cairo_translate(cr, 0.0, -1.0);
+  cairo_rectangle(cr, 0.1, 0.0, 0.3, 0.9);
+  cairo_set_source(cr, pat);
+  cairo_fill(cr);
+  cairo_restore(cr);
+
+  cairo_rectangle(cr, 0.35, 0.0, 0.1, 0.7);
+  cairo_set_source(cr, pat);
+  cairo_fill(cr);
+
+  cairo_pattern_destroy(pat);
+
+  cairo_move_to(cr, 0.55, 0.48);
+  cairo_curve_to(cr, 0.64, 0.06, 0.95, 0.15, 0.95, 0.46);
+  cairo_curve_to(cr, 0.95, 0.68, 0.74, 0.83, 0.55, 0.48);
+  cairo_fill(cr);
+
+final:
+  FINISH
+}
+
 void dtgtk_cairo_paint_linear_scale(cairo_t *cr, const gint x, const gint y, const gint w, const gint h, gint flags, void *data)
 {
   PREAMBLE(1, 1, 0, 0)

--- a/src/dtgtk/paint.h
+++ b/src/dtgtk/paint.h
@@ -215,6 +215,8 @@ void dtgtk_cairo_paint_histogram_scope(cairo_t *cr, gint x, gint y, gint w, gint
 void dtgtk_cairo_paint_waveform_scope(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 /** paint vectorscope icon */
 void dtgtk_cairo_paint_vectorscope(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
+/** paint split waveform/vectorscope icon */
+void dtgtk_cairo_paint_split_waveform_vectorscope(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 /** paint linear scale icon */
 void dtgtk_cairo_paint_linear_scale(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 /** paint logarithmic scale icon */


### PR DESCRIPTION
Add a scopes mode to show both waveform and vectorscope:

<img width="364" height="187" alt="image" src="https://github.com/user-attachments/assets/2fe16826-5f88-4d14-9c38-a6019bd7e288" />

This allows for a sense of both the lightness and chromaticity of an image without flipping between scopes.

The overlay buttons at the top right of the split view control both the waveform and vectorscope:

<img width="364" height="187" alt="image" src="https://github.com/user-attachments/assets/94fe5bee-6d65-455e-9a5d-dd03468e4a57" />

A possible improvement would be to move the waveform-specific buttons over the waveform. This would take a bit of design adjustment, as currently the top left side of the scope has other buttons.

To make this change work, there were some other code changes:

- This PR splits the multi-purpose "scope view button" into three distinct buttons (which can be separately shown/hid): histogram scale, vectorscope scale, and scope orientation. This allows for showing both scale and orientation buttons in split view.
- The code which figures out when to recalculate the scope on mode switch now handles when some scope data (e.g. waveform or vectorscope) doesn't need to be recalculated. This could still be improved a bit.

Closes: #20338