### PR TITLE
[Nightly] Support for creating a stable release in draft status

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -442,6 +442,13 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Download artifacts
         uses: actions/download-artifact@v8
+      - name: Get current date and set as environment variable
+        run: |
+          # Format date as YYYYMMDD
+          NOW=$(date +'%Y%m%d')
+          # Set the environment variable for subsequent steps
+          echo "RELEASE_DATE=$NOW" >> $GITHUB_ENV
+        shell: bash
       - name: Create GitHub release
         uses: ncipollo/release-action@v1.20.0
         env:
@@ -454,7 +461,7 @@ jobs:
           # We don't want a stable release that is in the process of being prepared
           # and not yet ready for publication to be visible
           draft: ${{ startsWith(github.ref, 'refs/tags/') }}
-          name: 'Darktable nightly build'
+          name: 'Darktable nightly build ${{ env.RELEASE_DATE }}'
           # Please do not modify the body text by adding line breaks in paragraphs, as this text should display well on screens of different widths
           body: |
             This is a nightly build of Darktable.


### PR DESCRIPTION
Resolves #20458.

[Releaser from andelf](https://github.com/andelf/nightly-release) we've been using so far doesn't support the draft status needed to create stable releases, and the very popular [softprops releaser](https://github.com/softprops/action-gh-release) (which I tried using) doesn't support removing all artifacts in an existing release, which is needed to update nightly releases (we don't want to pile up old artifacts in the nightly release). But another very popular releaser, [ncipollo/release-action](https://github.com/ncipollo/release-action), does everything we need.