### PR TITLE
Fix multi-binary AppRun launch failure when ARGV0 is absent

### DIFF
--- a/packaging/AppImage/AppRun
+++ b/packaging/AppImage/AppRun
@@ -24,7 +24,7 @@ if [[ ! -z $APPIMAGE ]] ; then
   BINARY_NAME=$(basename "$ARGV0")
   if [[ ! -z "$1" ]] && [[ -e "$HERE/usr/bin/$1" ]] ; then
     EXECFILE="$HERE/usr/bin/$1" ; shift
-  elif [[ -e "$HERE/usr/bin/$BINARY_NAME" ]] ; then
+  elif [[ ! -z "$BINARY_NAME" ]] && [[ -e "$HERE/usr/bin/$BINARY_NAME" ]] ; then
     EXECFILE="$HERE/usr/bin/$BINARY_NAME"
   else
     EXECFILE="$HERE/usr/bin/darktable"


### PR DESCRIPTION
### Problem
When executing the AppImage wrapper script in environments that do not populate the `$ARGV0` environment variable (such as `appimage-run` on NixOS), `$BINARY_NAME` evaluates to an empty string. 

This causes the conditional block `elif [[ -e "$HERE/usr/bin/$BINARY_NAME" ]]` to expand directly to checking the existence of the directory `"$HERE/usr/bin/"`. Because the directory exists, the clause evaluates to `true` and sets `EXECFILE` to the directory path itself, causing a launch failure with the shell error: `AppRun: line 36: .../usr/bin/: Is a directory`.
<img width="1386" height="155" alt="Image of terminal output with the following text:
[<usr-redacted>@nixos:~/Downloads]$ appimage-run Darktable-5.5.0+1325.g5f523d43b6-x86_64.AppImage 
Uncompress Darktable-5.5.0+1325.g5f523d43b6-x86_64.AppImage of type 02 @ offset 944632
[======================================================================================================================================================/] 8099/8099 100%
Darktable-5.5.0+1325.g5f523d43b6-x86_64.AppImage is now installed in /home/<usr-redacted>/.cache/appimage-run/c7ec773b24e9c2a85e0e09492f19d629040a00e0b62e515ec82446d0c50fe42a
/home/<usr-redacted>/.cache/appimage-run/c7ec773b24e9c2a85e0e09492f19d629040a00e0b62e515ec82446d0c50fe42a/AppRun.wrapped: Zeile 36: /home/<usr-redacted>/.cache/appimage-run/c7ec773b24e9c2a85e0e09492f19d629040a00e0b62e515ec82446d0c50fe42a/usr/bin/: Is a directory
" src="https://github.com/user-attachments/assets/0987a18a-82e8-4ffb-8490-92472d99249f" />

### Solution
Explicitly validate `[[ ! -z "$BINARY_NAME" ]]` within the conditional check before testing for path existence. This mirrors the pattern used two lines above (`[[ ! -z "$1" ]]`), ensuring empty string lookups fall through cleanly to the default fallback executable branch when `$ARGV0` is missing.