### PR TITLE
Fix 10 core issues: preferences, l10n, exposure proxy, preset defaults, shortcuts, casing, gallery, datetime, variables, and cli lock cleanup

### DIFF
--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -236,6 +236,10 @@ int main(int argc, char *arg[])
   gboolean verbose = FALSE, high_quality = TRUE, upscale = FALSE,
            style_overwrite = FALSE, custom_presets = TRUE, export_masks = FALSE,
            output_to_dir = FALSE;
+  dt_imageio_module_format_t *format = NULL;
+  dt_imageio_module_storage_t *storage = NULL;
+  dt_imageio_module_data_t *sdata = NULL, *fdata = NULL;
+  int res = 0;
 
   GList* inputs = NULL;
 
@@ -656,11 +660,8 @@ int main(int argc, char *arg[])
   if(total == 0)
   {
     fprintf(stderr, _("no images to export, aborting\n"));
-    free(m_arg);
-    g_free(output_filename);
-    if(output_ext)
-      g_free(output_ext);
-    exit(1);
+    res = 1;
+    goto cleanup;
   }
 
   // attach xmp, if requested:
@@ -674,11 +675,9 @@ int main(int argc, char *arg[])
       {
         fprintf(stderr, _("error: can't open XMP file %s"), xmp_filename);
         fprintf(stderr, "\n");
-        free(m_arg);
-        g_free(output_filename);
-        if(output_ext)
-          g_free(output_ext);
-        exit(1);
+        dt_image_cache_write_release(image, DT_IMAGE_CACHE_RELAXED);
+        res = 1;
+        goto cleanup;
       }
       // don't write new xmp:
       dt_image_cache_write_release(image, DT_IMAGE_CACHE_RELAXED);
@@ -749,30 +748,22 @@ int main(int argc, char *arg[])
   }
 
   // init the export data structures
-  dt_imageio_module_format_t *format;
-  dt_imageio_module_storage_t *storage;
-  dt_imageio_module_data_t *sdata, *fdata;
-
   storage = dt_imageio_get_storage_by_name("disk"); // only exporting to disk makes sense
   if(storage == NULL)
   {
     fprintf(
         stderr, "%s\n",
         _("cannot find disk storage module. please check your installation, something seems to be broken."));
-    free(m_arg);
-    g_free(output_filename);
-    g_free(output_ext);
-    exit(1);
+    res = 1;
+    goto cleanup;
   }
 
   sdata = storage->get_params(storage);
   if(sdata == NULL)
   {
     fprintf(stderr, "%s\n", _("failed to get parameters from storage module, aborting export ..."));
-    free(m_arg);
-    g_free(output_filename);
-    g_free(output_ext);
-    exit(1);
+    res = 1;
+    goto cleanup;
   }
 
   // and now for the really ugly hacks. don't tell your children about this one or they won't sleep at night
@@ -780,24 +771,23 @@ int main(int argc, char *arg[])
   g_strlcpy((char *)sdata, output_filename, DT_MAX_PATH_FOR_PARAMS);
   // all is good now, the last line didn't happen.
   g_free(output_filename);
+  output_filename = NULL;
 
   format = dt_imageio_get_format_by_name(output_ext);
   if(format == NULL)
   {
     fprintf(stderr, _("unknown extension '.%s'"), output_ext);
     fprintf(stderr, "\n");
-    free(m_arg);
-    g_free(output_ext);
-    exit(1);
+    res = 1;
+    goto cleanup;
   }
 
   fdata = format->get_params(format);
   if(fdata == NULL)
   {
     fprintf(stderr, "%s\n", _("failed to get parameters from format module, aborting export ..."));
-    free(m_arg);
-    g_free(output_ext);
-    exit(1);
+    res = 1;
+    goto cleanup;
   }
 
   uint32_t w, h, fw, fh, sw, sh;
@@ -840,7 +830,7 @@ int main(int argc, char *arg[])
 
   // TODO: add a callback to set the bpp without going through the config
 
-  int num = 1, res = 0;
+  int num = 1;
   for(GList *iter = id_list; iter; iter = g_list_next(iter), num++)
   {
     const int id = GPOINTER_TO_INT(iter->data);
@@ -864,14 +854,24 @@ int main(int argc, char *arg[])
       res = 1;
   }
 
+cleanup:
   // cleanup time
-  if(storage->finalize_store) storage->finalize_store(storage, sdata);
-  storage->free_params(storage, sdata);
-  format->free_params(format, fdata);
+  if(storage && sdata)
+  {
+    if(storage->finalize_store) storage->finalize_store(storage, sdata);
+    storage->free_params(storage, sdata);
+  }
+  if(format && fdata)
+  {
+    format->free_params(format, fdata);
+  }
   g_list_free(id_list);
 
   if(icc_filename)
     g_free(icc_filename);
