### PR TITLE
[innosetup] Add "Import into darktable" menu item to the right-click context menu on images

### DIFF
--- a/packaging/windows/darktable.iss.in
+++ b/packaging/windows/darktable.iss.in
@@ -123,6 +123,20 @@ Root: HKA; Subkey: "SOFTWARE\Classes\Directory\shell\ImportFolderIntoDarktable\c
   ValueType: string; Flags: uninsdeletekey; \
   ValueData: """{app}\bin\{#MyAppExeName}"" ""%1"""
 
+;
+; Add "Import into darktable" menu item to the right-click context menu on images.
+; Files that are not images will not be affected due to the "AppliesTo" filter.
+;
+Root: HKA; Subkey: "SOFTWARE\Classes\*\shell\ImportImageIntoDarktable"; \
+  ValueType: string; Flags: uninsdeletekey; \
+  ValueData: "Import into darktable"
+Root: HKA; Subkey: "SOFTWARE\Classes\*\shell\ImportImageIntoDarktable"; \
+  ValueType: string; Flags: uninsdeletekey; \
+  ValueName: "AppliesTo"; ValueData: "System.Kind:=picture"
+Root: HKA; Subkey: "SOFTWARE\Classes\*\shell\ImportImageIntoDarktable\command"; \
+  ValueType: string; Flags: uninsdeletekey; \
+  ValueData: """{app}\bin\{#MyAppExeName}"" ""%1"""
+
 ; To open a file from the "Open with" menu, Windows needs to know the exact command to execute
 Root: HKA; Subkey: "Software\Classes\Applications\{#MyAppExeName}\shell\open\command"; \
   ValueType: string; Flags: uninsdeletevalue; \

--- a/packaging/windows/darktable.iss.in
+++ b/packaging/windows/darktable.iss.in
@@ -116,6 +116,9 @@ Source: "AUTHORS";  DestDir: "{app}"; DestName: "AUTHORS.txt"; Flags: ignorevers
 Source: "LICENSE";  DestDir: "{app}"; DestName: "LICENSE.txt"; Flags: ignoreversion
 
 [Registry]
+;
+; Add "Import folder into darktable" menu item to the right-click context menu on folders.
+;
 Root: HKA; Subkey: "SOFTWARE\Classes\Directory\shell\ImportFolderIntoDarktable"; \
   ValueType: string; Flags: uninsdeletekey; \
   ValueData: "Import folder into darktable"
@@ -137,29 +140,44 @@ Root: HKA; Subkey: "SOFTWARE\Classes\*\shell\ImportImageIntoDarktable\command"; 
   ValueType: string; Flags: uninsdeletekey; \
   ValueData: """{app}\bin\{#MyAppExeName}"" ""%1"""
 
+;
 ; To open a file from the "Open with" menu, Windows needs to know the exact command to execute
+;
 Root: HKA; Subkey: "Software\Classes\Applications\{#MyAppExeName}\shell\open\command"; \
   ValueType: string; Flags: uninsdeletevalue; \
   ValueData: """{app}\bin\{#MyAppExeName}"" ""%1"""
 
+;
+; The variable below will be substituted by CMake with a list of those Inno Setup
+; Script commands that add in Registry items to the "Open with" menu for extensions
+; that this darktable build actually supports.
+;
 ${CMAKE_ADD_DARKTABLE_TO_OPENWITHLIST}
 
+;
+; Registering the app in "App Paths" is critical for GIMP to find darktable to open raw files.
+; This also allows us to launch the app by name only in the Run dialog (Win+R) and the taskbar
+; search bar (Win+S) without adding the darktable executable directory to the system PATH.
+;
 Root: HKA; Subkey: "SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\{#MyAppExeName}"; \
   ValueType: string; \
   ValueData: "{app}\bin\{#MyAppExeName}"; \
   Flags: uninsdeletekey
-
 Root: HKA; Subkey: "SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\{#MyAppCliExeName}"; \
   ValueType: string; \
   ValueData: "{app}\bin\{#MyAppCliExeName}"; \
   Flags: uninsdeletekey
 
+;
+; Add environment variables to the appropriate environment (system or user) for tethering
+; to work correctly via gphoto2. They tell the app from where to load the dynamic libraries
+; with the code for working with ports and cameras.
+;
 Root: HKA; Subkey: "{code:EnvironmentKey}"; \
   ValueType: string; \
   ValueName: "CAMLIBS"; \
   ValueData: "{app}\lib\libgphoto2\${CPACK_NSIS_GPHOTO2_VERSION}"; \
   Flags: uninsdeletevalue
-
 Root: HKA; Subkey: "{code:EnvironmentKey}"; \
   ValueType: string; \
   ValueName: "IOLIBS"; \


### PR DESCRIPTION
We add a menu item similar to the one added by the RawTherapee and ART installers. However, there is an imperfection in their implementations, they add an _open in their program_ item to the right-click context menu for <ins>all files</ins>. But for files that are not images, this makes no sense and only clutters the menu with useless items.

While researching how to fix this, I came across some not-so-widely known things in Windows: something called Advanced Query Syntax (AQS), a special System.Kind property that image files have, and support for filtering in registry asterisk keys by this property (the "AppliesTo" variable in the subkey).

So this change adds an image import menu item only to the right-click menu on _images_, without creating meaningless items for other file types.