### PR TITLE
Include filtered Exif, XMP metadata in jpeg-xl according to user's preferences instead of all-or-nothing workaround.

### DIFF
--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -2629,6 +2629,37 @@ gboolean dt_exif_read(dt_image_t *img,
   }
 }
 
+// Filter unwanted Exif tags for export (thumbnails and pixel dimensions for non-compressed)
+static void _filter_exif_for_export(Exiv2::ExifData &exifData, const int compressed)
+{
+  // Remove thumbnail
+  {
+    static const char *keys[] = {
+      "Exif.Thumbnail.Compression",
+      "Exif.Thumbnail.XResolution",
+      "Exif.Thumbnail.YResolution",
+      "Exif.Thumbnail.ResolutionUnit",
+      "Exif.Thumbnail.JPEGInterchangeFormat",
+      "Exif.Thumbnail.JPEGInterchangeFormatLength"
+    };
+    static const guint n_keys = G_N_ELEMENTS(keys);
+    _remove_exif_keys(exifData, keys, n_keys);
+  }
+
+  // Only compressed images may set PixelXDimension and PixelYDimension
+  if(!compressed)
+  {
+    static const char *keys[] = {
+      "Exif.Photo.PixelXDimension",
+      "Exif.Photo.PixelYDimension"
+    };
+    static const guint n_keys = G_N_ELEMENTS(keys);
+    _remove_exif_keys(exifData, keys, n_keys);
+  }
+
+  exifData.sortByTag();
+}
+
 int dt_exif_write_blob(uint8_t *blob,
                        uint32_t size,
                        const char *path,
@@ -2653,32 +2684,7 @@ int dt_exif_write_blob(uint8_t *blob,
       imgExifData.add(Exiv2::ExifKey(i->key()), &i->value());
     }
 
-    {
-      // Remove thumbnail
-      static const char *keys[] = {
-        "Exif.Thumbnail.Compression",
-        "Exif.Thumbnail.XResolution",
-        "Exif.Thumbnail.YResolution",
-        "Exif.Thumbnail.ResolutionUnit",
-        "Exif.Thumbnail.JPEGInterchangeFormat",
-        "Exif.Thumbnail.JPEGInterchangeFormatLength"
-      };
-      static const guint n_keys = G_N_ELEMENTS(keys);
-      _remove_exif_keys(imgExifData, keys, n_keys);
-    }
-
-    // Only compressed images may set PixelXDimension and PixelYDimension.
-    if(!compressed)
-    {
-      static const char *keys[] = {
-        "Exif.Photo.PixelXDimension",
-        "Exif.Photo.PixelYDimension"
-      };
-      static const guint n_keys = G_N_ELEMENTS(keys);
-      _remove_exif_keys(imgExifData, keys, n_keys);
-    }
-
-    imgExifData.sortByTag();
+    _filter_exif_for_export(imgExifData, compressed);
     write_metadata_threadsafe(image);
   }
   catch(const Exiv2::AnyError &e)
@@ -2690,6 +2696,50 @@ int dt_exif_write_blob(uint8_t *blob,
     return 0;
   }
   return 1;
+}
+
+int dt_exif_write_blob_to_buffer(uint8_t *input_blob,
+                                  uint32_t input_size,
+                                  uint8_t **output_blob,
+                                  const int compressed)
+{
+  *output_blob = NULL;
+
+  try
+  {
+    // Decode input Exif blob into memory
+    Exiv2::ExifData exifData;
+    Exiv2::ExifParser::decode(exifData, input_blob, input_size);
+
+    _filter_exif_for_export(exifData, compressed);
+
+    // Encode to buffer
+    Exiv2::Blob blob;
+    Exiv2::ExifParser::encode(blob, Exiv2::bigEndian, exifData);
+
+    const size_t output_size = blob.size();
+    *output_blob = (uint8_t *)g_malloc(output_size);
+    if(!*output_blob)
+    {
+      dt_print(DT_DEBUG_IMAGEIO, "[exif] could not allocate output buffer of size %zu", output_size);
+      return 0;
+    }
+
+    memcpy(*output_blob, blob.data(), output_size);
+    return (int)output_size;
+  }
+  catch(const Exiv2::AnyError &e)
+  {
+    dt_print(DT_DEBUG_IMAGEIO,
+             "[exiv2 dt_exif_write_blob_to_buffer] %s",
+             e.what());
+    if(*output_blob)
+    {
+      g_free(*output_blob);
+      *output_blob = NULL;
+    }
+    return 0;
+  }
 }
 
 static void _remove_exif_geotag(Exiv2::ExifData &exifData)

--- a/src/common/exif.h
+++ b/src/common/exif.h
@@ -95,6 +95,11 @@ void dt_exif_img_check_additional_tags(dt_image_t *img, const char *filename);
 /** write blob to file exif. merges with existing exif information.*/
 int dt_exif_write_blob(uint8_t *blob, uint32_t size, const char *path, const int compressed);
 
