### PR TITLE
Add log history viewer to bottom toolbar

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -2659,3 +2659,26 @@ popover *
 {
   background-color: @selected_bg_color;
 }
+
+/* log history popover */
+popover#log-history-popover scrolledwindow
+{
+  background-color: @bg_color;
+  border: none;
+}
+
+popover#log-history-popover row
+{
+  padding: 0;
+}
+
+popover#log-history-popover label
+{
+  color: @fg_color;
+}
+
+#log-history-popover overshoot,
+#log-history-popover undershoot
+{
+  all: unset;
+}

--- a/src/control/control.c
+++ b/src/control/control.c
@@ -40,6 +40,8 @@
 #include <string.h>
 #include <strings.h>
 
+#define DT_CTL_LOG_HISTORY_SIZE 1000
+
 static float _action_process_accels_show(const gpointer target,
                                          const dt_action_element_t element,
                                          const dt_action_effect_t effect,
@@ -227,6 +229,10 @@ void dt_control_init(const gboolean withgui)
 
   s->toast_pos = s->toast_ack = 0;
   s->toast_message_timeout_id = 0;
+
+  // persistent log history initialization
+  s->log_history = NULL;
+  dt_pthread_mutex_init(&s->log_history_mutex, NULL);
 
   pthread_cond_init(&s->cond, NULL);
   dt_pthread_mutex_init(&s->cond_mutex, NULL);
@@ -441,6 +447,13 @@ void dt_control_cleanup(const gboolean withgui)
     dt_pthread_mutex_destroy(&s->queue_mutex);
     dt_pthread_mutex_destroy(&s->cond_mutex);
     dt_pthread_mutex_destroy(&s->log_mutex);
+    dt_pthread_mutex_destroy(&s->log_history_mutex);
+    if(s->log_history)
+    {
+      for(GList *elem = s->log_history; elem; elem = elem->next)
+        g_free(elem->data);
+      g_list_free(s->log_history);
+    }
     dt_pthread_mutex_destroy(&s->res_mutex);
     dt_pthread_mutex_destroy(&s->progress_system.mutex);
     if(s->shortcuts) g_sequence_free(s->shortcuts);
@@ -755,9 +768,6 @@ void dt_control_log(const char *msg, ...)
     dc->log_pos++;
   }
 
-  g_free(escaped_msg);
-  va_end(ap);
-
   if(timeout)
     g_source_remove(dc->log_message_timeout_id);
 
@@ -765,8 +775,69 @@ void dt_control_log(const char *msg, ...)
     = g_timeout_add(DT_CTL_LOG_TIMEOUT + 1000 * (msglen / 40),
                     _dt_ctl_log_message_timeout_callback, NULL);
   dt_pthread_mutex_unlock(&dc->log_mutex);
+
+  // store in persistent history (with deduplication)
+  dt_pthread_mutex_lock(&dc->log_history_mutex);
+  if(g_list_length(dc->log_history) > 0)
+  {
+    char *last_msg = ((char *)g_list_last(dc->log_history)->data) + 32;
+    if(g_strcmp0(escaped_msg, last_msg) == 0)
+    {
+      g_free(escaped_msg);
+      va_end(ap);
+      dt_pthread_mutex_unlock(&dc->log_history_mutex);
+      // redraw center later in gui thread:
+      g_idle_add(_redraw_center, 0);
+      return;
+    }
+  }
+
+  // get current time
+  GDateTime *now = g_date_time_new_now_local();
+  gchar *timestamp = g_date_time_format(now, "%H:%M:%S");
+  g_date_time_unref(now);
+
+  // allocate entry: 32 bytes for timestamp + strlen(escaped_msg) + 1 for message
+  const size_t msg_len = strlen(escaped_msg) + 1;
+  char *entry = g_malloc(32 + msg_len);
+  g_strlcpy(entry, timestamp, 32);
+  memcpy(entry + 32, escaped_msg, msg_len);
+  g_free(timestamp);
+
+  dc->log_history = g_list_append(dc->log_history, entry);
+
+  // remove oldest entry if over limit
+  if(g_list_length(dc->log_history) > DT_CTL_LOG_HISTORY_SIZE)
+  {
+    g_free(dc->log_history->data);
+    dc->log_history = g_list_delete_link(dc->log_history, dc->log_history);
+  }
+  dt_pthread_mutex_unlock(&dc->log_history_mutex);
+
+  g_free(escaped_msg);
+  va_end(ap);
+
   // redraw center later in gui thread:
   g_idle_add(_redraw_center, 0);
