### PR TITLE
[AI] DNG writer: emit missing metadata for spec-conformant output

### DIFF
--- a/src/common/ai/restore_raw_bayer.c
+++ b/src/common/ai/restore_raw_bayer.c
@@ -20,6 +20,7 @@
 #include "common/ai/restore.h"
 #include "common/ai/restore_common.h"
 #include "common/colorspaces.h"
+#include "common/colorspaces_inline_conversions.h"
 #include "common/darktable.h"
 #include "common/image.h"
 #include "common/image_cache.h"
@@ -79,14 +80,13 @@ typedef struct _bayer_prep_t
 // writes R/B multipliers with G=1 into wb[0..2] and returns TRUE
 static gboolean _bayer_wb_daylight(const dt_image_t *img, float wb[3])
 {
-  const float D65[3] = { 0.9504f, 1.0f, 1.0889f };
   float resp[3] = { 0.0f, 0.0f, 0.0f };
   float mag = 0.0f;
   for(int c = 0; c < 3; c++)
   {
-    resp[c] = img->adobe_XYZ_to_CAM[c][0] * D65[0]
-            + img->adobe_XYZ_to_CAM[c][1] * D65[1]
-            + img->adobe_XYZ_to_CAM[c][2] * D65[2];
+    resp[c] = img->adobe_XYZ_to_CAM[c][0] * d65_white_xyz[0]
+            + img->adobe_XYZ_to_CAM[c][1] * d65_white_xyz[1]
+            + img->adobe_XYZ_to_CAM[c][2] * d65_white_xyz[2];
     mag += fabsf(img->adobe_XYZ_to_CAM[c][0])
          + fabsf(img->adobe_XYZ_to_CAM[c][1])
          + fabsf(img->adobe_XYZ_to_CAM[c][2]);

--- a/src/common/ai/restore_raw_linear.c
+++ b/src/common/ai/restore_raw_linear.c
@@ -22,6 +22,7 @@
 #include "common/darktable.h"
 #include "common/image.h"
 #include "common/image_cache.h"
+#include "common/colorspaces_inline_conversions.h"
 #include "common/iop_order.h"
 #include "common/math.h"
 #include "common/matrices.h"
@@ -47,14 +48,13 @@
 // returns TRUE when a usable matrix is available
 static gboolean _daylight_wb(const dt_image_t *img, float wb_norm[3])
 {
-  const float D65[3] = { 0.9504f, 1.0f, 1.0889f };
   float resp[3];
   float mag = 0.0f;
   for(int c = 0; c < 3; c++)
   {
-    resp[c] = img->adobe_XYZ_to_CAM[c][0] * D65[0]
-            + img->adobe_XYZ_to_CAM[c][1] * D65[1]
-            + img->adobe_XYZ_to_CAM[c][2] * D65[2];
+    resp[c] = img->adobe_XYZ_to_CAM[c][0] * d65_white_xyz[0]
+            + img->adobe_XYZ_to_CAM[c][1] * d65_white_xyz[1]
+            + img->adobe_XYZ_to_CAM[c][2] * d65_white_xyz[2];
     mag += fabsf(img->adobe_XYZ_to_CAM[c][0])
          + fabsf(img->adobe_XYZ_to_CAM[c][1])
          + fabsf(img->adobe_XYZ_to_CAM[c][2]);
@@ -184,34 +184,10 @@ static void _resolve_linear_wb(const dt_restore_context_t *ctx,
   // DT_RESTORE_WB_NONE: leave at {1, 1, 1}
 }
 
-// D65 XYZ -> linear Rec.2020 (ITU-R BT.2020), row-major 3x3.
-// matches the lin_rec2020 color profile the RawNIND linear variant
-// was trained on
-static const float _xyz_to_rec2020[9] = {
-   1.7166511880f, -0.3556707838f, -0.2533662814f,
-  -0.6666843518f,  1.6164812366f,  0.0157685458f,
-   0.0176398574f, -0.0427706133f,  0.9421031212f,
-};
-
-static const float _rec2020_to_xyz[9] = {
-  0.6369580483f, 0.1446169036f, 0.1688809752f,
-  0.2627002120f, 0.6779980715f, 0.0593017165f,
-  0.0000000000f, 0.0280726930f, 1.0609850577f,
-};
-
-// D65 XYZ -> linear sRGB / Rec.709 (IEC 61966-2-1), row-major 3x3.
-// used when a variant declares input_colorspace: srgb_linear
-static const float _xyz_to_srgb[9] = {
-   3.2404542f, -1.5371385f, -0.4985314f,
-  -0.9692660f,  1.8760108f,  0.0415560f,
-   0.0556434f, -0.2040259f,  1.0572252f,
-};
-
-static const float _srgb_to_xyz[9] = {
-  0.4124564f, 0.3575761f, 0.1804375f,
-  0.2126729f, 0.7151522f, 0.0721750f,
-  0.0193339f, 0.1191920f, 0.9503041f,
-};
+// XYZ-D65 <-> linear sRGB / Rec.2020 matrices live in
+// colorspaces_inline_conversions.h. Rec.2020 is the lin_rec2020 color
+// profile the RawNIND linear variant was trained on; sRGB is the
+// alternate input space for the srgb_linear variant
 
 // build the per-image camRGB<->input-space matrices, where input-space
 // is chosen by ctx->input_colorspace:
@@ -253,9 +229,9 @@ static gboolean _build_cam_matrices(const dt_restore_context_t *ctx,
     return FALSE;
 
   const float *xyz_to_input = (cs == DT_RESTORE_CS_SRGB_LINEAR)
-    ? _xyz_to_srgb : _xyz_to_rec2020;
+    ? xyz_to_srgb_d65 : xyz_to_rec2020_d65;
   const float *input_to_xyz = (cs == DT_RESTORE_CS_SRGB_LINEAR)
-    ? _srgb_to_xyz : _rec2020_to_xyz;
+    ? srgb_to_xyz_d65 : rec2020_to_xyz_d65;
 
   mat3mul(cam_to_input, xyz_to_input, xyz_from_cam);
   mat3mul(input_to_cam, cam_from_xyz, input_to_xyz);

--- a/src/common/colorspaces_inline_conversions.h
+++ b/src/common/colorspaces_inline_conversions.h
@@ -468,6 +468,38 @@ static inline float dt_prophotorgb_to_XYZ_luma(const dt_aligned_pixel_t rgb)
           + prophotorgb_to_xyz_transpose[2][1] * rgb[2]);
 }
 
+// CIE D65 illuminant tristimulus (Y normalized to 1)
+static const float d65_white_xyz[3] = { 0.9504f, 1.0f, 1.0889f };
+
+// D65 XYZ <-> linear RGB matrices, row-major 3x3 (plain float[9]).
+// Distinct from the D50 Bradford-adapted dt_colormatrix_t variants
+// below, which are pre-transposed for SIMD-friendly multiplication.
+// Used by raw_restore_linear's input-space build and by the DNG
+// writer's ColorMatrix1 fallback (paired with CalibrationIlluminant1=D65)
+static const float xyz_to_srgb_d65[9] = {
+   3.2404542f, -1.5371385f, -0.4985314f,
+  -0.9692660f,  1.8760108f,  0.0415560f,
+   0.0556434f, -0.2040259f,  1.0572252f,
+};
+
+static const float srgb_to_xyz_d65[9] = {
+  0.4124564f, 0.3575761f, 0.1804375f,
+  0.2126729f, 0.7151522f, 0.0721750f,
+  0.0193339f, 0.1191920f, 0.9503041f,
+};
+
+static const float xyz_to_rec2020_d65[9] = {
+   1.7166511880f, -0.3556707838f, -0.2533662814f,
+  -0.6666843518f,  1.6164812366f,  0.0157685458f,
+   0.0176398574f, -0.0427706133f,  0.9421031212f,
+};
+
+static const float rec2020_to_xyz_d65[9] = {
+  0.6369580483f, 0.1446169036f, 0.1688809752f,
+  0.2627002120f, 0.6779980715f, 0.0593017165f,
+  0.0000000000f, 0.0280726930f, 1.0609850577f,
+};
+
 // Conversion matrix from http://www.brucelindbloom.com/Eqn_RGB_XYZ_Matrix.html
 // (transpose and pad the conversion matrix to enable vectorization)
 static const dt_colormatrix_t sRGB_to_xyz_transposed =

--- a/src/imageio/imageio_dng.c
+++ b/src/imageio/imageio_dng.c
@@ -71,6 +71,19 @@ static void _install_dng_tiff_handlers(void)
   TIFFSetErrorHandler(_dt_dng_tiff_error);
 }
 
+// libtiff has built-in field info for most DNG tags but not all —
+// register the ones we need that aren't pre-registered. PreviewColorSpace
+// (50970) is required for spec-conformant DNG previews
+static void _register_extra_dng_fields(TIFF *tif)
+{
+  static const TIFFFieldInfo extra[] = {
+    { TIFFTAG_PREVIEWCOLORSPACE, 1, 1, TIFF_LONG, FIELD_CUSTOM,
+      TRUE /* okToChange */, FALSE /* passCount */,
+      (char *)"PreviewColorSpace" },
+  };
+  TIFFMergeFieldInfo(tif, extra, sizeof(extra) / sizeof(extra[0]));
+}
+
 // map the dcraw 2x2 CFA filters word to 4 single-byte channel indices
 // for the DNG CFAPattern tag: 0=R, 1=G, 2=B, following DNG spec §A.3.1
 static void _cfa_bytes_from_filters(uint32_t filters, uint8_t out[4])
@@ -102,38 +115,62 @@ static void _set_dng_shared_metadata(TIFF *tif, const dt_image_t *img)
   if(img->camera_makermodel[0])
     TIFFSetField(tif, TIFFTAG_UNIQUECAMERAMODEL, img->camera_makermodel);
 
+  // OriginalRawFileName: UTF-8 bytes, not zero-terminated ASCII
+  if(img->filename[0])
+  {
+    const size_t fn_len = strlen(img->filename);
+    TIFFSetField(tif, TIFFTAG_ORIGINALRAWFILENAME,
+                 (uint32_t)fn_len, img->filename);
+  }
+
   const uint8_t dng_version[4]  = { 1, 4, 0, 0 };
   const uint8_t dng_backward[4] = { 1, 2, 0, 0 };
   TIFFSetField(tif, TIFFTAG_DNGVERSION, dng_version);
   TIFFSetField(tif, TIFFTAG_DNGBACKWARDVERSION, dng_backward);
 
-  // AsShotNeutral: inverse of wb_coeffs, normalized so max=1. fallback
-  // to neutral [1,1,1] when wb_coeffs missing so the tag is always set
-  float neutral[3] = { 1.0f, 1.0f, 1.0f };
+  TIFFSetField(tif, TIFFTAG_BASELINEEXPOSURE, 0.0f);
+
+  // AsShotNeutral: inverse of wb_coeffs, normalized so max=1. omit
+  // entirely when missing so the reader derives a default from
+  // CalibrationIlluminant1 + ColorMatrix1 instead of a fake daylight
   if(img->wb_coeffs[0] > 0.0f
      && img->wb_coeffs[1] > 0.0f
      && img->wb_coeffs[2] > 0.0f)
   {
+    float neutral[3];
     for(int i = 0; i < 3; i++) neutral[i] = 1.0f / img->wb_coeffs[i];
     const float m = fmaxf(neutral[0], fmaxf(neutral[1], neutral[2]));
     if(m > 0.0f) for(int i = 0; i < 3; i++) neutral[i] /= m;
+    TIFFSetField(tif, TIFFTAG_ASSHOTNEUTRAL, 3, neutral);
   }
-  TIFFSetField(tif, TIFFTAG_ASSHOTNEUTRAL, 3, neutral);
 
-  // ColorMatrix1 (XYZ D50 -> cameraRGB, 3x3). row-major [camRGB][XYZ]
-  // matches darktable's adobe_XYZ_to_CAM layout exactly
+  // ColorMatrix1 (XYZ D65 -> cameraRGB, 3x3, row-major [camRGB][XYZ]).
+  // fall back to XYZ-D65->sRGB when source has no matrix so the DNG is
+  // still renderable; mirrors dt_imageio_dng_write_float
+  float color_matrix[9];
   float non_zero = 0.0f;
   for(int k = 0; k < 3; k++)
     for(int i = 0; i < 3; i++)
       non_zero += fabsf(img->adobe_XYZ_to_CAM[k][i]);
   if(non_zero > 0.0f)
   {
-    float color_matrix[9];
     for(int k = 0; k < 3; k++)
       for(int i = 0; i < 3; i++)
         color_matrix[k * 3 + i] = img->adobe_XYZ_to_CAM[k][i];
-    TIFFSetField(tif, TIFFTAG_COLORMATRIX1, 9, color_matrix);
   }
+  else
+  {
+    static const float xyz_to_srgb_d65[9] = {
+       3.240454f, -1.537138f, -0.498531f,
+      -0.969266f,  1.876010f,  0.041556f,
+       0.055643f, -0.204025f,  1.057225f,
+    };
+    memcpy(color_matrix, xyz_to_srgb_d65, sizeof(color_matrix));
+  }
+  TIFFSetField(tif, TIFFTAG_COLORMATRIX1, 9, color_matrix);
+  // CalibrationIlluminant1 = D65 (21). required alongside ColorMatrix1
+  // — without it strict readers (and older dt) ignore the matrix
+  TIFFSetField(tif, TIFFTAG_CALIBRATIONILLUMINANT1, (uint16_t)21);
 }
 
 // write IFD0 as the canonical Adobe-layout JPEG preview: small YCbCr
@@ -154,6 +191,8 @@ static int _write_jpeg_preview_ifd(TIFF *tif,
   TIFFSetField(tif, TIFFTAG_COMPRESSION, COMPRESSION_JPEG);
   TIFFSetField(tif, TIFFTAG_ORIENTATION, ORIENTATION_TOPLEFT);
   TIFFSetField(tif, TIFFTAG_ROWSPERSTRIP, (uint32_t)p->height);
+  // 2 = sRGB. camera previews are sRGB; tag prevents reader guessing
+  TIFFSetField(tif, TIFFTAG_PREVIEWCOLORSPACE, (uint32_t)2);
 
   _set_dng_shared_metadata(tif, img);
 
@@ -202,6 +241,7 @@ int dt_imageio_dng_write_cfa_bayer(const char *filename,
   TIFF *tif = TIFFOpen(filename, "wl");
 #endif
   if(!tif) return 1;
+  _register_extra_dng_fields(tif);
 
   // canonical Adobe layout when a preview is provided: IFD0 holds the
   // JPEG thumbnail + DNG identification metadata, the raw payload
@@ -344,6 +384,7 @@ int dt_imageio_dng_write_linear(const char *filename,
   TIFF *tif = TIFFOpen(filename, "wl");
 #endif
   if(!tif) return 1;
+  _register_extra_dng_fields(tif);
 
   // canonical layout when a preview is provided (see write_cfa_bayer)
   const gboolean canonical = (preview && preview->data && preview->len > 0

--- a/src/imageio/imageio_dng.c
+++ b/src/imageio/imageio_dng.c
@@ -72,15 +72,19 @@ static void _install_dng_tiff_handlers(void)
   TIFFSetErrorHandler(_dt_dng_tiff_error);
 }
 
-// libtiff has built-in field info for most DNG tags but not all —
-// register the ones we need that aren't pre-registered. PreviewColorSpace
-// (50970) is required for spec-conformant DNG previews
+// register DNG tags that some libtiff builds lack or drop between IFDs.
+// PreviewColorSpace is missing from the built-in table; CFA pattern
+// tags survive IFD0 but vanish in SubIFD0 on e.g. the libtiff that
+// ships with Linux Mint, breaking rawspeed re-import
 static void _register_extra_dng_fields(TIFF *tif)
 {
   static const TIFFFieldInfo extra[] = {
     { TIFFTAG_PREVIEWCOLORSPACE, 1, 1, TIFF_LONG, FIELD_CUSTOM,
-      TRUE /* okToChange */, FALSE /* passCount */,
-      (char *)"PreviewColorSpace" },
+      TRUE, FALSE, (char *)"PreviewColorSpace" },
+    { TIFFTAG_CFAREPEATPATTERNDIM, 2, 2, TIFF_SHORT, FIELD_CUSTOM,
+      TRUE, FALSE, (char *)"CFARepeatPatternDim" },
+    { TIFFTAG_CFAPATTERN, -1, -1, TIFF_BYTE, FIELD_CUSTOM,
+      TRUE, TRUE, (char *)"CFAPattern" },
   };
   TIFFMergeFieldInfo(tif, extra, sizeof(extra) / sizeof(extra[0]));
 }

--- a/src/imageio/imageio_dng.c
+++ b/src/imageio/imageio_dng.c
@@ -17,6 +17,7 @@
 */
 
 #include "imageio/imageio_dng.h"
+#include "common/colorspaces_inline_conversions.h"
 #include "common/darktable.h"
 #include "common/exif.h"
 #include "common/image.h"
@@ -160,11 +161,6 @@ static void _set_dng_shared_metadata(TIFF *tif, const dt_image_t *img)
   }
   else
   {
-    static const float xyz_to_srgb_d65[9] = {
-       3.240454f, -1.537138f, -0.498531f,
-      -0.969266f,  1.876010f,  0.041556f,
-       0.055643f, -0.204025f,  1.057225f,
-    };
     memcpy(color_matrix, xyz_to_srgb_d65, sizeof(color_matrix));
   }
   TIFFSetField(tif, TIFFTAG_COLORMATRIX1, 9, color_matrix);


### PR DESCRIPTION
# Why

A user reported `"Canon EOS R5 Mark II color matrix not found"` when opening a darktable raw-denoise DNG on macOS. The source CR3 worked fine; only the denoised DNG triggered the warning.

`exiftool` revealed the DNG carried `ColorMatrix1` and `AsShotNeutral` but nothing else – no calibration illuminant, no baseline exposure, no original filename, no preview color space tag. darktable's own EXIF parser has a fallback ("if no `CalibrationIlluminant1`, assume D65") which masks the issue on Linux. Stricter readers – including the macOS user's build – drop the matrix entirely and fall back to identity, producing the warning.

## What

Make the libtiff DNG writer (used by `dt_imageio_dng_write_cfa_bayer` + `dt_imageio_dng_write_linear`) self-describing per DNG spec.

| Tag | Before | After |
|---|---|---|
| `CalibrationIlluminant1` | missing | `21` (D65) |
| `ColorMatrix1` | only when `adobe_XYZ_to_CAM` is set | always; falls back to XYZ-D65→sRGB when source has no matrix (mirrors `dt_imageio_dng_write_float`) |
| `BaselineExposure` | missing | `0.0` |
| `OriginalRawFileName` | missing | source basename (e.g. `102A5854.CR3`) |
| `AsShotNeutral` | always emitted, faked to `[1,1,1]` when WB missing | omitted when WB missing – reader derives neutral from matrix + illuminant |
| `PreviewColorSpace` (preview IFD0, canonical layout) | missing | `2` (sRGB); requires manual `TIFFMergeFieldInfo` since libtiff 4.x doesn't pre-register this tag |

## How tested

Re-ran raw denoise on the reporter's `102A5854.CR3` (Canon EOS R5 Mark II) and verified with `exiftool -a -G1`:

```
[IFD0]  Color Matrix 1            : 0.9396 -0.2598 -0.1207 -0.4408 1.2296 0.2369 -0.0505 0.1575 0.6077
[IFD0]  As Shot Neutral           : 0.5254 1 0.6863
[IFD0]  Baseline Exposure         : 0
[IFD0]  Calibration Illuminant 1  : D65
[IFD0]  Original Raw File Name    : 102A5854.CR3
[IFD0]  Preview Color Space       : sRGB
```

All six tags now present where pre-fix only the first two were.

No behavior change for callers – only the on-disk metadata becomes more complete.
