### PR TITLE
OpenCL: prevent bogus huge durations in profiling output

### DIFF
--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -4093,22 +4093,36 @@ cl_int dt_opencl_events_flush(const int devid,
     else
       (*totalsuccess)++;
 
-    if(darktable.unmuted & DT_DEBUG_PERF)
+    if((darktable.unmuted & DT_DEBUG_PERF)
+       && err == CL_SUCCESS
+       && *retval == CL_COMPLETE)
     {
-      // get profiling info of event (only if darktable was called with '-d perf')
-      cl_ulong start;
-      cl_ulong end;
+      // get profiling info of event (only if darktable was called with '-d perf').
+      // Initialize start/end so a driver that wrongly returns CL_SUCCESS without
+      // populating the value cannot make us subtract garbage.
+      cl_ulong start = 0;
+      cl_ulong end = 0;
       cl_int errs = (cl->dlocl->symbols->dt_clGetEventProfilingInfo)(
           (*eventlist)[k], CL_PROFILING_COMMAND_START, sizeof(cl_ulong), &start, NULL);
       cl_int erre = (cl->dlocl->symbols->dt_clGetEventProfilingInfo)
         ((*eventlist)[k], CL_PROFILING_COMMAND_END,
          sizeof(cl_ulong), &end, NULL);
-      if(errs == CL_SUCCESS && erre == CL_SUCCESS)
+      if(errs == CL_SUCCESS && erre == CL_SUCCESS && end >= start)
       {
         (*eventtags)[k].timelapsed = end - start;
       }
       else
       {
+        // Driver returned success but timestamps are missing/inverted, or the
+        // profiling query itself failed. Surface this rather than silently
+        // producing a huge underflowed duration.
+        dt_print(DT_DEBUG_OPENCL,
+                 "[opencl_events_flush] invalid profiling data for '%s' on device %d"
+                 " (start=%" G_GUINT64_FORMAT ", end=%" G_GUINT64_FORMAT
+                 ", errs=%s, erre=%s)",
+                 tag[0] == '\0' ? "<?>" : tag, devid,
+                 (guint64)start, (guint64)end,
+                 cl_errstr(errs), cl_errstr(erre));
         (*eventtags)[k].timelapsed = 0;
         (*lostevents)++;
       }


### PR DESCRIPTION
When `-d opencl -d perf` is active, the profiling summary could report absurd values like, as in my Radeon 780M iGPU / ROCm 7.2 setup:
```
30.7033 [opencl_profiling] spent 73786974208.0000 seconds in [Read Image (from device to host)]
30.7034 [opencl_profiling] spent 36893487104.0000 seconds in [Write Image (from host to device)]
...
30.7035 [opencl_profiling] spent 110680457216.0000 seconds totally in command queue (with 0 events missing)
```

The cause was that `dt_opencl_events_flush` computed `end - start` as `cl_ulong` (unsigned) without guarding against drivers that return `CL_SUCCESS` from `clGetEventProfilingInfo` while leaving the output untouched, querying profiling info for events that did not reach `CL_COMPLETE`, or otherwise yielding `end < start`. The unsigned underflow then wrapped to ~UINT64_MAX nanoseconds, which the aggregation turned into multi-billion-second figures.

Initialize start/end, only query profiling info for events that completed cleanly, keep the `end >= start` sanity check, and emit a diagnostic identifying the offending tag, device, and raw timestamps when invalid data is encountered, so the underlying driver issue is surfaced rather than silently masked.

Here is a log showing the perf output with the additional debug msg: [darktable_amd_rocm_log.txt](https://github.com/user-attachments/files/28196593/darktable_amd_rocm_log.txt)


CC: @jenshannoschwalm 