### PR TITLE
Enable pocl OpenCL driver

### DIFF
--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -760,11 +760,10 @@ static gboolean _opencl_device_init(dt_opencl_t *cl,
       (type & CL_DEVICE_TYPE_ACCELERATOR)                 ? ", Accelerator" : "",
       unified_memory ? ", unified mem" : ", dedicated mem" );
 
-  if((is_cpu_device || is_custom_device) && newdevice)
+  if(is_custom_device && newdevice)
   {
     dt_print_nts(DT_DEBUG_OPENCL,
-                 "   *** discarding new %s ***\n",
-                 is_cpu_device ? "device as emulated by CPU" : "custom device");
+                 "   *** discarding new custom device ***\n");
     cl->dev[dev].disabled |= TRUE;
     res = TRUE;
     goto end;

--- a/src/common/opencl_drivers_blacklist.h
+++ b/src/common/opencl_drivers_blacklist.h
@@ -27,7 +27,6 @@ static const gchar *bad_opencl_drivers[] =
   // clang-format off
 
   "beignet",
-  "pocl",
   "clover",
   "amd-app",
 /*


### PR DESCRIPTION
Don't blacklist pocl and make it available even when CPU emulated as
1. It supports some hardware otherwise not available for OpenCL
2. The cpu emulation driver allows testing even on systems without OpenCL capable hardware for example when running the integration testsuite
