### PR TITLE
Fix pixelpipe extra runs

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -718,20 +718,23 @@ restart:
   const gboolean require_zoom_test = (pipe->changed & ~DT_DEV_PIPE_ZOOMED) || initial;
   initial = FALSE; // don't enforce dt_dev_pixelpipe_change() for restarts
 
+  const float anticipate_move = pipe->changed & DT_DEV_PIPE_ZOOMED
+              ? dt_conf_get_float("darkroom/ui/anticipate_move")
+              : 1.0f;
+
   /* dt_dev_pixelpipe_change()
       locks history mutex while syncing nodes
       finally calculates dimensions
       leaves clean pipe->changed
   */
-  const float anticipate_move = pipe->changed & DT_DEV_PIPE_ZOOMED ? dt_conf_get_float("darkroom/ui/anticipate_move") : 1.0f;
   if(changing || port_loading)
     dt_dev_pixelpipe_change(pipe, dev);
 
   float scale = 1.0f;
   int window_width = G_MAXINT;
   int window_height = G_MAXINT;
-  float zoom_x  = 0;
-  float zoom_y = 0;
+  float zoom_x  = 0.0f;
+  float zoom_y = 0.0f;
 
   if(port)
   {
@@ -740,7 +743,9 @@ restart:
     // the image boundary
     if(port_loading || require_zoom_test)
     {
-      dt_print_pipe(DT_DEBUG_PIPE, "[dt_dev_zoom_move]", pipe, NULL, DT_DEVICE_NONE, NULL, NULL);
+      dt_print_pipe(DT_DEBUG_PIPE, "dt_dev_zoom_move", pipe, NULL, DT_DEVICE_NONE, NULL, NULL, "%s%s",
+        port_loading ? "port_loading " : "",
+        require_zoom_test ? "required_test" : "");
       dt_dev_zoom_move(port, DT_ZOOM_MOVE, 0.0f, 0, 0.0f, 0.0f, TRUE);
     }
 
@@ -764,42 +769,41 @@ restart:
 
   dt_get_times(&start);
 
-  // keep error status of dt_dev_pixelpipe_process() for easy log code && check
-  // for safe dt_control_queue_redraw_widget
-  const gboolean problem = dt_dev_pixelpipe_process(pipe, dev, x, y, wd, ht, scale, devid);
-  const dt_dev_pixelpipe_stopper_t shutdown = dt_atomic_get_int(&pipe->shutdown);
-  if(problem || shutdown)
-    dt_print(DT_DEBUG_PIPE, "dt_dev_pixelpipe_process %dx%d x=%d y=%d %s%s",
-                wd, ht, x, y,
-                problem ? "problem " : "success ",
-                shutdown == DT_DEV_PIXELPIPE_STOP_NODES ? "DT_DEV_PIXELPIPE_STOP_NODES"
-                : shutdown == DT_DEV_PIXELPIPE_STOP_HQ  ? "DT_DEV_PIXELPIPE_STOP_HQ"
-                : shutdown == DT_DEV_PIXELPIPE_STOP_NO  ? "DT_DEV_PIXELPIPE_STOP_NO"
-                : "DT_DEV_PIXELPIPE_STOP_OTHER");
-  if(problem)
+  // keep return status of dt_dev_pixelpipe_process()
+  const gboolean stopped = dt_dev_pixelpipe_process(pipe, dev, x, y, wd, ht, scale, devid);
+  if(stopped)
   {
+    // If pixelpipe stopped that could be because of pipe->shutdown so we check that and reset.
+    const dt_dev_pixelpipe_stopper_t shutdown = dt_atomic_exch_int(&pipe->shutdown, DT_DEV_PIXELPIPE_STOP_NO);
+    const dt_iop_roi_t proi = (dt_iop_roi_t) {.x = x, .y = y, .width = wd, .height = ht, .scale = scale };
+    dt_print_pipe(DT_DEBUG_PIPE, "pipe stopped", pipe, NULL, DT_DEVICE_NONE, &proi, NULL, "%s%s%s%s",
+                shutdown == DT_DEV_PIXELPIPE_STOP_NODES ? "DT_DEV_PIXELPIPE_STOP_NODES"
+                  : shutdown == DT_DEV_PIXELPIPE_STOP_HQ  ? "DT_DEV_PIXELPIPE_STOP_HQ"
+                  : shutdown == DT_DEV_PIXELPIPE_STOP_NO  ? "" : "DT_DEV_PIXELPIPE_STOP_OTHER",
+                dev->image_force_reload ? "image_force_reload " : "",
+                pipe->loading ? "pipe_loading " : "",
+                pipe->input_changed ? "pipe_input_changed " : "");
+
+    /* In some cases we should stop restarting the pipe but exit with DT_DEV_PIXELPIPE_INVALID status
+       How can we handle the pipe->loading status in a better way?
+       Just restart?
+    */
     const gboolean img_changed = dev->image_force_reload || pipe->loading || pipe->input_changed;
-    // As image_force_reload could be set while we are restarting we clear it and possibly flush the cache too.
-    if(dev->image_force_reload) dt_dev_pixelpipe_cache_flush(pipe);
-    dev->image_force_reload = FALSE;
-    // interrupted because image changed?
     if(img_changed)
     {
-      dt_print(DT_DEBUG_PIPE, "img changed: %s%s%s",
-                  dev->image_force_reload ? "image_force_reload " : "",
-                  pipe->loading ? "pipe loading " : "",
-                  pipe->input_changed ? "input_changed " : "");
+      if(dev->image_force_reload)
+      {
+        dt_dev_pixelpipe_cache_flush(pipe);
+        dev->image_force_reload = FALSE;
+      }
       dt_mipmap_cache_release(&buf);
       dt_control_busy_leave();
       pipe->status = DT_DEV_PIXELPIPE_INVALID;
       dt_pthread_mutex_unlock(&pipe->mutex);
       return;
     }
-    if(shutdown)
-    {
-      dt_atomic_set_int(&pipe->shutdown, DT_DEV_PIXELPIPE_STOP_NO);
+    if(shutdown != DT_DEV_PIXELPIPE_STOP_NO)
       goto restart;
-    }
   }
 
   dt_show_times_f(&start,
@@ -810,9 +814,8 @@ restart:
   // maybe we got zoomed/panned in the meantime?
   if(port && pipe->changed != DT_DEV_PIPE_UNCHANGED)
   {
-    if(port->widget && !problem)
+    if(port->widget && !stopped)
       dt_control_queue_redraw_widget(port->widget);
-    dt_atomic_set_int(&pipe->shutdown, DT_DEV_PIXELPIPE_STOP_NO);
     goto restart;
   }
 

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -811,14 +811,6 @@ restart:
                   dev->image_storage.filename);
   _dev_average_delay_update(&start, &pipe->average_delay);
 
-  // maybe we got zoomed/panned in the meantime?
-  if(port && pipe->changed != DT_DEV_PIPE_UNCHANGED)
-  {
-    if(port->widget && !stopped)
-      dt_control_queue_redraw_widget(port->widget);
-    goto restart;
-  }
-
   pipe->status = DT_DEV_PIXELPIPE_VALID;
   pipe->loading = FALSE;
   dev->image_invalid_cnt = 0;

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -3318,25 +3318,6 @@ GtkWidget *dt_iop_gui_get_pluginui(dt_iop_module_t *module)
   return dtgtk_expander_get_frame(DTGTK_EXPANDER(module->expander));
 }
 
