### PR TITLE
Don't write extra lines with dt_print()

### DIFF
--- a/src/common/bilateralcl.c
+++ b/src/common/bilateralcl.c
@@ -148,7 +148,7 @@ dt_bilateral_cl_t *dt_bilateral_init_cl(const int devid,
 
 #if 0
   dt_print(DT_DEBUG_ALWAYS, "[bilateral] created grid [%d %d %d]"
-          " with sigma (%f %f) (%f %f)\n", b->size_x, b->size_y, b->size_z,
+          " with sigma (%f %f) (%f %f)", b->size_x, b->size_y, b->size_z,
           b->sigma_s, sigma_s, b->sigma_r, sigma_r);
 #endif
   return b;

--- a/src/common/history.c
+++ b/src/common/history.c
@@ -1541,7 +1541,7 @@ GList *dt_history_duplicate(GList *hist)
       {
         // nothing else to do
         dt_print(DT_DEBUG_ALWAYS, "[_duplicate_history]"
-                 " can't find base module for %s\n", old->op_name);
+                 " can't find base module for %s", old->op_name);
       }
     }
 

--- a/src/common/iop_order.c
+++ b/src/common/iop_order.c
@@ -2465,7 +2465,7 @@ gboolean dt_ioppr_check_iop_order_ext(dt_develop_t *dev,
     {
       const dt_iop_module_t *const restrict mod = modules->data;
 
-      if(!dt_iop_module_is(mod->so, "gamma"))
+      if(!dt_iop_module_is_gamma(mod))
       {
         iop_order_ok = FALSE;
         dt_print(DT_DEBUG_ALWAYS,

--- a/src/common/iop_profile.c
+++ b/src/common/iop_profile.c
@@ -1657,7 +1657,7 @@ gboolean dt_ioppr_transform_image_colorspace_rgb_cl
       {
         dt_print(DT_DEBUG_OPENCL,
                 "[dt_ioppr_transform_image_colorspace_rgb_cl] error on copy image"
-                 " for color transformation\n");
+                 " for color transformation");
         return FALSE;
       }
     }

--- a/src/imageio/imageio.c
+++ b/src/imageio/imageio.c
@@ -802,7 +802,7 @@ error_im:
       "[dt_imageio_large_thumbnail] error: The thumbnail image is not in "
       "JPEG format, and DT was built without neither GraphicsMagick or "
       "ImageMagick. Please rebuild DT with GraphicsMagick or ImageMagick "
-      "support enabled.\n");
+      "support enabled.");
 #endif
   }
 
@@ -1135,7 +1135,7 @@ gboolean dt_imageio_export_with_flags(const dt_imgid_t imgid,
       else
         dt_print(DT_DEBUG_ALWAYS,
                  "[imageio] please check that you have imported this style into darktable"
-                 " and specified it in the command line without the .dtstyle extension\n");
+                 " and specified it in the command line without the .dtstyle extension");
       goto error;
     }
 

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -898,7 +898,7 @@ dt_view_surface_value_t dt_view_image_get_surface_cached(const dt_imgid_t imgid,
         {
           dt_print(DT_DEBUG_ALWAYS,
                   "oops, there seems to be a code path not setting the"
-                  " color space of thumbnails!\n");
+                  " color space of thumbnails!");
         }
         else if(buf.color_space != DT_COLORSPACE_DISPLAY
                 && buf.color_space != DT_COLORSPACE_DISPLAY2)


### PR DESCRIPTION
In some cases the dt_print() logs had avoidable final "\n". One leftover dt_iop_module_is_gamma() call