### PR TITLE
Activate 100% zoom limit again

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -2433,12 +2433,19 @@
     <longdescription><![CDATA[in darktable's darkroom, where you do your edits, all controls are listed on a panel on the right; you can choose whether you want to use the scroll wheel or scroll gesture on your touchpad to scroll the panel, or to change the values of the control under the pointer; this latter modality enables faster editing, but this can be dangerous because you can change the values ​​of the module controls without noticing if you are not used to it\n\n<b>enabled:</b> the mouse wheel scrolls the modules panel and with <i>Ctrl+Alt</i> adjusts a control's value\n\n<b>disabled:</b> the mouse wheel adjusts the control under the pointer and with <i>Ctrl+Alt</i> scrolls the panel.]]></longdescription>
     <welcomescreen pagenum="5" questionnum="1"/>
   </dtconfig>
-  <dtconfig prefs="misc" section="interface">
+  <dtconfig prefs="misc" section="interface" restart="true">
     <name>darkroom/ui/touchpad_gestures</name>
     <type>bool</type>
     <default>true</default>
     <shortdescription>enable touchpad gestures in darkroom</shortdescription>
-    <longdescription><![CDATA[use two-finger touchpad gestures in darkroom for panning and pinch-to-zoom. <b>enabled:</b> touchpad pinch gestures zoom the image and two-finger touchpad scrolling pans it; <i>Ctrl+scroll</i> still uses the legacy zoom behavior. <b>disabled:</b> touchpad gestures are ignored and darkroom falls back to the legacy scroll behavior, including <i>Ctrl+scroll</i> for zooming in and out.]]></longdescription>
+    <longdescription><![CDATA[use two-finger touchpad gestures in darkroom for panning and pinch-to-zoom. <b>enabled:</b> touchpad pinch gestures zoom the image and two-finger touchpad scrolling pans it; <i>Ctrl+scroll</i> still uses the legacy zoom behavior. <b>disabled:</b> touchpad gestures are ignored and darkroom falls back to the legacy scroll behavior, including <i>Ctrl+scroll</i> for zooming in and out. (restart required)]]></longdescription>
+  </dtconfig>
+  <dtconfig prefs="misc" section="interface" restart="true">
+    <name>darkroom/ui/constrain_zoom</name>
+    <type>bool</type>
+    <default>true</default>
+    <shortdescription>constrain darkroom zoom between screen fit and 100%</shortdescription>
+    <longdescription><![CDATA[limits scroll-wheel and pinch-to-zoom in the darkroom to the range between screen fit (zoom out) and 100% (zoom in). <b>enabled:</b> zoom is constrained; hold <i>Ctrl</i> while zooming to temporarily lift the limit and zoom beyond 100%. <b>disabled:</b> zoom is never constrained and the additional <i>Ctrl</i> key press is not needed to zoom beyond 100%. (restart required)]]></longdescription>
   </dtconfig>
   <dtconfig prefs="darkroom" section="general">
     <name>plugins/darkroom/ui/border_size</name>

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -2433,19 +2433,19 @@
     <longdescription><![CDATA[in darktable's darkroom, where you do your edits, all controls are listed on a panel on the right; you can choose whether you want to use the scroll wheel or scroll gesture on your touchpad to scroll the panel, or to change the values of the control under the pointer; this latter modality enables faster editing, but this can be dangerous because you can change the values ​​of the module controls without noticing if you are not used to it\n\n<b>enabled:</b> the mouse wheel scrolls the modules panel and with <i>Ctrl+Alt</i> adjusts a control's value\n\n<b>disabled:</b> the mouse wheel adjusts the control under the pointer and with <i>Ctrl+Alt</i> scrolls the panel.]]></longdescription>
     <welcomescreen pagenum="5" questionnum="1"/>
   </dtconfig>
