### PR TITLE
Make the AI registry an internal singleton

### DIFF
--- a/src/common/ai_models.c
+++ b/src/common/ai_models.c
@@ -40,9 +40,11 @@ static inline char *realpath(const char *path, char *resolved_path)
 }
 #endif
 
-// internal layout of the opaque registry. external callers go through
-// the accessors in ai_models.h — the lock and the model list are
-// intentionally hidden so nobody can race-iterate or deadlock on them
+// internal layout of the registry singleton (darktable.ai_registry);
+// external callers go through the accessors in ai_models.h — the lock
+// and the model list are intentionally hidden so nobody can
+// race-iterate or deadlock on them
+typedef struct dt_ai_registry_t dt_ai_registry_t;
 struct dt_ai_registry_t
 {
   GList *models;              // list of dt_ai_model_t*
@@ -370,11 +372,13 @@ static char *_fetch_asset_digest(
 
 // core API
 
-// set up directories and provider config
-// no-ops if already initialized (models_dir != NULL)
-static void _setup_registry(dt_ai_registry_t *registry)
+// set up directories and provider config; returns FALSE if a required
+// directory could not be created — the model/cache dirs are unusable
+// and downloads/scans will fail; no-op returning TRUE if already
+// initialized (models_dir != NULL)
+static gboolean _setup_registry(dt_ai_registry_t *registry)
 {
-  if(registry->models_dir) return;
+  if(registry->models_dir) return TRUE;
 
   char cachedir[PATH_MAX] = {0};
   dt_loc_get_user_cache_dir(cachedir, sizeof(cachedir));
@@ -387,8 +391,18 @@ static void _setup_registry(dt_ai_registry_t *registry)
                               "darktable", "models", NULL);
   char *cache = g_build_filename(cachedir, "ai_downloads", NULL);
 
-  _ensure_directory(models);
-  _ensure_directory(cache);
+  // attempt both before bailing so the log reports every missing dir
+  gboolean ok = TRUE;
+  if(!_ensure_directory(models))
+  {
+    dt_print(DT_DEBUG_ALWAYS, "[ai_models] cannot create models dir: %s", models);
+    ok = FALSE;
+  }
+  if(!_ensure_directory(cache))
+  {
+    dt_print(DT_DEBUG_ALWAYS, "[ai_models] cannot create cache dir: %s", cache);
+    ok = FALSE;
+  }
 
   char *prov_str = dt_conf_get_string(DT_AI_CONF_PROVIDER);
   registry->provider = dt_ai_provider_from_string(prov_str);
@@ -398,14 +412,17 @@ static void _setup_registry(dt_ai_registry_t *registry)
   registry->models_dir = models;  // publish last
 
   dt_print(DT_DEBUG_AI,
-           "[ai_models] initialized: models_dir=%s, cache_dir=%s",
-           registry->models_dir, registry->cache_dir);
+           "[ai_models] initialized: models_dir=%s", registry->models_dir);
+  dt_print(DT_DEBUG_AI,
+           "[ai_models] initialized: cache_dir=%s", registry->cache_dir);
+  return ok;
 }
 
 // --- Registry state accessors ---
 
-gboolean dt_ai_registry_is_enabled(dt_ai_registry_t *registry)
+gboolean dt_ai_registry_is_enabled(void)
 {
+  dt_ai_registry_t *registry = darktable.ai_registry;
   if(!registry) return FALSE;
   g_mutex_lock(&registry->lock);
   const gboolean v = registry->ai_enabled;
@@ -413,42 +430,48 @@ gboolean dt_ai_registry_is_enabled(dt_ai_registry_t *registry)
   return v;
 }
 
-void dt_ai_registry_set_enabled(dt_ai_registry_t *registry, const gboolean enabled)
+void dt_ai_registry_set_enabled(const gboolean enabled)
 {
+  dt_ai_registry_t *registry = darktable.ai_registry;
   if(!registry) return;
   g_mutex_lock(&registry->lock);
   registry->ai_enabled = enabled;
   g_mutex_unlock(&registry->lock);
 }
 
-void dt_ai_registry_set_provider(dt_ai_registry_t *registry,
-                                 const dt_ai_provider_t provider)
+void dt_ai_registry_set_provider(const dt_ai_provider_t provider)
 {
+  dt_ai_registry_t *registry = darktable.ai_registry;
   if(!registry) return;
   g_mutex_lock(&registry->lock);
   registry->provider = provider;
   g_mutex_unlock(&registry->lock);
 }
 
-dt_ai_registry_t *dt_ai_models_init(void)
+gboolean dt_ai_models_init(void)
 {
   dt_ai_registry_t *registry = g_new0(dt_ai_registry_t, 1);
   g_mutex_init(&registry->lock);
 
   registry->ai_enabled = dt_conf_get_bool(CONF_AI_ENABLED);
 
+  // when AI starts disabled, directory setup is deferred to init_lazy;
+  // nothing can fail here, so report success
+  gboolean ok = TRUE;
   if(registry->ai_enabled)
-    _setup_registry(registry);
+    ok = _setup_registry(registry);
 
   // capture conf snapshot so *_changed_since_load() helpers reference
   // the startup state, not a value modified by user before first ORT use
   dt_ai_snapshot_conf_state();
 
-  return registry;
+  darktable.ai_registry = registry;
+  return ok;
 }
 
