### PR TITLE
fix: shift UB in _float_to_half() for float16 denormals

### DIFF
--- a/src/ai/backend_onnx.c
+++ b/src/ai/backend_onnx.c
@@ -533,7 +533,7 @@ static uint16_t _float_to_half(float f)
     const int shift = 1 - new_exp;
     if(shift > 24)
       return (uint16_t)(sign << 15);       // too small even for denormal
-    const uint32_t full_mant = (1 << 23) | mant; // restore implicit leading 1
+    const uint64_t full_mant = (1 << 23) | mant; // restore implicit leading 1
     const uint16_t half_mant = (uint16_t)(full_mant >> (13 + shift));
     return (uint16_t)((sign << 15) | half_mant);
   }


### PR DESCRIPTION
When converting float32 to float16 denormals, shift = 1 - new_exp can reach 24, so the shift amount in

    full_mant >> (13 + shift)

goes up to 37 on a uint32_t. Shifting a 32-bit value by >= 32 is UB per C11 6.5.7.

On x86 this silently misbehaves, the hardware masks the count to 5 bits, so >>37 runs as >>5 and gives a wrong nonzero result instead of 0. Affects floats with biased exponent 89-93 (e.g. around 5.8e-10f).

Fix: cast full_mant to uint64_t before the shift, making it valid for amounts up to 63.