### PR TITLE
[AI] Fix GUI freeze by removing history change signal handler

### DIFF
--- a/src/libs/neural_restore.c
+++ b/src/libs/neural_restore.c
@@ -2034,16 +2034,6 @@ static void _image_changed_callback(gpointer instance, dt_lib_module_t *self)
   _update_button_sensitivity(d);
 }
 
-// invalidate cached export when darkroom edits change the image
-static void _history_changed_callback(gpointer instance, dt_lib_module_t *self)
-{
-  dt_lib_neural_restore_t *d = (dt_lib_neural_restore_t *)self->data;
-  g_free(d->export_pixels);
-  d->export_pixels = NULL;
-  g_free(d->export_cairo);
-  d->export_cairo = NULL;
-  _update_button_sensitivity(d);
-}
 
 static void _ai_models_changed_callback(gpointer instance, dt_lib_module_t *self)
 {
@@ -2272,7 +2262,6 @@ void gui_init(dt_lib_module_t *self)
   DT_CONTROL_SIGNAL_HANDLE(DT_SIGNAL_SELECTION_CHANGED, _selection_changed_callback);
   DT_CONTROL_SIGNAL_HANDLE(DT_SIGNAL_DEVELOP_IMAGE_CHANGED, _image_changed_callback);
   DT_CONTROL_SIGNAL_HANDLE(DT_SIGNAL_AI_MODELS_CHANGED, _ai_models_changed_callback);
-  DT_CONTROL_SIGNAL_HANDLE(DT_SIGNAL_DEVELOP_HISTORY_CHANGE, _history_changed_callback);
 
   _update_info_label(d);
   _update_button_sensitivity(d);
@@ -2285,7 +2274,6 @@ void gui_cleanup(dt_lib_module_t *self)
   DT_CONTROL_SIGNAL_DISCONNECT(_selection_changed_callback, self);
   DT_CONTROL_SIGNAL_DISCONNECT(_image_changed_callback, self);
   DT_CONTROL_SIGNAL_DISCONNECT(_ai_models_changed_callback, self);
-  DT_CONTROL_SIGNAL_DISCONNECT(_history_changed_callback, self);
 
   if(d)
   {


### PR DESCRIPTION
Fix GUI deadlock when dragging sliders in darkroom (e.g. exposure) with the neural restore module present.

## Problem

The `DEVELOP_HISTORY_CHANGE` signal fires from the pixelpipe worker thread during slider changes. The neural restore callback handled this signal by calling `gtk_widget_set_sensitive()` to update the pick button - but GTK is not thread-safe. Calling GTK functions from a non-main thread causes a deadlock, freezing the GUI.

## Fix

Remove the `DEVELOP_HISTORY_CHANGE` signal handler entirely. Its purpose was to invalidate the cached export image so the picker wouldn't show stale data after edits. But:

- The picker shows a thumbnail for selecting a *area*, not for evaluating colors - a slightly stale image is fine
- The export cache is still invalidated on image change and selection change
- When the user clicks "process", the batch export runs fresh with current edits - the output is always correct

Fixes: #20738