### PR TITLE
Helping for the amd-app mess

### DIFF
--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -196,7 +196,7 @@ typedef int32_t dt_mask_id_t;
 // version of current performance configuration version
 // if you want to run an updated version of the performance configuration later
 // bump this number and make sure you have an updated logic in dt_configure_runtime_performance()
-#define DT_CURRENT_PERFORMANCE_CONFIGURE_VERSION 19
+#define DT_CURRENT_PERFORMANCE_CONFIGURE_VERSION 20
 #define DT_PERF_INFOSIZE 4096
 
 // every module has to define this:

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -434,7 +434,7 @@ static gboolean _opencl_read_device_config(const int devid)
     cldid->micro_nap = micro_nap;
     cldid->pinned_memory = pinned_memory ? TRUE : FALSE;
     cldid->asyncmode = asyncmode ? TRUE : FALSE;
-    cldid->disabled = disabled ? TRUE : FALSE;
+    cldid->disabled = disabled && dt_conf_get_int("performance_configuration_version_completed") != 19 ? TRUE : FALSE;
     cldid->advantage = advantage;
     cldid->unified_fraction = unified_fraction;
   }

--- a/src/common/opencl_drivers_blacklist.h
+++ b/src/common/opencl_drivers_blacklist.h
@@ -28,7 +28,6 @@ static const gchar *bad_opencl_drivers[] =
 
   "beignet",
   "clover",
-  "amd-app",
 /*
   Neo was originally blacklisted due to improper cache invalidation, but this has been fixed.
   Per Issue 20104, enabling neo for Windows.


### PR DESCRIPTION
The original 'amd-app' OpenCL drivers had not been maintained for > 10yrs and had lead to various issues on old hardware using that driver so we blacklisted it for dt 5.6. As it seems there is no reliable public versioning info available and no chance for a matrix working/not working.

Unfortunately the OpenCL drivers getting installed on windows systems via the AMD support also report themselves as AMD-APP also with recent drivers and hardware.

As we also had a dt OpenCl version bump v5->v6 this leads to disabled devices on fresh installs or updates to 5.6 if the conf entry for overriding blacklisting was false.

This leaves the majority of windows-amd users with a non-functional OpenCL subsystem. Many windows users will not feel good about textual configuring but prefer a simple dt update.

Done here:
1. revert blacklisting amd-app
2. The silent configure version bump re-enables disabled devices so users updating to 5.6.1 or current master / nightly builds won't have to fiddle around.

@TurboGit @gi-man this seems to be the best way right now to me. Would be for master and the 5.6.1 branch.