### PR TITLE
Some sigmoid and guided filter OpenCL improvements

### DIFF
--- a/data/kernels/guided_filter.cl
+++ b/data/kernels/guided_filter.cl
@@ -33,7 +33,7 @@ kernel void guided_filter_split_rgb_image(const int width,
   if(x >= width || y >= height) return;
 
   const float4 weight = { guide_weight, guide_weight, guide_weight, 0.0f };
-  const float4 pixel = weight * fmin(100.0f, fmax(0.0f, readpixel(guide, x, y+first)));
+  const float4 pixel = weight * fmin(100.0f, readpixel(guide, x, y+first));
   write_imagef(out_r, (int2)(x, y), pixel.x);
   write_imagef(out_g, (int2)(x, y), pixel.y);
   write_imagef(out_b, (int2)(x, y), pixel.z);
@@ -178,7 +178,7 @@ kernel void guided_filter_covariances(const int width,
   const float4 weight = { guide_weight, guide_weight, guide_weight, 0.0f };
   const float img_ = readsingle(img, x, y);
   const float4 imgv = { img_, img_, img_, 0.0f };
-  const float4 pixel = imgv * weight * fmin(100.0f, fmax(0.0f, readpixel(guide, x, y+first)));
+  const float4 pixel = imgv * weight * fmin(100.0f, readpixel(guide, x, y+first));
   write_imagef(cov_imgg_img_r, (int2)(x, y), pixel.x);
   write_imagef(cov_imgg_img_g, (int2)(x, y), pixel.y);
   write_imagef(cov_imgg_img_b, (int2)(x, y), pixel.z);
@@ -202,7 +202,7 @@ kernel void guided_filter_variances(const int width,
   if(x >= width || y >= height) return;
 
   const float4 weight = { guide_weight, guide_weight, guide_weight, 0.0f };
-  const float4 pixel = weight * fmin(100.0f, fmax(0.0f, readpixel(guide, x, y+first)));
+  const float4 pixel = weight * fmin(100.0f, readpixel(guide, x, y+first));
   write_imagef(var_imgg_rr, (int2)(x, y), pixel.x * pixel.x);
   write_imagef(var_imgg_rg, (int2)(x, y), pixel.x * pixel.y);
   write_imagef(var_imgg_rb, (int2)(x, y), pixel.x * pixel.z);
@@ -315,7 +315,7 @@ kernel void guided_filter_generate_result(const int width,
   const int y = get_global_id(1);
   if(x >= width || y >= height) return;
 
-  const float4 pixel = fmin(100.0f, fmax(0.0f, readpixel(guide, x, y+first)));
+  const float4 pixel = fmin(100.0f, readpixel(guide, x, y+first));
   const float a_r_ = pixel.x * readsingle(a_r, x, y);
   const float a_g_ = pixel.y * readsingle(a_g, x, y);
   const float a_b_ = pixel.z * readsingle(a_b, x, y);

--- a/data/kernels/sigmoid.cl
+++ b/data/kernels/sigmoid.cl
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    copyright (c) 2023 darktable developers.
+    copyright (c) 2023-2026 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -193,7 +193,7 @@ sigmoid_loglogistic_per_channel (read_only image2d_t in,
 
   if(x >= width || y >= height) return;
 
-  float4 i = read_imagef(in, sampleri, (int2)(x, y));
+  float4 i = Areadpixel(in, x, y);
   float alpha = i.w;
 
   i = matrix_product_float4(i, pipe_to_base);
@@ -239,7 +239,7 @@ sigmoid_loglogistic_rgb_ratio(read_only image2d_t in,
 
   if(x >= width || y >= height) return;
 
-  float4 i = read_imagef(in, sampleri, (int2)(x, y));
+  float4 i = Areadpixel(in, x, y);
   float alpha = i.w;
 
 

--- a/src/iop/sigmoid.c
+++ b/src/iop/sigmoid.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2020-2025 darktable developers.
+    Copyright (C) 2020-2026 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -797,12 +797,6 @@ int process_cl(dt_iop_module_t *self,
   const int width = roi_in->width;
   const int height = roi_in->height;
 
-  const float white_target = d->white_target;
-  const float paper_exp = d->paper_exposure;
-  const float film_fog = d->film_fog;
-  const float contrast_power = d->film_power;
-  const float skew_power = d->paper_power;
-
   const dt_iop_order_iccprofile_info_t *pipe_work_profile = dt_ioppr_get_pipe_work_profile_info(piece->pipe);
   const dt_iop_order_iccprofile_info_t *base_profile = _get_base_profile(self->dev, pipe_work_profile, d->base_primaries);
   dt_colormatrix_t pipe_to_base_transposed, base_to_rendering_transposed,
@@ -822,20 +816,17 @@ int process_cl(dt_iop_module_t *self,
 
   if(d->color_processing == DT_SIGMOID_METHOD_PER_CHANNEL)
   {
-    const float hue_preservation = d->hue_preservation;
     err = dt_opencl_enqueue_kernel_2d_args(
         devid, gd->kernel_sigmoid_loglogistic_per_channel, width, height, CLARG(dev_in), CLARG(dev_out),
-        CLARG(width), CLARG(height), CLARG(white_target), CLARG(paper_exp), CLARG(film_fog), CLARG(contrast_power),
-        CLARG(skew_power), CLARG(hue_preservation), CLARG(dev_pipe_to_base), CLARG(dev_base_to_rendering), CLARG(dev_rendering_to_pipe));
+        CLARG(width), CLARG(height), CLARG(d->white_target), CLARG(d->paper_exposure), CLARG(d->film_fog), CLARG(d->film_power),
+        CLARG(d->paper_power), CLARG(d->hue_preservation), CLARG(dev_pipe_to_base), CLARG(dev_base_to_rendering), CLARG(dev_rendering_to_pipe));
   }
   else
   {
-    const float black_target = d->black_target;
-
     err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_sigmoid_loglogistic_rgb_ratio, width, height,
                                            CLARG(dev_in), CLARG(dev_out), CLARG(width), CLARG(height),
-                                           CLARG(white_target), CLARG(black_target), CLARG(paper_exp),
-                                           CLARG(film_fog), CLARG(contrast_power), CLARG(skew_power));
+                                           CLARG(d->white_target), CLARG(d->black_target), CLARG(d->paper_exposure),
+                                           CLARG(d->film_fog), CLARG(d->film_power), CLARG(d->paper_power));
   }
 
 cleanup:


### PR DESCRIPTION
1. In sigmoid we can safely used the `Areadpixel()` variants for some subtle performance gain, also pass some parameters directly.
2. The OpenCL guided filter clipped negatives from input - different from CPU code - thus possibly with different results. In current code (as in the testsuite) we didn't have negatives so nothing noteworthy yet.

Integration tests without regressions.