### PR TITLE
RFC: get users to read WB tooltip

### DIFF
--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -2064,7 +2064,7 @@ static void _set_trouble_messages(dt_iop_module_t *self)
   {
     dt_iop_set_module_trouble_message
       (chr->temperature,
-        _("white balance applied twice"),
+        _("white balance applied twice (<u>details</u>)"),
         _("the color calibration module is enabled and already provides\n"
           "chromatic adaptation.\n"
           "set the white balance here to camera reference (D65)\n"
@@ -2073,7 +2073,7 @@ static void _set_trouble_messages(dt_iop_module_t *self)
 
     dt_iop_set_module_trouble_message
       (self,
-        _("white balance module error"),
+        _("white balance module error (<u>details</u>)"),
         _("the white balance module is not using the camera\n"
           "reference illuminant, which will cause issues here\n"
           "with chromatic adaptation. either set it to reference\n"
@@ -2086,7 +2086,7 @@ static void _set_trouble_messages(dt_iop_module_t *self)
   {
     dt_iop_set_module_trouble_message
       (chr->temperature,
-        _("white balance missing"),
+        _("white balance missing (<u>details</u>)"),
         _("this module is not providing a valid reference illuminant\n"
           "causing chromatic adaptation issues in color calibration.\n"
           "enable this module and either set it to reference\n"
@@ -2095,7 +2095,7 @@ static void _set_trouble_messages(dt_iop_module_t *self)
 
     dt_iop_set_module_trouble_message
       (self,
-        _("white balance missing"),
+        _("white balance missing (<u>details</u>)"),
         _("the white balance module is not providing a valid reference\n"
           "illuminant causing issues with chromatic adaptation here.\n"
           "enable white balance and either set it to reference\n"

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -291,11 +291,12 @@ void _display_module_trouble_message_callback(gpointer instance,
       if(label_widget)
       {
         // set the warning message in the module's message area just below the header
-        gtk_label_set_text(GTK_LABEL(label_widget), trouble_msg);
+        gtk_label_set_markup(GTK_LABEL(label_widget), trouble_msg);
       }
       else
       {
-        label_widget = gtk_label_new(trouble_msg);;
+        label_widget = gtk_label_new(NULL);
+        gtk_label_set_markup(GTK_LABEL(label_widget), trouble_msg);
         gtk_label_set_line_wrap(GTK_LABEL(label_widget), TRUE);
         gtk_label_set_xalign(GTK_LABEL(label_widget), 0.0);
         gtk_widget_set_name(label_widget, "iop-plugin-warning");


### PR DESCRIPTION
Since the majority of user complaints about the double white balance messages are from those who clearly haven't read the associated tooltip, apply a psychological trick to get them to read the tooltip: add what appears to be a hyperlink to more information, which will get them to hover over the message long enough for the tooltip to pop up (usually - one can actually click the fake link fast enough to prevent the popup).