### PR TITLE
Fixes darktable crashing when closing it while picker is active

### DIFF
--- a/src/gui/color_picker_proxy.c
+++ b/src/gui/color_picker_proxy.c
@@ -374,6 +374,15 @@ void dt_iop_color_picker_cleanup(void)
   DT_CONTROL_SIGNAL_DISCONNECT(_color_picker_proxy_preview_pipe_callback, NULL);
 }
 
+static void _color_picker_destroy(dt_iop_color_picker_t *picker)
+{
+  // When the widget is destroyed (e.g. during shutdown), clear the proxy pointer
+  // before freeing the struct to prevent use-after-free in dt_iop_color_picker_reset.
+  if(darktable.lib && darktable.lib->proxy.colorpicker.picker_proxy == picker)
+    darktable.lib->proxy.colorpicker.picker_proxy = NULL;
+  g_free(picker);
+}
+
 static GtkWidget *_color_picker_new(dt_iop_module_t *module,
                                     const dt_iop_color_picker_flags_t flags,
                                     GtkWidget *w,
@@ -394,7 +403,7 @@ static GtkWidget *_color_picker_new(dt_iop_module_t *module,
     }
     g_signal_connect_data(G_OBJECT(button), "button-press-event",
                           G_CALLBACK(_color_picker_callback_button_press),
-                          color_picker, (GClosureNotify)g_free, 0);
+                          color_picker, (GClosureNotify)_color_picker_destroy, 0);
     if(w) gtk_box_pack_start(GTK_BOX(w), button, FALSE, FALSE, 0);
 
     return button;
@@ -412,7 +421,7 @@ static GtkWidget *_color_picker_new(dt_iop_module_t *module,
     }
     g_signal_connect_data(G_OBJECT(w), "quad-pressed",
                           G_CALLBACK(_color_picker_callback),
-                          color_picker, (GClosureNotify)g_free, 0);
+                          color_picker, (GClosureNotify)_color_picker_destroy, 0);
 
     return w;
   }


### PR DESCRIPTION
This fixes occasional crashes closing darktable while a color picker is active in the darkroom.