### PR TITLE
scopes: fix buttons not appearing on mouseover

### DIFF
--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -469,16 +469,6 @@ static void _eventbox_scroll_callback(GtkEventControllerScroll* self,
   gdk_event_free(event);
 }
 
-static void _eventbox_motion_notify_callback(GtkEventControllerMotion *controller,
-                                             double x,
-                                             double y,
-                                             dt_scopes_t *s)
-{
-  // This is required in order to correctly display the button tooltips
-  // FIXME: it would seem possible that it is necessary to update button tooltips only when the main widget tooltip has changed, if the tooltip bubbled down, but calling this at the end of lib_histogram_update_tooltip() doesn't seem to help
-  dt_scopes_call_if_exists(s->cur_mode, update_buttons);
-}
-
 static void _eventbox_enter_notify_callback(GtkEventControllerMotion *controller,
                                             double x,
                                             double y,
@@ -496,6 +486,21 @@ static void _eventbox_enter_notify_callback(GtkEventControllerMotion *controller
                          dt_scopes_func_exists(s->cur_mode, draw_scope_channels));
   gtk_widget_show(s->button_box_left);
   gtk_widget_show(s->button_box_right);
+}
+
+static void _eventbox_motion_notify_callback(GtkEventControllerMotion *controller,
+                                             double x,
+                                             double y,
+                                             dt_scopes_t *s)
+{
+  // This is required in order to correctly display the button tooltips
+  // FIXME: it would seem possible that it is necessary to update button tooltips only when the main widget tooltip has changed, if the tooltip bubbled down, but calling this at the end of lib_histogram_update_tooltip() doesn't seem to help
+  dt_scopes_call_if_exists(s->cur_mode, update_buttons);
+  // On GTK3/X11, GDK_ENTER_NOTIFY events are not bubbled through GTK's event
+  // propagation, so a BUBBLE-phase GtkEventControllerMotion on the eventbox
+  // never receives the enter signal. Use motion as a fallback to show buttons.
+  if(!gtk_widget_get_visible(s->button_box_left))
+    _eventbox_enter_notify_callback(controller, x, y, s);
 }
 
 static void _eventbox_leave_notify_callback(GtkEventControllerMotion *controller,


### PR DESCRIPTION
The mode and option buttons in the scope sometimes do not appear on mouseover. This has been observed in Ubunutu 22.04 and 24.04 but not other systems.

See discussion in #20489. Fix courtesy of @masterpiga and Claude.

I'm still confused why this is visible on some systems but not others. Regardless this fix verified by @masterpiga and @wpferguson.

Here are the notes provided by Claude:

> Root cause in src/libs/histogram.c: Commit c8017a9 (PR #20465) replaced old-style enter-notify-event signal callbacks with GtkEventControllerMotion. The controller was set to GTK_PHASE_BUBBLE so motion events (which target child widgets like scope_draw) would bubble up to the eventbox. However, GDK_ENTER_NOTIFY events in GTK3/X11 are sent directly to each X11 window — they don't travel through GTK's propagation hierarchy. A GTK_PHASE_BUBBLE controller on the eventbox therefore never receives the enter signal, so _eventbox_enter_notify_callback never fires and the buttons are never shown.
> 
> Why macOS is unaffected: On the Quartz (Cocoa) backend, GDK synthesizes crossing events differently — they propagate cleanly through GTK's event system and are received by the BUBBLE-phase controller.
> 
> Why motion still works on Linux: motion-notify events target the innermost widget (scope_draw) and bubble up through GTK's propagation correctly, so tooltips and exposure controls work fine.
> 
> ## FIX
> 
> Reorder _eventbox_enter_notify_callback before
> _eventbox_motion_notify_callback, then call it from the motion callback as a fallback — only when the buttons aren't already visible. This is safe and harmless on macOS/Wayland where enter already fires correctly.