### PR TITLE
fix splash screen - Lua - darktable main window race condition

### DIFF
--- a/data/luarc
+++ b/data/luarc
@@ -42,10 +42,34 @@ dt.register_event(
       ov = old_view.id
     end
     if ov == "none" and new_view.id == "lighttable" then
+      dt.print_log("darktable is gui safe")
       darktable_gui_safe = true
     end
   end
 )
+
+--[[
+    Work around (fix) for darktable issue 21035
+
+    If darktable is started with a empty or non-existent configuration directory
+    the splash screen and Lua initialization may have a race condition that results
+    in a darktable crash.  
+
+    To work around that the following checks to see if there is an existing preference, 
+    which would mean the configuration directory is not empty, If the preference does
+    not exist, a 1 second sleep is added to allow the darktable main window to start 
+    before Lua tries to create widgets.
+
+    A preference is set to show that darktable has created a first run and doesn't need
+    to do a Lua sleep when starting
+]]
+
+if not dt.preferences.read("script_manager", "check_update", "bool") then
+  if not dt.preferences.read("luarc", "darktable_first_run_complete", "bool") then
+    dt.control.sleep(1000)
+  end
+end
+dt.preferences.write("luarc", "darktable_first_run_complete", "bool", true)
 
 -- check for gui so that we don't hang darktable-cli
 

--- a/data/luarc
+++ b/data/luarc
@@ -42,7 +42,6 @@ dt.register_event(
       ov = old_view.id
     end
     if ov == "none" and new_view.id == "lighttable" then
-      dt.print_log("darktable is gui safe")
       darktable_gui_safe = true
     end
   end


### PR DESCRIPTION
If darktable is started with a empty or non-existent configuration directory the splash screen and Lua initialization may have a race condition that results in a darktable crash.

To work around that a check is made to see if there is an existing preference, which would mean the configuration directory is not empty, If the preference does not exist, a 1 second sleep is added to allow the darktable main window to start before Lua tries to create widgets.

A preference is set to show that darktable has populated the configuration directory and doesn't need to do a Lua sleep when starting

Fixes #21035 
