### PR TITLE
Fix AI features ignoring `plugins/ai/models_path` override

### DIFF
--- a/src/ai/backend.h
+++ b/src/ai/backend.h
@@ -82,6 +82,11 @@ guint dt_ai_providers_bundled(void);
  *  the snapshot is independent of when ORT is lazily initialized. */
 void dt_ai_snapshot_conf_state(void);
 
+/** Read plugins/ai/models_path and expand ~ if present. Returns a
+ *  newly-allocated path, or NULL if the conf key is empty/unset.
+ *  Caller frees with g_free(). */
+gchar *dt_ai_resolve_models_path_override(void);
+
 /** TRUE if plugins/ai/ort_library_path differs from the value seen
  *  when ORT was loaded — the in-process ORT is stale, restart needed. */
 gboolean dt_ai_ort_path_changed_since_load(void);

--- a/src/ai/backend_common.c
+++ b/src/ai/backend_common.c
@@ -248,20 +248,18 @@ static void _scan_directory(dt_ai_environment_t *env, const char *root_path)
   g_dir_close(dir);
 }
 
-// scan custom search_paths + default config/data directories
+// scan search_paths + XDG data dir fallback. duplicate IDs are
+// rejected by _scan_directory (first-seen wins)
 static void _scan_all_paths(dt_ai_environment_t *env)
 {
-  if(env->search_paths)
+  if(env->search_paths && env->search_paths[0])
   {
     char **tokens = g_strsplit(env->search_paths, ";", -1);
     for(int i = 0; tokens[i] != NULL; i++)
-    {
       _scan_directory(env, tokens[i]);
-    }
     g_strfreev(tokens);
   }
 
-  // scan XDG data dir where the registry downloads/extracts models
   char *datadir = g_build_filename(g_get_user_data_dir(), "darktable", "models", NULL);
   _scan_directory(env, datadir);
   g_free(datadir);
@@ -269,9 +267,25 @@ static void _scan_all_paths(dt_ai_environment_t *env)
 
 // API implementation
 
+gchar *dt_ai_resolve_models_path_override(void)
+{
+  char *override = dt_conf_get_string("plugins/ai/models_path");
+  if(!override || !override[0])
+  {
+    g_free(override);
+    return NULL;
+  }
+  gchar *resolved;
+  if(override[0] == '~' && (override[1] == '/' || override[1] == '\0'))
+    resolved = g_build_filename(g_get_home_dir(), override + 2, NULL);
+  else
+    resolved = g_strdup(override);
+  g_free(override);
+  return resolved;
+}
+
 dt_ai_environment_t *dt_ai_env_init(const char *search_paths)
 {
-  // refuse to initialize when AI is disabled in preferences
   if(!dt_conf_get_bool("plugins/ai/enabled"))
   {
     dt_print(DT_DEBUG_AI,
@@ -281,10 +295,19 @@ dt_ai_environment_t *dt_ai_env_init(const char *search_paths)
 
   dt_print(DT_DEBUG_AI, "[darktable_ai] dt_ai_env_init start.");
 
+  // honor plugins/ai/models_path when no explicit paths are given
+  gchar *resolved_paths = NULL;
+  if(!search_paths)
+  {
+    resolved_paths = dt_ai_resolve_models_path_override();
+    if(resolved_paths) search_paths = resolved_paths;
+  }
+
   dt_ai_environment_t *env = g_new0(dt_ai_environment_t, 1);
   g_mutex_init(&env->lock);
   env->model_paths = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_free);
   env->search_paths = g_strdup(search_paths);
+  g_free(resolved_paths);
 
   // read user's preferred execution provider from config
   char *prov_str = dt_conf_get_string(DT_AI_CONF_PROVIDER);

--- a/src/common/ai_models.c
+++ b/src/common/ai_models.c
@@ -428,22 +428,10 @@ static void _setup_registry(dt_ai_registry_t *registry)
   char cachedir[PATH_MAX] = {0};
   dt_loc_get_user_cache_dir(cachedir, sizeof(cachedir));
 
-  // honour plugins/ai/models_path override; "~/..." expands to $HOME
-  char *override = dt_conf_get_string("plugins/ai/models_path");
-  if(override && override[0])
-  {
-    if(override[0] == '~' && (override[1] == '/' || override[1] == '\0'))
-      registry->models_dir
-        = g_build_filename(g_get_home_dir(), override + 2, NULL);
-    else
-      registry->models_dir = g_strdup(override);
-  }
-  else
-  {
+  registry->models_dir = dt_ai_resolve_models_path_override();
+  if(!registry->models_dir)
     registry->models_dir = g_build_filename(g_get_user_data_dir(),
                                             "darktable", "models", NULL);
-  }
-  g_free(override);
 
   registry->cache_dir = g_build_filename(cachedir, "ai_downloads", NULL);
 
@@ -1966,7 +1954,7 @@ dt_ai_environment_t *dt_ai_registry_get_env(dt_ai_registry_t *registry)
 
   g_mutex_lock(&registry->lock);
   if(!registry->env)
-    registry->env = dt_ai_env_init(NULL);
+    registry->env = dt_ai_env_init(registry->models_dir);
   g_mutex_unlock(&registry->lock);
 
   return registry->env;


### PR DESCRIPTION
Follow-up to #21049, which added the `plugins/ai/models_path` conf key to let users point darktable at a custom AI models folder. The preferences page picked the override up correctly (the AI tab listed installed models), but **neural restore** and the **AI object mask** tool kept reporting "model not found" – both created their own `dt_ai_environment_t` via `dt_ai_env_init(NULL)`, which scanned only the XDG default and didn't know about the conf key.

This was the case @wpferguson's multi-instance setup needed in the first place, so it should actually work end-to-end.

### What this PR does

Has `dt_ai_env_init(NULL)` fall back to the same `plugins/ai/models_path` value the registry already honors. The resolution lives in one helper, `dt_ai_resolve_models_path_override()`, so the registry, neural restore's env, and the object mask's env all read the path from the same source going forward.