-gboolean dt_iop_breakpoint(dt_develop_t *dev, dt_dev_pixelpipe_t *pipe)
-{
-  if(pipe != dev->preview_pipe
-     && pipe != dev->preview2.pipe)
-    sched_yield();
-
-  if(pipe != dev->preview_pipe
-     && pipe != dev->preview2.pipe
-     && pipe->changed == DT_DEV_PIPE_ZOOMED)
-    return TRUE;
-
-  if((pipe->changed != DT_DEV_PIPE_UNCHANGED
-      && pipe->changed != DT_DEV_PIPE_ZOOMED)
-     || dev->gui_leaving)
-    return TRUE;
-
-  return FALSE;
-}
-
 void dt_iop_nap(int32_t usec)
 {
   if(usec <= 0) return;

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -429,9 +429,6 @@ extern const struct dt_action_def_t dt_action_def_iop;
  */
 void dt_iop_cleanup_histogram(gpointer data, gpointer user_data);
 
-/** let plugins have breakpoints: */
-gboolean dt_iop_breakpoint(struct dt_develop_t *dev, struct dt_dev_pixelpipe_t *pipe);
-
 /** allow plugins to relinquish CPU and go to sleep for some time */
 void dt_iop_nap(int32_t usec);
 

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -1662,6 +1662,18 @@ static inline gboolean _skip_piece_on_tags(const dt_dev_pixelpipe_iop_t *piece)
           && dt_pipe_is_basic(piece->pipe);
 }
 
