### PR TITLE
[AI] Fix magenta highlight artifacts in RGB denoise by clamping model input to [0, 1]

### DIFF
--- a/src/common/ai/restore_rgb.c
+++ b/src/common/ai/restore_rgb.c
@@ -74,7 +74,8 @@ static const float _dwt_sigma_mul_default[DWT_DETAIL_BANDS] = {
 };
 
 // sRGB transfer function (gamma curve only, no primaries change).
-// values > 1.0 are allowed to preserve wide-gamut colors
+// extends to v > 1.0 via the polynomial; callers feeding model input
+// should clamp first since the model produces magenta on > 1 input.
 static inline float _linear_to_srgb(const float v)
 {
   if(v <= 0.0f) return 0.0f;
@@ -257,6 +258,12 @@ int dt_restore_run_patch(dt_restore_context_t *ctx,
         sg = sg > 0.0f ? sqrtf(sg) : 0.0f;
         sb = sb > 0.0f ? sqrtf(sb) : 0.0f;
       }
+      // clamp the model input so super-bright highlights (sun, specular)
+      // don't push it out-of-distribution; wide-gamut originals are
+      // preserved via in_gamut_mask pass-through downstream
+      sr = fminf(sr, 1.0f);
+      sg = fminf(sg, 1.0f);
+      sb = fminf(sb, 1.0f);
       srgb_in[p]             = _linear_to_srgb(sr);
       srgb_in[p + plane]     = _linear_to_srgb(sg);
       srgb_in[p + 2 * plane] = _linear_to_srgb(sb);
@@ -270,13 +277,13 @@ int dt_restore_run_patch(dt_restore_context_t *ctx,
     {
       const float v = in_patch[i];
       const float boosted = v > 0.0f ? sqrtf(v) : 0.0f;
-      srgb_in[i] = _linear_to_srgb(boosted);
+      srgb_in[i] = _linear_to_srgb(fminf(boosted, 1.0f));
     }
   }
   else
   {
     for(size_t i = 0; i < in_pixels; i++)
-      srgb_in[i] = _linear_to_srgb(in_patch[i]);
+      srgb_in[i] = _linear_to_srgb(fminf(in_patch[i], 1.0f));
   }
 
   const int num_inputs = dt_ai_get_input_count(ctx->ai_ctx);


### PR DESCRIPTION
Reported on the pixls.us forum: https://discuss.pixls.us/t/introducing-neural-restore-module-raw-denoise-denoise-and-upscale/57349/82

### Symptom

RGB denoise produced visible magenta starburst artifacts around the sun and other super-bright highlights on a sunset image. Worse with "preserve wide-gamut colors" off (big pink starburst); still visible with it on (smaller scattered dots near bright areas).

### Root cause

The denoise model is trained on sRGB content in [0, 1]. The working-profile → sRGB-linear matrix conversion in `dt_restore_run_patch` can produce values > 1 for super-bright pixels in wide-gamut sources. `_linear_to_srgb` extends naturally past 1 via its polynomial, so the model received out-of-distribution input and produced unpredictable chromatic output – R and B channels respond differently than G, yielding magenta.

The wide-gamut preservation path masked some of this (out-of-gamut pixels pass through with original values), but pixels just inside the 1% gamut margin still went through the model and produced the residual dots.

### Fix

Clamp `sr/sg/sb` to ≤ 1.0 with `fminf` before encoding to sRGB gamma and feeding the model. Applied in all three input branches (with-profile, no-profile-with-boost, no-profile-no-boost). `fminf` is NaN-safe – treats NaN as the smaller value, so any NaN that leaks in still produces 1.0 instead of being passed through unmodified.

Wide-gamut content remains intact:
- `in_gamut_mask` is computed on the original (un-clamped) sr/sg/sb, so out-of-gamut pixels are still correctly identified.
- Post-process pass 1 writes `in_patch[p]` (original working-profile value) for out-of-gamut pixels – the clamp only affects what the model sees, not what gets written out.

### Trade-off

For `preserve_wide_gamut=OFF`, super-bright pixels above 1.0 are now flat-clipped at 1.0 in the output instead of producing colored garbage. Strict improvement vs. magenta starburst.