### PR TITLE
adjustments to styles module

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -134,9 +134,10 @@ changes (where available).
 
 - Removed `Neo` Intel GPU from the Windows blacklist.
 
-- In the styles module, a new option has been added to control the
-  preview size in the tooltip. The available options are: no preview,
-  default size, and large size.
+- In the styles module, a new option has been added to hide the
+  preview in the tooltip. Additionally, a module preference now allows
+  you to change the preview size, with two options available: default 
+  and large.
 
 - Improved debugging option --dump-diff-pipe for those of you
   interested in OpenCL code and debugging.

--- a/data/darktableconfig.dtd
+++ b/data/darktableconfig.dtd
@@ -15,7 +15,7 @@
 <!ATTLIST dtconfig
 	prefs IDREF #IMPLIED
         section IDREF #IMPLIED
-        dialog (collect|recentcollect|import|tagging) #IMPLIED
+        dialog (collect|recentcollect|import|tagging|style) #IMPLIED
         ui (yes|no) #IMPLIED
         restart (true|false) #IMPLIED
         common (yes|no) #IMPLIED

--- a/data/darktableconfig.dtd
+++ b/data/darktableconfig.dtd
@@ -15,7 +15,7 @@
 <!ATTLIST dtconfig
 	prefs IDREF #IMPLIED
         section IDREF #IMPLIED
-        dialog (collect|recentcollect|import|tagging|style) #IMPLIED
+        dialog (collect|recentcollect|import|tagging) #IMPLIED
         ui (yes|no) #IMPLIED
         restart (true|false) #IMPLIED
         common (yes|no) #IMPLIED

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -3980,6 +3980,13 @@
     <longdescription>maximum height the styles list in lighttable will grow to before scrolling</longdescription>
   </dtconfig>
   <dtconfig>
+    <name>plugins/lighttable/style/preview_size</name>
+    <type>int</type>
+    <default>0</default>
+    <shortdescription>preview size on tooltip</shortdescription>
+    <longdescription>size of the preview on the tooltip</longdescription>
+  </dtconfig>
+  <dtconfig>
     <name>plugins/darkroom/toneequal/gui_page</name>
     <type>int</type>
     <default>0</default>

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -1037,13 +1037,6 @@
     <shortdescription/>
     <longdescription/>
   </dtconfig>
- <dtconfig>
-    <name>ui_last/styles_preview_mode</name>
-    <type>int</type>
-    <default>1</default>
-    <shortdescription/>
-    <longdescription/>
-  </dtconfig>
   <dtconfig>
     <name>ui_last/metadata_dialog_width</name>
     <type>int</type>

--- a/src/common/styles.h
+++ b/src/common/styles.h
@@ -43,11 +43,10 @@ typedef enum dt_style_applymode_t
   DT_STYLE_HISTORY_OVERWRITE = 1
 } dt_style_applymode_t;
 
-typedef enum dt_style_previewmode_t {
-  DT_STYLE_PREVIEW_NO,
+typedef enum dt_style_preview_size_t {
   DT_STYLE_PREVIEW_DEFAULT,
   DT_STYLE_PREVIEW_LARGE
-} dt_style_previewmode;
+} dt_style_preview_size_t;
 
 typedef struct dt_style_item_t
 {

--- a/src/gui/styles_dialog.c
+++ b/src/gui/styles_dialog.c
@@ -1025,11 +1025,11 @@ GtkWidget *dt_gui_style_content_dialog(char *name, const dt_imgid_t imgid)
   if(dt_is_valid_imgid(imgid))
   {
     gtk_box_pack_start(GTK_BOX(ht), gtk_separator_new(GTK_ORIENTATION_HORIZONTAL), TRUE, TRUE, 0);
-    const int preview_mode = dt_conf_get_int("ui_last/styles_preview_mode");
     // style preview
-    if(preview_mode != DT_STYLE_PREVIEW_NO)
+    const int preview_size = dt_conf_get_int("plugins/lighttable/style/preview_size");
+    if(!dt_conf_get_bool("ui_last/styles_hide_preview"))
     {
-      if(preview_mode == DT_STYLE_PREVIEW_LARGE)
+      if(preview_size == DT_STYLE_PREVIEW_LARGE)
       {
         data.psize = dt_conf_get_int("ui/style/large_preview_size");
       }

--- a/src/libs/styles.c
+++ b/src/libs/styles.c
@@ -894,7 +894,7 @@ void gui_init(dt_lib_module_t *self)
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->hide_preview),
                                dt_conf_get_bool("ui_last/styles_hide_preview"));
   gtk_widget_set_tooltip_text(d->hide_preview,
-                              _("hide preview of style applied to image"));
+                              _("hide preview of style on tooltip"));
 
   d->duplicate = gtk_check_button_new_with_label(_("create duplicate"));
   dt_action_define(DT_ACTION(self), NULL, N_("create duplicate"),
@@ -1016,8 +1016,8 @@ void _menuitem_preferences(GtkMenuItem *menuitem,
   GtkWidget *win = dt_ui_main_window(darktable.gui->ui);
   GtkWidget *dialog = gtk_dialog_new_with_buttons(_("style preview settings"), GTK_WINDOW(win),
                                                  GTK_DIALOG_DESTROY_WITH_PARENT,
-                                                 _("cancel"), GTK_RESPONSE_NONE,
-                                                 _("save"), GTK_RESPONSE_ACCEPT, NULL);
+                                                 _("_cancel"), GTK_RESPONSE_NONE,
+                                                 _("_save"), GTK_RESPONSE_ACCEPT, NULL);
   gtk_dialog_set_default_response(GTK_DIALOG(dialog), GTK_RESPONSE_ACCEPT);                                                 
   g_signal_connect(dialog, "key-press-event", G_CALLBACK(dt_handle_dialog_enter), NULL);
   

--- a/src/libs/styles.c
+++ b/src/libs/styles.c
@@ -772,12 +772,6 @@ static void _applymode_combobox_changed(GtkWidget *widget, gpointer user_data)
   dt_conf_set_int("plugins/lighttable/style/applymode", mode);
 }
 
