### PR TITLE
[AI] Fix AI object mask groups losing holes after vectorisation

### DIFF
--- a/src/common/ras2vect.c
+++ b/src/common/ras2vect.c
@@ -279,7 +279,11 @@ GList *ras2forms(const float *mask,
   potrace_param_free(param);
   _bm_free(bm);
 
-  if(out_signs) *out_signs = signs;
+  // restore potrace's traversal order (outer first, then its holes).
+  // group consumers need the outer at list position 0 so it acts as the
+  // base while holes subtract on top with DIFFERENCE mode
+  forms = g_list_reverse(forms);
+  if(out_signs) *out_signs = g_list_reverse(signs);
   return forms;
 }
 


### PR DESCRIPTION
Fixes #20870

When an AI object mask produces a shape with holes (e.g. a donut-shaped selection), the final mask was coming out as a solid outer region – the holes were silently missing. @shumconstedit tracked this down in the issue report with very clear screenshots and a reliable manual workaround (moving the outermost path to the bottom of the group in the Mask Manager).

## Root cause

`ras2forms` returns vectorised paths in reverse potrace order (innermost hole first, outer last) because of an internal `g_list_prepend` step. When the AI object mask's group builder iterated that list forward and appended each path to the group, the outer ended up at the last position.

The render consequence:

- Position 0: innermost hole with `DIFFERENCE` mode → subtracts from an empty buffer → no-op.
- Position 1: next hole → still no-op.
- Position N-1: outer with default `UNION` mode → drawn over the empty buffer, filling the whole region as a solid shape.

Net result: holes invisible in the rendered mask.

## Fix

Reverse the forms and signs lists in `_register_vectorized_forms` before building the group, so outer lands at position 0 (rendered first as the base) and holes follow after with `DIFFERENCE` (correctly subtracting from the base).

Naming convention is unchanged: outer gets `#1`, inner holes increment upward. In the Mask Manager this displays as `#N` at the top, `#1` at the bottom – matching the "newest-at-top" convention used for all other mask types in darktable.

## Scope

- Only touches `_register_vectorized_forms` in `src/develop/masks/object.c`.
- `ras2forms` itself is unchanged – the External Raster Masks module doesn't build a group from its output (registers each form independently), so it isn't affected.
- No XML/config/translation changes.