### PR TITLE
[AI] Wire CoreML into the persistent compile cache

### DIFF
--- a/data/ai_models.json
+++ b/data/ai_models.json
@@ -24,7 +24,7 @@
       "name": "denoise nind",
       "description": "UNet denoiser trained on NIND dataset",
       "task": "denoise",
-      "min_version": "0.1",
+      "min_version": "0.2",
       "github_asset": "denoise-nind.dtmodel",
       "default": true
     },
@@ -33,7 +33,7 @@
       "name": "raw denoise nind",
       "description": "UtNet2 raw denoiser trained on RawNIND dataset",
       "task": "rawdenoise",
-      "min_version": "0.1",
+      "min_version": "0.2",
       "github_asset": "rawdenoise-nind.dtmodel",
       "default": true
     },

--- a/src/ai/backend.h
+++ b/src/ai/backend.h
@@ -188,6 +188,9 @@ typedef struct dt_ai_model_info_t {
                            ///< Consumed internally by the load function to
                            ///< override the provider when the model declares
                            ///< the configured EP unsafe.
+  const char *coreml_format; ///< CoreML model format (JSON: string or
+                             ///< stem-keyed object). "neuralnetwork"
+                             ///< (default) or "mlprogram".
 } dt_ai_model_info_t;
 
 /* --- Model "attributes" lookup ---

--- a/src/ai/backend.h
+++ b/src/ai/backend.h
@@ -441,3 +441,23 @@ int dt_ai_get_output_shape(dt_ai_context_t *ctx, int index,
  * @param ctx The AI context to unload.
  */
 void dt_ai_unload_model(dt_ai_context_t *ctx);
+
+// compile-cache layout: <user_cache>/ai_v<SCHEMA>_<ep>_<fingerprint>/<model_id>/
+// bump SCHEMA when the layout changes incompatibly; old caches are skipped.
+#define DT_AI_CACHE_SCHEMA 1
+
+// build the compile-cache directory for (provider, fingerprint, model_id)
+// and mkdir -p it. pass model_id = "_shared" for caches without per-model
+// granularity. returns TRUE on success, FALSE on path overflow or mkdir failure.
+gboolean dt_ai_backend_cache_dir(dt_ai_provider_t provider,
+                                 const char *fingerprint,
+                                 const char *model_id,
+                                 char *out, size_t size);
+
+// remove every compile-cache subdir matching model_id across all providers
+// and schemas. called after a model is deleted or replaced.
+void dt_ai_backend_cache_invalidate(const char *model_id);
+
+// remove the entire compile-cache tree. exposed for a future user action;
+// not used internally.
+void dt_ai_backend_cache_invalidate_all(void);

--- a/src/ai/backend_common.c
+++ b/src/ai/backend_common.c
@@ -199,6 +199,29 @@ static void _scan_directory(dt_ai_environment_t *env, const char *root_path)
                 }
               }
 
