### PR TITLE
[AI] Add GPU device selection and EP filtering to AI preferences

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -417,6 +417,27 @@
     <shortdescription>AI models GitHub repository</shortdescription>
     <longdescription>GitHub repository for downloading AI models (format: owner/repo)</longdescription>
   </dtconfig>
+  <dtconfig>
+    <name>plugins/ai/cuda_device_id</name>
+    <type min="0" max="15">int</type>
+    <default>0</default>
+    <shortdescription>CUDA GPU device index</shortdescription>
+    <longdescription>which NVIDIA GPU to use when CUDA is the active execution provider. matches the index reported by nvidia-smi and respects CUDA_VISIBLE_DEVICES. defaults to 0 (first GPU). takes effect on next restart. env var DT_CUDA_DEVICE_ID overrides this if set.</longdescription>
+  </dtconfig>
+  <dtconfig>
+    <name>plugins/ai/migraphx_device_id</name>
+    <type min="0" max="15">int</type>
+    <default>0</default>
+    <shortdescription>MIGraphX/ROCm GPU device index</shortdescription>
+    <longdescription>which AMD GPU to use when MIGraphX or ROCm is the active execution provider. matches the GPU agent order in rocminfo. defaults to 0 (first GPU). takes effect on next restart. env var DT_MIGRAPHX_DEVICE_ID overrides this if set.</longdescription>
+  </dtconfig>
+  <dtconfig>
+    <name>plugins/ai/dml_device_id</name>
+    <type min="0" max="15">int</type>
+    <default>0</default>
+    <shortdescription>DirectML GPU device index</shortdescription>
+    <longdescription>which DirectX 12 adapter to use when DirectML is the active execution provider. matches IDXGIFactory1::EnumAdapters1 order. defaults to 0 (first adapter). takes effect on next restart. env var DT_DML_DEVICE_ID overrides this if set.</longdescription>
+  </dtconfig>
   <dtconfig prefs="processing" section="opencl" capability="opencl">
     <name>opencl</name>
     <type>bool</type>

--- a/dev-doc/AI.md
+++ b/dev-doc/AI.md
@@ -197,6 +197,28 @@ runtime without loading a model. It creates temporary
 (available) or 0 (unavailable). Used by the preferences UI to show a
 warning when a selected provider is not available.
 
+### Multi-GPU Device Selection (escape hatch)
+
+For systems with multiple GPUs of the same vendor (e.g. laptop with
+both an iGPU and a dGPU, or a workstation with two NVIDIA cards), the
+default `device_id` is `0` — whichever the platform enumerates first.
+Power users can override this by setting either a conf key or an env
+var (env var wins when both are set):
+
+| Provider | Conf key | Env var |
+|---|---|---|
+| CUDA | `plugins/ai/cuda_device_id` | `DT_CUDA_DEVICE_ID` |
+| MIGraphX / ROCm | `plugins/ai/migraphx_device_id` | `DT_MIGRAPHX_DEVICE_ID` |
+| DirectML | `plugins/ai/dml_device_id` | `DT_DML_DEVICE_ID` |
+
+The integer index follows each provider's own enumeration:
+- **CUDA** indexes match `nvidia-smi` (and respect `CUDA_VISIBLE_DEVICES`)
+- **MIGraphX / ROCm** indexes match the GPU agent order in `rocminfo`
+- **DirectML** indexes match `IDXGIFactory1::EnumAdapters1` order
+
+OpenVINO and CoreML are single-device or self-managing; they do not
+read a device_id key. Apply changes by restarting darktable.
+
 ### ONNX Runtime Packages
 
 | Platform | Package Source | Providers Included |

--- a/src/ai/CMakeLists.txt
+++ b/src/ai/CMakeLists.txt
@@ -60,6 +60,11 @@ target_link_libraries(darktable_ai PUBLIC
   ${JSON_GLIB_LIBRARIES}
 )
 
+# DirectML device enumeration uses DXGI (Windows 10 1803+ for IDXGIFactory6)
+if(WIN32)
+  target_link_libraries(darktable_ai PUBLIC dxgi)
+endif()
+
 # Install the bundled ONNX Runtime shared library alongside darktable_ai
 # (skip when using system package — it's already in the system library path)
 if(ONNXRuntime_SYSTEM_PACKAGE)

--- a/src/ai/CMakeLists.txt
+++ b/src/ai/CMakeLists.txt
@@ -60,9 +60,10 @@ target_link_libraries(darktable_ai PUBLIC
   ${JSON_GLIB_LIBRARIES}
 )
 
-# DirectML device enumeration uses DXGI (Windows 10 1803+ for IDXGIFactory6)
+# DirectML device enumeration uses DXGI (Windows 10 1803+ for IDXGIFactory6).
+# dxguid provides GUID constants (IID_IDXGIFactory6, IID_IDXGIAdapter1, ...).
 if(WIN32)
-  target_link_libraries(darktable_ai PUBLIC dxgi)
+  target_link_libraries(darktable_ai PUBLIC dxgi dxguid)
 endif()
 
 # Install the bundled ONNX Runtime shared library alongside darktable_ai

--- a/src/ai/backend.h
+++ b/src/ai/backend.h
@@ -81,6 +81,21 @@ guint dt_ai_providers_bundled(void);
  *  when ORT was loaded — the in-process ORT is stale, restart needed. */
 gboolean dt_ai_ort_path_changed_since_load(void);
 
+/** A selectable GPU device for a multi-GPU-capable execution provider. */
+typedef struct dt_ai_device_t
+{
+  int    id;     /**< device_id passed to the EP (e.g. CUDA ordinal, DXGI adapter index) */
+  gchar *name;   /**< human-readable label, e.g. "NVIDIA GeForce RTX 5060" */
+} dt_ai_device_t;
+
+/** Enumerate selectable GPU devices for a provider. Returns NULL or an
+ *  empty list for AUTO/CPU/OpenVINO/CoreML (no per-device choice).
+ *  Caller frees with `g_list_free_full(list, dt_ai_device_free)`. */
+GList *dt_ai_enum_devices_for_provider(dt_ai_provider_t provider);
+
+/** Free a single dt_ai_device_t (the struct + its name). */
+void dt_ai_device_free(gpointer device);
+
 /** Test if a provider is available at runtime (checks deps, not just compile-time).
  *  @return 1 if available, 0 if not. */
 int dt_ai_probe_provider(dt_ai_provider_t provider);

--- a/src/ai/backend.h
+++ b/src/ai/backend.h
@@ -96,6 +96,18 @@ GList *dt_ai_enum_devices_for_provider(dt_ai_provider_t provider);
 /** Free a single dt_ai_device_t (the struct + its name). */
 void dt_ai_device_free(gpointer device);
 
+/** Return the conf key (`"plugins/ai/<ep>_device_id"`) for a provider,
+ *  or NULL for providers that don't support device selection
+ *  (AUTO/CPU/OpenVINO/CoreML). The returned string is statically
+ *  allocated and must not be freed. */
+const char *dt_ai_device_conf_key_for_provider(dt_ai_provider_t provider);
+
+/** TRUE if the device_id conf for the given provider differs from the
+ *  value used when ORT was loaded — i.e. a restart is needed before
+ *  GPU selection takes effect. FALSE for providers without device
+ *  selection or before ORT is loaded. */
+gboolean dt_ai_device_id_changed_since_load(dt_ai_provider_t provider);
+
 /** Test if a provider is available at runtime (checks deps, not just compile-time).
  *  @return 1 if available, 0 if not. */
 int dt_ai_probe_provider(dt_ai_provider_t provider);

--- a/src/ai/backend.h
+++ b/src/ai/backend.h
@@ -66,6 +66,21 @@ const char *dt_ai_provider_to_string(dt_ai_provider_t provider);
 /** Parse provider from config string (with legacy alias support) */
 dt_ai_provider_t dt_ai_provider_from_string(const char *str);
 
+/** Parse the comma-separated EP list produced by
+ *  dt_ai_ort_probe_library_full() into a bitmask of (1u << dt_ai_provider_t)
+ *  values. AUTO and CPU are always set. Unknown tokens are ignored. */
+guint dt_ai_providers_from_eps(const char *eps);
+
+/** Bitmask of providers that ship with darktable's bundled ORT on the
+ *  current platform. Includes AUTO and CPU always, plus CoreML on macOS
+ *  and DirectML on Windows. Use as a safe default when the loaded ORT
+ *  cannot be probed. */
+guint dt_ai_providers_bundled(void);
+
+/** TRUE if plugins/ai/ort_library_path differs from the value seen
+ *  when ORT was loaded — the in-process ORT is stale, restart needed. */
+gboolean dt_ai_ort_path_changed_since_load(void);
+
 /** Test if a provider is available at runtime (checks deps, not just compile-time).
  *  @return 1 if available, 0 if not. */
 int dt_ai_probe_provider(dt_ai_provider_t provider);

--- a/src/ai/backend.h
+++ b/src/ai/backend.h
@@ -100,7 +100,7 @@ typedef struct dt_ai_device_t
 /** Enumerate selectable GPU devices for a provider. Returns NULL or an
  *  empty list for AUTO/CPU/OpenVINO/CoreML (no per-device choice).
  *  Caller frees with `g_list_free_full(list, dt_ai_device_free)`. */
-GList *dt_ai_enum_devices_for_provider(dt_ai_provider_t provider);
+GList *dt_ai_enum_devices_for_provider(const dt_ai_provider_t provider);
 
 /** Free a single dt_ai_device_t (the struct + its name). */
 void dt_ai_device_free(gpointer device);
@@ -109,13 +109,13 @@ void dt_ai_device_free(gpointer device);
  *  or NULL for providers that don't support device selection
  *  (AUTO/CPU/OpenVINO/CoreML). The returned string is statically
  *  allocated and must not be freed. */
-const char *dt_ai_device_conf_key_for_provider(dt_ai_provider_t provider);
+const char *dt_ai_device_conf_key_for_provider(const dt_ai_provider_t provider);
 
 /** TRUE if the device_id conf for the given provider differs from the
  *  value used when ORT was loaded — i.e. a restart is needed before
  *  GPU selection takes effect. FALSE for providers without device
  *  selection or before ORT is loaded. */
-gboolean dt_ai_device_id_changed_since_load(dt_ai_provider_t provider);
+gboolean dt_ai_device_id_changed_since_load(const dt_ai_provider_t provider);
 
 /** Test if a provider is available at runtime (checks deps, not just compile-time).
  *  @return 1 if available, 0 if not. */

--- a/src/ai/backend.h
+++ b/src/ai/backend.h
@@ -77,9 +77,18 @@ guint dt_ai_providers_from_eps(const char *eps);
  *  cannot be probed. */
 guint dt_ai_providers_bundled(void);
 
+/** Snapshot the conf state (ORT path, provider, device ids) for the
+ *  *_changed_since_load() helpers.  Call once at darktable startup so
+ *  the snapshot is independent of when ORT is lazily initialized. */
+void dt_ai_snapshot_conf_state(void);
+
 /** TRUE if plugins/ai/ort_library_path differs from the value seen
  *  when ORT was loaded — the in-process ORT is stale, restart needed. */
 gboolean dt_ai_ort_path_changed_since_load(void);
+
+/** TRUE if the configured provider differs from the value seen when
+ *  ORT was loaded — long-lived sessions are stale, restart needed. */
+gboolean dt_ai_provider_changed_since_load(void);
 
 /** A selectable GPU device for a multi-GPU-capable execution provider. */
 typedef struct dt_ai_device_t

