### PR TITLE
[AI] Speed up AI inference in neural restore module

### DIFF
--- a/src/ai/backend_onnx.c
+++ b/src/ai/backend_onnx.c
@@ -18,10 +18,12 @@
 
 #include "backend.h"
 #include "common/darktable.h"
+#include "common/file_location.h"
 #include "control/conf.h"
 #include <glib.h>
 #include <onnxruntime_c_api.h>
 #include <inttypes.h>
+#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -398,9 +400,90 @@ done:
   return (gpointer)api;
 }
 
+#if defined(__linux__)
+// configure AMD GPU caches (MIOpen kernel db + MIGraphX compiled-program
+// cache) via environment variables. these MUST be set before any ORT
+// internals query them — in practice that means before the MIGraphX
+// provider .so is loaded, which happens during the first model load.
+// setting them at OrtEnv init guarantees correct ordering
+//
+// MIOpen: without MIOPEN_USER_DB_PATH, the kernel find-db lives in a
+// temp location and may not survive between runs on consumer/iGPU AMD
+// where no prebuilt kdb ships — every launch recompiles conv shapes
+// from source via comgr/clang (10+ minutes on a Radeon iGPU)
+// MIGraphX: without ORT_MIGRAPHX_MODEL_CACHE_PATH, recompiles the whole
+// graph (compile_program: Begin/Complete) on every launch
+//
+// only sets vars the user hasn't already overridden so power users
+// keep control
+static void _setup_amd_caches(void)
+{
+  if(!g_file_test("/opt/rocm", G_FILE_TEST_IS_DIR))
+    return;
+
+  char cachedir[PATH_MAX] = { 0 };
+  dt_loc_get_user_cache_dir(cachedir, sizeof(cachedir));
+
+  gchar *miopen_dir = g_build_filename(cachedir, "ai", "amd", "miopen", NULL);
+  g_mkdir_with_parents(miopen_dir, 0700);
+  g_setenv("MIOPEN_USER_DB_PATH", miopen_dir, FALSE);
+  g_setenv("MIOPEN_CUSTOM_CACHE_DIR", miopen_dir, FALSE);
+  dt_print(DT_DEBUG_AI, "[darktable_ai] MIOpen cache: %s", miopen_dir);
+  g_free(miopen_dir);
+
+  gchar *migraphx_dir = g_build_filename(cachedir, "ai", "amd", "migraphx", NULL);
+  g_mkdir_with_parents(migraphx_dir, 0700);
+  g_setenv("ORT_MIGRAPHX_CACHE_PATH", migraphx_dir, FALSE);
+  g_setenv("ORT_MIGRAPHX_MODEL_CACHE_PATH", migraphx_dir, FALSE);
+  dt_print(DT_DEBUG_AI, "[darktable_ai] MIGraphX cache: %s", migraphx_dir);
+  g_free(migraphx_dir);
+}
+#endif
+
+// try to enable OpenVINO with disk cache via the dedicated V2 API;
+// SessionOptionsAppendExecutionProvider_OpenVINO_V2 (OrtApi, since 1.17)
+// takes string key/value pairs directly — version-stable, no struct ABI
+// to mismatch, and documented as the recommended path. OpenVINO compiles
+// ONNX → its internal IR on first inference (5-30s for a UNet), then
+// writes .blob files to cache_dir for instant reload on subsequent runs
+static gboolean _try_openvino_with_cache(OrtSessionOptions *session_opts)
+{
+  if(!g_ort || !g_ort->SessionOptionsAppendExecutionProvider_OpenVINO_V2)
+    return FALSE;
+
+  char cachedir[PATH_MAX] = { 0 };
+  dt_loc_get_user_cache_dir(cachedir, sizeof(cachedir));
+  gchar *ov_dir = g_build_filename(cachedir, "ai", "intel", "openvino", NULL);
+  g_mkdir_with_parents(ov_dir, 0700);
+
+  dt_print(DT_DEBUG_AI,
+           "[darktable_ai] attempting Intel OpenVINO (cache: %s)...", ov_dir);
+
+  const char *keys[] = { "device_type", "cache_dir" };
+  const char *values[] = { "AUTO", ov_dir };
+  OrtStatus *status = g_ort->SessionOptionsAppendExecutionProvider_OpenVINO_V2(
+    session_opts, keys, values, 2);
+
+  if(status)
+  {
+    dt_print(DT_DEBUG_AI,
+             "[darktable_ai] OpenVINO (with cache) failed: %s",
+             g_ort->GetErrorMessage(status));
+    g_ort->ReleaseStatus(status);
+    g_free(ov_dir);
+    return FALSE;
+  }
+  dt_print(DT_DEBUG_AI, "[darktable_ai] Intel OpenVINO enabled with disk cache.");
+  g_free(ov_dir);
+  return TRUE;
+}
+
 static gpointer _init_ort_env(gpointer data)
 {
   (void)data;
+#if defined(__linux__)
+  _setup_amd_caches();
+#endif
   OrtEnv *env = NULL;
 #ifdef ORT_LAZY_LOAD
   // ORT may emit additional schema-registration noise during env creation.
@@ -700,13 +783,17 @@ _enable_acceleration(OrtSessionOptions *session_opts, dt_ai_provider_t provider)
     break;
 
   case DT_AI_PROVIDER_MIGRAPHX:
-    // try MIGraphX first; fall back to ROCm for older ORT builds
+    // MIGraphX reads its cache env vars once at provider library
+    // load time, so they must be set before CreateEnv() — see
+    // _setup_amd_caches() above. OpenVINO (below) takes options
+    // per-session, so its cache path is passed inline here
     if(!_try_provider(session_opts, "OrtSessionOptionsAppendExecutionProvider_MIGraphX", "AMD MIGraphX", NULL))
       _try_provider(session_opts, "OrtSessionOptionsAppendExecutionProvider_ROCM", "AMD ROCm (legacy)", NULL);
     break;
 
   case DT_AI_PROVIDER_OPENVINO:
-    _try_provider(session_opts, "OrtSessionOptionsAppendExecutionProvider_OpenVINO", "Intel OpenVINO", "AUTO");
+    if(!_try_openvino_with_cache(session_opts))
+      _try_provider(session_opts, "OrtSessionOptionsAppendExecutionProvider_OpenVINO", "Intel OpenVINO", "AUTO");
     break;
 
   case DT_AI_PROVIDER_DIRECTML:
@@ -734,7 +821,7 @@ _enable_acceleration(OrtSessionOptions *session_opts, dt_ai_provider_t provider)
       "OrtSessionOptionsAppendExecutionProvider_DML",
       "Windows DirectML", NULL);
 #elif defined(__linux__)
