### PR TITLE
[Nightly] Add missing libarchive-dev dependency

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -52,6 +52,7 @@ jobs:
             git \
             gdb \
             intltool \
+            libarchive-dev \
             libatk1.0-dev \
             libcairo2-dev \
             libcolord-dev \


### PR DESCRIPTION
This is required for AppImage builds with AI enabled.
