### PR TITLE
Extensive logs for looping inside dt_dev_process_image_job()

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -827,8 +827,26 @@ restart:
   */
   if(port && pipe->changed != DT_DEV_PIPE_UNCHANGED)
   {
-    dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_VERBOSE, "image_job restart", pipe, NULL, DT_DEVICE_NONE, &proi, NULL);
-    goto restart;
+    /* A "special case" handling
+        If a non-image pixelpipe finished with `stopped == FALSE` and `changed == DT_DEV_PIPE_ZOOMED`
+        we don't have to restart but only have to calculate it's dimension and clear pipe->changed
+        avoiding superfluous pixelpipe runs.
+
+        With every restart - even without UI actions - we update zoom, x, y, wd and ht, results can
+        oscillate and might never converge resulting in lots of restarts or even infinite loops.
+    */
+    if(pipe->changed == DT_DEV_PIPE_ZOOMED && !stopped && !dt_pipe_is_image(pipe))
+    {
+      dt_dev_pixelpipe_get_dimensions(pipe, dev, pipe->iwidth, pipe->iheight,
+                                      &pipe->processed_width,
+                                      &pipe->processed_height);
+      pipe->changed = DT_DEV_PIPE_UNCHANGED;
+    }
+    else
+    {
+      dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_VERBOSE, "image_job restart", pipe, NULL, DT_DEVICE_NONE, &proi, NULL);
+      goto restart;
+    }
   }
 
   dt_print_pipe(DT_DEBUG_PIPE, "process_image_job done", pipe, NULL, DT_DEVICE_NONE, &proi, NULL, "\n");

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -651,8 +651,9 @@ void dt_dev_process_image_job(dt_develop_t *dev,
                              port ? 1.0 : buf.iscale);
 
   // We require calculation of pixelpipe dimensions via dt_dev_pixelpipe_change() in these cases
-  gboolean initial = pipe->loading || dev->image_force_reload || pipe->input_changed;
+  gboolean initial_change = pipe->loading || dev->image_force_reload || pipe->input_changed;
 