-    // try CUDA first, then MIGraphX
+    // try CUDA first, then MIGraphX (cache configured at env init)
     if(!_try_provider(
          session_opts,
          "OrtSessionOptionsAppendExecutionProvider_CUDA",
@@ -901,7 +988,7 @@ dt_ai_onnx_load_ext(const char *model_dir, const char *model_file,
     }
   }
 
-  // optimize: enable hardware acceleration
+  // optimize: enable hardware acceleration (AMD caches set at env init)
   _enable_acceleration(session_opts, provider);
 
 #ifdef _WIN32

--- a/src/common/ai/restore.c
+++ b/src/common/ai/restore.c
@@ -35,6 +35,14 @@ extern void dwt_denoise(float *buf, int width, int height,
 #define MAX_MODEL_INPUTS 4
 #define DWT_DETAIL_BANDS 5
 
+// candidate tile sizes from largest to smallest, used by both the
+// startup memory-budget selector and the runtime OOM-retry fallback.
+// the memory-budget check gates which entry is chosen at startup;
+// the tile size cache persists the result so JIT-compiling EPs
+// (MIGraphX, CoreML, TensorRT) only pay the compile cost once.
+#define DT_RESTORE_TILE_LADDER_1X {2048, 1536, 1024, 768, 512, 384, 256}
+#define DT_RESTORE_TILE_LADDER_SR {768, 512, 384, 256, 192}
+
 /* --- opaque struct definitions --- */
 
 struct dt_restore_env_t
@@ -49,6 +57,9 @@ struct dt_restore_context_t
   char *model_id;
   char *model_file;
   char *task;
+  int tile_size;    // tile size used to create the current session
+  char *dim_h;      // symbolic height dim name used for session overrides
+  char *dim_w;      // symbolic width dim name used for session overrides
   gint ref_count;
 };
 
@@ -128,58 +139,130 @@ void dt_restore_env_destroy(dt_restore_env_t *env)
 #define TASK_DENOISE "denoise"
 #define TASK_UPSCALE "upscale"
 
-// internal: resolve task -> model_id -> load
+static int _select_tile_size(int scale);
+
+// returns the cached tile size for model_id+scale+provider combo, or 0 if not set
+static int _get_cached_tile_size(const char *model_id, int scale)
+{
+  char *prov = dt_conf_get_string(DT_AI_CONF_PROVIDER);
+  char *key = g_strdup_printf("plugins/ai/tile_cache/%s/%d/%s",
+                               model_id, scale, prov ? prov : "auto");
+  g_free(prov);
+  const int cached = dt_conf_get_int(key);
+  g_free(key);
+  return cached;
+}
+
+// persist a successful tile size to darktablerc so the next run skips OOM retry
+static void _set_cached_tile_size(const char *model_id, int scale, int tile_size)
+{
+  char *prov = dt_conf_get_string(DT_AI_CONF_PROVIDER);
+  char *key = g_strdup_printf("plugins/ai/tile_cache/%s/%d/%s",
+                               model_id, scale, prov ? prov : "auto");
+  g_free(prov);
+  dt_conf_set_int(key, tile_size);
+  g_free(key);
+}
+
+// internal: create an ORT session for model_id/model_file with spatial dims
+// fixed to tile_size. returns a new ai_ctx, or NULL on failure.
+static dt_ai_context_t *_create_session(dt_ai_environment_t *ai_env,
+                                        const char *model_id,
+                                        const char *model_file,
+                                        const char *dim_h,
+                                        const char *dim_w,
+                                        int tile_size)
+{
+  const dt_ai_dim_override_t overrides[] = {
+    { "batch_size", 1 },
+    { "batch",      1 },
+    { dim_h,        tile_size },
+    { dim_w,        tile_size },
+  };
+  return dt_ai_load_model_ext(
+    ai_env, model_id, model_file,
+    DT_AI_PROVIDER_AUTO, DT_AI_OPT_ALL,
+    overrides, (int)G_N_ELEMENTS(overrides));
+}
+
+// internal: resolve task -> model_id -> load with tile size dim overrides
 static dt_restore_context_t *_load(
   dt_restore_env_t *env,
   const char *task,
-  const char *model_file)
+  const char *model_file,
+  int scale)
 {
   if(!env) return NULL;
 
-  char *model_id
-    = dt_ai_models_get_active_for_task(task);
+  char *model_id = dt_ai_models_get_active_for_task(task);
   if(!model_id || !model_id[0])
   {
     g_free(model_id);
     return NULL;
   }
 
-  dt_ai_context_t *ai_ctx = dt_ai_load_model(
-    env->ai_env, model_id, model_file,
-    DT_AI_PROVIDER_AUTO);
+  // look up spatial dimension names for this model
+  const char *dim_h, *dim_w;
+  dt_ai_models_get_spatial_dims(darktable.ai_registry, model_id,
+                                &dim_h, &dim_w);
+
+  // select tile size from cache or memory budget
+  int tile_size = _get_cached_tile_size(model_id, scale);
+  if(tile_size <= 0)
+    tile_size = _select_tile_size(scale);
+
+  dt_ai_context_t *ai_ctx = _create_session(
+    env->ai_env, model_id, model_file, dim_h, dim_w, tile_size);
   if(!ai_ctx)
   {
     g_free(model_id);
     return NULL;
   }
 
-  dt_restore_context_t *ctx
-    = g_new0(dt_restore_context_t, 1);
+  dt_restore_context_t *ctx = g_new0(dt_restore_context_t, 1);
   ctx->ref_count = 1;
-  ctx->ai_ctx = ai_ctx;
-  ctx->env = env;
-  ctx->task = g_strdup(task);
-  ctx->model_id = model_id;
+  ctx->ai_ctx    = ai_ctx;
+  ctx->env       = env;
+  ctx->task      = g_strdup(task);
+  ctx->model_id  = model_id;
   ctx->model_file = g_strdup(model_file);
+  ctx->tile_size = tile_size;
+  ctx->dim_h     = g_strdup(dim_h);
+  ctx->dim_w     = g_strdup(dim_w);
   return ctx;
+}
+
+// internal: recreate the ORT session with a smaller tile size after OOM.
+// updates ctx->ai_ctx and ctx->tile_size in place.
+// returns TRUE on success, FALSE if the reload also fails.
+static gboolean _reload_session(dt_restore_context_t *ctx, int new_tile_size)
+{
+  dt_ai_context_t *new_ctx = _create_session(
+    ctx->env->ai_env, ctx->model_id, ctx->model_file,
+    ctx->dim_h, ctx->dim_w, new_tile_size);
+  if(!new_ctx) return FALSE;
+  dt_ai_unload_model(ctx->ai_ctx);
+  ctx->ai_ctx    = new_ctx;
+  ctx->tile_size = new_tile_size;
+  return TRUE;
 }
 
 dt_restore_context_t *dt_restore_load_denoise(
   dt_restore_env_t *env)
 {
-  return _load(env, TASK_DENOISE, NULL);
+  return _load(env, TASK_DENOISE, NULL, 1);
 }
 
 dt_restore_context_t *dt_restore_load_upscale_x2(
   dt_restore_env_t *env)
 {
-  return _load(env, TASK_UPSCALE, "model_x2.onnx");
+  return _load(env, TASK_UPSCALE, "model_x2.onnx", 2);
 }
 
 dt_restore_context_t *dt_restore_load_upscale_x4(
   dt_restore_env_t *env)
 {
-  return _load(env, TASK_UPSCALE, "model_x4.onnx");
+  return _load(env, TASK_UPSCALE, "model_x4.onnx", 4);
 }
 
 
