### PR TITLE
Welcome screen: add theme selection step with translatable combobox labels

### DIFF
--- a/data/darktableconfig.dtd
+++ b/data/darktableconfig.dtd
@@ -42,4 +42,5 @@
         pagenum CDATA #IMPLIED
         questionnum CDATA #IMPLIED
         dirchooser (yes|no) #IMPLIED
+        options CDATA #IMPLIED
 >

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -3681,6 +3681,8 @@
     <type>string</type>
     <default>darktable-elegant-grey</default>
     <shortdescription>darktable theme</shortdescription>
+    <longdescription><![CDATA[the shade around your photo affects how you see its colors and tones while editing. grey is recommended because it's the most neutral – it doesn't push your eye in any direction\n\n<b>grey:</b> best for accurate color work\n\n<b>dark:</b> less distracting around your image\n\n<b>darker:</b> good for dimly-lit rooms]]></longdescription>
+    <welcomescreen pagenum="6" questionnum="1" options="darktable-elegant-grey|grey,darktable-elegant-dark|dark,darktable-elegant-darker|darker"/>
   </dtconfig>
   <dtconfig prefs="misc" section="interface">
     <name>ui_last/display_profile_source</name>

--- a/src/control/conf.c
+++ b/src/control/conf.c
@@ -953,6 +953,12 @@ gboolean dt_confgen_get_welcome_dirchooser(const char *name)
   return item ? item->welcome_dirchooser : FALSE;
 }
 
+const char *const *dt_confgen_get_welcome_options(const char *name)
+{
+  const dt_confgen_value_t *item = g_hash_table_lookup(darktable.conf->x_confgen, name);
+  return item ? (const char *const *)item->welcome_options : NULL;
+}
+
 static gint _welcome_key_compare(gconstpointer a, gconstpointer b)
 {
   const dt_confgen_value_t *ea =

--- a/src/control/conf.h
+++ b/src/control/conf.h
@@ -50,6 +50,7 @@ typedef struct dt_confgen_value_t
   int    welcome_pagenum;      // 0 = not on welcome screen; >0 = page number
   int    welcome_questionnum;  // sort order within page
   gboolean welcome_dirchooser; // TRUE to use a directory chooser widget
+  char **welcome_options;      // curated option list 
 } dt_confgen_value_t;
 
 typedef struct dt_conf_t
@@ -146,6 +147,10 @@ const char *dt_confgen_get_tooltip(const char *name);
 // welcome-screen metadata
 int         dt_confgen_get_welcome_pagenum(const char *name);
 gboolean    dt_confgen_get_welcome_dirchooser(const char *name);
+// NULL-terminated array of curated options for the welcome-screen combobox,
+// or NULL when the key has no welcome options. Owned by the confgen entry —
+// do not free
+const char *const *dt_confgen_get_welcome_options(const char *name);
 // Returns a newly-allocated GList of g_strdup'd conf keys with welcome_pagenum > 0,
 // sorted by (pagenum, questionnum).
 GList      *dt_confgen_get_welcome_keys(void);

--- a/src/gui/welcome.c
+++ b/src/gui/welcome.c
@@ -67,7 +67,12 @@ typedef struct
   // DIRCHOOSER and COMBOBOX:
   char *conf_key;
   // COMBOBOX only:
-  char **options; // array of option strings (conf values = display text)
+  char **options;        // array of option ids (written to conf)
+  char **option_labels;  // parallel array of display labels (NULL entry
+                         // when an option has no "id|label" form; in that
+                         // case the id itself is used as the display text).
+                         // labels are looked up via g_dpgettext2 at display
+                         // time so translators can localize them
   int n_options;
 } _dt_question_t;
 
@@ -89,8 +94,12 @@ static void _free_question(gpointer p)
     if(q->qtype == DT_QUESTION_COMBOBOX)
     {
       for(int i = 0; i < q->n_options; i++)
+      {
         g_free(q->options[i]);
+        if(q->option_labels) g_free(q->option_labels[i]);
+      }
       g_free(q->options);
+      g_free(q->option_labels);
     }
   }
   else if(q->qtype == DT_QUESTION_CHECKBOX && q->action.type != DT_WELCOME_ACTION_NONE)
@@ -188,7 +197,16 @@ static void _on_combo_changed(GtkComboBox *combo, gpointer data)
   const _dt_question_t *q = data;
   const int idx = gtk_combo_box_get_active(combo);
   if(idx >= 0 && idx < q->n_options)
