### PR TITLE
Fix green equilibration parameters

### DIFF
--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -1404,11 +1404,17 @@ void commit_params(dt_iop_module_t *self,
   if(use_method != DT_IOP_DEMOSAIC_PPG)
     d->median_thrs = 0.0f;
 
-  if(passing || bayer4 || true_monochrome)
-  {
+  // make sure we have no crazy stuff
+  if(d->green_eq < DT_IOP_GREEN_EQ_NO || d->green_eq > DT_IOP_GREEN_EQ_BOTH)
     d->green_eq = DT_IOP_GREEN_EQ_NO;
+
+  // only bayer have green equil
+  if(passing || !bayer)
+    d->green_eq = DT_IOP_GREEN_EQ_NO;
+
+  // color smoothing for bayer and xtrans
+  if(passing || bayer4 || true_monochrome)
     d->color_smoothing = DT_DEMOSAIC_SMOOTH_OFF;
-  }
 
   if(use_method & DT_DEMOSAIC_DUAL)
     d->color_smoothing = DT_DEMOSAIC_SMOOTH_OFF;

--- a/src/iop/demosaicing/basics.c
+++ b/src/iop/demosaicing/basics.c
@@ -339,14 +339,11 @@ static int green_equilibration_cl(const dt_iop_module_t *self,
       dev_out2 = dev_out;
       break;
     case DT_IOP_GREEN_EQ_BOTH:
+    default:
       dev_in1 = dev_in;
       dev_out1 = dev_tmp;
       dev_in2 = dev_tmp;
       dev_out2 = dev_out;
-      break;
-    case DT_IOP_GREEN_EQ_NO:
-    default:
-      goto error;
   }
 
   if(d->green_eq == DT_IOP_GREEN_EQ_FULL || d->green_eq == DT_IOP_GREEN_EQ_BOTH)


### PR DESCRIPTION
As reported in #21412 we can have wrong parameters for the green equilibration, this can happen

1. if we apply a demosaic preset generated on bayer sensors (including a valid green equil enum) to xtrans images (see integration test 064 as an example)
2. for some reason the xmp presented in the issue had some data completely out of range thus resulting in uninitialzed/black output data.

Fixes #21412

Release note: Fixed a bug in demosaic module resulting from bad green equilibration data.