### PR TITLE
[GUI] Add tooltips to mask toggles in `colorbalance rgb`

### DIFF
--- a/src/iop/colorbalancergb.c
+++ b/src/iop/colorbalancergb.c
@@ -1998,7 +1998,14 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_slider_set_digits(g->highlights_weight, 4);
   dt_bauhaus_slider_set_format(g->highlights_weight, "%");
   gtk_widget_set_tooltip_text(g->highlights_weight, _("weights of highlights over the whole tonal range"));
-  dt_bauhaus_widget_set_quad(g->highlights_weight, self, dtgtk_cairo_paint_showmask, TRUE, mask_callback, NULL);
+  dt_bauhaus_widget_set_quad(g->highlights_weight,
+                             self,
+                             dtgtk_cairo_paint_showmask,
+                             TRUE,
+                             mask_callback,
+                             _("displays a highlights mask, overlaid as a checkerboard\n"
+                               "the still-visible area of the image (not hidden by the mask) is the area\n"
+                               "that will be affected by the highlights sliders in the other tabs"));
 
   dt_gui_box_add(self->widget, dt_ui_section_label_new(C_("section", "threshold")));
 

--- a/src/iop/colorbalancergb.c
+++ b/src/iop/colorbalancergb.c
@@ -1979,7 +1979,14 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_slider_set_digits(g->shadows_weight, 4);
   dt_bauhaus_slider_set_format(g->shadows_weight, "%");
   gtk_widget_set_tooltip_text(g->shadows_weight, _("weight of the shadows over the whole tonal range"));
-  dt_bauhaus_widget_set_quad(g->shadows_weight, self, dtgtk_cairo_paint_showmask, TRUE, mask_callback, NULL);
+  dt_bauhaus_widget_set_quad(g->shadows_weight,
+                             self,
+                             dtgtk_cairo_paint_showmask,
+                             TRUE,
+                             mask_callback,
+                             _("displays a shadows mask, overlaid as a checkerboard\n"
+                               "the still-visible area of the image (not hidden by the mask) is the area\n"
+                               "that will be affected by the shadows sliders in the other tabs"));
 
   g->mask_grey_fulcrum = dt_bauhaus_slider_from_params(self, "mask_grey_fulcrum");
   dt_bauhaus_slider_set_digits(g->mask_grey_fulcrum, 4);

--- a/src/iop/colorbalancergb.c
+++ b/src/iop/colorbalancergb.c
@@ -1992,7 +1992,14 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_slider_set_digits(g->mask_grey_fulcrum, 4);
   dt_bauhaus_slider_set_format(g->mask_grey_fulcrum, "%");
   gtk_widget_set_tooltip_text(g->mask_grey_fulcrum, _("position of the middle-gray reference for masking"));
-  dt_bauhaus_widget_set_quad(g->mask_grey_fulcrum, self, dtgtk_cairo_paint_showmask, TRUE, mask_callback, NULL);
+  dt_bauhaus_widget_set_quad(g->mask_grey_fulcrum,
+                             self,
+                             dtgtk_cairo_paint_showmask,
+                             TRUE,
+                             mask_callback,
+                             _("displays a mid-tones mask, overlaid as a checkerboard\n"
+                               "the still-visible area of the image (not hidden by the mask) is the area\n"
+                               "that will be affected by the mid-tones sliders in the other tabs"));
 
   g->highlights_weight = dt_bauhaus_slider_from_params(self, "highlights_weight");
   dt_bauhaus_slider_set_digits(g->highlights_weight, 4);


### PR DESCRIPTION
We currently don't have tooltips for these mask toggles, so the user have no idea what they do exactly. The wording for these tooltips is taken from the descriptions in the user manual.