+  {
     dt_conf_set_string(q->conf_key, q->options[idx]);
+    // theme applies live so the user can preview grey/dark/darker
+    // and judge which surround they prefer before moving on
+    if(!g_strcmp0(q->conf_key, "ui_last/theme"))
+    {
+      dt_gui_load_theme(q->options[idx]);
+      dt_gui_apply_theme();
+    }
+  }
 }
 
 // ── navigation state ──────────────────────────────────────────────────────────
@@ -367,7 +385,15 @@ static GtkWidget *_build_page_widget(_dt_page_t *pg)
       const char *curval = dt_conf_get_string_const(q->conf_key);
       for(int oi = 0; oi < q->n_options; oi++)
       {
-        gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(combo), g_dpgettext2(NULL, "preferences", q->options[oi]));
+        // display label = the portion after '|' (translated via the
+        // "preferences" gettext context); fall back to the id when the
+        // entry has no label. conf value is always the id side
+        const char *display
+          = (q->option_labels && q->option_labels[oi])
+              ? q->option_labels[oi]
+              : q->options[oi];
+        gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(combo),
+                                       g_dpgettext2(NULL, "preferences", display));
         if(g_strcmp0(curval, q->options[oi]) == 0)
           gtk_combo_box_set_active(GTK_COMBO_BOX(combo), oi);
       }
@@ -514,8 +540,24 @@ static void _page_add_combobox(dt_welcome_screen_t *ws,
   q->conf_key = g_strdup(conf_key);
   q->n_options = n_options;
   q->options = g_new(char *, n_options);
+  q->option_labels = g_new(char *, n_options);
   for(int i = 0; i < n_options; i++)
-    q->options[i] = g_strdup(options[i]);
+  {
+    // split on '|': before is the id (conf value), after is the label
+    // (translatable display text). entries without '|' store NULL label
+    // and fall back to showing the id
+    const char *sep = strchr(options[i], '|');
+    if(sep)
+    {
+      q->options[i] = g_strndup(options[i], sep - options[i]);
+      q->option_labels[i] = g_strdup(sep + 1);
+    }
+    else
+    {
+      q->options[i] = g_strdup(options[i]);
+      q->option_labels[i] = NULL;
+    }
+  }
   g_ptr_array_add(pg->questions, q);
 }
 
@@ -571,6 +613,21 @@ void dt_welcome_screen_page_add_conf(dt_welcome_screen_t *ws,
   case DT_PATH:
     dt_welcome_screen_page_add_dirchooser(ws, page_idx, label, description, conf_key);
     break;
+  case DT_STRING:
+  {
+    // string-type keys can advertise a curated option list to the welcome
+    // screen via <welcomescreen options="a,b,c"/> without needing an <enum>
+    const char *const *opts = dt_confgen_get_welcome_options(conf_key);
+    int n = 0;
+    if(opts)
+      while(opts[n]) n++;
+    if(n > 0)
+      _page_add_combobox(ws, page_idx, label, description, conf_key, opts, n);
+    else
+      dt_print(DT_DEBUG_ALWAYS,
+               "[welcome] string conf key '%s' has no welcome options\n", conf_key);
+    break;
+  }
   default:
     dt_print(DT_DEBUG_ALWAYS,
              "[welcome] conf key '%s' has unsupported type for welcome screen\n", conf_key);

--- a/tools/generate_darktablerc_conf.xsl
+++ b/tools/generate_darktablerc_conf.xsl
@@ -33,6 +33,7 @@ typedef struct {
    const char *welcome_pagenum;      // "" or page number string for the welcome screen
    const char *welcome_questionnum;  // sort order within the welcome page
    const char *welcome_dirchooser;   // "yes" if a directory chooser should be used
+   const char *welcome_options;      // comma-separated curated option list for string-type keys
 } _default_config_t;
 
 static void _clear_confgen_value(void *value)
@@ -52,6 +53,8 @@ static void _clear_confgen_value(void *value)
   s->welcome_pagenum = 0;
   s->welcome_questionnum = 0;
   s->welcome_dirchooser = FALSE;
+  g_strfreev(s->welcome_options);
+  s->welcome_options = NULL;
 }
 
 static void _free_confgen_value(void *value)
@@ -96,9 +99,15 @@ static _default_config_t _config_variables[] =
     <xsl:choose>
       <xsl:when test="welcomescreen">
         <xsl:apply-templates select="welcomescreen" mode="welcome"/>
+        <xsl:text>&#xA;</xsl:text>
+        <!-- emit translation strings for each welcomescreen option label
+             (the portion after '|' in "id|label" pairs). WRAP_TRANSLATION
+             expands to nothing at compile but is picked up by xgettext,
+             matching how <enum> options get into the .pot catalog. -->
+        <xsl:apply-templates select="welcomescreen" mode="options_i18n"/>
       </xsl:when>
       <xsl:otherwise>