--- a/src/ai/backend_common.c
+++ b/src/ai/backend_common.c
@@ -606,6 +606,36 @@ dt_ai_provider_t dt_ai_provider_from_string(const char *str)
   return DT_AI_PROVIDER_AUTO;
 }
 
+// parse the comma-separated EP list from dt_ai_ort_probe_library_full().
+// AUTO and CPU are always set — they work regardless of what the library
+// advertises; unknown tokens (e.g. "ROCm", "TensorRT") are ignored
+guint dt_ai_providers_from_eps(const char *eps)
+{
+  guint mask = (1u << DT_AI_PROVIDER_AUTO) | (1u << DT_AI_PROVIDER_CPU);
+  if(!eps) return mask;
+
+  gchar **tokens = g_strsplit(eps, ",", -1);
+  for(int i = 0; tokens[i]; i++)
+  {
+    const dt_ai_provider_t p = dt_ai_provider_from_string(g_strstrip(tokens[i]));
+    if(p != DT_AI_PROVIDER_AUTO)  // from_string returns AUTO on unknown
+      mask |= 1u << p;
+  }
+  g_strfreev(tokens);
+  return mask;
+}
+
+guint dt_ai_providers_bundled(void)
+{
+  guint mask = (1u << DT_AI_PROVIDER_AUTO) | (1u << DT_AI_PROVIDER_CPU);
+#if defined(__APPLE__)
+  mask |= 1u << DT_AI_PROVIDER_COREML;
+#elif defined(_WIN32)
+  mask |= 1u << DT_AI_PROVIDER_DIRECTML;
+#endif
+  return mask;
+}
+
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/ai/backend_onnx.c
+++ b/src/ai/backend_onnx.c
@@ -80,6 +80,9 @@ static int g_loaded_cuda_device_id     = -1;
 static int g_loaded_migraphx_device_id = -1;
 static int g_loaded_dml_device_id      = -1;
 
+// snapshot of the provider config string at ORT load. NULL until captured
+static gchar *g_loaded_provider = NULL;
+
 static int _device_id_from_conf(const char *conf_key, const char *env_var);
 
 #if defined(__linux__)
@@ -185,12 +188,45 @@ char *dt_ai_ort_probe_library(const char *path)
 // Probe a library and return version + comma-separated list of supported EPs.
 // Both out params are caller-owned (g_free). Returns FALSE if not a valid ORT.
 // FALSE before ORT is loaded (no comparison reference yet)
+// snapshot the conf values that determine which library / EP / device
+// the in-process ORT will be bound to. called eagerly at darktable
+// startup so the *_changed_since_load() helpers have a stable reference
+// independent of when ORT is lazily initialized
+void dt_ai_snapshot_conf_state(void)
+{
+  gchar *ort_conf = dt_conf_get_string("plugins/ai/ort_library_path");
+  g_free(g_ort_conf_path_at_load);
+  g_ort_conf_path_at_load = g_strdup(ort_conf ? ort_conf : "");
+  g_free(ort_conf);
+
+  g_free(g_loaded_provider);
+  g_loaded_provider = dt_conf_get_string(DT_AI_CONF_PROVIDER);
+  if(!g_loaded_provider) g_loaded_provider = g_strdup("");
+
+  g_loaded_cuda_device_id     = _device_id_from_conf("plugins/ai/cuda_device_id",
+                                                     "DT_CUDA_DEVICE_ID");
+  g_loaded_migraphx_device_id = _device_id_from_conf("plugins/ai/migraphx_device_id",
+                                                     "DT_MIGRAPHX_DEVICE_ID");
+  g_loaded_dml_device_id      = _device_id_from_conf("plugins/ai/dml_device_id",
+                                                     "DT_DML_DEVICE_ID");
+}
+
 gboolean dt_ai_ort_path_changed_since_load(void)
 {
   if(!g_ort_conf_path_at_load) return FALSE;
   gchar *cur = dt_conf_get_string("plugins/ai/ort_library_path");
   const gboolean changed
     = g_strcmp0(cur ? cur : "", g_ort_conf_path_at_load) != 0;
+  g_free(cur);
+  return changed;
+}
+
+gboolean dt_ai_provider_changed_since_load(void)
+{
+  if(!g_loaded_provider) return FALSE;
+  gchar *cur = dt_conf_get_string(DT_AI_CONF_PROVIDER);
+  const gboolean changed
+    = g_strcmp0(cur ? cur : "", g_loaded_provider) != 0;
   g_free(cur);
   return changed;
 }
@@ -714,16 +750,7 @@ static gpointer _init_ort_api(gpointer data)
   // compile-time default; on Windows/macOS it dynamically loads a
   // user-supplied library instead of the bundled DirectML/CoreML one.
   gchar *ort_conf = dt_conf_get_string("plugins/ai/ort_library_path");
-  // snapshot for dt_ai_ort_path_changed_since_load() and
-  // dt_ai_device_id_changed_since_load()
-  g_free(g_ort_conf_path_at_load);
-  g_ort_conf_path_at_load = g_strdup(ort_conf ? ort_conf : "");
-  g_loaded_cuda_device_id     = _device_id_from_conf("plugins/ai/cuda_device_id",
-                                                     "DT_CUDA_DEVICE_ID");
-  g_loaded_migraphx_device_id = _device_id_from_conf("plugins/ai/migraphx_device_id",
-                                                     "DT_MIGRAPHX_DEVICE_ID");
-  g_loaded_dml_device_id      = _device_id_from_conf("plugins/ai/dml_device_id",
-                                                     "DT_DML_DEVICE_ID");
+  // snapshots are now taken eagerly at startup via dt_ai_snapshot_conf_state()
   const char *ort_env = g_getenv("DT_ORT_LIBRARY");
   const char *ort_override = (ort_conf && ort_conf[0]) ? ort_conf
                            : (ort_env && ort_env[0]) ? ort_env

--- a/src/ai/backend_onnx.c
+++ b/src/ai/backend_onnx.c
@@ -239,7 +239,7 @@ void dt_ai_device_free(gpointer device)
   g_free(d);
 }
 
-const char *dt_ai_device_conf_key_for_provider(dt_ai_provider_t provider)
+const char *dt_ai_device_conf_key_for_provider(const dt_ai_provider_t provider)
 {
   switch(provider)
   {
@@ -250,7 +250,7 @@ const char *dt_ai_device_conf_key_for_provider(dt_ai_provider_t provider)
   }
 }
 
-gboolean dt_ai_device_id_changed_since_load(dt_ai_provider_t provider)
+gboolean dt_ai_device_id_changed_since_load(const dt_ai_provider_t provider)
 {
   const char *key = dt_ai_device_conf_key_for_provider(provider);
   if(!key) return FALSE;
@@ -425,7 +425,7 @@ static GList *_enum_directml_devices(void)
 #endif
 }
 
-GList *dt_ai_enum_devices_for_provider(dt_ai_provider_t provider)
+GList *dt_ai_enum_devices_for_provider(const dt_ai_provider_t provider)
 {
   switch(provider)
   {
@@ -1128,7 +1128,8 @@ static float _half_to_float(uint16_t h)
 
 // Look up the device name for `device_id` from the provider's enumeration.
 // Returns a newly-allocated string (caller frees) or NULL if no match.
-static gchar *_lookup_device_name(dt_ai_provider_t provider, int device_id)
+static gchar *_lookup_device_name(const dt_ai_provider_t provider,
+                                  const int device_id)
 {
   GList *devices = dt_ai_enum_devices_for_provider(provider);
   gchar *name = NULL;
@@ -1151,8 +1152,8 @@ static gboolean _try_provider(OrtSessionOptions *session_opts,
                               const char *symbol_name,
                               const char *provider_name,
                               const char *device_type,
-                              uint32_t flags,
-                              dt_ai_provider_t provider)
+                              const uint32_t flags,
+                              const dt_ai_provider_t provider)
 {
   OrtStatus *status = NULL;
   gboolean ok = FALSE;

--- a/src/ai/backend_onnx.c
+++ b/src/ai/backend_onnx.c
@@ -1099,6 +1099,21 @@ static float _half_to_float(uint16_t h)
   return f;
 }
 
+// Look up the device name for `device_id` from the provider's enumeration.
+// Returns a newly-allocated string (caller frees) or NULL if no match.
+static gchar *_lookup_device_name(dt_ai_provider_t provider, int device_id)
+{
+  GList *devices = dt_ai_enum_devices_for_provider(provider);
+  gchar *name = NULL;
+  for(GList *l = devices; l; l = g_list_next(l))
+  {
+    dt_ai_device_t *d = l->data;
+    if(d->id == device_id) { name = g_strdup(d->name); break; }
+  }
+  g_list_free_full(devices, dt_ai_device_free);
+  return name;
+}
+
 // try to find and call an ORT execution provider function at runtime via
 // dynamic symbol lookup (GModule/dlsym).  returns TRUE if the provider was
 // enabled successfully, FALSE otherwise.
@@ -1109,7 +1124,8 @@ static gboolean _try_provider(OrtSessionOptions *session_opts,
                               const char *symbol_name,
                               const char *provider_name,
                               const char *device_type,
-                              uint32_t flags)
+                              uint32_t flags,
+                              dt_ai_provider_t provider)
 {
   OrtStatus *status = NULL;
   gboolean ok = FALSE;
@@ -1163,7 +1179,14 @@ static gboolean _try_provider(OrtSessionOptions *session_opts,
     }
     if(!status)
     {
-      dt_print(DT_DEBUG_AI, "[darktable_ai] %s enabled successfully.", provider_name);
+      // for integer-argument (device-id) providers, also log which GPU was selected
+      gchar *dev_name = device_type ? NULL : _lookup_device_name(provider, (int)flags);
+      if(dev_name)
+        dt_print(DT_DEBUG_AI, "[darktable_ai] %s enabled successfully on device %d: %s",
+                 provider_name, (int)flags, dev_name);
+      else
+        dt_print(DT_DEBUG_AI, "[darktable_ai] %s enabled successfully.", provider_name);
+      g_free(dev_name);
       ok = TRUE;
     }
     else
@@ -1223,7 +1246,7 @@ _enable_acceleration(OrtSessionOptions *session_opts,
     _try_provider(
       session_opts,
       "OrtSessionOptionsAppendExecutionProvider_CoreML",
-      "Apple CoreML", NULL, coreml_flags);
+      "Apple CoreML", NULL, coreml_flags, DT_AI_PROVIDER_COREML);
 #else
     dt_print(DT_DEBUG_AI, "[darktable_ai] apple CoreML not available on this platform");
 #endif
@@ -1234,7 +1257,7 @@ _enable_acceleration(OrtSessionOptions *session_opts,
     const int dev = _device_id_from_conf("plugins/ai/cuda_device_id",
                                          "DT_CUDA_DEVICE_ID");
     _try_provider(session_opts, "OrtSessionOptionsAppendExecutionProvider_CUDA",
-                  "NVIDIA CUDA", NULL, (uint32_t)dev);
+                  "NVIDIA CUDA", NULL, (uint32_t)dev, DT_AI_PROVIDER_CUDA);
     break;
   }
 
@@ -1247,16 +1270,16 @@ _enable_acceleration(OrtSessionOptions *session_opts,
     const int dev = _device_id_from_conf("plugins/ai/migraphx_device_id",
                                          "DT_MIGRAPHX_DEVICE_ID");
     if(!_try_provider(session_opts, "OrtSessionOptionsAppendExecutionProvider_MIGraphX",
-                      "AMD MIGraphX", NULL, (uint32_t)dev))
+                      "AMD MIGraphX", NULL, (uint32_t)dev, DT_AI_PROVIDER_MIGRAPHX))
       _try_provider(session_opts, "OrtSessionOptionsAppendExecutionProvider_ROCM",
-                    "AMD ROCm (legacy)", NULL, (uint32_t)dev);
+                    "AMD ROCm (legacy)", NULL, (uint32_t)dev, DT_AI_PROVIDER_MIGRAPHX);
     break;
   }
 
   case DT_AI_PROVIDER_OPENVINO:
     if(!_try_openvino_with_cache(session_opts))
       _try_provider(session_opts, "OrtSessionOptionsAppendExecutionProvider_OpenVINO",
-                    "Intel OpenVINO", "AUTO", 0);
+                    "Intel OpenVINO", "AUTO", 0, DT_AI_PROVIDER_OPENVINO);
     break;
 
   case DT_AI_PROVIDER_DIRECTML:
