### PR TITLE
Harden pixelpipe stops

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -772,11 +772,11 @@ restart:
   dt_get_times(&start);
 
   // keep return status of dt_dev_pixelpipe_process()
-  const gboolean stopped = dt_dev_pixelpipe_process(pipe, dev, x, y, wd, ht, scale, devid);
+  const gboolean early = dt_dev_pixelpipe_process(pipe, dev, x, y, wd, ht, scale, devid);
+  const dt_dev_pixelpipe_stopper_t shutdown = dt_atomic_exch_int(&pipe->shutdown, DT_DEV_PIXELPIPE_STOP_NO);
+  const gboolean stopped = early || shutdown != DT_DEV_PIXELPIPE_STOP_NO;
   if(stopped)
   {
-    // If pixelpipe stopped that could be because of pipe->shutdown so we check that and reset.
-    const dt_dev_pixelpipe_stopper_t shutdown = dt_atomic_exch_int(&pipe->shutdown, DT_DEV_PIXELPIPE_STOP_NO);
     const dt_iop_roi_t proi = (dt_iop_roi_t) {.x = x, .y = y, .width = wd, .height = ht, .scale = scale };
     dt_print_pipe(DT_DEBUG_PIPE, "pipe stopped", pipe, NULL, DT_DEVICE_NONE, &proi, NULL, "%s%s%s%s",
                 dt_dev_pixelpipe_shutdown_to_str(shutdown),

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -176,11 +176,11 @@ static void _cleanup_pinned_dev(dt_develop_t *pinned_dev)
   pinned_dev->preview2.widget = NULL;
 
   if(pinned_dev->preview2.pipe)
-    dt_atomic_set_int(&pinned_dev->preview2.pipe->shutdown, DT_DEV_PIXELPIPE_STOP_NODES);
+    dt_dev_pixelpipe_set_shutdown(pinned_dev->preview2.pipe, DT_DEV_PIXELPIPE_STOP_NODES);
   if(pinned_dev->preview_pipe)
-    dt_atomic_set_int(&pinned_dev->preview_pipe->shutdown, DT_DEV_PIXELPIPE_STOP_NODES);
+    dt_dev_pixelpipe_set_shutdown(pinned_dev->preview_pipe, DT_DEV_PIXELPIPE_STOP_NODES);
   if(pinned_dev->full.pipe)
-    dt_atomic_set_int(&pinned_dev->full.pipe->shutdown, DT_DEV_PIXELPIPE_STOP_NODES);
+    dt_dev_pixelpipe_set_shutdown(pinned_dev->full.pipe, DT_DEV_PIXELPIPE_STOP_NODES);
 
   if(pinned_dev->preview2.pipe)
   {

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -362,6 +362,28 @@ void dt_dev_pixelpipe_set_icc(dt_dev_pixelpipe_t *pipe,
   pipe->icc_intent = icc_intent;
 }
 
+void dt_dev_pixelpipe_set_shutdown(dt_dev_pixelpipe_t *pipe,
+                                       const dt_dev_pixelpipe_stopper_t stopper)
+{
+#ifndef DT_PIPE_CAS_SHUTDOWN
+
+  dt_atomic_set_int(&pipe->shutdown, stopper);
+  dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_VERBOSE, "pipe shutdown request",
+      pipe, NULL, pipe->devid, NULL, NULL, "%s", dt_dev_pixelpipe_shutdown_to_str(stopper));
+
+ #else
+
+  int expected = DT_DEV_PIXELPIPE_STOP_NO;
+  const gboolean new = dt_atomic_CAS_int(&pipe->shutdown, &expected, stopper);
+  dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_VERBOSE, "pipe shutdown request",
+      pipe, NULL, pipe->devid, NULL, NULL,
+      "%s %s",
+      new ? "" : "failed, was",
+      new ? dt_dev_pixelpipe_shutdown_to_str(stopper)
+          : dt_dev_pixelpipe_shutdown_to_str(expected));
+#endif
+}
+
 void dt_dev_pixelpipe_cleanup(dt_dev_pixelpipe_t *pipe)
 {
   dt_pthread_mutex_lock(&pipe->backbuf_mutex);
@@ -398,7 +420,7 @@ void dt_dev_pixelpipe_cleanup(dt_dev_pixelpipe_t *pipe)
 void dt_dev_pixelpipe_cleanup_nodes(dt_dev_pixelpipe_t *pipe)
 {
   // tell pipe that it should shut itself down if currently running
-  dt_atomic_set_int(&pipe->shutdown, DT_DEV_PIXELPIPE_STOP_NODES);
+  dt_dev_pixelpipe_set_shutdown(pipe, DT_DEV_PIXELPIPE_STOP_NODES);
 
   // FIXME: either this or all process() -> gdk mutices have to be changed!
   //        (this is a circular dependency on busy_mutex and the gdk mutex)

--- a/src/develop/pixelpipe_hb.h
+++ b/src/develop/pixelpipe_hb.h
@@ -31,6 +31,8 @@ G_BEGIN_DECLS
 
 #define DT_PIPECACHE_MIN 2
 
+// #define DT_PIPE_CAS_SHUTDOWN
+
 /** cached distorted mask at a geometric module's output boundary.
  *  used to avoid re-distorting masks from scratch when multiple
  *  downstream modules request the same mask type. */
@@ -320,6 +322,10 @@ static inline gboolean dt_pipe_mask_display(const dt_dev_pixelpipe_t *pipe)
 const char *dt_dev_pixelpipe_type_to_str(const dt_dev_pixelpipe_type_t pipe_type);
 // return pipe->shutdown as textual
 const char *dt_dev_pixelpipe_shutdown_to_str(const dt_dev_pixelpipe_stopper_t stopper);
+
+// sets pipe->shutdown in atomic mode
+// If DT_PIPE_CAS_SHUTDOWN is defined do that only if shutdown was DT_DEV_PIXELPIPE_STOP_NO
+void dt_dev_pixelpipe_set_shutdown(dt_dev_pixelpipe_t *pipe, const dt_dev_pixelpipe_stopper_t stopper);
 
 // inits the pixelpipe with plain passthrough input/output and empty input and default caching settings.
 gboolean dt_dev_pixelpipe_init(dt_dev_pixelpipe_t *pipe);

--- a/src/develop/pixelpipe_hb.h
+++ b/src/develop/pixelpipe_hb.h
@@ -98,6 +98,40 @@ typedef enum dt_dev_pixelpipe_status_t
   DT_DEV_PIXELPIPE_INVALID = 3  // pixelpipe has finished; invalid result
 } dt_dev_pixelpipe_status_t;
 
+/* dt_dev_pixelpipe_stopper_t is used as shutdown in dt_dev_pixelpipe_t.
+    By design we can write atomically on a pipe->shutdown to request an early exit
+    of the pixepipe process _dev_pixelpipe_process_rec().
+
+    This requires special care in
+      - _dev_pixelpipe_process_rec()
+      - dt_dev_process_image_job()
+    possibly invalidating wrong module input/output data in the pixelpipe cache,
+    ensure either an immediate restart of the pipe or exit of dt_dev_process_image_job()
+    with an error flag.
+    A reminder, when setting pipe->shutdown we might have to do that via dt_atomic_CAS_int()
+    with wxpected DT_DEV_PIXELPIPE_STOP_NO to avoid overwriting an earlier shutdown writing.
+
+    A summary about how these shutdown modes are supposed to work.
+
+    DT_DEV_PIXELPIPE_STOP_NO
+    Set whenever a pipe is started in _dev_pixelpipe_process_rec() as default.
+
+    DT_DEV_PIXELPIPE_STOP_NODES
+    Set if the pipe should stop as the pipe nodes are changed so a restart is desired asap.
+    As nodes are recreated, we don't have to fiddle with pixelpipe cache.
+
+    DT_DEV_PIXELPIPE_STOP_HQ
+    Used to switch between darkroom HQ modes.
+    Requires a restart of the pipe but pixelpipe cache can stay.
+
+    DT_DEV_PIXELPIPE_STOP_LAST
+    If the shutdown value is >= DT_DEV_PIXELPIPE_STOP_LAST it is understood as the iop_order
+    of a module.
+    Any module might set pipe->shutdown to it's iop_order, this is checked while processing
+    the pipe and if detected the piece input data and all pipe cachelines with at least
+    this iop_order will be invalidated.
+*/
+
 typedef enum dt_dev_pixelpipe_stopper_t
 {
   DT_DEV_PIXELPIPE_STOP_NO = 0,

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -1763,9 +1763,9 @@ static void _latescaling_quickbutton_clicked(GtkWidget *w,
           || (dev->second_wnd && dev->preview2.pipe->processing)))
   {
     if(dev->full.pipe->processing)
-      dt_atomic_set_int(&dev->full.pipe->shutdown, DT_DEV_PIXELPIPE_STOP_HQ);
+      dt_dev_pixelpipe_set_shutdown(dev->full.pipe, DT_DEV_PIXELPIPE_STOP_HQ);
     if(dev->second_wnd && dev->preview2.pipe->processing)
-      dt_atomic_set_int(&dev->preview2.pipe->shutdown, DT_DEV_PIXELPIPE_STOP_HQ);
+      dt_dev_pixelpipe_set_shutdown(dev->preview2.pipe, DT_DEV_PIXELPIPE_STOP_HQ);
 
     // do it the hard way for safety
     dt_dev_pixelpipe_rebuild(dev);
@@ -3201,7 +3201,7 @@ void gui_init(dt_view_t *self)
                                                               0,
                                                               _display2_intent_callback,
                                                               dev, intents_list);
-        
+
     if(!force_lcms2)
     {
       gtk_widget_set_no_show_all(dev->profile.display_intent_widget, TRUE);
@@ -4866,11 +4866,11 @@ static void _darkroom_ui_second_window_cleanup(dt_develop_t *dev)
     pinned_dev->preview2.widget = NULL;
 
     if(pinned_dev->preview2.pipe)
-      dt_atomic_set_int(&pinned_dev->preview2.pipe->shutdown, DT_DEV_PIXELPIPE_STOP_NODES);
+      dt_dev_pixelpipe_set_shutdown(pinned_dev->preview2.pipe, DT_DEV_PIXELPIPE_STOP_NODES);
     if(pinned_dev->preview_pipe)
-      dt_atomic_set_int(&pinned_dev->preview_pipe->shutdown, DT_DEV_PIXELPIPE_STOP_NODES);
+      dt_dev_pixelpipe_set_shutdown(pinned_dev->preview_pipe, DT_DEV_PIXELPIPE_STOP_NODES);
     if(pinned_dev->full.pipe)
-      dt_atomic_set_int(&pinned_dev->full.pipe->shutdown, DT_DEV_PIXELPIPE_STOP_NODES);
+      dt_dev_pixelpipe_set_shutdown(pinned_dev->full.pipe, DT_DEV_PIXELPIPE_STOP_NODES);
 
     if(pinned_dev->preview2.pipe)
     {


### PR DESCRIPTION
Whenever the `dt_dev_pixelpipe_process()` finished we check for shutdown independent on returned FALSE/TRUE,
we must ensure the shutdown value is read & cleared.
Under some conditions the pipe returned FALSE but shutdown was set in-between.

Added dev-info about the meaning/handling of the shutdown modes.
