### PR TITLE
[AI] Add plugins/ai/models_path to override the AI models folder

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -425,6 +425,13 @@
     <longdescription>GitHub repository for downloading AI models (format: owner/repo)</longdescription>
   </dtconfig>
   <dtconfig>
+    <name>plugins/ai/models_path</name>
+    <type>string</type>
+    <default></default>
+    <shortdescription>custom AI models folder</shortdescription>
+    <longdescription>folder where AI models are stored. leave empty for the default location. existing models in the default location are not migrated automatically</longdescription>
+  </dtconfig>
+  <dtconfig>
     <name>plugins/ai/cuda_device_id</name>
     <type min="0" max="15">int</type>
     <default>0</default>

--- a/src/common/ai_models.c
+++ b/src/common/ai_models.c
@@ -428,8 +428,23 @@ static void _setup_registry(dt_ai_registry_t *registry)
   char cachedir[PATH_MAX] = {0};
   dt_loc_get_user_cache_dir(cachedir, sizeof(cachedir));
 
-  registry->models_dir = g_build_filename(g_get_user_data_dir(), 
-                                          "darktable", "models", NULL);
+  // honour plugins/ai/models_path override; "~/..." expands to $HOME
+  char *override = dt_conf_get_string("plugins/ai/models_path");
+  if(override && override[0])
+  {
+    if(override[0] == '~' && (override[1] == '/' || override[1] == '\0'))
+      registry->models_dir
+        = g_build_filename(g_get_home_dir(), override + 2, NULL);
+    else
+      registry->models_dir = g_strdup(override);
+  }
+  else
+  {
+    registry->models_dir = g_build_filename(g_get_user_data_dir(),
+                                            "darktable", "models", NULL);
+  }
+  g_free(override);
+
   registry->cache_dir = g_build_filename(cachedir, "ai_downloads", NULL);
 
   _ensure_directory(registry->models_dir);


### PR DESCRIPTION
This isn't a real feature and it isn't a bugfix either – it's a small unblock for users who run multiple darktable installations side by side (testing, packaging, multi-config setups).

### Context

By default darktable stores downloaded AI models under `$XDG_DATA_HOME/darktable/models` – a single location shared across every darktable installation on the same user account. That's right for most people (one download, many configdirs), but it doesn't fit every setup.

The case that prompted this came from [darktable-org/lua-scripts#677 (comment)](https://github.com/darktable-org/lua-scripts/pull/677#issuecomment-4467460097): @wpferguson runs 40+ darktable installations on one machine, each with its own `--configdir` so they don't step on each other. Everything stays isolated per instance except the models folder, which is hard-coded to the shared user data dir.

### What this PR does

Adds one optional string conf key, `plugins/ai/models_path`. Empty (the default) → behaviour unchanged. Set → the AI registry uses that path verbatim, with a leading `~` expanded to `$HOME` so users can type `~/dt-models` in preferences. No migration of existing downloads; the longdescription notes this.