### PR TITLE
Masks: visualize restricted edit mode

### DIFF
--- a/src/develop/blend.h
+++ b/src/develop/blend.h
@@ -343,6 +343,7 @@ typedef struct dt_iop_gui_blend_data_t
   GtkWidget *masks_shapes[DEVELOP_MASKS_NB_SHAPES];
   int masks_type[DEVELOP_MASKS_NB_SHAPES];
   GtkWidget *masks_edit;
+  GtkWidget *masks_edit_mode;
   GtkWidget *masks_polarity;
   int *masks_combo_ids;
   dt_masks_edit_mode_t masks_shown;

--- a/src/develop/blend.h
+++ b/src/develop/blend.h
@@ -343,7 +343,6 @@ typedef struct dt_iop_gui_blend_data_t
   GtkWidget *masks_shapes[DEVELOP_MASKS_NB_SHAPES];
   int masks_type[DEVELOP_MASKS_NB_SHAPES];
   GtkWidget *masks_edit;
-  GtkWidget *masks_edit_mode;
   GtkWidget *masks_polarity;
   int *masks_combo_ids;
   dt_masks_edit_mode_t masks_shown;

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -1711,7 +1711,7 @@ static gboolean _blendop_masks_show_and_edit(GtkWidget *widget,
     gtk_toggle_button_set_active
       (GTK_TOGGLE_BUTTON(bd->masks_edit), bd->masks_shown != DT_MASKS_EDIT_OFF);
     if(bd->masks_shown == DT_MASKS_EDIT_RESTRICTED)
-      dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(bd->masks_edit), dtgtk_cairo_paint_lock, 0, NULL);
+      dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(bd->masks_edit), dtgtk_cairo_paint_masks_restricted_edit, 0, NULL);
     else
       dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(bd->masks_edit), dtgtk_cairo_paint_masks_eye, 0, NULL);  
     dt_masks_set_edit_mode(self, bd->masks_shown);

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -1710,8 +1710,10 @@ static gboolean _blendop_masks_show_and_edit(GtkWidget *widget,
 
     gtk_toggle_button_set_active
       (GTK_TOGGLE_BUTTON(bd->masks_edit), bd->masks_shown != DT_MASKS_EDIT_OFF);
-    gtk_toggle_button_set_active
-      (GTK_TOGGLE_BUTTON(bd->masks_edit_mode), bd->masks_shown == DT_MASKS_EDIT_RESTRICTED);      
+    if(bd->masks_shown == DT_MASKS_EDIT_RESTRICTED)
+      dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(bd->masks_edit), dtgtk_cairo_paint_lock, 0, NULL);
+    else
+      dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(bd->masks_edit), dtgtk_cairo_paint_masks_eye, 0, NULL);  
     dt_masks_set_edit_mode(self, bd->masks_shown);
 
     // set all add shape buttons to inactive
@@ -2779,12 +2781,6 @@ void dt_iop_gui_init_masks(GtkWidget *blendw, dt_iop_module_t *module)
     dt_gui_add_class(bd->masks_polarity, "dt_ignore_fg_state");
 
     GtkWidget *abox = dt_gui_hbox();
