### PR TITLE
split scope: move options for each scope to top right of that scope

### DIFF
--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -545,6 +545,7 @@ static void _eventbox_leave_notify_callback(GtkEventControllerMotion *controller
   }
   gtk_widget_hide(s->button_box_left);
   gtk_widget_hide(s->button_box_right);
+  gtk_widget_hide(s->button_box_split);
 }
 
 static void _lib_histogram_collapse_callback(dt_action_t *action)
@@ -590,6 +591,7 @@ void view_enter(struct dt_lib_module_t *self,
   // histogram, in which case gtk kindly generates enter events
   gtk_widget_hide(s->button_box_left);
   gtk_widget_hide(s->button_box_right);
+  gtk_widget_hide(s->button_box_split);
 
   // FIXME: set histogram data to blank if enter tether with no active image
 }
@@ -601,7 +603,7 @@ void view_leave(struct dt_lib_module_t *self,
   DT_CONTROL_SIGNAL_DISCONNECT(_lib_histogram_preview_updated_callback, self);
 }
 
-static gboolean _overlay_size_child_to_main(GtkOverlay *overlay,
+static gboolean _overlay_get_child_position(GtkOverlay *overlay,
                                             GtkWidget *child,
                                             GdkRectangle *alloc,
                                             GtkWidget *match)
@@ -686,30 +688,45 @@ void gui_init(dt_lib_module_t *self)
                      GDK_KEY_H, GDK_CONTROL_MASK | GDK_SHIFT_MASK);
 
   // a row of control buttons, split in two button boxes, on left and right side
+  // overlaying the current scope
+  //
   // self->widget (GtkEventBox)
   //   '--> GtkOverlay
   //          |--> scope_draw (DtGtkDrawingArea with dt_ui_resize_wrap)
   //          |--> button_box_left (GtkBox hori)
   //          |      '--> mode buttons
-  //          '--> button_box_right (GtkBox vert)
-  //                 |--> button_box_opt (GtkBox hori)
-  //                 |      '--> option buttons & button_box_rgb
-  //                 '--> vectorscope harmony buttons (GtkViewport)
-  // FIXME: put button_box_left_right into a single box so can load it into single overlay and turn on/off with one GTK call?
+  //          |--> button_box_right (GtkBox hori)
+  //          |      '--> option buttons for non-split or right side of split
+  //          '--> button_box_split (GtkBox hori)
+  //                 '--> option buttons for left side of split, if shown
   s->button_box_left = dt_gui_hbox();
   dt_gui_add_class(s->button_box_left, "button_box");
   gtk_widget_set_valign(s->button_box_left, GTK_ALIGN_START);
   gtk_widget_set_halign(s->button_box_left, GTK_ALIGN_START);
 
-  s->button_box_right = dt_gui_vbox();
+  s->button_box_split = dt_gui_hbox();
+  dt_gui_add_class(s->button_box_split, "button_box");
+  gtk_widget_set_valign(s->button_box_split, GTK_ALIGN_START);
+  gtk_widget_set_halign(s->button_box_split, GTK_ALIGN_END);
+  GtkWidget *outer_box_split = dt_gui_hbox();
+  gtk_box_set_homogeneous(GTK_BOX(outer_box_split), TRUE);
+  GtkWidget *split_spacer = dt_gui_hbox();
+  dt_gui_box_add(outer_box_split, s->button_box_split, split_spacer);
+
+  s->button_box_right = dt_gui_hbox();
   dt_gui_add_class(s->button_box_right, "button_box");
   gtk_widget_set_valign(s->button_box_right, GTK_ALIGN_START);
   gtk_widget_set_halign(s->button_box_right, GTK_ALIGN_END);
+  gtk_widget_set_hexpand(s->button_box_right, TRUE);
 
