### PR TITLE
common: preserve filename extension casing on copy_filename_extension (fixes #20259)

### DIFF
--- a/src/common/utility.c
+++ b/src/common/utility.c
@@ -1125,9 +1125,41 @@ char *dt_copy_filename_extension(const char *filename1,
                                  const char *filename2)
 {
   // assume both filenames have an extension
-  if(!filename2) return NULL;
+  if(!filename1 || !filename2) return NULL;
+  const char *dot1 = strrchr(filename1, '.');
   const char *dot2 = strrchr(filename2, '.');
   if(!dot2) return NULL;
+
+  if(dot1)
+  {
+    gboolean all_lower = TRUE;
+    gboolean all_upper = TRUE;
+    const char *p = dot1 + 1;
+    while(*p)
+    {
+      if(g_ascii_isalpha(*p))
+      {
+        if(g_ascii_isupper(*p)) all_lower = FALSE;
+        if(g_ascii_islower(*p)) all_upper = FALSE;
+      }
+      p++;
+    }
+
+    char *ext = g_strdup(dot2 + 1);
+    if(all_lower)
+    {
+      char *q = ext;
+      while(*q) { *q = g_ascii_tolower(*q); q++; }
+    }
+    else if(all_upper)
+    {
+      char *q = ext;
+      while(*q) { *q = g_ascii_toupper(*q); q++; }
+    }
+    char *res = dt_filename_change_extension(filename1, ext);
+    g_free(ext);
+    return res;
+  }
 
   return dt_filename_change_extension(filename1, dot2+1);
 }


### PR DESCRIPTION
Resolves #20259.

### Purpose & Goal
Preserve filename extension casing during duplicate file imports (preventing lowercase modifiers like `.jpg` from bypassing uppercase `.JPG` rules on duplicate copy filename generations).

### Implementation Details
- Updated `dt_copy_filename_extension` in `src/common/utility.c` to inspect the casing of the source file extension.
- Converts the copied extension to uppercase or lowercase to match the source file casing.

### Testing & Verification Approach
- Verified that target filenames are successfully matched:
  - duplicating `IMAGE.JPG` yields `IMAGE_01.JPG`
  - duplicating `image.jpg` yields `image_01.jpg`
- Verified that mixed casing extensions remain unaffected.

### Regression Safety
Casing checks only trigger on pure lowercase or uppercase states, ensuring full compatibility with custom/unusual extension formats.

### Development Note
This pull request was prepared with AI-assisted pair-programming (using the Gemini-powered Antigravity agent), and has been manually reviewed and refined for correctness.
