### PR TITLE
Expose expander state to CSS via dt_module_expanded class

### DIFF
--- a/src/dtgtk/expander.c
+++ b/src/dtgtk/expander.c
@@ -93,6 +93,8 @@ void dtgtk_expander_set_expanded(GtkDarktableExpander *expander, gboolean expand
 
     if(expanded)
     {
+      // expose expansion state to CSS so themes can style expanded modules
+      dt_gui_add_class(GTK_WIDGET(expander), "dt_module_expanded");
       _set_last_expanded(GTK_WIDGET(expander));
       GtkWidget *sw = gtk_widget_get_ancestor(_last_expanded, GTK_TYPE_SCROLLED_WINDOW);
       if(sw)
@@ -101,6 +103,8 @@ void dtgtk_expander_set_expanded(GtkDarktableExpander *expander, gboolean expand
         _start_pos.x = gtk_adjustment_get_value(gtk_scrolled_window_get_vadjustment(GTK_SCROLLED_WINDOW(sw)));
       }
     }
+    else
+      dt_gui_remove_class(GTK_WIDGET(expander), "dt_module_expanded");
 
     GtkWidget *frame = expander->body;
     if(frame)
@@ -348,6 +352,7 @@ GtkWidget *dtgtk_expander_new(GtkWidget *header, GtkWidget *body)
   expander
       = g_object_new(dtgtk_expander_get_type(), "orientation", GTK_ORIENTATION_VERTICAL, "spacing", 0, NULL);
   expander->expanded = TRUE;
+  dt_gui_add_class(GTK_WIDGET(expander), "dt_module_expanded");
   expander->header = header;
   expander->body = body;
 


### PR DESCRIPTION
**Small additive patch: +3 lines in one file, no behavioural change, no existing theme affected.**

I'm developing a new theme and need to style modules differently when expanded vs collapsed. The current architecture doesn't expose that state to CSS, so this patch adds a small hook – `GtkDarktableExpander` now carries a `dt_module_expanded` CSS class whenever its body is revealed, and drops it when collapsed.

Joins the existing `dt_module_active` / `dt_module_focus` family – same vocabulary theme authors already use.

### Why

For the new theme I'm following the **"chrome that recedes"** principle: passive UI fades into the background, interactive moments come forward. For collapsible modules that translates to *collapsed headers stay flat, expanded headers tint to match their body* so an open module reads as a single container. Without a CSS hook for expansion state there's no clean way to express this.