### PR TITLE
Fixed tiled colorin pipe temperature coeffs

### DIFF
--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -661,17 +661,17 @@ int process_cl(dt_iop_module_t *self,
   {
     for_four_channels(k)
     {
-      pipe->dsc.temperature.coeffs[k] *= coeffs[k];
+      pipe->dsc.temperature.coeffs[k] = chr->D65coeffs[k];
+      // note: tiling takes care about processed_maximum
       pipe->dsc.processed_maximum[k] *= coeffs[k];
     }
-  }
-  dt_print_pipe(DT_DEBUG_PARAMS | DT_DEBUG_PIPE,
-      corrected ? "coeff correction" : "coeff report",
+    dt_print_pipe(DT_DEBUG_PIPE, "coeff correction",
       pipe, self, devid, roi_in, roi_out, "`%s' %.3f(*%.3f) %.3f(*%.3f) %.3f(*%.3f)",
       dt_colorspaces_get_name(d->type, NULL),
       pipe->dsc.temperature.coeffs[0], coeffs[0],
       pipe->dsc.temperature.coeffs[1], coeffs[1],
       pipe->dsc.temperature.coeffs[2], coeffs[2]);
+  }
 
   cl_mem dev_m = NULL, dev_l = NULL, dev_r = NULL;
   cl_mem dev_g = NULL, dev_b = NULL, dev_coeffs = NULL;
@@ -1208,17 +1208,17 @@ void process(dt_iop_module_t *self,
   {
     for_four_channels(k)
     {
-      pipe->dsc.temperature.coeffs[k] *= coeffs[k];
+      pipe->dsc.temperature.coeffs[k] = chr->D65coeffs[k];
+      // note: tiling takes care about processed_maximum
       pipe->dsc.processed_maximum[k] *= coeffs[k];
     }
-  }
-  dt_print_pipe(DT_DEBUG_PARAMS | DT_DEBUG_PIPE,
-      corrected ? "coeff correction" : "coeff report",
+    dt_print_pipe(DT_DEBUG_PIPE, "coeff correction",
       pipe, self, DT_DEVICE_CPU, roi_in, roi_out, "`%s' %.3f(*%.3f) %.3f(*%.3f) %.3f(*%.3f)",
       dt_colorspaces_get_name(d->type, NULL),
       pipe->dsc.temperature.coeffs[0], coeffs[0],
       pipe->dsc.temperature.coeffs[1], coeffs[1],
       pipe->dsc.temperature.coeffs[2], coeffs[2]);
+  }
 
   const gboolean blue_mapping =
     d->blue_mapping && dt_image_is_matrix_correction_supported(&pipe->image);

--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -584,9 +584,6 @@ static void _workicc_changed(GtkWidget *widget, dt_iop_module_t *self)
   }
 }
 
-static const dt_aligned_pixel_t zero = { 0.0f, 0.0f, 0.0f, 0.0f };
-static const dt_aligned_pixel_t one = { 1.0f, 1.0f, 1.0f, 1.0f };
-
 static float lerp_lut(const float *const lut, const float v)
 {
   // TODO: check if optimization is worthwhile!

--- a/src/iop/hlreconstruct/opposed.c
+++ b/src/iop/hlreconstruct/opposed.c
@@ -344,7 +344,7 @@ static float *_process_opposed(dt_iop_module_t *self,
       }
 
       dt_print_pipe(DT_DEBUG_PIPE,
-          "opposed chroma", piece->pipe, self, DT_DEVICE_CPU, roi_in, roi_out,
+          "opposed chroma", piece->pipe, self, DT_DEVICE_CPU, NULL, NULL,
            "%12.7f (%d)%12.7f (%d)%12.7f (%d)%s%s",
           chrominance[0], (int)cnts[0],
           chrominance[1], (int)cnts[1],
@@ -544,7 +544,7 @@ static cl_int process_opposed_cl(dt_iop_module_t *self,
     }
 
     dt_print_pipe(DT_DEBUG_PIPE,
-        "opposed chroma", piece->pipe, self, piece->pipe->devid, roi_in, roi_out,
+        "opposed chroma", piece->pipe, self, piece->pipe->devid, NULL, NULL,
         "%12.7f (%d)%12.7f (%d)%12.7f (%d)%s%s",
         chrominance[0], (int)cnts[0],
         chrominance[1], (int)cnts[1],


### PR DESCRIPTION
Ensure the `pipe->dsc.temperature.coeffs[]` are correctly set to `D65coeffs[]` also if colorin is processed via tiling.

While fixing this and checking for all cases using late_correction:
1. we only want the log info for coeff correction if that happens and only for pipe
2. reduce log line length of opposed chroma calculation, we don't need rois here

@TurboGit this should be for master and 5.6, the bug is not hit often but with smaller graphics cards / large images there would be issues.

@kofa73 pinging you here because of your work on late-correction.