### PR TITLE
Fix raw denoise crash on raws with tight CFA border

### DIFF
--- a/src/common/ai/restore_raw_bayer.c
+++ b/src/common/ai/restore_raw_bayer.c
@@ -597,11 +597,16 @@ int dt_restore_raw_bayer(dt_restore_context_t *ctx,
         }
       }
 
-      // extended extent = core ± seam where a neighbor exists; matches model-output validity
-      const int ext_y0 = has_top  ? sensor_py_base - sensor_O : sensor_py_base;
-      const int ext_y1 = has_bot  ? sensor_py_end + sensor_O  : sensor_py_end;
-      const int ext_x0 = has_left ? sensor_px_base - sensor_O : sensor_px_base;
-      const int ext_x1 = has_right? sensor_px_end + sensor_O  : sensor_px_end;
+      // extended extent = core ± seam where a neighbor exists; matches
+      // model-output validity; clamped to the CFA buffer bounds
+      const int ext_y0 = MAX(0,
+                             has_top? sensor_py_base - sensor_O : sensor_py_base);
+      const int ext_y1 = MIN(height,
+                             has_bot  ? sensor_py_end + sensor_O  : sensor_py_end);
+      const int ext_x0 = MAX(0,
+                             has_left ? sensor_px_base - sensor_O : sensor_px_base);
+      const int ext_x1 = MIN(width,
+                             has_right? sensor_px_end + sensor_O  : sensor_px_end);
 
       for(int sr = ext_y0; sr < ext_y1; sr++)
       {


### PR DESCRIPTION
Closes #21497

`dt_restore_raw_bayer`'s per-tile "extended extent" adds `sensor_O` pixels on any side with a neighbour tile, but doesn't clamp to the CFA buffer bounds. On raws where the visible area sits tight against the sensor edge (e.g. `visible 3632x2720 in a 3648x2736 sensor`) the extension overshoots the buffer and `cfa_in[sr * width + sc]` reads past the allocation – classic `MALLOC_LARGE` gap crash.

Fix: clamp the four extents in `restore_raw_bayer.c` to `[0, width) × [0, height)`. Interior tiles unchanged; boundary tiles get clipped to what actually exists.