### PR TITLE
No real need to interpret the markup in global settings tooltips

### DIFF
--- a/tools/generate_prefs.xsl
+++ b/tools/generate_prefs.xsl
@@ -444,7 +444,7 @@ static void init_tab_generated(GtkWidget *dialog, GtkWidget *stack)
     /* xgettext:no-c-format */</xsl:text>
     </xsl:if>
       <xsl:text>
-    gtk_widget_set_tooltip_markup(widget, _("</xsl:text><xsl:value-of select="longdescription"/><xsl:text>"));</xsl:text>
+    gtk_widget_set_tooltip_text(widget, _("</xsl:text><xsl:value-of select="longdescription"/><xsl:text>"));</xsl:text>
   </xsl:if>
     <xsl:if test="@capability">
       <xsl:text>


### PR DESCRIPTION
This reverts a change that broke the display of one of the text tooltips, which was being interpreted as incorrect markup.

Please check, @masterpiga, that this change is safe.

Resolves #21249.
