### PR TITLE
Fix two small memory leaks in the camera import dialog

### DIFF
--- a/src/common/camera_control.c
+++ b/src/common/camera_control.c
@@ -1256,7 +1256,11 @@ void dt_camctl_import(const dt_camctl_t *c,
                       const dt_camera_t *cam,
                       GList *images)
 {
-  GList *ifiles = g_list_sort(images, (GCompareFunc)_sort_filename);
+  // Copy the list structure first. g_list_sort sorts in-place and modifies the list nodes,
+  // which would change the head pointer seen by the caller (params->images).
+  // Copying preserves the original list structure so the caller can successfully free it.
+  GList *ifiles = g_list_copy(images);
+  ifiles = g_list_sort(ifiles, (GCompareFunc)_sort_filename);
   char *prev_file = NULL;
   char *prev_output = NULL;
 
@@ -1340,6 +1344,11 @@ void dt_camctl_import(const dt_camctl_t *c,
     prev_file = file;
   }
   g_free(prev_output);
+
+  // Free only the copied list nodes. The actual filename strings are still owned
+  // by the original list 'images' and will be freed by the caller's cleanup handler.
+  // Using g_list_free_full here would result in a use-after-free or double-free.
+  g_list_free(ifiles);
 
   _dispatch_control_status(c, CAMERA_CONTROL_AVAILABLE);
   _camctl_unlock(c);

--- a/src/control/jobs/camera_jobs.c
+++ b/src/control/jobs/camera_jobs.c
@@ -369,7 +369,9 @@ static void dt_camera_import_cleanup(void *p)
 {
   dt_camera_import_t *params = p;
 
-  g_list_free(params->images);
+  // Free the dynamically allocated filename strings in the list, then the list itself.
+  // These strings were allocated by gtk_tree_model_get in import.c:_import_from_dialog_run.
+  g_list_free_full(params->images, g_free);
 
   dt_import_session_destroy(params->shared.session);
 


### PR DESCRIPTION
These were identified and fixed by AI tools as part of https://github.com/darktable-org/darktable/pull/21319 . Created a separate PR at the request of the reviewers there.

The leak in `camera_control.c`  was caused when a caller-allocated list was sorted in `dt_camctl_import()`. When the caller later went to `free` the list, it no longer had access to all of the list elements. Fixed by allocating and later freeing a scope-local shallow copy of the list.

The leak in `camera_jobs.c` was caused by a shallow call to `free`, which orphaned the underlying dynamically-allocated string data. Fixed by changing `g_list_free()` to `g_list_free_full()`.