### PR TITLE
[AI] Replace alt+click with ctrl+shift+click for object mask clear

### DIFF
--- a/src/develop/masks/object.c
+++ b/src/develop/masks/object.c
@@ -1114,12 +1114,10 @@ static int _object_events_button_pressed(
   if(gui->creation && which == 1
      && dt_modifier_is(state, GDK_CONTROL_MASK | GDK_SHIFT_MASK))
   {
-    // ctrl+shift+click: clear selection
-    if(d && d->encode_state == ENCODE_READY
-       && (gui->guipoints_count > 0 || d->mask || d->has_selection))
+    // ctrl+shift+click: clear selection (only after first selection)
+    if(d && d->has_selection && d->encode_state == ENCODE_READY)
     {
       _clear_selection(gui);
-      // refresh sliders back to step 1 (size only)
       if(darktable.develop->proxy.masks.module)
         darktable.develop->proxy.masks.list_change(
           darktable.develop->proxy.masks.module);
@@ -1606,11 +1604,14 @@ static void _object_events_post_expose(
   int dev_x = 0, dev_y = 0;
   if(win && pointer)
     gdk_window_get_device_position(win, pointer, &dev_x, &dev_y, &mod);
+  const gboolean has_sel = d && d->has_selection;
   const gboolean ctrl_shift_held
-    = (mod & (GDK_CONTROL_MASK | GDK_SHIFT_MASK))
-        == (GDK_CONTROL_MASK | GDK_SHIFT_MASK);
+    = has_sel
+      && (mod & (GDK_CONTROL_MASK | GDK_SHIFT_MASK))
+           == (GDK_CONTROL_MASK | GDK_SHIFT_MASK);
   const gboolean shift_held
-    = !ctrl_shift_held && (mod & GDK_SHIFT_MASK) != 0;
+    = has_sel && !ctrl_shift_held
+      && (mod & GDK_SHIFT_MASK) != 0;
 
   // convert device coordinates to preview pipe pixel space
   {


### PR DESCRIPTION
Addresses #20560 (ALT modifier not working on LXQt desktop)

## Problem

The object mask clear action used `alt+click`, but on LXQt the ALT key is grabbed by the window manager for window operations. Users on LXQt could not clear their mask selection.

Rather than requiring users to reconfigure their desktop, we can avoid the conflict by using a different modifier.

## Changes

- Replace `alt+click` with `ctrl+shift+click` for the mask clear action
- Draw a revert arrow cursor icon when ctrl+shift is held
- Force first click to always be foreground (positive selection) - shift and ctrl+shift are ignored until the user has an active selection
- Update hint text and mouse action registration

## Why ctrl+shift

- Not grabbed by any window manager
- A double-modifier is appropriate for a destructive action (clear all points)
- No conflict with existing object mask interactions
- Other darktable mask types already use ctrl+shift for various actions