### PR TITLE
Fixes bug in retouch module w/ blending on

### DIFF
--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -1241,12 +1241,13 @@ static inline gboolean _piece_fast_blend(const dt_dev_pixelpipe_iop_t *piece,
                                          const dt_iop_module_t *module)
 {
   return dt_pipe_is_canvas(piece->pipe)
-      && darktable.pipe_cache
-      && module->dev
-      && module->dev->gui_attached
-      && module == module->dev->gui_module
-      && dt_dev_modulegroups_test_activated(darktable.develop)
-      && _transform_for_blend(module, piece);
+         && darktable.pipe_cache
+         && dt_iop_has_focus(module)
+         // IOP_FLAGS_NO_MASKS modules (retouch, spots) consume their drawn forms
+         // inside process(), so the cached output depends on shape geometry that
+         // the fast-blend hash ignores. Skip the fast path for them.
+         && !(module->flags() & IOP_FLAGS_NO_MASKS)
+         && _transform_for_blend(module, piece);
 }
 
 static inline float *_get_fast_blendcache(const size_t nfloats,


### PR DESCRIPTION

## The bug

The pixelpipe's fast blend cache (`bcache`) caches the _focused_ module's `process()` output, so that tweaking **blend** parameters (opacity, blend mask…) can re-blend instantly without re-running `process()`. Its validity hash, `_piece_process_hash`, deliberately **excludes** the blend parameters — and with them, the drawn-mask group.

That's correct for ordinary modules, whose drawn mask is a _blend_ mask applied **after** `process()`. But **retouch** is flagged `IOP_FLAGS_NO_MASKS`: its shapes are consumed **inside** `process()` — the spots drive clone/heal/blur/fill. So when you moved or reshaped a shape:

-   The shape geometry changed →  `process()`  output  _should_  change.
-   But the bcache hash (params only)  **did not**  change → the stale pre-edit buffer was copied straight back.
-   Result: the UI says "working", but nothing changes

The path is active when **blending is engaged**, that's the gate (`mask_mode != DISABLED`) that turns the bcache on. The non-blending path was already fine: `dt_iop_commit_params` folds the spot geometry into the _main_ module-output cache hash whenever the module is in focus.

## ~~The Fix~~ [EDIT: revisited after Hanno's comment see below]

~~In `_piece_process_hash`, fold the form-group hash into the bcache validity hash for `NO_MASKS` modules — mirroring what `dt_iop_commit_params` already does for the main cache:~~

```c
if((module->flags() & IOP_FLAGS_NO_MASKS) && piece->blendop_data)
{
  const dt_develop_blend_params_t *const bp = piece->blendop_data;
  dt_masks_form_t *grp = dt_masks_get_from_id(module->dev, bp->mask_id);
  if(grp)
    phash = dt_masks_group_hash(phash, grp);
}

```

~~Only `retouch.c` (and `spots.c`) use `IOP_FLAGS_NO_MASKS`. This keeps the bcache's fast-path for genuine blend-only tweaks (opacity etc. leave the forms unchanged, so the cache still hits), while shape moves/reshapes now correctly invalidate it. It covers both the CPU and OpenCL process paths, since both use this hash.~~

## The Fix

Disable the fast-blend cache entirely for `IOP_FLAGS_NO_MASKS` modules by gating it off in `_piece_fast_blend` — the function that already collects all the cache-eligibility rules:

```c
return dt_pipe_is_canvas(piece->pipe)
         && darktable.pipe_cache
         && dt_iop_has_focus(module)
         // IOP_FLAGS_NO_MASKS modules (retouch, spots) consume their drawn forms
         // inside process(), so the cached output depends on shape geometry that
         // the fast-blend hash ignores. Skip the fast path for them.
         && !(module->flags() & IOP_FLAGS_NO_MASKS)
         && _transform_for_blend(module, piece);

```

Only `retouch.c` and `spots.c` use `IOP_FLAGS_NO_MASKS`, so this is precisely scoped to the affected modules. Putting the decision here keeps all fast-cache eligibility rules in one place and means the bcache is never even allocated for these modules — rather than maintaining a validity hash whose only purpose is to force a miss. It covers both the CPU and OpenCL process paths, since both consult `_piece_fast_blend`.

The trade-off: blend-only tweaks (e.g. dragging opacity) on retouch/spots will re-run `process()` instead of just re-blending from cache. That's acceptable — these modules have no blend mask, so the fast path bought little, and correctness wins.

### Without the fix

https://github.com/user-attachments/assets/efc1dc46-dc5d-4418-9ee6-4e9bad0beab7

### With the fix

https://github.com/user-attachments/assets/0a5393ae-c537-4e10-9e70-0aa7157aa7e5


Co-authored with Claude.