### PR TITLE
Properly tag non-nightly (i.e., not built from master) releases

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -459,7 +459,7 @@ jobs:
         with:
           allowUpdates: true     # required to allow nightly release updates
           removeArtifacts: true  # we don't want to pile up old artifacts in the nightly release
-          tag: nightly
+          tag: ${{ github.ref_name == 'master' && 'nightly' || github.ref_name }}
           prerelease: true
           # We don't want a stable release that is in the process of being prepared
           # and not yet ready for publication to be visible


### PR DESCRIPTION
Before this fix the tag was always `nightly`, even when building the release. This is not critical. All we need to do after that is to set the correct tag when editing the draft. And that's how 5.6.0 was released. But, really, it is better to set the correct tag right away. In addition, this removes the side effect of overwriting the nightly release when building stable release from the tag.
