### PR TITLE
Add SAM-style segmentation architecture

### DIFF
--- a/src/common/ai/segmentation.c
+++ b/src/common/ai/segmentation.c
@@ -28,8 +28,10 @@
 #include <stdlib.h>
 #include <string.h>
 
-// SAM encoder expects 1024x1024 input
+// SAM2 encoder expects 1024x1024 input; SAM3 uses 1008x1008
 #define SAM_INPUT_SIZE 1024
+#define SAM3_INPUT_SIZE 1008
+#define SAM3_MASK_SIZE 288
 
 // ImageNet normalization constants
 static const float IMG_MEAN[3] = {123.675f, 116.28f, 103.53f};
@@ -49,6 +51,7 @@ static const float IMG_STD[3] = {58.395f, 57.12f, 57.375f};
 typedef enum dt_seg_model_type_t
 {
   DT_SEG_MODEL_SAM,     // SAM/SAM2: multi-mask + IoU + low_res refinement
+  DT_SEG_MODEL_SAM3,    // SAM3: SAM-style decoder with native 1008px input
   DT_SEG_MODEL_SEGNEXT  // SegNext: single mask, full-res prev_mask refinement
 } dt_seg_model_type_t;
 
@@ -78,7 +81,7 @@ struct dt_seg_context_t
   size_t enc_sizes[MAX_ENCODER_OUTPUTS];
 
   // previous mask for iterative refinement
-  // SAM: low-res [1][1][prev_mask_dim][prev_mask_dim] (typically 256x256)
+  // SAM: low-res [1][1][prev_mask_dim][prev_mask_dim]
   // SegNext: full-res [1][1][prev_mask_dim][prev_mask_dim] (typically 1024x1024)
   float *prev_mask;
   int prev_mask_dim;
@@ -87,7 +90,8 @@ struct dt_seg_context_t
   // image dimensions that were encoded
   int encoded_width;
   int encoded_height;
-  float scale; // SAM_INPUT_SIZE / max(w, h)
+  int input_size;
+  float scale; // input_size / max(w, h)
   gboolean image_encoded;
 
   // RGB at encoded resolution, used as JBU guide when upsampling
@@ -100,19 +104,19 @@ struct dt_seg_context_t
 
 /* --- preprocessing --- */
 
-// resize RGB image so longest side = SAM_INPUT_SIZE, pad with zeros,
+// resize RGB image so longest side = target, pad with zeros,
 // convert HWC -> CHW.  When normalize=TRUE, applies ImageNet mean/std
 // (SAM models).  When FALSE, scales to [0,1] only (SegNext bakes
 // normalization into the ONNX encoder graph).
-// output: float buffer [1, 3, SAM_INPUT_SIZE, SAM_INPUT_SIZE]
+// output: float buffer [1, 3, target, target]
 static float *
 _preprocess_image(const uint8_t *rgb_data,
                   const int width,
                   const int height,
                   const gboolean normalize,
+                  const int target,
                   float *out_scale)
 {
-  const int target = SAM_INPUT_SIZE;
   const float scale = (float)target / (float)(width > height ? width : height);
   const int new_w = MIN((int)(width * scale + 0.5f), target);
   const int new_h = MIN((int)(height * scale + 0.5f), target);
@@ -432,6 +436,8 @@ dt_seg_context_t *dt_seg_load(dt_ai_environment_t *env, const char *model_id)
 
   if(strcmp(arch, "sam2") == 0)
     ctx->model_type = DT_SEG_MODEL_SAM;
+  else if(strcmp(arch, "sam3") == 0)
+    ctx->model_type = DT_SEG_MODEL_SAM3;
   else if(strcmp(arch, "segnext") == 0)
     ctx->model_type = DT_SEG_MODEL_SEGNEXT;
   else
@@ -443,16 +449,22 @@ dt_seg_context_t *dt_seg_load(dt_ai_environment_t *env, const char *model_id)
     return NULL;
   }
 
