### PR TITLE
[AI] Clarify AI provider enum: separate "probe all EPs" from "use user config"

### DIFF
--- a/dev-doc/AI.md
+++ b/dev-doc/AI.md
@@ -151,6 +151,14 @@ ctx = dt_ai_load_model_ext(env, id, file, provider,
 | Intel OpenVINO | `DT_AI_PROVIDER_OPENVINO` | `OpenVINO` | Linux, Windows, macOS (x86_64) |
 | Windows DirectML | `DT_AI_PROVIDER_DIRECTML` | `DirectML` | Windows |
 
+In addition, `DT_AI_PROVIDER_CONFIGURED` (`#define`, value -1) is a
+sentinel for `dt_ai_load_model()` / `dt_ai_load_model_ext()`: it reads
+the user's provider preference from `darktablerc` at call time. It is
+not a real provider and must never be stored in config or the provider
+table. Consumers that want to respect the user's setting (e.g. restore,
+segmentation) pass `CONFIGURED`; consumers that need a specific EP
+(e.g. the decoder forced to CPU) pass the EP directly.
+
 The `available` field in the provider descriptor is a compile-time
 platform guard controlled by `#if` preprocessor directives. It
 determines which providers are shown in the UI -- runtime availability
@@ -158,7 +166,8 @@ is checked separately.
 
 ### Auto-Detection Strategy
 
-When `DT_AI_PROVIDER_AUTO` is selected, the backend tries
+When `DT_AI_PROVIDER_AUTO` is selected (either by the user in
+preferences or resolved from `CONFIGURED`), the backend tries
 platform-native acceleration first and falls back gracefully:
 
 - **macOS**: CoreML -> CPU
@@ -361,7 +370,7 @@ dt_your_task_ctx_t *dt_your_task_load(
     return NULL;
   }
   dt_ai_context_t *ai_ctx = dt_ai_load_model(
-    env->ai_env, model_id, NULL, DT_AI_PROVIDER_AUTO);
+    env->ai_env, model_id, NULL, DT_AI_PROVIDER_CONFIGURED);
   g_free(model_id);
   if(!ai_ctx) return NULL;
 

--- a/src/ai/backend.h
+++ b/src/ai/backend.h
@@ -35,6 +35,12 @@ typedef enum {
   DT_AI_PROVIDER_COUNT  // must be last
 } dt_ai_provider_t;
 
+/** Sentinel for dt_ai_load_model / dt_ai_load_model_ext: read the
+ *  user's configured provider from darktablerc instead of forcing
+ *  a specific one. Not a real provider — never store in config or
+ *  the provider table. */
+#define DT_AI_PROVIDER_CONFIGURED (-1)
+
 /**
  * @brief Provider descriptor: maps enum to config/display strings.
  *
@@ -175,10 +181,8 @@ void dt_ai_env_destroy(dt_ai_environment_t *env);
 
 /**
  * @brief Set the default execution provider for this environment.
- *        When dt_ai_load_model / dt_ai_load_model_opts is called with
- *        DT_AI_PROVIDER_AUTO, the environment's provider is used instead.
  * @param env The environment handle.
- * @param provider The provider to use (DT_AI_PROVIDER_AUTO = platform auto-detect).
+ * @param provider The provider to use (DT_AI_PROVIDER_AUTO = probe all EPs).
  */
 void dt_ai_env_set_provider(dt_ai_environment_t *env, dt_ai_provider_t provider);
 
@@ -196,7 +200,7 @@ dt_ai_provider_t dt_ai_env_get_provider(dt_ai_environment_t *env);
  * @param env Library environment.
  * @param model_id ID of the model to load.
  * @param model_file Filename within the model directory (NULL = "model.onnx").
