### PR TITLE
Fixes masks jumping around when crop is toggled.

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -2802,8 +2802,11 @@ gboolean dt_dev_get_preview_size(const dt_develop_t *dev,
                                  float *wd,
                                  float *ht)
 {
-  *wd = dev->full.pipe->processed_width / dev->preview_pipe->iscale;
-  *ht = dev->full.pipe->processed_height / dev->preview_pipe->iscale;
+  // Use preview pipe's actual processed size, not full.pipe/iscale.
+  // The two differ by up to 1 pixel due to independent integer truncations
+  // in each pipeline (e.g. after crop), causing a systematic mask overlay shift.
+  *wd = dev->preview_pipe->processed_width;
+  *ht = dev->preview_pipe->processed_height;
   return *wd >= 1.f && *ht >= 1.f;
 }
 
@@ -3163,7 +3166,13 @@ void dt_dev_zoom_move(dt_dev_viewport_t *port,
 
   pts[0] = (zoom_x + 0.5f) * procw;
   pts[1] = (zoom_y + 0.5f) * proch;
-  const gboolean has_moved = fabsf(pts[0] - old_pts0) + fabsf(pts[1] - old_pts1) > 0.5f
+  // For validation-only calls (DT_ZOOM_MOVE with no movement), use a larger threshold
+  // to prevent sub-pixel clamping from causing a permanent viewport drift when the
+  // pipeline changes (e.g., crop module toggled). At high zoom levels, even a 0.5-pixel
+  // clamp in pipeline-output space backward-transforms to a 1-pixel shift in input space,
+  // which appears as a visible mask/image shift after the crop is removed.
+  const float moved_threshold = (zoom == DT_ZOOM_MOVE && !x && !y) ? 3.0f : 0.5f;
+  const gboolean has_moved = fabsf(pts[0] - old_pts0) + fabsf(pts[1] - old_pts1) > moved_threshold
     || (zoom == DT_ZOOM_MOVE && (x || y));
   if(has_moved)
   {

--- a/src/develop/masks.h
+++ b/src/develop/masks.h
@@ -1169,30 +1169,24 @@ static inline void dt_masks_get_image_size(float *width,
                                            float *iwidth,
                                            float *iheight)
 {
-  // Use full.pipe dimensions divided by iscale to obtain floating-point preview
-  // coordinates that exactly match the Cairo coordinate system used by the darkroom
-  // canvas (wd = full.pipe->processed_width / iscale, see dt_dev_get_preview_size).
-  // The integer-truncated backbuf_width / preview->iwidth values differ by up to
-  // one pixel from these floats, which causes a scale error that becomes a visible
-  // misalignment (~50-60 px) at high zoom levels for non-round image dimensions
-  // (e.g. 6022×4024 with iscale=6 → 1003.67 vs 1003).
-  // Use full.pipe dimensions divided by iscale to obtain floating-point preview
-  // coordinates that exactly match the Cairo coordinate system used by the darkroom
-  // canvas (wd = full.pipe->processed_width / iscale, see dt_dev_get_preview_size).
-  // The integer-truncated backbuf_width values differ by up to one pixel from these
-  // floats, which causes a scale error that becomes a visible misalignment at high
-  // zoom levels for non-round image dimensions.
-  //
   // iwidth/iheight must match preview->iwidth/iheight (= pipe->iwidth/iheight used
   // by _path_get_pts_border to scale corner coordinates before distort_transform).
-  // Using full.pipe->iwidth / iscale instead gives a non-integer value that does NOT
-  // match pipe->iwidth due to iscale rounding, causing a mismatch between the forward
-  // (display) and backward (drag normalization) coordinate transforms.
+  // width/height must match preview->processed_width/height, which is what both
+  // dt_dev_get_preview_size() and dt_view_paint_surface FALLBACK use as canvas size.
   const dt_develop_t *dev = darktable.develop;
   const dt_dev_pixelpipe_t *preview = dev->preview_pipe;
   const float iscale = preview->iscale > 0.f ? preview->iscale : 1.f;
 
-  if(dev->full.pipe && dev->full.pipe->processed_width > 0)
+  // Use preview pipe's actual processed dimensions, not full.pipe/iscale.
+  // The two differ by up to 1 pixel due to independent integer truncations
+  // in each pipeline (e.g. after crop), causing a systematic mask overlay shift.
+  // dt_dev_get_preview_size() uses the same value, so both are consistent.
+  if(preview->processed_width > 0)
+  {
+    if(width  ) *width   = preview->processed_width;
+    if(height ) *height  = preview->processed_height;
+  }
+  else if(dev->full.pipe && dev->full.pipe->processed_width > 0)
   {
     if(width  ) *width   = dev->full.pipe->processed_width  / iscale;
     if(height ) *height  = dev->full.pipe->processed_height / iscale;
@@ -1208,6 +1202,7 @@ static inline void dt_masks_get_image_size(float *width,
   // functions), so that backtransform(corner * pipe->iwidth) / iwidth = corner.
   if(iwidth ) *iwidth  = preview->iwidth;
   if(iheight) *iheight = preview->iheight;
+
 }
 
 G_END_DECLS

--- a/src/develop/masks/path.c
+++ b/src/develop/masks/path.c
@@ -1281,9 +1281,6 @@ static int _path_get_pts_border(dt_develop_t *dev,
 
   const float wd = pipe->iwidth, ht = pipe->iheight;
   const guint nb = g_list_length(form->points);
-  // DEBUG #19135
-  dt_print(DT_DEBUG_MASKS, "[path_get_pts_border] pipe->iwidth=%.1f pipe->backbuf_width=%d pipe->iscale=%.4f",
-           (float)pipe->iwidth, pipe->backbuf_width, pipe->iscale);
 
   dt_masks_dynbuf_t *dpoints = NULL, *dborder = NULL, *intersections = NULL;
   dt_masks_intbuf_t *gap_fill_segs = NULL;
@@ -1537,7 +1534,8 @@ static int _path_get_pts_border(dt_develop_t *dev,
     dt_free_align(border_init);
     return 1;
   }
-  else if(dt_dev_distort_transform_plus(dev, pipe, iop_order, transf_direction,
+  // Note: the if(source) branch above always returns, so this is not really an else-if.
+  if(dt_dev_distort_transform_plus(dev, pipe, iop_order, transf_direction,
                                         *points, *points_count))
   {
     if(!border
@@ -2162,20 +2160,6 @@ static int _path_events_button_pressed(dt_iop_module_t *module,
         gui->scrollx = pzx;
         gui->scrolly = pzy;
       }
-      // DEBUG #19135
-      {
-        const int k = gui->point_selected;
-        dt_masks_point_path_t *dbg = g_list_nth_data(form->points, k);
-        dt_print(DT_DEBUG_MASKS, "[path_button_press] point_selected=%d"
-                 "  click: pzx=%.6f pzy=%.6f  pzx*wd=%.4f pzy*ht=%.4f"
-                 "  gpt->points=(%.4f,%.4f)"
-                 "  corner=(%.6f,%.6f)"
-                 "  wd=%.4f iwidth=%.4f",
-                 k, pzx, pzy, pzx * wd, pzy * ht,
-                 gpt->points[k * 6 + 2], gpt->points[k * 6 + 3],
-                 dbg ? dbg->corner[0] : -1.f, dbg ? dbg->corner[1] : -1.f,
-                 wd, iwidth);
-      }
       gui->point_edited = gui->point_dragging = gui->point_selected;
       gpt->clockwise = _path_is_clockwise(form);
       dt_control_queue_redraw_center();
@@ -2540,22 +2524,6 @@ static int _path_events_mouse_moved(dt_iop_module_t *module,
   if(gui->point_dragging >= 0)
   {
     float pts[2] = { pzx * wd, pzy * ht };
-    // DEBUG #19135
-    {
-      dt_masks_point_path_t *dbg = g_list_nth_data(form->points, gui->point_dragging);
-      if(dbg)
-        dt_print(DT_DEBUG_MASKS, "[path_drag] point_dragging=%d  pzx=%.6f pzy=%.6f"
-                 "  pts_in=(%.4f,%.4f)"
-                 "  wd=%.4f iwidth=%.4f"
-                 "  corner=(%.6f,%.6f)"
-                 "  gpt=(%.4f,%.4f)",
-                 gui->point_dragging, pzx, pzy,
-                 pts[0], pts[1],
-                 wd, iwidth,
-                 dbg->corner[0], dbg->corner[1],
-                 gpt->points[gui->point_dragging * 6 + 2],
-                 gpt->points[gui->point_dragging * 6 + 3]);
-    }
     if(gui->creation && !g_list_shorter_than(form->points, 4))
     {
       // if we are near the first point, we have to say that the form should be closed
@@ -2574,15 +2542,6 @@ static int _path_events_mouse_moved(dt_iop_module_t *module,
 
     dt_dev_distort_backtransform(darktable.develop, pts, 1);
     dt_masks_point_path_t *bzpt = g_list_nth_data(form->points, gui->point_dragging);
-    // DEBUG #19135
-    dt_print(DT_DEBUG_MASKS, "[path_drag] after backtransform: pts=(%.4f,%.4f)"
-             "  /iwidth → norm=(%.6f,%.6f)"
-             "  bzpt->corner=(%.6f,%.6f)  delta=(%.6f,%.6f)",
-             pts[0], pts[1],
-             pts[0]/iwidth, pts[1]/iheight,
-             bzpt ? bzpt->corner[0] : -1.f, bzpt ? bzpt->corner[1] : -1.f,
-             bzpt ? pts[0]/iwidth - bzpt->corner[0] : 0.f,
-             bzpt ? pts[1]/iheight - bzpt->corner[1] : 0.f);
     pzx = pts[0] / iwidth;
     pzy = pts[1] / iheight;
 

--- a/src/iop/crop.c
+++ b/src/iop/crop.c
@@ -441,25 +441,23 @@ static gboolean _set_max_clip(dt_iop_module_t *self)
   return TRUE;
 }
 
-// Compute the crop offset (left, top) that modify_roi_out would produce for this piece.
-// Uses a scale factor on preview pipes to reduce integer-truncation rounding errors
-// (same approach as clipping.c), and naturally captures any alignment correction that
-// modify_roi_out adds for fixed-ratio export crops.
+// Compute the crop offset (left, top) that the pipeline actually uses for this piece.
+// Use factor=1 (buf_in dimensions without scaling) so the resulting integer crop_left/crop_top
+// exactly matches the roi_out.x/y produced by modify_roi_out during normal pipeline processing.
+// This ensures the mask overlay aligns pixel-accurately with the actual image buffer.
+// (A factor=100 scaling was previously used here to reduce float truncation error, but it
+// produced non-integer offsets like 446.69 while the pipeline crops at integer pixel 446,
+// causing a ~0.7 pixel misalignment visible as ~11 screen pixels at 1600% zoom.)
 static void _get_crop_offset(dt_iop_module_t *self,
                               dt_dev_pixelpipe_iop_t *piece,
                               float *crop_left,
                               float *crop_top)
 {
-  float factor = 1.0f;
-  if(piece->pipe->type & (DT_DEV_PIXELPIPE_PREVIEW | DT_DEV_PIXELPIPE_PREVIEW2)) factor = 100.0f;
-
   dt_iop_roi_t roi_in = piece->buf_in, roi_out;
-  roi_in.width  = (int)(piece->buf_in.width  * factor);
-  roi_in.height = (int)(piece->buf_in.height * factor);
   self->modify_roi_out(self, piece, &roi_out, &roi_in);
 
-  *crop_left = roi_out.x / factor;
-  *crop_top  = roi_out.y / factor;
+  *crop_left = roi_out.x;
+  *crop_top  = roi_out.y;
 }
 
 gboolean distort_transform(dt_iop_module_t *self,

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -133,6 +133,50 @@ static void _get_zoom_pos(dt_dev_viewport_t *port,
   }
 }
 
+/* Compute the correction (zoom_x_preview - zoom_x_full) to add to a full-pipe
+   normalized zoom position to get the equivalent preview-pipe position.
+   Mask overlay points live in preview-pipe output space while _get_zoom_pos()
+   and dt_dev_get_viewport_params() use the full pipe; applying this correction
+   makes mouse positions match mask point coordinates when crop (or similar
+   modules) rounds pixel counts differently in the two pipes. */
+static void _preview_pipe_zoom_correction(dt_develop_t *dev, float *cx, float *cy)
+{
+  *cx = *cy = 0.f;
+  if(!dev->preview_pipe || !dev->full.pipe) return;
+
+  const float full_iw = (float)dev->full.pipe->iwidth;
+  const float full_ih = (float)dev->full.pipe->iheight;
+  if(full_iw <= 0 || full_ih <= 0) return;
+
+  const float pp_wd   = (float)dev->preview_pipe->processed_width;
+  const float pp_ht   = (float)dev->preview_pipe->processed_height;
+  const float full_wd = (float)dev->full.pipe->processed_width;
+  const float full_ht = (float)dev->full.pipe->processed_height;
+  if(pp_wd <= 0 || pp_ht <= 0 || full_wd <= 0 || full_ht <= 0) return;
+
+  // Full-pipe viewport centre in normalised coords
+  float full_pts[2] = { dev->full.zoom_x, dev->full.zoom_y };
+  dt_dev_distort_transform_plus(dev, dev->full.pipe,
+                                0.0f, DT_DEV_TRANSFORM_DIR_ALL_GEOMETRY, full_pts, 1);
+  const float zoom_x_full = full_pts[0] / full_wd - 0.5f;
+  const float zoom_y_full = full_pts[1] / full_ht - 0.5f;
+
+  // Preview-pipe viewport centre in normalised coords
+  const float prev_iw = (float)dev->preview_pipe->iwidth;
+  const float prev_ih = (float)dev->preview_pipe->iheight;
+  float prev_pts[2] = {
+    dev->full.zoom_x * prev_iw / full_iw,
+    dev->full.zoom_y * prev_ih / full_ih
+  };
+  dt_dev_distort_transform_plus(dev, dev->preview_pipe,
+                                0.0f, DT_DEV_TRANSFORM_DIR_ALL_GEOMETRY, prev_pts, 1);
+  const float zoom_x_vp = prev_pts[0] / pp_wd - 0.5f;
+  const float zoom_y_vp = prev_pts[1] / pp_ht - 0.5f;
+
+  *cx = zoom_x_vp - zoom_x_full;
+  *cy = zoom_y_vp - zoom_y_full;
+}
+
 static void _get_zoom_pos_bnd(dt_dev_viewport_t *port,
                               const double x,
                               const double y,
@@ -698,6 +742,29 @@ void expose(dt_view_t *self,
   float pzx = FLT_MAX, pzy = 0.0f;
   float zoom_scale = dt_dev_get_zoom_scale(&dev->full, port->zoom, 1 << port->closeup, TRUE);
 
+  // Compute viewport center through the preview pipe. port->zoom_x is in full-pipe input
+  // space; scale to preview-pipe input space before forward-transforming. Mask overlay
+  // points live in preview-pipe output space, so the Cairo viewport must use the same
+  // coordinate origin — using the full-pipe result causes a sub-pixel divergence that
+  // becomes a visible shift at high zoom when crop changes the pipe aspect ratio.
+  const float full_iw = dev->full.pipe ? (float)dev->full.pipe->iwidth  : 1.f;
+  const float full_ih = dev->full.pipe ? (float)dev->full.pipe->iheight : 1.f;
+  const float prev_iw = dev->preview_pipe ? (float)dev->preview_pipe->iwidth  : 1.f;
+  const float prev_ih = dev->preview_pipe ? (float)dev->preview_pipe->iheight : 1.f;
+  float prev_pts[2] = {
+    port->zoom_x * prev_iw / full_iw,
+    port->zoom_y * prev_ih / full_ih
+  };
+  dt_dev_distort_transform_plus(dev, dev->preview_pipe,
+                                0.0f, DT_DEV_TRANSFORM_DIR_ALL_GEOMETRY, prev_pts, 1);
+  const float pp_wd = dev->preview_pipe->processed_width;
+  const float pp_ht = dev->preview_pipe->processed_height;
+  float zoom_x_vp = pp_wd > 0 ? prev_pts[0] / pp_wd - 0.5f : 0.f;
+  float zoom_y_vp = pp_ht > 0 ? prev_pts[1] / pp_ht - 0.5f : 0.f;
+  // apply same clamping as zoom_x/zoom_y (image fits nearly entirely in view)
+  if(boxw > 0.95f) zoom_x_vp = 0.f;
+  if(boxh > 0.95f) zoom_y_vp = 0.f;
+
   // don't draw guides and color pickers on image margins
   cairo_rectangle(cri, tb, tb, width - 2.0 * tb, height - 2.0 * tb);
 
@@ -763,6 +830,10 @@ void expose(dt_view_t *self,
     const float vp_y = (tb - 0.5f * height) / zoom_scale + 0.5f * ht + zoom_y * ht;
     cairo_rectangle(cri, vp_x, vp_y, vp_w, vp_h);
     cairo_clip(cri);
+    // Mask overlay points are in preview-pipe output space; shift the
+    // coordinate origin by the sub-pixel difference between full-pipe
+    // and preview-pipe viewport centres so overlays land on the image.
+    cairo_translate(cri, (zoom_x - zoom_x_vp) * wd, (zoom_y - zoom_y_vp) * ht);
     dt_masks_events_post_expose(dmod, cri, width, height, 0.0f, 0.0f, zoom_scale);
     cairo_restore(cri);
   }
@@ -3726,7 +3797,9 @@ void mouse_moved(dt_view_t *self,
      && !dt_iop_color_picker_is_visible(dev))
   {
     _get_zoom_pos(&dev->full, x, y, &zoom_x, &zoom_y, &zoom_scale);
-    handled = dt_masks_events_mouse_moved(dev->gui_module, zoom_x, zoom_y,
+    float corr_x, corr_y;
+    _preview_pipe_zoom_correction(dev, &corr_x, &corr_y);
+    handled = dt_masks_events_mouse_moved(dev->gui_module, zoom_x + corr_x, zoom_y + corr_y,
                                           pressure, which, zoom_scale);
   }
 
@@ -3810,7 +3883,9 @@ int button_released(dt_view_t *self,
   if(dev->form_visible)
   {
     _get_zoom_pos(&dev->full, x, y, &zoom_x, &zoom_y, &zoom_scale);
-    handled = dt_masks_events_button_released(dev->gui_module, zoom_x, zoom_y,
+    float corr_x, corr_y;
+    _preview_pipe_zoom_correction(dev, &corr_x, &corr_y);
+    handled = dt_masks_events_button_released(dev->gui_module, zoom_x + corr_x, zoom_y + corr_y,
                                               which, state, zoom_scale);
     if(handled) return handled;
   }
@@ -3987,7 +4062,9 @@ int button_pressed(dt_view_t *self,
   if(dev->form_visible)
   {
     _get_zoom_pos(&dev->full, x, y, &zoom_x, &zoom_y, &zoom_scale);
-    handled = dt_masks_events_button_pressed(dev->gui_module, zoom_x, zoom_y,
+    float corr_x, corr_y;
+    _preview_pipe_zoom_correction(dev, &corr_x, &corr_y);
+    handled = dt_masks_events_button_pressed(dev->gui_module, zoom_x + corr_x, zoom_y + corr_y,
                                              pressure, which, type, state);
     if(handled) return handled;
   }
@@ -4043,7 +4120,10 @@ void scrolled(dt_view_t *self,
      && !darktable.develop->darkroom_skip_mouse_events)
   {
     _get_zoom_pos(&dev->full, x, y, &zoom_x, &zoom_y, &zoom_scale);
-    handled = dt_masks_events_mouse_scrolled(dev->gui_module, zoom_x, zoom_y, up, state);
+    float corr_x, corr_y;
+    _preview_pipe_zoom_correction(dev, &corr_x, &corr_y);
+    handled = dt_masks_events_mouse_scrolled(dev->gui_module, zoom_x + corr_x, zoom_y + corr_y,
+                                             up, state);
     if(handled) return;
   }
 


### PR DESCRIPTION

Hopefully, this fixes issue #20563.

Fix in action:

https://github.com/user-attachments/assets/30098032-3d93-47be-91c1-a6b945c33011

* Works with HQ/Preview pipelines
* Works with different crop ratios
* Works regardless of the relative position of the mask and the crop module

I don't know what is your regular benchmark for mask stress testing, let's see if @TurboGit or @jenshannoschwalm can break it ⚒️ 

More details below.

## Root cause: two pipes, one pixel apart

darktable runs two independent pixel pipelines simultaneously:

- **Full pipe** — processes the image at full resolution (e.g. 6022×4024 → crop → 4023px wide)
- **Preview pipe** — processes a downscaled version (e.g. 1346×900 → crop → 899px wide)

Both apply exactly the same modules. The crop module computes its output size with
integer truncation:

```c
roi_out->x     = MAX(0, (int)(roi_in->width  * d->cx));
roi_out->width = MAX(4, (int)(roi_in->width  * (d->cw - d->cx)));
```

For a 3:1 crop ratio, `d->cx` is adjusted so the cropped output is exactly 3× the
height. In the full pipe this might produce `crop_left = 446` px; in the preview pipe,
working on a 6× smaller image, it might produce `crop_left = 74` px. But
`74 × 6 = 444 ≠ 446` — the two pipes are off by 2 input pixels, which is a fraction
of a preview pixel after downscaling. This fraction, multiplied by `zoom_scale` (~35×),
becomes ~35 screen pixels.

---

## The five changes

### 1. `src/iop/crop.c` — `_get_crop_offset()`: use integer crop offsets

**Before:** `_get_crop_offset` called `modify_roi_out` on a 100× scaled copy of
`buf_in` to reduce floating-point truncation error, then divided back by 100. This
produced a non-integer result (e.g. `446.69`) that didn't match what the pipeline
actually used (integer `446`), causing a ~0.7 px misalignment in every mask overlay.

**After:** Call `modify_roi_out` directly on `buf_in` at 1:1 scale. The result is the
exact same integer `roi_out.x/y` the pipeline computed during processing — mask
overlays now subtract the same integer offset the image data was cropped by.

### 2. `src/develop/develop.c` — `dt_dev_get_preview_size()`: use actual preview dimensions

**Before:** Computed the preview canvas size as `full_pipe->processed_width / iscale`
— a floating-point division of the full-pipe output.

**After:** Uses `preview_pipe->processed_width` directly. These two values differ by
up to 1 pixel when crop's integer truncation lands differently across the two pipes.
All mask coordinate code (`dt_masks_get_image_size`, hit testing, Cairo overlay) now
uses the same canvas size the preview pipe actually produced.

### 3. `src/develop/masks.h` — `dt_masks_get_image_size()`: same fix, same reason

This function is the single place all mask shape code fetches `wd`/`ht` (the canvas
size in which mask point coordinates live). It was computing
`full.pipe->processed_width / iscale` for the same reason as above. Changed to use
`preview_pipe->processed_width` as the primary source, with the old formula as a
fallback when the preview pipe hasn't processed yet.

### 4. `src/develop/develop.c` — `dt_dev_zoom_move()`: prevent viewport drift on crop toggle

**Before:** Any call to `dt_dev_zoom_move(DT_ZOOM_MOVE, 0, 0)` — a validation-only
call with no actual movement — used a 0.5-pixel threshold to decide whether
`port->zoom_x` needed updating. When a crop was toggled, the pipeline changed, and
the backward transform of the viewport center could land just over 0.5px from the
stored position, silently updating `zoom_x` by a sub-pixel amount. This drift
accumulated and appeared as an image/mask shift.

**After:** Validation-only calls (zero `x`/`y` with `DT_ZOOM_MOVE`) use a 3.0-pixel
threshold, which is large enough to absorb the integer-truncation rounding across the
crop toggle without suppressing real panning.

### 5. `src/views/darkroom.c` — Cairo overlay alignment and hit-test correction

This is the most complex change, needed because even with the above fixes the ~1
preview pixel difference between full-pipe and preview-pipe viewport centers still
exists structurally (the two pipes are independent and will always differ slightly
after integer operations).

**The remaining problem:** Mask overlay points are computed by `distort_transform`
through the *preview pipe* (output space: 0…899 px). The Cairo drawing transform in
`expose()` was set up using the *full-pipe* viewport center (`zoom_x` from
`dt_dev_get_viewport_params`). At high zoom this 1-pixel difference in image space
becomes ~35 screen pixels.

**`zoom_x_vp` computation:** Before drawing, `expose()` now also transforms the
viewport center through the preview pipe to get `zoom_x_vp` — the preview-pipe
equivalent of `zoom_x`.

**Drawing fix:** The main Cairo transform for all overlays (guides, crop frame, color
picker) still uses the full-pipe `zoom_x`, so those stay aligned with the image
bitmap. Only inside the mask-specific `cairo_save/restore` block is an additional
`cairo_translate((zoom_x - zoom_x_vp) * wd, ...)` applied, shifting the coordinate
origin by the exact sub-pixel difference so mask overlays land correctly on the image.

**Hit-test fix:** Mouse event handlers (`mouse_moved`, `button_pressed`,
`button_released`, `scrolled`) compute the mouse position through the full pipe via
`_get_zoom_pos`. Before passing it to any mask event function, they now call
`_preview_pipe_zoom_correction()` to compute the same `zoom_x_vp - zoom_x_full`
difference and add it to `pzx`/`pzy`. This makes the mouse coordinate land in the
same preview-pipe space as the mask point coordinates, so anchor selection, dragging,
and segment proximity detection all work correctly.