### PR TITLE
Add metadata query to Lua API

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -809,6 +809,7 @@ if(USE_LUA)
       "lua/lua.c"
       "lua/lualib.c"
       "lua/luastorage.c"
+      "lua/metadata.c"
       "lua/modules.c"
       "lua/password.c"
       "lua/preferences.c"

--- a/src/lua/init.c
+++ b/src/lua/init.c
@@ -35,6 +35,7 @@
 #include "lua/lua.h"
 #include "lua/lualib.h"
 #include "lua/luastorage.h"
+#include "lua/metadata.h"
 #include "lua/modules.h"
 #include "lua/password.h"
 #include "lua/preferences.h"
@@ -135,7 +136,7 @@ static lua_CFunction init_funcs[]
         dt_lua_init_luastorages,   dt_lua_init_tags,        dt_lua_init_film,     dt_lua_init_call,
         dt_lua_init_view,          dt_lua_init_events,      dt_lua_init_init,     dt_lua_init_widget,
         dt_lua_init_lualib,        dt_lua_init_gettext,     dt_lua_init_guides,   dt_lua_init_cairo,
-        dt_lua_init_password,      dt_lua_init_util,        NULL };
+        dt_lua_init_password,      dt_lua_init_util,        dt_lua_init_metadata, NULL };
 
 
 void dt_lua_init(lua_State *L, const char *lua_command)

--- a/src/lua/metadata.c
+++ b/src/lua/metadata.c
@@ -1,0 +1,57 @@
+/*
+   This file is part of darktable,
+   Copyright (C) 2026 darktable developers.
+
+   darktable is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   darktable is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "common/metadata.h"
+#include "lua/metadata.h"
+#include "lua/glist.h"
+#include "lua/types.h"
+
+static int exists(lua_State *L)
+{
+  gboolean result = false;
+  dt_metadata_t *md;
+
+  const char *tagname = luaL_checkstring(L, 1);
+
+  md = dt_metadata_get_metadata_by_tagname(tagname);
+
+  if(md)
+    result = true;
+
+  lua_pushboolean(L, result);
+  return 1;
+}
+
+int dt_lua_init_metadata(lua_State *L)
+{
+  dt_lua_push_darktable_lib(L);
+  dt_lua_goto_subtable(L, "metadata");
+
+  lua_pushcfunction(L, exists);
+  lua_setfield(L, -2, "exists");
+
+  lua_pop(L, 1);
+
+  return 0;
+}
+
+// clang-format off
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
+// clang-format on

--- a/src/lua/metadata.h
+++ b/src/lua/metadata.h
@@ -1,0 +1,30 @@
+/*
+   This file is part of darktable,
+   Copyright (C) 2026 darktable developers.
+
+   darktable is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   darktable is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "lua/lua.h"
+
+int dt_lua_init_metadata(lua_State *L);
+
+// clang-format off
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
+// clang-format on
+


### PR DESCRIPTION
#20872 added the ability for users to add additional metadata fields that are populated on image import.

The Lua API adds those fields to the `dt_lua_image_t` datatype as accessible members.

If you try and access a `dt_lua_image_t` member that doesn't exist, Lua throws an error that stops script execution.  The error can't be caught with a `pcall()`.

The fix is adding some metadata functionality to the Lua API.  This PR adds a `darktable.metadata.exists(<exif tag name>)` function to the API that returns true or false based on whether a user has registered the metadata in metadata editor.  Scripts can use this information to decide whether to spawn an external executable (exiv2 or exiftool) to get metadata or use the internal metadata.

Currently the metadata section only includes `exists()`.  Future functionality could be added to add and remove additional metadata tags without the user having to intervene. With the short time until feature freeze `exists()` is a needed feature and  the others can wait.

---

To test...

- Download the attached script, unzip it and add it to lua scripts
- start darktable with the -d lua flag
- add tag Exif.Canon.RawBurstModeRoll to metadata editor.
- start the test_metadata_api.lua
- check the log for "found Exif.Canon.RawBurstModeRoll"
- remove Exif.Canon.RawBurstModeRoll from metadata editor
- restart darktable
- check the log for "didn't find Exif.Canon.RawBurstModeRoll"

[test_metadata_api.zip](https://github.com/user-attachments/files/27540861/test_metadata_api.zip)