-  GtkWidget *button_box_opt = dt_gui_hbox();
-  gtk_widget_set_valign(button_box_opt, GTK_ALIGN_START);
-  gtk_widget_set_halign(button_box_opt, GTK_ALIGN_END);
-  dt_gui_box_add(s->button_box_right, button_box_opt);
+  s->overlay = gtk_overlay_new();
+  gtk_container_add(GTK_CONTAINER(s->overlay), s->scope_draw);
+  gtk_overlay_add_overlay(GTK_OVERLAY(s->overlay), s->button_box_left);
+  gtk_overlay_add_overlay(GTK_OVERLAY(s->overlay), s->button_box_right);
+  gtk_overlay_add_overlay(GTK_OVERLAY(s->overlay), outer_box_split);
+  // allow for dragging to change exposure in spaces where not buttons
+  gtk_overlay_set_overlay_pass_through (GTK_OVERLAY(s->overlay), s->button_box_left, TRUE);
+  gtk_overlay_set_overlay_pass_through (GTK_OVERLAY(s->overlay), outer_box_split, TRUE);
 
   // FIXME: the button transitions when they appear on mouseover
   // (mouse enters scope widget) or change (mouse click) cause redraws
@@ -723,20 +740,41 @@ void gui_init(dt_lib_module_t *self)
       dtgtk_cairo_paint_split_waveform_vectorscope,
       dtgtk_cairo_paint_rgb_parade,
       dtgtk_cairo_paint_histogram_scope };
+  // FIXME: can use use GtkStack or tabless GtkNotebook to handle
+  // mode-switching behavior -- drawable and right buttons?
   for(int i=0; i<DT_SCOPES_MODE_N; i++)
   {
-    // FIXME: can use use GtkStack or GtkNotebook with gtk_notebook_set_show_tabs() to FALSE to handle mode-switching behavior?
+    const char *const name = dt_scopes_call(&s->modes[i], name);
     s->modes[i].button_activate =
       dtgtk_togglebutton_new(dt_lib_histogram_scope_type_icons[i], CPF_NONE, NULL);
-    const char *const name = dt_scopes_call(&s->modes[i], name);
+    gtk_widget_set_halign(s->modes[i].button_activate, GTK_ALIGN_CENTER);
+    gtk_widget_set_valign(s->modes[i].button_activate, GTK_ALIGN_START);
     gtk_widget_set_tooltip_text(s->modes[i].button_activate, _(name));
     dt_action_define(dark, N_("modes"), name,
                      s->modes[i].button_activate, &dt_action_def_toggle);
-    dt_gui_box_add(s->button_box_left, s->modes[i].button_activate);
     // GTK4: use gtk_toggle_button_set_group(), GTK3: handle in callback
     s->modes[i].toggle_signal_handler =
       g_signal_connect_data(G_OBJECT(s->modes[i].button_activate), "toggled",
                             G_CALLBACK(_mode_toggle), s, NULL, 0);
+
+    if(s->modes[i].functions->add_options)
+    {
+      s->modes[i].options_box = dt_gui_hbox();
+      dt_scopes_call(&s->modes[i], add_options, dark);
+      dt_gui_box_add(s->button_box_right, s->modes[i].options_box);
+    }
+    else
+      s->modes[i].options_box = NULL;
+  }
+
+  // allow for clustering mode buttons in responsive layout
+  const int btns_per_row = 3;
+  for(int row_start=0; row_start < DT_SCOPES_MODE_N; row_start += btns_per_row)
+  {
+    GtkWidget *row = dt_gui_hbox();
+    for(int pos=row_start; pos < row_start+btns_per_row && pos < DT_SCOPES_MODE_N; pos++)
+      dt_gui_box_add(row, s->modes[pos].button_activate);
+    dt_gui_box_add(s->button_box_left, row);
   }
 
   dt_action_t *teth = &darktable.view_manager->proxy.tethering.view->actions;
@@ -745,11 +783,10 @@ void gui_init(dt_lib_module_t *self)
                        _lib_histogram_collapse_callback,
                        GDK_KEY_H, GDK_CONTROL_MASK | GDK_SHIFT_MASK);
 
-  // add option buttons
-
+  // RGB channel buttons
   s->button_box_rgb = dt_gui_hbox();
   gtk_widget_set_valign(s->button_box_rgb, GTK_ALIGN_CENTER);
-  gtk_widget_set_halign(s->button_box_rgb, GTK_ALIGN_END);
+  gtk_widget_set_halign(s->button_box_rgb, GTK_ALIGN_CENTER);
   // red/green/blue channel on/off
   for(int i=DT_SCOPES_RGB_RED; i < DT_SCOPES_RGB_N; i++)
   {
@@ -767,16 +804,8 @@ void gui_init(dt_lib_module_t *self)
     g_signal_connect(G_OBJECT(btn), "toggled", G_CALLBACK(_channel_toggle), s);
     s->channel_buttons[i] = btn;
   }
