### PR TITLE
Fixes race condition during mask resizing

### DIFF
--- a/src/develop/masks/group.c
+++ b/src/develop/masks/group.c
@@ -330,7 +330,7 @@ static int _group_get_mask(const dt_iop_module_t *const module,
   for(GList *fpts = form->points; fpts; fpts = g_list_next(fpts))
   {
     dt_masks_point_group_t *fpt = fpts->data;
-    dt_masks_form_t *sel = dt_masks_get_from_id(module->dev, fpt->formid);
+    dt_masks_form_t *sel = dt_masks_get_from_id_ext(piece->pipe->forms, fpt->formid);
     if(sel)
     {
       ok[pos] = dt_masks_get_mask(module, piece, sel, &bufs[pos],
@@ -648,7 +648,7 @@ static int _group_get_mask_roi(const dt_iop_module_t *const restrict module,
   for(GList *fpts = form->points; fpts; fpts = g_list_next(fpts))
   {
     dt_masks_point_group_t *fpt = fpts->data;
-    dt_masks_form_t *sel = dt_masks_get_from_id(module->dev, fpt->formid);
+    dt_masks_form_t *sel = dt_masks_get_from_id_ext(piece->pipe->forms, fpt->formid);
 
     if(sel)
     {


### PR DESCRIPTION

**Fixes race condition between the pixelpipe worker thread and the UI thread accessing `dev->forms` concurrently.**

[Crash report (txt)](https://github.com/user-attachments/files/28171763/mask_crash_report.txt)

During a mask resize operation, the call chain in the pixelpipe worker is:

```
dt_masks_group_render_roi
  → _group_get_mask_roi          [group.c:651]
    → dt_masks_get_from_id(module->dev, fpt->formid)   ← reads dev->forms LIVE
      → _path_get_mask_roi
        → _path_get_pts_border   ← crashes iterating form->points

```

At blend.c:595, the outer form is correctly fetched from `piece->pipe->forms` — a **deep copy** of `dev->forms` made at the start of the pipeline run (pixelpipe_hb.c:3092):

```c
pipe->forms = dt_masks_dup_forms_deep(dev->forms, NULL);

```

But when `_group_get_mask_roi` needs to look up **child forms** (the shapes inside a group), it bypasses the pipe's copy and goes directly to `dev->forms`:

```c
// group.c:651 — BUG
dt_masks_form_t *sel = dt_masks_get_from_id(module->dev, fpt->formid);
//                                           ^^^^^^^^^^^ dev->forms — live, mutable

```

The same bug exists in `_group_get_mask` at group.c:333.

While the pixelpipe worker iterates over a child path form's `form->points` GList in `_path_get_pts_border`, the UI thread (responding to a mouse resize) can modify that same GList in `dev->forms` — freeing or relocating nodes. When the worker thread then follows a `->next` pointer on a freed GList node, it reads address `0x0000000000000008` (GList.next is at offset 8 on 64-bit) and crashes.

----------

## Fix

Changed both unsafe lookups from `dev->forms` to `piece->pipe->forms` using `dt_masks_get_from_id_ext`:

**group.c:333** (in `_group_get_mask`):

```c
// Before:
dt_masks_form_t *sel = dt_masks_get_from_id(module->dev, fpt->formid);

// After:
dt_masks_form_t *sel = dt_masks_get_from_id_ext(piece->pipe->forms, fpt->formid);
```

**group.c:651** (in `_group_get_mask_roi`):

```c
// Before:
dt_masks_form_t *sel = dt_masks_get_from_id(module->dev, fpt->formid);

// After:
dt_masks_form_t *sel = dt_masks_get_from_id_ext(piece->pipe->forms, fpt->formid);
```

Both functions already have `piece` as a parameter with `piece->pipe->forms` available. `dt_masks_get_from_id_ext` already exists and takes exactly a `GList *` (the forms list) — it's already used correctly in `blend.c:595` for the outer form lookup.

Co-authored with Claude.