### PR TITLE
Fix zoom freezing at named stops

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -2887,9 +2887,9 @@ static float _calculate_new_scroll_zoom_tscale(const int up,
     {
     case SIZE_LARGE:
       tscalemax = constrained
-        ? (tscaleold > 2.0f
+        ? (tscaleold >= 2.0f
            ? tscaletop
-           : (tscaleold > 1.0f ? 2.0f : 1.0f))
+           : (tscaleold >= 1.0f ? 2.0f : 1.0f))
         : tscaletop;
       tscalemin = constrained
         ? (tscaleold < tscalefit
@@ -2899,7 +2899,7 @@ static float _calculate_new_scroll_zoom_tscale(const int up,
       break;
     case SIZE_MEDIUM:
       tscalemax = constrained
-        ? (tscaleold > 2.0f
+        ? (tscaleold >= 2.0f
            ? tscaletop
            : 2.0f)
         : tscaletop;
@@ -2911,7 +2911,7 @@ static float _calculate_new_scroll_zoom_tscale(const int up,
       break;
     case SIZE_SMALL:
       tscalemax = constrained
-        ? (tscaleold > 2.0f
+        ? (tscaleold >= 2.0f
            ? tscaletop
            : tscalefit)
         : tscaletop;


### PR DESCRIPTION
This caused zoom controls to become unresponsive, and changing the zoom level in the preview window to be ineffective.

**Cause:** In `_calculate_new_scroll_zoom_tscale`, the `tscalemax `soft-limit used strict `> N` comparisons. Once `tscaleold` snapped exactly to 1.0f (100%) or 2.0f (200%), the limit resolved to `N` itself, and `MIN(tscalenew, N) = N` — permanently stuck. This affected all three image-size cases.
**Fix:** Changed `> 1.0f` → `>= 1.0f` and `> 2.0f` → `>= 2.0f `throughout, so being exactly on a stop allows escaping it on the next scroll.

The zoom combo in the navigation panel was broken as a secondary symptom — if scroll zoom was stuck and `dt_dev_zoom_move` returned early (no change detected), `dt_control_navigation_redraw()` was never called, so the combo display wasn't refreshed.

Co-authored with Claude.