### PR TITLE
[AI] Add TIFFTAG_PREVIEWCOLORSPACE fallback for libtiff < 4.6

### DIFF
--- a/src/imageio/imageio_dng.c
+++ b/src/imageio/imageio_dng.c
@@ -36,6 +36,11 @@
 #include <wchar.h>
 #endif
 
+// fallback for libtiff < 4.6
+#ifndef TIFFTAG_PREVIEWCOLORSPACE
+#define TIFFTAG_PREVIEWCOLORSPACE 50970
+#endif
+
 // DNG uses SRATIONAL / RATIONAL for matrix and WB tags. libtiff accepts
 // these as float/double arrays and handles the conversion; we just pass
 // the values as double


### PR DESCRIPTION
Fixes #20932

`imageio_dng.c` fails to compile on libtiff < 4.6 (Debian 12, Ubuntu 22.04 / 24.04) because `TIFFTAG_PREVIEWCOLORSPACE` was only added in libtiff 4.6.

Adds a one-line `#ifndef` fallback that defines the macro to its DNG-spec value (50970) when libtiff didn't.

Verified against libtiff 4.3.0 source – it's the only DNG tag darktable uses that's missing in pre-4.6; everything else (`DNGVERSION`, `COLORMATRIX1`, `BLACKLEVEL`, `ACTIVEAREA`, …) has been there since 4.0.