### PR TITLE
scopes: move RYB color harmony chooser to the right side

### DIFF
--- a/src/gui/gtk.h
+++ b/src/gui/gtk.h
@@ -661,6 +661,7 @@ static inline GCallback G_CALLBACK(void *f) { return (GCallback)f; } // as a mac
     BOOLSIGNAL(signal, popup-menu) \
     BOOLSIGNAL(signal, query-tooltip) \
     BOOLSIGNAL(signal, match-selected) \
+    BOOLSIGNAL(signal, get-child-position) \
     ) == _Generic((DISABLINGPREFIX##c_handler), gboolean(*)(): TRUE, default: FALSE), \
     "signal " signal " return type does not match specified handler " #c_handler); \
   g_signal_connect_data((instance), (signal), (GCallback)(c_handler), (user_data), NULL, (GConnectFlags) 0); } while(0)

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -443,7 +443,7 @@ static void _eventbox_scroll_callback(GtkEventControllerScroll* self,
   GdkEvent *event = gtk_get_current_event();
   if(!event) return;
   if(gdk_event_get_event_type(event) == GDK_SCROLL)
-    {
+  {
     // FIXME: so long as we have event, test its flags -- and for GTK 4 we can use gtk_get_current_event() and get flags -- make a helper function to do this
     if(dt_modifier_is(event->scroll.state,
                       GDK_SHIFT_MASK | GDK_MOD1_MASK))
@@ -462,9 +462,10 @@ static void _eventbox_scroll_callback(GtkEventControllerScroll* self,
     }
     else
     {
-      // FIXME: should scrolling of scope be handled in the drawable rather than the eventbox? right now can scroll on buttons and it will change the vectorscope!
-      dt_scopes_call_if_exists(s->cur_mode, eventbox_scroll,
-                               event->scroll.x, event->scroll.y,
+      int ebx, eby;
+      gtk_widget_translate_coordinates(gtk_get_event_widget(event), s->scope_draw,
+                                       (int)event->scroll.x, (int)event->scroll.y, &ebx, &eby);
+      dt_scopes_call_if_exists(s->cur_mode, eventbox_scroll, ebx, eby,
                                dx, dy, event->scroll.state);
     }
   }
@@ -479,7 +480,6 @@ static void _eventbox_motion_notify_callback(GtkEventControllerMotion *controlle
   // This is required in order to correctly display the button tooltips
   // FIXME: it would seem possible that it is necessary to update button tooltips only when the main widget tooltip has changed, if the tooltip bubbled down, but calling this at the end of lib_histogram_update_tooltip() doesn't seem to help
   dt_scopes_call_if_exists(s->cur_mode, update_buttons);
-  dt_scopes_call_if_exists(s->cur_mode, eventbox_motion, controller, x, y);
 }
 
 static void _eventbox_enter_notify_callback(GtkEventControllerMotion *controller,
@@ -497,8 +497,8 @@ static void _eventbox_enter_notify_callback(GtkEventControllerMotion *controller
   dt_scopes_call(s->cur_mode, mode_enter);
   gtk_widget_set_visible(s->button_box_rgb,
                          dt_scopes_func_exists(s->cur_mode, draw_scope_channels));
-  gtk_widget_show(s->button_box_main);
-  gtk_widget_show(s->button_box_opt);
+  gtk_widget_show(s->button_box_left);
+  gtk_widget_show(s->button_box_right);
 }
 
 static void _eventbox_leave_notify_callback(GtkEventControllerMotion *controller,
@@ -521,8 +521,8 @@ static void _eventbox_leave_notify_callback(GtkEventControllerMotion *controller
     }
     gdk_event_free(event);
   }
-  gtk_widget_hide(s->button_box_main);
-  gtk_widget_hide(s->button_box_opt);
+  gtk_widget_hide(s->button_box_left);
+  gtk_widget_hide(s->button_box_right);
 }
 
 static void _lib_histogram_collapse_callback(dt_action_t *action)
@@ -564,8 +564,8 @@ void view_enter(struct dt_lib_module_t *self,
   }
   // button box should be hidden when enter view, unless mouse is over
   // histogram, in which case gtk kindly generates enter events
-  gtk_widget_hide(s->button_box_main);
-  gtk_widget_hide(s->button_box_opt);
+  gtk_widget_hide(s->button_box_left);
+  gtk_widget_hide(s->button_box_right);
 
   // FIXME: set histogram data to blank if enter tether with no active image
 }
@@ -575,6 +575,25 @@ void view_leave(struct dt_lib_module_t *self,
                 struct dt_view_t *new_view)
 {
   DT_CONTROL_SIGNAL_DISCONNECT(_lib_histogram_preview_updated_callback, self);
+}
+
+static gboolean _overlay_size_child_to_main(GtkOverlay *overlay, GtkWidget *child,
+                                            GdkRectangle *alloc, GtkWidget *match)
+{
+  // GtkOverlay clips main child to its parent widget size, but not
+  // other children. Make sure that we clip match.
+  // GTK4: use gtk_overlay_set_clip_overlay() and gtk_widget_set_valign()
+  if(child != match) return FALSE;
+  GtkAllocation main_alloc;
+  GtkRequisition req;
+  GtkWidget *main = gtk_bin_get_child(GTK_BIN(overlay));
+  gtk_widget_get_allocation(main, &main_alloc);
+  gtk_widget_get_preferred_size(child, NULL, &req);
+  alloc->width = req.width;
+  alloc->height = MIN(req.height, main_alloc.height);
+  alloc->x = main_alloc.width - req.width;   // right align
+  alloc->y = 0;
+  return TRUE;
 }
 
 void gui_init(dt_lib_module_t *self)
@@ -621,7 +640,6 @@ void gui_init(dt_lib_module_t *self)
   darktable.lib->proxy.histogram.process = _scope_process;
 
   // create widgets
-  GtkWidget *overlay = gtk_overlay_new();
   dt_action_t *dark =
     dt_action_section(&darktable.view_manager->proxy.darkroom.view->actions,
                       N_("histogram"));
@@ -633,33 +651,32 @@ void gui_init(dt_lib_module_t *self)
   dt_action_t *ac = dt_action_define(dark, NULL, N_("hide histogram"), s->scope_draw, NULL);
   dt_action_register(ac, NULL, _lib_histogram_collapse_callback,
                      GDK_KEY_H, GDK_CONTROL_MASK | GDK_SHIFT_MASK);
-  gtk_widget_set_events(s->scope_draw, GDK_ENTER_NOTIFY_MASK);
 
   // a row of control buttons, split in two button boxes, on left and right side
-  s->button_box_main = dt_gui_vbox();
-  dt_gui_add_class(s->button_box_main, "button_box");
-  gtk_widget_set_valign(s->button_box_main, GTK_ALIGN_START);
-  gtk_widget_set_halign(s->button_box_main, GTK_ALIGN_START);
+  // self->widget (GtkEventBox)
+  //   '--> GtkOverlay
+  //          |--> scope_draw (DtGtkDrawingArea with dt_ui_resize_wrap)
+  //          |--> button_box_left (GtkBox hori)
+  //          |      '--> mode buttons
+  //          '--> button_box_right (GtkBox vert)
+  //                 |--> button_box_opt (GtkBox hori)
+  //                 |      '--> option buttons & button_box_rgb
+  //                 '--> vectorscope harmony buttons (GtkViewport)
+  // FIXME: put button_box_left_right into a single box so can load it into single overlay and turn on/off with one GTK call?
+  s->button_box_left = dt_gui_hbox();
+  dt_gui_add_class(s->button_box_left, "button_box");
+  gtk_widget_set_valign(s->button_box_left, GTK_ALIGN_START);
+  gtk_widget_set_halign(s->button_box_left, GTK_ALIGN_START);
 
-  GtkWidget *box_left = dt_gui_hbox();
-  gtk_widget_set_valign(box_left, GTK_ALIGN_START);
-  gtk_widget_set_halign(box_left, GTK_ALIGN_START);
-  dt_gui_box_add(s->button_box_main, box_left);
+  s->button_box_right = dt_gui_vbox();
+  dt_gui_add_class(s->button_box_right, "button_box");
+  gtk_widget_set_valign(s->button_box_right, GTK_ALIGN_START);
+  gtk_widget_set_halign(s->button_box_right, GTK_ALIGN_END);
 
-  for(dt_scopes_mode_type_t i = 0; i < DT_SCOPES_MODE_N; i++)
-    dt_scopes_call_if_exists(&s->modes[i],
-                             add_to_main_box, dark, s->button_box_main);
-
-  s->button_box_opt = dt_gui_hbox();
-  dt_gui_add_class(s->button_box_opt, "button_box");
-  gtk_widget_set_valign(s->button_box_opt, GTK_ALIGN_START);
-  gtk_widget_set_halign(s->button_box_opt, GTK_ALIGN_END);
-
-  // this intermediate box is needed to make the actions on buttons work
-  GtkWidget *box_right = dt_gui_hbox();
-  gtk_widget_set_valign(box_right, GTK_ALIGN_START);
-  gtk_widget_set_halign(box_right, GTK_ALIGN_START);
-  dt_gui_box_add(s->button_box_opt, box_right);
+  GtkWidget *button_box_opt = dt_gui_hbox();
+  gtk_widget_set_valign(button_box_opt, GTK_ALIGN_START);
+  gtk_widget_set_halign(button_box_opt, GTK_ALIGN_END);
+  dt_gui_box_add(s->button_box_right, button_box_opt);
 
   // FIXME: the button transitions when they appear on mouseover
   // (mouse enters scope widget) or change (mouse click) cause redraws
@@ -675,14 +692,14 @@ void gui_init(dt_lib_module_t *self)
       dtgtk_cairo_paint_histogram_scope };
   for(int i=0; i<DT_SCOPES_MODE_N; i++)
   {
-    // FIXME: can use use GtkNotebook with gtk_notebook_set_show_tabs() to FALSE to handle mode-switching behavior?
+    // FIXME: can use use GtkStack or GtkNotebook with gtk_notebook_set_show_tabs() to FALSE to handle mode-switching behavior?
     s->modes[i].button_activate =
       dtgtk_togglebutton_new(dt_lib_histogram_scope_type_icons[i], CPF_NONE, NULL);
     const char *const name = dt_scopes_call(&s->modes[i], name);
     gtk_widget_set_tooltip_text(s->modes[i].button_activate, _(name));
     dt_action_define(dark, N_("modes"), name,
                      s->modes[i].button_activate, &dt_action_def_toggle);
-    dt_gui_box_add(box_left, s->modes[i].button_activate);
+    dt_gui_box_add(s->button_box_left, s->modes[i].button_activate);
     // GTK4: use gtk_toggle_button_set_group(), GTK3: handle in callback
     s->modes[i].toggle_signal_handler =
       g_signal_connect_data(G_OBJECT(s->modes[i].button_activate), "toggled",
@@ -695,10 +712,11 @@ void gui_init(dt_lib_module_t *self)
                        _lib_histogram_collapse_callback,
                        GDK_KEY_H, GDK_CONTROL_MASK | GDK_SHIFT_MASK);
 
+  // add option buttons
+
   s->button_box_rgb = dt_gui_hbox();
   gtk_widget_set_valign(s->button_box_rgb, GTK_ALIGN_CENTER);
   gtk_widget_set_halign(s->button_box_rgb, GTK_ALIGN_END);
-
   // red/green/blue channel on/off
   for(int i=DT_SCOPES_RGB_RED; i < DT_SCOPES_RGB_N; i++)
   {
@@ -717,15 +735,23 @@ void gui_init(dt_lib_module_t *self)
     s->channel_buttons[i] = btn;
   }
 
+  // hardwire waveform buttons before vectorscope in split, RGB
+  // channels after waveform/histogram options but before vectorscope
+  dt_scopes_call(&s->modes[DT_SCOPES_MODE_WAVEFORM], add_options, dark,
+                 s->button_box_right, button_box_opt);
+  dt_scopes_call(&s->modes[DT_SCOPES_MODE_HISTOGRAM], add_options, dark,
+                 s->button_box_right, button_box_opt);
+  dt_gui_box_add(button_box_opt, s->button_box_rgb);
+  dt_scopes_call(&s->modes[DT_SCOPES_MODE_VECTORSCOPE], add_options, dark,
+                 s->button_box_right, button_box_opt);
+
   for(dt_scopes_mode_type_t i = 0; i < DT_SCOPES_MODE_N; i++)
   {
-    dt_scopes_call_if_exists(&s->modes[i], add_to_options_box, dark, box_right);
     dt_scopes_call_if_exists(&s->modes[i], update_buttons);
     if(s->cur_mode == &s->modes[i])
       gtk_toggle_button_set_active
         (GTK_TOGGLE_BUTTON(s->modes[i].button_activate), TRUE);
   }
-  dt_gui_box_add(box_right, s->button_box_rgb);
 
   // FIXME: add a brightness control (via GtkScaleButton?). Different per each mode?
 
@@ -736,25 +762,12 @@ void gui_init(dt_lib_module_t *self)
   // show/hide the buttons. The drawable is below the buttons, and
   // hence won't catch motion events for the buttons, and gets a leave
   // event when the cursor moves over the buttons.
-  //
-  // |----- EventBox -----|
-  // |                    |
-  // |  |-- Overlay  --|  |
-  // |  |              |  |
-  // |  |  ButtonBox   |  |
-  // |  |              |  |
-  // |  |--------------|  |
-  // |  |              |  |
-  // |  |  DrawingArea |  |
-  // |  |              |  |
-  // |  |--------------|  |
-  // |                    |
-  // |--------------------|
+  GtkWidget *overlay = gtk_overlay_new();
+  gtk_container_add(GTK_CONTAINER(overlay), s->scope_draw);
+  gtk_overlay_add_overlay(GTK_OVERLAY(overlay), s->button_box_left);
+  gtk_overlay_add_overlay(GTK_OVERLAY(overlay), s->button_box_right);
 
   GtkWidget *eventbox = gtk_event_box_new();
-  gtk_container_add(GTK_CONTAINER(overlay), s->scope_draw);
-  gtk_overlay_add_overlay(GTK_OVERLAY(overlay), s->button_box_main);
-  gtk_overlay_add_overlay(GTK_OVERLAY(overlay), s->button_box_opt);
   gtk_container_add(GTK_CONTAINER(eventbox), overlay);
   self->widget = eventbox;
 
@@ -768,12 +781,17 @@ void gui_init(dt_lib_module_t *self)
                            _drawable_button_release, s);
   dt_gui_connect_motion(s->scope_draw, _drawable_motion, NULL,
                         _drawable_leave, s);
+  // constrain height of button_box_right to s->scope_draw, necessary
+  // so that harmony buttons are scrollable within overlay
+  g_signal_connect(G_OBJECT(overlay), "get-child-position",
+                   G_CALLBACK(_overlay_size_child_to_main), s->button_box_right);
 
-  // FIXME: scope implementation didn't setprop phase, maybe defaulted to bubble -- do we need to set this here?
-  dt_gui_connect_scroll(eventbox, GTK_EVENT_CONTROLLER_SCROLL_VERTICAL
-                                  | GTK_EVENT_CONTROLLER_SCROLL_DISCRETE,
-                        _eventbox_scroll_callback, s);
-  // FIXME: add (optional) propagation phase argument to dt_gui_connect_motion()
+  // FIXME: add (optional) propagation phase argument to dt_gui_connect_*()
+  GtkEventController *scroll_controller =
+    dt_gui_connect_scroll(eventbox, GTK_EVENT_CONTROLLER_SCROLL_VERTICAL
+                                    | GTK_EVENT_CONTROLLER_SCROLL_DISCRETE,
+                          _eventbox_scroll_callback, s);
+  gtk_event_controller_set_propagation_phase(scroll_controller, GTK_PHASE_CAPTURE);
   GtkEventController *motion_controller =
     dt_gui_connect_motion(eventbox, _eventbox_motion_notify_callback,
                           _eventbox_enter_notify_callback,

--- a/src/libs/scopes.h
+++ b/src/libs/scopes.h
@@ -104,10 +104,6 @@ typedef struct dt_scopes_functions_t
                           gdouble x, gdouble y,
                           gdouble delta_x, gdouble delta_y,
                           GdkModifierType state);
-  void (*eventbox_motion)(struct dt_scopes_mode_t *const self,
-                          GtkEventControllerMotion *controller,
-                          double x,
-                          double y);
   // set option button icons to current state, updates tooltips
   // accordingly, and if necessary update any state which depends on
   // current option buttons
@@ -115,12 +111,8 @@ typedef struct dt_scopes_functions_t
   void (*mode_enter)(struct dt_scopes_mode_t *const self);
   void (*mode_leave)(const struct dt_scopes_mode_t *const self);
   void (*gui_init)(struct dt_scopes_mode_t *const self, struct dt_scopes_t *const scopes);
-  void (*add_to_main_box)(struct dt_scopes_mode_t *const self,
-                          dt_action_t *dark,
-                          GtkWidget *box);
-  void (*add_to_options_box)(struct dt_scopes_mode_t *const mode,
-                             dt_action_t *dark,
-                             GtkWidget *box);
+  void (*add_options)(struct dt_scopes_mode_t *const mode, dt_action_t *dark,
+                      GtkWidget *box_right, GtkWidget *box_opt);
   void (*gui_cleanup)(struct dt_scopes_mode_t *const self);
 } dt_scopes_functions_t;
 
@@ -128,7 +120,7 @@ typedef struct dt_scopes_mode_t
 {
   const dt_scopes_functions_t *functions;
   void *data;
-  GtkWidget *button_activate;                   // GtkDarktableToggleButton which activates mode
+  GtkWidget *button_activate;                   // GtkDarktableToggleButton to activate
   gulong toggle_signal_handler;
   int update_counter;
   // point back to parent
@@ -146,11 +138,11 @@ typedef struct dt_scopes_t
   dt_scopes_highlight_t highlight;              // depends on mouse position
   scopes_channels_t channels;                   // display state chosen by RGB buttons
   // UI elements
-  GtkWidget *button_box_main;                   // GtkBox -- contains scope control buttons
-  GtkWidget *button_box_opt;                    // GtkBox -- contains options buttons
+  GtkWidget *button_box_left;                   // GtkBox -- contains scope mode buttons
+  GtkWidget *button_box_right;                  // GtkBox -- contains option buttons
   GtkWidget *button_box_rgb;                    // GtkBox -- contains RGB channels buttons
-  GtkWidget *channel_buttons[DT_SCOPES_RGB_N];  // Array of GtkToggleButton -- RGB channel display
-  GtkWidget *scope_draw;                        // GtkDrawingArea -- scope, scale, draggable overlays
+  GtkWidget *channel_buttons[DT_SCOPES_RGB_N];  // Array of GtkToggleButton -- RGB channels
+  GtkWidget *scope_draw;                        // GtkDrawingArea -- scope & resize
   // for access to data during process/draw
   dt_pthread_mutex_t lock;
 } dt_scopes_t;

--- a/src/libs/scopes/histogram.c
+++ b/src/libs/scopes/histogram.c
@@ -235,15 +235,14 @@ static void _hist_scale_clicked(GtkWidget *button, dt_scopes_mode_t *self)
   dt_scopes_refresh(self->scopes);
 }
 