-        <xsl:text>"", "", ""</xsl:text>
+        <xsl:text>"", "", "", ""</xsl:text>
       </xsl:otherwise>
     </xsl:choose>
     <xsl:text>&#xA;  },&#xA;</xsl:text>
@@ -141,6 +150,9 @@ void dt_confgen_init()
      item->welcome_pagenum     = var->welcome_pagenum ? atoi(var->welcome_pagenum) : 0;
      item->welcome_questionnum = var->welcome_questionnum ? atoi(var->welcome_questionnum) : 0;
      item->welcome_dirchooser = g_strcmp0(var->welcome_dirchooser, "yes") == 0;
+     item->welcome_options = (var->welcome_options && *var->welcome_options)
+                             ? g_strsplit(var->welcome_options, ",", -1)
+                             : NULL;
      item->is_common = *var->is_common == 'y';
    }
 }
@@ -230,7 +242,49 @@ void dt_confgen_init()
 <xsl:template match="welcomescreen" mode="welcome">
   <xsl:text>"</xsl:text><xsl:value-of select="@pagenum"/><xsl:text>", "</xsl:text>
   <xsl:value-of select="@questionnum"/><xsl:text>", "</xsl:text>
-  <xsl:value-of select="@dirchooser"/><xsl:text>"</xsl:text>
+  <xsl:value-of select="@dirchooser"/><xsl:text>", "</xsl:text>
+  <xsl:value-of select="@options"/><xsl:text>"</xsl:text>
+</xsl:template>
+
+<!-- Recursively walks the comma-separated options attribute and emits
+     WRAP_TRANSLATION(C_("preferences", "<label>")) for each entry that
+     contains a "|" (id|label form). Entries without a pipe are treated
+     as plain identifiers that don't need translation. -->
+<xsl:template name="_emit_option_labels">
+  <xsl:param name="str"/>
+  <xsl:variable name="head">
+    <xsl:choose>
+      <xsl:when test="contains($str, ',')">
+        <xsl:value-of select="substring-before($str, ',')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$str"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:variable>
+  <xsl:variable name="tail">
+    <xsl:if test="contains($str, ',')">
+      <xsl:value-of select="substring-after($str, ',')"/>
+    </xsl:if>
+  </xsl:variable>
+  <xsl:if test="contains($head, '|')">
+    <xsl:text>    WRAP_TRANSLATION(C_("preferences", "</xsl:text>
+    <xsl:value-of select="substring-after($head, '|')"/>
+    <xsl:text>"))&#xA;</xsl:text>
+  </xsl:if>
+  <xsl:if test="$tail != ''">
+    <xsl:call-template name="_emit_option_labels">
+      <xsl:with-param name="str" select="$tail"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template match="welcomescreen" mode="options_i18n">
+  <xsl:if test="@options">
+    <xsl:call-template name="_emit_option_labels">
+      <xsl:with-param name="str" select="@options"/>
+    </xsl:call-template>
+  </xsl:if>
 </xsl:template>
 
 </xsl:stylesheet>


### PR DESCRIPTION
Follow-up to #20456 (welcome screen framework by @masterpiga).

Theme is one of those configuration choices that's genuinely important for new users but easy to miss. The UI surround affects how your eye judges colours while editing, and darktable defaults to grey for a reason – it's the most neutral surround, which is why colour professionals use grey walls and monitor hoods. A user who picks a darker theme to match their other apps may not realise it biases their colour decisions.

This PR adds a theme step to the welcome screen, so first-run users see grey/dark/darker side by side with a short rationale and make the choice knowingly. Anyone who still wants a darker interface can pick that – this is about informed defaults, not overriding preferences.

## Framework change

The welcome screen didn't have a combobox path for plain `<type>string</type>` configs (`ui_last/theme` isn't enum-constrained because users can install custom themes). Added:

- **`<welcomescreen options="id|label,…"/>`** – id goes to conf, label to the combobox. Entries without `|` behave as before.
- **Translatable labels.** `tools/generate_darktablerc_conf.xsl` now emits `WRAP_TRANSLATION(C_("preferences", "<label>"))` for each label, same pattern as the existing `<enum>` mode. `xgettext` picks them up from `build/bin/conf_gen.h`; runtime `g_dpgettext2` resolves per locale. Theme ids stay untranslated so the loader keeps finding the right CSS.

### Deviation worth flagging

Theme selection applies **live** on combobox change so users can actually see each surround before deciding. Every other welcome-screen answer stashes until Done. Intentional – you can't judge a surround without seeing it – but flagging so any reviewer don't read it as inconsistent.