### PR TITLE
Rename some OpenCL functions

### DIFF
--- a/src/common/guided_filter.c
+++ b/src/common/guided_filter.c
@@ -676,13 +676,13 @@ static int _guided_filter_cl_fallback(int devid,
   if(!guide_host || !in_host || !out_host)
     goto error;
 
-  err = dt_opencl_copy_device_to_host(devid, guide_host, guide, width, height, ch * sizeof(float));
+  err = dt_opencl_copy_image_to_host(devid, guide_host, guide, width, height, ch * sizeof(float));
   if(err != CL_SUCCESS) goto error;
-  err = dt_opencl_copy_device_to_host(devid, in_host, in, width, height, sizeof(float));
+  err = dt_opencl_copy_image_to_host(devid, in_host, in, width, height, sizeof(float));
   if(err != CL_SUCCESS) goto error;
 
   guided_filter(guide_host, in_host, out_host, width, height, ch, w, sqrt_eps, guide_weight, min, max);
-  err = dt_opencl_write_host_to_device(devid, out_host, out, width, height, sizeof(float));
+  err = dt_opencl_write_host_to_image(devid, out_host, out, width, height, sizeof(float));
 
 error:
   if(err != CL_SUCCESS)  

--- a/src/common/iop_profile.c
+++ b/src/common/iop_profile.c
@@ -1433,8 +1433,7 @@ cl_int dt_ioppr_build_iccprofile_params_cl(const dt_iop_order_iccprofile_info_t 
       goto cleanup;
     }
 
-    dev_profile_lut = dt_opencl_copy_host_to_device(devid, profile_lut_cl, 256, 256 * 6,
-                                                    sizeof(float));
+    dev_profile_lut = dt_opencl_copy_host_to_image(devid, profile_lut_cl, 256, 256 * 6, sizeof(float));
     if(dev_profile_lut == NULL)
       err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
   }
