### PR TITLE
Initial implementation of Color Harmonizer module.

### DIFF
--- a/data/kernels/colorharmonizer.cl
+++ b/data/kernels/colorharmonizer.cl
@@ -1,0 +1,157 @@
+/*
+    This file is part of darktable,
+    Copyright (C) 2024 darktable developers.
+
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    darktable is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "common.h"
+#include "colorspace.h"
+
+static inline float wrap_hue(float h)
+{
+  h = fmod(h, 1.0f);
+  if(h < 0.0f) h += 1.0f;
+  return h;
+}
+
+// Pull the pixel hue toward the nearest harmony node, scaled by Gaussian proximity.
+// Also returns the winning node index and its max Gaussian weight via output pointers.
+//
+// The shift equals (nearest_node - px_hue) * max_w, so:
+//   - A pixel already at a node produces zero shift.
+//   - A pixel far from all nodes gets near-zero shift (max_w ≈ 0).
+static inline float get_weighted_hue_shift(const float px_hue,
+                                           constant const float *const nodes,
+                                           const int num_nodes,
+                                           const float zone_width_factor,
+                                           int *out_winning_idx,
+                                           float *out_max_weight)
+{
+  if(num_nodes <= 0)
+  {
+    *out_winning_idx = 0;
+    *out_max_weight = 0.0f;
+    return 0.0f;
+  }
+  const float sigma = zone_width_factor * 0.5f / (float)num_nodes;
+  const float inv_2sigma2 = 1.0f / (2.0f * sigma * sigma);
+
+  float max_w        = 0.0f;
+  int   winning_idx  = 0;
+  float diff_winning = 0.0f;
+
+  for(int i = 0; i < num_nodes; i++)
+  {
+    float d = fabs(px_hue - nodes[i]);
+    if(d > 0.5f) d = 1.0f - d;
+
+    const float w = exp(-d * d * inv_2sigma2);
+    float diff = nodes[i] - px_hue;
+    if(diff > 0.5f)       diff -= 1.0f;
+    else if(diff < -0.5f) diff += 1.0f;
+
+    if(w > max_w)
+    {
+      max_w        = w;
+      winning_idx  = i;
+      diff_winning = diff;
+    }
+  }
+
+  *out_winning_idx = winning_idx;
+  *out_max_weight  = max_w;
+  return diff_winning * max_w;
+}
+
+// Kernel 1: compute per-pixel correction maps (hue_delta, sat_delta) and
+// cache the forward JCH conversion so the apply kernel can skip it.
+// jch_out stores (J, chroma, normalized_hue, alpha) per pixel.
+kernel void colorharmonizer_map(read_only  image2d_t  in,
+                                global     float2    *p_out,
+                                global     float4    *jch_out,
+                                const int   width,
+                                const int   height,
+                                constant const float *const matrix_in,
+                                constant const float *const nodes,
+                                const int   num_nodes,
+                                const float zone_width,
+                                constant const float *const node_saturation,
+                                const float L_white)
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+  if(x >= width || y >= height) return;
+
+  const float4 pix_in = read_imagef(in, sampleri, (int2)(x, y));
+  float4 XYZ_D65 = matrix_product_float4(fmax(0.0f, pix_in), matrix_in);
+  float4 xyY = dt_D65_XYZ_to_xyY(XYZ_D65);
+  float4 JCH = xyY_to_dt_UCS_JCH(xyY, L_white);
+
+  const float hue = (JCH.z + M_PI_F) / (2.0f * M_PI_F);
+
+  const int idx = y * width + x;
+  jch_out[idx] = (float4)(JCH.x, JCH.y, hue, pix_in.w);
+
+  int   winning_idx = 0;
+  float max_weight  = 0.0f;
+  const float hue_shift = get_weighted_hue_shift(hue, nodes, num_nodes, zone_width,
+                                                 &winning_idx, &max_weight);
+
+  const float sd = (node_saturation[winning_idx] - 1.0f) * max_weight;
+
+  p_out[idx] = (float2)(hue_shift, sd);
+}
+
+// Kernel 2: apply Gaussian-smoothed corrections using cached JCH to produce output.
+// Reads from the JCH cache written by the map kernel, avoiding a redundant
+// forward RGB → JCH conversion.
+kernel void colorharmonizer_apply(write_only image2d_t  out,
+                                  const int   width,
+                                  const int   height,
+                                  constant const float *const matrix_out,
+                                  global const float4 *jch_in,
+                                  global const float2 *corrections,
+                                  const float effect_strength,
+                                  const float protect_neutral,
+                                  const float L_white)
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+  if(x >= width || y >= height) return;
+
+  const int    k      = y * width + x;
+  const float4 cached = jch_in[k];
+  const float  J      = cached.x;
+  const float  chroma = cached.y;
+  const float  hue    = cached.z;
+
+  const float2 corr = corrections[k];
+
+  const float t             = protect_neutral;
+  const float cutoff        = t * t * t * 0.03f;
+  const float chroma_weight = chroma / (chroma + cutoff + 1.0e-5f);
+
+  float4 JCH;
+  JCH.x = J;
+  JCH.y = fmax(chroma * (1.0f + corr.y * chroma_weight), 0.0f);
+  JCH.z = wrap_hue(hue + corr.x * effect_strength * chroma_weight) * 2.0f * M_PI_F - M_PI_F;
+
+  float4 xyY = dt_UCS_JCH_to_xyY(JCH, L_white);
+  float4 XYZ_D65 = dt_xyY_to_XYZ(xyY);
+
+  float4 pix_out = matrix_product_float4(XYZ_D65, matrix_out);
+  pix_out.w = cached.w;
+  write_imagef(out, (int2)(x, y), pix_out);
+}

--- a/data/kernels/colorharmonizer.cl
+++ b/data/kernels/colorharmonizer.cl
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2024 darktable developers.
+    Copyright (C) 2026 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/data/kernels/programs.conf
+++ b/data/kernels/programs.conf
@@ -40,3 +40,4 @@ sigmoid.cl              36
 colorequal.cl           37
 capture.cl              38
 agx.cl                  39
+colorharmonizer.cl      40

--- a/dev-doc/iop/colorharmonizer/README.md
+++ b/dev-doc/iop/colorharmonizer/README.md
@@ -1,0 +1,378 @@
+# color harmonizer
+
+**Group:** color
+**Pipeline position:** linear RGB, scene-referred
+**Internal color space:** darktable UCS / JCH (perceptual)
+
+---
+
+## What it does
+
+The color harmonizer nudges hues — and optionally chroma — toward a selected color palette: a set
+of geometrically related hue angles called *harmony nodes*. The goal is to reduce chromatic discord
+in an image. Colors that are "off-palette" are gently pulled toward the nearest node; colors
+already on a node are left unchanged. A per-node saturation multiplier can additionally boost or
+reduce the colorfulness of colors near each node.
+
+---
+
+## Color science
+
+### Color space: darktable UCS JCH
+
+All processing happens in **JCH**, the polar form of the **darktable Uniform Color Space 2022**
+(Aurélien Pierre, 2022). darktable UCS was designed specifically for scene-referred color grading:
+it uses a perceptually uniform hue-linear UV* plane derived from CIE xyY chromaticity, without the
+CAM (Color Appearance Model) complexity or absolute-luminance dependence of HDR-targeted spaces. It
+is the same space used by the color balance RGB and color equalizer modules.
+
+| Channel | Symbol | Meaning |
+|---------|--------|---------|
+| Lightness | J | Normalized perceptual lightness (J = L* / L_white) |
+| Chroma | C | Colorfulness, perceptually weighted |
+| Hue | H | Hue angle in [-π, π] radians; stored as normalized [0, 1) |
+
+The pipeline for each pixel is:
+
+```
+linear RGB (D50)
+  → XYZ D50
+  → XYZ D65          (CAT16 chromatic adaptation)
+  → xyY              (CIE chromaticity + luminance)
+  → darktable UCS JCH (hue-linear UV* plane → polar JCH)
+  [H and C modified]
+  → xyY              (inverse)
+  → XYZ D65
+  → XYZ D50          (inverse chromatic adaptation)
+  → linear RGB (D50)
+```
+
+`J` (lightness) is never modified. `H` (hue) is always modified proportionally to angular
+distance from the nearest node. `C` (chroma) is modified only when per-node saturation values
+differ from 1.0.
+
+### Hue normalization
+
+Hue angles are stored as fractions of a full rotation ([0, 1] = [0°, 360°]). All angular
+arithmetic wraps correctly at the 0/1 boundary.
+
+### Gaussian hue attraction
+
+Each pixel is pulled toward its **nearest** harmony node. The strength of that pull is weighted
+by a Gaussian whose width is controlled by the pull width.
+
+```
+σ = pull_width × 0.5 / N                 (N = number of nodes)
+
+w_i       = exp(−d_i² / 2σ²)             (d_i = circular distance from h to node i)
+diff_i    = nodes[i] − h  (wrapped to [−0.5, 0.5])
+
+nearest   = argmax_i(w_i)
+hue_shift = w_nearest × diff_nearest
+```
+
+The shift is proportional to the **angular distance from the nearest node** scaled by the
+Gaussian weight. This means:
+
+- A pixel **exactly at a node** always produces zero shift (`diff_nearest = 0`), regardless of
+  pull width. This is the key correctness invariant: node-colored pixels are never displaced.
+- A pixel **far from all nodes** receives near-zero shift because `w_nearest ≈ 0`.
+- The Gaussian `w_nearest` acts as a **proximity gate**: at wide pull widths it stays near 1
+  across the entire hue circle so all pixels are attracted; at narrow widths it falls off quickly
+  so only hues close to a node are affected.
+
+Using the nearest-node's own difference (rather than a weighted average of all nodes' differences)
+avoids an artefact where opposing nodes — e.g. in a complementary pair — partially cancel each
+other and displace pixels that are already correctly positioned on one node toward the other.
+
+### Per-node saturation
+
+Each harmony node carries an independent saturation multiplier `s_i ∈ [0, 2]`. For each pixel,
+the saturation delta is derived from the winning (nearest) node:
+
+```
+sat_delta = (s_nearest − 1) × w_nearest
+```
+
+Applied to chroma:
+
+```
+C_new = C × (1 + sat_delta × chroma_weight)
+      ≈ C × s_nearest   (at the node, where w_nearest = 1 and chroma_weight ≈ 1)
+```
+
+At the node the result is exactly the configured saturation multiplier. Away from the node the
+effect tapers to zero via the same Gaussian `w_nearest`. At `s_i = 1.0` (default) the saturation
+channel is unaffected.
+
+### The applied shift
+
+```
+cutoff        = t³ · 0.03                         t = neutral_protection ∈ [0, 1]
+chroma_weight = C / (C + cutoff + ε)
+
+pull    = pull_strength × chroma_weight
+new_hue = h + hue_shift × pull
+        = h + (w_nearest × diff_nearest) × pull
+
+new_C   = C × (1 + sat_delta × chroma_weight)
+```
+
+The cutoff at `t = 1` is 0.03. Vivid colors in photographic images typically have C ≥ 0.3,
+giving them a chroma weight ≥ 0.91 — almost the full effect — even at maximum neutral protection.
+Only near-neutral colors (C < 0.03) are substantially shielded. The cubic exponent concentrates
+slider sensitivity in the upper half of the range, where pastel and muted tones are progressively
+included in the protected zone.
+
+### Two-pass processing
+
+To allow optional spatial smoothing of the correction field, processing is split into two passes:
+
+**Pass 1 — map:** For each pixel, compute `hue_delta` and `sat_delta` from the current pixel's
+hue and the harmony nodes. Store these in two per-pixel correction maps.
+
+**Blur (optional):** If spatial smoothing is enabled, both maps are Gaussian-blurred. This softens
+zone-boundary transitions visible in smooth spatial gradients (e.g. skies, skin). The blur sigma
+scales with both the smoothing slider and the pull width.
+
+**Pass 2 — apply:** For each pixel, re-read its hue and chroma from the input, look up the
+(possibly blurred) `hue_delta` and `sat_delta`, and apply the final correction.
+
+On GPU (OpenCL), the map and apply passes are separate kernels; the blur runs on the correction
+buffer between them.
+
+---
+
+## Harmony rules
+
+All node positions are offsets from the anchor hue. Angles are in degrees.
+
+| Rule | Nodes | Node positions | Character |
+|------|-------|----------------|-----------|
+| **Monochromatic** | 1 | 0° | Single hue family |
+| **Analogous** | 3 | 0°, −30°, +30° | Adjacent neighbors; naturalistic, cohesive |
+| **Analogous complementary** | 4 | 0°, −30°, +30°, +180° | Analogous triad plus its opposite |
+| **Complementary** | 2 | 0°, +180° | Direct opposites; maximum contrast |
+| **Split complementary** | 3 | 0°, +150°, +210° | Anchor plus both neighbors of its complement |
+| **Dyad** | 2 | −30°, +30° | Anchor is symmetry axis, not a node |
+| **Triad** | 3 | 0°, +120°, +240° | Evenly spaced; balanced, colorful |
+| **Tetrad** | 4 | −30°, +30°, +150°, +210° | Two dyad pairs; anchor is symmetry axis, not a node |
+| **Square** | 4 | 0°, +90°, +180°, +270° | Four equally spaced hues |
+| **Custom** | 2–4 | Freely placed | User-defined node positions |
+
+> **Note on dyad and tetrad:** the anchor hue sets the symmetry axis of the pattern, not the
+> position of a node. The palette is symmetric around the anchor. This matches the vectorscope
+> harmony guide overlay.
+
+---
+
+## Controls
+
+### Harmony rule
+
+#### Vectorscope two-way sync
+When enabled (default), any change to the harmony rule, anchor hue, or custom node positions is
+immediately reflected in the vectorscope harmony overlay, and changes made in the vectorscope are
+reflected back in the module. Disable to make adjustments without disturbing the vectorscope
+display.
+
+#### Import from vectorscope *(refresh icon, standard modes only)*
+Imports the harmony rule and anchor hue currently configured in the vectorscope panel, then
+switches the histogram panel to the vectorscope view.
+
+#### Rule selector
+Selects the geometric pattern of the target palette. When switching to *custom*, the current
+rule's node positions are copied as a starting point.
+
+#### Infer from image *(camera icon, standard modes only)*
+Analyses the preview image's chroma-weighted hue histogram and automatically selects the harmony
+rule and anchor hue that best fit the image's existing color distribution — i.e. the combination
+that already covers the most chromatic energy and therefore requires the least correction.
+
+The algorithm:
+1. Builds a 360-bin hue histogram weighted by chroma (achromatic pixels are ignored).
+2. Smooths it with three passes of a circular box filter to suppress noise.
+3. Scores all 9 × 360 = 3,240 (rule, anchor) combinations at 1° resolution by computing what
+   fraction of chromatic energy falls within the Gaussian attraction zones of each rule's nodes.
+4. Sets the rule and anchor hue to the combination with the highest coverage score.
+
+The result replaces the current rule and anchor. Use **pull strength** to control how strongly
+the remaining off-palette hues are then pulled toward the detected palette.
+
+#### Anchor hue
+The primary hue from which all node positions are derived (not shown in *custom* mode). Expressed
+as a normalized value displayed in degrees. An eyedropper is available to sample a color directly
+from the image.
+
+The color swatch strip below the slider shows the actual node colors for quick visual feedback.
+
+#### Active nodes *(custom mode only)*
+Number of active harmony nodes in custom mode (2–4). Only the first N node rows are shown and
+active; the others are hidden.
+
+#### Node hue sliders *(custom mode only)*
+One row per active node. Each row shows a color swatch and a hue slider with an eyedropper. The
+hue slider sets the node position on the hue wheel (0°–360°). Use the eyedropper to sample a
+desired hue directly from the image.
+
+---
+
+### Effect controls
+
+#### Pull strength
+Global scale on the hue pull. At 0 nothing changes. At 1 the Gaussian proximity weight is the
+only limit on how far each pixel moves. A pixel exactly on a node shifts by 0; a pixel at the
+midpoint between two nodes is shifted by the Gaussian weight at that distance multiplied by its
+angular gap to the nearest node.
+
+Note: pull strength scales the **hue** correction only. The saturation correction (per-node
+saturation multipliers) is applied independently, at full strength regardless of this slider.
+
+#### Pull width
+Scales the standard deviation σ of each node's Gaussian attraction zone. Range: 0.25–4.0.
+
+- **< 1 (narrow):** the Gaussian decays quickly with distance; only hues very close to a node
+  are attracted. The rest of the hue wheel is barely touched. Useful for images already close to
+  harmonic, or when precise, surgical correction of specific hues is needed.
+- **= 1 (default):** the Gaussian tapers to roughly 14 % at the midpoint between adjacent nodes —
+  clean zone separation with smooth transitions.
+- **> 1 (wide):** the Gaussian stays high across most of the hue circle; all pixels are
+  attracted noticeably regardless of how far they are from a node. Useful for strongly discordant
+  images or a painterly look.
+
+Increasing pull width never displaces pixels that are already exactly on a harmony node — their
+angular distance to the nearest node is zero, so their hue shift is always zero.
+
+#### Neutral color protection
+Shields low-chroma pixels from correction. The weight for each pixel is:
+
+```
+chroma_weight = C / (C + t³ · 0.03)
+```
+
+At C = 0 the weight is always zero regardless of the slider: fully achromatic pixels (pure
+grays) are never touched. As C grows, the weight approaches 1. The slider sets how aggressively
+low-chroma pixels are exempted: low values protect only near-absolute grays; high values extend
+protection to muted and pastel tones. Even at the maximum, vivid colors remain largely unaffected.
+
+Default: 0.50.
+
+#### Smoothing
+Applies a Gaussian blur to the correction maps (hue delta and saturation delta) before they are
+applied to the image. This smooths the spatial transitions at zone boundaries — visible as subtle
+colour steps in smooth gradients like skies or skin when adjacent regions fall in different
+attraction zones.
+
+The blur sigma scales with both this slider and the current pull width: wider attraction zones
+span larger hue ranges and generate larger corrections, which can produce sharper spatial
+boundaries when pixels near each other fall on opposite sides of a zone midpoint.
+
+- **0 (default, off):** transitions are handled purely by the Gaussian interpolation in hue space.
+  Maximum detail is preserved. Recommended for most uses.
+- **0.1–0.5:** subtle spatial averaging to reduce colour noise in smooth areas.
+- **> 1.0:** broad spatial blending; can create a painterly effect but may bleed corrections
+  across image edges.
+
+---
+
+### Saturation section *(collapsible)*
+
+One row per active harmony node. Each row shows a color swatch (the node's hue) and a saturation
+multiplier slider.
+
+#### Node saturation sliders
+Saturation multiplier for colors near the corresponding harmony node.
+
+- **100 % (default):** chroma is unchanged.
+- **< 100 %:** desaturates colors near this node, proportionally to their Gaussian proximity.
+- **> 100 %:** boosts chroma near this node.
+
+The effect is weighted by the pixel's Gaussian proximity to the node (`w_nearest`) and further
+modulated by **neutral color protection** so near-achromatic pixels are spared. At the node itself
+(maximum weight) the chroma is multiplied by exactly the slider value.
+
+---
+
+## Usage guide
+
+### Basic workflow
+
+1. **Set the anchor hue.** Use the eyedropper to pick the dominant or most important color in
+   the scene — a sky, a garment, a skin tone — or drag the slider manually while watching the
+   swatch strip.
+
+2. **Choose a harmony rule.** For portraiture, *complementary* (subject vs. background) or
+   *analogous* (warm tones) are natural starting points. For landscapes, *triad* or *split
+   complementary* often work well. Enable *vectorscope two-way sync* (under the harmony rule
+   heading) to see the palette on the vectorscope while you choose.
+
+3. **Raise pull strength slowly.** Start around 0.2–0.3. The effect is graduated; values
+   above 0.6 are rarely needed for a convincing result.
+
+4. **Adjust pull width if needed.** If many off-palette hues are not moving enough, widen the
+   zones. If you want to correct only specific hue ranges without touching the rest, narrow them.
+
+5. **Use neutral color protection to taste.** Raise it for images with many desaturated tones
+   (architecture, faded film looks) to exempt pastels and muted tones from correction.
+
+6. **Use the saturation section for palette polishing.** Once the hue pull is set, open the
+   Saturation section to boost or calm chroma per node — e.g. boost the warm nodes and desaturate
+   the cool ones for a cinematic split-tone look.
+
+### Custom harmony mode
+
+Use *custom* when none of the geometric rules match the image's intended palette.
+
+1. Set the harmony rule to *custom*. The previous rule's node positions are copied as a starting
+   point.
+2. Use *active nodes* to select how many palette targets you need (2–4).
+3. Drag each node's hue slider or use its eyedropper to position nodes at the desired palette
+   hues.
+4. Raise pull strength to pull off-palette colors toward the custom nodes.
+
+Custom nodes are synced to the vectorscope as free-floating angle markers (the vectorscope shows
+no standard rule name for custom palettes).
+
+### Working with the vectorscope
+
+With *vectorscope two-way sync* enabled, the vectorscope overlays the harmony guide on the
+image's color distribution. Colors inside the guide arcs are on-palette; colors outside are
+being corrected. Use this to verify the pull is moving in the intended direction.
+
+To start from a palette already set in the vectorscope panel, click the *import from vectorscope*
+button (refresh icon, next to the sync checkbox).
+
+### Interaction with blending
+
+The module supports parametric and drawn masking. Common uses:
+
+- Apply harmonization only to the background by masking out the subject.
+- Use a luminance mask to restrict corrections to midtones.
+- Reduce opacity as a global intensity control on top of pull strength.
+
+### Typical parameter ranges
+
+| Goal | Pull strength | Pull width | Neutral color protection |
+|------|--------------|------------|-------------------------|
+| Subtle finishing touch | 0.1–0.25 | 1.0–1.5 | 0.2–0.4 |
+| Moderate creative grade | 0.3–0.5 | 1.5–2.5 | 0.2–0.5 |
+| Aggressive stylization | 0.5–0.9 | 2.5–4.0 | 0.0–0.3 |
+| Fix specific off-hues only | 0.4–0.8 | 0.25–0.7 | 0.2 |
+
+---
+
+## Technical notes
+
+- Lightness (`J`) is **never modified**. All radiometric accuracy is preserved.
+- Hue correction is zero for any pixel whose hue already matches a harmony node, regardless of
+  pull width or pull strength. This is a mathematical guarantee, not a threshold: the angular
+  distance to the nearest node is zero, so the shift is zero.
+- Chroma is modified only when at least one node has its saturation slider set away from 100 %.
+  With all nodes at 100 %, the saturation channel passes through unchanged.
+- OpenCL acceleration is supported; the GPU path is numerically equivalent to the CPU path.
+- Hue is undefined for fully achromatic pixels (C = 0). These pixels are unaffected by design:
+  the chroma weight drives to zero regardless of other settings.
+- darktable UCS is designed for scene-referred normalized data and does not depend on absolute
+  luminance, making it naturally suited to darktable's pipeline. Its hue axis was explicitly
+  constructed to be perceptually linear (equal angular steps correspond to equal perceived hue
+  differences), which is the key property exploited here.

--- a/dev-doc/iop/colorharmonizer/business_logic.md
+++ b/dev-doc/iop/colorharmonizer/business_logic.md
@@ -1,0 +1,843 @@
+# Color Harmonizer — Business Logic & Implementation Guide
+
+This document breaks down the math, design decisions, and code paths of the
+`colorharmonizer` IOP module. Each processing step is shown for both the CPU
+(`process()`) and OpenCL (`process_cl()` / `.cl` kernels) implementations, with
+rationale for the choices made.
+
+---
+
+## Table of Contents
+
+1. [Overview](#1-overview)
+2. [Color Spaces & Why UCS JCH](#2-color-spaces--why-ucs-jch)
+3. [Harmony Geometry](#3-harmony-geometry)
+4. [RYB ↔ UCS Hue Conversion](#4-ryb--ucs-hue-conversion)
+5. [Node Precomputation (`commit_params`)](#5-node-precomputation-commit_params)
+6. [Gaussian-Weighted Hue Shift](#6-gaussian-weighted-hue-shift)
+7. [Neutral Color Protection](#7-neutral-color-protection)
+8. [Per-Node Saturation Control](#8-per-node-saturation-control)
+9. [Processing Pipeline — CPU](#9-processing-pipeline--cpu)
+10. [Processing Pipeline — OpenCL](#10-processing-pipeline--opencl)
+11. [CPU vs OpenCL: Key Differences](#11-cpu-vs-opencl-key-differences)
+12. [Spatial Smoothing](#12-spatial-smoothing)
+13. [Auto-Detection Algorithm](#13-auto-detection-algorithm)
+14. [File & Line Reference](#14-file--line-reference)
+
+---
+
+## 1. Overview
+
+The Color Harmonizer shifts pixel hues toward a set of "harmony nodes" —
+canonical hue positions defined by classic color theory (complementary, triadic,
+etc.). The correction is:
+
+- **Perceptual**: operates in darktable UCS JCH, a uniform color space where
+  equal angular steps correspond to equal perceived hue differences.
+- **Smooth**: uses Gaussian weighting so pixels near a node are strongly
+  attracted, pixels between nodes are gently nudged, and pixels far from all
+  nodes are barely touched.
+- **Chroma-aware**: desaturated (near-gray) pixels are protected from hue
+  shifts via a tunable neutral-protection curve.
+
+The module supports both CPU (OpenMP-parallelized) and GPU (OpenCL) execution
+with identical visual results.
+
+---
+
+## 2. Color Spaces & Why UCS JCH
+
+### The problem with operating in RGB or HSL
+
+Hue in RGB-derived spaces (HSL, HSV) is non-uniform: a 30° rotation near
+orange produces a much larger perceived change than 30° near blue. Shifting
+hues in these spaces would produce uneven, artifact-prone corrections.
+
+### darktable UCS JCH
+
+The module converts every pixel to darktable's **Uniform Color Space** JCH
+model:
+
+| Component | Meaning | Range |
+|-----------|---------|-------|
+| **J** | Lightness (perceptual) | 0 → ~1 |
+| **C** | Chroma (colorfulness) | 0 → ~2 |
+| **H** | Hue angle (radians) | −π → +π |
+
+In this space, equal angular distances produce roughly equal perceived hue
+differences, making Gaussian weighting behave predictably.
+
+### Forward conversion chain (RGB → JCH)
+
+```
+Pipeline RGB (linear, scene-referred)
+  → XYZ (D50)           [3×3 matrix multiply via work profile]
+  → XYZ (D65)           [chromatic adaptation, CAT16]
+  → xyY                 [dt_D65_XYZ_to_xyY]
+  → dt_UCS JCH          [xyY_to_dt_UCS_JCH, requires L_white]
+```
+
+**CPU** — single call wrapping the entire chain:
+```c
+// colorharmonizer.c:460
+dt_ioppr_rgb_matrix_to_dt_UCS_JCH(px_rgb, px_JCH,
+    work_profile->matrix_in_transposed, L_white);
+```
+
+**OpenCL** — equivalent steps inline in the map kernel:
+```c
+// colorharmonizer.cl:98-100
+float4 XYZ_D65 = matrix_product_float4(fmax(0.0f, pix_in), matrix_in);
+float4 xyY     = dt_D65_XYZ_to_xyY(XYZ_D65);
+float4 JCH     = xyY_to_dt_UCS_JCH(xyY, L_white);
+```
+
+**Why the difference?** The CPU helper `dt_ioppr_rgb_matrix_to_dt_UCS_JCH`
+bundles the matrix multiply and adaptation into one function using the
+transposed work-profile matrix. On the GPU, the matrix is pre-multiplied with
+`XYZ_D50_to_D65_CAT16` on the host before upload, so the kernel does a single
+matrix multiply directly to D65 XYZ — avoiding an extra per-pixel adaptation
+step on the GPU.
+
+### Inverse conversion chain (JCH → RGB)
+
+```
+dt_UCS JCH
+  → xyY                 [dt_UCS_JCH_to_xyY]
+  → XYZ (D65)           [dt_xyY_to_XYZ]
+  → XYZ (D50)           [XYZ_D65_to_D50, CPU only — GPU folds into matrix]
+  → Pipeline RGB         [3×3 matrix multiply via work profile]
+```
+
+**CPU:**
+```c
+// colorharmonizer.c:477-482
+dt_UCS_JCH_to_xyY(px_JCH, L_white, px_xyY);
+dt_xyY_to_XYZ(px_xyY, px_xyz_d65);
+XYZ_D65_to_D50(px_xyz_d65, px_xyz);
+dt_apply_transposed_color_matrix(px_xyz,
+    work_profile->matrix_out_transposed, px_rgb_out);
+```
+
+**OpenCL:**
+```c
+// colorharmonizer.cl:151-154
+float4 xyY     = dt_UCS_JCH_to_xyY(JCH, L_white);
+float4 XYZ_D65 = dt_xyY_to_XYZ(xyY);
+float4 pix_out = matrix_product_float4(XYZ_D65, matrix_out);
+```
+
+The GPU `matrix_out` is pre-multiplied as
+`work_profile->matrix_out × XYZ_D65_to_D50_CAT16` on the host, collapsing two
+steps into one matrix multiply.
+
+### `L_white` — a constant, not a per-pixel value
+
+```c
+const float L_white = Y_to_dt_UCS_L_star(1.0f);
+```
+
+This converts Y=1 (the scene-referred white luminance) to the UCS lightness
+scale. It's the same for every pixel in a given pipeline run. The CPU computes
+it once before the pixel loop; the GPU receives it as a kernel argument —
+avoiding a redundant transcendental (`powf`) per pixel.
+
+### Normalized hue
+
+The module normalizes the JCH hue angle from [−π, +π] to [0, 1) for all
+internal arithmetic:
+
+```c
+const float hue = (JCH.z + M_PI_F) / (2.0f * M_PI_F);
+```
+
+This simplifies circular-distance calculations and makes the harmony node
+positions directly comparable. The inverse (back to radians) is applied just
+before the JCH→RGB conversion:
+
+```c
+JCH.z = new_hue * 2.0f * M_PI_F - M_PI_F;
+```
+
+---
+
+## 3. Harmony Geometry
+
+### The geometry table
+
+All predefined rules are defined in a single authoritative table in
+`color_harmony.h:83`, shared with the vectorscope overlay:
+
+```c
+static const struct { int n; float offsets[4]; } table[] = {
+  [MONOCHROMATIC]           = { 1, {  0/12  } },
+  [ANALOGOUS]               = { 3, { -1/12,  0/12, +1/12 } },
+  [ANALOGOUS_COMPLEMENTARY] = { 4, { -1/12,  0/12, +1/12, +6/12 } },
+  [COMPLEMENTARY]           = { 2, {  0/12, +6/12 } },
+  [SPLIT_COMPLEMENTARY]     = { 3, {  0/12, +5/12, +7/12 } },
+  [DYAD]                    = { 2, { -1/12, +1/12 } },
+  [TRIAD]                   = { 3, {  0/12, +4/12, +8/12 } },
+  [TETRAD]                  = { 4, { -1/12, +1/12, +5/12, +7/12 } },
+  [SQUARE]                  = { 4, {  0/12, +3/12, +6/12, +9/12 } },
+};
+```
+
+Each offset is a fraction of a full turn. 1/12 = 30° in the RYB color wheel
+(the same 12-sector wheel used in traditional color theory). The anchor
+rotation is added and the result wrapped to [0, 1).
+
+**Why a single table?** Keeping the geometry in one place guarantees that the
+guide lines drawn on the vectorscope exactly match the node positions used for
+processing. A dual definition would risk subtle angular mismatches.
+
+### Custom mode
+
+When `rule == CUSTOM`, the user provides up to 4 arbitrary hue positions
+directly in UCS space. These bypass the geometry table entirely — the
+`custom_hue[]` array is used as-is.
+
+---
+
+## 4. RYB ↔ UCS Hue Conversion
+
+### The problem
+
+The harmony geometry is defined in **RYB** (Red-Yellow-Blue) hue space — the
+traditional artist's color wheel. But processing happens in **UCS** hue space.
+These two spaces have a nonlinear relationship: RYB stretches the warm hues
+(yellow through red) and compresses the cool hues (blue through green) relative
+to UCS.
+
+### The Gossett piecewise-linear model
+
+The RYB mapping is based on the Gossett paint-mixing model. Six control points
+map evenly-spaced RGB hue knots to RYB hue values:
+
+```c
+// color_ryb.h:37-41
+static const float dt_color_ryb_x_vtx[7] = { 0, 1/6, 2/6, 3/6, 4/6, 5/6, 1 };  // RGB hue
+static const float dt_color_ryb_y_vtx[7] = { 0, 1/3, 0.472, 0.611, 0.715, 5/6, 1 };  // RYB hue
+```
+
+The path from UCS hue to RYB hue is indirect:
+
+```
+UCS hue → gamut-clipped sRGB → linearize → RGB HSV hue → piecewise-linear → RYB hue
+```
+
+This chain involves transcendentals (gamma, trig) and is too expensive to run
+per-pixel. The solution is a **pair of lookup tables**.
+
+### Precomputed LUTs
+
+Built once in `init_global()` via `_build_hue_luts()`:
+
+```c
+// colorharmonizer.c:641-656 (simplified)
+// Forward: UCS → RYB (720 entries = 0.5° resolution)
+for(int i = 0; i < 720; i++)
+  s_ucs_to_ryb_lut[i] = _ucs_hue_to_ryb_hue(i / 720.0f);
+
+// Inverse: RYB → UCS (nearest-neighbor search of the forward table)
+for(int j = 0; j < 720; j++) {
+  float target = j / 720.0f;
+  // find the forward-table entry closest to target
+  s_ryb_to_ucs_lut[j] = best_matching_ucs;
+}
+```
+
+**Why nearest-neighbor for the inverse?** The forward map (UCS→RYB) is
+monotonic but non-analytic (it goes through sRGB gamma and HSV extraction).
+Inverting it analytically is impractical. The brute-force O(n²) scan is cheap
+since it runs exactly once at application startup (720 × 720 = ~518k
+comparisons, sub-millisecond on any modern CPU). The resulting table accuracy
+(0.5° max error) is more than sufficient for positioning harmony nodes.
+
+### O(1) lookup with linear interpolation
+
+```c
+// colorharmonizer.c:621-626
+static inline float _ucs_to_ryb_fast(float ucs) {
+  const float pos = ucs * 720;
+  const int   i0  = (int)pos % 720;
+  const int   i1  = (i0 + 1) % 720;
+  return _hue_lerp(s_ucs_to_ryb_lut[i0], s_ucs_to_ryb_lut[i1], pos - (int)pos);
+}
+```
+
+`_hue_lerp` handles circular wraparound (e.g. interpolating between 0.95 and
+0.05 across the 0/1 boundary):
+
+```c
+static inline float _hue_lerp(float a, float b, float t) {
+  if(b - a >  0.5f) b -= 1.0f;
+  else if(a - b >  0.5f) a -= 1.0f;
+  float r = a + t * (b - a);
+  if(r < 0.0f) r += 1.0f;
+  return r;
+}
+```
+
+---
+
+## 5. Node Precomputation (`commit_params`)
+
+Harmony nodes are computed once per pipeline run, not per pixel:
+
+```c
+// colorharmonizer.c:366-376
+void commit_params(...) {
+  d->params = *p;
+  get_harmony_nodes(p->rule, p->anchor_hue, p->custom_hue,
+                    p->num_custom_nodes, d->nodes, &d->num_nodes);
+}
+```
+
+`get_harmony_nodes()` for predefined rules:
+
+```c
+// colorharmonizer.c:342-365
+// 1. Convert UCS anchor hue → RYB rotation (integer degrees)
+const int rotation = (int)roundf(_ucs_to_ryb_fast(anchor_hue) * 360.0f) % 360;
+
+// 2. Query the geometry table for absolute RYB node positions
+dt_color_harmony_get_sector_angles(rule + 1, rotation, node_angles, &num_nodes);
+
+// 3. Convert each RYB node back to UCS for processing
+for(int i = 0; i < *num_nodes; i++)
+  nodes[i] = _ryb_to_ucs_fast(node_angles[i]);
+```
+
+**Why convert twice (UCS → RYB → UCS)?** The geometry table defines angular
+relationships in RYB space (30° analogous, 180° complementary, etc.) because
+that matches the traditional artist's color wheel used in the vectorscope
+overlay. The user's anchor hue is stored in UCS, so we must convert to RYB to
+apply the geometry offsets, then back to UCS for processing. This round-trip
+ensures the processing nodes are exactly aligned with the vectorscope guide
+lines.
+
+---
+
+## 6. Gaussian-Weighted Hue Shift
+
+This is the core algorithm — it determines how much each pixel's hue is pulled
+toward the nearest harmony node.
+
+### Math
+
+For a pixel with hue `h` and `N` harmony nodes at positions `nᵢ`:
+
+1. **Gaussian sigma** scales with the zone width parameter and inversely with
+   node count:
+
+   ```
+   σ = pull_width × 0.5 / N
+   ```
+
+   More nodes = tighter zones per node (they must share the circle).
+
+2. **For each node** `nᵢ`, compute:
+   - Circular distance: `dᵢ = min(|h − nᵢ|, 1 − |h − nᵢ|)`
+   - Gaussian weight: `wᵢ = exp(−dᵢ² / 2σ²)`
+   - Signed angular difference: `Δᵢ = nᵢ − h` (wrapped to [−0.5, +0.5])
+
+3. **Winner-take-all**: select the node with the highest weight:
+
+   ```
+   hue_shift = Δ_winner × w_winner
+   ```
+
+### Key properties
+
+| Pixel position | `Δ_winner` | `w_winner` | Shift |
+|---|---|---|---|
+| Exactly at a node | 0 | 1.0 | **0** (no change needed) |
+| Near a node | small | ~1.0 | small pull toward node |
+| Between two nodes | moderate | moderate | moderate pull |
+| Far from all nodes | large | ~0 | **~0** (too far to reach) |
+
+The product `Δ × w` naturally produces zero shift at both extremes and a smooth
+bell-shaped correction in between.
+
+### Code — CPU
+
+```c
+// colorharmonizer.c:284-326
+static inline float get_weighted_hue_shift(
+    float px_hue, const float *nodes, int num_nodes,
+    float pull_width_factor,
+    int *out_winning_idx, float *out_max_weight)
+{
+  const float sigma      = pull_width_factor * 0.5f / (float)num_nodes;
+  const float inv_2sigma2 = 1.0f / (2.0f * sigma * sigma);
+
+  float max_w = 0.0f, diff_winning = 0.0f;
+  int   winning_idx = 0;
+
+  for(int i = 0; i < num_nodes; i++)
+  {
+    float d = fabsf(px_hue - nodes[i]);
+    if(d > 0.5f) d = 1.0f - d;            // circular distance
+
+    const float w = expf(-d * d * inv_2sigma2);
+    float diff = nodes[i] - px_hue;        // signed difference
+    if(diff > 0.5f)       diff -= 1.0f;    // wrap to (-0.5, +0.5]
+    else if(diff < -0.5f) diff += 1.0f;
+
+    if(w > max_w) {
+      max_w = w;  winning_idx = i;  diff_winning = diff;
+    }
+  }
+
+  *out_winning_idx = winning_idx;
+  *out_max_weight  = max_w;
+  return diff_winning * max_w;
+}
+```
+
+### Code — OpenCL
+
+```c
+// colorharmonizer.cl:35-78
+// Identical algorithm, adapted to OpenCL syntax (fabs → fabs, expf → exp,
+// output via pointer args, 'constant' address space for the node array).
+static inline float get_weighted_hue_shift(
+    const float px_hue,
+    constant const float *const nodes,
+    const int num_nodes,
+    const float zone_width_factor,
+    int *out_winning_idx,
+    float *out_max_weight)
+{
+  // ... same loop body, using exp() instead of expf() ...
+}
+```
+
+**Why winner-take-all instead of weighted average?** A weighted average of all
+nodes would pull every pixel toward the center of mass of the node set — losing
+the distinct palette identity. Winner-take-all preserves the nearest node's
+character and avoids averaging hues across the wheel (e.g. averaging red and
+cyan would produce gray, not a useful correction).
+
+---
+
+## 7. Neutral Color Protection
+
+Desaturated colors (grays, muted tones, skin highlights) should not be hue-
+shifted — they have no meaningful hue, and shifting them introduces color casts
+on near-neutral surfaces.
+
+### Math
+
+```
+cutoff = neutral_protection³ × 0.03
+chroma_weight = chroma / (chroma + cutoff + ε)
+```
+
+This is a **smooth hyperbolic ramp** from 0 (fully protected) to 1 (fully
+corrected):
+
+| `neutral_protection` | `cutoff` | Effect |
+|---|---|---|
+| 0.0 | 0 | No protection — all pixels shifted equally |
+| 0.5 | 0.00375 | Pastels partially protected |
+| 1.0 | 0.03 | Only vivid colors corrected |
+
+The **cubic mapping** (`t³ × 0.03`) distributes the slider's perceptual
+response evenly across its range. A linear mapping would concentrate most of
+the visible change in the first 20% of slider travel.
+
+### Why `ε = 1e-5`?
+
+Prevents division by zero when `chroma = 0` and `cutoff = 0` (i.e.,
+`neutral_protection = 0`). Without it, 0/0 would produce NaN.
+
+### Code — CPU
+
+```c
+// colorharmonizer.c:442-443 (before pixel loop)
+const float cutoff = np_t * np_t * np_t * 0.03f;
+
+// colorharmonizer.c:471 (inside pixel loop, fused path)
+const float chroma_weight = chroma / (chroma + cutoff + 1e-5f);
+```
+
+### Code — OpenCL
+
+```c
+// colorharmonizer.cl:136-138
+const float t             = protect_neutral;
+const float cutoff        = t * t * t * 0.03f;
+const float chroma_weight = chroma / (chroma + cutoff + 1.0e-5f);
+```
+
+Both hue shift and saturation correction are then scaled by `chroma_weight`:
+
+```c
+new_hue    = wrap_hue(hue + hue_shift × pull_strength × chroma_weight)
+new_chroma = max(chroma × (1 + sat_delta × chroma_weight), 0)
+```
+
+---
+
+## 8. Per-Node Saturation Control
+
+Each harmony node has an independent saturation multiplier (`node_saturation[i]`,
+range 0–2, default 1.0).
+
+### Math
+
+```
+sat_delta = (node_saturation[winning_idx] − 1.0) × max_weight
+new_chroma = chroma × (1 + sat_delta × chroma_weight)
+```
+
+- `node_saturation = 1.0` → `sat_delta = 0` → no change
+- `node_saturation = 0.5` → desaturate by up to 50%
+- `node_saturation = 1.5` → boost by up to 50%
+
+The `max_weight` factor ensures the saturation change is strongest for pixels
+close to that node and tapers off for distant pixels — same Gaussian falloff as
+the hue shift.
+
+---
+
+## 9. Processing Pipeline — CPU
+
+`process()` at `colorharmonizer.c:417-574`.
+
+### Path A: No Smoothing (`smoothing ≤ 0`) — Fused Single Pass
+
+This is the default and most interactive-responsive path.
+
+```
+For each pixel (OpenMP parallelized):
+  ┌─ Forward: RGB → JCH (1 matrix mul + nonlinear transforms)
+  │  Extract normalized hue and chroma
+  │
+  ├─ Compute: hue_shift = get_weighted_hue_shift(...)
+  │  Compute: sat_delta = (node_saturation[winner] − 1) × max_weight
+  │
+  ├─ Apply neutral protection: chroma_weight = chroma / (chroma + cutoff + ε)
+  │  Update: JCH.hue    = wrap_hue(hue + shift × strength × chroma_weight)
+  │  Update: JCH.chroma = max(chroma × (1 + sat_delta × chroma_weight), 0)
+  │
+  └─ Inverse: JCH → RGB (nonlinear transforms + 1 matrix mul)
+      Copy alpha from input
+```
+
+**Why fuse?** When smoothing is off, there is no spatial dependency between
+pixels — each pixel's correction depends only on its own hue. Fusing the
+forward conversion, correction, and inverse conversion into a single pass
+eliminates the need for intermediate buffers and halves memory traffic (read
+input once, write output once).
+
+### Path B: With Smoothing (`smoothing > 0`) — Two-Pass with JCH Cache
+
+When smoothing is enabled, the correction field must be spatially blurred before
+application. This requires two passes because blurring is a neighborhood
+operation that reads neighboring pixels' corrections.
+
+**Pass 1** — Forward conversion + correction computation:
+```
+Allocate:
+  jch_cache[3 × npx]    — stores J, chroma, normalized hue per pixel
+  corrections[2 × npx]  — stores hue_shift, sat_delta per pixel
+
+For each pixel (OpenMP):
+  Forward: RGB → JCH
+  Cache: jch_cache[k] = {J, chroma, hue}
+  Compute and cache: corrections[k] = {hue_shift, sat_delta}
+```
+
+**Spatial blur:**
+```c
+// colorharmonizer.c:533-535
+const float sigma = smoothing × max(1.5, 8.0 × scale_ratio) × max(1.0, pull_width);
+dt_gaussian_mean_blur(corrections, width, height, 2, sigma);
+```
+
+**Pass 2** — Apply blurred corrections from cache:
+```
+For each pixel (OpenMP):
+  Read cached J, chroma, hue
+  Read blurred hue_shift, sat_delta
+  Apply neutral protection and update JCH (same formulas)
+  Inverse: JCH → RGB
+```
+
+**Why cache JCH instead of re-converting from RGB?** The forward conversion
+(RGB → JCH) involves a matrix multiply, chromatic adaptation, and several
+nonlinear transforms (power functions, trig). It costs roughly 60% of the per-
+pixel budget. Re-doing it in Pass 2 would nearly double the total cost. Caching
+3 floats per pixel (J, chroma, hue) is cheap compared to the compute saved.
+
+**Why blur corrections instead of JCH directly?** Hue is circular — a Gaussian
+blur of hue values would produce nonsensical averages near the 0/1 wrap point
+(e.g., averaging 0.95 and 0.05 gives 0.50, which is completely wrong). The
+correction field (hue_shift, sat_delta) is a small signed displacement that is
+safe to average spatially.
+
+---
+
+## 10. Processing Pipeline — OpenCL
+
+`process_cl()` at `colorharmonizer.c:680-786`.
+
+The OpenCL path always uses the two-kernel architecture (even when smoothing is
+off) because kernel fusion would require a third kernel variant, adding
+maintenance burden for a marginal GPU gain.
+
+### Host setup
+
+```c
+// colorharmonizer.c:703-704
+// Pre-multiply matrices to fold CAT16 adaptation into the matrix multiply:
+dt_colormatrix_mul(input_matrix,  XYZ_D50_to_D65_CAT16, work_profile->matrix_in);
+dt_colormatrix_mul(output_matrix, work_profile->matrix_out, XYZ_D65_to_D50_CAT16);
+
+// Precompute L_white on host (constant for all pixels):
+const float L_white = Y_to_dt_UCS_L_star(1.0f);
+
+// Allocate GPU buffers:
+cl_mem corrections_cl;  // float2 per pixel: {hue_shift, sat_delta}
+cl_mem jch_cl;          // float4 per pixel: {J, chroma, hue, alpha}
+```
+
+**Why pre-multiply the matrices?** On the GPU, every instruction counts. By
+folding the D50↔D65 chromatic adaptation into the RGB↔XYZ matrix on the host,
+we save one 3×3 matrix-vector multiply per pixel in each kernel (two total).
+The host-side matrix multiply is negligible (3×3, done once).
+
+**Why cache alpha in the JCH buffer's `.w`?** The apply kernel does not have
+access to the input image texture (it was removed as an optimization — one
+fewer texture read per pixel). Alpha must travel from the map kernel to the
+apply kernel somehow, and it fits neatly in the unused 4th component of the
+float4 JCH cache.
+
+### Kernel 1: `colorharmonizer_map`
+
+```c
+// colorharmonizer.cl:81-118
+kernel void colorharmonizer_map(
+    read_only image2d_t in, global float2 *p_out,
+    global float4 *jch_out, const int width, const int height,
+    constant const float *matrix_in, constant const float *nodes,
+    const int num_nodes, const float zone_width,
+    constant const float *node_saturation, const float L_white)
+{
+  // Bounds check
+  if(x >= width || y >= height) return;
+
+  // Forward: read texel → matrix multiply → XYZ(D65) → xyY → JCH
+  const float4 pix_in  = read_imagef(in, sampleri, (int2)(x, y));
+  float4 XYZ_D65 = matrix_product_float4(fmax(0.0f, pix_in), matrix_in);
+  float4 xyY     = dt_D65_XYZ_to_xyY(XYZ_D65);
+  float4 JCH     = xyY_to_dt_UCS_JCH(xyY, L_white);
+
+  const float hue = (JCH.z + M_PI_F) / (2.0f * M_PI_F);
+
+  // Cache JCH + alpha for the apply kernel
+  jch_out[idx] = (float4)(JCH.x, JCH.y, hue, pix_in.w);
+
+  // Compute corrections
+  int winning_idx;  float max_weight;
+  float hue_shift = get_weighted_hue_shift(hue, nodes, num_nodes,
+                                            zone_width, &winning_idx, &max_weight);
+  float sd = (node_saturation[winning_idx] - 1.0f) * max_weight;
+
+  p_out[idx] = (float2)(hue_shift, sd);
+}
+```
+
+### Optional: Spatial blur (host-side)
+
+```c
+// colorharmonizer.c:748-752
+if(p->smoothing > 0.0f) {
+  const float sigma = p->smoothing * fmaxf(1.5f, 8.0f * roi_in->scale / piece->iscale)
+                      * fmaxf(1.0f, p->pull_width);
+  dt_gaussian_mean_blur_cl(devid, corrections_cl, width, height, 2, sigma);
+}
+```
+
+When smoothing is zero, the corrections buffer passes through unmodified.
+
+### Kernel 2: `colorharmonizer_apply`
+
+```c
+// colorharmonizer.cl:120-157
+kernel void colorharmonizer_apply(
+    write_only image2d_t out, const int width, const int height,
+    constant const float *matrix_out,
+    global const float4 *jch_in, global const float2 *corrections,
+    const float effect_strength, const float protect_neutral,
+    const float L_white)
+{
+  if(x >= width || y >= height) return;
+
+  // Read cached JCH and corrections
+  const float4 cached = jch_in[k];
+  const float2 corr   = corrections[k];
+
+  // Neutral protection
+  const float cutoff        = protect_neutral³ × 0.03f;
+  const float chroma_weight = cached.y / (cached.y + cutoff + 1e-5f);
+
+  // Apply corrections
+  float4 JCH;
+  JCH.x = cached.x;                                                     // J unchanged
+  JCH.y = fmax(cached.y * (1 + corr.y * chroma_weight), 0);             // saturation
+  JCH.z = wrap_hue(cached.z + corr.x * effect_strength * chroma_weight)
+          * 2π − π;                                                      // hue → radians
+
+  // Inverse: JCH → xyY → XYZ(D65) → RGB (via pre-multiplied matrix)
+  float4 xyY     = dt_UCS_JCH_to_xyY(JCH, L_white);
+  float4 XYZ_D65 = dt_xyY_to_XYZ(xyY);
+  float4 pix_out = matrix_product_float4(XYZ_D65, matrix_out);
+  pix_out.w      = cached.w;   // restore alpha from cache
+  write_imagef(out, (int2)(x, y), pix_out);
+}
+```
+
+---
+
+## 11. CPU vs OpenCL: Key Differences
+
+| Aspect | CPU | OpenCL |
+|---|---|---|
+| **smoothing=0 path** | Fused single pass (no buffers) | Always two kernels (map+apply) |
+| **Forward conversion** | `dt_ioppr_rgb_matrix_to_dt_UCS_JCH` | Inline in map kernel |
+| **Chromatic adaptation** | Separate `XYZ_D65_to_D50()` call | Folded into pre-multiplied matrix |
+| **Alpha passthrough** | Read directly from input buffer | Cached in `jch_out.w` |
+| **JCH cache layout** | 3 floats/pixel (J, C, H) | 4 floats/pixel (J, C, H, α) |
+| **Parallelism** | OpenMP threads over rows | GPU work-items per pixel |
+| **`L_white`** | Local variable | Kernel argument |
+
+**Why no fused single-pass on GPU?** Writing a third kernel
+(`colorharmonizer_fused`) for the smoothing=0 case would add code to maintain
+and test with marginal benefit — the JCH cache is a device-local buffer read,
+which on modern GPUs is nearly as fast as not caching at all. The two-kernel
+overhead (one extra kernel dispatch + one buffer allocation) is negligible
+compared to the pixel-processing time.
+
+---
+
+## 12. Spatial Smoothing
+
+### Purpose
+
+Without smoothing, the correction field can have sharp transitions at the
+boundaries between adjacent harmony zones. For most images this is fine — the
+Gaussian weighting already produces smooth gradients. But in images with subtle
+hue gradients crossing a zone boundary, a slight halo or banding artifact can
+appear. Spatial smoothing softens these transitions.
+
+### Sigma computation
+
+```c
+// colorharmonizer.c:533-534 (CPU) / 749-751 (CL)
+const float sigma = smoothing
+    × max(1.5, 8.0 × roi_in->scale / piece->iscale)
+    × max(1.0, pull_width);
+```
+
+- `roi_in->scale / piece->iscale`: adapts to the current zoom level / pipe
+  resolution. At preview resolution the blur is tighter; at full resolution it
+  scales up.
+- `max(1.0, pull_width)`: wider attraction zones need wider smoothing to
+  prevent visible zone boundaries.
+- `max(1.5, ...)`: prevents the sigma from collapsing to sub-pixel values at
+  high zoom.
+
+### What gets blurred
+
+The **correction field** (2 channels: hue_shift and sat_delta), not the image
+itself or the JCH values. This preserves image edges and detail while smoothing
+only the color-grading transitions.
+
+---
+
+## 13. Auto-Detection Algorithm
+
+### Goal
+
+Find the predefined harmony rule and anchor hue that already best explain the
+image's existing color distribution — i.e., the combination requiring the least
+correction.
+
+### Input: Chroma-weighted hue histogram
+
+Built during `_update_histogram()` (runs on the preview pipe):
+
+```c
+// For each pixel with chroma > 0.01:
+local_histo[hue_bin] += chroma;  // Weight by saturation — vivid colors matter more
+```
+
+360 bins, one per degree of UCS hue.
+
+### Scoring: `_score_harmony()`
+
+For a candidate (rule, anchor_hue):
+1. Compute harmony nodes
+2. For each histogram bin with energy:
+   - Find the maximum Gaussian weight across all nodes (using the same sigma
+     formula as the main algorithm with `pull_width = 1.0`)
+   - Accumulate `covered += histogram[bin] × max_weight`
+3. Return `covered / total` — fraction of chromatic energy within attraction
+   zones
+
+### Grid search
+
+```c
+for each rule in [monochromatic, ..., square]:    // 9 rules
+  for each anchor in [0°, 1°, ..., 359°]:         // 360 steps
+    score = _score_harmony(smoothed_histogram, rule, anchor)
+    track best
+```
+
+9 × 360 = 3,240 evaluations. Each evaluation iterates over 360 bins × up to 4
+nodes = ~1,440 operations. Total: ~4.7M floating-point ops — completes in
+under 1ms on a modern CPU.
+
+### Histogram smoothing
+
+Before scoring, the histogram is smoothed with 3 passes of a circular 3-tap
+box filter to suppress noise from individual pixels:
+
+```c
+for(int pass = 0; pass < 3; pass++)
+  for(int b = 0; b < 360; b++)
+    tmp[b] = (smooth[b-1] + smooth[b] + smooth[b+1]) / 3;
+```
+
+Three passes of a 3-tap box filter approximate a Gaussian with σ ≈ 1.2 bins
+(~1.2°). This prevents a single bright pixel from biasing the detection.
+
+---
+
+## 14. File & Line Reference
+
+| Component | File | Lines |
+|---|---|---|
+| Params struct | `src/iop/colorharmonizer.c` | 68–79 |
+| Pipe data struct | `src/iop/colorharmonizer.c` | 82–88 |
+| `get_weighted_hue_shift()` (CPU) | `src/iop/colorharmonizer.c` | 284–326 |
+| `get_weighted_hue_shift()` (CL) | `data/kernels/colorharmonizer.cl` | 35–78 |
+| `wrap_hue()` (CPU) | `src/iop/colorharmonizer.c` | 327–332 |
+| `wrap_hue()` (CL) | `data/kernels/colorharmonizer.cl` | 22–27 |
+| `get_harmony_nodes()` | `src/iop/colorharmonizer.c` | 342–365 |
+| `commit_params()` | `src/iop/colorharmonizer.c` | 366–376 |
+| `process()` — fused path | `src/iop/colorharmonizer.c` | 445–488 |
+| `process()` — two-pass path | `src/iop/colorharmonizer.c` | 490–574 |
+| `process_cl()` | `src/iop/colorharmonizer.c` | 680–786 |
+| `colorharmonizer_map` kernel | `data/kernels/colorharmonizer.cl` | 81–118 |
+| `colorharmonizer_apply` kernel | `data/kernels/colorharmonizer.cl` | 120–157 |
+| Harmony geometry table | `src/common/color_harmony.h` | 83 |
+| RYB control points | `src/common/color_ryb.h` | 37–41 |
+| LUT building | `src/iop/colorharmonizer.c` | 641–656 |
+| `_ucs_to_ryb_fast()` | `src/iop/colorharmonizer.c` | 621–626 |
+| `_ryb_to_ucs_fast()` | `src/iop/colorharmonizer.c` | 630–635 |
+| `_score_harmony()` | `src/iop/colorharmonizer.c` | 1321–1357 |
+| `_auto_detect_harmony()` | `src/iop/colorharmonizer.c` | 1359–1402 |

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -25,6 +25,7 @@ build/lib/darktable/plugins/introspection_colorbalancergb.c
 build/lib/darktable/plugins/introspection_colorchecker.c
 build/lib/darktable/plugins/introspection_colorcontrast.c
 build/lib/darktable/plugins/introspection_colorcorrection.c
+build/lib/darktable/plugins/introspection_colorharmonizer.c
 build/lib/darktable/plugins/introspection_colorequal.c
 build/lib/darktable/plugins/introspection_colorin.c
 build/lib/darktable/plugins/introspection_colorize.c
@@ -255,6 +256,7 @@ src/iop/colorbalancergb.c
 src/iop/colorchecker.c
 src/iop/colorcontrast.c
 src/iop/colorcorrection.c
+src/iop/colorharmonizer.c
 src/iop/colorequal.c
 src/iop/colorin.c
 src/iop/colorize.c

--- a/src/common/color_harmony.c
+++ b/src/common/color_harmony.c
@@ -24,6 +24,8 @@ void dt_color_harmony_init(dt_color_harmony_guide_t *layout)
   layout->type = DT_COLOR_HARMONY_NONE;
   layout->rotation = 0;
   layout->width = DT_COLOR_HARMONY_WIDTH_NORMAL;
+  layout->custom_n = 0;
+  memset(layout->custom_angles, 0, sizeof(layout->custom_angles));
 }
 
 void dt_color_harmony_set(const dt_imgid_t imgid,
@@ -58,8 +60,7 @@ void dt_color_harmony_set(const dt_imgid_t imgid,
   sqlite3_step(stmt);
   sqlite3_finalize(stmt);
 
-  // If inserted the proper link with the image table is done
-  // by the color_harmony_insert trigger.
+  // On insert, the link with the image table is maintained by the color_harmony_insert trigger.
 }
 
 gboolean dt_color_harmony_get(const dt_imgid_t imgid,
@@ -81,6 +82,9 @@ gboolean dt_color_harmony_get(const dt_imgid_t imgid,
     layout->type = sqlite3_column_int(stmt, 0);
     layout->rotation = sqlite3_column_int(stmt, 1);
     layout->width = sqlite3_column_int(stmt, 2);
+    // Custom angles are not persisted — they are set live by the IOP module.
+    layout->custom_n = 0;
+    memset(layout->custom_angles, 0, sizeof(layout->custom_angles));
     return TRUE;
   }
   else

--- a/src/common/color_harmony.h
+++ b/src/common/color_harmony.h
@@ -74,9 +74,9 @@ G_END_DECLS
 // harmony type and anchor rotation (integer degrees). n is set to the node count.
 // This is the single authoritative geometry table used by both the vectorscope overlay
 // and the processing pipeline; keeping it here avoids duplicating angle definitions.
-static inline void dt_color_harmony_get_sector_angles(dt_color_harmony_type_t type,
-                                                       int rotation,
-                                                       float *angles, int *n)
+static inline void dt_color_harmony_get_sector_angles(const dt_color_harmony_type_t type,
+                                                      const int rotation,
+                                                      float *angles, int *n)
 {
   static const struct { int n; float offsets[4]; } table[DT_COLOR_HARMONY_N] = {
     { 0, {  0.f                                          } }, // NONE

--- a/src/common/color_harmony.h
+++ b/src/common/color_harmony.h
@@ -51,22 +51,56 @@ typedef struct _color_harmony_t
   dt_color_harmony_type_t type;
   int rotation;
   dt_color_harmony_width_t width;
+  // When custom_n > 0, draw these absolute-angle nodes instead of the type+rotation table.
+  // Angles are normalized turns [0, 1), matching normalized UCS hue.
+  int   custom_n;
+  float custom_angles[4];
 } dt_color_harmony_guide_t;
 
 typedef int32_t dt_harmony_guide_id_t;
 
-// init layout to default value
 void dt_color_harmony_init(dt_color_harmony_guide_t *layout);
 
-// record color harmony in db for imgid
 void dt_color_harmony_set(const dt_imgid_t imgid,
                           const dt_color_harmony_guide_t layout);
 
-// get color harmony for imgid, return FALSE if not found in db
+// Returns FALSE if no harmony is recorded for imgid.
 gboolean dt_color_harmony_get(const dt_imgid_t imgid,
                               dt_color_harmony_guide_t *layout);
 
 G_END_DECLS
+
+// Returns the absolute RYB node positions (normalized turns [0,1)) for a predefined
+// harmony type and anchor rotation (integer degrees). n is set to the node count.
+// This is the single authoritative geometry table used by both the vectorscope overlay
+// and the processing pipeline; keeping it here avoids duplicating angle definitions.
+static inline void dt_color_harmony_get_sector_angles(dt_color_harmony_type_t type,
+                                                       int rotation,
+                                                       float *angles, int *n)
+{
+  static const struct { int n; float offsets[4]; } table[DT_COLOR_HARMONY_N] = {
+    { 0, {  0.f                                          } }, // NONE
+    { 1, {  0.f/12.f                                     } }, // MONOCHROMATIC
+    { 3, { -1.f/12.f,  0.f/12.f,  1.f/12.f              } }, // ANALOGOUS
+    { 4, { -1.f/12.f,  0.f/12.f,  1.f/12.f,  6.f/12.f  } }, // ANALOGOUS_COMPLEMENTARY
+    { 2, {  0.f/12.f,  6.f/12.f                         } }, // COMPLEMENTARY
+    { 3, {  0.f/12.f,  5.f/12.f,  7.f/12.f              } }, // SPLIT_COMPLEMENTARY
+    { 2, { -1.f/12.f,  1.f/12.f                         } }, // DYAD
+    { 3, {  0.f/12.f,  4.f/12.f,  8.f/12.f              } }, // TRIAD
+    { 4, { -1.f/12.f,  1.f/12.f,  5.f/12.f,  7.f/12.f  } }, // TETRAD
+    { 4, {  0.f/12.f,  3.f/12.f,  6.f/12.f,  9.f/12.f  } }, // SQUARE
+  };
+
+  if(type <= DT_COLOR_HARMONY_NONE || type >= DT_COLOR_HARMONY_N) { *n = 0; return; }
+  *n = table[type].n;
+  const float anchor = rotation / 360.0f;
+  for(int i = 0; i < *n; i++)
+  {
+    float a = table[type].offsets[i] + anchor;
+    a -= floorf(a); // wrap to [0, 1), handles negative offsets
+    angles[i] = a;
+  }
+}
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/common/color_ryb.h
+++ b/src/common/color_ryb.h
@@ -1,0 +1,53 @@
+/*
+    This file is part of darktable,
+    Copyright (C) 2010-2024 darktable developers.
+
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    darktable is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <math.h>
+
+// Piecewise mapping from RGB HSV hue to RYB (paint) hue.
+// Based on the Gossett paint-mixing model:
+//   "Paint Inspired Color Mixing and Compositing for Visualization"
+//   http://vis.computer.org/vis2004/DVD/infovis/papers/gossett.pdf
+//
+// x_vtx: evenly spaced 1/6 knots in [0, 1] (the RGB hue axis).
+// ryb_y_vtx: corresponding RYB hue values.
+//
+// These constants are also used by the RYB vectorscope
+// (src/libs/scopes/vectorscope.c), which builds cubic spline tables from them
+// for higher-accuracy pixel-level conversions. This header provides the same
+// mapping via simple piecewise-linear interpolation, which is accurate enough
+// for GUI display purposes (hue sliders, swatch colors).
+
+static const float dt_color_ryb_x_vtx[7] =
+  { 0.f, 1.f/6, 2.f/6, 3.f/6, 4.f/6, 5.f/6, 1.f };
+
+static const float dt_color_ryb_y_vtx[7] =
+  { 0.f, 1.f/3, 0.472217f, 0.611105f, 0.715271f, 5.f/6, 1.f };
+
+// Convert an RGB HSV hue [0, 1) to a RYB hue [0, 1) using piecewise linear
+// interpolation of the Gossett control points.
+static inline float dt_rgb_hue_to_ryb_hue(const float h)
+{
+  const float hc = h - floorf(h);
+  int i = 0;
+  while(i < 5 && hc >= dt_color_ryb_x_vtx[i + 1]) i++;
+  const float t = (hc - dt_color_ryb_x_vtx[i])
+                / (dt_color_ryb_x_vtx[i + 1] - dt_color_ryb_x_vtx[i]);
+  return dt_color_ryb_y_vtx[i] + t * (dt_color_ryb_y_vtx[i + 1] - dt_color_ryb_y_vtx[i]);
+}

--- a/src/common/colorspaces_inline_conversions.h
+++ b/src/common/colorspaces_inline_conversions.h
@@ -1430,11 +1430,28 @@ static inline void dt_UCS_HSB_to_XYZ(const dt_aligned_pixel_t HSB, const float L
   dt_xyY_to_XYZ(xyY, XYZ);
 }
 
-static inline void dt_UCS_JCH_to_XYZ(const dt_aligned_pixel_t JCH, const float L_w, dt_aligned_pixel_t XYZ)
+static inline void dt_UCS_JCH_to_XYZ(const dt_aligned_pixel_t JCH,
+                                     const float L_w,
+                                     dt_aligned_pixel_t XYZ)
 {
   dt_aligned_pixel_t xyY = { 0.f };
   dt_UCS_JCH_to_xyY(JCH, L_w, xyY);
   dt_xyY_to_XYZ(xyY, XYZ);
+}
+
+// Convert a darktable UCS JCH pixel to gamma-corrected sRGB.
+// Chain: JCH → XYZ(D65) → linear sRGB → sRGB gamma
+// Uses the native D65 sRGB matrix; skips the unnecessary D65→D50 adaptation step.
+static inline void dt_UCS_JCH_to_sRGB(const dt_aligned_pixel_t JCH,
+                                      const float L_w,
+                                      dt_aligned_pixel_t sRGB)
+{
+  dt_aligned_pixel_t XYZ_D65, linear;
+  dt_UCS_JCH_to_XYZ(JCH, L_w, XYZ_D65);
+  dt_XYZ_to_Rec709_D65(XYZ_D65, linear);
+  for_each_channel(c)
+    sRGB[c] = linear[c] <= 0.0031308f ? 12.92f * linear[c]
+                                      : 1.055f * powf(linear[c], 1.f / 2.4f) - 0.055f;
 }
 
 #undef DT_RESTRICT

--- a/src/common/colorspaces_inline_conversions.h
+++ b/src/common/colorspaces_inline_conversions.h
@@ -1430,6 +1430,13 @@ static inline void dt_UCS_HSB_to_XYZ(const dt_aligned_pixel_t HSB, const float L
   dt_xyY_to_XYZ(xyY, XYZ);
 }
 
+static inline void dt_UCS_JCH_to_XYZ(const dt_aligned_pixel_t JCH, const float L_w, dt_aligned_pixel_t XYZ)
+{
+  dt_aligned_pixel_t xyY = { 0.f };
+  dt_UCS_JCH_to_xyY(JCH, L_w, xyY);
+  dt_xyY_to_XYZ(xyY, XYZ);
+}
+
 #undef DT_RESTRICT
 
 // clang-format off

--- a/src/common/gaussian.h
+++ b/src/common/gaussian.h
@@ -114,8 +114,8 @@ void dt_gaussian_free_cl(dt_gaussian_cl_t *g);
 
 // OpenCL counterpart of dt_gaussian_mean_blur for GPU buffers.
 static inline int dt_gaussian_mean_blur_cl(const int devid, cl_mem buf,
-                                            const int width, const int height,
-                                            const int ch, const float sigma)
+                                           const int width, const int height,
+                                           const int ch, const float sigma)
 {
   const float range = 1.0e9f;
   const dt_aligned_pixel_t max = { range, range, range, range };

--- a/src/common/gaussian.h
+++ b/src/common/gaussian.h
@@ -57,6 +57,23 @@ void dt_gaussian_blur_4c(dt_gaussian_t *g, const float *const in, float *const o
 void dt_gaussian_free(dt_gaussian_t *g);
 void dt_gaussian_fast_blur(float *in, float *out, const int width, const int height, const float sigma, const float min, const float max, const int channels);
 
+// Convenience in-place Gaussian blur for IOP processing buffers.
+// Uses unbounded signal range; works for arbitrary channel counts (1, 2, or 4).
+static inline void dt_gaussian_mean_blur(float *const buf, const int width, const int height,
+                                          const int ch, const float sigma)
+{
+  const float range = 1.0e9f;
+  const dt_aligned_pixel_t max = { range, range, range, range };
+  const dt_aligned_pixel_t min = { -range, -range, -range, -range };
+  dt_gaussian_t *g = dt_gaussian_init(width, height, ch, max, min, sigma, DT_IOP_GAUSSIAN_ZERO);
+  if(!g) return;
+  if(ch == 4)
+    dt_gaussian_blur_4c(g, buf, buf);
+  else
+    dt_gaussian_blur(g, buf, buf);
+  dt_gaussian_free(g);
+}
+
 #ifdef HAVE_OPENCL
 typedef struct dt_gaussian_cl_global_t
 {
@@ -94,6 +111,22 @@ cl_int dt_gaussian_blur_cl_buffer(dt_gaussian_cl_t *g, cl_mem dev_in, cl_mem dev
 cl_int dt_gaussian_fast_blur_cl_buffer(const int devid, cl_mem dev_in, cl_mem dev_out, const int width, const int height, const float sigma, const int ch, const float min, const float max);
 
 void dt_gaussian_free_cl(dt_gaussian_cl_t *g);
+
+// OpenCL counterpart of dt_gaussian_mean_blur for GPU buffers.
+static inline int dt_gaussian_mean_blur_cl(const int devid, cl_mem buf,
+                                            const int width, const int height,
+                                            const int ch, const float sigma)
+{
+  const float range = 1.0e9f;
+  const dt_aligned_pixel_t max = { range, range, range, range };
+  const dt_aligned_pixel_t min = { -range, -range, -range, -range };
+  dt_gaussian_cl_t *g = dt_gaussian_init_cl(devid, width, height, ch, max, min, sigma,
+                                            DT_IOP_GAUSSIAN_ZERO);
+  if(!g) return DT_OPENCL_PROCESS_CL;
+  const cl_int err = dt_gaussian_blur_cl_buffer(g, buf, buf);
+  dt_gaussian_free_cl(g);
+  return err;
+}
 #endif
 
 // clang-format off

--- a/src/common/gaussian.h
+++ b/src/common/gaussian.h
@@ -59,8 +59,11 @@ void dt_gaussian_fast_blur(float *in, float *out, const int width, const int hei
 
 // Convenience in-place Gaussian blur for IOP processing buffers.
 // Uses unbounded signal range; works for arbitrary channel counts (1, 2, or 4).
-static inline void dt_gaussian_mean_blur(float *const buf, const int width, const int height,
-                                          const int ch, const float sigma)
+static inline void dt_gaussian_mean_blur(float *const buf,
+                                         const int width,
+                                         const int height,
+                                         const int ch,
+                                         const float sigma)
 {
   const float range = 1.0e9f;
   const dt_aligned_pixel_t max = { range, range, range, range };
@@ -113,9 +116,12 @@ cl_int dt_gaussian_fast_blur_cl_buffer(const int devid, cl_mem dev_in, cl_mem de
 void dt_gaussian_free_cl(dt_gaussian_cl_t *g);
 
 // OpenCL counterpart of dt_gaussian_mean_blur for GPU buffers.
-static inline int dt_gaussian_mean_blur_cl(const int devid, cl_mem buf,
-                                           const int width, const int height,
-                                           const int ch, const float sigma)
+static inline int dt_gaussian_mean_blur_cl(const int devid,
+                                           cl_mem buf,
+                                           const int width,
+                                           const int height,
+                                           const int ch,
+                                           const float sigma)
 {
   const float range = 1.0e9f;
   const dt_aligned_pixel_t max = { range, range, range, range };

--- a/src/common/iop_order.c
+++ b/src/common/iop_order.c
@@ -124,6 +124,7 @@ const dt_iop_order_entry_t legacy_order[] = {
   { {30.0f }, "defringe", 0},
   { {31.0f }, "equalizer", 0},
   { {32.0f }, "vibrance", 0},
+  { {32.5f }, "colorharmonizer", 0},
   { {33.0f }, "colorbalance", 0},
   { {33.2f }, "colorequal", 0},
   { {33.5f }, "colorbalancergb", 0},
@@ -245,6 +246,7 @@ const dt_iop_order_entry_t v30_order[] = {
                                   //    Really versatile yet under-used module, doing linear ops,
                                   //    very good in scene-referred workflow
   { {40.0f }, "basicadj", 0},        // module mixing view/model/control at once, usage should be discouraged
+  { {40.5f }, "colorharmonizer", 0}, // nudges hues towards a set of target nodes
   { {41.0f }, "colorbalance", 0},    // scene-referred color manipulation
   { {41.2f }, "colorequal", 0},
   { {41.5f }, "colorbalancergb", 0},    // scene-referred color manipulation
@@ -363,6 +365,7 @@ const dt_iop_order_entry_t v50_order[] = {
                                   //    Really versatile yet under-used module, doing linear ops,
                                   //    very good in scene-referred workflow
   { {40.0f }, "basicadj", 0},        // module mixing view/model/control at once, usage should be discouraged
+  { {40.5f }, "colorharmonizer", 0}, // nudges hues towards a set of target nodes
   { {41.0f }, "colorbalance", 0},    // scene-referred color manipulation
   { {41.2f }, "colorequal", 0},
   { {41.5f }, "colorbalancergb", 0},    // scene-referred color manipulation
@@ -481,6 +484,7 @@ const dt_iop_order_entry_t v30_jpg_order[] = {
                                     //    profile. Really versatile yet under-used module, doing linear ops, very
                                     //    good in scene-referred workflow
   { { 40.0f }, "basicadj", 0 },        // module mixing view/model/control at once, usage should be discouraged
+  { { 40.5f }, "colorharmonizer", 0 }, // nudges hues towards a set of target nodes
   { { 41.0f }, "colorbalance", 0 },    // scene-referred color manipulation
   { { 41.2f }, "colorequal", 0 },
   { { 41.5f }, "colorbalancergb", 0 }, // scene-referred color manipulation
@@ -602,6 +606,7 @@ const dt_iop_order_entry_t v50_jpg_order[] = {
                                     //    profile. Really versatile yet under-used module, doing linear ops, very
                                     //    good in scene-referred workflow
   { { 40.0f }, "basicadj", 0 },        // module mixing view/model/control at once, usage should be discouraged
+  { { 40.5f }, "colorharmonizer", 0 }, // nudges hues towards a set of target nodes
   { { 41.0f }, "colorbalance", 0 },    // scene-referred color manipulation
   { { 41.2f }, "colorequal", 0 },
   { { 41.5f }, "colorbalancergb", 0 }, // scene-referred color manipulation
@@ -732,6 +737,7 @@ void dt_ioppr_migrate_legacy_iop_order_list(GList *iop_order_list)
   _insert_before(iop_order_list, "filmicrgb", "agx");
   _insert_before(iop_order_list, "colorbalancergb", "colorequal");
   _insert_before(iop_order_list, "highlights", "rasterfile");
+  _insert_before(iop_order_list, "colorbalance", "colorharmonizer");
 }
 
 static dt_iop_order_t _ioppr_get_default_iop_order_version(const dt_imgid_t imgid)

--- a/src/common/iop_profile.h
+++ b/src/common/iop_profile.h
@@ -408,9 +408,9 @@ static inline void dt_ioppr_rgb_matrix_to_lab(const dt_aligned_pixel_t rgb,
 // work_profile->matrix_in_transposed) and L_white (from Y_to_dt_UCS_L_star(1.f)).
 // Assumes input is already clipped to non-negative values.
 static inline void dt_ioppr_rgb_matrix_to_dt_UCS_JCH(const float *const in,
-                                                       dt_aligned_pixel_t jch,
-                                                       const dt_colormatrix_t matrix_in_transposed,
-                                                       const float L_white)
+                                                     dt_aligned_pixel_t jch,
+                                                     const dt_colormatrix_t matrix_in_transposed,
+                                                     const float L_white)
 {
   dt_aligned_pixel_t xyz_d50, xyz_d65, xyY;
   dt_apply_transposed_color_matrix(in, matrix_in_transposed, xyz_d50);

--- a/src/common/iop_profile.h
+++ b/src/common/iop_profile.h
@@ -19,6 +19,7 @@
 #ifndef DT_IOP_PROFILE_H
 #define DT_IOP_PROFILE_H
 
+#include "common/chromatic_adaptation.h"
 #include "common/colorspaces_inline_conversions.h"
 #include "common/colorspaces.h"
 #include "common/file_location.h"
@@ -400,6 +401,22 @@ static inline void dt_ioppr_rgb_matrix_to_lab(const dt_aligned_pixel_t rgb,
   dt_ioppr_rgb_matrix_to_xyz(rgb, xyz, matrix_in_transposed, lut_in,
                              unbounded_coeffs_in, lutsize, nonlinearlut);
   dt_XYZ_to_Lab(xyz, lab);
+}
+
+// Convert a pixel from the pipe's working RGB space to darktable UCS JCH.
+// Takes the pre-transposed working-space → XYZ D50 matrix (available as
+// work_profile->matrix_in_transposed) and L_white (from Y_to_dt_UCS_L_star(1.f)).
+// Assumes input is already clipped to non-negative values.
+static inline void dt_ioppr_rgb_matrix_to_dt_UCS_JCH(const float *const in,
+                                                       dt_aligned_pixel_t jch,
+                                                       const dt_colormatrix_t matrix_in_transposed,
+                                                       const float L_white)
+{
+  dt_aligned_pixel_t xyz_d50, xyz_d65, xyY;
+  dt_apply_transposed_color_matrix(in, matrix_in_transposed, xyz_d50);
+  XYZ_D50_to_D65(xyz_d50, xyz_d65);
+  dt_D65_XYZ_to_xyY(xyz_d65, xyY);
+  xyY_to_dt_UCS_JCH(xyY, L_white, jch);
 }
 
 static inline float dt_ioppr_get_profile_info_middle_grey

--- a/src/iop/CMakeLists.txt
+++ b/src/iop/CMakeLists.txt
@@ -62,6 +62,7 @@ endmacro (add_iop)
 # @@_NEW_MODULE: when adding a new module here, please grep @@_NEW_MODULE in the code and adjust accordingly.
 
 # add_iop(useless "useless.c")
+add_iop(colorharmonizer "colorharmonizer.c" DEFAULT_VISIBLE)
 add_iop(rawprepare "rawprepare.c")
 add_iop(soften "soften.c")
 add_iop(bloom "bloom.c")

--- a/src/iop/colorequal.c
+++ b/src/iop/colorequal.c
@@ -61,6 +61,7 @@ None;midi:CC24=iop/colorequal/brightness/magenta
 #include "common/darktable.h"
 #include "common/eigf.h"
 #include "common/interpolation.h"
+#include "common/gaussian.h"
 #include "common/opencl.h"
 #include "common/color_picker.h"
 #include "control/conf.h"
@@ -428,24 +429,7 @@ int legacy_params(dt_iop_module_t *self,
   return 1;
 }
 
-void _mean_gaussian(float *const buf,
-                    const int width,
-                    const int height,
-                    const uint32_t ch,
-                    const float sigma)
-{
-  // We use unbounded signals, so don't care for the internal value clipping
-  const float range = 1.0e9;
-  const dt_aligned_pixel_t max = {range, range, range, range};
-  const dt_aligned_pixel_t min = {-range, -range, -range, -range};
-  dt_gaussian_t *g = dt_gaussian_init(width, height, ch, max, min, sigma, DT_IOP_GAUSSIAN_ZERO);
-  if(!g) return;
-  if(ch == 4)
-    dt_gaussian_blur_4c(g, buf, buf);
-  else
-    dt_gaussian_blur(g, buf, buf);
-  dt_gaussian_free(g);
-}
+// dt_gaussian_mean_blur() in common/gaussian.h replaces the former local dt_gaussian_mean_blur().
 
 
 // sRGB primary red records at 20° of hue in darktable UCS 22, so we offset the whole hue range
@@ -652,8 +636,8 @@ static void _prefilter_chromaticity(float *const restrict UV,
   // edges over diagonal ones as the by-the-book box blur (unweighted
   // local average) would.
 
-  _mean_gaussian(ds_UV, ds_width, ds_height, 2, gsigma);
-  _mean_gaussian(covariance, ds_width, ds_height, 4, gsigma);
+  dt_gaussian_mean_blur(ds_UV, ds_width, ds_height, 2, gsigma);
+  dt_gaussian_mean_blur(covariance, ds_width, ds_height, 4, gsigma);
 
   _finish_covariance(ds_pixels, ds_UV, covariance);
 
@@ -674,8 +658,8 @@ static void _prefilter_chromaticity(float *const restrict UV,
   }
 
   // Compute the averages of a and b for each filter
-  _mean_gaussian(ds_a, ds_width, ds_height, 4, gsigma);
-  _mean_gaussian(ds_b, ds_width, ds_height, 2, gsigma);
+  dt_gaussian_mean_blur(ds_a, ds_width, ds_height, 4, gsigma);
+  dt_gaussian_mean_blur(ds_b, ds_width, ds_height, 2, gsigma);
 
   // Upsample a and b to real-size image
   float *a = ds_a;
@@ -800,11 +784,11 @@ static void _guide_with_chromaticity(float *const restrict UV,
   // edges over diagonal ones as the by-the-book box blur (unweighted
   // local average) would.
   // We use unbounded signals, so don't care for the internal value clipping
-  _mean_gaussian(ds_UV, ds_width, ds_height, 2, gsigma);
-  _mean_gaussian(covariance, ds_width, ds_height, 4, gsigma);
-  _mean_gaussian(ds_corrections, ds_width, ds_height, 2, gsigma);
-  _mean_gaussian(ds_b_corrections, ds_width, ds_height, 1, 0.1f * gsigma);
-  _mean_gaussian(correlations, ds_width, ds_height, 4, gsigma);
+  dt_gaussian_mean_blur(ds_UV, ds_width, ds_height, 2, gsigma);
+  dt_gaussian_mean_blur(covariance, ds_width, ds_height, 4, gsigma);
+  dt_gaussian_mean_blur(ds_corrections, ds_width, ds_height, 2, gsigma);
+  dt_gaussian_mean_blur(ds_b_corrections, ds_width, ds_height, 1, 0.1f * gsigma);
+  dt_gaussian_mean_blur(correlations, ds_width, ds_height, 4, gsigma);
 
   _finish_covariance(ds_pixels, ds_UV, covariance);
 
@@ -879,8 +863,8 @@ static void _guide_with_chromaticity(float *const restrict UV,
   dt_free_align(covariance);
 
   // Compute the averages of a and b for each filter and blur
-  _mean_gaussian(ds_a, ds_width, ds_height, 4, gsigma);
-  _mean_gaussian(ds_b, ds_width, ds_height, 2, gsigma);
+  dt_gaussian_mean_blur(ds_a, ds_width, ds_height, 4, gsigma);
+  dt_gaussian_mean_blur(ds_b, ds_width, ds_height, 2, gsigma);
 
   // Upsample a and b to real-size image
   float *a = ds_a;
@@ -1049,7 +1033,7 @@ void process(dt_iop_module_t *self,
     Lscharr[k] = Y_to_dt_UCS_L_star(xyY[2]);
   }
 
-  _mean_gaussian(saturation, width, height, 1, sat_sigma);
+  dt_gaussian_mean_blur(saturation, width, height, 1, sat_sigma);
 
   // STEP 2 : smoothen UV to avoid discontinuities in hue
   if(d->use_filter && !run_fast)
@@ -1107,7 +1091,7 @@ void process(dt_iop_module_t *self,
   if(d->use_filter && !run_fast)
   {
     // blur the saturation gradients
-    _mean_gaussian(Lscharr, width, height, 1, scharr_sigma);
+    dt_gaussian_mean_blur(Lscharr, width, height, 1, scharr_sigma);
 
     // STEP 4: apply a guided filter on the corrections, guided with UV chromaticity, to ensure spatially-contiguous corrections.
     // Even if the hue is not perfectly constant this will help avoiding chroma noise.
@@ -1210,26 +1194,9 @@ void process(dt_iop_module_t *self,
   dt_free_align(Lscharr);
 }
 
+// dt_gaussian_mean_blur_cl() in common/gaussian.h replaces the former local dt_gaussian_mean_blur_cl().
+
 #if HAVE_OPENCL
-
-int _mean_gaussian_cl(const int devid,
-                      const cl_mem image,
-                      const int width,
-                      const int height,
-                      const int ch,
-                      const float sigma)
-{
-  const float range = 1.0e9;
-  const dt_aligned_pixel_t max = {range, range, range, range};
-  const dt_aligned_pixel_t min = {-range, -range, -range, -range};
-
-  dt_gaussian_cl_t *g = dt_gaussian_init_cl(devid, width, height, ch, max, min, sigma, DT_IOP_GAUSSIAN_ZERO);
-  if(!g) return DT_OPENCL_PROCESS_CL;
-
-  const cl_int err = dt_gaussian_blur_cl_buffer(g, image, image);
-  dt_gaussian_free_cl(g);
-  return err;
-}
 
 static cl_mem _init_covariance_cl(const int devid,
                                   const dt_iop_colorequal_global_data_t *gd,
@@ -1296,10 +1263,10 @@ static int _prefilter_chromaticity_cl(const int devid,
     goto error;
   }
 
-  err = _mean_gaussian_cl(devid, ds_UV, ds_width, ds_height, 2, gsigma);
+  err = dt_gaussian_mean_blur_cl(devid, ds_UV, ds_width, ds_height, 2, gsigma);
   if(err != CL_SUCCESS) goto error;
 
-  err = _mean_gaussian_cl(devid, covariance, ds_width, ds_height, 4, gsigma);
+  err = dt_gaussian_mean_blur_cl(devid, covariance, ds_width, ds_height, 4, gsigma);
   if(err != CL_SUCCESS) goto error;
 
   err = dt_opencl_enqueue_kernel_2d_args(devid, gd->ce_finish_covariance, ds_width, ds_height,
@@ -1327,10 +1294,10 @@ static int _prefilter_chromaticity_cl(const int devid,
     ds_UV = NULL;
   }
 
-  err = _mean_gaussian_cl(devid, ds_a, ds_width, ds_height, 4, gsigma);
+  err = dt_gaussian_mean_blur_cl(devid, ds_a, ds_width, ds_height, 4, gsigma);
   if(err != CL_SUCCESS) goto error;
 
-  err = _mean_gaussian_cl(devid, ds_b, ds_width, ds_height, 2, gsigma);
+  err = dt_gaussian_mean_blur_cl(devid, ds_b, ds_width, ds_height, 2, gsigma);
   if(err != CL_SUCCESS) goto error;
 
   a = ds_a;
@@ -1444,15 +1411,15 @@ static int _guide_with_chromaticity_cl(const int devid,
           CLARG(ds_width), CLARG(ds_height));
   if(err != CL_SUCCESS) goto error;
 
-  err = _mean_gaussian_cl(devid, ds_UV, ds_width, ds_height, 2, gsigma);
+  err = dt_gaussian_mean_blur_cl(devid, ds_UV, ds_width, ds_height, 2, gsigma);
   if(err != CL_SUCCESS) goto error;
-  err = _mean_gaussian_cl(devid, covariance, ds_width, ds_height, 4, gsigma);
+  err = dt_gaussian_mean_blur_cl(devid, covariance, ds_width, ds_height, 4, gsigma);
   if(err != CL_SUCCESS) goto error;
-  err = _mean_gaussian_cl(devid, ds_corrections, ds_width, ds_height, 2, gsigma);
+  err = dt_gaussian_mean_blur_cl(devid, ds_corrections, ds_width, ds_height, 2, gsigma);
   if(err != CL_SUCCESS) goto error;
-  err = _mean_gaussian_cl(devid, ds_b_corrections, ds_width, ds_height, 1, 0.1f * gsigma);
+  err = dt_gaussian_mean_blur_cl(devid, ds_b_corrections, ds_width, ds_height, 1, 0.1f * gsigma);
   if(err != CL_SUCCESS) goto error;
-  err = _mean_gaussian_cl(devid, correlations, ds_width, ds_height, 4, gsigma);
+  err = dt_gaussian_mean_blur_cl(devid, correlations, ds_width, ds_height, 4, gsigma);
   if(err != CL_SUCCESS) goto error;
 
   ds_a = dt_opencl_alloc_device_buffer(devid, 4 * ds_bsize);
@@ -1489,9 +1456,9 @@ static int _guide_with_chromaticity_cl(const int devid,
   dt_opencl_release_mem_object(covariance);
   covariance = NULL;
 
-  err = _mean_gaussian_cl(devid, ds_a, ds_width, ds_height, 4, gsigma);
+  err = dt_gaussian_mean_blur_cl(devid, ds_a, ds_width, ds_height, 4, gsigma);
   if(err != CL_SUCCESS) goto error;
-  err = _mean_gaussian_cl(devid, ds_b, ds_width, ds_height, 2, gsigma);
+  err = dt_gaussian_mean_blur_cl(devid, ds_b, ds_width, ds_height, 2, gsigma);
   if(err != CL_SUCCESS) goto error;
 
   a = ds_a;
@@ -1601,7 +1568,7 @@ int process_cl(dt_iop_module_t *self,
           CLARG(input_matrix_cl), CLARG(width),  CLARG(height));
   if(err != CL_SUCCESS) goto error;
 
-  err = _mean_gaussian_cl(devid, saturation, width, height, 1, sat_sigma);
+  err = dt_gaussian_mean_blur_cl(devid, saturation, width, height, 1, sat_sigma);
   if(err != CL_SUCCESS) goto error;
 
   // STEP 2 : smoothen UV to avoid discontinuities in hue
@@ -1621,7 +1588,7 @@ int process_cl(dt_iop_module_t *self,
 
   if(guiding && !run_fast)
   {
-    err = _mean_gaussian_cl(devid, Lscharr, width, height, 1, scharr_sigma);
+    err = dt_gaussian_mean_blur_cl(devid, Lscharr, width, height, 1, scharr_sigma);
     if(err != CL_SUCCESS) goto error;
 
     err = _guide_with_chromaticity_cl(devid, gd, UV, corrections, saturation, b_corrections, Lscharr, weight, width, height, par_sigma, d->param_feathering, bright_shift, sat_shift);

--- a/src/iop/colorharmonizer.c
+++ b/src/iop/colorharmonizer.c
@@ -1614,9 +1614,6 @@ void gui_init(dt_iop_module_t *self)
   g_signal_connect(G_OBJECT(g->sync_to_vectorscope), "toggled",
                    G_CALLBACK(_sync_to_vectorscope_toggled), self);
 
-  if(gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(g->sync_to_vectorscope)))
-    _sync_to_vectorscope_toggled(GTK_TOGGLE_BUTTON(g->sync_to_vectorscope), self);
-
   g->set_from_vectorscope = dtgtk_button_new(dtgtk_cairo_paint_refresh, CPF_NONE, NULL);
   gtk_widget_set_tooltip_text(g->set_from_vectorscope,
     _("import the harmony rule and anchor hue currently displayed in the vectorscope.\n"

--- a/src/iop/colorharmonizer.c
+++ b/src/iop/colorharmonizer.c
@@ -1,0 +1,1758 @@
+/*
+    This file is part of darktable,
+    Copyright (C) 2010-2024 darktable developers.
+
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    darktable is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "common/iop_profile.h"
+#include "common/math.h"
+#include "bauhaus/bauhaus.h"
+#include "dtgtk/button.h"
+#include "dtgtk/paint.h"
+#include "common/colorspaces.h"
+#include "common/colorspaces_inline_conversions.h"
+#include "common/chromatic_adaptation.h"
+#include "develop/imageop.h"
+#include "develop/imageop_gui.h"
+#include "gui/color_picker_proxy.h"
+#include "gui/gtk.h"
+#include "iop/iop_api.h"
+#include "libs/lib.h"
+#include "common/color_harmony.h"
+#include "common/color_ryb.h"
+#include "common/opencl.h"
+#include "common/gaussian.h"
+#include "control/conf.h"
+
+#include <gtk/gtk.h>
+#include <math.h>
+#include <stdlib.h>
+
+#define COLORHARMONIZER_HUE_BINS 360
+#define COLORHARMONIZER_MAX_NODES 4
+// Resolution for the RYB↔UCS lookup tables (0.5° steps).
+#define COLORHARMONIZER_RYB_INVERSE_STEPS 720
+
+// Precomputed hue conversion tables, built once in init_global.
+// Indexed by hue fraction × COLORHARMONIZER_RYB_INVERSE_STEPS.
+static float s_ucs_to_ryb_lut[COLORHARMONIZER_RYB_INVERSE_STEPS];
+static float s_ryb_to_ucs_lut[COLORHARMONIZER_RYB_INVERSE_STEPS];
+
+DT_MODULE_INTROSPECTION(6, dt_iop_colorharmonizer_params_t)
+
+typedef enum dt_iop_colorharmonizer_rule_t
+{
+  DT_COLORHARMONIZER_MONOCHROMATIC = 0,           // $DESCRIPTION: "monochromatic"
+  DT_COLORHARMONIZER_ANALOGOUS = 1,               // $DESCRIPTION: "analogous"
+  DT_COLORHARMONIZER_ANALOGOUS_COMPLEMENTARY = 2, // $DESCRIPTION: "analogous complementary"
+  DT_COLORHARMONIZER_COMPLEMENTARY = 3,           // $DESCRIPTION: "complementary"
+  DT_COLORHARMONIZER_SPLIT_COMPLEMENTARY = 4,     // $DESCRIPTION: "split complementary"
+  DT_COLORHARMONIZER_DYAD = 5,                    // $DESCRIPTION: "dyad"
+  DT_COLORHARMONIZER_TRIAD = 6,                   // $DESCRIPTION: "triad"
+  DT_COLORHARMONIZER_TETRAD = 7,                  // $DESCRIPTION: "tetrad"
+  DT_COLORHARMONIZER_SQUARE = 8,                  // $DESCRIPTION: "square"
+  DT_COLORHARMONIZER_CUSTOM = 9                   // $DESCRIPTION: "custom"
+} dt_iop_colorharmonizer_rule_t;
+
+typedef struct dt_iop_colorharmonizer_params_t
+{
+  dt_iop_colorharmonizer_rule_t rule; // $DEFAULT: DT_COLORHARMONIZER_COMPLEMENTARY $DESCRIPTION: "harmony rule"
+  float anchor_hue;                   // $MIN: 0.0 $MAX: 1.0 $DEFAULT: 0.1 $DESCRIPTION: "anchor hue"
+  float pull_strength;                // $MIN: 0.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "pull strength"
+  float neutral_protection;           // $MIN: 0.0 $MAX: 1.0 $DEFAULT: 0.5 $DESCRIPTION: "neutral color protection"
+  float pull_width;                   // $MIN: 0.25 $MAX: 4.0 $DEFAULT: 1.0 $DESCRIPTION: "pull width"
+  float custom_hue[4];                // $MIN: 0.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "custom node hue"
+  int   num_custom_nodes;             // $MIN: 2 $MAX: 4 $DEFAULT: 4 $DESCRIPTION: "nodes"
+  float node_saturation[4];           // $MIN: 0.0 $MAX: 2.0 $DEFAULT: 1.0 $DESCRIPTION: "node saturation"
+  float smoothing;                    // $MIN: 0.0 $MAX: 2.0 $DEFAULT: 0.0 $DESCRIPTION: "smoothing"
+} dt_iop_colorharmonizer_params_t;
+
+// Pipe data: params plus harmony node positions precomputed in commit_params so
+// that process() and process_cl() don't pay the RYB↔UCS conversion cost per run.
+typedef struct dt_iop_colorharmonizer_data_t
+{
+  dt_iop_colorharmonizer_params_t params;
+  float nodes[COLORHARMONIZER_MAX_NODES]; // UCS hue [0,1) of each harmony node
+  int   num_nodes;
+} dt_iop_colorharmonizer_data_t;
+
+typedef struct dt_iop_colorharmonizer_gui_data_t
+{
+  GtkWidget *rule, *anchor_hue, *pull_strength, *neutral_protection, *pull_width, *smoothing;
+  GtkWidget *set_from_vectorscope, *sync_to_vectorscope, *auto_detect;
+  GtkWidget *num_custom_nodes_slider;                    // node count (custom mode only)
+  GtkWidget *swatches_area;                              // horizontal swatches row (non-custom mode)
+  GtkWidget *node_swatch[COLORHARMONIZER_MAX_NODES];     // swatches inside swatches_area
+  GtkWidget *custom_swatch[COLORHARMONIZER_MAX_NODES];   // swatches inside custom rows
+  GtkWidget *custom_hue_slider[COLORHARMONIZER_MAX_NODES];
+  GtkWidget *custom_row[COLORHARMONIZER_MAX_NODES];
+  GtkWidget *sat_row[COLORHARMONIZER_MAX_NODES];         // saturation rows
+  GtkWidget *sat_slider[COLORHARMONIZER_MAX_NODES];      // per-node saturation sliders (chroma gradient)
+  dt_gui_collapsible_section_t sat_section;              // collapsible "Saturation" section
+  float      hue_histogram[COLORHARMONIZER_HUE_BINS];
+  gboolean   histogram_valid;
+  GMutex     histogram_lock;
+} dt_iop_colorharmonizer_gui_data_t;
+
+typedef struct dt_iop_colorharmonizer_global_data_t
+{
+  int kernel_colorharmonizer_map;
+  int kernel_colorharmonizer_apply;
+} dt_iop_colorharmonizer_global_data_t;
+
+const char *name()
+{
+  return _("color harmonizer");
+}
+
+const char **description(dt_iop_module_t *self)
+{
+  return dt_iop_set_description
+    (self,
+     _("harmonize colors toward a selected palette in perceptual space"),
+     _("creative color grading"),
+     _("linear, RGB, scene-referred"),
+     _("darktable UCS / JCH (perceptual)"),
+     _("linear, RGB, scene-referred"));
+}
+
+int flags()
+{
+  return IOP_FLAGS_INCLUDE_IN_STYLES | IOP_FLAGS_SUPPORTS_BLENDING;
+}
+
+int default_group()
+{
+  return IOP_GROUP_COLOR;
+}
+
+dt_iop_colorspace_type_t default_colorspace(dt_iop_module_t *self,
+                                            dt_dev_pixelpipe_t *pipe,
+                                            dt_dev_pixelpipe_iop_t *piece)
+{
+  // We work in RGB pipeline, convert internally to darktable UCS.
+  return IOP_CS_RGB;
+}
+
+int legacy_params(dt_iop_module_t *self,
+                  const void *const old_params,
+                  const int old_version,
+                  void **new_params,
+                  int32_t *new_params_size,
+                  int *new_version)
+{
+  if(old_version == 2)
+  {
+    typedef struct
+    {
+      dt_iop_colorharmonizer_rule_t rule;
+      float anchor_hue;
+      float pull_strength;
+      float neutral_protection;
+      float pull_width;
+    } v2_params_t;
+
+    typedef struct
+    {
+      dt_iop_colorharmonizer_rule_t rule;
+      float anchor_hue;
+      float pull_strength;
+      float neutral_protection;
+      float pull_width;
+      float custom_hue[4];
+    } v3_params_t;
+
+    const v2_params_t *o = old_params;
+    v3_params_t *n = malloc(sizeof(v3_params_t));
+    if(!n) return 1;
+
+    n->rule            = o->rule;
+    n->anchor_hue      = o->anchor_hue;
+    n->pull_strength = o->pull_strength;
+    n->neutral_protection = o->neutral_protection;
+    n->pull_width      = o->pull_width;
+    n->custom_hue[0]   = 0.0f;
+    n->custom_hue[1]   = 0.25f;
+    n->custom_hue[2]   = 0.5f;
+    n->custom_hue[3]   = 0.75f;
+
+    *new_params      = n;
+    *new_params_size = sizeof(v3_params_t);
+    *new_version     = 3;
+    return 0;
+  }
+  if(old_version == 3)
+  {
+    typedef struct
+    {
+      dt_iop_colorharmonizer_rule_t rule;
+      float anchor_hue;
+      float pull_strength;
+      float neutral_protection;
+      float pull_width;
+      float custom_hue[4];
+    } v3_params_t;
+
+    const v3_params_t *o = old_params;
+    dt_iop_colorharmonizer_params_t *n = malloc(sizeof(dt_iop_colorharmonizer_params_t));
+    if(!n) return 1;
+
+    n->rule             = o->rule;
+    n->anchor_hue       = o->anchor_hue;
+    n->pull_strength  = o->pull_strength;
+    n->neutral_protection  = o->neutral_protection;
+    n->pull_width       = o->pull_width;
+    for(int i = 0; i < 4; i++) n->custom_hue[i] = o->custom_hue[i];
+    n->num_custom_nodes = 4;
+    for(int i = 0; i < 4; i++) n->node_saturation[i] = 1.0f;
+
+    *new_params      = n;
+    *new_params_size = sizeof(dt_iop_colorharmonizer_params_t);
+    *new_version     = 5;
+    return 0;
+  }
+  if(old_version == 4)
+  {
+    typedef struct
+    {
+      dt_iop_colorharmonizer_rule_t rule;
+      float anchor_hue;
+      float pull_strength;
+      float neutral_protection;
+      float pull_width;
+      float custom_hue[4];
+      int   num_custom_nodes;
+    } v4_params_t;
+
+    const v4_params_t *o = old_params;
+    dt_iop_colorharmonizer_params_t *n = malloc(sizeof(dt_iop_colorharmonizer_params_t));
+    if(!n) return 1;
+
+    n->rule             = o->rule;
+    n->anchor_hue       = o->anchor_hue;
+    n->pull_strength  = o->pull_strength;
+    n->neutral_protection  = o->neutral_protection;
+    n->pull_width       = o->pull_width;
+    for(int i = 0; i < 4; i++) n->custom_hue[i] = o->custom_hue[i];
+    n->num_custom_nodes = o->num_custom_nodes;
+    for(int i = 0; i < 4; i++) n->node_saturation[i] = 1.0f;
+
+    *new_params      = n;
+    *new_params_size = sizeof(dt_iop_colorharmonizer_params_t);
+    *new_version     = 5;
+    return 0;
+  }
+  if(old_version == 5)
+  {
+    dt_iop_colorharmonizer_params_t *n = malloc(sizeof(dt_iop_colorharmonizer_params_t));
+    if(!n) return 1;
+    memcpy(n, old_params, sizeof(dt_iop_colorharmonizer_params_t) - sizeof(float));
+    n->smoothing = 0.0f;
+
+    *new_params      = n;
+    *new_params_size = sizeof(dt_iop_colorharmonizer_params_t);
+    *new_version     = 6;
+    return 0;
+  }
+  return 1;
+}
+
+// Compute a hue shift toward the nearest harmony node, scaled by Gaussian proximity.
+//
+// We use the nearest-node's angular difference (diff_winning) multiplied by
+// the peak Gaussian weight (max_w). This ensures:
+//   - A pixel already at a node gets zero shift (diff_winning = 0).
+//   - A pixel far from all nodes gets near-zero shift (max_w ≈ 0).
+//   - The correction magnitude tapers smoothly as the pixel moves away from its node.
+//
+//   Narrow zone (< 1): Gaussian drops off quickly → only hues very close to a
+//                       node are attracted; distant hues are barely shifted.
+//   Default zone (1):  Gaussian tapers to ~14 % at the midpoint between nodes.
+//   Wide zone   (> 1): Gaussian stays high across the full hue circle → broad,
+//                       global correction; all hues are pulled noticeably.
+static inline float get_weighted_hue_shift(float px_hue, const float *nodes, int num_nodes,
+                                           float pull_width_factor,
+                                           int *out_winning_idx, float *out_max_weight)
+{
+  if(num_nodes <= 0)
+  {
+    if(out_winning_idx) *out_winning_idx = 0;
+    if(out_max_weight) *out_max_weight = 0.0f;
+    return 0.0f;
+  }
+  const float sigma = pull_width_factor * 0.5f / (float)num_nodes;
+  const float inv_2sigma2 = 1.0f / (2.0f * sigma * sigma);
+
+  float max_w       = 0.0f;
+  int   winning_idx = 0;
+  float diff_winning = 0.0f;
+
+  for(int i = 0; i < num_nodes; i++)
+  {
+    float d = fabsf(px_hue - nodes[i]);
+    if(d > 0.5f) d = 1.0f - d;
+
+    const float w = expf(-d * d * inv_2sigma2);
+    float diff = nodes[i] - px_hue;
+    if(diff > 0.5f)       diff -= 1.0f;
+    else if(diff < -0.5f) diff += 1.0f;
+
+    if(w > max_w)
+    {
+      max_w       = w;
+      winning_idx = i;
+      diff_winning = diff;
+    }
+  }
+
+  if(out_winning_idx) *out_winning_idx = winning_idx;
+  if(out_max_weight)  *out_max_weight  = max_w;
+  return diff_winning * max_w;
+}
+
+static inline float wrap_hue(float h)
+{
+  h = fmodf(h, 1.0f);
+  if (h < 0.0f) h += 1.0f;
+  return h;
+}
+
+// Forward declarations: defined later in the file, needed here for get_harmony_nodes.
+static float _ucs_hue_to_ryb_hue(float ucs_hue);
+static float _ucs_to_ryb_fast(float ucs);
+static float _ryb_to_ucs_fast(float yrb);
+// Compute harmony node positions in UCS hue space [0,1).
+// For predefined rules the geometry comes from dt_color_harmony_get_sector_angles()
+// (color_harmony.h) so that the nodes used for processing are exactly aligned
+// with the guide overlay shown in the vectorscope.
+static inline void get_harmony_nodes(dt_iop_colorharmonizer_rule_t rule, float anchor_hue,
+                                     const float *custom_hue, int custom_n,
+                                     float *nodes, int *num_nodes)
+{
+  if(rule == DT_COLORHARMONIZER_CUSTOM)
+  {
+    const int n = CLAMP(custom_n, 1, COLORHARMONIZER_MAX_NODES);
+    for(int i = 0; i < n; i++)
+      nodes[i] = custom_hue ? custom_hue[i] : 0.0f;
+    *num_nodes = n;
+    return;
+  }
+
+  // Convert the UCS anchor hue to an integer RYB rotation (degrees) and look up
+  // the vectorscope geometry table to obtain absolute RYB node positions.
+  const int rotation = (int)roundf(_ucs_to_ryb_fast(anchor_hue) * 360.0f) % 360;
+  float node_angles[COLORHARMONIZER_MAX_NODES];
+  dt_color_harmony_get_sector_angles((dt_color_harmony_type_t)(rule + 1), rotation,
+                                     node_angles, num_nodes);
+  // Convert each RYB node back to UCS for use in the processing pipeline.
+  for(int i = 0; i < *num_nodes; i++)
+    nodes[i] = _ryb_to_ucs_fast(node_angles[i]);
+}
+
+void commit_params(dt_iop_module_t *self,
+                   dt_iop_params_t *p1,
+                   dt_dev_pixelpipe_t *pipe,
+                   dt_dev_pixelpipe_iop_t *piece)
+{
+  dt_iop_colorharmonizer_params_t *p = p1;
+  dt_iop_colorharmonizer_data_t   *d = piece->data;
+  d->params = *p;
+  get_harmony_nodes(p->rule, p->anchor_hue, p->custom_hue, p->num_custom_nodes,
+                    d->nodes, &d->num_nodes);
+}
+
+static void _update_histogram(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const float *ivoid, const dt_iop_roi_t *roi_in)
+{
+  if(!self->gui_data || !((piece->pipe->type & DT_DEV_PIXELPIPE_PREVIEW) == DT_DEV_PIXELPIPE_PREVIEW))
+    return;
+
+  dt_iop_colorharmonizer_gui_data_t *g = self->gui_data;
+  const dt_iop_order_iccprofile_info_t *const work_profile = dt_ioppr_get_pipe_work_profile_info(piece->pipe);
+  if(!work_profile) return;
+
+  const int ch = piece->colors;
+  const float L_white = Y_to_dt_UCS_L_star(1.0f);
+  float local_histo[COLORHARMONIZER_HUE_BINS] = { 0.0f };
+
+  for(int j = 0; j < roi_in->height; j++)
+  {
+    const float *src = ((const float *)ivoid) + (size_t)ch * roi_in->width * j;
+    for(int i = 0; i < roi_in->width; i++, src += ch)
+    {
+      dt_aligned_pixel_t px_rgb = { fmaxf(src[0], 0.0f), fmaxf(src[1], 0.0f),
+                                    fmaxf(src[2], 0.0f), 0.0f };
+      dt_aligned_pixel_t px_JCH;
+      dt_ioppr_rgb_matrix_to_dt_UCS_JCH(px_rgb, px_JCH, work_profile->matrix_in_transposed, L_white);
+
+      const float chroma = px_JCH[1];
+      if(chroma > 0.01f)
+      {
+        const float hue = (px_JCH[2] + M_PI_F) / (2.f * M_PI_F);
+        const int bin = (int)(hue * COLORHARMONIZER_HUE_BINS) % COLORHARMONIZER_HUE_BINS;
+        local_histo[bin] += chroma;
+      }
+    }
+  }
+
+  g_mutex_lock(&g->histogram_lock);
+  memcpy(g->hue_histogram, local_histo, sizeof(local_histo));
+  g->histogram_valid = TRUE;
+  g_mutex_unlock(&g->histogram_lock);
+}
+
+void process(dt_iop_module_t *self,
+             dt_dev_pixelpipe_iop_t *piece,
+             const void *const ivoid,
+             void *const ovoid,
+             const dt_iop_roi_t *const roi_in,
+             const dt_iop_roi_t *const roi_out)
+{
+  const dt_iop_colorharmonizer_data_t   *d = piece->data;
+  const dt_iop_colorharmonizer_params_t *p = &d->params;
+  const size_t ch = piece->colors;
+
+  if(!dt_iop_have_required_input_format(4, self, piece->colors, ivoid, ovoid, roi_in, roi_out))
+    return;
+
+  const float *const nodes = d->nodes;
+  const int num_nodes = d->num_nodes;
+
+  const dt_iop_order_iccprofile_info_t *const work_profile = dt_ioppr_get_pipe_work_profile_info(piece->pipe);
+  if(!work_profile) return;
+
+  const float L_white = Y_to_dt_UCS_L_star(1.0f);
+
+  const float pull_strength = p->pull_strength;
+  const float pull_width    = p->pull_width;
+  const float np_t          = p->neutral_protection;
+  // cutoff is the chroma level at which neutral_protection halves the correction
+  // (chroma_weight = 0.5 when chroma == cutoff). The cubic response concentrates
+  // the protective effect toward very low-chroma values.
+  const float cutoff        = np_t * np_t * np_t * 0.03f;
+
+  if(p->smoothing <= 0.0f)
+  {
+    // Fused single pass: forward conversion → correction → inverse conversion.
+    // No intermediate buffer needed; each pixel is touched exactly once.
+    DT_OMP_FOR()
+    for(int j = 0; j < roi_out->height; j++)
+    {
+      const float *in  = ((const float *)ivoid) + (size_t)ch * roi_in->width * j;
+      float       *out = ((float *)ovoid)        + (size_t)ch * roi_out->width * j;
+
+      for(int i = 0; i < roi_out->width; i++, in += ch, out += ch)
+      {
+        const dt_aligned_pixel_t px_rgb = { fmaxf(in[0], 0.0f), fmaxf(in[1], 0.0f),
+                                            fmaxf(in[2], 0.0f), 0.0f };
+        dt_aligned_pixel_t px_JCH;
+        dt_ioppr_rgb_matrix_to_dt_UCS_JCH(px_rgb, px_JCH, work_profile->matrix_in_transposed, L_white);
+
+        const float hue    = (px_JCH[2] + M_PI_F) / (2.f * M_PI_F);
+        const float chroma = px_JCH[1];
+
+        int   winning_idx = 0;
+        float max_weight  = 0.0f;
+        const float hue_shift = get_weighted_hue_shift(hue, nodes, num_nodes, pull_width,
+                                                       &winning_idx, &max_weight);
+        const float sat_delta = (p->node_saturation[winning_idx] - 1.0f) * max_weight;
+
+        // Smooth hyperbolic ramp: approaches 0 for neutral colors, ~1 for saturated colors.
+        const float chroma_weight = chroma / (chroma + cutoff + 1e-5f);
+
+        px_JCH[2] = wrap_hue(hue + hue_shift * pull_strength * chroma_weight) * 2.f * M_PI_F - M_PI_F;
+        px_JCH[1] = fmaxf(chroma * (1.0f + sat_delta * chroma_weight), 0.0f);
+
+        dt_aligned_pixel_t px_xyY, px_xyz_d65, px_xyz;
+        dt_UCS_JCH_to_xyY(px_JCH, L_white, px_xyY);
+        dt_xyY_to_XYZ(px_xyY, px_xyz_d65);
+        XYZ_D65_to_D50(px_xyz_d65, px_xyz);
+
+        dt_aligned_pixel_t px_rgb_out;
+        dt_apply_transposed_color_matrix(px_xyz, work_profile->matrix_out_transposed, px_rgb_out);
+        for_each_channel(c) out[c] = px_rgb_out[c];
+        out[3] = in[3];
+      }
+    }
+  }
+  else
+  {
+    // Two-pass with JCH caching: cache the forward conversion from Pass 1
+    // so Pass 2 only performs the inverse (JCH → RGB).
+    const size_t npx = (size_t)roi_out->width * roi_out->height;
+    float *jch_cache   = dt_alloc_align_float(3 * npx);
+    float *corrections = dt_alloc_align_float(2 * npx);
+    if(!jch_cache || !corrections)
+    {
+      dt_free_align(jch_cache);
+      dt_free_align(corrections);
+      return;
+    }
+
+    // Pass 1: forward RGB → JCH (cached) + compute per-pixel corrections.
+    DT_OMP_FOR()
+    for(int j = 0; j < roi_out->height; j++)
+    {
+      const float *in  = ((const float *)ivoid) + (size_t)ch * roi_in->width * j;
+      const size_t row = (size_t)j * roi_out->width;
+
+      for(int i = 0; i < roi_out->width; i++, in += ch)
+      {
+        const dt_aligned_pixel_t px_rgb = { fmaxf(in[0], 0.0f), fmaxf(in[1], 0.0f),
+                                            fmaxf(in[2], 0.0f), 0.0f };
+        dt_aligned_pixel_t px_JCH;
+        dt_ioppr_rgb_matrix_to_dt_UCS_JCH(px_rgb, px_JCH, work_profile->matrix_in_transposed, L_white);
+
+        const float hue = (px_JCH[2] + M_PI_F) / (2.f * M_PI_F);
+
+        const size_t k = row + i;
+        jch_cache[k * 3]     = px_JCH[0];  // J
+        jch_cache[k * 3 + 1] = px_JCH[1];  // chroma
+        jch_cache[k * 3 + 2] = hue;        // normalized hue [0,1)
+
+        int   winning_idx = 0;
+        float max_weight  = 0.0f;
+        const float hue_shift = get_weighted_hue_shift(hue, nodes, num_nodes, pull_width,
+                                                       &winning_idx, &max_weight);
+        corrections[k * 2]     = hue_shift;
+        corrections[k * 2 + 1] = (p->node_saturation[winning_idx] - 1.0f) * max_weight;
+      }
+    }
+
+    // Gaussian blur: smooth corrections spatially to soften zone-boundary transitions.
+    // sigma scales with the preview↔full-res ratio so the blur radius stays consistent
+    // across pipeline scales; 1.5 px is the minimum useful radius, and wider attraction
+    // zones warrant proportionally more smoothing.
+    const float sigma = p->smoothing * fmaxf(1.5f, 8.0f * roi_in->scale / piece->iscale)
+                        * fmaxf(1.0f, pull_width);
+    dt_gaussian_mean_blur(corrections, roi_out->width, roi_out->height, 2, sigma);
+
+    // Pass 2: apply blurred corrections using cached JCH (inverse only).
+    DT_OMP_FOR()
+    for(int j = 0; j < roi_out->height; j++)
+    {
+      const float *in  = ((const float *)ivoid) + (size_t)ch * roi_in->width  * j;
+      float       *out = ((float *)ovoid)        + (size_t)ch * roi_out->width * j;
+      const size_t row = (size_t)j * roi_out->width;
+
+      for(int i = 0; i < roi_out->width; i++, in += ch, out += ch)
+      {
+        const size_t k     = row + i;
+        const float J      = jch_cache[k * 3];
+        const float chroma = jch_cache[k * 3 + 1];
+        const float hue    = jch_cache[k * 3 + 2];
+
+        const float chroma_weight = chroma / (chroma + cutoff + 1e-5f);
+
+        const float new_hue = wrap_hue(hue + corrections[k * 2] * pull_strength * chroma_weight);
+        dt_aligned_pixel_t px_JCH = { J,
+                                      fmaxf(chroma * (1.0f + corrections[k * 2 + 1] * chroma_weight), 0.0f),
+                                      new_hue * 2.f * M_PI_F - M_PI_F,
+                                      0.0f };
+
+        dt_aligned_pixel_t px_xyY, px_xyz_d65, px_xyz;
+        dt_UCS_JCH_to_xyY(px_JCH, L_white, px_xyY);
+        dt_xyY_to_XYZ(px_xyY, px_xyz_d65);
+        XYZ_D65_to_D50(px_xyz_d65, px_xyz);
+
+        dt_aligned_pixel_t px_rgb_out;
+        dt_apply_transposed_color_matrix(px_xyz, work_profile->matrix_out_transposed, px_rgb_out);
+        for_each_channel(c) out[c] = px_rgb_out[c];
+        out[3] = in[3];
+      }
+    }
+
+    dt_free_align(jch_cache);
+    dt_free_align(corrections);
+  }
+
+  // Build a chroma-weighted hue histogram from the input for auto-detection.
+  _update_histogram(self, piece, ivoid, roi_in);
+}
+
+void init(dt_iop_module_t *self)
+{
+  dt_iop_default_init(self);
+
+  // Set sensible defaults for custom harmony nodes (evenly spread).
+  // Other fields use introspection defaults from the param annotations.
+  dt_iop_colorharmonizer_params_t *p = self->default_params;
+  p->custom_hue[0] = 0.0f;
+  p->custom_hue[1] = 0.25f;
+  p->custom_hue[2] = 0.5f;
+  p->custom_hue[3] = 0.75f;
+  memcpy(self->params, self->default_params, self->params_size);
+}
+
+void cleanup(dt_iop_module_t *self)
+{
+  dt_iop_default_cleanup(self);
+}
+
+void init_pipe(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
+{
+  piece->data = calloc(1, sizeof(dt_iop_colorharmonizer_data_t));
+}
+
+void cleanup_pipe(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
+{
+  free(piece->data);
+  piece->data = NULL;
+}
+
+// Linearly interpolate between two hue values on the circle, returning a result in [0,1).
+static inline float _hue_lerp(float a, float b, float t)
+{
+  if(b - a >  0.5f) b -= 1.0f;
+  else if(a - b >  0.5f) a -= 1.0f;
+  float r = a + t * (b - a);
+  if(r < 0.0f) r += 1.0f;
+  return r;
+}
+
+// O(1) UCS→RYB lookup with linear interpolation between table entries.
+static inline float _ucs_to_ryb_fast(float ucs)
+{
+  const float pos  = ucs * COLORHARMONIZER_RYB_INVERSE_STEPS;
+  const int   i0   = (int)pos % COLORHARMONIZER_RYB_INVERSE_STEPS;
+  const int   i1   = (i0 + 1) % COLORHARMONIZER_RYB_INVERSE_STEPS;
+  return _hue_lerp(s_ucs_to_ryb_lut[i0], s_ucs_to_ryb_lut[i1], pos - (int)pos);
+}
+
+// O(1) RYB→UCS lookup with linear interpolation between table entries.
+static inline float _ryb_to_ucs_fast(float ryb)
+{
+  const float pos  = ryb * COLORHARMONIZER_RYB_INVERSE_STEPS;
+  const int   i0   = (int)pos % COLORHARMONIZER_RYB_INVERSE_STEPS;
+  const int   i1   = (i0 + 1) % COLORHARMONIZER_RYB_INVERSE_STEPS;
+  return _hue_lerp(s_ryb_to_ucs_lut[i0], s_ryb_to_ucs_lut[i1], pos - (int)pos);
+}
+
+// Build both lookup tables once at module load.
+// Forward table (UCS→RYB): _ucs_hue_to_ryb_hue involves a gamut binary search, so
+// precomputing it avoids repeating that cost at every GUI or processing call.
+// Inverse table (RYB→UCS): nearest-match scan over the forward table — O(N²) but
+// N=720 and it only runs once, so the total cost is negligible.
+static void _build_hue_luts(void)
+{
+  for(int i = 0; i < COLORHARMONIZER_RYB_INVERSE_STEPS; i++)
+    s_ucs_to_ryb_lut[i] = _ucs_hue_to_ryb_hue(i / (float)COLORHARMONIZER_RYB_INVERSE_STEPS);
+
+  for(int j = 0; j < COLORHARMONIZER_RYB_INVERSE_STEPS; j++)
+  {
+    const float target = j / (float)COLORHARMONIZER_RYB_INVERSE_STEPS;
+    float best_dist = 1.0f, best_ucs = 0.0f;
+    for(int i = 0; i < COLORHARMONIZER_RYB_INVERSE_STEPS; i++)
+    {
+      float d = fabsf(s_ucs_to_ryb_lut[i] - target);
+      if(d > 0.5f) d = 1.0f - d;
+      if(d < best_dist) { best_dist = d; best_ucs = i / (float)COLORHARMONIZER_RYB_INVERSE_STEPS; }
+    }
+    s_ryb_to_ucs_lut[j] = best_ucs;
+  }
+}
+
+void init_global(dt_iop_module_so_t *self)
+{
+  _build_hue_luts();
+  const int program = 40; // colorharmonizer.cl in programs.conf
+  dt_iop_colorharmonizer_global_data_t *gd = malloc(sizeof(dt_iop_colorharmonizer_global_data_t));
+  self->data = gd;
+  gd->kernel_colorharmonizer_map    = dt_opencl_create_kernel(program, "colorharmonizer_map");
+  gd->kernel_colorharmonizer_apply  = dt_opencl_create_kernel(program, "colorharmonizer_apply");
+}
+
+void cleanup_global(dt_iop_module_so_t *self)
+{
+  dt_iop_colorharmonizer_global_data_t *gd = self->data;
+  dt_opencl_free_kernel(gd->kernel_colorharmonizer_map);
+  dt_opencl_free_kernel(gd->kernel_colorharmonizer_apply);
+  free(self->data);
+  self->data = NULL;
+}
+
+#ifdef HAVE_OPENCL
+int process_cl(dt_iop_module_t *self,
+               dt_dev_pixelpipe_iop_t *piece,
+               cl_mem dev_in, cl_mem dev_out,
+               const dt_iop_roi_t *const roi_in,
+               const dt_iop_roi_t *const roi_out)
+{
+  const dt_iop_colorharmonizer_data_t   *const d  = piece->data;
+  const dt_iop_colorharmonizer_params_t *const p  = &d->params;
+  const dt_iop_colorharmonizer_global_data_t *const gd = self->global_data;
+
+  cl_int err = DT_OPENCL_DEFAULT_ERROR;
+
+  if(piece->colors != 4)
+    return err;
+
+  const int devid  = piece->pipe->devid;
+  const int width  = roi_out->width;
+  const int height = roi_out->height;
+
+  const dt_iop_order_iccprofile_info_t *const work_profile = dt_ioppr_get_pipe_work_profile_info(piece->pipe);
+  if(!work_profile) return err;
+
+  dt_colormatrix_t input_matrix, output_matrix;
+  dt_colormatrix_mul(input_matrix,  XYZ_D50_to_D65_CAT16, work_profile->matrix_in);
+  dt_colormatrix_mul(output_matrix, work_profile->matrix_out, XYZ_D65_to_D50_CAT16);
+
+  float nodes[COLORHARMONIZER_MAX_NODES];
+  memcpy(nodes, d->nodes, sizeof(nodes));
+  const int num_nodes = d->num_nodes;
+  float node_saturation[COLORHARMONIZER_MAX_NODES];
+  for(int i = 0; i < COLORHARMONIZER_MAX_NODES; i++) node_saturation[i] = p->node_saturation[i];
+
+  const float L_white = Y_to_dt_UCS_L_star(1.0f);
+
+  cl_mem input_matrix_cl    = dt_opencl_copy_host_to_device_constant(devid, 12 * sizeof(float), input_matrix);
+  cl_mem output_matrix_cl   = dt_opencl_copy_host_to_device_constant(devid, 12 * sizeof(float), output_matrix);
+  cl_mem nodes_cl           = dt_opencl_copy_host_to_device_constant(devid, COLORHARMONIZER_MAX_NODES * sizeof(float), nodes);
+  cl_mem node_saturation_cl = dt_opencl_copy_host_to_device_constant(devid, COLORHARMONIZER_MAX_NODES * sizeof(float), node_saturation);
+
+  // Correction map buffer (float2 per pixel: hue_delta, sat_delta).
+  const size_t f2sz = (size_t)width * height * 2 * sizeof(float);
+  cl_mem corrections_cl = dt_opencl_alloc_device_buffer(devid, f2sz);
+
+  // JCH cache buffer (float4 per pixel: J, chroma, hue, alpha).
+  // Written by the map kernel so the apply kernel skips the forward conversion.
+  const size_t jchsz = (size_t)width * height * 4 * sizeof(float);
+  cl_mem jch_cl = dt_opencl_alloc_device_buffer(devid, jchsz);
+
+  if(!input_matrix_cl || !output_matrix_cl || !nodes_cl || !node_saturation_cl
+     || !corrections_cl || !jch_cl)
+  {
+    err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
+    goto error;
+  }
+
+  // Step 1: compute per-pixel correction maps + cache JCH.
+  err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_colorharmonizer_map, width, height,
+    CLARG(dev_in),
+    CLARG(corrections_cl),
+    CLARG(jch_cl),
+    CLARG(width), CLARG(height),
+    CLARG(input_matrix_cl),
+    CLARG(nodes_cl), CLARG(num_nodes),
+    CLARG(p->pull_width),
+    CLARG(node_saturation_cl),
+    CLARG(L_white));
+  if(err != CL_SUCCESS) goto error;
+
+  // Step 2: Gaussian-blur corrections spatially.
+  if(p->smoothing > 0.0f)
+  {
+    const float sigma = p->smoothing * fmaxf(1.5f, 8.0f * roi_in->scale / piece->iscale)
+                        * fmaxf(1.0f, p->pull_width);
+    if((err = dt_gaussian_mean_blur_cl(devid, corrections_cl, width, height, 2, sigma)) != CL_SUCCESS) goto error;
+  }
+
+  // Step 3: apply smoothed corrections from cached JCH → output.
+  err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_colorharmonizer_apply, width, height,
+    CLARG(dev_out),
+    CLARG(width), CLARG(height),
+    CLARG(output_matrix_cl),
+    CLARG(jch_cl),
+    CLARG(corrections_cl),
+    CLARG(p->pull_strength), CLARG(p->neutral_protection),
+    CLARG(L_white));
+
+  if(err == CL_SUCCESS && self->gui_data && (piece->pipe->type & DT_DEV_PIXELPIPE_PREVIEW) == DT_DEV_PIXELPIPE_PREVIEW)
+  {
+    float *host_in = dt_alloc_align_float((size_t)width * height * 4);
+    if(host_in)
+    {
+      if(dt_opencl_copy_device_to_host(devid, host_in, dev_in, width, height, 4 * sizeof(float)) == CL_SUCCESS)
+      {
+        _update_histogram(self, piece, host_in, roi_in);
+      }
+      dt_free_align(host_in);
+    }
+  }
+
+error:
+  dt_opencl_release_mem_object(input_matrix_cl);
+  dt_opencl_release_mem_object(output_matrix_cl);
+  dt_opencl_release_mem_object(nodes_cl);
+  dt_opencl_release_mem_object(node_saturation_cl);
+  dt_opencl_release_mem_object(corrections_cl);
+  dt_opencl_release_mem_object(jch_cl);
+  return err;
+}
+#endif
+
+// Convert a darktable UCS JCH pixel to gamma-corrected sRGB.
+// Chain: JCH → XYZ(D65) → linear sRGB → sRGB gamma
+// Uses the native D65 sRGB matrix; skips the unnecessary D65→D50 adaptation step.
+static inline void _jch_to_srgb(const dt_aligned_pixel_t JCH, const float L_white,
+                                 dt_aligned_pixel_t sRGB)
+{
+  dt_aligned_pixel_t XYZ_D65, linear;
+  dt_UCS_JCH_to_XYZ(JCH, L_white, XYZ_D65);
+  dt_XYZ_to_Rec709_D65(XYZ_D65, linear);
+  for_each_channel(c)
+    sRGB[c] = linear[c] <= 0.0031308f ? 12.92f * linear[c]
+                                      : 1.055f * powf(linear[c], 1.f / 2.4f) - 0.055f;
+}
+
+// Find the maximum sRGB-safe chroma for a UCS hue [0,1) at J = 0.65 (mid-brightness).
+// Uses 16 iterations of binary search; result fits within [0, 1] sRGB without clamping.
+static float _find_max_chroma(const float hue)
+{
+  const float L_white = Y_to_dt_UCS_L_star(1.0f);
+  const float H = hue * 2.f * M_PI_F - M_PI_F;  // [0,1) → [-π, π]
+  const float J = 0.65f;                         // ≈ Y=0.29, mid-brightness
+
+  float C_lo = 0.f, C_hi = 2.f;
+  for(int iter = 0; iter < 16; iter++)
+  {
+    const float C_mid = (C_lo + C_hi) * 0.5f;
+    dt_aligned_pixel_t JCH = { J, C_mid, H, 0.f };
+    dt_aligned_pixel_t sRGB;
+    _jch_to_srgb(JCH, L_white, sRGB);
+    if(sRGB[0] >= 0.f && sRGB[1] >= 0.f && sRGB[2] >= 0.f
+       && sRGB[0] <= 1.f && sRGB[1] <= 1.f && sRGB[2] <= 1.f)
+      C_lo = C_mid;
+    else
+      C_hi = C_mid;
+  }
+  return C_lo;
+}
+
+// Render a normalized UCS hue value [0,1) to display sRGB at mid-brightness.
+// Backs off 15% from the gamut boundary so swatches look vivid but not clipped.
+static void _hue_to_srgb(float hue, float *r, float *g, float *b)
+{
+  const float L_white = Y_to_dt_UCS_L_star(1.0f);
+  const float H = hue * 2.f * M_PI_F - M_PI_F;
+  const float J = 0.65f;
+
+  dt_aligned_pixel_t JCH = { J, _find_max_chroma(hue) * 0.85f, H, 0.f };
+  dt_aligned_pixel_t sRGB;
+  _jch_to_srgb(JCH, L_white, sRGB);
+  *r = CLAMP(sRGB[0], 0.f, 1.f);
+  *g = CLAMP(sRGB[1], 0.f, 1.f);
+  *b = CLAMP(sRGB[2], 0.f, 1.f);
+}
+
+static void _paint_hue_slider(GtkWidget *slider)
+{
+  for(int i = 0; i < DT_BAUHAUS_SLIDER_MAX_STOPS; i++)
+  {
+    const float stop = ((float)i / (float)(DT_BAUHAUS_SLIDER_MAX_STOPS - 1));
+    float r, g, b;
+    // slider positions are RYB fractions; convert to UCS for the color swatch
+    _hue_to_srgb(_ryb_to_ucs_fast(stop), &r, &g, &b);
+    dt_bauhaus_slider_set_stop(slider, stop, r, g, b);
+  }
+}
+
+static void _paint_all_hue_sliders(const dt_iop_colorharmonizer_gui_data_t *const g)
+{
+  _paint_hue_slider(g->anchor_hue);
+  for(int i = 0; i < COLORHARMONIZER_MAX_NODES; i++)
+    _paint_hue_slider(g->custom_hue_slider[i]);
+}
+
+// Paint a saturation slider with a gray→full-color gradient at the given UCS hue.
+static void _paint_sat_slider(GtkWidget *slider, const float hue)
+{
+  const float L_white = Y_to_dt_UCS_L_star(1.0f);
+  const float J = 0.65f;
+  const float H = hue * 2.f * M_PI_F - M_PI_F;
+
+  const float C_lo = _find_max_chroma(hue);
+  // C_swatch is the chroma used for the swatch (= the "neutral / 100%" reference color).
+  // The saturation slider ranges 0–2, so stop=0.5 maps to value=1.0 (neutral).
+  // We make stop=0.5 show the swatch color and stop=1.0 reach the gamut boundary (C_lo),
+  // so the right end looks as vivid as the swatch instead of appearing washed-out.
+  const float C_swatch = C_lo * 0.85f;
+
+  for(int i = 0; i < DT_BAUHAUS_SLIDER_MAX_STOPS; i++)
+  {
+    const float stop = (float)i / (float)(DT_BAUHAUS_SLIDER_MAX_STOPS - 1);
+    // Linear from 0 → C_swatch over [0, 0.5], then C_swatch → C_lo over [0.5, 1.0].
+    const float C = stop <= 0.5f ? stop * 2.f * C_swatch
+                                 : C_swatch + (stop - 0.5f) * 2.f * (C_lo - C_swatch);
+    dt_aligned_pixel_t JCH = { J, C, H, 0.f };
+    dt_aligned_pixel_t sRGB;
+    _jch_to_srgb(JCH, L_white, sRGB);
+    dt_bauhaus_slider_set_stop(slider, stop,
+                               CLAMP(sRGB[0], 0.f, 1.f),
+                               CLAMP(sRGB[1], 0.f, 1.f),
+                               CLAMP(sRGB[2], 0.f, 1.f));
+  }
+  gtk_widget_queue_draw(slider);
+}
+
+static void _paint_all_sat_sliders(const dt_iop_colorharmonizer_gui_data_t *const g,
+                                    const dt_iop_colorharmonizer_params_t *const p)
+{
+  float nodes[COLORHARMONIZER_MAX_NODES];
+  int num_nodes = 0;
+  get_harmony_nodes(p->rule, p->anchor_hue, p->custom_hue, p->num_custom_nodes, nodes, &num_nodes);
+  for(int i = 0; i < num_nodes; i++)
+    _paint_sat_slider(g->sat_slider[i], nodes[i]);
+}
+
+// Convert a UCS anchor_hue [0,1) to the RYB hue fraction [0,1) that the vectorscope uses.
+// Path: UCS hue → gamut-clipped sRGB → linearize → RGB HSV hue → RYB hue.
+static float _ucs_hue_to_ryb_hue(const float ucs_hue)
+{
+  float r, g, b;
+  _hue_to_srgb(ucs_hue, &r, &g, &b);
+  const dt_aligned_pixel_t srgb = { r, g, b, 0.f };
+  dt_aligned_pixel_t lrgb;
+  dt_sRGB_to_linear_sRGB(srgb, lrgb);
+  dt_aligned_pixel_t HCV;
+  dt_RGB_2_HCV(lrgb, HCV);
+  return dt_rgb_hue_to_ryb_hue(HCV[0]);
+}
+
+
+static void _push_to_vectorscope(dt_iop_module_t *self)
+{
+  dt_iop_colorharmonizer_params_t *p = self->params;
+  dt_color_harmony_guide_t guide;
+  dt_lib_histogram_get_harmony(darktable.lib, &guide);
+
+  if(p->rule == DT_COLORHARMONIZER_CUSTOM)
+  {
+    // Custom: provide absolute-angle nodes; type is left as NONE so the
+    // vectorscope's own UI shows no standard rule selected.
+    guide.type     = DT_COLOR_HARMONY_NONE;
+    guide.custom_n = p->num_custom_nodes;
+    for(int i = 0; i < p->num_custom_nodes; i++)
+      guide.custom_angles[i] = _ucs_to_ryb_fast(p->custom_hue[i]);
+  }
+  else
+  {
+    guide.type        = (dt_color_harmony_type_t)(p->rule + 1);
+    guide.rotation    = (int)roundf(_ucs_to_ryb_fast(p->anchor_hue) * 360.f) % 360;
+    guide.custom_n    = 0;
+  }
+
+  dt_lib_histogram_set_scope(darktable.lib, 0); // 0 = DT_LIB_HISTOGRAM_SCOPE_VECTORSCOPE
+  dt_lib_histogram_set_type(darktable.lib, 2);  // 2 = DT_LIB_HISTOGRAM_VECTORSCOPE_RYB
+  dt_lib_histogram_set_harmony(darktable.lib, &guide);
+}
+
+static void _anchor_hue_slider_changed(GtkWidget *widget, dt_iop_module_t *self)
+{
+  if(darktable.gui->reset) return;
+  dt_iop_color_picker_reset(self, TRUE);
+  dt_iop_colorharmonizer_params_t *p = self->params;
+  p->anchor_hue = _ryb_to_ucs_fast(dt_bauhaus_slider_get(widget) / 360.0f);
+  gui_changed(self, widget, NULL);
+  dt_dev_add_history_item(self->dev, self, TRUE);
+}
+
+// Apply a vectorscope harmony guide (rule + rotation) to params and refresh the GUI.
+// Precondition: guide->type != DT_COLOR_HARMONY_NONE.
+static void _apply_harmony_guide(dt_iop_module_t *self,
+                                  dt_iop_colorharmonizer_params_t *p,
+                                  dt_iop_colorharmonizer_gui_data_t *g,
+                                  const dt_color_harmony_guide_t *guide)
+{
+  p->rule      = (dt_iop_colorharmonizer_rule_t)(guide->type - 1);
+  p->anchor_hue = _ryb_to_ucs_fast(guide->rotation / 360.0f);
+
+  ++darktable.gui->reset;
+  dt_bauhaus_combobox_set(g->rule, p->rule);
+  dt_bauhaus_slider_set(g->anchor_hue, (float)guide->rotation);
+  --darktable.gui->reset;
+
+  gui_changed(self, NULL, NULL);
+  dt_dev_add_history_item(self->dev, self, TRUE);
+}
+
+static void _sync_custom_sliders(dt_iop_colorharmonizer_gui_data_t *g,
+                                  dt_iop_colorharmonizer_params_t *p);
+
+static void _on_vectorscope_harmony_changed(const dt_color_harmony_guide_t *guide, void *user_data)
+{
+  dt_iop_module_t *self = (dt_iop_module_t *)user_data;
+  if(!self || !self->gui_data) return;
+  if(!self->enabled) return;
+
+  if(guide->type == DT_COLOR_HARMONY_NONE)
+  {
+    // Custom harmony: the vectorscope rotated custom_angles in place (e.g. via scroll);
+    // sync the updated node positions back into params and refresh the UI.
+    if(guide->custom_n <= 0) return;
+    dt_iop_colorharmonizer_params_t *p = self->params;
+    dt_iop_colorharmonizer_gui_data_t *g = self->gui_data;
+    const int n = MIN(guide->custom_n, p->num_custom_nodes);
+    for(int i = 0; i < n; i++)
+      p->custom_hue[i] = _ryb_to_ucs_fast(guide->custom_angles[i]);
+    _sync_custom_sliders(g, p);
+    for(int i = 0; i < COLORHARMONIZER_MAX_NODES; i++)
+    {
+      gtk_widget_queue_draw(g->custom_swatch[i]);
+      gtk_widget_queue_draw(g->node_swatch[i]);
+    }
+    _paint_all_sat_sliders(g, p);
+    dt_dev_add_history_item(self->dev, self, TRUE);
+    return;
+  }
+
+  // _push_to_vectorscope() is called inside gui_changed() when sync is enabled, but since
+  // we fire the callback only from user interaction paths (not from dt_vec_set_harmony),
+  // the resulting push-back will not cause another callback invocation.
+  _apply_harmony_guide(self, self->params, self->gui_data, guide);
+}
+
+static void _sync_to_vectorscope_toggled(GtkToggleButton *button, dt_iop_module_t *self)
+{
+  dt_iop_colorharmonizer_gui_data_t *g = self->gui_data;
+  const gboolean active = gtk_toggle_button_get_active(button);
+  dt_conf_set_bool("plugins/darkroom/colorharmonizer/sync_to_vectorscope", active);
+
+  if(active)
+  {
+    _push_to_vectorscope(self);
+    dt_lib_histogram_set_harmony_callback(darktable.lib, _on_vectorscope_harmony_changed, self);
+  }
+  else
+  {
+    dt_lib_histogram_set_harmony_callback(darktable.lib, NULL, NULL);
+    // Custom guides only live in memory — clear them from the vectorscope when
+    // sync is disabled so they don't linger as stale overlays.
+    dt_iop_colorharmonizer_params_t *p = self->params;
+    if(p->rule == DT_COLORHARMONIZER_CUSTOM)
+    {
+      dt_color_harmony_guide_t guide;
+      dt_lib_histogram_get_harmony(darktable.lib, &guide);
+      guide.custom_n = 0;
+      guide.type     = DT_COLOR_HARMONY_NONE;
+      dt_lib_histogram_set_harmony(darktable.lib, &guide);
+    }
+  }
+
+  if(g && g->set_from_vectorscope)
+    gtk_widget_set_sensitive(g->set_from_vectorscope, !active);
+}
+
+static gboolean _swatch_draw_callback(GtkWidget *widget, cairo_t *cr, gpointer user_data)
+{
+  dt_iop_module_t *self = user_data;
+  dt_iop_colorharmonizer_params_t *p = self->params;
+  const int idx = GPOINTER_TO_INT(g_object_get_data(G_OBJECT(widget), "swatch-index"));
+
+  float hue = 0.0f;
+  gboolean show_color = TRUE;
+
+  if(p->rule == DT_COLORHARMONIZER_CUSTOM)
+  {
+    hue = p->custom_hue[idx];
+  }
+  else
+  {
+    float nodes[COLORHARMONIZER_MAX_NODES];
+    int num_nodes = 0;
+    get_harmony_nodes(p->rule, p->anchor_hue, NULL, COLORHARMONIZER_MAX_NODES, nodes, &num_nodes);
+    if(idx < num_nodes)
+      hue = nodes[idx];
+    else
+      show_color = FALSE; // unused slot: draw neutral grey
+  }
+
+  if(!show_color)
+  {
+    cairo_set_source_rgb(cr, 0.25, 0.25, 0.25);
+    cairo_paint(cr);
+    return TRUE;
+  }
+
+  float r, g, b;
+  _hue_to_srgb(hue, &r, &g, &b);
+  cairo_set_source_rgb(cr, r, g, b);
+  cairo_paint(cr);
+  return TRUE;
+}
+
+static void _custom_hue_changed(GtkWidget *widget, dt_iop_module_t *self)
+{
+  if(darktable.gui->reset) return;
+
+  // Deactivate any active color picker when the slider is moved directly.
+  dt_iop_color_picker_reset(self, TRUE);
+
+  dt_iop_colorharmonizer_params_t *p = self->params;
+  dt_iop_colorharmonizer_gui_data_t *g = self->gui_data;
+  const int idx = GPOINTER_TO_INT(g_object_get_data(G_OBJECT(widget), "slider-index"));
+
+  p->custom_hue[idx] = _ryb_to_ucs_fast(dt_bauhaus_slider_get(widget) / 360.0f);
+
+  gtk_widget_queue_draw(g->custom_swatch[idx]);
+  gtk_widget_queue_draw(g->node_swatch[idx]);
+  _paint_all_sat_sliders(g, p);
+  dt_dev_add_history_item(self->dev, self, TRUE);
+
+  if(g->sync_to_vectorscope
+     && gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(g->sync_to_vectorscope)))
+    _push_to_vectorscope(self);
+}
+
+static void _node_saturation_changed(GtkWidget *widget, dt_iop_module_t *self)
+{
+  if(darktable.gui->reset) return;
+  dt_iop_colorharmonizer_params_t *p = self->params;
+  const int idx = GPOINTER_TO_INT(g_object_get_data(G_OBJECT(widget), "slider-index"));
+  p->node_saturation[idx] = dt_bauhaus_slider_get(widget);
+  dt_dev_add_history_item(self->dev, self, TRUE);
+}
+
+// Initialize custom nodes when switching from a predefined rule to custom mode.
+// Reads the current vectorscope guide's sector positions and converts them to UCS.
+static void _init_custom_nodes_from_rule(dt_iop_module_t *self,
+                                          dt_iop_colorharmonizer_gui_data_t *g,
+                                          dt_iop_colorharmonizer_params_t *p,
+                                          dt_iop_colorharmonizer_rule_t old_rule)
+{
+  dt_color_harmony_guide_t guide;
+  dt_lib_histogram_get_harmony(darktable.lib, &guide);
+  float node_angles[COLORHARMONIZER_MAX_NODES];
+  int num_nodes = 0;
+  dt_lib_histogram_get_sector_angles(darktable.lib, guide.type, guide.rotation, node_angles, &num_nodes);
+
+  if(num_nodes < 1)
+  {
+    // Fallback: guide not yet available (sync off); derive from rule geometry in UCS.
+    get_harmony_nodes(old_rule, p->anchor_hue, NULL, 0, node_angles, &num_nodes);
+    for(int i = 0; i < num_nodes; i++) p->custom_hue[i] = node_angles[i];
+  }
+  else
+  {
+    for(int i = 0; i < num_nodes && i < COLORHARMONIZER_MAX_NODES; i++)
+      p->custom_hue[i] = _ryb_to_ucs_fast(node_angles[i]);
+  }
+
+  p->num_custom_nodes = CLAMP(num_nodes, 2, COLORHARMONIZER_MAX_NODES);
+  if(num_nodes < 2) p->custom_hue[1] = p->custom_hue[0]; // monochromatic fallback
+
+  ++darktable.gui->reset;
+  dt_bauhaus_slider_set(g->num_custom_nodes_slider, p->num_custom_nodes);
+  --darktable.gui->reset;
+}
+
+// Update widget visibility based on current mode (custom vs. predefined) and node count.
+static void _update_visibility(dt_iop_colorharmonizer_gui_data_t *g,
+                               dt_iop_colorharmonizer_params_t *p,
+                               gboolean is_custom)
+{
+  gtk_widget_set_visible(g->anchor_hue, !is_custom);
+  gtk_widget_set_visible(g->swatches_area, !is_custom);
+  gtk_widget_set_visible(g->num_custom_nodes_slider, is_custom);
+
+  int num_nodes = 0;
+
+  if(is_custom)
+  {
+    num_nodes = CLAMP(p->num_custom_nodes, 2, COLORHARMONIZER_MAX_NODES);
+    for(int i = 0; i < COLORHARMONIZER_MAX_NODES; i++)
+      gtk_widget_set_visible(g->custom_row[i], i < num_nodes);
+  }
+  else
+  {
+    for(int i = 0; i < COLORHARMONIZER_MAX_NODES; i++)
+      gtk_widget_set_visible(g->custom_row[i], FALSE);
+
+    float nodes[COLORHARMONIZER_MAX_NODES];
+    get_harmony_nodes(p->rule, p->anchor_hue, NULL, COLORHARMONIZER_MAX_NODES, nodes, &num_nodes);
+    for(int i = 0; i < COLORHARMONIZER_MAX_NODES; i++)
+      gtk_widget_set_visible(g->node_swatch[i], i < num_nodes);
+  }
+
+  for(int i = 0; i < COLORHARMONIZER_MAX_NODES; i++)
+    gtk_widget_set_visible(g->sat_row[i], i < num_nodes);
+}
+
+// Sync custom hue slider display values from params.
+static void _sync_custom_sliders(dt_iop_colorharmonizer_gui_data_t *g,
+                                  dt_iop_colorharmonizer_params_t *p)
+{
+  ++darktable.gui->reset;
+  for(int i = 0; i < COLORHARMONIZER_MAX_NODES; i++)
+    dt_bauhaus_slider_set(g->custom_hue_slider[i], _ucs_to_ryb_fast(p->custom_hue[i]) * 360.0f);
+  --darktable.gui->reset;
+}
+
+// Push the current harmony to the vectorscope if sync is enabled and the changed
+// widget is one that affects the harmony guide (rule, hue sliders, or full refresh).
+static void _sync_vectorscope_if_enabled(dt_iop_module_t *self,
+                                          dt_iop_colorharmonizer_gui_data_t *g,
+                                          GtkWidget *widget)
+{
+  if(!g->sync_to_vectorscope
+     || !gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(g->sync_to_vectorscope)))
+    return;
+
+  if(self->enabled)
+  {
+    gboolean is_hue_widget = (widget == g->anchor_hue);
+    if(!is_hue_widget)
+      for(int i = 0; i < COLORHARMONIZER_MAX_NODES; i++)
+        if(widget == g->custom_hue_slider[i]) { is_hue_widget = TRUE; break; }
+
+    if(!widget || widget == g->rule || is_hue_widget || widget == g->num_custom_nodes_slider)
+    {
+      if(!widget) dt_iop_request_focus(self);
+      _push_to_vectorscope(self);
+    }
+  }
+}
+
+void gui_changed(dt_iop_module_t *self, GtkWidget *widget, void *previous)
+{
+  dt_iop_colorharmonizer_gui_data_t *g = self->gui_data;
+  if(!g) return;
+
+  dt_iop_colorharmonizer_params_t *p = self->params;
+  const gboolean is_custom = (p->rule == DT_COLORHARMONIZER_CUSTOM);
+
+  // When switching to custom mode, seed the nodes from the current vectorscope guide.
+  if(widget == g->rule && is_custom && previous)
+  {
+    const dt_iop_colorharmonizer_rule_t old_rule = *(dt_iop_colorharmonizer_rule_t *)previous;
+    if(old_rule != DT_COLORHARMONIZER_CUSTOM)
+      _init_custom_nodes_from_rule(self, g, p, old_rule);
+  }
+
+  _update_visibility(g, p, is_custom);
+
+  for(int i = 0; i < COLORHARMONIZER_MAX_NODES; i++)
+  {
+    gtk_widget_queue_draw(g->node_swatch[i]);
+    gtk_widget_queue_draw(g->custom_swatch[i]);
+  }
+
+  if(is_custom)
+    _sync_custom_sliders(g, p);
+
+  _paint_all_hue_sliders(g);
+  _paint_all_sat_sliders(g, p);
+  _sync_vectorscope_if_enabled(self, g, widget);
+}
+
+void gui_update(dt_iop_module_t *self)
+{
+  dt_iop_colorharmonizer_gui_data_t *g = self->gui_data;
+  dt_iop_colorharmonizer_params_t *p = self->params;
+
+  // _from_params sliders/combos (rule, pull_strength, pull_width, neutral_protection,
+  // smoothing, num_custom_nodes) auto-sync before gui_update() is called; only custom
+  // widgets that need coordinate conversion or aren't _from_params need manual sync.
+  ++darktable.gui->reset;
+  dt_bauhaus_slider_set(g->anchor_hue, _ucs_to_ryb_fast(p->anchor_hue) * 360.0f);
+  for(int i = 0; i < COLORHARMONIZER_MAX_NODES; i++)
+  {
+    dt_bauhaus_slider_set(g->custom_hue_slider[i], _ucs_to_ryb_fast(p->custom_hue[i]) * 360.0f);
+    dt_bauhaus_slider_set(g->sat_slider[i], p->node_saturation[i]);
+  }
+  --darktable.gui->reset;
+
+  dt_gui_update_collapsible_section(&g->sat_section);
+  gui_changed(self, NULL, NULL);
+  dt_iop_color_picker_reset(self, TRUE);
+}
+
+// Convert a picked pixel color (pipeline RGB) to a normalized darktable UCS hue [0, 1).
+// Returns FALSE only if the work profile is unavailable.
+static gboolean _picked_color_to_hue(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, float *out_hue)
+{
+  const dt_iop_order_iccprofile_info_t *const work_profile = pipe->work_profile_info;
+  if(!work_profile) return FALSE;
+
+  dt_aligned_pixel_t px_rgb, px_xyz;
+  for(int c = 0; c < 3; c++) px_rgb[c] = fmaxf(self->picked_color[c], 0.0f);
+  px_rgb[3] = 0.0f;
+
+  const float (*const matrix_in)[4] = (const float (*)[4])work_profile->matrix_in;
+  px_xyz[0] = matrix_in[0][0]*px_rgb[0] + matrix_in[0][1]*px_rgb[1] + matrix_in[0][2]*px_rgb[2];
+  px_xyz[1] = matrix_in[1][0]*px_rgb[0] + matrix_in[1][1]*px_rgb[1] + matrix_in[1][2]*px_rgb[2];
+  px_xyz[2] = matrix_in[2][0]*px_rgb[0] + matrix_in[2][1]*px_rgb[1] + matrix_in[2][2]*px_rgb[2];
+  px_xyz[3] = 0.0f;
+
+  const float L_white = Y_to_dt_UCS_L_star(1.0f);
+  dt_aligned_pixel_t px_xyz_d65, px_xyY, px_JCH;
+  XYZ_D50_to_D65(px_xyz, px_xyz_d65);
+  dt_D65_XYZ_to_xyY(px_xyz_d65, px_xyY);
+  xyY_to_dt_UCS_JCH(px_xyY, L_white, px_JCH);
+
+  *out_hue = (px_JCH[2] + M_PI_F) / (2.f * M_PI_F);
+  return TRUE;
+}
+
+void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpipe_t *pipe)
+{
+  dt_iop_colorharmonizer_gui_data_t *g = self->gui_data;
+  dt_iop_colorharmonizer_params_t *p = self->params;
+
+  float hue = 0.0f;
+  if(!_picked_color_to_hue(self, pipe, &hue)) return;
+
+  if(picker == g->anchor_hue)
+  {
+    p->anchor_hue = hue;
+    ++darktable.gui->reset;
+    dt_bauhaus_slider_set(g->anchor_hue, _ucs_to_ryb_fast(hue) * 360.0f);
+    --darktable.gui->reset;
+
+    for(int i = 0; i < COLORHARMONIZER_MAX_NODES; i++)
+    {
+      gtk_widget_queue_draw(g->custom_swatch[i]);
+      gtk_widget_queue_draw(g->node_swatch[i]);
+    }
+
+    dt_dev_add_history_item(self->dev, self, TRUE);
+    gui_changed(self, g->anchor_hue, NULL);
+    return;
+  }
+
+  for(int i = 0; i < COLORHARMONIZER_MAX_NODES; i++)
+  {
+    if(picker == g->custom_hue_slider[i])
+    {
+      p->custom_hue[i] = hue;
+      ++darktable.gui->reset;
+      dt_bauhaus_slider_set(g->custom_hue_slider[i], _ucs_to_ryb_fast(hue) * 360.0f);
+      --darktable.gui->reset;
+      gtk_widget_queue_draw(g->custom_swatch[i]);
+      dt_dev_add_history_item(self->dev, self, TRUE);
+      gui_changed(self, g->custom_hue_slider[i], NULL);
+      return;
+    }
+  }
+}
+
+// Score how well a rule+anchor covers the image's hue histogram.
+// Returns a coverage fraction in [0,1]: the fraction of chromatic energy that
+// falls within the Gaussian attraction zones of the harmony nodes.
+// Uses the same sigma formula as the main algorithm (pull_width_factor = 1.0).
+static float _score_harmony(const float *histo, int num_bins,
+                              dt_iop_colorharmonizer_rule_t rule, float anchor_hue)
+{
+  float nodes[COLORHARMONIZER_MAX_NODES];
+  int num_nodes = 1;
+  get_harmony_nodes(rule, anchor_hue, NULL, COLORHARMONIZER_MAX_NODES, nodes, &num_nodes);
+
+  if(num_nodes <= 0) return 0.0f;
+  const float sigma = 0.5f / (float)num_nodes;
+  const float inv_2sigma2 = 1.0f / (2.0f * sigma * sigma);
+
+  float total   = 0.0f;
+  float covered = 0.0f;
+
+  for(int b = 0; b < num_bins; b++)
+  {
+    if(histo[b] <= 0.0f) continue;
+    const float h = (b + 0.5f) / (float)num_bins;
+
+    float max_w = 0.0f;
+    for(int i = 0; i < num_nodes; i++)
+    {
+      float d = fabsf(h - nodes[i]);
+      if(d > 0.5f) d = 1.0f - d;
+      const float w = expf(-d * d * inv_2sigma2);
+      if(w > max_w) max_w = w;
+    }
+
+    covered += histo[b] * max_w;
+    total   += histo[b];
+  }
+
+  return (total > 1e-6f) ? (covered / total) : 0.0f;
+}
+
+// Analyse a chroma-weighted hue histogram and return the harmony rule and
+// anchor hue that best explain the existing color distribution (i.e. the
+// combination that already covers the most chromatic energy).
+static void _auto_detect_harmony(const float *histo, int num_bins,
+                                  dt_iop_colorharmonizer_rule_t *best_rule,
+                                  float *best_anchor)
+{
+  // Smooth the histogram with three passes of a circular box filter to
+  // suppress noise from individual pixels before scoring.
+  float smooth[COLORHARMONIZER_HUE_BINS];
+  memcpy(smooth, histo, num_bins * sizeof(float));
+  for(int pass = 0; pass < 3; pass++)
+  {
+    float tmp[COLORHARMONIZER_HUE_BINS];
+    for(int b = 0; b < num_bins; b++)
+    {
+      const int prev = (b - 1 + num_bins) % num_bins;
+      const int next = (b + 1) % num_bins;
+      tmp[b] = (smooth[prev] + smooth[b] + smooth[next]) * (1.0f / 3.0f);
+    }
+    memcpy(smooth, tmp, num_bins * sizeof(float));
+  }
+
+  float best_score = -1.0f;
+  *best_rule   = DT_COLORHARMONIZER_COMPLEMENTARY;
+  *best_anchor = 0.0f;
+
+  // Only test predefined (non-custom) rules
+  const int num_rules = DT_COLORHARMONIZER_SQUARE + 1;
+  const int num_steps = 360; // 1° resolution — 9 × 360 = 3240 combinations, still fast
+
+  for(int r = 0; r < num_rules; r++)
+  {
+    for(int a = 0; a < num_steps; a++)
+    {
+      const float anchor = (float)a / (float)num_steps;
+      const float score  = _score_harmony(smooth, num_bins,
+                                          (dt_iop_colorharmonizer_rule_t)r, anchor);
+      if(score > best_score)
+      {
+        best_score   = score;
+        *best_rule   = (dt_iop_colorharmonizer_rule_t)r;
+        *best_anchor = anchor;
+      }
+    }
+  }
+}
+
+static void _auto_detect_callback(GtkButton *button, dt_iop_module_t *self)
+{
+  dt_iop_colorharmonizer_gui_data_t *g = self->gui_data;
+  dt_iop_colorharmonizer_params_t   *p = self->params;
+
+  g_mutex_lock(&g->histogram_lock);
+  if(!g->histogram_valid)
+  {
+    g_mutex_unlock(&g->histogram_lock);
+    dt_control_log(_("no histogram available yet — wait for the preview to finish processing"));
+    return;
+  }
+  float histo[COLORHARMONIZER_HUE_BINS];
+  memcpy(histo, g->hue_histogram, sizeof(histo));
+  g_mutex_unlock(&g->histogram_lock);
+
+  dt_iop_colorharmonizer_rule_t best_rule;
+  float best_anchor;
+  _auto_detect_harmony(histo, COLORHARMONIZER_HUE_BINS, &best_rule, &best_anchor);
+
+  p->rule       = best_rule;
+  p->anchor_hue = best_anchor;
+
+  ++darktable.gui->reset;
+  dt_bauhaus_combobox_set(g->rule, p->rule);
+  dt_bauhaus_slider_set(g->anchor_hue, _ucs_to_ryb_fast(p->anchor_hue) * 360.0f);
+  --darktable.gui->reset;
+
+  gui_changed(self, NULL, NULL);
+  dt_dev_add_history_item(self->dev, self, TRUE);
+
+  if(g->sync_to_vectorscope
+     && gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(g->sync_to_vectorscope)))
+    _push_to_vectorscope(self);
+}
+
+static void _set_from_vectorscope_callback(GtkButton *button, dt_iop_module_t *self)
+{
+  dt_color_harmony_guide_t guide;
+
+  dt_lib_histogram_get_harmony(darktable.lib, &guide);
+
+  if(guide.type != DT_COLOR_HARMONY_NONE)
+    _apply_harmony_guide(self, self->params, self->gui_data, &guide);
+
+  // select vectorscope in histogram view
+  dt_lib_histogram_set_scope(darktable.lib, 0); // 0 = DT_LIB_HISTOGRAM_SCOPE_VECTORSCOPE
+}
+
+// Create a colored hue swatch (24×24 drawing area) with the standard draw callback.
+static GtkWidget *_create_swatch(int index, dt_iop_module_t *self)
+{
+  GtkWidget *swatch = gtk_drawing_area_new();
+  gtk_widget_set_size_request(swatch, DT_PIXEL_APPLY_DPI(24), DT_PIXEL_APPLY_DPI(24));
+  g_object_set_data(G_OBJECT(swatch), "swatch-index", GINT_TO_POINTER(index));
+  g_signal_connect(G_OBJECT(swatch), "draw", G_CALLBACK(_swatch_draw_callback), self);
+  return swatch;
+}
+
+void gui_init(dt_iop_module_t *self)
+{
+  dt_iop_colorharmonizer_gui_data_t *g = IOP_GUI_ALLOC(colorharmonizer);
+  GtkWidget *main_box = self->widget = dt_gui_vbox();
+
+  GtkWidget *rule_row = dt_gui_hbox();
+  dt_gui_box_add(self->widget, rule_row);
+  self->widget = rule_row;
+  g->rule = dt_bauhaus_combobox_from_params(self, "rule");
+  gtk_widget_set_hexpand(g->rule, TRUE);
+  self->widget = main_box;
+
+  g->auto_detect = dtgtk_button_new(dtgtk_cairo_paint_camera, CPF_NONE, NULL);
+  gtk_widget_set_tooltip_text(g->auto_detect,
+    _("analyze the image's hue distribution and automatically suggest the harmony rule\n"
+      "and anchor hue that best match its existing color palette.\n"
+      "\n"
+      "the detection scores every rule and anchor combination against a chroma-weighted\n"
+      "histogram of the preview image, then selects the combination that already covers\n"
+      "the most chromatic energy — i.e. requires the least correction.\n"
+      "\n"
+      "the result replaces the current rule and anchor hue. use pull strength to control\n"
+      "how strongly the remaining off-palette colors are pulled toward the detected palette."));
+  g_signal_connect(G_OBJECT(g->auto_detect), "clicked", G_CALLBACK(_auto_detect_callback), self);
+  dt_gui_box_add(rule_row, g->auto_detect);
+
+  gtk_widget_set_tooltip_text(g->rule,
+    _("harmony rule that defines which hues are considered 'in harmony'.\n"
+      "\n"
+      "monochromatic: a single hue family — only one node.\n"
+      "analogous: three adjacent hues spaced 30° apart — naturalistic, cohesive.\n"
+      "analogous complementary: analogous triad plus its complement — rich but balanced.\n"
+      "complementary: two hues opposite on the wheel — high contrast, vibrant.\n"
+      "split complementary: one hue and the two hues flanking its complement — vivid yet less stark.\n"
+      "dyad: two hues separated by 60° — gentle contrast.\n"
+      "triad: three hues evenly spaced 120° apart — balanced, colorful.\n"
+      "tetrad: four hues in two complementary pairs spaced 60° — complex, needs restraint.\n"
+      "square: four hues evenly spaced 90° apart — strong and varied.\n"
+      "custom: define all four harmony node hues independently."));
+
+  {
+    GtkWidget *slider = dt_bauhaus_slider_new_with_range(self, 0.0f, 360.0f, 0.5f, 0.0f, 1);
+    dt_bauhaus_widget_set_label(slider, NULL, N_("anchor hue"));
+    dt_bauhaus_slider_set_feedback(slider, 0);
+    dt_bauhaus_slider_set_format(slider, "°");
+    dt_bauhaus_slider_set_digits(slider, 1);
+    g_signal_connect(G_OBJECT(slider), "value-changed",
+                     G_CALLBACK(_anchor_hue_slider_changed), self);
+    g->anchor_hue = dt_color_picker_new(self, DT_COLOR_PICKER_POINT_AREA, slider);
+    dt_bauhaus_widget_set_quad_tooltip(g->anchor_hue,
+      _("pick hue from image.\n"
+        "ctrl+click to select an area"));
+    gtk_widget_set_tooltip_text(g->anchor_hue,
+      _("the primary 'key' hue of the harmony — the first node from which all others are derived.\n"
+        "\n"
+        "drag the slider or use the color picker (eyedropper) to sample a dominant hue directly\n"
+        "from the image. the remaining harmony nodes are computed automatically from this hue\n"
+        "and the selected rule.\n"
+        "\n"
+        "tip: pick a skin tone, a sky, or another dominant subject color to anchor the palette."));
+    dt_gui_box_add(self->widget, g->anchor_hue);
+  }
+
+  // Node count slider — shown in custom mode only; placed before swatches/rows so it
+  // controls how many are visible.
+  g->num_custom_nodes_slider = dt_bauhaus_slider_from_params(self, "num_custom_nodes");
+  dt_bauhaus_slider_set_digits(g->num_custom_nodes_slider, 0);
+  gtk_widget_set_tooltip_text(g->num_custom_nodes_slider,
+    _("number of active harmony nodes in custom mode (2–4).\n"
+      "nodes are numbered from the top; inactive nodes are hidden."));
+
+  // Horizontal swatches area — shown in non-custom mode (read-only node colors)
+  g->swatches_area = dt_gui_hbox();
+  for(int i = 0; i < COLORHARMONIZER_MAX_NODES; i++)
+  {
+    g->node_swatch[i] = _create_swatch(i, self);
+    gtk_widget_set_hexpand(g->node_swatch[i], TRUE);
+    dt_gui_box_add(g->swatches_area, g->node_swatch[i]);
+  }
+  dt_gui_box_add(self->widget, g->swatches_area);
+
+  // Vertical swatch rows — one per harmony node (max 4), shown in custom mode only
+  for(int i = 0; i < COLORHARMONIZER_MAX_NODES; i++)
+  {
+    GtkWidget *row = dt_gui_hbox();
+
+    // Color swatch (small square showing the node's hue)
+    g->custom_swatch[i] = _create_swatch(i, self);
+    dt_gui_box_add(row, g->custom_swatch[i]);
+
+    // Hue slider with color picker
+    GtkWidget *slider = dt_bauhaus_slider_new_with_range_and_feedback(
+        self, 0.0f, 360.0f, 0.5f, 0.0f, 1, 0);
+    dt_bauhaus_slider_set_format(slider, "°");
+    g_object_set_data(G_OBJECT(slider), "slider-index", GINT_TO_POINTER(i));
+    g_signal_connect(G_OBJECT(slider), "value-changed",
+                     G_CALLBACK(_custom_hue_changed), self);
+    gtk_widget_set_tooltip_text(slider,
+      _("hue of this harmony node (0°–360°).\n"
+        "only active in 'custom' harmony mode.\n"
+        "use the color picker to sample the desired hue from the image."));
+
+    // Wrap slider with color picker quad button
+    g->custom_hue_slider[i] = dt_color_picker_new(self, DT_COLOR_PICKER_POINT_AREA, slider);
+    dt_bauhaus_widget_set_quad_tooltip(g->custom_hue_slider[i],
+      _("pick hue from image.\n"
+        "ctrl+click to select an area"));
+
+    gtk_widget_set_hexpand(g->custom_hue_slider[i], TRUE);
+    dt_gui_box_add(row, g->custom_hue_slider[i]);
+
+    g->custom_row[i] = row;
+    dt_gui_box_add(self->widget, row);
+  }
+
+  GtkWidget *sync_row = dt_gui_hbox();
+
+  g->sync_to_vectorscope = gtk_check_button_new_with_label(_("vectorscope two-way sync"));
+  gtk_widget_set_tooltip_text(g->sync_to_vectorscope,
+    _("when enabled, the vectorscope harmony overlay is kept in sync with\n"
+      "the harmony rule and anchor hue controls in the module.\n"
+      "disable to adjust the module without disturbing the vectorscope display, and vice-versa."));
+
+  const char *conf_key = "plugins/darkroom/colorharmonizer/sync_to_vectorscope";
+  if(!dt_conf_key_exists(conf_key))
+    dt_conf_set_bool(conf_key, TRUE);
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->sync_to_vectorscope), dt_conf_get_bool(conf_key));
+
+  g_signal_connect(G_OBJECT(g->sync_to_vectorscope), "toggled",
+                   G_CALLBACK(_sync_to_vectorscope_toggled), self);
+
+  if(gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(g->sync_to_vectorscope)))
+    _sync_to_vectorscope_toggled(GTK_TOGGLE_BUTTON(g->sync_to_vectorscope), self);
+
+  g->set_from_vectorscope = dtgtk_button_new(dtgtk_cairo_paint_refresh, CPF_NONE, NULL);
+  gtk_widget_set_tooltip_text(g->set_from_vectorscope,
+    _("import the harmony rule and anchor hue currently displayed in the vectorscope.\n"
+      "also switches the histogram panel to the vectorscope view if it is not already active."));
+  g_signal_connect(G_OBJECT(g->set_from_vectorscope), "clicked",
+                   G_CALLBACK(_set_from_vectorscope_callback), self);
+
+  gtk_widget_set_hexpand(g->sync_to_vectorscope, TRUE);
+  dt_gui_box_add(sync_row, g->sync_to_vectorscope);
+  dt_gui_box_add(sync_row, g->set_from_vectorscope);
+  dt_gui_box_add(self->widget, sync_row);
+
+
+  // "set from vectorscope" is redundant when sync is active; disable it initially
+  // (sync checkbox starts checked, so the button starts insensitive)
+  gtk_widget_set_sensitive(g->set_from_vectorscope,
+      !gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(g->sync_to_vectorscope)));
+
+  g->histogram_valid = FALSE;
+  g_mutex_init(&g->histogram_lock);
+
+  g->pull_strength = dt_bauhaus_slider_from_params(self, "pull_strength");
+  gtk_widget_set_tooltip_text(g->pull_strength,
+    _("how strongly off-harmony hues are pulled toward the nearest harmony node.\n"
+      "\n"
+      "0: no effect — colors are left unchanged.\n"
+      "low values (0.1–0.3): subtle nudge, colors lean toward the palette without\n"
+      "  losing their original character.\n"
+      "high values (0.7–1.0): aggressive correction, most hues converge noticeably\n"
+      "  onto the harmony nodes.\n"
+      "\n"
+      "the shift is weighted by each pixel's chroma: fully desaturated pixels (grays)\n"
+      "are never affected regardless of this setting."));
+
+  g->pull_width = dt_bauhaus_slider_from_params(self, "pull_width");
+  dt_bauhaus_slider_set_digits(g->pull_width, 2);
+  gtk_widget_set_tooltip_text(g->pull_width,
+    _("controls the angular reach of each harmony node's attraction.\n"
+      "\n"
+      "the attraction is Gaussian — strongest at the node center and tapering smoothly\n"
+      "outward. zone width scales the standard deviation of this Gaussian linearly.\n"
+      "\n"
+      "narrow (< 1): only hues very close to a node are pulled — selective, precise.\n"
+      "  useful when colors are already near-harmonic and need only a gentle correction.\n"
+      "default (1): each node's influence tapers to near-zero at the midpoint between\n"
+      "  adjacent nodes — clean separation with smooth transitions.\n"
+      "wide (> 1): attraction zones overlap — broader, more global hue shift.\n"
+      "  useful for strongly discordant images or when a painterly look is desired."));
+
+  g->neutral_protection = dt_bauhaus_slider_from_params(self, "neutral_protection");
+  dt_bauhaus_slider_set_digits(g->neutral_protection, 2);
+  gtk_widget_set_tooltip_text(g->neutral_protection,
+    _("shields low-chroma (desaturated) colors from the hue correction.\n"
+      "\n"
+      "0: no protection — grays, skin highlights, and muted tones are all shifted.\n"
+      "low values (0.1–0.3): only near-neutral grays are exempted; pastels are still affected.\n"
+      "mid values (0.4–0.6): muted and pastel colors are increasingly spared.\n"
+      "high values (0.7–1.0): only vivid, saturated colors are corrected; everything else\n"
+      "  is left close to its original hue.\n"
+      "\n"
+      "the weighting is smooth and hyperbolic — there is no hard cutoff. protection grows\n"
+      "gradually from zero and the slider response is distributed evenly across its range."));
+
+  g->smoothing = dt_bauhaus_slider_from_params(self, "smoothing");
+  dt_bauhaus_slider_set_digits(g->smoothing, 2);
+  gtk_widget_set_tooltip_text(g->smoothing,
+    _("controls the intensity of smoothing applied to the correction field.\n"
+      "\n"
+      "0: disable smoothing (recommended) — transitions are handled by smooth interpolation\n"
+      "  in hue space, preserving the maximum amount of image detail.\n"
+      "low values (0.1–0.5): subtle spatial averaging to reduce color noise in shadows.\n"
+      "high values (> 1.0): broad spatial blending; creates a soft, painterly look but may\n"
+      "  blur the grading across image edges, causing some visual separation."));
+
+  dt_gui_new_collapsible_section(&g->sat_section,
+                                 "plugins/darkroom/colorharmonizer/expand_saturation",
+                                 _("saturation"),
+                                 GTK_BOX(main_box),
+                                 DT_ACTION(self));
+  self->widget = GTK_WIDGET(g->sat_section.container);
+
+  static const char *sat_labels[] = { N_("hue 1"), N_("hue 2"), N_("hue 3"), N_("hue 4") };
+  for(int i = 0; i < COLORHARMONIZER_MAX_NODES; i++)
+  {
+    GtkWidget *slider = dt_bauhaus_slider_new_with_range(self, 0.0f, 2.0f, 0.01f, 1.0f, 2);
+    dt_bauhaus_widget_set_label(slider, NULL, _(sat_labels[i]));
+    dt_bauhaus_slider_set_factor(slider, 100.f);
+    dt_bauhaus_slider_set_format(slider, "%");
+    dt_bauhaus_slider_set_digits(slider, 0);
+    g_object_set_data(G_OBJECT(slider), "slider-index", GINT_TO_POINTER(i));
+    g_signal_connect(G_OBJECT(slider), "value-changed",
+                     G_CALLBACK(_node_saturation_changed), self);
+    gtk_widget_set_tooltip_text(slider,
+      _("saturation multiplier for colors near this harmony node.\n"
+        "100% = unchanged. below 100% desaturates; above 100% boosts saturation.\n"
+        "the effect is weighted by the pixel's proximity to this node\n"
+        "and respects the 'neutral hue protection' setting."));
+    g->sat_slider[i] = slider;
+    g->sat_row[i] = slider;
+    dt_gui_box_add(self->widget, slider);
+  }
+
+  self->widget = main_box;
+}
+
+void gui_focus(dt_iop_module_t *self, gboolean in)
+{
+  dt_iop_colorharmonizer_gui_data_t *g = self->gui_data;
+  if(!g) return;
+  const gboolean sync = g->sync_to_vectorscope
+      && gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(g->sync_to_vectorscope));
+  if(in)
+  {
+    if(sync && self->enabled)
+      _push_to_vectorscope(self);
+    // Ensure the callback is registered on first focus-in.
+    // darktable.lib is not yet initialized when gui_init runs, so we defer
+    // the initial registration until the module is actually shown.
+    dt_lib_histogram_set_harmony_callback(darktable.lib,
+        sync ? _on_vectorscope_harmony_changed : NULL,
+        sync ? self : NULL);
+  }
+  else
+  {
+    // Unregister while not focused so other modules can register their own callback.
+    dt_lib_histogram_set_harmony_callback(darktable.lib, NULL, NULL);
+  }
+}
+
+void gui_cleanup(dt_iop_module_t *self)
+{
+  dt_iop_colorharmonizer_gui_data_t *g = self->gui_data;
+  if(g)
+  {
+    dt_lib_histogram_set_harmony_callback(darktable.lib, NULL, NULL);
+    g_mutex_clear(&g->histogram_lock);
+  }
+  dt_iop_default_cleanup(self);
+}

--- a/src/iop/colorharmonizer.c
+++ b/src/iop/colorharmonizer.c
@@ -49,7 +49,7 @@
 static float s_ucs_to_ryb_lut[COLORHARMONIZER_RYB_INVERSE_STEPS];
 static float s_ryb_to_ucs_lut[COLORHARMONIZER_RYB_INVERSE_STEPS];
 
-DT_MODULE_INTROSPECTION(6, dt_iop_colorharmonizer_params_t)
+DT_MODULE_INTROSPECTION(1, dt_iop_colorharmonizer_params_t)
 
 typedef enum dt_iop_colorharmonizer_rule_t
 {
@@ -111,6 +111,12 @@ typedef struct dt_iop_colorharmonizer_global_data_t
   int kernel_colorharmonizer_apply;
 } dt_iop_colorharmonizer_global_data_t;
 
+static float _ucs_hue_to_ryb_hue(const float ucs_hue);
+static float _ucs_to_ryb_fast(const float ucs);
+static float _ryb_to_ucs_fast(const float yrb);
+static void _sync_custom_sliders(const dt_iop_colorharmonizer_params_t *p,
+                                 dt_iop_colorharmonizer_gui_data_t *g);
+
 const char *name()
 {
   return _("color harmonizer");
@@ -145,129 +151,6 @@ dt_iop_colorspace_type_t default_colorspace(dt_iop_module_t *self,
   return IOP_CS_RGB;
 }
 
-int legacy_params(dt_iop_module_t *self,
-                  const void *const old_params,
-                  const int old_version,
-                  void **new_params,
-                  int32_t *new_params_size,
-                  int *new_version)
-{
-  if(old_version == 2)
-  {
-    typedef struct
-    {
-      dt_iop_colorharmonizer_rule_t rule;
-      float anchor_hue;
-      float pull_strength;
-      float neutral_protection;
-      float pull_width;
-    } v2_params_t;
-
-    typedef struct
-    {
-      dt_iop_colorharmonizer_rule_t rule;
-      float anchor_hue;
-      float pull_strength;
-      float neutral_protection;
-      float pull_width;
-      float custom_hue[4];
-    } v3_params_t;
-
-    const v2_params_t *o = old_params;
-    v3_params_t *n = malloc(sizeof(v3_params_t));
-    if(!n) return 1;
-
-    n->rule            = o->rule;
-    n->anchor_hue      = o->anchor_hue;
-    n->pull_strength = o->pull_strength;
-    n->neutral_protection = o->neutral_protection;
-    n->pull_width      = o->pull_width;
-    n->custom_hue[0]   = 0.0f;
-    n->custom_hue[1]   = 0.25f;
-    n->custom_hue[2]   = 0.5f;
-    n->custom_hue[3]   = 0.75f;
-
-    *new_params      = n;
-    *new_params_size = sizeof(v3_params_t);
-    *new_version     = 3;
-    return 0;
-  }
-  if(old_version == 3)
-  {
-    typedef struct
-    {
-      dt_iop_colorharmonizer_rule_t rule;
-      float anchor_hue;
-      float pull_strength;
-      float neutral_protection;
-      float pull_width;
-      float custom_hue[4];
-    } v3_params_t;
-
-    const v3_params_t *o = old_params;
-    dt_iop_colorharmonizer_params_t *n = malloc(sizeof(dt_iop_colorharmonizer_params_t));
-    if(!n) return 1;
-
-    n->rule             = o->rule;
-    n->anchor_hue       = o->anchor_hue;
-    n->pull_strength  = o->pull_strength;
-    n->neutral_protection  = o->neutral_protection;
-    n->pull_width       = o->pull_width;
-    for(int i = 0; i < 4; i++) n->custom_hue[i] = o->custom_hue[i];
-    n->num_custom_nodes = 4;
-    for(int i = 0; i < 4; i++) n->node_saturation[i] = 1.0f;
-
-    *new_params      = n;
-    *new_params_size = sizeof(dt_iop_colorharmonizer_params_t);
-    *new_version     = 5;
-    return 0;
-  }
-  if(old_version == 4)
-  {
-    typedef struct
-    {
-      dt_iop_colorharmonizer_rule_t rule;
-      float anchor_hue;
-      float pull_strength;
-      float neutral_protection;
-      float pull_width;
-      float custom_hue[4];
-      int   num_custom_nodes;
-    } v4_params_t;
-
-    const v4_params_t *o = old_params;
-    dt_iop_colorharmonizer_params_t *n = malloc(sizeof(dt_iop_colorharmonizer_params_t));
-    if(!n) return 1;
-
-    n->rule             = o->rule;
-    n->anchor_hue       = o->anchor_hue;
-    n->pull_strength  = o->pull_strength;
-    n->neutral_protection  = o->neutral_protection;
-    n->pull_width       = o->pull_width;
-    for(int i = 0; i < 4; i++) n->custom_hue[i] = o->custom_hue[i];
-    n->num_custom_nodes = o->num_custom_nodes;
-    for(int i = 0; i < 4; i++) n->node_saturation[i] = 1.0f;
-
-    *new_params      = n;
-    *new_params_size = sizeof(dt_iop_colorharmonizer_params_t);
-    *new_version     = 5;
-    return 0;
-  }
-  if(old_version == 5)
-  {
-    dt_iop_colorharmonizer_params_t *n = malloc(sizeof(dt_iop_colorharmonizer_params_t));
-    if(!n) return 1;
-    memcpy(n, old_params, sizeof(dt_iop_colorharmonizer_params_t) - sizeof(float));
-    n->smoothing = 0.0f;
-
-    *new_params      = n;
-    *new_params_size = sizeof(dt_iop_colorharmonizer_params_t);
-    *new_version     = 6;
-    return 0;
-  }
-  return 1;
-}
-
 // Compute a hue shift toward the nearest harmony node, scaled by Gaussian proximity.
 //
 // We use the nearest-node's angular difference (diff_winning) multiplied by
@@ -281,9 +164,12 @@ int legacy_params(dt_iop_module_t *self,
 //   Default zone (1):  Gaussian tapers to ~14 % at the midpoint between nodes.
 //   Wide zone   (> 1): Gaussian stays high across the full hue circle → broad,
 //                       global correction; all hues are pulled noticeably.
-static inline float get_weighted_hue_shift(float px_hue, const float *nodes, int num_nodes,
-                                           float pull_width_factor,
-                                           int *out_winning_idx, float *out_max_weight)
+static inline float get_weighted_hue_shift(const float px_hue,
+                                           const float *nodes,
+                                           const int num_nodes,
+                                           const float pull_width_factor,
+                                           int *out_winning_idx,
+                                           float *out_max_weight)
 {
   if(num_nodes <= 0)
   {
@@ -328,16 +214,13 @@ static inline float wrap_hue(float h)
   return h;
 }
 
-// Forward declarations: defined later in the file, needed here for get_harmony_nodes.
-static float _ucs_hue_to_ryb_hue(float ucs_hue);
-static float _ucs_to_ryb_fast(float ucs);
-static float _ryb_to_ucs_fast(float yrb);
 // Compute harmony node positions in UCS hue space [0,1).
 // For predefined rules the geometry comes from dt_color_harmony_get_sector_angles()
 // (color_harmony.h) so that the nodes used for processing are exactly aligned
 // with the guide overlay shown in the vectorscope.
-static inline void get_harmony_nodes(dt_iop_colorharmonizer_rule_t rule, float anchor_hue,
-                                     const float *custom_hue, int custom_n,
+static inline void get_harmony_nodes(const dt_iop_colorharmonizer_rule_t rule,
+                                     const float anchor_hue,
+                                     const float *custom_hue, const int custom_n,
                                      float *nodes, int *num_nodes)
 {
   if(rule == DT_COLORHARMONIZER_CUSTOM)
@@ -372,7 +255,10 @@ void commit_params(dt_iop_module_t *self,
                     d->nodes, &d->num_nodes);
 }
 
-static void _update_histogram(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const float *ivoid, const dt_iop_roi_t *roi_in)
+static void _update_histogram(dt_iop_module_t *self,
+                              dt_dev_pixelpipe_iop_t *piece,
+                              const float *ivoid,
+                              const dt_iop_roi_t *roi_in)
 {
   if(!self->gui_data || !((piece->pipe->type & DT_DEV_PIXELPIPE_PREVIEW) == DT_DEV_PIXELPIPE_PREVIEW))
     return;
@@ -599,19 +485,23 @@ void cleanup(dt_iop_module_t *self)
   dt_iop_default_cleanup(self);
 }
 
-void init_pipe(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
+void init_pipe(dt_iop_module_t *self,
+               dt_dev_pixelpipe_t *pipe,
+               dt_dev_pixelpipe_iop_t *piece)
 {
   piece->data = calloc(1, sizeof(dt_iop_colorharmonizer_data_t));
 }
 
-void cleanup_pipe(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
+void cleanup_pipe(dt_iop_module_t *self,
+                  dt_dev_pixelpipe_t *pipe,
+                  dt_dev_pixelpipe_iop_t *piece)
 {
   free(piece->data);
   piece->data = NULL;
 }
 
 // Linearly interpolate between two hue values on the circle, returning a result in [0,1).
-static inline float _hue_lerp(float a, float b, float t)
+static inline float _hue_lerp(float a, float b, const float t)
 {
   if(b - a >  0.5f) b -= 1.0f;
   else if(a - b >  0.5f) a -= 1.0f;
@@ -621,7 +511,7 @@ static inline float _hue_lerp(float a, float b, float t)
 }
 
 // O(1) UCS→RYB lookup with linear interpolation between table entries.
-static inline float _ucs_to_ryb_fast(float ucs)
+static inline float _ucs_to_ryb_fast(const float ucs)
 {
   const float pos  = ucs * COLORHARMONIZER_RYB_INVERSE_STEPS;
   const int   i0   = (int)pos % COLORHARMONIZER_RYB_INVERSE_STEPS;
@@ -630,7 +520,7 @@ static inline float _ucs_to_ryb_fast(float ucs)
 }
 
 // O(1) RYB→UCS lookup with linear interpolation between table entries.
-static inline float _ryb_to_ucs_fast(float ryb)
+static inline float _ryb_to_ucs_fast(const float ryb)
 {
   const float pos  = ryb * COLORHARMONIZER_RYB_INVERSE_STEPS;
   const int   i0   = (int)pos % COLORHARMONIZER_RYB_INVERSE_STEPS;
@@ -684,7 +574,8 @@ void cleanup_global(dt_iop_module_so_t *self)
 #ifdef HAVE_OPENCL
 int process_cl(dt_iop_module_t *self,
                dt_dev_pixelpipe_iop_t *piece,
-               cl_mem dev_in, cl_mem dev_out,
+               cl_mem dev_in,
+               cl_mem dev_out,
                const dt_iop_roi_t *const roi_in,
                const dt_iop_roi_t *const roi_out)
 {
@@ -792,19 +683,6 @@ error:
 }
 #endif
 
-// Convert a darktable UCS JCH pixel to gamma-corrected sRGB.
-// Chain: JCH → XYZ(D65) → linear sRGB → sRGB gamma
-// Uses the native D65 sRGB matrix; skips the unnecessary D65→D50 adaptation step.
-static inline void _jch_to_srgb(const dt_aligned_pixel_t JCH, const float L_white,
-                                 dt_aligned_pixel_t sRGB)
-{
-  dt_aligned_pixel_t XYZ_D65, linear;
-  dt_UCS_JCH_to_XYZ(JCH, L_white, XYZ_D65);
-  dt_XYZ_to_Rec709_D65(XYZ_D65, linear);
-  for_each_channel(c)
-    sRGB[c] = linear[c] <= 0.0031308f ? 12.92f * linear[c]
-                                      : 1.055f * powf(linear[c], 1.f / 2.4f) - 0.055f;
-}
 
 // Find the maximum sRGB-safe chroma for a UCS hue [0,1) at J = 0.65 (mid-brightness).
 // Uses 16 iterations of binary search; result fits within [0, 1] sRGB without clamping.
@@ -820,7 +698,7 @@ static float _find_max_chroma(const float hue)
     const float C_mid = (C_lo + C_hi) * 0.5f;
     dt_aligned_pixel_t JCH = { J, C_mid, H, 0.f };
     dt_aligned_pixel_t sRGB;
-    _jch_to_srgb(JCH, L_white, sRGB);
+    dt_UCS_JCH_to_sRGB(JCH, L_white, sRGB);
     if(sRGB[0] >= 0.f && sRGB[1] >= 0.f && sRGB[2] >= 0.f
        && sRGB[0] <= 1.f && sRGB[1] <= 1.f && sRGB[2] <= 1.f)
       C_lo = C_mid;
@@ -832,7 +710,10 @@ static float _find_max_chroma(const float hue)
 
 // Render a normalized UCS hue value [0,1) to display sRGB at mid-brightness.
 // Backs off 15% from the gamut boundary so swatches look vivid but not clipped.
-static void _hue_to_srgb(float hue, float *r, float *g, float *b)
+static void _hue_to_srgb(const float hue,
+                         float *r,
+                         float *g,
+                         float *b)
 {
   const float L_white = Y_to_dt_UCS_L_star(1.0f);
   const float H = hue * 2.f * M_PI_F - M_PI_F;
@@ -840,7 +721,7 @@ static void _hue_to_srgb(float hue, float *r, float *g, float *b)
 
   dt_aligned_pixel_t JCH = { J, _find_max_chroma(hue) * 0.85f, H, 0.f };
   dt_aligned_pixel_t sRGB;
-  _jch_to_srgb(JCH, L_white, sRGB);
+  dt_UCS_JCH_to_sRGB(JCH, L_white, sRGB);
   *r = CLAMP(sRGB[0], 0.f, 1.f);
   *g = CLAMP(sRGB[1], 0.f, 1.f);
   *b = CLAMP(sRGB[2], 0.f, 1.f);
@@ -887,7 +768,7 @@ static void _paint_sat_slider(GtkWidget *slider, const float hue)
                                  : C_swatch + (stop - 0.5f) * 2.f * (C_lo - C_swatch);
     dt_aligned_pixel_t JCH = { J, C, H, 0.f };
     dt_aligned_pixel_t sRGB;
-    _jch_to_srgb(JCH, L_white, sRGB);
+    dt_UCS_JCH_to_sRGB(JCH, L_white, sRGB);
     dt_bauhaus_slider_set_stop(slider, stop,
                                CLAMP(sRGB[0], 0.f, 1.f),
                                CLAMP(sRGB[1], 0.f, 1.f),
@@ -897,7 +778,7 @@ static void _paint_sat_slider(GtkWidget *slider, const float hue)
 }
 
 static void _paint_all_sat_sliders(const dt_iop_colorharmonizer_gui_data_t *const g,
-                                    const dt_iop_colorharmonizer_params_t *const p)
+                                   const dt_iop_colorharmonizer_params_t *const p)
 {
   float nodes[COLORHARMONIZER_MAX_NODES];
   int num_nodes = 0;
@@ -919,7 +800,6 @@ static float _ucs_hue_to_ryb_hue(const float ucs_hue)
   dt_RGB_2_HCV(lrgb, HCV);
   return dt_rgb_hue_to_ryb_hue(HCV[0]);
 }
-
 
 static void _push_to_vectorscope(dt_iop_module_t *self)
 {
@@ -961,9 +841,9 @@ static void _anchor_hue_slider_changed(GtkWidget *widget, dt_iop_module_t *self)
 // Apply a vectorscope harmony guide (rule + rotation) to params and refresh the GUI.
 // Precondition: guide->type != DT_COLOR_HARMONY_NONE.
 static void _apply_harmony_guide(dt_iop_module_t *self,
-                                  dt_iop_colorharmonizer_params_t *p,
-                                  dt_iop_colorharmonizer_gui_data_t *g,
-                                  const dt_color_harmony_guide_t *guide)
+                                 dt_iop_colorharmonizer_params_t *p,
+                                 dt_iop_colorharmonizer_gui_data_t *g,
+                                 const dt_color_harmony_guide_t *guide)
 {
   p->rule      = (dt_iop_colorharmonizer_rule_t)(guide->type - 1);
   p->anchor_hue = _ryb_to_ucs_fast(guide->rotation / 360.0f);
@@ -976,9 +856,6 @@ static void _apply_harmony_guide(dt_iop_module_t *self,
   gui_changed(self, NULL, NULL);
   dt_dev_add_history_item(self->dev, self, TRUE);
 }
-
-static void _sync_custom_sliders(dt_iop_colorharmonizer_gui_data_t *g,
-                                  dt_iop_colorharmonizer_params_t *p);
 
 static void _on_vectorscope_harmony_changed(const dt_color_harmony_guide_t *guide, void *user_data)
 {
@@ -996,7 +873,7 @@ static void _on_vectorscope_harmony_changed(const dt_color_harmony_guide_t *guid
     const int n = MIN(guide->custom_n, p->num_custom_nodes);
     for(int i = 0; i < n; i++)
       p->custom_hue[i] = _ryb_to_ucs_fast(guide->custom_angles[i]);
-    _sync_custom_sliders(g, p);
+    _sync_custom_sliders(p, g);
     for(int i = 0; i < COLORHARMONIZER_MAX_NODES; i++)
     {
       gtk_widget_queue_draw(g->custom_swatch[i]);
@@ -1044,7 +921,9 @@ static void _sync_to_vectorscope_toggled(GtkToggleButton *button, dt_iop_module_
     gtk_widget_set_sensitive(g->set_from_vectorscope, !active);
 }
 
-static gboolean _swatch_draw_callback(GtkWidget *widget, cairo_t *cr, gpointer user_data)
+static gboolean _swatch_draw_callback(GtkWidget *widget,
+                                      cairo_t *cr,
+                                      gpointer user_data)
 {
   dt_iop_module_t *self = user_data;
   dt_iop_colorharmonizer_params_t *p = self->params;
@@ -1117,9 +996,9 @@ static void _node_saturation_changed(GtkWidget *widget, dt_iop_module_t *self)
 // Initialize custom nodes when switching from a predefined rule to custom mode.
 // Reads the current vectorscope guide's sector positions and converts them to UCS.
 static void _init_custom_nodes_from_rule(dt_iop_module_t *self,
-                                          dt_iop_colorharmonizer_gui_data_t *g,
-                                          dt_iop_colorharmonizer_params_t *p,
-                                          dt_iop_colorharmonizer_rule_t old_rule)
+                                         const dt_iop_colorharmonizer_rule_t old_rule,
+                                         dt_iop_colorharmonizer_gui_data_t *g,
+                                         dt_iop_colorharmonizer_params_t *p)
 {
   dt_color_harmony_guide_t guide;
   dt_lib_histogram_get_harmony(darktable.lib, &guide);
@@ -1148,9 +1027,9 @@ static void _init_custom_nodes_from_rule(dt_iop_module_t *self,
 }
 
 // Update widget visibility based on current mode (custom vs. predefined) and node count.
-static void _update_visibility(dt_iop_colorharmonizer_gui_data_t *g,
-                               dt_iop_colorharmonizer_params_t *p,
-                               gboolean is_custom)
+static void _update_visibility(const dt_iop_colorharmonizer_params_t *p,
+                               const gboolean is_custom,
+                               dt_iop_colorharmonizer_gui_data_t *g)
 {
   gtk_widget_set_visible(g->anchor_hue, !is_custom);
   gtk_widget_set_visible(g->swatches_area, !is_custom);
@@ -1180,8 +1059,8 @@ static void _update_visibility(dt_iop_colorharmonizer_gui_data_t *g,
 }
 
 // Sync custom hue slider display values from params.
-static void _sync_custom_sliders(dt_iop_colorharmonizer_gui_data_t *g,
-                                  dt_iop_colorharmonizer_params_t *p)
+static void _sync_custom_sliders(const dt_iop_colorharmonizer_params_t *p,
+                                 dt_iop_colorharmonizer_gui_data_t *g)
 {
   ++darktable.gui->reset;
   for(int i = 0; i < COLORHARMONIZER_MAX_NODES; i++)
@@ -1192,8 +1071,8 @@ static void _sync_custom_sliders(dt_iop_colorharmonizer_gui_data_t *g,
 // Push the current harmony to the vectorscope if sync is enabled and the changed
 // widget is one that affects the harmony guide (rule, hue sliders, or full refresh).
 static void _sync_vectorscope_if_enabled(dt_iop_module_t *self,
-                                          dt_iop_colorharmonizer_gui_data_t *g,
-                                          GtkWidget *widget)
+                                         dt_iop_colorharmonizer_gui_data_t *g,
+                                         GtkWidget *widget)
 {
   if(!g->sync_to_vectorscope
      || !gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(g->sync_to_vectorscope)))
@@ -1227,10 +1106,10 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *widget, void *previous)
   {
     const dt_iop_colorharmonizer_rule_t old_rule = *(dt_iop_colorharmonizer_rule_t *)previous;
     if(old_rule != DT_COLORHARMONIZER_CUSTOM)
-      _init_custom_nodes_from_rule(self, g, p, old_rule);
+      _init_custom_nodes_from_rule(self, old_rule, g, p);
   }
 
-  _update_visibility(g, p, is_custom);
+  _update_visibility(p, is_custom, g);
 
   for(int i = 0; i < COLORHARMONIZER_MAX_NODES; i++)
   {
@@ -1239,7 +1118,7 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *widget, void *previous)
   }
 
   if(is_custom)
-    _sync_custom_sliders(g, p);
+    _sync_custom_sliders(p, g);
 
   _paint_all_hue_sliders(g);
   _paint_all_sat_sliders(g, p);
@@ -1270,7 +1149,9 @@ void gui_update(dt_iop_module_t *self)
 
 // Convert a picked pixel color (pipeline RGB) to a normalized darktable UCS hue [0, 1).
 // Returns FALSE only if the work profile is unavailable.
-static gboolean _picked_color_to_hue(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, float *out_hue)
+static gboolean _picked_color_to_hue(dt_iop_module_t *self,
+                                     dt_dev_pixelpipe_t *pipe,
+                                     float *out_hue)
 {
   const dt_iop_order_iccprofile_info_t *const work_profile = pipe->work_profile_info;
   if(!work_profile) return FALSE;
@@ -1295,7 +1176,9 @@ static gboolean _picked_color_to_hue(dt_iop_module_t *self, dt_dev_pixelpipe_t *
   return TRUE;
 }
 
-void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpipe_t *pipe)
+void color_picker_apply(dt_iop_module_t *self,
+                        GtkWidget *picker,
+                        dt_dev_pixelpipe_t *pipe)
 {
   dt_iop_colorharmonizer_gui_data_t *g = self->gui_data;
   dt_iop_colorharmonizer_params_t *p = self->params;
@@ -1341,8 +1224,10 @@ void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpi
 // Returns a coverage fraction in [0,1]: the fraction of chromatic energy that
 // falls within the Gaussian attraction zones of the harmony nodes.
 // Uses the same sigma formula as the main algorithm (pull_width_factor = 1.0).
-static float _score_harmony(const float *histo, int num_bins,
-                              dt_iop_colorharmonizer_rule_t rule, float anchor_hue)
+static float _score_harmony(const float *histo,
+                            const int num_bins,
+                            const dt_iop_colorharmonizer_rule_t rule,
+                            const float anchor_hue)
 {
   float nodes[COLORHARMONIZER_MAX_NODES];
   int num_nodes = 1;
@@ -1379,9 +1264,10 @@ static float _score_harmony(const float *histo, int num_bins,
 // Analyse a chroma-weighted hue histogram and return the harmony rule and
 // anchor hue that best explain the existing color distribution (i.e. the
 // combination that already covers the most chromatic energy).
-static void _auto_detect_harmony(const float *histo, int num_bins,
-                                  dt_iop_colorharmonizer_rule_t *best_rule,
-                                  float *best_anchor)
+static void _auto_detect_harmony(const float *histo,
+                                 const int num_bins,
+                                 dt_iop_colorharmonizer_rule_t *best_rule,
+                                 float *best_anchor)
 {
   // Smooth the histogram with three passes of a circular box filter to
   // suppress noise from individual pixels before scoring.
@@ -1474,7 +1360,7 @@ static void _set_from_vectorscope_callback(GtkButton *button, dt_iop_module_t *s
 }
 
 // Create a colored hue swatch (24×24 drawing area) with the standard draw callback.
-static GtkWidget *_create_swatch(int index, dt_iop_module_t *self)
+static GtkWidget *_create_swatch(dt_iop_module_t *self, const int index)
 {
   GtkWidget *swatch = gtk_drawing_area_new();
   gtk_widget_set_size_request(swatch, DT_PIXEL_APPLY_DPI(24), DT_PIXEL_APPLY_DPI(24));
@@ -1558,7 +1444,7 @@ void gui_init(dt_iop_module_t *self)
   g->swatches_area = dt_gui_hbox();
   for(int i = 0; i < COLORHARMONIZER_MAX_NODES; i++)
   {
-    g->node_swatch[i] = _create_swatch(i, self);
+    g->node_swatch[i] = _create_swatch(self, i);
     gtk_widget_set_hexpand(g->node_swatch[i], TRUE);
     dt_gui_box_add(g->swatches_area, g->node_swatch[i]);
   }
@@ -1570,7 +1456,7 @@ void gui_init(dt_iop_module_t *self)
     GtkWidget *row = dt_gui_hbox();
 
     // Color swatch (small square showing the node's hue)
-    g->custom_swatch[i] = _create_swatch(i, self);
+    g->custom_swatch[i] = _create_swatch(self, i);
     dt_gui_box_add(row, g->custom_swatch[i]);
 
     // Hue slider with color picker

--- a/src/iop/colorharmonizer.c
+++ b/src/iop/colorharmonizer.c
@@ -116,6 +116,7 @@ static float _ucs_to_ryb_fast(const float ucs);
 static float _ryb_to_ucs_fast(const float yrb);
 static void _sync_custom_sliders(const dt_iop_colorharmonizer_params_t *p,
                                  dt_iop_colorharmonizer_gui_data_t *g);
+static gboolean _auto_detect_button_enable_idle(gpointer user_data);
 
 const char *name()
 {
@@ -291,10 +292,17 @@ static void _update_histogram(dt_iop_module_t *self,
     }
   }
 
+  const gboolean was_invalid = !g->histogram_valid;
   g_mutex_lock(&g->histogram_lock);
   memcpy(g->hue_histogram, local_histo, sizeof(local_histo));
   g->histogram_valid = TRUE;
   g_mutex_unlock(&g->histogram_lock);
+
+  if(was_invalid)
+  {
+    g_object_ref(g->auto_detect);
+    gdk_threads_add_idle(_auto_detect_button_enable_idle, g->auto_detect);
+  }
 }
 
 void process(dt_iop_module_t *self,
@@ -1310,19 +1318,31 @@ static void _auto_detect_harmony(const float *histo,
   }
 }
 
+static gboolean _auto_detect_button_enable_idle(gpointer user_data)
+{
+  GtkWidget *btn = GTK_WIDGET(user_data);
+  gtk_widget_set_sensitive(btn, TRUE);
+  gtk_widget_set_tooltip_text(btn,
+    _("analyze the image's hue distribution and automatically suggest the harmony rule\n"
+      "and anchor hue that best match its existing color palette.\n"
+      "\n"
+      "the detection scores every rule and anchor combination against a chroma-weighted\n"
+      "histogram of the preview image, then selects the combination that already covers\n"
+      "the most chromatic energy — i.e. requires the least correction.\n"
+      "\n"
+      "the result replaces the current rule and anchor hue. use pull strength to control\n"
+      "how strongly the remaining off-palette colors are pulled toward the detected palette."));
+  g_object_unref(btn);
+  return G_SOURCE_REMOVE;
+}
+
 static void _auto_detect_callback(GtkButton *button, dt_iop_module_t *self)
 {
   dt_iop_colorharmonizer_gui_data_t *g = self->gui_data;
   dt_iop_colorharmonizer_params_t   *p = self->params;
 
-  g_mutex_lock(&g->histogram_lock);
-  if(!g->histogram_valid)
-  {
-    g_mutex_unlock(&g->histogram_lock);
-    dt_control_log(_("no histogram available yet — wait for the preview to finish processing"));
-    return;
-  }
   float histo[COLORHARMONIZER_HUE_BINS];
+  g_mutex_lock(&g->histogram_lock);
   memcpy(histo, g->hue_histogram, sizeof(histo));
   g_mutex_unlock(&g->histogram_lock);
 
@@ -1382,16 +1402,9 @@ void gui_init(dt_iop_module_t *self)
   self->widget = main_box;
 
   g->auto_detect = dtgtk_button_new(dtgtk_cairo_paint_camera, CPF_NONE, NULL);
+  gtk_widget_set_sensitive(g->auto_detect, FALSE);
   gtk_widget_set_tooltip_text(g->auto_detect,
-    _("analyze the image's hue distribution and automatically suggest the harmony rule\n"
-      "and anchor hue that best match its existing color palette.\n"
-      "\n"
-      "the detection scores every rule and anchor combination against a chroma-weighted\n"
-      "histogram of the preview image, then selects the combination that already covers\n"
-      "the most chromatic energy — i.e. requires the least correction.\n"
-      "\n"
-      "the result replaces the current rule and anchor hue. use pull strength to control\n"
-      "how strongly the remaining off-palette colors are pulled toward the detected palette."));
+    _("not yet available — wait for the preview to finish processing."));
   g_signal_connect(G_OBJECT(g->auto_detect), "clicked", G_CALLBACK(_auto_detect_callback), self);
   dt_gui_box_add(rule_row, g->auto_detect);
 

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -20,6 +20,7 @@
 #include "common/color_picker.h"
 #include "gui/accelerators.h"
 #include "scopes.h"
+#include "scopes/vectorscope.h"
 
 // FIXME: is this used?
 #ifdef GDK_WINDOWING_QUARTZ
@@ -34,16 +35,11 @@ static void _lib_histogram_set_scope(dt_lib_module_t *self, int scope);
 static void _lib_histogram_set_type(dt_lib_module_t *self, int type);
 static void _lib_histogram_set_harmony_callback(dt_lib_module_t *self,
     void (*cb)(const dt_color_harmony_guide_t *, void *), void *user_data);
-static void _lib_histogram_get_sector_angles(dt_lib_module_t *self, dt_color_harmony_type_t type,
-                                             int rotation, float *angles, int *n);
-
-extern void dt_vec_get_harmony(dt_scopes_mode_t *mode, dt_color_harmony_guide_t *guide);
-extern void dt_vec_set_harmony(dt_scopes_mode_t *mode, const dt_color_harmony_guide_t *guide);
-extern void dt_vec_set_vectorscope_type(dt_scopes_mode_t *mode, int type);
-extern void dt_vec_get_sector_angles(dt_color_harmony_type_t type, int rotation,
-                                     float *angles, int *n);
-extern void dt_vec_set_harmony_changed_callback(dt_scopes_mode_t *mode,
-    void (*cb)(const dt_color_harmony_guide_t *, void *), void *user_data);
+static void _lib_histogram_get_sector_angles(dt_lib_module_t *self,
+                                             const dt_color_harmony_type_t type,
+                                             const int rotation,
+                                             float *angles,
+                                             int *n);
 
 static const gchar *rgb_names[DT_SCOPES_RGB_N] =
   { N_("red"),
@@ -897,8 +893,11 @@ static void _lib_histogram_set_type(dt_lib_module_t *self, int type)
   }
 }
 
-static void _lib_histogram_get_sector_angles(dt_lib_module_t *self, dt_color_harmony_type_t type,
-                                             int rotation, float *angles, int *n)
+static void _lib_histogram_get_sector_angles(dt_lib_module_t *self,
+                                             const dt_color_harmony_type_t type,
+                                             const int rotation,
+                                             float *angles,
+                                             int *n)
 {
   dt_vec_get_sector_angles(type, rotation, angles, n);
 }

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -28,6 +28,23 @@
 
 DT_MODULE(1)
 
+static void _lib_histogram_get_harmony(dt_lib_module_t *self, dt_color_harmony_guide_t *guide);
+static void _lib_histogram_set_harmony(dt_lib_module_t *self, const dt_color_harmony_guide_t *guide);
+static void _lib_histogram_set_scope(dt_lib_module_t *self, int scope);
+static void _lib_histogram_set_type(dt_lib_module_t *self, int type);
+static void _lib_histogram_set_harmony_callback(dt_lib_module_t *self,
+    void (*cb)(const dt_color_harmony_guide_t *, void *), void *user_data);
+static void _lib_histogram_get_sector_angles(dt_lib_module_t *self, dt_color_harmony_type_t type,
+                                             int rotation, float *angles, int *n);
+
+extern void dt_vec_get_harmony(dt_scopes_mode_t *mode, dt_color_harmony_guide_t *guide);
+extern void dt_vec_set_harmony(dt_scopes_mode_t *mode, const dt_color_harmony_guide_t *guide);
+extern void dt_vec_set_vectorscope_type(dt_scopes_mode_t *mode, int type);
+extern void dt_vec_get_sector_angles(dt_color_harmony_type_t type, int rotation,
+                                     float *angles, int *n);
+extern void dt_vec_set_harmony_changed_callback(dt_scopes_mode_t *mode,
+    void (*cb)(const dt_color_harmony_guide_t *, void *), void *user_data);
+
 static const gchar *rgb_names[DT_SCOPES_RGB_N] =
   { N_("red"),
     N_("green"),
@@ -647,6 +664,12 @@ void gui_init(dt_lib_module_t *self)
   // FIXME: do need to pass self, or can wrap a callback as a lambda
   darktable.lib->proxy.histogram.module = self;
   darktable.lib->proxy.histogram.process = _scope_process;
+  darktable.lib->proxy.histogram.get_harmony = _lib_histogram_get_harmony;
+  darktable.lib->proxy.histogram.set_harmony = _lib_histogram_set_harmony;
+  darktable.lib->proxy.histogram.set_scope = _lib_histogram_set_scope;
+  darktable.lib->proxy.histogram.set_type = _lib_histogram_set_type;
+  darktable.lib->proxy.histogram.get_sector_angles = _lib_histogram_get_sector_angles;
+  darktable.lib->proxy.histogram.set_harmony_callback = _lib_histogram_set_harmony_callback;
 
   // create widgets
   dt_action_t *dark =
@@ -826,6 +849,58 @@ void gui_cleanup(dt_lib_module_t *self)
 
   dt_free_align(self->data);
   self->data = NULL;
+}
+
+static void _lib_histogram_get_harmony(dt_lib_module_t *self, dt_color_harmony_guide_t *guide)
+{
+  if(self && guide)
+  {
+    dt_scopes_t *s = (dt_scopes_t *)self->data;
+    dt_vec_get_harmony(&s->modes[DT_SCOPES_MODE_VECTORSCOPE], guide);
+  }
+}
+
+static void _lib_histogram_set_harmony(dt_lib_module_t *self, const dt_color_harmony_guide_t *guide)
+{
+  if(self && guide)
+  {
+    dt_scopes_t *s = (dt_scopes_t *)self->data;
+    dt_vec_set_harmony(&s->modes[DT_SCOPES_MODE_VECTORSCOPE], guide);
+  }
+}
+
+static void _lib_histogram_set_harmony_callback(dt_lib_module_t *self,
+    void (*cb)(const dt_color_harmony_guide_t *, void *), void *user_data)
+{
+  if(self)
+  {
+    dt_scopes_t *s = (dt_scopes_t *)self->data;
+    dt_vec_set_harmony_changed_callback(&s->modes[DT_SCOPES_MODE_VECTORSCOPE], cb, user_data);
+  }
+}
+
+static void _lib_histogram_set_scope(dt_lib_module_t *self, int scope)
+{
+  if(self && scope >= 0 && scope < DT_SCOPES_MODE_N)
+  {
+    dt_scopes_t *s = (dt_scopes_t *)self->data;
+    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(s->modes[scope].button_activate), TRUE);
+  }
+}
+
+static void _lib_histogram_set_type(dt_lib_module_t *self, int type)
+{
+  if(self && type >= 0)
+  {
+    dt_scopes_t *s = (dt_scopes_t *)self->data;
+    dt_vec_set_vectorscope_type(&s->modes[DT_SCOPES_MODE_VECTORSCOPE], type);
+  }
+}
+
+static void _lib_histogram_get_sector_angles(dt_lib_module_t *self, dt_color_harmony_type_t type,
+                                             int rotation, float *angles, int *n)
+{
+  dt_vec_get_sector_angles(type, rotation, angles, n);
 }
 
 // clang-format off

--- a/src/libs/lib.c
+++ b/src/libs/lib.c
@@ -1584,8 +1584,11 @@ void dt_lib_histogram_set_type(dt_lib_t *lib, int type)
   lib->proxy.histogram.set_type(lib->proxy.histogram.module, type);
 }
 
-void dt_lib_histogram_get_sector_angles(dt_lib_t *lib, dt_color_harmony_type_t type,
-                                        int rotation, float *angles, int *n)
+void dt_lib_histogram_get_sector_angles(dt_lib_t *lib,
+                                        const dt_color_harmony_type_t type,
+                                        const int rotation,
+                                        float *angles,
+                                        int *n)
 {
   if(n) *n = 0;
   if(!lib || !lib->proxy.histogram.module || !lib->proxy.histogram.get_sector_angles) return;

--- a/src/libs/lib.c
+++ b/src/libs/lib.c
@@ -1518,7 +1518,7 @@ gchar *dt_lib_get_localized_name(const gchar *plugin_name)
 void dt_lib_colorpicker_set_box_area(dt_lib_t *lib,
                                      const dt_pickerbox_t box)
 {
-  if(!lib->proxy.colorpicker.module || !lib->proxy.colorpicker.set_sample_box_area) return;
+  if(!lib || !lib->proxy.colorpicker.module || !lib->proxy.colorpicker.set_sample_box_area) return;
   lib->proxy.colorpicker.set_sample_box_area(lib->proxy.colorpicker.module, box);
   gtk_widget_grab_focus(dt_ui_center(darktable.gui->ui));
 }
@@ -1526,7 +1526,7 @@ void dt_lib_colorpicker_set_box_area(dt_lib_t *lib,
 void dt_lib_colorpicker_set_point(dt_lib_t *lib,
                                   const float pos[2])
 {
-  if(!lib->proxy.colorpicker.module || !lib->proxy.colorpicker.set_sample_point) return;
+  if(!lib || !lib->proxy.colorpicker.module || !lib->proxy.colorpicker.set_sample_point) return;
   lib->proxy.colorpicker.set_sample_point(lib->proxy.colorpicker.module, pos);
   gtk_widget_grab_focus(dt_ui_center(darktable.gui->ui));
 }
@@ -1549,12 +1549,52 @@ void dt_lib_colorpicker_setup(dt_lib_t *lib,
                               const gboolean pick_output)
 
 {
-  if(!lib->proxy.colorpicker.module || !lib->proxy.colorpicker.setup_sample) return;
+  if(!lib || !lib->proxy.colorpicker.module || !lib->proxy.colorpicker.setup_sample) return;
   lib->proxy.colorpicker.setup_sample(lib->proxy.colorpicker.module, denoise, pick_output);
+}
+
+void dt_lib_histogram_get_harmony(dt_lib_t *lib, dt_color_harmony_guide_t *guide)
+{
+  if(!lib || !lib->proxy.histogram.module || !lib->proxy.histogram.get_harmony) return;
+  lib->proxy.histogram.get_harmony(lib->proxy.histogram.module, guide);
+}
+
+void dt_lib_histogram_set_harmony(dt_lib_t *lib, const dt_color_harmony_guide_t *guide)
+{
+  if(!lib || !lib->proxy.histogram.module || !lib->proxy.histogram.set_harmony) return;
+  lib->proxy.histogram.set_harmony(lib->proxy.histogram.module, guide);
+}
+
+void dt_lib_histogram_set_harmony_callback(dt_lib_t *lib,
+    void (*cb)(const dt_color_harmony_guide_t *, void *), void *user_data)
+{
+  if(!lib || !lib->proxy.histogram.module || !lib->proxy.histogram.set_harmony_callback) return;
+  lib->proxy.histogram.set_harmony_callback(lib->proxy.histogram.module, cb, user_data);
+}
+
+void dt_lib_histogram_set_scope(dt_lib_t *lib, int scope)
+{
+  if(!lib || !lib->proxy.histogram.module || !lib->proxy.histogram.set_scope) return;
+  lib->proxy.histogram.set_scope(lib->proxy.histogram.module, scope);
+}
+
+void dt_lib_histogram_set_type(dt_lib_t *lib, int type)
+{
+  if(!lib || !lib->proxy.histogram.module || !lib->proxy.histogram.set_type) return;
+  lib->proxy.histogram.set_type(lib->proxy.histogram.module, type);
+}
+
+void dt_lib_histogram_get_sector_angles(dt_lib_t *lib, dt_color_harmony_type_t type,
+                                        int rotation, float *angles, int *n)
+{
+  if(n) *n = 0;
+  if(!lib || !lib->proxy.histogram.module || !lib->proxy.histogram.get_sector_angles) return;
+  lib->proxy.histogram.get_sector_angles(lib->proxy.histogram.module, type, rotation, angles, n);
 }
 
 dt_lib_module_t *dt_lib_get_module(const char *name)
 {
+  if(!darktable.lib) return NULL;
   /* hide/show modules as last config */
   for(GList *iter = darktable.lib->plugins; iter; iter = g_list_next(iter))
   {

--- a/src/libs/lib.h
+++ b/src/libs/lib.h
@@ -77,9 +77,15 @@ typedef struct dt_lib_t
                       int width, int height,
                       const dt_iop_order_iccprofile_info_t *const profile_info_from,
                       const dt_iop_order_iccprofile_info_t *const profile_info_to);