+static inline gboolean _dev_pixelpipe_stop_request(const dt_develop_t *dev,
+                                                   const dt_dev_pixelpipe_t *pipe)
+{
+  // sched_yield() doesn't make sense on current multicore systems any longer
+  return (dev && dev->gui_leaving)
+      || (dt_pipe_is_full(pipe) && pipe->changed == DT_DEV_PIPE_ZOOMED)
+      || (dt_pipe_is_full(pipe) && dev->image_force_reload)
+      || (dt_pipe_is_preview(pipe) && pipe->loading)
+      || (dt_pipe_is_preview2(pipe) && pipe->loading)
+      || (pipe->changed != DT_DEV_PIPE_UNCHANGED && pipe->changed != DT_DEV_PIPE_ZOOMED);
+}
+
 // recursive helper for process, returns TRUE in case of unfinished work or error
 static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
                                            dt_develop_t *dev,
@@ -1761,17 +1773,9 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
     return FALSE;
   }
 
-  // 2) if history changed or exit event, abort processing?
-  // preview pipe: abort on all but zoom events (same buffer anyways)
-  // if image has changed, stop now.
-  if(dt_iop_breakpoint(dev, pipe)
-     || (pipe == dev->full.pipe     && dev->image_force_reload)
-     || (pipe == dev->preview_pipe  && dev->preview_pipe->loading)
-     || (pipe == dev->preview2.pipe && dev->preview2.pipe->loading)
-     || dev->gui_leaving)
-  {
+  // 2) if history changed or exit event ... abort pipe processing?
+  if(_dev_pixelpipe_stop_request(dev, pipe))
     return TRUE;
-  }
 
   // 3) input -> output
   if(!modules)

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -1673,6 +1673,9 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
                                            GList *pieces,
                                            const int pos)
 {
+  /* As this is done recursively we check for any dt_dev_pixelpipe_stopper_t
+     signal that might have been set.
+  */
   if(dt_pipe_shutdown(pipe))
     return TRUE;
 
@@ -1728,9 +1731,6 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
   const size_t bufsize = (size_t)bpp * roi_out->width * roi_out->height;
 
   // 1) if cached buffer is still available, return data
-  if(dt_pipe_shutdown(pipe))
-    return TRUE;
-
   dt_hash_t hash = dt_dev_pixelpipe_cache_hash(roi_out, pipe, pos);
 
   // we do not want data from the preview pixelpipe cache
@@ -1752,10 +1752,6 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
   {
     dt_dev_pixelpipe_cache_get(pipe, hash, bufsize,
                                output, out_format, module, TRUE);
-
-    if(dt_pipe_shutdown(pipe))
-      return TRUE;
-
     dt_print_pipe(DT_DEBUG_PIPE,
                   "pipe data: from cache",
                   pipe, module, DT_DEVICE_NONE, &roi_in, NULL);
@@ -1930,15 +1926,15 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
     dt_show_times_f(&start, "[dev_pixelpipe]",
                     "initing base buffer [%s]", dt_dev_pixelpipe_type_to_str(pipe->type));
 
-    return dt_pipe_shutdown(pipe);
+    return FALSE;
   }
+
+  if(dt_pipe_shutdown(pipe))
+    return TRUE;
 
   // 3b) recurse and obtain output array in &input
 
   // get region of interest which is needed in input
-  if(dt_pipe_shutdown(pipe))
-    return TRUE;
-
   module->modify_roi_in(module, piece, roi_out, &roi_in);
   if((darktable.unmuted & DT_DEBUG_PIPE) && memcmp(roi_out, &roi_in, sizeof(dt_iop_roi_t)))
   {
@@ -1973,10 +1969,10 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
 
   const size_t out_bpp = dt_iop_buffer_dsc_to_bpp(*out_format);
 
-  // reserve new cache line: output
   if(dt_pipe_shutdown(pipe))
     return TRUE;
 
+  // reserve new cache line: output
   const gboolean important = module
       && dt_pipe_no_mask_display(pipe)
       && dt_pipe_is_canvas(pipe)


### PR DESCRIPTION
What is this about? Currently i am aware of at least 4 issues/limitations in pixelpipe code that need attention.
1. We sometimes invalidate parts of the pipe cache where it's not required. Deferred to early 5.8 so we get lot's of field testing ...
2. In rare situations we still can have "loops". This is pretty rare now but yet there are at least two late reports in #20536 and #20105. I couldn't reproduce lately but something to be observed (first commit has improved logs for tracking this ...)
3. Pixelpipe interruption while processing modules doesn't work as good as intended. Also deferred to 5.8 for field testing ...
4. When zooming in/out in darkroom we had potentially costly superfluous pixelpipe runs. That was also reported - can't find the issue. The penalty in this log is pretty small - a) it's a fast machine b) we had a hit for the cache c) our cache strategy currently ensures cacheline writing for that very late module (which is also costly especially on OpenCL)
 
