### PR TITLE
log all OpenCL fallbacks

### DIFF
--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -2076,9 +2076,12 @@ int dt_opencl_lock_device(const int pipetype)
       heavy = darktable.develop->late_scaling.enabled;
       break;
     default:
+      // every DT_DEV_PIXELPIPE_ANY value is handled above; reaching here
+      // means a new pipe type was added without updating this switch
       free(priority);
       priority = NULL;
       mandatory = FALSE;
+      dt_unreachable_codepath_with_desc("unhandled pixelpipe type in dt_opencl_lock_device");
   }
 
   dt_pthread_mutex_unlock(&cl->lock);
@@ -2107,6 +2110,9 @@ int dt_opencl_lock_device(const int pipetype)
 
       if(!mandatory)
       {
+        dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE,
+                 "[opencl_fallback] opencl_lock_device: no free opencl"
+                 " device for non-mandatory pipe, fallback to CPU");
         free(priority);
         return DT_DEVICE_CPU;
       }

--- a/src/develop/imageop_math.c
+++ b/src/develop/imageop_math.c
@@ -215,6 +215,9 @@ int dt_iop_clip_and_zoom_roi_cl(int devid,
   {
     // We ran into a "vertical number of taps exceeds the vertical workgroupsize" problem
     // Instead of redoing the whole thing later we do an internal fallback to cpu here
+    dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE,
+             "[opencl_fallback] clip_and_zoom: vertical taps exceed"
+             " workgroup size, falling back to CPU");
     float *in = dt_alloc_align_float((size_t)roi_in->width * roi_in->height * 4);
     float *out = dt_alloc_align_float((size_t)roi_out->width * roi_out->height * 4);
     if(out && in)

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -2153,7 +2153,14 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
     if(possible_cl && !fits_on_device)
     {
       if(!_piece_may_tile(piece))
+      {
+        dt_print_pipe(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE,
+                      "opencl fallback", pipe, module, pipe->devid,
+                      &roi_in, roi_out, "%s",
+                      "no GPU path: data doesn't fit on device and module"
+                      " can't tile, falling back to CPU");
         possible_cl = FALSE;
+      }
 
       const float advantage = darktable.opencl->dev[pipe->devid].advantage;
       if(possible_cl && (advantage > 0.0f))
@@ -2184,7 +2191,14 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
         {
           const dt_iop_order_iccprofile_info_t *profile = dt_ioppr_get_pipe_current_profile_info(module, pipe);
           if(profile && !dt_is_valid_colormatrix(profile->matrix_in[0][0]))
+          {
+            dt_print_pipe(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE,
+                          "opencl fallback", pipe, module, pipe->devid,
+                          &roi_in, roi_out, "%s",
+                          "no GPU path: RGB scene blend needs a valid input"
+                          " colormatrix, falling back to CPU");
             possible_cl = FALSE;
+          }
         }
       }
     }

--- a/src/iop/bilat.c
+++ b/src/iop/bilat.c
@@ -301,8 +301,15 @@ void commit_params(dt_iop_module_t *self,
 
 #ifdef HAVE_OPENCL
   if(d->mode == s_mode_bilateral)
-    piece->process_cl_ready =
-      (piece->process_cl_ready && !dt_opencl_avoid_atomics(pipe->devid));
+  {
+    if(dt_opencl_avoid_atomics(pipe->devid))
+    {
+      dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE,
+               "[opencl_fallback] %s: no GPU path: device avoids atomics",
+               self->op);
+      piece->process_cl_ready = FALSE;
+    }
+  }
 #endif
   if(d->mode == s_mode_local_laplacian)
     piece->process_tiling_ready = FALSE; // can't deal with tiles, sorry.

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -3161,6 +3161,9 @@ void commit_params(dt_iop_module_t *self,
 #endif
       )
     {
+      dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE,
+               "[opencl_fallback] %s: no GPU path: diagnostics require CPU",
+               self->op);
       piece->process_cl_ready = FALSE;
     }
   }

