### PR TITLE
Some safe fixes as suggested in #21515

### DIFF
--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -1803,7 +1803,7 @@ void dt_bauhaus_combobox_set_text(GtkWidget *widget,
                                   const char *text)
 {
   const dt_bauhaus_combobox_data_t *d = _combobox_data(widget);
-  if(!d || !d->editable) return;
+  if(!d || !d->editable || !text) return;
 
   g_strlcpy(d->text, text, DT_BAUHAUS_MAX_TEXT);
   gtk_widget_queue_draw(GTK_WIDGET(widget));

--- a/src/common/locallaplacian.c
+++ b/src/common/locallaplacian.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2016-2024 darktable developers.
+    Copyright (C) 2016-2026 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -243,7 +243,7 @@ static inline float *ll_pad_input(
 #define LL_FILL(fallback) do {\
     float isx = ((i - max_supp) + b->roi->x)/b->roi->scale;\
     float isy = ((j - max_supp) + b->roi->y)/b->roi->scale;\
-    if(isx < 0 || isy >= b->buf->width\
+    if(isx < 0 || isx >= b->buf->width\
     || isy < 0 || isy >= b->buf->height)\
       out[*wd2*j+i] = (fallback);\
     else\

--- a/src/control/conf.c
+++ b/src/control/conf.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2019-2023 darktable developers.
+    Copyright (C) 2019-2026 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -60,7 +60,7 @@ static inline char *_conf_get_var(const char *name)
   }
 
   // FIXME: why insert garbage?
-  // still no luck? insert garbage:
+  // still no luck? insert a garbage string with length=0:
   str = (char *)g_malloc0(sizeof(int32_t));
   g_hash_table_insert(darktable.conf->table, g_strdup(name), str);
 
@@ -346,9 +346,7 @@ const char *dt_conf_get_string_const(const char *name)
 gboolean dt_conf_key_not_empty(const char *name)
 {
   const char *val = dt_conf_get_string_const(name);
-  if(val == NULL)      return FALSE;
-  if(strlen(val) == 0) return FALSE;
-  return TRUE;
+  return strlen(val) != 0;
 }
 
 gboolean dt_conf_get_folder_to_file_chooser(const char *name, GtkFileChooser *chooser)
@@ -552,6 +550,8 @@ void dt_conf_init(dt_conf_t *cf,
     g_strlcpy(cf->filename, filename, sizeof(cf->filename));
   }
 
+  // guard inserting conf values
+  dt_pthread_mutex_lock(&darktable.conf->mutex);
   dt_conf_read_values(filename, _conf_insert_value);
 
   if(override_entries)
@@ -564,6 +564,7 @@ void dt_conf_init(dt_conf_t *cf,
                           g_strdup(entry->value));
     }
   }
+  dt_pthread_mutex_unlock(&darktable.conf->mutex);
 
 #undef LINE_SIZE
 

--- a/src/control/jobs.c
+++ b/src/control/jobs.c
@@ -614,7 +614,8 @@ void dt_control_jobs_init()
   // start threads
   control->num_threads = dt_worker_threads();
   control->thread = (pthread_t *)calloc(control->num_threads, sizeof(pthread_t));
