### PR TITLE
Adds a configuration option to disable auto-centering of the filmstirp

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -2467,6 +2467,13 @@
     <shortdescription>show scrollbars for central view</shortdescription>
     <longdescription>defines whether scrollbars should be displayed</longdescription>
   </dtconfig>
+  <dtconfig>
+    <name>filmstrip/ui/auto_scroll</name>
+    <type>bool</type>
+    <default>true</default>
+    <shortdescription>auto-scroll filmstrip to selected image</shortdescription>
+    <longdescription>when enabled, the filmstrip automatically scrolls to center the newly selected image</longdescription>
+  </dtconfig>
   <dtconfig prefs="lighttable" section="general">
      <name>lighttable/ui/milliseconds</name>
      <type>bool</type>

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -1848,6 +1848,9 @@ static void _dt_active_images_callback(gpointer instance, dt_thumbtable_t *table
     return;
 
   if(!darktable.view_manager->active_images) return;
+  if(table->mode == DT_THUMBTABLE_MODE_FILMSTRIP
+     && !dt_conf_get_bool("filmstrip/ui/auto_scroll"))
+    return;
   const int activeid = GPOINTER_TO_INT(darktable.view_manager->active_images->data);
   dt_thumbtable_set_offset_image(table, activeid, TRUE);
 }

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -1329,7 +1329,8 @@ static void _view_darkroom_filmstrip_activate_callback(gpointer instance,
 
     _dev_change_image(dev, imgid);
     // move filmstrip
-    dt_thumbtable_set_offset_image(dt_ui_thumbtable(darktable.gui->ui), imgid, TRUE);
+    if(dt_conf_get_bool("filmstrip/ui/auto_scroll"))
+      dt_thumbtable_set_offset_image(dt_ui_thumbtable(darktable.gui->ui), imgid, TRUE);
     // force redraw
     dt_control_queue_redraw();
   }


### PR DESCRIPTION
Auto-centering can be problematic, especially when working on a sequence of similar looking images.
The filmstrip moves back and forth and one loses track of where the previous image was.

This only adds a hidden config option, i.e., no changes to the preferences UI.

I would be happy to add that as well if this PR is accepted and the addition is deemed worthy.