+  // adjust pipeline according to changed flag set by {add,pop}_history_item.
   if(pipe->loading)
   {
     // init pixel pipeline
@@ -701,7 +702,8 @@ void dt_dev_process_image_job(dt_develop_t *dev,
     pipe->input_changed = FALSE;
   }
 
-// adjust pipeline according to changed flag set by {add,pop}_history_item.
+  int restarts = 0; // to check looping
+
 restart:
   if(dev->gui_leaving)
   {
@@ -715,10 +717,10 @@ restart:
   if(port == &dev->full)
     pipe->input_timestamp = dev->timestamp;
 
-  const gboolean changing = (pipe->changed != DT_DEV_PIPE_UNCHANGED) || initial;
+  const gboolean changing = (pipe->changed != DT_DEV_PIPE_UNCHANGED) || initial_change;
   const gboolean port_loading = port && pipe->loading;
-  const gboolean require_zoom_test = (pipe->changed & ~DT_DEV_PIPE_ZOOMED) || initial;
-  initial = FALSE; // don't enforce dt_dev_pixelpipe_change() for restarts
+  const gboolean require_zoom_test = (pipe->changed & ~DT_DEV_PIPE_ZOOMED) || initial_change;
+  initial_change = FALSE; // don't enforce dt_dev_pixelpipe_change() for restarts
 
   const float anticipate_move = pipe->changed & DT_DEV_PIPE_ZOOMED
               ? dt_conf_get_float("darkroom/ui/anticipate_move")
@@ -740,9 +742,12 @@ restart:
 
   if(port)
   {
-    // if just changed to an image with a different aspect ratio or
-    // altered image orientation, the prior zoom xy could now be beyond
-    // the image boundary
+    /* if just changed to an image with a different aspect ratio or
+        altered image orientation, the prior zoom xy could now be beyond
+        the image boundary.
+        dt_dev_zoom_move() possibly leaves port->pipe->changed DT_DEV_PIPE_ZOOMED;
+        and might redraw the widgets as a side effect
+    */
     if(port_loading || require_zoom_test)
     {
       dt_print_pipe(DT_DEBUG_PIPE, "dt_dev_zoom_move", pipe, NULL, DT_DEVICE_NONE, NULL, NULL, "%s%s",
@@ -751,7 +756,7 @@ restart:
       dt_dev_zoom_move(port, DT_ZOOM_MOVE, 0.0f, 0, 0.0f, 0.0f, TRUE);
     }
 
-    // determine scale according to new dimensions
+    // determine scale according to current dimensions
     dt_dev_zoom_t zoom;
     int closeup;
     dt_dev_get_viewport_params(port, &zoom, &closeup, &zoom_x, &zoom_y);
@@ -775,15 +780,21 @@ restart:
   const gboolean early = dt_dev_pixelpipe_process(pipe, dev, x, y, wd, ht, scale, devid);
   const dt_dev_pixelpipe_stopper_t shutdown = dt_atomic_exch_int(&pipe->shutdown, DT_DEV_PIXELPIPE_STOP_NO);
   const gboolean stopped = early || shutdown != DT_DEV_PIXELPIPE_STOP_NO;
-  if(stopped)
-  {
-    const dt_iop_roi_t proi = (dt_iop_roi_t) {.x = x, .y = y, .width = wd, .height = ht, .scale = scale };
-    dt_print_pipe(DT_DEBUG_PIPE, "pipe stopped", pipe, NULL, DT_DEVICE_NONE, &proi, NULL, "%s%s%s%s",
+
+  const dt_iop_roi_t proi = (dt_iop_roi_t) {.x = x, .y = y, .width = wd, .height = ht, .scale = scale };
+  dt_print_pipe(DT_DEBUG_PIPE, stopped ? "pixelpipe_process stopped" : "pixelpipe_process good",
+              pipe, NULL, DT_DEVICE_NONE, &proi, NULL, "%s%s %s%s%s%s%s",
+                restarts > 5 ? "LOOPING " : "",
                 dt_dev_pixelpipe_shutdown_to_str(shutdown),
                 dev->image_force_reload ? "image_force_reload " : "",
                 pipe->loading ? "pipe_loading " : "",
-                pipe->input_changed ? "pipe_input_changed " : "");
+                pipe->input_changed ? "pipe_input_changed " : "",
+                pipe->changed & DT_DEV_PIPE_ZOOMED ? "zoomed " : "",
+                pipe->changed & DT_DEV_PIPE_SYNCH ? "synch" : "");
+  restarts++;
 
+  if(stopped)
+  {
     /* In some cases we should stop restarting the pipe but exit with DT_DEV_PIXELPIPE_INVALID status
        How can we handle the pipe->loading status in a better way?
        Just restart?
@@ -803,17 +814,24 @@ restart:
       return;
     }
 
-    /* pixelpipe stops due to changed pipe nodes, HQ mode changes or module aborts.
-       All want restarts as pipe status is not valid yet.
+    /* pixelpipe stopped due to changed pipe nodes, HQ mode changes or module aborts
+        while processing the pipe. All require restarts as pipe status is not valid yet.
     */
     if(shutdown != DT_DEV_PIXELPIPE_STOP_NO)
       goto restart;
   }
 
-  // pipe requires pending dimension check, don't fiddle with redrawing the widget
+  /* Restarts are required because of
+     - DT_DEV_PIPE_SYNCH if there was a history change without taken dt_dev_pixelpipe_change()
+     - DT_DEV_PIPE_ZOOMED if we miss pixelpipe dimension.
+  */
   if(port && pipe->changed != DT_DEV_PIPE_UNCHANGED)
+  {
+    dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_VERBOSE, "image_job restart", pipe, NULL, DT_DEVICE_NONE, &proi, NULL);
     goto restart;
+  }
 
+  dt_print_pipe(DT_DEBUG_PIPE, "process_image_job done", pipe, NULL, DT_DEVICE_NONE, &proi, NULL, "\n");
   dt_show_times_f(&start,
                   "[dev_process_image] pixel pipeline", "processing `%s'",
                   dev->image_storage.filename);
@@ -3224,6 +3242,10 @@ void dt_dev_zoom_move(dt_dev_viewport_t *port,
      && old_closeup == port->closeup)
     return;
 
+  dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_CONTROL | DT_DEBUG_VERBOSE,
+    "dt_dev_zoom_move sets DT_DEV_PIPE_ZOOMED", port->pipe, NULL, DT_DEVICE_NONE, NULL, NULL, "%s%s",
+      port->widget ? "redraw_widget " : "",
+      port == &dev->full ? "navigation_redraw" : "");
   // Mark pipe as needing zoom update
   port->pipe->changed |= DT_DEV_PIPE_ZOOMED;
 

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -1977,6 +1977,8 @@ void dt_view_paint_surface(cairo_t *cr,
 
   if(use_preview_fallback)
   {
+    dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_EXPOSE | DT_DEBUG_VERBOSE,
+      "dt_view_paint_surface sets DT_DEV_PIPE_ZOOMED", port->pipe, NULL, DT_DEVICE_NONE, NULL, NULL);
     port->pipe->changed |= DT_DEV_PIPE_ZOOMED;
     if(port->pipe->status == DT_DEV_PIXELPIPE_VALID)
       port->pipe->status = DT_DEV_PIXELPIPE_DIRTY;


### PR DESCRIPTION
- added log info for -d pipe about restarting
- renamed initial for clarity
- a few comments inside code
- setters of loop-critical DT_DEV_PIPE_ZOOMED report setting this with -d verbose

@TurboGit so far safe and good for 5.6 as no algorithm stuff has changed and allows far better debugging at this critical point. 
_________________________________________________________________________________________________________
This is still about `dt_dev_process_image_job()`, since #21207 - a fix to handle history setting resulting in different pipe dimensions - we can see two types of superfluous pixelpipe runs.

Type one - pretty common and often mitigated by pipecache - as in
```
    10,1022 pipe starting             CL0 [full]                                          (101/70)  1738x1200 sc=0,320; 'SIU00482.ARW' ID=9572, rusticlamdradeon8060sgraphics using 20722MB
    10,1023 modified roi IN               [full]           lens                   1400    (101/70)  1738x1200 sc=0,320 -->    (109/66)  1719x1205 sc=0,320; ID=9572
    10,1023 modified roi IN               [full]           demosaic                900    (109/66)  1719x1205 sc=0,320 -->   (340/206)  5373x3766 sc=1,000; ID=9572
    10,1023 modified roi IN               [full]           highlights              500   (340/206)  5373x3766 sc=1,000 -->       (0/0)  6020x4024 sc=1,000; ID=9572
    10,1023 modified roi IN               [full]           rawprepare              100       (0/0)  6020x4024 sc=1,000 -->       (0/0)  6048x4024 sc=1,000; ID=9572
    10,1023 pipe data: full               [full]                                             (0/0)  6048x4024 sc=1,000; 
    10,1025 chroma data                                    channelmixerrgb        3400  D65=YES.  D65 2,835 1,000 1,499, AS-SHOT 3,027 1,000 1,625 ID=9572
    10,1088 process                   CL0 [full]           rawprepare              100       (0/0)  6048x4024 sc=1,000 -->       (0/0)  6020x4024 sc=1,000; IOP_CS_RAW 194,2MB
    10,1104 process                   CL0 [full]           temperature             300       (0/0)  6020x4024 sc=1,000; IOP_CS_RAW 193,8MB
    10,1120 process                   CL0 [full]           highlights              500       (0/0)  6020x4024 sc=1,000 -->   (340/206)  5373x3766 sc=1,000; IOP_CS_RAW 242,2MB
    10,1135 process                   CL0 [full]           demosaic                900   (340/206)  5373x3766 sc=1,000 -->    (109/66)  1719x1205 sc=0,320; IOP_CS_RAW -> IOP_CS_RGB 356,9MB
    10,1838 process                   CL0 [full]           lens                   1400    (109/66)  1719x1205 sc=0,320 -->    (101/70)  1738x1200 sc=0,320; IOP_CS_RGB 150,8MB
    10,1869 process                   CL0 [full]           exposure               2500    (101/70)  1738x1200 sc=0,320; IOP_CS_RGB 66,7MB
    10,1876 process                   CL0 [full]           colorin                3300    (101/70)  1738x1200 sc=0,320; IOP_CS_RGB -> IOP_CS_LAB 66,7MB
    10,1877 coeff correction          CL0 [full]           colorin                3300    (101/70)  1738x1200 sc=0,320; `Standard color matrix' 2,835(*0,936) 1,000(*1,000) 1,499(*0,922)
    10,1886 transform colorspace      CL0 [full]           channelmixerrgb        3400    (101/70)  1738x1200 sc=0,320; IOP_CS_LAB -> IOP_CS_RGB `Linear Rec2020 RGB'
    10,1892 process                   CL0 [full]           channelmixerrgb        3400    (101/70)  1738x1200 sc=0,320; IOP_CS_RGB 66,7MB
    10,1901 process                   CL0 [full]           diffuse                3500    (101/70)  1738x1200 sc=0,320; IOP_CS_RGB 342,0MB
    11,3376 process                   CL0 [full]           colorbalancergb        5400    (101/70)  1738x1200 sc=0,320; IOP_CS_RGB 66,7MB
    11,3393 process                   CL0 [full]           agx                    6000    (101/70)  1738x1200 sc=0,320; IOP_CS_RGB 66,7MB
    11,3400 transform colorspace      CL0 [full]           colorout               8600    (101/70)  1738x1200 sc=0,320; IOP_CS_RGB -> IOP_CS_LAB `Linear Rec2020 RGB'
    11,3403 process                   CL0 [full]           colorout               8600    (101/70)  1738x1200 sc=0,320; IOP_CS_LAB -> IOP_CS_RGB 66,7MB
    11,3503 importance hints          CL0 [full]           colorout               8600    (101/70)  1738x1200 sc=0,320; important_in
    11,3557 process                   CPU [full]           gamma                  9300    (101/70)  1738x1200 sc=0,320; IOP_CS_RGB 67MB
    11,3592 cache report                  [full]                                        64 lines (important=4, used=16, invalid=10). Using 644MB, limit=3010MB. Hits/run=0,00. Hits/test=0,000
    11,3592 pipe finished             CL0 [full]                                          (101/70)  1738x1200 sc=0,320; 'SIU00482.ARW' ID=9572
    11,3592 pixelpipe_process good        [full]                                          (101/70)  1738x1200 sc=0,320; run=0: DT_DEV_PIXELPIPE_STOP_NO zoomed 
    11,3592 image_job dimension           [full]                                          (101/70)  1738x1200 sc=0,320; 
    11,3592 dev_pixelpipe_change          [full]                                        zoomed, 
    11,3592 get dimensions                [full]                                             (0/0)  6048x4024 sc=1,000; ID=9572
    11,3592 modified roi OUT              [full]           rawprepare              100       (0/0)  6048x4024 sc=1,000 -->       (0/0)  6020x4024 sc=1,000; 
    11,3594 pipe cache check              [full]                                        64 lines (important=4, used=6). Freed: invalid 485MB used 0MB. Using 160MB, limit=3010MB
    11,3594 pipe starting             CL0 [full]                                          (101/70)  1738x1200 sc=0,320; 'SIU00482.ARW' ID=9572, rusticlamdradeon8060sgraphics using 20722MB
    11,3594 cache HIT                     [full]           gamma                  9300  IOP_CS_RGB 2,835 1,000 1,499, hash=ee3b15b0fe816f5e
    11,3594 pipe data: from cache         [full]           gamma                  9300    (101/70)  1738x1200 sc=0,320; 
    11,3596 cache report                  [full]                                        64 lines (important=4, used=6, invalid=0). Using 160MB, limit=3010MB. Hits/run=0,25. Hits/test=0,033
    11,3596 pipe finished             CL0 [full]                                          (101/70)  1738x1200 sc=0,320; 'SIU00482.ARW' ID=9572
    11,3596 pixelpipe_process good        [full]                                          (101/70)  1738x1200 sc=0,320; run=1: DT_DEV_PIXELPIPE_STOP_NO 
    11,3596 process_image_job done        [full]                                          (101/70)  1738x1200 sc=0,320; 
```

Type 2 is hard to trigger - @kofa73 got one log showing this, hard to read but look at 8828.3756!
Unfortunately this can end up in an infinite loop - you can interrupt this almost always by choosing another zoom or position in the canvas.

@kofa73 @piratenpanda @wpferguson @TurboGit and testers; after this has been merged or by doing it locally please have a look at develop.c L. 830 and: comment the `restart()` uncomment the ` dt_dev_pixelpipe_change(pipe, dev)` 


```
  8828.1757 [dt_dev_process_image_job] loading image. took 0.000 secs (0.000 CPU)
  8828.1757 dev_pixelpipe_change          [full HQ]                                     zoomed, 
  8828.1757 get dimensions                [full HQ]                                          (0/0)  4992x3280 sc=1.000; ID=20487
  8828.1757 modified roi OUT              [full HQ]        rawprepare              100       (0/0)  4992x3280 sc=1.000 -->       (0/0)  4946x3278 sc=1.000; 
  8828.1757 modified roi OUT              [full HQ]        flip                   1800       (0/0)  4946x3278 sc=1.000 -->       (0/0)  3278x4946 sc=1.000; 
  8828.1757 modified roi OUT              [full HQ]        crop                   2900       (0/0)  3278x4946 sc=1.000 -->   (155/793)  2382x3859 sc=1.000; 
  8828.1920 pipe cache check              [full HQ]                                     64 lines (important=34, used=34). Freed: invalid 0MB used 229MB. Using 2004MB, limit=2007MB
  8828.1921 pipe starting             CL0 [full HQ]                                        (0/575)  2922x1845 sc=1.611; '2026-05-30-19-22-17-DSC_0043.NEF' ID=20487, nvidiacudaquadrortx4000 using 4907MB
  8828.1921 modified roi IN               [full HQ]        finalscale             8500     (0/575)  2922x1845 sc=1.611 -->       (0/0)  2382x3859 sc=1.000; ID=20487
  8828.1921 cache HIT                     [full HQ]        agx                    6000  IOP_CS_RGB 2.268 1.000 1.217, hash=6a3f71d4fb52ca8c
  8828.1921 pipe data: from cache         [full HQ]        agx                    6000       (0/0)  2382x3859 sc=1.000; 
  8828.1921 pipe cache get                [full HQ]        finalscale             8500  IOP_CS_RGB important line 34(56) at 0x7417c0937040. hash=791394e6b660fa30
  8828.1922 process                   CPU [full HQ]        finalscale             8500       (0/0)  2382x3859 sc=1.000 -->     (0/575)  2922x1845 sc=1.611; IOP_CS_RGB 376MB
  8828.1922 resample_plain            CPU                                                    (0/0)  2382x3859 sc=1.000 -->     (0/575)  2922x1845 sc=1.611; lanczos3
  8828.2254 [resample_plain] plan 0.000 secs (0.000 CPU) resample 0.033 secs (0.227 CPU)
  8828.2254 [dev_pixelpipe] took 0.033 secs (0.227 CPU) [full] processed `finalscale' on CPU
  8828.2254 pipe cache get                [full HQ]        colorout               8600  IOP_CS_RGB important line 27(56) at 0x7417a5cb1040. hash=12e014ef57f7662a
  8828.2255 transform colorspace      CL0 [full HQ]        colorout               8600     (0/575)  2922x1845 sc=1.611; IOP_CS_RGB -> IOP_CS_LAB `linear Rec2020 RGB'
  8828.2633 [opencl copy_host_to_device] did alloc/copy img buffer on device 'NVIDIA CUDA Quadro RTX 4000' id=0
  8828.2647 [opencl copy_host_to_device] did alloc/copy img buffer on device 'NVIDIA CUDA Quadro RTX 4000' id=0
  8828.2779 [dt_ioppr_transform_image_colorspace_cl] inplace IOP_CS_RGB-->IOP_CS_LAB took 0.015 secs (0.021 GPU) [colorout]
  8828.2786 process                   CL0 [full HQ]        colorout               8600     (0/575)  2922x1845 sc=1.611; IOP_CS_LAB -> IOP_CS_RGB 172.5MB
  8828.2788 [opencl copy_host_to_device] did alloc/copy img buffer on device 'NVIDIA CUDA Quadro RTX 4000' id=0
  8828.2789 [opencl copy_host_to_device] did alloc/copy img buffer on device 'NVIDIA CUDA Quadro RTX 4000' id=0
  8828.2790 [opencl copy_host_to_device] did alloc/copy img buffer on device 'NVIDIA CUDA Quadro RTX 4000' id=0
  8828.2888 [dt_opencl_read_host_from_device_raw] read image from device 'NVIDIA CUDA Quadro RTX 4000' id=0
  8828.2888 copy CL data to host      CL0 [full HQ]        colorout               8600     (0/575)  2922x1845 sc=1.611; 
  8828.2890 [dev_pixelpipe] took 0.064 secs (0.059 CPU) [full] processed `colorout' on GPU
  8828.2890 importance hints          CL0 [full HQ]        colorout               8600     (0/575)  2922x1845 sc=1.611; cldata
  8828.2890 pipe cache get                [full HQ]        gamma                  9300  IOP_CS_RGB important line 54(57) at 0x741792dbd040. hash=af8457c0718f533e
  8828.3371 [dt_opencl_read_host_from_device_raw] read image from device 'NVIDIA CUDA Quadro RTX 4000' id=0
  8828.3374 process                   CPU [full HQ]        gamma                  9300     (0/575)  2922x1845 sc=1.611; IOP_CS_RGB 173MB
  8828.3494 [dev_pixelpipe] took 0.060 secs (0.100 CPU) [full] processed `gamma' on CPU
  8828.3494 [opencl_profiling] profiling device 0 ('NVIDIA CUDA Quadro RTX 4000'):
  8828.3494 [opencl_profiling] spent  0.0006 seconds in colorspaces_transform_rgb_matrix_to_lab
  8828.3494 [opencl_profiling] spent  0.0013 seconds in colorout
  8828.3494 [opencl_profiling] spent  0.0552 seconds in [Read Image (from device to host)]
  8828.3494 [opencl_profiling] spent  0.0571 seconds totally in command queue (with 0 events missing)
  8828.3518 cache report                  [full HQ]                                     64 lines (important=35, used=37, invalid=0). Using 2251MB, limit=2007MB. Hits/run=0.59. Hits/test=0.074
  8828.3518 pipe finished             CL0 [full HQ]                                        (0/575)  2922x1845 sc=1.611; '2026-05-30-19-22-17-DSC_0043.NEF' ID=20487
  8828.3518 [dev_process_image] pixel pipeline took 0.176 secs (0.394 CPU) processing `2026-05-30-19-22-17-DSC_0043.NEF'
  8828.3756 [dt_dev_process_image_job] loading image. took 0.000 secs (0.000 CPU)
  8828.3756 dev_pixelpipe_change          [full HQ]                                     zoomed, 
  8828.3756 get dimensions                [full HQ]                                          (0/0)  4992x3280 sc=1.000; ID=20487
  8828.3756 modified roi OUT              [full HQ]        rawprepare              100       (0/0)  4992x3280 sc=1.000 -->       (0/0)  4946x3278 sc=1.000; 
  8828.3756 modified roi OUT              [full HQ]        flip                   1800       (0/0)  4946x3278 sc=1.000 -->       (0/0)  3278x4946 sc=1.000; 
  8828.3757 modified roi OUT              [full HQ]        crop                   2900       (0/0)  3278x4946 sc=1.000 -->   (155/793)  2382x3859 sc=1.000; 
  8828.3761 pipe cache check              [full HQ]                                     64 lines (important=35, used=36). Freed: invalid 0MB used 22MB. Using 2228MB, limit=2007MB
  8828.3762 pipe starting             CL0 [full HQ]                                          (0/0)  2922x1845 sc=1.611; '2026-05-30-19-22-17-DSC_0043.NEF' ID=20487, nvidiacudaquadrortx4000 using 4907MB
  8828.3762 modified roi IN               [full HQ]        finalscale             8500       (0/0)  2922x1845 sc=1.611 -->       (0/0)  2382x3859 sc=1.000; ID=20487
```

