### PR TITLE
Make sure kernel parameters are aligned

### DIFF
--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -3634,7 +3634,7 @@ int dt_dev_write_scharr_mask_cl(dt_dev_pixelpipe_iop_t *piece,
         wboff ? 1.0f : 1.0f / p->dsc.temperature.coeffs[2], 1.0f };
 
   err = dt_opencl_enqueue_kernel_2d_args(devid, darktable.opencl->blendop->kernel_calc_Y0_mask, width, height,
-     CLARG(tmp), CLARG(in), CLARG(width), CLARG(height), CLFLARRAY(4, wb));
+     CLARG(tmp), CLARG(in), CLARG(width), CLARG(height), CLARG(wb));
   if(err != CL_SUCCESS) goto error;
 
   err = dt_opencl_enqueue_kernel_2d_args(devid,

--- a/src/iop/atrous.c
+++ b/src/iop/atrous.c
@@ -442,7 +442,7 @@ int process_cl(dt_iop_module_t *self,
     err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_synthesize, width, height,
                               CLARG(dev_out), CLARG(pp_coarse), CLARG(dev_detail),
                               CLARG(width), CLARG(height),
-                              CLFLARRAY(4, thrs[scale]), CLFLARRAY(4, boost[scale]));
+                              CLARG(thrs[scale]), CLARG(boost[scale]));
     if(err != CL_SUCCESS) goto error;
 
     // swap scratch buffers but leave as is for the final round to keep pp_coarse correct
@@ -558,14 +558,14 @@ int process_cl(dt_iop_module_t *self,
                               CLARG(dev_tmp), CLARG(dev_out),
                               CLARG(dev_detail[scale]),
                               CLARG(width), CLARG(height),
-                              CLFLARRAY(4, thrs[scale]), CLFLARRAY(4, boost[scale]));
+                              CLARG(thrs[scale]), CLARG(boost[scale]));
 
     else
       err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_synthesize, width, height,
                               CLARG(dev_out), CLARG(dev_tmp),
                               CLARG(dev_detail[scale]),
                               CLARG(width), CLARG(height),
-                              CLFLARRAY(4, thrs[scale]), CLFLARRAY(4, boost[scale]));
+                              CLARG(thrs[scale]), CLARG(boost[scale]));
     if(err != CL_SUCCESS) goto error;
   }
   dt_opencl_finish_sync_pipe(devid, piece->pipe->type);

--- a/src/iop/demosaicing/dual.c
+++ b/src/iop/demosaicing/dual.c
@@ -118,7 +118,7 @@ int dual_demosaic_cl(const dt_iop_module_t *self,
         wboff ? 1.0f : 1.0f / p->dsc.temperature.coeffs[2], 1.0f };
 
   err = dt_opencl_enqueue_kernel_2d_args(devid, darktable.opencl->blendop->kernel_calc_Y0_mask, width, height,
-     CLARG(mask), CLARG(high_image), CLARG(width), CLARG(height), CLFLARRAY(4, wb));
+     CLARG(mask), CLARG(high_image), CLARG(width), CLARG(height), CLARG(wb));
   if(err != CL_SUCCESS) goto finish;
 
   err = dt_opencl_enqueue_kernel_2d_args(devid, darktable.opencl->blendop->kernel_calc_scharr_mask, width, height,

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -2521,7 +2521,7 @@ static int process_wavelets_cl(dt_iop_module_t *self,
     err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_denoiseprofile_synthesize, width, height,
                               CLARG(dev_buf1), CLARG(dev_detail[s]),
                               CLARG(dev_buf2), CLARG(width), CLARG(height),
-                              CLFLARRAY(4, thrs), CLFLARRAY(4, boost));
+                              CLARG(thrs), CLARG(boost));
     if(err != CL_SUCCESS) goto error;
 
     // swap buffers

--- a/src/iop/hazeremoval.c
+++ b/src/iop/hazeremoval.c
@@ -808,16 +808,17 @@ static int _dehaze_cl(dt_iop_module_t *self,
                       cl_mem trans_map,
                       cl_mem img_out,
                       const float t_min,
-                      const float *const A0)
+                      const float *const A)
 {
   dt_iop_hazeremoval_global_data_t *gd = self->global_data;
   const int width = dt_opencl_get_image_width(img_in);
   const int height = dt_opencl_get_image_height(img_in);
 
+  const dt_aligned_pixel_t A0 = { A[0], A[1], A[2], A[3]};
   return dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_hazeremoval_dehaze, width, height,
                                           CLARG(width), CLARG(height),
                                           CLARG(img_in), CLARG(trans_map),
-                                          CLARG(img_out), CLARG(t_min), CLFLARRAY(4, A0));
+                                          CLARG(img_out), CLARG(t_min), CLARG(A0));
 }
 
 void tiling_callback(dt_iop_module_t *self,

--- a/src/iop/rawoverexposed.c
+++ b/src/iop/rawoverexposed.c
@@ -339,8 +339,7 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
               CLARG(dev_in), CLARG(dev_out), CLARG(dev_coord),
               CLARG(width), CLARG(height),
               CLARG(dev_raw), CLARG(raw_width), CLARG(raw_height), CLARG(filters), CLARG(dev_xtrans),
-              CLARG(dev_thresholds),
-              CLFLARRAY(4, color));
+              CLARG(dev_thresholds), CLARG(color));
 
 error:
   dt_opencl_release_mem_object(dev_xtrans);


### PR DESCRIPTION
If a kernel uses a float4 parameters that should be passed via CLARG() as that makes sure it's aligned to it's size on the parameter stack and we can avoid the CLFLARRAY() macro.