### PR TITLE
DNG Opcodelist3 Gainmap for DJI Drones

### DIFF
--- a/data/kernels/dng_opcode.cl
+++ b/data/kernels/dng_opcode.cl
@@ -1,0 +1,85 @@
+/*
+    This file is part of darktable,
+    copyright (c) 2026 darktable developers.
+
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    darktable is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "common.h"
+
+/* DNG OpcodeList3 GainMap, shared by demosaic and rawprepare.
+
+   The bilinear interpolation is written out by hand rather than using a linear
+   sampler so that this stays bit-comparable with dt_dng_gain_map_apply() on the
+   CPU; a sampler would be shorter but introduces hardware dependent rounding.
+   Any change here must be mirrored there. */
+__kernel void
+dng_gain_map(read_only image2d_t in,
+             write_only image2d_t out,
+             global const float *map_gain,
+             const int width,
+             const int height,
+             const int map_w,
+             const int map_h,
+             const int nplanes,
+             const float x0,
+             const float y0,
+             const float step,
+             const float raw_w,
+             const float raw_h,
+             const float rel_to_map_x,
+             const float rel_to_map_y,
+             const float map_origin_h,
+             const float map_origin_v)
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+  if(x >= width || y >= height) return;
+
+  const float rel_y = (y0 + ((float)y + 0.5f) * step) / raw_h;
+  const float y_map = clamp((rel_y - map_origin_v) * rel_to_map_y, 0.0f, (float)(map_h - 1));
+  const int y_i0 = min((int)y_map, map_h - 1);
+  const int y_i1 = min(y_i0 + 1, map_h - 1);
+  const float y_frac = y_map - y_i0;
+
+  const float rel_x = (x0 + ((float)x + 0.5f) * step) / raw_w;
+  const float x_map = clamp((rel_x - map_origin_h) * rel_to_map_x, 0.0f, (float)(map_w - 1));
+  const int x_i0 = min((int)x_map, map_w - 1);
+  const int x_i1 = min(x_i0 + 1, map_w - 1);
+  const float x_frac = x_map - x_i0;
+
+  float gain[3];
+  for(int c = 0; c < 3; c++)
+  {
+    // "the last gain map plane is used for any remaining planes being modified"
+    const int p = min(c, nplanes - 1);
+    const float g00 = map_gain[(y_i0 * map_w + x_i0) * nplanes + p];
+    const float g01 = map_gain[(y_i0 * map_w + x_i1) * nplanes + p];
+    const float g10 = map_gain[(y_i1 * map_w + x_i0) * nplanes + p];
+    const float g11 = map_gain[(y_i1 * map_w + x_i1) * nplanes + p];
+
+    const float gain_top    = (1.0f - x_frac) * g00 + x_frac * g01;
+    const float gain_bottom = (1.0f - x_frac) * g10 + x_frac * g11;
+    gain[c] = (1.0f - y_frac) * gain_top + y_frac * gain_bottom;
+  }
+
+  float4 pixel = Areadpixel(in, x, y);
+  const float alpha = pixel.w;
+  pixel.x *= gain[0];
+  pixel.y *= gain[1];
+  pixel.z *= gain[2];
+  pixel.w = alpha;
+
+  write_imagef(out, (int2)(x, y), pixel);
+}

--- a/data/kernels/programs.conf
+++ b/data/kernels/programs.conf
@@ -44,3 +44,4 @@ colorharmonizer.cl      40
 overlay.cl              41
 bilinear.cl             42
 spektrafilm.cl          43
+dng_opcode.cl           44

--- a/data/kernels/programs.conf
+++ b/data/kernels/programs.conf
@@ -42,3 +42,4 @@ capture.cl              38
 agx.cl                  39
 colorharmonizer.cl      40
 overlay.cl              41
+dng_opcode.cl           42

--- a/src/common/dng_opcode.c
+++ b/src/common/dng_opcode.c
@@ -21,6 +21,7 @@
 
 #include "debug.h"
 #include "dng_opcode.h"
+#include "develop/imageop.h"
 
 #define OPCODE_ID_GAINMAP (9)
 #define OPCODE_ID_WARP_RECTILINEAR (1)
@@ -57,6 +58,38 @@ static uint32_t _get_long(uint8_t *ptr)
   return GUINT32_FROM_BE(in);
 }
 
