### PR TITLE
[AI] GPU acceleration install: manifest-driven scripts

### DIFF
--- a/.github/workflows/refresh-ort-gpu.yml
+++ b/.github/workflows/refresh-ort-gpu.yml
@@ -1,0 +1,31 @@
+name: Refresh ONNX Runtime GPU registry
+
+on:
+  schedule:
+    # 1st of each month at 06:00 UTC. ONNX Runtime ships every 4-6 weeks
+    # and Radeon updates ROCm patches roughly quarterly, so monthly is
+    # frequent enough to catch updates without spamming review
+    - cron: '0 6 1 * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Configure git
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+      - name: Refresh registry and open PR if changed
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python3 tools/ai/refresh-ort-gpu.py --update --pr || true

--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -171,6 +171,8 @@ if(USE_AI)
   #
   FILE(COPY ai_models.json DESTINATION "${DARKTABLE_DATADIR}")
   install(FILES ai_models.json DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/darktable COMPONENT DTApplication)
+  FILE(COPY ort_gpu.json DESTINATION "${DARKTABLE_DATADIR}")
+  install(FILES ort_gpu.json DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/darktable COMPONENT DTApplication)
 endif(USE_AI)
 
 #

--- a/data/ort_gpu.json
+++ b/data/ort_gpu.json
@@ -13,11 +13,11 @@
       "cuda_max": "12.99",
       "ort_version": "1.25.1",
       "url": "https://github.com/microsoft/onnxruntime/releases/download/v1.25.1/onnxruntime-linux-x64-gpu-1.25.1.tgz",
-      "sha256": "c5f804ff5d239b436fa59e9f2fb288a39f7eb9552f6a636c8b71e792e91a8808",
+      "sha256": "ddfc4ca4ccc9cd5345d3820edab710ee84e749569d052eed92c42693d3b448a8",
       "format": "tgz",
       "lib_pattern": "libonnxruntime",
       "install_subdir": "onnxruntime-cuda",
