### PR TITLE
[README.md] Remove link to community page on Mastodon

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,4 +494,3 @@ Community
 ---------
 
 * [Darktable forum on pixls.us](https://discuss.pixls.us/c/software/darktable/19)
-* [Darktable on Mastodon](https://photog.social/@darktable)


### PR DESCRIPTION
[The page on Mastodon](https://photog.social/@darktable) was maintained as a personal project by a community member and contributor who stopped participating and deleted (deactivated? I don't know...) this page. At least for now, we should remove this link, it's broken...