### PR TITLE
Port diffuse or sharpen changes from Ansel

### DIFF
--- a/data/kernels/diffuse.cl
+++ b/data/kernels/diffuse.cl
@@ -175,9 +175,9 @@ diffuse_pde(read_only image2d_t HF, read_only image2d_t LF,
             write_only image2d_t output,
             const int width, const int height,
             const float4 anisotropy, const int4 isotropy_type,
-            const float regularization, const float variance_threshold,
-            const float current_radius_square, const int mult,
-            const float4 ABCD, const float strength)
+            const float normalized_regularization, const float variance_threshold,
+            const int mult, const float4 ABCD,
+            const float strength)
 {
   const int x = get_global_id(0);
   const int y = get_global_id(1);
@@ -185,8 +185,6 @@ diffuse_pde(read_only image2d_t HF, read_only image2d_t LF,
   if(x >= width || y >= height) return;
 
   const char opacity = (has_mask) ? read_imageui(mask, sampleri, (int2)(x, y)).x : 1;
-
-  const float4 regularization_factor = regularization * current_radius_square / 9.f;
 
   float4 out;
 
@@ -202,16 +200,33 @@ diffuse_pde(read_only image2d_t HF, read_only image2d_t LF,
       y,
       clamp((y + mult * H_STEP), 0, height - 1) };
 
-    // fetch non-local pixels and store them locally and contiguously
+    // Fetch the local 3x3 neighborhoods and accumulate the HF/LF
+    // energy regularizer in the same pass.
     float4 neighbour_pixel_HF[9];
     float4 neighbour_pixel_LF[9];
+    float4 energy = (float4)0.f;
 
     for(int ii = 0; ii < 3; ii++)
       for(int jj = 0; jj < 3; jj++)
       {
-        neighbour_pixel_HF[3 * ii + jj] = read_imagef(HF, samplerA, (int2)(j_neighbours[ii], i_neighbours[jj]));
-        neighbour_pixel_LF[3 * ii + jj] = read_imagef(LF, samplerA, (int2)(j_neighbours[ii], i_neighbours[jj]));
+        const int k = 3 * ii + jj;
+        const int2 p = (int2)(j_neighbours[ii], i_neighbours[jj]);
+        const float4 hf_value = read_imagef(HF, samplerA, p);
+        const float4 lf_value = read_imagef(LF, samplerA, p);
+        neighbour_pixel_HF[k] = hf_value;
+        neighbour_pixel_LF[k] = lf_value;
+        // Exposure-invariant band energy: HF/LF ratio squared.
+        // Clamp LF to a strictly positive floor to match the CPU path
+        // and avoid divide-by-zero.
+        const float4 safe_lf = fmax(lf_value - (float4)(FLT_MIN), (float4)0.f) + (float4)(FLT_MIN);
+        const float4 ratio = hf_value / safe_lf;
+        energy += ratio * ratio;
       }
+
+    // normalized_regularization already folds together the user
+    // regularization, the 3x3-support averaging factor (1/9), and the
+    // physical blur radius of the current wavelet band.
+    energy = variance_threshold + energy * normalized_regularization;
 
     // build the local anisotropic convolution filters for gradients and laplacians
     float4 gradient[2], laplacian[2];
@@ -256,9 +271,8 @@ diffuse_pde(read_only image2d_t HF, read_only image2d_t LF,
     compute_kern(c2[2], cos_theta_sin_theta_grad, cos_theta_grad_sq, sin_theta_grad_sq, isotropy_type.z, kern_third);
     compute_kern(c2[3], cos_theta_sin_theta_lapl, cos_theta_lapl_sq, sin_theta_lapl_sq, isotropy_type.w, kern_fourth);
 
-    // convolve filters and compute the variance and the regularization term
+    // convolve filters
     float4 derivatives[4] = { (float4)0.f };
-    float4 variance = (float4)0.f;
 
     #pragma unroll
     for(int k = 0; k < 9; k++)
@@ -267,30 +281,22 @@ diffuse_pde(read_only image2d_t HF, read_only image2d_t LF,
       derivatives[1] += kern_second[k] * neighbour_pixel_LF[k];
       derivatives[2] += kern_third[k] * neighbour_pixel_HF[k];
       derivatives[3] += kern_fourth[k] * neighbour_pixel_HF[k];
-      variance += sqf(neighbour_pixel_HF[k]);
     }
 
-    // Regularize the variance taking into account the blurring scale.
-    // This allows to keep the scene-referred variance roughly constant
-    // regardless of the wavelet scale where we compute it.
-    // Prevents large scale halos when deblurring.
-    variance = variance_threshold + variance * regularization_factor;
-
-    // compute the update
+    // compute the update -- use neighbour_pixel[4] (the center pixel,
+    // already fetched) instead of re-reading from the image.
     float4 acc = (float4)0.f;
     for(int k = 0; k < 4; k++) acc += derivatives[k] * ((float *)&ABCD)[k];
-    float4 hf = read_imagef(HF, samplerA, (int2)(x, y));
-    acc = (hf * strength + acc / variance);
+    acc = (neighbour_pixel_HF[4] * strength + acc / energy);
 
     // update the solution
-    float4 lf = read_imagef(LF, samplerA, (int2)(x, y));
-    out = fmax(acc + lf, 0.f);
+    out = fmax(acc + neighbour_pixel_LF[4], 0.f);
   }
   else
   {
     float4 hf = read_imagef(HF, samplerA, (int2)(x, y));
     float4 lf = read_imagef(LF, samplerA, (int2)(x, y));
-    out = hf + lf;
+    out = fmax(hf + lf, 0.f);
   }
 
   write_imagef(output, (int2)(x, y), out);

--- a/data/kernels/diffuse.cl
+++ b/data/kernels/diffuse.cl
@@ -200,8 +200,8 @@ diffuse_pde(read_only image2d_t HF, read_only image2d_t LF,
       y,
       clamp((y + mult * H_STEP), 0, height - 1) };
 
-    // Fetch the local 3x3 neighborhoods and accumulate the HF/LF
-    // energy regularizer in the same pass.
+    // Fetch the local 3x3 neighborhoods used by the anisotropic stencils
+    // and accumulate the HF/LF energy regularizer in the same pass.
     float4 neighbour_pixel_HF[9];
     float4 neighbour_pixel_LF[9];
     float4 energy = (float4)0.f;
@@ -215,9 +215,8 @@ diffuse_pde(read_only image2d_t HF, read_only image2d_t LF,
         const float4 lf_value = read_imagef(LF, samplerA, p);
         neighbour_pixel_HF[k] = hf_value;
         neighbour_pixel_LF[k] = lf_value;
-        // Exposure-invariant band energy: HF/LF ratio squared.
-        // Clamp LF to a strictly positive floor to match the CPU path
-        // and avoid divide-by-zero.
+        // Clamp LF to a strictly positive floor to avoid divide-by-zero in
+        // the HF/LF energy estimate
         const float4 safe_lf = fmax(lf_value - (float4)(FLT_MIN), (float4)0.f) + (float4)(FLT_MIN);
         const float4 ratio = hf_value / safe_lf;
         energy += ratio * ratio;
@@ -283,10 +282,9 @@ diffuse_pde(read_only image2d_t HF, read_only image2d_t LF,
       derivatives[3] += kern_fourth[k] * neighbour_pixel_HF[k];
     }
 
-    // compute the update -- use neighbour_pixel[4] (the center pixel,
-    // already fetched) instead of re-reading from the image.
     float4 acc = (float4)0.f;
     for(int k = 0; k < 4; k++) acc += derivatives[k] * ((float *)&ABCD)[k];
+    // neighbour_pixel_HF[4]: center pixel, already read from image
     acc = (neighbour_pixel_HF[4] * strength + acc / energy);
 
     // update the solution

--- a/src/iop/diffuse.c
+++ b/src/iop/diffuse.c
@@ -1522,13 +1522,14 @@ static inline cl_int wavelets_process_cl(const int devid,
       buffer_out = LF_odd;
     }
 
-    // Compute wavelets low-frequency scales
-    err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_filmic_bspline_horizontal, width, height,
+    // Keep the same separable order as the CPU path: vertical pass first,
+    // then horizontal pass.
+    err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_filmic_bspline_vertical, width, height,
                               CLARG(buffer_in), CLARG(HF[s]),
                               CLARG(width), CLARG(height), CLARG(mult));
     if(err != CL_SUCCESS) return err;
 
-    err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_filmic_bspline_vertical, width, height,
+    err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_filmic_bspline_horizontal, width, height,
                               CLARG(HF[s]), CLARG(buffer_out),
                               CLARG(width), CLARG(height), CLARG(mult));
     if(err != CL_SUCCESS) return err;

--- a/src/iop/diffuse.c
+++ b/src/iop/diffuse.c
@@ -1561,7 +1561,7 @@ static inline cl_int wavelets_process_cl(const int devid,
     const int mult = 1 << s;
     const float current_radius = equivalent_sigma_at_step(B_SPLINE_SIGMA, s);
     const float real_radius = current_radius * zoom;
-    const float current_radius_square = sqf(current_radius);
+    const float normalized_regularization = regularization / 9.f * sqf(real_radius);
 
     const float norm =
       expf(-sqf(real_radius - (float)data->radius_center) / sqf(data->radius));
@@ -1598,8 +1598,8 @@ static inline cl_int wavelets_process_cl(const int devid,
                               CLARG(has_mask), CLARG(buffer_out),
                               CLARG(width), CLARG(height),
                               CLARG(anisotropy), CLARG(isotropy_type),
-                              CLARG(regularization), CLARG(variance_threshold),
-                              CLARG(current_radius_square), CLARG(mult), CLARG(ABCD),
+                              CLARG(normalized_regularization), CLARG(variance_threshold),
+                              CLARG(mult), CLARG(ABCD),
                               CLARG(strength));
     if(err != CL_SUCCESS) return err;
 

--- a/src/iop/diffuse.c
+++ b/src/iop/diffuse.c
@@ -1128,9 +1128,9 @@ static inline void heat_PDE_diffusion(const float *const restrict high_freq,
         }
         for_each_channel(c, aligned(acc,HF,LF,energy,out))
         {
-          acc[c] = (HF[index + c] * strength + acc[c] / energy[c]);
+          acc[c] = (neighbour_pixel_HF[4][c] * strength + acc[c] / energy[c]);
           // update the solution
-          out[index + c] = fmaxf(acc[c] + LF[index + c], 0.f);
+          out[index + c] = fmaxf(acc[c] + neighbour_pixel_LF[4][c], 0.f);
         }
       }
       else

--- a/src/iop/diffuse.c
+++ b/src/iop/diffuse.c
@@ -955,9 +955,8 @@ static inline void heat_PDE_diffusion(const float *const restrict high_freq,
                                       const size_t height,
                                       const dt_aligned_pixel_t anisotropy,
                                       const dt_isotropy_t isotropy_type[4],
-                                      const float regularization,
                                       const float variance_threshold,
-                                      const float current_radius_square,
+                                      const float normalized_regularization,
                                       const int mult,
                                       const dt_aligned_pixel_t ABCD,
                                       const float strength)
@@ -981,7 +980,6 @@ static inline void heat_PDE_diffusion(const float *const restrict high_freq,
   const float *const restrict LF = DT_IS_ALIGNED(low_freq);
   const float *const restrict HF = DT_IS_ALIGNED(high_freq);
 
-  const float regularization_factor = regularization * current_radius_square / 9.f;
   DT_OMP_FOR()
   for(size_t row = 0; row < height; ++row)
   {
@@ -1009,6 +1007,7 @@ static inline void heat_PDE_diffusion(const float *const restrict high_freq,
         // fetch non-local pixels and store them locally and contiguously
         dt_aligned_pixel_t neighbour_pixel_HF[9];
         dt_aligned_pixel_t neighbour_pixel_LF[9];
+        dt_aligned_pixel_t energy = { 0.f };
 
         for(size_t ii = 0; ii < 3; ii++)
           for(size_t jj = 0; jj < 3; jj++)
@@ -1016,10 +1015,25 @@ static inline void heat_PDE_diffusion(const float *const restrict high_freq,
             size_t neighbor = 4 * (i_neighbours[ii] + j_neighbours[jj]);
             for_each_channel(c)
             {
-              neighbour_pixel_HF[3 * ii + jj][c] = HF[neighbor + c];
-              neighbour_pixel_LF[3 * ii + jj][c] = LF[neighbor + c];
+              const float hf_val = HF[neighbor + c];
+              const float lf_val = LF[neighbor + c];
+              neighbour_pixel_HF[3 * ii + jj][c] = hf_val;
+              neighbour_pixel_LF[3 * ii + jj][c] = lf_val;
+              // Exposure-invariant band energy: HF/LF ratio squared.
+              // Clamp LF to a strictly positive floor to avoid division by zero.
+              const float safe_lf = fmaxf(lf_val - FLT_MIN, 0.f) + FLT_MIN;
+              energy[c] += sqf(hf_val / safe_lf);
             }
           }
+
+        // Regularize the energy taking into account the physical blur radius.
+        // normalized_regularization already folds together the user
+        // regularization, the 3x3-support averaging factor (1/9), and the
+        // physical blur radius of the current wavelet band.
+        for_each_channel(c, aligned(energy))
+        {
+          energy[c] = variance_threshold + energy[c] * normalized_regularization;
+        }
 
         // c² in https://www.researchgate.net/publication/220663968
         dt_aligned_pixel_t c2[4];
@@ -1094,8 +1108,7 @@ static inline void heat_PDE_diffusion(const float *const restrict high_freq,
                        kern_fourth);
 
         dt_aligned_pixel_t derivatives[4] = { { 0.f } };
-        dt_aligned_pixel_t variance = { 0.f };
-        // convolve filters and compute the variance and the regularization term
+        // convolve filters
         for(size_t k = 0; k < 9; k++)
         {
           for_each_channel(c,aligned(derivatives,neighbour_pixel_LF,kern_first,kern_second))
@@ -1104,16 +1117,7 @@ static inline void heat_PDE_diffusion(const float *const restrict high_freq,
             derivatives[1][c] += kern_second[k][c] * neighbour_pixel_LF[k][c];
             derivatives[2][c] += kern_third[k][c] * neighbour_pixel_HF[k][c];
             derivatives[3][c] += kern_fourth[k][c] * neighbour_pixel_HF[k][c];
-            variance[c] += sqf(neighbour_pixel_HF[k][c]);
           }
-        }
-        // Regularize the variance taking into account the blurring scale.
-        // This allows to keep the scene-referred variance roughly constant
-        // regardless of the wavelet scale where we compute it.
-        // Prevents large scale halos when deblurring.
-        for_each_channel(c, aligned(variance))
-        {
-          variance[c] = variance_threshold + variance[c] * regularization_factor;
         }
         // compute the update
         dt_aligned_pixel_t acc = { 0.f };
@@ -1122,18 +1126,18 @@ static inline void heat_PDE_diffusion(const float *const restrict high_freq,
           for_each_channel(c, aligned(acc,derivatives,ABCD))
             acc[c] += derivatives[k][c] * ABCD[k];
         }
-        for_each_channel(c, aligned(acc,HF,LF,variance,out))
+        for_each_channel(c, aligned(acc,HF,LF,energy,out))
         {
-          acc[c] = (HF[index + c] * strength + acc[c] / variance[c]);
+          acc[c] = (HF[index + c] * strength + acc[c] / energy[c]);
           // update the solution
           out[index + c] = fmaxf(acc[c] + LF[index + c], 0.f);
         }
       }
       else
       {
-        // only copy input to output, do nothing
+        // only copy input to output, clamp to non-negative
         for_each_channel(c, aligned(out, HF, LF : 64))
-          out[index + c] = HF[index + c] + LF[index + c];
+          out[index + c] = fmaxf(HF[index + c] + LF[index + c], 0.f);
       }
     }
   }
@@ -1271,10 +1275,14 @@ static inline gboolean wavelets_process(const float *const restrict in,
 
     if(s == 0) buffer_out = reconstructed;
 
+    // Pre-compute the regularization factor using the zoom-aware physical radius.
+    // This folds together: user regularization, 3x3 averaging (1/9), and sqf(real_radius).
+    const float normalized_regularization = regularization / 9.f * sqf(real_radius);
+
     // Compute wavelets low-frequency scales
     heat_PDE_diffusion(HF[s], buffer_in, mask, has_mask, buffer_out, width, height,
-                       anisotropy, isotropy_type, regularization,
-                       variance_threshold, sqf(current_radius), mult, ABCD, strength);
+                       anisotropy, isotropy_type, variance_threshold,
+                       normalized_regularization, mult, ABCD, strength);
 
     if(darktable.dump_pfm_module)
     {

--- a/src/iop/diffuse.c
+++ b/src/iop/diffuse.c
@@ -972,7 +972,7 @@ static inline void heat_PDE_diffusion(const float *const restrict high_freq,
   //    automatic detection similar to the structure one,
   //  * generalize the framework for isotropic diffusion and
   //    anisotropic weighted on the isophote direction
-  //  * add a variance regularization to better avoid edges.
+  //  * add an HF-band energy regularization to better avoid edges.
   // The sharpness setting mimics the contrast equalizer effect by
   // simply multiplying the HF by some gain.
 
@@ -1019,8 +1019,8 @@ static inline void heat_PDE_diffusion(const float *const restrict high_freq,
               const float lf_val = LF[neighbor + c];
               neighbour_pixel_HF[3 * ii + jj][c] = hf_val;
               neighbour_pixel_LF[3 * ii + jj][c] = lf_val;
-              // Exposure-invariant band energy: HF/LF ratio squared.
-              // Clamp LF to a strictly positive floor to avoid division by zero.
+              // Clamp LF to a strictly positive floor to avoid divide-by-zero in
+              // the HF/LF energy estimate
               const float safe_lf = fmaxf(lf_val - FLT_MIN, 0.f) + FLT_MIN;
               energy[c] += sqf(hf_val / safe_lf);
             }
@@ -1275,7 +1275,6 @@ static inline gboolean wavelets_process(const float *const restrict in,
 
     if(s == 0) buffer_out = reconstructed;
 
-    // Pre-compute the regularization factor using the zoom-aware physical radius.
     // This folds together: user regularization, 3x3 averaging (1/9), and sqf(real_radius).
     const float normalized_regularization = regularization / 9.f * sqf(real_radius);
 


### PR DESCRIPTION
Aurélien recently published an article on DoS maths at https://ansel.photos/en/resources/diffuse-or-sharpen-math/, and made a number of changes to diffuse.c and diffuse.cl.

This is my attempt at porting them to darktable.

* replace variance calculation with exposure-invariant band energy ratio (HF/LF squared) (see 'Defining a regularization metric', eq 50 - 54)
* avoid divide-by-zero (low-frequency denominator)
* fix OpenCL vs CPU inconsistencies (vertical, then horizontal convolution pass)
* enforce zero-clamping for pixels that fall outside the module's highlight inpainting threshold mask (@aurelienpierre I think this **does** change pixels that are not covered by the mask, is this intentional? the Ansel comment says 'only copy input to output, do nothing', but there is a change due to the clamping)
* optimise OpenCL memory access (reuse the 3x3 loop's center pixel and pass precomputed values into the convolution kernel)

For reference, the commits from Ansel:
* [d7b0cfab](https://github.com/aurelienpierreeng/ansel/commit/d7b0cfab) - Fix diffuse & sharpen bugs
* [c10ae197](https://github.com/aurelienpierreeng/ansel/commit/c10ae197) - diffuse or sharpen: fix post-optimization regression on GPU, better align CPU-GPU code
* [6fbe2a41](https://github.com/aurelienpierreeng/ansel/commit/6fbe2a41) - Fix D & S GPU vs. CPU inconsistencies for real
* [f24440d5](https://github.com/aurelienpierreeng/ansel/commit/f24440d5) - Fix diffuse again

The integration tests **will** have to be adjusted, if the PR is accepted, there are strong differences.