### PR TITLE
[GUI] Latitude is not the best term for linear region of the curve

### DIFF
--- a/src/iop/filmic.c
+++ b/src/iop/filmic.c
@@ -1533,7 +1533,7 @@ void gui_init(dt_iop_module_t *self)
   // latitude slider
   g->latitude_stops = dt_bauhaus_slider_new_with_range(self, 0.01, 16.0, 0, p->latitude_stops, 3);
   dt_bauhaus_slider_set_soft_range(g->latitude_stops, 2, 8.0);
-  dt_bauhaus_widget_set_label(g->latitude_stops, NULL, NC_("curve-linear-part-width", "latitude"));
+  dt_bauhaus_widget_set_label(g->latitude_stops, NULL, N_("linear region"));
   dt_bauhaus_slider_set_format(g->latitude_stops, _(" EV"));
   gtk_widget_set_tooltip_text(g->latitude_stops,
                               _("width of the linear domain in the middle of the curve.\n"

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -179,7 +179,7 @@ typedef struct dt_iop_filmicrgb_params_t
   float black_point_target; // $MIN: 0.000 $MAX: 20.000 $DEFAULT: 0.01517634 $DESCRIPTION: "target black luminance"
   float white_point_target; // $MIN: 0 $MAX: 1600 $DEFAULT: 100 $DESCRIPTION: "target white luminance"
   float output_power;       // $MIN: 1 $MAX: 10 $DEFAULT: 4.0 $DESCRIPTION: "hardness"
-  float latitude;           // $MIN: 0.01 $MAX: 99 $DEFAULT: 0.01
+  float latitude;           // $MIN: 0.01 $MAX: 99 $DEFAULT: 0.01 $DESCRIPTION: "linear region"
   float contrast;           // $MIN: 0 $MAX: 5 $DEFAULT: 1.0
   float saturation;         // $MIN: -200 $MAX: 200 $DEFAULT: 0 $DESCRIPTION: "extreme luminance saturation"
   float balance;            // $MIN: -50 $MAX: 50 $DEFAULT: 0.0 $DESCRIPTION: "shadows ↔ highlights balance"
@@ -4510,7 +4510,7 @@ void gui_init(dt_iop_module_t *self)
                                 "increase to make highlights brighter and less compressed.\n"
                                 "decrease to mute highlights."));
 
-  g->latitude = dt_bauhaus_slider_from_params(self, NC_("curve-linear-part-width", "latitude"));
+  g->latitude = dt_bauhaus_slider_from_params(self, "latitude");
   dt_bauhaus_slider_set_soft_range(g->latitude, 0.1, 90.0);
   dt_bauhaus_slider_set_format(g->latitude, "%");
   gtk_widget_set_tooltip_text(g->latitude,


### PR DESCRIPTION
Sorry, I should have checked what effect the changes in #20880 would have. The change seemed so trivial that I didn't. But the problem is that changing the parameter name in `dt_bauhaus_slider_from_params` breaks the introspective connection of this widget with the corresponding parameter. :-(

So, first of all, this PR fixes the introduced breakage. But the problem remains that the word "latitude" has primarily a geographical meaning. Accordingly, in translations there can be terms that have only this meaning. In fact, this is the case at least in the Czech translation, where the translation "`zeměpisná šírka`" literally means "`geographic latitude`". So the current Czech translation of the slider in Filmic RGB looks extremely surprising.

I started to research whether "latitude" is really a common term for the linear part of a curve. I didn't find anything like that, it seems more like it's a name invented by the module author. The only thing that comes to mind when the word latitude is used in a photographic context is ["exposure latitude"](https://en.wikipedia.org/wiki/Exposure_latitude)which is a completely different concept and is another reason why "latitude" in the context of a curve is a poor name choice.

This PR changes the name of the slider from "latitude" to "linear region" which is a common term, short enough for a label in the GUI and completely self-explanatory without having to guess the meaning.
