### PR TITLE
[AI] Fix object mask encoding ignoring crop/rotate/perspective

### DIFF
--- a/src/develop/masks/object.c
+++ b/src/develop/masks/object.c
@@ -108,10 +108,12 @@ static dt_hash_t _compute_distort_hash(dt_develop_t *dev)
   for(GList *l = dev->history; l; l = g_list_next(l))
   {
     const dt_dev_history_item_t *item = l->data;
-    if(!item->enabled || !item->module
-       || !item->module->distort_transform)
-      continue;
-    hash = dt_hash(hash, item->params, item->module->params_size);
+    if(item->enabled
+       && item->module
+       && item->module->distort_transform)
+    {
+      hash = dt_hash(hash, item->params, item->module->params_size);
+    }
   }
   return hash;
 }


### PR DESCRIPTION
## Summary

- Fix encoder receiving pre-crop/rotate image when creating object masks after geometric edits
- Detect distortion changes (crop/rotate/perspective/lens) and re-encode when geometry changes on the same image
- Sync darkroom history to database before launching encode thread so the export pipe sees current edits

## Problem

When the user applied crop, rotate, or perspective correction and then created an AI object mask, the encoder received the unmodified image. This caused the mask to be misaligned with the visible (cropped/rotated) image.

Three root causes:

1. Encoding was only invalidated on image ID change - geometric edits on the same image were not detected
2. In-memory module parameters (crop/rotate) were not flushed to the database, so the encode thread's independent pipeline read stale history
3. Module ordering in the export pipeline was not synced, preventing geometric modules from being applied