### PR TITLE
Proposal: Textual long description for `delimiters for size categories`

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -1526,7 +1526,7 @@
     <type>string</type>
     <default>120|400</default>
     <shortdescription>delimiters for size categories</shortdescription>
-    <longdescription>size categories are used to be able to set different overlays and CSS values depending of the size of the thumbnail, separated by |.\nfor example, 120|400 means 3 categories of thumbnails: &lt;120px, 120-400px, >400px</longdescription>
+    <longdescription>size categories are used to be able to set different overlays and CSS values depending of the size of the thumbnail, separated by |.\nfor example, 120|400 means 3 categories of thumbnails: up to 120px, 120-400px, more than 400px</longdescription>
   </dtconfig>
   <dtconfig prefs="lighttable" section="thumbs">
     <name>plugins/lighttable/extended_pattern</name>


### PR DESCRIPTION
For some reason the usage of `&lt;` in `<longdescription>` fails to generate valid markup. A textual form might be better to read anyway.

See #21249, can be reproduced here in english, engl. truecase, french ... The german translation uses a text form so that's working.
I know next to nothing about this translation stuff so there might be a much better way ... 