### PR TITLE
[GUI] Improve warning about non-linear profile in EXR export

### DIFF
--- a/src/imageio/format/exr.cc
+++ b/src/imageio/format/exr.cc
@@ -243,7 +243,7 @@ int write_image(dt_imageio_module_data_t *tmp,
   goto icc_end;
 
 icc_error:
-  dt_control_log(_("the selected output profile doesn't work well with EXR"));
+  dt_control_log(_("the selected output profile isn't linear, expect incorrect display by image viewers"));
   dt_print(DT_DEBUG_ALWAYS,
            "[exr export] warning: exporting with anything but linear matrix profiles "
            "might lead to wrong results when opening the image\n");


### PR DESCRIPTION
When I was adding new compression types to EXR export I noticed a scary, but without any specific information warning in the control_log:
```
the selected output profile doesn't work well with EXR
```
This PR corrects the wording, clearly explaining what is wrong with the profile and the consequences of choosing a nonlinear profile:

```
the selected output profile isn't linear, expect incorrect display by image viewers
```