### PR TITLE
Remove remnants of OPENMP SIMD codepath in darktable configuration XML

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -3849,13 +3849,6 @@
     <longdescription>if more images are display in expose mode, zooming will be deactivated</longdescription>
   </dtconfig>
   <dtconfig>
-    <name>codepaths/openmp_simd</name>
-    <type>bool</type>
-    <default>false</default>
-    <shortdescription>enable usage of OpenMP SIMD codepaths. if enabled, and such codepath exists, it will have the highest priority</shortdescription>
-    <longdescription></longdescription>
-  </dtconfig>
-  <dtconfig>
     <name>allow_lab_output</name>
     <type>bool</type>
     <default>false</default>


### PR DESCRIPTION
Just a follow-up to what was done in #13875.