### PR TITLE
[AI] Fix AI object mask path not matching red overlay

### DIFF
--- a/src/common/ras2vect.c
+++ b/src/common/ras2vect.c
@@ -66,8 +66,6 @@ static void _bm_free(potrace_bitmap_t *bm)
   }
 }
 
-#define SET_THRESHOLD 0.6f
-
 static inline void _scale_point(float p[2],
                                 const float xscale,
                                 const float yscale,
@@ -141,6 +139,7 @@ GList *ras2forms(const float *mask,
                  const int width,
                  const int height,
                  const dt_image_t *const image,
+                 const float threshold,
                  const int turdsize,
                  const double alphamax,
                  GList **out_signs)
@@ -158,7 +157,7 @@ GList *ras2forms(const float *mask,
     for(int x=0; x < width; x++)
     {
       const int index = x + y * width;
-      if(mask[index] < SET_THRESHOLD)
+      if(mask[index] < threshold)
       {
         // black enough to be a point of the form
         BM_USET(bm, x, y);

--- a/src/common/ras2vect.h
+++ b/src/common/ras2vect.h
@@ -31,10 +31,12 @@
    returned: '+' for outer boundaries, '-' for holes.
    The caller must free this list with g_list_free().
 */
+// pixels with mask < threshold are inside the form
 GList *ras2forms(const float *mask,
                  const int width,
                  const int height,
                  const dt_image_t *const image,
+                 const float threshold,
                  const int turdsize,
                  const double alphamax,
                  GList **out_signs);

--- a/src/develop/masks/object.c
+++ b/src/develop/masks/object.c
@@ -797,6 +797,11 @@ static void _update_preview(_object_data_t *d)
      && !dt_conf_get_bool(CONF_OBJECT_PATH_PREVIEW_KEY))
     return;
 
+  // ras2forms inherits potrace's convention: pixels < threshold are
+  // "inside the form" (black ink on white paper). our AI mask uses the
+  // opposite — high values = inside the object — so we invert both the
+  // mask and the threshold here. result: the path traces the same
+  // contour as the red overlay (mask > user_threshold)
   const size_t n = (size_t)d->mask_w * d->mask_h;
   float *inv_mask = g_try_malloc(n * sizeof(float));
   if(!inv_mask) return;
@@ -804,7 +809,10 @@ static void _update_preview(_object_data_t *d)
   for(size_t i = 0; i < n; i++)
     inv_mask[i] = 1.0f - d->mask[i];
 
+  const float thresh = 1.0f - CLAMP(dt_conf_get_float(CONF_OBJECT_THRESHOLD_KEY),
+                                    0.3f, 0.9f);
   d->preview_forms = ras2forms(inv_mask, d->mask_w, d->mask_h, NULL,
+                               thresh,
                                d->preview_cleanup, (double)d->preview_smoothing,
                                &d->preview_signs);
   g_free(inv_mask);
@@ -1100,9 +1108,11 @@ static dt_masks_form_t *_finalize_mask(dt_iop_module_t *module,
 
   const int cleanup = dt_conf_get_int(CONF_OBJECT_CLEANUP_KEY);
   const float smoothing = dt_conf_get_float(CONF_OBJECT_SMOOTHING_KEY);
+  const float thresh = 1.0f - CLAMP(dt_conf_get_float(CONF_OBJECT_THRESHOLD_KEY),
+                                    0.3f, 0.9f);
   GList *signs = NULL;
   GList *forms = ras2forms(inv_mask, d->mask_w, d->mask_h, NULL,
-                           cleanup, (double)smoothing, &signs);
+                           thresh, cleanup, (double)smoothing, &signs);
   g_free(inv_mask);
 
   return _register_vectorized_forms(module, forms, signs, d->mask_w, d->mask_h);

--- a/src/iop/rasterfile.c
+++ b/src/iop/rasterfile.c
@@ -50,6 +50,8 @@
 #include <omp.h>
 #endif
 
+#define SET_THRESHOLD 0.6f
+
 DT_MODULE_INTROSPECTION(1, dt_iop_rasterfile_params_t)
 
 typedef enum dt_iop_rasterfile_mode_t
@@ -164,7 +166,8 @@ static void _vectorize_button_clicked(GtkWidget *widget,
   dt_pthread_mutex_lock(&cd->lock);
 
   const dt_image_t *const image = &(self->dev->image_storage);
-  GList *forms = ras2forms(cd->mask, cd->width, cd->height, image, 0, 0.0, NULL);
+  GList *forms = ras2forms(cd->mask, cd->width, cd->height, image,
+                           SET_THRESHOLD, 0, 0.0, NULL);
 
   dt_pthread_mutex_unlock(&cd->lock);
 


### PR DESCRIPTION
The vector path overlay drawn for the AI object mask did not match the red mask overlay. The path always traced the contour at `mask > 0.4` regardless of the user's threshold setting, while the red overlay correctly used the configured `plugins/darkroom/masks/object/threshold` (default 0.5, range 0.3–0.9). The two diverged at every threshold value except a narrow band around 0.4.

### Cause

`ras2forms()` had a hardcoded `#define SET_THRESHOLD 0.6f` for binarizing the mask before potrace traced it. The two call sites in `object.c` inverted the AI mask (`1 - mask`) and passed it through unchanged, so the trace always happened at the inverted-0.6 contour (i.e. `mask > 0.4`). The user-configured threshold was never threaded into the trace.

### Fix

- Add a `float threshold` parameter to `ras2forms()`; remove the hardcoded `SET_THRESHOLD` constant.
- In `object.c`, pass `1 - user_threshold` at both call sites (preview render + commit) so the trace uses the same contour the red overlay paints.
- In `iop/rasterfile.c`, keep the existing 0.6 behaviour by defining a local `SET_THRESHOLD` constant and passing it explicitly. Rasterfile masks come from already-binarized PNGs, so the previous behaviour is preserved.

A short comment in `object.c` documents the polarity convention: `ras2forms` inherits potrace's "low = inside the form" semantics, while our AI mask uses "high = inside the object" - hence the inversion of mask and threshold.