### PR TITLE
[Nightly] Stop nightly builds of the deprecated Windows Installer

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -322,12 +322,6 @@ jobs:
           cp ${{ env.BUILD_DIR }}/darktable.iss ./
           iscc "darktable.iss"
           mv Output/*.exe ${{ env.BUILD_DIR }}/
-      - name: Create NSIS installer
-        if: runner.arch != 'ARM64'
-        run: |
-          pacboy --noconfirm -S --needed nsis:p
-          cd "${BUILD_DIR}"
-          cmake --build "${BUILD_DIR}" --target package
       - name: Get version info
         run: |
           cd ${SRC_DIR}


### PR DESCRIPTION
NSIS Windows installer has long been a parallel-built, alternative nightly installer. There is no need for this for a long time. It is still downloaded (and yes, under a file name that clearly indicates that it is a deprecated installer), but much less often than the main one. It's time to stop offering it in nightly builds.