### PR TITLE
Fix culling viewport not tracking zoom during deferred gesture

### DIFF
--- a/src/dtgtk/thumbnail.c
+++ b/src/dtgtk/thumbnail.c
@@ -659,6 +659,56 @@ static void _thumb_set_image_area(dt_thumbnail_t *thumb,
   gtk_widget_set_margin_top(thumb->w_image_box, posy);
 }
 
+// Resize the image box (w_image — the rectangle the grey frame is drawn around)
+// so it hugs the visible image at the current zoom, and recenter the pan to
+// account for the size change. The visible extent is the rendered surface size
+// (img_width/img_height, produced at img_surf_zoom) scaled to the current
+// thumb->zoom. In the surface-reload path img_surf_zoom has just been set equal
+// to thumb->zoom so the scale is 1; during a deferred zoom gesture (surface not
+// yet reloaded) the scale tracks how far the zoom has advanced past the surface,
+// so the box still grows/shrinks live with the gesture instead of snapping only
+// when the surface is finally reloaded.
+static void _thumb_update_image_box(dt_thumbnail_t *thumb)
+{
+  if(!thumb->img_surf) return;
+
+  const float scale =
+    (thumb->img_surf_zoom > 0.0f) ? thumb->zoom / thumb->img_surf_zoom : 1.0f;
+
+  int image_w = 0;
+  int image_h = 0;
+  gtk_widget_get_size_request(thumb->w_image_box, &image_w, &image_h);
+
+  // the box hugs the image but never exceeds the available image area
+  const int imgbox_w =
+    MIN(image_w, (int)(thumb->img_width * scale / darktable.gui->ppd_thb));
+  const int imgbox_h =
+    MIN(image_h, (int)(thumb->img_height * scale / darktable.gui->ppd_thb));
+
+  // record the box size before the change so we can recenter the pan
+  int ww = 0;
+  int hh = 0;
+  gtk_widget_get_size_request(thumb->w_image, &ww, &hh);
+  _thumb_set_image_size(thumb, imgbox_w, imgbox_h);
+  // the box size may have been slightly sanitized, so we read it back
+  int nwi = 0;
+  int nhi = 0;
+  gtk_widget_get_size_request(thumb->w_image, &nwi, &nhi);
+
+  // panning value needs to be adjusted if the box size changed
+  thumb->zoomx = thumb->zoomx + (nwi - ww) / 2.0;
+  thumb->zoomy = thumb->zoomy + (nhi - hh) / 2.0;
+  // sanitize against the (scaled) real image extent, accounting for ppd
+  thumb->zoomx =
+    CLAMP(thumb->zoomx,
+          (nwi * darktable.gui->ppd_thb - thumb->img_width * scale)
+          / darktable.gui->ppd_thb, 0);
+  thumb->zoomy =
+    CLAMP(thumb->zoomy,
+          (nhi * darktable.gui->ppd_thb - thumb->img_height * scale)
+          / darktable.gui->ppd_thb, 0);
+}
+
 static gboolean _event_image_draw(GtkWidget *widget,
                                   cairo_t *cr,
                                   gpointer user_data)
@@ -812,36 +862,10 @@ static gboolean _event_image_draw(GtkWidget *widget,
       // record the zoom this surface was rendered at, so deferred-gesture bound
       // math can scale the real surface extent to the current (advancing) zoom.
       thumb->img_surf_zoom = thumb->zoom;
-      // and we want to resize the imagebox to fit in the imagearea
-      const int imgbox_w = MIN(image_w, thumb->img_width / darktable.gui->ppd_thb);
-      const int imgbox_h = MIN(image_h, thumb->img_height / darktable.gui->ppd_thb);
-      // we record the imagebox size before the change
-      int hh = 0;
-      int ww = 0;
-      gtk_widget_get_size_request(thumb->w_image, &ww, &hh);
-      // and we set the new size of the imagebox
-      _thumb_set_image_size(thumb, imgbox_w, imgbox_h);
-      // the imagebox size may have been slightly sanitized, so we get it again
-      int nhi = 0;
-      int nwi = 0;
-      gtk_widget_get_size_request(thumb->w_image, &nwi, &nhi);
-
-      // panning value need to be adjusted if the imagebox size as changed
-      thumb->zoomx = thumb->zoomx + (nwi - ww) / 2.0;
-      thumb->zoomy = thumb->zoomy + (nhi - hh) / 2.0;
-      // let's sanitize and apply panning values as we are sure the
-      // zoomed image is loaded now here we have to make sure to
-      // properly align according to ppd
-      thumb->zoomx
-          = CLAMP(thumb->zoomx,
-                  (nwi * darktable.gui->ppd_thb - thumb->img_width)
-                  / darktable.gui->ppd_thb,
-                  0);
-      thumb->zoomy
-          = CLAMP(thumb->zoomy,
-                  (nhi * darktable.gui->ppd_thb - thumb->img_height)
-                  / darktable.gui->ppd_thb,
-                  0);
+      // resize the image box to hug the freshly-loaded surface and recenter the
+      // pan for the size change (scale collapses to 1 here as img_surf_zoom was
+      // just set to thumb->zoom)
+      _thumb_update_image_box(thumb);
 
       // for overlay block, we need to resize it
       if(thumb->over == DT_THUMBNAIL_OVERLAYS_HOVER_BLOCK)
@@ -2277,6 +2301,12 @@ void dt_thumbnail_image_refresh_zoom(dt_thumbnail_t *thumb)
 void dt_thumbnail_image_preview_zoom(dt_thumbnail_t *thumb)
 {
   thumb->zoom_preview_pending = TRUE;
+
+  // resize the image box (grey frame) to track the new zoom even though the
+  // surface reload is deferred — otherwise the box only resizes when the gesture
+  // ends and the surface is finally reloaded, leaving the frame stuck at the
+  // previous zoom's size mid-gesture.
+  _thumb_update_image_box(thumb);
 
   // we ensure that the image is not completely outside the thumbnail,
   // otherwise the image_draw is not triggered


### PR DESCRIPTION
The grey image frame is drawn around w_image, which is resized to MIN(area, scaled_image_extent) only inside _event_image_draw on a surface reload. The image-surface caching commit (efebaa3586) made pinch / smooth ctrl+scroll defer the surface reload during the gesture and only rescale the stale surface via a cairo transform, so the box was never resized mid-gesture. It snapped to the new size only when the gesture ended and the surface finally reloaded.

As a result the viewport no longer grew and shrank with the zoom: it stayed at its initial size during the gesture, and when the gesture-end event arrived inconsistently (as touchpads do) it could expand on zoom-in and stay expanded on the next zoom-out, leaving the grey frame over a large area with a small image inside and throwing off the pan.

Extract the box-resize and pan-recenter logic from _event_image_draw into _thumb_update_image_box() and call it from both the reload path and the deferred-preview path. The helper sizes w_image to the visible extent img_width * (zoom / img_surf_zoom) clamped to the available area, then recenters and clamps the pan for the size change. In the reload path img_surf_zoom has just been set to zoom so the scale is 1.0 and the behaviour is identical to before; during a deferred gesture the scale tracks how far the zoom has advanced, so the box grows and shrinks live while the expensive surface reload stays deferred to gesture end.

Fixes: https://github.com/darktable-org/darktable/issues/21132

Disclaimer: this work was co-created with Claude.