### PR TITLE
Rename mask resampling

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -693,7 +693,7 @@ void dt_dump_pipe_diff_pfm(
     const size_t o1 = k + border;
     const size_t o2 = k + pk;
     /* we show a shaded image as background but mark NAN and inf locations */
-    const float shade = good ? 0.05f * sqrtf(CLIP(scale * fmaxf(0.0f, b[k]))) : 0.0f;
+    const float shade = good ? 0.02f * sqrtf(CLIP(scale * fmaxf(0.0f, b[k]))) : 0.0f;
     o[o1] = o[o2] = shade;
     o[o2 + pk-border] = good ? shade : 1.0f;
     /* diffs and ratios are only shown if signal is good */
@@ -706,9 +706,9 @@ void dt_dump_pipe_diff_pfm(
                           ? ((cval > gval ? cval / gval : gval / cval) - 1.0f)
                           : 0.0f;
       if(diff > 1e-7)
-        o[o1] = 0.3f + CLIP(100.0f * sqrtf(diff));
-      if(quot > 1e-3)
-        o[o2] = 0.3f + CLIP(10.0f * quot);
+        o[o1] = 0.2f + CLIP(100.0f * sqrtf(diff));
+      if(quot > 1e-5)
+        o[o2] = 0.2f + CLIP(10.0f * sqrtf(quot));
     }
     else
       invalids += 1;

--- a/src/common/interpolation.c
+++ b/src/common/interpolation.c
@@ -1437,7 +1437,7 @@ int dt_interpolation_resample_roi_cl(const dt_interpolation_t *itor,
 /** Applies resampling (re-scaling) on *full* input and output buffers.
  *  roi_in and roi_out define the part of the buffers that is affected.
  */
-void dt_interpolation_resample_1c(const dt_interpolation_t *itor,
+void dt_interpolation_resample_mask(const dt_interpolation_t *itor,
                                   float *out,
                                   const dt_iop_roi_t *const roi_out,
                                   const float *const in,
@@ -1464,7 +1464,7 @@ void dt_interpolation_resample_1c(const dt_interpolation_t *itor,
   const gboolean copymode = roi_out->scale == 1.0f;
 
   dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_VERBOSE,
-                copymode ? "resample 1:1" : "resample",
+                copymode ? "resample mask 1:1" : "resample mask",
                 NULL, NULL, DT_DEVICE_CPU, roi_in, roi_out, "%s",
                 !copymode ? itor->name : (wd_fit && ht_fit) ? "inside" : "expanded");
 
@@ -1487,7 +1487,7 @@ void dt_interpolation_resample_1c(const dt_interpolation_t *itor,
       else
         memset(o, 0, out_stride);
     }
-    dt_show_times_f(&start, "[resample_1c_plain]", "1:1 copy/crop of %dx%d pixels",
+    dt_show_times_f(&start, "[resample_mask]", "1:1 copy/crop of %dx%d pixels",
                     roi_in->width, roi_in->height);
     // All done, so easy case
     return;
@@ -1565,7 +1565,7 @@ void dt_interpolation_resample_1c(const dt_interpolation_t *itor,
       // Output pixel is ready
       float *o = (float *)((char *)out + (size_t)oy * out_stride
                            + (size_t)ox * sizeof(float));
-      *o = fmaxf(0.0f, vs);
+      *o = CLIP(vs);  // masks never want under/overshoots from resampling
 
       // Reset vertical resampling context
       viidx -= vl;
@@ -1580,21 +1580,21 @@ void dt_interpolation_resample_1c(const dt_interpolation_t *itor,
   exit:
   if(error)
     dt_print_pipe(DT_DEBUG_ALWAYS,
-      "resample 1c failed", NULL, NULL, DT_DEVICE_CPU, roi_in, roi_out);
+      "resample mask failed", NULL, NULL, DT_DEVICE_CPU, roi_in, roi_out);
 
   /* Free the resampling plans. It's nasty to optimize allocs like that, but
    * it simplifies the code :-D. The length array is in fact the only memory
    * allocated. */
   dt_free_align(hlength);
   dt_free_align(vlength);
-  _show_2_times(&start, &mid, "resample_1c_plain");
+  _show_2_times(&start, &mid, "resample_mask_plain");
 }
 
 /** Applies resampling (re-scaling) on a specific region-of-interest of an image. The input
  *  and output buffers hold exactly those roi's. roi_in and roi_out define the relative
  *  positions of the roi's within the full input and output image, respectively.
  */
-void dt_interpolation_resample_roi_1c(const dt_interpolation_t *itor,
+void dt_interpolation_resample_roi_mask(const dt_interpolation_t *itor,
                                       float *out,
                                       const dt_iop_roi_t *const roi_out,
                                       const float *const in,
@@ -1606,7 +1606,7 @@ void dt_interpolation_resample_roi_1c(const dt_interpolation_t *itor,
   dt_iop_roi_t iroi = *roi_in;
   iroi.x = iroi.y = 0;
 
-  dt_interpolation_resample_1c(itor, out, &oroi, in, &iroi);
+  dt_interpolation_resample_mask(itor, out, &oroi, in, &iroi);
 }
 
 // clang-format off

--- a/src/common/interpolation.h
+++ b/src/common/interpolation.h
@@ -179,11 +179,11 @@ int dt_interpolation_resample_roi_cl(const dt_interpolation_t *itor, int devid, 
                                      const dt_iop_roi_t *const roi_in);
 #endif
 
-void dt_interpolation_resample_1c(const dt_interpolation_t *itor,
+void dt_interpolation_resample_mask(const dt_interpolation_t *itor,
                                   float *out, const dt_iop_roi_t *const roi_out,
                                   const float *const in, const dt_iop_roi_t *const roi_in);
 
-void dt_interpolation_resample_roi_1c(const dt_interpolation_t *itor,
+void dt_interpolation_resample_roi_mask(const dt_interpolation_t *itor,
                                       float *out, const dt_iop_roi_t *const roi_out,
                                       const float *const in, const dt_iop_roi_t *const roi_in);
 

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -489,7 +489,7 @@ void distort_mask(dt_iop_module_t *self,
   if(roi_out->scale != roi_in->scale)
   {
     const dt_interpolation_t *itor = dt_interpolation_new(DT_INTERPOLATION_USERPREF_WARP);
-    dt_interpolation_resample_roi_1c(itor, out, roi_out, in, roi_in);
+    dt_interpolation_resample_roi_mask(itor, out, roi_out, in, roi_in);
   }
   else
     dt_iop_copy_image_roi(out, in, 1, roi_in, roi_out);

--- a/src/iop/finalscale.c
+++ b/src/iop/finalscale.c
@@ -140,7 +140,7 @@ void distort_mask(dt_iop_module_t *self,
                   const dt_iop_roi_t *const roi_out)
 {
   const dt_interpolation_t *itor = dt_interpolation_new(DT_INTERPOLATION_USERPREF);
-  dt_interpolation_resample_1c(itor, out, roi_out, in, roi_in);
+  dt_interpolation_resample_mask(itor, out, roi_out, in, roi_in);
 }
 
 #ifdef HAVE_OPENCL

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -333,7 +333,7 @@ void distort_mask(dt_iop_module_t *self,
   if(roi_out->scale != roi_in->scale)
   {
     const dt_interpolation_t *itor = dt_interpolation_new(DT_INTERPOLATION_USERPREF_WARP);
-    dt_interpolation_resample_roi_1c(itor, out, roi_out, in, roi_in);
+    dt_interpolation_resample_roi_mask(itor, out, roi_out, in, roi_in);
   }
   else
     dt_iop_copy_image_roi(out, in, 1, roi_in, roi_out);

--- a/src/iop/rasterfile.c
+++ b/src/iop/rasterfile.c
@@ -644,7 +644,7 @@ void distort_mask(dt_iop_module_t *self,
   if(roi_out->scale != roi_in->scale)
   {
     const dt_interpolation_t *itor = dt_interpolation_new(DT_INTERPOLATION_USERPREF_WARP);
-    dt_interpolation_resample_1c(itor, out, roi_out, in, roi_in);
+    dt_interpolation_resample_mask(itor, out, roi_out, in, roi_in);
   }
   else
     dt_iop_copy_image_roi(out, in, 1, roi_in, roi_out);


### PR DESCRIPTION
Make used function more clear by renaming, also make sure distorted masks never under/overshoot due to resampling.