### PR TITLE
[AI] Neural restore: switch to static-shape models with CPU fallback

### DIFF
--- a/src/ai/backend.h
+++ b/src/ai/backend.h
@@ -184,6 +184,10 @@ typedef struct dt_ai_model_info_t {
   const char *backend;     ///< Backend type (e.g. "onnx")
   int num_inputs;          ///< Number of model inputs (default 1)
   const char *attributes;  ///< Optional attributes
+  const char *cpu_only;    ///< Top-level cpu_only block (JSON: array or object).
+                           ///< Consumed internally by the load function to
+                           ///< override the provider when the model declares
+                           ///< the configured EP unsafe.
 } dt_ai_model_info_t;
 
 /* --- Model "attributes" lookup ---
@@ -314,10 +318,18 @@ typedef struct {
  * @param env Library environment.
  * @param model_id ID of the model to load.
  * @param model_file Filename within the model directory (NULL = "model.onnx").
+ *                   When the model package declares per-file cpu_only entries,
+ *                   matching is done against this filename's stem (the
+ *                   basename minus the ".onnx" extension).
  * @param provider Execution provider (DT_AI_PROVIDER_CONFIGURED = use user config).
+ *                 The load function may override this to CPU when the model
+ *                 declares the configured GPU EP unsafe (see cpu_only attribute).
  * @param opt_level Graph optimization level.
  * @param dim_overrides Array of symbolic dimension overrides (NULL = none).
  * @param n_overrides Number of overrides.
+ * @param ep_flags EP-specific flag bitmask. Callers should pass 0; the
+ *                 load function adds bits internally based on the model's
+ *                 cpu_only declaration (e.g. COREML_FLAG_USE_CPU_ONLY).
  * @return dt_ai_context_t* Context ready for inference, or NULL.
  */
 dt_ai_context_t *dt_ai_load_model_ext(dt_ai_environment_t *env,

--- a/src/ai/backend_common.c
+++ b/src/ai/backend_common.c
@@ -173,6 +173,29 @@ static void _scan_directory(dt_ai_environment_t *env, const char *root_path)
                 }
               }
 
+              // capture top-level "cpu_only" (sibling to "attributes")
+              // as a JSON string; can be either an array (applies to all
+              // models in the package) or an object (keyed by onnx filename)
+              info->cpu_only = NULL;
+              if(json_object_has_member(obj, "cpu_only"))
+              {
+                JsonNode *co_node = json_object_get_member(obj, "cpu_only");
+                if(co_node
+                   && (JSON_NODE_HOLDS_ARRAY(co_node)
+                       || JSON_NODE_HOLDS_OBJECT(co_node)))
+                {
+                  JsonGenerator *gen = json_generator_new();
+                  json_generator_set_root(gen, co_node);
+                  gchar *s = json_generator_to_data(gen, NULL);
+                  if(s)
+                  {
+                    _store_string(env, s, &info->cpu_only);
+                    g_free(s);
+                  }
+                  g_object_unref(gen);
+                }
+              }
+
               env->models = g_list_prepend(env->models, info);
               g_hash_table_insert(
                 env->model_paths,
@@ -360,6 +383,10 @@ dt_ai_onnx_load_ext(const char *model_dir, const char *model_file,
                     const dt_ai_dim_override_t *dim_overrides, int n_overrides,
                     uint32_t ep_flags);
 
+static gboolean _provider_cpu_only(const dt_ai_model_info_t *info,
+                                   const char *model_file,
+                                   dt_ai_provider_t configured);
+
 // model loading with backend dispatch
 
 dt_ai_context_t *dt_ai_load_model(dt_ai_environment_t *env,
@@ -398,6 +425,47 @@ dt_ai_context_t *dt_ai_load_model_ext(dt_ai_environment_t *env,
     char *prov_str = dt_conf_get_string(DT_AI_CONF_PROVIDER);
     provider = dt_ai_provider_from_string(prov_str);
     g_free(prov_str);
+  }
+
+  // EP safety: if the model declares the configured provider unsafe via
+  // its cpu_only attribute, override the load to fall back to CPU. on
+  // CoreML this stays inside the EP via USE_CPU_ONLY (preserves BNNS
+  // kernels); on every other GPU EP we load with the plain CPU EP. AUTO
+  // and CPU providers are exempt from the check
+  const dt_ai_model_info_t *model_info
+    = dt_ai_get_model_info_by_id(env, model_id);
+  if(model_info
+     && _provider_cpu_only(model_info, model_file, provider))
+  {
+    const char *prov_name = NULL;
+    for(int i = 0; i < DT_AI_PROVIDER_COUNT; i++)
+      if(dt_ai_providers[i].value == provider)
+      {
+        prov_name = dt_ai_providers[i].config_string;
+        break;
+      }
+    if(provider == DT_AI_PROVIDER_COREML)
+    {
+      ep_flags |= 1;  // COREML_FLAG_USE_CPU_ONLY
+      dt_print(DT_DEBUG_AI,
+               "[darktable_ai] model %s%s%s prefers CPU on %s; "
+               "using CoreML CPU compute units",
+               model_id,
+               model_file ? " file=" : "",
+               model_file ? model_file : "",
+               prov_name);
+    }
+    else
+    {
+      dt_print(DT_DEBUG_AI,
+               "[darktable_ai] model %s%s%s prefers CPU on %s; "
+               "switching to CPU provider",
+               model_id,
+               model_file ? " file=" : "",
+               model_file ? model_file : "",
+               prov_name);
+      provider = DT_AI_PROVIDER_CPU;
+    }
   }
 
   g_mutex_lock(&env->lock);
@@ -570,6 +638,88 @@ int *dt_ai_model_attribute_int_array(const dt_ai_model_info_t *info,
     }
   }
   if(p) g_object_unref(p);
+  return result;
+}
+
+// resolve the model's "cpu_only" block against `configured`. the block
+// can take two forms:
+//
+//   cpu_only: [coreml, directml]        (flat list — applies to all)
+//   cpu_only:                           (keyed by onnx filename stem)
+//     model_bayer: [coreml, directml]
+//     model_linear: []
+//
+// when `configured` appears (case-insensitively) in the relevant list,
+// the model declares it unsafe and the caller (dt_ai_load_model_ext)
+// overrides the load: CoreML keeps the EP but sets USE_CPU_ONLY; any
+// other GPU EP is replaced by DT_AI_PROVIDER_CPU. returns FALSE for
+// AUTO/CPU providers, missing block, or providers not in the list
+static gboolean _provider_cpu_only(const dt_ai_model_info_t *info,
+                                   const char *model_file,
+                                   dt_ai_provider_t configured)
+{
+  if(!info || !info->cpu_only
+     || configured == DT_AI_PROVIDER_AUTO
+     || configured == DT_AI_PROVIDER_CPU
+     || configured == DT_AI_PROVIDER_CONFIGURED)
+    return FALSE;
+
+  // map provider enum to its config_string (e.g. "CoreML", "DirectML")
+  const char *prov_name = NULL;
+  for(int i = 0; i < DT_AI_PROVIDER_COUNT; i++)
+    if(dt_ai_providers[i].value == configured)
+    {
+      prov_name = dt_ai_providers[i].config_string;
+      break;
+    }
+  if(!prov_name) return FALSE;
+
+  JsonParser *parser = json_parser_new();
+  gboolean result = FALSE;
+  if(json_parser_load_from_data(parser, info->cpu_only, -1, NULL))
+  {
+    JsonNode *root = json_parser_get_root(parser);
+
+    // "cpu_only" can be either a flat array (applies to every model in
+    // the package) or an object keyed by onnx filename stem — the
+    // basename without the ".onnx" extension. dropping the extension
+    // keeps the YAML readable (no quoting needed for keys with dots)
+    JsonArray *arr = NULL;
+    gchar *stem = NULL;
+    if(root && JSON_NODE_HOLDS_ARRAY(root))
+    {
+      arr = json_node_get_array(root);
+    }
+    else if(root && JSON_NODE_HOLDS_OBJECT(root) && model_file)
+    {
+      const char *dot = strrchr(model_file, '.');
+      stem = dot ? g_strndup(model_file, dot - model_file)
+                 : g_strdup(model_file);
+      JsonObject *obj = json_node_get_object(root);
+      if(json_object_has_member(obj, stem))
+      {
+        JsonNode *vn = json_object_get_member(obj, stem);
+        if(vn && JSON_NODE_HOLDS_ARRAY(vn))
+          arr = json_node_get_array(vn);
+      }
+    }
+
+    if(arr)
+    {
+      const guint n = json_array_get_length(arr);
+      for(guint i = 0; i < n; i++)
+      {
+        const gchar *s = json_array_get_string_element(arr, i);
+        if(s && !g_ascii_strcasecmp(s, prov_name))
+        {
+          result = TRUE;
+          break;
+        }
+      }
+    }
+    g_free(stem);
+  }
+  g_object_unref(parser);
   return result;
 }
 

--- a/src/ai/backend_onnx.c
+++ b/src/ai/backend_onnx.c
@@ -62,6 +62,9 @@ struct dt_ai_context_t
 // this in lockstep with any model that requires a newer opset
 #define DT_ORT_MIN_API_VERSION 14
 
+// cache size for per-device VRAM lookups; ORT also uses a uint32 device id
+#define DT_AI_MAX_CUDA_DEVICES 8
+
 // global singletons (initialized exactly once via g_once)
 // ORT requires at most one OrtEnv per process.
 static const OrtApi *g_ort = NULL;
