### PR TITLE
Make ctrl+shift+scroll in culling layout zoom in into individual image

### DIFF
--- a/src/dtgtk/culling.c
+++ b/src/dtgtk/culling.c
@@ -689,7 +689,7 @@ static gboolean _event_scroll(GtkWidget *widget,
   }
 
   if(e->direction == GDK_SCROLL_SMOOTH && !e->is_stop
-     && dt_modifier_is(e->state, GDK_CONTROL_MASK))
+     && dt_modifiers_include(e->state, GDK_CONTROL_MASK))
   {
     gdouble dx = 0.0, dy = 0.0;
     if(dt_gui_get_scroll_deltas(e, &dx, &dy) && (dx != 0.0 || dy != 0.0))
@@ -718,7 +718,7 @@ static gboolean _event_scroll(GtkWidget *widget,
   // We check before the unit-delta path so fractional smooth scroll is used for panning
   // with full fidelity rather than being accumulated into integer steps.
   if(e->direction == GDK_SCROLL_SMOOTH && !e->is_stop
-     && !dt_modifier_is(e->state, GDK_CONTROL_MASK))
+     && !dt_modifiers_include(e->state, GDK_CONTROL_MASK))
   {
     // Check if any thumbnail is zoomed in; if so, pan instead of navigate.
     float fz = 1.0f;


### PR DESCRIPTION
The smooth-scroll zoom/pan paths added for touchpad support gated the ctrl check on dt_modifier_is(), which requires an exact modifier match. With ctrl+shift held this failed, so smooth-scroll events (touchpads, and mouse wheels on Wayland/modern GTK) fell into the pan path instead of zooming the single hovered image as before.

Use dt_modifiers_include() so ctrl+<any>+scroll routes to zoom, matching the discrete-wheel path and restoring the pre-touchpad behavior.

This fixes a regression introduced within https://github.com/darktable-org/darktable/pull/20888.

Fixes https://github.com/darktable-org/darktable/issues/21195