### PR TITLE
Fix agx crash on gui_init in AgX

### DIFF
--- a/src/iop/agx.c
+++ b/src/iop/agx.c
@@ -1727,12 +1727,14 @@ static void _update_curve_warnings(dt_iop_module_t *self)
   const gboolean warnings_enabled = dt_conf_get_bool("plugins/darkroom/agx/enable_curve_warnings");
   const tone_mapping_params_t params = _calculate_tone_mapping_params(p);
 
-  dt_bauhaus_widget_set_quad_paint(g->basic_curve_controls.curve_toe_power,
-                                    params.need_convex_toe && warnings_enabled
-                                    ? dtgtk_cairo_paint_warning : NULL, CPF_ACTIVE, NULL);
-  dt_bauhaus_widget_set_quad_paint(g->basic_curve_controls.curve_shoulder_power,
-                                    params.need_concave_shoulder && warnings_enabled
-                                    ? dtgtk_cairo_paint_warning : NULL, CPF_ACTIVE, NULL);
+  if(g->basic_curve_controls.curve_toe_power)
+    dt_bauhaus_widget_set_quad_paint(g->basic_curve_controls.curve_toe_power,
+                                     params.need_convex_toe && warnings_enabled
+                                     ? dtgtk_cairo_paint_warning : NULL, CPF_ACTIVE, NULL);
+  if(g->basic_curve_controls.curve_shoulder_power)
+    dt_bauhaus_widget_set_quad_paint(g->basic_curve_controls.curve_shoulder_power,
+                                     params.need_concave_shoulder && warnings_enabled
+                                     ? dtgtk_cairo_paint_warning : NULL, CPF_ACTIVE, NULL);
 }
 
 static void _update_redraw_dynamic_gui(dt_iop_module_t* const self,


### PR DESCRIPTION
This caused darktable to crash occasionally when entering the darkroom.

**Cause:** During gui_init, `dt_bauhaus_slider_set_soft_range()` on the curve_contrast_around_pivot slider fires a signal chain → _update_curve_warnings → tries to dereference curve_toe_power/curve_shoulder_power which may not be assigned yet.
**Fix:** Added `if(widget)` guards before the two `dt_bauhaus_widget_set_quad_paint()` calls.

Co-authored with Claude.