### PR TITLE
RELEASE_NOTES.md: Note raster mask PNG export in AI object mask release notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -72,6 +72,9 @@ changes (where available).
   and the lightweight decoder produces masks interactively. Each click
   runs iterative refinement passes that tighten the mask, plus an
   optional DenseCRF refinement pass for clean, edge-aware boundaries.
+  The generated mask can optionally be exported as a PNG for use
+  with the *external raster masks* module when finer edge detail is
+  needed than the vectorized mask provides.
 
 - Added neural restore module in the lighttable/darkroom sidebar
   covering three AI-based tasks: raw denoise, denoise, and


### PR DESCRIPTION
Per reminder on [#20646](https://github.com/darktable-org/darktable/pull/20646#issuecomment-4651545084), the raster mask export added in #20646 wasn't mentioned in the release notes. This PR adds a short note under the existing AI object mask entry.
