### PR TITLE
Add --library option to darktable-cli for reading history from database

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -231,6 +231,9 @@ changes (where available).
 - Added a new option to filter images by capture month in collections
   and collection filters.
 
+- Added `--library` option to `darktable-cli` to use the image library
+  instead of XMP files for reading processing history. 
+
 ## Bug Fixes
 
 - Properly apply the iop-order when applying a style at export

--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -198,6 +198,18 @@ static dt_iop_color_intent_t get_icc_intent(const char* option)
 }
 #undef ICC_INTENT_FROM_STR
 
+static gboolean _inputs_have_xmp_sidecar(const GList* inputs)
+{
+  for(const GList *l = inputs; l; l = g_list_next(l))
+  {
+    char sidecar[PATH_MAX + 5];
+    snprintf(sidecar, sizeof(sidecar), "%s.xmp", (const gchar *)l->data);
+    if(!g_file_test(sidecar, G_FILE_TEST_EXISTS))
+      return FALSE;
+  }
+  return inputs != NULL;
+}
+
 int main(int argc, char *arg[])
 {
 #ifdef __APPLE__
@@ -450,19 +462,42 @@ int main(int argc, char *arg[])
   for(; k < argc; k++) m_arg[m_argc++] = arg[k];
   m_arg[m_argc] = NULL;
 
-  if( (inputs && file_counter < 1) || (!inputs && file_counter < 2) || file_counter > 3)
+  gboolean args_error = FALSE;
+  if(inputs && file_counter < 1)
+  {
+    fprintf(stderr, _("error: output file or directory must be specified\n\n"));
+    args_error = TRUE;
+  }
+  else if(!inputs && file_counter < 2)
+  {
+    if(file_counter == 0)
+      fprintf(stderr, _("error: input file and output file must be specified\n\n"));
+    else
+      fprintf(stderr, _("error: output file or directory must be specified\n\n"));
+    args_error = TRUE;
+  }
+  else if(file_counter > 3)
+  {
+    fprintf(stderr, _("error: too many positional arguments\n\n"));
+    args_error = TRUE;
+  }
+  else if(inputs && file_counter == 3)
+  {
+    fprintf(stderr, _("error: input file and import opts specified! that's not supported!\n"));
+    args_error = TRUE;
+  }
+
+  if(args_error)
   {
     usage(arg[0]);
     free(m_arg);
-    if(output_filename)
-      g_free(output_filename);
-    if(output_ext)
-      g_free(output_ext);
-    if(inputs)
-      g_list_free_full(inputs, g_free);
+    g_free(output_filename);
+    g_free(output_ext);
+    g_list_free_full(inputs, g_free);
     exit(1);
   }
-  else if(inputs && file_counter == 1)
+
+  if(inputs && file_counter == 1)
   {
     //user specified inputs as options, and only dest is present
     if(output_filename)
@@ -479,18 +514,6 @@ int main(int argc, char *arg[])
     xmp_filename = input_filename;
     input_filename = NULL;
   }
-  else if(inputs && file_counter == 3)
-  {
-    fprintf(stderr, _("error: input file and import opts specified! that's not supported!\n"));
-    usage(arg[0]);
-    free(m_arg);
-    if(output_filename)
-      g_free(output_filename);
-    if(output_ext)
-      g_free(output_ext);
-    g_list_free_full(inputs, g_free);
-    exit(1);
-  }
   else if(file_counter == 2)
   {
     // assume no xmp file given
@@ -506,6 +529,11 @@ int main(int argc, char *arg[])
     inputs = g_list_prepend(inputs, g_strdup(input_filename));
     input_filename = NULL;
   }
+
+  // auto-detect XMP sidecar: darktable's import reads <input>.xmp automatically,
+  // so only check for existence to decide whether to suppress the "no XMP" notice.
+  if(!xmp_filename && !library && ! _inputs_have_xmp_sidecar(inputs))
+    fprintf(stderr, "%s\n", _("notice: no XMP sidecar file nor library path provided, using default settings for export"));
 
   if(g_file_test(output_filename, G_FILE_TEST_IS_DIR))
   {

--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -93,6 +93,8 @@ fprintf(stderr, "darktable %s\n"
                 "                          if specified, takes preference over output\n"
                 "   --import <file or dir> specify input file or dir, can be used'\n"
                 "                          multiple times instead of input file\n"
+                "   --library <path> read the history stack from library database\n"
+                "                    instead of XMP sidecar files\n"
                 "   --icc-type <type> specify icc type, default to NONE\n"
                 "                     use --help icc-type for list of supported types\n"
                 "   --icc-file <file> specify icc filename, default to NONE\n"
@@ -216,6 +218,7 @@ int main(int argc, char *arg[])
   gchar *output_filename = NULL;
   gchar *output_ext = NULL;
   char *style = NULL;
+  char *library = NULL;
   int file_counter = 0;
   int width = 0, height = 0, bpp = 0;
   gboolean verbose = FALSE, high_quality = TRUE, upscale = FALSE,
@@ -365,6 +368,11 @@ int main(int argc, char *arg[])
         else
           fprintf(stderr, _("notice: input file or dir '%s' doesn't exist, skipping\n"), arg[k]);
       }
+      else if(!strcmp(arg[k], "--library") && argc > k + 1)
+      {
+        k++;
+        library = arg[k];
+      }
       else if(!strcmp(arg[k], "--icc-type") && argc > k + 1)
       {
         k++;
@@ -436,7 +444,7 @@ int main(int argc, char *arg[])
   char **m_arg = malloc(sizeof(char *) * (5 + argc - k + 1));
   m_arg[m_argc++] = "darktable-cli";
   m_arg[m_argc++] = "--library";
-  m_arg[m_argc++] = ":memory:";
+  m_arg[m_argc++] = library ? library : ":memory:";
   m_arg[m_argc++] = "--conf";
   m_arg[m_argc++] = "write_sidecar_files=never";
   for(; k < argc; k++) m_arg[m_argc++] = arg[k];


### PR DESCRIPTION
Add a `--library <path>` command-line option that allows specifying a library.db database file to read image processing history stacks from, instead of requiring XMP sidecar files, for people who do not use XMP sidecar files.

When `--library` is not specified, the previous behavior of using an in-memory database is preserved.

Fixes: https://github.com/darktable-org/darktable/issues/19472