### PR TITLE
[AI] Fix over-aggressive optical-black trim in AI raw denoise

### DIFF
--- a/src/common/ai/restore_raw_bayer.c
+++ b/src/common/ai/restore_raw_bayer.c
@@ -324,73 +324,6 @@ static void _pack_bayer_tile(const float *cfa,
   }
 }
 
-// trim optical-black inside the metadata-reported visible region: scan
-// rows/cols inward and shrink while their mean stays at the black level.
-// Sony bodies report p_width/p_height that overcounts the actual visible
-// region (A7R V: by 64×40 px). Shrinks in CFA-aligned pairs of 2
-static void _bayer_trim_optical_black(const float *cfa,
-                                      int width,
-                                      int vis_y_lo, int vis_x_lo,
-                                      int *vis_y_hi, int *vis_x_hi,
-                                      const float black[4],
-                                      const float range[4])
-{
-  const float avg_black = 0.25f
-    * (black[0] + black[1] + black[2] + black[3]);
-  const float avg_range = 0.25f
-    * (range[0] + range[1] + range[2] + range[3]);
-  const float threshold = avg_black + 0.005f * avg_range;
-
-  // cap shrinkage so a uniformly-dark frame can't eat into real content
-  const int max_shrink = 256;
-  const int min_y_hi = *vis_y_hi - max_shrink;
-  const int min_x_hi = *vis_x_hi - max_shrink;
-
-  // sub-sample (~2k samples per row/col is plenty to detect OB vs content)
-  const int sx = ((*vis_x_hi - vis_x_lo) > 2048)
-                 ? ((*vis_x_hi - vis_x_lo) / 2048) : 1;
-  const int sy = ((*vis_y_hi - vis_y_lo) > 2048)
-                 ? ((*vis_y_hi - vis_y_lo) / 2048) : 1;
-
-  while(*vis_y_hi - 2 >= vis_y_lo && *vis_y_hi - 2 >= min_y_hi)
-  {
-    const int r0 = *vis_y_hi - 2;
-    const int r1 = *vis_y_hi - 1;
-    double s0 = 0.0, s1 = 0.0;
-    int n = 0;
-    for(int c = vis_x_lo; c < *vis_x_hi; c += sx)
-    {
-      s0 += cfa[(size_t)r0 * width + c];
-      s1 += cfa[(size_t)r1 * width + c];
-      n++;
-    }
-    if(n == 0) break;
-    const float m0 = (float)(s0 / n);
-    const float m1 = (float)(s1 / n);
-    if(m0 < threshold && m1 < threshold) *vis_y_hi -= 2;
-    else break;
-  }
-
-  while(*vis_x_hi - 2 >= vis_x_lo && *vis_x_hi - 2 >= min_x_hi)
-  {
-    const int c0 = *vis_x_hi - 2;
-    const int c1 = *vis_x_hi - 1;
-    double s0 = 0.0, s1 = 0.0;
-    int n = 0;
-    for(int r = vis_y_lo; r < *vis_y_hi; r += sy)
-    {
-      s0 += cfa[(size_t)r * width + c0];
-      s1 += cfa[(size_t)r * width + c1];
-      n++;
-    }
-    if(n == 0) break;
-    const float m0 = (float)(s0 / n);
-    const float m1 = (float)(s1 / n);
-    if(m0 < threshold && m1 < threshold) *vis_x_hi -= 2;
-    else break;
-  }
-}
-
 int dt_restore_raw_bayer(dt_restore_context_t *ctx,
                          const dt_image_t *img,
                          const float *cfa_in,
@@ -429,25 +362,12 @@ int dt_restore_raw_bayer(dt_restore_context_t *ctx,
     cfa_out[i] = (uint16_t)(cv + 0.5f);
   }
 
-  // working region in sensor coords: [y0..y0+2*Hh) x [x0..x0+2*Wh).
-  // trim any optical-black inside the metadata-reported visible region
-  const int vis_x_lo = (img->p_width  > 0) ? img->crop_x : 0;
-  const int vis_y_lo = (img->p_height > 0) ? img->crop_y : 0;
-  int vis_end_x = (img->p_width  > 0) ? (img->crop_x + img->p_width)  : width;
-  int vis_end_y = (img->p_height > 0) ? (img->crop_y + img->p_height) : height;
-  const int vis_end_x_pre = vis_end_x;
-  const int vis_end_y_pre = vis_end_y;
-  _bayer_trim_optical_black(cfa_in, width,
-                            vis_y_lo, vis_x_lo,
-                            &vis_end_y, &vis_end_x,
-                            prep.black, prep.range);
-  if(vis_end_x != vis_end_x_pre || vis_end_y != vis_end_y_pre)
-    dt_print(DT_DEBUG_AI,
-             "[restore_raw_bayer] trimmed optical-black: "
-             "%dx%d → %dx%d (dropped %d cols, %d rows)",
-             vis_end_x_pre - vis_x_lo, vis_end_y_pre - vis_y_lo,
-             vis_end_x - vis_x_lo, vis_end_y - vis_y_lo,
-             vis_end_x_pre - vis_end_x, vis_end_y_pre - vis_end_y);
+  // working region in sensor coords: [y0..y0+2*Hh) x [x0..x0+2*Wh),
+  // bounded by the metadata-reported visible region
+  const int vis_x_lo  = (img->p_width  > 0) ? img->crop_x : 0;
+  const int vis_y_lo  = (img->p_height > 0) ? img->crop_y : 0;
+  const int vis_end_x = (img->p_width  > 0) ? (img->crop_x + img->p_width)  : width;
+  const int vis_end_y = (img->p_height > 0) ? (img->crop_y + img->p_height) : height;
   const int Hh = (vis_end_y - y0) / 2;
   const int Wh = (vis_end_x - x0) / 2;
   if(Hh <= 0 || Wh <= 0) return 0;  // too small; output == input
@@ -918,14 +838,10 @@ int dt_restore_raw_bayer_preview_piped(dt_restore_context_t *ctx,
   // even-snapped inference tile origin in sensor coords
   int pp_sr0 = 0, pp_sc0 = 0;
   int pp_mir_y_lo, pp_mir_y_hi, pp_mir_x_lo, pp_mir_x_hi;
-  const int pp_vis_x_lo  = (img->p_width  > 0) ? img->crop_x : 0;
-  const int pp_vis_y_lo  = (img->p_height > 0) ? img->crop_y : 0;
-  int pp_vis_x_hi = (img->p_width  > 0) ? (img->crop_x + img->p_width)  : width;
-  int pp_vis_y_hi = (img->p_height > 0) ? (img->crop_y + img->p_height) : height;
-  _bayer_trim_optical_black(cfa_full, width,
-                            pp_vis_y_lo, pp_vis_x_lo,
-                            &pp_vis_y_hi, &pp_vis_x_hi,
-                            prep.black, prep.range);
+  const int pp_vis_x_lo = (img->p_width  > 0) ? img->crop_x : 0;
+  const int pp_vis_y_lo = (img->p_height > 0) ? img->crop_y : 0;
+  const int pp_vis_x_hi = (img->p_width  > 0) ? (img->crop_x + img->p_width)  : width;
+  const int pp_vis_y_hi = (img->p_height > 0) ? (img->crop_y + img->p_height) : height;
   _bayer_tile_geometry(ctx, &prep, inf_y, inf_x, width, height,
                        pp_vis_y_lo, pp_vis_y_hi, pp_vis_x_lo, pp_vis_x_hi,
                        &pp_sr0, &pp_sc0,


### PR DESCRIPTION
Fixes the issue @da-phil reported in https://github.com/darktable-org/darktable/pull/21037#issuecomment-4470881718 – the heuristic ate ~256 rows off the bottom of his image.

The original motivation was real: on a few raws the AI denoise output showed a thin dark band at the edge, because rawspeed's `p_width × p_height` for some bodies still includes a strip of true optical-black pixels. I added a small detector that scanned the trailing rows/cols and trimmed anything that looked masked.

In practice it turned out to be too aggressive – on @da-phil's image it crossed from OB into real content and removed 256 rows. Hard to tune a content-based check that's both safe and useful.

The structural fix we already had – restricting the working region to `crop_x/crop_y + p_width × p_height` and using `mir_*` reflection at the borders – is enough on its own. That matches what rawprepare does downstream for normal rendering, so the AI module now processes the same region the rest of the pipeline does. Retested two of the original problem files: no dark bands. So this PR just drops the detector and its call sites.