### PR TITLE
[AI] Show AI build status in compile options at startup

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -920,9 +920,15 @@ char *version = g_strdup_printf(
 #endif
 
 #ifdef HAVE_WEBP
-               "  WebP                   -> ENABLED\n",
+               "  WebP                   -> ENABLED\n"
 #else
-               "  WebP                   -> DISABLED\n",
+               "  WebP                   -> DISABLED\n"
+#endif
+
+#ifdef HAVE_AI
+               "  AI                     -> ENABLED\n",
+#else
+               "  AI                     -> DISABLED\n",
 #endif
 
                PACKAGE_DOCS,


### PR DESCRIPTION
Add `AI -> ENABLED/DISABLED` to the compile options printed at startup, matching the existing format for other optional features.