### PR TITLE
Some OpenCL maintenance and improves

### DIFF
--- a/data/kernels/blendop.cl
+++ b/data/kernels/blendop.cl
@@ -1340,7 +1340,7 @@ blendop_rgb_jzczhz(__read_only image2d_t in_a, __read_only image2d_t in_b, __rea
       break;
 
     case DEVELOP_BLEND_AVERAGE:
-      o = a * (1.0f - opacity) + (a + b)/2.0f * opacity;
+      o = a * (1.0f - opacity) + 0.5f * (a + b) * opacity;
       break;
 
     case DEVELOP_BLEND_ADD:
@@ -1500,51 +1500,51 @@ blendop_display_channel(__read_only image2d_t in_a, __read_only image2d_t in_b, 
   switch(channel & DT_DEV_PIXELPIPE_DISPLAY_ANY)
   {
     case DT_DEV_PIXELPIPE_DISPLAY_L:
-      c = clipf(a.x / 100.0f / dtcl_exp2(boost_factors[DEVELOP_BLENDIF_L_in]));
+      c = a.x / 100.0f / dtcl_exp2(boost_factors[DEVELOP_BLENDIF_L_in]);
       is_lab = 1;
       break;
     case (DT_DEV_PIXELPIPE_DISPLAY_L | DT_DEV_PIXELPIPE_DISPLAY_OUTPUT):
-      c = clipf(b.x / 100.0f / dtcl_exp2(boost_factors[DEVELOP_BLENDIF_L_out]));
+      c = b.x / 100.0f / dtcl_exp2(boost_factors[DEVELOP_BLENDIF_L_out]);
       is_lab = 1;
       break;
     case DT_DEV_PIXELPIPE_DISPLAY_a:
-      c = clipf(a.y / 256.0f / dtcl_exp2(boost_factors[DEVELOP_BLENDIF_A_in]) + 0.5f);
+      c = a.y / 256.0f / dtcl_exp2(boost_factors[DEVELOP_BLENDIF_A_in]) + 0.5f;
       is_lab = 1;
       break;
     case (DT_DEV_PIXELPIPE_DISPLAY_a | DT_DEV_PIXELPIPE_DISPLAY_OUTPUT):
-      c = clipf(b.y / 256.0f / dtcl_exp2(boost_factors[DEVELOP_BLENDIF_A_out]) + 0.5f);
+      c = b.y / 256.0f / dtcl_exp2(boost_factors[DEVELOP_BLENDIF_A_out]) + 0.5f;
       is_lab = 1;
       break;
     case DT_DEV_PIXELPIPE_DISPLAY_b:
-      c = clipf(a.z / 256.0f / dtcl_exp2(boost_factors[DEVELOP_BLENDIF_B_in]) + 0.5f);
+      c = a.z / 256.0f / dtcl_exp2(boost_factors[DEVELOP_BLENDIF_B_in]) + 0.5f;
       is_lab = 1;
       break;
     case (DT_DEV_PIXELPIPE_DISPLAY_b | DT_DEV_PIXELPIPE_DISPLAY_OUTPUT):
-      c = clipf(b.z / 256.0f / dtcl_exp2(boost_factors[DEVELOP_BLENDIF_A_in]) + 0.5f);
+      c = b.z / 256.0f / dtcl_exp2(boost_factors[DEVELOP_BLENDIF_A_in]) + 0.5f;
       is_lab = 1;
       break;
     case DT_DEV_PIXELPIPE_DISPLAY_R:
-      c = clipf(a.x / dtcl_exp2(boost_factors[DEVELOP_BLENDIF_RED_in]));
+      c = a.x / dtcl_exp2(boost_factors[DEVELOP_BLENDIF_RED_in]);
       is_lab = 0;
       break;
     case (DT_DEV_PIXELPIPE_DISPLAY_R | DT_DEV_PIXELPIPE_DISPLAY_OUTPUT):
-      c = clipf(b.x / dtcl_exp2(boost_factors[DEVELOP_BLENDIF_RED_out]));
+      c = b.x / dtcl_exp2(boost_factors[DEVELOP_BLENDIF_RED_out]);
       is_lab = 0;
       break;
     case DT_DEV_PIXELPIPE_DISPLAY_G:
-      c = clipf(a.y / dtcl_exp2(boost_factors[DEVELOP_BLENDIF_GREEN_in]));
+      c = a.y / dtcl_exp2(boost_factors[DEVELOP_BLENDIF_GREEN_in]);
       is_lab = 0;
       break;
     case (DT_DEV_PIXELPIPE_DISPLAY_G | DT_DEV_PIXELPIPE_DISPLAY_OUTPUT):
-      c = clipf(b.y / dtcl_exp2(boost_factors[DEVELOP_BLENDIF_GREEN_out]));
+      c = b.y / dtcl_exp2(boost_factors[DEVELOP_BLENDIF_GREEN_out]);
       is_lab = 0;
       break;
     case DT_DEV_PIXELPIPE_DISPLAY_B:
-      c = clipf(a.z / dtcl_exp2(boost_factors[DEVELOP_BLENDIF_BLUE_in]));
+      c = a.z / dtcl_exp2(boost_factors[DEVELOP_BLENDIF_BLUE_in]);
       is_lab = 0;
       break;
     case (DT_DEV_PIXELPIPE_DISPLAY_B | DT_DEV_PIXELPIPE_DISPLAY_OUTPUT):
-      c = clipf(b.z / dtcl_exp2(boost_factors[DEVELOP_BLENDIF_BLUE_out]));
+      c = b.z / dtcl_exp2(boost_factors[DEVELOP_BLENDIF_BLUE_out]);
       is_lab = 0;
       break;
     case DT_DEV_PIXELPIPE_DISPLAY_GRAY:
@@ -1552,7 +1552,7 @@ blendop_display_channel(__read_only image2d_t in_a, __read_only image2d_t in_b, 
         c = 0.3f * a.x + 0.59f * a.y + 0.11f * a.z;
       else
         c = get_rgb_matrix_luminance(a, profile_info, profile_info->matrix_in, profile_lut);
-      c = clipf(c / dtcl_exp2(boost_factors[DEVELOP_BLENDIF_GRAY_in]));
+      c = c / dtcl_exp2(boost_factors[DEVELOP_BLENDIF_GRAY_in]);
       is_lab = 0;
       break;
     case (DT_DEV_PIXELPIPE_DISPLAY_GRAY | DT_DEV_PIXELPIPE_DISPLAY_OUTPUT):
@@ -1560,87 +1560,87 @@ blendop_display_channel(__read_only image2d_t in_a, __read_only image2d_t in_b, 
         c = 0.3f * b.x + 0.59f * b.y + 0.11f * b.z;
       else
         c = get_rgb_matrix_luminance(b, profile_info, profile_info->matrix_in, profile_lut);
-      c = clipf(c / dtcl_exp2(boost_factors[DEVELOP_BLENDIF_GRAY_out]));
+      c = c / dtcl_exp2(boost_factors[DEVELOP_BLENDIF_GRAY_out]);
       is_lab = 0;
       break;
     case DT_DEV_PIXELPIPE_DISPLAY_LCH_C:
       LCH = Lab_2_LCH(a);
-      c = clipf(LCH.y / (128.0f * M_SQRT2_F / exp2(boost_factors[DEVELOP_BLENDIF_C_in])));
+      c = LCH.y / (128.0f * M_SQRT2_F / exp2(boost_factors[DEVELOP_BLENDIF_C_in]));
       is_lab = 1;
       break;
     case (DT_DEV_PIXELPIPE_DISPLAY_LCH_C | DT_DEV_PIXELPIPE_DISPLAY_OUTPUT):
       LCH = Lab_2_LCH(b);
-      c = clipf(LCH.y / (128.0f * M_SQRT2_F) / exp2(boost_factors[DEVELOP_BLENDIF_C_out]));
+      c = LCH.y / (128.0f * M_SQRT2_F) / exp2(boost_factors[DEVELOP_BLENDIF_C_out]);
       is_lab = 1;
       break;
     case DT_DEV_PIXELPIPE_DISPLAY_LCH_h:
       LCH = Lab_2_LCH(a);
-      c = clipf(LCH.z); // no boost for hues
+      c = LCH.z; // no boost for hues
       is_lab = 1;
       break;
     case (DT_DEV_PIXELPIPE_DISPLAY_LCH_h | DT_DEV_PIXELPIPE_DISPLAY_OUTPUT):
       LCH = Lab_2_LCH(b);
-      c = clipf(LCH.z); // no boost for hues
+      c = LCH.z; // no boost for hues
       is_lab = 1;
       break;
     case DT_DEV_PIXELPIPE_DISPLAY_HSL_H:
       HSL = RGB_2_HSL(a);
-      c = clipf(HSL.x); // no boost for hues
+      c = HSL.x; // no boost for hues
       is_lab = 0;
       break;
     case (DT_DEV_PIXELPIPE_DISPLAY_HSL_H | DT_DEV_PIXELPIPE_DISPLAY_OUTPUT):
       HSL = RGB_2_HSL(b);
-      c = clipf(HSL.x); // no boost for hues
+      c = HSL.x; // no boost for hues
       is_lab = 0;
       break;
     case DT_DEV_PIXELPIPE_DISPLAY_HSL_S:
       HSL = RGB_2_HSL(a);
-      c = clipf(HSL.y); // no boost for HSL
+      c = HSL.y; // no boost for HSL
       is_lab = 0;
       break;
     case (DT_DEV_PIXELPIPE_DISPLAY_HSL_S | DT_DEV_PIXELPIPE_DISPLAY_OUTPUT):
       HSL = RGB_2_HSL(b);
-      c = clipf(HSL.y); // no boost for HSL
+      c = HSL.y; // no boost for HSL
       is_lab = 0;
       break;
     case DT_DEV_PIXELPIPE_DISPLAY_HSL_l:
       HSL = RGB_2_HSL(a);
-      c = clipf(HSL.z); // no boost for HSL
+      c = HSL.z; // no boost for HSL
       is_lab = 0;
       break;
     case (DT_DEV_PIXELPIPE_DISPLAY_HSL_l | DT_DEV_PIXELPIPE_DISPLAY_OUTPUT):
       HSL = RGB_2_HSL(b);
-      c = clipf(HSL.z); // no boost for HSL
+      c = HSL.z; // no boost for HSL
       is_lab = 0;
       break;
     case DT_DEV_PIXELPIPE_DISPLAY_JzCzhz_Jz:
       JzCzhz = rgb_to_JzCzhz(a, profile_info, profile_lut, use_profile);
-      c = clipf(JzCzhz.x / exp2(boost_factors[DEVELOP_BLENDIF_Jz_in]));
+      c = JzCzhz.x / exp2(boost_factors[DEVELOP_BLENDIF_Jz_in]);
       is_lab = 0;
       break;
     case (DT_DEV_PIXELPIPE_DISPLAY_JzCzhz_Jz | DT_DEV_PIXELPIPE_DISPLAY_OUTPUT):
       JzCzhz = rgb_to_JzCzhz(b, profile_info, profile_lut, use_profile);
-      c = clipf(JzCzhz.x / dtcl_exp2(boost_factors[DEVELOP_BLENDIF_Jz_out]));
+      c = JzCzhz.x / dtcl_exp2(boost_factors[DEVELOP_BLENDIF_Jz_out]);
       is_lab = 0;
       break;
     case DT_DEV_PIXELPIPE_DISPLAY_JzCzhz_Cz:
       JzCzhz = rgb_to_JzCzhz(a, profile_info, profile_lut, use_profile);
-      c = clipf(JzCzhz.y / dtcl_exp2(boost_factors[DEVELOP_BLENDIF_Cz_in]));
+      c = JzCzhz.y / dtcl_exp2(boost_factors[DEVELOP_BLENDIF_Cz_in]);
       is_lab = 0;
       break;
     case (DT_DEV_PIXELPIPE_DISPLAY_JzCzhz_Cz | DT_DEV_PIXELPIPE_DISPLAY_OUTPUT):
       JzCzhz = rgb_to_JzCzhz(b, profile_info, profile_lut, use_profile);
-      c = clipf(JzCzhz.y / dtcl_exp2(boost_factors[DEVELOP_BLENDIF_Cz_out]));
+      c = JzCzhz.y / dtcl_exp2(boost_factors[DEVELOP_BLENDIF_Cz_out]);
       is_lab = 0;
       break;
     case DT_DEV_PIXELPIPE_DISPLAY_JzCzhz_hz:
       JzCzhz = rgb_to_JzCzhz(a, profile_info, profile_lut, use_profile);
-      c = clipf(JzCzhz.z / dtcl_exp2(boost_factors[DEVELOP_BLENDIF_hz_in]));
+      c = JzCzhz.z / dtcl_exp2(boost_factors[DEVELOP_BLENDIF_hz_in]);
       is_lab = 0;
       break;
     case (DT_DEV_PIXELPIPE_DISPLAY_JzCzhz_hz | DT_DEV_PIXELPIPE_DISPLAY_OUTPUT):
       JzCzhz = rgb_to_JzCzhz(b, profile_info, profile_lut, use_profile);
-      c = clipf(JzCzhz.z / dtcl_exp2(boost_factors[DEVELOP_BLENDIF_hz_out]));
+      c = JzCzhz.z / dtcl_exp2(boost_factors[DEVELOP_BLENDIF_hz_out]);
       is_lab = 0;
       break;
     default:
@@ -1649,7 +1649,7 @@ blendop_display_channel(__read_only image2d_t in_a, __read_only image2d_t in_b, 
       break;
   }
 
-  a.x = a.y = a.z = c;
+  a.x = a.y = a.z = clipf(c);
   a.w = opacity;
 
   if(is_lab)
@@ -1668,4 +1668,53 @@ blendop_display_channel(__read_only image2d_t in_a, __read_only image2d_t in_b, 
   }
 
   write_imagef(out, (int2)(x, y), a);
+}
+
+static inline float calcBlendFactor(float val, float threshold)
+{
+    // sigmoid function
+    // result is in ]0;1] range
+    // inflexion point is at (x, y) (threshold, 0.5)
+    return 1.0f / (1.0f + dt_fast_expf(16.0f - (16.0f / threshold) * val));
+}
+
+__kernel void calc_Y0_mask(global float *mask,
+                          __read_only image2d_t in,
+                          const int w,
+                          const int height,
+                          const float4 wb)
+{
+  const int col = get_global_id(0);
+  const int row = get_global_id(1);
+  if((col >= w) || (row >= height)) return;
+  const int idx = mad24(row, w, col);
+
+  const float4 pt = wb * fmax(0.0f, Areadpixel(in, col, row));
+  mask[idx] = dtcl_sqrt((pt.x + pt.y + pt.z) / 3.0f);
+}
+
+__kernel void calc_scharr_mask(global float *in, global float *out, const int w, const int height)
+{
+  const int col = get_global_id(0);
+  const int row = get_global_id(1);
+  if((col >= w) || (row >= height)) return;
+
+  const int oidx = mad24(row, w, col);
+  const int incol = clamp(col, 1, w - 2);
+  const int inrow = clamp(row, 1, height -2);
+  const int idx = mad24(inrow, w, incol);
+  const float gradient_magnitude = scharr_gradient(in, idx, w);
+  out[oidx] = clipf(gradient_magnitude / 16.0f);
+}
+
+__kernel void calc_detail_blend(global float *in, global float *out, const int w, const int height, const float threshold, const int detail)
+{
+  const int col = get_global_id(0);
+  const int row = get_global_id(1);
+  if((col >= w) || (row >= height)) return;
+
+  const int idx = mad24(row, w, col);
+
+  const float blend = clipf(calcBlendFactor(in[idx], threshold));
+  out[idx] = detail ? blend : 1.0f - blend;
 }

--- a/data/kernels/demosaic_rcd.cl
+++ b/data/kernels/demosaic_rcd.cl
@@ -18,14 +18,6 @@
 
 #include "common.h"
 
-static inline float calcBlendFactor(float val, float threshold)
-{
-    // sigmoid function
-    // result is in ]0;1] range
-    // inflexion point is at (x, y) (threshold, 0.5)
-    return 1.0f / (1.0f + dt_fast_expf(16.0f - (16.0f / threshold) * val));
-}
-
 // Populate cfa and rgb data by normalized input
 __kernel void rcd_populate (__read_only image2d_t in, global float *cfa, global float *rgb0, global float *rgb1, global float *rgb2, const int w, const int height, const unsigned int filters, const float scale)
 {
@@ -313,46 +305,6 @@ __kernel void write_blended_dual(__read_only image2d_t high,
   write_imagef(out, (int2)(col, row), data);
 }
 
-__kernel void calc_Y0_mask(global float *mask,
-                          __read_only image2d_t in,
-                          const int w,
-                          const int height,
-                          const float4 wb)
-{
-  const int col = get_global_id(0);
-  const int row = get_global_id(1);
-  if((col >= w) || (row >= height)) return;
-  const int idx = mad24(row, w, col);
-
-  const float4 pt = wb * fmax(0.0f, Areadpixel(in, col, row));
-  mask[idx] = dtcl_sqrt((pt.x + pt.y + pt.z) / 3.0f);
-}
-
-__kernel void calc_scharr_mask(global float *in, global float *out, const int w, const int height)
-{
-  const int col = get_global_id(0);
-  const int row = get_global_id(1);
-  if((col >= w) || (row >= height)) return;
-
-  const int oidx = mad24(row, w, col);
-  const int incol = clamp(col, 1, w - 2);
-  const int inrow = clamp(row, 1, height -2);
-  const int idx = mad24(inrow, w, incol);
-  const float gradient_magnitude = scharr_gradient(in, idx, w);
-  out[oidx] = clipf(gradient_magnitude / 16.0f);
-}
-
-__kernel void calc_detail_blend(global float *in, global float *out, const int w, const int height, const float threshold, const int detail)
-{
-  const int col = get_global_id(0);
-  const int row = get_global_id(1);
-  if((col >= w) || (row >= height)) return;
-
-  const int idx = mad24(row, w, col);
-
-  const float blend = clipf(calcBlendFactor(in[idx], threshold));
-  out[idx] = detail ? blend : 1.0f - blend;
-}
 
 kernel void demosaic_box3(read_only image2d_t in,
                           write_only image2d_t out,

--- a/src/common/bilateralcl.c
+++ b/src/common/bilateralcl.c
@@ -200,9 +200,8 @@ cl_int dt_bilateral_slice_to_output_cl(dt_bilateral_cl_t *b, cl_mem in, cl_mem o
   cl_mem tmp = dt_opencl_alloc_device(b->devid, b->width, b->height, sizeof(float) * 4);
   if(tmp == NULL) goto error;
 
-  size_t origin[] = { 0, 0 };
   size_t region[] = { b->width, b->height };
-  err = dt_opencl_enqueue_copy_image(b->devid, out, tmp, origin, origin, region);
+  err = dt_opencl_enqueue_copy_image(b->devid, out, tmp, CLIMG_ORIGIN, CLIMG_ORIGIN, region);
   if(err != CL_SUCCESS) goto error;
 
   err = dt_opencl_enqueue_kernel_2d_args(b->devid, b->global->kernel_slice2, b->width, b->height,

--- a/src/common/gaussian.c
+++ b/src/common/gaussian.c
@@ -927,7 +927,6 @@ cl_int dt_gaussian_blur_cl(dt_gaussian_cl_t *g, cl_mem dev_in, cl_mem dev_out)
   else
     return DT_OPENCL_PROCESS_CL;
 
-  size_t origin[] = { 0, 0 };
   size_t region[] = { width, height };
   size_t local[2] = { blocksize, blocksize };
   size_t sizes[2];
@@ -937,7 +936,7 @@ cl_int dt_gaussian_blur_cl(dt_gaussian_cl_t *g, cl_mem dev_in, cl_mem dev_out)
   _compute_gauss_params(g->sigma, g->order, &a0, &a1, &a2, &a3, &b1, &b2, &coefp, &coefn);
 
   // copy dev_in to intermediate buffer dev_temp1
-  err = dt_opencl_enqueue_copy_image_to_buffer(devid, dev_in, dev_temp1, origin, region, 0);
+  err = dt_opencl_enqueue_copy_image_to_buffer(devid, dev_in, dev_temp1, CLIMG_ORIGIN, region, 0);
   if(err != CL_SUCCESS) return err;
 
   // first blur step: column by column with dev_temp1 -> dev_temp2
@@ -976,7 +975,7 @@ cl_int dt_gaussian_blur_cl(dt_gaussian_cl_t *g, cl_mem dev_in, cl_mem dev_out)
     return err;
 
   // finally produce output in dev_out
-  return dt_opencl_enqueue_copy_buffer_to_image(devid, dev_temp1, dev_out, 0, origin, region);
+  return dt_opencl_enqueue_copy_buffer_to_image(devid, dev_temp1, dev_out, 0, CLIMG_ORIGIN, region);
 }
 
 cl_int dt_gaussian_blur_cl_buffer(dt_gaussian_cl_t *g, cl_mem dev_in, cl_mem dev_out)

--- a/src/common/guided_filter.c
+++ b/src/common/guided_filter.c
@@ -560,9 +560,8 @@ static int _guided_filter_cl_impl(int devid,
       if(tiling)
       {
         size_t insrc[]  = { 0, first_in };
-        size_t tdest[]  = { 0, 0 };
         size_t iarea[]  = { width, t_height };
-        err = dt_opencl_enqueue_copy_image(devid, dev_in, in, insrc, tdest, iarea);
+        err = dt_opencl_enqueue_copy_image(devid, dev_in, in, insrc, CLIMG_ORIGIN, iarea);
       }
 
       if(err == CL_SUCCESS) err = _cl_split_rgb(devid, width, t_height, first_in, guide, imgg_mean_r, imgg_mean_g, imgg_mean_b, guide_weight);

--- a/src/common/interpolation.c
+++ b/src/common/interpolation.c
@@ -1245,10 +1245,9 @@ int dt_interpolation_resample_cl(const dt_interpolation_t *itor,
     if(wd_fit && ht_fit)
     {
       size_t iorigin[] = { dx, dy };
-      size_t oorigin[] = { 0, 0 };
       size_t region[] = { width, height };
       // copy original input from dev_in -> dev_out as starting point
-      err = dt_opencl_enqueue_copy_image(devid, dev_in, dev_out, iorigin, oorigin, region);
+      err = dt_opencl_enqueue_copy_image(devid, dev_in, dev_out, iorigin, CLIMG_ORIGIN, region);
     }
     else
     {

--- a/src/common/iop_profile.c
+++ b/src/common/iop_profile.c
@@ -1491,14 +1491,13 @@ gboolean dt_ioppr_transform_image_colorspace_cl
   const gboolean inplace = dev_img_in == dev_img_out;
   const gboolean anyraw = cst_to == IOP_CS_RAW || cst_from == IOP_CS_RAW;
 
-  size_t origin[] = { 0, 0 };
   size_t region[] = { width, height };
 
   *converted_cst = cst_to;
   if(cst_from == cst_to)
   {
     if(!inplace)
-      err = dt_opencl_enqueue_copy_image(devid, dev_img_in, dev_img_out, origin, origin, region);
+      err = dt_opencl_enqueue_copy_image(devid, dev_img_in, dev_img_out, CLIMG_ORIGIN, CLIMG_ORIGIN, region);
     return err == CL_SUCCESS;
   }
 
@@ -1508,7 +1507,7 @@ gboolean dt_ioppr_transform_image_colorspace_cl
   {
     *converted_cst = cst_from;
     if(!inplace && !anyraw)
-      err = dt_opencl_enqueue_copy_image(devid, dev_img_in, dev_img_out, origin, origin, region);
+      err = dt_opencl_enqueue_copy_image(devid, dev_img_in, dev_img_out, CLIMG_ORIGIN, CLIMG_ORIGIN, region);
 
     if(!inplace || cst_to == IOP_CS_RAW || cst_from == IOP_CS_RAW)
       dt_print(DT_DEBUG_PIPE,
@@ -1579,7 +1578,7 @@ gboolean dt_ioppr_transform_image_colorspace_cl
         goto cleanup;
       }
 
-      err = dt_opencl_enqueue_copy_image(devid, dev_img_in, dev_tmp, origin, origin, region);
+      err = dt_opencl_enqueue_copy_image(devid, dev_img_in, dev_tmp, CLIMG_ORIGIN, CLIMG_ORIGIN, region);
       if(err != CL_SUCCESS)
         goto cleanup;
     }
@@ -1678,10 +1677,8 @@ gboolean dt_ioppr_transform_image_colorspace_rgb_cl
   {
     if(dev_img_in != dev_img_out)
     {
-      size_t origin[] = { 0, 0 };
       size_t region[] = { width, height };
-
-      err = dt_opencl_enqueue_copy_image(devid, dev_img_in, dev_img_out, origin, origin, region);
+      err = dt_opencl_enqueue_copy_image(devid, dev_img_in, dev_img_out, CLIMG_ORIGIN, CLIMG_ORIGIN, region);
       if(err != CL_SUCCESS)
       {
         dt_print(DT_DEBUG_OPENCL,
@@ -1723,8 +1720,7 @@ gboolean dt_ioppr_transform_image_colorspace_rgb_cl
     dt_times_t start_time = { 0 };
     dt_get_perf_times(&start_time);
 
-    size_t origin[] = { 0, 0, 0 };
-    size_t region[] = { width, height, 1 };
+    size_t region[] = { width, height };
 
     kernel_transform = darktable.opencl->colorspaces->kernel_colorspaces_transform_rgb_matrix_to_rgb;
 
@@ -1746,7 +1742,7 @@ gboolean dt_ioppr_transform_image_colorspace_rgb_cl
         goto cleanup;
       }
 
-      err = dt_opencl_enqueue_copy_image(devid, dev_img_in, dev_tmp, origin, origin, region);
+      err = dt_opencl_enqueue_copy_image(devid, dev_img_in, dev_tmp, CLIMG_ORIGIN, CLIMG_ORIGIN, region);
       if(err != CL_SUCCESS)
          goto cleanup;
      }

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -899,10 +899,13 @@ static gboolean _opencl_device_init(dt_opencl_t *cl,
     cl->dev[dev].clroundup_ht = 16;
   }
 
+  const gboolean fastopencl = dt_conf_get_bool("opencl_fast");
   dt_print_nts(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE,
                "   ROUNDUP WIDTH & HEIGHT    %ix%i\n", cl->dev[dev].clroundup_wd, cl->dev[dev].clroundup_ht);
   dt_print_nts(DT_DEBUG_OPENCL,
                "   EVENTS HANDLED:           %s\n", STR_YESNO(cl->dev[dev].use_events));
+  dt_print_nts(DT_DEBUG_OPENCL,
+               "   OPENCL FAST MODE:         %s\n", STR_YESNO(fastopencl));
   dt_print_nts(DT_DEBUG_OPENCL,
                "   TILING ADVANTAGE:         %.3f\n", cl->dev[dev].advantage);
   dt_print_nts(DT_DEBUG_OPENCL,
@@ -981,7 +984,7 @@ static gboolean _opencl_device_init(dt_opencl_t *cl,
   escapedkerneldir = dt_util_str_replace(kerneldir, " ", "\\ ");
 #endif
 
-  const char* compile_opt = dt_conf_get_bool("opencl_fast") ? DT_OPENCL_DEFAULT_COMPILE_OPTI : DT_OPENCL_DEFAULT_COMPILE_DEFAULT;
+  const char* compile_opt = fastopencl ? DT_OPENCL_DEFAULT_COMPILE_OPTI : DT_OPENCL_DEFAULT_COMPILE_DEFAULT;
   cl->dev[dev].cflags = g_strdup_printf("-w %s%s -D%s=1",
                                 compile_opt,
                                 cl->dev[dev].cuda && cl->dev[dev].atomic_support ? " -DNVIDIA_SM_20=1" : "",
@@ -1139,6 +1142,7 @@ void dt_opencl_init(dt_opencl_t *cl,
   cl->enabled = FALSE;
   cl->stopped = FALSE;
   cl->error_count = 0;
+  cl->fastcl = dt_conf_get_bool("opencl_fast");
 #if CL_TARGET_OPENCL_VERSION == 300
   cl->api30 = TRUE;
 #else
@@ -1523,7 +1527,7 @@ finally:
         cl->dev[i].max_global_mem = reserved;
         cl->dev[i].max_mem_alloc = MIN(cl->dev[i].max_mem_alloc, reserved);
         dt_print_nts(DT_DEBUG_OPENCL,
-               "   UNIFIED MEM SIZE:         %.0f MB reserved for '%s' id=%d",
+               "   UNIFIED MEM SIZE:         %.0f MB reserved for '%s' id=%d\n",
                (double)reserved / 1024.0 / 1024.0, cl->dev[i].cname, i);
         res->total_memory -= reserved;
       }
@@ -3490,8 +3494,8 @@ void *dt_opencl_duplicate_image(const int devid, const cl_mem src)
   cl_mem new = dt_opencl_alloc_device(devid, width, height, el);
   if(new == NULL) return NULL;
 
-  size_t origin[]   = { 0, 0, 0 };
-  size_t region[] = { width, height, 1 };
+  size_t origin[]   = { 0, 0 };
+  size_t region[] = { width, height };
   const cl_int err = dt_opencl_enqueue_copy_image(devid, src, new, origin, origin, region);
   if(err != CL_SUCCESS)
   {
@@ -3686,6 +3690,12 @@ gboolean dt_opencl_running(void)
   return _cl_running();
 }
 
+/** runtime check for cl system running in fast mode */
+gboolean dt_opencl_running_fast(void)
+{
+  return _cl_running() ? darktable.opencl->fastcl : FALSE;
+}
+
 /** update enabled flag and profile with value from preferences */
 void dt_opencl_update_settings(void)
 {
@@ -3780,7 +3790,7 @@ static cl_event *_opencl_events_get_slot(const int devid,
   // if first time called: allocate initial buffers
   if(*eventlist == NULL)
   {
-    int newevents = DT_OPENCL_EVENTLISTSIZE;
+    int newevents = DT_OPENCL_EVENTS;
     *eventlist = calloc(newevents, sizeof(cl_event));
     *eventtags = calloc(newevents, sizeof(dt_opencl_eventtag_t));
     if(!*eventlist || !*eventtags)
@@ -3823,7 +3833,7 @@ static cl_event *_opencl_events_get_slot(const int devid,
   // if no more space left in eventlist: grow buffer
   if(*numevents == *maxevents)
   {
-    int newevents = *maxevents + DT_OPENCL_EVENTLISTSIZE;
+    int newevents = *maxevents + DT_OPENCL_EVENTS;
     cl_event *neweventlist = calloc(newevents, sizeof(cl_event));
     dt_opencl_eventtag_t *neweventtags = calloc(newevents, sizeof(dt_opencl_eventtag_t));
     if(!neweventlist || !neweventtags)

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -3494,9 +3494,8 @@ void *dt_opencl_duplicate_image(const int devid, const cl_mem src)
   cl_mem new = dt_opencl_alloc_device(devid, width, height, el);
   if(new == NULL) return NULL;
 
-  size_t origin[]   = { 0, 0 };
   size_t region[] = { width, height };
-  const cl_int err = dt_opencl_enqueue_copy_image(devid, src, new, origin, origin, region);
+  const cl_int err = dt_opencl_enqueue_copy_image(devid, src, new, CLIMG_ORIGIN, CLIMG_ORIGIN, region);
   if(err != CL_SUCCESS)
   {
     dt_opencl_release_mem_object(new);

--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -21,7 +21,6 @@
 #define DT_OPENCL_MAX_PLATFORMS 5
 #define DT_OPENCL_MAX_PROGRAMS 256
 #define DT_OPENCL_MAX_KERNELS 512
-#define DT_OPENCL_EVENTLISTSIZE 256
 #define DT_OPENCL_EVENTNAMELENGTH 64
 #define DT_OPENCL_MAX_ERRORS 5
 #define DT_OPENCL_MAX_INCLUDES 8
@@ -32,13 +31,14 @@
 #define DT_OPENCL_CBUFFSIZE 1024
 #define DT_OPENCL_DEFAULT_HEADROOM 600
 
-/* The number of events handled by the driver is principally not limited.
+/* The number of events handled by the driver is principally not limited and can't be checked.
    If a device handler can't process a function handling an event it will return
    an error codition that will be checked in darktable.
    Still we don't want to stress the device resources too much so we try to keep
    handled events in a safe range.
+   The internal list of events takes this as granularity too.
 */
-#define DT_OPENCL_EVENTS 4096
+#define DT_OPENCL_EVENTS 2048
 
 // some pseudo error codes in dt opencl usage
 #define DT_OPENCL_DEFAULT_ERROR -999
@@ -229,6 +229,7 @@ typedef struct dt_opencl_t
   gboolean print_statistics;
   gboolean enabled;
   gboolean stopped;
+  gboolean fastcl;  // for fast runtime checks instead of reading the conf
   int num_devs;
   int error_count;
   int opencl_synchronization_timeout;
@@ -422,6 +423,9 @@ gboolean dt_opencl_is_enabled(void);
 
 /** runtime check for cl system running */
 gboolean dt_opencl_running(void);
+
+/** runtime check for cl system running in fast mode */
+gboolean dt_opencl_running_fast(void);
 
 /** update enabled flag and profile with value from preferences */
 void dt_opencl_update_settings(void);
@@ -708,6 +712,10 @@ static inline gboolean dt_opencl_is_enabled(void)
   return FALSE;
 }
 static inline gboolean dt_opencl_running(void)
+{
+  return FALSE;
+}
+static inline gboolean dt_opencl_running_fast(void)
 {
   return FALSE;
 }

--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -62,6 +62,9 @@
 
 G_BEGIN_DECLS
 
+// instead of declaring the size_t struct for origin we have a #define for this for readability
+#define CLIMG_ORIGIN (size_t[]){0,0}
+
 #define ROUNDUP(a, n) ((a) % (n) == 0 ? (a) : ((a) / (n)+1) * (n))
 
 // use per device roundups here

--- a/src/develop/blend.c
+++ b/src/develop/blend.c
@@ -1406,14 +1406,12 @@ dt_blendop_cl_global_t *dt_develop_blend_init_cl_global(void)
     dt_opencl_create_kernel(program, "blendop_set_mask");
   b->kernel_blendop_display_channel =
     dt_opencl_create_kernel(program, "blendop_display_channel");
-
-  const int program_rcd = 31;
   b->kernel_calc_Y0_mask =
-    dt_opencl_create_kernel(program_rcd, "calc_Y0_mask");
+    dt_opencl_create_kernel(program, "calc_Y0_mask");
   b->kernel_calc_scharr_mask =
-    dt_opencl_create_kernel(program_rcd, "calc_scharr_mask");
+    dt_opencl_create_kernel(program, "calc_scharr_mask");
   b->kernel_calc_blend =
-    dt_opencl_create_kernel(program_rcd, "calc_detail_blend");
+    dt_opencl_create_kernel(program, "calc_detail_blend");
 
   return b;
 #else

--- a/src/develop/blend.c
+++ b/src/develop/blend.c
@@ -998,7 +998,6 @@ gboolean dt_develop_blend_process_cl(dt_iop_module_t *self,
   dt_colorspaces_iccprofile_info_cl_t *work_profile_info_cl = NULL;
   cl_float *work_profile_lut_cl = NULL;
 
-  size_t origin[] = { 0, 0 };
   size_t region[] = { owidth, oheight };
 
   // parameters, for every channel the 4 limits + pre-computed
@@ -1183,7 +1182,7 @@ gboolean dt_develop_blend_process_cl(dt_iop_module_t *self,
           if(dev_guide == NULL) goto error;
 
           size_t origin_1[] = { dx, dy };
-          err = dt_opencl_enqueue_copy_image(devid, dev_in, dev_guide, origin, origin_1, region);
+          err = dt_opencl_enqueue_copy_image(devid, dev_in, dev_guide, CLIMG_ORIGIN, origin_1, region);
           if(err != CL_SUCCESS)
           {
             dt_opencl_release_mem_object(dev_guide);
@@ -1253,7 +1252,7 @@ gboolean dt_develop_blend_process_cl(dt_iop_module_t *self,
   err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
   dev_tmp = dt_opencl_alloc_device(devid, owidth, oheight, sizeof(float) * ch);
   if(dev_tmp == NULL) goto error;
-  err = dt_opencl_enqueue_copy_image(devid, dev_out, dev_tmp, origin, origin, region);
+  err = dt_opencl_enqueue_copy_image(devid, dev_out, dev_tmp, CLIMG_ORIGIN, CLIMG_ORIGIN, region);
   if(err != CL_SUCCESS) goto error;
 
   if(request_mask_display & DT_DEV_PIXELPIPE_DISPLAY_ANY)

--- a/src/develop/blends/blendif_rgb_jzczhz.c
+++ b/src/develop/blends/blendif_rgb_jzczhz.c
@@ -557,7 +557,7 @@ _BLEND_FUNC _blend_average(const float *const a,
     const float local_opacity = mask[i];
     for(int k = 0; k < DT_BLENDIF_RGB_BCH; k++)
     {
-      out[j + k] = a[j + k] * (1.0f - local_opacity) + (a[j + k] + b[j + k]) / 2.0f * local_opacity;
+      out[j + k] = a[j + k] * (1.0f - local_opacity) + 0.5f * (a[j + k] + b[j + k]) * local_opacity;
     }
     out[j + DT_BLENDIF_RGB_BCH] = local_opacity;
   }

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -3652,9 +3652,8 @@ int process_cl(dt_iop_module_t *self,
   // if module is set to neutral parameters we just copy input->output and are done
   if(_isneutral(d))
   {
-    size_t origin[] = { 0, 0 };
     size_t region[] = { roi_out->width, roi_out->height };
-    err = dt_opencl_enqueue_copy_image(devid, dev_in, dev_out, origin, origin, region);
+    err = dt_opencl_enqueue_copy_image(devid, dev_in, dev_out, CLIMG_ORIGIN, CLIMG_ORIGIN, region);
     if(err != CL_SUCCESS) goto error;
     return CL_SUCCESS;
   }

--- a/src/iop/atrous.c
+++ b/src/iop/atrous.c
@@ -525,10 +525,9 @@ int process_cl(dt_iop_module_t *self,
     if(dev_detail[k] == NULL) goto error;
   }
 
-  size_t origin[] = { 0, 0 };
   size_t region[] = { width, height };
   // copy original input from dev_in -> dev_out as starting point
-  err = dt_opencl_enqueue_copy_image(devid, dev_in, dev_out, origin, origin, region);
+  err = dt_opencl_enqueue_copy_image(devid, dev_in, dev_out, CLIMG_ORIGIN, CLIMG_ORIGIN, region);
   if(err != CL_SUCCESS) goto error;
 
   /* decompose image into detail scales and coarse (the latter is left

--- a/src/iop/basecurve.c
+++ b/src/iop/basecurve.c
@@ -774,9 +774,8 @@ int process_cl_fusion(dt_iop_module_t *self,
         CLARG(dev_col[0]), CLARG(dev_out), CLARG(dev_tmp1), CLARG(width), CLARG(height));
       if(err != CL_SUCCESS) goto error;
 
-      size_t origin[] = { 0, 0 };
       size_t region[] = { width, height };
-      err = dt_opencl_enqueue_copy_image(devid, dev_tmp1, dev_col[0], origin, origin, region);
+      err = dt_opencl_enqueue_copy_image(devid, dev_tmp1, dev_col[0], CLIMG_ORIGIN, CLIMG_ORIGIN, region);
       if(err != CL_SUCCESS) goto error;
     }
 
@@ -814,9 +813,8 @@ int process_cl_fusion(dt_iop_module_t *self,
           CLARG(dev_comb[k]), CLARG(dev_col[k]), CLARG(dev_tmp1), CLARG(w), CLARG(h));
         if(err != CL_SUCCESS) goto error;
 
-        size_t origin[] = { 0, 0 };
         size_t region[] = { w, h };
-        err = dt_opencl_enqueue_copy_image(devid, dev_tmp1, dev_comb[k], origin, origin, region);
+        err = dt_opencl_enqueue_copy_image(devid, dev_tmp1, dev_comb[k], CLIMG_ORIGIN, CLIMG_ORIGIN, region);
         if(err != CL_SUCCESS) goto error;
       }
       else
@@ -826,9 +824,8 @@ int process_cl_fusion(dt_iop_module_t *self,
           CLARG(dev_comb[k]), CLARG(dev_col[k]), CLARG(dev_tmp2), CLARG(dev_tmp1), CLARG(w), CLARG(h));
         if(err != CL_SUCCESS) goto error;
 
-        size_t origin[] = { 0, 0 };
         size_t region[] = { w, h };
-        err = dt_opencl_enqueue_copy_image(devid, dev_tmp1, dev_comb[k], origin, origin, region);
+        err = dt_opencl_enqueue_copy_image(devid, dev_tmp1, dev_comb[k], CLIMG_ORIGIN, CLIMG_ORIGIN, region);
         if(err != CL_SUCCESS) goto error;
       }
     }
@@ -853,9 +850,8 @@ int process_cl_fusion(dt_iop_module_t *self,
       if(err != CL_SUCCESS) goto error;
 
       // dev_tmp1[k] -> dev_comb[k]
-      size_t origin[] = { 0, 0 };
       size_t region[] = { w, h };
-      err = dt_opencl_enqueue_copy_image(devid, dev_tmp1, dev_comb[k], origin, origin, region);
+      err = dt_opencl_enqueue_copy_image(devid, dev_tmp1, dev_comb[k], CLIMG_ORIGIN, CLIMG_ORIGIN, region);
       if(err != CL_SUCCESS) goto error;
     }
 
@@ -873,9 +869,8 @@ int process_cl_fusion(dt_iop_module_t *self,
       if(err != CL_SUCCESS) goto error;
 
       // dev_tmp2 -> dev_comb[k]
-      size_t origin[] = { 0, 0 };
       size_t region[] = { w, h };
-      err = dt_opencl_enqueue_copy_image(devid, dev_tmp2, dev_comb[k], origin, origin, region);
+      err = dt_opencl_enqueue_copy_image(devid, dev_tmp2, dev_comb[k], CLIMG_ORIGIN, CLIMG_ORIGIN, region);
       if(err != CL_SUCCESS) goto error;
     }
   }

--- a/src/iop/borders.c
+++ b/src/iop/borders.c
@@ -638,12 +638,11 @@ int process_cl(dt_iop_module_t *self,
     if(err != CL_SUCCESS) goto error;
   }
 
-  size_t iorigin[] = { 0, 0, 0 };
-  size_t oorigin[] = { binfo.border_in_x, binfo.border_in_y, 0 };
-  size_t region[]  = { roi_in->width, roi_in->height, 1 };
+  size_t oorigin[] = { binfo.border_in_x, binfo.border_in_y };
+  size_t region[]  = { roi_in->width, roi_in->height };
 
   // copy original input from dev_in -> dev_out as starting point
-  err = dt_opencl_enqueue_copy_image(devid, dev_in, dev_out, iorigin, oorigin, region);
+  err = dt_opencl_enqueue_copy_image(devid, dev_in, dev_out, CLIMG_ORIGIN, oorigin, region);
 
 error:
   return err;

--- a/src/iop/clipping.c
+++ b/src/iop/clipping.c
@@ -1086,9 +1086,8 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
   if(!d->flags && d->angle == 0.0 && d->all_off && roi_in->width == roi_out->width
      && roi_in->height == roi_out->height)
   {
-    size_t origin[] = { 0, 0 };
     size_t region[] = { width, height };
-    err = dt_opencl_enqueue_copy_image(devid, dev_in, dev_out, origin, origin, region);
+    err = dt_opencl_enqueue_copy_image(devid, dev_in, dev_out, CLIMG_ORIGIN, CLIMG_ORIGIN, region);
     if(err != CL_SUCCESS) goto error;
   }
   else

--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -646,9 +646,8 @@ int process_cl(dt_iop_module_t *self,
 
   if(d->type == DT_COLORSPACE_LAB)
   {
-    size_t origin[] = { 0, 0 };
     size_t region[] = { width, height };
-    return dt_opencl_enqueue_copy_image(devid, dev_in, dev_out, origin, origin, region);
+    return dt_opencl_enqueue_copy_image(devid, dev_in, dev_out, CLIMG_ORIGIN, CLIMG_ORIGIN, region);
   }
 
   const dt_dev_chroma_t *chr = &self->dev->chroma;

--- a/src/iop/colormapping.c
+++ b/src/iop/colormapping.c
@@ -675,9 +675,8 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
     }
     else
     {
-      size_t origin[] = { 0, 0 };
       size_t region[] = { width, height };
-      err = dt_opencl_enqueue_copy_image(devid, dev_out, dev_tmp, origin, origin, region);
+      err = dt_opencl_enqueue_copy_image(devid, dev_out, dev_tmp, CLIMG_ORIGIN, CLIMG_ORIGIN, region);
       if(err != CL_SUCCESS) goto error;
     }
 
@@ -687,9 +686,8 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
   }
   else
   {
-    size_t origin[] = { 0, 0 };
     size_t region[] = { width, height };
-    err = dt_opencl_enqueue_copy_image(devid, dev_in, dev_out, origin, origin, region);
+    err = dt_opencl_enqueue_copy_image(devid, dev_in, dev_out, CLIMG_ORIGIN, CLIMG_ORIGIN, region);
   }
 
 error:

--- a/src/iop/colorout.c
+++ b/src/iop/colorout.c
@@ -324,9 +324,8 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
 
   if(d->type == DT_COLORSPACE_LAB)
   {
-    size_t origin[] = { 0, 0 };
     size_t region[] = { roi_in->width, roi_in->height };
-    err = dt_opencl_enqueue_copy_image(devid, dev_in, dev_out, origin, origin, region);
+    err = dt_opencl_enqueue_copy_image(devid, dev_in, dev_out, CLIMG_ORIGIN, CLIMG_ORIGIN, region);
     if(err != CL_SUCCESS) goto error;
     return CL_SUCCESS;
   }

--- a/src/iop/crop.c
+++ b/src/iop/crop.c
@@ -609,10 +609,8 @@ int process_cl(dt_iop_module_t *self,
                const dt_iop_roi_t *const roi_in,
                const dt_iop_roi_t *const roi_out)
 {
-  size_t origin[] = { 0, 0 };
   size_t region[] = { roi_out->width, roi_out->height };
-  return dt_opencl_enqueue_copy_image(piece->pipe->devid, dev_in, dev_out,
-                                            origin, origin, region);
+  return dt_opencl_enqueue_copy_image(piece->pipe->devid, dev_in, dev_out, CLIMG_ORIGIN, CLIMG_ORIGIN, region);
 }
 #endif
 

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -1109,9 +1109,8 @@ int process_cl(dt_iop_module_t *self,
                tile_nr, num_tiles, group, first_in, last_in, t_rows);
 
         size_t insrc[]  = { 0, first_in };
-        size_t tdest[]  = { 0, 0 };
         size_t iarea[]  = { iwidth, t_rows };
-        err = dt_opencl_enqueue_copy_image(devid, in_image, t_in, insrc, tdest, iarea);
+        err = dt_opencl_enqueue_copy_image(devid, in_image, t_in, insrc, CLIMG_ORIGIN, iarea);
         if(err != CL_SUCCESS) goto finish;
       }
 
@@ -1119,10 +1118,8 @@ int process_cl(dt_iop_module_t *self,
         err = demosaic_box3_cl(self, piece, t_in, t_high, dev_xtrans, iwidth, t_rows, filters);
       else if(method == DT_IOP_DEMOSAIC_MONO)
       {
-        size_t insrc[]  = { 0, 0 };
-        size_t tdest[]  = { 0, 0 };
         size_t iarea[]  = { iwidth, t_rows };
-        err = dt_opencl_enqueue_copy_image(devid, t_in, t_high, insrc, tdest, iarea);
+        err = dt_opencl_enqueue_copy_image(devid, t_in, t_high, CLIMG_ORIGIN, CLIMG_ORIGIN, iarea);
       }
       else if(passthru || method == DT_IOP_DEMOSAIC_PPG)
         err = process_default_cl(self, piece, t_in, t_high, dev_xtrans, iwidth, t_rows, method, filters);

--- a/src/iop/demosaicing/basics.c
+++ b/src/iop/demosaicing/basics.c
@@ -286,9 +286,8 @@ static int color_smoothing_cl(const dt_iop_module_t *self,
   if(dev_t1 == dev_tmp)
   {
     // copy data from dev_tmp -> dev_out
-    size_t origin[] = { 0, 0 };
     size_t region[] = { width, height };
-    err = dt_opencl_enqueue_copy_image(devid, dev_tmp, dev_out, origin, origin, region);
+    err = dt_opencl_enqueue_copy_image(devid, dev_tmp, dev_out, CLIMG_ORIGIN, CLIMG_ORIGIN, region);
   }
 
 error:

--- a/src/iop/demosaicing/xtrans.c
+++ b/src/iop/demosaicing/xtrans.c
@@ -2022,9 +2022,8 @@ static cl_int process_markesteijn_cl(const dt_iop_module_t *self,
     // note: we need to take swap of buffers into account, so current output lies in dev_t1
     if(dev_t1 != dev_tmptmp)
     {
-      size_t origin[] = { 0, 0 };
       size_t region[] = { width, height };
-      err = dt_opencl_enqueue_copy_image(devid, dev_t1, dev_tmptmp, origin, origin, region);
+      err = dt_opencl_enqueue_copy_image(devid, dev_t1, dev_tmptmp, CLIMG_ORIGIN, CLIMG_ORIGIN, region);
       if(err != CL_SUCCESS) goto error;
     }
 

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -2233,9 +2233,8 @@ static int process_wavelets_cl(dt_iop_module_t *self,
   if(npixels < 2)
   {
     // copy original input from dev_in -> dev_out
-    size_t origin[] = { 0, 0 };
     size_t region[] = { width, height };
-    err = dt_opencl_enqueue_copy_image(devid, dev_in, dev_out, origin, origin, region);
+    err = dt_opencl_enqueue_copy_image(devid, dev_in, dev_out, CLIMG_ORIGIN, CLIMG_ORIGIN, region);
     if(err != CL_SUCCESS) goto error;
     free(dev_detail);
     return CL_SUCCESS;
@@ -2528,9 +2527,8 @@ static int process_wavelets_cl(dt_iop_module_t *self,
   // account, so current output lies in dev_buf1
   if(dev_buf1 != dev_tmp)
   {
-    size_t origin[] = { 0, 0 };
     size_t region[] = { width, height };
-    err = dt_opencl_enqueue_copy_image(devid, dev_buf1, dev_tmp, origin, origin, region);
+    err = dt_opencl_enqueue_copy_image(devid, dev_buf1, dev_tmp, CLIMG_ORIGIN, CLIMG_ORIGIN, region);
     if(err != CL_SUCCESS) goto error;
   }
 

--- a/src/iop/diffuse.c
+++ b/src/iop/diffuse.c
@@ -1620,12 +1620,11 @@ int process_cl(dt_iop_module_t *self,
   const int width = roi_in->width;
   const int height = roi_in->height;
 
-  size_t origin[] = { 0, 0 };
   size_t region[] = { width, height };
 
   // allow fast mode, just copy input to output
   if(fastmode)
-    return dt_opencl_enqueue_copy_image(devid, dev_in, dev_out, origin, origin, region);
+    return dt_opencl_enqueue_copy_image(devid, dev_in, dev_out, CLIMG_ORIGIN, CLIMG_ORIGIN, region);
 
   cl_mem in = dev_in;
   cl_mem temp_in = NULL;
@@ -1657,7 +1656,7 @@ int process_cl(dt_iop_module_t *self,
   // because we use a lot of memory here.
   if(!temp1 || !temp2 || !LF_odd || !LF_even || !mask || out_of_memory)
   {
-    dt_opencl_enqueue_copy_image(devid, dev_in, dev_out, origin, origin, region);
+    dt_opencl_enqueue_copy_image(devid, dev_in, dev_out, CLIMG_ORIGIN, CLIMG_ORIGIN, region);
     err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
     goto error;
   }

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -2317,8 +2317,7 @@ static inline cl_int reconstruct_highlights_cl(const cl_mem in, const cl_mem mas
     if(err != CL_SUCCESS) goto error;
 
     // Take a backup copy of HF_RGB in HF_grey - only HF_RGB will be blurred
-    size_t origin[] = { 0, 0 };
-    err = dt_opencl_enqueue_copy_image(devid, HF_RGB, HF_grey, origin, origin, sizes);
+    err = dt_opencl_enqueue_copy_image(devid, HF_RGB, HF_grey, CLIMG_ORIGIN, CLIMG_ORIGIN, sizes);
     if(err != CL_SUCCESS) goto error;
 
     // interpolate/blur/inpaint (same thing) the RGB high-frequency to fill holes

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -545,9 +545,8 @@ int process_cl(dt_iop_module_t *self,
     else
     {
       size_t iorigin[] = { roi_out->x, roi_out->y };
-      size_t oorigin[] = { 0, 0 };
       size_t region[] = { roi_out->width, roi_out->height };
-      return dt_opencl_enqueue_copy_image(devid, dev_in, dev_out, iorigin, oorigin, region);
+      return dt_opencl_enqueue_copy_image(devid, dev_in, dev_out, iorigin, CLIMG_ORIGIN, region);
     }
   }
 

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -1324,7 +1324,6 @@ static int _process_cl_lf(dt_iop_module_t *self,
   const float orig_w = roi_in->scale * piece->buf_in.width;
   const float orig_h = roi_in->scale * piece->buf_in.height;
 
-  size_t origin[] = { 0, 0 };
   size_t iregion[] = { (size_t)iwidth, (size_t)iheight };
   size_t oregion[] = { (size_t)owidth, (size_t)oheight };
 
@@ -1334,7 +1333,7 @@ static int _process_cl_lf(dt_iop_module_t *self,
 
   if(!d->lens || !d->lens->Maker || d->crop <= 0.0f)
     return dt_opencl_enqueue_copy_image(devid, dev_in, dev_out,
-                                        origin, origin, oregion);
+                                        CLIMG_ORIGIN, CLIMG_ORIGIN, oregion);
 
   switch(interpolation->id)
   {
@@ -1401,7 +1400,7 @@ static int _process_cl_lf(dt_iop_module_t *self,
     else
     {
       err = dt_opencl_enqueue_copy_image(devid, dev_in, dev_tmp,
-                                         origin, origin, oregion);
+                                         CLIMG_ORIGIN, CLIMG_ORIGIN, oregion);
       if(err != CL_SUCCESS) goto error;
     }
 
@@ -1437,7 +1436,7 @@ static int _process_cl_lf(dt_iop_module_t *self,
     else
     {
       err = dt_opencl_enqueue_copy_image(devid, dev_tmp, dev_out,
-                                         origin, origin, oregion);
+                                         CLIMG_ORIGIN, CLIMG_ORIGIN, oregion);
       if(err != CL_SUCCESS) goto error;
     }
   }
@@ -1478,7 +1477,7 @@ static int _process_cl_lf(dt_iop_module_t *self,
     else
     {
       err = dt_opencl_enqueue_copy_image(devid, dev_in, dev_tmp,
-                                         origin, origin, iregion);
+                                         CLIMG_ORIGIN, CLIMG_ORIGIN, iregion);
       if(err != CL_SUCCESS) goto error;
     }
 
@@ -1512,7 +1511,7 @@ static int _process_cl_lf(dt_iop_module_t *self,
     else
     {
       err = dt_opencl_enqueue_copy_image(devid, dev_tmp, dev_out,
-                                         origin, origin, oregion);
+                                         CLIMG_ORIGIN, CLIMG_ORIGIN, oregion);
     }
   }
 
@@ -2834,10 +2833,9 @@ static int _process_cl_md(dt_iop_module_t *self,
 
   if(!d->nc || d->modify_flags == DT_IOP_LENS_MODFLAG_NONE)
   {
-    size_t origin[] = { 0, 0 };
     size_t oregion[] = { (size_t)roi_out->width, (size_t)roi_out->height };
     return dt_opencl_enqueue_copy_image(devid, dev_in, dev_out,
-                                        origin, origin, oregion);
+                                        CLIMG_ORIGIN, CLIMG_ORIGIN, oregion);
   }
 
   const float w2 = 0.5f * roi_in->scale * piece->buf_in.width;
@@ -3126,10 +3124,9 @@ int process_cl(dt_iop_module_t *self,
   }
   else
   {
-    size_t origin[] = { 0, 0 };
     size_t region[] = { (size_t)roi_in->width, (size_t)roi_in->height };
     err = dt_opencl_enqueue_copy_image(piece->pipe->devid, data,
-                                       dev_out, origin, origin, region);
+                                       dev_out, CLIMG_ORIGIN, CLIMG_ORIGIN, region);
   }
 
   if(data != dev_in)

--- a/src/iop/liquify.c
+++ b/src/iop/liquify.c
@@ -1558,9 +1558,8 @@ int process_cl(dt_iop_module_t *self,
   // 1. copy the whole image (we'll change only a small part of it)
   {
     size_t src[]    = { roi_out->x - roi_in->x, roi_out->y - roi_in->y };
-    size_t dest[]   = { 0, 0 };
     size_t extent[] = { width, height };
-    err = dt_opencl_enqueue_copy_image(devid, dev_in, dev_out, src, dest, extent);
+    err = dt_opencl_enqueue_copy_image(devid, dev_in, dev_out, src, CLIMG_ORIGIN, extent);
     if(err != CL_SUCCESS) return err;
   }
 

--- a/src/iop/mask_manager.c
+++ b/src/iop/mask_manager.c
@@ -100,9 +100,8 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   const int width = roi_in->width;
   const int height = roi_in->height;
 
-  size_t origin[] = { 0, 0 };
   size_t region[] = { width, height };
-  return dt_opencl_enqueue_copy_image(devid, dev_in, dev_out, origin, origin, region);
+  return dt_opencl_enqueue_copy_image(devid, dev_in, dev_out, CLIMG_ORIGIN, CLIMG_ORIGIN, region);
 }
 #endif
 

--- a/src/iop/rasterfile.c
+++ b/src/iop/rasterfile.c
@@ -514,9 +514,8 @@ int process_cl(dt_iop_module_t *self,
   else
   {
     size_t iorigin[] = { roi_out->x, roi_out->y };
-    size_t oorigin[] = { 0, 0 };
     size_t region[] = { roi_out->width, roi_out->height };
-    err = dt_opencl_enqueue_copy_image(devid, dev_in, dev_out, iorigin, oorigin, region);
+    err = dt_opencl_enqueue_copy_image(devid, dev_in, dev_out, iorigin, CLIMG_ORIGIN, region);
   }
 
   if(dt_iop_is_raster_mask_used(piece->module, BLEND_RASTER_ID)

--- a/src/iop/rawoverexposed.c
+++ b/src/iop/rawoverexposed.c
@@ -251,12 +251,11 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
   const int width = roi_out->width;
   const int height = roi_out->height;
 
-  size_t origin[] = { 0, 0 };
   size_t region[] = { width, height };
 
   process_common_setup(self, piece);
 
-  err = dt_opencl_enqueue_copy_image(devid, dev_in, dev_out, origin, origin, region);
+  err = dt_opencl_enqueue_copy_image(devid, dev_in, dev_out, CLIMG_ORIGIN, CLIMG_ORIGIN, region);
   if(err != CL_SUCCESS) goto error;
 
   const int colorscheme = dev->rawoverexposed.colorscheme;

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -4600,9 +4600,8 @@ int process_cl(dt_iop_module_t *self,
 
   // copy input image to the new buffer
   {
-    size_t origin[] = { 0, 0 };
     size_t region[] = { roi_rt->width, roi_rt->height };
-    err = dt_opencl_enqueue_copy_image_to_buffer(devid, dev_in, in_retouch, origin, region, 0);
+    err = dt_opencl_enqueue_copy_image_to_buffer(devid, dev_in, in_retouch, CLIMG_ORIGIN, region, 0);
     if(err != CL_SUCCESS) goto cleanup;
   }
 

--- a/src/iop/sharpen.c
+++ b/src/iop/sharpen.c
@@ -141,9 +141,8 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
 
   if(rad == 0)
   {
-    size_t origin[] = { 0, 0 };
     size_t region[] = { width, height };
-    err = dt_opencl_enqueue_copy_image(devid, dev_in, dev_out, origin, origin, region);
+    err = dt_opencl_enqueue_copy_image(devid, dev_in, dev_out, CLIMG_ORIGIN, CLIMG_ORIGIN, region);
     if(err != CL_SUCCESS) goto error;
     return CL_SUCCESS;
   }
@@ -152,9 +151,8 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
   // normally not needed for OpenCL but implemented here for identity with CPU code path
   if(width < 2 * rad + 1 || height < 2 * rad + 1)
   {
-    size_t origin[] = { 0, 0 };
     size_t region[] = { width, height };
-    err = dt_opencl_enqueue_copy_image(devid, dev_in, dev_out, origin, origin, region);
+    err = dt_opencl_enqueue_copy_image(devid, dev_in, dev_out, CLIMG_ORIGIN, CLIMG_ORIGIN, region);
     if(err != CL_SUCCESS) goto error;
     return CL_SUCCESS;
   }

--- a/src/iop/velvia.c
+++ b/src/iop/velvia.c
@@ -216,9 +216,8 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
 
   if(strength <= 0.0f)
   {
-    size_t origin[] = { 0, 0 };
     size_t region[] = { width, height };
-    err = dt_opencl_enqueue_copy_image(devid, dev_in, dev_out, origin, origin, region);
+    err = dt_opencl_enqueue_copy_image(devid, dev_in, dev_out, CLIMG_ORIGIN, CLIMG_ORIGIN, region);
   }
   else
   {


### PR DESCRIPTION
1. OpenCL event handling uses a smaller/safer number of events as not all drivers support 4096. The granularity of allocated dt event slots has been increased and now uses DT_OPENCL_EVENTS for less internal calloc/memcpy.
2. As we may want to use different high level OpenCL code if running in OpenCL fast mode we now have `dt_opencl_running_fast()` to check instead of using the costly conf reading.
3. Some corrections for logs and `dt_opencl_enqueue_copy_image()`