+              // capture top-level "coreml_format" (string or
+              // stem-keyed object) as a JSON string
+              info->coreml_format = NULL;
+              if(json_object_has_member(obj, "coreml_format"))
+              {
+                JsonNode *cf_node
+                  = json_object_get_member(obj, "coreml_format");
+                if(cf_node
+                   && (JSON_NODE_HOLDS_VALUE(cf_node)
+                       || JSON_NODE_HOLDS_OBJECT(cf_node)))
+                {
+                  JsonGenerator *gen = json_generator_new();
+                  json_generator_set_root(gen, cf_node);
+                  gchar *s = json_generator_to_data(gen, NULL);
+                  if(s)
+                  {
+                    _store_string(env, s, &info->coreml_format);
+                    g_free(s);
+                  }
+                  g_object_unref(gen);
+                }
+              }
+
               env->models = g_list_prepend(env->models, info);
               g_hash_table_insert(
                 env->model_paths,
@@ -686,6 +709,49 @@ static gboolean _provider_cpu_only(const dt_ai_model_info_t *info,
   return result;
 }
 
+// TRUE if the manifest opts in to MLProgram via "mlprogram" — flat
+// string or stem-keyed object, same shape as cpu_only. unknown values
+// and missing blocks default to NeuralNetwork (Apple's historical
+// CoreML default, lowest-surprise for untested models)
+static gboolean _coreml_use_mlprogram(const dt_ai_model_info_t *info,
+                                      const char *model_file)
+{
+  if(!info || !info->coreml_format) return FALSE;
+
+  JsonParser *parser = json_parser_new();
+  gboolean use_mlprogram = FALSE;
+  if(json_parser_load_from_data(parser, info->coreml_format, -1, NULL))
+  {
+    JsonNode *root = json_parser_get_root(parser);
+    const char *value = NULL;
+    gchar *stem = NULL;
+
+    if(root && JSON_NODE_HOLDS_VALUE(root))
+    {
+      value = json_node_get_string(root);
+    }
+    else if(root && JSON_NODE_HOLDS_OBJECT(root) && model_file)
+    {
+      const char *dot = strrchr(model_file, '.');
+      stem = dot ? g_strndup(model_file, dot - model_file)
+                 : g_strdup(model_file);
+      JsonObject *obj = json_node_get_object(root);
+      if(json_object_has_member(obj, stem))
+      {
+        JsonNode *vn = json_object_get_member(obj, stem);
+        if(vn && JSON_NODE_HOLDS_VALUE(vn))
+          value = json_node_get_string(vn);
+      }
+    }
+
+    if(value && !g_ascii_strcasecmp(value, "mlprogram"))
+      use_mlprogram = TRUE;
+    g_free(stem);
+  }
+  g_object_unref(parser);
+  return use_mlprogram;
+}
+
 // platform-specific candidate order for AUTO. each candidate is tried
 // via dt_ai_probe_provider() and the model's cpu_only list — the first
 // available, non-banned EP wins. CoreML's cpu_only entry does not skip
@@ -751,6 +817,7 @@ static dt_ai_provider_t _resolve_provider(dt_ai_provider_t configured,
   if(configured == DT_AI_PROVIDER_CPU) return DT_AI_PROVIDER_CPU;
 
   const char *id = model_id ? model_id : "?";
+  dt_ai_provider_t result = DT_AI_PROVIDER_CPU;
 
   if(configured == DT_AI_PROVIDER_AUTO)
   {
@@ -760,7 +827,8 @@ static dt_ai_provider_t _resolve_provider(dt_ai_provider_t configured,
     // bundled ORT always supports the platform EP, and if it doesn't,
     // the load fallback chain in dt_ai_onnx_load_ext demotes to CPU
     const gboolean skip_probe = (n == 1);
-    for(int i = 0; i < n; i++)
+    gboolean resolved = FALSE;
+    for(int i = 0; i < n && !resolved; i++)
     {
       const dt_ai_provider_t c = cands[i];
       if(!skip_probe && !dt_ai_probe_provider(c)) continue;
@@ -770,28 +838,32 @@ static dt_ai_provider_t _resolve_provider(dt_ai_provider_t configured,
         dt_print(DT_DEBUG_AI,
                  "[darktable_ai] provider auto -> %s for %s",
                  _provider_config_name(c), id);
-        return c;
+        result = c;
+        resolved = TRUE;
       }
-      if(c == DT_AI_PROVIDER_COREML)
+      else if(c == DT_AI_PROVIDER_COREML)
       {
         *inout_ep_flags |= 1;  // COREML_FLAG_USE_CPU_ONLY
         dt_print(DT_DEBUG_AI,
                  "[darktable_ai] provider auto -> %s (cpu compute units) "
                  "for %s — model prefers CPU on %s",
                  _provider_config_name(c), id, _provider_config_name(c));
-        return c;
+        result = c;
+        resolved = TRUE;
       }
-      dt_print(DT_DEBUG_AI,
-               "[darktable_ai] auto: skipping %s for %s — model prefers CPU",
-               _provider_config_name(c), id);
+      else
+      {
+        dt_print(DT_DEBUG_AI,
+                 "[darktable_ai] auto: skipping %s for %s — model prefers CPU",
+                 _provider_config_name(c), id);
+      }
     }
-    dt_print(DT_DEBUG_AI, "[darktable_ai] provider auto -> CPU for %s", id);
-    return DT_AI_PROVIDER_CPU;
+    if(!resolved)
+      dt_print(DT_DEBUG_AI, "[darktable_ai] provider auto -> CPU for %s", id);
   }
-
-  // concrete EP explicitly chosen
-  if(_provider_cpu_only(info, model_file, configured))
+  else if(_provider_cpu_only(info, model_file, configured))
   {
+    // concrete EP banned by cpu_only
     if(configured == DT_AI_PROVIDER_COREML)
     {
       *inout_ep_flags |= 1;  // COREML_FLAG_USE_CPU_ONLY
@@ -799,15 +871,25 @@ static dt_ai_provider_t _resolve_provider(dt_ai_provider_t configured,
                "[darktable_ai] %s prefers CPU on %s — using CoreML CPU "
                "compute units",
                id, _provider_config_name(configured));
-      return configured;
+      result = configured;
     }
-    dt_print(DT_DEBUG_AI,
-             "[darktable_ai] %s prefers CPU on %s — switching to CPU provider",
-             id, _provider_config_name(configured));
-    return DT_AI_PROVIDER_CPU;
+    else
+    {
+      dt_print(DT_DEBUG_AI,
+               "[darktable_ai] %s prefers CPU on %s — switching to CPU provider",
+               id, _provider_config_name(configured));
+    }
+  }
+  else
+  {
+    result = configured;
   }
 
-  return configured;
+  if(result == DT_AI_PROVIDER_COREML
+     && _coreml_use_mlprogram(info, model_file))
+    *inout_ep_flags |= 16;  // COREML_FLAG_CREATE_MLPROGRAM
+
+  return result;
 }
 
 // provider string conversion

--- a/src/ai/backend_common.c
+++ b/src/ai/backend_common.c
@@ -18,9 +18,12 @@
 
 #include "backend.h"
 #include "common/darktable.h"
+#include "common/file_location.h"
 #include "control/conf.h"
 #include <glib.h>
+#include <glib/gstdio.h>
 #include <json-glib/json-glib.h>
+#include <limits.h>
 #include <string.h>
 
 // provider table
@@ -868,6 +871,125 @@ guint dt_ai_providers_bundled(void)
   mask |= 1u << DT_AI_PROVIDER_DIRECTML;
 #endif
   return mask;
+}
+
+// compile-cache helpers
+
+static const char *_ep_name(dt_ai_provider_t provider)
+{
+  switch(provider)
+  {
+    case DT_AI_PROVIDER_COREML:    return "coreml";
+    case DT_AI_PROVIDER_CUDA:      return "cuda";
+    case DT_AI_PROVIDER_MIGRAPHX:  return "migraphx";
+    case DT_AI_PROVIDER_OPENVINO:  return "openvino";
+    case DT_AI_PROVIDER_DIRECTML:  return "directml";
+    default:                       return NULL;
+  }
+}
+
+static void _cache_rmdir_recursive(const char *path)
+{
+  GDir *dir = g_dir_open(path, 0, NULL);
+  if(!dir) return;
+
+  const gchar *name;
+  while((name = g_dir_read_name(dir)))
+  {
+    gchar *child = g_build_filename(path, name, NULL);
+    if(g_file_test(child, G_FILE_TEST_IS_DIR))
+      _cache_rmdir_recursive(child);
+    else
+      g_unlink(child);
+    g_free(child);
+  }
+  g_dir_close(dir);
+  g_rmdir(path);
+}
+
+gboolean dt_ai_backend_cache_dir(dt_ai_provider_t provider,
+                                 const char *fingerprint,
+                                 const char *model_id,
+                                 char *out, size_t size)
+{
+  if(!out || size == 0) return FALSE;
+  const char *ep = _ep_name(provider);
+  if(!ep || !fingerprint || !model_id || !model_id[0]) return FALSE;
+
+  char cachedir[PATH_MAX] = { 0 };
+  dt_loc_get_user_cache_dir(cachedir, sizeof(cachedir));
+
+  gchar *subdir = g_strdup_printf("ai_v%d_%s_%s",
+                                  DT_AI_CACHE_SCHEMA, ep, fingerprint);
+  gchar *full = g_build_filename(cachedir, subdir, model_id, NULL);
+  g_free(subdir);
+
+  const size_t len = strlen(full);
+  if(len + 1 > size)
+  {
+    g_free(full);
+    return FALSE;
+  }
+  if(g_mkdir_with_parents(full, 0700) == -1)
+  {
+    dt_print(DT_DEBUG_AI,
+             "[ai_cache] failed to create cache directory: %s", full);
+    g_free(full);
+    return FALSE;
+  }
+  memcpy(out, full, len + 1);
+  g_free(full);
+  return TRUE;
+}
+
+void dt_ai_backend_cache_invalidate(const char *model_id)
+{
+  if(!model_id || !model_id[0]) return;
+
+  char cachedir[PATH_MAX] = { 0 };
+  dt_loc_get_user_cache_dir(cachedir, sizeof(cachedir));
+
+  GDir *dir = g_dir_open(cachedir, 0, NULL);
+  if(!dir) return;
+
+  // match every "ai_v<N>_<ep>_<fingerprint>" sibling and walk into
+  // <model_id>, catching old schemas/EPs too
+  const gchar *name;
+  while((name = g_dir_read_name(dir)))
+  {
+    if(!g_str_has_prefix(name, "ai_v")) continue;
+    gchar *model_subdir = g_build_filename(cachedir, name, model_id, NULL);
+    if(g_file_test(model_subdir, G_FILE_TEST_IS_DIR))
+    {
+      dt_print(DT_DEBUG_AI, "[ai_cache] invalidating %s", model_subdir);
+      _cache_rmdir_recursive(model_subdir);
+    }
+    g_free(model_subdir);
+  }
+  g_dir_close(dir);
+}
+
+void dt_ai_backend_cache_invalidate_all(void)
+{
+  char cachedir[PATH_MAX] = { 0 };
+  dt_loc_get_user_cache_dir(cachedir, sizeof(cachedir));
+
+  GDir *dir = g_dir_open(cachedir, 0, NULL);
+  if(!dir) return;
+
+  const gchar *name;
+  while((name = g_dir_read_name(dir)))
+  {
+    if(!g_str_has_prefix(name, "ai_v")) continue;
+    gchar *full = g_build_filename(cachedir, name, NULL);
+    if(g_file_test(full, G_FILE_TEST_IS_DIR))
+    {
+      dt_print(DT_DEBUG_AI, "[ai_cache] invalidating %s", full);
+      _cache_rmdir_recursive(full);
+    }
+    g_free(full);
+  }
+  g_dir_close(dir);
 }
 
 // clang-format off

--- a/src/ai/backend_onnx.c
+++ b/src/ai/backend_onnx.c
@@ -85,7 +85,15 @@ static int g_loaded_dml_device_id      = -1;
 // snapshot of the provider config string at ORT load. NULL until captured
 static gchar *g_loaded_provider = NULL;
 
+// loaded ORT version string, used in the cache fingerprint to
+// invalidate stale compiled artifacts after an ORT upgrade
+static gchar *g_ort_version = NULL;
+
 static int _device_id_from_conf(const char *conf_key, const char *env_var);
+static gchar *_lookup_device_name(const dt_ai_provider_t provider,
+                                  const int device_id);
+static gchar *_backend_cache_fingerprint(dt_ai_provider_t provider,
+                                         int device_id);
 
 #if defined(__linux__)
 // check that the CUDA driver supports the installed CUDA runtime version;
@@ -769,6 +777,8 @@ static const OrtApi *_ort_api_from_module(GModule *mod, const char *label)
   }
   const OrtApiBase *base = get_api_base();
   const char *lib_version = base->GetVersionString();
