### PR TITLE
More fixes 56

### DIFF
--- a/data/kernels/blendop.cl
+++ b/data/kernels/blendop.cl
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2011-2025 darktable developers.
+    Copyright (C) 2011-2026 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -433,9 +433,9 @@ blendop_mask_Lab(__read_only image2d_t in_a, __read_only image2d_t in_b, __read_
 
   if(x >= width || y >= height) return;
 
-  float4 a = read_imagef(in_a, sampleri, (int2)(x, y) + offs); // see comment in blend.c:dt_develop_blend_process_cl()
-  float4 b = read_imagef(in_b, sampleri, (int2)(x, y));
-  float form = read_imagef(mask_in, sampleri, (int2)(x, y)).x;
+  float4 a = readpixel(in_a, x+offs.x, y+offs.y); // see comment in blend.c:dt_develop_blend_process_cl()
+  float4 b = readpixel(in_b, x, y);
+  float form = readsingle(mask_in, x, y);
 
   float conditional = blendif_factor_Lab(a, b, blendif, blendif_parameters, mask_mode, mask_combine);
 
@@ -454,7 +454,7 @@ blendop_mask_RAW(__read_only image2d_t in_a, __read_only image2d_t in_b, __read_
   const int y = get_global_id(1);
 
   if(x >= width || y >= height) return;
-  float form = read_imagef(mask_in, sampleri, (int2)(x, y)).x;
+  float form = readsingle(mask_in, x, y);
 
   float opacity = (mask_combine & DEVELOP_COMBINE_INV) ? 1.0f - form : form;
 
@@ -471,9 +471,9 @@ blendop_mask_rgb_hsl(__read_only image2d_t in_a, __read_only image2d_t in_b, __r
 
   if(x >= width || y >= height) return;
 
-  float4 a = read_imagef(in_a, sampleri, (int2)(x, y) + offs); // see comment in blend.c:dt_develop_blend_process_cl()
-  float4 b = read_imagef(in_b, sampleri, (int2)(x, y));
-  float form = read_imagef(mask_in, sampleri, (int2)(x, y)).x;
+  float4 a = readpixel(in_a, x+offs.x, y+offs.y); // see comment in blend.c:dt_develop_blend_process_cl()
+  float4 b = readpixel(in_b, x, y);
+  float form = readsingle(mask_in, x, y);
 
   const unsigned int invert_mask = (blendif >> 16) ^ (mask_combine & DEVELOP_COMBINE_INCL ? 0 : DEVELOP_BLENDIF_RGB_MASK);
 
@@ -495,9 +495,9 @@ blendop_mask_rgb_jzczhz(__read_only image2d_t in_a, __read_only image2d_t in_b, 
 
   if(x >= width || y >= height || use_work_profile == 0) return;
 
-  float4 a = read_imagef(in_a, sampleri, (int2)(x, y) + offs); // see comment in blend.c:dt_develop_blend_process_cl()
-  float4 b = read_imagef(in_b, sampleri, (int2)(x, y));
-  float form = read_imagef(mask_in, sampleri, (int2)(x, y)).x;
+  float4 a = readpixel(in_a, x+offs.x, y+offs.y); // see comment in blend.c:dt_develop_blend_process_cl()
+  float4 b = readpixel(in_b, x, y);
+  float form = readsingle(mask_in, x, y);
 
   const unsigned int invert_mask = (blendif >> 16) ^ (mask_combine & DEVELOP_COMBINE_INCL ? 0 : DEVELOP_BLENDIF_RGB_MASK);
 
@@ -525,15 +525,15 @@ blendop_Lab(__read_only image2d_t in_a, __read_only image2d_t in_b, __read_only 
 
   if((blend_mode & DEVELOP_BLEND_REVERSE) == DEVELOP_BLEND_REVERSE)
   {
-    b = read_imagef(in_a, sampleri, (int2)(x, y) + offs);
-    a = read_imagef(in_b, sampleri, (int2)(x, y));
+    b = readpixel(in_a, x+offs.x, y+offs.y);
+    a = readpixel(in_b, x, y);
   }
   else
   {
-    a = read_imagef(in_a, sampleri, (int2)(x, y) + offs);
-    b = read_imagef(in_b, sampleri, (int2)(x, y));
+    a = readpixel(in_a, x+offs.x, y+offs.y);
+    b = readpixel(in_b, x, y);
   }
-  float opacity = read_imagef(mask, sampleri, (int2)(x, y)).x;
+  float opacity = readsingle(mask, x, y);
 
   /* scale L down to [0; 1] and a,b to [-1; 1] */
   const float4 scale = (float4)(100.0f, 128.0f, 128.0f, 1.0f);
@@ -546,7 +546,7 @@ blendop_Lab(__read_only image2d_t in_a, __read_only image2d_t in_b, __read_only 
   const float4 lmax = (float4)(1.0f, 2.0f, 2.0f, 1.0f);       /* max + fabs(min) */
   const float4 halfmax = (float4)(0.5f, 1.0f, 1.0f, 0.5f);    /* lmax / 2.0f */
   const float4 doublemax = (float4)(2.0f, 4.0f, 4.0f, 2.0f);  /* lmax * 2.0f */
-  const float opacity2 = opacity*opacity;
+  const float opacity2 = fsquare(opacity);
 
   float4 la = clamp(a + fabs(min), lmin, lmax);
   float4 lb = clamp(b + fabs(min), lmin, lmax);
@@ -812,15 +812,15 @@ blendop_RAW(__read_only image2d_t in_a, __read_only image2d_t in_b, __read_only 
 
   if((blend_mode & DEVELOP_BLEND_REVERSE) == DEVELOP_BLEND_REVERSE)
   {
-    b = read_imagef(in_a, sampleri, (int2)(x, y) + offs).x;
-    a = read_imagef(in_b, sampleri, (int2)(x, y)).x;
+    b = readsingle(in_a, x+offs.x, y+offs.y);
+    a = readsingle(in_b, x, y);
   }
   else
   {
-    a = read_imagef(in_a, sampleri, (int2)(x, y) + offs).x;
-    b = read_imagef(in_b, sampleri, (int2)(x, y)).x;
+    a = readsingle(in_a, x+offs.x, y+offs.y);
+    b = readsingle(in_b, x, y);
   }
-  float opacity = read_imagef(mask, sampleri, (int2)(x, y)).x;
+  float opacity = readsingle(mask, x, y);
 
   const float min = 0.0f;
   const float max = 1.0f;
@@ -828,7 +828,7 @@ blendop_RAW(__read_only image2d_t in_a, __read_only image2d_t in_b, __read_only 
   const float lmax = 1.0f;        /* max + fabs(min) */
   const float halfmax = 0.5f;     /* lmax / 2.0f */
   const float doublemax = 2.0f;   /* lmax * 2.0f */
-  const float opacity2 = opacity*opacity;
+  const float opacity2 = fsquare(opacity);
 
   float la = clamp(a + fabs(min), lmin, lmax);
   float lb = clamp(b + fabs(min), lmin, lmax);
@@ -958,16 +958,16 @@ blendop_RAW4(__read_only image2d_t in_a, __read_only image2d_t in_b, __read_only
 
   if((blend_mode & DEVELOP_BLEND_REVERSE) == DEVELOP_BLEND_REVERSE)
   {
-    b = read_imagef(in_a, sampleri, (int2)(x, y) + offs);
-    a = read_imagef(in_b, sampleri, (int2)(x, y));
+    b = readpixel(in_a, x+offs.x, y+offs.y);
+    a = readpixel(in_b, x, y);
   }
   else
   {
-    a = read_imagef(in_a, sampleri, (int2)(x, y) + offs);
-    b = read_imagef(in_b, sampleri, (int2)(x, y));
+    a = readpixel(in_a, x+offs.x, y+offs.y);
+    b = readpixel(in_b, x, y);
   }
 
-  float4 opacity = read_imagef(mask, sampleri, (int2)(x, y)).x;
+  float4 opacity = readsingle(mask, x, y);
 
   const float4 min = 0.0f;
   const float4 max = 1.0f;
@@ -1108,15 +1108,15 @@ blendop_rgb_hsl(__read_only image2d_t in_a, __read_only image2d_t in_b, __read_o
 
   if((blend_mode & DEVELOP_BLEND_REVERSE) == DEVELOP_BLEND_REVERSE)
   {
-    b = read_imagef(in_a, sampleri, (int2)(x, y) + offs);
-    a = read_imagef(in_b, sampleri, (int2)(x, y));
+    b = readpixel(in_a, x+offs.x, y+offs.y);
+    a = readpixel(in_b, x, y);
   }
   else
   {
-    a = read_imagef(in_a, sampleri, (int2)(x, y) + offs);
-    b = read_imagef(in_b, sampleri, (int2)(x, y));
+    a = readpixel(in_a, x+offs.x, y+offs.y);
+    b = readpixel(in_b, x, y);
   }
-  float opacity = read_imagef(mask, sampleri, (int2)(x, y)).x;
+  float opacity = readsingle(mask, x, y);
 
   const float4 min = (float4)(0.0f, 0.0f, 0.0f, 1.0f);
   const float4 max = (float4)(1.0f, 1.0f, 1.0f, 1.0f);
@@ -1124,7 +1124,7 @@ blendop_rgb_hsl(__read_only image2d_t in_a, __read_only image2d_t in_b, __read_o
   const float4 lmax = (float4)(1.0f, 1.0f, 1.0f, 1.0f);       /* max + fabs(min) */
   const float4 halfmax = (float4)(0.5f, 0.5f, 0.5f, 1.0f);    /* lmax / 2.0f */
   const float4 doublemax = (float4)(2.0f, 2.0f, 2.0f, 1.0f);  /* lmax * 2.0f */
-  const float opacity2 = opacity*opacity;
+  const float opacity2 = fsquare(opacity);
 
   float4 la = clamp(a + fabs(min), lmin, lmax);
   float4 lb = clamp(b + fabs(min), lmin, lmax);
@@ -1266,8 +1266,8 @@ blendop_rgb_hsl(__read_only image2d_t in_a, __read_only image2d_t in_b, __read_o
       ta = RGB_2_HSV(a);
       tb = RGB_2_HSV(b);
       // blend color vectors of input and output
-      d = ta.y*cos(DT_2PI_F*ta.x) * (1.0f - opacity) + tb.y*cos(DT_2PI_F*tb.x) * opacity;
-      s = ta.y*sin(DT_2PI_F*ta.x) * (1.0f - opacity) + tb.y*sin(DT_2PI_F*tb.x) * opacity;
+      d = ta.y*dtcl_cos(DT_2PI_F*ta.x) * (1.0f - opacity) + tb.y*dtcl_cos(DT_2PI_F*tb.x) * opacity;
+      s = ta.y*dtcl_sin(DT_2PI_F*ta.x) * (1.0f - opacity) + tb.y*dtcl_sin(DT_2PI_F*tb.x) * opacity;
       to.x = fmod(atan2(s, d)/DT_2PI_F+1.0f, 1.0f);
       to.y = dt_fast_hypot(s, d);
       to.z = ta.z;
@@ -1320,15 +1320,15 @@ blendop_rgb_jzczhz(__read_only image2d_t in_a, __read_only image2d_t in_b, __rea
 
   if((blend_mode & DEVELOP_BLEND_REVERSE) == DEVELOP_BLEND_REVERSE)
   {
-    b = read_imagef(in_a, sampleri, (int2)(x, y) + offs);
-    a = read_imagef(in_b, sampleri, (int2)(x, y));
+    b = readpixel(in_a, x+offs.x, y+offs.y);
+    a = readpixel(in_b, x, y);
   }
   else
   {
-    a = read_imagef(in_a, sampleri, (int2)(x, y) + offs);
-    b = read_imagef(in_b, sampleri, (int2)(x, y));
+    a = readpixel(in_a, x+offs.x, y+offs.y);
+    b = readpixel(in_b, x, y);
   }
-  float opacity = read_imagef(mask, sampleri, (int2)(x, y)).x;
+  float opacity = readsingle(mask, x, y);
   float norm_a;
   float norm_b;
 
@@ -1433,7 +1433,7 @@ blendop_mask_tone_curve(__read_only image2d_t mask_in, __write_only image2d_t ma
 
   if (x >= width || y >= height) return;
 
-  float opacity = read_imagef(mask_in, sampleri, (int2)(x, y)).x;
+  float opacity = readsingle(mask_in, x, y);
   float scaled_opacity = (2.f * opacity / gopacity - 1.f);
   if (1.f - brightness <= 0.f)
     scaled_opacity = opacity <= mask_epsilon ? -1.f : 1.f;
@@ -1480,9 +1480,9 @@ blendop_display_channel(__read_only image2d_t in_a, __read_only image2d_t in_b, 
 
   if(x >= width || y >= height) return;
 
-  float4 a = read_imagef(in_a, sampleri, (int2)(x, y) + offs); // see comment in blend.c:dt_develop_blend_process_cl()
-  float4 b = read_imagef(in_b, sampleri, (int2)(x, y));
-  float opacity = read_imagef(mask, sampleri, (int2)(x, y)).x;
+  float4 a = readpixel(in_a, x+offs.x, y+offs.y); // see comment in blend.c:dt_develop_blend_process_cl()
+  float4 b = readpixel(in_b, x, y);
+  float opacity = readsingle(mask, x, y);
 
   float c;
   float4 LCH;
@@ -1495,51 +1495,51 @@ blendop_display_channel(__read_only image2d_t in_a, __read_only image2d_t in_b, 
   switch(channel & DT_DEV_PIXELPIPE_DISPLAY_ANY)
   {
     case DT_DEV_PIXELPIPE_DISPLAY_L:
-      c = clipf(a.x / 100.0f / exp2(boost_factors[DEVELOP_BLENDIF_L_in]));
+      c = clipf(a.x / 100.0f / dtcl_exp2(boost_factors[DEVELOP_BLENDIF_L_in]));
       is_lab = 1;
       break;
     case (DT_DEV_PIXELPIPE_DISPLAY_L | DT_DEV_PIXELPIPE_DISPLAY_OUTPUT):
-      c = clipf(b.x / 100.0f / exp2(boost_factors[DEVELOP_BLENDIF_L_out]));
+      c = clipf(b.x / 100.0f / dtcl_exp2(boost_factors[DEVELOP_BLENDIF_L_out]));
       is_lab = 1;
       break;
     case DT_DEV_PIXELPIPE_DISPLAY_a:
-      c = clipf(a.y / 256.0f / exp2(boost_factors[DEVELOP_BLENDIF_A_in]) + 0.5f);
+      c = clipf(a.y / 256.0f / dtcl_exp2(boost_factors[DEVELOP_BLENDIF_A_in]) + 0.5f);
       is_lab = 1;
       break;
     case (DT_DEV_PIXELPIPE_DISPLAY_a | DT_DEV_PIXELPIPE_DISPLAY_OUTPUT):
-      c = clipf(b.y / 256.0f / exp2(boost_factors[DEVELOP_BLENDIF_A_out]) + 0.5f);
+      c = clipf(b.y / 256.0f / dtcl_exp2(boost_factors[DEVELOP_BLENDIF_A_out]) + 0.5f);
       is_lab = 1;
       break;
     case DT_DEV_PIXELPIPE_DISPLAY_b:
-      c = clipf(a.z / 256.0f / exp2(boost_factors[DEVELOP_BLENDIF_B_in]) + 0.5f);
+      c = clipf(a.z / 256.0f / dtcl_exp2(boost_factors[DEVELOP_BLENDIF_B_in]) + 0.5f);
       is_lab = 1;
       break;
     case (DT_DEV_PIXELPIPE_DISPLAY_b | DT_DEV_PIXELPIPE_DISPLAY_OUTPUT):
-      c = clipf(b.z / 256.0f / exp2(boost_factors[DEVELOP_BLENDIF_A_in]) + 0.5f);
+      c = clipf(b.z / 256.0f / dtcl_exp2(boost_factors[DEVELOP_BLENDIF_A_in]) + 0.5f);
       is_lab = 1;
       break;
     case DT_DEV_PIXELPIPE_DISPLAY_R:
-      c = clipf(a.x / exp2(boost_factors[DEVELOP_BLENDIF_RED_in]));
+      c = clipf(a.x / dtcl_exp2(boost_factors[DEVELOP_BLENDIF_RED_in]));
       is_lab = 0;
       break;
     case (DT_DEV_PIXELPIPE_DISPLAY_R | DT_DEV_PIXELPIPE_DISPLAY_OUTPUT):
-      c = clipf(b.x / exp2(boost_factors[DEVELOP_BLENDIF_RED_out]));
+      c = clipf(b.x / dtcl_exp2(boost_factors[DEVELOP_BLENDIF_RED_out]));
       is_lab = 0;
       break;
     case DT_DEV_PIXELPIPE_DISPLAY_G:
-      c = clipf(a.y / exp2(boost_factors[DEVELOP_BLENDIF_GREEN_in]));
+      c = clipf(a.y / dtcl_exp2(boost_factors[DEVELOP_BLENDIF_GREEN_in]));
       is_lab = 0;
       break;
     case (DT_DEV_PIXELPIPE_DISPLAY_G | DT_DEV_PIXELPIPE_DISPLAY_OUTPUT):
-      c = clipf(b.y / exp2(boost_factors[DEVELOP_BLENDIF_GREEN_out]));
+      c = clipf(b.y / dtcl_exp2(boost_factors[DEVELOP_BLENDIF_GREEN_out]));
       is_lab = 0;
       break;
     case DT_DEV_PIXELPIPE_DISPLAY_B:
-      c = clipf(a.z / exp2(boost_factors[DEVELOP_BLENDIF_BLUE_in]));
+      c = clipf(a.z / dtcl_exp2(boost_factors[DEVELOP_BLENDIF_BLUE_in]));
       is_lab = 0;
       break;
     case (DT_DEV_PIXELPIPE_DISPLAY_B | DT_DEV_PIXELPIPE_DISPLAY_OUTPUT):
-      c = clipf(b.z / exp2(boost_factors[DEVELOP_BLENDIF_BLUE_out]));
+      c = clipf(b.z / dtcl_exp2(boost_factors[DEVELOP_BLENDIF_BLUE_out]));
       is_lab = 0;
       break;
     case DT_DEV_PIXELPIPE_DISPLAY_GRAY:
@@ -1547,7 +1547,7 @@ blendop_display_channel(__read_only image2d_t in_a, __read_only image2d_t in_b, 
         c = 0.3f * a.x + 0.59f * a.y + 0.11f * a.z;
       else
         c = get_rgb_matrix_luminance(a, profile_info, profile_info->matrix_in, profile_lut);
-      c = clipf(c / exp2(boost_factors[DEVELOP_BLENDIF_GRAY_in]));
+      c = clipf(c / dtcl_exp2(boost_factors[DEVELOP_BLENDIF_GRAY_in]));
       is_lab = 0;
       break;
     case (DT_DEV_PIXELPIPE_DISPLAY_GRAY | DT_DEV_PIXELPIPE_DISPLAY_OUTPUT):
@@ -1555,7 +1555,7 @@ blendop_display_channel(__read_only image2d_t in_a, __read_only image2d_t in_b, 
         c = 0.3f * b.x + 0.59f * b.y + 0.11f * b.z;
       else
         c = get_rgb_matrix_luminance(b, profile_info, profile_info->matrix_in, profile_lut);
-      c = clipf(c / exp2(boost_factors[DEVELOP_BLENDIF_GRAY_out]));
+      c = clipf(c / dtcl_exp2(boost_factors[DEVELOP_BLENDIF_GRAY_out]));
       is_lab = 0;
       break;
     case DT_DEV_PIXELPIPE_DISPLAY_LCH_C:
@@ -1615,27 +1615,27 @@ blendop_display_channel(__read_only image2d_t in_a, __read_only image2d_t in_b, 
       break;
     case (DT_DEV_PIXELPIPE_DISPLAY_JzCzhz_Jz | DT_DEV_PIXELPIPE_DISPLAY_OUTPUT):
       JzCzhz = rgb_to_JzCzhz(b, profile_info, profile_lut, use_profile);
-      c = clipf(JzCzhz.x / exp2(boost_factors[DEVELOP_BLENDIF_Jz_out]));
+      c = clipf(JzCzhz.x / dtcl_exp2(boost_factors[DEVELOP_BLENDIF_Jz_out]));
       is_lab = 0;
       break;
     case DT_DEV_PIXELPIPE_DISPLAY_JzCzhz_Cz:
       JzCzhz = rgb_to_JzCzhz(a, profile_info, profile_lut, use_profile);
-      c = clipf(JzCzhz.y / exp2(boost_factors[DEVELOP_BLENDIF_Cz_in]));
+      c = clipf(JzCzhz.y / dtcl_exp2(boost_factors[DEVELOP_BLENDIF_Cz_in]));
       is_lab = 0;
       break;
     case (DT_DEV_PIXELPIPE_DISPLAY_JzCzhz_Cz | DT_DEV_PIXELPIPE_DISPLAY_OUTPUT):
       JzCzhz = rgb_to_JzCzhz(b, profile_info, profile_lut, use_profile);
-      c = clipf(JzCzhz.y / exp2(boost_factors[DEVELOP_BLENDIF_Cz_out]));
+      c = clipf(JzCzhz.y / dtcl_exp2(boost_factors[DEVELOP_BLENDIF_Cz_out]));
       is_lab = 0;
       break;
     case DT_DEV_PIXELPIPE_DISPLAY_JzCzhz_hz:
       JzCzhz = rgb_to_JzCzhz(a, profile_info, profile_lut, use_profile);
-      c = clipf(JzCzhz.z / exp2(boost_factors[DEVELOP_BLENDIF_hz_in]));
+      c = clipf(JzCzhz.z / dtcl_exp2(boost_factors[DEVELOP_BLENDIF_hz_in]));
       is_lab = 0;
       break;
     case (DT_DEV_PIXELPIPE_DISPLAY_JzCzhz_hz | DT_DEV_PIXELPIPE_DISPLAY_OUTPUT):
       JzCzhz = rgb_to_JzCzhz(b, profile_info, profile_lut, use_profile);
-      c = clipf(JzCzhz.z / exp2(boost_factors[DEVELOP_BLENDIF_hz_out]));
+      c = clipf(JzCzhz.z / dtcl_exp2(boost_factors[DEVELOP_BLENDIF_hz_out]));
       is_lab = 0;
       break;
     default:

--- a/data/kernels/colorspace.h
+++ b/data/kernels/colorspace.h
@@ -68,8 +68,8 @@ static inline float4 Lab_2_LCH(float4 Lab)
 static inline float4 LCH_2_Lab(float4 LCH)
 {
   const float L = LCH.x;
-  const float a = cos(DT_2PI_F*LCH.z) * LCH.y;
-  const float b = sin(DT_2PI_F*LCH.z) * LCH.y;
+  const float a = dtcl_cos(DT_2PI_F*LCH.z) * LCH.y;
+  const float b = dtcl_sin(DT_2PI_F*LCH.z) * LCH.y;
 
   return (float4)(L, a, b, LCH.w);
 }
@@ -86,8 +86,8 @@ static inline float4 lab_f(float4 x)
 static inline float4 XYZ_to_Lab(float4 xyz)
 {
   float4 lab;
-  const float4 d50 = (float4)(0.9642f, 1.0f, 0.8249f, 1.0f);
-  xyz = lab_f(xyz / d50);
+  const float4 d50i = (float4)(1.0f / 0.9642f, 1.0f, 1.0f / 0.8249f, 1.0f);
+  xyz = lab_f(xyz * d50i);
   lab.x = 116.0f * xyz.y - 16.0f;
   lab.y = 500.0f * (xyz.x - xyz.y);
   lab.z = 200.0f * (xyz.y - xyz.z);
@@ -98,7 +98,7 @@ static inline float4 XYZ_to_Lab(float4 xyz)
 
 static inline float4 lab_f_inv(float4 x)
 {
-  const float4 epsilon = 0.20689655172413796f;
+  const float4 epsilon = 0.20689655172413796f; // cbrtf(216.0f/24389.0f
   const float4 kappa   = 24389.0f / 27.0f;
   return (x > epsilon) ? x*x*x : ((float4)116.0f * x - (float4)16.0f)/kappa;
 }

--- a/data/kernels/noise_generator.h
+++ b/data/kernels/noise_generator.h
@@ -93,8 +93,8 @@ static inline float4 gaussian_noise_simd(const float4 mu, const float4 sigma, ui
   const float4 flip_comp = { 0.0f, 1.0f, 0.0f, 0.0f };
 
   // flip is a 4×1 boolean mask
-  const float4 noise = flip * dtcl_sqrt(-2.0f * dtcl_log(u1)) * dtcl_cos(2.f * M_PI_F * u2) +
-                       flip_comp * dtcl_sqrt(-2.0f * dtcl_log(u1)) * dtcl_sin(2.f * M_PI_F * u2);
+  const float4 noise = flip * dtcl_sqrt(-2.0f * dtcl_log(u1)) * dtcl_cos(DT_2PI_F * u2) +
+                       flip_comp * dtcl_sqrt(-2.0f * dtcl_log(u1)) * dtcl_sin(DT_2PI_F * u2);
   return noise * sigma + mu;
 }
 
@@ -118,8 +118,8 @@ static inline float4 poisson_noise_simd(const float4 mu, const float4 sigma, uin
   const float4 flip_comp = { 0.0f, 1.0f, 0.0f, 0.0f };
 
   // flip is a 4×1 boolean mask
-  const float4 noise = flip * dtcl_sqrt(-2.0f * dtcl_log(u1)) * dtcl_cos(2.f * M_PI_F * u2) +
-                       flip_comp * dtcl_sqrt(-2.0f * dtcl_log(u1)) * dtcl_sin(2.f * M_PI_F * u2);
+  const float4 noise = flip * dtcl_sqrt(-2.0f * dtcl_log(u1)) * dtcl_cos(DT_2PI_F * u2) +
+                       flip_comp * dtcl_sqrt(-2.0f * dtcl_log(u1)) * dtcl_sin(DT_2PI_F * u2);
 
   // now we have gaussian noise, then apply Anscombe transform to get poissonian one
   const float4 r = noise * sigma + 2.0f * dtcl_sqrt(fmax(mu + (3.f / 8.f), 0.0f));

--- a/src/common/bilateralcl.c
+++ b/src/common/bilateralcl.c
@@ -200,8 +200,8 @@ cl_int dt_bilateral_slice_to_output_cl(dt_bilateral_cl_t *b, cl_mem in, cl_mem o
   cl_mem tmp = dt_opencl_alloc_device(b->devid, b->width, b->height, sizeof(float) * 4);
   if(tmp == NULL) goto error;
 
-  size_t origin[] = { 0, 0, 0 };
-  size_t region[] = { b->width, b->height, 1 };
+  size_t origin[] = { 0, 0 };
+  size_t region[] = { b->width, b->height };
   err = dt_opencl_enqueue_copy_image(b->devid, out, tmp, origin, origin, region);
   if(err != CL_SUCCESS) goto error;
 

--- a/src/common/bilateralcl.c
+++ b/src/common/bilateralcl.c
@@ -156,8 +156,8 @@ dt_bilateral_cl_t *dt_bilateral_init_cl(const int devid,
 
 cl_int dt_bilateral_splat_cl(dt_bilateral_cl_t *b, cl_mem in)
 {
-  size_t sizes[] = { ROUNDUP(b->width, b->blocksizex), ROUNDUP(b->height, b->blocksizey), 1 };
-  size_t local[] = { b->blocksizex, b->blocksizey, 1 };
+  size_t sizes[2] = { ROUNDUP(b->width, b->blocksizex), ROUNDUP(b->height, b->blocksizey) };
+  size_t local[2] = { b->blocksizex, b->blocksizey };
   return dt_opencl_enqueue_kernel_2d_local_args(b->devid, b->global->kernel_splat, sizes, local,
     CLARG(in), CLARG(b->dev_grid),
     CLARG(b->width), CLARG(b->height), CLARG(b->size_x), CLARG(b->size_y), CLARG(b->size_z), CLARG(b->sigma_s),

--- a/src/common/colorspaces_inline_conversions.h
+++ b/src/common/colorspaces_inline_conversions.h
@@ -77,9 +77,9 @@ static inline __m128 lab_f_m_sse2(const __m128 x)
 /** uses D50 white point. */
 static inline __m128 dt_XYZ_to_Lab_sse2(const __m128 XYZ)
 {
-  const __m128 d50 = _mm_set_ps(1.0f, 0.8249f, 1.0f, 0.9642f);
+  const __m128 d50 = _mm_set_ps(1.0f, 1.0f / 0.8249f, 1.0f, 1.0f / 0.9642f);
   const __m128 coef = _mm_set_ps(0.0f, 200.0f, 500.0f, 116.0f);
-  const __m128 f = lab_f_m_sse2(XYZ / d50);
+  const __m128 f = lab_f_m_sse2(XYZ * d50);
   // because d50_inv.z is 0.0f, lab_f(0) == 16/116, so Lab[0] = 116*f[0] - 16 equal to 116*(f[0]-f[3])
   return coef * (_mm_shuffle_ps(f, f, _MM_SHUFFLE(3, 1, 0, 1)) - _mm_shuffle_ps(f, f, _MM_SHUFFLE(3, 2, 1, 3)));
 }

--- a/src/common/gaussian.c
+++ b/src/common/gaussian.c
@@ -927,8 +927,8 @@ cl_int dt_gaussian_blur_cl(dt_gaussian_cl_t *g, cl_mem dev_in, cl_mem dev_out)
   else
     return DT_OPENCL_PROCESS_CL;
 
-  size_t origin[] = { 0, 0, 0 };
-  size_t region[] = { width, height, 1 };
+  size_t origin[] = { 0, 0 };
+  size_t region[] = { width, height };
   size_t local[2] = { blocksize, blocksize };
   size_t sizes[2];
 

--- a/src/common/gaussian.c
+++ b/src/common/gaussian.c
@@ -929,8 +929,8 @@ cl_int dt_gaussian_blur_cl(dt_gaussian_cl_t *g, cl_mem dev_in, cl_mem dev_out)
 
   size_t origin[] = { 0, 0, 0 };
   size_t region[] = { width, height, 1 };
-  size_t local[] = { blocksize, blocksize, 1 };
-  size_t sizes[3];
+  size_t local[2] = { blocksize, blocksize };
+  size_t sizes[2];
 
   // compute gaussian parameters
   float a0, a1, a2, a3, b1, b2, coefp, coefn;

--- a/src/common/guided_filter.c
+++ b/src/common/guided_filter.c
@@ -559,9 +559,9 @@ static int _guided_filter_cl_impl(int devid,
     {
       if(tiling)
       {
-        size_t insrc[]  = { 0, first_in, 0 };
-        size_t tdest[]  = { 0, 0, 0 };
-        size_t iarea[]  = { width, t_height, 1 };
+        size_t insrc[]  = { 0, first_in };
+        size_t tdest[]  = { 0, 0 };
+        size_t iarea[]  = { width, t_height };
         err = dt_opencl_enqueue_copy_image(devid, dev_in, in, insrc, tdest, iarea);
       }
 
@@ -616,9 +616,9 @@ static int _guided_filter_cl_impl(int devid,
 
       if(err == CL_SUCCESS && tiling)
       {
-        size_t tsrc[]   = { 0, first_out, 0 };
-        size_t odest[]  = { 0, group, 0 };
-        size_t oarea[]  = { width, out_height, 1 };
+        size_t tsrc[]   = { 0, first_out };
+        size_t odest[]  = { 0, group };
+        size_t oarea[]  = { width, out_height };
         // copy relevant fraction of tiled output back
         err = dt_opencl_enqueue_copy_image(devid, out, dev_out, tsrc, odest, oarea);
       }

--- a/src/common/interpolation.c
+++ b/src/common/interpolation.c
@@ -1350,8 +1350,8 @@ int dt_interpolation_resample_cl(const dt_interpolation_t *itor,
     goto error;
   }
 
-  size_t sizes[3] = { ROUNDUPDWD(width, devid), ROUNDUP(height * taps, vblocksize), 1 };
-  size_t local[3] = { 1, vblocksize, 1 };
+  size_t sizes[2] = { ROUNDUPDWD(width, devid), ROUNDUP(height * taps, vblocksize) };
+  size_t local[2] = { 1, vblocksize };
 
   // store resampling plan to device memory hindex, vindex, hkernel,
   // vkernel: (v|h)maxtaps might be too small, so store a bit more

--- a/src/common/interpolation.c
+++ b/src/common/interpolation.c
@@ -1272,9 +1272,9 @@ int dt_interpolation_resample_cl(const dt_interpolation_t *itor,
   {
     if(wd_fit && ht_fit)
     {
-      size_t iorigin[] = { dx, dy, 0 };
-      size_t oorigin[] = { 0, 0, 0 };
-      size_t region[] = { width, height, 1 };
+      size_t iorigin[] = { dx, dy };
+      size_t oorigin[] = { 0, 0 };
+      size_t region[] = { width, height };
       // copy original input from dev_in -> dev_out as starting point
       err = dt_opencl_enqueue_copy_image(devid, dev_in, dev_out, iorigin, oorigin, region);
     }

--- a/src/common/iop_profile.c
+++ b/src/common/iop_profile.c
@@ -1491,8 +1491,8 @@ gboolean dt_ioppr_transform_image_colorspace_cl
   const gboolean inplace = dev_img_in == dev_img_out;
   const gboolean anyraw = cst_to == IOP_CS_RAW || cst_from == IOP_CS_RAW;
 
-  size_t origin[] = { 0, 0, 0 };
-  size_t region[] = { width, height, 1 };
+  size_t origin[] = { 0, 0 };
+  size_t region[] = { width, height };
 
   *converted_cst = cst_to;
   if(cst_from == cst_to)
@@ -1678,8 +1678,8 @@ gboolean dt_ioppr_transform_image_colorspace_rgb_cl
   {
     if(dev_img_in != dev_img_out)
     {
-      size_t origin[] = { 0, 0, 0 };
-      size_t region[] = { width, height, 1 };
+      size_t origin[] = { 0, 0 };
+      size_t region[] = { width, height };
 
       err = dt_opencl_enqueue_copy_image(devid, dev_img_in, dev_img_out, origin, origin, region);
       if(err != CL_SUCCESS)

--- a/src/common/nlmeans_core.c
+++ b/src/common/nlmeans_core.c
@@ -608,8 +608,8 @@ static inline cl_int nlmeans_cl_horiz(
         const int bwidth,
         const int hblocksize)
 {
-  const size_t sizesl[3] = { bwidth, ROUNDUPDHT(height, devid), 1 };
-  const size_t local[3] = { hblocksize, 1, 1 };
+  const size_t sizesl[2] = { bwidth, ROUNDUPDHT(height, devid) };
+  const size_t local[2] = { hblocksize, 1 };
   return dt_opencl_enqueue_kernel_2d_local_args(devid, kernel, sizesl, local,
     CLARG(dev_U4), CLARG(dev_U4_t), CLARG(width), CLARG(height), CLARRAY(2, q),
     CLARG(P), CLLOCAL((hblocksize + 2 * P) * sizeof(float)));
@@ -625,7 +625,7 @@ static inline cl_int nlmeans_cl_accu(
         const int q[2],
         const int height,
         const int width,
-        const size_t sizes[3])
+        const size_t sizes[2])
 {
   return dt_opencl_enqueue_kernel_2d_args(devid, kernel, sizes[0], sizes[1],
     CLARG(dev_in), CLARG(dev_out), CLARG(dev_U4_tt), CLARG(width), CLARG(height), CLARRAY(2, q));
@@ -689,8 +689,8 @@ int nlmeans_denoise_cl(
     if(err != CL_SUCCESS) break;
 
     // add together the column sums and compute the weighting of the current patch for each pixel
-    const size_t sizesl[3] = { ROUNDUPDWD(width, devid), bheight, 1 };
-    const size_t local[3] = { 1, vblocksize, 1 };
+    const size_t sizesl[2] = { ROUNDUPDWD(width, devid), bheight };
+    const size_t local[2] = { 1, vblocksize };
     const float sharpness = params->sharpness;
     cl_mem dev_U4_tt = buckets[bucket_next(&state, NUM_BUCKETS)];
     err = dt_opencl_enqueue_kernel_2d_local_args(devid, params->kernel_vert, sizesl, local,

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -2765,10 +2765,17 @@ int dt_opencl_enqueue_kernel_ndim_with_local(const int dev,
     (cl->dlocl->symbols->dt_clGetKernelInfo)(cl->dev[dev].kernel[kernel],
                                              CL_KERNEL_FUNCTION_NAME, sizeof(buf), buf, NULL);
   cl_event *eventp = _opencl_events_get_slot(dev, buf);
+
+  // do we have to pass the 1 for dimension greater than dimensions ?
+  // it seems not to be necessary but we always did that until now
+  // const size_t nsizes[3] = { sizes[0], dimensions > 1 ? sizes[1]: 1, dimensions > 2 ? sizes[2]: 1};
   cl_int err = (cl->dlocl->symbols->dt_clEnqueueNDRangeKernel)(cl->dev[dev].cmd_queue,
                                                                cl->dev[dev].kernel[kernel],
-                                                               dimensions, NULL, sizes,
-                                                               local, 0, NULL, eventp);
+                                                               dimensions,
+                                                               NULL,  // global_work_offset
+                                                               sizes, // global_work_size
+                                                               local, // local_work_size, maybe NULL
+                                                               0, NULL, eventp);
 
   if(err != CL_SUCCESS)
     dt_print(DT_DEBUG_OPENCL,
@@ -2804,7 +2811,7 @@ int dt_opencl_enqueue_kernel_2d_args_internal(const int dev,
               cl->name_saved[kernel], kernel, cl->dev[dev].fullname, dev, cl_errstr(err));
     return err;
   }
-  const size_t sizes[] = { ROUNDUPDWD(w, dev), ROUNDUPDHT(h, dev), 1 };
+  const size_t sizes[2] = { ROUNDUPDWD(w, dev), ROUNDUPDHT(h, dev) };
 
   return dt_opencl_enqueue_kernel_2d_with_local(dev, kernel, sizes, NULL);
 }
@@ -2826,8 +2833,7 @@ int dt_opencl_enqueue_kernel_2d_local_args_internal(const int dev,
               cl->name_saved[kernel], kernel, cl->dev[dev].fullname, dev, cl_errstr(err));
     return err;
   }
-  const size_t nsizes[3] = { sizes[0], sizes[1], 1 };
-  return dt_opencl_enqueue_kernel_2d_with_local(dev, kernel, nsizes, local);
+  return dt_opencl_enqueue_kernel_2d_with_local(dev, kernel, sizes, local);
 }
 
 int dt_opencl_enqueue_kernel_1d_args_internal(const int dev,
@@ -2847,7 +2853,7 @@ int dt_opencl_enqueue_kernel_1d_args_internal(const int dev,
               cl->name_saved[kernel], kernel, cl->dev[dev].fullname, dev, cl_errstr(err));
     return err;
   }
-  const size_t sizes[] = { ROUNDUPDWD(x, dev), 1, 1 };
+  const size_t sizes[1] = { ROUNDUPDWD(x, dev) };
 
   return dt_opencl_enqueue_kernel_ndim_with_local(dev, kernel, sizes, NULL, 1);
 }
@@ -2980,10 +2986,15 @@ int dt_opencl_enqueue_copy_image(const int devid,
   if(!_cldev_running(devid))
     return DT_OPENCL_NODEVICE;
 
+  size_t osrc[3] = { orig_src[0], orig_src[1], 0 };
+  size_t odst[3] = { orig_dst[0], orig_dst[1], 0 };
+  size_t reg[3] = { region[0], region[1], 1 };
+
   cl_event *eventp = _opencl_events_get_slot(devid, "[Copy Image (on device)]");
   const cl_int err = (darktable.opencl->dlocl->symbols->dt_clEnqueueCopyImage)
-    (darktable.opencl->dev[devid].cmd_queue, src, dst, orig_src, orig_dst,
-     region, 0, NULL, eventp);
+    (darktable.opencl->dev[devid].cmd_queue, src, dst,
+     osrc, odst, reg,
+     0, NULL, eventp);
 
   if(err != CL_SUCCESS)
     dt_print(DT_DEBUG_OPENCL,

--- a/src/develop/blend.c
+++ b/src/develop/blend.c
@@ -995,8 +995,8 @@ gboolean dt_develop_blend_process_cl(dt_iop_module_t *self,
   dt_colorspaces_iccprofile_info_cl_t *work_profile_info_cl = NULL;
   cl_float *work_profile_lut_cl = NULL;
 
-  size_t origin[] = { 0, 0, 0 };
-  size_t region[] = { owidth, oheight, 1 };
+  size_t origin[] = { 0, 0 };
+  size_t region[] = { owidth, oheight };
 
   // parameters, for every channel the 4 limits + pre-computed
   // increasing slope and decreasing slope
@@ -1179,7 +1179,7 @@ gboolean dt_develop_blend_process_cl(dt_iop_module_t *self,
           cl_mem dev_guide = dt_opencl_alloc_device(devid, owidth, oheight, sizeof(float) * ch);
           if(dev_guide == NULL) goto error;
 
-          size_t origin_1[] = { dx, dy, 0 };
+          size_t origin_1[] = { dx, dy };
           err = dt_opencl_enqueue_copy_image(devid, dev_in, dev_guide, origin, origin_1, region);
           if(err != CL_SUCCESS)
           {

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -2239,7 +2239,7 @@ void dt_iop_commit_params(dt_iop_module_t *module,
       }
 
       if(blendop_params->mask_mode & DEVELOP_MASK_RASTER && new_raster)
-        dt_dev_pixelpipe_cache_invalidate_later(pipe, new_raster->iop_order);
+        dt_dev_pixelpipe_cache_invalidate_later(pipe, new_raster->iop_order, "blend new raster: ");
     }
   }
   piece->hash = phash;
@@ -3648,7 +3648,7 @@ void dt_iop_piece_set_raster(dt_dev_pixelpipe_iop_t *piece,
 
   // If we place a raster mask we must invalidate the following cachelines
   if(!new)
-    dt_dev_pixelpipe_cache_invalidate_later(piece->pipe, piece->module->iop_order);
+    dt_dev_pixelpipe_cache_invalidate_later(piece->pipe, piece->module->iop_order, "set raster: ");
 
   dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_MASKS,
     "write raster mask", piece->pipe, piece->module, DT_DEVICE_NONE, roi_in, roi_out, "%s (%ix%i)",
@@ -3662,7 +3662,7 @@ void dt_iop_piece_clear_raster(dt_dev_pixelpipe_iop_t *piece, float *mask)
   {
     dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_MASKS,
         "delete raster mask", piece->pipe, piece->module, piece->pipe->devid, NULL, NULL);
-    dt_dev_pixelpipe_cache_invalidate_later(piece->pipe, piece->module->iop_order);
+    dt_dev_pixelpipe_cache_invalidate_later(piece->pipe, piece->module->iop_order, "clear raster: ");
   }
   dt_free_align(mask);
 }
@@ -3883,7 +3883,7 @@ void dt_iop_refresh_center(const dt_iop_module_t *module)
   dt_develop_t *dev = module->dev;
   if(dev && dev->gui_attached)
   {
-    dt_dev_pixelpipe_cache_invalidate_later(dev->full.pipe, module->iop_order);
+    dt_dev_pixelpipe_cache_invalidate_later(dev->full.pipe, module->iop_order, "refresh: ");
     //ensure that commit_params gets called to pick up any GUI changes
     dev->full.pipe->changed |= DT_DEV_PIPE_SYNCH;
     dt_dev_invalidate(dev);
@@ -3897,7 +3897,7 @@ void dt_iop_refresh_preview(const dt_iop_module_t *module)
   dt_develop_t *dev = module->dev;
   if(dev && dev->gui_attached)
   {
-    dt_dev_pixelpipe_cache_invalidate_later(dev->preview_pipe, module->iop_order);
+    dt_dev_pixelpipe_cache_invalidate_later(dev->preview_pipe, module->iop_order, "refresh: ");
     //ensure that commit_params gets called to pick up any GUI changes
     dev->full.pipe->changed |= DT_DEV_PIPE_SYNCH;
     dt_dev_invalidate_all(dev);
@@ -3911,7 +3911,7 @@ void dt_iop_refresh_preview2(const dt_iop_module_t *module)
   dt_develop_t *dev = module->dev;
   if(dev && dev->gui_attached)
   {
-    dt_dev_pixelpipe_cache_invalidate_later(dev->preview2.pipe, module->iop_order);
+    dt_dev_pixelpipe_cache_invalidate_later(dev->preview2.pipe, module->iop_order, "refresh: ");
     //ensure that commit_params gets called to pick up any GUI changes
     dev->full.pipe->changed |= DT_DEV_PIPE_SYNCH;
     dt_dev_invalidate_all(dev);

--- a/src/develop/pixelpipe_cache.c
+++ b/src/develop/pixelpipe_cache.c
@@ -374,7 +374,8 @@ static void _mark_invalid_cacheline(const dt_dev_pixelpipe_cache_t *cache, const
 }
 
 void dt_dev_pixelpipe_cache_invalidate_later(dt_dev_pixelpipe_t *pipe,
-                                             const int32_t order)
+                                             const int32_t order,
+                                             const char *info)
 {
   const dt_dev_pixelpipe_cache_t *cache = &pipe->cache;
   int invalidated = 0;
@@ -394,13 +395,14 @@ void dt_dev_pixelpipe_cache_invalidate_later(dt_dev_pixelpipe_t *pipe,
     dt_print_pipe(DT_DEBUG_PIPE,
     order ? "pipecache invalidate" : "pipecache flush",
     pipe, NULL, DT_DEVICE_NONE, NULL, NULL,
-    "%i cachelines after ioporder=%i%s",
+    "%s%i cachelines after ioporder=%i%s",
+    info ? info : "",
     invalidated, order, bcache ? ", blend cache" : "");
 }
 
 void dt_dev_pixelpipe_cache_flush(dt_dev_pixelpipe_t *pipe)
 {
-  dt_dev_pixelpipe_cache_invalidate_later(pipe, 0);
+  dt_dev_pixelpipe_cache_invalidate_later(pipe, 0, "flush: ");
 }
 
 void dt_dev_pixelpipe_important_cacheline(const dt_dev_pixelpipe_t *pipe,

--- a/src/develop/pixelpipe_cache.h
+++ b/src/develop/pixelpipe_cache.h
@@ -84,7 +84,7 @@ gboolean dt_dev_pixelpipe_cache_available(struct dt_dev_pixelpipe_t *pipe, const
 void dt_dev_pixelpipe_cache_flush(struct dt_dev_pixelpipe_t *pipe);
 
 /** invalidates all cachelines for modules with at least the same iop_order */
-void dt_dev_pixelpipe_cache_invalidate_later(struct dt_dev_pixelpipe_t *pipe, const int32_t order);
+void dt_dev_pixelpipe_cache_invalidate_later(struct dt_dev_pixelpipe_t *pipe, const int32_t order, const char *info);
 
 /** makes this buffer very important after it has been pulled from the cache. */
 void dt_dev_pixelpipe_important_cacheline(const struct dt_dev_pixelpipe_t *pipe, const void *data, const size_t size);

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -710,7 +710,7 @@ void dt_dev_pixelpipe_usedetails(dt_dev_pixelpipe_iop_t *piece)
   if(!pipe->want_detail_mask)
   {
     dt_print_pipe(DT_DEBUG_PIPE, "details requested", pipe, piece->module, DT_DEVICE_NONE, NULL, NULL);
-    dt_dev_pixelpipe_cache_invalidate_later(pipe, 0);
+    dt_dev_pixelpipe_cache_invalidate_later(pipe, 0, "usedetails ");
     pipe->want_detail_mask = TRUE;
   }
 }
@@ -1235,7 +1235,7 @@ static inline gboolean _module_pipe_stop(dt_dev_pixelpipe_t *pipe, float *input)
     if(stopper >= DT_DEV_PIXELPIPE_STOP_LAST)
     {
       dt_dev_pixelpipe_invalidate_cacheline(pipe, input);
-      dt_dev_pixelpipe_cache_invalidate_later(pipe, stopper);
+      dt_dev_pixelpipe_cache_invalidate_later(pipe, stopper, "pipe stop: ");
     }
   }
   return stopper != DT_DEV_PIXELPIPE_STOP_NO;

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -3652,8 +3652,8 @@ int process_cl(dt_iop_module_t *self,
   // if module is set to neutral parameters we just copy input->output and are done
   if(_isneutral(d))
   {
-    size_t origin[] = { 0, 0, 0 };
-    size_t region[] = { roi_out->width, roi_out->height, 1 };
+    size_t origin[] = { 0, 0 };
+    size_t region[] = { roi_out->width, roi_out->height };
     err = dt_opencl_enqueue_copy_image(devid, dev_in, dev_out, origin, origin, region);
     if(err != CL_SUCCESS) goto error;
     return CL_SUCCESS;

--- a/src/iop/atrous.c
+++ b/src/iop/atrous.c
@@ -525,8 +525,8 @@ int process_cl(dt_iop_module_t *self,
     if(dev_detail[k] == NULL) goto error;
   }
 
-  size_t origin[] = { 0, 0, 0 };
-  size_t region[] = { width, height, 1 };
+  size_t origin[] = { 0, 0 };
+  size_t region[] = { width, height };
   // copy original input from dev_in -> dev_out as starting point
   err = dt_opencl_enqueue_copy_image(devid, dev_in, dev_out, origin, origin, region);
   if(err != CL_SUCCESS) goto error;

--- a/src/iop/basecurve.c
+++ b/src/iop/basecurve.c
@@ -774,8 +774,8 @@ int process_cl_fusion(dt_iop_module_t *self,
         CLARG(dev_col[0]), CLARG(dev_out), CLARG(dev_tmp1), CLARG(width), CLARG(height));
       if(err != CL_SUCCESS) goto error;
 
-      size_t origin[] = { 0, 0, 0 };
-      size_t region[] = { width, height, 1 };
+      size_t origin[] = { 0, 0 };
+      size_t region[] = { width, height };
       err = dt_opencl_enqueue_copy_image(devid, dev_tmp1, dev_col[0], origin, origin, region);
       if(err != CL_SUCCESS) goto error;
     }
@@ -814,8 +814,8 @@ int process_cl_fusion(dt_iop_module_t *self,
           CLARG(dev_comb[k]), CLARG(dev_col[k]), CLARG(dev_tmp1), CLARG(w), CLARG(h));
         if(err != CL_SUCCESS) goto error;
 
-        size_t origin[] = { 0, 0, 0 };
-        size_t region[] = { w, h, 1 };
+        size_t origin[] = { 0, 0 };
+        size_t region[] = { w, h };
         err = dt_opencl_enqueue_copy_image(devid, dev_tmp1, dev_comb[k], origin, origin, region);
         if(err != CL_SUCCESS) goto error;
       }
@@ -826,8 +826,8 @@ int process_cl_fusion(dt_iop_module_t *self,
           CLARG(dev_comb[k]), CLARG(dev_col[k]), CLARG(dev_tmp2), CLARG(dev_tmp1), CLARG(w), CLARG(h));
         if(err != CL_SUCCESS) goto error;
 
-        size_t origin[] = { 0, 0, 0 };
-        size_t region[] = { w, h, 1 };
+        size_t origin[] = { 0, 0 };
+        size_t region[] = { w, h };
         err = dt_opencl_enqueue_copy_image(devid, dev_tmp1, dev_comb[k], origin, origin, region);
         if(err != CL_SUCCESS) goto error;
       }
@@ -853,8 +853,8 @@ int process_cl_fusion(dt_iop_module_t *self,
       if(err != CL_SUCCESS) goto error;
 
       // dev_tmp1[k] -> dev_comb[k]
-      size_t origin[] = { 0, 0, 0 };
-      size_t region[] = { w, h, 1 };
+      size_t origin[] = { 0, 0 };
+      size_t region[] = { w, h };
       err = dt_opencl_enqueue_copy_image(devid, dev_tmp1, dev_comb[k], origin, origin, region);
       if(err != CL_SUCCESS) goto error;
     }
@@ -873,8 +873,8 @@ int process_cl_fusion(dt_iop_module_t *self,
       if(err != CL_SUCCESS) goto error;
 
       // dev_tmp2 -> dev_comb[k]
-      size_t origin[] = { 0, 0, 0 };
-      size_t region[] = { w, h, 1 };
+      size_t origin[] = { 0, 0 };
+      size_t region[] = { w, h };
       err = dt_opencl_enqueue_copy_image(devid, dev_tmp2, dev_comb[k], origin, origin, region);
       if(err != CL_SUCCESS) goto error;
     }

--- a/src/iop/bloom.c
+++ b/src/iop/bloom.c
@@ -240,8 +240,8 @@ int process_cl(dt_iop_module_t *self,
   const size_t bwidth = ROUNDUP(width, hblocksize);
   const size_t bheight = ROUNDUP(height, vblocksize);
 
-  size_t sizes[3];
-  size_t local[3];
+  size_t sizes[2];
+  size_t local[2];
 
   for(int i = 0; i < NUM_BUCKETS; i++)
   {
@@ -265,7 +265,6 @@ int process_cl(dt_iop_module_t *self,
       sizes[1] = ROUNDUPDHT(height, devid);
       local[0] = hblocksize;
       local[1] = 1;
-      local[2] = 1;
       dev_tmp2 = dev_tmp[bucket_next(&state, NUM_BUCKETS)];
       err = dt_opencl_enqueue_kernel_2d_local_args(devid, gd->kernel_bloom_hblur, sizes, local,
                                 CLARG(dev_tmp1),
@@ -283,7 +282,6 @@ int process_cl(dt_iop_module_t *self,
       sizes[1] = bheight;
       local[0] = 1;
       local[1] = vblocksize;
-      local[2] = 1;
       dev_tmp1 = dev_tmp[bucket_next(&state, NUM_BUCKETS)];
       err = dt_opencl_enqueue_kernel_2d_local_args(devid, gd->kernel_bloom_vblur, sizes, local,
                                 CLARG(dev_tmp2), CLARG(dev_tmp1),

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -2181,7 +2181,7 @@ void process(dt_iop_module_t *self,
         // anyway
         _auto_detect_WB(in, out, data->illuminant_type, roi_in->width, roi_in->height,
                         ch, RGB_to_XYZ, g->XYZ);
-        dt_dev_pixelpipe_cache_invalidate_later(piece->pipe, self->iop_order);
+        dt_dev_pixelpipe_cache_invalidate_later(piece->pipe, self->iop_order, "AI RGB: ");
         dt_iop_gui_leave_critical_section(self);
       }
 

--- a/src/iop/clipping.c
+++ b/src/iop/clipping.c
@@ -1086,8 +1086,8 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
   if(!d->flags && d->angle == 0.0 && d->all_off && roi_in->width == roi_out->width
      && roi_in->height == roi_out->height)
   {
-    size_t origin[] = { 0, 0, 0 };
-    size_t region[] = { width, height, 1 };
+    size_t origin[] = { 0, 0 };
+    size_t region[] = { width, height };
     err = dt_opencl_enqueue_copy_image(devid, dev_in, dev_out, origin, origin, region);
     if(err != CL_SUCCESS) goto error;
   }

--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -646,8 +646,8 @@ int process_cl(dt_iop_module_t *self,
 
   if(d->type == DT_COLORSPACE_LAB)
   {
-    size_t origin[] = { 0, 0, 0 };
-    size_t region[] = { width, height, 1 };
+    size_t origin[] = { 0, 0 };
+    size_t region[] = { width, height };
     return dt_opencl_enqueue_copy_image(devid, dev_in, dev_out, origin, origin, region);
   }
 

--- a/src/iop/colormapping.c
+++ b/src/iop/colormapping.c
@@ -675,8 +675,8 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
     }
     else
     {
-      size_t origin[] = { 0, 0, 0 };
-      size_t region[] = { width, height, 1 };
+      size_t origin[] = { 0, 0 };
+      size_t region[] = { width, height };
       err = dt_opencl_enqueue_copy_image(devid, dev_out, dev_tmp, origin, origin, region);
       if(err != CL_SUCCESS) goto error;
     }
@@ -687,8 +687,8 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
   }
   else
   {
-    size_t origin[] = { 0, 0, 0 };
-    size_t region[] = { width, height, 1 };
+    size_t origin[] = { 0, 0 };
+    size_t region[] = { width, height };
     err = dt_opencl_enqueue_copy_image(devid, dev_in, dev_out, origin, origin, region);
   }
 

--- a/src/iop/colorout.c
+++ b/src/iop/colorout.c
@@ -324,8 +324,8 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
 
   if(d->type == DT_COLORSPACE_LAB)
   {
-    size_t origin[] = { 0, 0, 0 };
-    size_t region[] = { roi_in->width, roi_in->height, 1 };
+    size_t origin[] = { 0, 0 };
+    size_t region[] = { roi_in->width, roi_in->height };
     err = dt_opencl_enqueue_copy_image(devid, dev_in, dev_out, origin, origin, region);
     if(err != CL_SUCCESS) goto error;
     return CL_SUCCESS;

--- a/src/iop/colorreconstruction.c
+++ b/src/iop/colorreconstruction.c
@@ -935,8 +935,8 @@ static cl_int dt_iop_colorreconstruct_bilateral_splat_cl(dt_iop_colorreconstruct
   cl_int err = DT_OPENCL_PROCESS_CL;
   if(!b) return err;
   int pref = precedence;
-  size_t sizes[] = { ROUNDUP(b->width, b->blocksizex), ROUNDUP(b->height, b->blocksizey), 1 };
-  size_t local[] = { b->blocksizex, b->blocksizey, 1 };
+  size_t sizes[] = { ROUNDUP(b->width, b->blocksizex), ROUNDUP(b->height, b->blocksizey) };
+  size_t local[] = { b->blocksizex, b->blocksizey };
   err = dt_opencl_enqueue_kernel_2d_local_args(b->devid, b->global->kernel_colorreconstruct_splat, sizes, local,
     CLARG(in), CLARG(b->dev_grid),
     CLARG(b->width), CLARG(b->height), CLARG(b->size_x), CLARG(b->size_y), CLARG(b->size_z), CLARG(b->sigma_s),

--- a/src/iop/crop.c
+++ b/src/iop/crop.c
@@ -609,8 +609,8 @@ int process_cl(dt_iop_module_t *self,
                const dt_iop_roi_t *const roi_in,
                const dt_iop_roi_t *const roi_out)
 {
-  size_t origin[] = { 0, 0, 0 };
-  size_t region[] = { roi_out->width, roi_out->height, 1 };
+  size_t origin[] = { 0, 0 };
+  size_t region[] = { roi_out->width, roi_out->height };
   return dt_opencl_enqueue_copy_image(piece->pipe->devid, dev_in, dev_out,
                                             origin, origin, region);
 }

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -1108,9 +1108,9 @@ int process_cl(dt_iop_module_t *self,
               "tile=%.3d/%.3d, group=%.5d first=%.5d last=%.5d rows=%.4d",
                tile_nr, num_tiles, group, first_in, last_in, t_rows);
 
-        size_t insrc[]  = { 0, first_in, 0 };
-        size_t tdest[]  = { 0, 0, 0 };
-        size_t iarea[]  = { iwidth, t_rows, 1 };
+        size_t insrc[]  = { 0, first_in };
+        size_t tdest[]  = { 0, 0 };
+        size_t iarea[]  = { iwidth, t_rows };
         err = dt_opencl_enqueue_copy_image(devid, in_image, t_in, insrc, tdest, iarea);
         if(err != CL_SUCCESS) goto finish;
       }
@@ -1119,9 +1119,9 @@ int process_cl(dt_iop_module_t *self,
         err = demosaic_box3_cl(self, piece, t_in, t_high, dev_xtrans, iwidth, t_rows, filters);
       else if(method == DT_IOP_DEMOSAIC_MONO)
       {
-        size_t insrc[]  = { 0, 0, 0 };
-        size_t tdest[]  = { 0, 0, 0 };
-        size_t iarea[]  = { iwidth, t_rows, 1 };
+        size_t insrc[]  = { 0, 0 };
+        size_t tdest[]  = { 0, 0 };
+        size_t iarea[]  = { iwidth, t_rows };
         err = dt_opencl_enqueue_copy_image(devid, t_in, t_high, insrc, tdest, iarea);
       }
       else if(passthru || method == DT_IOP_DEMOSAIC_PPG)
@@ -1153,9 +1153,9 @@ int process_cl(dt_iop_module_t *self,
 
       if(tiling)
       {
-        size_t tsrc[]   = { 0, first_out, 0 };
-        size_t odest[]  = { 0, group, 0 };
-        size_t oarea[]  = { iwidth, out_height, 1 };
+        size_t tsrc[]   = { 0, first_out };
+        size_t odest[]  = { 0, group };
+        size_t oarea[]  = { iwidth, out_height };
         err = dt_opencl_enqueue_copy_image(devid, t_out, out_image, tsrc, odest, oarea);
         if(err != CL_SUCCESS) goto finish;
       }

--- a/src/iop/demosaicing/basics.c
+++ b/src/iop/demosaicing/basics.c
@@ -482,97 +482,89 @@ static int process_default_cl(const dt_iop_module_t *self,
   cl_mem dev_med = NULL;
   cl_int err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
 
-    if(demosaicing_method == DT_IOP_DEMOSAIC_PASSTHROUGH_MONOCHROME)
-    {
-      err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_passthrough_monochrome, width, height,
+  if(demosaicing_method == DT_IOP_DEMOSAIC_PASSTHROUGH_MONOCHROME)
+  {
+    err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_passthrough_monochrome, width, height,
         CLARG(dev_in), CLARG(dev_out), CLARG(width), CLARG(height));
-      if(err != CL_SUCCESS) goto error;
-    }
-    else if(demosaicing_method == DT_IOP_DEMOSAIC_PASSTHROUGH_COLOR)
-    {
-      err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_passthrough_color, width, height,
+  }
+  else if(demosaicing_method == DT_IOP_DEMOSAIC_PASSTHROUGH_COLOR)
+  {
+    err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_passthrough_color, width, height,
         CLARG(dev_in), CLARG(dev_out), CLARG(width), CLARG(height),
         CLARG(filters), CLARG(dev_xtrans));
-      if(err != CL_SUCCESS) goto error;
-    }
-    else if(demosaicing_method == DT_IOP_DEMOSAIC_PPG)
+  }
+  else if(demosaicing_method == DT_IOP_DEMOSAIC_PPG)
+  {
+    dev_tmp = dt_opencl_alloc_device(devid, width, height, sizeof(float) * 4);
+    if(dev_tmp == NULL) goto error;
+
+    err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_border_interpolate, width, height,
+          CLARG(dev_in), CLARG(dev_tmp), CLARG(width), CLARG(height), CLARG(filters));
+    if(err != CL_SUCCESS) goto error;
+
+    if(d->median_thrs > 0.0f)
     {
-      dev_tmp = dt_opencl_alloc_device(devid, width, height, sizeof(float) * 4);
-      if(dev_tmp == NULL)
+      dev_med = dt_opencl_alloc_device(devid, width, height, sizeof(float) * 4);
+      if(dev_med == NULL)
       {
         err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
         goto error;
       }
 
-      {
-        err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_border_interpolate, width, height,
-          CLARG(dev_in), CLARG(dev_tmp), CLARG(width), CLARG(height), CLARG(filters));
-        if(err != CL_SUCCESS) goto error;
-      }
-
-      if(d->median_thrs > 0.0f)
-      {
-        dev_med = dt_opencl_alloc_device(devid, width, height, sizeof(float) * 4);
-        if(dev_med == NULL)
-        {
-          err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
-          goto error;
-        }
-
-        dt_opencl_local_buffer_t locopt
+      dt_opencl_local_buffer_t locopt
           = (dt_opencl_local_buffer_t){ .xoffset = 2*2, .xfactor = 1, .yoffset = 2*2, .yfactor = 1,
                                         .cellsize = 1 * sizeof(float), .overhead = 0,
                                         .sizex = 1 << 8, .sizey = 1 << 8 };
 
-        err = dt_opencl_local_buffer_opt(devid, gd->kernel_pre_median, &locopt);
-        if(err != CL_SUCCESS) goto error;
+      err = dt_opencl_local_buffer_opt(devid, gd->kernel_pre_median, &locopt);
+      if(err != CL_SUCCESS) goto error;
 
-        const size_t sizes[2] = { ROUNDUP(width, locopt.sizex), ROUNDUP(height, locopt.sizey) };
-        const size_t local[2] = { locopt.sizex, locopt.sizey };
-        err = dt_opencl_enqueue_kernel_2d_local_args(devid, gd->kernel_pre_median, sizes, local,
+      const size_t sizes[2] = { ROUNDUP(width, locopt.sizex), ROUNDUP(height, locopt.sizey) };
+      const size_t local[2] = { locopt.sizex, locopt.sizey };
+      err = dt_opencl_enqueue_kernel_2d_local_args(devid, gd->kernel_pre_median, sizes, local,
           CLARG(dev_in), CLARG(dev_med), CLARG(width),
           CLARG(height), CLARG(filters), CLARG(d->median_thrs), CLLOCAL(sizeof(float) * (locopt.sizex + 4) * (locopt.sizey + 4)));
-        if(err != CL_SUCCESS) goto error;
-        dev_in = dev_out;
-      }
-      else dev_med = dev_in;
+      if(err != CL_SUCCESS) goto error;
+      dev_in = dev_out;
+    }
+    else dev_med = dev_in;
 
-      {
-        dt_opencl_local_buffer_t locopt
+    {
+      dt_opencl_local_buffer_t locopt
           = (dt_opencl_local_buffer_t){ .xoffset = 2*3, .xfactor = 1, .yoffset = 2*3, .yfactor = 1,
                                         .cellsize = sizeof(float) * 1, .overhead = 0,
                                         .sizex = 1 << 8, .sizey = 1 << 8 };
 
-        err = dt_opencl_local_buffer_opt(devid, gd->kernel_ppg_green, &locopt);
-        if(err != CL_SUCCESS) goto error;
+      err = dt_opencl_local_buffer_opt(devid, gd->kernel_ppg_green, &locopt);
+      if(err != CL_SUCCESS) goto error;
 
-        const size_t sizes[2] = { ROUNDUP(width, locopt.sizex), ROUNDUP(height, locopt.sizey) };
-        const size_t local[2] = { locopt.sizex, locopt.sizey };
-        err = dt_opencl_enqueue_kernel_2d_local_args(devid, gd->kernel_ppg_green, sizes, local,
+      const size_t sizes[2] = { ROUNDUP(width, locopt.sizex), ROUNDUP(height, locopt.sizey) };
+      const size_t local[2] = { locopt.sizex, locopt.sizey };
+      err = dt_opencl_enqueue_kernel_2d_local_args(devid, gd->kernel_ppg_green, sizes, local,
           CLARG(dev_med), CLARG(dev_tmp), CLARG(width),
           CLARG(height), CLARG(filters), CLLOCAL(sizeof(float) * (locopt.sizex + 2*3) * (locopt.sizey + 2*3)),
           CLARGINT(100000));
-        if(err != CL_SUCCESS) goto error;
-      }
+      if(err != CL_SUCCESS) goto error;
+    }
 
-      {
-        dt_opencl_local_buffer_t locopt
+    {
+      dt_opencl_local_buffer_t locopt
           = (dt_opencl_local_buffer_t){ .xoffset = 2*1, .xfactor = 1, .yoffset = 2*1, .yfactor = 1,
                                         .cellsize = 4 * sizeof(float), .overhead = 0,
                                         .sizex = 1 << 8, .sizey = 1 << 8 };
 
-        err = dt_opencl_local_buffer_opt(devid, gd->kernel_ppg_redblue, &locopt);
-        if(err != CL_SUCCESS) goto error;
+      err = dt_opencl_local_buffer_opt(devid, gd->kernel_ppg_redblue, &locopt);
+      if(err != CL_SUCCESS) goto error;
 
-        const size_t sizes[2] = { ROUNDUP(width, locopt.sizex), ROUNDUP(height, locopt.sizey) };
-        const size_t local[2] = { locopt.sizex, locopt.sizey };
-        err = dt_opencl_enqueue_kernel_2d_local_args(devid, gd->kernel_ppg_redblue, sizes, local,
+      const size_t sizes[2] = { ROUNDUP(width, locopt.sizex), ROUNDUP(height, locopt.sizey) };
+      const size_t local[2] = { locopt.sizex, locopt.sizey };
+      err = dt_opencl_enqueue_kernel_2d_local_args(devid, gd->kernel_ppg_redblue, sizes, local,
           CLARG(dev_tmp), CLARG(dev_out), CLARG(width),
           CLARG(height), CLARG(filters), CLLOCAL(sizeof(float) * 4 * (locopt.sizex + 2) * (locopt.sizey + 2)),
           CLARGINT(100000));
-        if(err != CL_SUCCESS) goto error;
-      }
+      if(err != CL_SUCCESS) goto error;
     }
+  }
 
 error:
   if(dev_med != dev_in) dt_opencl_release_mem_object(dev_med);

--- a/src/iop/demosaicing/basics.c
+++ b/src/iop/demosaicing/basics.c
@@ -286,8 +286,8 @@ static int color_smoothing_cl(const dt_iop_module_t *self,
   if(dev_t1 == dev_tmp)
   {
     // copy data from dev_tmp -> dev_out
-    size_t origin[] = { 0, 0, 0 };
-    size_t region[] = { width, height, 1 };
+    size_t origin[] = { 0, 0 };
+    size_t region[] = { width, height };
     err = dt_opencl_enqueue_copy_image(devid, dev_tmp, dev_out, origin, origin, region);
   }
 

--- a/src/iop/demosaicing/basics.c
+++ b/src/iop/demosaicing/basics.c
@@ -266,8 +266,8 @@ static int color_smoothing_cl(const dt_iop_module_t *self,
   cl_mem dev_t1 = dev_out;
   cl_mem dev_t2 = dev_tmp;
 
-  const size_t sizes[] = { ROUNDUP(width, locopt.sizex), ROUNDUP(height, locopt.sizey), 1 };
-  const size_t local[] = { locopt.sizex, locopt.sizey, 1 };
+  const size_t sizes[] = { ROUNDUP(width, locopt.sizex), ROUNDUP(height, locopt.sizey) };
+  const size_t local[] = { locopt.sizex, locopt.sizey };
   for(int pass = 0; pass < passes; pass++)
   {
     err = dt_opencl_enqueue_kernel_2d_local_args(devid, gd->kernel_color_smoothing, sizes, local,
@@ -372,8 +372,8 @@ static int green_equilibration_cl(const dt_iop_module_t *self,
       goto error;
     }
 
-    const size_t fsizes[3] = { bwidth, bheight, 1 };
-    const size_t flocal[3] = { flocopt.sizex, flocopt.sizey, 1 };
+    const size_t fsizes[2] = { bwidth, bheight };
+    const size_t flocal[2] = { flocopt.sizex, flocopt.sizey };
     err = dt_opencl_enqueue_kernel_2d_local_args(devid, gd->kernel_green_eq_favg_reduce_first, fsizes, flocal,
       CLARG(dev_in1), CLARG(width),
       CLARG(height), CLARG(dev_m), CLARG(filters),
@@ -397,8 +397,8 @@ static int green_equilibration_cl(const dt_iop_module_t *self,
       goto error;
     }
 
-    const size_t ssizes[3] = { (size_t)reducesize * slocopt.sizex, 1, 1 };
-    const size_t slocal[3] = { slocopt.sizex, 1, 1 };
+    const size_t ssizes[2] = { (size_t)reducesize * slocopt.sizex, 1 };
+    const size_t slocal[2] = { slocopt.sizex, 1 };
     err = dt_opencl_enqueue_kernel_2d_local_args(devid, gd->kernel_green_eq_favg_reduce_second, ssizes, slocal,
       CLARG(dev_m), CLARG(dev_r),
       CLARG(bufsize), CLLOCAL(sizeof(float) * 2 * slocopt.sizex));
@@ -444,8 +444,8 @@ static int green_equilibration_cl(const dt_iop_module_t *self,
     err = dt_opencl_local_buffer_opt(devid, gd->kernel_green_eq_lavg, &locopt);
     if(err != CL_SUCCESS) goto error;
 
-    const size_t sizes[3] = { ROUNDUP(width, locopt.sizex), ROUNDUP(height, locopt.sizey), 1 };
-    const size_t local[3] = { locopt.sizex, locopt.sizey, 1 };
+    const size_t sizes[2] = { ROUNDUP(width, locopt.sizex), ROUNDUP(height, locopt.sizey) };
+    const size_t local[2] = { locopt.sizex, locopt.sizey };
     err = dt_opencl_enqueue_kernel_2d_local_args(devid, gd->kernel_green_eq_lavg, sizes, local,
       CLARG(dev_in2), CLARG(dev_out2),
       CLARG(width), CLARG(height), CLARG(filters),
@@ -527,8 +527,8 @@ static int process_default_cl(const dt_iop_module_t *self,
         err = dt_opencl_local_buffer_opt(devid, gd->kernel_pre_median, &locopt);
         if(err != CL_SUCCESS) goto error;
 
-        const size_t sizes[3] = { ROUNDUP(width, locopt.sizex), ROUNDUP(height, locopt.sizey), 1 };
-        const size_t local[3] = { locopt.sizex, locopt.sizey, 1 };
+        const size_t sizes[2] = { ROUNDUP(width, locopt.sizex), ROUNDUP(height, locopt.sizey) };
+        const size_t local[2] = { locopt.sizex, locopt.sizey };
         err = dt_opencl_enqueue_kernel_2d_local_args(devid, gd->kernel_pre_median, sizes, local,
           CLARG(dev_in), CLARG(dev_med), CLARG(width),
           CLARG(height), CLARG(filters), CLARG(d->median_thrs), CLLOCAL(sizeof(float) * (locopt.sizex + 4) * (locopt.sizey + 4)));
@@ -546,8 +546,8 @@ static int process_default_cl(const dt_iop_module_t *self,
         err = dt_opencl_local_buffer_opt(devid, gd->kernel_ppg_green, &locopt);
         if(err != CL_SUCCESS) goto error;
 
-        const size_t sizes[3] = { ROUNDUP(width, locopt.sizex), ROUNDUP(height, locopt.sizey), 1 };
-        const size_t local[3] = { locopt.sizex, locopt.sizey, 1 };
+        const size_t sizes[2] = { ROUNDUP(width, locopt.sizex), ROUNDUP(height, locopt.sizey) };
+        const size_t local[2] = { locopt.sizex, locopt.sizey };
         err = dt_opencl_enqueue_kernel_2d_local_args(devid, gd->kernel_ppg_green, sizes, local,
           CLARG(dev_med), CLARG(dev_tmp), CLARG(width),
           CLARG(height), CLARG(filters), CLLOCAL(sizeof(float) * (locopt.sizex + 2*3) * (locopt.sizey + 2*3)),
@@ -564,8 +564,8 @@ static int process_default_cl(const dt_iop_module_t *self,
         err = dt_opencl_local_buffer_opt(devid, gd->kernel_ppg_redblue, &locopt);
         if(err != CL_SUCCESS) goto error;
 
-        const size_t sizes[3] = { ROUNDUP(width, locopt.sizex), ROUNDUP(height, locopt.sizey), 1 };
-        const size_t local[3] = { locopt.sizex, locopt.sizey, 1 };
+        const size_t sizes[2] = { ROUNDUP(width, locopt.sizex), ROUNDUP(height, locopt.sizey) };
+        const size_t local[2] = { locopt.sizex, locopt.sizey };
         err = dt_opencl_enqueue_kernel_2d_local_args(devid, gd->kernel_ppg_redblue, sizes, local,
           CLARG(dev_tmp), CLARG(dev_out), CLARG(width),
           CLARG(height), CLARG(filters), CLLOCAL(sizeof(float) * 4 * (locopt.sizex + 2) * (locopt.sizey + 2)),

--- a/src/iop/demosaicing/vng.c
+++ b/src/iop/demosaicing/vng.c
@@ -185,6 +185,7 @@ static void vng_interpolate(float *out,
   const int prow = is_xtrans ? 6 : 8;
   const int pcol = is_xtrans ? 6 : 2;
   const int colors = is_xtrans ? 3 : 4;
+  const gboolean mix_greens = !is_xtrans && !is_4bayer;
 
   // separate out G1 and G2 in RGGB Bayer patterns
   uint32_t filters4 = filters;
@@ -318,7 +319,7 @@ finish:
   DT_OMP_FOR()
   for(size_t i = 0; i < (size_t)width * height * 4; i+=4)
   {
-    if(!is_xtrans)
+    if(mix_greens)
     {
       out[i+1] = 0.5f * (out[i+1] + out[i+3]);
       out[i+3] = 0.0f;

--- a/src/iop/demosaicing/xtrans.c
+++ b/src/iop/demosaicing/xtrans.c
@@ -2022,8 +2022,8 @@ static cl_int process_markesteijn_cl(const dt_iop_module_t *self,
     // note: we need to take swap of buffers into account, so current output lies in dev_t1
     if(dev_t1 != dev_tmptmp)
     {
-      size_t origin[] = { 0, 0, 0 };
-      size_t region[] = { width, height, 1 };
+      size_t origin[] = { 0, 0 };
+      size_t region[] = { width, height };
       err = dt_opencl_enqueue_copy_image(devid, dev_t1, dev_tmptmp, origin, origin, region);
       if(err != CL_SUCCESS) goto error;
     }

--- a/src/iop/demosaicing/xtrans.c
+++ b/src/iop/demosaicing/xtrans.c
@@ -1737,8 +1737,8 @@ static cl_int process_markesteijn_cl(const dt_iop_module_t *self,
     if(err != CL_SUCCESS) goto error;
 
     {
-      const size_t sizes[3] = { ROUNDUP(width, locopt_g1_g3.sizex), ROUNDUP(height, locopt_g1_g3.sizey), 1 };
-      const size_t local[3] = { locopt_g1_g3.sizex, locopt_g1_g3.sizey, 1 };
+      const size_t sizes[2] = { ROUNDUP(width, locopt_g1_g3.sizex), ROUNDUP(height, locopt_g1_g3.sizey) };
+      const size_t local[2] = { locopt_g1_g3.sizex, locopt_g1_g3.sizey };
       err = dt_opencl_enqueue_kernel_2d_local_args(devid, gd->kernel_markesteijn_green_minmax, sizes, local,
         CLARG(dev_rgb[0]), CLARG(dev_gminmax),
         CLARG(width), CLARG(height), CLARGINT(PAD_G1_G3), CLARRAY(2, sgreen),
@@ -1756,8 +1756,8 @@ static cl_int process_markesteijn_cl(const dt_iop_module_t *self,
     if(err != CL_SUCCESS) goto error;
 
     {
-      const size_t sizes[3] = { ROUNDUP(width, locopt_g_interp.sizex), ROUNDUP(height, locopt_g_interp.sizey), 1 };
-      const size_t local[3] = { locopt_g_interp.sizex, locopt_g_interp.sizey, 1 };
+      const size_t sizes[2] = { ROUNDUP(width, locopt_g_interp.sizex), ROUNDUP(height, locopt_g_interp.sizey) };
+      const size_t local[2] = { locopt_g_interp.sizex, locopt_g_interp.sizey };
       err = dt_opencl_enqueue_kernel_2d_local_args(devid, gd->kernel_markesteijn_interpolate_green, sizes, local,
         CLARG(dev_rgb[0]), CLARG(dev_rgb[1]), CLARG(dev_rgb[2]), CLARG(dev_rgb[3]),
         CLARG(dev_gminmax), CLARG(width), CLARG(height),
@@ -1810,8 +1810,8 @@ static cl_int process_markesteijn_cl(const dt_iop_module_t *self,
         const char dir[2] = { i, i ^ 1 };
 
         // we use dev_aux to transport intermediate results from one loop run to the next
-        const size_t sizes[3] = { ROUNDUP(width, locopt_rb_g.sizex), ROUNDUP(height, locopt_rb_g.sizey), 1 };
-        const size_t local[3] = { locopt_rb_g.sizex, locopt_rb_g.sizey, 1 };
+        const size_t sizes[2] = { ROUNDUP(width, locopt_rb_g.sizex), ROUNDUP(height, locopt_rb_g.sizey) };
+        const size_t local[2] = { locopt_rb_g.sizex, locopt_rb_g.sizey };
         err = dt_opencl_enqueue_kernel_2d_local_args(devid, gd->kernel_markesteijn_solitary_green, sizes, local,
           CLARG(dev_trgb[0]), CLARG(dev_aux), CLARG(width), CLARG(height), CLARG(pad_rb_g),
           CLARG(d), CLARRAY(2, dir), CLARG(h), CLARRAY(2, sgreen), CLARG(dev_xtrans), CLLOCAL(sizeof(float) * 4 * (locopt_rb_g.sizex + 2*2) * (locopt_rb_g.sizey + 2*2)));
@@ -1832,8 +1832,8 @@ static cl_int process_markesteijn_cl(const dt_iop_module_t *self,
 
       for(int d = 0; d < 4; d++)
       {
-        const size_t sizes[3] = { ROUNDUP(width, locopt_rb_br.sizex), ROUNDUP(height, locopt_rb_br.sizey), 1 };
-        const size_t local[3] = { locopt_rb_br.sizex, locopt_rb_br.sizey, 1 };
+        const size_t sizes[2] = { ROUNDUP(width, locopt_rb_br.sizex), ROUNDUP(height, locopt_rb_br.sizey) };
+        const size_t local[2] = { locopt_rb_br.sizex, locopt_rb_br.sizey };
         err = dt_opencl_enqueue_kernel_2d_local_args(devid, gd->kernel_markesteijn_red_and_blue, sizes, local,
           CLARG(dev_rgb[d]), CLARG(width), CLARG(height), CLARG(pad_rb_br), CLARG(d), CLARRAY(2, sgreen),
           CLARG(dev_xtrans), CLLOCAL(sizeof(float) * 4 * (locopt_rb_br.sizex + 2*3) * (locopt_rb_br.sizey + 2*3)));
@@ -1852,8 +1852,8 @@ static cl_int process_markesteijn_cl(const dt_iop_module_t *self,
 
       for(int d = 0, n = 0; d < ndir; d += 2, n++)
       {
-        const size_t sizes[3] = { ROUNDUP(width, locopt_g22.sizex), ROUNDUP(height, locopt_g22.sizey), 1 };
-        const size_t local[3] = { locopt_g22.sizex, locopt_g22.sizey, 1 };
+        const size_t sizes[2] = { ROUNDUP(width, locopt_g22.sizex), ROUNDUP(height, locopt_g22.sizey) };
+        const size_t local[2] = { locopt_g22.sizex, locopt_g22.sizey };
         err = dt_opencl_enqueue_kernel_2d_local_args(devid, gd->kernel_markesteijn_interpolate_twoxtwo, sizes, local,
           CLARG(dev_rgb[n]), CLARG(width), CLARG(height), CLARG(pad_g22), CLARG(d), CLARRAY(2, sgreen),
           CLARG(dev_xtrans), CLARG(dev_allhex), CLLOCAL(sizeof(float) * 4 * (locopt_g22.sizex + 2*2) * (locopt_g22.sizey + 2*2)));
@@ -1896,8 +1896,8 @@ static cl_int process_markesteijn_cl(const dt_iop_module_t *self,
 
 
       // differentiate in all directions
-      const size_t sizes_diff[3] = { ROUNDUP(width, locopt_diff.sizex), ROUNDUP(height, locopt_diff.sizey), 1 };
-      const size_t local_diff[3] = { locopt_diff.sizex, locopt_diff.sizey, 1 };
+      const size_t sizes_diff[2] = { ROUNDUP(width, locopt_diff.sizex), ROUNDUP(height, locopt_diff.sizey) };
+      const size_t local_diff[2] = { locopt_diff.sizex, locopt_diff.sizey };
       err = dt_opencl_enqueue_kernel_2d_local_args(devid, gd->kernel_markesteijn_differentiate, sizes_diff, local_diff,
         CLARG(dev_aux), CLARG(dev_drv[d]),
         CLARG(width), CLARG(height), CLARG(pad_yuv), CLARG(d), CLLOCAL(sizeof(float) * 4 * (locopt_diff.sizex + 2*1) * (locopt_diff.sizey + 2*1)));
@@ -1936,8 +1936,8 @@ static cl_int process_markesteijn_cl(const dt_iop_module_t *self,
 
     for(int d = 0; d < ndir; d++)
     {
-      const size_t sizes[3] = { ROUNDUP(width, locopt_homo.sizex),ROUNDUP(height, locopt_homo.sizey), 1 };
-      const size_t local[3] = { locopt_homo.sizex, locopt_homo.sizey, 1 };
+      const size_t sizes[2] = { ROUNDUP(width, locopt_homo.sizex),ROUNDUP(height, locopt_homo.sizey) };
+      const size_t local[2] = { locopt_homo.sizex, locopt_homo.sizey };
       err = dt_opencl_enqueue_kernel_2d_local_args(devid, gd->kernel_markesteijn_homo_set, sizes, local,
         CLARG(dev_drv[d]), CLARG(dev_aux),
         CLARG(dev_homo[d]), CLARG(width), CLARG(height), CLARG(pad_homo), CLLOCAL(sizeof(float) * (locopt_homo.sizex + 2*1) * (locopt_homo.sizey + 2*1)));
@@ -1962,8 +1962,8 @@ static cl_int process_markesteijn_cl(const dt_iop_module_t *self,
 
     for(int d = 0; d < ndir; d++)
     {
-      size_t sizes[3] = { ROUNDUP(width, locopt_homo_sum.sizex), ROUNDUP(height, locopt_homo_sum.sizey), 1 };
-      size_t local[3] = { locopt_homo_sum.sizex, locopt_homo_sum.sizey, 1 };
+      size_t sizes[2] = { ROUNDUP(width, locopt_homo_sum.sizex), ROUNDUP(height, locopt_homo_sum.sizey) };
+      size_t local[2] = { locopt_homo_sum.sizex, locopt_homo_sum.sizey };
       err = dt_opencl_enqueue_kernel_2d_local_args(devid, gd->kernel_markesteijn_homo_sum, sizes, local,
         CLARG(dev_homo[d]), CLARG(dev_homosum[d]),
         CLARG(width), CLARG(height), CLARG(pad_tile), CLLOCAL(sizeof(char) * (locopt_homo_sum.sizex + 2*2) * (locopt_homo_sum.sizey + 2*2)));

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -2087,8 +2087,8 @@ static int process_nlmeans_cl(dt_iop_module_t *self,
 
   const size_t bwidth = ROUNDUP(width, hblocksize);
   const size_t bheight = ROUNDUP(height, vblocksize);
-  size_t sizesl[3];
-  size_t local[3];
+  size_t sizesl[2];
+  size_t local[2];
 
   for(int kj_index = -K; kj_index <= 0; kj_index++)
   {
@@ -2116,10 +2116,8 @@ static int process_nlmeans_cl(dt_iop_module_t *self,
 
       sizesl[0] = bwidth;
       sizesl[1] = ROUNDUPDHT(height, devid);
-      sizesl[2] = 1;
       local[0] = hblocksize;
       local[1] = 1;
-      local[2] = 1;
       cl_mem dev_U4_t = buckets[bucket_next(&state, NUM_BUCKETS)];
       err = dt_opencl_enqueue_kernel_2d_local_args(devid, gd->kernel_denoiseprofile_horiz, sizesl, local,
                 CLARG(dev_U4), CLARG(dev_U4_t),
@@ -2129,10 +2127,8 @@ static int process_nlmeans_cl(dt_iop_module_t *self,
 
       sizesl[0] = ROUNDUPDWD(width, devid);
       sizesl[1] = bheight;
-      sizesl[2] = 1;
       local[0] = 1;
       local[1] = vblocksize;
-      local[2] = 1;
       cl_mem dev_U4_tt = buckets[bucket_next(&state, NUM_BUCKETS)];
       err = dt_opencl_enqueue_kernel_2d_local_args(devid, gd->kernel_denoiseprofile_vert, sizesl, local,
               CLARG(dev_U4_t), CLARG(dev_U4_tt),
@@ -2414,15 +2410,13 @@ static int process_wavelets_cl(dt_iop_module_t *self,
     // determine thrs as bayesshrink
     dt_aligned_pixel_t sum_y2 = { 0.0f };
 
-    size_t lsizes[3];
-    size_t llocal[3];
+    size_t lsizes[2];
+    size_t llocal[2];
 
     lsizes[0] = bwidth;
     lsizes[1] = bheight;
-    lsizes[2] = 1;
     llocal[0] = flocopt.sizex;
     llocal[1] = flocopt.sizey;
-    llocal[2] = 1;
     err = dt_opencl_enqueue_kernel_2d_local_args(devid, gd->kernel_denoiseprofile_reduce_first, lsizes, llocal,
                               CLARG((dev_detail[s])),
                               CLARG(width), CLARG(height),
@@ -2433,10 +2427,8 @@ static int process_wavelets_cl(dt_iop_module_t *self,
 
     lsizes[0] = (size_t)reducesize * slocopt.sizex;
     lsizes[1] = 1;
-    lsizes[2] = 1;
     llocal[0] = slocopt.sizex;
     llocal[1] = 1;
-    llocal[2] = 1;
     err = dt_opencl_enqueue_kernel_2d_local_args(devid, gd->kernel_denoiseprofile_reduce_second, lsizes, llocal,
                               CLARG(dev_m), CLARG(dev_r),
                               CLARG(bufsize), CLLOCAL(sizeof(float) * 4 * slocopt.sizex));

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -2232,8 +2232,8 @@ static int process_wavelets_cl(dt_iop_module_t *self,
   if(npixels < 2)
   {
     // copy original input from dev_in -> dev_out
-    size_t origin[] = { 0, 0, 0 };
-    size_t region[] = { width, height, 1 };
+    size_t origin[] = { 0, 0 };
+    size_t region[] = { width, height };
     err = dt_opencl_enqueue_copy_image(devid, dev_in, dev_out, origin, origin, region);
     if(err != CL_SUCCESS) goto error;
     free(dev_detail);
@@ -2527,8 +2527,8 @@ static int process_wavelets_cl(dt_iop_module_t *self,
   // account, so current output lies in dev_buf1
   if(dev_buf1 != dev_tmp)
   {
-    size_t origin[] = { 0, 0, 0 };
-    size_t region[] = { width, height, 1 };
+    size_t origin[] = { 0, 0 };
+    size_t region[] = { width, height };
     err = dt_opencl_enqueue_copy_image(devid, dev_buf1, dev_tmp, origin, origin, region);
     if(err != CL_SUCCESS) goto error;
   }

--- a/src/iop/diffuse.c
+++ b/src/iop/diffuse.c
@@ -1620,14 +1620,14 @@ int process_cl(dt_iop_module_t *self,
   const int width = roi_in->width;
   const int height = roi_in->height;
 
-  size_t origin[] = { 0, 0, 0 };
-  size_t region[] = { width, height, 1 };
+  size_t origin[] = { 0, 0 };
+  size_t region[] = { width, height };
 
   // allow fast mode, just copy input to output
   if(fastmode)
     return dt_opencl_enqueue_copy_image(devid, dev_in, dev_out, origin, origin, region);
 
-  size_t sizes[3] = { ROUNDUPDWD(width, devid), ROUNDUPDHT(height, devid), 1 };
+  size_t sizes[2] = { ROUNDUPDWD(width, devid), ROUNDUPDHT(height, devid) };
 
   cl_mem in = dev_in;
   cl_mem temp_in = NULL;

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -2231,7 +2231,7 @@ static inline cl_int reconstruct_highlights_cl(const cl_mem in, const cl_mem mas
   const int devid = piece->pipe->devid;
   const int width = roi_in->width;
   const int height = roi_in->height;
-  size_t sizes[] = { ROUNDUPDWD(width, devid), ROUNDUPDHT(height, devid), 1 };
+  size_t sizes[] = { ROUNDUPDWD(width, devid), ROUNDUPDHT(height, devid) };
 
   // wavelets scales
   const int scales = get_scales(roi_in, piece);
@@ -2317,7 +2317,7 @@ static inline cl_int reconstruct_highlights_cl(const cl_mem in, const cl_mem mas
     if(err != CL_SUCCESS) goto error;
 
     // Take a backup copy of HF_RGB in HF_grey - only HF_RGB will be blurred
-    size_t origin[] = { 0, 0, 0 };
+    size_t origin[] = { 0, 0 };
     err = dt_opencl_enqueue_copy_image(devid, HF_RGB, HF_grey, origin, origin, sizes);
     if(err != CL_SUCCESS) goto error;
 

--- a/src/iop/globaltonemap.c
+++ b/src/iop/globaltonemap.c
@@ -401,8 +401,8 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
 
       const int reducesize = MIN(REDUCESIZE, ROUNDUP(bufsize, slocopt.sizex) / slocopt.sizex);
 
-      size_t sizes[3];
-      size_t local[3];
+      size_t sizes[2];
+      size_t local[2];
 
       dev_m = dt_opencl_alloc_device_buffer(devid, sizeof(float) * bufsize);
       if(dev_m == NULL) goto finally;
@@ -414,7 +414,6 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
       sizes[1] = bheight;
       local[0] = flocopt.sizex;
       local[1] = flocopt.sizey;
-      local[2] = 1;
       err = dt_opencl_enqueue_kernel_2d_local_args(devid, gd->kernel_pixelmax_first, sizes, local,
         CLARG(dev_in), CLARG(width), CLARG(height),
         CLARG(dev_m), CLLOCAL(sizeof(float) * flocopt.sizex * flocopt.sizey));
@@ -424,7 +423,6 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
       sizes[1] = 1;
       local[0] = slocopt.sizex;
       local[1] = 1;
-      local[2] = 1;
       err = dt_opencl_enqueue_kernel_2d_local_args(devid, gd->kernel_pixelmax_second, sizes, local,
         CLARG(dev_m), CLARG(dev_r), CLARG(bufsize),
         CLLOCAL(sizeof(float) * slocopt.sizex));

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -632,8 +632,8 @@ int process_cl(dt_iop_module_t *self,
     dev_xtrans = dt_opencl_copy_host_to_device_constant(devid, sizeof(piece->xtrans), piece->xtrans);
     if(dev_xtrans == NULL) goto finish;
 
-    size_t sizes[] = { ROUNDUP(roi_in->width, blocksizex), ROUNDUP(roi_in->height, blocksizey), 1 };
-    size_t local[] = { blocksizex, blocksizey, 1 };
+    size_t sizes[2] = { ROUNDUP(roi_in->width, blocksizex), ROUNDUP(roi_in->height, blocksizey) };
+    size_t local[2] = { blocksizex, blocksizey };
     err = dt_opencl_enqueue_kernel_2d_local_args(devid, gd->kernel_highlights_1f_lch_xtrans, sizes, local,
       CLARG(dev_in), CLARG(dev_out),
       CLARG(roi_in->width), CLARG(roi_in->height),

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -544,9 +544,9 @@ int process_cl(dt_iop_module_t *self,
       return dt_iop_clip_and_zoom_roi_cl(devid, dev_out, dev_in, roi_out, roi_in);
     else
     {
-      size_t iorigin[] = { roi_out->x, roi_out->y, 0 };
-      size_t oorigin[] = { 0, 0, 0 };
-      size_t region[] = { roi_out->width, roi_out->height, 1 };
+      size_t iorigin[] = { roi_out->x, roi_out->y };
+      size_t oorigin[] = { 0, 0 };
+      size_t region[] = { roi_out->width, roi_out->height };
       return dt_opencl_enqueue_copy_image(devid, dev_in, dev_out, iorigin, oorigin, region);
     }
   }

--- a/src/iop/highpass.c
+++ b/src/iop/highpass.c
@@ -180,8 +180,8 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
   const size_t bwidth = ROUNDUP(width, hblocksize);
   const size_t bheight = ROUNDUP(height, vblocksize);
 
-  size_t sizes[3];
-  size_t local[3];
+  size_t sizes[2];
+  size_t local[2];
 
   dev_tmp = dt_opencl_alloc_device(devid, width, height, sizeof(float) * 4);
   if(dev_tmp == NULL) goto error;
@@ -202,7 +202,6 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
     sizes[1] = ROUNDUPDHT(height, devid);
     local[0] = hblocksize;
     local[1] = 1;
-    local[2] = 1;
     err = dt_opencl_enqueue_kernel_2d_local_args(devid, gd->kernel_highpass_hblur, sizes, local,
       CLARG(dev_tmp), CLARG(dev_out),
       CLARG(dev_m), CLARG(wdh), CLARG(width), CLARG(height), CLARG(hblocksize), CLLOCAL((hblocksize + 2 * wdh) * sizeof(float)));
@@ -213,7 +212,6 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
     sizes[1] = bheight;
     local[0] = 1;
     local[1] = vblocksize;
-    local[2] = 1;
     err = dt_opencl_enqueue_kernel_2d_local_args(devid, gd->kernel_highpass_vblur, sizes, local,
       CLARG(dev_out), CLARG(dev_tmp),
       CLARG(dev_m), CLARG(wdh), CLARG(width), CLARG(height), CLARG(vblocksize), CLLOCAL((vblocksize + 2 * wdh) * sizeof(float)));

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -1324,9 +1324,9 @@ static int _process_cl_lf(dt_iop_module_t *self,
   const float orig_w = roi_in->scale * piece->buf_in.width;
   const float orig_h = roi_in->scale * piece->buf_in.height;
 
-  size_t origin[] = { 0, 0, 0 };
-  size_t iregion[] = { (size_t)iwidth, (size_t)iheight, 1 };
-  size_t oregion[] = { (size_t)owidth, (size_t)oheight, 1 };
+  size_t origin[] = { 0, 0 };
+  size_t iregion[] = { (size_t)iwidth, (size_t)iheight };
+  size_t oregion[] = { (size_t)owidth, (size_t)oheight };
 
   int modflags;
   int ldkernel = -1;
@@ -2834,8 +2834,8 @@ static int _process_cl_md(dt_iop_module_t *self,
 
   if(!d->nc || d->modify_flags == DT_IOP_LENS_MODFLAG_NONE)
   {
-    size_t origin[] = { 0, 0, 0 };
-    size_t oregion[] = { (size_t)roi_out->width, (size_t)roi_out->height, 1 };
+    size_t origin[] = { 0, 0 };
+    size_t oregion[] = { (size_t)roi_out->width, (size_t)roi_out->height };
     return dt_opencl_enqueue_copy_image(devid, dev_in, dev_out,
                                         origin, origin, oregion);
   }
@@ -3126,8 +3126,8 @@ int process_cl(dt_iop_module_t *self,
   }
   else
   {
-    size_t origin[] = { 0, 0, 0 };
-    size_t region[] = { (size_t)roi_in->width, (size_t)roi_in->height, 1 };
+    size_t origin[] = { 0, 0 };
+    size_t region[] = { (size_t)roi_in->width, (size_t)roi_in->height };
     err = dt_opencl_enqueue_copy_image(piece->pipe->devid, data,
                                        dev_out, origin, origin, region);
   }

--- a/src/iop/liquify.c
+++ b/src/iop/liquify.c
@@ -1557,9 +1557,9 @@ int process_cl(dt_iop_module_t *self,
 
   // 1. copy the whole image (we'll change only a small part of it)
   {
-    size_t src[]    = { roi_out->x - roi_in->x, roi_out->y - roi_in->y, 0 };
-    size_t dest[]   = { 0, 0, 0 };
-    size_t extent[] = { width, height, 1 };
+    size_t src[]    = { roi_out->x - roi_in->x, roi_out->y - roi_in->y };
+    size_t dest[]   = { 0, 0 };
+    size_t extent[] = { width, height };
     err = dt_opencl_enqueue_copy_image(devid, dev_in, dev_out, src, dest, extent);
     if(err != CL_SUCCESS) return err;
   }

--- a/src/iop/mask_manager.c
+++ b/src/iop/mask_manager.c
@@ -100,8 +100,8 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   const int width = roi_in->width;
   const int height = roi_in->height;
 
-  size_t origin[] = { 0, 0, 0 };
-  size_t region[] = { width, height, 1 };
+  size_t origin[] = { 0, 0 };
+  size_t region[] = { width, height };
   return dt_opencl_enqueue_copy_image(devid, dev_in, dev_out, origin, origin, region);
 }
 #endif

--- a/src/iop/nlmeans.c
+++ b/src/iop/nlmeans.c
@@ -264,8 +264,8 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
   else
     vblocksize = 1;
 
-  size_t sizesl[3];
-  size_t local[3];
+  size_t sizesl[2];
+  size_t local[2];
 
   err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_nlmeans_init, width, height,
           CLARG(dev_U2), CLARG(width), CLARG(height));
@@ -288,10 +288,8 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
 
       sizesl[0] = bwidth;
       sizesl[1] = ROUNDUPDHT(height, devid);
-      sizesl[2] = 1;
       local[0] = hblocksize;
       local[1] = 1;
-      local[2] = 1;
       cl_mem dev_U4_t = buckets[bucket_next(&state, NUM_BUCKETS)];
       err = dt_opencl_enqueue_kernel_2d_local_args(devid, gd->kernel_nlmeans_horiz, sizesl, local,
         CLARG(dev_U4), CLARG(dev_U4_t), CLARG(width),
@@ -301,10 +299,8 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
 
       sizesl[0] = ROUNDUPDWD(width, devid);
       sizesl[1] = bheight;
-      sizesl[2] = 1;
       local[0] = 1;
       local[1] = vblocksize;
-      local[2] = 1;
       cl_mem dev_U4_tt = buckets[bucket_next(&state, NUM_BUCKETS)];
       err = dt_opencl_enqueue_kernel_2d_local_args(devid, gd->kernel_nlmeans_vert, sizesl, local,
         CLARG(dev_U4_t), CLARG(dev_U4_tt),

--- a/src/iop/rasterfile.c
+++ b/src/iop/rasterfile.c
@@ -510,9 +510,9 @@ int process_cl(dt_iop_module_t *self,
     err = dt_iop_clip_and_zoom_cl(devid, dev_out, dev_in, roi_out, roi_in);
   else
   {
-    size_t iorigin[] = { roi_out->x, roi_out->y, 0 };
-    size_t oorigin[] = { 0, 0, 0 };
-    size_t region[] = { roi_out->width, roi_out->height, 1 };
+    size_t iorigin[] = { roi_out->x, roi_out->y };
+    size_t oorigin[] = { 0, 0 };
+    size_t region[] = { roi_out->width, roi_out->height };
     err = dt_opencl_enqueue_copy_image(devid, dev_in, dev_out, iorigin, oorigin, region);
   }
 

--- a/src/iop/rawoverexposed.c
+++ b/src/iop/rawoverexposed.c
@@ -251,8 +251,8 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
   const int width = roi_out->width;
   const int height = roi_out->height;
 
-  size_t origin[] = { 0, 0, 0 };
-  size_t region[] = { width, height, 1 };
+  size_t origin[] = { 0, 0 };
+  size_t region[] = { width, height };
 
   process_common_setup(self, piece);
 

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -4600,8 +4600,8 @@ int process_cl(dt_iop_module_t *self,
 
   // copy input image to the new buffer
   {
-    size_t origin[] = { 0, 0, 0 };
-    size_t region[] = { roi_rt->width, roi_rt->height, 1 };
+    size_t origin[] = { 0, 0 };
+    size_t region[] = { roi_rt->width, roi_rt->height };
     err = dt_opencl_enqueue_copy_image_to_buffer(devid, dev_in, in_retouch, origin, region, 0);
     if(err != CL_SUCCESS) goto cleanup;
   }

--- a/src/iop/sharpen.c
+++ b/src/iop/sharpen.c
@@ -141,8 +141,8 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
 
   if(rad == 0)
   {
-    size_t origin[] = { 0, 0, 0 };
-    size_t region[] = { width, height, 1 };
+    size_t origin[] = { 0, 0 };
+    size_t region[] = { width, height };
     err = dt_opencl_enqueue_copy_image(devid, dev_in, dev_out, origin, origin, region);
     if(err != CL_SUCCESS) goto error;
     return CL_SUCCESS;
@@ -152,8 +152,8 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
   // normally not needed for OpenCL but implemented here for identity with CPU code path
   if(width < 2 * rad + 1 || height < 2 * rad + 1)
   {
-    size_t origin[] = { 0, 0, 0 };
-    size_t region[] = { width, height, 1 };
+    size_t origin[] = { 0, 0 };
+    size_t region[] = { width, height };
     err = dt_opencl_enqueue_copy_image(devid, dev_in, dev_out, origin, origin, region);
     if(err != CL_SUCCESS) goto error;
     return CL_SUCCESS;

--- a/src/iop/sharpen.c
+++ b/src/iop/sharpen.c
@@ -191,8 +191,8 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
   const size_t bwidth = ROUNDUP(width, hblocksize);
   const size_t bheight = ROUNDUP(height, vblocksize);
 
-  size_t sizes[3];
-  size_t local[3];
+  size_t sizes[2];
+  size_t local[2];
 
   dev_tmp = dt_opencl_alloc_device(devid, width, height, sizeof(float) * 4);
   if(dev_tmp == NULL) goto error;
@@ -205,7 +205,6 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
   sizes[1] = ROUNDUPDHT(height, devid);
   local[0] = hblocksize;
   local[1] = 1;
-  local[2] = 1;
   err = dt_opencl_enqueue_kernel_2d_local_args(devid, gd->kernel_sharpen_hblur, sizes, local,
     CLARG(dev_in), CLARG(dev_out), CLARG(dev_m),
     CLARG(rad), CLARG(width), CLARG(height), CLARG(hblocksize), CLLOCAL((hblocksize + 2 * rad) * sizeof(float)));
@@ -216,7 +215,6 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
   sizes[1] = bheight;
   local[0] = 1;
   local[1] = vblocksize;
-  local[2] = 1;
   err = dt_opencl_enqueue_kernel_2d_local_args(devid, gd->kernel_sharpen_vblur, sizes, local,
     CLARG(dev_out), CLARG(dev_tmp), CLARG(dev_m),
     CLARG(rad), CLARG(width), CLARG(height), CLARG(vblocksize), CLLOCAL((vblocksize + 2 * rad) * sizeof(float)));

--- a/src/iop/soften.c
+++ b/src/iop/soften.c
@@ -233,8 +233,8 @@ int process_cl(dt_iop_module_t *self,
   const size_t bwidth = ROUNDUP(width, hblocksize);
   const size_t bheight = ROUNDUP(height, vblocksize);
 
-  size_t sizes[3];
-  size_t local[3];
+  size_t sizes[2];
+  size_t local[2];
 
   cl_int err = DT_OPENCL_SYSMEM_ALLOCATION;
   dev_tmp = dt_opencl_alloc_device(devid, width, height, sizeof(float) * 4);
@@ -253,10 +253,8 @@ int process_cl(dt_iop_module_t *self,
     /* horizontal blur */
     sizes[0] = bwidth;
     sizes[1] = ROUNDUPDHT(height, devid);
-    sizes[2] = 1;
     local[0] = hblocksize;
     local[1] = 1;
-    local[2] = 1;
     err = dt_opencl_enqueue_kernel_2d_local_args(devid, gd->kernel_soften_hblur, sizes, local,
                               CLARG(dev_tmp), CLARG(dev_out), CLARG(dev_m),
                               CLARG(wdh), CLARG(width), CLARG(height), CLARG(hblocksize),
@@ -267,10 +265,8 @@ int process_cl(dt_iop_module_t *self,
     /* vertical blur */
     sizes[0] = ROUNDUPDWD(width, devid);
     sizes[1] = bheight;
-    sizes[2] = 1;
     local[0] = 1;
     local[1] = vblocksize;
-    local[2] = 1;
     err = dt_opencl_enqueue_kernel_2d_local_args(devid, gd->kernel_soften_vblur, sizes, local,
       CLARG(dev_out), CLARG(dev_tmp), CLARG(dev_m),
       CLARG(wdh), CLARG(width), CLARG(height), CLARG(vblocksize), CLLOCAL((vblocksize + 2 * wdh) * 4 * sizeof(float)));

--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -1131,7 +1131,7 @@ void toneeq_process(dt_iop_module_t *self,
         compute_luminance_mask(in, luminance, width, height, d);
         g->luminance_valid = TRUE;
         dt_iop_gui_leave_critical_section(self);
-        dt_dev_pixelpipe_cache_invalidate_later(piece->pipe, self->iop_order);
+        dt_dev_pixelpipe_cache_invalidate_later(piece->pipe, self->iop_order, "toneequal: ");
       }
     }
     else // make it dummy-proof

--- a/src/iop/velvia.c
+++ b/src/iop/velvia.c
@@ -216,8 +216,8 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
 
   if(strength <= 0.0f)
   {
-    size_t origin[] = { 0, 0, 0 };
-    size_t region[] = { width, height, 1 };
+    size_t origin[] = { 0, 0 };
+    size_t region[] = { width, height };
     err = dt_opencl_enqueue_copy_image(devid, dev_in, dev_out, origin, origin, region);
   }
   else

--- a/src/libs/history.c
+++ b/src/libs/history.c
@@ -1312,7 +1312,7 @@ static gboolean _lib_history_button_clicked_callback(GtkWidget *widget,
     For raws we have at least rawprepare and demosaic
   */
   const int order = dt_image_is_raw(&darktable.develop->image_storage) ? 2 : 0;
-  dt_dev_pixelpipe_cache_invalidate_later(darktable.develop->preview_pipe, order);
+  dt_dev_pixelpipe_cache_invalidate_later(darktable.develop->preview_pipe, order, "history button: ");
 
   /* signal history changed */
   dt_dev_undo_end_record(darktable.develop);


### PR DESCRIPTION
Two noteworthy commits
1. The demosaicing of bayer4 images was lately broken so a bugfix via dd787a32101c06aa71789f64b5b9941525857336
2. Added some log info about *why* cachelines are invalidated for further investigation of possible perf gains via ad8e93e39ae5db350a09b25c23ddfc94443b12c9

The other stuff is OpenCL maintenance/cleanup with some minor perf gains when using the fast compiler mode.

Tested integration suite, no regressions. (BTW there is no test for bayer4 images but that's certainly a cornercase)