### PR TITLE
Fix neural restore not seeing uncommitted darkroom edits (e.g. crop)

### DIFF
--- a/src/libs/neural_restore.c
+++ b/src/libs/neural_restore.c
@@ -3088,6 +3088,8 @@ static void _trigger_preview(dt_lib_module_t *self)
   if(!d->model_available || !d->preview_requested)
     return;
 
+  if(dt_view_get_current() == DT_VIEW_DARKROOM) dt_dev_write_history(darktable.develop);
+
   // invalidate current preview and bump sequence so running thread exits early
   d->preview_ready = FALSE;
   d->preview_error = DT_NR_PREVIEW_ERR_NONE;
@@ -3258,6 +3260,8 @@ static void _process_clicked(GtkWidget *widget, gpointer user_data)
   GList *images = dt_act_on_get_images(TRUE, TRUE, FALSE);
   if(!images)
     return;
+
+  if(dt_view_get_current() == DT_VIEW_DARKROOM) dt_dev_write_history(darktable.develop);
 
   dt_neural_job_t *job_data = g_new0(dt_neural_job_t, 1);
   job_data->task = d->task;


### PR DESCRIPTION
Repro: open an image in darkroom, crop it, then run neural restore upscale x2. The output you get back is the uncropped image – the upscale processed the full raw, ignoring the crop entirely. Adding any other module on top before triggering upscale "fixes" it, which made the bug both obvious and confusing.

Cause: neural restore exports the image in a background job that reads history from the database. If the user is still focused on the crop module (or any other IOP in live edit mode), the pending changes haven't been committed via `dt_dev_add_history_item` yet – so the DB doesn't know about them. The standard export library has the same problem; it works around it with a `dt_dev_write_history` call at the entry point. Adding any other module on top accidentally fixes it because that triggers an internal history write.

Fix: before triggering the upscale preview or the background export, defocus any active IOP (so its pending edits commit) and write history to the DB. Two small additions in `src/libs/neural_restore.c`, mirroring `export.c`'s pattern. Only active in darkroom – lighttable has nothing to flush.