### PR TITLE
AI subsystem: review fixes

### DIFF
--- a/src/ai/backend.h
+++ b/src/ai/backend.h
@@ -60,6 +60,13 @@ extern const dt_ai_provider_desc_t dt_ai_providers[DT_AI_PROVIDER_COUNT];
 /** Config key for the AI execution provider preference */
 #define DT_AI_CONF_PROVIDER "plugins/ai/provider"
 
+/* CoreML EP flag bits, mirroring values from ORT's
+ * coreml_provider_factory.h. defined here so the backend layer doesn't
+ * need to drag the EP header into either file; single source of truth
+ * if Apple ever renumbers the enum. */
+#define DT_COREML_FLAG_USE_CPU_ONLY     0x001u
+#define DT_COREML_FLAG_CREATE_MLPROGRAM 0x010u
+
 /** Get display name for a provider enum value */
 const char *dt_ai_provider_to_string(dt_ai_provider_t provider);
 

--- a/src/ai/backend.h
+++ b/src/ai/backend.h
@@ -52,7 +52,7 @@ typedef struct dt_ai_provider_desc_t {
   dt_ai_provider_t value;
   const char *config_string;
   const char *display_name;
-  int available;
+  gboolean available;
 } dt_ai_provider_desc_t;
 
 extern const dt_ai_provider_desc_t dt_ai_providers[DT_AI_PROVIDER_COUNT];
@@ -78,8 +78,10 @@ guint dt_ai_providers_from_eps(const char *eps);
 guint dt_ai_providers_bundled(void);
 
 /** Snapshot the conf state (ORT path, provider, device ids) for the
- *  *_changed_since_load() helpers.  Call once at darktable startup so
- *  the snapshot is independent of when ORT is lazily initialized. */
+ *  *_changed_since_load() helpers. Idempotent — subsequent calls are
+ *  no-ops. Recommended to call once at darktable startup so the
+ *  snapshot reflects pre-modification state; if forgotten, the
+ *  *_changed_since_load() helpers auto-snapshot on first use. */
 void dt_ai_snapshot_conf_state(void);
 
 /** Free heap-allocated backend globals (cached strings, conf snapshot).
@@ -382,6 +384,14 @@ typedef struct dt_ai_tensor_t {
   int64_t *shape;     ///< Array of dimensions
   int ndim;           ///< Number of dimensions
 } dt_ai_tensor_t;
+
+/**
+ * @brief Number of elements implied by a shape (product of all dims).
+ *        Multiply by the element size (sizeof(float), etc.) to get
+ *        the buffer byte length. Returns 0 if any dim is non-positive
+ *        or if ndim is 0.
+ */
+size_t dt_ai_tensor_element_count(const int64_t *shape, int ndim);
 
 /**
  * @brief Run inference through the loaded model.

--- a/src/ai/backend.h
+++ b/src/ai/backend.h
@@ -323,7 +323,7 @@ dt_ai_provider_t dt_ai_env_get_provider(dt_ai_environment_t *env);
 dt_ai_context_t *dt_ai_load_model(dt_ai_environment_t *env,
                                   const char *model_id,
                                   const char *model_file,
-                                  dt_ai_provider_t provider);
+                                  const dt_ai_provider_t provider);
 
 /**
  * @brief Symbolic dimension override for models with dynamic shapes.
@@ -358,10 +358,10 @@ typedef struct {
 dt_ai_context_t *dt_ai_load_model_ext(dt_ai_environment_t *env,
                                        const char *model_id,
                                        const char *model_file,
-                                       dt_ai_provider_t provider,
-                                       dt_ai_opt_level_t opt_level,
+                                       const dt_ai_provider_t provider,
+                                       const dt_ai_opt_level_t opt_level,
                                        const dt_ai_dim_override_t *dim_overrides,
-                                       int n_overrides);
+                                       const int n_overrides);
 
 /**
  * @brief Tensor Data Types
@@ -398,7 +398,7 @@ typedef struct dt_ai_tensor_t {
  *        the buffer byte length. Returns 0 if any dim is non-positive
  *        or if ndim is 0.
  */
