### PR TITLE
[CI/CD] Install Lua as lua54 package in MSYS2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -267,7 +267,7 @@ jobs:
             libtiff:p
             libwebp:p
             libxml2:p
-            lua:p
+            lua54:p
             omp:p
             openexr:p
             openjpeg2:p

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -278,7 +278,7 @@ jobs:
             SDL2:p
             sqlite3:p
             zlib:p
-          update: false
+          update: true
       - run: git config --global core.autocrlf input
         shell: bash
       - uses: actions/checkout@v6

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -257,7 +257,7 @@ jobs:
             libtiff:p
             libwebp:p
             libxml2:p
-            lua:p
+            lua54:p
             omp:p
             openexr:p
             openjpeg2:p

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -269,7 +269,7 @@ jobs:
             sqlite3:p
             webp-pixbuf-loader:p
             zlib:p
-          update: false
+          update: true
       - name: Build and install the latest compatible version of exiv2
         run: |
           git clone --branch v0.27.7 --depth 1 https://github.com/Exiv2/exiv2 src-exiv2


### PR DESCRIPTION
The lua package has just been upgraded to version 5.5 in MSYS2, and the version 5.4 we need can be installed using the lua54 package.