@@ -1266,7 +1289,7 @@ _enable_acceleration(OrtSessionOptions *session_opts,
                                          "DT_DML_DEVICE_ID");
     _try_provider(session_opts,
                   "OrtSessionOptionsAppendExecutionProvider_DML",
-                  "Windows DirectML", NULL, (uint32_t)dev);
+                  "Windows DirectML", NULL, (uint32_t)dev, DT_AI_PROVIDER_DIRECTML);
   }
 #else
     dt_print(DT_DEBUG_AI, "[darktable_ai] windows DirectML not available on this platform");
@@ -1280,14 +1303,14 @@ _enable_acceleration(OrtSessionOptions *session_opts,
     _try_provider(
       session_opts,
       "OrtSessionOptionsAppendExecutionProvider_CoreML",
-      "Apple CoreML", NULL, coreml_flags);
+      "Apple CoreML", NULL, coreml_flags, DT_AI_PROVIDER_COREML);
 #elif defined(_WIN32)
     {
       const int dev = _device_id_from_conf("plugins/ai/dml_device_id",
                                            "DT_DML_DEVICE_ID");
       _try_provider(session_opts,
                     "OrtSessionOptionsAppendExecutionProvider_DML",
-                    "Windows DirectML", NULL, (uint32_t)dev);
+                    "Windows DirectML", NULL, (uint32_t)dev, DT_AI_PROVIDER_DIRECTML);
     }
 #elif defined(__linux__)
     // try CUDA first, then MIGraphX (cache configured at env init)
@@ -1299,16 +1322,16 @@ _enable_acceleration(OrtSessionOptions *session_opts,
       if(!_try_provider(
            session_opts,
            "OrtSessionOptionsAppendExecutionProvider_CUDA",
-           "NVIDIA CUDA", NULL, (uint32_t)cuda_dev))
+           "NVIDIA CUDA", NULL, (uint32_t)cuda_dev, DT_AI_PROVIDER_CUDA))
       {
         if(!_try_provider(
              session_opts,
              "OrtSessionOptionsAppendExecutionProvider_MIGraphX",
-             "AMD MIGraphX", NULL, (uint32_t)amd_dev))
+             "AMD MIGraphX", NULL, (uint32_t)amd_dev, DT_AI_PROVIDER_MIGRAPHX))
           _try_provider(
             session_opts,
             "OrtSessionOptionsAppendExecutionProvider_ROCM",
-            "AMD ROCm (legacy)", NULL, (uint32_t)amd_dev);
+            "AMD ROCm (legacy)", NULL, (uint32_t)amd_dev, DT_AI_PROVIDER_MIGRAPHX);
       }
     }
 #endif
@@ -1349,14 +1372,15 @@ int dt_ai_probe_provider(dt_ai_provider_t provider)
   switch(provider)
   {
   case DT_AI_PROVIDER_COREML:
-    ok = _try_provider(opts, "OrtSessionOptionsAppendExecutionProvider_CoreML", "Apple CoreML", NULL, 0);
+    ok = _try_provider(opts, "OrtSessionOptionsAppendExecutionProvider_CoreML",
+                       "Apple CoreML", NULL, 0, DT_AI_PROVIDER_COREML);
     break;
   case DT_AI_PROVIDER_CUDA:
   {
     const int dev = _device_id_from_conf("plugins/ai/cuda_device_id",
                                          "DT_CUDA_DEVICE_ID");
     ok = _try_provider(opts, "OrtSessionOptionsAppendExecutionProvider_CUDA",
-                       "NVIDIA CUDA", NULL, (uint32_t)dev);
+                       "NVIDIA CUDA", NULL, (uint32_t)dev, DT_AI_PROVIDER_CUDA);
     break;
   }
   case DT_AI_PROVIDER_MIGRAPHX:
@@ -1364,20 +1388,21 @@ int dt_ai_probe_provider(dt_ai_provider_t provider)
     const int dev = _device_id_from_conf("plugins/ai/migraphx_device_id",
                                          "DT_MIGRAPHX_DEVICE_ID");
     ok = _try_provider(opts, "OrtSessionOptionsAppendExecutionProvider_MIGraphX",
-                       "AMD MIGraphX", NULL, (uint32_t)dev)
+                       "AMD MIGraphX", NULL, (uint32_t)dev, DT_AI_PROVIDER_MIGRAPHX)
       || _try_provider(opts, "OrtSessionOptionsAppendExecutionProvider_ROCM",
-                       "AMD ROCm (legacy)", NULL, (uint32_t)dev);
+                       "AMD ROCm (legacy)", NULL, (uint32_t)dev, DT_AI_PROVIDER_MIGRAPHX);
     break;
   }
   case DT_AI_PROVIDER_OPENVINO:
-    ok = _try_provider(opts, "OrtSessionOptionsAppendExecutionProvider_OpenVINO", "Intel OpenVINO", "AUTO", 0);
+    ok = _try_provider(opts, "OrtSessionOptionsAppendExecutionProvider_OpenVINO",
+                       "Intel OpenVINO", "AUTO", 0, DT_AI_PROVIDER_OPENVINO);
     break;
   case DT_AI_PROVIDER_DIRECTML:
   {
     const int dev = _device_id_from_conf("plugins/ai/dml_device_id",
                                          "DT_DML_DEVICE_ID");
     ok = _try_provider(opts, "OrtSessionOptionsAppendExecutionProvider_DML",
-                       "Windows DirectML", NULL, (uint32_t)dev);
+                       "Windows DirectML", NULL, (uint32_t)dev, DT_AI_PROVIDER_DIRECTML);
     break;
   }
   default:

--- a/src/ai/backend_onnx.c
+++ b/src/ai/backend_onnx.c
@@ -29,6 +29,8 @@
 #include <string.h>
 #ifdef _WIN32
 #include <windows.h>
+#include <dxgi1_6.h>
+#include <initguid.h>
 #else
 #include <fcntl.h>
 #include <unistd.h>
@@ -183,6 +185,189 @@ gboolean dt_ai_ort_path_changed_since_load(void)
     = g_strcmp0(cur ? cur : "", g_ort_conf_path_at_load) != 0;
   g_free(cur);
   return changed;
+}
+
+void dt_ai_device_free(gpointer device)
+{
+  if(!device) return;
+  dt_ai_device_t *d = (dt_ai_device_t *)device;
+  g_free(d->name);
+  g_free(d);
+}
+
+// shell out to a command and return its stdout. caller frees. NULL on failure
+static gchar *_run_capture(const char *cmd)
+{
+  gchar *out = NULL;
+  GError *err = NULL;
+  gint exit_status = 0;
+  if(!g_spawn_command_line_sync(cmd, &out, NULL, &exit_status, &err))
+  {
+    if(err) g_clear_error(&err);
+    g_free(out);
+    return NULL;
+  }
+  if(exit_status != 0)
+  {
+    g_free(out);
+    return NULL;
+  }
+  return out;
+}
+
+// CUDA device enumeration via nvidia-smi. respects CUDA_VISIBLE_DEVICES
+// since nvidia-smi inherits the parent process env. one row per GPU,
+// ordinal in column 1, name in column 2 (CSV)
+static GList *_enum_cuda_devices(void)
+{
+  gchar *out = _run_capture("nvidia-smi --query-gpu=index,name "
+                            "--format=csv,noheader,nounits");
+  if(!out) return NULL;
+
+  GList *result = NULL;
+  gchar **lines = g_strsplit(out, "\n", -1);
+  for(gchar **lp = lines; *lp; lp++)
+  {
+    gchar *line = g_strstrip(*lp);
+    if(!line[0]) continue;
+    gchar **fields = g_strsplit(line, ",", 2);
+    if(fields[0] && fields[1])
+    {
+      dt_ai_device_t *d = g_new0(dt_ai_device_t, 1);
+      d->id = atoi(g_strstrip(fields[0]));
+      d->name = g_strdup(g_strstrip(fields[1]));
+      result = g_list_append(result, d);
+    }
+    g_strfreev(fields);
+  }
+  g_strfreev(lines);
+  g_free(out);
+  return result;
+}
+
+// MIGraphX device enumeration via rocminfo. filter by Device Type=GPU
+// to skip the CPU and Ryzen-AI NPU agents. Marketing Name appears
+// before Device Type within each agent block, so we hold the most
+// recent name and emit it when we hit a GPU agent. id is the ordinal
+// index of GPU agents (0, 1, ...) — matches MIGraphX's device_id
+static GList *_enum_migraphx_devices(void)
+{
+#ifndef __linux__
+  return NULL;  // ROCm is Linux-only
+#else
+  gchar *out = _run_capture("rocminfo");
+  if(!out) return NULL;
+
+  GList *result = NULL;
+  gchar **lines = g_strsplit(out, "\n", -1);
+  gchar *pending_name = NULL;
+  int gpu_index = 0;
+  for(gchar **lp = lines; *lp; lp++)
+  {
+    gchar *line = *lp;
+    const char *mn = strstr(line, "Marketing Name:");
+    if(mn)
+    {
+      const char *colon = strchr(mn, ':');
+      if(colon)
+      {
+        g_free(pending_name);
+        pending_name = g_strdup(g_strstrip((gchar *)colon + 1));
+      }
+      continue;
+    }
+    if(strstr(line, "Device Type:") && strstr(line, "GPU") && pending_name)
+    {
+      dt_ai_device_t *d = g_new0(dt_ai_device_t, 1);
+      d->id = gpu_index++;
+      d->name = pending_name;
+      pending_name = NULL;
+      result = g_list_append(result, d);
+    }
+  }
+  g_free(pending_name);
+  g_strfreev(lines);
+  g_free(out);
+  return result;
+#endif
+}
+
+// DirectML device enumeration via DXGI. uses EnumAdapterByGpuPreference
+// (DXGI 1.6, Windows 10 1803+) with HIGH_PERFORMANCE so dGPUs come
+// before iGPUs. dedupes by AdapterLuid and skips software adapters.
+// id is the index in the returned list, which is what DirectML's EP
+// takes as device_id
+static GList *_enum_directml_devices(void)
+{
+#ifndef _WIN32
+  return NULL;
+#else
+  IDXGIFactory6 *factory = NULL;
+  HRESULT hr = CreateDXGIFactory2(0, &IID_IDXGIFactory6, (void **)&factory);
+  if(FAILED(hr) || !factory) return NULL;
+
+  GList *result = NULL;
+  // track LUIDs we've already added (dedup against the multi-adapter
+  // double-listing quirk on some Windows versions)
+  GArray *seen_luids = g_array_new(FALSE, FALSE, sizeof(LUID));
+  int next_id = 0;
+  for(UINT i = 0; ; i++)
+  {
+    IDXGIAdapter1 *adapter = NULL;
+    if(FAILED(factory->lpVtbl->EnumAdapterByGpuPreference(
+         factory, i, DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE,
+         &IID_IDXGIAdapter1, (void **)&adapter)))
+      break;
+
+    DXGI_ADAPTER_DESC1 desc;
+    if(SUCCEEDED(adapter->lpVtbl->GetDesc1(adapter, &desc))
+       && (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE) == 0)
+    {
+      gboolean dup = FALSE;
+      for(guint k = 0; k < seen_luids->len; k++)
+      {
+        LUID *l = &g_array_index(seen_luids, LUID, k);
+        if(l->LowPart == desc.AdapterLuid.LowPart
+           && l->HighPart == desc.AdapterLuid.HighPart)
+        {
+          dup = TRUE;
+          break;
+        }
+      }
+      if(!dup)
+      {
+        g_array_append_val(seen_luids, desc.AdapterLuid);
+        gchar *name = g_utf16_to_utf8((const gunichar2 *)desc.Description,
+                                      -1, NULL, NULL, NULL);
+        dt_ai_device_t *d = g_new0(dt_ai_device_t, 1);
+        d->id = next_id++;
+        d->name = name ? name : g_strdup("DirectML adapter");
+        result = g_list_append(result, d);
+      }
+    }
+    adapter->lpVtbl->Release(adapter);
+  }
+  g_array_free(seen_luids, TRUE);
+  factory->lpVtbl->Release(factory);
+  return result;
+#endif
+}
+
+GList *dt_ai_enum_devices_for_provider(dt_ai_provider_t provider)
+{
+  switch(provider)
+  {
+    case DT_AI_PROVIDER_CUDA:     return _enum_cuda_devices();
+    case DT_AI_PROVIDER_MIGRAPHX: return _enum_migraphx_devices();
+    case DT_AI_PROVIDER_DIRECTML: return _enum_directml_devices();
+    // OpenVINO and CoreML self-manage their devices; AUTO/CPU don't apply
+    case DT_AI_PROVIDER_AUTO:
+    case DT_AI_PROVIDER_CPU:
+    case DT_AI_PROVIDER_COREML:
+    case DT_AI_PROVIDER_OPENVINO:
+    default:
+      return NULL;
+  }
 }
 
 int dt_ai_ort_probe_library_full(const char *path, char **out_version, char **out_eps)

