### PR TITLE
Fixes SEGFAULT in thumbtable.c

### DIFF
--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -2288,7 +2288,7 @@ static void _event_dnd_get(GtkWidget *widget,
                            const guint time,
                            dt_thumbtable_t *table)
 {
-  if (!table->drag_list) return;
+  if(!table->drag_list) return;
   g_assert(selection_data != NULL);
 
   switch(target_type)


### PR DESCRIPTION
When `l` is `NULL` (no images), the loop doesn't run, images stays `NULL`, `dt_util_glist_to_str` returns `NULL`, and strlen(`NULL`) crashes.

I experienced this crash once when dragging something by accident in the lighttable. I cannot reproduce, I am not sure how I managed to hit this code path.

@TurboGit 