### PR TITLE
modulegroups: dynamically select tone-mapper defaults in beginner preset (fixes #20959)

### DIFF
--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -1657,7 +1657,14 @@ void init_presets(dt_lib_module_t *self)
   AM("ashift");
 
   if(is_scene_referred)
-    AM("sigmoid");
+  {
+    if(wf_filmic)
+      AM("filmicrgb");
+    else if(wf_agx)
+      AM("agx");
+    else
+      AM("sigmoid");
+  }
   else
     AM("basecurve");
 


### PR DESCRIPTION
Resolves #20959.

### Purpose & Goal
Ensure the beginner preset in Quick Access Panel (QAP) respects active user workflow preferences (`filmicrgb`, `agx`, or `sigmoid`) rather than always hardcoding `sigmoid`.

### Implementation Details
- Updated the preset initialization logic in `src/libs/modulegroups.c` to inspect the workflow configuration (`plugins/darkroom/workflow`).
- Conditionally load `filmicrgb`, `agx`, or `sigmoid` based on active workflow settings.

### Testing & Verification Approach
- Verified the beginner panel configuration dynamically maps the correct modules:
  - filmic workflow -> filmicrgb
  - AgX workflow -> agx
  - sigmoid or none -> sigmoid

### Regression Safety
Maintains safe fallback behavior and respects existing scene-referred configuration schemes without breaking legacy presets.

### Development Note
This pull request was prepared with AI-assisted pair-programming (using the Gemini-powered Antigravity agent), and has been manually reviewed and refined for correctness.