--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -1469,6 +1469,9 @@ void commit_params(dt_iop_module_t *self,
        (d->input, d->cmatrix,
         d->lut[0], d->lut[1], d->lut[2], LUT_SAMPLES))
     {
+      dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE,
+               "[opencl_fallback] %s: no GPU path: input profile needs lcms2",
+               self->op);
       piece->process_cl_ready = FALSE;
       dt_mark_colormatrix_invalid(&d->cmatrix[0][0]);
       d->xform_cam_Lab = cmsCreateTransform(d->input, input_format, Lab,
@@ -1495,6 +1498,9 @@ void commit_params(dt_iop_module_t *self,
                                                     d->lut[0], d->lut[1], d->lut[2],
                                                     LUT_SAMPLES))
     {
+      dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE,
+               "[opencl_fallback] %s: no GPU path: input profile needs lcms2",
+               self->op);
       piece->process_cl_ready = FALSE;
       dt_mark_colormatrix_invalid(&d->cmatrix[0][0]);
       d->xform_cam_Lab = cmsCreateTransform(d->input, input_format, Lab,
@@ -1538,6 +1544,9 @@ void commit_params(dt_iop_module_t *self,
                                                     d->lut[0], d->lut[1], d->lut[2],
                                                     LUT_SAMPLES))
     {
+      dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE,
+               "[opencl_fallback] %s: no GPU path: input profile needs lcms2",
+               self->op);
       piece->process_cl_ready = FALSE;
       dt_mark_colormatrix_invalid(&d->cmatrix[0][0]);
       d->xform_cam_Lab = cmsCreateTransform(d->input, TYPE_RGBA_FLT, Lab,

--- a/src/iop/colormapping.c
+++ b/src/iop/colormapping.c
@@ -735,7 +735,15 @@ void commit_params(dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_
   memcpy(d, p, sizeof(dt_iop_colormapping_params_t));
 #ifdef HAVE_OPENCL
   if(d->equalization > 0.1f)
-    piece->process_cl_ready = (piece->process_cl_ready && !dt_opencl_avoid_atomics(pipe->devid));
+  {
+    if(dt_opencl_avoid_atomics(pipe->devid))
+    {
+      dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE,
+               "[opencl_fallback] %s: no GPU path: device avoids atomics",
+               self->op);
+      piece->process_cl_ready = FALSE;
+    }
+  }
 #endif
 }
 
@@ -1048,4 +1056,3 @@ void gui_cleanup(dt_iop_module_t *self)
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/iop/colorout.c
+++ b/src/iop/colorout.c
@@ -708,6 +708,9 @@ void commit_params(dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_
                                                       d->lut[0], d->lut[1], d->lut[2], LUT_SAMPLES))
   {
     dt_mark_colormatrix_invalid(&d->cmatrix[0][0]);
+    dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE,
+             "[opencl_fallback] %s: no GPU path: output profile needs lcms2",
+             self->op);
     piece->process_cl_ready = FALSE;
     d->xform = cmsCreateProofingTransform(Lab, TYPE_LabA_FLT, output, output_format, softproof,
                                           out_intent, INTENT_RELATIVE_COLORIMETRIC, transformFlags);
@@ -727,6 +730,9 @@ void commit_params(dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_
                                                         d->lut[0], d->lut[1], d->lut[2], LUT_SAMPLES))
     {
       dt_mark_colormatrix_invalid(&d->cmatrix[0][0]);
+      dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE,
+               "[opencl_fallback] %s: no GPU path: output profile needs lcms2",
+               self->op);
       piece->process_cl_ready = FALSE;
 
       d->xform = cmsCreateProofingTransform(Lab, TYPE_LabA_FLT, output, output_format, softproof,

--- a/src/iop/colorreconstruction.c
+++ b/src/iop/colorreconstruction.c
@@ -1153,7 +1153,13 @@ void commit_params(dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_
   d->hue = p->hue;
 
 #ifdef HAVE_OPENCL
-  piece->process_cl_ready = (piece->process_cl_ready && !dt_opencl_avoid_atomics(pipe->devid));
+  if(dt_opencl_avoid_atomics(pipe->devid))
+  {
+    dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE,
+             "[opencl_fallback] %s: no GPU path: device avoids atomics",
+             self->op);
+    piece->process_cl_ready = FALSE;
+  }
 #endif
 }
 

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -2804,7 +2804,11 @@ void commit_params(dt_iop_module_t *self,
 #endif
 
   // display selection don't work with opencl
-  piece->process_cl_ready = (g && g->display_mask) ? FALSE : TRUE;
+  if(g && g->display_mask)
+    dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE,
+             "[opencl_fallback] %s: no GPU path: mask display requires CPU",
+             self->op);
+  piece->process_cl_ready = !(g && g->display_mask);
   d->channel = (dt_iop_colorzones_channel_t)p->channel;
   d->mode = p->mode;
 

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -1419,15 +1419,27 @@ void commit_params(dt_iop_module_t *self,
   switch(d->demosaicing_method)
   {
     case DT_IOP_DEMOSAIC_AMAZE:
+      dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE,
+               "[opencl_fallback] %s: no GPU path: AMaZE is not supported",
+               self->op);
       piece->process_cl_ready = FALSE;
       break;
     case DT_IOP_DEMOSAIC_LMMSE:
+      dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE,
+               "[opencl_fallback] %s: no GPU path: LMMSE is not supported",
+               self->op);
       piece->process_cl_ready = FALSE;
       break;
     case DT_IOP_DEMOSAIC_AMAZE_DUAL:
+      dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE,
+               "[opencl_fallback] %s: no GPU path: dual AMaZE is not supported",
+               self->op);
       piece->process_cl_ready = FALSE;
       break;
     case DT_IOP_DEMOSAIC_FDC:
+      dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE,
+               "[opencl_fallback] %s: no GPU path: FDC is not supported",
+               self->op);
       piece->process_cl_ready = FALSE;
       break;
     default:
@@ -1437,6 +1449,9 @@ void commit_params(dt_iop_module_t *self,
   if(bayer4)
   {
     // 4Bayer images not implemented in OpenCL yet
+    dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE,
+             "[opencl_fallback] %s: no GPU path: 4Bayer input is not supported",
+             self->op);
     piece->process_cl_ready = FALSE;
 
     // Get and store the matrix to go from camera to RGB for 4Bayer images

--- a/src/iop/finalscale.c
+++ b/src/iop/finalscale.c
@@ -98,7 +98,12 @@ void modify_roi_in(dt_iop_module_t *self,
   // FIXME As long as we don't support upscaling via OpenCL we can & should disable OpenCL
   // here to avoid the costly later fallback to CPU upscaling
   if(roi_in->scale > 1.0f)
+  {
+    dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE,
+             "[opencl_fallback] %s: no GPU path: upscaling is not supported",
+             self->op);
     piece->process_cl_ready = FALSE;
+  }
 
   roi_in->scale = 1.0f;
 
@@ -151,7 +156,7 @@ int process_cl(dt_iop_module_t *self,
 {
   if(roi_out->scale > 1.0f) // trust cl code for 1:1 copy here or downscale
   {
-    dt_print(DT_DEBUG_OPENCL,
+    dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE,
              "[opencl_finalscale] upscaling not yet supported by opencl code");
     return DT_OPENCL_PROCESS_CL;
   }

--- a/src/iop/globaltonemap.c
+++ b/src/iop/globaltonemap.c
@@ -555,7 +555,15 @@ void commit_params(dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_
 
 #ifdef HAVE_OPENCL
   if(d->detail != 0.0f)
-    piece->process_cl_ready = (piece->process_cl_ready && !dt_opencl_avoid_atomics(pipe->devid));
+  {
+    if(dt_opencl_avoid_atomics(pipe->devid))
+    {
+      dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE,
+               "[opencl_fallback] %s: no GPU path: device avoids atomics",
+               self->op);
+      piece->process_cl_ready = FALSE;
+    }
+  }
 #endif
 }
 

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -1033,8 +1033,16 @@ void commit_params(dt_iop_module_t *self,
      FIXME the opposed preprocessing might be added as OpenCL too
   */
   const gboolean opplinear = (d->mode == DT_IOP_HIGHLIGHTS_OPPOSED) && linear;
+  const gboolean unsupported_cl =
+    (d->mode == DT_IOP_HIGHLIGHTS_INPAINT)
+    || (d->mode == DT_IOP_HIGHLIGHTS_SEGMENTS)
+    || opplinear;
 
-  piece->process_cl_ready = ((d->mode == DT_IOP_HIGHLIGHTS_INPAINT) || (d->mode == DT_IOP_HIGHLIGHTS_SEGMENTS) || opplinear) ? FALSE : TRUE;
+  if(unsupported_cl)
+    dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE,
+             "[opencl_fallback] %s: no GPU path: highlights mode is not supported",
+             self->op);
+  piece->process_cl_ready = !unsupported_cl;
 
   if((d->mode == DT_IOP_HIGHLIGHTS_SEGMENTS) || (d->mode == DT_IOP_HIGHLIGHTS_OPPOSED))
     piece->process_tiling_ready = FALSE;
@@ -1043,7 +1051,12 @@ void commit_params(dt_iop_module_t *self,
 
   dt_iop_highlights_gui_data_t *g = self->gui_data;
   if(g && (g->hlr_mask_mode == DT_HIGHLIGHTS_MASK_CLIPPED) && linear && fullpipe)
+  {
+    dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE,
+             "[opencl_fallback] %s: no GPU path: clipped mask display requires CPU",
+             self->op);
     piece->process_cl_ready = FALSE;
+  }
 }
 
 void init_global(dt_iop_module_so_t *self)

--- a/src/iop/invert.c
+++ b/src/iop/invert.c
@@ -457,10 +457,22 @@ void commit_params(dt_iop_module_t *self, dt_iop_params_t *params, dt_dev_pixelp
   for(int k = 0; k < 4; k++) d->color[k] = p->color[k];
 
   // x-trans images not implemented in OpenCL yet
-  if(pipe->image.buf_dsc.filters == 9u) piece->process_cl_ready = FALSE;
+  if(pipe->image.buf_dsc.filters == 9u)
+  {
+    dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE,
+             "[opencl_fallback] %s: no GPU path: X-Trans input is not supported",
+             self->op);
+    piece->process_cl_ready = FALSE;
+  }
 
   // 4Bayer images not implemented in OpenCL yet
-  if(self->dev->image_storage.flags & DT_IMAGE_4BAYER) piece->process_cl_ready = FALSE;
+  if(self->dev->image_storage.flags & DT_IMAGE_4BAYER)
+  {
+    dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE,
+             "[opencl_fallback] %s: no GPU path: 4Bayer input is not supported",
+             self->op);
+    piece->process_cl_ready = FALSE;
+  }
 
   if(self->hide_enable_button) piece->enabled = FALSE;
 }