- * @param provider Execution provider to use for hardware acceleration.
+ * @param provider Execution provider (DT_AI_PROVIDER_CONFIGURED = use user config).
  * @return dt_ai_context_t* Context ready for inference, or NULL.
  */
 dt_ai_context_t *dt_ai_load_model(dt_ai_environment_t *env,
@@ -219,7 +223,7 @@ typedef struct {
  * @param env Library environment.
  * @param model_id ID of the model to load.
  * @param model_file Filename within the model directory (NULL = "model.onnx").
- * @param provider Execution provider to use for hardware acceleration.
+ * @param provider Execution provider (DT_AI_PROVIDER_CONFIGURED = use user config).
  * @param opt_level Graph optimization level.
  * @param dim_overrides Array of symbolic dimension overrides (NULL = none).
  * @param n_overrides Number of overrides.

--- a/src/ai/backend_common.c
+++ b/src/ai/backend_common.c
@@ -368,10 +368,10 @@ dt_ai_context_t *dt_ai_load_model_ext(dt_ai_environment_t *env,
     return NULL;
   }
 
-  // resolve AUTO: re-read from config so preference changes take effect
-  // immediately without requiring app restart.  Read config before acquiring
-  // env->lock to avoid lock-ordering issues with darktable's config lock
-  if(provider == DT_AI_PROVIDER_AUTO)
+  // resolve CONFIGURED: read the user's provider preference from config.
+  // read config before acquiring env->lock to avoid lock-ordering issues
+  // with darktable's config lock
+  if(provider == DT_AI_PROVIDER_CONFIGURED)
   {
     char *prov_str = dt_conf_get_string(DT_AI_CONF_PROVIDER);
     provider = dt_ai_provider_from_string(prov_str);

--- a/src/common/ai/restore.c
+++ b/src/common/ai/restore.c
@@ -186,11 +186,10 @@ static dt_ai_context_t *_create_session(dt_ai_environment_t *ai_env,
 }
 
 // internal: resolve task -> model_id -> load with tile size dim overrides
-static dt_restore_context_t *_load(
-  dt_restore_env_t *env,
-  const char *task,
-  const char *model_file,
-  int scale)
+static dt_restore_context_t *_load(dt_restore_env_t *env,
+                                   const char *task,
+                                   const char *model_file,
+                                   int scale)
 {
   if(!env) return NULL;
 
@@ -247,24 +246,20 @@ static gboolean _reload_session(dt_restore_context_t *ctx, int new_tile_size)
   return TRUE;
 }
 
-dt_restore_context_t *dt_restore_load_denoise(
-  dt_restore_env_t *env)
+dt_restore_context_t *dt_restore_load_denoise(dt_restore_env_t *env)
 {
   return _load(env, TASK_DENOISE, NULL, 1);
 }
 
-dt_restore_context_t *dt_restore_load_upscale_x2(
-  dt_restore_env_t *env)
+dt_restore_context_t *dt_restore_load_upscale_x2(dt_restore_env_t *env)
 {
   return _load(env, TASK_UPSCALE, "model_x2.onnx", 2);
 }
 
-dt_restore_context_t *dt_restore_load_upscale_x4(
-  dt_restore_env_t *env)
+dt_restore_context_t *dt_restore_load_upscale_x4(dt_restore_env_t *env)
 {
   return _load(env, TASK_UPSCALE, "model_x4.onnx", 4);
 }
-
 
 dt_restore_context_t *dt_restore_ref(dt_restore_context_t *ctx)
 {
@@ -287,10 +282,8 @@ void dt_restore_unref(dt_restore_context_t *ctx)
   }
 }
 
-
-static gboolean _model_available(
-  dt_restore_env_t *env,
-  const char *task)
+static gboolean _model_available(dt_restore_env_t *env,
+                                 const char *task)
 {
   if(!env || !env->ai_env) return FALSE;
   char *model_id
@@ -307,14 +300,12 @@ static gboolean _model_available(
   return (info != NULL);
 }
 
-gboolean dt_restore_denoise_available(
-  dt_restore_env_t *env)
+gboolean dt_restore_denoise_available(dt_restore_env_t *env)
 {
   return _model_available(env, TASK_DENOISE);
 }
 
-gboolean dt_restore_upscale_available(
-  dt_restore_env_t *env)
+gboolean dt_restore_upscale_available(dt_restore_env_t *env)
 {
   return _model_available(env, TASK_UPSCALE);
 }

--- a/src/common/ai/restore.c
+++ b/src/common/ai/restore.c
@@ -181,7 +181,7 @@ static dt_ai_context_t *_create_session(dt_ai_environment_t *ai_env,
   };
   return dt_ai_load_model_ext(
     ai_env, model_id, model_file,
-    DT_AI_PROVIDER_AUTO, DT_AI_OPT_ALL,
+    DT_AI_PROVIDER_CONFIGURED, DT_AI_OPT_ALL,
     overrides, (int)G_N_ELEMENTS(overrides));
 }
 

--- a/src/common/ai/segmentation.c
+++ b/src/common/ai/segmentation.c
@@ -211,10 +211,9 @@ dt_seg_context_t *dt_seg_load(dt_ai_environment_t *env, const char *model_id)
   if(!env || !model_id)
     return NULL;
 
-  // provider is resolved from the environment (read from config at init time),
-  // passing AUTO lets dt_ai_load_model resolve it
+  // use the user's configured provider for the encoder (the heavy part)
   dt_ai_context_t *encoder
-    = dt_ai_load_model(env, model_id, "encoder.onnx", DT_AI_PROVIDER_AUTO);
+    = dt_ai_load_model(env, model_id, "encoder.onnx", DT_AI_PROVIDER_CONFIGURED);
   if(!encoder)
   {
     dt_print(DT_DEBUG_AI, "[segmentation] failed to load encoder for %s", model_id);


### PR DESCRIPTION
Code cleanup to improve maintainability - no functional changes.

`DT_AI_PROVIDER_AUTO` previously had dual meaning: "probe all EPs" when used as a user setting, and "read user config" when passed as a function parameter. This made call sites confusing and error-prone for future contributors.

- Add `DT_AI_PROVIDER_CONFIGURED` (`#define -1`) as a sentinel for `dt_ai_load_model()` / `dt_ai_load_model_ext()` - reads the user's provider preference from `darktablerc` at call time
- `AUTO` now strictly means "probe all available EPs in platform order"
- `CONFIGURED` is not a real provider - never stored in config or the provider table
- Update restore and segmentation call sites to pass `CONFIGURED` instead of `AUTO`

Runtime behavior is identical before and after this change.