### PR TITLE
[AI] Fix AMD ORT install: layout, content, lib detection

### DIFF
--- a/data/ort_gpu.json
+++ b/data/ort_gpu.json
@@ -82,7 +82,11 @@
       "required_libs": [
         "libmigraphx_c.so.3",
         "librocm_smi64.so.7"
-      ]
+      ],
+      "lib_extra_patterns": [
+        "libhipblas"
+      ],
+      "preserve_layout": true
     },
     {
       "vendor": "amd",
@@ -97,7 +101,13 @@
       "lib_pattern": "libonnxruntime",
       "install_subdir": "onnxruntime-migraphx",
       "size_mb": 100,
-      "requirements": "ROCm 7.1, MIGraphX"
+      "requirements": "ROCm 7.1, MIGraphX",
+      "lib_extra_patterns": [
+        "libamd",
+        "librocprofiler",
+        "libzstd"
+      ],
+      "preserve_layout": true
     },
     {
       "vendor": "amd",
@@ -112,7 +122,8 @@
       "lib_pattern": "libonnxruntime",
       "install_subdir": "onnxruntime-migraphx",
       "size_mb": 50,
-      "requirements": "ROCm 7.2, MIGraphX"
+      "requirements": "ROCm 7.2, MIGraphX",
+      "preserve_layout": false
     },
     {
       "vendor": "intel",

--- a/src/ai/backend_onnx.c
+++ b/src/ai/backend_onnx.c
@@ -549,6 +549,31 @@ int dt_ai_ort_probe_library_full(const char *path, char **out_version, char **ou
   return TRUE;
 }
 
+// find libonnxruntime.so.* recursively, skip auditwheel *.libs/ peers
+static gchar *_scan_for_ort_lib(const char *root)
+{
+  GDir *d = g_dir_open(root, 0, NULL);
+  if(!d) return NULL;
+  gchar *result = NULL;
+  const gchar *name;
+  while((name = g_dir_read_name(d)) && !result)
+  {
+    gchar *p = g_build_filename(root, name, NULL);
+    if(g_file_test(p, G_FILE_TEST_IS_DIR))
+    {
+      if(!g_str_has_suffix(name, ".libs"))
+        result = _scan_for_ort_lib(p);
+    }
+    else if(g_str_has_prefix(name, "libonnxruntime.so."))
+    {
+      result = g_strdup(p);
+    }
+    g_free(p);
+  }
+  g_dir_close(d);
+  return result;
+}
+
 // Scan system and user-space paths for valid ORT libraries.
 // Returns a GList of dt_ai_ort_found_t (caller owns list and contents).
 GList *dt_ai_ort_find_libraries(void)
@@ -624,20 +649,8 @@ GList *dt_ai_ort_find_libraries(void)
       else
       {
         g_free(exact);
-        GDir *d = g_dir_open(dir, 0, NULL);
-        if(d)
-        {
-          const gchar *name;
-          while((name = g_dir_read_name(d)))
-          {
-            if(g_str_has_prefix(name, "libonnxruntime.so."))
-            {
-              user_paths[i] = g_build_filename(dir, name, NULL);
-              break;
-            }
-          }
-          g_dir_close(d);
-        }
+        // preserve_layout puts the lib in onnxruntime/capi/
+        user_paths[i] = _scan_for_ort_lib(dir);
       }
 #endif
     }

--- a/tools/ai/install-ort-gpu.sh
+++ b/tools/ai/install-ort-gpu.sh
@@ -359,6 +359,10 @@ PKG_LIB_PATTERN=$(_field lib_pattern "libonnxruntime")
 # wheels that bundle their own dependencies alongside ORT (e.g. the
 # Linux onnxruntime-openvino wheel ships libopenvino*, libtbb*)
 PKG_LIB_EXTRA_PATTERNS=$(echo "$PKG_JSON" | jq -r '.lib_extra_patterns // [] | .[]' 2>/dev/null || true)
+# preserve_layout: TRUE for manylinux wheels with auditwheel-bundled deps
+# whose providers .so RPATH is `$ORIGIN/../../<ep>.libs` (e.g. AMD MIGraphX).
+# default flat extraction matches OpenVINO's $ORIGIN-only RPATH
+PKG_PRESERVE_LAYOUT=$(echo "$PKG_JSON" | jq -r '.preserve_layout // false' 2>/dev/null || echo false)
 PKG_INSTALL_SUBDIR=$(_field install_subdir "onnxruntime-gpu")
 PKG_SIZE_MB=$(_field size_mb "0")
 PKG_ORT_VERSION=$(_field ort_version "")
@@ -425,29 +429,27 @@ fi
 
 # --- Extract ---
 echo "Extracting..."
+
+# nuke any prior install — preserve_layout creates subdirs that a
+# per-pattern depth-1 clean wouldn't catch
+rm -rf "$INSTALL_DIR"
 mkdir -p "$INSTALL_DIR"
 