@@ -198,6 +281,8 @@ void dt_restore_unref(dt_restore_context_t *ctx)
     g_free(ctx->task);
     g_free(ctx->model_id);
     g_free(ctx->model_file);
+    g_free(ctx->dim_h);
+    g_free(ctx->dim_w);
     g_free(ctx);
   }
 }
@@ -272,18 +357,14 @@ int dt_restore_get_overlap(int scale)
   return (scale > 1) ? OVERLAP_UPSCALE : OVERLAP_DENOISE;
 }
 
-int dt_restore_select_tile_size(int scale)
+static int _select_tile_size(int scale)
 {
-  static const int candidates_1x[] =
-    {2048, 1536, 1024, 768, 512, 384, 256};
-  static const int n_1x = 7;
-  static const int candidates_sr[] =
-    {512, 384, 256, 192};
-  static const int n_sr = 4;
-
-  const int *candidates = (scale > 1)
-    ? candidates_sr : candidates_1x;
-  const int n_candidates = (scale > 1) ? n_sr : n_1x;
+  const int ladder_1x[] = DT_RESTORE_TILE_LADDER_1X;
+  const int ladder_sr[] = DT_RESTORE_TILE_LADDER_SR;
+  const int *candidates = (scale > 1) ? ladder_sr : ladder_1x;
+  const int n_candidates = (scale > 1)
+    ? (int)(sizeof(ladder_sr) / sizeof(int))
+    : (int)(sizeof(ladder_1x) / sizeof(int));
 
   const size_t avail = dt_get_available_mem();
   const size_t budget = avail / 4;
@@ -402,8 +483,7 @@ int dt_restore_process_tiled(dt_restore_context_t *ctx,
                              int scale,
                              dt_restore_row_writer_t row_writer,
                              void *writer_data,
-                             struct _dt_job_t *control_job,
-                             int tile_size)
+                             struct _dt_job_t *control_job)
 {
   if(!ctx || !in_data || !row_writer)
     return 1;
@@ -411,11 +491,16 @@ int dt_restore_process_tiled(dt_restore_context_t *ctx,
   const int O = (scale > 1) ? OVERLAP_UPSCALE : OVERLAP_DENOISE;
   const int S = scale;
   const int out_w = width * S;
-  const int min_tile = (scale > 1) ? 192 : 256;
-  int T = tile_size;
+  const int ladder_1x[] = DT_RESTORE_TILE_LADDER_1X;
+  const int ladder_sr[] = DT_RESTORE_TILE_LADDER_SR;
+  const int *ladder = (scale > 1) ? ladder_sr : ladder_1x;
+  const int n_ladder = (scale > 1)
+    ? (int)(sizeof(ladder_sr) / sizeof(int))
+    : (int)(sizeof(ladder_1x) / sizeof(int));
+  int T = ctx->tile_size;
 
-  // outer retry loop: if inference fails (e.g. GPU OOM), halve
-  // the tile size and try again with smaller tiles
+  // outer retry loop: on inference failure (e.g. GPU OOM) drop to the
+  // next smaller candidate in the shared ladder and try again
 retry:;
   int step = T - 2 * O;
   int T_out = T * S;
@@ -523,19 +608,25 @@ retry:;
       if(dt_restore_run_patch(
            ctx, tile_in, T, T, tile_out, S) != 0)
       {
-        // retry with smaller tiles if no rows have been delivered
-        // yet (safe to restart). once rows are written we can't
-        // rewind the row_writer (e.g. TIFF is sequential)
-        if(T / 2 >= min_tile && ty == 0)
+        // retry with the next smaller ladder entry if no rows have
+        // been delivered yet (safe to restart). once rows are written
+        // we can't rewind the row_writer (e.g. TIFF is sequential).
+        // _reload_session() recreates the ORT session for the smaller
+        // tile size (dim overrides are shape-specific).
+        int next_T = 0;
+        for(int i = 0; i < n_ladder; i++)
+          if(ladder[i] < T) { next_T = ladder[i]; break; }
+        if(next_T > 0 && ty == 0
+           && _reload_session(ctx, next_T))
         {
           dt_print(DT_DEBUG_AI,
                    "[restore] inference failed at tile %d,%d "
                    "(T=%d), retrying with T=%d",
-                   x, y, T, T / 2);
+                   x, y, T, next_T);
           g_free(tile_in);
           g_free(tile_out);
           g_free(row_buf);
-          T = T / 2;
+          T = next_T;
           goto retry;
         }
         dt_print(DT_DEBUG_AI,
@@ -586,6 +677,10 @@ retry:;
       }
     }
   }
