### PR TITLE
Fix tone_curve mask blending

### DIFF
--- a/data/kernels/blendop.cl
+++ b/data/kernels/blendop.cl
@@ -1423,18 +1423,22 @@ blendop_rgb_jzczhz(__read_only image2d_t in_a, __read_only image2d_t in_b, __rea
 
 
 __kernel void
-blendop_mask_tone_curve(__read_only image2d_t mask_in, __write_only image2d_t mask_out,
-			const int width, const int height,
-			const float e, const float brightness, const float gopacity)
+blendop_mask_tone_curve(__read_only image2d_t mask_in,
+                        __write_only image2d_t mask_out,
+                        const int width,
+                        const int height,
+			                  const float e,
+                        const float brightness,
+                        const float gopacity)
 {
-  const float mask_epsilon = 16 * FLT_EPSILON;  // empirical mask threshold for fully transparent masks
+  const float mask_epsilon = 16.0f * FLT_EPSILON;  // empirical mask threshold for fully transparent masks
   const int x = get_global_id(0);
   const int y = get_global_id(1);
 
   if (x >= width || y >= height) return;
 
   float opacity = readsingle(mask_in, x, y);
-  float scaled_opacity = (2.f * opacity / gopacity - 1.f);
+  float scaled_opacity = 2.f * opacity / gopacity - 1.f;
   if (1.f - brightness <= 0.f)
     scaled_opacity = opacity <= mask_epsilon ? -1.f : 1.f;
   else if (1.f + brightness <= 0.f)
@@ -1449,7 +1453,8 @@ blendop_mask_tone_curve(__read_only image2d_t mask_in, __write_only image2d_t ma
     scaled_opacity = (scaled_opacity + brightness) / (1.f + brightness);
     scaled_opacity = fmax(scaled_opacity, -1.f);
   }
-  opacity = clipf(((scaled_opacity * e / (1.f + (e - 1.f) * fabs(scaled_opacity))) / 2.f + 0.5f) * gopacity);
+  opacity = 0.5f * (scaled_opacity * e / (1.f + (e - 1.f) * fabs(scaled_opacity))) + 0.5f;
+  opacity = clipf(opacity > 1e-6 ? opacity : 0.0f) * gopacity;
   write_imagef(mask_out, (int2)(x, y), opacity);
 }
 

--- a/src/develop/blend.c
+++ b/src/develop/blend.c
@@ -302,24 +302,23 @@ static void _refine_with_detail_mask(dt_iop_module_t *self,
   dt_control_log(_("detail mask blending error"));
 }
 
-static size_t _get_post_operations(const dt_develop_blend_params_t *const params,
+static size_t _get_post_operations(const dt_develop_blend_params_t *const bp,
                                    const dt_dev_pixelpipe_iop_t *const piece,
                                    _develop_mask_post_processing operations[3])
 {
-  const gboolean mask_feather = params->feathering_radius > 0.1f && piece->colors >= 3;
-  const gboolean mask_blur = params->blur_radius > 0.1f;
-  const gboolean mask_tone_curve =
-    fabsf(params->contrast) >= 0.01f || fabsf(params->brightness) >= 0.01f;
+  const gboolean mask_feather = bp->feathering_radius > 0.1f && piece->colors >= 3;
+  const gboolean mask_blur = bp->blur_radius > 0.1f;
+  const gboolean mask_tone_curve = fabsf(bp->contrast) >= 0.01f || fabsf(bp->brightness) >= 0.01f;
 
   const gboolean mask_feather_before =
-       params->feathering_guide == DEVELOP_MASK_GUIDE_IN_BEFORE_BLUR
-    || params->feathering_guide == DEVELOP_MASK_GUIDE_OUT_BEFORE_BLUR;
+       bp->feathering_guide == DEVELOP_MASK_GUIDE_IN_BEFORE_BLUR
+    || bp->feathering_guide == DEVELOP_MASK_GUIDE_OUT_BEFORE_BLUR;
 
   const gboolean mask_feather_out =
-       params->feathering_guide == DEVELOP_MASK_GUIDE_OUT_BEFORE_BLUR
-    || params->feathering_guide == DEVELOP_MASK_GUIDE_OUT_AFTER_BLUR;
+       bp->feathering_guide == DEVELOP_MASK_GUIDE_OUT_BEFORE_BLUR
+    || bp->feathering_guide == DEVELOP_MASK_GUIDE_OUT_AFTER_BLUR;
 
-  const float opacity = CLIP(params->opacity / 100.0f);
+  const float opacity = CLIP(bp->opacity / 100.0f);
 
   memset(operations, 0, sizeof(_develop_mask_post_processing) * 3);
   size_t index = 0;
@@ -418,8 +417,7 @@ static void _develop_blend_process_mask_tone_curve(float *const restrict mask,
   DT_OMP_FOR_SIMD(aligned(mask:64))
   for(size_t k = 0; k < buffsize; k++)
   {
-    float x = mask[k] / opacity;
-    x = 2.f * x - 1.f;
+    float x = 2.0f * mask[k] / opacity - 1.0f;
     if(1.f - brightness <= 0.f)
       x = mask[k] <= mask_epsilon ? -1.f : 1.f;
     else if(1.f + brightness <= 0.f)
@@ -434,7 +432,12 @@ static void _develop_blend_process_mask_tone_curve(float *const restrict mask,
       x = (x + brightness) / (1.f + brightness);
       x = fmaxf(x, -1.f);
     }
-    mask[k] = CLIP(((x * e / (1.f + (e - 1.f) * fabsf(x))) / 2.f + 0.5f) * opacity);
+    const float cval = 0.5f * (x * e / (1.f + (e - 1.f) * fabsf(x))) + 0.5f;
+    /*  we don't want *very* small masking values possibly resulting from above maths
+        so we make sure they above a threshold
+    */
+    const float mval = cval > 1e-6 ? cval : 0.0f;
+    mask[k] = CLIP(mval) * opacity;
   }
 }
 
@@ -1225,12 +1228,10 @@ gboolean dt_develop_blend_process_cl(dt_iop_module_t *self,
       else if(operation == DEVELOP_MASK_POST_TONE_CURVE)
       {
         const float e = expf(3.f * d->contrast);
-        const float brightness = d->brightness;
-
         err = dt_opencl_enqueue_kernel_2d_args(devid, kernel_mask_tone_curve, owidth, oheight,
                                   CLARG(dev_mask), CLARG(dev_mask_2),
                                   CLARG(owidth), CLARG(oheight),
-                                  CLARG(e), CLARG(brightness), CLARG(opacity));
+                                  CLARG(e), CLARG(d->brightness), CLARG(opacity));
         if(err != CL_SUCCESS)
         {
           dt_print(DT_DEBUG_OPENCL,


### PR DESCRIPTION
In both - CPU and OpenCL - codepaths the resulting blending mask values could lead to mask values very slightly above zero where in fact they should be zero.

In case of extremely large signal levels this could lead to brightness bleeding into areas clearly outside the masks. See 

Fixes #20883

We make sure mask values below 1e-6 are set to 0.