### PR TITLE
Fix out-of-bounds write in path mask border gap-filling

### DIFF
--- a/src/develop/masks/path.c
+++ b/src/develop/masks/path.c
@@ -604,6 +604,17 @@ static void _path_points_fill_border_gaps(float *cmax,
                                           dt_masks_intbuf_t *fill_seg_indexes,
                                           const gboolean clockwise)
 {
+  // Degenerate geometry (e.g. a freshly-added node whose control points
+  // coincide with its corner) can leave a border or center point unset
+  // (DT_INVALID_COORDINATE == -FLT_MAX). Computing an arc through such a point
+  // yields an infinite radius and an arc length `l` that saturates to INT_MAX;
+  // 2*(l-1) then overflows to a negative reserve count, defeating the dynbuf
+  // growth check and driving the fill loop below into an unbounded
+  // out-of-bounds write. Bail out on such input.
+  if(bmin[0] == DT_INVALID_COORDINATE || bmax[0] == DT_INVALID_COORDINATE
+     || cmax[0] == DT_INVALID_COORDINATE)
+    return;
+
   // we want to find the start and end angles
   double a1 = angle_2d(bmin[0], bmin[1], cmax[0], cmax[1]);
   double a2 = angle_2d(bmax[0], bmax[1], cmax[0], cmax[1]);
@@ -625,12 +636,13 @@ static void _path_points_fill_border_gaps(float *cmax,
   const float r2 = dt_fast_hypotf(bmax[1] - cmax[1], bmax[0] - cmax[0]);
 
   // and the max length of the circle arc
-  int l = 0;
-  if(a2 > a1)
-    l = (a2 - a1) * fmaxf(r1, r2);
-  else
-    l = (a1 - a2) * fmaxf(r1, r2);
-  if(l < 2) return;
+  const float radius = fmaxf(r1, r2);
+  // a non-finite radius would make `arc_len` saturate to INT_MAX and overflow
+  // the `2*(l-1)` reserve count below; reject it defensively
+  if(!isfinite(radius)) return;
+  const double arc_len = (a2 > a1 ? (a2 - a1) : (a1 - a2)) * (double)radius;
+  if(arc_len < 2.0 || arc_len > (double)(INT_MAX / 4)) return;
+  const int l = (int)arc_len;
 
   // and now we add the points
   const float incra = (a2 - a1) / l;


### PR DESCRIPTION
This is arguably a rare latent bug that I was lucky enough to stumble upon in the middle of an editing session.

Fireworks ensued.

### Problem

darktable crashes (`SIGSEGV`, heap buffer overflow) while moving the mouse during path-mask creation. Backtrace:

```
_path_get_pts_border  (inlined _path_points_fill_border_gaps)
_path_get_points_border
dt_masks_gui_form_create
_path_events_mouse_moved

```

### Root cause

`_path_points_fill_border_gaps()` builds an arc between two border points. When the next segment is **collapsed** — its corner and both control handles essentially coincident — `_path_border_get_XY` computes a zero derivative and returns `DT_INVALID_COORDINATE` (`-FLT_MAX`) for the border point `bmax`. From there:

1.  `dt_fast_hypotf()`  on that point overflows the radius to  `+Inf`.
2.  The arc length  `l = (a2 - a1) * fmaxf(r1, r2)`  becomes  `Inf`;  `(int)Inf`  saturates to  `INT_MAX`.
3.  `2*(l-1)`  overflows  `int`  to a small  **negative**  value, so  `dt_masks_dynbuf_reserve_n()`  skips its buffer-growth check (and rewinds  `pos`) and returns a pointer into the unenlarged buffer.
4.  The fill loop  `for(int i = 1; i < l; i++)`  then performs ~2.1 billion sequential writes, running off the end of the buffer into unmapped memory.

### Why it's rare

The crash needs `bmax` to be **exactly** `DT_INVALID_COORDINATE`, i.e. an exactly-zero segment derivative. The caller deliberately samples the border at `t = 0.00001` rather than `t = 0` precisely to avoid this: at that offset even an ordinary sharp-corner node (handle on the corner) still yields a small non-zero tangent, so `bmax` is valid and the arc length stays small. Only a fully degenerate segment (corner ≈ both handles) makes the tangent round to zero. Such segments occur only transiently — e.g. dropping a node almost on top of another, or a node mid-creation before its handles spread — and only with `nb >= 3`, which gates this code path. Once the precondition is met the overflow fires deterministically; the rarity is entirely in reaching that degenerate geometry.

### Proposed fix

In `_path_points_fill_border_gaps()`:

-   Bail out early if any input point (`bmin`/`bmax`/`cmax`) is  `DT_INVALID_COORDINATE`. This compares against a finite sentinel, so it holds regardless of fast-math flags.
-   Defensive guard: reject a non-finite radius and clamp the arc length to  `INT_MAX/4`  before the  `int`  cast, so  `2*(l-1)`  can never overflow.

Co-authored with Claude.