-
-  // hardwire waveform buttons before vectorscope in split, RGB
-  // channels after waveform/histogram options but before vectorscope
-  dt_scopes_call(&s->modes[DT_SCOPES_MODE_WAVEFORM], add_options, dark,
-                 s->button_box_right, button_box_opt);
-  dt_scopes_call(&s->modes[DT_SCOPES_MODE_HISTOGRAM], add_options, dark,
-                 s->button_box_right, button_box_opt);
-  dt_gui_box_add(button_box_opt, s->button_box_rgb);
-  dt_scopes_call(&s->modes[DT_SCOPES_MODE_VECTORSCOPE], add_options, dark,
-                 s->button_box_right, button_box_opt);
+  // RGB channels are always rightmost
+  dt_gui_box_add(s->button_box_right, s->button_box_rgb);
 
   for(dt_scopes_mode_type_t i = 0; i < DT_SCOPES_MODE_N; i++)
   {
@@ -788,22 +817,14 @@ void gui_init(dt_lib_module_t *self)
 
   // FIXME: add a brightness control (via GtkScaleButton?). Different per each mode?
 
-  // assemble the widgets
-
-  // The main widget is an overlay which has no window, and hence
-  // can't catch events. We need something on top to catch events to
-  // show/hide the buttons. The drawable is below the buttons, and
-  // hence won't catch motion events for the buttons, and gets a leave
-  // event when the cursor moves over the buttons.
-  GtkWidget *overlay = gtk_overlay_new();
-  gtk_container_add(GTK_CONTAINER(overlay), s->scope_draw);
-  gtk_overlay_add_overlay(GTK_OVERLAY(overlay), s->button_box_left);
-  gtk_overlay_add_overlay(GTK_OVERLAY(overlay), s->button_box_right);
-
+  // The overlay has no window, and hence can't catch events. We need
+  // something on top to catch events to show/hide the buttons. The
+  // drawable is below the buttons, and hence won't catch motion
+  // events for the buttons, and gets a leave event when the cursor
+  // moves over the buttons.
   GtkWidget *eventbox = gtk_event_box_new();
-  gtk_container_add(GTK_CONTAINER(eventbox), overlay);
+  gtk_container_add(GTK_CONTAINER(eventbox), s->overlay);
   self->widget = eventbox;
-
   gtk_widget_set_name(self->widget, "main-histogram");
 
   /* connect callbacks */
@@ -816,8 +837,8 @@ void gui_init(dt_lib_module_t *self)
                         _drawable_leave, s);
   // constrain height of button_box_right to s->scope_draw, necessary
   // so that harmony buttons are scrollable within overlay
-  g_signal_connect(G_OBJECT(overlay), "get-child-position",
-                   G_CALLBACK(_overlay_size_child_to_main), s->button_box_right);
+  g_signal_connect(G_OBJECT(s->overlay), "get-child-position",
+                   G_CALLBACK(_overlay_get_child_position), s->button_box_right);
 
   // FIXME: add (optional) propagation phase argument to dt_gui_connect_*()
   GtkEventController *scroll_controller =

--- a/src/libs/scopes.h
+++ b/src/libs/scopes.h
@@ -110,9 +110,10 @@ typedef struct dt_scopes_functions_t
   void (*update_buttons)(const struct dt_scopes_mode_t *const self);
   void (*mode_enter)(struct dt_scopes_mode_t *const self);
   void (*mode_leave)(const struct dt_scopes_mode_t *const self);
-  void (*gui_init)(struct dt_scopes_mode_t *const self, struct dt_scopes_t *const scopes);
-  void (*add_options)(struct dt_scopes_mode_t *const mode, dt_action_t *dark,
-                      GtkWidget *box_right, GtkWidget *box_opt);
+  void (*gui_init)(struct dt_scopes_mode_t *const self,
+                   struct dt_scopes_t *const scopes);
+  void (*add_options)(struct dt_scopes_mode_t *const mode,
+                      dt_action_t *dark);
   void (*gui_cleanup)(struct dt_scopes_mode_t *const self);
 } dt_scopes_functions_t;
 
