### PR TITLE
[AI] Fix stale mask selection persisting after module reset

### DIFF
--- a/src/develop/masks.h
+++ b/src/develop/masks.h
@@ -444,6 +444,7 @@ typedef struct dt_masks_form_gui_t
 
   // opaque per-type data (e.g. segmentation context for object masks)
   void *scratchpad;
+  void (*scratchpad_cleanup)(struct dt_masks_form_gui_t *gui);
 } dt_masks_form_gui_t;
 
 /** special value to indicate an invalid or uninitialized coordinate */

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -1312,6 +1312,11 @@ void dt_masks_events_post_expose(const dt_iop_module_t *module,
 void dt_masks_clear_form_gui(const dt_develop_t *dev)
 {
   if(!dev->form_gui) return;
+  if(dev->form_gui->scratchpad_cleanup)
+  {
+    dev->form_gui->scratchpad_cleanup(dev->form_gui);
+    dev->form_gui->scratchpad_cleanup = NULL;
+  }
   g_list_free_full(dev->form_gui->points, dt_masks_form_gui_points_free);
   dev->form_gui->points = NULL;
   dt_masks_dynbuf_free(dev->form_gui->guipoints);

--- a/src/develop/masks/object.c
+++ b/src/develop/masks/object.c
@@ -74,7 +74,6 @@ typedef struct _object_data_t
   gboolean model_loaded;    // whether the model was loaded
   int encode_state;         // uses _encode_state_t values (atomic access)
   dt_imgid_t encoded_imgid; // image ID that was encoded
-  dt_imgid_t last_seen_imgid; // last image seen in post_expose (detects navigation)
   dt_hash_t encoded_distort_hash; // distort hash at encode time (detects crop/rotate)
   int encode_w, encode_h;   // encoding resolution (for coordinate mapping)
   uint8_t *encode_rgb;      // stored RGB from encoding (uint8, HWC, 3ch)
@@ -91,7 +90,6 @@ typedef struct _object_data_t
   int preview_cleanup;              // current cleanup (potrace turdsize, 0-100)
   float preview_smoothing;          // current smoothing (potrace alphamax, 0.0-1.3)
   float preview_feather;            // path border/feather (0.0-0.5, normalized)
-  dt_iop_module_t *creation_module; // module that started this session
 } _object_data_t;
 
 static _object_data_t *_get_data(dt_masks_form_gui_t *gui)
@@ -1333,35 +1331,14 @@ static void _object_events_post_expose(
   if(!gui->creation)
     return;
 
-  // ensure scratchpad exists.
-  // if a previous session left stale mask data (selection was made but
-  // not committed), clear mask state but keep the encoding
-  // so re-encoding is not needed
+  // ensure scratchpad exists
   _object_data_t *d = _get_data(gui);
-  if(d && d->has_selection && d->creation_module != gui->creation_module)
-  {
-    g_free(d->mask);
-    d->mask = NULL;
-    d->mask_w = d->mask_h = 0;
-    d->has_selection = FALSE;
-    _free_preview_forms(d);
-    if(gui->guipoints)
-      dt_masks_dynbuf_reset(gui->guipoints);
-    if(gui->guipoints_payload)
-      dt_masks_dynbuf_reset(gui->guipoints_payload);
-    gui->guipoints_count = 0;
-    if(d->seg)
-      dt_seg_reset_prev_mask(d->seg);
-    d->creation_module = gui->creation_module;
-  }
   if(!d)
   {
     d = g_new0(_object_data_t, 1);
     d->preview_cleanup = dt_conf_get_int(CONF_OBJECT_CLEANUP_KEY);
     d->preview_smoothing = dt_conf_get_float(CONF_OBJECT_SMOOTHING_KEY);
     d->preview_feather = dt_conf_get_float(CONF_OBJECT_FEATHER_KEY);
-    d->last_seen_imgid = NO_IMGID;
-    d->creation_module = gui->creation_module;
 
     // restore persistent model (stays loaded across mask sessions)
     // if the active model changed in preferences, discard the old one
@@ -1400,19 +1377,15 @@ static void _object_events_post_expose(
     }
 
     gui->scratchpad = d;
+    gui->scratchpad_cleanup = _free_data;
   }
 
-  // detect image change, navigation, or stale session:
-  // reset everything so the user starts a fresh mask session
+  // detect distortion changes (crop/rotate on same image):
+  // reset encoding so the image is re-analyzed
   const dt_imgid_t cur_imgid = darktable.develop->image_storage.id;
   const int cur_state = g_atomic_int_get(&d->encode_state);
-  const gboolean navigated_away
-    = d->last_seen_imgid != NO_IMGID
-      && d->last_seen_imgid != cur_imgid;
-  d->last_seen_imgid = cur_imgid;
   if((cur_state == ENCODE_READY || cur_state == ENCODE_ERROR)
-     && (navigated_away
-         || d->encoded_imgid != cur_imgid
+     && (d->encoded_imgid != cur_imgid
          || d->encoded_distort_hash != _compute_distort_hash(darktable.develop)))
   {
     if(d->encode_thread)


### PR DESCRIPTION
Fixes #20602

After module reset, the old mask selection persisted when re-entering object mask creation on the same module.

## Root cause

The object mask scratchpad (which holds mask state, encoding, and AI context) was not freed on module reset, image switch, or mask tool deactivation. Previous workarounds tracked `last_seen_imgid`, `creation_module`, and `guipoints_count` to detect stale sessions, but missed the module reset case.

## Fix

Add a `scratchpad_cleanup` callback to `dt_masks_form_gui_t`. When `dt_masks_clear_form_gui` is called (on module reset, image switch, mask deactivation), it invokes the callback to properly free the scratchpad. The object mask registers `_free_data` as the callback, which joins any running encode thread, persists the model to `darktable.ai_seg`, and frees all resources.

This replaces the three previous workarounds (`last_seen_imgid`, `creation_module` comparison, `guipoints_count == 0` check) with a single mechanism in the mask infrastructure. No other mask type uses scratchpad, so the change is a no-op for circle, ellipse, path, brush, and gradient masks.