### PR TITLE
Fix late color_smoothing and green equilibration regressions

### DIFF
--- a/data/kernels/demosaic_ppg.cl
+++ b/data/kernels/demosaic_ppg.cl
@@ -116,10 +116,10 @@ green_equilibration_lavg(read_only image2d_t in,
       const float c2 = (fabs(o2_1 - o2_2) + fabs(o2_1 - o2_3) + fabs(o2_1 - o2_4) + fabs(o2_2 - o2_3) + fabs(o2_3 - o2_4) + fabs(o2_2 - o2_4)) / 6.0f;
 
       if((o < maximum * 0.95f) && (c1 < maximum * thr) && (c2 < maximum * thr))
-          o *= m1/m2;
+          o = fmax(0.0f, o * m1/m2);
     }
   }
-  write_imagef (out, (int2)(x, y), o);
+  write_imagef(out, (int2)(x, y), o);
 }
 
 
@@ -230,9 +230,10 @@ green_equilibration_favg_apply(read_only image2d_t in,
   const int c = FC(y, x, filters);
 
   const int isgreen1 = (c == GREEN && !(y & 1)); // on even lines
-
-  pixel *= (isgreen1 ? gr_ratio : 1.0f);
-
+  if(isgreen1)
+  {
+    pixel = fmax(0.0f, pixel * gr_ratio);
+  }
   write_imagef (out, (int2)(x, y), pixel);
 }
 
@@ -419,7 +420,7 @@ color_smoothing(read_only image2d_t in,
   cas(s6, s4);
   cas(s4, s2);
 
-  o.x = s4 + o.y;
+  o.x = fmax(0.0f, s4 + o.y);
 
 
   // 3x3 median for B
@@ -453,7 +454,7 @@ color_smoothing(read_only image2d_t in,
   cas(s6, s4);
   cas(s4, s2);
 
-  o.z = s4 + o.y;
+  o.z = fmax(0.0f, s4 + o.y);
 
   write_imagef(out, (int2) (x, y), o);
 }

--- a/src/iop/demosaicing/basics.c
+++ b/src/iop/demosaicing/basics.c
@@ -138,7 +138,7 @@ static void color_smoothing(float *out,
           SWAPmed(4, 2);
           SWAPmed(6, 4);
           SWAPmed(4, 2);
-          outp[c] = med[4] + outp[1];
+          outp[c] = fmaxf(0.0f, med[4] + outp[1]);
         }
       }
     }
@@ -190,7 +190,7 @@ static void green_equilibration_lavg(float *out,
                           + fabsf(o2_3 - o2_4) + fabsf(o2_2 - o2_4)) / 6.0f;
         if((in[j * width + i] < maximum * 0.95f) && (c1 < maximum * thr) && (c2 < maximum * thr))
         {
-          out[j * width + i] = in[j * width + i] * m1 / m2;
+          out[j * width + i] = fmaxf(0.0f, in[j * width + i] * m1 / m2);
         }
       }
     }
@@ -230,7 +230,7 @@ static void green_equilibration_favg(float *out,
   {
     for(int i = oi; i < (width - 1 - g2_offset); i += 2)
     {
-      out[(size_t)j * width + i] = in[(size_t)j * width + i] * gr_ratio;
+      out[(size_t)j * width + i] = fmaxf(0.0f, in[(size_t)j * width + i] * gr_ratio);
     }
   }
 }


### PR DESCRIPTION
1. Use the old CPU code (before 6aa937e5230ed971612f29eb5b93e85fd5da0ecb and b76657f5b4b1bcfcbe572b129be929c742f1966d ) as that breaks old edits.
2. Modified OpenCL code code to work exactly as CPU with less diffs.

See #20620