### PR TITLE
[AI] Add model update check and preferences UI improvements

### DIFF
--- a/src/common/ai_models.c
+++ b/src/common/ai_models.c
@@ -788,6 +788,140 @@ void dt_ai_models_refresh_status(dt_ai_registry_t *registry)
   g_mutex_unlock(&registry->lock);
 }
 
+void dt_ai_models_check_updates(dt_ai_registry_t *registry)
+{
+  if(!registry) return;
+
+  // only check once per session
+  g_mutex_lock(&registry->lock);
+  if(registry->updates_checked)
+  {
+    g_mutex_unlock(&registry->lock);
+    return;
+  }
+  registry->updates_checked = TRUE;
+  const char *repository = g_strdup(registry->repository);
+  g_mutex_unlock(&registry->lock);
+
+  if(!repository || !repository[0])
+  {
+    g_free((char *)repository);
+    return;
+  }
+
+  // find the latest compatible release tag
+  char *error_msg = NULL;
+  char *release_tag
+    = _find_latest_compatible_release(repository, &error_msg);
+  if(!release_tag)
+  {
+    dt_print(DT_DEBUG_AI,
+             "[ai_models] check_updates: no compatible release found%s%s",
+             error_msg ? ": " : "", error_msg ? error_msg : "");
+    g_free(error_msg);
+    g_free((char *)repository);
+    return;
+  }
+  g_free(error_msg);
+
+  // fetch versions.json from the release
+  char *url = g_strdup_printf(
+    "https://github.com/%s/releases/download/%s/versions.json",
+    repository, release_tag);
+
+  CURL *curl = curl_easy_init();
+  if(!curl)
+  {
+    g_free(url);
+    g_free(release_tag);
+    g_free((char *)repository);
+    return;
+  }
+  dt_curl_init(curl, FALSE);
+
+  GString *response = g_string_new(NULL);
+  curl_easy_setopt(curl, CURLOPT_URL, url);
+  curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, _curl_write_string);
+  curl_easy_setopt(curl, CURLOPT_WRITEDATA, response);
+  curl_easy_setopt(curl, CURLOPT_TIMEOUT, 15L);
+  curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
+
+  CURLcode res = curl_easy_perform(curl);
+  long http_code = 0;
+  curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code);
+  curl_easy_cleanup(curl);
+  g_free(url);
+  g_free(release_tag);
+  g_free((char *)repository);
+
+  if(res != CURLE_OK || http_code != 200)
+  {
+    dt_print(DT_DEBUG_AI,
+             "[ai_models] check_updates: failed to fetch versions.json"
+             " (curl=%d, http=%ld)",
+             res, http_code);
+    g_string_free(response, TRUE);
+    return;
+  }
+
+  // parse versions.json
+  JsonParser *parser = json_parser_new();
+  if(!json_parser_load_from_data(parser, response->str,
+                                 response->len, NULL))
+  {
+    g_object_unref(parser);
+    g_string_free(response, TRUE);
+    dt_print(DT_DEBUG_AI,
+             "[ai_models] check_updates: failed to parse versions.json");
+    return;
+  }
+  g_string_free(response, TRUE);
+
+  JsonNode *root = json_parser_get_root(parser);
+  JsonObject *root_obj = json_node_get_object(root);
+  JsonObject *models_obj
+    = json_object_has_member(root_obj, "models")
+      ? json_object_get_object_member(root_obj, "models")
+      : NULL;
+
+  if(!models_obj)
+  {
+    g_object_unref(parser);
+    dt_print(DT_DEBUG_AI,
+             "[ai_models] check_updates: no 'models' object in "
+             "versions.json");
+    return;
+  }
+
+  // compare remote versions with installed versions
+  g_mutex_lock(&registry->lock);
+  for(GList *l = registry->models; l; l = g_list_next(l))
+  {
+    dt_ai_model_t *model = (dt_ai_model_t *)l->data;
+    if(model->status != DT_AI_MODEL_DOWNLOADED)
+      continue;
+
+    if(!json_object_has_member(models_obj, model->id))
+      continue;
+
+    const char *remote_version
+      = json_object_get_string_member(models_obj, model->id);
+    if(!remote_version) continue;
+
+    if(_version_compare(model->version, remote_version) < 0)
+    {
+      model->status = DT_AI_MODEL_UPDATE_AVAILABLE;
+      dt_print(DT_DEBUG_AI,
+               "[ai_models] update available for %s: v%s -> v%s",
+               model->id,
+               model->version ? model->version : "?",
+               remote_version);
+    }
+  }
+  g_mutex_unlock(&registry->lock);
+  g_object_unref(parser);
+}
+
 void dt_ai_models_cleanup(dt_ai_registry_t *registry)
 {
   if(!registry)

--- a/src/common/ai_models.h
+++ b/src/common/ai_models.h
@@ -38,6 +38,7 @@ typedef enum dt_ai_model_status_t
   DT_AI_MODEL_NOT_DOWNLOADED = 0,
   DT_AI_MODEL_DOWNLOADING,
   DT_AI_MODEL_DOWNLOADED,
+  DT_AI_MODEL_UPDATE_AVAILABLE,
   DT_AI_MODEL_UPDATE_REQUIRED,
   DT_AI_MODEL_ERROR,
 } dt_ai_model_status_t;
