### PR TITLE
scroll: replace dx + dy with dominant axis, correct sign

### DIFF
--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -508,13 +508,21 @@ static gboolean _popup_scroll(GtkWidget *widget,
                               gpointer user_data)
 {
   dt_bauhaus_widget_t *w = darktable.bauhaus->current;
-  int delta_y = 0;
-  if(dt_gui_get_scroll_unit_delta(event, &delta_y))
+  if(w->type == DT_BAUHAUS_COMBOBOX)
   {
-    if(w->type == DT_BAUHAUS_COMBOBOX)
-      _combobox_next_sensitive(w, delta_y, 0, w->combobox.mute_scrolling);
-    else
-      _slider_zoom_range(w, delta_y);
+    // match keyboard: right & down -> next
+    int delta_x = 0, delta_y = 0;
+    if(dt_gui_get_scroll_unit_deltas(event, &delta_x, &delta_y))
+    {
+      int delta = abs(delta_x) > abs(delta_y) ? delta_x : delta_y;
+      _combobox_next_sensitive(w, delta, 0, w->combobox.mute_scrolling);
+    }
+  }
+  else
+  {
+    int delta = 0;
+    if(dt_gui_get_scroll_unit_delta(event, &delta))
+      _slider_zoom_range(w, delta);
   }
   return TRUE;
 }