+
+  // persist tile size on first full success so subsequent runs skip OOM retry
+  if(res == 0)
+    _set_cached_tile_size(ctx->model_id, S, ctx->tile_size);
 
 cleanup:
   g_free(tile_in);

--- a/src/common/ai/restore.h
+++ b/src/common/ai/restore.h
@@ -130,13 +130,6 @@ gboolean dt_restore_upscale_available(dt_restore_env_t *env);
 /* --- tile size --- */
 
 /**
- * @brief select optimal tile size based on available memory
- * @param scale upscale factor (1 for denoise)
- * @return tile size in pixels
- */
-int dt_restore_select_tile_size(int scale);
-
-/**
  * @brief get tile overlap for a given scale factor
  * @param scale upscale factor (1 for denoise)
  * @return overlap in pixels
@@ -189,15 +182,14 @@ int dt_restore_run_patch(dt_restore_context_t *ctx,
  * completed scanlines via the row_writer callback. input is
  * float4 RGBA interleaved (from dt export).
  *
- * @param ctx loaded restore context
+ * @param ctx loaded restore context (tile_size is stored in ctx)
  * @param in_data input pixels (float4 RGBA, width * height)
  * @param width input width
  * @param height input height
  * @param scale upscale factor (1 for denoise)
  * @param row_writer callback receiving 3ch float scanlines
  * @param writer_data user data passed to row_writer
- * @param control_job job handle for progress/cancellation
- * @param tile_size tile size from dt_restore_select_tile_size
+ * @param control_job job handle for progress/cancellation (NULL-safe)
  * @return 0 on success
  */
 int dt_restore_process_tiled(dt_restore_context_t *ctx,
@@ -206,8 +198,7 @@ int dt_restore_process_tiled(dt_restore_context_t *ctx,
                              int scale,
                              dt_restore_row_writer_t row_writer,
                              void *writer_data,
-                             struct _dt_job_t *control_job,
-                             int tile_size);
+                             struct _dt_job_t *control_job);
 
 /* --- detail recovery --- */
 

