### PR TITLE
Fix 4-Bayer (CYGM/RGBE) raws falling into AI Bayer denoise path

### DIFF
--- a/src/common/ai/restore.c
+++ b/src/common/ai/restore.c
@@ -431,6 +431,8 @@ dt_restore_sensor_class_t dt_restore_classify_sensor(const dt_image_t *img)
     return DT_RESTORE_SENSOR_CLASS_UNSUPPORTED;
   if(img->flags & (DT_IMAGE_MONOCHROME | DT_IMAGE_MONOCHROME_BAYER))
     return DT_RESTORE_SENSOR_CLASS_UNSUPPORTED;
+  if(img->flags & DT_IMAGE_4BAYER)
+    return DT_RESTORE_SENSOR_CLASS_LINEAR;
   const uint32_t filters = img->buf_dsc.filters;
   if(filters == 9u) return DT_RESTORE_SENSOR_CLASS_XTRANS;
   if(filters != 0u) return DT_RESTORE_SENSOR_CLASS_BAYER;


### PR DESCRIPTION
[kofa73 spotted](https://github.com/darktable-org/darktable/commit/896accf7fcef92be3e364e9d43f6525d883b1014#r187496935) that the AI raw denoise sensor classifier treats anything with a non-zero, non-X-Trans CFA pattern as standard Bayer – including 4-colour CFAs like CYGM and RGBE (a handful of early-2000s Canon PowerShots, the Sony DSC-F828). The Bayer code path is hard-wired for 3 channels and indexes `wb_norm[3]`, but `FC()` on those sensors can return `3` for the fourth colour → out-of-bounds read.

These sensors are vanishingly rare, but valid darktable images do exist for them, and there's no training data for a 4-channel AI denoise variant either.

Fix is a one-line check in `dt_restore_classify_sensor`: if `DT_IMAGE_4BAYER` is set, route to the linear path – same way X-Trans is already routed.