### PR TITLE
[CI] Emergency fix for broken header file in libheif 1.22.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -295,6 +295,8 @@ jobs:
           cd -
       - name: Build and Install
         run: |
+          # Emergency fix for broken libheif header file. Should be removed when a fixed libheif package is available in MSYS2.
+          perl -pi -e 's/struct heif_bad_pixel { uint32_t row; uint32_t column; };/typedef struct heif_bad_pixel { uint32_t row; uint32_t column; } heif_bad_pixel;/g' /ucrt64/include/libheif/heif_properties.h
           cmake -E make_directory "${BUILD_DIR}"
           cmake -E make_directory "${INSTALL_PREFIX}"
           $(cygpath ${SRC_DIR})/.ci/ci-script.sh
@@ -363,6 +365,8 @@ jobs:
           brew bundle --quiet || true
       - name: Build and Install
         run: |
+          # Emergency fix for broken libheif header file. Should be removed when a fixed libheif package is available in Homebrew.
+          perl -pi -e 's/struct heif_bad_pixel { uint32_t row; uint32_t column; };/typedef struct heif_bad_pixel { uint32_t row; uint32_t column; } heif_bad_pixel;/g' /opt/homebrew/include/libheif/heif_properties.h
           cmake -E make_directory "${BUILD_DIR}";
           cmake -E make_directory "${INSTALL_PREFIX}";
           ./src/.ci/ci-script.sh;


### PR DESCRIPTION
As you can see, this is an emergency fix until we get a version of libheif with the proper fix in these package bases.
