### PR TITLE
[AI] Unify ORT install + detection across Linux and Windows

### DIFF
--- a/src/ai/backend_onnx.c
+++ b/src/ai/backend_onnx.c
@@ -552,7 +552,7 @@ int dt_ai_ort_probe_library_full(const char *path, char **out_version, char **ou
   return TRUE;
 }
 
-// find libonnxruntime.so.* recursively, skip auditwheel *.libs/ peers
+// find the ORT runtime library recursively, skipping *.libs/ peers
 static gchar *_scan_for_ort_lib(const char *root)
 {
   GDir *d = g_dir_open(root, 0, NULL);
@@ -567,7 +567,11 @@ static gchar *_scan_for_ort_lib(const char *root)
       if(!g_str_has_suffix(name, ".libs"))
         result = _scan_for_ort_lib(p);
     }
+#ifdef _WIN32
+    else if(g_strcmp0(name, "onnxruntime.dll") == 0)
+#else
     else if(g_str_has_prefix(name, "libonnxruntime.so."))
+#endif
     {
       result = g_strdup(p);
     }
@@ -618,33 +622,11 @@ GList *dt_ai_ort_find_libraries(void)
     if(g_file_test(dir, G_FILE_TEST_IS_DIR))
     {
 #ifdef _WIN32
-      // look for onnxruntime.dll
-      gchar *exact = g_build_filename(dir, "onnxruntime.dll", NULL);
-      if(g_file_test(exact, G_FILE_TEST_EXISTS))
-      {
-        user_paths[i] = exact;
-      }
-      else
-      {
-        g_free(exact);
-        GDir *d = g_dir_open(dir, 0, NULL);
-        if(d)
-        {
-          const gchar *name;
-          while((name = g_dir_read_name(d)))
-          {
-            if(g_str_has_prefix(name, "onnxruntime") &&
-               g_str_has_suffix(name, ".dll"))
-            {
-              user_paths[i] = g_build_filename(dir, name, NULL);
-              break;
-            }
-          }
-          g_dir_close(d);
-        }
-      }
+      const char *flat_name = "onnxruntime.dll";
 #else
-      gchar *exact = g_build_filename(dir, "libonnxruntime.so", NULL);
+      const char *flat_name = "libonnxruntime.so";
+#endif
+      gchar *exact = g_build_filename(dir, flat_name, NULL);
       if(g_file_test(exact, G_FILE_TEST_EXISTS))
       {
         user_paths[i] = exact;
@@ -652,10 +634,8 @@ GList *dt_ai_ort_find_libraries(void)
       else
       {
         g_free(exact);
-        // preserve_layout puts the lib in onnxruntime/capi/
         user_paths[i] = _scan_for_ort_lib(dir);
       }
-#endif
     }
     g_free(dir);
   }