@@ -77,13 +78,14 @@ typedef void (*dt_ai_progress_callback)(const char *model_id,
  */
 typedef struct dt_ai_registry_t
 {
-  GList *models;           // List of dt_ai_model_t*
-  char *repository;        // GitHub repository (e.g. "darktable-org/darktable-ai")
-  char *models_dir;        // Path to user's models directory
-  char *cache_dir;         // Path to download cache directory
-  gboolean ai_enabled;     // Global AI enable/disable
+  GList *models;              // List of dt_ai_model_t*
+  char *repository;           // GitHub repository (e.g. "darktable-org/darktable-ai")
+  char *models_dir;           // Path to user's models directory
+  char *cache_dir;            // Path to download cache directory
+  gboolean ai_enabled;        // Global AI enable/disable
   dt_ai_provider_t provider;  // Selected execution provider
-  GMutex lock;             // Thread safety for registry access
+  gboolean updates_checked;   // TRUE after first check_updates call
+  GMutex lock;                // Thread safety for registry access
 } dt_ai_registry_t;
 
 // --- Core API ---
@@ -121,6 +123,15 @@ void dt_ai_models_init_lazy(dt_ai_registry_t *registry);
  * @param registry The registry to update
  */
 void dt_ai_models_refresh_status(dt_ai_registry_t *registry);
+
+/**
+ * @brief Check for model updates by fetching versions.json from the
+ *        remote repository. Sets DT_AI_MODEL_UPDATE_AVAILABLE on
+ *        models where a newer version exists but the installed
+ *        version still meets min_version
+ * @param registry The registry to update
+ */
+void dt_ai_models_check_updates(dt_ai_registry_t *registry);
 
 /**
  * @brief Clean up and free the registry

--- a/src/gui/preferences_ai.c
+++ b/src/gui/preferences_ai.c
@@ -155,6 +155,8 @@ static const char *_status_to_string(dt_ai_model_status_t status)
   {
   case DT_AI_MODEL_DOWNLOADED:
     return _("downloaded");
+  case DT_AI_MODEL_UPDATE_AVAILABLE:
+    return _("update available");
   case DT_AI_MODEL_UPDATE_REQUIRED:
     return _("update required");
   case DT_AI_MODEL_DOWNLOADING:
@@ -177,6 +179,7 @@ static void _refresh_model_list(dt_prefs_ai_data_t *data)
   gtk_list_store_clear(data->model_store);
 
   dt_ai_models_refresh_status(darktable.ai_registry);
+  dt_ai_models_check_updates(darktable.ai_registry);
 
   const int count = dt_ai_models_get_count(darktable.ai_registry);
   dt_print(DT_DEBUG_AI, "[preferences_ai] refreshing model list, count=%d", count);
@@ -194,7 +197,8 @@ static void _refresh_model_list(dt_prefs_ai_data_t *data)
       model->id ? model->id : "(null)");
 
     // check if this model is the active one for its task
-    const gboolean is_downloaded = (model->status == DT_AI_MODEL_DOWNLOADED);
+    const gboolean is_downloaded = (model->status == DT_AI_MODEL_DOWNLOADED
+                                    || model->status == DT_AI_MODEL_UPDATE_AVAILABLE);
     gboolean is_active = FALSE;
     if(model->task && model->task[0])
     {
@@ -226,6 +230,7 @@ static void _refresh_model_list(dt_prefs_ai_data_t *data)
       model->is_default ? _("yes") : _("no"),
       COL_VERSION,
       (model->status == DT_AI_MODEL_DOWNLOADED
+       || model->status == DT_AI_MODEL_UPDATE_AVAILABLE
        || model->status == DT_AI_MODEL_UPDATE_REQUIRED)
         ? (model->version ? model->version : "0.0") : "–",
       COL_ID,
@@ -696,6 +701,7 @@ static void _on_download_selected(GtkButton *button, gpointer user_data)
     if(model)
     {
       gboolean need_download = (model->status == DT_AI_MODEL_NOT_DOWNLOADED
+                                || model->status == DT_AI_MODEL_UPDATE_AVAILABLE
                                 || model->status == DT_AI_MODEL_UPDATE_REQUIRED);
       dt_ai_model_free(model);
       if(need_download && !_download_model_with_dialog(data, id))
@@ -720,6 +726,7 @@ static void _on_download_default(GtkButton *button, gpointer user_data)
     gboolean need_download
       = (model->is_default
          && (model->status == DT_AI_MODEL_NOT_DOWNLOADED
+             || model->status == DT_AI_MODEL_UPDATE_AVAILABLE
              || model->status == DT_AI_MODEL_UPDATE_REQUIRED));
     char *id = need_download ? g_strdup(model->id) : NULL;
     dt_ai_model_free(model);
@@ -748,6 +755,7 @@ static void _on_download_all(GtkButton *button, gpointer user_data)
     if(!model)
       continue;
     gboolean need_download = (model->status == DT_AI_MODEL_NOT_DOWNLOADED
+                              || model->status == DT_AI_MODEL_UPDATE_AVAILABLE
                               || model->status == DT_AI_MODEL_UPDATE_REQUIRED);
     char *id = need_download ? g_strdup(model->id) : NULL;
     dt_ai_model_free(model);
@@ -828,7 +836,8 @@ static void _on_delete_selected(GtkButton *button, gpointer user_data)
     dt_ai_model_t *model = dt_ai_models_get_by_id(darktable.ai_registry, id);
     if(model)
     {
-      if(model->status == DT_AI_MODEL_DOWNLOADED)
+      if(model->status == DT_AI_MODEL_DOWNLOADED
+         || model->status == DT_AI_MODEL_UPDATE_AVAILABLE)
       {
         to_delete = g_list_append(to_delete, g_strdup(id));
         delete_count++;
@@ -876,12 +885,6 @@ static void _on_delete_selected(GtkButton *button, gpointer user_data)
   }
 
   g_list_free_full(to_delete, g_free);
-}
-
-static void _on_refresh(GtkButton *button, gpointer user_data)
-{
-  dt_prefs_ai_data_t *data = (dt_prefs_ai_data_t *)user_data;
-  _refresh_model_list(data);
 }
 
 #if !defined(__APPLE__)
@@ -1421,6 +1424,8 @@ void init_tab_ai(GtkWidget *dialog, GtkWidget *stack)
 #ifdef HAVE_AI_DOWNLOAD
   // download selected button
   data->download_selected_btn = gtk_button_new_with_label(_("download selected"));
+  gtk_widget_set_tooltip_text(data->download_selected_btn,
+    _("download or update the selected models"));
   g_signal_connect(
     data->download_selected_btn,
     "clicked",
@@ -1430,6 +1435,8 @@ void init_tab_ai(GtkWidget *dialog, GtkWidget *stack)
 
   // download default button
   data->download_default_btn = gtk_button_new_with_label(_("download default"));
+  gtk_widget_set_tooltip_text(data->download_default_btn,
+    _("download or update all default models"));
   g_signal_connect(
     data->download_default_btn,
     "clicked",
@@ -1439,17 +1446,23 @@ void init_tab_ai(GtkWidget *dialog, GtkWidget *stack)
 
   // download all button
   data->download_all_btn = gtk_button_new_with_label(_("download all"));
+  gtk_widget_set_tooltip_text(data->download_all_btn,
+    _("download or update all available models"));
   g_signal_connect(data->download_all_btn, "clicked", G_CALLBACK(_on_download_all), data);
   dt_gui_box_add(button_box, data->download_all_btn);
 #endif // HAVE_AI_DOWNLOAD
 
   // install model button
   data->install_btn = gtk_button_new_with_label(_("install model"));
+  gtk_widget_set_tooltip_text(data->install_btn,
+    _("install a model from a local .dtmodel file"));
   g_signal_connect(data->install_btn, "clicked", G_CALLBACK(_on_install_model), data);
   dt_gui_box_add(button_box, data->install_btn);
 
   // delete selected button
   data->delete_selected_btn = gtk_button_new_with_label(_("delete selected"));
+  gtk_widget_set_tooltip_text(data->delete_selected_btn,
+    _("remove the selected models from disk"));
   g_signal_connect(
     data->delete_selected_btn,
     "clicked",
@@ -1457,10 +1470,6 @@ void init_tab_ai(GtkWidget *dialog, GtkWidget *stack)
     data);
   dt_gui_box_add(button_box, data->delete_selected_btn);
 
-  // refresh button
-  GtkWidget *refresh_btn = gtk_button_new_with_label(_("refresh"));
-  g_signal_connect(refresh_btn, "clicked", G_CALLBACK(_on_refresh), data);
-  dt_gui_box_add(button_box, refresh_btn);
 
   dt_gui_box_add(data->controls_box, models_grid);
 


### PR DESCRIPTION
- Check for model updates by fetching `versions.json` from the remote repository
- Add `DT_AI_MODEL_UPDATE_AVAILABLE` status for models where a newer version exists but the installed version still meets the minimum requirement
- Download buttons now handle updates - selecting a model with "update available" and clicking "download selected" re-downloads it
- Add tooltips to all AI preferences buttons
- Remove redundant "refresh" button (model list already refreshes automatically)

## Details

- `dt_ai_models_check_updates()` runs once per session on first preferences tab open
- Fetches `versions.json` from the latest compatible release, compares remote versions against installed versions using the existing `_version_compare()` function
- Repository string is `g_strdup`'d under the lock to avoid use-after-free
- Models with `UPDATE_AVAILABLE` status remain fully usable (checkbox enabled, deletable)