### PR TITLE
[AI] Add adaptive detail recovery and configurable preview export size

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -3753,6 +3753,20 @@
     <longdescription>this folder (and sub-folders) contains PFM/PNG files used by the raster mask import module. (restart required)</longdescription>
   </dtconfig>
 <dtconfig>
+    <name>plugins/lighttable/neural_restore/preview_export_size</name>
+    <type min="0">int</type>
+    <default>0</default>
+    <shortdescription>neural restore preview export size</shortdescription>
+    <longdescription>maximum resolution (in pixels) for the preview export. 0 means full resolution. set a lower value (e.g. 2048) for faster preview generation on slower machines</longdescription>
+  </dtconfig>
+  <dtconfig>
+    <name>plugins/lighttable/neural_restore/detail_recovery_bands</name>
+    <type>string</type>
+    <default>0.5,0.3,0.1,0.05,0.02</default>
+    <shortdescription>detail recovery wavelet band thresholds</shortdescription>
+    <longdescription>comma-separated sigma multipliers for wavelet detail recovery bands (finest to coarsest). controls how much noise vs texture is recovered by the detail recovery slider</longdescription>
+  </dtconfig>
+  <dtconfig>
     <name>plugins/lighttable/neural_restore/preview_height</name>
     <type min="100" max="800">int</type>
     <default>200</default>

--- a/src/common/ai/restore.c
+++ b/src/common/ai/restore.c
@@ -52,13 +52,50 @@ struct dt_restore_context_t
   gint ref_count;
 };
 
-static const float _dwt_detail_noise[DWT_DETAIL_BANDS] = {
-  0.04f,  // band 0 (finest) — strong noise suppression
-  0.03f,  // band 1
-  0.02f,  // band 2
-  0.01f,  // band 3
-  0.005f  // band 4 (coarsest) — preserve most detail
+// default multipliers of residual sigma for each wavelet band.
+// band 0 (finest) gets the strongest suppression since fine-scale
+// features are hardest to distinguish from noise. coarser bands
+// preserve more because they capture real texture.
+// tunable via darktablerc: plugins/lighttable/neural_restore/detail_recovery_bands
+static const float _dwt_sigma_mul_default[DWT_DETAIL_BANDS] = {
+  0.5f,   // band 0 (finest) — suppress fine luminance noise
+  0.3f,   // band 1
+  0.1f,   // band 2
+  0.05f,  // band 3
+  0.02f   // band 4 (coarsest) — keep almost everything
 };
+
+// compute adaptive noise thresholds from residual standard deviation
+static void _compute_adaptive_noise(const float *const restrict buf,
+                                    const size_t npix,
+                                    float noise[DWT_DETAIL_BANDS])
+{
+  // read band multipliers from config (comma-separated list).
+  // e.g. "0.5,0.3,0.1,0.05,0.02" in darktablerc
+  float sigma_mul[DWT_DETAIL_BANDS];
+  memcpy(sigma_mul, _dwt_sigma_mul_default, sizeof(sigma_mul));
+  gchar *val = dt_conf_get_string("plugins/lighttable/neural_restore/detail_recovery_bands");
+  if(val && val[0])
+  {
+    gchar **parts = g_strsplit(val, ",", DWT_DETAIL_BANDS);
+    for(int b = 0; parts[b] && b < DWT_DETAIL_BANDS; b++)
+      sigma_mul[b] = g_ascii_strtod(g_strstrip(parts[b]), NULL);
+    g_strfreev(parts);
+  }
+  g_free(val);
+
+  double sum = 0.0, sum2 = 0.0;
+  for(size_t i = 0; i < npix; i++)
+  {
+    sum += (double)buf[i];
+    sum2 += (double)buf[i] * (double)buf[i];
+  }
+  const double mean = sum / (double)npix;
+  const float sigma = (float)sqrt(sum2 / (double)npix - mean * mean);
+
+  for(int b = 0; b < DWT_DETAIL_BANDS; b++)
+    noise[b] = sigma * sigma_mul[b];
+}
 
 /* --- environment lifecycle --- */
 
@@ -589,8 +626,10 @@ void dt_restore_apply_detail_recovery(const float *original_4ch,
     lum_residual[i] = lum_orig - lum_den;
   }
 
+  float noise[DWT_DETAIL_BANDS];
+  _compute_adaptive_noise(lum_residual, npix, noise);
   dwt_denoise(lum_residual, width, height,
-              DWT_DETAIL_BANDS, _dwt_detail_noise);
+              DWT_DETAIL_BANDS, noise);
 
 #ifdef _OPENMP
 #pragma omp parallel for simd default(none)       \
