### PR TITLE
More interpolating improvements

### DIFF
--- a/data/kernels/basic.cl
+++ b/data/kernels/basic.cl
@@ -1658,7 +1658,7 @@ clip_rotate_bilinear(read_only image2d_t in, write_only image2d_t out, const int
 
   float4 o = (ii >=0 && jj >= 0 && ii < in_width && jj < in_height) ? read_imagef(in, samplerf, po) : (float4)0.0f;
 
-  write_imagef (out, (int2)(x, y), o);
+  write_ipixel(out, (int2)(x, y), o);
 }
 
 
@@ -1733,7 +1733,7 @@ clip_rotate_bicubic(read_only image2d_t in,
 
   pixel = (tx >= 0 && ty >= 0 && tx < in_width && ty < in_height) ? pixel / weight : (float4)0.0f;
 
-  write_imagef (out, (int2)(x, y), pixel);
+  write_ipixel(out, (int2)(x, y), pixel);
 }
 
 
@@ -1794,7 +1794,7 @@ clip_rotate_lanczos2(read_only image2d_t in, write_only image2d_t out, const int
 
   pixel = (tx >= 0 && ty >= 0 && tx < in_width && ty < in_height) ? pixel / weight : (float4)0.0f;
 
-  write_imagef (out, (int2)(x, y), pixel);
+  write_ipixel(out, (int2)(x, y), pixel);
 }
 
 
@@ -1856,7 +1856,7 @@ clip_rotate_lanczos3(read_only image2d_t in, write_only image2d_t out, const int
 
   pixel = (tx >= 0 && ty >= 0 && tx < in_width && ty < in_height) ? pixel / weight : (float4)0.0f;
 
-  write_imagef (out, (int2)(x, y), pixel);
+  write_ipixel(out, (int2)(x, y), pixel);
 }
 
 float maketaps_bilinear(float *taps,
@@ -2153,7 +2153,7 @@ lens_distort_bilinear (read_only image2d_t in, write_only image2d_t out, const i
 
   pixel = all(isfinite(pixel.xyz)) ? pixel : (float4)0.0f;
 
-  write_imagef (out, (int2)(x, y), pixel);
+  write_ipixel(out, (int2)(x, y), pixel);
 }
 
 /* kernels for the lens plugin: bicubic interpolation */
@@ -2199,66 +2199,54 @@ lens_distort_bicubic (read_only image2d_t in,
     }
   }
 
-
   rx = ppi[0] - (float)roi_in_x;
   ry = ppi[1] - (float)roi_in_y;
-  rx = clamp(rx, 0.0f, (float)(iwidth - 1));
-  ry = clamp(ry, 0.0f, (float)(iheight - 1));
-
-  tx = rx;
-  ty = ry;
+  tx = (int)rx;
+  ty = (int)ry;
 
   sum = 0.0f;
   weight = 0.0f;
   for(int jj = 1 - kwidth; jj <= kwidth; jj++)
     for(int ii= 1 - kwidth; ii <= kwidth; ii++)
   {
-    int i = clamp(tx + ii, 0, iwidth - 1);
-    int j = clamp(ty + jj, 0, iheight - 1);
+    int i = tx + ii;
+    int j = ty + jj;
 
     float wx = interpolation_func_bicubic((float)i - rx);
     float wy = interpolation_func_bicubic((float)j - ry);
     float w = wx * wy;
 
-    sum += read_imagef(in, samplerc, (int2)(i, j)).x * w;
+    sum += Areadpixel(in, clip_mirror(i, iwidth-1), clip_mirror(j, iheight-1)).x * w;
     weight += w;
   }
   pixel.x = sum/weight;
 
-
   rx = ppi[2] - (float)roi_in_x;
   ry = ppi[3] - (float)roi_in_y;