-  <dtconfig prefs="misc" section="interface" restart="true">
+  <dtconfig prefs="misc" section="interface">
     <name>darkroom/ui/touchpad_gestures</name>
     <type>bool</type>
     <default>true</default>
     <shortdescription>enable touchpad gestures in darkroom</shortdescription>
-    <longdescription><![CDATA[use two-finger touchpad gestures in darkroom for panning and pinch-to-zoom. <b>enabled:</b> touchpad pinch gestures zoom the image and two-finger touchpad scrolling pans it; <i>Ctrl+scroll</i> still uses the legacy zoom behavior. <b>disabled:</b> touchpad gestures are ignored and darkroom falls back to the legacy scroll behavior, including <i>Ctrl+scroll</i> for zooming in and out. (restart required)]]></longdescription>
+    <longdescription><![CDATA[use two-finger touchpad gestures in darkroom for panning and pinch-to-zoom. <b>enabled:</b> touchpad pinch gestures zoom the image and two-finger touchpad scrolling pans it; <i>Ctrl+scroll</i> still uses the legacy zoom behavior. <b>disabled:</b> touchpad gestures are ignored and darkroom falls back to the legacy scroll behavior, including <i>Ctrl+scroll</i> for zooming in and out.]]></longdescription>
   </dtconfig>
-  <dtconfig prefs="misc" section="interface" restart="true">
+  <dtconfig prefs="misc" section="interface">
     <name>darkroom/ui/constrain_zoom</name>
     <type>bool</type>
     <default>true</default>
     <shortdescription>constrain darkroom zoom between screen fit and 100%</shortdescription>