@@ -633,8 +672,10 @@ float *dt_restore_compute_dwt_detail(const float *before_3ch,
     lum_residual[i] = lum_orig - lum_den;
   }
 
+  float noise[DWT_DETAIL_BANDS];
+  _compute_adaptive_noise(lum_residual, npix, noise);
   dwt_denoise(lum_residual, width, height,
-              DWT_DETAIL_BANDS, _dwt_detail_noise);
+              DWT_DETAIL_BANDS, noise);
 
   return lum_residual;
 }

--- a/src/libs/neural_restore.c
+++ b/src/libs/neural_restore.c
@@ -120,7 +120,7 @@
 
 DT_MODULE(1)
 
-#define PREVIEW_EXPORT_SIZE 1024
+#define CONF_PREVIEW_EXPORT_SIZE "plugins/lighttable/neural_restore/preview_export_size"
 // warn the user when upscaled output exceeds this many megapixels
 #define LARGE_OUTPUT_MP 60.0
 
@@ -1137,8 +1137,9 @@ static gpointer _preview_thread(gpointer data)
   }
   else
   {
-    cap.parent.max_width = PREVIEW_EXPORT_SIZE;
-    cap.parent.max_height = PREVIEW_EXPORT_SIZE;
+    const int export_size = dt_conf_get_int(CONF_PREVIEW_EXPORT_SIZE);
+    cap.parent.max_width = export_size;
+    cap.parent.max_height = export_size;
 
     dt_imageio_module_format_t fmt = {
       .mime = _ai_get_mime,
@@ -1178,9 +1179,11 @@ static gpointer _preview_thread(gpointer data)
   }
 
   dt_print(DT_DEBUG_AI,
-           "[neural_restore] preview: %s %dx%d, scale=%d",
+           "[neural_restore] preview: %s %dx%d, scale=%d, "
+           "export_size=%d",
            owns_pixels ? "exported" : "reusing",
-           pixels_w, pixels_h, pd->scale);
+           pixels_w, pixels_h, pd->scale,
+           owns_pixels ? cap.parent.max_width : 0);
 
   // crop region matching widget aspect ratio
   // clamp crop to export dimensions and max preview size to keep


### PR DESCRIPTION
This PR adds some small improvements based on early feedback from users. Addresses the followings asks:
- 1:1 preview without image down-scaling to evaluate real effect
- why detail recovery slider does not make any visible effect

## Summary

- Switch to adaptive wavelet thresholds for detail recovery based on residual statistics
- Make preview export size configurable (default full resolution)
- Add configurable wavelet band thresholds for power users

## Adaptive detail recovery

Detail recovery previously used hardcoded absolute thresholds that were tuned for 1024px previews. At full resolution, the denoise model makes subtler per-pixel changes, so the fixed thresholds suppressed all recovered detail.

Now computes the standard deviation of the luminance residual (original – denoised) and sets wavelet thresholds as fractions of sigma. This adapts automatically to any resolution, model, and noise level.

## Configurable preview export

- Default changed from 1024px to full resolution (0 = no limit)
- Configurable via `darktablerc`: `plugins/lighttable/neural_restore/preview_export_size`
- Users on slower machines can set e.g. 2048 for faster previews

## Configurable wavelet bands

Power users can tune detail recovery noise separation via `darktablerc`:

```
plugins/lighttable/neural_restore/detail_recovery_bands=0.5,0.3,0.1,0.05,0.02
```

Values are sigma multipliers per wavelet band (finest to coarsest). Lower values recover more detail at the cost of some noise.