### PR TITLE
[AI] Fix object mask concurrency and shape-lifetime bugs

### DIFF
--- a/src/common/ai/segmentation.c
+++ b/src/common/ai/segmentation.c
@@ -570,6 +570,9 @@ void dt_seg_warmup_decoder(dt_seg_context_t *ctx)
         .shape = has_mask_shape, .ndim = 1};
 
     int64_t masks_shape[4] = {1, nm, dec_h, dec_w};
+    // shapes must outlive outputs[] used by dt_ai_run below
+    int64_t iou_shape[2] = {1, nm};
+    int64_t lr_shape[4] = {1, nm, pm_dim, pm_dim};
     float iou_buf[MAX_NUM_MASKS];
 
     dt_ai_tensor_t outputs[3];
@@ -577,8 +580,6 @@ void dt_seg_warmup_decoder(dt_seg_context_t *ctx)
 
     if(is_sam)
     {
-      int64_t iou_shape[2] = {1, nm};
-      int64_t lr_shape[4] = {1, nm, pm_dim, pm_dim};
       const int dec_outputs = dt_ai_get_output_count(ctx->decoder);
 
       outputs[0] = (dt_ai_tensor_t){
@@ -847,6 +848,9 @@ float *dt_seg_compute_mask(dt_seg_context_t *ctx,
   dt_ai_tensor_t dec_outputs[3];
   int n_dec_out;
   int64_t masks_shape[4] = {1, nm, dec_h, dec_w};
+  // shapes must outlive dec_outputs[] used by dt_ai_run below
+  int64_t iou_shape[2] = {1, nm};
+  int64_t low_res_shape[4] = {1, nm, pm_dim, pm_dim};
 
   float iou_pred[MAX_NUM_MASKS];
   float *low_res = NULL;
@@ -854,7 +858,6 @@ float *dt_seg_compute_mask(dt_seg_context_t *ctx,
   if(is_sam)
   {
     // SAM: masks [1,N,H,W] + iou [1,N], optionally low_res [1,N,pm,pm]
-    int64_t iou_shape[2] = {1, nm};
     const int dec_out_count = dt_ai_get_output_count(ctx->decoder);
 
     dec_outputs[0] = (dt_ai_tensor_t){
@@ -875,7 +878,6 @@ float *dt_seg_compute_mask(dt_seg_context_t *ctx,
         g_free(masks);
         return NULL;
       }
-      int64_t low_res_shape[4] = {1, nm, pm_dim, pm_dim};
       dec_outputs[2] = (dt_ai_tensor_t){
         .data = low_res, .type = DT_AI_FLOAT, .shape = low_res_shape, .ndim = 4};
       n_dec_out = 3;

--- a/src/develop/masks/object.c
+++ b/src/develop/masks/object.c
@@ -425,12 +425,9 @@ static gpointer _encode_thread_func(gpointer data)
     dt_seg_disk_cache_save(d->seg, imgid, distort_hash,
                            rgb, out_w, out_h);
 
-  // signal ready immediately so the user can start placing points,
-  // the warmup below continues on this background thread - if the user
-  // clicks before it finishes, ORT serializes concurrent Run() calls on
-  // the same session, so the decode simply waits for the warmup to
-  // complete first - in practice, users need a moment to position their
-  // cursor, so the ~1 s warmup usually finishes before the first click
+  // signal ready so the user can start placing points; warmup continues
+  // on this thread; _run_decoder joins the thread on the first click to
+  // avoid a race with warmup on the shared segmentation context
   g_atomic_int_set(&d->encode_state, ok ? ENCODE_READY : ENCODE_ERROR);
 
   // warm up decoder with real encoder embeddings so the first user click
@@ -689,6 +686,13 @@ static void _run_decoder(dt_masks_form_gui_t *gui)
     return;
   if(gui->guipoints_count <= 0)
     return;
+
+  // wait for encode thread: warmup may still be running after ENCODE_READY
+  if(d->encode_thread)
+  {
+    g_thread_join(d->encode_thread);
+    d->encode_thread = NULL;
+  }
 
   dt_gui_cursor_set_busy();
 


### PR DESCRIPTION
Two open PRs by @sjuxax have been awaiting a response from the author for a while. I don't consider everything in those PRs meaningful for merging, but a couple of fixes are genuinely worth having. This PR ports only those.

The originals:

- [#20774 – Fix object mask ASan races and scratch overflows](https://github.com/darktable-org/darktable/pull/20774)
  - **Ported:** the `_run_decoder` thread-join fix. Real concurrency bug.
  - **Skipped:** per-iteration `malloc`/`free` replacements of `dt_get_perthread()` in `box_filters.cc` and `guided_filter.c`. These patch symptoms rather than the root cause (likely a pool-sizing issue in `dt_alloc_perthread_float`), and the hot-path allocator churn would regress performance for every user, not just those running ASan.

- [#20775 – Fix SAM2 segmentation ASan crashes](https://github.com/darktable-org/darktable/pull/20775)
  - **Ported:** the decoder shape-array lifetime fix. Genuine UB per C standard and zero runtime cost.
  - **Skipped:** `DT_AI_OPT_DISABLED` for the SAM2.1 encoder. This disables ORT graph optimization for all SAM2 users to work around an ORT 1.24.x UAF that may be ASan-only, at a measurable inference-performance cost. Worth revisiting if confirmed to crash in release builds.

## What's in this PR

1. **Wait for encode thread before decoding.** `ENCODE_READY` is published before the background warmup finishes, so a fast user click could race the warmup on the shared `dt_seg_context_t`. `_run_decoder()` now joins the thread first – immediate no-op if warmup already completed, brief pause otherwise. Related comment at the ready-signal site was updated to reflect the new behavior.

2. **Keep decoder output shape arrays alive through `dt_ai_run`.** In `dt_seg_warmup_decoder` and `dt_seg_compute_mask`, `iou_shape` / `lr_shape` / `low_res_shape` were declared inside an inner `if(is_sam)` block while pointers to them were stored in an `outputs[]` array from the outer scope. Per C, their lifetime ended at the closing `}` of the inner block – the `dt_ai_run()` call afterward read through dangling pointers. Works in release today because compilers rarely recycle stack slots between sibling scopes, but caught by ASan and a latent time bomb for future compiler versions. Moved to the outer scope; zero runtime cost.