-# clean prior install of the same library family so old versioned .so
-# files (and stale symlinks) don't shadow the new install. without this
-# you get a directory containing both libonnxruntime.so.1.24.4 and
-# .so.1.25.1, with the .so.1 symlink pointing at whichever was first
-find "$INSTALL_DIR" -maxdepth 1 -name "${PKG_LIB_PATTERN}*.so*" \
-  -delete 2>/dev/null || true
-for pattern in $PKG_LIB_EXTRA_PATTERNS; do
-  find "$INSTALL_DIR" -maxdepth 1 -name "${pattern}*.so*" \
-    -delete 2>/dev/null || true
-done
-
-# build the find -name expression covering the main pattern + any extras
+# flat: copy matched files to INSTALL_DIR/<basename>
+# preserve_layout: keep archive's relative paths (required for manylinux
+# wheels whose providers .so RPATH is `$ORIGIN/../../<ep>.libs`)
 _extract_libs() {
   local search_root="$1"
-  local pattern
-  find "$search_root" -name "${PKG_LIB_PATTERN}*" -type f | while read -r f; do
-    cp "$f" "$INSTALL_DIR/"
-  done
-  for pattern in $PKG_LIB_EXTRA_PATTERNS; do
+  local pattern f rel
+  for pattern in "$PKG_LIB_PATTERN" $PKG_LIB_EXTRA_PATTERNS; do
     find "$search_root" -name "${pattern}*" -type f | while read -r f; do
-      cp "$f" "$INSTALL_DIR/"
+      if [ "$PKG_PRESERVE_LAYOUT" = "true" ]; then
+        rel="${f#$search_root/}"
+        mkdir -p "$INSTALL_DIR/$(dirname "$rel")"
+        cp "$f" "$INSTALL_DIR/$rel"
+      else
+        cp "$f" "$INSTALL_DIR/"
+      fi
     done
   done
 }
@@ -513,20 +515,22 @@ PY
 }
 
 if [ "$PLATFORM" = "linux" ]; then
-  for f in "$INSTALL_DIR"/*.so*; do
-    [ -f "$f" ] || continue
+  find "$INSTALL_DIR" -name "*.so*" -type f | while read -r f; do
     clear_execstack "$f" || true
   done
 fi
 
 # --- Verify ---
-# prefer the versioned main library (libonnxruntime.so.X.Y.Z) and pick
-# the newest by version. sort -V puts 1.25.1 after 1.24.4 even when
-# the dir still has both for any reason
-ORT_SO=$(find "$INSTALL_DIR" -maxdepth 1 -name "${PKG_LIB_PATTERN}.so.*" 2>/dev/null \
+# preserve_layout: recurse, skip auditwheel-bundled *.libs/ dirs
+# flat: only look at depth 1
+if [ "$PKG_PRESERVE_LAYOUT" = "true" ]; then
+  _find_args=(! -path '*/*.libs/*')
+else
+  _find_args=(-maxdepth 1)
+fi
+ORT_SO=$(find "$INSTALL_DIR" "${_find_args[@]}" -name "${PKG_LIB_PATTERN}.so.*" -type f 2>/dev/null \
            | sort -V | tail -1)
-# fallback to any matching .so (skip provider libs which aren't the entry point)
-[ -z "$ORT_SO" ] && ORT_SO=$(find "$INSTALL_DIR" -maxdepth 1 -name "${PKG_LIB_PATTERN}*.so*" 2>/dev/null \
+[ -z "$ORT_SO" ] && ORT_SO=$(find "$INSTALL_DIR" "${_find_args[@]}" -name "${PKG_LIB_PATTERN}*.so*" -type f 2>/dev/null \
                               | grep -v providers | sort -V | tail -1)
 
 if [ -z "$ORT_SO" ]; then
@@ -536,7 +540,7 @@ fi
 
 echo ""
 echo "Done. Installed to: $INSTALL_DIR"
-ls -lh "$INSTALL_DIR/"*.so* 2>/dev/null || true
+echo "Library: $ORT_SO"
 echo ""
 echo "To enable in darktable:"
 echo ""


### PR DESCRIPTION
The AMD MIGraphX install was broken two ways: each ROCm version ships a structurally different wheel, and the detect button missed nested install layouts.

## Changes

- **Manifest**: per-version AMD config based on actual wheel inspection (7.0 + 7.1 auditwheel-isolated → `preserve_layout: true`; 7.2  system-only → `preserve_layout: false`).
- **Installer** (`install-ort-gpu.sh`): new `preserve_layout` flag keeps archive paths under install dir so
  manylinux wheels' `$ORIGIN/../../<ep>.libs` RPATH resolves. Default false preserves OpenVINO + NVIDIA flat behaviour.
- **Detect button**: recurses into `~/.local/lib/onnxruntime-*/` skipping `*.libs/`.

Verified on Fedora 44 (rocm-hip 7.1.1) and unchanged OpenVINO/NVIDIA paths.