### PR TITLE
Make RustiCL default for non-apples

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -226,6 +226,8 @@ changes (where available).
 - Removed `Neo` Intel and `pocl` OpenCL drivers from blacklist,
   the `AMD-APP` driver has been added as not supported by AMD for 10yrs.
 
+- RustiCL is the preferred OpenCL driver instead ROCm on AMD systems.
+
 - In the styles module, a new option has been added to hide the
   preview in the tooltip. Additionally, a module preference now allows
   you to change the preview size, with two options available: default

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -503,14 +503,14 @@
   <dtconfig prefs="processing" section="platform" capability="nonapple" restart="true">
     <name>clplatform_amdacceleratedparallelprocessing</name>
     <type>bool</type>
-    <default>${DEFCONFIG_NONAPPLE}</default>
+    <default>false</default>
     <shortdescription>AMD ROCm</shortdescription>
     <longdescription>AMD Accelerated Parallel Processing (vendor provided)</longdescription>
   </dtconfig>
   <dtconfig prefs="processing" section="platform" capability="nonapple" restart="true">
     <name>clplatform_rusticl</name>
     <type>bool</type>
-    <default>false</default>
+    <default>${DEFCONFIG_NONAPPLE}</default>
     <shortdescription>RustiCL</shortdescription>
     <longdescription>RustiCL Mesa OpenCL. if you want to use this, you should disable the vendor driver</longdescription>
   </dtconfig>


### PR DESCRIPTION
As rusticl
- has been proven to be rock-stable for darktable if available
- shows no significant performance penalties (vs ROCm on AMD graphics)
- if by far easier to install than ROCm
- had far less reported issues with driver versions

we favor this as default over ROCm.