That's what is fixed in this PR. In master we find in the `-d pipe` log (without opencl but that does not matter principally) after zooming in (spot lines after `pipe finished`)
```
    37,7032 transform colorspace      CPU [full]           colorout               8600       (0/0)  1408x1029 sc=0,137; IOP_CS_RGB -> IOP_CS_LAB `Linear Rec2020 RGB'
    37,7050 process                   CPU [full]           colorout               8600       (0/0)  1408x1029 sc=0,137; IOP_CS_LAB -> IOP_CS_RGB 46MB
    37,7063 process                   CPU [full]           gamma                  9300       (0/0)  1408x1029 sc=0,137; IOP_CS_RGB 46MB
    37,7081 cache report                  [full]                                        64 lines (important=5, used=24, invalid=0). Using 1292MB, limit=3010MB. Hits/run=0,33. Hits/test=0,037
    37,7081 pipe finished             CPU [full]                                             (0/0)  1408x1029 sc=0,137; 'L1010715.DNG' ID=8953
    37,7082 dev_pixelpipe_change          [full]                                        zoomed, 
    37,7082 get dimensions                [full]                                             (0/0)  9536x6344 sc=1,000; ID=8953
    37,7082 modified roi OUT              [full]           rawprepare              100       (0/0)  9536x6344 sc=1,000 -->       (0/0)  9520x6336 sc=1,000; 
    37,7082 modified roi OUT              [full]           ashift                 1700       (0/0)  9520x6336 sc=1,000 -->       (0/0) 10248x7495 sc=1,000; 
    37,7082 pipe cache check              [full]                                        64 lines (important=5, used=24). Freed: invalid 0MB used 0MB. Using 1292MB, limit=3010MB
    37,7082 pipe starting             CPU [full]                                             (0/0)  1408x1029 sc=0,137; 'L1010715.DNG' ID=8953 using 65847MB
    37,7083 cache HIT                     [full]           gamma                  9300  IOP_CS_RGB 1,883 1,000 1,748, hash=c9634c9a874e0708
    37,7083 pipe data: from cache         [full]           gamma                  9300       (0/0)  1408x1029 sc=0,137; 
    37,7084 cache report                  [full]                                        64 lines (important=5, used=24, invalid=0). Using 1292MB, limit=3010MB. Hits/run=0,50. Hits/test=0,071
    37,7084 pipe finished             CPU [full]                                             (0/0)  1408x1029 sc=0,137; 'L1010715.DNG' ID=8953
