### PR TITLE
Image pixelpipe restart fix

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -779,7 +779,7 @@ restart:
     dt_print_pipe(DT_DEBUG_PIPE, "pipe stopped", pipe, NULL, DT_DEVICE_NONE, &proi, NULL, "%s%s%s%s",
                 shutdown == DT_DEV_PIXELPIPE_STOP_NODES ? "DT_DEV_PIXELPIPE_STOP_NODES"
                   : shutdown == DT_DEV_PIXELPIPE_STOP_HQ  ? "DT_DEV_PIXELPIPE_STOP_HQ"
-                  : shutdown == DT_DEV_PIXELPIPE_STOP_NO  ? "" : "DT_DEV_PIXELPIPE_STOP_OTHER",
+                  : shutdown == DT_DEV_PIXELPIPE_STOP_NO  ? "" : "DT_DEV_PIXELPIPE_STOP_MODULE",
                 dev->image_force_reload ? "image_force_reload " : "",
                 pipe->loading ? "pipe_loading " : "",
                 pipe->input_changed ? "pipe_input_changed " : "");
@@ -802,9 +802,17 @@ restart:
       dt_pthread_mutex_unlock(&pipe->mutex);
       return;
     }
+
+    /* pixelpipe stops due to changed pipe nodes, HQ mode changes or module aborts.
+       All want restarts as pipe status is not valid yet.
+    */
     if(shutdown != DT_DEV_PIXELPIPE_STOP_NO)
       goto restart;
   }