-/* static void _preview_size_combobox_changed(GtkWidget *widget, gpointer user_data)
-{
-  const int size = dt_bauhaus_combobox_get(widget);
-  dt_conf_set_int("plugins/lighttable/style/preview_size", size);
-}  */
-
 void gui_update(dt_lib_module_t *self)
 {
   dt_lib_styles_t *d = self->data;
@@ -912,19 +906,6 @@ void gui_init(dt_lib_module_t *self)
   gtk_widget_set_tooltip_text(d->duplicate,
                               _("creates a duplicate of the image before applying style"));
   gtk_widget_set_no_show_all(d->duplicate, TRUE);                              
-
-/*   DT_BAUHAUS_COMBOBOX_NEW_FULL(d->preview_mode, self, NULL, N_("preview"),
-                               _("change size or hide preview on tooltip of style"),
-                               dt_conf_get_int("ui_last/styles_preview_mode"),
-                               _previewmode_combobox_changed, self,
-                               N_("no"), N_("default"), N_("large"));  
- */
-/*   GtkWidget *box = dt_gui_hbox();
-  dt_gui_box_add(box, d->duplicate);
-  gtk_widget_set_halign(d->duplicate, GTK_ALIGN_START);
-  gtk_widget_set_hexpand(d->duplicate, TRUE);
-  dt_gui_box_add(box, d->preview_mode);
-  gtk_widget_set_halign(d->preview_mode, GTK_ALIGN_END); */
 
   DT_BAUHAUS_COMBOBOX_NEW_FULL(d->applymode, self, NULL, N_("mode"),
                                _("how to handle existing history"),

--- a/src/libs/styles.c
+++ b/src/libs/styles.c
@@ -45,7 +45,6 @@ typedef struct dt_lib_styles_t
   GtkTreeView *tree;
   GtkWidget *create_button, *edit_button, *delete_button;
   GtkWidget *import_button, *export_button, *applymode, *apply_button;
-  GtkWidget *preview_mode;
   GtkWidget *hide_preview;
 } dt_lib_styles_t;
 
@@ -773,11 +772,11 @@ static void _applymode_combobox_changed(GtkWidget *widget, gpointer user_data)
   dt_conf_set_int("plugins/lighttable/style/applymode", mode);
 }
 
-/* static void _previewmode_combobox_changed(GtkWidget *widget, gpointer user_data)
+static void _preview_size_combobox_changed(GtkWidget *widget, gpointer user_data)
 {
-  const int mode = dt_bauhaus_combobox_get(widget);
-  dt_conf_set_int("ui_last/styles_preview_mode", mode);
-} */
+  const int size = dt_bauhaus_combobox_get(widget);
+  dt_conf_set_int("plugins/lighttable/style/preview_size", size);
+} 
 
 void gui_update(dt_lib_module_t *self)
 {
@@ -1038,7 +1037,30 @@ void _menuitem_preferences(GtkMenuItem *menuitem,
                                                  GTK_DIALOG_DESTROY_WITH_PARENT,
                                                  _("cancel"), GTK_RESPONSE_NONE,
                                                  _("save"), GTK_RESPONSE_ACCEPT, NULL);
+  gtk_dialog_set_default_response(GTK_DIALOG(dialog), GTK_RESPONSE_ACCEPT);                                                 
   g_signal_connect(dialog, "key-press-event", G_CALLBACK(dt_handle_dialog_enter), NULL);
+  
+  GtkWidget *preview_size;
+  const int size = dt_conf_get_int("plugins/lighttable/style/preview_size");
+  DT_BAUHAUS_COMBOBOX_NEW_FULL(preview_size, self, NULL, N_("preview size"),
+                            _("change size of preview on tooltip of style"),
+                            size,
+                            _preview_size_combobox_changed, self,
+                            N_("default"), N_("large"));  
+
+  dt_gui_dialog_add(GTK_DIALOG(dialog), preview_size);         
+
+#ifdef GDK_WINDOWING_QUARTZ
+  dt_osx_disallow_fullscreen(dialog);
+#endif
+  gtk_widget_show_all(dialog);
+  int res = gtk_dialog_run(GTK_DIALOG(dialog));      
+  if(res == GTK_RESPONSE_NONE)
+  {
+    // user clicked cancel -> restore previous value
+    dt_conf_set_int("plugins/lighttable/style/preview_size", size);
+  }
+  gtk_widget_destroy(dialog);
 }
 
 void set_preferences(void *menu, dt_lib_module_t *self)

