### PR TITLE
Add ONNX Runtime bundling to macOS packaging

### DIFF
--- a/packaging/macosx/3_make_hb_darktable_package.sh
+++ b/packaging/macosx/3_make_hb_darktable_package.sh
@@ -246,6 +246,24 @@ for dtSharedObj in $dtSharedObjDirs; do
     cp -LR "$homebrewHome"/lib/"$dtSharedObj"/"$dtSharedObjVersion"/* "$dtResourcesDir"/lib/"$dtSharedObj"
 done
 
+# Add ONNX Runtime (for AI support)
+if ! ls "$dtResourcesDir"/lib/darktable/libonnxruntime.*.dylib &>/dev/null \
+   && ! ls "$dtResourcesDir"/lib/libonnxruntime.*.dylib &>/dev/null; then
+    ortLibDir=""
+    if [[ -d "$buildDir/_deps/onnxruntime/lib" ]]; then
+        ortLibDir="$buildDir/_deps/onnxruntime/lib"
+    elif [[ -d "../../src/external/onnxruntime/lib" ]]; then
+        ortLibDir="../../src/external/onnxruntime/lib"
+    fi
+    if [[ -n "$ortLibDir" ]]; then
+        echo "Installing ONNX Runtime from $ortLibDir"
+        ortDylib=$(find "$ortLibDir" -maxdepth 1 -name 'libonnxruntime.*.dylib' | head -1)
+        if [[ -n "$ortDylib" ]]; then
+            cp -L "$ortDylib" "$dtResourcesDir/lib/$(basename "$ortDylib")"
+        fi
+    fi
+fi
+
 # Add homebrew translations
 dtTranslations="gtk30 gtk30-properties gtk-mac-integration iso_639-2 gphoto2 exiv2"
 for dtTranslation in $dtTranslations; do

--- a/src/ai/CMakeLists.txt
+++ b/src/ai/CMakeLists.txt
@@ -61,7 +61,7 @@ elseif(APPLE)
   file(GLOB _ORT_DYLIB "${ONNXRuntime_LIB_DIR}/libonnxruntime.*.dylib")
   if(_ORT_DYLIB)
     install(FILES ${_ORT_DYLIB}
-      DESTINATION ${CMAKE_INSTALL_LIBDIR}/darktable
+      DESTINATION ${CMAKE_INSTALL_LIBDIR}
     )
   endif()
 elseif(WIN32)


### PR DESCRIPTION
## Summary

- Install ONNX Runtime to `lib/` (not `lib/darktable/`) on macOS so it lands alongside other bundled dylibs in the app bundle, consistent with how `install_dependencies` handles homebrew libraries
- Add fallback ONNX Runtime copy in the packaging script for direct builds where CMake install wasn't run
- Works with both auto-downloaded and homebrew-installed ONNX Runtime

##Changes

- `src/ai/CMakeLists.txt`: macOS install destination changed from `LIBDIR/darktable` to `LIBDIR` (Linux/Windows unchanged)
- `packaging/macosx/3_make_hb_darktable_package.sh`: fallback section to copy ONNX Runtime dylib if not already present from CMake install or homebrew

Fixes: #20503