### PR TITLE
Third round of OpenCL maintenance for 5.6

### DIFF
--- a/data/kernels/atrous.cl
+++ b/data/kernels/atrous.cl
@@ -19,11 +19,11 @@
 #include "common.h"
 
 
-float4
+static inline float4
 weight(const float4 c1, const float4 c2, const float sharpen)
 {
-  const float wc = dtcl_exp(-((c1.y - c2.y)*(c1.y - c2.y) + (c1.z - c2.z)*(c1.z - c2.z)) * sharpen);
-  const float wl = dtcl_exp(- (c1.x - c2.x)*(c1.x - c2.x) * sharpen);
+  float wc = dtcl_exp(-((c1.y - c2.y)*(c1.y - c2.y) + (c1.z - c2.z)*(c1.z - c2.z)) * sharpen);
+  float wl = dtcl_exp(- (c1.x - c2.x)*(c1.x - c2.x) * sharpen);
   return (float4)(wl, wc, wc, 1.0f);
 }
 
@@ -50,12 +50,9 @@ eaw_decompose(__read_only image2d_t in,
   float4 wgt = (float4)(0.0f);
   for(int j=0;j<5;j++) for(int i=0;i<5;i++)
   {
-    const int xx = mad24(mult, i - 2, x);
-    const int yy = mad24(mult, j - 2, y);
-    const int k  = mad24(j, 5, i);
-
-    const float4 px = read_imagef(in, sampleri, (int2)(xx, yy));
-    const float4 w = filter[k]*weight(pixel, px, sharpen);
+    const int2 pp = { mad24(mult, i - 2, x), mad24(mult, j - 2, y) };
+    const float4 px = read_imagef(in, sampleri, pp);
+    const float4 w = filter[mad24(j, 5, i)] * weight(pixel, px, sharpen);
 
     sum += w*px;
     wgt += w;

--- a/data/kernels/basic.cl
+++ b/data/kernels/basic.cl
@@ -183,7 +183,7 @@ invert_1f(read_only image2d_t in, write_only image2d_t out, const int width, con
   const float pixel = read_imagef(in, sampleri, (int2)(x, y)).x;
   const float inv_pixel = color[FC(ry+y, rx+x, filters)] - pixel;
 
-  write_imagef (out, (int2)(x, y), (float4)(clamp(inv_pixel, 0.0f, 1.0f), 0.0f, 0.0f, 0.0f));
+  write_imagef (out, (int2)(x, y), (float4)(clipf(inv_pixel), 0.0f, 0.0f, 0.0f));
 }
 
 kernel void
@@ -2726,7 +2726,7 @@ kernel void md_vignette(read_only image2d_t in,
   const float cx = ((float)(roix + x) - w2);
   const float cy = ((float)(roiy + y) - h2);
   const float4 spline =
-    _interpolate_linear_spline(knots_vig, vig, knots, r * sqrt(cx*cx + cy*cy));
+    _interpolate_linear_spline(knots_vig, vig, knots, r * dt_fast_hypot(cx, cy));
 
   float4 pixel  = read_imagef(in, sampleri, (int2)(x, y));
   pixel /= fmax(1e-4, spline);
@@ -2755,7 +2755,7 @@ kernel void lens_man_vignette(read_only image2d_t in,
 
   const float dx = ((float)(roix + x) - w2);
   const float dy = ((float)(roiy + y) - h2);
-  const float radius = sqrt(dx*dx + dy*dy) * inv_maxr;
+  const float radius = dt_fast_hypot(dx, dy) * inv_maxr;
   const float4 val = fmax(0.0f, intensity * _calc_vignette_spline(radius, spline, splinesize));
 
   float4 pixel  = read_imagef(in, samplerA, (int2)(x, y));
@@ -3057,7 +3057,7 @@ kernel void md_lens_correction(read_only image2d_t in,
 
   const float cx = ((float)(roox + x) - w2) / scale;
   const float cy = ((float)(rooy + y) - h2) / scale;
-  const float radius = r * sqrt(cx*cx + cy*cy);
+  const float radius = r * dt_fast_hypot(cx, cy);
   const float limw = (float)iwidth - 1.0f;
   const float limh = (float)iheight - 1.0f;
   float output[4];

--- a/data/kernels/blendop.cl
+++ b/data/kernels/blendop.cl
@@ -1595,7 +1595,7 @@ blendop_display_channel(__read_only image2d_t in_a, __read_only image2d_t in_b, 
       break;
     case (DT_DEV_PIXELPIPE_DISPLAY_HSL_S | DT_DEV_PIXELPIPE_DISPLAY_OUTPUT):
       HSL = RGB_2_HSL(b);
-      c = clamp(HSL.y, 0.0f, 1.0f); // no boost for HSL
+      c = clipf(HSL.y); // no boost for HSL
       is_lab = 0;
       break;
     case DT_DEV_PIXELPIPE_DISPLAY_HSL_l:

--- a/data/kernels/channelmixer.cl
+++ b/data/kernels/channelmixer.cl
@@ -242,7 +242,7 @@ static inline float4 chroma_adapt_bradford(const float4 RGB,
 
   // Do white balance
   downscale_vector(&LMS, Y);
-    bradford_adapt_D50(&LMS, illuminant, p, full);
+  bradford_adapt_D50(&LMS, illuminant, p, full);
   upscale_vector(&LMS, Y);
 
   // Compute the 3D mix - this is a rotation + homothety of the vector base
@@ -266,7 +266,7 @@ static inline float4 chroma_adapt_CAT16(const float4 RGB,
 
   // Do white balance
   downscale_vector(&LMS, Y);
-    CAT16_adapt_D50(&LMS, illuminant, p, full); // force full-adaptation
+  CAT16_adapt_D50(&LMS, illuminant, p, full); // force full-adaptation
   upscale_vector(&LMS, Y);
 
   // Compute the 3D mix - this is a rotation + homothety of the vector base
@@ -285,7 +285,7 @@ static inline float4 chroma_adapt_XYZ(const float4 RGB,
 
   // Do white balance in XYZ
   downscale_vector(&XYZ_mixed, Y);
-    XYZ_adapt_D50(&XYZ_mixed, illuminant);
+  XYZ_adapt_D50(&XYZ_mixed, illuminant);
   upscale_vector(&XYZ_mixed, Y);
 
   // Compute the 3D mix in XYZ - this is a rotation + homothety of the vector base

--- a/data/kernels/denoiseprofile.cl
+++ b/data/kernels/denoiseprofile.cl
@@ -499,22 +499,19 @@ denoiseprofile_decompose(read_only image2d_t in, write_only image2d_t coarse, wr
 kernel void
 denoiseprofile_synthesize(read_only image2d_t coarse, read_only image2d_t detail, write_only image2d_t out,
      const int width, const int height,
-     const float t0, const float t1, const float t2, const float t3,
-     const float b0, const float b1, const float b2, const float b3)
+     const float4 threshold, const float4 boost)
 {
   const int x = get_global_id(0);
   const int y = get_global_id(1);
 
   if(x >= width || y >= height) return;
 
-  const float4 threshold = (float4)(t0, t1, t2, t3);
-  const float4 boost     = (float4)(b0, b1, b2, b3);
   float4 c = read_imagef(coarse, sampleri, (int2)(x, y));
   float4 d = read_imagef(detail, sampleri, (int2)(x, y));
-  float4 amount = copysign(max((float4)(0.0f), fabs(d) - threshold), d);
+  float4 amount = copysign(fmax((float4)(0.0f), fabs(d) - threshold), d);
   float4 sum = c + boost*amount;
   sum.w = c.w;
-  write_imagef (out, (int2)(x, y), sum);
+  write_imagef(out, (int2)(x, y), sum);
 }
 
 

--- a/data/kernels/filmic.cl
+++ b/data/kernels/filmic.cl
@@ -101,7 +101,7 @@ filmic (read_only image2d_t in, write_only image2d_t out, int width, int height,
     maxRGB = maxRGB / grey;
     maxRGB = (maxRGB < noise) ? noise : maxRGB;
     maxRGB = (native_log2(maxRGB) - shadows_range) / dynamic_range;
-    maxRGB = clamp(maxRGB, 0.0f, 1.0f);
+    maxRGB = clipf(maxRGB);
 
     const float index = maxRGB;
 
@@ -205,7 +205,7 @@ static inline float filmic_desaturate_v1(const float x, const float sigma_toe, c
   const float key_toe = native_exp(-0.5f * radius_toe * radius_toe / sigma_toe);
   const float key_shoulder = native_exp(-0.5f * radius_shoulder * radius_shoulder / sigma_shoulder);
 
-  return 1.0f - clamp((key_toe + key_shoulder) / saturation, 0.0f, 1.0f);
+  return 1.0f - clipf((key_toe + key_shoulder) / saturation);
 }
 
 
@@ -303,7 +303,7 @@ static inline float log_tonemapping_v2(const float x,
                                        const float grey, const float black,
                                        const float dynamic_range)
 {
-  return clamp((native_log2(x / grey) - black) / dynamic_range, 0.f, 1.f);
+  return clipf((native_log2(x / grey) - black) / dynamic_range);
 }
 
 
@@ -896,7 +896,7 @@ static inline float4 filmic_chroma_v1(const float4 i,
 
   // Filmic S curve on the max RGB
   // Apply the transfer function of the display
-  norm = dtcl_pow(clamp(filmic_spline(norm, M1, M2, M3, M4, M5, latitude_min, latitude_max, type), 0.0f, 1.0f), output_power);
+  norm = dtcl_pow(clipf(filmic_spline(norm, M1, M2, M3, M4, M5, latitude_min, latitude_max, type)), output_power);
 
   return o * norm;
 }
@@ -1047,7 +1047,7 @@ filmic_mask_clipped_pixels(read_only image2d_t in, write_only image2d_t out,
 
   const float pix_max = fmax(dtcl_sqrt(i2.x + i2.y + i2.z), 0.f);
   const float argument = -pix_max * normalize + feathering;
-  const float weight = clamp(1.0f / ( 1.0f + native_exp2(argument)), 0.f, 1.f);
+  const float weight = clipf(1.0f / ( 1.0f + native_exp2(argument)));
 
   if(4.f > argument) *is_clipped = 1;
 

--- a/data/kernels/hazeremoval.cl
+++ b/data/kernels/hazeremoval.cl
@@ -128,7 +128,7 @@ kernel void hazeremoval_transision_map(const int width, const int height, read_o
 
 kernel void hazeremoval_dehaze(const int width, const int height, read_only image2d_t in,
                                read_only image2d_t trans_map, write_only image2d_t out, const float t_min,
-                               const float A0_r, const float A0_g, const float A0_b)
+                               const float4 A0)
 {
   const int x = get_global_id(0);
   const int y = get_global_id(1);
@@ -136,7 +136,7 @@ kernel void hazeremoval_dehaze(const int width, const int height, read_only imag
 
   const float4 pixel = read_imagef(in, sampleri, (int2)(x, y));
   const float t = fmax(read_imagef(trans_map, sampleri, (int2)(x, y)).x, t_min);
-  write_imagef(
-      out, (int2)(x, y),
-      (float4)((pixel.x - A0_r) / t + A0_r, (pixel.y - A0_g) / t + A0_g, (pixel.z - A0_b) / t + A0_b, pixel.w));
+
+  write_imagef(out, (int2)(x, y),
+      (float4)((pixel.x - A0.x) / t + A0.x, (pixel.y - A0.y) / t + A0.y, (pixel.z - A0.z) / t + A0.z, pixel.w));
 }

--- a/src/common/bilateral.c
+++ b/src/common/bilateral.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2016-2023 darktable developers.
+    Copyright (C) 2016-2026 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/src/common/bilateralcl.c
+++ b/src/common/bilateralcl.c
@@ -158,10 +158,10 @@ cl_int dt_bilateral_splat_cl(dt_bilateral_cl_t *b, cl_mem in)
 {
   size_t sizes[] = { ROUNDUP(b->width, b->blocksizex), ROUNDUP(b->height, b->blocksizey), 1 };
   size_t local[] = { b->blocksizex, b->blocksizey, 1 };
-  dt_opencl_set_kernel_args(b->devid, b->global->kernel_splat, 0, CLARG(in), CLARG(b->dev_grid),
+  return dt_opencl_enqueue_kernel_2d_local_args(b->devid, b->global->kernel_splat, sizes, local,
+    CLARG(in), CLARG(b->dev_grid),
     CLARG(b->width), CLARG(b->height), CLARG(b->size_x), CLARG(b->size_y), CLARG(b->size_z), CLARG(b->sigma_s),
     CLARG(b->sigma_r), CLLOCAL(b->blocksizex * b->blocksizey * sizeof(int)), CLLOCAL(b->blocksizex * b->blocksizey * 8 * sizeof(float)));
-  return dt_opencl_enqueue_kernel_2d_with_local(b->devid, b->global->kernel_splat, sizes, local);
 }
 
 cl_int dt_bilateral_blur_cl(dt_bilateral_cl_t *b)
@@ -191,7 +191,7 @@ cl_int dt_bilateral_blur_cl(dt_bilateral_cl_t *b)
   stride3 = b->size_x * b->size_y;
   return dt_opencl_enqueue_kernel_2d_args(b->devid, b->global->kernel_blur_line_z, b->size_x, b->size_y,
           CLARG(b->dev_grid_tmp), CLARG(b->dev_grid),
-          CLARG(stride1), CLARG(stride2), CLARG(stride3), CLARG(b->size_x), CLARG(b->size_y), CLARG(b->size_z));   
+          CLARG(stride1), CLARG(stride2), CLARG(stride3), CLARG(b->size_x), CLARG(b->size_y), CLARG(b->size_z));
 }
 
 cl_int dt_bilateral_slice_to_output_cl(dt_bilateral_cl_t *b, cl_mem in, cl_mem out, const float detail)

--- a/src/common/gaussian.c
+++ b/src/common/gaussian.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2012-2024 darktable developers.
+    Copyright (C) 2012-2026 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -951,10 +951,9 @@ cl_int dt_gaussian_blur_cl(dt_gaussian_cl_t *g, cl_mem dev_in, cl_mem dev_out)
   // intermediate step: transpose dev_temp2 -> dev_temp1
   sizes[0] = bwidth;
   sizes[1] = bheight;
-  sizes[2] = 1;
-  dt_opencl_set_kernel_args(devid, kernel_gaussian_transpose, 0, CLARG(dev_temp2), CLARG(dev_temp1),
+  err = dt_opencl_enqueue_kernel_2d_local_args(devid, kernel_gaussian_transpose, sizes, local,
+    CLARG(dev_temp2), CLARG(dev_temp1),
     CLARG(width), CLARG(height), CLARG(blocksize), CLLOCAL(bpp * blocksize * (blocksize + 1)));
-  err = dt_opencl_enqueue_kernel_2d_with_local(devid, kernel_gaussian_transpose, sizes, local);
   if(err != CL_SUCCESS)
     return err;
 
@@ -970,10 +969,9 @@ cl_int dt_gaussian_blur_cl(dt_gaussian_cl_t *g, cl_mem dev_in, cl_mem dev_out)
   // transpose back dev_temp2 -> dev_temp1
   sizes[0] = bheight;
   sizes[1] = bwidth;
-  sizes[2] = 1;
-  dt_opencl_set_kernel_args(devid, kernel_gaussian_transpose, 0, CLARG(dev_temp2), CLARG(dev_temp1),
+  err = dt_opencl_enqueue_kernel_2d_local_args(devid, kernel_gaussian_transpose, sizes, local,
+    CLARG(dev_temp2), CLARG(dev_temp1),
     CLARG(height), CLARG(width), CLARG(blocksize), CLLOCAL(bpp * blocksize * (blocksize + 1)));
-  err = dt_opencl_enqueue_kernel_2d_with_local(devid, kernel_gaussian_transpose, sizes, local);
   if(err != CL_SUCCESS)
     return err;
 
@@ -1045,10 +1043,9 @@ cl_int dt_gaussian_blur_cl_buffer(dt_gaussian_cl_t *g, cl_mem dev_in, cl_mem dev
   // intermediate step: transpose dev_temp2 -> dev_temp1
   sizes[0] = bwidth;
   sizes[1] = bheight;
-  sizes[2] = 1;
-  dt_opencl_set_kernel_args(devid, kernel_gaussian_transpose, 0, CLARG(dev_temp2), CLARG(dev_temp1),
+  err = dt_opencl_enqueue_kernel_2d_local_args(devid, kernel_gaussian_transpose, sizes, local,
+    CLARG(dev_temp2), CLARG(dev_temp1),
     CLARG(width), CLARG(height), CLARG(blocksize), CLLOCAL(bpp * blocksize * (blocksize + 1)));
-  err = dt_opencl_enqueue_kernel_2d_with_local(devid, kernel_gaussian_transpose, sizes, local);
   if(err != CL_SUCCESS)
     return err;
 
@@ -1065,10 +1062,9 @@ cl_int dt_gaussian_blur_cl_buffer(dt_gaussian_cl_t *g, cl_mem dev_in, cl_mem dev
   // destination buffer
   sizes[0] = bheight;
   sizes[1] = bwidth;
-  sizes[2] = 1;
-  dt_opencl_set_kernel_args(devid, kernel_gaussian_transpose, 0, CLARG(dev_temp2), CLARG(dev_out),
+  return dt_opencl_enqueue_kernel_2d_local_args(devid, kernel_gaussian_transpose, sizes, local,
+    CLARG(dev_temp2), CLARG(dev_out),
     CLARG(height), CLARG(width), CLARG(blocksize), CLLOCAL(bpp * blocksize * (blocksize + 1)));
-  return dt_opencl_enqueue_kernel_2d_with_local(devid, kernel_gaussian_transpose, sizes, local);
 }
 
 cl_int dt_gaussian_fast_blur_cl_buffer(const int devid,

--- a/src/common/interpolation.c
+++ b/src/common/interpolation.c
@@ -1,6 +1,6 @@
 /* --------------------------------------------------------------------------
     This file is part of darktable,
-    Copyright (C) 2012-2025 darktable developers.
+    Copyright (C) 2012-2026 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -1382,15 +1382,15 @@ int dt_interpolation_resample_cl(const dt_interpolation_t *itor,
   dev_vmeta = dt_opencl_copy_host_to_device_constant(devid, sizeof(int) * height * 3, vmeta);
   if(dev_vmeta == NULL) goto error;
 
-  dt_opencl_set_kernel_args(devid, kernel, 0, CLARG(dev_in), CLARG(dev_out),
-                            CLARG(width), CLARG(height),
-                            CLARG(dev_hmeta), CLARG(dev_vmeta), CLARG(dev_hlength),
-                            CLARG(dev_vlength), CLARG(dev_hindex),
-                            CLARG(dev_vindex), CLARG(dev_hkernel), CLARG(dev_vkernel),
-                            CLARG(hmaxtaps), CLARG(taps), CLLOCAL(hmaxtaps * sizeof(float)),
-                            CLLOCAL(hmaxtaps * sizeof(int)),
-                            CLLOCAL(vblocksize * 4 * sizeof(float)));
-  err = dt_opencl_enqueue_kernel_2d_with_local(devid, kernel, sizes, local);
+  err = dt_opencl_enqueue_kernel_2d_local_args(devid, kernel, sizes, local,
+            CLARG(dev_in), CLARG(dev_out),
+            CLARG(width), CLARG(height),
+            CLARG(dev_hmeta), CLARG(dev_vmeta), CLARG(dev_hlength),
+            CLARG(dev_vlength), CLARG(dev_hindex),
+            CLARG(dev_vindex), CLARG(dev_hkernel), CLARG(dev_vkernel),
+            CLARG(hmaxtaps), CLARG(taps), CLLOCAL(hmaxtaps * sizeof(float)),
+            CLLOCAL(hmaxtaps * sizeof(int)),
+            CLLOCAL(vblocksize * 4 * sizeof(float)));
 
 error:
   if(err == CL_SUCCESS)

--- a/src/common/locallaplaciancl.c
+++ b/src/common/locallaplaciancl.c
@@ -1,7 +1,7 @@
 #ifdef HAVE_OPENCL
 /*
     This file is part of darktable,
-    Copyright (C) 2016-2020 darktable developers.
+    Copyright (C) 2016-2026 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -136,15 +136,19 @@ cl_int dt_local_laplacian_cl(
   // create gauss pyramid of padded input, write coarse directly to output
   for(int l=1;l<b->num_levels;l++)
   {
-    const int wd = dl(b->bwidth, l), ht = dl(b->bheight, l);
-    size_t sizes[] = { ROUNDUPDWD(wd, b->devid), ROUNDUPDHT(ht, b->devid), 1 };
-    dt_opencl_set_kernel_args(b->devid, b->global->kernel_gauss_reduce, 0, CLARG(b->dev_padded[l-1]));
+    const int wd = dl(b->bwidth, l);
+    const int ht = dl(b->bheight, l);
+
     if(l == b->num_levels-1)
-      dt_opencl_set_kernel_args(b->devid, b->global->kernel_gauss_reduce, 1, CLARG(b->dev_output[l]));
+      err = dt_opencl_enqueue_kernel_2d_args(b->devid, b->global->kernel_gauss_reduce, wd, ht,
+              CLARG(b->dev_padded[l-1]),
+              CLARG(b->dev_output[l]),
+              CLARG(wd), CLARG(ht));
     else
-      dt_opencl_set_kernel_args(b->devid, b->global->kernel_gauss_reduce, 1, CLARG(b->dev_padded[l]));
-    dt_opencl_set_kernel_args(b->devid, b->global->kernel_gauss_reduce, 2, CLARG(wd), CLARG(ht));
-    err = dt_opencl_enqueue_kernel_2d(b->devid, b->global->kernel_gauss_reduce, sizes);
+      err = dt_opencl_enqueue_kernel_2d_args(b->devid, b->global->kernel_gauss_reduce, wd, ht,
+              CLARG(b->dev_padded[l-1]),
+              CLARG(b->dev_padded[l]),
+              CLARG(wd), CLARG(ht));
     if(err != CL_SUCCESS) goto error;
   }
 

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -2939,8 +2939,12 @@ int dt_opencl_read_host_from_device_raw(const int devid,
 
   if(err != CL_SUCCESS)
     dt_print(DT_DEBUG_OPENCL,
-             "[dt_opencl_read_host_from_device_raw] could not read from device '%s' id=%d: %s",
+             "[dt_opencl_read_host_from_device_raw] could not read image from device '%s' id=%d: %s",
              darktable.opencl->dev[devid].fullname, devid, cl_errstr(err));
+  else
+    dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE,
+             "[dt_opencl_read_host_from_device_raw] read image from device '%s' id=%d",
+             darktable.opencl->dev[devid].fullname, devid);
 
   return err;
 }
@@ -2992,8 +2996,14 @@ int dt_opencl_write_host_to_device_raw(const int devid,
      rowpitch, 0, host, 0, NULL, eventp);
   if(err != CL_SUCCESS)
     dt_print(DT_DEBUG_OPENCL,
-             "[dt_opencl_write_host_to_device_raw] could not write to device '%s' id=%d: %s",
+             "[dt_opencl_write_host_to_device_raw] could not write image to device '%s' id=%d: %s",
              darktable.opencl->dev[devid].fullname, devid, cl_errstr(err));
+  else
+    dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE,
+             "[dt_opencl_write_host_to_device_raw] wrote image to device '%s' id=%d",
+             darktable.opencl->dev[devid].fullname, devid);
+
+
   _check_clmem_err(devid, err);
   return err;
 }
@@ -3015,8 +3025,13 @@ int dt_opencl_enqueue_copy_image(const int devid,
 
   if(err != CL_SUCCESS)
     dt_print(DT_DEBUG_OPENCL,
-             "[opencl copy_image] could not copy on device '%s' id=%d: %s",
+             "[opencl copy_image] could not copy image on device '%s' id=%d: %s",
              darktable.opencl->dev[devid].fullname, devid, cl_errstr(err));
+  else
+    dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE,
+             "[opencl copy_image] copied image on device '%s' id=%d",
+             darktable.opencl->dev[devid].fullname, devid);
+
   _check_clmem_err(devid, err);
   return err;
 }
@@ -3038,8 +3053,13 @@ int dt_opencl_enqueue_copy_image_to_buffer(const int devid,
 
   if(err != CL_SUCCESS)
     dt_print(DT_DEBUG_OPENCL,
-             "[opencl copy_image_to_buffer] could not copy on device '%s' id=%d: %s",
+             "[opencl copy_image_to_buffer] could not copy image to buffer device '%s' id=%d: %s",
              darktable.opencl->dev[devid].fullname, devid, cl_errstr(err));
+  else
+    dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE,
+             "[opencl copy_image_to_buffer] copied image to buffer device '%s' id=%d",
+             darktable.opencl->dev[devid].fullname, devid);
+
   _check_clmem_err(devid, err);
   return err;
 }
@@ -3061,8 +3081,13 @@ int dt_opencl_enqueue_copy_buffer_to_image(const int devid,
 
   if(err != CL_SUCCESS)
     dt_print(DT_DEBUG_OPENCL,
-             "[opencl copy_buffer_to_image] could not copy on device '%s' id=%d: %s",
+             "[opencl copy_buffer_to_image] could not copy buffer to image on device '%s' id=%d: %s",
              darktable.opencl->dev[devid].fullname, devid, cl_errstr(err));
+  else
+    dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE,
+             "[opencl copy_buffer_to_image] copied buffer to image on device '%s' id=%d",
+             darktable.opencl->dev[devid].fullname, devid);
+
   _check_clmem_err(devid, err);
   return err;
 }
@@ -3084,8 +3109,13 @@ int dt_opencl_enqueue_copy_buffer_to_buffer(const int devid,
      dstoffset, size, 0, NULL, eventp);
   if(err != CL_SUCCESS)
     dt_print(DT_DEBUG_OPENCL,
-             "[opencl copy_buffer_to_buffer] could not copy on device '%s' id=%d: %s",
+             "[opencl copy_buffer_to_buffer] could not copy buffer to buffer on device '%s' id=%d: %s",
              darktable.opencl->dev[devid].fullname, devid, cl_errstr(err));
+  else
+    dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE,
+             "[opencl copy_buffer_to_buffer] copied buffer to buffer on device '%s' id=%d",
+             darktable.opencl->dev[devid].fullname, devid);
+
   _check_clmem_err(devid, err);
   return err;
 }
@@ -3109,8 +3139,13 @@ int dt_opencl_read_buffer_from_device(const int devid,
      offset, size, host, 0, NULL, eventp);
   if(err != CL_SUCCESS)
     dt_print(DT_DEBUG_OPENCL,
-             "[opencl read_buffer_from_device] could not read from device '%s' id=%d: %s",
+             "[opencl read_buffer_from_device] could not read buffer from device '%s' id=%d: %s",
              darktable.opencl->dev[devid].fullname, devid, cl_errstr(err));
+  else
+    dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE,
+             "[opencl read_buffer_from_device] read buffer from device '%s' id=%d",
+             darktable.opencl->dev[devid].fullname, devid);
+
   return err;
 }
 
@@ -3134,8 +3169,12 @@ int dt_opencl_write_buffer_to_device(const int devid,
 
   if(err != CL_SUCCESS)
     dt_print(DT_DEBUG_OPENCL,
-             "[opencl write_buffer_to_device] could not write to device '%s' id=%d: %s",
+             "[opencl write_buffer_to_device] could not write buffer to device '%s' id=%d: %s",
              darktable.opencl->dev[devid].fullname, devid, cl_errstr(err));
+  else
+    dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE,
+             "[opencl write_buffer_to_device] wrote buffer to device '%s' id=%d",
+             darktable.opencl->dev[devid].fullname, devid);
   return err;
 }
 
@@ -3209,6 +3248,11 @@ static void *_opencl_copy_host_to_device_rowpitch(const int devid,
              "[opencl copy_host_to_device]"
              " could not alloc/copy img buffer on device '%s' id=%d: %s",
              darktable.opencl->dev[devid].fullname, devid, cl_errstr(err));
+  else
+    dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE,
+             "[opencl copy_host_to_device]"
+             " did alloc/copy img buffer on device '%s' id=%d",
+             darktable.opencl->dev[devid].fullname, devid);
 
   _check_clmem_err(devid, err);
   dt_opencl_memory_statistics(devid, dev, OPENCL_MEMORY_ADD);
@@ -3261,8 +3305,13 @@ void *dt_opencl_map_buffer(const int devid,
 
   if(err != CL_SUCCESS)
     dt_print(DT_DEBUG_OPENCL,
-             "[opencl map buffer] could not map buffer on device '%s' id=%d: %s",
+             "[opencl map buffer] could not map buffer to device '%s' id=%d: %s",
              darktable.opencl->dev[devid].fullname, devid, cl_errstr(err));
+  else
+    dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE,
+             "[opencl map buffer] mapped buffer to device '%s' id=%d",
+             darktable.opencl->dev[devid].fullname, devid);
+
   _check_clmem_err(devid, err);
   return ptr;
 }
@@ -3280,8 +3329,12 @@ int dt_opencl_unmap_mem_object(const int devid,
 
   if(err != CL_SUCCESS)
     dt_print(DT_DEBUG_OPENCL,
-             "[opencl unmap mem object] could not unmap mem object on device '%s' id=%d: %s",
+             "[opencl unmap mem object] could not unmap mem object from device '%s' id=%d: %s",
              darktable.opencl->dev[devid].fullname, devid, cl_errstr(err));
+  else
+    dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE,
+             "[opencl unmap mem object] unmapped mem object from device '%s' id=%d",
+             darktable.opencl->dev[devid].fullname, devid);
   return err;
 }
 
@@ -3397,12 +3450,12 @@ size_t dt_opencl_get_mem_object_size(const cl_mem mem)
 static int _opencl_get_mem_context_id(const cl_mem mem)
 {
   cl_context context;
-  if(mem == NULL) return -1;
+  if(mem == NULL) return DT_DEVICE_NONE;
 
   const cl_int err = (darktable.opencl->dlocl->symbols->dt_clGetMemObjectInfo)
     (mem, CL_MEM_CONTEXT, sizeof(context), &context, NULL);
   if(err != CL_SUCCESS)
-    return -1;
+    return DT_DEVICE_NONE;
 
   for(int devid = 0; devid < darktable.opencl->num_devs; devid++)
   {
@@ -3410,7 +3463,7 @@ static int _opencl_get_mem_context_id(const cl_mem mem)
       return devid;
   }
 
-  return -1;
+  return DT_DEVICE_NONE;
 }
 
 int dt_opencl_get_image_width(const cl_mem mem)
@@ -3981,12 +4034,12 @@ static void _opencl_events_profiling(const int devid,
   for(int i = 1; i < items; i++)
   {
     dt_print(DT_DEBUG_OPENCL, "[opencl_profiling] spent %7.4f seconds in %s",
-             (double)timings[i],
+             (double)fmaxf(0.0f, timings[i]),
              tags[i][0] == '\0' ? "<?>" : tags[i]);
     total += timings[i];
   }
   // aggregated timing info for items without tag (if any)
-  if(timings[0] != 0.0f)
+  if(timings[0] > 0.0f)
   {
     dt_print(DT_DEBUG_OPENCL, "[opencl_profiling] spent %7.4f seconds (unallocated)",
              (double)timings[0]);

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -2847,6 +2847,27 @@ int dt_opencl_enqueue_kernel_2d_args_internal(const int dev,
   return dt_opencl_enqueue_kernel_2d_with_local(dev, kernel, sizes, NULL);
 }
 
+int dt_opencl_enqueue_kernel_2d_local_args_internal(const int dev,
+                                                    const int kernel,
+                                                    const size_t *sizes,
+                                                    const size_t *local, ...)
+{
+  va_list ap;
+  va_start(ap, local);
+  const cl_int err = _opencl_set_kernel_args(dev, kernel, 0, ap);
+  va_end(ap);
+  if(err != CL_SUCCESS)
+  {
+    dt_opencl_t *cl = darktable.opencl;
+    dt_print(DT_DEBUG_OPENCL,
+             "[dt_opencl_enqueue_kernel_2d_local_args_internal] kernel `%s' (%i) on device '%s' id=%d: %s",
+              cl->name_saved[kernel], kernel, cl->dev[dev].fullname, dev, cl_errstr(err));
+    return err;
+  }
+  const size_t nsizes[3] = { sizes[0], sizes[1], 1 };
+  return dt_opencl_enqueue_kernel_2d_with_local(dev, kernel, nsizes, local);
+}
+
 int dt_opencl_enqueue_kernel_1d_args_internal(const int dev,
                                               const int kernel,
                                               const size_t x,

--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -32,6 +32,14 @@
 #define DT_OPENCL_CBUFFSIZE 1024
 #define DT_OPENCL_DEFAULT_HEADROOM 600
 
+/* The number of events handled by the driver is principally not limited.
+   If a device handler can't process a function handling an event it will return
+   an error codition that will be checked in darktable.
+   Still we don't want to stress the device resources too much so we try to keep
+   handled events in a safe range.
+*/
+#define DT_OPENCL_EVENTS 4096
+
 // some pseudo error codes in dt opencl usage
 #define DT_OPENCL_DEFAULT_ERROR -999
 #define DT_OPENCL_SYSMEM_ALLOCATION -998
@@ -180,13 +188,7 @@ typedef struct dt_opencl_device_t
   int clroundup_wd;
   int clroundup_ht;
 
-  // This defines how often should dt_opencl_events_get_slot do a
-  // dt_opencl_events_flush.  It should definitely le lower than the
-  // number of events that can be handled by the device/driver.
-  // FIXME we should be able to test for that with using >= OpenCl 2.0
-  int event_handles;
-
-  // opencl_events enabled for the device, set internally via event_handles
+  // opencl_events enabled for the device
   gboolean use_events;
 
   // async pixelpipe mode for device if set to TRUE OpenCL pixelpipe

--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -390,6 +390,11 @@ int dt_opencl_enqueue_kernel_2d_with_local(const int dev,
 #define dt_opencl_enqueue_kernel_2d_args(dev, kernel, w, h, ...) \
     dt_opencl_enqueue_kernel_2d_args_internal(dev, kernel, w, h, __VA_ARGS__, CLWRAP(SIZE_MAX, NULL))
 
+/** call kernel with arguments, sizes and local! */
+#define dt_opencl_enqueue_kernel_2d_local_args(dev, kernel, sizes, local, ...) \
+    dt_opencl_enqueue_kernel_2d_local_args_internal(dev, kernel, sizes, local, __VA_ARGS__, CLWRAP(SIZE_MAX, NULL))
+
+
 #define dt_opencl_enqueue_kernel_1d_args(dev, kernel, x, ...) \
     dt_opencl_enqueue_kernel_1d_args_internal(dev, kernel, x, __VA_ARGS__, CLWRAP(SIZE_MAX, NULL))
 
@@ -397,6 +402,10 @@ int dt_opencl_enqueue_kernel_2d_args_internal(const int dev,
                                               const int kernel,
                                               const size_t w,
                                               const size_t h, ...);
+int dt_opencl_enqueue_kernel_2d_local_args_internal(const int dev,
+                                                    const int kernel,
+                                                    const size_t *sizes,
+                                                    const size_t *local, ...);
 int dt_opencl_enqueue_kernel_1d_args_internal(const int dev,
                                               const int kernel,
                                               const size_t x, ...);

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -3617,14 +3617,12 @@ int dt_dev_write_scharr_mask_cl(dt_dev_pixelpipe_iop_t *piece,
   const gboolean wboff = !p->dsc.temperature.enabled || !rawmode;
 
   const dt_aligned_pixel_t wb =
-      { wboff ? 1.0f : p->dsc.temperature.coeffs[0],
-        wboff ? 1.0f : p->dsc.temperature.coeffs[1],
-        wboff ? 1.0f : p->dsc.temperature.coeffs[2] };
+      { wboff ? 1.0f : 1.0f / p->dsc.temperature.coeffs[0],
+        wboff ? 1.0f : 1.0f / p->dsc.temperature.coeffs[1],
+        wboff ? 1.0f : 1.0f / p->dsc.temperature.coeffs[2], 1.0f };
 
-  err = dt_opencl_enqueue_kernel_2d_args(devid,
-     darktable.opencl->blendop->kernel_calc_Y0_mask, width, height,
-     CLARG(tmp), CLARG(in), CLARG(width), CLARG(height),
-     CLARG(wb[0]), CLARG(wb[1]), CLARG(wb[2]));
+  err = dt_opencl_enqueue_kernel_2d_args(devid, darktable.opencl->blendop->kernel_calc_Y0_mask, width, height,
+     CLARG(tmp), CLARG(in), CLARG(width), CLARG(height), CLFLARRAY(4, wb));
   if(err != CL_SUCCESS) goto error;
 
   err = dt_opencl_enqueue_kernel_2d_args(devid,

--- a/src/iop/atrous.c
+++ b/src/iop/atrous.c
@@ -442,7 +442,7 @@ int process_cl(dt_iop_module_t *self,
     err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_synthesize, width, height,
                               CLARG(dev_out), CLARG(pp_coarse), CLARG(dev_detail),
                               CLARG(width), CLARG(height),
-                              CLFLARRAY(4, &thrs[scale]), CLFLARRAY(4, &boost[scale]));
+                              CLFLARRAY(4, thrs[scale]), CLFLARRAY(4, boost[scale]));
     if(err != CL_SUCCESS) goto error;
 
     // swap scratch buffers but leave as is for the final round to keep pp_coarse correct
@@ -558,14 +558,14 @@ int process_cl(dt_iop_module_t *self,
                               CLARG(dev_tmp), CLARG(dev_out),
                               CLARG(dev_detail[scale]),
                               CLARG(width), CLARG(height),
-                              CLFLARRAY(4, &thrs[scale]), CLFLARRAY(4, &boost[scale]));  
+                              CLFLARRAY(4, thrs[scale]), CLFLARRAY(4, boost[scale]));
 
     else
       err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_synthesize, width, height,
                               CLARG(dev_out), CLARG(dev_tmp),
                               CLARG(dev_detail[scale]),
                               CLARG(width), CLARG(height),
-                              CLFLARRAY(4, &thrs[scale]), CLFLARRAY(4, &boost[scale]));  
+                              CLFLARRAY(4, thrs[scale]), CLFLARRAY(4, boost[scale]));
     if(err != CL_SUCCESS) goto error;
   }
   dt_opencl_finish_sync_pipe(devid, piece->pipe->type);

--- a/src/iop/basecurve.c
+++ b/src/iop/basecurve.c
@@ -747,25 +747,20 @@ int process_cl_fusion(dt_iop_module_t *self,
     {
       const float mul = exposure_increment(d->exposure_stops, e, d->exposure_fusion, d->exposure_bias);
 
-      size_t sizes[] = { ROUNDUPDWD(width, devid), ROUNDUPDHT(height, devid), 1 };
       if(d->preserve_colors == DT_RGB_NORM_NONE)
-      {
-        dt_opencl_set_kernel_args(devid, gd->kernel_basecurve_legacy_lut, 0, CLARG(dev_in), CLARG(dev_tmp1),
+        err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_basecurve_legacy_lut, width, height,
+          CLARG(dev_in), CLARG(dev_tmp1),
           CLARG(width), CLARG(height), CLARG(mul), CLARG(dev_m), CLARG(dev_coeffs));
-        err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_basecurve_legacy_lut, sizes);
-        if(err != CL_SUCCESS) goto error;
-      }
       else
-      {
-        dt_opencl_set_kernel_args(devid, gd->kernel_basecurve_lut, 0, CLARG(dev_in), CLARG(dev_tmp1), CLARG(width),
+        err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_basecurve_lut, width, height,
+          CLARG(dev_in), CLARG(dev_tmp1), CLARG(width),
           CLARG(height), CLARG(mul), CLARG(dev_m), CLARG(dev_coeffs), CLARG(preserve_colors), CLARG(dev_profile_info),
           CLARG(dev_profile_lut), CLARG(use_work_profile));
-        err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_basecurve_lut, sizes);
-      }
+      if(err != CL_SUCCESS) goto error;
 
-      dt_opencl_set_kernel_args(devid, gd->kernel_basecurve_compute_features, 0, CLARG(dev_tmp1), CLARG(dev_col[0]),
+      err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_basecurve_compute_features, width, height,
+        CLARG(dev_tmp1), CLARG(dev_col[0]),
         CLARG(width), CLARG(height));
-      err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_basecurve_compute_features, sizes);
       if(err != CL_SUCCESS) goto error;
     }
 

--- a/src/iop/clipping.c
+++ b/src/iop/clipping.c
@@ -1134,15 +1134,10 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
     const float maa[4] = { ma, mb, md, me };
     const float mbb[2] = { mg, mh };
 
-    size_t sizes[3];
-
-    sizes[0] = ROUNDUPDWD(width, devid);
-    sizes[1] = ROUNDUPDHT(height, devid);
-    sizes[2] = 1;
-    dt_opencl_set_kernel_args(devid, crkernel, 0, CLARG(dev_in), CLARG(dev_out), CLARG(width), CLARG(height),
+    err = dt_opencl_enqueue_kernel_2d_args(devid, crkernel, width, height,
+      CLARG(dev_in), CLARG(dev_out), CLARG(width), CLARG(height),
       CLARG(roi_in->width), CLARG(roi_in->height), CLARG(roi), CLARG(roo), CLARG(roi_in->scale), CLARG(roi_out->scale),
       CLARG(d->flip), CLARG(t), CLARG(k), CLARG(m), CLARG(k_space), CLARG(ka), CLARG(maa), CLARG(mbb));
-    err = dt_opencl_enqueue_kernel_2d(devid, crkernel, sizes);
   }
 
 error:

--- a/src/iop/colisa.c
+++ b/src/iop/colisa.c
@@ -1,6 +1,6 @@
 /*
   This file is part of darktable,
-  Copyright (C) 2013-2024 darktable developers.
+  Copyright (C) 2013-2026 darktable developers.
 
   darktable is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -137,14 +137,9 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
   dev_lcoeffs = dt_opencl_copy_host_to_device_constant(devid, sizeof(float) * 3, d->lunbounded_coeffs);
   if(dev_lcoeffs == NULL) goto error;
 
-  size_t sizes[3];
-  sizes[0] = ROUNDUPDWD(width, devid);
-  sizes[1] = ROUNDUPDHT(height, devid);
-  sizes[2] = 1;
-  dt_opencl_set_kernel_args(devid, gd->kernel_colisa, 0, CLARG(dev_in), CLARG(dev_out), CLARG(width),
+  err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_colisa, width, height,
+    CLARG(dev_in), CLARG(dev_out), CLARG(width),
     CLARG(height), CLARG(saturation), CLARG(dev_cm), CLARG(dev_ccoeffs), CLARG(dev_lm), CLARG(dev_lcoeffs));
-
-  err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_colisa, sizes);
 
 error:
   dt_opencl_release_mem_object(dev_lcoeffs);

--- a/src/iop/colorbalance.c
+++ b/src/iop/colorbalance.c
@@ -773,7 +773,6 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
   const int devid = piece->pipe->devid;
   const int width = roi_in->width;
   const int height = roi_in->height;
-  size_t sizes[] = { ROUNDUPDWD(width, devid), ROUNDUPDHT(height, devid), 1 };
 
   switch(d->mode)
   {
@@ -795,10 +794,10 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
                   grey = d->grey / 100.0f,
                   saturation = d->saturation;
 
-      dt_opencl_set_kernel_args(devid, gd->kernel_colorbalance, 0, CLARG(dev_in), CLARG(dev_out), CLARG(width),
+      err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_colorbalance, width, height,
+        CLARG(dev_in), CLARG(dev_out), CLARG(width),
         CLARG(height), CLARG(lift), CLARG(gain), CLARG(gamma_inv), CLARG(saturation), CLARG(contrast),
         CLARG(grey));
-      err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_colorbalance, sizes);
       if(err != CL_SUCCESS) goto error;
       return CL_SUCCESS;
 
@@ -823,10 +822,10 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
                   saturation = d->saturation,
                   saturation_out = d->saturation_out;
 
-      dt_opencl_set_kernel_args(devid, gd->kernel_colorbalance_lgg, 0, CLARG(dev_in), CLARG(dev_out),
+      err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_colorbalance_lgg, width, height,
+        CLARG(dev_in), CLARG(dev_out),
         CLARG(width), CLARG(height), CLARG(lift), CLARG(gain), CLARG(gamma_inv), CLARG(saturation), CLARG(contrast),
         CLARG(grey), CLARG(saturation_out));
-      err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_colorbalance_lgg, sizes);
       if(err != CL_SUCCESS) goto error;
       return CL_SUCCESS;
 
@@ -851,10 +850,10 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
                   saturation = d->saturation,
                   saturation_out = d->saturation_out;
 
-      dt_opencl_set_kernel_args(devid, gd->kernel_colorbalance_cdl, 0, CLARG(dev_in), CLARG(dev_out),
+      err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_colorbalance_cdl, width, height,
+        CLARG(dev_in), CLARG(dev_out),
         CLARG(width), CLARG(height), CLARG(lift), CLARG(gain), CLARG(gamma), CLARG(saturation), CLARG(contrast),
         CLARG(grey), CLARG(saturation_out));
-      err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_colorbalance_cdl, sizes);
       if(err != CL_SUCCESS) goto error;
       return CL_SUCCESS;
 

--- a/src/iop/colorreconstruction.c
+++ b/src/iop/colorreconstruction.c
@@ -1,6 +1,6 @@
 /*
   This file is part of darktable,
-  Copyright (C) 2015-2024 darktable developers.
+  Copyright (C) 2015-2026 darktable developers.
 
   darktable is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -932,68 +932,63 @@ static dt_iop_colorreconstruct_bilateral_cl_t *dt_iop_colorreconstruct_bilateral
 static cl_int dt_iop_colorreconstruct_bilateral_splat_cl(dt_iop_colorreconstruct_bilateral_cl_t *b, cl_mem in, const float threshold,
                                                          dt_iop_colorreconstruct_precedence_t precedence, const float *params)
 {
-  cl_int err = -666;
+  cl_int err = DT_OPENCL_PROCESS_CL;
   if(!b) return err;
   int pref = precedence;
   size_t sizes[] = { ROUNDUP(b->width, b->blocksizex), ROUNDUP(b->height, b->blocksizey), 1 };
   size_t local[] = { b->blocksizex, b->blocksizey, 1 };
-  dt_opencl_set_kernel_args(b->devid, b->global->kernel_colorreconstruct_splat, 0, CLARG(in), CLARG(b->dev_grid),
+  err = dt_opencl_enqueue_kernel_2d_local_args(b->devid, b->global->kernel_colorreconstruct_splat, sizes, local,
+    CLARG(in), CLARG(b->dev_grid),
     CLARG(b->width), CLARG(b->height), CLARG(b->size_x), CLARG(b->size_y), CLARG(b->size_z), CLARG(b->sigma_s),
     CLARG(b->sigma_r), CLARG(threshold), CLARG(pref), CLARRAY(4, params), CLLOCAL(b->blocksizex * b->blocksizey * sizeof(int)),
     CLLOCAL(b->blocksizex * b->blocksizey * 4 * sizeof(float)));
-  err = dt_opencl_enqueue_kernel_2d_with_local(b->devid, b->global->kernel_colorreconstruct_splat, sizes, local);
   return err;
 }
 
 static cl_int dt_iop_colorreconstruct_bilateral_blur_cl(dt_iop_colorreconstruct_bilateral_cl_t *b)
 {
-  cl_int err = -666;
+  cl_int err = DT_OPENCL_PROCESS_CL;
   if(!b) return err;
-  size_t sizes[3] = { 0, 0, 1 };
 
   err = dt_opencl_enqueue_copy_buffer_to_buffer(b->devid, b->dev_grid, b->dev_grid_tmp, 0, 0,
                                                 sizeof(float) * b->size_x * b->size_y * b->size_z * 4);
   if(err != CL_SUCCESS) return err;
 
-  sizes[0] = ROUNDUPDWD(b->size_z, b->devid);
-  sizes[1] = ROUNDUPDHT(b->size_y, b->devid);
   int stride1, stride2, stride3;
   stride1 = b->size_x * b->size_y;
   stride2 = b->size_x;
   stride3 = 1;
-  dt_opencl_set_kernel_args(b->devid, b->global->kernel_colorreconstruct_blur_line, 0, CLARG(b->dev_grid_tmp),
+  err = dt_opencl_enqueue_kernel_2d_args(b->devid, b->global->kernel_colorreconstruct_blur_line, b->size_z, b->size_y,
+    CLARG(b->dev_grid_tmp),
     CLARG(b->dev_grid), CLARG(stride1), CLARG(stride2), CLARG(stride3), CLARG(b->size_z), CLARG(b->size_y),
     CLARG(b->size_x));
-  err = dt_opencl_enqueue_kernel_2d(b->devid, b->global->kernel_colorreconstruct_blur_line, sizes);
   if(err != CL_SUCCESS) return err;
 
   stride1 = b->size_x * b->size_y;
   stride2 = 1;
   stride3 = b->size_x;
-  sizes[0] = ROUNDUPDWD(b->size_z, b->devid);
-  sizes[1] = ROUNDUPDHT(b->size_x, b->devid);
-  dt_opencl_set_kernel_args(b->devid, b->global->kernel_colorreconstruct_blur_line, 0, CLARG(b->dev_grid),
+  err = dt_opencl_enqueue_kernel_2d_args(b->devid, b->global->kernel_colorreconstruct_blur_line, b->size_z, b->size_x,
+    CLARG(b->dev_grid),
     CLARG(b->dev_grid_tmp), CLARG(stride1), CLARG(stride2), CLARG(stride3), CLARG(b->size_z), CLARG(b->size_x),
     CLARG(b->size_y));
-  err = dt_opencl_enqueue_kernel_2d(b->devid, b->global->kernel_colorreconstruct_blur_line, sizes);
   if(err != CL_SUCCESS) return err;
 
   stride1 = 1;
   stride2 = b->size_x;
   stride3 = b->size_x * b->size_y;
-  sizes[0] = ROUNDUPDWD(b->size_x, b->devid);
-  sizes[1] = ROUNDUPDHT(b->size_y, b->devid);
-  dt_opencl_set_kernel_args(b->devid, b->global->kernel_colorreconstruct_blur_line, 0, CLARG(b->dev_grid_tmp),
+
+  err = dt_opencl_enqueue_kernel_2d_args(b->devid, b->global->kernel_colorreconstruct_blur_line, b->size_x, b->size_y,
+    CLARG(b->dev_grid_tmp),
     CLARG(b->dev_grid), CLARG(stride1), CLARG(stride2), CLARG(stride3), CLARG(b->size_x), CLARG(b->size_y),
     CLARG(b->size_z));
-  err = dt_opencl_enqueue_kernel_2d(b->devid, b->global->kernel_colorreconstruct_blur_line, sizes);
+
   return err;
 }
 
 static cl_int dt_iop_colorreconstruct_bilateral_slice_cl(dt_iop_colorreconstruct_bilateral_cl_t *b, cl_mem in, cl_mem out,
                                                          const float threshold, const dt_iop_roi_t *roi, const float iscale)
 {
-  cl_int err = -666;
+  cl_int err = DT_OPENCL_PROCESS_CL;
   if(!b) return err;
   const int bxy[2] = { b->x, b->y };
   const int roixy[2] = { roi->x, roi->y };
@@ -1020,7 +1015,7 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
 
   const float params[4] = { hue, M_PI*M_PI/8, 0.0f, 0.0f };
 
-  cl_int err = -666;
+  cl_int err = DT_OPENCL_PROCESS_CL;
 
   dt_iop_colorreconstruct_bilateral_cl_t *b;
   dt_iop_colorreconstruct_bilateral_frozen_t *can = NULL;

--- a/src/iop/demosaicing/basics.c
+++ b/src/iop/demosaicing/basics.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2010-2025 darktable developers.
+    Copyright (C) 2010-2026 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -270,10 +270,9 @@ static int color_smoothing_cl(const dt_iop_module_t *self,
   {
     const size_t sizes[] = { ROUNDUP(width, locopt.sizex), ROUNDUP(height, locopt.sizey), 1 };
     const size_t local[] = { locopt.sizex, locopt.sizey, 1 };
-    dt_opencl_set_kernel_args(devid, gd->kernel_color_smoothing, 0,
+    err = dt_opencl_enqueue_kernel_2d_local_args(devid, gd->kernel_color_smoothing, sizes, local,
       CLARG(dev_t1), CLARG(dev_t2), CLARG(width),
       CLARG(height), CLLOCAL(sizeof(float) * 4 * (locopt.sizex + 2) * (locopt.sizey + 2)));
-    err = dt_opencl_enqueue_kernel_2d_with_local(devid, gd->kernel_color_smoothing, sizes, local);
     if(err != CL_SUCCESS) goto error;
 
     // swap dev_t1 and dev_t2
@@ -374,11 +373,10 @@ static int green_equilibration_cl(const dt_iop_module_t *self,
 
     const size_t fsizes[3] = { bwidth, bheight, 1 };
     const size_t flocal[3] = { flocopt.sizex, flocopt.sizey, 1 };
-    dt_opencl_set_kernel_args(devid, gd->kernel_green_eq_favg_reduce_first, 0,
+    err = dt_opencl_enqueue_kernel_2d_local_args(devid, gd->kernel_green_eq_favg_reduce_first, fsizes, flocal,
       CLARG(dev_in1), CLARG(width),
       CLARG(height), CLARG(dev_m), CLARG(filters),
       CLLOCAL(sizeof(float) * 2 * flocopt.sizex * flocopt.sizey));
-    err = dt_opencl_enqueue_kernel_2d_with_local(devid, gd->kernel_green_eq_favg_reduce_first, fsizes, flocal);
     if(err != CL_SUCCESS) goto error;
 
     dt_opencl_local_buffer_t slocopt
@@ -400,10 +398,9 @@ static int green_equilibration_cl(const dt_iop_module_t *self,
 
     const size_t ssizes[3] = { (size_t)reducesize * slocopt.sizex, 1, 1 };
     const size_t slocal[3] = { slocopt.sizex, 1, 1 };
-    dt_opencl_set_kernel_args(devid, gd->kernel_green_eq_favg_reduce_second, 0,
+    err = dt_opencl_enqueue_kernel_2d_local_args(devid, gd->kernel_green_eq_favg_reduce_second, ssizes, slocal,
       CLARG(dev_m), CLARG(dev_r),
       CLARG(bufsize), CLLOCAL(sizeof(float) * 2 * slocopt.sizex));
-    err = dt_opencl_enqueue_kernel_2d_with_local(devid, gd->kernel_green_eq_favg_reduce_second, ssizes, slocal);
     if(err != CL_SUCCESS) goto error;
 
     sumsum = dt_alloc_align_float((size_t)2 * reducesize);
@@ -447,11 +444,10 @@ static int green_equilibration_cl(const dt_iop_module_t *self,
 
     const size_t sizes[3] = { ROUNDUP(width, locopt.sizex), ROUNDUP(height, locopt.sizey), 1 };
     const size_t local[3] = { locopt.sizex, locopt.sizey, 1 };
-    dt_opencl_set_kernel_args(devid, gd->kernel_green_eq_lavg, 0,
+    err = dt_opencl_enqueue_kernel_2d_local_args(devid, gd->kernel_green_eq_lavg, sizes, local,
       CLARG(dev_in2), CLARG(dev_out2),
       CLARG(width), CLARG(height), CLARG(filters),
       CLARG(threshold), CLLOCAL(sizeof(float) * (locopt.sizex + 4) * (locopt.sizey + 4)));
-    err = dt_opencl_enqueue_kernel_2d_with_local(devid, gd->kernel_green_eq_lavg, sizes, local);
     if(err != CL_SUCCESS) goto error;
   }
 
@@ -531,10 +527,9 @@ static int process_default_cl(const dt_iop_module_t *self,
 
         const size_t sizes[3] = { ROUNDUP(width, locopt.sizex), ROUNDUP(height, locopt.sizey), 1 };
         const size_t local[3] = { locopt.sizex, locopt.sizey, 1 };
-        dt_opencl_set_kernel_args(devid, gd->kernel_pre_median, 0,
+        err = dt_opencl_enqueue_kernel_2d_local_args(devid, gd->kernel_pre_median, sizes, local,
           CLARG(dev_in), CLARG(dev_med), CLARG(width),
           CLARG(height), CLARG(filters), CLARG(d->median_thrs), CLLOCAL(sizeof(float) * (locopt.sizex + 4) * (locopt.sizey + 4)));
-        err = dt_opencl_enqueue_kernel_2d_with_local(devid, gd->kernel_pre_median, sizes, local);
         if(err != CL_SUCCESS) goto error;
         dev_in = dev_out;
       }
@@ -551,11 +546,9 @@ static int process_default_cl(const dt_iop_module_t *self,
 
         const size_t sizes[3] = { ROUNDUP(width, locopt.sizex), ROUNDUP(height, locopt.sizey), 1 };
         const size_t local[3] = { locopt.sizex, locopt.sizey, 1 };
-        dt_opencl_set_kernel_args(devid, gd->kernel_ppg_green, 0,
+        err = dt_opencl_enqueue_kernel_2d_local_args(devid, gd->kernel_ppg_green, sizes, local,
           CLARG(dev_med), CLARG(dev_tmp), CLARG(width),
           CLARG(height), CLARG(filters), CLLOCAL(sizeof(float) * (locopt.sizex + 2*3) * (locopt.sizey + 2*3)));
-
-        err = dt_opencl_enqueue_kernel_2d_with_local(devid, gd->kernel_ppg_green, sizes, local);
         if(err != CL_SUCCESS) goto error;
       }
 
@@ -570,11 +563,9 @@ static int process_default_cl(const dt_iop_module_t *self,
 
         const size_t sizes[3] = { ROUNDUP(width, locopt.sizex), ROUNDUP(height, locopt.sizey), 1 };
         const size_t local[3] = { locopt.sizex, locopt.sizey, 1 };
-        dt_opencl_set_kernel_args(devid, gd->kernel_ppg_redblue, 0,
+        err = dt_opencl_enqueue_kernel_2d_local_args(devid, gd->kernel_ppg_redblue, sizes, local,
           CLARG(dev_tmp), CLARG(dev_out), CLARG(width),
           CLARG(height), CLARG(filters), CLLOCAL(sizeof(float) * 4 * (locopt.sizex + 2) * (locopt.sizey + 2)));
-
-        err = dt_opencl_enqueue_kernel_2d_with_local(devid, gd->kernel_ppg_redblue, sizes, local);
         if(err != CL_SUCCESS) goto error;
       }
     }

--- a/src/iop/demosaicing/dual.c
+++ b/src/iop/demosaicing/dual.c
@@ -113,13 +113,12 @@ int dual_demosaic_cl(const dt_iop_module_t *self,
 
   const gboolean wboff = !p->dsc.temperature.enabled;
   const dt_aligned_pixel_t wb =
-      { wboff ? 1.0f : p->dsc.temperature.coeffs[0],
-        wboff ? 1.0f : p->dsc.temperature.coeffs[1],
-        wboff ? 1.0f : p->dsc.temperature.coeffs[2] };
+      { wboff ? 1.0f : 1.0f / p->dsc.temperature.coeffs[0],
+        wboff ? 1.0f : 1.0f / p->dsc.temperature.coeffs[1],
+        wboff ? 1.0f : 1.0f / p->dsc.temperature.coeffs[2], 1.0f };
 
   err = dt_opencl_enqueue_kernel_2d_args(devid, darktable.opencl->blendop->kernel_calc_Y0_mask, width, height,
-     CLARG(mask), CLARG(high_image), CLARG(width), CLARG(height),
-     CLARG(wb[0]), CLARG(wb[1]), CLARG(wb[2]));
+     CLARG(mask), CLARG(high_image), CLARG(width), CLARG(height), CLFLARRAY(4, wb));
   if(err != CL_SUCCESS) goto finish;
 
   err = dt_opencl_enqueue_kernel_2d_args(devid, darktable.opencl->blendop->kernel_calc_scharr_mask, width, height,

--- a/src/iop/demosaicing/rcd.c
+++ b/src/iop/demosaicing/rcd.c
@@ -630,10 +630,9 @@ static cl_int process_rcd_cl(dt_iop_module_t *self,
 
     size_t sizes[3] = { ROUNDUP(width, locopt.sizex), ROUNDUP(height, locopt.sizey), 1 };
     size_t local[3] = { locopt.sizex, locopt.sizey, 1 };
-    dt_opencl_set_kernel_args(devid, gd->kernel_rcd_border_green, 0, CLARG(dev_in), CLARG(dev_tmp),
-        CLARG(width), CLARG(height), CLARG(filters), CLLOCAL(sizeof(float) * (locopt.sizex + 2*3) * (locopt.sizey + 2*3)),
-        CLARGINT(32));
-    err = dt_opencl_enqueue_kernel_2d_with_local(devid, gd->kernel_rcd_border_green, sizes, local);
+    err = dt_opencl_enqueue_kernel_2d_local_args(devid, gd->kernel_rcd_border_green, sizes, local,
+        CLARG(dev_in), CLARG(dev_tmp), CLARG(width), CLARG(height), CLARG(filters),
+        CLLOCAL(sizeof(float) * (locopt.sizex + 2*3) * (locopt.sizey + 2*3)), CLARGINT(32));
     if(err != CL_SUCCESS) goto error;
   }
 
@@ -648,10 +647,9 @@ static cl_int process_rcd_cl(dt_iop_module_t *self,
 
     size_t sizes[3] = { ROUNDUP(width, locopt.sizex), ROUNDUP(height, locopt.sizey), 1 };
     size_t local[3] = { locopt.sizex, locopt.sizey, 1 };
-    dt_opencl_set_kernel_args(devid, gd->kernel_rcd_border_redblue, 0, CLARG(dev_tmp), CLARG(dev_out),
-      CLARG(width), CLARG(height), CLARG(filters), CLLOCAL(sizeof(float) * 4 * (locopt.sizex + 2) * (locopt.sizey + 2)),
-      CLARGINT(16));
-    err = dt_opencl_enqueue_kernel_2d_with_local(devid, gd->kernel_rcd_border_redblue, sizes, local);
+    err = dt_opencl_enqueue_kernel_2d_local_args(devid, gd->kernel_rcd_border_redblue, sizes, local,
+      CLARG(dev_tmp), CLARG(dev_out), CLARG(width), CLARG(height), CLARG(filters),
+      CLLOCAL(sizeof(float) * 4 * (locopt.sizex + 2) * (locopt.sizey + 2)), CLARGINT(16));
     if(err != CL_SUCCESS) goto error;
   }
   dt_opencl_release_mem_object(dev_tmp);

--- a/src/iop/demosaicing/vng.c
+++ b/src/iop/demosaicing/vng.c
@@ -338,7 +338,7 @@ static cl_int process_vng_cl(const dt_iop_module_t *self,
 {
   const dt_iop_demosaic_global_data_t *gd = self->global_data;
   const gboolean is_xtrans = (filters == 9u);
- 
+
   // separate out G1 and G2 in Bayer patterns
   uint32_t filters4;
   if(is_xtrans)
@@ -487,13 +487,12 @@ static cl_int process_vng_cl(const dt_iop_module_t *self,
 
     size_t sizes[3] = { ROUNDUP(width, locopt.sizex), ROUNDUP(height, locopt.sizey), 1 };
     size_t local[3] = { locopt.sizex, locopt.sizey, 1 };
-    dt_opencl_set_kernel_args(devid, gd->kernel_vng_lin_interpolate, 0,
+    err = dt_opencl_enqueue_kernel_2d_local_args(devid, gd->kernel_vng_lin_interpolate, sizes, local,
         CLARG(dev_in), CLARG(tmp_out),
         CLARG(width), CLARG(height), CLARG(border),
         CLARG(filters4), CLARG(dev_xtrans), CLARG(dev_lookup),
         CLLOCAL(sizeof(float) * (locopt.sizex + 2) * (locopt.sizey + 2)),
         CLARG(only_vng_linear));
-    err = dt_opencl_enqueue_kernel_2d_with_local(devid, gd->kernel_vng_lin_interpolate, sizes, local);
     if(err != CL_SUCCESS) goto finish;
   }
 
@@ -511,11 +510,10 @@ static cl_int process_vng_cl(const dt_iop_module_t *self,
 
   size_t sizes[3] = { ROUNDUP(width, locopt.sizex), ROUNDUP(height, locopt.sizey), 1 };
   size_t local[3] = { locopt.sizex, locopt.sizey, 1 };
-  dt_opencl_set_kernel_args(devid, gd->kernel_vng_interpolate, 0,
+  err = dt_opencl_enqueue_kernel_2d_local_args(devid, gd->kernel_vng_interpolate, sizes, local,
         CLARG(dev_in), CLARG(dev_tmp), CLARG(dev_out),
         CLARG(width), CLARG(height), CLARG(filters4),
         CLARG(dev_xtrans), CLARG(dev_ips), CLARG(dev_code), CLLOCAL(sizeof(float) * 4 * (locopt.sizex + 4) * (locopt.sizey + 4)));
-  err = dt_opencl_enqueue_kernel_2d_with_local(devid, gd->kernel_vng_interpolate, sizes, local);
 
 finish:
   dt_opencl_release_mem_object(dev_tmp);

--- a/src/iop/demosaicing/xtrans.c
+++ b/src/iop/demosaicing/xtrans.c
@@ -1737,11 +1737,10 @@ static cl_int process_markesteijn_cl(const dt_iop_module_t *self,
     {
       const size_t sizes[3] = { ROUNDUP(width, locopt_g1_g3.sizex), ROUNDUP(height, locopt_g1_g3.sizey), 1 };
       const size_t local[3] = { locopt_g1_g3.sizex, locopt_g1_g3.sizey, 1 };
-      dt_opencl_set_kernel_args(devid, gd->kernel_markesteijn_green_minmax, 0,
+      err = dt_opencl_enqueue_kernel_2d_local_args(devid, gd->kernel_markesteijn_green_minmax, sizes, local,
         CLARG(dev_rgb[0]), CLARG(dev_gminmax),
         CLARG(width), CLARG(height), CLARGINT(PAD_G1_G3), CLARRAY(2, sgreen),
         CLARG(dev_xtrans), CLARG(dev_allhex), CLLOCAL(sizeof(float) * (locopt_g1_g3.sizex + 2*3) * (locopt_g1_g3.sizey + 2*3)));
-      err = dt_opencl_enqueue_kernel_2d_with_local(devid, gd->kernel_markesteijn_green_minmax, sizes, local);
       if(err != CL_SUCCESS) goto error;
     }
 
@@ -1757,12 +1756,11 @@ static cl_int process_markesteijn_cl(const dt_iop_module_t *self,
     {
       const size_t sizes[3] = { ROUNDUP(width, locopt_g_interp.sizex), ROUNDUP(height, locopt_g_interp.sizey), 1 };
       const size_t local[3] = { locopt_g_interp.sizex, locopt_g_interp.sizey, 1 };
-      dt_opencl_set_kernel_args(devid, gd->kernel_markesteijn_interpolate_green, 0,
+      err = dt_opencl_enqueue_kernel_2d_local_args(devid, gd->kernel_markesteijn_interpolate_green, sizes, local,
         CLARG(dev_rgb[0]), CLARG(dev_rgb[1]), CLARG(dev_rgb[2]), CLARG(dev_rgb[3]),
         CLARG(dev_gminmax), CLARG(width), CLARG(height),
         CLARGINT(PAD_G_INTERP), CLARRAY(2, sgreen), CLARG(dev_xtrans),
         CLARG(dev_allhex), CLLOCAL(sizeof(float) * 4 * (locopt_g_interp.sizex + 2*6) * (locopt_g_interp.sizey + 2*6)));
-      err = dt_opencl_enqueue_kernel_2d_with_local(devid, gd->kernel_markesteijn_interpolate_green, sizes, local);
       if(err != CL_SUCCESS) goto error;
     }
 
@@ -1812,10 +1810,9 @@ static cl_int process_markesteijn_cl(const dt_iop_module_t *self,
         // we use dev_aux to transport intermediate results from one loop run to the next
         const size_t sizes[3] = { ROUNDUP(width, locopt_rb_g.sizex), ROUNDUP(height, locopt_rb_g.sizey), 1 };
         const size_t local[3] = { locopt_rb_g.sizex, locopt_rb_g.sizey, 1 };
-        dt_opencl_set_kernel_args(devid, gd->kernel_markesteijn_solitary_green, 0,
+        err = dt_opencl_enqueue_kernel_2d_local_args(devid, gd->kernel_markesteijn_solitary_green, sizes, local,
           CLARG(dev_trgb[0]), CLARG(dev_aux), CLARG(width), CLARG(height), CLARG(pad_rb_g),
           CLARG(d), CLARRAY(2, dir), CLARG(h), CLARRAY(2, sgreen), CLARG(dev_xtrans), CLLOCAL(sizeof(float) * 4 * (locopt_rb_g.sizex + 2*2) * (locopt_rb_g.sizey + 2*2)));
-        err = dt_opencl_enqueue_kernel_2d_with_local(devid, gd->kernel_markesteijn_solitary_green, sizes, local);
         if(err != CL_SUCCESS) goto error;
 
         if((d < 2) || (d & 1)) dev_trgb++;
@@ -1835,10 +1832,9 @@ static cl_int process_markesteijn_cl(const dt_iop_module_t *self,
       {
         const size_t sizes[3] = { ROUNDUP(width, locopt_rb_br.sizex), ROUNDUP(height, locopt_rb_br.sizey), 1 };
         const size_t local[3] = { locopt_rb_br.sizex, locopt_rb_br.sizey, 1 };
-        dt_opencl_set_kernel_args(devid, gd->kernel_markesteijn_red_and_blue, 0,
+        err = dt_opencl_enqueue_kernel_2d_local_args(devid, gd->kernel_markesteijn_red_and_blue, sizes, local,
           CLARG(dev_rgb[d]), CLARG(width), CLARG(height), CLARG(pad_rb_br), CLARG(d), CLARRAY(2, sgreen),
           CLARG(dev_xtrans), CLLOCAL(sizeof(float) * 4 * (locopt_rb_br.sizex + 2*3) * (locopt_rb_br.sizey + 2*3)));
-        err = dt_opencl_enqueue_kernel_2d_with_local(devid, gd->kernel_markesteijn_red_and_blue, sizes, local);
         if(err != CL_SUCCESS) goto error;
       }
 
@@ -1856,10 +1852,9 @@ static cl_int process_markesteijn_cl(const dt_iop_module_t *self,
       {
         const size_t sizes[3] = { ROUNDUP(width, locopt_g22.sizex), ROUNDUP(height, locopt_g22.sizey), 1 };
         const size_t local[3] = { locopt_g22.sizex, locopt_g22.sizey, 1 };
-        dt_opencl_set_kernel_args(devid, gd->kernel_markesteijn_interpolate_twoxtwo, 0,
+        err = dt_opencl_enqueue_kernel_2d_local_args(devid, gd->kernel_markesteijn_interpolate_twoxtwo, sizes, local,
           CLARG(dev_rgb[n]), CLARG(width), CLARG(height), CLARG(pad_g22), CLARG(d), CLARRAY(2, sgreen),
           CLARG(dev_xtrans), CLARG(dev_allhex), CLLOCAL(sizeof(float) * 4 * (locopt_g22.sizex + 2*2) * (locopt_g22.sizey + 2*2)));
-        err = dt_opencl_enqueue_kernel_2d_with_local(devid, gd->kernel_markesteijn_interpolate_twoxtwo, sizes, local);
         if(err != CL_SUCCESS) goto error;
       }
     }
@@ -1901,10 +1896,9 @@ static cl_int process_markesteijn_cl(const dt_iop_module_t *self,
       // differentiate in all directions
       const size_t sizes_diff[3] = { ROUNDUP(width, locopt_diff.sizex), ROUNDUP(height, locopt_diff.sizey), 1 };
       const size_t local_diff[3] = { locopt_diff.sizex, locopt_diff.sizey, 1 };
-      dt_opencl_set_kernel_args(devid, gd->kernel_markesteijn_differentiate, 0,
+      err = dt_opencl_enqueue_kernel_2d_local_args(devid, gd->kernel_markesteijn_differentiate, sizes_diff, local_diff,
         CLARG(dev_aux), CLARG(dev_drv[d]),
         CLARG(width), CLARG(height), CLARG(pad_yuv), CLARG(d), CLLOCAL(sizeof(float) * 4 * (locopt_diff.sizex + 2*1) * (locopt_diff.sizey + 2*1)));
-      err = dt_opencl_enqueue_kernel_2d_with_local(devid, gd->kernel_markesteijn_differentiate, sizes_diff, local_diff);
       if(err != CL_SUCCESS) goto error;
     }
 
@@ -1942,10 +1936,9 @@ static cl_int process_markesteijn_cl(const dt_iop_module_t *self,
     {
       const size_t sizes[3] = { ROUNDUP(width, locopt_homo.sizex),ROUNDUP(height, locopt_homo.sizey), 1 };
       const size_t local[3] = { locopt_homo.sizex, locopt_homo.sizey, 1 };
-      dt_opencl_set_kernel_args(devid, gd->kernel_markesteijn_homo_set, 0,
+      err = dt_opencl_enqueue_kernel_2d_local_args(devid, gd->kernel_markesteijn_homo_set, sizes, local,
         CLARG(dev_drv[d]), CLARG(dev_aux),
         CLARG(dev_homo[d]), CLARG(width), CLARG(height), CLARG(pad_homo), CLLOCAL(sizeof(float) * (locopt_homo.sizex + 2*1) * (locopt_homo.sizey + 2*1)));
-      err = dt_opencl_enqueue_kernel_2d_with_local(devid, gd->kernel_markesteijn_homo_set, sizes, local);
       if(err != CL_SUCCESS) goto error;
     }
 
@@ -1969,10 +1962,9 @@ static cl_int process_markesteijn_cl(const dt_iop_module_t *self,
     {
       size_t sizes[3] = { ROUNDUP(width, locopt_homo_sum.sizex), ROUNDUP(height, locopt_homo_sum.sizey), 1 };
       size_t local[3] = { locopt_homo_sum.sizex, locopt_homo_sum.sizey, 1 };
-      dt_opencl_set_kernel_args(devid, gd->kernel_markesteijn_homo_sum, 0,
+      err = dt_opencl_enqueue_kernel_2d_local_args(devid, gd->kernel_markesteijn_homo_sum, sizes, local,
         CLARG(dev_homo[d]), CLARG(dev_homosum[d]),
         CLARG(width), CLARG(height), CLARG(pad_tile), CLLOCAL(sizeof(char) * (locopt_homo_sum.sizex + 2*2) * (locopt_homo_sum.sizey + 2*2)));
-      err = dt_opencl_enqueue_kernel_2d_with_local(devid, gd->kernel_markesteijn_homo_sum, sizes, local);
       if(err != CL_SUCCESS) goto error;
     }
 

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -2526,9 +2526,7 @@ static int process_wavelets_cl(dt_iop_module_t *self,
     err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_denoiseprofile_synthesize, width, height,
                               CLARG(dev_buf1), CLARG(dev_detail[s]),
                               CLARG(dev_buf2), CLARG(width), CLARG(height),
-                              CLARG(thrs[0]), CLARG(thrs[1]), CLARG(thrs[2]),
-                              CLARG(thrs[3]), CLARG(boost[0]), CLARG(boost[1]),
-                              CLARG(boost[2]), CLARG(boost[3]));
+                              CLFLARRAY(4, thrs), CLFLARRAY(4, boost));
     if(err != CL_SUCCESS) goto error;
 
     // swap buffers

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -2011,11 +2011,11 @@ static int process_nlmeans_cl(dt_iop_module_t *self,
   if(!d->use_new_vst)
     err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_denoiseprofile_precondition, width, height,
             CLARG(dev_in), CLARG(dev_tmp),
-            CLARG(width), CLARG(height), CLARG(aa), CLARG(sigma2));      
+            CLARG(width), CLARG(height), CLARG(aa), CLARG(sigma2));
   else
     err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_denoiseprofile_precondition_v2, width, height,
             CLARG(dev_in), CLARG(dev_tmp),
-            CLARG(width), CLARG(height), CLARG(aa), CLARG(p), CLARG(bb), CLARG(wb));      
+            CLARG(width), CLARG(height), CLARG(aa), CLARG(p), CLARG(bb), CLARG(wb));
   if(err != CL_SUCCESS) goto final;
 
 #if USE_NEW_IMPL_CL
@@ -2126,13 +2126,10 @@ static int process_nlmeans_cl(dt_iop_module_t *self,
       local[1] = 1;
       local[2] = 1;
       cl_mem dev_U4_t = buckets[bucket_next(&state, NUM_BUCKETS)];
-      dt_opencl_set_kernel_args(devid, gd->kernel_denoiseprofile_horiz,
-                                0, CLARG(dev_U4), CLARG(dev_U4_t),
-                                CLARG(width), CLARG(height), CLARG(q), CLARG(P),
-                                CLLOCAL(sizeof(float) * (hblocksize + 2 * P)));
-      err = dt_opencl_enqueue_kernel_2d_with_local(devid,
-                                                   gd->kernel_denoiseprofile_horiz,
-                                                   sizesl, local);
+      err = dt_opencl_enqueue_kernel_2d_local_args(devid, gd->kernel_denoiseprofile_horiz, sizesl, local,
+                CLARG(dev_U4), CLARG(dev_U4_t),
+                CLARG(width), CLARG(height), CLARG(q), CLARG(P),
+                CLLOCAL(sizeof(float) * (hblocksize + 2 * P)));
       if(err != CL_SUCCESS) goto error;
 
       sizesl[0] = ROUNDUPDWD(width, devid);
@@ -2142,20 +2139,17 @@ static int process_nlmeans_cl(dt_iop_module_t *self,
       local[1] = vblocksize;
       local[2] = 1;
       cl_mem dev_U4_tt = buckets[bucket_next(&state, NUM_BUCKETS)];
-      dt_opencl_set_kernel_args(devid, gd->kernel_denoiseprofile_vert,
-                                0, CLARG(dev_U4_t), CLARG(dev_U4_tt),
-                                CLARG(width), CLARG(height),
-                                CLARG(q), CLARG(P), CLARG(norm),
-                                CLLOCAL(sizeof(float) * (vblocksize + 2 * P)),
-                                CLARG(central_pixel_weight), CLARG(dev_U4));
-      err = dt_opencl_enqueue_kernel_2d_with_local(devid,
-                                                   gd->kernel_denoiseprofile_vert,
-                                                   sizesl, local);
+      err = dt_opencl_enqueue_kernel_2d_local_args(devid, gd->kernel_denoiseprofile_vert, sizesl, local,
+              CLARG(dev_U4_t), CLARG(dev_U4_tt),
+              CLARG(width), CLARG(height),
+              CLARG(q), CLARG(P), CLARG(norm),
+              CLLOCAL(sizeof(float) * (vblocksize + 2 * P)),
+              CLARG(central_pixel_weight), CLARG(dev_U4));
       if(err != CL_SUCCESS) goto error;
 
       err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_denoiseprofile_accu, width, height,
                           CLARG(dev_tmp), CLARG(dev_U2), CLARG(dev_U4_tt),
-                          CLARG(width), CLARG(height), CLARG(q));        
+                          CLARG(width), CLARG(height), CLARG(q));
       if(err != CL_SUCCESS) goto error;
       dt_opencl_finish_sync_pipe(devid, piece->pipe->type);
     }
@@ -2371,12 +2365,12 @@ static int process_wavelets_cl(dt_iop_module_t *self,
   if(!d->use_new_vst)
   {
     err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_denoiseprofile_precondition, width, height,
-            CLARG(dev_in), CLARG(dev_out), CLARG(width), CLARG(height), CLARG(aa), CLARG(sigma2));    
+            CLARG(dev_in), CLARG(dev_out), CLARG(width), CLARG(height), CLARG(aa), CLARG(sigma2));
   }
   else if(d->wavelet_color_mode == MODE_RGB)
   {
     err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_denoiseprofile_precondition_v2, width, height,
-            CLARG(dev_in), CLARG(dev_out), CLARG(width), CLARG(height), CLARG(aa), CLARG(p), CLARG(bb), CLARG(wb));      
+            CLARG(dev_in), CLARG(dev_out), CLARG(width), CLARG(height), CLARG(aa), CLARG(p), CLARG(bb), CLARG(wb));
   }
   else
   {
@@ -2404,7 +2398,7 @@ static int process_wavelets_cl(dt_iop_module_t *self,
     err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_denoiseprofile_decompose, width, height,
             CLARG(dev_buf1), CLARG(dev_buf2),
             CLARG(dev_detail[s]), CLARG(width), CLARG(height),
-            CLARG(s), CLARG(inv_sigma2), CLARG(dev_filter));      
+            CLARG(s), CLARG(inv_sigma2), CLARG(dev_filter));
     if(err != CL_SUCCESS) goto error;
 
     // swap buffers
@@ -2434,14 +2428,11 @@ static int process_wavelets_cl(dt_iop_module_t *self,
     llocal[0] = flocopt.sizex;
     llocal[1] = flocopt.sizey;
     llocal[2] = 1;
-    dt_opencl_set_kernel_args(devid, gd->kernel_denoiseprofile_reduce_first, 0,
+    err = dt_opencl_enqueue_kernel_2d_local_args(devid, gd->kernel_denoiseprofile_reduce_first, lsizes, llocal,
                               CLARG((dev_detail[s])),
                               CLARG(width), CLARG(height),
                               CLARG(dev_m),
                               CLLOCAL(sizeof(float) * 4 * flocopt.sizex * flocopt.sizey));
-    err = dt_opencl_enqueue_kernel_2d_with_local(devid,
-                                                 gd->kernel_denoiseprofile_reduce_first,
-                                                 lsizes, llocal);
     if(err != CL_SUCCESS) goto error;
 
 
@@ -2451,12 +2442,9 @@ static int process_wavelets_cl(dt_iop_module_t *self,
     llocal[0] = slocopt.sizex;
     llocal[1] = 1;
     llocal[2] = 1;
-    dt_opencl_set_kernel_args(devid, gd->kernel_denoiseprofile_reduce_second, 0,
+    err = dt_opencl_enqueue_kernel_2d_local_args(devid, gd->kernel_denoiseprofile_reduce_second, lsizes, llocal,
                               CLARG(dev_m), CLARG(dev_r),
                               CLARG(bufsize), CLLOCAL(sizeof(float) * 4 * slocopt.sizex));
-    err = dt_opencl_enqueue_kernel_2d_with_local(devid,
-                                                 gd->kernel_denoiseprofile_reduce_second,
-                                                 lsizes, llocal);
     if(err != CL_SUCCESS) goto error;
 
     err = dt_opencl_read_buffer_from_device(devid, (void *)sumsum, dev_r, 0,
@@ -2540,7 +2528,7 @@ static int process_wavelets_cl(dt_iop_module_t *self,
                               CLARG(dev_buf2), CLARG(width), CLARG(height),
                               CLARG(thrs[0]), CLARG(thrs[1]), CLARG(thrs[2]),
                               CLARG(thrs[3]), CLARG(boost[0]), CLARG(boost[1]),
-                              CLARG(boost[2]), CLARG(boost[3]));      
+                              CLARG(boost[2]), CLARG(boost[3]));
     if(err != CL_SUCCESS) goto error;
 
     // swap buffers

--- a/src/iop/globaltonemap.c
+++ b/src/iop/globaltonemap.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2012-2024 darktable developers.
+    Copyright (C) 2012-2026 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -412,24 +412,22 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
 
       sizes[0] = bwidth;
       sizes[1] = bheight;
-      sizes[2] = 1;
       local[0] = flocopt.sizex;
       local[1] = flocopt.sizey;
       local[2] = 1;
-      dt_opencl_set_kernel_args(devid, gd->kernel_pixelmax_first, 0, CLARG(dev_in), CLARG(width), CLARG(height),
+      err = dt_opencl_enqueue_kernel_2d_local_args(devid, gd->kernel_pixelmax_first, sizes, local,
+        CLARG(dev_in), CLARG(width), CLARG(height),
         CLARG(dev_m), CLLOCAL(sizeof(float) * flocopt.sizex * flocopt.sizey));
-      err = dt_opencl_enqueue_kernel_2d_with_local(devid, gd->kernel_pixelmax_first, sizes, local);
       if(err != CL_SUCCESS) goto finally;
 
       sizes[0] = (size_t)reducesize * slocopt.sizex;
       sizes[1] = 1;
-      sizes[2] = 1;
       local[0] = slocopt.sizex;
       local[1] = 1;
       local[2] = 1;
-      dt_opencl_set_kernel_args(devid, gd->kernel_pixelmax_second, 0, CLARG(dev_m), CLARG(dev_r), CLARG(bufsize),
+      err = dt_opencl_enqueue_kernel_2d_local_args(devid, gd->kernel_pixelmax_second, sizes, local,
+        CLARG(dev_m), CLARG(dev_r), CLARG(bufsize),
         CLLOCAL(sizeof(float) * slocopt.sizex));
-      err = dt_opencl_enqueue_kernel_2d_with_local(devid, gd->kernel_pixelmax_second, sizes, local);
       if(err != CL_SUCCESS) goto finally;
 
       maximum = dt_alloc_align_float((size_t)reducesize);

--- a/src/iop/hazeremoval.c
+++ b/src/iop/hazeremoval.c
@@ -817,8 +817,7 @@ static int _dehaze_cl(dt_iop_module_t *self,
   return dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_hazeremoval_dehaze, width, height,
                                           CLARG(width), CLARG(height),
                                           CLARG(img_in), CLARG(trans_map),
-                                          CLARG(img_out), CLARG(t_min),
-                                          CLARG(A0[0]), CLARG(A0[1]), CLARG(A0[2]));
+                                          CLARG(img_out), CLARG(t_min), CLFLARRAY(4, A0));
 }
 
 void tiling_callback(dt_iop_module_t *self,

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -640,12 +640,11 @@ int process_cl(dt_iop_module_t *self,
 
     size_t sizes[] = { ROUNDUP(roi_in->width, blocksizex), ROUNDUP(roi_in->height, blocksizey), 1 };
     size_t local[] = { blocksizex, blocksizey, 1 };
-    dt_opencl_set_kernel_args(devid, gd->kernel_highlights_1f_lch_xtrans, 0,
+    err = dt_opencl_enqueue_kernel_2d_local_args(devid, gd->kernel_highlights_1f_lch_xtrans, sizes, local,
       CLARG(dev_in), CLARG(dev_out),
       CLARG(roi_in->width), CLARG(roi_in->height),
       CLARG(clip), CLARG(dev_xtrans),
       CLLOCAL(sizeof(float) * (blocksizex + 4) * (blocksizey + 4)));
-    err = dt_opencl_enqueue_kernel_2d_with_local(devid, gd->kernel_highlights_1f_lch_xtrans, sizes, local);
   }
   else if(dmode == DT_IOP_HIGHLIGHTS_LAPLACIAN)
   {

--- a/src/iop/profile_gamma.c
+++ b/src/iop/profile_gamma.c
@@ -221,18 +221,14 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
   cl_mem dev_table = NULL;
   cl_mem dev_coeffs = NULL;
 
-
-  size_t sizes[3] = { ROUNDUPDWD(width, devid), ROUNDUPDHT(height, devid), 1 };
-
   if(d->mode == PROFILEGAMMA_LOG)
   {
     const float dynamic_range = d->dynamic_range;
     const float shadows_range = d->shadows_range;
     const float grey = d->grey_point / 100.0f;
-    dt_opencl_set_kernel_args(devid, gd->kernel_profilegamma_log, 0, CLARG(dev_in), CLARG(dev_out),
+    err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_profilegamma_log, width, height,
+      CLARG(dev_in), CLARG(dev_out),
       CLARG(width), CLARG(height), CLARG(dynamic_range), CLARG(shadows_range), CLARG(grey));
-
-    err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_profilegamma_log, sizes);
   }
   else if(d->mode == PROFILEGAMMA_GAMMA)
   {
@@ -242,10 +238,9 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
     dev_coeffs = dt_opencl_copy_host_to_device_constant(devid, sizeof(float) * 3, d->unbounded_coeffs);
     if(dev_coeffs == NULL) goto error;
 
-    dt_opencl_set_kernel_args(devid, gd->kernel_profilegamma, 0, CLARG(dev_in), CLARG(dev_out), CLARG(width),
+    err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_profilegamma, width, height,
+      CLARG(dev_in), CLARG(dev_out), CLARG(width),
       CLARG(height), CLARG(dev_table), CLARG(dev_coeffs));
-
-    err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_profilegamma, sizes);
   }
 
 error:

--- a/src/iop/rawoverexposed.c
+++ b/src/iop/rawoverexposed.c
@@ -1,6 +1,6 @@
 /*
    This file is part of darktable,
-   Copyright (C) 2016-2025 darktable developers.
+   Copyright (C) 2016-2026 darktable developers.
 
    darktable is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -327,19 +327,20 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
   dev_thresholds = dt_opencl_copy_host_to_device_constant(devid, sizeof(unsigned int) * 4, (void *)d->threshold);
   if(dev_thresholds == NULL) goto error;
 
-  size_t sizes[2] = { ROUNDUPDWD(width, devid), ROUNDUPDHT(height, devid) };
-  dt_opencl_set_kernel_args(devid, kernel, 0,
-    CLARG(dev_in), CLARG(dev_out), CLARG(dev_coord),
-    CLARG(width), CLARG(height),
-    CLARG(dev_raw), CLARG(raw_width), CLARG(raw_height), CLARG(filters), CLARG(dev_xtrans),
-    CLARG(dev_thresholds));
-
   if(dev->rawoverexposed.mode == DT_DEV_RAWOVEREXPOSED_MODE_MARK_CFA)
-    dt_opencl_set_kernel_args(devid, kernel, 11, CLARG(dev_colors));
+    err = dt_opencl_enqueue_kernel_2d_args(devid, kernel, width, height,
+              CLARG(dev_in), CLARG(dev_out), CLARG(dev_coord),
+              CLARG(width), CLARG(height),
+              CLARG(dev_raw), CLARG(raw_width), CLARG(raw_height), CLARG(filters), CLARG(dev_xtrans),
+              CLARG(dev_thresholds),
+              CLARG(dev_colors));
   else if(dev->rawoverexposed.mode == DT_DEV_RAWOVEREXPOSED_MODE_MARK_SOLID)
-    dt_opencl_set_kernel_args(devid, kernel, 11, CLFLARRAY(4, color));
-
-  err = dt_opencl_enqueue_kernel_2d(devid, kernel, sizes);
+     err = dt_opencl_enqueue_kernel_2d_args(devid, kernel, width, height,
+              CLARG(dev_in), CLARG(dev_out), CLARG(dev_coord),
+              CLARG(width), CLARG(height),
+              CLARG(dev_raw), CLARG(raw_width), CLARG(raw_height), CLARG(filters), CLARG(dev_xtrans),
+              CLARG(dev_thresholds),
+              CLFLARRAY(4, color));
 
 error:
   dt_opencl_release_mem_object(dev_xtrans);

--- a/src/iop/soften.c
+++ b/src/iop/soften.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2011-2025 darktable developers.
+    Copyright (C) 2011-2026 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -243,8 +243,7 @@ int process_cl(dt_iop_module_t *self,
   dev_m = dt_opencl_copy_host_to_device_constant(devid, mat_size, mat);
   if(dev_m == NULL) goto error;
 
-  err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_soften_overexposed,
-                                         width, height,
+  err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_soften_overexposed, width, height,
     CLARG(dev_in), CLARG(dev_tmp),
     CLARG(width), CLARG(height), CLARG(saturation), CLARG(brightness));
   if(err != CL_SUCCESS) goto error;
@@ -258,12 +257,10 @@ int process_cl(dt_iop_module_t *self,
     local[0] = hblocksize;
     local[1] = 1;
     local[2] = 1;
-    dt_opencl_set_kernel_args(devid, gd->kernel_soften_hblur, 0,
+    err = dt_opencl_enqueue_kernel_2d_local_args(devid, gd->kernel_soften_hblur, sizes, local,
                               CLARG(dev_tmp), CLARG(dev_out), CLARG(dev_m),
                               CLARG(wdh), CLARG(width), CLARG(height), CLARG(hblocksize),
                               CLLOCAL((hblocksize + 2 * wdh) * 4 * sizeof(float)));
-    err = dt_opencl_enqueue_kernel_2d_with_local(devid, gd->kernel_soften_hblur,
-                                                 sizes, local);
     if(err != CL_SUCCESS) goto error;
 
 
@@ -274,9 +271,9 @@ int process_cl(dt_iop_module_t *self,
     local[0] = 1;
     local[1] = vblocksize;
     local[2] = 1;
-    dt_opencl_set_kernel_args(devid, gd->kernel_soften_vblur, 0, CLARG(dev_out), CLARG(dev_tmp), CLARG(dev_m),
+    err = dt_opencl_enqueue_kernel_2d_local_args(devid, gd->kernel_soften_vblur, sizes, local,
+      CLARG(dev_out), CLARG(dev_tmp), CLARG(dev_m),
       CLARG(wdh), CLARG(width), CLARG(height), CLARG(vblocksize), CLLOCAL((vblocksize + 2 * wdh) * 4 * sizeof(float)));
-    err = dt_opencl_enqueue_kernel_2d_with_local(devid, gd->kernel_soften_vblur, sizes, local);
     if(err != CL_SUCCESS) goto error;
   }
 


### PR DESCRIPTION
1. b4ea5351de867063b86c0748b7a585caf4d73657 introduces `dt_opencl_enqueue_kernel_2d_local_args()` as an equivalent to `dt_opencl_enqueue_kernel_2d_args()`  for improved readability
2. 84ad991dd742c203d3446bc7d377794b6994d9a7 makes use of above macro
3. In 108965627326e45059eb879d2ae2811fcb2c2cc9 we have various minor OpenCL kernel improvements with subtle performance gains or maintenance by using available functions.
4. 9a7631e5e9a756e2295ea554c4a1e94cf1ccd8b5 will help to investigate performance issues related to host<->cldevice memory interactions.