### PR TITLE
Control log exiv write error

### DIFF
--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -6127,10 +6127,11 @@ gboolean dt_exif_xmp_write(const dt_imgid_t imgid,
   }
   catch(const Exiv2::AnyError &e)
   {
-    dt_print(DT_DEBUG_IMAGEIO,
+    dt_print(DT_DEBUG_ALWAYS,
              "[dt_exif_xmp_write] %s: caught exiv2 exception '%s'",
              filename,
              e.what());
+    dt_control_log(_("cannot write XMP file '%s': '%s'"), filename, e.what());
     return TRUE;
   }
 }


### PR DESCRIPTION
In case of 'caught exiv2 exception' while trying to write the xmp file, we should
- always report this via log
- also report this via UI control log

Fixes #21280 
 at least the dt UI part of that

As no new strings introduced possible for 5.6