### PR TITLE
Prefault OpenCL readback destinations

### DIFF
--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -46,6 +46,9 @@
 #include <errno.h>
 #include <libgen.h>
 #include <sys/stat.h>
+#if !defined(_WIN32)
+#include <unistd.h>
+#endif
 #include <zlib.h>
 
 static const char *_opencl_get_vendor_by_id(unsigned int id);
@@ -70,6 +73,14 @@ static gboolean _opencl_build_program(const int dev,
 static char *_ascii_str_canonical(const char *in, char *out, int maxlen);
 
 static char *_strsep(char **stringp, const char *delim);
+
+static void _opencl_prefault_host_write_pages(const int devid, void *host, const size_t bytes);
+int dt_opencl_read_host_from_device_rowpitch(const int devid,
+                                             void *host,
+                                             void *device,
+                                             const int width,
+                                             const int height,
+                                             const int rowpitch);
 
 /** read scheduling profile for config variables */
 static dt_opencl_scheduling_profile_t _opencl_get_scheduling_profile(void);
@@ -2871,13 +2882,56 @@ int dt_opencl_copy_device_to_host(const int devid,
                                   const int height,
                                   const int bpp)
 {
+  if(host && width > 0 && height > 0 && bpp > 0)
+    _opencl_prefault_host_write_pages(devid, host, (size_t)width * height * bpp);
+
+  return dt_opencl_read_host_from_device_rowpitch(devid, host, device,
+                                                  width, height, bpp * width);
+}
+
+static void _opencl_prefault_host_write_pages(const int devid, void *host, const size_t bytes)
+{
+#if !defined(_WIN32)
+  if(!host || bytes == 0) return;
+  if(!_cldev_running(devid)) return;
+
+  dt_opencl_t *cl = darktable.opencl;
+  if(!cl->fastcl || !cl->dev[devid].unified_memory) return;
+
+  const long page_size = sysconf(_SC_PAGESIZE);
+  const size_t step = page_size > 0 ? (size_t)page_size : 4096;
+  if(bytes < step) return;
+
+  volatile unsigned char *p = (volatile unsigned char *)host;
+
+  // NVIDIA OpenCL on unified-memory systems can be extremely slow when a
+  // blocking read faults large cold host buffers from inside the driver.
+  // Touch the destination pages first so the driver sees committed memory.
+  for(size_t offset = 0; offset < bytes; offset += step)
+    p[offset] = p[offset];
+
+  p[bytes - 1] = p[bytes - 1];
+#else
+  (void)devid;
+  (void)host;
+  (void)bytes;
+#endif
+}
+
+int dt_opencl_read_host_from_device_rowpitch(const int devid,
+                                             void *host,
+                                             void *device,
+                                             const int width,
+                                             const int height,
+                                             const int rowpitch)
+{
   if(!_cldev_running(devid))
     return DT_OPENCL_NODEVICE;
 
   const size_t region[2] = { width, height };
   // blocking.
   return dt_opencl_read_host_from_device_raw(devid, host, device, CLIMG_ORIGIN,
-                                             region, (size_t)width * bpp, TRUE);
+                                             region, rowpitch, TRUE);
 }
 
 int dt_opencl_read_host_from_device_raw(const int devid,


### PR DESCRIPTION
I found that darktable was very slow on my NVIDIA DGX Spark with the GB10 super chip.

darktable's OpenCL path was working correctly, but export performance could be
much slower than CPU for mixed CPU/GPU pipelines. Profiling showed most of the
loss in `[Read Image (from device to host)]`.

The underlying issue was not raw host/GPU bandwidth. A standalone OpenCL test
showed `clEnqueueReadImage` is fast when the destination host memory is already
committed, but extremely slow when the destination is a large cold malloc buffer.
Pre-faulting destination pages before the blocking read avoids that NVIDIA
OpenCL slow path.

## Environment

```sh
nvidia-smi
clinfo
/opt/darktable/bin/darktable-cltest
```

Observed locally:

```text
GPU: NVIDIA GB10
Driver: 580.142
CUDA/OpenCL platform: NVIDIA CUDA, OpenCL 3.0 CUDA 13.0.97
darktable OpenCL: enabled
darktable OpenCL fast mode: enabled
darktable scheduling profile: very fast GPU
```

## darktable repro

The integration test image is small enough to keep repro time short, but the
`almost-all` history stack is useful because it forces several CPU/GPU
transitions.

```sh
tmp=$(mktemp -d /tmp/dt-opencl-repro.XXXXXX)

/usr/bin/time -f "REAL %e" \
  /opt/darktable/bin/darktable-cli \
  src/tests/integration/images/mire1.cr2 \
  src/tests/integration/0103-almost-all/almost-all.xmp \
  "$tmp/out" \
  --width 0 --height 0 --hq true \
  --apply-custom-presets false \
  --out-ext jpg \
  --core \
  -d opencl -d perf \
  >"$tmp/gpu.log" 2>&1

rg 'Read Image|totally in command queue|pixel pipeline processing took|exported' "$tmp/gpu.log"
```

Before the patch, representative results were:

```text
real time: ~16.8s
pixel pipeline: ~15.3s
[Read Image (from device to host)]: ~8.0s
OpenCL command queue total: ~10.7s
```

After the patch:

```text
real time: ~9.7-9.9s
pixel pipeline: ~8.2-8.5s
[Read Image (from device to host)]: ~0.032s
OpenCL command queue total: ~2.7-2.8s
```

CPU-only comparison after the patch:

```sh
/usr/bin/time -f "REAL %e" \
  /opt/darktable/bin/darktable-cli \
  src/tests/integration/images/mire1.cr2 \
  src/tests/integration/0103-almost-all/almost-all.xmp \
  "$tmp/cpu-out" \
  --width 0 --height 0 --hq true \
  --apply-custom-presets false \
  --out-ext jpg \
  --core --disable-opencl \
  -d perf
```

Representative CPU-only result:

```text
real time: ~9.8-10.2s
pixel pipeline: ~8.7-9.1s
```

## Standalone OpenCL repro

This isolates the driver behavior from darktable. A readback into warm host
memory is fast. A readback into a cold host allocation is extremely slow.
Touching the destination pages first fixes it.

```c
#define CL_TARGET_OPENCL_VERSION 300
#include <CL/cl.h>
#include <stdio.h>
#include <stdlib.h>
#include <string.h>
#include <time.h>

static double now_sec(void)
{
  struct timespec ts;
  clock_gettime(CLOCK_MONOTONIC, &ts);
  return ts.tv_sec + ts.tv_nsec * 1e-9;
}

static void check(cl_int err, const char *what)
{
  if(err != CL_SUCCESS)
  {
    fprintf(stderr, "%s failed: %d\n", what, err);
    exit(1);
  }
}

int main(void)
{
  const size_t w = 3888, h = 2592;
  const size_t bytes = w * h * 4 * sizeof(float);
  cl_int err;
  cl_platform_id platform;
  cl_device_id device;
  check(clGetPlatformIDs(1, &platform, NULL), "clGetPlatformIDs");
  check(clGetDeviceIDs(platform, CL_DEVICE_TYPE_GPU, 1, &device, NULL), "clGetDeviceIDs");

  cl_context ctx = clCreateContext(NULL, 1, &device, NULL, NULL, &err);
  check(err, "clCreateContext");
  cl_command_queue q = clCreateCommandQueueWithProperties(ctx, device, 0, &err);
  check(err, "clCreateCommandQueueWithProperties");

  cl_image_format fmt = { CL_RGBA, CL_FLOAT };
  cl_image_desc desc;
  memset(&desc, 0, sizeof(desc));
  desc.image_type = CL_MEM_OBJECT_IMAGE2D;
  desc.image_width = w;
  desc.image_height = h;
  cl_mem img = clCreateImage(ctx, CL_MEM_READ_WRITE, &fmt, &desc, NULL, &err);
  check(err, "clCreateImage");

  void *host = aligned_alloc(64, bytes);
  void *coldhost = aligned_alloc(64, bytes);
  void *pretouched = aligned_alloc(64, bytes);
  if(!host || !coldhost || !pretouched) return 2;
  memset(host, 0, bytes);

  const size_t origin[3] = { 0, 0, 0 };
  const size_t region[3] = { w, h, 1 };
  const size_t rowpitch = w * 4 * sizeof(float);
  check(clEnqueueWriteImage(q, img, CL_TRUE, origin, region, rowpitch, 0, host, 0, NULL, NULL),
        "warm write image");

  double warm_total = 0.0;
  for(int i = 0; i < 8; i++)
  {
    double t0 = now_sec();
    check(clEnqueueReadImage(q, img, CL_TRUE, origin, region, rowpitch, 0, host, 0, NULL, NULL),
          "warm read image");
    warm_total += now_sec() - t0;
  }

  double t0 = now_sec();
  check(clEnqueueReadImage(q, img, CL_TRUE, origin, region, rowpitch, 0, coldhost, 0, NULL, NULL),
        "cold read image");
  double cold = now_sec() - t0;

  t0 = now_sec();
  memset(pretouched, 0, bytes);
  double touch = now_sec() - t0;
  t0 = now_sec();
  check(clEnqueueReadImage(q, img, CL_TRUE, origin, region, rowpitch, 0, pretouched, 0, NULL, NULL),
        "pretouched read image");
  double pretouched_read = now_sec() - t0;

  printf("size %.1f MiB\n", bytes / 1048576.0);
  printf("warm read avg %.6f sec\n", warm_total / 8.0);
  printf("cold read %.6f sec\n", cold);
  printf("pretouch %.6f sec, read %.6f sec, total %.6f sec\n",
         touch, pretouched_read, touch + pretouched_read);

  clReleaseMemObject(img);
  clReleaseCommandQueue(q);
  clReleaseContext(ctx);
  free(host);
  free(coldhost);
  free(pretouched);
  return 0;
}
```

Compile and run:

```sh
cc -O2 /tmp/ocl_read_image_bench.c -lOpenCL -o /tmp/ocl_read_image_bench
/tmp/ocl_read_image_bench
```

Representative result:

```text
size 153.8 MiB
warm read avg 0.004426 sec
cold read 2.317996 sec
pretouch 0.053719 sec, read 0.003950 sec, total 0.057669 sec
```

## Code change

The patch pre-faults destination pages in `dt_opencl_copy_device_to_host()`
before calling the existing blocking image readback path.

This is intentionally done in the common full-image copy helper because that is
the path used when the pixelpipe must move an OpenCL image back to CPU memory
before a CPU-only module or cache use.

## Regression considerations

Likely downside:

- Every full-image device-to-host copy now performs one host write per page
  before the OpenCL read.
- On platforms where the driver already handles cold pageable memory well, this
  adds a small CPU-side page-touch cost.
- For buffers that are already resident, this is redundant work.

Why the risk is limited:

- The touched memory is the destination of a blocking device-to-host read and is
  expected to be writable.
- The read overwrites the destination immediately afterward on success.
- The overhead is one byte per page, not a full memset of the image.
- For cold buffers on this NVIDIA unified-memory system, the added pre-touch is
  orders of magnitude cheaper than letting the OpenCL driver fault the pages.
- CPU-only processing is unaffected.

Potential follow-up refinements:

- Apply the pre-fault only above a size threshold.
- Make it conditional on NVIDIA/OpenCL/unified-memory devices if other vendors
  show measurable regressions.
- Consider pre-faulting cache allocations at allocation time instead of at
  OpenCL readback time.
