### PR TITLE
pixelpipe_cache: hash export profile so consumers (e.g. agx) invalidate on change

### DIFF
--- a/src/common/iop_profile.c
+++ b/src/common/iop_profile.c
@@ -985,6 +985,19 @@ dt_ioppr_set_pipe_output_profile_info(struct dt_develop_t *dev,
   return profile_info;
 }
 
+dt_iop_order_iccprofile_info_t *
+dt_ioppr_set_pipe_export_profile_info(struct dt_develop_t *dev,
+                                      struct dt_dev_pixelpipe_t *pipe,
+                                      const dt_colorspaces_color_profile_type_t type,
+                                      const char *filename,
+                                      const int intent)
+{
+  dt_iop_order_iccprofile_info_t *profile_info =
+    dt_ioppr_add_profile_info_to_list(dev, type, filename, intent);
+  pipe->export_profile_info = profile_info;
+  return profile_info;
+}
+
 dt_iop_order_iccprofile_info_t *dt_ioppr_get_histogram_profile_info(struct dt_develop_t *dev)
 {
   dt_colorspaces_color_profile_type_t histogram_profile_type;

--- a/src/common/iop_profile.h
+++ b/src/common/iop_profile.h
@@ -115,6 +115,15 @@ dt_ioppr_set_pipe_output_profile_info(struct dt_develop_t *dev,
                                       const char *filename,
                                       const int intent);
 
+/** Record the export profile, used as a cache-identity tag. Returns the (possibly NULL)
+   interned profile-info pointer, no fallback for sRGB in case of failure. */
+dt_iop_order_iccprofile_info_t *
+dt_ioppr_set_pipe_export_profile_info(struct dt_develop_t *dev,
+                                      struct dt_dev_pixelpipe_t *pipe,
+                                      const dt_colorspaces_color_profile_type_t type,
+                                      const char *filename,
+                                      const int intent);
+
 /** returns a reference to the histogram profile info
  * histogram profile must not be cleanup()
  */

--- a/src/develop/pixelpipe_cache.c
+++ b/src/develop/pixelpipe_cache.c
@@ -125,6 +125,7 @@ static dt_hash_t _dev_pixelpipe_cache_basichash(dt_dev_pixelpipe_t *pipe,
   hash = dt_hash(hash, &pipe->input_profile_info, sizeof(pipe->input_profile_info));
   hash = dt_hash(hash, &pipe->work_profile_info, sizeof(pipe->work_profile_info));
   hash = dt_hash(hash, &pipe->output_profile_info, sizeof(pipe->output_profile_info));
+  hash = dt_hash(hash, &pipe->export_profile_info, sizeof(pipe->export_profile_info));
 
   // go through all modules up to position and compute a hash using the operation and params.
   GList *pieces = pipe->nodes;

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -291,6 +291,7 @@ gboolean dt_dev_pixelpipe_init_cached(dt_dev_pixelpipe_t *pipe,
   pipe->work_profile_info = NULL;
   pipe->input_profile_info = NULL;
   pipe->output_profile_info = NULL;
+  pipe->export_profile_info = NULL;
   pipe->runs = 0;
   pipe->bcache_data = NULL;
   pipe->bcache_hash = DT_INVALID_HASH;

--- a/src/develop/pixelpipe_hb.h
+++ b/src/develop/pixelpipe_hb.h
@@ -145,6 +145,8 @@ typedef struct dt_dev_pixelpipe_t
   struct dt_iop_order_iccprofile_info_t *input_profile_info;
   /** output profile info **/
   struct dt_iop_order_iccprofile_info_t *output_profile_info;
+  /** used only as a cache-identity tag to invalidate the cache **/
+  struct dt_iop_order_iccprofile_info_t *export_profile_info;
 
   // instances of pixelpipe, stored in GList of dt_dev_pixelpipe_iop_t
   GList *nodes;

--- a/src/iop/colorout.c
+++ b/src/iop/colorout.c
@@ -555,6 +555,9 @@ void commit_params(dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_
 
   d->type = p->type;
 
+  // to be used in pixel-pipe cache
+  dt_ioppr_set_pipe_export_profile_info(self->dev, piece->pipe, p->type, p->filename, p->intent);
+
   const gboolean force_lcms2 = dt_conf_get_bool("plugins/lighttable/export/force_lcms2");
 
   dt_colorspaces_color_profile_type_t out_type = DT_COLORSPACE_SRGB;


### PR DESCRIPTION
Added export_profile_info to dt_dev_pixelpipe_t (populated in iop_profile.c dt_ioppr_set_pipe_export_profile_info, which is called from colourout commit_params), used in pixelpipe_cache.c _dev_pixelpipe_cache_basichash, so the pipeline cache is invalidated and consumers (currently: only agx.c) are re-run.

Fixes #20526. Tested locally.