### PR TITLE
scopes: use convenience macros in split mode

### DIFF
--- a/src/libs/scopes/split.c
+++ b/src/libs/scopes/split.c
@@ -36,8 +36,8 @@ static void _split_process(dt_scopes_mode_t *const self,
                           const dt_iop_order_iccprofile_info_t *vs_prof)
 {
   dt_scopes_split_t *const d = self->data;
-  d->left->functions->process(d->left, input, roi, vs_prof);
-  d->right->functions->process(d->right, input, roi, vs_prof);
+  dt_scopes_call(d->left, process, input, roi, vs_prof);
+  dt_scopes_call(d->right, process, input, roi, vs_prof);
   self->update_counter = self->scopes->update_counter;
 }
 
@@ -50,13 +50,11 @@ static void _split_draw_highlight(const dt_scopes_mode_t *const self,
   const dt_scopes_split_t *const d = self->data;
   const int half_width = width / 2;
   cairo_save(cr);
-  if(d->left->functions->draw_highlight)
-    d->left->functions->draw_highlight(d->left, cr, self->scopes->highlight,
-                                       half_width, height);
+  dt_scopes_call_if_exists(d->left, draw_highlight, cr, self->scopes->highlight,
+                           half_width, height);
   cairo_translate(cr, half_width, 0);
-  if(d->right->functions->draw_highlight)
-    d->right->functions->draw_highlight(d->right, cr, self->scopes->highlight,
-                                        half_width, height);
+  dt_scopes_call_if_exists(d->right, draw_highlight, cr, self->scopes->highlight,
+                           half_width, height);
   cairo_restore(cr);
 }
 
@@ -68,11 +66,9 @@ static void _split_draw_bkgd(const dt_scopes_mode_t *const self,
   const dt_scopes_split_t *const d = self->data;
   const int half_width = width / 2;
   cairo_save(cr);
-  if(d->left->functions->draw_bkgd)
-    d->left->functions->draw_bkgd(d->left, cr, half_width, height);
+  dt_scopes_call_if_exists(d->left, draw_bkgd, cr, half_width, height);
   cairo_translate(cr, half_width, 0);
-  if(d->right->functions->draw_bkgd)
-    d->right->functions->draw_bkgd(d->right, cr, half_width, height);
+  dt_scopes_call_if_exists(d->right, draw_bkgd, cr, half_width, height);
   cairo_restore(cr);
 }
 
@@ -84,11 +80,9 @@ static void _split_draw_grid(const dt_scopes_mode_t *const self,
   const dt_scopes_split_t *const d = self->data;
   const int half_width = width / 2;
   cairo_save(cr);
-  if(d->left->functions->draw_grid)
-    d->left->functions->draw_grid(d->left, cr, half_width, height);
+  dt_scopes_call_if_exists(d->left, draw_grid, cr, half_width, height);
   cairo_translate(cr, half_width, 0);
-  if(d->right->functions->draw_grid)
-    d->right->functions->draw_grid(d->right, cr, half_width, height);
+  dt_scopes_call_if_exists(d->right, draw_grid, cr, half_width, height);
   cairo_restore(cr);
 }
 
@@ -107,12 +101,10 @@ static void _split_draw(const dt_scopes_mode_t *const self,
     cairo_rectangle(cr, 0, 0, half_width, height);
     cairo_clip(cr);
     if(d->left->functions->draw_scope_channels)
-      d->left->functions->draw_scope_channels(d->left, cr,
-                                              half_width, height,
-                                              self->scopes->channels);
+      dt_scopes_call(d->left, draw_scope_channels,
+                     cr, half_width, height, self->scopes->channels);
     else
-      d->left->functions->draw_scope(d->left, cr,
-                                     half_width, height);
+      dt_scopes_call(d->left, draw_scope, cr, half_width, height);
     cairo_restore(cr);
   }
   // FIXME: make slight gap/line between two scopes, as it is crammed, especially visibile in RYB vectorscope where color harmony name is awkwardly close to waveform
@@ -123,12 +115,10 @@ static void _split_draw(const dt_scopes_mode_t *const self,
     cairo_rectangle(cr, 0, 0, half_width, height);
     cairo_clip(cr);
     if(d->right->functions->draw_scope_channels)
-      d->right->functions->draw_scope_channels(d->right, cr,
-                                               half_width, height,
-                                               self->scopes->channels);
+      dt_scopes_call(d->right, draw_scope_channels,
+                     cr, half_width, height, self->scopes->channels);
     else
-      d->right->functions->draw_scope(d->right, cr,
-                                      half_width, height);
+      dt_scopes_call(d->right, draw_scope, cr, half_width, height);
     cairo_restore(cr);
   }
 }
