### PR TITLE
[AI] Fix stale per-EP compile-cache after model delete/redownload

### DIFF
--- a/src/ai/backend.h
+++ b/src/ai/backend.h
@@ -441,3 +441,23 @@ int dt_ai_get_output_shape(dt_ai_context_t *ctx, int index,
  * @param ctx The AI context to unload.
  */
 void dt_ai_unload_model(dt_ai_context_t *ctx);
+
+// compile-cache layout: <user_cache>/ai_v<SCHEMA>_<ep>_<fingerprint>/<model_id>/
+// bump SCHEMA when the layout changes incompatibly; old caches are skipped.
+#define DT_AI_CACHE_SCHEMA 1
+
+// build the compile-cache directory for (provider, fingerprint, model_id)
+// and mkdir -p it. pass model_id = "_shared" for caches without per-model
+// granularity. returns TRUE on success, FALSE on path overflow or mkdir failure.
+gboolean dt_ai_backend_cache_dir(dt_ai_provider_t provider,
+                                 const char *fingerprint,
+                                 const char *model_id,
+                                 char *out, size_t size);
+
+// remove every compile-cache subdir matching model_id across all providers
+// and schemas. called after a model is deleted or replaced.
+void dt_ai_backend_cache_invalidate(const char *model_id);
+
+// remove the entire compile-cache tree. exposed for a future user action;
+// not used internally.
+void dt_ai_backend_cache_invalidate_all(void);

--- a/src/ai/backend_common.c
+++ b/src/ai/backend_common.c
@@ -18,9 +18,12 @@
 
 #include "backend.h"
 #include "common/darktable.h"
+#include "common/file_location.h"
 #include "control/conf.h"
 #include <glib.h>
+#include <glib/gstdio.h>
 #include <json-glib/json-glib.h>
+#include <limits.h>
 #include <string.h>
 
 // provider table
@@ -868,6 +871,125 @@ guint dt_ai_providers_bundled(void)
   mask |= 1u << DT_AI_PROVIDER_DIRECTML;
 #endif
   return mask;
+}
+
+// compile-cache helpers
+
+static const char *_ep_name(dt_ai_provider_t provider)
+{
+  switch(provider)
+  {
+    case DT_AI_PROVIDER_COREML:    return "coreml";
+    case DT_AI_PROVIDER_CUDA:      return "cuda";
+    case DT_AI_PROVIDER_MIGRAPHX:  return "migraphx";
+    case DT_AI_PROVIDER_OPENVINO:  return "openvino";
+    case DT_AI_PROVIDER_DIRECTML:  return "directml";
+    default:                       return NULL;
+  }
+}
+
+static void _cache_rmdir_recursive(const char *path)
+{
+  GDir *dir = g_dir_open(path, 0, NULL);
+  if(!dir) return;
+
+  const gchar *name;
+  while((name = g_dir_read_name(dir)))
+  {
+    gchar *child = g_build_filename(path, name, NULL);
+    if(g_file_test(child, G_FILE_TEST_IS_DIR))
+      _cache_rmdir_recursive(child);
+    else
+      g_unlink(child);
+    g_free(child);
+  }
+  g_dir_close(dir);
+  g_rmdir(path);
+}
+
+gboolean dt_ai_backend_cache_dir(dt_ai_provider_t provider,
+                                 const char *fingerprint,
+                                 const char *model_id,
+                                 char *out, size_t size)
+{
+  if(!out || size == 0) return FALSE;
+  const char *ep = _ep_name(provider);
+  if(!ep || !fingerprint || !model_id || !model_id[0]) return FALSE;
+
+  char cachedir[PATH_MAX] = { 0 };
+  dt_loc_get_user_cache_dir(cachedir, sizeof(cachedir));
+
+  gchar *subdir = g_strdup_printf("ai_v%d_%s_%s",
+                                  DT_AI_CACHE_SCHEMA, ep, fingerprint);
+  gchar *full = g_build_filename(cachedir, subdir, model_id, NULL);
+  g_free(subdir);
+
+  const size_t len = strlen(full);
+  if(len + 1 > size)
+  {
+    g_free(full);
+    return FALSE;
+  }
+  if(g_mkdir_with_parents(full, 0700) == -1)
+  {
+    dt_print(DT_DEBUG_AI,
+             "[ai_cache] failed to create cache directory: %s", full);
+    g_free(full);
+    return FALSE;
+  }
+  memcpy(out, full, len + 1);
+  g_free(full);
+  return TRUE;
+}
+
+void dt_ai_backend_cache_invalidate(const char *model_id)
+{
+  if(!model_id || !model_id[0]) return;
+
+  char cachedir[PATH_MAX] = { 0 };
+  dt_loc_get_user_cache_dir(cachedir, sizeof(cachedir));
+
+  GDir *dir = g_dir_open(cachedir, 0, NULL);
+  if(!dir) return;
+
+  // match every "ai_v<N>_<ep>_<fingerprint>" sibling and walk into
+  // <model_id>, catching old schemas/EPs too
+  const gchar *name;
+  while((name = g_dir_read_name(dir)))
+  {
+    if(!g_str_has_prefix(name, "ai_v")) continue;
+    gchar *model_subdir = g_build_filename(cachedir, name, model_id, NULL);
+    if(g_file_test(model_subdir, G_FILE_TEST_IS_DIR))
+    {
+      dt_print(DT_DEBUG_AI, "[ai_cache] invalidating %s", model_subdir);
+      _cache_rmdir_recursive(model_subdir);
+    }
+    g_free(model_subdir);
+  }
+  g_dir_close(dir);
+}
+
+void dt_ai_backend_cache_invalidate_all(void)
+{
+  char cachedir[PATH_MAX] = { 0 };
+  dt_loc_get_user_cache_dir(cachedir, sizeof(cachedir));
+
+  GDir *dir = g_dir_open(cachedir, 0, NULL);
+  if(!dir) return;
+
+  const gchar *name;
+  while((name = g_dir_read_name(dir)))
+  {
+    if(!g_str_has_prefix(name, "ai_v")) continue;
+    gchar *full = g_build_filename(cachedir, name, NULL);
+    if(g_file_test(full, G_FILE_TEST_IS_DIR))
+    {
+      dt_print(DT_DEBUG_AI, "[ai_cache] invalidating %s", full);
+      _cache_rmdir_recursive(full);
+    }
+    g_free(full);
+  }
+  g_dir_close(dir);
 }
 
 // clang-format off

