### PR TITLE
Stabilize filename hash

### DIFF
--- a/src/common/utility.c
+++ b/src/common/utility.c
@@ -356,6 +356,13 @@ size_t dt_utf8_strlcpy(char *dest,
   return s - src;
 }
 
+size_t dt_strlcpy_to_fixed(char *dest, const char *src, const size_t dest_size)
+{
+  memset(dest, 0, dest_size);
+  return g_strlcpy(dest, src, dest_size);
+}
+
+
 gboolean dt_util_test_image_file(const char *filename)
 {
   if(g_access(filename, R_OK)) return FALSE;

--- a/src/common/utility.h
+++ b/src/common/utility.h
@@ -64,6 +64,9 @@ gchar *dt_util_fix_path(const gchar *path);
 size_t dt_utf8_strlcpy(char *dest,
                        const char *src,
                        const size_t n);
+/** g_strlcpy variant that zero-fills the destination first, useful e.g.
+    to keep hash stable for IOP params filename fields */
+size_t dt_strlcpy_to_fixed(char *dest, const char *src, const size_t dest_size);
 /** returns true if a file is regular, has read access and a filesize > 0 */
 gboolean dt_util_test_image_file(const char *filename);
 /** returns true if the path represents a directory with write access */

--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -251,7 +251,7 @@ int legacy_params(dt_iop_module_t *self,
     else
     {
       new->type = DT_COLORSPACE_FILE;
-      g_strlcpy(new->filename, old->iccprofile, sizeof(new->filename));
+      dt_strlcpy_to_fixed(new->filename, old->iccprofile, sizeof(new->filename));
     }
 
     new->intent = old->intent;
@@ -308,7 +308,7 @@ int legacy_params(dt_iop_module_t *self,
     else
     {
       new->type = DT_COLORSPACE_FILE;
-      g_strlcpy(new->filename, old->iccprofile, sizeof(new->filename));
+      dt_strlcpy_to_fixed(new->filename, old->iccprofile, sizeof(new->filename));
     }
 
     new->intent = old->intent;
@@ -366,7 +366,7 @@ int legacy_params(dt_iop_module_t *self,
     else
     {
       new->type = DT_COLORSPACE_FILE;
-      g_strlcpy(new->filename, old->iccprofile, sizeof(new->filename));
+      dt_strlcpy_to_fixed(new->filename, old->iccprofile, sizeof(new->filename));
     }
 
     new->intent = old->intent;
@@ -396,7 +396,7 @@ int legacy_params(dt_iop_module_t *self,
     memset(new, 0, sizeof(*new));
 
     new->type = old->type;
-    g_strlcpy(new->filename, old->filename, sizeof(new->filename));
+    dt_strlcpy_to_fixed(new->filename, old->filename, sizeof(new->filename));
     new->intent = old->intent;
     new->normalize = old->normalize;
     new->blue_mapping = old->blue_mapping;
@@ -428,12 +428,12 @@ int legacy_params(dt_iop_module_t *self,
     memset(new, 0, sizeof(*new));
 
     new->type = old->type;
-    g_strlcpy(new->filename, old->filename, sizeof(new->filename));
+    dt_strlcpy_to_fixed(new->filename, old->filename, sizeof(new->filename));
     new->intent = old->intent;
     new->normalize = old->normalize;
     new->blue_mapping = old->blue_mapping;
     new->type_work = old->type_work;
-    g_strlcpy(new->filename_work, old->filename_work, sizeof(new->filename_work));
+    dt_strlcpy_to_fixed(new->filename_work, old->filename_work, sizeof(new->filename_work));
     _resolve_work_profile(&new->type_work, new->filename_work);
 
     *new_params = new;
@@ -544,7 +544,7 @@ static void _workicc_changed(GtkWidget *widget, dt_iop_module_t *self)
     if(pp->work_pos == pos)
     {
       type_work = pp->type;
-      g_strlcpy(filename_work, pp->filename, sizeof(filename_work));
+      dt_strlcpy_to_fixed(filename_work, pp->filename, sizeof(filename_work));
       break;
     }
   }
@@ -1255,8 +1255,8 @@ void commit_params(dt_iop_module_t *self,
 
   d->type = p->type;
   d->type_work = p->type_work;
-  g_strlcpy(d->filename, p->filename, sizeof(d->filename));
-  g_strlcpy(d->filename_work, p->filename_work, sizeof(d->filename_work));
+  dt_strlcpy_to_fixed(d->filename, p->filename, sizeof(d->filename));
+  dt_strlcpy_to_fixed(d->filename_work, p->filename_work, sizeof(d->filename_work));
 
   const cmsHPROFILE Lab =
     dt_colorspaces_get_profile(DT_COLORSPACE_LAB, "", DT_PROFILE_DIRECTION_ANY)->profile;

--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -24,6 +24,7 @@
 #include "common/colorspaces_inline_conversions.h"
 #include "common/image_cache.h"
 #include "common/opencl.h"
+#include "common/utility.h"
 #include "control/control.h"
 #include "develop/develop.h"
 #include "gui/gtk.h"
@@ -551,7 +552,7 @@ static void _workicc_changed(GtkWidget *widget, dt_iop_module_t *self)
   if(type_work != DT_COLORSPACE_NONE)
   {
     p->type_work = type_work;
-    g_strlcpy(p->filename_work, filename_work, sizeof(p->filename_work));
+    dt_strlcpy_to_fixed(p->filename_work, filename_work, sizeof(p->filename_work));
 
     const dt_iop_order_iccprofile_info_t *const work_profile =
       dt_ioppr_add_profile_info_to_list(self->dev, p->type_work,

--- a/src/iop/colorout.c
+++ b/src/iop/colorout.c
@@ -189,7 +189,7 @@ int legacy_params(dt_iop_module_t *self,
     else
     {
       n->type = DT_COLORSPACE_FILE;
-      g_strlcpy(n->filename, o->iccprofile, sizeof(n->filename));
+      dt_strlcpy_to_fixed(n->filename, o->iccprofile, sizeof(n->filename));
     }
 
     n->intent = o->intent;
@@ -214,7 +214,7 @@ int legacy_params(dt_iop_module_t *self,
     memset(n, 0, sizeof(dt_iop_colorout_params_v5_t));
 
     n->type = o->type;
-    g_strlcpy(n->filename, o->filename, sizeof(n->filename));
+    dt_strlcpy_to_fixed(n->filename, o->filename, sizeof(n->filename));
     n->intent = o->intent;
 
     *new_params = n;

--- a/src/iop/colorout.c
+++ b/src/iop/colorout.c
@@ -23,6 +23,7 @@
 #include "common/imagebuf.h"
 #include "common/iop_profile.h"
 #include "common/opencl.h"
+#include "common/utility.h"
 #include "control/conf.h"
 #include "control/control.h"
 #include "develop/develop.h"
@@ -262,7 +263,7 @@ static void output_profile_changed(GtkWidget *widget, dt_iop_module_t *self)
     if(pp->out_pos == pos)
     {
       p->type = pp->type;
-      g_strlcpy(p->filename, pp->filename, sizeof(p->filename));
+      dt_strlcpy_to_fixed(p->filename, pp->filename, sizeof(p->filename));
       dt_dev_add_history_item(darktable.develop, self, TRUE);
 
       DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_CONTROL_PROFILE_USER_CHANGED, DT_COLORSPACES_PROFILE_TYPE_EXPORT);
@@ -586,7 +587,7 @@ void commit_params(dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_
     if(pipe->icc_type != DT_COLORSPACE_NONE)
     {
       p->type = pipe->icc_type;
-      g_strlcpy(p->filename, pipe->icc_filename, sizeof(p->filename));
+      dt_strlcpy_to_fixed(p->filename, pipe->icc_filename, sizeof(p->filename));
     }
     if((unsigned int)pipe->icc_intent < DT_INTENT_LAST) p->intent = pipe->icc_intent;
 

--- a/src/iop/overlay.c
+++ b/src/iop/overlay.c
@@ -1032,6 +1032,9 @@ static void _drag_and_drop_received(GtkWidget *widget,
 
         dt_overlay_record(imgid_target_image, imgid_intended_overlay);
 
+        // zero-fill so trailing bytes of any previous image path do not bleed
+        // into piece->hash (params are hashed by full buffer length)
+        memset(p->filename, 0, sizeof(p->filename));
         dt_image_full_path(imgid_intended_overlay, p->filename, sizeof(p->filename), NULL);
 
         dt_dev_add_history_item(darktable.develop, self, TRUE);

--- a/src/iop/rasterfile.c
+++ b/src/iop/rasterfile.c
@@ -35,6 +35,7 @@
 #include "common/fast_guided_filter.h"
 #include "common/pfm.h"
 #include "common/ras2vect.h"
+#include "common/utility.h"
 #include "imageio/imageio_png.h"
 #include "gui/accelerators.h"
 #include "gui/gtk.h"
@@ -399,11 +400,11 @@ static void _fbutton_clicked(GtkWidget *widget, dt_iop_module_t *self)
     if(within)
     {
       char *relativepath = g_path_get_dirname(filepath);
-      g_strlcpy(p->path, relativepath, sizeof(p->path));
+      dt_strlcpy_to_fixed(p->path, relativepath, sizeof(p->path));
       g_free(relativepath);
 
       char *bname = g_path_get_basename(filepath);
-      g_strlcpy(p->file, bname, sizeof(p->file));
+      dt_strlcpy_to_fixed(p->file, bname, sizeof(p->file));
       g_free(bname);
 
       _update_filepath(self);
@@ -426,7 +427,7 @@ static void _file_callback(GtkWidget *widget, dt_iop_module_t *self)
 {
   dt_iop_rasterfile_params_t *p = self->params;
   const gchar *select = dt_bauhaus_combobox_get_text(widget);
-  g_strlcpy(p->file, select, sizeof(p->file));
+  dt_strlcpy_to_fixed(p->file, select, sizeof(p->file));
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 

--- a/src/iop/rasterfile.c
+++ b/src/iop/rasterfile.c
@@ -608,7 +608,7 @@ void commit_params(dt_iop_module_t *self,
 
   d->mode = p->mode;
   gchar *fullpath = g_build_filename(p->path, p->file, NULL);
-  g_strlcpy(d->filepath, fullpath, sizeof(d->filepath));
+  dt_strlcpy_to_fixed(d->filepath, fullpath, sizeof(d->filepath));
   g_free(fullpath);
 }
 

--- a/src/iop/watermark.c
+++ b/src/iop/watermark.c
@@ -22,6 +22,7 @@
 #include "common/tags.h"
 #include "common/variables.h"
 #include "common/datetime.h"
+#include "common/utility.h"
 #include "control/control.h"
 #include "develop/develop.h"
 #include "develop/imageop.h"
@@ -1095,11 +1096,10 @@ static void _watermark_callback(GtkWidget *tb,
 
   DT_GUARD_GUI_UPDATE();
   dt_iop_watermark_params_t *p = self->params;
-  memset(p->filename, 0, sizeof(p->filename));
   const int n = dt_bauhaus_combobox_get(g->watermarks);
-  g_strlcpy(p->filename,
-            (char *)g_list_nth_data(g->watermarks_filenames, n),
-            sizeof(p->filename));
+  dt_strlcpy_to_fixed(p->filename,
+                      (char *)g_list_nth_data(g->watermarks_filenames, n),
+                      sizeof(p->filename));
   _text_color_font_set_sensitive(g, p->filename);
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
@@ -1241,7 +1241,7 @@ static void _text_callback(GtkWidget *entry,
 {
   DT_GUARD_GUI_UPDATE();
   dt_iop_watermark_params_t *p = self->params;
-  g_strlcpy(p->text, gtk_entry_get_text(GTK_ENTRY(entry)), sizeof(p->text));
+  dt_strlcpy_to_fixed(p->text, gtk_entry_get_text(GTK_ENTRY(entry)), sizeof(p->text));
   dt_conf_set_string("plugins/darkroom/watermark/text", p->text);
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
@@ -1271,7 +1271,7 @@ static void _fontsel_callback(GtkWidget *button,
   dt_iop_watermark_params_t *p = self->params;
 
   gchar *fontname = gtk_font_chooser_get_font(GTK_FONT_CHOOSER(button));
-  g_strlcpy(p->font, fontname, sizeof(p->font));
+  dt_strlcpy_to_fixed(p->font, fontname, sizeof(p->font));
   g_free(fontname);
   dt_conf_set_string("plugins/darkroom/watermark/font", p->font);
   dt_dev_add_history_item(darktable.develop, self, TRUE);

--- a/src/iop/watermark.c
+++ b/src/iop/watermark.c
@@ -230,9 +230,11 @@ int legacy_params(dt_iop_module_t *self,
     n->alignment = o->alignment;
     n->rotate = 0.0;
     n->scale_base = DT_SCALE_MAINMENU_IMAGE;
-    g_strlcpy(n->filename, o->filename, sizeof(n->filename));
-    g_strlcpy(n->text, "", sizeof(n->text));
-    g_strlcpy(n->font, "DejaVu Sans 10", sizeof(n->font));
+    n->scale_img = DT_SCALE_IMG_LARGER;
+    n->scale_svg = DT_SCALE_SVG_WIDTH;
+    dt_strlcpy_to_fixed(n->filename, o->filename, sizeof(n->filename));
+    dt_strlcpy_to_fixed(n->text, "", sizeof(n->text));
+    dt_strlcpy_to_fixed(n->font, "DejaVu Sans 10", sizeof(n->font));
     n->color[0] = n->color[1] = n->color[2] = 0;
 
     *new_params = n;
@@ -267,10 +269,12 @@ int legacy_params(dt_iop_module_t *self,
     n->yoffset = o->yoffset;
     n->alignment = o->alignment;
     n->rotate = 0.0;
-    n->scale_base = DT_SCALE_MAINMENU_IMAGE;
-    g_strlcpy(n->filename, o->filename, sizeof(n->filename));
-    g_strlcpy(n->text, "", sizeof(n->text));
-    g_strlcpy(n->font, "DejaVu Sans 10", sizeof(n->font));
+    n->scale_base = (dt_iop_watermark_base_scale_t)o->sizeto;
+    n->scale_img = DT_SCALE_IMG_LARGER;
+    n->scale_svg = DT_SCALE_SVG_WIDTH;
+    dt_strlcpy_to_fixed(n->filename, o->filename, sizeof(n->filename));
+    dt_strlcpy_to_fixed(n->text, "", sizeof(n->text));
+    dt_strlcpy_to_fixed(n->font, "DejaVu Sans 10", sizeof(n->font));
     n->color[0] = n->color[1] = n->color[2] = 0;
 
     *new_params = n;
@@ -308,10 +312,11 @@ int legacy_params(dt_iop_module_t *self,
     n->alignment = o->alignment;
     n->rotate = o->rotate;
     n->scale_base = (dt_iop_watermark_base_scale_t)o->sizeto;
-    // let scale_img and scale_svg at the default values
-    g_strlcpy(n->filename, o->filename, sizeof(n->filename));
-    g_strlcpy(n->text, "", sizeof(n->text));
-    g_strlcpy(n->font, "DejaVu Sans 10", sizeof(n->font));
+    n->scale_img = DT_SCALE_IMG_LARGER;
+    n->scale_svg = DT_SCALE_SVG_WIDTH;
+    dt_strlcpy_to_fixed(n->filename, o->filename, sizeof(n->filename));
+    dt_strlcpy_to_fixed(n->text, "", sizeof(n->text));
+    dt_strlcpy_to_fixed(n->font, "DejaVu Sans 10", sizeof(n->font));
     n->color[0] = n->color[1] = n->color[2] = 0;
 
     *new_params = n;
@@ -355,10 +360,11 @@ int legacy_params(dt_iop_module_t *self,
     n->alignment = o->alignment;
     n->rotate = o->rotate;
     n->scale_base = (dt_iop_watermark_base_scale_t)o->sizeto;
-    // let scale_img and scale_svg at the default values
-    g_strlcpy(n->filename, o->filename, sizeof(n->filename));
-    g_strlcpy(n->text, o->text, sizeof(n->text));
-    g_strlcpy(n->font, o->font, sizeof(n->font));
+    n->scale_img = DT_SCALE_IMG_LARGER;
+    n->scale_svg = DT_SCALE_SVG_WIDTH;
+    dt_strlcpy_to_fixed(n->filename, o->filename, sizeof(n->filename));
+    dt_strlcpy_to_fixed(n->text, o->text, sizeof(n->text));
+    dt_strlcpy_to_fixed(n->font, o->font, sizeof(n->font));
     n->color[0] = o->color[0];
     n->color[1] = o->color[1];
     n->color[2] = o->color[2];
@@ -404,10 +410,11 @@ int legacy_params(dt_iop_module_t *self,
     n->alignment = o->alignment;
     n->rotate = o->rotate;
     n->scale_base = (dt_iop_watermark_base_scale_t)o->sizeto;
-    // let scale_img and scale_svg at the default values
-    g_strlcpy(n->filename, o->filename, sizeof(n->filename));
-    g_strlcpy(n->text, o->text, sizeof(n->text));
-    g_strlcpy(n->font, o->font, sizeof(n->font));
+    n->scale_img = DT_SCALE_IMG_LARGER;
+    n->scale_svg = DT_SCALE_SVG_WIDTH;
+    dt_strlcpy_to_fixed(n->filename, o->filename, sizeof(n->filename));
+    dt_strlcpy_to_fixed(n->text, o->text, sizeof(n->text));
+    dt_strlcpy_to_fixed(n->font, o->font, sizeof(n->font));
     n->color[0] = o->color[0];
     n->color[1] = o->color[1];
     n->color[2] = o->color[2];
@@ -431,9 +438,9 @@ int legacy_params(dt_iop_module_t *self,
     n->scale_base = o->scale_base;
     n->scale_img = o->scale_img;
     n->scale_svg = o->scale_svg;
-    g_strlcpy(n->filename, o->filename, sizeof(n->filename));
-    g_strlcpy(n->text, o->text, sizeof(n->text));
-    g_strlcpy(n->font, o->font, sizeof(n->font));
+    dt_strlcpy_to_fixed(n->filename, o->filename, sizeof(n->filename));
+    dt_strlcpy_to_fixed(n->text, o->text, sizeof(n->text));
+    dt_strlcpy_to_fixed(n->font, o->font, sizeof(n->font));
     n->color[0] = o->color[0];
     n->color[1] = o->color[1];
     n->color[2] = o->color[2];
@@ -1294,14 +1301,11 @@ void commit_params(dt_iop_module_t *self,
   d->scale_base = p->scale_base;
   d->scale_img = p->scale_img;
   d->scale_svg = p->scale_svg;
-  memset(d->filename, 0, sizeof(d->filename));
-  g_strlcpy(d->filename, p->filename, sizeof(d->filename));
-  memset(d->text, 0, sizeof(d->text));
-  g_strlcpy(d->text, p->text, sizeof(d->text));
+  dt_strlcpy_to_fixed(d->filename, p->filename, sizeof(d->filename));
+  dt_strlcpy_to_fixed(d->text, p->text, sizeof(d->text));
   for(int k=0; k<3; k++)
     d->color[k] = p->color[k];
-  memset(d->font, 0, sizeof(d->font));
-  g_strlcpy(d->font, p->font, sizeof(d->font));
+  dt_strlcpy_to_fixed(d->font, p->font, sizeof(d->font));
 
 // dt_print(DT_DEBUG_ALWAYS, "Commit params: %s...",d->filename);
 }
@@ -1380,8 +1384,8 @@ void init(dt_iop_module_t *self)
 
   dt_iop_watermark_params_t *d = self->default_params;
 
-  g_strlcpy(d->filename, "darktable.svg", sizeof(d->filename));
-  g_strlcpy(d->font, "DejaVu Sans 10", sizeof(d->font));
+  dt_strlcpy_to_fixed(d->filename, "darktable.svg", sizeof(d->filename));
+  dt_strlcpy_to_fixed(d->font, "DejaVu Sans 10", sizeof(d->font));
 }
 
 void gui_init(dt_iop_module_t *self)


### PR DESCRIPTION
- Cache stability: filename buffers in module->params were not zero-filled before g_strlcpy, so trailing junk bytes unpredictably shifted piece->hash even when the user reselected the same file. Added dt_strlcpy_to_fixed (memset + g_strlcpy). Applied to colorin, colorout, overlay, rasterfile, watermark (filename and font).
- Watermark legacy_params missing migration: v1–v5 -> v6 left scale_img and scale_svg uninitialised (malloc'd params, comment claimed "default values" but none were ever set). Now set to DT_SCALE_IMG_LARGER / DT_SCALE_SVG_WIDTH (current defaults in dt_iop_watermark_params_t).
- Watermark legacy_params suspicious migration: v2 already has sizeto, but v2 -> v6 hard-coded scale_base = DT_SCALE_MAINMENU_IMAGE. v3/v4/v5 assign scale_base from o->sizeto; now v2->v6 does that, too.
