### PR TITLE
Fix crash in scalepixels when used with rotate-and-perspective module

### DIFF
--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -3482,7 +3482,7 @@ void process(dt_iop_module_t *self,
     dt_iop_gui_enter_critical_section(self);
     g->isflipped = isflipped;
 
-    const size_t requested_size = piece->buf_in.width * piece->buf_in.height;
+    const size_t requested_size = (size_t)roi_in->width * roi_in->height;
 
     // save a copy of preview input buffer for parameter fitting
     if(g->buf == NULL
@@ -3497,11 +3497,11 @@ void process(dt_iop_module_t *self,
 
     if(g->buf /* && hash != g->buf_hash */)
     {
-      // copy data; seems to be safe we don't care aboit roi_in here
+      // copy data using actual roi_in dimensions (can exceed buf_in when scale > 1.0)
       dt_iop_image_copy_by_size(g->buf, ivoid, roi_in->width, roi_in->height, ch);
 
-      g->buf_width = piece->buf_in.width;
-      g->buf_height = piece->buf_in.height;
+      g->buf_width = roi_in->width;
+      g->buf_height = roi_in->height;
       g->buf_x_off = roi_in->x;
       g->buf_y_off = roi_in->y;
       g->buf_scale = roi_in->scale;
@@ -3621,7 +3621,7 @@ int process_cl(dt_iop_module_t *self,
     dt_iop_gui_enter_critical_section(self);
     g->isflipped = isflipped;
 
-    const size_t requested_size = (size_t)piece->buf_in.width * piece->buf_in.height;
+    const size_t requested_size = (size_t)roi_in->width * roi_in->height;
 
     // save a copy of preview input buffer for parameter fitting
     if(g->buf == NULL || (size_t)g->buf_width * g->buf_height < requested_size)
@@ -3634,12 +3634,12 @@ int process_cl(dt_iop_module_t *self,
 
     if(g->buf /* && hash != g->buf_hash */)
     {
-      // copy data
+      // copy data using actual roi_in dimensions (can exceed buf_in when scale > 1.0)
       err = dt_opencl_copy_device_to_host(devid, g->buf, dev_in,
                                           roi_in->width, roi_in->height, sizeof(float) * 4);
 
-      g->buf_width = piece->buf_in.width;
-      g->buf_height = piece->buf_in.height;
+      g->buf_width = roi_in->width;
+      g->buf_height = roi_in->height;
       g->buf_x_off = roi_in->x;
       g->buf_y_off = roi_in->y;
       g->buf_scale = roi_in->scale;

--- a/src/iop/scalepixels.c
+++ b/src/iop/scalepixels.c
@@ -154,19 +154,24 @@ void distort_mask(dt_iop_module_t *self,
                   const dt_iop_roi_t *const roi_in,
                   const dt_iop_roi_t *const roi_out)
 {
-  const dt_iop_scalepixels_data_t * const d = piece->data;
   const dt_interpolation_t *iter = dt_interpolation_new(DT_INTERPOLATION_USERPREF_WARP);
   const int iw = roi_in->width;
   const int ih = roi_in->height;
   const size_t ow = roi_out->width;
+
+  // Compute scale factors locally from the actual roi_in/roi_out to ensure
+  // consistency, rather than relying on d->x_scale/d->y_scale which may have
+  // been overwritten by _precalculate_scale() with different ROI dimensions.
+  const float x_scale = (roi_in->width * 1.0f) / (roi_out->width * 1.0f);
+  const float y_scale = (roi_in->height * 1.0f) / (roi_out->height * 1.0f);
 
   DT_OMP_FOR(collapse(2))
   for(int row = 0; row < roi_out->height; row++)
   {
     for(int col = 0; col < roi_out->width; col++)
     {
-      const float x = col * d->x_scale;
-      const float y = row * d->y_scale;
+      const float x = col * x_scale;
+      const float y = row * y_scale;
       out[ow * row + col] = CLIP(dt_interpolation_compute_sample(iter, in, x, y, iw, ih, 1, iw));
     }
   }
@@ -221,7 +226,12 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
   const int ch = piece->colors;
   const int ch_width = ch * roi_in->width;
   const dt_interpolation_t *interpolation = dt_interpolation_new(DT_INTERPOLATION_USERPREF);
-  const dt_iop_scalepixels_data_t * const d = piece->data;
+
+  // Compute scale factors locally from the actual roi_in/roi_out to ensure
+  // consistency, rather than relying on d->x_scale/d->y_scale which may have
+  // been overwritten by _precalculate_scale() with different ROI dimensions.
+  const float x_scale = (roi_in->width * 1.0f) / (roi_out->width * 1.0f);
+  const float y_scale = (roi_in->height * 1.0f) / (roi_out->height * 1.0f);
 
   DT_OMP_FOR()
   // (slow) point-by-point transformation.
@@ -231,8 +241,8 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
     float *out = ((float *)ovoid) + (size_t)4 * j * roi_out->width;
     for(int i = 0; i < roi_out->width; i++, out += 4)
     {
-      const float x = i*d->x_scale;
-      const float y = j*d->y_scale;
+      const float x = i * x_scale;
+      const float y = j * y_scale;
       dt_interpolation_compute_pixel4c(interpolation, (float *)ivoid, out, x, y, roi_in->width,
                                        roi_in->height, ch_width);
     }


### PR DESCRIPTION
* Compute `x_scale`/`y_scale` locally in `process()` from actual `roi_in`/`roi_out` instead of using `d->x_scale`/`d->y_scale` which can be overwritten by `precalculate_scale()` called from `distort_transform`/`distort_backtransform` with different ROI dimensions, causing out-of-bounds interpolation access.

* Implement `distort_mask()` enabling masks to work correctly when module is at non-standard pipeline position.

* Fix buffer overflow in (ashift.c) `g->buf` allocation: the buffer was allocated using `piece->buf_in.width * piece->buf_in.height` but then filled with `roi_in->width * roi_in->height * 4 floats`. When `roi_in->scale > 1.0` (zoomed in), `roi_in` dimensions exceed `buf_in`, causing a write past the end of the buffer. Fixed in both the CPU path (`process()`) and OpenCL path (`process_cl()`) by changing `requested_size`, `g->buf_width`, and `g->buf_height` to use `roi_in` dimensions instead of `piece->buf_in`.

Fixes #17286

Disclaimer: co-created with Claude.