### PR TITLE
Fix culling pan/zoom bounds for letterboxed images

### DIFF
--- a/src/dtgtk/culling.c
+++ b/src/dtgtk/culling.c
@@ -409,15 +409,16 @@ static gboolean _zoom_to_center(dt_thumbnail_t *th,
   int iw = 0;
   int ih = 0;
   gtk_widget_get_size_request(th->w_image_box, &iw, &ih);
-  // Compute the bound from the new zoom directly. img_width * z_ratio assumes
-  // the surface is at the previous zoom, but during deferred pinch zoom the
-  // surface stays at the gesture-start zoom and z_ratio is only the per-step
-  // ratio — so img_width * z_ratio under-estimates the effective width and the
-  // image progressively drifts toward the top-left corner.
-  int img_w = 0, img_h = 0;
-  gtk_widget_get_size_request(th->w_image, &img_w, &img_h);
-  const float effective_w = (float)img_w * darktable.gui->ppd_thb * zd;
-  const float effective_h = (float)img_h * darktable.gui->ppd_thb * zd;
+  // Bound to the real rendered image extent rather than box*zoom: the latter
+  // assumes the image fills the box, but a photo whose aspect ratio differs from
+  // the box is letterboxed, so box*zoom over-estimates the extent in the
+  // letterboxed dimension and the image drifts toward that edge.
+  // img_width/img_height are at th->img_surf_zoom; scale to the new zoom zd. This
+  // references the surface zoom directly (not the per-step z_ratio), so it stays
+  // correct across a whole deferred gesture where the surface is never reloaded.
+  const float zr = (th->img_surf_zoom > 0.0f) ? zd / th->img_surf_zoom : 1.0f;
+  const float effective_w = (float)th->img_width * zr;
+  const float effective_h = (float)th->img_height * zr;
   th->zoomx = fmaxf((float)iw - effective_w,
                     fminf(0.0f, iw / 2.0 - (iw / 2.0 - th->zoomx) * z_ratio));
   th->zoomy = fmaxf((float)ih - effective_h,
@@ -734,7 +735,11 @@ static gboolean _event_scroll(GtkWidget *widget,
       dt_print(DT_DEBUG_INPUT,
                "[culling scroll] ctrl+scroll zoom_delta=%.2f x_culling=%.1f y_culling=%.1f",
                zoom_delta, x_culling, y_culling);
-      _thumbs_zoom_add(table, zoom_delta, x_culling, y_culling, e->state, TRUE);
+      // discrete wheel: a single click has no continuous gesture and emits no
+      // smooth is_stop event to finalise it, so reload the surface immediately
+      // (still cheap — the native mipmap surface cache is reused).  Leaving it
+      // deferred would freeze the image at a stale, scaled-up resolution.
+      _thumbs_zoom_add(table, zoom_delta, x_culling, y_culling, e->state, FALSE);
     }
     else
     {
@@ -925,8 +930,11 @@ static gboolean _event_motion_notify(GtkWidget *widget,
       int iw = 0;
       int ih = 0;
       gtk_widget_get_size_request(th->w_image, &iw, &ih);
-      const int mindx = (int)(iw * darktable.gui->ppd_thb * (1.0f - th->zoom));
-      const int mindy = (int)(ih * darktable.gui->ppd_thb * (1.0f - th->zoom));
+      // bound to the real rendered image extent (handles letterboxing), scaled to
+      // the current zoom in case the surface is still at the gesture-start zoom.
+      const float zr = (th->img_surf_zoom > 0.0f) ? th->zoom / th->img_surf_zoom : 1.0f;
+      const int mindx = (int)(iw * darktable.gui->ppd_thb - th->img_width * zr);
+      const int mindy = (int)(ih * darktable.gui->ppd_thb - th->img_height * zr);
       if(th->zoomx > 0)
         th->zoomx = 0;
       if(th->zoomx < mindx)
@@ -2313,8 +2321,11 @@ gboolean dt_culling_pan_move(dt_culling_t *table,
     dt_thumbnail_t *th = l->data;
     int iw = 0, ih = 0;
     gtk_widget_get_size_request(th->w_image, &iw, &ih);
-    const int mindx = (int)(iw * darktable.gui->ppd_thb * (1.0f - th->zoom));
-    const int mindy = (int)(ih * darktable.gui->ppd_thb * (1.0f - th->zoom));
+    // bound to the real rendered image extent (handles letterboxing), scaled to
+    // the current zoom in case the surface is still at the gesture-start zoom.
+    const float zr = (th->img_surf_zoom > 0.0f) ? th->zoom / th->img_surf_zoom : 1.0f;
+    const int mindx = (int)(iw * darktable.gui->ppd_thb - th->img_width * zr);
+    const int mindy = (int)(ih * darktable.gui->ppd_thb - th->img_height * zr);
     if(th->zoomx > 0) th->zoomx = 0;
     if(th->zoomx < mindx) th->zoomx = mindx;
     if(th->zoomy > 0) th->zoomy = 0;

--- a/src/dtgtk/thumbnail.c
+++ b/src/dtgtk/thumbnail.c
@@ -372,19 +372,14 @@ static void _thumb_draw_image(dt_thumbnail_t *thumb,
     cairo_save(cr);
     const float scaler = 1.0f / darktable.gui->ppd_thb;
 
-    // During an active zoom gesture (zoom_preview_pending) the surface may have been
-    // rendered at a different zoom level (zoom_rendered) than the current th->zoom.
-    // Compute an extra scale factor so the stale surface is displayed at the correct
-    // visual size without needing to reload/recreate it.  When zoom_rendered == th->zoom
-    // (normal case) extra_scale collapses to 1.0 and the code path is identical to before.
+    // During an active zoom gesture (zoom_preview_pending) the surface was rendered
+    // at thumb->img_surf_zoom while thumb->zoom has already advanced.  Compute an extra
+    // scale factor so the stale surface is displayed at the correct visual size without
+    // reloading it.  When img_surf_zoom == thumb->zoom (normal case) extra_scale collapses
+    // to 1.0 and the code path is identical to before.
     float extra_scale = 1.0f;
-    if(w > 0 && thumb->img_width > 0 && thumb->zoom > 0.0f)
-    {
-      const float zoom_rendered = (float)thumb->img_width
-                                  / ((float)w * darktable.gui->ppd_thb);
-      if(zoom_rendered > 0.0f)
-        extra_scale = CLAMP(thumb->zoom / zoom_rendered, 0.1f, 20.0f);
-    }
+    if(thumb->img_surf_zoom > 0.0f && thumb->zoom > 0.0f)
+      extra_scale = CLAMP(thumb->zoom / thumb->img_surf_zoom, 0.1f, 20.0f);
 
     // Apply outer scaler (handles HiDPI) for frame; apply extra_scale inner for image.
     cairo_scale(cr, scaler, scaler);
@@ -814,6 +809,9 @@ static gboolean _event_image_draw(GtkWidget *widget,
     {
       thumb->img_width = cairo_image_surface_get_width(thumb->img_surf);
       thumb->img_height = cairo_image_surface_get_height(thumb->img_surf);
+      // record the zoom this surface was rendered at, so deferred-gesture bound
+      // math can scale the real surface extent to the current (advancing) zoom.
+      thumb->img_surf_zoom = thumb->zoom;
       // and we want to resize the imagebox to fit in the imagearea
       const int imgbox_w = MIN(image_w, thumb->img_width / darktable.gui->ppd_thb);
       const int imgbox_h = MIN(image_h, thumb->img_height / darktable.gui->ppd_thb);
@@ -1734,6 +1732,7 @@ dt_thumbnail_t *dt_thumbnail_new(const int width,
   thumb->zoomable = (container == DT_THUMBNAIL_CONTAINER_CULLING
                      || container == DT_THUMBNAIL_CONTAINER_PREVIEW);
   thumb->zoom = 1.0f;
+  thumb->img_surf_zoom = 1.0f;
   thumb->overlay_timeout_duration = dt_conf_get_int("plugins/lighttable/overlay_timeout");
   thumb->tooltip = tooltip;
   thumb->expose_again_timeout_id = 0;
@@ -2365,16 +2364,24 @@ void dt_thumbnail_set_overlay(dt_thumbnail_t *thumb,
 void dt_thumbnail_image_refresh_position(dt_thumbnail_t *thumb)
 {
   // let's sanitize and apply panning values
-  // Use thumb->zoom (always current) rather than img_width/img_height: during a
-  // deferred pinch-zoom gesture the surface may still be at zoom=1.0 while
-  // thumb->zoom has been advanced, so img_width-based bounds would clamp to 0
-  // and discard the in-flight pan. After a surface reload these formulas are
-  // algebraically identical since img_width = iw * ppd_thb * zoom.
+  // Bound the pan to the real rendered image extent (img_width/img_height), which
+  // accounts for letterboxing when the image aspect ratio differs from the box.
+  // During a deferred gesture the surface is still at img_surf_zoom while thumb->zoom
+  // has advanced, so we scale the extent by (zoom / img_surf_zoom). When the surface
+  // is current this ratio is 1.0 and the bound is the exact image edge.
   int iw = 0;
   int ih = 0;
   gtk_widget_get_size_request(thumb->w_image, &iw, &ih);
-  thumb->zoomx = CLAMP(thumb->zoomx, iw * (1.0f - thumb->zoom), 0);
-  thumb->zoomy = CLAMP(thumb->zoomy, ih * (1.0f - thumb->zoom), 0);
+  const float zr =
+    (thumb->img_surf_zoom > 0.0f) ? thumb->zoom / thumb->img_surf_zoom : 1.0f;
+  thumb->zoomx =
+    CLAMP(thumb->zoomx,
+          (iw * darktable.gui->ppd_thb - thumb->img_width * zr) / darktable.gui->ppd_thb,
+          0);
+  thumb->zoomy =
+    CLAMP(thumb->zoomy,
+          (ih * darktable.gui->ppd_thb - thumb->img_height * zr) / darktable.gui->ppd_thb,
+          0);
   gtk_widget_queue_draw(thumb->w_main);
 }
 

--- a/src/dtgtk/thumbnail.h
+++ b/src/dtgtk/thumbnail.h
@@ -109,6 +109,10 @@ typedef struct
   gboolean img_surf_preview; // if TRUE, the image is originated from preview pipe
   gboolean img_surf_dirty;   // if TRUE, we need to recreate the surface on next drawing code
   gboolean zoom_preview_pending; // TRUE during active gesture: draw stale surface scaled, defer surface reload
+  float img_surf_zoom; // the thumb->zoom value img_surf was actually rendered at.
+                       // During a deferred gesture thumb->zoom advances while img_surf
+                       // (and img_width/img_height) stay at this value, so bound math
+                       // scales the real surface extent by (zoom / img_surf_zoom).
   // Cache of the native-resolution (pre-scaling) color-converted mipmap surface.
   // Reused across zoom events at the same mipmap level so the expensive
   // calloc + color-transform is only done once per mip-level transition.


### PR DESCRIPTION
Commit efebaa3586 (the surface-caching optimization) replaced the real rendered image extent (img_width/img_height) in the pan/zoom bound math with box_size * zoom. Those are only equal when the photo fills the image box — a letterboxed/pillarboxed photo over-estimates the pannable range in the boxed dimension. Result: navigating left/right in culling made the image jump left while keeping vertical alignment, and discrete ctrl+scroll got stuck in a never-finalized deferred preview at a stale resolution.
The fix restores the real-extent bounds and keeps them correct mid-gesture by scaling with zoom / img_surf_zoom.

Fixes: https://github.com/darktable-org/darktable/issues/21132

Disclaimer: this work was co-created with Claude.