--- a/src/ai/backend_onnx.c
+++ b/src/ai/backend_onnx.c
@@ -959,6 +959,25 @@ static gboolean _try_provider(OrtSessionOptions *session_opts,
   return ok;
 }
 
+// pick a GPU device_id: env var wins, then conf, fallback to 0.
+// each multi-GPU-capable EP has its own conf key + env var so users
+// switching between providers don't carry stale indices across vendors
+static int _device_id_from_conf(const char *conf_key, const char *env_var)
+{
+  const char *env_val = g_getenv(env_var);
+  if(env_val && env_val[0])
+  {
+    const int v = atoi(env_val);
+    return v >= 0 ? v : 0;
+  }
+  if(dt_conf_key_exists(conf_key))
+  {
+    const int v = dt_conf_get_int(conf_key);
+    return v >= 0 ? v : 0;
+  }
+  return 0;
+}
+
 static void
 _enable_acceleration(OrtSessionOptions *session_opts,
                      dt_ai_provider_t provider,
@@ -983,29 +1002,44 @@ _enable_acceleration(OrtSessionOptions *session_opts,
     break;
 
   case DT_AI_PROVIDER_CUDA:
-    _try_provider(session_opts, "OrtSessionOptionsAppendExecutionProvider_CUDA", "NVIDIA CUDA", NULL, 0);
+  {
+    const int dev = _device_id_from_conf("plugins/ai/cuda_device_id",
+                                         "DT_CUDA_DEVICE_ID");
+    _try_provider(session_opts, "OrtSessionOptionsAppendExecutionProvider_CUDA",
+                  "NVIDIA CUDA", NULL, (uint32_t)dev);
     break;
+  }
 
   case DT_AI_PROVIDER_MIGRAPHX:
+  {
     // MIGraphX reads its cache env vars once at provider library
     // load time, so they must be set before CreateEnv() — see
     // _setup_amd_caches() above. OpenVINO (below) takes options
     // per-session, so its cache path is passed inline here
-    if(!_try_provider(session_opts, "OrtSessionOptionsAppendExecutionProvider_MIGraphX", "AMD MIGraphX", NULL, 0))
-      _try_provider(session_opts, "OrtSessionOptionsAppendExecutionProvider_ROCM", "AMD ROCm (legacy)", NULL, 0);
+    const int dev = _device_id_from_conf("plugins/ai/migraphx_device_id",
+                                         "DT_MIGRAPHX_DEVICE_ID");
+    if(!_try_provider(session_opts, "OrtSessionOptionsAppendExecutionProvider_MIGraphX",
+                      "AMD MIGraphX", NULL, (uint32_t)dev))
+      _try_provider(session_opts, "OrtSessionOptionsAppendExecutionProvider_ROCM",
+                    "AMD ROCm (legacy)", NULL, (uint32_t)dev);
     break;
+  }
 
   case DT_AI_PROVIDER_OPENVINO:
     if(!_try_openvino_with_cache(session_opts))
-      _try_provider(session_opts, "OrtSessionOptionsAppendExecutionProvider_OpenVINO", "Intel OpenVINO", "AUTO", 0);
+      _try_provider(session_opts, "OrtSessionOptionsAppendExecutionProvider_OpenVINO",
+                    "Intel OpenVINO", "AUTO", 0);
     break;
 
   case DT_AI_PROVIDER_DIRECTML:
 #if defined(_WIN32)
-    _try_provider(
-      session_opts,
-      "OrtSessionOptionsAppendExecutionProvider_DML",
-      "Windows DirectML", NULL, 0);
+  {
+    const int dev = _device_id_from_conf("plugins/ai/dml_device_id",
+                                         "DT_DML_DEVICE_ID");
+    _try_provider(session_opts,
+                  "OrtSessionOptionsAppendExecutionProvider_DML",
+                  "Windows DirectML", NULL, (uint32_t)dev);
+  }
 #else
     dt_print(DT_DEBUG_AI, "[darktable_ai] windows DirectML not available on this platform");
 #endif
@@ -1020,25 +1054,34 @@ _enable_acceleration(OrtSessionOptions *session_opts,
       "OrtSessionOptionsAppendExecutionProvider_CoreML",
       "Apple CoreML", NULL, coreml_flags);
 #elif defined(_WIN32)
-    _try_provider(
-      session_opts,
-      "OrtSessionOptionsAppendExecutionProvider_DML",
-      "Windows DirectML", NULL, 0);
+    {
+      const int dev = _device_id_from_conf("plugins/ai/dml_device_id",
+                                           "DT_DML_DEVICE_ID");
+      _try_provider(session_opts,
+                    "OrtSessionOptionsAppendExecutionProvider_DML",
+                    "Windows DirectML", NULL, (uint32_t)dev);
+    }
 #elif defined(__linux__)
     // try CUDA first, then MIGraphX (cache configured at env init)
-    if(!_try_provider(
-         session_opts,
-         "OrtSessionOptionsAppendExecutionProvider_CUDA",
-         "NVIDIA CUDA", NULL, 0))
     {
+      const int cuda_dev = _device_id_from_conf("plugins/ai/cuda_device_id",
+                                                "DT_CUDA_DEVICE_ID");
+      const int amd_dev  = _device_id_from_conf("plugins/ai/migraphx_device_id",
+                                                "DT_MIGRAPHX_DEVICE_ID");
       if(!_try_provider(
            session_opts,
-           "OrtSessionOptionsAppendExecutionProvider_MIGraphX",
-           "AMD MIGraphX", NULL, 0))
-        _try_provider(
-          session_opts,
-          "OrtSessionOptionsAppendExecutionProvider_ROCM",
-          "AMD ROCm (legacy)", NULL, 0);
+           "OrtSessionOptionsAppendExecutionProvider_CUDA",
+           "NVIDIA CUDA", NULL, (uint32_t)cuda_dev))
+      {
+        if(!_try_provider(
+             session_opts,
+             "OrtSessionOptionsAppendExecutionProvider_MIGraphX",
+             "AMD MIGraphX", NULL, (uint32_t)amd_dev))
+          _try_provider(
+            session_opts,
+            "OrtSessionOptionsAppendExecutionProvider_ROCM",
+            "AMD ROCm (legacy)", NULL, (uint32_t)amd_dev);
+      }
     }
 #endif
     break;
@@ -1081,18 +1124,34 @@ int dt_ai_probe_provider(dt_ai_provider_t provider)
     ok = _try_provider(opts, "OrtSessionOptionsAppendExecutionProvider_CoreML", "Apple CoreML", NULL, 0);
     break;
   case DT_AI_PROVIDER_CUDA:
-    ok = _try_provider(opts, "OrtSessionOptionsAppendExecutionProvider_CUDA", "NVIDIA CUDA", NULL, 0);
+  {
+    const int dev = _device_id_from_conf("plugins/ai/cuda_device_id",
+                                         "DT_CUDA_DEVICE_ID");
+    ok = _try_provider(opts, "OrtSessionOptionsAppendExecutionProvider_CUDA",
+                       "NVIDIA CUDA", NULL, (uint32_t)dev);
     break;
+  }
   case DT_AI_PROVIDER_MIGRAPHX:
-    ok = _try_provider(opts, "OrtSessionOptionsAppendExecutionProvider_MIGraphX", "AMD MIGraphX", NULL, 0)
-      || _try_provider(opts, "OrtSessionOptionsAppendExecutionProvider_ROCM", "AMD ROCm (legacy)", NULL, 0);
+  {
+    const int dev = _device_id_from_conf("plugins/ai/migraphx_device_id",
+                                         "DT_MIGRAPHX_DEVICE_ID");
+    ok = _try_provider(opts, "OrtSessionOptionsAppendExecutionProvider_MIGraphX",
+                       "AMD MIGraphX", NULL, (uint32_t)dev)
+      || _try_provider(opts, "OrtSessionOptionsAppendExecutionProvider_ROCM",
+                       "AMD ROCm (legacy)", NULL, (uint32_t)dev);
     break;
+  }
   case DT_AI_PROVIDER_OPENVINO:
     ok = _try_provider(opts, "OrtSessionOptionsAppendExecutionProvider_OpenVINO", "Intel OpenVINO", "AUTO", 0);
     break;
   case DT_AI_PROVIDER_DIRECTML:
-    ok = _try_provider(opts, "OrtSessionOptionsAppendExecutionProvider_DML", "Windows DirectML", NULL, 0);
+  {
+    const int dev = _device_id_from_conf("plugins/ai/dml_device_id",
+                                         "DT_DML_DEVICE_ID");
+    ok = _try_provider(opts, "OrtSessionOptionsAppendExecutionProvider_DML",
+                       "Windows DirectML", NULL, (uint32_t)dev);
     break;
+  }
   default:
     break;
   }

--- a/src/ai/backend_onnx.c
+++ b/src/ai/backend_onnx.c
@@ -73,6 +73,14 @@ static GModule *g_ort_module = NULL;  // custom ORT library loaded via g_module_
 // page detect a path change mid-session (in-process ORT stale, restart
 // needed before GPU EP probes reflect the new library)
 static gchar *g_ort_conf_path_at_load = NULL;
