### PR TITLE
darkroom: fix viewport not refreshing on Win32 GDK backend

### DIFF
--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -476,6 +476,7 @@ static inline gboolean _full_request(dt_develop_t *dev)
   return
         dev->full.pipe->status == DT_DEV_PIXELPIPE_DIRTY
      || dev->full.pipe->status == DT_DEV_PIXELPIPE_INVALID
+     || dev->full.pipe->changed != DT_DEV_PIPE_UNCHANGED
      || dev->full.pipe->input_timestamp < dev->preview_pipe->input_timestamp;
 }
 
@@ -589,7 +590,8 @@ void expose(dt_view_t *self,
 
   const gboolean expose_full =
         port->pipe->backbuf                                // do we have an image?
-     && port->pipe->output_imgid == dev->image_storage.id; // same image?
+     && port->pipe->output_imgid == dev->image_storage.id  // same image?
+     && !port->pipe->loading;                              // not loading a new one?
 
   if(expose_full)
   {
@@ -603,9 +605,25 @@ void expose(dt_view_t *self,
     }
     if(!dt_conf_get_bool("darkroom/ui/loading_screen"))
     {
-      // cache the rendered bitmap for use while loading the next image
+      // Cache the rendered content for display while loading the next image.
+#ifdef _WIN32
+      // On the Win32 GDK backend, holding a cairo_surface_reference() to
+      // cairo_get_target(cri) prevents GTK from properly invalidating the
+      // widget surface, causing gtk_widget_queue_draw() to silently fail
+      // (issue #20831). Copy to a standalone image surface instead.
+      cairo_surface_t *target = cairo_get_target(cri);
+      if(width > 0 && height > 0)
+      {
+        darktable.gui->surface = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, width, height);
+        cairo_t *cr2 = cairo_create(darktable.gui->surface);
+        cairo_set_source_surface(cr2, target, 0, 0);
+        cairo_paint(cr2);
+        cairo_destroy(cr2);
+      }
+#else
       darktable.gui->surface = cairo_get_target(cri);
       cairo_surface_reference(darktable.gui->surface);
+#endif
     }
   }
   else if(dev->preview_pipe->output_imgid != dev->image_storage.id)
@@ -734,6 +752,12 @@ void expose(dt_view_t *self,
         cairo_set_source_surface(cri, darktable.gui->surface, 0, 0);
         cairo_paint(cri);
         cairo_restore(cri);
+      }
+      else
+      {
+        // No cached surface (first entry from lighttable) — paint background
+        dt_gui_gtk_set_source_rgb(cri, DT_GUI_COLOR_DARKROOM_BG);
+        cairo_paint(cri);
       }
       dt_toast_log("%s", load_txt);
     }
@@ -3593,6 +3617,23 @@ void leave(dt_view_t *self)
   dt_iop_color_picker_cleanup();
   if(darktable.lib->proxy.colorpicker.picker_proxy)
     dt_iop_color_picker_reset(darktable.lib->proxy.colorpicker.picker_proxy->module, FALSE);
+
+  // Clear cached surface so the loading screen shows on next darkroom entry
+  if(darktable.gui->surface)
+  {
+    cairo_surface_destroy(darktable.gui->surface);
+    darktable.gui->surface = NULL;
+  }
+
+  // Invalidate pipe output so expose_full is FALSE on next entry.
+  // Without this, re-opening the same image skips the loading screen
+  // because the stale backbuf + matching output_imgid makes expose_full TRUE.
+  dt_pthread_mutex_lock(&darktable.develop->full.pipe->backbuf_mutex);
+  g_free(darktable.develop->full.pipe->backbuf);
+  darktable.develop->full.pipe->backbuf = NULL;
+  darktable.develop->full.pipe->output_imgid = NO_IMGID;
+  dt_pthread_mutex_unlock(&darktable.develop->full.pipe->backbuf_mutex);
+  darktable.develop->preview_pipe->output_imgid = NO_IMGID;
 
   DT_CONTROL_SIGNAL_DISCONNECT_ALL(self, "darkroom");
 


### PR DESCRIPTION
On Windows (GTK 3.24.52, MSYS2/UCRT64), the darkroom viewport failed to redraw after zoom, pan, or overlay changes. The widget's draw handler was called but the content never appeared on screen until an external trigger (e.g. window move) forced a full surface recreation.

Root cause: commit 76ff82f556 ("fix regression in darkroom switching between images") introduced a cairo_surface_reference() to cairo_get_target(cri) — GTK's internal drawing surface — to cache the rendered image for smooth transitions when loading_screen is OFF. On the Win32 GDK backend this prevents GTK from properly invalidating the widget, causing gtk_widget_queue_draw() to silently fail.

The original double buffering via a standalone gui->surface was removed in 89764470fd ("remove unnecessary double buffering"). Commit 76ff82f556 re-introduced surface caching but took a shortcut by referencing GTK's target rather than maintaining a proper standalone surface.

Fix by copying the rendered content into a standalone cairo_image_surface instead of referencing GTK's internal target. Also:

- Add pipe->changed to _full_request() so the pipe is resubmitted when zoom/pan changes are pending, regardless of pipe status.
- Add !pipe->loading to expose_full condition to prevent displaying stale backbuf data while a new image is being loaded.
- Clear backbuf, output_imgid, and cached surface in leave() so re-entering darkroom starts with a clean state.
- Paint darkroom background when no cached surface is available (first entry from lighttable with loading_screen OFF).

Note: GTK overlay widgets (e.g. toast messages) may still composite against a stale backing store during the loading phase. This is a pre-existing GTK Win32 compositor limitation and is not addressed here.

Fixes #20831