--- a/tools/ai/install-ort-gpu.ps1
+++ b/tools/ai/install-ort-gpu.ps1
@@ -268,22 +268,58 @@ if ($Package.sha256) {
 
 # --- Extract ---
 Write-Host "Extracting..."
+
+# preserve_layout: keep the archive's relative paths (required for wheels
+# whose DLLs reference sibling files via relative paths).
+# flat (default): copy matched DLLs straight into the install dir.
+$preserveLayout = [bool]$Package.preserve_layout
+$libPattern = $Package.lib_pattern
+$libPatterns = @($libPattern) + @($Package.lib_extra_patterns | Where-Object { $_ })
+
+# nuke any prior install — preserve_layout creates subdirs that a
+# per-pattern depth-1 clean wouldn't catch
+if ($preserveLayout) {
+    if (Test-Path $InstallDir) {
+        Remove-Item -Path $InstallDir -Recurse -Force
+    }
+}
 New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
 
-# clean prior install of the same library family so old versioned DLLs
-# don't shadow the new install. matches the shell-script behavior on
-# Linux: remove ${libPattern}*.dll before extracting the new package
-$libPattern = $Package.lib_pattern
-Get-ChildItem -Path $InstallDir -Filter "${libPattern}*.dll" -File -ErrorAction SilentlyContinue |
-    Remove-Item -Force -ErrorAction SilentlyContinue
-foreach ($extra in @($Package.lib_extra_patterns)) {
-    if ($extra) {
-        Get-ChildItem -Path $InstallDir -Filter "${extra}*.dll" -File -ErrorAction SilentlyContinue |
+if (-not $preserveLayout) {
+    # flat install: drop old versioned DLLs of the same family so they
+    # don't shadow the new install
+    foreach ($pat in $libPatterns) {
+        Get-ChildItem -Path $InstallDir -Filter "${pat}*.dll" -File -ErrorAction SilentlyContinue |
             Remove-Item -Force -ErrorAction SilentlyContinue
     }
 }
 
 $ExtractDir = Join-Path $TempDir "extracted"
+
+# copy DLLs matching any of $patterns from $searchRoot into $InstallDir,
+# either flat or preserving relative paths
+function Copy-MatchingLibs([string]$searchRoot, [string[]]$patterns, [bool]$preserve) {
+    $count = 0
+    Get-ChildItem -Path $searchRoot -Recurse -File |
+        Where-Object { $_.Extension -eq ".dll" } |
+        Where-Object {
+            $name = $_.Name
+            $null -ne ($patterns | Where-Object { $name -like "${_}*" } | Select-Object -First 1)
+        } |
+        ForEach-Object {
+            if ($preserve) {
+                $rel = $_.FullName.Substring($searchRoot.Length).TrimStart('\','/')
+                $dest = Join-Path $InstallDir $rel
+                $destDir = Split-Path -Parent $dest
+                if (-not (Test-Path $destDir)) { New-Item -ItemType Directory -Path $destDir -Force | Out-Null }
+                Copy-Item $_.FullName -Destination $dest -Force
+            } else {
+                Copy-Item $_.FullName -Destination $InstallDir -Force
+            }
+            $count++
+        }
+    return $count
+}
 
 switch ($Package.format) {
     "zip" {
@@ -312,14 +348,7 @@ switch ($Package.format) {
     }
 }
 
-# Copy matching libraries
-$copied = 0
-Get-ChildItem -Path $ExtractDir -Recurse -File |
-    Where-Object { $_.Name -like "${libPattern}*" -and $_.Extension -eq ".dll" } |
-    ForEach-Object {
-        Copy-Item $_.FullName -Destination $InstallDir -Force
-        $copied++
-    }
+$copied = Copy-MatchingLibs $ExtractDir $libPatterns $preserveLayout
 
 # Clean up
 Remove-Item -Recurse -Force $TempDir
@@ -358,14 +387,8 @@ if ($Package.runtime_url) {
             $rtExtract = Join-Path $rtTempDir "extracted"
             Expand-Archive -Path $rtArchive -DestinationPath $rtExtract -Force
             $rtPattern = if ($Package.runtime_lib_pattern) { $Package.runtime_lib_pattern } else { "openvino" }
-            $rtCopied = 0
-            Get-ChildItem -Path $rtExtract -Recurse -File |
-                Where-Object { $_.Extension -eq ".dll" } |
-                Where-Object { $_.Name -like "${rtPattern}*" -or $_.Name -like "tbb*.dll" } |
-                ForEach-Object {
-                    Copy-Item $_.FullName -Destination $InstallDir -Force
-                    $rtCopied++
-                }
+            $rtPatterns = @($rtPattern) + @($Package.runtime_extra_patterns | Where-Object { $_ })
+            $rtCopied = Copy-MatchingLibs $rtExtract $rtPatterns $preserveLayout
             if ($rtCopied -gt 0) {
                 Write-Host "Bundled $rtCopied runtime DLLs."
             }
@@ -450,13 +473,28 @@ if ($Selected.vendor -eq "nvidia") {
 }
 
 # --- Verify ---
-$ortDll = Get-ChildItem "$InstallDir\$libPattern*" -File |
-    Where-Object { $_.Extension -eq ".dll" } |
-    Select-Object -First 1
+# preserve_layout: recurse, skip auditwheel-bundled *.libs/ dirs (Linux
+# convention; harmless on Windows). flat: only look at depth 1.
+if ($preserveLayout) {
+    $ortDll = Get-ChildItem -Path $InstallDir -Recurse -File -Filter "$libPattern*.dll" |
+        Where-Object { $_.FullName -notmatch '\\[^\\]+\.libs\\' } |
+        Select-Object -First 1
+    $listing = Get-ChildItem -Path $InstallDir -Recurse -File |
+        Where-Object { $_.FullName -notmatch '\\[^\\]+\.libs\\' }
+} else {
+    $ortDll = Get-ChildItem -Path $InstallDir -File -Filter "$libPattern*.dll" |
+        Select-Object -First 1
+    $listing = Get-ChildItem -Path $InstallDir -File
+}
+
+if (-not $ortDll) {
+    Write-Host "Error: no $libPattern*.dll found after extraction." -ForegroundColor Red
+    exit 1
+}
 
 Write-Host ""
 Write-Host "Done. Installed to: $InstallDir"
-Get-ChildItem "$InstallDir\*" -File | Format-Table Name, Length -AutoSize
+$listing | Format-Table Name, Length -AutoSize
 Write-Host ""
 Write-Host "To enable in darktable:"
 Write-Host ""


### PR DESCRIPTION
Brings the Windows install script and the in-app library detection up to par with the Linux paths. Fixes a Windows build warning in `dt_ai_ort_find_libraries` from the previous platform-split scan, and synchronises behaviour so the same manifest fields and the same install/detect logic run on both platforms.

`preserve_layout` is currently only used by Linux AMD/ROCm wheels that ship auditwheel-bundled deps. Windows has no shipped use yet – this is preparatory work so a future package with nested DLLs (or detect-button testing) is handled without code changes.

### Changes

- `tools/ai/install-ort-gpu.ps1` – parse `preserve_layout` from the manifest. A shared `Copy-MatchingLibs` helper drives both main and runtime-bundle extraction. Verify step recurses (skipping `*.libs/`) in preserve-layout mode.
- `src/ai/backend_onnx.c` – `dt_ai_ort_find_libraries` uses one recursive scan path on both platforms. The Windows-only flat-only branch is removed, fixing the build warning and letting the preferences "detect" button find a nested ORT DLL the same way it does on Linux.