### PR TITLE
Lua - force writing of cache after mipmap generation

### DIFF
--- a/src/lua/image.c
+++ b/src/lua/image.c
@@ -152,6 +152,8 @@ static int generate_cache(lua_State *L)
     dt_mipmap_cache_get(&buf, imgid, k, DT_MIPMAP_BLOCKING, 'r');
     dt_mipmap_cache_release(&buf);
   }
+  // ensure mipmap written to disk
+  dt_mipmap_cache_evict(imgid);
   // thumbnail in sync with image
   dt_history_hash_set_mipmap(imgid);
 


### PR DESCRIPTION
`dt_lua_image_t:generate_cache()` now forces the created mipmap to be written to disk so that it's available when darktable restarts.

Fixes #20715