### PR TITLE
[AI] Fix disk cache load with dynamic encoder output shapes

### DIFF
--- a/src/common/ai/segmentation.c
+++ b/src/common/ai/segmentation.c
@@ -1200,12 +1200,17 @@ gboolean dt_seg_disk_cache_load(dt_seg_context_t *ctx,
     }
     for(int d = 0; d < tmp_ndims[i] && ok; d++)
     {
+      // skip validation for dynamic dims - the model may report
+      // dynamic shapes at load time that resolve only after inference
+      if(ctx->enc_shapes[i][d] <= 0 || tmp_shapes[i][d] <= 0)
+        continue;
       if(tmp_shapes[i][d] != ctx->enc_shapes[i][d])
       {
         ok = FALSE;
         dt_print(DT_DEBUG_AI,
-                 "[segmentation] disk cache: shape mismatch for output %d dim %d",
-                 i, d);
+                 "[segmentation] disk cache: shape mismatch for "
+                 "output %d dim %d (file=%" PRId64 ", model=%" PRId64 ")",
+                 i, d, tmp_shapes[i][d], ctx->enc_shapes[i][d]);
       }
     }
 
@@ -1264,6 +1269,11 @@ gboolean dt_seg_disk_cache_load(dt_seg_context_t *ctx,
   {
     ctx->enc_data[i] = tmp_data[i];
     ctx->enc_sizes[i] = tmp_sizes[i];
+    // update shapes from cache -- the model may have dynamic dims
+    // that are only resolved after inference
+    ctx->enc_ndims[i] = tmp_ndims[i];
+    memcpy(ctx->enc_shapes[i], tmp_shapes[i],
+           tmp_ndims[i] * sizeof(int64_t));
   }
   ctx->encoded_width = enc_w;
   ctx->encoded_height = enc_h;


### PR DESCRIPTION
## Problem

The disk cache for object mask encoder embeddings always fails on the first load after restarting darktable. The second load of the same image (within the same session) works fine.

## Root cause

When the model loads with `ORT_DISABLE_ALL` (fallback for ORT versions where optimization crashes), encoder output shapes are reported as dynamic (`-1`). The cache file stores the resolved shapes from a previous inference (e.g. `[1, 32, 256, 256]`), but on load the validation compares them against the model's unresolved shapes (`[-1, 32, -1, -1]`) and rejects the mismatch.

After re-encoding, `ctx->enc_shapes` gets updated with resolved values, so subsequent cache loads in the same session succeed.

## Fix

- Skip dimension validation when either the model or cache file reports a dynamic dim (`<= 0`)
- Copy resolved shapes from the cache file into `ctx->enc_shapes` after a successful load, so the decoder gets valid shapes instead of `-1`