-  // SAM requires external ImageNet normalization; SegNext bakes it into the encoder
-  ctx->normalize = (ctx->model_type == DT_SEG_MODEL_SAM);
+  const gboolean is_sam_model = ctx->model_type == DT_SEG_MODEL_SAM
+                                || ctx->model_type == DT_SEG_MODEL_SAM3;
+  ctx->input_size = ctx->model_type == DT_SEG_MODEL_SAM3
+                    ? SAM3_INPUT_SIZE
+                    : SAM_INPUT_SIZE;
+
+  // SAM models require external ImageNet normalization; SegNext bakes it into the encoder
+  ctx->normalize = is_sam_model;
 
   // query decoder mask output shape: [1, N, H, W] (SAM) or [1, 1, H, W] (SegNext)
   int64_t dec_out_shape[MAX_TENSOR_DIMS];
   const int dec_out_ndim = dt_ai_get_output_shape(decoder, 0, dec_out_shape, MAX_TENSOR_DIMS);
 
-  if(ctx->model_type == DT_SEG_MODEL_SAM)
+  if(is_sam_model)
   {
-    // SAM path
+    // SAM/SAM3 path
     ctx->num_masks = (dec_out_ndim >= 4 && dec_out_shape[1] > 1) ? (int)dec_out_shape[1] : 0;
 
     if(ctx->num_masks == 0)
@@ -517,20 +529,22 @@ dt_seg_context_t *dt_seg_load(dt_ai_environment_t *env, const char *model_id)
                ctx->dec_mask_h, ctx->dec_mask_w, ctx->num_masks);
     }
 
-    // if dims are still dynamic after override, fall back to SAM_INPUT_SIZE,
+    // if dims are still dynamic after override, fall back to input_size,
     // the backend uses ORT-allocated outputs for dynamic shapes and reports
     // actual dims after inference via the shape array
     if(ctx->dec_mask_h <= 0 || ctx->dec_mask_w <= 0)
     {
       dt_print(DT_DEBUG_AI,
                "[segmentation] using fallback mask dims %dx%d (runtime-resolved)",
-               SAM_INPUT_SIZE, SAM_INPUT_SIZE);
-      ctx->dec_mask_h = SAM_INPUT_SIZE;
-      ctx->dec_mask_w = SAM_INPUT_SIZE;
+               ctx->input_size, ctx->input_size);
+      ctx->dec_mask_h = ctx->input_size;
+      ctx->dec_mask_w = ctx->input_size;
     }
 
     // query low_res mask spatial dimensions from decoder output 2
-    ctx->prev_mask_dim = 256; // default
+    ctx->prev_mask_dim = ctx->model_type == DT_SEG_MODEL_SAM3
+                         ? SAM3_MASK_SIZE
+                         : 256;
     {
       int64_t lr_shape[MAX_TENSOR_DIMS];
       const int lr_ndim = dt_ai_get_output_shape(decoder, 2, lr_shape, MAX_TENSOR_DIMS);
@@ -559,7 +573,10 @@ dt_seg_context_t *dt_seg_load(dt_ai_environment_t *env, const char *model_id)
     return NULL;
   }
 
