### PR TITLE
Fix OpenCL kernel compilation

### DIFF
--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -981,31 +981,15 @@ static gboolean _opencl_device_init(dt_opencl_t *cl,
   escapedkerneldir = dt_util_str_replace(kerneldir, " ", "\\ ");
 #endif
 
-  gchar* compile_option_name_cname =
-    g_strdup_printf("%s%s_building", DT_CLDEVICE_HEAD, cl->dev[dev].cname);
-  const char* compile_opt = NULL;
-
-  if(dt_conf_key_exists(compile_option_name_cname)
-     && (dt_conf_get_int("performance_configuration_version_completed") > 17))
-    compile_opt = dt_conf_get_string_const(compile_option_name_cname);
-  else
-    compile_opt = dt_conf_get_bool("opencl_fast") ? DT_OPENCL_DEFAULT_COMPILE_OPTI : DT_OPENCL_DEFAULT_COMPILE_DEFAULT;
-
-  gchar *my_option = g_strdup(compile_opt);
-  dt_conf_set_string(compile_option_name_cname, my_option);
-
+  const char* compile_opt = dt_conf_get_bool("opencl_fast") ? DT_OPENCL_DEFAULT_COMPILE_OPTI : DT_OPENCL_DEFAULT_COMPILE_DEFAULT;
   cl->dev[dev].cflags = g_strdup_printf("-w %s%s -D%s=1",
-                                my_option,
+                                compile_opt,
                                 cl->dev[dev].cuda && cl->dev[dev].atomic_support ? " -DNVIDIA_SM_20=1" : "",
                                 _opencl_get_vendor_by_id(vendor_id));
   cl->dev[dev].options = g_strdup_printf("%s -I%s",
                              cl->dev[dev].cflags, escapedkerneldir);
 
-  dt_print_nts(DT_DEBUG_OPENCL, "   CL COMPILER OPTION:       %s\n", my_option);
   dt_print_nts(DT_DEBUG_OPENCL, "   CL COMPILER COMMAND:      %s\n", cl->dev[dev].options);
-
-  g_free(compile_option_name_cname);
-  g_free(my_option);
   g_free(escapedkerneldir);
   escapedkerneldir = NULL;
 
@@ -1015,6 +999,7 @@ static gboolean _opencl_device_init(dt_opencl_t *cl,
                                                      "colorspaces.cl",
                                                      "colorspace.h",
                                                      "common.h",
+                                                     "guided_filter.cl",
                                                      NULL };
 
   char *includemd5[DT_OPENCL_MAX_INCLUDES] = { NULL };

--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2010-2025 darktable developers.
+    Copyright (C) 2010-2026 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -24,7 +24,7 @@
 #define DT_OPENCL_EVENTLISTSIZE 256
 #define DT_OPENCL_EVENTNAMELENGTH 64
 #define DT_OPENCL_MAX_ERRORS 5
-#define DT_OPENCL_MAX_INCLUDES 7
+#define DT_OPENCL_MAX_INCLUDES 8
 #define DT_OPENCL_VENDOR_AMD 4098
 #define DT_OPENCL_VENDOR_NVIDIA 4318
 #define DT_OPENCL_VENDOR_APPLE 16940800
@@ -72,9 +72,7 @@ G_BEGIN_DECLS
 #define DT_OPENCL_DEFAULT_COMPILE_OPTI ("-cl-fast-relaxed-math")
 #define DT_CLDEVICE_HEAD ("cldevice_v6_")
 
-// version for current darktable cl kernels
-// this is reflected in the kernel directory and allows to
-// enforce a new kernel compilation cycle
+// version for current darktable cl kernels reflected in the kernel directory
 #define DT_OPENCL_KERNELS 6
 
 typedef enum dt_opencl_memory_t


### PR DESCRIPTION
Remove usage of a string conf setting for OpenCL compilation flags. This is solely set by conf "opencl_fast".
Removed redundant log line.