### PR TITLE
dtgtk/expander: prevent UAF on _last_expanded

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -97,6 +97,13 @@ changes (where available).
   file rather than upscale the embedded JPEG for higher resolution
   thumbnails/previews, use the new configuration option "auto".
 
+- In Quick Access Panel, "go to full version..." now reliably scrolls
+  to the correct module.
+
+- In filmstrip, keyboard shortcuts for rating/color labels/reject now
+  apply to the thumbnail under the cursor (including overlay elements)
+  instead of the currently opened image.
+
 - Fix for usage of incorrect color profiles on secondary monitors on
   Windows.
 


### PR DESCRIPTION
- Regression follow-up for `c30ddea67c` (`fix: scroll to correct module when navigating from Quick Access Panel`).
- That change fixed issue #19692 but introduced an intermittent UAF risk in `dtgtk/expander` when `_last_expanded` outlived the widget during import-time UI rebuilds.
- This PR replaces raw `_last_expanded` handling with weak-pointer tracking, so destroyed widgets auto-null the pointer and no stale dereference occurs.