### PR TITLE
[Nightly] Revert "Bump libheif version to the latest for AppImage build"

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -124,7 +124,7 @@ jobs:
             libxfixes-dev
       - name: Build and install fresh libheif with built-in decoders
         run: |
-          git clone --branch v1.22.0 --depth 1 https://github.com/strukturag/libheif src-libheif
+          git clone --branch v1.21.2 --depth 1 https://github.com/strukturag/libheif src-libheif
           cd src-libheif
           cmake -S . -B build -G Ninja \
             -DCMAKE_BUILD_TYPE=Release \


### PR DESCRIPTION
The version of libheif we upgraded to contained a syntax error in the header that prevented our code from compiling.
Fixed by upstream in https://github.com/strukturag/libheif/commit/ef124f9988e57a06ad6d102c236d2bb4b82aef5d, but I don't think we should use the HEAD of libheif development, so we'll downgrade to the previous release until a fixed version is released.