+  g_free(g_ort_version);
+  g_ort_version = g_strdup(lib_version ? lib_version : "unknown");
   dt_print(DT_DEBUG_AI, "[darktable_ai] loaded ORT %s from '%s'", lib_version, label);
 
   // try the compiled API version first, then fall back to lower versions
@@ -882,8 +892,10 @@ static gpointer _init_ort_api(gpointer data)
   {
     // Windows/macOS: use the directly linked ORT library (DirectML/CoreML).
     const OrtApiBase *base = OrtGetApiBase();
-    dt_print(DT_DEBUG_AI, "[darktable_ai] loaded ORT %s (bundled)",
-             base->GetVersionString());
+    const char *bundled_version = base->GetVersionString();
+    g_free(g_ort_version);
+    g_ort_version = g_strdup(bundled_version ? bundled_version : "unknown");
+    dt_print(DT_DEBUG_AI, "[darktable_ai] loaded ORT %s (bundled)", bundled_version);
     api = base->GetApi(ORT_API_VERSION);
   }
 #endif
@@ -947,22 +959,32 @@ static void _setup_amd_caches(void)
   if(!_ort_has_provider("MIGraphXExecutionProvider"))
     return;
 
-  char cachedir[PATH_MAX] = { 0 };
-  dt_loc_get_user_cache_dir(cachedir, sizeof(cachedir));
+  const int dev = _device_id_from_conf("plugins/ai/migraphx_device_id",
+                                       "DT_MIGRAPHX_DEVICE_ID");
+  gchar *fp = _backend_cache_fingerprint(DT_AI_PROVIDER_MIGRAPHX, dev);
 