-    <longdescription><![CDATA[limits scroll-wheel and pinch-to-zoom in the darkroom to the range between screen fit (zoom out) and 100% (zoom in). <b>enabled:</b> zoom is constrained; hold <i>Ctrl</i> while zooming to temporarily lift the limit and zoom beyond 100%. <b>disabled:</b> zoom is never constrained and the additional <i>Ctrl</i> key press is not needed to zoom beyond 100%. (restart required)]]></longdescription>
+    <longdescription><![CDATA[limits scroll-wheel and pinch-to-zoom in the darkroom to the range between screen fit (zoom out) and 100% (zoom in). <b>enabled:</b> zoom is constrained; hold <i>Ctrl</i> while zooming to temporarily lift the limit and zoom beyond 100%. <b>disabled:</b> zoom is never constrained and the additional <i>Ctrl</i> key press is not needed to zoom beyond 100%.]]></longdescription>
   </dtconfig>
   <dtconfig prefs="darkroom" section="general">
     <name>plugins/darkroom/ui/border_size</name>

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -151,6 +151,8 @@ void dt_dev_init(dt_develop_t *dev,
   dev->full.color_assessment = dt_conf_get_bool("full_window/color_assessment");
   dev->preview2.color_assessment = dt_conf_get_bool("second_window/color_assessment");
 
+  dev->constrain_zoom = dt_conf_get_bool("darkroom/ui/constrain_zoom");
+
   dev->full.zoom = dev->preview2.zoom = DT_ZOOM_FIT;
   dev->full.closeup = dev->preview2.closeup = 0;
   dev->full.zoom_x = dev->full.zoom_y = dev->preview2.zoom_x = dev->preview2.zoom_y = 0.0f;
@@ -2847,11 +2849,20 @@ gboolean dt_dev_get_processed_size(dt_dev_viewport_t *port,
   return FALSE;
 }
 
-static float _calculate_new_scroll_zoom_tscale(const int up,
-                                               const gboolean constrained,
-                                               const float tscaleold,
-                                               const float tscalefit)
+// Compute the zoom soft limits for a given old tscale.
+// Shared between scroll-step zoom and continuous (pinch) zoom so both honor
+// the same constrain semantics: cap at 100%/200%/top depending on where the
+// previous scale sits, with CTRL clearing `constrained` upstream as the
+// escape hatch.
+static void _zoom_constraint_bounds(const gboolean constrained,
+                                    const float tscaleold,
+                                    const float tscalefit,
+                                    float *tscalemin,
+                                    float *tscalemax)
 {
+  const float tscaletop = 16.0f;
+  const float tscalefloor = MIN(0.5f * tscalefit, 1.0f);
+
   enum {
     SIZE_SMALL,
     SIZE_MEDIUM,
@@ -2865,6 +2876,48 @@ static float _calculate_new_scroll_zoom_tscale(const int up,
   else
     image_size = SIZE_SMALL;
 
+  switch(image_size)
+  {
+    case SIZE_LARGE:
+      *tscalemax = constrained
+        ? (tscaleold > 2.0f
+           ? tscaletop
+           : (tscaleold > 1.0f ? 2.0f : 1.0f))
+        : tscaletop;
+      *tscalemin = constrained
+        ? (tscaleold < tscalefit
+           ? tscalefloor
+           : tscalefit)
+        : tscalefloor;
+      break;
+    case SIZE_MEDIUM:
+      *tscalemax = constrained
+        ? (tscaleold > 2.0f
+           ? tscaletop
+           : 2.0f)
+        : tscaletop;
+      *tscalemin = constrained
+        ? (tscaleold < tscalefit
+           ? tscalefloor
+           : tscalefit)
+        : tscalefloor;
+      break;
+    case SIZE_SMALL:
+      *tscalemax = constrained
+        ? (tscaleold > 2.0f
+           ? tscaletop
+           : tscalefit)
+        : tscaletop;
+      *tscalemin = tscalefloor;
+      break;
+  }
+}
+
+static float _calculate_new_scroll_zoom_tscale(const int up,
+                                               const gboolean constrained,
+                                               const float tscaleold,
+                                               const float tscalefit)
+{
   // at 200% zoom level or more, we use a step of 2x, while at lower level we use 1.1x
   const float step =
     up
@@ -2875,59 +2928,20 @@ static float _calculate_new_scroll_zoom_tscale(const int up,
   float tscalenew = up ? tscaleold * step : tscaleold / step;
 
   // when zooming, secure we include 2:1, 1:1 and FIT levels anyway in the zoom stops
-  if((tscalenew - tscalefit) * (tscaleold - tscalefit) < 0 && image_size != SIZE_SMALL)
+  const gboolean is_small = tscalefit > 2.0f;
+  if((tscalenew - tscalefit) * (tscaleold - tscalefit) < 0 && !is_small)
     tscalenew = tscalefit;
   else if((tscalenew - 1.0f) * (tscaleold - 1.0f) < 0)
     tscalenew = 1.0f;
   else if((tscalenew - 2.0f) * (tscaleold - 2.0f) < 0)
     tscalenew = 2.0f;
 
-  float tscalemax, tscalemin;            // the zoom soft limits
-  const float tscaletop = 16.0f; // the zoom hard limits
-  const float tscalefloor = MIN(0.5f * tscalefit, 1.0f);
+  float tscalemin, tscalemax;
+  _zoom_constraint_bounds(constrained, tscaleold, tscalefit, &tscalemin, &tscalemax);
 
-  switch (image_size) // here we set the logic of zoom limits
-    {
-    case SIZE_LARGE:
-      tscalemax = constrained
-        ? (tscaleold > 2.0f
-           ? tscaletop
-           : (tscaleold > 1.0f ? 2.0f : 1.0f))
-        : tscaletop;
-      tscalemin = constrained
-        ? (tscaleold < tscalefit
-           ? tscalefloor
-           : tscalefit)
-        : tscalefloor;
-      break;
-    case SIZE_MEDIUM:
-      tscalemax = constrained
-        ? (tscaleold > 2.0f
-           ? tscaletop
-           : 2.0f)
-        : tscaletop;
-      tscalemin = constrained
-        ? (tscaleold < tscalefit
-           ? tscalefloor
-           : tscalefit)
-        : tscalefloor;
-      break;
-    case SIZE_SMALL:
-      tscalemax = constrained
-        ? (tscaleold > 2.0f
-           ? tscaletop
-           : tscalefit)
-        : tscaletop;
-      tscalemin = tscalefloor;
-      break;
-    }
-
-  // we enforce the zoom limits
-  tscalenew = up
+  return up
     ? MIN(tscalenew, tscalemax)
     : MAX(tscalenew, tscalemin);
-
-  return tscalenew;
 }
 
 static char *_transform_type(const dt_dev_transform_direction_t transf_direction)
@@ -3105,13 +3119,13 @@ void dt_dev_zoom_move(dt_dev_viewport_t *port,
     else if(zoom == DT_ZOOM_SCROLL)
     {
       zoom = DT_ZOOM_FREE;
-      const float fitscale = dt_dev_get_zoom_scale(port, DT_ZOOM_FIT, 1.0, FALSE);
+      const float fitscale = dt_dev_get_zoom_scale(port, DT_ZOOM_FIT, 1, FALSE);
       const float tscaleold = cur_scale * ppd;
       const float tscale = _calculate_new_scroll_zoom_tscale (closeup, constrain, tscaleold, fitscale * ppd);
       scale = tscale / ppd;
 
       closeup = 0;
-      if(tscale < 1.9999)
+      if(tscale < 1.9999f)
         scale = tscale / ppd;
       else
       {
@@ -3143,6 +3157,20 @@ void dt_dev_zoom_move(dt_dev_viewport_t *port,
       zoom_x = dev->full_preview_last_zoom_x;
       zoom_y = dev->full_preview_last_zoom_y;
       scale = port->zoom_scale;
+    }
+    else if(zoom == DT_ZOOM_FREE && constrain)
+    {
+      // Continuous zoom (pinch): apply the same soft caps as scroll. Using
+      // the current scale as tscaleold means once we clamp at 100%, the next
+      // frame still sees tscaleold == 1.0 and stays clamped; if a prior CTRL
+      // frame lifted us past 1.0, the released-CTRL frame sees tscaleold > 1.0
+      // and progresses up to the 200% cap — matching the scroll escape hatch.
+      const float fitscale = dt_dev_get_zoom_scale(port, DT_ZOOM_FIT, 1, FALSE);
+      const float tscaleold = cur_scale * ppd;
+      float tscalemin, tscalemax;
+      _zoom_constraint_bounds(TRUE, tscaleold, fitscale * ppd,
+                              &tscalemin, &tscalemax);
+      scale = CLAMP(scale * ppd, tscalemin, tscalemax) / ppd;
     }
 
     port->closeup = closeup;

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -2890,9 +2890,9 @@ static float _calculate_new_scroll_zoom_tscale(const int up,
     {
     case SIZE_LARGE:
       tscalemax = constrained
-        ? (tscaleold >= 2.0f
+        ? (tscaleold > 2.0f
            ? tscaletop
-           : (tscaleold >= 1.0f ? 2.0f : 1.0f))
+           : (tscaleold > 1.0f ? 2.0f : 1.0f))
         : tscaletop;
       tscalemin = constrained
         ? (tscaleold < tscalefit
@@ -2902,7 +2902,7 @@ static float _calculate_new_scroll_zoom_tscale(const int up,
       break;
     case SIZE_MEDIUM:
       tscalemax = constrained
-        ? (tscaleold >= 2.0f
+        ? (tscaleold > 2.0f
            ? tscaletop
            : 2.0f)
         : tscaletop;
@@ -2914,7 +2914,7 @@ static float _calculate_new_scroll_zoom_tscale(const int up,
       break;
     case SIZE_SMALL:
       tscalemax = constrained
-        ? (tscaleold >= 2.0f
+        ? (tscaleold > 2.0f
            ? tscaletop
            : tscalefit)
         : tscaletop;

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -357,6 +357,7 @@ typedef struct dt_develop_t
   int mask_form_selected_id; // select a mask inside an iop
   gboolean darkroom_skip_mouse_events; // skip mouse events for masks
   gboolean darkroom_mouse_in_center_area; // TRUE if the mouse cursor is in center area
+  gboolean constrain_zoom;   // cached value of "darkroom/ui/constrain_zoom" pref
 
   GList *module_filter_out;
   

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -347,6 +347,7 @@ typedef struct dt_develop_t
   struct
   {
     GtkWidget *floating_window, *softproof_button, *gamut_button; // TODO (#18559): remove gtk stuff from here
+    GtkWidget *display_intent_widget, *display2_intent_widget;    // TODO (#18559): remove gtk stuff from here
   } profile;
 
   GtkWidget *second_wnd, *second_wnd_button; // TODO (#18559): remove gtk stuff from here

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -727,20 +727,13 @@ static gboolean _draw(GtkWidget *da,
 }
 
 static GdkDevice *_touchpad = NULL;
-static gboolean _touchpad_gestures_enabled(void)
+
+static void _touchpad_gestures_pref_changed(gpointer instance,
+                                            gpointer user_data)
 {
-  // If conf_gen.h was built before darktableconfig.xml.in gained this key
-  // (incremental build without cmake reconfigure), dt_confgen_value_exists
-  // returns FALSE and dt_conf_get_bool gets an empty string → FALSE.
-  // Default to enabled in that case so a stale build doesn't silently break gestures.
-  if(!dt_confgen_value_exists("darkroom/ui/touchpad_gestures", DT_DEFAULT))
-  {
-    dt_print(DT_DEBUG_INPUT,
-             "[touchpad] 'darkroom/ui/touchpad_gestures' missing from confgen"
-             " (stale conf_gen.h — run cmake reconfigure), defaulting to enabled");
-    return TRUE;
-  }
-  return dt_conf_get_bool("darkroom/ui/touchpad_gestures");
+  (void)instance;
+  dt_gui_gtk_t *gui = user_data;
+  gui->touchpad_gestures_enabled = dt_conf_get_bool("darkroom/ui/touchpad_gestures");
 }
 
 static gboolean _input_event(GtkWidget *widget,
@@ -773,7 +766,7 @@ static gboolean _input_event(GtkWidget *widget,
       break;
   }
 
-  if(event->type == GDK_TOUCHPAD_PINCH && _touchpad_gestures_enabled())
+  if(event->type == GDK_TOUCHPAD_PINCH && darktable.gui->touchpad_gestures_enabled)
   {
     const GdkEventTouchpadPinch *pinch = &event->touchpad_pinch;
     dt_print(DT_DEBUG_INPUT,
@@ -805,7 +798,7 @@ static gboolean _scrolled(GtkWidget *widget,
 {
   (void)user_data;
   GdkDevice *device = gdk_event_get_source_device((GdkEvent *)event);
-  const gboolean touchpad_enabled = _touchpad_gestures_enabled();
+  const gboolean touchpad_enabled = darktable.gui->touchpad_gestures_enabled;
   const gboolean ctrl_pressed = dt_modifier_is(event->state, GDK_CONTROL_MASK);
 
   dt_print(DT_DEBUG_INPUT,
@@ -1514,6 +1507,10 @@ int dt_gui_gtk_init(dt_gui_gtk_t *gui)
 
   // Init focus peaking
   gui->show_focus_peaking = dt_conf_get_bool("ui/show_focus_peaking");
+
+  gui->touchpad_gestures_enabled = TRUE;
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_PREFERENCES_CHANGE,
+                            _touchpad_gestures_pref_changed, gui);
 
   /* Have the delete event (window close) end the program */
   snprintf(path, sizeof(path), "%s/icons", datadir);

--- a/src/gui/gtk.h
+++ b/src/gui/gtk.h
@@ -132,6 +132,7 @@ typedef struct dt_gui_gtk_t
 
   gboolean show_overlays;
   gboolean show_focus_peaking;
+  gboolean touchpad_gestures_enabled;
   double overlay_red, overlay_blue, overlay_green, overlay_contrast;
   GtkWidget *focus_peaking_button;
 

--- a/src/libs/navigation.c
+++ b/src/libs/navigation.c
@@ -466,7 +466,10 @@ static void _zoom_changed(GtkWidget *widget, gpointer user_data)
   else
     scale = val / 100.0f * ppd;
 
-  dt_dev_zoom_move(port, zoom, scale, closeup, -1.0f, -1.0f, TRUE);
+  // Preset zoom picks (small / 50% / custom %) take DT_ZOOM_FREE with an
+  // explicit scale — don't run them through the constrain soft caps.
+  dt_dev_zoom_move(port, zoom, scale, closeup, -1.0f, -1.0f,
+                   zoom != DT_ZOOM_FREE);
 }
 
 static gboolean _lib_navigation_widget_to_center(GtkEventController *controller,

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -2194,28 +2194,23 @@ end:
   }
 }
 
-static void _preference_changed_display_intent(gpointer instance,
-                                gpointer user_data)
-{
-  GtkWidget *display_intent = GTK_WIDGET(user_data);
-
-  const int force_lcms2 = dt_conf_get_bool("plugins/lighttable/export/force_lcms2");
-
-  gtk_widget_set_no_show_all(display_intent, !force_lcms2);
-  gtk_widget_set_visible(display_intent, force_lcms2);
-
-  dt_get_sysresource_level();
-  dt_opencl_update_settings();
-  dt_configure_ppd_dpi(darktable.gui);
-}
-
 static void _preference_changed(gpointer instance,
                                 const dt_view_t *self)
 {
   (void)instance;
   dt_develop_t *dev = self->data;
-  
+
   dev->constrain_zoom = dt_conf_get_bool("darkroom/ui/constrain_zoom");
+
+  const gboolean force_lcms2 = dt_conf_get_bool("plugins/lighttable/export/force_lcms2");
+  gtk_widget_set_no_show_all(dev->profile.display_intent_widget, !force_lcms2);
+  gtk_widget_set_visible(dev->profile.display_intent_widget, force_lcms2);
+  gtk_widget_set_no_show_all(dev->profile.display2_intent_widget, !force_lcms2);
+  gtk_widget_set_visible(dev->profile.display2_intent_widget, force_lcms2);
+
+  dt_get_sysresource_level();
+  dt_opencl_update_settings();
+  dt_configure_ppd_dpi(darktable.gui);
 
   for(const GList *modules = dev->iop; modules; modules = g_list_next(modules))
   {
@@ -3192,25 +3187,25 @@ void gui_init(dt_view_t *self)
           N_("absolute colorimetric"),
           NULL };
 
-    GtkWidget *display_intent = dt_bauhaus_combobox_new_full(DT_ACTION(self),
+    dev->profile.display_intent_widget  = dt_bauhaus_combobox_new_full(DT_ACTION(self),
                                                              N_("profiles"),
                                                              N_("intent"),
                                                              "",
                                                              0,
                                                              _display_intent_callback,
                                                              dev, intents_list);
-    GtkWidget *display2_intent = dt_bauhaus_combobox_new_full(DT_ACTION(self),
+    dev->profile.display2_intent_widget = dt_bauhaus_combobox_new_full(DT_ACTION(self),
                                                               N_("profiles"),
                                                               N_("preview intent"),
                                                               "",
                                                               0,
                                                               _display2_intent_callback,
                                                               dev, intents_list);
-
+        
     if(!force_lcms2)
     {
-      gtk_widget_set_no_show_all(display_intent, TRUE);
-      gtk_widget_set_no_show_all(display2_intent, TRUE);
+      gtk_widget_set_no_show_all(dev->profile.display_intent_widget, TRUE);
+      gtk_widget_set_no_show_all(dev->profile.display2_intent_widget, TRUE);
     }
 
     GtkWidget *display_profile = dt_bauhaus_combobox_new_action(DT_ACTION(self));
@@ -3313,21 +3308,16 @@ void gui_init(dt_view_t *self)
 
     _update_softproof_gamut_checking(dev);
 
-    // update the gui when the preferences changed (i.e. show intent when using lcms2)
-    DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_PREFERENCES_CHANGE,
-                              _preference_changed_display_intent, display_intent);
-    DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_PREFERENCES_CHANGE,
-                              _preference_changed_display_intent, display2_intent);
-    // and when profiles change
+    // update the gui when profiles change (intent visibility is handled by _preference_changed)
     DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_CONTROL_PROFILE_USER_CHANGED,
                               _display_profile_changed, display_profile);
     DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_CONTROL_PROFILE_USER_CHANGED,
                               _display2_profile_changed, display2_profile);
 
     GtkWidget *vbox = dt_gui_vbox
-      (display_profile, display_intent,
+      (display_profile, dev->profile.display_intent_widget,
        gtk_separator_new(GTK_ORIENTATION_HORIZONTAL),
-       display2_profile, display2_intent, display2_color_assessment,
+       display2_profile, dev->profile.display2_intent_widget, display2_color_assessment,
        gtk_separator_new(GTK_ORIENTATION_HORIZONTAL),
        softproof_profile, histogram_profile);
 

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -4198,8 +4198,9 @@ void scrolled(dt_view_t *self,
     if(handled) return;
   }
 
-  // free zoom
-  const gboolean constrained = !dt_modifier_is(state, GDK_CONTROL_MASK);
+  // free zoom: constrain when the config asks for it AND CTRL isn't held
+  const gboolean constrained =
+    dev->constrain_zoom && !dt_modifier_is(state, GDK_CONTROL_MASK);
   dt_dev_zoom_move(&dev->full, DT_ZOOM_SCROLL, 0.0f, up, x, y, constrained);
 }
 
@@ -4257,7 +4258,9 @@ gboolean gesture_pinch(dt_view_t *self,
 {
   dt_develop_t *dev = self->data;
   if(!dev) return FALSE;
-  (void)state;
+  // constrain when the config asks for it AND CTRL isn't held
+  const gboolean constrained =
+    dev->constrain_zoom && !dt_modifier_is(state, GDK_CONTROL_MASK);
 
   // Gesture-mode classifier: each event contributes its zoom_eq & pan_eq magnitude in pixels
   // to a decaying score. When the recent history is zoom-dominant (score > ZOOM_DOMINANT_PX)
@@ -4340,7 +4343,7 @@ gboolean gesture_pinch(dt_view_t *self,
              "[darkroom pinch] pan component eff_dx=%.3f eff_dy=%.3f"
              " (score=%.2f zoom_eq=%.2f pan_eq=%.2f)",
              eff_dx, eff_dy, zoom_pan_score, zoom_eq_px, pan_eq_px);
-    dt_dev_zoom_move(&dev->full, DT_ZOOM_MOVE, 1.0f, 0, eff_dx, eff_dy, TRUE);
+    dt_dev_zoom_move(&dev->full, DT_ZOOM_MOVE, 1.0f, 0, eff_dx, eff_dy, constrained);
   }
 
   const float ppd = dev->full.ppd;
@@ -4368,7 +4371,7 @@ gboolean gesture_pinch(dt_view_t *self,
            dev->full.border_size, dev->full.width, dev->full.height,
            dx, dy, eff_dx, eff_dy, zoom_pan_score, zoom_dominant,
            scale, state, tscale, tscalefloor, tscaletop, zoom_scale);
-  dt_dev_zoom_move(&dev->full, DT_ZOOM_FREE, zoom_scale, 0, x_local, y_local, TRUE);
+  dt_dev_zoom_move(&dev->full, DT_ZOOM_FREE, zoom_scale, 0, x_local, y_local, constrained);
 
   return TRUE;
 }
@@ -4559,7 +4562,6 @@ static gboolean _second_window_scrolled_callback(GtkWidget *widget,
                                                  dt_develop_t *dev)
 {
   if(dev->gui_leaving) return TRUE;
-
   int delta_y;
   if(dt_gui_get_scroll_unit_delta(event, &delta_y))
   {
@@ -4569,7 +4571,8 @@ static gboolean _second_window_scrolled_callback(GtkWidget *widget,
 
     dt_dev_viewport_t *port = pinned_dev ? &pinned_dev->preview2 : &dev->preview2;
 
-    const gboolean constrained = !dt_modifier_is(event->state, GDK_CONTROL_MASK);
+    const gboolean constrained =
+      dev->constrain_zoom && !dt_modifier_is(event->state, GDK_CONTROL_MASK);
     dt_dev_zoom_move(port, DT_ZOOM_SCROLL, 0.0f, delta_y < 0,
                      event->x, event->y, constrained);
   }

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -2194,7 +2194,7 @@ end:
   }
 }
 
-static void _preference_changed(gpointer instance,
+static void _preference_changed_display_intent(gpointer instance,
                                 gpointer user_data)
 {
   GtkWidget *display_intent = GTK_WIDGET(user_data);
@@ -2209,10 +2209,14 @@ static void _preference_changed(gpointer instance,
   dt_configure_ppd_dpi(darktable.gui);
 }
 
-static void _preference_changed_button_hide(gpointer instance,
-                                            const dt_view_t *self)
+static void _preference_changed(gpointer instance,
+                                const dt_view_t *self)
 {
+  (void)instance;
   dt_develop_t *dev = self->data;
+  
+  dev->constrain_zoom = dt_conf_get_bool("darkroom/ui/constrain_zoom");
+
   for(const GList *modules = dev->iop; modules; modules = g_list_next(modules))
   {
     dt_iop_module_t *module = modules->data;
@@ -3311,9 +3315,9 @@ void gui_init(dt_view_t *self)
 
     // update the gui when the preferences changed (i.e. show intent when using lcms2)
     DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_PREFERENCES_CHANGE,
-                              _preference_changed, display_intent);
+                              _preference_changed_display_intent, display_intent);
     DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_PREFERENCES_CHANGE,
-                              _preference_changed, display2_intent);
+                              _preference_changed_display_intent, display2_intent);
     // and when profiles change
     DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_CONTROL_PROFILE_USER_CHANGED,
                               _display_profile_changed, display_profile);
@@ -3580,8 +3584,8 @@ void enter(dt_view_t *self)
   // switch on groups as they were last time:
   dt_dev_modulegroups_set(dev, dt_conf_get_int("plugins/darkroom/groups"));
 
-  // connect to preference change for module header button hiding
-  DT_CONTROL_SIGNAL_HANDLE(DT_SIGNAL_PREFERENCES_CHANGE, _preference_changed_button_hide);
+  // connect to preference change for callback for button hiding and constrain_zoom
+  DT_CONTROL_SIGNAL_HANDLE(DT_SIGNAL_PREFERENCES_CHANGE, _preference_changed);
   dt_iop_color_picker_init();
 
   dt_image_check_camera_missing_sample(&dev->image_storage);


### PR DESCRIPTION
Activate 100% scroll limit again and also make scroll limit configurable through config parameter `darkroom/ui/constrain_zoom`, which is TRUE by default, keeping the previous
behavior:
* zooming in is limited to 100%
* zooming out is limited to screen-fit

This is an effort to satisfy both use-cases discussed in https://github.com/darktable-org/darktable/issues/21027.

Disclaimer: this work was co-created with Claude.