+/** write filtered exif blob to memory buffer (in-memory filtering, no temporary files).
+ * caller must free output_blob with g_free().
+ * returns size of output buffer, or 0 on error. */
+int dt_exif_write_blob_to_buffer(uint8_t *input_blob, uint32_t input_size, uint8_t **output_blob, const int compressed);
+
 /** write xmp sidecar file. */
 /** if force_write is FALSE, the current contents of the sidecar file are compared against what
     would be written, and the write is skipped if they are the same.  This preserves the sidecar

--- a/src/imageio/format/jxl.c
+++ b/src/imageio/format/jxl.c
@@ -309,8 +309,8 @@ int write_image(struct dt_imageio_module_data_t *data,
   if(exif && exif_len > 0)
     LIBJXL_ASSERT(JxlEncoderUseBoxes(encoder));
 
-  /* TODO: workaround; remove when exiv2 implements JXL BMFF write support and use dt_exif_write_blob() after
-   * closing file instead */
+  // Embed metadata into JXL BMFF container
+  // Note: exif must be provided already filtered from imageio.c
   if(exif && exif_len > 0)
   {
     // Prepend the 4 byte (zero) offset to the blob before writing
@@ -319,20 +319,16 @@ int write_image(struct dt_imageio_module_data_t *data,
     if(!exif_buf)
       JXL_FAIL("could not allocate Exif buffer of size %zu", (size_t)(exif_len + 4));
     memmove(exif_buf + 4, exif, exif_len);
-    // Exiv2 < 0.28 doesn't support Brotli compressed boxes
-    LIBJXL_ASSERT(JxlEncoderAddBox(encoder, "Exif", exif_buf, exif_len + 4, JXL_FALSE));
+    LIBJXL_ASSERT(JxlEncoderAddBox(encoder, "Exif", exif_buf, exif_len + 4, JXL_TRUE));
   }
 
-  /* TODO: workaround; remove when exiv2 implements JXL BMFF write support and update flags() */
-  /* TODO: workaround; uses valid exif as a way to indicate ALL metadata was requested */
-  if(exif && exif_len > 0)
+  if(exif && exif_len > 0) // TODO separate signal for "include XMP"
   {
     xmp_string = dt_exif_xmp_read_string(imgid);
     size_t xmp_len;
     if(xmp_string
        && (xmp_len = strlen(xmp_string)) > 0)
     {
-      // Exiv2 < 0.28 doesn't support Brotli compressed boxes
       LIBJXL_ASSERT(JxlEncoderAddBox(encoder, "xml ",
                                      (const uint8_t *)xmp_string, xmp_len, JXL_FALSE));
     }
@@ -434,14 +430,12 @@ int levels(dt_imageio_module_data_t *data)
 
 int flags(dt_imageio_module_data_t *data)
 {
-  /*
-   * As of exiv2 0.27.5 there is no write support for the JXL BMFF format,
-   * so we do not return the XMP supported flag currently.
-   * Once exiv2 write support is there, the flag can be returned, and the
-   * direct XMP embedding workaround using JxlEncoderAddBox("xml ") above
-   * can be removed.
-   */
-  return 0; /* FORMAT_FLAGS_SUPPORT_XMP; */
+#if defined(EXV_ENABLE_BMFF) && defined(EXV_HAVE_BROTLI)
+  // exiv2 >= 0.28 with JXL BMFF format and Brotli compression
+  return FORMAT_FLAGS_SUPPORT_XMP;
+#else
+  return 0;
+#endif
 }
 
 static inline int _bpp_to_enum(int bpp)

--- a/src/imageio/format/jxl.c
+++ b/src/imageio/format/jxl.c
@@ -322,18 +322,6 @@ int write_image(struct dt_imageio_module_data_t *data,
     LIBJXL_ASSERT(JxlEncoderAddBox(encoder, "Exif", exif_buf, exif_len + 4, JXL_TRUE));
   }
 
-  if(exif && exif_len > 0) // TODO separate signal for "include XMP"
-  {
-    xmp_string = dt_exif_xmp_read_string(imgid);
-    size_t xmp_len;
-    if(xmp_string
-       && (xmp_len = strlen(xmp_string)) > 0)
-    {
-      LIBJXL_ASSERT(JxlEncoderAddBox(encoder, "xml ",
-                                     (const uint8_t *)xmp_string, xmp_len, JXL_FALSE));
-    }
-  }
-
   JxlPixelFormat pixel_format = { 3, JXL_TYPE_FLOAT, JXL_NATIVE_ENDIAN, 0 };
 
   // Fix pixel stride

--- a/src/imageio/imageio.c
+++ b/src/imageio/imageio.c
@@ -1477,7 +1477,6 @@ gboolean dt_imageio_export_with_flags(const dt_imgid_t imgid,
      && (!strcmp(format->mime(NULL), "image/avif")
          || !strcmp(format->mime(NULL), "image/heif")
          || !strcmp(format->mime(NULL), "image/x-exr")
-         || !strcmp(format->mime(NULL), "image/jxl")
          || !strcmp(format->mime(NULL), "image/x-xcf")))
   {
     const int32_t meta_all =
@@ -1487,7 +1486,43 @@ gboolean dt_imageio_export_with_flags(const dt_imgid_t imgid,
     md_flags_set = metadata ? (metadata->flags & meta_all) == meta_all : FALSE;
   }
 
-  if(!ignore_exif && md_flags_set)
+  // Some formats expect to add metadata in the encoder instead of re-opening the file with exiv2.
+  gboolean md_encoder_adds_exif = !strcmp(format->mime(NULL), "image/jxl");
+
+  if (!ignore_exif && md_encoder_adds_exif)
+  {
+    uint8_t *exif_profile0 = NULL; // Exif data should be 65536 bytes
+                                  // max, but if original size is
+                                  // close to that, adding new tags
+                                  // could make it go over that... so
+                                  // let it be and see what happens
+                                  // when we write the image
+    char pathname[PATH_MAX] = { 0 };
+    gboolean from_cache = TRUE;
+    dt_image_full_path(imgid, pathname, sizeof(pathname), &from_cache);
+
+    // Read unfiltered exif from source image
+    uint8_t *exif_profile0 = NULL;
+    const int length0 = dt_exif_read_blob(&exif_profile0, pathname, imgid, sRGB,
+                                          processed_width, processed_height, FALSE);
+
+    // Filter metadata in-memory (no temporary files needed)
+    uint8_t *filtered_exif = NULL;
+    int filtered_exif_len = 0;
+    if(!ignore_exif && md_flags_set && exif_profile0 && length0 > 0)
+    {
+      filtered_exif_len = dt_exif_write_blob_to_buffer(exif_profile0, length0, &filtered_exif, 1);
+    }
+    free(exif_profile0);
+
+    // write image with filtered metadata
+    res = (format->write_image(format_params, filename, outbuf, icc_type,
+                              icc_filename, filtered_exif, filtered_exif_len, imgid,
+                              num, total, &pipe, export_masks)) != 0;
+
+    g_free(filtered_exif);
+  }
+  else if(!ignore_exif && md_flags_set)
   {
     uint8_t *exif_profile = NULL; // Exif data should be 65536 bytes
                                   // max, but if original size is

--- a/src/imageio/imageio.c
+++ b/src/imageio/imageio.c
@@ -1492,11 +1492,11 @@ gboolean dt_imageio_export_with_flags(const dt_imgid_t imgid,
   if (!ignore_exif && md_encoder_adds_exif)
   {
     uint8_t *exif_profile0 = NULL; // Exif data should be 65536 bytes
-                                  // max, but if original size is
-                                  // close to that, adding new tags
-                                  // could make it go over that... so
-                                  // let it be and see what happens
-                                  // when we write the image
+                                   // max, but if original size is
+                                   // close to that, adding new tags
+                                   // could make it go over that... so
+                                   // let it be and see what happens
+                                   // when we write the image
     char pathname[PATH_MAX] = { 0 };
     gboolean from_cache = TRUE;
     dt_image_full_path(imgid, pathname, sizeof(pathname), &from_cache);


### PR DESCRIPTION
Filter Exif data in memory, then write using the jpeg-xl encoder.  This method is appropriate for jpeg-xl and might be appropriate for the other special-cased formats.

In jpeg-xl the Exif data [does not affect rendering](https://github.com/ImageMagick/jpeg-xl/blob/main/doc/format_overview.md#metadata-versus-image-data), but obviously we like to have it. Some people prefer to have Exif at the beginning of the file, which we do here.

Since the encoder is capable of adding metadata, I like this method better than what darktable does for most formats (re-opens the file later to add metadata).  Having the encoder add all the metadata greatly reduces the concern that older versions of Exiv2, or Exiv2 compiled without brotli support, are unable to read it.

My version of Exiv2 _is_ able to add the XMP metadata in an `"xml "` box at the end of the file. It would be nice to add the XMP metadata in the encoder as well, but this would require more refactors in `imageio.c` and a way to pass "should write xmp?" to `jxl.c`.

When exporting to jpeg-xl using this patch, e.g. `$ jxlinfo -v P1180022.jxl` shows that the file includes both Exif and xml (XMP) metadata.

```
box: type: "JXL " size: 12, contents size: 4
JPEG XL file format container (ISO/IEC 18181-2)
box: type: "ftyp" size: 20, contents size: 12
box: type: "jxlp" size: 30, contents size: 22
JPEG XL image, 3464x4610, lossy, 12-bit RGB
num_color_channels: 3
num_extra_channels: 0
intensity_target: 10000.000000 nits
min_nits: 0.000000
relative_to_max_display: 0
linear_below: 0.000000
have_preview: 0
have_animation: 0
Intrinsic dimensions: 3464x4610
Orientation: 1 (Normal)
Color space: RGB, D65, Rec.2100 primaries, PQ transfer function, rendering intent: Perceptual
box: type: "brob" size: 12690, contents size: 12682
Brotli-compressed Exif metadata: 12690 compressed bytes
box: type: "brob" size: 1898, contents size: 1890
Brotli-compressed xml  metadata: 1898 compressed bytes
box: type: "jxlp" size: 4034, contents size: 4026
```

This PR builds on, includes https://github.com/darktable-org/darktable/pull/21342