### PR TITLE
handle race condition when importing image(s) at startup

### DIFF
--- a/src/libs/backgroundjobs.c
+++ b/src/libs/backgroundjobs.c
@@ -134,9 +134,15 @@ static gboolean _added_gui_thread(gpointer user_data)
   gtk_widget_show_all(params->instance_widget);
   gtk_widget_show(params->self_widget);
 
-  GdkCursor *cursor = gdk_cursor_new_from_name(gdk_display_get_default(), "default");
-  gdk_window_set_cursor(gtk_widget_get_window(params->instance_widget), cursor);
-  g_object_unref(cursor);
+  // instance cursor to tell user that, if this is a blocking job with
+  // a global busy cursor, the cancel box in this widget can stop it
+  GdkWindow *window = gtk_widget_get_window(params->instance_widget);
+  if(window)
+  {
+    GdkCursor *cursor = gdk_cursor_new_from_name(gdk_display_get_default(), "default");
+    gdk_window_set_cursor(window, cursor);
+    g_object_unref(cursor);
+  }
 
   free(params);
   return G_SOURCE_REMOVE;


### PR DESCRIPTION
Make sure that we have a `GdkWindow` before setting its cursor in `_added_gui_thread()` in backgroundjobs.c. This avoids a warning (and perhaps crash?) at startup when importing images via the command line.

Sequence:

1. User starts darktable with command line arguments of either a directory name or > 1 file/directory names
2. `dt_init()` triggers a background import job (directly or via `dt_load_from_string()` calling `dt_film_import()`)
3. import function (`dt_pathlist_import_create()` or `dt_film_import1_create()`) calls `dt_control_job_add_progress()`
4. `dt_control_job_add_progress()` calls `dt_control_progress_create()`
5. `dt_control_progress_create()` calls `control->progress_system.proxy.added()` which points to `_lib_backgroundjobs_added()`
6. `_lib_backgroundjobs_added()` creates a job instance widget with information about the job and calls `_added_gui_thread()` in the global main context
7. `_added_gui_thread()` packs the instance widget into the progress widget then sets the instance widget cursor to `"default"`.

There is a race condition: In step 2, `dt_init()` triggers the import before it shows the main window. It is possible that we will get all the way to step 7 before `dt_init()` call `gtk_widget_show_all()` on the main window. In that case, there is no `GdkWindow` associated with the instance widget. The call to `gtk_widget_get_window()` in `_added_gui_thread()` will return `NULL`, and then the call to `gdk_window_set_cursor()` using the `GdkWindow` gives this warning:

```
gdk_window_set_cursor: assertion 'GDK_IS_WINDOW (window)' failed
```

This occurs approx. half the time when I start up darktable with a command line argument of a directory containing a single raw image.  I have also seen crashes at startup, but am not clear if this is related to this race condition.

The per-widget "default" cursor was added in
1877d1ad232e9745e1858332ebdc98d3674beab1 to visually signal that there was a way to cancel blocking jobs. When a job is `PROGRESS_BLOCKING`, the top level window has a busy cursor, but it should still be a pointer over the progress widget, to signal that it is possible to click the cancel button.

An alternative fix would be to, in `dt_init()`, move the import images calls to after the main window is realized. Simply testing for `NULL` as in this commit should risk fewer side effects. It should be OK not to change the cursor during an initial image import, as that job is not `PROGRESS_BLOCKING`, and there should be a main window displayed before any `PROGRESS_BLOCKING` jobs start.

This may be related to #20529.