### PR TITLE
read user-defined exif tags

### DIFF
--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -2370,6 +2370,23 @@ static bool _exif_decode_exif_data(dt_image_t *img, Exiv2::ExifData &exifData)
       }
     };
 
+    // read user defined exif tags from metadata editor
+    dt_pthread_mutex_lock(&darktable.metadata_threadsafe);
+    for(GList *iter = dt_metadata_get_list(); iter; iter = iter->next)
+    {
+      dt_metadata_t *metadata = (dt_metadata_t *)iter->data;
+      gchar *tagname_lower = g_ascii_strdown(metadata->tagname, -1);
+      gboolean is_exif = (g_strstr_len(tagname_lower, -1, "exif") != NULL);
+      g_free(tagname_lower);
+
+      if(is_exif && FIND_EXIF_TAG(metadata->tagname))
+      {
+        std::string str = pos->print(&exifData);
+        dt_metadata_set_import(img->id, metadata->tagname, str.c_str());
+      }
+    }
+    dt_pthread_mutex_unlock(&darktable.metadata_threadsafe);
+
     img->exif_inited = TRUE;
     return true;
   }

--- a/src/gui/metadata_tags.c
+++ b/src/gui/metadata_tags.c
@@ -86,7 +86,6 @@ static void _tree_selection_change(GtkTreeSelection *selection, gpointer user_da
 }
 
 GtkWidget *dt_metadata_tags_dialog(GtkWidget *parent,
-                                   const gboolean user_editable_only,
                                    gpointer metadata_activated_callback,
                                    gpointer user_data)
 {
@@ -127,33 +126,9 @@ GtkWidget *dt_metadata_tags_dialog(GtkWidget *parent,
   if(!taglist)
     taglist = (GList *) dt_exif_get_exiv2_taglist();
 
-  // list of user-editable tagnames for the metadata editor
-  const char *allowed_tag_names[] =
-    {
-      "Xmp.dc.",
-      "Xmp.acdsee.",
-      "Xmp.iptc.",
-      "Xmp.dwc.",
-      "Iptc."
-    };
-
   for(GList *tag = taglist; tag; tag = g_list_next(tag))
   {
     const char *tagname = tag->data;
-
-    if(user_editable_only)
-    {
-      // for the metadata editor we only want to expose user-editable fields
-      gboolean allowed = FALSE;
-      for(int i = 0; (i < sizeof(allowed_tag_names) / sizeof(allowed_tag_names[0])) && !allowed; i++)
-      {
-        if(g_strstr_len(tagname, -1, allowed_tag_names[i]) == tagname)
-          allowed = TRUE;
-      }
-
-      if(!allowed)
-        continue;
-    }
 
     char *type = g_strstr_len(tagname, -1, ",");
     if(type)

--- a/src/gui/metadata_tags.h
+++ b/src/gui/metadata_tags.h
@@ -17,7 +17,7 @@
 */
 
 gchar *dt_metadata_tags_get_selected();
-GtkWidget *dt_metadata_tags_dialog(GtkWidget *parent, const gboolean user_editable_only, gpointer metadata_activated_callback, gpointer user_data);
+GtkWidget *dt_metadata_tags_dialog(GtkWidget *parent, gpointer metadata_activated_callback, gpointer user_data);
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/libs/export_metadata.c
+++ b/src/libs/export_metadata.c
@@ -98,7 +98,7 @@ static void _metadata_activated(GtkTreeView *tree_view,
 // dialog to add metadata tag into the formula list
 static void _add_tag_button_clicked(GtkButton *button, dt_lib_export_metadata_t *d)
 {
-  GtkWidget *dialog = dt_metadata_tags_dialog(d->dialog, FALSE, _metadata_activated, d);
+  GtkWidget *dialog = dt_metadata_tags_dialog(d->dialog, _metadata_activated, d);
 
 #ifdef GDK_WINDOWING_QUARTZ
   dt_osx_disallow_fullscreen(dialog);

--- a/src/libs/metadata.c
+++ b/src/libs/metadata.c
@@ -745,7 +745,7 @@ static void _metadata_activated(GtkTreeView *tree_view,
 // dialog to add metadata tag into the formula list
 static void _add_tag_button_clicked(GtkButton *button, dt_lib_metadata_t *d)
 {
-  GtkWidget *dialog = dt_metadata_tags_dialog(d->dialog, TRUE, _metadata_activated, d);
+  GtkWidget *dialog = dt_metadata_tags_dialog(d->dialog, _metadata_activated, d);
 
 #ifdef GDK_WINDOWING_QUARTZ
   dt_osx_disallow_fullscreen(dialog);


### PR DESCRIPTION
This change implements reading of exif tags which were added to the metadata editor.

In previous versions the metadata editor allowed to add all tags which are supported by exiv2. This led to some confusion when users added exif tags to the metadata editor and then expected these tags to be read on import, which didn't work.

The "solution" was to restrict the list of allowed tags for the metadata editor to only those tags which are supposed to be user-editable. I have removed this restriction, now the user has complete freedom on what tags to add.

Now on _import_ or _refresh EXIF_ the user-defined tags from the metadata editor are read from the image as well.

To test this I have added 5 exif tags to the metadata editor, which are definitely embedded in the image:

<img width="547" height="309" alt="Bildschirmfoto 2026-04-24 um 12 25 47" src="https://github.com/user-attachments/assets/98861547-5c9d-4345-bdaf-33510444a128" />

Which looks like this:

<img width="450" height="188" alt="Bildschirmfoto 2026-04-24 um 12 26 04" src="https://github.com/user-attachments/assets/21e65a12-1e97-4943-bea7-1796b298586f" />

After importing a new image (or _refresh EXIF_ on already existing ones):

<img width="451" height="188" alt="Bildschirmfoto 2026-04-24 um 12 26 18" src="https://github.com/user-attachments/assets/583aa8cb-8fb6-41da-a294-5c7c4d1cee52" />

Image information panel:

<img width="447" height="91" alt="Bildschirmfoto 2026-04-24 um 13 02 55" src="https://github.com/user-attachments/assets/56a4dcce-e10d-4e6e-88ee-2a1bd73bc315" />
   
fixes #20856 

@wpferguson : would you like to test?