-      // FIXME: now that PR #5532 is merged, define this as
-      // dt_atomic_int and include "common/atomic.h" and use
-      // dt_atomic_set_int() and dt_atomic_get_int()
+      void (*get_harmony)(struct dt_lib_module_t *self, dt_color_harmony_guide_t *guide);
+      void (*set_harmony)(struct dt_lib_module_t *self, const dt_color_harmony_guide_t *guide);
+      void (*set_scope)(struct dt_lib_module_t *self, int scope);
+      void (*set_type)(struct dt_lib_module_t *self, int type);
+      void (*get_sector_angles)(struct dt_lib_module_t *self, dt_color_harmony_type_t type,
+                                int rotation, float *angles, int *n);
+      void (*set_harmony_callback)(struct dt_lib_module_t *self,
+                                   void (*cb)(const dt_color_harmony_guide_t *, void *),
+                                   void *user_data);
       gboolean is_linear;
     } histogram;
 
@@ -216,6 +222,26 @@ void dt_lib_colorpicker_set_box_area(dt_lib_t *lib,
 /** set the colorpicker point selection tool and position */
 void dt_lib_colorpicker_set_point(dt_lib_t *lib,
                                   const float pos[2]);
+
+/** get the histogram color harmony */
+void dt_lib_histogram_get_harmony(dt_lib_t *lib, dt_color_harmony_guide_t *guide);
+
+/** set the histogram color harmony */
+void dt_lib_histogram_set_harmony(dt_lib_t *lib, const dt_color_harmony_guide_t *guide);
+
+/** register a callback notified on user-driven vectorscope harmony changes */
+void dt_lib_histogram_set_harmony_callback(dt_lib_t *lib,
+    void (*cb)(const dt_color_harmony_guide_t *, void *), void *user_data);
+
+/** set the histogram scope type */
+void dt_lib_histogram_set_scope(dt_lib_t *lib, int scope);
+
+/** set the histogram vectorscope type */
+void dt_lib_histogram_set_type(dt_lib_t *lib, int type);
+
+/** get the absolute RYB sector angles for a predefined harmony type and rotation */
+void dt_lib_histogram_get_sector_angles(dt_lib_t *lib, dt_color_harmony_type_t type,
+                                        int rotation, float *angles, int *n);
 
 /* reset color picker pos to default */
 void dt_lib_colorpicker_reset_box_area(dt_pickerbox_t box);

--- a/src/libs/lib.h
+++ b/src/libs/lib.h
@@ -81,8 +81,11 @@ typedef struct dt_lib_t
       void (*set_harmony)(struct dt_lib_module_t *self, const dt_color_harmony_guide_t *guide);
       void (*set_scope)(struct dt_lib_module_t *self, int scope);
       void (*set_type)(struct dt_lib_module_t *self, int type);
-      void (*get_sector_angles)(struct dt_lib_module_t *self, dt_color_harmony_type_t type,
-                                int rotation, float *angles, int *n);
+      void (*get_sector_angles)(struct dt_lib_module_t *self,
+                                const dt_color_harmony_type_t type,
+                                const int rotation,
+                                float *angles,
+                                int *n);
       void (*set_harmony_callback)(struct dt_lib_module_t *self,
                                    void (*cb)(const dt_color_harmony_guide_t *, void *),
                                    void *user_data);
@@ -240,8 +243,11 @@ void dt_lib_histogram_set_scope(dt_lib_t *lib, int scope);
 void dt_lib_histogram_set_type(dt_lib_t *lib, int type);
 
 /** get the absolute RYB sector angles for a predefined harmony type and rotation */
-void dt_lib_histogram_get_sector_angles(dt_lib_t *lib, dt_color_harmony_type_t type,
-                                        int rotation, float *angles, int *n);
+void dt_lib_histogram_get_sector_angles(dt_lib_t *lib,
+                                        const dt_color_harmony_type_t type,
+                                        const int rotation,
+                                        float *angles,
+                                        int *n);
 
 /* reset color picker pos to default */
 void dt_lib_colorpicker_reset_box_area(dt_pickerbox_t box);

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -1601,6 +1601,7 @@ void init_presets(dt_lib_module_t *self)
   AM("colorout");
   AM("colorzones");
   AM("colorequal");
+  AM("colorharmonizer");
   AM("lut3d");
   AM("monochrome");
   AM("profile");
@@ -1765,6 +1766,7 @@ void init_presets(dt_lib_module_t *self)
   AM("channelmixerrgb");
   AM("colorbalancergb");
   AM("colorequal");
+  AM("colorharmonizer");
   AM("primaries");
 
   SMG(C_("modulegroup", "correct"), "correct");

--- a/src/libs/scopes/vectorscope.c
+++ b/src/libs/scopes/vectorscope.c
@@ -24,6 +24,7 @@
 #include "gui/accelerators.h"
 #include "libs/colorpicker.h"
 #include "scopes.h"
+#include "scopes/vectorscope.h"
 
 // # of gradations between each primary/secondary to draw the hue ring
 // this is tuned to most degenerate cases: curve to blue primary in
@@ -1540,14 +1541,15 @@ void dt_vec_set_harmony(dt_scopes_mode_t *mode, const dt_color_harmony_guide_t *
 }
 
 void dt_vec_set_harmony_changed_callback(dt_scopes_mode_t *mode,
-    void (*cb)(const dt_color_harmony_guide_t *, void *), void *user_data)
+                                         void (*cb)(const dt_color_harmony_guide_t *, void *),
+                                         void *user_data)
 {
   dt_scopes_vec_t *const d = mode->data;
   d->harmony_changed_cb = cb;
   d->harmony_changed_user_data = user_data;
 }
 
