### PR TITLE
Propagate source tags to imported neural restore output

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -86,12 +86,12 @@ changes (where available).
   split preview with area picker, a strength slider (DWT-based texture
   recovery for RGB denoise; linear source/denoised blend for raw
   denoise), batch processing with tiled inference, and automatic
-  library re-import with image grouping. Raw denoise writes a DNG (CFA
-  Bayer or LinearRaw); image denoise and upscale write a TIFF
-  embedding the output ICC profile. GPU acceleration is inherited from
-  the AI backend. If GPU inference fails (out of memory, unsupported
-  operator, execution provider crash), darktable automatically retries
-  on CPU.
+  library re-import with image grouping and tag propagation from the
+  source image. Raw denoise writes a DNG (CFA Bayer or LinearRaw);
+  image denoise and upscale write a TIFF embedding the output ICC profile.
+  GPU acceleration is inherited from the AI backend. If GPU inference
+  fails (out of memory, unsupported operator, execution provider crash),
+  darktable automatically retries on CPU.
 
 - Added `colorharmonizer` module that applies color harmony
   corrections in UCS color space, rotating hues toward a target

--- a/src/libs/neural_restore.c
+++ b/src/libs/neural_restore.c
@@ -202,6 +202,7 @@
 #include "common/grouping.h"
 #include "common/image_cache.h"
 #include "common/mipmap_cache.h"
+#include "common/tags.h"
 #include "control/jobs/control_jobs.h"
 #include "control/signal.h"
 #include "develop/develop.h"
@@ -1003,6 +1004,18 @@ static void _import_image(const char *filename,
       dt_image_cache_read_release(src);
       if(source_is_leader)
         dt_grouping_change_representative(newid);
+
+      // propagate the source's user tags so the output stays visible
+      // in tag-based collections (TRUE = skip darktable|* auto-tags)
+      GList *src_tags = NULL;
+      if(dt_tag_get_attached(source_imgid, &src_tags, TRUE))
+      {
+        GList *targets = g_list_prepend(NULL, GINT_TO_POINTER(newid));
+        for(GList *t = src_tags; t; t = t->next)
+          dt_tag_attach_images(((dt_tag_t *)t->data)->id, targets, FALSE);
+        g_list_free(targets);
+      }
+      dt_tag_free_result(&src_tags);
     }
     // refresh the collection so the new image appears in the thumb grid
     dt_collection_update_query(darktable.collection,


### PR DESCRIPTION
Fixes #21309

When neural restore creates an output (raw denoise → DNG, denoise / upscale → TIFF) and auto-imports it, the new image gets grouped with the source but doesn't inherit its tags. If you're viewing a tag-based collection, the result vanishes from view – easy to misread as a failed import.

This copies the source's user-applied tags over to the new image so it stays visible. Same helper handles all three tasks, so one fix covers raw denoise, denoise, and upscale. `darktable|*` auto-tags are skipped – only what the user actually attached gets copied.