### PR TITLE
Fix msgfmt error in fr.po

### DIFF
--- a/po/fr.po
+++ b/po/fr.po
@@ -21857,7 +21857,7 @@ msgstr ""
 "Affiche un masque de hauts lumières, superposé sous forme de damier\n"
 "la partie de l'image toujours visible (non masquée) correspond à la zone qui "
 "sera affectée\n"
-"par les curseurs de hauts lumières dans les autres onglets.\n"
+"par les curseurs de hauts lumières dans les autres onglets."
 
 #: ../src/iop/colorbalancergb.c:2017
 msgctxt "section"


### PR DESCRIPTION
This is a fix for:
```
FAILED: [code=1] share/locale/fr/LC_MESSAGES/darktable.mo /__w/darktable/darktable/build/share/locale/fr/LC_MESSAGES/darktable.mo 
cd /__w/darktable/darktable/build/po && /usr/bin/msgfmt -v -c /__w/darktable/darktable/src/po/fr.po -o /__w/darktable/darktable/build/bin/../share/locale/fr/LC_MESSAGES/darktable.mo
/__w/darktable/darktable/src/po/fr.po:21856: 'msgid' and 'msgstr' entries do not both end with '\n'
/usr/bin/msgfmt: found 1 fatal error
5882 translated messages.
```
