### PR TITLE
histogram: don't change to grab cursor when click on vectorscope

### DIFF
--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -322,8 +322,9 @@ static void _drawable_drag_begin(GtkGestureDrag* gesture,
 
 static void _drawable_drag_end(GtkGestureDrag* g, gdouble ox, gdouble oy, dt_scopes_t *s)
 {
-  dt_control_change_cursor("grab");
   s->dragging = FALSE;
+  dt_control_change_cursor(s->highlight == DT_SCOPES_HIGHLIGHT_NONE
+                           ? "default" : "grab");
 }
 
 static void _drawable_drag_update(GtkGestureDrag* gesture,
@@ -384,10 +385,8 @@ static void _drawable_motion(GtkEventControllerMotion *controller,
   {
     lib_histogram_update_tooltip(s);
     dt_scopes_refresh(s);
-    if(s->highlight == DT_SCOPES_HIGHLIGHT_NONE)
-      dt_control_change_cursor("default");
-    else
-      dt_control_change_cursor("grab");
+    dt_control_change_cursor(s->highlight == DT_SCOPES_HIGHLIGHT_NONE
+                             ? "default" : "grab");
   }
 }
 


### PR DESCRIPTION
Clicking on vectorscope will signal "drag-begin". The handler immediately denies this, as vectorscope is not draggable. This signals "drag-end". That handler assumed that the scope was draggable and so always changed the cursor to "grab". This would then not be reset when the cursor left the scope, as _drawable_leave() assumed that the cursor had not been changed.

Fix is on drag-end to set cursor to "grab" if the cursor is in a draggable area and "default" otherwise.

Made this test via ternary operator, and use ternary operator as well in cursor change in motion-handling code.

Fixes #20807