### PR TITLE
[AI] Fix stack smash in Permutohedral Key constructor for implicit axis

### DIFF
--- a/src/iop/Permutohedral.h
+++ b/src/iop/Permutohedral.h
@@ -170,7 +170,11 @@ public:
       DT_OMP_SIMD()
       for(int i = 0; i < KD; i++)
 	 key[i] = origin.key[i] + direction;
-      key[dim] = origin.key[dim] - direction * KD;
+      // KD of the lattice's (KD+1) coords are stored; the (KD+1)-th is
+      // implicit (-sum). skip the adjustment for the implicit axis to
+      // avoid writing key[KD] and smashing the stack
+      if(dim < KD)
+        key[dim] = origin.key[dim] - direction * KD;
       setHash();
     }
 


### PR DESCRIPTION
Fix out-of-bounds write in `PermutohedralLattice::Key` constructor that smashed the stack canary on every OpenMP worker during DenseCRF mask refinement, crashing darktable on the first AI object-mask click.

Reported at https://discuss.pixls.us/t/introducing-neural-restore-module-raw-denoise-denoise-and-upscale/57349/62

The lattice stores `KD = D` explicit coordinates with the `(D+1)`-th implicit (sum-zero constraint), but `blur()` calls the neighbor constructor with `dim ∈ [0..D]`. When `dim == KD`, the unconditional `key[dim] = …` wrote past the `short key[KD]` array. Guarded with `if(dim < KD)` - the implicit axis needs no second adjustment.