+
+  g_free(output_filename);
+  g_free(output_ext);
 
   dt_cleanup();
 

--- a/src/common/datetime.c
+++ b/src/common/datetime.c
@@ -149,6 +149,16 @@ gboolean dt_datetime_gdatetime_to_local(char *local,
         g_free(sdt);
         sdt = sdt2;
       }
+      if(sdt)
+      {
+        char *p = sdt;
+        while((p = strstr(p, "\xe2\x88\xb6")) != NULL)
+        {
+          *p = ':';
+          memmove(p + 1, p + 3, strlen(p + 3) + 1);
+          p++;
+        }
+      }
       g_strlcpy(local, sdt, local_size);
       g_free(sdt);
       return TRUE;

--- a/src/common/l10n.c
+++ b/src/common/l10n.c
@@ -85,15 +85,31 @@ static void _set_locale(const char *ui_lang, const char *old_env, const gboolean
     if(full_locale)
     {
       g_setenv("LANG", full_locale, TRUE);
+#ifdef WIN32
+      _putenv_s("LANG", full_locale);
+#endif
       g_free(full_locale);
     }
     g_setenv("LANGUAGE", ui_lang, TRUE);
+#ifdef WIN32
+    _putenv_s("LANGUAGE", ui_lang);
+#endif
     if(gui) gtk_disable_setlocale();
   }
   else if(old_env && *old_env)
+  {
     g_setenv("LANGUAGE", old_env, TRUE);
+#ifdef WIN32
+    _putenv_s("LANGUAGE", old_env);
+#endif
+  }
   else
+  {
     g_unsetenv("LANGUAGE");
+#ifdef WIN32
+    _putenv_s("LANGUAGE", "");
+#endif
+  }
 
   setlocale(LC_ALL, "");
 }
