### PR TITLE
Add protection against NULL dereference crash in thumbtable.c

### DIFF
--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -1603,7 +1603,8 @@ static gboolean _event_button_release(GtkWidget *widget,
       else
       {
         if(table->mode != DT_THUMBTABLE_MODE_ZOOM
-           || !table->drag_thumb->moved)
+           ||
+           (table->drag_thumb && !table->drag_thumb->moved))
         {
           dt_selection_select_single(darktable.selection, id);
           DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_VIEWMANAGER_THUMBTABLE_ACTIVATE, id);


### PR DESCRIPTION
A crash due to this NULL dereference was actually observed and reported in issue #20354. This does not fix the bug reported in the issue, but it protects against the crash also mentioned in that issue.

P.S. Chaining pointer dereferences without checks is evil. Absolute evil.
