### PR TITLE
[GUI] [i18n] Fix displaying short month names

### DIFF
--- a/src/libs/filters/date.c
+++ b/src/libs/filters/date.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2022 darktable developers.
+    Copyright (C) 2022-2026 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/src/libs/filters/date.c
+++ b/src/libs/filters/date.c
@@ -117,9 +117,9 @@ static gchar *_month_pretty_print(const gchar *raw_txt)
     if(mask & (1 << i))
     {
       if(txt)
-        dt_util_str_cat(&txt, ", %s", _(dt_month_short_names[i]));
+        dt_util_str_cat(&txt, ", %s", Q_(dt_month_short_names[i]));
       else
-        txt = g_strdup(_(dt_month_short_names[i]));
+        txt = g_strdup(Q_(dt_month_short_names[i]));
     }
   }
   return txt ? txt : g_strdup(_("all"));
@@ -181,7 +181,7 @@ static void _month_widget_init(dt_lib_filtering_rule_t *rule, const dt_collectio
 
   for(int i = 0; i < 12; i++)
   {
-    month->toggles[i] = gtk_toggle_button_new_with_label(_(dt_month_short_names[i]));
+    month->toggles[i] = gtk_toggle_button_new_with_label(Q_(dt_month_short_names[i]));
     gtk_widget_set_tooltip_text(month->toggles[i],
                                 _("filter by capture month\n"
                                   "click to toggle month selection"));


### PR DESCRIPTION
This fix handles context inside the translatable string of short month names. We had to use context here to distinguish a string that is the same as both the full and short name of the month, "May". Without the distinction, we would not be able to have a short and full form in those translations where these names differ for this month.

Without this fix, the GUI would show the string including the context, i.e. `short_month_name|May` instead of `May`.