### PR TITLE
gtk4-ify scrolling continued (left/right panels, navigation, and geotagging) and add pinch-to-zoom on navigation widget

### DIFF
--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -3078,14 +3078,6 @@ static void _widget_scroll(GtkEventControllerScroll *controller,
   GdkEvent *event = gtk_get_current_event();
   if(!event || gdk_event_get_event_type(event) != GDK_SCROLL)
     dt_print(DT_DEBUG_ALWAYS, "[_widget_scroll] called on non-scroll event");
-  else if(dt_gui_ignore_scroll(&event->scroll))
-  {
-    // event controller handlers can't propagate events, so synthesize
-    // an event directly to the destination widget
-    GtkWidget *sw = gtk_widget_get_ancestor(widget, GTK_TYPE_SCROLLED_WINDOW);
-    if(sw)
-      gtk_widget_event(sw, event);
-  }
   else if(darktable.control->mapping_widget)
   {
     // handle speed adjustment in mapping mode in dispatcher
@@ -3732,8 +3724,9 @@ static void dt_bh_init(DtBauhausWidget *w)
   dt_gui_connect_motion(w, _widget_motion, _widget_enter, _widget_leave, widget);
 
   GtkEventController *scroll_controller =
-    dt_gui_connect_scroll_discrete(w, GTK_EVENT_CONTROLLER_SCROLL_BOTH_AXES,
-                                   _widget_scroll, widget);
+    dt_gui_connect_scroll(w, GTK_EVENT_CONTROLLER_SCROLL_BOTH_AXES
+                             | GTK_EVENT_CONTROLLER_SCROLL_DISCRETE,
+                          _widget_scroll, widget);
   // allows for capturing propagated events from other widgets
   gtk_event_controller_set_propagation_phase(scroll_controller, GTK_PHASE_BUBBLE);
 

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -423,6 +423,7 @@ static gboolean _borders_button_pressed(GtkWidget *w,
 }
 
 // FIXME: if this is only called from scroll handlers, move this logic to scroll proxy
+// FIXME: just call with GdkModifierType as state
 gboolean dt_gui_ignore_scroll(GdkEventScroll *event)
 {
   const gboolean ignore_without_mods =
@@ -794,14 +795,21 @@ static gboolean _scrolled(GtkWidget *widget,
   return TRUE;
 }
 
-static gboolean _borders_scrolled(GtkWidget *widget,
-                                  GdkEventScroll *event,
-                                  const gpointer user_data)
+static void _panel_scrolled(GtkEventControllerScroll *controller,
+                            double dx, double dy,
+                            GtkAdjustment *adj)
 {
-  // pass the scroll event to the matching side panel
-  gtk_widget_event(GTK_WIDGET(user_data), (GdkEvent*)event);
-
-  return TRUE;
+  // GTK4: don't need to clamp to upper/lower
+  const double lower = gtk_adjustment_get_lower(adj);
+  const double upper = gtk_adjustment_get_upper(adj)
+                       - gtk_adjustment_get_page_size(adj);
+  const double step = gtk_adjustment_get_step_increment(adj);
+  const double old_val = gtk_adjustment_get_value(adj);
+  const double new_val = CLAMPF(old_val + dy * step, lower, upper);
+  gtk_adjustment_set_value(adj, new_val);
+  // GTK3: explicitly consume the scroll
+  g_signal_stop_emission_by_name(controller, "scroll");
+  // GTK4: return GDK_EVENT_STOP;
 }
 
 static void _scrollbar_changed(GtkWidget *widget,
@@ -2507,6 +2515,7 @@ static gboolean _ui_init_panel_container_center_scroll_event(GtkWidget *widget,
   return (((event->state & gtk_accelerator_get_default_mod_mask())
            != darktable.gui->sidebar_scroll_mask)
           != dt_conf_get_bool("darkroom/ui/sidebar_scroll_default"));
+  // GTK4: return GDK_EVENT_PROPAGATE/GDK_EVENT_STOP
 }
 
 static gboolean _on_drag_motion_drop(GtkWidget *empty, GdkDragContext *dc, const gint x, const gint y, const guint time, const gboolean drop)
@@ -2623,42 +2632,46 @@ static gboolean _side_panel_draw(GtkWidget *widget,
 static GtkWidget *_ui_init_panel_container_center(GtkWidget *container,
                                                   const gboolean left)
 {
-  GtkWidget *widget;
-
   /* create the scrolled window */
-  widget = gtk_scrolled_window_new(NULL, GTK_ADJUSTMENT(gtk_adjustment_new(0, 0, 100, 1, 10, 10)));
-  gtk_widget_set_can_focus(widget, TRUE);
-  gtk_scrolled_window_set_placement(GTK_SCROLLED_WINDOW(widget),
+  GtkAdjustment *vadj = gtk_adjustment_new(0, 0, 100, 1, 10, 10);
+  GtkWidget *sw = gtk_scrolled_window_new(NULL, GTK_ADJUSTMENT(vadj));
+  gtk_widget_set_can_focus(sw, TRUE);
+  gtk_scrolled_window_set_placement(GTK_SCROLLED_WINDOW(sw),
                                     left ? GTK_CORNER_TOP_LEFT : GTK_CORNER_TOP_RIGHT);
-  gtk_box_pack_start(GTK_BOX(container), widget, TRUE, TRUE, 0);
-  gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(widget), GTK_POLICY_NEVER,
+  gtk_box_pack_start(GTK_BOX(container), sw, TRUE, TRUE, 0);
+  gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(sw), GTK_POLICY_NEVER,
                                  dt_conf_get_bool("panel_scrollbars_always_visible")
                                  ? GTK_POLICY_ALWAYS
                                  : GTK_POLICY_AUTOMATIC);
-  gtk_scrolled_window_set_propagate_natural_width(GTK_SCROLLED_WINDOW(widget), TRUE);
+  gtk_scrolled_window_set_propagate_natural_width(GTK_SCROLLED_WINDOW(sw), TRUE);
 
-  // we want the left/right window border to scroll the module lists
-  g_signal_connect(G_OBJECT(left
-                            ? darktable.gui->widgets.right_border
-                            : darktable.gui->widgets.left_border),
-                   "scroll-event", G_CALLBACK(_borders_scrolled), widget);
+  // scrolling the left/right window border scrolls the module lists,
+  // passing on scroll via gtk_widget_event() breaks kinetic scrolling
+  // and isn't GTK4 ready, so directly change GtkAdjustment
+  dt_gui_connect_scroll(left
+                        ? darktable.gui->widgets.right_border
+                        : darktable.gui->widgets.left_border,
+                        GTK_EVENT_CONTROLLER_SCROLL_VERTICAL,
+                        _panel_scrolled, vadj);
 
   /* avoid scrolling with wheel, it's distracting (you'll end up over
-   * a control, and scroll it's value) */
-  g_signal_connect(G_OBJECT(widget), "scroll-event",
+   * a control, and scroll it's value), only scroll on modifier */
+  // GTK4: this is absolutely not GTK4 compatible, but there is no way
+  // in GTK3 to have child widgets have their own scroll behavior and
+  // have a GtkEventControllerScroll on the parent GtkScrolledWindow.
+  g_signal_connect(G_OBJECT(sw), "scroll-event",
                    G_CALLBACK(_ui_init_panel_container_center_scroll_event),
                    NULL);
 
   /* create the container */
-  container = widget;
-  widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
-  gtk_widget_set_name(widget, "plugins_vbox_left");
-  gtk_container_add(GTK_CONTAINER(container), widget);
-  g_signal_connect_swapped(widget, "draw", G_CALLBACK(_side_panel_draw), NULL);
+  GtkWidget *box = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
+  gtk_widget_set_name(box, "plugins_vbox_left");
+  gtk_container_add(GTK_CONTAINER(sw), box);
+  g_signal_connect_swapped(box, "draw", G_CALLBACK(_side_panel_draw), NULL);
 
   GtkWidget *empty = gtk_event_box_new();
   gtk_widget_set_tooltip_text(empty, _("right-click to show/hide modules"));
-  gtk_box_pack_end(GTK_BOX(widget), empty, TRUE, TRUE, 0);
+  gtk_box_pack_end(GTK_BOX(box), empty, TRUE, TRUE, 0);
   gtk_drag_dest_set(empty, 0, NULL, 0, GDK_ACTION_COPY);
   g_signal_connect(empty, "drag-motion", G_CALLBACK(_on_drag_motion_drop), GINT_TO_POINTER(FALSE));
   g_signal_connect(empty, "drag-drop", G_CALLBACK(_on_drag_motion_drop), GINT_TO_POINTER(TRUE));
@@ -2668,8 +2681,7 @@ static GtkWidget *_ui_init_panel_container_center(GtkWidget *container,
   dt_action_t *ac = dt_action_define(&darktable.control->actions_global, NULL,
                                      N_("show/hide modules"), empty, NULL);
   dt_action_register(ac, NULL, _add_remove_modules, 0, 0);
-
-  return widget;
+  return box;
 }
 
 static GtkWidget *_ui_init_panel_container_bottom(GtkWidget *container)
@@ -4761,6 +4773,39 @@ GtkEventController *(dt_gui_connect_motion)(GtkWidget *widget,
   return controller;
 }
 
+typedef void (*scroll_handler_t)(GtkEventControllerScroll*, gdouble, gdouble, gpointer);
+static gdouble _scroll_discrete_dx = 0.0;
+static gdouble _scroll_discrete_dy = 0.0;
+static const char *_scroll_real_handler_key = "real-scroll-handler";
+
+static gboolean _scroll_sidebar(GtkEventControllerScroll* controller,
+                                gdouble dy,
+                                GdkEvent* event)
+{
+  // GTK4: the sidebar scroll controller can capture scrolls then
+  // decide whether to propogate them or scroll itself depending on
+  // modifiers state, and this function will no longer be needed
+  GtkWidget *const widget =
+    gtk_event_controller_get_widget(GTK_EVENT_CONTROLLER(controller));
+  const GtkWidget *panel = NULL;
+  if(dt_ui_panel_ancestor(darktable.gui->ui, DT_UI_PANEL_LEFT, widget))
+    panel = darktable.gui->ui->panels[DT_UI_PANEL_LEFT];
+  else if(dt_ui_panel_ancestor(darktable.gui->ui, DT_UI_PANEL_RIGHT, widget))
+    panel = darktable.gui->ui->panels[DT_UI_PANEL_RIGHT];
+  if(panel && dt_gui_ignore_scroll(&event->scroll))
+  {
+    // FIXME: do we need to even check if in left/right panel? will this break if mouse over a widget within a GtkScrolledWindow within the panel GtkScrolledWindow?
+    GtkWidget *const sw = gtk_widget_get_ancestor(widget, GTK_TYPE_SCROLLED_WINDOW);
+    if(sw)
+    {
+      GtkAdjustment *vadj = gtk_scrolled_window_get_vadjustment(GTK_SCROLLED_WINDOW(sw));
+      _panel_scrolled(controller, 0.0, dy, vadj);
+      return TRUE;
+    }
+  }
+  return FALSE;
+}
+
 static float _scroll_attenuate(gdouble delta)
 {
 #ifndef GDK_WINDOWING_QUARTZ
@@ -4779,36 +4824,6 @@ static float _scroll_attenuate(gdouble delta)
   return scale * copysign(pow(fabs(delta), compression), delta);
 }
 
-typedef void (*scroll_handler_t)(GtkEventControllerScroll*, gdouble, gdouble, gpointer);
-static gdouble _scroll_discrete_dx = 0.0;
-static gdouble _scroll_discrete_dy = 0.0;
-static const char *_scroll_real_handler_key = "real-scroll-handler";
-
-static gboolean _scroll_sidebar(GtkEventControllerScroll* controller,
-                                GdkEvent* event)
-{
-  GtkWidget *const widget =
-    gtk_event_controller_get_widget(GTK_EVENT_CONTROLLER(controller));
-  const GtkWidget *panel = NULL;
-  if(dt_ui_panel_ancestor(darktable.gui->ui, DT_UI_PANEL_LEFT, widget))
-    panel = darktable.gui->ui->panels[DT_UI_PANEL_LEFT];
-  else if(dt_ui_panel_ancestor(darktable.gui->ui, DT_UI_PANEL_RIGHT, widget))
-    panel = darktable.gui->ui->panels[DT_UI_PANEL_RIGHT];
-  if(panel && dt_gui_ignore_scroll(&event->scroll))
-  {
-    // FIXME: do need to test if ancestor is scrollable? do we need to even check if in left/right panel?
-    GtkWidget *const sw = gtk_widget_get_ancestor(widget, GTK_TYPE_SCROLLED_WINDOW);
-    if(sw)
-    {
-      // event controller handlers can't propagate events, so synthesize
-      // an event directly to the destination widget
-      gtk_widget_event(sw, event);
-      return TRUE;
-    }
-  }
-  return FALSE;
-}
-
 static void _scroll_proxy_real(GtkEventControllerScroll* controller,
                                gdouble dx,
                                gdouble dy,
@@ -4817,10 +4832,11 @@ static void _scroll_proxy_real(GtkEventControllerScroll* controller,
 {
   GdkEvent *const event = gtk_get_current_event();
   if(!event) return;
+  // FIXME: make sure this logic is right -- want to ignore emulated pointer events, attenuate scroll events with data, and use any deltas not emulated
   if(gdk_event_get_event_type(event) == GDK_SCROLL
      // don't double counting real and emulated smooth scroll events
      && !gdk_event_get_pointer_emulated(event)
-     && !_scroll_sidebar(controller, event))
+     && !_scroll_sidebar(controller, dy, event))
   {
     if(event->scroll.direction == GDK_SCROLL_SMOOTH)
     {

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -422,6 +422,7 @@ static gboolean _borders_button_pressed(GtkWidget *w,
   return TRUE;
 }
 
+// FIXME: if this is only called from scroll handlers, move this logic to scroll proxy
 gboolean dt_gui_ignore_scroll(GdkEventScroll *event)
 {
   const gboolean ignore_without_mods =
@@ -4760,92 +4761,139 @@ GtkEventController *(dt_gui_connect_motion)(GtkWidget *widget,
   return controller;
 }
 
-GtkEventController *(dt_gui_connect_scroll)(GtkWidget *widget,
-                                            GtkEventControllerScrollFlags flags,
-                                            GCallback scroll,
-                                            gpointer data)
+static float _scroll_attenuate(gdouble delta)
 {
-  GtkEventController *controller = gtk_event_controller_scroll_new(widget, flags);
-  gtk_event_controller_set_propagation_phase(controller, GTK_PHASE_TARGET);
-  g_object_weak_ref(G_OBJECT (widget), (GWeakNotify) g_object_unref, controller);
-  // GTK4 gtk_widget_add_controller(widget, GTK_EVENT_CONTROLLER(controller));
-  if(scroll) g_signal_connect(controller, "scroll", G_CALLBACK(scroll), data);
-  return controller;
+#ifndef GDK_WINDOWING_QUARTZ
+  // Linux/Windows smooth scroll events are 0 < delta <= 1, slightly
+  // amplify small deltas and damp larger deltas
+  const double scale = 0.95;
+  const double compression = 0.9;
+#else
+  // MacOS scrolling is apparently distance-based, so can produce a
+  // range of large/small deltas. Most are delta 1, a few can be as
+  // high as 10. Compress the higher scroll deltas in particular, and
+  // place them all in range of Linux/Windows scrolling.
+  const double scale = 0.06;
+  const double compression = 0.7;
+#endif
+  return scale * copysign(pow(fabs(delta), compression), delta);
 }
 
 typedef void (*scroll_handler_t)(GtkEventControllerScroll*, gdouble, gdouble, gpointer);
 static gdouble _scroll_discrete_dx = 0.0;
 static gdouble _scroll_discrete_dy = 0.0;
-static const char *_scroll_discrete_real_handler_key = "real-scroll-discrete-handler";
+static const char *_scroll_real_handler_key = "real-scroll-handler";
 
-static void _scroll_discrete_proxy(GtkEventControllerScroll* controller,
-                                   gdouble dx,
-                                   gdouble dy,
-                                   gpointer user_data)
+static gboolean _scroll_sidebar(GtkEventControllerScroll* controller,
+                                GdkEvent* event)
 {
-  GdkEvent *event = gtk_get_current_event();
-  if(!event) return;
-  // avoid double counting real and emulated events
-  if(!gdk_event_get_pointer_emulated(event))
+  GtkWidget *const widget =
+    gtk_event_controller_get_widget(GTK_EVENT_CONTROLLER(controller));
+  const GtkWidget *panel = NULL;
+  if(dt_ui_panel_ancestor(darktable.gui->ui, DT_UI_PANEL_LEFT, widget))
+    panel = darktable.gui->ui->panels[DT_UI_PANEL_LEFT];
+  else if(dt_ui_panel_ancestor(darktable.gui->ui, DT_UI_PANEL_RIGHT, widget))
+    panel = darktable.gui->ui->panels[DT_UI_PANEL_RIGHT];
+  if(panel && dt_gui_ignore_scroll(&event->scroll))
   {
-    if(gdk_event_get_event_type(event) == GDK_SCROLL
-       && event->scroll.direction == GDK_SCROLL_SMOOTH)
+    // FIXME: do need to test if ancestor is scrollable? do we need to even check if in left/right panel?
+    GtkWidget *const sw = gtk_widget_get_ancestor(widget, GTK_TYPE_SCROLLED_WINDOW);
+    if(sw)
     {
-      // MacOS scrolling is apparently distance-based, so can produce
-      // a range of large/small deltas. Most current code accumulates
-      // & attenuates via dt_gui_get_scroll_unit_deltas(). For
-      // GTK4-ready "scroll" events, use discrete scrolling based on
-      // gtk_event_controller_scroll_handle_event(), with attenuation.
-#ifdef GDK_WINDOWING_QUARTZ
-      const double scale = 0.06;
-      const double compression = 0.7;
-#else
-      const double scale = 0.95;
-      const double compression = 0.9;
-#endif
-      dx = scale * copysign(pow(fabs(dx), compression), dx);
-      dy = scale * copysign(pow(fabs(dy), compression), dy);
-      _scroll_discrete_dx += dx;
-      _scroll_discrete_dy += dy;
-      dx = dy = 0.0;
-      if(fabs(_scroll_discrete_dx) >= 1.0)
+      // event controller handlers can't propagate events, so synthesize
+      // an event directly to the destination widget
+      gtk_widget_event(sw, event);
+      return TRUE;
+    }
+  }
+  return FALSE;
+}
+
+static void _scroll_proxy_real(GtkEventControllerScroll* controller,
+                               gdouble dx,
+                               gdouble dy,
+                               gpointer user_data,
+                               gboolean discrete)
+{
+  GdkEvent *const event = gtk_get_current_event();
+  if(!event) return;
+  if(gdk_event_get_event_type(event) == GDK_SCROLL
+     // don't double counting real and emulated smooth scroll events
+     && !gdk_event_get_pointer_emulated(event)
+     && !_scroll_sidebar(controller, event))
+  {
+    if(event->scroll.direction == GDK_SCROLL_SMOOTH)
+    {
+      dx = _scroll_attenuate(dx);
+      dy = _scroll_attenuate(dy);
+      if(discrete)
       {
-        int steps = trunc(_scroll_discrete_dx);
-        _scroll_discrete_dx -= steps;
-        dx = steps;
+        _scroll_discrete_dx += dx;
+        _scroll_discrete_dy += dy;
+        dx = dy = 0.0;
+        // can return |delta| > 1, but clamping to -1 < delta < 1 dulls
+        // responsiveness, so it is up to the caller to handle this
+        // FIXME: actually clamp and if caller doesn't want clamping
+        //        they should not use discerete scrolling?
+        // FIXME: make another flag to setup func if want to clamp?
+        if(fabs(_scroll_discrete_dx) >= 1.0)
+        {
+          const int steps = trunc(_scroll_discrete_dx);
+          _scroll_discrete_dx -= steps;
+          dx = steps;
+        }
+        if(fabs(_scroll_discrete_dy) >= 1.0)
+        {
+          const int steps = trunc(_scroll_discrete_dy);
+          _scroll_discrete_dy -= steps;
+          dy = steps;
+        }
       }
-      if(fabs(_scroll_discrete_dy) >= 1.0)
-      {
-        int steps = trunc(_scroll_discrete_dy);
-        _scroll_discrete_dy -= steps;
-        dy = steps;
-      }
-      // FIXME: modern mouse wheels can produce smooth scroll events
-      //        with |delta| > 1, for now the caller must clamp these
     }
     if(dx != 0.0 || dy != 0.0)
     {
-      scroll_handler_t real_handler =
-        g_object_get_data(G_OBJECT(controller), _scroll_discrete_real_handler_key);
+      const scroll_handler_t real_handler =
+        g_object_get_data(G_OBJECT(controller), _scroll_real_handler_key);
       real_handler(controller, dx, dy, user_data);
     }
   }
   gdk_event_free(event);
 }
 
-GtkEventController *(dt_gui_connect_scroll_discrete)(GtkWidget *widget,
-                                                     GtkEventControllerScrollFlags flags,
-                                                     GCallback scroll_callback,
-                                                     gpointer user_data)
+static void _scroll_proxy(GtkEventControllerScroll* controller,
+                          gdouble dx,
+                          gdouble dy,
+                          gpointer data)
 {
-  // Use proxy, not GTK discrete scrolling, to attenuate. We could use
-  // GTK discrete scrolling for non-MacOS, but it makes it hard to
-  // test if a chunk of code is particular to one OS.
-  GtkEventController *controller =
-    dt_gui_connect_scroll(widget, flags & ~GTK_EVENT_CONTROLLER_SCROLL_DISCRETE,
-                          _scroll_discrete_proxy, user_data);
-  g_object_set_data(G_OBJECT(controller),
-                    _scroll_discrete_real_handler_key, scroll_callback);
+  _scroll_proxy_real(controller, dx, dy, data, FALSE);
+}
+
+static void _scroll_discrete_proxy(GtkEventControllerScroll* controller,
+                                   gdouble dx,
+                                   gdouble dy,
+                                   gpointer data)
+{
+  _scroll_proxy_real(controller, dx, dy, data, TRUE);
+}
+
+GtkEventController *(dt_gui_connect_scroll)(GtkWidget *widget,
+                                               GtkEventControllerScrollFlags flags,
+                                               GCallback scroll,
+                                               gpointer data)
+{
+  // FIXME: instead of using two proxy functions, set controller property if discrete
+  const scroll_handler_t proxy =
+    (flags & GTK_EVENT_CONTROLLER_SCROLL_DISCRETE) ?
+    _scroll_discrete_proxy : _scroll_proxy;
+  // proxy will attenuate, so bypass GTK's discrete scrolling code
+  flags &= ~GTK_EVENT_CONTROLLER_SCROLL_DISCRETE;
+
+  GtkEventController *const controller = gtk_event_controller_scroll_new(widget, flags);
+  gtk_event_controller_set_propagation_phase(controller, GTK_PHASE_TARGET);
+  g_object_weak_ref(G_OBJECT(widget), (GWeakNotify) g_object_unref, controller);
+  // GTK4 gtk_widget_add_controller(widget, GTK_EVENT_CONTROLLER(controller));
+  g_signal_connect(controller, "scroll", G_CALLBACK(proxy), data);
+  g_object_set_data(G_OBJECT(controller), _scroll_real_handler_key, scroll);
   return controller;
 }
 

--- a/src/gui/gtk.h
+++ b/src/gui/gtk.h
@@ -583,14 +583,6 @@ GtkEventController *(dt_gui_connect_scroll)(GtkWidget *widget,
   ASSERT_FUNC_TYPE(scroll, void(*)(GtkEventControllerScroll *, double, double, __typeof__(data))), \
   dt_gui_connect_scroll(GTK_WIDGET(widget), (flags), G_CALLBACK(scroll), (data)))
 
-GtkEventController *(dt_gui_connect_scroll_discrete)(GtkWidget *widget,
-						     GtkEventControllerScrollFlags flags,
-						     GCallback scroll,
-						     gpointer data);
-#define dt_gui_connect_scroll_discrete(widget, flags, scroll, data) ( \
-  ASSERT_FUNC_TYPE(scroll, void(*)(GtkEventControllerScroll *, double, double, __typeof__(data))), \
-  dt_gui_connect_scroll_discrete(GTK_WIDGET(widget), (flags), G_CALLBACK(scroll), (data)))
-
 #define dt_gui_claim(gesture) \
       gtk_gesture_set_state(GTK_GESTURE(gesture), GTK_EVENT_SEQUENCE_CLAIMED)
 #define dt_gui_deny(gesture) \

--- a/src/libs/geotagging.c
+++ b/src/libs/geotagging.c
@@ -1439,26 +1439,20 @@ static void _selection_changed_callback(gpointer instance, dt_lib_module_t *self
 #endif
 }
 
-static gboolean _datetime_scroll_over(GtkWidget *w, GdkEventScroll *event, dt_lib_module_t *self)
+static void _datetime_scroll_over(GtkEventControllerScroll *controller,
+                                  double dx, double dy,
+                                  dt_lib_module_t *self)
 {
-  if(dt_gui_ignore_scroll(event)) return FALSE;
-
   dt_lib_geotagging_t *d = self->data;
   if(!d->editing)
   {
+    GtkWidget* w = gtk_event_controller_get_widget(GTK_EVENT_CONTROLLER(controller));
     int i = 0;
     for(i = 0; i < DT_GEOTAG_PARTS_NB; i++)
       if(w == d->dt.widget[i]) break;
 
-    int delta_y;
-    int increment = 0;
-    if(dt_gui_get_scroll_unit_delta(event, &delta_y))
-    {
-      if(delta_y < 0) increment = 1;
-      else if(delta_y > 0) increment = -1;
-    }
-
-    if(dt_modifier_is(event->state, GDK_SHIFT_MASK))
+    int increment = CLAMPF(-dy, -1, 1);
+    if(dt_modifier_eq(controller, GDK_SHIFT_MASK))
       increment *= 10;
 
     GDateTime *datetime;
@@ -1491,8 +1485,6 @@ static gboolean _datetime_scroll_over(GtkWidget *w, GdkEventScroll *event, dt_li
 
     _new_datetime(datetime, self);
   }
-
-  return TRUE;
 }
 
 // type 0 date/time, 1 original date/time, 2 offset
@@ -2006,7 +1998,11 @@ void gui_init(dt_lib_module_t *self)
   {
     g_signal_connect(d->dt.widget[i], "changed", G_CALLBACK(_datetime_entry_changed), self);
     g_signal_connect(d->dt.widget[i], "key-press-event", G_CALLBACK(_datetime_key_pressed), self);
-    g_signal_connect(d->dt.widget[i], "scroll-event", G_CALLBACK(_datetime_scroll_over), self);
+    dt_gui_connect_scroll(d->dt.widget[i],
+                          GTK_EVENT_CONTROLLER_SCROLL_VERTICAL
+                          | GTK_EVENT_CONTROLLER_SCROLL_DISCRETE,
+                          _datetime_scroll_over,
+                          self);
   }
   DT_CONTROL_SIGNAL_HANDLE(DT_SIGNAL_SELECTION_CHANGED, _selection_changed_callback);
   DT_CONTROL_SIGNAL_HANDLE(DT_SIGNAL_MOUSE_OVER_IMAGE_CHANGE, _mouse_over_image_callback);

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -861,8 +861,9 @@ void gui_init(dt_lib_module_t *self)
 
   // FIXME: add (optional) propagation phase argument to dt_gui_connect_*()
   GtkEventController *scroll_controller =
-    dt_gui_connect_scroll_discrete(eventbox, GTK_EVENT_CONTROLLER_SCROLL_BOTH_AXES,
-                                   _eventbox_scroll_callback, s);
+    dt_gui_connect_scroll(eventbox, GTK_EVENT_CONTROLLER_SCROLL_BOTH_AXES
+                                    | GTK_EVENT_CONTROLLER_SCROLL_DISCRETE,
+                          _eventbox_scroll_callback, s);
   gtk_event_controller_set_propagation_phase(scroll_controller, GTK_PHASE_CAPTURE);
   // use GTK_PHASE_TARGET to capture enter/leave events, as
   // enter/leave events apparently not bubbled in GTK < 3.24.43.

--- a/src/libs/navigation.c
+++ b/src/libs/navigation.c
@@ -51,6 +51,18 @@ static gboolean _lib_navigation_draw_callback(GtkWidget *widget,
 static gboolean _lib_navigation_motion_notify_callback(GtkWidget *widget,
                                                        GdkEventMotion *event,
                                                        dt_lib_module_t *self);
+/* scroll callback */
+static void _lib_navigation_scroll_callback(GtkEventControllerScroll *controller,
+                                            double dx, double dy,
+                                            dt_lib_module_t *self);
+/* zoom begin callback */
+static void _lib_navigation_pinch_begin_callback(GtkGesture *gesture,
+                                                GdkEventSequence* sequence,
+                                                dt_lib_module_t *self);
+/* zoom scale-changed callback */
+static void _lib_navigation_pinch_scale_callback(GtkGesture *gesture,
+                                                gdouble scale,
+                                                dt_lib_module_t *self);
 /* button press callback */
 static gboolean _lib_navigation_button_press_callback(GtkWidget *widget,
                                                       GdkEvent *event,
@@ -218,10 +230,17 @@ void gui_init(dt_lib_module_t *self)
                    G_CALLBACK(_lib_navigation_draw_callback), self);
   g_signal_connect(G_OBJECT(thumbnail), "button-press-event",
                    G_CALLBACK(_lib_navigation_button_press_callback), self);
-  g_signal_connect(G_OBJECT(thumbnail), "scroll-event",
-                   G_CALLBACK(_lib_navigation_button_press_callback), self);
   g_signal_connect(G_OBJECT(thumbnail), "button-release-event",
                    G_CALLBACK(_lib_navigation_button_release_callback), self);
+  dt_gui_connect_scroll(thumbnail, GTK_EVENT_CONTROLLER_SCROLL_BOTH_AXES,
+                        _lib_navigation_scroll_callback, self);
+  // FIXME: Make helper function for zoom gesture. If discrete zooming
+  //        as here is a well-used pattern, make proxy which handles
+  //        this so don't need to implement a "begin" handler here.
+  GtkGesture *zoom_gesture = gtk_gesture_zoom_new(thumbnail);
+  g_object_weak_ref(G_OBJECT(thumbnail), (GWeakNotify) g_object_unref, zoom_gesture);
+  g_signal_connect(zoom_gesture, "begin", G_CALLBACK(_lib_navigation_pinch_begin_callback), self);
+  g_signal_connect(zoom_gesture, "scale-changed", G_CALLBACK(_lib_navigation_pinch_scale_callback), self);
   g_signal_connect(G_OBJECT(thumbnail), "motion-notify-event",
                    G_CALLBACK(_lib_navigation_motion_notify_callback), self);
   g_signal_connect(G_OBJECT(thumbnail), "leave-notify-event",
@@ -448,6 +467,114 @@ static void _zoom_changed(GtkWidget *widget, gpointer user_data)
     scale = val / 100.0f * ppd;
 
   dt_dev_zoom_move(port, zoom, scale, closeup, -1.0f, -1.0f, TRUE);
+}
+
+static gboolean _lib_navigation_widget_to_center(GtkEventController *controller,
+                                                 gdouble in_x, gdouble in_y,
+                                                 gdouble *out_x, gdouble *out_y)
+{
+  dt_develop_t *dev = darktable.develop;
+  if(!dev->preview_pipe->backbuf
+     || dev->image_storage.id != dev->preview_pipe->output_imgid)
+    return FALSE;
+  dt_dev_viewport_t *port = &dev->full;
+
+  GtkAllocation alloc_nav, alloc_center;
+  GtkWidget *nav = gtk_event_controller_get_widget(controller);
+  GtkWidget *center = dt_ui_center(darktable.gui->ui);
+  gtk_widget_get_allocation(nav, &alloc_nav);
+  gtk_widget_get_allocation(center, &alloc_center);
+  int procw, proch;
+  dt_dev_get_processed_size(port, &procw, &proch);
+
+  // navigation widget image dimensions
+  const double nav_scale = MIN((double)alloc_nav.width / procw,
+                               (double)alloc_nav.height / proch);
+  const double nav_img_w = procw * nav_scale;
+  const double nav_img_h = proch * nav_scale;
+  // nav widget coords to nav widget's image coords
+  const double x_nav_img = in_x - (alloc_nav.width - nav_img_w) / 2.0;
+  const double y_nav_img = in_y - (alloc_nav.height - nav_img_h) / 2.0;
+
+  // visible part of image in center widget in navigation widget
+  // coords with zoom-to-fit defaults
+  float zoom_x, zoom_y, boxw, boxh;
+  if(!dt_dev_get_zoom_bounds(port, &zoom_x, &zoom_y, &boxw, &boxh))
+  { // zoom-to-fit
+    zoom_x = zoom_y = 0.0;
+    boxw = boxh = 1.0;
+  }
+  const double vis_w = nav_img_w * boxw;
+  const double vis_h = nav_img_h * boxh;
+  const double vis_x = nav_img_w * (0.5 + zoom_x) - vis_w * 0.5;
+  const double vis_y = nav_img_h * (0.5 + zoom_y) - vis_h * 0.5;
+
+  // navigation image coords to center widget coords
+  *out_x = (x_nav_img - vis_x) / vis_w * alloc_center.width;
+  *out_y = (y_nav_img - vis_y) / vis_h * alloc_center.height;
+  return TRUE;
+}
+
+static void _lib_navigation_scroll_callback(GtkEventControllerScroll *controller,
+                                            double dx, double dy,
+                                            // FIXME: if unused don't pass
+                                            dt_lib_module_t *self)
+{
+  GdkEvent *event = gtk_get_current_event();
+  if(event)
+  {
+    GdkDevice *device = gdk_event_get_source_device(event);
+    if(device && gdk_device_get_source(device) == GDK_SOURCE_TOUCHPAD
+       && event->scroll.direction == GDK_SCROLL_SMOOTH)
+      dt_dev_zoom_move(&darktable.develop->full, DT_ZOOM_MOVE,
+                       15.0, 0, dx, dy, TRUE);
+    else
+    {
+      const gboolean constrain = !dt_modifier_eq(controller, GDK_CONTROL_MASK);
+      gdouble x, y;
+      if(_lib_navigation_widget_to_center(GTK_EVENT_CONTROLLER(controller),
+                                          event->scroll.x, event->scroll.y,
+                                          &x, &y))
+        dt_dev_zoom_move(&darktable.develop->full, DT_ZOOM_SCROLL,
+                         0.0f, dy < 0, x, y, constrain);
+    }
+    gdk_event_free(event);
+  }
+}
+
+static gdouble pinch_last_scale = 1.0;
+
+static void _lib_navigation_pinch_begin_callback(GtkGesture *gesture,
+                                                 GdkEventSequence* sequence,
+                                                 dt_lib_module_t *self)
+{
+  gtk_gesture_set_state(gesture, GTK_EVENT_SEQUENCE_CLAIMED);
+  pinch_last_scale = 1.0;
+}
+
+static void _lib_navigation_pinch_scale_callback(GtkGesture *gesture,
+                                                 gdouble scale,
+                                                 dt_lib_module_t *self)
+{
+  gdouble wx, wy, cx, cy;
+  if(gtk_gesture_get_bounding_box_center(gesture, &wx, &wy)
+     && _lib_navigation_widget_to_center(GTK_EVENT_CONTROLLER(gesture),
+                                         wx, wy, &cx, &cy))
+  {
+    const double pinch_step_ratio = 1.1;
+    const double ratio = scale / pinch_last_scale;
+    int zoom_step = -1;
+    if(ratio > pinch_step_ratio)
+      zoom_step = 1;
+    else if(ratio < 1.0 / pinch_step_ratio)
+      zoom_step = 0;
+    if(zoom_step >= 0)
+    {
+      dt_dev_zoom_move(&darktable.develop->full, DT_ZOOM_SCROLL,
+                       0.0f, zoom_step, cx, cy, TRUE);
+      pinch_last_scale = scale;
+    }
+  }
 }
 
 static gboolean _lib_navigation_button_press_callback(GtkWidget *widget,


### PR DESCRIPTION
- Clean up and improve the scrolling event controller setup functions. Eliminate `dt_gui_connect_scroll_discrete()` and merge it into `dt_gui_connect_scroll()`.
- Make the proxy scroll event controller handle whether (depending on modifier key) it should scroll a widget or the left/right panel. Note why still use GTK3-style "scroll-event" in one case, but note how to handle this in GTK4. 
- Use an event controller to allow scrolling of left/right borders to cause the corresponding panels to scroll. Make the handler (GTK4-style) scroll the GtkAdjustment directly, rather than sending the event to the widget (GTK3-style).
- Use an event controller to scroll geotagging date/time.
- Use an event controller to handle scrolling in navigation utility module in order to zoom or pan. Again, don't send events to the center view widget, but make them trigger the necessary zoom directly.
- Add a pinch-to-zoom gesture in the navigation utility module to parallel the same gesture which is now available in the center view.
- Make sure that zooming the navigation widget zooms, as possible, on the cursor position. (I used `dt_dev_get_zoom_bounds()` and then same hand-rolled math to make this work. If there's a better helper function for this, it could make that code simpler.)
- Tidy variable names in `_ui_init_panel_container_center()` for clarity.

This looks to be part of a series of commits to make GTK4-ready scrolling handling.