--- a/src/libs/styles.c
+++ b/src/libs/styles.c
@@ -1030,6 +1030,24 @@ void gui_reset(dt_lib_module_t *self)
   dt_lib_gui_queue_update(self);
 }
 
+void _menuitem_preferences(GtkMenuItem *menuitem,
+                           dt_lib_module_t *self)
+{
+  GtkWidget *win = dt_ui_main_window(darktable.gui->ui);
+  GtkWidget *dialog = gtk_dialog_new_with_buttons(_("style preview settings"), GTK_WINDOW(win),
+                                                 GTK_DIALOG_DESTROY_WITH_PARENT,
+                                                 _("cancel"), GTK_RESPONSE_NONE,
+                                                 _("save"), GTK_RESPONSE_ACCEPT, NULL);
+  g_signal_connect(dialog, "key-press-event", G_CALLBACK(dt_handle_dialog_enter), NULL);
+}
+
+void set_preferences(void *menu, dt_lib_module_t *self)
+{
+  GtkWidget *mi = gtk_menu_item_new_with_label(_("preferences..."));
+  g_signal_connect(G_OBJECT(mi), "activate", G_CALLBACK(_menuitem_preferences), self);
+  gtk_menu_shell_append(GTK_MENU_SHELL(menu), mi);
+}
+
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/libs/styles.c
+++ b/src/libs/styles.c
@@ -46,6 +46,7 @@ typedef struct dt_lib_styles_t
   GtkWidget *create_button, *edit_button, *delete_button;
   GtkWidget *import_button, *export_button, *applymode, *apply_button;
   GtkWidget *preview_mode;
+  GtkWidget *hide_preview;
 } dt_lib_styles_t;
 
 const char *name(dt_lib_module_t *self)
@@ -760,17 +761,23 @@ static void _duplicate_callback(GtkWidget *widget, dt_lib_styles_t *d)
                    gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(d->duplicate)));
 }
 
+static void _hide_preview_callback(GtkWidget *widget, dt_lib_styles_t *d)
+{
+  dt_conf_set_bool("ui_last/styles_hide_preview",
+                   gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(d->hide_preview)));
+}
+
 static void _applymode_combobox_changed(GtkWidget *widget, gpointer user_data)
 {
   const int mode = dt_bauhaus_combobox_get(widget);
   dt_conf_set_int("plugins/lighttable/style/applymode", mode);
 }
 
-static void _previewmode_combobox_changed(GtkWidget *widget, gpointer user_data)
+/* static void _previewmode_combobox_changed(GtkWidget *widget, gpointer user_data)
 {
   const int mode = dt_bauhaus_combobox_get(widget);
   dt_conf_set_int("ui_last/styles_preview_mode", mode);
-}
+} */
 
 void gui_update(dt_lib_module_t *self)
 {
@@ -886,6 +893,16 @@ void gui_init(dt_lib_module_t *self)
   g_signal_connect(d->entry, "changed", G_CALLBACK(_entry_callback), d);
   g_signal_connect(d->entry, "activate", G_CALLBACK(_entry_activated), d);
 
+  d->hide_preview = gtk_check_button_new_with_label(_("hide preview"));
+  dt_action_define(DT_ACTION(self), NULL, N_("hide preview"),
+                   d->hide_preview, &dt_action_def_toggle);
+  gtk_label_set_ellipsize(GTK_LABEL(gtk_bin_get_child(GTK_BIN(d->hide_preview))), PANGO_ELLIPSIZE_START);
+  g_signal_connect(d->hide_preview, "toggled", G_CALLBACK(_hide_preview_callback), d);
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->hide_preview),
+                               dt_conf_get_bool("ui_last/styles_hide_preview"));
+  gtk_widget_set_tooltip_text(d->hide_preview,
+                              _("hide preview of style applied to image"));
+
   d->duplicate = gtk_check_button_new_with_label(_("create duplicate"));
   dt_action_define(DT_ACTION(self), NULL, N_("create duplicate"),
                    d->duplicate, &dt_action_def_toggle);
