### PR TITLE
Opencl per device configs

### DIFF
--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -341,7 +341,7 @@ unsigned int dt_opencl_tiling_align(const int devid)
   return 4;
 }
 
-void dt_opencl_write_device_config(const int devid)
+static void _opencl_write_device_config(const int devid)
 {
   if(devid <= DT_DEVICE_CPU) return;
 
@@ -366,7 +366,7 @@ void dt_opencl_write_device_config(const int devid)
     cl->dev[devid].advantage,
     cl->dev[devid].unified_fraction);
   dt_print_nts(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE,
-           "\n[dt_opencl_write_device_config] writing data '%s' for '%s'\n", dat, key);
+           "\n[opencl_write_device_config] writing data '%s' for '%s'\n", dat, key);
   dt_conf_set_string(key, dat);
   setlocale(LC_NUMERIC, locale);
 
@@ -376,11 +376,11 @@ void dt_opencl_write_device_config(const int devid)
   g_snprintf(key, 254, "%s%s_id%i", DT_CLDEVICE_HEAD, cl->dev[devid].cname, devid);
   g_snprintf(dat, 510, "%i", cl->dev[devid].headroom);
   dt_print_nts(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE,
-           "[dt_opencl_write_device_config] writing data '%s' for '%s'\n", dat, key);
+           "[opencl_write_device_config] writing data '%s' for '%s'\n", dat, key);
   dt_conf_set_string(key, dat);
 }
 
-gboolean dt_opencl_read_device_config(const int devid)
+static gboolean _opencl_read_device_config(const int devid)
 {
   if(devid <= DT_DEVICE_CPU) return FALSE;
 
@@ -439,7 +439,7 @@ gboolean dt_opencl_read_device_config(const int devid)
   else // this is used if updating to 4.0 or fresh installs; see
        // commenting _opencl_get_unused_device_mem()
     cldid->headroom = DT_OPENCL_DEFAULT_HEADROOM;
-  dt_opencl_write_device_config(devid);
+  _opencl_write_device_config(devid);
   return !existing_device || !safety_ok;
 }
 
