### PR TITLE
[Nightly] Emergency fix for broken libheif 1.22.0 header for nightly builds

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -305,6 +305,8 @@ jobs:
           lensfun-update-data
       - name: Build and Install
         run: |
+          # Emergency fix for broken libheif header file. Should be removed when a fixed libheif package is available in MSYS2.
+          perl -pi -e 's/struct heif_bad_pixel { uint32_t row; uint32_t column; };/typedef struct heif_bad_pixel { uint32_t row; uint32_t column; } heif_bad_pixel;/g' /ucrt64/include/libheif/heif_properties.h /clangarm64/include/libheif/heif_properties.h
           cmake -E make_directory "${BUILD_DIR}"
           cmake -E make_directory "${INSTALL_PREFIX}"
           $(cygpath ${SRC_DIR})/.ci/ci-script.sh
@@ -394,6 +396,8 @@ jobs:
         uses: andymckay/cancel-action@0.5
       - name: Build and Install
         run: |
+          # Emergency fix for broken libheif header file. Should be removed when a fixed libheif package is available in Homebrew.
+          perl -pi -e 's/struct heif_bad_pixel { uint32_t row; uint32_t column; };/typedef struct heif_bad_pixel { uint32_t row; uint32_t column; } heif_bad_pixel;/g' /opt/homebrew/include/libheif/heif_properties.h /usr/local/include/libheif/heif_properties.h
           cmake -E make_directory "${BUILD_DIR}";
           cmake -E make_directory "${INSTALL_PREFIX}";
           ./src/.ci/ci-script.sh;


### PR DESCRIPTION
This fix is ​​similar to #21087 but for nightly builds.