### PR TITLE
[AI] Bump minimum ORT API to v18 (ORT 1.18) for ROCm 6.0 + V2 CUDA options

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,8 +122,9 @@ GPU-enabled build of [ONNX Runtime](https://onnxruntime.ai/) separately:
   * macOS 11+ (Big Sur)
   * Apple Silicon (M1+)
 
-**GPU memory:** 4 GB VRAM minimum, 8 GB+ recommended. With less memory
-darktable will use smaller tiles, which is slower but still works.
+**GPU memory:** 4 GB VRAM minimum. Models ship with fixed input
+dimensions sized to fit this budget; if GPU inference fails (out of
+memory, unsupported op), darktable automatically falls back to CPU.
 
 To enable GPU acceleration, set the path to the GPU-enabled ONNX Runtime library in
 preferences → processing → AI. darktable will auto-detect available execution providers.
@@ -237,7 +238,7 @@ Optional dependencies (minimum version):
 * libgphoto2 2.5 *(for camera tethering)*
 * Imath 3.1.0 *(for 16-bit "half" float TIFF export and faster import)*
 * libavif 0.9.3 *(for AVIF import & export)*
-* ONNX Runtime 1.16 *(for AI inference)*
+* ONNX Runtime 1.18 *(for AI inference)*
 * libarchive 3.8.5 *(for AI models download)*
 * libheif 1.13.0 *(for HEIF/HEIC/HIF import; also for AVIF import if no libavif)*
 * libjxl 0.7.0 *(for JPEG XL import & export)*

--- a/src/ai/backend_onnx.c
+++ b/src/ai/backend_onnx.c
@@ -56,11 +56,10 @@ struct dt_ai_context_t
   gboolean dynamic_outputs;
 };
 
-// minimum ORT API we'll fall back to when the runtime library is older
-// than what we were compiled against. v14 = ORT 1.14, the first release
-// with ONNX opset 18 support — older ORT can't run our models. bump
-// this in lockstep with any model that requires a newer opset
-#define DT_ORT_MIN_API_VERSION 14
+// minimum ORT API we accept. v18 = ORT 1.18, required for ROCm 6.0
+// and the V2 CUDA EP options API. caps ONNX opset at 20 — bump in
+// lockstep with any model that needs a newer opset
+#define DT_ORT_MIN_API_VERSION 18
 
 // global singletons (initialized exactly once via g_once)
 // ORT requires at most one OrtEnv per process.


### PR DESCRIPTION
Raises the minimum ONNX Runtime version we accept from 1.14 to 1.18.

## Why

- **ROCm 6.0 support.** ORT 1.14–1.17 only support ROCm 5.x; AMD users on current Linux distros (ROCm 6.0+) need 1.18.
- **V2 CUDA EP options API.** Required for the recent CUDA VRAM-leak fix (`CreateCUDAProviderOptions` / `UpdateCUDAProviderOptions` / `SessionOptionsAppendExecutionProvider_CUDA_V2`).
- Also caps the ONNX opset ceiling at 20, which is what current AI model exports target.