### PR TITLE
Fix AppImage update info for release builds

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -338,7 +338,7 @@ jobs:
         with:
           path: ${{ env.BUILD_DIR }}/*.exe
           name: artifact-windows-${{ runner.arch }}
-          retention-days: 2
+          retention-days: 1
 
   macOS:
     if: github.repository == 'darktable-org/darktable' || github.event_name == 'workflow_dispatch'
@@ -418,7 +418,7 @@ jobs:
         with:
           path: ${{ env.INSTALL_PREFIX }}/darktable-${{ env.VERSION }}-${{ env.ARCHITECTURE }}.dmg
           name: artifact-macos-${{ runner.arch }}
-          retention-days: 2
+          retention-days: 1
 
   upload_to_release:
     permissions:


### PR DESCRIPTION
We need this so that the release AppImages look for update to the next release, not to the next nightly builds.