### PR TITLE
Fix soft 100% lighttable zoom from surface cache filter

### DIFF
--- a/src/dtgtk/culling.c
+++ b/src/dtgtk/culling.c
@@ -324,6 +324,28 @@ static void _set_table_zoom_ratio(dt_culling_t *table, dt_thumbnail_t *th)
   table->zoom_ratio = dt_thumbnail_get_zoom_ratio(th);
 }
 
+// Safety-net finaliser for deferred zoom gestures: fires once no further zoom
+// event has arrived for a short while. This guarantees the surface is reloaded
+// at the correct resolution even when the input device never emits a smooth
+// scroll "stop" event (or emits it without the ctrl modifier still held).
+static gboolean _zoom_finalize_timeout(gpointer user_data)
+{
+  dt_culling_t *table = (dt_culling_t *)user_data;
+  table->zoom_finalize_timeout_id = 0;
+  dt_culling_zoom_end(table);
+  return G_SOURCE_REMOVE;
+}
+
+// (Re)arm the deferred-zoom finaliser. Called after each deferred zoom event so
+// the timer keeps sliding forward while the gesture is ongoing and only fires
+// once the user actually stops.
+static void _schedule_zoom_finalize(dt_culling_t *table)
+{
+  if(table->zoom_finalize_timeout_id)
+    g_source_remove(table->zoom_finalize_timeout_id);
+  table->zoom_finalize_timeout_id = g_timeout_add(200, _zoom_finalize_timeout, table);
+}
+
 static gboolean _zoom_and_shift(dt_thumbnail_t *th,
                                 const int x_offset,
                                 const int y_offset,
@@ -520,6 +542,12 @@ static gboolean _thumbs_zoom_add(dt_culling_t *table,
       _set_table_zoom_ratio(table, th);
   }
 
+  // Deferred gestures only rescale the stale surface; arm the safety-net timer
+  // so the proper surface reload still happens shortly after scrolling stops
+  // even if no smooth-scroll "stop" event arrives to call dt_culling_zoom_end().
+  if(deferred)
+    _schedule_zoom_finalize(table);
+
   return TRUE;
 }
 
@@ -648,9 +676,13 @@ static gboolean _event_scroll(GtkWidget *widget,
   // accumulator path below, which would otherwise batch several events into
   // a single coarse 0.5-unit step.
   //
-  // Scroll stop event: trigger a proper surface reload now that the gesture is done.
-  if(e->direction == GDK_SCROLL_SMOOTH && e->is_stop
-     && dt_modifier_is(e->state, GDK_CONTROL_MASK))
+  // Scroll stop event: trigger a proper surface reload now that the gesture is
+  // done. We deliberately do NOT require ctrl to still be held here: the stop
+  // event often arrives after the user has released ctrl, and a deferred zoom
+  // must be finalised regardless. (If no zoom was pending this is a no-op, and
+  // the safety-net timer in _thumbs_zoom_add covers devices that never emit a
+  // stop event at all.)
+  if(e->direction == GDK_SCROLL_SMOOTH && e->is_stop)
   {
     dt_culling_zoom_end(table);
     return TRUE;
@@ -2251,6 +2283,12 @@ gboolean dt_culling_zoom_add(dt_culling_t *table,
 void dt_culling_zoom_end(dt_culling_t *table)
 {
   if(!table) return;
+  // We are finalising now, so cancel any pending safety-net timer.
+  if(table->zoom_finalize_timeout_id)
+  {
+    g_source_remove(table->zoom_finalize_timeout_id);
+    table->zoom_finalize_timeout_id = 0;
+  }
   for(GList *l = table->list; l; l = g_list_next(l))
   {
     dt_thumbnail_t *th = l->data;

--- a/src/dtgtk/culling.h
+++ b/src/dtgtk/culling.h
@@ -72,6 +72,12 @@ typedef struct dt_culling_t
   double pan_y;          //
   gboolean mouse_inside; // is the mouse inside culling center view ?
 
+  // Safety-net timer that finalises a deferred zoom gesture (reloads the
+  // surface at the correct resolution) shortly after the last zoom event.
+  // Smooth-scroll "stop" events are not reliably delivered by every device,
+  // so we cannot depend on them alone to trigger dt_culling_zoom_end().
+  guint zoom_finalize_timeout_id;
+
   gboolean focus; // do we show focus rectangles on images ?
 
   dt_thumbnail_overlay_t overlays; // overlays type

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -826,7 +826,20 @@ dt_view_surface_value_t dt_view_image_get_surface_cached(const dt_imgid_t imgid,
         cairo_t *cr = cairo_create(*surface);
         cairo_scale(cr, scale, scale);
         cairo_set_source_surface(cr, *mip_cache, 0, 0);
-        cairo_pattern_set_filter(cairo_get_source(cr), darktable.gui->filter_image);
+        // Match the filter logic of the full path below: at a 1:1 mapping
+        // (scale ~ 1.0, i.e. a true 100% view) use NEAREST so we display the
+        // cached native pixels exactly, pixel-for-pixel, rather than softening
+        // them with interpolation.  The cached surface always corresponds to
+        // the exact mip (we only cache when mip == buf.size && buf_wd > 30), so
+        // the skull/fallback branches of the full path can't apply here.
+        if(fabsf(scale - 1.0f) < 0.01f)
+          cairo_pattern_set_filter(cairo_get_source(cr), CAIRO_FILTER_NEAREST);
+        else
+          cairo_pattern_set_filter(cairo_get_source(cr),
+                                   ((darktable.gui->filter_image == CAIRO_FILTER_FAST)
+                                    && quality)
+                                   ? CAIRO_FILTER_GOOD
+                                   : darktable.gui->filter_image);
         cairo_paint(cr);
         cairo_destroy(cr);
         return DT_VIEW_SURFACE_OK;


### PR DESCRIPTION
The culling surface cache fast path in dt_view_image_get_surface_cached always scaled the cached native surface with filter_image, even at a 1:1 mapping. At a true 100% view this interpolated pixels that the full (non-cached) path renders with CAIRO_FILTER_NEAREST, so a 100% thumbnail looked softer than the same image at 100% in darkroom.

Mirror the full path's scale-dependent filter selection in the fast path: use NEAREST when scale ~ 1.0, otherwise filter_image (GOOD when quality). The cached surface always matches the exact mip, so the skull/fallback branches don't apply here.

Fixes https://github.com/darktable-org/darktable/issues/21132