### PR TITLE
Fix tiled temperature setting processed_maximum

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -404,6 +404,9 @@ changes (where available).
   WB. This was due to a missing reset letting the Color Calibration
   module starting with a wrong WB.
 
+- Fixed wrong color coefficients and pipe processed_maximum due to tiling
+  in temperature and colorin modules.
+
 - Avoid speckles when creating drawn masks using the vectorize option
   in the Raster File module.
 

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -522,8 +522,8 @@ static inline void _publish_chroma(dt_dev_pixelpipe_iop_t *piece)
   for_four_channels(k)
   {
     piece->pipe->dsc.temperature.coeffs[k] = d->coeffs[k];
-    piece->pipe->dsc.processed_maximum[k] =
-      d->coeffs[k] * piece->pipe->dsc.processed_maximum[k];
+    // As there are no modules changing processed_maximum this is safe
+    piece->pipe->dsc.processed_maximum[k] = d->coeffs[k];
     chr->wb_coeffs[k] = d->coeffs[k];
   }
   chr->late_correction = (d->preset == DT_IOP_TEMP_D65_LATE);


### PR DESCRIPTION
In tiled mode the processed maximum would grow resulting in bad corrections especially if highlights reconstruction using opposed or laplacian is active.

@TurboGit heavy tiling stress tests also showed this - a clear bug. **this** one and the last PR are the "bad boys" for the issues some people reported with "off-colors"
Integration tests are fine, nothing new.

For example 50mpix images on 2GB cards (or 100mpix on 4GB) could possibly be hit.  


@kofa73 again

Fixes #20043 #20862 