### PR TITLE
Fix blending log

### DIFF
--- a/src/common/guided_filter.c
+++ b/src/common/guided_filter.c
@@ -489,7 +489,8 @@ static int _guided_filter_cl_impl(int devid,
   const float advantage = hint > 1.0f ? 1.0f / hint : 0.1f;
   const gboolean possible = ((float)valid_rows / (float)tile_height) > advantage;
 
-  dt_print(DT_DEBUG_PIPE | DT_DEBUG_TILING,
+  if(tiling || (darktable.unmuted & DT_DEBUG_VERBOSE))
+    dt_print(DT_DEBUG_PIPE | DT_DEBUG_TILING,
       "[guided CL_%d filter] %s tile_height=%d tiles=%d valid=%d overlap=%d",
       devid,
       !possible ? "impossible" : (tiling ? "tiling" : "direct"),
@@ -549,7 +550,8 @@ static int _guided_filter_cl_impl(int devid,
     const int first_out = overlap - missing;
     const int out_height = t_height - first_out;
 
-    dt_print(DT_DEBUG_TILING,
+    if(tiling)
+      dt_print(DT_DEBUG_TILING,
             "[guided CL_%d filter] tile=%.3d/%.3d, group=%.4d first_in=%.4d last_in=%.4d outrows=%.4d trows=%.4d",
              devid, tile_nr, num_tiles, group, first_in, last_in, out_height, t_height);
 

--- a/src/develop/blend.c
+++ b/src/develop/blend.c
@@ -447,6 +447,7 @@ static const char *_develop_blend_colorspace_to_str(const dt_develop_blend_color
   }
 }
 
+/* we test in pixelpipe processing if this required */
 void dt_develop_blend_process(dt_iop_module_t *self,
                               dt_dev_pixelpipe_iop_t *piece,
                               const void *const ivoid,
@@ -454,15 +455,8 @@ void dt_develop_blend_process(dt_iop_module_t *self,
                               const dt_iop_roi_t *const roi_in,
                               const dt_iop_roi_t *const roi_out)
 {
-  if(piece->pipe->bypass_blendif && dt_iop_has_focus(self))
-    return;
-
-  const dt_develop_blend_params_t *const d = piece->blendop_data;
-  if(!d) return;
-
+  dt_develop_blend_params_t *const d = piece->blendop_data;
   const dt_develop_mask_mode_t mask_mode = d->mask_mode;
-  // check if blend is disabled
-  if(!(mask_mode & DEVELOP_MASK_ENABLED)) return;
 
   const gboolean raster = mask_mode & DEVELOP_MASK_RASTER;
   const gboolean mode_drawn = mask_mode & DEVELOP_MASK_MASK;
@@ -858,6 +852,7 @@ static inline void _blend_process_cl_exchange(cl_mem *a, cl_mem *b)
   *b = tmp;
 }
 
+/* we test in pixelpipe processing if this required */
 gboolean dt_develop_blend_process_cl(dt_iop_module_t *self,
                                      dt_dev_pixelpipe_iop_t *piece,
                                      cl_mem dev_in,
@@ -865,15 +860,8 @@ gboolean dt_develop_blend_process_cl(dt_iop_module_t *self,
                                      const dt_iop_roi_t *roi_in,
                                      const dt_iop_roi_t *roi_out)
 {
-  if(piece->pipe->bypass_blendif && dt_iop_has_focus(self))
-    return TRUE;
-
   dt_develop_blend_params_t *const d = piece->blendop_data;
-  if(!d) return TRUE;
-
   const dt_develop_mask_mode_t mask_mode = d->mask_mode;
-  // check if blend is disabled: just return, output is already in dev_out
-  if(!(mask_mode & DEVELOP_MASK_ENABLED)) return TRUE;
 
   const size_t ch = piece->colors;           // the number of channels in the buffer
   const int owidth = roi_out->width;


### PR DESCRIPTION
1. If we use the -d perf option we want correct reports if there was and blending. We test for requested blending in pixelpipe code now.
2. The OpenCL guided filter internal tiling had some superfluous log info that was used when implementing the code.