-  gchar *miopen_dir = g_build_filename(cachedir, "ai", "amd", "miopen", NULL);
-  g_mkdir_with_parents(miopen_dir, 0700);
-  g_setenv("MIOPEN_USER_DB_PATH", miopen_dir, FALSE);
-  g_setenv("MIOPEN_CUSTOM_CACHE_DIR", miopen_dir, FALSE);
-  dt_print(DT_DEBUG_AI, "[darktable_ai] MIOpen cache: %s", miopen_dir);
-  g_free(miopen_dir);
+  // two independent sub-caches (MIOpen kernel DB + MIGraphX engine
+  // cache). reserved model-id names "_miopen" / "_migraphx" give each
+  // its own subdir; invalidate-by-model never matches these because
+  // real model_ids don't start with underscore
+  char miopen_dir[PATH_MAX] = { 0 };
+  if(dt_ai_backend_cache_dir(DT_AI_PROVIDER_MIGRAPHX, fp,
+                             "_miopen", miopen_dir, sizeof(miopen_dir)))
+  {
+    g_setenv("MIOPEN_USER_DB_PATH", miopen_dir, FALSE);
+    g_setenv("MIOPEN_CUSTOM_CACHE_DIR", miopen_dir, FALSE);
+    dt_print(DT_DEBUG_AI, "[darktable_ai] MIOpen cache: %s", miopen_dir);
+  }
 