@@ -137,10 +127,8 @@ static void _split_append_to_tooltip(const dt_scopes_mode_t *const self,
                                      gchar **tip)
 {
   const dt_scopes_split_t *const d = self->data;
-  if(d->left->functions->append_to_tooltip)
-    d->left->functions->append_to_tooltip(d->left, tip);
-  if(d->right->functions->append_to_tooltip)
-    d->right->functions->append_to_tooltip(d->right, tip);
+  dt_scopes_call_if_exists(d->left, append_to_tooltip, tip);
+  dt_scopes_call_if_exists(d->right, append_to_tooltip, tip);
 }
 
 static double _split_get_exposure_pos(const dt_scopes_mode_t *const self,
@@ -153,20 +141,20 @@ static double _split_get_exposure_pos(const dt_scopes_mode_t *const self,
   if(x < allocation.width/2.0)
   {
     if(d->left->functions->get_exposure_pos)
-      return d->left->functions->get_exposure_pos(d->left, x*2.0, y);
+      return dt_scopes_call(d->left, get_exposure_pos, x*2.0, y);
     else
       dt_print(DT_DEBUG_ALWAYS,
-               "[_split_get_exposure_pos] no %s (left) get_exposure_pos at %f, %f\n",
-               d->left->functions->name(d->left), x, y);
+               "[_split_get_exposure_pos] no %s (left) get_exposure_pos at %f, %f",
+               dt_scopes_call(d->left, name), x, y);
   }
   else
   {
     if(d->right->functions->get_exposure_pos)
-      return d->right->functions->get_exposure_pos(d->right, x*2.0-allocation.width, y);
+      return dt_scopes_call(d->right, get_exposure_pos, x*2.0-allocation.width, y);
     else
       dt_print(DT_DEBUG_ALWAYS,
-               "[_split_get_exposure_pos] no %s (right) get_exposure_pos at %f, %f\n",
-               d->right->functions->name(d->right), x, y);
+               "[_split_get_exposure_pos] no %s (right) get_exposure_pos at %f, %f",
+               dt_scopes_call(d->right, name), x, y);
   }
   return x;
 }
@@ -177,19 +165,18 @@ static dt_scopes_highlight_t _split_get_highlight(const dt_scopes_mode_t *const 
 {
   const dt_scopes_split_t *const d = self->data;
   if((posx < 0.5) && d->left->functions->get_highlight)
-    return d->left->functions->get_highlight(d->left, posx*2.0, posy);
-  else if((posx >= 0.5) && d->right->functions->get_highlight)
-    return d->right->functions->get_highlight(d->right, posx*2.0-1.0, posy);
-  else
-    return DT_SCOPES_HIGHLIGHT_NONE;
+    return dt_scopes_call(d->left, get_highlight, posx*2.0, posy);
+  if((posx >= 0.5) && d->right->functions->get_highlight)
+    return dt_scopes_call(d->right, get_highlight, posx*2.0-1.0, posy);
+  return DT_SCOPES_HIGHLIGHT_NONE;
 }
 
 static void _split_clear(dt_scopes_mode_t *const self)
 {
   // FIXME: make sure this is actually called appropriately in libs/histogram.c
   dt_scopes_split_t *const d = self->data;
-  d->left->functions->clear(d->left);
-  d->right->functions->clear(d->right);
+  dt_scopes_call(d->left, clear);
+  dt_scopes_call(d->right, clear);
 }
 
 static void _split_eventbox_scroll(dt_scopes_mode_t *const self,
@@ -200,24 +187,24 @@ static void _split_eventbox_scroll(dt_scopes_mode_t *const self,
   dt_scopes_split_t *const d = self->data;
   GtkAllocation allocation;
   gtk_widget_get_allocation(self->scopes->scope_draw, &allocation);
-  if((x < allocation.width/2) && d->left->functions->eventbox_scroll)
-    d->left->functions->eventbox_scroll(d->left, x, y, delta_x, delta_y, state);
-  if((x >= allocation.width/2) && d->right->functions->eventbox_scroll)
-    d->right->functions->eventbox_scroll(d->right, x, y, delta_x, delta_y, state);
+  if(x < allocation.width/2)
+    dt_scopes_call_if_exists(d->left, eventbox_scroll, x, y, delta_x, delta_y, state);
+  if(x >= allocation.width/2)
+    dt_scopes_call_if_exists(d->right, eventbox_scroll, x, y, delta_x, delta_y, state);
 }
 
 static void _split_update_buttons(const dt_scopes_mode_t *const self)
 {
   dt_scopes_split_t *d = self->data;
-  d->left->functions->update_buttons(d->left);
-  d->right->functions->update_buttons(d->right);
+  dt_scopes_call(d->left, update_buttons);
+  dt_scopes_call(d->right, update_buttons);
 }
 
 static void _split_mode_enter(dt_scopes_mode_t *const self)
 {
   const dt_scopes_split_t *const d = self->data;
-  d->left->functions->mode_enter(d->left);
-  d->right->functions->mode_enter(d->right);
+  dt_scopes_call(d->left, mode_enter);
+  dt_scopes_call(d->right, mode_enter);
   self->update_counter = MAX(d->left->update_counter, d->right->update_counter);
   if(d->left->update_counter != d->right->update_counter)
     dt_scopes_reprocess();
@@ -226,8 +213,8 @@ static void _split_mode_enter(dt_scopes_mode_t *const self)
 static void _split_mode_leave(const dt_scopes_mode_t *const self)
 {
   const dt_scopes_split_t *const d = self->data;
-  d->left->functions->mode_leave(d->left);
-  d->right->functions->mode_leave(d->right);
+  dt_scopes_call(d->left, mode_leave);
+  dt_scopes_call(d->right, mode_leave);
 }
 
 static void _split_gui_init(dt_scopes_mode_t *const self,


### PR DESCRIPTION
Makes code a bit less repetitive and consistent with other scope modes which use these macros.

Also:
- Minor simplifying of conditionals
- Remove extraneous newlines in two dt_print() calls

Note that we can use dt_scopes_call_if_exists() in all cases as it does not provide a return value.

This PR shouldn't have any user-visible changes.