### PR TITLE
NULL guard in _preview_write_image (fixes GCC 16 -Werror=nonnull)

### DIFF
--- a/src/imageio/imageio.c
+++ b/src/imageio/imageio.c
@@ -1730,6 +1730,7 @@ static int _preview_write_image(dt_imageio_module_data_t *data,
 {
   _imageio_preview_t *d = (_imageio_preview_t *)data;
 
+  if(!in) return 1;
   memcpy(d->buf, in, sizeof(uint32_t) * data->width * data->height);
   d->width = data->width;
   d->height = data->height;


### PR DESCRIPTION
Add a NULL guard at the top of `_preview_write_image()` to fix the build under GCC 16+ with `-Werror=nonnull`.

Fixes #20894

## Details
GCC 16's interprocedural NULL analysis follows function pointers and detects that `dt_imageio_export()` passes `NULL` for the `in` argument when the format mime is `"x-copy"` ([imageio.c:1010-1014](src/imageio/imageio.c#L1010-L1014)). Since `_preview_write_image` is registered as a `write_image` callback, GCC concludes that NULL can reach the `memcpy` call inside it. The diagnostic is technically correct: `memcpy` from a NULL source is undefined behaviour even when `n` is zero.

In practice the runtime path doesn't fire for the preview format, but the static analysis can't see that.

The fix is a one-line `if(!in) return 1;` at the top of the function – return non-zero so a future caller that *does* pass NULL gets a clear error rather than UB.

The bug has been latent since [b49bf38062](https://github.com/darktable-org/darktable/commit/b49bf38062) (Oct 2022); only newer GCC versions (16+) catch it because of stricter NULL propagation across indirect calls.