-  gchar *migraphx_dir = g_build_filename(cachedir, "ai", "amd", "migraphx", NULL);
-  g_mkdir_with_parents(migraphx_dir, 0700);
-  g_setenv("ORT_MIGRAPHX_CACHE_PATH", migraphx_dir, FALSE);
-  g_setenv("ORT_MIGRAPHX_MODEL_CACHE_PATH", migraphx_dir, FALSE);
-  dt_print(DT_DEBUG_AI, "[darktable_ai] MIGraphX cache: %s", migraphx_dir);
-  g_free(migraphx_dir);
+  char migraphx_dir[PATH_MAX] = { 0 };
+  if(dt_ai_backend_cache_dir(DT_AI_PROVIDER_MIGRAPHX, fp,
+                             "_migraphx", migraphx_dir, sizeof(migraphx_dir)))
+  {
+    g_setenv("ORT_MIGRAPHX_CACHE_PATH", migraphx_dir, FALSE);
+    g_setenv("ORT_MIGRAPHX_MODEL_CACHE_PATH", migraphx_dir, FALSE);
+    dt_print(DT_DEBUG_AI, "[darktable_ai] MIGraphX cache: %s", migraphx_dir);
+  }
+  g_free(fp);
 }
 #endif
 
@@ -978,10 +1000,13 @@ static gboolean _try_openvino_with_cache(OrtSessionOptions *session_opts)
      || !g_ort->SessionOptionsAppendExecutionProvider_OpenVINO_V2)
     return FALSE;
 