@@ -642,7 +642,7 @@ static gboolean _opencl_device_init(dt_opencl_t *cl,
   cl->dev[dev].cname = strdup(cname);
   cl->dev[dev].vendor_id = vendor_id;
 
-  const gboolean newdevice = dt_opencl_read_device_config(dev);
+  const gboolean newdevice = _opencl_read_device_config(dev);
   dt_print_nts(DT_DEBUG_OPENCL,
                "\n   DEVICE:                   %d: '%s'%s\n",
                k, device_name, (newdevice) ? ", NEW" : "" );
@@ -1029,7 +1029,7 @@ static gboolean _opencl_device_init(dt_opencl_t *cl,
   if(newdevice) // so far the device seems to be ok. Make sure to
                 // write&export the conf database to
   {
-    dt_opencl_write_device_config(dev);
+    _opencl_write_device_config(dev);
     dt_conf_save(darktable.conf);
   }
 
@@ -1125,7 +1125,7 @@ static gboolean _opencl_device_init(dt_opencl_t *cl,
 
 end:
   // we always write the device config to keep track of disabled devices
-  dt_opencl_write_device_config(dev);
+  _opencl_write_device_config(dev);
 
   if(res)
     dt_pthread_mutex_destroy(&cl->dev[dev].lock);
@@ -1747,7 +1747,6 @@ static int _take_from_list(int *list,
 
   return result;
 }
-
 
 static int _device_by_cname(const char *name)
 {

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -1028,7 +1028,6 @@ static gboolean _opencl_device_init(dt_opencl_t *cl,
                 // write&export the conf database to
   {
     _opencl_write_device_config(dev);
-    dt_conf_save(darktable.conf);
   }
 
   // now load all darktable cl kernels.

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -345,17 +345,13 @@ static void _opencl_write_device_config(const int devid)
 {
   if(devid <= DT_DEVICE_CPU) return;
 
-  /* As we have floats as per-device parameters we keep track of current locale
-     and do conversions via "C" here and while reading device config
-  */
-  gchar *locale = g_strdup(setlocale(LC_ALL, NULL));
-  setlocale(LC_NUMERIC, "C");
-
   dt_opencl_t *cl = darktable.opencl;
+  const float adv = floorf(cl->dev[devid].advantage);
+
   gchar key[256] = { 0 };
   gchar dat[512] = { 0 };
   g_snprintf(key, 254, "%s%s", DT_CLDEVICE_HEAD, cl->dev[devid].cname);
-  g_snprintf(dat, 510, "%i %i %i %i %i %.3f %.3f",
+  g_snprintf(dat, 510, "%i %i %i %i %i %i.%03i 0.%03i",
     cl->dev[devid].micro_nap,
     cl->dev[devid].pinned_memory,
 
@@ -363,12 +359,12 @@ static void _opencl_write_device_config(const int devid)
     cl->dev[devid].use_events ? 1 : 0,
     cl->dev[devid].asyncmode,
     cl->dev[devid].disabled,
-    cl->dev[devid].advantage,
-    cl->dev[devid].unified_fraction);
+    (int)(adv),
+    (int)(1000.0f * (cl->dev[devid].advantage - adv)),
+    (int)(1000.0f * cl->dev[devid].unified_fraction));
   dt_print_nts(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE,
            "\n[opencl_write_device_config] writing data '%s' for '%s'\n", dat, key);
   dt_conf_set_string(key, dat);
-  setlocale(LC_NUMERIC, locale);
 
   // Also take care of extended device data, these are not only device
   // specific but also depend on the devid to support systems with two
@@ -384,9 +380,6 @@ static gboolean _opencl_read_device_config(const int devid)
 {
   if(devid <= DT_DEVICE_CPU) return FALSE;
 
-  gchar *locale = g_strdup(setlocale(LC_ALL, NULL));
-  setlocale(LC_NUMERIC, "C");
-
   dt_opencl_t *cl = darktable.opencl;
   dt_opencl_device_t *cldid = &cl->dev[devid];
   gchar key[256] = { 0 };
@@ -396,27 +389,32 @@ static gboolean _opencl_read_device_config(const int devid)
   gboolean safety_ok = TRUE;
   if(existing_device)
   {
+    /* The per-device conf string includes two floats, to avoid conflicts with
+       the different dot/comma representations depending on current locale we
+       read the different parts of the float string as ints using dummys for
+       separation. Also see the conf writing equivalent above.
+    */
     const gchar *dat = dt_conf_get_string_const(key);
+    char dummy;
     int micro_nap;
     int pinned_memory;
     int events;
     int asyncmode;
     int disabled;
-    float advantage;
-    float unified_fraction;
-    sscanf(dat, "%i %i %i %i %i %f %f",
-           &micro_nap, &pinned_memory, &events, &asyncmode, &disabled, &advantage, &unified_fraction);
+    int advantage1;
+    int advantage2;
+    int unified_fraction;
+    sscanf(dat, "%i %i %i %i %i %d %c %d %c %c %d",
+           &micro_nap, &pinned_memory, &events, &asyncmode, &disabled, &advantage1, &dummy, &advantage2, &dummy, &dummy, &unified_fraction);
 
     cldid->use_events = events ? TRUE : FALSE;
     cldid->micro_nap = micro_nap;
     cldid->pinned_memory = pinned_memory ? TRUE : FALSE;
     cldid->asyncmode = asyncmode ? TRUE : FALSE;
     cldid->disabled = disabled ? TRUE : FALSE;
-    cldid->advantage = advantage;
-    cldid->unified_fraction = unified_fraction;
-    setlocale(LC_NUMERIC, locale);
+    cldid->advantage = (float)advantage1 + 0.001f * (float)advantage2;
+    cldid->unified_fraction = 0.001f * (float)unified_fraction;
   }
-
 
   // do some safety housekeeping
   if((cldid->unified_fraction < 0.05f) || (cldid->unified_fraction > 0.5f))
@@ -1585,8 +1583,9 @@ finally:
         cl->dev[i].max_global_mem = reserved;
         cl->dev[i].max_mem_alloc = MIN(cl->dev[i].max_mem_alloc, reserved);
         dt_print_nts(DT_DEBUG_OPENCL,
-               "   UNIFIED MEM SIZE:         %.0f MB reserved for '%s' id=%d\n",
-               (double)reserved / 1024.0 / 1024.0, cl->dev[i].cname, i);
+               "   UNIFIED MEM SIZE:         %.0f MB (%i%%) reserved for '%s' id=%d\n",
+               (double)reserved / 1024.0 / 1024.0, (int)(100.0f * cl->dev[i].unified_fraction),
+               cl->dev[i].cname, i);
         res->total_memory -= reserved;
       }
     }

--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -602,8 +602,6 @@ cl_int dt_opencl_local_buffer_opt(const int devid,
                                   dt_opencl_local_buffer_t *factors);
 
 /** utility functions handling device specific properties */
-void dt_opencl_write_device_config(const int devid);
-gboolean dt_opencl_read_device_config(const int devid);
 gboolean dt_opencl_avoid_atomics(const int devid);
 void dt_opencl_micro_nap(const int devid);
 gboolean dt_opencl_use_pinned_memory(const int devid);

--- a/src/control/conf.c
+++ b/src/control/conf.c
@@ -906,7 +906,7 @@ static void _conf_print(const gchar *key, const gchar *val, FILE *f)
   fprintf(f, "%s=%s\n", key, val);
 }
 
-void dt_conf_save(dt_conf_t *cf)
+static void _conf_save(dt_conf_t *cf)
 {
   FILE *fc = g_fopen(cf->filename_common, "wb");
   FILE *fs = g_fopen(cf->filename, "wb");
@@ -932,7 +932,7 @@ void dt_conf_save(dt_conf_t *cf)
 }
 void dt_conf_cleanup(dt_conf_t *cf)
 {
-  dt_conf_save(cf);
+  _conf_save(cf);
   g_hash_table_unref(cf->table);
   g_hash_table_unref(cf->override_entries);
   g_hash_table_unref(cf->x_confgen);

--- a/src/control/conf.h
+++ b/src/control/conf.h
@@ -110,7 +110,6 @@ void dt_conf_init(dt_conf_t *cf,
                   const gboolean is_common,
                   GSList *override_entries);
 void dt_conf_cleanup(dt_conf_t *cf);
-void dt_conf_save(dt_conf_t *cf);
 gboolean dt_conf_key_exists(const char *key);
 void dt_conf_remove_key(const char *key);
 gboolean dt_conf_key_not_empty(const char *key);


### PR DESCRIPTION
1. Make OpenCL device read&write configs static and don't expose outside
2. **Avoid use of `locale` while reading/writing OpenCL device configs**
Instead of reading/writing floats we do it using integers and fiddle a bit using `snprintf()` and `sscanf()`. This is safe as we know the floating point representation of the data in the conf string and avoids fiddling with locales.

@TurboGit @da-phil  the use of locales in this part of code is certainly part of the problem we have when initializing dt OpenCL so high priority.

 @TurboGit in general we might need to look in depth into conf strings related to floats. If you look at the config file some are represented with dots, some with comma. Not sure if we always get the correct value if there is a mismatch.  