### PR TITLE
Opencl 56 updates 2

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -410,6 +410,13 @@
     <shortdescription>activate OpenCL support</shortdescription>
     <longdescription>if found, use OpenCL runtime on your system to speed up processing by using your graphics card(s).\ncan be switched on and off at any time.</longdescription>
   </dtconfig>
+  <dtconfig prefs="processing" section="opencl" capability="opencl" restart="true">
+    <name>opencl_fast</name>
+    <type>bool</type>
+    <default>false</default>
+    <shortdescription>OpenCL fast mode</shortdescription>
+    <longdescription>if set the OpenCL compiler uses aggressive optimizing for better performance with reduced precision so more differences between CPU and OpenCL are expected.</longdescription>
+  </dtconfig>
   <dtconfig prefs="processing" section="opencl" capability="opencl">
     <name>opencl_scheduling_profile</name>
     <type>

--- a/data/kernels/basic.cl
+++ b/data/kernels/basic.cl
@@ -273,7 +273,7 @@ kernel void
 highlights_1f_clip (read_only image2d_t in, write_only image2d_t out,
                     const int iwidth, const int iheight,
                     const int owidth, const int oheight,
-                    global float *clips, const int dx, const int dy,
+                    const float4 clip, const int dx, const int dy,
                     const int filters, global const unsigned char (*const xtrans)[6])
 {
   const int x = get_global_id(0);
@@ -284,13 +284,14 @@ highlights_1f_clip (read_only image2d_t in, write_only image2d_t out,
   const int irow = y + dy;
   const int icol = x + dx;
   float pixel = 0.0f;
+  float clips[4] = { clip.x, clip.y, clip.z, clip.w};
   if((icol >= 0) && (irow >= 0) && (irow < iheight) && (icol < iwidth))
   {
     const int color = fcol(irow, icol, filters, xtrans);
-    pixel = read_imagef(in, sampleri, (int2)(icol, irow)).x;
+    pixel = readsingle(in, icol, irow);
     pixel = fmin(clips[color], pixel);
   }
-  write_imagef (out, (int2)(x, y), pixel);
+  write_imagef(out, (int2)(x, y), pixel);
 }
 
 kernel void highlights_false_color(
@@ -304,7 +305,7 @@ kernel void highlights_false_color(
         const int dy,
         const unsigned int filters,
         global const unsigned char (*const xtrans)[6],
-        global const float *clips)
+        const float4 clip)
 {
   const int x = get_global_id(0);
   const int y = get_global_id(1);
@@ -314,10 +315,11 @@ kernel void highlights_false_color(
   const int irow = y + dy;
   const int icol = x + dx;
   float oval = 0.0f;
+  float clips[4] = { clip.x, clip.y, clip.z, clip.w};
 
   if((irow >= 0) && (icol >= 0) && (icol < iwidth) && (irow < iheight))
   {
-    const float ival = read_imagef(in, sampleri, (int2)(icol, irow)).x;
+    const float ival = readsingle(in, icol, irow);
     const int c = fcol(irow, icol, filters, xtrans);
     oval = (ival < clips[c]) ? 0.2f * ival : 1.0f;
   }
@@ -347,7 +349,7 @@ static float _calc_refavg(
   {
     for(int dx = dxmin; dx < dxmax; dx++)
     {
-      const float val = fmax(0.0f, read_imagef(in, sampleri, (int2)(dx, dy)).x);
+      const float val = fmax(0.0f, readsingle(in, dx, dy));
       const int c = fcol(dy, dx, filters, xtrans);
       sum[c] += val;
       cnt[c] += 1.0f;
@@ -355,11 +357,11 @@ static float _calc_refavg(
   }
 
   for(int c = 0; c < 3; c++)
-    mean[c] = (cnt[c] > 0.0f) ? dtcl_pow((correction[c] * sum[c]) / cnt[c], 0.33333333333f) : 0.0f;
+    mean[c] = (cnt[c] > 0.0f) ? cbrt((correction[c] * sum[c]) / cnt[c]) : 0.0f;
 
   const float croot_refavg[3] = { 0.5f * (mean[1] + mean[2]), 0.5f * (mean[0] + mean[2]), 0.5f * (mean[0] + mean[1])};
   const int color = fcol(row, col, filters, xtrans);
-  return dtcl_pow(croot_refavg[color], 3.0f);
+  return fcube(croot_refavg[color]);
 }
 
 kernel void highlights_initmask(
@@ -494,7 +496,7 @@ kernel void highlights_chroma(
   {
     const int idx = mad24(row, width, col);
     const int color = fcol(row, col, filters, xtrans);
-    const float inval = fmax(0.0f, read_imagef(in, sampleri, (int2)(col, row)).x);
+    const float inval = readsingle(in, col, row);
     const int px = color * msize + mad24(row/3, mwidth, col/3);
     if(mask[px] && (inval > 0.2f*clips[color]) && (inval < clips[color]))
     {
@@ -542,7 +544,7 @@ kernel void highlights_opposed(
 
   if((icol >= 0) && (icol < iwidth) && (irow >= 0) && (irow < iheight))
   {
-    val = fmax(0.0f, read_imagef(in, sampleri, (int2)(icol, irow)).x);
+    val = readsingle(in, icol, irow);
 
     if(!fastcopymode)
     {

--- a/data/kernels/capture.cl
+++ b/data/kernels/capture.cl
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    copyright (c) 2025 darktable developer.
+    copyright (c) 2026 darktable developer.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -185,7 +185,7 @@ __kernel void prepare_blend(__read_only image2d_t cfa,
                             global const unsigned char (*const xtrans)[6],
                             global float *mask,
                             global float *Yold,
-                            global float *whites,
+                            const float4 wb,
                             const int w,
                             const int height)
 {
@@ -193,10 +193,11 @@ __kernel void prepare_blend(__read_only image2d_t cfa,
   const int row = get_global_id(1);
   if(col >= w || row >= height) return;
 
-  float4 rgb = read_imagef(dev_out, samplerA, (int2)(col, row));
+  float whites[4] = { wb.x, wb.y, wb.z, wb.w };
+
+  float4 rgb = Areadpixel(dev_out, col, row);
   // Photometric/digital ITU BT.709
-  const float4 flum = (float4)( 0.212671f, 0.715160f, 0.072169f, 0.0f );
-  rgb *= flum;
+  rgb *= (float4)( 0.212671f, 0.715160f, 0.072169f, 0.0f );
   const float Y = fmax(0.0f, rgb.x + rgb.y + rgb.z);
   const int k = mad24(row, w, col);
   Yold[k] = Y;
@@ -205,7 +206,7 @@ __kernel void prepare_blend(__read_only image2d_t cfa,
   {
     const int w2 = 2 * w;
     const int color = (filters == 9u) ? FCxtrans(row, col, xtrans) : FC(row, col, filters);
-    const float val = read_imagef(cfa, samplerA, (int2)(col, row)).x;
+    const float val = Areadsingle(cfa, col, row);
     if(val > whites[color] || Y < CAPTURE_YMIN)
     {
       mask[k-w2-1] = mask[k-w2]  = mask[k-w2+1] =
@@ -289,7 +290,7 @@ __kernel void show_blend_mask(__read_only image2d_t in,
   const int row = get_global_id(1);
   if(col >= width || row >= height) return;
 
-  float4 pix = read_imagef(in, samplerA, (int2)(col, row));
+  float4 pix = fmax(0.0f, Areadpixel(in, col, row));
   const float blend = blender ? blend_mask[mad24(row, width, col)]
                               : (float)sigma_mask[mad24(row, width, col)] / 255.0f;
   pix.w = blend;
@@ -308,15 +309,14 @@ __kernel void capture_result( __read_only image2d_t in,
   const int row = get_global_id(1);
   if(col >= width || row >= height) return;
 
-  float4 pix = read_imagef(in, samplerA, (int2)(col, row));
+  float4 pix = Areadpixel(in, col, row);
   const int k = mad24(row, width, col);
 
   if(blendmask[k] > 0.0f)
   {
     const float mixer = clipf(blendmask[k]);
     const float luminance_new = mix(luminance[k], tmp[k], mixer);
-    const float4 factor = luminance_new / fmax(luminance[k], CAPTURE_YMIN);
-    pix *= factor;
+    pix *= (float4)(luminance_new / fmax(luminance[k], CAPTURE_YMIN));
   }
   write_imagef(out, (int2)(col, row), pix);
 }

--- a/data/kernels/common.h
+++ b/data/kernels/common.h
@@ -41,9 +41,7 @@ constant sampler_t samplerA = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_NONE    
 #define BLUE 2
 #define ALPHA 3
 
-#define DT_OPENCL_PERFORMANCE
-
-#ifdef DT_OPENCL_PERFORMANCE
+#if(defined(__FAST_RELAXED_MATH__) && __FAST_RELAXED_MATH__ == 1)
   #define dtcl_sin(A) native_sin(A)
   #define dtcl_cos(A) native_cos(A)
   #define dtcl_sqrt(A) native_sqrt(A)
@@ -155,7 +153,41 @@ static inline float fsquare(const float a)
   return (a * a);
 }
 
+static inline float fcube(const float a)
+{
+  return (a * a * a);
+}
+
 static inline float clipf(const float a)
 {
   return clamp(a, 0.0f, 1.0f);
+}
+
+/* Some inline functions making life easier when reading photosites
+   or pixels from cl_mem images.
+  The variants with a leading A use the faster samplerA interpolater, only
+  to be used with safe positions as otherwise the read value will be undefined,
+  (on AMD possibly NaN).
+*/
+static inline float readsingle(read_only image2d_t in, int col, int row)
+{
+  return read_imagef(in, sampleri, (int2)(col, row)).x;
+}
+static inline float Areadsingle(read_only image2d_t in, int col, int row)
+{
+  return read_imagef(in, samplerA, (int2)(col, row)).x;
+}
+
+static inline float4 readpixel(read_only image2d_t in, int col, int row)
+{
+  return read_imagef(in, sampleri, (int2)(col, row));
+}
+static inline float4 Areadpixel(read_only image2d_t in, int col, int row)
+{
+  return read_imagef(in, samplerA, (int2)(col, row));
+}
+
+static inline float readalpha(read_only image2d_t in, int col, int row)
+{
+  return clipf(read_imagef(in, sampleri, (int2)(col, row)).w);
 }

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1568,9 +1568,6 @@ int dt_init(int argc,
   // set the interface language and prepare selection for prefs & confgen
   darktable.l10n = dt_l10n_init(init_gui);
 
-  const int last_configure_version =
-    dt_conf_get_int("performance_configuration_version_completed");
-
   gboolean has_workspace = FALSE;
 
   // we need this REALLY early so that error messages can be shown,
@@ -1653,6 +1650,8 @@ int dt_init(int argc,
   {
     dt_splash_screen_create(FALSE);
   }
+  const int last_configure_version =
+    dt_conf_get_int("performance_configuration_version_completed");
 
   // detect cpu features and decide which codepaths to enable
   dt_codepaths_init();
@@ -2595,6 +2594,16 @@ void dt_configure_runtime_performance(const int old, char *info)
   {
     g_strlcat(info, INFO_HEADER, DT_PERF_INFOSIZE);
     g_strlcat(info, _("OpenCL mandatory timeout has been updated to 1000.\n\n"), DT_PERF_INFOSIZE);
+  }
+
+  if(old == 18)
+  {
+    g_strlcat(info, INFO_HEADER, DT_PERF_INFOSIZE);
+    g_strlcat(info, _("OpenCL 'per device' settings have changed.\n\n"), DT_PERF_INFOSIZE);
+    g_strlcat(info, _("you will find 'per device' data in 'cldevice_v6_canonical-name'. content is:"), DT_PERF_INFOSIZE);
+    g_strlcat(info, "\n  ", DT_PERF_INFOSIZE);
+    g_strlcat(info, _(" 'micro_nap' 'pinned_memory' 'eventhandles' 'async' 'disabled' 'advantage' 'unified_fraction'"), DT_PERF_INFOSIZE);
+    g_strlcat(info, "\n\n", DT_PERF_INFOSIZE);
   }
 
   #undef INFO_HEADER

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -196,7 +196,7 @@ typedef int32_t dt_mask_id_t;
 // version of current performance configuration version
 // if you want to run an updated version of the performance configuration later
 // bump this number and make sure you have an updated logic in dt_configure_runtime_performance()
-#define DT_CURRENT_PERFORMANCE_CONFIGURE_VERSION 18
+#define DT_CURRENT_PERFORMANCE_CONFIGURE_VERSION 19
 #define DT_PERF_INFOSIZE 4096
 
 // every module has to define this:

--- a/src/common/math.h
+++ b/src/common/math.h
@@ -285,7 +285,10 @@ static inline float sqf(const float x)
 {
   return x * x;
 }
-
+static inline float fcube(const float a)
+{
+  return (a * a * a);
+}
 
 DT_OMP_DECLARE_SIMD(aligned(p:16))
 static inline float median9f(const float *p)

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -339,16 +339,12 @@ void dt_opencl_write_device_config(const int devid)
   gchar key[256] = { 0 };
   gchar dat[512] = { 0 };
   g_snprintf(key, 254, "%s%s", DT_CLDEVICE_HEAD, cl->dev[devid].cname);
-  g_snprintf(dat, 510, "%i %i %i %i %i %i %i %i %.3f %.3f %.3f",
-    0, // don't use avoid atomics any longer
+  g_snprintf(dat, 510, "%i %i %i %i %i %.3f %.3f",
     cl->dev[devid].micro_nap,
     cl->dev[devid].pinned_memory,
-    cl->dev[devid].clroundup_wd,
-    cl->dev[devid].clroundup_ht,
     cl->dev[devid].use_events ? DT_OPENCL_EVENTS : 0,
     cl->dev[devid].asyncmode,
     cl->dev[devid].disabled,
-    0.0f, // dummy for now as we don't have the benching any more
     cl->dev[devid].advantage,
     cl->dev[devid].unified_fraction);
   dt_print_nts(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE,
@@ -383,38 +379,23 @@ gboolean dt_opencl_read_device_config(const int devid)
   if(existing_device)
   {
     const gchar *dat = dt_conf_get_string_const(key);
-    int idummy;
     int micro_nap;
     int pinned_memory;
     int events;
     int asyncmode;
     int disabled;
-    float dummy; // unused
     float advantage;
     float unified_fraction;
-    sscanf(dat, "%i %i %i %i %i %i %i %i %f %f %f",
-           &idummy, &micro_nap, &pinned_memory, &idummy, &idummy,
-           &events, &asyncmode, &disabled, &dummy, &advantage, &unified_fraction);
+    sscanf(dat, "%i %i %i %i %i %f %f",
+           &micro_nap, &pinned_memory, &events, &asyncmode, &disabled, &advantage, &unified_fraction);
 
     cldid->use_events = events ? TRUE : FALSE;
-
-    // some rudimentary safety checking if string seems to be ok
-    safety_ok = (advantage >= 0.0f) && (advantage <= 10000.0f);
-
-    if(safety_ok)
-    {
-      cldid->micro_nap = micro_nap;
-      cldid->pinned_memory = pinned_memory;
-      cldid->asyncmode = asyncmode;
-      cldid->disabled = disabled;
-      cldid->advantage = advantage;
-      cldid->unified_fraction = unified_fraction;
-    }
-    else // if there is something wrong with the found conf key reset to defaults
-    {
-      dt_print(DT_DEBUG_OPENCL,
-               "[dt_opencl_read_device_config] malformed data '%s' for '%s'", dat, key);
-    }
+    cldid->micro_nap = micro_nap;
+    cldid->pinned_memory = pinned_memory ? TRUE : FALSE;
+    cldid->asyncmode = asyncmode ? TRUE : FALSE;
+    cldid->disabled = disabled ? TRUE : FALSE;
+    cldid->advantage = advantage;
+    cldid->unified_fraction = unified_fraction;
     setlocale(LC_NUMERIC, locale);
   }
 
@@ -426,10 +407,6 @@ gboolean dt_opencl_read_device_config(const int devid)
     cldid->micro_nap = 250;
   if((cldid->advantage < 0.0f) || (cldid->advantage > 10000.0f))
     cldid->advantage = 0.0f;
-
-  cldid->asyncmode =  cldid->asyncmode ? TRUE : FALSE;
-  cldid->disabled = cldid->disabled ? TRUE : FALSE;
-  cldid->pinned_memory = cldid->pinned_memory ? TRUE : FALSE;
 
   // Also take care of extended device data, these are not only device
   // specific but also depend on the devid
@@ -1012,18 +989,7 @@ static gboolean _opencl_device_init(dt_opencl_t *cl,
      && (dt_conf_get_int("performance_configuration_version_completed") > 17))
     compile_opt = dt_conf_get_string_const(compile_option_name_cname);
   else
-  {
-    if(!strcmp("nvidiacuda", pname))
-      compile_opt = DT_OPENCL_DEFAULT_COMPILE_OPTI;
-    else if(!strcmp("apple", pname))
-      compile_opt = DT_OPENCL_DEFAULT_COMPILE_OPTI;
-    else if(!strcmp("amdacceleratedparallelprocessing", pname))
-      compile_opt = DT_OPENCL_DEFAULT_COMPILE_OPTI;
-    else if(!strncmp("rusticl", pname, 7))
-      compile_opt = DT_OPENCL_DEFAULT_COMPILE_OPTI;
-    else
-      compile_opt = DT_OPENCL_DEFAULT_COMPILE_DEFAULT;
-  }
+    compile_opt = dt_conf_get_bool("opencl_fast") ? DT_OPENCL_DEFAULT_COMPILE_OPTI : DT_OPENCL_DEFAULT_COMPILE_DEFAULT;
 
   gchar *my_option = g_strdup(compile_opt);
   dt_conf_set_string(compile_option_name_cname, my_option);
@@ -2298,6 +2264,9 @@ static gboolean _opencl_load_program(const int dev,
   // Include compiler flags for checksum
   len = g_strlcpy(start, cl->dev[dev].cflags, end - start);
   start += len;
+
+  start[0] = dt_conf_get_bool("opencl_fast");
+  start += 1;
 
   /* make sure that the md5sums of all the includes are applied as well */
   for(int n = 0; n < DT_OPENCL_MAX_INCLUDES; n++)

--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -70,12 +70,12 @@ G_BEGIN_DECLS
 
 #define DT_OPENCL_DEFAULT_COMPILE_DEFAULT ("")
 #define DT_OPENCL_DEFAULT_COMPILE_OPTI ("-cl-fast-relaxed-math")
-#define DT_CLDEVICE_HEAD ("cldevice_v5_")
+#define DT_CLDEVICE_HEAD ("cldevice_v6_")
 
 // version for current darktable cl kernels
 // this is reflected in the kernel directory and allows to
 // enforce a new kernel compilation cycle
-#define DT_OPENCL_KERNELS 5
+#define DT_OPENCL_KERNELS 6
 
 typedef enum dt_opencl_memory_t
 {

--- a/src/iop/demosaicing/capture.c
+++ b/src/iop/demosaicing/capture.c
@@ -1058,10 +1058,9 @@ static int _capture_sharpen_cl(dt_iop_module_t *self,
   cl_mem luminance = dt_opencl_alloc_device_buffer(devid, bsize);
   cl_mem tmp2 = dt_opencl_alloc_device_buffer(devid, bsize);
   cl_mem tmp1 = dt_opencl_alloc_device_buffer(devid, bsize);
-  cl_mem whites = dt_opencl_copy_host_to_device_constant(devid, 4 * sizeof(float), icoeffs);
   cl_mem dev_rgb = dt_opencl_duplicate_image(devid, dev_out);
 
-  if(!blendmask || !luminance || !tmp2 || !tmp1 || !whites || !dev_rgb) goto finish;
+  if(!blendmask || !luminance || !tmp2 || !tmp1 || !dev_rgb) goto finish;
 
   err = dt_opencl_enqueue_kernel_2d_args(devid, gd->prefill_clip_mask, width, height,
           CLARG(tmp2), CLARG(width), CLARG(height));
@@ -1069,7 +1068,7 @@ static int _capture_sharpen_cl(dt_iop_module_t *self,
 
   err = dt_opencl_enqueue_kernel_2d_args(devid, gd->prepare_blend, width, height,
           CLARG(dev_in), CLARG(dev_out), CLARG(filters), CLARG(dev_xtrans), CLARG(tmp2), CLARG(tmp1),
-          CLARG(whites), CLARG(width), CLARG(height));
+          CLARG(icoeffs), CLARG(width), CLARG(height));
   if(err != CL_SUCCESS) goto finish;
 
   err = dt_opencl_enqueue_kernel_2d_args(devid, gd->modify_blend, width, height,
@@ -1140,7 +1139,6 @@ static int _capture_sharpen_cl(dt_iop_module_t *self,
   dt_opencl_release_mem_object(tmp2);
   dt_opencl_release_mem_object(tmp1);
   dt_opencl_release_mem_object(luminance);
-  dt_opencl_release_mem_object(whites);
 
   return err;
 }

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -558,7 +558,6 @@ int process_cl(dt_iop_module_t *self,
 
   cl_int err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
   cl_mem dev_xtrans = NULL;
-  cl_mem dev_clips = NULL;
 
   if(g && fullpipe)
   {
@@ -574,9 +573,8 @@ int process_cl(dt_iop_module_t *self,
                            mclip * (c[BLUE]  <= 0.0f ? 1.0f : c[BLUE]),
                            mclip * (c[GREEN] <= 0.0f ? 1.0f : c[GREEN]) };
 
-        dev_clips = dt_opencl_copy_host_to_device_constant(devid, 4 * sizeof(float), clips);
         dev_xtrans = dt_opencl_copy_host_to_device_constant(devid, sizeof(piece->xtrans), piece->xtrans);
-        if(!dev_clips || !dev_xtrans) goto finish;
+        if(!dev_xtrans) goto finish;
 
         const int dy = roi_out->y - roi_in->y;
         const int dx = roi_out->x - roi_in->x;
@@ -587,7 +585,7 @@ int process_cl(dt_iop_module_t *self,
           CLARG(roi_in->width), CLARG(roi_in->height),
           CLARG(dx), CLARG(dy),
           CLARG(filters), CLARG(dev_xtrans),
-          CLARG(dev_clips));
+          CLARG(clips));
         announce = FALSE;
         goto finish;
       }
@@ -658,11 +656,15 @@ int process_cl(dt_iop_module_t *self,
     const dt_dev_chroma_t *chr = &self->dev->chroma;
     dt_aligned_pixel_t clips = { clip, clip, clip, clip};
     if(chr->late_correction)
-    for_each_channel(c)
-      clips[c] *= chr->as_shot[c] / chr->D65coeffs[c];
-    dev_clips = dt_opencl_copy_host_to_device_constant(devid, 4 * sizeof(float), clips);
+    {
+      clips[0] *= chr->as_shot[0] / chr->D65coeffs[0];
+      clips[1] *= chr->as_shot[1] / chr->D65coeffs[1];
+      clips[2] *= chr->as_shot[2] / chr->D65coeffs[2];
+      clips[3] *= chr->as_shot[1] / chr->D65coeffs[1];
+    }
+
     dev_xtrans = dt_opencl_copy_host_to_device_constant(devid, sizeof(piece->xtrans), piece->xtrans);
-    if(!dev_clips || !dev_xtrans) goto finish;
+    if(!dev_xtrans) goto finish;
 
     // raw images with clip mode (both bayer and xtrans)
     const int dy = roi_out->y - roi_in->y;
@@ -671,7 +673,7 @@ int process_cl(dt_iop_module_t *self,
       CLARG(dev_in), CLARG(dev_out),
       CLARG(roi_in->width), CLARG(roi_in->height),
       CLARG(roi_out->width), CLARG(roi_out->height),
-      CLARG(dev_clips), CLARG(dx), CLARG(dy),
+      CLARG(clips), CLARG(dx), CLARG(dy),
       CLARG(filters), CLARG(dev_xtrans));
   }
   if(err != CL_SUCCESS) goto finish;
@@ -703,7 +705,6 @@ int process_cl(dt_iop_module_t *self,
   finish:
   if(err != CL_SUCCESS) dt_iop_piece_clear_raster(piece, NULL);
 
-  dt_opencl_release_mem_object(dev_clips);
   dt_opencl_release_mem_object(dev_xtrans);
   return err;
 }
@@ -736,7 +737,10 @@ static void process_clip(dt_iop_module_t *self,
     dt_aligned_pixel_t clips = { clip, clip, clip, clip};
     if(chr->late_correction)
     {
-      for_each_channel(c) clips[c] *= chr->as_shot[c] / chr->D65coeffs[c];
+      clips[0] *= chr->as_shot[0] / chr->D65coeffs[0];
+      clips[1] *= chr->as_shot[1] / chr->D65coeffs[1];
+      clips[2] *= chr->as_shot[2] / chr->D65coeffs[2];
+      clips[3] *= chr->as_shot[1] / chr->D65coeffs[1];
     }
     for(int row = 0; row < roi_out->height; row++)
     {

--- a/src/iop/hlreconstruct/opposed.c
+++ b/src/iop/hlreconstruct/opposed.c
@@ -48,12 +48,10 @@ static dt_hash_t _opposed_hash(dt_dev_pixelpipe_iop_t *piece)
 
 static inline float _calc_linear_refavg(const float *in, const int color)
 {
-  const dt_aligned_pixel_t ins = { powf(fmaxf(0.0f, in[0]), 1.0f / HL_POWERF),
-                                   powf(fmaxf(0.0f, in[1]), 1.0f / HL_POWERF),
-                                   powf(fmaxf(0.0f, in[2]), 1.0f / HL_POWERF), 0.0f };
+  const dt_aligned_pixel_t ins = { cbrtf(fmaxf(0.0f, in[0])), cbrtf(fmaxf(0.0f, in[1])), cbrtf(fmaxf(0.0f, in[2])), 0.0f };
   const dt_aligned_pixel_t opp = { 0.5f*(ins[1]+ins[2]), 0.5f*(ins[0]+ins[2]), 0.5f*(ins[0]+ins[1]), 0.0f};
 
-  return powf(opp[color], HL_POWERF);
+  return fcube(opp[color]);
 }
 
 static inline size_t _raw_to_cmap(const size_t width, const size_t row, const size_t col)

--- a/src/iop/hlreconstruct/segbased.c
+++ b/src/iop/hlreconstruct/segbased.c
@@ -88,8 +88,6 @@ The chosen segmentation algorithm works like this:
 #define HL_FLOAT_PLANES 8
 #define HL_BORDER 8
 
-#define HL_POWERF 3.0f
-
 static inline float _local_std_deviation(const float *p, const int w)
 {
   const int w2 = 2*w;
@@ -214,13 +212,13 @@ static inline float _calc_refavg(const float *in,
     }
   }
   for_each_channel(c)
-    mean[c] = (cnt[c] > 0.0f) ? powf((correction[c] * mean[c]) / cnt[c], 1.0f / HL_POWERF) : 0.0f;
+    mean[c] = (cnt[c] > 0.0f) ? cbrtf((correction[c] * mean[c]) / cnt[c]) : 0.0f;
 
   const dt_aligned_pixel_t croot_refavg = { 0.5f * (mean[1] + mean[2]),
                                             0.5f * (mean[0] + mean[2]),
                                             0.5f * (mean[0] + mean[1]),
                                             0.0f};
-  return (linear) ? powf(croot_refavg[color], HL_POWERF) : croot_refavg[color];
+  return (linear) ? fcube(croot_refavg[color]) : croot_refavg[color];
 }
 
 static void _initial_gradients(const size_t w,
@@ -464,7 +462,7 @@ static void _process_segmentation(dt_dev_pixelpipe_iop_t *piece,
 
   const dt_aligned_pixel_t icoeffs = { piece->pipe->dsc.temperature.coeffs[0], piece->pipe->dsc.temperature.coeffs[1], piece->pipe->dsc.temperature.coeffs[2]};
   const dt_aligned_pixel_t clips = { clipval * icoeffs[0], clipval * icoeffs[1], clipval * icoeffs[2]};
-  const dt_aligned_pixel_t cube_coeffs = { powf(clips[0], 1.0f / HL_POWERF), powf(clips[1], 1.0f / HL_POWERF), powf(clips[2], 1.0f / HL_POWERF)};
+  const dt_aligned_pixel_t cube_coeffs = {cbrtf(clips[0]), cbrtf(clips[1]), cbrtf(clips[2]), 0.0f};
 
   const dt_dev_chroma_t *chr = &piece->module->dev->chroma;
   const gboolean late = chr->late_correction;
@@ -543,7 +541,7 @@ static void _process_segmentation(dt_dev_pixelpipe_iop_t *piece,
         }
 
         for_each_channel(c)
-          mean[c] = (cnt[c] > 0.0f) ? powf(correction[c] * mean[c] / cnt[c], 1.0f / HL_POWERF) : 0.0f;
+          mean[c] = (cnt[c] > 0.0f) ? cbrtf(correction[c] * mean[c] / cnt[c]) : 0.0f;
         const dt_aligned_pixel_t cube_refavg = { 0.5f * (mean[1] + mean[2]),
                                                  0.5f * (mean[0] + mean[2]),
                                                  0.5f * (mean[0] + mean[1]),
@@ -612,7 +610,7 @@ static void _process_segmentation(dt_dev_pixelpipe_iop_t *piece,
           {
             const float cand_reference = isegments[color].val2[pid];
             const float refavg_here = _calc_refavg(input, xtrans, filters, row, col, roi_in, correction, FALSE);
-            const float oval = powf(refavg_here + candidate - cand_reference, HL_POWERF);
+            const float oval = fcube(refavg_here + candidate - cand_reference);
             tmpout[idx] = plane[color][o] = fmaxf(inval, oval);
           }
         }


### PR DESCRIPTION
**OpenCL Version update for 5.6**

1. The OpenCL compiler optimizing flags can lead to better performance with reduced precision.
   The effect is depending on the vendor and used compiler.
   Instead of relying on the user to modify this we now have an option in preferences in the
   OpenCL section: "OpenCL fast mode"
   If switched on the compiler is allowed to use more aggressive optimizing.
   This flag is also included in the kernel hash enforcing a recompile cycle if changed.
2. After recent dt OpenCL interface changes we don't need some per-device settings any more.
   While updating a message is pesented to the user.
   The per-device conf string is now with a preceding 'cldevice_v6_'
   We now have per device:
     micro_nap pinned_memory use_events asyncmode disabled, advantage, unified_fraction

3. Introduce a few helper inline functions for opencl kernels

__________________________________________________________________________
**Slightly improved capture OpenCL interface**

1. Pass icoeffs as a float4 instead of cl_mem
2. use inlines for reading.
3. minor improvements internally

_________________________________________________________________________
**Highlights maintenance and minor fix**

1. OpenCL clip mode and falsecolor got a simpler kernel calling interface
2. Support bayer4 images properly in clip mode
3. As we used pow(x, 3) for opposed ref calculation for some time now and there has been no further
   refinement possible, let's use fcube and cbrt instead of the costly pow() also having higher precision.

__________________________________________________________________________

@TurboGit
6350167ff168f73bc5a01ac1b1b2001a37c87f61 would be my proposal to expose basic compiler stuff in an easy-to-use way to the users. As noted the effect is depending on vendor & compiler so nothing to predict precisely. Also the per-device config has been stripped to what-we-use

Other two commits are basically maintenance/corrections no result changes in integration tests observed or expected.

BTW we might also want to specify  `--conf plugins/lighttable/export/pixel_interpolator_warp=bilinear` or whatever your system uses for stability.