-  char cachedir[PATH_MAX] = { 0 };
-  dt_loc_get_user_cache_dir(cachedir, sizeof(cachedir));
-  gchar *ov_dir = g_build_filename(cachedir, "ai", "intel", "openvino", NULL);
-  g_mkdir_with_parents(ov_dir, 0700);
+  // process-global (no per-model id at session-creation time)
+  gchar *fp = _backend_cache_fingerprint(DT_AI_PROVIDER_OPENVINO, -1);
+  char ov_dir[PATH_MAX] = { 0 };
+  const gboolean ok = dt_ai_backend_cache_dir(
+    DT_AI_PROVIDER_OPENVINO, fp, "_shared", ov_dir, sizeof(ov_dir));
+  g_free(fp);
+  if(!ok) return FALSE;
 
   dt_print(DT_DEBUG_AI,
            "[darktable_ai] attempting Intel OpenVINO (cache: %s)...", ov_dir);
@@ -997,11 +1022,9 @@ static gboolean _try_openvino_with_cache(OrtSessionOptions *session_opts)
              "[darktable_ai] OpenVINO (with cache) failed: %s",
              g_ort->GetErrorMessage(status));
     g_ort->ReleaseStatus(status);
-    g_free(ov_dir);
     return FALSE;
   }
   dt_print(DT_DEBUG_AI, "[darktable_ai] Intel OpenVINO enabled with disk cache.");
-  g_free(ov_dir);
   return TRUE;
 }
 
@@ -1219,6 +1242,77 @@ static gchar *_lookup_device_name(const dt_ai_provider_t provider,
   }
   g_list_free_full(devices, dt_ai_device_free);
   return name;