@@ -121,6 +122,7 @@ typedef struct dt_scopes_mode_t
   const dt_scopes_functions_t *functions;
   void *data;
   GtkWidget *button_activate;                   // GtkDarktableToggleButton to activate
+  GtkWidget *options_box;                       // GtkBox with option buttons
   gulong toggle_signal_handler;
   int update_counter;
   // point back to parent
@@ -139,9 +141,11 @@ typedef struct dt_scopes_t
   scopes_channels_t channels;                   // display state chosen by RGB buttons
   gboolean dragging;                            // pre-GtkGestureDrag hack
   // UI elements
-  GtkWidget *button_box_left;                   // GtkBox -- contains scope mode buttons
-  GtkWidget *button_box_right;                  // GtkBox -- contains option buttons
-  GtkWidget *button_box_rgb;                    // GtkBox -- contains RGB channels buttons
+  GtkWidget *overlay;                           // GtkOverlay -- scope and buttons
+  GtkWidget *button_box_left;                   // GtkBox -- scope mode buttons
+  GtkWidget *button_box_split;                  // GtkBox -- option buttons for left scope
+  GtkWidget *button_box_right;                  // GtkBox -- option buttons for main scope
+  GtkWidget *button_box_rgb;                    // GtkBox -- RGB channels buttons
   GtkWidget *channel_buttons[DT_SCOPES_RGB_N];  // Array of GtkToggleButton -- RGB channels
   GtkWidget *scope_draw;                        // GtkDrawingArea -- scope & resize
   // for access to data during process/draw

--- a/src/libs/scopes/histogram.c
+++ b/src/libs/scopes/histogram.c
@@ -235,14 +235,15 @@ static void _hist_scale_clicked(GtkWidget *button, dt_scopes_mode_t *self)
   dt_scopes_refresh(self->scopes);
 }
 
-static void _hist_add_options(dt_scopes_mode_t *const self, dt_action_t *dark,
-                              GtkWidget *box_right, GtkWidget *box_opt)
+static void _hist_add_options(dt_scopes_mode_t *const self,
+                              dt_action_t *dark)
 {
   dt_scopes_hist_t *d = self->data;
   d->scale_button = dtgtk_button_new(dtgtk_cairo_paint_empty, CPF_NONE, NULL);
+  gtk_widget_set_valign(d->scale_button, GTK_ALIGN_START);
   dt_action_define(dark, NULL, N_("switch histogram scale"),
                    d->scale_button, &dt_action_def_button);
-  dt_gui_box_add(box_opt, d->scale_button);
+  dt_gui_box_add(self->options_box, d->scale_button);
   g_signal_connect(G_OBJECT(d->scale_button), "clicked",
                    G_CALLBACK(_hist_scale_clicked), self);
 }

--- a/src/libs/scopes/split.c
+++ b/src/libs/scopes/split.c
@@ -206,14 +206,96 @@ static void _split_update_buttons(const dt_scopes_mode_t *const self)
   dt_scopes_call(d->right, update_buttons);
 }
 