--- a/src/common/ai_models.c
+++ b/src/common/ai_models.c
@@ -68,6 +68,8 @@ static void _model_free(dt_ai_model_t *model)
   g_free(model->checksum);
   g_free(model->version);
   g_free(model->min_version);
+  g_free(model->spatial_dim_h);
+  g_free(model->spatial_dim_w);
   g_free(model);
 }
 
@@ -653,6 +655,17 @@ static dt_ai_model_t *_parse_local_model_config(const char *config_path,
     model->task = g_strdup(json_object_get_string_member(obj, "task"));
   if(json_object_has_member(obj, "version"))
     model->version = g_strdup(json_object_get_string_member(obj, "version"));
+  if(json_object_has_member(obj, "spatial_dims"))
+  {
+    JsonArray *arr = json_object_get_array_member(obj, "spatial_dims");
+    if(arr && json_array_get_length(arr) >= 2)
+    {
+      const char *h = json_array_get_string_element(arr, 0);
+      const char *w = json_array_get_string_element(arr, 1);
+      if(h && h[0]) model->spatial_dim_h = g_strdup(h);
+      if(w && w[0]) model->spatial_dim_w = g_strdup(w);
+    }
+  }
 
   // no github_asset, no checksum — local-only model
   model->enabled = TRUE;
@@ -720,6 +733,10 @@ void dt_ai_models_refresh_status(dt_ai_registry_t *registry)
           g_free(model->version);
           model->version = g_strdup(local->version);
         }