@@ -267,9 +270,67 @@ gboolean dt_ai_device_id_changed_since_load(const dt_ai_provider_t provider)
   return cur != loaded;
 }
 
-// shell out to a command and return its stdout. caller frees. NULL on failure
+// shell out to a command and return its stdout (caller frees, NULL on failure).
+// Windows path uses CreateProcessA directly so a GUI-subsystem parent doesn't
+// flash a console window when spawning console children (nvidia-smi, rocminfo).
+// caller must pass an ASCII command without quoted paths -- the Windows
+// branch doesn't shell-tokenize and Linux's g_spawn parses different rules
 static gchar *_run_capture(const char *cmd)
 {
+#ifdef _WIN32
+  SECURITY_ATTRIBUTES sa = { 0 };
+  sa.nLength = sizeof(sa);
+  sa.bInheritHandle = TRUE;
+
+  HANDLE rd = NULL, wr = NULL;
+  if(!CreatePipe(&rd, &wr, &sa, 0))
+    return NULL;
+  // read end must not be inherited or ReadFile never sees EOF
+  SetHandleInformation(rd, HANDLE_FLAG_INHERIT, 0);
+
+  STARTUPINFOA si = { 0 };
+  si.cb = sizeof(si);
+  si.dwFlags = STARTF_USESHOWWINDOW | STARTF_USESTDHANDLES;
+  si.wShowWindow = SW_HIDE;
+  si.hStdOutput = wr;
+  si.hStdError = wr;
+  si.hStdInput = NULL;
+
+  PROCESS_INFORMATION pi = { 0 };
+  // CreateProcessA writes into the cmdline buffer
+  gchar *cmdline = g_strdup(cmd);
+  const BOOL ok = CreateProcessA(NULL, cmdline,
+                                 NULL, NULL, TRUE,
+                                 CREATE_NO_WINDOW,
+                                 NULL, NULL, &si, &pi);
+  g_free(cmdline);
+  CloseHandle(wr);
+  if(!ok)
+  {
+    CloseHandle(rd);
+    return NULL;
+  }
+
+  GString *out = g_string_new(NULL);
+  char buf[4096];
+  DWORD n = 0;
+  while(ReadFile(rd, buf, sizeof(buf), &n, NULL) && n > 0)
+    g_string_append_len(out, buf, (gssize)n);
+  CloseHandle(rd);
+
+  WaitForSingleObject(pi.hProcess, INFINITE);
+  DWORD exit_code = 0;
+  GetExitCodeProcess(pi.hProcess, &exit_code);
+  CloseHandle(pi.hProcess);
+  CloseHandle(pi.hThread);
+
+  if(exit_code != 0)
+  {
+    g_string_free(out, TRUE);
+    return NULL;
+  }
+  return g_string_free(out, FALSE);
+#else
   gchar *out = NULL;
   GError *err = NULL;
   gint exit_status = 0;
@@ -285,6 +346,7 @@ static gchar *_run_capture(const char *cmd)
     return NULL;
   }
   return out;
+#endif
 }
 
 // CUDA device enumeration via nvidia-smi. respects CUDA_VISIBLE_DEVICES
@@ -1295,6 +1357,137 @@ static int _device_id_from_conf(const char *conf_key, const char *env_var)
   return 0;
 }
 
