### PR TITLE
OpenCL copy functions accept NULL as cl image src/dest

### DIFF
--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -2922,7 +2922,7 @@ int dt_opencl_read_host_from_device_raw(const int devid,
 }
 
 int dt_opencl_write_host_to_device(const int devid,
-                                   void *host,
+                                   const void *host,
                                    void *device,
                                    const int width,
                                    const int height,
@@ -2933,7 +2933,7 @@ int dt_opencl_write_host_to_device(const int devid,
 }
 
 int dt_opencl_write_host_to_device_rowpitch(const int devid,
-                                            void *host,
+                                            const void *host,
                                             void *device,
                                             const int width,
                                             const int height,
@@ -2950,7 +2950,7 @@ int dt_opencl_write_host_to_device_rowpitch(const int devid,
 }
 
 int dt_opencl_write_host_to_device_raw(const int devid,
-                                       void *host,
+                                       const void *host,
                                        void *device,
                                        const size_t *origin,
                                        const size_t *region,
@@ -2981,18 +2981,18 @@ int dt_opencl_write_host_to_device_raw(const int devid,
 }
 
 int dt_opencl_enqueue_copy_image(const int devid,
-                                 cl_mem src,
+                                 const cl_mem src,
                                  cl_mem dst,
-                                 size_t *orig_src,
-                                 size_t *orig_dst,
-                                 size_t *region)
+                                 const size_t *orig_src,
+                                 const size_t *orig_dst,
+                                 const size_t *region)
 {
   if(!_cldev_running(devid))
     return DT_OPENCL_NODEVICE;
 
-  size_t osrc[3] = { orig_src[0], orig_src[1], 0 };
-  size_t odst[3] = { orig_dst[0], orig_dst[1], 0 };
-  size_t reg[3] = { region[0], region[1], 1 };
+  const size_t osrc[3] = { orig_src ? orig_src[0] : 0, orig_src ? orig_src[1] : 0, 0 };
+  const size_t odst[3] = { orig_dst ? orig_dst[0] : 0, orig_dst ? orig_dst[1] : 0, 0 };
+  const size_t reg[3] = { region[0], region[1], 1 };
 
   cl_event *eventp = _opencl_events_get_slot(devid, "[Copy Image (on device)]");
   const cl_int err = (darktable.opencl->dlocl->symbols->dt_clEnqueueCopyImage)
@@ -3014,16 +3014,16 @@ int dt_opencl_enqueue_copy_image(const int devid,
 }
 
 int dt_opencl_enqueue_copy_image_to_buffer(const int devid,
-                                           cl_mem src_image,
+                                           const cl_mem src_image,
                                            cl_mem dst_buffer,
-                                           size_t *origin,
-                                           size_t *region,
-                                           size_t offset)
+                                           const size_t *origin,
+                                           const size_t *region,
+                                           const size_t offset)
 {
   if(!_cldev_running(devid))
     return DT_OPENCL_NODEVICE;
 
-  const size_t org[3] = { origin[0], origin[1], 0 };
+  const size_t org[3] = { origin ? origin[0] : 0, origin ? origin[1] : 0, 0 };
   const size_t reg[3] = { region[0], region[1], 1 };
   cl_event *eventp = _opencl_events_get_slot(devid, "[Copy Image to Buffer (on device)]");
   const cl_int err = (darktable.opencl->dlocl->symbols->dt_clEnqueueCopyImageToBuffer)
@@ -3044,16 +3044,16 @@ int dt_opencl_enqueue_copy_image_to_buffer(const int devid,
 }
 
 int dt_opencl_enqueue_copy_buffer_to_image(const int devid,
-                                           cl_mem src_buffer,
+                                           const cl_mem src_buffer,
                                            cl_mem dst_image,
-                                           size_t offset,
-                                           size_t *origin,
-                                           size_t *region)
+                                           const size_t offset,
+                                           const size_t *origin,
+                                           const size_t *region)
 {
   if(!_cldev_running(devid))
     return DT_OPENCL_NODEVICE;
 
-  const size_t org[3] = { origin[0], origin[1], 0 };
+  const size_t org[3] = { origin ? origin[0] : 0, origin ? origin[1] : 0, 0 };
   const size_t reg[3] = { region[0], region[1], 1 };
   cl_event *eventp = _opencl_events_get_slot(devid, "[Copy Buffer to Image (on device)]");
   const cl_int err = (darktable.opencl->dlocl->symbols->dt_clEnqueueCopyBufferToImage)
@@ -3074,11 +3074,11 @@ int dt_opencl_enqueue_copy_buffer_to_image(const int devid,
 }
 
 int dt_opencl_enqueue_copy_buffer_to_buffer(const int devid,
-                                            cl_mem src_buffer,
+                                            const cl_mem src_buffer,
                                             cl_mem dst_buffer,
-                                            size_t srcoffset,
-                                            size_t dstoffset,
-                                            size_t size)
+                                            const size_t srcoffset,
+                                            const size_t dstoffset,
+                                            const size_t size)
 {
   if(!_cldev_running(devid))
     return DT_OPENCL_NODEVICE;
@@ -3345,7 +3345,12 @@ void *dt_opencl_alloc_device(const int devid,
   else if(bpp == sizeof(uint8_t))
     fmt = (cl_image_format){ CL_R, CL_UNSIGNED_INT8 };
   else
+  {
+    dt_print(DT_DEBUG_OPENCL,
+             "[opencl alloc_device] could not alloc image on device '%s' id=%d because of unknon bpp=%d format",
+             cl->dev[devid].fullname, devid, bpp);
     return NULL;
+  }
 
   cl_image_desc desc;
   memset(&desc, 0, sizeof(cl_image_desc));
@@ -3356,9 +3361,9 @@ void *dt_opencl_alloc_device(const int devid,
   cl_mem dev = (cl->dlocl->symbols->dt_clCreateImage)
     (cl->dev[devid].context, CL_MEM_READ_WRITE, &fmt, &desc, NULL, &err);
 
-  if(err != CL_SUCCESS)
+  if(err != CL_SUCCESS || dev == NULL)
     dt_print(DT_DEBUG_OPENCL,
-             "[opencl alloc_device] could not alloc img buffer on device '%s' id=%d: %s",
+             "[opencl alloc_device] could not alloc image on device '%s' id=%d: %s",
              cl->dev[devid].fullname, devid, cl_errstr(err));
 
   _check_clmem_err(devid, err);
@@ -3506,7 +3511,7 @@ void *dt_opencl_duplicate_image(const int devid, const cl_mem src)
 
 void dt_opencl_dump_pipe_pfm(const char* mod,
                              const int devid,
-                             cl_mem img,
+                             const cl_mem img,
                              const gboolean input,
                              const char *pipe)
 {
@@ -3653,7 +3658,7 @@ gboolean dt_opencl_image_fits_device(const int devid,
 
 /** round size to a multiple of the value given in the device specifig
  * config parameter clroundup_wd/ht */
-int dt_opencl_dev_roundup_width(int size,
+int dt_opencl_dev_roundup_width(const int size,
                                 const int devid)
 {
   if(_cldev_running(devid))
@@ -3665,7 +3670,7 @@ int dt_opencl_dev_roundup_width(int size,
     return 0;
 }
 
-int dt_opencl_dev_roundup_height(int size,
+int dt_opencl_dev_roundup_height(const int size,
                                  const int devid)
 {
   if(_cldev_running(devid))

--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -62,8 +62,9 @@
 
 G_BEGIN_DECLS
 
-// instead of declaring the size_t struct for origin we have a #define for this for readability
-#define CLIMG_ORIGIN (size_t[]){0,0}
+// instead of declaring the size_t struct for origin/dest at (0,0) we have CLIMG_ORIGIN for readability
+// All functions in opencl.c make sure to pass a correct size_t struct
+#define CLIMG_ORIGIN NULL
 
 #define ROUNDUP(a, n) ((a) % (n) == 0 ? (a) : ((a) / (n)+1) * (n))
 
@@ -457,21 +458,21 @@ int dt_opencl_read_host_from_device_raw(const int devid,
                                         const int blocking);
 
 int dt_opencl_write_host_to_device(const int devid,
-                                   void *host,
+                                   const void *host,
                                    void *device,
                                    const int width,
                                    const int height,
                                    const int bpp);
 
 int dt_opencl_write_host_to_device_rowpitch(const int devid,
-                                            void *host,
+                                            const void *host,
                                             void *device,
                                             const int width,
                                             const int height,
                                             const int rowpitch);
 
 int dt_opencl_write_host_to_device_raw(const int devid,
-                                       void *host,
+                                       const void *host,
                                        void *device,
                                        const size_t *origin,
                                        const size_t *region,
@@ -489,11 +490,11 @@ void *dt_opencl_copy_host_to_device_constant(const int devid,
                                              void *host);
 
 int dt_opencl_enqueue_copy_image(const int devid,
-                                 cl_mem src,
+                                 const cl_mem src,
                                  cl_mem dst,
-                                 size_t *orig_src,
-                                 size_t *orig_dst,
-                                 size_t *region);
+                                 const size_t *orig_src,
+                                 const size_t *orig_dst,
+                                 const size_t *region);
 
 void *dt_opencl_alloc_device(const int devid,
                              const int width,
@@ -501,25 +502,25 @@ void *dt_opencl_alloc_device(const int devid,
                              const int bpp);
 
 int dt_opencl_enqueue_copy_image_to_buffer(const int devid,
-                                           cl_mem src_image,
+                                           const cl_mem src_image,
                                            cl_mem dst_buffer,
-                                           size_t *origin,
-                                           size_t *region,
-                                           size_t offset);
+                                           const size_t *origin,
+                                           const size_t *region,
+                                           const size_t offset);
 
 int dt_opencl_enqueue_copy_buffer_to_image(const int devid,
-                                           cl_mem src_buffer,
+                                           const cl_mem src_buffer,
                                            cl_mem dst_image,
-                                           size_t offset,
-                                           size_t *origin,
-                                           size_t *region);
+                                           const size_t offset,
+                                           const size_t *origin,
+                                           const size_t *region);
 
 int dt_opencl_enqueue_copy_buffer_to_buffer(const int devid,
-                                            cl_mem src_buffer,
+                                            const cl_mem src_buffer,
                                             cl_mem dst_buffer,
-                                            size_t srcoffset,
-                                            size_t dstoffset,
-                                            size_t size);
+                                            const size_t srcoffset,
+                                            const size_t dstoffset,
+                                            const size_t size);
 
 int dt_opencl_read_buffer_from_device(const int devid,
                                       void *host,
@@ -555,24 +556,24 @@ int dt_opencl_unmap_mem_object(const int devid,
                                cl_mem mem_object,
                                void *mapped_ptr);
 
-size_t dt_opencl_get_mem_object_size(cl_mem mem);
+size_t dt_opencl_get_mem_object_size(const cl_mem mem);
 
-int dt_opencl_get_image_width(cl_mem mem);
+int dt_opencl_get_image_width(const cl_mem mem);
 
-int dt_opencl_get_image_height(cl_mem mem);
+int dt_opencl_get_image_height(const cl_mem mem);
 
-int dt_opencl_get_image_element_size(cl_mem mem);
+int dt_opencl_get_image_element_size(const cl_mem mem);
 
 void *dt_opencl_duplicate_image(const int devid, const cl_mem src);
 
 void dt_opencl_dump_pipe_pfm(const char* mod,
                              const int devid,
-                             cl_mem img,
+                             const cl_mem img,
                              const gboolean input,
                              const char *pipe);
 
 void dt_opencl_memory_statistics(int devid,
-                                 cl_mem mem,
+                                 const cl_mem mem,
                                  dt_opencl_memory_t action);
 
 /** check if image size fit into limits given by OpenCL runtime */
@@ -593,9 +594,9 @@ cl_ulong dt_opencl_get_device_memalloc(const int devid);
 
 /** round size to a multiple of the value given in the device specifig
  * config parameter for opencl_size_roundup */
-int dt_opencl_dev_roundup_width(int size,
+int dt_opencl_dev_roundup_width(const int size,
                                 const int devid);
-int dt_opencl_dev_roundup_height(int size,
+int dt_opencl_dev_roundup_height(const int size,
                                  const int devid);
 
 /** reset eventlist to empty state */


### PR DESCRIPTION
Redefine CLIMG_ORIGIN while keeping readability.
As the dt opencl copy functions handle the src/dest size_t structs anyway it's simpler (and also safe with old c/c++ compilers) to simply pass a NULL and check for that.

While being here
- some constify work
- some improved checks and logs

Fixes #20950 

@TurboGit i think this is a clean approach ...