### PR TITLE
Fix a misleading flag in OpenCL per device config

### DIFF
--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -342,7 +342,9 @@ void dt_opencl_write_device_config(const int devid)
   g_snprintf(dat, 510, "%i %i %i %i %i %.3f %.3f",
     cl->dev[devid].micro_nap,
     cl->dev[devid].pinned_memory,
-    cl->dev[devid].use_events ? DT_OPENCL_EVENTS : 0,
+
+    // this used to define the number of slots, now a bool and using DT_OPENCL_EVENTS if true
+    cl->dev[devid].use_events ? 1 : 0,
     cl->dev[devid].asyncmode,
     cl->dev[devid].disabled,
     cl->dev[devid].advantage,


### PR DESCRIPTION
The per-device setting for events is in fact just a boolean flag. If set, dt will use OpenCL events when calling enqueue kernels (but the number of slots in internal structures is not exposed any more and can't be "tuned" by users).

Why?
Principally the maximum number of allowed events not removed from the device internal list is not restricted but we had a lot of issues with high numbers. Let's stay somewhat conservative here! (We can't check what is allowed via the OpenCL api)

Also - users might be inclined to increase this in hope for better performance, that is definitely not the case! Instead it put's extra burden on dt and the device.

@Phemisters this is the fix for the misleading entry in per device conf settings :-)