### PR TITLE
[innosetup] Add icon to right-click context menu items for darktable

### DIFF
--- a/packaging/windows/darktable.iss.in
+++ b/packaging/windows/darktable.iss.in
@@ -122,6 +122,9 @@ Source: "LICENSE";  DestDir: "{app}"; DestName: "LICENSE.txt"; Flags: ignorevers
 Root: HKA; Subkey: "SOFTWARE\Classes\Directory\shell\ImportFolderIntoDarktable"; \
   ValueType: string; Flags: uninsdeletekey; \
   ValueData: "Import folder into darktable"
+Root: HKA; Subkey: "SOFTWARE\Classes\Directory\shell\ImportFolderIntoDarktable"; \
+  ValueType: string; Flags: uninsdeletekey; \
+  ValueName: "Icon"; ValueData: """{app}\bin\{#MyAppExeName}"",0"
 Root: HKA; Subkey: "SOFTWARE\Classes\Directory\shell\ImportFolderIntoDarktable\command"; \
   ValueType: string; Flags: uninsdeletekey; \
   ValueData: """{app}\bin\{#MyAppExeName}"" ""%1"""
@@ -133,6 +136,9 @@ Root: HKA; Subkey: "SOFTWARE\Classes\Directory\shell\ImportFolderIntoDarktable\c
 Root: HKA; Subkey: "SOFTWARE\Classes\*\shell\ImportImageIntoDarktable"; \
   ValueType: string; Flags: uninsdeletekey; \
   ValueData: "Import into darktable"
+Root: HKA; Subkey: "SOFTWARE\Classes\*\shell\ImportImageIntoDarktable"; \
+  ValueType: string; Flags: uninsdeletekey; \
+  ValueName: "Icon"; ValueData: """{app}\bin\{#MyAppExeName}"",0"
 Root: HKA; Subkey: "SOFTWARE\Classes\*\shell\ImportImageIntoDarktable"; \
   ValueType: string; Flags: uninsdeletekey; \
   ValueName: "AppliesTo"; ValueData: "System.Kind:=picture"


### PR DESCRIPTION
This is just polishing the darktable integration on Windows. Follow-up to #21109, adding an icon to the darktable item in the context menu.

This is obviously safe, the worst that can happen if it's not done correctly is that the added icon won't actually appear in the menu (i.e., as if this code were not in the registry). However, I tested this on Windows 11 and at least on my system it works.