### PR TITLE
print on mac os: fix double color management when using printer ICC profiles

### DIFF
--- a/src/common/cups_print.c
+++ b/src/common/cups_print.c
@@ -547,11 +547,35 @@ void dt_print_file(const dt_imgid_t imgid,
 
     cupsFreeDests(num_dests, dests);
 
-    // if we have a profile, disable cm on CUPS, this is important as dt does the cm
+    // When a printer ICC profile is selected, tell CUPS to skip its
+    // own color management — darktable already did the conversion
+    // via LittleCMS, and the ICC profile is embedded in the PDF.
+    //
+    // Linux: cm-calibration=true causes pdftoraster to set cm_disabled=1,
+    //        skipping its own color management.
+    //
+    // macOS: cgpdftoraster ignores cm-calibration. Instead we send
+    //        AP_ColorMatchingMode=AP_ApplicationColorMatching which
+    //        tells both cgpdftoraster and the printer driver that the
+    //        application already handled color matching.
 
     num_options = cupsAddOption("cm-calibration",
                                 *pinfo->printer.profile ? "true" : "false",
                                 num_options, &options);
+
+#ifdef __APPLE__
+    if(*pinfo->printer.profile)
+    {
+      // dot-notation variant appears to be legacy but is observed in
+      // print jobs from other macOS applications
+      num_options = cupsAddOption("AP.ColorMatchingMode",
+                                  "AP_ApplicationColorMatching",
+                                  num_options, &options);
+      num_options = cupsAddOption("AP_ColorMatchingMode",
+                                  "AP_ApplicationColorMatching",
+                                  num_options, &options);
+    }
+#endif
 
     // media to print on
 

--- a/src/libs/print_settings.c
+++ b/src/libs/print_settings.c
@@ -445,7 +445,7 @@ static void _create_pdf(dt_job_t *job,
 
   const float page_width  = dt_pdf_mm_to_point(width);
   const float page_height = dt_pdf_mm_to_point(height);
-  const int icc_id = 0;
+  int icc_id = 0;
 
   dt_pdf_image_t *pdf_image[MAX_IMAGE_PER_PAGE];
 
@@ -454,11 +454,19 @@ static void _create_pdf(dt_job_t *job,
                                params->prt.printer.resolution,
                                DT_PDF_STREAM_ENCODER_FLATE);
 
-/*
-  // ??? should a profile be embedded here?
-  if(*printer_profile)
-    icc_id = dt_pdf_add_icc(pdf, printer_profile);
-*/
+#ifdef __APPLE__
+  // On macOS, embed the printer ICC profile in the PDF so the
+  // already-converted pixel data is correctly tagged with its actual
+  // color space. Without this, cgpdftoraster assumes DeviceRGB = sRGB
+  // and misinterprets the data.
+  //
+  // On Linux this must NOT be done — Poppler (inside pdftoraster) would
+  // see the ICCBased color space and convert the data back to sRGB,
+  // undoing the LittleCMS conversion. Linux uses cm-calibration instead.
+  if(params->p_icc_profile && *params->p_icc_profile)
+    icc_id = dt_pdf_add_icc(pdf, params->p_icc_profile);
+#endif
+
   int32_t count = 0;
 
   for(int k=0; k<imgs.count; k++)
@@ -778,6 +786,13 @@ static void _print_button_clicked(GtkWidget *widget, dt_lib_module_t *self)
   params->p_icc_profile = g_strdup(ps->v_piccprofile);
   params->p_icc_intent = ps->v_pintent;
   params->black_point_compensation = ps->v_black_point_compensation;
+
+  // Propagate the printer profile selection so dt_print_file() can
+  // tell CUPS to skip color management when dt already did the
+  // ICC conversion. See cups_print.c for platform-specific details.
+  if(ps->v_piccprofile && *ps->v_piccprofile)
+    g_strlcpy(params->prt.printer.profile, ps->v_piccprofile,
+              sizeof(params->prt.printer.profile));
 
   dt_control_add_job(DT_JOB_QUEUE_USER_EXPORT, job);
 }


### PR DESCRIPTION
When a printer ICC profile is selected, darktable applies the color conversion via LittleCMS but then fails to communicate this to the downstream CUPS pipeline, causing double color management:

1. The printer.profile field on the print info struct was never populated from the user's profile selection, so the cm-calibration CUPS option was always set to "false". This meant the CUPS pdftoraster filter (Linux) would re-apply color management to already-converted data. Fixed by propagating the profile selection into printer.profile before calling dt_print_file().  For users using TurboPrint for ICC profiles, this remains 'false' if no ICC profile is selected.   @TurboGit - if you're still active, please chime in if this doesn't match your understanding.  However, I don't use Darktable on Linux at the moment, so I don't have great ways of testing this.  I am not totally sure of this fix, but I believe it is directionally correct towards telling CUPS that the embedded pixel data has already been converted.

2. On macOS, Apple's cgpdftoraster filter ignores cm-calibration entirely. It reads the PDF color space metadata and assumes DeviceRGB means sRGB, then converts via ColorSync. The printer ICC profile was never embedded in the generated PDF (code existed but was commented out with a "???" note since 2015). Fixed by embedding the profile via dt_pdf_add_icc() so cgpdftoraster recognizes the actual color space.

---

#### Test Prints (macos)

* **TOP** - Darktable WITH this patch applied
* **MIDDLE** - CaptureOne using the same ICC profile.  Conversion done via ColorSync within CaptureOne.
* **BOTTOM** - Darktable WITHOUT this patch applied.

I have been printing for a while _with_ CaptureOne and I believe the results are good enough to benchmark against, and with this patch, the Darktable prints now match CaptureOne.

![dt-print-icc-fixes](https://github.com/user-attachments/assets/3e396694-8e9a-4dba-832f-44ec123d21a8)
