### PR TITLE
more intuitive histogram control

### DIFF
--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -848,7 +848,7 @@ static void _exposure_proxy_handle_event(int n_press,
     else if(!n_press)
     { // scroll
       const float step = dt_bauhaus_slider_get_step(widget);
-      dt_bauhaus_slider_set(widget, val + delta * step * accel);
+      dt_bauhaus_slider_set(widget, val - delta * step * accel);
     }
     else
     { // drag


### PR DESCRIPTION
Attempt to make the histogram control by the mouse wheel more intuitive.
Wheel up - moves any edge of the histogram to the right, and wheel down - to the left. Perhaps this is an association with the coordinate axes: the direction to the right, like the direction up, is an increase.