### PR TITLE
[AI] Handle OrtStatus from ReleaseAvailableProviders to fix warnings

### DIFF
--- a/src/ai/backend_onnx.c
+++ b/src/ai/backend_onnx.c
@@ -513,7 +513,10 @@ int dt_ai_ort_probe_library_full(const char *path, char **out_version, char **ou
           g_string_append(eps, label);
         }
         if(probe_api->ReleaseAvailableProviders)
-          probe_api->ReleaseAvailableProviders(providers, n_providers);
+        {
+          OrtStatus *rs = probe_api->ReleaseAvailableProviders(providers, n_providers);
+          if(rs) probe_api->ReleaseStatus(rs);
+        }
       }
     }
 
@@ -875,7 +878,10 @@ static gboolean _ort_has_provider(const char *name)
   for(int i = 0; i < n && !found; i++)
     if(g_strcmp0(providers[i], name) == 0) found = TRUE;
   if(g_ort->ReleaseAvailableProviders)
-    g_ort->ReleaseAvailableProviders(providers, n);
+  {
+    OrtStatus *rs = g_ort->ReleaseAvailableProviders(providers, n);
+    if(rs) g_ort->ReleaseStatus(rs);
+  }
   return found;
 }
 


### PR DESCRIPTION
Small fix, addresses the build warnings reported by @pehar1 in https://github.com/darktable-org/darktable/pull/20933#issuecomment-4385910109

`ReleaseAvailableProviders` returns an `OrtStatus *` and is marked `warn_unused_result` in newer ONNX Runtime headers. Both call sites were dropping the return value.

Updated to capture the status and release it via `ReleaseStatus` when non-NULL.