+
+  // image pipes require pending dimension check
+  if(port && dt_pipe_is_image(pipe) && pipe->changed != DT_DEV_PIPE_UNCHANGED)
+    goto restart;
 
   dt_show_times_f(&start,
                   "[dev_process_image] pixel pipeline", "processing `%s'",
@@ -3860,7 +3868,7 @@ void dt_dev_image(const dt_imgid_t imgid,
   dev.gui_attached = FALSE;
   dt_dev_pixelpipe_t *pipe = dev.full.pipe;
 
-  pipe->type |= DT_DEV_PIXELPIPE_IMAGE | (finalscale ? DT_DEV_PIXELPIPE_IMAGE_FINAL : 0);
+  pipe->type |= DT_DEV_PIXELPIPE_IMAGE | (finalscale ? DT_DEV_PIXELPIPE_IMAGE_FINAL : DT_DEV_PIXELPIPE_NONE);
   // load image and set history_end
 
   dev.snapshot_id = snapshot_id;

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -611,7 +611,7 @@ void dt_dev_process_image_job(dt_develop_t *dev,
 
   dt_pthread_mutex_lock(&pipe->mutex);
 
-  if(dev->gui_leaving || dt_pipe_shutdown(pipe))
+  if(dev->gui_leaving || (dt_atomic_get_int(&pipe->shutdown) != DT_DEV_PIXELPIPE_STOP_NO))
   {
     dt_pthread_mutex_unlock(&pipe->mutex);
     return;
@@ -3727,7 +3727,7 @@ static gboolean _dev_wait_hash(dt_develop_t *dev,
 
   for(int n = 0; n < nloop; n++)
   {
-    if(dt_pipe_shutdown(pipe))
+    if(dt_atomic_get_int(&pipe->shutdown) != DT_DEV_PIXELPIPE_STOP_NO)
       return TRUE;  // stop waiting if pipe shuts down
 
     dt_hash_t probehash;

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -50,7 +50,7 @@
 // benchmarking and pfm dumps should happen for these pipes
 static inline gboolean _is_debug_pipe(const dt_dev_pixelpipe_t *pipe)
 {
-  return (pipe->type & (DT_DEV_PIXELPIPE_FULL | DT_DEV_PIXELPIPE_EXPORT));
+  return dt_pipe_is_full(pipe) || dt_pipe_is_export(pipe);
 }
 
 // forward declarations for mask cache helpers
@@ -1107,16 +1107,7 @@ static gboolean _transform_for_blend(const dt_iop_module_t *const self,
                                      const dt_dev_pixelpipe_iop_t *const piece)
 {
   const dt_develop_blend_params_t *const d = piece->blendop_data;
-  if(d)
-  {
-    // check only if blend is active
-    if((self->flags() & IOP_FLAGS_SUPPORTS_BLENDING)
-       && (d->mask_mode != DEVELOP_MASK_DISABLED))
-    {
-      return TRUE;
-    }
-  }
-  return FALSE;
+  return d && (d->mask_mode != DEVELOP_MASK_DISABLED) && (self->flags() & IOP_FLAGS_SUPPORTS_BLENDING);
 }
 
 static gboolean _request_color_pick(dt_dev_pixelpipe_t *pipe,
@@ -1267,9 +1258,7 @@ static inline gboolean _piece_wants_blending(const dt_dev_pixelpipe_iop_t *piece
     return FALSE;
 
   const dt_develop_blend_params_t *const d = piece->blendop_data;
-  if(!d || !(d->mask_mode & DEVELOP_MASK_ENABLED)) return FALSE;
-
-  return TRUE;
+  return d && (d->mask_mode & DEVELOP_MASK_ENABLED);
 }
 
 static gboolean _pixelpipe_process_on_CPU(dt_dev_pixelpipe_t *pipe,
@@ -3068,7 +3057,7 @@ gboolean dt_dev_pixelpipe_process(dt_dev_pixelpipe_t *pipe,
                                   const int devid)
 {
   pipe->processing = TRUE;
-  pipe->nocache = (pipe->type & DT_DEV_PIXELPIPE_IMAGE) != 0;
+  pipe->nocache = dt_pipe_is_image(pipe);
   pipe->runs++;
   pipe->opencl_enabled = dt_opencl_running();
 
@@ -3745,7 +3734,7 @@ gboolean dt_dev_write_scharr_mask(dt_dev_pixelpipe_iop_t *piece,
 
 #ifdef HAVE_OPENCL
 int dt_dev_write_scharr_mask_cl(dt_dev_pixelpipe_iop_t *piece,
-                                cl_mem in,
+                                const cl_mem in,
                                 const dt_iop_roi_t *const roi,
                                 const gboolean rawmode)
 {

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -53,6 +53,12 @@ static inline gboolean _is_debug_pipe(const dt_dev_pixelpipe_t *pipe)
   return dt_pipe_is_full(pipe) || dt_pipe_is_export(pipe);
 }
 
+static inline gboolean _pipe_has_shutdown(dt_dev_pixelpipe_t *pipe)
+{
+  return dt_atomic_get_int(&pipe->shutdown) != DT_DEV_PIXELPIPE_STOP_NO;
+}
+
+
 // forward declarations for mask cache helpers
 static void _clear_piece_mask_caches(dt_dev_pixelpipe_iop_t *piece);
 static void _free_distort_bufs(dt_dev_pixelpipe_t *pipe);
@@ -1275,7 +1281,7 @@ static gboolean _pixelpipe_process_on_CPU(dt_dev_pixelpipe_t *pipe,
                                           dt_pixelpipe_flow_t *pixelpipe_flow,
                                           const int position)
 {
-  if(dt_pipe_shutdown(pipe))
+  if(_pipe_has_shutdown(pipe))
     return TRUE;
 
   // the data buffers must always have an alignment to DT_CACHELINE_BYTES
@@ -1327,12 +1333,12 @@ static gboolean _pixelpipe_process_on_CPU(dt_dev_pixelpipe_t *pipe,
                                       cst_from, cst_to, &input_format->cst,
                                       work_profile);
 
-  if(dt_pipe_shutdown(pipe))
+  if(_pipe_has_shutdown(pipe))
     return TRUE;
 
   _collect_histogram_on_CPU(pipe, dev, input, roi_in, module, piece, pixelpipe_flow);
 
-  if(dt_pipe_shutdown(pipe))
+  if(_pipe_has_shutdown(pipe))
     return TRUE;
 
   const size_t in_bpp = dt_iop_buffer_dsc_to_bpp(input_format);
@@ -1380,7 +1386,7 @@ static gboolean _pixelpipe_process_on_CPU(dt_dev_pixelpipe_t *pipe,
       module->process_tiling(module, piece, input, *output, roi_in, roi_out, in_bpp);
       if(want_bcache)
       {
-        if(dt_pipe_no_mask_display(pipe) && !dt_pipe_shutdown(pipe))
+        if(dt_pipe_no_mask_display(pipe) && !_pipe_has_shutdown(pipe))
         {
           float *cache = _get_fast_blendcache(nfloats, phash, pipe);
           if(cache) dt_iop_image_copy(cache, *output, nfloats);
@@ -1422,7 +1428,7 @@ static gboolean _pixelpipe_process_on_CPU(dt_dev_pixelpipe_t *pipe,
         if(module->process_plain)
         {
           dt_get_times(&start);
-          for(int i = 0; i < counter && !dt_pipe_shutdown(pipe); i++)
+          for(int i = 0; i < counter && !_pipe_has_shutdown(pipe); i++)
             module->process_plain(module, piece, input, *output, roi_in, roi_out);
           dt_get_times(&end);
           const float clock = (end.clock - start.clock) / (float) counter;
@@ -1443,7 +1449,7 @@ static gboolean _pixelpipe_process_on_CPU(dt_dev_pixelpipe_t *pipe,
       module->process(module, piece, input, *output, roi_in, roi_out);
       if(want_bcache)
       {
-        if(dt_pipe_no_mask_display(pipe) && !dt_pipe_shutdown(pipe))
+        if(dt_pipe_no_mask_display(pipe) && !_pipe_has_shutdown(pipe))
         {
           float *cache = _get_fast_blendcache(nfloats, phash, pipe);
           if(cache) dt_iop_image_copy(cache, *output, nfloats);
@@ -1473,7 +1479,7 @@ static gboolean _pixelpipe_process_on_CPU(dt_dev_pixelpipe_t *pipe,
   // and save the output colorspace
   pipe->dsc.cst = module->output_colorspace(module, pipe, piece);
 
-  if(dt_pipe_shutdown(pipe))
+  if(_pipe_has_shutdown(pipe))
     return TRUE;
 
   dt_iop_colorspace_type_t blend_cst = dt_develop_blend_colorspace(piece, pipe->dsc.cst);
@@ -1498,7 +1504,7 @@ static gboolean _pixelpipe_process_on_CPU(dt_dev_pixelpipe_t *pipe,
     DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_CONTROL_PICKERDATA_READY, module, pipe);
   }
 
-  if(dt_pipe_shutdown(pipe))
+  if(_pipe_has_shutdown(pipe))
     return TRUE;
 
   // blend needs input/output images with default colorspace
@@ -1529,7 +1535,7 @@ static gboolean _pixelpipe_process_on_CPU(dt_dev_pixelpipe_t *pipe,
     }
   }
 
-  if(dt_pipe_shutdown(pipe))
+  if(_pipe_has_shutdown(pipe))
     return TRUE;
 
   /* process blending on CPU */
@@ -1540,7 +1546,7 @@ static gboolean _pixelpipe_process_on_CPU(dt_dev_pixelpipe_t *pipe,
     *pixelpipe_flow &= ~PIXELPIPE_FLOW_BLENDED_ON_GPU;
   }
 
-  return dt_pipe_shutdown(pipe);
+  return _pipe_has_shutdown(pipe);
 }
 
 #ifdef HAVE_OPENCL
@@ -1572,7 +1578,7 @@ static cl_int _opencl_benchmark(dt_dev_pixelpipe_t *pipe,
   const int counter = full ? 100 : 50;
   cl_int err = CL_SUCCESS;
   dt_get_times(&bench);
-  for(int i = 0; i < counter && bout != NULL && err == CL_SUCCESS && !dt_pipe_shutdown(pipe); i++)
+  for(int i = 0; i < counter && bout != NULL && err == CL_SUCCESS && !_pipe_has_shutdown(pipe); i++)
     err = module->process_cl(module, piece, bin, bout, roi_in, roi_out);
   dt_get_times(&end);
   const float clock = (end.clock - bench.clock) / (float)counter;
@@ -1677,7 +1683,7 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
   /* As this is done recursively we check for any dt_dev_pixelpipe_stopper_t
      signal that might have been set.
   */
-  if(dt_pipe_shutdown(pipe))
+  if(_pipe_has_shutdown(pipe))
     return TRUE;
 
   dt_iop_roi_t roi_in = *roi_out;
@@ -1770,7 +1776,7 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
   if(!modules)
   {
     // 3a) import input array with given scale and roi
-    if(dt_pipe_shutdown(pipe))
+    if(_pipe_has_shutdown(pipe))
       return TRUE;
 
     dt_times_t start;
@@ -1922,7 +1928,7 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
     return FALSE;
   }
 
-  if(dt_pipe_shutdown(pipe))
+  if(_pipe_has_shutdown(pipe))
     return TRUE;
 
   // 3b) recurse and obtain output array in &input
@@ -1962,7 +1968,7 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
 
   const size_t out_bpp = dt_iop_buffer_dsc_to_bpp(*out_format);
 
-  if(dt_pipe_shutdown(pipe))
+  if(_pipe_has_shutdown(pipe))
     return TRUE;
 
   // reserve new cache line: output
@@ -1974,7 +1980,7 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
   dt_dev_pixelpipe_cache_get(pipe, hash, bufsize,
                              output, out_format, module, important);
 
-  if(dt_pipe_shutdown(pipe))
+  if(_pipe_has_shutdown(pipe))
     return TRUE;
 
   gboolean important_cl = FALSE;
@@ -2055,7 +2061,7 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
   assert(tiling.factor > 0.0f);
   assert(tiling.factor_cl > 0.0f);
 
-  if(dt_pipe_shutdown(pipe))
+  if(_pipe_has_shutdown(pipe))
     return TRUE;
 
   piece->module->position = pos;
@@ -2231,7 +2237,7 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
           }
         }
 
-        if(dt_pipe_shutdown(pipe))
+        if(_pipe_has_shutdown(pipe))
           return TRUE;
 
         dt_dev_prepare_piece_cfa(piece, &roi_in);
@@ -2273,7 +2279,7 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
             if(want_bcache && (err == CL_SUCCESS))
             {
               // processing was good
-              if(dt_pipe_no_mask_display(pipe) && !dt_pipe_shutdown(pipe))
+              if(dt_pipe_no_mask_display(pipe) && !_pipe_has_shutdown(pipe))
               {
                 float *cache = _get_fast_blendcache(out_bpp * roi_out->width * roi_out->height / sizeof(float), phash, pipe);
                 if(cache)
@@ -2305,11 +2311,11 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
                           cl_errstr(err));
           else if(_is_debug_pipe(pipe))
           {
-            if(darktable.dump_pfm_pipe && !dt_pipe_shutdown(pipe))
+            if(darktable.dump_pfm_pipe && !_pipe_has_shutdown(pipe))
               dt_opencl_dump_pipe_pfm(module->op, pipe->devid, *cl_mem_output,
                                     FALSE, dt_dev_pixelpipe_type_to_str(pipe->type));
 
-            if(darktable.dump_diff_pipe && !dt_pipe_shutdown(pipe))
+            if(darktable.dump_diff_pipe && !_pipe_has_shutdown(pipe))
               _opencl_dump_diff_pipe_pfm(pipe, module, piece, cl_mem_input, *cl_mem_output, roi_out, &roi_in, cst_out);
           }
 
@@ -2356,7 +2362,7 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
           DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_CONTROL_PICKERDATA_READY, module, pipe);
         }
 
-        if(dt_pipe_shutdown(pipe))
+        if(_pipe_has_shutdown(pipe))
            return TRUE;
 
         // blend needs input/output images with default colorspace
@@ -2407,7 +2413,7 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
         if(success_opencl)
           success_opencl = dt_opencl_finish_sync_pipe(pipe->devid, pipe->type);
 
-        if(dt_pipe_shutdown(pipe))
+        if(_pipe_has_shutdown(pipe))
         {
           dt_opencl_release_mem_object(cl_mem_input);
           return TRUE;
@@ -2442,7 +2448,7 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
           valid_input_on_gpu_only = FALSE;
         }
 
-        if(dt_pipe_shutdown(pipe))
+        if(_pipe_has_shutdown(pipe))
            return TRUE;
 
         // transform to module input colorspace if not done already
@@ -2454,7 +2460,7 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
                                               work_profile);
         }
 
-        if(dt_pipe_shutdown(pipe))
+        if(_pipe_has_shutdown(pipe))
           return TRUE;
 
         // histogram collection for module
@@ -2464,7 +2470,7 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
                                     module, piece, &pixelpipe_flow);
         }
 
-        if(dt_pipe_shutdown(pipe))
+        if(_pipe_has_shutdown(pipe))
           return TRUE;
 
         /* now call process_tiling_cl of module; module should emit
@@ -2484,7 +2490,7 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
                                             *output, &roi_in, roi_out, in_bpp);
             if(want_bcache && (err == CL_SUCCESS))
             {
-              if(dt_pipe_no_mask_display(pipe) && !dt_pipe_shutdown(pipe))
+              if(dt_pipe_no_mask_display(pipe) && !_pipe_has_shutdown(pipe))
               {
                 float *cache = _get_fast_blendcache(nfloats, phash, pipe);
                 if(cache) dt_iop_image_copy(cache, *output, nfloats);
@@ -2537,7 +2543,7 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
           DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_CONTROL_PICKERDATA_READY, module, pipe);
         }
 
-        if(dt_pipe_shutdown(pipe))
+        if(_pipe_has_shutdown(pipe))
            return TRUE;
 
         // blend needs input/output images with default colorspace
@@ -2569,7 +2575,7 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
           }
         }
 
-        if(dt_pipe_shutdown(pipe))
+        if(_pipe_has_shutdown(pipe))
           return TRUE;
 
         /* do process blending on cpu (this is anyhow fast enough) */
@@ -2584,7 +2590,7 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
         if(success_opencl)
           success_opencl = dt_opencl_finish_sync_pipe(pipe->devid, pipe->type);
 
-        if(dt_pipe_shutdown(pipe))
+        if(_pipe_has_shutdown(pipe))
           return TRUE;
       }
       else
@@ -2594,7 +2600,7 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
         success_opencl = FALSE;
       }
 
-      if(dt_pipe_shutdown(pipe))
+      if(_pipe_has_shutdown(pipe))
       {
         dt_opencl_release_mem_object(cl_mem_input);
         return TRUE;
@@ -2661,7 +2667,7 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
             }
           }
 
-          if(dt_pipe_shutdown(pipe))
+          if(_pipe_has_shutdown(pipe))
           {
             dt_opencl_release_mem_object(cl_mem_input);
             return TRUE;
@@ -2718,7 +2724,7 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
           return TRUE;
       }
 
-      if(dt_pipe_shutdown(pipe))
+      if(_pipe_has_shutdown(pipe))
         return TRUE;
     }
     else
@@ -2907,7 +2913,7 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
   }
 
   // 4) colorpicker and scopes:
-  if(dt_pipe_shutdown(pipe))
+  if(_pipe_has_shutdown(pipe))
     return TRUE;
 
   if(dev->gui_attached && !dev->gui_leaving
@@ -2937,7 +2943,7 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
                                            display_profile,
                                            dt_ioppr_get_histogram_profile_info(dev));
   }
-  return dt_pipe_shutdown(pipe);
+  return _pipe_has_shutdown(pipe);
 }
 
 

--- a/src/develop/pixelpipe_hb.h
+++ b/src/develop/pixelpipe_hb.h
@@ -268,6 +268,14 @@ static inline gboolean dt_pipe_is_screen(const dt_dev_pixelpipe_t *pipe)
 {
   return (pipe->type & DT_DEV_PIXELPIPE_SCREEN);
 }
+static inline gboolean dt_pipe_is_image(const dt_dev_pixelpipe_t *pipe)
+{
+  return (pipe->type & DT_DEV_PIXELPIPE_IMAGE);
+}
+static inline gboolean dt_pipe_is_image_final(const dt_dev_pixelpipe_t *pipe)
+{
+  return (pipe->type & DT_DEV_PIXELPIPE_IMAGE_FINAL);
+}
 static inline gboolean dt_pipe_no_mask_display(const dt_dev_pixelpipe_t *pipe)
 {
   return pipe->mask_display == DT_DEV_PIXELPIPE_DISPLAY_NONE;
@@ -390,7 +398,7 @@ gboolean dt_dev_write_scharr_mask(dt_dev_pixelpipe_iop_t *piece,
                                   const gboolean mode);
 #ifdef HAVE_OPENCL
 int dt_dev_write_scharr_mask_cl(dt_dev_pixelpipe_iop_t *piece,
-                                cl_mem in,
+                                const cl_mem in,
                                 const dt_iop_roi_t *const roi_in,
                                 const gboolean mode);
 #endif

--- a/src/develop/pixelpipe_hb.h
+++ b/src/develop/pixelpipe_hb.h
@@ -227,11 +227,6 @@ typedef struct dt_dev_pixelpipe_t
 
 struct dt_develop_t;
 
-static inline gboolean dt_pipe_shutdown(dt_dev_pixelpipe_t *pipe)
-{
-  return dt_atomic_get_int(&pipe->shutdown) != DT_DEV_PIXELPIPE_STOP_NO;
-}
-
 static inline gboolean dt_pipe_is_fast(const dt_dev_pixelpipe_t *pipe)
 {
   return (pipe->type & DT_DEV_PIXELPIPE_FAST);

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -4053,7 +4053,7 @@ static int call_distort_transform(const dt_develop_t *dev,
   if(piece->module == self
       // && *piece->enabled see note below
       && !(dt_iop_module_is_skipped(dev, piece->module)
-            && (pipe->type & DT_DEV_PIXELPIPE_BASIC)))
+            && dt_pipe_is_basic(pipe)))
   {
     ret = piece->module->distort_transform(piece->module, piece, points, points_count);
   }

--- a/src/iop/cacorrect.c
+++ b/src/iop/cacorrect.c
@@ -257,7 +257,7 @@ void process(dt_iop_module_t *self,
 
   const uint32_t filters = piece->filters;  // Just in case we want to use a roi_in 
 
-  const gboolean run_fast = piece->pipe->type & DT_DEV_PIXELPIPE_FAST;
+  const gboolean run_fast = dt_pipe_is_fast(piece->pipe);
 
   dt_iop_cacorrect_data_t *d = piece->data;
 

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -2159,7 +2159,7 @@ void process(dt_iop_module_t *self,
 #ifdef AI_ACTIVATED
     gboolean exit = FALSE;
 #endif
-    if(g->run_profile && piece->pipe->type == DT_DEV_PIXELPIPE_PREVIEW)
+    if(g->run_profile && dt_pipe_is_preview(piece->pipe))
     {
       dt_iop_gui_enter_critical_section(self);
       _extract_color_checker(in, out, roi_in, g, RGB_to_XYZ,
@@ -2284,7 +2284,7 @@ void process(dt_iop_module_t *self,
 
   // run dE validation at output
   if(self->dev->gui_attached && g)
-    if(g->run_validation && piece->pipe->type == DT_DEV_PIXELPIPE_PREVIEW)
+    if(g->run_validation && dt_pipe_is_preview(piece->pipe))
     {
       _validate_color_checker(out, roi_out, g, RGB_to_XYZ, XYZ_to_RGB, XYZ_to_CAM);
       g->run_validation = FALSE;
@@ -3130,7 +3130,7 @@ void commit_params(dt_iop_module_t *self,
   convert_any_XYZ_to_LMS(XYZ, d->illuminant, d->adaptation);
   d->illuminant[3] = 0.f;
 
-  const gboolean preview = piece->pipe->type == DT_DEV_PIXELPIPE_PREVIEW;
+  const gboolean preview = dt_pipe_is_preview(piece->pipe);
   const gboolean run_profile = preview && g && g->run_profile;
   const gboolean run_validation = preview && g && g->run_validation;
 

--- a/src/iop/colorequal.c
+++ b/src/iop/colorequal.c
@@ -989,7 +989,7 @@ void process(dt_iop_module_t *self,
   const dt_iop_colorequal_gui_data_t *g = self->gui_data;
   const gboolean fullpipe = dt_pipe_is_full(piece->pipe);
   const int mask_mode = g && fullpipe ? g->mask_mode : 0;
-  const gboolean run_fast = piece->pipe->type & DT_DEV_PIXELPIPE_FAST;
+  const gboolean run_fast = dt_pipe_is_fast(piece->pipe);
 
   const float *const restrict in = (float*)i;
   float *const restrict out = (float*)o;
@@ -1531,7 +1531,7 @@ int process_cl(dt_iop_module_t *self,
   const gboolean fullpipe = dt_pipe_is_full(piece->pipe);
   const int mask_mode = g && fullpipe ? g->mask_mode : 0;
   const int guiding = d->use_filter;
-  const gboolean run_fast = piece->pipe->type & DT_DEV_PIXELPIPE_FAST;
+  const gboolean run_fast = dt_pipe_is_fast(piece->pipe);
 
   float white, sat_shift, max_brightness_shift, corr_max_brightness_shift, bright_shift, gradient_amp, hue_sigma, par_sigma, sat_sigma, scharr_sigma;
   _prepare_process(roi_in->scale / piece->iscale, d,

--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -1324,7 +1324,7 @@ void commit_params(dt_iop_module_t *self,
     piece->enabled = FALSE;
     return;
   }
-  if(!(piece->pipe->type & DT_DEV_PIXELPIPE_IMAGE_FINAL))
+  if(!dt_pipe_is_image_final(piece->pipe))
     piece->enabled = TRUE;
 
   if(type == DT_COLORSPACE_ENHANCED_MATRIX)

--- a/src/iop/crop.c
+++ b/src/iop/crop.c
@@ -622,7 +622,7 @@ void commit_params(dt_iop_module_t *self,
   dt_iop_crop_params_t *p = (dt_iop_crop_params_t *)p1;
   dt_iop_crop_data_t *d = piece->data;
 
-  if(dt_iop_has_focus(self) && (pipe->type & DT_DEV_PIXELPIPE_BASIC))
+  if(dt_iop_has_focus(self) && dt_pipe_is_basic(pipe))
   {
     d->cx = 0.0f;
     d->cy = 0.0f;

--- a/src/iop/diffuse.c
+++ b/src/iop/diffuse.c
@@ -1344,7 +1344,7 @@ void process(dt_iop_module_t *self,
              const dt_iop_roi_t *const roi_in,
              const dt_iop_roi_t *const roi_out)
 {
-  const gboolean fastmode = piece->pipe->type & DT_DEV_PIXELPIPE_FAST;
+  const gboolean fastmode = dt_pipe_is_fast(piece->pipe);
 
   const dt_iop_diffuse_data_t *const data = piece->data;
 
@@ -1607,7 +1607,7 @@ int process_cl(dt_iop_module_t *self,
                const dt_iop_roi_t *const roi_in,
                const dt_iop_roi_t *const roi_out)
 {
-  const gboolean fastmode = piece->pipe->type & DT_DEV_PIXELPIPE_FAST;
+  const gboolean fastmode = dt_pipe_is_fast(piece->pipe);
 
   const dt_iop_diffuse_data_t *const data = piece->data;
   dt_iop_diffuse_global_data_t *const gd = self->global_data;

--- a/src/iop/dither.c
+++ b/src/iop/dither.c
@@ -671,7 +671,7 @@ void process(
     _process_posterize(self, piece, ivoid, ovoid, roi_in, roi_out);
   else
   {
-    const gboolean fastmode = piece->pipe->type & DT_DEV_PIXELPIPE_FAST;
+    const gboolean fastmode = dt_pipe_is_fast(piece->pipe);
     _process_floyd_steinberg(self, piece, ivoid, ovoid, roi_in, roi_out, fastmode);
   }
 }

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -2063,7 +2063,7 @@ void tiling_callback(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece,
   const int scales = get_scales(roi_in, piece);
   const int max_filter_radius = (1 << scales);
   const dt_iop_filmicrgb_data_t *const data = piece->data;
-  const gboolean run_fast = !data->enable_highlight_reconstruction || piece->pipe->type & DT_DEV_PIXELPIPE_FAST;
+  const gboolean run_fast = !data->enable_highlight_reconstruction || dt_pipe_is_fast(piece->pipe);
 
   // without reconstruction: in + out + 1ch_mask
   // with reconstruction: in + out + reconst + inpaint + 2 * scales + temp + 1ch_mask
@@ -2128,7 +2128,7 @@ void process(dt_iop_module_t *self,
     }
   }
 
-  const gboolean run_fast = piece->pipe->type & DT_DEV_PIXELPIPE_FAST;
+  const gboolean run_fast = dt_pipe_is_fast(piece->pipe);
   // allocate reconstruction buffer, but only if we actually want to use it
   float *const restrict reconstructed
     = run_fast ? NULL : dt_alloc_align_float((size_t)roi_out->width * roi_out->height * 4);
@@ -2463,7 +2463,7 @@ int process_cl(dt_iop_module_t *self,
     }
   }
 
-  const gboolean run_fast = piece->pipe->type & DT_DEV_PIXELPIPE_FAST;
+  const gboolean run_fast = dt_pipe_is_fast(piece->pipe);
 
   if(!run_fast && is_clipped > 0 && d->enable_highlight_reconstruction)
   {

--- a/src/iop/finalscale.c
+++ b/src/iop/finalscale.c
@@ -58,10 +58,8 @@ dt_iop_colorspace_type_t default_colorspace(dt_iop_module_t *self,
 
 static inline gboolean _gui_fullpipe(dt_dev_pixelpipe_iop_t *piece)
 {
-  return piece->pipe->type & (DT_DEV_PIXELPIPE_FULL
-                              | DT_DEV_PIXELPIPE_PREVIEW2
-                              | DT_DEV_PIXELPIPE_IMAGE)
-    && darktable.develop->late_scaling.enabled;
+  return (dt_pipe_is_canvas(piece->pipe) || dt_pipe_is_image(piece->pipe))
+     && darktable.develop->late_scaling.enabled;
 }
 
 void modify_roi_in(dt_iop_module_t *self,
@@ -194,9 +192,8 @@ void commit_params(dt_iop_module_t *self,
                    dt_dev_pixelpipe_t *pipe,
                    dt_dev_pixelpipe_iop_t *piece)
 {
-  const int use_finalscale = DT_DEV_PIXELPIPE_IMAGE | DT_DEV_PIXELPIPE_IMAGE_FINAL;
   piece->enabled = dt_pipe_is_export(piece->pipe)
-                  || (pipe->type & use_finalscale) == use_finalscale
+                  || (dt_pipe_is_image(pipe) && dt_pipe_is_image_final(pipe))
                   || _gui_fullpipe(piece);
 }
 

--- a/src/iop/grain.c
+++ b/src/iop/grain.c
@@ -442,7 +442,7 @@ void process(dt_iop_module_t *self,
 
   unsigned int hash = _hash_string(piece->pipe->image.filename) % (int)fmax(roi_out->width * 0.3, 1.0);
 
-  const gboolean fastmode = piece->pipe->type & DT_DEV_PIXELPIPE_FAST;
+  const gboolean fastmode = dt_pipe_is_fast(piece->pipe);
   // Apply grain to image
   const float strength = (data->strength / 100.0f);
   // double zoom=1.0+(8*(data->scale/100.0));

--- a/src/iop/hazeremoval.c
+++ b/src/iop/hazeremoval.c
@@ -637,9 +637,8 @@ void process(dt_iop_module_t *self,
     dt_iop_gui_leave_critical_section(self);
   }
 
-  // FIXME in pipe->type |= DT_DEV_PIXELPIPE_IMAGE mode we currently can't receive data from preview
-  // so we at least leave a note to the user
-  if((piece->pipe->type & DT_DEV_PIXELPIPE_IMAGE) && !hq)
+  // As we can't receive data from preview we at least leave a note to the user
+  if(dt_pipe_is_image(piece->pipe) && !hq)
     dt_control_log(_("inconsistent output"));
 
   // In all other cases we calculate distance_max and A0 here.
@@ -907,9 +906,8 @@ int process_cl(dt_iop_module_t *self,
     dt_iop_gui_leave_critical_section(self);
   }
 
-  // FIXME in pipe->type |= DT_DEV_PIXELPIPE_IMAGE mode we currently can't receive data from preview
-  // so we at least leave a note to the user
-  if((piece->pipe->type & DT_DEV_PIXELPIPE_IMAGE) && !hq)
+  // As we can't receive data from preview we at least leave a note to the user
+  if(dt_pipe_is_image(piece->pipe) && !hq)
     dt_control_log(_("inconsistent output"));
 
   // In all other cases we calculate distance_max and A0 here.

--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -1053,9 +1053,9 @@ void toneeq_process(dt_iop_module_t *self,
     }
     else if(dt_pipe_is_preview(piece->pipe))
     {
-      // For DT_DEV_PIXELPIPE_PREVIEW, we need to cache it too to
-      // compute the full image stats upon user request in GUI threads
-      // locks are required since GUI reads and writes on that buffer.
+      // For preview pipe we need to cache it too because we have to
+      // compute the full image stats upon user request in GUI threads.
+      // Locks are required since GUI reads and writes on that buffer.
 
       // Re-allocate a new buffer if the thumb preview size has changed
       dt_iop_gui_enter_critical_section(self);


### PR DESCRIPTION
The `Avoid some superfluous full pixelpipe runs` commit b34c81b83cf6ac31dd4329e8b9817cbd64edcbc2 broke pipe processing for image pipes. In that case we need the final image dimensions so we restart.

While being here:
1. We should give some slightly better hints for pixelpipe stop reports and document in code.
2. introduced tests `dt_pipe_is_image()` and `dt_pipe_is_image_final()` and consequently used all those tests all over the code.
3. A few minor code simplifications