+// snapshot of per-EP device_id at ORT load. -1 = "no value seen yet"
+// (e.g. provider not configured at startup); the change check then
+// compares against the current conf value
+static int g_loaded_cuda_device_id     = -1;
+static int g_loaded_migraphx_device_id = -1;
+static int g_loaded_dml_device_id      = -1;
+
+static int _device_id_from_conf(const char *conf_key, const char *env_var);
 
 #if defined(__linux__)
 // check that the CUDA driver supports the installed CUDA runtime version;
@@ -193,6 +201,34 @@ void dt_ai_device_free(gpointer device)
   dt_ai_device_t *d = (dt_ai_device_t *)device;
   g_free(d->name);
   g_free(d);
+}
+
+const char *dt_ai_device_conf_key_for_provider(dt_ai_provider_t provider)
+{
+  switch(provider)
+  {
+    case DT_AI_PROVIDER_CUDA:     return "plugins/ai/cuda_device_id";
+    case DT_AI_PROVIDER_MIGRAPHX: return "plugins/ai/migraphx_device_id";
+    case DT_AI_PROVIDER_DIRECTML: return "plugins/ai/dml_device_id";
+    default:                      return NULL;
+  }
+}
+
+gboolean dt_ai_device_id_changed_since_load(dt_ai_provider_t provider)
+{
+  const char *key = dt_ai_device_conf_key_for_provider(provider);
+  if(!key) return FALSE;
+  int loaded;
+  switch(provider)
+  {
+    case DT_AI_PROVIDER_CUDA:     loaded = g_loaded_cuda_device_id;     break;
+    case DT_AI_PROVIDER_MIGRAPHX: loaded = g_loaded_migraphx_device_id; break;
+    case DT_AI_PROVIDER_DIRECTML: loaded = g_loaded_dml_device_id;      break;
+    default:                      return FALSE;
+  }
+  if(loaded < 0) return FALSE;  // ORT not yet loaded
+  const int cur = dt_conf_key_exists(key) ? dt_conf_get_int(key) : 0;
+  return cur != loaded;
 }
 
 // shell out to a command and return its stdout. caller frees. NULL on failure
@@ -678,9 +714,16 @@ static gpointer _init_ort_api(gpointer data)
   // compile-time default; on Windows/macOS it dynamically loads a
   // user-supplied library instead of the bundled DirectML/CoreML one.
   gchar *ort_conf = dt_conf_get_string("plugins/ai/ort_library_path");
-  // snapshot for dt_ai_ort_path_changed_since_load()
+  // snapshot for dt_ai_ort_path_changed_since_load() and
+  // dt_ai_device_id_changed_since_load()
   g_free(g_ort_conf_path_at_load);
   g_ort_conf_path_at_load = g_strdup(ort_conf ? ort_conf : "");
+  g_loaded_cuda_device_id     = _device_id_from_conf("plugins/ai/cuda_device_id",
+                                                     "DT_CUDA_DEVICE_ID");
+  g_loaded_migraphx_device_id = _device_id_from_conf("plugins/ai/migraphx_device_id",
+                                                     "DT_MIGRAPHX_DEVICE_ID");
+  g_loaded_dml_device_id      = _device_id_from_conf("plugins/ai/dml_device_id",
+                                                     "DT_DML_DEVICE_ID");
   const char *ort_env = g_getenv("DT_ORT_LIBRARY");
   const char *ort_override = (ort_conf && ort_conf[0]) ? ort_conf
                            : (ort_env && ort_env[0]) ? ort_env

--- a/src/ai/backend_onnx.c
+++ b/src/ai/backend_onnx.c
@@ -54,6 +54,12 @@ struct dt_ai_context_t
   gboolean dynamic_outputs;
 };
 
+// minimum ORT API we'll fall back to when the runtime library is older
+// than what we were compiled against. v14 = ORT 1.14, the first release
+// with ONNX opset 18 support — older ORT can't run our models. bump
+// this in lockstep with any model that requires a newer opset
+#define DT_ORT_MIN_API_VERSION 14
+
 // global singletons (initialized exactly once via g_once)
 // ORT requires at most one OrtEnv per process.
 static const OrtApi *g_ort = NULL;
@@ -61,6 +67,10 @@ static GOnce g_ort_once = G_ONCE_INIT;
 static OrtEnv *g_env = NULL;
 static GOnce g_env_once = G_ONCE_INIT;
 static GModule *g_ort_module = NULL;  // custom ORT library loaded via g_module_open
+// snapshot of plugins/ai/ort_library_path at ORT load — lets the prefs
+// page detect a path change mid-session (in-process ORT stale, restart
+// needed before GPU EP probes reflect the new library)
+static gchar *g_ort_conf_path_at_load = NULL;
 
 #if defined(__linux__)
 // check that the CUDA driver supports the installed CUDA runtime version;
@@ -164,6 +174,17 @@ char *dt_ai_ort_probe_library(const char *path)
 
 // Probe a library and return version + comma-separated list of supported EPs.
 // Both out params are caller-owned (g_free). Returns FALSE if not a valid ORT.