-  rx = clamp(rx, 0.0f, (float)(iwidth - 1));
-  ry = clamp(ry, 0.0f, (float)(iheight - 1));
-
-  tx = rx;
-  ty = ry;
+  tx = (int)rx;
+  ty = (int)ry;
 
   sum2 = (float2)0.0f;
   weight = 0.0f;
   for(int jj = 1 - kwidth; jj <= kwidth; jj++)
     for(int ii= 1 - kwidth; ii <= kwidth; ii++)
   {
-    int i = clamp(tx + ii, 0, iwidth - 1);
-    int j = clamp(ty + jj, 0, iheight - 1);
+    int i = tx + ii;
+    int j = ty + jj;
 
     float wx = interpolation_func_bicubic((float)i - rx);
     float wy = interpolation_func_bicubic((float)j - ry);
     float w = wx * wy;
 
-    sum2 += read_imagef(in, samplerc, (int2)(i, j)).yw * w;
+    sum2 += Areadpixel(in, clip_mirror(i, iwidth-1), clip_mirror(j, iheight-1)).yw * w;
     weight += w;
   }
   pixel.yw = sum2/weight;
 
-
   rx = ppi[4] - (float)roi_in_x;
   ry = ppi[5] - (float)roi_in_y;
-  rx = clamp(rx, 0.0f, (float)(iwidth - 1));
-  ry = clamp(ry, 0.0f, (float)(iheight - 1));
-
-  tx = rx;
-  ty = ry;
+  tx = (int)rx;
+  ty = (int)ry;
 
   sum = 0.0f;
   weight = 0.0f;
@@ -2272,14 +2260,13 @@ lens_distort_bicubic (read_only image2d_t in,
     float wy = interpolation_func_bicubic((float)j - ry);
     float w = wx * wy;
 
-    sum += read_imagef(in, samplerc, (int2)(i, j)).z * w;
+    sum += Areadpixel(in, clip_mirror(i, iwidth-1), clip_mirror(j, iheight-1)).z * w;
     weight += w;
   }
   pixel.z = sum/weight;
 
   pixel = all(isfinite(pixel.xyz)) ? pixel : (float4)0.0f;
-
-  write_imagef (out, (int2)(x, y), pixel);
+  write_ipixel(out, (int2)(x, y), pixel);
 }
 
 
