### PR TITLE
Show warning on 4BAYER raw denoise preview

### DIFF
--- a/src/libs/neural_restore.c
+++ b/src/libs/neural_restore.c
@@ -1697,6 +1697,19 @@ static void _update_info_label(dt_lib_neural_restore_t *d)
                           : _("output: LinearRaw DNG"));
   }
 
+  // 4BAYER preview shows no denoise effect (no RGB→CFA mapping)
+  if(d->task == NEURAL_TASK_RAW_DENOISE && dt_is_valid_imgid(imgid))
+  {
+    const dt_image_t *cached = dt_image_cache_get(imgid, 'r');
+    if(cached)
+    {
+      if(cached->flags & DT_IMAGE_4BAYER)
+        snprintf(d->warning_text, sizeof(d->warning_text), "%s",
+                 _("preview unavailable – process to save result"));
+      dt_image_cache_read_release(cached);
+    }
+  }
+
   // gamut note (informational, not a warning): reuse the same info
   // line as the upscale size display. for denoise, shows standalone
   // in info_text_left; for upscale, appended to the size info. not


### PR DESCRIPTION
Follow-up to [kofa's review on #21463](https://github.com/darktable-org/darktable/pull/21463#pullrequestreview-4606700445).

For 4BAYER (CYGM/RGBE) raws, the preview's re-mosaic step has no RGB→CFA mapping – the model runs but its output can't be written back into the mosaic buffer, so before and after look identical in the split view. kofa flagged this: user sees "before / after look the same" and doesn't know why.

Batch processing still works – it uses a demosaic-then-denoise path that writes a Linear DNG directly, no re-mosaic needed. So the preview is the only broken bit.

Fix: red warning bar at the top of the preview for 4BAYER images, using the same mechanism the upscale task uses for "large output" warnings. Text: `preview unavailable – process to save result`.
