### PR TITLE
Button to straighten horizon

### DIFF
--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -246,6 +246,8 @@ typedef struct dt_develop_t
 
     // this module receives right-drag events if not already claimed
     struct dt_iop_module_t *rotate;
+    // when set, left-click events are forwarded to proxy.rotate (used for fix horizon from quick access)
+    gboolean forward_left_click;
 
     // modulegroups plugin hooks
     struct

--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -3585,13 +3585,17 @@ void dtgtk_cairo_paint_horizon(cairo_t *cr, const gint x, const gint y, const gi
 {
   PREAMBLE(1, 1, 0, 0)
 
-  // horizon line
+  // horizon line (2px tall)
+  cairo_matrix_t matrix;
+  cairo_get_matrix(cr, &matrix);
+  cairo_set_line_width(cr, 2.0 / matrix.yy);
   cairo_move_to(cr, 0.0, 0.55);
   cairo_line_to(cr, 1.0, 0.55);
   cairo_stroke(cr);
 
-  // sun half circle above horizon, centered on the line
-  cairo_arc_negative(cr, 0.5, 0.55, 0.22, 0, -M_PI);
+  // sun half circle above horizon (2px thick, with 1px gap)
+  cairo_set_line_width(cr, 2.0 / matrix.yy);
+  cairo_arc_negative(cr, 0.5, 0.55 - 1.0 / matrix.yy, 0.22, 0, -M_PI);
   cairo_stroke(cr);
 
   FINISH

--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -3581,6 +3581,22 @@ void dtgtk_cairo_paint_snapshots_restore(cairo_t *cr, const gint x, const gint y
   FINISH
 }
 
+void dtgtk_cairo_paint_horizon(cairo_t *cr, const gint x, const gint y, const gint w, const gint h, gint flags, void *data)
+{
+  PREAMBLE(1, 1, 0, 0)
+
+  // horizon line
+  cairo_move_to(cr, 0.0, 0.55);
+  cairo_line_to(cr, 1.0, 0.55);
+  cairo_stroke(cr);
+
+  // sun half circle above horizon
+  cairo_arc(cr, 0.3, 0.35, 0.15, -M_PI, 0);
+  cairo_stroke(cr);
+
+  FINISH
+}
+
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -3590,8 +3590,8 @@ void dtgtk_cairo_paint_horizon(cairo_t *cr, const gint x, const gint y, const gi
   cairo_line_to(cr, 1.0, 0.55);
   cairo_stroke(cr);
 
-  // sun half circle above horizon
-  cairo_arc(cr, 0.3, 0.35, 0.15, -M_PI, 0);
+  // sun half circle above horizon, centered on the line
+  cairo_arc_negative(cr, 0.5, 0.55, 0.22, 0, -M_PI);
   cairo_stroke(cr);
 
   FINISH

--- a/src/dtgtk/paint.h
+++ b/src/dtgtk/paint.h
@@ -359,6 +359,8 @@ void dtgtk_cairo_paint_filtering_menu(cairo_t *cr, gint x, gint y, gint w, gint 
 
 /** Paint an icon for snapshots restore button */
 void dtgtk_cairo_paint_snapshots_restore(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
+/** paint a horizon fix icon */
+void dtgtk_cairo_paint_horizon(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 
 G_END_DECLS
 

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -367,6 +367,7 @@ typedef struct dt_iop_ashift_gui_data_t
   GtkWidget *structure_quad;
   GtkWidget *structure_lines;
   gboolean straightening;
+  gboolean straighten_click_mode;
   gboolean fix_horizon_active;
   float straighten_x;
   float straighten_y;
@@ -4823,7 +4824,47 @@ int button_pressed(dt_iop_module_t *self,
          || (g->fix_horizon_active && which == GDK_BUTTON_PRIMARY)))
   {
     dt_control_change_cursor("crosshair");
+
+    // click-click mode when fix horizon button is active and right-click
+    if(g->fix_horizon_active && which == GDK_BUTTON_SECONDARY)
+    {
+      if(g->straightening)
+      {
+        // second right-click: finalize the straightening
+        g->straightening = FALSE;
+        g->straighten_click_mode = FALSE;
+
+        const float angle = _calculate_straightening(self, pzx, pzy, g->straighten_x, g->straighten_y, wd, ht, zoom_scale);
+
+        dt_bauhaus_widget_set_quad_active(g->rotation, FALSE);
+        g->fix_horizon_active = FALSE;
+        darktable.develop->proxy.forward_left_click = FALSE;
+        dt_control_change_cursor("default");
+
+        if(angle != 0.0f)
+        {
+          const float n = dt_bauhaus_slider_get(g->rotation) - angle;
+          dt_bauhaus_slider_set(g->rotation, n);
+          dt_toast_log(_("rotation adjusted by %3.2f° to %3.2f°"), -angle, n);
+        }
+        dt_control_queue_redraw_center();
+        return TRUE;
+      }
+      else
+      {
+        // first right-click: record the first point
+        g->straightening = TRUE;
+        g->straighten_click_mode = TRUE;
+        g->straighten_x = pzx;
+        g->straighten_y = pzy;
+        dt_control_queue_redraw_center();
+        return TRUE;
+      }
+    }
+
+    // drag mode for left-click (with button active) or right-click (without button)
     g->straightening = TRUE;
+    g->straighten_click_mode = FALSE;
     g->straighten_x = pzx;
     g->straighten_y = pzy;
     return TRUE;
@@ -5062,6 +5103,9 @@ int button_released(dt_iop_module_t *self,
 
   if(g->straightening)
   {
+    // if in click-click mode, do nothing on release (waiting for second click)
+    if(g->straighten_click_mode) return TRUE;
+
     g->straightening = FALSE;
 
     const float bzx = g->straighten_x, bzy = g->straighten_y;
@@ -5483,7 +5527,16 @@ static void _event_fix_horizon_quad_clicked(GtkWidget *widget,
 {
   dt_iop_ashift_gui_data_t *g = self->gui_data;
   g->fix_horizon_active = dt_bauhaus_widget_get_quad_active(widget);
-  dt_control_change_cursor(g->fix_horizon_active ? "crosshair" : "default");
+  if(!g->fix_horizon_active)
+  {
+    g->straightening = FALSE;
+    g->straighten_click_mode = FALSE;
+    dt_control_change_cursor("default");
+  }
+  else
+  {
+    dt_control_change_cursor("crosshair");
+  }
   darktable.develop->proxy.forward_left_click = g->fix_horizon_active;
 }
 
@@ -5975,6 +6028,7 @@ void gui_init(dt_iop_module_t *self)
   g->jobparams = 0;
   g->adjust_crop = FALSE;
   g->fix_horizon_active = FALSE;
+  g->straighten_click_mode = FALSE;
   g->lastx = g->lasty = -1.0f;
   g->crop_cx = g->crop_cy = 1.0f;
 
@@ -5994,7 +6048,7 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_widget_set_quad_toggle(g->rotation, TRUE);
   g_signal_connect(G_OBJECT(g->rotation), "quad-pressed",
                    G_CALLBACK(_event_fix_horizon_quad_clicked), (gpointer)self);
-  dt_bauhaus_widget_set_quad_tooltip(g->rotation, _("fix the horizon by drawing a line on the image\nclick to activate, then click and drag on the image"));
+  dt_bauhaus_widget_set_quad_tooltip(g->rotation, _("fix the horizon by drawing a line on the image\n\nleft-click and drag on the image\nOR\nright-click to place the first point\nthen right click again to release the tool"));
 
   g->cropmode = dt_bauhaus_combobox_from_params(self, "cropmode");
   g_signal_connect(G_OBJECT(g->cropmode), "value-changed",
@@ -6090,8 +6144,8 @@ void gui_init(dt_iop_module_t *self)
 
   gtk_widget_set_tooltip_text
     (g->rotation,
-     _("rotate image\nright-click and drag to define a horizontal or vertical"
-       " line by drawing on the image"));
+     _("rotate image\nright-click twice to define a horizontal or vertical"
+       " line on the image"));
   gtk_widget_set_tooltip_text
     (g->lensshift_v, _("apply lens shift correction in one direction"));
   gtk_widget_set_tooltip_text

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -5535,6 +5535,8 @@ static void _event_fix_horizon_quad_clicked(GtkWidget *widget,
   }
   else
   {
+    if(self->off) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(self->off), TRUE);
+    dt_iop_request_focus(self);
     dt_control_change_cursor("crosshair");
   }
   darktable.develop->proxy.forward_left_click = g->fix_horizon_active;

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -6048,7 +6048,10 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_widget_set_quad_toggle(g->rotation, TRUE);
   g_signal_connect(G_OBJECT(g->rotation), "quad-pressed",
                    G_CALLBACK(_event_fix_horizon_quad_clicked), (gpointer)self);
-  dt_bauhaus_widget_set_quad_tooltip(g->rotation, _("fix the horizon by drawing a line on the image\n\nleft-click and drag on the image\nOR\nright-click to place the first point\nthen right click again to release the tool"));
+  dt_bauhaus_widget_set_quad_tooltip(g->rotation,
+                                     _("fix the horizon by drawing a line on the image\n\n"
+                                       "left-click and drag on the image\nOR\nright-click "
+                                       "to place the first point\nthen right-click again to release the tool"));
 
   g->cropmode = dt_bauhaus_combobox_from_params(self, "cropmode");
   g_signal_connect(G_OBJECT(g->cropmode), "value-changed",
@@ -6144,8 +6147,8 @@ void gui_init(dt_iop_module_t *self)
 
   gtk_widget_set_tooltip_text
     (g->rotation,
-     _("rotate image\nright-click twice to define a horizontal or vertical"
-       " line on the image"));
+     _("rotate image\nright-click and drag to define a horizontal or vertical"
+       " line by drawing on the image"));
   gtk_widget_set_tooltip_text
     (g->lensshift_v, _("apply lens shift correction in one direction"));
   gtk_widget_set_tooltip_text

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -5071,6 +5071,7 @@ int button_released(dt_iop_module_t *self,
     {
       dt_bauhaus_widget_set_quad_active(g->rotation, FALSE);
       g->fix_horizon_active = FALSE;
+      darktable.develop->proxy.forward_left_click = FALSE;
       dt_control_change_cursor("default");
     }
 
@@ -5483,6 +5484,7 @@ static void _event_fix_horizon_quad_clicked(GtkWidget *widget,
   dt_iop_ashift_gui_data_t *g = self->gui_data;
   g->fix_horizon_active = dt_bauhaus_widget_get_quad_active(widget);
   dt_control_change_cursor(g->fix_horizon_active ? "crosshair" : "default");
+  darktable.develop->proxy.forward_left_click = g->fix_horizon_active;
 }
 
 static int _event_structure_auto_clicked(GtkWidget *widget,
@@ -6178,7 +6180,10 @@ void gui_init(dt_iop_module_t *self)
 void gui_cleanup(dt_iop_module_t *self)
 {
   if(darktable.develop->proxy.rotate == self)
+  {
     darktable.develop->proxy.rotate = NULL;
+    darktable.develop->proxy.forward_left_click = FALSE;
+  }
 
   const dt_iop_ashift_gui_data_t *g = self->gui_data;
   if(g->lines) free(g->lines);

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -6051,7 +6051,7 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_widget_set_quad_tooltip(g->rotation,
                                      _("fix the horizon by drawing a line on the image\n\n"
                                        "left-click and drag on the image\nOR\nright-click "
-                                       "to place the first point\nthen right-click again to release the tool"));
+                                       "to place the first point,\nthen right-click again to finish and rotate the image"));
 
   g->cropmode = dt_bauhaus_combobox_from_params(self, "cropmode");
   g_signal_connect(G_OBJECT(g->cropmode), "value-changed",

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -5992,7 +5992,7 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_widget_set_quad_toggle(g->rotation, TRUE);
   g_signal_connect(G_OBJECT(g->rotation), "quad-pressed",
                    G_CALLBACK(_event_fix_horizon_quad_clicked), (gpointer)self);
-  dt_bauhaus_widget_set_quad_tooltip(g->rotation, _("fix the horizon by drawing a line on the image"));
+  dt_bauhaus_widget_set_quad_tooltip(g->rotation, _("fix the horizon by drawing a line on the image\nclick to activate, then click and drag on the image"));
 
   g->cropmode = dt_bauhaus_combobox_from_params(self, "cropmode");
   g_signal_connect(G_OBJECT(g->cropmode), "value-changed",

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -5535,7 +5535,12 @@ static void _event_fix_horizon_quad_clicked(GtkWidget *widget,
   }
   else
   {
-    if(self->off) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(self->off), TRUE);
+    if(self->off)
+    {
+      gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(self->off), TRUE);
+      dt_bauhaus_widget_set_quad_active(widget, TRUE);
+      g->fix_horizon_active = TRUE;
+    }
     dt_iop_request_focus(self);
     dt_control_change_cursor("crosshair");
   }
@@ -5896,13 +5901,14 @@ static gboolean _event_draw(GtkWidget *widget,
 
 void gui_focus(dt_iop_module_t *self, const gboolean in)
 {
+  dt_iop_ashift_gui_data_t *g = self->gui_data;
+
   darktable.develop->history_postpone_invalidate = in
     && dt_dev_modulegroups_test_activated(darktable.develop);
 
   if(self->enabled)
   {
     dt_iop_ashift_params_t *p = self->params;
-    dt_iop_ashift_gui_data_t *g = self->gui_data;
     if(in)
     {
       _shadow_crop_box(p,g);
@@ -5914,6 +5920,16 @@ void gui_focus(dt_iop_module_t *self, const gboolean in)
       _gui_update_structure_states(self, NULL);
       _do_clean_structure(self, p, TRUE);
     }
+  }
+
+  if(!in && g->fix_horizon_active)
+  {
+    dt_bauhaus_widget_set_quad_active(g->rotation, FALSE);
+    g->fix_horizon_active = FALSE;
+    g->straightening = FALSE;
+    g->straighten_click_mode = FALSE;
+    darktable.develop->proxy.forward_left_click = FALSE;
+    dt_control_change_cursor("default");
   }
 }
 

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -367,6 +367,7 @@ typedef struct dt_iop_ashift_gui_data_t
   GtkWidget *structure_quad;
   GtkWidget *structure_lines;
   gboolean straightening;
+  gboolean fix_horizon_active;
   float straighten_x;
   float straighten_y;
   int fitting;
@@ -4817,7 +4818,9 @@ int button_pressed(dt_iop_module_t *self,
   if(!dt_dev_get_preview_size(self->dev, &wd, &ht)) return 1;
 
   // if we start to draw a straightening line
-  if(!g->lines && which == GDK_BUTTON_SECONDARY)
+  if(!g->lines
+     && (which == GDK_BUTTON_SECONDARY
+         || (g->fix_horizon_active && which == GDK_BUTTON_PRIMARY)))
   {
     dt_control_change_cursor("crosshair");
     g->straightening = TRUE;
@@ -5063,6 +5066,14 @@ int button_released(dt_iop_module_t *self,
 
     const float bzx = g->straighten_x, bzy = g->straighten_y;
     const float angle = _calculate_straightening(self, pzx, pzy, bzx, bzy, wd, ht, zoom_scale);
+
+    if(g->fix_horizon_active)
+    {
+      dt_bauhaus_widget_set_quad_active(g->rotation, FALSE);
+      g->fix_horizon_active = FALSE;
+      dt_control_change_cursor("default");
+    }
+
     if(angle == 0.0f) return TRUE;
 
     const float n = dt_bauhaus_slider_get(g->rotation) - angle;
@@ -5464,6 +5475,14 @@ static int _event_fit_both_button_clicked(GtkWidget *widget,
     return TRUE;
   }
   return FALSE;
+}
+
+static void _event_fix_horizon_quad_clicked(GtkWidget *widget,
+                                            dt_iop_module_t *self)
+{
+  dt_iop_ashift_gui_data_t *g = self->gui_data;
+  g->fix_horizon_active = dt_bauhaus_widget_get_quad_active(widget);
+  dt_control_change_cursor(g->fix_horizon_active ? "crosshair" : "default");
 }
 
 static int _event_structure_auto_clicked(GtkWidget *widget,
@@ -5953,6 +5972,7 @@ void gui_init(dt_iop_module_t *self)
   g->jobcode = ASHIFT_JOBCODE_NONE;
   g->jobparams = 0;
   g->adjust_crop = FALSE;
+  g->fix_horizon_active = FALSE;
   g->lastx = g->lasty = -1.0f;
   g->crop_cx = g->crop_cy = 1.0f;
 
@@ -5967,6 +5987,12 @@ void gui_init(dt_iop_module_t *self)
   dt_shortcut_register(ac, 0, DT_ACTION_EFFECT_UP, GDK_KEY_bracketleft, GDK_MOD1_MASK);
   dt_shortcut_register(ac, 0, DT_ACTION_EFFECT_DOWN, GDK_KEY_bracketright, GDK_MOD1_MASK);
   dt_shortcut_register(ac, 0, 0, GDK_KEY_r, GDK_MOD1_MASK);
+
+  dt_bauhaus_widget_set_quad_paint(g->rotation, dtgtk_cairo_paint_horizon, 0, NULL);
+  dt_bauhaus_widget_set_quad_toggle(g->rotation, TRUE);
+  g_signal_connect(G_OBJECT(g->rotation), "quad-pressed",
+                   G_CALLBACK(_event_fix_horizon_quad_clicked), (gpointer)self);
+  dt_bauhaus_widget_set_quad_tooltip(g->rotation, _("fix the horizon by drawing a line on the image"));
 
   g->cropmode = dt_bauhaus_combobox_from_params(self, "cropmode");
   g_signal_connect(G_OBJECT(g->cropmode), "value-changed",

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -858,7 +858,8 @@ void expose(dt_view_t *self,
   // if dragging the rotation line, do it and nothing else
   if(dev->proxy.rotate
      && (darktable.control->button_down_which == GDK_BUTTON_SECONDARY
-         || dmod == dev->proxy.rotate))
+         || dmod == dev->proxy.rotate
+         || dev->proxy.forward_left_click))
   {
     // reminder, we want this to be exposed always for guidings
     if(dev->proxy.rotate && dev->proxy.rotate->gui_post_expose)
@@ -3872,6 +3873,20 @@ void mouse_moved(dt_view_t *self,
      && !dt_iop_color_picker_is_visible(dev)
      && darktable.control->button_down
      && darktable.control->button_down_which == GDK_BUTTON_PRIMARY
+     && dev->proxy.rotate)
+  {
+    _get_zoom_pos(&dev->full, x, y, &zoom_x, &zoom_y, &zoom_scale);
+    handled = dev->proxy.rotate->mouse_moved(dev->proxy.rotate, zoom_x, zoom_y,
+                                             pressure, which, zoom_scale);
+  }
+
+  // fix horizon click-click: forward mouse moves with no button held
+  // so the rubber-band line updates between the two right-clicks
+  if(dev->proxy.forward_left_click
+     && !handled
+     && !darktable.develop->darkroom_skip_mouse_events
+     && !dt_iop_color_picker_is_visible(dev)
+     && !darktable.control->button_down
      && dev->proxy.rotate)
   {
     _get_zoom_pos(&dev->full, x, y, &zoom_x, &zoom_y, &zoom_scale);

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -3865,6 +3865,20 @@ void mouse_moved(dt_view_t *self,
                                           pressure, which, zoom_scale);
   }
 
+  // fix horizon: forward to proxy.rotate bypassing basics guard
+  if(dev->proxy.forward_left_click
+     && !handled
+     && !darktable.develop->darkroom_skip_mouse_events
+     && !dt_iop_color_picker_is_visible(dev)
+     && darktable.control->button_down
+     && darktable.control->button_down_which == GDK_BUTTON_PRIMARY
+     && dev->proxy.rotate)
+  {
+    _get_zoom_pos(&dev->full, x, y, &zoom_x, &zoom_y, &zoom_scale);
+    handled = dev->proxy.rotate->mouse_moved(dev->proxy.rotate, zoom_x, zoom_y,
+                                             pressure, which, zoom_scale);
+  }
+
   // module
   if(dev->gui_module && dev->gui_module->mouse_moved
      && !handled
@@ -3935,6 +3949,14 @@ int button_released(dt_view_t *self,
   float zoom_x = FLT_MAX, zoom_y, zoom_scale;
   // rotate
   if(which == GDK_BUTTON_SECONDARY && dev->proxy.rotate)
+  {
+    _get_zoom_pos(&dev->full, x, y, &zoom_x, &zoom_y, &zoom_scale);
+    handled = dev->proxy.rotate->button_released(dev->proxy.rotate, zoom_x, zoom_y,
+                                                 which, state, zoom_scale);
+    if(handled) return handled;
+  }
+  // fix horizon: forward to proxy.rotate bypassing basics guard
+  if(which == GDK_BUTTON_PRIMARY && dev->proxy.forward_left_click && dev->proxy.rotate)
   {
     _get_zoom_pos(&dev->full, x, y, &zoom_x, &zoom_y, &zoom_scale);
     handled = dev->proxy.rotate->button_released(dev->proxy.rotate, zoom_x, zoom_y,
@@ -4128,6 +4150,14 @@ int button_pressed(dt_view_t *self,
     _preview_pipe_zoom_correction(dev, &corr_x, &corr_y);
     handled = dt_masks_events_button_pressed(dev->gui_module, zoom_x + corr_x, zoom_y + corr_y,
                                              pressure, which, type, state);
+    if(handled) return handled;
+  }
+  // fix horizon: forward to proxy.rotate bypassing basics guard
+  if(dev->proxy.forward_left_click && which == GDK_BUTTON_PRIMARY && dev->proxy.rotate)
+  {
+    _get_zoom_pos(&dev->full, x, y, &zoom_x, &zoom_y, &zoom_scale);
+    handled = dev->proxy.rotate->button_pressed(dev->proxy.rotate, zoom_x, zoom_y,
+                                                pressure, which, type, state, zoom_scale);
     if(handled) return handled;
   }
   // module


### PR DESCRIPTION
I've added a simple button that allows you to simply straighten horizon. Similar to how we can use right-click + drag. I think this should help new users easily adopt darktable.

<img width="229" height="242" alt="image" src="https://github.com/user-attachments/assets/5f4fbfed-e0de-480b-9d3d-0e66e5d9a741" />