+static void _responsive_buttons(dt_scopes_t *const s)
+{
+  const int scopes_width = gtk_widget_get_allocated_width(s->scope_draw);
+  // no sense calculating while still allocating scope
+  if(scopes_width <= 1) return;
+
+  // widths calculated on startup
+  static int btns_mode_hori = 0;
+  static int btns_opt_hori = 0;
+  static int btns_opt_vert = 0;
+  static int extra = 0;
+
+  // make a reasonable guess at button box widths based on CSS, which
+  // won't be as accurate as the actual allocated size, but does allow
+  // for a layout without buttons moving after first shown
+  if(!btns_mode_hori)
+  {
+    GtkStyleContext *ctx = gtk_widget_get_style_context(s->cur_mode->button_activate);
+    GValue val = G_VALUE_INIT;
+    gtk_style_context_get_property(ctx, "min-width",
+                                   gtk_style_context_get_state(ctx),
+                                   &val);
+    double min_w = 0.0;
+    if(G_VALUE_HOLDS_INT(&val))
+      min_w = g_value_get_int(&val);
+    else if(G_VALUE_HOLDS_DOUBLE(&val))
+      min_w = g_value_get_double(&val);
+    else
+      dt_print(DT_DEBUG_ALWAYS, "[_responsive_buttons] unexpected type for min-width");
+    g_value_unset(&val);
+    if(min_w == 0.0) return;
+
+    const int mode_btns_hori = DT_SCOPES_MODE_N;
+    const int opt_btns_wave = 1;  // FIXME: change this if there are more
+    const int opt_btns_hori = DT_SCOPES_RGB_N + opt_btns_wave;
+    const int opt_btns_vert = 1 + opt_btns_wave;
+    const int estd_margin = 6;  // for both boxes and buttons
+    const double estd_btn_width = min_w + estd_margin;
+    extra = estd_btn_width;
+    btns_mode_hori = estd_btn_width * mode_btns_hori + estd_margin;
+    btns_opt_hori = estd_btn_width * opt_btns_hori + estd_margin;
+    btns_opt_vert = estd_btn_width * opt_btns_vert + estd_margin;
+  }
+
+  // collapse rgb buttons to prevent mode/option buttons overlap, and
+  // as last recourse collapse mode buttons
+  GtkOrientation orient_btn_left = GTK_ORIENTATION_HORIZONTAL;
+  GtkOrientation orient_btn_rgb = GTK_ORIENTATION_HORIZONTAL;
+  const int split_width = scopes_width/2;
+  if(btns_mode_hori + btns_opt_hori + extra > split_width)
+    orient_btn_rgb = GTK_ORIENTATION_VERTICAL;
+  if(btns_mode_hori + btns_opt_vert + extra > split_width)
+    orient_btn_left = GTK_ORIENTATION_VERTICAL;
+  // compact layout should show all buttons without overlap on the
+  // smallest panel width and scope height
+  gtk_orientable_set_orientation(GTK_ORIENTABLE(s->button_box_left), orient_btn_left);
+  gtk_orientable_set_orientation(GTK_ORIENTABLE(s->button_box_rgb), orient_btn_rgb);
+}
+
+static void _reparent(GtkWidget *src, GtkWidget *dest, GtkWidget *child)
+{
+  // as enter/leave can be called multiple times, check the child
+  // widget is in src
+  if(gtk_widget_get_parent(child) == src)
+  {
+    g_object_ref(child);
+    gtk_container_remove(GTK_CONTAINER(src), child);
+    dt_gui_box_add(dest, child);
+    g_object_unref(child);
+  }
+}
+
 static void _split_mode_enter(dt_scopes_mode_t *const self)
 {
   const dt_scopes_split_t *const d = self->data;
+
+  _responsive_buttons(self->scopes);
   dt_scopes_call(d->left, mode_enter);
   dt_scopes_call(d->right, mode_enter);
   self->update_counter = MAX(d->left->update_counter, d->right->update_counter);
   if(d->left->update_counter != d->right->update_counter)
     dt_scopes_reprocess();
+
+  // reparent waveform and RGB channel buttons to left split options
+  _reparent(self->scopes->button_box_right, self->scopes->button_box_split,
+            d->left->options_box);
+  if(d->left->functions->draw_scope_channels)
+    _reparent(self->scopes->button_box_right, self->scopes->button_box_split,
+              self->scopes->button_box_rgb);
+  gtk_widget_show_all(self->scopes->button_box_split);
 }
 
 static void _split_mode_leave(const dt_scopes_mode_t *const self)
@@ -221,6 +303,25 @@ static void _split_mode_leave(const dt_scopes_mode_t *const self)
   const dt_scopes_split_t *const d = self->data;
   dt_scopes_call(d->left, mode_leave);
   dt_scopes_call(d->right, mode_leave);