@@ -1443,8 +1442,7 @@ cl_int dt_ioppr_build_iccprofile_params_cl(const dt_iop_order_iccprofile_info_t 
     profile_lut_cl = calloc(1, sizeof(cl_float) * 1 * 6);
 
     if(profile_lut_cl)
-      dev_profile_lut = dt_opencl_copy_host_to_device(devid, profile_lut_cl, 1, 1 * 6,
-                                                      sizeof(float));
+      dev_profile_lut = dt_opencl_copy_host_to_image(devid, profile_lut_cl, 1, 1 * 6, sizeof(float));
     else
       dev_profile_lut = NULL;
 
@@ -1579,7 +1577,7 @@ gboolean dt_ioppr_transform_image_colorspace_cl(struct dt_iop_module_t *self,
 
     dev_profile_info = dt_opencl_copy_host_to_device_constant(devid, sizeof(profile_info_cl),
                                                               &profile_info_cl);
-    dev_lut = dt_opencl_copy_host_to_device(devid, lut_cl, 256, 256 * 6, sizeof(float));
+    dev_lut = dt_opencl_copy_host_to_image(devid, lut_cl, 256, 256 * 6, sizeof(float));
 
     if(dev_profile_info == NULL || dev_lut == NULL)
     {
@@ -1610,7 +1608,7 @@ gboolean dt_ioppr_transform_image_colorspace_cl(struct dt_iop_module_t *self,
       goto cleanup;
     }
 
-    err = dt_opencl_copy_device_to_host(devid, src_buffer, dev_img_in,
+    err = dt_opencl_copy_image_to_host(devid, src_buffer, dev_img_in,
                                         width, height, 4 * sizeof(float));
     if(err != CL_SUCCESS)
       goto cleanup;
@@ -1620,7 +1618,7 @@ gboolean dt_ioppr_transform_image_colorspace_cl(struct dt_iop_module_t *self,
                                         width, height, cst_from, cst_to,
                                         converted_cst, profile_info);
 
-    err = dt_opencl_write_host_to_device(devid, src_buffer, dev_img_out,
+    err = dt_opencl_write_host_to_image(devid, src_buffer, dev_img_out,
                                          width, height, 4 * sizeof(float));
   }
 
@@ -1716,11 +1714,11 @@ gboolean dt_ioppr_transform_image_colorspace_rgb_cl
 
     dev_profile_info_from = dt_opencl_copy_host_to_device_constant(devid, sizeof(profile_info_from_cl),
                                                  &profile_info_from_cl);
-    dev_lut_from = dt_opencl_copy_host_to_device(devid, lut_from_cl, 256, 256 * 6, sizeof(float));
+    dev_lut_from = dt_opencl_copy_host_to_image(devid, lut_from_cl, 256, 256 * 6, sizeof(float));
 
     dev_profile_info_to = dt_opencl_copy_host_to_device_constant(devid, sizeof(profile_info_to_cl),
                                                  &profile_info_to_cl);
-    dev_lut_to = dt_opencl_copy_host_to_device(devid, lut_to_cl, 256, 256 * 6, sizeof(float));
+    dev_lut_to = dt_opencl_copy_host_to_image(devid, lut_to_cl, 256, 256 * 6, sizeof(float));
 
     float matrix3x3[9];
     pack_3xSSE_to_3x3(matrix, matrix3x3);
@@ -1768,7 +1766,7 @@ gboolean dt_ioppr_transform_image_colorspace_rgb_cl
       goto cleanup;
     }
 
-    err = dt_opencl_copy_device_to_host(devid, src_buffer_in, dev_img_in,
+    err = dt_opencl_copy_image_to_host(devid, src_buffer_in, dev_img_in,
                                         width, height, 4 * sizeof(float));
     if(err != CL_SUCCESS)
       goto cleanup;
@@ -1778,7 +1776,7 @@ gboolean dt_ioppr_transform_image_colorspace_rgb_cl
                                             width, height, profile_info_from,
                                             profile_info_to, message);
 
-    err = dt_opencl_write_host_to_device(devid, src_buffer_out, dev_img_out,
+    err = dt_opencl_write_host_to_image(devid, src_buffer_out, dev_img_out,
                                          width, height, 4 * sizeof(float));
   }
 

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -2868,7 +2868,7 @@ int dt_opencl_enqueue_kernel_1d_args_internal(const int dev,
   return dt_opencl_enqueue_kernel_ndim_with_local(dev, kernel, sizes, NULL, 1);
 }
 
-int dt_opencl_copy_device_to_host(const int devid,
+int dt_opencl_copy_image_to_host(const int devid,
                                   void *host,
                                   cl_mem image,
                                   const int width,
@@ -2880,11 +2880,11 @@ int dt_opencl_copy_device_to_host(const int devid,
 
   const size_t region[2] = { width, height };
   // blocking.
-  return dt_opencl_read_host_from_device_raw(devid, host, image, CLIMG_ORIGIN,
+  return dt_opencl_read_host_from_image_raw(devid, host, image, CLIMG_ORIGIN,
                                              region, (size_t)width * bpp, TRUE);
 }
 
-int dt_opencl_read_host_from_device_raw(const int devid,
+int dt_opencl_read_host_from_image_raw(const int devid,
                                         void *host,
                                         cl_mem image,
                                         const size_t *origin,
@@ -2909,17 +2909,17 @@ int dt_opencl_read_host_from_device_raw(const int devid,
 
   if(err != CL_SUCCESS)
     dt_print(DT_DEBUG_OPENCL,
-             "[dt_opencl_read_host_from_device_raw] could not read image from device '%s' id=%d: %s",
+             "[dt_opencl_read_host_from_image_raw] could not read image from device '%s' id=%d: %s",
              darktable.opencl->dev[devid].fullname, devid, cl_errstr(err));
   else
     dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE,
-             "[dt_opencl_read_host_from_device_raw] read image from device '%s' id=%d",
+             "[dt_opencl_read_host_from_image_raw] read image from device '%s' id=%d",
              darktable.opencl->dev[devid].fullname, devid);
 
   return err;
 }
 
-int dt_opencl_write_host_to_device(const int devid,
+int dt_opencl_write_host_to_image(const int devid,
                                    const void *host,
                                    cl_mem image,
                                    const int width,
@@ -2931,11 +2931,11 @@ int dt_opencl_write_host_to_device(const int devid,
 
   const size_t region[2] = { width, height };
   // blocking.
-  return dt_opencl_write_host_to_device_raw(devid, host, image, CLIMG_ORIGIN,
+  return dt_opencl_write_host_to_image_raw(devid, host, image, CLIMG_ORIGIN,
                                             region, (size_t)width * bpp, TRUE);
 }
 
-int dt_opencl_write_host_to_device_raw(const int devid,
+int dt_opencl_write_host_to_image_raw(const int devid,
                                        const void *host,
                                        cl_mem image,
                                        const size_t *origin,
@@ -2957,11 +2957,11 @@ int dt_opencl_write_host_to_device_raw(const int devid,
 
   if(err != CL_SUCCESS)
     dt_print(DT_DEBUG_OPENCL,
-             "[dt_opencl_write_host_to_device_raw] could not write image to device '%s' id=%d: %s",
+             "[dt_opencl_write_host_to_image_raw] could not write image to device '%s' id=%d: %s",
              darktable.opencl->dev[devid].fullname, devid, cl_errstr(err));
   else
     dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE,
-             "[dt_opencl_write_host_to_device_raw] wrote image to device '%s' id=%d",
+             "[dt_opencl_write_host_to_image_raw] wrote image to device '%s' id=%d",
              darktable.opencl->dev[devid].fullname, devid);
 
 
@@ -3180,7 +3180,7 @@ void *dt_opencl_copy_host_to_device_constant(const int devid,
 }
 
 
-static void *_opencl_copy_host_to_device_rowpitch(const int devid,
+static void *_opencl_copy_host_to_image_rowpitch(const int devid,
                                              void *host,
                                              const int width,
                                              const int height,
@@ -3230,13 +3230,13 @@ static void *_opencl_copy_host_to_device_rowpitch(const int devid,
   return dev;
 }
 
-void *dt_opencl_copy_host_to_device(const int devid,
+void *dt_opencl_copy_host_to_image(const int devid,
                                     void *host,
                                     const int width,
                                     const int height,
                                     const int bpp)
 {
-  return _opencl_copy_host_to_device_rowpitch(devid, host, width, height, bpp, 0);
+  return _opencl_copy_host_to_image_rowpitch(devid, host, width, height, bpp, 0);
 }
 
 void dt_opencl_release_mem_object(cl_mem mem)
@@ -3513,7 +3513,7 @@ void dt_opencl_dump_pipe_pfm(const char* mod,
   float *data = dt_alloc_aligned((size_t)width * height * element_size);
   if(data)
   {
-    if(dt_opencl_copy_device_to_host(devid, data, img, width, height, element_size) == CL_SUCCESS)
+    if(dt_opencl_copy_image_to_host(devid, data, img, width, height, element_size) == CL_SUCCESS)
       dt_dump_pfm_file(pipe, data, width, height, element_size, mod,
                        "[dt_opencl_dump_pipe_pfm]", input, !input, FALSE);
 

--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -435,14 +435,14 @@ gboolean dt_opencl_running_fast(void);
 void dt_opencl_update_settings(void);
 
 /** HAVE_OPENCL mode only: copy and alloc buffers. */
-int dt_opencl_copy_device_to_host(const int devid,
+int dt_opencl_copy_image_to_host(const int devid,
                                   void *host,
                                   cl_mem image,
                                   const int width,
                                   const int height,
                                   const int bpp);
 
-int dt_opencl_read_host_from_device_raw(const int devid,
+int dt_opencl_read_host_from_image_raw(const int devid,
                                         void *host,
                                         cl_mem image,
                                         const size_t *origin,
@@ -450,14 +450,14 @@ int dt_opencl_read_host_from_device_raw(const int devid,
                                         const int rowpitch,
                                         const gboolean blocking);
 
-int dt_opencl_write_host_to_device(const int devid,
+int dt_opencl_write_host_to_image(const int devid,
                                    const void *host,
                                    cl_mem image,
                                    const int width,
                                    const int height,
                                    const int bpp);
 
-int dt_opencl_write_host_to_device_raw(const int devid,
+int dt_opencl_write_host_to_image_raw(const int devid,
                                        const void *host,
                                        cl_mem image,
                                        const size_t *origin,
@@ -465,7 +465,7 @@ int dt_opencl_write_host_to_device_raw(const int devid,
                                        const int rowpitch,
                                        const gboolean blocking);
 
-void *dt_opencl_copy_host_to_device(const int devid,
+void *dt_opencl_copy_host_to_image(const int devid,
                                     void *host,
                                     const int width,
                                     const int height,

--- a/src/develop/blend.c
+++ b/src/develop/blend.c
@@ -1086,7 +1086,7 @@ gboolean dt_develop_blend_process_cl(dt_iop_module_t *self,
       dt_iop_image_fill(mask, 0.0f, owidth, oheight, 1); //mask[k] = value;
     }
 
-    err = dt_opencl_write_host_to_device(devid, mask, dev_mask, owidth, oheight, sizeof(float));
+    err = dt_opencl_write_host_to_image(devid, mask, dev_mask, owidth, oheight, sizeof(float));
     if(err != CL_SUCCESS) goto error;
   }
   else
@@ -1131,7 +1131,7 @@ gboolean dt_develop_blend_process_cl(dt_iop_module_t *self,
 
     _refine_with_detail_mask_cl(self, piece, mask, roi_in, roi_out, d->details, devid);
 
-    err = dt_opencl_write_host_to_device(devid, mask, dev_mask_2, owidth, oheight, sizeof(float));
+    err = dt_opencl_write_host_to_image(devid, mask, dev_mask_2, owidth, oheight, sizeof(float));
     if(err != CL_SUCCESS) goto error;
 
     // The following call to clFinish() works around a bug in some OpenCL
@@ -1331,7 +1331,7 @@ gboolean dt_develop_blend_process_cl(dt_iop_module_t *self,
     // get back final mask from the device as the raster mask
     if(!raster)
     {
-      err = dt_opencl_copy_device_to_host(devid, mask, dev_mask, owidth, oheight, sizeof(float));
+      err = dt_opencl_copy_image_to_host(devid, mask, dev_mask, owidth, oheight, sizeof(float));
       if(err != CL_SUCCESS)
       {
         dt_iop_piece_clear_raster(piece, _mask);

--- a/src/develop/imageop_math.c
+++ b/src/develop/imageop_math.c
@@ -219,11 +219,11 @@ int dt_iop_clip_and_zoom_roi_cl(int devid,
     float *out = dt_alloc_align_float((size_t)roi_out->width * roi_out->height * 4);
     if(out && in)
     {
-      err = dt_opencl_copy_device_to_host(devid, in, dev_in, roi_in->width, roi_in->height, 4 * sizeof(float));
+      err = dt_opencl_copy_image_to_host(devid, in, dev_in, roi_in->width, roi_in->height, 4 * sizeof(float));
       if(err == CL_SUCCESS)
       {
         dt_iop_clip_and_zoom_roi(out, in, roi_out, roi_in);
-        err = dt_opencl_write_host_to_device(devid, out, dev_out, roi_out->width, roi_out->height, 4 * sizeof(float));
+        err = dt_opencl_write_host_to_image(devid, out, dev_out, roi_out->width, roi_out->height, 4 * sizeof(float));
       }
 
     }

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -839,7 +839,7 @@ static void _histogram_collect_cl(const int devid,
 
   if(!pixel) return;
 
-  if(dt_opencl_copy_device_to_host(devid, pixel, img, roi->width, roi->height, sizeof(float) * 4)
+  if(dt_opencl_copy_image_to_host(devid, pixel, img, roi->width, roi->height, sizeof(float) * 4)
     != CL_SUCCESS)
   {
     dt_free_align(tmpbuf);
@@ -992,7 +992,7 @@ static void _pixelpipe_picker_cl(const int devid,
   if(pixel == NULL) return;
 
   // get the required part of the image from opencl device
-  if(dt_opencl_read_host_from_device_raw(devid, pixel, img,
+  if(dt_opencl_read_host_from_image_raw(devid, pixel, img,
                                          origin, region, region[0] * bpp, TRUE) != CL_SUCCESS)
   {
     dt_print_pipe(DT_DEBUG_PIPE,
@@ -1623,10 +1623,10 @@ static void _opencl_dump_diff_pipe_pfm(dt_dev_pixelpipe_t *pipe,
     float *cpudata = dt_alloc_align_float((size_t)ow * oh * cho);
     if(clin && clout && cpudata)
     {
-      cl_int err = dt_opencl_copy_device_to_host(pipe->devid, clout, out, ow, oh, cho * sizeof(float));
+      cl_int err = dt_opencl_copy_image_to_host(pipe->devid, clout, out, ow, oh, cho * sizeof(float));
       if(err == CL_SUCCESS)
       {
-        err = dt_opencl_copy_device_to_host(pipe->devid, clin, in, iw, ih, ch);
+        err = dt_opencl_copy_image_to_host(pipe->devid, clin, in, iw, ih, ch);
         if(err == CL_SUCCESS)
         {
           module->process(module, piece, clin, cpudata, roi_in, roi_out);
@@ -1865,7 +1865,7 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
           gboolean done = FALSE;
           if(cl_scale_possible)
           {
-            cl_mem clin = dt_opencl_copy_host_to_device(pipe->devid, pipe->input, roi_in.width, roi_in.height, bpp);
+            cl_mem clin = dt_opencl_copy_host_to_image(pipe->devid, pipe->input, roi_in.width, roi_in.height, bpp);
             cl_mem clout = dt_opencl_alloc_device(pipe->devid, roi_out->width, roi_out->height, bpp);
             if(clin && clout)
             {
@@ -1881,7 +1881,7 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
                     CLARG(clout), CLARG(clout), CLARG(roi_out->width), CLARG(roi_out->height), CLARGFLOAT(0.41666666666666666667f));
 
               if(err == CL_SUCCESS)
-                err = dt_opencl_copy_device_to_host(pipe->devid, *output, clout, roi_out->width, roi_out->height, bpp);
+                err = dt_opencl_copy_image_to_host(pipe->devid, *output, clout, roi_out->width, roi_out->height, bpp);
               if(err == CL_SUCCESS)
                 done = TRUE;
               else
@@ -2162,7 +2162,7 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
       if(cl_mem_input != NULL || fits_on_device)
       {
         if(cl_mem_input == NULL)
-          cl_mem_input = dt_opencl_copy_host_to_device(pipe->devid, input, roi_in.width, roi_in.height, in_bpp);
+          cl_mem_input = dt_opencl_copy_host_to_image(pipe->devid, input, roi_in.width, roi_in.height, in_bpp);
 
         if(cl_mem_input)
         {
@@ -2250,7 +2250,7 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
           cl_int err = CL_SUCCESS;
           if(bcaching)
           {
-            *cl_mem_output = dt_opencl_copy_host_to_device(pipe->devid, pipe->bcache_data, roi_out->width, roi_out->height, out_bpp);
+            *cl_mem_output = dt_opencl_copy_host_to_image(pipe->devid, pipe->bcache_data, roi_out->width, roi_out->height, out_bpp);
             if(*cl_mem_output == NULL)
             {
               // for some reason reading from bcache failed so let's clear/invalidate it now and leave the error condition
@@ -2276,7 +2276,7 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
                 float *cache = _get_fast_blendcache(out_bpp * roi_out->width * roi_out->height / sizeof(float), phash, pipe);
                 if(cache)
                 {
-                  err = dt_opencl_copy_device_to_host(pipe->devid, cache, *cl_mem_output, roi_out->width, roi_out->height, out_bpp);
+                  err = dt_opencl_copy_image_to_host(pipe->devid, cache, *cl_mem_output, roi_out->width, roi_out->height, out_bpp);
                   if(err != CL_SUCCESS)
                   {
                     // for some reason writing to bcache failed so let's clear/invalidate it now and leave the error condition
@@ -2416,7 +2416,7 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
         if(cl_mem_input != NULL)
         {
           /* copy back to CPU buffer, then clean unneeded buffer */
-          if(dt_opencl_copy_device_to_host(pipe->devid, input, cl_mem_input, roi_in.width, roi_in.height, in_bpp)
+          if(dt_opencl_copy_image_to_host(pipe->devid, input, cl_mem_input, roi_in.width, roi_in.height, in_bpp)
             != CL_SUCCESS)
           {
             dt_print_pipe(DT_DEBUG_OPENCL,
@@ -2616,7 +2616,7 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
           if(cl_mem_input != NULL)
           {
             /* copy input to host memory, so we can find it in cache and wait via blocking flag */
-            if(dt_opencl_copy_device_to_host(pipe->devid, input, cl_mem_input, roi_in.width, roi_in.height, in_bpp)
+            if(dt_opencl_copy_image_to_host(pipe->devid, input, cl_mem_input, roi_in.width, roi_in.height, in_bpp)
               != CL_SUCCESS)
             {
               important_cl_input = FALSE;
@@ -2664,7 +2664,7 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
              In-place colorspace conversion to input cst is good as the cpu fallback
              won't do that conversion again.
           */
-          if(dt_opencl_copy_device_to_host(pipe->devid, input, cl_mem_input, roi_in.width, roi_in.height, in_bpp)
+          if(dt_opencl_copy_image_to_host(pipe->devid, input, cl_mem_input, roi_in.width, roi_in.height, in_bpp)
             != CL_SUCCESS)
           {
             dt_print_pipe(DT_DEBUG_OPENCL,
@@ -2696,7 +2696,7 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
       /* cleanup unneeded opencl input buffer, and copy back to CPU */
       if(cl_mem_input != NULL)
       {
-        if(dt_opencl_copy_device_to_host(pipe->devid, input, cl_mem_input, roi_in.width, roi_in.height, in_bpp)
+        if(dt_opencl_copy_image_to_host(pipe->devid, input, cl_mem_input, roi_in.width, roi_in.height, in_bpp)
           != CL_SUCCESS)
         {
           dt_print_pipe(DT_DEBUG_OPENCL,
@@ -2814,7 +2814,7 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
     gboolean valid_output = TRUE;
 #ifdef HAVE_OPENCL
     if(*cl_mem_output != NULL)
-      valid_output = dt_opencl_copy_device_to_host(pipe->devid, *output, *cl_mem_output, roi_out->width, roi_out->height, bpp)
+      valid_output = dt_opencl_copy_image_to_host(pipe->devid, *output, *cl_mem_output, roi_out->width, roi_out->height, bpp)
         == CL_SUCCESS;
 
 #endif
@@ -2984,10 +2984,8 @@ static gboolean _dev_pixelpipe_process_rec_and_backcopy(dt_dev_pixelpipe_t *pipe
   {
     if(*cl_mem_output != NULL)
     {
-      cl_int err = dt_opencl_copy_device_to_host(
-                    pipe->devid, *output, *cl_mem_output,
-                    roi_out->width, roi_out->height,
-                    dt_iop_buffer_dsc_to_bpp(*out_format));
+      cl_int err = dt_opencl_copy_image_to_host(pipe->devid, *output, *cl_mem_output,
+                    roi_out->width, roi_out->height, dt_iop_buffer_dsc_to_bpp(*out_format));
       dt_opencl_release_mem_object(*cl_mem_output);
       *cl_mem_output = NULL;
 

--- a/src/develop/tiling.c
+++ b/src/develop/tiling.c
@@ -1527,14 +1527,14 @@ static int _default_process_tiling_cl_ptp(dt_iop_module_t *self,
                  (size_t)wd * in_bpp);
 
         /* blocking memory transfer: pinned host input buffer -> opencl/device tile */
-        err = dt_opencl_write_host_to_device_raw(devid, (char *)input_buffer, input, origin, region,
+        err = dt_opencl_write_host_to_image_raw(devid, (char *)input_buffer, input, origin, region,
                                                  wd * in_bpp, TRUE);
         if(err != CL_SUCCESS) use_pinned_memory = FALSE;
       }
       else
       {
         /* blocking direct memory transfer: host input image -> opencl/device tile */
-        err = dt_opencl_write_host_to_device_raw(devid, (char *)ivoid + ioffs, input, origin, region, ipitch, TRUE);
+        err = dt_opencl_write_host_to_image_raw(devid, (char *)ivoid + ioffs, input, origin, region, ipitch, TRUE);
       }
       if(err != CL_SUCCESS) goto error;
 
@@ -1561,7 +1561,7 @@ static int _default_process_tiling_cl_ptp(dt_iop_module_t *self,
       if(use_pinned_memory)
       {
         /* blocking memory transfer: complete opencl/device tile -> pinned host output buffer */
-        err = dt_opencl_read_host_from_device_raw(devid, (char *)output_buffer, output, origin, region,
+        err = dt_opencl_read_host_from_image_raw(devid, (char *)output_buffer, output, origin, region,
                                                   wd * out_bpp, TRUE);
         if(err != CL_SUCCESS)
         {
@@ -1597,7 +1597,7 @@ static int _default_process_tiling_cl_ptp(dt_iop_module_t *self,
       else
       {
         /* blocking direct memory transfer: good part of opencl/device tile -> host output image */
-        err = dt_opencl_read_host_from_device_raw(devid, (char *)ovoid + ooffs, output, origin, region,
+        err = dt_opencl_read_host_from_image_raw(devid, (char *)ovoid + ooffs, output, origin, region,
                                                   opitch, TRUE);
         if(err != CL_SUCCESS) goto error;
       }
@@ -1971,14 +1971,14 @@ static int _default_process_tiling_cl_roi(dt_iop_module_t *self,
                  (size_t)iroi_full.width * in_bpp);
 
         /* blocking memory transfer: pinned host input buffer -> opencl/device tile */
-        err = dt_opencl_write_host_to_device_raw(devid, (char *)input_buffer, input, CLIMG_ORIGIN, iregion,
+        err = dt_opencl_write_host_to_image_raw(devid, (char *)input_buffer, input, CLIMG_ORIGIN, iregion,
                                                  (size_t)iroi_full.width * in_bpp, TRUE);
         if(err != CL_SUCCESS) use_pinned_memory = FALSE;
       }
       else
       {
         /* blocking direct memory transfer: host input image -> opencl/device tile */
-        err = dt_opencl_write_host_to_device_raw(devid, (char *)ivoid + ioffs, input, CLIMG_ORIGIN, iregion,
+        err = dt_opencl_write_host_to_image_raw(devid, (char *)ivoid + ioffs, input, CLIMG_ORIGIN, iregion,
                                                  ipitch, TRUE);
       }
       if(err != CL_SUCCESS) goto error;
@@ -2008,7 +2008,7 @@ static int _default_process_tiling_cl_roi(dt_iop_module_t *self,
       if(use_pinned_memory)
       {
         /* blocking memory transfer: complete opencl/device tile -> pinned host output buffer */
-        err = dt_opencl_read_host_from_device_raw(devid, (char *)output_buffer, output, CLIMG_ORIGIN, ofregion,
+        err = dt_opencl_read_host_from_image_raw(devid, (char *)output_buffer, output, CLIMG_ORIGIN, ofregion,
                                                   (size_t)oroi_full.width * out_bpp, TRUE);
         if(err != CL_SUCCESS)
         {
@@ -2025,7 +2025,7 @@ static int _default_process_tiling_cl_roi(dt_iop_module_t *self,
       else
       {
         /* blocking direct memory transfer: good part of opencl/device tile -> host output image */
-        err = dt_opencl_read_host_from_device_raw(devid, (char *)ovoid + ooffs, output, oorigin, oregion,
+        err = dt_opencl_read_host_from_image_raw(devid, (char *)ovoid + ooffs, output, oorigin, oregion,
                                                   opitch, TRUE);
         if(err != CL_SUCCESS) goto error;
       }

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -3635,7 +3635,7 @@ int process_cl(dt_iop_module_t *self,
     if(g->buf /* && hash != g->buf_hash */)
     {
       // copy data using actual roi_in dimensions (can exceed buf_in when scale > 1.0)
-      err = dt_opencl_copy_device_to_host(devid, g->buf, dev_in,
+      err = dt_opencl_copy_image_to_host(devid, g->buf, dev_in,
                                           roi_in->width, roi_in->height, sizeof(float) * 4);
 
       g->buf_width = roi_in->width;

--- a/src/iop/basecurve.c
+++ b/src/iop/basecurve.c
@@ -734,7 +734,7 @@ int process_cl_fusion(dt_iop_module_t *self,
     }
   }
 
-  dev_m = dt_opencl_copy_host_to_device(devid, d->table, 256, 256, sizeof(float));
+  dev_m = dt_opencl_copy_host_to_image(devid, d->table, 256, 256, sizeof(float));
   if(dev_m == NULL) goto error;
 
   dev_coeffs = dt_opencl_copy_host_to_device_constant(devid, sizeof(float) * 3, d->unbounded_coeffs);
@@ -915,7 +915,7 @@ int process_cl_lut(dt_iop_module_t *self,
   const int height = roi_in->height;
   const int preserve_colors = d->preserve_colors;
 
-  dev_m = dt_opencl_copy_host_to_device(devid, d->table, 256, 256, sizeof(float));
+  dev_m = dt_opencl_copy_host_to_image(devid, d->table, 256, 256, sizeof(float));
   dev_coeffs = dt_opencl_copy_host_to_device_constant(devid, sizeof(float) * 3, d->unbounded_coeffs);
   if(!dev_m || !dev_coeffs) goto error;
 

--- a/src/iop/basicadj.c
+++ b/src/iop/basicadj.c
@@ -1311,7 +1311,7 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
         goto cleanup;
       }
 
-      err = dt_opencl_copy_device_to_host(devid, src_buffer, dev_in, width, height, ch * sizeof(float));
+      err = dt_opencl_copy_image_to_host(devid, src_buffer, dev_in, width, height, ch * sizeof(float));
       if(err != CL_SUCCESS)
       {
         dt_print(DT_DEBUG_ALWAYS, "[basicadj process_cl] error allocating memory for color transformation 2");
@@ -1368,7 +1368,7 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
                                             &dev_profile_info, &dev_profile_lut);
   if(err != CL_SUCCESS) goto cleanup;
 
-  dev_gamma = dt_opencl_copy_host_to_device(devid, d->lut_gamma, 256, 256, sizeof(float));
+  dev_gamma = dt_opencl_copy_host_to_image(devid, d->lut_gamma, 256, 256, sizeof(float));
   if(dev_gamma == NULL)
   {
     dt_print(DT_DEBUG_ALWAYS, "[basicadj process_cl] error allocating memory 3");
@@ -1376,7 +1376,7 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
     goto cleanup;
   }
 
-  dev_contrast = dt_opencl_copy_host_to_device(devid, d->lut_contrast, 256, 256, sizeof(float));
+  dev_contrast = dt_opencl_copy_host_to_image(devid, d->lut_contrast, 256, 256, sizeof(float));
   if(dev_contrast == NULL)
   {
     dt_print(DT_DEBUG_ALWAYS, "[basicadj process_cl] error allocating memory 4");

--- a/src/iop/censorize.c
+++ b/src/iop/censorize.c
@@ -348,13 +348,13 @@ int process_cl(dt_iop_module_t *self,
   dev_tmp = dt_opencl_duplicate_image(devid, dev_out);
   if(dev_tmp == NULL) goto error;
 
-  dev_cm = dt_opencl_copy_host_to_device(devid, d->ctable, 256, 256, sizeof(float));
+  dev_cm = dt_opencl_copy_host_to_image(devid, d->ctable, 256, 256, sizeof(float));
   if(dev_cm == NULL) goto error;
 
   dev_ccoeffs = dt_opencl_copy_host_to_device_constant(devid, sizeof(float) * 3, d->cunbounded_coeffs);
   if(dev_ccoeffs == NULL) goto error;
 
-  dev_lm = dt_opencl_copy_host_to_device(devid, d->ltable, 256, 256, sizeof(float));
+  dev_lm = dt_opencl_copy_host_to_image(devid, d->ltable, 256, 256, sizeof(float));
   if(dev_lm == NULL) goto error;
 
   dev_lcoeffs = dt_opencl_copy_host_to_device_constant(devid, sizeof(float) * 3, d->lunbounded_coeffs);

--- a/src/iop/colisa.c
+++ b/src/iop/colisa.c
@@ -128,11 +128,11 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
   cl_mem dev_lm = NULL;
   cl_mem dev_lcoeffs = NULL;
 
-  dev_cm = dt_opencl_copy_host_to_device(devid, d->ctable, 256, 256, sizeof(float));
+  dev_cm = dt_opencl_copy_host_to_image(devid, d->ctable, 256, 256, sizeof(float));
   if(dev_cm == NULL) goto error;
   dev_ccoeffs = dt_opencl_copy_host_to_device_constant(devid, sizeof(float) * 3, d->cunbounded_coeffs);
   if(dev_ccoeffs == NULL) goto error;
-  dev_lm = dt_opencl_copy_host_to_device(devid, d->ltable, 256, 256, sizeof(float));
+  dev_lm = dt_opencl_copy_host_to_image(devid, d->ltable, 256, 256, sizeof(float));
   if(dev_lm == NULL) goto error;
   dev_lcoeffs = dt_opencl_copy_host_to_device_constant(devid, sizeof(float) * 3, d->lunbounded_coeffs);
   if(dev_lcoeffs == NULL) goto error;

--- a/src/iop/colorharmonizer.c
+++ b/src/iop/colorharmonizer.c
@@ -674,7 +674,7 @@ int process_cl(dt_iop_module_t *self,
     float *host_in = dt_alloc_align_float((size_t)width * height * 4);
     if(host_in)
     {
-      if(dt_opencl_copy_device_to_host(devid, host_in, dev_in, width, height, 4 * sizeof(float)) == CL_SUCCESS)
+      if(dt_opencl_copy_image_to_host(devid, host_in, dev_in, width, height, 4 * sizeof(float)) == CL_SUCCESS)
       {
         _update_histogram(self, piece, host_in, roi_in);
       }

--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -703,11 +703,11 @@ int process_cl(dt_iop_module_t *self,
   if(dev_m == NULL) goto error;
   dev_l = dt_opencl_copy_host_to_device_constant(devid, sizeof(float) * 9, lmat);
   if(dev_l == NULL) goto error;
-  dev_r = dt_opencl_copy_host_to_device(devid, d->lut[0], 256, 256, sizeof(float));
+  dev_r = dt_opencl_copy_host_to_image(devid, d->lut[0], 256, 256, sizeof(float));
   if(dev_r == NULL) goto error;
-  dev_g = dt_opencl_copy_host_to_device(devid, d->lut[1], 256, 256, sizeof(float));
+  dev_g = dt_opencl_copy_host_to_image(devid, d->lut[1], 256, 256, sizeof(float));
   if(dev_g == NULL) goto error;
-  dev_b = dt_opencl_copy_host_to_device(devid, d->lut[2], 256, 256, sizeof(float));
+  dev_b = dt_opencl_copy_host_to_image(devid, d->lut[2], 256, 256, sizeof(float));
   if(dev_b == NULL) goto error;
   dev_coeffs =
     dt_opencl_copy_host_to_device_constant(devid, sizeof(float) * 3 * 3,

--- a/src/iop/colormapping.c
+++ b/src/iop/colormapping.c
@@ -605,7 +605,7 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
     g->ch = ch;
 
     if(g->buffer)
-      err = dt_opencl_copy_device_to_host(devid, g->buffer, dev_in, width, height, ch * sizeof(float));
+      err = dt_opencl_copy_image_to_host(devid, g->buffer, dev_in, width, height, ch * sizeof(float));
 
     dt_iop_gui_leave_critical_section(self);
 

--- a/src/iop/colorout.c
+++ b/src/iop/colorout.c
@@ -337,11 +337,11 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
   pack_3xSSE_to_3x3(d->cmatrix, cmatrix);
   dev_m = dt_opencl_copy_host_to_device_constant(devid, sizeof(float) * 9, cmatrix);
   if(dev_m == NULL) goto error;
-  dev_r = dt_opencl_copy_host_to_device(devid, d->lut[0], 256, 256, sizeof(float));
+  dev_r = dt_opencl_copy_host_to_image(devid, d->lut[0], 256, 256, sizeof(float));
   if(dev_r == NULL) goto error;
-  dev_g = dt_opencl_copy_host_to_device(devid, d->lut[1], 256, 256, sizeof(float));
+  dev_g = dt_opencl_copy_host_to_image(devid, d->lut[1], 256, 256, sizeof(float));
   if(dev_g == NULL) goto error;
-  dev_b = dt_opencl_copy_host_to_device(devid, d->lut[2], 256, 256, sizeof(float));
+  dev_b = dt_opencl_copy_host_to_image(devid, d->lut[2], 256, 256, sizeof(float));
   if(dev_b == NULL) goto error;
   dev_coeffs
       = dt_opencl_copy_host_to_device_constant(devid, sizeof(float) * 3 * 3, (float *)d->unbounded_coeffs);

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -611,9 +611,9 @@ int process_cl(dt_iop_module_t *self,
     ? gd->kernel_colorzones_v3
     : gd->kernel_colorzones;
 
-  dev_L = dt_opencl_copy_host_to_device(devid, d->lut[0], 256, 256, sizeof(float));
-  dev_a = dt_opencl_copy_host_to_device(devid, d->lut[1], 256, 256, sizeof(float));
-  dev_b = dt_opencl_copy_host_to_device(devid, d->lut[2], 256, 256, sizeof(float));
+  dev_L = dt_opencl_copy_host_to_image(devid, d->lut[0], 256, 256, sizeof(float));
+  dev_a = dt_opencl_copy_host_to_image(devid, d->lut[1], 256, 256, sizeof(float));
+  dev_b = dt_opencl_copy_host_to_image(devid, d->lut[2], 256, 256, sizeof(float));
 
   if(dev_L == NULL || dev_a == NULL || dev_b == NULL)
     goto error;

--- a/src/iop/demosaicing/capture.c
+++ b/src/iop/demosaicing/capture.c
@@ -1000,7 +1000,7 @@ static void _capture_radius_cl(dt_iop_module_t *self,
   float *in = dt_iop_image_alloc(roi->width, roi->height, ch);
   if(!in) goto finish;
 
-  err = dt_opencl_copy_device_to_host(pipe->devid, in, dev_in, roi->width, roi->height, sizeof(float) * ch);
+  err = dt_opencl_copy_image_to_host(pipe->devid, in, dev_in, roi->width, roi->height, sizeof(float) * ch);
   if(err == CL_SUCCESS)
     _capture_radius(self, piece, in, roi, xtrans, filters);
 

--- a/src/iop/filmic.c
+++ b/src/iop/filmic.c
@@ -564,10 +564,10 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
   cl_mem dev_table = NULL;
   cl_mem diff_table = NULL;
 
-  dev_table = dt_opencl_copy_host_to_device(devid, d->table, 256, 256, sizeof(float));
+  dev_table = dt_opencl_copy_host_to_image(devid, d->table, 256, 256, sizeof(float));
   if(dev_table == NULL) goto error;
 
-  diff_table = dt_opencl_copy_host_to_device(devid, d->grad_2, 256, 256, sizeof(float));
+  diff_table = dt_opencl_copy_host_to_image(devid, d->grad_2, 256, 256, sizeof(float));
   if(diff_table == NULL) goto error;
 
   const float dynamic_range = d->dynamic_range;

--- a/src/iop/hazeremoval.c
+++ b/src/iop/hazeremoval.c
@@ -714,7 +714,7 @@ static float _ambient_light_cl(dt_iop_module_t *self,
   const int height = dt_opencl_get_image_height(img);
   const int element_size = dt_opencl_get_image_element_size(img);
   float *in = dt_alloc_aligned((size_t)width * height * element_size);
-  cl_int err = dt_opencl_copy_device_to_host(devid, in, img, width, height, element_size);
+  cl_int err = dt_opencl_copy_image_to_host(devid, in, img, width, height, element_size);
   if(err != CL_SUCCESS) goto error;
 
   const const_rgb_image img_in = (const_rgb_image) {in, width, height, element_size / sizeof(float)};

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -679,7 +679,7 @@ int process_cl(dt_iop_module_t *self,
     float *cpdata = dt_alloc_align_float(ch * roi_out->width * roi_out->height);
     if(cpdata)
     {
-      if(dt_opencl_copy_device_to_host(devid, cpdata, dev_out, roi_out->width, roi_out->height, ch * sizeof(float)) == CL_SUCCESS)
+      if(dt_opencl_copy_image_to_host(devid, cpdata, dev_out, roi_out->width, roi_out->height, ch * sizeof(float)) == CL_SUCCESS)
         mask = _provide_raster_mask(roi_in, roi_out, cpdata, d->clip, piece);
       dt_free_align(cpdata);
     }

--- a/src/iop/levels.c
+++ b/src/iop/levels.c
@@ -452,7 +452,7 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
   const int width = roi_out->width;
   const int height = roi_out->height;
 
-  dev_lut = dt_opencl_copy_host_to_device(devid, d->lut, 256, 256, sizeof(float));
+  dev_lut = dt_opencl_copy_host_to_image(devid, d->lut, 256, 256, sizeof(float));
   if(dev_lut == NULL) goto error;
 
   err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_levels, width, height,

--- a/src/iop/lowlight.c
+++ b/src/iop/lowlight.c
@@ -203,7 +203,7 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
 
   dt_Lab_to_XYZ(Lab_sw, XYZ_sw);
 
-  dev_m = dt_opencl_copy_host_to_device(devid, d->lut, 256, 256, sizeof(float));
+  dev_m = dt_opencl_copy_host_to_image(devid, d->lut, 256, 256, sizeof(float));
   if(dev_m == NULL) goto finish;
 
   err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_lowlight, width, height,

--- a/src/iop/lowpass.c
+++ b/src/iop/lowpass.c
@@ -296,13 +296,13 @@ int process_cl(dt_iop_module_t *self,
   dev_tmp = dt_opencl_duplicate_image(devid, dev_out);
   if(dev_tmp == NULL) goto error;
 
-  dev_cm = dt_opencl_copy_host_to_device(devid, d->ctable, 256, 256, sizeof(float));
+  dev_cm = dt_opencl_copy_host_to_image(devid, d->ctable, 256, 256, sizeof(float));
   if(dev_cm == NULL) goto error;
 
   dev_ccoeffs = dt_opencl_copy_host_to_device_constant(devid, sizeof(float) * 3, d->cunbounded_coeffs);
   if(dev_ccoeffs == NULL) goto error;
 
-  dev_lm = dt_opencl_copy_host_to_device(devid, d->ltable, 256, 256, sizeof(float));
+  dev_lm = dt_opencl_copy_host_to_image(devid, d->ltable, 256, 256, sizeof(float));
   if(dev_lm == NULL) goto error;
 
   dev_lcoeffs = dt_opencl_copy_host_to_device_constant(devid, sizeof(float) * 3, d->lunbounded_coeffs);

--- a/src/iop/profile_gamma.c
+++ b/src/iop/profile_gamma.c
@@ -232,7 +232,7 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
   }
   else if(d->mode == PROFILEGAMMA_GAMMA)
   {
-    dev_table = dt_opencl_copy_host_to_device(devid, d->table, 256, 256, sizeof(float));
+    dev_table = dt_opencl_copy_host_to_image(devid, d->table, 256, 256, sizeof(float));
     if(dev_table == NULL) goto error;
 
     dev_coeffs = dt_opencl_copy_host_to_device_constant(devid, sizeof(float) * 3, d->unbounded_coeffs);

--- a/src/iop/rawoverexposed.c
+++ b/src/iop/rawoverexposed.c
@@ -268,7 +268,7 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
   const int raw_height = buf.height;
 
   err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
-  dev_raw = dt_opencl_copy_host_to_device(devid, buf.buf, raw_width, raw_height, sizeof(uint16_t));
+  dev_raw = dt_opencl_copy_host_to_image(devid, buf.buf, raw_width, raw_height, sizeof(uint16_t));
   if(dev_raw == NULL) goto error;
 
   const size_t coordbufsize = (size_t)height * width * 2 * sizeof(float);

--- a/src/iop/rawprepare.c
+++ b/src/iop/rawprepare.c
@@ -530,7 +530,7 @@ int process_cl(dt_iop_module_t *self,
       err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
       dev_gainmap[i] = dt_opencl_alloc_device(devid, map_size[0], map_size[1], sizeof(float));
       if(dev_gainmap[i] == NULL) goto finish;
-      err = dt_opencl_write_host_to_device(devid, d->gainmaps[i]->map_gain, dev_gainmap[i],
+      err = dt_opencl_write_host_to_image(devid, d->gainmaps[i]->map_gain, dev_gainmap[i],
                                            map_size[0], map_size[1], sizeof(float));
       if(err != CL_SUCCESS) goto finish;
     }

--- a/src/iop/rgbcurve.c
+++ b/src/iop/rgbcurve.c
@@ -1811,15 +1811,15 @@ int process_cl(dt_iop_module_t *self,
   if(err != CL_SUCCESS) goto cleanup;
 
   err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
-  dev_r = dt_opencl_copy_host_to_device(devid, d->table[DT_IOP_RGBCURVE_R],
+  dev_r = dt_opencl_copy_host_to_image(devid, d->table[DT_IOP_RGBCURVE_R],
                                         256, 256, sizeof(float));
   if(dev_r == NULL) goto cleanup;
 
-  dev_g = dt_opencl_copy_host_to_device(devid, d->table[DT_IOP_RGBCURVE_G],
+  dev_g = dt_opencl_copy_host_to_image(devid, d->table[DT_IOP_RGBCURVE_G],
                                         256, 256, sizeof(float));
   if(dev_g == NULL) goto cleanup;
 
-  dev_b = dt_opencl_copy_host_to_device(devid, d->table[DT_IOP_RGBCURVE_B],
+  dev_b = dt_opencl_copy_host_to_image(devid, d->table[DT_IOP_RGBCURVE_B],
                                         256, 256, sizeof(float));
   if(dev_b == NULL) goto cleanup;
 

--- a/src/iop/rgblevels.c
+++ b/src/iop/rgblevels.c
@@ -1439,7 +1439,7 @@ int process_cl(dt_iop_module_t *self,
         goto cleanup;
       }
 
-      err = dt_opencl_copy_device_to_host(devid, src_buffer,
+      err = dt_opencl_copy_image_to_host(devid, src_buffer,
                                           dev_in, width, height, ch * sizeof(float));
       if(err != CL_SUCCESS)
       {
@@ -1471,19 +1471,19 @@ int process_cl(dt_iop_module_t *self,
   const int autoscale = d->params.autoscale;
   const int preserve_colors = d->params.preserve_colors;
 
-  dev_lutr = dt_opencl_copy_host_to_device(devid, d->lut[0], 256, 256, sizeof(float));
+  dev_lutr = dt_opencl_copy_host_to_image(devid, d->lut[0], 256, 256, sizeof(float));
   if(dev_lutr == NULL)
   {
     err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
     goto cleanup;
   }
-  dev_lutg = dt_opencl_copy_host_to_device(devid, d->lut[1], 256, 256, sizeof(float));
+  dev_lutg = dt_opencl_copy_host_to_image(devid, d->lut[1], 256, 256, sizeof(float));
   if(dev_lutg == NULL)
   {
     err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
     goto cleanup;
   }
-  dev_lutb = dt_opencl_copy_host_to_device(devid, d->lut[2], 256, 256, sizeof(float));
+  dev_lutb = dt_opencl_copy_host_to_image(devid, d->lut[2], 256, 256, sizeof(float));
   if(dev_lutb == NULL)
   {
     err = CL_MEM_OBJECT_ALLOCATION_FAILURE;

--- a/src/iop/tonecurve.c
+++ b/src/iop/tonecurve.c
@@ -331,13 +331,13 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
                                             &dev_profile_info, &dev_profile_lut);
   if(err != CL_SUCCESS) goto error;
 
-  dev_L = dt_opencl_copy_host_to_device(devid, d->table[ch_L], 256, 256, sizeof(float));
+  dev_L = dt_opencl_copy_host_to_image(devid, d->table[ch_L], 256, 256, sizeof(float));
   if(dev_L == NULL) goto error;
 
-  dev_a = dt_opencl_copy_host_to_device(devid, d->table[ch_a], 256, 256, sizeof(float));
+  dev_a = dt_opencl_copy_host_to_image(devid, d->table[ch_a], 256, 256, sizeof(float));
   if(dev_a == NULL) goto error;
 
-  dev_b = dt_opencl_copy_host_to_device(devid, d->table[ch_b], 256, 256, sizeof(float));
+  dev_b = dt_opencl_copy_host_to_image(devid, d->table[ch_b], 256, 256, sizeof(float));
   if(dev_b == NULL) goto error;
 
   dev_coeffs_L = dt_opencl_copy_host_to_device_constant(devid, sizeof(float) * 3,


### PR DESCRIPTION
For the sake of readability / understanding OpenCL code, all `dt_opencl_xxx()` functions reading or writing `cl_mem image` should be named accordingly, in those cases the misleading `_device_` part has been replaced by `_image_`

Trivial stuff but certainly helps reading ...