### PR TITLE
[Nightly] Bump libheif version to the latest for AppImage build

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -124,7 +124,7 @@ jobs:
             libxfixes-dev
       - name: Build and install fresh libheif with built-in decoders
         run: |
-          git clone --branch v1.22.2 --depth 1 https://github.com/strukturag/libheif src-libheif
+          git clone --branch v1.23.0 --depth 1 https://github.com/strukturag/libheif src-libheif
           cd src-libheif
           cmake -S . -B build -G Ninja \
             -DCMAKE_BUILD_TYPE=Release \


### PR DESCRIPTION
I ran a test nightly build, it was successful.