### PR TITLE
gallery: dynamically generate curl download command in web gallery (fixes #19369)

### DIFF
--- a/src/imageio/storage/gallery.c
+++ b/src/imageio/storage/gallery.c
@@ -531,9 +531,7 @@ void finalize_store(dt_imageio_module_storage_t *self, dt_imageio_module_data_t 
   fprintf(f, "        <p style=\"clear:both;\"></p>\n"
              "    </div>\n"
              "    <div class=\"footer\">\n"
-             "      <script language=\"JavaScript\" type=\"text/javascript\">\n"
-             "      document.write(\"download all: <em>curl -O#  \" + document.documentURI.replace( /\\\\/g, '/' ).replace( /\\/[^\\/]*$/, '' ) + \"/img_[0000-%04zu].jpg</em>\")\n"
-             "      </script><br />\n"
+             "      <span id=\"download-all\"></span><br />\n"
              "      created with %s\n"
              "    </div>\n"
              "    <div class=\"pswp\" tabindex=\"-1\" role=\"dialog\" aria-hidden=\"true\">\n"
@@ -576,7 +574,6 @@ void finalize_store(dt_imageio_module_storage_t *self, dt_imageio_module_data_t 
              "<script>\n"
              "var pswpElement = document.querySelectorAll('.pswp')[0];\n"
              "var items = [\n",
-          count,
           darktable_package_string);
   while(d->l)
   {
@@ -596,6 +593,13 @@ void finalize_store(dt_imageio_module_storage_t *self, dt_imageio_module_data_t 
              "    var gallery = new PhotoSwipe( pswpElement, PhotoSwipeUI_Default, items, options);\n"
              "    gallery.init();\n"
              "}\n"
+             "var curl_cmd = \"curl -O#\";\n"
+             "var base = document.documentURI.replace(/\\\\/g, '/').replace(/\\/[^\\/]*$/, '');\n"
+             "for (var i = 0; i < items.length; i++) {\n"
+             "  curl_cmd += \" \\\"\" + base + \"/\" + items[i].src + \"\\\"\";\n"
+             "}\n"
+             "var el = document.getElementById(\"download-all\");\n"
+             "if(el) el.innerHTML = \"download all: <em>\" + curl_cmd + \"</em>\";\n"
              "</script>\n"
              "</html>\n");
   fclose(f);


### PR DESCRIPTION
Resolves #19369.

### Purpose & Goal
Fix hardcoded web gallery download-all instructions that broke whenever the user used custom naming patterns.

### Implementation Details
- Replaced the static curl pattern `img_[0000-%04zu].jpg` in `src/imageio/storage/gallery.c` with a client-side JavaScript loop.
- The script dynamically builds the curl command by reading the actual PhotoSwipe `items` array.

### Testing & Verification Approach
- Verified exported HTML output with standard and custom file formats. Conformed curl commands safely wrap items in double quotes to handle spaces/casing correctly.

### Regression Safety
Dynamic iteration eliminates hardcoded format assumptions, preventing broken curl strings in all future exports.

### Development Note
This pull request was prepared with AI-assisted pair-programming (using the Gemini-powered Antigravity agent), and has been manually reviewed and refined for correctness.
