### PR TITLE
[AI] Add model version tracking with cache invalidation and compatibility checking

### DIFF
--- a/data/ai_models.json
+++ b/data/ai_models.json
@@ -6,6 +6,7 @@
       "name": "mask sam2.1 hiera small",
       "description": "Segment Anything 2.1 (Hiera Small) for interactive masking",
       "task": "mask",
+      "min_version": "1.0",
       "github_asset": "mask-object-sam21-small.dtmodel",
       "default": true
     },
@@ -14,6 +15,7 @@
       "name": "mask segnext vitb-sax2 hq",
       "description": "SegNext ViT-B SAx2 HQ fine-tuned for interactive masking",
       "task": "mask",
+      "min_version": "1.0",
       "github_asset": "mask-object-segnext-b2hq.dtmodel",
       "default": false
     }

--- a/src/common/ai/segmentation.c
+++ b/src/common/ai/segmentation.c
@@ -17,6 +17,7 @@
 */
 
 #include "common/ai/segmentation.h"
+#include "common/ai_models.h"
 #include "ai/backend.h"
 #include "common/database.h"
 #include "common/darktable.h"
@@ -88,7 +89,8 @@ struct dt_seg_context_t
   float scale; // SAM_INPUT_SIZE / max(w, h)
   gboolean image_encoded;
 
-  char *model_id; // model identifier (for cache validation)
+  char *model_id;      // model identifier (for cache validation)
+  char *model_version; // model version (for cache validation)
 };
 
 /* --- preprocessing --- */
@@ -232,10 +234,31 @@ dt_seg_context_t *dt_seg_load(dt_ai_environment_t *env, const char *model_id)
     return NULL;
   }
 
+  // check model version compatibility
+  const char *version = dt_ai_model_get_version(model_id);
+  const char *min_ver = dt_ai_model_get_min_version(model_id);
+  if(min_ver)
+  {
+    int ver_major = 0, min_major = 0;
+    sscanf(version, "%d", &ver_major);
+    sscanf(min_ver, "%d", &min_major);
+    if(ver_major < min_major)
+    {
+      dt_print(DT_DEBUG_ALWAYS,
+               "[segmentation] model %s v%s incompatible "
+               "(requires v%s) - please update model",
+               model_id, version, min_ver);
+      dt_ai_unload_model(encoder);
+      dt_ai_unload_model(decoder);
+      return NULL;
+    }
+  }
+
   dt_seg_context_t *ctx = g_new0(dt_seg_context_t, 1);
   ctx->encoder = encoder;
   ctx->decoder = decoder;
   ctx->model_id = g_strdup(model_id);
+  ctx->model_version = g_strdup(version);
 
   // query encoder output count and shapes from model metadata
   ctx->n_enc_outputs = dt_ai_get_output_count(encoder);