```

With this PR we find
```
     9,9485 process                   CPU [full]           demosaic                900     (131/0)  9236x6332 sc=1,000 -->      (18/0)   1269x870 sc=0,137; IOP_CS_RAW -> IOP_CS_RGB 953MB
    10,5854 process                   CPU [full]           lens                   1400      (18/0)   1269x870 sc=0,137 -->       (0/0)   1307x870 sc=0,137; IOP_CS_RGB 82MB
    10,5973 process                   CPU [full]           ashift                 1700       (0/0)   1307x870 sc=0,137 -->       (0/0)  1408x1029 sc=0,137; IOP_CS_RGB 53MB
    10,5997 process                   CPU [full]           exposure               2500       (0/0)  1408x1029 sc=0,137; IOP_CS_RGB 46MB
    10,6004 process                   CPU [full]           colorin                3300       (0/0)  1408x1029 sc=0,137; IOP_CS_RGB -> IOP_CS_LAB 46MB
    10,6004 coeff correction          CPU [full]           colorin                3300       (0/0)  1408x1029 sc=0,137; `Embedded matrix' 1,883(*0,828) 1,000(*1,000) 1,748(*1,015)
    10,6025 transform colorspace      CPU [full]           channelmixerrgb        3400       (0/0)  1408x1029 sc=0,137; IOP_CS_LAB -> IOP_CS_RGB `Linear Rec2020 RGB'
    10,6028 process                   CPU [full]           channelmixerrgb        3400       (0/0)  1408x1029 sc=0,137; IOP_CS_RGB 46MB
    10,6090 process                   CPU [full]           colorbalancergb        5400       (0/0)  1408x1029 sc=0,137; IOP_CS_RGB 46MB
    10,6254 process                   CPU [full]           agx                    6000       (0/0)  1408x1029 sc=0,137; IOP_CS_RGB 46MB
    10,6377 transform colorspace      CPU [full]           colorout               8600       (0/0)  1408x1029 sc=0,137; IOP_CS_RGB -> IOP_CS_LAB `Linear Rec2020 RGB'
    10,6400 process                   CPU [full]           colorout               8600       (0/0)  1408x1029 sc=0,137; IOP_CS_LAB -> IOP_CS_RGB 46MB
    10,6416 process                   CPU [full]           gamma                  9300       (0/0)  1408x1029 sc=0,137; IOP_CS_RGB 46MB
    10,6437 cache report                  [full]                                        64 lines (important=5, used=24, invalid=0). Using 1292MB, limit=3010MB. Hits/run=0,33. Hits/test=0,037
    10,6437 pipe finished             CPU [full]                                             (0/0)  1408x1029 sc=0,137; 'L1010715.DNG' ID=8953
```

Pinging @kofa73 @TurboGit @ralfbrown @dterrahe (if you are reading) 
Overview about the commits ( i think all are good&safe (1) and (4) would be the minimal variant ...
______________________________________________________________________________________
** (1) Some cleanup in dt_dev_process_image_job()**

A reminder: dt_dev_pixelpipe_process() returns a gboolean status flag, this is TRUE if the pipe returned "early" for some reason. That could be due to a pipe->shutdown or some user interaction like zooming or switching image.

If status was TRUE we always check and reset pipe->shutdown atomically so we don't have to do that manually.
Some improved logs and comments.

______________________________________________________________________________________
**(2) Fixes for dt_pipe_shutdown()**

In some situations the shutdown checks while processing the pipe don't make sense.
Some code line changes for readability.

_______________________________________________________________________________________
**(3) Redefinition of dt_iop_breakpoint()**

This code is used only in pixelpipe_hb.c so it has been redefined there as `static inline gboolean _dev_pixelpipe_stop_request()`
- as it might be of use with dev == NULL we have a dereferencing check
- on current systems sched_yield() is not helping any longer.

_______________________________________________________________________
**(4) Avoid some superfluous full pixelpipe runs**

When zooming in/out in darkroom we had some extra pixelpipe runs due to bad restarting in `dt_dev_process_image_job()`.
As we take care for redrawing via a signal later, the removed part of the code was just bad.
The penalty was mostly not that bad because of caching but that depends on memory and on OpenCL if a module late in the pipe had cl_mem saved. But clearly bad.



   