### PR TITLE
Fix exposure adjustment when scrolling over the scopes

### DIFF
--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -493,7 +493,7 @@ static void _eventbox_scroll_callback(GtkEventControllerScroll* self,
       // FIXME: should handle smooth scrolling rather than discrete?
       // FIXME: should scrolling of scope be handled in the drawable rather than
       //        the eventbox.
-      dt_dev_exposure_handle_event(0, dy - dx, event->scroll.state,
+      dt_dev_exposure_handle_event(0, dx - dy, event->scroll.state,
                                    s->highlight == DT_SCOPES_HIGHLIGHT_BLACK_POINT);
     }
     else


### PR DESCRIPTION
Fixes https://github.com/darktable-org/darktable/commit/3c8a77af68b5889ed2681fad9b7e46f419f2d067#commitcomment-182858683

- scrolling up/down over the scopes should brighten/darken the image: increase/decrease _exposure_ OR decrease/increase _black level correction_ (lift/crushe shadows) in the _exposure_ module
- dragging right/left (or up/down, depending on the scope's orientation) already moves the scope display in the direction of the drag (so no change in this PR): right/up: increase exposure or lift shadows; left/down: decrease exposure/crush shadows

@dtorop, do you agree?