### PR TITLE
Simplify tiling alignments

### DIFF
--- a/src/develop/blend.c
+++ b/src/develop/blend.c
@@ -1458,8 +1458,7 @@ void tiling_callback_blendop(dt_iop_module_t *self,
   tiling->maxbuf = 1.0f;
   tiling->overhead = 0;
   tiling->overlap = 0;
-  tiling->xalign = 1;
-  tiling->yalign = 1;
+  tiling->align = 1;
 
   dt_develop_blend_params_t *const bldata = piece->blendop_data;
   if(bldata)

--- a/src/develop/tiling.h
+++ b/src/develop/tiling.h
@@ -36,11 +36,8 @@ typedef struct dt_develop_tiling_t
   unsigned overhead;
   /** overlap needed between tiles (in pixels) */
   unsigned overlap;
-  /** horizontal and vertical alignment requirement of upper left position
-      of tiles. set to a value of 1 for no alignment, or 2 to account for
-      Bayer pattern. */
-  unsigned xalign;
-  unsigned yalign;
+  /** horizontal and vertical alignment requirement of upper left position of tiles */
+  unsigned align;
 } dt_develop_tiling_t;
 
 int default_process_tiling_cl(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece,

--- a/src/iop/atrous.c
+++ b/src/iop/atrous.c
@@ -602,8 +602,7 @@ void tiling_callback(dt_iop_module_t *self,
   tiling->maxbuf_cl = 1.0f;
   tiling->overhead = 0;
   tiling->overlap = max_filter_radius;
-  tiling->xalign = 1;
-  tiling->yalign = 1;
+  tiling->align = 1;
   return;
 }
 

--- a/src/iop/basecurve.c
+++ b/src/iop/basecurve.c
@@ -980,24 +980,19 @@ void tiling_callback(dt_iop_module_t *self,
 {
   dt_iop_basecurve_data_t *const d = piece->data;
 
+  tiling->maxbuf = 1.0f;
+  tiling->overhead = 0;
+  tiling->align = 1;
+
   if(d->exposure_fusion)
   {
     const int rad = MIN(roi_in->width, (int)ceilf(256 * roi_in->scale / piece->iscale));
-
     tiling->factor = 6.666f;                 // in + out + col[] + comb[] + 2*tmp
-    tiling->maxbuf = 1.0f;
-    tiling->overhead = 0;
-    tiling->xalign = 1;
-    tiling->yalign = 1;
     tiling->overlap = rad;
   }
   else
   {
     tiling->factor = 2.0f;                   // in + out
-    tiling->maxbuf = 1.0f;
-    tiling->overhead = 0;
-    tiling->xalign = 1;
-    tiling->yalign = 1;
     tiling->overlap = 0;
   }
 }

--- a/src/iop/basicadj.c
+++ b/src/iop/basicadj.c
@@ -537,8 +537,7 @@ void tiling_callback(dt_iop_module_t *self,
   tiling->maxbuf_cl = 1.0f;
   tiling->overhead = 0;
   tiling->overlap = 0;
-  tiling->xalign = 1;
-  tiling->yalign = 1;
+  tiling->align = 1;
 }
 void commit_params(dt_iop_module_t *self,
                    dt_iop_params_t *params,

--- a/src/iop/bilat.c
+++ b/src/iop/bilat.c
@@ -254,6 +254,8 @@ void tiling_callback(dt_iop_module_t *self,
   // the total scale is composed of scale before input to the pipeline (iscale),
   // and the scale of the roi.
 
+  tiling->align = 1;
+  tiling->overhead = 0;
   if(d->mode == s_mode_bilateral)
   {
     // used to adjuste blur level depending on size. Don't amplify noise if magnified > 100%
@@ -270,10 +272,7 @@ void tiling_callback(dt_iop_module_t *self,
     tiling->factor = 2.0f + (float)dt_bilateral_memory_use(width, height, sigma_s, sigma_r) / basebuffer;
     tiling->maxbuf
         = fmax(1.0f, (float)dt_bilateral_singlebuffer_size(width, height, sigma_s, sigma_r) / basebuffer);
-    tiling->overhead = 0;
     tiling->overlap = ceilf(4 * sigma_s);
-    tiling->xalign = 1;
-    tiling->yalign = 1;
   }
   else  // mode == s_mode_local_laplacian
   {
@@ -287,10 +286,7 @@ void tiling_callback(dt_iop_module_t *self,
     tiling->factor = 2.0f + (float)local_laplacian_memory_use(width, height) / basebuffer;
     tiling->maxbuf
         = fmax(1.0f, (float)local_laplacian_singlebuffer_size(width, height) / basebuffer);
-    tiling->overhead = 0;
     tiling->overlap = rad;
-    tiling->xalign = 1;
-    tiling->yalign = 1;
   }
 }
 

--- a/src/iop/bilateral.cc
+++ b/src/iop/bilateral.cc
@@ -356,8 +356,7 @@ void tiling_callback(dt_iop_module_t *self,
   }
   tiling->overhead = 0;
   tiling->overlap = rad;
-  tiling->xalign = 1;
-  tiling->yalign = 1;
+  tiling->align = 1;
   tiling->maxbuf = 1.0f;
 }
 

--- a/src/iop/bloom.c
+++ b/src/iop/bloom.c
@@ -322,8 +322,7 @@ void tiling_callback(dt_iop_module_t *self,
   tiling->maxbuf = 1.0f;
   tiling->overhead = 0;
   tiling->overlap = 5 * radius; // This is a guess. TODO: check if that's sufficiently large
-  tiling->xalign = 1;
-  tiling->yalign = 1;
+  tiling->align = 1;
   return;
 }
 

--- a/src/iop/censorize.c
+++ b/src/iop/censorize.c
@@ -388,8 +388,7 @@ void tiling_callback(dt_iop_module_t *self,
   tiling->maxbuf_cl = 1.0f;
   tiling->overhead = 0;
   tiling->overlap = 0;
-  tiling->xalign = 1;
-  tiling->yalign = 1;
+  tiling->align = 1;
 }
 
 void init_global(dt_iop_module_so_t *self)

--- a/src/iop/colorequal.c
+++ b/src/iop/colorequal.c
@@ -347,8 +347,7 @@ void tiling_callback(dt_iop_module_t *self,
   const dt_iop_colorequal_data_t *data = piece->data;
 
   tiling->maxbuf = 1.0f;
-  tiling->xalign = 1;
-  tiling->yalign = 1;
+  tiling->align = 1;
   tiling->overhead = (2 * SATSIZE + 4 * LUT_ELEM) * sizeof(float);
   const int maxradius = MAX(data->chroma_size, data->param_size);
   tiling->overlap = 16 + maxradius; // safe feathering

--- a/src/iop/colormapping.c
+++ b/src/iop/colormapping.c
@@ -725,8 +725,7 @@ void tiling_callback(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece,
       = fmaxf(1.0f, (float)dt_bilateral_singlebuffer_size(width, height, sigma_s, sigma_r) / basebuffer);
   tiling->overhead = 0;
   tiling->overlap = ceilf(4 * sigma_s);
-  tiling->xalign = 1;
-  tiling->yalign = 1;
+  tiling->align = 1;
 }
 
 void commit_params(dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_t *pipe,

--- a/src/iop/colorreconstruction.c
+++ b/src/iop/colorreconstruction.c
@@ -1126,9 +1126,7 @@ void tiling_callback(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece,
       = fmax(1.0f, (float)dt_iop_colorreconstruct_bilateral_singlebuffer_size(width, height, sigma_s, sigma_r) / basebuffer);
   tiling->overhead = 0;
   tiling->overlap = ceilf(4 * sigma_s);
-  tiling->xalign = 1;
-  tiling->yalign = 1;
-  return;
+  tiling->align = 1;
 }
 
 

--- a/src/iop/defringe.c
+++ b/src/iop/defringe.c
@@ -126,8 +126,7 @@ void tiling_callback(dt_iop_module_t *self,
   tiling->maxbuf = fmax(1.0f, (float)dt_gaussian_singlebuffer_size(width, height, channels)/basebuffer);
   tiling->overhead = 0;
   tiling->overlap = 2 * p->radius;
-  tiling->xalign = 1;
-  tiling->yalign = 1;
+  tiling->align = 1;
 }
 
 // fibonacci lattice to select surrounding pixels for different cases

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -854,6 +854,8 @@ void tiling_callback(dt_iop_module_t *self,
 {
   dt_iop_denoiseprofile_params_t *d = piece->data;
 
+  tiling->align = 1;
+  tiling->overhead = 0;
   if(d->mode == MODE_NLMEANS || d->mode == MODE_NLMEANS_AUTO)
   {
     // pixel filter size:
@@ -868,10 +870,7 @@ void tiling_callback(dt_iop_module_t *self,
     // in + out + (2 + NUM_BUCKETS * 0.25) tmp:
     tiling->factor_cl = 4.0f + 0.25f * NUM_BUCKETS;
     tiling->maxbuf = 1.0f;
-    tiling->overhead = 0;
     tiling->overlap = P + K_scattered;
-    tiling->xalign = 1;
-    tiling->yalign = 1;
   }
   else
   {
@@ -903,12 +902,8 @@ void tiling_callback(dt_iop_module_t *self,
     tiling->factor_cl = 3.5f + max_scale; // in + out + tmp + reducebuffer + scale buffers
     tiling->maxbuf = 1.0f;
     tiling->maxbuf_cl = 1.0f;
-    tiling->overhead = 0;
     tiling->overlap = max_filter_radius;
-    tiling->xalign = 1;
-    tiling->yalign = 1;
   }
-
 }
 
 static inline void precondition(const float *const in,

--- a/src/iop/diffuse.c
+++ b/src/iop/diffuse.c
@@ -797,8 +797,7 @@ void tiling_callback(dt_iop_module_t *self,
   tiling->maxbuf_cl = 1.0f;
   tiling->overhead = 0;
   tiling->overlap = max_filter_radius;
-  tiling->xalign = 1;
-  tiling->yalign = 1;
+  tiling->align = 1;
   return;
 }
 

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -2087,8 +2087,7 @@ void tiling_callback(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece,
   tiling->maxbuf_cl = 1.0f;
   tiling->overhead = 0;
   tiling->overlap = max_filter_radius;
-  tiling->xalign = 1;
-  tiling->yalign = 1;
+  tiling->align = 1;
   return;
 }
 

--- a/src/iop/finalscale.c
+++ b/src/iop/finalscale.c
@@ -129,8 +129,7 @@ void tiling_callback(dt_iop_module_t *self,
   tiling->overhead = 0;
 
   tiling->overlap = 4;
-  tiling->xalign = 1;
-  tiling->yalign = 1;
+  tiling->align = 1;
 }
 
 void distort_mask(dt_iop_module_t *self,

--- a/src/iop/globaltonemap.c
+++ b/src/iop/globaltonemap.c
@@ -538,9 +538,7 @@ void tiling_callback(dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece
       = (detail ? MAX(1.0f, (float)dt_bilateral_singlebuffer_size2(width, height, sigma_s, sigma_r) / basebuffer) : 1.0f);
   tiling->overhead = 0;
   tiling->overlap = (detail ? ceilf(4 * sigma_s) : 0);
-  tiling->xalign = 1;
-  tiling->yalign = 1;
-  return;
+  tiling->align = 1;
 }
 
 void commit_params(dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_t *pipe,

--- a/src/iop/hazeremoval.c
+++ b/src/iop/hazeremoval.c
@@ -832,8 +832,7 @@ void tiling_callback(dt_iop_module_t *self,
   tiling->maxbuf_cl = 1.0f;
   tiling->overhead = 0;
   tiling->overlap = 0;
-  tiling->xalign = 1;
-  tiling->yalign = 1;
+  tiling->align = 1;
 }
 
 int process_cl(dt_iop_module_t *self,

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -399,8 +399,7 @@ void tiling_callback(dt_iop_module_t *self,
   const gboolean is_bayer = filters && (filters != 9u);
   const gboolean is_xtrans = filters && (filters == 9u);
 
-  tiling->xalign = 1;
-  tiling->yalign = 1;
+  tiling->align = 1;
   tiling->overlap = 0;
   tiling->factor = 2.0f;
   tiling->factor_cl = 2.0f;

--- a/src/iop/highpass.c
+++ b/src/iop/highpass.c
@@ -112,9 +112,7 @@ void tiling_callback(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece,
   tiling->maxbuf = 1.0f;
   tiling->overhead = 0;
   tiling->overlap = wdh;
-  tiling->xalign = 1;
-  tiling->yalign = 1;
-  return;
+  tiling->align = 1;
 }
 
 

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -1535,8 +1535,7 @@ static void _tiling_callback_lf(dt_iop_module_t *self,
   tiling->maxbuf = 1.5f;
   tiling->overhead = 0;
   tiling->overlap = 4;
-  tiling->xalign = 1;
-  tiling->yalign = 1;
+  tiling->align = 1;
   dt_iop_lens_data_t *d = (dt_iop_lens_data_t *)piece->data;
   if(d->v_strength != 0.0f) tiling->factor += 1.0f;
 }
@@ -2598,8 +2597,7 @@ static void _tiling_callback_md(dt_iop_module_t *self,
   tiling->maxbuf = 1.5f;
   tiling->overhead = 0;
   tiling->overlap = 4;
-  tiling->xalign = 1;
-  tiling->yalign = 1;
+  tiling->align = 1;
 }
 
 static void _tiling_callback_vg(dt_iop_module_t *self,
@@ -2612,8 +2610,7 @@ static void _tiling_callback_vg(dt_iop_module_t *self,
   tiling->maxbuf = 1.0f;
   tiling->overhead = 0;
   tiling->overlap = 4;
-  tiling->xalign = 1;
-  tiling->yalign = 1;
+  tiling->align = 1;
 }
 
 static gboolean _distort_transform_md(dt_iop_module_t *self,

--- a/src/iop/lowpass.c
+++ b/src/iop/lowpass.c
@@ -362,9 +362,7 @@ void tiling_callback(dt_iop_module_t *self,
   }
   tiling->overhead = 0;
   tiling->overlap = ceilf(4 * sigma);
-  tiling->xalign = 1;
-  tiling->yalign = 1;
-  return;
+  tiling->align = 1;
 }
 
 void process(dt_iop_module_t *self,

--- a/src/iop/monochrome.c
+++ b/src/iop/monochrome.c
@@ -312,9 +312,7 @@ void tiling_callback(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece,
   tiling->maxbuf_cl = tiling->maxbuf;
   tiling->overhead = 0;
   tiling->overlap = ceilf(4 * sigma_s);
-  tiling->xalign = 1;
-  tiling->yalign = 1;
-  return;
+  tiling->align = 1;
 }
 
 void commit_params(dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_t *pipe,

--- a/src/iop/nlmeans.c
+++ b/src/iop/nlmeans.c
@@ -350,9 +350,7 @@ void tiling_callback(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece,
   tiling->maxbuf = 1.0f;
   tiling->overhead = 0;
   tiling->overlap = P + K;
-  tiling->xalign = 1;
-  tiling->yalign = 1;
-  return;
+  tiling->align = 1;
 }
 
 void process(

--- a/src/iop/overexposed.c
+++ b/src/iop/overexposed.c
@@ -379,8 +379,7 @@ void tiling_callback(dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece
   tiling->maxbuf_cl = 1.0f;
   tiling->overhead = 0;
   tiling->overlap = 0;
-  tiling->xalign = 1;
-  tiling->yalign = 1;
+  tiling->align = 1;
 }
 
 

--- a/src/iop/rasterfile.c
+++ b/src/iop/rasterfile.c
@@ -616,8 +616,7 @@ void tiling_callback(dt_iop_module_t *self,
                      dt_develop_tiling_t *tiling)
 {
   tiling->maxbuf = 1.0f;
-  tiling->xalign = 1;
-  tiling->yalign = 1;
+  tiling->align = 1;
   tiling->overhead = 0;
   tiling->factor = 2.0f;
 }

--- a/src/iop/rawoverexposed.c
+++ b/src/iop/rawoverexposed.c
@@ -382,9 +382,7 @@ void tiling_callback(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece,
   tiling->maxbuf = 1.0f;
   tiling->overhead = (size_t)raw_width * raw_height * sizeof(uint16_t);
   tiling->overlap = 0;
-  tiling->xalign = 1;
-  tiling->yalign = 1;
-  return;
+  tiling->align = 1;
 }
 
 void commit_params(dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_t *pipe,

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -2270,8 +2270,7 @@ void tiling_callback(dt_iop_module_t *self,
   tiling->maxbuf_cl = 1.0f;
   tiling->overhead = 0;
   tiling->overlap = 0;
-  tiling->xalign = 1;
-  tiling->yalign = 1;
+  tiling->align = 1;
 }
 
 void init_pipe(dt_iop_module_t *self,

--- a/src/iop/shadhi.c
+++ b/src/iop/shadhi.c
@@ -618,9 +618,7 @@ void tiling_callback(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece,
 
   tiling->overhead = 0;
   tiling->overlap = ceilf(4 * sigma);
-  tiling->xalign = 1;
-  tiling->yalign = 1;
-  return;
+  tiling->align = 1;
 }
 
 void commit_params(dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_t *pipe,

--- a/src/iop/sharpen.c
+++ b/src/iop/sharpen.c
@@ -240,7 +240,7 @@ void tiling_callback(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece,
                      const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out,
                      dt_develop_tiling_t *tiling)
 {
-  dt_iop_sharpen_data_t *d = piece->data;
+  const dt_iop_sharpen_data_t *d = piece->data;
   const int rad = MIN(MAXR, ceilf(d->radius * roi_in->scale / piece->iscale));
 
   tiling->factor = 2.1f; // in + out + tmprow
@@ -248,9 +248,7 @@ void tiling_callback(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece,
   tiling->maxbuf = 1.0f;
   tiling->overhead = 0;
   tiling->overlap = rad;
-  tiling->xalign = 1;
-  tiling->yalign = 1;
-  return;
+  tiling->align = 1;
 }
 
 void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,

--- a/src/iop/soften.c
+++ b/src/iop/soften.c
@@ -315,9 +315,7 @@ void tiling_callback(dt_iop_module_t *self,
   tiling->maxbuf = 1.0f;
   tiling->overhead = 0;
   tiling->overlap = wdh;
-  tiling->xalign = 1;
-  tiling->yalign = 1;
-  return;
+  tiling->align = 1;
 }
 
 void init_global(dt_iop_module_so_t *self)

--- a/src/iop/useless.c
+++ b/src/iop/useless.c
@@ -264,8 +264,7 @@ void tiling_callback(dt_iop_module_t *self,
   tiling->overhead = 0;     // number of bytes of fixed overhead
   tiling->overlap = 0;      // how many pixels do we need to access
                             // from the neighboring tile?
-  tiling->xalign = 1;
-  tiling->yalign = 1;
+  tiling->align = 1;
 }
 #endif
 


### PR DESCRIPTION
1. We aligned to positions in generic tiling code at the _lms() of both dimensions anyway, so let's simplify that and use one aligner.
2. We don't have to tile on the sensor snapping any more as all rawspace modules get their cfa patterns presented correctly so the defaults can always be 1.
3. Currently we don't need any alignment at all but the code doesn't hurt and possibly we might have modules that would want to do so. Anyway the OpenCL code wants alignment at least for width.