--- a/src/ai/backend_onnx.c
+++ b/src/ai/backend_onnx.c
@@ -85,7 +85,15 @@ static int g_loaded_dml_device_id      = -1;
 // snapshot of the provider config string at ORT load. NULL until captured
 static gchar *g_loaded_provider = NULL;
 
+// loaded ORT version string, used in the cache fingerprint to
+// invalidate stale compiled artifacts after an ORT upgrade
+static gchar *g_ort_version = NULL;
+
 static int _device_id_from_conf(const char *conf_key, const char *env_var);
+static gchar *_lookup_device_name(const dt_ai_provider_t provider,
+                                  const int device_id);
+static gchar *_backend_cache_fingerprint(dt_ai_provider_t provider,
+                                         int device_id);
 
 #if defined(__linux__)
 // check that the CUDA driver supports the installed CUDA runtime version;
@@ -769,6 +777,8 @@ static const OrtApi *_ort_api_from_module(GModule *mod, const char *label)
   }
   const OrtApiBase *base = get_api_base();
   const char *lib_version = base->GetVersionString();
+  g_free(g_ort_version);
+  g_ort_version = g_strdup(lib_version ? lib_version : "unknown");
   dt_print(DT_DEBUG_AI, "[darktable_ai] loaded ORT %s from '%s'", lib_version, label);
 
   // try the compiled API version first, then fall back to lower versions
@@ -882,8 +892,10 @@ static gpointer _init_ort_api(gpointer data)
   {
     // Windows/macOS: use the directly linked ORT library (DirectML/CoreML).
     const OrtApiBase *base = OrtGetApiBase();
-    dt_print(DT_DEBUG_AI, "[darktable_ai] loaded ORT %s (bundled)",
-             base->GetVersionString());
+    const char *bundled_version = base->GetVersionString();
+    g_free(g_ort_version);
+    g_ort_version = g_strdup(bundled_version ? bundled_version : "unknown");
+    dt_print(DT_DEBUG_AI, "[darktable_ai] loaded ORT %s (bundled)", bundled_version);
     api = base->GetApi(ORT_API_VERSION);
   }
 #endif
@@ -947,22 +959,32 @@ static void _setup_amd_caches(void)
   if(!_ort_has_provider("MIGraphXExecutionProvider"))
     return;
 
