### PR TITLE
Fix neural denoise/upscale grouping logic when input image is not the group leader

### DIFF
--- a/src/libs/neural_restore.c
+++ b/src/libs/neural_restore.c
@@ -996,8 +996,10 @@ static void _import_image(const char *filename,
     if(dt_is_valid_imgid(source_imgid))
     {
       const dt_image_t *src = dt_image_cache_get(source_imgid, 'r');
-      // get source image group ID; fallback to source_imgid if cache miss to avoid invalid 0 (NO_IMGID) group ID
-      const dt_imgid_t grpid = (src && dt_is_valid_imgid(src->group_id)) ? src->group_id : source_imgid;
+      // get source image group ID; fallback to source_imgid if cache miss to
+      // avoid invalid 0 (NO_IMGID) group ID
+      const dt_imgid_t grpid = (src && dt_is_valid_imgid(src->group_id)) ?
+        src->group_id : source_imgid;
       dt_image_cache_read_release(src);
       dt_grouping_add_to_group(grpid, newid);
       // promote the output as group leader, but only when the source

--- a/src/libs/neural_restore.c
+++ b/src/libs/neural_restore.c
@@ -995,13 +995,15 @@ static void _import_image(const char *filename,
     dt_print(DT_DEBUG_AI, "[neural_restore] imported imgid=%d: %s", newid, filename);
     if(dt_is_valid_imgid(source_imgid))
     {
-      dt_grouping_add_to_group(source_imgid, newid);
+      const dt_image_t *src = dt_image_cache_get(source_imgid, 'r');
+      // get source image group ID; fallback to source_imgid if cache miss to avoid invalid 0 (NO_IMGID) group ID
+      const dt_imgid_t grpid = (src && dt_is_valid_imgid(src->group_id)) ? src->group_id : source_imgid;
+      dt_image_cache_read_release(src);
+      dt_grouping_add_to_group(grpid, newid);
       // promote the output as group leader, but only when the source
       // was the current leader — preserves any manually-set leader the
       // user deliberately chose
-      const dt_image_t *src = dt_image_cache_get(source_imgid, 'r');
-      const gboolean source_is_leader = src && src->group_id == source_imgid;
-      dt_image_cache_read_release(src);
+      const gboolean source_is_leader = (grpid == source_imgid);
       if(source_is_leader)
         dt_grouping_change_representative(newid);
 

--- a/src/libs/neural_restore.c
+++ b/src/libs/neural_restore.c
@@ -1075,8 +1075,10 @@ static void _import_image(const char *filename,
       }
 
       const dt_image_t *src = dt_image_cache_get(source_imgid, 'r');
-      // get source image group ID; fallback to source_imgid if cache miss to avoid invalid 0 (NO_IMGID) group ID
-      const dt_imgid_t grpid = (src && dt_is_valid_imgid(src->group_id)) ? src->group_id : source_imgid;
+      // get source image group ID; fallback to source_imgid if cache miss to
+      // avoid invalid 0 (NO_IMGID) group ID
+      const dt_imgid_t grpid = (src && dt_is_valid_imgid(src->group_id)) ?
+        src->group_id : source_imgid;
       dt_image_cache_read_release(src);
       dt_grouping_add_to_group(grpid, newid);
 

--- a/src/libs/neural_restore.c
+++ b/src/libs/neural_restore.c
@@ -1074,13 +1074,16 @@ static void _import_image(const char *filename,
         g_list_free_full(meta, g_free);
       }
 
-      dt_grouping_add_to_group(source_imgid, newid);
+      const dt_image_t *src = dt_image_cache_get(source_imgid, 'r');
+      // get source image group ID; fallback to source_imgid if cache miss to avoid invalid 0 (NO_IMGID) group ID
+      const dt_imgid_t grpid = (src && dt_is_valid_imgid(src->group_id)) ? src->group_id : source_imgid;
+      dt_image_cache_read_release(src);
+      dt_grouping_add_to_group(grpid, newid);
+
       // promote the output as group leader, but only when the source
       // was the current leader — preserves any manually-set leader the
       // user deliberately chose
-      const dt_image_t *src = dt_image_cache_get(source_imgid, 'r');
-      const gboolean source_is_leader = src && src->group_id == source_imgid;
-      dt_image_cache_read_release(src);
+      const gboolean source_is_leader = (grpid == source_imgid);
       if(source_is_leader)
         dt_grouping_change_representative(newid);
 


### PR DESCRIPTION
This PR fixes a bug in the neural_restore functions (raw denoise, denoise, and upscale) where the result of the operation would not be grouped with the input image unless the input image was its group leader. Image groups in darktable are identified by their group leader (see src/common/grouping.c). Previously, the "group with original" logic was just calling `dt_grouping_add_to_group()` with the input image's ID, which isn't necessarily the same as the input image's group ID.

*disclosure: bug identified and fixed in part by AI tools with close human supervision*