### PR TITLE
Offer more than one OpenCL starting option

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -727,11 +727,11 @@ static int32_t _detect_opencl_job_run(dt_job_t *job)
   return 0;
 }
 
-static dt_job_t *_detect_opencl_job_create(gboolean exclude_opencl)
+static dt_job_t *_detect_opencl_job_create(int options)
 {
   dt_job_t *job = dt_control_job_create(&_detect_opencl_job_run, "detect opencl devices");
   if(!job) return NULL;
-  dt_control_job_set_params(job, GINT_TO_POINTER(exclude_opencl), NULL);
+  dt_control_job_set_params(job, GINT_TO_POINTER(options), NULL);
   return job;
 }
 
@@ -1022,10 +1022,10 @@ int dt_init(int argc,
   darktable.tmp_directory = NULL;
   darktable.bench_module = NULL;
 
-  gboolean exclude_opencl = TRUE;
+  int options = DT_OPENCL_OPTION_EXCLUDE;
   gboolean print_statistics = FALSE;
 #ifdef HAVE_OPENCL
-  exclude_opencl = FALSE;
+  options = DT_OPENCL_OPTION_NONE;
   print_statistics = (strstr(argv[0], "darktable-cltest") == NULL);
 #endif
 
@@ -1331,7 +1331,7 @@ int dt_init(int argc,
       else if(!strcmp(argv[k], "--disable-opencl"))
       {
 #ifdef HAVE_OPENCL
-        exclude_opencl = TRUE;
+        options |= DT_OPENCL_OPTION_EXCLUDE;
 #endif
         argv[k] = NULL;
       }
@@ -1907,9 +1907,9 @@ int dt_init(int argc,
 
   // Only then kick off the OpenCL background job
   if(init_gui)
-    dt_control_add_job(DT_JOB_QUEUE_SYSTEM_BG, _detect_opencl_job_create(exclude_opencl));
+    dt_control_add_job(DT_JOB_QUEUE_SYSTEM_BG, _detect_opencl_job_create(options));
   else
-    dt_opencl_init(darktable.opencl, exclude_opencl, print_statistics);
+    dt_opencl_init(darktable.opencl, options, print_statistics);
 
   // must come before mipmap_cache, because that one will need to access image dimensions stored in here:
   dt_image_cache_init();

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -178,6 +178,14 @@ typedef int32_t dt_filmid_t;
 #define DT_DEVICE_CPU -1
 #define DT_DEVICE_NONE -2
 
+// We have several bitmask opencl start options passed to dt_opencl_init()
+#define DT_OPENCL_OPTION_NONE 0       // default
+#define DT_OPENCL_OPTION_EXCLUDE 1    // --disable-opencl:  disables OpenCL for the session
+// some reserved options, mentioned cli options might not be available depending on build
+#define DT_OPENCL_OPTION_FAST_TILE 2  // --cl-tiling:       use OpenCL tiling mode (debugging session)
+#define DT_OPENCL_OPTION_SPURIOS 4    // --cl-spurious:     insert random OpenCL errors while processing modules (debugging session)
+#define DT_OPENCL_OPTION_MIGRATE 8    // --cl-migrate:      enforce cl_mem migration while allocating cl_mem (debugging session)
+
 typedef int32_t dt_mask_id_t;
 #define INVALID_MASKID (-1)
 #define NO_MASKID (0)

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -211,6 +211,10 @@ const char *cl_errstr(cl_int error)
       return "DT_OPENCL_PROCESS_CL";
     case DT_OPENCL_NODEVICE:
       return "DT_OPENCL_NODEVICE";
+    case DT_OPENCL_SPURIOUS:
+      return "DT_OPENCL_SPURIOUS";
+    case DT_OPENCL_MIGRATE:
+      return "DT_OPENCL_MIGRATE";
     default:
       return "Unknown OpenCL error";
   }
@@ -1224,15 +1228,19 @@ static void _cleanup_cl_device_mem(dt_opencl_t *cl, const int i)
 }
 
 void dt_opencl_init(dt_opencl_t *cl,
-                    const gboolean exclude_opencl,
+                    const int options,
                     const gboolean print_statistics)
 {
+  const gboolean exclude_opencl = options & DT_OPENCL_OPTION_EXCLUDE;
   dt_pthread_mutex_init(&cl->lock, NULL);
   cl->inited = FALSE;
   cl->enabled = FALSE;
   cl->stopped = FALSE;
   cl->error_count = 0;
   cl->fastcl = dt_conf_get_bool("opencl_fast");
+  cl->fast_tiling = options & DT_OPENCL_OPTION_FAST_TILE;
+  cl->spurious = options & DT_OPENCL_OPTION_SPURIOS;
+  cl->migrate = options & DT_OPENCL_OPTION_MIGRATE;
 #if CL_TARGET_OPENCL_VERSION == 300
   cl->api30 = TRUE;
 #else
@@ -1262,7 +1270,7 @@ void dt_opencl_init(dt_opencl_t *cl,
   if(exclude_opencl)
   {
     dt_print_nts(DT_DEBUG_OPENCL,
-             "[opencl_init] opencl disabled due to explicit user request\n");
+             "[opencl_init] opencl disabled by --disable-opencl\n");
     goto finally;
   }
 

--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -45,6 +45,8 @@
 #define DT_OPENCL_SYSMEM_ALLOCATION -998
 #define DT_OPENCL_PROCESS_CL -997
 #define DT_OPENCL_NODEVICE -996
+#define DT_OPENCL_SPURIOUS -995
+#define DT_OPENCL_MIGRATE -994
 
 #include "common/darktable.h"
 
@@ -234,6 +236,9 @@ typedef struct dt_opencl_t
   gboolean enabled;
   gboolean stopped;
   gboolean fastcl;  // for fast runtime checks instead of reading the conf
+  gboolean fast_tiling;
+  gboolean spurious;
+  gboolean migrate;
   int num_devs;
   int error_count;
   int opencl_synchronization_timeout;
@@ -307,7 +312,7 @@ int dt_opencl_get_device_info(dt_opencl_t *cl,
 
 /** inits the opencl subsystem. */
 void dt_opencl_init(dt_opencl_t *cl,
-                    const gboolean exclude_opencl,
+                    const int options,
                     const gboolean print_statistics);
 
 /** cleans up the opencl subsystem. */
@@ -628,7 +633,7 @@ typedef struct dt_opencl_t
 } dt_opencl_t;
 
 static inline void dt_opencl_init(dt_opencl_t *cl,
-                                  const gboolean exclude_opencl,
+                                  const int options,
                                   const gboolean print_statistics)
 {
   cl->inited = FALSE;


### PR DESCRIPTION
Currently we start OpenCL via `dt_opencl_init()` with one specific gboolean option to disable the OpenCL subsysten.

In preparation for more global flags via cli we now pass a bit-field int value.
```
- DT_OPENCL_OPTION_NONE 0       // default
- DT_OPENCL_OPTION_EXCLUDE 1    // --disable-opencl:  disables OpenCL for the session
- // some reserved options, mentioned cli options might not be available depending on build
- DT_OPENCL_OPTION_FAST_TILE 2  // --cl-tiling:       use OpenCL tiling mode (debugging session)
- DT_OPENCL_OPTION_SPURIOS 4    // --cl-spurious:     insert random OpenCL errors while processing modules (debugging session)
- DT_OPENCL_OPTION_MIGRATE 8    // --cl-migrate:      enforce cl_mem migration while allocating cl_mem (debugging session)
```
are used/reserved, if set by options the according gbooleans in `dt_opencl_t` are set too.

Two addional dt specific OpenCL error codes for improved debugging.
 `DT_OPENCL_SPURIOUS`
 `DT_OPENCL_MIGRATE`