+}
+
+GList *dt_control_log_history_get_entries(void)
+{
+  dt_control_t *dc = darktable.control;
+  if(!dc) return NULL;
+
+  dt_pthread_mutex_lock(&dc->log_history_mutex);
+
+  GList *result = NULL;
+  for(GList *elem = dc->log_history; elem; elem = elem->next)
+  {
+    char *entry = (char *)elem->data;
+    gchar *line = g_strdup_printf("[%s] %s", entry, entry + 32);
+    result = g_list_append(result, line);
+  }
+
+  dt_pthread_mutex_unlock(&dc->log_history_mutex);
+  return result;
 }
 
 static void _toast_log(const gboolean markup, const char *msg, va_list ap)

--- a/src/control/control.h
+++ b/src/control/control.h
@@ -54,6 +54,7 @@ void dt_control_mouse_enter(void);
 gboolean dt_control_configure(GtkWidget *da, GdkEventConfigure *event, gpointer user_data);
 void dt_control_log(const char *msg, ...) __attribute__((format(printf, 1, 2)));
 void dt_control_log_ack_all(void);
+GList *dt_control_log_history_get_entries(void);
 void dt_toast_log(const char *msg, ...) __attribute__((format(printf, 1, 2)));
 void dt_toast_markup_log(const char *msg, ...) __attribute__((format(printf, 1, 2)));
 void dt_control_busy_enter();
@@ -165,6 +166,10 @@ typedef struct dt_control_t
   int32_t toast_pos, toast_ack;
   char toast_message[DT_CTL_TOAST_SIZE][DT_CTL_TOAST_MSG_SIZE];
   guint toast_message_timeout_id;
+
+  // persistent log history
+  GList *log_history;                     // GList of log history entries (newest last)
+  dt_pthread_mutex_t log_history_mutex;   // mutex for history access
 
   // gui settings
   dt_pthread_mutex_t global_mutex, image_mutex;

--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -2243,6 +2243,38 @@ void dtgtk_cairo_paint_text_label(cairo_t *cr, const gint x, const gint y, const
   FINISH
 }
 
