### PR TITLE
Fix film roll sorting for folder name/display name

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -800,6 +800,7 @@
       <enum>
         <option>import time</option>
         <option>folder name</option>
+        <option>display name</option>
       </enum>
     </type>
     <default>import time</default>

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -164,11 +164,18 @@ static int _is_time_property(const int property);
 
 static void _populate_collect_combo(GtkWidget *w);
 
-static gint _sort_filmroll_rows(gconstpointer a, gconstpointer b)
+static gint _sort_filmroll_by_display_name(gconstpointer a, gconstpointer b)
 {
   const filmroll_row_t *ra = a;
   const filmroll_row_t *rb = b;
   return g_ascii_strcasecmp(ra->folder, rb->folder);
+}
+
+static gint _sort_filmroll_rows(gconstpointer a, gconstpointer b)
+{
+  const filmroll_row_t *ra = a;
+  const filmroll_row_t *rb = b;
+  return g_ascii_strcasecmp(ra->value, rb->value);
 }
 
 static gint _sort_filmroll_by_id(gconstpointer a, gconstpointer b)
@@ -2431,14 +2438,20 @@ static void _list_view(dt_lib_collect_rule_t *dr)
       {
         const gboolean sort_by_import_time =
           dt_conf_is_equal("plugins/collect/filmroll_sort", "import time");
+        const gboolean sort_by_folder_name = 
+          dt_conf_is_equal("plugins/collect/filmroll_sort", "folder name");
       
         if(sort_by_import_time)
         {      
           rows = g_list_sort(rows, _sort_filmroll_by_id);
         }
-        else
+        else if(sort_by_folder_name)
         {
           rows = g_list_sort(rows, _sort_filmroll_rows);
+        }
+        else
+        {
+          rows = g_list_sort(rows, _sort_filmroll_by_display_name);
         }
       
         if(sort_descending)


### PR DESCRIPTION
**Fixes #20751**
**Supersedes #20703 and #20718** - This solution provides a better implementation that addresses the original issue while maintaining the performance improvements from the batch film roll loading refactor

Examples use /volumes/aa/ and /users/bb/.

Added a option in preferences for sort film roll by for "display name".   Which is used to sort film rolls by the current folder level displayed.  Tested both ascending and descending.
- aa/2010/a
- aa/2013/b
- bb/2012/c

Reverted back the option "folder name" to sort by the full path name to avoid confusing anyone due to the long standing implementation.  Tested both ascending and descending.
- bb/2012/c
- aa/2010/a
- aa/2013/c 

Tested import time sorting ascending and descending.

The sorting is now handled in-memory after fetching filmroll data.

<img width="534" height="253" alt="filmsort_add" src="https://github.com/user-attachments/assets/304fda1d-297e-49db-9ddf-e0ab050c5808" />
