### PR TITLE
Some improvements for highlights correction (mainly opposed)

### DIFF
--- a/data/kernels/basic.cl
+++ b/data/kernels/basic.cl
@@ -209,7 +209,7 @@ whitebalance_1f(read_only image2d_t in, write_only image2d_t out, const int widt
   const int x = get_global_id(0);
   const int y = get_global_id(1);
   if(x >= width || y >= height) return;
-  const float pixel = read_imagef(in, sampleri, (int2)(x, y)).x;
+  float pixel = readsingle(in, x, y);
   write_imagef(out, (int2)(x, y), pixel * coeffs[FC(y, x, filters)]);
 }
 
@@ -220,7 +220,7 @@ whitebalance_1f_xtrans(read_only image2d_t in, write_only image2d_t out, const i
   const int x = get_global_id(0);
   const int y = get_global_id(1);
   if(x >= width || y >= height) return;
-  const float pixel = read_imagef(in, sampleri, (int2)(x, y)).x;
+  float pixel = readsingle(in, x, y);
   write_imagef(out, (int2)(x, y), pixel * coeffs[FCxtrans(y, x, xtrans)]);
 }
 
@@ -232,7 +232,7 @@ whitebalance_4f(read_only image2d_t in, write_only image2d_t out, const int widt
   const int x = get_global_id(0);
   const int y = get_global_id(1);
   if(x >= width || y >= height) return;
-  const float4 pixel = read_imagef(in, sampleri, (int2)(x, y));
+  float4 pixel = readpixel(in, x, y);
   write_imagef (out, (int2)(x, y), (float4)(pixel.x * coeffs[0], pixel.y * coeffs[1], pixel.z * coeffs[2], pixel.w));
 }
 
@@ -244,7 +244,7 @@ exposure (read_only image2d_t in, write_only image2d_t out, const int width, con
   const int y = get_global_id(1);
 
   if(x >= width || y >= height) return;
-  float4 pixel = read_imagef(in, sampleri, (int2)(x, y));
+  float4 pixel = readpixel(in, x, y);
   pixel.xyz = ((pixel - black ) * scale).xyz;
   write_imagef (out, (int2)(x, y), pixel);
 }
