### PR TITLE
Fix dt_seg_load discarding env provider override on CPU fallback

### DIFF
--- a/src/common/ai/segmentation.c
+++ b/src/common/ai/segmentation.c
@@ -303,9 +303,11 @@ dt_seg_context_t *dt_seg_load(dt_ai_environment_t *env, const char *model_id)
   if(!env || !model_id)
     return NULL;
 
-  // use the user's configured provider for the encoder (the heavy part)
+  // honour explicit env override (e.g. CPU fallback after a CoreML failure);
+  // CONFIGURED would re-read conf and lose the override
+  const dt_ai_provider_t enc_provider = dt_ai_env_get_provider(env);
   dt_ai_context_t *encoder
-    = dt_ai_load_model(env, model_id, "encoder.onnx", DT_AI_PROVIDER_CONFIGURED);
+    = dt_ai_load_model(env, model_id, "encoder.onnx", enc_provider);
   if(!encoder)
   {
     dt_print(DT_DEBUG_AI, "[segmentation] failed to load encoder for %s", model_id);


### PR DESCRIPTION
User report: <https://discuss.pixls.us/t/darktable-ai-masking-analyses-failing-multiiple-selections-no-longer-working/58687/5>

## The bug

After a CoreML encoder failure (`Feature ... required but not specified`, a known CoreML cache-poisoning issue), [object.c:391-405](src/develop/masks/object.c#L391-L405) sets the env provider to CPU and retries `dt_seg_load`. But `dt_seg_load` was asking for the encoder with `DT_AI_PROVIDER_CONFIGURED` — a sentinel that tells `_resolve_provider` to re-read `plugins/ai/provider` from conf, ignoring `env->provider`. So the override was dropped and CoreML got loaded a second time, hitting the same poisoned cache:

```
[object mask] encoding failed, retrying with CPU provider
[darktable_ai] CoreML format: NeuralNetwork        ← still CoreML
[segmentation] encoder failed: -3                  ← same error
```

## The fix

Pass `env->provider` directly instead of `DT_AI_PROVIDER_CONFIGURED`. First-load behaviour unchanged — env was initialised from the same conf string. Decoder still pinned to CPU as before.