@@ -897,18 +914,18 @@ void gui_init(dt_lib_module_t *self)
                               _("creates a duplicate of the image before applying style"));
   gtk_widget_set_no_show_all(d->duplicate, TRUE);                              
 
-  DT_BAUHAUS_COMBOBOX_NEW_FULL(d->preview_mode, self, NULL, N_("preview"),
+/*   DT_BAUHAUS_COMBOBOX_NEW_FULL(d->preview_mode, self, NULL, N_("preview"),
                                _("change size or hide preview on tooltip of style"),
                                dt_conf_get_int("ui_last/styles_preview_mode"),
                                _previewmode_combobox_changed, self,
                                N_("no"), N_("default"), N_("large"));  
-
-  GtkWidget *box = dt_gui_hbox();
+ */
+/*   GtkWidget *box = dt_gui_hbox();
   dt_gui_box_add(box, d->duplicate);
   gtk_widget_set_halign(d->duplicate, GTK_ALIGN_START);
   gtk_widget_set_hexpand(d->duplicate, TRUE);
   dt_gui_box_add(box, d->preview_mode);
-  gtk_widget_set_halign(d->preview_mode, GTK_ALIGN_END);
+  gtk_widget_set_halign(d->preview_mode, GTK_ALIGN_END); */
 
   DT_BAUHAUS_COMBOBOX_NEW_FULL(d->applymode, self, NULL, N_("mode"),
                                _("how to handle existing history"),
@@ -963,7 +980,7 @@ void gui_init(dt_lib_module_t *self)
   self->widget = dt_gui_vbox
     (d->entry,
      dt_ui_resize_wrap(GTK_WIDGET(d->tree), 250, "plugins/lighttable/style/windowheight"),
-     box, d->applymode,
+     d->hide_preview, d->duplicate, d->applymode,
      dt_gui_hbox(d->create_button, d->edit_button, d->delete_button),
      dt_gui_hbox(d->import_button, d->export_button),
      d->apply_button);

--- a/src/libs/styles.c
+++ b/src/libs/styles.c
@@ -772,11 +772,11 @@ static void _applymode_combobox_changed(GtkWidget *widget, gpointer user_data)
   dt_conf_set_int("plugins/lighttable/style/applymode", mode);
 }
 
-static void _preview_size_combobox_changed(GtkWidget *widget, gpointer user_data)
+/* static void _preview_size_combobox_changed(GtkWidget *widget, gpointer user_data)
 {
   const int size = dt_bauhaus_combobox_get(widget);
   dt_conf_set_int("plugins/lighttable/style/preview_size", size);
-} 
+}  */
 
 void gui_update(dt_lib_module_t *self)
 {
@@ -1041,11 +1041,10 @@ void _menuitem_preferences(GtkMenuItem *menuitem,
   g_signal_connect(dialog, "key-press-event", G_CALLBACK(dt_handle_dialog_enter), NULL);
   
   GtkWidget *preview_size;
-  const int size = dt_conf_get_int("plugins/lighttable/style/preview_size");
   DT_BAUHAUS_COMBOBOX_NEW_FULL(preview_size, self, NULL, N_("preview size"),
                             _("change size of preview on tooltip of style"),
-                            size,
-                            _preview_size_combobox_changed, self,
+                            dt_conf_get_int("plugins/lighttable/style/preview_size"),
+                            NULL, self,
                             N_("default"), N_("large"));  
 
   dt_gui_dialog_add(GTK_DIALOG(dialog), preview_size);         
@@ -1055,9 +1054,9 @@ void _menuitem_preferences(GtkMenuItem *menuitem,
 #endif
   gtk_widget_show_all(dialog);
   int res = gtk_dialog_run(GTK_DIALOG(dialog));      
-  if(res == GTK_RESPONSE_NONE)
+  if(res == GTK_RESPONSE_ACCEPT)
   {
-    // user clicked cancel -> restore previous value
+    const int size = dt_bauhaus_combobox_get(preview_size);
     dt_conf_set_int("plugins/lighttable/style/preview_size", size);
   }
   gtk_widget_destroy(dialog);


### PR DESCRIPTION
As discussed in PR #20473 I have made the following changes to the styles module:
- The combobox for the preview, where a large, default, or no preview could be chosen, has been replaced with a checkbox to hide the preview on the tooltip.
- The preview size can now be set in the module preferences. Like before, there are two options: default and large.
- the "hide preview" checkbox is now above the "create duplicate" checkbox, not in the same row. This is better for very narrow side panels (as reported in the mentioned PR).

The actual sizes in pixels of default and large  remain as "hidden" preferences.