+void dtgtk_cairo_paint_messages(cairo_t *cr, const gint x, const gint y, const gint w, const gint h, gint flags, void *data)
+{
+  PREAMBLE(1, 1, 0, 0)
+
+  // speech bubble outline
+  cairo_move_to(cr, 0.15, 0.1);
+  cairo_line_to(cr, 0.85, 0.1);
+  cairo_curve_to(cr, 0.92, 0.1, 0.95, 0.15, 0.95, 0.22);
+  cairo_line_to(cr, 0.95, 0.68);
+  cairo_curve_to(cr, 0.95, 0.75, 0.92, 0.8, 0.85, 0.8);
+  cairo_line_to(cr, 0.35, 0.8);
+  cairo_line_to(cr, 0.15, 1.0);
+  cairo_line_to(cr, 0.2, 0.8);
+  cairo_line_to(cr, 0.15, 0.8);
+  cairo_curve_to(cr, 0.08, 0.8, 0.05, 0.75, 0.05, 0.68);
+  cairo_line_to(cr, 0.05, 0.22);
+  cairo_curve_to(cr, 0.05, 0.15, 0.08, 0.1, 0.15, 0.1);
+  cairo_close_path(cr);
+  cairo_stroke(cr);
+
+  // text lines inside
+  cairo_move_to(cr, 0.2, 0.3);
+  cairo_line_to(cr, 0.8, 0.3);
+  cairo_move_to(cr, 0.2, 0.47);
+  cairo_line_to(cr, 0.65, 0.47);
+  cairo_move_to(cr, 0.2, 0.64);
+  cairo_line_to(cr, 0.7, 0.64);
+  cairo_stroke(cr);
+
+  FINISH
+}
+
 void dtgtk_cairo_paint_union(cairo_t *cr, const gint x, const gint y, const gint w, const gint h, gint flags, void *data)
 {
   PREAMBLE(1, 1, 0, 0)

--- a/src/dtgtk/paint.h
+++ b/src/dtgtk/paint.h
@@ -153,6 +153,8 @@ void dtgtk_cairo_paint_showmask(cairo_t *cr, gint x, gint y, gint w, gint h, gin
 void dtgtk_cairo_paint_alignment(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 /** paint a text label icon */
 void dtgtk_cairo_paint_text_label(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
+/** paint a message/chat bubble icon */
+void dtgtk_cairo_paint_messages(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 /** paint a styles icon */
 void dtgtk_cairo_paint_styles(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 /** paint the ? help label */

--- a/src/libs/CMakeLists.txt
+++ b/src/libs/CMakeLists.txt
@@ -22,6 +22,7 @@ set(MODULES ${MODULES} hinter)
 set(MODULES ${MODULES} global_toolbox)
 set(MODULES ${MODULES} timeline)
 set(MODULES ${MODULES} image_infos)
+set(MODULES ${MODULES} log_history)
 
 # modules
 add_library(import MODULE "import.c")
@@ -64,6 +65,7 @@ add_library(hinter MODULE "tools/hinter.c")
 add_library(global_toolbox MODULE "tools/global_toolbox.c")
 add_library(timeline MODULE "tools/timeline.c")
 add_library(image_infos MODULE "tools/image_infos.c")
+add_library(log_history MODULE "tools/log_history.c")
 
 if(PortMidi_FOUND)
   add_definitions("-DHAVE_PORTMIDI")

--- a/src/libs/tools/log_history.c
+++ b/src/libs/tools/log_history.c
@@ -1,0 +1,197 @@
+/*
+    This file is part of darktable,
+    Copyright (C) 2026 darktable developers.
+
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    darktable is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "control/signal.h"
+#include "control/control.h"
+#include "dtgtk/button.h"
+#include "gui/gtk.h"
+#include "libs/lib.h"
+#include "libs/lib_api.h"
+
+DT_MODULE(1)
+
+typedef struct dt_lib_log_history_t
+{
+  GtkWidget *button;
+  GtkWidget *popover;
+  GtkWidget *list_box;
+  GtkWidget *scrolled;
+} dt_lib_log_history_t;
+
+static void _populate_list_box(dt_lib_module_t *self);
+static void _log_redraw_callback(gpointer instance, dt_lib_module_t *self);
+static gboolean _button_press_release(GtkWidget *button,
+                                      GdkEventButton *event,
+                                      dt_lib_module_t *self);
+
+const char *name(dt_lib_module_t *self)
+{
+  return N_("log history");
+}
+
+dt_view_type_flags_t views(dt_lib_module_t *self)
+{
+  return DT_VIEW_ALL;
+}
+
+uint32_t container(dt_lib_module_t *self)
+{
+  return DT_UI_CONTAINER_PANEL_CENTER_BOTTOM_RIGHT;
+}
+
+int expandable(dt_lib_module_t *self)
+{
+  return 0;
+}
+
+int position(const dt_lib_module_t *self)
+{
+  return 1000;
+}
+
+static void _populate_list_box(dt_lib_module_t *self)
+{
+  dt_lib_log_history_t *d = self->data;
+  if(!d || !d->list_box) return;
+
+  // Remove existing rows
+  GList *children = gtk_container_get_children(GTK_CONTAINER(d->list_box));
+  for(GList *elem = children; elem; elem = elem->next)
+    gtk_widget_destroy(GTK_WIDGET(elem->data));
+  g_list_free(children);
+
+  GList *entries = dt_control_log_history_get_entries();
+
+  if(entries)
+  {
+    entries = g_list_reverse(entries); // show newest entries at the top
+
+    for(GList *elem = g_list_first(entries);
+        elem;
+        elem = g_list_next(elem))
+    {
+      gchar *line = (gchar *)elem->data;
+      GtkWidget *label = gtk_label_new(line);
+      gtk_label_set_xalign(GTK_LABEL(label), 0.0f);
+      gtk_label_set_selectable(GTK_LABEL(label), TRUE);
+      dt_gui_add_class(label, "dt_monospace");
+      gtk_list_box_insert(GTK_LIST_BOX(d->list_box), label, -1);
+    }
+    g_list_free_full(entries, g_free);
+  }
+  gtk_widget_show_all(d->popover);
+}
+
+static void _log_redraw_callback(gpointer instance, dt_lib_module_t *self)
+{
+  dt_lib_log_history_t *d = self->data;
+  if(d->popover && gtk_widget_is_visible(d->popover))
+    _populate_list_box(self);
+}
+
+static gboolean _button_press_release(GtkWidget *button,
+                                      GdkEventButton *event,
+                                      dt_lib_module_t *self)
+{
+  static guint start_time = 0;
+
+  int delay = 0;
+  g_object_get(gtk_settings_get_default(), "gtk-long-press-time", &delay, NULL);
+
+  if((event->type == GDK_BUTTON_PRESS
+      && (event->button == GDK_BUTTON_PRIMARY
+          || event->button == GDK_BUTTON_SECONDARY))
+     || (event->type == GDK_BUTTON_RELEASE
+         && event->time - start_time > delay))
+  {
+    dt_lib_log_history_t *d = self->data;
+    if(gtk_widget_is_visible(d->popover))
+      gtk_popover_popdown(GTK_POPOVER(d->popover));
+    else
+    {
+      _populate_list_box(self);
+      gtk_popover_popup(GTK_POPOVER(d->popover));
+    }
+    return TRUE;
+  }
+  else
+  {
+    start_time = event->time;
+    return FALSE;
+  }
+}
+
+void gui_init(dt_lib_module_t *self)
+{
+  dt_lib_log_history_t *d = g_malloc0(sizeof(dt_lib_log_history_t));
+  self->data = d;
+
+  d->button = dtgtk_button_new(dtgtk_cairo_paint_messages, CPF_NONE, NULL);
+  gtk_widget_set_tooltip_text(d->button, _("view log history"));
+  dt_gui_add_help_link(d->button, "message_log");
+
+  d->popover = gtk_popover_new(d->button);
+  gtk_widget_set_name(d->popover, "log-history-popover");
+  gtk_popover_set_position(GTK_POPOVER(d->popover), GTK_POS_TOP);
+
+  d->list_box = gtk_list_box_new();
+  gtk_list_box_set_selection_mode(GTK_LIST_BOX(d->list_box), GTK_SELECTION_NONE);
+  gtk_widget_set_name(d->list_box, "log-history-list");
+
+  d->scrolled = gtk_scrolled_window_new(NULL, NULL);
+  gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(d->scrolled),
+                                 GTK_POLICY_AUTOMATIC, GTK_POLICY_AUTOMATIC);
+  gtk_scrolled_window_set_min_content_height(GTK_SCROLLED_WINDOW(d->scrolled),
+                                             DT_PIXEL_APPLY_DPI(200));
+
+  gtk_widget_set_size_request(d->scrolled,
+                              DT_PIXEL_APPLY_DPI(700),
+                              DT_PIXEL_APPLY_DPI(200));
+
+  gtk_container_add(GTK_CONTAINER(d->scrolled), d->list_box);
+  gtk_container_add(GTK_CONTAINER(d->popover), d->scrolled);
+
+  g_signal_connect(G_OBJECT(d->button), "button-press-event",
+                   G_CALLBACK(_button_press_release), self);
+  g_signal_connect(G_OBJECT(d->button), "button-release-event",
+                   G_CALLBACK(_button_press_release), self);
+
+  self->widget = dt_gui_hbox(d->button);
+
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_CONTROL_LOG_REDRAW,
+                            G_CALLBACK(_log_redraw_callback), self);
+}
+
+void gui_cleanup(dt_lib_module_t *self)
+{
+  dt_lib_log_history_t *d = self->data;
+
+  DT_CONTROL_SIGNAL_DISCONNECT(G_CALLBACK(_log_redraw_callback), self);
+
+  if(d->popover)
+    gtk_widget_destroy(d->popover);
+
+  g_free(d);
+  self->data = NULL;
+}
+
+// clang-format off
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
+// clang-format on


### PR DESCRIPTION
Add a persistent circular buffer (1000 entries) for dt_control_log messages, stored as a GList in dt_control_t. Each entry contains a timestamp (HH:MM:SS) and the log message, with consecutive duplicate messages filtered out.

A new toolbar button (speech bubble icon) in the center-bottom-right panel opens a GtkPopover with a scrollable GtkListBox displaying all log entries in monospace font. Clicking the button toggles the popover. Entries are selectable for copy-paste.

Files added/modified:
- src/control/control.{h,c}: GList-based log history storage, dt_control_log_history_get_entries() API
- src/dtgtk/paint.{h,c}: new dtgtk_cairo_paint_messages icon
- src/libs/tools/log_history.c: new lib module with popover UI
- src/libs/CMakeLists.txt: register the new module
- data/themes/darktable.css: popover styling

Co-authored-by: OpenCode Zen