### PR TITLE
Some faster pixelpipe

### DIFF
--- a/data/kernels/colorspaces.cl
+++ b/data/kernels/colorspaces.cl
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    copyright (c) 2019 edgardo hoszowski.
+    Copyright (C) 2019-2026 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -20,15 +20,19 @@
 #include "colorspace.h"
 
 kernel void
-colorspaces_transform_lab_to_rgb_matrix(read_only image2d_t in, write_only image2d_t out, const int width, const int height,
-    constant const dt_colorspaces_iccprofile_info_cl_t *const profile_info, read_only image2d_t lut)
+colorspaces_transform_lab_to_rgb_matrix(read_only image2d_t in,
+                                        write_only image2d_t out,
+                                        const int width,
+                                        const int height,
+                                        constant const dt_colorspaces_iccprofile_info_cl_t *const profile_info,
+                                        read_only image2d_t lut)
 {
   const int x = get_global_id(0);
   const int y = get_global_id(1);
 
   if(x >= width || y >= height) return;
 
-  float4 pixel = read_imagef(in, sampleri, (int2)(x, y));
+  float4 pixel = Areadpixel(in, x, y);
   pixel.xyz = Lab_to_XYZ(pixel).xyz;
   pixel = matrix_product(pixel, profile_info->matrix_out);
 
@@ -39,15 +43,19 @@ colorspaces_transform_lab_to_rgb_matrix(read_only image2d_t in, write_only image
 }
 
 kernel void
-colorspaces_transform_rgb_matrix_to_lab(read_only image2d_t in, write_only image2d_t out, const int width, const int height,
-    constant const dt_colorspaces_iccprofile_info_cl_t *const profile_info, read_only image2d_t lut)
+colorspaces_transform_rgb_matrix_to_lab(read_only image2d_t in,
+                                        write_only image2d_t out,
+                                        const int width,
+                                        const int height,
+                                        constant const dt_colorspaces_iccprofile_info_cl_t *const profile_info,
+                                        read_only image2d_t lut)
 {
   const int x = get_global_id(0);
   const int y = get_global_id(1);
 
   if(x >= width || y >= height) return;
 
-  float4 pixel = read_imagef(in, sampleri, (int2)(x, y));
+  float4 pixel = Areadpixel(in, x, y);
 
   if(profile_info->nonlinearlut)
     pixel = apply_trc_in(pixel, profile_info, lut);
@@ -59,17 +67,22 @@ colorspaces_transform_rgb_matrix_to_lab(read_only image2d_t in, write_only image
 }
 
 kernel void
-colorspaces_transform_rgb_matrix_to_rgb(read_only image2d_t in, write_only image2d_t out, const int width, const int height,
-    constant const dt_colorspaces_iccprofile_info_cl_t *const profile_info_from, read_only image2d_t lut_from,
-    constant const dt_colorspaces_iccprofile_info_cl_t *const profile_info_to, read_only image2d_t lut_to,
-    constant const float *const matrix)
+colorspaces_transform_rgb_matrix_to_rgb(read_only image2d_t in,
+                                        write_only image2d_t out,
+                                        const int width,
+                                        const int height,
+                                        constant const dt_colorspaces_iccprofile_info_cl_t *const profile_info_from,
+                                        read_only image2d_t lut_from,
+                                        constant const dt_colorspaces_iccprofile_info_cl_t *const profile_info_to,
+                                        read_only image2d_t lut_to,
+                                        constant const float *const matrix)
 {
   const int x = get_global_id(0);
   const int y = get_global_id(1);
 
   if(x >= width || y >= height) return;
 
-  float4 pixel = read_imagef(in, sampleri, (int2)(x, y));
+  float4 pixel = Areadpixel(in, x, y);
 
   if(profile_info_from->nonlinearlut)
     pixel = apply_trc_in(pixel, profile_info_from, lut_from);
@@ -83,13 +96,17 @@ colorspaces_transform_rgb_matrix_to_rgb(read_only image2d_t in, write_only image
 }
 
 kernel void
-colorspaces_transform_gamma(read_only image2d_t in, write_only image2d_t out, const int width, const int height, const float gamma)
+colorspaces_transform_gamma(read_only image2d_t in,
+                            write_only image2d_t out,
+                            const int width,
+                            const int height,
+                            const float gamma)
 {
   const int x = get_global_id(0);
   const int y = get_global_id(1);
 
   if(x >= width || y >= height) return;
 
-  const float4 pixel = fmax(0.0f, read_imagef(in, sampleri, (int2)(x, y)) );
+  float4 pixel = fmax(0.0f, Areadpixel(in, x, y));
   write_imagef(out, (int2)(x, y), dtcl_pow(pixel, gamma));
 }

--- a/src/common/gaussian.c
+++ b/src/common/gaussian.c
@@ -927,7 +927,7 @@ cl_int dt_gaussian_blur_cl(dt_gaussian_cl_t *g, cl_mem dev_in, cl_mem dev_out)
   else
     return DT_OPENCL_PROCESS_CL;
 
-  size_t region[] = { width, height };
+  size_t region[2] = { width, height };
   size_t local[2] = { blocksize, blocksize };
   size_t sizes[2];
 
@@ -1024,8 +1024,8 @@ cl_int dt_gaussian_blur_cl_buffer(dt_gaussian_cl_t *g, cl_mem dev_in, cl_mem dev
   else
     return  DT_OPENCL_PROCESS_CL;
 
-  size_t local[] = { blocksize, blocksize, 1 };
-  size_t sizes[3];
+  size_t local[2] = { blocksize, blocksize };
+  size_t sizes[2];
 
   // compute gaussian parameters
   float a0, a1, a2, a3, b1, b2, coefp, coefn;

--- a/src/common/heal.c
+++ b/src/common/heal.c
@@ -436,17 +436,17 @@ cl_int dt_heal_cl(heal_params_cl_t *p, cl_mem dev_src, cl_mem dev_dest, const fl
   if(dest_buffer == NULL) goto cleanup;
 
   err = dt_opencl_read_buffer_from_device(p->devid, (void *)src_buffer, dev_src, 0,
-                                          (size_t)width * height * ch * sizeof(float), CL_TRUE);
+                                          (size_t)width * height * ch * sizeof(float), TRUE);
   if(err != CL_SUCCESS) goto cleanup;
 
   err = dt_opencl_read_buffer_from_device(p->devid, (void *)dest_buffer, dev_dest, 0,
-                                          (size_t)width * height * ch * sizeof(float), CL_TRUE);
+                                          (size_t)width * height * ch * sizeof(float), TRUE);
   if(err != CL_SUCCESS) goto cleanup;
 
   // I couldn't make it run fast on opencl (the reduction takes forever), so just call the cpu version
   dt_heal(src_buffer, dest_buffer, mask_buffer, width, height, ch, max_iter);
 
-  err = dt_opencl_write_buffer_to_device(p->devid, dest_buffer, dev_dest, 0, sizeof(float) * width * height * ch, CL_TRUE);
+  err = dt_opencl_write_buffer_to_device(p->devid, dest_buffer, dev_dest, 0, sizeof(float) * width * height * ch, TRUE);
 
 cleanup:
   if(src_buffer) dt_free_align(src_buffer);

--- a/src/common/iop_profile.c
+++ b/src/common/iop_profile.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2020-2025 darktable developers.
+    Copyright (C) 2020-2026 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -516,8 +516,7 @@ static inline void _transform_matrix_rgb
    const dt_iop_order_iccprofile_info_t *const profile_info_from,
    const dt_iop_order_iccprofile_info_t *const profile_info_to)
 {
-  const int ch = 4;
-  const size_t stride = (size_t)width * height * ch;
+  const size_t stride = (size_t)width * height * 4;
 
   // RGB -> XYZ -> RGB are 2 matrices products, they can be premultiplied globally ahead
   // and put in a new matrix. then we spare one matrix product per pixel.
@@ -1429,7 +1428,7 @@ cl_int dt_ioppr_build_iccprofile_params_cl(const dt_iop_order_iccprofile_info_t 
   }
   else
   {
-    profile_lut_cl = malloc(sizeof(cl_float) * 1 * 6);
+    profile_lut_cl = calloc(1, sizeof(cl_float) * 1 * 6);
 
     if(profile_lut_cl)
       dev_profile_lut = dt_opencl_copy_host_to_device(devid, profile_lut_cl, 1, 1 * 6,
@@ -1491,7 +1490,7 @@ gboolean dt_ioppr_transform_image_colorspace_cl
   const gboolean inplace = dev_img_in == dev_img_out;
   const gboolean anyraw = cst_to == IOP_CS_RAW || cst_from == IOP_CS_RAW;
 
-  size_t region[] = { width, height };
+  const size_t region[2] = { width, height };
 
   *converted_cst = cst_to;
   if(cst_from == cst_to)
@@ -1524,11 +1523,9 @@ gboolean dt_ioppr_transform_image_colorspace_cl
     return err == CL_SUCCESS;
   }
 
-  const size_t ch = 4;
   float *src_buffer = NULL;
 
   int kernel_transform = 0;
-  cl_mem dev_tmp = NULL;
   cl_mem dev_profile_info = NULL;
   cl_mem dev_lut = NULL;
   dt_colorspaces_iccprofile_info_cl_t profile_info_cl;
@@ -1569,47 +1566,24 @@ gboolean dt_ioppr_transform_image_colorspace_cl
     _ioppr_get_profile_info_cl(profile_info, &profile_info_cl);
     lut_cl = _ioppr_get_trc_cl(profile_info);
 
-    if(inplace)
-    {
-      dev_tmp = dt_opencl_alloc_device(devid, width, height, sizeof(float) * 4);
-      if(dev_tmp == NULL)
-      {
-        err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
-        goto cleanup;
-      }
-
-      err = dt_opencl_enqueue_copy_image(devid, dev_img_in, dev_tmp, CLIMG_ORIGIN, CLIMG_ORIGIN, region);
-      if(err != CL_SUCCESS)
-        goto cleanup;
-    }
-    else
-    {
-      dev_tmp = dev_img_in;
-    }
-
     dev_profile_info = dt_opencl_copy_host_to_device_constant(devid, sizeof(profile_info_cl),
                                                               &profile_info_cl);
-    if(dev_profile_info == NULL)
-    {
-      err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
-      goto cleanup;
-    }
     dev_lut = dt_opencl_copy_host_to_device(devid, lut_cl, 256, 256 * 6, sizeof(float));
-    if(dev_lut == NULL)
+
+    if(dev_profile_info == NULL || dev_lut == NULL)
     {
       err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
       goto cleanup;
     }
 
     err = dt_opencl_enqueue_kernel_2d_args(devid, kernel_transform, width, height,
-                                           CLARG(dev_tmp), CLARG(dev_img_out),
+                                           CLARG(dev_img_in), CLARG(dev_img_out),
                                            CLARG(width), CLARG(height),
                                            CLARG(dev_profile_info), CLARG(dev_lut));
-    if(err != CL_SUCCESS)
-      goto cleanup;
-
-    dt_print(DT_DEBUG_PERF,
-             "[dt_ioppr_transform_image_colorspace_cl] %s-->%s took %.3f secs (%.3f GPU) [%s%s]",
+    if(err == CL_SUCCESS)
+      dt_print(DT_DEBUG_PERF,
+             "[dt_ioppr_transform_image_colorspace_cl]%s %s-->%s took %.3f secs (%.3f GPU) [%s%s]",
+             inplace ? " inplace" : "",
              dt_iop_colorspace_to_name(cst_from), dt_iop_colorspace_to_name(cst_to),
              dt_get_lap_time(&start_time.clock),
              dt_get_lap_utime(&start_time.user),
@@ -1618,7 +1592,7 @@ gboolean dt_ioppr_transform_image_colorspace_cl
   else
   {
     // no matrix, call lcms2
-    src_buffer = dt_alloc_align_float(ch * width * height);
+    src_buffer = dt_alloc_align_float((size_t)4 * width * height);
     if(src_buffer == NULL)
     {
       err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
@@ -1626,7 +1600,7 @@ gboolean dt_ioppr_transform_image_colorspace_cl
     }
 
     err = dt_opencl_copy_device_to_host(devid, src_buffer, dev_img_in,
-                                        width, height, ch * sizeof(float));
+                                        width, height, 4 * sizeof(float));
     if(err != CL_SUCCESS)
       goto cleanup;
 
@@ -1636,7 +1610,7 @@ gboolean dt_ioppr_transform_image_colorspace_cl
                                         converted_cst, profile_info);
 
     err = dt_opencl_write_host_to_device(devid, src_buffer, dev_img_out,
-                                         width, height, ch * sizeof(float));
+                                         width, height, 4 * sizeof(float));
   }
 
 cleanup:
@@ -1645,8 +1619,6 @@ cleanup:
              "[dt_ioppr_transform_image_colorspace_cl] had error: %s", cl_errstr(err));
 
   dt_free_align(src_buffer);
-  if(dev_tmp && inplace)
-    dt_opencl_release_mem_object(dev_tmp);
   dt_opencl_release_mem_object(dev_profile_info);
   dt_opencl_release_mem_object(dev_lut);
   if(lut_cl)
@@ -1672,12 +1644,14 @@ gboolean dt_ioppr_transform_image_colorspace_rgb_cl
   {
     return FALSE;
   }
+
+  const size_t region[2] = { width, height };
+
   if(profile_info_from->type == profile_info_to->type
      && strcmp(profile_info_from->filename, profile_info_to->filename) == 0)
   {
     if(dev_img_in != dev_img_out)
     {
-      size_t region[] = { width, height };
       err = dt_opencl_enqueue_copy_image(devid, dev_img_in, dev_img_out, CLIMG_ORIGIN, CLIMG_ORIGIN, region);
       if(err != CL_SUCCESS)
       {
@@ -1691,13 +1665,11 @@ gboolean dt_ioppr_transform_image_colorspace_rgb_cl
     return TRUE;
   }
 
-  const size_t ch = 4;
   float *src_buffer_in = NULL;
   float *src_buffer_out = NULL;
-  int in_place = (dev_img_in == dev_img_out);
+  const gboolean in_place = (dev_img_in == dev_img_out);
 
   int kernel_transform = 0;
-  cl_mem dev_tmp = NULL;
 
   cl_mem dev_profile_info_from = NULL;
   cl_mem dev_lut_from = NULL;
@@ -1720,8 +1692,6 @@ gboolean dt_ioppr_transform_image_colorspace_rgb_cl
     dt_times_t start_time = { 0 };
     dt_get_perf_times(&start_time);
 
-    size_t region[] = { width, height };
-
     kernel_transform = darktable.opencl->colorspaces->kernel_colorspaces_transform_rgb_matrix_to_rgb;
 
     _ioppr_get_profile_info_cl(profile_info_from, &profile_info_from_cl);
@@ -1733,92 +1703,54 @@ gboolean dt_ioppr_transform_image_colorspace_rgb_cl
     dt_colormatrix_t matrix;
     dt_colormatrix_mul(matrix, profile_info_to->matrix_out, profile_info_from->matrix_in);
 
-    if(in_place)
-    {
-      dev_tmp = dt_opencl_alloc_device(devid, width, height, sizeof(float) * 4);
-      if(dev_tmp == NULL)
-      {
-        err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
-        goto cleanup;
-      }
-
-      err = dt_opencl_enqueue_copy_image(devid, dev_img_in, dev_tmp, CLIMG_ORIGIN, CLIMG_ORIGIN, region);
-      if(err != CL_SUCCESS)
-         goto cleanup;
-     }
-    else
-    {
-      dev_tmp = dev_img_in;
-    }
-
-    dev_profile_info_from
-        = dt_opencl_copy_host_to_device_constant(devid, sizeof(profile_info_from_cl),
+    dev_profile_info_from = dt_opencl_copy_host_to_device_constant(devid, sizeof(profile_info_from_cl),
                                                  &profile_info_from_cl);
-    if(dev_profile_info_from == NULL)
-    {
-      err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
-      goto cleanup;
-    }
     dev_lut_from = dt_opencl_copy_host_to_device(devid, lut_from_cl, 256, 256 * 6, sizeof(float));
-    if(dev_lut_from == NULL)
-    {
-      err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
-      goto cleanup;
-    }
 
-    dev_profile_info_to
-        = dt_opencl_copy_host_to_device_constant(devid, sizeof(profile_info_to_cl),
+    dev_profile_info_to = dt_opencl_copy_host_to_device_constant(devid, sizeof(profile_info_to_cl),
                                                  &profile_info_to_cl);
-    if(dev_profile_info_to == NULL)
-    {
-      err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
-      goto cleanup;
-    }
     dev_lut_to = dt_opencl_copy_host_to_device(devid, lut_to_cl, 256, 256 * 6, sizeof(float));
-    if(dev_lut_to == NULL)
-    {
-      err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
-      goto cleanup;
-    }
+
     float matrix3x3[9];
     pack_3xSSE_to_3x3(matrix, matrix3x3);
     matrix_cl = dt_opencl_copy_host_to_device_constant(devid, sizeof(matrix3x3), &matrix3x3);
-    if(matrix_cl == NULL)
+
+    if(dev_lut_to == NULL || dev_profile_info_to == NULL || dev_lut_from == NULL || dev_profile_info_from == NULL || matrix_cl == NULL)
     {
       err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
       goto cleanup;
     }
 
     err = dt_opencl_enqueue_kernel_2d_args(devid, kernel_transform, width, height,
-                                           CLARG(dev_tmp), CLARG(dev_img_out),
+                                           CLARG(dev_img_in), CLARG(dev_img_out),
                                            CLARG(width), CLARG(height),
                                            CLARG(dev_profile_info_from),
                                            CLARG(dev_lut_from),
                                            CLARG(dev_profile_info_to),
                                            CLARG(dev_lut_to),
                                            CLARG(matrix_cl));
-    if(err != CL_SUCCESS)
-      goto cleanup;
-
-  dt_print(DT_DEBUG_PIPE,
-    "dt_ioppr_transform_image_colorspace_rgb_CL `%s' -> `%s' [%s]",
+    if(err == CL_SUCCESS)
+    {
+      dt_print(DT_DEBUG_PIPE, "dt_ioppr_transform_image_colorspace_rgb_CL%s `%s' -> `%s' [%s]",
+             in_place ? " inplace" : "",
              dt_colorspaces_get_name(profile_info_from->type, profile_info_from->filename),
              dt_colorspaces_get_name(profile_info_to->type, profile_info_to->filename),
             message ? message : "");
 
-    dt_print(DT_DEBUG_PERF,
-             "image colorspace transform_rgb_CL  `%s' -> `%s' took %.3f secs (%.3f GPU) [%s]",
+      dt_print(DT_DEBUG_PERF, "image colorspace transform_rgb_CL%s  `%s' -> `%s' took %.3f secs (%.3f GPU) [%s]",
+             in_place ? " inplace" : "",
              dt_colorspaces_get_name(profile_info_from->type, profile_info_from->filename),
              dt_colorspaces_get_name(profile_info_to->type, profile_info_to->filename),
              dt_get_lap_time(&start_time.clock),
              dt_get_lap_utime(&start_time.user),
              message ? message : "");
+    }
   }
   else
   {
     // no matrix, call lcms2
-    src_buffer_in  = dt_alloc_align_float(ch * width * height);
-    src_buffer_out = dt_alloc_align_float(ch * width * height);
+    src_buffer_in  = dt_alloc_align_float((size_t)4 * width * height);
+    src_buffer_out = dt_alloc_align_float((size_t)4 * width * height);
     if(src_buffer_in == NULL || src_buffer_out == NULL)
     {
       err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
@@ -1826,7 +1758,7 @@ gboolean dt_ioppr_transform_image_colorspace_rgb_cl
     }
 
     err = dt_opencl_copy_device_to_host(devid, src_buffer_in, dev_img_in,
-                                        width, height, ch * sizeof(float));
+                                        width, height, 4 * sizeof(float));
     if(err != CL_SUCCESS)
       goto cleanup;
 
@@ -1836,7 +1768,7 @@ gboolean dt_ioppr_transform_image_colorspace_rgb_cl
                                             profile_info_to, message);
 
     err = dt_opencl_write_host_to_device(devid, src_buffer_out, dev_img_out,
-                                         width, height, ch * sizeof(float));
+                                         width, height, 4 * sizeof(float));
   }
 
 cleanup:
@@ -1853,7 +1785,6 @@ cleanup:
   dt_opencl_release_mem_object(dev_lut_to);
   dt_opencl_release_mem_object(matrix_cl);
 
-  if(dev_tmp && in_place) dt_opencl_release_mem_object(dev_tmp);
   if(lut_from_cl) free(lut_from_cl);
   if(lut_to_cl) free(lut_to_cl);
 

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -2882,11 +2882,10 @@ int dt_opencl_read_host_from_device_rowpitch(const int devid,
 {
   if(!_cldev_running(devid))
     return DT_OPENCL_NODEVICE;
-  const size_t origin[] = { 0, 0, 0 };
-  const size_t region[] = { width, height, 1 };
+  const size_t region[2] = { width, height };
   // blocking.
-  return dt_opencl_read_host_from_device_raw(devid, host, device, origin,
-                                             region, rowpitch, CL_TRUE);
+  return dt_opencl_read_host_from_device_raw(devid, host, device, CLIMG_ORIGIN,
+                                             region, rowpitch, TRUE);
 }
 
 int dt_opencl_read_host_from_device_raw(const int devid,
@@ -2895,10 +2894,13 @@ int dt_opencl_read_host_from_device_raw(const int devid,
                                         const size_t *origin,
                                         const size_t *region,
                                         const int rowpitch,
-                                        const int blocking)
+                                        const gboolean blocking)
 {
   if(!_cldev_running(devid))
     return DT_OPENCL_NODEVICE;
+
+  const size_t org[3] = { origin ? origin[0] : 0, origin ? origin[1] : 0, 0 };
+  const size_t reg[3] = { region[0], region[1], 1 };
 
   cl_event *eventp = _opencl_events_get_slot(devid, "[Read Image (from device to host)]");
 
@@ -2906,7 +2908,7 @@ int dt_opencl_read_host_from_device_raw(const int devid,
     (darktable.opencl->dev[devid].cmd_queue,
      device,
      blocking ? CL_TRUE : CL_FALSE,
-     origin, region, rowpitch,
+     org, reg, rowpitch,
      0, host, 0, NULL, eventp);
 
   if(err != CL_SUCCESS)
@@ -2942,11 +2944,10 @@ int dt_opencl_write_host_to_device_rowpitch(const int devid,
   if(!_cldev_running(devid))
     return DT_OPENCL_NODEVICE;
 
-  const size_t origin[] = { 0, 0, 0 };
-  const size_t region[] = { width, height, 1 };
+  const size_t region[2] = { width, height };
   // blocking.
-  return dt_opencl_write_host_to_device_raw(devid, host, device, origin,
-                                            region, rowpitch, CL_TRUE);
+  return dt_opencl_write_host_to_device_raw(devid, host, device, CLIMG_ORIGIN,
+                                            region, rowpitch, TRUE);
 }
 
 int dt_opencl_write_host_to_device_raw(const int devid,
@@ -2955,17 +2956,20 @@ int dt_opencl_write_host_to_device_raw(const int devid,
                                        const size_t *origin,
                                        const size_t *region,
                                        const int rowpitch,
-                                       const int blocking)
+                                       const gboolean blocking)
 {
   if(!_cldev_running(devid))
     return DT_OPENCL_NODEVICE;
+
+  const size_t org[3] = { origin ? origin[0] : 0, origin ? origin[1] : 0, 0 };
+  const size_t reg[3] = { region[0], region[1], 1 };
 
   cl_event *eventp = _opencl_events_get_slot(devid, "[Write Image (from host to device)]");
   const cl_int err = (darktable.opencl->dlocl->symbols->dt_clEnqueueWriteImage)
     (darktable.opencl->dev[devid].cmd_queue,
      device, blocking ? CL_TRUE : CL_FALSE,
-     origin, region,
-     rowpitch, 0, host, 0, NULL, eventp);
+     org, reg, rowpitch, 0, host, 0, NULL, eventp);
+
   if(err != CL_SUCCESS)
     dt_print(DT_DEBUG_OPENCL,
              "[dt_opencl_write_host_to_device_raw] could not write image to device '%s' id=%d: %s",
@@ -3106,7 +3110,7 @@ int dt_opencl_read_buffer_from_device(const int devid,
                                       void *device,
                                       const size_t offset,
                                       const size_t size,
-                                      const int blocking)
+                                      const gboolean blocking)
 {
   if(!_cldev_running(devid))
     return DT_OPENCL_NODEVICE;
@@ -3135,7 +3139,7 @@ int dt_opencl_write_buffer_to_device(const int devid,
                                      void *device,
                                      const size_t offset,
                                      const size_t size,
-                                     const int blocking)
+                                     const gboolean blocking)
 {
   if(!_cldev_running(devid))
     return DT_OPENCL_NODEVICE;
@@ -3268,7 +3272,7 @@ void dt_opencl_release_mem_object(cl_mem mem)
 
 void *dt_opencl_map_buffer(const int devid,
                            cl_mem buffer,
-                           const int blocking,
+                           const gboolean blocking,
                            const int flags,
                            size_t offset,
                            size_t size)

--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -455,7 +455,7 @@ int dt_opencl_read_host_from_device_raw(const int devid,
                                         const size_t *origin,
                                         const size_t *region,
                                         const int rowpitch,
-                                        const int blocking);
+                                        const gboolean blocking);
 
 int dt_opencl_write_host_to_device(const int devid,
                                    const void *host,
@@ -477,7 +477,7 @@ int dt_opencl_write_host_to_device_raw(const int devid,
                                        const size_t *origin,
                                        const size_t *region,
                                        const int rowpitch,
-                                       const int blocking);
+                                       const gboolean blocking);
 
 void *dt_opencl_copy_host_to_device(const int devid,
                                     void *host,
@@ -527,14 +527,14 @@ int dt_opencl_read_buffer_from_device(const int devid,
                                       void *device,
                                       const size_t offset,
                                       const size_t size,
-                                      const int blocking);
+                                      const gboolean blocking);
 
 int dt_opencl_write_buffer_to_device(const int devid,
                                      void *host,
                                      void *device,
                                      const size_t offset,
                                      const size_t size,
-                                     const int blocking);
+                                     const gboolean blocking);
 
 void *dt_opencl_alloc_device_buffer(const int devid,
                                     const size_t size);
@@ -547,7 +547,7 @@ void dt_opencl_release_mem_object(cl_mem mem);
 
 void *dt_opencl_map_buffer(const int devid,
                            cl_mem buffer,
-                           const int blocking,
+                           const gboolean blocking,
                            const int flags,
                            size_t offset,
                            size_t size);

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -962,8 +962,8 @@ static void _pixelpipe_picker_cl(const int devid,
                          picker_source, box))
     return;
 
-  const size_t origin[3] = { box[0], box[1], 0 };
-  const size_t region[3] = { box[2] - box[0], box[3] - box[1], 1 };
+  const size_t origin[2] = { box[0], box[1] };
+  const size_t region[2] = { box[2] - box[0], box[3] - box[1] };
 
   float *pixel = NULL;
   float *tmpbuf = NULL;
@@ -982,7 +982,7 @@ static void _pixelpipe_picker_cl(const int devid,
 
   // get the required part of the image from opencl device
   if(dt_opencl_read_host_from_device_raw(devid, pixel, img,
-                                         origin, region, region[0] * bpp, CL_TRUE) != CL_SUCCESS)
+                                         origin, region, region[0] * bpp, TRUE) != CL_SUCCESS)
   {
     dt_print_pipe(DT_DEBUG_PIPE,
                   picker_source == PIXELPIPE_PICKER_INPUT

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -1363,11 +1363,11 @@ static gboolean _pixelpipe_process_on_CPU(dt_dev_pixelpipe_t *pipe,
                      TRUE, dt_dev_pixelpipe_type_to_str(pipe->type));
 
   const size_t nfloats = bpp * roi_out->width * roi_out->height / sizeof(float);
-  const gboolean relevant = _piece_fast_blend(piece, module);
-  const dt_hash_t phash = relevant
+  const gboolean want_bcache = _piece_fast_blend(piece, module);
+  const dt_hash_t phash = want_bcache
     ? _piece_process_hash(piece, roi_out, module, position)
     : DT_INVALID_HASH;
-  const gboolean bcaching = relevant
+  const gboolean bcaching = want_bcache
     ? pipe->bcache_data && phash == pipe->bcache_hash && phash != DT_INVALID_HASH
     : FALSE;
 
@@ -1387,7 +1387,7 @@ static gboolean _pixelpipe_process_on_CPU(dt_dev_pixelpipe_t *pipe,
     else
     {
       module->process_tiling(module, piece, input, *output, roi_in, roi_out, in_bpp);
-      if(relevant)
+      if(want_bcache)
       {
         if(pipe->mask_display == DT_DEV_PIXELPIPE_DISPLAY_NONE
           && !dt_pipe_shutdown(pipe))
@@ -1453,7 +1453,7 @@ static gboolean _pixelpipe_process_on_CPU(dt_dev_pixelpipe_t *pipe,
     else
     {
       module->process(module, piece, input, *output, roi_in, roi_out);
-      if(relevant)
+      if(want_bcache)
       {
         if(pipe->mask_display == DT_DEV_PIXELPIPE_DISPLAY_NONE
           && !dt_pipe_shutdown(pipe))
@@ -1563,6 +1563,95 @@ static inline gboolean _opencl_pipe_isok(dt_dev_pixelpipe_t *pipe)
          && !darktable.opencl->stopped
          && pipe->opencl_enabled
          && (pipe->devid >= 0);
+}
+
+static cl_int _opencl_benchmark(dt_dev_pixelpipe_t *pipe,
+                                dt_iop_module_t *module,
+                                dt_dev_pixelpipe_iop_t *piece,
+                                const cl_mem bin,
+                                const dt_iop_roi_t *roi_out,
+                                const dt_iop_roi_t *roi_in,
+                                const size_t bpp)
+{
+  dt_times_t bench;
+  dt_times_t end;
+  cl_mem bout = dt_opencl_alloc_device(pipe->devid, roi_out->width, roi_out->height, bpp);
+  if(bout == NULL) return CL_MEM_OBJECT_ALLOCATION_FAILURE;
+
+  const int old_muted = darktable.unmuted;
+  darktable.unmuted = 0;
+  const gboolean full = pipe->type & DT_DEV_PIXELPIPE_FULL;
+  const float mpix = (roi_out->width * roi_out->height) / 1.0e6;
+  const int counter = (pipe->type & DT_DEV_PIXELPIPE_FULL) ? 100 : 50;
+  cl_int err = CL_SUCCESS;
+  dt_get_times(&bench);
+  for(int i = 0; i < counter && bout != NULL && err == CL_SUCCESS && !dt_pipe_shutdown(pipe); i++)
+    err = module->process_cl(module, piece, bin, bout, roi_in, roi_out);
+  dt_get_times(&end);
+  const float clock = (end.clock - bench.clock) / (float)counter;
+  dt_print(DT_DEBUG_ALWAYS,
+      "[bench module %s GPU]%s `%s' takes %8.5fs,%7.2fmpix,%9.3fpix/us",
+      full ? "full" : "export",
+      err == CL_SUCCESS ? "" : " error",
+      module->op, clock, mpix, mpix/clock);
+  dt_opencl_release_mem_object(bout);
+  darktable.unmuted = old_muted;
+  return err;
+}
+
+static void _opencl_dump_diff_pipe_pfm(dt_dev_pixelpipe_t *pipe,
+                                       dt_iop_module_t *module,
+                                       dt_dev_pixelpipe_iop_t *piece,
+                                       cl_mem in,
+                                       cl_mem out,
+                                       const dt_iop_roi_t *roi_out,
+                                       const dt_iop_roi_t *roi_in,
+                                       const int cst)
+{
+  const int ch = dt_opencl_get_image_element_size(in);
+  const int cho = dt_opencl_get_image_element_size(out) / sizeof(float);
+  if((ch == 4 || ch == 16 || ch == 2) // input supports 1/4 channel floats and 1ch uint16
+    && (cho == 1 || cho == 4)       // output for 1/4 channel floats
+    && (dt_str_commasubstring(darktable.dump_diff_pipe, module->op)
+        || dt_str_commasubstring(darktable.dump_diff_pipe, "complete")))
+  {
+    const int ow = roi_out->width;
+    const int oh = roi_out->height;
+    const int iw = roi_in->width;
+    const int ih = roi_in->height;
+    float *clin = dt_alloc_aligned((size_t)iw * ih * ch);
+    float *clout = dt_alloc_align_float((size_t)ow * oh * cho);
+    float *cpudata = dt_alloc_align_float((size_t)ow * oh * cho);
+    if(clin && clout && cpudata)
+    {
+      cl_int err = dt_opencl_copy_device_to_host(pipe->devid, clout, out,
+                                                              ow, oh, cho * sizeof(float));
+      if(err == CL_SUCCESS)
+      {
+        err = dt_opencl_copy_device_to_host(pipe->devid, clin, in, iw, ih, ch);
+        if(err == CL_SUCCESS)
+        {
+          module->process(module, piece, clin, cpudata, roi_in, roi_out);
+          if(cst == IOP_CS_LAB)
+          {
+            for(size_t k = 0; k < (size_t)ow * oh * cho; k+=cho)
+            {
+              dt_aligned_pixel_t XYZ;
+              dt_Lab_to_XYZ(cpudata + k, XYZ);
+              dt_XYZ_to_linearRGB(XYZ, cpudata + k);
+              dt_Lab_to_XYZ(clout + k, XYZ);
+              dt_XYZ_to_linearRGB(XYZ, clout + k);
+            }
+          }
+          dt_dump_pipe_diff_pfm(module->op, clout, cpudata, ow, oh, cho,
+                                            dt_dev_pixelpipe_type_to_str(pipe->type));
+        }
+      }
+    }
+    dt_free_align(cpudata);
+    dt_free_align(clout);
+    dt_free_align(clin);
+  }
 }
 #endif
 
@@ -1685,7 +1774,7 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
      || (pipe == dev->full.pipe     && dev->image_force_reload)
      || (pipe == dev->preview_pipe  && dev->preview_pipe->loading)
      || (pipe == dev->preview2.pipe && dev->preview2.pipe->loading)
-     || (dev->gui_leaving))
+     || dev->gui_leaving)
   {
     return TRUE;
   }
@@ -1788,50 +1877,30 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
           gboolean done = FALSE;
           if(cl_scale_possible)
           {
-            cl_mem tmp_input = dt_opencl_alloc_device(pipe->devid, roi_in.width, roi_in.height, bpp);
-            cl_mem linear_input = dt_opencl_alloc_device(pipe->devid, roi_in.width, roi_in.height, bpp);
-            cl_mem tmp_output = NULL;
-            cl_mem linear_output = NULL;
-            if(tmp_input && linear_input)
+            cl_mem clin = dt_opencl_copy_host_to_device(pipe->devid, pipe->input, roi_in.width, roi_in.height, bpp);
+            cl_mem clout = dt_opencl_alloc_device(pipe->devid, roi_out->width, roi_out->height, bpp);
+            if(clin && clout)
             {
-              cl_int err = dt_opencl_write_host_to_device(pipe->devid, pipe->input, tmp_input, roi_in.width, roi_in.height, bpp);
-              if(err == CL_SUCCESS)
-              {
-                const float fgamma = 2.4f;
+              cl_int err = CL_SUCCESS;
+              if(gamma)
                 err = dt_opencl_enqueue_kernel_2d_args(pipe->devid, darktable.opencl->colorspaces->kernel_colorspaces_gamma, roi_in.width, roi_in.height,
-                        CLARG(tmp_input), CLARG(linear_input), CLARG(roi_in.width), CLARG(roi_in.height), CLARG(fgamma));
-                dt_opencl_release_mem_object(tmp_input);
-                tmp_input = NULL;
-              }
+                        CLARG(clin), CLARG(clin), CLARG(roi_in.width), CLARG(roi_in.height), CLARGFLOAT(2.4f));
               if(err == CL_SUCCESS)
-              {
-                linear_output = dt_opencl_alloc_device(pipe->devid, roi_out->width, roi_out->height, bpp);
-                if(!linear_output) err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
-                if(err == CL_SUCCESS)
-                  err = dt_iop_clip_and_zoom_cl(pipe->devid, linear_output, linear_input, roi_out, &roi_in);
-                dt_opencl_release_mem_object(linear_input);
-                linear_input = NULL;
-              }
+                err = dt_iop_clip_and_zoom_cl(pipe->devid, clout, clin, roi_out, &roi_in);
+
+              if(err == CL_SUCCESS && gamma)
+                err = dt_opencl_enqueue_kernel_2d_args(pipe->devid, darktable.opencl->colorspaces->kernel_colorspaces_gamma, roi_out->width, roi_out->height,
+                    CLARG(clout), CLARG(clout), CLARG(roi_out->width), CLARG(roi_out->height), CLARGFLOAT(0.41666666666666666667f));
+
               if(err == CL_SUCCESS)
-              {
-                tmp_output = dt_opencl_alloc_device(pipe->devid, roi_out->width, roi_out->height, bpp);
-                if(!tmp_output) err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
-                const float fgamma = 1.0f / 2.4f;
-                if(err == CL_SUCCESS)
-                  err = dt_opencl_enqueue_kernel_2d_args(pipe->devid, darktable.opencl->colorspaces->kernel_colorspaces_gamma, roi_out->width, roi_out->height,
-                    CLARG(linear_output), CLARG(tmp_output), CLARG(roi_out->width), CLARG(roi_out->height), CLARG(fgamma));
-              }
-              if(err == CL_SUCCESS)
-                err = dt_opencl_copy_device_to_host(pipe->devid, *output, tmp_output, roi_out->width, roi_out->height, bpp);
+                err = dt_opencl_copy_device_to_host(pipe->devid, *output, clout, roi_out->width, roi_out->height, bpp);
               if(err == CL_SUCCESS)
                 done = TRUE;
               else
                 dt_print(DT_DEBUG_PIPE | DT_DEBUG_OPENCL, "OpenCL pipe data: clip&zoom failed");
             }
-            dt_opencl_release_mem_object(tmp_input);
-            dt_opencl_release_mem_object(tmp_output);
-            dt_opencl_release_mem_object(linear_input);
-            dt_opencl_release_mem_object(linear_output);
+            dt_opencl_release_mem_object(clin);
+            dt_opencl_release_mem_object(clout);
           }
 
           if(!done)
@@ -2097,85 +2166,62 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
       const int cst_to = module->input_colorspace(module, pipe, piece);
       const int cst_out = module->output_colorspace(module, pipe, piece);
 
-      if(fits_on_device)
-      {
-        /* image is small enough -> try to directly process entire image with opencl */
-        /* input is not on gpu memory -> copy it there */
-        if(cl_mem_input == NULL)
-        {
-          cl_mem_input = dt_opencl_alloc_device(pipe->devid,
-                                                roi_in.width, roi_in.height, in_bpp);
-          if(cl_mem_input == NULL)
-          {
-            dt_print_pipe(DT_DEBUG_OPENCL | DT_DEBUG_PIPE,
-              "no input cl_mem",
-              pipe, module, pipe->devid, &roi_in, roi_out);
-            success_opencl = FALSE;
-          }
-
-          if(success_opencl)
-          {
-            if(dt_opencl_write_host_to_device(pipe->devid, input, cl_mem_input,
-                                              roi_in.width, roi_in.height, in_bpp) != CL_SUCCESS)
-            {
-              dt_print_pipe(DT_DEBUG_OPENCL,
-                            "process",
-                            pipe, module, pipe->devid, &roi_in, roi_out, "%s",
-                            "couldn't copy image to OpenCL device");
-              success_opencl = FALSE;
-            }
-          }
-        }
-
-        if(dt_pipe_shutdown(pipe))
-        {
-          dt_opencl_release_mem_object(cl_mem_input);
-          return TRUE;
-        }
-
-        /* try to allocate GPU memory for output */
-        if(success_opencl)
-        {
-          *cl_mem_output = dt_opencl_alloc_device(pipe->devid,
-                                                  roi_out->width, roi_out->height, bpp);
-          if(*cl_mem_output == NULL)
-          {
-            dt_print_pipe(DT_DEBUG_OPENCL | DT_DEBUG_PIPE,
-              "no output cl_mem",
-              pipe, module, pipe->devid, &roi_in, roi_out);
-            success_opencl = FALSE;
-          }
-        }
-
-        // indirectly give gpu some air to breathe (and to do display related stuff)
-        dt_opencl_micro_nap(pipe->devid);
-
-        // transform to input colorspace
-        if(success_opencl)
-        {
-          if(cst_from != cst_to)
-            dt_print_pipe(DT_DEBUG_PIPE,
-                          "transform colorspace",
+      if(cst_from != cst_to)
+        dt_print_pipe(DT_DEBUG_PIPE, "transform colorspace",
                           pipe, module, pipe->devid, &roi_in, NULL, "%s -> %s `%s'",
                           dt_iop_colorspace_to_name(cst_from),
                           dt_iop_colorspace_to_name(cst_to),
                           work_profile ? dt_colorspaces_get_name(work_profile->type, work_profile->filename) : "no work profile");
 
-          success_opencl = dt_ioppr_transform_image_colorspace_cl(module, pipe->devid,
+      gboolean didconvert = FALSE;
+      if(cl_mem_input != NULL || fits_on_device)
+      {
+        if(cl_mem_input == NULL)
+          cl_mem_input = dt_opencl_copy_host_to_device(pipe->devid, input, roi_in.width, roi_in.height, in_bpp);
+
+        if(cl_mem_input)
+        {
+          didconvert = success_opencl = dt_ioppr_transform_image_colorspace_cl(module, pipe->devid,
                                                                   cl_mem_input, cl_mem_input,
                                                                   roi_in.width, roi_in.height,
                                                                   input_cst_cl, cst_to, &input_cst_cl,
                                                                   work_profile);
         }
+        else
+        {
+          success_opencl = FALSE;
+        }
+      }
 
+      const gboolean want_bcache = _piece_fast_blend(piece, module);
+      const dt_hash_t phash = want_bcache
+            ? _piece_process_hash(piece, roi_out, module, pos)
+            : DT_INVALID_HASH;
+      const gboolean bcaching = want_bcache && pipe->bcache_data && phash == pipe->bcache_hash && phash != DT_INVALID_HASH;
+
+      dt_print_pipe(DT_DEBUG_PIPE,
+                        bcaching ? "from blend cache" : "process",
+                        pipe, module, pipe->devid, &roi_in, roi_out, "%s%s%s%s%s %.1fMB",
+                        dt_iop_colorspace_to_name(cst_to),
+                        cst_to != cst_out ? " -> " : "",
+                        cst_to != cst_out ? dt_iop_colorspace_to_name(cst_out) : "",
+                        fits_on_device ? "" : ", tiled",
+                        *cl_mem_output ? ", stale outimage" : "",
+                        1e-6 * (tiling.factor_cl * (m_width * m_height * m_bpp) + tiling.overhead));
+      if(*cl_mem_output)
+      {
+        dt_opencl_release_mem_object(*cl_mem_output);
+        *cl_mem_output = NULL;
+      }
+
+      if(fits_on_device)
+      {
         // histogram collection for module
         if(success_opencl
            && (dev->gui_attached
                || !(piece->request_histogram & DT_REQUEST_ONLY_IN_GUI))
            && (piece->request_histogram & DT_REQUEST_ON))
         {
-          // we abuse the empty output buffer on host for intermediate storage of data in
-          // histogram_collect_cl()
           const size_t outbufsize = bpp * roi_out->width * roi_out->height;
 
           _histogram_collect_cl(pipe->devid, piece, cl_mem_input,
@@ -2210,94 +2256,61 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
            meaningful messages in case of error */
         if(success_opencl)
         {
-          const gboolean relevant = _piece_fast_blend(piece, module);
-          const dt_hash_t phash = relevant
-            ? _piece_process_hash(piece, roi_out, module, pos)
-            : DT_INVALID_HASH;
-          const gboolean bcaching = relevant
-            ? pipe->bcache_data && phash == pipe->bcache_hash && phash != DT_INVALID_HASH
-            : FALSE;
-
-          dt_print_pipe(DT_DEBUG_PIPE,
-                        bcaching ? "from blend cache" : "process",
-                        pipe, module, pipe->devid, &roi_in, roi_out, "%s%s%s %.1fMB",
-                        dt_iop_colorspace_to_name(cst_to),
-                        cst_to != cst_out ? " -> " : "",
-                        cst_to != cst_out ? dt_iop_colorspace_to_name(cst_out) : "",
-                        1e-6 * (tiling.factor_cl * (m_width * m_height * m_bpp) + tiling.overhead));
-
-          // this code section is for simplistic benchmarking via --bench-module
-          if((pipe->type & (DT_DEV_PIXELPIPE_FULL | DT_DEV_PIXELPIPE_EXPORT))
-             && darktable.bench_module)
+          if(pipe->type & (DT_DEV_PIXELPIPE_FULL | DT_DEV_PIXELPIPE_EXPORT))
           {
-            if(dt_str_commasubstring(darktable.bench_module, module->op))
-            {
-              dt_times_t bench;
-              dt_times_t end;
-              const int old_muted = darktable.unmuted;
-              darktable.unmuted = 0;
-              const gboolean full = pipe->type & DT_DEV_PIXELPIPE_FULL;
-              const float mpix = (roi_out->width * roi_out->height) / 1.0e6;
-              const int counter = (pipe->type & DT_DEV_PIXELPIPE_FULL) ? 100 : 50;
-              gboolean success = TRUE;
-              dt_get_times(&bench);
-              for(int i = 0; i < counter && !dt_pipe_shutdown(pipe); i++)
-              {
-                if(success)
-                  success = module->process_cl(module, piece, cl_mem_input, *cl_mem_output,
-                                                &roi_in, roi_out) == CL_SUCCESS;
-              }
-              if(success)
-              {
-                dt_get_times(&end);
-                const float clock = (end.clock - bench.clock) / (float)counter;
-                dt_print(DT_DEBUG_ALWAYS,
-                         "[bench module %s GPU] `%s' takes %8.5fs,%7.2fmpix,%9.3fpix/us",
-                         full ? "full" : "export",
-                         module->op,
-                         clock, mpix, mpix/clock);
-              }
-              else
-                dt_print(DT_DEBUG_ALWAYS,
-                         "[bench module %s GPU] `%s' finished without success",
-                         full ? "full" : "export", module->op);
-              darktable.unmuted = old_muted;
-            }
-          }
-          const gboolean pfm_dump = darktable.dump_pfm_pipe
-            && (pipe->type & (DT_DEV_PIXELPIPE_FULL | DT_DEV_PIXELPIPE_EXPORT))
-            && dt_str_commasubstring(darktable.dump_pfm_pipe, module->op);
+            if(darktable.bench_module && dt_str_commasubstring(darktable.bench_module, module->op))
+              _opencl_benchmark(pipe, module, piece, cl_mem_input, roi_out, &roi_in, bpp);
 
-          if(pfm_dump)
-            dt_opencl_dump_pipe_pfm(module->op, pipe->devid, cl_mem_input,
-                                    TRUE, dt_dev_pixelpipe_type_to_str(pipe->type));
+            if(darktable.dump_pfm_pipe && dt_str_commasubstring(darktable.dump_pfm_pipe, module->op))
+              dt_opencl_dump_pipe_pfm(module->op, pipe->devid, cl_mem_input, TRUE, dt_dev_pixelpipe_type_to_str(pipe->type));
+          }
 
           cl_int err = CL_SUCCESS;
-
           if(bcaching)
           {
-            err = dt_opencl_write_host_to_device(pipe->devid, pipe->bcache_data,
-                                                 *cl_mem_output, roi_out->width,
-                                                 roi_out->height, out_bpp);
+            *cl_mem_output = dt_opencl_copy_host_to_device(pipe->devid, pipe->bcache_data, roi_out->width, roi_out->height, out_bpp);
+            if(*cl_mem_output == NULL)
+            {
+              // for some reason reading from bcache failed so let's clear/invalidate it now and leave the error condition
+              dt_free_align(pipe->bcache_data);
+              pipe->bcache_data = NULL;
+              pipe->bcache_hash = DT_INVALID_HASH;
+              err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
+            }
           }
           else
           {
-            err = module->process_cl(module, piece, cl_mem_input, *cl_mem_output,
-                                     &roi_in, roi_out);
-            if(relevant && (err == CL_SUCCESS))
+            *cl_mem_output = dt_opencl_alloc_device(pipe->devid, roi_out->width, roi_out->height, bpp);
+            if(*cl_mem_output)
+              err = module->process_cl(module, piece, cl_mem_input, *cl_mem_output, &roi_in, roi_out);
+            else
+              err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
+
+            if(want_bcache && (err == CL_SUCCESS))
             {
+              // processing was good
               if(pipe->mask_display == DT_DEV_PIXELPIPE_DISPLAY_NONE
                 && !dt_pipe_shutdown(pipe))
               {
                 float *cache = _get_fast_blendcache(out_bpp * roi_out->width * roi_out->height / sizeof(float), phash, pipe);
                 if(cache)
+                {
                   err = dt_opencl_copy_device_to_host(pipe->devid, cache, *cl_mem_output,
                                                         roi_out->width, roi_out->height, out_bpp);
+                  if(err != CL_SUCCESS)
+                  {
+                    // for some reason writing to bcache failed so let's clear/invalidate it now and leave the error condition
+                    dt_free_align(cache);
+                    pipe->bcache_data = NULL;
+                    pipe->bcache_hash = DT_INVALID_HASH;
+                  }
+                }
               }
               else
                 pipe->bcache_hash = DT_INVALID_HASH;
             }
           }
+
           success_opencl = (err == CL_SUCCESS);
 
           if(!success_opencl)
@@ -2307,63 +2320,14 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
                           "device=%i (%s), %s",
                           pipe->devid, darktable.opencl->dev[pipe->devid].cname,
                           cl_errstr(err));
-
-          if(success_opencl)
+          else if(pipe->type & (DT_DEV_PIXELPIPE_FULL | DT_DEV_PIXELPIPE_EXPORT))
           {
-            if(pfm_dump && !dt_pipe_shutdown(pipe))
+            if(darktable.dump_pfm_pipe && !dt_pipe_shutdown(pipe))
               dt_opencl_dump_pipe_pfm(module->op, pipe->devid, *cl_mem_output,
                                     FALSE, dt_dev_pixelpipe_type_to_str(pipe->type));
 
-            if(pipe->type & (DT_DEV_PIXELPIPE_FULL | DT_DEV_PIXELPIPE_EXPORT)
-                && darktable.dump_diff_pipe
-                && !dt_pipe_shutdown(pipe))
-            {
-              const int ch = dt_opencl_get_image_element_size(cl_mem_input);
-              const int cho = dt_opencl_get_image_element_size(*cl_mem_output) / sizeof(float);
-              if((ch == 4 || ch == 16 || ch == 2) // input supports 1/4 channel floats and 1ch uint16
-                  && (cho == 1 || cho == 4)       // output for 1/4 channel floats
-                  && (dt_str_commasubstring(darktable.dump_diff_pipe, module->op)
-                      || dt_str_commasubstring(darktable.dump_diff_pipe, "complete")))
-              {
-                const int ow = roi_out->width;
-                const int oh = roi_out->height;
-                const int iw = roi_in.width;
-                const int ih = roi_in.height;
-                float *clindata = dt_alloc_aligned((size_t)iw * ih * ch);
-                float *cloutdata = dt_alloc_align_float((size_t)ow * oh * cho);
-                float *cpudata = dt_alloc_align_float((size_t)ow * oh * cho);
-                if(clindata && cloutdata && cpudata)
-                {
-                  cl_int terr = dt_opencl_copy_device_to_host(pipe->devid,
-                                                              cloutdata, *cl_mem_output,
-                                                              ow, oh, cho * sizeof(float));
-                  if(terr == CL_SUCCESS)
-                  {
-                    terr = dt_opencl_copy_device_to_host(pipe->devid,
-                                                         clindata, cl_mem_input, iw, ih, ch);
-                    if(terr == CL_SUCCESS)
-                    {
-                      module->process(module, piece, clindata, cpudata, &roi_in, roi_out);
-                      if(cst_out == IOP_CS_LAB)
-                      {
-                        for(size_t k = 0; k < (size_t)ow * oh * 4; k+=4)
-                        {
-                          dt_aligned_pixel_t XYZ;
-                          dt_Lab_to_XYZ(cpudata + k, XYZ);
-                          dt_XYZ_to_linearRGB(XYZ, cpudata + k);
-                          dt_Lab_to_XYZ(cloutdata + k, XYZ);
-                          dt_XYZ_to_linearRGB(XYZ, cloutdata + k);
-                        }
-                      }
-                      dt_dump_pipe_diff_pfm(module->op, cloutdata, cpudata, ow, oh, cho,
-                                            dt_dev_pixelpipe_type_to_str(pipe->type));                  }
-                  }
-                }
-                dt_free_align(cpudata);
-                dt_free_align(cloutdata);
-                dt_free_align(clindata);
-              }
-            }
+            if(darktable.dump_diff_pipe && !dt_pipe_shutdown(pipe))
+              _opencl_dump_diff_pipe_pfm(pipe, module, piece, cl_mem_input, *cl_mem_output, roi_out, &roi_in, cst_out);
           }
 
           pixelpipe_flow |= (PIXELPIPE_FLOW_PROCESSED_ON_GPU);
@@ -2498,18 +2462,9 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
         if(dt_pipe_shutdown(pipe))
            return TRUE;
 
-        // indirectly give gpu some air to breathe (and to do display related stuff)
-        dt_opencl_micro_nap(pipe->devid);
-
-        // transform to module input colorspace
-        if(success_opencl)
+        // transform to module input colorspace if not done already
+        if(success_opencl && !didconvert)
         {
-          if(cst_from != cst_to)
-            dt_print_pipe(DT_DEBUG_PIPE,
-                          "transform colorspace",
-                          pipe, module, pipe->devid, &roi_in, NULL, "%s -> %s",
-                          dt_iop_colorspace_to_name(cst_from),
-                          dt_iop_colorspace_to_name(cst_to));
           dt_ioppr_transform_image_colorspace(module, input, input,
                                               roi_in.width, roi_in.height,
                                               input_format->cst, cst_to, &input_format->cst,
@@ -2533,21 +2488,6 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
            meaningful messages in case of error */
         if(success_opencl)
         {
-          const gboolean relevant = _piece_fast_blend(piece, module);
-          const dt_hash_t phash = relevant
-            ? _piece_process_hash(piece, roi_out, module, pos)
-            : DT_INVALID_HASH;
-          const gboolean bcaching = relevant
-            ? pipe->bcache_data && phash == pipe->bcache_hash && phash != DT_INVALID_HASH
-            : FALSE;
-
-          dt_print_pipe(DT_DEBUG_PIPE,
-                        bcaching ? "from blend cache tile" : "process tiles",
-                        pipe, module, pipe->devid, &roi_in, roi_out, "%s%s%s",
-                        dt_iop_colorspace_to_name(cst_to),
-                        cst_to != cst_out ? " -> " : "",
-                        cst_to != cst_out ? dt_iop_colorspace_to_name(cst_out) : "");
-
           cl_int err = CL_SUCCESS;
 
           const size_t nfloats = out_bpp * roi_out->width * roi_out->height / sizeof(float);
@@ -2559,7 +2499,7 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
           {
             err = module->process_tiling_cl(module, piece, input,
                                             *output, &roi_in, roi_out, in_bpp);
-            if(relevant && (err == CL_SUCCESS))
+            if(want_bcache && (err == CL_SUCCESS))
             {
               if(pipe->mask_display == DT_DEV_PIXELPIPE_DISPLAY_NONE
                 && !dt_pipe_shutdown(pipe))
@@ -2938,10 +2878,10 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
                                     roi_out->width, roi_out->height, bpp);
 #endif
 
-    int ch = (*out_format)->channels;
+    const int ch = (*out_format)->channels;
     if((*out_format)->datatype == TYPE_FLOAT && (ch == 1 || ch == 4))
     {
-      int m = ch - 1;
+      const int m = ch - 1;
 
       gboolean hasinf = FALSE, hasnan = FALSE;
       dt_aligned_pixel_t min = { FLT_MAX, FLT_MAX, FLT_MAX };

--- a/src/develop/tiling.c
+++ b/src/develop/tiling.c
@@ -1467,7 +1467,7 @@ static int _default_process_tiling_cl_ptp(dt_iop_module_t *self,
   if(use_pinned_memory)
   {
 
-    input_buffer = dt_opencl_map_buffer(devid, pinned_input, CL_TRUE, CL_MAP_WRITE, 0,
+    input_buffer = dt_opencl_map_buffer(devid, pinned_input, TRUE, CL_MAP_WRITE, 0,
                                         (size_t)width * height * in_bpp);
     if(input_buffer == NULL)
     {
@@ -1497,7 +1497,7 @@ static int _default_process_tiling_cl_ptp(dt_iop_module_t *self,
   if(use_pinned_memory)
   {
 
-    output_buffer = dt_opencl_map_buffer(devid, pinned_output, CL_TRUE, CL_MAP_READ, 0,
+    output_buffer = dt_opencl_map_buffer(devid, pinned_output, TRUE, CL_MAP_READ, 0,
                                          (size_t)width * height * out_bpp);
     if(output_buffer == NULL)
     {
@@ -1523,8 +1523,8 @@ static int _default_process_tiling_cl_ptp(dt_iop_module_t *self,
       if((wd <= 2 * overlap && tx > 0) || (ht <= 2 * overlap && ty > 0)) continue;
 
       /* origin and region of effective part of tile, which we want to store later */
-      size_t origin[] = { 0, 0, 0 };
-      size_t region[] = { wd, ht, 1 };
+      size_t origin[2] = { 0, 0 };
+      size_t region[2] = { wd, ht };
 
       /* roi_in and roi_out for process_cl on subbuffer */
       dt_iop_roi_t iroi = { roi_in->x + tx * tile_wd, roi_in->y + ty * tile_ht, wd, ht, roi_in->scale };
@@ -1567,14 +1567,13 @@ static int _default_process_tiling_cl_ptp(dt_iop_module_t *self,
 
         /* blocking memory transfer: pinned host input buffer -> opencl/device tile */
         err = dt_opencl_write_host_to_device_raw(devid, (char *)input_buffer, input, origin, region,
-                                                 wd * in_bpp, CL_TRUE);
+                                                 wd * in_bpp, TRUE);
         if(err != CL_SUCCESS) use_pinned_memory = FALSE;
       }
       else
       {
         /* blocking direct memory transfer: host input image -> opencl/device tile */
-        err = dt_opencl_write_host_to_device_raw(devid, (char *)ivoid + ioffs, input, origin, region, ipitch,
-                                                 CL_TRUE);
+        err = dt_opencl_write_host_to_device_raw(devid, (char *)ivoid + ioffs, input, origin, region, ipitch, TRUE);
       }
       if(err != CL_SUCCESS) goto error;
 
@@ -1602,7 +1601,7 @@ static int _default_process_tiling_cl_ptp(dt_iop_module_t *self,
       {
         /* blocking memory transfer: complete opencl/device tile -> pinned host output buffer */
         err = dt_opencl_read_host_from_device_raw(devid, (char *)output_buffer, output, origin, region,
-                                                  wd * out_bpp, CL_TRUE);
+                                                  wd * out_bpp, TRUE);
         if(err != CL_SUCCESS)
         {
           use_pinned_memory = FALSE;
@@ -1638,7 +1637,7 @@ static int _default_process_tiling_cl_ptp(dt_iop_module_t *self,
       {
         /* blocking direct memory transfer: good part of opencl/device tile -> host output image */
         err = dt_opencl_read_host_from_device_raw(devid, (char *)ovoid + ooffs, output, origin, region,
-                                                  opitch, CL_TRUE);
+                                                  opitch, TRUE);
         if(err != CL_SUCCESS) goto error;
       }
 
@@ -1852,7 +1851,7 @@ static int _default_process_tiling_cl_roi(dt_iop_module_t *self,
   if(use_pinned_memory)
   {
 
-    input_buffer = dt_opencl_map_buffer(devid, pinned_input, CL_TRUE, CL_MAP_WRITE, 0,
+    input_buffer = dt_opencl_map_buffer(devid, pinned_input, TRUE, CL_MAP_WRITE, 0,
                                         (size_t)width * height * in_bpp);
     if(input_buffer == NULL)
     {
@@ -1881,7 +1880,7 @@ static int _default_process_tiling_cl_roi(dt_iop_module_t *self,
   if(use_pinned_memory)
   {
 
-    output_buffer = dt_opencl_map_buffer(devid, pinned_output, CL_TRUE, CL_MAP_READ, 0,
+    output_buffer = dt_opencl_map_buffer(devid, pinned_output, TRUE, CL_MAP_READ, 0,
                                          (size_t)width * height * out_bpp);
     if(output_buffer == NULL)
     {
@@ -1992,16 +1991,16 @@ static int _default_process_tiling_cl_roi(dt_iop_module_t *self,
       const size_t ooffs = (size_t)(out_dy * opitch) + (size_t)(out_dx * out_bpp);
 
       /* origin and region of full input tile */
-      size_t iorigin[] = { 0, 0, 0 };
-      size_t iregion[] = { iroi_full.width, iroi_full.height, 1 };
+      size_t iorigin[2] = { 0, 0 };
+      size_t iregion[2] = { iroi_full.width, iroi_full.height };
 
       /* origin and region of full output tile */
-      size_t oforigin[] = { 0, 0, 0 };
-      size_t ofregion[] = { oroi_full.width, oroi_full.height, 1 };
+      size_t oforigin[2] = { 0, 0 };
+      size_t ofregion[2] = { oroi_full.width, oroi_full.height };
 
       /* origin and region of good part of output tile */
-      size_t oorigin[] = { oroi_good.x - oroi_full.x, oroi_good.y - oroi_full.y, 0 };
-      size_t oregion[] = { oroi_good.width, oroi_good.height, 1 };
+      size_t oorigin[2] = { oroi_good.x - oroi_full.x, oroi_good.y - oroi_full.y };
+      size_t oregion[2] = { oroi_good.width, oroi_good.height };
 
       dt_print(DT_DEBUG_TILING,
                "[default_process_tiling_cl_roi] [%s] process tile (%zu,%zu) size %dx%d at origin [%d,%d]",
@@ -2046,14 +2045,14 @@ static int _default_process_tiling_cl_roi(dt_iop_module_t *self,
 
         /* blocking memory transfer: pinned host input buffer -> opencl/device tile */
         err = dt_opencl_write_host_to_device_raw(devid, (char *)input_buffer, input, iorigin, iregion,
-                                                 (size_t)iroi_full.width * in_bpp, CL_TRUE);
+                                                 (size_t)iroi_full.width * in_bpp, TRUE);
         if(err != CL_SUCCESS) use_pinned_memory = FALSE;
       }
       else
       {
         /* blocking direct memory transfer: host input image -> opencl/device tile */
         err = dt_opencl_write_host_to_device_raw(devid, (char *)ivoid + ioffs, input, iorigin, iregion,
-                                                 ipitch, CL_TRUE);
+                                                 ipitch, TRUE);
       }
       if(err != CL_SUCCESS) goto error;
 
@@ -2083,7 +2082,7 @@ static int _default_process_tiling_cl_roi(dt_iop_module_t *self,
       {
         /* blocking memory transfer: complete opencl/device tile -> pinned host output buffer */
         err = dt_opencl_read_host_from_device_raw(devid, (char *)output_buffer, output, oforigin, ofregion,
-                                                  (size_t)oroi_full.width * out_bpp, CL_TRUE);
+                                                  (size_t)oroi_full.width * out_bpp, TRUE);
         if(err != CL_SUCCESS)
         {
           use_pinned_memory = FALSE;
@@ -2100,7 +2099,7 @@ static int _default_process_tiling_cl_roi(dt_iop_module_t *self,
       {
         /* blocking direct memory transfer: good part of opencl/device tile -> host output image */
         err = dt_opencl_read_host_from_device_raw(devid, (char *)ovoid + ooffs, output, oorigin, oregion,
-                                                  opitch, CL_TRUE);
+                                                  opitch, TRUE);
         if(err != CL_SUCCESS) goto error;
       }
 

--- a/src/develop/tiling.c
+++ b/src/develop/tiling.c
@@ -1325,6 +1325,9 @@ static int _default_process_tiling_cl_ptp(dt_iop_module_t *self,
   cl_int err = CL_SUCCESS; // we take care for errors below
   cl_mem input = NULL;
   cl_mem output = NULL;
+  size_t cltile_w = 0;
+  size_t cltile_h = 0;
+
   cl_mem pinned_input = NULL;
   cl_mem pinned_output = NULL;
   void *input_buffer = NULL;
@@ -1539,17 +1542,24 @@ static int _default_process_tiling_cl_ptp(dt_iop_module_t *self,
                wd, ht, tx * tile_wd, ty * tile_ht);
 
       /* get input and output buffers */
-      input = dt_opencl_alloc_device(devid, wd, ht, in_bpp);
-      output = dt_opencl_alloc_device(devid, wd, ht, out_bpp);
-      if(output == NULL || input == NULL)
+      if(cltile_w != wd || cltile_h != ht)
       {
-        err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
-        goto error;
+        dt_opencl_release_mem_object(input);
+        dt_opencl_release_mem_object(output);
+        input = dt_opencl_alloc_device(devid, wd, ht, in_bpp);
+        output = dt_opencl_alloc_device(devid, wd, ht, out_bpp);
+        if(output == NULL || input == NULL)
+        {
+          err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
+          goto error;
+        }
+        cltile_w = wd;
+        cltile_h = ht;
       }
 
       if(use_pinned_memory)
       {
-/* prepare pinned input tile buffer: copy part of input image */
+        /* prepare pinned input tile buffer: copy part of input image */
         DT_OMP_FOR()
         for(size_t j = 0; j < ht; j++)
           memcpy((char *)input_buffer + j * wd * in_bpp, (char *)ivoid + ioffs + j * ipitch,
@@ -1558,19 +1568,15 @@ static int _default_process_tiling_cl_ptp(dt_iop_module_t *self,
         /* blocking memory transfer: pinned host input buffer -> opencl/device tile */
         err = dt_opencl_write_host_to_device_raw(devid, (char *)input_buffer, input, origin, region,
                                                  wd * in_bpp, CL_TRUE);
-        if(err != CL_SUCCESS)
-        {
-          use_pinned_memory = FALSE;
-          goto error;
-        }
+        if(err != CL_SUCCESS) use_pinned_memory = FALSE;
       }
       else
       {
         /* blocking direct memory transfer: host input image -> opencl/device tile */
         err = dt_opencl_write_host_to_device_raw(devid, (char *)ivoid + ioffs, input, origin, region, ipitch,
                                                  CL_TRUE);
-        if(err != CL_SUCCESS) goto error;
       }
+      if(err != CL_SUCCESS) goto error;
 
       /* take original processed_maximum as starting point */
       for(int k = 0; k < 4; k++) piece->pipe->dsc.processed_maximum[k] = processed_maximum_saved[k];
@@ -1621,8 +1627,8 @@ static int _default_process_tiling_cl_ptp(dt_iop_module_t *self,
 
       if(use_pinned_memory)
       {
-/* copy "good" part of tile from pinned output buffer to output image */
-//        DT_OMP_FOR(shared(origin, region))
+        /* copy "good" part of tile from pinned output buffer to output image */
+        //        DT_OMP_FOR(shared(origin, region))
         for(size_t j = 0; j < region[1]; j++)
           memcpy((char *)ovoid + ooffs + j * opitch,
                  (char *)output_buffer + ((j + origin[1]) * wd + origin[0]) * out_bpp,
@@ -1635,12 +1641,6 @@ static int _default_process_tiling_cl_ptp(dt_iop_module_t *self,
                                                   opitch, CL_TRUE);
         if(err != CL_SUCCESS) goto error;
       }
-
-      /* release input and output buffers */
-      dt_opencl_release_mem_object(input);
-      input = NULL;
-      dt_opencl_release_mem_object(output);
-      output = NULL;
 
       /* block until opencl queue has finished to free all used event handlers */
       dt_opencl_finish_sync_pipe(devid, piece->pipe->type);
@@ -1693,6 +1693,10 @@ static int _default_process_tiling_cl_roi(dt_iop_module_t *self,
   cl_int err = CL_SUCCESS; // we take care for errors below
   cl_mem input = NULL;
   cl_mem output = NULL;
+  size_t cltile_ow = 0;
+  size_t cltile_oh = 0;
+  size_t cltile_iw = 0;
+  size_t cltile_ih = 0;
   cl_mem pinned_input = NULL;
   cl_mem pinned_output = NULL;
   void *input_buffer = NULL;
@@ -2010,8 +2014,22 @@ static int _default_process_tiling_cl_roi(dt_iop_module_t *self,
                out_dx, out_dy, delta);
 
       /* get opencl input and output buffers */
-      input = dt_opencl_alloc_device(devid, iroi_full.width, iroi_full.height, in_bpp);
-      output = dt_opencl_alloc_device(devid, oroi_full.width, oroi_full.height, out_bpp);
+      if(cltile_iw != iroi_full.width || cltile_ih != iroi_full.height)
+      {
+        dt_opencl_release_mem_object(input);
+        input = dt_opencl_alloc_device(devid, iroi_full.width, iroi_full.height, in_bpp);
+        cltile_iw = iroi_full.width;
+        cltile_ih = iroi_full.height;
+      }
+
+      if(cltile_ow != oroi_full.width || cltile_oh != oroi_full.height)
+      {
+        dt_opencl_release_mem_object(output);
+        output = dt_opencl_alloc_device(devid, oroi_full.width, oroi_full.height, out_bpp);
+        cltile_ow = oroi_full.width;
+        cltile_oh = oroi_full.height;
+      }
+
       if(output == NULL || input == NULL)
       {
         err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
@@ -2020,7 +2038,7 @@ static int _default_process_tiling_cl_roi(dt_iop_module_t *self,
 
       if(use_pinned_memory)
       {
-/* prepare pinned input tile buffer: copy part of input image */
+        /* prepare pinned input tile buffer: copy part of input image */
         DT_OMP_FOR(shared(iroi_full))
         for(size_t j = 0; j < iroi_full.height; j++)
           memcpy((char *)input_buffer + j * iroi_full.width * in_bpp, (char *)ivoid + ioffs + j * ipitch,
@@ -2029,19 +2047,15 @@ static int _default_process_tiling_cl_roi(dt_iop_module_t *self,
         /* blocking memory transfer: pinned host input buffer -> opencl/device tile */
         err = dt_opencl_write_host_to_device_raw(devid, (char *)input_buffer, input, iorigin, iregion,
                                                  (size_t)iroi_full.width * in_bpp, CL_TRUE);
-        if(err != CL_SUCCESS)
-        {
-          use_pinned_memory = FALSE;
-          goto error;
-        }
+        if(err != CL_SUCCESS) use_pinned_memory = FALSE;
       }
       else
       {
         /* blocking direct memory transfer: host input image -> opencl/device tile */
         err = dt_opencl_write_host_to_device_raw(devid, (char *)ivoid + ioffs, input, iorigin, iregion,
                                                  ipitch, CL_TRUE);
-        if(err != CL_SUCCESS) goto error;
       }
+      if(err != CL_SUCCESS) goto error;
 
       /* take original processed_maximum as starting point */
       for(int k = 0; k < 4; k++) piece->pipe->dsc.processed_maximum[k] = processed_maximum_saved[k];
@@ -2075,7 +2089,7 @@ static int _default_process_tiling_cl_roi(dt_iop_module_t *self,
           use_pinned_memory = FALSE;
           goto error;
         }
-/* copy "good" part of tile from pinned output buffer to output image */
+        /* copy "good" part of tile from pinned output buffer to output image */
         DT_OMP_FOR(shared(oroi_full, oorigin, oregion))
         for(size_t j = 0; j < oregion[1]; j++)
           memcpy((char *)ovoid + ooffs + j * opitch,
@@ -2089,12 +2103,6 @@ static int _default_process_tiling_cl_roi(dt_iop_module_t *self,
                                                   opitch, CL_TRUE);
         if(err != CL_SUCCESS) goto error;
       }
-
-      /* release input and output buffers */
-      dt_opencl_release_mem_object(input);
-      input = NULL;
-      dt_opencl_release_mem_object(output);
-      output = NULL;
 
       /* block until opencl queue has finished to free all used event handlers */
       dt_opencl_finish_sync_pipe(devid, piece->pipe->type);

--- a/src/iop/colorreconstruction.c
+++ b/src/iop/colorreconstruction.c
@@ -820,7 +820,7 @@ static dt_iop_colorreconstruct_bilateral_frozen_t *dt_iop_colorreconstruct_bilat
   {
     // read bilateral grid from device memory to host buffer (blocking)
     cl_int err = dt_opencl_read_buffer_from_device(b->devid, bf->buf, b->dev_grid, 0,
-                                    sizeof(dt_iop_colorreconstruct_Lab_t) * b->size_x * b->size_y * b->size_z, CL_TRUE);
+                                    sizeof(dt_iop_colorreconstruct_Lab_t) * b->size_x * b->size_y * b->size_z, TRUE);
     if(err != CL_SUCCESS)
     {
       dt_print(DT_DEBUG_OPENCL,
@@ -916,7 +916,7 @@ static dt_iop_colorreconstruct_bilateral_cl_t *dt_iop_colorreconstruct_bilateral
   {
     // write bilateral grid from host buffer to device memory (blocking)
     cl_int err = dt_opencl_write_buffer_to_device(b->devid, bf->buf, b->dev_grid, 0,
-                                    bf->size_x * bf->size_y * bf->size_z * sizeof(dt_iop_colorreconstruct_Lab_t), CL_TRUE);
+                                    bf->size_x * bf->size_y * bf->size_z * sizeof(dt_iop_colorreconstruct_Lab_t), TRUE);
     if(err != CL_SUCCESS)
     {
       dt_print(DT_DEBUG_OPENCL,

--- a/src/iop/demosaicing/basics.c
+++ b/src/iop/demosaicing/basics.c
@@ -411,7 +411,7 @@ static int green_equilibration_cl(const dt_iop_module_t *self,
     }
 
     err = dt_opencl_read_buffer_from_device(devid, (void *)sumsum, dev_r, 0,
-                                            sizeof(float) * 2 * reducesize, CL_TRUE);
+                                            sizeof(float) * 2 * reducesize, TRUE);
     if(err != CL_SUCCESS) goto error;
 
     double sum1 = 0.0;

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -2435,7 +2435,7 @@ static int process_wavelets_cl(dt_iop_module_t *self,
     if(err != CL_SUCCESS) goto error;
 
     err = dt_opencl_read_buffer_from_device(devid, (void *)sumsum, dev_r, 0,
-                                            sizeof(float) * 4 * reducesize, CL_TRUE);
+                                            sizeof(float) * 4 * reducesize, TRUE);
     if(err != CL_SUCCESS) goto error;
 
     for(int k = 0; k < reducesize; k++)

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -2433,7 +2433,7 @@ int process_cl(dt_iop_module_t *self,
 
   uint32_t is_clipped = 0;
   clipped = dt_opencl_alloc_device_buffer(devid, sizeof(uint32_t));
-  err = dt_opencl_write_buffer_to_device(devid, &is_clipped, clipped, 0, sizeof(uint16_t), CL_TRUE);
+  err = dt_opencl_write_buffer_to_device(devid, &is_clipped, clipped, 0, sizeof(uint16_t), TRUE);
   if(err != CL_SUCCESS) goto error;
 
   // build a mask of clipped pixels
@@ -2444,7 +2444,7 @@ int process_cl(dt_iop_module_t *self,
   if(err != CL_SUCCESS) goto error;
 
   // check for clipped pixels
-  err = dt_opencl_read_buffer_from_device(devid, &is_clipped, clipped, 0, sizeof(uint32_t), CL_TRUE);
+  err = dt_opencl_read_buffer_from_device(devid, &is_clipped, clipped, 0, sizeof(uint32_t), TRUE);
   if(err != CL_SUCCESS) goto error;
   dt_opencl_release_mem_object(clipped);
   clipped = NULL;

--- a/src/iop/globaltonemap.c
+++ b/src/iop/globaltonemap.c
@@ -435,7 +435,7 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
         goto finally;
       }
       err = dt_opencl_read_buffer_from_device(devid, (void *)maximum, dev_r, 0,
-                                            sizeof(float) * reducesize, CL_TRUE);
+                                            sizeof(float) * reducesize, TRUE);
       if(err != CL_SUCCESS) goto finally;
 
       dt_opencl_release_mem_object(dev_r);

--- a/src/iop/hlreconstruct/opposed.c
+++ b/src/iop/hlreconstruct/opposed.c
@@ -516,7 +516,7 @@ static cl_int process_opposed_cl(dt_iop_module_t *self,
             CLARG(filters), CLARG(dev_xtrans), CLARG(dev_clips), CLARG(dev_correction));
     if(err != CL_SUCCESS) goto error;
 
-    err = dt_opencl_read_buffer_from_device(devid, claccu, dev_accu, 0, accusize, CL_TRUE);
+    err = dt_opencl_read_buffer_from_device(devid, claccu, dev_accu, 0, accusize, TRUE);
     if(err != CL_SUCCESS) goto error;
 
     // collect row data and accumulate

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -1386,7 +1386,7 @@ static int _process_cl_lf(dt_iop_module_t *self,
 
       err = dt_opencl_write_buffer_to_device(devid, tmpbuf,
                                              dev_tmpbuf, 0,
-                                             tmpbufsize, CL_TRUE);
+                                             tmpbufsize, TRUE);
       if(err != CL_SUCCESS) goto error;
 
       err = dt_opencl_enqueue_kernel_2d_args(devid, ldkernel, owidth, oheight,
@@ -1421,7 +1421,7 @@ static int _process_cl_lf(dt_iop_module_t *self,
 
       const size_t bsize =
         (size_t)ch * roi_out->width * roi_out->height * sizeof(float);
-      err = dt_opencl_write_buffer_to_device(devid, tmpbuf, dev_tmpbuf, 0, bsize, CL_TRUE);
+      err = dt_opencl_write_buffer_to_device(devid, tmpbuf, dev_tmpbuf, 0, bsize, TRUE);
       if(err != CL_SUCCESS) goto error;
 
       err = dt_opencl_enqueue_kernel_2d_args
@@ -1463,7 +1463,7 @@ static int _process_cl_lf(dt_iop_module_t *self,
       const size_t bsize =
         (size_t)ch * roi_in->width * roi_in->height * sizeof(float);
       err = dt_opencl_write_buffer_to_device(devid, tmpbuf,
-                                             dev_tmpbuf, 0, bsize, CL_TRUE);
+                                             dev_tmpbuf, 0, bsize, TRUE);
       if(err != CL_SUCCESS) goto error;
 
       err = dt_opencl_enqueue_kernel_2d_args
@@ -1497,7 +1497,7 @@ static int _process_cl_lf(dt_iop_module_t *self,
 
       err = dt_opencl_write_buffer_to_device(devid, tmpbuf,
                                              dev_tmpbuf, 0,
-                                             tmpbufsize, CL_TRUE);
+                                             tmpbufsize, TRUE);
       if(err != CL_SUCCESS) goto error;
 
       err = dt_opencl_enqueue_kernel_2d_args

--- a/src/iop/overlay.c
+++ b/src/iop/overlay.c
@@ -706,7 +706,7 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece,
   cl_mem dev_overlay = dt_opencl_alloc_device_buffer(devid, overlay_size);
   if(!dev_overlay) goto cleanup;
 
-  err = dt_opencl_write_buffer_to_device(devid, image, dev_overlay, 0, overlay_size, CL_TRUE);
+  err = dt_opencl_write_buffer_to_device(devid, image, dev_overlay, 0, overlay_size, TRUE);
   if(err != CL_SUCCESS) goto cleanup;
 
   const float opacity = data->opacity / 100.0f;

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -3930,8 +3930,7 @@ cl_int rt_process_stats_cl(dt_iop_module_t *self,
 
   err = dt_opencl_read_buffer_from_device(devid,
                                           (void *)src_buffer, dev_img, 0,
-                                          (size_t)width * height * ch * sizeof(float),
-                                          CL_TRUE);
+                                          (size_t)width * height * ch * sizeof(float), TRUE);
   if(err != CL_SUCCESS)
     goto cleanup;
 
@@ -3939,8 +3938,7 @@ cl_int rt_process_stats_cl(dt_iop_module_t *self,
   rt_process_stats(self, piece, src_buffer, width, height, ch, levels);
 
   err = dt_opencl_write_buffer_to_device(devid, src_buffer, dev_img, 0,
-                                         sizeof(float) * ch * width * height,
-                                         CL_TRUE);
+                                         sizeof(float) * ch * width * height, TRUE);
 cleanup:
   dt_free_align(src_buffer);
 
@@ -3968,8 +3966,7 @@ cl_int rt_adjust_levels_cl(dt_iop_module_t *self,
   }
 
   err = dt_opencl_read_buffer_from_device(devid, (void *)src_buffer, dev_img, 0,
-                                          (size_t)width * height * ch * sizeof(float),
-                                          CL_TRUE);
+                                          (size_t)width * height * ch * sizeof(float), TRUE);
   if(err != CL_SUCCESS)
     goto cleanup;
 
@@ -3977,8 +3974,7 @@ cl_int rt_adjust_levels_cl(dt_iop_module_t *self,
   rt_adjust_levels(self, piece, src_buffer, width, height, ch, levels);
 
   err = dt_opencl_write_buffer_to_device(devid, src_buffer, dev_img, 0,
-                                         sizeof(float) * ch * width * height,
-                                         CL_TRUE);
+                                         sizeof(float) * ch * width * height, TRUE);
 
 cleanup:
   dt_free_align(src_buffer);
@@ -4045,7 +4041,7 @@ static cl_int rt_build_scaled_mask_cl(const int devid,
     goto cleanup;
 
   err = dt_opencl_write_buffer_to_device(devid, *mask_scaled, dev_mask_scaled, 0,
-          sizeof(float) * roi_mask_scaled->width * roi_mask_scaled->height, CL_TRUE);
+          sizeof(float) * roi_mask_scaled->width * roi_mask_scaled->height, TRUE);
   if(err != CL_SUCCESS)
     goto cleanup;
 


### PR DESCRIPTION
**Some OpenCL pixelpipe performance gains**

1. OpenCL inplace colorspace conversions are much faster now.
   As the converting kernels read/write strictly pixelwise in safe locations we are safe with OpenCL 1.2 ro read/write to same image and
    - can use the faster Areadpixel variants
    - don't require an intermediate image2d_t and do a backcopy.
2. pixelpipe OpenCL code got some improvements while initializing image2d_t by reading from host instead of alloc & read later
3. Fixed and improved initial non-raw image OpenCL gamma corrected scaling. (we did gamma corrected scaling even when not necessary)
4. Fixed a corner case where profile_lut_cl data was not initialized to zero.
5. Some refactoring of pixelpipe OpenCL section for readability of pixelpipe.

_________________________________________________________________
**Avoid reallocation of cl_mem images in OpenCL tiling**

It's not a large overhead but allocating/releasing two cl_mem images per tile is an avoidable overhead if current tile size matches last processed tile, (significant when heavy tiling in ptp code).
__________________________________________________________________
**Some OpenCL maintenance**

1. `dt_opencl_read_host_from_device_raw()` and `dt_opencl_write_host_to_device_raw()` both expand origin and area to the 3dim size_t array internally and accept CLIMG_ORIGIN
2. All functions using a blocking flag have that defined as a gboolean, callers use TRUE/FALSE and the translation to CL_TRUE/CL_FALSE happens internally.
____________________________________________________________________

@TurboGit no regressions found while fixing a few bugs and increasing performance.