-void dt_ai_models_init_lazy(dt_ai_registry_t *registry)
+void dt_ai_models_init_lazy(void)
 {
+  dt_ai_registry_t *registry = darktable.ai_registry;
   if(!registry || registry->models_dir)
   {
     // catch broken publication order in _setup_registry: any field
@@ -461,7 +484,7 @@ void dt_ai_models_init_lazy(dt_ai_registry_t *registry)
   _setup_registry(registry);
   g_mutex_unlock(&registry->lock);
 
-  dt_ai_models_load_registry(registry);
+  dt_ai_models_load_registry();
 }
 
 static dt_ai_model_t *_parse_model_json(JsonObject *obj)
@@ -489,8 +512,9 @@ static dt_ai_model_t *_parse_model_json(JsonObject *obj)
   return model;
 }
 
-gboolean dt_ai_models_load_registry(dt_ai_registry_t *registry)
+gboolean dt_ai_models_load_registry(void)
 {
+  dt_ai_registry_t *registry = darktable.ai_registry;
   if(!registry || !registry->ai_enabled)
     return FALSE;
 
@@ -594,7 +618,7 @@ gboolean dt_ai_models_load_registry(dt_ai_registry_t *registry)
   g_free(registry_path);
 
   // check which models are actually downloaded
-  dt_ai_models_refresh_status(registry);
+  dt_ai_models_refresh_status();
 
   return TRUE;
 }
@@ -682,8 +706,9 @@ static gboolean _valid_model_id(const char *model_id)
   return TRUE;
 }
 
-void dt_ai_models_refresh_status(dt_ai_registry_t *registry)
+void dt_ai_models_refresh_status(void)
 {
+  dt_ai_registry_t *registry = darktable.ai_registry;
   if(!registry)
     return;
 
@@ -802,8 +827,9 @@ void dt_ai_models_refresh_status(dt_ai_registry_t *registry)
   g_mutex_unlock(&registry->lock);
 }
 
-void dt_ai_models_check_updates(dt_ai_registry_t *registry)
+void dt_ai_models_check_updates(void)
 {
+  dt_ai_registry_t *registry = darktable.ai_registry;
   if(!registry) return;
 
   // only check once per session
@@ -945,10 +971,14 @@ void dt_ai_models_check_updates(dt_ai_registry_t *registry)
   g_object_unref(parser);
 }
 
-void dt_ai_models_cleanup(dt_ai_registry_t *registry)
+void dt_ai_models_cleanup(void)
 {
+  dt_ai_registry_t *registry = darktable.ai_registry;
   if(!registry)
     return;
+
+  // unpublish before teardown so nothing can pick up a half-freed registry
+  darktable.ai_registry = NULL;
 
   g_mutex_lock(&registry->lock);
   g_list_free_full(registry->models, (GDestroyNotify)_model_free);
@@ -979,8 +1009,9 @@ _find_model_unlocked(dt_ai_registry_t *registry, const char *model_id)
   return NULL;
 }
 
-int dt_ai_models_get_count(dt_ai_registry_t *registry)
+int dt_ai_models_get_count(void)
 {
+  dt_ai_registry_t *registry = darktable.ai_registry;
   if(!registry)
     return 0;
   g_mutex_lock(&registry->lock);
@@ -989,9 +1020,9 @@ int dt_ai_models_get_count(dt_ai_registry_t *registry)
   return count;
 }
 
