### PR TITLE
Refactor dt_iop_module_is()

### DIFF
--- a/src/common/ai/restore.c
+++ b/src/common/ai/restore.c
@@ -682,7 +682,7 @@ int dt_restore_run_user_pipe_roi(dt_imgid_t imgid,
   for(GList *n = pipe.nodes; n; n = g_list_next(n))
   {
     dt_dev_pixelpipe_iop_t *piece = n->data;
-    if(dt_iop_module_is(piece->module->so, "rawdenoise"))
+    if(dt_iop_module_is(piece->module, "rawdenoise"))
       piece->enabled = FALSE;
   }
 

--- a/src/common/ai/restore_raw_linear.c
+++ b/src/common/ai/restore_raw_linear.c
@@ -307,8 +307,8 @@ static int _run_demosaic_pipe(const dt_imgid_t imgid,
   for(GList *n = pipe.nodes; n; n = g_list_next(n))
   {
     dt_dev_pixelpipe_iop_t *piece = n->data;
-    if(dt_iop_module_is(piece->module->so, "temperature")
-       || dt_iop_module_is(piece->module->so, "rawdenoise"))
+    if(dt_iop_module_is(piece->module, "temperature")
+       || dt_iop_module_is(piece->module, "rawdenoise"))
       piece->enabled = FALSE;
   }
 

--- a/src/common/colorspaces.c
+++ b/src/common/colorspaces.c
@@ -794,10 +794,10 @@ const dt_colorspaces_color_profile_t *dt_colorspaces_get_work_profile
   {
     for(const GList *modules = darktable.iop; modules; modules = g_list_next(modules))
     {
-      const dt_iop_module_so_t *module = (const dt_iop_module_so_t *)(modules->data);
-      if(dt_iop_module_is(module, "colorin"))
+      const dt_iop_module_so_t *mod_so = (const dt_iop_module_so_t *)(modules->data);
+      if(dt_iop_module_so_is(mod_so, "colorin"))
       {
-        colorin = module;
+        colorin = mod_so;
         break;
       }
     }
@@ -853,10 +853,10 @@ const dt_colorspaces_color_profile_t *dt_colorspaces_get_output_profile
   {
     for(const GList *modules = darktable.iop; modules; modules = g_list_next(modules))
     {
-      const dt_iop_module_so_t *module = (const dt_iop_module_so_t *)(modules->data);
-      if(dt_iop_module_is(module, "colorout"))
+      const dt_iop_module_so_t *mod_so = (const dt_iop_module_so_t *)(modules->data);
+      if(dt_iop_module_so_is(mod_so, "colorout"))
       {
-        colorout = module;
+        colorout = mod_so;
         break;
       }
     }

--- a/src/common/iop_order.c
+++ b/src/common/iop_order.c
@@ -1478,7 +1478,7 @@ static void _count_iop_module(GList *iop,
   for(const GList *modules = iop; modules; modules = g_list_next(modules))
   {
     const dt_iop_module_t *const restrict mod = modules->data;
-    if(dt_iop_module_is(mod->so, operation))
+    if(dt_iop_module_is(mod, operation))
     {
       (*count)++;
       if(*max_multi_priority < mod->multi_priority)
@@ -1531,7 +1531,7 @@ static int _get_multi_priority(dt_develop_t *dev,
   for(const GList *l = dev->iop; l; l = g_list_next(l))
   {
     const dt_iop_module_t *const restrict mod = l->data;
-    if((!only_disabled || !mod->enabled) && dt_iop_module_is(mod->so, operation))
+    if((!only_disabled || !mod->enabled) && dt_iop_module_is(mod, operation))
     {
       count++;
       if(count == n) return mod->multi_priority;
@@ -1984,8 +1984,8 @@ gboolean dt_ioppr_check_can_move_before_iop(GList *iop_list,
         {
           const dt_iop_order_rule_t *const restrict rule = rules->data;
 
-          if(dt_iop_module_is(module->so, rule->op_prev)
-             && dt_iop_module_is(mod->so, rule->op_next))
+          if(dt_iop_module_is(module, rule->op_prev)
+             && dt_iop_module_is(mod, rule->op_next))
           {
             rule_found = TRUE;
             break;
@@ -2071,8 +2071,8 @@ gboolean dt_ioppr_check_can_move_before_iop(GList *iop_list,
         {
           const dt_iop_order_rule_t *const restrict rule = rules->data;
 
-          if(dt_iop_module_is(mod->so, rule->op_prev)
-             && dt_iop_module_is(module->so, rule->op_next))
+          if(dt_iop_module_is(mod, rule->op_prev)
+             && dt_iop_module_is(module, rule->op_next))
           {
             rule_found = TRUE;
             break;
@@ -2364,7 +2364,7 @@ static void _ioppr_check_rules(GList *iop_list,
       const dt_iop_order_rule_t *const restrict rule = rules->data;
 
       // mod must be before rule->op_next
-      if(dt_iop_module_is(mod->so, rule->op_prev))
+      if(dt_iop_module_is(mod, rule->op_prev))
       {
         // check if there's a rule->op_next module before mod
         for(const GList *modules_prev = g_list_previous(modules);
@@ -2386,7 +2386,7 @@ static void _ioppr_check_rules(GList *iop_list,
         }
       }
       // mod must be after rule->op_prev
-      else if(dt_iop_module_is(mod->so, rule->op_next))
+      else if(dt_iop_module_is(mod, rule->op_next))
       {
         // check if there's a rule->op_prev module after mod
         for(const GList *modules_next = g_list_next(modules);

--- a/src/common/iop_profile.c
+++ b/src/common/iop_profile.c
@@ -838,17 +838,17 @@ dt_iop_order_iccprofile_info_t *dt_ioppr_get_iop_work_profile_info(const struct 
     dt_iop_module_t *mod = modules->data;
 
     // we reach the module, that's it
-    if(dt_iop_module_is(mod->so, module->op)) break;
+    if(dt_iop_module_is(mod, module->op)) break;
 
     // if we reach colorout means that the module is after it
-    if(dt_iop_module_is(mod->so, "colorout"))
+    if(dt_iop_module_is(mod, "colorout"))
     {
       in_between = FALSE;
       break;
     }
 
     // we reach colorin, so far we're good
-    if(dt_iop_module_is(mod->so, "colorin"))
+    if(dt_iop_module_is(mod, "colorin"))
     {
       in_between = TRUE;
       break;
@@ -1049,7 +1049,7 @@ void dt_ioppr_get_work_profile_type(struct dt_develop_t *dev,
   for(const GList *modules = darktable.iop; modules; modules = g_list_next(modules))
   {
     dt_iop_module_so_t *module_so = modules->data;
-    if(dt_iop_module_is(module_so, "colorin"))
+    if(dt_iop_module_so_is(module_so, "colorin"))
     {
       colorin_so = module_so;
       break;
@@ -1060,7 +1060,7 @@ void dt_ioppr_get_work_profile_type(struct dt_develop_t *dev,
     for(const GList *modules = dev->iop; modules; modules = g_list_next(modules))
     {
       dt_iop_module_t *module = modules->data;
-      if(dt_iop_module_is(module->so, "colorin"))
+      if(dt_iop_module_is(module, "colorin"))
       {
         colorin = module;
         break;
@@ -1101,7 +1101,7 @@ void dt_ioppr_get_export_profile_type(struct dt_develop_t *dev,
       modules = g_list_previous(modules))
   {
     dt_iop_module_so_t *module_so = modules->data;
-    if(dt_iop_module_is(module_so, "colorout"))
+    if(dt_iop_module_so_is(module_so, "colorout"))
     {
       colorout_so = module_so;
       break;
@@ -1112,7 +1112,7 @@ void dt_ioppr_get_export_profile_type(struct dt_develop_t *dev,
     for(const GList *modules = g_list_last(dev->iop); modules; modules = g_list_previous(modules))
     {
       dt_iop_module_t *module = modules->data;
-      if(dt_iop_module_is(module->so, "colorout"))
+      if(dt_iop_module_is(module, "colorout"))
       {
         colorout = module;
         break;

--- a/src/common/styles.c
+++ b/src/common/styles.c
@@ -753,7 +753,7 @@ void dt_styles_apply_style_item(dt_develop_t *dev,
         }
         else
         {
-          if(dt_iop_module_is(module->so, "spots") && style_item->module_version == 1)
+          if(dt_iop_module_is(module, "spots") && style_item->module_version == 1)
           {
             // FIXME: not sure how to handle this here...
             // quick and dirty hack to handle spot removal legacy_params
@@ -770,7 +770,7 @@ void dt_styles_apply_style_item(dt_develop_t *dev,
          * by default, so if it is disabled, enable it, and replace params with
          * default_params. if user want to, he can disable it.
          */
-        if(dt_iop_module_is(module->so, "flip")
+        if(dt_iop_module_is(module, "flip")
            && !module->enabled
            && labs(style_item->module_version) == 1)
         {

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -1433,7 +1433,7 @@ void dt_dev_add_masks_history_item_ext(dt_develop_t *dev,
     for(GList *modules = dev->iop; modules; modules = g_list_next(modules))
     {
       dt_iop_module_t *mod = modules->data;
-      if(dt_iop_module_is(mod->so, "mask_manager"))
+      if(dt_iop_module_is(mod, "mask_manager"))
       {
         module = mod;
         break;
@@ -1875,7 +1875,7 @@ static gboolean _dev_auto_apply_presets(dt_develop_t *dev)
           // For new edits the temperature will be added back
           // depending on the chromatic adaptation the standard way.
 
-          if(dt_iop_module_is(module->so, "temperature")
+          if(dt_iop_module_is(module, "temperature")
              && (image->change_timestamp == -1))
           {
             // it is important to recover temperature in this case
@@ -2452,7 +2452,7 @@ void dt_dev_read_history_ext(dt_develop_t *dev,
     for(GList *modules = dev->iop; modules; modules = g_list_next(modules))
     {
       dt_iop_module_t *module = modules->data;
-      if(dt_iop_module_is(module->so, module_name))
+      if(dt_iop_module_is(module, module_name))
       {
         // make sure that module not supporting multiple instances are
         // selected here.
@@ -2506,9 +2506,9 @@ void dt_dev_read_history_ext(dt_develop_t *dev,
 
     if(is_workflow_none && hist->module->enabled)
     {
-      if(dt_iop_module_is(hist->module->so, "temperature"))
+      if(dt_iop_module_is(hist->module, "temperature"))
         temperature = hist->module;
-      if(dt_iop_module_is(hist->module->so, "channelmixerrgb"))
+      if(dt_iop_module_is(hist->module, "channelmixerrgb"))
         channelmixerrgb = hist->module;
     }
 
@@ -2616,7 +2616,7 @@ void dt_dev_read_history_ext(dt_develop_t *dev,
       }
       else
       {
-        if(dt_iop_module_is(hist->module->so, "spots")
+        if(dt_iop_module_is(hist->module, "spots")
            && modversion == 1)
         {
           // quick and dirty hack to handle spot removal legacy_params
@@ -2632,7 +2632,7 @@ void dt_dev_read_history_ext(dt_develop_t *dev,
        * by default, so if it is disabled, enable it, and replace params with
        * default_params. if user want to, he can disable it.
        */
-      if(dt_iop_module_is(hist->module->so, "flip")
+      if(dt_iop_module_is(hist->module, "flip")
          && !hist->enabled
          && labs(modversion) == 1)
       {
@@ -3317,7 +3317,7 @@ float dt_dev_exposure_get_effective_exposure(dt_develop_t *dev)
   for(const GList *modules = darktable.iop; modules; modules = g_list_next(modules))
   {
     const dt_iop_module_so_t *module_so = modules->data;
-    if(dt_iop_module_is(module_so, "exposure"))
+    if(dt_iop_module_so_is(module_so, "exposure"))
     {
       exposure_so = module_so;
       break;

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -1164,7 +1164,7 @@ static void _gui_off_callback(GtkToggleButton *togglebutton,
     dt_dev_modulegroups_update_visibility(darktable.develop);
 }
 
-gboolean dt_iop_so_is_hidden(dt_iop_module_so_t *module)
+gboolean dt_iop_so_is_hidden(const dt_iop_module_so_t *module)
 {
   gboolean is_hidden = TRUE;
   if(!(module->flags() & IOP_FLAGS_HIDDEN))
@@ -1179,12 +1179,12 @@ gboolean dt_iop_so_is_hidden(dt_iop_module_so_t *module)
   return is_hidden;
 }
 
-gboolean dt_iop_is_hidden(dt_iop_module_t *module)
+gboolean dt_iop_is_hidden(const dt_iop_module_t *module)
 {
   return !module || !module->so || dt_iop_so_is_hidden(module->so);
 }
 
-gboolean dt_iop_shown_in_group(dt_iop_module_t *module, uint32_t group)
+gboolean dt_iop_shown_in_group(dt_iop_module_t *module, const uint32_t group)
 {
   if(group == DT_MODULEGROUP_NONE) return TRUE;
 
@@ -1944,7 +1944,7 @@ dt_iop_module_t *dt_iop_commit_blend_params(dt_iop_module_t *module,
   for(GList *iter = module->dev->iop; iter; iter = g_list_next(iter))
   {
     dt_iop_module_t *candidate = iter->data;
-    if(dt_iop_module_is(candidate->so, blendop_params->raster_mask_source))
+    if(dt_iop_module_is(candidate, blendop_params->raster_mask_source))
     {
       if(candidate->multi_priority == blendop_params->raster_mask_instance)
       {
@@ -3341,7 +3341,7 @@ dt_iop_module_t *dt_iop_get_module_from_list(GList *iop_list, const char *op)
   for(GList *modules = iop_list; modules; modules = g_list_next(modules))
   {
     dt_iop_module_t *mod = modules->data;
-    if(dt_iop_module_is(mod->so, op))
+    if(dt_iop_module_is(mod, op))
     {
       result = mod;
       break;
@@ -3362,10 +3362,10 @@ dt_iop_module_so_t *dt_iop_get_module_so(const char *op)
 
   for(GList *modules = darktable.iop; modules; modules = g_list_next(modules))
   {
-    dt_iop_module_so_t *mod = modules->data;
-    if(dt_iop_module_is(mod, op))
+    dt_iop_module_so_t *mod_so = modules->data;
+    if(dt_iop_module_so_is(mod_so, op))
     {
-      result = mod;
+      result = mod_so;
       break;
     }
   }
@@ -3378,9 +3378,9 @@ int dt_iop_get_module_flags(const char *op)
   GList *modules = darktable.iop;
   while(modules)
   {
-    dt_iop_module_so_t *module = modules->data;
-    if(dt_iop_module_is(module, op))
-      return module->flags();
+    dt_iop_module_so_t *module_so = modules->data;
+    if(dt_iop_module_so_is(module_so, op))
+      return module_so->flags();
     modules = g_list_next(modules);
   }
   return 0;
@@ -3659,7 +3659,7 @@ dt_iop_module_t *dt_iop_get_module_by_op_priority(GList *modules,
   {
     dt_iop_module_t *mod = m->data;
 
-    if(dt_iop_module_is(mod->so, operation)
+    if(dt_iop_module_is(mod, operation)
        && (mod->multi_priority == multi_priority || multi_priority == -1))
     {
       mod_ret = mod;
@@ -3800,7 +3800,7 @@ dt_iop_module_t *dt_iop_get_module_by_instance_name(GList *modules,
   {
     dt_iop_module_t *mod = m->data;
 
-    if((dt_iop_module_is(mod->so, operation))
+    if((dt_iop_module_is(mod, operation))
        && ((multi_name == NULL) || (strcmp(mod->multi_name, multi_name) == 0)))
     {
       mod_ret = mod;
@@ -3835,7 +3835,7 @@ gboolean dt_iop_is_first_instance(GList *modules, const dt_iop_module_t *module)
   while(iop)
   {
     dt_iop_module_t *m = iop->data;
-    if(dt_iop_module_is(m->so, module->op))
+    if(dt_iop_module_is(m, module->op))
     {
       is_first = (m == module);
       break;

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -336,10 +336,10 @@ void dt_iop_init_pipe(dt_iop_module_t *module,
                       struct dt_dev_pixelpipe_t *pipe,
                       struct dt_dev_pixelpipe_iop_t *piece);
 /** checks if iop do have an ui */
-gboolean dt_iop_so_is_hidden(dt_iop_module_so_t *module);
-gboolean dt_iop_is_hidden(dt_iop_module_t *module);
+gboolean dt_iop_so_is_hidden(const dt_iop_module_so_t *module);
+gboolean dt_iop_is_hidden(const dt_iop_module_t *module);
 /** checks whether iop is shown in specified group */
-gboolean dt_iop_shown_in_group(dt_iop_module_t *module, uint32_t group);
+gboolean dt_iop_shown_in_group(dt_iop_module_t *module, const uint32_t group);
 /** enter a GUI critical section by acquiring gui_data->lock **/
 static inline void dt_iop_gui_enter_critical_section(dt_iop_module_t *const module)
   ACQUIRE(&module->gui_lock)
@@ -389,9 +389,8 @@ void dt_iop_commit_params(dt_iop_module_t *module,
    Also watch out for a raster mask source module to get it's first `target`,
    dt_iop_commit_blend_params() either returns NULL or the source module.
 */
-dt_iop_module_t *dt_iop_commit_blend_params
-  (dt_iop_module_t *module,
-   const struct dt_develop_blend_params_t *blendop_params);
+dt_iop_module_t *dt_iop_commit_blend_params(dt_iop_module_t *module,
+                                            const struct dt_develop_blend_params_t *blendop_params);
 /** make sure the raster mask is advertised if available */
 void dt_iop_advertise_rastermask(dt_iop_module_t *module, const int mask_mode);
 /** creates a label widget for the expander, with callback to enable/disable this module. */
@@ -449,19 +448,25 @@ dt_iop_module_t *dt_iop_get_module_by_instance_name(GList *modules,
                                                     const char *operation,
                                                     const char *multi_name);
 /** check for module name */
-static inline gboolean dt_iop_module_is(const dt_iop_module_so_t *module,
-                                        const char*operation)
+static inline gboolean dt_iop_module_is(const dt_iop_module_t *module,
+                                        const char* operation)
+{
+  return !g_strcmp0(module->so->op, operation);
+}
+
+static inline gboolean dt_iop_module_so_is(const dt_iop_module_so_t *module,
+                                           const char* operation)
 {
   return !g_strcmp0(module->op, operation);
 }
 
 static inline gboolean dt_iop_module_is_gamma(const dt_iop_module_t *module)
 {
-  return dt_iop_module_is(module->so, "gamma");
+  return dt_iop_module_is(module, "gamma");
 }
 static inline gboolean dt_iop_module_is_finalscale(const dt_iop_module_t *module)
 {
-  return dt_iop_module_is(module->so, "finalscale");
+  return dt_iop_module_is(module, "finalscale");
 }
 
 /** count instances of a module **/

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -1927,8 +1927,8 @@ static int _brush_events_button_released(dt_iop_module_t *module,
         // and we switch in edit mode to show all the forms
         // spots and retouch have their own handling of creation_continuous
         if(gui->creation_continuous
-           && (dt_iop_module_is(crea_module->so, "spots")
-               || dt_iop_module_is(crea_module->so, "retouch")))
+           && (dt_iop_module_is(crea_module, "spots")
+               || dt_iop_module_is(crea_module, "retouch")))
           dt_masks_set_edit_mode_single_form(crea_module, form->formid, DT_MASKS_EDIT_FULL);
         else if(!gui->creation_continuous)
           dt_masks_set_edit_mode(crea_module, DT_MASKS_EDIT_FULL);
@@ -1942,8 +1942,8 @@ static int _brush_events_button_released(dt_iop_module_t *module,
       {
         //spot and retouch manage creation_continuous in their own way
         if(crea_module
-           && !dt_iop_module_is(crea_module->so, "spots")
-           && !dt_iop_module_is(crea_module->so, "retouch"))
+           && !dt_iop_module_is(crea_module, "spots")
+           && !dt_iop_module_is(crea_module, "retouch"))
         {
           dt_iop_gui_blend_data_t *bd = crea_module->blend_data;
           for(int n = 0; n < DEVELOP_MASKS_NB_SHAPES; n++)

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -307,8 +307,8 @@ static int _circle_events_button_pressed(dt_iop_module_t *module,
       // and we switch in edit mode to show all the forms
       // spots and retouch have their own handling of creation_continuous
       if(gui->creation_continuous
-         && (dt_iop_module_is(crea_module->so, "spots")
-             || dt_iop_module_is(crea_module->so, "retouch")))
+         && (dt_iop_module_is(crea_module, "spots")
+             || dt_iop_module_is(crea_module, "retouch")))
         dt_masks_set_edit_mode_single_form(crea_module, form->formid, DT_MASKS_EDIT_FULL);
       else if(!gui->creation_continuous)
         dt_masks_set_edit_mode(crea_module, DT_MASKS_EDIT_FULL);
@@ -355,8 +355,8 @@ static int _circle_events_button_pressed(dt_iop_module_t *module,
     //spot and retouch manage creation_continuous in their own way
     if(gui->creation_continuous
        && (!crea_module
-           || (!dt_iop_module_is(crea_module->so, "spots")
-               && !dt_iop_module_is(crea_module->so, "retouch"))))
+           || (!dt_iop_module_is(crea_module, "spots")
+               && !dt_iop_module_is(crea_module, "retouch"))))
     {
       if(crea_module)
       {

--- a/src/develop/masks/ellipse.c
+++ b/src/develop/masks/ellipse.c
@@ -676,8 +676,8 @@ static int _ellipse_events_button_pressed(dt_iop_module_t *module,
       // and we switch in edit mode to show all the forms
       // spots and retouch have their own handling of creation_continuous
       if(gui->creation_continuous
-         && (dt_iop_module_is(crea_module->so, "spots")
-             || dt_iop_module_is(crea_module->so, "retouch")))
+         && (dt_iop_module_is(crea_module, "spots")
+             || dt_iop_module_is(crea_module, "retouch")))
         dt_masks_set_edit_mode_single_form(crea_module, form->formid, DT_MASKS_EDIT_FULL);
       else if(!gui->creation_continuous)
         dt_masks_set_edit_mode(crea_module, DT_MASKS_EDIT_FULL);
@@ -724,8 +724,8 @@ static int _ellipse_events_button_pressed(dt_iop_module_t *module,
     //spot and retouch manage creation_continuous in their own way
     if(gui->creation_continuous
        && (!crea_module
-           || (!dt_iop_module_is(crea_module->so, "spots")
-               && !dt_iop_module_is(crea_module->so, "retouch"))))
+           || (!dt_iop_module_is(crea_module, "spots")
+               && !dt_iop_module_is(crea_module, "retouch"))))
     {
       if(crea_module)
       {

--- a/src/develop/masks/path.c
+++ b/src/develop/masks/path.c
@@ -1978,8 +1978,8 @@ static int _path_events_button_pressed(dt_iop_module_t *module,
         // and we switch in edit mode to show all the forms
         // spots and retouch have their own handling of creation_continuous
         if(gui->creation_continuous
-           && (dt_iop_module_is(crea_module->so, "spots")
-               || dt_iop_module_is(crea_module->so, "retouch")))
+           && (dt_iop_module_is(crea_module, "spots")
+               || dt_iop_module_is(crea_module, "retouch")))
           dt_masks_set_edit_mode_single_form(crea_module, form->formid, DT_MASKS_EDIT_FULL);
         else if(!gui->creation_continuous)
           dt_masks_set_edit_mode(crea_module, DT_MASKS_EDIT_FULL);
@@ -1993,8 +1993,8 @@ static int _path_events_button_pressed(dt_iop_module_t *module,
       {
         //spot and retouch manage creation_continuous in their own way
         if(crea_module
-           && !dt_iop_module_is(crea_module->so, "spots")
-           && !dt_iop_module_is(crea_module->so, "retouch"))
+           && !dt_iop_module_is(crea_module, "spots")
+           && !dt_iop_module_is(crea_module, "retouch"))
         {
           dt_iop_gui_blend_data_t *bd = crea_module->blend_data;
           for(int n = 0; n < DEVELOP_MASKS_NB_SHAPES; n++)

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -512,17 +512,17 @@ static void _dev_pixelpipe_synch(dt_dev_pixelpipe_t *pipe,
       // not appropriate for the image.  Fixing that seemed to be
       // almost impossible after long discussions but at least we can
       // test, correct and add a problem hint here.
-      if(dt_iop_module_is(piece->module->so, "demosaic")
-         || dt_iop_module_is(piece->module->so, "rawprepare"))
+      if(dt_iop_module_is(piece->module, "demosaic")
+         || dt_iop_module_is(piece->module, "rawprepare"))
       {
         if(rawprep_img && !active)
           piece->enabled = TRUE;
         else if(!rawprep_img && active)
           piece->enabled = FALSE;
       }
-      else if((dt_iop_module_is(piece->module->so, "rawdenoise"))
-              || (dt_iop_module_is(piece->module->so, "hotpixels"))
-              || (dt_iop_module_is(piece->module->so, "cacorrect")))
+      else if((dt_iop_module_is(piece->module, "rawdenoise"))
+              || (dt_iop_module_is(piece->module, "hotpixels"))
+              || (dt_iop_module_is(piece->module, "cacorrect")))
       {
         if(!rawprep_img && active) piece->enabled = FALSE;
       }
@@ -567,7 +567,7 @@ static void _dev_pixelpipe_synch(dt_dev_pixelpipe_t *pipe,
         for(GList *m = dev->module_filter_out; m; m = g_list_next(m))
         {
           char *mod = (char *)(m->data);
-          if(dt_iop_module_is(piece->module->so, mod))
+          if(dt_iop_module_is(piece->module, mod))
           {
             piece->enabled = FALSE;
             dt_print_pipe(DT_DEBUG_PARAMS | DT_DEBUG_PIPE,
@@ -2978,7 +2978,7 @@ void dt_dev_pixelpipe_disable_after(dt_dev_pixelpipe_t *pipe, const char *op)
 {
   GList *nodes = g_list_last(pipe->nodes);
   dt_dev_pixelpipe_iop_t *piece = nodes->data;
-  while(!dt_iop_module_is(piece->module->so, op))
+  while(!dt_iop_module_is(piece->module, op))
   {
     piece->enabled = FALSE;
     piece = NULL;
@@ -2992,7 +2992,7 @@ void dt_dev_pixelpipe_disable_before(dt_dev_pixelpipe_t *pipe, const char *op)
 {
   GList *nodes = pipe->nodes;
   dt_dev_pixelpipe_iop_t *piece = nodes->data;
-  while(!dt_iop_module_is(piece->module->so, op))
+  while(!dt_iop_module_is(piece->module, op))
   {
     piece->enabled = FALSE;
     piece = NULL;
@@ -3810,7 +3810,7 @@ int dt_dev_write_scharr_mask_cl(dt_dev_pixelpipe_iop_t *piece,
 // this expects a mask prepared by rawprepare or demosaic and distorts it
 // through all pipeline modules until target
 float *dt_dev_distort_detail_mask(dt_dev_pixelpipe_iop_t *piece,
-                                  float *src,
+                                  const float *src,
                                   const dt_iop_module_t *target_module,
                                   const dt_hash_t src_hash)
 {
@@ -3825,14 +3825,14 @@ float *dt_dev_distort_detail_mask(dt_dev_pixelpipe_iop_t *piece,
   {
     const dt_dev_pixelpipe_iop_t *candidate = iter->data;
 
-    if(dt_iop_module_is(candidate->module->so, "demosaic")
+    if(dt_iop_module_is(candidate->module, "demosaic")
        && candidate->enabled
        && raw_img)
     {
       source_iter = iter;
       break;
     }
-    if(dt_iop_module_is(candidate->module->so, "rawprepare")
+    if(dt_iop_module_is(candidate->module, "rawprepare")
        && candidate->enabled
        && !raw_img)
     {

--- a/src/develop/pixelpipe_hb.h
+++ b/src/develop/pixelpipe_hb.h
@@ -281,7 +281,7 @@ static inline gboolean dt_pipe_mask_display(const dt_dev_pixelpipe_t *pipe)
 }
 
 // report pipe->type as textual string
-const char *dt_dev_pixelpipe_type_to_str(dt_dev_pixelpipe_type_t pipe_type);
+const char *dt_dev_pixelpipe_type_to_str(const dt_dev_pixelpipe_type_t pipe_type);
 
 // inits the pixelpipe with plain passthrough input/output and empty input and default caching settings.
 gboolean dt_dev_pixelpipe_init(dt_dev_pixelpipe_t *pipe);
@@ -412,9 +412,9 @@ void dt_print_pipe_ext(const char *title,
 
 // helper function writing the pipe-processed ctmask data to dest
 float *dt_dev_distort_detail_mask(dt_dev_pixelpipe_iop_t *piece,
-                                  float *src,
+                                  const float *src,
                                   const struct dt_iop_module_t *target_module,
-                                  dt_hash_t src_hash);
+                                  const dt_hash_t src_hash);
 
 dt_hash_t dt_dev_pixelpipe_piece_hash(dt_dev_pixelpipe_iop_t *piece,
                                       const dt_iop_roi_t *roi,

--- a/src/gui/presets.c
+++ b/src/gui/presets.c
@@ -474,18 +474,16 @@ gboolean dt_gui_presets_confirm_and_delete(const char *name,
     // deregistering accel...
     for(GList *modules = darktable.iop; modules; modules = modules->next)
     {
-      dt_iop_module_so_t *mod = modules->data;
-
-      if(dt_iop_module_is(mod, module_name))
+      dt_iop_module_so_t *mod_so = modules->data;
+      if(dt_iop_module_so_is(mod_so, module_name))
       {
-        dt_action_rename_preset(&mod->actions, name, NULL);
+        dt_action_rename_preset(&mod_so->actions, name, NULL);
         break;
       }
     }
     for(GList *libs = darktable.lib->plugins; libs; libs = g_list_next(libs))
     {
       dt_lib_module_t *lib = libs->data;
-
       if(!strcmp(lib->plugin_name, module_name))
       {
         dt_action_rename_preset(&lib->actions, name, NULL);

--- a/src/imageio/imageio.c
+++ b/src/imageio/imageio.c
@@ -1263,7 +1263,7 @@ gboolean dt_imageio_export_with_flags(const dt_imgid_t imgid,
     for(GList *modules = dev.iop; modules; modules = g_list_next(modules))
     {
       colorout = (dt_iop_module_t *)modules->data;
-      if(colorout->get_p && strcmp(colorout->op, "colorout") == 0)
+      if(colorout->get_p && dt_iop_module_is(colorout, "colorout"))
       {
         const dt_colorspaces_color_profile_type_t *type =
           colorout->get_p(colorout->params, "type");

--- a/src/iop/overlay.c
+++ b/src/iop/overlay.c
@@ -208,17 +208,17 @@ static GList *_get_disabled_modules(const dt_iop_module_t *self,
     if((after
           && !dt_iop_module_is_gamma(mod)
           && !dt_iop_module_is_finalscale(mod)
-          && !dt_iop_module_is(mod->so, "crop")
-          && !dt_iop_module_is(mod->so, "ashift"))
+          && !dt_iop_module_is(mod, "crop")
+          && !dt_iop_module_is(mod, "ashift"))
     || (is_current
-         && ( dt_iop_module_is(mod->so, "overlay")
-           || dt_iop_module_is(mod->so, "enlargecanvas"))))
+         && ( dt_iop_module_is(mod, "overlay")
+           || dt_iop_module_is(mod, "enlargecanvas"))))
     {
       result = g_list_prepend(result, mod->op);
     }
 
     // look for ourself, disable all modules after this point
-    if(dt_iop_module_is(mod->so, self_module->op)
+    if(dt_iop_module_is(mod, self_module->op)
          && mod->multi_priority == multi_priority)
       after = TRUE;
   }

--- a/src/libs/masks.c
+++ b/src/libs/masks.c
@@ -1463,7 +1463,7 @@ gboolean _find_mask_iter_by_values(GtkTreeModel *model,
     _lib_masks_get_values(model, iter, &mod, NULL, &fid);
     gboolean found = (fid == formid)
       && ((level == 1)
-          || (module == NULL || (mod && dt_iop_module_is(module->so, mod->op))));
+          || (module == NULL || (mod && dt_iop_module_is(module, mod->op))));
     if(found) return found;
 
     GtkTreeIter child, parent = *iter;
@@ -1738,7 +1738,7 @@ static gboolean _lib_masks_selection_change_r(GtkTreeModel *model,
 
     if((id == selectid)
        && ((level == 1)
-           || (module == NULL || (mod && dt_iop_module_is(module->so, mod->op)))))
+           || (module == NULL || (mod && dt_iop_module_is(module, mod->op)))))
     {
       gtk_tree_selection_select_iter(selection, &i);
       found = TRUE;

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -1264,7 +1264,7 @@ static gboolean _dev_load_requested_image(gpointer user_data)
     for(const GList *l = dev->iop; l; l = g_list_next(l))
     {
       dt_iop_module_t *mod = l->data;
-      if(dt_iop_module_is(module->so, mod->op))
+      if(dt_iop_module_is(module, mod->op))
         base_multi_priority = MIN(base_multi_priority, mod->multi_priority);
     }
 
@@ -1372,7 +1372,7 @@ static gboolean _dev_load_requested_image(gpointer user_data)
     for(const GList *modules = dev->iop; modules; modules = g_list_next(modules))
     {
       dt_iop_module_t *module = modules->data;
-      if(dt_iop_module_is(module->so, active_plugin))
+      if(dt_iop_module_is(module, active_plugin))
       {
         valid = TRUE;
         dt_iop_request_focus(module);
@@ -2351,8 +2351,8 @@ static void _toggle_mask_visibility_callback(dt_action_t *action)
   //retouch and spot removal module use masks differently and have
   //different buttons associated keep the shortcuts independent
   if(mod
-     && !dt_iop_module_is(mod->so, "spots")
-     && !dt_iop_module_is(mod->so, "retouch"))
+     && !dt_iop_module_is(mod, "spots")
+     && !dt_iop_module_is(mod, "retouch"))
   {
     dt_iop_gui_blend_data_t *bd = mod->blend_data;
 
@@ -3546,7 +3546,7 @@ void enter(dt_view_t *self)
     for(const GList *modules = dev->iop; modules; modules = g_list_next(modules))
     {
       dt_iop_module_t *module = modules->data;
-      if(dt_iop_module_is(module->so, active_plugin))
+      if(dt_iop_module_is(module, active_plugin))
         dt_iop_request_focus(module);
     }
   }


### PR DESCRIPTION
In the vast majority of using `gboolean dt_iop_module_is(const dt_iop_module_so_t *module, const char* op)` we test for `module->so` so let us redefine it in a clear and shorter way:

 `gboolean dt_iop_module_is(const dt_iop_module_t *module, const char* op)`

For the few cases where we definitely test for the module->so->op (as we did before) we now have
`gboolean dt_iop_module_so_is(const dt_iop_module_so_t *module, const char* op)`

Some missed constify while checking this