-    bd->masks_edit_mode = dt_iop_togglebutton_new(module, "blend`tools",
-                                             N_("mask edit mode"),
-                                             N_("mask edit mode"),
-                                             G_CALLBACK(_blendop_masks_show_and_edit),
-                                             FALSE, 0, 0,
-                                             dtgtk_cairo_paint_lock, abox);
     bd->masks_edit = dt_iop_togglebutton_new(module, "blend`tools",
                                              N_("show and edit mask elements"),
                                              N_("show and edit in restricted mode (no moving/resizing of shapes)"),

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -1710,6 +1710,8 @@ static gboolean _blendop_masks_show_and_edit(GtkWidget *widget,
 
     gtk_toggle_button_set_active
       (GTK_TOGGLE_BUTTON(bd->masks_edit), bd->masks_shown != DT_MASKS_EDIT_OFF);
+    gtk_toggle_button_set_active
+      (GTK_TOGGLE_BUTTON(bd->masks_edit_mode), bd->masks_shown == DT_MASKS_EDIT_RESTRICTED);      
     dt_masks_set_edit_mode(self, bd->masks_shown);
 
     // set all add shape buttons to inactive

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -2777,6 +2777,12 @@ void dt_iop_gui_init_masks(GtkWidget *blendw, dt_iop_module_t *module)
     dt_gui_add_class(bd->masks_polarity, "dt_ignore_fg_state");
 
     GtkWidget *abox = dt_gui_hbox();
+    bd->masks_edit_mode = dt_iop_togglebutton_new(module, "blend`tools",
+                                             N_("mask edit mode"),
+                                             N_("mask edit mode"),
+                                             G_CALLBACK(_blendop_masks_show_and_edit),
+                                             FALSE, 0, 0,
+                                             dtgtk_cairo_paint_lock, abox);
     bd->masks_edit = dt_iop_togglebutton_new(module, "blend`tools",
                                              N_("show and edit mask elements"),
                                              N_("show and edit in restricted mode (no moving/resizing of shapes)"),

--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -509,6 +509,30 @@ void dtgtk_cairo_paint_masks_eye(cairo_t *cr, const gint x, const gint y, const 
   FINISH
 }
 
+void dtgtk_cairo_paint_masks_restricted_edit(cairo_t *cr, const gint x, const gint y, const gint w, const gint h, gint flags, void *data)
+{
+  PREAMBLE(1, 1, 0, 0)
+
+  const double dashed[] = { 0.2, 0.2 };
+  const int len = sizeof(dashed) / sizeof(dashed[0]);
+  cairo_set_dash(cr, dashed, len, 0);
+
+  cairo_arc(cr, 0.75, 0.75, 0.75, 2.8, 4.7124);
+  cairo_stroke(cr);
+
+  // Adding the lock body
+  cairo_rectangle(cr, 0.25, 0.5, .5, .45);
+  cairo_fill(cr);
+
+  // Adding the lock shank
+  cairo_translate(cr, .5, .5);
+  cairo_scale(cr, .2, .4);
+  cairo_arc(cr, 0, 0, 1, M_PI, 0);
+  cairo_stroke(cr);
+
+  FINISH
+}
+
 void dtgtk_cairo_paint_masks_circle(cairo_t *cr, const gint x, const gint y, const gint w, const gint h, gint flags, void *data)
 {
   PREAMBLE(1.1, 1, 0, 0)

--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -520,6 +520,9 @@ void dtgtk_cairo_paint_masks_restricted_edit(cairo_t *cr, const gint x, const gi
   cairo_arc(cr, 0.75, 0.75, 0.75, 2.8, 4.7124);
   cairo_stroke(cr);
 
+  cairo_save(cr);
+  cairo_translate(cr, 0.15, 0); 
+
   // Adding the lock body
   cairo_rectangle(cr, 0.25, 0.5, .5, .45);
   cairo_fill(cr);
@@ -527,8 +530,11 @@ void dtgtk_cairo_paint_masks_restricted_edit(cairo_t *cr, const gint x, const gi
   // Adding the lock shank
   cairo_translate(cr, .5, .5);
   cairo_scale(cr, .2, .4);
+  cairo_set_line_width(cr, 0.2); 
   cairo_arc(cr, 0, 0, 1, M_PI, 0);
   cairo_stroke(cr);
+
+  cairo_restore(cr);
 
   FINISH
 }

--- a/src/dtgtk/paint.h
+++ b/src/dtgtk/paint.h
@@ -262,6 +262,8 @@ void dtgtk_cairo_paint_map_pin(cairo_t *cr, gint x, gint y, gint w, gint h, gint
 
 /** Paint an eye icon for masks */
 void dtgtk_cairo_paint_masks_eye(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
+/** Paint an icon for masks in restricted edit mode */
+void dtgtk_cairo_paint_masks_restricted_edit(cairo_t *cr, const gint x, const gint y, const gint w, const gint h, gint flags, void *data);
 /** Paint a circle icon for masks */
 void dtgtk_cairo_paint_masks_circle(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 /** Paint an ellipse icon for masks */


### PR DESCRIPTION
This is a solution proposal for issue https://github.com/darktable-org/darktable/issues/20402 .
When editing shapes of masks, it is possible to switch to a restricted edit mode (by CTRL-click), where it is not possible to change the size of or move the masks. However, it is not visible on the UI, whether the restricted edit mode is active.
This PR introduces a new icon to indicate the edit mode. Normally, the following icon is shown on the button to switch on the shape editing:
<img width="139" height="88" alt="image" src="https://github.com/user-attachments/assets/9e8e6fe3-e2f8-4036-8356-e966b9270b70" />
When in restricted mode, the icon changes to this:
<img width="173" height="112" alt="image" src="https://github.com/user-attachments/assets/10fce9dc-feac-4266-9669-0c2d45855916" />

closes https://github.com/darktable-org/darktable/issues/20402 .