-  char cachedir[PATH_MAX] = { 0 };
-  dt_loc_get_user_cache_dir(cachedir, sizeof(cachedir));
+  const int dev = _device_id_from_conf("plugins/ai/migraphx_device_id",
+                                       "DT_MIGRAPHX_DEVICE_ID");
+  gchar *fp = _backend_cache_fingerprint(DT_AI_PROVIDER_MIGRAPHX, dev);
 
-  gchar *miopen_dir = g_build_filename(cachedir, "ai", "amd", "miopen", NULL);
-  g_mkdir_with_parents(miopen_dir, 0700);
-  g_setenv("MIOPEN_USER_DB_PATH", miopen_dir, FALSE);
-  g_setenv("MIOPEN_CUSTOM_CACHE_DIR", miopen_dir, FALSE);
-  dt_print(DT_DEBUG_AI, "[darktable_ai] MIOpen cache: %s", miopen_dir);
-  g_free(miopen_dir);
+  // two independent sub-caches (MIOpen kernel DB + MIGraphX engine
+  // cache). reserved model-id names "_miopen" / "_migraphx" give each
+  // its own subdir; invalidate-by-model never matches these because
+  // real model_ids don't start with underscore
+  char miopen_dir[PATH_MAX] = { 0 };
+  if(dt_ai_backend_cache_dir(DT_AI_PROVIDER_MIGRAPHX, fp,
+                             "_miopen", miopen_dir, sizeof(miopen_dir)))
+  {
+    g_setenv("MIOPEN_USER_DB_PATH", miopen_dir, FALSE);
+    g_setenv("MIOPEN_CUSTOM_CACHE_DIR", miopen_dir, FALSE);
+    dt_print(DT_DEBUG_AI, "[darktable_ai] MIOpen cache: %s", miopen_dir);
+  }
 
-  gchar *migraphx_dir = g_build_filename(cachedir, "ai", "amd", "migraphx", NULL);
-  g_mkdir_with_parents(migraphx_dir, 0700);
-  g_setenv("ORT_MIGRAPHX_CACHE_PATH", migraphx_dir, FALSE);
-  g_setenv("ORT_MIGRAPHX_MODEL_CACHE_PATH", migraphx_dir, FALSE);
-  dt_print(DT_DEBUG_AI, "[darktable_ai] MIGraphX cache: %s", migraphx_dir);
-  g_free(migraphx_dir);
+  char migraphx_dir[PATH_MAX] = { 0 };
+  if(dt_ai_backend_cache_dir(DT_AI_PROVIDER_MIGRAPHX, fp,
+                             "_migraphx", migraphx_dir, sizeof(migraphx_dir)))
+  {
+    g_setenv("ORT_MIGRAPHX_CACHE_PATH", migraphx_dir, FALSE);
+    g_setenv("ORT_MIGRAPHX_MODEL_CACHE_PATH", migraphx_dir, FALSE);
+    dt_print(DT_DEBUG_AI, "[darktable_ai] MIGraphX cache: %s", migraphx_dir);
+  }
+  g_free(fp);
 }
 #endif
 
@@ -978,10 +1000,13 @@ static gboolean _try_openvino_with_cache(OrtSessionOptions *session_opts)
      || !g_ort->SessionOptionsAppendExecutionProvider_OpenVINO_V2)
     return FALSE;
 
-  char cachedir[PATH_MAX] = { 0 };
-  dt_loc_get_user_cache_dir(cachedir, sizeof(cachedir));
-  gchar *ov_dir = g_build_filename(cachedir, "ai", "intel", "openvino", NULL);
-  g_mkdir_with_parents(ov_dir, 0700);
+  // process-global (no per-model id at session-creation time)
+  gchar *fp = _backend_cache_fingerprint(DT_AI_PROVIDER_OPENVINO, -1);
+  char ov_dir[PATH_MAX] = { 0 };
+  const gboolean ok = dt_ai_backend_cache_dir(
+    DT_AI_PROVIDER_OPENVINO, fp, "_shared", ov_dir, sizeof(ov_dir));
+  g_free(fp);
+  if(!ok) return FALSE;
 
   dt_print(DT_DEBUG_AI,
            "[darktable_ai] attempting Intel OpenVINO (cache: %s)...", ov_dir);
@@ -997,11 +1022,9 @@ static gboolean _try_openvino_with_cache(OrtSessionOptions *session_opts)
              "[darktable_ai] OpenVINO (with cache) failed: %s",
              g_ort->GetErrorMessage(status));
     g_ort->ReleaseStatus(status);
