### PR TITLE
Fix `purge_nonexistent_images.bat` to correctly handle images which have cyrillic (or other alphabets) in the path

### DIFF
--- a/tools/purge_nonexistent_images.bat
+++ b/tools/purge_nonexistent_images.bat
@@ -4,6 +4,8 @@
 ::
 
 @echo off
+chcp 65001 >nul
+
 where.exe /q sqlite3
 if %ERRORLEVEL% EQU 1 (
   echo Error: sqlite3.exe is not installed or is not in PATH
@@ -72,9 +74,15 @@ if %dryrun% EQU 0 (
 
 set ids=
 
+:: Write sqlite3 output to a temp UTF-8 file to preserve Cyrillic characters.
+:: Direct 'for /f ... in (\'sqlite3 ...\')' re-encodes output through the
+:: legacy OEM code page, corrupting non-ASCII paths even with chcp 65001.
+set TMPFILE=%TEMP%\dt_purge_tmp_%RANDOM%.txt
+sqlite3.exe -utf8 %DBFILE% %QUERY% > "%TMPFILE%"
+
 setlocal EnableDelayedExpansion
-for /f "tokens=1* delims=|" %%a in ('sqlite3.exe %DBFILE% %QUERY%') do (
-  if not exist %%b (
+for /f "usebackq tokens=1* delims=|" %%a in ("%TMPFILE%") do (
+  if not exist "%%b" (
     echo.  %%b with ID %%a
     if .!ids!==. (
       set ids=%%a
@@ -84,16 +92,18 @@ for /f "tokens=1* delims=|" %%a in ('sqlite3.exe %DBFILE% %QUERY%') do (
   )
 )
 
+del "%TMPFILE%" >nul 2>&1
+
 if %dryrun% EQU 0 (
   echo This is NOT dry run
   for %%a in (images,meta_data) do (
       echo Removing from %%a...
-      sqlite3 %DBFILE% "DELETE FROM %%a WHERE id IN (%ids%)"
+      sqlite3 %DBFILE% "DELETE FROM %%a WHERE id IN (!ids!)"
   )
 
   for %%a in (color_labels,history,masks_history,selected_images,tagged_images,history_hash,module_order) do (
       echo Removing from %%a...
-      sqlite3 %DBFILE% "DELETE FROM %%a WHERE imgid in (%ids%)"
+      sqlite3 %DBFILE% "DELETE FROM %%a WHERE imgid in (!ids!)"
   )
 
   rem delete now-empty film rolls
@@ -109,6 +119,7 @@ if %dryrun% EQU 0 (
   echo %commandline% --purge
 )
 
+endlocal
 exit 0
 
 :HELP

--- a/tools/purge_nonexistent_images.bat
+++ b/tools/purge_nonexistent_images.bat
@@ -4,6 +4,8 @@
 ::
 
 @echo off
+
+for /f "tokens=4" %%a in ('chcp') do set "OLD_CP=%%a"
 chcp 65001 >nul
 
 where.exe /q sqlite3
@@ -92,6 +94,7 @@ for /f "usebackq tokens=1* delims=|" %%a in ("%TMPFILE%") do (
   )
 )
 
+chcp %OLD_CP% >nul
 del "%TMPFILE%" >nul 2>&1
 
 if %dryrun% EQU 0 (


### PR DESCRIPTION
I've made a fix for the **purge_nonexistent_images.bat removes existing files** / #20915 issue I recently added. I used Claude, because I'm not very proficient in .bat scripts. I've checked it and works completely fine and now it only removes the images that are really missing.

<img width="1920" height="1050" alt="Screenshot 2026-05-02 172152" src="https://github.com/user-attachments/assets/98b5bc5b-2e0b-483d-9b83-e71ec947c25e" />
<img width="976" height="495" alt="Screenshot 2026-05-02 172311" src="https://github.com/user-attachments/assets/0e8ad172-769e-465b-8a67-8c920e54f610" />
<img width="1920" height="1050" alt="Screenshot 2026-05-02 172352" src="https://github.com/user-attachments/assets/65f6f486-767f-4f76-b092-69d7d6336ea6" />

Here is some description from Claude itself:

> The script uses for /f ... in ('sqlite3.exe ...') to iterate over query results. On Windows, this form of command substitution captures the child process output through the legacy OEM code page (e.g. CP866 for Russian locales), regardless of the active console code page set by chcp. SQLite3 outputs UTF-8 text, but for /f re-encodes it through the OEM code page, mangling any characters outside the ASCII range. The resulting garbled path string never matches a real filesystem entry, so if not exist always evaluates to true — and the image is treated as missing and scheduled for deletion, even though the underlying file is perfectly intact.