### PR TITLE
Draft: lua: expose pixmaps and icons install dirs in configuration

### DIFF
--- a/src/lua/configuration.c
+++ b/src/lua/configuration.c
@@ -119,6 +119,22 @@ int dt_lua_init_configuration(lua_State *L)
   lua_pushstring(L, tmp_path);
   lua_settable(L, -3);
 
+  lua_pushstring(L, "pixmaps_dir");
+  {
+    gchar *pixmaps_dir = g_build_filename(tmp_path, "pixmaps", NULL);
+    lua_pushstring(L, pixmaps_dir);
+    g_free(pixmaps_dir);
+  }
+  lua_settable(L, -3);
+
+  lua_pushstring(L, "icons_dir");
+  {
+    gchar *icons_dir = g_build_filename(tmp_path, "icons", NULL);
+    lua_pushstring(L, icons_dir);
+    g_free(icons_dir);
+  }
+  lua_settable(L, -3);
+
   lua_pushstring(L, "version");
   lua_pushstring(L, darktable_package_version);
   lua_settable(L, -3);

--- a/src/lua/configuration.h
+++ b/src/lua/configuration.h
@@ -47,7 +47,7 @@
 /* incompatible API change */
 #define LUA_API_VERSION_MAJOR 9
 /* backward compatible API change */
-#define LUA_API_VERSION_MINOR 7
+#define LUA_API_VERSION_MINOR 8
 /* bugfixes that should not change anything to the API */
 #define LUA_API_VERSION_PATCH 0
 /* suffix for unstable version */

--- a/tools/lua_doc/content.lua
+++ b/tools/lua_doc/content.lua
@@ -262,6 +262,8 @@ darktable.configuration.verbose:set_text([[True if the Lua logdomain is enabled.
 darktable.configuration.tmp_dir:set_text([[The name of the directory where darktable will store temporary files.]])
 darktable.configuration.config_dir:set_text([[The name of the directory where darktable will find its global configuration objects (modules).]])
 darktable.configuration.cache_dir:set_text([[The name of the directory where darktable will store its mipmaps.]])
+darktable.configuration.pixmaps_dir:set_text([[The directory where darktable installs pixmap assets (logos, miscellaneous images, and the `plugins/darkroom/` tree of module icons as SVG or PNG). Build a full pathname by appending a relative file path for use with GUI widgets that accept an image file, for example a button `image` field.]])
+darktable.configuration.icons_dir:set_text([[The directory that darktable prepends to the GTK icon theme search path (multi-size `hicolor` layout, including the `darktable` application icon).]])
 darktable.configuration.api_version_major:set_text([[The major version number of the lua API.]])
 darktable.configuration.api_version_minor:set_text([[The minor version number of the lua API.]])
 darktable.configuration.api_version_patch:set_text([[The patch version number of the lua API.]])


### PR DESCRIPTION
closes #16792 

Add darktable.configuration.pixmaps_dir and .icons_dir (under the data directory), built with g_build_filename so paths match the installed layout on all platforms. Document them in the Lua API generator and bump the Lua API to 9.8.0.

Scripts can point widgets or file reads at shipped artwork (e.g. plugins/darkroom/*.svg) without hardcoding data_dir subpaths.
