### PR TITLE
[GUI] Add a separate tooltip for the crop orientation flipping button

### DIFF
--- a/src/iop/crop.c
+++ b/src/iop/crop.c
@@ -1388,13 +1388,19 @@ void gui_init(dt_iop_module_t *self)
 
   g_signal_connect(G_OBJECT(g->aspect_presets), "value-changed",
                    G_CALLBACK(_event_aspect_presets_changed), self);
+
   gtk_widget_set_tooltip_text
     (g->aspect_presets,
      _("set the aspect ratio\n"
        "the list is sorted: from most square to least square\n"
        "to enter custom aspect ratio open the combobox and type ratio in x:y"
        " or decimal format"));
-  dt_bauhaus_widget_set_quad(g->aspect_presets, self, dtgtk_cairo_paint_aspectflip, FALSE, _event_aspect_flip, NULL);
+  dt_bauhaus_widget_set_quad(g->aspect_presets,
+                             self,
+                             dtgtk_cairo_paint_aspectflip,
+                             FALSE,
+                             _event_aspect_flip,
+                             _("flip crop orientation between horizontal and vertical"));
 
   GtkWidget *box_enabled = dt_gui_vbox(g->aspect_presets);
 


### PR DESCRIPTION
While the icon on this button is probably good enough for the user to guess its purpose, it would be better to also add a tooltip.