### PR TITLE
A few more calloc and dt_strlcpy_to_fixed fixes

### DIFF
--- a/src/iop/borders.c
+++ b/src/iop/borders.c
@@ -188,7 +188,7 @@ int legacy_params(dt_iop_module_t *self,
     } dt_iop_borders_params_v1_t;
 
     const dt_iop_borders_params_v1_t *o = (dt_iop_borders_params_v1_t *)old_params;
-    dt_iop_borders_params_v3_t *n = malloc(sizeof(dt_iop_borders_params_v3_t));
+    dt_iop_borders_params_v3_t *n = calloc(1, sizeof(dt_iop_borders_params_v3_t));
 
     *n = default_v3; // start with a fresh copy of default parameters
     memcpy(n->color, o->color, sizeof(o->color));
@@ -224,7 +224,7 @@ int legacy_params(dt_iop_module_t *self,
     } dt_iop_borders_params_v2_t;
 
     const dt_iop_borders_params_v2_t *o = (dt_iop_borders_params_v2_t *)old_params;
-    dt_iop_borders_params_v3_t *n = malloc(sizeof(dt_iop_borders_params_v3_t));
+    dt_iop_borders_params_v3_t *n = calloc(1, sizeof(dt_iop_borders_params_v3_t));
 
     memcpy(n, o, sizeof(struct dt_iop_borders_params_v2_t));
     n->max_border_size = FALSE;
@@ -268,7 +268,7 @@ int legacy_params(dt_iop_module_t *self,
     } dt_iop_borders_params_v4_t;
 
     const dt_iop_borders_params_v3_t *o = (dt_iop_borders_params_v3_t *)old_params;
-    dt_iop_borders_params_v4_t *n = malloc(sizeof(dt_iop_borders_params_v4_t));
+    dt_iop_borders_params_v4_t *n = calloc(1, sizeof(dt_iop_borders_params_v4_t));
 
     memcpy(n, o, sizeof(struct dt_iop_borders_params_v3_t));
 

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -31,6 +31,7 @@
 #include "common/file_location.h"
 #include "common/imagebuf.h"
 #include "common/opencl.h"
+#include "common/utility.h"
 #include "control/control.h"
 #include "develop/develop.h"
 #include "develop/imageop.h"
@@ -3442,9 +3443,9 @@ void reload_defaults(dt_iop_module_t *self)
   dt_iop_lens_params_t *d = (dt_iop_lens_params_t *)self->default_params;
 
   new_lens = _lens_sanitize(img->exif_lens);
-  g_strlcpy(d->lens, new_lens, sizeof(d->lens));
+  dt_strlcpy_to_fixed(d->lens, new_lens, sizeof(d->lens));
   free(new_lens);
-  g_strlcpy(d->camera, img->exif_model, sizeof(d->camera));
+  dt_strlcpy_to_fixed(d->camera, img->exif_model, sizeof(d->camera));
   d->crop = img->exif_crop;
   d->aperture = img->exif_aperture;
   d->focal = img->exif_focal_length;
@@ -3495,7 +3496,7 @@ void reload_defaults(dt_iop_module_t *self)
          *
          * Let's unset lens name and re-run lens query
          */
-        g_strlcpy(d->lens, "", sizeof(d->lens));
+        dt_strlcpy_to_fixed(d->lens, "", sizeof(d->lens));
 
         dt_pthread_mutex_lock(&darktable.plugin_threadsafe);
         lens = gd->db->FindLenses(cam[0], NULL, d->lens, 0);
@@ -3528,7 +3529,7 @@ void reload_defaults(dt_iop_module_t *self)
           }
 
           // and set lens to it
-          g_strlcpy(d->lens, lens[lens_i]->Model, sizeof(d->lens));
+          dt_strlcpy_to_fixed(d->lens, lens[lens_i]->Model, sizeof(d->lens));
         }
 
         d->target_geom = _lenstype_from_lensfun_lenstype(lens[lens_i]->Type);
@@ -3727,7 +3728,7 @@ static void _camera_set(dt_iop_module_t *self, const lfCamera *cam)
     return;
   }
 
-  g_strlcpy(p->camera, cam->Model, sizeof(p->camera));
+  dt_strlcpy_to_fixed(p->camera, cam->Model, sizeof(p->camera));
   p->crop = cam->CropFactor;
   g->camera = cam;
 