-void dt_vec_set_vectorscope_type(dt_scopes_mode_t *mode, int type)
+void dt_vec_set_vectorscope_type(dt_scopes_mode_t *mode, const int type)
 {
   dt_scopes_vec_t *const d = mode->data;
   if(d->vectorscope_type == (dt_scopes_vec_vectorscope_type_t)type) return;
@@ -1560,8 +1562,10 @@ void dt_vec_set_vectorscope_type(dt_scopes_mode_t *mode, int type)
 
 // Returns the absolute RYB hue positions (normalized turns [0,1)) of the sectors
 // for the given predefined harmony type and rotation. n is set to the sector count.
-void dt_vec_get_sector_angles(dt_color_harmony_type_t type, int rotation,
-                              float *angles, int *n)
+void dt_vec_get_sector_angles(const dt_color_harmony_type_t type,
+                              const int rotation,
+                              float *angles,
+                              int *n)
 {
   dt_color_harmony_get_sector_angles(type, rotation, angles, n);
 }

--- a/src/libs/scopes/vectorscope.c
+++ b/src/libs/scopes/vectorscope.c
@@ -18,6 +18,7 @@
 
 #include "common/atomic.h"
 #include "common/color_harmony.h"
+#include "common/color_ryb.h"
 #include "common/image_cache.h"
 #include "common/math.h"
 #include "gui/accelerators.h"
@@ -121,6 +122,10 @@ typedef struct dt_scopes_vec_t
   dt_color_harmony_guide_t harmony_guide;
   dt_color_harmony_type_t harmony_prelight;
   dt_color_harmony_type_t ignore_prelight;
+
+  // callback fired on user-driven harmony changes (button click or scroll rotation)
+  void (*harmony_changed_cb)(const dt_color_harmony_guide_t *guide, void *user_data);
+  void *harmony_changed_user_data;
 } dt_scopes_vec_t;
 
 
