### PR TITLE
[AI] Add OOM retry to raw denoise preview paths and extract shared step-down helper

### DIFF
--- a/src/common/ai/restore.c
+++ b/src/common/ai/restore.c
@@ -791,6 +791,23 @@ gboolean dt_restore_reload_session(dt_restore_context_t *ctx,
   return _reload_session(ctx, new_tile_size);
 }
 
+gboolean dt_restore_step_down_tile_size(dt_restore_context_t *ctx,
+                                        int *T_inout)
+{
+  if(!ctx || !T_inout) return FALSE;
+  int next_T = 0;
+  for(int i = 0; i < ctx->n_tile_ladder; i++)
+    if(ctx->tile_ladder[i] < *T_inout)
+    {
+      next_T = ctx->tile_ladder[i];
+      break;
+    }
+  if(next_T <= 0 || !_reload_session(ctx, next_T))
+    return FALSE;
+  *T_inout = next_T;
+  return TRUE;
+}
+
 void dt_restore_persist_tile_size(const dt_restore_context_t *ctx)
 {
   if(ctx && ctx->model_id)

--- a/src/common/ai/restore.h
+++ b/src/common/ai/restore.h
@@ -322,6 +322,29 @@ int dt_restore_get_tile_size(const dt_restore_context_t *ctx);
 gboolean dt_restore_reload_session(dt_restore_context_t *ctx,
                                    int new_tile_size);
 
+// @brief step the loaded session down to the next smaller tile size
+//
+// shared OOM-retry helper used by all batch and preview pipelines.
+// looks up the next-smaller entry in ctx->tile_ladder and calls
+// dt_restore_reload_session. on success updates *T_inout in place
+// and returns TRUE; on failure (no smaller size or reload failed)
+// leaves *T_inout untouched and returns FALSE.
+//
+// emits no log output — callers own observability so they can phrase
+// the message with their own state (e.g. tile coordinates, pre/post
+// T value). callers are also expected to free per-tile buffers and
+// propagate the inference error.
+//
+// not thread-safe: mutates ctx->ai_ctx and ctx->tile_size. callers
+// must not invoke this on a ctx shared with another thread that may
+// be running inference.
+//
+// @param ctx loaded restore context
+// @param T_inout current tile size; replaced with the new one on success
+// @return TRUE if the session was successfully recreated at a smaller T
+gboolean dt_restore_step_down_tile_size(dt_restore_context_t *ctx,
+                                        int *T_inout);
+
 // @brief persist the current tile size to darktablerc
 //
 // once the bayer pipeline has processed an image end-to-end at

--- a/src/common/ai/restore_raw_bayer.c
+++ b/src/common/ai/restore_raw_bayer.c
@@ -347,8 +347,6 @@ int dt_restore_raw_bayer(dt_restore_context_t *ctx,
   // tile setup in packed (half-res) space
   const int O = OVERLAP_PACKED;
   int T = dt_restore_get_tile_size(ctx);
-  int n_ladder = 0;
-  const int *ladder = dt_restore_get_tile_ladder(ctx, &n_ladder);
   if(T <= 2 * O) T = 256;  // defensive fallback
 
 retry:;
@@ -485,21 +483,16 @@ retry:;
       {
         // step down the ladder if possible. first tile only so we
         // don't rewrite pixels we've already delivered
-        int next_T = 0;
-        for(int i = 0; i < n_ladder; i++)
-          if(ladder[i] < T) { next_T = ladder[i]; break; }
-        if(next_T > 0 && ty == 0 && tx == 0
-           && dt_restore_reload_session(ctx, next_T))
+        if(ty == 0 && tx == 0 && dt_restore_step_down_tile_size(ctx, &T))
         {
           dt_print(DT_DEBUG_AI,
-                   "[restore_raw_bayer] inference failed at T=%d, retrying T=%d",
-                   T, next_T);
+                   "[restore_raw_bayer] tile %d,%d failed, retrying at T=%d",
+                   tx, ty, T);
           g_free(tile_in);
           g_free(tile_out);
           g_free(h_strip_top);
           g_free(h_strip_bot);
           g_free(v_strip_left);
-          T = next_T;
           goto retry;
         }
         dt_print(DT_DEBUG_AI,
@@ -780,31 +773,50 @@ int dt_restore_raw_bayer_preview_piped(dt_restore_context_t *ctx,
   const uint32_t filters = prep.filters;
   const float    clip_max = prep.clip_max;
 
-  const int T = dt_restore_get_tile_size(ctx);
-  if(T <= 0) return 1;
-  const int sensor_T = 2 * T;
-  const int max_disp = sensor_T - 4 * OVERLAP_PACKED;
-  if(crop_w > max_disp || crop_h > max_disp) return 1;
-
-  // snap crop to CFA grid
+  // snap crop to CFA grid (T-independent, do once)
   crop_x = (crop_x / 2) * 2;
   crop_y = (crop_y / 2) * 2;
   crop_w = (crop_w / 2) * 2;
   crop_h = (crop_h / 2) * 2;
   if(crop_w <= 0 || crop_h <= 0) return 1;
 
+  // OOM-retry loop: on inference failure step down the model's tile
+  // ladder and rebuild the single-tile geometry + packed tile. mirrors
+  // the batch path's recovery, scoped to one tile (no row_writer to
+  // rewind, no ty/tx==0 guard needed)
+  int T = dt_restore_get_tile_size(ctx);
+  if(T <= 0) return 1;
+
+  float *tile_in = NULL;
+  float *tile_out = NULL;
+  int sensor_T = 0;
+  int pp_sr0 = 0, pp_sc0 = 0;
+  size_t tile_out_w = 0;
+  size_t tile_out_plane = 0;
+
+retry:;
+  sensor_T = 2 * T;
+  const int max_disp = sensor_T - 4 * OVERLAP_PACKED;
+  if(crop_w > max_disp || crop_h > max_disp)
+  {
+    g_free(tile_in);
+    g_free(tile_out);
+    return 1;
+  }
+
   int inf_x = crop_x + crop_w / 2 - sensor_T / 2;
   int inf_y = crop_y + crop_h / 2 - sensor_T / 2;
   inf_x = (inf_x / 2) * 2;
   inf_y = (inf_y / 2) * 2;
 
-  // inference (single tile)
   const size_t tile_in_plane = (size_t)T * T;
-  const size_t tile_out_w = 2 * (size_t)T;
-  const size_t tile_out_plane = tile_out_w * tile_out_w;
+  tile_out_w = 2 * (size_t)T;
+  tile_out_plane = tile_out_w * tile_out_w;
 
-  float *tile_in = g_try_malloc(tile_in_plane * 4 * sizeof(float));
-  float *tile_out = g_try_malloc(tile_out_plane * 3 * sizeof(float));
+  g_free(tile_in);
+  g_free(tile_out);
+  tile_in = g_try_malloc(tile_in_plane * 4 * sizeof(float));
+  tile_out = g_try_malloc(tile_out_plane * 3 * sizeof(float));
   if(!tile_in || !tile_out)
   {
     g_free(tile_in);
@@ -815,7 +827,7 @@ int dt_restore_raw_bayer_preview_piped(dt_restore_context_t *ctx,
   // geometry applies the same orientation + mirror policy as the batch
   // path. sr0_base / sc0_base for the preview is the user-centred,
   // even-snapped inference tile origin in sensor coords
-  int pp_sr0, pp_sc0, pp_mir_y_lo, pp_mir_y_hi, pp_mir_x_lo, pp_mir_x_hi;
+  int pp_mir_y_lo, pp_mir_y_hi, pp_mir_x_lo, pp_mir_x_hi;
   _bayer_tile_geometry(ctx, &prep, inf_y, inf_x, width, height,
                        &pp_sr0, &pp_sc0,
                        &pp_mir_y_lo, &pp_mir_y_hi,
@@ -827,6 +839,14 @@ int dt_restore_raw_bayer_preview_piped(dt_restore_context_t *ctx,
 
   if(dt_restore_run_patch_bayer(ctx, tile_in, T, T, tile_out) != 0)
   {
+    if(dt_restore_step_down_tile_size(ctx, &T))
+    {
+      dt_print(DT_DEBUG_AI,
+               "[restore_raw_bayer] preview failed, retrying at T=%d", T);
+      goto retry;
+    }
+    dt_print(DT_DEBUG_AI,
+             "[restore_raw_bayer] preview inference failed at T=%d", T);
     g_free(tile_in);
     g_free(tile_out);
     return 1;

--- a/src/common/ai/restore_raw_linear.c
+++ b/src/common/ai/restore_raw_linear.c
@@ -507,8 +507,6 @@ int dt_restore_raw_linear(dt_restore_context_t *ctx,
   // tile setup
   const int O = OVERLAP_LINEAR;
   int T = dt_restore_get_tile_size(ctx);
-  int n_ladder = 0;
-  const int *ladder = dt_restore_get_tile_ladder(ctx, &n_ladder);
   if(T <= 2 * O) T = 256;
 
 retry:;
@@ -602,26 +600,21 @@ retry:;
       // inference
       if(dt_restore_run_patch_3ch_raw(ctx, tile_in, T, T, tile_out) != 0)
       {
-        int next_T = 0;
-        for(int i = 0; i < n_ladder; i++)
-          if(ladder[i] < T) { next_T = ladder[i]; break; }
-        if(next_T > 0 && ty == 0 && tx == 0
-           && dt_restore_reload_session(ctx, next_T))
+        if(ty == 0 && tx == 0 && dt_restore_step_down_tile_size(ctx, &T))
         {
           dt_print(DT_DEBUG_AI,
-                   "[restore_raw_linear] inference failed at T=%d, retry T=%d",
-                   T, next_T);
+                   "[restore_raw_linear] tile %d,%d failed, retrying at T=%d",
+                   tx, ty, T);
           g_free(tile_in);
           g_free(tile_out);
           g_free(h_strip_top);
           g_free(h_strip_bot);
           g_free(v_strip_left);
-          T = next_T;
           goto retry;
         }
         dt_print(DT_DEBUG_AI,
-                 "[restore_raw_linear] inference failed at tile %d,%d "
-                 "(T=%d)", tx, ty, T);
+                 "[restore_raw_linear] inference failed at tile %d,%d (T=%d)",
+                 tx, ty, T);
         res = 1;
         break;
       }
@@ -973,14 +966,6 @@ int dt_restore_raw_linear_preview_piped(dt_restore_context_t *ctx,
 
   if(width <= 0 || height <= 0 || crop_w <= 0 || crop_h <= 0) return 1;
 
-  const int T = dt_restore_get_tile_size(ctx);
-  if(T <= 0) return 1;
-  const int max_disp = T - 2 * OVERLAP_LINEAR;
-  if(crop_w > max_disp || crop_h > max_disp) return 1;
-
-  int inf_x = crop_x + crop_w / 2 - T / 2;
-  int inf_y = crop_y + crop_h / 2 - T / 2;
-
   // WB + matrix prep (same as dt_restore_raw_linear_prepare /
   // dt_restore_raw_linear_preview — but we also need the REVERSE
   // transforms to go back to camRGB raw for pipe input)
@@ -1001,11 +986,39 @@ int dt_restore_raw_linear_preview_piped(dt_restore_context_t *ctx,
       cam_to_input[i] = input_to_cam[i] = (i % 4 == 0) ? 1.0f : 0.0f;
   }
 
+  // OOM-retry loop: on inference failure step down the model's tile
+  // ladder and rebuild the single-tile geometry. mirrors the batch
+  // path's recovery, scoped to one tile (no row_writer to rewind)
+  int T = dt_restore_get_tile_size(ctx);
+  if(T <= 0) return 1;
+
+  float *tile_in = NULL;
+  float *tile_out = NULL;
+  int inf_x = 0, inf_y = 0;
+  size_t tile_plane = 0;
+  float exposure_boost = 1.0f;
+
+retry:;
+  {
+    const int max_disp = T - 2 * OVERLAP_LINEAR;
+    if(crop_w > max_disp || crop_h > max_disp)
+    {
+      g_free(tile_in);
+      g_free(tile_out);
+      return 1;
+    }
+  }
+
+  inf_x = crop_x + crop_w / 2 - T / 2;
+  inf_y = crop_y + crop_h / 2 - T / 2;
+
   // extract crop + overlap from cached full lin_rec2020 -> tile_in
   // apply exposure boost (same as preview), run inference
-  const size_t tile_plane = (size_t)T * T;
-  float *tile_in = g_try_malloc(tile_plane * 3 * sizeof(float));
-  float *tile_out = g_try_malloc(tile_plane * 3 * sizeof(float));
+  tile_plane = (size_t)T * T;
+  g_free(tile_in);
+  g_free(tile_out);
+  tile_in = g_try_malloc(tile_plane * 3 * sizeof(float));
+  tile_out = g_try_malloc(tile_plane * 3 * sizeof(float));
   if(!tile_in || !tile_out)
   {
     g_free(tile_in);
@@ -1027,11 +1040,19 @@ int dt_restore_raw_linear_preview_piped(dt_restore_context_t *ctx,
     }
   }
 
-  float exposure_boost = 1.0f;
+  exposure_boost = 1.0f;
   _linear_exposure_boost(ctx, tile_in, tile_plane, NULL, &exposure_boost);
 
   if(dt_restore_run_patch_3ch_raw(ctx, tile_in, T, T, tile_out) != 0)
   {
+    if(dt_restore_step_down_tile_size(ctx, &T))
+    {
+      dt_print(DT_DEBUG_AI,
+               "[restore_raw_linear] preview failed, retrying at T=%d", T);
+      goto retry;
+    }
+    dt_print(DT_DEBUG_AI,
+             "[restore_raw_linear] preview inference failed at T=%d", T);
     g_free(tile_in);
     g_free(tile_out);
     return 1;

--- a/src/common/ai/restore_rgb.c
+++ b/src/common/ai/restore_rgb.c
@@ -542,10 +542,6 @@ int dt_restore_process_tiled(dt_restore_context_t *ctx,
   const int O = dt_restore_get_overlap(scale);
   const int S = scale;
   const int out_w = width * S;
-  // ladder was resolved at load time (either model's input_sizes or
-  // the built-in default for this scale) and travels with the context
-  const int *ladder = ctx->tile_ladder;
-  const int n_ladder = ctx->n_tile_ladder;
   int T = ctx->tile_size;
 
   // outer retry loop: on inference failure (e.g. GPU OOM) drop to the
@@ -659,28 +655,20 @@ retry:;
       {
         // retry with the next smaller ladder entry if no rows have
         // been delivered yet (safe to restart). once rows are written
-        // we can't rewind the row_writer (e.g. TIFF is sequential).
-        // _reload_session() recreates the ORT session for the smaller
-        // tile size (dim overrides are shape-specific).
-        int next_T = 0;
-        for(int i = 0; i < n_ladder; i++)
-          if(ladder[i] < T) { next_T = ladder[i]; break; }
-        if(next_T > 0 && ty == 0
-           && dt_restore_reload_session(ctx, next_T))
+        // we can't rewind the row_writer (e.g. TIFF is sequential)
+        if(ty == 0 && dt_restore_step_down_tile_size(ctx, &T))
         {
           dt_print(DT_DEBUG_AI,
-                   "[restore_rgb] inference failed at tile %d,%d "
-                   "(T=%d), retrying with T=%d",
-                   x, y, T, next_T);
+                   "[restore_rgb] tile %d,%d failed, retrying at T=%d",
+                   tx, ty, T);
           g_free(tile_in);
           g_free(tile_out);
           g_free(row_buf);
-          T = next_T;
           goto retry;
         }
         dt_print(DT_DEBUG_AI,
-                 "[restore_rgb] inference failed at"
-                 " tile %d,%d (T=%d, minimum reached)", x, y, T);
+                 "[restore_rgb] inference failed at tile %d,%d (T=%d)",
+                 tx, ty, T);
         res = 1;
         goto cleanup;
       }


### PR DESCRIPTION
The raw bayer and raw linear **preview** paths called `dt_restore_run_patch_*` directly with no fallback — when CUDA/CoreML OOM'd at the picked tile size, the preview returned `err=1` and rendered black. The RGB preview already worked because it goes through `dt_restore_process_tiled`, which has the retry loop. The raw previews bypass it.

This PR closes the gap and consolidates the retry pattern.

- **Add OOM retry to both raw preview paths.** [`dt_restore_raw_bayer_preview_piped`](src/common/ai/restore_raw_bayer.c) and [`dt_restore_raw_linear_preview_piped`](src/common/ai/restore_raw_linear.c) now wrap their geometry + alloc + pack + inference in a `retry:` block and step down the model's tile ladder on failure. Single-tile so no `ty/tx==0` guard is needed.

- **Extract `dt_restore_step_down_tile_size` helper.** Path-agnostic next-T lookup + session reload, shared by all 5 callsites (3 batch + 2 preview). Helper is pure logic — no logging, no tile awareness — so callers own their observability and can include tile coordinates / pre-post T in their own messages. Documented as not thread-safe (mutates `ctx->ai_ctx` and `ctx->tile_size`); the deeper concurrent-inference fix lives in the planned ai backend refactor.

- **Restore mid-stream failure logs.** Previously each batch path logged `inference failed at tile X,Y (T=N)` on non-recoverable failures. The earlier helper-with-internal-logging design lost the tile coordinates; now each callsite emits both the retry message (with tile coords + new T) and the final failure message (with tile coords + final T) — no duplication.