### PR TITLE
fix: uninitialized roi_out in dt_dev_pixelpipe_get_dimensions()

### DIFF
--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -3333,7 +3333,7 @@ void dt_dev_pixelpipe_get_dimensions(dt_dev_pixelpipe_t *pipe,
   dt_print_pipe(DT_DEBUG_PIPE,
                 "get dimensions",
                 pipe, NULL, DT_DEVICE_NONE, &roi_in, NULL, "ID=%i", pipe->image.id);
-  dt_iop_roi_t roi_out;
+  dt_iop_roi_t roi_out = roi_in;
   GList *modules = pipe->iop;
   GList *pieces = pipe->nodes;
   while(modules)


### PR DESCRIPTION
roi_out is declared without initialization and only written inside the while loop. If pipe->iop is empty the loop never runs and roi_out is read uninitialized when assigning to *width and *height.

Initialized roi_out to roi_in so the output dimensions fall back to the input dimensions when no modules are in the pipeline.