### PR TITLE
add collection filter for duplicates

### DIFF
--- a/src/common/collection.c
+++ b/src/common/collection.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2024-2025 darktable developers.
+    Copyright (C) 2024-2026 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -652,6 +652,8 @@ const char *dt_collection_name_untranslated(const dt_collection_properties_t pro
       return N_("geotagging");
     case DT_COLLECTION_PROP_GROUP_ID:
       return N_("group");
+    case DT_COLLECTION_PROP_DUPLICATES:
+      return N_("duplicates");
     case DT_COLLECTION_PROP_LOCAL_COPY:
       return N_("local copy");
     case DT_COLLECTION_PROP_MODULE:
@@ -1565,6 +1567,36 @@ static gchar *get_query_string(const dt_collection_properties_t property, const 
               || !g_strcmp0(escaped_text, "$LOCAL_COPY"))
       {
         query = g_strdup_printf("(flags & %d) ", DT_IMAGE_LOCAL_COPY);
+      }
+      else // by default, we select all the images
+      {
+        query = g_strdup("1 = 1");
+      }
+      break;
+
+    case DT_COLLECTION_PROP_DUPLICATES: // duplicates
+      if(!g_strcmp0(escaped_text, _("images with duplicates"))
+         || !g_strcmp0(escaped_text, "$IMGS_WITH_DUPLICATES"))
+      {
+        query = g_strdup
+          ("(mi.id IN ("
+           "   SELECT i.id"
+           "   FROM main.images i"
+           "   JOIN ("
+           "     SELECT film_id"
+           "          , filename"
+           "     FROM main.images"
+           "     GROUP BY film_id"
+           "            , filename"
+           "     HAVING COUNT(*) > 1"
+           "   ) dups ON i.film_id = dups.film_id AND i.filename = dups.filename)) ");
+      }
+      else if(!g_strcmp0(escaped_text, _("duplicates only"))
+         || !g_strcmp0(escaped_text, "$DUPLICATES_ONLY"))
+      {
+        query = g_strdup
+          ("(mi.version > (SELECT MIN(version) FROM main.images"
+           "               WHERE film_id = mi.film_id AND filename = mi.filename)) ");
       }
       else // by default, we select all the images
       {

--- a/src/common/collection.h
+++ b/src/common/collection.h
@@ -119,6 +119,8 @@ typedef enum dt_collection_properties_t
 
   DT_COLLECTION_PROP_EXPOSURE_BIAS,
 
+  DT_COLLECTION_PROP_DUPLICATES,
+
   // all new collection types need to be added before DT_COLLECTION_PROP_LAST,
   // which separates actual collection types from special flag values
   DT_COLLECTION_PROP_LAST,

--- a/src/libs/filtering.c
+++ b/src/libs/filtering.c
@@ -214,6 +214,7 @@ typedef struct _filter_t
 #include "libs/filters/history.c"
 #include "libs/filters/iso.c"
 #include "libs/filters/local_copy.c"
+#include "libs/filters/duplicates.c"
 #include "libs/filters/misc.c"
 #include "libs/filters/module_order.c"
 #include "libs/filters/rating.c"
@@ -239,6 +240,7 @@ static _filter_t filters[]
         { DT_COLLECTION_PROP_EXPOSURE, _exposure_widget_init, _exposure_update },
         { DT_COLLECTION_PROP_EXPOSURE_BIAS, _exposure_bias_widget_init, _exposure_bias_update },
         { DT_COLLECTION_PROP_GROUP_ID, _misc_widget_init, _misc_update },
+        { DT_COLLECTION_PROP_DUPLICATES, _duplicates_widget_init, _duplicates_update },
         { DT_COLLECTION_PROP_LOCAL_COPY, _local_copy_widget_init, _local_copy_update },
         { DT_COLLECTION_PROP_HISTORY, _history_widget_init, _history_update },
         { DT_COLLECTION_PROP_ORDER, _module_order_widget_init, _module_order_update },
@@ -920,6 +922,7 @@ static gboolean _rule_show_popup(GtkWidget *widget, dt_lib_filtering_rule_t *rul
 
   _popup_add_item(spop, _("darktable"), 0, TRUE, NULL, NULL, self, 0.0);
   ADD_COLLECT_ENTRY(spop, DT_COLLECTION_PROP_GROUP_ID);
+  ADD_COLLECT_ENTRY(spop, DT_COLLECTION_PROP_DUPLICATES);
   ADD_COLLECT_ENTRY(spop, DT_COLLECTION_PROP_LOCAL_COPY);
   ADD_COLLECT_ENTRY(spop, DT_COLLECTION_PROP_HISTORY);
   ADD_COLLECT_ENTRY(spop, DT_COLLECTION_PROP_MODULE);
@@ -979,6 +982,7 @@ static void _populate_rules_combo(GtkWidget *w)
 
   dt_bauhaus_combobox_add_section(w, _("darktable"));
   ADD_COLLECT_ENTRY(DT_COLLECTION_PROP_GROUP_ID);
+  ADD_COLLECT_ENTRY(DT_COLLECTION_PROP_DUPLICATES);
   ADD_COLLECT_ENTRY(DT_COLLECTION_PROP_LOCAL_COPY);
   ADD_COLLECT_ENTRY(DT_COLLECTION_PROP_HISTORY);
   ADD_COLLECT_ENTRY(DT_COLLECTION_PROP_MODULE);
@@ -1644,6 +1648,7 @@ static void _topbar_populate_rules_combo(GtkWidget *w, dt_lib_filtering_t *d)
   dt_bauhaus_combobox_add_section(w, _("darktable"));
   nb = dt_bauhaus_combobox_length(w);
   ADD_COLLECT_ENTRY(DT_COLLECTION_PROP_GROUP_ID);
+  ADD_COLLECT_ENTRY(DT_COLLECTION_PROP_DUPLICATES);
   ADD_COLLECT_ENTRY(DT_COLLECTION_PROP_LOCAL_COPY);
   ADD_COLLECT_ENTRY(DT_COLLECTION_PROP_HISTORY);
   ADD_COLLECT_ENTRY(DT_COLLECTION_PROP_MODULE);

--- a/src/libs/filters/duplicates.c
+++ b/src/libs/filters/duplicates.c
@@ -1,0 +1,181 @@
+/*
+    This file is part of darktable,
+    Copyright (C) 2026 darktable developers.
+
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    darktable is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/*
+  This file contains the necessary routines to implement a filter for the filtering module
+*/
+
+typedef struct _widgets_duplicates_t
+{
+  dt_lib_filtering_rule_t *rule;
+
+  GtkWidget *combo;
+} _widgets_duplicates_t;
+
+typedef enum _duplicates_type_t
+{
+  _DUP_ALL = 0,
+  _DUP_WITH_DUPS,
+  _DUP_DUPS_ONLY
+} _duplicates_type_t;
+
+static const char *_duplicates_names[]
+    = { N_("all images"), N_("images with duplicates"), N_("duplicates only"), NULL };
+
+static void _duplicates_synchronise(_widgets_duplicates_t *source)
+{
+  _widgets_duplicates_t *dest = NULL;
+  if(source == source->rule->w_specific_top)
+    dest = source->rule->w_specific;
+  else
+    dest = source->rule->w_specific_top;
+
+  if(dest)
+  {
+    source->rule->manual_widget_set++;
+    const int val = dt_bauhaus_combobox_get(source->combo);
+    dt_bauhaus_combobox_set(dest->combo, val);
+    source->rule->manual_widget_set--;
+  }
+}
+
+static void _duplicates_changed(GtkWidget *widget, gpointer user_data)
+{
+  _widgets_duplicates_t *duplicates = (_widgets_duplicates_t *)user_data;
+  if(duplicates->rule->manual_widget_set) return;
+
+  const _duplicates_type_t tp = dt_bauhaus_combobox_get(duplicates->combo);
+  switch(tp)
+  {
+    case _DUP_ALL:
+      _rule_set_raw_text(duplicates->rule, "", TRUE);
+      break;
+    case _DUP_WITH_DUPS:
+      _rule_set_raw_text(duplicates->rule, "$IMGS_WITH_DUPLICATES", TRUE);
+      break;
+    case _DUP_DUPS_ONLY:
+      _rule_set_raw_text(duplicates->rule, "$DUPLICATES_ONLY", TRUE);
+      break;
+  }
+  _duplicates_synchronise(duplicates);
+}
+
+static void _duplicates_decode(const gchar *txt, int *val)
+{
+  if(!txt || strlen(txt) == 0) return;
+
+  if(!g_strcmp0(txt, "$IMGS_WITH_DUPLICATES"))
+    *val = _DUP_WITH_DUPS;
+  else if(!g_strcmp0(txt, "$DUPLICATES_ONLY"))
+    *val = _DUP_DUPS_ONLY;
+  else
+    *val = _DUP_ALL;
+}
+
+static gboolean _duplicates_update(dt_lib_filtering_rule_t *rule)
+{
+  if(!rule->w_specific) return FALSE;
+  int val = _DUP_ALL;
+  _duplicates_decode(rule->raw_text, &val);
+
+  rule->manual_widget_set++;
+  _widgets_duplicates_t *duplicates = (_widgets_duplicates_t *)rule->w_specific;
+  char query[1024] = { 0 };
+  // clang-format off
+  g_snprintf(query, sizeof(query),
+                   "SELECT CASE "
+                   "         WHEN dups.min_version = version THEN 0"
+                   "         ELSE 1"
+                   "       END AS orig"
+                   "     , COUNT(*) AS count"
+                   " FROM main.images AS mi"
+                   " JOIN ("
+                   "   SELECT film_id AS f_id"
+                   "        , filename"
+                   "        , MIN(version) AS min_version"
+                   "   FROM main.images"
+                   "   GROUP BY f_id"
+                   "          , filename"
+                   "   HAVING COUNT(*) > 1"
+                   " ) dups ON mi.film_id = dups.f_id AND mi.filename = dups.filename"
+                   " WHERE %s"
+                   " GROUP BY orig"
+                   " ORDER BY orig ASC",
+                   rule->lib->last_where_ext);
+  // clang-format on
+  int counts[2] = { 0 };
+  sqlite3_stmt *stmt;
+  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), query, -1, &stmt, NULL);
+  while(sqlite3_step(stmt) == SQLITE_ROW)
+  {
+    const int i = sqlite3_column_int(stmt, 0);
+    const int count = sqlite3_column_int(stmt, 1);
+    counts[i] = count;
+  }
+  sqlite3_finalize(stmt);
+
+  // 0 = originals only
+  // 1 = duplicates only
+  counts[0] += counts[1]; // counter for originals + all duplicates
+
+  for(int i = 0; i < 2; i++)
+  {
+    gchar *item = g_strdup_printf("%s (%d)", _(_duplicates_names[i + 1]), counts[i]);
+    dt_bauhaus_combobox_set_entry_label(duplicates->combo, i + 1, item);
+    g_free(item);
+  }
+
+  dt_bauhaus_combobox_set(duplicates->combo, val);
+  _duplicates_synchronise(duplicates);
+  rule->manual_widget_set--;
+
+  return TRUE;
+}
+
+static void _duplicates_widget_init(dt_lib_filtering_rule_t *rule, const dt_collection_properties_t prop,
+                                    const gchar *text, dt_lib_module_t *self, const gboolean top)
+{
+  _widgets_duplicates_t *duplicates = g_malloc0(sizeof(_widgets_duplicates_t));
+  duplicates->rule = rule;
+
+  duplicates->combo = dt_bauhaus_combobox_new_full(
+      DT_ACTION(self), N_("rules"), N_("duplicates"), _("duplicates state filter"), 0,
+      (GtkCallback)_duplicates_changed, duplicates, _duplicates_names);
+  dt_bauhaus_widget_hide_label(duplicates->combo);
+
+  if(top)
+    gtk_box_pack_start(GTK_BOX(rule->w_special_box_top), duplicates->combo, TRUE, TRUE, 0);
+  else
+    gtk_box_pack_start(GTK_BOX(rule->w_special_box), duplicates->combo, TRUE, TRUE, 0);
+
+  if(top)
+  {
+    dt_gui_add_class(duplicates->combo, "dt_quick_filter");
+  }
+
+  if(top)
+    rule->w_specific_top = duplicates;
+  else
+    rule->w_specific = duplicates;
+}
+
+// clang-format off
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
+// clang-format on


### PR DESCRIPTION
I have implemented it so that the lowest version number is treated as the "original" image.

- _images with duplicates_: selects all images which have at least one additional version, including the originals.
- _duplicates only_: only selects the duplicates without the originals. This makes it easy to delete all duplicates and let the originals untouched.


<img width="207" height="204" alt="Bildschirmfoto 2026-03-10 um 15 04 34" src="https://github.com/user-attachments/assets/68720677-a5be-47f0-a1e2-38092acab81b" />

<img width="273" height="64" alt="Bildschirmfoto 2026-03-10 um 15 05 11" src="https://github.com/user-attachments/assets/2856207f-5bd7-4442-8eeb-8c25c0f74346" />

fixes #20472 
