### PR TITLE
Fix Sony lens corrections lost on export EXIF round-trip

### DIFF
--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -985,9 +985,13 @@ static gboolean _check_lens_correction_data(Exiv2::ExifData &exifData,
    * Sony lens correction data
    */
   if(Exiv2::versionNumber() >= EXIV2_MAKE_VERSION(0, 27, 4)
-    && _exif_read_exif_tag(exifData, &posd, "Exif.SubImage1.DistortionCorrParams")
-    && _exif_read_exif_tag(exifData, &posc, "Exif.SubImage1.ChromaticAberrationCorrParams")
-    && _exif_read_exif_tag(exifData, &posv, "Exif.SubImage1.VignettingCorrParams"))
+    && ((_exif_read_exif_tag(exifData, &posd, "Exif.SubImage1.DistortionCorrParams")
+         && _exif_read_exif_tag(exifData, &posc, "Exif.SubImage1.ChromaticAberrationCorrParams")
+         && _exif_read_exif_tag(exifData, &posv, "Exif.SubImage1.VignettingCorrParams"))
+        // DNG round-trip: dt_exif_read_blob copies these to IFD0 by numeric ID
+        || (_exif_read_exif_tag(exifData, &posd, "Exif.Image.0x7037")
+            && _exif_read_exif_tag(exifData, &posc, "Exif.Image.0x7035")
+            && _exif_read_exif_tag(exifData, &posv, "Exif.Image.0x7032"))))
   {
     // Validate
     const int nc = posd->toLong(0);
@@ -2754,13 +2758,45 @@ int dt_exif_read_blob(uint8_t **buf,
     // also for DNG files.
 
     // Remove subimage* trees, related to thumbnails or HDR usually; also UserCrop.
+    // Keep Sony lens-correction tags that live in SubImage1
     for(Exiv2::ExifData::iterator i = exifData.begin(); i != exifData.end();)
     {
       static const std::string needle = "Exif.SubImage";
-      if(i->key().compare(0, needle.length(), needle) == 0)
+      const std::string &key = i->key();
+      if(key.compare(0, needle.length(), needle) == 0
+         && key != "Exif.SubImage1.DistortionCorrParams"
+         && key != "Exif.SubImage1.ChromaticAberrationCorrParams"
+         && key != "Exif.SubImage1.VignettingCorrParams")
         i = exifData.erase(i);
       else
         ++i;
+    }
+
+    // copy Sony SubImage1 lens-correction tags to IFD0 by numeric ID.
+    // exiv2 knows the Sony tag names only via its Sony parser, so it
+    // silently drops Exif.SubImage1.*CorrParams when writing into
+    // generic TIFF/DNG containers; the numeric Exif.Image.0xNNNN form
+    // survives as an unknown TIFF tag with its original type preserved
+    static const struct { const char *src; const char *dst; } sony_copies[] = {
+      { "Exif.SubImage1.DistortionCorrParams",          "Exif.Image.0x7037" },
+      { "Exif.SubImage1.ChromaticAberrationCorrParams", "Exif.Image.0x7035" },
+      { "Exif.SubImage1.VignettingCorrParams",          "Exif.Image.0x7032" },
+    };
+    for(size_t k = 0; k < G_N_ELEMENTS(sony_copies); k++)
+    {
+      try
+      {
+        Exiv2::ExifData::iterator src =
+          exifData.findKey(Exiv2::ExifKey(sony_copies[k].src));
+        if(src != exifData.end())
+          exifData.add(Exiv2::ExifKey(sony_copies[k].dst), &src->value());
+      }
+      catch(const Exiv2::AnyError &e)
+      {
+        dt_print(DT_DEBUG_IMAGEIO,
+                 "[exiv2 dt_exif_read_blob] failed to copy %s -> %s: %s",
+                 sony_copies[k].src, sony_copies[k].dst, e.what());
+      }
     }
 
     {


### PR DESCRIPTION
Closes #21437

`dt_exif_read_blob` unconditionally strips all `Exif.SubImage*` entries before writing the export EXIF blob – the comment says "thumbnails or HDR usually". But Sony bodies put their embedded distortion / CA / vignetting correction params there too (`Exif.SubImage1.DistortionCorrParams`, `ChromaticAberrationCorrParams`, `VignettingCorrParams`), so they got nuked along with the thumbnails. Re-importing any exported file from a Sony ARW lost the `embedded metadata` option in the lens correction module – noticeable for users whose lens isn't in Lensfun (newer Sony G/GM lenses, third-party glass).

Two-part fix in `src/common/exif.cc`:

1. Whitelist the three Sony correction tags from the SubImage strip
2. Copy them to IFD0 by numeric ID (`Exif.Image.0x7037 / 0x7035 / 0x7032`). exiv2 only understands the Sony tag names via its Sony parser, so it silently drops `Exif.SubImage1.*CorrParams` when writing into generic TIFF/DNG containers – the numeric form survives as an unknown TIFF tag with its original type intact

The Sony reader in `_check_lens_correction_data` gets a fallback to read from the numeric IFD0 location, mirroring the existing OpcodeList read pattern (which already supports `Exif.SubImage1.X` or `Exif.Image.X`).
