### PR TITLE
fix flipped exposure change when dragging in histogram/waveform

### DIFF
--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -1115,10 +1115,12 @@ void dt_bauhaus_widget_set_quad_tooltip(GtkWidget *widget,
 
 static float _widget_width(const dt_bauhaus_widget_t *w)
 {
-  return gtk_widget_get_allocated_width(GTK_WIDGET(w))
-         - w->margin.left - w->padding.left
-         - w->margin.right - w->padding.right
-         - _widget_get_quad_width(w);
+  // unallocated widgets have a width of 1, and should keep that width
+  // even when accounting for the quad width
+  return MAX(1.0f, gtk_widget_get_allocated_width(GTK_WIDGET(w))
+                   - w->margin.left - w->padding.left
+                   - w->margin.right - w->padding.right
+                   - _widget_get_quad_width(w));
 }
 
 gchar *dt_bauhaus_widget_get_tooltip_markup(GtkWidget *widget,

--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -849,6 +849,17 @@ static void _exposure_proxy_handle_event(gpointer controller,
     if(!n_press)
       darktable.bauhaus->scroll(widget, controller);
     else
+    {
+      // ignores the quad width, but is accurate enough
+      const int slider_width = gtk_widget_get_allocated_width(widget);
+      // FIXME: it would be nice to fetch scope_height when using waveform
+      const int scope_width =
+        gtk_widget_get_allocated_width(darktable.lib->proxy.histogram.module->widget);
+      // bauhaus scales motion to slider widget, but we want to scale
+      // proportional to the scope widget, particularly when the
+      // slider has not been allocated and has a width of 1 (which can
+      // happen if its module group has not yet been displayed)
+      x = x * slider_width / scope_width;
       if(GTK_IS_GESTURE_SINGLE(controller))
         if(n_press > 0)
           darktable.bauhaus->press(controller, n_press, x, 0, widget);
@@ -856,6 +867,7 @@ static void _exposure_proxy_handle_event(gpointer controller,
           darktable.bauhaus->release(controller, -n_press, x, 0, widget);
       else
         darktable.bauhaus->motion(controller, x, 0, widget);
+    }
 
     gchar *text = dt_bauhaus_slider_get_text(widget, dt_bauhaus_slider_get(widget));
     dt_action_widget_toast(DT_ACTION(self), widget, "%s", text);


### PR DESCRIPTION
When darktable starts up with an active module group which does not contain exposure controls (by default either the "basic" module group or quick access module group), the exposure iop is not immediately allocated. In this case dragging in the histogram/waveform results in a flipped drag.

If a slider has not yet been allocated, GTK returns a width of 1 for that slider. If the slider has a quad width, bauhaus then reported a negative slider width.

Slider drag adjustments are determined by mouse position change relative to the slider width. A negative slider width resulted in flipping the drag direction relative to the slider.

This commit fixes this by:

1) properly returning width of an unallocated bauhaus widget as 1, even when it has a quad button
2) making exposure drag in a scope proportional to the histogram width rather than the (approximate) reported exposure iop slider width

Fixes: #20350