### PR TITLE
Mention dt_module_expanded CSS class in release notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -212,6 +212,9 @@ changes (where available).
   cursor previously appeared as an old-style wristwatch instead of
   the familiar spinning wheel.
 
+- Themes can now style expanded modules differently from collapsed
+  ones, via a new `dt_module_expanded` CSS class.
+
 ## Performance Improvements
 
 - Increased performance for OpenCL guided filter by internal tiling.


### PR DESCRIPTION
Small follow-up to #21170 (a59f338): that commit added a `dt_module_expanded` CSS class to expanded modules so themes can style them differently from collapsed ones, but it didn't make it into the release notes. Added a one-line bullet under "UI/UX Improvements" so theme authors find the new hook when they read the notes.