### PR TITLE
fix string garbage in AI checksum message

### DIFF
--- a/src/common/ai_models.c
+++ b/src/common/ai_models.c
@@ -1164,11 +1164,12 @@ char *dt_ai_models_download_sync(dt_ai_registry_t *registry,
     if(!checksum_copy)
     {
       g_free(release_tag);
-      SET_STATUS_AND_RETURN(
-        DT_AI_MODEL_ERROR,
-        g_strdup_printf(_("could not obtain checksum for %s — "
-                          "refusing to download without integrity verification"),
-                        asset));
+
+      char *msg = g_strdup_printf(_("could not obtain checksum for %s — "
+                                    "refusing to download without integrity verification"),
+                                  asset);
+
+      SET_STATUS_AND_RETURN(DT_AI_MODEL_ERROR, msg);
     }
   }
 


### PR DESCRIPTION
This was a chance find.
I had a wrong AI repository setting in my darktablerc (leftover from previous tests) so the models could not be downloaded. 

This gave me the following message:

<img width="587" height="187" alt="Bildschirmfoto 2026-03-15 um 12 35 10" src="https://github.com/user-attachments/assets/bae73570-cfa7-4aea-ae0e-e595dc23eb6b" />

The reason is that `asset` is used to build the message string and is then passed to the macro `SET_STATUS_AND_RETURN` where it is g_free'd.

Steps to reproduce:

- set `plugins/ai/repository=andriiryzhkov/darktable-ai` in darktablerc
- go to preferences --> AI and try to download a model

fixes #20528 