-  const char *type_name = (ctx->model_type == DT_SEG_MODEL_SAM) ? "SAM" : "SegNext";
+  const char *type_name = ctx->model_type == DT_SEG_MODEL_SAM3
+                          ? "SAM3"
+                          : (ctx->model_type == DT_SEG_MODEL_SAM
+                             ? "SAM" : "SegNext");
   dt_print(DT_DEBUG_AI,
            "[segmentation] model loaded: %s [%s] (enc_outputs=%d, num_masks=%d, "
            "dec_dims=%dx%d, prev_mask_dim=%d)",
@@ -595,7 +612,8 @@ void dt_seg_warmup_decoder(dt_seg_context_t *ctx)
 
   dt_print(DT_DEBUG_AI, "[segmentation] warming up decoder...");
   const double t0 = dt_get_wtime();
-  const gboolean is_sam = (ctx->model_type == DT_SEG_MODEL_SAM);
+  const gboolean is_sam = ctx->model_type == DT_SEG_MODEL_SAM
+                          || ctx->model_type == DT_SEG_MODEL_SAM3;
   const int pm_dim = ctx->prev_mask_dim;
   const int nm = ctx->num_masks;
   const int dec_h = ctx->dec_mask_h;
@@ -730,12 +748,13 @@ dt_seg_encode_image(dt_seg_context_t *ctx,
     return TRUE;
 
   float scale;
-  float *preprocessed = _preprocess_image(rgb_data, width, height, ctx->normalize, &scale);
+  float *preprocessed = _preprocess_image(rgb_data, width, height,
+                                          ctx->normalize, ctx->input_size, &scale);
   if(!preprocessed)
     return FALSE;
 
   // run encoder
-  int64_t input_shape[4] = {1, 3, SAM_INPUT_SIZE, SAM_INPUT_SIZE};
+  int64_t input_shape[4] = {1, 3, ctx->input_size, ctx->input_size};
   dt_ai_tensor_t input
     = { .data = preprocessed,
        .type  = DT_AI_FLOAT,
@@ -865,7 +884,8 @@ float *dt_seg_compute_mask(dt_seg_context_t *ctx,
   if(!ctx || !ctx->image_encoded || !points || n_points <= 0)
     return NULL;
 
-  const gboolean is_sam = (ctx->model_type == DT_SEG_MODEL_SAM);
+  const gboolean is_sam = ctx->model_type == DT_SEG_MODEL_SAM
+                          || ctx->model_type == DT_SEG_MODEL_SAM3;
 
   // build point prompts
   // SAM ONNX requires a padding point (0,0) with label -1 appended
@@ -1093,7 +1113,7 @@ float *dt_seg_compute_mask(dt_seg_context_t *ctx,
     return NULL;
   }
 
-  const float mask_scale = ctx->scale * (float)dec_h / (float)SAM_INPUT_SIZE;
+  const float mask_scale = ctx->scale * (float)dec_h / (float)ctx->input_size;
   _crop_resize_mask(masks + (size_t)best * per_mask,
                     dec_w, dec_h,
                     result, final_w, final_h,
@@ -1122,7 +1142,8 @@ gboolean dt_seg_is_encoded(dt_seg_context_t *ctx)
 
 gboolean dt_seg_supports_box(dt_seg_context_t *ctx)
 {
-  return ctx ? (ctx->model_type == DT_SEG_MODEL_SAM) : FALSE;
+  return ctx ? (ctx->model_type == DT_SEG_MODEL_SAM
+                || ctx->model_type == DT_SEG_MODEL_SAM3) : FALSE;
 }
 
 void dt_seg_reset_prev_mask(dt_seg_context_t *ctx)

--- a/src/common/ai/segmentation.c
+++ b/src/common/ai/segmentation.c
@@ -307,11 +307,39 @@ dt_seg_context_t *dt_seg_load(dt_ai_environment_t *env, const char *model_id)
   if(!env || !model_id)
     return NULL;
 
+  // detect model type from arch field in model registry before loading
+  // sessions, since SAM3 encoder graphs may need conservative ORT options
+  const dt_ai_model_info_t *minfo
+    = dt_ai_get_model_info_by_id(env, model_id);
+  const char *arch = minfo ? minfo->arch : "";
+  dt_seg_model_type_t model_type;
+
+  if(strcmp(arch, "sam2") == 0)
+    model_type = DT_SEG_MODEL_SAM;
+  else if(strcmp(arch, "sam3") == 0)
+    model_type = DT_SEG_MODEL_SAM3;
+  else if(strcmp(arch, "segnext") == 0)
+    model_type = DT_SEG_MODEL_SEGNEXT;
+  else
+  {
+    dt_print(DT_DEBUG_AI,
+             "[segmentation] unknown arch '%s' for %s",
+             arch, model_id);
+    return NULL;
+  }
+
+  const gboolean is_sam_model = model_type == DT_SEG_MODEL_SAM
+                                || model_type == DT_SEG_MODEL_SAM3;
+
   // honour explicit env override (e.g. CPU fallback after a CoreML failure);
   // CONFIGURED would re-read conf and lose the override
   const dt_ai_provider_t enc_provider = dt_ai_env_get_provider(env);
+  const dt_ai_opt_level_t enc_opt = model_type == DT_SEG_MODEL_SAM3
+                                    ? DT_AI_OPT_DISABLED
+                                    : DT_AI_OPT_ALL;
   dt_ai_context_t *encoder
-    = dt_ai_load_model(env, model_id, "encoder.onnx", enc_provider);
+    = dt_ai_load_model_ext(env, model_id, "encoder.onnx", enc_provider,
+                           enc_opt, NULL, 0);
   if(!encoder)
   {
     dt_print(DT_DEBUG_AI, "[segmentation] failed to load encoder for %s", model_id);
@@ -354,6 +382,7 @@ dt_seg_context_t *dt_seg_load(dt_ai_environment_t *env, const char *model_id)
   dt_seg_context_t *ctx = g_new0(dt_seg_context_t, 1);
   ctx->encoder = encoder;
   ctx->decoder = decoder;
+  ctx->model_type = model_type;
   ctx->model_id = g_strdup(model_id);
   ctx->model_version = g_strdup(version);
 
@@ -429,28 +458,6 @@ dt_seg_context_t *dt_seg_load(dt_ai_environment_t *env, const char *model_id)
                     di ? ", " : "", di, ctx->enc_order[di]);
   dt_print(DT_DEBUG_AI, "[segmentation] tensor routing: %s", map);
 
-  // detect model type from arch field in model registry
-  const dt_ai_model_info_t *minfo
-    = dt_ai_get_model_info_by_id(env, model_id);
-  const char *arch = minfo ? minfo->arch : "";
-
-  if(strcmp(arch, "sam2") == 0)
-    ctx->model_type = DT_SEG_MODEL_SAM;
-  else if(strcmp(arch, "sam3") == 0)
-    ctx->model_type = DT_SEG_MODEL_SAM3;
-  else if(strcmp(arch, "segnext") == 0)
-    ctx->model_type = DT_SEG_MODEL_SEGNEXT;
-  else
-  {
-    dt_print(DT_DEBUG_AI,
-             "[segmentation] unknown arch '%s' for %s",
-             arch, model_id);
-    dt_seg_free(ctx);
-    return NULL;
-  }
-
-  const gboolean is_sam_model = ctx->model_type == DT_SEG_MODEL_SAM
-                                || ctx->model_type == DT_SEG_MODEL_SAM3;
   ctx->input_size = ctx->model_type == DT_SEG_MODEL_SAM3
                     ? SAM3_INPUT_SIZE
                     : SAM_INPUT_SIZE;

--- a/src/common/ai/segmentation.c
+++ b/src/common/ai/segmentation.c
@@ -28,7 +28,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-// default SAM-style encoder input size
+// default SAM encoder input size
 #define SAM_INPUT_SIZE 1024
 
 // ImageNet normalization constants
@@ -48,7 +48,7 @@ static const float IMG_STD[3] = {58.395f, 57.12f, 57.375f};
 // model architecture type, determines preprocessing, decoder I/O, and refinement
 typedef enum dt_seg_model_type_t
 {
-  DT_SEG_MODEL_SAM,     // SAM-style: multi-mask + IoU + low_res refinement
+  DT_SEG_MODEL_SAM,     // SAM: multi-mask + IoU + low_res refinement
   DT_SEG_MODEL_SEGNEXT  // SegNext: single mask, full-res prev_mask refinement
 } dt_seg_model_type_t;
 
@@ -98,29 +98,6 @@ struct dt_seg_context_t
   char *model_id;      // model identifier (for cache validation)
   char *model_version; // model version (for cache validation)
 };
-
-static dt_ai_opt_level_t
-_seg_encoder_optimization(const dt_ai_model_info_t *info)
-{
-  dt_ai_opt_level_t opt = DT_AI_OPT_ALL;
-  char *opt_str = dt_ai_model_attribute_string(info, "encoder_optimization");
-
-  if(opt_str)
-  {
-    if(g_strcmp0(opt_str, "disabled") == 0
-       || g_strcmp0(opt_str, "none") == 0)
-      opt = DT_AI_OPT_DISABLED;
-    else if(g_strcmp0(opt_str, "basic") == 0)
-      opt = DT_AI_OPT_BASIC;
-    else if(g_strcmp0(opt_str, "all") != 0)
-      dt_print(DT_DEBUG_AI,
-               "[segmentation] unknown encoder_optimization '%s', using all",
-               opt_str);
-    g_free(opt_str);
-  }
-
-  return opt;
-}
 
 /* --- preprocessing --- */
 
@@ -327,8 +304,7 @@ dt_seg_context_t *dt_seg_load(dt_ai_environment_t *env, const char *model_id)
   if(!env || !model_id)
     return NULL;
 
-  // detect model type before loading sessions so manifest attributes can
-  // influence backend options
+  // detect model type from arch field in model registry
   const dt_ai_model_info_t *minfo
     = dt_ai_get_model_info_by_id(env, model_id);
   const char *arch = minfo ? minfo->arch : "";
@@ -351,10 +327,8 @@ dt_seg_context_t *dt_seg_load(dt_ai_environment_t *env, const char *model_id)
   // honour explicit env override (e.g. CPU fallback after a CoreML failure);
   // CONFIGURED would re-read conf and lose the override
   const dt_ai_provider_t enc_provider = dt_ai_env_get_provider(env);
-  const dt_ai_opt_level_t enc_opt = _seg_encoder_optimization(minfo);
   dt_ai_context_t *encoder
-    = dt_ai_load_model_ext(env, model_id, "encoder.onnx", enc_provider,
-                           enc_opt, NULL, 0);
+    = dt_ai_load_model(env, model_id, "encoder.onnx", enc_provider);
   if(!encoder)
   {
     dt_print(DT_DEBUG_AI, "[segmentation] failed to load encoder for %s", model_id);
@@ -474,13 +448,6 @@ dt_seg_context_t *dt_seg_load(dt_ai_environment_t *env, const char *model_id)
   dt_print(DT_DEBUG_AI, "[segmentation] tensor routing: %s", map);
 
   ctx->input_size = dt_ai_model_attribute_int(minfo, "input_size", SAM_INPUT_SIZE);
-  if(ctx->input_size <= 0)
-  {
-    dt_print(DT_DEBUG_AI,
-             "[segmentation] invalid input_size %d, using %d",
-             ctx->input_size, SAM_INPUT_SIZE);
-    ctx->input_size = SAM_INPUT_SIZE;
-  }
 
   // SAM models require external ImageNet normalization; SegNext bakes it into the encoder
   ctx->normalize = is_sam_model;
@@ -491,7 +458,7 @@ dt_seg_context_t *dt_seg_load(dt_ai_environment_t *env, const char *model_id)
 
   if(is_sam_model)
   {
-    // SAM-style path
+    // SAM path
     ctx->num_masks = (dec_out_ndim >= 4 && dec_out_shape[1] > 1) ? (int)dec_out_shape[1] : 0;
 
     if(ctx->num_masks == 0)
@@ -570,13 +537,6 @@ dt_seg_context_t *dt_seg_load(dt_ai_environment_t *env, const char *model_id)
 
     // query low_res mask spatial dimensions from decoder output 2
     ctx->prev_mask_dim = dt_ai_model_attribute_int(minfo, "prev_mask_size", 256);
-    if(ctx->prev_mask_dim <= 0)
-    {
-      dt_print(DT_DEBUG_AI,
-               "[segmentation] invalid prev_mask_size %d, using 256",
-               ctx->prev_mask_dim);
-      ctx->prev_mask_dim = 256;
-    }
     {
       int64_t lr_shape[MAX_TENSOR_DIMS];
       const int lr_ndim = dt_ai_get_output_shape(decoder, 2, lr_shape, MAX_TENSOR_DIMS);
@@ -608,9 +568,9 @@ dt_seg_context_t *dt_seg_load(dt_ai_environment_t *env, const char *model_id)
   const char *type_name = ctx->model_type == DT_SEG_MODEL_SAM
                           ? "SAM" : "SegNext";
   dt_print(DT_DEBUG_AI,
-           "[segmentation] model loaded: %s [%s] (enc_outputs=%d, num_masks=%d, "
+           "[segmentation] model loaded: %s [%s] (input_size=%d, enc_outputs=%d, num_masks=%d, "
            "dec_dims=%dx%d, prev_mask_dim=%d)",
-           model_id, type_name, ctx->n_enc_outputs, ctx->num_masks,
+           model_id, type_name, ctx->input_size, ctx->n_enc_outputs, ctx->num_masks,
            ctx->dec_mask_h, ctx->dec_mask_w, ctx->prev_mask_dim);
   return ctx;
 }

--- a/src/common/ai/segmentation.c
+++ b/src/common/ai/segmentation.c
@@ -28,10 +28,8 @@
 #include <stdlib.h>
 #include <string.h>
 
-// SAM2 encoder expects 1024x1024 input; SAM3 uses 1008x1008
+// default SAM-style encoder input size
 #define SAM_INPUT_SIZE 1024
-#define SAM3_INPUT_SIZE 1008
-#define SAM3_MASK_SIZE 288
 
 // ImageNet normalization constants
 static const float IMG_MEAN[3] = {123.675f, 116.28f, 103.53f};
@@ -50,8 +48,7 @@ static const float IMG_STD[3] = {58.395f, 57.12f, 57.375f};
 // model architecture type, determines preprocessing, decoder I/O, and refinement
 typedef enum dt_seg_model_type_t
 {
-  DT_SEG_MODEL_SAM,     // SAM/SAM2: multi-mask + IoU + low_res refinement
-  DT_SEG_MODEL_SAM3,    // SAM3: SAM-style decoder with native 1008px input
+  DT_SEG_MODEL_SAM,     // SAM-style: multi-mask + IoU + low_res refinement
   DT_SEG_MODEL_SEGNEXT  // SegNext: single mask, full-res prev_mask refinement
 } dt_seg_model_type_t;
 
@@ -101,6 +98,29 @@ struct dt_seg_context_t
   char *model_id;      // model identifier (for cache validation)
   char *model_version; // model version (for cache validation)
 };
+
+static dt_ai_opt_level_t
+_seg_encoder_optimization(const dt_ai_model_info_t *info)
+{
+  dt_ai_opt_level_t opt = DT_AI_OPT_ALL;
+  char *opt_str = dt_ai_model_attribute_string(info, "encoder_optimization");
+
+  if(opt_str)
+  {
+    if(g_strcmp0(opt_str, "disabled") == 0
+       || g_strcmp0(opt_str, "none") == 0)
+      opt = DT_AI_OPT_DISABLED;
+    else if(g_strcmp0(opt_str, "basic") == 0)
+      opt = DT_AI_OPT_BASIC;
+    else if(g_strcmp0(opt_str, "all") != 0)
+      dt_print(DT_DEBUG_AI,
+               "[segmentation] unknown encoder_optimization '%s', using all",
+               opt_str);
+    g_free(opt_str);
+  }
+
+  return opt;
+}
 
 /* --- preprocessing --- */
 
@@ -307,17 +327,15 @@ dt_seg_context_t *dt_seg_load(dt_ai_environment_t *env, const char *model_id)
   if(!env || !model_id)
     return NULL;
 
-  // detect model type from arch field in model registry before loading
-  // sessions, since SAM3 encoder graphs may need conservative ORT options
+  // detect model type before loading sessions so manifest attributes can
+  // influence backend options
   const dt_ai_model_info_t *minfo
     = dt_ai_get_model_info_by_id(env, model_id);
   const char *arch = minfo ? minfo->arch : "";
   dt_seg_model_type_t model_type;
 
-  if(strcmp(arch, "sam2") == 0)
+  if(strcmp(arch, "sam") == 0 || strcmp(arch, "sam2") == 0)
     model_type = DT_SEG_MODEL_SAM;
-  else if(strcmp(arch, "sam3") == 0)
-    model_type = DT_SEG_MODEL_SAM3;
   else if(strcmp(arch, "segnext") == 0)
     model_type = DT_SEG_MODEL_SEGNEXT;
   else
@@ -328,15 +346,12 @@ dt_seg_context_t *dt_seg_load(dt_ai_environment_t *env, const char *model_id)
     return NULL;
   }
 
-  const gboolean is_sam_model = model_type == DT_SEG_MODEL_SAM
-                                || model_type == DT_SEG_MODEL_SAM3;
+  const gboolean is_sam_model = model_type == DT_SEG_MODEL_SAM;
 
   // honour explicit env override (e.g. CPU fallback after a CoreML failure);
   // CONFIGURED would re-read conf and lose the override
   const dt_ai_provider_t enc_provider = dt_ai_env_get_provider(env);
-  const dt_ai_opt_level_t enc_opt = model_type == DT_SEG_MODEL_SAM3
-                                    ? DT_AI_OPT_DISABLED
-                                    : DT_AI_OPT_ALL;
+  const dt_ai_opt_level_t enc_opt = _seg_encoder_optimization(minfo);
   dt_ai_context_t *encoder
     = dt_ai_load_model_ext(env, model_id, "encoder.onnx", enc_provider,
                            enc_opt, NULL, 0);
@@ -458,9 +473,14 @@ dt_seg_context_t *dt_seg_load(dt_ai_environment_t *env, const char *model_id)
                     di ? ", " : "", di, ctx->enc_order[di]);
   dt_print(DT_DEBUG_AI, "[segmentation] tensor routing: %s", map);
 
-  ctx->input_size = ctx->model_type == DT_SEG_MODEL_SAM3
-                    ? SAM3_INPUT_SIZE
-                    : SAM_INPUT_SIZE;
+  ctx->input_size = dt_ai_model_attribute_int(minfo, "input_size", SAM_INPUT_SIZE);
+  if(ctx->input_size <= 0)
+  {
+    dt_print(DT_DEBUG_AI,
+             "[segmentation] invalid input_size %d, using %d",
+             ctx->input_size, SAM_INPUT_SIZE);
+    ctx->input_size = SAM_INPUT_SIZE;
+  }
 
   // SAM models require external ImageNet normalization; SegNext bakes it into the encoder
   ctx->normalize = is_sam_model;
@@ -471,7 +491,7 @@ dt_seg_context_t *dt_seg_load(dt_ai_environment_t *env, const char *model_id)
 
   if(is_sam_model)
   {
-    // SAM/SAM3 path
+    // SAM-style path
     ctx->num_masks = (dec_out_ndim >= 4 && dec_out_shape[1] > 1) ? (int)dec_out_shape[1] : 0;
 
     if(ctx->num_masks == 0)
@@ -549,9 +569,14 @@ dt_seg_context_t *dt_seg_load(dt_ai_environment_t *env, const char *model_id)
     }
 
     // query low_res mask spatial dimensions from decoder output 2
-    ctx->prev_mask_dim = ctx->model_type == DT_SEG_MODEL_SAM3
-                         ? SAM3_MASK_SIZE
-                         : 256;
+    ctx->prev_mask_dim = dt_ai_model_attribute_int(minfo, "prev_mask_size", 256);
+    if(ctx->prev_mask_dim <= 0)
+    {
+      dt_print(DT_DEBUG_AI,
+               "[segmentation] invalid prev_mask_size %d, using 256",
+               ctx->prev_mask_dim);
+      ctx->prev_mask_dim = 256;
+    }
     {
       int64_t lr_shape[MAX_TENSOR_DIMS];
       const int lr_ndim = dt_ai_get_output_shape(decoder, 2, lr_shape, MAX_TENSOR_DIMS);
@@ -580,10 +605,8 @@ dt_seg_context_t *dt_seg_load(dt_ai_environment_t *env, const char *model_id)
     return NULL;
   }
 
-  const char *type_name = ctx->model_type == DT_SEG_MODEL_SAM3
-                          ? "SAM3"
-                          : (ctx->model_type == DT_SEG_MODEL_SAM
-                             ? "SAM" : "SegNext");
+  const char *type_name = ctx->model_type == DT_SEG_MODEL_SAM
+                          ? "SAM" : "SegNext";
   dt_print(DT_DEBUG_AI,
            "[segmentation] model loaded: %s [%s] (enc_outputs=%d, num_masks=%d, "
            "dec_dims=%dx%d, prev_mask_dim=%d)",
@@ -619,8 +642,7 @@ void dt_seg_warmup_decoder(dt_seg_context_t *ctx)
 
   dt_print(DT_DEBUG_AI, "[segmentation] warming up decoder...");
   const double t0 = dt_get_wtime();
-  const gboolean is_sam = ctx->model_type == DT_SEG_MODEL_SAM
-                          || ctx->model_type == DT_SEG_MODEL_SAM3;
+  const gboolean is_sam = ctx->model_type == DT_SEG_MODEL_SAM;
   const int pm_dim = ctx->prev_mask_dim;
   const int nm = ctx->num_masks;
   const int dec_h = ctx->dec_mask_h;
@@ -891,8 +913,7 @@ float *dt_seg_compute_mask(dt_seg_context_t *ctx,
   if(!ctx || !ctx->image_encoded || !points || n_points <= 0)
     return NULL;
 
-  const gboolean is_sam = ctx->model_type == DT_SEG_MODEL_SAM
-                          || ctx->model_type == DT_SEG_MODEL_SAM3;
+  const gboolean is_sam = ctx->model_type == DT_SEG_MODEL_SAM;
 
   // build point prompts
   // SAM ONNX requires a padding point (0,0) with label -1 appended
@@ -1149,8 +1170,7 @@ gboolean dt_seg_is_encoded(dt_seg_context_t *ctx)
 
 gboolean dt_seg_supports_box(dt_seg_context_t *ctx)
 {
-  return ctx ? (ctx->model_type == DT_SEG_MODEL_SAM
-                || ctx->model_type == DT_SEG_MODEL_SAM3) : FALSE;
+  return ctx ? (ctx->model_type == DT_SEG_MODEL_SAM) : FALSE;
 }
 
 void dt_seg_reset_prev_mask(dt_seg_context_t *ctx)


### PR DESCRIPTION
This PR Add support for the SAM3 segmentation models ("arch": "sam3"). I know darktable can't ship SAM3 because of licences, but someone could get the model on its own if it is supported.

SAM3 uses the existing SAM-style encoder/decoder flow but with different dimensions:
- 1008x1008 encoder input
- 288x288 mask feedback size

The SAM2 path remains unchanged at 1024x1024 input and 256x256 mask size. SegNext behavior is unchanged.

For SAM3 encoder loading, graph optimizations are disabled to avoid ONNX Runtime session creation issues.

To test it, you can request access to SAM3 and download sam3.pt (https://huggingface.co/facebook/sam3). Place it alongside this [script](https://github.com/user-attachments/files/29674721/export_sam3_native.py) and run it with `uv run export_sam3_native.py `. This will create `mask-object-sam3.dtmodel` you can import in darktable.

Disclaimer: Co-created with Codex.