@@ -3951,7 +3952,7 @@ static void _lens_set(dt_iop_module_t *self,
   maker = lf_mlstr_get(lens->Maker);
   model = lf_mlstr_get(lens->Model);
 
-  g_strlcpy(p->lens, lens->Model, sizeof(p->lens));
+  dt_strlcpy_to_fixed(p->lens, lens->Model, sizeof(p->lens));
 
   if(model)
   {

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -438,7 +438,7 @@ int legacy_params(dt_iop_module_t *self,
 
     const dt_iop_lens_params_v2_t *o = (dt_iop_lens_params_v2_t *)old_params;
     dt_iop_lens_params_v10_t *n =
-      (dt_iop_lens_params_v10_t *)malloc(sizeof(dt_iop_lens_params_v10_t));
+      (dt_iop_lens_params_v10_t *)calloc(1, sizeof(dt_iop_lens_params_v10_t));
 
     n->modify_flags = _modflags_from_lensfun_mods(o->modify_flags);
     n->inverse = (dt_iop_lens_mode_t)o->inverse;
@@ -506,7 +506,7 @@ int legacy_params(dt_iop_module_t *self,
 
     const dt_iop_lens_params_v3_t *o = (dt_iop_lens_params_v3_t *)old_params;
     dt_iop_lens_params_v10_t *n =
-      (dt_iop_lens_params_v10_t *)malloc(sizeof(dt_iop_lens_params_v10_t));
+      (dt_iop_lens_params_v10_t *)calloc(1, sizeof(dt_iop_lens_params_v10_t));
 
     n->modify_flags = _modflags_from_lensfun_mods(o->modify_flags);
     n->inverse = (dt_iop_lens_mode_t)o->inverse;
@@ -573,7 +573,7 @@ int legacy_params(dt_iop_module_t *self,
 
     const dt_iop_lens_params_v4_t *o = (dt_iop_lens_params_v4_t *)old_params;
     dt_iop_lens_params_v10_t *n =
-      (dt_iop_lens_params_v10_t *)malloc(sizeof(dt_iop_lens_params_v10_t));
+      (dt_iop_lens_params_v10_t *)calloc(1, sizeof(dt_iop_lens_params_v10_t));
 
     n->modify_flags = _modflags_from_lensfun_mods(o->modify_flags);
     n->inverse = (dt_iop_lens_mode_t)o->inverse;
@@ -640,7 +640,7 @@ int legacy_params(dt_iop_module_t *self,
 
     const dt_iop_lens_params_v5_t *o = (dt_iop_lens_params_v5_t *)old_params;
     dt_iop_lens_params_v10_t *n =
-      (dt_iop_lens_params_v10_t *)malloc(sizeof(dt_iop_lens_params_v10_t));
+      (dt_iop_lens_params_v10_t *)calloc(1, sizeof(dt_iop_lens_params_v10_t));
 
     // The unique method in previous versions was Lensfun
     n->modify_flags = _modflags_from_lensfun_mods(o->modify_flags);
@@ -713,7 +713,7 @@ int legacy_params(dt_iop_module_t *self,
 
     const dt_iop_lens_params_v6_t *o = (dt_iop_lens_params_v6_t *)old_params;
     dt_iop_lens_params_v10_t *n =
-      (dt_iop_lens_params_v10_t *)malloc(sizeof(dt_iop_lens_params_v10_t));
+      (dt_iop_lens_params_v10_t *)calloc(1, sizeof(dt_iop_lens_params_v10_t));
 
     n->method = o->method;
     n->modify_flags = (dt_iop_lens_modflag_t)o->modify_flags;
@@ -787,7 +787,7 @@ int legacy_params(dt_iop_module_t *self,
 
     const dt_iop_lens_params_v7_t *o = (dt_iop_lens_params_v7_t *)old_params;
     dt_iop_lens_params_v10_t *n =
-      (dt_iop_lens_params_v10_t *)malloc(sizeof(dt_iop_lens_params_v10_t));
+      (dt_iop_lens_params_v10_t *)calloc(1, sizeof(dt_iop_lens_params_v10_t));
 
     n->method = o->method;
     n->modify_flags = (dt_iop_lens_modflag_t)o->modify_flags;
@@ -862,7 +862,7 @@ int legacy_params(dt_iop_module_t *self,
 
     const dt_iop_lens_params_v8_t *o = (dt_iop_lens_params_v8_t *)old_params;
     dt_iop_lens_params_v10_t *n =
-      (dt_iop_lens_params_v10_t *)malloc(sizeof(dt_iop_lens_params_v10_t));
+      (dt_iop_lens_params_v10_t *)calloc(1, sizeof(dt_iop_lens_params_v10_t));
 
     n->method = o->method;
     n->modify_flags = (dt_iop_lens_modflag_t)o->modify_flags;
@@ -931,7 +931,7 @@ int legacy_params(dt_iop_module_t *self,
 
     const dt_iop_lens_params_v9_t *o = (dt_iop_lens_params_v9_t *)old_params;
     dt_iop_lens_params_v10_t *n =
-      (dt_iop_lens_params_v10_t *)malloc(sizeof(dt_iop_lens_params_v10_t));
+      (dt_iop_lens_params_v10_t *)calloc(1, sizeof(dt_iop_lens_params_v10_t));
 
     memcpy(n, o, sizeof(dt_iop_lens_params_v9_t));
     // new in v10

--- a/src/iop/lut3d.c
+++ b/src/iop/lut3d.c
@@ -185,7 +185,7 @@ int legacy_params(dt_iop_module_t *self,
     } dt_iop_lut3d_params_v1_t;
 
     const dt_iop_lut3d_params_v1_t *o = (dt_iop_lut3d_params_v1_t *)old_params;
-    dt_iop_lut3d_params_v3_t *n = malloc(sizeof(dt_iop_lut3d_params_v3_t));
+    dt_iop_lut3d_params_v3_t *n = calloc(1, sizeof(dt_iop_lut3d_params_v3_t));
     g_strlcpy(n->filepath, o->filepath, sizeof(n->filepath));
     n->colorspace = o->colorspace;
     n->interpolation = o->interpolation;
@@ -212,7 +212,7 @@ int legacy_params(dt_iop_module_t *self,
     } dt_iop_lut3d_params_v2_t;
 
     const dt_iop_lut3d_params_v2_t *o = (dt_iop_lut3d_params_v2_t *)old_params;
-    dt_iop_lut3d_params_v3_t *n = malloc(sizeof(dt_iop_lut3d_params_v3_t));
+    dt_iop_lut3d_params_v3_t *n = calloc(1, sizeof(dt_iop_lut3d_params_v3_t));
     memcpy(n, o, sizeof(dt_iop_lut3d_params_v3_t)); // v3 is smaller
 
     *new_params = n;

--- a/src/iop/lut3d.c
+++ b/src/iop/lut3d.c
@@ -22,6 +22,7 @@
 #include "common/colorspaces_inline_conversions.h"
 #include "common/file_location.h"
 #include "common/iop_profile.h"
+#include "common/utility.h"
 #include "develop/imageop.h"
 #include "develop/imageop_gui.h"
 #include "dtgtk/button.h"
@@ -1425,12 +1426,12 @@ static void _filepath_callback(GtkWidget *widget, dt_iop_module_t *self)
       p->lutname[0] = 0;
       _lut3d_clear_lutname_list(g);
     }
-    g_strlcpy(p->filepath, filepath, sizeof(p->filepath));
+    dt_strlcpy_to_fixed(p->filepath, filepath, sizeof(p->filepath));
     _get_compressed_clut(self, FALSE);
     _show_hide_controls(self);
     gtk_entry_set_text(GTK_ENTRY(g->lutentry), "");
 #else
-    g_strlcpy(p->filepath, filepath, sizeof(p->filepath));
+    dt_strlcpy_to_fixed(p->filepath, filepath, sizeof(p->filepath));
 #endif // HAVE_GMIC
     dt_dev_add_history_item(darktable.develop, self, TRUE);
   }
@@ -1456,7 +1457,7 @@ static void _lutname_callback(GtkTreeSelection *selection, dt_iop_module_t *self
     gtk_tree_model_get(model, &iter, DT_LUT3D_COL_NAME, &lutname, -1);
     if(lutname[0] && strcmp(lutname, p->lutname) != 0)
     {
-      g_strlcpy(p->lutname, lutname, sizeof(p->lutname));
+      dt_strlcpy_to_fixed(p->lutname, lutname, sizeof(p->lutname));
       _get_compressed_clut(self, TRUE);
       dt_dev_add_history_item(darktable.develop, self, TRUE);
     }


### PR DESCRIPTION
A follow-up to #21133 -- some legacy param migrations to avoid data leaks, some string copies to improve hash stability. For example, in `lens`, if selecting between lenses manually, the remnants of an old lens names were not zeroed out, so switching from a short-named lens to a long-named and back would change the hash for caching.
I think this now includes all the low-hanging fruit.