@@ -1058,8 +1081,10 @@ gboolean dt_seg_disk_cache_save(dt_seg_context_t *ctx,
   const uint32_t magic = SEG_CACHE_MAGIC;
   const uint32_t version = SEG_CACHE_VERSION;
   const int32_t n_out = ctx->n_enc_outputs;
-  // model id (length-prefixed string)
+  // model id and version (length-prefixed strings)
   const uint32_t mid_len = ctx->model_id ? (uint32_t)strlen(ctx->model_id) : 0;
+  const uint32_t mver_len = ctx->model_version
+    ? (uint32_t)strlen(ctx->model_version) : 0;
 
   // header
   ok = ok && fwrite(&magic, 4, 1, fp) == 1;
@@ -1069,6 +1094,9 @@ gboolean dt_seg_disk_cache_save(dt_seg_context_t *ctx,
   ok = ok && fwrite(&mid_len, 4, 1, fp) == 1;
   if(mid_len > 0)
     ok = ok && fwrite(ctx->model_id, 1, mid_len, fp) == mid_len;
+  ok = ok && fwrite(&mver_len, 4, 1, fp) == 1;
+  if(mver_len > 0)
+    ok = ok && fwrite(ctx->model_version, 1, mver_len, fp) == mver_len;
   ok = ok && fwrite(&ctx->encoded_width, 4, 1, fp) == 1;
   ok = ok && fwrite(&ctx->encoded_height, 4, 1, fp) == 1;
   ok = ok && fwrite(&ctx->scale, 4, 1, fp) == 1;
@@ -1155,17 +1183,27 @@ gboolean dt_seg_disk_cache_load(dt_seg_context_t *ctx,
     ok = ok && fread(file_model_id, 1, mid_len, fp) == mid_len;
   else if(mid_len >= sizeof(file_model_id))
     ok = FALSE;
+  // read model version
+  uint32_t mver_len = 0;
+  ok = ok && fread(&mver_len, 4, 1, fp) == 1;
+  char file_model_ver[64] = {0};
+  if(ok && mver_len > 0 && mver_len < sizeof(file_model_ver))
+    ok = ok && fread(file_model_ver, 1, mver_len, fp) == mver_len;
+  else if(mver_len >= sizeof(file_model_ver))
+    ok = FALSE;
   ok = ok && fread(&enc_w, 4, 1, fp) == 1;
   ok = ok && fread(&enc_h, 4, 1, fp) == 1;
   ok = ok && fread(&scale, 4, 1, fp) == 1;
   ok = ok && fread(&n_out, 4, 1, fp) == 1;
 
+  const char *cur_ver = ctx->model_version ? ctx->model_version : "0.0";
   if(!ok || magic != SEG_CACHE_MAGIC
      || version != SEG_CACHE_VERSION
      || file_imgid != imgid
      || file_distort_hash != distort_hash
      || !ctx->model_id
-     || strcmp(file_model_id, ctx->model_id) != 0)
+     || strcmp(file_model_id, ctx->model_id) != 0
+     || strcmp(file_model_ver, cur_ver) != 0)
   {
     fclose(fp);
     return FALSE;
@@ -1329,6 +1367,7 @@ void dt_seg_free(dt_seg_context_t *ctx)
     g_free(ctx->enc_data[i]);
   g_free(ctx->prev_mask);
   g_free(ctx->model_id);
+  g_free(ctx->model_version);
   g_free(ctx);
 }
 

--- a/src/common/ai_models.c
+++ b/src/common/ai_models.c
@@ -45,6 +45,17 @@ static inline char *realpath(const char *path, char *resolved_path)
 #define CONF_MODEL_ENABLED_PREFIX "plugins/ai/models/"
 #define CONF_ACTIVE_MODEL_PREFIX "plugins/ai/models/active/"
 
+// compare version strings "X.Y", returns -1 if a<b, 0 if a==b, 1 if a>b
+static int _version_compare(const char *a, const char *b)
+{
+  int ax = 0, ay = 0, bx = 0, by = 0;
+  if(a) sscanf(a, "%d.%d", &ax, &ay);
+  if(b) sscanf(b, "%d.%d", &bx, &by);
+  if(ax != bx) return ax < bx ? -1 : 1;
+  if(ay != by) return ay < by ? -1 : 1;
+  return 0;
+}
+
 static void _model_free(dt_ai_model_t *model)
 {
   if(!model)
@@ -55,6 +66,8 @@ static void _model_free(dt_ai_model_t *model)
   g_free(model->task);
   g_free(model->github_asset);
   g_free(model->checksum);
+  g_free(model->version);
+  g_free(model->min_version);
   g_free(model);
 }
 
@@ -69,6 +82,8 @@ static dt_ai_model_t *_model_copy(const dt_ai_model_t *src)
   copy->task = g_strdup(src->task);
   copy->github_asset = g_strdup(src->github_asset);
   copy->checksum = g_strdup(src->checksum);
+  copy->version = g_strdup(src->version);
+  copy->min_version = g_strdup(src->min_version);
   copy->is_default = src->is_default;
   copy->enabled = src->enabled;
   copy->status = src->status;
@@ -467,6 +482,8 @@ static dt_ai_model_t *_parse_model_json(JsonObject *obj)
     model->github_asset = g_strdup(json_object_get_string_member(obj, "github_asset"));
   if(json_object_has_member(obj, "checksum"))
     model->checksum = g_strdup(json_object_get_string_member(obj, "checksum"));
+  if(json_object_has_member(obj, "min_version"))
+    model->min_version = g_strdup(json_object_get_string_member(obj, "min_version"));
   if(json_object_has_member(obj, "default"))
     model->is_default = json_object_get_boolean_member(obj, "default");
 
@@ -634,6 +651,8 @@ static dt_ai_model_t *_parse_local_model_config(const char *config_path,
     model->description = g_strdup(json_object_get_string_member(obj, "description"));
   if(json_object_has_member(obj, "task"))
     model->task = g_strdup(json_object_get_string_member(obj, "task"));
+  if(json_object_has_member(obj, "version"))
+    model->version = g_strdup(json_object_get_string_member(obj, "version"));
 
   // no github_asset, no checksum — local-only model
   model->enabled = TRUE;
@@ -692,6 +711,30 @@ void dt_ai_models_refresh_status(dt_ai_registry_t *registry)
        && g_file_test(config_path, G_FILE_TEST_EXISTS))
     {
       model->status = DT_AI_MODEL_DOWNLOADED;
+      // read version from the model's own config.json
+      dt_ai_model_t *local = _parse_local_model_config(config_path, model->id);
+      if(local)
+      {
+        if(local->version && local->version[0])
+        {
+          g_free(model->version);
+          model->version = g_strdup(local->version);
+        }
+        _model_free(local);
+
+        // check if installed version meets minimum requirement
+        if(model->min_version
+           && _version_compare(model->version, model->min_version) < 0)
+        {
+          model->status = DT_AI_MODEL_UPDATE_REQUIRED;
+          dt_print(DT_DEBUG_AI,
+                   "[ai_models] model %s v%s is older than "
+                   "required v%s - please update",
+                   model->id,
+                   model->version ? model->version : "0.0",
+                   model->min_version);
+        }
+      }
     }
     else
     {
@@ -1558,6 +1601,47 @@ char *dt_ai_models_get_active_for_task(const char *task)
   }
 
   return NULL;
+}
+
+const char *dt_ai_model_get_version(const char *model_id)
+{
+  if(!model_id || !darktable.ai_registry)
+    return "0.0";
+
+  const char *result = "0.0";
+  g_mutex_lock(&darktable.ai_registry->lock);
+  for(GList *l = darktable.ai_registry->models; l; l = g_list_next(l))
+  {
+    const dt_ai_model_t *m = l->data;
+    if(m->id && strcmp(m->id, model_id) == 0)
+    {
+      if(m->version && m->version[0])
+        result = m->version;
+      break;
+    }
+  }
+  g_mutex_unlock(&darktable.ai_registry->lock);
+  return result;
+}
+
+const char *dt_ai_model_get_min_version(const char *model_id)
+{
+  if(!model_id || !darktable.ai_registry)
+    return NULL;
+
+  const char *result = NULL;
+  g_mutex_lock(&darktable.ai_registry->lock);
+  for(GList *l = darktable.ai_registry->models; l; l = g_list_next(l))
+  {
+    const dt_ai_model_t *m = l->data;
+    if(m->id && strcmp(m->id, model_id) == 0)
+    {
+      result = m->min_version;
+      break;
+    }
+  }
+  g_mutex_unlock(&darktable.ai_registry->lock);
+  return result;
 }
 
 void dt_ai_models_set_active_for_task(const char *task, const char *model_id)

--- a/src/common/ai_models.h
+++ b/src/common/ai_models.h
@@ -38,6 +38,7 @@ typedef enum dt_ai_model_status_t
   DT_AI_MODEL_NOT_DOWNLOADED = 0,
   DT_AI_MODEL_DOWNLOADING,
   DT_AI_MODEL_DOWNLOADED,
+  DT_AI_MODEL_UPDATE_REQUIRED,
   DT_AI_MODEL_ERROR,
 } dt_ai_model_status_t;
 
