### PR TITLE
datetime: sanitize Unicode Ratio separators into ASCII colons on Windows (fixes #20036)

### DIFF
--- a/src/common/datetime.c
+++ b/src/common/datetime.c
@@ -149,6 +149,16 @@ gboolean dt_datetime_gdatetime_to_local(char *local,
         g_free(sdt);
         sdt = sdt2;
       }
+      if(sdt)
+      {
+        char *p = sdt;
+        while((p = strstr(p, "\xe2\x88\xb6")) != NULL)
+        {
+          *p = ':';
+          memmove(p + 1, p + 3, strlen(p + 3) + 1);
+          p++;
+        }
+      }
       g_strlcpy(local, sdt, local_size);
       g_free(sdt);
       return TRUE;


### PR DESCRIPTION
Resolves #20036.

### Purpose & Goal
Replace localized Unicode Ratio characters (`∶`, UTF-8 `\xe2\x88\xb6`) with standard ASCII colons (`:`) in date-time strings on Windows, preventing rendering bugs and backend date-time parsing crashes.

### Implementation Details
- Implemented UTF-8 character search and byte-shifting logic inside `dt_datetime_gdatetime_to_local` in `src/common/datetime.c`.

### Testing & Verification Approach
- Checked that time string byte shifting uses `memmove` safely to copy the remaining string (including the null terminator) when shifting from 3-byte ratio to 1-byte colon.

### Regression Safety
Shifts are safe and bounds-checked to prevent buffer overruns or memory corruption.

### Development Note
This pull request was prepared with AI-assisted pair-programming (using the Gemini-powered Antigravity agent), and has been manually reviewed and refined for correctness.