-      "size_mb": 200,
+      "size_mb": 250,
       "requirements": "CUDA 12.x, cuDNN 9.x"
     },
     {
@@ -28,7 +28,7 @@
       "cuda_max": "13.99",
       "ort_version": "1.25.1",
       "url": "https://github.com/microsoft/onnxruntime/releases/download/v1.25.1/onnxruntime-linux-x64-gpu_cuda13-1.25.1.tgz",
-      "sha256": "fdc6eb18317b4eaeda8b3b86595e5da7e853f72bac67ccac9b04ffc20c9f7fe0",
+      "sha256": "ebc14e1290db2a30a7bb415bd1c3e1390a7816bb4db87677dc36d071ed22833c",
       "format": "tgz",
       "lib_pattern": "libonnxruntime",
       "install_subdir": "onnxruntime-cuda",
@@ -43,11 +43,11 @@
       "cuda_max": "12.99",
       "ort_version": "1.25.1",
       "url": "https://github.com/microsoft/onnxruntime/releases/download/v1.25.1/onnxruntime-win-x64-gpu-1.25.1.zip",
-      "sha256": "ef3337a0b8184eb8beec310f7c83bd50376b3eefc43aab84ac8e452f6987df0a",
+      "sha256": "e72bc4895f84400368382d7b7287c018eabbb2be384e67446f3ab64af7fe5552",
       "format": "zip",
       "lib_pattern": "onnxruntime",
       "install_subdir": "onnxruntime-cuda",
-      "size_mb": 200,
+      "size_mb": 300,
       "requirements": "CUDA 12.x, cuDNN 9.x"
     },
     {
@@ -58,11 +58,11 @@
       "cuda_max": "13.99",
       "ort_version": "1.25.1",
       "url": "https://github.com/microsoft/onnxruntime/releases/download/v1.25.1/onnxruntime-win-x64-gpu_cuda13-1.25.1.zip",
-      "sha256": "971be8cf984950672934a3173669590a8ece10b44746883420da8066ba836707",
+      "sha256": "d54b465e5f9300d8928c43772751ac95c123ebd90069a0a4b8ce02e503335469",
       "format": "zip",
       "lib_pattern": "onnxruntime",
       "install_subdir": "onnxruntime-cuda",
-      "size_mb": 200,
+      "size_mb": 300,
       "requirements": "CUDA 13.x, cuDNN 9.x"
     },
     {
@@ -73,11 +73,11 @@
       "rocm_max": "7.0",
       "ort_version": "1.22.1",
       "url": "https://repo.radeon.com/rocm/manylinux/rocm-rel-7.0.2/onnxruntime_rocm-1.22.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl",
-      "sha256": "953a4e152f944391798880d88ea3d887c1109cfdc622815d81c07e2e1abc080e",
+      "sha256": "0f9c1555c31cc1bef84504807a0747486017ec4bd9b9f7df0b15e659140a7f7e",
       "format": "whl",
       "lib_pattern": "libonnxruntime",
       "install_subdir": "onnxruntime-migraphx",
-      "size_mb": 300,
+      "size_mb": 200,
       "requirements": "ROCm 7.0, MIGraphX",
       "required_libs": [
         "libmigraphx_c.so.3",
@@ -107,11 +107,11 @@
       "rocm_max": "7.2",
       "ort_version": "1.23.2",
       "url": "https://repo.radeon.com/rocm/manylinux/rocm-rel-7.2.2/onnxruntime_migraphx-1.23.2-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl",
-      "sha256": "45d556a6c261383f3e1f1469764a6ce94dc9daaa65fc3d494406d9cd357a3656",
+      "sha256": "76f22bba96991d6653c8169999817203cde72e6703b8211f00dc8dd80ff8e43b",
       "format": "whl",
       "lib_pattern": "libonnxruntime",
       "install_subdir": "onnxruntime-migraphx",
-      "size_mb": 300,
+      "size_mb": 50,
       "requirements": "ROCm 7.2, MIGraphX"
     },
     {

--- a/data/ort_gpu.json
+++ b/data/ort_gpu.json
@@ -1,0 +1,155 @@
+{
+  "version": 1,
+  "install_docs": {
+    "nvidia": "https://developer.nvidia.com/cudnn-downloads",
+    "amd": "https://rocm.docs.amd.com/projects/install-on-linux/en/latest/"
+  },
+  "packages": [
+    {
+      "vendor": "nvidia",
+      "platform": "linux",
+      "arch": "x86_64",
+      "cuda_min": "12.0",
+      "cuda_max": "12.99",
+      "ort_version": "1.25.1",
+      "url": "https://github.com/microsoft/onnxruntime/releases/download/v1.25.1/onnxruntime-linux-x64-gpu-1.25.1.tgz",
+      "sha256": "c5f804ff5d239b436fa59e9f2fb288a39f7eb9552f6a636c8b71e792e91a8808",
+      "format": "tgz",
+      "lib_pattern": "libonnxruntime",
+      "install_subdir": "onnxruntime-cuda",
+      "size_mb": 200,
+      "requirements": "CUDA 12.x, cuDNN 9.x"
+    },
+    {
+      "vendor": "nvidia",
+      "platform": "linux",
+      "arch": "x86_64",
+      "cuda_min": "13.0",
+      "cuda_max": "13.99",
+      "ort_version": "1.25.1",
+      "url": "https://github.com/microsoft/onnxruntime/releases/download/v1.25.1/onnxruntime-linux-x64-gpu_cuda13-1.25.1.tgz",
+      "sha256": "fdc6eb18317b4eaeda8b3b86595e5da7e853f72bac67ccac9b04ffc20c9f7fe0",
+      "format": "tgz",
+      "lib_pattern": "libonnxruntime",
+      "install_subdir": "onnxruntime-cuda",
+      "size_mb": 200,
+      "requirements": "CUDA 13.x, cuDNN 9.x"
+    },
+    {
+      "vendor": "nvidia",
+      "platform": "windows",
+      "arch": "x86_64",
+      "cuda_min": "12.0",
+      "cuda_max": "12.99",
+      "ort_version": "1.25.1",
+      "url": "https://github.com/microsoft/onnxruntime/releases/download/v1.25.1/onnxruntime-win-x64-gpu-1.25.1.zip",
+      "sha256": "ef3337a0b8184eb8beec310f7c83bd50376b3eefc43aab84ac8e452f6987df0a",
+      "format": "zip",
+      "lib_pattern": "onnxruntime",
+      "install_subdir": "onnxruntime-cuda",
+      "size_mb": 200,
+      "requirements": "CUDA 12.x, cuDNN 9.x"
+    },
+    {
+      "vendor": "nvidia",
+      "platform": "windows",
+      "arch": "x86_64",
+      "cuda_min": "13.0",
+      "cuda_max": "13.99",
+      "ort_version": "1.25.1",
+      "url": "https://github.com/microsoft/onnxruntime/releases/download/v1.25.1/onnxruntime-win-x64-gpu_cuda13-1.25.1.zip",
+      "sha256": "971be8cf984950672934a3173669590a8ece10b44746883420da8066ba836707",
+      "format": "zip",
+      "lib_pattern": "onnxruntime",
+      "install_subdir": "onnxruntime-cuda",
+      "size_mb": 200,
+      "requirements": "CUDA 13.x, cuDNN 9.x"
+    },
+    {
+      "vendor": "amd",
+      "platform": "linux",
+      "arch": "x86_64",
+      "rocm_min": "7.0",
+      "rocm_max": "7.0",
+      "ort_version": "1.22.1",
+      "url": "https://repo.radeon.com/rocm/manylinux/rocm-rel-7.0.2/onnxruntime_rocm-1.22.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl",
+      "sha256": "953a4e152f944391798880d88ea3d887c1109cfdc622815d81c07e2e1abc080e",
+      "format": "whl",
+      "lib_pattern": "libonnxruntime",
+      "install_subdir": "onnxruntime-migraphx",
+      "size_mb": 300,
+      "requirements": "ROCm 7.0, MIGraphX",
+      "required_libs": [
+        "libmigraphx_c.so.3",
+        "librocm_smi64.so.7"
+      ]
+    },
+    {
+      "vendor": "amd",
+      "platform": "linux",
+      "arch": "x86_64",
+      "rocm_min": "7.1",
+      "rocm_max": "7.1",
+      "ort_version": "1.23.1",
+      "url": "https://repo.radeon.com/rocm/manylinux/rocm-rel-7.1.1/onnxruntime_migraphx-1.23.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl",
+      "sha256": "0bb62f7c2b326b2435396ef90a5f3ad030fe779aa9d0da7013d8b514c27de08f",
+      "format": "whl",
+      "lib_pattern": "libonnxruntime",
+      "install_subdir": "onnxruntime-migraphx",
+      "size_mb": 100,
+      "requirements": "ROCm 7.1, MIGraphX"
+    },
+    {
+      "vendor": "amd",
+      "platform": "linux",
+      "arch": "x86_64",
+      "rocm_min": "7.2",
+      "rocm_max": "7.2",
+      "ort_version": "1.23.2",
+      "url": "https://repo.radeon.com/rocm/manylinux/rocm-rel-7.2.2/onnxruntime_migraphx-1.23.2-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl",
+      "sha256": "45d556a6c261383f3e1f1469764a6ce94dc9daaa65fc3d494406d9cd357a3656",
+      "format": "whl",
+      "lib_pattern": "libonnxruntime",
+      "install_subdir": "onnxruntime-migraphx",
+      "size_mb": 300,
+      "requirements": "ROCm 7.2, MIGraphX"
+    },
+    {
+      "vendor": "intel",
+      "platform": "linux",
+      "arch": "x86_64",
+      "ort_version": "1.24.1",
+      "url": "https://files.pythonhosted.org/packages/50/cf/17ba72de2df0fcba349937d2788f154397bbc2d1a2d67772a97e26f6bc5f/onnxruntime_openvino-1.24.1-cp312-cp312-manylinux_2_28_x86_64.whl",
+      "sha256": "d617fac2f59a6ab5ea59a788c3e1592240a129642519aaeaa774761dfe35150e",
+      "format": "whl",
+      "lib_pattern": "libonnxruntime",
+      "lib_extra_patterns": [
+        "libopenvino",
+        "libtbb"
+      ],
+      "install_subdir": "onnxruntime-openvino",
+      "size_mb": 80,
+      "requirements": "Intel GPU driver (OpenCL)"
+    },
+    {
+      "vendor": "intel",
+      "platform": "windows",
+      "arch": "x86_64",
+      "ort_version": "1.24.1",
+      "url": "https://files.pythonhosted.org/packages/59/37/d301f2c68b19a9485ed5db3047e0fb52478f3e73eb08c7d2a7c61be7cc1c/onnxruntime_openvino-1.24.1-cp312-cp312-win_amd64.whl",
+      "sha256": "f186335a9c9b255633275290da7521d3d4d14c7773fee3127bfa040234d3fa5a",
+      "format": "whl",
+      "lib_pattern": "onnxruntime",
+      "install_subdir": "onnxruntime-openvino",
+      "size_mb": 20,
+      "requirements": "Intel GPU driver",
+      "runtime_url": "https://files.pythonhosted.org/packages/73/cb/07035dcbf60347c0706c4f8d3ffb003c34fe8205e4041699a6655cc858c3/openvino-2026.1.0-21367-cp312-cp312-win_amd64.whl",
+      "runtime_sha256": "21fbc8f9aa765d9ded024311f4e48e38118643cda0f0139dcfa5422c0c457eb6",
+      "runtime_lib_pattern": "openvino",
+      "runtime_extra_patterns": [
+        "tbb"
+      ],
+      "runtime_size_mb": 70
+    }
+  ]
+}

--- a/tools/ai/README.md
+++ b/tools/ai/README.md
@@ -1,0 +1,107 @@
+# GPU-Accelerated ONNX Runtime for darktable
+
+darktable bundles a CPU-only ONNX Runtime on Linux, DirectML on Windows,
+and CoreML on macOS. To enable GPU acceleration for AI features (denoise,
+upscale, segmentation), install a GPU-enabled ORT build using the
+preferences UI or one of the install scripts in this directory.
+
+## What's bundled by default
+
+| Platform | Bundled ORT | GPU support |
+|----------|------------|-------------|
+| Linux | CPU only | None – install GPU ORT below |
+| Windows | DirectML | AMD, NVIDIA, Intel via DirectX 12 |
+| macOS | CoreML | Apple Neural Engine |
+
+## Easiest: install from darktable preferences
+
+1. Open darktable preferences (Ctrl+,)
+2. Go to the **AI** tab
+3. Click **install** – darktable detects your GPU and downloads
+   the correct ORT package automatically
+4. Restart darktable
+
+Click **detect** instead to find a previously installed or
+system-packaged ORT library.
+
+## Installing via script
+
+Linux:
+```bash
+./tools/ai/install-ort-gpu.sh --help    # see all flags
+./tools/ai/install-ort-gpu.sh
+```
+
+Windows (PowerShell):
+```powershell
+.\tools\ai\install-ort-gpu.ps1 -Help    # see all flags
+.\tools\ai\install-ort-gpu.ps1
+```
+
+If Windows blocks the script ("running scripts is disabled on this
+system"), bypass once:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\tools\ai\install-ort-gpu.ps1
+```
+
+### Requirements
+
+**NVIDIA (CUDA)** – Pascal-or-newer GPU (compute 6.0+), driver 525+,
+CUDA 12.x or 13.x toolkit, cuDNN 9.x.
+
+**AMD (MIGraphX)** – ROCm-supported GPU (Radeon RX 6000+ / Instinct
+MI100+), ROCm 7.x with MIGraphX. Wheels are manylinux-repaired and
+bundle their own ROCm runtime.
+
+**Intel (OpenVINO)** – Intel iGPU (HD/UHD/Iris Xe) or Arc discrete,
+GPU driver with OpenCL (`intel-opencl-icd`) and/or Level Zero. The
+OpenVINO runtime ships in the package.
+
+### AMD: building from source
+
+If the prebuilt package doesn't work (ABI mismatch, unsupported ROCm
+version), build ORT against your installed ROCm:
+
+```bash
+./tools/ai/install-ort-amd-build.sh
+```
+
+Requires cmake 3.26+, gcc/g++, python3, git. Takes 10–20 minutes.
+
+## Enabling the custom ORT in darktable
+
+After running the script or built-in installer:
+
+1. Open darktable preferences (Ctrl+,)
+2. Go to the **AI** tab
+3. Click **detect**, or use the browse button to select the library
+   manually
+4. Restart darktable
+
+Or set `DT_ORT_LIBRARY` in the environment:
+
+```bash
+# Linux
+DT_ORT_LIBRARY=~/.local/lib/onnxruntime-cuda/libonnxruntime.so.1.24.4 darktable
+```
+```powershell
+# Windows
+$env:DT_ORT_LIBRARY="$env:LOCALAPPDATA\onnxruntime-cuda\onnxruntime.dll"; darktable
+```
+
+If neither preference nor env var is set, darktable uses the bundled
+ORT (CPU on Linux, DirectML on Windows, CoreML on macOS).
+
+## Verifying
+
+```bash
+darktable -d ai
+```
+
+Look for:
+```
+[darktable_ai] loaded ORT 1.24.4 from '/home/user/.local/lib/onnxruntime-cuda/libonnxruntime.so.1.24.4'
+[darktable_ai] execution provider: CUDA
+[darktable_ai] NVIDIA CUDA enabled successfully on device 0: NVIDIA GeForce RTX 4090
+```

--- a/tools/ai/README.md
+++ b/tools/ai/README.md
@@ -2,14 +2,14 @@
 
 darktable bundles a CPU-only ONNX Runtime on Linux, DirectML on Windows,
 and CoreML on macOS. To enable GPU acceleration for AI features (denoise,
-upscale, segmentation), install a GPU-enabled ORT build using the
+upscale, segmentation), install a GPU-enabled ONNX Runtime build using the
 preferences UI or one of the install scripts in this directory.
 
 ## What's bundled by default
 
-| Platform | Bundled ORT | GPU support |
+| Platform | Bundled ONNX Runtime | GPU support |
 |----------|------------|-------------|
-| Linux | CPU only | None – install GPU ORT below |
+| Linux | CPU only | None – install GPU ONNX Runtime below |
 | Windows | DirectML | AMD, NVIDIA, Intel via DirectX 12 |
 | macOS | CoreML | Apple Neural Engine |
 
@@ -18,11 +18,11 @@ preferences UI or one of the install scripts in this directory.
 1. Open darktable preferences (Ctrl+,)
 2. Go to the **AI** tab
 3. Click **install** – darktable detects your GPU and downloads
-   the correct ORT package automatically
+   the correct ONNX Runtime package automatically
 4. Restart darktable
 
 Click **detect** instead to find a previously installed or
-system-packaged ORT library.
+system-packaged ONNX Runtime library.
 
 ## Installing via script
 
@@ -61,7 +61,7 @@ OpenVINO runtime ships in the package.
 ### AMD: building from source
 
 If the prebuilt package doesn't work (ABI mismatch, unsupported ROCm
-version), build ORT against your installed ROCm:
+version), build ONNX Runtime against your installed ROCm:
 
 ```bash
 ./tools/ai/install-ort-amd-build.sh
@@ -69,7 +69,7 @@ version), build ORT against your installed ROCm:
 
 Requires cmake 3.26+, gcc/g++, python3, git. Takes 10–20 minutes.
 
-## Enabling the custom ORT in darktable
+## Enabling the custom ONNX Runtime in darktable
 
 After running the script or built-in installer:
 
@@ -91,7 +91,7 @@ $env:DT_ORT_LIBRARY="$env:LOCALAPPDATA\onnxruntime-cuda\onnxruntime.dll"; darkta
 ```
 
 If neither preference nor env var is set, darktable uses the bundled
-ORT (CPU on Linux, DirectML on Windows, CoreML on macOS).
+ONNX Runtime (CPU on Linux, DirectML on Windows, CoreML on macOS).
 
 ## Verifying
 
@@ -105,3 +105,45 @@ Look for:
 [darktable_ai] execution provider: CUDA
 [darktable_ai] NVIDIA CUDA enabled successfully on device 0: NVIDIA GeForce RTX 4090
 ```
+
+## Maintaining the GPU package registry
+
+`data/ort_gpu.json` lists the upstream ONNX Runtime URLs the install scripts and
+preferences UI pull from. It needs to be refreshed whenever Microsoft
+ships a new ONNX Runtime release or AMD ships a new ROCm patch. Use the
+script in this directory:
+
+```bash
+# show what would change (no writes); exits non-zero if updates exist
+python3 tools/ai/refresh-ort-gpu.py --check
+
+# apply the updates in place
+python3 tools/ai/refresh-ort-gpu.py --update
+
+# apply and open a PR via gh CLI (CI mode; needs GITHUB_TOKEN)
+python3 tools/ai/refresh-ort-gpu.py --update --pr
+
+# verbose progress (otherwise quiet by default in --update mode)
+python3 tools/ai/refresh-ort-gpu.py --check -v
+```
+
+What it does:
+
+- Queries `api.github.com/repos/microsoft/onnxruntime/releases` for the
+  latest non-prerelease that has all four expected GPU assets
+  (linux/windows × CUDA 12/13). Updates the four NVIDIA entries.
+- Scrapes `https://repo.radeon.com/rocm/manylinux/`, finds the cp312
+  ONNX Runtime wheel in each `rocm-rel-X.Y.Z/` directory, and keeps the
+  latest patch per ROCm minor. Updates the AMD entries with
+  range-based matching (`rocm_min: "7.2"`, `rocm_max: "7.3"` covers
+  every 7.2.x patch).
+- Computes SHA256 only for wheels whose URL changed since the last
+  refresh — a no-op run does no downloads.
+- Preserves vendors it doesn't manage (e.g. Intel/OpenVINO) and any
+  manual fields (`required_libs`, `lib_pattern`, `install_subdir`).
+
+Stdlib only — no extra Python deps. Network access required.
+
+A weekly CI job (`.github/workflows/refresh-ort-gpu.yml`) runs the
+script in `--update --pr` mode every Monday and opens a PR if anything
+upstream moved. Maintainer reviews and merges; nothing is auto-merged.

--- a/tools/ai/install-ort-amd-build.sh
+++ b/tools/ai/install-ort-amd-build.sh
@@ -1,0 +1,251 @@
+#!/bin/bash
+#
+# Build and install ONNX Runtime with MIGraphX ExecutionProvider
+# for darktable AI acceleration on AMD GPUs.
+#
+# Unlike NVIDIA (which has pre-built packages), MIGraphX EP must be
+# built from source to match the installed ROCm version.
+#
+# Requirements:
+#   - AMD GPU supported by ROCm (RDNA2+, CDNA+)
+#   - ROCm 7.x with MIGraphX installed
+#   - Build tools: cmake 3.26+, gcc/g++, python3
+#
+# Usage: install-ort-amd-build.sh [-y|--yes] [install-dir]
+
+set -euo pipefail
+
+YES=false
+FORCE=false
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -y|--yes) YES=true; shift ;;
+    -f|--force) FORCE=true; shift ;;
+    *) break ;;
+  esac
+done
+
+INSTALL_DIR="${1:-$HOME/.local/lib/onnxruntime-migraphx}"
+ROCM_HOME="${ROCM_HOME:-/opt/rocm}"
+BUILD_DIR="${TMPDIR:-/tmp}/ort-migraphx-build"
+
+# --- Platform checks (before user prompt) ---
+if [ "$(uname -s)" != "Linux" ]; then
+  echo "Error: this script is for Linux only." >&2
+  exit 1
+fi
+
+if [ "$(uname -m)" != "x86_64" ]; then
+  echo "Error: MIGraphX EP is only available for x86_64 (got $(uname -m))." >&2
+  exit 1
+fi
+
+# --- Info & confirmation ---
+echo ""
+echo "ONNX Runtime - MIGraphX ExecutionProvider builder"
+echo "==================================================="
+echo ""
+echo "This will build ONNX Runtime from source with AMD MIGraphX support"
+echo "to enable GPU acceleration for darktable AI features"
+echo "(denoise, upscale, segmentation)."
+echo ""
+echo "Unlike NVIDIA, there is no pre-built package - ORT must be compiled"
+echo "against the ROCm version installed on your system."
+echo ""
+echo "Requirements:"
+echo "  - AMD GPU supported by ROCm (Radeon RX 6000+, Instinct MI100+)"
+echo "  - ROCm 7.x with MIGraphX"
+echo "  - cmake 3.26+, gcc/g++, python3, git"
+echo ""
+echo "Actions:"
+echo "  - Clone ORT source (~300 MB)"
+echo "  - Build with MIGraphX EP (10-20 min depending on hardware)"
+echo "  - Install shared libraries to: $INSTALL_DIR"
+echo ""
+
+if [ "$YES" = false ]; then
+  read -rp "Continue? [y/N] " answer
+  if [[ ! "$answer" =~ ^[Yy] ]]; then
+    echo "Aborted."
+    exit 0
+  fi
+  echo ""
+fi
+
+# --- Helper: distro-specific install hint ---
+distro_hint() {
+  local pkg_deb="$1" pkg_rpm="$2" pkg_arch="$3" pkg_suse="$4" fallback_url="$5"
+  if [ -f /etc/os-release ]; then
+    . /etc/os-release
+    case "$ID" in
+      ubuntu|debian|linuxmint|pop)
+        echo "  Install on $NAME:"
+        echo "    $pkg_deb"
+        ;;
+      fedora|rhel|centos|rocky|alma)
+        echo "  Install on $NAME:"
+        echo "    $pkg_rpm"
+        ;;
+      arch|manjaro|endeavouros)
+        echo "  Install on $NAME:"
+        echo "    $pkg_arch"
+        ;;
+      opensuse*|sles)
+        echo "  Install on $NAME:"
+        echo "    $pkg_suse"
+        ;;
+      *)
+        echo "  Download from: $fallback_url"
+        return
+        ;;
+    esac
+  else
+    echo "  Download from: $fallback_url"
+  fi
+}
+
+if [ "$FORCE" = false ]; then
+  # --- Check ROCm ---
+  if ! command -v rocminfo &>/dev/null || [ ! -d "$ROCM_HOME" ]; then
+    echo "Error: ROCm not found at $ROCM_HOME"
+    echo ""
+    distro_hint \
+      "sudo apt install rocm  (add AMD repo first: https://rocm.docs.amd.com/projects/install-on-linux/en/latest/)" \
+      "sudo dnf install rocm  (add AMD repo first: https://rocm.docs.amd.com/projects/install-on-linux/en/latest/)" \
+      "sudo pacman -S rocm-hip-sdk" \
+      "sudo zypper install rocm  (add AMD repo first: https://rocm.docs.amd.com/projects/install-on-linux/en/latest/)" \
+      "https://rocm.docs.amd.com/projects/install-on-linux/en/latest/"
+    echo ""
+    exit 1
+  fi
+else
+  echo "Skipping dependency checks (--force)"
+fi
+
+ROCM_VERSION="unknown"
+if [ -f "$ROCM_HOME/.info/version" ]; then
+  ROCM_VERSION=$(cat "$ROCM_HOME/.info/version")
+fi
+echo "ROCm: $ROCM_VERSION ($ROCM_HOME)"
+
+# --- Select ORT version matching ROCm ---
+ROCM_MAJOR_MINOR=$(echo "$ROCM_VERSION" | grep -oP '^\d+\.\d+')
+case "$ROCM_MAJOR_MINOR" in
+  # 7.3+) ORT_VERSION="1.24.4" ;;  # TODO: confirm when docs are updated
+  7.2*) ORT_VERSION="1.23.2" ;;
+  7.1*) ORT_VERSION="1.23.1" ;;
+  7.0*) ORT_VERSION="1.22.1" ;;
+  6.4*) ORT_VERSION="1.21.0" ;;
+  6.3*) ORT_VERSION="1.19.0" ;;
+  6.2*) ORT_VERSION="1.18.0" ;;
+  6.1*) ORT_VERSION="1.17.0" ;;
+  6.0*) ORT_VERSION="1.16.0" ;;
+  *)
+    echo ""
+    echo "Error: unsupported ROCm version $ROCM_VERSION"
+    echo "  Supported: ROCm 6.0 - 7.2"
+    echo "  Update ROCm or set ORT_VERSION manually and re-run."
+    echo ""
+    exit 1
+    ;;
+esac
+echo "ORT version: $ORT_VERSION (matched to ROCm $ROCM_MAJOR_MINOR)"
+
+if [ "$FORCE" = false ]; then
+  # --- Check MIGraphX ---
+  if ! command -v migraphx-driver &>/dev/null \
+     && [ ! -f "$ROCM_HOME/lib/libmigraphx.so" ] \
+     && [ ! -f "$ROCM_HOME/lib64/libmigraphx.so" ]; then
+    echo ""
+    echo "Error: MIGraphX not found in $ROCM_HOME"
+    echo ""
+    distro_hint \
+      "sudo apt install migraphx migraphx-dev" \
+      "sudo dnf install migraphx migraphx-devel" \
+      "sudo pacman -S migraphx" \
+      "sudo zypper install migraphx migraphx-devel" \
+      "https://rocm.docs.amd.com/projects/install-on-linux/en/latest/"
+    echo ""
+    exit 1
+  fi
+  echo "MIGraphX: found"
+
+  # --- Check build tools ---
+  MISSING=""
+  command -v cmake &>/dev/null || MISSING="$MISSING cmake"
+  command -v g++ &>/dev/null   || MISSING="$MISSING g++"
+  command -v git &>/dev/null   || MISSING="$MISSING git"
+  command -v python3 &>/dev/null || MISSING="$MISSING python3"
+
+  if [ -n "$MISSING" ]; then
+    echo ""
+    echo "Error: missing build tools:$MISSING"
+    echo ""
+    distro_hint \
+      "sudo apt install$MISSING" \
+      "sudo dnf install$MISSING" \
+      "sudo pacman -S$MISSING" \
+      "sudo zypper install$MISSING" \
+      ""
+    echo ""
+    exit 1
+  fi
+fi
+
+CMAKE_VERSION=$(cmake --version 2>/dev/null | head -1 | grep -oP '[0-9]+\.[0-9]+' || echo "unknown")
+echo "cmake: $CMAKE_VERSION"
+
+# --- Clone & build ---
+echo ""
+echo "Cloning ONNX Runtime v${ORT_VERSION}..."
+
+rm -rf "$BUILD_DIR"
+mkdir -p "$BUILD_DIR"
+
+git clone --depth 1 --branch "v${ORT_VERSION}" \
+  https://github.com/microsoft/onnxruntime.git "$BUILD_DIR/onnxruntime"
+
+cd "$BUILD_DIR/onnxruntime"
+
+# Patch Eigen hash mismatch - GitLab regenerates zip archives, breaking the
+# hardcoded SHA1 in older ORT releases. Remove the URL_HASH line from
+# eigen.cmake so FetchContent downloads without verification.
+if [ -f "cmake/external/eigen.cmake" ]; then
+  sed -i '/URL_HASH/d' cmake/external/eigen.cmake
+  echo "Patched Eigen: removed URL_HASH check (GitLab zip archive mismatch)"
+fi
+
+echo ""
+echo "Building with MIGraphX EP (this will take 30-60 minutes)..."
+echo ""
+
+./build.sh \
+  --config Release \
+  --build_shared_lib \
+  --parallel \
+  --skip_tests \
+  --use_migraphx \
+  --migraphx_home "$ROCM_HOME"
+
+# --- Install ---
+BUILD_LIB_DIR="$BUILD_DIR/onnxruntime/build/Linux/Release"
+
+mkdir -p "$INSTALL_DIR"
+cp "$BUILD_LIB_DIR/"libonnxruntime*.so* "$INSTALL_DIR/"
+
+# Clean up build tree (~2 GB)
+rm -rf "$BUILD_DIR"
+
+ORT_SO=$(ls "$INSTALL_DIR/libonnxruntime.so."* 2>/dev/null | head -1)
+
+echo ""
+echo "Done. Installed to: $INSTALL_DIR"
+ls -lh "$INSTALL_DIR/"*.so* 2>/dev/null
+echo ""
+echo "To use with darktable:"
+echo ""
+echo "  DT_ORT_LIBRARY=$ORT_SO darktable"
+echo ""
+echo "Or add to ~/.bashrc:"
+echo ""
+echo "  export DT_ORT_LIBRARY=$ORT_SO"

