### PR TITLE
AppImage: prefer Wayland backend, fall back to x11

### DIFF
--- a/packaging/AppImage/AppRun
+++ b/packaging/AppImage/AppRun
@@ -14,6 +14,11 @@ HERE="$(dirname "$(readlink -f "${0}")")"
 
 source "$HERE"/apprun-hooks/"linuxdeploy-plugin-gtk.sh"
 
+# The GTK linuxdeploy plugin forces GDK_BACKEND=x11 as a workaround for
+# older crashes. Darktable supports Wayland natively, so override this
+# and fall back to x11 only if Wayland is unavailable.
+export GDK_BACKEND="wayland,x11"
+
 export CAMLIBS=$HERE/usr/lib/libgphoto2/`ls -1 --group-directories-first $HERE/usr/lib/libgphoto2|head -1`
 
 export IOLIBS=$HERE/usr/lib/libgphoto2_port/`ls -1 --group-directories-first $HERE/usr/lib/libgphoto2_port|head -1`


### PR DESCRIPTION
Trying to fix https://github.com/darktable-org/darktable/issues/21214 with generous help from claude. 

The linuxdeploy GTK plugin hardcodes GDK_BACKEND=x11 as a workaround for older crashes. Darktable supports Wayland natively, so override this setting after the plugin runs. GTK will automatically fall back to x11 if no Wayland compositor is available.

As far as I understand this makes sense. I re-compiled the AppImage and it correctly launches into wayland. Also tried the AppImage in a Linux Mint XFCE VM and it doesn't break launching there. 

It does however break launching darktable with GDK_BACKEND=x11 to force into x11 on wayland. Which I suppose is a corner case maybe not worth supporting. 

