### PR TITLE
Try using `clEnqueueMigrateMemObjects`

### DIFF
--- a/src/common/dlopencl.c
+++ b/src/common/dlopencl.c
@@ -225,6 +225,12 @@ dt_dlopencl_t *dt_dlopencl_init(const char *name)
                                            (void (**)(void)) & ocl->symbols->dt_clGetMemObjectInfo);
     success = success && dt_gmodule_symbol(module, "clGetImageInfo",
                                            ((void (**)(void)) & ocl->symbols->dt_clGetImageInfo));
+    success = success && dt_gmodule_symbol(module, "clEnqueueMigrateMemObjects",
+                                           ((void (**)(void)) & ocl->symbols->dt_clEnqueueMigrateMemObjects));
+    success = success && dt_gmodule_symbol(module, "clEnqueueFillBuffer",
+                                           ((void (**)(void)) & ocl->symbols->dt_clEnqueueFillBuffer));
+    success = success && dt_gmodule_symbol(module, "clEnqueueFillImage",
+                                           ((void (**)(void)) & ocl->symbols->dt_clEnqueueFillImage));
   }
 
   ocl->have_opencl = success;

--- a/src/common/dlopencl.h
+++ b/src/common/dlopencl.h
@@ -133,6 +133,10 @@ typedef cl_int (*dt_clEnqueueNativeKernel_t)(cl_command_queue, void (*user_func)
 typedef cl_int (*dt_clEnqueueMarker_t)(cl_command_queue, cl_event *);
 typedef cl_int (*dt_clEnqueueWaitForEvents_t)(cl_command_queue, cl_uint, const cl_event *);
 
+typedef cl_int (*dt_clEnqueueMigrateMemObjects_t)(cl_command_queue, cl_uint, const cl_mem*, cl_mem_migration_flags, cl_uint, const cl_event*, cl_event*);
+typedef cl_int (*dt_clEnqueueFillBuffer_t)(cl_command_queue, cl_mem, const void *, size_t, size_t, size_t, cl_uint, const cl_event *, cl_event *);
+typedef cl_int (*dt_clEnqueueFillImage_t)(cl_command_queue, cl_mem, const void *, const size_t *, const size_t *, cl_uint, const cl_event *, cl_event *);
+
 typedef struct dt_dlopencl_symbols_t
 {
   dt_clGetPlatformIDs_t dt_clGetPlatformIDs;
@@ -206,6 +210,9 @@ typedef struct dt_dlopencl_symbols_t
   dt_clEnqueueNativeKernel_t dt_clEnqueueNativeKernel;
   dt_clEnqueueMarker_t dt_clEnqueueMarker;
   dt_clEnqueueWaitForEvents_t dt_clEnqueueWaitForEvents;
+  dt_clEnqueueMigrateMemObjects_t dt_clEnqueueMigrateMemObjects;
+  dt_clEnqueueFillBuffer_t dt_clEnqueueFillBuffer;
+  dt_clEnqueueFillImage_t dt_clEnqueueFillImage;
 } dt_dlopencl_symbols_t;
 
 

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -2871,6 +2871,26 @@ int dt_opencl_enqueue_kernel_1d_args_internal(const int dev,
   return dt_opencl_enqueue_kernel_ndim_with_local(dev, kernel, sizes, NULL, 1);
 }
 
+int dt_opencl_migrate_cl_mem(const int devid, cl_mem mem)
+{
+  if(!_cldev_running(devid))
+    return DT_OPENCL_NODEVICE;
+
+  cl_event *eventp = _opencl_events_get_slot(devid, "[migrate cl_mem]");
+
+  const cl_mem list[1] = { mem };
+  const cl_int err = (darktable.opencl->dlocl->symbols->dt_clEnqueueMigrateMemObjects)
+    (darktable.opencl->dev[devid].cmd_queue,
+      1, list, CL_MIGRATE_MEM_OBJECT_HOST,
+      0, NULL, eventp);
+
+  if(err != CL_SUCCESS)
+    dt_print(DT_DEBUG_OPENCL,
+             "[dt_opencl_migrate_cl_mem] on device '%s' id=%d failed: %s",
+             darktable.opencl->dev[devid].fullname, devid, cl_errstr(err));
+  return err;
+}
+
 int dt_opencl_copy_device_to_host(const int devid,
                                   void *host,
                                   cl_mem image,

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -2901,6 +2901,8 @@ int dt_opencl_copy_device_to_host(const int devid,
   if(!_cldev_running(devid))
     return DT_OPENCL_NODEVICE;
 
+  dt_opencl_migrate_cl_mem(devid, image);
+
   const size_t region[2] = { width, height };
   // blocking.
   return dt_opencl_read_host_from_device_raw(devid, host, image, CLIMG_ORIGIN,

--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -541,6 +541,7 @@ void *dt_opencl_map_buffer(const int devid,
 int dt_opencl_unmap_mem_object(const int devid,
                                cl_mem mem_object,
                                void *mapped_ptr);
+int dt_opencl_migrate_cl_mem(const int devid, cl_mem mem);
 
 size_t dt_opencl_get_mem_object_size(const cl_mem mem);
 


### PR DESCRIPTION
See #21069 

1. Just brute force usage in `dt_opencl_copy_device_to_host()` as that was the reported bottleneck
2. Here on AMD/rusticl with unified mem
a) no critical performance drops
b) no reported errors
c) no instabilities  