### PR TITLE
Read touchpad gestures preference at startup

### DIFF
--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -1508,7 +1508,7 @@ int dt_gui_gtk_init(dt_gui_gtk_t *gui)
   // Init focus peaking
   gui->show_focus_peaking = dt_conf_get_bool("ui/show_focus_peaking");
 
-  gui->touchpad_gestures_enabled = TRUE;
+  gui->touchpad_gestures_enabled = dt_conf_get_bool("darkroom/ui/touchpad_gestures");
   DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_PREFERENCES_CHANGE,
                             _touchpad_gestures_pref_changed, gui);
 


### PR DESCRIPTION
The touchpad_gestures_enabled flag was hardcoded to TRUE at GUI init and only updated when the preference changed during a session. As a result darkroom always started in gesture mode regardless of the saved darkroom/ui/touchpad_gestures value. Initialize the flag from conf.

Fix fixes the observed issue mentioned in https://github.com/darktable-org/darktable/pull/21188