### PR TITLE
Copy source metadata when running neural denoise/upscale

### DIFF
--- a/dev-doc/AI.md
+++ b/dev-doc/AI.md
@@ -497,8 +497,9 @@ for each task, see **[AI_Tasks.md](AI_Tasks.md)**.
 The neural-restore consumer (denoise / upscale / rawdenoise) writes
 its output to a sibling file (TIFF or DNG), then auto-imports it via
 `_import_image` in `neural_restore.c`. The new image is grouped with
-its source and inherits the source's user-applied tags so the output
-shows up in tag-based collections that contained the source.
+its source and inherits the source's user-applied tags, rating, color
+labels, and other metadata so the output appears in any filtered views
+or collections where the source image does.
 
 ---
 

--- a/src/libs/neural_restore.c
+++ b/src/libs/neural_restore.c
@@ -999,17 +999,11 @@ static void _import_image(const char *filename,
     {
       // retrieve and copy image rating from the source image
       const dt_image_t *src_rate = dt_image_cache_get(source_imgid, 'r');
-      if(src_rate)
-      {
-        const int rating = dt_image_get_xmp_rating(src_rate);
-        dt_image_cache_read_release(src_rate);
-        dt_image_t *img = dt_image_cache_get(newid, 'w');
-        if(img)
-        {
-          dt_image_set_xmp_rating(img, rating);
-          dt_image_cache_write_release(img, DT_IMAGE_CACHE_SAFE);
-        }
-      }
+      const int rating = dt_image_get_xmp_rating(src_rate);
+      dt_image_cache_read_release(src_rate);
+      dt_image_t *img = dt_image_cache_get(newid, 'w');
+      dt_image_set_xmp_rating(img, rating);
+      dt_image_cache_write_release(img, DT_IMAGE_CACHE_SAFE);
 
       // retrieve and copy color labels from the source image
       const int color_labels = dt_colorlabels_get_labels(source_imgid);
@@ -1036,7 +1030,7 @@ static void _import_image(const char *filename,
       GList *meta = dt_metadata_get_list_id(source_imgid);
       if(meta)
       {
-        GList *imgs = g_list_append(NULL, GINT_TO_POINTER(newid));
+        GList *imgs = g_list_prepend(NULL, GINT_TO_POINTER(newid));
         dt_metadata_set_list_id(imgs, meta, FALSE, FALSE);
         g_list_free(imgs);
         g_list_free_full(meta, g_free);
@@ -1066,7 +1060,6 @@ static void _import_image(const char *filename,
 
       // sync metadata changes to sidecar files and trigger UI updates
       dt_image_synch_xmp(newid);
-      DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_METADATA_CHANGED, DT_METADATA_SIGNAL_NEW_VALUE);
     }
     // refresh the collection so the new image appears in the thumb grid
     dt_collection_update_query(darktable.collection,
@@ -1115,6 +1108,8 @@ static gboolean _job_finished_idle(gpointer data)
     for(GList *l = fd->images; l; l = g_list_next(l))
       g_hash_table_remove(d->processing_images, l->data);
     _update_button_sensitivity(d);
+    if (fd->images)
+      DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_METADATA_CHANGED, DT_METADATA_SIGNAL_NEW_VALUE);
   }
   g_list_free(fd->images);
   g_free(fd);

--- a/src/libs/neural_restore.c
+++ b/src/libs/neural_restore.c
@@ -201,6 +201,8 @@
 #include "common/film.h"
 #include "common/grouping.h"
 #include "common/image_cache.h"
+#include "common/colorlabels.h"
+#include "common/metadata.h"
 #include "common/mipmap_cache.h"
 #include "common/tags.h"
 #include "control/jobs/control_jobs.h"
@@ -995,6 +997,51 @@ static void _import_image(const char *filename,
     dt_print(DT_DEBUG_AI, "[neural_restore] imported imgid=%d: %s", newid, filename);
     if(dt_is_valid_imgid(source_imgid))
     {
+      // retrieve and copy image rating from the source image
+      const dt_image_t *src_rate = dt_image_cache_get(source_imgid, 'r');
+      if(src_rate)
+      {
+        const int rating = dt_image_get_xmp_rating(src_rate);
+        dt_image_cache_read_release(src_rate);
+        dt_image_t *img = dt_image_cache_get(newid, 'w');
+        if(img)
+        {
+          dt_image_set_xmp_rating(img, rating);
+          dt_image_cache_write_release(img, DT_IMAGE_CACHE_SAFE);
+        }
+      }
+
+      // retrieve and copy color labels from the source image
+      const int color_labels = dt_colorlabels_get_labels(source_imgid);
+      for(int color = 0; color < DT_COLORLABELS_LAST; color++)
+      {
+        if(color_labels & (1 << color))
+        {
+          dt_colorlabels_set_label(newid, color);
+        }
+      }
+
+      // retrieve and copy manual geolocation metadata
+      dt_image_geoloc_t geoloc;
+      geoloc.longitude = NAN;
+      geoloc.latitude = NAN;
+      geoloc.elevation = NAN;
+      dt_image_get_location(source_imgid, &geoloc);
+      if(!isnan(geoloc.longitude) && !isnan(geoloc.latitude))
+      {
+        dt_image_set_location(newid, &geoloc, FALSE, FALSE);
+      }
+
+      // retrieve and copy database-only metadata like title, description, etc.
+      GList *meta = dt_metadata_get_list_id(source_imgid);
+      if(meta)
+      {
+        GList *imgs = g_list_append(NULL, GINT_TO_POINTER(newid));
+        dt_metadata_set_list_id(imgs, meta, FALSE, FALSE);
+        g_list_free(imgs);
+        g_list_free_full(meta, g_free);
+      }
+
       dt_grouping_add_to_group(source_imgid, newid);
       // promote the output as group leader, but only when the source
       // was the current leader — preserves any manually-set leader the
@@ -1016,6 +1063,10 @@ static void _import_image(const char *filename,
         g_list_free(targets);
       }
       dt_tag_free_result(&src_tags);
+
+      // sync metadata changes to sidecar files and trigger UI updates
+      dt_image_synch_xmp(newid);
+      DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_METADATA_CHANGED, DT_METADATA_SIGNAL_NEW_VALUE);
     }
     // refresh the collection so the new image appears in the thumb grid
     dt_collection_update_query(darktable.collection,


### PR DESCRIPTION
This PR copies the XMP and darktable-only metadata (color label, rating, manually-applied geotags, etc) from the source image to the newly-created one when running neural_restore operations (raw denoise, denoise, or upscale). Previously, only EXIF data and tags were being copied.

*disclaimer: some of this PR was written with AI tools. I have already reviewed it all to the best of my ability*