-  control->job = (dt_job_t **)calloc(control->num_threads, sizeof(dt_job_t *));
+  // allocate enough jobs to match _control_get_threadid()
+  control->job = (dt_job_t **)calloc(control->num_threads+1, sizeof(dt_job_t *));
 
   dt_atomic_set_int(&control->running, DT_CONTROL_STATE_RUNNING);
 

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -3524,7 +3524,10 @@ dt_iop_module_t *dt_dev_module_duplicate_ext(dt_develop_t *dev,
   // we create the new module
   dt_iop_module_t *module = calloc(1, sizeof(dt_iop_module_t));
   if(dt_iop_load_module(module, base->so, base->dev))
+  {
+    free(module);
     return NULL;
+  }
   module->instance = base->instance;
 
   // we set the multi-instance priority and the iop order

--- a/src/imageio/imageio_png.c
+++ b/src/imageio/imageio_png.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2009-2025 darktable developers.
+    Copyright (C) 2009-2026 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -247,7 +247,7 @@ dt_imageio_retval_t dt_imageio_open_png(dt_image_t *img,
     {
       mipbuf[4 * index]     = (buf[2 * (3 * index)]     * 256.0f + buf[2 * (3 * index)     + 1]) * normalizer;
       mipbuf[4 * index + 1] = (buf[2 * (3 * index + 1)] * 256.0f + buf[2 * (3 * index + 1) + 1]) * normalizer;
-      mipbuf[4 * index + 2] = (buf[2 * (3 * index + 2)] * 256.0f + buf[2 * (3 * index + 1) + 1]) * normalizer;
+      mipbuf[4 * index + 2] = (buf[2 * (3 * index + 2)] * 256.0f + buf[2 * (3 * index + 2) + 1]) * normalizer;
     }
   }
 

--- a/src/imageio/storage/piwigo.c
+++ b/src/imageio/storage/piwigo.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2018-2025 darktable developers.
+    Copyright (C) 2018-2026 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -224,7 +224,7 @@ static void _piwigo_api_post(_piwigo_api_context_t *ctx,
                              char *filename,
                              const gboolean isauth);
 
-static size_t curl_write_data_cb(void *ptr,
+static size_t _curl_write_data_cb(void *ptr,
                                  const size_t size,
                                  const size_t nmemb,
                                  void *data)
@@ -289,7 +289,7 @@ static void _piwigo_free_account(void *data)
 
 static void _piwigo_load_account(dt_storage_piwigo_gui_data_t *ui)
 {
-  if(!ui->accounts)
+  if(ui->accounts)
   {
     g_list_free_full(ui->accounts, _piwigo_free_account);
     ui->accounts = NULL;
@@ -407,7 +407,7 @@ static int _piwigo_api_post_internal(_piwigo_api_context_t *ctx,
 
   curl_easy_setopt(ctx->curl_ctx, CURLOPT_URL, url->str);
   curl_easy_setopt(ctx->curl_ctx, CURLOPT_POST, 1L);
-  curl_easy_setopt(ctx->curl_ctx, CURLOPT_WRITEFUNCTION, curl_write_data_cb);
+  curl_easy_setopt(ctx->curl_ctx, CURLOPT_WRITEFUNCTION, _curl_write_data_cb);
   curl_easy_setopt(ctx->curl_ctx, CURLOPT_WRITEDATA, response);
 
   if(isauth)

--- a/src/iop/hlreconstruct/segmentation.c
+++ b/src/iop/hlreconstruct/segmentation.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2022-2023 darktable developers.
+    Copyright (C) 2022-2026 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -203,7 +203,7 @@ static inline int _test_dilate(const uint32_t *img, const size_t i, const size_t
            img[i+w4-8] | img[i+w4-7] | img[i+w4+7] | img[i+w4+8] |
            img[i+w5-7] | img[i+w5+7] |
            img[i+w6-6] | img[i+w6-5] | img[i+w6+5] | img[i+w6+6] |
-           img[i+w7-6] | img[i+w7-5] | img[i+w7-4] | img[i+w7+4] | img[i+w7+5] | img[i-w7+6] |
+           img[i+w7-6] | img[i+w7-5] | img[i+w7-4] | img[i+w7+4] | img[i+w7+5] | img[i+w7+6] |
            img[i+w8-4] | img[i+w8-3] | img[i+w8-2] | img[i+w8-1] | img[i+w8] | img[i+w8+1] | img[i+w8+2] | img[i+w8+3] | img[i+w8+4];
   return retval;
 }
@@ -639,7 +639,7 @@ gboolean dt_segmentation_init_struct(dt_iop_segmentation_t *seg,
 
   if(!seg->data || !seg->size
                 || !seg->xmin || !seg->xmax || !seg->ymin || !seg->ymax
-                || !seg->val2 || !seg->val2)
+                || !seg->val1 || !seg->val2)
   {
     dt_segmentation_free_struct(seg);
     return TRUE;

--- a/src/iop/negadoctor.c
+++ b/src/iop/negadoctor.c
@@ -326,7 +326,7 @@ void process(dt_iop_module_t *const self, dt_dev_pixelpipe_iop_t *const piece,
              const dt_iop_roi_t *const restrict roi_in, const dt_iop_roi_t *const restrict roi_out)
 {
   const dt_iop_negadoctor_data_t *const d = piece->data;
-  assert(piece->colors = 4);
+  assert(piece->colors == 4);
 
   const float *const restrict in = (float *)ivoid;
   float *const restrict out = (float *)ovoid;


### PR DESCRIPTION
I checked the "analysis" and found these genuine issues (leaving out all database stuff as i am not qualified on that) that would be for 5.6.1 too

"real bugs" are 2,3,6 and likely 7 since we initialize the conf system twice and possibly do background jobs that might "race badly"

1. fix check for a correct x-position in local-laplacian LL_FILL
2. fix allocation check in segmentation, also a subtle mask dilating fix
3. fixed bad blue color for writing 16bit png files
4. fixed account deleting in piwigo due to an incorrect test
5. fixed wrong assert use in negadoctor
6. make sure we have enough allocated job structs for _control_get_threadid()
7. guard initial conf readings via the conf mutex
8. check for a text nullstring to be passed to a bauhaus combobox
9. possibly avoiding a memleak if duplicating the module failed (very unlikely)

