### PR TITLE
Introduce generic theme variants.

### DIFF
--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -7,6 +7,33 @@ endif(USE_OPENCL)
 
 FILE(GLOB THEME_FILES "themes/*.css")
 FILE(COPY ${THEME_FILES} DESTINATION "${DARKTABLE_DATADIR}/themes")
+
+# theme variant manifests carry the labels shown in preferences, so they
+# go through intltool the same way the .desktop and appdata files do
+FILE(GLOB PO_FILES "${CMAKE_CURRENT_SOURCE_DIR}/../po/*.po")
+FILE(GLOB VARIANTS_IN "themes/*.variants.in")
+foreach(variants_in ${VARIANTS_IN})
+  get_filename_component(variants_name ${variants_in} NAME_WE)
+  set(variants_out "${DARKTABLE_DATADIR}/themes/${variants_name}.variants")
+  add_custom_command(
+    OUTPUT ${variants_out}
+    COMMAND ${CMAKE_COMMAND} -E make_directory "${DARKTABLE_DATADIR}/themes"
+    COMMAND sh -c "${intltool_merge_BIN} --desktop-style \"${CMAKE_CURRENT_SOURCE_DIR}/../po\" \"${variants_in}\" \"${variants_out}\""
+    MAIN_DEPENDENCY ${variants_in}
+    DEPENDS ${PO_FILES}
+    )
+  list(APPEND VARIANTS_FILES ${variants_out})
+endforeach()
+if(VARIANTS_FILES)
+  add_custom_target(darktable.theme_variants ALL DEPENDS ${VARIANTS_FILES})
+  # darktable cannot show a theme's options without this file, so building
+  # the binary alone has to produce it too - not only a full `make`
+  add_dependencies(darktable darktable.theme_variants)
+  install(FILES ${VARIANTS_FILES}
+          DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/darktable/themes
+          COMPONENT DTApplication)
+endif()
+
 install(FILES ${THEME_FILES} DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/darktable/themes COMPONENT DTApplication)
 
 #

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -40,6 +40,37 @@
     <default>false</default>
     <shortdescription>modify theme with user tweaks</shortdescription>
   </dtconfig>
+  <dtconfig common="yes">
+    <name>themes/rounded-header</name>
+    <type>bool</type>
+    <default>false</default>
+    <shortdescription>use rounded module's header</shortdescription>
+  </dtconfig>
+  <dtconfig common="yes">
+    <name>themes/focused-module-border</name>
+    <type>bool</type>
+    <default>false</default>
+    <shortdescription>use small border around module</shortdescription>
+  </dtconfig>
+  <dtconfig common="yes">
+    <name>themes/expanded-module-border</name>
+    <type>bool</type>
+    <default>false</default>
+    <shortdescription>use small border around module</shortdescription>
+  </dtconfig>
+  <dtconfig common="yes">
+    <name>themes/colored-accent</name>
+    <type>int</type>
+    <default>0</default>
+    <shortdescription>use colored accent for some UI elements</shortdescription>
+  </dtconfig>
+  <dtconfig common="yes">
+    <name>themes/condensed</name>
+    <type>bool</type>
+    <default>false</default>
+    <shortdescription>condensed panels' controls</shortdescription>
+    <longdescription>use condensed panels' controls in all views</longdescription>
+  </dtconfig>
   <dtconfig prefs="misc" section="accel">
     <name>accel/prefer_focused</name>
     <type>bool</type>
@@ -160,13 +191,6 @@
     <default>triangle</default>
     <shortdescription>marker shape</shortdescription>
     <longdescription>the shape of the slider marker</longdescription>
-  </dtconfig>
-  <dtconfig prefs="misc" section="interface" common="yes" restart="true">
-    <name>themes/condensed</name>
-    <type>bool</type>
-    <default>false</default>
-    <shortdescription>condensed panels' controls</shortdescription>
-    <longdescription>use condensed panels' controls in all views</longdescription>
   </dtconfig>
   <dtconfig prefs="misc" section="interface" common="yes">
     <name>darkroom/ui/auto_module_name_update</name>

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -41,30 +41,6 @@
     <shortdescription>modify theme with user tweaks</shortdescription>
   </dtconfig>
   <dtconfig common="yes">
-    <name>themes/rounded-header</name>
-    <type>bool</type>
-    <default>false</default>
-    <shortdescription>use rounded module's header</shortdescription>
-  </dtconfig>
-  <dtconfig common="yes">
-    <name>themes/focused-module-border</name>
-    <type>bool</type>
-    <default>false</default>
-    <shortdescription>use small border around module</shortdescription>
-  </dtconfig>
-  <dtconfig common="yes">
-    <name>themes/expanded-module-border</name>
-    <type>bool</type>
-    <default>false</default>
-    <shortdescription>use small border around module</shortdescription>
-  </dtconfig>
-  <dtconfig common="yes">
-    <name>themes/colored-accent</name>
-    <type>int</type>
-    <default>0</default>
-    <shortdescription>use colored accent for some UI elements</shortdescription>
-  </dtconfig>
-  <dtconfig common="yes">
     <name>themes/condensed</name>
     <type>bool</type>
     <default>false</default>

--- a/data/themes/chunk-blue-accent-color.css
+++ b/data/themes/chunk-blue-accent-color.css
@@ -1,0 +1,4 @@
+
+@define-color active_module_icon_fg @accent_blue;
+
+@import url("chunk-colored-accent.css");

--- a/data/themes/chunk-blue-expanded-module-border.css
+++ b/data/themes/chunk-blue-expanded-module-border.css
@@ -1,0 +1,4 @@
+
+@define-color plugin_expanded_border_color @accent_blue;
+
+@import url("chunk-expanded-module-border.css");

--- a/data/themes/chunk-blue-focused-module-border.css
+++ b/data/themes/chunk-blue-focused-module-border.css
@@ -1,0 +1,4 @@
+
+@define-color plugin_focus_border_color @accent_blue;
+
+@import url("chunk-focused-module-border.css");

--- a/data/themes/chunk-colored-accent.css
+++ b/data/themes/chunk-colored-accent.css
@@ -1,0 +1,19 @@
+
+#right #module-header > button:first-child:checked,
+#right #basics-header-box > button:first-child:checked
+{
+  color: @active_module_icon_fg;
+}
+
+#right #module-header > button:first-child:hover,
+#right #basics-header-box > button:first-child:hover
+{
+  background-color: black;
+}
+
+#right > box:last-child #module-header
+{
+ background-color: @bg_color;
+ border-radius: 0px;
+ margin-right: 0.9em;
+}

--- a/data/themes/chunk-condensed.css
+++ b/data/themes/chunk-condensed.css
@@ -34,3 +34,12 @@
    min-height: 12px;
    font-size: 0.95em;
 }
+
+#left #module-header,
+#right #module-header,
+#right #basics-header-box
+{
+  border-radius: 0px;
+  margin: 0px;
+  padding: 4px;
+}

--- a/data/themes/chunk-dark-expanded-module-border.css
+++ b/data/themes/chunk-dark-expanded-module-border.css
@@ -1,0 +1,4 @@
+
+@define-color plugin_expanded_border_color shade(@plugin_bg_color, 0.5);
+
+@import url("chunk-expanded-module-border.css");

--- a/data/themes/chunk-dark-focused-module-border.css
+++ b/data/themes/chunk-dark-focused-module-border.css
@@ -1,0 +1,4 @@
+
+@define-color plugin_focus_border_color shade(@plugin_bg_color, 0.5);
+
+@import url("chunk-focused-module-border.css");

--- a/data/themes/chunk-expanded-module-border.css
+++ b/data/themes/chunk-expanded-module-border.css
@@ -1,0 +1,13 @@
+
+/* ensure space for border is reserved for all modules */
+#iop-expander
+{
+  border: 0.1em solid @plugin_bg_color;
+  margin: 0.2em 0.2em 0 0.2em;
+}
+
+/* border for expanded modules */
+#iop-expander.dt_module_expanded
+{
+  border: 0.1em solid @plugin_expanded_border_color;
+}

--- a/data/themes/chunk-focused-module-border.css
+++ b/data/themes/chunk-focused-module-border.css
@@ -1,0 +1,13 @@
+
+/* ensure space for border is reserved for all modules */
+#iop-expander
+{
+  border: 0.1em solid @plugin_bg_color;
+  margin: 0.2em 0.2em 0 0.2em;
+}
+
+/* border for focused modules */
+#iop-expander.dt_module_expanded.dt_module_focus
+{
+  border: 0.1em solid @plugin_focus_border_color;
+}

--- a/data/themes/chunk-green-accent-color.css
+++ b/data/themes/chunk-green-accent-color.css
@@ -1,0 +1,4 @@
+
+@define-color active_module_icon_fg @accent_green;
+
+@import url("chunk-colored-accent.css");

--- a/data/themes/chunk-green-expanded-module-border.css
+++ b/data/themes/chunk-green-expanded-module-border.css
@@ -1,0 +1,4 @@
+
+@define-color plugin_expanded_border_color @accent_green;
+
+@import url("chunk-expanded-module-border.css");

--- a/data/themes/chunk-green-focused-module-border.css
+++ b/data/themes/chunk-green-focused-module-border.css
@@ -1,0 +1,4 @@
+
+@define-color plugin_focus_border_color @accent_green;
+
+@import url("chunk-focused-module-border.css");

