### PR TITLE
Preventing terminal windows in Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ tools/iop_deps.pdf
 cscope.out
 .*.swp
 .vscode/
+.vs/
 .clangd/
 .cache
 tags
@@ -25,3 +26,5 @@ output*png
 Brewfile.lock.json
 CMakeLists.txt.user
 workspace/
+
+CMakeUserPresets.json

--- a/data/luarc
+++ b/data/luarc
@@ -20,6 +20,29 @@ ipairs = function(t)
   end
 end
 
+
+local dt = require "darktable"
+if dt.configuration.running_os == "windows" then
+  -- Lua on Windows opens a cmd terminal window whenver
+  -- a subprocess is started. We need to use Win32 APIs
+  -- which do not do this, and replace the standard Lua functions.
+
+  -- os.execute = dt.windows.os_execute
+
+  io.close = dt.windows.close
+  io.flush = dt.windows.flush
+  io.input = dt.windows.input
+  io.lines = dt.windows.lines
+  io.open = dt.windows.open
+  io.output = dt.windows.output
+  io.popen = dt.windows.popen
+  io.read = dt.windows.read
+  io.tmpfile = dt.windows.tmpfile
+  io.type = dt.windows.type
+  io.write = dt.windows.write
+  end
+
+
 -- script installer
 
 local _scripts_install = {}

