### PR TITLE
Bump AI model registry min_version to 1.0 for release

### DIFF
--- a/data/ai_models.json
+++ b/data/ai_models.json
@@ -5,35 +5,35 @@
       "id": "mask-object-sam21-small",
       "name": "mask sam2.1 hiera small",
       "task": "mask",
-      "min_version": "0.1",
+      "min_version": "1.0",
       "default": true
     },
     {
       "id": "mask-object-segnext-b2hq",
       "name": "mask segnext vitb-sax2 hq",
       "task": "mask",
-      "min_version": "0.1",
+      "min_version": "1.0",
       "default": false
     },
     {
       "id": "denoise-nind",
       "name": "denoise nind",
       "task": "denoise",
-      "min_version": "0.2",
+      "min_version": "1.0",
       "default": true
     },
     {
       "id": "rawdenoise-nind",
       "name": "raw denoise nind",
       "task": "rawdenoise",
-      "min_version": "0.2",
+      "min_version": "1.0",
       "default": true
     },
     {
       "id": "upscale-realplksr",
       "name": "upscale realplksr",
       "task": "upscale",
-      "min_version": "0.2",
+      "min_version": "1.0",
       "default": true
     }
   ]


### PR DESCRIPTION
Bump `min_version` to `1.0` for all entries in `data/ai_models.json` so darktable requires the freshly-released v1.0 model metadata.

Prerequisite: https://github.com/darktable-org/darktable-ai/pull/34 (model version bump to 1.0). This PR must land *after* darktable-ai PR 34 is merged.