@@ -2329,25 +2316,22 @@ lens_distort_lanczos2 (read_only image2d_t in,
 
   rx = ppi[0] - (float)roi_in_x;
   ry = ppi[1] - (float)roi_in_y;
-  rx = clamp(rx, 0.0f, (float)(iwidth - 1));
-  ry = clamp(ry, 0.0f, (float)(iheight - 1));
-
-  tx = rx;
-  ty = ry;
+  tx = (int)rx;
+  ty = (int)ry;
 
   sum = 0.0f;
   weight = 0.0f;
   for(int jj = 1 - kwidth; jj <= kwidth; jj++)
     for(int ii= 1 - kwidth; ii <= kwidth; ii++)
   {
-    int i = clamp(tx + ii, 0, iwidth - 1);
-    int j = clamp(ty + jj, 0, iheight - 1);
+    int i = tx + ii;
+    int j = ty + jj;
 
     float wx = interpolation_func_lanczos(2, (float)i - rx);
     float wy = interpolation_func_lanczos(2, (float)j - ry);
     float w = wx * wy;
 
-    sum += read_imagef(in, samplerc, (int2)(i, j)).x * w;
+    sum += Areadpixel(in, clip_mirror(i, iwidth-1), clip_mirror(j, iheight-1)).x * w;
     weight += w;
   }
   pixel.x = sum/weight;
@@ -2355,58 +2339,50 @@ lens_distort_lanczos2 (read_only image2d_t in,
 
   rx = ppi[2] - (float)roi_in_x;
   ry = ppi[3] - (float)roi_in_y;
-  rx = clamp(rx, 0.0f, (float)(iwidth - 1));
-  ry = clamp(ry, 0.0f, (float)(iheight - 1));
-
-  tx = rx;
-  ty = ry;
+  tx = (int)rx;
+  ty = (int)ry;
 
   sum2 = (float2)0.0f;
   weight = 0.0f;
   for(int jj = 1 - kwidth; jj <= kwidth; jj++)
     for(int ii= 1 - kwidth; ii <= kwidth; ii++)
   {
-    int i = clamp(tx + ii, 0, iwidth - 1);
-    int j = clamp(ty + jj, 0, iheight - 1);
+    int i = tx + ii;
+    int j = ty + jj;
 
     float wx = interpolation_func_lanczos(2, (float)i - rx);
     float wy = interpolation_func_lanczos(2, (float)j - ry);
     float w = wx * wy;
 
-    sum2 += read_imagef(in, samplerc, (int2)(i, j)).yw * w;
+    sum2 += Areadpixel(in, clip_mirror(i, iwidth-1), clip_mirror(j, iheight-1)).yw * w;
     weight += w;
   }
   pixel.yw = sum2/weight;
 
-
   rx = ppi[4] - (float)roi_in_x;
   ry = ppi[5] - (float)roi_in_y;
-  rx = clamp(rx, 0.0f, (float)(iwidth - 1));
-  ry = clamp(ry, 0.0f, (float)(iheight - 1));
-
-  tx = rx;
-  ty = ry;
+  tx = (int)rx;
+  ty = (int)ry;
 
   sum = 0.0f;
   weight = 0.0f;
   for(int jj = 1 - kwidth; jj <= kwidth; jj++)
     for(int ii= 1 - kwidth; ii <= kwidth; ii++)
   {
-    int i = clamp(tx + ii, 0, iwidth - 1);
-    int j = clamp(ty + jj, 0, iheight - 1);
+    int i = tx + ii;
+    int j = ty + jj;
 
     float wx = interpolation_func_lanczos(2, (float)i - rx);
     float wy = interpolation_func_lanczos(2, (float)j - ry);
     float w = wx * wy;
 
-    sum += read_imagef(in, samplerc, (int2)(i, j)).z * w;
+    sum += Areadpixel(in, clip_mirror(i, iwidth-1), clip_mirror(j, iheight-1)).z * w;
     weight += w;
   }
   pixel.z = sum/weight;
 
   pixel = all(isfinite(pixel.xyz)) ? pixel : (float4)0.0f;
-
-  write_imagef (out, (int2)(x, y), pixel);
+  write_ipixel(out, (int2)(x, y), pixel);
 }
 
 
@@ -2448,84 +2424,72 @@ lens_distort_lanczos3 (read_only image2d_t in, write_only image2d_t out, const i
 
   rx = ppi[0] - (float)roi_in_x;
   ry = ppi[1] - (float)roi_in_y;
-  rx = clamp(rx, 0.0f, (float)(iwidth - 1));
-  ry = clamp(ry, 0.0f, (float)(iheight - 1));
-
-  tx = rx;
-  ty = ry;
+  tx = (int)rx;
+  ty = (int)ry;
 
   sum = 0.0f;
   weight = 0.0f;
   for(int jj = 1 - kwidth; jj <= kwidth; jj++)
     for(int ii= 1 - kwidth; ii <= kwidth; ii++)
   {
-    int i = clamp(tx + ii, 0, iwidth - 1);
-    int j = clamp(ty + jj, 0, iheight - 1);
+    int i = tx + ii;
+    int j = ty + jj;
 
     float wx = interpolation_func_lanczos(3, (float)i - rx);
     float wy = interpolation_func_lanczos(3, (float)j - ry);
     float w = wx * wy;
 
-    sum += read_imagef(in, samplerc, (int2)(i, j)).x * w;
+    sum += Areadpixel(in, clip_mirror(i, iwidth-1), clip_mirror(j, iheight-1)).x * w;
     weight += w;
   }
   pixel.x = sum/weight;
 
-
   rx = ppi[2] - (float)roi_in_x;
   ry = ppi[3] - (float)roi_in_y;
-  rx = clamp(rx, 0.0f, (float)(iwidth - 1));
-  ry = clamp(ry, 0.0f, (float)(iheight - 1));
-
-  tx = rx;
-  ty = ry;
+  tx = (int)rx;
+  ty = (int)ry;
 
   sum2 = (float2)0.0f;
   weight = 0.0f;
   for(int jj = 1 - kwidth; jj <= kwidth; jj++)
     for(int ii= 1 - kwidth; ii <= kwidth; ii++)
   {
-    int i = clamp(tx + ii, 0, iwidth - 1);
-    int j = clamp(ty + jj, 0, iheight - 1);
+    int i = tx + ii;
+    int j = ty + jj;
 
     float wx = interpolation_func_lanczos(3, (float)i - rx);
     float wy = interpolation_func_lanczos(3, (float)j - ry);
     float w = wx * wy;
 
-    sum2 += read_imagef(in, samplerc, (int2)(i, j)).yw * w;
+    sum2 += Areadpixel(in, clip_mirror(i, iwidth-1), clip_mirror(j, iheight-1)).yw * w;
     weight += w;
   }
   pixel.yw = sum2/weight;
 
-
   rx = ppi[4] - (float)roi_in_x;
   ry = ppi[5] - (float)roi_in_y;
-  rx = clamp(rx, 0.0f, (float)(iwidth - 1));
-  ry = clamp(ry, 0.0f, (float)(iheight - 1));
-
-  tx = rx;
-  ty = ry;
+  tx = (int)rx;
+  ty = (int)ry;
 
   sum = 0.0f;
   weight = 0.0f;
   for(int jj = 1 - kwidth; jj <= kwidth; jj++)
     for(int ii= 1 - kwidth; ii <= kwidth; ii++)
   {
-    int i = clamp(tx + ii, 0, iwidth - 1);
-    int j = clamp(ty + jj, 0, iheight - 1);
+    int i = tx + ii;
+    int j = ty + jj;
 
     float wx = interpolation_func_lanczos(3, (float)i - rx);
     float wy = interpolation_func_lanczos(3, (float)j - ry);
     float w = wx * wy;
 
-    sum += read_imagef(in, samplerc, (int2)(i, j)).z * w;
+    sum += Areadpixel(in, clip_mirror(i, iwidth-1), clip_mirror(j, iheight-1)).z * w;
     weight += w;
   }
   pixel.z = sum/weight;
 
   pixel = all(isfinite(pixel.xyz)) ? pixel : (float4)0.0f;
-
-  write_imagef (out, (int2)(x, y), pixel);
+  write_ipixel(out, (int2)(x, y), pixel);
 }
 
 
@@ -2572,10 +2536,10 @@ ashift_bilinear(read_only image2d_t in, write_only image2d_t out, const int widt
   int ty = ry;
 
   float4 pixel = (tx >= 0 && ty >= 0 && tx < iwidth && ty < iheight)
-                ? fmax(0.0f, read_imagef(in, samplerf, (float2)(rx, ry)))
+                ? read_imagef(in, samplerf, (float2)(rx+0.5f, ry+0.5f))
                 : (float4)0.0f;
 
-  write_imagef (out, (int2)(x, y), pixel);
+  write_ipixel(out, (int2)(x, y), pixel);
 }
 
 /* kernel for the ashift module: bicubic interpolation */
@@ -2647,10 +2611,10 @@ ashift_bicubic (read_only image2d_t in,
   }
 
   pixel = (tx >= 0 && ty >= 0 && tx < iwidth && ty < iheight)
-          ? fmax(0.0f, pixel/weight)
+          ? pixel/weight
           : (float4)0.0f;
 
-  write_imagef (out, (int2)(x, y), pixel);
+  write_ipixel(out, (int2)(x, y), pixel);
 }
 
 
