### PR TITLE
Windows: synchronize UI language settings with _putenv_s for libintl (fixes #20194)

### DIFF
--- a/src/common/l10n.c
+++ b/src/common/l10n.c
@@ -33,6 +33,7 @@
 #ifdef _WIN32
 #include "win/dtwin.h"
 #include <windows.h>
+#include <stdlib.h>
 #endif
 
 static gchar* _dt_full_locale_name(const char *locale)
@@ -85,15 +86,31 @@ static void _set_locale(const char *ui_lang, const char *old_env, const gboolean
     if(full_locale)
     {
       g_setenv("LANG", full_locale, TRUE);
+#ifdef WIN32
+      _putenv_s("LANG", full_locale);
+#endif
       g_free(full_locale);
     }
     g_setenv("LANGUAGE", ui_lang, TRUE);
+#ifdef WIN32
+    _putenv_s("LANGUAGE", ui_lang);
+#endif
     if(gui) gtk_disable_setlocale();
   }
   else if(old_env && *old_env)
+  {
     g_setenv("LANGUAGE", old_env, TRUE);
+#ifdef WIN32
+    _putenv_s("LANGUAGE", old_env);
+#endif
+  }
   else
+  {
     g_unsetenv("LANGUAGE");
+#ifdef WIN32
+    _putenv_s("LANGUAGE", "");
+#endif
+  }
 
   setlocale(LC_ALL, "");
 }
@@ -239,6 +256,9 @@ static void _dt_get_language_names(GList *languages)
         {
           // code taken in parts from GIMP's gimplanguagestore-parser.c
           g_setenv("LANGUAGE", language->code, TRUE);
+#ifdef WIN32
+          _putenv_s("LANGUAGE", language->code);
+#endif
           setlocale (LC_ALL, language->code);
 
           char *localized_name = g_strdup(dgettext("iso_639-2", name));
@@ -251,6 +271,9 @@ static void _dt_get_language_names(GList *languages)
             g_free(localized_name);
 
             g_setenv("LANGUAGE", language->base_code, TRUE);
+#ifdef WIN32
+            _putenv_s("LANGUAGE", language->base_code);
+#endif
             setlocale (LC_ALL, language->base_code);
 
             localized_name = g_strdup(dgettext("iso_639-2", name));


### PR DESCRIPTION
Resolves #20194.

### Purpose & Goal
In Windows, changing the language in darktable preferences had no effect on the interface because standard library `gettext` calls on MSVC/Windows query the MSVCRT environment block rather than the GLib environment set by `g_setenv`.

### Implementation Details
- Added environment variable synchronization blocks in `src/common/l10n.c` using Windows CRT-specific `_putenv_s` for `LANG` and `LANGUAGE` variables.
- Explicitly included `<stdlib.h>` inside the `#ifdef _WIN32` guard.

### Testing & Verification Approach
- Tested changing the language inside preferences on a Windows build and verified the UI changes immediately.
- Verified compile safety across MinGW-w64 and MSVC toolchains with the header inclusion.

### Regression Safety
All modifications are strictly scoped inside the `#ifdef _WIN32` block, leaving POSIX/UNIX systems (Linux, macOS) completely unaffected.

### Development Note
This pull request was prepared with AI-assisted pair-programming (using the Gemini-powered Antigravity agent), and has been manually reviewed and refined for correctness.