+// query total VRAM for a CUDA device via nvidia-smi, cached per device.
+// returns 0 on failure
+G_LOCK_DEFINE_STATIC(cuda_vram_cache);
+static size_t _cuda_total_vram_bytes(int device_id)
+{
+  static size_t cached[DT_AI_MAX_CUDA_DEVICES] = { 0 };
+  static gboolean queried[DT_AI_MAX_CUDA_DEVICES] = { FALSE };
+  if(device_id < 0 || device_id >= DT_AI_MAX_CUDA_DEVICES) return 0;
+
+  G_LOCK(cuda_vram_cache);
+  if(queried[device_id])
+  {
+    const size_t hit = cached[device_id];
+    G_UNLOCK(cuda_vram_cache);
+    return hit;
+  }
+  G_UNLOCK(cuda_vram_cache);
+
+  gchar *cmd = g_strdup_printf(
+    "nvidia-smi --query-gpu=memory.total "
+    "--format=csv,noheader,nounits -i %d", device_id);
+  gchar *out = _run_capture(cmd);
+  g_free(cmd);
+
+  size_t bytes = 0;
+  if(out)
+  {
+    const long mb = atol(g_strstrip(out));
+    if(mb > 0) bytes = (size_t)mb * 1024UL * 1024UL;
+    g_free(out);
+  }
+
+  G_LOCK(cuda_vram_cache);
+  cached[device_id] = bytes;
+  queried[device_id] = TRUE;
+  G_UNLOCK(cuda_vram_cache);
+  return bytes;
+}
+
+// gpu_mem_limit (bytes) for CUDA EP. precedence:
+//   env DT_CUDA_MEM_LIMIT_MB > conf plugins/ai/cuda_mem_limit_mb > 75% VRAM.
+// returns 0 = no cap
+static size_t _cuda_mem_limit_bytes(int device_id)
+{
+  const char *env = g_getenv("DT_CUDA_MEM_LIMIT_MB");
+  if(env && env[0])
+  {
+    const long mb = atol(env);
+    if(mb > 0) return (size_t)mb * 1024UL * 1024UL;
+  }
+  if(dt_conf_key_exists("plugins/ai/cuda_mem_limit_mb"))
+  {
+    const int mb = dt_conf_get_int("plugins/ai/cuda_mem_limit_mb");
+    if(mb > 0) return (size_t)mb * 1024UL * 1024UL;
+  }
+  const size_t total = _cuda_total_vram_bytes(device_id);
+  if(total == 0) return 0;
+  return total - total / 4;
+}
+
+// configure CUDA EP via V2 options API. HEURISTIC algo search and
+// kSameAsRequested arena avoid a per-Run VRAM leak observed on Blackwell
+// (large cuDNN workspaces not returning to the arena between Runs).
+// returns FALSE if V2 setup fails so callers can fall back to V1
+static gboolean _try_cuda_v2(OrtSessionOptions *session_opts, int device_id)
+{
+  if(!g_ort
+     || !g_ort->CreateCUDAProviderOptions
+     || !g_ort->UpdateCUDAProviderOptions
+     || !g_ort->SessionOptionsAppendExecutionProvider_CUDA_V2
+     || !g_ort->ReleaseCUDAProviderOptions)
+    return FALSE;
+
+#if defined(__linux__)
+  if(!_check_cuda_driver_compat()) return FALSE;
+#endif
+
+  dt_print(DT_DEBUG_AI, "[darktable_ai] attempting to enable NVIDIA CUDA (V2)...");
+
+  OrtCUDAProviderOptionsV2 *opts = NULL;
+  OrtStatus *st = g_ort->CreateCUDAProviderOptions(&opts);
+  if(st)
+  {
+    g_ort->ReleaseStatus(st);
+    return FALSE;
+  }
+
+  const size_t cap = _cuda_mem_limit_bytes(device_id);
+  gchar *dev_str = g_strdup_printf("%d", device_id);
+  gchar *cap_str = cap ? g_strdup_printf("%zu", cap) : NULL;
+
+  const char *keys[4];
+  const char *vals[4];
+  int n = 0;
+  keys[n] = "device_id";                vals[n++] = dev_str;
+  keys[n] = "arena_extend_strategy";    vals[n++] = "kSameAsRequested";
+  keys[n] = "cudnn_conv_algo_search";   vals[n++] = "HEURISTIC";
+  if(cap_str) { keys[n] = "gpu_mem_limit"; vals[n++] = cap_str; }
+
+  st = g_ort->UpdateCUDAProviderOptions(opts, keys, vals, n);
+  g_free(dev_str);
+  g_free(cap_str);
+  if(st)
+  {
+    dt_print(DT_DEBUG_AI, "[darktable_ai] CUDA V2 UpdateOptions failed: %s",
+             g_ort->GetErrorMessage(st));
+    g_ort->ReleaseStatus(st);
+    g_ort->ReleaseCUDAProviderOptions(opts);
+    return FALSE;
+  }
+
+  st = g_ort->SessionOptionsAppendExecutionProvider_CUDA_V2(session_opts, opts);
+  g_ort->ReleaseCUDAProviderOptions(opts);
+  if(st)
+  {
+    dt_print(DT_DEBUG_AI, "[darktable_ai] CUDA V2 append failed: %s",
+             g_ort->GetErrorMessage(st));
+    g_ort->ReleaseStatus(st);
+    return FALSE;
+  }
+
+  gchar *dev_name = _lookup_device_name(DT_AI_PROVIDER_CUDA, device_id);
+  dt_print(DT_DEBUG_AI,
+           "[darktable_ai] NVIDIA CUDA enabled successfully on device %d: %s "
+           "(mem_limit=%zu MB, algo=HEURISTIC, arena=kSameAsRequested)",
+           device_id, dev_name ? dev_name : "?",
+           cap ? cap / (1024UL * 1024UL) : 0);
+  g_free(dev_name);
+  return TRUE;
+}
+
 static void
 _enable_acceleration(OrtSessionOptions *session_opts,
                      dt_ai_provider_t provider,
@@ -1322,8 +1515,9 @@ _enable_acceleration(OrtSessionOptions *session_opts,
   {
     const int dev = _device_id_from_conf("plugins/ai/cuda_device_id",
                                          "DT_CUDA_DEVICE_ID");
-    _try_provider(session_opts, "OrtSessionOptionsAppendExecutionProvider_CUDA",
-                  "NVIDIA CUDA", NULL, (uint32_t)dev, DT_AI_PROVIDER_CUDA);
+    if(!_try_cuda_v2(session_opts, dev))
+      _try_provider(session_opts, "OrtSessionOptionsAppendExecutionProvider_CUDA",
+                    "NVIDIA CUDA", NULL, (uint32_t)dev, DT_AI_PROVIDER_CUDA);
     break;
   }
 
@@ -1385,10 +1579,13 @@ _enable_acceleration(OrtSessionOptions *session_opts,
                                                 "DT_CUDA_DEVICE_ID");
       const int amd_dev  = _device_id_from_conf("plugins/ai/migraphx_device_id",
                                                 "DT_MIGRAPHX_DEVICE_ID");
-      if(!_try_provider(
-           session_opts,
-           "OrtSessionOptionsAppendExecutionProvider_CUDA",
-           "NVIDIA CUDA", NULL, (uint32_t)cuda_dev, DT_AI_PROVIDER_CUDA))
+      const gboolean cuda_ok =
+        _try_cuda_v2(session_opts, cuda_dev)
+        || _try_provider(session_opts,
+                         "OrtSessionOptionsAppendExecutionProvider_CUDA",
+                         "NVIDIA CUDA", NULL, (uint32_t)cuda_dev,
+                         DT_AI_PROVIDER_CUDA);
+      if(!cuda_ok)
       {
         if(!_try_provider(
              session_opts,

--- a/src/common/ai/restore.c
+++ b/src/common/ai/restore.c
@@ -226,8 +226,7 @@ static dt_ai_context_t *_create_session(dt_ai_environment_t *ai_env,
                                         const char *model_file,
                                         const char *dim_h,
                                         const char *dim_w,
-                                        int tile_size,
-                                        uint32_t ep_flags)
+                                        int tile_size)
 {
   const dt_ai_dim_override_t overrides[] = {
     { "batch_size", 1 },
@@ -238,14 +237,20 @@ static dt_ai_context_t *_create_session(dt_ai_environment_t *ai_env,
   return dt_ai_load_model_ext(
     ai_env, model_id, model_file,
     DT_AI_PROVIDER_CONFIGURED, DT_AI_OPT_ALL,
-    overrides, (int)G_N_ELEMENTS(overrides), ep_flags);
+    overrides, (int)G_N_ELEMENTS(overrides), 0);
 }
 
-// internal: resolve task -> model_id -> load with tile size dim overrides
+// internal: resolve task -> model_id -> load with tile size dim overrides.
+// `stem` is the file-stem variant key inside the package's attributes
+// object (e.g. "model_bayer" → looks up attributes.model_bayer.* and
+// loads model_bayer.onnx). non-variant tasks pass stem=NULL and supply
+// `default_file` directly. `expected_kind` is the input_kind contract
+// the caller wants enforced; UNKNOWN skips the check
 static dt_restore_context_t *_load(dt_restore_env_t *env,
                                    const char *task,
-                                   const char *variant,
+                                   const char *stem,
                                    const char *default_file,
+                                   dt_restore_input_kind_t expected_kind,
                                    int scale)
 {
   if(!env) return NULL;
@@ -265,37 +270,27 @@ static dt_restore_context_t *_load(dt_restore_env_t *env,
   const dt_ai_model_info_t *info
     = dt_ai_get_model_info_by_id(env->ai_env, model_id);
 
-  // variant-aware config lookup: variant models must declare their ONNX
-  // filename under variants.<variant>.onnx. input_kind is stashed on ctx
-  // so raw paths can sanity-check they're pointing at the right model.
-  // non-variant models (denoise, upscale) pass variant=NULL and supply
-  // the filename directly via default_file
-  char *variant_file = NULL;
+  char *model_file = stem
+    ? g_strdup_printf("%s.onnx", stem)
+    : g_strdup(default_file);
   char *input_kind = NULL;
   // policy strings (all optional; NULL falls through to defaults)
   char *cs_str = NULL, *wb_str = NULL, *scale_str = NULL;
   char *bo_str = NULL, *edge_str = NULL;
-  // expected input_kind for this variant slot. raw variants MUST match
-  // one of the declared v1 contracts; non-variant tasks pass UNKNOWN
-  // and skip the contract check entirely
-  dt_restore_input_kind_t expected_kind = DT_RESTORE_INPUT_KIND_UNKNOWN;
-  if(variant)
+  if(stem)
   {
-    char *k_file  = g_strdup_printf("variants.%s.onnx", variant);
-    char *k_kind  = g_strdup_printf("variants.%s.input_kind", variant);
-    char *k_cs    = g_strdup_printf("variants.%s.input_colorspace", variant);
-    char *k_wb    = g_strdup_printf("variants.%s.wb_norm", variant);
-    char *k_scale = g_strdup_printf("variants.%s.output_scale", variant);
-    char *k_bo    = g_strdup_printf("variants.%s.bayer_orientation", variant);
-    char *k_edge  = g_strdup_printf("variants.%s.edge_pad", variant);
-    variant_file = dt_ai_model_attribute_string(info, k_file);
+    char *k_kind  = g_strdup_printf("%s.input_kind", stem);
+    char *k_cs    = g_strdup_printf("%s.input_colorspace", stem);
+    char *k_wb    = g_strdup_printf("%s.wb_norm", stem);
+    char *k_scale = g_strdup_printf("%s.output_scale", stem);
+    char *k_bo    = g_strdup_printf("%s.bayer_orientation", stem);
+    char *k_edge  = g_strdup_printf("%s.edge_pad", stem);
     input_kind   = dt_ai_model_attribute_string(info, k_kind);
     cs_str       = dt_ai_model_attribute_string(info, k_cs);
     wb_str       = dt_ai_model_attribute_string(info, k_wb);
     scale_str    = dt_ai_model_attribute_string(info, k_scale);
     bo_str       = dt_ai_model_attribute_string(info, k_bo);
     edge_str     = dt_ai_model_attribute_string(info, k_edge);
-    g_free(k_file);
     g_free(k_kind);
     g_free(k_cs);
     g_free(k_wb);
@@ -303,36 +298,11 @@ static dt_restore_context_t *_load(dt_restore_env_t *env,
     g_free(k_bo);
     g_free(k_edge);
 
-    if(!variant_file)
-    {
-      dt_print(DT_DEBUG_AI,
-               "[restore] model %s declares no variants.%s.onnx — "
-               "cannot load variant",
-               model_id, variant);
-      g_free(input_kind);
-      g_free(cs_str);
-      g_free(wb_str);
-      g_free(scale_str);
-      g_free(bo_str);
-      g_free(edge_str);
-      g_free(model_id);
-      return NULL;
-    }
-
-    // contract check: the variant slot name pins which input_kind we
-    // expect. older manifests predate the label; if unset, assume the
-    // expected one (back-compat). a declared-but-wrong label is a hard
-    // error — refusing to load keeps mis-packaged ONNX from crashing
-    // at inference with a confusing shape-mismatch
-    if(!g_strcmp0(task, TASK_RAWDENOISE))
-    {
-      if(!g_strcmp0(variant, "bayer"))
-        expected_kind = DT_RESTORE_INPUT_KIND_BAYER_V1;
-      else if(!g_strcmp0(variant, "xtrans"))
-        expected_kind = DT_RESTORE_INPUT_KIND_XTRANS_V1;
-      else if(!g_strcmp0(variant, "linear"))
-        expected_kind = DT_RESTORE_INPUT_KIND_LINEAR_V1;
-    }
+    // contract check: the caller pins which input_kind it expects.
+    // older manifests predate the label; if unset, assume the expected
+    // one (back-compat). a declared-but-wrong label is a hard error —
+    // refusing to load keeps mis-packaged ONNX from crashing at
+    // inference with a confusing shape-mismatch
     if(expected_kind != DT_RESTORE_INPUT_KIND_UNKNOWN)
     {
       const dt_restore_input_kind_t declared = _parse_input_kind(input_kind);
@@ -342,30 +312,29 @@ static dt_restore_context_t *_load(dt_restore_env_t *env,
       if(mismatch || (!missing && declared == DT_RESTORE_INPUT_KIND_UNKNOWN))
       {
         dt_print(DT_DEBUG_AI,
-                 "[restore] model %s variant '%s': input_kind '%s' "
+                 "[restore] model %s '%s': input_kind '%s' "
                  "does not match expected '%s' — refusing to load",
-                 model_id, variant, input_kind,
+                 model_id, stem, input_kind,
                  _input_kind_name(expected_kind));
         dt_control_log(_("raw denoise model %s: incompatible input_kind"),
                        model_id);
+        g_free(model_file);
         g_free(input_kind);
         g_free(cs_str);
         g_free(wb_str);
         g_free(scale_str);
         g_free(bo_str);
         g_free(edge_str);
-        g_free(variant_file);
         g_free(model_id);
         return NULL;
       }
     }
 
     dt_print(DT_DEBUG_AI,
-             "[restore] variant '%s': file=%s input_kind=%s",
-             variant, variant_file,
+             "[restore] '%s': file=%s input_kind=%s",
+             stem, model_file,
              input_kind ? input_kind : "(none)");
   }
-  const char *model_file = variant ? variant_file : default_file;
 
   // resolve the tile ladder: model-declared input_sizes if present,
   // otherwise a copy of the built-in ladder for this scale
@@ -390,24 +359,15 @@ static dt_restore_context_t *_load(dt_restore_env_t *env,
     tile_size = _select_tile_size(tile_ladder, n_tile_ladder, scale);
   }
 
-  // CoreML CPU-only flag: models whose intermediate activations
-  // overflow FP16 (e.g. raw denoise) declare this in config.json
-  // to force CoreML's CPU path which runs FP32
-  const uint32_t ep_flags
-    = dt_ai_model_attribute_bool(info, "coreml_cpu_only") ? 1 : 0;
-  if(ep_flags)
-    dt_print(DT_DEBUG_AI,
-             "[restore] model %s: coreml_cpu_only=true (ep_flags=%u)",
-             model_id, ep_flags);
-
+  // EP safety (cpu_only attribute) is resolved inside the backend by
+  // matching the model_file against the model's top-level cpu_only list
   dt_ai_context_t *ai_ctx = _create_session(
-    env->ai_env, model_id, model_file, dim_h, dim_w, tile_size,
-    ep_flags);
+    env->ai_env, model_id, model_file, dim_h, dim_w, tile_size);
   if(!ai_ctx)
   {
     g_free(model_id);
     g_free(tile_ladder);
-    g_free(variant_file);
+    g_free(model_file);
     g_free(input_kind);
     g_free(cs_str);
     g_free(wb_str);
@@ -425,11 +385,10 @@ static dt_restore_context_t *_load(dt_restore_env_t *env,
   ctx->input_kind          = input_kind;   // take ownership
   ctx->scale               = scale;
   ctx->model_id            = model_id;
-  ctx->model_file          = g_strdup(model_file);
+  ctx->model_file          = model_file;   // take ownership
   ctx->tile_size           = tile_size;
   ctx->tile_ladder         = tile_ladder;
   ctx->n_tile_ladder       = n_tile_ladder;
-  ctx->ep_flags            = ep_flags;
   ctx->dim_h               = g_strdup(dim_h);
   ctx->dim_w               = g_strdup(dim_w);
   ctx->preserve_wide_gamut = TRUE;
@@ -461,8 +420,8 @@ static dt_restore_context_t *_load(dt_restore_env_t *env,
     ctx->wb_mode          = _parse_wb_mode(wb_str, default_wb);
     ctx->output_scale     = _parse_output_scale(scale_str, DT_RESTORE_OUT_MATCH_GAIN);
     ctx->input_colorspace = _parse_colorspace(cs_str, default_cs);
-    char *k_tm = variant
-      ? g_strdup_printf("variants.%s.target_mean", variant) : NULL;
+    char *k_tm = stem
+      ? g_strdup_printf("%s.target_mean", stem) : NULL;
     ctx->target_mean = k_tm
       ? _parse_target_mean(info, k_tm, default_tm) : default_tm;
     g_free(k_tm);
@@ -501,7 +460,6 @@ static dt_restore_context_t *_load(dt_restore_env_t *env,
     dt_print(DT_DEBUG_AI,
              "[restore] model %s declares shadow_boost attribute",
              model_id);
-  g_free(variant_file);
   return ctx;
 }
 
@@ -521,7 +479,7 @@ static gboolean _reload_session(dt_restore_context_t *ctx, int new_tile_size)
 
   dt_ai_context_t *new_ctx = _create_session(
     ctx->env->ai_env, ctx->model_id, ctx->model_file,
-    ctx->dim_h, ctx->dim_w, new_tile_size, ctx->ep_flags);
+    ctx->dim_h, ctx->dim_w, new_tile_size);
   if(!new_ctx) return FALSE;
   ctx->ai_ctx    = new_ctx;
   ctx->tile_size = new_tile_size;
@@ -530,7 +488,8 @@ static gboolean _reload_session(dt_restore_context_t *ctx, int new_tile_size)
 
 dt_restore_context_t *dt_restore_load_denoise(dt_restore_env_t *env)
 {
-  return _load(env, TASK_DENOISE, NULL, NULL, 1);
+  return _load(env, TASK_DENOISE, NULL, NULL,
+               DT_RESTORE_INPUT_KIND_UNKNOWN, 1);
 }
 
 dt_restore_sensor_class_t dt_restore_classify_sensor(const dt_image_t *img)
@@ -547,46 +506,51 @@ dt_restore_sensor_class_t dt_restore_classify_sensor(const dt_image_t *img)
 
 dt_restore_context_t *dt_restore_load_rawdenoise_bayer(dt_restore_env_t *env)
 {
-  // scale 1x, same pipeline as denoise; filename comes from the model's
-  // variants.bayer.onnx attribute. loading fails if the YAML doesn't
-  // declare it — no silent fallback for broken model packages
-  return _load(env, TASK_RAWDENOISE, "bayer", NULL, 1);
+  // scale 1x, same pipeline as denoise; loads model_bayer.onnx and
+  // reads its policy knobs from attributes.model_bayer.*
+  return _load(env, TASK_RAWDENOISE, "model_bayer", NULL,
+               DT_RESTORE_INPUT_KIND_BAYER_V1, 1);
 }
 
 dt_restore_context_t *dt_restore_load_rawdenoise_linear(dt_restore_env_t *env)
 {
   // generic-demosaic fallback: Foveon, monochrome-with-pattern, and
   // currently also X-Trans (until dt_restore_load_rawdenoise_xtrans
-  // gets a dedicated variant to load)
-  return _load(env, TASK_RAWDENOISE, "linear", NULL, 1);
+  // gets a dedicated model_xtrans to load)
+  return _load(env, TASK_RAWDENOISE, "model_linear", NULL,
+               DT_RESTORE_INPUT_KIND_LINEAR_V1, 1);
 }
 
 dt_restore_context_t *dt_restore_load_rawdenoise_xtrans(dt_restore_env_t *env)
 {
-  // prefer a dedicated xtrans variant when the manifest declares one;
+  // prefer a dedicated model_xtrans when the manifest declares one;
   // fall back to the linear pipeline otherwise. this lets a future
   // RawNIND release ship a dedicated X-Trans model via just a manifest
   // update — no code changes in darktable (assuming the dedicated model
   // shares the linear pipeline; a structurally different X-Trans input
   // format would still need its own preprocessing code)
-  dt_restore_context_t *ctx = _load(env, TASK_RAWDENOISE, "xtrans", NULL, 1);
+  dt_restore_context_t *ctx = _load(env, TASK_RAWDENOISE, "model_xtrans", NULL,
+                                    DT_RESTORE_INPUT_KIND_XTRANS_V1, 1);
   if(!ctx)
   {
     dt_print(DT_DEBUG_AI,
-             "[restore] no dedicated xtrans variant; using linear as fallback");
-    ctx = _load(env, TASK_RAWDENOISE, "linear", NULL, 1);
+             "[restore] no dedicated xtrans model; using linear as fallback");
+    ctx = _load(env, TASK_RAWDENOISE, "model_linear", NULL,
+                DT_RESTORE_INPUT_KIND_LINEAR_V1, 1);
   }
   return ctx;
 }
 
 dt_restore_context_t *dt_restore_load_upscale_x2(dt_restore_env_t *env)
 {
-  return _load(env, TASK_UPSCALE, NULL, "model_x2.onnx", 2);
+  return _load(env, TASK_UPSCALE, NULL, "model_x2.onnx",
+               DT_RESTORE_INPUT_KIND_UNKNOWN, 2);
 }
 
 dt_restore_context_t *dt_restore_load_upscale_x4(dt_restore_env_t *env)
 {
-  return _load(env, TASK_UPSCALE, NULL, "model_x4.onnx", 4);
+  return _load(env, TASK_UPSCALE, NULL, "model_x4.onnx",
+               DT_RESTORE_INPUT_KIND_UNKNOWN, 4);
 }
 
 dt_restore_context_t *dt_restore_ref(dt_restore_context_t *ctx)

--- a/src/common/ai/restore.c
+++ b/src/common/ai/restore.c
@@ -36,14 +36,6 @@
 #define OVERLAP_DENOISE 64
 #define OVERLAP_UPSCALE 16
 
-// candidate tile sizes from largest to smallest, used by both the
-// startup memory-budget selector and the runtime OOM-retry fallback.
-// the memory-budget check gates which entry is chosen at startup;
-// the tile size cache persists the result so JIT-compiling EPs
-// (MIGraphX, CoreML, TensorRT) only pay the compile cost once
-#define DT_RESTORE_TILE_LADDER_1X {2048, 1536, 1024, 768, 512, 384, 256}
-#define DT_RESTORE_TILE_LADDER_SR {768, 512, 384, 256, 192}
-
 // --- environment lifecycle ---
 
 dt_restore_env_t *dt_restore_env_init(void)
@@ -186,64 +178,36 @@ static float _parse_target_mean(const dt_ai_model_info_t *info,
   return (float)v;
 }
 
-static int _select_tile_size(const int *ladder, int n_ladder, int scale);
-// resolve the tile ladder for a model: prefer the "input_sizes" JSON
-// array attribute from config.json when present, otherwise fall back
-// to the built-in ladder for the model's scale. always returns a
-// freshly-allocated int[] + count that the caller owns and g_free()s
-static void _resolve_tile_ladder(const dt_ai_model_info_t *info,
-                                 int scale,
-                                 int **out_sizes,
-                                 int *out_count);
-
-// returns the cached tile size for model_id+scale+provider combo, or 0 if not set
-static int _get_cached_tile_size(const char *model_id, int scale)
+// resolve the model's declared input size. all NR models ship static
+// ONNX exports with one fixed input H×W, declared in config.json as
+// either "<stem>.input_sizes" (multi-model package) or top-level
+// "input_sizes" (single-model package). returns the first entry, or
+// 0 if neither is declared
+static int _resolve_tile_size(const dt_ai_model_info_t *info,
+                              const char *stem)
 {
-  char *prov = dt_conf_get_string(DT_AI_CONF_PROVIDER);
-  char *key = g_strdup_printf("plugins/ai/tile_cache/%s/%d/%s",
-                               model_id, scale, prov ? prov : "auto");
-  g_free(prov);
-  const int cached = dt_conf_get_int(key);
-  g_free(key);
-  return cached;
+  int n = 0;
+  int *sizes = NULL;
+  if(stem)
+  {
+    char *key = g_strdup_printf("%s.input_sizes", stem);
+    sizes = dt_ai_model_attribute_int_array(info, key, &n);
+    g_free(key);
+  }
+  if(!sizes || n == 0)
+  {
+    g_free(sizes);
+    sizes = dt_ai_model_attribute_int_array(info, "input_sizes", &n);
+  }
+  const int tile_size = (sizes && n > 0) ? sizes[0] : 0;
+  g_free(sizes);
+  return tile_size;
 }
 
-// persist a successful tile size to darktablerc so the next run skips OOM retry
-static void _set_cached_tile_size(const char *model_id, int scale, int tile_size)
-{
-  char *prov = dt_conf_get_string(DT_AI_CONF_PROVIDER);
-  char *key = g_strdup_printf("plugins/ai/tile_cache/%s/%d/%s",
-                               model_id, scale, prov ? prov : "auto");
-  g_free(prov);
-  dt_conf_set_int(key, tile_size);
-  g_free(key);
-}
-
-// internal: create an ORT session for model_id/model_file with spatial dims
-// fixed to tile_size. returns a new ai_ctx, or NULL on failure
-static dt_ai_context_t *_create_session(dt_ai_environment_t *ai_env,
-                                        const char *model_id,
-                                        const char *model_file,
-                                        const char *dim_h,
-                                        const char *dim_w,
-                                        int tile_size)
-{
-  const dt_ai_dim_override_t overrides[] = {
-    { "batch_size", 1 },
-    { "batch",      1 },
-    { dim_h,        tile_size },
-    { dim_w,        tile_size },
-  };
-  return dt_ai_load_model_ext(
-    ai_env, model_id, model_file,
-    DT_AI_PROVIDER_CONFIGURED, DT_AI_OPT_ALL,
-    overrides, (int)G_N_ELEMENTS(overrides), 0);
-}
-
-// internal: resolve task -> model_id -> load with tile size dim overrides.
-// `stem` is the file-stem variant key inside the package's attributes
-// object (e.g. "model_bayer" → looks up attributes.model_bayer.* and
-// loads model_bayer.onnx). non-variant tasks pass stem=NULL and supply
+// internal: resolve task -> model_id -> load static ONNX. `stem` is the
+// file-stem variant key inside the package's attributes object (e.g.
+// "model_bayer" → looks up attributes.model_bayer.* and loads
+// model_bayer.onnx). non-variant tasks pass stem=NULL and supply
 // `default_file` directly. `expected_kind` is the input_kind contract
 // the caller wants enforced; UNKNOWN skips the check
 static dt_restore_context_t *_load(dt_restore_env_t *env,
@@ -261,11 +225,6 @@ static dt_restore_context_t *_load(dt_restore_env_t *env,
     g_free(model_id);
     return NULL;
   }
-
-  // look up spatial dimension names for this model
-  const char *dim_h, *dim_w;
-  dt_ai_models_get_spatial_dims(darktable.ai_registry, model_id,
-                                &dim_h, &dim_w);
 
   const dt_ai_model_info_t *info
     = dt_ai_get_model_info_by_id(env->ai_env, model_id);
@@ -336,37 +295,38 @@ static dt_restore_context_t *_load(dt_restore_env_t *env,
              input_kind ? input_kind : "(none)");
   }
 
-  // resolve the tile ladder: model-declared input_sizes if present,
-  // otherwise a copy of the built-in ladder for this scale
-  int *tile_ladder = NULL;
-  int n_tile_ladder = 0;
-  _resolve_tile_ladder(info, scale, &tile_ladder, &n_tile_ladder);
-
-  // select tile size from cache, but only if the cached value is still
-  // a member of the ladder — otherwise a model upgrade that narrowed
-  // its supported input_sizes would load with a stale size and fail
-  // at graph shape inference (U-Nets are strict about spatial dims)
-  int tile_size = _get_cached_tile_size(model_id, scale);
-  gboolean cached_ok = FALSE;
-  for(int i = 0; i < n_tile_ladder && !cached_ok; i++)
-    if(tile_ladder[i] == tile_size) cached_ok = TRUE;
-  if(!cached_ok)
+  // static-shape ONNX: the model declares its input dim and we use it
+  // verbatim. no fallback ladder, no cache, no OOM retry — packaging
+  // is expected to pick a tile size that fits the target hardware
+  const int tile_size = _resolve_tile_size(info, stem);
+  if(tile_size <= 0)
   {
-    if(tile_size > 0)
-      dt_print(DT_DEBUG_AI,
-               "[restore] cached tile size %d not in ladder, re-selecting",
-               tile_size);
-    tile_size = _select_tile_size(tile_ladder, n_tile_ladder, scale);
+    dt_print(DT_DEBUG_AI,
+             "[restore] model %s%s%s declares no input_sizes — "
+             "static ONNX requires a fixed tile size",
+             model_id,
+             stem ? " stem=" : "", stem ? stem : "");
+    dt_control_log(_("AI model %s: missing input_sizes in manifest"),
+                   model_id);
+    g_free(model_file);
+    g_free(input_kind);
+    g_free(cs_str);
+    g_free(wb_str);
+    g_free(scale_str);
+    g_free(bo_str);
+    g_free(edge_str);
+    g_free(model_id);
+    return NULL;
   }
 
   // EP safety (cpu_only attribute) is resolved inside the backend by
   // matching the model_file against the model's top-level cpu_only list
-  dt_ai_context_t *ai_ctx = _create_session(
-    env->ai_env, model_id, model_file, dim_h, dim_w, tile_size);
+  dt_ai_context_t *ai_ctx = dt_ai_load_model_ext(
+    env->ai_env, model_id, model_file,
+    DT_AI_PROVIDER_CONFIGURED, DT_AI_OPT_ALL, NULL, 0, 0);
   if(!ai_ctx)
   {
     g_free(model_id);
-    g_free(tile_ladder);
     g_free(model_file);
     g_free(input_kind);
     g_free(cs_str);
@@ -387,10 +347,6 @@ static dt_restore_context_t *_load(dt_restore_env_t *env,
   ctx->model_id            = model_id;
   ctx->model_file          = model_file;   // take ownership
   ctx->tile_size           = tile_size;
-  ctx->tile_ladder         = tile_ladder;
-  ctx->n_tile_ladder       = n_tile_ladder;
-  ctx->dim_h               = g_strdup(dim_h);
-  ctx->dim_w               = g_strdup(dim_w);
   ctx->preserve_wide_gamut = TRUE;
 
   // resolve policy enums: per-variant defaults reproduce today's
@@ -463,29 +419,6 @@ static dt_restore_context_t *_load(dt_restore_env_t *env,
   return ctx;
 }
 
-// internal: recreate the ORT session with a smaller tile size after OOM.
-// updates ctx->ai_ctx and ctx->tile_size in place.
-// returns TRUE on success, FALSE if the reload also fails.
-//
-// unload the old session BEFORE creating the new one: after a GPU OOM
-// the old session is still holding VRAM, and trying to allocate even
-// a tiny new session on top triggers a cascade of init failures in
-// ORT's provider-fallback retry path. freeing first lets the new
-// session fit without the retries
-static gboolean _reload_session(dt_restore_context_t *ctx, int new_tile_size)
-{
-  dt_ai_unload_model(ctx->ai_ctx);
-  ctx->ai_ctx = NULL;
-
-  dt_ai_context_t *new_ctx = _create_session(
-    ctx->env->ai_env, ctx->model_id, ctx->model_file,
-    ctx->dim_h, ctx->dim_w, new_tile_size);
-  if(!new_ctx) return FALSE;
-  ctx->ai_ctx    = new_ctx;
-  ctx->tile_size = new_tile_size;
-  return TRUE;
-}
-
 dt_restore_context_t *dt_restore_load_denoise(dt_restore_env_t *env)
 {
   return _load(env, TASK_DENOISE, NULL, NULL,
@@ -543,13 +476,15 @@ dt_restore_context_t *dt_restore_load_rawdenoise_xtrans(dt_restore_env_t *env)
 
 dt_restore_context_t *dt_restore_load_upscale_x2(dt_restore_env_t *env)
 {
-  return _load(env, TASK_UPSCALE, NULL, "model_x2.onnx",
+  // stem "model_x2" → loads model_x2.onnx and reads its tile ladder
+  // from attributes.model_x2.input_sizes when declared
+  return _load(env, TASK_UPSCALE, "model_x2", NULL,
                DT_RESTORE_INPUT_KIND_UNKNOWN, 2);
 }
 
 dt_restore_context_t *dt_restore_load_upscale_x4(dt_restore_env_t *env)
 {
-  return _load(env, TASK_UPSCALE, NULL, "model_x4.onnx",
+  return _load(env, TASK_UPSCALE, "model_x4", NULL,
                DT_RESTORE_INPUT_KIND_UNKNOWN, 4);
 }
 
@@ -569,9 +504,6 @@ void dt_restore_unref(dt_restore_context_t *ctx)
     g_free(ctx->input_kind);
     g_free(ctx->model_id);
     g_free(ctx->model_file);
-    g_free(ctx->dim_h);
-    g_free(ctx->dim_w);
-    g_free(ctx->tile_ladder);
     g_free(ctx);
   }
 }
@@ -614,73 +546,6 @@ gboolean dt_restore_upscale_available(dt_restore_env_t *env)
 int dt_restore_get_overlap(int scale)
 {
   return (scale > 1) ? OVERLAP_UPSCALE : OVERLAP_DENOISE;
-}
-
-static int _select_tile_size(const int *ladder, int n_ladder, int scale)
-{
-  const size_t avail = dt_get_available_mem();
-  const size_t budget = avail / 4;
-
-  for(int i = 0; i < n_ladder; i++)
-  {
-    const size_t T = (size_t)ladder[i];
-    const size_t T_out = T * scale;
-    const size_t tile_in = T * T * 3 * sizeof(float);
-    const size_t tile_out
-      = T_out * T_out * 3 * sizeof(float);
-    const size_t ort_factor = (scale > 1) ? 50 : 100;
-    const size_t ort_overhead
-      = T_out * T_out * 3 * sizeof(float) * ort_factor;
-    const size_t total = tile_in + tile_out + ort_overhead;
-
-    if(total <= budget)
-    {
-      dt_print(DT_DEBUG_AI,
-               "[restore] tile size %d (scale=%d, need %zuMB, budget %zuMB)",
-               ladder[i], scale,
-               total / (1024 * 1024),
-               budget / (1024 * 1024));
-      return ladder[i];
-    }
-  }
-
-  dt_print(DT_DEBUG_AI,
-           "[restore] using minimum tile size %d (budget %zuMB)",
-           ladder[n_ladder - 1],
-           budget / (1024 * 1024));
-  return ladder[n_ladder - 1];
-}
-
-static void _resolve_tile_ladder(const dt_ai_model_info_t *info,
-                                 int scale,
-                                 int **out_sizes,
-                                 int *out_count)
-{
-  // prefer the model's declared input_sizes if present: some exports
-  // ship with a fixed set of supported tile sizes (e.g. the model was
-  // compiled for specific spatial dims) and using anything outside
-  // that list will either refuse to run or produce garbage
-  int n = 0;
-  int *sizes = dt_ai_model_attribute_int_array(info, "input_sizes", &n);
-  if(sizes && n > 0)
-  {
-    *out_sizes = sizes;
-    *out_count = n;
-    return;
-  }
-  g_free(sizes);
-
-  // fall back to the built-in ladder for the model's scale
-  static const int ladder_1x[] = DT_RESTORE_TILE_LADDER_1X;
-  static const int ladder_sr[] = DT_RESTORE_TILE_LADDER_SR;
-  const int *src = (scale > 1) ? ladder_sr : ladder_1x;
-  const int src_n = (scale > 1)
-    ? (int)(sizeof(ladder_sr) / sizeof(int))
-    : (int)(sizeof(ladder_1x) / sizeof(int));
-  int *copy = g_new(int, src_n);
-  memcpy(copy, src, src_n * sizeof(int));
-  *out_sizes = copy;
-  *out_count = src_n;
 }
 
 int dt_restore_run_patch_bayer(dt_restore_context_t *ctx,
@@ -731,51 +596,34 @@ int dt_restore_run_patch_3ch_raw(dt_restore_context_t *ctx,
   return dt_ai_run(ctx->ai_ctx, &input, 1, &output, 1);
 }
 
-const int *dt_restore_get_tile_ladder(const dt_restore_context_t *ctx,
-                                      int *out_count)
-{
-  if(!ctx)
-  {
-    if(out_count) *out_count = 0;
-    return NULL;
-  }
-  if(out_count) *out_count = ctx->n_tile_ladder;
-  return ctx->tile_ladder;
-}
-
 int dt_restore_get_tile_size(const dt_restore_context_t *ctx)
 {
   return ctx ? ctx->tile_size : 0;
 }
 
-gboolean dt_restore_reload_session(dt_restore_context_t *ctx,
-                                   int new_tile_size)
+gboolean dt_restore_reload_session_cpu(dt_restore_context_t *ctx)
 {
-  if(!ctx) return FALSE;
-  return _reload_session(ctx, new_tile_size);
-}
-
-gboolean dt_restore_step_down_tile_size(dt_restore_context_t *ctx,
-                                        int *T_inout)
-{
-  if(!ctx || !T_inout) return FALSE;
-  int next_T = 0;
-  for(int i = 0; i < ctx->n_tile_ladder; i++)
-    if(ctx->tile_ladder[i] < *T_inout)
-    {
-      next_T = ctx->tile_ladder[i];
-      break;
-    }
-  if(next_T <= 0 || !_reload_session(ctx, next_T))
+  if(!ctx || !ctx->env || !ctx->env->ai_env || !ctx->model_id)
     return FALSE;
-  *T_inout = next_T;
-  return TRUE;
-}
 
-void dt_restore_persist_tile_size(const dt_restore_context_t *ctx)
-{
-  if(ctx && ctx->model_id)
-    _set_cached_tile_size(ctx->model_id, ctx->scale, ctx->tile_size);
+  // unload the old session BEFORE creating the new one: on GPU EPs the
+  // failing session may still hold VRAM, and the CPU session creation
+  // happens to be cheaper if no other ORT state is in flight
+  dt_ai_unload_model(ctx->ai_ctx);
+  ctx->ai_ctx = NULL;
+
+  dt_ai_context_t *new_ctx = dt_ai_load_model_ext(
+    ctx->env->ai_env, ctx->model_id, ctx->model_file,
+    DT_AI_PROVIDER_CPU, DT_AI_OPT_ALL, NULL, 0, 0);
+  if(!new_ctx)
+  {
+    dt_print(DT_DEBUG_AI,
+             "[restore] CPU fallback session load failed for %s",
+             ctx->model_id);
+    return FALSE;
+  }
+  ctx->ai_ctx = new_ctx;
+  return TRUE;
 }
 
 // shared bridge: run the user's darktable pixelpipe on an arbitrary sensor

--- a/src/common/ai/restore.h
+++ b/src/common/ai/restore.h
@@ -290,70 +290,28 @@ int dt_restore_run_patch_3ch_raw(dt_restore_context_t *ctx,
                                  int w, int h,
                                  float *out_3ch);
 
-// @brief look up the tile ladder for a restore context
+// @brief tile size baked into the loaded ONNX model
 //
-// exposes the model-declared (or default) input_sizes list in
-// packed-space. used by the bayer pipeline to pick a starting
-// tile size that respects the model's declared shapes.
-//
-// @param ctx loaded restore context
-// @param out_count filled with number of entries (may be NULL)
-// @return pointer to the ladder (owned by ctx; do not free). NULL
-//         if ctx is NULL.
-const int *dt_restore_get_tile_ladder(const dt_restore_context_t *ctx,
-                                      int *out_count);
-
-// @brief current tile size stored in the loaded session
+// the static ONNX exports declare a fixed input H×W; this returns it
+// in packed-space (i.e. model-input units, half-sensor for bayer).
+// callers must tile at exactly this size — there is no fallback for
+// inference failures since the graph is static.
 //
 // @param ctx loaded restore context
-// @return tile size in packed-space, or 0 if ctx is NULL
+// @return tile size, or 0 if ctx is NULL
 int dt_restore_get_tile_size(const dt_restore_context_t *ctx);
 
-// @brief recreate the ORT session for a different tile size
+// @brief reload the session on the CPU execution provider
 //
-// used by the bayer OOM-retry loop to step down the ladder
-// when inference fails. keeps the same model/provider; only the
-// H/W dim overrides change. the old session is unloaded first
-// (avoids VRAM cascade on GPU OOM).
-//
-// @param ctx loaded restore context
-// @param new_tile_size new tile size (must be a ladder member)
-// @return TRUE on success
-gboolean dt_restore_reload_session(dt_restore_context_t *ctx,
-                                   int new_tile_size);
-
-// @brief step the loaded session down to the next smaller tile size
-//
-// shared OOM-retry helper used by all batch and preview pipelines.
-// looks up the next-smaller entry in ctx->tile_ladder and calls
-// dt_restore_reload_session. on success updates *T_inout in place
-// and returns TRUE; on failure (no smaller size or reload failed)
-// leaves *T_inout untouched and returns FALSE.
-//
-// emits no log output — callers own observability so they can phrase
-// the message with their own state (e.g. tile coordinates, pre/post
-// T value). callers are also expected to free per-tile buffers and
-// propagate the inference error.
-//
-// not thread-safe: mutates ctx->ai_ctx and ctx->tile_size. callers
-// must not invoke this on a ctx shared with another thread that may
-// be running inference.
+// used as a fallback when GPU inference fails (unsupported op, VRAM
+// OOM, EP crash). unloads the previous session first so it releases
+// GPU resources cleanly. tile size and all policy state stay the same;
+// only the provider changes. callers should attempt this at most once
+// per session — a second failure on CPU is a real error.
 //
 // @param ctx loaded restore context
-// @param T_inout current tile size; replaced with the new one on success
-// @return TRUE if the session was successfully recreated at a smaller T
-gboolean dt_restore_step_down_tile_size(dt_restore_context_t *ctx,
-                                        int *T_inout);
-
-// @brief persist the current tile size to darktablerc
-//
-// once the bayer pipeline has processed an image end-to-end at
-// ctx->tile_size without OOM, call this so the next run skips the
-// retry loop and JIT-compiling providers don't pay the compile
-// cost again.
-//
-// @param ctx loaded restore context
-void dt_restore_persist_tile_size(const dt_restore_context_t *ctx);
+// @return TRUE on success, FALSE if the CPU session also fails to load
+gboolean dt_restore_reload_session_cpu(dt_restore_context_t *ctx);
 
 // @brief run darktable's real user pixelpipe on a sensor buffer, ROI-clipped.
 //

--- a/src/common/ai/restore_common.h
+++ b/src/common/ai/restore_common.h
@@ -165,7 +165,6 @@ struct dt_restore_context_t
   // startup budget selector and the runtime OOM retry loop iterate it
   int *tile_ladder;
   int n_tile_ladder;
-  uint32_t ep_flags;  // execution provider flags (e.g. CoreML CPU-only)
   gint ref_count;
 };
 

--- a/src/common/ai/restore_common.h
+++ b/src/common/ai/restore_common.h
@@ -141,9 +141,7 @@ struct dt_restore_context_t
   dt_restore_edge_pad_t          edge_pad;
   float                          target_mean;  // NAN = no exposure boost
   int scale;        // model upscale factor (1 for denoise, 2/4 for upscale)
-  int tile_size;    // tile size used to create the current session
-  char *dim_h;      // symbolic height dim name used for session overrides
-  char *dim_w;      // symbolic width dim name used for session overrides
+  int tile_size;    // static input dim baked into the loaded ONNX
   // color management (RGB path): convert working profile → sRGB before
   // inference and back after. if has_profile is FALSE, fall back to
   // gamma-only conversion (treats working-profile numbers as if sRGB).
@@ -159,12 +157,6 @@ struct dt_restore_context_t
   // per image inside dt_restore_process_tiled() based on luminance.
   gboolean shadow_boost_capable;
   gboolean shadow_boost;
-  // tile ladder candidates from largest to smallest; either the
-  // model's "input_sizes" attribute from config.json (when declared)
-  // or a copy of the built-in ladder for the model's scale. both the
-  // startup budget selector and the runtime OOM retry loop iterate it
-  int *tile_ladder;
-  int n_tile_ladder;
   gint ref_count;
 };
 

--- a/src/common/ai/restore_raw_bayer.c
+++ b/src/common/ai/restore_raw_bayer.c
@@ -346,12 +346,11 @@ int dt_restore_raw_bayer(dt_restore_context_t *ctx,
 
   // tile setup in packed (half-res) space
   const int O = OVERLAP_PACKED;
-  int T = dt_restore_get_tile_size(ctx);
-  if(T <= 2 * O) T = 256;  // defensive fallback
-
-retry:;
+  const int T = dt_restore_get_tile_size(ctx);
+  if(T <= 2 * O) return 1;
   const int step = T - 2 * O;
   if(step <= 0) return 1;
+  gboolean cpu_fallback_done = FALSE;
   const size_t tile_in_plane = (size_t)T * T;
   const size_t tile_out_w = 2 * (size_t)T;
   const size_t tile_out_plane = tile_out_w * tile_out_w;
@@ -481,19 +480,18 @@ retry:;
       // inference
       if(dt_restore_run_patch_bayer(ctx, tile_in, T, T, tile_out) != 0)
       {
-        // step down the ladder if possible. first tile only so we
-        // don't rewrite pixels we've already delivered
-        if(ty == 0 && tx == 0 && dt_restore_step_down_tile_size(ctx, &T))
+        // GPU failure on the first tile: retry once on CPU
+        if(tx == 0 && ty == 0 && !cpu_fallback_done
+           && dt_restore_reload_session_cpu(ctx))
         {
           dt_print(DT_DEBUG_AI,
-                   "[restore_raw_bayer] tile %d,%d failed, retrying at T=%d",
-                   tx, ty, T);
-          g_free(tile_in);
-          g_free(tile_out);
-          g_free(h_strip_top);
-          g_free(h_strip_bot);
-          g_free(v_strip_left);
-          goto retry;
+                   "[restore_raw_bayer] GPU inference failed; "
+                   "retrying on CPU");
+          dt_control_log(_("AI raw denoise: GPU inference failed, "
+                           "falling back to CPU"));
+          cpu_fallback_done = TRUE;
+          tx--;
+          continue;
         }
         dt_print(DT_DEBUG_AI,
                  "[restore_raw_bayer] inference failed at tile %d,%d (T=%d)",
@@ -734,8 +732,6 @@ retry:;
              (unsigned)omin, (unsigned)omax,
              n ? (double)osum / n : 0.0,
              black[0], white);
-
-    dt_restore_persist_tile_size(ctx);
   }
 
   return res;
@@ -780,29 +776,13 @@ int dt_restore_raw_bayer_preview_piped(dt_restore_context_t *ctx,
   crop_h = (crop_h / 2) * 2;
   if(crop_w <= 0 || crop_h <= 0) return 1;
 
-  // OOM-retry loop: on inference failure step down the model's tile
-  // ladder and rebuild the single-tile geometry + packed tile. mirrors
-  // the batch path's recovery, scoped to one tile (no row_writer to
-  // rewind, no ty/tx==0 guard needed)
-  int T = dt_restore_get_tile_size(ctx);
+  const int T = dt_restore_get_tile_size(ctx);
   if(T <= 0) return 1;
 
-  float *tile_in = NULL;
-  float *tile_out = NULL;
-  int sensor_T = 0;
-  int pp_sr0 = 0, pp_sc0 = 0;
-  size_t tile_out_w = 0;
-  size_t tile_out_plane = 0;
-
-retry:;
-  sensor_T = 2 * T;
+  const int sensor_T = 2 * T;
   const int max_disp = sensor_T - 4 * OVERLAP_PACKED;
   if(crop_w > max_disp || crop_h > max_disp)
-  {
-    g_free(tile_in);
-    g_free(tile_out);
     return 1;
-  }
 
   int inf_x = crop_x + crop_w / 2 - sensor_T / 2;
   int inf_y = crop_y + crop_h / 2 - sensor_T / 2;
@@ -810,13 +790,11 @@ retry:;
   inf_y = (inf_y / 2) * 2;
 
   const size_t tile_in_plane = (size_t)T * T;
-  tile_out_w = 2 * (size_t)T;
-  tile_out_plane = tile_out_w * tile_out_w;
+  const size_t tile_out_w = 2 * (size_t)T;
+  const size_t tile_out_plane = tile_out_w * tile_out_w;
 
-  g_free(tile_in);
-  g_free(tile_out);
-  tile_in = g_try_malloc(tile_in_plane * 4 * sizeof(float));
-  tile_out = g_try_malloc(tile_out_plane * 3 * sizeof(float));
+  float *tile_in = g_try_malloc(tile_in_plane * 4 * sizeof(float));
+  float *tile_out = g_try_malloc(tile_out_plane * 3 * sizeof(float));
   if(!tile_in || !tile_out)
   {
     g_free(tile_in);
@@ -827,6 +805,7 @@ retry:;
   // geometry applies the same orientation + mirror policy as the batch
   // path. sr0_base / sc0_base for the preview is the user-centred,
   // even-snapped inference tile origin in sensor coords
+  int pp_sr0 = 0, pp_sc0 = 0;
   int pp_mir_y_lo, pp_mir_y_hi, pp_mir_x_lo, pp_mir_x_hi;
   _bayer_tile_geometry(ctx, &prep, inf_y, inf_x, width, height,
                        &pp_sr0, &pp_sc0,
@@ -837,13 +816,18 @@ retry:;
                    pp_mir_y_lo, pp_mir_y_hi, pp_mir_x_lo, pp_mir_x_hi,
                    T, &prep, tile_in);
 
-  if(dt_restore_run_patch_bayer(ctx, tile_in, T, T, tile_out) != 0)
+  gboolean cpu_fallback_done = FALSE;
+  while(dt_restore_run_patch_bayer(ctx, tile_in, T, T, tile_out) != 0)
   {
-    if(dt_restore_step_down_tile_size(ctx, &T))
+    if(!cpu_fallback_done && dt_restore_reload_session_cpu(ctx))
     {
       dt_print(DT_DEBUG_AI,
-               "[restore_raw_bayer] preview failed, retrying at T=%d", T);
-      goto retry;
+               "[restore_raw_bayer] preview GPU inference failed; "
+               "retrying on CPU");
+      dt_control_log(_("AI raw denoise: GPU inference failed, "
+                       "falling back to CPU"));
+      cpu_fallback_done = TRUE;
+      continue;
     }
     dt_print(DT_DEBUG_AI,
              "[restore_raw_bayer] preview inference failed at T=%d", T);

--- a/src/common/ai/restore_raw_linear.c
+++ b/src/common/ai/restore_raw_linear.c
@@ -482,18 +482,16 @@ int dt_restore_raw_linear(dt_restore_context_t *ctx,
 
   // tile setup
   const int O = OVERLAP_LINEAR;
-  int T = dt_restore_get_tile_size(ctx);
-  if(T <= 2 * O) T = 256;
-
-retry:;
-  const int step = T - 2 * O;
-  if(step <= 0)
+  const int T = dt_restore_get_tile_size(ctx);
+  if(T <= 2 * O)
   {
     dt_free_align(rgb_src);
     dt_free_align(rgb_out);
     dt_free_align(rgba);
     return 1;
   }
+  const int step = T - 2 * O;
+  gboolean cpu_fallback_done = FALSE;
   const size_t tile_plane = (size_t)T * T;
   const int cols = (w + step - 1) / step;
   const int rows = (h + step - 1) / step;
@@ -576,17 +574,18 @@ retry:;
       // inference
       if(dt_restore_run_patch_3ch_raw(ctx, tile_in, T, T, tile_out) != 0)
       {
-        if(ty == 0 && tx == 0 && dt_restore_step_down_tile_size(ctx, &T))
+        // GPU failure on the first tile: retry once on CPU
+        if(tx == 0 && ty == 0 && !cpu_fallback_done
+           && dt_restore_reload_session_cpu(ctx))
         {
           dt_print(DT_DEBUG_AI,
-                   "[restore_raw_linear] tile %d,%d failed, retrying at T=%d",
-                   tx, ty, T);
-          g_free(tile_in);
-          g_free(tile_out);
-          g_free(h_strip_top);
-          g_free(h_strip_bot);
-          g_free(v_strip_left);
-          goto retry;
+                   "[restore_raw_linear] GPU inference failed; "
+                   "retrying on CPU");
+          dt_control_log(_("AI raw denoise: GPU inference failed, "
+                           "falling back to CPU"));
+          cpu_fallback_done = TRUE;
+          tx--;
+          continue;
         }
         dt_print(DT_DEBUG_AI,
                  "[restore_raw_linear] inference failed at tile %d,%d (T=%d)",
@@ -813,8 +812,6 @@ retry:;
       rgb_out[i + plane]     = cam[1];
       rgb_out[i + 2 * plane] = cam[2];
     }
-
-    dt_restore_persist_tile_size(ctx);
   }
 
   dt_free_align(rgb_src);
@@ -962,39 +959,20 @@ int dt_restore_raw_linear_preview_piped(dt_restore_context_t *ctx,
       cam_to_input[i] = input_to_cam[i] = (i % 4 == 0) ? 1.0f : 0.0f;
   }
 
-  // OOM-retry loop: on inference failure step down the model's tile
-  // ladder and rebuild the single-tile geometry. mirrors the batch
-  // path's recovery, scoped to one tile (no row_writer to rewind)
-  int T = dt_restore_get_tile_size(ctx);
+  const int T = dt_restore_get_tile_size(ctx);
   if(T <= 0) return 1;
 
-  float *tile_in = NULL;
-  float *tile_out = NULL;
-  int inf_x = 0, inf_y = 0;
-  size_t tile_plane = 0;
-  float exposure_boost = 1.0f;
+  const int max_disp = T - 2 * OVERLAP_LINEAR;
+  if(crop_w > max_disp || crop_h > max_disp) return 1;
 
-retry:;
-  {
-    const int max_disp = T - 2 * OVERLAP_LINEAR;
-    if(crop_w > max_disp || crop_h > max_disp)
-    {
-      g_free(tile_in);
-      g_free(tile_out);
-      return 1;
-    }
-  }
-
-  inf_x = crop_x + crop_w / 2 - T / 2;
-  inf_y = crop_y + crop_h / 2 - T / 2;
+  const int inf_x = crop_x + crop_w / 2 - T / 2;
+  const int inf_y = crop_y + crop_h / 2 - T / 2;
 
   // extract crop + overlap from cached full lin_rec2020 -> tile_in
   // apply exposure boost (same as preview), run inference
-  tile_plane = (size_t)T * T;
-  g_free(tile_in);
-  g_free(tile_out);
-  tile_in = g_try_malloc(tile_plane * 3 * sizeof(float));
-  tile_out = g_try_malloc(tile_plane * 3 * sizeof(float));
+  const size_t tile_plane = (size_t)T * T;
+  float *tile_in = g_try_malloc(tile_plane * 3 * sizeof(float));
+  float *tile_out = g_try_malloc(tile_plane * 3 * sizeof(float));
   if(!tile_in || !tile_out)
   {
     g_free(tile_in);
@@ -1016,16 +994,21 @@ retry:;
     }
   }
 
-  exposure_boost = 1.0f;
+  float exposure_boost = 1.0f;
   _linear_exposure_boost(ctx, tile_in, tile_plane, NULL, &exposure_boost);
 
-  if(dt_restore_run_patch_3ch_raw(ctx, tile_in, T, T, tile_out) != 0)
+  gboolean cpu_fallback_done = FALSE;
+  while(dt_restore_run_patch_3ch_raw(ctx, tile_in, T, T, tile_out) != 0)
   {
-    if(dt_restore_step_down_tile_size(ctx, &T))
+    if(!cpu_fallback_done && dt_restore_reload_session_cpu(ctx))
     {
       dt_print(DT_DEBUG_AI,
-               "[restore_raw_linear] preview failed, retrying at T=%d", T);
-      goto retry;
+               "[restore_raw_linear] preview GPU inference failed; "
+               "retrying on CPU");
+      dt_control_log(_("AI raw denoise: GPU inference failed, "
+                       "falling back to CPU"));
+      cpu_fallback_done = TRUE;
+      continue;
     }
     dt_print(DT_DEBUG_AI,
              "[restore_raw_linear] preview inference failed at T=%d", T);

--- a/src/common/ai/restore_rgb.c
+++ b/src/common/ai/restore_rgb.c
@@ -542,11 +542,9 @@ int dt_restore_process_tiled(dt_restore_context_t *ctx,
   const int O = dt_restore_get_overlap(scale);
   const int S = scale;
   const int out_w = width * S;
-  int T = ctx->tile_size;
+  const int T = ctx->tile_size;
+  gboolean cpu_fallback_done = FALSE;
 
-  // outer retry loop: on inference failure (e.g. GPU OOM) drop to the
-  // next smaller candidate in the shared ladder and try again
-retry:;
   int step = T - 2 * O;
   int T_out = T * S;
   int O_out = O * S;
@@ -653,18 +651,18 @@ retry:;
       if(dt_restore_run_patch(
            ctx, tile_in, T, T, tile_out, S) != 0)
       {
-        // retry with the next smaller ladder entry if no rows have
-        // been delivered yet (safe to restart). once rows are written
-        // we can't rewind the row_writer (e.g. TIFF is sequential)
-        if(ty == 0 && dt_restore_step_down_tile_size(ctx, &T))
+        // GPU failure on the first tile: retry once on CPU. safe only
+        // before any rows have been delivered to the writer
+        if(tx == 0 && ty == 0 && !cpu_fallback_done
+           && dt_restore_reload_session_cpu(ctx))
         {
           dt_print(DT_DEBUG_AI,
-                   "[restore_rgb] tile %d,%d failed, retrying at T=%d",
-                   tx, ty, T);
-          g_free(tile_in);
-          g_free(tile_out);
-          g_free(row_buf);
-          goto retry;
+                   "[restore_rgb] GPU inference failed; retrying on CPU");
+          dt_control_log(_("AI denoise: GPU inference failed, "
+                           "falling back to CPU"));
+          cpu_fallback_done = TRUE;
+          tx--;  // re-run the same tile on the new session
+          continue;
         }
         dt_print(DT_DEBUG_AI,
                  "[restore_rgb] inference failed at tile %d,%d (T=%d)",
@@ -714,10 +712,6 @@ retry:;
       }
     }
   }
-
-  // persist tile size on first full success so subsequent runs skip OOM retry
-  if(res == 0)
-    dt_restore_persist_tile_size(ctx);
 
 cleanup:
   g_free(tile_in);


### PR DESCRIPTION
Companion to [darktable-ai#22](https://github.com/darktable-org/darktable-ai/pull/22) – **both must land together**. Bug-fix PR; no new functionality.

### Issues fixed

- **Spurious "tile size not in ladder" errors during normal use** – old OOM-retry stepped down the ladder on transient EP hitches. Dropped; static-shape models have one fixed tile size, replaced retry with a one-shot CPU fallback.
- **Multi-second hitches on first inference (CoreML / MIGraphX)** – dynamic-shape exports made JIT EPs recompile per shape. Static exports also unlock faster GPU kernel selection.
- **NaN/Inf from `rawdenoise-nind` bayer on Apple ANE** – FP16 overflow. New provider-agnostic `cpu_only` block matched by ONNX filename replaces the narrow per-variant `coreml_cpu_only` attribute.
- **CUDA VRAM leak on Blackwell** – V1 EP options leak per `Run`. Switched to V2 options, HEURISTIC search, `kSameAsRequested` arena, `gpu_mem_limit` from `nvidia-smi`.

All four NR models fit in **4 GB VRAM**.