### PR TITLE
Point in-app help links to /development/ docs unconditionally

### DIFF
--- a/src/common/usermanual_url.c
+++ b/src/common/usermanual_url.c
@@ -236,7 +236,8 @@ char *dt_get_manual_base_url()
   //   <lang> = en / fr ...              (default = en)
 
   // in case of a standard release, append the dt version to the url
-  if(dt_is_dev_version())
+  //TODO: drop the "TRUE ||" if dtdocs resumes per-release snapshots
+  if(TRUE || dt_is_dev_version())
   {
     dt_util_str_cat(&base_url, "development/");
   }


### PR DESCRIPTION
Long-term half of #21417. **This PR does not fix the 5.6 release** – users on already-shipped 5.6 binaries will keep getting 404s until a server-side redirect for `/usermanual/5.6/*` is added separately. This change only ensures the bug stops recurring from 5.8 onward.

### Why

dtdocs stopped publishing per-release snapshots after 5.2, so the URLs we've been constructing for stable builds – e.g. `/usermanual/5.6/en/...` – just 404. The server has manual per-version redirects for 5.0 / 5.2 / 5.4, but 5.6 was missed when it shipped, and the same will recur with every future release as long as we keep encoding the build version in the URL.

### What it does

`dt_get_manual_base_url()` now always emits `/usermanual/development/`, the only modern path dtdocs actually publishes. Dev builds were already emitting that; stable builds now do the same. No per-version redirect rule will be needed for 5.8 or anything after.