--- a/data/themes/chunk-light-expanded-module-border.css
+++ b/data/themes/chunk-light-expanded-module-border.css
@@ -1,0 +1,4 @@
+
+@define-color plugin_expanded_border_color shade(@plugin_bg_color, 2.0);
+
+@import url("chunk-expanded-module-border.css");

--- a/data/themes/chunk-light-focused-module-border.css
+++ b/data/themes/chunk-light-focused-module-border.css
@@ -1,0 +1,4 @@
+
+@define-color plugin_focus_border_color shade(@plugin_bg_color, 2.0);
+
+@import url("chunk-focused-module-border.css");

--- a/data/themes/chunk-orange-accent-color.css
+++ b/data/themes/chunk-orange-accent-color.css
@@ -1,0 +1,4 @@
+
+@define-color active_module_icon_fg @accent_orange;
+
+@import url("chunk-colored-accent.css");

--- a/data/themes/chunk-orange-expanded-module-border.css
+++ b/data/themes/chunk-orange-expanded-module-border.css
@@ -1,0 +1,4 @@
+
+@define-color plugin_expanded_border_color @accent_orange;
+
+@import url("chunk-expanded-module-border.css");

--- a/data/themes/chunk-orange-focused-module-border.css
+++ b/data/themes/chunk-orange-focused-module-border.css
@@ -1,0 +1,4 @@
+
+@define-color plugin_focus_border_color @accent_orange;
+
+@import url("chunk-focused-module-border.css");

--- a/data/themes/chunk-rounded-header.css
+++ b/data/themes/chunk-rounded-header.css
@@ -1,0 +1,28 @@
+
+@define-color header_color shade(@plugin_bg_color, 0.8);
+@define-color header_color_bg shade(@plugin_bg_color, 1.1);
+
+#left #module-header,
+#right #module-header,
+#right #basics-header-box
+{
+  background-color: @header_color;
+  border-radius: 0px;
+}
+
+#left #module-header
+{
+  border-top-right-radius: 15px;
+}
+
+#right #module-header,
+#right #basics-header-box
+{
+  border-top-left-radius: 15px;
+}
+
+#iop-expander,
+.dt_module_expanded
+{
+   background-color: @header_color_bg;
+}

--- a/data/themes/chunk-yellow-accent-color.css
+++ b/data/themes/chunk-yellow-accent-color.css
@@ -1,0 +1,4 @@
+
+@define-color active_module_icon_fg @accent_yellow;
+
+@import url("chunk-colored-accent.css");

--- a/data/themes/chunk-yellow-expanded-module-border.css
+++ b/data/themes/chunk-yellow-expanded-module-border.css
@@ -1,0 +1,4 @@
+
+@define-color plugin_expanded_border_color @accent_yellow;
+
+@import url("chunk-expanded-module-border.css");

--- a/data/themes/chunk-yellow-focused-module-border.css
+++ b/data/themes/chunk-yellow-focused-module-border.css
@@ -1,0 +1,4 @@
+
+@define-color plugin_focus_border_color @accent_yellow;
+
+@import url("chunk-focused-module-border.css");

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -231,6 +231,12 @@ Why that? Just because it's a developer choice and most classes use underscore i
 @define-color colorlabel_yellow rgb(255,180,0);
 @define-color colorlabel_purple rgb(230,0,230);
 