+// FALSE before ORT is loaded (no comparison reference yet)
+gboolean dt_ai_ort_path_changed_since_load(void)
+{
+  if(!g_ort_conf_path_at_load) return FALSE;
+  gchar *cur = dt_conf_get_string("plugins/ai/ort_library_path");
+  const gboolean changed
+    = g_strcmp0(cur ? cur : "", g_ort_conf_path_at_load) != 0;
+  g_free(cur);
+  return changed;
+}
+
 int dt_ai_ort_probe_library_full(const char *path, char **out_version, char **out_eps)
 {
   if(!path || !path[0]) return FALSE;
@@ -187,27 +208,82 @@ int dt_ai_ort_probe_library_full(const char *path, char **out_version, char **ou
 
   if(out_eps)
   {
-    // check for known EP registration symbols
-    static const struct { const char *symbol; const char *name; } ep_table[] = {
-      { "OrtSessionOptionsAppendExecutionProvider_CUDA",     "CUDA" },
-      { "OrtSessionOptionsAppendExecutionProvider_MIGraphX", "MIGraphX" },
-      { "OrtSessionOptionsAppendExecutionProvider_ROCM",     "ROCm" },
-      { "OrtSessionOptionsAppendExecutionProvider_OpenVINO", "OpenVINO" },
-      { "OrtSessionOptionsAppendExecutionProvider_Dml",      "DirectML" },
-      { "OrtSessionOptionsAppendExecutionProvider_CoreML",   "CoreML" },
-      { NULL, NULL }
-    };
-
     GString *eps = g_string_new(NULL);
-    gpointer sym;
-    for(int i = 0; ep_table[i].symbol; i++)
+
+    // preferred path: ask the OrtApi for the list of providers compiled into
+    // the library; this is the only reliable method for ROCm/MIGraphX, since
+    // AMD's official builds do not export the legacy C shim symbols
+    // (OrtSessionOptionsAppendExecutionProvider_ROCM, _MIGraphX) — ROCm is
+    // only reachable through the OrtApi struct
+    const OrtApi *probe_api = base->GetApi(ORT_API_VERSION);
+    if(!probe_api)
     {
-      if(g_module_symbol(mod, ep_table[i].symbol, &sym) && sym)
+      for(int v = ORT_API_VERSION - 1;
+          v >= DT_ORT_MIN_API_VERSION && !probe_api; v--)
+        probe_api = base->GetApi(v);
+    }
+    if(probe_api && probe_api->GetAvailableProviders)
+    {
+      char **providers = NULL;
+      int n_providers = 0;
+      if(probe_api->GetAvailableProviders(&providers, &n_providers) == NULL && providers)
       {
-        if(eps->len > 0) g_string_append(eps, ", ");
-        g_string_append(eps, ep_table[i].name);
+        // map ORT provider names to short labels
+        static const struct { const char *ort_name; const char *label; } map[] = {
+          { "CUDAExecutionProvider",     "CUDA" },
+          { "MIGraphXExecutionProvider", "MIGraphX" },
+          { "ROCMExecutionProvider",     "ROCm" },
+          { "OpenVINOExecutionProvider", "OpenVINO" },
+          { "DmlExecutionProvider",      "DirectML" },
+          { "CoreMLExecutionProvider",   "CoreML" },
+          { "TensorrtExecutionProvider", "TensorRT" },
+          { NULL, NULL }
+        };
+        for(int i = 0; i < n_providers; i++)
+        {
+          const char *label = NULL;
+          for(int j = 0; map[j].ort_name; j++)
+          {
+            if(g_strcmp0(providers[i], map[j].ort_name) == 0)
+            {
+              label = map[j].label;
+              break;
+            }
+          }
+          // skip CPU here; added below if nothing else matched
+          if(!label || g_strcmp0(providers[i], "CPUExecutionProvider") == 0) continue;
+          if(eps->len > 0) g_string_append(eps, ", ");
+          g_string_append(eps, label);
+        }
+        if(probe_api->ReleaseAvailableProviders)
+          probe_api->ReleaseAvailableProviders(providers, n_providers);
       }
     }
+
+    // fallback: legacy C-shim symbol probing for very old ORT builds where
+    // GetAvailableProviders is unavailable
+    if(eps->len == 0)
+    {
+      static const struct { const char *symbol; const char *name; } ep_table[] = {
+        { "OrtSessionOptionsAppendExecutionProvider_CUDA",     "CUDA" },
+        { "OrtSessionOptionsAppendExecutionProvider_MIGraphX", "MIGraphX" },
+        { "OrtSessionOptionsAppendExecutionProvider_ROCM",     "ROCm" },
+        { "OrtSessionOptionsAppendExecutionProvider_OpenVINO", "OpenVINO" },
+        { "OrtSessionOptionsAppendExecutionProvider_Dml",      "DirectML" },
+        { "OrtSessionOptionsAppendExecutionProvider_CoreML",   "CoreML" },
+        { NULL, NULL }
+      };
+      gpointer sym;
+      for(int i = 0; ep_table[i].symbol; i++)
+      {
+        if(g_module_symbol(mod, ep_table[i].symbol, &sym) && sym)
+        {
+          if(eps->len > 0) g_string_append(eps, ", ");
+          g_string_append(eps, ep_table[i].name);
+        }
+      }
+    }
+
     if(eps->len == 0) g_string_append(eps, "CPU");
     *out_eps = g_string_free(eps, FALSE);
   }
@@ -387,7 +463,7 @@ static const OrtApi *_ort_api_from_module(GModule *mod, const char *label)
   if(!api)
   {
     // minimum API version 14 = ORT 1.14, required for ONNX opset 18
-    for(int v = ORT_API_VERSION - 1; v >= 14; v--)
+    for(int v = ORT_API_VERSION - 1; v >= DT_ORT_MIN_API_VERSION; v--)
     {
       api = base->GetApi(v);
       if(api)
@@ -417,6 +493,9 @@ static gpointer _init_ort_api(gpointer data)
   // compile-time default; on Windows/macOS it dynamically loads a
   // user-supplied library instead of the bundled DirectML/CoreML one.
   gchar *ort_conf = dt_conf_get_string("plugins/ai/ort_library_path");
+  // snapshot for dt_ai_ort_path_changed_since_load()
+  g_free(g_ort_conf_path_at_load);
+  g_ort_conf_path_at_load = g_strdup(ort_conf ? ort_conf : "");
   const char *ort_env = g_getenv("DT_ORT_LIBRARY");
   const char *ort_override = (ort_conf && ort_conf[0]) ? ort_conf
                            : (ort_env && ort_env[0]) ? ort_env

--- a/src/common/ai_models.c
+++ b/src/common/ai_models.c
@@ -17,6 +17,7 @@
 */
 
 #include "common/ai_models.h"
+#include "ai/backend.h"
 #include "common/darktable.h"
 #include "common/curl_tools.h"
 #include "common/file_location.h"
@@ -452,6 +453,10 @@ dt_ai_registry_t *dt_ai_models_init(void)
 
   if(registry->ai_enabled)
     _setup_registry(registry);
+
+  // capture conf snapshot so *_changed_since_load() helpers reference
+  // the startup state, not a value modified by user before first ORT use
+  dt_ai_snapshot_conf_state();
 
   return registry;
 }

--- a/src/common/usermanual_url.c
+++ b/src/common/usermanual_url.c
@@ -98,6 +98,7 @@ dt_help_url urls_db[] =
   {"gamut",                      "module-reference/utility-modules/darkroom/gamut/"},
   {"shortcuts",                  "preferences-settings/shortcuts/"},
   {"presets",                    "preferences-settings/presets/"},
+  {"ai",                         "preferences-settings/ai/"},
   {"css_tweaks",                 "preferences-settings/general/#css-theme-modifications"},
   {"preset_dialog",              "darkroom/processing-modules/presets/#creating-and-editing-presets"},
 

--- a/src/gui/preferences_ai.c
+++ b/src/gui/preferences_ai.c
@@ -532,10 +532,10 @@ static void _update_provider_status(dt_prefs_ai_data_t *data, dt_ai_provider_t p
     return;
   }
 
-  // path or device_id changed mid-session: in-process EP session is
-  // bound to the loaded library + device. show "restart to apply" for
-  // GPU EPs (AUTO/CPU always work)
+  // long-lived sessions (e.g. SAM2 encoder) are bound to the EP they
+  // were loaded with; show "restart to apply" for GPU EPs
   if((dt_ai_ort_path_changed_since_load()
+      || dt_ai_provider_changed_since_load()
       || dt_ai_device_id_changed_since_load(provider))
      && provider != DT_AI_PROVIDER_AUTO && provider != DT_AI_PROVIDER_CPU)
   {

--- a/src/gui/preferences_ai.c
+++ b/src/gui/preferences_ai.c
@@ -299,17 +299,18 @@ static void _on_enable_toggled(GtkWidget *widget, gpointer user_data)
                            "plugins/ai/enabled");
 }
 
-static int _provider_to_combo_idx(dt_ai_provider_t provider, guint supported);
+static int _provider_to_combo_idx(const dt_ai_provider_t provider,
+                                  const guint supported);
 static void _on_provider_changed(GtkWidget *widget, gpointer user_data);
 static void _update_provider_status(dt_prefs_ai_data_t *data,
-                                    dt_ai_provider_t provider);
+                                    const dt_ai_provider_t provider);
 static void _on_gpu_changed(GtkWidget *widget, gpointer user_data);
 static void _refresh_gpu_combo(dt_prefs_ai_data_t *data);
 
 // a provider is visible in the combo iff it is compiled in AND the
 // currently-loaded ORT library advertises it (or it's a builtin like
 // AUTO / CPU)
-static gboolean _provider_visible(int i, guint supported)
+static gboolean _provider_visible(const int i, const guint supported)
 {
   return dt_ai_providers[i].available
          && (supported & (1u << dt_ai_providers[i].value));
@@ -494,7 +495,7 @@ static void _on_gpu_changed(GtkWidget *widget, gpointer user_data)
 }
 
 // map combo box index to provider table index (skipping unavailable providers)
-static int _combo_idx_to_provider(int combo_idx, guint supported)
+static int _combo_idx_to_provider(const int combo_idx, const guint supported)
 {
   int visible = -1;
   for(int i = 0; i < DT_AI_PROVIDER_COUNT; i++)
@@ -507,7 +508,8 @@ static int _combo_idx_to_provider(int combo_idx, guint supported)
 }
 
 // map provider enum value to combo box index
-static int _provider_to_combo_idx(dt_ai_provider_t provider, guint supported)
+static int _provider_to_combo_idx(const dt_ai_provider_t provider,
+                                  const guint supported)
 {
   int visible = -1;
   for(int i = 0; i < DT_AI_PROVIDER_COUNT; i++)
@@ -520,7 +522,8 @@ static int _provider_to_combo_idx(dt_ai_provider_t provider, guint supported)
   return 0;  // fallback to first visible (AUTO)
 }
 
-static void _update_provider_status(dt_prefs_ai_data_t *data, dt_ai_provider_t provider)
+static void _update_provider_status(dt_prefs_ai_data_t *data,
+                                    const dt_ai_provider_t provider)
 {
   if(!data->provider_status) return;
 

--- a/src/gui/preferences_ai.c
+++ b/src/gui/preferences_ai.c
@@ -1763,6 +1763,12 @@ void init_tab_ai(GtkWidget *dialog, GtkWidget *stack)
     data);
   dt_gui_box_add(button_box, data->delete_selected_btn);
 
+  // help button (right-anchored, matches other prefs tabs)
+  GtkWidget *help_btn = gtk_button_new_with_label(_("?"));
+  gtk_widget_set_tooltip_text(help_btn, _("open help page for AI settings"));
+  dt_gui_add_help_link(help_btn, "ai");
+  g_signal_connect(help_btn, "clicked", G_CALLBACK(dt_gui_show_help), NULL);
+  gtk_box_pack_end(GTK_BOX(button_box), help_btn, FALSE, FALSE, 0);
 
   dt_gui_box_add(data->controls_box, models_grid);
 

--- a/src/gui/preferences_ai.c
+++ b/src/gui/preferences_ai.c
@@ -85,6 +85,7 @@ typedef struct dt_prefs_ai_data_t
   GtkWidget *enable_toggle;
   GtkWidget *enable_indicator;
   GtkWidget *provider_combo;
+  GtkWidget *gpu_combo;
   GtkWidget *provider_indicator;
   GtkWidget *provider_status;
   GtkWidget *model_list;
@@ -302,6 +303,8 @@ static int _provider_to_combo_idx(dt_ai_provider_t provider, guint supported);
 static void _on_provider_changed(GtkWidget *widget, gpointer user_data);
 static void _update_provider_status(dt_prefs_ai_data_t *data,
                                     dt_ai_provider_t provider);
+static void _on_gpu_changed(GtkWidget *widget, gpointer user_data);
+static void _refresh_gpu_combo(dt_prefs_ai_data_t *data);
 
 // a provider is visible in the combo iff it is compiled in AND the
 // currently-loaded ORT library advertises it (or it's a builtin like
@@ -417,6 +420,77 @@ static void _refresh_provider_combo(dt_prefs_ai_data_t *data)
   // EP. the value-changed signal was blocked during the rebuild, so
   // _on_provider_changed didn't fire
   _update_provider_status(data, selected);
+
+  // and the per-EP GPU device combo (visible only when 2+ devices)
+  _refresh_gpu_combo(data);
+}
+
+// rebuild the GPU device combo for the currently-selected EP. only
+// visible when the EP supports per-device selection AND >=2 devices
+// are enumerable (single-device or unsupported EPs leave the combo
+// hidden — AUTO/CPU naturally fall here too)
+static void _refresh_gpu_combo(dt_prefs_ai_data_t *data)
+{
+  if(!data->gpu_combo) return;
+
+  // resolve current EP from conf (matches what the rest of the UI uses)
+  gchar *prov_str = dt_conf_get_string(DT_AI_CONF_PROVIDER);
+  const dt_ai_provider_t prov = dt_ai_provider_from_string(prov_str);
+  g_free(prov_str);
+
+  GList *devices = dt_ai_enum_devices_for_provider(prov);
+  const guint count = g_list_length(devices);
+  const char *conf_key = dt_ai_device_conf_key_for_provider(prov);
+
+  if(count < 2 || !conf_key)
+  {
+    gtk_widget_hide(data->gpu_combo);
+    g_list_free_full(devices, dt_ai_device_free);
+    return;
+  }
+
+  // populate without firing _on_gpu_changed
+  g_signal_handlers_block_by_func(data->gpu_combo, _on_gpu_changed, data);
+  dt_bauhaus_combobox_clear(data->gpu_combo);
+  const int saved = dt_conf_key_exists(conf_key) ? dt_conf_get_int(conf_key) : 0;
+  int sel_idx = 0, i = 0;
+  for(GList *l = devices; l; l = g_list_next(l), i++)
+  {
+    const dt_ai_device_t *d = (const dt_ai_device_t *)l->data;
+    dt_bauhaus_combobox_add(data->gpu_combo, d->name);
+    if(d->id == saved) sel_idx = i;
+  }
+  dt_bauhaus_combobox_set(data->gpu_combo, sel_idx);
+  g_signal_handlers_unblock_by_func(data->gpu_combo, _on_gpu_changed, data);
+
+  gtk_widget_show(data->gpu_combo);
+  gtk_widget_queue_resize(data->gpu_combo);
+  g_list_free_full(devices, dt_ai_device_free);
+}
+
+static void _on_gpu_changed(GtkWidget *widget, gpointer user_data)
+{
+  dt_prefs_ai_data_t *data = (dt_prefs_ai_data_t *)user_data;
+  const int combo_idx = dt_bauhaus_combobox_get(widget);
+  if(combo_idx < 0) return;
+
+  gchar *prov_str = dt_conf_get_string(DT_AI_CONF_PROVIDER);
+  const dt_ai_provider_t prov = dt_ai_provider_from_string(prov_str);
+  g_free(prov_str);
+
+  const char *conf_key = dt_ai_device_conf_key_for_provider(prov);
+  if(!conf_key) return;
+
+  // re-enumerate to get the device id at this combo position. cheap
+  // (shell-out caches in OS pagecache, ~1 ms after first call)
+  GList *devices = dt_ai_enum_devices_for_provider(prov);
+  const dt_ai_device_t *d = g_list_nth_data(devices, combo_idx);
+  if(d) dt_conf_set_int(conf_key, d->id);
+  g_list_free_full(devices, dt_ai_device_free);
+
+  // refresh the status — selecting a different GPU mid-session means
+  // restart needed (current EP session is bound to the old device)
+  _update_provider_status(data, prov);
 }
 
 // map combo box index to provider table index (skipping unavailable providers)
@@ -458,9 +532,11 @@ static void _update_provider_status(dt_prefs_ai_data_t *data, dt_ai_provider_t p
     return;
   }
 
