### PR TITLE
Reorder mask shape buttons to logical progression

### DIFF
--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -2810,6 +2810,14 @@ void dt_iop_gui_init_masks(GtkWidget *blendw, dt_iop_module_t *module)
                                                   FALSE, 0, 0,
                                                   dtgtk_cairo_paint_masks_gradient, abox);
 
+    bd->masks_type[4] = DT_MASKS_BRUSH;
+    bd->masks_shapes[4] = dt_iop_togglebutton_new(module, "blend`shapes",
+                                                  N_("add brush"),
+                                                  N_("add multiple brush strokes"),
+                                                  G_CALLBACK(_blendop_masks_add_shape),
+                                                  FALSE, 0, 0,
+                                                  dtgtk_cairo_paint_masks_brush, abox);
+
     bd->masks_type[1] = DT_MASKS_PATH;
     bd->masks_shapes[1] = dt_iop_togglebutton_new(module, "blend`shapes",
                                                   N_("add path"),
@@ -2833,14 +2841,6 @@ void dt_iop_gui_init_masks(GtkWidget *blendw, dt_iop_module_t *module)
                                                   G_CALLBACK(_blendop_masks_add_shape),
                                                   FALSE, 0, 0,
                                                   dtgtk_cairo_paint_masks_circle, abox);
-
-    bd->masks_type[4] = DT_MASKS_BRUSH;
-    bd->masks_shapes[4] = dt_iop_togglebutton_new(module, "blend`shapes",
-                                                  N_("add brush"),
-                                                  N_("add multiple brush strokes"),
-                                                  G_CALLBACK(_blendop_masks_add_shape),
-                                                  FALSE, 0, 0,
-                                                  dtgtk_cairo_paint_masks_brush, abox);
 
     bd->masks_box = GTK_BOX(dt_gui_vbox(hbox, abox));
     _add_wrapped_box(blendw, bd->masks_box, "masks_drawn");

--- a/src/libs/masks.c
+++ b/src/libs/masks.c
@@ -1901,7 +1901,7 @@ void gui_init(dt_lib_module_t *self)
 
   GtkWidget *shape_buttons = dt_gui_hbox
     (dt_gui_expand(dt_ui_label_new(_("created shapes"))),
-     d->bt_brush, d->bt_circle, d->bt_ellipse, d->bt_path, d->bt_gradient);
+     d->bt_circle, d->bt_ellipse, d->bt_path, d->bt_brush, d->bt_gradient);
 #ifdef HAVE_AI
   dt_gui_box_add(shape_buttons, d->bt_object);
 #endif


### PR DESCRIPTION
The mask shape tool buttons in both the mask manager and the blending module are reordered from simple to complex:

**circle → ellipse → path → brush → gradient → object**

Previously the order was inconsistent: brush was first in the mask manager, gradient was first in blending, and object was placed before all geometric shapes in blending.

The new order follows a natural progression from basic geometric shapes (circle, ellipse) through freeform shapes (path, brush) to specialized tools (gradient, AI object)

Before
<img width="118" height="28" alt="order_before" src="https://github.com/user-attachments/assets/bfcabd7b-f01f-4278-9528-ff5ab24a3df5" />

After
<img width="118" height="28" alt="order_after" src="https://github.com/user-attachments/assets/c856a20f-046e-4731-93e3-5f6ee8afc840" />

PS: In release 5.4.1 order differs in mask manager and blending module.