@@ -52,6 +53,8 @@ typedef struct dt_ai_model_t
   char *task;            // Task type: "denoise", "upscale", etc.
   char *github_asset;    // Asset filename in GitHub release
   char *checksum;        // SHA256 checksum (format: "sha256:...")
+  char *version;         // actual version from model's config.json
+  char *min_version;     // minimum required version from registry
   gboolean is_default;   // TRUE if model is a default model for its task
   gboolean enabled;      // User preference (stored in darktablerc)
   dt_ai_model_status_t status;
@@ -253,6 +256,20 @@ void dt_ai_models_set_enabled(dt_ai_registry_t *registry, const char *model_id,
  * @return Newly allocated model ID string (caller must free), or NULL if none active
  */
 char *dt_ai_models_get_active_for_task(const char *task);
+
+/**
+ * @brief Get the version string of a model by ID.
+ * @return Version string (e.g. "1.0"), or "0.0" if not set.
+ *         Pointer valid until next registry refresh. Do not free.
+ */
+const char *dt_ai_model_get_version(const char *model_id);
+
+/**
+ * @brief Get the minimum required version from the registry.
+ * @return Min version string, or NULL if not set.
+ *         Pointer valid until next registry refresh. Do not free.
+ */
+const char *dt_ai_model_get_min_version(const char *model_id);
 
 /**
  * @brief Set the active model for a task (exclusive — clears previous).

--- a/src/gui/preferences_ai.c
+++ b/src/gui/preferences_ai.c
@@ -66,6 +66,7 @@ enum
 {
   COL_SELECTED,
   COL_NAME,
+  COL_VERSION,
   COL_TASK,
   COL_DESCRIPTION,
   COL_ENABLED,
@@ -147,6 +148,8 @@ static const char *_status_to_string(dt_ai_model_status_t status)
   {
   case DT_AI_MODEL_DOWNLOADED:
     return _("downloaded");
+  case DT_AI_MODEL_UPDATE_REQUIRED:
+    return _("update required");
   case DT_AI_MODEL_DOWNLOADING:
     return _("downloading...");
   case DT_AI_MODEL_ERROR:
@@ -214,6 +217,10 @@ static void _refresh_model_list(dt_prefs_ai_data_t *data)
       _status_to_string(model->status),
       COL_DEFAULT,
       model->is_default ? _("yes") : _("no"),
+      COL_VERSION,
+      (model->status == DT_AI_MODEL_DOWNLOADED
+       || model->status == DT_AI_MODEL_UPDATE_REQUIRED)
+        ? (model->version ? model->version : "0.0") : "–",
       COL_ID,
       model->id,
       -1);
@@ -661,7 +668,8 @@ static void _on_download_selected(GtkButton *button, gpointer user_data)
     dt_ai_model_t *model = dt_ai_models_get_by_id(darktable.ai_registry, id);
     if(model)
     {
-      gboolean need_download = (model->status == DT_AI_MODEL_NOT_DOWNLOADED);
+      gboolean need_download = (model->status == DT_AI_MODEL_NOT_DOWNLOADED
+                                || model->status == DT_AI_MODEL_UPDATE_REQUIRED);
       dt_ai_model_free(model);
       if(need_download && !_download_model_with_dialog(data, id))
         break; // stop on error or cancel
@@ -683,7 +691,9 @@ static void _on_download_default(GtkButton *button, gpointer user_data)
     if(!model)
       continue;
     gboolean need_download
-      = (model->is_default && model->status == DT_AI_MODEL_NOT_DOWNLOADED);
+      = (model->is_default
+         && (model->status == DT_AI_MODEL_NOT_DOWNLOADED
+             || model->status == DT_AI_MODEL_UPDATE_REQUIRED));
     char *id = need_download ? g_strdup(model->id) : NULL;
     dt_ai_model_free(model);
     if(need_download)
@@ -710,7 +720,8 @@ static void _on_download_all(GtkButton *button, gpointer user_data)
     dt_ai_model_t *model = dt_ai_models_get_by_index(darktable.ai_registry, i);
     if(!model)
       continue;
-    gboolean need_download = (model->status == DT_AI_MODEL_NOT_DOWNLOADED);
+    gboolean need_download = (model->status == DT_AI_MODEL_NOT_DOWNLOADED
+                              || model->status == DT_AI_MODEL_UPDATE_REQUIRED);
     char *id = need_download ? g_strdup(model->id) : NULL;
     dt_ai_model_free(model);
     if(need_download)
@@ -984,6 +995,7 @@ void init_tab_ai(GtkWidget *dialog, GtkWidget *stack)
     NUM_COLS,
     G_TYPE_BOOLEAN, // selected
     G_TYPE_STRING,  // name
+    G_TYPE_STRING,  // version
     G_TYPE_STRING,  // task
     G_TYPE_STRING,  // description
     G_TYPE_BOOLEAN, // enabled
@@ -1050,6 +1062,15 @@ void init_tab_ai(GtkWidget *dialog, GtkWidget *stack)
     NULL);
   gtk_tree_view_column_set_expand(name_col, FALSE);
   gtk_tree_view_append_column(GTK_TREE_VIEW(data->model_list), name_col);
+
+  // version column
+  GtkTreeViewColumn *version_col = gtk_tree_view_column_new_with_attributes(
+    _("version"),
+    text_renderer,
+    "text",
+    COL_VERSION,
+    NULL);
+  gtk_tree_view_append_column(GTK_TREE_VIEW(data->model_list), version_col);
 
   // task column
   GtkTreeViewColumn *task_col = gtk_tree_view_column_new_with_attributes(


### PR DESCRIPTION
## Summary
- Add "X.Y" version field to AI models, read from the model's own `config.json`
- Add `min_version` field to the registry (`ai_models.json`) defining the minimum version darktable code requires
- Invalidate disk cache when model version changes
- Show version column in AI preferences tab
- Block model loading when major version is incompatible
- Show "update required" status and allow re-download for outdated models

## Details

**Version sources:**
- `version` comes from the model's `config.json` (inside the `.dtmodel` package) – this is the actual installed version
- `min_version` comes from `ai_models.json` (shipped with darktable) – this is the minimum version the current code supports

**Version format "X.Y":**
- X = major version. A change means model I/O changed and requires darktable code updates. If installed X < required X, the model is blocked from loading
- Y = minor version. Incremental model improvements (better weights, same interface). No code changes needed, model still works

**Cache invalidation:**
- Model version is included in the disk cache header (cache format bumped from v1 to v2)
- Old caches are automatically rejected by the format version check
- Version mismatch between cache and loaded model triggers re-encoding

**Preferences UI:**
- New "version" column after "name", shows actual version for downloaded models, "–" for not downloaded
- Status shows "update required" when installed version < min_version
- All three download buttons (selected/default/all) allow re-downloading models with "update required" status