+        g_free(model->spatial_dim_h);
+        g_free(model->spatial_dim_w);
+        model->spatial_dim_h = g_strdup(local->spatial_dim_h);
+        model->spatial_dim_w = g_strdup(local->spatial_dim_w);
         _model_free(local);
 
         // check if installed version meets minimum requirement
@@ -1802,6 +1819,27 @@ char *dt_ai_models_get_path(dt_ai_registry_t *registry, const char *model_id)
     return NULL;
 
   return g_build_filename(registry->models_dir, model_id, NULL);
+}
+
+void dt_ai_models_get_spatial_dims(dt_ai_registry_t *registry,
+                                   const char *model_id,
+                                   const char **out_h,
+                                   const char **out_w)
+{
+  *out_h = "height";
+  *out_w = "width";
+  if(!registry || !_valid_model_id(model_id)) return;
+
+  g_mutex_lock(&registry->lock);
+  dt_ai_model_t *model = _find_model_unlocked(registry, model_id);
+  if(model)
+  {
+    if(model->spatial_dim_h && model->spatial_dim_h[0])
+      *out_h = model->spatial_dim_h;
+    if(model->spatial_dim_w && model->spatial_dim_w[0])
+      *out_w = model->spatial_dim_w;
+  }
+  g_mutex_unlock(&registry->lock);
 }
 
 // clang-format off

--- a/src/common/ai_models.h
+++ b/src/common/ai_models.h
@@ -56,6 +56,8 @@ typedef struct dt_ai_model_t
   char *checksum;        // SHA256 checksum (format: "sha256:...")
   char *version;         // actual version from model's config.json
   char *min_version;     // minimum required version from registry
+  char *spatial_dim_h;   // symbolic name of height dimension (default "height")
+  char *spatial_dim_w;   // symbolic name of width dimension (default "width")
   gboolean is_default;   // TRUE if model is a default model for its task
   gboolean enabled;      // User preference (stored in darktablerc)
   dt_ai_model_status_t status;
@@ -300,3 +302,15 @@ void dt_ai_models_set_active_for_task(const char *task, const char *model_id);
  * @return Path string (caller must free), or NULL if not downloaded
  */
 char *dt_ai_models_get_path(dt_ai_registry_t *registry, const char *model_id);