+  // move all children back to right options box
+  _reparent(self->scopes->button_box_split, self->scopes->button_box_right,
+            d->left->options_box);
+  if(d->left->functions->draw_scope_channels)
+    _reparent(self->scopes->button_box_split, self->scopes->button_box_right,
+              self->scopes->button_box_rgb);
+  gtk_widget_hide(self->scopes->button_box_split);
+  gtk_orientable_set_orientation(GTK_ORIENTABLE(self->scopes->button_box_left),
+                                 GTK_ORIENTATION_HORIZONTAL);
+  gtk_orientable_set_orientation(GTK_ORIENTABLE(self->scopes->button_box_rgb),
+                                 GTK_ORIENTATION_HORIZONTAL);
+}
+
+static void _overlay_size_allocate(GtkWidget *overlay,
+                                   GtkAllocation* allocation,
+                                   dt_scopes_mode_t *const self)
+{
+  if(self->scopes->cur_mode == self)
+    _responsive_buttons(self->scopes);
 }
 
 static void _split_gui_init(dt_scopes_mode_t *const self,
@@ -230,6 +331,17 @@ static void _split_gui_init(dt_scopes_mode_t *const self,
   self->data = (void *)d;
   d->left = &self->scopes->modes[DT_SCOPES_MODE_WAVEFORM];
   d->right = &self->scopes->modes[DT_SCOPES_MODE_VECTORSCOPE];
+}
+
+static void _split_add_options(dt_scopes_mode_t *const self,
+                               dt_action_t *dark)
+{
+  // must be called after _split_gui_init as need more initializaiton,
+  // this does result in making an empty options_box and adding it to
+  // button_box_right, but that should be no harm
+  // FIXME: can wait to set this up until mode_enter?
+  g_signal_connect(G_OBJECT(self->scopes->overlay), "size-allocate",
+                   G_CALLBACK(_overlay_size_allocate), self);
 }
 
 static void _split_gui_cleanup(dt_scopes_mode_t *const self)
@@ -256,7 +368,7 @@ const dt_scopes_functions_t dt_scopes_functions_split = {
   .mode_enter = _split_mode_enter,
   .mode_leave = _split_mode_leave,
   .gui_init = _split_gui_init,
-  .add_options = NULL,
+  .add_options = _split_add_options,
   .gui_cleanup = _split_gui_cleanup
 };
 

--- a/src/libs/scopes/vectorscope.c
+++ b/src/libs/scopes/vectorscope.c
@@ -1220,12 +1220,12 @@ static void _harmony_adjust_page(GtkWidget *widget,
                                  dt_scopes_mode_t *self)
 {
   dt_scopes_vec_t *const d = self->data;
-  // size adjustment page to options buttons box which, in turn,
-  // changes height with the resizeable scopes widget
-  // FIXME: when user resizes scope vertically, next time mouse moves, the buttons widget jumps to new position, so should recalculate its position here based on mouse position during resize
+  // FIXME: when user resizes scope vertically, next time mouse moves,
+  // the buttons widget jumps to new position, so should recalculate
+  // its position here based on mouse position during resize
   gtk_adjustment_set_page_size
     (gtk_scrollable_get_vadjustment(GTK_SCROLLABLE(d->harmony_viewport)),
-     alloc->height - gtk_widget_get_allocated_height(self->scopes->button_box_left));
+     alloc->height - gtk_widget_get_allocated_height(d->colorspace_button));
 }
 
 static void _harmony_motion(GtkEventControllerMotion *controller,
@@ -1411,25 +1411,21 @@ static void _vec_gui_init(dt_scopes_mode_t *const self,
 }
 
 static void _vec_add_options(dt_scopes_mode_t *const self,
-                             dt_action_t *dark,
-                             GtkWidget *box_right,
-                             GtkWidget *box_opt)
+                             dt_action_t *dark)
 {
   dt_scopes_vec_t *const d = self->data;
 
   d->colorspace_button = dtgtk_button_new(dtgtk_cairo_paint_empty, CPF_NONE, NULL);
   dt_action_define(dark, NULL, N_("cycle vectorscope types"),
                    d->colorspace_button, &dt_action_def_button);
+
   d->vec_scale_button = dtgtk_button_new(dtgtk_cairo_paint_empty, CPF_NONE, NULL);
+  gtk_widget_set_valign(d->vec_scale_button, GTK_ALIGN_START);
   dt_action_define(dark, NULL, N_("switch vectorscope scale"),
                    d->vec_scale_button, &dt_action_def_button);
-  dt_gui_box_add(box_opt, d->vec_scale_button, d->colorspace_button);
 
   d->harmony_viewport = gtk_viewport_new(NULL, NULL);
   gtk_widget_set_halign(d->harmony_viewport, GTK_ALIGN_END);
-  dt_gui_box_add(box_right, d->harmony_viewport);
-  g_signal_connect(G_OBJECT(box_right), "size-allocate",
-                   G_CALLBACK(_harmony_adjust_page), self);
 
   d->color_harmony_box = dt_gui_vbox();
   gtk_widget_set_valign(d->color_harmony_box, GTK_ALIGN_START);
@@ -1453,7 +1449,11 @@ static void _vec_add_options(dt_scopes_mode_t *const self,
     dt_gui_box_add(d->color_harmony_box, rb);
     d->color_harmony_button[i] = rb;
   }
+
   gtk_container_add(GTK_CONTAINER(d->harmony_viewport), d->color_harmony_box);
+  GtkWidget *colorspace_box = dt_gui_vbox();
+  dt_gui_box_add(colorspace_box, d->colorspace_button, d->harmony_viewport);
+  dt_gui_box_add(self->options_box, d->vec_scale_button, colorspace_box);
 
   // FIXME: do we need this action, or is it vestigial?
   dt_action_register(dark, N_("cycle color harmonies"),
@@ -1465,6 +1465,8 @@ static void _vec_add_options(dt_scopes_mode_t *const self,
   g_signal_connect(G_OBJECT(d->colorspace_button), "clicked",
                    G_CALLBACK(_vec_colorspace_clicked), self);
   dt_gui_connect_motion(d->harmony_viewport, _harmony_motion, NULL, _harmony_leave, self);
+  g_signal_connect(G_OBJECT(colorspace_box), "size-allocate",
+                   G_CALLBACK(_harmony_adjust_page), self);
 
   DT_CONTROL_SIGNAL_HANDLE(DT_SIGNAL_DEVELOP_IMAGE_CHANGED, _vec_signal_image_changed);
 }

--- a/src/libs/scopes/waveform.c
+++ b/src/libs/scopes/waveform.c
@@ -392,14 +392,15 @@ static void _wave_orient_clicked(GtkWidget *button, dt_scopes_mode_t *const self
   dt_scopes_reprocess();
 }
 
-static void _wave_add_options(dt_scopes_mode_t *const self, dt_action_t *dark,
-                              GtkWidget *box_right, GtkWidget *box_opt)
+static void _wave_add_options(dt_scopes_mode_t *const self,
+                              dt_action_t *dark)
 {
   dt_scopes_wave_t *const d = self->data;
   d->orient_button = dtgtk_button_new(dtgtk_cairo_paint_empty, CPF_NONE, NULL);
+  gtk_widget_set_valign(d->orient_button, GTK_ALIGN_START);
   dt_action_define(dark, NULL, N_("switch scope orientation"),
                    d->orient_button, &dt_action_def_button);
-  dt_gui_box_add(box_opt, d->orient_button);
+  dt_gui_box_add(self->options_box, d->orient_button);
   g_signal_connect(G_OBJECT(d->orient_button), "clicked",
                    G_CALLBACK(_wave_orient_clicked), self);
 }


### PR DESCRIPTION
Move the option buttons for waveform scope in split mode to the top right of that scope. Previously, all options were in the top right of the module, with no clear differentiation between waveform/vectorscope options.

With this PR:

<img width="489" height="189" alt="image" src="https://github.com/user-attachments/assets/69f1d920-5080-4193-a3bb-d0daa0aeb860" />

Before this PR:

<img width="489" height="189" alt="image" src="https://github.com/user-attachments/assets/29ea2d65-24cf-4271-be33-4aed867bac0f" />

Make buttons responsive when module widget is narrow. Buttons can be packed vertically if necessary to allow mode and left scope option buttons to all fit into the left half of the scope module.

Narrower configuration:

<img width="455" height="189" alt="image" src="https://github.com/user-attachments/assets/a64d4b2f-0882-4f34-9e69-38a3f858177d" />

Narrowest configuration:

<img width="284" height="189" alt="image" src="https://github.com/user-attachments/assets/d5e5097d-e0d0-43df-bd73-7eeb25ff96c2" />

This PR has two rationales:

1. Provide more clarity in split mode about which option buttons correspond to which scope.
2. Open up space in the interface for other scope options (e.g. luminance-only or from raw data).