### PR TITLE
[CI/CD] Remove emergency libheif fix for macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -362,7 +362,7 @@ jobs:
           brew update > /dev/null || true
           cd src/.ci
           export HOMEBREW_NO_INSTALL_UPGRADE=1
-          brew bundle --quiet || true
+          brew bundle --verbose || true
       - name: Build and Install
         run: |
           # Emergency fix for broken libheif header file. Should be removed when a fixed libheif package is available in Homebrew.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -365,8 +365,6 @@ jobs:
           brew bundle --verbose || true
       - name: Build and Install
         run: |
-          # Emergency fix for broken libheif header file. Should be removed when a fixed libheif package is available in Homebrew.
-          perl -pi -e 's/struct heif_bad_pixel { uint32_t row; uint32_t column; };/typedef struct heif_bad_pixel { uint32_t row; uint32_t column; } heif_bad_pixel;/g' /opt/homebrew/include/libheif/heif_properties.h
           cmake -E make_directory "${BUILD_DIR}";
           cmake -E make_directory "${INSTALL_PREFIX}";
           ./src/.ci/ci-script.sh;

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -396,8 +396,6 @@ jobs:
         uses: andymckay/cancel-action@0.5
       - name: Build and Install
         run: |
-          # Emergency fix for broken libheif header file. Should be removed when a fixed libheif package is available in Homebrew.
-          perl -pi -e 's/struct heif_bad_pixel { uint32_t row; uint32_t column; };/typedef struct heif_bad_pixel { uint32_t row; uint32_t column; } heif_bad_pixel;/g' /opt/homebrew/include/libheif/heif_properties.h /usr/local/include/libheif/heif_properties.h
           cmake -E make_directory "${BUILD_DIR}";
           cmake -E make_directory "${INSTALL_PREFIX}";
           ./src/.ci/ci-script.sh;

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -382,7 +382,7 @@ jobs:
           brew update > /dev/null || true
           cd src/.ci
           export HOMEBREW_NO_INSTALL_UPGRADE=1
-          brew bundle --quiet || true
+          brew bundle --verbose || true
 
           # rebuild graphicsmagick for macOS bundling
           export HOMEBREW_NO_INSTALL_FROM_API=1


### PR DESCRIPTION
Additionally, I added verbosity when installing Homebrew packages so that when investigating problems, we can see the versions of the packages being installed.