-static void _hist_add_to_options_box(dt_scopes_mode_t *const self,
-                                     dt_action_t *dark,
-                                     GtkWidget *box)
+static void _hist_add_options(dt_scopes_mode_t *const self, dt_action_t *dark,
+                              GtkWidget *box_right, GtkWidget *box_opt)
 {
   dt_scopes_hist_t *d = self->data;
   d->scale_button = dtgtk_button_new(dtgtk_cairo_paint_empty, CPF_NONE, NULL);
   dt_action_define(dark, NULL, N_("switch histogram scale"),
                    d->scale_button, &dt_action_def_button);
-  dt_gui_box_add(box, d->scale_button);
+  dt_gui_box_add(box_opt, d->scale_button);
   g_signal_connect(G_OBJECT(d->scale_button), "clicked",
                    G_CALLBACK(_hist_scale_clicked), self);
 }
@@ -271,13 +270,11 @@ const dt_scopes_functions_t dt_scopes_functions_histogram = {
   .get_exposure_pos = _hist_get_exposure_pos,
   .append_to_tooltip = NULL,
   .eventbox_scroll = NULL,
-  .eventbox_motion = NULL,
   .update_buttons = _hist_update_buttons,
   .mode_enter = _hist_mode_enter,
   .mode_leave = _hist_mode_leave,
   .gui_init = _hist_gui_init,
-  .add_to_main_box = NULL,
-  .add_to_options_box = _hist_add_to_options_box,
+  .add_options = _hist_add_options,
   .gui_cleanup = _hist_gui_cleanup
 };
 

