### PR TITLE
[Nightly] Fix lensfun-update-data

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -167,6 +167,7 @@ jobs:
           popd
       - name: Update Lensfun data
         run: |
+          sudo sed -i 's/lensfun.sourceforge.net/lensfun.github.io/' $(which lensfun-update-data)
           sudo lensfun-update-data
       - name: Build and Install
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -167,6 +167,7 @@ jobs:
           popd
       - name: Update Lensfun data
         run: |
+          sudo sed -i 's/wilson.bronger.org\/lensfun-db/lensfun.github.io\/db/' $(which lensfun-update-data)
           sudo sed -i 's/lensfun.sourceforge.net/lensfun.github.io/' $(which lensfun-update-data)
           sudo lensfun-update-data
       - name: Build and Install


### PR DESCRIPTION
This fix forces lensfun-update-data to work with a reliable (hosted on GitHub Pages) server, removing attempts to connect to the sourceforge server (which is less reliable) and a private backup server that is currently unavailable and which causes data updates by this script to fail.

@TurboGit - It would be good to merge this ASAP, the last two nightly builds were unsuccessful due to the failure to update the Lensfun database. I tested this by running it in my fork, it works.