@@ -2723,10 +2687,10 @@ ashift_lanczos2(read_only image2d_t in,
   }
 
   pixel = (tx >= 0 && ty >= 0 && tx < iwidth && ty < iheight)
-        ? fmax(0.0f, pixel/weight)
+        ? pixel/weight
         : (float4)0.0f;
 
-  write_imagef (out, (int2)(x, y), pixel);
+  write_ipixel(out, (int2)(x, y), pixel);
 }
 
 
@@ -2799,10 +2763,10 @@ ashift_lanczos3(read_only image2d_t in,
   }
 
   pixel = (tx >= 0 && ty >= 0 && tx < iwidth && ty < iheight)
-          ? fmax(0.0f, pixel/weight)
+          ? pixel/weight
           : (float4)0.0f;
 
-  write_imagef (out, (int2)(x, y), pixel);
+  write_ipixel(out, (int2)(x, y), pixel);
 }
 
 float _calc_vignette_spline(const float radius,
@@ -2909,7 +2873,7 @@ lens_vignette (read_only image2d_t in,
   if(x >= width || y >= height) return;
 
   float4 pixel = Areadpixel(in, x, y);
-  float4 scale = pi[mad24(y, width, x)]/(float4)0.5f;
+  float4 scale = 2.0f * pi[mad24(y, width, x)];
 
   pixel.xyz *= scale.xyz;
 
@@ -2961,7 +2925,7 @@ kernel void md_lens_correction(read_only image2d_t in,
   }
 
   float4 pixel = {output[0], output[1], output[2], output[3]};
-  write_imagef(out, (int2)(x, y), pixel);
+  write_ipixel(out, (int2)(x, y), pixel);
 }
 #undef MAXKNOTS
 
@@ -3760,7 +3724,7 @@ interpolation_resample (read_only image2d_t in,
   {
     // Clip negative RGB that may be produced by Lanczos undershooting
     // Negative RGB are invalid values no matter the RGB space (light is positive)
-    write_imagef (out, (int2)(x, y), fmax(buffer[ylid], 0.f));
+    write_ipixel(out, (int2)(x, y), buffer[ylid]);
   }
 }
 

--- a/data/kernels/common.h
+++ b/data/kernels/common.h
@@ -252,6 +252,7 @@ static inline float readsingle(read_only image2d_t in, int col, int row)
 {
   return read_imagef(in, sampleri, (int2)(col, row)).x;
 }
+
 static inline float Areadsingle(read_only image2d_t in, int col, int row)
 {
   return read_imagef(in, samplerA, (int2)(col, row)).x;
@@ -267,7 +268,17 @@ static inline float4 Areadpixel(read_only image2d_t in, int col, int row)
   return read_imagef(in, samplerA, (int2)(col, row));
 }
 
+static inline float4 Creadpixel(read_only image2d_t in, int col, int row)
+{
+  return read_imagef(in, samplerc, (int2)(col, row));
+}
+
 static inline float readalpha(read_only image2d_t in, int col, int row)
 {
   return clipf(read_imagef(in, sampleri, (int2)(col, row)).w);
+}
+
+static inline void write_ipixel(write_only image2d_t out, const int2 pos, const float4 pixel)
+{
+  write_imagef(out, pos, fmax(0.0f, pixel));
 }

--- a/data/kernels/demosaic_ppg.cl
+++ b/data/kernels/demosaic_ppg.cl
@@ -521,15 +521,15 @@ clip_and_zoom_demosaic_half_size(__read_only image2d_t in,
     const float yfilter = (j == 0) ? 1.0f - d.y : ((j == samples+1) ? d.y : 1.0f);
 
     // get four mosaic pattern uint16:
-    const float p1 = readsingle(in, xx,   yy  );
-    const float p2 = readsingle(in, xx+1, yy  );
-    const float p3 = readsingle(in, xx,   yy+1);
-    const float p4 = readsingle(in, xx+1, yy+1);
+    const float p1 = fmax(0.0f, readsingle(in, xx,   yy  ));
+    const float p2 = fmax(0.0f, readsingle(in, xx+1, yy  ));
+    const float p3 = fmax(0.0f, readsingle(in, xx,   yy+1));
+    const float p4 = fmax(0.0f, readsingle(in, xx+1, yy+1));
     color += yfilter*xfilter*(float4)(p1, (p2+p3)*0.5f, p4, 0.0f);
     weight += yfilter*xfilter;
   }
-  color = (weight > 0.0f) ? fmax(0.0f, color)/weight : (float4)0.0f;
-  write_imagef (out, (int2)(x, y), color);
+  color = (weight > 0.0f) ? color/weight : (float4)0.0f;
+  write_ipixel(out, (int2)(x, y), color);
 }
 
 