+/* pastel colors for the variants (module borders and active module) */
+@define-color accent_green #C1E1C5;
+@define-color accent_blue #9FBFE2;
+@define-color accent_yellow #E6E6A1;
+@define-color accent_orange #E6C2A1;
+
 /* Reset GTK defaults - Otherwise dt inherits Adwaita default theme dark */
 *
 {
@@ -1337,6 +1343,13 @@ filechooser row:hover .sidebar-icon
 #preferences-box .sidebar label
 {
   padding: 0.14em 0.84em;
+}
+
+#theme-variant
+{
+  margin-left: 2em;
+  padding-left: 0.5em;
+  min-height: 1.5em;
 }
 
 /*--------------------

--- a/data/themes/darktable.variants.in
+++ b/data/themes/darktable.variants.in
@@ -1,0 +1,89 @@
+# Options offered on top of this theme, shown in preferences below the
+# theme selector. Every theme shipped with darktable @imports darktable.css,
+# so all of them inherit this file and none needs a copy.
+#
+# Each group is one control. `$value` in `css` is replaced by the selected
+# option; `css_<option>` overrides it for one option, and an empty value
+# means that option adds no CSS at all.
+#
+# A `[<control>/labels]` group names the options; without one an option
+# shows its own id. Keys prefixed with `_` are translated at build time by
+# intltool, which only accepts letters and digits in a key – so an option
+# id here must be alphanumeric for its label to reach translators. A theme
+# of your own has no such limit: write `light-blue[de]=...` by hand.
+#
+# A theme of your own goes beside your .css as <theme>.variants. Add
+# `inherits=darktable` under a [theme] group to keep these and add your own.
+#
+# A theme without a manifest inherits the one belonging to whatever its CSS
+# @imports. That only reaches a theme installed alongside this file: GTK
+# resolves an @import relative to the importing file, so a theme in
+# ~/.config/darktable/themes cannot import a shipped one. Such a theme has
+# to carry its own CSS in full, and name its parent with `inherits=` – which
+# is looked up by theme name, in the config dir first and then here.
+
+[condensed]
+type=bool
+_label=condensed module controls
+_tooltip=use condensed module controls
+default=false
+css=chunk-condensed.css
+
+[rounded-header]
+type=bool
+_label=rounded module headers
+_tooltip=use rounded corners on module headers
+default=false
+css=chunk-rounded-header.css
+
+[accent-color]
+type=enum
+_label=accent color
+_tooltip=set the theme accent color for the interface
+values=none;green;blue;yellow;orange
+default=none
+css=chunk-$value-accent-color.css
+css_none=
+
+[accent-color/labels]
+_none=none
+_green=green
+_blue=blue
+_yellow=yellow
+_orange=orange
+
+[focused-module-border]
+type=enum
+_label=focused module border
+_tooltip=draw a border around the focused module
+values=none;light;dark;green;blue;yellow;orange
+default=none
+css=chunk-$value-focused-module-border.css
+css_none=
+
+[focused-module-border/labels]
+_none=none
+_light=light
+_dark=dark
+_green=green
+_blue=blue
+_yellow=yellow
+_orange=orange
+
+[expanded-module-border]
+type=enum
+_label=expanded module border
+_tooltip=draw a border around expanded modules
+values=none;light;dark;green;blue;yellow;orange
+default=none
+css=chunk-$value-expanded-module-border.css
+css_none=
+
+[expanded-module-border/labels]
+_none=none
+_light=light
+_dark=dark
+_green=green
+_blue=blue
+_yellow=yellow
+_orange=orange

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -96,6 +96,7 @@ build/lib/darktable/plugins/introspection_vignette.c
 build/lib/darktable/plugins/introspection_watermark.c
 build/lib/darktable/plugins/introspection_zonesystem.c
 build/share/darktable/org.darktable.darktable.desktop.in
+[type: gettext/keys] data/themes/darktable.variants.in
 data/org.darktable.darktable.appdata.xml.in
 data/org.darktable.darktable.desktop.in
 src/bauhaus/bauhaus.c

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -161,6 +161,7 @@ FILE(GLOB SOURCE_FILES
   "gui/splash.c"
   "gui/welcome.c"
   "gui/styles_dialog.c"
+  "gui/theme_variants.c"
   "imageio/imageio.c"
   "imageio/imageio_dng.c"
   "imageio/imageio_jpeg.c"

--- a/src/control/conf.c
+++ b/src/control/conf.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2019-2023 darktable developers.
+    Copyright (C) 2019-2026 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -689,7 +689,10 @@ gboolean dt_confgen_is_common(const char *name)
     return item->is_common;
   }
 
-  return FALSE;
+  // a theme declares its own variants, so those keys are not in
+  // darktableconfig.xml. the theme is loaded before the main config is
+  // read, so they belong in the common file like every other themes/ key
+  return g_str_has_prefix(name, "themes/");
 }
 
 const char *dt_confgen_get_label(const char *name)

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -3709,6 +3709,67 @@ void dt_gui_load_theme(const char *theme)
     _add_theme_import(&themecss, datadir, "themes", "chunk-condensed.css");
   }
 
+  // chunk-rounded-header
+
+  if(dt_conf_get_bool("themes/rounded-header"))
+  {
+    _add_theme_import(&themecss, datadir, "themes", "chunk-rounded-header.css");
+  }
+
+  // chunk-colored-accent
+
+  int index = dt_conf_get_int("themes/accent-color");
+
+  if(index > 0)
+  {
+    const char *colors[] =
+        {
+            "none",
+            "green",
+            "blue",
+            "yellow",
+            "orange"
+        };
+
+    char *chunk = g_strdup_printf
+      ("chunk-%s-accent-color.css",
+       colors[index]);
+    _add_theme_import(&themecss, datadir, "themes", chunk);
+    g_free(chunk);
+  }
+
+  // focused module border
+
+  const char *border_colors[] =
+      {
+          "none",
+          "light",
+          "dark",
+          "green",
+          "blue",
+          "yellow",
+          "orange"};
+
+  index = dt_conf_get_int("themes/focused-module-border");
+
+  if (index > 0)
+  {
+    char *chunk = g_strdup_printf("chunk-%s-focused-module-border.css",
+                                  border_colors[index]);
+    _add_theme_import(&themecss, datadir, "themes", chunk);
+    g_free(chunk);
+  }
+
+  index = dt_conf_get_int("themes/expanded-module-border");
+
+  if (index > 0)
+  {
+    char *chunk = g_strdup_printf("chunk-%s-expanded-module-border.css",
+                                  border_colors[index]);
+    _add_theme_import(&themecss, datadir, "themes", chunk);
+    g_free(chunk);
+  }
+
   // load any OS specific themes tweak file to fix some platform specific issues
 
 #ifdef __APPLE__

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -37,6 +37,7 @@
 #include "dtgtk/thumbtable.h"
 #include "gui/accelerators.h"
 #include "gui/gtk.h"
+#include "gui/theme_variants.h"
 
 #include "common/styles.h"
 #include "common/usermanual_url.h"
@@ -3635,8 +3636,12 @@ void _add_theme_import(char **themecss,
 // load a CSS theme
 void dt_gui_load_theme(const char *theme)
 {
+  // this stores `theme` in ui_last/theme, freeing whatever that key held
+  // – and callers pass exactly that. work from a copy
+  gchar *theme_name = g_strdup(theme);
+
   char theme_css[PATH_MAX] = { 0 };
-  g_snprintf(theme_css, sizeof(theme_css), "%s.css", theme);
+  g_snprintf(theme_css, sizeof(theme_css), "%s.css", theme_name);
 
   if(!dt_conf_key_exists("use_system_font"))
     dt_conf_set_bool("use_system_font", TRUE);
@@ -3673,14 +3678,17 @@ void dt_gui_load_theme(const char *theme)
       // fallback to default theme
       g_free(path);
       // NOTE: When changing the default theme, don't forget to change it here!
-      path = g_build_filename(datadir, "themes", "darktable-elegant-grey.css", NULL);
-      dt_conf_set_string("ui_last/theme", "darktable-elegant-grey");
+      g_free(theme_name);
+      theme_name = g_strdup("darktable-elegant-grey");
+      char *css = g_strconcat(theme_name, ".css", NULL);
+      path = g_build_filename(datadir, "themes", css, NULL);
+      g_free(css);
     }
-    else
-      dt_conf_set_string("ui_last/theme", theme);
   }
-  else
-    dt_conf_set_string("ui_last/theme", theme);
+
+  // whatever actually loaded is what this session is using, and what its
+  // variants are looked up against below
+  dt_conf_set_string("ui_last/theme", theme_name);
 
   GError *error = NULL;
 
@@ -3690,7 +3698,7 @@ void dt_gui_load_theme(const char *theme)
 
   // We load the themes in this specific order:
   //   1. The main darktable-*.css
-  //   2. condensed.css (if enabled)
+  //   2. the chunks the theme's variants select (if any)
   //   3. OS specific tweaks (linux|macos|windows).css (if any)
   //   4. user.css (if enabled)
 
@@ -3702,73 +3710,25 @@ void dt_gui_load_theme(const char *theme)
 
   gchar *themecss = g_strjoin(NULL, "@import url('", path_uri, "');", NULL);
 
-  // chunk-condensed.css
-
-  if(dt_conf_get_bool("themes/condensed"))
+  // the options the theme declares in <theme>.variants, each selecting
+  // one chunk to import after the theme itself
+  GList *variants = dt_theme_variants_load(theme_name);
+  for(GList *v = variants; v; v = g_list_next(v))
   {
-    _add_theme_import(&themecss, datadir, "themes", "chunk-condensed.css");
-  }
+    const dt_theme_variant_t *variant = (const dt_theme_variant_t *)v->data;
+    char *chunk = dt_theme_variant_css(variant, dt_theme_variant_get(variant));
+    if(!chunk) continue;
 
-  // chunk-rounded-header
-
-  if(dt_conf_get_bool("themes/rounded-header"))
-  {
-    _add_theme_import(&themecss, datadir, "themes", "chunk-rounded-header.css");
-  }
-
-  // chunk-colored-accent
-
-  int index = dt_conf_get_int("themes/accent-color");
-
-  if(index > 0)
-  {
-    const char *colors[] =
-        {
-            "none",
-            "green",
-            "blue",
-            "yellow",
-            "orange"
-        };
-
-    char *chunk = g_strdup_printf
-      ("chunk-%s-accent-color.css",
-       colors[index]);
-    _add_theme_import(&themecss, datadir, "themes", chunk);
+    // a user theme may ship its own chunks, so look beside it first
+    char *user = g_build_filename(configdir, "themes", chunk, NULL);
+    _add_theme_import(&themecss,
+                      g_file_test(user, G_FILE_TEST_EXISTS)
+                        ? configdir : datadir,
+                      "themes", chunk);
+    g_free(user);
     g_free(chunk);
   }
-
-  // focused module border
-
-  const char *border_colors[] =
-      {
-          "none",
-          "light",
-          "dark",
-          "green",
-          "blue",
-          "yellow",
-          "orange"};
-
-  index = dt_conf_get_int("themes/focused-module-border");
-
-  if (index > 0)
-  {
-    char *chunk = g_strdup_printf("chunk-%s-focused-module-border.css",
-                                  border_colors[index]);
-    _add_theme_import(&themecss, datadir, "themes", chunk);
-    g_free(chunk);
-  }
-
-  index = dt_conf_get_int("themes/expanded-module-border");
-
-  if (index > 0)
-  {
-    char *chunk = g_strdup_printf("chunk-%s-expanded-module-border.css",
-                                  border_colors[index]);
-    _add_theme_import(&themecss, datadir, "themes", chunk);
-    g_free(chunk);
-  }
+  dt_theme_variants_free(variants);
 
   // load any OS specific themes tweak file to fix some platform specific issues
 
@@ -3810,6 +3770,8 @@ void dt_gui_load_theme(const char *theme)
   g_free(themecss);
 
   g_object_unref(themes_style_provider);
+
+  g_free(theme_name);
 }
 
 void dt_gui_apply_theme()

--- a/src/gui/preferences.c
+++ b/src/gui/preferences.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2010-2025 darktable developers.
+    Copyright (C) 2010-2026 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -202,6 +202,51 @@ static void use_sys_font_callback(GtkWidget *widget,
   else
     gtk_widget_set_state_flags(GTK_WIDGET(user_data), GTK_STATE_FLAG_NORMAL, TRUE);
 
+  reload_ui_last_theme();
+}
+
+static void use_rounded_header_callback(GtkWidget *widget,
+                                        gpointer user_data)
+{
+  dt_conf_set_bool("themes/rounded-header",
+                   gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget)));
+
+  reload_ui_last_theme();
+}
+
+static void use_condensed_control_callback(GtkWidget *widget,
+                                           gpointer user_data)
+{
+  dt_conf_set_bool("themes/condensed",
+                   gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget)));
+
+  reload_ui_last_theme();
+}
+
+static void use_accent_color_callback(GtkWidget *widget,
+                                        gpointer user_data)
+{
+  const int selected = dt_bauhaus_combobox_get(widget);
+
+  dt_conf_set_int("themes/accent-color", selected);
+  reload_ui_last_theme();
+}
+
+static void use_focused_module_border_callback(GtkWidget *widget,
+                                               gpointer user_data)
+{
+  const int selected = dt_bauhaus_combobox_get(widget);
+
+  dt_conf_set_int("themes/focused-module-border", selected);
+  reload_ui_last_theme();
+}
+
+static void use_expanded_module_border_callback(GtkWidget *widget,
+                                                gpointer user_data)
+{
+  const int selected = dt_bauhaus_combobox_get(widget);
+
+  dt_conf_set_int("themes/expanded-module-border", selected);
   reload_ui_last_theme();
 }
 
@@ -412,6 +457,115 @@ static void init_tab_general(GtkWidget *dialog,
   g_signal_connect(G_OBJECT(widget), "value-changed",
                    G_CALLBACK(theme_callback), 0);
   gtk_widget_set_tooltip_text(widget, _("set the theme for the user interface"));
+
+  // theme variants
+
+  // condensed controls
+  GtkWidget *t_condensed = gtk_check_button_new();
+  label = gtk_label_new(_("condensed module controls"));
+  gtk_widget_set_name(label, "theme-variant");
+  gtk_widget_set_halign(label, GTK_ALIGN_START);
+  labelev = gtk_event_box_new();
+  gtk_widget_add_events(labelev, GDK_BUTTON_PRESS_MASK);
+  gtk_container_add(GTK_CONTAINER(labelev), label);
+  gtk_grid_attach(GTK_GRID(grid), labelev, 0, line++, 1, 1);
+  gtk_grid_attach_next_to(GTK_GRID(grid), t_condensed, labelev, GTK_POS_RIGHT, 1, 1);
+  gtk_widget_set_tooltip_text(t_condensed, _("use condensed module controls"));
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(t_condensed),
+                               dt_conf_get_bool("themes/condensed"));
+  g_signal_connect(G_OBJECT(t_condensed), "toggled",
+                   G_CALLBACK(use_condensed_control_callback),
+                  (gpointer)t_condensed);
+
+  // rounded header
+  GtkWidget *t_rounded = gtk_check_button_new();
+  label = gtk_label_new(_("rounded module headers"));
+  gtk_widget_set_name(label, "theme-variant");
+  gtk_widget_set_halign(label, GTK_ALIGN_START);
+  labelev = gtk_event_box_new();
+  gtk_widget_add_events(labelev, GDK_BUTTON_PRESS_MASK);
+  gtk_container_add(GTK_CONTAINER(labelev), label);
+  gtk_grid_attach(GTK_GRID(grid), labelev, 0, line++, 1, 1);
+  gtk_grid_attach_next_to(GTK_GRID(grid), t_rounded, labelev, GTK_POS_RIGHT, 1, 1);
+  gtk_widget_set_tooltip_text(t_rounded, _("use rounded module headers variant"));
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(t_rounded),
+                               dt_conf_get_bool("themes/rounded-header"));
+  g_signal_connect(G_OBJECT(t_rounded), "toggled",
+                   G_CALLBACK(use_rounded_header_callback), (gpointer)t_rounded);
+
+  // focused module border
+  label = gtk_label_new(_("focused module border"));
+  gtk_widget_set_name(label, "theme-variant");
+  gtk_widget_set_halign(label, GTK_ALIGN_START);
+  widget = dt_bauhaus_combobox_new(NULL);
+  dt_bauhaus_combobox_set_selected_text_align(widget, DT_BAUHAUS_COMBOBOX_ALIGN_LEFT);
+
+  labelev = gtk_event_box_new();
+  gtk_widget_add_events(labelev, GDK_BUTTON_PRESS_MASK);
+  gtk_container_add(GTK_CONTAINER(labelev), label);
+  gtk_grid_attach(GTK_GRID(grid), labelev, 0, line++, 1, 1);
+  gtk_grid_attach_next_to(GTK_GRID(grid), widget, labelev, GTK_POS_RIGHT, 1, 1);
+  dt_bauhaus_combobox_add_aligned(widget, _("none"), DT_BAUHAUS_COMBOBOX_ALIGN_LEFT);
+  dt_bauhaus_combobox_add_aligned(widget, _("light"), DT_BAUHAUS_COMBOBOX_ALIGN_LEFT);
+  dt_bauhaus_combobox_add_aligned(widget, _("dark"), DT_BAUHAUS_COMBOBOX_ALIGN_LEFT);
+  dt_bauhaus_combobox_add_aligned(widget, _("green"), DT_BAUHAUS_COMBOBOX_ALIGN_LEFT);
+  dt_bauhaus_combobox_add_aligned(widget, _("blue"), DT_BAUHAUS_COMBOBOX_ALIGN_LEFT);
+  dt_bauhaus_combobox_add_aligned(widget, _("yellow"), DT_BAUHAUS_COMBOBOX_ALIGN_LEFT);
+  dt_bauhaus_combobox_add_aligned(widget, _("orange"), DT_BAUHAUS_COMBOBOX_ALIGN_LEFT);
+  dt_bauhaus_combobox_set(widget, dt_conf_get_int("themes/focused-module-border"));
+  g_signal_connect(G_OBJECT(widget), "value-changed",
+                   G_CALLBACK(use_focused_module_border_callback), 0);
+  gtk_widget_set_tooltip_text(widget,
+                              _("set the focused module border color"));
+
+  // expanded module border
+  label = gtk_label_new(_("expanded module border"));
+  gtk_widget_set_name(label, "theme-variant");
+  gtk_widget_set_halign(label, GTK_ALIGN_START);
+  widget = dt_bauhaus_combobox_new(NULL);
+  dt_bauhaus_combobox_set_selected_text_align(widget, DT_BAUHAUS_COMBOBOX_ALIGN_LEFT);
+
+  labelev = gtk_event_box_new();
+  gtk_widget_add_events(labelev, GDK_BUTTON_PRESS_MASK);
+  gtk_container_add(GTK_CONTAINER(labelev), label);
+  gtk_grid_attach(GTK_GRID(grid), labelev, 0, line++, 1, 1);
+  gtk_grid_attach_next_to(GTK_GRID(grid), widget, labelev, GTK_POS_RIGHT, 1, 1);
+  dt_bauhaus_combobox_add_aligned(widget, _("none"), DT_BAUHAUS_COMBOBOX_ALIGN_LEFT);
+  dt_bauhaus_combobox_add_aligned(widget, _("light"), DT_BAUHAUS_COMBOBOX_ALIGN_LEFT);
+  dt_bauhaus_combobox_add_aligned(widget, _("dark"), DT_BAUHAUS_COMBOBOX_ALIGN_LEFT);
+  dt_bauhaus_combobox_add_aligned(widget, _("green"), DT_BAUHAUS_COMBOBOX_ALIGN_LEFT);
+  dt_bauhaus_combobox_add_aligned(widget, _("blue"), DT_BAUHAUS_COMBOBOX_ALIGN_LEFT);
+  dt_bauhaus_combobox_add_aligned(widget, _("yellow"), DT_BAUHAUS_COMBOBOX_ALIGN_LEFT);
+  dt_bauhaus_combobox_add_aligned(widget, _("orange"), DT_BAUHAUS_COMBOBOX_ALIGN_LEFT);
+  dt_bauhaus_combobox_set(widget, dt_conf_get_int("themes/expanded-module-border"));
+  g_signal_connect(G_OBJECT(widget), "value-changed",
+                   G_CALLBACK(use_expanded_module_border_callback), 0);
+  gtk_widget_set_tooltip_text(widget,
+                              _("set the expanded module border color"));
+
+  // accent color
+  label = gtk_label_new(_("accent color"));
+  gtk_widget_set_name(label, "theme-variant");
+  gtk_widget_set_halign(label, GTK_ALIGN_START);
+  widget = dt_bauhaus_combobox_new(NULL);
+  dt_bauhaus_combobox_set_selected_text_align(widget, DT_BAUHAUS_COMBOBOX_ALIGN_LEFT);
+
+  labelev = gtk_event_box_new();
+  gtk_widget_add_events(labelev, GDK_BUTTON_PRESS_MASK);
+  gtk_container_add(GTK_CONTAINER(labelev), label);
+  gtk_grid_attach(GTK_GRID(grid), labelev, 0, line++, 1, 1);
+  gtk_grid_attach_next_to(GTK_GRID(grid), widget, labelev, GTK_POS_RIGHT, 1, 1);
+  dt_bauhaus_combobox_add_aligned(widget, _("none"), DT_BAUHAUS_COMBOBOX_ALIGN_LEFT);
+  dt_bauhaus_combobox_add_aligned(widget, _("green"), DT_BAUHAUS_COMBOBOX_ALIGN_LEFT);
+  dt_bauhaus_combobox_add_aligned(widget, _("blue"), DT_BAUHAUS_COMBOBOX_ALIGN_LEFT);
+  dt_bauhaus_combobox_add_aligned(widget, _("yellow"), DT_BAUHAUS_COMBOBOX_ALIGN_LEFT);
+  dt_bauhaus_combobox_add_aligned(widget, _("orange"), DT_BAUHAUS_COMBOBOX_ALIGN_LEFT);
+  dt_bauhaus_combobox_set
+    (widget, dt_conf_get_int("themes/accent-color"));
+  g_signal_connect(G_OBJECT(widget), "value-changed",
+                   G_CALLBACK(use_accent_color_callback), 0);
+  gtk_widget_set_tooltip_text(widget,
+                              _("set the theme accent color for the interface"));
 
   //Font size check and spin buttons
   GtkWidget *usesysfont = gtk_check_button_new();

--- a/src/gui/preferences.c
+++ b/src/gui/preferences.c
@@ -30,6 +30,7 @@
 #include "gui/accelerators.h"
 #include "gui/draw.h"
 #include "gui/gtk.h"
+#include "gui/theme_variants.h"
 #include "gui/preferences.h"
 #ifdef HAVE_AI
 #include "gui/preferences_ai.h"
@@ -123,7 +124,9 @@ static void load_themes_dir(const char *basedir)
       // files that are not meant to be used as themes, but only included in
       // other CSS files. This allows us to have a modular structure for our CSS
       // and avoid code duplication between themes.
-      if(!g_str_has_prefix(d_name, "chunk-"))
+      // .variants manifests sit beside the themes and are not themes
+      if(!g_str_has_prefix(d_name, "chunk-")
+         && g_str_has_suffix(d_name, ".css"))
         darktable.themes = g_list_append(darktable.themes, g_strdup(d_name));
     }
     g_dir_close(dir);
@@ -154,6 +157,9 @@ static void reload_ui_last_theme(void)
   dt_bauhaus_load_theme();
 }
 
+typedef struct dt_variants_ui_t dt_variants_ui_t;
+static void _build_theme_variants(dt_variants_ui_t *ui);
+
 static void theme_callback(GtkWidget *widget, gpointer user_data)
 {
   const int selected = dt_bauhaus_combobox_get(widget);
@@ -162,6 +168,9 @@ static void theme_callback(GtkWidget *widget, gpointer user_data)
   if(i) *i = '\0';
   dt_gui_load_theme(theme);
   dt_bauhaus_load_theme();
+
+  // a different theme declares different options
+  if(user_data) _build_theme_variants((dt_variants_ui_t *)user_data);
 }
 
 static void usercss_callback(GtkWidget *widget, gpointer user_data)
@@ -205,49 +214,125 @@ static void use_sys_font_callback(GtkWidget *widget,
   reload_ui_last_theme();
 }
 
-static void use_rounded_header_callback(GtkWidget *widget,
-                                        gpointer user_data)
+// theme variants are declared by the theme, so one pair of callbacks
+// serves every control; the variant itself rides in user_data
+static void _variant_bool_callback(GtkWidget *widget,
+                                   gpointer user_data)
 {
-  dt_conf_set_bool("themes/rounded-header",
-                   gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget)));
+  const dt_theme_variant_t *variant = (const dt_theme_variant_t *)user_data;
+  char *key = dt_theme_variant_conf_key(variant);
+  dt_conf_set_string(key,
+                     gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget))
+                       ? "true" : "false");
+  g_free(key);
 
   reload_ui_last_theme();
 }
 
-static void use_condensed_control_callback(GtkWidget *widget,
-                                           gpointer user_data)
+static void _variant_enum_callback(GtkWidget *widget,
+                                   gpointer user_data)
 {
-  dt_conf_set_bool("themes/condensed",
-                   gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget)));
-
-  reload_ui_last_theme();
-}
-
-static void use_accent_color_callback(GtkWidget *widget,
-                                        gpointer user_data)
-{
+  const dt_theme_variant_t *variant = (const dt_theme_variant_t *)user_data;
   const int selected = dt_bauhaus_combobox_get(widget);
+  const char *value = g_list_nth_data(variant->values, MAX(selected, 0));
+  if(!value) return;
 
-  dt_conf_set_int("themes/accent-color", selected);
+  char *key = dt_theme_variant_conf_key(variant);
+  dt_conf_set_string(key, value);
+  g_free(key);
+
   reload_ui_last_theme();
 }
 
-static void use_focused_module_border_callback(GtkWidget *widget,
-                                               gpointer user_data)
+// theme variants get a grid of their own: a theme change replaces the
+// whole set, and some rows below are placed at absolute positions that a
+// varying number of variant rows would displace
+typedef struct dt_variants_ui_t
 {
-  const int selected = dt_bauhaus_combobox_get(widget);
+  GtkWidget *grid;
+  GtkSizeGroup *labels;    // shared with the preferences grid, which
+  GtkSizeGroup *controls;  // sizes its columns separately from ours
+  GList *variants;
+} dt_variants_ui_t;
 
-  dt_conf_set_int("themes/focused-module-border", selected);
-  reload_ui_last_theme();
+static void _variants_ui_free(void *data)
+{
+  dt_variants_ui_t *ui = (dt_variants_ui_t *)data;
+  dt_theme_variants_free(ui->variants);
+  if(ui->labels) g_object_unref(ui->labels);
+  if(ui->controls) g_object_unref(ui->controls);
+  g_free(ui);
 }
 
-static void use_expanded_module_border_callback(GtkWidget *widget,
-                                                gpointer user_data)
+// (re)create one control per option the current theme declares. called
+// again whenever the theme changes, since the options change with it.
+// the controls share the main grid so they line up with everything else
+static void _build_theme_variants(dt_variants_ui_t *ui)
 {
-  const int selected = dt_bauhaus_combobox_get(widget);
+  GList *children = gtk_container_get_children(GTK_CONTAINER(ui->grid));
+  for(GList *c = children; c; c = g_list_next(c))
+    gtk_widget_destroy(GTK_WIDGET(c->data));
+  g_list_free(children);
 
-  dt_conf_set_int("themes/expanded-module-border", selected);
-  reload_ui_last_theme();
+  dt_theme_variants_free(ui->variants);
+  ui->variants =
+    dt_theme_variants_load(dt_conf_get_string_const("ui_last/theme"));
+
+  int row = 0;
+  for(GList *v = ui->variants; v; v = g_list_next(v))
+  {
+    dt_theme_variant_t *variant = (dt_theme_variant_t *)v->data;
+    const char *current = dt_theme_variant_get(variant);
+    const int line = row++;
+    GtkWidget *widget = NULL;
+
+    GtkWidget *label = gtk_label_new(variant->label);
+    gtk_widget_set_name(label, "theme-variant");
+    gtk_widget_set_halign(label, GTK_ALIGN_START);
+    GtkWidget *labelev = gtk_event_box_new();
+    gtk_widget_add_events(labelev, GDK_BUTTON_PRESS_MASK);
+    gtk_container_add(GTK_CONTAINER(labelev), label);
+    gtk_grid_attach(GTK_GRID(ui->grid), labelev, 0, line, 1, 1);
+    gtk_size_group_add_widget(ui->labels, labelev);
+
+    if(variant->type == DT_THEME_VARIANT_BOOL)
+    {
+      widget = gtk_check_button_new();
+      gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget),
+                                   !g_strcmp0(current, "true"));
+      g_signal_connect(G_OBJECT(widget), "toggled",
+                       G_CALLBACK(_variant_bool_callback), variant);
+    }
+    else
+    {
+      widget = dt_bauhaus_combobox_new(NULL);
+      // as the language and theme combos above: left for the closed
+      // widget, left for the popup list
+      dt_bauhaus_combobox_set_selected_text_align(widget,
+                                                  DT_BAUHAUS_COMBOBOX_ALIGN_LEFT);
+      int active = 0, index = 0;
+      for(GList *o = variant->values, *n = variant->labels;
+          o && n;
+          o = g_list_next(o), n = g_list_next(n), index++)
+      {
+        dt_bauhaus_combobox_add_aligned(widget, (const char *)n->data,
+                                        DT_BAUHAUS_COMBOBOX_ALIGN_LEFT);
+        if(!g_strcmp0((const char *)o->data, current)) active = index;
+      }
+      dt_bauhaus_combobox_set(widget, active);
+      // match the combos above, not the longest option name
+      gtk_size_group_add_widget(ui->controls, widget);
+      g_signal_connect(G_OBJECT(widget), "value-changed",
+                       G_CALLBACK(_variant_enum_callback), variant);
+    }
+
+    gtk_grid_attach_next_to(GTK_GRID(ui->grid), widget, labelev,
+                            GTK_POS_RIGHT, 1, 1);
+    if(variant->tooltip) gtk_widget_set_tooltip_text(widget, variant->tooltip);
+
+    gtk_widget_show_all(labelev);
+    gtk_widget_show_all(widget);
+  }
 }
 
 static void save_usercss(GtkTextBuffer *buffer)
@@ -388,6 +473,11 @@ static void init_tab_general(GtkWidget *dialog,
 
   gtk_stack_add_titled(GTK_STACK(stack), container, _("general"), _("general"));
 
+  // the theme variants grid sizes its columns separately from this one;
+  // these keep the two aligned
+  GtkSizeGroup *label_group = gtk_size_group_new(GTK_SIZE_GROUP_HORIZONTAL);
+  GtkSizeGroup *control_group = gtk_size_group_new(GTK_SIZE_GROUP_HORIZONTAL);
+
   // language
 
   GtkWidget *label = gtk_label_new(_("interface language"));
@@ -418,6 +508,8 @@ static void init_tab_general(GtkWidget *dialog,
                                 "(restart required)"));
   gtk_grid_attach(GTK_GRID(grid), labelev, 0, line++, 1, 1);
   gtk_grid_attach_next_to(GTK_GRID(grid), widget, labelev, GTK_POS_RIGHT, 1, 1);
+  gtk_size_group_add_widget(label_group, labelev);
+  gtk_size_group_add_widget(control_group, widget);
   g_signal_connect(G_OBJECT(labelev), "button-press-event",
                    G_CALLBACK(reset_language_widget), (gpointer)widget);
 
@@ -435,6 +527,8 @@ static void init_tab_general(GtkWidget *dialog,
   gtk_container_add(GTK_CONTAINER(labelev), label);
   gtk_grid_attach(GTK_GRID(grid), labelev, 0, line++, 1, 1);
   gtk_grid_attach_next_to(GTK_GRID(grid), widget, labelev, GTK_POS_RIGHT, 1, 1);
+  gtk_size_group_add_widget(label_group, labelev);
+  gtk_size_group_add_widget(control_group, widget);
 
   // read all themes
   char *theme_name = dt_conf_get_string("ui_last/theme");
@@ -454,118 +548,23 @@ static void init_tab_general(GtkWidget *dialog,
 
   dt_bauhaus_combobox_set(widget, selected);
 
+  // the variant controls, just below the theme selector
+  dt_variants_ui_t *variants_ui = g_malloc0(sizeof(dt_variants_ui_t));
+  variants_ui->grid = gtk_grid_new();
+  gtk_grid_set_row_spacing(GTK_GRID(variants_ui->grid), DT_PIXEL_APPLY_DPI(3));
+  gtk_grid_set_column_spacing(GTK_GRID(variants_ui->grid),
+                              DT_PIXEL_APPLY_DPI(5));
+  variants_ui->labels = label_group;      // takes the references
+  variants_ui->controls = control_group;
+  g_object_set_data_full(G_OBJECT(dialog), "dt-theme-variants",
+                         variants_ui, _variants_ui_free);
+
   g_signal_connect(G_OBJECT(widget), "value-changed",
-                   G_CALLBACK(theme_callback), 0);
+                   G_CALLBACK(theme_callback), variants_ui);
   gtk_widget_set_tooltip_text(widget, _("set the theme for the user interface"));
 
-  // theme variants
-
-  // condensed controls
-  GtkWidget *t_condensed = gtk_check_button_new();
-  label = gtk_label_new(_("condensed module controls"));
-  gtk_widget_set_name(label, "theme-variant");
-  gtk_widget_set_halign(label, GTK_ALIGN_START);
-  labelev = gtk_event_box_new();
-  gtk_widget_add_events(labelev, GDK_BUTTON_PRESS_MASK);
-  gtk_container_add(GTK_CONTAINER(labelev), label);
-  gtk_grid_attach(GTK_GRID(grid), labelev, 0, line++, 1, 1);
-  gtk_grid_attach_next_to(GTK_GRID(grid), t_condensed, labelev, GTK_POS_RIGHT, 1, 1);
-  gtk_widget_set_tooltip_text(t_condensed, _("use condensed module controls"));
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(t_condensed),
-                               dt_conf_get_bool("themes/condensed"));
-  g_signal_connect(G_OBJECT(t_condensed), "toggled",
-                   G_CALLBACK(use_condensed_control_callback),
-                  (gpointer)t_condensed);
-
-  // rounded header
-  GtkWidget *t_rounded = gtk_check_button_new();
-  label = gtk_label_new(_("rounded module headers"));
-  gtk_widget_set_name(label, "theme-variant");
-  gtk_widget_set_halign(label, GTK_ALIGN_START);
-  labelev = gtk_event_box_new();
-  gtk_widget_add_events(labelev, GDK_BUTTON_PRESS_MASK);
-  gtk_container_add(GTK_CONTAINER(labelev), label);
-  gtk_grid_attach(GTK_GRID(grid), labelev, 0, line++, 1, 1);
-  gtk_grid_attach_next_to(GTK_GRID(grid), t_rounded, labelev, GTK_POS_RIGHT, 1, 1);
-  gtk_widget_set_tooltip_text(t_rounded, _("use rounded module headers variant"));
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(t_rounded),
-                               dt_conf_get_bool("themes/rounded-header"));
-  g_signal_connect(G_OBJECT(t_rounded), "toggled",
-                   G_CALLBACK(use_rounded_header_callback), (gpointer)t_rounded);
-
-  // focused module border
-  label = gtk_label_new(_("focused module border"));
-  gtk_widget_set_name(label, "theme-variant");
-  gtk_widget_set_halign(label, GTK_ALIGN_START);
-  widget = dt_bauhaus_combobox_new(NULL);
-  dt_bauhaus_combobox_set_selected_text_align(widget, DT_BAUHAUS_COMBOBOX_ALIGN_LEFT);
-
-  labelev = gtk_event_box_new();
-  gtk_widget_add_events(labelev, GDK_BUTTON_PRESS_MASK);
-  gtk_container_add(GTK_CONTAINER(labelev), label);
-  gtk_grid_attach(GTK_GRID(grid), labelev, 0, line++, 1, 1);
-  gtk_grid_attach_next_to(GTK_GRID(grid), widget, labelev, GTK_POS_RIGHT, 1, 1);
-  dt_bauhaus_combobox_add_aligned(widget, _("none"), DT_BAUHAUS_COMBOBOX_ALIGN_LEFT);
-  dt_bauhaus_combobox_add_aligned(widget, _("light"), DT_BAUHAUS_COMBOBOX_ALIGN_LEFT);
-  dt_bauhaus_combobox_add_aligned(widget, _("dark"), DT_BAUHAUS_COMBOBOX_ALIGN_LEFT);
-  dt_bauhaus_combobox_add_aligned(widget, _("green"), DT_BAUHAUS_COMBOBOX_ALIGN_LEFT);
-  dt_bauhaus_combobox_add_aligned(widget, _("blue"), DT_BAUHAUS_COMBOBOX_ALIGN_LEFT);
-  dt_bauhaus_combobox_add_aligned(widget, _("yellow"), DT_BAUHAUS_COMBOBOX_ALIGN_LEFT);
-  dt_bauhaus_combobox_add_aligned(widget, _("orange"), DT_BAUHAUS_COMBOBOX_ALIGN_LEFT);
-  dt_bauhaus_combobox_set(widget, dt_conf_get_int("themes/focused-module-border"));
-  g_signal_connect(G_OBJECT(widget), "value-changed",
-                   G_CALLBACK(use_focused_module_border_callback), 0);
-  gtk_widget_set_tooltip_text(widget,
-                              _("set the focused module border color"));
-
-  // expanded module border
-  label = gtk_label_new(_("expanded module border"));
-  gtk_widget_set_name(label, "theme-variant");
-  gtk_widget_set_halign(label, GTK_ALIGN_START);
-  widget = dt_bauhaus_combobox_new(NULL);
-  dt_bauhaus_combobox_set_selected_text_align(widget, DT_BAUHAUS_COMBOBOX_ALIGN_LEFT);
-
-  labelev = gtk_event_box_new();
-  gtk_widget_add_events(labelev, GDK_BUTTON_PRESS_MASK);
-  gtk_container_add(GTK_CONTAINER(labelev), label);
-  gtk_grid_attach(GTK_GRID(grid), labelev, 0, line++, 1, 1);
-  gtk_grid_attach_next_to(GTK_GRID(grid), widget, labelev, GTK_POS_RIGHT, 1, 1);
-  dt_bauhaus_combobox_add_aligned(widget, _("none"), DT_BAUHAUS_COMBOBOX_ALIGN_LEFT);
-  dt_bauhaus_combobox_add_aligned(widget, _("light"), DT_BAUHAUS_COMBOBOX_ALIGN_LEFT);
-  dt_bauhaus_combobox_add_aligned(widget, _("dark"), DT_BAUHAUS_COMBOBOX_ALIGN_LEFT);
-  dt_bauhaus_combobox_add_aligned(widget, _("green"), DT_BAUHAUS_COMBOBOX_ALIGN_LEFT);
-  dt_bauhaus_combobox_add_aligned(widget, _("blue"), DT_BAUHAUS_COMBOBOX_ALIGN_LEFT);
-  dt_bauhaus_combobox_add_aligned(widget, _("yellow"), DT_BAUHAUS_COMBOBOX_ALIGN_LEFT);
-  dt_bauhaus_combobox_add_aligned(widget, _("orange"), DT_BAUHAUS_COMBOBOX_ALIGN_LEFT);
-  dt_bauhaus_combobox_set(widget, dt_conf_get_int("themes/expanded-module-border"));
-  g_signal_connect(G_OBJECT(widget), "value-changed",
-                   G_CALLBACK(use_expanded_module_border_callback), 0);
-  gtk_widget_set_tooltip_text(widget,
-                              _("set the expanded module border color"));
-
-  // accent color
-  label = gtk_label_new(_("accent color"));
-  gtk_widget_set_name(label, "theme-variant");
-  gtk_widget_set_halign(label, GTK_ALIGN_START);
-  widget = dt_bauhaus_combobox_new(NULL);
-  dt_bauhaus_combobox_set_selected_text_align(widget, DT_BAUHAUS_COMBOBOX_ALIGN_LEFT);
-
-  labelev = gtk_event_box_new();
-  gtk_widget_add_events(labelev, GDK_BUTTON_PRESS_MASK);
-  gtk_container_add(GTK_CONTAINER(labelev), label);
-  gtk_grid_attach(GTK_GRID(grid), labelev, 0, line++, 1, 1);
-  gtk_grid_attach_next_to(GTK_GRID(grid), widget, labelev, GTK_POS_RIGHT, 1, 1);
-  dt_bauhaus_combobox_add_aligned(widget, _("none"), DT_BAUHAUS_COMBOBOX_ALIGN_LEFT);
-  dt_bauhaus_combobox_add_aligned(widget, _("green"), DT_BAUHAUS_COMBOBOX_ALIGN_LEFT);
-  dt_bauhaus_combobox_add_aligned(widget, _("blue"), DT_BAUHAUS_COMBOBOX_ALIGN_LEFT);
-  dt_bauhaus_combobox_add_aligned(widget, _("yellow"), DT_BAUHAUS_COMBOBOX_ALIGN_LEFT);
-  dt_bauhaus_combobox_add_aligned(widget, _("orange"), DT_BAUHAUS_COMBOBOX_ALIGN_LEFT);
-  dt_bauhaus_combobox_set
-    (widget, dt_conf_get_int("themes/accent-color"));
-  g_signal_connect(G_OBJECT(widget), "value-changed",
-                   G_CALLBACK(use_accent_color_callback), 0);
-  gtk_widget_set_tooltip_text(widget,
-                              _("set the theme accent color for the interface"));
+  gtk_grid_attach(GTK_GRID(grid), variants_ui->grid, 0, line++, 2, 1);
+  _build_theme_variants(variants_ui);
 
   //Font size check and spin buttons
   GtkWidget *usesysfont = gtk_check_button_new();
@@ -586,7 +585,16 @@ static void init_tab_general(GtkWidget *dialog,
   gtk_widget_add_events(labelev, GDK_BUTTON_PRESS_MASK);
   gtk_container_add(GTK_CONTAINER(labelev), label);
   gtk_grid_attach(GTK_GRID(grid), labelev, i, i?2:line++, 1, 1);
+  // font_prefs_align_right moves these to a narrower column
+  if(!i) gtk_size_group_add_widget(label_group, labelev);
   gtk_grid_attach_next_to(GTK_GRID(grid), usesysfont, labelev, GTK_POS_RIGHT, 1, 1);
+  // opposite row 2 is the variants grid, as tall as the theme declares
+  // options; stay with the two rows above rather than centering on it
+  if(i)
+  {
+    gtk_widget_set_valign(labelev, GTK_ALIGN_START);
+    gtk_widget_set_valign(usesysfont, GTK_ALIGN_START);
+  }
   gtk_widget_set_tooltip_text(usesysfont, _("use system font size"));
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(usesysfont),
                                dt_conf_get_bool("use_system_font"));
@@ -609,6 +617,7 @@ static void init_tab_general(GtkWidget *dialog,
   gtk_widget_add_events(labelev, GDK_BUTTON_PRESS_MASK);
   gtk_container_add(GTK_CONTAINER(labelev), label);
   gtk_grid_attach(GTK_GRID(grid), labelev, i, i?0:line++, 1, 1);
+  if(!i) gtk_size_group_add_widget(label_group, labelev);
   gtk_grid_attach_next_to(GTK_GRID(grid), fontsize, labelev, GTK_POS_RIGHT, 1, 1);
   gtk_widget_set_tooltip_text(fontsize, _("font size in points"));
   gtk_spin_button_set_value(GTK_SPIN_BUTTON(fontsize), dt_conf_get_float("font_size"));
@@ -622,6 +631,7 @@ static void init_tab_general(GtkWidget *dialog,
   gtk_widget_add_events(labelev, GDK_BUTTON_PRESS_MASK);
   gtk_container_add(GTK_CONTAINER(labelev), label);
   gtk_grid_attach(GTK_GRID(grid), labelev, i, i?1:line++, 1, 1);
+  if(!i) gtk_size_group_add_widget(label_group, labelev);
   gtk_grid_attach_next_to(GTK_GRID(grid), screen_dpi_overwrite, labelev,
                           GTK_POS_RIGHT, 1, 1);
   gtk_widget_set_tooltip_text
@@ -653,6 +663,7 @@ static void init_tab_general(GtkWidget *dialog,
   gtk_widget_add_events(labelev, GDK_BUTTON_PRESS_MASK);
   gtk_container_add(GTK_CONTAINER(labelev), label);
   gtk_grid_attach(GTK_GRID(grid), labelev, 0, line++, 1, 1);
+  gtk_size_group_add_widget(label_group, labelev);
   gtk_grid_attach_next_to(GTK_GRID(grid), tw->apply_toggle, labelev, GTK_POS_RIGHT, 1, 1);
   gtk_widget_set_tooltip_text(tw->apply_toggle,
                               _("modify theme with CSS keyed below (saved to user.css)"));

--- a/src/gui/theme_variants.c
+++ b/src/gui/theme_variants.c
@@ -1,0 +1,382 @@
+/*
+    This file is part of darktable,
+    Copyright (C) 2026 darktable developers.
+
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    darktable is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "gui/theme_variants.h"
+
+#include "common/darktable.h"
+#include "common/file_location.h"
+#include "control/conf.h"
+
+#include <string.h>
+
+// reserved group: describes the manifest itself, not a variant
+#define DT_VARIANTS_GROUP_THEME "theme"
+
+// bounded so a circular set of @imports cannot recurse forever
+#define DT_VARIANTS_MAX_DEPTH 8
+
+static GList *_variants_load(const char *theme, int depth);
+
+static void _variant_free(void *data)
+{
+  dt_theme_variant_t *v = (dt_theme_variant_t *)data;
+  if(!v) return;
+
+  g_free(v->owner);
+  g_free(v->key);
+  g_free(v->label);
+  g_free(v->tooltip);
+  g_free(v->css);
+  g_free(v->def);
+  g_list_free_full(v->values, g_free);
+  g_list_free_full(v->labels, g_free);
+  if(v->css_override) g_hash_table_destroy(v->css_override);
+  g_free(v);
+}
+
+void dt_theme_variants_free(GList *variants)
+{
+  g_list_free_full(variants, _variant_free);
+}
+
+// a theme file in the user config dir, else in the data dir. same order
+// dt_gui_load_theme uses, so a user theme shadows a shipped one
+static char *_theme_file(const char *theme, const char *ext)
+{
+  if(!theme || !*theme) return NULL;
+
+  char configdir[PATH_MAX] = { 0 }, datadir[PATH_MAX] = { 0 };
+  dt_loc_get_user_config_dir(configdir, sizeof(configdir));
+  dt_loc_get_datadir(datadir, sizeof(datadir));
+
+  char *name = g_strconcat(theme, ext, NULL);
+  char *path = g_build_filename(configdir, "themes", name, NULL);
+
+  if(!g_file_test(path, G_FILE_TEST_EXISTS))
+  {
+    g_free(path);
+    path = g_build_filename(datadir, "themes", name, NULL);
+    if(!g_file_test(path, G_FILE_TEST_EXISTS))
+    {
+      g_free(path);
+      path = NULL;
+    }
+  }
+
+  g_free(name);
+  return path;
+}
+
+// the themes `theme` builds on, from its @import lines and in that order.
+// chunks are partial CSS, never themes, so they are skipped
+static GList *_css_imports(const char *theme)
+{
+  char *path = _theme_file(theme, ".css");
+  if(!path) return NULL;
+
+  char *css = NULL;
+  if(!g_file_get_contents(path, &css, NULL, NULL))
+  {
+    g_free(path);
+    return NULL;
+  }
+  g_free(path);
+
+  GList *imports = NULL;
+  GRegex *re = g_regex_new("@import\\s+url\\(\\s*[\"']?([^\"')]+)[\"']?\\s*\\)",
+                           0, 0, NULL);
+  GMatchInfo *match = NULL;
+  g_regex_match(re, css, 0, &match);
+
+  while(g_match_info_matches(match))
+  {
+    char *name = g_match_info_fetch(match, 1);
+    if(name && g_str_has_suffix(name, ".css")
+       && !g_str_has_prefix(name, "chunk-"))
+    {
+      // imports name the file, variants are looked up by theme name
+      name[strlen(name) - strlen(".css")] = '\0';
+      imports = g_list_append(imports, name);
+    }
+    else
+      g_free(name);
+
+    g_match_info_next(match, NULL);
+  }
+
+  g_match_info_free(match);
+  g_regex_unref(re);
+  g_free(css);
+
+  return imports;
+}
+
+// split "a;b;c" as GKeyFile writes it, dropping the empty trailing field
+static GList *_string_list(char **raw, gsize length)
+{
+  GList *list = NULL;
+  for(gsize i = 0; i < length; i++)
+    if(raw[i] && *raw[i])
+      list = g_list_append(list, g_strdup(raw[i]));
+  return list;
+}
+
+// the option `value` names, or NULL when the theme does not offer it.
+// returns the list's own string so callers can borrow it
+static const char *_offered(const dt_theme_variant_t *variant,
+                            const char *value)
+{
+  for(GList *l = variant->values; l; l = g_list_next(l))
+    if(!g_strcmp0((const char *)l->data, value)) return (const char *)l->data;
+  return NULL;
+}
+
+static dt_theme_variant_t *_parse_group(GKeyFile *kf,
+                                        const char *group,
+                                        const char *owner)
+{
+  dt_theme_variant_t *v = g_malloc0(sizeof(dt_theme_variant_t));
+  v->owner = g_strdup(owner);
+  v->key = g_strdup(group);
+
+  char *type = g_key_file_get_string(kf, group, "type", NULL);
+  v->type = (type && !g_strcmp0(type, "enum"))
+    ? DT_THEME_VARIANT_ENUM
+    : DT_THEME_VARIANT_BOOL;
+  g_free(type);
+
+  // a theme ships its own translations; the key stands in without them
+  v->label = g_key_file_get_locale_string(kf, group, "label", NULL, NULL);
+  if(!v->label) v->label = g_strdup(group);
+  v->tooltip = g_key_file_get_locale_string(kf, group, "tooltip", NULL, NULL);
+
+  v->css = g_key_file_get_string(kf, group, "css", NULL);
+  v->def = g_key_file_get_string(kf, group, "default", NULL);
+
+  if(v->type == DT_THEME_VARIANT_ENUM)
+  {
+    gsize n = 0;
+    char **values = g_key_file_get_string_list(kf, group, "values", &n, NULL);
+    v->values = values ? _string_list(values, n) : NULL;
+    g_strfreev(values);
+
+    // a [<group>/labels] group names the options – one bare key each,
+    // which is all intltool will translate. css_<value> overrides the
+    // template for one option; empty means it adds no CSS at all, which
+    // is how "none" switches a variant off
+    char *labels_group = g_strconcat(group, "/labels", NULL);
+
+    for(GList *o = v->values; o; o = g_list_next(o))
+    {
+      const char *value = (const char *)o->data;
+
+      char *label = g_key_file_get_locale_string(kf, labels_group, value,
+                                                 NULL, NULL);
+      v->labels = g_list_append(v->labels, label ? label : g_strdup(value));
+
+      char *key = g_strconcat("css_", value, NULL);
+      if(g_key_file_has_key(kf, group, key, NULL))
+      {
+        if(!v->css_override)
+          v->css_override = g_hash_table_new_full(g_str_hash, g_str_equal,
+                                                  g_free, g_free);
+        g_hash_table_insert(v->css_override, g_strdup(value),
+                            g_key_file_get_string(kf, group, key, NULL));
+      }
+      g_free(key);
+    }
+    g_free(labels_group);
+
+    // a default the theme does not offer would show one option in
+    // preferences and apply another; an absent default already means the
+    // first one, so use that
+    if(v->def && !_offered(v, v->def))
+    {
+      dt_print(DT_DEBUG_ALWAYS,
+               "[theme_variants] %s: default \"%s\" is not one of its values",
+               group, v->def);
+      g_free(v->def);
+      v->def = NULL;
+    }
+    if(!v->def && v->values) v->def = g_strdup(v->values->data);
+  }
+  else if(!v->def)
+    v->def = g_strdup("false");
+
+  return v;
+}
+
+static GList *_variants_load(const char *theme, int depth)
+{
+  if(depth > DT_VARIANTS_MAX_DEPTH) return NULL;
+
+  char *path = _theme_file(theme, ".variants");
+
+  if(!path)
+  {
+    // no manifest of its own: inherit from whatever this theme builds on,
+    // which is the same relationship its CSS already states
+    GList *result = NULL;
+    GList *imports = _css_imports(theme);
+    for(GList *l = imports; l && !result; l = g_list_next(l))
+      result = _variants_load((const char *)l->data, depth + 1);
+    g_list_free_full(imports, g_free);
+    return result;
+  }
+
+  GKeyFile *kf = g_key_file_new();
+  GError *error = NULL;
+  if(!g_key_file_load_from_file(kf, path, G_KEY_FILE_NONE, &error))
+  {
+    dt_print(DT_DEBUG_ALWAYS,
+             "[theme_variants] cannot read %s: %s",
+             path, error ? error->message : "unknown error");
+    if(error) g_error_free(error);
+    g_key_file_free(kf);
+    g_free(path);
+    return NULL;
+  }
+  g_free(path);
+
+  GList *variants = NULL;
+
+  // a manifest that names a parent extends it rather than replacing it,
+  // so a theme can add one variant without restating the family's
+  char *inherits = g_key_file_get_string(kf, DT_VARIANTS_GROUP_THEME,
+                                         "inherits", NULL);
+  if(inherits && *inherits)
+    variants = _variants_load(inherits, depth + 1);
+  g_free(inherits);
+
+  gsize n = 0;
+  char **groups = g_key_file_get_groups(kf, &n);
+  for(gsize i = 0; groups && i < n; i++)
+  {
+    if(!g_strcmp0(groups[i], DT_VARIANTS_GROUP_THEME)) continue;
+    if(strchr(groups[i], '/')) continue;  // [<group>/labels], read below
+
+    dt_theme_variant_t *v = _parse_group(kf, groups[i], theme);
+
+    // a theme redeclaring an inherited variant replaces it in place, so
+    // the controls keep the order the parent gave them
+    GList *prev = NULL;
+    for(GList *l = variants; l && !prev; l = g_list_next(l))
+      if(!g_strcmp0(((dt_theme_variant_t *)l->data)->key, v->key)) prev = l;
+
+    if(prev)
+    {
+      _variant_free(prev->data);
+      prev->data = v;
+    }
+    else
+      variants = g_list_append(variants, v);
+  }
+  g_strfreev(groups);
+  g_key_file_free(kf);
+
+  return variants;
+}
+
+// themes/condensed shipped before variants were per theme. carry it over
+// once, or everyone who enabled it silently gets it switched off
+static void _migrate_legacy_keys(void)
+{
+  static gboolean done = FALSE;
+  if(done) return;
+  done = TRUE;
+
+  if(dt_conf_key_exists("themes/darktable/condensed")
+     || !dt_conf_key_exists("themes/condensed"))
+    return;
+
+  dt_conf_set_string("themes/darktable/condensed",
+                     dt_conf_get_bool("themes/condensed") ? "true" : "false");
+}
+
+GList *dt_theme_variants_load(const char *theme)
+{
+  _migrate_legacy_keys();
+  return _variants_load(theme, 0);
+}
+
+char *dt_theme_variant_conf_key(const dt_theme_variant_t *variant)
+{
+  if(!variant) return NULL;
+  return g_strdup_printf("themes/%s/%s", variant->owner, variant->key);
+}
+
+const char *dt_theme_variant_get(const dt_theme_variant_t *variant)
+{
+  if(!variant) return "";
+
+  char *key = dt_theme_variant_conf_key(variant);
+  char *stored = dt_conf_key_exists(key) ? dt_conf_get_string(key) : NULL;
+  g_free(key);
+
+  const char *result = variant->def ? variant->def : "";
+
+  if(stored && *stored)
+  {
+    if(variant->type == DT_THEME_VARIANT_BOOL)
+    {
+      result = !g_strcmp0(stored, "true") ? "true" : "false";
+    }
+    else
+    {
+      // a value the theme no longer offers falls back to the default
+      const char *offered = _offered(variant, stored);
+      if(offered) result = offered;
+    }
+  }
+  g_free(stored);
+
+  return result;
+}
+
+char *dt_theme_variant_css(const dt_theme_variant_t *variant,
+                           const char *value)
+{
+  if(!variant || !value) return NULL;
+
+  if(variant->type == DT_THEME_VARIANT_BOOL)
+    return g_strcmp0(value, "true") ? NULL : g_strdup(variant->css);
+
+  if(variant->css_override
+     && g_hash_table_contains(variant->css_override, value))
+  {
+    const char *css = g_hash_table_lookup(variant->css_override, value);
+    return (css && *css) ? g_strdup(css) : NULL;
+  }
+
+  if(!variant->css) return NULL;
+
+  char *css = dt_util_str_replace(variant->css, "$value", value);
+  if(css && !*css)
+  {
+    g_free(css);
+    css = NULL;
+  }
+  return css;
+}
+
+// clang-format off
+// modelines: These editor modelines have been set for all relevant files
+// by tools/update_modelines.py
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on;
+// clang-format on

--- a/src/gui/theme_variants.h
+++ b/src/gui/theme_variants.h
@@ -1,0 +1,100 @@
+/*
+    This file is part of darktable,
+    Copyright (C) 2026 darktable developers.
+
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    darktable is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <glib.h>
+
+// Options a theme offers on top of its CSS, declared by the theme rather
+// than by darktable. A theme ships <theme>.variants beside <theme>.css:
+//
+//   [accent-color]
+//   type=enum
+//   label=accent color
+//   label[de]=Akzentfarbe
+//   values=none;green;blue
+//   default=none
+//   css=chunk-$value-accent-color.css
+//   css.none=
+//
+// Each group is one control in preferences and one CSS chunk imported
+// after the theme. A theme with no manifest inherits the one belonging to
+// the theme it @imports, so a family declares its variants once.
+
+typedef enum dt_theme_variant_type_t
+{
+  DT_THEME_VARIANT_BOOL = 0,
+  DT_THEME_VARIANT_ENUM
+} dt_theme_variant_type_t;
+
+typedef struct dt_theme_variant_t
+{
+  char *owner;      // theme that declares this; namespaces the conf key
+  char *key;        // group name, e.g. "accent-color"
+  char *label;      // localized, for the preferences control
+  char *tooltip;    // localized, may be NULL
+  dt_theme_variant_type_t type;
+  GList *values;    // char*, option ids; NULL for a bool
+  GList *labels;    // char*, localized, same length as values
+  char *css;        // chunk name, "$value" replaced by the option id
+  GHashTable *css_override;  // option id -> chunk name, "" for none
+  char *def;        // default option id, or "true"/"false" for a bool
+} dt_theme_variant_t;
+
+/**
+ * @brief The variants offered by `theme`, in declaration order
+ *
+ * Resolves <theme>.variants from the user config dir, then the data dir.
+ * A theme without one inherits through its CSS @import chain; a theme
+ * with one may add `inherits=` to extend rather than replace.
+ *
+ * @param theme Theme name without extension, e.g. "darktable-elegant-grey"
+ * @return List of dt_theme_variant_t*, empty when nothing is declared.
+ *         Free with dt_theme_variants_free()
+ */
+GList *dt_theme_variants_load(const char *theme);
+
+void dt_theme_variants_free(GList *variants);
+
+/**
+ * @brief Where this variant's value is stored, "themes/<owner>/<key>"
+ * @return Newly allocated string, free with g_free()
+ */
+char *dt_theme_variant_conf_key(const dt_theme_variant_t *variant);
+
+/**
+ * @brief The option currently selected, falling back to the declared
+ *        default. A value no longer offered by the theme is ignored.
+ * @return Borrowed option id, valid while `variant` is; never NULL
+ */
+const char *dt_theme_variant_get(const dt_theme_variant_t *variant);
+
+/**
+ * @brief The CSS chunk `value` asks for
+ * @return Newly allocated chunk filename, or NULL when this option adds
+ *         no CSS. Free with g_free()
+ */
+char *dt_theme_variant_css(const dt_theme_variant_t *variant,
+                           const char *value);
+
+// clang-format off
+// modelines: These editor modelines have been set for all relevant files
+// by tools/update_modelines.py
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on;
+// clang-format on


### PR DESCRIPTION
The main theme can now be adapted with variants.
 - **condensed**
 - **rounded header**
 - **focused module border** (light, dark, green, blue, yellow, orange)
 - **expanded module border** (light, dark, green, blue, yellow, orange)
 - **accent color** (green, blue, yellow, orange)

The "condensed" variant was already available into the Miscellaneous / Interface section. It is now part of the general theme section and handled as a standard variant.

The variants controls are proposed just below the main theme and are indented to make it clear that those are part of the theming.

The GUI:

<img width="820" height="368" alt="image" src="https://github.com/user-attachments/assets/1b7609a8-b545-445a-b5ea-9481968d51e4" />

Why?

Many people are today asking for this, rounder corner, colored accent, more condensed UI (already in master). Having a more structured way to support sub-theming (or variant) seems a good way to give more freedom.

This has been tested on the 3 main themes : grey, dark and darker.

### Green accent + module border:

<img width="394" height="479" alt="image" src="https://github.com/user-attachments/assets/3d3ed1ff-ea08-4451-924d-9b0e3e0e564f" />

### Yellow accent + rounded border 

<img width="394" height="479" alt="image" src="https://github.com/user-attachments/assets/1beb8657-50dd-4a1c-9577-a7e3cd29ace4" />