-dt_ai_model_t *dt_ai_models_get_by_index(dt_ai_registry_t *registry,
-                                         const int index)
+dt_ai_model_t *dt_ai_models_get_by_index(const int index)
 {
+  dt_ai_registry_t *registry = darktable.ai_registry;
   if(!registry || index < 0)
     return NULL;
   g_mutex_lock(&registry->lock);
@@ -1001,9 +1032,9 @@ dt_ai_model_t *dt_ai_models_get_by_index(dt_ai_registry_t *registry,
   return copy;
 }
 
-dt_ai_model_t *dt_ai_models_get_by_id(dt_ai_registry_t *registry,
-                                      const char *model_id)
+dt_ai_model_t *dt_ai_models_get_by_id(const char *model_id)
 {
+  dt_ai_registry_t *registry = darktable.ai_registry;
   if(!registry || !model_id)
     return NULL;
   g_mutex_lock(&registry->lock);
@@ -1362,9 +1393,9 @@ static void _activate_if_unset(dt_ai_registry_t *registry,
 
 // install a local .dtmodel file (zip archive) into the models directory.
 // returns error message (caller must free) or NULL on success.
-char *dt_ai_models_install_local(dt_ai_registry_t *registry,
-                                 const char *filepath)
+char *dt_ai_models_install_local(const char *filepath)
 {
+  dt_ai_registry_t *registry = darktable.ai_registry;
   if(!registry || !filepath)
     return g_strdup(_("invalid parameters"));
 
@@ -1390,7 +1421,7 @@ char *dt_ai_models_install_local(dt_ai_registry_t *registry,
   }
 
   // rescan models directory to pick up newly installed model
-  dt_ai_models_refresh_status(registry);
+  dt_ai_models_refresh_status();
 
   _activate_if_unset(registry, installed_id);
 
@@ -1420,12 +1451,12 @@ static const char *_pick_fallback_active_unlocked(dt_ai_registry_t *registry,
 
 #ifdef HAVE_AI_DOWNLOAD
 // synchronous download - returns error message or NULL on success
-char *dt_ai_models_download_sync(dt_ai_registry_t *registry,
-                                 const char *model_id,
+char *dt_ai_models_download_sync(const char *model_id,
                                  dt_ai_progress_callback callback,
                                  gpointer user_data,
                                  const gboolean *cancel_flag)
 {
+  dt_ai_registry_t *registry = darktable.ai_registry;
   dt_print(DT_DEBUG_AI,
            "[ai_models] download requested for: %s",
            model_id ? model_id : "(null)");
@@ -1705,12 +1736,11 @@ char *dt_ai_models_download_sync(dt_ai_registry_t *registry,
 }
 
 // wrapper that returns boolean for compatibility
-gboolean dt_ai_models_download(dt_ai_registry_t *registry,
-                               const char *model_id,
+gboolean dt_ai_models_download(const char *model_id,
                                dt_ai_progress_callback callback,
                                gpointer user_data)
 {
-  char *error = dt_ai_models_download_sync(registry, model_id, callback, user_data, NULL);
+  char *error = dt_ai_models_download_sync(model_id, callback, user_data, NULL);
   if(error)
   {
     dt_print(DT_DEBUG_AI, "[ai_models] download error: %s", error);
@@ -1720,11 +1750,10 @@ gboolean dt_ai_models_download(dt_ai_registry_t *registry,
   return TRUE;
 }
 
-gboolean dt_ai_models_download_default(
-  dt_ai_registry_t *registry,
-  dt_ai_progress_callback callback,
-  gpointer user_data)
+gboolean dt_ai_models_download_default(dt_ai_progress_callback callback,
+                                       gpointer user_data)
 {
+  dt_ai_registry_t *registry = darktable.ai_registry;
   if(!registry)
     return FALSE;
 
@@ -1742,17 +1771,17 @@ gboolean dt_ai_models_download_default(
   gboolean any_started = FALSE;
   for(GList *l = ids; l; l = g_list_next(l))
   {
-    if(dt_ai_models_download(registry, (const char *)l->data, callback, user_data))
+    if(dt_ai_models_download((const char *)l->data, callback, user_data))
       any_started = TRUE;
   }
   g_list_free_full(ids, g_free);
   return any_started;
 }
 
-gboolean dt_ai_models_download_all(dt_ai_registry_t *registry,
-                                   dt_ai_progress_callback callback,
+gboolean dt_ai_models_download_all(dt_ai_progress_callback callback,
                                    gpointer user_data)
 {
+  dt_ai_registry_t *registry = darktable.ai_registry;
   if(!registry)
     return FALSE;
 
@@ -1770,7 +1799,7 @@ gboolean dt_ai_models_download_all(dt_ai_registry_t *registry,
   gboolean any_started = FALSE;
   for(GList *l = ids; l; l = g_list_next(l))
   {
-    if(dt_ai_models_download(registry, (const char *)l->data, callback, user_data))
+    if(dt_ai_models_download((const char *)l->data, callback, user_data))
       any_started = TRUE;
   }
   g_list_free_full(ids, g_free);
@@ -1806,8 +1835,9 @@ static gboolean _rmdir_recursive(const char *path)
   return g_rmdir(path) == 0;
 }
 
-gboolean dt_ai_models_delete(dt_ai_registry_t *registry, const char *model_id)
+gboolean dt_ai_models_delete(const char *model_id)
 {
+  dt_ai_registry_t *registry = darktable.ai_registry;
   if(!registry || !_valid_model_id(model_id))
     return FALSE;
 
@@ -1861,11 +1891,9 @@ gboolean dt_ai_models_delete(dt_ai_registry_t *registry, const char *model_id)
 
 // configuration
 
-void dt_ai_models_set_enabled(
-  dt_ai_registry_t *registry,
-  const char *model_id,
-  gboolean enabled)
+void dt_ai_models_set_enabled(const char *model_id, gboolean enabled)
 {
+  dt_ai_registry_t *registry = darktable.ai_registry;
   if(!registry || !model_id)
     return;
 
@@ -1980,8 +2008,9 @@ void dt_ai_models_set_active_for_task(const char *task, const char *model_id)
   g_free(conf_key);
 }
 
-char *dt_ai_models_get_path(dt_ai_registry_t *registry, const char *model_id)
+char *dt_ai_models_get_path(const char *model_id)
 {
+  dt_ai_registry_t *registry = darktable.ai_registry;
   if(!registry || !_valid_model_id(model_id))
     return NULL;
 
@@ -1996,11 +2025,11 @@ char *dt_ai_models_get_path(dt_ai_registry_t *registry, const char *model_id)
   return g_build_filename(registry->models_dir, model_id, NULL);
 }
 
-void dt_ai_models_get_spatial_dims(dt_ai_registry_t *registry,
-                                   const char *model_id,
+void dt_ai_models_get_spatial_dims(const char *model_id,
                                    const char **out_h,
                                    const char **out_w)
 {
+  dt_ai_registry_t *registry = darktable.ai_registry;
   *out_h = "height";
   *out_w = "width";
   if(!registry || !_valid_model_id(model_id)) return;
@@ -2027,10 +2056,9 @@ static char *_card_str(JsonObject *obj, const char *key)
   return (val && val[0]) ? g_strdup(val) : NULL;
 }
 
-dt_ai_model_card_t *dt_ai_models_get_card(dt_ai_registry_t *registry,
-                                          const char *model_id)
+dt_ai_model_card_t *dt_ai_models_get_card(const char *model_id)
 {
-  char *model_path = dt_ai_models_get_path(registry, model_id);
+  char *model_path = dt_ai_models_get_path(model_id);
   if(!model_path)
   {
     dt_print(DT_DEBUG_AI,
@@ -2106,8 +2134,9 @@ void dt_ai_model_card_free(dt_ai_model_card_t *card)
   g_free(card);
 }
 
-dt_ai_environment_t *dt_ai_registry_get_env(dt_ai_registry_t *registry)
+dt_ai_environment_t *dt_ai_registry_get_env(void)
 {
+  dt_ai_registry_t *registry = darktable.ai_registry;
   if(!registry || !registry->ai_enabled)
     return NULL;
 

--- a/src/common/ai_models.h
+++ b/src/common/ai_models.h
@@ -68,18 +68,14 @@ typedef void (*dt_ai_progress_callback)(const char *model_id,
                                         const double progress,
                                         gpointer user_data);
 
-/**
- * @brief AI Models Registry — opaque handle.
- *
- * The registry holds a private mutex and the in-memory model list.
- * Both are intentionally hidden so callers can't deadlock by acquiring
- * the lock directly, race-iterate the list, or touch fields without
- * going through the API. The full definition lives in ai_models.c.
- *
- * External callers should treat the type as opaque and use the
- * accessor functions below.
- */
-typedef struct dt_ai_registry_t dt_ai_registry_t;
+// The AI models registry is a per-session singleton owned by
+// darktable.ai_registry. It is created by dt_ai_models_init() and
+// destroyed by dt_ai_models_cleanup(); the struct itself (private
+// mutex + in-memory model list) is defined only in ai_models.c so
+// callers can't deadlock on the lock or race-iterate the list. Every
+// function below operates on that singleton implicitly — there is no
+// registry handle to pass around. All are safe to call before init or
+// on a non-AI build, where they no-op (returning FALSE/0/NULL).
 
 // --- Registry state accessors ---
 // thin, locked accessors for the few fields external callers need to
@@ -87,42 +83,44 @@ typedef struct dt_ai_registry_t dt_ai_registry_t;
 
 /**
  * @brief TRUE if AI is currently enabled (global toggle in prefs).
- *        Safe to call from any thread; NULL registry returns FALSE.
+ *        Safe to call from any thread.
  */
-gboolean dt_ai_registry_is_enabled(dt_ai_registry_t *registry);
+gboolean dt_ai_registry_is_enabled(void);
 
 /**
  * @brief Set the global AI-enabled state in the registry.
  *        Does NOT write to darktablerc — caller must persist the
  *        preference separately. Safe to call from any thread.
  */
-void dt_ai_registry_set_enabled(dt_ai_registry_t *registry, const gboolean enabled);
+void dt_ai_registry_set_enabled(const gboolean enabled);
 
 /**
  * @brief Set the execution provider in the registry.
  *        Does NOT write to darktablerc — caller must persist the
  *        preference separately. Safe to call from any thread.
  */
-void dt_ai_registry_set_provider(dt_ai_registry_t *registry,
-                                 const dt_ai_provider_t provider);
+void dt_ai_registry_set_provider(const dt_ai_provider_t provider);
 
 // --- Core API ---
 
 /**
- * @brief Initialize the AI models registry
- * @return New registry instance, or NULL on error
+ * @brief Initialize the AI models registry singleton.
+ *        On return darktable.ai_registry points at the new registry
+ *        (always created). When AI is enabled at startup this also sets
+ *        up the model/cache directories.
+ * @return TRUE if ready; FALSE if directory setup failed (the registry
+ *         still exists but downloads/scans will not work)
  */
-dt_ai_registry_t *dt_ai_models_init(void);
+gboolean dt_ai_models_init(void);
 
 /**
  * @brief Load model registry from `ai_models.json` bundled with the
  *        darktable installation (looked up under DATADIR). There is
  *        no caller-supplied path — the registry source is fixed by
  *        the install layout.
- * @param registry The registry to populate
  * @return TRUE on success
  */
-gboolean dt_ai_models_load_registry(dt_ai_registry_t *registry);
+gboolean dt_ai_models_load_registry(void);
 
 /**
  * @brief Lazy-initialize AI registry at runtime
@@ -134,16 +132,13 @@ gboolean dt_ai_models_load_registry(dt_ai_registry_t *registry);
  * locally installed models.
  *
  * Safe to call multiple times — no-ops if already initialized.
- *
- * @param registry The registry to initialize
  */
-void dt_ai_models_init_lazy(dt_ai_registry_t *registry);
+void dt_ai_models_init_lazy(void);
 
 /**
  * @brief Scan models directory and update download status
- * @param registry The registry to update
  */
-void dt_ai_models_refresh_status(dt_ai_registry_t *registry);
+void dt_ai_models_refresh_status(void);
 
 /**
  * @brief Check for model updates by fetching versions.json from the
@@ -157,16 +152,13 @@ void dt_ai_models_refresh_status(dt_ai_registry_t *registry);
  *        UPDATE_REQUIRED means darktable cannot use the installed
  *        model with the current code; UPDATE_AVAILABLE is a soft
  *        nudge — the installed model still works.
- *
- * @param registry The registry to update
  */
-void dt_ai_models_check_updates(dt_ai_registry_t *registry);
+void dt_ai_models_check_updates(void);
 
 /**
- * @brief Clean up and free the registry
- * @param registry The registry to destroy
+ * @brief Clean up and free the registry singleton (sets it to NULL).
  */
-void dt_ai_models_cleanup(dt_ai_registry_t *registry);
+void dt_ai_models_cleanup(void);
 
 // --- Model Access ---
 // All get functions return a COPY of the model. Caller must free with dt_ai_model_free().
@@ -180,110 +172,94 @@ void dt_ai_model_free(dt_ai_model_t *model);
 
 /**
  * @brief Get number of models in registry
- * @param registry The registry
  * @return Number of models
  */
-int dt_ai_models_get_count(dt_ai_registry_t *registry);
+int dt_ai_models_get_count(void);
 
 /**
  * @brief Get model by index (returns a copy, caller must free with dt_ai_model_free)
- * @param registry The registry
  * @param index Index 0 to count-1
  * @return Model copy (caller owns), or NULL
  */
-dt_ai_model_t *dt_ai_models_get_by_index(dt_ai_registry_t *registry,
-                                         const int index);
+dt_ai_model_t *dt_ai_models_get_by_index(const int index);
 
 /**
  * @brief Get model by ID (returns a copy, caller must free with dt_ai_model_free)
- * @param registry The registry
  * @param model_id The unique model ID
  * @return Model copy (caller owns), or NULL
  */
-dt_ai_model_t *dt_ai_models_get_by_id(dt_ai_registry_t *registry,
-                                      const char *model_id);
+dt_ai_model_t *dt_ai_models_get_by_id(const char *model_id);
 
 // --- Install Operations ---
 
 /**
  * @brief Install a model from a local .dtmodel file
- * @param registry The registry
  * @param filepath Path to the .dtmodel file (zip archive)
  * @return Error message (caller must free) or NULL on success
  */
-char *dt_ai_models_install_local(dt_ai_registry_t *registry, const char *filepath);
+char *dt_ai_models_install_local(const char *filepath);
 
 #ifdef HAVE_AI_DOWNLOAD
 // --- Download Operations ---
 
 /**
  * @brief Download a specific model synchronously
- * @param registry The registry
  * @param model_id The model to download
  * @param callback Progress callback (may be NULL)
  * @param user_data Data for callback
  * @param cancel_flag Pointer to boolean checked for cancellation (may be NULL)
  * @return Error message (caller must free) or NULL on success
  */
-char *dt_ai_models_download_sync(dt_ai_registry_t *registry, const char *model_id,
+char *dt_ai_models_download_sync(const char *model_id,
                                  dt_ai_progress_callback callback,
                                  gpointer user_data,
                                  const gboolean *cancel_flag);
 
 /**
  * @brief Download a specific model (convenience wrapper)
- * @param registry The registry
  * @param model_id The model to download
  * @param callback Progress callback (may be NULL)
  * @param user_data Data for callback
  * @return TRUE on success
  */
-gboolean dt_ai_models_download(dt_ai_registry_t *registry,
-                               const char *model_id,
+gboolean dt_ai_models_download(const char *model_id,
                                dt_ai_progress_callback callback,
                                gpointer user_data);
 
 /**
  * @brief Download all default models (runs in background)
- * @param registry The registry
  * @param callback Progress callback (may be NULL)
  * @param user_data Data for callback
  * @return TRUE if downloads started successfully
  */
-gboolean dt_ai_models_download_default(dt_ai_registry_t *registry,
-                                       dt_ai_progress_callback callback,
+gboolean dt_ai_models_download_default(dt_ai_progress_callback callback,
                                        gpointer user_data);
 
 /**
  * @brief Download all models (runs in background)
- * @param registry The registry
  * @param callback Progress callback (may be NULL)
  * @param user_data Data for callback
  * @return TRUE if downloads started successfully
  */
-gboolean dt_ai_models_download_all(dt_ai_registry_t *registry,
-                                   dt_ai_progress_callback callback,
+gboolean dt_ai_models_download_all(dt_ai_progress_callback callback,
                                    gpointer user_data);
 #endif /* HAVE_AI_DOWNLOAD */
 
 /**
  * @brief Delete a downloaded model
- * @param registry The registry
  * @param model_id The model to delete
  * @return TRUE on success
  */
-gboolean dt_ai_models_delete(dt_ai_registry_t *registry, const char *model_id);
+gboolean dt_ai_models_delete(const char *model_id);
 
 // --- Configuration ---
 
 /**
  * @brief Set model enabled state (persisted to config)
- * @param registry The registry
  * @param model_id The model ID
  * @param enabled Whether the model should be enabled
  */
-void dt_ai_models_set_enabled(dt_ai_registry_t *registry, const char *model_id,
-                              gboolean enabled);
+void dt_ai_models_set_enabled(const char *model_id, gboolean enabled);
 
 /**
  * @brief Get the active model ID for a task.
@@ -331,21 +307,18 @@ void dt_ai_models_set_active_for_task(const char *task, const char *model_id);
 
 /**
  * @brief Get the path to a downloaded model's directory
- * @param registry The registry
  * @param model_id The model ID
  * @return Path string (caller must free), or NULL if not downloaded
  */
-char *dt_ai_models_get_path(dt_ai_registry_t *registry, const char *model_id);
+char *dt_ai_models_get_path(const char *model_id);
 
 /**
  * @brief Get the symbolic spatial dimension names for a model
- * @param registry The registry
  * @param model_id The model identifier
  * @param out_h Output: height dimension name (never NULL; points to static default if unset)
  * @param out_w Output: width dimension name (never NULL; points to static default if unset)
  */
-void dt_ai_models_get_spatial_dims(dt_ai_registry_t *registry,
-                                   const char *model_id,
+void dt_ai_models_get_spatial_dims(const char *model_id,
                                    const char **out_h,
                                    const char **out_w);
 
@@ -370,13 +343,11 @@ typedef struct dt_ai_model_card_t
 
 /**
  * @brief Read model card from config.json on disk
- * @param registry The registry
  * @param model_id The model identifier
  * @return Card struct (caller must free with dt_ai_model_card_free),
  *         or NULL if model directory not found
  */
-dt_ai_model_card_t *dt_ai_models_get_card(
-  dt_ai_registry_t *registry, const char *model_id);
+dt_ai_model_card_t *dt_ai_models_get_card(const char *model_id);
 
 /**
  * @brief Free a model card returned by dt_ai_models_get_card
@@ -387,7 +358,6 @@ void dt_ai_model_card_free(dt_ai_model_card_t *card);
  * @brief Get or lazily create the AI backend environment.
  *        The environment is cached in the registry and destroyed
  *        by dt_ai_models_cleanup().
- * @param registry The registry
  * @return Environment handle, or NULL if AI is disabled
  */
-dt_ai_environment_t *dt_ai_registry_get_env(dt_ai_registry_t *registry);
+dt_ai_environment_t *dt_ai_registry_get_env(void);

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1666,14 +1666,16 @@ int dt_init(int argc,
   darktable.color_profiles = dt_colorspaces_init();
 
 #ifdef HAVE_AI
-  // initialize AI models registry
-  darktable.ai_registry = dt_ai_models_init();
-  if(darktable.ai_registry)
+  // initialize AI models registry (the singleton darktable.ai_registry)
+  if(dt_ai_models_init())
   {
-    dt_ai_models_load_registry(darktable.ai_registry);
-    if(!dt_ai_registry_is_enabled(darktable.ai_registry))
+    dt_ai_models_load_registry();
+    if(!dt_ai_registry_is_enabled())
       dt_print(DT_DEBUG_AI, "[darktable_ai] AI subsystem is disabled");
   }
+  else
+    dt_print(DT_DEBUG_ALWAYS,
+             "[darktable_ai] could not set up AI directories; AI features unavailable");
 #endif
 
   // initialize datetime data
@@ -2222,8 +2224,7 @@ void dt_cleanup()
 
   dt_colorspaces_cleanup(darktable.color_profiles);
 #ifdef HAVE_AI
-  dt_ai_models_cleanup(darktable.ai_registry);
-  darktable.ai_registry = NULL;
+  dt_ai_models_cleanup();
   dt_ai_backend_cleanup_globals();
 #endif
   dt_conf_cleanup(darktable.conf);

--- a/src/develop/masks/object.c
+++ b/src/develop/masks/object.c
@@ -1983,10 +1983,10 @@ const dt_masks_functions_t dt_masks_functions_object = {
 
 gboolean dt_masks_object_available(void)
 {
-  if(!dt_ai_registry_is_enabled(darktable.ai_registry))
+  if(!dt_ai_registry_is_enabled())
     return FALSE;
   char *model_id = dt_ai_models_get_active_for_task("mask");
-  dt_ai_model_t *model = dt_ai_models_get_by_id(darktable.ai_registry, model_id);
+  dt_ai_model_t *model = dt_ai_models_get_by_id(model_id);
   g_free(model_id);
   const gboolean available = model && model->status == DT_AI_MODEL_DOWNLOADED;
   dt_ai_model_free(model);

--- a/src/gui/preferences_ai.c
+++ b/src/gui/preferences_ai.c
@@ -203,14 +203,14 @@ static void _refresh_model_list(dt_prefs_ai_data_t *data)
 
   gtk_list_store_clear(data->model_store);
 
-  dt_ai_models_refresh_status(darktable.ai_registry);
-  dt_ai_models_check_updates(darktable.ai_registry);
+  dt_ai_models_refresh_status();
+  dt_ai_models_check_updates();
 
-  const int count = dt_ai_models_get_count(darktable.ai_registry);
+  const int count = dt_ai_models_get_count();
   dt_print(DT_DEBUG_AI, "[preferences_ai] refreshing model list, count=%d", count);
   for(int i = 0; i < count; i++)
   {
-    dt_ai_model_t *model = dt_ai_models_get_by_index(darktable.ai_registry, i);
+    dt_ai_model_t *model = dt_ai_models_get_by_index(i);
     if(!model)
     {
       dt_print(DT_DEBUG_AI, "[preferences_ai] model at index %d is NULL", i);
@@ -301,12 +301,12 @@ static void _on_enable_toggled(GtkWidget *widget, gpointer user_data)
   dt_conf_set_bool("plugins/ai/enabled", enabled);
   if(darktable.ai_registry)
   {
-    dt_ai_registry_set_enabled(darktable.ai_registry, enabled);
+    dt_ai_registry_set_enabled(enabled);
 
     // lazy-init directories + models on first enable
     if(enabled)
     {
-      dt_ai_models_init_lazy(darktable.ai_registry);
+      dt_ai_models_init_lazy();
       _refresh_model_list(data);
     }
   }
@@ -552,7 +552,7 @@ static void _update_provider_status(dt_prefs_ai_data_t *data,
 
   // don't probe GPU providers when AI is disabled —
   // initializing MIGraphX/ROCm on unsupported GPUs can abort()
-  if(!dt_ai_registry_is_enabled(darktable.ai_registry))
+  if(!dt_ai_registry_is_enabled())
   {
     gtk_label_set_text(GTK_LABEL(data->provider_status), "");
     return;
@@ -587,7 +587,7 @@ static void _on_provider_changed(GtkWidget *widget, gpointer user_data)
   const int combo_idx = dt_bauhaus_combobox_get(widget);
   const int pi = _combo_idx_to_provider(combo_idx, data->supported_providers);
   dt_conf_set_string(DT_AI_CONF_PROVIDER, dt_ai_providers[pi].config_string);
-  dt_ai_registry_set_provider(darktable.ai_registry, dt_ai_providers[pi].value);
+  dt_ai_registry_set_provider(dt_ai_providers[pi].value);
   _update_string_indicator(data->provider_indicator, DT_AI_CONF_PROVIDER);
   _update_provider_status(data, dt_ai_providers[pi].value);
 }
@@ -807,7 +807,6 @@ static gpointer _download_thread_func(gpointer user_data)
   dt_download_dialog_t *dl = (dt_download_dialog_t *)user_data;
 
   char *error = dt_ai_models_download_sync(
-    darktable.ai_registry,
     dl->model_id,
     _download_progress_callback,
     dl,
@@ -825,7 +824,7 @@ static gpointer _download_thread_func(gpointer user_data)
 static gboolean
 _download_model_with_dialog(dt_prefs_ai_data_t *data, const char *model_id)
 {
-  dt_ai_model_t *model = dt_ai_models_get_by_id(darktable.ai_registry, model_id);
+  dt_ai_model_t *model = dt_ai_models_get_by_id(model_id);
   if(!model)
     return FALSE;
 
@@ -939,7 +938,7 @@ static void _on_download_selected(GtkButton *button, gpointer user_data)
   for(GList *l = ids; l; l = g_list_next(l))
   {
     const char *id = (const char *)l->data;
-    dt_ai_model_t *model = dt_ai_models_get_by_id(darktable.ai_registry, id);
+    dt_ai_model_t *model = dt_ai_models_get_by_id(id);
     if(model)
     {
       gboolean need_download = (model->status == DT_AI_MODEL_NOT_DOWNLOADED
@@ -959,10 +958,10 @@ static void _on_download_default(GtkButton *button, gpointer user_data)
   dt_prefs_ai_data_t *data = (dt_prefs_ai_data_t *)user_data;
 
   // download default models that need downloading
-  const int count = dt_ai_models_get_count(darktable.ai_registry);
+  const int count = dt_ai_models_get_count();
   for(int i = 0; i < count; i++)
   {
-    dt_ai_model_t *model = dt_ai_models_get_by_index(darktable.ai_registry, i);
+    dt_ai_model_t *model = dt_ai_models_get_by_index(i);
     if(!model)
       continue;
     gboolean need_download
@@ -1021,7 +1020,7 @@ static void _on_install_model(GtkButton *button, gpointer user_data)
   for(GSList *l = files; l; l = l->next)
   {
     const char *filepath = (const char *)l->data;
-    char *error = dt_ai_models_install_local(darktable.ai_registry, filepath);
+    char *error = dt_ai_models_install_local(filepath);
     if(error)
     {
       gchar *base = g_path_get_basename(filepath);
@@ -1068,7 +1067,7 @@ static void _on_delete_selected(GtkButton *button, gpointer user_data)
   for(GList *l = ids; l; l = g_list_next(l))
   {
     const char *id = (const char *)l->data;
-    dt_ai_model_t *model = dt_ai_models_get_by_id(darktable.ai_registry, id);
+    dt_ai_model_t *model = dt_ai_models_get_by_id(id);
     if(model)
     {
       if(model->status == DT_AI_MODEL_DOWNLOADED
@@ -1104,7 +1103,7 @@ static void _on_delete_selected(GtkButton *button, gpointer user_data)
     for(GList *l = to_delete; l; l = g_list_next(l))
     {
       const char *model_id = (const char *)l->data;
-      if(dt_ai_models_delete(darktable.ai_registry, model_id))
+      if(dt_ai_models_delete(model_id))
       {
         dt_print(DT_DEBUG_AI, "[preferences_ai] deleted model: %s", model_id);
         any_deleted = TRUE;
@@ -1127,7 +1126,7 @@ static void _show_model_card(dt_prefs_ai_data_t *data,
   if(!model_id || !model_id[0]) return;
 
   const char *dash = "\xe2\x80\x93";  // en dash for missing fields
-  dt_ai_model_card_t *card = dt_ai_models_get_card(darktable.ai_registry, model_id);
+  dt_ai_model_card_t *card = dt_ai_models_get_card(model_id);
 
   const char *name = (card && card->name)
     ? card->name : model_id;

--- a/src/lua/ai.c
+++ b/src/lua/ai.c
@@ -841,14 +841,13 @@ static int _context_close(lua_State *L)
 //   task (string), status (int), is_default (bool)
 static int _ai_models(lua_State *L)
 {
-  dt_ai_registry_t *reg = darktable.ai_registry;
   lua_newtable(L);
-  if(!reg) return 1;
+  if(!darktable.ai_registry) return 1;
 
-  const int count = dt_ai_models_get_count(reg);
+  const int count = dt_ai_models_get_count();
   for(int i = 0; i < count; i++)
   {
-    dt_ai_model_t *m = dt_ai_models_get_by_index(reg, i);
+    dt_ai_model_t *m = dt_ai_models_get_by_index(i);
     if(!m) continue;
     lua_newtable(L);
     lua_pushstring(L, m->id);
@@ -908,8 +907,7 @@ static int _ai_load_model(lua_State *L)
   if(lua_gettop(L) >= 3 && !lua_isnil(L, 3))
     model_file = luaL_checkstring(L, 3);
 
-  dt_ai_environment_t *env
-    = dt_ai_registry_get_env(darktable.ai_registry);
+  dt_ai_environment_t *env = dt_ai_registry_get_env();
   if(!env)
     return luaL_error(L, "AI subsystem is not available");
 


### PR DESCRIPTION
The AI models registry has always been a per-session singleton owned by `darktable.ai_registry`, created once in `dt_init()` and destroyed in `dt_cleanup()`. Despite that, most of the `ai_models` API threaded a `dt_ai_registry_t *registry` argument through every call, and every caller passed the same global. A few functions (`dt_ai_models_get_active_for_task`, `dt_ai_model_get_version`, `dt_ai_model_get_min_version`, `dt_ai_models_set_active_for_task`) already reached into the global directly, leaving the API half-converted and the opaque type leaking into the public header for no benefit.

This PR finishes the conversion: the registry parameter is dropped from the public API and sourced from `darktable.ai_registry` internally, and the `dt_ai_registry_t` type moves entirely into `ai_models.c`.

### Notes

I kept this separate from my earlier fix in #21144 on purpose - it stands on its own. It is mostly mechanical refactoring, does not change any behavior, and I tested it on all three platforms (Linux, Windows, macOS).

The AI subsystem is new this cycle and has not shipped in a release yet, so now is a cheap time to do it: there are still few call sites, and no released version has set the current inconsistent API as the example for future AI code to copy. The longer it waits, the more call sites pile up.

My mild preference would be to merge it for 5.6.0 while the call sites are few, but it is a larger change than a typical freeze fix, so I completely understand if you would rather hold it for the next dev cycle - whatever works best for the project.