--- a/data/kernels/liquify.cl
+++ b/data/kernels/liquify.cl
@@ -123,9 +123,9 @@ warp_kernel (read_only image2d_t in,
   // loop over support region (eg. 6x6 pixels for lanczos3)
   for (sample_pos.y = 1 - a; sample_pos.y <= a; ++sample_pos.y)
     for (sample_pos.x = 1 - a; sample_pos.x <= a; ++sample_pos.x)
-      Sxy += fmax(0.0f, read_imagef(in, sampleri, in_pos + convert_float2(sample_pos)))
+      Sxy += read_imagef(in, sampleri, in_pos + convert_float2(sample_pos))
 	      * lk[sample_pos.x].x * lk[sample_pos.y].y;
 
-  Sxy = fmax(0.0f, Sxy / fmax(1e-7f, norm.x * norm.y));
-  write_imagef(out, pos - roi_out_origin, Sxy);
+  Sxy = Sxy / (norm.x * norm.y);
+  write_ipixel(out, pos - roi_out_origin, Sxy);
 }

--- a/src/common/interpolation.c
+++ b/src/common/interpolation.c
@@ -520,6 +520,8 @@ float dt_interpolation_compute_sample(const dt_interpolation_t *itor,
   // Compute both horizontal and vertical kernels
   const float normh = _compute_upsampling_kernel(itor, kernelh, NULL, x);
   const float normv = _compute_upsampling_kernel(itor, kernelv, NULL, y);
+  // Precompute the inverse of the filter norm for later use
+  const float oonorm = (1.f / (normh * normv));
 
   int ix = (int)x;
   int iy = (int)y;
@@ -550,7 +552,7 @@ float dt_interpolation_compute_sample(const dt_interpolation_t *itor,
       s += kernelv[i] * h;
       in += linestride;
     }
-    s = s / (normh * normv);
+    s = _interpolated_out(s * oonorm);
   }
   else if(ix >= 0 && iy >= 0 && ix < width && iy < height)
   {
@@ -572,7 +574,7 @@ float dt_interpolation_compute_sample(const dt_interpolation_t *itor,
       }
       s += kernelv[i] * h;
     }
