### PR TITLE
Fix ORT noise in default logs; gate verbosity

### DIFF
--- a/src/ai/backend_onnx.c
+++ b/src/ai/backend_onnx.c
@@ -1202,11 +1202,29 @@ static gpointer _init_ort_env(gpointer data)
   _setup_amd_caches();
 #endif
   OrtEnv *env = NULL;
+  // ORT log level:
+  //   - default                → FATAL (effectively silent; only unrecoverable crashes surface)
+  //   - -d ai or -d all        → ERROR (default when debugging AI)
+  //   - -d ai/-d all + env     → ORT_LOGGING_LEVEL=verbose|info|warning|error|fatal overrides
+  OrtLoggingLevel log_level = ORT_LOGGING_LEVEL_FATAL;
+  if(darktable.unmuted & DT_DEBUG_AI)
+  {
+    log_level = ORT_LOGGING_LEVEL_ERROR;
+    const char *level_str = g_getenv("ORT_LOGGING_LEVEL");
+    if(level_str)
+    {
+      if(!g_ascii_strcasecmp(level_str, "verbose"))      log_level = ORT_LOGGING_LEVEL_VERBOSE;
+      else if(!g_ascii_strcasecmp(level_str, "info"))    log_level = ORT_LOGGING_LEVEL_INFO;
+      else if(!g_ascii_strcasecmp(level_str, "warning")) log_level = ORT_LOGGING_LEVEL_WARNING;
+      else if(!g_ascii_strcasecmp(level_str, "error"))   log_level = ORT_LOGGING_LEVEL_ERROR;
+      else if(!g_ascii_strcasecmp(level_str, "fatal"))   log_level = ORT_LOGGING_LEVEL_FATAL;
+    }
+  }
 #ifdef ORT_LAZY_LOAD
   // ORT may emit additional schema-registration noise during env creation.
   const int saved = _stderr_suppress_begin();
 #endif
-  OrtStatus *status = g_ort.api->CreateEnv(ORT_LOGGING_LEVEL_WARNING, "DarktableAI", &env);
+  OrtStatus *status = g_ort.api->CreateEnv(log_level, "DarktableAI", &env);
 #ifdef ORT_LAZY_LOAD
   _stderr_suppress_end(saved);
 #endif


### PR DESCRIPTION
Out of the box, running darktable with any AI model loaded leaks ONNX Runtime's internal warnings into the user's terminal – things like `VerifyEachNodeIsAssignedToAnEp ... Some nodes were not assigned to the preferred execution providers ...`. These warnings are routine on CoreML and most other EPs; they don't indicate a problem, and end users have no reason to see them.

This PR makes ORT silent by default and gates verbosity on the existing debug flags:

| Invocation | ORT log level |
|---|---|
| `darktable` | FATAL – silent (only unrecoverable crashes) |
| `darktable -d ai` or `-d all` | ERROR |
| `ORT_LOGGING_LEVEL=warning darktable -d ai` | WARNING |
| `ORT_LOGGING_LEVEL=verbose darktable -d all` | VERBOSE |

The `ORT_LOGGING_LEVEL` env var only takes effect together with a debug flag, so casual users can't accidentally turn on the firehose by exporting a stray variable.