### PR TITLE
Fix calling dt_dev_zoom_move() params

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -1051,7 +1051,7 @@ void dt_dev_configure(dt_dev_viewport_t *port)
     port->width = wd;
     port->height = ht;
     port->pipe->changed |= DT_DEV_PIPE_ZOOMED;
-    dt_dev_zoom_move(port, DT_ZOOM_MOVE, 0.0f, TRUE, 0.0f, 0.0f, TRUE);
+    dt_dev_zoom_move(port, DT_ZOOM_MOVE, 0.0f, 1, 0.0f, 0.0f, TRUE);
   }
 }
 
@@ -3381,9 +3381,10 @@ void dt_dev_zoom_move(dt_dev_viewport_t *port,
     return;
 
   dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_CONTROL | DT_DEBUG_VERBOSE,
-    "dt_dev_zoom_move sets DT_DEV_PIPE_ZOOMED", port->pipe, NULL, DT_DEVICE_NONE, NULL, NULL, "%s%s",
-      port->widget ? "redraw_widget " : "",
-      port == &dev->full ? "navigation_redraw" : "");
+    "dt_dev_zoom_move", port->pipe, NULL, DT_DEVICE_NONE, NULL, NULL,
+      "set DT_DEV_PIPE_ZOOMED%s%s",
+      port->widget ? ", redraw_widget" : "",
+      port == &dev->full ? ", navigation_redraw" : "");
   // Mark pipe as needing zoom update
   port->pipe->changed |= DT_DEV_PIPE_ZOOMED;
 

--- a/src/libs/navigation.c
+++ b/src/libs/navigation.c
@@ -547,7 +547,7 @@ static void _lib_navigation_scroll_callback(GtkEventControllerScroll *controller
                                           &x, &y))
       {
         const double delta = fabs(dx) > fabs(dy) ? -dx : dy;
-        const gboolean zoom_in = delta < 0;
+        const int zoom_in = delta < 0.0 ? 1 : 0;
 
         dt_dev_zoom_move(&darktable.develop->full, DT_ZOOM_SCROLL,
                          0.0f, zoom_in, x, y, constrain);

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -3924,7 +3924,7 @@ void enter(dt_view_t *self)
   }
 
   // image should be there now.
-  dt_dev_zoom_move(&dev->full, DT_ZOOM_MOVE, -1.f, TRUE, 0.0f, 0.0f, TRUE);
+  dt_dev_zoom_move(&dev->full, DT_ZOOM_MOVE, -1.f, 1, 0.0f, 0.0f, TRUE);
 
   /* connect signal for filmstrip image activate */
   DT_CONTROL_SIGNAL_HANDLE(DT_SIGNAL_VIEWMANAGER_THUMBTABLE_ACTIVATE,
@@ -5001,7 +5001,7 @@ static gboolean _second_window_scrolled_callback(GtkWidget *widget,
 
     const gboolean constrained =
       dev->constrain_zoom && !dt_modifier_is(dt_gdk_event_get_state(event), GDK_CONTROL_MASK);
-    dt_dev_zoom_move(port, DT_ZOOM_SCROLL, 0.0f, delta_y < 0,
+    dt_dev_zoom_move(port, DT_ZOOM_SCROLL, 0.0f, delta_y < 0 ? 1 : 0,
                      dt_gdk_event_get_x(event), dt_gdk_event_get_y(event), constrained);
   }
 

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -2010,7 +2010,7 @@ void dt_view_paint_surface(cairo_t *cr,
   if(use_preview_fallback)
   {
     dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_EXPOSE | DT_DEBUG_VERBOSE,
-      "dt_view_paint_surface sets DT_DEV_PIPE_ZOOMED", port->pipe, NULL, DT_DEVICE_NONE, NULL, NULL);
+      "dt_view_paint_surface", port->pipe, NULL, DT_DEVICE_NONE, NULL, NULL, "preview fallback set DT_DEV_PIPE_ZOOMED");
     port->pipe->changed |= DT_DEV_PIPE_ZOOMED;
     if(port->pipe->status == DT_DEV_PIXELPIPE_VALID)
       port->pipe->status = DT_DEV_PIXELPIPE_DIRTY;


### PR DESCRIPTION
The 'closeup' parameter is an 'int' so we don't want to pass bools.
log readability fixes.