### PR TITLE
[AI] Gate AMD/OpenVINO setup on actual EP availability

### DIFF
--- a/src/ai/backend_onnx.c
+++ b/src/ai/backend_onnx.c
@@ -861,6 +861,24 @@ done:
   return (gpointer)api;
 }
 
+// query ORT for whether a given execution provider was compiled into
+// the loaded library; safe to call before CreateEnv — GetAvailableProviders
+// just lists statically-linked / loadable providers, it does not load them
+static gboolean _ort_has_provider(const char *name)
+{
+  if(!g_ort || !g_ort->GetAvailableProviders) return FALSE;
+  char **providers = NULL;
+  int n = 0;
+  if(g_ort->GetAvailableProviders(&providers, &n) != NULL || !providers)
+    return FALSE;
+  gboolean found = FALSE;
+  for(int i = 0; i < n && !found; i++)
+    if(g_strcmp0(providers[i], name) == 0) found = TRUE;
+  if(g_ort->ReleaseAvailableProviders)
+    g_ort->ReleaseAvailableProviders(providers, n);
+  return found;
+}
+
 #if defined(__linux__)
 // configure AMD GPU caches (MIOpen kernel db + MIGraphX compiled-program
 // cache) via environment variables. these MUST be set before any ORT
@@ -879,7 +897,7 @@ done:
 // keep control
 static void _setup_amd_caches(void)
 {
-  if(!g_file_test("/opt/rocm", G_FILE_TEST_IS_DIR))
+  if(!_ort_has_provider("MIGraphXExecutionProvider"))
     return;
 
   char cachedir[PATH_MAX] = { 0 };
@@ -909,7 +927,8 @@ static void _setup_amd_caches(void)
 // writes .blob files to cache_dir for instant reload on subsequent runs
 static gboolean _try_openvino_with_cache(OrtSessionOptions *session_opts)
 {
-  if(!g_ort || !g_ort->SessionOptionsAppendExecutionProvider_OpenVINO_V2)
+  if(!_ort_has_provider("OpenVINOExecutionProvider")
+     || !g_ort->SessionOptionsAppendExecutionProvider_OpenVINO_V2)
     return FALSE;
 
   char cachedir[PATH_MAX] = { 0 };


### PR DESCRIPTION
Gate AMD MIOpen/MIGraphX cache setup and OpenVINO V2 setup on actual EP availability (`OrtApi::GetAvailableProviders`) instead of the `/opt/rocm` directory check.

Reported in [#20926](https://github.com/darktable-org/darktable/issues/20926#issuecomment-4380233996): on Fedora distro-packaged ROCm (no `/opt/rocm`) and side-by-side installs (`/opt/rocm-X.Y`), the cache env vars were never set, so every launch recompiled MIOpen kernels (10+ minutes on consumer AMD) and the MIGraphX graph.

## Fix

- New file-static helper `_ort_has_provider(name)` wrapping `GetAvailableProviders`. Safe to call before `CreateEnv` (does not load any EP).
- `_setup_amd_caches()`: replace `g_file_test("/opt/rocm", ...)` with `_ort_has_provider("MIGraphXExecutionProvider")`.
- `_try_openvino_with_cache()`: add `_ort_has_provider("OpenVINOExecutionProvider")` before the existing V2 function-pointer check. Both are required - EP must be compiled in and the V2 API must exist.