+}
+
+// strip non-alphanumeric chars in place so the result is safe to embed
+// in a directory name
+static void _alnum_inplace(char *s)
+{
+  if(!s) return;
+  char *r = s, *w = s;
+  while(*r)
+  {
+    if(g_ascii_isalnum(*r)) *w++ = *r;
+    r++;
+  }
+  *w = '\0';
+}
+
+// hardware fingerprint for the per-EP cache subdir. for device-aware
+// EPs (CUDA/DirectML/MIGraphX) the fingerprint is the alphanumeric
+// device name so different GPUs get different cache slots.
+// driver-version is left out for now; bump DT_AI_CACHE_SCHEMA if the
+// compiled-artifact format ever changes incompatibly
+static gchar *_backend_cache_fingerprint(dt_ai_provider_t provider,
+                                         int device_id)
+{
+  gchar *base = NULL;
+  switch(provider)
+  {
+    case DT_AI_PROVIDER_COREML:
+#if defined(__aarch64__) || defined(__arm64__)
+      base = g_strdup("arm64");
+#elif defined(__x86_64__) || defined(_M_X64)
+      base = g_strdup("x86_64");
+#else
+      base = g_strdup("default");
+#endif
+      break;
+
+    case DT_AI_PROVIDER_OPENVINO:
+      // OpenVINO uses device_type="AUTO" everywhere we call it; no
+      // per-device id concept at the session level
+      base = g_strdup("auto");
+      break;
+
+    case DT_AI_PROVIDER_CUDA:
+    case DT_AI_PROVIDER_DIRECTML:
+    case DT_AI_PROVIDER_MIGRAPHX:
+    {
+      gchar *name = _lookup_device_name(provider, device_id);
+      if(name) _alnum_inplace(name);
+      if(name && name[0])
+        base = name;  // ownership transfers to base
+      else
+      {
+        g_free(name);
+        base = g_strdup("default");
+      }
+      break;
+    }
+
+    default:
+      base = g_strdup("default");
+      break;
+  }
+
+  // suffix ORT version so an upgrade invalidates stale artifacts
+  gchar *ort = g_ort_version ? g_strdup(g_ort_version) : g_strdup("ortunknown");
+  _alnum_inplace(ort);
+  gchar *full = g_strdup_printf("%s_ort%s", base, ort);
+  g_free(base);
+  g_free(ort);
+  return full;
 }
 
 // try to find and call an ORT execution provider function at runtime via

--- a/src/ai/backend_onnx.c
+++ b/src/ai/backend_onnx.c
@@ -18,7 +18,6 @@
 
 #include "backend.h"
 #include "common/darktable.h"
-#include "common/file_location.h"
 #include "control/conf.h"
 #include <glib.h>
 #include <onnxruntime_c_api.h>
@@ -1411,6 +1410,48 @@ static gboolean _try_provider(OrtSessionOptions *session_opts,
   return ok;
 }
 
+// V2 keyed-options attach for CoreML. translates ep_flags into named
+// options and wires ModelCacheDirectory for persistent compile cache
+static gboolean _try_coreml_v2(OrtSessionOptions *session_opts,
+                               uint32_t ep_flags,
+                               const char *cache_dir)
+{
+  if(!g_ort || !g_ort->SessionOptionsAppendExecutionProvider) return FALSE;
+
+  const char *keys[8];
+  const char *vals[8];
+  size_t n = 0;
+
+  keys[n] = "ModelFormat";
+  vals[n] = (ep_flags & 16) ? "MLProgram" : "NeuralNetwork";
+  n++;
+
+  keys[n] = "MLComputeUnits";
+  vals[n] = (ep_flags & 1) ? "CPUOnly" : "ALL";
+  n++;
+
+  if(cache_dir && cache_dir[0])
+  {
+    keys[n] = "ModelCacheDirectory";
+    vals[n] = cache_dir;
+    n++;
+  }
+
+  dt_print(DT_DEBUG_AI, "[darktable_ai] attempting to enable Apple CoreML (V2)...");
+  OrtStatus *status = g_ort->SessionOptionsAppendExecutionProvider(
+    session_opts, "CoreML", keys, vals, n);
+  if(status)
+  {
+    dt_print(DT_DEBUG_AI,
+             "[darktable_ai] Apple CoreML (V2) enable failed: %s",
+             g_ort->GetErrorMessage(status));
+    g_ort->ReleaseStatus(status);
+    return FALSE;
+  }
+  dt_print(DT_DEBUG_AI, "[darktable_ai] Apple CoreML (V2) enabled successfully.");
+  return TRUE;
+}
+
 // pick a GPU device_id: env var wins, then conf, fallback to 0.
 // each multi-GPU-capable EP has its own conf key + env var so users
 // switching between providers don't carry stale indices across vendors