@@ -139,9 +144,9 @@ const char* _vec_name(const dt_scopes_mode_t *const self)
 // which compresses mainly the cyan colors (while also reversible)
 // https://danielhaim.com/research/downloads/Computational%20RYB%20Color%20Model%20and%20its%20Applications.pdf
 
-const float x_vtx[7] =     {0.0, 0.166667, 0.333333, 0.5, 0.666667, 0.833333, 1.0};
-const float rgb_y_vtx[7] = {0.0, 0.083333, 0.166667, 0.383838, 0.586575, 0.833333, 1.0};
-const float ryb_y_vtx[7] = {0.0, 0.333333, 0.472217, 0.611105, 0.715271, 0.833333, 1.0};
+// x_vtx and ryb_y_vtx are provided by common/color_ryb.h as
+// dt_color_ryb_x_vtx and dt_color_ryb_y_vtx.
+static const float rgb_y_vtx[7] = {0.0, 0.083333, 0.166667, 0.383838, 0.586575, 0.833333, 1.0};
 
 static void _ryb2rgb(const dt_aligned_pixel_t ryb,
                      dt_aligned_pixel_t rgb,
@@ -149,7 +154,7 @@ static void _ryb2rgb(const dt_aligned_pixel_t ryb,
 {
   dt_aligned_pixel_t HSV;
   dt_RGB_2_HSV(ryb, HSV);
-  HSV[0] = interpolate_val(sizeof(x_vtx)/sizeof(float), (float *)x_vtx, HSV[0],
+  HSV[0] = interpolate_val(sizeof(dt_color_ryb_x_vtx)/sizeof(float), (float *)dt_color_ryb_x_vtx, HSV[0],
                            (float *)rgb_y_vtx, (float *)ryb2rgb_ypp, CUBIC_SPLINE);
   dt_HSV_2_RGB(HSV, rgb);
 }
@@ -160,8 +165,8 @@ static void _rgb2ryb(const dt_aligned_pixel_t rgb,
 {
   dt_aligned_pixel_t HSV;
   dt_RGB_2_HSV(rgb, HSV);
-  HSV[0] = interpolate_val(sizeof(x_vtx)/sizeof(float), (float *)x_vtx, HSV[0],
-                           (float *)ryb_y_vtx, (float *)rgb2ryb_ypp, CUBIC_SPLINE);
+  HSV[0] = interpolate_val(sizeof(dt_color_ryb_x_vtx)/sizeof(float), (float *)dt_color_ryb_x_vtx, HSV[0],
+                           (float *)dt_color_ryb_y_vtx, (float *)rgb2ryb_ypp, CUBIC_SPLINE);
   dt_HSV_2_RGB(HSV, ryb);
 }
 
@@ -827,35 +832,57 @@ static void _vec_draw(const dt_scopes_mode_t *const self,
   const gboolean display_live_samples = d->vectorscope_samples
     && darktable.lib->proxy.colorpicker.display_samples;
 
-  // we draw the color harmony guidelines
+  // we draw the color harmony guidelines (only in RYB mode)
+  const gboolean is_ryb = (d->vectorscope_type == DT_SCOPES_VEC_VECTORSCOPE_RYB);
+  const gboolean is_custom_harmony = is_ryb && (d->harmony_guide.custom_n > 0);
   dt_color_harmony_type_t cur_harmony =
-    (d->vectorscope_type == DT_SCOPES_VEC_VECTORSCOPE_RYB
+    (is_ryb
      ? (d->harmony_prelight != DT_COLOR_HARMONY_NONE ? d->harmony_prelight : d->harmony_guide.type)
      : DT_COLOR_HARMONY_NONE);
-  if(cur_harmony)
+  if(cur_harmony || is_custom_harmony)
   {
     cairo_save(cr);
 
     const float hw = dt_scopes_vec_color_harmony_width[d->harmony_guide.width];
     cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(1.));
-    const dt_scopes_vec_color_harmony_t hm = _vec_color_harmonies[cur_harmony];
-    for(int i = 0; i < hm.sectors; i++)
+
+     if(is_custom_harmony)
     {
-      float hr = vs_radius * hm.length[i];
-      if(d->vectorscope_scale == DT_SCOPES_VEC_SCALE_LOGARITHMIC)
-        hr = baselog(hr, vs_radius);
-      const float span1 = (i > 0
-                           ? MIN(hw, (hm.angle[i] - hm.angle[i-1]) / 2.f)
-                           : hw); // avoid sectors overlap
-      const float span2 = (i < hm.sectors - 1
-                           ? MIN(hw, (hm.angle[i+1] - hm.angle[i]) / 2.f)
-                           : hw);
-      const float angle1 =
-        (hm.angle[i] - span1) * 2.f * M_PI_F + deg2radf((float)d->harmony_guide.rotation);
-      const float angle2 =
-        (hm.angle[i] + span2) * 2.f * M_PI_F + deg2radf((float)d->harmony_guide.rotation);
-      cairo_arc(cr, 0., 0., hr * scale, angle1, angle2);
-      cairo_line_to(cr, 0., 0.);
+      // Custom harmony: nodes are at absolute hue positions (normalized turns [0,1)).
+      // Each node gets a fixed-width sector; no rotation offset is applied.
+      const int n = d->harmony_guide.custom_n;
+      for(int i = 0; i < n; i++)
+      {
+        const float center = d->harmony_guide.custom_angles[i] * 2.f * M_PI_F;
+        const float span   = hw * 2.f * M_PI_F;
+        float hr = vs_radius * 0.80f;
+        if(d->vectorscope_scale == DT_SCOPES_VEC_SCALE_LOGARITHMIC)
+          hr = baselog(hr, vs_radius);
+        cairo_arc(cr, 0., 0., hr * scale, center - span, center + span);
+        cairo_line_to(cr, 0., 0.);
+      }
+    }
+    else
+    {
+      const dt_scopes_vec_color_harmony_t hm = _vec_color_harmonies[cur_harmony];
+      for(int i = 0; i < hm.sectors; i++)
+      {
+        float hr = vs_radius * hm.length[i];
+        if(d->vectorscope_scale == DT_SCOPES_VEC_SCALE_LOGARITHMIC)
+          hr = baselog(hr, vs_radius);
+        const float span1 = (i > 0
+                            ? MIN(hw, (hm.angle[i] - hm.angle[i-1]) / 2.f)
+                            : hw); // avoid sectors overlap
+        const float span2 = (i < hm.sectors - 1
+                            ? MIN(hw, (hm.angle[i+1] - hm.angle[i]) / 2.f)
+                            : hw);
+        const float angle1 =
+          (hm.angle[i] - span1) * 2.f * M_PI_F + deg2radf((float)d->harmony_guide.rotation);
+        const float angle2 =
+          (hm.angle[i] + span2) * 2.f * M_PI_F + deg2radf((float)d->harmony_guide.rotation);
+        cairo_arc(cr, 0., 0., hr * scale, angle1, angle2);
+        cairo_line_to(cr, 0., 0.);
+      }
     }
     cairo_close_path(cr);
     cairo_set_source(cr, bkgd_pat);
@@ -882,9 +909,11 @@ static void _vec_draw(const dt_scopes_mode_t *const self,
       graph_pat = cairo_pop_group(cr);
     }
 
-    if(gtk_widget_get_visible(self->scopes->button_box_right))
+    // FIXME: is there a less awkward way to check if the mouse is over this, or could this even be another widget in the overlay?
+    if(!is_custom_harmony && gtk_widget_get_visible(self->scopes->button_box_right))
     {
       // draw information about current selected harmony
+      const dt_scopes_vec_color_harmony_t hm = _vec_color_harmonies[cur_harmony];
       PangoLayout *layout;
       PangoRectangle ink;
       PangoFontDescription *desc =
@@ -1044,10 +1073,12 @@ static void _color_harmony_changed_record(dt_scopes_mode_t *const self)
   const dt_imgid_t imgid = darktable.develop->image_storage.id;
   dt_image_t *img = dt_image_cache_get(imgid, 'w');
   if(img)
+  {
     memcpy(&img->color_harmony_guide,
            &d->harmony_guide,
            sizeof(dt_color_harmony_guide_t));
-  dt_image_cache_write_release_info(img, DT_IMAGE_CACHE_SAFE, "histogram color_harmony_changed_record");
+    dt_image_cache_write_release_info(img, DT_IMAGE_CACHE_SAFE, "histogram color_harmony_changed_record");
+  }
 
   dt_scopes_refresh(self->scopes);
 }
@@ -1056,12 +1087,13 @@ static void _color_harmony_state_changed(GtkWidget *widget,
                                          GtkStateFlags flags,
                                          dt_scopes_mode_t *const self)
 {
+  if(!self || !self->data) return;
   dt_scopes_vec_t *const d = self->data;
   GtkStateFlags new_flags = gtk_widget_get_state_flags(widget);
   const dt_color_harmony_type_t prior = d->harmony_prelight;
   if(new_flags & GTK_STATE_FLAG_PRELIGHT)
   {
-    for(dt_color_harmony_type_t i = DT_COLOR_HARMONY_NONE+1; i < DT_COLOR_HARMONY_N - 1; i++)
+    for(dt_color_harmony_type_t i = DT_COLOR_HARMONY_NONE+1; i < DT_COLOR_HARMONY_N; i++)
       if(d->color_harmony_button[i] == widget && i != d->ignore_prelight)
       {
         d->harmony_prelight = i;
@@ -1075,6 +1107,7 @@ static void _color_harmony_state_changed(GtkWidget *widget,
 static void _color_harmony_toggled(GtkButton *button,
                                    dt_scopes_mode_t *const self)
 {
+  if(!self || !self->data) return;
   // this toggle handler is the way to set d->harmony_guide.type:
   // updating the UI widget will update internal data structures, but
   // not vice versa
@@ -1112,6 +1145,8 @@ static void _color_harmony_toggled(GtkButton *button,
     }
   }
   _color_harmony_changed_record(self);
+  if(d->harmony_changed_cb)
+    d->harmony_changed_cb(&d->harmony_guide, d->harmony_changed_user_data);
 }
 
 static void _vec_append_to_tooltip(const dt_scopes_mode_t *const self,
@@ -1119,7 +1154,7 @@ static void _vec_append_to_tooltip(const dt_scopes_mode_t *const self,
 {
   const dt_scopes_vec_t *const d = self->data;
   if(d->vectorscope_type == DT_SCOPES_VEC_VECTORSCOPE_RYB &&
-     d->harmony_guide.type != DT_COLOR_HARMONY_NONE)
+     (d->harmony_guide.type != DT_COLOR_HARMONY_NONE || d->harmony_guide.custom_n > 0))
     dt_util_str_cat(tip, "\n%s\n%s\n%s\n%s",
                     _("scroll to coarse-rotate"),
                     _("ctrl+scroll to fine rotate"),
@@ -1155,6 +1190,14 @@ static void _vec_eventbox_scroll(dt_scopes_mode_t *const self,
       gtk_toggle_button_set_active
         (GTK_TOGGLE_BUTTON(d->color_harmony_button[new_type]), TRUE);
   }
+  else if(d->harmony_guide.custom_n > 0)
+  {
+    // Custom harmony: rotate all nodes together as a group.
+    const float step = dt_modifier_is(state, GDK_CONTROL_MASK) ? 1.0f / 360.0f : 15.0f / 360.0f;
+    for(int i = 0; i < d->harmony_guide.custom_n; i++)
+      d->harmony_guide.custom_angles[i] =
+        fmodf(d->harmony_guide.custom_angles[i] + delta * step + 1.0f, 1.0f);
+  }
   else
   {
     if(dt_modifier_is(state, GDK_CONTROL_MASK)) // CTRL+SCROLL
@@ -1167,6 +1210,8 @@ static void _vec_eventbox_scroll(dt_scopes_mode_t *const self,
     d->harmony_guide.rotation = (d->harmony_guide.rotation + 360) % 360;
   }
   _color_harmony_changed_record(self);
+  if(d->harmony_changed_cb)
+    d->harmony_changed_cb(&d->harmony_guide, d->harmony_changed_user_data);
 }
 
 static void _harmony_adjust_page(GtkWidget *widget,
@@ -1345,10 +1390,10 @@ static void _vec_gui_init(dt_scopes_mode_t *const self,
   d->vectorscope_samples = NULL;
   d->selected_sample = -1;
 
-  d->rgb2ryb_ypp = interpolate_set(sizeof(x_vtx)/sizeof(float),
-                                   (float *)x_vtx, (float *)ryb_y_vtx, CUBIC_SPLINE);
-  d->ryb2rgb_ypp = interpolate_set(sizeof(x_vtx)/sizeof(float),
-                                   (float *)x_vtx, (float *)rgb_y_vtx, CUBIC_SPLINE);
+  d->rgb2ryb_ypp = interpolate_set(sizeof(dt_color_ryb_x_vtx)/sizeof(float),
+                                   (float *)dt_color_ryb_x_vtx, (float *)dt_color_ryb_y_vtx, CUBIC_SPLINE);
+  d->ryb2rgb_ypp = interpolate_set(sizeof(dt_color_ryb_x_vtx)/sizeof(float),
+                                   (float *)dt_color_ryb_x_vtx, (float *)rgb_y_vtx, CUBIC_SPLINE);
 
   // set the default harmony (last used), the actual harmony for the image
   // will be restored later.
@@ -1464,6 +1509,62 @@ const dt_scopes_functions_t dt_scopes_functions_vectorscope =
   .add_options = _vec_add_options,
   .gui_cleanup = _vec_gui_cleanup
 };
+
+void dt_vec_get_harmony(dt_scopes_mode_t *mode, dt_color_harmony_guide_t *guide)
+{
+  const dt_scopes_vec_t *const d = mode->data;
+  memcpy(guide, &d->harmony_guide, sizeof(dt_color_harmony_guide_t));
+}
+
+void dt_vec_set_harmony(dt_scopes_mode_t *mode, const dt_color_harmony_guide_t *guide)
+{
+  dt_scopes_vec_t *const d = mode->data;
+  const dt_color_harmony_type_t old_type = d->harmony_guide.type;
+  memcpy(&d->harmony_guide, guide, sizeof(dt_color_harmony_guide_t));
+
+  // Deactivate old button (with signal blocking to avoid re-entering _color_harmony_toggled)
+  if(old_type != DT_COLOR_HARMONY_NONE)
+  {
+    g_signal_handler_block(d->color_harmony_button[old_type], d->toggle_signal_handler[old_type]);
+    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->color_harmony_button[old_type]), FALSE);
+    g_signal_handler_unblock(d->color_harmony_button[old_type], d->toggle_signal_handler[old_type]);
+  }
+  // Activate new button
+  if(guide->type != DT_COLOR_HARMONY_NONE)
+  {
+    g_signal_handler_block(d->color_harmony_button[guide->type], d->toggle_signal_handler[guide->type]);
+    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->color_harmony_button[guide->type]), TRUE);
+    g_signal_handler_unblock(d->color_harmony_button[guide->type], d->toggle_signal_handler[guide->type]);
+  }
+  _color_harmony_changed_record(mode);
+}
+
+void dt_vec_set_harmony_changed_callback(dt_scopes_mode_t *mode,
+    void (*cb)(const dt_color_harmony_guide_t *, void *), void *user_data)
+{
+  dt_scopes_vec_t *const d = mode->data;
+  d->harmony_changed_cb = cb;
+  d->harmony_changed_user_data = user_data;
+}
+
+void dt_vec_set_vectorscope_type(dt_scopes_mode_t *mode, int type)
+{
+  dt_scopes_vec_t *const d = mode->data;
+  if(d->vectorscope_type == (dt_scopes_vec_vectorscope_type_t)type) return;
+  d->vectorscope_type = (dt_scopes_vec_vectorscope_type_t)type;
+  dt_conf_set_string("plugins/darkroom/histogram/vectorscope",
+                     dt_scopes_vec_vectorscope_type_names[d->vectorscope_type]);
+  _vec_update_buttons(mode);
+  dt_scopes_reprocess();
+}
+
+// Returns the absolute RYB hue positions (normalized turns [0,1)) of the sectors
+// for the given predefined harmony type and rotation. n is set to the sector count.
+void dt_vec_get_sector_angles(dt_color_harmony_type_t type, int rotation,
+                              float *angles, int *n)
+{
+  dt_color_harmony_get_sector_angles(type, rotation, angles, n);
+}
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/libs/scopes/vectorscope.h
+++ b/src/libs/scopes/vectorscope.h
@@ -1,0 +1,42 @@
+/*
+    This file is part of darktable,
+    Copyright (C) 2026 darktable developers.
+
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    darktable is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include "common/color_harmony.h"
+#include "scopes.h"
+
+void dt_vec_get_harmony(dt_scopes_mode_t *mode,
+                        dt_color_harmony_guide_t *guide);
+void dt_vec_set_harmony(dt_scopes_mode_t *mode,
+                        const dt_color_harmony_guide_t *guide);
+void dt_vec_set_vectorscope_type(dt_scopes_mode_t *mode,
+                                 const int type);
+void dt_vec_get_sector_angles(const dt_color_harmony_type_t type,
+                              const int rotation,
+                              float *angles,
+                              int *n);
+void dt_vec_set_harmony_changed_callback(dt_scopes_mode_t *mode,
+                                         void (*cb)(const dt_color_harmony_guide_t *, void *),
+                                         void *user_data);
+
+// clang-format off
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
+// clang-format on


### PR DESCRIPTION
# Overview
* Adds a new IOP that applies color harmony corrections in UCS color space, rotating hues toward a target harmony structure (complementary, split-complementary, triadic, tetradic, etc.) while protecting neutrals
* GPU-accelerated via OpenCL kernel ([`colorharmonizer.cl`](/masterpiga/darktable/tree/color_harmonizer/data/kernels/colorharmonizer.cl))
* Harmony rules defined by a configurable anchor hue + pull strength, pull width, and smoothing parameters
* Supports a fully custom harmony mode with up to N free-position nodes
* Per-node saturation boosts after hue correction
* RYB color wheel support for perceptually natural hue angles
* Module documentation:
  * [Overview / usage](/masterpiga/darktable/tree/color_harmonizer/dev-doc/iop/colorharmonizer/README.md)
  * [Business logic implementation details](/masterpiga/darktable/tree/color_harmonizer/dev-doc/iop/colorharmonizer/business_logic.md)

# Vectorscope integration
* The colorharmonizer module registers a callback (`_on_vectorscope_harmony_changed`) so dragging the guide in the vectorscope syncs back to the module's params and history
* Histogram proxy extended with harmony get/set/callback API ([`histogram.c`](/masterpiga/darktable/tree/color_harmonizer/src/libs/histogram.c), [`lib.h`](/masterpiga/darktable/tree/color_harmonizer/src/libs/lib.h))

# Pixelpipe position
* Placed before colorbalance, colorequal, and colorbalancergb in all pipeline presets (legacy and scene-referred) — position ~32.5/40.5 — so those modules can fine-tune the harmony output ([`iop_order.c`](/masterpiga/darktable/tree/color_harmonizer/src/common/iop_order.c))

# Shared utilities extracted

* `dt_gaussian_mean_blur()` / `dt_gaussian_mean_blur_cl()` moved from `colorequal.c` into [`gaussian.h`](/masterpiga/darktable/tree/color_harmonizer/src/common/gaussian.h) as shared inline helpers; `colorequal.c` updated to use them
* RYB↔RGB conversion in [`color_ryb.h`](/masterpiga/darktable/tree/color_harmonizer/src/common/color_ryb.h)
* Color harmony geometry (sector angles, arc widths) in [`color_harmony.h`](/masterpiga/darktable/tree/color_harmonizer/src/common/color_harmony.h) / [`color_harmony.c`](/masterpiga/darktable/tree/color_harmonizer/src/common/color_harmony.c)
* UCS fast approximations added to [`colorspaces_inline_conversions.h`](/masterpiga/darktable/tree/color_harmonizer/src/common/colorspaces_inline_conversions.h)
* dt_iop_profile_info_t additions in [`iop_profile.h`](/masterpiga/darktable/tree/color_harmonizer/src/common/iop_profile.h)

# Main technical choices

See [business logic implementation details](/masterpiga/darktable/tree/color_harmonizer/dev-doc/iop/colorharmonizer/business_logic.md) for a more detailed analysis.

## Perceptual color space (UCS JCH)

All hue manipulation happens in darktable's Uniform Color Space rather than HSL/HSV. Equal angular steps in UCS correspond to equal perceived hue differences, which makes the Gaussian weighting behave predictably. The cost is a heavier per-pixel pipeline (matrix multiply + chromatic adaptation + nonlinear transforms in both directions), accepted as necessary for perceptual accuracy.

## RYB geometry, UCS processing

Predefined harmony rules are defined on the RYB (painter's) wheel because it matches users' intuition and the vectorscope overlay. Processing happens in UCS. The anchor hue does a round-trip UCS→RYB (to apply the geometry table offsets) then RYB→UCS (to recover processing node positions). This ensures the attraction zones are pixel-accurate with the guide lines shown in the vectorscope.

## Precomputed LUTs for hue remapping

The UCS→RYB conversion involves sRGB gamma, HSV extraction, and a Gossett piecewise-linear mapping — too expensive per pixel. Two 720-entry tables are built once at init_global: the forward table fills directly from the conversion function; the inverse is found by nearest-match scan over the forward table (O(N²), N=720, runs once at startup, negligible cost). All subsequent calls are O(1) with linear interpolation.

## Winner-takes-all node selection

Each pixel is attracted to its nearest harmony node only, not a weighted blend of all nodes. A blend would pull every pixel toward the geometric center of the node set — losing the palette identity and potentially averaging complementary hues into gray. Winner-takes-all preserves each zone's distinct character.

## Neutral protection via hyperbolic ramp

The correction is gated by chroma / (chroma + cutoff + ε) — a smooth saturating curve that approaches zero for near-neutral colors and one for vivid ones. The cutoff = np_t³ × 0.03 cubic mapping distributes the slider's perceptual effect evenly; a linear mapping would concentrate most visible change in the bottom 20% of slider travel.

## Two processing paths (CPU)

When smoothing is off, a single fused loop runs forward conversion, correction, and inverse conversion per pixel with no intermediate buffers. When smoothing is on, the forward conversion and per-pixel corrections are cached in pass 1; the correction field (not the image) is Gaussian-blurred; pass 2 applies blurred corrections from cache, skipping the expensive forward conversion. Blurring the correction field rather than hue values directly avoids circular-average artifacts near the 0/1 hue wrap point.

## Always two-kernel on GPU, always two-pass on CPU when smoothing > 0

The OpenCL path unconditionally uses a map kernel + apply kernel with shared GPU buffers, even at smoothing=0. Adding a third fused kernel for that case would double the shader variants for a marginal benefit — device-local buffer reads are cheap on modern GPUs. The CPU does fuse at smoothing=0 since avoiding the intermediate allocation is free there.

# Context

Earlier versions of this module have been shared with [the Pixls community](https://discuss.pixls.us/t/new-module-packages-available-color-harmonizer/56322?u=masterpiga), where it has received some preliminary testing and a rather positive welcome.