--- a/src/libs/scopes/split.c
+++ b/src/libs/scopes/split.c
@@ -20,9 +20,6 @@
 
 typedef struct dt_scopes_split_t
 {
-  // point back to parent
-  // FIXME: is this healthy? is this needed?
-  dt_scopes_t *scopes;
   dt_scopes_mode_t *left;
   dt_scopes_mode_t *right;
 } dt_scopes_split_t;
@@ -54,11 +51,11 @@ static void _split_draw_highlight(const dt_scopes_mode_t *const self,
   const int half_width = width / 2;
   cairo_save(cr);
   if(d->left->functions->draw_highlight)
-    d->left->functions->draw_highlight(d->left, cr, d->scopes->highlight,
+    d->left->functions->draw_highlight(d->left, cr, self->scopes->highlight,
                                        half_width, height);
   cairo_translate(cr, half_width, 0);
   if(d->right->functions->draw_highlight)
-    d->right->functions->draw_highlight(d->right, cr, d->scopes->highlight,
+    d->right->functions->draw_highlight(d->right, cr, self->scopes->highlight,
                                         half_width, height);
   cairo_restore(cr);
 }
@@ -104,7 +101,7 @@ static void _split_draw(const dt_scopes_mode_t *const self,
   const dt_scopes_split_t *const d = self->data;
   const int half_width = width / 2;
 
-  if(d->left->update_counter == d->scopes->update_counter)
+  if(d->left->update_counter == self->scopes->update_counter)
   {
     cairo_save(cr);
     cairo_rectangle(cr, 0, 0, half_width, height);
@@ -112,13 +109,14 @@ static void _split_draw(const dt_scopes_mode_t *const self,
     if(d->left->functions->draw_scope_channels)
       d->left->functions->draw_scope_channels(d->left, cr,
                                               half_width, height,
-                                              d->scopes->channels);
+                                              self->scopes->channels);
     else
       d->left->functions->draw_scope(d->left, cr,
                                      half_width, height);
     cairo_restore(cr);
   }
-  if(d->right->update_counter == d->scopes->update_counter)
+  // FIXME: make slight gap/line between two scopes, as it is crammed, especially visibile in RYB vectorscope where color harmony name is awkwardly close to waveform
+  if(d->right->update_counter == self->scopes->update_counter)
   {
     cairo_save(cr);
     cairo_translate(cr, half_width, 0);
@@ -127,7 +125,7 @@ static void _split_draw(const dt_scopes_mode_t *const self,
     if(d->right->functions->draw_scope_channels)
       d->right->functions->draw_scope_channels(d->right, cr,
                                                half_width, height,
-                                               d->scopes->channels);
+                                               self->scopes->channels);
     else
       d->right->functions->draw_scope(d->right, cr,
                                       half_width, height);
@@ -151,7 +149,7 @@ static double _split_get_exposure_pos(const dt_scopes_mode_t *const self,
 {
   const dt_scopes_split_t *const d = self->data;
   GtkAllocation allocation;
-  gtk_widget_get_allocation(d->scopes->scope_draw, &allocation);
+  gtk_widget_get_allocation(self->scopes->scope_draw, &allocation);
   if(x < allocation.width/2.0)
   {
     if(d->left->functions->get_exposure_pos)
@@ -201,25 +199,11 @@ static void _split_eventbox_scroll(dt_scopes_mode_t *const self,
 {
   dt_scopes_split_t *const d = self->data;
   GtkAllocation allocation;
-  gtk_widget_get_allocation(d->scopes->scope_draw, &allocation);
+  gtk_widget_get_allocation(self->scopes->scope_draw, &allocation);
   if((x < allocation.width/2) && d->left->functions->eventbox_scroll)
     d->left->functions->eventbox_scroll(d->left, x, y, delta_x, delta_y, state);
   if((x >= allocation.width/2) && d->right->functions->eventbox_scroll)
     d->right->functions->eventbox_scroll(d->right, x, y, delta_x, delta_y, state);
-}
-
-static void _split_eventbox_motion(dt_scopes_mode_t *const self,
-                                   GtkEventControllerMotion *controller,
-                                   double x,
-                                   double y)
-{
-  dt_scopes_split_t *const d = self->data;
-  GtkAllocation allocation;
-  gtk_widget_get_allocation(d->scopes->scope_draw, &allocation);
-  if((x < allocation.width/2) && d->left->functions->eventbox_motion)
-    d->left->functions->eventbox_motion(d->left, controller, x, y);
-  if((x >= allocation.width/2) && d->right->functions->eventbox_motion)
-    d->right->functions->eventbox_motion(d->right, controller, x, y);
 }
 
 static void _split_update_buttons(const dt_scopes_mode_t *const self)
@@ -251,11 +235,8 @@ static void _split_gui_init(dt_scopes_mode_t *const self,
 {
   dt_scopes_split_t *d = dt_calloc1_align_type(dt_scopes_split_t);
   self->data = (void *)d;
-  // FIXME: ideal this is an attribute of self set up by caller
-  d->scopes = scopes;
-
-  d->left = &d->scopes->modes[DT_SCOPES_MODE_VECTORSCOPE];
-  d->right = &d->scopes->modes[DT_SCOPES_MODE_WAVEFORM];
+  d->left = &self->scopes->modes[DT_SCOPES_MODE_WAVEFORM];
+  d->right = &self->scopes->modes[DT_SCOPES_MODE_VECTORSCOPE];
 }
 
 static void _split_gui_cleanup(dt_scopes_mode_t *const self)
@@ -278,13 +259,11 @@ const dt_scopes_functions_t dt_scopes_functions_split = {
   .get_exposure_pos = _split_get_exposure_pos,
   .append_to_tooltip = _split_append_to_tooltip,
   .eventbox_scroll = _split_eventbox_scroll,
-  .eventbox_motion = _split_eventbox_motion,
   .update_buttons = _split_update_buttons,
   .mode_enter = _split_mode_enter,
   .mode_leave = _split_mode_leave,
   .gui_init = _split_gui_init,
-  .add_to_main_box = NULL,
-  .add_to_options_box = NULL,
+  .add_options = NULL,
   .gui_cleanup = _split_gui_cleanup
 };
 

--- a/src/libs/scopes/vectorscope.c
+++ b/src/libs/scopes/vectorscope.c
@@ -104,7 +104,7 @@ typedef struct dt_scopes_vec_t
   double vectorscope_radius;
 
   GtkWidget *color_harmony_box;        // GtkBox -- contains color harmony buttons
-  GtkWidget *color_harmony_fix;        // GtkFixed -- contains moveable color harmony buttons
+  GtkWidget *harmony_viewport;         // GtkViewport -- contains moveable color harmony buttons
   GtkWidget *vec_scale_button;         // GtkButton -- linear or logarithmic vectorscope
   GtkWidget *colorspace_button;        // GtkButton -- vectorscope colorspace
   GtkWidget *color_harmony_button
@@ -882,8 +882,7 @@ static void _vec_draw(const dt_scopes_mode_t *const self,
       graph_pat = cairo_pop_group(cr);
     }
 
-    // FIXME: is there a less awkward way to check if the mouse is over this, or could this even be another widget in the overlay?
-    if(gtk_widget_get_visible(self->scopes->button_box_main))
+    if(gtk_widget_get_visible(self->scopes->button_box_right))
     {
       // draw information about current selected harmony
       PangoLayout *layout;
@@ -894,7 +893,7 @@ static void _vec_draw(const dt_scopes_mode_t *const self,
       pango_font_description_set_absolute_size(desc, DT_PIXEL_APPLY_DPI(16) * PANGO_SCALE);
       layout = pango_cairo_create_layout(cr);
       pango_layout_set_font_description(layout, desc);
-      pango_layout_set_alignment(layout, PANGO_ALIGN_RIGHT);
+      pango_layout_set_alignment(layout, PANGO_ALIGN_LEFT);
 
       gchar *text = g_strdup_printf("%d°\n%s", d->harmony_guide.rotation, _(hm.name));
 
@@ -903,8 +902,7 @@ static void _vec_draw(const dt_scopes_mode_t *const self,
       pango_layout_get_pixel_extents(layout, NULL, &ink);
       cairo_scale(cr, 1., -1.);
       cairo_rotate(cr, -d->vectorscope_angle);
-      cairo_move_to(cr,
-                    0.48f * width - ink.width - ink.x,
+      cairo_move_to(cr, -0.48 * width - ink.x,
                     0.48 * height - ink.height - ink.y);
       pango_cairo_show_layout(cr, layout);
       cairo_stroke(cr);
@@ -1070,14 +1068,6 @@ static void _color_harmony_state_changed(GtkWidget *widget,
         d->ignore_prelight = DT_COLOR_HARMONY_NONE;
       }
   }
-  else
-  {
-    // FIXME: ideal would be to leave harmony preview on until leave
-    // the container of harmony buttons, so don't flicker as move
-    // between buttons
-    d->harmony_prelight = DT_COLOR_HARMONY_NONE;
-    d->ignore_prelight = DT_COLOR_HARMONY_NONE;
-  }
   if(d->harmony_prelight != prior)
     dt_scopes_refresh(self->scopes);
 }
@@ -1116,6 +1106,7 @@ static void _color_harmony_toggled(GtkButton *button,
           g_signal_handler_unblock(d->color_harmony_button[prior], d->toggle_signal_handler[prior]);
         }
         d->harmony_guide.type = i;
+        d->harmony_prelight = i;  // in case is a scroll event
         d->ignore_prelight = DT_COLOR_HARMONY_NONE;
       }
     }
@@ -1178,23 +1169,44 @@ static void _vec_eventbox_scroll(dt_scopes_mode_t *const self,
   _color_harmony_changed_record(self);
 }
 
-static void _vec_eventbox_motion(dt_scopes_mode_t *const self,
-                                 GtkEventControllerMotion *controller,
-                                 double x,
-                                 double y)
+static void _harmony_adjust_page(GtkWidget *widget,
+                                 GtkAllocation* alloc, dt_scopes_mode_t *self)
 {
   dt_scopes_vec_t *const d = self->data;
-  // FIXME: replace the color harmony box buttons with a widget with a combobox, then get rid of the eventbox motion callback
-  // FIXME: this shouldn't do anything unless in RYB mode
-  GtkWidget *widget = gtk_event_controller_get_widget(GTK_EVENT_CONTROLLER(controller));
-  GtkAllocation fix_alloc;
-  // FIXME: why use gtk_widget_get_allocation vs. gtk_widget_get_allocated_height?
-  gtk_widget_get_allocation(d->color_harmony_fix, &fix_alloc);
-  const int full_height = gtk_widget_get_allocated_height(widget);
-  const int excess =
-    gtk_widget_get_allocated_height(d->color_harmony_box) + fix_alloc.y - full_height;
-  const int shift = excess * MAX(y - fix_alloc.y, 0) / (full_height - fix_alloc.y);
-  gtk_fixed_move(GTK_FIXED(d->color_harmony_fix), d->color_harmony_box, 0, - MAX(shift, 0));
+  // size adjustment page to options buttons box which, in turn,
+  // changes height with the resizeable scopes widget
+  // FIXME: when user resizes scope vertically, next time mouse moves, the buttons widget jumps to new position, so should recalculate its position here based on mouse position during resize
+  gtk_adjustment_set_page_size
+    (gtk_scrollable_get_vadjustment(GTK_SCROLLABLE(d->harmony_viewport)),
+     alloc->height - gtk_widget_get_allocated_height(self->scopes->button_box_left));
+}
+
+static void _harmony_motion(GtkEventControllerMotion *controller,
+                            double x,
+                            double y,
+                            dt_scopes_mode_t *const self)
+{
+  // harmony type buttons scroll as mouse ranges from below the top
+  // buttons to the scope bottom less resize handle
+  dt_scopes_vec_t *const d = self->data;
+  // FIXME: replace the color harmony box buttons with a widget with a combobox, then get rid of the complicated code to support the custom scrolling widgets
+  GtkAdjustment *vadj = gtk_scrollable_get_vadjustment(GTK_SCROLLABLE(d->harmony_viewport));
+  const double scrollable_area = gtk_adjustment_get_page_size(vadj);
+  const double max_val = gtk_adjustment_get_upper(vadj) - scrollable_area;
+  const double val = max_val * y / (scrollable_area - DT_RESIZE_HANDLE_SIZE);
+  gtk_adjustment_set_value(vadj, val);
+}
+
+static void _harmony_leave(GtkEventControllerMotion *controller,
+                           dt_scopes_mode_t *const self)
+{
+  dt_scopes_vec_t *const d = self->data;
+  d->ignore_prelight = DT_COLOR_HARMONY_NONE;
+  if(d->harmony_prelight != DT_COLOR_HARMONY_NONE)
+  {
+    d->harmony_prelight = DT_COLOR_HARMONY_NONE;
+    dt_scopes_refresh(self->scopes);
+  }
 }
 
 static void _vec_scale_clicked(GtkWidget *button, dt_scopes_mode_t *const self)
@@ -1348,17 +1360,28 @@ static void _vec_gui_init(dt_scopes_mode_t *const self,
   d->harmony_prelight = d->ignore_prelight = DT_COLOR_HARMONY_NONE;
 }
 
-static void _vec_add_to_main_box(dt_scopes_mode_t *const self,
-                                 dt_action_t *dark,
-                                 GtkWidget *box)
+static void _vec_add_options(dt_scopes_mode_t *const self, dt_action_t *dark,
+                             GtkWidget *box_right, GtkWidget *box_opt)
 {
   dt_scopes_vec_t *const d = self->data;
+
+  d->colorspace_button = dtgtk_button_new(dtgtk_cairo_paint_empty, CPF_NONE, NULL);
+  dt_action_define(dark, NULL, N_("cycle vectorscope types"),
+                   d->colorspace_button, &dt_action_def_button);
+  d->vec_scale_button = dtgtk_button_new(dtgtk_cairo_paint_empty, CPF_NONE, NULL);
+  dt_action_define(dark, NULL, N_("switch vectorscope scale"),
+                   d->vec_scale_button, &dt_action_def_button);
+  dt_gui_box_add(box_opt, d->vec_scale_button, d->colorspace_button);
+
+  d->harmony_viewport = gtk_viewport_new(NULL, NULL);
+  gtk_widget_set_halign(d->harmony_viewport, GTK_ALIGN_END);
+  dt_gui_box_add(box_right, d->harmony_viewport);
+  g_signal_connect(G_OBJECT(box_right), "size-allocate",
+                   G_CALLBACK(_harmony_adjust_page), self);
+
   d->color_harmony_box = dt_gui_vbox();
   gtk_widget_set_valign(d->color_harmony_box, GTK_ALIGN_START);
   gtk_widget_set_halign(d->color_harmony_box, GTK_ALIGN_START);
-  d->color_harmony_fix = gtk_fixed_new();
-  gtk_fixed_put(GTK_FIXED(d->color_harmony_fix), d->color_harmony_box, 0, 0);
-  dt_gui_box_add(box, d->color_harmony_fix);
 
   // a series of buttons for color harmony guide lines
   for(dt_color_harmony_type_t i = DT_COLOR_HARMONY_MONOCHROMATIC;
@@ -1378,32 +1401,18 @@ static void _vec_add_to_main_box(dt_scopes_mode_t *const self,
     dt_gui_box_add(d->color_harmony_box, rb);
     d->color_harmony_button[i] = rb;
   }
+  gtk_container_add(GTK_CONTAINER(d->harmony_viewport), d->color_harmony_box);
 
   // FIXME: do we need this action, or is it vestigial?
   dt_action_register(dark, N_("cycle color harmonies"),
                      _lib_histogram_cycle_harmony_callback, 0, 0);
-}
-
-// FIXME: s/gui_init_options/gui_add_to_options/
-static void _vec_gui_init_options(dt_scopes_mode_t *const self,
-                                  dt_action_t *dark,
-                                  GtkWidget *box)
-{
-  dt_scopes_vec_t *const d = self->data;
-
-  d->colorspace_button = dtgtk_button_new(dtgtk_cairo_paint_empty, CPF_NONE, NULL);
-  dt_action_define(dark, NULL, N_("cycle vectorscope types"),
-                   d->colorspace_button, &dt_action_def_button);
-  d->vec_scale_button = dtgtk_button_new(dtgtk_cairo_paint_empty, CPF_NONE, NULL);
-  dt_action_define(dark, NULL, N_("switch vectorscope scale"),
-                   d->vec_scale_button, &dt_action_def_button);
-  dt_gui_box_add(box, d->colorspace_button, d->vec_scale_button);
 
   /* connect callbacks */
   g_signal_connect(G_OBJECT(d->vec_scale_button), "clicked",
                    G_CALLBACK(_vec_scale_clicked), self);
   g_signal_connect(G_OBJECT(d->colorspace_button), "clicked",
                    G_CALLBACK(_vec_colorspace_clicked), self);
+  dt_gui_connect_motion(d->harmony_viewport, _harmony_motion, NULL, _harmony_leave, self);
 
   DT_CONTROL_SIGNAL_HANDLE(DT_SIGNAL_DEVELOP_IMAGE_CHANGED, _vec_signal_image_changed);
 }
@@ -1441,13 +1450,11 @@ const dt_scopes_functions_t dt_scopes_functions_vectorscope = {
   .get_exposure_pos = NULL,
   .append_to_tooltip = _vec_append_to_tooltip,
   .eventbox_scroll = _vec_eventbox_scroll,
-  .eventbox_motion = _vec_eventbox_motion,
   .update_buttons = _vec_update_buttons,
   .mode_enter = _vec_mode_enter,
   .mode_leave = _vec_mode_leave,
   .gui_init = _vec_gui_init,
-  .add_to_main_box = _vec_add_to_main_box,
-  .add_to_options_box = _vec_gui_init_options,
+  .add_options = _vec_add_options,
   .gui_cleanup = _vec_gui_cleanup
 };
 

--- a/src/libs/scopes/waveform.c
+++ b/src/libs/scopes/waveform.c
@@ -392,15 +392,14 @@ static void _wave_orient_clicked(GtkWidget *button, dt_scopes_mode_t *const self
   dt_scopes_reprocess();
 }
 
-static void _wave_add_to_options_box(dt_scopes_mode_t *const self,
-                                     dt_action_t *dark,
-                                     GtkWidget *box)
+static void _wave_add_options(dt_scopes_mode_t *const self, dt_action_t *dark,
+                              GtkWidget *box_right, GtkWidget *box_opt)
 {
   dt_scopes_wave_t *const d = self->data;
   d->orient_button = dtgtk_button_new(dtgtk_cairo_paint_empty, CPF_NONE, NULL);
   dt_action_define(dark, NULL, N_("switch scope orientation"),
                    d->orient_button, &dt_action_def_button);
-  dt_gui_box_add(box, d->orient_button);
+  dt_gui_box_add(box_opt, d->orient_button);
   g_signal_connect(G_OBJECT(d->orient_button), "clicked",
                    G_CALLBACK(_wave_orient_clicked), self);
 }
@@ -429,13 +428,11 @@ const dt_scopes_functions_t dt_scopes_functions_waveform = {
   .get_exposure_pos = _wave_get_exposure_pos,
   .append_to_tooltip = NULL,
   .eventbox_scroll = NULL,
-  .eventbox_motion = NULL,
   .update_buttons = _wave_update_buttons,
   .mode_enter = _wave_mode_enter,
   .mode_leave = _wave_mode_leave,
   .gui_init = _wave_gui_init,
-  .add_to_main_box = NULL,
-  .add_to_options_box = _wave_add_to_options_box,
+  .add_options = _wave_add_options,
   .gui_cleanup = _wave_gui_cleanup
 };
 
@@ -543,13 +540,11 @@ const dt_scopes_functions_t dt_scopes_functions_parade = {
   .get_exposure_pos = _wave_get_exposure_pos,
   .append_to_tooltip = NULL,
   .eventbox_scroll = NULL,
-  .eventbox_motion = NULL,
   .update_buttons = _wave_update_buttons,
   .mode_enter = _wave_mode_enter,
   .mode_leave = _wave_mode_leave,
   .gui_init = _parade_gui_init,
-  .add_to_main_box = NULL,
-  .add_to_options_box = NULL,
+  .add_options = NULL,
   .gui_cleanup = _parade_gui_cleanup
 };
 


### PR DESCRIPTION
This is a minor UI change (keep all the option buttons on same side), but a bunch of code cleanups come with it. In particular, the harmony chooser buttons are now in a GtkViewport, rather than a GtkFixed, and they no longer overlap with the top row of buttons.

### Detailed notes

All option buttons for modes are now on the right, including the vertical buttons to choose the color harmony, which were previously on the right. Resequence option buttons so that vectorscope options are to right of waveform options and the colorspace button is to right of scale button. The harmony buttons on far right now appear below the colorspace button. Rejigger containers of buttons to make this work. Move text about current harmony to bottom left of vectorscope to make room for the color harmony buttons on right.

Flip (again) the split scopes so that vectorscope is on the right. This makes sense as it is overlaid by the color harmony type buttons when in RYB mode.

Use a viewport for color harmony buttons scrolling rather than a GtkFixed. This is more GTK-ish. The harmony buttons, when they scroll, no longer overlap with the row of buttons above them.

Handle get-child-position signal to size right button box to <= height of the scope. These buttons are a non-main child widget of an overlay, so GTK3 requires this manual work. This ensures that the color harmony button viewport doesn't go past the bottom of the scopes, and so allows for proper scrolling of the viewport. Also add a size-allocate handler for the button box to scale the viewport's scrolling adjustment page size to the drawable height.

Remove flicker from harmony guide overlay preview when moving between harmony buttons. Only turn off prelight preview when cursor leaves the buttons scrollable viewport. Previously the preview would turn off whenever the mouse was in the space between buttons, which caused flickering. Also, when change harmony overlay via scroll when cursor is over the buttons, show newly chosen rather than prelit overlay.

Get rid of no longer needed eventbox_motion and add_to_main_box vfuncs. Make a more generalized add_options (formerly add_to_options_box) vfunc.

Also misc. cleanups including: Don't store current scope in split mode internal data. It is accessible through dt_scopes_mode_t.