### PR TITLE
[AI] Fix auto-downloaded ORT not found

### DIFF
--- a/src/ai/backend_onnx.c
+++ b/src/ai/backend_onnx.c
@@ -347,6 +347,20 @@ static gpointer _init_ort_api(gpointer data)
     GModule *ort_mod = g_module_open(ORT_LIBRARY_PATH, G_MODULE_BIND_LAZY);
     _stderr_suppress_end(saved);
 
+    // If the linker can't find it by name alone (e.g. custom install prefix
+    // like /opt/darktable), try the darktable plugin directory where cmake
+    // installs the bundled ORT alongside other libraries.
+    if(!ort_mod && darktable.plugindir)
+    {
+      gchar *bundled = g_build_filename(darktable.plugindir, ORT_LIBRARY_PATH, NULL);
+      const int saved2 = _stderr_suppress_begin();
+      ort_mod = g_module_open(bundled, G_MODULE_BIND_LAZY);
+      _stderr_suppress_end(saved2);
+      if(ort_mod)
+        dt_print(DT_DEBUG_AI, "[darktable_ai] loaded ORT from plugindir: %s", bundled);
+      g_free(bundled);
+    }
+
     if(!ort_mod)
     {
       dt_print(DT_DEBUG_AI,


### PR DESCRIPTION
Fixes #20730

## Summary

When darktable is built with auto-downloaded ONNX Runtime (no system `libonnxruntime-dev` package) and installed to a custom prefix (e.g. `/opt/darktable`), the bundled ORT library is not found at runtime.

## Root cause

cmake installs the auto-downloaded ORT to `lib/darktable/` alongside plugins and other darktable libraries. At runtime, `g_module_open("libonnxruntime.so.1.24.4")` resolves via the dynamic linker, which only searches standard paths (`/usr/lib`, `/usr/local/lib`, `LD_LIBRARY_PATH`). Custom prefixes like `/opt/darktable/lib/darktable/` are not in this search path.

Note: this only affects auto-downloaded ORT. System packages (`sudo apt install libonnxruntime-dev`) install to `/usr/lib/` which the linker finds automatically.

## Fix

Add a fallback in `_init_ort_api()`: if the linker can't resolve the library by name, try loading from `darktable.plugindir` - the same directory where cmake installed it.

Loading order:
1. Config preference (`plugins/ai/ort_library_path`) or `DT_ORT_LIBRARY` env var
2. System linker search (`g_module_open` by filename)
3. **New:** darktable plugin directory fallback
4. Error if all fail

## Workarounds (before this fix)

- Install system package: `sudo apt install libonnxruntime-dev` (Ubuntu 24.10+)
- Set the path manually in preferences → AI → ONNX Runtime library
- Set `LD_LIBRARY_PATH=/opt/darktable/lib/darktable`