### PR TITLE
Silence CMake SQLite depreciation warning

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -445,7 +445,7 @@ include_directories(SYSTEM ${LensFun_INCLUDE_DIRS})
 list(APPEND LIBS ${LensFun_LIBRARIES})
 
 find_package(SQLite3 3.26 REQUIRED)
-list(APPEND LIBS SQLite::SQLite3)
+list(APPEND LIBS SQLite3::SQLite3)
 
 foreach(lib ${OUR_LIBS} GIO GThread GModule PangoCairo Rsvg2 PNG JPEG TIFF LCMS2 JsonGlib)
   find_package(${lib} REQUIRED)


### PR DESCRIPTION
Latest CMake tells me:

CMake Warning (dev) at src/CMakeLists.txt:1061 (target_link_libraries):
  The library that is being linked to, SQLite::SQLite3, is marked as being
  deprecated by the owner.  The message provided by the developer is:

  The target name SQLite::SQLite3 is deprecated.  Please use SQLite3::SQLite3
  instead.