### PR TITLE
Do not override library edit history from XMP sidecar file when using darktable-cli

### DIFF
--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -95,6 +95,8 @@ fprintf(stderr, "darktable %s\n"
                 "                          multiple times instead of input file\n"
                 "   --library <path> read the history stack from library database\n"
                 "                    instead of XMP sidecar files\n"
+                "                    using ':memory:' for an empty in-memory library\n"
+                "                    is useless for darktable cli export\n"
                 "   --icc-type <type> specify icc type, default to NONE\n"
                 "                     use --help icc-type for list of supported types\n"
                 "   --icc-file <file> specify icc filename, default to NONE\n"
@@ -384,6 +386,13 @@ int main(int argc, char *arg[])
       {
         k++;
         library = arg[k];
+        if(!strcmp(library, ":memory:"))
+        {
+          fprintf(stderr, _("empty in-memory library is useless for darktable cli export\n"));
+          usage(arg[0]);
+          exit(1);
+        }
+
       }
       else if(!strcmp(arg[k], "--icc-type") && argc > k + 1)
       {

--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -575,6 +575,9 @@ int main(int argc, char *arg[])
     exit(1);
   }
 
+  // When --library was provided, use the DB history; otherwise keep XMP override mode.
+  darktable.prefer_library_history = (library != NULL);
+
   GList *id_list = NULL;
 
   for(GList *l = inputs; l != NULL; l=g_list_next(l))

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -486,6 +486,9 @@ typedef struct darktable_t
   int32_t unmuted_signal_dbg_acts;
   gboolean unmuted_signal_dbg[DT_SIGNAL_COUNT];
   gboolean pipe_cache;
+  // Keep database history for known images rather than replacing it from XMP.
+  // Set by darktable-cli with explicit --library <db>; GUI and CLI use XMP by default.
+  gboolean prefer_library_history;
   int gui_running;		// atomic, access with g_atomic_int_*()
   GTimeZone *utc_tz;
   GDateTime *origin_gdt;

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -1874,8 +1874,13 @@ static dt_imgid_t _image_import_internal(const dt_filmid_t film_id,
     if(img)
       img->flags &= ~DT_IMAGE_REMOVE;
     dt_image_cache_write_release(img, DT_IMAGE_CACHE_RELAXED);
-    _image_read_duplicates(id, normalized_filename, raise_signals);
-    dt_image_synch_all_xmp(normalized_filename);
+    // Reconcile with XMP sidecars unless library history is preferred to avoid
+    // overwriting library edit history with potentially stale XMP history.
+    if(!darktable.prefer_library_history)
+    {
+      _image_read_duplicates(id, normalized_filename, raise_signals);
+      dt_image_synch_all_xmp(normalized_filename);
+    }
     g_free(ext);
     g_free(normalized_filename);
     if(raise_signals)


### PR DESCRIPTION
When darktable-cli is executed via the `--library <db>` and the RAW file to be exported has an associated (potentially stale) XMP sidecar file, the library history stack gets overridden. This change proposes to prefer the library database history entry over an existing XMP sidecar file once the `--library` argument is provided to darktable-cli.