@@ -239,6 +255,9 @@ static void _dt_get_language_names(GList *languages)
         {
           // code taken in parts from GIMP's gimplanguagestore-parser.c
           g_setenv("LANGUAGE", language->code, TRUE);
+#ifdef WIN32
+          _putenv_s("LANGUAGE", language->code);
+#endif
           setlocale (LC_ALL, language->code);
 
           char *localized_name = g_strdup(dgettext("iso_639-2", name));
@@ -251,6 +270,9 @@ static void _dt_get_language_names(GList *languages)
             g_free(localized_name);
 
             g_setenv("LANGUAGE", language->base_code, TRUE);
+#ifdef WIN32
+            _putenv_s("LANGUAGE", language->base_code);
+#endif
             setlocale (LC_ALL, language->base_code);
 
             localized_name = g_strdup(dgettext("iso_639-2", name));

--- a/src/common/utility.c
+++ b/src/common/utility.c
@@ -1125,9 +1125,41 @@ char *dt_copy_filename_extension(const char *filename1,
                                  const char *filename2)
 {
   // assume both filenames have an extension
-  if(!filename2) return NULL;
+  if(!filename1 || !filename2) return NULL;
+  const char *dot1 = strrchr(filename1, '.');
   const char *dot2 = strrchr(filename2, '.');
   if(!dot2) return NULL;
+
+  if(dot1)
+  {
+    gboolean all_lower = TRUE;
+    gboolean all_upper = TRUE;
+    const char *p = dot1 + 1;
+    while(*p)
+    {
+      if(g_ascii_isalpha(*p))
+      {
+        if(g_ascii_isupper(*p)) all_lower = FALSE;
+        if(g_ascii_islower(*p)) all_upper = FALSE;
+      }
+      p++;
+    }
+
+    char *ext = g_strdup(dot2 + 1);
+    if(all_lower)
+    {
+      char *q = ext;
+      while(*q) { *q = g_ascii_tolower(*q); q++; }
+    }
+    else if(all_upper)
+    {
+      char *q = ext;
+      while(*q) { *q = g_ascii_toupper(*q); q++; }
+    }
+    char *res = dt_filename_change_extension(filename1, ext);
+    g_free(ext);
+    return res;
+  }
 
   return dt_filename_change_extension(filename1, dot2+1);
 }

--- a/src/common/variables.c
+++ b/src/common/variables.c
@@ -35,6 +35,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <time.h>
+#include <glib/gstdio.h>
 
 typedef struct dt_variables_data_t
 {
@@ -685,6 +686,35 @@ static char *_get_base_value(dt_variables_params_t *params, char **variable)
   else if(_has_prefix(variable, "FILE.EXTENSION")
           || _has_prefix(variable, "FILE_EXTENSION"))
     result = g_strdup(params->data->file_ext);
+  else if(_has_prefix(variable, "FILE.SIZE")
+          || _has_prefix(variable, "FILE_SIZE"))
+  {
+    char filepath[PATH_MAX] = { 0 };
+    if(params->filename)
+    {
+      g_strlcpy(filepath, params->filename, sizeof(filepath));
+    }
+    else if(dt_is_valid_imgid(params->imgid))
+    {
+      const dt_image_t *img = params->img
+        ? (dt_image_t *)params->img
+        : dt_image_cache_get(params->imgid, 'r');
+      if(img)
+      {
+        dt_image_full_path(img->id, filepath, sizeof(filepath), NULL);
+        if(!params->img) dt_image_cache_read_release(img);
+      }
+    }
+
+    if(filepath[0])
+    {
+      GStatBuf statbuf;
+      if(g_stat(filepath, &statbuf) == 0)
+      {
+        result = g_format_size(statbuf.st_size);
+      }
+    }
+  }
   else if(_has_prefix(variable, "SEQUENCE"))
   {
     uint8_t nb_digit = 4;

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -3359,10 +3359,33 @@ static dt_dev_proxy_exposure_t *_dev_exposure_proxy_available(dt_develop_t *dev)
   return instance && instance->module ? instance : NULL;
 }
 
+static dt_iop_module_t *_get_preferred_exposure_module(dt_develop_t *dev)
+{
+  if (dt_view_get_current() != DT_VIEW_DARKROOM) return NULL;
+
+  const dt_iop_module_so_t *exposure_so = NULL;
+  for(const GList *modules = darktable.iop; modules; modules = g_list_next(modules))
+  {
+    const dt_iop_module_so_t *module_so = modules->data;
+    if(dt_iop_module_so_is(module_so, "exposure"))
+    {
+      exposure_so = module_so;
+      break;
+    }
+  }
+
+  if (exposure_so)
+  {
+    return dt_iop_get_module_enabled_preferring_unmasked_first_instance(exposure_so);
+  }
+  return NULL;
+}
+
 float dt_dev_exposure_get_exposure(dt_develop_t *dev)
 {
-  const dt_dev_proxy_exposure_t *instance = _dev_exposure_proxy_available(dev);
-  return instance && instance->get_exposure && instance->module->enabled ? instance->get_exposure(instance->module) : 0.0f;
+  if (!dev->proxy.exposure.get_exposure) return 0.0f;
+  dt_iop_module_t *module = _get_preferred_exposure_module(dev);
+  return module && module->enabled ? dev->proxy.exposure.get_exposure(module) : 0.0f;
 }
 
 float dt_dev_exposure_get_effective_exposure(dt_develop_t *dev)
@@ -3404,8 +3427,9 @@ float dt_dev_exposure_get_effective_exposure(dt_develop_t *dev)
 
 float dt_dev_exposure_get_black(dt_develop_t *dev)
 {
-  const dt_dev_proxy_exposure_t *instance = _dev_exposure_proxy_available(dev);
-  return instance && instance->get_black  && instance->module->enabled ? instance->get_black(instance->module) : 0.0f;
+  if (!dev->proxy.exposure.get_black) return 0.0f;
+  dt_iop_module_t *module = _get_preferred_exposure_module(dev);
+  return module && module->enabled ? dev->proxy.exposure.get_black(module) : 0.0f;
 }
 
 void dt_dev_exposure_handle_event(int n_press, gdouble delta,

--- a/src/gui/preferences_ai.c
+++ b/src/gui/preferences_ai.c
@@ -246,7 +246,7 @@ static void _refresh_model_list(dt_prefs_ai_data_t *data)
       COL_NAME,
       model->name ? model->name : model->id,
       COL_TASK,
-      model->task ? model->task : "",
+      model->task ? _(model->task) : "",
       COL_STATUS,
       _status_to_string(model->status),
       COL_DEFAULT,

--- a/src/imageio/storage/gallery.c
+++ b/src/imageio/storage/gallery.c
@@ -531,9 +531,7 @@ void finalize_store(dt_imageio_module_storage_t *self, dt_imageio_module_data_t 
   fprintf(f, "        <p style=\"clear:both;\"></p>\n"
              "    </div>\n"
              "    <div class=\"footer\">\n"
-             "      <script language=\"JavaScript\" type=\"text/javascript\">\n"
-             "      document.write(\"download all: <em>curl -O#  \" + document.documentURI.replace( /\\\\/g, '/' ).replace( /\\/[^\\/]*$/, '' ) + \"/img_[0000-%04zu].jpg</em>\")\n"
-             "      </script><br />\n"
+             "      <span id=\"download-all\"></span><br />\n"
              "      created with %s\n"
              "    </div>\n"
              "    <div class=\"pswp\" tabindex=\"-1\" role=\"dialog\" aria-hidden=\"true\">\n"
@@ -576,7 +574,6 @@ void finalize_store(dt_imageio_module_storage_t *self, dt_imageio_module_data_t 
              "<script>\n"
              "var pswpElement = document.querySelectorAll('.pswp')[0];\n"
              "var items = [\n",
-          count,
           darktable_package_string);
   while(d->l)
   {
@@ -596,6 +593,13 @@ void finalize_store(dt_imageio_module_storage_t *self, dt_imageio_module_data_t 
              "    var gallery = new PhotoSwipe( pswpElement, PhotoSwipeUI_Default, items, options);\n"
              "    gallery.init();\n"
              "}\n"
+             "var curl_cmd = \"curl -O#\";\n"
+             "var base = document.documentURI.replace(/\\\\/g, '/').replace(/\\/[^\\/]*$/, '');\n"
+             "for (var i = 0; i < items.length; i++) {\n"
+             "  curl_cmd += \" \\\"\" + base + \"/\" + items[i].src + \"\\\"\";\n"
+             "}\n"
+             "var el = document.getElementById(\"download-all\");\n"
+             "if(el) el.innerHTML = \"download all: <em>\" + curl_cmd + \"</em>\";\n"
              "</script>\n"
              "</html>\n");
   fclose(f);

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -5964,8 +5964,8 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_slider_set_factor(g->rotation, -1.f);
   dt_bauhaus_slider_set_soft_range(g->rotation, -ROTATION_RANGE, ROTATION_RANGE);
   dt_action_t *ac = dt_action_widget(g->rotation);
-  dt_shortcut_register(ac, 0, DT_ACTION_EFFECT_UP, GDK_KEY_bracketleft, GDK_MOD1_MASK);
-  dt_shortcut_register(ac, 0, DT_ACTION_EFFECT_DOWN, GDK_KEY_bracketright, GDK_MOD1_MASK);
+  dt_shortcut_register(ac, 0, DT_ACTION_EFFECT_DOWN, GDK_KEY_bracketleft, GDK_MOD1_MASK);
+  dt_shortcut_register(ac, 0, DT_ACTION_EFFECT_UP, GDK_KEY_bracketright, GDK_MOD1_MASK);
   dt_shortcut_register(ac, 0, 0, GDK_KEY_r, GDK_MOD1_MASK);
 
   g->cropmode = dt_bauhaus_combobox_from_params(self, "cropmode");

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -1657,7 +1657,14 @@ void init_presets(dt_lib_module_t *self)
   AM("ashift");
 
   if(is_scene_referred)
-    AM("sigmoid");
+  {
+    if(wf_filmic)
+      AM("filmicrgb");
+    else if(wf_agx)
+      AM("agx");
+    else
+      AM("sigmoid");
+  }
   else
     AM("basecurve");
 


### PR DESCRIPTION
This pull request addresses 10 core bugs and enhancements in Darktable:

1. **AI Panel Translation (Issue #21219)**: Wrapped the AI model task name in the `_()` translation macro in `src/gui/preferences_ai.c`.
2. **Language Switching (Issue #20194)**: Synchronized `LANG` and `LANGUAGE` environment settings using `_putenv_s` on Windows in `src/common/l10n.c`.
3. **Exposure Proxy (Issue #19560)**: Fixed proxy getters in `src/develop/develop.c` to select the first enabled, unmasked exposure instance.
4. **Beginner Preset defaults (Issue #20959)**: Dynamically selected tone-mapper default (sigmoid/filmicrgb/agx) based on active workflow in `src/libs/modulegroups.c`.
5. **Ashift Shortcuts (Issue #20233)**: Aligned alt-`[` and alt-`]` rotation directions with `[` and `]` in `src/iop/ashift.c`.
6. **Gallery Download Command (Issue #19369)**: Dynamically generated curl download-all command based on gallery items in `src/imageio/storage/gallery.c`.
7. **Casing Modifiers (Issue #20259)**: Preserved extension casing in `dt_copy_filename_extension` in `src/common/utility.c`.
8. **File Size Variable (Issue #19771)**: Implemented `$(FILE_SIZE)` and `$(FILE.SIZE)` variables in `src/common/variables.c`.
9. **Ratio Separator (Issue #20036)**: Sanitized Unicode Ratio separator into standard ASCII colons in formatted dates on Windows in `src/common/datetime.c`.
10. **CLI Database Locks (Issue #19584)**: Routed premature exits in `src/cli/main.c` through unified cleanup to prevent stale lock files.
