### PR TITLE
[AI] Fix Windows CUDA/OpenVINO support and prevent CUDA driver mismatch crash on Linux

### DIFF
--- a/src/ai/backend_common.c
+++ b/src/ai/backend_common.c
@@ -39,7 +39,7 @@ const dt_ai_provider_desc_t dt_ai_providers[DT_AI_PROVIDER_COUNT] = {
 #endif
   },
   { DT_AI_PROVIDER_CUDA,     "CUDA",     "NVIDIA CUDA",
-#if defined(__linux__)
+#if defined(__linux__) || defined(_WIN32)
     1
 #else
     0
@@ -53,7 +53,7 @@ const dt_ai_provider_desc_t dt_ai_providers[DT_AI_PROVIDER_COUNT] = {
 #endif
   },
   { DT_AI_PROVIDER_OPENVINO, "OpenVINO", "Intel OpenVINO",
-#if defined(__linux__) || (defined(__APPLE__) && defined(__x86_64__))
+#if defined(__linux__) || defined(_WIN32) || (defined(__APPLE__) && defined(__x86_64__))
     1
 #else
     0

--- a/src/ai/backend_onnx.c
+++ b/src/ai/backend_onnx.c
@@ -73,12 +73,15 @@ static gboolean _check_cuda_driver_compat(void)
 
   cached = 1;  // assume ok until proven otherwise
 
-  static const char *cudart_names[] = {
-    "libcudart.so.13", "libcudart.so.12", "libcudart.so.11", "libcudart.so", NULL
-  };
-  GModule *mod = NULL;
-  for(int i = 0; cudart_names[i] && !mod; i++)
-    mod = g_module_open(cudart_names[i], G_MODULE_BIND_LAZY | G_MODULE_BIND_LOCAL);
+  // try unversioned first (available when dev package is installed),
+  // then probe versioned names from high to low
+  GModule *mod = g_module_open("libcudart.so", G_MODULE_BIND_LAZY | G_MODULE_BIND_LOCAL);
+  for(int v = 20; !mod && v >= 11; v--)
+  {
+    char name[32];
+    snprintf(name, sizeof(name), "libcudart.so.%d", v);
+    mod = g_module_open(name, G_MODULE_BIND_LAZY | G_MODULE_BIND_LOCAL);
+  }
   if(!mod) return TRUE;  // can't check — assume compatible
 
   typedef int (*cuda_ver_fn)(int *);

--- a/src/ai/backend_onnx.c
+++ b/src/ai/backend_onnx.c
@@ -62,6 +62,54 @@ static OrtEnv *g_env = NULL;
 static GOnce g_env_once = G_ONCE_INIT;
 static GModule *g_ort_module = NULL;  // custom ORT library loaded via g_module_open
 
+#if defined(__linux__)
+// check that the CUDA driver supports the installed CUDA runtime version;
+// a mismatch causes ORT's CUDA EP to abort() during first inference;
+// result is cached — the check runs only once per process
+static gboolean _check_cuda_driver_compat(void)
+{
+  static int cached = -1;  // -1 = unchecked, 0 = incompatible, 1 = ok
+  if(cached >= 0) return cached == 1;
+
+  cached = 1;  // assume ok until proven otherwise
+
+  static const char *cudart_names[] = {
+    "libcudart.so.13", "libcudart.so.12", "libcudart.so.11", "libcudart.so", NULL
+  };
+  GModule *mod = NULL;
+  for(int i = 0; cudart_names[i] && !mod; i++)
+    mod = g_module_open(cudart_names[i], G_MODULE_BIND_LAZY | G_MODULE_BIND_LOCAL);
+  if(!mod) return TRUE;  // can't check — assume compatible
+
+  typedef int (*cuda_ver_fn)(int *);
+  cuda_ver_fn drv_fn = NULL, rt_fn = NULL;
+  g_module_symbol(mod, "cudaDriverGetVersion",  (gpointer *)&drv_fn);
+  g_module_symbol(mod, "cudaRuntimeGetVersion", (gpointer *)&rt_fn);
+
+  if(drv_fn && rt_fn)
+  {
+    int drv = 0, rt = 0;
+    drv_fn(&drv);
+    rt_fn(&rt);
+    dt_print(DT_DEBUG_AI,
+             "[darktable_ai] CUDA driver %d.%d, runtime %d.%d",
+             drv / 1000, (drv % 1000) / 10,
+             rt / 1000, (rt % 1000) / 10);
+    if(drv < rt)
+    {
+      dt_print(DT_DEBUG_AI,
+               "[darktable_ai] CUDA driver %d.%d is too old for runtime %d.%d — "
+               "disabling CUDA to prevent crash. Update your NVIDIA driver.",
+               drv / 1000, (drv % 1000) / 10,
+               rt / 1000, (rt % 1000) / 10);
+      cached = 0;
+    }
+  }
+  g_module_close(mod);
+  return cached == 1;
+}
+#endif  // __linux__
+
 #ifdef ORT_LAZY_LOAD
 // redirect fd 2 to /dev/null.  returns the saved fd on success, -1 on failure.
 static int _stderr_suppress_begin(void)
@@ -774,6 +822,12 @@ static gboolean _try_provider(OrtSessionOptions *session_opts,
       func_ptr = (void *)GetProcAddress(h, symbol_name);
   }
 #else
+#if defined(__linux__)
+  // before enabling CUDA EP, verify the driver supports the installed runtime;
+  // a driver/runtime version mismatch causes ORT to abort() during inference
+  if(strstr(symbol_name, "CUDA") && !_check_cuda_driver_compat())
+    return FALSE;
+#endif
   GModule *mod = g_module_open(NULL, 0);
   void *func_ptr = NULL;
   if(mod)

--- a/src/ai/backend_onnx.c
+++ b/src/ai/backend_onnx.c
@@ -60,6 +60,7 @@ static const OrtApi *g_ort = NULL;
 static GOnce g_ort_once = G_ONCE_INIT;
 static OrtEnv *g_env = NULL;
 static GOnce g_env_once = G_ONCE_INIT;
+static GModule *g_ort_module = NULL;  // custom ORT library loaded via g_module_open
 
 #ifdef ORT_LAZY_LOAD
 // redirect fd 2 to /dev/null.  returns the saved fd on success, -1 on failure.
@@ -168,6 +169,9 @@ int dt_ai_ort_probe_library_full(const char *path, char **out_version, char **ou
 // Returns a GList of dt_ai_ort_found_t (caller owns list and contents).
 GList *dt_ai_ort_find_libraries(void)
 {
+#ifdef _WIN32
+  static const char *system_paths[] = { NULL };
+#else
   // system library paths (distro packages)
   static const char *system_paths[] = {
     "/usr/lib/libonnxruntime.so",
@@ -178,17 +182,56 @@ GList *dt_ai_ort_find_libraries(void)
     "/usr/local/lib64/libonnxruntime.so",
     NULL
   };
+#endif
 
-  // user-space paths (install scripts) — scan for versioned .so files
-  const char *home = g_get_home_dir();
+  // user-space paths (install scripts) — scan for ORT libraries
   static const char *subdirs[] = { "onnxruntime-cuda", "onnxruntime-migraphx", "onnxruntime-openvino" };
   gchar *user_paths[3] = { NULL };
 
+#ifdef _WIN32
+  // on Windows the install script puts libraries under %LOCALAPPDATA%
+  const char *local_app = g_getenv("LOCALAPPDATA");
+  const char *base_dir = local_app ? local_app : g_get_home_dir();
+#else
+  const char *base_dir = g_get_home_dir();
+#endif
+
   for(int i = 0; i < 3; i++)
   {
-    gchar *dir = g_build_filename(home, ".local/lib", subdirs[i], NULL);
+#ifdef _WIN32
+    gchar *dir = g_build_filename(base_dir, subdirs[i], NULL);
+#else
+    gchar *dir = g_build_filename(base_dir, ".local/lib", subdirs[i], NULL);
+#endif
     if(g_file_test(dir, G_FILE_TEST_IS_DIR))
     {
+#ifdef _WIN32
+      // look for onnxruntime.dll
+      gchar *exact = g_build_filename(dir, "onnxruntime.dll", NULL);
+      if(g_file_test(exact, G_FILE_TEST_EXISTS))
+      {
+        user_paths[i] = exact;
+      }
+      else
+      {
+        g_free(exact);
+        GDir *d = g_dir_open(dir, 0, NULL);
+        if(d)
+        {
+          const gchar *name;
+          while((name = g_dir_read_name(d)))
+          {
+            if(g_str_has_prefix(name, "onnxruntime") &&
+               g_str_has_suffix(name, ".dll"))
+            {
+              user_paths[i] = g_build_filename(dir, name, NULL);
+              break;
+            }
+          }
+          g_dir_close(d);
+        }
+      }
+#else
       gchar *exact = g_build_filename(dir, "libonnxruntime.so", NULL);
       if(g_file_test(exact, G_FILE_TEST_EXISTS))
       {
@@ -212,6 +255,7 @@ GList *dt_ai_ort_find_libraries(void)
           g_dir_close(d);
         }
       }
+#endif
     }
     g_free(dir);
   }
@@ -329,6 +373,24 @@ static gpointer _init_ort_api(gpointer data)
 
   if(ort_override)
   {
+#ifdef _WIN32
+    // set the DLL search directory to the custom ORT location so that
+    // provider DLLs (onnxruntime_providers_cuda.dll) and their bundled
+    // dependencies (cuDNN, cublas) are found by LoadLibrary;
+    // the install script copies all required DLLs into this directory
+    gchar *ort_dir = g_path_get_dirname(ort_override);
+    if(ort_dir)
+    {
+      wchar_t *wdir = g_utf8_to_utf16(ort_dir, -1, NULL, NULL, NULL);
+      if(wdir)
+      {
+        SetDllDirectoryW(wdir);
+        dt_print(DT_DEBUG_AI, "[darktable_ai] set DLL directory: %s", ort_dir);
+        g_free(wdir);
+      }
+      g_free(ort_dir);
+    }
+#endif
     GModule *ort_mod = g_module_open(ort_override, G_MODULE_BIND_LAZY);
     if(!ort_mod)
     {
@@ -337,6 +399,7 @@ static gpointer _init_ort_api(gpointer data)
                ort_override, g_module_error());
       goto done;
     }
+    g_ort_module = ort_mod;  // keep handle for _try_provider EP lookups
     api = _ort_api_from_module(ort_mod, ort_override);
   }
 #ifdef ORT_LAZY_LOAD
@@ -695,18 +758,20 @@ static gboolean _try_provider(OrtSessionOptions *session_opts,
   dt_print(DT_DEBUG_AI, "[darktable_ai] attempting to enable %s...", provider_name);
 
 #ifdef _WIN32
-  // on windows, we need to get the handle to onnxruntime.dll, not the main executable
-  HMODULE h = GetModuleHandleA("onnxruntime.dll");
-  if(!h)
-  {
-    // if not already loaded, try to load it
-    h = LoadLibraryA("onnxruntime.dll");
-  }
   void *func_ptr = NULL;
-  if(h)
+  // if a custom ORT library was loaded (e.g. CUDA build), look up the
+  // EP symbol there — the bundled DirectML onnxruntime.dll won't have it
+  if(g_ort_module)
   {
-    func_ptr = (void *)GetProcAddress(h, symbol_name);
-    // don't call FreeLibrary - we want to keep onnxruntime.dll loaded
+    g_module_symbol(g_ort_module, symbol_name, &func_ptr);
+  }
+  if(!func_ptr)
+  {
+    HMODULE h = GetModuleHandleA("onnxruntime.dll");
+    if(!h)
+      h = LoadLibraryA("onnxruntime.dll");
+    if(h)
+      func_ptr = (void *)GetProcAddress(h, symbol_name);
   }
 #else
   GModule *mod = g_module_open(NULL, 0);


### PR DESCRIPTION
Two fixes for AI backend reliability on Windows and Linux:

- **Windows CUDA/OpenVINO support**: fix EP probing, library detection, and DLL loading so CUDA and OpenVINO providers work on Windows alongside the bundled DirectML build
- **Linux CUDA driver check**: detect driver/runtime version mismatch before enabling CUDA EP to prevent ORT's `abort()` crash during inference

### Windows changes

- Enable CUDA and OpenVINO provider visibility on Windows (`backend_common.c`)
- Add Windows DLL search paths for user-installed ORT libraries (`%LOCALAPPDATA%/onnxruntime-cuda/` etc.)
- Scan for `onnxruntime.dll` instead of `.so` files
- Set `SetDllDirectoryW` to the custom ORT directory so provider DLLs (CUDA, cuDNN, cublas) are found by `LoadLibrary`
- Look up EP symbols in the custom-loaded `g_ort_module` first, fall back to system `onnxruntime.dll` – fixes the case where the bundled DirectML build doesn't have CUDA symbols

### Linux CUDA driver check

- New `_check_cuda_driver_compat()`: loads `libcudart.so`, calls `cudaDriverGetVersion` / `cudaRuntimeGetVersion`, compares versions
- If driver < runtime, logs a clear message and disables CUDA EP instead of letting ORT `abort()` mid-inference
- Result is cached per process – check runs only once
- Called from `_try_provider` before any CUDA EP symbol lookup