--- a/tools/ai/install-ort-gpu.ps1
+++ b/tools/ai/install-ort-gpu.ps1
@@ -270,6 +270,19 @@ if ($Package.sha256) {
 Write-Host "Extracting..."
 New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
 
+# clean prior install of the same library family so old versioned DLLs
+# don't shadow the new install. matches the shell-script behavior on
+# Linux: remove ${libPattern}*.dll before extracting the new package
+$libPattern = $Package.lib_pattern
+Get-ChildItem -Path $InstallDir -Filter "${libPattern}*.dll" -File -ErrorAction SilentlyContinue |
+    Remove-Item -Force -ErrorAction SilentlyContinue
+foreach ($extra in @($Package.lib_extra_patterns)) {
+    if ($extra) {
+        Get-ChildItem -Path $InstallDir -Filter "${extra}*.dll" -File -ErrorAction SilentlyContinue |
+            Remove-Item -Force -ErrorAction SilentlyContinue
+    }
+}
+
 $ExtractDir = Join-Path $TempDir "extracted"
 
 switch ($Package.format) {
@@ -300,10 +313,9 @@ switch ($Package.format) {
 }
 
 # Copy matching libraries
-$libPattern = $Package.lib_pattern
 $copied = 0
 Get-ChildItem -Path $ExtractDir -Recurse -File |
-    Where-Object { $_.Name -like "${libPattern}*" -and ($_.Extension -eq ".dll" -or $_.Extension -eq ".so" -or $_.Name -match "\.so\.") } |
+    Where-Object { $_.Name -like "${libPattern}*" -and $_.Extension -eq ".dll" } |
     ForEach-Object {
         Copy-Item $_.FullName -Destination $InstallDir -Force
         $copied++
@@ -348,7 +360,7 @@ if ($Package.runtime_url) {
             $rtPattern = if ($Package.runtime_lib_pattern) { $Package.runtime_lib_pattern } else { "openvino" }
             $rtCopied = 0
             Get-ChildItem -Path $rtExtract -Recurse -File |
-                Where-Object { $_.Extension -eq ".dll" -or $_.Extension -eq ".so" -or $_.Name -match "\.so\." } |
+                Where-Object { $_.Extension -eq ".dll" } |
                 Where-Object { $_.Name -like "${rtPattern}*" -or $_.Name -like "tbb*.dll" } |
                 ForEach-Object {
                     Copy-Item $_.FullName -Destination $InstallDir -Force
@@ -439,7 +451,7 @@ if ($Selected.vendor -eq "nvidia") {
 
 # --- Verify ---
 $ortDll = Get-ChildItem "$InstallDir\$libPattern*" -File |
-    Where-Object { $_.Extension -eq ".dll" -or $_.Name -match "\.so" } |
+    Where-Object { $_.Extension -eq ".dll" } |
     Select-Object -First 1
 
 Write-Host ""

--- a/tools/ai/install-ort-gpu.ps1
+++ b/tools/ai/install-ort-gpu.ps1
@@ -1,0 +1,460 @@
+<#
+.SYNOPSIS
+    Install GPU-accelerated ONNX Runtime for darktable.
+
+.DESCRIPTION
+    Reads the package manifest (data/ort_gpu.json) to determine the
+    correct download URL for the detected GPU, downloads the ORT
+    package, and installs the libraries to
+    %LOCALAPPDATA%\onnxruntime-<vendor>\.
+
+    For NVIDIA, additionally bundles cuDNN and the required CUDA
+    toolkit DLLs (cublas, cublasLt, cudart, cufft, curand) from the
+    user's installed CUDA toolkit so the resulting directory is
+    self-contained.
+
+    Supported vendors on Windows:
+      - NVIDIA via CUDA EP   (requires CUDA 12.x or 13.x + cuDNN 9.x)
+      - Intel  via OpenVINO  (requires Intel GPU driver)
+
+    GPU auto-detection uses:
+      - nvidia-smi                       (NVIDIA)
+      - Get-CimInstance Win32_VideoController (Intel)
+
+    After installing, point darktable at the new library:
+      Preferences -> AI -> ONNX Runtime library -> "detect" or "browse"
+    Restart darktable to apply.  Or set DT_ORT_LIBRARY=<path> in the
+    environment.
+
+.PARAMETER Yes
+    Skip the interactive "Continue?" prompt.
+
+.PARAMETER Force
+    Skip the vendor-specific dependency check (CUDA toolkit, cuDNN).
+    The download proceeds regardless; if dependencies are missing at
+    runtime, ORT will fall back to CPU.
+
+.PARAMETER Vendor
+    Force a specific GPU vendor and skip auto-detection.
+    Valid values: "nvidia", "intel".
+
+.PARAMETER Manifest
+    Use a custom ort_gpu.json manifest.  Default search order:
+        <script>\..\..\data\ort_gpu.json
+        <script>\..\..\share\darktable\ort_gpu.json
+        $env:ProgramFiles\darktable\share\darktable\ort_gpu.json
+        $env:LOCALAPPDATA\darktable\share\darktable\ort_gpu.json
+
+.EXAMPLE
+    .\install-ort-gpu.ps1
+    Detect the GPU, prompt for confirmation, install.
+
+.EXAMPLE
+    .\install-ort-gpu.ps1 -Yes
+    Same as above without confirmation.
+
+.EXAMPLE
+    .\install-ort-gpu.ps1 -Vendor nvidia -Yes
+    Install the NVIDIA package without GPU detection.
+
+.EXAMPLE
+    .\install-ort-gpu.ps1 -Force -Yes
+    Install without checking dependencies.
+#>
+param(
+    [switch]$Yes,
+    [switch]$Force,
+    [string]$Vendor = "",
+    [string]$Manifest = "",
+    [switch]$Help
+)
+
+if ($Help) {
+    Get-Help $MyInvocation.MyCommand.Path -Detailed
+    exit 0
+}
+
+$ErrorActionPreference = "Stop"
+
+# --- Locate manifest ---
+if (-not $Manifest) {
+    $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+    $candidates = @(
+        (Join-Path $ScriptDir "..\..\data\ort_gpu.json"),
+        (Join-Path $ScriptDir "..\..\share\darktable\ort_gpu.json"),
+        (Join-Path $env:ProgramFiles "darktable\share\darktable\ort_gpu.json"),
+        (Join-Path $env:LOCALAPPDATA "darktable\share\darktable\ort_gpu.json")
+    )
+    foreach ($c in $candidates) {
+        if (Test-Path $c) { $Manifest = $c; break }
+    }
+    if (-not $Manifest) {
+        Write-Host "Error: cannot find ort_gpu.json manifest." -ForegroundColor Red
+        Write-Host "  Use -Manifest <path> to specify it manually."
+        exit 1
+    }
+}
+
+if (-not (Test-Path $Manifest)) {
+    Write-Host "Error: manifest not found: $Manifest" -ForegroundColor Red
+    exit 1
+}
+
+$Platform = "windows"
+$Arch = "x86_64"
+
+# --- Load manifest ---
+$ManifestData = Get-Content $Manifest -Raw | ConvertFrom-Json
+
+# --- Detect GPU (skipped with -Vendor) ---
+$Vendors = @()
+$Selected = $null
+
+if ($Vendor) {
+    if ($Vendor -notin @("nvidia", "intel")) {
+        Write-Host "Error: unknown vendor '$Vendor'. Use: nvidia, intel" -ForegroundColor Red
+        exit 1
+    }
+    Write-Host "Vendor override: $Vendor (skipping GPU detection)"
+    $Selected = @{ vendor = $Vendor; label = $Vendor; driver = "" }
+} else {
+    # NVIDIA
+    $NvidiaSmi = Get-Command nvidia-smi -ErrorAction SilentlyContinue
+    if ($NvidiaSmi) {
+        $NvidiaInfo = (nvidia-smi --query-gpu=name,driver_version --format=csv,noheader 2>$null |
+                       Select-Object -First 1)
+        if ($NvidiaInfo) {
+            $fields = $NvidiaInfo -split ","
+            $Vendors += @{
+                vendor = "nvidia"
+                label = $fields[0].Trim()
+                driver = if ($fields.Count -gt 1) { $fields[1].Trim() } else { "unknown" }
+            }
+        }
+    }
+
+    # Intel
+    $IntelGPU = Get-CimInstance Win32_VideoController -ErrorAction SilentlyContinue |
+        Where-Object { $_.Name -match 'Intel' }
+    if ($IntelGPU) {
+        $Vendors += @{
+            vendor = "intel"
+            label = $IntelGPU.Name
+            driver = $IntelGPU.DriverVersion
+        }
+    }
+
+    if ($Vendors.Count -eq 0) {
+        Write-Host ""
+        Write-Host "No supported GPU detected." -ForegroundColor Red
+        Write-Host ""
+        Write-Host "Supported: NVIDIA (CUDA), Intel (OpenVINO)"
+        Write-Host "Ensure GPU drivers are installed, or use -Vendor <nvidia|intel>."
+        Write-Host ""
+        exit 1
+    }
+
+    # --- Handle multiple vendors ---
+    if ($Vendors.Count -eq 1) {
+        $Selected = $Vendors[0]
+    } else {
+        Write-Host ""
+        Write-Host "Multiple GPUs detected:"
+        for ($i = 0; $i -lt $Vendors.Count; $i++) {
+            $v = $Vendors[$i]
+            $ep = switch ($v.vendor) { "nvidia" { "CUDA" } "intel" { "OpenVINO" } }
+            Write-Host "  $($i+1)) $($v.label) ($($v.driver)) [$ep]"
+        }
+        Write-Host ""
+        $choice = Read-Host "Select GPU [1-$($Vendors.Count)]"
+        $idx = [int]$choice - 1
+        if ($idx -lt 0 -or $idx -ge $Vendors.Count) {
+            Write-Host "Invalid selection." -ForegroundColor Red
+            exit 1
+        }
+        $Selected = $Vendors[$idx]
+    }
+}
+
+# --- Detect CUDA version for NVIDIA package matching ---
+$CudaMM = ""
+if ($Selected.vendor -eq "nvidia") {
+    $nvcc = Get-Command nvcc -ErrorAction SilentlyContinue
+    if ($nvcc) {
+        $nvccOut = nvcc --version 2>$null | Select-String 'V(\d+\.\d+)' |
+            ForEach-Object { $_.Matches[0].Groups[1].Value }
+        if ($nvccOut) { $CudaMM = $nvccOut }
+    }
+}
+
+# --- Find matching package in manifest ---
+$Package = $null
+foreach ($p in $ManifestData.packages) {
+    if ($p.vendor -ne $Selected.vendor) { continue }
+    if ($p.platform -ne $Platform) { continue }
+    if ($p.arch -and $p.arch -ne $Arch) { continue }
+    # NVIDIA: match CUDA version range
+    if ($CudaMM -and $p.cuda_min) {
+        if ([version]$CudaMM -lt [version]$p.cuda_min) { continue }
+        if ($p.cuda_max -and [version]$CudaMM -gt [version]$p.cuda_max) { continue }
+    }
+    $Package = $p
+    break
+}
+
+if (-not $Package) {
+    Write-Host ""
+    Write-Host "Error: no matching package found for $($Selected.vendor)/$Platform/$Arch" -ForegroundColor Red
+    if ($CudaMM) { Write-Host "  CUDA version: $CudaMM" }
+    exit 1
+}
+
+$InstallDir = Join-Path $env:LOCALAPPDATA $Package.install_subdir
+
+# --- Info & confirmation ---
+Write-Host ""
+Write-Host "ONNX Runtime $($Package.ort_version) - GPU acceleration installer"
+Write-Host "============================================================"
+Write-Host ""
+Write-Host "GPU: $($Selected.label)"
+if ($Selected.driver) { Write-Host "Driver: $($Selected.driver)" }
+Write-Host "ORT version: $($Package.ort_version)"
+Write-Host "Download size: ~$($Package.size_mb) MB"
+Write-Host "Install to: $InstallDir"
+if ($Package.requirements) { Write-Host "Requirements: $($Package.requirements)" }
+Write-Host ""
+
+if (-not $Yes) {
+    $answer = Read-Host "Continue? [y/N]"
+    if ($answer -notmatch '^[Yy]') {
+        Write-Host "Aborted."
+        exit 0
+    }
+    Write-Host ""
+}
+
+# --- Download ---
+$TempDir = Join-Path $env:TEMP "ort-gpu-$(Get-Random)"
+New-Item -ItemType Directory -Path $TempDir -Force | Out-Null
+
+$ext = switch ($Package.format) { "zip" { ".zip" } "whl" { ".zip" } "tgz" { ".tgz" } default { "" } }
+$ArchivePath = Join-Path $TempDir "ort-package$ext"
+
+Write-Host "Downloading..."
+try {
+    $ProgressPreference = 'SilentlyContinue'
+    Invoke-WebRequest -Uri $Package.url -OutFile $ArchivePath -UseBasicParsing
+} catch {
+    Write-Host "Error: download failed." -ForegroundColor Red
+    Write-Host "  URL: $($Package.url)"
+    Write-Host "  $($_.Exception.Message)"
+    Remove-Item -Recurse -Force $TempDir
+    exit 1
+}
+
+# --- Verify checksum ---
+if ($Package.sha256) {
+    Write-Host "Verifying checksum..."
+    $ActualHash = (Get-FileHash -Path $ArchivePath -Algorithm SHA256).Hash.ToLower()
+    if ($ActualHash -ne $Package.sha256) {
+        Write-Host "Error: checksum mismatch!" -ForegroundColor Red
+        Write-Host "  Expected: $($Package.sha256)"
+        Write-Host "  Got:      $ActualHash"
+        Remove-Item -Recurse -Force $TempDir
+        exit 1
+    }
+    Write-Host "Checksum OK."
+}
+
+# --- Extract ---
+Write-Host "Extracting..."
+New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
+
+$ExtractDir = Join-Path $TempDir "extracted"
+
+switch ($Package.format) {
+    "zip" {
+        Expand-Archive -Path $ArchivePath -DestinationPath $ExtractDir -Force
+    }
+    "whl" {
+        # wheels are zip files
+        Expand-Archive -Path $ArchivePath -DestinationPath $ExtractDir -Force
+    }
+    "tgz" {
+        # PowerShell doesn't natively handle tgz; use tar if available
+        $tar = Get-Command tar -ErrorAction SilentlyContinue
+        if ($tar) {
+            New-Item -ItemType Directory -Path $ExtractDir -Force | Out-Null
+            tar xzf $ArchivePath -C $ExtractDir
+        } else {
+            Write-Host "Error: tar not found, cannot extract .tgz" -ForegroundColor Red
+            Remove-Item -Recurse -Force $TempDir
+            exit 1
+        }
+    }
+    default {
+        Write-Host "Error: unsupported format: $($Package.format)" -ForegroundColor Red
+        Remove-Item -Recurse -Force $TempDir
+        exit 1
+    }
+}
+
+# Copy matching libraries
+$libPattern = $Package.lib_pattern
+$copied = 0
+Get-ChildItem -Path $ExtractDir -Recurse -File |
+    Where-Object { $_.Name -like "${libPattern}*" -and ($_.Extension -eq ".dll" -or $_.Extension -eq ".so" -or $_.Name -match "\.so\.") } |
+    ForEach-Object {
+        Copy-Item $_.FullName -Destination $InstallDir -Force
+        $copied++
+    }
+
+# Clean up
+Remove-Item -Recurse -Force $TempDir
+
+if ($copied -eq 0) {
+    Write-Host "Error: no libraries found after extraction." -ForegroundColor Red
+    exit 1
+}
+
+# --- Bundle runtime dependencies from a separate wheel (e.g. OpenVINO) ---
+if ($Package.runtime_url) {
+    Write-Host "Downloading runtime dependencies..."
+    $rtTempDir = Join-Path $env:TEMP "ort-runtime-$(Get-Random)"
+    New-Item -ItemType Directory -Path $rtTempDir -Force | Out-Null
+    $rtArchive = Join-Path $rtTempDir "runtime.zip"
+
+    try {
+        $ProgressPreference = 'SilentlyContinue'
+        Invoke-WebRequest -Uri $Package.runtime_url -OutFile $rtArchive -UseBasicParsing
+    } catch {
+        Write-Host "Warning: runtime download failed: $($_.Exception.Message)" -ForegroundColor Yellow
+        Remove-Item -Recurse -Force $rtTempDir
+    }
+
+    if (Test-Path $rtArchive) {
+        # verify checksum
+        $rtOk = $true
+        if ($Package.runtime_sha256) {
+            $rtHash = (Get-FileHash -Path $rtArchive -Algorithm SHA256).Hash.ToLower()
+            if ($rtHash -ne $Package.runtime_sha256) {
+                Write-Host "Warning: runtime checksum mismatch, skipping." -ForegroundColor Yellow
+                $rtOk = $false
+            }
+        }
+        if ($rtOk) {
+            $rtExtract = Join-Path $rtTempDir "extracted"
+            Expand-Archive -Path $rtArchive -DestinationPath $rtExtract -Force
+            $rtPattern = if ($Package.runtime_lib_pattern) { $Package.runtime_lib_pattern } else { "openvino" }
+            $rtCopied = 0
+            Get-ChildItem -Path $rtExtract -Recurse -File |
+                Where-Object { $_.Extension -eq ".dll" -or $_.Extension -eq ".so" -or $_.Name -match "\.so\." } |
+                Where-Object { $_.Name -like "${rtPattern}*" -or $_.Name -like "tbb*.dll" } |
+                ForEach-Object {
+                    Copy-Item $_.FullName -Destination $InstallDir -Force
+                    $rtCopied++
+                }
+            if ($rtCopied -gt 0) {
+                Write-Host "Bundled $rtCopied runtime DLLs."
+            }
+        }
+        Remove-Item -Recurse -Force $rtTempDir
+    }
+}
+
+# --- Bundle cuDNN DLLs for NVIDIA (avoids PATH issues) ---
+if ($Selected.vendor -eq "nvidia") {
+    # determine CUDA major version to pick the right cuDNN subdirectory
+    $cudaMajor = ""
+    if ($CudaMM) { $cudaMajor = ($CudaMM -split '\.')[0] }
+
+    $cudnnSrc = $null
+    $cudnnRoot = Join-Path $env:ProgramFiles "NVIDIA\CUDNN"
+    if (Test-Path $cudnnRoot) {
+        # find the cuDNN bin subdirectory matching our CUDA major version
+        # layout: CUDNN\v9.20\bin\13.2\x64\cudnn64_9.dll
+        Get-ChildItem -Path $cudnnRoot -Directory | ForEach-Object {
+            $binDir = Join-Path $_.FullName "bin"
+            if (Test-Path $binDir) {
+                Get-ChildItem -Path $binDir -Directory | ForEach-Object {
+                    if ($cudaMajor -and $_.Name.StartsWith($cudaMajor)) {
+                        $x64 = Join-Path $_.FullName "x64"
+                        if (Test-Path $x64) { $cudnnSrc = $x64 }
+                        else { $cudnnSrc = $_.FullName }
+                    }
+                }
+            }
+        }
+        # fallback: find any cudnn64_*.dll recursively
+        if (-not $cudnnSrc) {
+            $fallback = Get-ChildItem -Path $cudnnRoot -Filter "cudnn64_*.dll" -Recurse -ErrorAction SilentlyContinue |
+                Select-Object -First 1
+            if ($fallback) { $cudnnSrc = $fallback.DirectoryName }
+        }
+    }
+    # also check CUDA_PATH\bin
+    if (-not $cudnnSrc -and $env:CUDA_PATH) {
+        $cudaBin = Join-Path $env:CUDA_PATH "bin"
+        if (Get-ChildItem -Path $cudaBin -Filter "cudnn64_*.dll" -ErrorAction SilentlyContinue |
+            Select-Object -First 1) { $cudnnSrc = $cudaBin }
+    }
+
+    if ($cudnnSrc) {
+        $cudnnCopied = 0
+        Get-ChildItem -Path $cudnnSrc -Filter "cudnn*.dll" | ForEach-Object {
+            Copy-Item $_.FullName -Destination $InstallDir -Force
+            $cudnnCopied++
+        }
+        if ($cudnnCopied -gt 0) {
+            Write-Host "Bundled $cudnnCopied cuDNN DLLs from: $cudnnSrc"
+        }
+    } else {
+        Write-Host "Warning: cuDNN not found, CUDA EP may fail at runtime." -ForegroundColor Yellow
+    }
+
+    # bundle required CUDA runtime DLLs from toolkit
+    if ($env:CUDA_PATH) {
+        $cudaCopied = 0
+        $cudaLibs = @("cublas*.dll", "cublasLt*.dll", "cudart*.dll",
+                       "cufft*.dll", "curand*.dll")
+        # CUDA 13+ puts DLLs in bin\x64\, older in bin\
+        @("bin\x64", "bin") | ForEach-Object {
+            $dir = Join-Path $env:CUDA_PATH $_
+            if (Test-Path $dir) {
+                foreach ($pattern in $cudaLibs) {
+                    Get-ChildItem -Path $dir -Filter $pattern -ErrorAction SilentlyContinue | ForEach-Object {
+                        if (-not (Test-Path (Join-Path $InstallDir $_.Name))) {
+                            Copy-Item $_.FullName -Destination $InstallDir -Force
+                            $cudaCopied++
+                        }
+                    }
+                }
+            }
+        }
+        if ($cudaCopied -gt 0) {
+            Write-Host "Bundled $cudaCopied CUDA runtime DLLs from toolkit."
+        }
+    }
+}
+
+# --- Verify ---
+$ortDll = Get-ChildItem "$InstallDir\$libPattern*" -File |
+    Where-Object { $_.Extension -eq ".dll" -or $_.Name -match "\.so" } |
+    Select-Object -First 1
+
+Write-Host ""
+Write-Host "Done. Installed to: $InstallDir"
+Get-ChildItem "$InstallDir\*" -File | Format-Table Name, Length -AutoSize
+Write-Host ""
+Write-Host "To enable in darktable:"
+Write-Host ""
+Write-Host "  1. Open darktable preferences (Ctrl+,)"
+Write-Host "  2. Go to the AI tab"
+Write-Host "  3. Click 'detect' to find the installed library automatically,"
+Write-Host "     or set 'ONNX Runtime library' to:"
+Write-Host "     $($ortDll.FullName)"
+Write-Host "  4. Restart darktable"
+Write-Host ""
+Write-Host "Or via command line:"
+Write-Host ""
+Write-Host "  `$env:DT_ORT_LIBRARY=`"$($ortDll.FullName)`"; darktable"

--- a/tools/ai/install-ort-gpu.sh
+++ b/tools/ai/install-ort-gpu.sh
@@ -427,6 +427,17 @@ fi
 echo "Extracting..."
 mkdir -p "$INSTALL_DIR"
 
+# clean prior install of the same library family so old versioned .so
+# files (and stale symlinks) don't shadow the new install. without this
+# you get a directory containing both libonnxruntime.so.1.24.4 and
+# .so.1.25.1, with the .so.1 symlink pointing at whichever was first
+find "$INSTALL_DIR" -maxdepth 1 -name "${PKG_LIB_PATTERN}*.so*" \
+  -delete 2>/dev/null || true
+for pattern in $PKG_LIB_EXTRA_PATTERNS; do
+  find "$INSTALL_DIR" -maxdepth 1 -name "${pattern}*.so*" \
+    -delete 2>/dev/null || true
+done
+
 # build the find -name expression covering the main pattern + any extras
 _extract_libs() {
   local search_root="$1"
@@ -509,10 +520,14 @@ if [ "$PLATFORM" = "linux" ]; then
 fi
 
 # --- Verify ---
-# prefer the main library (libonnxruntime.so.X.Y.Z), not providers
-ORT_SO=$(find "$INSTALL_DIR" -maxdepth 1 -name "${PKG_LIB_PATTERN}.so.*" -o -name "${PKG_LIB_PATTERN}.dll" 2>/dev/null | head -1)
-# fallback to any matching .so
-[ -z "$ORT_SO" ] && ORT_SO=$(find "$INSTALL_DIR" -maxdepth 1 -name "${PKG_LIB_PATTERN}*.so*" 2>/dev/null | grep -v providers | head -1)
+# prefer the versioned main library (libonnxruntime.so.X.Y.Z) and pick
+# the newest by version. sort -V puts 1.25.1 after 1.24.4 even when
+# the dir still has both for any reason
+ORT_SO=$(find "$INSTALL_DIR" -maxdepth 1 -name "${PKG_LIB_PATTERN}.so.*" 2>/dev/null \
+           | sort -V | tail -1)
+# fallback to any matching .so (skip provider libs which aren't the entry point)
+[ -z "$ORT_SO" ] && ORT_SO=$(find "$INSTALL_DIR" -maxdepth 1 -name "${PKG_LIB_PATTERN}*.so*" 2>/dev/null \
+                              | grep -v providers | sort -V | tail -1)
 
 if [ -z "$ORT_SO" ]; then
   echo "Error: no library found after extraction." >&2
@@ -521,7 +536,7 @@ fi
 
 echo ""
 echo "Done. Installed to: $INSTALL_DIR"
-ls -lh "$INSTALL_DIR/"*.so* 2>/dev/null || ls -lh "$INSTALL_DIR/"*.dll 2>/dev/null || true
+ls -lh "$INSTALL_DIR/"*.so* 2>/dev/null || true
 echo ""
 echo "To enable in darktable:"
 echo ""

--- a/tools/ai/install-ort-gpu.sh
+++ b/tools/ai/install-ort-gpu.sh
@@ -1,0 +1,537 @@
+#!/bin/bash
+#
+# Install GPU-accelerated ONNX Runtime for darktable.
+
+set -euo pipefail
+
+usage() {
+  cat <<EOF
+NAME
+    install-ort-gpu.sh – install GPU-accelerated ONNX Runtime for darktable
+
+SYNOPSIS
+    install-ort-gpu.sh [-y|--yes] [-f|--force]
+                       [--vendor <nvidia|amd|intel>]
+                       [--manifest <path>]
+                       [-h|--help]
+
+DESCRIPTION
+    Reads the package manifest (data/ort_gpu.json) to determine the
+    correct download URL for the detected GPU, downloads the ORT
+    package, and installs the libraries to ~/.local/lib/onnxruntime-<vendor>/.
+
+    Supported vendors on Linux:
+      - NVIDIA via CUDA EP        (requires CUDA 12.x or 13.x + cuDNN 9.x)
+      - AMD    via MIGraphX/ROCm  (requires ROCm 7.x with MIGraphX)
+      - Intel  via OpenVINO       (requires Intel GPU driver with OpenCL)
+
+    GPU auto-detection uses:
+      - nvidia-smi             (NVIDIA)
+      - /opt/rocm/.info/version (AMD)
+      - lspci                  (Intel)
+
+    After installing, point darktable at the new library:
+      Preferences -> AI -> ONNX Runtime library -> "detect" or "browse"
+    Restart darktable to apply.  Or set DT_ORT_LIBRARY=<path> in the
+    environment.
+
+OPTIONS
+    -y, --yes
+        Skip the interactive "Continue?" prompt.
+
+    -f, --force
+        Skip the vendor-specific dependency check (CUDA toolkit, cuDNN
+        SO, ROCm install, OpenCL ICD).  The download proceeds regardless;
+        if dependencies are missing at runtime, ORT will fall back to CPU.
+
+    --vendor <nvidia|amd|intel>
+        Force a specific GPU vendor and skip auto-detection.
+
+    --manifest <path>
+        Use a custom ort_gpu.json manifest.  Default search order:
+            <script>/../../data/ort_gpu.json
+            <script>/../../share/darktable/ort_gpu.json
+            /usr/share/darktable/ort_gpu.json
+            /usr/local/share/darktable/ort_gpu.json
+
+    -h, --help
+        Show this help and exit.
+
+EXAMPLES
+    install-ort-gpu.sh
+        Detect the GPU, prompt for confirmation, install.
+
+    install-ort-gpu.sh -y
+        Same as above without confirmation.
+
+    install-ort-gpu.sh --vendor amd -y
+        Install the AMD/MIGraphX package without GPU detection.
+
+    install-ort-gpu.sh --force -y
+        Install without checking dependencies.
+EOF
+}
+
+YES=false
+FORCE=false
+MANIFEST=""
+VENDOR_OVERRIDE=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -y|--yes) YES=true; shift ;;
+    -f|--force) FORCE=true; shift ;;
+    --manifest) MANIFEST="$2"; shift 2 ;;
+    --vendor) VENDOR_OVERRIDE="$2"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) break ;;
+  esac
+done
+
+# --- Locate manifest ---
+if [ -z "$MANIFEST" ]; then
+  # try relative to script, then installed location
+  SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+  if [ -f "$SCRIPT_DIR/../../data/ort_gpu.json" ]; then
+    MANIFEST="$SCRIPT_DIR/../../data/ort_gpu.json"
+  elif [ -f "$SCRIPT_DIR/../../share/darktable/ort_gpu.json" ]; then
+    MANIFEST="$SCRIPT_DIR/../../share/darktable/ort_gpu.json"
+  elif [ -f "/usr/share/darktable/ort_gpu.json" ]; then
+    MANIFEST="/usr/share/darktable/ort_gpu.json"
+  elif [ -f "/usr/local/share/darktable/ort_gpu.json" ]; then
+    MANIFEST="/usr/local/share/darktable/ort_gpu.json"
+  else
+    echo "Error: cannot find ort_gpu.json manifest." >&2
+    echo "  Use --manifest <path> to specify it manually." >&2
+    exit 1
+  fi
+fi
+
+if [ ! -f "$MANIFEST" ]; then
+  echo "Error: manifest not found: $MANIFEST" >&2
+  exit 1
+fi
+
+# --- Platform checks ---
+if [ "$(uname -s)" != "Linux" ]; then
+  echo "Error: this script is for Linux only." >&2
+  exit 1
+fi
+
+ARCH=$(uname -m)
+PLATFORM="linux"
+
+# --- Detect GPU (skipped with --vendor) ---
+VENDOR=""
+GPU_LABEL=""
+DRIVER_VERSION=""
+GPU_LABEL_AMD=""
+DRIVER_VERSION_AMD=""
+GPU_LABEL_INTEL=""
+ROCM_MM=""
+CUDA_MM=""
+
+# Detect ROCm version using a distro-agnostic cascade. Each source is tried
+# in order until one yields a usable X.Y[.Z] version string.
+# Sets ROCM_VERSION and ROCM_MM if found.
+detect_rocm_version() {
+  ROCM_VERSION=""
+  local v=""
+
+  # Cascade of detection strategies, ordered from most reliable to fallback.
+  # All strategies are distro-independent except where explicitly noted.
+  local sources=(
+    # 1. Canonical AMD installer version file (all distros, AMD repo install)
+    'cat /opt/rocm/.info/version 2>/dev/null'
+    # 2. Versioned install dir symlink target (e.g. /opt/rocm -> rocm-6.2.0)
+    'readlink -f /opt/rocm 2>/dev/null | grep -oE "rocm-[0-9]+\.[0-9]+(\.[0-9]+)?" | sed "s/rocm-//"'
+    # 3. Any /opt/rocm-X.Y[.Z] directory (side-by-side installs)
+    'ls -d /opt/rocm-[0-9]*.[0-9]* 2>/dev/null | sed "s|.*/rocm-||" | sort -V | tail -1'
+    # 4. hipconfig (works wherever HIP is on PATH)
+    'command -v hipconfig >/dev/null && hipconfig --version 2>/dev/null'
+    # 5. pkg-config (works for any distro that ships .pc files)
+    'command -v pkg-config >/dev/null && pkg-config --modversion rocm-core 2>/dev/null'
+    # 6. dpkg (Debian/Ubuntu)
+    'command -v dpkg-query >/dev/null && dpkg-query -W -f="\${Version}" rocm-core 2>/dev/null'
+    # 7. rpm (Fedora/RHEL/openSUSE)
+    'command -v rpm >/dev/null && rpm -q --qf "%{VERSION}" rocm-core 2>/dev/null'
+    'command -v rpm >/dev/null && rpm -q --qf "%{VERSION}" rocm-runtime 2>/dev/null'
+    # 8. pacman (Arch)
+    'command -v pacman >/dev/null && pacman -Q rocm-core 2>/dev/null | awk "{print \$2}"'
+  )
+
+  for cmd in "${sources[@]}"; do
+    v=$(eval "$cmd" 2>/dev/null | tr -d '[:space:]' || true)
+    # strip distro suffixes like "-1.fc41" or "-1ubuntu1"
+    v="${v%%-*}"
+    if [[ "$v" =~ ^[0-9]+\.[0-9]+ ]]; then
+      ROCM_VERSION="$v"
+      break
+    fi
+  done
+
+  if [ -n "$ROCM_VERSION" ]; then
+    ROCM_MM=$(echo "$ROCM_VERSION" | grep -oP '^\d+\.\d+')
+  fi
+}
+
+# Detect installed CUDA toolkit version. Sets CUDA_MM (major.minor) if found.
+# nvcc is often absent on non-developer systems; fall back to library/path probes.
+detect_cuda_version() {
+  CUDA_MM=""
+  local v=""
+
+  # nvcc — most authoritative when available
+  if command -v nvcc &>/dev/null; then
+    v=$(nvcc --version 2>/dev/null | grep -oP 'V\K\d+\.\d+' || true)
+    [[ "$v" =~ ^[0-9]+\.[0-9]+ ]] && { CUDA_MM="$v"; return; }
+  fi
+
+  # version.json (CUDA 11.1+) or version.txt (older)
+  v=$(grep -oP '"version"\s*:\s*"\K\d+\.\d+' /usr/local/cuda/version.json 2>/dev/null \
+      || grep -oP 'CUDA Version \K\d+\.\d+' /usr/local/cuda/version.txt 2>/dev/null \
+      || true)
+  [[ "$v" =~ ^[0-9]+\.[0-9]+ ]] && { CUDA_MM="$v"; return; }
+
+  # libcudart.so major version from ldconfig — works regardless of install method
+  v=$(ldconfig -p 2>/dev/null | grep -oP 'libcudart\.so\.\K\d+' | sort -V | tail -1 || true)
+  [[ "$v" =~ ^[0-9]+$ ]] && { CUDA_MM="${v}.0"; return; }
+}
+
+if [ -n "$VENDOR_OVERRIDE" ]; then
+  case "$VENDOR_OVERRIDE" in
+    nvidia|amd|intel) VENDOR="$VENDOR_OVERRIDE" ;;
+    *)
+      echo "Error: unknown vendor '$VENDOR_OVERRIDE'. Use: nvidia, amd, intel" >&2
+      exit 1
+      ;;
+  esac
+  echo "Vendor override: $VENDOR_OVERRIDE (skipping GPU detection)"
+  # still collect version info for package matching
+  if [ "$VENDOR_OVERRIDE" = "amd" ]; then
+    detect_rocm_version
+  fi
+  if [ "$VENDOR_OVERRIDE" = "nvidia" ]; then
+    detect_cuda_version
+  fi
+else
+  # NVIDIA
+  if command -v nvidia-smi &>/dev/null; then
+    NVIDIA_INFO=$(nvidia-smi --query-gpu=name,driver_version --format=csv,noheader 2>/dev/null || true)
+    if [ -n "$NVIDIA_INFO" ]; then
+      # comma-join names across all detected GPUs; driver version is
+      # identical per row, take from the first
+      GPU_LABEL=$(echo "$NVIDIA_INFO" | awk -F, '{
+          gsub(/^[[:space:]]+|[[:space:]]+$/, "", $1)
+          printf "%s%s", (NR>1 ? ", " : ""), $1
+        }')
+      DRIVER_VERSION=$(echo "$NVIDIA_INFO" | head -1 | cut -d, -f2 | xargs)
+      VENDOR="nvidia"
+      detect_cuda_version
+    fi
+  fi
+
+  # AMD
+  detect_rocm_version
+  if [ -n "$ROCM_VERSION" ] || command -v rocminfo &>/dev/null; then
+    # rocminfo lists multiple agents (CPU, GPU, sometimes NPU on Ryzen AI);
+    # use Device Type to pick the GPU. Marketing Name appears before Device
+    # Type within each agent block, so we hold the most recent name and
+    # print it when we hit a GPU agent.
+    # `|| true` swallows the SIGPIPE-induced non-zero exit status the
+    # pipeline gets under `pipefail` when awk's `exit` closes stdin
+    # before rocminfo finishes writing — without it, $() would also
+    # capture a fallback echo and concatenate two values into one var
+    AMD_NAME=$(rocminfo 2>/dev/null | awk '
+        /Marketing Name:/  { sub(/.*Marketing Name:[[:space:]]*/, ""); sub(/[[:space:]]+$/, ""); mn=$0 }
+        /Device Type:.*GPU/{ if(out) out = out ", " mn; else out = mn }
+        END                { print out }
+      ' || true)
+    [ -z "$AMD_NAME" ] && AMD_NAME="AMD GPU"
+    if [ -n "$VENDOR" ]; then
+      VENDOR="$VENDOR amd"
+    else
+      VENDOR="amd"
+    fi
+    GPU_LABEL_AMD="${AMD_NAME}"
+    DRIVER_VERSION_AMD="ROCm ${ROCM_VERSION}"
+  fi
+
+  # Intel
+  INTEL_GPU=$(lspci 2>/dev/null | grep -i 'VGA.*Intel\|Display.*Intel' | sed 's/.*: //' | awk '{
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", $0)
+      printf "%s%s", (NR>1 ? ", " : ""), $0
+    }' || true)
+  if [ -n "$INTEL_GPU" ] || ldconfig -p 2>/dev/null | grep -q libze_loader; then
+    if [ -n "$VENDOR" ]; then
+      VENDOR="$VENDOR intel"
+    else
+      VENDOR="intel"
+    fi
+    GPU_LABEL_INTEL="${INTEL_GPU:-Intel GPU}"
+  fi
+
+  if [ -z "$VENDOR" ]; then
+    echo ""
+    echo "No supported GPU detected."
+    echo ""
+    echo "Supported: NVIDIA (CUDA), AMD (ROCm/MIGraphX), Intel (OpenVINO)"
+    echo "Ensure GPU drivers are installed, or use --vendor <nvidia|amd|intel>."
+    echo ""
+    exit 1
+  fi
+fi
+
+# --- Handle multiple vendors ---
+VENDORS=($VENDOR)
+SELECTED=""
+
+if [ ${#VENDORS[@]} -eq 1 ]; then
+  SELECTED="${VENDORS[0]}"
+else
+  echo ""
+  echo "Multiple GPUs detected:"
+  for i in "${!VENDORS[@]}"; do
+    v="${VENDORS[$i]}"
+    case "$v" in
+      nvidia) echo "  $((i+1))) NVIDIA: $GPU_LABEL ($DRIVER_VERSION)" ;;
+      amd)    echo "  $((i+1))) AMD: $GPU_LABEL_AMD ($DRIVER_VERSION_AMD)" ;;
+      intel)  echo "  $((i+1))) Intel: $GPU_LABEL_INTEL" ;;
+    esac
+  done
+  echo ""
+  read -rp "Select GPU [1-${#VENDORS[@]}]: " choice
+  idx=$((choice - 1))
+  if [ "$idx" -lt 0 ] || [ "$idx" -ge ${#VENDORS[@]} ]; then
+    echo "Invalid selection." >&2
+    exit 1
+  fi
+  SELECTED="${VENDORS[$idx]}"
+fi
+
+# set labels for selected vendor (with fallbacks for --vendor override)
+case "$SELECTED" in
+  nvidia) SEL_LABEL="${GPU_LABEL:-NVIDIA GPU}"; SEL_DRIVER="$DRIVER_VERSION" ;;
+  amd)    SEL_LABEL="${GPU_LABEL_AMD:-AMD GPU}"; SEL_DRIVER="${DRIVER_VERSION_AMD:-}" ;;
+  intel)  SEL_LABEL="${GPU_LABEL_INTEL:-Intel GPU}"; SEL_DRIVER="" ;;
+esac
+
+# --- Find matching package in manifest ---
+if ! command -v jq &>/dev/null; then
+  echo "Error: jq is required to parse the manifest." >&2
+  echo "  Install with: sudo apt install jq" >&2
+  exit 1
+fi
+
+PKG_JSON=$(jq -c --arg v "$SELECTED" --arg p "$PLATFORM" --arg a "$ARCH" \
+  --arg r "${ROCM_MM:-}" --arg c "${CUDA_MM:-}" \
+  '[.packages[] | select(.vendor==$v and .platform==$p and (.arch // "x86_64")==$a) |
+   if ($r != "" and .rocm_min != null) then select(.rocm_min <= $r and (.rocm_max // "99") >= $r) else . end |
+   if ($c != "" and .cuda_min != null) then select(.cuda_min <= $c and (.cuda_max // "99") >= $c) else . end] | first' \
+  "$MANIFEST" 2>/dev/null || true)
+
+if [ -z "$PKG_JSON" ]; then
+  echo ""
+  echo "Error: no matching package found in manifest for $SELECTED/$PLATFORM/$ARCH"
+  [ -n "${ROCM_MM:-}" ] && echo "  ROCm version: $ROCM_MM"
+  [ -n "${CUDA_MM:-}" ] && echo "  CUDA version: $CUDA_MM"
+  echo "  Check ort_gpu.json for supported configurations."
+  echo ""
+  exit 1
+fi
+
+# Warn when CUDA version could not be detected — package was selected
+# without version filtering and may not match the installed toolkit.
+if [ "$SELECTED" = "nvidia" ] && [ -z "${CUDA_MM:-}" ]; then
+  echo "Warning: could not detect installed CUDA toolkit version."
+  echo "  Proceeding with: Requirements: $(_field requirements '')"
+  echo ""
+fi
+
+# Extract fields from JSON
+_field() {
+  echo "$PKG_JSON" | jq -r ".$1 // \"$2\""
+}
+
+PKG_URL=$(_field url "")
+PKG_FORMAT=$(_field format "tgz")
+PKG_LIB_PATTERN=$(_field lib_pattern "libonnxruntime")
+# additional name prefixes to copy out of the same archive — used for
+# wheels that bundle their own dependencies alongside ORT (e.g. the
+# Linux onnxruntime-openvino wheel ships libopenvino*, libtbb*)
+PKG_LIB_EXTRA_PATTERNS=$(echo "$PKG_JSON" | jq -r '.lib_extra_patterns // [] | .[]' 2>/dev/null || true)
+PKG_INSTALL_SUBDIR=$(_field install_subdir "onnxruntime-gpu")
+PKG_SIZE_MB=$(_field size_mb "0")
+PKG_ORT_VERSION=$(_field ort_version "")
+PKG_REQUIREMENTS=$(_field requirements "")
+PKG_SHA256=$(_field sha256 "")
+
+INSTALL_DIR="$HOME/.local/lib/$PKG_INSTALL_SUBDIR"
+
+# --- Info & confirmation ---
+echo ""
+echo "ONNX Runtime $PKG_ORT_VERSION - GPU acceleration installer"
+echo "============================================================"
+echo ""
+echo "GPU: $SEL_LABEL"
+[ -n "$SEL_DRIVER" ] && echo "Driver: $SEL_DRIVER"
+echo "ORT version: $PKG_ORT_VERSION"
+echo "Download size: ~${PKG_SIZE_MB} MB"
+echo "Install to: $INSTALL_DIR"
+[ -n "$PKG_REQUIREMENTS" ] && echo "Requirements: $PKG_REQUIREMENTS"
+echo ""
+
+if [ "$YES" = false ]; then
+  read -rp "Continue? [y/N] " answer
+  if [[ ! "$answer" =~ ^[Yy] ]]; then
+    echo "Aborted."
+    exit 0
+  fi
+  echo ""
+fi
+
+# --- Download ---
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+ARCHIVE="$TMPDIR/ort-package"
+
+echo "Downloading..."
+if command -v wget &>/dev/null; then
+  wget -q --show-progress -O "$ARCHIVE" "$PKG_URL"
+elif command -v curl &>/dev/null; then
+  curl -fL --progress-bar -o "$ARCHIVE" "$PKG_URL"
+else
+  echo "Error: neither wget nor curl found." >&2
+  exit 1
+fi
+
+if [ ! -s "$ARCHIVE" ]; then
+  echo "Error: download failed from $PKG_URL" >&2
+  exit 1
+fi
+
+# --- Verify checksum ---
+if [ -n "$PKG_SHA256" ]; then
+  echo "Verifying checksum..."
+  ACTUAL_SHA256=$(sha256sum "$ARCHIVE" | cut -d' ' -f1)
+  if [ "$ACTUAL_SHA256" != "$PKG_SHA256" ]; then
+    echo "Error: checksum mismatch!" >&2
+    echo "  Expected: $PKG_SHA256" >&2
+    echo "  Got:      $ACTUAL_SHA256" >&2
+    exit 1
+  fi
+  echo "Checksum OK."
+fi
+
+# --- Extract ---
+echo "Extracting..."
+mkdir -p "$INSTALL_DIR"
+
+# build the find -name expression covering the main pattern + any extras
+_extract_libs() {
+  local search_root="$1"
+  local pattern
+  find "$search_root" -name "${PKG_LIB_PATTERN}*" -type f | while read -r f; do
+    cp "$f" "$INSTALL_DIR/"
+  done
+  for pattern in $PKG_LIB_EXTRA_PATTERNS; do
+    find "$search_root" -name "${pattern}*" -type f | while read -r f; do
+      cp "$f" "$INSTALL_DIR/"
+    done
+  done
+}
+
+case "$PKG_FORMAT" in
+  tgz)
+    tar xzf "$ARCHIVE" -C "$TMPDIR"
+    _extract_libs "$TMPDIR"
+    ;;
+  zip|whl)
+    unzip -q -o "$ARCHIVE" -d "$TMPDIR/extracted"
+    _extract_libs "$TMPDIR/extracted"
+    ;;
+  *)
+    echo "Error: unsupported archive format: $PKG_FORMAT" >&2
+    exit 1
+    ;;
+esac
+
+# --- Clear executable-stack flag (Linux only) ---
+# Some upstream ORT builds (notably AMD's ROCm/MIGraphX packages) ship
+# libonnxruntime.so with PT_GNU_STACK marked RWE. glibc >= 2.41 refuses to
+# dlopen such objects with "cannot enable executable stack as shared object
+# requires", so darktable's probe reports the library as invalid. The flag
+# is purely a linker-metadata mistake; clearing it is safe.
+clear_execstack() {
+  local f="$1"
+  if ! command -v readelf &>/dev/null; then return 0; fi
+  readelf -lW "$f" 2>/dev/null | grep -q 'GNU_STACK.*RWE' || return 0
+  echo "  patching executable-stack flag on $(basename "$f")"
+  if command -v execstack &>/dev/null; then
+    execstack -c "$f" 2>/dev/null && return 0
+  fi
+  # Fallback: clear the X bit in PT_GNU_STACK p_flags directly. ELF64 only.
+  # We locate the program header by reading e_phoff/e_phentsize/e_phnum from
+  # the ELF header and scan for PT_GNU_STACK (p_type == 0x6474e551).
+  python3 - "$f" <<'PY' 2>/dev/null && return 0
+import struct, sys
+p = sys.argv[1]
+with open(p, 'r+b') as fh:
+    data = fh.read(64)
+    if data[:4] != b'\x7fELF' or data[4] != 2:  # ELF64 only
+        sys.exit(1)
+    e_phoff = struct.unpack_from('<Q', data, 32)[0]
+    e_phentsize = struct.unpack_from('<H', data, 54)[0]
+    e_phnum = struct.unpack_from('<H', data, 56)[0]
+    PT_GNU_STACK = 0x6474e551
+    for i in range(e_phnum):
+        off = e_phoff + i * e_phentsize
+        fh.seek(off)
+        ph = fh.read(e_phentsize)
+        p_type, p_flags = struct.unpack_from('<II', ph, 0)
+        if p_type == PT_GNU_STACK:
+            new_flags = p_flags & ~0x1  # clear PF_X
+            fh.seek(off + 4)
+            fh.write(struct.pack('<I', new_flags))
+            sys.exit(0)
+sys.exit(1)
+PY
+  echo "  warning: could not clear execstack flag (install 'execstack' or python3)" >&2
+  echo "           the library may fail to load on glibc >= 2.41" >&2
+  return 1
+}
+
+if [ "$PLATFORM" = "linux" ]; then
+  for f in "$INSTALL_DIR"/*.so*; do
+    [ -f "$f" ] || continue
+    clear_execstack "$f" || true
+  done
+fi
+
+# --- Verify ---
+# prefer the main library (libonnxruntime.so.X.Y.Z), not providers
+ORT_SO=$(find "$INSTALL_DIR" -maxdepth 1 -name "${PKG_LIB_PATTERN}.so.*" -o -name "${PKG_LIB_PATTERN}.dll" 2>/dev/null | head -1)
+# fallback to any matching .so
+[ -z "$ORT_SO" ] && ORT_SO=$(find "$INSTALL_DIR" -maxdepth 1 -name "${PKG_LIB_PATTERN}*.so*" 2>/dev/null | grep -v providers | head -1)
+
+if [ -z "$ORT_SO" ]; then
+  echo "Error: no library found after extraction." >&2
+  exit 1
+fi
+
+echo ""
+echo "Done. Installed to: $INSTALL_DIR"
+ls -lh "$INSTALL_DIR/"*.so* 2>/dev/null || ls -lh "$INSTALL_DIR/"*.dll 2>/dev/null || true
+echo ""
+echo "To enable in darktable:"
+echo ""
+echo "  1. Open darktable preferences (Ctrl+,)"
+echo "  2. Go to the AI tab"
+echo "  3. Click 'detect' to find the installed library automatically,"
+echo "     or set 'ONNX Runtime library' to:"
+echo "     $ORT_SO"
+echo "  4. Restart darktable"
+echo ""
+echo "Or via command line:"
+echo ""
+echo "  DT_ORT_LIBRARY=$ORT_SO darktable"

--- a/tools/ai/refresh-ort-gpu.py
+++ b/tools/ai/refresh-ort-gpu.py
@@ -1,0 +1,561 @@
+#!/usr/bin/env python3
+# This file is part of darktable, copyright (C) 2026 darktable developers.
+# License GPL v3+.
+"""
+refresh-ort-gpu.py — keep data/ort_gpu.json in sync with upstream
+ONNX Runtime release locations.
+
+Scrapes:
+  * GitHub releases of microsoft/onnxruntime (NVIDIA CUDA tarballs/zips)
+  * https://repo.radeon.com/rocm/manylinux/      (AMD ROCm wheels)
+  * PyPI onnxruntime-openvino + openvino           (Intel OpenVINO wheels)
+
+For each (vendor, platform, accelerator-version) tuple in the existing
+registry, looks up the freshest upstream URL and computes its SHA256.
+If anything changed, prints a unified diff (--check), updates the file
+in place (--update), or opens a PR (--pr).
+
+We keep one entry per (CUDA major | ROCm minor) — wheel ABI is stable
+within those granularities so finer pinning is unnecessary churn.
+See data/ort_gpu.json comment / RAWDENOISE.md for rationale.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import urllib.request
+import urllib.error
+from collections.abc import Iterable
+from html.parser import HTMLParser
+from pathlib import Path
+
+REGISTRY_PATH = Path(__file__).resolve().parents[2] / "data" / "ort_gpu.json"
+
+RADEON_INDEX = "https://repo.radeon.com/rocm/manylinux/"
+GH_RELEASES = "https://api.github.com/repos/microsoft/onnxruntime/releases"
+PYPI_OPENVINO_ORT = "https://pypi.org/pypi/onnxruntime-openvino/json"
+PYPI_OPENVINO_RUNTIME = "https://pypi.org/pypi/openvino/json"
+
+# Python ABI tag we ship against. ONNX Runtime publishes cp310, cp311, cp312, cp313
+# wheels — we standardize on cp312 to match the install scripts.
+PY_TAG = "cp312"
+
+# CUDA platforms / asset shape. The pattern is keyed by (platform, cuda_major).
+CUDA_PATTERNS = {
+    ("linux", 12): "onnxruntime-linux-x64-gpu-{ver}.tgz",
+    ("linux", 13): "onnxruntime-linux-x64-gpu_cuda13-{ver}.tgz",
+    ("windows", 12): "onnxruntime-win-x64-gpu-{ver}.zip",
+    ("windows", 13): "onnxruntime-win-x64-gpu_cuda13-{ver}.zip",
+}
+
+# Intel: PyPI wheel platform tags per OS. cp312 cp312 is added by _find_pypi_wheel
+INTEL_WHEEL_TAGS = {
+    "linux":   ("manylinux_2_28_x86_64",),
+    "windows": ("win_amd64",),
+}
+
+logger = logging.getLogger("refresh-ort-gpu")
+
+
+# -----------------------------------------------------------------------------
+# minimal HTTP helpers (stdlib only — no requests dep)
+
+def http_get(url: str, accept: str = "*/*", timeout: int = 30) -> bytes:
+    req = urllib.request.Request(url, headers={"User-Agent": "dt-ort-refresh", "Accept": accept})
+    with urllib.request.urlopen(req, timeout=timeout) as r:
+        return r.read()
+
+
+def http_get_json(url: str) -> object:
+    return json.loads(http_get(url, accept="application/json").decode())
+
+
+_FORMAT_MAGIC = {
+    # detect that the bytes we got back actually look like the file
+    # type we expect — guards against URLs that resolve to an HTML error
+    # page served as 200 OK, or a redirect to a login wall
+    "whl": b"PK\x03\x04",  # ZIP
+    "zip": b"PK\x03\x04",
+    "tgz": b"\x1f\x8b",    # gzip
+}
+
+
+def stream_sha256(url: str, fmt: str | None = None,
+                  expected_size: int | None = None,
+                  min_size: int = 1 << 20) -> tuple[str, int]:
+    """Stream-download a URL and return (sha256_hex, byte_count).
+
+    Validates the first bytes match `fmt`'s magic when given, and that
+    the total size is at least `min_size` (1 MiB by default — anything
+    smaller can't be one of our wheels/tarballs and is almost certainly
+    an error page)."""
+    h = hashlib.sha256()
+    n = 0
+    head: bytes = b""
+    req = urllib.request.Request(url, headers={"User-Agent": "dt-ort-refresh"})
+    with urllib.request.urlopen(req, timeout=120) as r:
+        while True:
+            chunk = r.read(1 << 20)  # 1 MiB
+            if not chunk:
+                break
+            if not head:
+                head = chunk[:8]
+            h.update(chunk)
+            n += len(chunk)
+            if expected_size and n > expected_size * 1.5:
+                raise RuntimeError(f"runaway download from {url} ({n} bytes)")
+    if n < min_size:
+        raise RuntimeError(
+            f"{url}: got only {n} bytes (expected >={min_size}); "
+            "URL likely returned an error page"
+        )
+    if fmt and (magic := _FORMAT_MAGIC.get(fmt)):
+        if not head.startswith(magic):
+            raise RuntimeError(
+                f"{url}: first bytes {head!r} don't match {fmt} magic "
+                f"{magic!r}; URL probably resolves to wrong content"
+            )
+    return h.hexdigest(), n
+
+
+# -----------------------------------------------------------------------------
+# Radeon directory scrape
+
+class _LinkParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self.hrefs: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag != "a":
+            return
+        for k, v in attrs:
+            if k == "href" and v:
+                self.hrefs.append(v)
+
+
+def _list_links(url: str) -> list[str]:
+    p = _LinkParser()
+    p.feed(http_get(url).decode("utf-8", errors="replace"))
+    return p.hrefs
+
+
+_ROCM_DIR_RE = re.compile(r"^rocm-rel-(\d+)\.(\d+)(?:\.(\d+))?/$")
+_ORT_WHL_RE = re.compile(
+    r"^onnxruntime_(rocm|migraphx)-(\d+\.\d+\.\d+)-"
+    rf"{PY_TAG}-{PY_TAG}-([\w._]+)\.whl$"
+)
+
+
+def discover_radeon_wheels() -> dict[tuple[int, int], dict]:
+    """Return {(rocm_major, rocm_minor): {patch, ort_version, url, package}}.
+
+    Only the *latest patch* in each minor is returned. URLs point at the
+    real wheel observed in that patch's directory (filename tag may
+    differ across patches, e.g. linux_x86_64 vs manylinux).
+    """
+    logger.info("scraping %s", RADEON_INDEX)
+    rocm_dirs: dict[tuple[int, int], tuple[tuple[int, int, int], str]] = {}
+    for href in _list_links(RADEON_INDEX):
+        m = _ROCM_DIR_RE.match(href)
+        if not m:
+            continue
+        major, minor = int(m.group(1)), int(m.group(2))
+        # ROCm 6.x is not supported — known issues with the bundled libs
+        if major < 7:
+            continue
+        patch = int(m.group(3)) if m.group(3) else 0
+        sortkey = (major, minor, patch)
+        prev = rocm_dirs.get((major, minor))
+        if prev is None or sortkey > prev[0]:
+            rocm_dirs[(major, minor)] = (sortkey, href.rstrip("/"))
+
+    result: dict[tuple[int, int], dict] = {}
+    for (major, minor), ((_, _, patch), dirname) in sorted(rocm_dirs.items()):
+        dir_url = RADEON_INDEX + dirname + "/"
+        try:
+            files = _list_links(dir_url)
+        except urllib.error.HTTPError as e:
+            logger.warning("skipping %s: %s", dir_url, e)
+            continue
+
+        # find the cp312 ONNX Runtime wheel; prefer onnxruntime_migraphx (7.1+),
+        # fall back to onnxruntime_rocm (7.0)
+        best: tuple[str, str, str] | None = None  # (package, ver, fname)
+        for fn in files:
+            mw = _ORT_WHL_RE.match(fn)
+            if not mw:
+                continue
+            pkg, ver = mw.group(1), mw.group(2)
+            # prefer migraphx if both present
+            if best is None or (best[0] == "rocm" and pkg == "migraphx"):
+                best = (pkg, ver, fn)
+        if best is None:
+            logger.info("rocm %d.%d.%d: no cp312 ONNX Runtime wheel", major, minor, patch)
+            continue
+        pkg, ver, fname = best
+        result[(major, minor)] = dict(
+            patch=patch,
+            ort_version=ver,
+            package=pkg,
+            url=dir_url + fname,
+            filename=fname,
+            requirements=f"ROCm {major}.{minor}, MIGraphX",
+        )
+        logger.info("rocm %d.%d.%d -> %s %s", major, minor, patch, pkg, ver)
+    return result
+
+
+# -----------------------------------------------------------------------------
+# GitHub microsoft/onnxruntime releases scrape (NVIDIA)
+
+def discover_cuda_assets() -> dict[tuple[str, int], dict]:
+    """Return {(platform, cuda_major): {ort_version, url}} for the latest
+    onnxruntime release that has all four expected assets present."""
+    logger.info("querying %s", GH_RELEASES)
+    headers = {"User-Agent": "dt-ort-refresh", "Accept": "application/vnd.github+json"}
+    if (token := os.environ.get("GITHUB_TOKEN")):
+        headers["Authorization"] = f"Bearer {token}"
+    req = urllib.request.Request(GH_RELEASES + "?per_page=20", headers=headers)
+    with urllib.request.urlopen(req, timeout=30) as r:
+        releases = json.load(r)
+
+    result: dict[tuple[str, int], dict] = {}
+    for rel in releases:
+        if rel.get("draft") or rel.get("prerelease"):
+            continue
+        ver = rel["tag_name"].lstrip("v")
+        assets = {a["name"]: a["browser_download_url"] for a in rel.get("assets", [])}
+        match: dict[tuple[str, int], dict] = {}
+        for (plat, cuda_maj), tmpl in CUDA_PATTERNS.items():
+            name = tmpl.format(ver=ver)
+            if name not in assets:
+                logger.info("rel %s missing %s", ver, name)
+                break
+            match[(plat, cuda_maj)] = dict(
+                ort_version=ver, url=assets[name], requirements=f"CUDA {cuda_maj}.x, cuDNN 9.x",
+            )
+        if len(match) == len(CUDA_PATTERNS):
+            logger.info("nvidia release %s has all assets", ver)
+            return match
+    raise RuntimeError("no recent onnxruntime release has the full CUDA asset set")
+
+
+# -----------------------------------------------------------------------------
+# registry diff
+
+def proposed_amd(existing: list[dict], wheels: dict[tuple[int, int], dict]) -> list[dict]:
+    """Build the AMD section of the new registry. Reuses entry shape +
+    extra fields (size_mb, lib_pattern, install_subdir, required_libs)
+    from the existing entries when present, so manual fields are kept."""
+    new: list[dict] = []
+    by_minor = {}
+    for e in existing:
+        if e.get("vendor") != "amd":
+            continue
+        try:
+            mm = e["rocm_min"].split(".")
+            by_minor[(int(mm[0]), int(mm[1]))] = e
+        except (KeyError, ValueError):
+            pass
+
+    for (major, minor), info in sorted(wheels.items()):
+        old = by_minor.get((major, minor), {})
+        # tight per-minor range: bash matcher uses inclusive `>=`,
+        # so overlapping ranges across minors would let `jq | first`
+        # pick the wrong entry. one entry per ROCm minor — patches
+        # match because the detector truncates to major.minor
+        mm = f"{major}.{minor}"
+        entry = {
+            "vendor": "amd",
+            "platform": "linux",
+            "arch": "x86_64",
+            "rocm_min": mm,
+            "rocm_max": mm,
+            "ort_version": info["ort_version"],
+            "url": info["url"],
+            # left empty here so fill_sha256 always considers this entry
+            # for verification — pre-populating from `old` would make
+            # the early-skip mistake an outdated registry SHA for a
+            # PyPI-trusted one
+            "sha256": "",
+            "format": "whl",
+            "lib_pattern": old.get("lib_pattern", "libonnxruntime"),
+            "install_subdir": old.get("install_subdir", "onnxruntime-migraphx"),
+            "size_mb": old.get("size_mb", 200),
+            "requirements": info["requirements"],
+        }
+        if "required_libs" in old:
+            entry["required_libs"] = old["required_libs"]
+        new.append(entry)
+    return new
+
+
+def proposed_nvidia(existing: list[dict], assets: dict[tuple[str, int], dict]) -> list[dict]:
+    new: list[dict] = []
+    by_key = {}
+    for e in existing:
+        if e.get("vendor") != "nvidia":
+            continue
+        try:
+            cm = int(float(e["cuda_min"]))
+            by_key[(e["platform"], cm)] = e
+        except (KeyError, ValueError):
+            pass
+
+    for (plat, cuda_maj), info in sorted(assets.items()):
+        old = by_key.get((plat, cuda_maj), {})
+        entry = {
+            "vendor": "nvidia",
+            "platform": plat,
+            "arch": "x86_64",
+            "cuda_min": f"{cuda_maj}.0",
+            "cuda_max": f"{cuda_maj}.99",
+            "ort_version": info["ort_version"],
+            "url": info["url"],
+            # see proposed_amd note: left empty so fill_sha256 always
+            # verifies — never carry old SHA blindly
+            "sha256": "",
+            "format": "tgz" if plat == "linux" else "zip",
+            "lib_pattern": old.get("lib_pattern", "libonnxruntime" if plat == "linux" else "onnxruntime"),
+            "install_subdir": old.get("install_subdir", "onnxruntime-cuda"),
+            "size_mb": old.get("size_mb", 200),
+            "requirements": info["requirements"],
+        }
+        new.append(entry)
+    return new
+
+
+def fill_sha256(new_entries: list[dict], existing_entries: list[dict]) -> None:
+    """Resolve sha256 for every entry that doesn't already carry one
+    from a trusted upstream (PyPI's JSON API).
+
+    Always downloads + hashes the wheel even when the URL matches an
+    existing registry entry. Any cheaper shortcut (HEAD size check,
+    Etag, etc.) misses drift between similar-sized versions: e.g. ORT
+    1.24.4 and 1.25.1 are both ~210 MB so size is identical, but their
+    SHAs differ. The only reliable way to know the cache is correct is
+    to compute the SHA fresh.
+
+    Cost: ~2 GB downloaded per run. For monthly CI that's negligible.
+    Logs a warning when the stored SHA differs from upstream so drift
+    in the source-of-truth registry is surfaced in CI output.
+    """
+    by_url = {e["url"]: e for e in existing_entries}
+    for entry in new_entries:
+        # Intel/PyPI entries arrive with sha256 already filled in from
+        # PyPI's published digest — those are authoritative
+        if entry.get("sha256"):
+            continue
+
+        logger.info("downloading %s for sha256...", entry["url"])
+        sha, n = stream_sha256(entry["url"], fmt=entry.get("format"))
+        entry["sha256"] = sha
+        # round size up to nearest 50 MB for readability
+        mb_actual = n / (1 << 20)
+        entry["size_mb"] = max(50, ((int(mb_actual) + 49) // 50) * 50)
+
+        old = by_url.get(entry["url"])
+        if old and old.get("sha256") and old["sha256"] != sha:
+            logger.warning(
+                "%s: registry SHA %s does not match upstream %s — "
+                "registry was drifted (manual edit, upstream rebuild, etc.)",
+                entry["url"], old["sha256"][:12] + "...",
+                sha[:12] + "...")
+
+
+# -----------------------------------------------------------------------------
+# PyPI scrape (Intel: onnxruntime-openvino + openvino runtime)
+
+def _round_size_mb(byte_count: int, step_mb: int = 10) -> int:
+    """Round byte_count up to the nearest step_mb, with a step floor."""
+    mb = byte_count / (1 << 20)
+    return max(step_mb, ((int(mb) + step_mb - 1) // step_mb) * step_mb)
+
+
+def _pypi_pick_wheel(release_files: list[dict],
+                     platform_tags: tuple[str, ...]) -> dict | None:
+    """Pick the cp312 bdist_wheel matching one of the given platform tags."""
+    for f in release_files:
+        if f.get("packagetype") != "bdist_wheel":
+            continue
+        fn = f.get("filename", "")
+        if PY_TAG not in fn:
+            continue
+        if not any(plat in fn for plat in platform_tags):
+            continue
+        return f
+    return None
+
+
+def discover_intel_assets() -> dict[str, dict]:
+    """Return {platform: {ort_version, url, sha256, size_mb,
+    [runtime_url, runtime_sha256, runtime_size_mb]}}.
+
+    Latest cp312 onnxruntime_openvino wheel from PyPI per platform.
+    Windows additionally pulls the matching openvino runtime wheel —
+    on Linux openvino libs are bundled inside the ONNX Runtime wheel, on Windows
+    they ship as a separate package."""
+    logger.info("querying %s", PYPI_OPENVINO_ORT)
+    data = http_get_json(PYPI_OPENVINO_ORT)
+    ver = data["info"]["version"]
+    files = data["releases"][ver]
+
+    result: dict[str, dict] = {}
+    for plat, tags in INTEL_WHEEL_TAGS.items():
+        wheel = _pypi_pick_wheel(files, tags)
+        if not wheel:
+            logger.info("intel %s: no cp312 wheel in onnxruntime-openvino %s", plat, ver)
+            continue
+        result[plat] = dict(
+            ort_version=ver,
+            url=wheel["url"],
+            sha256=wheel["digests"]["sha256"],
+            size_mb=_round_size_mb(wheel["size"], 10),
+        )
+
+    if "windows" in result:
+        logger.info("querying %s", PYPI_OPENVINO_RUNTIME)
+        rt = http_get_json(PYPI_OPENVINO_RUNTIME)
+        rt_ver = rt["info"]["version"]
+        rt_wheel = _pypi_pick_wheel(rt["releases"][rt_ver],
+                                    INTEL_WHEEL_TAGS["windows"])
+        if rt_wheel:
+            result["windows"]["runtime_url"] = rt_wheel["url"]
+            result["windows"]["runtime_sha256"] = rt_wheel["digests"]["sha256"]
+            result["windows"]["runtime_size_mb"] = _round_size_mb(rt_wheel["size"], 10)
+        else:
+            logger.warning("intel windows: openvino runtime wheel not found in %s", rt_ver)
+
+    return result
+
+
+def proposed_intel(existing: list[dict], assets: dict[str, dict]) -> list[dict]:
+    """Build replacement intel entries from PyPI assets, preserving any
+    existing static fields (lib_pattern, install_subdir, requirements,
+    *_extra_patterns) that the discoverer can't infer."""
+    by_plat = {e["platform"]: e for e in existing if e.get("vendor") == "intel"}
+    new: list[dict] = []
+    for plat, info in sorted(assets.items()):
+        old = by_plat.get(plat, {})
+        entry: dict = {
+            "vendor": "intel",
+            "platform": plat,
+            "arch": "x86_64",
+            "ort_version": info["ort_version"],
+            "url": info["url"],
+            "sha256": info["sha256"],
+            "format": "whl",
+            "lib_pattern": old.get("lib_pattern",
+                                   "libonnxruntime" if plat == "linux" else "onnxruntime"),
+        }
+        if "lib_extra_patterns" in old:
+            entry["lib_extra_patterns"] = old["lib_extra_patterns"]
+        entry["install_subdir"] = old.get("install_subdir", "onnxruntime-openvino")
+        entry["size_mb"] = info["size_mb"]
+        entry["requirements"] = old.get("requirements", "Intel GPU driver (OpenCL)")
+        if plat == "windows" and "runtime_url" in info:
+            entry["runtime_url"] = info["runtime_url"]
+            entry["runtime_sha256"] = info["runtime_sha256"]
+            entry["runtime_lib_pattern"] = old.get("runtime_lib_pattern", "openvino")
+            if "runtime_extra_patterns" in old:
+                entry["runtime_extra_patterns"] = old["runtime_extra_patterns"]
+            entry["runtime_size_mb"] = info["runtime_size_mb"]
+        new.append(entry)
+    return new
+
+
+# -----------------------------------------------------------------------------
+# registry I/O
+
+def load_registry() -> dict:
+    return json.loads(REGISTRY_PATH.read_text())
+
+
+def write_registry(data: dict) -> None:
+    REGISTRY_PATH.write_text(json.dumps(data, indent=2) + "\n")
+
+
+def render_diff(old: dict, new: dict) -> str:
+    import difflib
+    a = json.dumps(old, indent=2).splitlines(keepends=True)
+    b = json.dumps(new, indent=2).splitlines(keepends=True)
+    return "".join(difflib.unified_diff(a, b, fromfile="ort_gpu.json (current)", tofile="ort_gpu.json (proposed)"))
+
+
+# -----------------------------------------------------------------------------
+# main
+
+def build_proposed(existing: dict) -> dict:
+    """Build the proposed registry. Computes sha256 only for changed URLs.
+    Preserves any vendor we don't manage untouched."""
+    pkgs = list(existing.get("packages", []))
+    nvidia = proposed_nvidia(pkgs, discover_cuda_assets())
+    amd = proposed_amd(pkgs, discover_radeon_wheels())
+    intel = proposed_intel(pkgs, discover_intel_assets())
+    preserved = [e for e in pkgs if e.get("vendor") not in {"nvidia", "amd", "intel"}]
+    new_pkgs = nvidia + amd + intel + preserved
+    fill_sha256(new_pkgs, pkgs)
+    out = dict(existing)
+    out["packages"] = new_pkgs
+    return out
+
+
+def open_pr(diff: str) -> None:
+    branch = f"refresh-ort-gpu-{os.environ.get('GITHUB_RUN_ID', 'manual')}"
+    subprocess.check_call(["git", "checkout", "-b", branch])
+    subprocess.check_call(["git", "add", str(REGISTRY_PATH)])
+    subprocess.check_call(["git", "commit", "-m", "refresh ort_gpu.json from upstream"])
+    subprocess.check_call(["git", "push", "-u", "origin", branch])
+    body = (
+        "Automated update from `tools/ai/refresh-ort-gpu.py`.\n\n"
+        "```diff\n" + diff + "\n```"
+    )
+    subprocess.check_call(["gh", "pr", "create", "--title", "Refresh ONNX Runtime GPU registry", "--body", body])
+
+
+def main(argv: list[str]) -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    mode = p.add_mutually_exclusive_group()
+    mode.add_argument("--check", action="store_true", help="dry-run; print diff and exit non-zero if changes")
+    mode.add_argument("--update", action="store_true", help="rewrite data/ort_gpu.json in place")
+    p.add_argument("--pr", action="store_true", help="open a PR with the changes (implies --update)")
+    p.add_argument("-v", "--verbose", action="store_true")
+    args = p.parse_args(argv)
+
+    logging.basicConfig(level=logging.INFO if args.verbose or args.check else logging.WARNING,
+                        format="%(message)s")
+
+    if args.pr and not args.update:
+        args.update = True
+    if not (args.check or args.update):
+        args.check = True  # default
+
+    existing = load_registry()
+    proposed = build_proposed(existing)
+
+    if proposed == existing:
+        print("ort_gpu.json is up to date.")
+        return 0
+
+    diff = render_diff(existing, proposed)
+    print(diff)
+
+    if args.update:
+        write_registry(proposed)
+        print(f"\nwrote {REGISTRY_PATH}")
+    if args.pr:
+        open_pr(diff)
+    return 1 if args.check else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
Follow-up to #20647 (ORT library path preference and custom loading). Addresses #20532.

## Summary

Manifest-driven system for installing GPU-accelerated ONNX Runtime directly from darktable or via scripts.

### Package manifest (`data/ort_gpu.json`)

All download URLs, SHA-256 checksums, archive formats, and ROCm version mappings in a single JSON file – update it to change URLs/versions without rebuilding darktable. Supports NVIDIA (CUDA), AMD (MIGraphX), and Intel (OpenVINO) on Linux and Windows.

### Unified install scripts

| Script | Platform | Requires |
|--------|----------|----------|
| `install-ort-gpu.sh` | Linux | jq |
| `install-ort-gpu.ps1` | Windows | PowerShell |
| `install-ort-amd-build.sh` | Linux | cmake, gcc, python3 |

Scripts read the same `ort_gpu.json` manifest, detect GPU, download and verify the matching package. Support `--vendor`, `--force`, `--manifest` flags.

### Documentation

`tools/ai/README.md` – install methods, EP table, manifest format, manual install, verification.