### PR TITLE
history: make history reset undo/redo work again

### DIFF
--- a/src/common/history_snapshot.c
+++ b/src/common/history_snapshot.c
@@ -307,14 +307,16 @@ void dt_history_snapshot_undo_pop(gpointer user_data,
   {
     dt_undo_lt_history_t *hist = (dt_undo_lt_history_t *)data;
 
+    /* Prevent the develop-history recording callbacks from creating
+     * additional DT_UNDO_HISTORY entries when restoring the DB/XMP
+     * snapshot. This keeps the undo/redo stacks coherent so redo
+     * remains available after undo. */
+    dt_undo_disable_next(darktable.undo);
+
     if(action == DT_ACTION_UNDO)
-    {
       _history_snapshot_restore(hist->imgid, hist->before, hist->before_history_end);
-    }
     else
-    {
       _history_snapshot_restore(hist->imgid, hist->after, hist->after_history_end);
-    }
 
     *imgs = g_list_append(*imgs, GINT_TO_POINTER(hist->imgid));
   }

--- a/src/libs/history.c
+++ b/src/libs/history.c
@@ -1342,11 +1342,16 @@ void gui_reset(dt_lib_module_t *self)
           (_("delete image's history?"), "",
            _("do you really want to clear history of current image?")))
   {
+    /* Record a lighttable-history undo so the user can undo a full
+     * history reset (this writes DB/XMP and must be revertible).
+     * Also record a develop (in-memory) history snapshot inside the
+     * same undo group so undo restores both DB/XMP and the current
+     * develop state (including the auto-applied defaults). */
+    dt_undo_start_group(darktable.undo, DT_UNDO_LT_HISTORY);
     dt_dev_undo_start_record(darktable.develop);
-
-    dt_history_delete_on_image_ext(imgid, FALSE, TRUE);
-
+    dt_history_delete(imgid, TRUE);
     dt_dev_undo_end_record(darktable.develop);
+    dt_undo_end_group(darktable.undo);
 
     dt_dev_modulegroups_set(darktable.develop, dt_dev_modulegroups_get(darktable.develop));
 


### PR DESCRIPTION
Currently, you are not able to undo a history reset on a photo; performing an undo will simply undo the last step of the newly applied history defaults.

This patch records grouped lighttable-history and develop-state undo for history reset, and disables redundant undo recording during history snapshot restore.

This keeps the undo/redo stacks coherent and makes undo/redo work exactly as a user expects.