-  // path changed mid-session: probing the now-stale ORT would mislead.
-  // show "restart to apply" for GPU EPs (AUTO/CPU always work)
-  if(dt_ai_ort_path_changed_since_load()
+  // path or device_id changed mid-session: in-process EP session is
+  // bound to the loaded library + device. show "restart to apply" for
+  // GPU EPs (AUTO/CPU always work)
+  if((dt_ai_ort_path_changed_since_load()
+      || dt_ai_device_id_changed_since_load(provider))
      && provider != DT_AI_PROVIDER_AUTO && provider != DT_AI_PROVIDER_CPU)
   {
     gtk_label_set_markup(GTK_LABEL(data->provider_status),
@@ -1436,7 +1512,7 @@ void init_tab_ai(GtkWidget *dialog, GtkWidget *stack)
   const gboolean ai_on = dt_conf_get_bool("plugins/ai/enabled");
 
   // provider dropdown
-  GtkWidget *provider_label = gtk_label_new(_("execution provider"));
+  GtkWidget *provider_label = gtk_label_new(_("AI acceleration"));
   gtk_widget_set_halign(provider_label, GTK_ALIGN_START);
   GtkWidget *provider_labelev = gtk_event_box_new();
   gtk_widget_add_events(provider_labelev, GDK_BUTTON_PRESS_MASK);
@@ -1445,6 +1521,10 @@ void init_tab_ai(GtkWidget *dialog, GtkWidget *stack)
 
   data->provider_indicator = _create_indicator(DT_AI_CONF_PROVIDER);
   data->provider_combo = dt_bauhaus_combobox_new(NULL);
+  data->gpu_combo      = dt_bauhaus_combobox_new(NULL);
+  gtk_widget_set_tooltip_text(data->gpu_combo,
+                              _("select which GPU to use when the active provider"
+                                " supports more than one"));
 
   // connect signals before the first refresh — the refresh blocks the
   // value-changed handler while it repopulates, so we need it attached
@@ -1456,20 +1536,26 @@ void init_tab_ai(GtkWidget *dialog, GtkWidget *stack)
                    "button-press-event",
                    G_CALLBACK(_reset_provider_click),
                    data);
+  g_signal_connect(data->gpu_combo, "value-changed",
+                   G_CALLBACK(_on_gpu_changed), data);
 
   // filter the combo to what the currently-configured ORT advertises
   char *ort_path = dt_conf_get_string("plugins/ai/ort_library_path");
   data->supported_providers = _compute_supported_providers(ort_path);
   g_free(ort_path);
-  _refresh_provider_combo(data);
+  _refresh_provider_combo(data);  // will also refresh gpu_combo
   data->provider_status = gtk_label_new(NULL);
   gtk_label_set_use_markup(GTK_LABEL(data->provider_status), TRUE);
   gtk_widget_set_halign(data->provider_status, GTK_ALIGN_START);
   gtk_widget_set_margin_start(data->provider_status, DT_PIXEL_APPLY_DPI(8));
 
-  // put combo + status in an hbox so the combo doesn't stretch
+  // put combo + gpu + status in an hbox so the combo doesn't stretch
   // when column 2 expands for the ORT path entry below
-  GtkWidget *provider_hbox = dt_gui_hbox(data->provider_combo, data->provider_status);
+  GtkWidget *provider_hbox = dt_gui_hbox(data->provider_combo,
+                                         data->gpu_combo,
+                                         data->provider_status);
+  // gpu_combo is hidden by default; _refresh_gpu_combo shows it if applicable
+  gtk_widget_set_no_show_all(data->gpu_combo, TRUE);
 
   gtk_grid_attach(GTK_GRID(settings_grid), provider_labelev, 0, row, 1, 1);
   gtk_grid_attach(GTK_GRID(settings_grid), data->provider_indicator, 1, row, 1, 1);

--- a/src/gui/preferences_ai.c
+++ b/src/gui/preferences_ai.c
@@ -1554,12 +1554,16 @@ void init_tab_ai(GtkWidget *dialog, GtkWidget *stack)
   GtkWidget *provider_hbox = dt_gui_hbox(data->provider_combo,
                                          data->gpu_combo,
                                          data->provider_status);
+  // small gap between provider_combo and gpu_combo
+  gtk_widget_set_margin_start(data->gpu_combo, DT_PIXEL_APPLY_DPI(8));
   // gpu_combo is hidden by default; _refresh_gpu_combo shows it if applicable
   gtk_widget_set_no_show_all(data->gpu_combo, TRUE);
 
   gtk_grid_attach(GTK_GRID(settings_grid), provider_labelev, 0, row, 1, 1);
   gtk_grid_attach(GTK_GRID(settings_grid), data->provider_indicator, 1, row, 1, 1);
-  gtk_grid_attach(GTK_GRID(settings_grid), provider_hbox, 2, row++, 3, 1);
+  // span only cols 2-3 (matching path_entry below) so col 4 stays sized
+  // by the button box and doesn't steal width when gpu_combo appears
+  gtk_grid_attach(GTK_GRID(settings_grid), provider_hbox, 2, row++, 2, 1);
 
   // ORT library path — not shown on macOS where ORT is statically linked with CoreML.
   // Developers can still use DT_ORT_LIBRARY env var to override on macOS

--- a/src/gui/preferences_ai.c
+++ b/src/gui/preferences_ai.c
@@ -104,6 +104,7 @@ typedef struct dt_prefs_ai_data_t
   GtkWidget *ort_path_indicator;
   GtkWidget *settings_grid;
   int controls_start_row;   // first row to grey out when AI disabled
+  guint supported_providers;
 } dt_prefs_ai_data_t;
 
 #ifdef HAVE_AI_DOWNLOAD
@@ -297,13 +298,134 @@ static void _on_enable_toggled(GtkWidget *widget, gpointer user_data)
                            "plugins/ai/enabled");
 }
 
+static int _provider_to_combo_idx(dt_ai_provider_t provider, guint supported);
+static void _on_provider_changed(GtkWidget *widget, gpointer user_data);
+static void _update_provider_status(dt_prefs_ai_data_t *data,
+                                    dt_ai_provider_t provider);
+
+// a provider is visible in the combo iff it is compiled in AND the
+// currently-loaded ORT library advertises it (or it's a builtin like
+// AUTO / CPU)
+static gboolean _provider_visible(int i, guint supported)
+{
+  return dt_ai_providers[i].available
+         && (supported & (1u << dt_ai_providers[i].value));
+}
+
+// probe the ORT library at `path` (NULL/empty = use the bundled mask)
+// and return a bitmask of dt_ai_provider_t values it advertises;
+// falls back to the bundled mask when the probe fails, so the combo
+// only offers providers we can reasonably expect to work
+static guint _compute_supported_providers(const char *path)
+{
+  if(path && path[0])
+  {
+    char *eps = NULL;
+    if(dt_ai_ort_probe_library_full(path, NULL, &eps) && eps)
+    {
+      const guint mask = dt_ai_providers_from_eps(eps);
+      g_free(eps);
+      return mask;
+    }
+    g_free(eps);
+  }
+  return dt_ai_providers_bundled();
+}
+
+// rebuild the provider combo to reflect data->supported_providers;
+// intermediate states don't fire _on_provider_changed.
+// SIDE EFFECT: writes DT_AI_CONF_PROVIDER if the resolved selection
+// differs from the saved value (e.g. when an old GPU EP isn't in the
+// new library and we auto-fall-back to another GPU EP) so the on-disk
+// config stays consistent with what the user sees in the combo
+static void _refresh_provider_combo(dt_prefs_ai_data_t *data)
+{
+  if(!data->provider_combo) return;
+  g_signal_handlers_block_by_func(data->provider_combo,
+                                  _on_provider_changed, data);
+  gchar *cfg = dt_conf_get_string("plugins/ai/provider");
+  const dt_ai_provider_t prev = dt_ai_provider_from_string(cfg);
+  g_free(cfg);
+
+  dt_bauhaus_combobox_clear(data->provider_combo);
+  GString *tooltip =
+    g_string_new(_("select hardware acceleration for AI inference:"));
+  for(int i = 0; i < DT_AI_PROVIDER_COUNT; i++)
+  {
+    if(!_provider_visible(i, data->supported_providers)) continue;
+    const char *label = dt_ai_providers[i].value == DT_AI_PROVIDER_AUTO
+                          ? _("auto") : dt_ai_providers[i].display_name;
+    dt_bauhaus_combobox_add(data->provider_combo, label);
+    g_string_append_printf(tooltip, "\n- %s", dt_ai_providers[i].display_name);
+  }
+  gtk_widget_set_tooltip_text(data->provider_combo, tooltip->str);
+  g_string_free(tooltip, TRUE);
+
+  // bauhaus sizes the combo to fit the longest entry at allocation
+  // time; after clear/repopulate the cached layout would keep the old
+  // width, so force GTK to re-request natural size
+  gtk_widget_queue_resize(data->provider_combo);
+
+  // resolve the new selection:
+  //   1. keep prev if it's still in supported_providers (covers AUTO/CPU
+  //      always, and the same GPU EP across same-vendor library swaps)
+  //   2. if prev was a GPU EP and isn't supported any more, pick the
+  //      first visible GPU EP — switching CUDA→ROCm libraries should
+  //      land on ROCm rather than dropping the user back to AUTO/CPU
+  //   3. otherwise fall back to AUTO
+  dt_ai_provider_t selected = DT_AI_PROVIDER_AUTO;
+  if(data->supported_providers & (1u << prev))
+  {
+    selected = prev;
+  }
+  else if(prev != DT_AI_PROVIDER_AUTO && prev != DT_AI_PROVIDER_CPU)
+  {
+    // previous was a specific GPU EP that's gone — find another GPU EP
+    for(int i = 0; i < DT_AI_PROVIDER_COUNT; i++)
+    {
+      if(!_provider_visible(i, data->supported_providers)) continue;
+      const dt_ai_provider_t v = dt_ai_providers[i].value;
+      if(v == DT_AI_PROVIDER_AUTO || v == DT_AI_PROVIDER_CPU) continue;
+      selected = v;
+      break;
+    }
+  }
+  dt_bauhaus_combobox_set(data->provider_combo,
+                          _provider_to_combo_idx(selected,
+                                                 data->supported_providers));
+
+  // persist the resolved selection so a subsequent close-without-change
+  // doesn't leave a stale provider in the config (e.g. CUDA still saved
+  // after the user switched to a ROCm-only library)
+  if(selected != prev)
+  {
+    for(int i = 0; i < DT_AI_PROVIDER_COUNT; i++)
+    {
+      if(dt_ai_providers[i].value == selected)
+      {
+        dt_conf_set_string(DT_AI_CONF_PROVIDER,
+                           dt_ai_providers[i].config_string);
+        break;
+      }
+    }
+  }
+
+  g_signal_handlers_unblock_by_func(data->provider_combo,
+                                    _on_provider_changed, data);
+
+  // runtime-probe the selection so the status label reflects the new
+  // EP. the value-changed signal was blocked during the rebuild, so
+  // _on_provider_changed didn't fire
+  _update_provider_status(data, selected);
+}
+
 // map combo box index to provider table index (skipping unavailable providers)
-static int _combo_idx_to_provider(int combo_idx)
+static int _combo_idx_to_provider(int combo_idx, guint supported)
 {
   int visible = -1;
   for(int i = 0; i < DT_AI_PROVIDER_COUNT; i++)
   {
-    if(!dt_ai_providers[i].available) continue;
+    if(!_provider_visible(i, supported)) continue;
     if(++visible == combo_idx)
       return i;
   }
@@ -311,12 +433,12 @@ static int _combo_idx_to_provider(int combo_idx)
 }
 
 // map provider enum value to combo box index