-    s = s / (normh * normv);
+    s = _interpolated_out(s * oonorm);
   }
   return s; // if called for masks make sure to CLIP to avoid interpolator under/overshoots
 }
@@ -643,7 +645,7 @@ void dt_interpolation_compute_pixel4c(const dt_interpolation_t *itor,
     }
 
     for_each_channel(c,aligned(out))
-      out[c] = fmaxf(0.0f, oonorm * pixel[c]);
+      out[c] = _interpolated_out(pixel[c] * oonorm);
   }
   else if(ix >= 0 && iy >= 0 && ix < width && iy < height)
   {
@@ -673,7 +675,7 @@ void dt_interpolation_compute_pixel4c(const dt_interpolation_t *itor,
     }
 
     for_each_channel(c,aligned(out))
-      out[c] = fmaxf(0.0f, oonorm * pixel[c]);
+      out[c] = _interpolated_out(pixel[c] * oonorm);
   }
   else
   {
@@ -1114,11 +1116,9 @@ void dt_interpolation_resample(const dt_interpolation_t *itor,
       // Output pixel is ready
       const size_t baseidx = (size_t)oy * out_stride_floats + (size_t)ox * 4;
 
-      // Clip negative RGB that may be produced by Lanczos undershooting
-      // Negative RGB are invalid values no matter the RGB space (light is positive)
       dt_aligned_pixel_t pixel;
       for_each_channel(c, aligned(vs:16))
-        pixel[c] = fmaxf(0.0f, vs[c]);
+        pixel[c] = _interpolated_out(vs[c]);
       copy_pixel_nontemporal(out + baseidx, pixel);
 
       // Reset vertical resampling context

--- a/src/common/math.h
+++ b/src/common/math.h
@@ -811,6 +811,15 @@ static inline double rad2deg(const double radians)
   return radians / M_PI * 180.0;
 }
 
+/* Reminder: keep in sync with opencl write_ipixel()
+   All pixel interpolators use this, currently we restrict output of resampling to be at least zero
+*/
+static inline float _interpolated_out(const float val)
+{
+  return MAX(0.0f, val);
+}
+
+
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
 // vim: shiftwidth=2 expandtab tabstop=2 cindent


### PR DESCRIPTION
1. Currently almost all interpolating functions make sure the output stays above zero. In preparation for unrestricted output we now have two inline functions in opencl common.h and CPU maths.h, both are used all over the code base for possibly changing this.
2. OpenCL bilinear ashift code now has far less differences vs CPU
3. Fixed a minor liquify mixing bug
4. lensfun interpolators get the correct mirror mode as we do for ashift (and alike) and embedded lens correction.
5. fixed fast bayer zoom demosaicer to behave like most (and default) demosaicers avoiding negative input for all 3 color channels.

@TurboGit found no regressions, diff improvements where expected in 0077 and 0110