@@ -261,7 +261,7 @@ highlights_4f_clip (read_only image2d_t in, write_only image2d_t out, const int 
 
   // 4f/pixel means that this has been debayered already.
   // it's thus hopeless to recover highlights here (this code path is just used for preview and non-raw images)
-  float4 pixel = read_imagef(in, sampleri, (int2)(x, y));
+  float4 pixel = readpixel(in, x, y);
   // default: // 0, DT_IOP_HIGHLIGHTS_CLIP
   pixel.x = fmin(clip, pixel.x);
   pixel.y = fmin(clip, pixel.y);
@@ -294,18 +294,17 @@ highlights_1f_clip (read_only image2d_t in, write_only image2d_t out,
   write_imagef(out, (int2)(x, y), pixel);
 }
 
-kernel void highlights_false_color(
-        read_only image2d_t in,
-        write_only image2d_t out,
-        const int owidth,
-        const int oheight,
-        const int iwidth,
-        const int iheight,
-        const int dx,
-        const int dy,
-        const unsigned int filters,
-        global const unsigned char (*const xtrans)[6],
-        const float4 clip)
+kernel void highlights_false_color(read_only image2d_t in,
+                                   write_only image2d_t out,
+                                   const int owidth,
+                                   const int oheight,
+                                   const int iwidth,
+                                   const int iheight,
+                                   const int dx,
+                                   const int dy,
+                                   const unsigned int filters,
+                                   global const unsigned char (*const xtrans)[6],
+                                   const float4 clip)
 {
   const int x = get_global_id(0);
   const int y = get_global_id(1);
@@ -326,53 +325,45 @@ kernel void highlights_false_color(
   write_imagef (out, (int2)(x, y), oval);
 }
 
-static float _calc_refavg(
-        read_only image2d_t in,
-        global const unsigned char (*const xtrans)[6],
-        const unsigned int filters,
-        int row,
-        int col,
-        int maxrow,
-        int maxcol,
-        global const float *correction)
+static float _calc_refavg(read_only image2d_t in,
+                          global const unsigned char (*const xtrans)[6],
+                          const unsigned int filters,
+                          int row,
+                          int col,
+                          int maxrow,
+                          int maxcol,
+                          global const float *correction)
 {
   float mean[3] = { 0.0f, 0.0f, 0.0f };
-  float sum[3] =  { 0.0f, 0.0f, 0.0f };
   float cnt[3]  = { 0.0f, 0.0f, 0.0f };
 
-  const int dymin = max(0, row - 1);
-  const int dxmin = max(0, col - 1);
-  const int dymax = min(maxrow - 1, row + 2);
-  const int dxmax = min(maxcol - 1, col + 2);
-
-  for(int dy = dymin; dy < dymax; dy++)
+  for(int dy = max(0, row - 1); dy < min(maxrow - 1, row + 2); dy++)
   {
-    for(int dx = dxmin; dx < dxmax; dx++)
+    for(int dx = max(0, col - 1); dx < min(maxcol - 1, col + 2); dx++)
     {
       const float val = fmax(0.0f, readsingle(in, dx, dy));
       const int c = fcol(dy, dx, filters, xtrans);
-      sum[c] += val;
+      mean[c] += val;
       cnt[c] += 1.0f;
     }
   }
 
   for(int c = 0; c < 3; c++)
-    mean[c] = (cnt[c] > 0.0f) ? cbrt((correction[c] * sum[c]) / cnt[c]) : 0.0f;
+    mean[c] = (cnt[c] > 0.0f) ? cbrt((correction[c] * mean[c]) / cnt[c]) : 0.0f;
 
-  const float croot_refavg[3] = { 0.5f * (mean[1] + mean[2]), 0.5f * (mean[0] + mean[2]), 0.5f * (mean[0] + mean[1])};
-  const int color = fcol(row, col, filters, xtrans);
+  float croot_refavg[3] = { 0.5f * (mean[1] + mean[2]), 0.5f * (mean[0] + mean[2]), 0.5f * (mean[0] + mean[1])};
+  int color = fcol(row, col, filters, xtrans);
   return fcube(croot_refavg[color]);
 }
 
-kernel void highlights_initmask(
-        read_only image2d_t in,
-        global char *inmask,
-        const int msize,
-        const int mwidth,
-        const int mheight,
-        const unsigned int filters,
-        global const unsigned char (*const xtrans)[6],
-        global const float *clips)
+kernel void highlights_initmask(read_only image2d_t in,
+                                global char *inmask,
+                                const int msize,
+                                const int mwidth,
+                                const int mheight,
+                                const unsigned int filters,
+                                global const unsigned char (*const xtrans)[6],
+                                global const float *clips)
 {
   const int mcol = get_global_id(0);
   const int mrow = get_global_id(1);
@@ -380,36 +371,49 @@ kernel void highlights_initmask(
   if((mcol >= mwidth) || (mrow >= mheight))
     return;
 
-  const int mdx = mad24(mrow, mwidth, mcol);
-
-  if((mcol < 1) || (mrow < 1) || (mcol > mwidth -2) || (mrow > mheight-2))
-  {
-    for(int c = 0; c < 3; c++)
-      inmask[c*msize + mdx] = 0;
-    return;
-  }
-
+  int mdx = mad24(mrow, mwidth, mcol);
   char mbuff[3] = { 0, 0, 0 };
-  for(int y = -1; y < 2; y++)
+  if(mcol < mwidth-1 && mrow < mheight-1)
   {
-    for(int x = -1; x < 2; x++)
+    for(int y = 0; y < 3; y++)
     {
-      const int color = fcol(mrow+y, mcol+x, filters, xtrans);
-      const float val = fmax(0.0f, read_imagef(in, sampleri, (int2)(3 * mcol + x, 3 * mrow + y)).x);
-      mbuff[color] += (val >= clips[color]) ? 1 : 0;
+      for(int x = 0; x < 3; x++)
+      {
+        int color = fcol(3*mrow+y, 3*mcol+x, filters, xtrans);
+        float val = readsingle(in, 3*mcol+x, 3*mrow+y);
+        mbuff[color] += (val >= clips[color]) ? 1 : 0;
+      }
     }
   }
 
   for(int c = 0; c < 3; c++)
-    inmask[c*msize + mdx] = (mbuff[c] != 0) ? 1 : 0;
+    inmask[c*msize + mdx] = mbuff[c] ? 1 : 0;
 }
 
-kernel void highlights_dilatemask(
-        global char *in,
-        global char *out,
-        const int msize,
-        const int mwidth,
-        const int mheight)
+static char _mask_dilated(global char *in, const int w1)
+{
+  if(in[0])
+    return 1;
+
+  if(in[-w1-1] | in[-w1] | in[-w1+1] | in[-1] | in[1] | in[w1-1] | in[w1] | in[w1+1])
+    return 1;
+
+  const int w2 = 2*w1;
+  const int w3 = 3*w1;
+  return (in[-w3-2] | in[-w3-1] | in[-w3]   | in[-w3+1] | in[-w3+2] |
+          in[-w2-3] | in[-w2-2] | in[-w2-1] | in[-w2]   | in[-w2+1] | in[-w2+2] | in[-w2+3] |
+          in[-w1-3] | in[-w1-2] | in[-w1+2] | in[-w1+3] |
+          in[-3]    | in[-2]    | in[2]     | in[3]     |
+          in[w1-3]  | in[w1-2]  | in[w1+2]  | in[w1+3]  |
+          in[w2-3]  | in[w2-2]  | in[w2-1]  | in[w2]    | in[w2+1]  | in[w2+2]  | in[w2+3] |
+          in[w3-2]  | in[w3-1]  | in[w3]    | in[w3+1]  | in[w3+2]) ? 1 : 0;
+}
+
+kernel void highlights_dilatemask(global char *in,
+                                  global char *out,
+                                  const int msize,
+                                  const int mwidth,
+                                  const int mheight)
 {
   const int col = get_global_id(0);
   const int row = get_global_id(1);
@@ -417,82 +421,34 @@ kernel void highlights_dilatemask(
   if((col >= mwidth) || (row >= mheight))
     return;
 
-  const int w1 = mwidth;
-  const int w2 = 2 * mwidth;
-  const int w3 = 3 * mwidth;
-  const int moff = mad24(row, w1, col);
+  int mx = mad24(row, mwidth, col);
+  bool safe = col >= 3 && row >= 3 && col < mwidth - 4 && row < mheight - 4;
 
-  if((col < 3) || (row < 3) || (col > mwidth - 4) || (row > mheight - 4))
-  {
-    out[moff] = 0;
-    out[moff + msize] = 0;
-    out[moff + 2*msize] = 0;
-    return;
-  }
-
-  int i = moff;
-  out[i] = (in[i-w1-1] | in[i-w1] | in[i-w1+1] |
-         in[i-1]    | in[i]    | in[i+1] |
-         in[i+w1-1] | in[i+w1] | in[i+w1+1] |
-         in[i-w2-1] | in[i-w2] | in[i-w2+1] |
-         in[i-w1-2] | in[i-w1+2] | in[i-2]    | in[i+2] | in[i+w1-2] | in[i+w1+2] |
-         in[i+w2-1] | in[i+w2]   | in[i+w2+1] |
-         in[i-w3-2] | in[i-w3-1] | in[i-w3] | in[i-w3+1] | in[i-w3+2] |
-         in[i-w2-3] | in[i-w2-2] | in[i-w2+2] | in[i-w2+3] |
-         in[i-w1-3] | in[i-w1+3] | in[i-3] | in[i+3] | in[i+w1-3] | in[i+w1+3] |
-         in[i+w2-3] | in[i+w2-2] | in[i+w2+2] | in[i+w2+3] |
-         in[i+w3-2] | in[i+w3-1] | in[i+w3] | in[i+w3+1] | in[i+w3+2]) ? 1 : 0;
-
-  i = msize + moff;
-  out[i] = (in[i-w1-1] | in[i-w1] | in[i-w1+1] |
-         in[i-1]    | in[i]    | in[i+1] |
-         in[i+w1-1] | in[i+w1] | in[i+w1+1] |
-         in[i-w2-1] | in[i-w2] | in[i-w2+1] |
-         in[i-w1-2] | in[i-w1+2] | in[i-2]    | in[i+2] | in[i+w1-2] | in[i+w1+2] |
-         in[i+w2-1] | in[i+w2]   | in[i+w2+1] |
-         in[i-w3-2] | in[i-w3-1] | in[i-w3] | in[i-w3+1] | in[i-w3+2] |
-         in[i-w2-3] | in[i-w2-2] | in[i-w2+2] | in[i-w2+3] |
-         in[i-w1-3] | in[i-w1+3] | in[i-3] | in[i+3] | in[i+w1-3] | in[i+w1+3] |
-         in[i+w2-3] | in[i+w2-2] | in[i+w2+2] | in[i+w2+3] |
-         in[i+w3-2] | in[i+w3-1] | in[i+w3] | in[i+w3+1] | in[i+w3+2]) ? 1 : 0;
-
-  i = 2*msize + moff;
-  out[i] = (in[i-w1-1] | in[i-w1] | in[i-w1+1] |
-         in[i-1]    | in[i]    | in[i+1] |
-         in[i+w1-1] | in[i+w1] | in[i+w1+1] |
-         in[i-w2-1] | in[i-w2] | in[i-w2+1] |
-         in[i-w1-2] | in[i-w1+2] | in[i-2]    | in[i+2] | in[i+w1-2] | in[i+w1+2] |
-         in[i+w2-1] | in[i+w2]   | in[i+w2+1] |
-         in[i-w3-2] | in[i-w3-1] | in[i-w3] | in[i-w3+1] | in[i-w3+2] |
-         in[i-w2-3] | in[i-w2-2] | in[i-w2+2] | in[i-w2+3] |
-         in[i-w1-3] | in[i-w1+3] | in[i-3] | in[i+3] | in[i+w1-3] | in[i+w1+3] |
-         in[i+w2-3] | in[i+w2-2] | in[i+w2+2] | in[i+w2+3] |
-         in[i+w3-2] | in[i+w3-1] | in[i+w3] | in[i+w3+1] | in[i+w3+2]) ? 1 : 0;
+  out[mx] =         safe ? _mask_dilated(in + mx, mwidth)           : in[mx];
+  out[mx+msize] =   safe ? _mask_dilated(in + mx + msize, mwidth)   : in[mx + msize];
+  out[mx+2*msize] = safe ? _mask_dilated(in + mx + 2*msize, mwidth) : in[mx + 2*msize];
 }
 
-
-kernel void highlights_chroma(
-        read_only image2d_t in,
-        global char *mask,
-        global float *accu,
-        const int width,
-        const int height,
-        const int msize,
-        const int mwidth,
-        const unsigned int filters,
-        global const unsigned char (*const xtrans)[6],
-        global const float *clips,
-        global const float *correction)
+kernel void highlights_chroma(read_only image2d_t in,
+                              global char *mask,
+                              global float *accu,
+                              const int width,
+                              const int height,
+                              const int msize,
+                              const int mwidth,
+                              const unsigned int filters,
+                              global const unsigned char (*const xtrans)[6],
+                              global const float *clips,
+                              global const float *correction)
 {
   const int row = get_global_id(0);
-
-  if((row < 3) || (row > height - 4)) return;
+  if(row >= height) return;
 
   float sum[4] = {0.0f, 0.0f, 0.0f, 0.0f};
   float cnt[4] = {0.0f, 0.0f, 0.0f, 0.0f};
 
   float clipped = 0.0f;
-  for(int col = 3; col < width-4; col++)
+  for(int col = 0; col < width; col++)
   {
     const int idx = mad24(row, width, col);
     const int color = fcol(row, col, filters, xtrans);
@@ -509,37 +465,33 @@ kernel void highlights_chroma(
 
   for(int c = 0; c < 3; c++)
   {
-    if(cnt[c] > 0.0f)
-    {
-      accu[row*8 + 2*c] = sum[c];
-      accu[row*8 + 2*c +1] = cnt[c];
-    }
+    accu[row*8 + 2*c] = sum[c];
+    accu[row*8 + 2*c +1] = cnt[c];
   }
   accu[row*8 + 6] = clipped;
 }
 
-kernel void highlights_opposed(
-        read_only image2d_t in,
-        write_only image2d_t out,
-        const int owidth,
-        const int oheight,
-        const int iwidth,
-        const int iheight,
-        const int dx,
-        const int dy,
-        const unsigned int filters,
-        global const unsigned char (*const xtrans)[6],
-        global const float *clips,
-        global const float *chroma,
-        global const float *correction,
-        const int fastcopymode)
+kernel void highlights_opposed(read_only image2d_t in,
+                               write_only image2d_t out,
+                               const int owidth,
+                               const int oheight,
+                               const int iwidth,
+                               const int iheight,
+                               const int dx,
+                               const int dy,
+                               const unsigned int filters,
+                               global const unsigned char (*const xtrans)[6],
+                               global const float *clips,
+                               global const float *chroma,
+                               global const float *correction,
+                               const int fastcopymode)
 {
   const int x = get_global_id(0);
   const int y = get_global_id(1);
   if(x >= owidth || y >= oheight) return;
 
-  const int irow = y + dy;
-  const int icol = x + dx;
+  int irow = y + dy;
+  int icol = x + dx;
   float val = 0.0f;
 
   if((icol >= 0) && (icol < iwidth) && (irow >= 0) && (irow < iheight))
@@ -582,7 +534,7 @@ highlights_1f_lch_bayer (read_only image2d_t in, write_only image2d_t out, const
   {
     for(int ii = 0; ii <= 1; ii++)
     {
-      const float val = read_imagef(in, sampleri, (int2)(x+ii, y+jj)).x;
+      const float val = readsingle(in, x+ii, y+jj);
 
       pixel = (ii == 0 && jj == 0) ? val : pixel;
 
@@ -680,7 +632,7 @@ highlights_1f_lch_xtrans (read_only image2d_t in, write_only image2d_t out, cons
     if(bufidx >= maxbuf) continue;
     const int xx = xul + bufidx % stride;
     const int yy = yul + bufidx / stride;
-    buffer[bufidx] = fmax(0.0f, read_imagef(in, sampleri, (int2)(xx, yy)).x);
+    buffer[bufidx] = readsingle(in, xx, yy);
   }
 
   // center buffer around current x,y-Pixel

--- a/src/iop/hlreconstruct/opposed.c
+++ b/src/iop/hlreconstruct/opposed.c
@@ -244,7 +244,7 @@ static float *_process_opposed(dt_iop_module_t *self,
 
   const size_t mwidth  = roi_in->width / 3;
   const size_t mheight = roi_in->height / 3;
-  const size_t msize = dt_round_size((size_t) (mwidth+1) * (mheight+1), 16);
+  const size_t msize = dt_round_size((size_t) mwidth * mheight, 16);
 
   const dt_hash_t opphash = _opposed_hash(piece);
   dt_aligned_pixel_t chrominance = {0.0f, 0.0f, 0.0f, 0.0f};
@@ -266,26 +266,25 @@ static float *_process_opposed(dt_iop_module_t *self,
     {
       gboolean anyclipped = FALSE;
       DT_OMP_FOR(reduction( | : anyclipped) collapse(2))
-      for(int mrow = 1; mrow < mheight-1; mrow++)
+      for(int mrow = 0; mrow < mheight-1; mrow++)
       {
-        for(int mcol = 1; mcol < mwidth-1; mcol++)
+        for(int mcol = 0; mcol < mwidth-1; mcol++)
         {
           char mbuff[3] = { 0, 0, 0 };
-          const size_t grp = 3 * (mrow * roi_in->width + mcol);
-          for(int y = -1; y < 2; y++)
+          for(int y = 0; y < 3; y++)
           {
-            for(int x = -1; x < 2; x++)
+            for(int x = 0; x < 3; x++)
             {
-              const size_t idx = grp + y * roi_in->width + x;
-              const int color = fcol(mrow+y, mcol+x, filters, xtrans);
+              const size_t idx = (3*mrow + y) * roi_in->width + 3*mcol + x;
+              const int color = fcol(3*mrow+y, 3*mcol+x, filters, xtrans);
               const gboolean clipped = input[idx] >= clips[color];
-              mbuff[color] += (clipped) ? 1 : 0;
+              mbuff[color] += clipped ? 1 : 0;
             }
           }
           for_three_channels(c)
           {
-            mask[c * msize + mrow * mwidth + mcol] = (mbuff[c]) ? 1 : 0;
-            anyclipped |= (mbuff[c]) ? 1 : 0;
+            mask[c * msize + mrow * mwidth + mcol] = mbuff[c] ? 1 : 0;
+            anyclipped |= mbuff[c] ? 1 : 0;
           }
         }
       }
@@ -301,23 +300,24 @@ static float *_process_opposed(dt_iop_module_t *self,
          If there are no clipped locations we keep the chrominance correction at 0 but make it valid
         */
         DT_OMP_FOR(collapse(2))
-        for(size_t row = 3; row < mheight - 3; row++)
+        for(size_t row = 0; row < mheight; row++)
         {
-          for(size_t col = 3; col < mwidth - 3; col++)
+          for(size_t col = 0; col < mwidth; col++)
           {
             const size_t mx = row * mwidth + col;
-            mask[3*msize + mx] = _mask_dilated(mask + mx, mwidth);
-            mask[4*msize + mx] = _mask_dilated(mask + msize + mx, mwidth);
-            mask[5*msize + mx] = _mask_dilated(mask + 2*msize + mx, mwidth);
+            const gboolean safe = col >= 3 && row >= 3 && col < mwidth - 4 && row < mheight - 4;
+            mask[3*msize + mx] = safe ? _mask_dilated(mask + mx, mwidth)          : mask[mx];
+            mask[4*msize + mx] = safe ? _mask_dilated(mask + msize + mx, mwidth)  : mask[mx + msize];
+            mask[5*msize + mx] = safe ? _mask_dilated(mask + 2*msize + mx, mwidth): mask[mx + 2*msize];
           }
         }
 
         const dt_aligned_pixel_t lo_clips = { 0.2f * clips[0], 0.2f * clips[1], 0.2f * clips[2], 1.0f };
-       /* After having the surrounding mask for each color channel we can calculate the chrominance corrections. */
+        /* After having the surrounding mask for each color channel we can calculate the chrominance corrections. */
         DT_OMP_FOR(reduction(+ : sums, cnts) collapse(2))
-        for(size_t row = 3; row < roi_in->height - 3; row++)
+        for(size_t row = 0; row < roi_in->height; row++)
         {
-          for(size_t col = 3; col < roi_in->width - 3; col++)
+          for(size_t col = 0; col < roi_in->width; col++)
           {
             const size_t idx = row * roi_in->width + col;
             const int color = fcol(row, col, filters, xtrans);
@@ -356,7 +356,7 @@ static float *_process_opposed(dt_iop_module_t *self,
     dt_free_align(mask);
   }
 
-  float *tmpout = (keep) ? dt_alloc_align_float(roi_in->width * roi_in->height) : NULL;
+  float *tmpout = keep ? dt_alloc_align_float(roi_in->width * roi_in->height) : NULL;
   if(tmpout)
   {
     DT_OMP_FOR(collapse(2))
@@ -366,7 +366,7 @@ static float *_process_opposed(dt_iop_module_t *self,
       {
         const size_t idx = row * roi_in->width + col;
         const int color = fcol(row, col, filters, xtrans);
-        const float inval = MAX(0.0f, input[idx]);
+        const float inval = input[idx];
         if(inval >= clips[color])
         {
           const float ref = _calc_refavg(input, xtrans, filters, row, col, roi_in, correction, TRUE);
@@ -395,7 +395,7 @@ static float *_process_opposed(dt_iop_module_t *self,
         else
         {
           const int color = fcol(irow, icol, filters, xtrans);
-          oval = MAX(0.0f, input[ix]);
+          oval = input[ix];
           if(oval >= clips[color])
           {
             const float ref = _calc_refavg(input, xtrans, filters, irow, icol, roi_in, correction, TRUE);
@@ -476,8 +476,8 @@ static cl_int process_opposed_cl(dt_iop_module_t *self,
     // We don't have valid chrominance correction so go the hard way
     const int mwidth  = roi_in->width / 3;
     const int mheight = roi_in->height / 3;
-    const int msize = dt_round_size((size_t) (mwidth+1) * (mheight+1), 4);
-    const size_t mbufsize = 4 * dt_round_size(msize, DT_CACHELINE_BYTES);
+    const int msize = dt_round_size((size_t) mwidth * mheight, 16);
+    const size_t mbufsize = sizeof(float) * msize;
 
     dev_inmask = dt_opencl_alloc_device_buffer(devid, mbufsize);
     if(dev_inmask == NULL) goto error;
@@ -498,20 +498,17 @@ static cl_int process_opposed_cl(dt_iop_module_t *self,
     if(err != CL_SUCCESS) goto error;
 
     err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
-    const size_t accu_floats = 8 * dt_round_size((size_t)roi_in->height, DT_CACHELINE_BYTES);
+    const size_t accu_floats = 8 * roi_in->height;
     const size_t accusize = sizeof(float) * accu_floats;
     dev_accu = dt_opencl_alloc_device_buffer(devid, accusize);
     if(dev_accu == NULL) goto error;
 
-    claccu = dt_calloc_align_float(accu_floats);
+    claccu = dt_alloc_align_float(accu_floats);
     if(claccu == NULL)
     {
       err = DT_OPENCL_SYSMEM_ALLOCATION;
       goto error;
     }
-
-    err = dt_opencl_write_buffer_to_device(devid, claccu, dev_accu, 0, accusize, CL_TRUE);
-    if(err != CL_SUCCESS) goto error;
 
     err = dt_opencl_enqueue_kernel_1d_args(devid, gd->kernel_highlights_chroma, roi_in->height,
             CLARG(dev_in), CLARG(dev_outmask), CLARG(dev_accu),
@@ -527,7 +524,7 @@ static cl_int process_opposed_cl(dt_iop_module_t *self,
     dt_aligned_pixel_t sums = { 0.0f, 0.0f, 0.0f};
     dt_aligned_pixel_t cnts = { 0.0f, 0.0f, 0.0f};
     float clipped = 0.0f;
-    for(int row = 3; row < roi_in->height - 4; row++)
+    for(int row = 0; row < roi_in->height; row++)
     {
       for_three_channels(c)
       {
@@ -553,8 +550,8 @@ static cl_int process_opposed_cl(dt_iop_module_t *self,
         chrominance[0], (int)cnts[0],
         chrominance[1], (int)cnts[1],
         chrominance[2], (int)cnts[2],
-        piece->pipe->type == DT_DEV_PIXELPIPE_FULL ? " saved" : "",
-        img_oppclipped ? "" : " unclipped");
+          piece->pipe->type == DT_DEV_PIXELPIPE_FULL ? " saved" : "",
+          img_oppclipped ? "" : " unclipped");
   }
 
   err = CL_MEM_OBJECT_ALLOCATION_FAILURE;


### PR DESCRIPTION
1. The mask locations for opposed highlights reconstruction now reflect exactly the 3x3 photosite area starting at pipe raw data 0/0. This
   - results in a slightly improved calculation of the global chrominance correction
   - allows simplifications when calculating buffer requirements
   - results in slightly better reconstructed data at border
2. deduplicated and fixed mask dilating OpenCL code.
3. As we correctly calculate chroma correcting data for accumulation in OpenCL path for all locations we can avoid writing a cleared accu buffer.
4. Fix CPU code wrongfully correcting data to be at least zero while doing opposed or Lch algorithms resulting in larger CPU/OpenCL diffs and possibly different demosaicer output.
5. Some further minor maintenance in kernels.

____________________________________________________________________________
Why is this desired?
1. As mentioned in above (4) the CPU code clipped negatives and pushed that up the pipe but handling negatives is absolutely the demosaicer's job. (they handle this different ...)
2. As a reminder: the data for chroma correction are calculated (per color channel) from color-corrected but still unclipped sensor data at locations very close (~12 photosites range) to the border clipped/unclipped. This analysis was suboptimal with subtly improved data especially at very smooth transitions like happening with blown-out sky. The new algorithm is more stable and with identical results for OpenCL / CPU. So also an improvement. Data differences are very small and will only be noticed with difficult situations. So nothing to worry about with current edits. People might notice more smooth transitions in blown out parts. 
____________________________________________________________________________
Attached current local master integration log
[master.log](https://github.com/user-attachments/files/26314598/master.log)
and what found with this commit
[opposed.log](https://github.com/user-attachments/files/26314607/opposed.log)

and a stripped down and commented diff of both.

@TurboGit - some comments about this PR.
1. I checked all new "regressions" and they are due to the fix and thus expected.
2. In some cases these "regressions" come with a big decrease of OpenCL / CPU diffs, also expected and desired like in 162, 163, 164 these are now stable, possibly the ref images should be updated and GPU/CPU diffs should be fixed.
3. In tests using opposed we see a number of decreases in diffs, also expected and confirming the new algo works as expected.

About the tests
1. I don't understand the results of 158, i guess it fails because of max dE ?
2. We always have a few diffs for CPU vs reference even with fresh refs. Do we still need some more specified confs? Or would we have to specify compiler instructions? I have no idea here ...
3. My system is pretty fast, if you want me to do full integration logs also with OpenCL regularly - let me know.

  

 