### PR TITLE
Fixes #21426.

### DIFF
--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -3601,7 +3601,6 @@ float *dt_dev_get_raster_mask(dt_dev_pixelpipe_iop_t *piece,
       // walk forward using ping-pong buffers
       int buf_idx = 0;
       const float *inmask = start_data;
-      gboolean distorted = FALSE;
 
       for(GList *iter = start_iter; iter; iter = g_list_next(iter))
       {
@@ -3644,7 +3643,6 @@ float *dt_dev_get_raster_mask(dt_dev_pixelpipe_iop_t *piece,
             inmask = out;
             final_roi = roo;
             buf_idx = 1 - buf_idx;
-            distorted = TRUE;
           }
           else if(_distort_piece_roi(it_piece)) goto failure;
         }
@@ -3653,8 +3651,12 @@ float *dt_dev_get_raster_mask(dt_dev_pixelpipe_iop_t *piece,
           break;
       }
 
-      // if we distorted, return a freshly allocated copy (ping-pong bufs are reused)
-      if(distorted)
+      // Any data that does not come from the source module's raster_masks
+      // table (ping-pong buffers and cached intermediate masks) has its
+      // lifetime managed by the pixelpipe, so we must not hand it out
+      // directly. Allocate our own copy and flag it via free_mask so the
+      // caller knows to free it.
+      if(inmask != raster_mask)
       {
         const size_t num_floats = (size_t)final_roi->width * final_roi->height;
         float *result = dt_iop_image_alloc(final_roi->width, final_roi->height, 1);


### PR DESCRIPTION
The bug (a SIGSEGV in blend, regressed by commit c32d613's raster-mask caching): In dt_dev_get_raster_mask, the local raster_mask pointer holds the source-sized mask from the hash table. The walk-forward loop only set the distorted flag when a distort_mask actually ran. On a raster-mask cache hit where the cached boundary was the last geometric step before the target, no distortion runs, so distorted stayed FALSE, the copy step was skipped, and the function returned the source-sized buffer while reporting the target-sized final_roi. The size check passed (target == target), so blend then read past the end of the undersized buffer → crash.

Co-authored by @kofa73 and Codex, reviewed by Claude, PR-ed by me. That was quite some teamwork!