### PR TITLE
Fix neural restore output ignored by "ignore non-raw" filter

### DIFF
--- a/src/libs/neural_restore.c
+++ b/src/libs/neural_restore.c
@@ -994,7 +994,7 @@ static void _import_image(const char *filename,
   char *dir = g_path_get_dirname(filename);
   const dt_filmid_t filmid = dt_film_new(&film, dir);
   g_free(dir);
-  const dt_imgid_t newid = dt_image_import(filmid, filename, FALSE, FALSE);
+  const dt_imgid_t newid = dt_image_import(filmid, filename, TRUE, FALSE);
   dt_film_cleanup(&film);
 
   if(dt_is_valid_imgid(newid))


### PR DESCRIPTION
Closes #21454

When the "ignore non-raw images" import preference is enabled, neural restore's TIFF output was silently dropped on auto-import, even with the module's "add to the current collection" checkbox ticked. The user's explicit per-file consent got overridden by a global filter designed for bulk camera imports.

One-word fix in `src/libs/neural_restore.c`: pass `override_ignore_nonraws = TRUE` to `dt_image_import`. Matches how every other user-initiated single-file import site in the codebase already calls it (`cli/main.c`, `import_session.c`, `image_jobs.c`, `darktable.c`).

The filter still applies to bulk camera / folder imports where it belongs.
