### PR TITLE
[AI] Reset AI model min_version to 0.1 and drop NAFNet from defaults

### DIFF
--- a/data/ai_models.json
+++ b/data/ai_models.json
@@ -6,7 +6,7 @@
       "name": "mask sam2.1 hiera small",
       "description": "Segment Anything 2.1 (Hiera Small) for interactive masking",
       "task": "mask",
-      "min_version": "1.0",
+      "min_version": "0.1",
       "github_asset": "mask-object-sam21-small.dtmodel",
       "default": true
     },
@@ -15,7 +15,7 @@
       "name": "mask segnext vitb-sax2 hq",
       "description": "SegNext ViT-B SAx2 HQ fine-tuned for interactive masking",
       "task": "mask",
-      "min_version": "1.0",
+      "min_version": "0.1",
       "github_asset": "mask-object-segnext-b2hq.dtmodel",
       "default": false
     },
@@ -24,22 +24,16 @@
       "name": "denoise nind",
       "description": "UNet denoiser trained on NIND dataset",
       "task": "denoise",
+      "min_version": "0.1",
       "github_asset": "denoise-nind.dtmodel",
       "default": true
-    },
-    {
-      "id": "denoise-nafnet",
-      "name": "denoise nafnet small",
-      "description": "NAFNet denoiser trained on SIDD dataset",
-      "task": "denoise",
-      "github_asset": "denoise-nafnet.dtmodel",
-      "default": false
     },
     {
       "id": "rawdenoise-nind",
       "name": "raw denoise nind",
       "description": "UtNet2 raw denoiser trained on RawNIND dataset",
       "task": "rawdenoise",
+      "min_version": "0.1",
       "github_asset": "rawdenoise-nind.dtmodel",
       "default": true
     },
@@ -48,6 +42,7 @@
       "name": "upscale bsrgan",
       "description": "BSRGAN 2x and 4x blind super-resolution",
       "task": "upscale",
+      "min_version": "0.1",
       "github_asset": "upscale-bsrgan.dtmodel",
       "default": true
     }


### PR DESCRIPTION
Routine maintenance on `data/ai_models.json` ahead of the release cycle:

- Reset `min_version` to `0.1` across the registered models so the nightly model channel can be tested against nightly DT. The versions will be bumped back to `1.0` at release.
- Drop the `denoise-nafnet` entry. It wasn't a default, and it stays available for manual installation via AI preferences.