### PR TITLE
Delete stale database lockfiles for workspaces other than the default one

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1718,7 +1718,7 @@ int dt_init(int argc,
       if(connection) g_object_unref(connection);
     }
     dt_splash_screen_destroy(); // dismiss splash screen before potentially showing error dialog
-    if(!image_loaded_elsewhere && init_gui) dt_database_show_error(darktable.db);
+    if(!image_loaded_elsewhere && init_gui) dt_database_show_error(darktable.db, dblabel);
 
     dt_print(DT_DEBUG_ALWAYS, "ERROR: can't acquire database lock, aborting.");
     return 1;

--- a/src/common/database.c
+++ b/src/common/database.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2011-2025 darktable developers.
+    Copyright (C) 2011-2026 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -3830,7 +3830,7 @@ static void _sanitize_db(dt_database_t *db)
 #undef TRY_PREPARE
 #undef FINALIZE
 
-void dt_database_show_error(const dt_database_t *db)
+void dt_database_show_error(const dt_database_t *db, const char *dblabel)
 {
   if(!db->lock_acquired)
   {
@@ -3838,6 +3838,14 @@ void dt_database_show_error(const dt_database_t *db)
     snprintf(lck_pathname, sizeof(lck_pathname), "%s.lock", db->error_dbfilename);
     char *lck_dirname = g_strdup(lck_pathname);
     char *last_dirsep_position = g_strrstr(lck_dirname, G_DIR_SEPARATOR_S);
+    char library_lock_basename[1024];
+    if(strlen(dblabel) == 0)
+      strncpy(library_lock_basename, "library.db.lock",
+              sizeof(library_lock_basename));
+    else
+      snprintf(library_lock_basename, sizeof(library_lock_basename),
+               "library-%s.db.lock", dblabel);
+    
     if(last_dirsep_position)
       *last_dirsep_position = '\0';  // make lck_dirname contain only the directory name
 
@@ -3862,11 +3870,11 @@ void dt_database_show_error(const dt_database_t *db)
           "\n"
           "  4 - If you have done this or are certain that no other instances of darktable are running, \n"
           "      this probably means that the last instance was ended abnormally. \n"
-          "      Click on the \"delete database lock files\" button to delete the files <i>data.db.lock</i> and <i>library.db.lock</i>. \n"
+          "      Click on the \"delete database lock files\" button to delete the files <i>data.db.lock</i> and <i>%s</i>. \n"
           "\n\n"
           "      <i><u>Caution!</u> Do not delete these files without first undertaking the above checks, \n"
           "      otherwise you risk generating serious inconsistencies in your database.</i>\n"),
-      db->error_other_pid);
+      db->error_other_pid, library_lock_basename);
     // clang-format on
 
     gboolean delete_lockfiles =
@@ -3890,10 +3898,9 @@ void dt_database_show_error(const dt_database_t *db)
           status += remove(lck_filename);
         g_free(lck_filename);
 
-        lck_filename = g_strconcat(lck_dirname, "/library.db.lock", NULL);
+        lck_filename = g_strconcat(lck_dirname, G_DIR_SEPARATOR_S, library_lock_basename, NULL);
         if(g_access(lck_filename, F_OK) != -1)
           status += remove(lck_filename);
-        g_free(lck_filename);
 
         if(status==0)
           dt_gui_show_standalone_yes_no_dialog
@@ -3904,9 +3911,10 @@ void dt_database_show_error(const dt_database_t *db)
           dt_gui_show_standalone_yes_no_dialog
             (_("error"), g_markup_printf_escaped(
               _("\nat least one file could not be deleted.\n"
-                "you may try to manually delete the files <i>data.db.lock</i> and <i>library.db.lock</i>\n"
-                "in folder <a href=\"file:///%s\">%s</a>.\n"), lck_dirname, lck_dirname),
+                "you may try to manually delete the files <i>data.db.lock</i> and <i>%s</i>\n"
+                "in folder <a href=\"file:///%s\">%s</a>.\n"), lck_filename, lck_dirname, lck_dirname),
              _("_ok"), NULL);
+        g_free(lck_filename);
       }
     }
 

--- a/src/common/database.h
+++ b/src/common/database.h
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2011-2020 darktable developers.
+    Copyright (C) 2011-2026 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -39,7 +39,7 @@ const gchar *dt_database_get_path(const struct dt_database_t *db);
 gboolean dt_database_get_lock_acquired(const struct dt_database_t *db);
 /** show an error popup. this has to be postponed until after we tried
  * using dbus to reach another instance */
-void dt_database_show_error(const struct dt_database_t *db);
+void dt_database_show_error(const struct dt_database_t *db, const char *dblabel);
 /** perform pre-db-close optimizations (always call when quiting darktable) */
 void dt_database_optimize(const struct dt_database_t *);
 /** conditionally perfrom db maintenance */


### PR DESCRIPTION
When darktable tries to delete possibly stale lock files at startup (after user approval), the name of the library lockfile must be built dependent on the workspace used. This is done by amending the function dt_database_show_error() to handle this correctly.

Tested on Linux only.

Fixes #20463.