### PR TITLE
[CI] Increase the cancelling timeout to increase the chances of getting packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
         run: |
           sed -i 's/archive\.ubuntu/azure\.archive\.ubuntu/' /etc/apt/sources.list.d/ubuntu.sources
       - name: Update base packages
-        timeout-minutes: 1
+        timeout-minutes: 15
         run: |
           set -xe
           rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
We increasing the maximum amount of time a packages updating step can run before it is automatically canceled. The repositories may be alive but under denial of service attack and responding very slowly.