@@ -1575,10 +1616,23 @@ _enable_acceleration(OrtSessionOptions *session_opts,
 
   case DT_AI_PROVIDER_COREML:
 #if defined(__APPLE__)
-    _try_provider(
-      session_opts,
-      "OrtSessionOptionsAppendExecutionProvider_CoreML",
-      "Apple CoreML", NULL, coreml_flags, DT_AI_PROVIDER_COREML);
+  {
+    dt_print(DT_DEBUG_AI,
+             "[darktable_ai] CoreML format: %s%s",
+             (coreml_flags & 16) ? "MLProgram" : "NeuralNetwork",
+             (coreml_flags & 1) ? " (CPU compute units)" : "");
+    gchar *fp = _backend_cache_fingerprint(DT_AI_PROVIDER_COREML, -1);
+    char coreml_cache[PATH_MAX] = { 0 };
+    const gboolean have_cache = dt_ai_backend_cache_dir(
+      DT_AI_PROVIDER_COREML, fp, "_shared", coreml_cache, sizeof(coreml_cache));
+    g_free(fp);
+    if(!_try_coreml_v2(session_opts, coreml_flags,
+                       have_cache ? coreml_cache : NULL))
+      _try_provider(
+        session_opts,
+        "OrtSessionOptionsAppendExecutionProvider_CoreML",
+        "Apple CoreML", NULL, coreml_flags, DT_AI_PROVIDER_COREML);
+  }
 #else
     dt_print(DT_DEBUG_AI, "[darktable_ai] apple CoreML not available on this platform");
 #endif

--- a/src/common/ai_models.c
+++ b/src/common/ai_models.c
@@ -1535,6 +1535,10 @@ char *dt_ai_models_download_sync(dt_ai_registry_t *registry,
   g_unlink(download_path);
   g_free(download_path);
 
+  // invalidate before flipping status so the next session sees a fresh
+  // compile, not a stale artifact from the previous model file
+  dt_ai_backend_cache_invalidate(model_id);
+
   // mark success
   g_mutex_lock(&registry->lock);
   dt_ai_model_t *m = _find_model_unlocked(registry, model_id);
@@ -1680,6 +1684,8 @@ gboolean dt_ai_models_delete(dt_ai_registry_t *registry, const char *model_id)
   char *model_dir = g_build_filename(registry->models_dir, model_id, NULL);
   _rmdir_recursive(model_dir);
   g_free(model_dir);
+
+  dt_ai_backend_cache_invalidate(model_id);
 
   char *task_copy = NULL;
   g_mutex_lock(&registry->lock);


### PR DESCRIPTION
CoreML was the only execution provider left out of the cache infrastructure that OpenVINO and MIGraphX already use. Without it, every darktable cold launch re-compiles CoreML models from ONNX – 5–6 s for the SAM encoder, 1–3 s for the denoise CNNs, on every launch.

The fix is small: switch the CoreML attach from the legacy `OrtSessionOptionsAppendExecutionProvider_CoreML(opts, flags)` shim to ORT 1.18's keyed-options API, which exposes `ModelCacheDirectory`. We wire it to the same per-EP cache layout already in `dt_ai_backend_cache_dir()`. Second launch reuses the compiled artifact, SAM cold start drops from 5.65 s → 0.81 s.

## What's in here

- `_try_coreml_v2()` – attaches CoreML via `OrtApi::SessionOptionsAppendExecutionProvider` with named options (`ModelFormat`, `MLComputeUnits`, `ModelCacheDirectory`). The legacy shim stays as a safe fallback if V2 returns an error.
- Wires `ModelCacheDirectory` to `dt_ai_backend_cache_dir(DT_AI_PROVIDER_COREML, …)`. CoreML's compiled `.mlmodelc` / `.mlpackage` partitions persist across launches.
- New optional `coreml_format` field in model manifests – defaults to `neuralnetwork` (today's behavior, no change for any existing model). Models that benchmark cleanly on MLProgram can opt in via their package. Matching darktable-ai PR opts in the small denoise CNNs where MLProgram shaves another 13–34% off inference. Requires https://github.com/darktable-org/darktable-ai/pull/25

Requires #21071 