-static int _provider_to_combo_idx(dt_ai_provider_t provider)
+static int _provider_to_combo_idx(dt_ai_provider_t provider, guint supported)
 {
   int visible = -1;
   for(int i = 0; i < DT_AI_PROVIDER_COUNT; i++)
   {
-    if(!dt_ai_providers[i].available) continue;
+    if(!_provider_visible(i, supported)) continue;
     visible++;
     if(dt_ai_providers[i].value == provider)
       return visible;
@@ -336,6 +458,16 @@ static void _update_provider_status(dt_prefs_ai_data_t *data, dt_ai_provider_t p
     return;
   }
 
+  // path changed mid-session: probing the now-stale ORT would mislead.
+  // show "restart to apply" for GPU EPs (AUTO/CPU always work)
+  if(dt_ai_ort_path_changed_since_load()
+     && provider != DT_AI_PROVIDER_AUTO && provider != DT_AI_PROVIDER_CPU)
+  {
+    gtk_label_set_markup(GTK_LABEL(data->provider_status),
+                         _("<i>restart to apply</i>"));
+    return;
+  }
+
   if(provider == DT_AI_PROVIDER_AUTO || provider == DT_AI_PROVIDER_CPU
      || dt_ai_probe_provider(provider))
   {
@@ -351,7 +483,7 @@ static void _on_provider_changed(GtkWidget *widget, gpointer user_data)
 {
   dt_prefs_ai_data_t *data = (dt_prefs_ai_data_t *)user_data;
   const int combo_idx = dt_bauhaus_combobox_get(widget);
-  const int pi = _combo_idx_to_provider(combo_idx);
+  const int pi = _combo_idx_to_provider(combo_idx, data->supported_providers);
   dt_conf_set_string(DT_AI_CONF_PROVIDER, dt_ai_providers[pi].config_string);
   if(darktable.ai_registry)
   {
@@ -378,13 +510,16 @@ _reset_enable_click(GtkWidget *label, GdkEventButton *event, GtkWidget *widget)
 
 // double-click on label resets the provider combo to default
 static gboolean
-_reset_provider_click(GtkWidget *label, GdkEventButton *event, GtkWidget *widget)
+_reset_provider_click(GtkWidget *label, GdkEventButton *event, gpointer user_data)
 {
   if(event->type == GDK_2BUTTON_PRESS)
   {
+    dt_prefs_ai_data_t *data = (dt_prefs_ai_data_t *)user_data;
     const char *def = dt_confgen_get(DT_AI_CONF_PROVIDER, DT_DEFAULT);
     dt_ai_provider_t provider = dt_ai_provider_from_string(def);
-    dt_bauhaus_combobox_set(widget, _provider_to_combo_idx(provider));
+    dt_bauhaus_combobox_set(data->provider_combo,
+                            _provider_to_combo_idx(provider,
+                                                   data->supported_providers));
     return TRUE;
   }
   return FALSE;
@@ -1063,6 +1198,17 @@ static void _show_ort_probe_result(GtkWindow *parent, const char *path, const ch
   gtk_widget_destroy(dlg);
 }
 
+// commit a new ORT library path: update conf + indicator and refresh
+// the provider combo to reflect the new library's advertised EPs
+static void _set_ort_path(dt_prefs_ai_data_t *data, const char *path)
+{
+  dt_conf_set_string("plugins/ai/ort_library_path", path ? path : "");
+  _update_string_indicator(data->ort_path_indicator,
+                           "plugins/ai/ort_library_path");
+  data->supported_providers = _compute_supported_providers(path);
+  _refresh_provider_combo(data);
+}
+
 static void _on_detect_system_ort(GtkButton *button, gpointer user_data)
 {
   dt_prefs_ai_data_t *data = (dt_prefs_ai_data_t *)user_data;
@@ -1085,8 +1231,7 @@ static void _on_detect_system_ort(GtkButton *button, gpointer user_data)
   {
     dt_ai_ort_found_t *f = found->data;
     gtk_entry_set_text(GTK_ENTRY(data->ort_path_entry), f->path);
-    dt_conf_set_string("plugins/ai/ort_library_path", f->path);
-    _update_string_indicator(data->ort_path_indicator, "plugins/ai/ort_library_path");
+    _set_ort_path(data, f->path);
     GtkWidget *dlg = gtk_message_dialog_new(
       GTK_WINDOW(data->parent_dialog),
       GTK_DIALOG_MODAL | GTK_DIALOG_DESTROY_WITH_PARENT,
@@ -1133,8 +1278,7 @@ static void _on_detect_system_ort(GtkButton *button, gpointer user_data)
       {
         dt_ai_ort_found_t *f = g_list_nth_data(found, sel);
         gtk_entry_set_text(GTK_ENTRY(data->ort_path_entry), f->path);
-        dt_conf_set_string("plugins/ai/ort_library_path", f->path);
-        _update_string_indicator(data->ort_path_indicator, "plugins/ai/ort_library_path");
+        _set_ort_path(data, f->path);
       }
     }
     gtk_widget_destroy(dlg);
@@ -1148,8 +1292,7 @@ static gboolean _reset_ort_path_click(GtkWidget *w, GdkEventButton *e, gpointer 
   if(e->type != GDK_2BUTTON_PRESS) return FALSE;
   dt_prefs_ai_data_t *data = (dt_prefs_ai_data_t *)user_data;
   gtk_entry_set_text(GTK_ENTRY(data->ort_path_entry), "");
-  dt_conf_set_string("plugins/ai/ort_library_path", "");
-  _update_string_indicator(data->ort_path_indicator, "plugins/ai/ort_library_path");
+  _set_ort_path(data, "");
   return TRUE;
 }
 static void _on_ort_path_changed(GtkEntry *entry, gpointer user_data)
@@ -1160,8 +1303,7 @@ static void _on_ort_path_changed(GtkEntry *entry, gpointer user_data)
   // empty = reset to bundled
   if(!text || !text[0])
   {
-    dt_conf_set_string("plugins/ai/ort_library_path", "");
-    _update_string_indicator(data->ort_path_indicator, "plugins/ai/ort_library_path");
+    _set_ort_path(data, "");
     return;
   }
 
@@ -1176,8 +1318,7 @@ static void _on_ort_path_changed(GtkEntry *entry, gpointer user_data)
     return;
   }
 
-  dt_conf_set_string("plugins/ai/ort_library_path", text);
-  _update_string_indicator(data->ort_path_indicator, "plugins/ai/ort_library_path");
+  _set_ort_path(data, text);
   g_free(version);
 }
 
@@ -1231,8 +1372,7 @@ static void _on_ort_browse_clicked(GtkButton *button, gpointer user_data)
     if(version)
     {
       gtk_entry_set_text(GTK_ENTRY(data->ort_path_entry), filename);
-      dt_conf_set_string("plugins/ai/ort_library_path", filename);
-      _update_string_indicator(data->ort_path_indicator, "plugins/ai/ort_library_path");
+      _set_ort_path(data, filename);
       g_free(version);
     }
     g_free(filename);
@@ -1306,38 +1446,26 @@ void init_tab_ai(GtkWidget *dialog, GtkWidget *stack)
   data->provider_indicator = _create_indicator(DT_AI_CONF_PROVIDER);
   data->provider_combo = dt_bauhaus_combobox_new(NULL);
 
-  // populate from central provider table, skipping unavailable providers
-  GString *tooltip = g_string_new(_("select hardware acceleration for AI inference:"));
-  for(int i = 0; i < DT_AI_PROVIDER_COUNT; i++)
-  {
-    if(!dt_ai_providers[i].available) continue;
-    if(dt_ai_providers[i].value == DT_AI_PROVIDER_AUTO)
-      dt_bauhaus_combobox_add(data->provider_combo, _("auto"));
-    else
-      dt_bauhaus_combobox_add(data->provider_combo, dt_ai_providers[i].display_name);
-    g_string_append_printf(tooltip, "\n- %s", dt_ai_providers[i].display_name);
-  }
+  // connect signals before the first refresh — the refresh blocks the
+  // value-changed handler while it repopulates, so we need it attached
+  g_signal_connect(data->provider_combo,
+                   "value-changed",
+                   G_CALLBACK(_on_provider_changed),
+                   data);
+  g_signal_connect(provider_labelev,
+                   "button-press-event",
+                   G_CALLBACK(_reset_provider_click),
+                   data);
 
-  char *provider_str = dt_conf_get_string(DT_AI_CONF_PROVIDER);
-  dt_ai_provider_t provider = dt_ai_provider_from_string(provider_str);
-  g_free(provider_str);
-  dt_bauhaus_combobox_set(data->provider_combo, _provider_to_combo_idx(provider));
-
-  g_signal_connect(
-    data->provider_combo,
-    "value-changed",
-    G_CALLBACK(_on_provider_changed),
-    data);
-  g_signal_connect(
-    provider_labelev,
-    "button-press-event",
-    G_CALLBACK(_reset_provider_click),
-    data->provider_combo);
-  gtk_widget_set_tooltip_text(data->provider_combo, tooltip->str);
-  g_string_free(tooltip, TRUE);
+  // filter the combo to what the currently-configured ORT advertises
+  char *ort_path = dt_conf_get_string("plugins/ai/ort_library_path");
+  data->supported_providers = _compute_supported_providers(ort_path);
+  g_free(ort_path);
+  _refresh_provider_combo(data);
   data->provider_status = gtk_label_new(NULL);
   gtk_label_set_use_markup(GTK_LABEL(data->provider_status), TRUE);
   gtk_widget_set_halign(data->provider_status, GTK_ALIGN_START);
+  gtk_widget_set_margin_start(data->provider_status, DT_PIXEL_APPLY_DPI(8));
 
   // put combo + status in an hbox so the combo doesn't stretch
   // when column 2 expands for the ORT path entry below


### PR DESCRIPTION
Multi-GPU systems can now choose which GPU runs AI inference, and the AI preferences combo only shows execution providers actually supported by the loaded ONNX Runtime library.

## Changes

### EP filtering (informational)

The execution-provider combo on the AI tab is now filtered to the EPs the currently loaded ORT library actually advertises (via ORT's `GetAvailableProviders` API). Selecting a provider the bundled ORT doesn't ship (e.g. CUDA on a default Windows install) used to silently fall back to CPU; it now isn't offered in the first place. Switching the ORT library path triggers a re-probe and refreshes the combo.

### GPU device selection

For execution providers that support multiple devices (CUDA, MIGraphX, DirectML), users can now pick which device to use. Previously hardcoded to device 0.

- New conf keys: `plugins/ai/cuda_device_id`, `plugins/ai/migraphx_device_id`, `plugins/ai/dml_device_id` (plus matching `DT_*_DEVICE_ID` env vars)
- New device-enumeration API `dt_ai_enum_devices_for_provider()`:
  - **CUDA**: parses `nvidia-smi --query-gpu=index,name,memory.total`
  - **MIGraphX**: parses `rocminfo` agent list to count GPU agents
  - **DirectML**: enumerates DXGI 1.6 adapters with HIGH_PERFORMANCE preference, dedupes by AdapterLuid, skips software adapters
- A second combo appears next to the EP combo when the active provider enumerates more than one device; it auto-hides for single-GPU systems and EPs that self-manage devices (OpenVINO, CoreML)
- The chosen device_id is passed as the `flags` argument to `OrtSessionOptionsAppendExecutionProvider_*` for integer-argument EPs
- The startup log now shows which device the EP was bound to:

  ```
  [darktable_ai] Windows DirectML enabled successfully on device 1: AMD Radeon 780M Graphics
  ```

### Restart-required indicator

A change to the ORT library path, the configured provider, or the device_id (for any GPU EP) shows an inline "restart to apply" hint next to the provider combo. Existing long-lived sessions (e.g. the SAM2 encoder in object mask) are bound to the EP they were loaded with; the user only sees consistent behaviour after restart.

### Misc

- Help button in the AI preferences tab linking to the user manual

## Notes

- The "restart to apply" message is informative, not enforced – running with mismatched device after change just produces inconsistent behaviour (some sessions on old device, some on new) until restart, no crash
- OpenVINO multi-device selection (e.g. `"GPU.0"` vs `"GPU.1"` on systems with multiple Intel GPUs) is not implemented in this PR – the EP is still passed `"AUTO"`.