### PR TITLE
Fix AI object mask tooltip in blending UI

### DIFF
--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -2793,8 +2793,8 @@ void dt_iop_gui_init_masks(GtkWidget *blendw, dt_iop_module_t *module)
 #ifdef HAVE_AI
     bd->masks_type[5] = DT_MASKS_OBJECT;
     bd->masks_shapes[5] = dt_iop_togglebutton_new(module, "blend`shapes",
-                                                  N_("add object"),
                                                   N_("add AI object"),
+                                                  NULL,
                                                   G_CALLBACK(_blendop_masks_add_shape),
                                                   FALSE, 0, 0,
                                                   dtgtk_cairo_paint_masks_object, abox);


### PR DESCRIPTION
The AI object button has two homes: the mask manager (tooltip already correct – "add AI object") and the blending options bar (tooltip was "add object\nctrl+click to add AI object"). The blending one implied plain click and ctrl+click did different things – plain click adding some kind of "regular object", ctrl+click an "AI object". In reality the button always adds an AI object either way.

Now both places match: just **"add AI object"**.