### PR TITLE
variables: implement $(FILE_SIZE) and $(FILE.SIZE) variables (fixes #19771)

### DIFF
--- a/src/common/variables.c
+++ b/src/common/variables.c
@@ -35,6 +35,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <time.h>
+#include <glib/gstdio.h>
 
 typedef struct dt_variables_data_t
 {
@@ -685,6 +686,35 @@ static char *_get_base_value(dt_variables_params_t *params, char **variable)
   else if(_has_prefix(variable, "FILE.EXTENSION")
           || _has_prefix(variable, "FILE_EXTENSION"))
     result = g_strdup(params->data->file_ext);
+  else if(_has_prefix(variable, "FILE.SIZE")
+          || _has_prefix(variable, "FILE_SIZE"))
+  {
+    char filepath[PATH_MAX] = { 0 };
+    if(params->filename)
+    {
+      g_strlcpy(filepath, params->filename, sizeof(filepath));
+    }
+    else if(dt_is_valid_imgid(params->imgid))
+    {
+      const dt_image_t *img = params->img
+        ? (dt_image_t *)params->img
+        : dt_image_cache_get(params->imgid, 'r');
+      if(img)
+      {
+        dt_image_full_path(img->id, filepath, sizeof(filepath), NULL);
+        if(!params->img) dt_image_cache_read_release(img);
+      }
+    }
+
+    if(filepath[0])
+    {
+      GStatBuf statbuf;
+      if(g_stat(filepath, &statbuf) == 0)
+      {
+        result = g_format_size(statbuf.st_size);
+      }
+    }
+  }
   else if(_has_prefix(variable, "SEQUENCE"))
   {
     uint8_t nb_digit = 4;

--- a/src/tests/variables.c
+++ b/src/tests/variables.c
@@ -53,6 +53,8 @@ static const test_t test_variables = {
     {"foo-$(FILE_NAME)-bar", "foo-abcdef12345abcdef-bar"},
     {"äöü-$(FILE_NAME)-äöü", "äöü-abcdef12345abcdef-äöü"},
     {"$(FILE_NAME).$(SEQUENCE)", "abcdef12345abcdef.0023"},
+    {"$(FILE_SIZE)", ""},
+    {"$(FILE.SIZE)", ""},
     {"$(NONEXISTANT)", ""},
     {"foo-$(NONEXISTANT)-bar", "foo--bar"},
 


### PR DESCRIPTION
Resolves #19771.

### Purpose & Goal
Implement human-readable variables `$(FILE_SIZE)` and `$(FILE.SIZE)` for watermark and filename export overlays.

### Implementation Details
- Added expansion logic to `_get_base_value` in `src/common/variables.c` utilizing `g_stat` and `g_format_size`.
- Added automated unit test cases to the darktable variables test suite in `src/tests/variables.c`.

### Testing & Verification Approach
- Automated testing via `darktable-test-variables` test suite to check fallback behavior on dummy filenames.
- Verified human-readable output (e.g. `14.2 MB`, `800 KB`) on local filesystem tests.

### Regression Safety
Ensured all dynamically allocated glib formatted string pointers are correctly cleaned up by the parser, preventing memory leaks.

### Development Note
This pull request was prepared with AI-assisted pair-programming (using the Gemini-powered Antigravity agent), and has been manually reviewed and refined for correctness.
