### PR TITLE
Add documentation comment to power function in example_basic.c

### DIFF
--- a/src/external/LuaAutoC/examples/example_basic.c
+++ b/src/external/LuaAutoC/examples/example_basic.c
@@ -1,5 +1,6 @@
 #include "../lautoc.h"
 
+// 计算浮点数 val 的 pow 次幂。
 float power(float val, int pow) {
   float x = 1.0;
   for(int i = 0; i < pow; i++) {


### PR DESCRIPTION
### Problem
The `power` function in `src/external/LuaAutoC/examples/example_basic.c` lacks a documentation comment, making it harder to understand its purpose and parameters, which negatively impacts code readability and maintenance.

### Solution
Added a single-line comment to the function to describe its behavior: "计算浮点数 val 的 pow 次幂。" (Calculates the pow-th power of floating-point number val.). This aligns with the codebase's style for improving clarity without altering functionality.

### Verification
The change is purely additive documentation and does not affect the program's logic or external behavior. It can be verified by reviewing the added comment for accuracy and consistency with the codebase standards.