### PR TITLE
Usability of CPU vs GPU pfm dumping

### DIFF
--- a/src/common/pfm.c
+++ b/src/common/pfm.c
@@ -242,12 +242,10 @@ void dt_write_pfm(const char *filename,
 
   if(bpp == 2)
     fprintf(f, "P5\n%d %d\n", (int)width, (int)height);
+  else if(bpp == 4)
+    fprintf(f, "Pf\n%d %d\n-1.0\n", (int)width, (int)height);
   else
-    fprintf(f,
-            "P%s\n%d %d\n-1.0\n",
-            (bpp == sizeof(float)) ? "f" : "F",
-            (int)width,
-            (int)height);
+    fprintf(f, "PF\n%d %d\n-1.0\n", (int)width, (int)height);
 
   void *buf_line = dt_alloc_align_float(width * 4);
   for(size_t row = 0; row < height; row++)


### PR DESCRIPTION
The `--dump-diff-pipe A,B,C` option is the most important debugging tool to track discrepancies between CPU and OpenCL processing for modules specified in the list by writing pfm files to a tmp location.

New features for 5.6:
1. you may specify 'complete' in the module list for all modules.
2. support for rawprepare has been added
3. detection of invalid data

Basically we process the data presented in the pixelpipe (only full or export) to OpenCL two times on the same input data, on the pipe's OpenCL device and on CPU. Afterwards we compare both normalized outputs.

All written files contain at least 2 subimages, all debugging information is visualized with bright pixels over a shaded background image so you know exactly where an issue happens.

The *first* subimage shows the difference between CPU and OpenCL if it is > 1e-7 so it's pretty sensitive. The *second* subimage shows the ratio where it is outside the 0.999 -> 1.001 range (if signal is above a threshold).

In some cases either the CPU or GPU data can somewhere have NaNs or infinites. If such are detected there is a *third* subimage showing those locations.


@TurboGit sorry to bother you again with this tool. Anyway, it's much better now and pinpoints to problems.
May i ask you to test this for `demosaic-xtrans-vng` on your nvidia system and share the written demosaicer pfm file? (Thanks for tiling const :-)