### PR TITLE
fix: fix batch script Cyrillic paths and disk export backslash stripping on Windows

### DIFF
--- a/src/imageio/storage/disk.c
+++ b/src/imageio/storage/disk.c
@@ -335,6 +335,14 @@ int store(dt_imageio_module_storage_t *self,
 {
   dt_imageio_disk_t *d = (dt_imageio_disk_t *)sdata;
 
+#ifdef _WIN32
+  {
+    gchar *clean_filename = dt_util_str_replace(d->filename, "\\", "/");
+    g_strlcpy(d->filename, clean_filename, sizeof(d->filename));
+    g_free(clean_filename);
+  }
+#endif
+
   char filename[PATH_MAX] = { 0 };
   char input_dir[PATH_MAX] = { 0 };
   char pattern[DT_MAX_PATH_FOR_PARAMS];

--- a/src/imageio/storage/gallery.c
+++ b/src/imageio/storage/gallery.c
@@ -265,6 +265,14 @@ int store(dt_imageio_module_storage_t *self,
 {
   dt_imageio_gallery_t *d = (dt_imageio_gallery_t *)sdata;
 
+#ifdef _WIN32
+  {
+    gchar *clean_filename = dt_util_str_replace(d->filename, "\\", "/");
+    g_strlcpy(d->filename, clean_filename, sizeof(d->filename));
+    g_free(clean_filename);
+  }
+#endif
+
   char filename[PATH_MAX] = { 0 };
   char dirname[PATH_MAX] = { 0 };
   dt_image_full_path(imgid, dirname, sizeof(dirname), NULL);

--- a/src/imageio/storage/latex.c
+++ b/src/imageio/storage/latex.c
@@ -231,6 +231,14 @@ int store(dt_imageio_module_storage_t *self, dt_imageio_module_data_t *sdata, co
 {
   dt_imageio_latex_t *d = (dt_imageio_latex_t *)sdata;
 
+#ifdef _WIN32
+  {
+    gchar *clean_filename = dt_util_str_replace(d->filename, "\\", "/");
+    g_strlcpy(d->filename, clean_filename, sizeof(d->filename));
+    g_free(clean_filename);
+  }
+#endif
+
   char filename[PATH_MAX] = { 0 };
   char dirname[PATH_MAX] = { 0 };
   dt_image_full_path(imgid, dirname, sizeof(dirname), NULL);

--- a/tools/purge_nonexistent_images.bat
+++ b/tools/purge_nonexistent_images.bat
@@ -72,9 +72,15 @@ if %dryrun% EQU 0 (
 
 set ids=
 
+set "TEMP_FILE=%TEMP%\dt_purge_%RANDOM%.txt"
+sqlite3.exe %DBFILE% %QUERY% > "%TEMP_FILE%"
+
+for /f "tokens=4" %%a in ('chcp') do set "OLD_CP=%%a"
+chcp 65001 >nul
+
 setlocal EnableDelayedExpansion
-for /f "tokens=1* delims=|" %%a in ('sqlite3.exe %DBFILE% %QUERY%') do (
-  if not exist %%b (
+for /f "usebackq tokens=1* delims=|" %%a in ("%TEMP_FILE%") do (
+  if not exist "%%b" (
     echo.  %%b with ID %%a
     if .!ids!==. (
       set ids=%%a
@@ -83,6 +89,9 @@ for /f "tokens=1* delims=|" %%a in ('sqlite3.exe %DBFILE% %QUERY%') do (
     )
   )
 )
+
+chcp %OLD_CP% >nul
+del "%TEMP_FILE%" 2>nul
 
 if %dryrun% EQU 0 (
   echo This is NOT dry run


### PR DESCRIPTION
This PR resolves two Windows-specific issues:

1. **Fix purge_nonexistent_images.bat with Cyrillic paths (#20915)**:
   - Sets the active code page to 65001 (UTF-8) during the file existence check loop.
   - Redirects `sqlite3` output to a temp file and reads it using `usebackq` inside `for /f`, avoiding the cmd.exe character truncation/corruption parser bug when executing subprocesses under CP 65001.
   - Quotes path parameters in `if not exist "%%b"` to correctly handle folders/filenames containing spaces.

2. **Fix Windows backslash path stripping in disk, gallery, and latex storage modules (#20981)**:
   - Cleans `d->filename` in the `store()` function on Windows by replacing all backslashes `\` with forward slashes `/` before copying to the pattern string.
   - Forward slashes are natively supported as path separators by Windows filesystem APIs, and preventing backslashes in the pattern keeps them from being stripped as escape sequences during variable expansion.