+
+/**
+ * @brief Get the symbolic spatial dimension names for a model
+ * @param registry The registry
+ * @param model_id The model identifier
+ * @param out_h Output: height dimension name (never NULL; points to static default if unset)
+ * @param out_w Output: width dimension name (never NULL; points to static default if unset)
+ */
+void dt_ai_models_get_spatial_dims(dt_ai_registry_t *registry,
+                                   const char *model_id,
+                                   const char **out_h,
+                                   const char **out_w);

--- a/src/libs/neural_restore.c
+++ b/src/libs/neural_restore.c
@@ -97,6 +97,7 @@
 */
 
 #include "common/ai/restore.h"
+#include "control/conf.h"
 #include "bauhaus/bauhaus.h"
 #include "common/act_on.h"
 #include "common/collection.h"
@@ -544,7 +545,6 @@ static int _ai_write_image(dt_imageio_module_data_t *data,
     }
   }
 
-  const int tile_size = dt_restore_select_tile_size(S);
   const float recovery_alpha = job->detail_recovery / 100.0f;
   const gboolean need_buffer = (recovery_alpha > 0.0f && S == 1);
 
@@ -565,8 +565,7 @@ static int _ai_write_image(dt_imageio_module_data_t *data,
     res = dt_restore_process_tiled(job->ctx, in_data,
                                    width, height, S,
                                    _buf_row_writer, &bwd,
-                                   job->control_job,
-                                   tile_size);
+                                   job->control_job);
 
     if(res == 0)
     {
@@ -611,8 +610,7 @@ static int _ai_write_image(dt_imageio_module_data_t *data,
                                    width, height, S,
                                    _tiff_row_writer,
                                    &twd,
-                                   job->control_job,
-                                   tile_size);
+                                   job->control_job);
     g_free(scratch);
   }
 
@@ -1281,13 +1279,10 @@ static gpointer _preview_thread(gpointer data)
   }
 
   // use the same tiled processing as batch — this handles mirror
-  // padding, overlap blending, and planar conversion identically
-  // cap tile size to the crop dimensions - no point using a 2048²
-  // tile for a 256×176 crop. oversized tiles waste GPU memory and
-  // can exhaust VRAM on smaller GPUs, leaving CUDA in a bad state
-  const int max_dim = (crop_w > crop_h) ? crop_w : crop_h;
-  const int selected = dt_restore_select_tile_size(pd->scale);
-  const int tile_size = (selected < max_dim) ? selected : max_dim;
+  // padding, overlap blending, and planar conversion identically.
+  // tile size is fixed at model load time (ctx->tile_size) and shared
+  // across preview and batch so JIT-compiling EPs (MIGraphX, CoreML,
+  // TensorRT) compile the kernel only once per session.
   float *out_4ch = g_try_malloc((size_t)pw * ph * 4 * sizeof(float));
   if(!out_4ch)
   {
@@ -1297,13 +1292,13 @@ static gpointer _preview_thread(gpointer data)
   }
 
   dt_print(DT_DEBUG_AI,
-           "[neural_restore] preview: tiled inference %dx%d, tile=%d",
-           crop_w, crop_h, tile_size);
+           "[neural_restore] preview: tiled inference %dx%d",
+           crop_w, crop_h);
 
   _buf_writer_data_t bwd = { .out_buf = out_4ch, .out_w = pw };
   const int ret = dt_restore_process_tiled(
     ctx, crop_4ch, crop_w, crop_h, pd->scale,
-    _buf_row_writer, &bwd, NULL, tile_size);
+    _buf_row_writer, &bwd, NULL);
   g_free(crop_4ch);
   dt_restore_unref(ctx);
 


### PR DESCRIPTION
## Summary

- Specialize dynamic ONNX model sessions to a concrete tile size at load time using `AddFreeDimensionOverrideByName`, so JIT-compiling execution providers (MIGraphX, CoreML, TensorRT) compile the kernel once per session instead of recompiling on every inference call
- Cache the working tile size in `darktablerc` (keyed by model/scale/provider) so subsequent runs skip OOM retry entirely
- Persist AMD GPU caches (MIOpen kernel DB + MIGraphX compiled programs) and Intel OpenVINO compiled blobs to the user cache directory, eliminating multi-minute recompilation on every launch
- Add `spatial_dims` field to model `config.json` so each model declares its symbolic dimension names