### PR TITLE
tagging: unref GtkEntryCompletion to fix tag-rate slowdown

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -427,6 +427,8 @@ changes (where available).
 - Fixed collection range selection not working if the collection is in
   descending sort order.
 
+- Fix use-after-free bug in tagging code which caused an instant crash
+
 ## Lua
 
 ### API Version

--- a/src/libs/tagging.c
+++ b/src/libs/tagging.c
@@ -3882,6 +3882,12 @@ static void _lib_tagging_tag_show(dt_action_t *action)
                    G_CALLBACK(_match_selected_func), self);
   gtk_entry_completion_set_match_func(completion, _completion_match_func, NULL, NULL);
   gtk_entry_set_completion(GTK_ENTRY(entry), completion);
+  // the entry now holds its own reference to the completion; drop ours so
+  // the completion (and the reference it keeps on the current dictionary
+  // filter) is released when the floating entry is destroyed. Leaking it
+  // pins stale GtkTreeModelFilters to the dictionary store and makes every
+  // later rebuild fan out to all of them (quadratic slowdown over a session).
+  g_object_unref(completion);
   gtk_widget_set_name(entry, "tag-completion");
 
   gtk_editable_select_region(GTK_EDITABLE(entry), 0, -1);


### PR DESCRIPTION
The quick-tag popup leaked its GtkEntryCompletion (the creation ref was never dropped after `gtk_entry_set_completion` took its own). Each leak pinned the current dictionary `GtkTreeModelFilter`. Since `_init_treeview` now recreates the filter on every rebuild, these leaks accumulate stale filters on the dictionary store, making each rebuild fan out to all of them and tagging slow down quadratically over a session. Unref the completion so it and its filter reference are freed with the floating entry.

This is an attempt to fix the issue reported in https://github.com/darktable-org/darktable/pull/21125#issuecomment-4643472397.