@@ -3087,14 +3095,17 @@ static void _widget_scroll(GtkEventControllerScroll *controller,
   {
     gtk_widget_grab_focus(widget);
 
-    int delta = dx + dy;
-    if(delta != 0)
+    int magnitude_x = fabs(dx);
+    int magnitude_y = fabs(dy);
+
+    if(magnitude_x || magnitude_y)
     {
       dt_bauhaus_widget_t *w = (dt_bauhaus_widget_t *)widget;
       _request_focus(w);
 
       if(w->type == DT_BAUHAUS_SLIDER)
       {
+        int delta = magnitude_x > magnitude_y ? -dx : dy;
         const gboolean force = darktable.control->element == DT_ACTION_ELEMENT_FORCE
                             && event->scroll.window == gtk_widget_get_window(widget);
         if(force && dt_modifier_is(event->scroll.state, GDK_SHIFT_MASK | GDK_CONTROL_MASK))
@@ -3106,7 +3117,12 @@ static void _widget_scroll(GtkEventControllerScroll *controller,
           _slider_add_step(widget, - delta, event->scroll.state, force);
       }
       else
+      {
+        // match keyboard: right & down -> next
+        int delta = magnitude_x > magnitude_y ? dx : dy;
+
         _combobox_next_sensitive(w, delta, 0, FALSE);
+      }
     }
   }
   if(event) gdk_event_free(event);

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -2368,9 +2368,13 @@ static gboolean _presets_scroll_callback(GtkWidget *widget,
 {
   if(dt_gui_ignore_scroll(event)) return FALSE;
 
-  int delta_y = 0;
-  if(dt_gui_get_scroll_unit_delta(event, &delta_y))
-    dt_gui_presets_apply_adjacent_preset(module, delta_y);
+  // preset cycling: right==down==next
+  int delta_x = 0, delta_y = 0;
+  if(dt_gui_get_scroll_unit_deltas(event, &delta_x, &delta_y))
+  {
+    const int delta = abs(delta_x) > abs(delta_y) ? delta_x : delta_y;
+    dt_gui_presets_apply_adjacent_preset(module, delta);
+  }
 
   return TRUE;
 }

--- a/src/dtgtk/culling.c
+++ b/src/dtgtk/culling.c
@@ -694,10 +694,11 @@ static gboolean _event_scroll(GtkWidget *widget,
     gdouble dx = 0.0, dy = 0.0;
     if(dt_gui_get_scroll_deltas(e, &dx, &dy) && (dx != 0.0 || dy != 0.0))
     {
-    // dt_gui_get_scroll_deltas gives the raw fractional platform delta.
+      // dt_gui_get_scroll_deltas gives the raw fractional platform delta.
       // Scale so that one full unit of scroll (delta_y == 1.0) matches the
-      // 0.5 zoom_delta of a discrete mouse-wheel click.
-      const float zoom_delta = (float)(-(dx + dy) * 0.5);
+      // 0.5 zoom_delta of a discrete mouse-wheel click. right==up==zoom-in
+      const gdouble delta = fabs(dx) > fabs(dy) ? -dx : dy;
+      const float zoom_delta = (float)(-delta * 0.5);
       // convert screen to culling coordinates
       int ox = 0, oy = 0;
       GdkWindow *win = gtk_widget_get_window(table->widget);
@@ -750,12 +751,14 @@ static gboolean _event_scroll(GtkWidget *widget,
     }
   }
 
-  int delta;
-  if(dt_gui_get_scroll_unit_delta(e, &delta))
+  int delta_x = 0, delta_y = 0;
+  if(dt_gui_get_scroll_unit_deltas(e, &delta_x, &delta_y))
   {
+    const gboolean is_horizontal = abs(delta_x) > abs(delta_y);
     if(dt_modifiers_include(e->state, GDK_CONTROL_MASK))
     {
-      // zooming
+      // zooming: right==up==zoom-in
+      const int delta = is_horizontal ? -delta_x : delta_y;
       const float zoom_delta = delta < 0 ? 0.5f : -0.5f;
       // convert screen to culling coordinates
       int ox = 0, oy = 0;
@@ -775,6 +778,8 @@ static gboolean _event_scroll(GtkWidget *widget,
     }
     else
     {
+      // navigation: right==down==next
+      const int delta = is_horizontal ? delta_x : delta_y;
       const int move = delta < 0 ? -1 : 1;
       dt_print(DT_DEBUG_INPUT, "[culling scroll] navigate move=%d", move);
       _thumbs_move(table, move);

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -1121,7 +1121,7 @@ static gboolean _event_scroll(GtkWidget *widget,
                               dt_thumbtable_t *table)
 {
   GdkEventScroll *e = (GdkEventScroll *)event;
-  int delta_x, delta_y;
+  int delta;
 
   // file manager can either scroll fractionally and smoothly for precision
   // touch pads, or in one-thumbnail increments for clicky scroll wheels,
@@ -1129,16 +1129,25 @@ static gboolean _event_scroll(GtkWidget *widget,
   if(table->mode == DT_THUMBTABLE_MODE_FILEMANAGER
       && !dt_modifier_is(e->state, GDK_CONTROL_MASK))
   {
-    gdouble deltaf_x, deltaf_y;
+    gdouble deltaf = 0.f;
     gboolean did_scroll;
     if(dt_conf_get_bool("thumbtable_fractional_scrolling"))
     {
+      gdouble deltaf_x, deltaf_y;
       did_scroll = dt_gui_get_scroll_deltas(e, &deltaf_x, &deltaf_y);
+      if (did_scroll) {
+        // file manager scroll: tilt right (delta_x >) 0 or scroll down (delta_y > 0) -> down (towards the last image)
+        deltaf = fabs(deltaf_x) > fabs(deltaf_y) ? deltaf_x : deltaf_y;
+      }
     }
     else
     {
+      int delta_x, delta_y;
       did_scroll = dt_gui_get_scroll_unit_deltas(e, &delta_x, &delta_y);
-      deltaf_y = (float)delta_y;
+      if (did_scroll)
+      {
+        deltaf = abs(delta_x) > abs(delta_y) ? delta_x : delta_y;
+      }
     }
     if(did_scroll)
     {
@@ -1148,14 +1157,14 @@ static gboolean _event_scroll(GtkWidget *widget,
       {
         table->scroll_timeout_id = g_timeout_add(10, _event_scroll_compressed, table);
       }
-      table->scroll_value += deltaf_y;
+      table->scroll_value += deltaf;
     }
     // we stop here to avoid scrolledwindow to move
     return TRUE;
   }
 
   // filmstrip and zoom mode always use clicky scroll:
-  if(dt_gui_get_scroll_unit_deltas(e, &delta_x, &delta_y))
+  if(dt_gui_get_scroll_unit_delta(e, &delta))
   {
     // for zoomable, scroll = zoom
     if(table->mode == DT_THUMBTABLE_MODE_ZOOM
@@ -1163,7 +1172,7 @@ static gboolean _event_scroll(GtkWidget *widget,
     {
       if(table->mode == DT_THUMBTABLE_MODE_FILMSTRIP)
       {
-        const int sx = CLAMP(table->view_width / ((table->view_width / table->thumb_size / 2 + (delta_x+delta_y)) * 2 + 1),
+        const int sx = CLAMP(table->view_width / ((table->view_width / table->thumb_size / 2 + delta) * 2 + 1),
                              dt_conf_get_int("min_panel_height"),
                              dt_conf_get_int("max_panel_height"));
         dt_ui_panel_set_size(darktable.gui->ui, DT_UI_PANEL_BOTTOM, sx);
@@ -1171,13 +1180,17 @@ static gboolean _event_scroll(GtkWidget *widget,
       else
       {
         const int old = dt_view_lighttable_get_zoom(darktable.view_manager);
-        const int new = CLAMP(old + delta_y, 1, DT_LIGHTTABLE_MAX_ZOOM);
+        const int new = CLAMP(old + delta, 1, DT_LIGHTTABLE_MAX_ZOOM);
         dt_thumbtable_zoom_changed(table, old, new);
       }
     }
     else if(table->mode == DT_THUMBTABLE_MODE_FILMSTRIP)
     {
-      _move(table, -(delta_x+delta_y) * (dt_modifier_is(e->state, GDK_SHIFT_MASK)
+      int delta_x, delta_y;
+      dt_gui_get_scroll_unit_deltas(e, &delta_x, &delta_y);
+      // filmstrip scroll: tilt right (delta_x >) 0 or scroll down (delta_y > 0) -> down (towards the last image)
+      delta = abs(delta_x) > abs(delta_y) ? delta_x : delta_y;
+      _move(table, -delta * (dt_modifier_is(e->state, GDK_SHIFT_MASK)
                   ? table->view_width - table->thumb_size
                   : table->thumb_size), 0, TRUE);
 
@@ -1187,7 +1200,7 @@ static gboolean _event_scroll(GtkWidget *widget,
         dt_control_set_mouse_over_id(th->imgid);
     }
   }
-  // we stop here to avoid scrolledwindow to move
+  // we stop here to avoid scrolled window to move
   return TRUE;
 }
 
@@ -1527,7 +1540,7 @@ static gboolean _event_motion_notify(GtkWidget *widget,
     table->drag_dy += dy;
     if(table->drag_thumb && !table->drag_thumb->moved)
     {
-      // we only considers that this is a real move if the total
+      // we only consider that this is a real move if the total
       // distance is not too low
       table->drag_thumb->moved =
         ((abs(table->drag_dx) + abs(table->drag_dy)) > DT_PIXEL_APPLY_DPI(8));

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -1121,7 +1121,6 @@ static gboolean _event_scroll(GtkWidget *widget,
                               dt_thumbtable_t *table)
 {
   GdkEventScroll *e = (GdkEventScroll *)event;
-  int delta;
 
   // file manager can either scroll fractionally and smoothly for precision
   // touch pads, or in one-thumbnail increments for clicky scroll wheels,
@@ -1164,12 +1163,16 @@ static gboolean _event_scroll(GtkWidget *widget,
   }
 
   // filmstrip and zoom mode always use clicky scroll:
-  if(dt_gui_get_scroll_unit_delta(e, &delta))
+  int delta_x, delta_y;
+
+  if(dt_gui_get_scroll_unit_deltas(e, &delta_x, &delta_y))
   {
     // for zoomable, scroll = zoom
     if(table->mode == DT_THUMBTABLE_MODE_ZOOM
        || dt_modifier_is(e->state, GDK_CONTROL_MASK))
     {
+      // up==right==zoom in
+      const int delta = abs(delta_x) > abs(delta_y) ? -delta_x : delta_y;
       if(table->mode == DT_THUMBTABLE_MODE_FILMSTRIP)
       {
         const int sx = CLAMP(table->view_width / ((table->view_width / table->thumb_size / 2 + delta) * 2 + 1),
@@ -1186,10 +1189,8 @@ static gboolean _event_scroll(GtkWidget *widget,
     }
     else if(table->mode == DT_THUMBTABLE_MODE_FILMSTRIP)
     {
-      int delta_x, delta_y;
-      dt_gui_get_scroll_unit_deltas(e, &delta_x, &delta_y);
       // filmstrip scroll: tilt right (delta_x >) 0 or scroll down (delta_y > 0) -> down (towards the last image)
-      delta = abs(delta_x) > abs(delta_y) ? delta_x : delta_y;
+      const int delta = abs(delta_x) > abs(delta_y) ? delta_x : delta_y;
       _move(table, -delta * (dt_modifier_is(e->state, GDK_SHIFT_MASK)
                   ? table->view_width - table->thumb_size
                   : table->thumb_size), 0, TRUE);

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -4556,7 +4556,8 @@ gboolean dt_shortcut_dispatcher(GtkWidget *w,
       int delta;
       if(middle_click || dt_gui_get_scroll_unit_delta(&event->scroll, &delta))
       {
-        s.speed = middle_click ? -1 : powf(10.0f, delta);
+        // delta < 0 -> 10^(-delta) increases speed
+        s.speed = middle_click ? -1 : powf(10.0f, -delta);
 
         if(_insert_shortcut(&s, TRUE, FALSE))
           dt_control_log("%s", _action_description(&s, 2));

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -4022,16 +4022,19 @@ GtkNotebook *dt_ui_notebook_new(dt_action_def_t *def)
 
 static gboolean _notebook_scroll_callback(GtkNotebook *notebook,
                                           GdkEventScroll *event,
-                                          gpointer user_data)
-{
+                                          gpointer user_data) {
   if(dt_gui_ignore_scroll(event)) return FALSE;
 
-  int delta = 0;
-  if(dt_gui_get_scroll_unit_delta(event, &delta) && delta)
+  int delta_x = 0, delta_y = 0;
+  if(dt_gui_get_scroll_unit_deltas(event, &delta_x, &delta_y))
+  {
+    // RIGHT: delta_x > 0, DOWN: delta_y > 0 -> next, like in filmstrip and lists
+    const int delta = abs(delta_x) > abs(delta_y) ? -delta_x : -delta_y;
     _action_process_tabs(notebook, DT_ACTION_EFFECT_DEFAULT_KEY,
                          delta < 0
                          ? DT_ACTION_EFFECT_NEXT
                          : DT_ACTION_EFFECT_PREVIOUS, delta);
+  }
 
   return TRUE;
 }

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -603,7 +603,8 @@ gboolean dt_gui_get_scroll_delta(const GdkEventScroll *event,
   gdouble delta_x, delta_y;
   if(dt_gui_get_scroll_deltas(event, &delta_x, &delta_y))
   {
-    *delta = delta_x + delta_y;
+    // treat right like up, left like down
+    *delta = fabs(delta_x) > fabs(delta_y) ? -delta_x : delta_y;
     return TRUE;
   }
   return FALSE;
@@ -615,7 +616,8 @@ gboolean dt_gui_get_scroll_unit_delta(const GdkEventScroll *event,
   int delta_x, delta_y;
   if(dt_gui_get_scroll_unit_deltas(event, &delta_x, &delta_y))
   {
-    *delta = delta_x + delta_y;
+    // treat right like up, left like down
+    *delta = abs(delta_x) > abs(delta_y) ? -delta_x : delta_y;
     return TRUE;
   }
   return FALSE;

--- a/src/gui/gtk.h
+++ b/src/gui/gtk.h
@@ -236,7 +236,7 @@ gboolean dt_gui_get_scroll_unit_deltas(const GdkEventScroll *event, int *delta_x
  * So if Shift changes scrolling effect, both scrolls should be handled the same.
  * For this case (or if it's otherwise useful) use the following 2 functions. */
 
-/* Return sum of scroll deltas from event. Return TRUE if any deltas
+/* Return delta of larger magnitude from the event. Return TRUE if any deltas
  * can be retrieved. Handles both GDK_SCROLL_UP/DOWN/LEFT/RIGHT and
  * GDK_SCROLL_SMOOTH style scroll events. */
 gboolean dt_gui_get_scroll_delta(const GdkEventScroll *event, gdouble *delta);

--- a/src/iop/atrous.c
+++ b/src/iop/atrous.c
@@ -1523,7 +1523,7 @@ static gboolean area_scrolled(GtkWidget *widget,
   int delta_y;
   if(dt_gui_get_scroll_unit_delta(event, &delta_y))
   {
-    g->mouse_radius = CLAMP(g->mouse_radius * (1.0 + 0.1 * delta_y), 0.25 / BANDS, 1.0);
+    g->mouse_radius = CLAMP(g->mouse_radius * (1.0 - 0.1 * delta_y), 0.25 / BANDS, 1.0);
     gtk_widget_queue_draw(widget);
   }
   return TRUE;

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -1911,8 +1911,8 @@ static gboolean _area_scrolled_callback(GtkWidget *widget,
     }
     else
     {
-      delta_y *= -DT_IOP_COLORZONES_DEFAULT_STEP;
-      return _move_point_internal(self, widget, g->selected, 0.f, delta_y, event->state);
+      const float dy = delta_y * -DT_IOP_COLORZONES_DEFAULT_STEP;
+      return _move_point_internal(self, widget, g->selected, 0.f, dy, event->state);
     }
   }
 

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -1906,7 +1906,7 @@ static gboolean _area_scrolled_callback(GtkWidget *widget,
     if(g->edit_by_area)
     {
       const int bands = p->curve_num_nodes[g->channel];
-      g->mouse_radius = CLAMP(g->mouse_radius * (1.0 + 0.1 * delta_y), 0.2 / bands, 1.0);
+      g->mouse_radius = CLAMP(g->mouse_radius * (1.0 - 0.1 * delta_y), 0.2 / bands, 1.0);
       gtk_widget_queue_draw(widget);
     }
     else

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -3548,7 +3548,7 @@ static gboolean denoiseprofile_scrolled(GtkWidget *widget,
   int delta_y;
   if(dt_gui_get_scroll_unit_delta(event, &delta_y))
   {
-    g->mouse_radius = CLAMP(g->mouse_radius * (1.f + 0.1f * delta_y),
+    g->mouse_radius = CLAMP(g->mouse_radius * (1.f - 0.1f * delta_y),
                             0.2f / DT_IOP_DENOISE_PROFILE_BANDS, 1.f);
     gtk_widget_queue_draw(widget);
   }

--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -840,6 +840,8 @@ static void _exposure_proxy_handle_event(int n_press,
                                   ? g->deflicker_target_level : g->exposure);
     const float val = dt_bauhaus_slider_get(widget);
     const float accel = dt_accel_get_speed_multiplier(widget, state);
+    // delta > 0 means 'brighten'; increase exposure or move the black point correction
+    // in the negative direction
     if(is_blackpoint)
       delta = -delta;
 

--- a/src/iop/lowlight.c
+++ b/src/iop/lowlight.c
@@ -776,7 +776,7 @@ static gboolean lowlight_scrolled(GtkWidget *widget, GdkEventScroll *event, dt_i
   int delta_y;
   if(dt_gui_get_scroll_unit_delta(event, &delta_y))
   {
-    g->mouse_radius = CLAMP(g->mouse_radius * (1.0 + 0.1 * delta_y), 0.2 / DT_IOP_LOWLIGHT_BANDS, 1.0);
+    g->mouse_radius = CLAMP(g->mouse_radius * (1.0 - 0.1 * delta_y), 0.2 / DT_IOP_LOWLIGHT_BANDS, 1.0);
     gtk_widget_queue_draw(widget);
   }
 

--- a/src/iop/monochrome.c
+++ b/src/iop/monochrome.c
@@ -538,7 +538,7 @@ static gboolean _monochrome_scrolled(GtkWidget *widget, GdkEventScroll *event, d
   if(dt_gui_get_scroll_unit_delta(event, &delta_y))
   {
     const float old_size = p->size;
-    p->size = CLAMP(p->size + delta_y * 0.1, 0.5f, 3.0f);
+    p->size = CLAMP(p->size - delta_y * 0.1, 0.5f, 3.0f);
     if(old_size != p->size) dt_dev_add_history_item(darktable.develop, self, TRUE);
     gtk_widget_queue_draw(widget);
   }

--- a/src/iop/rawdenoise.c
+++ b/src/iop/rawdenoise.c
@@ -857,7 +857,7 @@ static gboolean rawdenoise_scrolled(GtkWidget *widget, GdkEventScroll *event, dt
   int delta_y;
   if(dt_gui_get_scroll_unit_delta(event, &delta_y))
   {
-    g->mouse_radius = CLAMP(g->mouse_radius * (1.0 + 0.1 * delta_y), 0.2 / DT_IOP_RAWDENOISE_BANDS, 1.0);
+    g->mouse_radius = CLAMP(g->mouse_radius * (1.0 - 0.1 * delta_y), 0.2 / DT_IOP_RAWDENOISE_BANDS, 1.0);
     gtk_widget_queue_draw(widget);
   }
 

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -502,7 +502,17 @@ static void _eventbox_scroll_callback(GtkEventControllerScroll* self,
       // FIXME: should handle smooth scrolling rather than discrete?
       // FIXME: should scrolling of scope be handled in the drawable rather than
       //        the eventbox.
-      dt_dev_exposure_handle_event(0, dy - dx, event->scroll.state,
+
+      // get the dominant direction, standardize on delta < 0 => up==right
+      const gdouble delta = fabs(dx) > fabs(dy) ? -dx : dy;
+      // for exposure ('highlight') mode: we want up/right: brighten the image
+      // -> increase exposure, or decrease black point (exposure handles that);
+      // in vectorscope, rgb parade, parts of the visualization moves upwards;
+      // in histogram, to the right.
+      // dt_dev_exposure_handle_event requires 'delta' in the 'brighten' > 0 convention, that is also what
+      // drag events emit
+
+      dt_dev_exposure_handle_event(0, - delta, event->scroll.state,
                                    s->highlight == DT_SCOPES_HIGHLIGHT_BLACK_POINT);
     }
     else

--- a/src/libs/navigation.c
+++ b/src/libs/navigation.c
@@ -544,8 +544,13 @@ static void _lib_navigation_scroll_callback(GtkEventControllerScroll *controller
       if(_lib_navigation_widget_to_center(GTK_EVENT_CONTROLLER(controller),
                                           event->scroll.x, event->scroll.y,
                                           &x, &y))
+      {
+        const double delta = fabs(dx) > fabs(dy) ? -dx : dy;
+        const gboolean zoom_in = delta < 0;
+
         dt_dev_zoom_move(&darktable.develop->full, DT_ZOOM_SCROLL,
-                         0.0f, dy < 0, x, y, constrain);
+                         0.0f, zoom_in, x, y, constrain);
+      }
     }
     gdk_event_free(event);
   }

--- a/src/libs/scopes/vectorscope.c
+++ b/src/libs/scopes/vectorscope.c
@@ -1172,7 +1172,8 @@ static void _vec_eventbox_scroll(dt_scopes_mode_t *const self,
 
   // FIXME: if have own drawable for vectorscope can set scroll handler directly
   // clamp as mouse wheel scrolls sometimes report a delta of 2
-  const int delta = CLAMP(delta_y, -1.0, 1.0);
+  const gdouble dominant_axis_delta = fabs(delta_x) > fabs(delta_y) ? -delta_x : delta_y;
+  const int delta = CLAMP(dominant_axis_delta, -1.0, 1.0);
   if(dt_modifier_is(state, GDK_SHIFT_MASK)) //( SHIFT+SCROLL
   {
     d->harmony_guide.width = (d->harmony_guide.width + delta + DT_COLOR_HARMONY_WIDTH_N)

--- a/src/libs/scopes/vectorscope.c
+++ b/src/libs/scopes/vectorscope.c
@@ -1173,7 +1173,7 @@ static void _vec_eventbox_scroll(dt_scopes_mode_t *const self,
   // FIXME: if have own drawable for vectorscope can set scroll handler directly
   // clamp as mouse wheel scrolls sometimes report a delta of 2
   const gdouble dominant_axis_delta = fabs(delta_x) > fabs(delta_y) ? -delta_x : delta_y;
-  const int delta = CLAMP(dominant_axis_delta, -1.0, 1.0);
+  const int delta = (int) CLAMP(dominant_axis_delta, -1.0, 1.0);
   if(dt_modifier_is(state, GDK_SHIFT_MASK)) //( SHIFT+SCROLL
   {
     d->harmony_guide.width = (d->harmony_guide.width + delta + DT_COLOR_HARMONY_WIDTH_N)
@@ -1181,8 +1181,12 @@ static void _vec_eventbox_scroll(dt_scopes_mode_t *const self,
   }
   else if(dt_modifier_is(state, GDK_MOD1_MASK)) // ALT+SCROLL
   {
+    // we want up, left: previous type; down, right: next type
+    const gdouble dominant_axis_selection_delta = fabs(delta_x) > fabs(delta_y) ? delta_x : delta_y;
+    const int selection_delta = (int) CLAMP(dominant_axis_selection_delta, -1.0, 1.0);
+
     const dt_color_harmony_type_t new_type =
-      (d->harmony_guide.type + delta + DT_COLOR_HARMONY_N) % DT_COLOR_HARMONY_N;
+      (d->harmony_guide.type + selection_delta + DT_COLOR_HARMONY_N) % DT_COLOR_HARMONY_N;
     if(new_type == DT_COLOR_HARMONY_NONE)
       // turn all buttons off
       gtk_toggle_button_set_active

--- a/src/libs/tools/timeline.c
+++ b/src/libs/tools/timeline.c
@@ -1342,10 +1342,11 @@ static gboolean _lib_timeline_scroll_callback(GtkWidget *w, GdkEventScroll *e, d
   }
   else
   {
-    int delta;
-    if(dt_gui_get_scroll_unit_delta(e, &delta))
+    // timeline panning: right==down==forward
+    int delta_x = 0, delta_y = 0;
+    if(dt_gui_get_scroll_unit_deltas(e, &delta_x, &delta_y))
     {
-      int move = delta;
+      int move = abs(delta_x) > abs(delta_y) ? delta_x : delta_y;
       if(dt_modifier_is(e->state, GDK_SHIFT_MASK)) move *= 2;
 
       _time_add(&(strip->time_pos), move, strip->zoom);

--- a/src/views/map.c
+++ b/src/views/map.c
@@ -2020,30 +2020,32 @@ static gboolean _view_map_scroll_event(GtkWidget *w,
   osm_gps_map_point_get_degrees(p, &lat, &lon);
   if(lib->loc.main.id > 0)
   {
+    const gboolean increase = event->direction == GDK_SCROLL_UP || event->direction == GDK_SCROLL_RIGHT;
+    const gboolean decrease = event->direction == GDK_SCROLL_DOWN || event->direction == GDK_SCROLL_LEFT;
     if(dt_map_location_included(lon, lat, &lib->loc.main.data))
     {
       if(dt_modifier_is(event->state, GDK_SHIFT_MASK))
       {
-        if(event->direction == GDK_SCROLL_DOWN)
+        if(increase)
           lib->loc.main.data.delta1 *= 1.1;
-        else
+        else if(decrease)
           lib->loc.main.data.delta1 /= 1.1;
       }
       else if(dt_modifier_is(event->state, GDK_CONTROL_MASK))
       {
-        if(event->direction == GDK_SCROLL_DOWN)
+        if(increase)
           lib->loc.main.data.delta2 *= 1.1;
-        else
+        else if(decrease)
           lib->loc.main.data.delta2 /= 1.1;
       }
       else
       {
-        if(event->direction == GDK_SCROLL_DOWN)
+        if(increase)
         {
           lib->loc.main.data.delta1 *= 1.1;
           lib->loc.main.data.delta2 *= 1.1;
         }
-        else
+        else if (decrease)
         {
           lib->loc.main.data.delta1 /= 1.1;
           lib->loc.main.data.delta2 /= 1.1;


### PR DESCRIPTION
Scrolling logic used to calculate delta = dx + dy. Two issues:
- usually, we want up and right to mean the same thing (increase a value, a diameter), but up = dy < 0, right = dx > 0, so right was treated as equivalent to down
- diagonals would either amplify or reduce the effect (e.g. moving up (dy < 0) + right (dx > 0) on a touchpad could potentially cancel out) 

Consistency fixes:
- Zoom up/right = in, down/left = out:
  - Darkroom center image zoom (discrete/non-touchpad path)
  - Darkroom 2nd window zoom
  - Color zones zoom (hold a)
  - Slider pop-up zoom (resolution/range)
  - Timeline zoom (Ctrl+scroll)

- Value: up/right = increase / down/left = decrease
  - Sliders — value up/down and the reversed left/right tilt
  - Color correction — saturation
  - Tone equalizer — brighten/darken on hover
  - Graduated density — density (Ctrl) and hardness (Shift)
  - Liquify — stamp size, effect strength, and rotate direction
  - Zone system — number of zones

- effect circle: up/right = enlarge, down/left = shrink
  - Contrast equalizer (atrous), denoise (profiled), raw denoise, lowlight, color zones (edit-by-area) -- feedback circles
  - Monochrome — selection circle radius
  - Rotate & perspective — analysis selection radius

- Mask / shape scale: up/right = increase, down/left = decrease
  - Drawn mask overlays — circle, ellipse, brush, path, gradient, object, group

- Node / handle / marker move: up/right = move up; down/left: down
  - Base curve / tone curve / RGB curves — point up/down
  - Color equalizer — graph nodes up/down
  - RGB levels / levels — histogram handles
  - Retouch — wavelet/decomposition bar (top slider, bottom slider, dot position)
  - Gradient slider active marker (e.g. retouch wavelet-scale preview handle)

fix for issues listed in #20843 (plus a few others identified later)

Release notes:
> Consistent zoom and scroll behaviour in the UI:
>  - zoom: scrolling up/down zooms in/out; in most cases, wheel tilt right/left is also supported;
>  - radius and size adjustments: scrolling up and tilting right increase the value, scrolling down and tilting left decrease it (drawn masks, liquify stamps, rotate and perspective selection radius, and feedback circles in contrast equalizer, denoise (profiled), raw denoise, lowlight, color zones, and monochrome);
>  - navigation/scrolling: scrolling up and tilting left move towards the beginning; scrolling down and tilting right move towards the end (lighttable thumbnails, darkroom filmstrip, GUI lists and comboboxes, notebook tabs)