--- a/src/iop/lowpass.c
+++ b/src/iop/lowpass.c
@@ -467,7 +467,15 @@ void commit_params(dt_iop_module_t *self,
 
 #ifdef HAVE_OPENCL
   if(d->lowpass_algo == LOWPASS_ALGO_BILATERAL)
-    piece->process_cl_ready = (piece->process_cl_ready && !dt_opencl_avoid_atomics(pipe->devid));
+  {
+    if(dt_opencl_avoid_atomics(pipe->devid))
+    {
+      dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE,
+               "[opencl_fallback] %s: no GPU path: device avoids atomics",
+               self->op);
+      piece->process_cl_ready = FALSE;
+    }
+  }
 #endif
 
 

--- a/src/iop/monochrome.c
+++ b/src/iop/monochrome.c
@@ -326,7 +326,13 @@ void commit_params(dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_
   d->highlights = p->highlights;
 
 #ifdef HAVE_OPENCL
-  piece->process_cl_ready = (piece->process_cl_ready && !dt_opencl_avoid_atomics(pipe->devid));
+  if(dt_opencl_avoid_atomics(pipe->devid))
+  {
+    dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE,
+             "[opencl_fallback] %s: no GPU path: device avoids atomics",
+             self->op);
+    piece->process_cl_ready = FALSE;
+  }
 #endif
 }
 

--- a/src/iop/shadhi.c
+++ b/src/iop/shadhi.c
@@ -641,7 +641,15 @@ void commit_params(dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_
 
 #ifdef HAVE_OPENCL
   if(d->shadhi_algo == SHADHI_ALGO_BILATERAL)
-    piece->process_cl_ready = (piece->process_cl_ready && !dt_opencl_avoid_atomics(pipe->devid));
+  {
+    if(dt_opencl_avoid_atomics(pipe->devid))
+    {
+      dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE,
+               "[opencl_fallback] %s: no GPU path: device avoids atomics",
+               self->op);
+      piece->process_cl_ready = FALSE;
+    }
+  }
 #endif
 }
 

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -713,7 +713,12 @@ void commit_params(dt_iop_module_t *self,
 
   // 4Bayer images not implemented in OpenCL yet
   if(self->dev->image_storage.flags & DT_IMAGE_4BAYER)
+  {
+    dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE,
+             "[opencl_fallback] %s: no GPU path: 4Bayer input is not supported",
+             self->op);
     piece->process_cl_ready = FALSE;
+  }
 
   d->preset = p->preset;
 


### PR DESCRIPTION
Some diagnostic OpenCL logging of non-error cases, to aid tracing CPU/GPU paths (only logged with `-d opencl -d verbose`). One non-logging change: fail hard in opencl.c if a new pipeline type is introduced without coverage.