### PR TITLE
Some pipe maintenance

### DIFF
--- a/src/common/iop_profile.c
+++ b/src/common/iop_profile.c
@@ -879,7 +879,7 @@ dt_ioppr_set_pipe_work_profile_info(struct dt_develop_t *dev,
   dt_iop_order_iccprofile_info_t *profile_info =
     dt_ioppr_add_profile_info_to_list(dev, type, filename, intent);
 
-  if(!profile_info && (pipe->type & DT_DEV_PIXELPIPE_PREVIEW) && (type == DT_COLORSPACE_FILE))
+  if(!profile_info && dt_pipe_is_preview(pipe) && (type == DT_COLORSPACE_FILE))
       dt_control_log(_("work icc profile '%s' missing"), filename);
 
   if(profile_info == NULL
@@ -910,7 +910,7 @@ dt_ioppr_set_pipe_input_profile_info(struct dt_develop_t *dev,
 
   if(profile_info == NULL)
   {
-    if((pipe->type & DT_DEV_PIXELPIPE_PREVIEW) && (type == DT_COLORSPACE_FILE))
+    if(dt_pipe_is_preview(pipe) && (type == DT_COLORSPACE_FILE))
       dt_control_log(_("input icc profile '%s' missing"), filename);
 
     dt_print(DT_DEBUG_PIPE,
@@ -963,7 +963,7 @@ dt_ioppr_set_pipe_output_profile_info(struct dt_develop_t *dev,
   dt_iop_order_iccprofile_info_t *profile_info =
     dt_ioppr_add_profile_info_to_list(dev, type, filename, intent);
 
-  if(!profile_info && (pipe->type & DT_DEV_PIXELPIPE_PREVIEW) && (type == DT_COLORSPACE_FILE))
+  if(!profile_info && dt_pipe_is_preview(pipe) && (type == DT_COLORSPACE_FILE))
     dt_control_log(_("output icc profile '%s' missing"), filename);
 
   if(profile_info == NULL

--- a/src/develop/blend.c
+++ b/src/develop/blend.c
@@ -998,7 +998,7 @@ gboolean dt_develop_blend_process_cl(dt_iop_module_t *self,
   dt_colorspaces_iccprofile_info_cl_t *work_profile_info_cl = NULL;
   cl_float *work_profile_lut_cl = NULL;
 
-  size_t region[] = { owidth, oheight };
+  const size_t region[2] = { owidth, oheight };
 
   // parameters, for every channel the 4 limits + pre-computed
   // increasing slope and decreasing slope

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -295,7 +295,7 @@ gboolean dt_dev_pixelpipe_init_cached(dt_dev_pixelpipe_t *pipe,
 size_t dt_get_available_pipe_mem(const dt_dev_pixelpipe_t *pipe)
 {
   const size_t allmem = dt_get_available_mem();
-  return MAX(DT_MEGA, allmem / (pipe->type & DT_DEV_PIXELPIPE_THUMBNAIL ? 3 : 1));
+  return MAX(DT_MEGA, allmem / (dt_pipe_is_thumb(pipe) ? 3 : 1));
 }
 
 static void get_output_format(dt_iop_module_t *module,

--- a/src/develop/pixelpipe_hb.h
+++ b/src/develop/pixelpipe_hb.h
@@ -240,6 +240,14 @@ static inline gboolean dt_pipe_is_full(const dt_dev_pixelpipe_t *pipe)
 {
   return (pipe->type & DT_DEV_PIXELPIPE_FULL);
 }
+static inline gboolean dt_pipe_is_thumb(const dt_dev_pixelpipe_t *pipe)
+{
+  return (pipe->type & DT_DEV_PIXELPIPE_THUMBNAIL);
+}
+static inline gboolean dt_pipe_is_export(const dt_dev_pixelpipe_t *pipe)
+{
+  return (pipe->type & DT_DEV_PIXELPIPE_EXPORT);
+}
 static inline gboolean dt_pipe_is_basic(const dt_dev_pixelpipe_t *pipe)
 {
   return (pipe->type & DT_DEV_PIXELPIPE_BASIC);
@@ -251,6 +259,10 @@ static inline gboolean dt_pipe_is_canvas(const dt_dev_pixelpipe_t *pipe)
 static inline gboolean dt_pipe_is_preview(const dt_dev_pixelpipe_t *pipe)
 {
   return (pipe->type & DT_DEV_PIXELPIPE_PREVIEW);
+}
+static inline gboolean dt_pipe_is_preview2(const dt_dev_pixelpipe_t *pipe)
+{
+  return (pipe->type & DT_DEV_PIXELPIPE_PREVIEW2);
 }
 static inline gboolean dt_pipe_is_screen(const dt_dev_pixelpipe_t *pipe)
 {

--- a/src/develop/tiling.c
+++ b/src/develop/tiling.c
@@ -745,8 +745,8 @@ static void _default_process_tiling_ptp(dt_iop_module_t *self,
       if((wd <= 2 * overlap && tx > 0) || (ht <= 2 * overlap && ty > 0)) continue;
 
       /* origin and region of effective part of tile, which we want to store later */
-      size_t origin[] = { 0, 0, 0 };
-      size_t region[] = { wd, ht, 1 };
+      size_t origin[2] = { 0, 0 };
+      size_t region[2] = { wd, ht };
 
       /* roi_in and roi_out for process_cl on subbuffer */
       dt_iop_roi_t iroi = { roi_in->x + tx * tile_wd, roi_in->y + ty * tile_ht, wd, ht, roi_in->scale };

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -3652,7 +3652,7 @@ int process_cl(dt_iop_module_t *self,
   // if module is set to neutral parameters we just copy input->output and are done
   if(_isneutral(d))
   {
-    size_t region[] = { roi_out->width, roi_out->height };
+    const size_t region[2] = { roi_out->width, roi_out->height };
     err = dt_opencl_enqueue_copy_image(devid, dev_in, dev_out, CLIMG_ORIGIN, CLIMG_ORIGIN, region);
     if(err != CL_SUCCESS) goto error;
     return CL_SUCCESS;

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -1196,7 +1196,7 @@ void modify_roi_out(dt_iop_module_t *self,
   {
     dt_print_pipe(DT_DEBUG_PIPE,
         "insane data", piece->pipe, self, DT_DEVICE_NONE, roi_in, roi_out);
-    if(piece->pipe->type & DT_DEV_PIXELPIPE_FULL)
+    if(dt_pipe_is_full(piece->pipe))
     {
       dt_control_log
         (_("module '%s' has insane data so it is bypassed for now."
@@ -3447,7 +3447,7 @@ void process(dt_iop_module_t *self,
   const int ch_width = ch * roi_in->width;
 
   // only for preview pipe: collect input buffer data and do some other evaluations
-  if(g && self->dev->gui_attached && (piece->pipe->type & DT_DEV_PIXELPIPE_PREVIEW))
+  if(g && self->dev->gui_attached && dt_pipe_is_preview(piece->pipe))
   {
     // we want to find out if the final output image is flipped in relation to this iop
     // so we can adjust the gui labels accordingly
@@ -3585,7 +3585,7 @@ int process_cl(dt_iop_module_t *self,
   cl_mem dev_homo = NULL;
 
   // only for preview pipe: collect input buffer data and do some other evaluations
-  if(self->dev->gui_attached && g && (piece->pipe->type & DT_DEV_PIXELPIPE_PREVIEW))
+  if(self->dev->gui_attached && g && dt_pipe_is_preview(piece->pipe))
   {
     // we want to find out if the final output image is flipped in relation to this iop
     // so we can adjust the gui labels accordingly

--- a/src/iop/atrous.c
+++ b/src/iop/atrous.c
@@ -525,7 +525,7 @@ int process_cl(dt_iop_module_t *self,
     if(dev_detail[k] == NULL) goto error;
   }
 
-  size_t region[] = { width, height };
+  const size_t region[2] = { width, height };
   // copy original input from dev_in -> dev_out as starting point
   err = dt_opencl_enqueue_copy_image(devid, dev_in, dev_out, CLIMG_ORIGIN, CLIMG_ORIGIN, region);
   if(err != CL_SUCCESS) goto error;

--- a/src/iop/atrous.c
+++ b/src/iop/atrous.c
@@ -289,7 +289,7 @@ static void process_wavelets(dt_iop_module_t *self,
   const int width = roi_out->width;
   const int height = roi_out->height;
 
-  if(self->dev->gui_attached && (piece->pipe->type & DT_DEV_PIXELPIPE_FULL))
+  if(self->dev->gui_attached && dt_pipe_is_full(piece->pipe))
   {
     dt_iop_atrous_gui_data_t *g = self->gui_data;
     g->num_samples = get_samples(g->sample, d, roi_in, piece);
@@ -376,7 +376,7 @@ int process_cl(dt_iop_module_t *self,
   float sharp[MAX_NUM_SCALES];
   const int max_scale = get_scales(thrs, boost, sharp, d, roi_in, piece);
 
-  if(self->dev->gui_attached && (piece->pipe->type & DT_DEV_PIXELPIPE_FULL))
+  if(self->dev->gui_attached && dt_pipe_is_full(piece->pipe))
   {
     dt_iop_atrous_gui_data_t *g = self->gui_data;
     g->num_samples = get_samples(g->sample, d, roi_in, piece);
@@ -486,7 +486,7 @@ int process_cl(dt_iop_module_t *self,
   float sharp[MAX_NUM_SCALES];
   const int max_scale = get_scales(thrs, boost, sharp, d, roi_in, piece);
 
-  if(self->dev->gui_attached && (piece->pipe->type & DT_DEV_PIXELPIPE_FULL))
+  if(self->dev->gui_attached && dt_pipe_is_full(piece->pipe))
   {
     dt_iop_atrous_gui_data_t *g = self->gui_data;
     g->num_samples = get_samples(g->sample, d, roi_in, piece);

--- a/src/iop/basecurve.c
+++ b/src/iop/basecurve.c
@@ -774,7 +774,7 @@ int process_cl_fusion(dt_iop_module_t *self,
         CLARG(dev_col[0]), CLARG(dev_out), CLARG(dev_tmp1), CLARG(width), CLARG(height));
       if(err != CL_SUCCESS) goto error;
 
-      size_t region[] = { width, height };
+      const size_t region[2] = { width, height };
       err = dt_opencl_enqueue_copy_image(devid, dev_tmp1, dev_col[0], CLIMG_ORIGIN, CLIMG_ORIGIN, region);
       if(err != CL_SUCCESS) goto error;
     }
@@ -813,7 +813,7 @@ int process_cl_fusion(dt_iop_module_t *self,
           CLARG(dev_comb[k]), CLARG(dev_col[k]), CLARG(dev_tmp1), CLARG(w), CLARG(h));
         if(err != CL_SUCCESS) goto error;
 
-        size_t region[] = { w, h };
+        const size_t region[2] = { w, h };
         err = dt_opencl_enqueue_copy_image(devid, dev_tmp1, dev_comb[k], CLIMG_ORIGIN, CLIMG_ORIGIN, region);
         if(err != CL_SUCCESS) goto error;
       }
@@ -824,7 +824,7 @@ int process_cl_fusion(dt_iop_module_t *self,
           CLARG(dev_comb[k]), CLARG(dev_col[k]), CLARG(dev_tmp2), CLARG(dev_tmp1), CLARG(w), CLARG(h));
         if(err != CL_SUCCESS) goto error;
 
-        size_t region[] = { w, h };
+        const size_t region[2] = { w, h };
         err = dt_opencl_enqueue_copy_image(devid, dev_tmp1, dev_comb[k], CLIMG_ORIGIN, CLIMG_ORIGIN, region);
         if(err != CL_SUCCESS) goto error;
       }
@@ -850,7 +850,7 @@ int process_cl_fusion(dt_iop_module_t *self,
       if(err != CL_SUCCESS) goto error;
 
       // dev_tmp1[k] -> dev_comb[k]
-      size_t region[] = { w, h };
+      const size_t region[2] = { w, h };
       err = dt_opencl_enqueue_copy_image(devid, dev_tmp1, dev_comb[k], CLIMG_ORIGIN, CLIMG_ORIGIN, region);
       if(err != CL_SUCCESS) goto error;
     }
@@ -869,7 +869,7 @@ int process_cl_fusion(dt_iop_module_t *self,
       if(err != CL_SUCCESS) goto error;
 
       // dev_tmp2 -> dev_comb[k]
-      size_t region[] = { w, h };
+      const size_t region[2] = { w, h };
       err = dt_opencl_enqueue_copy_image(devid, dev_tmp2, dev_comb[k], CLIMG_ORIGIN, CLIMG_ORIGIN, region);
       if(err != CL_SUCCESS) goto error;
     }

--- a/src/iop/basicadj.c
+++ b/src/iop/basicadj.c
@@ -1294,7 +1294,7 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
   const int height = roi_in->height;
 
   // process auto levels
-  if(g && (piece->pipe->type & DT_DEV_PIXELPIPE_PREVIEW))
+  if(g && dt_pipe_is_preview(piece->pipe))
   {
     dt_iop_gui_enter_critical_section(self);
     if(g->call_auto_exposure == 1 && !darktable.gui->reset)
@@ -1412,7 +1412,7 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
   dt_iop_basicadj_gui_data_t *g = self->gui_data;
 
   // process auto levels
-  if(g && (piece->pipe->type & DT_DEV_PIXELPIPE_PREVIEW))
+  if(g && dt_pipe_is_preview(piece->pipe))
   {
     dt_iop_gui_enter_critical_section(self);
     if(g->call_auto_exposure == 1 && !darktable.gui->reset)

--- a/src/iop/bilateral.cc
+++ b/src/iop/bilateral.cc
@@ -166,7 +166,7 @@ void process(dt_iop_module_t *self,
   // if rad <= 6 use naive version!
   const int prad = (int)(3.0f * fmaxf(sigma[0], sigma[1]) + 1.0f);
   const int rad = MIN(prad, MIN(roi_out->width, roi_out->height) - 2 * prad);
-  const gboolean thumb = piece->pipe->type & DT_DEV_PIXELPIPE_THUMBNAIL;
+  const gboolean thumb = dt_pipe_is_thumb(piece->pipe);
   if(rad < 1 || (rad <= MAX_DIRECT_STAMP_RADIUS && thumb))
   {
     // no use denoising the thumbnail. takes ages without permutohedral

--- a/src/iop/borders.c
+++ b/src/iop/borders.c
@@ -638,8 +638,8 @@ int process_cl(dt_iop_module_t *self,
     if(err != CL_SUCCESS) goto error;
   }
 
-  size_t oorigin[] = { binfo.border_in_x, binfo.border_in_y };
-  size_t region[]  = { roi_in->width, roi_in->height };
+  const size_t oorigin[2] = { binfo.border_in_x, binfo.border_in_y };
+  const size_t region[2]  = { roi_in->width, roi_in->height };
 
   // copy original input from dev_in -> dev_out as starting point
   err = dt_opencl_enqueue_copy_image(devid, dev_in, dev_out, CLIMG_ORIGIN, oorigin, region);

--- a/src/iop/cacorrect.c
+++ b/src/iop/cacorrect.c
@@ -263,7 +263,7 @@ void process(dt_iop_module_t *self,
 
   // the colorshift avoiding requires non-downscaled data for sure so we
   // don't do this for preview
-  const gboolean avoidshift = d->avoidshift && !(piece->pipe->type & DT_DEV_PIXELPIPE_PREVIEW);
+  const gboolean avoidshift = d->avoidshift && !dt_pipe_is_preview(piece->pipe);
   const int iterations = d->iterations;
 
   // Because we can't break parallel processing, we need a switch do handle the errors

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -2131,7 +2131,7 @@ void process(dt_iop_module_t *self,
     return; // image has been copied through to output and module's
             // trouble flag has been updated
 
-  if(piece->pipe->type & DT_DEV_PIXELPIPE_PREVIEW)
+  if(dt_pipe_is_preview(piece->pipe))
     _declare_cat_on_pipe(self, FALSE);
 
   dt_colormatrix_t RGB_to_XYZ;
@@ -2172,7 +2172,7 @@ void process(dt_iop_module_t *self,
     if(data->illuminant_type == DT_ILLUMINANT_DETECT_EDGES
        || data->illuminant_type == DT_ILLUMINANT_DETECT_SURFACES)
     {
-      if(piece->pipe->type & DT_DEV_PIXELPIPE_FULL)
+      if(dt_pipe_is_full(piece->pipe))
       {
         // detection on full image only
         dt_iop_gui_enter_critical_section(self);
@@ -2305,7 +2305,7 @@ int process_cl(dt_iop_module_t *self,
   const dt_iop_order_iccprofile_info_t *const work_profile =
     dt_ioppr_get_pipe_current_profile_info(self, piece->pipe);
 
-  if(piece->pipe->type & DT_DEV_PIXELPIPE_PREVIEW)
+  if(dt_pipe_is_preview(piece->pipe))
     _declare_cat_on_pipe(self, FALSE);
 
   if(d->illuminant_type == DT_ILLUMINANT_CAMERA)
@@ -3157,7 +3157,7 @@ void commit_params(dt_iop_module_t *self,
         || // delta E validation
         ( (d->illuminant_type == DT_ILLUMINANT_DETECT_EDGES ||
            d->illuminant_type == DT_ILLUMINANT_DETECT_SURFACES ) && // WB extraction mode
-           (piece->pipe->type & DT_DEV_PIXELPIPE_FULL) )
+           dt_pipe_is_full(piece->pipe))
 #endif
       )
     {

--- a/src/iop/clipping.c
+++ b/src/iop/clipping.c
@@ -1086,7 +1086,7 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
   if(!d->flags && d->angle == 0.0 && d->all_off && roi_in->width == roi_out->width
      && roi_in->height == roi_out->height)
   {
-    size_t region[] = { width, height };
+    const size_t region[2] = { width, height };
     err = dt_opencl_enqueue_copy_image(devid, dev_in, dev_out, CLIMG_ORIGIN, CLIMG_ORIGIN, region);
     if(err != CL_SUCCESS) goto error;
   }

--- a/src/iop/clipping.c
+++ b/src/iop/clipping.c
@@ -480,7 +480,7 @@ gboolean distort_transform(dt_iop_module_t *self,
   // as dt_iop_roi_t contain int values and not floats, we can have some rounding errors
   // as a workaround, we use a factor for preview pipes
   float factor = 1.0f;
-  if(piece->pipe->type & (DT_DEV_PIXELPIPE_PREVIEW | DT_DEV_PIXELPIPE_PREVIEW2)) factor = 100.0f;
+  if(dt_pipe_is_preview(piece->pipe)) factor = 100.0f;
   // we first need to be sure that all data values are computed
   // this is done in modify_roi_out fct, so we create tmp roi
   dt_iop_roi_t roi_out, roi_in;
@@ -548,7 +548,7 @@ gboolean distort_backtransform(dt_iop_module_t *self,
   // as dt_iop_roi_t contain int values and not floats, we can have some rounding errors
   // as a workaround, we use a factor for preview pipes
   float factor = 1.0f;
-  if(piece->pipe->type & (DT_DEV_PIXELPIPE_PREVIEW | DT_DEV_PIXELPIPE_PREVIEW2)) factor = 100.0f;
+  if(dt_pipe_is_preview(piece->pipe)) factor = 100.0f;
   // we first need to be sure that all data values are computed
   // this is done in modify_roi_out fct, so we create tmp roi
   dt_iop_roi_t roi_out, roi_in;
@@ -908,7 +908,7 @@ void modify_roi_out(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, dt_iop
     roi_out->height = roi_in->height;
     piece->enabled = FALSE;
 
-    if(piece->pipe->type & DT_DEV_PIXELPIPE_FULL)
+    if(dt_pipe_is_full(piece->pipe))
       dt_control_log
         (_("module '%s' has insane data so it is bypassed for now. you should disable it or change parameters\n"),
          self->name());

--- a/src/iop/colorbalancergb.c
+++ b/src/iop/colorbalancergb.c
@@ -642,8 +642,8 @@ void process(dt_iop_module_t *self,
   const float *const restrict brilliance = DT_IS_ALIGNED_PIXEL((const float *const restrict)d->brilliance);
 
   const gint mask_display
-      = ((piece->pipe->type & DT_DEV_PIXELPIPE_FULL) && self->dev->gui_attached
-         && g && g->mask_display);
+      = dt_pipe_is_full(piece->pipe) && self->dev->gui_attached
+         && g && g->mask_display;
 
   // pixel size of the checker background
   const size_t checker_1 = (mask_display) ? DT_PIXEL_APPLY_DPI(d->checker_size) : 0;
@@ -1027,8 +1027,8 @@ int process_cl(dt_iop_module_t *self,
 
   // Size of the checker
   const gint mask_display
-      = ((piece->pipe->type & DT_DEV_PIXELPIPE_FULL) && self->dev->gui_attached
-         && g && g->mask_display);
+      = dt_pipe_is_full(piece->pipe) && self->dev->gui_attached
+         && g && g->mask_display;
   const int checker_1 = (mask_display) ? DT_PIXEL_APPLY_DPI(d->checker_size) : 0;
   const int checker_2 = 2 * checker_1;
   const int mask_type = (mask_display) ? g->mask_type : 0;

--- a/src/iop/colorequal.c
+++ b/src/iop/colorequal.c
@@ -987,7 +987,7 @@ void process(dt_iop_module_t *self,
   }
   const dt_iop_colorequal_data_t *d = piece->data;
   const dt_iop_colorequal_gui_data_t *g = self->gui_data;
-  const gboolean fullpipe = piece->pipe->type & DT_DEV_PIXELPIPE_FULL;
+  const gboolean fullpipe = dt_pipe_is_full(piece->pipe);
   const int mask_mode = g && fullpipe ? g->mask_mode : 0;
   const gboolean run_fast = piece->pipe->type & DT_DEV_PIXELPIPE_FAST;
 
@@ -1528,7 +1528,7 @@ int process_cl(dt_iop_module_t *self,
   const size_t bsize = (size_t) width * height * sizeof(float);
 
   const dt_iop_colorequal_gui_data_t *g = (dt_iop_colorequal_gui_data_t *)self->gui_data;
-  const gboolean fullpipe = piece->pipe->type & DT_DEV_PIXELPIPE_FULL;
+  const gboolean fullpipe = dt_pipe_is_full(piece->pipe);
   const int mask_mode = g && fullpipe ? g->mask_mode : 0;
   const int guiding = d->use_filter;
   const gboolean run_fast = piece->pipe->type & DT_DEV_PIXELPIPE_FAST;

--- a/src/iop/colorharmonizer.c
+++ b/src/iop/colorharmonizer.c
@@ -263,7 +263,7 @@ static void _update_histogram(dt_iop_module_t *self,
                               const float *ivoid,
                               const dt_iop_roi_t *roi_in)
 {
-  if(!self->gui_data || !((piece->pipe->type & DT_DEV_PIXELPIPE_PREVIEW) == DT_DEV_PIXELPIPE_PREVIEW))
+  if(!self->gui_data || !dt_pipe_is_preview(piece->pipe))
     return;
 
   dt_iop_colorharmonizer_gui_data_t *g = self->gui_data;
@@ -669,7 +669,7 @@ int process_cl(dt_iop_module_t *self,
     CLARG(p->pull_strength), CLARG(p->neutral_protection),
     CLARG(L_white));
 
-  if(err == CL_SUCCESS && self->gui_data && (piece->pipe->type & DT_DEV_PIXELPIPE_PREVIEW) == DT_DEV_PIXELPIPE_PREVIEW)
+  if(err == CL_SUCCESS && self->gui_data && dt_pipe_is_preview(piece->pipe))
   {
     float *host_in = dt_alloc_align_float((size_t)width * height * 4);
     if(host_in)

--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -646,7 +646,7 @@ int process_cl(dt_iop_module_t *self,
 
   if(d->type == DT_COLORSPACE_LAB)
   {
-    size_t region[] = { width, height };
+    const size_t region[2] = { width, height };
     return dt_opencl_enqueue_copy_image(devid, dev_in, dev_out, CLIMG_ORIGIN, CLIMG_ORIGIN, region);
   }
 

--- a/src/iop/colormapping.c
+++ b/src/iop/colormapping.c
@@ -675,7 +675,7 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
     }
     else
     {
-      size_t region[] = { width, height };
+      const size_t region[2] = { width, height };
       err = dt_opencl_enqueue_copy_image(devid, dev_out, dev_tmp, CLIMG_ORIGIN, CLIMG_ORIGIN, region);
       if(err != CL_SUCCESS) goto error;
     }
@@ -686,7 +686,7 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
   }
   else
   {
-    size_t region[] = { width, height };
+    const size_t region[2] = { width, height };
     err = dt_opencl_enqueue_copy_image(devid, dev_in, dev_out, CLIMG_ORIGIN, CLIMG_ORIGIN, region);
   }
 

--- a/src/iop/colormapping.c
+++ b/src/iop/colormapping.c
@@ -448,7 +448,7 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
   const float sigma_r = 8.0f; // does not depend on scale
 
   // save a copy of preview input buffer so we can get histogram and color statistics out of it
-  if(self->dev->gui_attached && g && (piece->pipe->type & DT_DEV_PIXELPIPE_PREVIEW) && (data->flag & ACQUIRE))
+  if(self->dev->gui_attached && g && dt_pipe_is_preview(piece->pipe) && (data->flag & ACQUIRE))
   {
     dt_iop_gui_enter_critical_section(self);
     if(g->buffer) dt_free_align(g->buffer);
@@ -594,7 +594,7 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
 
 
   // save a copy of preview input buffer so we can get histogram and color statistics out of it
-  if(self->dev->gui_attached && g && (piece->pipe->type & DT_DEV_PIXELPIPE_PREVIEW) && (data->flag & ACQUIRE))
+  if(self->dev->gui_attached && g && dt_pipe_is_preview(piece->pipe) && (data->flag & ACQUIRE))
   {
     dt_iop_gui_enter_critical_section(self);
     dt_free_align(g->buffer);

--- a/src/iop/colorout.c
+++ b/src/iop/colorout.c
@@ -567,7 +567,7 @@ void commit_params(dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_
   cmsHPROFILE softproof = NULL;
   cmsUInt32Number output_format = TYPE_RGBA_FLT;
 
-  d->mode = (pipe->type & DT_DEV_PIXELPIPE_FULL) ? darktable.color_profiles->mode : DT_PROFILE_NORMAL;
+  d->mode = dt_pipe_is_full(pipe) ? darktable.color_profiles->mode : DT_PROFILE_NORMAL;
 
   if(d->xform)
   {
@@ -581,7 +581,7 @@ void commit_params(dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_
   piece->process_cl_ready = TRUE;
 
   /* if we are exporting then check and set usage of override profile */
-  if(pipe->type & DT_DEV_PIXELPIPE_EXPORT)
+  if(dt_pipe_is_export(pipe))
   {
     if(pipe->icc_type != DT_COLORSPACE_NONE)
     {
@@ -594,13 +594,13 @@ void commit_params(dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_
     out_filename = p->filename;
     out_intent = p->intent;
   }
-  else if(pipe->type & DT_DEV_PIXELPIPE_THUMBNAIL)
+  else if(dt_pipe_is_thumb(pipe))
   {
     out_type = dt_mipmap_cache_get_colorspace();
     out_filename = (out_type == DT_COLORSPACE_DISPLAY ? darktable.color_profiles->display_filename : "");
     out_intent = darktable.color_profiles->display_intent;
   }
-  else if(pipe->type & DT_DEV_PIXELPIPE_PREVIEW2)
+  else if(dt_pipe_is_preview2(pipe))
   {
     /* preview2 is only used in second darkroom window, using display2 profile as output */
     out_type = darktable.color_profiles->display2_type;
@@ -653,7 +653,7 @@ void commit_params(dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_
   }
 
   /* creating softproof profile if softproof is enabled */
-  if((d->mode != DT_PROFILE_NORMAL) && (pipe->type & DT_DEV_PIXELPIPE_FULL))
+  if((d->mode != DT_PROFILE_NORMAL) && dt_pipe_is_full(pipe))
   {
     const dt_colorspaces_color_profile_t *prof = dt_colorspaces_get_profile
       (darktable.color_profiles->softproof_type,

--- a/src/iop/colorout.c
+++ b/src/iop/colorout.c
@@ -325,7 +325,7 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
 
   if(d->type == DT_COLORSPACE_LAB)
   {
-    size_t region[] = { roi_in->width, roi_in->height };
+    const size_t region[2] = { roi_in->width, roi_in->height };
     err = dt_opencl_enqueue_copy_image(devid, dev_in, dev_out, CLIMG_ORIGIN, CLIMG_ORIGIN, region);
     if(err != CL_SUCCESS) goto error;
     return CL_SUCCESS;

--- a/src/iop/colorreconstruction.c
+++ b/src/iop/colorreconstruction.c
@@ -623,7 +623,7 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
   if(sigma_s > DT_COLORRECONSTRUCT_SPATIAL_APPROX
      && self->dev->gui_attached
      && g
-     && (piece->pipe->type & DT_DEV_PIXELPIPE_FULL))
+     && dt_pipe_is_full(piece->pipe))
   {
     // if we are zoomed in more than just a little bit, we try to use the canned grid of the preview pipeline
     if(dt_dev_get_zoomed_in() > 1.05f)
@@ -653,7 +653,7 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
   dt_iop_colorreconstruct_bilateral_slice(b, in, out, data->threshold, roi_in, piece->iscale);
 
   // here is where we generate the canned bilateral grid of the preview pipe for later use
-  if(self->dev->gui_attached && g && (piece->pipe->type & DT_DEV_PIXELPIPE_PREVIEW))
+  if(self->dev->gui_attached && g && dt_pipe_is_preview(piece->pipe))
   {
     dt_hash_t hash = dt_dev_hash_plus(self->dev, piece->pipe, self->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL);
     dt_iop_gui_enter_critical_section(self);
@@ -1024,7 +1024,7 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
   if(sigma_s > DT_COLORRECONSTRUCT_SPATIAL_APPROX
      && self->dev->gui_attached
      && g
-     && (piece->pipe->type & DT_DEV_PIXELPIPE_FULL))
+     && dt_pipe_is_full(piece->pipe))
   {
     // if we are zoomed in more than just a little bit, we try to use the canned grid of the preview pipeline
     if(dt_dev_get_zoomed_in() > 1.05f)
@@ -1056,7 +1056,7 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
   err = dt_iop_colorreconstruct_bilateral_slice_cl(b, dev_in, dev_out, d->threshold, roi_in, piece->iscale);
   if(err != CL_SUCCESS) goto error;
 
-  if(self->dev->gui_attached && g && (piece->pipe->type & DT_DEV_PIXELPIPE_PREVIEW))
+  if(self->dev->gui_attached && g && dt_pipe_is_preview(piece->pipe))
   {
     dt_hash_t hash = dt_dev_hash_plus(self->dev, piece->pipe, self->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL);
     dt_iop_gui_enter_critical_section(self);

--- a/src/iop/colortransfer.c
+++ b/src/iop/colortransfer.c
@@ -300,7 +300,7 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
 
   if(data->flag == ACQUIRE)
   {
-    if(piece->pipe->type & DT_DEV_PIXELPIPE_PREVIEW)
+    if(dt_pipe_is_preview(piece->pipe))
     {
       // only get stuff from the preview pipe, rest stays untouched.
       int hist[HISTN];

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -579,7 +579,7 @@ void process(dt_iop_module_t *self,
   dt_iop_colorzones_gui_data_t *g = self->gui_data;
 
   // display selection if requested
-  if((piece->pipe->type & DT_DEV_PIXELPIPE_FULL)
+  if(dt_pipe_is_full(piece->pipe)
      && g
      && g->display_mask
      && dt_iop_has_focus(self)
@@ -2789,7 +2789,7 @@ void commit_params(dt_iop_module_t *self,
   dt_iop_colorzones_params_t *p = (dt_iop_colorzones_params_t *)p1;
   dt_iop_colorzones_gui_data_t *g = self->gui_data;
 
-  if(pipe->type & DT_DEV_PIXELPIPE_PREVIEW)
+  if(dt_pipe_is_preview(pipe))
     piece->request_histogram |= DT_REQUEST_ON;
   else
     piece->request_histogram &= ~DT_REQUEST_ON;

--- a/src/iop/crop.c
+++ b/src/iop/crop.c
@@ -532,7 +532,7 @@ void modify_roi_out(dt_iop_module_t *self,
   roi_out->width = MAX(4, (int)odx);
   roi_out->height = MAX(4, (int)ody);
 
-  const gboolean exporting = piece->pipe->type & (DT_DEV_PIXELPIPE_EXPORT | DT_DEV_PIXELPIPE_THUMBNAIL);
+  const gboolean exporting = dt_pipe_is_export(piece->pipe) || dt_pipe_is_thumb(piece->pipe);
   const gboolean aligned = d->ratio_d != 0 && d->ratio_n != 0;
   if(!exporting || !aligned)
     return;

--- a/src/iop/crop.c
+++ b/src/iop/crop.c
@@ -609,7 +609,7 @@ int process_cl(dt_iop_module_t *self,
                const dt_iop_roi_t *const roi_in,
                const dt_iop_roi_t *const roi_out)
 {
-  size_t region[] = { roi_out->width, roi_out->height };
+  const size_t region[2] = { roi_out->width, roi_out->height };
   return dt_opencl_enqueue_copy_image(piece->pipe->devid, dev_in, dev_out, CLIMG_ORIGIN, CLIMG_ORIGIN, region);
 }
 #endif

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -279,10 +279,10 @@ static gboolean _demosaic_full(const dt_dev_pixelpipe_iop_t *const piece,
       || piece->pipe->want_detail_mask)
     return TRUE;
 
-  if(piece->pipe->type & DT_DEV_PIXELPIPE_THUMBNAIL)
+  if(dt_pipe_is_thumb(piece->pipe))
     return _get_thumb_quality(roi_out->width, roi_out->height);
 
-  if(piece->pipe->type & DT_DEV_PIXELPIPE_PREVIEW)
+  if(dt_pipe_is_preview(piece->pipe))
     return roi_out->scale > (piece->pipe->dsc.filters == 9u ? 0.667f : 0.5f);
 
   return TRUE;
@@ -650,8 +650,8 @@ void process(dt_iop_module_t *self,
 
   dt_dev_clear_scharr_mask(pipe);
 
-  const gboolean run_fast = pipe->type & (DT_DEV_PIXELPIPE_FAST | DT_DEV_PIXELPIPE_PREVIEW);
-  const gboolean fullpipe = pipe->type & DT_DEV_PIXELPIPE_FULL;
+  const gboolean run_fast = dt_pipe_is_fast(pipe) || dt_pipe_is_preview(pipe);
+  const gboolean fullpipe = dt_pipe_is_full(pipe);
 
   const uint8_t(*const xtrans)[6] = piece->xtrans;
   const dt_iop_demosaic_data_t *d = piece->data;
@@ -710,7 +710,7 @@ void process(dt_iop_module_t *self,
   }
 
   const gboolean demosaic_mask = pipe->mask_display == DT_DEV_PIXELPIPE_DISPLAY_PASSTHRU;
-  const gboolean no_masking = pipe->mask_display == DT_DEV_PIXELPIPE_DISPLAY_NONE;
+  const gboolean no_masking = dt_pipe_no_mask_display(pipe);
   const gboolean dual = (demosaicing_method & DT_DEMOSAIC_DUAL) && !run_fast && !show_sigma && !show_capture && !demosaic_mask;
   const gboolean direct = roi_out->width == width && roi_out->height == height && feqf(roi_in->scale, roi_out->scale, 1e-8f);
   const gboolean passthru = method == DT_IOP_DEMOSAIC_PASSTHROUGH_MONOCHROME
@@ -912,8 +912,8 @@ int process_cl(dt_iop_module_t *self,
 {
   const dt_image_t *img = &self->dev->image_storage;
   dt_dev_pixelpipe_t *const pipe = piece->pipe;
-  const gboolean run_fast = pipe->type & (DT_DEV_PIXELPIPE_FAST | DT_DEV_PIXELPIPE_PREVIEW);
-  const gboolean fullpipe = pipe->type & DT_DEV_PIXELPIPE_FULL;
+  const gboolean run_fast = dt_pipe_is_fast(pipe) || dt_pipe_is_preview(pipe);
+  const gboolean fullpipe = dt_pipe_is_full(pipe);
   const gboolean true_monochrome = dt_image_is_mono_sraw(img);
 
   uint8_t(*const xtrans)[6] = piece->xtrans;
@@ -1001,7 +1001,7 @@ int process_cl(dt_iop_module_t *self,
   }
 
   const gboolean direct = roi_out->width == iwidth && roi_out->height == iheight && feqf(roi_in->scale, roi_out->scale, 1e-8f);
-  const gboolean no_masking = pipe->mask_display == DT_DEV_PIXELPIPE_DISPLAY_NONE;
+  const gboolean no_masking = dt_pipe_no_mask_display(pipe);
   const gboolean demosaic_mask = pipe->mask_display == DT_DEV_PIXELPIPE_DISPLAY_PASSTHRU;
   const gboolean dual = (demosaicing_method & DT_DEMOSAIC_DUAL) && !run_fast && !show_sigma && !show_capture && !demosaic_mask;
   const gboolean passthru = method == DT_IOP_DEMOSAIC_PASSTHROUGH_MONOCHROME

--- a/src/iop/demosaicing/capture.c
+++ b/src/iop/demosaicing/capture.c
@@ -768,7 +768,7 @@ static void _capture_radius(dt_iop_module_t *self,
   dt_iop_demosaic_data_t *d = piece->data;
   dt_iop_demosaic_gui_data_t *g = self->gui_data;
   const dt_dev_pixelpipe_t *pipe = piece->pipe;
-  const gboolean fullpipe = pipe->type & DT_DEV_PIXELPIPE_FULL;
+  const gboolean fullpipe = dt_pipe_is_full(pipe);
   const dt_iop_buffer_dsc_t *dsc = &pipe->dsc;
 
   gboolean reliable;
@@ -804,7 +804,7 @@ static void _capture_noise(dt_iop_module_t *self,
   dt_iop_demosaic_gui_data_t *g = self->gui_data;
   dt_iop_demosaic_params_t *p = self->params;
   const dt_dev_pixelpipe_t *pipe = piece->pipe;
-  const gboolean fullpipe = pipe->type & DT_DEV_PIXELPIPE_FULL;
+  const gboolean fullpipe = dt_pipe_is_full(pipe);
   const float thrs = 0.01f * (int)(100.0f * _get_variance_threshold(self));
   const gboolean same_thrs = feqf(p->cs_thrs, thrs, 0.01f);
 
@@ -829,7 +829,7 @@ static inline gboolean _noise_requested(dt_iop_module_t *self,
   const dt_iop_demosaic_gui_data_t *g = self->gui_data;
   const dt_iop_demosaic_data_t *d = piece->data;
   const gboolean invalid_thrs = d->cs_thrs <= 0.0f;
-  const gboolean fullpipe = piece->pipe->type & DT_DEV_PIXELPIPE_FULL;
+  const gboolean fullpipe = dt_pipe_is_full(piece->pipe);
 
   // do we require a calculation of the noise threshold?
 
@@ -848,7 +848,7 @@ static inline gboolean _radius_requested(dt_iop_module_t *self,
   const dt_iop_demosaic_gui_data_t *g = self->gui_data;
   const dt_iop_demosaic_data_t *d = piece->data;
   const gboolean invalid_radius = d->cs_radius <= 0.0f;
-  const gboolean fullpipe = piece->pipe->type & DT_DEV_PIXELPIPE_FULL;
+  const gboolean fullpipe = dt_pipe_is_full(piece->pipe);
 
   // do we require a calculation of the capture radius?
 
@@ -882,7 +882,7 @@ static void _capture_sharpen(dt_iop_module_t *self,
   const dt_iop_demosaic_data_t *d = piece->data;
   const dt_iop_demosaic_global_data_t *gd = self->global_data;
 
-  if(pipe->type & DT_DEV_PIXELPIPE_THUMBNAIL)
+  if(dt_pipe_is_thumb(pipe))
   {
     const gboolean hqthumb = _get_thumb_quality(pipe->final_width, pipe->final_height);
     if(!hqthumb) return;
@@ -1035,7 +1035,7 @@ static int _capture_sharpen_cl(dt_iop_module_t *self,
   const dt_iop_demosaic_data_t *const d = piece->data;
   dt_iop_demosaic_global_data_t *const gd = self->global_data;
 
-  if(pipe->type & DT_DEV_PIXELPIPE_THUMBNAIL)
+  if(dt_pipe_is_thumb(pipe))
   {
     const gboolean hqthumb = _get_thumb_quality(pipe->final_width, pipe->final_height);
     if(!hqthumb) return CL_SUCCESS;

--- a/src/iop/demosaicing/xtrans.c
+++ b/src/iop/demosaicing/xtrans.c
@@ -2022,7 +2022,7 @@ static cl_int process_markesteijn_cl(const dt_iop_module_t *self,
     // note: we need to take swap of buffers into account, so current output lies in dev_t1
     if(dev_t1 != dev_tmptmp)
     {
-      size_t region[] = { width, height };
+      const size_t region[2] = { width, height };
       err = dt_opencl_enqueue_copy_image(devid, dev_t1, dev_tmptmp, CLIMG_ORIGIN, CLIMG_ORIGIN, region);
       if(err != CL_SUCCESS) goto error;
     }

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -2231,7 +2231,7 @@ static int process_wavelets_cl(dt_iop_module_t *self,
   if(npixels < 2)
   {
     // copy original input from dev_in -> dev_out
-    size_t region[] = { width, height };
+    const size_t region[2] = { width, height };
     err = dt_opencl_enqueue_copy_image(devid, dev_in, dev_out, CLIMG_ORIGIN, CLIMG_ORIGIN, region);
     if(err != CL_SUCCESS) goto error;
     free(dev_detail);
@@ -2525,7 +2525,7 @@ static int process_wavelets_cl(dt_iop_module_t *self,
   // account, so current output lies in dev_buf1
   if(dev_buf1 != dev_tmp)
   {
-    size_t region[] = { width, height };
+    const size_t region[2] = { width, height };
     err = dt_opencl_enqueue_copy_image(devid, dev_buf1, dev_tmp, CLIMG_ORIGIN, CLIMG_ORIGIN, region);
     if(err != CL_SUCCESS) goto error;
   }

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -229,7 +229,7 @@ static void debug_dump_PFM(const dt_dev_pixelpipe_iop_t *const piece,
                            const int scale)
 {
   if(!darktable.dump_pfm_module) return;
-  if((piece->pipe->type & DT_DEV_PIXELPIPE_FULL) == 0) return;
+  if(!dt_pipe_is_full(piece->pipe)) return;
 
   char name[256];
   snprintf(name, sizeof(name), namespec, scale);
@@ -1640,15 +1640,13 @@ static float nlmeans_scattering(int *nbhood,
   float scattering = d->scattering;
 
   const int maxk = (K * K * K + 7.0 * K * sqrt(K)) * scattering / 6.0 + K;
-  if(piece->pipe->type
-     & (DT_DEV_PIXELPIPE_PREVIEW | DT_DEV_PIXELPIPE_FAST | DT_DEV_PIXELPIPE_THUMBNAIL))
+  if(dt_pipe_is_fast(piece->pipe) || dt_pipe_is_preview(piece->pipe) || dt_pipe_is_thumb(piece->pipe))
   {
     // much faster but inaccurate for previews
     K = MIN(3, K);
     scattering = (maxk - K) * 6.0 / (K * K * K + 7.0 * K * sqrt(K));
   }
-  else if((piece->pipe->type & (DT_DEV_PIXELPIPE_FULL | DT_DEV_PIXELPIPE_PREVIEW2))
-          && !darktable.develop->late_scaling.enabled)
+  else if(dt_pipe_is_canvas(piece->pipe) && !darktable.develop->late_scaling.enabled)
   {
     // faster but slightly more inaccurate
     K = MAX(MIN(4, K), K * scale);
@@ -1903,7 +1901,7 @@ static void process_variance(dt_iop_module_t *self,
   size_t npixels = (size_t)width * height;
 
   dt_iop_image_copy_by_size(ovoid, ivoid, width, height, 4);
-  if((piece->pipe->type & DT_DEV_PIXELPIPE_PREVIEW) || (g == NULL))
+  if(dt_pipe_is_preview(piece->pipe) || (g == NULL))
   {
     return;
   }

--- a/src/iop/diffuse.c
+++ b/src/iop/diffuse.c
@@ -1620,7 +1620,7 @@ int process_cl(dt_iop_module_t *self,
   const int width = roi_in->width;
   const int height = roi_in->height;
 
-  size_t region[] = { width, height };
+  const size_t region[2] = { width, height };
 
   // allow fast mode, just copy input to output
   if(fastmode)

--- a/src/iop/dither.c
+++ b/src/iop/dither.c
@@ -302,7 +302,7 @@ static int _get_dither_parameters(
   int graymode = -1;
   *levels = 65536;
   const int l1 = floorf(1.0f + dt_log2f(1.0f / scale));
-  const int bds = (piece->pipe->type & DT_DEV_PIXELPIPE_EXPORT) ? 1 : l1 * l1;
+  const int bds = dt_pipe_is_export(piece->pipe) ? 1 : l1 * l1;
   switch(data->dither_type)
   {
     case DITHER_FS1BIT:
@@ -376,7 +376,7 @@ static int _get_dither_parameters(
           break;
       }
       // no automatic dithering for preview and thumbnail
-      if(piece->pipe->type & (DT_DEV_PIXELPIPE_PREVIEW | DT_DEV_PIXELPIPE_THUMBNAIL))
+      if(dt_pipe_is_preview(piece->pipe) || dt_pipe_is_thumb(piece->pipe))
       {
         graymode = -1;
       }

--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -494,7 +494,7 @@ static void _process_common_setup(dt_iop_module_t *self,
     }
 
     // second, show computed correction in UI.
-    if(g && (piece->pipe->type & DT_DEV_PIXELPIPE_PREVIEW))
+    if(g && dt_pipe_is_preview(piece->pipe))
     {
       dt_iop_gui_enter_critical_section(self);
       g->deflicker_computed_exposure = exposure;

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -2116,7 +2116,7 @@ void process(dt_iop_module_t *self,
     && mask_clipped_pixels(in, mask, data->normalize, data->reconstruct_feather, roi_out->width, roi_out->height);
 
   // display mask and exit
-  if(self->dev->gui_attached && (piece->pipe->type & DT_DEV_PIXELPIPE_FULL) && mask)
+  if(self->dev->gui_attached && dt_pipe_is_full(piece->pipe) && mask)
   {
     const dt_iop_filmicrgb_gui_data_t *g = self->gui_data;
 
@@ -2449,7 +2449,7 @@ int process_cl(dt_iop_module_t *self,
   clipped = NULL;
 
   // display mask and exit
-  if(self->dev->gui_attached && (piece->pipe->type & DT_DEV_PIXELPIPE_FULL))
+  if(self->dev->gui_attached && dt_pipe_is_full(piece->pipe))
   {
     const dt_iop_filmicrgb_gui_data_t *g = self->gui_data;
 

--- a/src/iop/finalscale.c
+++ b/src/iop/finalscale.c
@@ -159,7 +159,7 @@ int process_cl(dt_iop_module_t *self,
   }
 
   const int devid = piece->pipe->devid;
-  const gboolean exporting = piece->pipe->type == DT_DEV_PIXELPIPE_EXPORT;
+  const gboolean exporting = dt_pipe_is_export(piece->pipe);
 
   dt_print_pipe(DT_DEBUG_IMAGEIO,
                 exporting ? "clip_and_zoom_roi" : "clip_and_zoom",
@@ -178,7 +178,7 @@ void process(dt_iop_module_t *self,
              const dt_iop_roi_t *const roi_in,
              const dt_iop_roi_t *const roi_out)
 {
-  const gboolean exporting = piece->pipe->type == DT_DEV_PIXELPIPE_EXPORT;
+  const gboolean exporting = dt_pipe_is_export(piece->pipe);
   dt_print_pipe(DT_DEBUG_IMAGEIO,
                 exporting ? "clip_and_zoom_roi" : "clip_and_zoom",
                 piece->pipe, self, DT_DEVICE_CPU, roi_in, roi_out);
@@ -195,7 +195,7 @@ void commit_params(dt_iop_module_t *self,
                    dt_dev_pixelpipe_iop_t *piece)
 {
   const int use_finalscale = DT_DEV_PIXELPIPE_IMAGE | DT_DEV_PIXELPIPE_IMAGE_FINAL;
-  piece->enabled = piece->pipe->type == DT_DEV_PIXELPIPE_EXPORT
+  piece->enabled = dt_pipe_is_export(piece->pipe)
                   || (pipe->type & use_finalscale) == use_finalscale
                   || _gui_fullpipe(piece);
 }

--- a/src/iop/globaltonemap.c
+++ b/src/iop/globaltonemap.c
@@ -203,7 +203,7 @@ static inline void process_drago(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *
   // Drago needs the absolute Lmax value of the image. In pixelpipe FULL we can not reliably get this value
   // as the pixelpipe might only see part of the image (region of interest). Therefore we try to get lwmax from
   // the PREVIEW pixelpipe which luckily stores it for us.
-  if(self->dev->gui_attached && g && (piece->pipe->type & DT_DEV_PIXELPIPE_FULL))
+  if(self->dev->gui_attached && g && dt_pipe_is_full(piece->pipe))
   {
     dt_iop_gui_enter_critical_section(self);
     const dt_hash_t hash = g->hash;
@@ -238,7 +238,7 @@ static inline void process_drago(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *
   }
 
   // PREVIEW pixelpipe stores lwmax
-  if(self->dev->gui_attached && g && (piece->pipe->type & DT_DEV_PIXELPIPE_PREVIEW))
+  if(self->dev->gui_attached && g && dt_pipe_is_preview(piece->pipe))
   {
     dt_hash_t hash = dt_dev_hash_plus(self->dev, piece->pipe, self->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL);
     dt_iop_gui_enter_critical_section(self);
@@ -363,7 +363,7 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
     float tmp_lwmax = -FLT_MAX;
 
     // see comments in process() about lwmax value
-    if(self->dev->gui_attached && g && (piece->pipe->type & DT_DEV_PIXELPIPE_FULL))
+    if(self->dev->gui_attached && g && dt_pipe_is_full(piece->pipe))
     {
       dt_iop_gui_enter_critical_section(self);
       const dt_hash_t hash = g->hash;
@@ -464,7 +464,7 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
     parameters[2] = bl;
     parameters[3] = lwmax;
 
-    if(self->dev->gui_attached && g && (piece->pipe->type & DT_DEV_PIXELPIPE_PREVIEW))
+    if(self->dev->gui_attached && g && dt_pipe_is_preview(piece->pipe))
     {
       dt_hash_t hash = dt_dev_hash_plus(self->dev, piece->pipe, self->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL);
       dt_iop_gui_enter_critical_section(self);

--- a/src/iop/hazeremoval.c
+++ b/src/iop/hazeremoval.c
@@ -588,14 +588,14 @@ void process(dt_iop_module_t *self,
   const float eps = sqrtf(0.025f);    // regularization parameter for guided filter
   const gboolean compatibility_mode = d->compatibility_mode;
   const gboolean gui = self->dev->gui_attached && g;
-  const gboolean fullpipes = piece->pipe->type & (DT_DEV_PIXELPIPE_FULL | DT_DEV_PIXELPIPE_PREVIEW2);
+  const gboolean fullpipes = dt_pipe_is_canvas(piece->pipe);
   const gboolean hq = darktable.develop->late_scaling.enabled;
-  const gboolean fullhq = hq && (piece->pipe->type & DT_DEV_PIXELPIPE_FULL);
+  const gboolean fullhq = hq && dt_pipe_is_full(piece->pipe);
 
   /*  max distance and A0 for ambient light are stored and kept for the opther pipes by the preview pipe.
       If we run in HQ mode let's keep the fullpipe data too for slightly improved results.
   */
-  const gboolean storing = gui && ((piece->pipe->type & DT_DEV_PIXELPIPE_PREVIEW) || fullhq);
+  const gboolean storing = gui && (dt_pipe_is_preview(piece->pipe) || fullhq);
 
   const float *const restrict in = (float*)ivoid;
   float *const restrict out = (float*)ovoid;
@@ -864,13 +864,13 @@ int process_cl(dt_iop_module_t *self,
   const float eps = sqrtf(0.025f);    // regularization parameter for guided filter
   const gboolean compatibility_mode = d->compatibility_mode;
   const gboolean gui = self->dev->gui_attached && g;
-  const gboolean fullpipes = piece->pipe->type & (DT_DEV_PIXELPIPE_FULL | DT_DEV_PIXELPIPE_PREVIEW2);
+  const gboolean fullpipes = dt_pipe_is_canvas(piece->pipe);
   const gboolean hq = darktable.develop->late_scaling.enabled;
-  const gboolean fullhq = hq && (piece->pipe->type & DT_DEV_PIXELPIPE_FULL);
+  const gboolean fullhq = hq && dt_pipe_is_full(piece->pipe);
   /*  max distance and A0 for ambient light are stored and kept for the opther pipes by the preview pipe.
       If we run in HQ mode let's keep the fullpipe data too for slightly improved results.
   */
-  const gboolean storing = gui && ((piece->pipe->type & DT_DEV_PIXELPIPE_PREVIEW) || fullhq);
+  const gboolean storing = gui && (dt_pipe_is_preview(piece->pipe) || fullhq);
   rgb_pixel A0 = { NAN, NAN, NAN, 0.0f };
   float distance_max = NAN;
 

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -544,8 +544,8 @@ int process_cl(dt_iop_module_t *self,
       return dt_iop_clip_and_zoom_roi_cl(devid, dev_out, dev_in, roi_out, roi_in);
     else
     {
-      size_t iorigin[] = { roi_out->x, roi_out->y };
-      size_t region[] = { roi_out->width, roi_out->height };
+      const size_t iorigin[2] = { roi_out->x, roi_out->y };
+      const size_t region[2] = { roi_out->width, roi_out->height };
       return dt_opencl_enqueue_copy_image(devid, dev_in, dev_out, iorigin, CLIMG_ORIGIN, region);
     }
   }

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -550,7 +550,7 @@ int process_cl(dt_iop_module_t *self,
     }
   }
 
-  const gboolean fullpipe = pipe->type & DT_DEV_PIXELPIPE_FULL;
+  const gboolean fullpipe = dt_pipe_is_full(pipe);
   const dt_iop_highlights_mode_t dmode =  d->mode;
   const float clipper = d->clip * highlights_clip_magics[dmode];
 
@@ -832,8 +832,8 @@ void process(dt_iop_module_t *self,
     return;
   }
 
-  const gboolean fullpipe = pipe->type & DT_DEV_PIXELPIPE_FULL;
-  const gboolean fastmode = pipe->type & DT_DEV_PIXELPIPE_FAST;
+  const gboolean fullpipe = dt_pipe_is_full(pipe);
+  const gboolean fastmode = dt_pipe_is_fast(pipe);
   const dt_iop_highlights_mode_t dmode = fastmode && (d->mode == DT_IOP_HIGHLIGHTS_SEGMENTS)
                                         ? DT_IOP_HIGHLIGHTS_OPPOSED
                                         : d->mode;
@@ -876,7 +876,7 @@ void process(dt_iop_module_t *self,
 
   /* While rendering thumnbnails we look for an acceptable lower quality */
   gboolean high_quality = TRUE;
-  if(pipe->type & DT_DEV_PIXELPIPE_THUMBNAIL)
+  if(dt_pipe_is_thumb(pipe))
   {
     const dt_mipmap_size_t level = dt_mipmap_cache_get_matching_size(pipe->final_width, pipe->final_height);
     const char *min = dt_conf_get_string_const("plugins/lighttable/thumbnail_hq_min_level");
@@ -1039,7 +1039,7 @@ void commit_params(dt_iop_module_t *self,
   if((d->mode == DT_IOP_HIGHLIGHTS_SEGMENTS) || (d->mode == DT_IOP_HIGHLIGHTS_OPPOSED))
     piece->process_tiling_ready = FALSE;
 
-  const gboolean fullpipe = piece->pipe->type & DT_DEV_PIXELPIPE_FULL;
+  const gboolean fullpipe = dt_pipe_is_full(piece->pipe);
 
   dt_iop_highlights_gui_data_t *g = self->gui_data;
   if(g && (g->hlr_mask_mode == DT_HIGHLIGHTS_MASK_CLIPPED) && linear && fullpipe)

--- a/src/iop/hlreconstruct/segbased.c
+++ b/src/iop/hlreconstruct/segbased.c
@@ -457,7 +457,7 @@ static void _process_segmentation(dt_dev_pixelpipe_iop_t *piece,
 {
   const uint8_t(*const xtrans)[6] = (const uint8_t(*const)[6])piece->xtrans;
   const uint32_t filters = piece->filters;
-  const gboolean fullpipe = piece->pipe->type & DT_DEV_PIXELPIPE_FULL;
+  const gboolean fullpipe = dt_pipe_is_full(piece->pipe);
   const float clipval = MAX(0.1f, highlights_clip_magics[DT_IOP_HIGHLIGHTS_SEGMENTS] * d->clip);
 
   const dt_aligned_pixel_t icoeffs = { piece->pipe->dsc.temperature.coeffs[0], piece->pipe->dsc.temperature.coeffs[1], piece->pipe->dsc.temperature.coeffs[2]};

--- a/src/iop/hotpixels.c
+++ b/src/iop/hotpixels.c
@@ -349,7 +349,7 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
     fixed = _process_bayer(data, ivoid, ovoid, roi_out);
   }
 
-  if(g != NULL && self->dev->gui_attached && (piece->pipe->type & DT_DEV_PIXELPIPE_FULL))
+  if(g && self->dev->gui_attached && dt_pipe_is_full(piece->pipe))
   {
     g->pixels_fixed = fixed;
   }
@@ -374,7 +374,7 @@ void commit_params(dt_iop_module_t *self, dt_iop_params_t *params, dt_dev_pixelp
   d->multiplier = p->strength / 2.0;
   d->threshold = p->threshold;
   d->permissive = p->permissive;
-  d->markfixed = p->markfixed && (!(pipe->type & (DT_DEV_PIXELPIPE_EXPORT | DT_DEV_PIXELPIPE_THUMBNAIL)));
+  d->markfixed = p->markfixed && (!(dt_pipe_is_thumb(pipe) || dt_pipe_is_export(pipe)));
 
   const dt_image_t *img = &pipe->image;
   const gboolean monoraw = (img->flags & DT_IMAGE_S_RAW) && (img->flags & DT_IMAGE_MONOCHROME);

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -1896,9 +1896,7 @@ static void _commit_params_lf(dt_iop_module_t *self,
   }
 
   /* calculate which corrections will be applied by Lensfun */
-  if(self->dev->gui_attached
-     && g
-     && (piece->pipe->type & DT_DEV_PIXELPIPE_PREVIEW))
+  if(self->dev->gui_attached && g && dt_pipe_is_preview(piece->pipe))
   {
     const gboolean raw_monochrome = dt_image_is_monochrome(&self->dev->image_storage);
     const int used_lf_mask = (raw_monochrome)
@@ -2561,8 +2559,7 @@ static void _commit_params_md(dt_iop_module_t *self,
      || (d->scale_md > 2.0f)) // reset image scale if unproper data
     d->scale_md = 1.0f;
 
-  if(self->dev->gui_attached && g
-     && (piece->pipe->type & DT_DEV_PIXELPIPE_PREVIEW))
+  if(self->dev->gui_attached && g && dt_pipe_is_preview(piece->pipe))
   {
     dt_iop_gui_enter_critical_section(self);
     g->corrections_done = _check_corrections_md(d);
@@ -2577,8 +2574,7 @@ static void _commit_params_vig(dt_iop_module_t *self,
 {
   dt_iop_lens_gui_data_t *g = (dt_iop_lens_gui_data_t *)self->gui_data;
 
-  if(self->dev->gui_attached && g
-     && (piece->pipe->type & DT_DEV_PIXELPIPE_PREVIEW))
+  if(self->dev->gui_attached && g && dt_pipe_is_preview(piece->pipe))
   {
     dt_iop_gui_enter_critical_section(self);
     g->corrections_done = 0;
@@ -3009,7 +3005,7 @@ void process(dt_iop_module_t *self,
 {
   dt_iop_lens_data_t *d = (dt_iop_lens_data_t *)piece->data;
   dt_iop_lens_gui_data_t *g = (dt_iop_lens_gui_data_t *)self->gui_data;
-  const gboolean mask = g && g->vig_masking && (piece->pipe->type & DT_DEV_PIXELPIPE_FULL);
+  const gboolean mask = g && g->vig_masking && dt_pipe_is_full(piece->pipe);
   const gboolean pre_vignette = mask || (d->v_strength > 0.0f);
   const gboolean pass_mode = piece->pipe->mask_display == DT_DEV_PIXELPIPE_DISPLAY_PASSTHRU;
   float *data = (float *)ivoid;
@@ -3088,7 +3084,7 @@ int process_cl(dt_iop_module_t *self,
 
   dt_iop_lens_data_t *d = (dt_iop_lens_data_t *)piece->data;
   dt_iop_lens_gui_data_t *g = (dt_iop_lens_gui_data_t *)self->gui_data;
-  const gboolean mask = g && g->vig_masking && (piece->pipe->type & DT_DEV_PIXELPIPE_FULL);
+  const gboolean mask = g && g->vig_masking && dt_pipe_is_full(piece->pipe);
   const gboolean pre_vignette = mask || (d->v_strength > 0.0f);
   const gboolean pass_mode = piece->pipe->mask_display == DT_DEV_PIXELPIPE_DISPLAY_PASSTHRU;
 

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -1324,8 +1324,8 @@ static int _process_cl_lf(dt_iop_module_t *self,
   const float orig_w = roi_in->scale * piece->buf_in.width;
   const float orig_h = roi_in->scale * piece->buf_in.height;
 
-  size_t iregion[] = { (size_t)iwidth, (size_t)iheight };
-  size_t oregion[] = { (size_t)owidth, (size_t)oheight };
+  const size_t iregion[2] = { (size_t)iwidth, (size_t)iheight };
+  const size_t oregion[2] = { (size_t)owidth, (size_t)oheight };
 
   int modflags;
   int ldkernel = -1;
@@ -2829,7 +2829,7 @@ static int _process_cl_md(dt_iop_module_t *self,
 
   if(!d->nc || d->modify_flags == DT_IOP_LENS_MODFLAG_NONE)
   {
-    size_t oregion[] = { (size_t)roi_out->width, (size_t)roi_out->height };
+    const size_t oregion[2] = { (size_t)roi_out->width, (size_t)roi_out->height };
     return dt_opencl_enqueue_copy_image(devid, dev_in, dev_out,
                                         CLIMG_ORIGIN, CLIMG_ORIGIN, oregion);
   }
@@ -3120,7 +3120,7 @@ int process_cl(dt_iop_module_t *self,
   }
   else
   {
-    size_t region[] = { (size_t)roi_in->width, (size_t)roi_in->height };
+    const size_t region[2] = { (size_t)roi_in->width, (size_t)roi_in->height };
     err = dt_opencl_enqueue_copy_image(piece->pipe->devid, data,
                                        dev_out, CLIMG_ORIGIN, CLIMG_ORIGIN, region);
   }

--- a/src/iop/levels.c
+++ b/src/iop/levels.c
@@ -340,7 +340,7 @@ static void commit_params_late(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *pi
 
   if(d->mode == LEVELS_MODE_AUTOMATIC)
   {
-    if(g && (piece->pipe->type & DT_DEV_PIXELPIPE_FULL))
+    if(g && dt_pipe_is_full(piece->pipe))
     {
       dt_iop_gui_enter_critical_section(self);
       const dt_hash_t hash = g->hash;
@@ -362,7 +362,7 @@ static void commit_params_late(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *pi
       compute_lut(piece);
     }
 
-    if((piece->pipe->type & DT_DEV_PIXELPIPE_PREVIEW)
+    if(dt_pipe_is_preview(piece->pipe)
        || d->levels[0] == DT_LEVELS_UNINIT || d->levels[1] == DT_LEVELS_UNINIT
        || d->levels[2] == DT_LEVELS_UNINIT)
     {
@@ -370,7 +370,7 @@ static void commit_params_late(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *pi
       compute_lut(piece);
     }
 
-    if(g && (piece->pipe->type & DT_DEV_PIXELPIPE_PREVIEW) && d->mode == LEVELS_MODE_AUTOMATIC)
+    if(g && dt_pipe_is_preview(piece->pipe) && d->mode == LEVELS_MODE_AUTOMATIC)
     {
       dt_hash_t hash = dt_dev_hash_plus(self->dev, piece->pipe, self->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL);
       dt_iop_gui_enter_critical_section(self);
@@ -482,7 +482,7 @@ void commit_params(dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_
   dt_iop_levels_data_t *d = piece->data;
   dt_iop_levels_params_t *p = (dt_iop_levels_params_t *)p1;
 
-  if(pipe->type & DT_DEV_PIXELPIPE_PREVIEW)
+  if(dt_pipe_is_preview(pipe))
     piece->request_histogram |= DT_REQUEST_ON;
   else
     piece->request_histogram &= ~DT_REQUEST_ON;

--- a/src/iop/mask_manager.c
+++ b/src/iop/mask_manager.c
@@ -100,7 +100,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   const int width = roi_in->width;
   const int height = roi_in->height;
 
-  size_t region[] = { width, height };
+  const size_t region[2] = { width, height };
   return dt_opencl_enqueue_copy_image(devid, dev_in, dev_out, CLIMG_ORIGIN, CLIMG_ORIGIN, region);
 }
 #endif

--- a/src/iop/nlmeans.c
+++ b/src/iop/nlmeans.c
@@ -368,7 +368,7 @@ void process(
   const dt_aligned_pixel_t norm2 = { nL * nL, nC * nC, nC * nC, 1.0f };
 
   // faster but less accurate processing by skipping half the patches on previews and thumbnails
-  const int decimate = (piece->pipe->type & (DT_DEV_PIXELPIPE_PREVIEW | DT_DEV_PIXELPIPE_THUMBNAIL));
+  const int decimate = dt_pipe_is_preview(piece->pipe) || dt_pipe_is_thumb(piece->pipe);
 
   const dt_nlmeans_param_t params = { .scattering = 0,
                                       .scale = scale,

--- a/src/iop/overexposed.c
+++ b/src/iop/overexposed.c
@@ -403,8 +403,7 @@ void cleanup_global(dt_iop_module_so_t *self)
 void commit_params(dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_t *pipe,
                    dt_dev_pixelpipe_iop_t *piece)
 {
-  const gboolean fullpipe = piece->pipe->type & DT_DEV_PIXELPIPE_FULL;
-  piece->enabled = self->dev->overexposed.enabled && fullpipe && self->dev->gui_attached;
+  piece->enabled = self->dev->overexposed.enabled && dt_pipe_is_full(piece->pipe) && self->dev->gui_attached;
 }
 
 void init_pipe(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)

--- a/src/iop/rasterfile.c
+++ b/src/iop/rasterfile.c
@@ -501,7 +501,7 @@ int process_cl(dt_iop_module_t *self,
 {
   dt_dev_pixelpipe_t *pipe = piece->pipe;
   const ssize_t ch = pipe->dsc.filters ? 1 : 4;
-  const gboolean fullpipe = pipe->type & DT_DEV_PIXELPIPE_FULL;
+  const gboolean fullpipe = dt_pipe_is_full(pipe);
   const gboolean visual = fullpipe && dt_iop_has_focus(self);
 
   const int devid = pipe->devid;
@@ -555,7 +555,7 @@ void process(dt_iop_module_t *self,
   else
     dt_iop_copy_image_roi(out, in, ch, roi_in, roi_out);
 
-  const gboolean fullpipe = pipe->type & DT_DEV_PIXELPIPE_FULL;
+  const gboolean fullpipe = dt_pipe_is_full(pipe);
   const gboolean request = dt_iop_is_raster_mask_used(piece->module, BLEND_RASTER_ID);
   const gboolean visual = fullpipe && dt_iop_has_focus(self);
   float *mask = visual || request ? _get_rasterfile_mask(piece, roi_in, roi_out) : NULL;

--- a/src/iop/rasterfile.c
+++ b/src/iop/rasterfile.c
@@ -513,8 +513,8 @@ int process_cl(dt_iop_module_t *self,
     err = dt_iop_clip_and_zoom_cl(devid, dev_out, dev_in, roi_out, roi_in);
   else
   {
-    size_t iorigin[] = { roi_out->x, roi_out->y };
-    size_t region[] = { roi_out->width, roi_out->height };
+    const size_t iorigin[2] = { roi_out->x, roi_out->y };
+    const size_t region[2] = { roi_out->width, roi_out->height };
     err = dt_opencl_enqueue_copy_image(devid, dev_in, dev_out, iorigin, CLIMG_ORIGIN, region);
   }
 

--- a/src/iop/rawoverexposed.c
+++ b/src/iop/rawoverexposed.c
@@ -389,7 +389,7 @@ void commit_params(dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_
   dt_develop_t *dev = self->dev;
 
   const dt_image_t *const image = &(dev->image_storage);
-  const gboolean fullpipe = piece->pipe->type & DT_DEV_PIXELPIPE_FULL;
+  const gboolean fullpipe = dt_pipe_is_full(piece->pipe);
   const gboolean sensorok = (image->flags & DT_IMAGE_4BAYER) == 0;
 
   piece->enabled = dev->rawoverexposed.enabled && fullpipe && dev->gui_attached && sensorok;

--- a/src/iop/rawoverexposed.c
+++ b/src/iop/rawoverexposed.c
@@ -251,7 +251,7 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
   const int width = roi_out->width;
   const int height = roi_out->height;
 
-  size_t region[] = { width, height };
+  const size_t region[2] = { width, height };
 
   process_common_setup(self, piece);
 

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -3807,7 +3807,7 @@ void process(dt_iop_module_t *self,
   // init the decompose routine
   dwt_p = dt_dwt_init(in_retouch, roi_rt->width, roi_rt->height, 4, p->num_scales,
                       (!display_wavelet_scale
-                       || !(piece->pipe->type & DT_DEV_PIXELPIPE_FULL))
+                       || !dt_pipe_is_full(piece->pipe))
                       ? 0
                       : p->curr_scale,
                       p->merge_from_scale, &usr_data,
@@ -3815,7 +3815,7 @@ void process(dt_iop_module_t *self,
   if(dwt_p == NULL) goto cleanup;
 
   // check if this module should expose mask.
-  if((piece->pipe->type & DT_DEV_PIXELPIPE_FULL) && g
+  if(dt_pipe_is_full(piece->pipe) && g
      && (g->mask_display || display_wavelet_scale)
      && dt_iop_has_focus(self) && (piece->pipe == self->dev->full.pipe))
   {
@@ -3828,7 +3828,7 @@ void process(dt_iop_module_t *self,
     usr_data.mask_display = TRUE;
   }
 
-  if(piece->pipe->type & DT_DEV_PIXELPIPE_FULL)
+  if(dt_pipe_is_full(piece->pipe))
   {
     // check if the image support this number of scales
     if(dt_iop_has_focus(self))
@@ -3851,7 +3851,7 @@ void process(dt_iop_module_t *self,
                                 p->preview_levels[2] };
 
   // process auto levels
-  if(g && (piece->pipe->type & DT_DEV_PIXELPIPE_FULL))
+  if(g && dt_pipe_is_full(piece->pipe))
   {
     dt_iop_gui_enter_critical_section(self);
     if(g->preview_auto_levels == 1 && !darktable.gui->reset)
@@ -4614,8 +4614,7 @@ int process_cl(dt_iop_module_t *self,
 
   // init the decompose routine
   dwt_p = dt_dwt_init_cl(devid, in_retouch, roi_rt->width, roi_rt->height, p->num_scales,
-                         (!display_wavelet_scale
-                          || !(piece->pipe->type & DT_DEV_PIXELPIPE_FULL))
+                         (!display_wavelet_scale || !dt_pipe_is_full(piece->pipe))
                          ? 0 : p->curr_scale,
                          p->merge_from_scale,
                          &usr_data,
@@ -4627,7 +4626,7 @@ int process_cl(dt_iop_module_t *self,
   }
 
   // check if this module should expose mask.
-  if((piece->pipe->type & DT_DEV_PIXELPIPE_FULL)
+  if(dt_pipe_is_full(piece->pipe)
      && g && g->mask_display
      && dt_iop_has_focus(self)
      && (piece->pipe == self->dev->full.pipe))
@@ -4645,7 +4644,7 @@ int process_cl(dt_iop_module_t *self,
     usr_data.mask_display = TRUE;
   }
 
-  if(piece->pipe->type & DT_DEV_PIXELPIPE_FULL)
+  if(dt_pipe_is_full(piece->pipe))
   {
     // check if the image support this number of scales
     if(dt_iop_has_focus(self))
@@ -4669,7 +4668,7 @@ int process_cl(dt_iop_module_t *self,
                                 p->preview_levels[2] };
 
   // process auto levels
-  if(g && (piece->pipe->type & DT_DEV_PIXELPIPE_FULL))
+  if(g && dt_pipe_is_full(piece->pipe))
   {
     dt_iop_gui_enter_critical_section(self);
     if(g->preview_auto_levels == 1 && !darktable.gui->reset)

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -4596,7 +4596,7 @@ int process_cl(dt_iop_module_t *self,
 
   // copy input image to the new buffer
   {
-    size_t region[] = { roi_rt->width, roi_rt->height };
+    const size_t region[2] = { roi_rt->width, roi_rt->height };
     err = dt_opencl_enqueue_copy_image_to_buffer(devid, dev_in, in_retouch, CLIMG_ORIGIN, region, 0);
     if(err != CL_SUCCESS) goto cleanup;
   }

--- a/src/iop/rgbcurve.c
+++ b/src/iop/rgbcurve.c
@@ -1748,7 +1748,7 @@ void commit_params(dt_iop_module_t *self,
   dt_iop_rgbcurve_data_t *d = piece->data;
   dt_iop_rgbcurve_params_t *p = (dt_iop_rgbcurve_params_t *)p1;
 
-  if(pipe->type & DT_DEV_PIXELPIPE_PREVIEW)
+  if(dt_pipe_is_preview(pipe))
   {
     piece->request_histogram |= DT_REQUEST_ON;
     self->histogram_middle_grey = p->compensate_middle_grey;

--- a/src/iop/rgblevels.c
+++ b/src/iop/rgblevels.c
@@ -847,7 +847,7 @@ void commit_params(dt_iop_module_t *self,
   dt_iop_rgblevels_data_t *d = piece->data;
   dt_iop_rgblevels_params_t *p = (dt_iop_rgblevels_params_t *)p1;
 
-  if(pipe->type & DT_DEV_PIXELPIPE_PREVIEW)
+  if(dt_pipe_is_preview(pipe))
     piece->request_histogram |= DT_REQUEST_ON;
   else
     piece->request_histogram &= ~DT_REQUEST_ON;
@@ -1267,7 +1267,7 @@ void process(dt_iop_module_t *self,
     dt_ioppr_get_pipe_work_profile_info(piece->pipe);
 
   // process auto levels
-  if(g && (piece->pipe->type & DT_DEV_PIXELPIPE_PREVIEW))
+  if(g && dt_pipe_is_preview(piece->pipe))
   {
     dt_iop_gui_enter_critical_section(self);
     if(g->call_auto_levels == 1 && !darktable.gui->reset)
@@ -1420,7 +1420,7 @@ int process_cl(dt_iop_module_t *self,
   const int height = roi_out->height;
 
   // process auto levels
-  if(g && (piece->pipe->type & DT_DEV_PIXELPIPE_PREVIEW))
+  if(g && dt_pipe_is_preview(piece->pipe))
   {
     dt_iop_gui_enter_critical_section(self);
     if(g->call_auto_levels == 1 && !darktable.gui->reset)

--- a/src/iop/sharpen.c
+++ b/src/iop/sharpen.c
@@ -141,7 +141,7 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
 
   if(rad == 0)
   {
-    size_t region[] = { width, height };
+    const size_t region[2] = { width, height };
     err = dt_opencl_enqueue_copy_image(devid, dev_in, dev_out, CLIMG_ORIGIN, CLIMG_ORIGIN, region);
     if(err != CL_SUCCESS) goto error;
     return CL_SUCCESS;
@@ -151,7 +151,7 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
   // normally not needed for OpenCL but implemented here for identity with CPU code path
   if(width < 2 * rad + 1 || height < 2 * rad + 1)
   {
-    size_t region[] = { width, height };
+    const size_t region[2] = { width, height };
     err = dt_opencl_enqueue_copy_image(devid, dev_in, dev_out, CLIMG_ORIGIN, CLIMG_ORIGIN, region);
     if(err != CL_SUCCESS) goto error;
     return CL_SUCCESS;

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -723,7 +723,7 @@ void commit_params(dt_iop_module_t *self,
   */
   chr->late_correction = p->preset == DT_IOP_TEMP_D65_LATE;
   chr->temperature = piece->enabled ? self : NULL;
-  if(pipe->type & DT_DEV_PIXELPIPE_PREVIEW && !piece->enabled)
+  if(dt_pipe_is_preview(pipe) && !piece->enabled)
     dt_iop_set_module_trouble_message(self, NULL, NULL, NULL);
 }
 

--- a/src/iop/tonecurve.c
+++ b/src/iop/tonecurve.c
@@ -726,7 +726,7 @@ void commit_params(dt_iop_module_t *self,
   dt_iop_tonecurve_data_t *d = piece->data;
   dt_iop_tonecurve_params_t *p = (dt_iop_tonecurve_params_t *)p1;
 
-  if(pipe->type & DT_DEV_PIXELPIPE_PREVIEW)
+  if(dt_pipe_is_preview(pipe))
     piece->request_histogram |= DT_REQUEST_ON;
   else
     piece->request_histogram &= ~DT_REQUEST_ON;

--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -1033,7 +1033,7 @@ void toneeq_process(dt_iop_module_t *self,
       dt_iop_gui_leave_critical_section(self);
     }
 
-    if(piece->pipe->type & DT_DEV_PIXELPIPE_FULL)
+    if(dt_pipe_is_full(piece->pipe))
     {
       // For DT_DEV_PIXELPIPE_FULL, we cache the luminance mask for performance
       // but it's not accessed from GUI
@@ -1051,7 +1051,7 @@ void toneeq_process(dt_iop_module_t *self,
       luminance = g->full_preview_buf;
       cached = TRUE;
     }
-    else if(piece->pipe->type & DT_DEV_PIXELPIPE_PREVIEW)
+    else if(dt_pipe_is_preview(piece->pipe))
     {
       // For DT_DEV_PIXELPIPE_PREVIEW, we need to cache it too to
       // compute the full image stats upon user request in GUI threads
@@ -1097,7 +1097,7 @@ void toneeq_process(dt_iop_module_t *self,
   {
     // caching path : store the luminance mask for GUI access
 
-    if(piece->pipe->type & DT_DEV_PIXELPIPE_FULL)
+    if(dt_pipe_is_full(piece->pipe))
     {
       dt_hash_t saved_hash;
       hash_set_get(&g->ui_preview_hash, &saved_hash, &self->gui_lock);
@@ -1113,7 +1113,7 @@ void toneeq_process(dt_iop_module_t *self,
         hash_set_get(&hash, &g->ui_preview_hash, &self->gui_lock);
       }
     }
-    else if(piece->pipe->type & DT_DEV_PIXELPIPE_PREVIEW)
+    else if(dt_pipe_is_preview(piece->pipe))
     {
       dt_hash_t saved_hash;
       hash_set_get(&g->thumb_preview_hash, &saved_hash, &self->gui_lock);
@@ -1146,7 +1146,7 @@ void toneeq_process(dt_iop_module_t *self,
   }
 
   // Display output
-  if(self->dev->gui_attached && (piece->pipe->type & DT_DEV_PIXELPIPE_FULL))
+  if(self->dev->gui_attached && dt_pipe_is_full(piece->pipe))
   {
     if(g->mask_display)
     {

--- a/src/iop/velvia.c
+++ b/src/iop/velvia.c
@@ -216,7 +216,7 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
 
   if(strength <= 0.0f)
   {
-    size_t region[] = { width, height };
+    const size_t region[2] = { width, height };
     err = dt_opencl_enqueue_copy_image(devid, dev_in, dev_out, CLIMG_ORIGIN, CLIMG_ORIGIN, region);
   }
   else

--- a/src/iop/zonesystem.c
+++ b/src/iop/zonesystem.c
@@ -159,7 +159,7 @@ static void process_common_setup(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *
   const int width = roi_out->width;
   const int height = roi_out->height;
 
-  if(self->dev->gui_attached && (piece->pipe->type & DT_DEV_PIXELPIPE_PREVIEW))
+  if(self->dev->gui_attached && dt_pipe_is_preview(piece->pipe))
   {
     dt_iop_zonesystem_gui_data_t *g = self->gui_data;
     dt_iop_gui_enter_critical_section(self);
@@ -193,7 +193,7 @@ static void process_common_cleanup(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t
 
   /* if gui and have buffer lets gaussblur and fill buffer with zone indexes */
   if(self->dev->gui_attached
-     && (piece->pipe->type & DT_DEV_PIXELPIPE_PREVIEW)
+     && dt_pipe_is_preview(piece->pipe)
      && g && g->in_preview_buffer
      && g->out_preview_buffer)
   {


### PR DESCRIPTION
**Pipe type checking maintenance**

Make use of the recently introduced pipe->type checks like dt_pipe_is_preview() all over the code base. (A few more tests have been added ...)

Note: there are a few cases where we check for "pipe-identity" that need further investigation.

**More OpenCL high level maintenance**

Use const and defined sizes where appropriate.