-size_t dt_ai_tensor_element_count(const int64_t *shape, int ndim);
+size_t dt_ai_tensor_element_count(const int64_t *shape, const int ndim);
 
 /**
  * @brief Run inference through the loaded model.

--- a/src/ai/backend.h
+++ b/src/ai/backend.h
@@ -340,9 +340,6 @@ typedef struct {
  * @param opt_level Graph optimization level.
  * @param dim_overrides Array of symbolic dimension overrides (NULL = none).
  * @param n_overrides Number of overrides.
- * @param ep_flags EP-specific flag bitmask. Callers should pass 0; the
- *                 load function adds bits internally based on the model's
- *                 cpu_only declaration (e.g. COREML_FLAG_USE_CPU_ONLY).
  * @return dt_ai_context_t* Context ready for inference, or NULL.
  */
 dt_ai_context_t *dt_ai_load_model_ext(dt_ai_environment_t *env,
@@ -351,8 +348,7 @@ dt_ai_context_t *dt_ai_load_model_ext(dt_ai_environment_t *env,
                                        dt_ai_provider_t provider,
                                        dt_ai_opt_level_t opt_level,
                                        const dt_ai_dim_override_t *dim_overrides,
-                                       int n_overrides,
-                                       uint32_t ep_flags);
+                                       int n_overrides);
 
 /**
  * @brief Tensor Data Types

--- a/src/ai/backend.h
+++ b/src/ai/backend.h
@@ -318,6 +318,10 @@ dt_ai_context_t *dt_ai_load_model(dt_ai_environment_t *env,
 
 /**
  * @brief Symbolic dimension override for models with dynamic shapes.
+ *
+ * The `name` pointer is only read during the dt_ai_load_model_ext call
+ * — the backend copies anything it needs to keep. Caller may free the
+ * string (or let it go out of scope) immediately after load returns.
  */
 typedef struct {
   const char *name;  ///< Symbolic dimension name (e.g. "num_labels")
@@ -363,7 +367,14 @@ typedef enum {
 } dt_ai_dtype_t;
 
 /**
- * @brief Tensor descriptor for I/O
+ * @brief Tensor descriptor for I/O.
+ *
+ * No explicit byte-size field — the buffer length is implied by
+ * `shape[0] * shape[1] * ... * shape[ndim-1] * sizeof(elem)` where
+ * `sizeof(elem)` is derived from `type`. Caller owns the buffer and
+ * is responsible for allocating enough space. Both `data` and `shape`
+ * pointers are borrowed for the duration of dt_ai_run; the backend
+ * does not copy them.
  */
 typedef struct dt_ai_tensor_t {
   void *data;         ///< Pointer to raw data buffer

--- a/src/ai/backend_common.c
+++ b/src/ai/backend_common.c
@@ -447,7 +447,7 @@ static dt_ai_provider_t _resolve_provider(dt_ai_provider_t configured,
 dt_ai_context_t *dt_ai_load_model(dt_ai_environment_t *env,
                                   const char *model_id,
                                   const char *model_file,
-                                  dt_ai_provider_t provider)
+                                  const dt_ai_provider_t provider)
 {
   return dt_ai_load_model_ext(env, model_id, model_file, provider,
                               DT_AI_OPT_ALL, NULL, 0);
@@ -456,10 +456,10 @@ dt_ai_context_t *dt_ai_load_model(dt_ai_environment_t *env,
 dt_ai_context_t *dt_ai_load_model_ext(dt_ai_environment_t *env,
                                       const char *model_id,
                                       const char *model_file,
-                                      dt_ai_provider_t provider,
-                                      dt_ai_opt_level_t opt_level,
+                                      const dt_ai_provider_t provider,
+                                      const dt_ai_opt_level_t opt_level,
                                       const dt_ai_dim_override_t *dim_overrides,
-                                      int n_overrides)
+                                      const int n_overrides)
 {
   if(!env || !model_id)
     return NULL;
@@ -478,8 +478,9 @@ dt_ai_context_t *dt_ai_load_model_ext(dt_ai_environment_t *env,
   uint32_t ep_flags = 0;
   const dt_ai_model_info_t *model_info
     = dt_ai_get_model_info_by_id(env, model_id);
-  provider = _resolve_provider(provider, model_id, model_info,
-                               model_file, &ep_flags);
+  const dt_ai_provider_t resolved
+    = _resolve_provider(provider, model_id, model_info,
+                        model_file, &ep_flags);
 
   g_mutex_lock(&env->lock);
   const char *model_dir_orig
@@ -510,7 +511,7 @@ dt_ai_context_t *dt_ai_load_model_ext(dt_ai_environment_t *env,
 
   if(strcmp(backend_copy, "onnx") == 0)
   {
-    ctx = dt_ai_onnx_load_ext(model_dir, model_file, provider, opt_level,
+    ctx = dt_ai_onnx_load_ext(model_dir, model_file, resolved, opt_level,
                                dim_overrides, n_overrides, ep_flags);
   }
   else
@@ -956,7 +957,7 @@ const char *dt_ai_provider_to_string(dt_ai_provider_t provider)
   return dt_ai_providers[0].display_name;  // fallback to "auto"
 }
 
-size_t dt_ai_tensor_element_count(const int64_t *shape, int ndim)
+size_t dt_ai_tensor_element_count(const int64_t *shape, const int ndim)
 {
   if(!shape || ndim <= 0) return 0;
   size_t n = 1;

--- a/src/ai/backend_common.c
+++ b/src/ai/backend_common.c
@@ -927,6 +927,18 @@ const char *dt_ai_provider_to_string(dt_ai_provider_t provider)
   return dt_ai_providers[0].display_name;  // fallback to "auto"
 }
 
+size_t dt_ai_tensor_element_count(const int64_t *shape, int ndim)
+{
+  if(!shape || ndim <= 0) return 0;
+  size_t n = 1;
+  for(int i = 0; i < ndim; i++)
+  {
+    if(shape[i] <= 0) return 0;
+    n *= (size_t)shape[i];
+  }
+  return n;
+}
+
 dt_ai_provider_t dt_ai_provider_from_string(const char *str)
 {
   if(!str)

--- a/src/ai/backend_common.c
+++ b/src/ai/backend_common.c
@@ -641,7 +641,16 @@ int *dt_ai_model_attribute_int_array(const dt_ai_model_info_t *info,
   if(v && JSON_NODE_HOLDS_ARRAY(v))
   {
     JsonArray *arr = json_node_get_array(v);
-    const guint n = json_array_get_length(arr);
+    guint n = json_array_get_length(arr);
+    // cap manifest-driven allocation — single digits are typical
+    const guint max_n = 256;
+    if(n > max_n)
+    {
+      dt_print(DT_DEBUG_AI,
+               "[darktable_ai] attribute '%s': %u elements exceeds cap %u, "
+               "truncating", key, n, max_n);
+      n = max_n;
+    }
     if(n > 0)
     {
       result = g_new(int, n);
@@ -685,7 +694,8 @@ static gboolean _provider_cpu_only(const dt_ai_model_info_t *info,
 
   JsonParser *parser = json_parser_new();
   gboolean result = FALSE;
-  if(json_parser_load_from_data(parser, info->cpu_only, -1, NULL))
+  GError *err = NULL;
+  if(json_parser_load_from_data(parser, info->cpu_only, -1, &err))
   {
     JsonNode *root = json_parser_get_root(parser);
 
@@ -728,6 +738,15 @@ static gboolean _provider_cpu_only(const dt_ai_model_info_t *info,
     }
     g_free(stem);
   }
+  else if(err)
+  {
+    // malformed cpu_only silently disables the EP safety constraint
+    dt_print(DT_DEBUG_ALWAYS,
+             "[darktable_ai] model '%s': malformed cpu_only JSON (%s) — "
+             "EP safety constraint ignored",
+             info->id ? info->id : "?", err->message);
+    g_error_free(err);
+  }
   g_object_unref(parser);
   return result;
 }
@@ -743,7 +762,8 @@ static gboolean _coreml_use_mlprogram(const dt_ai_model_info_t *info,
 
   JsonParser *parser = json_parser_new();
   gboolean use_mlprogram = FALSE;
-  if(json_parser_load_from_data(parser, info->coreml_format, -1, NULL))
+  GError *err = NULL;
+  if(json_parser_load_from_data(parser, info->coreml_format, -1, &err))
   {
     JsonNode *root = json_parser_get_root(parser);
     const char *value = NULL;
@@ -770,6 +790,14 @@ static gboolean _coreml_use_mlprogram(const dt_ai_model_info_t *info,
     if(value && !g_ascii_strcasecmp(value, "mlprogram"))
       use_mlprogram = TRUE;
     g_free(stem);
+  }
+  else if(err)
+  {
+    dt_print(DT_DEBUG_ALWAYS,
+             "[darktable_ai] model '%s': malformed coreml_format JSON (%s) — "
+             "falling back to NeuralNetwork",
+             info->id ? info->id : "?", err->message);
+    g_error_free(err);
   }
   g_object_unref(parser);
   return use_mlprogram;

--- a/src/ai/backend_common.c
+++ b/src/ai/backend_common.c
@@ -846,15 +846,16 @@ static dt_ai_provider_t _resolve_provider(dt_ai_provider_t configured,
   {
     int n = 0;
     const dt_ai_provider_t *cands = _auto_candidates(&n);
-    // single-candidate platforms (macOS, Windows) skip the probe — the
-    // bundled ORT always supports the platform EP, and if it doesn't,
-    // the load fallback chain in dt_ai_onnx_load_ext demotes to CPU
-    const gboolean skip_probe = (n == 1);
+    // probe every candidate — even single-candidate platforms (macOS,
+    // Windows). assuming the bundled EP is present breaks when a user
+    // points plugins/ai/ort_library_path at a non-bundled or CPU-only
+    // ORT. dt_ai_probe_provider memoizes its result, so the cost is
+    // a single _try_provider call per EP per process
     gboolean resolved = FALSE;
     for(int i = 0; i < n && !resolved; i++)
     {
       const dt_ai_provider_t c = cands[i];
-      if(!skip_probe && !dt_ai_probe_provider(c)) continue;
+      if(!dt_ai_probe_provider(c)) continue;
       const gboolean banned = _provider_cpu_only(info, model_file, c);
       if(!banned)
       {

--- a/src/ai/backend_common.c
+++ b/src/ai/backend_common.c
@@ -867,7 +867,7 @@ static dt_ai_provider_t _resolve_provider(dt_ai_provider_t configured,
       }
       else if(c == DT_AI_PROVIDER_COREML)
       {
-        *inout_ep_flags |= 1;  // COREML_FLAG_USE_CPU_ONLY
+        *inout_ep_flags |= DT_COREML_FLAG_USE_CPU_ONLY;
         dt_print(DT_DEBUG_AI,
                  "[darktable_ai] provider auto -> %s (cpu compute units) "
                  "for %s — model prefers CPU on %s",
@@ -890,7 +890,7 @@ static dt_ai_provider_t _resolve_provider(dt_ai_provider_t configured,
     // concrete EP banned by cpu_only
     if(configured == DT_AI_PROVIDER_COREML)
     {
-      *inout_ep_flags |= 1;  // COREML_FLAG_USE_CPU_ONLY
+      *inout_ep_flags |= DT_COREML_FLAG_USE_CPU_ONLY;
       dt_print(DT_DEBUG_AI,
                "[darktable_ai] %s prefers CPU on %s — using CoreML CPU "
                "compute units",
@@ -911,7 +911,7 @@ static dt_ai_provider_t _resolve_provider(dt_ai_provider_t configured,
 
   if(result == DT_AI_PROVIDER_COREML
      && _coreml_use_mlprogram(info, model_file))
-    *inout_ep_flags |= 16;  // COREML_FLAG_CREATE_MLPROGRAM
+    *inout_ep_flags |= DT_COREML_FLAG_CREATE_MLPROGRAM;
 
   return result;
 }

--- a/src/ai/backend_common.c
+++ b/src/ai/backend_common.c
@@ -450,7 +450,7 @@ dt_ai_context_t *dt_ai_load_model(dt_ai_environment_t *env,
                                   dt_ai_provider_t provider)
 {
   return dt_ai_load_model_ext(env, model_id, model_file, provider,
-                              DT_AI_OPT_ALL, NULL, 0, 0);
+                              DT_AI_OPT_ALL, NULL, 0);
 }
 
 dt_ai_context_t *dt_ai_load_model_ext(dt_ai_environment_t *env,
@@ -459,8 +459,7 @@ dt_ai_context_t *dt_ai_load_model_ext(dt_ai_environment_t *env,
                                       dt_ai_provider_t provider,
                                       dt_ai_opt_level_t opt_level,
                                       const dt_ai_dim_override_t *dim_overrides,
-                                      int n_overrides,
-                                      uint32_t ep_flags)
+                                      int n_overrides)
 {
   if(!env || !model_id)
     return NULL;
@@ -473,9 +472,10 @@ dt_ai_context_t *dt_ai_load_model_ext(dt_ai_environment_t *env,
   }
 
   // resolve CONFIGURED/AUTO to a concrete EP and apply the model's
-  // cpu_only safety constraint in one place. ep_flags may be updated
-  // (e.g. COREML_FLAG_USE_CPU_ONLY) so the EP can stay enabled while
-  // honoring the constraint
+  // cpu_only safety constraint in one place. ep_flags is owned by the
+  // load function (e.g. COREML_FLAG_USE_CPU_ONLY) so the EP can stay
+  // enabled while honoring the constraint
+  uint32_t ep_flags = 0;
   const dt_ai_model_info_t *model_info
     = dt_ai_get_model_info_by_id(env, model_id);
   provider = _resolve_provider(provider, model_id, model_info,

--- a/src/ai/backend_onnx.c
+++ b/src/ai/backend_onnx.c
@@ -297,7 +297,15 @@ char *dt_ai_ort_probe_library(const char *path)
 // use so they always have a reference to compare against
 void dt_ai_snapshot_conf_state(void)
 {
-  if(g_conf_snapshot.taken) return;
+  // serialise first-init: racing threads must not both run the body
+  // and leak each other's g_strdup'd strings
+  static GMutex snapshot_lock;
+  g_mutex_lock(&snapshot_lock);
+  if(g_conf_snapshot.taken)
+  {
+    g_mutex_unlock(&snapshot_lock);
+    return;
+  }
   g_conf_snapshot.taken = TRUE;
 
   gchar *ort_conf = dt_conf_get_string("plugins/ai/ort_library_path");
@@ -315,6 +323,8 @@ void dt_ai_snapshot_conf_state(void)
                                                      "DT_MIGRAPHX_DEVICE_ID");
   g_conf_snapshot.dml_device_id      = _device_id_from_conf("plugins/ai/dml_device_id",
                                                      "DT_DML_DEVICE_ID");
+
+  g_mutex_unlock(&snapshot_lock);
 }
 
 void dt_ai_backend_cleanup_globals(void)
@@ -322,6 +332,7 @@ void dt_ai_backend_cleanup_globals(void)
   g_free(g_ort.version);            g_ort.version = NULL;
   g_free(g_conf_snapshot.ort_path); g_conf_snapshot.ort_path = NULL;
   g_free(g_conf_snapshot.provider); g_conf_snapshot.provider = NULL;
+  g_conf_snapshot.taken = FALSE;  // allow re-init on plugin/test reload
 }
 
 gboolean dt_ai_ort_path_changed_since_load(void)
@@ -674,7 +685,19 @@ int dt_ai_ort_probe_library_full(const char *path, char **out_version, char **ou
     {
       char **providers = NULL;
       int n_providers = 0;
-      if(probe_api->GetAvailableProviders(&providers, &n_providers) == NULL && providers)
+      OrtStatus *gap_st
+        = probe_api->GetAvailableProviders(&providers, &n_providers);
+      if(gap_st)
+      {
+        probe_api->ReleaseStatus(gap_st);
+        if(providers && probe_api->ReleaseAvailableProviders)
+        {
+          OrtStatus *rs
+            = probe_api->ReleaseAvailableProviders(providers, n_providers);
+          if(rs) probe_api->ReleaseStatus(rs);
+        }
+      }
+      else if(providers)
       {
         // map ORT provider names to short labels
         static const struct { const char *ort_name; const char *label; } map[] = {
@@ -1058,8 +1081,19 @@ static gboolean _ort_has_provider(const char *name)
   if(!g_ort.api || !g_ort.api->GetAvailableProviders) return FALSE;
   char **providers = NULL;
   int n = 0;
-  if(g_ort.api->GetAvailableProviders(&providers, &n) != NULL || !providers)
+  OrtStatus *st = g_ort.api->GetAvailableProviders(&providers, &n);
+  if(st)
+  {
+    g_ort.api->ReleaseStatus(st);
+    // ORT may have partially populated providers before erroring
+    if(providers && g_ort.api->ReleaseAvailableProviders)
+    {
+      OrtStatus *rs = g_ort.api->ReleaseAvailableProviders(providers, n);
+      if(rs) g_ort.api->ReleaseStatus(rs);
+    }
     return FALSE;
+  }
+  if(!providers) return FALSE;
   gboolean found = FALSE;
   for(int i = 0; i < n && !found; i++)
     if(g_strcmp0(providers[i], name) == 0) found = TRUE;

--- a/src/ai/backend_onnx.c
+++ b/src/ai/backend_onnx.c
@@ -957,8 +957,15 @@ static gpointer _init_ort_api(gpointer data)
                ort_override, g_module_error());
       goto done;
     }
-    g_ort.module = ort_mod;  // keep handle for _try_provider EP lookups
     api = _ort_api_from_module(ort_mod, ort_override);
+    if(!api)
+    {
+      // api probe failed (version too old / not an ORT lib): close the
+      // handle so we don't keep a non-functional library mapped
+      g_module_close(ort_mod);
+      goto done;
+    }
+    g_ort.module = ort_mod;  // keep handle for _try_provider EP lookups
   }
 #ifdef ORT_LAZY_LOAD
   else
@@ -992,6 +999,12 @@ static gpointer _init_ort_api(gpointer data)
       goto done;
     }
     api = _ort_api_from_module(ort_mod, ORT_LIBRARY_PATH);
+    if(!api)
+    {
+      g_module_close(ort_mod);
+      goto done;
+    }
+    g_ort.module = ort_mod;  // keep handle for _try_provider EP lookups
   }
 #else
   else

--- a/src/ai/backend_onnx.c
+++ b/src/ai/backend_onnx.c
@@ -2569,7 +2569,8 @@ int dt_ai_run(
                  "[darktable_ai] GetTensorMutableData output[%d] failed: %s",
                  i, g_ort.api->GetErrorMessage(status));
         g_ort.api->ReleaseStatus(status);
-        continue;
+        ret = -3;
+        break;
       }
 
       // query ORT's actual tensor size to avoid reading past its allocation.
@@ -2582,7 +2583,8 @@ int dt_ai_run(
         dt_print(DT_DEBUG_AI, "[darktable_ai] GetTensorTypeAndShape output[%d] failed: %s",
                  i, g_ort.api->GetErrorMessage(status));
         g_ort.api->ReleaseStatus(status);
-        continue;
+        ret = -3;
+        break;
       }
       // update caller's shape array with actual ORT output dimensions.
       // this is essential for dynamic-shape models where the caller's
@@ -2607,7 +2609,8 @@ int dt_ai_run(
         dt_print(DT_DEBUG_AI, "[darktable_ai] GetTensorShapeElementCount output[%d] failed: %s",
                  i, g_ort.api->GetErrorMessage(status));
         g_ort.api->ReleaseStatus(status);
-        continue;
+        ret = -3;
+        break;
       }
 
       const int64_t caller_count
@@ -2616,7 +2619,8 @@ int dt_ai_run(
       {
         dt_print(DT_DEBUG_AI,
                  "[darktable_ai] invalid shape for output[%d] post-copy", i);
-        continue;
+        ret = -3;
+        break;
       }
 
       // use the smaller of ORT's actual size and caller's expected size
@@ -2643,7 +2647,8 @@ int dt_ai_run(
           dt_print(DT_DEBUG_AI,
                    "[darktable_ai] unknown dtype %d for output[%d]",
                    outputs[i].type, i);
-          continue;
+          ret = -3;
+          break;
         }
         outputs[i].data = g_try_malloc(ort_element_count * type_size);
         if(!outputs[i].data)
@@ -2651,7 +2656,8 @@ int dt_ai_run(
           dt_print(DT_DEBUG_AI,
                    "[darktable_ai] failed to allocate output[%d] (%zu elements)",
                    i, ort_element_count);
-          continue;
+          ret = -3;
+          break;
         }
       }
 
@@ -2673,7 +2679,8 @@ int dt_ai_run(
           dt_print(DT_DEBUG_AI,
                    "[darktable_ai] unknown dtype %d for output[%d] post-copy",
                    outputs[i].type, i);
-          continue;
+          ret = -3;
+          break;
         }
         memcpy(outputs[i].data, raw_data, element_count * type_size);
       }

--- a/src/ai/backend_onnx.c
+++ b/src/ai/backend_onnx.c
@@ -136,20 +136,34 @@ static gboolean _check_cuda_driver_compat(void)
   if(drv_fn && rt_fn)
   {
     int drv = 0, rt = 0;
-    drv_fn(&drv);
-    rt_fn(&rt);
-    dt_print(DT_DEBUG_AI,
-             "[darktable_ai] CUDA driver %d.%d, runtime %d.%d",
-             drv / 1000, (drv % 1000) / 10,
-             rt / 1000, (rt % 1000) / 10);
-    if(drv < rt)
+    // cudaSuccess == 0 — anything else means we couldn't read the version
+    // (no driver, init failure, no devices). conservatively treat that
+    // as incompatible so we don't try to enable CUDA on a broken stack
+    const int drv_rc = drv_fn(&drv);
+    const int rt_rc = rt_fn(&rt);
+    if(drv_rc != 0 || rt_rc != 0)
     {
       dt_print(DT_DEBUG_AI,
-               "[darktable_ai] CUDA driver %d.%d is too old for runtime %d.%d — "
-               "disabling CUDA to prevent crash. Update your NVIDIA driver.",
+               "[darktable_ai] CUDA version query failed (drv rc=%d, "
+               "rt rc=%d) — disabling CUDA",
+               drv_rc, rt_rc);
+      cached = 0;
+    }
+    else
+    {
+      dt_print(DT_DEBUG_AI,
+               "[darktable_ai] CUDA driver %d.%d, runtime %d.%d",
                drv / 1000, (drv % 1000) / 10,
                rt / 1000, (rt % 1000) / 10);
-      cached = 0;
+      if(drv < rt)
+      {
+        dt_print(DT_DEBUG_AI,
+                 "[darktable_ai] CUDA driver %d.%d is too old for runtime %d.%d — "
+                 "disabling CUDA to prevent crash. Update your NVIDIA driver.",
+                 drv / 1000, (drv % 1000) / 10,
+                 rt / 1000, (rt % 1000) / 10);
+        cached = 0;
+      }
     }
   }
   g_module_close(mod);

--- a/src/ai/backend_onnx.c
+++ b/src/ai/backend_onnx.c
@@ -1563,11 +1563,11 @@ static gboolean _try_coreml_v2(OrtSessionOptions *session_opts,
   size_t n = 0;
 
   keys[n] = "ModelFormat";
-  vals[n] = (ep_flags & 16) ? "MLProgram" : "NeuralNetwork";
+  vals[n] = (ep_flags & DT_COREML_FLAG_CREATE_MLPROGRAM) ? "MLProgram" : "NeuralNetwork";
   n++;
 
   keys[n] = "MLComputeUnits";
-  vals[n] = (ep_flags & 1) ? "CPUOnly" : "ALL";
+  vals[n] = (ep_flags & DT_COREML_FLAG_USE_CPU_ONLY) ? "CPUOnly" : "ALL";
   n++;
 
   if(cache_dir && cache_dir[0])
@@ -1924,8 +1924,8 @@ _enable_acceleration(OrtSessionOptions *session_opts,
   {
     dt_print(DT_DEBUG_AI,
              "[darktable_ai] CoreML format: %s%s",
-             (coreml_flags & 16) ? "MLProgram" : "NeuralNetwork",
-             (coreml_flags & 1) ? " (CPU compute units)" : "");
+             (coreml_flags & DT_COREML_FLAG_CREATE_MLPROGRAM) ? "MLProgram" : "NeuralNetwork",
+             (coreml_flags & DT_COREML_FLAG_USE_CPU_ONLY) ? " (CPU compute units)" : "");
     gchar *fp = _backend_cache_fingerprint(DT_AI_PROVIDER_COREML, -1);
     char coreml_cache[PATH_MAX] = { 0 };
     const gboolean have_cache = dt_ai_backend_cache_dir(

--- a/src/ai/backend_onnx.c
+++ b/src/ai/backend_onnx.c
@@ -155,6 +155,53 @@ static gboolean _check_cuda_driver_compat(void)
   g_module_close(mod);
   return cached == 1;
 }
+
+// check that the ROCm runtime is loadable AND reports at least one
+// HIP device; ORT's MIGraphX/ROCm EP can abort() during load if the
+// kernel HSA support is missing or no GPU agent is available.
+// result is cached — the check runs only once per process
+static gboolean _check_rocm_runtime(void)
+{
+  static int cached = -1;  // -1 = unchecked, 0 = unusable, 1 = ok
+  if(cached >= 0) return cached == 1;
+
+  cached = 1;  // assume ok until proven otherwise
+
+  // try unversioned first, then probe versioned names from high to low
+  GModule *mod = g_module_open("libamdhip64.so",
+                               G_MODULE_BIND_LAZY | G_MODULE_BIND_LOCAL);
+  for(int v = 8; !mod && v >= 5; v--)
+  {
+    char name[32];
+    snprintf(name, sizeof(name), "libamdhip64.so.%d", v);
+    mod = g_module_open(name, G_MODULE_BIND_LAZY | G_MODULE_BIND_LOCAL);
+  }
+  if(!mod) return TRUE;  // can't check — assume compatible
+
+  typedef int (*hip_count_fn)(int *);
+  hip_count_fn count_fn = NULL;
+  g_module_symbol(mod, "hipGetDeviceCount", (gpointer *)&count_fn);
+
+  if(count_fn)
+  {
+    int n = 0;
+    const int rc = count_fn(&n);
+    if(rc == 0 && n > 0)
+    {
+      dt_print(DT_DEBUG_AI,
+               "[darktable_ai] ROCm: %d HIP device(s) detected", n);
+    }
+    else
+    {
+      dt_print(DT_DEBUG_AI,
+               "[darktable_ai] ROCm: hipGetDeviceCount rc=%d n=%d — "
+               "disabling MIGraphX/ROCm to prevent crash", rc, n);
+      cached = 0;
+    }
+  }
+  g_module_close(mod);
+  return cached == 1;
+}
 #endif  // __linux__
 
 // hide ORT's expected stderr noise (GetApi probe rejections, dlopen errors)
@@ -1413,6 +1460,11 @@ static gboolean _try_provider(OrtSessionOptions *session_opts,
   // before enabling CUDA EP, verify the driver supports the installed runtime;
   // a driver/runtime version mismatch causes ORT to abort() during inference
   if(strstr(symbol_name, "CUDA") && !_check_cuda_driver_compat())
+    return FALSE;
+  // same guard for MIGraphX/ROCm: kernel HSA mismatch or missing GPU
+  // agent causes ORT to abort() during provider load
+  if((strstr(symbol_name, "MIGraphX") || strstr(symbol_name, "ROCM"))
+     && !_check_rocm_runtime())
     return FALSE;
 #endif
   GModule *mod = g_module_open(NULL, 0);

--- a/src/ai/backend_onnx.c
+++ b/src/ai/backend_onnx.c
@@ -93,6 +93,7 @@ static struct {
   int    cuda_device_id;
   int    migraphx_device_id;
   int    dml_device_id;
+  gboolean taken;
 } g_conf_snapshot = {
   .cuda_device_id     = -1,
   .migraphx_device_id = -1,
@@ -228,11 +229,16 @@ char *dt_ai_ort_probe_library(const char *path)
 // both out params are caller-owned (g_free). Returns FALSE if not a valid ORT.
 // FALSE before ORT is loaded (no comparison reference yet)
 // snapshot the conf values that determine which library / EP / device
-// the in-process ORT will be bound to. called eagerly at darktable
-// startup so the *_changed_since_load() helpers have a stable reference
-// independent of when ORT is lazily initialized
+// the in-process ORT will be bound to. idempotent — subsequent calls
+// are no-ops so the snapshot reflects whichever state existed first.
+// callers should still call eagerly at darktable startup; if they
+// forget, the *_changed_since_load() helpers auto-snapshot on first
+// use so they always have a reference to compare against
 void dt_ai_snapshot_conf_state(void)
 {
+  if(g_conf_snapshot.taken) return;
+  g_conf_snapshot.taken = TRUE;
+
   gchar *ort_conf = dt_conf_get_string("plugins/ai/ort_library_path");
   g_free(g_conf_snapshot.ort_path);
   g_conf_snapshot.ort_path = g_strdup(ort_conf ? ort_conf : "");
@@ -259,6 +265,7 @@ void dt_ai_backend_cleanup_globals(void)
 
 gboolean dt_ai_ort_path_changed_since_load(void)
 {
+  dt_ai_snapshot_conf_state();  // no-op if already taken
   if(!g_conf_snapshot.ort_path) return FALSE;
   gchar *cur = dt_conf_get_string("plugins/ai/ort_library_path");
   const gboolean changed
@@ -269,6 +276,7 @@ gboolean dt_ai_ort_path_changed_since_load(void)
 
 gboolean dt_ai_provider_changed_since_load(void)
 {
+  dt_ai_snapshot_conf_state();  // no-op if already taken
   if(!g_conf_snapshot.provider) return FALSE;
   gchar *cur = dt_conf_get_string(DT_AI_CONF_PROVIDER);
   const gboolean changed
@@ -300,6 +308,7 @@ gboolean dt_ai_device_id_changed_since_load(const dt_ai_provider_t provider)
 {
   const char *key = dt_ai_device_conf_key_for_provider(provider);
   if(!key) return FALSE;
+  dt_ai_snapshot_conf_state();  // no-op if already taken
   int loaded;
   switch(provider)
   {

--- a/src/common/ai/restore.c
+++ b/src/common/ai/restore.c
@@ -465,12 +465,8 @@ dt_restore_context_t *dt_restore_load_rawdenoise_xtrans(dt_restore_env_t *env)
   dt_restore_context_t *ctx = _load(env, TASK_RAWDENOISE, "model_xtrans", NULL,
                                     DT_RESTORE_INPUT_KIND_XTRANS_V1, 1);
   if(!ctx)
-  {
-    dt_print(DT_DEBUG_AI,
-             "[restore] no dedicated xtrans model; using linear as fallback");
     ctx = _load(env, TASK_RAWDENOISE, "model_linear", NULL,
                 DT_RESTORE_INPUT_KIND_LINEAR_V1, 1);
-  }
   return ctx;
 }
 

--- a/src/common/ai/restore.c
+++ b/src/common/ai/restore.c
@@ -323,7 +323,7 @@ static dt_restore_context_t *_load(dt_restore_env_t *env,
   // matching the model_file against the model's top-level cpu_only list
   dt_ai_context_t *ai_ctx = dt_ai_load_model_ext(
     env->ai_env, model_id, model_file,
-    DT_AI_PROVIDER_CONFIGURED, DT_AI_OPT_ALL, NULL, 0, 0);
+    DT_AI_PROVIDER_CONFIGURED, DT_AI_OPT_ALL, NULL, 0);
   if(!ai_ctx)
   {
     g_free(model_id);
@@ -614,7 +614,7 @@ gboolean dt_restore_reload_session_cpu(dt_restore_context_t *ctx)
 
   dt_ai_context_t *new_ctx = dt_ai_load_model_ext(
     ctx->env->ai_env, ctx->model_id, ctx->model_file,
-    DT_AI_PROVIDER_CPU, DT_AI_OPT_ALL, NULL, 0, 0);
+    DT_AI_PROVIDER_CPU, DT_AI_OPT_ALL, NULL, 0);
   if(!new_ctx)
   {
     dt_print(DT_DEBUG_AI,

--- a/src/common/ai/restore.h
+++ b/src/common/ai/restore.h
@@ -68,6 +68,13 @@ typedef enum
 dt_restore_sensor_class_t dt_restore_classify_sensor(const dt_image_t *img);
 
 // --- environment lifecycle ---
+//
+// Threading: dt_restore_env_t is NOT internally synchronised. The
+// underlying dt_ai_environment_t is shared by every load / refresh /
+// _model_available call on the same env. Consumers must serialise
+// these against each other (e.g. via the consumer's own ctx lock) —
+// in particular a refresh must not overlap with a model load that's
+// borrowing model_info pointers from the env's model list.
 
 // @brief initialize the restore environment
 //

--- a/src/common/ai/restore_raw_bayer.c
+++ b/src/common/ai/restore_raw_bayer.c
@@ -197,9 +197,11 @@ static void _bayer_gain_match(const float *tile_in,
   const double out_mean = out_sum / (double)(3 * tile_out_plane);
   // allow negative gain too: the RawNIND model output scale is
   // arbitrary by design (match_gain post-step during training absorbs
-  // it); in some variants the sign is also inverted. guard only
-  // against near-zero mean
-  const float gain = (fabsf((float)out_mean) > 1e-8f)
+  // it); in some variants the sign is also inverted. guard against
+  // near-zero out_mean relative to in_mean — an absolute threshold
+  // is useless because out_mean is typically ~10^6 * in_mean
+  const double thr = 1e-6 * fabs(in_mean);
+  const float gain = (fabs(out_mean) > thr)
     ? (float)(in_mean / out_mean) : 1.0f;
   if(gain != 1.0f)
   {

--- a/src/common/ai/segmentation.c
+++ b/src/common/ai/segmentation.c
@@ -317,7 +317,7 @@ dt_seg_context_t *dt_seg_load(dt_ai_environment_t *env, const char *model_id)
   // issues with some decoder graphs (e.g. SegNext's Concat->Reshape)
   dt_ai_context_t *decoder
     = dt_ai_load_model_ext(env, model_id, "decoder.onnx", DT_AI_PROVIDER_CPU,
-                           DT_AI_OPT_DISABLED, NULL, 0, 0);
+                           DT_AI_OPT_DISABLED, NULL, 0);
   if(!decoder)
   {
     dt_print(DT_DEBUG_AI, "[segmentation] failed to load decoder for %s", model_id);
@@ -480,7 +480,7 @@ dt_seg_context_t *dt_seg_load(dt_ai_environment_t *env, const char *model_id)
       const dt_ai_dim_override_t overrides[] = {{"num_labels", 1}};
       ctx->decoder = dt_ai_load_model_ext(env, model_id, "decoder.onnx",
                                            DT_AI_PROVIDER_CPU, DT_AI_OPT_BASIC,
-                                           overrides, 1, 0);
+                                           overrides, 1);
       if(!ctx->decoder)
       {
         dt_print(DT_DEBUG_AI, "[segmentation] failed to reload decoder for %s", model_id);

--- a/src/common/ai/segmentation.c
+++ b/src/common/ai/segmentation.c
@@ -1011,16 +1011,28 @@ float *dt_seg_compute_mask(dt_seg_context_t *ctx,
   }
 
   // re-read actual mask dimensions -- the backend updates the shape array
-  // for dynamic-output models after ORT reports the real tensor shape
+  // for dynamic-output models after ORT reports the real tensor shape.
+  // only shrink: growing would push `masks + best * per_mask` past the
+  // allocated buffer on indexed reads below
   if(masks_shape[2] > 0 && masks_shape[3] > 0
      && ((int)masks_shape[2] != dec_h || (int)masks_shape[3] != dec_w))
   {
-    dt_print(DT_DEBUG_AI,
-             "[segmentation] actual decoder output: %"PRId64"x%"PRId64" (allocated %dx%d)",
-             masks_shape[2], masks_shape[3], dec_h, dec_w);
-    dec_h = (int)masks_shape[2];
-    dec_w = (int)masks_shape[3];
-    per_mask = (size_t)dec_h * dec_w;
+    if((int)masks_shape[2] <= dec_h && (int)masks_shape[3] <= dec_w)
+    {
+      dt_print(DT_DEBUG_AI,
+               "[segmentation] actual decoder output: %"PRId64"x%"PRId64" (allocated %dx%d)",
+               masks_shape[2], masks_shape[3], dec_h, dec_w);
+      dec_h = (int)masks_shape[2];
+      dec_w = (int)masks_shape[3];
+      per_mask = (size_t)dec_h * dec_w;
+    }
+    else
+    {
+      dt_print(DT_DEBUG_ALWAYS,
+               "[segmentation] actual decoder output %"PRId64"x%"PRId64" "
+               "exceeds allocated %dx%d — using allocated dims",
+               masks_shape[2], masks_shape[3], dec_h, dec_w);
+    }
   }
 
   // select best mask and cache refinement data

--- a/src/common/ai/segmentation.c
+++ b/src/common/ai/segmentation.c
@@ -697,7 +697,10 @@ void dt_seg_warmup_decoder(dt_seg_context_t *ctx)
       n_out = 1;
     }
 
-    dt_ai_run(ctx->decoder, inputs, ni, outputs, n_out);
+    const int wr = dt_ai_run(ctx->decoder, inputs, ni, outputs, n_out);
+    if(wr != 0)
+      dt_print(DT_DEBUG_AI,
+               "[segmentation] decoder warmup failed (rc=%d)", wr);
   }
 
 cleanup:

--- a/src/common/ai/segmentation.c
+++ b/src/common/ai/segmentation.c
@@ -415,10 +415,13 @@ dt_seg_context_t *dt_seg_load(dt_ai_environment_t *env, const char *model_id)
     }
   }
 
-  dt_print(DT_DEBUG_AI,
-           "[segmentation] encoder-decoder reorder: [%d, %d, %d, %d] (n=%d)",
-           ctx->enc_order[0], ctx->enc_order[1], ctx->enc_order[2], ctx->enc_order[3],
-           ctx->n_enc_outputs);
+  char map[128] = {0};
+  int off = 0;
+  for(int di = 0; di < ctx->n_enc_outputs; di++)
+    off += snprintf(map + off, sizeof(map) - off,
+                    "%sdec[%d] <- enc[%d]",
+                    di ? ", " : "", di, ctx->enc_order[di]);
+  dt_print(DT_DEBUG_AI, "[segmentation] tensor routing: %s", map);
 
   // detect model type from arch field in model registry
   const dt_ai_model_info_t *minfo

--- a/src/common/ai/segmentation.h
+++ b/src/common/ai/segmentation.h
@@ -25,6 +25,13 @@
 /**
  * @brief Opaque segmentation context (holds encoder+decoder sessions
  *        and cached image embeddings).
+ *
+ * Threading: a context is NOT internally synchronised. The encoder
+ * may be invoked from a background thread, the decoder typically
+ * runs on the UI thread on a user click. Callers must serialise
+ * dt_seg_encode_image / dt_seg_compute_mask / dt_seg_reset_*
+ * against each other (and against dt_seg_free) — the prev_mask and
+ * has_prev_mask fields are mutated by both encode and compute.
  */
 typedef struct dt_seg_context_t dt_seg_context_t;
 

--- a/src/common/ai_models.c
+++ b/src/common/ai_models.c
@@ -379,19 +379,23 @@ static void _setup_registry(dt_ai_registry_t *registry)
   char cachedir[PATH_MAX] = {0};
   dt_loc_get_user_cache_dir(cachedir, sizeof(cachedir));
 
-  registry->models_dir = dt_ai_resolve_models_path_override();
-  if(!registry->models_dir)
-    registry->models_dir = g_build_filename(g_get_user_data_dir(),
-                                            "darktable", "models", NULL);
+  // models_dir is the unlocked "already-initialised" sentinel in
+  // init_lazy, so it must be the LAST field published
+  char *models = dt_ai_resolve_models_path_override();
+  if(!models)
+    models = g_build_filename(g_get_user_data_dir(),
+                              "darktable", "models", NULL);
+  char *cache = g_build_filename(cachedir, "ai_downloads", NULL);
 
-  registry->cache_dir = g_build_filename(cachedir, "ai_downloads", NULL);
-
-  _ensure_directory(registry->models_dir);
-  _ensure_directory(registry->cache_dir);
+  _ensure_directory(models);
+  _ensure_directory(cache);
 
   char *prov_str = dt_conf_get_string(DT_AI_CONF_PROVIDER);
   registry->provider = dt_ai_provider_from_string(prov_str);
   g_free(prov_str);
+
+  registry->cache_dir = cache;
+  registry->models_dir = models;  // publish last
 
   dt_print(DT_DEBUG_AI,
            "[ai_models] initialized: models_dir=%s, cache_dir=%s",

--- a/src/common/ai_models.c
+++ b/src/common/ai_models.c
@@ -413,7 +413,7 @@ gboolean dt_ai_registry_is_enabled(dt_ai_registry_t *registry)
   return v;
 }
 
-void dt_ai_registry_set_enabled(dt_ai_registry_t *registry, gboolean enabled)
+void dt_ai_registry_set_enabled(dt_ai_registry_t *registry, const gboolean enabled)
 {
   if(!registry) return;
   g_mutex_lock(&registry->lock);
@@ -422,7 +422,7 @@ void dt_ai_registry_set_enabled(dt_ai_registry_t *registry, gboolean enabled)
 }
 
 void dt_ai_registry_set_provider(dt_ai_registry_t *registry,
-                                 dt_ai_provider_t provider)
+                                 const dt_ai_provider_t provider)
 {
   if(!registry) return;
   g_mutex_lock(&registry->lock);

--- a/src/common/ai_models.c
+++ b/src/common/ai_models.c
@@ -1362,10 +1362,15 @@ char *dt_ai_models_install_local(dt_ai_registry_t *registry,
     return g_strdup_printf(_("file not found: %s"), filepath);
 
   char *installed_id = _zip_top_dir(filepath);
-  if(!installed_id || !installed_id[0])
+  if(!_valid_model_id(installed_id))
   {
+    // zip's top-level dir becomes the model id and a conf key — reject
+    // empty / "." / ".." / path-separator content before it gets there
+    char *err = g_strdup_printf(
+      _("archive top-level directory is not a valid model id: \"%s\""),
+      installed_id ? installed_id : "");
     g_free(installed_id);
-    return g_strdup(_("could not read model id from archive"));
+    return err;
   }
 
   if(!_extract_zip_atomic(filepath, registry->models_dir, installed_id))

--- a/src/common/ai_models.c
+++ b/src/common/ai_models.c
@@ -449,7 +449,13 @@ dt_ai_registry_t *dt_ai_models_init(void)
 
 void dt_ai_models_init_lazy(dt_ai_registry_t *registry)
 {
-  if(!registry || registry->models_dir) return;
+  if(!registry || registry->models_dir)
+  {
+    // catch broken publication order in _setup_registry: any field
+    // added must be initialised BEFORE models_dir, the sentinel
+    if(registry) g_assert(registry->cache_dir);
+    return;
+  }
 
   g_mutex_lock(&registry->lock);
   _setup_registry(registry);

--- a/src/common/ai_models.c
+++ b/src/common/ai_models.c
@@ -1099,6 +1099,8 @@ static gboolean _verify_checksum(const char *filepath,
 }
 #endif //HAVE_AI_DOWNLOAD
 
+static gboolean _rmdir_recursive(const char *path);
+
 static gboolean _extract_zip(const char *zippath,
                              const char *destdir)
 {
@@ -1237,6 +1239,74 @@ static gboolean _extract_zip(const char *zippath,
   return success;
 }
 
+// atomically install a .dtmodel into dest_root/<model_id>/.
+// extract into a staging directory inside dest_root, then rename
+// the model subdir into its final place only on full success.
+// on failure, staging is cleaned up and the existing
+// dest_root/<model_id>/ (if any) is left untouched.
+static gboolean _extract_zip_atomic(const char *zippath,
+                                    const char *dest_root,
+                                    const char *model_id)
+{
+  if(!zippath || !dest_root || !model_id || !model_id[0])
+    return FALSE;
+
+  _ensure_directory(dest_root);
+
+  // staging dir as a sibling of the final dir, so the rename is
+  // intra-filesystem and atomic. g_mkdtemp fills XXXXXX with a
+  // unique suffix and creates the directory
+  gchar *staging
+    = g_strdup_printf("%s%s.staging.XXXXXX", dest_root, G_DIR_SEPARATOR_S);
+  if(!g_mkdtemp(staging))
+  {
+    dt_print(DT_DEBUG_AI,
+             "[ai_models] failed to create staging dir under %s", dest_root);
+    g_free(staging);
+    return FALSE;
+  }
+
+  if(!_extract_zip(zippath, staging))
+  {
+    _rmdir_recursive(staging);
+    g_free(staging);
+    return FALSE;
+  }
+
+  // the zip's top-level dir is the model id; the extracted tree is
+  // staging/<model_id>/. move it to dest_root/<model_id>/.
+  gchar *staged_model = g_build_filename(staging, model_id, NULL);
+  gchar *final_path = g_build_filename(dest_root, model_id, NULL);
+
+  if(!g_file_test(staged_model, G_FILE_TEST_IS_DIR))
+  {
+    dt_print(DT_DEBUG_AI,
+             "[ai_models] archive top-level does not match model id '%s'",
+             model_id);
+    _rmdir_recursive(staging);
+    g_free(staging);
+    g_free(staged_model);
+    g_free(final_path);
+    return FALSE;
+  }
+
+  // replace any existing install; we just verified a complete copy in staging
+  if(g_file_test(final_path, G_FILE_TEST_EXISTS))
+    _rmdir_recursive(final_path);
+
+  const gboolean ok = g_rename(staged_model, final_path) == 0;
+  if(!ok)
+    dt_print(DT_DEBUG_AI,
+             "[ai_models] failed to move staged model into place: %s -> %s",
+             staged_model, final_path);
+
+  g_free(staged_model);
+  g_free(final_path);
+  _rmdir_recursive(staging);  // remove the now-empty staging parent
+  g_free(staging);
+  return ok;
+}
+
 // peek at the first archive entry to recover the model_id (the top
 // level directory name in the zip layout)
 static char *_zip_top_dir(const char *zippath)
@@ -1292,8 +1362,13 @@ char *dt_ai_models_install_local(dt_ai_registry_t *registry,
     return g_strdup_printf(_("file not found: %s"), filepath);
 
   char *installed_id = _zip_top_dir(filepath);
+  if(!installed_id || !installed_id[0])
+  {
+    g_free(installed_id);
+    return g_strdup(_("could not read model id from archive"));
+  }
 
-  if(!_extract_zip(filepath, registry->models_dir))
+  if(!_extract_zip_atomic(filepath, registry->models_dir, installed_id))
   {
     g_free(installed_id);
     return g_strdup(_("failed to extract model archive"));
@@ -1568,8 +1643,11 @@ char *dt_ai_models_download_sync(dt_ai_registry_t *registry,
                       asset));
   }
 
-  // extract to models directory (zip already contains model_id folder)
-  if(!_extract_zip(download_path, registry->models_dir))
+  // extract to models directory (zip already contains model_id folder).
+  // atomic: staging dir + rename, so a partial extract never leaves a
+  // half-written model_id directory that refresh_status would treat as
+  // DOWNLOADED.
+  if(!_extract_zip_atomic(download_path, registry->models_dir, model_id))
   {
     g_unlink(download_path);
     g_free(download_path);

--- a/src/common/ai_models.c
+++ b/src/common/ai_models.c
@@ -40,6 +40,22 @@ static inline char *realpath(const char *path, char *resolved_path)
 }
 #endif
 
+// internal layout of the opaque registry. external callers go through
+// the accessors in ai_models.h — the lock and the model list are
+// intentionally hidden so nobody can race-iterate or deadlock on them
+struct dt_ai_registry_t
+{
+  GList *models;              // list of dt_ai_model_t*
+  char *repository;           // github repository (e.g. "darktable-org/darktable-ai")
+  char *models_dir;           // path to user's models directory
+  char *cache_dir;            // path to download cache directory
+  gboolean ai_enabled;        // global AI enable/disable
+  dt_ai_provider_t provider;  // selected execution provider
+  gboolean updates_checked;   // TRUE after first check_updates call
+  struct dt_ai_environment_t *env;  // lazily created backend environment
+  GMutex lock;                // thread safety for registry access
+};
+
 // config keys
 #define CONF_AI_ENABLED "plugins/ai/enabled"
 #define CONF_AI_REPOSITORY "plugins/ai/repository"
@@ -380,6 +396,34 @@ static void _setup_registry(dt_ai_registry_t *registry)
   dt_print(DT_DEBUG_AI,
            "[ai_models] initialized: models_dir=%s, cache_dir=%s",
            registry->models_dir, registry->cache_dir);
+}
+
+// --- Registry state accessors ---
+
+gboolean dt_ai_registry_is_enabled(dt_ai_registry_t *registry)
+{
+  if(!registry) return FALSE;
+  g_mutex_lock(&registry->lock);
+  const gboolean v = registry->ai_enabled;
+  g_mutex_unlock(&registry->lock);
+  return v;
+}
+
+void dt_ai_registry_set_enabled(dt_ai_registry_t *registry, gboolean enabled)
+{
+  if(!registry) return;
+  g_mutex_lock(&registry->lock);
+  registry->ai_enabled = enabled;
+  g_mutex_unlock(&registry->lock);
+}
+
+void dt_ai_registry_set_provider(dt_ai_registry_t *registry,
+                                 dt_ai_provider_t provider)
+{
+  if(!registry) return;
+  g_mutex_lock(&registry->lock);
+  registry->provider = provider;
+  g_mutex_unlock(&registry->lock);
 }
 
 dt_ai_registry_t *dt_ai_models_init(void)

--- a/src/common/ai_models.h
+++ b/src/common/ai_models.h
@@ -21,15 +21,6 @@
 #include <glib.h>
 #include "ai/backend.h"
 
-// Ensure PATH_MAX is defined on all platforms
-#ifndef PATH_MAX
-#ifdef _WIN32
-#define PATH_MAX _MAX_PATH
-#else
-#define PATH_MAX 4096
-#endif
-#endif
-
 /**
  * @brief Model download/availability status
  */

--- a/src/common/ai_models.h
+++ b/src/common/ai_models.h
@@ -75,21 +75,42 @@ typedef void (*dt_ai_progress_callback)(const char *model_id,
                                         gpointer user_data);
 
 /**
- * @brief AI Models Registry
- * Central registry for managing AI models
+ * @brief AI Models Registry — opaque handle.
+ *
+ * The registry holds a private mutex and the in-memory model list.
+ * Both are intentionally hidden so callers can't deadlock by acquiring
+ * the lock directly, race-iterate the list, or touch fields without
+ * going through the API. The full definition lives in ai_models.c.
+ *
+ * External callers should treat the type as opaque and use the
+ * accessor functions below.
  */
-typedef struct dt_ai_registry_t
-{
-  GList *models;              // List of dt_ai_model_t*
-  char *repository;           // GitHub repository (e.g. "darktable-org/darktable-ai")
-  char *models_dir;           // Path to user's models directory
-  char *cache_dir;            // Path to download cache directory
-  gboolean ai_enabled;        // Global AI enable/disable
-  dt_ai_provider_t provider;  // Selected execution provider
-  gboolean updates_checked;   // TRUE after first check_updates call
-  struct dt_ai_environment_t *env;  // Lazily created backend environment
-  GMutex lock;                // Thread safety for registry access
-} dt_ai_registry_t;
+typedef struct dt_ai_registry_t dt_ai_registry_t;
+
+// --- Registry state accessors ---
+// thin, locked accessors for the few fields external callers need to
+// touch. all other registry state is accessed via the model APIs below
+
+/**
+ * @brief TRUE if AI is currently enabled (global toggle in prefs).
+ *        Safe to call from any thread; NULL registry returns FALSE.
+ */
+gboolean dt_ai_registry_is_enabled(dt_ai_registry_t *registry);
+
+/**
+ * @brief Set the global AI-enabled state in the registry.
+ *        Does NOT write to darktablerc — caller must persist the
+ *        preference separately. Safe to call from any thread.
+ */
+void dt_ai_registry_set_enabled(dt_ai_registry_t *registry, gboolean enabled);
+
+/**
+ * @brief Set the execution provider in the registry.
+ *        Does NOT write to darktablerc — caller must persist the
+ *        preference separately. Safe to call from any thread.
+ */
+void dt_ai_registry_set_provider(dt_ai_registry_t *registry,
+                                 dt_ai_provider_t provider);
 
 // --- Core API ---
 

--- a/src/common/ai_models.h
+++ b/src/common/ai_models.h
@@ -53,7 +53,10 @@ typedef struct dt_ai_model_t
   char *description;     // Short description
   char *task;            // Task type: "denoise", "upscale", etc.
   char *github_asset;    // Asset filename in GitHub release
-  char *checksum;        // SHA256 checksum (format: "sha256:...")
+  char *checksum;        // checksum string, format "<algo>:<hex>"
+                         // (today only "sha256:..." is produced by the
+                         // GitHub asset digest API; parser tolerates
+                         // other algos but only sha256 is verified)
   char *version;         // actual version from model's config.json
   char *min_version;     // minimum required version from registry
   char *spatial_dim_h;   // symbolic name of height dimension (default "height")
@@ -121,7 +124,10 @@ void dt_ai_registry_set_provider(dt_ai_registry_t *registry,
 dt_ai_registry_t *dt_ai_models_init(void);
 
 /**
- * @brief Load model registry from JSON file
+ * @brief Load model registry from `ai_models.json` bundled with the
+ *        darktable installation (looked up under DATADIR). There is
+ *        no caller-supplied path — the registry source is fixed by
+ *        the install layout.
  * @param registry The registry to populate
  * @return TRUE on success
  */
@@ -150,9 +156,17 @@ void dt_ai_models_refresh_status(dt_ai_registry_t *registry);
 
 /**
  * @brief Check for model updates by fetching versions.json from the
- *        remote repository. Sets DT_AI_MODEL_UPDATE_AVAILABLE on
- *        models where a newer version exists but the installed
- *        version still meets min_version
+ *        remote repository, and update each model's status:
+ *
+ *        - installed >= remote → DT_AI_MODEL_DOWNLOADED (no change)
+ *        - installed <  remote AND installed >= min_version
+ *          → DT_AI_MODEL_UPDATE_AVAILABLE
+ *        - installed <  min_version → DT_AI_MODEL_UPDATE_REQUIRED
+ *
+ *        UPDATE_REQUIRED means darktable cannot use the installed
+ *        model with the current code; UPDATE_AVAILABLE is a soft
+ *        nudge — the installed model still works.
+ *
  * @param registry The registry to update
  */
 void dt_ai_models_check_updates(dt_ai_registry_t *registry);
@@ -286,6 +300,13 @@ void dt_ai_models_set_enabled(dt_ai_registry_t *registry, const char *model_id,
  * Looks up the centralized config key `plugins/ai/models/active/{task}`.
  * If not set, falls back to legacy consumer config keys, then to the
  * default downloaded model for the task.
+ *
+ * SIDE EFFECT: when the lookup resolves via the default-downloaded
+ * fallback (no conf key present), the resulting id is also written
+ * back to `plugins/ai/models/active/{task}`. Subsequent calls see an
+ * "explicit" choice that was actually materialized by the first call.
+ * Once the conf key holds any value (including the empty string from
+ * an explicit clear), the fallback is bypassed and no write happens.
  *
  * @param task The task type (e.g. "mask", "denoise")
  * @return Newly allocated model ID string (caller must free), or NULL if none active

--- a/src/common/ai_models.h
+++ b/src/common/ai_models.h
@@ -96,7 +96,7 @@ gboolean dt_ai_registry_is_enabled(dt_ai_registry_t *registry);
  *        Does NOT write to darktablerc — caller must persist the
  *        preference separately. Safe to call from any thread.
  */
-void dt_ai_registry_set_enabled(dt_ai_registry_t *registry, gboolean enabled);
+void dt_ai_registry_set_enabled(dt_ai_registry_t *registry, const gboolean enabled);
 
 /**
  * @brief Set the execution provider in the registry.
@@ -104,7 +104,7 @@ void dt_ai_registry_set_enabled(dt_ai_registry_t *registry, gboolean enabled);
  *        preference separately. Safe to call from any thread.
  */
 void dt_ai_registry_set_provider(dt_ai_registry_t *registry,
-                                 dt_ai_provider_t provider);
+                                 const dt_ai_provider_t provider);
 
 // --- Core API ---
 

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1671,7 +1671,7 @@ int dt_init(int argc,
   if(darktable.ai_registry)
   {
     dt_ai_models_load_registry(darktable.ai_registry);
-    if(!darktable.ai_registry->ai_enabled)
+    if(!dt_ai_registry_is_enabled(darktable.ai_registry))
       dt_print(DT_DEBUG_AI, "[darktable_ai] AI subsystem is disabled");
   }
 #endif

--- a/src/common/densecrf.cc
+++ b/src/common/densecrf.cc
@@ -111,7 +111,8 @@ extern "C" void dt_dense_crf_binary(float *probabilities,
 {
   if(!probabilities || !rgb
      || width <= 0 || height <= 0
-     || n_iterations <= 0)
+     || n_iterations <= 0
+     || sigma_spatial <= 0.0f || sigma_rgb <= 0.0f)
     return;
 
   const int n = width * height;

--- a/src/common/densecrf.cc
+++ b/src/common/densecrf.cc
@@ -172,14 +172,17 @@ extern "C" void dt_dense_crf_binary(float *probabilities,
   }
 
   const size_t n_threads = (size_t)dt_get_num_threads();
-  // grid_points hint for hash-table sizing — over-estimate is harmless,
-  // under-estimate triggers an internal re-grow
-  const size_t spatial_grid = (size_t)((float)height * inv_sigma_s
-                                       * (float)width * inv_sigma_s);
-  const size_t bilateral_grid = (size_t)((float)height * inv_sigma_s
-                                         * (float)width * inv_sigma_s
-                                         * inv_sigma_c * inv_sigma_c * inv_sigma_c
-                                         * 256.0f * 256.0f * 256.0f);
+  // hash-table sizing hint — cap so small sigmas can't request GBs;
+  // the lattice re-grows as needed if we under-estimate
+  const size_t MAX_GRID_HINT = (size_t)1 << 24;  // ~16M buckets
+  size_t spatial_grid = (size_t)((float)height * inv_sigma_s
+                                 * (float)width * inv_sigma_s);
+  size_t bilateral_grid = (size_t)((float)height * inv_sigma_s
+                                   * (float)width * inv_sigma_s
+                                   * inv_sigma_c * inv_sigma_c * inv_sigma_c
+                                   * 256.0f * 256.0f * 256.0f);
+  if(spatial_grid > MAX_GRID_HINT)   spatial_grid   = MAX_GRID_HINT;
+  if(bilateral_grid > MAX_GRID_HINT) bilateral_grid = MAX_GRID_HINT;
 
   // Permutohedral lattices use `new` internally and can throw std::bad_alloc
   // on OOM; catch here so the exception never crosses the C boundary

--- a/src/develop/masks/object.c
+++ b/src/develop/masks/object.c
@@ -291,6 +291,7 @@ static gpointer _encode_thread_func(gpointer data)
   {
     dt_print(DT_DEBUG_AI,
              "[object mask] failed to get image buffer for encoding");
+    dt_mipmap_cache_release(&buf);
     dt_dev_cleanup(&dev);
     g_atomic_int_set(&d->encode_state, ENCODE_ERROR);
     return NULL;

--- a/src/develop/masks/object.c
+++ b/src/develop/masks/object.c
@@ -1982,7 +1982,7 @@ const dt_masks_functions_t dt_masks_functions_object = {
 
 gboolean dt_masks_object_available(void)
 {
-  if(!darktable.ai_registry || !darktable.ai_registry->ai_enabled)
+  if(!dt_ai_registry_is_enabled(darktable.ai_registry))
     return FALSE;
   char *model_id = dt_ai_models_get_active_for_task("mask");
   dt_ai_model_t *model = dt_ai_models_get_by_id(darktable.ai_registry, model_id);

--- a/src/gui/preferences_ai.c
+++ b/src/gui/preferences_ai.c
@@ -301,9 +301,7 @@ static void _on_enable_toggled(GtkWidget *widget, gpointer user_data)
   dt_conf_set_bool("plugins/ai/enabled", enabled);
   if(darktable.ai_registry)
   {
-    g_mutex_lock(&darktable.ai_registry->lock);
-    darktable.ai_registry->ai_enabled = enabled;
-    g_mutex_unlock(&darktable.ai_registry->lock);
+    dt_ai_registry_set_enabled(darktable.ai_registry, enabled);
 
     // lazy-init directories + models on first enable
     if(enabled)
@@ -554,7 +552,7 @@ static void _update_provider_status(dt_prefs_ai_data_t *data,
 
   // don't probe GPU providers when AI is disabled —
   // initializing MIGraphX/ROCm on unsupported GPUs can abort()
-  if(!darktable.ai_registry || !darktable.ai_registry->ai_enabled)
+  if(!dt_ai_registry_is_enabled(darktable.ai_registry))
   {
     gtk_label_set_text(GTK_LABEL(data->provider_status), "");
     return;
@@ -589,12 +587,7 @@ static void _on_provider_changed(GtkWidget *widget, gpointer user_data)
   const int combo_idx = dt_bauhaus_combobox_get(widget);
   const int pi = _combo_idx_to_provider(combo_idx, data->supported_providers);
   dt_conf_set_string(DT_AI_CONF_PROVIDER, dt_ai_providers[pi].config_string);
-  if(darktable.ai_registry)
-  {
-    g_mutex_lock(&darktable.ai_registry->lock);
-    darktable.ai_registry->provider = dt_ai_providers[pi].value;
-    g_mutex_unlock(&darktable.ai_registry->lock);
-  }
+  dt_ai_registry_set_provider(darktable.ai_registry, dt_ai_providers[pi].value);
   _update_string_indicator(data->provider_indicator, DT_AI_CONF_PROVIDER);
   _update_provider_status(data, dt_ai_providers[pi].value);
 }

--- a/src/gui/preferences_ai.c
+++ b/src/gui/preferences_ai.c
@@ -776,7 +776,6 @@ static gboolean _update_progress_idle(gpointer user_data)
   g_mutex_lock(&dl->mutex);
   double progress = dl->progress;
   gboolean finished = dl->finished;
-  char *error = dl->error ? g_strdup(dl->error) : NULL;
   g_mutex_unlock(&dl->mutex);
 
   if(dl->dialog && GTK_IS_WIDGET(dl->dialog))
@@ -797,7 +796,6 @@ static gboolean _update_progress_idle(gpointer user_data)
     gtk_dialog_response(GTK_DIALOG(dl->dialog), GTK_RESPONSE_OK);
   }
 
-  g_free(error);
   // removal is owned by the caller; returning G_SOURCE_REMOVE here
   // would race with that explicit remove
   return G_SOURCE_CONTINUE;

--- a/src/libs/neural_restore.c
+++ b/src/libs/neural_restore.c
@@ -2848,6 +2848,12 @@ static gpointer _preview_thread_raw(gpointer data)
     gchar *cfg_file = (cfg_type == DT_COLORSPACE_FILE)
       ? dt_conf_get_string(CONF_ICC_FILE)
       : NULL;
+    const dt_colorspaces_color_profile_t *work_cp
+      = dt_colorspaces_get_work_profile(pd->imgid);
+    const dt_colorspaces_color_profile_type_t dst_type
+      = (cfg_type == DT_COLORSPACE_NONE)
+        ? (work_cp ? work_cp->type : DT_COLORSPACE_LIN_REC2020)
+        : cfg_type;
     dt_imageio_export_with_flags(
       pd->imgid, "unused", &fmt,
       (dt_imageio_module_data_t *)&cap,
@@ -2861,9 +2867,7 @@ static gpointer _preview_thread_raw(gpointer data)
       NULL,   // filter
       FALSE,  // copy_metadata
       FALSE,  // export_masks
-      (cfg_type == DT_COLORSPACE_NONE)
-        ? dt_colorspaces_get_work_profile(pd->imgid)->type
-        : cfg_type,
+      dst_type,
       cfg_file,
       DT_INTENT_PERCEPTUAL,
       NULL, NULL, 1, 1, NULL, -1);

--- a/src/libs/neural_restore.c
+++ b/src/libs/neural_restore.c
@@ -1224,6 +1224,7 @@ static int _process_raw_denoise_bayer(dt_neural_job_t *j,
   g_free(jpeg_buf);
   g_free(exif_blob);
   g_free(cfa_out);
+  if(res != 0) g_unlink(out_filename);
   return res;
 }
 
@@ -1275,6 +1276,7 @@ static int _process_raw_denoise_linear(dt_neural_job_t *j,
   g_free(jpeg_buf);
   g_free(exif_blob);
   dt_free_align(rgb);
+  if(res != 0) g_unlink(out_filename);
   return res;
 }
 

--- a/src/libs/neural_restore.c
+++ b/src/libs/neural_restore.c
@@ -2275,6 +2275,11 @@ static void _cancel_preview(dt_lib_module_t *self)
   d->export_pixels = NULL;
   g_free(d->export_cairo);
   d->export_cairo = NULL;
+  // raw-denoise crops — strength slider would otherwise reblend stale
+  g_free(d->preview_raw_src_rgb);
+  d->preview_raw_src_rgb = NULL;
+  g_free(d->preview_raw_denoised_rgb);
+  d->preview_raw_denoised_rgb = NULL;
   d->picking_thumbnail = FALSE;
   gtk_widget_queue_draw(d->preview_area);
 }

--- a/src/lua/ai.c
+++ b/src/lua/ai.c
@@ -838,18 +838,14 @@ static int _context_close(lua_State *L)
 static int _ai_models(lua_State *L)
 {
   dt_ai_registry_t *reg = darktable.ai_registry;
-  if(!reg)
-  {
-    lua_newtable(L);
-    return 1;
-  }
-
-  g_mutex_lock(&reg->lock);
   lua_newtable(L);
-  int idx = 1;
-  for(GList *l = reg->models; l; l = g_list_next(l))
+  if(!reg) return 1;
+
+  const int count = dt_ai_models_get_count(reg);
+  for(int i = 0; i < count; i++)
   {
-    dt_ai_model_t *m = l->data;
+    dt_ai_model_t *m = dt_ai_models_get_by_index(reg, i);
+    if(!m) continue;
     lua_newtable(L);
     lua_pushstring(L, m->id);
     lua_setfield(L, -2, "id");
@@ -863,9 +859,9 @@ static int _ai_models(lua_State *L)
     lua_setfield(L, -2, "status");
     lua_pushboolean(L, m->is_default);
     lua_setfield(L, -2, "is_default");
-    lua_rawseti(L, -2, idx++);
+    lua_rawseti(L, -2, i + 1);
+    dt_ai_model_free(m);
   }
-  g_mutex_unlock(&reg->lock);
   return 1;
 }
 

--- a/src/lua/ai.c
+++ b/src/lua/ai.c
@@ -1100,6 +1100,11 @@ static int _load_image_from_imgid(lua_State *L)
     .bpp = _lua_capture_bpp,
     .write_image = _lua_capture_write};
 
+  const dt_colorspaces_color_profile_t *work_cp
+    = dt_colorspaces_get_work_profile(imgid);
+  const dt_colorspaces_color_profile_type_t dst_type
+    = work_cp ? work_cp->type : DT_COLORSPACE_LIN_REC2020;
+
   dt_imageio_export_with_flags(imgid,
                                "unused",
                                &fmt,
@@ -1114,7 +1119,7 @@ static int _load_image_from_imgid(lua_State *L)
                                NULL,   // filter
                                FALSE,  // copy_metadata
                                FALSE,  // export_masks
-                               dt_colorspaces_get_work_profile(imgid)->type,
+                               dst_type,
                                NULL,
                                DT_INTENT_PERCEPTUAL,
                                NULL, NULL, 1, 1, NULL, -1);

--- a/src/lua/ai.c
+++ b/src/lua/ai.c
@@ -1565,6 +1565,7 @@ static int _tensor_save_tiff(lua_State *L)
     }
   }
 
+  gboolean write_ok = TRUE;
   if(bpp == 32)
   {
     // write float scanlines (NCHW → HWC interleaved)
@@ -1572,6 +1573,7 @@ static int _tensor_save_tiff(lua_State *L)
     if(!row)
     {
       TIFFClose(tif);
+      g_unlink(path);
       return luaL_error(L, "failed to allocate row buffer");
     }
     for(int y = 0; y < H; y++)
@@ -1579,7 +1581,11 @@ static int _tensor_save_tiff(lua_State *L)
       for(int x = 0; x < W; x++)
         for(int c = 0; c < C; c++)
           row[x * C + c] = t->data[c * H * W + y * W + x];
-      TIFFWriteScanline(tif, row, y, 0);
+      if(TIFFWriteScanline(tif, row, y, 0) < 0)
+      {
+        write_ok = FALSE;
+        break;
+      }
     }
     g_free(row);
   }
@@ -1591,6 +1597,7 @@ static int _tensor_save_tiff(lua_State *L)
     if(!row)
     {
       TIFFClose(tif);
+      g_unlink(path);
       return luaL_error(L, "failed to allocate row buffer");
     }
     for(int y = 0; y < H; y++)
@@ -1602,12 +1609,21 @@ static int _tensor_save_tiff(lua_State *L)
           v = CLAMP(v, 0.0f, 1.0f);
           row[x * C + c] = (uint16_t)(v * 65535.0f + 0.5f);
         }
-      TIFFWriteScanline(tif, row, y, 0);
+      if(TIFFWriteScanline(tif, row, y, 0) < 0)
+      {
+        write_ok = FALSE;
+        break;
+      }
     }
     g_free(row);
   }
 
   TIFFClose(tif);
+  if(!write_ok)
+  {
+    g_unlink(path);
+    return luaL_error(L, "failed to write TIFF '%s'", path);
+  }
   return 0;
 }
 

--- a/src/lua/ai.c
+++ b/src/lua/ai.c
@@ -37,6 +37,10 @@
 #include <string.h>
 #include <tiffio.h>
 
+#ifdef _WIN32
+#include <wchar.h>
+#endif
+
 /* maximum tensor dimensions */
 #define MAX_TENSOR_DIMS 8
 
@@ -1525,7 +1529,13 @@ static int _tensor_save_tiff(lua_State *L)
     return luaL_error(L,
       "save_tiff requires 1 or 3 channels, got %d", C);
 
+#ifdef _WIN32
+  wchar_t *wpath = g_utf8_to_utf16(path, -1, NULL, NULL, NULL);
+  TIFF *tif = wpath ? TIFFOpenW(wpath, "w") : NULL;
+  g_free(wpath);
+#else
   TIFF *tif = TIFFOpen(path, "w");
+#endif
   if(!tif)
     return luaL_error(L, "cannot open '%s' for writing", path);
 

--- a/src/tests/unittests/ai/test_ai_backend.c
+++ b/src/tests/unittests/ai/test_ai_backend.c
@@ -332,7 +332,7 @@ static void test_load_opt_levels(void **state)
   // DT_AI_OPT_BASIC
   dt_ai_context_t *ctx_basic
     = dt_ai_load_model_ext(env, "test-multiply", NULL,
-                           DT_AI_PROVIDER_CPU, DT_AI_OPT_BASIC, NULL, 0, 0);
+                           DT_AI_PROVIDER_CPU, DT_AI_OPT_BASIC, NULL, 0);
   assert_non_null(ctx_basic);
 
   // verify inference still works with basic optimization
@@ -348,7 +348,7 @@ static void test_load_opt_levels(void **state)
   // DT_AI_OPT_DISABLED
   dt_ai_context_t *ctx_none
     = dt_ai_load_model_ext(env, "test-multiply", NULL,
-                           DT_AI_PROVIDER_CPU, DT_AI_OPT_DISABLED, NULL, 0, 0);
+                           DT_AI_PROVIDER_CPU, DT_AI_OPT_DISABLED, NULL, 0);
   assert_non_null(ctx_none);
   dt_ai_unload_model(ctx_none);
 }


### PR DESCRIPTION
I ran a multi-pass AI-assisted review over the new AI subsystem code – headers, core implementation, domain logic, UI layer, Lua bindings, and a few adjacent non-AI files. I traced every claim line-by-line against the actual code before touching anything, and roughly one in five survived that check. The rest is in this PR.

Everything here is small and preventive. No new features, no behaviour rewrites, no refactors beyond the minimum needed for a specific bug. Each finding is its own commit so anything can be cherry-picked or reverted on its own.

## What's in here

- **NULL-deref guards** where I was dereferencing helper return values without checking – the safe pattern already existed elsewhere in the same files, the new code just hadn't picked it up.
- **Cleanup on error paths**: mipmap cache release, stale raw-preview crops on image switch, partial DNG/TIFF files unlinked when the write fails partway.
- **Atomic disk writes** via temp + rename (`.dtmodel` install, segmentation disk cache). A crash mid-write no longer leaves a half-written file that confuses the next run.
- **Surfacing return codes** that were getting silently swallowed – `dt_ai_run`, `TIFFWriteScanline`, decoder warmup.
- **Bounds and sanity checks** for caller-controlled inputs: densecrf sigmas, decoder shape updates that would otherwise read past the mask buffer.
- **Runtime preflights** so ORT can't `abort()` the process during execution-provider init on a broken CUDA or ROCm stack.
- **API cleanup**: `dt_ai_registry_t` is now opaque to external callers, the unused `ep_flags` parameter is gone, `dt_ai_snapshot_conf_state` is idempotent.
- **Documentation**: threading contracts and pointer-lifetime contracts where they weren't written down.

## Risk

Low. Most fixes are one-line guards or unlink-on-failure additions. The largest single change is the opaque-registry refactor (`f4bd660574`) – a mechanical rename that keeps the same semantics under the same lock as before.