### PR TITLE
Markesteijn and VNG demosaic fixes

### DIFF
--- a/data/kernels/demosaic_markesteijn.cl
+++ b/data/kernels/demosaic_markesteijn.cl
@@ -50,7 +50,7 @@ markesteijn_initial_copy(read_only image2d_t in, global float *rgb, const int wi
 
   const int f = FCxtrans(y, x, xtrans);
 
-  const float p = fmax(0.0f, read_imagef(in, sampleri, (int2)(x, y)).x);
+  const float p = fmax(0.0f, readsingle(in, x, y));
 
   for(int c = 0; c < 3; c++)
     pix[c] = (c == f) ? p : 0.0f;
@@ -897,7 +897,7 @@ markesteijn_accu(read_only image2d_t in, write_only image2d_t out, global float 
 
   const int glidx = mad24(y, width, x);
 
-  float4 pixel = read_imagef(in, sampleri, (int2)(x, y));
+  float4 pixel = readpixel(in, x, y);
   float4 add = vload4(glidx, rgb);
   add.w = 1.0f;
 
@@ -918,7 +918,7 @@ markesteijn_final(read_only image2d_t in, write_only image2d_t out, const int wi
   // take sufficient border into account
   if(x < border || x >= width-border || y < border || y >= height-border) return;
 
-  float4 pixel = read_imagef(in, sampleri, (int2)(x, y));
+  float4 pixel = readpixel(in, x, y);
 
   pixel = (pixel.w > 0.0f) ? pixel/pixel.w : (float4)0.0f;
   pixel.w = 0.0f;

--- a/data/kernels/demosaic_vng.cl
+++ b/data/kernels/demosaic_vng.cl
@@ -28,7 +28,7 @@ vng_lin_interpolate(read_only image2d_t in,
                     global const unsigned char (*const xtrans)[6],
                     global const int (*const lookup)[16][32],
                     local float *buffer,
-                    const int equil)
+                    const int only_linear)
 {
   const int x = get_global_id(0);
   const int y = get_global_id(1);
@@ -59,7 +59,7 @@ vng_lin_interpolate(read_only image2d_t in,
     if(bufidx >= maxbuf) continue;
     const int xx = xul + bufidx % stride;
     const int yy = yul + bufidx / stride;
-    buffer[bufidx] = fmax(0.0f, read_imagef(in, sampleri, (int2)(xx, yy)).x);
+    buffer[bufidx] = fmax(0.0f, readsingle(in, xx, yy));
   }
 
   // center buffer around current x,y-Pixel
@@ -73,31 +73,40 @@ vng_lin_interpolate(read_only image2d_t in,
 
   const bool is_xtrans = filters == 9; 
   const int colors = is_xtrans ? 3 : 4;
-  const int av = (filters == 9) ? 2 : 1;
   const int size = is_xtrans ? 6 : 16;
 
   float sum[4] = { 0.0f };
   float o[4] = { 0.0f };
 
+  // approximate outermost single pixels
   if(x < 1 || x >= width-1 || y < 1 || y >= height-1)
   {
     int count[4] = { 0 };
-    for(int j = y-av; j <= y+av; j++)
+    for(int j = y-1; j <= y+1; j++)
     {
-      for(int i = x-av; i <= x+av; i++)
+      for(int i = x-1; i <= x+1; i++)
       {
         if(j >= 0 && i >= 0 && j < height && i < width)
         {
           const int f = fcol(j, i, filters, xtrans);
-          sum[f] += fmax(0.0f, read_imagef(in, sampleri, (int2)(i, j)).x);
+          sum[f] += fmax(0.0f, readsingle(in, i, j));
           count[f]++;
         }
       }
     }
+    const int f = fcol(y, x, filters, xtrans);
+    // for current cell, copy the current sensor's color data,
+    // interpolate the other two colors from surrounding pixels of
+    // their color
     for(int c = 0; c < colors; c++)
-      o[c] = sum[c] / fmax(1.0f, (float)count[c]);
+    {
+      if(c != f && count[c] != 0)
+        o[c] = sum[c] / count[c];
+      else
+        o[c] = fmax(0.0f, readsingle(in, x, y));
+    }
   }
-  else
+  else // do the bilinear stuff
   {
     global const int *ip = lookup[y % size][x % size];
     const int num_pixels = ip[0];
@@ -120,17 +129,16 @@ vng_lin_interpolate(read_only image2d_t in,
     o[ip[0]] = buffer[0];
   }
 
-  if(!is_xtrans && equil)
+  if(only_linear && !is_xtrans)
   {
     o[1] = 0.5f * (o[1] + o[3]);
     o[3] = 0.0f;
   }
-  write_imagef(out, (int2)(x, y), (float4)(o[0], o[1], o[2], o[3]));
+  write_imagef(out, (int2)(x, y), fmax(0.0f, (float4)(o[0], o[1], o[2], o[3])));
 }
 
 kernel void
-vng_interpolate(read_only image2d_t input,
-                read_only image2d_t in,
+vng_interpolate(read_only image2d_t in,
                 write_only image2d_t out,
                 const int width,
                 const int height,
@@ -169,7 +177,7 @@ vng_interpolate(read_only image2d_t input,
     if(bufidx >= maxbuf) continue;
     const int xx = xul + bufidx % stride;
     const int yy = yul + bufidx / stride;
-    const float4 pixel = fmax(0.0f, read_imagef(in, sampleri, (int2)(xx, yy)));
+    const float4 pixel = fmax(0.0f, readpixel(in, xx, yy));
     vstore4(pixel, bufidx, buffer);
   }
 
@@ -179,10 +187,21 @@ vng_interpolate(read_only image2d_t input,
   barrier(CLK_LOCAL_MEM_FENCE);
   if(x >= width || y >= height) return;
 
-  const bool is_xtrans = filters == 9; 
-  const int colors = is_xtrans ? 3 : 4;
-  const int av = is_xtrans ? 2 : 1;
+  const bool is_xtrans = filters == 9;
+  // we don't touch data at the outermost 2 pixels
+  if(x < 2 || x >= width-2 || y < 2 || y >= height-2)
+  {
+    float4 val = readpixel(in, x, y);
+    if(!is_xtrans)
+    {
+      val.y = 0.5f * (val.y + val.w);
+      val.w = 0.0f;
+    }
+    write_imagef(out, (int2)(x, y), fmax(0.0f, val));
+    return;
+  }
 
+  const int colors = is_xtrans ? 3 : 4;
   const int prow = is_xtrans ? 6 : 8;
   const int pcol = is_xtrans ? 6 : 2;
 
@@ -227,41 +246,14 @@ vng_interpolate(read_only image2d_t input,
     if(gmax < gval[g]) gmax = gval[g];
   }
 
-  const bool border = x < 2 || x >= width-2 || y < 2 || y >= height-2;
-  float b[4] = { 0.0f };
-  // Ok lets calculate the border pixel, we'll need it soon
-  if(border)
-  {
-    int count[4] = { 0 };
-    for(int j = y-av; j <= y+av; j++)
-    {
-      for(int i = x-av; i <= x+av; i++)
-      {
-        if(j >= 0 && i >= 0 && j < height && i < width)
-        {
-          const int f = fcol(j, i, filters, xtrans);
-          b[f] += fmax(0.0f, read_imagef(input, sampleri, (int2)(i, j)).x);
-          count[f]++;
-        }
-      }
-    }
-    for(int c = 0; c < colors; c++)
-      b[c] /= fmax(1.0f, (float)count[c]);
-  }
-
+  float o[4] = { 0.0f };
   if(gmax == 0.0f)
   {
-    if(!border)
-    {
-      for(int c = 0; c < colors; c++)
-        b[c] = buffer[c];
-    }
-    if(!is_xtrans)
-    {
-      b[1] = 0.5f * (b[1] + b[3]);
-      b[3] = 0.0f;
-    }
-    write_imagef(out, (int2)(x, y), (float4)(b[0], b[1], b[2], b[3]));
+    o[0] = buffer[0];
+    o[1] = is_xtrans ? buffer[1] : 0.5f * (buffer[1] + buffer[3]);
+    o[2] = buffer[2];
+    o[3] = 0.0f;
+    write_imagef(out, (int2)(x, y), fmax(0.0f, (float4)(o[0], o[1], o[2], o[3])));
     return;
   }
 
@@ -303,26 +295,16 @@ vng_interpolate(read_only image2d_t input,
   }
 
   // save to output
-  float o[4] = { 0.0f };
   for(int c = 0; c < colors; c++)
   {
     float tot = buffer[color];
     if(c != color) tot += (sum[c] - sum[color]) / num;
-    o[c] = fmax(0.0f, tot);
+    o[c] = tot;
   }
 
-  if(border)
-  {
-    for(int c = 0; c < colors; c++)
-      o[c] = b[c];
-  }
-
-  if(!is_xtrans)
-  {
-    o[1] = 0.5f * (o[1] + o[3]);
-    o[3] = 0.0f;
-  }
-  write_imagef(out, (int2)(x, y), (float4)(o[0], o[1], o[2], 0.0f));
+  o[1] = is_xtrans ? o[1] : 0.5f * (o[1] + o[3]);
+  o[3] = 0.0f;
+  write_imagef(out, (int2)(x, y), fmax(0.0f, (float4)(o[0], o[1], o[2], 0.0f)));
 }
 
 kernel void
@@ -362,7 +344,7 @@ clip_and_zoom_demosaic_third_size_xtrans(read_only image2d_t in, write_only imag
     {
       for(int j = 0; j < 3; j++)
         for(int i = 0; i < 3; i++)
-          col[FCxtrans(yy + j, xx + i, xtrans)] += fmax(0.0f, read_imagef(in, sampleri, (int2)(xx + i, yy + j)).x);
+          col[FCxtrans(yy + j, xx + i, xtrans)] += fmax(0.0f, readsingle(in, xx + i, yy + j));
       num++;
     }
 

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -853,7 +853,7 @@ void process(dt_iop_module_t *self,
         if(method == DT_IOP_DEMOSAIC_FDC)
           xtrans_fdc_interpolate(t_out, t_in, width, t_rows, xtrans, exif_iso);
         else if(method == DT_IOP_DEMOSAIC_MARKESTEIJN || method == DT_IOP_DEMOSAIC_MARKESTEIJN_3)
-          xtrans_markesteijn_interpolate(t_out, t_in, width, t_rows, xtrans, passes);
+          xtrans_markesteijn_interpolate(t_out, t_in, width, t_rows, xtrans, passes, filters);
         else
           vng_interpolate(t_out, t_in, width, t_rows, filters, xtrans, FALSE);
       }

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -1746,7 +1746,7 @@ void gui_init(dt_iop_module_t *self)
   const int xtranspos = dt_bauhaus_combobox_get_from_value(g->demosaic_method_bayer, DT_DEMOSAIC_XTRANS);
 
   for(int i=0;i<8;i++) dt_bauhaus_combobox_remove_at(g->demosaic_method_bayer, xtranspos);
-  gtk_widget_set_tooltip_text(g->demosaic_method_bayer, _("Bayer sensor demosaicing method, PPG and RCD are fast, AMaZE and LMMSE are slow.\nLMMSE is suited best for high ISO images.\ndual demosaicers increase processing time by blending a VNG variant in a second pass."));
+  gtk_widget_set_tooltip_text(g->demosaic_method_bayer, _("Bayer sensor demosaicing method, PPG and RCD are fast, AMaZE and LMMSE are slow.\nLMMSE is suited best for high ISO images.\nVNG4 is good in rare cases avoiding maze patterns.\ndual demosaicers increase processing time by blending a VNG variant in a second pass."));
 
   g->demosaic_method_xtrans = dt_bauhaus_combobox_from_params(self, "demosaicing_method");
   for(int i=0;i<xtranspos;i++) dt_bauhaus_combobox_remove_at(g->demosaic_method_xtrans, 0);

--- a/src/iop/demosaicing/vng.c
+++ b/src/iop/demosaicing/vng.c
@@ -18,12 +18,13 @@
 
 /* taken from dcraw and demosaic_ppg below */
 
-static void lin_interpolate(float *out,
-                            const float *const in,
-                            const int width,
-                            const int height,
-                            const uint32_t filters,
-                            const uint8_t (*const xtrans)[6])
+static void _vng_lininterpolate(float *out,
+                                const float *const in,
+                                const int width,
+                                const int height,
+                                const uint32_t filters,
+                                const uint8_t (*const xtrans)[6],
+                                const int border)
 {
   const int colors = (filters == 9) ? 3 : 4;
   // border interpolate
@@ -107,6 +108,13 @@ static void lin_interpolate(float *out,
     const float *buf_in = in + width * row + 1;
     for(int col = 1; col < width - 1; col++)
     {
+      if(col == border && row >= border && row < height - border)
+      {
+        col = width - border;
+        buf = out + (size_t)4 * width * row + 4 * col;
+        buf_in = in + (size_t)width * row + col;
+      }
+      if(col == width) break;
       dt_aligned_pixel_t sum = { 0.0f };
       int *ip = &(lookup[row % size][col % size][0]);
       // for each adjoining pixel not of this pixel's color, sum up its weighted values
@@ -192,7 +200,7 @@ static void vng_interpolate(float *out,
   else
     filters4 = filters | 0x0c0c0c0cu;
 
-  lin_interpolate(out, in, width, height, filters4, xtrans);
+  _vng_lininterpolate(out, in, width, height, filters4, xtrans, 1000000);
 
   // if only linear interpolation is requested we can stop it here
   if(only_vng_linear)

--- a/src/iop/demosaicing/vng.c
+++ b/src/iop/demosaicing/vng.c
@@ -26,7 +26,8 @@ static void _vng_lininterpolate(float *out,
                                 const uint8_t (*const xtrans)[6],
                                 const int border)
 {
-  const int colors = (filters == 9) ? 3 : 4;
+  const gboolean is_xtrans = filters == 9;
+  const int colors = is_xtrans ? 3 : 4;
   // border interpolate
   DT_OMP_FOR()
   for(int row = 0; row < height; row++)
@@ -123,7 +124,8 @@ static void _vng_lininterpolate(float *out,
       // for each interpolated color, load it into the pixel
       for(int i = colors; --i; ip += 2)
         buf[*ip] = sum[ip[0]] / ip[1];
-      buf[*ip] = fmaxf(0.0f, *buf_in);
+      buf[*ip] = *buf_in;
+      dt_vector_clipneg(buf);
       buf += 4;
       buf_in++;
     }
@@ -186,7 +188,6 @@ static void vng_interpolate(float *out,
   float(*brow[4])[4];
   const gboolean is_xtrans = (filters == 9);
   const gboolean is_4bayer = FILTERS_ARE_4BAYER(filters);
-  const gboolean is_bayer = !(is_xtrans || is_4bayer);
   const int prow = is_xtrans ? 6 : 8;
   const int pcol = is_xtrans ? 6 : 2;
   const int colors = is_xtrans ? 3 : 4;
@@ -204,10 +205,7 @@ static void vng_interpolate(float *out,
 
   // if only linear interpolation is requested we can stop it here
   if(only_vng_linear)
-  {
-    if(is_bayer) goto bayer_greens;
-    else return;
-  }
+    goto finish;
 
   char *buffer = dt_alloc_aligned(sizeof(**brow) * width * 3 + sizeof(*ip) * prow * pcol * 320);
   if(!buffer)
@@ -322,12 +320,16 @@ static void vng_interpolate(float *out,
   _copy_abovezero(out + (4 * ((height - 3) * width + 2)), (float *)(brow[1] + 2), width - 4);
   dt_free_align(buffer);
 
-bayer_greens:
-  if(is_bayer)
+finish:
+  DT_OMP_FOR()
+  for(size_t i = 0; i < (size_t)width * height * 4; i+=4)
   {
-    DT_OMP_FOR()
-    for(int i = 0; i < height * width; i++)
-      out[i * 4 + 1] = (out[i * 4 + 1] + out[i * 4 + 3]) / 2.0f;
+    if(!is_xtrans)
+    {
+      out[i+1] = 0.5f * (out[i+1] + out[i+3]);
+      out[i+3] = 0.0f;
+    }
+    dt_vector_clipneg(&out[i]);
   }
 }
 
@@ -507,7 +509,7 @@ static cl_int process_vng_cl(const dt_iop_module_t *self,
   if(only_vng_linear)
     goto finish;
 
-  // do full VNG interpolation; linear data is in dev_tmp
+  // do full VNG interpolation; linear data is in dev_tmp; don't touch outermost 2 pixels
   dt_opencl_local_buffer_t locopt
       = (dt_opencl_local_buffer_t){ .xoffset = 2*2, .xfactor = 1, .yoffset = 2*2, .yfactor = 1,
                                       .cellsize = 4 * sizeof(float), .overhead = 0,
@@ -519,7 +521,7 @@ static cl_int process_vng_cl(const dt_iop_module_t *self,
   size_t sizes[3] = { ROUNDUP(width, locopt.sizex), ROUNDUP(height, locopt.sizey), 1 };
   size_t local[3] = { locopt.sizex, locopt.sizey, 1 };
   err = dt_opencl_enqueue_kernel_2d_local_args(devid, gd->kernel_vng_interpolate, sizes, local,
-        CLARG(dev_in), CLARG(dev_tmp), CLARG(dev_out),
+        CLARG(dev_tmp), CLARG(dev_out),
         CLARG(width), CLARG(height), CLARG(filters4),
         CLARG(dev_xtrans), CLARG(dev_ips), CLARG(dev_code), CLLOCAL(sizeof(float) * 4 * (locopt.sizex + 4) * (locopt.sizey + 4)));
 

--- a/src/iop/demosaicing/xtrans.c
+++ b/src/iop/demosaicing/xtrans.c
@@ -47,7 +47,8 @@ static void xtrans_markesteijn_interpolate(float *out,
                                            const int width,
                                            const int height,
                                            const uint8_t (*const xtrans)[6],
-                                           const int passes)
+                                           const int passes,
+                                           const uint32_t filters)
 {
   static const short orth[12] = { 1, 0, 0, 1, -1, 0, 0, -1, 1, 0, 0, 1 },
                      patt[2][16] = { { 0, 1, 0, -1, 2, 0, -1, 0, 1, 1, 1, -1, 0, 0, 0, 0 },
@@ -137,7 +138,7 @@ static void xtrans_markesteijn_interpolate(float *out,
           if((col >= 0) && (row >= 0) && (col < width) && (row < height))
           {
             const int f = FCNxtrans(row, col, xtrans);
-            for(int c = 0; c < 3; c++) pix[c] = (c == f) ? in[width * row + col] : 0.f;
+            for(int c = 0; c < 3; c++) pix[c] = (c == f) ? fmax(0.0f, in[width * row + col]) : 0.f;
           }
           else
           {
@@ -152,7 +153,7 @@ static void xtrans_markesteijn_interpolate(float *out,
 #define TRANSLATE(n, size) ((n >= size) ? (2 * size - n - 2) : abs(n))
                 const int cy = TRANSLATE(row, height), cx = TRANSLATE(col, width);
                 if(c == FCNxtrans(cy, cx, xtrans))
-                  pix[c] = in[width * cy + cx];
+                  pix[c] = fmaxf(0.0f, in[width * cy + cx]);
                 else
                 {
                   // interpolate if mirror pixel is a different color
@@ -165,7 +166,7 @@ static void xtrans_markesteijn_interpolate(float *out,
                       const int ff = FCNxtrans(yy, xx, xtrans);
                       if(ff == c)
                       {
-                        sum += in[width * yy + xx];
+                        sum += fmaxf(0.0f, in[width * yy + xx]);
                         count++;
                       }
                     }
@@ -177,7 +178,8 @@ static void xtrans_markesteijn_interpolate(float *out,
         }
 
       // duplicate rgb[0] to rgb[1], rgb[2], and rgb[3]
-      for(int c = 1; c <= 3; c++) memcpy(rgb[c], rgb[0], sizeof(*rgb));
+      for(int c = 1; c <= 3; c++)
+        dt_iop_image_copy((float*)rgb[c], (float*)rgb[0], sizeof(*rgb) / sizeof(float));
 
       // note that successive calculations are inset within the tile
       // so as to give enough border data, and there needs to be a 6
@@ -502,11 +504,12 @@ static void xtrans_markesteijn_interpolate(float *out,
             }
           }
           for(int c = 0; c < 3; c++)
-            out[4 * (width * (row + top) + col + left) + c] = MAX(0.0f, avg[c]/avg[3]);
+            out[4 * (width * (row + top) + col + left) + c] = fmaxf(0.0f, avg[c]/avg[3]);
         }
     }
   }
   dt_free_align(all_buffers);
+  _vng_lininterpolate(out, in, width, height, filters, xtrans, pad_tile);
 }
 
 #undef TS


### PR DESCRIPTION
**Markesteijn demosaicer fixes**
1. The CPU code deserves the better border calculation as we do for OpenCL since very long. There is a small performance penalty but with clearly better results. I was likely just overseen for many years.
2. The VNG linear interpolation got modifications to handle borders.
3. Fix subtle differences between OpenCL and CPU for low levels.

**Various VNG demosaicer fixes**
1. Fix OpenCL VNG full interpolation, we must not touch the outermost 2 pixels, they have been interpolated already in the linear phase.
2. Ensure identical results for VNG initial 1-photosite borders.
3. Fix VNG final green mixing for bayer4 sensors. Do this at the end of processing for both CPU and GPU code.
4. Fix some maths leading to different results OpenCL vs CPU
5. Added tooltip why VNG4 is still a valuable demosaicer.

@TurboGit this definitely changes expected output for all xtrans related tests as we change the border maths. (0065 0066 0068 0100 0145 0146 0165 0173) All related tests show less differences btw.

For these parts all is good to me so ready to be merged.

Pending work on demosaicers: Some deduplication of PPG/RCD/LMMSE border code, still too large GPU/CPU differences for green averaging for some reason. 

`after` that pending work it will be the work on tests with large diffs ...