### PR TITLE
Fix OpenCL possible for previews with DT_DEV_PIXELPIPE_PREVIEW

### DIFF
--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -1152,9 +1152,9 @@ static gboolean _transform_for_blend(const dt_iop_module_t *const self,
   return d && (d->mask_mode != DEVELOP_MASK_DISABLED) && (self->flags() & IOP_FLAGS_SUPPORTS_BLENDING);
 }
 
-static gboolean _request_color_pick(dt_dev_pixelpipe_t *pipe,
-                                    dt_develop_t *dev,
-                                    dt_iop_module_t *module)
+static gboolean _request_color_pick(const dt_dev_pixelpipe_t *pipe,
+                                    const dt_develop_t *dev,
+                                    const dt_iop_module_t *module)
 {
   // Does the current active module need a picker?
   return
@@ -2139,7 +2139,7 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
     gboolean possible_cl =
         module->process_cl
         && piece->process_cl_ready
-        && !(dt_pipe_is_canvas(pipe) && (module->flags() & IOP_FLAGS_PREVIEW_NON_OPENCL));
+        && !(dt_pipe_is_preview(pipe) && (module->flags() & IOP_FLAGS_PREVIEW_NON_OPENCL));
 
     const uint32_t m_bpp = MAX(in_bpp, bpp);
     const size_t m_width = MAX(roi_in.width, roi_out->width);

--- a/src/iop/colortransfer.c
+++ b/src/iop/colortransfer.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2010-2024 darktable developers.
+    Copyright (C) 2010-2026 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -358,12 +358,6 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
       {
         const float L = in[j];
         const dt_aligned_pixel_t Lab = { L, in[j + 1], in[j + 2] };
-// a, b: subtract mean, scale nvar/var, add nmean
-#if 0 // single cluster, gives color banding
-        const int ki = get_cluster(in + j, data->n, mean);
-        out[j+1] = 100.0/out[j] * ((Lab[1] - mean[ki][0])*data->var[mapio[ki]][0]/var[ki][0] + data->mean[mapio[ki]][0]);
-        out[j+2] = 100.0/out[j] * ((Lab[2] - mean[ki][1])*data->var[mapio[ki]][1]/var[ki][1] + data->mean[mapio[ki]][1]);
-#else // fuzzy weighting
         get_clusters(in + j, data->n, mean, weight);
         out[j + 1] = out[j + 2] = 0.0f;
         for(int c = 0; c < data->n; c++)
@@ -373,7 +367,6 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
           out[j + 2] += weight[c] * ((Lab[2] - mean[c][1]) * data->var[mapio[c]][1] / var[c][1]
                                      + data->mean[mapio[c]][1]);
         }
-#endif
         out[j + 3] = in[j + 3];
         j += ch;
       }


### PR DESCRIPTION
The `IOP_FLAGS_PREVIEW_NON_OPENCL` explicitly tells not to use OpenCL for the preview pipe so we have to test that instead of canvas.

While checking the code, colortransfer is deprecated but removing dead code there.