### PR TITLE
Fix startup crash from OpenCL init setlocale() racing main-thread gettext()

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1560,6 +1560,32 @@ int dt_init(int argc,
   // set the interface language and prepare selection for prefs & confgen
   darktable.l10n = dt_l10n_init(init_gui);
 
+  // Pin this thread (the main / GUI thread, which performs the overwhelming
+  // majority of gettext() calls) to a private, thread-local copy of the locale
+  // that dt_l10n_init() just finalized. setlocale() and gettext() both act on
+  // glibc's *global* locale and are not safe to call concurrently: setlocale()
+  // frees and rebuilds the global locale data while gettext() reads it.
+  // Background worker threads routinely trigger setlocale() indirectly when they
+  // dlopen and initialize third-party libraries (the OpenCL ICD loader and GPU
+  // vendor drivers, libcups during printer discovery, ...). With the main thread
+  // reading from a private locale, those concurrent global setlocale() calls can
+  // no longer corrupt the state our gettext() reads, which was causing
+  // intermittent startup crashes (SIGSEGV / "free(): invalid pointer" /
+  // "realloc(): invalid pointer") during the gettext-heavy GUI construction.
+  // This must run after dt_l10n_init() has finalized the locale and before any
+  // worker threads are created in dt_control_init(). The private locale lives
+  // for the whole process and is intentionally never freed.
+  //
+  // Not done on Windows: darktable's per-region locale helpers there toggle
+  // _configthreadlocale(_DISABLE_PER_THREAD_LOCALE), which would silently undo a
+  // permanent pin on the main thread.
+#if !defined(WIN32)
+  {
+    const locale_t main_locale = newlocale(LC_ALL_MASK, "", (locale_t)0);
+    if(main_locale) uselocale(main_locale);
+  }
+#endif
+
   gboolean has_workspace = FALSE;
 
   // we need this REALLY early so that error messages can be shown,

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -718,20 +718,6 @@ void dt_dump_pipe_diff_pfm(
   dt_free_align(o);
 }
 
-static int32_t _detect_opencl_job_run(dt_job_t *job)
-{
-  dt_opencl_init(darktable.opencl, GPOINTER_TO_INT(dt_control_job_get_params(job)), TRUE);
-  return 0;
-}
-
-static dt_job_t *_detect_opencl_job_create(gboolean exclude_opencl)
-{
-  dt_job_t *job = dt_control_job_create(&_detect_opencl_job_run, "detect opencl devices");
-  if(!job) return NULL;
-  dt_control_job_set_params(job, GINT_TO_POINTER(exclude_opencl), NULL);
-  return job;
-}
-
 static int32_t _backthumbs_job_run(dt_job_t *job)
 {
   dt_update_thumbs_thread(dt_control_job_get_params(job));
@@ -1876,7 +1862,6 @@ int dt_init(int argc,
   dt_splash_screen_set_progress(_("initializing WB presets"));
   dt_wb_presets_init(NULL);
 
-  // Do locale-sensitive init BEFORE starting any background worker jobs
   dt_splash_screen_set_progress(_("loading noise profiles"));
   darktable.noiseprofile_parser = dt_noiseprofile_init(noiseprofiles_from_command);
 
@@ -1885,11 +1870,16 @@ int dt_init(int argc,
   darktable.points = (dt_points_t *)calloc(1, sizeof(dt_points_t));
   dt_points_init(darktable.points, dt_get_num_threads());
 
-  // Only then kick off the OpenCL background job
-  if(init_gui)
-    dt_control_add_job(DT_JOB_QUEUE_SYSTEM_BG, _detect_opencl_job_create(exclude_opencl));
-  else
-    dt_opencl_init(darktable.opencl, exclude_opencl, print_statistics);
+  // OpenCL initialization must run synchronously on the main thread, even in
+  // the GUI path. Loading the ICD loader and the GPU vendor drivers calls
+  // setlocale() internally, which is not reentrant with the gettext() calls
+  // the main thread keeps making while loading modules and building the GUI.
+  // Running this in a background worker job races that global locale state and
+  // intermittently corrupts the heap, surfacing as a SIGSEGV or
+  // "free(): invalid pointer" during early GUI construction (e.g. while the
+  // welcome screen / main window is being shown). This is the same class of
+  // bug as the reorder of the JSON/gettext preset parsers just above.
+  dt_opencl_init(darktable.opencl, exclude_opencl, print_statistics);
 
   // must come before mipmap_cache, because that one will need to access image dimensions stored in here:
   dt_image_cache_init();

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1560,31 +1560,18 @@ int dt_init(int argc,
   // set the interface language and prepare selection for prefs & confgen
   darktable.l10n = dt_l10n_init(init_gui);
 
-  // Pin this thread (the main / GUI thread, which performs the overwhelming
-  // majority of gettext() calls) to a private, thread-local copy of the locale
-  // that dt_l10n_init() just finalized. setlocale() and gettext() both act on
-  // glibc's *global* locale and are not safe to call concurrently: setlocale()
-  // frees and rebuilds the global locale data while gettext() reads it.
-  // Background worker threads routinely trigger setlocale() indirectly when they
-  // dlopen and initialize third-party libraries (the OpenCL ICD loader and GPU
-  // vendor drivers, libcups during printer discovery, ...). With the main thread
-  // reading from a private locale, those concurrent global setlocale() calls can
-  // no longer corrupt the state our gettext() reads, which was causing
-  // intermittent startup crashes (SIGSEGV / "free(): invalid pointer" /
-  // "realloc(): invalid pointer") during the gettext-heavy GUI construction.
-  // This must run after dt_l10n_init() has finalized the locale and before any
-  // worker threads are created in dt_control_init(). The private locale lives
-  // for the whole process and is intentionally never freed.
-  //
-  // Not done on Windows: darktable's per-region locale helpers there toggle
-  // _configthreadlocale(_DISABLE_PER_THREAD_LOCALE), which would silently undo a
-  // permanent pin on the main thread.
-#if !defined(WIN32)
-  {
-    const locale_t main_locale = newlocale(LC_ALL_MASK, "", (locale_t)0);
-    if(main_locale) uselocale(main_locale);
-  }
-#endif
+  // Pin the main (GUI) thread -- which performs the overwhelming majority of
+  // gettext() calls -- to a private, thread-local copy of the locale that
+  // dt_l10n_init() just finalized, so setlocale() calls made concurrently on
+  // other threads (directly or from inside third-party libraries such as the
+  // OpenCL ICD loader, GPU vendor drivers or libcups) can no longer corrupt the
+  // global locale state our gettext() reads. This was causing intermittent
+  // startup crashes (SIGSEGV / "free(): invalid pointer" / "realloc(): invalid
+  // pointer") during the gettext-heavy GUI construction. See
+  // dt_pthread_setlocale(); every darktable worker / lua thread is pinned the
+  // same way. Must run after dt_l10n_init() has finalized the locale and before
+  // any worker threads are created in dt_control_init().
+  dt_pthread_setlocale();
 
   gboolean has_workspace = FALSE;
 

--- a/src/common/dtpthread.c
+++ b/src/common/dtpthread.c
@@ -25,6 +25,8 @@
 #include <pthread.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <locale.h>
 #include <inttypes.h>
 
 #ifdef _WIN32
@@ -32,6 +34,38 @@
 #endif // _WIN32
 
 #include "common/dtpthread.h"
+
+void dt_pthread_setlocale(void)
+{
+#if !defined(_WIN32)
+  // a private copy of the locale the process was started with; this thread's
+  // gettext() reads it instead of the global locale, so it is immune to
+  // setlocale() called concurrently on any other thread. Lives for the whole
+  // thread and is intentionally never freed.
+  const locale_t loc = newlocale(LC_ALL_MASK, "", (locale_t)0);
+  if(loc) uselocale(loc);
+#endif
+}
+
+// Trampoline used by dt_pthread_create() so that every darktable-spawned thread
+// pins its locale before running its actual work (see dt_pthread_setlocale()).
+typedef struct _dt_pthread_start_t
+{
+  void *(*start_routine)(void *);
+  void *arg;
+} _dt_pthread_start_t;
+
+static void *_dt_pthread_start(void *arg)
+{
+  _dt_pthread_start_t *params = (_dt_pthread_start_t *)arg;
+  void *(*start_routine)(void *) = params->start_routine;
+  void *real_arg = params->arg;
+  free(params);
+
+  dt_pthread_setlocale();
+
+  return start_routine(real_arg);
+}
 
 int dt_pthread_create(pthread_t *thread, void *(*start_routine)(void *), void *arg)
 {
@@ -60,9 +94,17 @@ int dt_pthread_create(pthread_t *thread, void *(*start_routine)(void *), void *a
   }
   assert(ret == 0);
 
-  ret = pthread_create(thread, &attr, start_routine, arg);
+  // wrap the thread entry so it pins a private locale before running (the
+  // trampoline frees params; on failure we free it here since it won't run)
+  _dt_pthread_start_t *params = malloc(sizeof(_dt_pthread_start_t));
+  assert(params);
+  params->start_routine = start_routine;
+  params->arg = arg;
+
+  ret = pthread_create(thread, &attr, _dt_pthread_start, params);
   if(ret != 0)
   {
+    free(params);
     printf("[dt_pthread_create] error: pthread_create() returned %s\n", _pthread_ret_mess(ret));
     fflush(stdout);
   }

--- a/src/common/dtpthread.h
+++ b/src/common/dtpthread.h
@@ -572,6 +572,16 @@ int dt_pthread_create(pthread_t *thread, void *(*start_routine)(void *), void *a
 int dt_pthread_join(pthread_t thread);
 void dt_pthread_setname(const char *name);
 
+// Pin the calling thread to a private, thread-local copy of the locale, so that
+// setlocale() calls made concurrently by other threads (directly or from inside
+// third-party libraries) can no longer corrupt the global locale state this
+// thread reads through gettext() & friends. Threads created via
+// dt_pthread_create() are pinned automatically; threads created by other means
+// (e.g. glib's g_thread_new / g_thread_pool) must call this once at entry.
+// No-op on Windows, where darktable's per-region locale helpers toggle
+// _configthreadlocale(_DISABLE_PER_THREAD_LOCALE) and would undo a permanent pin.
+void dt_pthread_setlocale(void);
+
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/dtgtk/range.c
+++ b/src/dtgtk/range.c
@@ -200,11 +200,10 @@ static gchar *_default_print_func(const double value, const gboolean detailled)
 static gboolean _default_decode_func(const gchar *text, double *value)
 {
   // TODO : verify the value is numeric
-  gchar *locale = g_strdup(setlocale(LC_ALL, NULL));
-  setlocale(LC_NUMERIC, "C");
-  *value = atof(text);
-  setlocale(LC_NUMERIC, locale);
-  g_free(locale);
+  // parse locale-independently (always '.' as decimal separator) without ever
+  // touching the global locale, which a background thread may be mutating via
+  // setlocale() (see the main-thread locale pin in dt_init())
+  *value = g_ascii_strtod(text, NULL);
   return TRUE;
 }
 static gchar *_default_print_date_func(const double value, const gboolean detailled)

--- a/src/lua/call.c
+++ b/src/lua/call.c
@@ -120,6 +120,9 @@ static void drop_thread(lua_State*L, int thread_num)
 
 static void run_async_thread_main(gpointer data,gpointer user_data)
 {
+  // glib thread-pool worker: pin a private locale so the gettext() calls made
+  // while running lua scripts cannot race a setlocale() on another thread
+  dt_pthread_setlocale();
   // lua lock ownership transferred from parent thread
   int thread_num = GPOINTER_TO_INT(data);
   lua_State*L = darktable.lua_state.state;
@@ -571,6 +574,9 @@ void dt_lua_async_call_string_internal(const char* function, int line,const char
 
 static gpointer lua_thread_main(gpointer data)
 {
+  // this glib thread runs the lua main loop and dispatches scripts; pin its
+  // locale too (see dt_pthread_setlocale())
+  dt_pthread_setlocale();
   darktable.lua_state.pool = g_thread_pool_new(run_async_thread_main,NULL,-1,false,NULL);
   darktable.lua_state.loop = g_main_loop_new(darktable.lua_state.context,false);
   g_main_loop_run(darktable.lua_state.loop);


### PR DESCRIPTION
Run dt_opencl_init synchronously on the main thread in the GUI path instead of as a background worker job.
This fix trades startup robustness and consistency between GUI and darktable-cli entrypoints for longer startup time and effectively reverts 0040492dde ("Don't block UI during opencl initialisation").

In the GUI path, OpenCL detection was queued as a job on the system worker pool (darktable.c:1890). dt_opencl_init loads the ICD loader and the GPU vendor drivers, which call setlocale() internally. setlocale() in glibc frees and rebuilds the global locale data structures and is not reentrant with the gettext() reads the main thread keeps making while loading modules and building the GUI (gtk_widget_show_all, the welcome screen). The concurrent write/read corrupts the locale heap, surfacing intermittently (~10-20% of startups) as either a SIGSEGV in early GUI construction or a "free(): invalid pointer" abort. The corruption is often latent: it lands during module loading and only crashes later, so it appears as a crash "after closing the welcome dialog".

This is the same class of bug as the earlier reorder of the JSON/gettext preset parsers (commit aecfb6d71d); that fix only protected the parsers immediately following the job enqueue, not the much larger gettext load of GUI construction that runs afterwards. The non-GUI path was always immune because it already calls dt_opencl_init synchronously.

Running OpenCL init on the main thread serializes the vendor-lib setlocale() with all gettext() calls, eliminating the race, and makes OpenCL ready before the GUI is built. This reverts the parallelism from commit 0040492dde ("Don't block UI during opencl initialisation"): the splash now shows "starting OpenCL" for the duration of detection.

The _detect_opencl_job_run/_detect_opencl_job_create helpers are removed as they are no longer used. Behavior is otherwise unchanged: the GUI job hardcoded print_statistics=TRUE, which is identical to the value for any non-cltest run.

---------

Here are the realistic alternatives, grouped by strategy, with why each does or doesn't hold up.

**A. Serialize the two operations (what I did with this fix)**

**A1.** Global mutex shared by the OpenCL job and all gettext. Hold a lock in the worker during dt_opencl_init and in the main thread around its
gettext.
- ❌ Impractical — gettext is invoked implicitly by every _() call everywhere; you can't wrap them all. If you only wrap the GUI-construction
phase, you've just reimplemented sequential execution with more moving parts and a worse failure mode.

**A2.** Join the job before GUI construction. Main thread waits for the OpenCL worker to finish before it starts module loading / show_all.
- ❌ The main thread is blocked for the whole detection anyway, so wall-clock and UX are identical to current approach — but with a pointless extra thread. No upside.

**B. Shrink the race window (mitigate, not eliminate)**

**B1.** Defer the job to after the gettext burst. Keep it async but enqueue it just before gtk_main(), after module loading, show_all, and the welcome
  screen.
- ✅ Preserves the parallelism; the dense gettext burst no longer overlaps driver loading; startup stays fast.
- ❌ Does not eliminate it — gettext keeps happening after the GUI is up (tooltips, lazy/dynamic labels, view switches), so a small overlap window
  with setlocale remains. Trades a clear correctness guarantee for "much rarer."
  
**C. Isolate the locale mutation**

**C1.** uselocale() (per-thread locale) on the worker. Doesn't work: the vendor drivers call the global setlocale(), which ignores our per-thread
uselocale(). We can't stop a third-party .so from touching global state.

**C2.** Pre-warm vendor libs on the main thread, then detect async. Trigger the dlopen + first clGetPlatformIDs/clGetDeviceInfo (which is what calls
setlocale) synchronously, then parallelize the rest.
- ❌ The setlocale happens deep inside driver init, which is most of the cost — so you'd serialize nearly all of it anyway, for a fragile, driver-dependent guess at "where the setlocale is." 

**C3.** Detect OpenCL in a separate process (like the existing darktable-cltest/cmstest). The subprocess loads the drivers; setlocale in another
process can't touch our locale heap.
- ✅ Fully isolates the race and keeps the main process responsive; reuses existing out-of-process tooling.
- ❌ Significant machinery: spawn, serialize device/capability results back over IPC, error/timeout handling. Much larger change than warranted for this bug.

**C4.** Interpose our own setlocale symbol that takes darktable's lock.
- ❌ ELF interposition is fragile and non-portable (won't catch already-resolved calls inside vendor libs, RTLD_LOCAL, Windows/macOS differences). Don't.

**Bottom line**

The only options that guarantee correctness is the current approach, A2 and C3 (subprocess). The current change is by far the smallest, most maintainable change and brings the GUI path in line with the already-proven CLI path — which is why it's the recommendation. If the ~1–2s splash extension turns out to be unacceptable on slow/multi-GPU systems, C3 (subprocess detection) is the principled way to get both speed and correctness; B1 (defer) is the cheap stopgap if you'll accept "much rarer instead of never."



This might fix https://github.com/darktable-org/darktable/issues/21035

Disclaimer: this work was co-created with Claude.