### PR TITLE
Correct fix for #21249

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -1526,7 +1526,7 @@
     <type>string</type>
     <default>120|400</default>
     <shortdescription>delimiters for size categories</shortdescription>
-    <longdescription>size categories are used to be able to set different overlays and CSS values depending of the size of the thumbnail, separated by |.\nfor example, 120|400 means 3 categories of thumbnails: &lt;120px, 120-400px, >400px</longdescription>
+    <longdescription>size categories are used to be able to set different overlays and CSS values depending on the size of the thumbnail, separated by |.\nfor example, 120|400 means 3 categories of thumbnails: up to 120px, 120-400px, more than 400px</longdescription>
   </dtconfig>
   <dtconfig prefs="lighttable" section="thumbs">
     <name>plugins/lighttable/extended_pattern</name>

--- a/tools/generate_prefs.xsl
+++ b/tools/generate_prefs.xsl
@@ -444,7 +444,7 @@ static void init_tab_generated(GtkWidget *dialog, GtkWidget *stack)
     /* xgettext:no-c-format */</xsl:text>
     </xsl:if>
       <xsl:text>
-    gtk_widget_set_tooltip_text(widget, _("</xsl:text><xsl:value-of select="longdescription"/><xsl:text>"));</xsl:text>
+    gtk_widget_set_tooltip_markup(widget, _("</xsl:text><xsl:value-of select="longdescription"/><xsl:text>"));</xsl:text>
   </xsl:if>
     <xsl:if test="@capability">
       <xsl:text>


### PR DESCRIPTION
This reverts commit fde876bfd8d5dbdda0383f98c4b472bffe25a45c. Reverting to text was a mistake, because adding markup and reusing tooltips in the welcome screen forces us to interpret the markup in the tooltips. Thanks to @masterpiga for pointing this out.

Additionally, the grammatically incorrect phrase "depending of" has been corrected. Should be "depending on".

@TurboGit Yes, this is a violation of string freezing, but it is better to allow one untranslated tooltip than to have it just missing due to a parsing error and clogging up the log with a large number of error messages.