### PR TITLE
fix onnx lib handling on macOS

### DIFF
--- a/packaging/macosx/3_make_hb_darktable_package.sh
+++ b/packaging/macosx/3_make_hb_darktable_package.sh
@@ -246,22 +246,10 @@ for dtSharedObj in $dtSharedObjDirs; do
     cp -LR "$homebrewHome"/lib/"$dtSharedObj"/"$dtSharedObjVersion"/* "$dtResourcesDir"/lib/"$dtSharedObj"
 done
 
-# Add ONNX Runtime (for AI support)
-if ! ls "$dtResourcesDir"/lib/darktable/libonnxruntime.*.dylib &>/dev/null \
-   && ! ls "$dtResourcesDir"/lib/libonnxruntime.*.dylib &>/dev/null; then
-    ortLibDir=""
-    if [[ -d "$buildDir/_deps/onnxruntime/lib" ]]; then
-        ortLibDir="$buildDir/_deps/onnxruntime/lib"
-    elif [[ -d "../../src/external/onnxruntime/lib" ]]; then
-        ortLibDir="../../src/external/onnxruntime/lib"
-    fi
-    if [[ -n "$ortLibDir" ]]; then
-        echo "Installing ONNX Runtime from $ortLibDir"
-        ortDylib=$(find "$ortLibDir" -maxdepth 1 -name 'libonnxruntime.*.dylib' | head -1)
-        if [[ -n "$ortDylib" ]]; then
-            cp -L "$ortDylib" "$dtResourcesDir/lib/$(basename "$ortDylib")"
-        fi
-    fi
+# Handle ONNX Runtime (for AI support)
+# TODO: this is only a hack to deal with the downloaded onnxruntime
+if ls "$dtResourcesDir"/lib/darktable/libonnxruntime.*.dylib &>/dev/null; then
+  mv "$dtResourcesDir"/lib/darktable/libonnxruntime.*.dylib "$dtResourcesDir"/lib
 fi
 
 # Add homebrew translations

--- a/src/ai/CMakeLists.txt
+++ b/src/ai/CMakeLists.txt
@@ -63,7 +63,7 @@ elseif(APPLE)
   file(GLOB _ORT_DYLIB "${ONNXRuntime_LIB_DIR}/libonnxruntime.*.dylib")
   if(_ORT_DYLIB)
     install(FILES ${_ORT_DYLIB}
-      DESTINATION ${CMAKE_INSTALL_LIBDIR}
+      DESTINATION ${CMAKE_INSTALL_LIBDIR}/darktable
     )
   endif()
 elseif(WIN32)


### PR DESCRIPTION
This fixes the onnxruntime library handling on macOS.

Explanation:
On macOS the onnxruntime lib is downloaded from Github during CMAKE build because the version provided by Homebrew is not built with CoreML support (this download without user permission is another topic).

darktable expects dynamic libraries to be either in the system library paths or in `<install_dir>/lib/darktable` (only libdarktable should reside here).
The downloaded onnxruntime is installed in `<install_dir>/lib` which makes all darktable CLI programs to fail.

This PR is a quick hack to solve these problems:

- `libonnxruntime.dylib` is installed in `<install_dir>/lib/darktable` so it is found by all CLI programs
- during bundling the macOS App package the lib is moved to `./lib` and handled as all other dylibs

@andriiryzhkov : 
I would *really* prefer to open a PR at the Homebrew package to avoid this kind of mess!
The existing issue https://github.com/Homebrew/homebrew-core/issues/177367 was closed as _not planned_ because it was raised as a bug instead of a feature request.
 