### PR TITLE
ashift: align alt-[ and alt-] rotation shortcuts with [ and ] (fixes #20233)

### DIFF
--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -5964,8 +5964,8 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_slider_set_factor(g->rotation, -1.f);
   dt_bauhaus_slider_set_soft_range(g->rotation, -ROTATION_RANGE, ROTATION_RANGE);
   dt_action_t *ac = dt_action_widget(g->rotation);
-  dt_shortcut_register(ac, 0, DT_ACTION_EFFECT_UP, GDK_KEY_bracketleft, GDK_MOD1_MASK);
-  dt_shortcut_register(ac, 0, DT_ACTION_EFFECT_DOWN, GDK_KEY_bracketright, GDK_MOD1_MASK);
+  dt_shortcut_register(ac, 0, DT_ACTION_EFFECT_DOWN, GDK_KEY_bracketleft, GDK_MOD1_MASK);
+  dt_shortcut_register(ac, 0, DT_ACTION_EFFECT_UP, GDK_KEY_bracketright, GDK_MOD1_MASK);
   dt_shortcut_register(ac, 0, 0, GDK_KEY_r, GDK_MOD1_MASK);
 
   g->cropmode = dt_bauhaus_combobox_from_params(self, "cropmode");


### PR DESCRIPTION
Resolves #20233.

### Purpose & Goal
Align fine rotation shortcuts (`alt-[` and `alt-]`) direction behavior with the standard coarse rotation shortcuts (`[` and `]`).

### Implementation Details
- Swapped action rotation mappings (`DT_ACTION_EFFECT_DOWN` and `DT_ACTION_EFFECT_UP`) for `GDK_KEY_bracketleft` and `GDK_KEY_bracketright` in `src/iop/ashift.c`.

### Testing & Verification Approach
- Confirmed key presses trigger the correct rotation direction in ashift slider. `alt-[` rotates CCW (down) and `alt-]` rotates CW (up), matching `[` (CCW) and `]` (CW) coarse behaviors in `flip.c`.

### Regression Safety
Updates the hotkey bindings without affecting slider limits or mathematical rotation logic.

### Development Note
This pull request was prepared with AI-assisted pair-programming (using the Gemini-powered Antigravity agent), and has been manually reviewed and refined for correctness.
