### PR TITLE
Two profile related fixes

### DIFF
--- a/src/common/iop_profile.c
+++ b/src/common/iop_profile.c
@@ -628,8 +628,7 @@ static inline void _transform_matrix(struct dt_iop_module_t *self,
 }
 
 
-#define DT_IOPPR_LUT_SAMPLES 0x10000
-
+#define DT_IOPPR_LUT_SAMPLES_FALLBACK 0x10000
 void dt_ioppr_init_profile_info(dt_iop_order_iccprofile_info_t *profile_info,
                                 const int lutsize)
 {
@@ -643,7 +642,7 @@ void dt_ioppr_init_profile_info(dt_iop_order_iccprofile_info_t *profile_info,
                                            = profile_info->unbounded_coeffs_out[2][0] = -1.0f;
   profile_info->nonlinearlut = 0;
   profile_info->grey = 0.f;
-  profile_info->lutsize = (lutsize > 0) ? lutsize: DT_IOPPR_LUT_SAMPLES;
+  profile_info->lutsize = (lutsize > 0) ? lutsize: DT_IOPPR_LUT_SAMPLES_FALLBACK;
   for(int i = 0; i < 3; i++)
   {
     profile_info->lut_in[i] = dt_alloc_align_float(profile_info->lutsize);
@@ -652,8 +651,7 @@ void dt_ioppr_init_profile_info(dt_iop_order_iccprofile_info_t *profile_info,
     profile_info->lut_out[i][0] = -1.0f;
   }
 }
-
-#undef DT_IOPPR_LUT_SAMPLES
+#undef DT_IOPPR_LUT_SAMPLES_FALLBACK
 
 void dt_ioppr_cleanup_profile_info(dt_iop_order_iccprofile_info_t *profile_info)
 {
@@ -818,6 +816,7 @@ dt_ioppr_add_profile_info_to_list(struct dt_develop_t *dev,
     }
     else
     {
+      dt_ioppr_cleanup_profile_info(profile_info);
       dt_free_align(profile_info);
       profile_info = NULL;
     }

--- a/src/iop/colorout.c
+++ b/src/iop/colorout.c
@@ -620,10 +620,13 @@ void commit_params(dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_
   }
 
   // when the output type is Lab then process is a nop, so we can avoid creating a transform
-  // and the subsequent error messages
+  // and the subsequent error messages but still have to publish the profile_info
   d->type = out_type;
   if(out_type == DT_COLORSPACE_LAB)
+  {
+    dt_ioppr_set_pipe_output_profile_info(self->dev, piece->pipe, d->type, out_filename, p->intent);
     return;
+  }
 
   /*
    * Setup transform flags


### PR DESCRIPTION
@kofa73 got aware of these (besides many others wanting deeper investigation) 
________________________________________________________________________________________
**Fix missing output_profile_info in colorout commit_params**

For LAB type colorout profiles we missed the pulishing via `dt_ioppr_set_pipe_output_profile_info()` in the early exit code.
_______________________________________________________________________________________
**Fix iop_profile related memleaks**

If `_ioppr_generate_profile_info()` failed to generate a profile in `dt_ioppr_add_profile_info_to_list()` we must also free the included lut_in/out arrays.
______________________________________________________________________________________
@TurboGit the first commit could indeed lead to wrong colors :-)