### PR TITLE
Adds a welcome screen to configure basic settings.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -108,6 +108,9 @@ changes (where available).
   with other applications. If SSD is not implemented (Gnome/Mutter
   under Wayland), use client-side decorations (CSD).
 
+- Added a welcome screen to help users understand and set the most
+  relevant configuration options on the first run.
+
 ## Performance Improvements
 
 - Increased performance for OpenCL guided filter by internal tiling.

--- a/data/darktableconfig.dtd
+++ b/data/darktableconfig.dtd
@@ -11,7 +11,7 @@
         title CDATA #REQUIRED
 >
 
-<!ELEMENT dtconfig (name,type,default,capability?,shortdescription?,longdescription?)>
+<!ELEMENT dtconfig (name,type,default,capability?,shortdescription?,longdescription?,welcomescreen?)>
 <!ATTLIST dtconfig
 	prefs IDREF #IMPLIED
         section IDREF #IMPLIED
@@ -36,3 +36,10 @@
 <!ELEMENT default (#PCDATA)>
 <!ELEMENT shortdescription (#PCDATA)>
 <!ELEMENT longdescription (#PCDATA)>
+
+<!ELEMENT welcomescreen EMPTY>
+<!ATTLIST welcomescreen
+        pagenum CDATA #IMPLIED
+        questionnum CDATA #IMPLIED
+        dirchooser (yes|no) #IMPLIED
+>

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -107,6 +107,13 @@
     <shortdescription>show splash screen at startup</shortdescription>
     <longdescription>display a small window showing the progress of darktable startup before the main window appears</longdescription>
   </dtconfig>
+  <dtconfig prefs="misc" section="interface" common="yes">
+    <name>ui/show_welcome_screen</name>
+    <type>bool</type>
+    <default>true</default>
+    <shortdescription>show welcome screen on first run</shortdescription>
+    <longdescription>display the welcome setup screen the first time darktable is launched</longdescription>
+  </dtconfig>
   <dtconfig prefs="misc" section="interface">
     <name>accel/load_defaults</name>
     <type>bool</type>
@@ -326,7 +333,8 @@
     </type>
     <default>on import</default>
     <shortdescription>create XMP files</shortdescription>
-    <longdescription>XMP sidecar files hold information about all your development steps to allow flawless re-importing of image files.\n\ndepending on the selected mode sidecar files will be created:\n - 'never': all development information will be stored only in the library database\n - 'on import': immediately after importing the image\n - 'after edit': after any user change on the image or adding tags.</longdescription>
+    <longdescription><![CDATA[XMP sidecar files store all editing steps, ratings, tags and color labels alongside your images in an open format readable by other applications, and provide an emergency backup if the databse and its backups are lost\n\n<b>never:</b> information is stored only in darktable's database; if it is lost or corrupted, your edits cannot be recovered from the files\n\n<b>after edit:</b> the XMP file is created after the first intentional (i.e., non auto-applied) edit and updated after each editing session\n\n<b>on import:</b> an XMP file is created when the image is imported, and updated after each change]]></longdescription>
+    <welcomescreen pagenum="3" questionnum="1"/>
   </dtconfig>
   <dtconfig prefs="storage" section="XMP">
     <name>compress_xmp_tags</name>
@@ -1587,7 +1595,8 @@
     <type>string</type>
     <default>$(PICTURES_FOLDER)/Darktable</default>
     <shortdescription>base filmroll's directory</shortdescription>
-    <longdescription>directory where new imported filmrolls are created</longdescription>
+    <longdescription><![CDATA[directory where newly imported filmrolls are stored; the default uses <b>$(PICTURES_FOLDER)</b>, which expands to your system's pictures folder: <i>~/Pictures</i> on macOS and Linux, <i>C:/Users/username/Pictures</i> on Windows]]></longdescription>
+    <welcomescreen pagenum="2" questionnum="1" dirchooser="yes"/>
   </dtconfig>
 
   <dtconfig prefs="import" section="session">
@@ -1752,7 +1761,8 @@
      <type>bool</type>
     <default>true</default>
     <shortdescription>prioritize the hovered image over the selected images</shortdescription>
-    <longdescription>this defines how the list of images to act on is constructed.</longdescription>
+    <longdescription><![CDATA[in the lightroom, where culling takes place, you can apply actions (e.g., setting ratings) to the hovered image or to the selected ones\n\n<b>enabled</b> actions apply to the hovered image (less clicking)\n\n<b>disabled</b> actions apply to the current selection (less error prone)]]></longdescription>
+    <welcomescreen pagenum="4" questionnum="1"/>
   </dtconfig>
   <dtconfig>
     <name>plugins/lighttable/collect/num_rules</name>
@@ -2349,7 +2359,8 @@
     <type>bool</type>
     <default>false</default>
     <shortdescription>mouse wheel scrolls modules side panel by default</shortdescription>
-    <longdescription>when enabled, use mouse wheel to scroll modules side panel.  use ctrl+alt to use mouse wheel for data entry.  when disabled, this behavior is reversed</longdescription>
+    <longdescription><![CDATA[in darktable's darkroom, where you do your edits, all controls are listed on a panel on the right; you can choose whether you want to use the scroll wheel or scroll gesture on your touchpad to scroll the panel, or to change the values of the control under the pointer; this latter modality enables faster editing, but it can be confusing if you are not used to it\n\n<b>enabled:</b> the mouse wheel scrolls the modules panel and <i>Ctrl+Alt</i> adjusts a control's value\n\n<b>disabled:</b> the mouse wheel adjusts the control under the pointer and <i>Ctrl+Alt</i> scrolls the panel.]]></longdescription>
+    <welcomescreen pagenum="5" questionnum="1"/>
   </dtconfig>
   <dtconfig prefs="darkroom" section="general">
     <name>plugins/darkroom/ui/border_size</name>
@@ -3642,7 +3653,8 @@
     </type>
     <default>scene-referred (sigmoid)</default>
     <shortdescription>auto-apply pixel workflow defaults</shortdescription>
-    <longdescription>scene-referred workflow is based on linear modules and will auto-apply the corresponding tone mapper (shown in parenthesis), color calibration and exposure,\ndisplay-referred workflow is based on Lab modules and will auto-apply base curve, white balance and the legacy module pipe order.</longdescription>
+    <longdescription><![CDATA[selects which workflow will use by default in the darkroom\n\n<b>scene-referred (sigmoid)</b> modern workflow, fewer tonemapper controls\n\n<b>scene-referred (filmic)</b> modern workflow, more tone mapping controls\n\n<b>scene-referred (AgX)</b> modern workflow, maximum tone mapping control\n\n<b>display-referred (legacy)</b> legacy workflow (not recommended)\n\n<b>none</b> do not use a predefined workflow]]></longdescription>
+    <welcomescreen pagenum="1" questionnum="1"/>
   </dtconfig>
   <dtconfig prefs="processing" section="general">
     <name>plugins/darkroom/basecurve/auto_apply_percamera_presets</name>

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -2520,6 +2520,40 @@ Details :
     margin-bottom: 10pt;
 }
 
+/* welcome screen */
+#welcome-page
+{
+    padding: 16px;
+}
+
+#welcome-page > box
+{
+    margin-top: 4px;
+    margin-bottom: 4px;
+}
+
+#welcome-page > box > box
+{
+    margin-top: 4px;
+    margin-bottom: 4px;
+}
+
+#welcome-paragraph
+{
+  margin-top: 1em;
+  margin-bottom: 1em;
+}
+
+#welcome-footer
+{
+    padding: 8px;
+}
+
+#welcome-prev,
+#welcome-next {
+  margin-right: .2em;
+}
+
 /* ??? TO BE REMOVED ON DT 5.0 : script_manager power button */
 button#pb_off
 {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -148,6 +148,7 @@ FILE(GLOB SOURCE_FILES
   "gui/preferences.c"
   "gui/presets.c"
   "gui/splash.c"
+  "gui/welcome.c"
   "gui/styles_dialog.c"
   "imageio/imageio.c"
   "imageio/imageio_jpeg.c"

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -69,6 +69,7 @@
 #include "gui/presets.h"
 #include "gui/styles.h"
 #include "gui/splash.h"
+#include "gui/welcome.h"
 #include "imageio/imageio_module.h"
 #include "libs/lib.h"
 #include "lua/init.h"
@@ -2038,6 +2039,7 @@ int dt_init(int argc,
     dt_gui_gtk_load_config();
     dt_gui_process_events();
     dt_splash_screen_destroy();
+    dt_welcome_screen_run_if_needed();
 
     // finally set the cursor to be the default.
     // for some reason this is needed on some systems to pick up the correctly themed cursor

--- a/src/control/conf.c
+++ b/src/control/conf.c
@@ -500,7 +500,10 @@ gchar *dt_conf_read_values(const char *filename,
   }
   else if(darktable.conf->x_confgen)
   {
-    // we initialize the conf table with default values
+    // We initialize the conf table with default values.
+    // For common keys, prefer the value already loaded from darktablerc-common
+    // (if present) over the confgen default, so that a freshly-created
+    // darktablerc inherits shared settings rather than resetting them.
     GHashTableIter iter;
     gpointer key, value;
 
@@ -508,6 +511,8 @@ gchar *dt_conf_read_values(const char *filename,
     while(g_hash_table_iter_next (&iter, &key, &value))
     {
       const char *name = (const char *)key;
+      if(dt_confgen_is_common(name) && g_hash_table_lookup(darktable.conf->table, name))
+        continue;
       const dt_confgen_value_t *entry = (dt_confgen_value_t *)value;
       gchar *v = callback(name, entry->def);
       if(v)
@@ -932,6 +937,76 @@ void dt_conf_cleanup(dt_conf_t *cf)
   g_hash_table_unref(cf->override_entries);
   g_hash_table_unref(cf->x_confgen);
   dt_pthread_mutex_destroy(&darktable.conf->mutex);
+}
+
+// ── welcome-screen metadata ───────────────────────────────────────────────────
+
+int dt_confgen_get_welcome_pagenum(const char *name)
+{
+  const dt_confgen_value_t *item = g_hash_table_lookup(darktable.conf->x_confgen, name);
+  return item ? item->welcome_pagenum : 0;
+}
+
+gboolean dt_confgen_get_welcome_dirchooser(const char *name)
+{
+  const dt_confgen_value_t *item = g_hash_table_lookup(darktable.conf->x_confgen, name);
+  return item ? item->welcome_dirchooser : FALSE;
+}
+
+static gint _welcome_key_compare(gconstpointer a, gconstpointer b)
+{
+  const dt_confgen_value_t *ea =
+    g_hash_table_lookup(darktable.conf->x_confgen, (const char *)a);
+  const dt_confgen_value_t *eb =
+    g_hash_table_lookup(darktable.conf->x_confgen, (const char *)b);
+  if(!ea || !eb) return 0;
+  if(ea->welcome_pagenum != eb->welcome_pagenum)
+    return ea->welcome_pagenum - eb->welcome_pagenum;
+  return ea->welcome_questionnum - eb->welcome_questionnum;
+}
+
+GList *dt_confgen_get_welcome_keys(void)
+{
+  GList *result = NULL;
+  GHashTableIter iter;
+  gpointer key, value;
+  g_hash_table_iter_init(&iter, darktable.conf->x_confgen);
+  while(g_hash_table_iter_next(&iter, &key, &value))
+  {
+    const dt_confgen_value_t *entry = value;
+    if(entry->welcome_pagenum > 0)
+      result = g_list_prepend(result, g_strdup((const char *)key));
+  }
+  result = g_list_sort(result, _welcome_key_compare);
+
+  // validate page and question numbering: pages must start at 1 with no gaps;
+  // questions on each page must start at 1 with no gaps.
+  int expected_page = 1;
+  int expected_question = 1;
+  int cur_page = 0;
+  for(GList *l = result; l; l = l->next)
+  {
+    const char *k = l->data;
+    const dt_confgen_value_t *e = g_hash_table_lookup(darktable.conf->x_confgen, k);
+    if(!e) continue;
+
+    if(e->welcome_pagenum != cur_page)
+    {
+      if(e->welcome_pagenum != expected_page)
+        fprintf(stderr, "[confgen] welcome screen: expected page %d but got page %d (key: %s)\n",
+                expected_page, e->welcome_pagenum, k);
+      cur_page = e->welcome_pagenum;
+      expected_page = cur_page + 1;
+      expected_question = 1;
+    }
+
+    if(e->welcome_questionnum != expected_question)
+      fprintf(stderr, "[confgen] welcome screen: on page %d expected question %d but got %d (key: %s)\n",
+              cur_page, expected_question, e->welcome_questionnum, k);
+    expected_question = e->welcome_questionnum + 1;
+  }
+
+  return result;
 }
 
 // clang-format off

--- a/src/control/conf.h
+++ b/src/control/conf.h
@@ -47,6 +47,9 @@ typedef struct dt_confgen_value_t
   char *shortdesc;
   char *longdesc;
   gboolean is_common;
+  int    welcome_pagenum;      // 0 = not on welcome screen; >0 = page number
+  int    welcome_questionnum;  // sort order within page
+  gboolean welcome_dirchooser; // TRUE to use a directory chooser widget
 } dt_confgen_value_t;
 
 typedef struct dt_conf_t
@@ -139,6 +142,13 @@ const char *dt_confgen_get(const char *name,
 
 const char *dt_confgen_get_label(const char *name);
 const char *dt_confgen_get_tooltip(const char *name);
+
+// welcome-screen metadata
+int         dt_confgen_get_welcome_pagenum(const char *name);
+gboolean    dt_confgen_get_welcome_dirchooser(const char *name);
+// Returns a newly-allocated GList of g_strdup'd conf keys with welcome_pagenum > 0,
+// sorted by (pagenum, questionnum).
+GList      *dt_confgen_get_welcome_keys(void);
 
 gboolean dt_conf_is_default(const char *name);
 gchar* dt_conf_expand_default_dir(const char *dir);

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -1200,7 +1200,9 @@ gboolean dt_shortcut_tooltip_callback(GtkWidget *widget,
     GtkWidget *label = gtk_label_new(NULL);
     gtk_label_set_markup(GTK_LABEL(label), markup_text);
     gtk_label_set_line_wrap(GTK_LABEL(label), TRUE);
-    if(original_markup && !strchr(original_markup,'\n'))
+    // Set a preferred width for tooltips that have no manual line breaks,
+    // or that contain markup tags (which tend to produce long runs of text).
+    if(original_markup && (!strchr(original_markup, '\n') || strchr(original_markup, '<')))
       gtk_label_set_max_width_chars(GTK_LABEL(label), 70);
     gtk_widget_set_halign(label, GTK_ALIGN_START);
 

--- a/src/gui/preferences.c
+++ b/src/gui/preferences.c
@@ -1371,7 +1371,7 @@ GtkWidget *dt_gui_preferences_bool(GtkGrid *grid,
                                    const gboolean swap)
 {
   GtkWidget *w_label = dt_ui_label_new(_(dt_confgen_get_label(key)));
-  gtk_widget_set_tooltip_text(w_label, _(dt_confgen_get_tooltip(key)));
+  gtk_widget_set_tooltip_markup(w_label, _(dt_confgen_get_tooltip(key)));
   GtkWidget *labelev = gtk_event_box_new();
   gtk_widget_add_events(labelev, GDK_BUTTON_PRESS_MASK);
   gtk_container_add(GTK_CONTAINER(labelev), w_label);
@@ -1429,7 +1429,7 @@ GtkWidget *dt_gui_preferences_int(GtkGrid *grid,
                                   const guint line)
 {
   GtkWidget *w_label = dt_ui_label_new(_(dt_confgen_get_label(key)));
-  gtk_widget_set_tooltip_text(w_label, _(dt_confgen_get_tooltip(key)));
+  gtk_widget_set_tooltip_markup(w_label, _(dt_confgen_get_tooltip(key)));
   GtkWidget *labelev = gtk_event_box_new();
   gtk_widget_add_events(labelev, GDK_BUTTON_PRESS_MASK);
   gtk_container_add(GTK_CONTAINER(labelev), w_label);
@@ -1470,7 +1470,7 @@ GtkWidget *dt_gui_preferences_enum(dt_action_t *action,
                                                  : DT_BAUHAUS_COMBOBOX_ALIGN_LEFT;
   dt_bauhaus_combobox_set_selected_text_align(w, align);
   if(action)
-    gtk_widget_set_tooltip_text(w, _(dt_confgen_get_tooltip(key)));
+    gtk_widget_set_tooltip_markup(w, _(dt_confgen_get_tooltip(key)));
 
   const char *values = dt_confgen_get(key, DT_VALUES);
   const char *defstr = dt_confgen_get(key, DT_DEFAULT);
@@ -1540,7 +1540,7 @@ GtkWidget *dt_gui_preferences_string(GtkGrid *grid,
                                      const guint line)
 {
   GtkWidget *w_label = dt_ui_label_new(_(dt_confgen_get_label(key)));
-  gtk_widget_set_tooltip_text(w_label, _(dt_confgen_get_tooltip(key)));
+  gtk_widget_set_tooltip_markup(w_label, _(dt_confgen_get_tooltip(key)));
   GtkWidget *labelev = gtk_event_box_new();
   gtk_widget_add_events(labelev, GDK_BUTTON_PRESS_MASK);
   gtk_container_add(GTK_CONTAINER(labelev), w_label);

--- a/src/gui/welcome.c
+++ b/src/gui/welcome.c
@@ -367,7 +367,7 @@ static GtkWidget *_build_page_widget(_dt_page_t *pg)
       const char *curval = dt_conf_get_string_const(q->conf_key);
       for(int oi = 0; oi < q->n_options; oi++)
       {
-        gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(combo), _(q->options[oi]));
+        gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(combo), g_dpgettext2(NULL, "preferences", q->options[oi]));
         if(g_strcmp0(curval, q->options[oi]) == 0)
           gtk_combo_box_set_active(GTK_COMBO_BOX(combo), oi);
       }
@@ -678,13 +678,13 @@ void dt_welcome_screen_show(dt_welcome_screen_t *ws)
   }
 
   // Navigation buttons (right-aligned)
-  GtkWidget *btn_prev = gtk_button_new_with_mnemonic(_("_Prev"));
+  GtkWidget *btn_prev = gtk_button_new_with_mnemonic(_("_prev"));
   gtk_widget_set_name(btn_prev, "welcome-prev");
 
-  GtkWidget *btn_next = gtk_button_new_with_mnemonic(_("_Next"));
+  GtkWidget *btn_next = gtk_button_new_with_mnemonic(_("_next"));
   gtk_widget_set_name(btn_next, "welcome-next");
 
-  GtkWidget *btn_close = gtk_button_new_with_mnemonic(_("_Close"));
+  GtkWidget *btn_close = gtk_button_new_with_mnemonic(_("_close"));
   gtk_widget_set_name(btn_close, "welcome-close");
 
   dt_gui_box_add(GTK_BOX(footer), dt_gui_expand(progress_box),

--- a/src/gui/welcome.c
+++ b/src/gui/welcome.c
@@ -1,0 +1,829 @@
+/*
+    This file is part of darktable,
+    Copyright (C) 2026 darktable developers.
+
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    darktable is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "welcome.h"
+#include "common/darktable.h"
+#include "control/conf.h"
+#include "dtgtk/button.h"
+#include "gui/gtk.h"
+#ifdef GDK_WINDOWING_QUARTZ
+#include "osx/osx.h"
+#endif
+
+#define LOGO_SIZE 80
+
+// ── internal types ────────────────────────────────────────────────────────────
+
+// Action that fires when a checkbox is toggled.
+typedef enum
+{
+  DT_WELCOME_ACTION_NONE,
+  DT_WELCOME_ACTION_SET_BOOL,
+} _dt_welcome_action_type_t;
+
+typedef struct
+{
+  _dt_welcome_action_type_t type;
+  const char *key;
+} _dt_welcome_action_t;
+
+typedef enum
+{
+  DT_QUESTION_CHECKBOX,
+  DT_QUESTION_DIRCHOOSER,
+  DT_QUESTION_PARAGRAPH,
+  DT_QUESTION_COMBOBOX,
+} _dt_question_type_t;
+
+typedef struct
+{
+  GPtrArray *questions; // array of _dt_question_t *
+} _dt_page_t;
+
+typedef struct
+{
+  _dt_question_type_t qtype;
+  char *label;       // widget label text
+  char *description; // optional, HTML subset → rendered as Pango markup
+  gboolean centered; // for DT_QUESTION_PARAGRAPH: centre-align text
+  // CHECKBOX only:
+  gboolean default_active;
+  _dt_welcome_action_t action;
+  // DIRCHOOSER and COMBOBOX:
+  char *conf_key;
+  // COMBOBOX only:
+  char **options; // array of option strings (conf values = display text)
+  int n_options;
+} _dt_question_t;
+
+struct _dt_welcome_screen_t
+{
+  GPtrArray *pages; // array of _dt_page_t *
+};
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+static void _free_question(gpointer p)
+{
+  _dt_question_t *q = p;
+  g_free(q->label);
+  g_free(q->description);
+  if(q->qtype == DT_QUESTION_DIRCHOOSER || q->qtype == DT_QUESTION_COMBOBOX)
+  {
+    g_free(q->conf_key);
+    if(q->qtype == DT_QUESTION_COMBOBOX)
+    {
+      for(int i = 0; i < q->n_options; i++)
+        g_free(q->options[i]);
+      g_free(q->options);
+    }
+  }
+  else if(q->qtype == DT_QUESTION_CHECKBOX && q->action.type != DT_WELCOME_ACTION_NONE)
+    g_free((char *)q->action.key);
+  g_free(q);
+}
+
+static void _free_page(gpointer p)
+{
+  _dt_page_t *pg = p;
+  g_ptr_array_free(pg->questions, TRUE);
+  g_free(pg);
+}
+
+// ── logo ──────────────────────────────────────────────────────────────────────
+
+static GtkWidget *_get_logo(void)
+{
+  const dt_logo_season_t season = dt_util_get_logo_season();
+  gchar *image_file =
+      season == DT_LOGO_SEASON_NONE
+          ? g_strdup_printf("%s/pixmaps/idbutton.svg", darktable.datadir)
+          : g_strdup_printf("%s/pixmaps/idbutton-%d.svg", darktable.datadir, season);
+
+  GdkPixbuf *pb = gdk_pixbuf_new_from_file_at_size(image_file, LOGO_SIZE, -1, NULL);
+  g_free(image_file);
+
+  GtkWidget *logo;
+  if(pb)
+  {
+    logo = gtk_image_new_from_pixbuf(pb);
+    g_object_unref(pb);
+  }
+  else
+    logo = gtk_label_new("darktable");
+
+  gtk_widget_set_name(logo, "welcome-logo");
+  gtk_widget_set_halign(logo, GTK_ALIGN_CENTER);
+  return logo;
+}
+
+// ── checkbox callback ─────────────────────────────────────────────────────────
+
+static void _on_answer_toggled(GtkToggleButton *btn, gpointer data)
+{
+  const _dt_welcome_action_t *action = data;
+  if(action->type == DT_WELCOME_ACTION_SET_BOOL)
+    dt_conf_set_bool(action->key, gtk_toggle_button_get_active(btn));
+}
+
+// ── dirchooser callbacks ──────────────────────────────────────────────────────
+
+static void _on_dir_entry_changed(GtkEntry *entry, gpointer data)
+{
+  dt_conf_set_string((const char *)data, gtk_entry_get_text(entry));
+}
+
+static void _on_browse_dir_clicked(GtkWidget *btn, gpointer data)
+{
+  GtkEntry *entry = GTK_ENTRY(data);
+  GtkWidget *topwindow = gtk_widget_get_toplevel(btn);
+  if(!GTK_IS_WINDOW(topwindow))
+    topwindow = dt_ui_main_window(darktable.gui->ui);
+
+  GtkFileChooserNative *fc = gtk_file_chooser_native_new(
+      _("select directory"), GTK_WINDOW(topwindow),
+      GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER, _("_open"), _("_cancel"));
+
+  // Strip pattern variables (e.g. "$(PICTURES_FOLDER)/...") before
+  // passing the path to the chooser.
+  gchar *old = g_strdup(gtk_entry_get_text(entry));
+  char *dollar = g_strstr_len(old, -1, "$");
+  if(dollar)
+    *dollar = '\0';
+  if(*old)
+    gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(fc), old);
+  g_free(old);
+
+  if(gtk_native_dialog_run(GTK_NATIVE_DIALOG(fc)) == GTK_RESPONSE_ACCEPT)
+  {
+    gchar *dir = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(fc));
+    // Escape backslashes (needed on Windows; harmless elsewhere).
+    gchar *escaped = dt_util_str_replace(dir, "\\", "\\\\");
+    gtk_entry_set_text(entry, escaped); // "changed" signal writes to conf
+    g_free(dir);
+    g_free(escaped);
+  }
+  g_object_unref(fc);
+}
+
+// ── combobox callback ─────────────────────────────────────────────────────────
+
+static void _on_combo_changed(GtkComboBox *combo, gpointer data)
+{
+  const _dt_question_t *q = data;
+  const int idx = gtk_combo_box_get_active(combo);
+  if(idx >= 0 && idx < q->n_options)
+    dt_conf_set_string(q->conf_key, q->options[idx]);
+}
+
+// ── navigation state ──────────────────────────────────────────────────────────
+
+typedef struct
+{
+  GtkWidget *stack;
+  GtkWidget *prev_btn;
+  GtkWidget *next_btn;
+  GtkWidget *progress_box;
+  int n_stack_pages; // user pages + final page
+  int current;
+} _nav_t;
+
+static void _update_navigation(_nav_t *nav)
+{
+  // Update stack
+  GList *children = gtk_container_get_children(GTK_CONTAINER(nav->stack));
+  GtkWidget *target = g_list_nth_data(children, nav->current);
+  if(target)
+    gtk_stack_set_visible_child(GTK_STACK(nav->stack), target);
+  g_list_free(children);
+
+  // Prev / Next: always visible, just grayed out when unavailable.
+  const gboolean is_last = (nav->current == nav->n_stack_pages - 1);
+  gtk_widget_set_sensitive(nav->prev_btn, nav->current > 0);
+  gtk_widget_set_sensitive(nav->next_btn, !is_last);
+
+  // Progress dots
+  GList *dots = gtk_container_get_children(GTK_CONTAINER(nav->progress_box));
+  int idx = 0;
+  for(GList *l = dots; l; l = l->next, idx++)
+  {
+    GtkWidget *dot = l->data;
+    gtk_label_set_text(GTK_LABEL(dot), idx == nav->current ? "●" : "○");
+  }
+  g_list_free(dots);
+}
+
+static void _on_prev(GtkWidget *btn, gpointer data)
+{
+  (void)btn;
+  _nav_t *nav = data;
+  if(nav->current > 0)
+  {
+    nav->current--;
+    _update_navigation(nav);
+  }
+}
+
+static void _on_next(GtkWidget *btn, gpointer data)
+{
+  (void)btn;
+  _nav_t *nav = data;
+  if(nav->current < nav->n_stack_pages - 1)
+  {
+    nav->current++;
+    _update_navigation(nav);
+  }
+}
+
+// ── page widget builder ───────────────────────────────────────────────────────
+
+static GtkWidget *_build_page_widget(_dt_page_t *pg)
+{
+  // The box IS the page: vertically centered in the stack's allocated height,
+  // so that content floats in the middle rather than sticking to the top.
+  GtkWidget *box = dt_gui_vbox();
+  gtk_widget_set_name(box, "welcome-page");
+  gtk_widget_set_valign(box, GTK_ALIGN_CENTER);
+
+  for(guint qi = 0; qi < pg->questions->len; qi++)
+  {
+    _dt_question_t *q = pg->questions->pdata[qi];
+
+    if(q->qtype == DT_QUESTION_PARAGRAPH)
+    {
+      GtkWidget *para = gtk_label_new(NULL);
+      gtk_label_set_markup(GTK_LABEL(para), q->label);
+      gtk_widget_set_name(para, "welcome-paragraph");
+      gtk_label_set_line_wrap(GTK_LABEL(para), TRUE);
+      if(q->centered)
+      {
+        gtk_widget_set_halign(para, GTK_ALIGN_CENTER);
+        gtk_label_set_xalign(GTK_LABEL(para), 0.5f);
+        gtk_label_set_justify(GTK_LABEL(para), GTK_JUSTIFY_CENTER);
+      }
+      else
+      {
+        gtk_widget_set_halign(para, GTK_ALIGN_FILL);
+        gtk_label_set_xalign(GTK_LABEL(para), 0.0f);
+        gtk_label_set_justify(GTK_LABEL(para), GTK_JUSTIFY_LEFT);
+      }
+      dt_gui_box_add(GTK_BOX(box), para);
+    }
+    else if(q->qtype == DT_QUESTION_DIRCHOOSER)
+    {
+      // Row 1: [bold label (left)] [entry + browse button (right)]
+      // Row 2: description, left-aligned
+      GtkWidget *col = dt_gui_vbox();
+      gtk_widget_set_hexpand(col, TRUE);
+
+      GtkWidget *row1 = dt_gui_hbox();
+
+      GtkWidget *lbl = gtk_label_new(NULL);
+      {
+        char *esc = g_markup_escape_text(q->label, -1);
+        char *mu = g_strdup_printf("<b>%s</b>", esc);
+        gtk_label_set_markup(GTK_LABEL(lbl), mu);
+        g_free(esc);
+        g_free(mu);
+      }
+      gtk_widget_set_name(lbl, "welcome-answer");
+      gtk_widget_set_halign(lbl, GTK_ALIGN_START);
+      gtk_widget_set_valign(lbl, GTK_ALIGN_CENTER);
+
+      GtkWidget *hbox = dt_gui_hbox();
+      GtkWidget *entry = gtk_entry_new();
+      gtk_widget_set_name(entry, "welcome-dir-entry");
+      gtk_widget_set_hexpand(entry, TRUE);
+      const char *cur = dt_conf_get_string_const(q->conf_key);
+      gtk_entry_set_text(GTK_ENTRY(entry), cur ? cur : "");
+      g_signal_connect(G_OBJECT(entry), "changed",
+                       G_CALLBACK(_on_dir_entry_changed), q->conf_key);
+
+      GtkWidget *btn = dtgtk_button_new(dtgtk_cairo_paint_directory, CPF_NONE, NULL);
+      gtk_widget_set_tooltip_text(btn, _("select directory"));
+      g_signal_connect(G_OBJECT(btn), "clicked",
+                       G_CALLBACK(_on_browse_dir_clicked), entry);
+      dt_gui_box_add(GTK_BOX(hbox), entry, btn);
+
+      gtk_widget_set_hexpand(hbox, TRUE);
+      dt_gui_box_add(GTK_BOX(row1), lbl, hbox);
+      dt_gui_box_add(GTK_BOX(col), row1);
+
+      if(q->description && q->description[0])
+      {
+        GtkWidget *desc = gtk_label_new(NULL);
+        gtk_label_set_markup(GTK_LABEL(desc), q->description);
+        gtk_widget_set_name(desc, "welcome-question-description");
+        gtk_widget_set_halign(desc, GTK_ALIGN_FILL);
+        gtk_widget_set_hexpand(desc, TRUE);
+        gtk_label_set_xalign(GTK_LABEL(desc), 0.0f);
+        gtk_label_set_line_wrap(GTK_LABEL(desc), TRUE);
+        dt_gui_box_add(GTK_BOX(col), desc);
+      }
+
+      dt_gui_box_add(GTK_BOX(box), col);
+    }
+    else if(q->qtype == DT_QUESTION_COMBOBOX)
+    {
+      // Row 1: [bold label (left)] [combo (right)]
+      // Row 2: description, left-aligned
+      GtkWidget *col = dt_gui_vbox();
+      gtk_widget_set_hexpand(col, TRUE);
+
+      GtkWidget *row1 = dt_gui_hbox();
+
+      GtkWidget *lbl = gtk_label_new(NULL);
+      {
+        char *esc = g_markup_escape_text(q->label, -1);
+        char *mu = g_strdup_printf("<b>%s</b>", esc);
+        gtk_label_set_markup(GTK_LABEL(lbl), mu);
+        g_free(esc);
+        g_free(mu);
+      }
+      gtk_widget_set_name(lbl, "welcome-answer");
+      gtk_widget_set_halign(lbl, GTK_ALIGN_START);
+      gtk_widget_set_valign(lbl, GTK_ALIGN_CENTER);
+      gtk_widget_set_hexpand(lbl, TRUE);
+
+      GtkWidget *combo = gtk_combo_box_text_new();
+      gtk_widget_set_name(combo, "welcome-combo");
+      gtk_widget_set_halign(combo, GTK_ALIGN_END);
+      gtk_widget_set_valign(combo, GTK_ALIGN_CENTER);
+      const char *curval = dt_conf_get_string_const(q->conf_key);
+      for(int oi = 0; oi < q->n_options; oi++)
+      {
+        gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(combo), _(q->options[oi]));
+        if(g_strcmp0(curval, q->options[oi]) == 0)
+          gtk_combo_box_set_active(GTK_COMBO_BOX(combo), oi);
+      }
+      g_signal_connect(G_OBJECT(combo), "changed", G_CALLBACK(_on_combo_changed), q);
+
+      dt_gui_box_add(GTK_BOX(row1), lbl, combo);
+      dt_gui_box_add(GTK_BOX(col), row1);
+
+      if(q->description && q->description[0])
+      {
+        GtkWidget *desc = gtk_label_new(NULL);
+        gtk_label_set_markup(GTK_LABEL(desc), q->description);
+        gtk_widget_set_name(desc, "welcome-question-description");
+        gtk_widget_set_halign(desc, GTK_ALIGN_FILL);
+        gtk_widget_set_hexpand(desc, TRUE);
+        gtk_label_set_xalign(GTK_LABEL(desc), 0.0f);
+        gtk_label_set_line_wrap(GTK_LABEL(desc), TRUE);
+        dt_gui_box_add(GTK_BOX(col), desc);
+      }
+
+      dt_gui_box_add(GTK_BOX(box), col);
+    }
+    else
+    {
+      // CHECKBOX: row 1 = [bold label (left)] [checkbox (right)]
+      //           row 2 = description, left-aligned
+      GtkWidget *col = dt_gui_vbox();
+      gtk_widget_set_hexpand(col, TRUE);
+
+      GtkWidget *row1 = dt_gui_hbox();
+
+      GtkWidget *lbl = gtk_label_new(NULL);
+      {
+        char *esc = g_markup_escape_text(q->label, -1);
+        char *mu = g_strdup_printf("<b>%s</b>", esc);
+        gtk_label_set_markup(GTK_LABEL(lbl), mu);
+        g_free(esc);
+        g_free(mu);
+      }
+      gtk_widget_set_name(lbl, "welcome-answer");
+      gtk_widget_set_halign(lbl, GTK_ALIGN_START);
+      gtk_widget_set_valign(lbl, GTK_ALIGN_CENTER);
+      gtk_widget_set_hexpand(lbl, TRUE);
+
+      GtkWidget *cb = gtk_check_button_new();
+      gtk_widget_set_name(cb, "welcome-answer");
+      gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(cb), q->default_active);
+      gtk_widget_set_valign(cb, GTK_ALIGN_CENTER);
+      if(q->action.type != DT_WELCOME_ACTION_NONE)
+        g_signal_connect(G_OBJECT(cb), "toggled",
+                         G_CALLBACK(_on_answer_toggled), &q->action);
+
+      dt_gui_box_add(GTK_BOX(row1), lbl, cb);
+      dt_gui_box_add(GTK_BOX(col), row1);
+
+      if(q->description && q->description[0])
+      {
+        GtkWidget *desc = gtk_label_new(NULL);
+        gtk_label_set_markup(GTK_LABEL(desc), q->description);
+        gtk_widget_set_name(desc, "welcome-question-description");
+        gtk_widget_set_halign(desc, GTK_ALIGN_FILL);
+        gtk_widget_set_hexpand(desc, TRUE);
+        gtk_label_set_xalign(GTK_LABEL(desc), 0.0f);
+        gtk_label_set_line_wrap(GTK_LABEL(desc), TRUE);
+        dt_gui_box_add(GTK_BOX(col), desc);
+      }
+
+      dt_gui_box_add(GTK_BOX(box), col);
+    }
+  }
+
+  return box;
+}
+
+// ── public API ────────────────────────────────────────────────────────────────
+
+dt_welcome_screen_t *dt_welcome_screen_new(void)
+{
+  dt_welcome_screen_t *ws = g_new0(dt_welcome_screen_t, 1);
+  ws->pages = g_ptr_array_new_with_free_func(_free_page);
+  return ws;
+}
+
+int dt_welcome_screen_add_page(dt_welcome_screen_t *ws)
+{
+  _dt_page_t *pg = g_new0(_dt_page_t, 1);
+  pg->questions = g_ptr_array_new_with_free_func(_free_question);
+  g_ptr_array_add(ws->pages, pg);
+  return (int)ws->pages->len - 1;
+}
+
+static void _page_add_checkbox(dt_welcome_screen_t *ws,
+                               int page_idx,
+                               const char *label,
+                               const char *description,
+                               gboolean default_active,
+                               _dt_welcome_action_t action)
+{
+  _dt_page_t *pg = ws->pages->pdata[page_idx];
+
+  _dt_question_t *q = g_new0(_dt_question_t, 1);
+  q->label = g_strdup(label);
+  q->description = g_strdup(description ? description : "");
+  q->default_active = default_active;
+  q->action = action;
+  if(q->action.type != DT_WELCOME_ACTION_NONE)
+    q->action.key = g_strdup(action.key);
+
+  g_ptr_array_add(pg->questions, q);
+}
+
+void dt_welcome_screen_page_add_dirchooser(dt_welcome_screen_t *ws,
+                                           int page_idx,
+                                           const char *label,
+                                           const char *description,
+                                           const char *conf_key)
+{
+  g_return_if_fail(ws && page_idx >= 0 && page_idx < (int)ws->pages->len);
+
+  _dt_page_t *pg = ws->pages->pdata[page_idx];
+
+  _dt_question_t *q = g_new0(_dt_question_t, 1);
+  q->qtype = DT_QUESTION_DIRCHOOSER;
+  q->label = g_strdup(label);
+  q->description = g_strdup(description ? description : "");
+  q->conf_key = g_strdup(conf_key);
+
+  g_ptr_array_add(pg->questions, q);
+}
+
+static void _page_add_combobox(dt_welcome_screen_t *ws,
+                               int page_idx,
+                               const char *label,
+                               const char *description,
+                               const char *conf_key,
+                               const char *const *options,
+                               int n_options)
+{
+  _dt_page_t *pg = ws->pages->pdata[page_idx];
+  _dt_question_t *q = g_new0(_dt_question_t, 1);
+  q->qtype = DT_QUESTION_COMBOBOX;
+  q->label = g_strdup(label);
+  q->description = g_strdup(description ? description : "");
+  q->conf_key = g_strdup(conf_key);
+  q->n_options = n_options;
+  q->options = g_new(char *, n_options);
+  for(int i = 0; i < n_options; i++)
+    q->options[i] = g_strdup(options[i]);
+  g_ptr_array_add(pg->questions, q);
+}
+
+// Parse confgen DT_VALUES string "[A][B][C]" into a g_new'd array of g_strdup'd strings.
+// *n_out receives the count.  Caller must g_strfreev() the result.
+static char **_parse_enum_values(const char *enum_values, int *n_out)
+{
+  GPtrArray *arr = g_ptr_array_new();
+  for(const char *p = enum_values ? enum_values : ""; *p == '[';)
+  {
+    p++; // skip '['
+    const char *end = strchr(p, ']');
+    if(!end)
+      break;
+    g_ptr_array_add(arr, g_strndup(p, end - p));
+    p = end + 1;
+  }
+  *n_out = (int)arr->len;
+  g_ptr_array_add(arr, NULL); // NULL-terminate for g_strfreev
+  return (char **)g_ptr_array_free(arr, FALSE);
+}
+
+void dt_welcome_screen_page_add_conf(dt_welcome_screen_t *ws,
+                                     int page_idx,
+                                     const char *conf_key,
+                                     const char *description)
+{
+  g_return_if_fail(ws && page_idx >= 0 && page_idx < (int)ws->pages->len);
+  g_return_if_fail(conf_key);
+
+  const dt_confgen_type_t type = dt_confgen_type(conf_key);
+  const char *label = _(dt_confgen_get_label(conf_key));
+
+  switch(type)
+  {
+  case DT_BOOL:
+  {
+    const gboolean def = dt_confgen_get_bool(conf_key, DT_DEFAULT);
+    _dt_welcome_action_t action = {DT_WELCOME_ACTION_SET_BOOL, conf_key};
+    _page_add_checkbox(ws, page_idx, label, description, def, action);
+    break;
+  }
+  case DT_ENUM:
+  {
+    int n = 0;
+    char **opts = _parse_enum_values(dt_confgen_get(conf_key, DT_VALUES), &n);
+    if(n > 0)
+      _page_add_combobox(ws, page_idx, label, description,
+                         conf_key, (const char *const *)opts, n);
+    g_strfreev(opts);
+    break;
+  }
+  case DT_PATH:
+    dt_welcome_screen_page_add_dirchooser(ws, page_idx, label, description, conf_key);
+    break;
+  default:
+    dt_print(DT_DEBUG_ALWAYS,
+             "[welcome] conf key '%s' has unsupported type for welcome screen\n", conf_key);
+    break;
+  }
+}
+
+void dt_welcome_screen_page_add_paragraph(dt_welcome_screen_t *ws,
+                                          int page_idx,
+                                          const char *text,
+                                          gboolean centered)
+{
+  g_return_if_fail(ws && page_idx >= 0 && page_idx < (int)ws->pages->len);
+
+  _dt_page_t *pg = ws->pages->pdata[page_idx];
+  _dt_question_t *q = g_new0(_dt_question_t, 1);
+  q->qtype = DT_QUESTION_PARAGRAPH;
+  q->label = g_strdup(text ? text : "");
+  q->centered = centered;
+  g_ptr_array_add(pg->questions, q);
+}
+
+// Called by the close button; destroys the window, which causes the
+// GMainLoop in dt_welcome_screen_show() to quit.
+static void _on_close(GtkWidget *btn, gpointer data)
+{
+  (void)btn;
+  gtk_widget_destroy(GTK_WIDGET(data));
+}
+
+void dt_welcome_screen_show(dt_welcome_screen_t *ws)
+{
+  GtkWindow *main_win = GTK_WINDOW(dt_ui_main_window(darktable.gui->ui));
+
+  // Use a plain GtkWindow instead of GtkDialog so there is no
+  // built-in (empty) action area leaving dead space at the bottom.
+  GtkWidget *window = gtk_window_new(GTK_WINDOW_TOPLEVEL);
+  gtk_window_set_title(GTK_WINDOW(window), _("Welcome to darktable!"));
+  gtk_window_set_transient_for(GTK_WINDOW(window), main_win);
+  gtk_window_set_modal(GTK_WINDOW(window), TRUE);
+  gtk_window_set_destroy_with_parent(GTK_WINDOW(window), TRUE);
+  gtk_widget_set_name(window, "welcome-dialog");
+
+#ifdef GDK_WINDOWING_QUARTZ
+  dt_osx_disallow_fullscreen(window);
+#endif
+
+  gtk_window_set_default_size(GTK_WINDOW(window), 500, -1);
+  gtk_window_set_position(GTK_WINDOW(window), GTK_WIN_POS_CENTER_ON_PARENT);
+
+  GtkWidget *content = dt_gui_vbox();
+  gtk_widget_set_name(content, "welcome-content");
+  gtk_container_add(GTK_CONTAINER(window), content);
+
+  // ── static header (logo + app name) – never moves between pages ──────────
+  dt_gui_box_add(GTK_BOX(content), _get_logo());
+
+  GtkWidget *app_name = gtk_label_new(_("Welcome to darktable!"));
+  gtk_widget_set_name(app_name, "welcome-title");
+  gtk_widget_set_halign(app_name, GTK_ALIGN_CENTER);
+  dt_gui_box_add(GTK_BOX(content), app_name);
+
+  GtkWidget *sep_header = gtk_separator_new(GTK_ORIENTATION_HORIZONTAL);
+  gtk_widget_set_name(sep_header, "welcome-separator");
+  dt_gui_box_add(GTK_BOX(content), sep_header);
+
+  // ── stack of pages ────────────────────────────────────────────────────────
+  GtkWidget *stack = gtk_stack_new();
+  gtk_stack_set_transition_type(GTK_STACK(stack), GTK_STACK_TRANSITION_TYPE_SLIDE_LEFT_RIGHT);
+  gtk_widget_set_name(stack, "welcome-stack");
+
+  const int n_total = (int)ws->pages->len;
+
+  for(int i = 0; i < n_total; i++)
+  {
+    _dt_page_t *pg = ws->pages->pdata[i];
+    GtkWidget *page = _build_page_widget(pg);
+    char name[16];
+    g_snprintf(name, sizeof(name), "page%d", i);
+    gtk_stack_add_named(GTK_STACK(stack), page, name);
+  }
+
+  gtk_widget_set_vexpand(stack, TRUE);
+  dt_gui_box_add(GTK_BOX(content), dt_gui_expand(stack));
+
+  // ── footer ────────────────────────────────────────────────────────────────
+  GtkWidget *sep_footer = gtk_separator_new(GTK_ORIENTATION_HORIZONTAL);
+  gtk_widget_set_name(sep_footer, "welcome-separator");
+  dt_gui_box_add(GTK_BOX(content), sep_footer);
+
+  GtkWidget *footer = dt_gui_hbox();
+  gtk_widget_set_name(footer, "welcome-footer");
+  dt_gui_box_add(GTK_BOX(content), footer);
+
+  // Progress dots (left-aligned)
+  GtkWidget *progress_box = dt_gui_hbox();
+  gtk_widget_set_name(progress_box, "welcome-progress");
+  gtk_widget_set_halign(progress_box, GTK_ALIGN_START);
+
+  for(int i = 0; i < n_total; i++)
+  {
+    GtkWidget *dot = gtk_label_new(i == 0 ? "●" : "○");
+    gtk_widget_set_name(dot, "welcome-dot");
+    dt_gui_box_add(GTK_BOX(progress_box), dot);
+  }
+
+  // Navigation buttons (right-aligned)
+  GtkWidget *btn_prev = gtk_button_new_with_mnemonic(_("_Prev"));
+  gtk_widget_set_name(btn_prev, "welcome-prev");
+
+  GtkWidget *btn_next = gtk_button_new_with_mnemonic(_("_Next"));
+  gtk_widget_set_name(btn_next, "welcome-next");
+
+  GtkWidget *btn_close = gtk_button_new_with_mnemonic(_("_Close"));
+  gtk_widget_set_name(btn_close, "welcome-close");
+
+  dt_gui_box_add(GTK_BOX(footer), dt_gui_expand(progress_box),
+                 btn_prev, btn_next, btn_close);
+
+  // ── navigation state ──────────────────────────────────────────────────────
+  _nav_t nav = {
+      .stack = stack,
+      .prev_btn = btn_prev,
+      .next_btn = btn_next,
+      .progress_box = progress_box,
+      .n_stack_pages = n_total,
+      .current = 0,
+  };
+
+  g_signal_connect(G_OBJECT(btn_prev), "clicked", G_CALLBACK(_on_prev), &nav);
+  g_signal_connect(G_OBJECT(btn_next), "clicked", G_CALLBACK(_on_next), &nav);
+  g_signal_connect(G_OBJECT(btn_close), "clicked", G_CALLBACK(_on_close), window);
+
+  // Set initial state (hides prev on page 0)
+  _update_navigation(&nav);
+
+  // Block until the window is destroyed (close button or WM close).
+  GMainLoop *loop = g_main_loop_new(NULL, FALSE);
+  g_signal_connect_swapped(G_OBJECT(window), "destroy",
+                           G_CALLBACK(g_main_loop_quit), loop);
+
+  gtk_widget_show_all(window);
+  g_main_loop_run(loop);
+  g_main_loop_unref(loop);
+}
+
+void dt_welcome_screen_free(dt_welcome_screen_t *ws)
+{
+  if(!ws)
+    return;
+  g_ptr_array_free(ws->pages, TRUE);
+  g_free(ws);
+}
+
+// ── content definition & entry point ─────────────────────────────────────────
+
+static dt_welcome_screen_t *_build_welcome_screen(void)
+{
+  dt_welcome_screen_t *ws = dt_welcome_screen_new();
+
+  // ── Page 0: intro (hardcoded) ─────────────────────────────────────────────
+  int page_idx = dt_welcome_screen_add_page(ws);
+
+  dt_welcome_screen_page_add_paragraph
+    (ws, page_idx, _("Let's set up a few options to get you started."), TRUE);
+  dt_welcome_screen_page_add_paragraph
+    (ws, page_idx,
+     _("If you are unsure, don't worry! Just go ahead with the default, "
+       "you can always change all values later in the <b>preferences</b>."),
+     TRUE);
+  dt_welcome_screen_page_add_paragraph
+    (ws, page_idx,
+     _("You can close this window at any time, in which case the defaults will be applied."),
+     TRUE);
+
+  // ── Dynamic conf pages (driven from darktableconfig.xml.in) ──────────────
+  GList *keys = dt_confgen_get_welcome_keys();
+  int cur_page = 0;
+
+  for(GList *l = keys; l; l = l->next)
+  {
+    const char *key = l->data;
+    const int pagenum = dt_confgen_get_welcome_pagenum(key);
+    const char *raw_desc = dt_confgen_get_tooltip(key);
+    const char *desc = (raw_desc && *raw_desc) ? _(raw_desc) : NULL;
+
+    if(pagenum != cur_page)
+    {
+      cur_page = pagenum;
+      page_idx = dt_welcome_screen_add_page(ws);
+    }
+
+    if(dt_confgen_get_welcome_dirchooser(key))
+      dt_welcome_screen_page_add_dirchooser
+        (ws, page_idx, _(dt_confgen_get_label(key)), desc, key);
+    else
+      dt_welcome_screen_page_add_conf(ws, page_idx, key, desc);
+  }
+
+  g_list_free_full(keys, g_free);
+
+  // ── Last page: outro (hardcoded) ──────────────────────────────────────────
+  page_idx = dt_welcome_screen_add_page(ws);
+
+  dt_welcome_screen_page_add_paragraph
+    (ws, page_idx, _("<b>You are all set!</b>"), TRUE);
+  dt_welcome_screen_page_add_paragraph
+    (ws, page_idx,
+     _("darktable is extremely configurable and has a wealth of options. "
+       "Here we covered just the most essential ones — make sure to explore the "
+       "<b>preferences</b> to get the full picture."),
+     TRUE);
+
+  {
+    /* xgettext: %s is a URL; keep <a href="%s"> and </a> unchanged */
+    gchar *text = g_strdup_printf(_("Read the <a href=\"%s\">user manual</a> "
+                                    "to learn more and make the most of darktable."),
+                                  "https://docs.darktable.org/usermanual/stable/en/");
+    dt_welcome_screen_page_add_paragraph
+      (ws, page_idx, text, TRUE);
+    g_free(text);
+  }
+
+  dt_welcome_screen_page_add_paragraph
+    (ws, page_idx,
+     _("And remember that you can always click on the <b>?</b> on "
+       "the top toolbar to get help right where you need it."),
+     TRUE);
+
+  dt_welcome_screen_page_add_paragraph
+    (ws, page_idx, _("Happy editing with darktable!"), TRUE);
+
+  return ws;
+}
+
+void dt_welcome_screen_run_if_needed(void)
+{
+  if(dt_gimpmode())
+    return;
+  if(!dt_conf_get_bool("ui/show_welcome_screen"))
+    return;
+
+  // Clear the flag before showing so that a crash during the dialog
+  // doesn't cause an infinite loop on next launch.
+  dt_conf_set_bool("ui/show_welcome_screen", FALSE);
+
+  dt_welcome_screen_t *ws = _build_welcome_screen();
+  dt_welcome_screen_show(ws);
+  dt_welcome_screen_free(ws);
+}
+
+// clang-format off
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
+// clang-format on

--- a/src/gui/welcome.h
+++ b/src/gui/welcome.h
@@ -1,0 +1,75 @@
+/*
+    This file is part of darktable,
+    Copyright (C) 2026 darktable developers.
+
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    darktable is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <gtk/gtk.h>
+
+// Opaque handle.
+typedef struct _dt_welcome_screen_t dt_welcome_screen_t;
+
+// Allocate an empty welcome screen.
+dt_welcome_screen_t *dt_welcome_screen_new(void);
+
+// Append an empty page.  Returns the page index (0-based) to use with the
+// dt_welcome_screen_page_add_*() functions.
+int dt_welcome_screen_add_page(dt_welcome_screen_t *ws);
+
+// Add a conf-key-driven widget to a page.
+// The widget type (checkbox / combobox / directory chooser) and its label
+// are inferred from the darktableconfig.xml metadata for conf_key.
+// description is optional (NULL = none); it accepts Pango markup
+// (e.g. <b>, <i>, <a href="...">).
+void dt_welcome_screen_page_add_conf(dt_welcome_screen_t *ws,
+                                     int                  page_idx,
+                                     const char          *conf_key,
+                                     const char          *description);
+
+// Add a plain paragraph of text to a page (Pango markup supported).
+// Pass centered=TRUE to centre-align the text horizontally.
+void dt_welcome_screen_page_add_paragraph(dt_welcome_screen_t *ws,
+                                          int                  page_idx,
+                                          const char          *text,
+                                          gboolean             centered);
+
+// Add a directory-chooser row to a page.
+// Reads and writes a string conf key holding the directory path.
+// Use this for string keys that hold path patterns (e.g. containing
+// $(PICTURES_FOLDER)) which cannot be typed as 'dir' in the XML.
+// description is optional (NULL = none).
+void dt_welcome_screen_page_add_dirchooser(dt_welcome_screen_t *ws,
+                                           int                  page_idx,
+                                           const char          *label,
+                                           const char          *description,
+                                           const char          *conf_key);
+
+// Build the GTK dialog and block until the user closes it.
+void dt_welcome_screen_show(dt_welcome_screen_t *ws);
+
+// Free all resources (call after dt_welcome_screen_show returns).
+void dt_welcome_screen_free(dt_welcome_screen_t *ws);
+
+// High-level entry point: checks the "ui/show_welcome_screen" preference,
+// builds and shows the screen on first run, then clears the flag.
+void dt_welcome_screen_run_if_needed(void);
+
+// clang-format off
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
+// clang-format on

--- a/src/libs/geotagging.c
+++ b/src/libs/geotagging.c
@@ -28,6 +28,7 @@
 #include "dtgtk/button.h"
 #include "control/jobs.h"
 #include "gui/accelerators.h"
+#include "gui/gtk.h"
 #include "libs/lib_api.h"
 #ifdef HAVE_MAP
 #include "views/view.h"
@@ -1812,7 +1813,7 @@ void gui_init(dt_lib_module_t *self)
 
   // time zone entry
   GtkWidget *label = dt_ui_label_new(_(dt_confgen_get_label("plugins/lighttable/geotagging/tz")));
-  gtk_widget_set_tooltip_text(label, _(dt_confgen_get_tooltip("plugins/lighttable/geotagging/tz")));
+  gtk_widget_set_tooltip_markup(label, _(dt_confgen_get_tooltip("plugins/lighttable/geotagging/tz")));
 
   gtk_grid_attach(grid, label, 0, line, 2, 1);
 

--- a/tools/generate_darktablerc_conf.xsl
+++ b/tools/generate_darktablerc_conf.xsl
@@ -30,6 +30,9 @@ typedef struct {
    const char *max;		// maximum value (optional, may be NULL or empty string)
    const char *shortdesc;	// short one-line description
    const char *longdesc;	// long, potentially multi-line description (optional)
+   const char *welcome_pagenum;      // "" or page number string for the welcome screen
+   const char *welcome_questionnum;  // sort order within the welcome page
+   const char *welcome_dirchooser;   // "yes" if a directory chooser should be used
 } _default_config_t;
 
 static void _clear_confgen_value(void *value)
@@ -46,6 +49,9 @@ static void _clear_confgen_value(void *value)
   s->shortdesc = NULL;
   g_free(s->longdesc);
   s->longdesc = NULL;
+  s->welcome_pagenum = 0;
+  s->welcome_questionnum = 0;
+  s->welcome_dirchooser = FALSE;
 }
 
 static void _free_confgen_value(void *value)
@@ -78,7 +84,23 @@ static _default_config_t _config_variables[] =
     <xsl:text>",&#xA;    </xsl:text>
     <xsl:apply-templates select="shortdescription"/>
     <xsl:text>,&#xA;    </xsl:text>
-    <xsl:apply-templates select="longdescription"/>
+    <xsl:choose>
+      <xsl:when test="longdescription">
+        <xsl:apply-templates select="longdescription"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:text>""</xsl:text>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:text>,&#xA;    </xsl:text>
+    <xsl:choose>
+      <xsl:when test="welcomescreen">
+        <xsl:apply-templates select="welcomescreen" mode="welcome"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:text>"", "", ""</xsl:text>
+      </xsl:otherwise>
+    </xsl:choose>
     <xsl:text>&#xA;  },&#xA;</xsl:text>
   </xsl:for-each>
 
@@ -116,6 +138,9 @@ void dt_confgen_init()
      item->enum_values = _copy_string(var->enum_values);
      item->shortdesc = _copy_string(var->shortdesc);
      item->longdesc = _copy_string(var->longdesc);
+     item->welcome_pagenum     = var->welcome_pagenum ? atoi(var->welcome_pagenum) : 0;
+     item->welcome_questionnum = var->welcome_questionnum ? atoi(var->welcome_questionnum) : 0;
+     item->welcome_dirchooser = g_strcmp0(var->welcome_dirchooser, "yes") == 0;
      item->is_common = *var->is_common == 'y';
    }
 }
@@ -200,6 +225,12 @@ void dt_confgen_init()
       <xsl:text>"))&#xA;</xsl:text>
     </xsl:if>
   </xsl:for-each>
+</xsl:template>
+
+<xsl:template match="welcomescreen" mode="welcome">
+  <xsl:text>"</xsl:text><xsl:value-of select="@pagenum"/><xsl:text>", "</xsl:text>
+  <xsl:value-of select="@questionnum"/><xsl:text>", "</xsl:text>
+  <xsl:value-of select="@dirchooser"/><xsl:text>"</xsl:text>
 </xsl:template>
 
 </xsl:stylesheet>

--- a/tools/generate_prefs.xsl
+++ b/tools/generate_prefs.xsl
@@ -412,7 +412,7 @@ static void init_tab_generated(GtkWidget *dialog, GtkWidget *stack)
     /* xgettext:no-c-format */</xsl:text>
     </xsl:if>
       <xsl:text>
-    gtk_widget_set_tooltip_text(widget, _("</xsl:text><xsl:value-of select="longdescription"/><xsl:text>"));</xsl:text>
+    gtk_widget_set_tooltip_markup(widget, _("</xsl:text><xsl:value-of select="longdescription"/><xsl:text>"));</xsl:text>
   </xsl:if>
     <xsl:if test="@capability">
       <xsl:text>


### PR DESCRIPTION
This was suggested by @TurboGit. It allows us to keep the current defaults while making sure that new users are at least aware of certain options (most notably, scroll on widgets/panels) and, in case, have a chance to change them before it is too late.

The window, with the exception of the first/last page, which contain static messages, is constructed dynamically based on specific annotations in darktableconfig.xml.in.

The longdescription field is used for the description of the configuration option in the welcome screen, and the widget type is automatically inferred from the property. The `dirchooser` option must be set explicitly when a directory chooser should be used for a string property.

https://github.com/user-attachments/assets/30b4bb12-98ae-4e1e-bea1-d51ccf68d942

The current options that are promoted to the welcome screen are my personal and completely arbitrary selection. Of course, feel free to add/remove. It should remain a relatively small set (5-10) of the most critical options. The ones that I included are the ones that, IMHO, every new user should at least be aware of.

I updated the relevant descriptions to include more context, as when the welcome screen runs users have no clue of what they are doing. Since these tooltips include markup, I updated the call sites that render tooltips in the preferences accordingly.

