### PR TITLE
control log: Max 1 on screen now that we have a log history.

### DIFF
--- a/src/control/control.h
+++ b/src/control/control.h
@@ -105,7 +105,7 @@ struct dt_control_t;
 /** sets the hinter message */
 void dt_control_hinter_message(const char *message);
 
-#define DT_CTL_LOG_SIZE 8 // must be power-of-2
+#define DT_CTL_LOG_SIZE 2 // must be power-of-2
 #define DT_CTL_TOAST_SIZE 2
 
 #define DT_CTL_LOG_MSG_SIZE 1000


### PR DESCRIPTION
**Why**:

Now that we have a log history window we can reduce the number of displayed log on screen at the same time. This avoid cluttering a bit the main window. With this patch we have now 3 messages instead of 7 at the same time.

**Alternative**:

Set the value to `2` to get a single message on screen as it was some time ago.

**Proposal**:

If agreed we could have this in `5.6`, it is safe and seems good for UX. But I won't push for this if there is no vote for it as it is a minor point.