### PR TITLE
Define the function only on platforms where it will be used

### DIFF
--- a/src/ai/backend_onnx.c
+++ b/src/ai/backend_onnx.c
@@ -552,6 +552,7 @@ int dt_ai_ort_probe_library_full(const char *path, char **out_version, char **ou
   return TRUE;
 }
 
+#if !defined(_WIN32)
 // find libonnxruntime.so.* recursively, skip auditwheel *.libs/ peers
 static gchar *_scan_for_ort_lib(const char *root)
 {
@@ -576,6 +577,7 @@ static gchar *_scan_for_ort_lib(const char *root)
   g_dir_close(d);
   return result;
 }
+#endif
 
 // Scan system and user-space paths for valid ORT libraries.
 // Returns a GList of dt_ai_ort_found_t (caller owns list and contents).


### PR DESCRIPTION
This avoids compiler warning about defining but not using a function on Windows:

```
C:/msys64/home/victor/darktable/src/ai/backend_onnx.c:556:15: warning: '_scan_for_ort_lib' defined but not used [-Wunused-function]
  556 | static gchar *_scan_for_ort_lib(const char *root)
      |               ^~~~~~~~~~~~~~~~~
```

FYI @andriiryzhkov as this is your code (possibly still not final) and you probably want to be aware of any changes that someone else makes to it.