### PR TITLE
Fix OpenCL lookup gamut

### DIFF
--- a/data/kernels/colorspace.h
+++ b/data/kernels/colorspace.h
@@ -952,9 +952,10 @@ static inline float soft_clip(const float x, const float soft_threshold, const f
 
 static inline float lookup_gamut(global const float *gamut_lut, const float x)
 {
+
   // Linearly interpolate the value of the gamut LUT at the hue angle in radians.
   // convert in LUT coordinate
-  const float x_test = (LUT_ELEM - 1) * (x + M_PI_F) / (2.f * M_PI_F);
+  const float x_test = (float)LUT_ELEM * (x + M_PI_F) / (2.f * M_PI_F);
 
   // find the 2 closest integer coordinates (next/previous)
   const float x_prev = floor(x_test);

--- a/data/kernels/extended.cl
+++ b/data/kernels/extended.cl
@@ -770,7 +770,7 @@ colorbalancergb (read_only image2d_t in, write_only image2d_t out,
   const int y = get_global_id(1);
   if(x >= width || y >= height) return;
   // we clip pipeline RGB while reading; this also ensures a proper alpha
-  const float4 pix_in = fmax(0.0f, read_imagef(in, sampleri, (int2)(x, y)));
+  float4 pix_in = fmax(0.0f, readpixel(in, x, y));
 
   float4 XYZ_D65 = 0.f;
   float4 LMS = 0.f;
@@ -802,7 +802,7 @@ colorbalancergb (read_only image2d_t in, write_only image2d_t out,
   Ych.z = hue_rotation_matrix[0] * cos_h + hue_rotation_matrix[1] * sin_h;
   Ych.w = hue_rotation_matrix[2] * cos_h + hue_rotation_matrix[3] * sin_h;
 
-  // Linear chroma : distance to achromatic at constant luminance in scene-referred
+  // Linear chroma : distance to achromatic at constant luminance in scene-referred
   const float chroma_boost = chroma_global + dot(opacities, chroma);
   const float vib = vibrance * (1.0f - dtcl_pow(Ych.y, fabs(vibrance)));
   const float chroma_factor = fmax(1.f + chroma_boost + vib, 0.f);
@@ -962,7 +962,7 @@ colorbalancergb (read_only image2d_t in, write_only image2d_t out,
     JCH = dt_UCS_HCB_to_JCH(HCB);
 
     // Gamut mapping
-    const float max_colorfulness = lookup_gamut(gamut_lut, JCH.z); // WARNING : this is M²
+    const float max_colorfulness = lookup_gamut(gamut_lut, JCH.z); // WARNING : this is M²
     const float max_chroma = 15.932993652962535f * dtcl_pow(JCH.x * L_white, 0.6523997524738018f) * dtcl_pow(max_colorfulness, 0.6007557017508491f) / L_white;
     const float4 JCH_gamut_boundary = { JCH.x, max_chroma, JCH.z, 0.f };
     const float4 HSB_gamut_boundary = dt_UCS_JCH_to_HSB(JCH_gamut_boundary);


### PR DESCRIPTION
OpenCL vs CPU diffs due to different lookup_gamut code have been fixed. colorbalancergb and colorequalizer modules were affected.

@TurboGit large diffs for 0083 0093 0158 0159 0161 0167 should be updated, the UCS related big problems in coloreq in colorbalancergb-ucs are gone.