+static void _parse_and_append_gain_map(uint8_t *param, uint32_t param_size, GList **dng_gain_maps,
+                                        const char *source)
+{
+  uint32_t gain_count = (param_size - 76) / 4;
+  dt_dng_gain_map_t *gm = g_malloc(sizeof(dt_dng_gain_map_t) + gain_count * sizeof(float));
+  gm->top           = _get_long(&param[0]);
+  gm->left          = _get_long(&param[4]);
+  gm->bottom        = _get_long(&param[8]);
+  gm->right         = _get_long(&param[12]);
+  gm->plane         = _get_long(&param[16]);
+  gm->planes        = _get_long(&param[20]);
+  gm->row_pitch     = _get_long(&param[24]);
+  gm->col_pitch     = _get_long(&param[28]);
+  gm->map_points_v  = _get_long(&param[32]);
+  gm->map_points_h  = _get_long(&param[36]);
+  gm->map_spacing_v = _get_double(&param[40]);
+  gm->map_spacing_h = _get_double(&param[48]);
+  gm->map_origin_v  = _get_double(&param[56]);
+  gm->map_origin_h  = _get_double(&param[64]);
+  gm->map_planes    = _get_long(&param[72]);
+  for(int i = 0; i < gain_count; i++)
+    gm->map_gain[i] = _get_float(&param[76 + 4 * i]);
+  *dng_gain_maps = g_list_append(*dng_gain_maps, gm);
+  dt_print(DT_DEBUG_IMAGEIO,
+    "[dng_opcode] %s GainMap parsed: top=%u left=%u bottom=%u right=%u "
+    "plane=%u planes=%u row_pitch=%u col_pitch=%u "
+    "map_points_v=%u map_points_h=%u map_planes=%u gain_count=%u",
+    source, gm->top, gm->left, gm->bottom, gm->right,
+    gm->plane, gm->planes, gm->row_pitch, gm->col_pitch,
+    gm->map_points_v, gm->map_points_h, gm->map_planes, gain_count);
+}
+
 void dt_dng_opcode_process_opcode_list_2(uint8_t *buf, uint32_t buf_size, dt_image_t *img)
 {
   g_list_free_full(img->dng_gain_maps, g_free);
@@ -79,27 +112,7 @@ void dt_dng_opcode_process_opcode_list_2(uint8_t *buf, uint32_t buf_size, dt_ima
 
     if(opcode_id == OPCODE_ID_GAINMAP)
     {
-      uint32_t gain_count = (param_size - 76) / 4;
-      dt_dng_gain_map_t *gm = g_malloc(sizeof(dt_dng_gain_map_t) + gain_count * sizeof(float));
-      gm->top = _get_long(&param[0]);
-      gm->left = _get_long(&param[4]);
-      gm->bottom = _get_long(&param[8]);
-      gm->right = _get_long(&param[12]);
-      gm->plane = _get_long(&param[16]);
-      gm->planes = _get_long(&param[20]);
-      gm->row_pitch = _get_long(&param[24]);
-      gm->col_pitch = _get_long(&param[28]);
-      gm->map_points_v = _get_long(&param[32]);
-      gm->map_points_h = _get_long(&param[36]);
-      gm->map_spacing_v = _get_double(&param[40]);
-      gm->map_spacing_h = _get_double(&param[48]);
-      gm->map_origin_v = _get_double(&param[56]);
-      gm->map_origin_h = _get_double(&param[64]);
-      gm->map_planes = _get_long(&param[72]);
-      for(int i = 0; i < gain_count; i++)
-        gm->map_gain[i] = _get_float(&param[76 + 4*i]);
-
-      img->dng_gain_maps = g_list_append(img->dng_gain_maps, gm);
+      _parse_and_append_gain_map(param, param_size, &(img->dng_gain_maps), "OpcodeList2");
     }
     else
     {
@@ -114,9 +127,13 @@ void dt_dng_opcode_process_opcode_list_2(uint8_t *buf, uint32_t buf_size, dt_ima
 
 void dt_dng_opcode_process_opcode_list_3(uint8_t *buf, uint32_t buf_size, dt_image_t *img)
 {
+  g_list_free_full(img->dng_gain_maps_opcode3, g_free);
+  img->dng_gain_maps_opcode3 = NULL;
+
   dt_image_correction_data_t *cd = &img->exif_correction_data;
   cd->dng.has_warp = FALSE;
   cd->dng.has_vignette = FALSE;
+  cd->dng.has_gainmap = FALSE;
 
   uint32_t count = _get_long(&buf[0]);
   uint32_t offset = 4;
@@ -167,6 +184,16 @@ void dt_dng_opcode_process_opcode_list_3(uint8_t *buf, uint32_t buf_size, dt_ima
       img->exif_correction_type = CORRECTION_TYPE_DNG;
     }
 
+    else if(opcode_id == OPCODE_ID_GAINMAP)
+    {
+      _parse_and_append_gain_map(param, param_size, &(img->dng_gain_maps_opcode3), "OpcodeList3");
+      // unlike WarpRectilinear and VignetteRadial this does not set
+      // exif_correction_type: the GainMap is applied by demosaic or rawprepare, not
+      // by lens, so a file whose only OpcodeList3 entry is a GainMap must not be
+      // pushed into the lens embedded metadata method
+      cd->dng.has_gainmap = TRUE;
+    }
+
     else
     {
       dt_print(DT_DEBUG_IMAGEIO, "[dng_opcode] OpcodeList3 has unsupported %s opcode %d",
@@ -177,3 +204,188 @@ void dt_dng_opcode_process_opcode_list_3(uint8_t *buf, uint32_t buf_size, dt_ima
     count--;
   }
 }
+
+/* GainMap application, shared by demosaic (CFA raws) and rawprepare (linear DNGs).
+   Both see the data as three colour planes, which is the stage OpcodeList3 is
+   defined for, so neither needs any CFA logic. */
+
+const dt_dng_gain_map_t *dt_dng_gain_map_opcode3(const dt_image_t *img)
+{
+  if(g_list_length(img->dng_gain_maps_opcode3) != 1)
+  {
+    // an empty list is the normal case and not worth reporting
+    if(img->dng_gain_maps_opcode3)
+      dt_print(DT_DEBUG_IMAGEIO,
+        "[dng_opcode] GainMap rejected: found %u maps, need exactly 1",
+        g_list_length(img->dng_gain_maps_opcode3));
+    return NULL;
+  }
+
+  const dt_dng_gain_map_t *g =
+    (const dt_dng_gain_map_t *)g_list_nth_data(img->dng_gain_maps_opcode3, 0);
+
+  /* DNG 1.7.1 p.115 leaves MapPlanes free and says "If Planes > MapPlanes, the
+     last gain map plane is used for any remaining planes being modified", so a
+     one plane map covering all three channels is legal and is what a pure
+     falloff correction looks like. Only 1 and 3 are meaningful for three plane
+     data, so anything else is rejected rather than guessed at.
+
+     The map itself need not cover the whole frame -- outside its bounds the
+     spec replicates the edge values, which is what the clamp in the sampler
+     does -- but Top/Left/Bottom/Right bound the *area modified*, and the spec
+     does not say whether MapOrigin and MapSpacing are then relative to that
+     rectangle or to the whole image. Requiring the full frame makes the two
+     readings identical, so that ambiguity cannot bite us. */
+  if(g == NULL
+     || g->plane != 0
+     || g->planes != 3
+     || (g->map_planes != 1 && g->map_planes != 3)
+     || g->row_pitch != 1
+     || g->col_pitch != 1
+     || g->map_points_v < 2
+     || g->map_points_h < 2
+     || g->map_spacing_v <= 0.0
+     || g->map_spacing_h <= 0.0
+     || g->top != 0
+     || g->left != 0
+     || g->bottom != (uint32_t)img->height
+     || g->right != (uint32_t)img->width)
+  {
+    dt_print(DT_DEBUG_IMAGEIO,
+      "[dng_opcode] GainMap rejected: plane=%u planes=%u map_planes=%u "
+      "row_pitch=%u col_pitch=%u map_points_v=%u map_points_h=%u "
+      "top=%u left=%u bottom=%u right=%u (image %dx%d)",
+      g ? g->plane : 0, g ? g->planes : 0, g ? g->map_planes : 0,
+      g ? g->row_pitch : 0, g ? g->col_pitch : 0,
+      g ? g->map_points_v : 0, g ? g->map_points_h : 0,
+      g ? g->top : 0, g ? g->left : 0, g ? g->bottom : 0, g ? g->right : 0,
+      img->width, img->height);
+    return NULL;
+  }
+
+  return g;
+}
+
+void dt_dng_gain_map_apply(const dt_dng_gain_map_t *gm,
+                           const dt_image_t *img,
+                           const float *const in,
+                           float *const out,
+                           const int width,
+                           const int height,
+                           const float x0,
+                           const float y0,
+                           const float step)
+{
+  const int map_w = gm->map_points_h;
+  const int map_h = gm->map_points_v;
+  const int nplanes = gm->map_planes;
+
+  /* The GainMap is defined over the full raw frame, so normalise the raw
+     coordinates the caller gave us against the raw dimensions. The half pixel
+     offset is the pixel-centred convention the spec spells out for these
+     fields (DNG 1.7.1 p.72). */
+  const float raw_w = (float)img->width;
+  const float raw_h = (float)img->height;
+
+  const float rel_to_map_x = 1.0f / gm->map_spacing_h;
+  const float rel_to_map_y = 1.0f / gm->map_spacing_v;
+  const float map_origin_h = gm->map_origin_h;
+  const float map_origin_v = gm->map_origin_v;
+
+  DT_OMP_FOR()
+  for(int row = 0; row < height; row++)
+  {
+    const float rel_y = (y0 + ((float)row + 0.5f) * step) / raw_h;
+    const float y_map = CLAMPF((rel_y - map_origin_v) * rel_to_map_y, 0.0f, (float)(map_h - 1));
+    const int y_i0 = MIN((int)y_map, map_h - 1);
+    const int y_i1 = MIN(y_i0 + 1, map_h - 1);
+    const float y_frac = y_map - y_i0;
+
+    for(int col = 0; col < width; col++)
+    {
+      const size_t idx = 4 * (size_t)(row * width + col);
+      const float rel_x = (x0 + ((float)col + 0.5f) * step) / raw_w;
+      const float x_map = CLAMPF((rel_x - map_origin_h) * rel_to_map_x, 0.0f, (float)(map_w - 1));
+      const int x_i0 = MIN((int)x_map, map_w - 1);
+      const int x_i1 = MIN(x_i0 + 1, map_w - 1);
+      const float x_frac = x_map - x_i0;
+
+      for_three_channels(c)
+      {
+        // "the last gain map plane is used for any remaining planes being modified"
+        const int p = MIN(c, nplanes - 1);
+        const float g00 = gm->map_gain[(y_i0 * map_w + x_i0) * nplanes + p];
+        const float g01 = gm->map_gain[(y_i0 * map_w + x_i1) * nplanes + p];
+        const float g10 = gm->map_gain[(y_i1 * map_w + x_i0) * nplanes + p];
+        const float g11 = gm->map_gain[(y_i1 * map_w + x_i1) * nplanes + p];
+
+        const float gain_top    = (1.0f - x_frac) * g00 + x_frac * g01;
+        const float gain_bottom = (1.0f - x_frac) * g10 + x_frac * g11;
+
+        out[idx + c] = in[idx + c] * ((1.0f - y_frac) * gain_top + y_frac * gain_bottom);
+      }
+
+      out[idx + 3] = in[idx + 3];
+    }
+  }
+}
+
+#ifdef HAVE_OPENCL
+dt_dng_gain_map_cl_global_t *dt_dng_gain_map_init_cl_global(void)
+{
+  dt_dng_gain_map_cl_global_t *g = malloc(sizeof(dt_dng_gain_map_cl_global_t));
+
+  const int program = 44; // dng_opcode.cl, from programs.conf
+  g->kernel_dng_gain_map = dt_opencl_create_kernel(program, "dng_gain_map");
+  return g;
+}
+
+void dt_dng_gain_map_free_cl_global(dt_dng_gain_map_cl_global_t *g)
+{
+  if(!g) return;
+  dt_opencl_free_kernel(g->kernel_dng_gain_map);
+  free(g);
+}
+
+int dt_dng_gain_map_apply_cl(const int devid,
+                             const dt_dng_gain_map_t *gm,
+                             const dt_image_t *img,
+                             cl_mem dev_in,
+                             cl_mem dev_out,
+                             const int width,
+                             const int height,
+                             const float x0,
+                             const float y0,
+                             const float step)
+{
+  const int map_w = gm->map_points_h;
+  const int map_h = gm->map_points_v;
+  const int nplanes = gm->map_planes;
+  const size_t ngains = (size_t)map_w * map_h * nplanes;
+
+  cl_mem dev_map = dt_opencl_copy_host_to_device_constant
+    (devid, ngains * sizeof(float), (void *)gm->map_gain);
+  if(dev_map == NULL) return DT_OPENCL_SYSMEM_ALLOCATION;
+
+  // keep these in step with dt_dng_gain_map_apply()
+  const float raw_w = (float)img->width;
+  const float raw_h = (float)img->height;
+  const float rel_to_map_x = 1.0f / gm->map_spacing_h;
+  const float rel_to_map_y = 1.0f / gm->map_spacing_v;
+  const float map_origin_h = gm->map_origin_h;
+  const float map_origin_v = gm->map_origin_v;
+
+  const int err = dt_opencl_enqueue_kernel_2d_args
+    (devid, darktable.opencl->dng_gain_map->kernel_dng_gain_map, width, height,
+     CLARG(dev_in), CLARG(dev_out), CLARG(dev_map),
+     CLARG(width), CLARG(height),
+     CLARG(map_w), CLARG(map_h), CLARG(nplanes),
+     CLARG(x0), CLARG(y0), CLARG(step),
+     CLARG(raw_w), CLARG(raw_h),
+     CLARG(rel_to_map_x), CLARG(rel_to_map_y),
+     CLARG(map_origin_h), CLARG(map_origin_v));
+
+  dt_opencl_release_mem_object(dev_map);
+  return err;
+}
+#endif

--- a/src/common/dng_opcode.c
+++ b/src/common/dng_opcode.c
@@ -236,7 +236,18 @@ const dt_dng_gain_map_t *dt_dng_gain_map_opcode3(const dt_image_t *img)
      does -- but Top/Left/Bottom/Right bound the *area modified*, and the spec
      does not say whether MapOrigin and MapSpacing are then relative to that
      rectangle or to the whole image. Requiring the full frame makes the two
-     readings identical, so that ambiguity cannot bite us. */
+     readings identical, so that ambiguity cannot bite us.
+
+     "The whole image" here is the active area, not the raw buffer, which is
+     why this compares against p_width/p_height rather than width/height.
+     OpcodeList3 runs after demosaic, by which point rawprepare has cropped
+     the masked borders away, so the rectangle the file describes is the
+     cropped one. Whether a sensor reads out padding depends on the capture
+     mode rather than the camera: an FC8482 in its default binned mode
+     writes a 4096x2268 buffer around a 4032x2268 active area, while the
+     same drone in 48MP mode writes 8064x6048 with no padding. Comparing
+     against width silently rejected a perfectly good map in the first
+     case and worked by luck in the second. */
   if(g == NULL
      || g->plane != 0
      || g->planes != 3
@@ -260,8 +271,8 @@ const dt_dng_gain_map_t *dt_dng_gain_map_opcode3(const dt_image_t *img)
      || !dt_isfinite((float)g->map_origin_h)
      || g->top != 0
      || g->left != 0
-     || g->bottom != (uint32_t)img->height
-     || g->right != (uint32_t)img->width)
+     || g->bottom != (uint32_t)img->p_height
+     || g->right != (uint32_t)img->p_width)
   {
     dt_print(DT_DEBUG_IMAGEIO,
       "[dng_opcode] GainMap rejected: plane=%u planes=%u map_planes=%u "
@@ -271,7 +282,7 @@ const dt_dng_gain_map_t *dt_dng_gain_map_opcode3(const dt_image_t *img)
       g ? g->row_pitch : 0, g ? g->col_pitch : 0,
       g ? g->map_points_v : 0, g ? g->map_points_h : 0,
       g ? g->top : 0, g ? g->left : 0, g ? g->bottom : 0, g ? g->right : 0,
-      img->width, img->height);
+      img->p_width, img->p_height);
     return NULL;
   }
 

--- a/src/common/dng_opcode.c
+++ b/src/common/dng_opcode.c
@@ -21,6 +21,7 @@
 
 #include "debug.h"
 #include "dng_opcode.h"
+#include "common/math.h"
 #include "develop/imageop.h"
 
 #define OPCODE_ID_GAINMAP (9)
@@ -244,8 +245,19 @@ const dt_dng_gain_map_t *dt_dng_gain_map_opcode3(const dt_image_t *img)
      || g->col_pitch != 1
      || g->map_points_v < 2
      || g->map_points_h < 2
-     || g->map_spacing_v <= 0.0
-     || g->map_spacing_h <= 0.0
+     /* The spacings are reciprocated below, so reject anything that will not
+        survive it. Written as !(x > 0.0) rather than x <= 0.0 so that a NaN
+        read from a malformed file is rejected too, and the reciprocal is
+        checked because a positive but denormal spacing overflows to infinity
+        once it is narrowed to float. */
+     || !(g->map_spacing_v > 0.0)
+     || !(g->map_spacing_h > 0.0)
+     || !dt_isfinite((float)g->map_spacing_v)
+     || !dt_isfinite((float)g->map_spacing_h)
+     || !dt_isfinite((float)(1.0 / g->map_spacing_v))
+     || !dt_isfinite((float)(1.0 / g->map_spacing_h))
+     || !dt_isfinite((float)g->map_origin_v)
+     || !dt_isfinite((float)g->map_origin_h)
      || g->top != 0
      || g->left != 0
      || g->bottom != (uint32_t)img->height

--- a/src/common/dng_opcode.c
+++ b/src/common/dng_opcode.c
@@ -21,6 +21,7 @@
 
 #include "debug.h"
 #include "dng_opcode.h"
+#include "develop/imageop.h"
 
 #define OPCODE_ID_GAINMAP (9)
 #define OPCODE_ID_WARP_RECTILINEAR (1)
@@ -57,6 +58,38 @@ static uint32_t _get_long(uint8_t *ptr)
   return GUINT32_FROM_BE(in);
 }
 
+static void _parse_and_append_gain_map(uint8_t *param, uint32_t param_size, GList **dng_gain_maps,
+                                        const char *source)
+{
+  uint32_t gain_count = (param_size - 76) / 4;
+  dt_dng_gain_map_t *gm = g_malloc(sizeof(dt_dng_gain_map_t) + gain_count * sizeof(float));
+  gm->top           = _get_long(&param[0]);
+  gm->left          = _get_long(&param[4]);
+  gm->bottom        = _get_long(&param[8]);
+  gm->right         = _get_long(&param[12]);
+  gm->plane         = _get_long(&param[16]);
+  gm->planes        = _get_long(&param[20]);
+  gm->row_pitch     = _get_long(&param[24]);
+  gm->col_pitch     = _get_long(&param[28]);
+  gm->map_points_v  = _get_long(&param[32]);
+  gm->map_points_h  = _get_long(&param[36]);
+  gm->map_spacing_v = _get_double(&param[40]);
+  gm->map_spacing_h = _get_double(&param[48]);
+  gm->map_origin_v  = _get_double(&param[56]);
+  gm->map_origin_h  = _get_double(&param[64]);
+  gm->map_planes    = _get_long(&param[72]);
+  for(int i = 0; i < gain_count; i++)
+    gm->map_gain[i] = _get_float(&param[76 + 4 * i]);
+  *dng_gain_maps = g_list_append(*dng_gain_maps, gm);
+  dt_print(DT_DEBUG_IMAGEIO,
+    "[dng_opcode] %s GainMap parsed: top=%u left=%u bottom=%u right=%u "
+    "plane=%u planes=%u row_pitch=%u col_pitch=%u "
+    "map_points_v=%u map_points_h=%u map_planes=%u gain_count=%u",
+    source, gm->top, gm->left, gm->bottom, gm->right,
+    gm->plane, gm->planes, gm->row_pitch, gm->col_pitch,
+    gm->map_points_v, gm->map_points_h, gm->map_planes, gain_count);
+}
+
 void dt_dng_opcode_process_opcode_list_2(uint8_t *buf, uint32_t buf_size, dt_image_t *img)
 {
   g_list_free_full(img->dng_gain_maps, g_free);
@@ -79,27 +112,7 @@ void dt_dng_opcode_process_opcode_list_2(uint8_t *buf, uint32_t buf_size, dt_ima
 
     if(opcode_id == OPCODE_ID_GAINMAP)
     {
-      uint32_t gain_count = (param_size - 76) / 4;
-      dt_dng_gain_map_t *gm = g_malloc(sizeof(dt_dng_gain_map_t) + gain_count * sizeof(float));
-      gm->top = _get_long(&param[0]);
-      gm->left = _get_long(&param[4]);
-      gm->bottom = _get_long(&param[8]);
-      gm->right = _get_long(&param[12]);
-      gm->plane = _get_long(&param[16]);
-      gm->planes = _get_long(&param[20]);
-      gm->row_pitch = _get_long(&param[24]);
-      gm->col_pitch = _get_long(&param[28]);
-      gm->map_points_v = _get_long(&param[32]);
-      gm->map_points_h = _get_long(&param[36]);
-      gm->map_spacing_v = _get_double(&param[40]);
-      gm->map_spacing_h = _get_double(&param[48]);
-      gm->map_origin_v = _get_double(&param[56]);
-      gm->map_origin_h = _get_double(&param[64]);
-      gm->map_planes = _get_long(&param[72]);
-      for(int i = 0; i < gain_count; i++)
-        gm->map_gain[i] = _get_float(&param[76 + 4*i]);
-
-      img->dng_gain_maps = g_list_append(img->dng_gain_maps, gm);
+      _parse_and_append_gain_map(param, param_size, &(img->dng_gain_maps), "OpcodeList2");
     }
     else
     {
@@ -114,9 +127,13 @@ void dt_dng_opcode_process_opcode_list_2(uint8_t *buf, uint32_t buf_size, dt_ima
 
 void dt_dng_opcode_process_opcode_list_3(uint8_t *buf, uint32_t buf_size, dt_image_t *img)
 {
+  g_list_free_full(img->dng_gain_maps_opcode3, g_free);
+  img->dng_gain_maps_opcode3 = NULL;
+
   dt_image_correction_data_t *cd = &img->exif_correction_data;
   cd->dng.has_warp = FALSE;
   cd->dng.has_vignette = FALSE;
+  cd->dng.has_gainmap = FALSE;
 
   uint32_t count = _get_long(&buf[0]);
   uint32_t offset = 4;
@@ -167,6 +184,16 @@ void dt_dng_opcode_process_opcode_list_3(uint8_t *buf, uint32_t buf_size, dt_ima
       img->exif_correction_type = CORRECTION_TYPE_DNG;
     }
 
+    else if(opcode_id == OPCODE_ID_GAINMAP)
+    {
+      _parse_and_append_gain_map(param, param_size, &(img->dng_gain_maps_opcode3), "OpcodeList3");
+      // unlike WarpRectilinear and VignetteRadial this does not set
+      // exif_correction_type: the GainMap is applied by demosaic or rawprepare, not
+      // by lens, so a file whose only OpcodeList3 entry is a GainMap must not be
+      // pushed into the lens embedded metadata method
+      cd->dng.has_gainmap = TRUE;
+    }
+
     else
     {
       dt_print(DT_DEBUG_IMAGEIO, "[dng_opcode] OpcodeList3 has unsupported %s opcode %d",
@@ -177,3 +204,188 @@ void dt_dng_opcode_process_opcode_list_3(uint8_t *buf, uint32_t buf_size, dt_ima
     count--;
   }
 }
+
+/* GainMap application, shared by demosaic (CFA raws) and rawprepare (linear DNGs).
+   Both see the data as three colour planes, which is the stage OpcodeList3 is
+   defined for, so neither needs any CFA logic. */
+
+const dt_dng_gain_map_t *dt_dng_gain_map_opcode3(const dt_image_t *img)
+{
+  if(g_list_length(img->dng_gain_maps_opcode3) != 1)
+  {
+    // an empty list is the normal case and not worth reporting
+    if(img->dng_gain_maps_opcode3)
+      dt_print(DT_DEBUG_IMAGEIO,
+        "[dng_opcode] GainMap rejected: found %u maps, need exactly 1",
+        g_list_length(img->dng_gain_maps_opcode3));
+    return NULL;
+  }
+
+  const dt_dng_gain_map_t *g =
+    (const dt_dng_gain_map_t *)g_list_nth_data(img->dng_gain_maps_opcode3, 0);
+
+  /* DNG 1.7.1 p.115 leaves MapPlanes free and says "If Planes > MapPlanes, the
+     last gain map plane is used for any remaining planes being modified", so a
+     one plane map covering all three channels is legal and is what a pure
+     falloff correction looks like. Only 1 and 3 are meaningful for three plane
+     data, so anything else is rejected rather than guessed at.
+
+     The map itself need not cover the whole frame -- outside its bounds the
+     spec replicates the edge values, which is what the clamp in the sampler
+     does -- but Top/Left/Bottom/Right bound the *area modified*, and the spec
+     does not say whether MapOrigin and MapSpacing are then relative to that
+     rectangle or to the whole image. Requiring the full frame makes the two
+     readings identical, so that ambiguity cannot bite us. */
+  if(g == NULL
+     || g->plane != 0
+     || g->planes != 3
+     || (g->map_planes != 1 && g->map_planes != 3)
+     || g->row_pitch != 1
+     || g->col_pitch != 1
+     || g->map_points_v < 2
+     || g->map_points_h < 2
+     || g->map_spacing_v <= 0.0
+     || g->map_spacing_h <= 0.0
+     || g->top != 0
+     || g->left != 0
+     || g->bottom != (uint32_t)img->height
+     || g->right != (uint32_t)img->width)
+  {
+    dt_print(DT_DEBUG_IMAGEIO,
+      "[dng_opcode] GainMap rejected: plane=%u planes=%u map_planes=%u "
+      "row_pitch=%u col_pitch=%u map_points_v=%u map_points_h=%u "
+      "top=%u left=%u bottom=%u right=%u (image %dx%d)",
+      g ? g->plane : 0, g ? g->planes : 0, g ? g->map_planes : 0,
+      g ? g->row_pitch : 0, g ? g->col_pitch : 0,
+      g ? g->map_points_v : 0, g ? g->map_points_h : 0,
+      g ? g->top : 0, g ? g->left : 0, g ? g->bottom : 0, g ? g->right : 0,
+      img->width, img->height);
+    return NULL;
+  }
+
+  return g;
+}
+
+void dt_dng_gain_map_apply(const dt_dng_gain_map_t *gm,
+                           const dt_image_t *img,
+                           const float *const in,
+                           float *const out,
+                           const int width,
+                           const int height,
+                           const float x0,
+                           const float y0,
+                           const float step)
+{
+  const int map_w = gm->map_points_h;
+  const int map_h = gm->map_points_v;
+  const int nplanes = gm->map_planes;
+
+  /* The GainMap is defined over the full raw frame, so normalise the raw
+     coordinates the caller gave us against the raw dimensions. The half pixel
+     offset is the pixel-centred convention the spec spells out for these
+     fields (DNG 1.7.1 p.72). */
+  const float raw_w = (float)img->width;
+  const float raw_h = (float)img->height;
+
+  const float rel_to_map_x = 1.0f / gm->map_spacing_h;
+  const float rel_to_map_y = 1.0f / gm->map_spacing_v;
+  const float map_origin_h = gm->map_origin_h;
+  const float map_origin_v = gm->map_origin_v;
+
+  DT_OMP_FOR()
+  for(int row = 0; row < height; row++)
+  {
+    const float rel_y = (y0 + ((float)row + 0.5f) * step) / raw_h;
+    const float y_map = CLAMPF((rel_y - map_origin_v) * rel_to_map_y, 0.0f, (float)(map_h - 1));
+    const int y_i0 = MIN((int)y_map, map_h - 1);
+    const int y_i1 = MIN(y_i0 + 1, map_h - 1);
+    const float y_frac = y_map - y_i0;
+
+    for(int col = 0; col < width; col++)
+    {
+      const size_t idx = 4 * (size_t)(row * width + col);
+      const float rel_x = (x0 + ((float)col + 0.5f) * step) / raw_w;
+      const float x_map = CLAMPF((rel_x - map_origin_h) * rel_to_map_x, 0.0f, (float)(map_w - 1));
+      const int x_i0 = MIN((int)x_map, map_w - 1);
+      const int x_i1 = MIN(x_i0 + 1, map_w - 1);
+      const float x_frac = x_map - x_i0;
+
+      for_three_channels(c)
+      {
+        // "the last gain map plane is used for any remaining planes being modified"
+        const int p = MIN(c, nplanes - 1);
+        const float g00 = gm->map_gain[(y_i0 * map_w + x_i0) * nplanes + p];
+        const float g01 = gm->map_gain[(y_i0 * map_w + x_i1) * nplanes + p];
+        const float g10 = gm->map_gain[(y_i1 * map_w + x_i0) * nplanes + p];
+        const float g11 = gm->map_gain[(y_i1 * map_w + x_i1) * nplanes + p];
+
+        const float gain_top    = (1.0f - x_frac) * g00 + x_frac * g01;
+        const float gain_bottom = (1.0f - x_frac) * g10 + x_frac * g11;
+
+        out[idx + c] = in[idx + c] * ((1.0f - y_frac) * gain_top + y_frac * gain_bottom);
+      }
+
+      out[idx + 3] = in[idx + 3];
+    }
+  }
+}
+
+#ifdef HAVE_OPENCL
+dt_dng_gain_map_cl_global_t *dt_dng_gain_map_init_cl_global(void)
+{
+  dt_dng_gain_map_cl_global_t *g = malloc(sizeof(dt_dng_gain_map_cl_global_t));
+
+  const int program = 42; // dng_opcode.cl, from programs.conf
+  g->kernel_dng_gain_map = dt_opencl_create_kernel(program, "dng_gain_map");
+  return g;
+}
+
+void dt_dng_gain_map_free_cl_global(dt_dng_gain_map_cl_global_t *g)
+{
+  if(!g) return;
+  dt_opencl_free_kernel(g->kernel_dng_gain_map);
+  free(g);
+}
+
+int dt_dng_gain_map_apply_cl(const int devid,
+                             const dt_dng_gain_map_t *gm,
+                             const dt_image_t *img,
+                             cl_mem dev_in,
+                             cl_mem dev_out,
+                             const int width,
+                             const int height,
+                             const float x0,
+                             const float y0,
+                             const float step)
+{
+  const int map_w = gm->map_points_h;
+  const int map_h = gm->map_points_v;
+  const int nplanes = gm->map_planes;
+  const size_t ngains = (size_t)map_w * map_h * nplanes;
+
+  cl_mem dev_map = dt_opencl_copy_host_to_device_constant
+    (devid, ngains * sizeof(float), (void *)gm->map_gain);
+  if(dev_map == NULL) return DT_OPENCL_SYSMEM_ALLOCATION;
+
+  // keep these in step with dt_dng_gain_map_apply()
+  const float raw_w = (float)img->width;
+  const float raw_h = (float)img->height;
+  const float rel_to_map_x = 1.0f / gm->map_spacing_h;
+  const float rel_to_map_y = 1.0f / gm->map_spacing_v;
+  const float map_origin_h = gm->map_origin_h;
+  const float map_origin_v = gm->map_origin_v;
+
+  const int err = dt_opencl_enqueue_kernel_2d_args
+    (devid, darktable.opencl->dng_gain_map->kernel_dng_gain_map, width, height,
+     CLARG(dev_in), CLARG(dev_out), CLARG(dev_map),
+     CLARG(width), CLARG(height),
+     CLARG(map_w), CLARG(map_h), CLARG(nplanes),
+     CLARG(x0), CLARG(y0), CLARG(step),
+     CLARG(raw_w), CLARG(raw_h),
+     CLARG(rel_to_map_x), CLARG(rel_to_map_y),
+     CLARG(map_origin_h), CLARG(map_origin_v));
+
+  dt_opencl_release_mem_object(dev_map);
+  return err;
+}
+#endif

--- a/src/common/dng_opcode.h
+++ b/src/common/dng_opcode.h
@@ -61,6 +61,10 @@ const dt_dng_gain_map_t *dt_dng_gain_map_opcode3(const dt_image_t *img);
 /* Multiply the GainMap into 4-channel float data. in and out may be the same
    buffer.
 
+   gm must have come from dt_dng_gain_map_opcode3(): that is where the map is
+   checked for the shape this assumes, including spacings that can safely be
+   reciprocated. Do not hand it a map straight off the parser.
+
    The caller supplies the geometry explicitly rather than passing a roi,
    because the two callers do not derive it the same way. x0/y0 are the full
    resolution raw sensor coordinates of output pixel (0,0), including whatever

--- a/src/common/dng_opcode.h
+++ b/src/common/dng_opcode.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include <stdint.h>
+#include "common/opencl.h"
 #include "image.h"
 
 G_BEGIN_DECLS
@@ -45,6 +46,63 @@ typedef struct dt_dng_gain_map_t
 
 void dt_dng_opcode_process_opcode_list_2(uint8_t *buf, uint32_t size, dt_image_t *img);
 void dt_dng_opcode_process_opcode_list_3(uint8_t *buf, uint32_t size, dt_image_t *img);
+
+struct dt_iop_roi_t;
+
+/* Return the OpcodeList3 GainMap of img if the list holds exactly one map and it
+   is of a form we support, NULL otherwise. OpcodeList3 is applied "just after
+   the image has been demosaiced" (DNG 1.7.1, tag 51022), so the data is always
+   three colour planes and no CFA layout is involved.
+
+   Callers are demosaic for CFA raws and rawprepare for linear DNGs, which are
+   mutually exclusive on pipe->dsc.filters. */
+const dt_dng_gain_map_t *dt_dng_gain_map_opcode3(const dt_image_t *img);
+
+/* Multiply the GainMap into 4-channel float data. in and out may be the same
+   buffer.
+
+   The caller supplies the geometry explicitly rather than passing a roi,
+   because the two callers do not derive it the same way. x0/y0 are the full
+   resolution raw sensor coordinates of output pixel (0,0), including whatever
+   crop rawprepare applied, and step is how many raw pixels one output pixel
+   spans. Deriving these from roi_out alone is wrong in demosaic: the resample
+   that produces its output ignores roi shifts (see the comment on
+   dt_iop_clip_and_zoom_roi), so the buffer origin is roi_in's, which differs
+   from roi_out->x / roi_out->scale by the integer truncation in
+   demosaic's modify_roi_in. */
+void dt_dng_gain_map_apply(const dt_dng_gain_map_t *gm,
+                           const dt_image_t *img,
+                           const float *const in,
+                           float *const out,
+                           const int width,
+                           const int height,
+                           const float x0,
+                           const float y0,
+                           const float step);
+
+#ifdef HAVE_OPENCL
+typedef struct dt_dng_gain_map_cl_global_t
+{
+  int kernel_dng_gain_map;
+} dt_dng_gain_map_cl_global_t;
+
+dt_dng_gain_map_cl_global_t *dt_dng_gain_map_init_cl_global(void);
+void dt_dng_gain_map_free_cl_global(dt_dng_gain_map_cl_global_t *g);
+
+/* OpenCL counterpart of dt_dng_gain_map_apply(). Returns a CL error code so the
+   caller can let the pixelpipe fall back to the CPU rather than silently
+   dropping the correction. */
+int dt_dng_gain_map_apply_cl(const int devid,
+                             const dt_dng_gain_map_t *gm,
+                             const dt_image_t *img,
+                             cl_mem dev_in,
+                             cl_mem dev_out,
+                             const int width,
+                             const int height,
+                             const float x0,
+                             const float y0,
+                             const float step);
+#endif
 
 G_END_DECLS
 

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -2255,6 +2255,7 @@ void dt_image_init(dt_image_t *img)
   img->usercrop[0] = img->usercrop[1] = 0;
   img->usercrop[2] = img->usercrop[3] = 1;
   img->dng_gain_maps = NULL;
+  img->dng_gain_maps_opcode3 = NULL;
   img->exif_correction_type = CORRECTION_TYPE_NONE;
   memset(&img->exif_correction_data, 0, sizeof(img->exif_correction_data));
   img->cache_entry = 0;

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -2243,6 +2243,7 @@ void dt_image_init(dt_image_t *img)
   img->usercrop[0] = img->usercrop[1] = 0;
   img->usercrop[2] = img->usercrop[3] = 1;
   img->dng_gain_maps = NULL;
+  img->dng_gain_maps_opcode3 = NULL;
   img->exif_correction_type = CORRECTION_TYPE_NONE;
   memset(&img->exif_correction_data, 0, sizeof(img->exif_correction_data));
   img->cache_entry = 0;

--- a/src/common/image.h
+++ b/src/common/image.h
@@ -181,6 +181,8 @@ typedef union dt_image_correction_data_t
     float centre_vig[2];
     gboolean has_warp;
     gboolean has_vignette;
+    // a GainMap in OpcodeList3, applied after demosaic (see dng_gain_maps_opcode3)
+    gboolean has_gainmap;
   } dng;
   struct {
     gboolean has_dist;
@@ -360,6 +362,9 @@ typedef struct dt_image_t
 
   /* GainMaps from DNG OpcodeList2 exif tag */
   GList *dng_gain_maps;
+
+  /* GainMaps from DNG OpcodeList3 exif tag */
+  GList *dng_gain_maps_opcode3;
 
   /* convenience pointer back into the image cache, so we can return
    * dt_image_t* there directly. */

--- a/src/common/image.h
+++ b/src/common/image.h
@@ -178,6 +178,8 @@ typedef union dt_image_correction_data_t
     float centre_vig[2];
     gboolean has_warp;
     gboolean has_vignette;
+    // a GainMap in OpcodeList3, applied after demosaic (see dng_gain_maps_opcode3)
+    gboolean has_gainmap;
   } dng;
   struct {
     gboolean has_dist;
@@ -357,6 +359,9 @@ typedef struct dt_image_t
 
   /* GainMaps from DNG OpcodeList2 exif tag */
   GList *dng_gain_maps;
+
+  /* GainMaps from DNG OpcodeList3 exif tag */
+  GList *dng_gain_maps_opcode3;
 
   /* convenience pointer back into the image cache, so we can return
    * dt_image_t* there directly. */

--- a/src/common/image_cache.c
+++ b/src/common/image_cache.c
@@ -206,6 +206,7 @@ static void _image_cache_deallocate(void *data, dt_cache_entry_t *entry)
   dt_image_t *img = entry->data;
   g_free(img->profile);
   g_list_free_full(img->dng_gain_maps, g_free);
+  g_list_free_full(img->dng_gain_maps_opcode3, g_free);
   g_free(img);
   entry->data = NULL;
 }

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -28,6 +28,7 @@
 #include "common/gaussian.h"
 #include "common/guided_filter.h"
 #include "common/heal.h"
+#include "common/dng_opcode.h"
 #include "common/interpolation.h"
 #include "common/locallaplaciancl.h"
 #include "common/opencl_drivers_blacklist.h"
@@ -1572,6 +1573,7 @@ finally:
     cl->bilinear = dt_bilinear_init_cl_global();
     cl->gaussian = dt_gaussian_init_cl_global();
     cl->interpolation = dt_interpolation_init_cl_global();
+    cl->dng_gain_map = dt_dng_gain_map_init_cl_global();
     cl->local_laplacian = dt_local_laplacian_init_cl_global();
     cl->dwt = dt_dwt_init_cl_global();
     cl->heal = dt_heal_init_cl_global();
@@ -1629,6 +1631,7 @@ void dt_opencl_cleanup(dt_opencl_t *cl)
     dt_bilinear_free_cl_global(cl->bilinear);
     dt_gaussian_free_cl_global(cl->gaussian);
     dt_interpolation_free_cl_global(cl->interpolation);
+    dt_dng_gain_map_free_cl_global(cl->dng_gain_map);
     dt_dwt_free_cl_global(cl->dwt);
     dt_heal_free_cl_global(cl->heal);
     dt_colorspaces_free_cl_global(cl->colorspaces);

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -27,6 +27,7 @@
 #include "common/gaussian.h"
 #include "common/guided_filter.h"
 #include "common/heal.h"
+#include "common/dng_opcode.h"
 #include "common/interpolation.h"
 #include "common/locallaplaciancl.h"
 #include "common/opencl_drivers_blacklist.h"
@@ -1591,6 +1592,7 @@ finally:
     cl->bilateral = dt_bilateral_init_cl_global();
     cl->gaussian = dt_gaussian_init_cl_global();
     cl->interpolation = dt_interpolation_init_cl_global();
+    cl->dng_gain_map = dt_dng_gain_map_init_cl_global();
     cl->local_laplacian = dt_local_laplacian_init_cl_global();
     cl->dwt = dt_dwt_init_cl_global();
     cl->heal = dt_heal_init_cl_global();
@@ -1647,6 +1649,7 @@ void dt_opencl_cleanup(dt_opencl_t *cl)
     dt_bilateral_free_cl_global(cl->bilateral);
     dt_gaussian_free_cl_global(cl->gaussian);
     dt_interpolation_free_cl_global(cl->interpolation);
+    dt_dng_gain_map_free_cl_global(cl->dng_gain_map);
     dt_dwt_free_cl_global(cl->dwt);
     dt_heal_free_cl_global(cl->heal);
     dt_colorspaces_free_cl_global(cl->colorspaces);

--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -260,6 +260,9 @@ typedef struct dt_opencl_t
   // global kernels for interpolation resampling.
   struct dt_interpolation_cl_global_t *interpolation;
 
+  // global kernel for the DNG OpcodeList3 GainMap, shared by demosaic and rawprepare.
+  struct dt_dng_gain_map_cl_global_t *dng_gain_map;
+
   // global kernels for local laplacian filter.
   struct dt_local_laplacian_cl_global_t *local_laplacian;
 

--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -265,6 +265,9 @@ typedef struct dt_opencl_t
   // global kernels for interpolation resampling.
   struct dt_interpolation_cl_global_t *interpolation;
 
+  // global kernel for the DNG OpcodeList3 GainMap, shared by demosaic and rawprepare.
+  struct dt_dng_gain_map_cl_global_t *dng_gain_map;
+
   // global kernels for local laplacian filter.
   struct dt_local_laplacian_cl_global_t *local_laplacian;
 

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -1086,23 +1086,43 @@ int process_cl(dt_iop_module_t *self,
        applied to the approximated output */
     const dt_dng_gain_map_t *gm_fast = _gain_map(self, piece);
 
+    /* The GainMap kernel reads and writes one pixel per work item, but an
+       image cannot be both read from and written to by the same kernel, so
+       let the zoom write a scratch image and take dev_out from there. */
+    cl_mem dev_zoomed = dev_out;
+    cl_mem dev_scratch = NULL;
+    if(gm_fast)
+    {
+      dev_scratch = dt_opencl_alloc_device(devid,
+                                           dt_opencl_get_image_width(dev_out),
+                                           dt_opencl_get_image_height(dev_out),
+                                           dt_opencl_get_image_element_size(dev_out));
+      if(dev_scratch == NULL)
+      {
+        dt_opencl_release_mem_object(dev_xtrans);
+        return DT_OPENCL_SYSMEM_ALLOCATION;
+      }
+      dev_zoomed = dev_scratch;
+    }
+
     if(is_xtrans)
       // sample third-size image
       err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_zoom_third_size, roi_out->width, roi_out->height,
-          CLARG(dev_in), CLARG(dev_out), CLARG(roi_out->width), CLARG(roi_out->height),
+          CLARG(dev_in), CLARG(dev_zoomed), CLARG(roi_out->width), CLARG(roi_out->height),
           CLARG(iwidth), CLARG(iheight), CLARG(roi_out->scale), CLARG(dev_xtrans));
     else if(method == DT_IOP_DEMOSAIC_PASSTHROUGH_MONOCHROME)
       err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_zoom_passthrough_monochrome, roi_out->width, roi_out->height,
-          CLARG(dev_in), CLARG(dev_out), CLARG(roi_out->width), CLARG(roi_out->height),
+          CLARG(dev_in), CLARG(dev_zoomed), CLARG(roi_out->width), CLARG(roi_out->height),
           CLARG(iwidth), CLARG(iheight), CLARG(roi_out->scale));
     else // bayer
       err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_zoom_half_size, roi_out->width, roi_out->height,
-          CLARG(dev_in), CLARG(dev_out), CLARG(roi_out->width), CLARG(roi_out->height),
+          CLARG(dev_in), CLARG(dev_zoomed), CLARG(roi_out->width), CLARG(roi_out->height),
           CLARG(iwidth), CLARG(iheight), CLARG(roi_out->scale), CLARG(filters));
 
     if(err == CL_SUCCESS && gm_fast)
-      err = _apply_gain_map_cl(self, piece, gm_fast, dev_out, dev_out, roi_out, devid);
+      err = _apply_gain_map_cl(self, piece, gm_fast, dev_scratch, dev_out, roi_out, devid);
 
+    dt_opencl_release_mem_object(dev_scratch);
     dt_opencl_release_mem_object(dev_xtrans);
     return err;
   }
@@ -1290,13 +1310,27 @@ int process_cl(dt_iop_module_t *self,
 
   /* The GainMap is defined on the sensor grid, so it is applied to the full
      scale demosaiced data before any resampling to canvas or export size, and
-     before the detail mask is derived from it. The image is passed as both read
-     and write argument: the kernel only ever modifies the pixel it read, which
-     every known driver handles, as elsewhere in dt. */
+     before the detail mask is derived from it. An image cannot be both read
+     from and written to by one kernel, so the result goes to a scratch image
+     and is copied back; out_image is dev_out when the pipe asked for the data
+     in place, so it cannot simply be swapped for the scratch one. */
   const dt_dng_gain_map_t *gm = _gain_map(self, piece);
   if(gm)
   {
-    err = _apply_gain_map_cl(self, piece, gm, out_image, out_image, roi_in, devid);
+    cl_mem dev_scratch = dt_opencl_alloc_device(devid, iwidth, iheight, sizeof(float) * 4);
+    if(dev_scratch == NULL)
+    {
+      err = DT_OPENCL_SYSMEM_ALLOCATION;
+      goto finish;
+    }
+    err = _apply_gain_map_cl(self, piece, gm, out_image, dev_scratch, roi_in, devid);
+    if(err == CL_SUCCESS)
+    {
+      const size_t region[] = { iwidth, iheight };
+      err = dt_opencl_enqueue_copy_image(devid, dev_scratch, out_image,
+                                         CLIMG_ORIGIN, CLIMG_ORIGIN, region);
+    }
+    dt_opencl_release_mem_object(dev_scratch);
     if(err != CL_SUCCESS) goto finish;
   }
 

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -19,6 +19,7 @@
 #include "bauhaus/bauhaus.h"
 #include "common/colorspaces.h"
 #include "common/darktable.h"
+#include "common/dng_opcode.h"
 #include "common/interpolation.h"
 #include "common/opencl.h"
 #include "common/image_cache.h"
@@ -47,7 +48,7 @@
 #include <string.h>
 #include <time.h>
 
-DT_MODULE_INTROSPECTION(6, dt_iop_demosaic_params_t)
+DT_MODULE_INTROSPECTION(7, dt_iop_demosaic_params_t)
 
 #define DT_DEMOSAIC_XTRANS 1024 // masks for non-Bayer demosaic ops
 #define DT_DEMOSAIC_DUAL 2048   // masks for dual demosaicing methods
@@ -154,6 +155,7 @@ typedef struct dt_iop_demosaic_params_t
   int cs_iter;                                  // $MIN: 1 $MAX: 25 $DEFAULT: 8 $DESCRIPTION: "iterations"
   float cs_center;                              // $MIN: 0.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "sharp center"
   gboolean cs_enabled;                          // $DEFAULT: FALSE $DESCRIPTION: "capture sharpen"
+  gboolean dng_gainmap;                         // $DEFAULT: TRUE $DESCRIPTION: "DNG GainMap"
 } dt_iop_demosaic_params_t;
 
 typedef struct dt_iop_demosaic_gui_data_t
@@ -255,6 +257,7 @@ typedef struct dt_iop_demosaic_data_t
   int cs_iter;
   float cs_center;
   gboolean cs_enabled;
+  gboolean dng_gainmap;
 } dt_iop_demosaic_data_t;
 
 static gboolean _get_thumb_quality(const int width, const int height)
@@ -358,6 +361,23 @@ int legacy_params(dt_iop_module_t *self,
     gboolean cs_enabled;
   } dt_iop_demosaic_params_v6_t;
 
+  typedef struct dt_iop_demosaic_params_v7_t
+  {
+    dt_iop_demosaic_greeneq_t green_eq;
+    float median_thrs;
+    dt_iop_demosaic_smooth_t color_smoothing;
+    dt_iop_demosaic_method_t demosaicing_method;
+    dt_iop_demosaic_lmmse_t lmmse_refine;
+    float dual_thrs;
+    float cs_radius;
+    float cs_thrs;
+    float cs_boost;
+    int cs_iter;
+    float cs_center;
+    gboolean cs_enabled;
+    gboolean dng_gainmap;
+  } dt_iop_demosaic_params_v7_t;
+
   typedef struct dt_iop_demosaic_params_v5_t
   {
     dt_iop_demosaic_greeneq_t green_eq;
@@ -458,6 +478,23 @@ int legacy_params(dt_iop_module_t *self,
     *new_params_size = sizeof(dt_iop_demosaic_params_v6_t);
     *new_version = 6;
    return 0;
+  }
+
+  if(old_version == 6)
+  {
+    const dt_iop_demosaic_params_v6_t *o = (dt_iop_demosaic_params_v6_t *)old_params;
+    dt_iop_demosaic_params_v7_t *n = malloc(sizeof(dt_iop_demosaic_params_v7_t));
+    memcpy(n, o, sizeof *o);
+
+    /* An existing edit was developed without the OpcodeList3 GainMap, so leave
+       it alone: switching it on here would silently change how every already
+       processed file carrying one looks. New edits default to TRUE. */
+    n->dng_gainmap = FALSE;
+
+    *new_params = n;
+    *new_params_size = sizeof(dt_iop_demosaic_params_v7_t);
+    *new_version = 7;
+    return 0;
   }
 
   return 1;
@@ -636,6 +673,58 @@ static gboolean _tiling_requirements(dt_iop_module_t *self,
   return TRUE;
 }
 
+/* The DNG OpcodeList3 GainMap applies "just after the image has been
+   demosaiced" (DNG 1.7.1, tag 51022), which is here. Only CFA raws are handled
+   in this module; linear DNGs never reach a demosaicer and are corrected in
+   rawprepare instead, so the two paths cannot both fire on the same image. */
+static const dt_dng_gain_map_t *_gain_map(dt_iop_module_t *self,
+                                          dt_dev_pixelpipe_iop_t *const piece)
+{
+  const dt_iop_demosaic_data_t *d = piece->data;
+  if(!d->dng_gainmap || piece->filters == 0) return NULL;
+  return dt_dng_gain_map_opcode3(&self->dev->image_storage);
+}
+
+/* Apply the map to a 4-channel float buffer covering roi, in raw sensor
+   coordinates. step is how many raw pixels one buffer pixel spans. */
+static void _apply_gain_map(dt_iop_module_t *self,
+                            dt_dev_pixelpipe_iop_t *const piece,
+                            const dt_dng_gain_map_t *gm,
+                            float *const buf,
+                            const dt_iop_roi_t *const roi,
+                            const int devid)
+{
+  const dt_image_t *const image = &self->dev->image_storage;
+  const float x0 = (float)image->crop_x + roi->x / roi->scale;
+  const float y0 = (float)image->crop_y + roi->y / roi->scale;
+  const float step = 1.0f / roi->scale;
+  dt_print_pipe(DT_DEBUG_PIPE, "dng gainmap", piece->pipe, self, devid, roi, NULL,
+                "OpcodeList3 %ux%u map, %u planes; raw origin=%.1f,%.1f step=%.3f",
+                gm->map_points_h, gm->map_points_v, gm->map_planes, x0, y0, step);
+  dt_dng_gain_map_apply(gm, image, buf, buf, roi->width, roi->height, x0, y0, step);
+}
+
+#ifdef HAVE_OPENCL
+static int _apply_gain_map_cl(dt_iop_module_t *self,
+                              dt_dev_pixelpipe_iop_t *const piece,
+                              const dt_dng_gain_map_t *gm,
+                              cl_mem src,
+                              cl_mem dst,
+                              const dt_iop_roi_t *const roi,
+                              const int devid)
+{
+  const dt_image_t *const image = &self->dev->image_storage;
+  const float x0 = (float)image->crop_x + roi->x / roi->scale;
+  const float y0 = (float)image->crop_y + roi->y / roi->scale;
+  const float step = 1.0f / roi->scale;
+  dt_print_pipe(DT_DEBUG_PIPE, "dng gainmap", piece->pipe, self, devid, roi, NULL,
+                "OpcodeList3 %ux%u map, %u planes; raw origin=%.1f,%.1f step=%.3f",
+                gm->map_points_h, gm->map_points_v, gm->map_planes, x0, y0, step);
+  return dt_dng_gain_map_apply_cl(devid, gm, image, src, dst,
+                                  roi->width, roi->height, x0, y0, step);
+}
+#endif
+
 void process(dt_iop_module_t *self,
              dt_dev_pixelpipe_iop_t *const piece,
              const void *const i,
@@ -703,6 +792,12 @@ void process(dt_iop_module_t *self,
       dt_iop_clip_and_zoom_demosaic_third_size_xtrans_f((float *)o, in, roi_out, roi_in, roi_out->width, width, xtrans);
     else
       dt_iop_clip_and_zoom_demosaic_half_size_f((float *)o, in, roi_out, roi_in, roi_out->width, width, filters);
+
+    /* this path never materialises a full scale buffer, so the GainMap is
+       applied to the approximated output instead */
+    const dt_dng_gain_map_t *gm_fast = _gain_map(self, piece);
+    if(gm_fast)
+      _apply_gain_map(self, piece, gm_fast, (float *)o, roi_out, DT_DEVICE_CPU);
 
     return;
   }
@@ -887,6 +982,13 @@ void process(dt_iop_module_t *self,
   if(tiling) dt_free_align(t_out);
   dt_free_align(green_in);
 
+  /* The GainMap is defined on the sensor grid, so it is applied to the full
+     scale demosaiced data before any resampling to canvas or export size, and
+     before the detail mask is derived from it. */
+  const dt_dng_gain_map_t *gm = _gain_map(self, piece);
+  if(gm)
+    _apply_gain_map(self, piece, gm, out, roi_in, DT_DEVICE_CPU);
+
   if(pipe->want_detail_mask)
     dt_dev_write_scharr_mask(piece, out, roi_in, TRUE);
 
@@ -979,23 +1081,30 @@ int process_cl(dt_iop_module_t *self,
   if(!fullscale)
   {
     dt_print_pipe(DT_DEBUG_PIPE, "demosaic approx zoom", pipe, self, devid, roi_in, roi_out);
+
+    /* this path never materialises a full scale buffer, so the GainMap is
+       applied to the approximated output */
+    const dt_dng_gain_map_t *gm_fast = _gain_map(self, piece);
+
     if(is_xtrans)
-    {
       // sample third-size image
       err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_zoom_third_size, roi_out->width, roi_out->height,
           CLARG(dev_in), CLARG(dev_out), CLARG(roi_out->width), CLARG(roi_out->height),
           CLARG(iwidth), CLARG(iheight), CLARG(roi_out->scale), CLARG(dev_xtrans));
-      dt_opencl_release_mem_object(dev_xtrans);
-      return err;
-    }
     else if(method == DT_IOP_DEMOSAIC_PASSTHROUGH_MONOCHROME)
-      return dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_zoom_passthrough_monochrome, roi_out->width, roi_out->height,
+      err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_zoom_passthrough_monochrome, roi_out->width, roi_out->height,
           CLARG(dev_in), CLARG(dev_out), CLARG(roi_out->width), CLARG(roi_out->height),
           CLARG(iwidth), CLARG(iheight), CLARG(roi_out->scale));
     else // bayer
-      return dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_zoom_half_size, roi_out->width, roi_out->height,
+      err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_zoom_half_size, roi_out->width, roi_out->height,
           CLARG(dev_in), CLARG(dev_out), CLARG(roi_out->width), CLARG(roi_out->height),
           CLARG(iwidth), CLARG(iheight), CLARG(roi_out->scale), CLARG(filters));
+
+    if(err == CL_SUCCESS && gm_fast)
+      err = _apply_gain_map_cl(self, piece, gm_fast, dev_out, dev_out, roi_out, devid);
+
+    dt_opencl_release_mem_object(dev_xtrans);
+    return err;
   }
 
   const gboolean direct = roi_out->width == iwidth && roi_out->height == iheight && feqf(roi_in->scale, roi_out->scale, 1e-8f);
@@ -1179,6 +1288,18 @@ int process_cl(dt_iop_module_t *self,
     t_low = NULL;
   }
 
+  /* The GainMap is defined on the sensor grid, so it is applied to the full
+     scale demosaiced data before any resampling to canvas or export size, and
+     before the detail mask is derived from it. The image is passed as both read
+     and write argument: the kernel only ever modifies the pixel it read, which
+     every known driver handles, as elsewhere in dt. */
+  const dt_dng_gain_map_t *gm = _gain_map(self, piece);
+  if(gm)
+  {
+    err = _apply_gain_map_cl(self, piece, gm, out_image, out_image, roi_in, devid);
+    if(err != CL_SUCCESS) goto finish;
+  }
+
   if(pipe->want_detail_mask)
   {
     err = dt_dev_write_scharr_mask_cl(piece, out_image, roi_in, TRUE);
@@ -1211,6 +1332,7 @@ finish:
   }
   return err;
 }
+
 #endif
 #undef MIN_TILE_ROWS
 
@@ -1370,6 +1492,7 @@ void commit_params(dt_iop_module_t *self,
   d->cs_boost = p->cs_boost;
   d->cs_center = p->cs_center;
   d->cs_enabled = p->cs_enabled;
+  d->dng_gainmap = p->dng_gainmap;
   // magic function to have CS iterations with fine granularity for values <= 11 and then rising up to 50
   d->cs_iter = p->cs_iter + (int)(0.000065f * powf((float)p->cs_iter, 4.0f));
   const gboolean xmethod = use_method & DT_DEMOSAIC_XTRANS;

--- a/src/iop/rawprepare.c
+++ b/src/iop/rawprepare.c
@@ -481,6 +481,7 @@ int process_cl(dt_iop_module_t *self,
   cl_mem dev_sub = NULL;
   cl_mem dev_div = NULL;
   cl_mem dev_gainmap[4] = {NULL};
+  cl_mem dev_scratch = NULL;
   cl_int err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
 
 
@@ -534,8 +535,22 @@ int process_cl(dt_iop_module_t *self,
 
   const size_t sizes[2] = { ROUNDUPDWD(roi_in->width, devid), ROUNDUPDHT(roi_in->height, devid) };
 
+  /* The GainMap kernel below reads and writes one pixel per work item, but an
+     image cannot be both read from and written to by the same kernel, so let
+     this one write a scratch image and take dev_out from there. */
+  cl_mem dev_target = dev_out;
+  if(d->gainmap_opcode3)
+  {
+    dev_scratch = dt_opencl_alloc_device(devid,
+                                         dt_opencl_get_image_width(dev_out),
+                                         dt_opencl_get_image_height(dev_out),
+                                         dt_opencl_get_image_element_size(dev_out));
+    if(dev_scratch == NULL) goto finish;
+    dev_target = dev_scratch;
+  }
+
   dt_opencl_set_kernel_args(devid, kernel, 0,
-    CLARG(dev_in), CLARG(dev_out),
+    CLARG(dev_in), CLARG(dev_target),
     CLARG(width), CLARG(height),
     CLARG(csx), CLARG(csy),
     CLARG(dev_sub), CLARG(dev_div), CLARG(roi_out->x), CLARG(roi_out->y));
@@ -569,7 +584,7 @@ int process_cl(dt_iop_module_t *self,
                   d->gainmap_opcode3->map_points_h, d->gainmap_opcode3->map_points_v,
                   d->gainmap_opcode3->map_planes);
     err = dt_dng_gain_map_apply_cl(devid, d->gainmap_opcode3, &piece->pipe->image,
-                                   dev_out, dev_out,
+                                   dev_scratch, dev_out,
                                    roi_out->width, roi_out->height,
                                    (roi_out->x + csx) / roi_out->scale,
                                    (roi_out->y + csy) / roi_out->scale,
@@ -577,6 +592,7 @@ int process_cl(dt_iop_module_t *self,
   }
 
 finish:
+  dt_opencl_release_mem_object(dev_scratch);
   dt_opencl_release_mem_object(dev_sub);
   dt_opencl_release_mem_object(dev_div);
 

--- a/src/iop/rawprepare.c
+++ b/src/iop/rawprepare.c
@@ -79,6 +79,9 @@ typedef struct dt_iop_rawprepare_data_t
   gboolean apply_gainmaps;
   // GainMap for each filter of RGGB Bayer pattern
   dt_dng_gain_map_t *gainmaps[4];
+  /* DNG OpcodeList3 GainMap for linear DNGs, owned by the image cache. NULL
+     unless the image is already demosaiced, in which case demosaic handles it. */
+  const dt_dng_gain_map_t *gainmap_opcode3;
 } dt_iop_rawprepare_data_t;
 
 typedef struct dt_iop_rawprepare_global_data_t
@@ -440,6 +443,22 @@ void process(dt_iop_module_t *self,
     }
   }
 
+  if(d->gainmap_opcode3)
+  {
+    dt_print_pipe(DT_DEBUG_PIPE, "dng gainmap", piece->pipe, self, DT_DEVICE_CPU, NULL, roi_out,
+                  "OpcodeList3 %ux%u map, %u planes",
+                  d->gainmap_opcode3->map_points_h, d->gainmap_opcode3->map_points_v,
+                  d->gainmap_opcode3->map_planes);
+    /* unlike demosaic, rawprepare does not resample: it reads the input at
+       (csx + i, csy + j), so roi_out maps straight back to raw coordinates and
+       csx/csy already carry the crop. */
+    dt_dng_gain_map_apply(d->gainmap_opcode3, &piece->pipe->image, out, out,
+                          roi_out->width, roi_out->height,
+                          (roi_out->x + csx) / roi_out->scale,
+                          (roi_out->y + csy) / roi_out->scale,
+                          1.0f / roi_out->scale);
+  }
+
   const gboolean color_sraw = !(dt_image_is_raw(&piece->pipe->image) ||  dt_image_is_mono_sraw(&piece->pipe->image));
   if(color_sraw && piece->pipe->want_detail_mask)
     dt_dev_write_scharr_mask(piece, out, roi_out, FALSE);
@@ -463,6 +482,7 @@ int process_cl(dt_iop_module_t *self,
   cl_mem dev_div = NULL;
   cl_mem dev_gainmap[4] = {NULL};
   cl_int err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
+
 
   int kernel = -1;
   gboolean gainmap_args = FALSE;
@@ -513,6 +533,7 @@ int process_cl(dt_iop_module_t *self,
   const int height = roi_out->height;
 
   const size_t sizes[2] = { ROUNDUPDWD(roi_in->width, devid), ROUNDUPDHT(roi_in->height, devid) };
+
   dt_opencl_set_kernel_args(devid, kernel, 0,
     CLARG(dev_in), CLARG(dev_out),
     CLARG(width), CLARG(height),
@@ -540,6 +561,20 @@ int process_cl(dt_iop_module_t *self,
        CLARG(map_size), CLARG(im_to_rel), CLARG(rel_to_map), CLARG(map_origin));
   }
   err = dt_opencl_enqueue_kernel_2d(devid, kernel, sizes);
+
+  if(err == CL_SUCCESS && d->gainmap_opcode3)
+  {
+    dt_print_pipe(DT_DEBUG_PIPE, "dng gainmap", piece->pipe, self, devid, NULL, roi_out,
+                  "OpcodeList3 %ux%u map, %u planes",
+                  d->gainmap_opcode3->map_points_h, d->gainmap_opcode3->map_points_v,
+                  d->gainmap_opcode3->map_planes);
+    err = dt_dng_gain_map_apply_cl(devid, d->gainmap_opcode3, &piece->pipe->image,
+                                   dev_out, dev_out,
+                                   roi_out->width, roi_out->height,
+                                   (roi_out->x + csx) / roi_out->scale,
+                                   (roi_out->y + csy) / roi_out->scale,
+                                   1.0f / roi_out->scale);
+  }
 
 finish:
   dt_opencl_release_mem_object(dev_sub);
@@ -727,6 +762,17 @@ void commit_params(dt_iop_module_t *self,
     d->apply_gainmaps = _check_gain_maps(self, d->gainmaps);
   else
     d->apply_gainmaps = FALSE;
+
+  /* OpcodeList3 is defined for demosaiced data, so for a CFA raw it belongs in
+     demosaic and not here. A linear DNG never reaches a demosaicer, and this is
+     the first module that sees it as three colour planes, so it is corrected
+     here instead. Following the OpcodeList2 maps, it is offered under the same
+     "flat field" control. */
+  d->gainmap_opcode3 = (p->flat_field == FLAT_FIELD_EMBEDDED
+                        && !piece->pipe->dsc.filters
+                        && piece->colors == 4)
+    ? dt_dng_gain_map_opcode3(&piece->pipe->image)
+    : NULL;
 
   if(_image_set_rawcrops(self, pipe->image.id, d->left, d->right, d->top, d->bottom))
     DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_METADATA_UPDATE);


### PR DESCRIPTION
Applies the GainMap opcode from DNG `OpcodeList3`, which corrects lens shading and per-channel colour shading. DJI drones write one there; darktable currently ignores it, so affected files open with visible corner falloff and a colour cast the camera's own JPEG does not have.

darktable already handles GainMaps in `OpcodeList2` — the four per-CFA-plane maps Adobe's converter writes — in `rawprepare`. **That path is untouched by this PR.** This adds the `OpcodeList3` form, which the spec stages differently.

Includes @mb271's commits directly, so his rebase and fixes keep his authorship.

## Where it is applied

The two opcode lists are defined for different points in the pipeline, and this PR follows that split:

| list | spec wording | module |
|---|---|---|
| `OpcodeList2` | "just after it has been mapped to linear reference values" | `rawprepare` (unchanged) |
| `OpcodeList3` | "just after it has been demosaiced" | `demosaic`, or `rawprepare` for linear DNGs |

`demosaic` is the module that turns a CFA raw into three colour planes, which is the stage `OpcodeList3` describes. The correction is applied **inside** `process()` and `process_cl()`, on the full-scale demosaiced buffer, immediately before the detail mask is derived from it.

That placement matters: the map is defined on the sensor grid, so it is evaluated there rather than on whatever grid the user's chosen resampling mode produces. An earlier revision wrapped `process()` and corrected its output, which tied a sensor-domain correction to a display-domain resample — @jenshannoschwalm rejected that, correctly.

Consequences of the placement:

- **Every sensor layout works with no CFA logic at all.** The data is plain RGB, so Bayer, X-Trans and linear DNGs are handled identically.
- **No geometric module intervenes.** `rotatepixels` (iop order 11) and `scalepixels` (12) sit between `demosaic` (8) and `lens` (13), and `rotatepixels` is `default_enabled` whenever the sensor has a rotation, so anything downstream of it would be misaligned on those cameras.
- **Opcode order is preserved.** The spec applies opcodes in list order. DJI files list `GainMap, WarpRectilinear`; with the GainMap in `demosaic` and `WarpRectilinear` in `lens`, that is the order the pipeline produces.
- **The detail mask sees corrected data**, and therefore so do capture sharpening and dual demosaic. This is a behaviour change on files carrying a GainMap, not only a restructuring.

The approximate-zoom path never materialises a full-scale buffer, so it corrects its own output instead.

Linear DNGs never reach a demosaicer, so `rawprepare` — the first module that sees them as three planes — handles those, under the existing "flat field" control. The two paths gate on `pipe->dsc.filters` and are mutually exclusive, so nothing is corrected twice.

## Existing edits are not changed

Applying the correction changes how affected files render, so it cannot simply switch on for edits developed without it. `demosaic` gains a parameter and its introspection is bumped 6 → 7. `legacy_params()` maps an existing v6 edit to off; new edits default to on.

There is no widget: applying a correction the vendor explicitly asked for is not a user choice, and the parameter exists only to keep faith with edits made before it existed. Nobody who has already developed a GainMap-carrying file sees it change, because released darktable never applied it.

## Shared code

Validation, the bilinear sampler and one OpenCL kernel live in `common/dng_opcode.c` next to the parsing, rather than being duplicated across the two modules. The kernel is registered as `darktable.opencl->dng_gain_map`, following the existing pattern for `gaussian`, `bilateral` and `interpolation`.

`dt_dng_gain_map_apply()` takes the raw sensor origin and step explicitly rather than a roi, because the two callers derive them differently: `demosaic` resamples, so its origin comes from `roi_in` and its step from `roi_out->scale`; `rawprepare` only index-shifts by `csx`/`csy` and maps straight back from `roi_out`. Deriving from `roi_out` alone was wrong in `demosaic` and produced a sub-pixel misalignment when zoomed past 100% and panned — see 36e880ce.

The kernel writes out the bilinear interpolation by hand rather than using a linear sampler, so it matches the CPU function; a sampler would be shorter but introduces hardware-dependent rounding. The image is passed as both read and write argument, which is safe here because the kernel only modifies the pixel it read.

## Specification notes

Read against [DNG 1.7.1](https://helpx.adobe.com/content/dam/help/en/camera-raw/digital-negative/jcr_content/root/content/flex/items/position/position-par/download_section_733958301/download-1/DNG_Spec_1_7_1_0.pdf); the GainMap opcode is pp. 114–115.

- **`MapPlanes` is not restricted to 1 or 3.** p. 115: *"If Planes > MapPlanes, the last gain map plane is used for any remaining planes being modified"*, so indexing is `min(plane, MapPlanes-1)`. A single-plane map applied to all three channels is legal and is what a pure falloff correction looks like. Only 1 and 3 are meaningful for three-plane data, so anything else is rejected rather than guessed at.
- **Sampling uses pixel centres**, per the half-pixel convention on p. 72, which also states that the usage of `MapPointsV/H`, `MapOriginV/H` and `MapSpacingV/H` is consistent with the GainMap opcode.
- **Out-of-bounds map values replicate the edge**, per p. 115, which is what the clamp does. `Top/Left/Bottom/Right` bound the *area modified*, a different thing, and the spec does not say whether `MapOrigin`/`MapSpacing` are then relative to that rectangle or to the whole image. Requiring the full frame makes both readings identical and sidesteps the ambiguity.
- **Chapter 7 requires clipping to 0.0–1.0 after each opcode. This deliberately does not.** Clipping would discard the highlight headroom that highlight reconstruction needs. It is a knowing deviation from Adobe's reference behaviour and can differ in blown corners.

Validation accepts a single map covering the whole frame, with `Planes == 3`, `RowPitch == ColPitch == 1`, and one or three map planes. Anything else is a no-op.

## Testing

Measurements below are full-resolution 16-bit exports on default processing, with a noise floor established first by running the same build twice — both files gave **0 differing pixels** between runs, so the figures are not run-to-run variation.

**DJI FC8482** (Mini 4 Pro), `OpcodeList3` = `GainMap, WarpRectilinear`, 32×32×3 map:
- Correction applies and matches the drone's own JPEG on visual comparison.
- CPU vs OpenCL: RMSE 2.6e-5 of range over 8064×6048.
- Darkroom: an existing v6 edit renders with the map skipped; discarding history applies it and the corners come good.

**Google Pixel 8**, DNG 1.6, Bayer, `OpcodeList2` = four per-CFA-plane GainMaps, `OpcodeList3` = `WarpRectilinear` only:
- The four `OpcodeList2` maps parse and apply exactly as on master.
- **None of the new code runs** — no debug line is emitted, which is only reachable when the map pointer is NULL.
- CPU vs OpenCL on this file: RMSE 8.8e-5, i.e. **more** than the DJI file with the GainMap active. The new code contributes less divergence than the stock demosaicers already do.

**Canon CR2**: no GainMap output of any kind, no log spam.

Earlier in this PR @mb271 compared output against [raw2dng/dngpreprocess](https://github.com/paolodepetrillo/raw2dng/tree/dngpreprocess), which applies GainMaps via Adobe's DNG SDK, and found the results identical. That was against the original `rawprepare` implementation, so it is worth repeating against this one.

## Known gaps

- **The linear-DNG path in `rawprepare` has never executed.** No DNG has been found from any vendor carrying a GainMap in `OpcodeList3` at all, let alone a linear one — the Pixel 8 above has `WarpRectilinear` only. That path is written to the spec and is a no-op for every file we can test. A linear DNG with an `OpcodeList3` GainMap would be very welcome.
- `WarpRectilinear2` is not parsed, so the optional-warp skip rule on pp. 120–122 does not apply. Out of scope here.
- The commit history builds up and then replaces two earlier placements (`rawprepare`, then `lens`). They are kept as separate revertible commits rather than squashed, so the intermediate states stay cherry-pickable. Happy to squash.

## AI assistance

This work was done with AI assistance, including this description. The original commits were written with Claude Sonnet 4.6; the rebase and everything since was done using Claude Code with Claude Opus 5. I have tested every change on my own files and reviewed the reasoning, but I want to be upfront that I am not the author of the C code and am not familiar with the heavy math or the specs involved.
