### PR TITLE
Fix OpenCL sharpen border diffs

### DIFF
--- a/data/kernels/sharpen.cl
+++ b/data/kernels/sharpen.cl
@@ -1,5 +1,6 @@
 /*
     This file is part of darktable,
+    Copyright (C) 2026 darktable developers.
     copyright (c) 2011 ulrich pegelow.
 
     darktable is free software: you can redistribute it and/or modify
@@ -28,10 +29,9 @@ sharpen_hblur(read_only image2d_t in, write_only image2d_t out, global const flo
   const int lsz = get_local_size(0);
   const int x = get_global_id(0);
   const int y = get_global_id(1);
-  float4 pixel = (float4)0.0f;
 
   /* read pixel and fill center part of buffer */
-  pixel = read_imagef(in, sampleri, (int2)(x, y));
+  float4 pixel = readpixel(in, x, y);
   buffer[rad + lid] = pixel.x;
 
   /* left wing of buffer */
@@ -40,7 +40,7 @@ sharpen_hblur(read_only image2d_t in, write_only image2d_t out, global const flo
     const int l = mad24(n, lsz, lid + 1);
     if(l > rad) continue;
     const int xx = mad24((int)get_group_id(0), lsz, -l);
-    buffer[rad - l] = read_imagef(in, sampleri, (int2)(xx, y)).x;
+    buffer[rad - l] = readsingle(in, xx, y);
   }
     
   /* right wing of buffer */
@@ -49,24 +49,26 @@ sharpen_hblur(read_only image2d_t in, write_only image2d_t out, global const flo
     const int r = mad24(n, lsz, lsz - lid);
     if(r > rad) continue;
     const int xx = mad24((int)get_group_id(0), lsz, lsz - 1 + r);
-    buffer[rad + lsz - 1 + r] = read_imagef(in, sampleri, (int2)(xx, y)).x;
+    buffer[rad + lsz - 1 + r] = readsingle(in, xx, y);
   }
 
   barrier(CLK_LOCAL_MEM_FENCE);
 
   if(x >= width || y >= height) return;
 
-  buffer += lid + rad;
-  m += rad;
-
-  float sum = 0.0f;
-
-  for (int i=-rad; i<=rad; i++)
+  if(x >= rad && x < width-rad)
   {
-    sum += buffer[i] * m[i];
-  }
+    buffer += lid + rad;
+    m += rad;
 
-  pixel.x = sum;
+    float sum = 0.0f;
+
+    for (int i=-rad; i<=rad; i++)
+    {
+      sum += buffer[i] * m[i];
+    }
+    pixel.x = sum;
+  }
   write_imagef (out, (int2)(x, y), pixel);
 }
 
@@ -79,10 +81,9 @@ sharpen_vblur(read_only image2d_t in, write_only image2d_t out, global const flo
   const int lsz = get_local_size(1);
   const int x = get_global_id(0);
   const int y = get_global_id(1);
-  float4 pixel = (float4)0.0f;
 
   /* read pixel and fill center part of buffer */
-  pixel = read_imagef(in, sampleri, (int2)(x, y));
+  float4 pixel = readpixel(in, x, y);
   buffer[rad + lid] = pixel.x;
 
   /* left wing of buffer */
@@ -91,7 +92,7 @@ sharpen_vblur(read_only image2d_t in, write_only image2d_t out, global const flo
     const int l = mad24(n, lsz, lid + 1);
     if(l > rad) continue;
     const int yy = mad24((int)get_group_id(1), lsz, -l);
-    buffer[rad - l] = read_imagef(in, sampleri, (int2)(x, yy)).x;
+    buffer[rad - l] = readsingle(in, x, yy);
   }
     
   /* right wing of buffer */
@@ -100,24 +101,26 @@ sharpen_vblur(read_only image2d_t in, write_only image2d_t out, global const flo
     const int r = mad24(n, lsz, lsz - lid);
     if(r > rad) continue;
     const int yy = mad24((int)get_group_id(1), lsz, lsz - 1 + r);
-    buffer[rad + lsz - 1 + r] = read_imagef(in, sampleri, (int2)(x, yy)).x;
+    buffer[rad + lsz - 1 + r] = readsingle(in, x, yy);
   }
 
   barrier(CLK_LOCAL_MEM_FENCE);
 
   if(x >= width || y >= height) return;
 
-  buffer += lid + rad;
-  m += rad;
-
-  float sum = 0.0f;
-
-  for (int i=-rad; i<=rad; i++)
+  if(y >= rad && y < height-rad)
   {
-    sum += buffer[i] * m[i];
-  }
+    buffer += lid + rad;
+    m += rad;
 
-  pixel.x = sum;
+    float sum = 0.0f;
+
+    for (int i=-rad; i<=rad; i++)
+    {
+      sum += buffer[i] * m[i];
+    }
+    pixel.x = sum;
+  }
   write_imagef (out, (int2)(x, y), pixel);
 }
 
@@ -132,21 +135,24 @@ sharpen_vblur(read_only image2d_t in, write_only image2d_t out, global const flo
  */  
 kernel void
 sharpen_mix(read_only image2d_t in_a, read_only image2d_t in_b, write_only image2d_t out,
-            const int width, const int height, const float sharpen, const float thrs)
+            const int width, const int height, const float sharpen, const float thrs, const int rad)
 {
   const int x = get_global_id(0);
   const int y = get_global_id(1);
 
   if(x >= width || y >= height) return;
 
-  float4 pixel = read_imagef(in_a, sampleri, (int2)(x, y));
-  float blurredx  = read_imagef(in_b, sampleri, (int2)(x, y)).x;
-  float4 Labmin = (float4)(0.0f, -128.0f, -128.0f, 0.0f);
-  float4 Labmax = (float4)(100.0f, 128.0f, 128.0f, 1.0f);
+  float4 pixel = readpixel(in_a, x, y);
+  if(x >= rad && y >= rad && x < width-rad && y < height-rad)
+  {
+    float blurredx  = readsingle(in_b, x, y);
+    float4 Labmin = (float4)(0.0f, -128.0f, -128.0f, 0.0f);
+    float4 Labmax = (float4)(100.0f, 128.0f, 128.0f, 1.0f);
 
-  float delta = pixel.x - blurredx;
-  float amount = sharpen * copysign(fmax(0.0f, fabs(delta) - thrs), delta);
-  pixel.x = pixel.x + amount;
+    float delta = pixel.x - blurredx;
+    float amount = sharpen * copysign(fmax(0.0f, fabs(delta) - thrs), delta);
+    pixel.x = pixel.x + amount;
+  }
   write_imagef (out, (int2)(x, y), pixel);
 }
 

--- a/src/iop/sharpen.c
+++ b/src/iop/sharpen.c
@@ -225,7 +225,7 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
   /* mixing tmp and in -> out */
   err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_sharpen_mix, width, height,
     CLARG(dev_in), CLARG(dev_tmp), CLARG(dev_out),
-    CLARG(width), CLARG(height), CLARG(d->amount), CLARG(d->threshold));
+    CLARG(width), CLARG(height), CLARG(d->amount), CLARG(d->threshold), CLARG(rad));
 
 error:
   dt_opencl_release_mem_object(dev_m);


### PR DESCRIPTION
Don't sharpen the pixels outer than radius, same as we do in CPU code.

See 0029-color-correction in integration tests.