### PR TITLE
Enforce loading screen on windows systems

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -2645,7 +2645,7 @@
     <shortdescription>whether to show the compute variance mode in denoiseprofile</shortdescription>
     <longdescription>adds a mode in denoiseprofile that allows to compute the variance after the generalized anscombe transform is performed</longdescription>
   </dtconfig>
-  <dtconfig prefs="darkroom" section="general">
+  <dtconfig prefs="darkroom" capability="nonwindows" section="general">
     <name>darkroom/ui/loading_screen</name>
     <type>bool</type>
     <default>true</default>

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -2082,9 +2082,11 @@ int dt_init(int argc,
   dt_capabilities_add("nonapple");
 #elif defined(__APPLE__)
   dt_capabilities_add("apple");
+  dt_capabilities_add("nonwindows");
 #else
   dt_capabilities_add("linux");
   dt_capabilities_add("nonapple");
+  dt_capabilities_add("nonwindows");
 #endif
 
   dt_print(DT_DEBUG_CONTROL,

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -591,6 +591,12 @@ void expose(dt_view_t *self,
         port->pipe->backbuf                                // do we have an image?
      && port->pipe->output_imgid == dev->image_storage.id; // same image?
 
+  const gboolean use_loading_screen =
+#ifdef _WIN32
+    TRUE;
+#else
+    dt_conf_get_bool("darkroom/ui/loading_screen");
+#endif
   if(expose_full)
   {
     // draw image
@@ -601,7 +607,7 @@ void expose(dt_view_t *self,
       cairo_surface_destroy(darktable.gui->surface);
       darktable.gui->surface = NULL;
     }
-    if(!dt_conf_get_bool("darkroom/ui/loading_screen"))
+    if(!use_loading_screen)
     {
       // cache the rendered bitmap for use while loading the next image
       darktable.gui->surface = cairo_get_target(cri);
@@ -687,14 +693,14 @@ void expose(dt_view_t *self,
     else
     {
       fontsize = DT_PIXEL_APPLY_DPI(14);
-      if(dt_conf_get_bool("darkroom/ui/loading_screen"))
+      if(use_loading_screen)
         load_txt = g_strdup_printf(C_("darkroom", "loading `%s' ..."),
                                    dev->image_storage.filename);
       else
         load_txt = g_strdup(dev->image_storage.filename);
     }
 
-    if(dt_conf_get_bool("darkroom/ui/loading_screen"))
+    if(use_loading_screen)
     {
       dt_gui_gtk_set_source_rgb(cri, DT_GUI_COLOR_DARKROOM_BG);
       cairo_paint(cri);


### PR DESCRIPTION
As
- we can't agree on removing the loading screen conf option (#21402)
- there are issues on windows systems if loading screen is disabled (#21128 #21395 and more)

let's enforce the loading screen on windows systems for now. Adds capability "nonwindows" so the preferences menu won't confuse windows users.

Release note:
Enforce darktable loading screen on windowes system to avoid darkroom refreshing issues