--- a/packaging/windows/README.md
+++ b/packaging/windows/README.md
@@ -2,9 +2,18 @@ The steps to build darktable Windows executable and make installer (Windows 8.1 
 [UCRT installed](https://support.microsoft.com/en-us/topic/update-for-universal-c-runtime-in-windows-c0514201-7fe6-95a3-b0a5-287930f3560c))
 are as follows:
 
-* Install MSYS2 (instructions and prerequisites can be found on the official website: https://www.msys2.org)
+A short summary about the installation environment: The compilation is done by MSYS2 (For more background, see the documentation at https://www.msys2.org). In short, MSYS2 provides a Unix development environmnent (binaries, libraries, compilers etc) on Windows. In contrast to WSL, it does not run in a virtual machine. Instead, the binaries are native Windows binaries. 
 
-* Start the MSYS terminal and update the base system until no further updates are available by repeating:
+We will use the Universal C Runtime (UCRT), which is a newer runtime (in comparison with MSVCRT). See the information about the environments on MSYS at https://www.msys2.org/docs/environments.
+
+Note that there are two terminals. The MSYS terminal is for "normal" system work, and the UCRT64 terminal is for building (this is achived by prepending the MSYS64's `bin` directory to the PATH, thus giving precedence to the UCRT64 toolchain).
+
+
+* Install MSYS2 (instructions and prerequisites can be found on the official website: https://www.msys2.org). For additional convenience, 
+  configure the Windows terminal (https://www.msys2.org/docs/terminals/#windows-terminal) appropriately.
+  
+
+* Start the MSYS (not UCRT64) terminal and update the base system until no further updates are available by repeating:
     ```bash
     pacman -Syu
     ```
@@ -12,7 +21,7 @@ are as follows:
 * From the MSYS terminal, install the toolchain (assuming x64), developer tools and git:
     ```bash
     pacman -S --needed base-devel git intltool po4a
-    pacman -S --needed mingw-w64-ucrt-x86_64-{cc,cmake,gcc-libs,ninja,omp}
+    pacman -S --needed mingw-w64-ucrt-x86_64-{cc,cmake,gcc-libs,ninja,omp} #Install the UCRT64 toolchain
     ```
 
 * Install required and recommended dependencies for darktable:
@@ -93,3 +102,15 @@ If you like experimenting you could also install `mingw-w64-ucrt-x86_64-{clang,l
 Windows on Arm (WoA) users should use the `mingw-w64-clang-aarch64-` prefix when installing packages above and build within the CLANGARM64 environment instead (note that it is not currently possible to build the installer image because of missing `nsis`).
 
 Have fun with this, report back your findings.
+
+
+## Development with Visual Studio Code
+
+After installing and configuring MSYS2 from above, create a `CMakeUserPresets.json` in the root directory of this repository.
+
+
+
+https://cadhut.com/2020/08/02/how-to-set-up-and-use-msys2/
+https://www.msys2.org/docs/environments/
+
+https://dominikberner.ch/cmake-presets-best-practices/#:~:text=The%20command%20to%20configure%20a%20project%20using%20a,CMake%20with%20cmake%20--build%20--preset%20%3Cpreset-name%3E%20--target%20test.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -157,6 +157,9 @@ FILE(GLOB SOURCE_FILES
   "imageio/imageio_tiff.c"
   "libs/lib.c"
   "views/view.c"
+  if(WIN32)
+    "lua/windows.c"
+  endif(WIN32)
   )
 
 FILE(GLOB HEADER_FILES "*.h" "common/*.h" "external/OpenCL/CL/*.h" "control/*.h" "iop/*.h" "libs/*.h" "views/*.h")

--- a/src/external/lua/src/lapi.c
+++ b/src/external/lua/src/lapi.c
@@ -175,7 +175,7 @@ LUA_API int lua_absindex (lua_State *L, int idx) {
 
 LUA_API int lua_gettop (lua_State *L) {
   return cast_int(L->top.p - (L->ci->func.p + 1));
-}
+}°
 
 
 LUA_API void lua_settop (lua_State *L, int idx) {

--- a/src/lua/init.c
+++ b/src/lua/init.c
@@ -45,6 +45,7 @@
 #include "lua/types.h"
 #include "lua/util.h"
 #include "lua/view.h"
+#include "lua/windows.h"
 #include "lua/widget/widget.h"
 
 static int _lua_fully_initialized = false;
@@ -136,14 +137,23 @@ static int run_early_script(lua_State* L)
 }
 
 
+#ifndef WIN32
 static lua_CFunction init_funcs[]
     = { dt_lua_init_glist,         dt_lua_init_image,       dt_lua_init_styles,   dt_lua_init_print,
         dt_lua_init_configuration, dt_lua_init_preferences, dt_lua_init_database, dt_lua_init_gui,
         dt_lua_init_luastorages,   dt_lua_init_tags,        dt_lua_init_film,     dt_lua_init_call,
         dt_lua_init_view,          dt_lua_init_events,      dt_lua_init_init,     dt_lua_init_widget,
         dt_lua_init_lualib,        dt_lua_init_gettext,     dt_lua_init_guides,   dt_lua_init_cairo,
-        dt_lua_init_password,      dt_lua_init_util,        NULL };
-
+        dt_lua_init_password,      NULL };
+#else
+static lua_CFunction init_funcs[]
+    = { dt_lua_init_glist,         dt_lua_init_image,       dt_lua_init_styles,   dt_lua_init_print,
+        dt_lua_init_configuration, dt_lua_init_preferences, dt_lua_init_database, dt_lua_init_gui,
+        dt_lua_init_luastorages,   dt_lua_init_tags,        dt_lua_init_film,     dt_lua_init_call,
+        dt_lua_init_view,          dt_lua_init_events,      dt_lua_init_init,     dt_lua_init_widget,
+        dt_lua_init_lualib,        dt_lua_init_gettext,     dt_lua_init_guides,   dt_lua_init_cairo,
+        dt_lua_init_password,      dt_lua_init_windows,     NULL };
+#endif
 
 void dt_lua_init(lua_State *L, const char *lua_command)
 {

--- a/src/lua/windows.c
+++ b/src/lua/windows.c
@@ -1,0 +1,937 @@
+#include <lua.h>
+#include <lauxlib.h>
+#include <windows.h>
+#include <io.h>
+#include <locale.h>
+#include <io.h>
+#include <fcntl.h>
+
+
+#define WINDOWS_FILE_METATABLE "PROCESS_INFORMATION*"
+
+/*
+** Change this macro to accept other modes for 'fopen' besides
+** the standard ones.
+*/
+#if !defined(l_checkmode)
+
+/* accepted extensions to 'mode' in 'fopen' */
+#if !defined(L_MODEEXT)
+#define L_MODEEXT	"b"
+#endif
+
+/* Check whether 'mode' matches '[rwa]%+?[L_MODEEXT]*' */
+static int l_checkmode (const char *mode) {
+  return (*mode != '\0' && strchr("rwa", *(mode++)) != NULL &&
+         (*mode != '+' || ((void)(++mode), 1)) &&  /* skip if char is '+' */
+         (strspn(mode, L_MODEEXT) == strlen(mode)));  /* check extensions */
+}
+
+#endif
+
+/*
+** {======================================================
+** l_popen spawns a new process connected to the current
+** one through the file streams.
+** =======================================================
+*/
+
+#if !defined(l_popen)		/* { */
+
+#if defined(LUA_USE_POSIX)	/* { */
+
+#define l_popen(L,c,m)		(fflush(NULL), popen(c,m))
+#define l_pclose(L,file)	(pclose(file))
+
+#elif defined(LUA_USE_WINDOWS)	/* }{ */
+
+
+
+static FILE* l_popen(lua_State *L, const char* filename, const char *mode, PROCESS_INFORMATION* pi) {
+  // https://learn.microsoft.com/en-us/windows/win32/procthread/creating-a-child-process-with-redirected-input-and-output
+
+  ZeroMemory(pi, sizeof(PROCESS_INFORMATION));
+
+  HANDLE g_hChildStd_IN_Rd = NULL;
+  HANDLE g_hChildStd_IN_Wr = NULL;
+  HANDLE g_hChildStd_OUT_Rd = NULL;
+  HANDLE g_hChildStd_OUT_Wr = NULL;
+
+  SECURITY_ATTRIBUTES saAttr;
+  ZeroMemory(&saAttr, sizeof(SECURITY_ATTRIBUTES));
+  saAttr.nLength = sizeof(SECURITY_ATTRIBUTES);
+  saAttr.bInheritHandle = TRUE;
+  saAttr.lpSecurityDescriptor = NULL;
+
+
+  //TODO: Create single pipe
+  // Pipe for child process' STDOUT
+  if (!CreatePipe(&g_hChildStd_OUT_Rd, &g_hChildStd_OUT_Wr, &saAttr, 0)) {
+    printf("Error creating pipe\n");
+    return NULL;
+  }
+
+  if ( ! SetHandleInformation(g_hChildStd_OUT_Rd, HANDLE_FLAG_INHERIT, 0) ) {
+    printf("TODO error handling\n");
+    return NULL;
+  }
+
+  // Pipe for child process' STDIN
+  if (!CreatePipe(&g_hChildStd_IN_Rd, &g_hChildStd_IN_Wr, &saAttr, 0)) {
+    printf("Error creating pipe\n");
+    return NULL;
+  }
+
+  if ( ! SetHandleInformation(g_hChildStd_IN_Wr, HANDLE_FLAG_INHERIT, 0) ) {
+    printf("TODO error handling\n");
+    return NULL;
+  }
+
+  STARTUPINFO si;
+  ZeroMemory(&si, sizeof(si));
+  si.cb = sizeof(si);
+  si.hStdError = g_hChildStd_OUT_Wr;
+  si.hStdOutput = g_hChildStd_OUT_Wr;
+  si.hStdInput = g_hChildStd_IN_Rd;
+  si.dwFlags |=  STARTF_USESTDHANDLES;
+
+
+
+  int required_buffer_size = MultiByteToWideChar(CP_UTF8, 0, filename, -1, NULL, 0);
+  LPWSTR utf16buf = malloc(required_buffer_size * sizeof(WCHAR));
+  if (!MultiByteToWideChar(CP_UTF8, 0, filename, -1, utf16buf, required_buffer_size)) {
+    printf("Could nto convert to unicode\n");
+    return NULL;
+  }
+
+  if (!CreateProcessW( 
+    NULL,
+    utf16buf,
+    NULL,
+    NULL,
+    TRUE,
+    0,
+    NULL,
+    NULL,
+    &si,
+    pi)
+  ) {
+    printf("Could not create process\n");
+    free(utf16buf);
+    return NULL;
+  }
+  
+  free(utf16buf);
+
+  CloseHandle(g_hChildStd_OUT_Wr);
+  CloseHandle(g_hChildStd_IN_Rd);
+
+  int fd = -1;
+  if (strcmp(mode, "r") == 0) {
+    fd = _open_osfhandle((intptr_t) g_hChildStd_OUT_Rd, 0);
+  } else if (strcmp(mode, "w") == 0) {
+    fd = _open_osfhandle((intptr_t) g_hChildStd_IN_Wr, 0);
+  }
+
+  if (fd == -1) {
+    printf("Could not open file descriptor");
+    return NULL;
+  }
+
+  FILE* f = _fdopen(fd, mode);
+  return f;
+}
+
+int l_pclose(lua_State *L, FILE* file, PROCESS_INFORMATION *pi) {
+  // Close read file descriptor first, then wait for the process to exit
+  _pclose(file);
+
+  if (WaitForSingleObject(pi->hProcess, INFINITE) == WAIT_FAILED) {
+    printf("Error waiting for process exit: %d\n", GetLastError);
+    return 1;
+  };
+  DWORD exit_code;
+  if (!GetExitCodeProcess(pi->hProcess, &exit_code)) {
+    int error_code = GetLastError();
+    printf("Error getting exit code: %d\n", error_code);
+    return 1;
+  }
+  if (!CloseHandle(pi->hProcess)) {
+    int error_code = GetLastError();
+    printf("Error closing hProcess: %d\n", error_code);
+    return 1;
+  }
+  if (!CloseHandle(pi->hThread)) {
+    int error_code = GetLastError();
+    printf("Error closing hThread: %d\n", error_code);
+    return 1;
+  }
+
+  return exit_code;
+}
+
+#if !defined(l_checkmodep)
+/* Windows accepts "[rw][bt]?" as valid modes */
+#define l_checkmodep(m)	((m[0] == 'r' || m[0] == 'w') && \
+  (m[1] == '\0' || ((m[1] == 'b' || m[1] == 't') && m[2] == '\0')))
+#endif
+
+#else				/* }{ */
+
+/* ISO C definitions */
+#define l_popen(L,c,m)  \
+	  ((void)c, (void)m, \
+	  luaL_error(L, "'popen' not supported"), \
+	  (FILE*)0)
+#define l_pclose(L,file)		((void)L, (void)file, -1)
+
+#endif				/* } */
+
+#endif				/* } */
+
+
+#if !defined(l_checkmodep)
+/* By default, Lua accepts only "r" or "w" as valid modes */
+#define l_checkmodep(m)        ((m[0] == 'r' || m[0] == 'w') && m[1] == '\0')
+#endif
+
+/* }====================================================== */
+
+
+#if !defined(l_getc)		/* { */
+
+#if defined(LUA_USE_POSIX)
+#define l_getc(f)		getc_unlocked(f)
+#define l_lockfile(f)		flockfile(f)
+#define l_unlockfile(f)		funlockfile(f)
+#else
+#define l_getc(f)		getc(f)
+#define l_lockfile(f)		((void)0)
+#define l_unlockfile(f)		((void)0)
+#endif
+
+#endif				/* } */
+
+
+/*
+** {======================================================
+** l_fseek: configuration for longer offsets
+** =======================================================
+*/
+
+#if !defined(l_fseek)		/* { */
+
+#if defined(LUA_USE_POSIX)	/* { */
+
+#include <sys/types.h>
+
+#define l_fseek(f,o,w)		fseeko(f,o,w)
+#define l_ftell(f)		ftello(f)
+#define l_seeknum		off_t
+
+#elif defined(LUA_USE_WINDOWS) && !defined(_CRTIMP_TYPEINFO) \
+   && defined(_MSC_VER) && (_MSC_VER >= 1400)	/* }{ */
+
+/* Windows (but not DDK) and Visual C++ 2005 or higher */
+#define l_fseek(f,o,w)		_fseeki64(f,o,w)
+#define l_ftell(f)		_ftelli64(f)
+#define l_seeknum		__int64
+
+#else				/* }{ */
+
+/* ISO C definitions */
+#define l_fseek(f,o,w)		fseek(f,o,w)
+#define l_ftell(f)		ftell(f)
+#define l_seeknum		long
+
+#endif				/* } */
+
+#endif				/* } */
+
+/* }====================================================== */
+
+
+
+#define IO_PREFIX	"_IO_"
+#define IOPREF_LEN	(sizeof(IO_PREFIX)/sizeof(char) - 1)
+#define IO_INPUT	(IO_PREFIX "input")
+#define IO_OUTPUT	(IO_PREFIX "output")
+
+
+// Adjusted to additionally hold a PROCESS_INFORMATION>*
+typedef struct LStream {
+  FILE* f; /* If it is "only" a file, we only have the HANDLE to read the file */
+  PROCESS_INFORMATION pi; /* For processes, the handle is hold inside the PROCESS_INFORMATION */
+  lua_CFunction closef;  /* to close stream (NULL for closed streams) */
+} LStream;
+
+#define tolstream(L)	((LStream *)luaL_checkudata(L, 1, WINDOWS_FILE_METATABLE))
+
+#define isclosed(p)	((p)->closef == NULL)
+
+
+static int io_type (lua_State *L) {
+  LStream *p;
+  luaL_checkany(L, 1);
+  p = (LStream *)luaL_testudata(L, 1, WINDOWS_FILE_METATABLE);
+  if (p == NULL)
+    luaL_pushfail(L);  /* not a file */
+  else if (isclosed(p))
+    lua_pushliteral(L, "closed file");
+  else
+    lua_pushliteral(L, "file");
+  return 1;
+}
+
+
+static int f_tostring (lua_State *L) {
+  LStream *p = tolstream(L);
+  if (isclosed(p))
+    lua_pushliteral(L, "windows file (closed)");
+  else
+    lua_pushfstring(L, "windows file (%p)", p->f);
+  return 1;
+}
+
+
+static FILE *tofile (lua_State *L) {
+  LStream *p = tolstream(L);
+  if (isclosed(p))
+    luaL_error(L, "attempt to use a closed file");
+  return p->f;
+}
+
+
+/*
+** When creating file handles, always creates a 'closed' file handle
+** before opening the actual file; so, if there is a memory error, the
+** handle is in a consistent state.
+*/
+static LStream *newprefile (lua_State *L) {
+  LStream *p = (LStream *)lua_newuserdatauv(L, sizeof(LStream), 0);
+  p->closef = NULL;  /* mark file handle as 'closed' */
+  luaL_setmetatable(L, WINDOWS_FILE_METATABLE);
+  return p;
+}
+
+
+/*
+** Calls the 'close' function from a file handle. The 'volatile' avoids
+** a bug in some versions of the Clang compiler (e.g., clang 3.0 for
+** 32 bits).
+*/
+static int aux_close (lua_State *L) {
+  LStream *p = tolstream(L);
+  volatile lua_CFunction cf = p->closef;
+  p->closef = NULL;  /* mark stream as closed */
+  return (*cf)(L);  /* close it */
+}
+
+
+static int f_close (lua_State *L) {
+  tofile(L);  /* make sure argument is an open stream */
+  return aux_close(L);
+}
+
+
+static int io_close (lua_State *L) {
+  if (lua_isnone(L, 1))  /* no argument? */
+    lua_getfield(L, LUA_REGISTRYINDEX, IO_OUTPUT);  /* use default output */
+  return f_close(L);
+}
+
+
+static int f_gc (lua_State *L) {
+  LStream *p = tolstream(L);
+  if (!isclosed(p) && p->f != NULL)
+    aux_close(L);  /* ignore closed and incompletely open files */
+  return 0;
+}
+
+
+/*
+** function to close regular files
+*/
+static int io_fclose (lua_State *L) {
+  LStream *p = tolstream(L);
+  errno = 0;
+  return luaL_fileresult(L, (fclose(p->f) == 0), NULL);
+}
+
+
+static LStream *newfile (lua_State *L) {
+  LStream *p = newprefile(L);
+  p->f = NULL;
+  p->closef = &io_fclose;
+  return p;
+}
+
+
+static void opencheck (lua_State *L, const char *fname, const char *mode) {
+  LStream *p = newfile(L);
+  p->f = fopen(fname, mode);
+  if (p->f == NULL)
+    luaL_error(L, "cannot open file '%s' (%s)", fname, strerror(errno));
+}
+
+
+static int io_open (lua_State *L) {
+  const char *filename = luaL_checkstring(L, 1);
+  const char *mode = luaL_optstring(L, 2, "r");
+  LStream *p = newfile(L);
+  const char *md = mode;  /* to traverse/check mode */
+  luaL_argcheck(L, l_checkmode(md), 2, "invalid mode");
+  errno = 0;
+  p->f = fopen(filename, mode);
+  return (p->f == NULL) ? luaL_fileresult(L, 0, filename) : 1;
+}
+
+
+/*
+** function to close 'popen' files
+*/
+static int io_pclose (lua_State *L) {
+  LStream *p = tolstream(L);
+  errno = 0;
+  return luaL_execresult(L, l_pclose(L, p->f, &p->pi));
+}
+
+
+static int io_popen (lua_State *L) {
+  const char *filename = luaL_checkstring(L, 1);
+  const char *mode = luaL_optstring(L, 2, "r");
+  LStream *p = newprefile(L);
+  luaL_argcheck(L, l_checkmodep(mode), 2, "invalid mode");
+  errno = 0;
+  p->f = l_popen(L, filename, mode, &p->pi);
+  p->closef = &io_pclose;
+  return (p->f == NULL) ? luaL_fileresult(L, 0, filename) : 1;
+}
+
+
+static int io_tmpfile (lua_State *L) {
+  LStream *p = newfile(L);
+  errno = 0;
+  p->f = tmpfile();
+  return (p->f == NULL) ? luaL_fileresult(L, 0, NULL) : 1;
+}
+
+
+static FILE *getiofile (lua_State *L, const char *findex) {
+  LStream *p;
+  lua_getfield(L, LUA_REGISTRYINDEX, findex);
+  p = (LStream *)lua_touserdata(L, -1);
+  if (isclosed(p))
+    luaL_error(L, "default %s file is closed", findex + IOPREF_LEN);
+  return p->f;
+}
+
+
+static int g_iofile (lua_State *L, const char *f, const char *mode) {
+  if (!lua_isnoneornil(L, 1)) {
+    const char *filename = lua_tostring(L, 1);
+    if (filename)
+      opencheck(L, filename, mode);
+    else {
+      tofile(L);  /* check that it's a valid file handle */
+      lua_pushvalue(L, 1);
+    }
+    lua_setfield(L, LUA_REGISTRYINDEX, f);
+  }
+  /* return current value */
+  lua_getfield(L, LUA_REGISTRYINDEX, f);
+  return 1;
+}
+
+
+static int io_input (lua_State *L) {
+  return g_iofile(L, IO_INPUT, "r");
+}
+
+
+static int io_output (lua_State *L) {
+  return g_iofile(L, IO_OUTPUT, "w");
+}
+
+
+static int io_readline (lua_State *L);
+
+
+/*
+** maximum number of arguments to 'f:lines'/'io.lines' (it + 3 must fit
+** in the limit for upvalues of a closure)
+*/
+#define MAXARGLINE	250
+
+/*
+** Auxiliary function to create the iteration function for 'lines'.
+** The iteration function is a closure over 'io_readline', with
+** the following upvalues:
+** 1) The file being read (first value in the stack)
+** 2) the number of arguments to read
+** 3) a boolean, true iff file has to be closed when finished ('toclose')
+** *) a variable number of format arguments (rest of the stack)
+*/
+static void aux_lines (lua_State *L, int toclose) {
+  int n = lua_gettop(L) - 1;  /* number of arguments to read */
+  luaL_argcheck(L, n <= MAXARGLINE, MAXARGLINE + 2, "too many arguments");
+  lua_pushvalue(L, 1);  /* file */
+  lua_pushinteger(L, n);  /* number of arguments to read */
+  lua_pushboolean(L, toclose);  /* close/not close file when finished */
+  lua_rotate(L, 2, 3);  /* move the three values to their positions */
+  lua_pushcclosure(L, io_readline, 3 + n);
+}
+
+
+static int f_lines (lua_State *L) {
+  tofile(L);  /* check that it's a valid file handle */
+  aux_lines(L, 0);
+  return 1;
+}
+
+
+/*
+** Return an iteration function for 'io.lines'. If file has to be
+** closed, also returns the file itself as a second result (to be
+** closed as the state at the exit of a generic for).
+*/
+static int io_lines (lua_State *L) {
+  int toclose;
+  if (lua_isnone(L, 1)) lua_pushnil(L);  /* at least one argument */
+  if (lua_isnil(L, 1)) {  /* no file name? */
+    lua_getfield(L, LUA_REGISTRYINDEX, IO_INPUT);  /* get default input */
+    lua_replace(L, 1);  /* put it at index 1 */
+    tofile(L);  /* check that it's a valid file handle */
+    toclose = 0;  /* do not close it after iteration */
+  }
+  else {  /* open a new file */
+    const char *filename = luaL_checkstring(L, 1);
+    opencheck(L, filename, "r");
+    lua_replace(L, 1);  /* put file at index 1 */
+    toclose = 1;  /* close it after iteration */
+  }
+  aux_lines(L, toclose);  /* push iteration function */
+  if (toclose) {
+    lua_pushnil(L);  /* state */
+    lua_pushnil(L);  /* control */
+    lua_pushvalue(L, 1);  /* file is the to-be-closed variable (4th result) */
+    return 4;
+  }
+  else
+    return 1;
+}
+
+
+/*
+** {======================================================
+** READ
+** =======================================================
+*/
+
+
+/* maximum length of a numeral */
+#if !defined (L_MAXLENNUM)
+#define L_MAXLENNUM     200
+#endif
+
+
+/* auxiliary structure used by 'read_number' */
+typedef struct {
+  FILE *f;  /* file being read */
+  int c;  /* current character (look ahead) */
+  int n;  /* number of elements in buffer 'buff' */
+  char buff[L_MAXLENNUM + 1];  /* +1 for ending '\0' */
+} RN;
+
+
+/*
+** Add current char to buffer (if not out of space) and read next one
+*/
+static int nextc (RN *rn) {
+  if (rn->n >= L_MAXLENNUM) {  /* buffer overflow? */
+    rn->buff[0] = '\0';  /* invalidate result */
+    return 0;  /* fail */
+  }
+  else {
+    rn->buff[rn->n++] = rn->c;  /* save current char */
+    rn->c = l_getc(rn->f);  /* read next one */
+    return 1;
+  }
+}
+
+
+/*
+** Accept current char if it is in 'set' (of size 2)
+*/
+static int test2 (RN *rn, const char *set) {
+  if (rn->c == set[0] || rn->c == set[1])
+    return nextc(rn);
+  else return 0;
+}
+
+
+/*
+** Read a sequence of (hex)digits
+*/
+static int readdigits (RN *rn, int hex) {
+  int count = 0;
+  while ((hex ? isxdigit(rn->c) : isdigit(rn->c)) && nextc(rn))
+    count++;
+  return count;
+}
+
+
+/*
+** Read a number: first reads a valid prefix of a numeral into a buffer.
+** Then it calls 'lua_stringtonumber' to check whether the format is
+** correct and to convert it to a Lua number.
+*/
+static int read_number (lua_State *L, FILE *f) {
+  RN rn;
+  int count = 0;
+  int hex = 0;
+  char decp[2];
+  rn.f = f; rn.n = 0;
+  decp[0] = lua_getlocaledecpoint();  /* get decimal point from locale */
+  decp[1] = '.';  /* always accept a dot */
+  l_lockfile(rn.f);
+  do { rn.c = l_getc(rn.f); } while (isspace(rn.c));  /* skip spaces */
+  test2(&rn, "-+");  /* optional sign */
+  if (test2(&rn, "00")) {
+    if (test2(&rn, "xX")) hex = 1;  /* numeral is hexadecimal */
+    else count = 1;  /* count initial '0' as a valid digit */
+  }
+  count += readdigits(&rn, hex);  /* integral part */
+  if (test2(&rn, decp))  /* decimal point? */
+    count += readdigits(&rn, hex);  /* fractional part */
+  if (count > 0 && test2(&rn, (hex ? "pP" : "eE"))) {  /* exponent mark? */
+    test2(&rn, "-+");  /* exponent sign */
+    readdigits(&rn, 0);  /* exponent digits */
+  }
+  ungetc(rn.c, rn.f);  /* unread look-ahead char */
+  l_unlockfile(rn.f);
+  rn.buff[rn.n] = '\0';  /* finish string */
+  if (lua_stringtonumber(L, rn.buff))
+    return 1;  /* ok, it is a valid number */
+  else {  /* invalid format */
+   lua_pushnil(L);  /* "result" to be removed */
+   return 0;  /* read fails */
+  }
+}
+
+
+static int test_eof (lua_State *L, FILE *f) {
+  int c = getc(f);
+  ungetc(c, f);  /* no-op when c == EOF */
+  lua_pushliteral(L, "");
+  return (c != EOF);
+}
+
+
+static int read_line (lua_State *L, FILE *f, int chop) {
+  luaL_Buffer b;
+  int c;
+  luaL_buffinit(L, &b);
+  do {  /* may need to read several chunks to get whole line */
+    char *buff = luaL_prepbuffer(&b);  /* preallocate buffer space */
+    int i = 0;
+    l_lockfile(f);  /* no memory errors can happen inside the lock */
+    while (i < LUAL_BUFFERSIZE && (c = l_getc(f)) != EOF && c != '\n')
+      buff[i++] = c;  /* read up to end of line or buffer limit */
+    l_unlockfile(f);
+    luaL_addsize(&b, i);
+  } while (c != EOF && c != '\n');  /* repeat until end of line */
+  if (!chop && c == '\n')  /* want a newline and have one? */
+    luaL_addchar(&b, c);  /* add ending newline to result */
+  luaL_pushresult(&b);  /* close buffer */
+  /* return ok if read something (either a newline or something else) */
+  return (c == '\n' || lua_rawlen(L, -1) > 0);
+}
+
+
+static void read_all (lua_State *L, FILE *f) {
+  size_t nr;
+  luaL_Buffer b;
+  luaL_buffinit(L, &b);
+  do {  /* read file in chunks of LUAL_BUFFERSIZE bytes */
+    char *p = luaL_prepbuffer(&b);
+    nr = fread(p, sizeof(char), LUAL_BUFFERSIZE, f);
+    luaL_addsize(&b, nr);
+  } while (nr == LUAL_BUFFERSIZE);
+  luaL_pushresult(&b);  /* close buffer */
+}
+
+
+static int read_chars (lua_State *L, FILE *f, size_t n) {
+  size_t nr;  /* number of chars actually read */
+  char *p;
+  luaL_Buffer b;
+  luaL_buffinit(L, &b);
+  p = luaL_prepbuffsize(&b, n);  /* prepare buffer to read whole block */
+  nr = fread(p, sizeof(char), n, f);  /* try to read 'n' chars */
+  luaL_addsize(&b, nr);
+  luaL_pushresult(&b);  /* close buffer */
+  return (nr > 0);  /* true iff read something */
+}
+
+
+static int g_read (lua_State *L, FILE *f, int first) {
+  int nargs = lua_gettop(L) - 1;
+  int n, success;
+  clearerr(f);
+  errno = 0;
+  if (nargs == 0) {  /* no arguments? */
+    success = read_line(L, f, 1);
+    n = first + 1;  /* to return 1 result */
+  }
+  else {
+    /* ensure stack space for all results and for auxlib's buffer */
+    luaL_checkstack(L, nargs+LUA_MINSTACK, "too many arguments");
+    success = 1;
+    for (n = first; nargs-- && success; n++) {
+      if (lua_type(L, n) == LUA_TNUMBER) {
+        size_t l = (size_t)luaL_checkinteger(L, n);
+        success = (l == 0) ? test_eof(L, f) : read_chars(L, f, l);
+      }
+      else {
+        const char *p = luaL_checkstring(L, n);
+        if (*p == '*') p++;  /* skip optional '*' (for compatibility) */
+        switch (*p) {
+          case 'n':  /* number */
+            success = read_number(L, f);
+            break;
+          case 'l':  /* line */
+            success = read_line(L, f, 1);
+            break;
+          case 'L':  /* line with end-of-line */
+            success = read_line(L, f, 0);
+            break;
+          case 'a':  /* file */
+            read_all(L, f);  /* read entire file */
+            success = 1; /* always success */
+            break;
+          default:
+            return luaL_argerror(L, n, "invalid format");
+        }
+      }
+    }
+  }
+  if (ferror(f))
+    return luaL_fileresult(L, 0, NULL);
+  if (!success) {
+    lua_pop(L, 1);  /* remove last result */
+    luaL_pushfail(L);  /* push nil instead */
+  }
+  return n - first;
+}
+
+
+static int io_read (lua_State *L) {
+  return g_read(L, getiofile(L, IO_INPUT), 1);
+}
+
+
+static int f_read (lua_State *L) {
+  return g_read(L, tofile(L), 2);
+}
+
+
+/*
+** Iteration function for 'lines'.
+*/
+static int io_readline (lua_State *L) {
+  LStream *p = (LStream *)lua_touserdata(L, lua_upvalueindex(1));
+  int i;
+  int n = (int)lua_tointeger(L, lua_upvalueindex(2));
+  if (isclosed(p))  /* file is already closed? */
+    return luaL_error(L, "file is already closed");
+  lua_settop(L , 1);
+  luaL_checkstack(L, n, "too many arguments");
+  for (i = 1; i <= n; i++)  /* push arguments to 'g_read' */
+    lua_pushvalue(L, lua_upvalueindex(3 + i));
+  n = g_read(L, p->f, 2);  /* 'n' is number of results */
+  if (lua_toboolean(L, -n))  /* read at least one value? */
+    return n;  /* return them */
+  else {  /* first result is false: EOF or error */
+    if (n > 1) {  /* is there error information? */
+      /* 2nd result is error message */
+      return luaL_error(L, "%s", lua_tostring(L, -n + 1));
+    }
+    if (lua_toboolean(L, lua_upvalueindex(3))) {  /* generator created file? */
+      lua_settop(L, 0);  /* clear stack */
+      lua_pushvalue(L, lua_upvalueindex(1));  /* push file at index 1 */
+      aux_close(L);  /* close it */
+    }
+    return 0;
+  }
+}
+
+/* }====================================================== */
+
+
+static int g_write (lua_State *L, FILE *f, int arg) {
+  int nargs = lua_gettop(L) - arg;
+  int status = 1;
+  errno = 0;
+  for (; nargs--; arg++) {
+    if (lua_type(L, arg) == LUA_TNUMBER) {
+      /* optimization: could be done exactly as for strings */
+      int len = lua_isinteger(L, arg)
+                ? fprintf(f, LUA_INTEGER_FMT,
+                             (LUAI_UACINT)lua_tointeger(L, arg))
+                : fprintf(f, LUA_NUMBER_FMT,
+                             (LUAI_UACNUMBER)lua_tonumber(L, arg));
+      status = status && (len > 0);
+    }
+    else {
+      size_t l;
+      const char *s = luaL_checklstring(L, arg, &l);
+      status = status && (fwrite(s, sizeof(char), l, f) == l);
+    }
+  }
+  if (status)
+    return 1;  /* file handle already on stack top */
+  else return luaL_fileresult(L, status, NULL);
+}
+
+
+static int io_write (lua_State *L) {
+  return g_write(L, getiofile(L, IO_OUTPUT), 1);
+}
+
+
+static int f_write (lua_State *L) {
+  FILE *f = tofile(L);
+  lua_pushvalue(L, 1);  /* push file at the stack top (to be returned) */
+  return g_write(L, f, 2);
+}
+
+
+static int f_seek (lua_State *L) {
+  static const int mode[] = {SEEK_SET, SEEK_CUR, SEEK_END};
+  static const char *const modenames[] = {"set", "cur", "end", NULL};
+  FILE *f = tofile(L);
+  int op = luaL_checkoption(L, 2, "cur", modenames);
+  lua_Integer p3 = luaL_optinteger(L, 3, 0);
+  l_seeknum offset = (l_seeknum)p3;
+  luaL_argcheck(L, (lua_Integer)offset == p3, 3,
+                  "not an integer in proper range");
+  errno = 0;
+  op = l_fseek(f, offset, mode[op]);
+  if (op)
+    return luaL_fileresult(L, 0, NULL);  /* error */
+  else {
+    lua_pushinteger(L, (lua_Integer)l_ftell(f));
+    return 1;
+  }
+}
+
+
+static int f_setvbuf (lua_State *L) {
+  static const int mode[] = {_IONBF, _IOFBF, _IOLBF};
+  static const char *const modenames[] = {"no", "full", "line", NULL};
+  FILE *f = tofile(L);
+  int op = luaL_checkoption(L, 2, NULL, modenames);
+  lua_Integer sz = luaL_optinteger(L, 3, LUAL_BUFFERSIZE);
+  int res;
+  errno = 0;
+  res = setvbuf(f, NULL, mode[op], (size_t)sz);
+  return luaL_fileresult(L, res == 0, NULL);
+}
+
+
+
+static int io_flush (lua_State *L) {
+  FILE *f = getiofile(L, IO_OUTPUT);
+  errno = 0;
+  return luaL_fileresult(L, fflush(f) == 0, NULL);
+}
+
+
+static int f_flush (lua_State *L) {
+  FILE *f = tofile(L);
+  errno = 0;
+  return luaL_fileresult(L, fflush(f) == 0, NULL);
+}
+
+
+/*
+** functions for 'io' library
+*/
+static const luaL_Reg iolib[] = {
+  {"close", io_close},
+  {"flush", io_flush},
+  {"input", io_input},
+  {"lines", io_lines},
+  {"open", io_open},
+  {"output", io_output},
+  {"popen", io_popen},
+  {"read", io_read},
+  {"tmpfile", io_tmpfile},
+  {"type", io_type},
+  {"write", io_write},
+  {NULL, NULL}
+};
+
+
+/*
+** methods for file handles
+*/
+static const luaL_Reg meth[] = {
+  {"read", f_read},
+  {"write", f_write},
+  {"lines", f_lines},
+  {"flush", f_flush},
+  {"seek", f_seek},
+  {"close", f_close},
+  {"setvbuf", f_setvbuf},
+  {NULL, NULL}
+};
+
+
+/*
+** metamethods for file handles
+*/
+static const luaL_Reg metameth[] = {
+  {"__index", NULL},  /* place holder */
+  {"__gc", f_gc},
+  {"__close", f_gc},
+  {"__tostring", f_tostring},
+  {NULL, NULL}
+};
+
+
+static void createmeta (lua_State *L) {
+  luaL_newmetatable(L, WINDOWS_FILE_METATABLE);  /* metatable for file handles */
+  luaL_setfuncs(L, metameth, 0);  /* add metamethods to new metatable */
+  luaL_newlibtable(L, meth);  /* create method table */
+  luaL_setfuncs(L, meth, 0);  /* add file methods to method table */
+  lua_setfield(L, -2, "__index");  /* metatable.__index = method table */
+  lua_pop(L, 1);  /* pop metatable */
+}
+
+
+/*
+** function to (not) close the standard files stdin, stdout, and stderr
+*/
+static int io_noclose (lua_State *L) {
+  LStream *p = tolstream(L);
+  p->closef = &io_noclose;  /* keep file opened */
+  luaL_pushfail(L);
+  lua_pushliteral(L, "cannot close standard file");
+  return 2;
+}
+
+
+int dt_lua_init_windows(lua_State *L){
+    luaL_newlib(L, iolib);
+    createmeta(L);
+
+    return 1;
+}
+
+// clang-format off
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
+// clang-format on

--- a/src/lua/windows.c
+++ b/src/lua/windows.c
@@ -120,7 +120,7 @@ static FILE* l_popen(lua_State *L, const char* filename, const char *mode, PROCE
     free(utf16buf);
     return NULL;
   }
-  
+
   free(utf16buf);
 
   CloseHandle(g_hChildStd_OUT_Wr);
@@ -912,7 +912,8 @@ static void createmeta (lua_State *L) {
 
 
 /*
-** function to (not) close the standard files stdin, stdout, and stderr
+** function to (not) close the standard fi
+les stdin, stdout, and stderr
 */
 static int io_noclose (lua_State *L) {
   LStream *p = tolstream(L);
@@ -924,11 +925,12 @@ static int io_noclose (lua_State *L) {
 
 
 int dt_lua_init_windows(lua_State *L){
-    luaL_newlib(L, iolib);
-    createmeta(L);
-
-    return 1;
-}
+  luaL_newlib(L, iolib);
+  createmeta(L);
+    
+  lua_pop(L, 1);
+  return 0;
+  }
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/lua/windows.h
+++ b/src/lua/windows.h
@@ -1,0 +1,28 @@
+/*
+   This file is part of darktable,
+   Copyright (C) 2013-2020 darktable developers.
+
+   darktable is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   darktable is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+int dt_lua_init_windows(lua_State *L);
+
+// clang-format off
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
+// clang-format on
+


### PR DESCRIPTION
This is basically a WIP for https://github.com/darktable-org/darktable/issues/17193.

It is replacing many of the Lua standard implementation by calling Windows APIs directly, which will not open terminal windows. I have mostly copied the Lua source code and adjusted it where necessary, because everything was so tightly coupled that I could not just replace some functions.