### PR TITLE
Adds a new action to pin images from the film roll in the 2nd window and support for D&D.

### DIFF
--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -434,6 +434,8 @@ void dt_dev_pipe_synch_all(dt_develop_t *dev);
  * even when the user navigates to other images.
  */
 void dt_dev_toggle_preview2_pinned(dt_develop_t *dev);
+// Pin a specific image (by imgid) in the second window, loading its history from DB.
+void dt_dev_pin_image(dt_develop_t *dev, dt_imgid_t imgid);
 void dt_dev_set_histogram_pre(dt_develop_t *dev);
 void dt_dev_reprocess_all(dt_develop_t *dev);
 void dt_dev_reprocess_center(dt_develop_t *dev);


### PR DESCRIPTION
This adds the ability to pin an image directly from the thumbtable, which makes it possible to show different images in the 2nd window while keeping the same image in the main window.

It adds a context menu to the images in the thumbtable, which for the moment contains only this one action.

It also fixes a bug that may cause darktable to crash when the 2nd window is toggled off and on very quickly, which may try to recreate the window while the previous one has not finished clearing up yet.

@TurboGit This is another follow up to https://github.com/darktable-org/darktable/pull/19963.