### PR TITLE
add touchpad zoom and pan gestures

### DIFF
--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -736,6 +736,7 @@ static gboolean _input_event(GtkWidget *widget,
 {
   (void)user_data;
 
+#ifdef GDK_WINDOWING_QUARTZ
   if(event->type == GDK_TOUCHPAD_PINCH)
   {
     const GdkEventTouchpadPinch *pinch = &event->touchpad_pinch;
@@ -746,6 +747,7 @@ static gboolean _input_event(GtkWidget *widget,
       return TRUE;
     }
   }
+#endif
 
   return FALSE;
 }
@@ -756,6 +758,7 @@ static gboolean _scrolled(GtkWidget *widget,
 {
   (void)user_data;
 
+#ifdef GDK_WINDOWING_QUARTZ
   if(event->direction == GDK_SCROLL_SMOOTH && !event->is_stop
      && (event->delta_x != 0.0 || event->delta_y != 0.0)
      && dt_view_manager_gesture_pan(darktable.view_manager, event->x, event->y,
@@ -764,6 +767,7 @@ static gboolean _scrolled(GtkWidget *widget,
     gtk_widget_queue_draw(widget);
     return TRUE;
   }
+#endif
 
   int delta_y;
   if(dt_gui_get_scroll_unit_delta(event, &delta_y))

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -3722,6 +3722,67 @@ void scrolled(dt_view_t *self,
   dt_dev_zoom_move(&dev->full, DT_ZOOM_SCROLL, 0.0f, up, x, y, constrained);
 }
 
+gboolean gesture_pan(dt_view_t *self,
+                     const double x,
+                     const double y,
+                     const double dx,
+                     const double dy,
+                     const int state)
+{
+  dt_develop_t *dev = self->data;
+  (void)x;
+  (void)y;
+  (void)state;
+  if(!dev) return FALSE;
+  if(dx == 0.0 && dy == 0.0) return FALSE;
+
+  dt_dev_zoom_move(&dev->full, DT_ZOOM_MOVE, 1.0f, 0, dx, dy, TRUE);
+  return TRUE;
+}
+
+gboolean gesture_pinch(dt_view_t *self,
+                       const double x,
+                       const double y,
+                       const int phase,
+                       const double scale,
+                       const int state)
+{
+  dt_develop_t *dev = self->data;
+  if(!dev) return FALSE;
+  const gboolean constrained = !dt_modifier_is(state, GDK_CONTROL_MASK);
+
+  static double pinch_last_scale = 0.0;
+
+  if(phase == GDK_TOUCHPAD_GESTURE_PHASE_BEGIN)
+  {
+    pinch_last_scale = scale > 0.0 ? scale : 1.0;
+    return TRUE;
+  }
+
+  if(phase == GDK_TOUCHPAD_GESTURE_PHASE_END
+     || phase == GDK_TOUCHPAD_GESTURE_PHASE_CANCEL)
+  {
+    pinch_last_scale = 0.0;
+    return TRUE;
+  }
+
+  if(phase != GDK_TOUCHPAD_GESTURE_PHASE_UPDATE) return FALSE;
+  if(pinch_last_scale <= 0.0 || scale <= 0.0) return FALSE;
+
+  if(scale > pinch_last_scale)
+  {
+    dt_dev_zoom_move(&dev->full, DT_ZOOM_SCROLL, 0.0f, 1, x, y, constrained);
+    pinch_last_scale = scale;
+  }
+  else if(scale < pinch_last_scale)
+  {
+    dt_dev_zoom_move(&dev->full, DT_ZOOM_SCROLL, 0.0f, 0, x, y, constrained);
+    pinch_last_scale = scale;
+  }
+
+  return TRUE;
+}
+
 static void _change_slider_accel_precision(dt_action_t *action)
 {
   const int curr_precision = dt_conf_get_int("accel/slider_precision");

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -3734,6 +3734,19 @@ gboolean gesture_pan(dt_view_t *self,
   (void)y;
   (void)state;
   if(!dev) return FALSE;
+
+  // Mask editing (brush etc.) uses scroll for tool parameters.
+  if(dev->form_visible
+     && !darktable.develop->darkroom_skip_mouse_events)
+    return FALSE;
+
+  // Let active modules consume scroll for their own interactions (e.g. brush size).
+  if(dev->gui_module && dev->gui_module->scrolled
+     && !darktable.develop->darkroom_skip_mouse_events
+     && !dt_iop_color_picker_is_visible(dev)
+     && dt_dev_modulegroups_test_activated(darktable.develop))
+    return FALSE;
+
   if(dx == 0.0 && dy == 0.0) return FALSE;
 
   dt_dev_zoom_move(&dev->full, DT_ZOOM_MOVE, 1.0f, 0, dx, dy, TRUE);

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -669,6 +669,34 @@ void dt_view_manager_scrolled(dt_view_manager_t *vm,
     vm->current_view->scrolled(vm->current_view, x, y, up, state);
 }
 
+gboolean dt_view_manager_gesture_pan(dt_view_manager_t *vm,
+                                     const double x,
+                                     const double y,
+                                     const double dx,
+                                     const double dy,
+                                     const int state)
+{
+  if(!vm->current_view)
+    return FALSE;
+  if(vm->current_view->gesture_pan)
+    return vm->current_view->gesture_pan(vm->current_view, x, y, dx, dy, state);
+  return FALSE;
+}
+
+gboolean dt_view_manager_gesture_pinch(dt_view_manager_t *vm,
+                                       const double x,
+                                       const double y,
+                                       const int phase,
+                                       const double scale,
+                                       const int state)
+{
+  if(!vm->current_view)
+    return FALSE;
+  if(vm->current_view->gesture_pinch)
+    return vm->current_view->gesture_pinch(vm->current_view, x, y, phase, scale, state);
+  return FALSE;
+}
+
 void dt_view_manager_scrollbar_changed(dt_view_manager_t *vm,
                                        const double x,
                                        const double y)

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -677,10 +677,17 @@ gboolean dt_view_manager_gesture_pan(dt_view_manager_t *vm,
                                      const int state)
 {
   if(!vm->current_view)
+  {
     return FALSE;
-  if(vm->current_view->gesture_pan)
+  }
+  else if(vm->current_view->gesture_pan)
+  {
     return vm->current_view->gesture_pan(vm->current_view, x, y, dx, dy, state);
-  return FALSE;
+  }
+  else
+  {
+    return FALSE;
+  }
 }
 
 gboolean dt_view_manager_gesture_pinch(dt_view_manager_t *vm,
@@ -691,10 +698,17 @@ gboolean dt_view_manager_gesture_pinch(dt_view_manager_t *vm,
                                        const int state)
 {
   if(!vm->current_view)
+  {
     return FALSE;
-  if(vm->current_view->gesture_pinch)
+  }
+  else if(vm->current_view->gesture_pinch)
+  {
     return vm->current_view->gesture_pinch(vm->current_view, x, y, phase, scale, state);
-  return FALSE;
+  }
+  else
+  {
+    return FALSE;
+  }
 }
 
 void dt_view_manager_scrollbar_changed(dt_view_manager_t *vm,

--- a/src/views/view.h
+++ b/src/views/view.h
@@ -453,6 +453,18 @@ void dt_view_manager_scrolled(dt_view_manager_t *vm,
                               const double y,
                               const int up,
                               const int state);
+gboolean dt_view_manager_gesture_pan(dt_view_manager_t *vm,
+                                     const double x,
+                                     const double y,
+                                     const double dx,
+                                     const double dy,
+                                     const int state);
+gboolean dt_view_manager_gesture_pinch(dt_view_manager_t *vm,
+                                       const double x,
+                                       const double y,
+                                       const int phase,
+                                       const double scale,
+                                       const int state);
 void dt_view_manager_scrollbar_changed(dt_view_manager_t *vm,
                                        const double x,
                                        const double y);

--- a/src/views/view_api.h
+++ b/src/views/view_api.h
@@ -58,6 +58,8 @@ OPTIONAL(int, button_pressed, struct dt_view_t *self, double x, double y, double
 OPTIONAL(void, configure, struct dt_view_t *self, int width, int height);
 OPTIONAL(void, scrolled, struct dt_view_t *self, double x, double y, int up, int state); // mouse scrolled in view
 OPTIONAL(void, scrollbar_changed, struct dt_view_t *self, double x, double y); // scrollbars changed in view
+OPTIONAL(gboolean, gesture_pan, struct dt_view_t *self, double x, double y, double dx, double dy, int state);
+OPTIONAL(gboolean, gesture_pinch, struct dt_view_t *self, double x, double y, int phase, double scale, int state);
 
 // list of mouse actions
 OPTIONAL(GSList *, mouse_actions, const struct dt_view_t *self);


### PR DESCRIPTION
Closes #18048

Adds touchpad gestures in Darkroom:
- pinch zoom in/out
- two-finger pan

Implementation keeps existing layering:
- GTK collects gesture input
- view manager dispatches to current view
- behavior stays implemented in Darkroom view

Details:
- pan uses normalized smooth-scroll deltas (`dt_gui_get_scroll_deltas`) and applies the existing smooth-delta scale factor to keep mac behavior while improving non-mac sensitivity.
- pan still avoids consuming input in darkroom states where scroll is used for mask/brush interactions (e.g. brush size), preserving existing editing behavior.
- pinch remains step-based and is rate-limited to reduce over-sensitive zoom jumps.

Related: #20261

![gesture](https://github.com/user-attachments/assets/c04b754a-e161-4500-ab98-5993db72588f)

