### PR TITLE
Fix object mask cursor indicator leaking under overlay windows

### DIFF
--- a/src/develop/masks/object.c
+++ b/src/develop/masks/object.c
@@ -1707,6 +1707,11 @@ static void _object_events_post_expose(cairo_t *cr,
   int dev_x = 0, dev_y = 0;
   if(win && pointer)
     gdk_window_get_device_position(win, pointer, &dev_x, &dev_y, &mod);
+
+  // skip indicator when pointer is over a window above us (e.g. prefs)
+  if(pointer
+     && gdk_device_get_window_at_position(pointer, NULL, NULL) != win)
+    return;
   const gboolean has_sel = d && d->has_selection;
   const gboolean ctrl_shift_held
     = has_sel


### PR DESCRIPTION
If you're in the object mask creation mode and you open preferences (or any other window) over the darkroom without leaving the mask tool, the mask's "+" cursor indicator keeps tracking the cursor underneath the overlay – you can see it moving on the darkroom behind the prefs window as you move the mouse over the prefs widgets.

Root cause: the mask tool's post-expose handler calls `gdk_window_get_device_position()` every redraw to figure out where to draw the indicator. That function returns the pointer's coordinates relative to the darkroom window regardless of which window the cursor is actually over, so as long as the coordinates land inside the canvas bounds, the indicator gets drawn there – even when the cursor is visually somewhere else.

Fix: also ask `gdk_device_get_window_at_position()` which window the pointer is actually over, and skip the indicator if it's not the darkroom canvas.