-    g_free(ov_dir);
     return FALSE;
   }
   dt_print(DT_DEBUG_AI, "[darktable_ai] Intel OpenVINO enabled with disk cache.");
-  g_free(ov_dir);
   return TRUE;
 }
 
@@ -1219,6 +1242,77 @@ static gchar *_lookup_device_name(const dt_ai_provider_t provider,
   }
   g_list_free_full(devices, dt_ai_device_free);
   return name;
+}
+
+// strip non-alphanumeric chars in place so the result is safe to embed
+// in a directory name
+static void _alnum_inplace(char *s)
+{
+  if(!s) return;
+  char *r = s, *w = s;
+  while(*r)
+  {
+    if(g_ascii_isalnum(*r)) *w++ = *r;
+    r++;
+  }
+  *w = '\0';
+}
+
+// hardware fingerprint for the per-EP cache subdir. for device-aware
+// EPs (CUDA/DirectML/MIGraphX) the fingerprint is the alphanumeric
+// device name so different GPUs get different cache slots.
+// driver-version is left out for now; bump DT_AI_CACHE_SCHEMA if the
+// compiled-artifact format ever changes incompatibly
+static gchar *_backend_cache_fingerprint(dt_ai_provider_t provider,
+                                         int device_id)
+{
+  gchar *base = NULL;
+  switch(provider)
+  {
+    case DT_AI_PROVIDER_COREML:
+#if defined(__aarch64__) || defined(__arm64__)
+      base = g_strdup("arm64");
+#elif defined(__x86_64__) || defined(_M_X64)
+      base = g_strdup("x86_64");
+#else
+      base = g_strdup("default");
+#endif
+      break;
+
+    case DT_AI_PROVIDER_OPENVINO:
+      // OpenVINO uses device_type="AUTO" everywhere we call it; no
+      // per-device id concept at the session level
+      base = g_strdup("auto");
+      break;
+
+    case DT_AI_PROVIDER_CUDA:
+    case DT_AI_PROVIDER_DIRECTML:
+    case DT_AI_PROVIDER_MIGRAPHX:
+    {
+      gchar *name = _lookup_device_name(provider, device_id);
+      if(name) _alnum_inplace(name);
+      if(name && name[0])
+        base = name;  // ownership transfers to base
+      else
+      {
+        g_free(name);
+        base = g_strdup("default");
+      }
+      break;
+    }
+
+    default:
+      base = g_strdup("default");
+      break;
+  }
+
+  // suffix ORT version so an upgrade invalidates stale artifacts
+  gchar *ort = g_ort_version ? g_strdup(g_ort_version) : g_strdup("ortunknown");
+  _alnum_inplace(ort);
+  gchar *full = g_strdup_printf("%s_ort%s", base, ort);
+  g_free(base);
+  g_free(ort);
+  return full;
 }
 
 // try to find and call an ORT execution provider function at runtime via

--- a/src/common/ai_models.c
+++ b/src/common/ai_models.c
@@ -1535,6 +1535,10 @@ char *dt_ai_models_download_sync(dt_ai_registry_t *registry,
   g_unlink(download_path);
   g_free(download_path);
 
+  // invalidate before flipping status so the next session sees a fresh
+  // compile, not a stale artifact from the previous model file
+  dt_ai_backend_cache_invalidate(model_id);
+
   // mark success
   g_mutex_lock(&registry->lock);
   dt_ai_model_t *m = _find_model_unlocked(registry, model_id);
@@ -1680,6 +1684,8 @@ gboolean dt_ai_models_delete(dt_ai_registry_t *registry, const char *model_id)
   char *model_dir = g_build_filename(registry->models_dir, model_id, NULL);
   _rmdir_recursive(model_dir);
   g_free(model_dir);
+
+  dt_ai_backend_cache_invalidate(model_id);
 
   char *task_copy = NULL;
   g_mutex_lock(&registry->lock);


### PR DESCRIPTION
When an AI model is deleted, redownloaded, or when ORT is upgraded, the compiled artifacts some EPs write to `~/.cache/darktable/` can go stale relative to the new bytes or new ORT version. The result is hard-to-diagnose breakage – wrong outputs, silent CPU fallbacks, or first-inference crashes.

This adds a small cache-layout helper and the invalidation hooks the EPs were missing.