### PR TITLE
bauhaus: receive scroll events propagated from other widgets

### DIFF
--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -3738,9 +3738,12 @@ static void dt_bh_init(DtBauhausWidget *w)
 
   dt_gui_connect_motion(w, _widget_motion, _widget_enter, _widget_leave, widget);
 
-  dt_gui_connect_scroll(w, GTK_EVENT_CONTROLLER_SCROLL_BOTH_AXES
-                           | GTK_EVENT_CONTROLLER_SCROLL_DISCRETE,
-                        _widget_scroll, widget);
+  GtkEventController *scroll_controller =
+    dt_gui_connect_scroll(w, GTK_EVENT_CONTROLLER_SCROLL_BOTH_AXES
+                             | GTK_EVENT_CONTROLLER_SCROLL_DISCRETE,
+                          _widget_scroll, widget);
+  // allows for capturing propagated events from other widgets
+  gtk_event_controller_set_propagation_phase(scroll_controller, GTK_PHASE_BUBBLE);
 
   gtk_widget_set_can_focus(widget, TRUE);
   dt_gui_add_class(widget, "dt_bauhaus");


### PR DESCRIPTION
Switching bauhaus to GTK4-ready scrolling behavior in 215911fc2ee4e37bed615d6b944a162dcaebe47f caused bauhaus to no longer handle synthetic scroll events sent from other widgets. Setting the scroll event controller to receive events in `GTK_PHASE_BUBBLE` fixes this.

The colorequal iop synthesizes scroll events from its graph widget to the appropriate bauhaus slider. This commit restores the ability of the bauhaus sliders to capture these events.

Fixes: #20641.