### PR TITLE
[AI] Move segmentation from src/ai to src/common/ai for consistency

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -461,6 +461,7 @@ if(USE_AI)
 
   FILE(GLOB SOURCE_FILES_AI
     "common/ai_models.c"
+    "common/ai/segmentation.c"
     "develop/masks/object.c"
     "gui/preferences_ai.c"
   )

--- a/src/ai/CMakeLists.txt
+++ b/src/ai/CMakeLists.txt
@@ -4,8 +4,6 @@ add_library(darktable_ai STATIC
   backend.h
   backend_common.c
   backend_onnx.c
-  segmentation.h
-  segmentation.c
 )
 
 # Find ONNX Runtime (auto-downloads if not present)

--- a/src/common/ai/segmentation.c
+++ b/src/common/ai/segmentation.c
@@ -16,8 +16,8 @@
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include "segmentation.h"
-#include "backend.h"
+#include "common/ai/segmentation.h"
+#include "ai/backend.h"
 #include "common/darktable.h"
 #include <inttypes.h>
 #include <math.h>

--- a/src/common/ai/segmentation.h
+++ b/src/common/ai/segmentation.h
@@ -18,7 +18,7 @@
 
 #pragma once
 
-#include "backend.h"
+#include "ai/backend.h"
 #include <glib.h>
 
 /**

--- a/src/develop/masks/object.c
+++ b/src/develop/masks/object.c
@@ -16,7 +16,7 @@
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include "ai/segmentation.h"
+#include "common/ai/segmentation.h"
 #include "common/ai_models.h"
 #include "common/colorspaces.h"
 #include "common/debug.h"


### PR DESCRIPTION
This is just a refactoring, no new functionality introduced.

## Rationale

Establishes a clean separation between the two AI layers:

- `src/ai/` - pure ONNX Runtime backend (`backend.h`, `backend_common.c`, `backend_onnx.c`). Self-contained, no darktable core dependencies. Builds as `darktable_ai` static library.
- `src/common/ai/` - higher-level AI modules that bridge the AI backend with darktable core. Compiled conditionally (`USE_AI=ON`) as part of the main `lib_darktable` target.

This ensures that any AI module in `src/common/ai/` can freely use darktable core APIs without introducing cross-library link dependencies - which would break the Windows build where the linker is stricter about unresolved symbols in static libraries.

Aligns with the same refactoring done for `restore.c` in PR #20523, moving all non-backend AI code to `src/common/ai/` for consistency and maintainability.