### PR TITLE
Add release note for pan gesture fix when drawing masks (for release-5.6.1)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -129,6 +129,9 @@ changes (where available).
 
 - Fixed some subtle segment issues in highlights segmentation mode.
 
+- Fixed two-finger scrolling falling through to zoom when drawing masks,
+  scrolling now pans unless the active mask consumes the gesture.
+
 ## Lua
 
 ### API Version


### PR DESCRIPTION
This is adding the missing release note after https://github.com/darktable-org/darktable/pull/21490 was merged and cherry-picked onto darktable-5.6.x branch.