### PR TITLE
Fix typedef/struct syntax in useless.c

### DIFF
--- a/src/iop/useless.c
+++ b/src/iop/useless.c
@@ -192,12 +192,12 @@ int legacy_params(dt_iop_module_t *self,
                   int32_t *new_params_size,
                   int *new_version)
 {
-  typedef dt_iop_useless_params_v3_t
+  typedef struct dt_iop_useless_params_v3_t
   {
     int checker_scale;
     float factor;
     int strength;
-  }
+  } dt_iop_useless_params_v3_t;
 
   // do migration from 2 to 3 (one step at a time, this legacy_params
   // update is incremental and will be done as many time as needed to


### PR DESCRIPTION
Use correct syntax for the dt_iop_useless_params_v3_t typedef.