### PR TITLE
fix filter widgets not updated on collection change

### DIFF
--- a/src/libs/filtering.c
+++ b/src/libs/filtering.c
@@ -1447,13 +1447,14 @@ static void _dt_collection_updated(gpointer instance, dt_collection_change_t que
   {
     g_free(d->last_where_ext);
     d->last_where_ext = where_ext;
-    for(int i = 0; i <= d->nb_rules; i++)
-    {
-      _widget_update(&d->rule[i]);
-    }
   }
   else
     g_free(where_ext);
+
+  for(int i = 0; i <= d->nb_rules; i++)
+  {
+    _widget_update(&d->rule[i]);
+  }
 }
 
 static void _history_pretty_print(const char *buf, char *out, size_t outsize)


### PR DESCRIPTION
While implementing #20479 I noticed that the collection filter widgets are not updated when the collection changes.

fixes #20483 
