### PR TITLE
Fix 4-Bayer raws falling into 3-channel linear write path

### DIFF
--- a/src/common/ai/restore_raw_linear.c
+++ b/src/common/ai/restore_raw_linear.c
@@ -1117,7 +1117,7 @@ int dt_restore_raw_linear_preview_piped(dt_restore_context_t *ctx,
       }
       const size_t pix = (size_t)sr_raw * raw_w + sc_raw;
 
-      if(is_linear)
+      if(is_linear && mip_channels >= 3)
       {
         // float mipmaps are already in [0, 1]; uint16 needs un-prepare
         for(int c = 0; c < 3; c++)
@@ -1135,6 +1135,12 @@ int dt_restore_raw_linear_preview_piped(dt_restore_context_t *ctx,
             ((float *)patched)[off] = cam[c];
           }
         }
+      }
+      else if(is_linear)
+      {
+        // 4BAYER (CYGM/RGBE) classified as LINEAR but has mip_channels==1.
+        // no canonical RGB→CYGM/RGBE mapping; leave the original mosaic
+        // pixel untouched (already in `patched` from the memcpy above)
       }
       else
       {

--- a/src/libs/neural_restore.c
+++ b/src/libs/neural_restore.c
@@ -1366,8 +1366,10 @@ static int _process_raw_denoise_one(dt_neural_job_t *j,
       // most LINEAR-class inputs are computational raws (Apple
       // ProRAW, Google HDR+, etc.) that have already been denoised
       // on-device; the model will run but adds little; Canon/Nikon
-      // sRAW is the exception; warn once per job and proceed
-      if(!j->linear_warned)
+      // sRAW is the exception; warn once per job and proceed.
+      // 4BAYER (CYGM/RGBE) piggybacks on LINEAR class but isn't a
+      // computational raw — skip the misleading toast
+      if(!j->linear_warned && !(flags & DT_IMAGE_4BAYER))
       {
         j->linear_warned = TRUE;
         dt_control_log(_("raw denoise: this image is already pre-demosaiced "
@@ -2720,8 +2722,10 @@ static gpointer _preview_thread_raw(gpointer data)
 
   // same caveat as the batch path: LINEAR is usually a computational
   // raw that's already been denoised on-device. warn once per imgid
-  // so picking a different patch doesn't re-toast
+  // so picking a different patch doesn't re-toast. 4BAYER piggybacks
+  // on LINEAR class but isn't computational — skip the toast for it
   if(cls == DT_RESTORE_SENSOR_CLASS_LINEAR
+     && !(img_meta.flags & DT_IMAGE_4BAYER)
      && d->preview_linear_warned_imgid != pd->imgid)
   {
     d->preview_linear_warned_imgid = pd->imgid;


### PR DESCRIPTION
Follow-up to #21429. @kofa73 [caught a leftover mismatch](https://github.com/darktable-org/darktable/pull/21429#discussion_r3496421476) in the LINEAR write path.

4-Bayer raws (CYGM/RGBE) classify as LINEAR per the prior June fix, but they keep a 1-channel mosaic buffer (`mip_channels == 1`) while the linear write loop writes 3 channels per pixel – clobbering neighbour pixels. Affected hardware is from 2000–2003 and largely unsupported by rawspeed today, but the mismatch is real.

Two small changes:

- `restore_raw_linear.c`: guard the 3-channel write with `mip_channels >= 3`. 4-Bayer falls into a no-op branch and the original mosaic pixel survives from the upfront `memcpy(patched, mbuf.buf, ...)`
- `neural_restore.c`: skip the "this image is already pre-demosaiced" toast for 4-Bayer in both batch and preview paths – it's misleading since 4-Bayer is a mosaic, not pre-demosaiced