### PR TITLE
Fix install-ort-gpu on CUDA 12 after ORT 1.27

### DIFF
--- a/data/ort_gpu.json
+++ b/data/ort_gpu.json
@@ -13,12 +13,11 @@
       "cuda_min": "12.0",
       "cuda_max": "12.99",
       "source": {
-        "type": "pypi",
-        "package": "onnxruntime-gpu",
-        "platform_tags": ["manylinux_2_28_x86_64", "manylinux_2_27_x86_64"],
-        "python_tag": "cp312"
+        "type": "github_release",
+        "repo": "microsoft/onnxruntime",
+        "asset_pattern": "onnxruntime-linux-x64-gpu_cuda12-{version}.tgz"
       },
-      "format": "whl",
+      "format": "tgz",
       "lib_pattern": "libonnxruntime",
       "install_subdir": "onnxruntime-cuda",
       "requirements": "CUDA 12, cuDNN 9"
@@ -30,11 +29,12 @@
       "cuda_min": "13.0",
       "cuda_max": "13.99",
       "source": {
-        "type": "github_release",
-        "repo": "microsoft/onnxruntime",
-        "asset_pattern": "onnxruntime-linux-x64-gpu_cuda13-{version}.tgz"
+        "type": "pypi",
+        "package": "onnxruntime-gpu",
+        "platform_tags": ["manylinux_2_28_x86_64", "manylinux_2_27_x86_64"],
+        "python_tag": "cp312"
       },
-      "format": "tgz",
+      "format": "whl",
       "lib_pattern": "libonnxruntime",
       "install_subdir": "onnxruntime-cuda",
       "requirements": "CUDA 13, cuDNN 9"
@@ -46,12 +46,11 @@
       "cuda_min": "12.0",
       "cuda_max": "12.99",
       "source": {
-        "type": "pypi",
-        "package": "onnxruntime-gpu",
-        "platform_tags": ["win_amd64"],
-        "python_tag": "cp312"
+        "type": "github_release",
+        "repo": "microsoft/onnxruntime",
+        "asset_pattern": "onnxruntime-win-x64-gpu_cuda12-{version}.zip"
       },
-      "format": "whl",
+      "format": "zip",
       "lib_pattern": "onnxruntime",
       "install_subdir": "onnxruntime-cuda",
       "requirements": "CUDA 12, cuDNN 9"
@@ -63,11 +62,12 @@
       "cuda_min": "13.0",
       "cuda_max": "13.99",
       "source": {
-        "type": "github_release",
-        "repo": "microsoft/onnxruntime",
-        "asset_pattern": "onnxruntime-win-x64-gpu_cuda13-{version}.zip"
+        "type": "pypi",
+        "package": "onnxruntime-gpu",
+        "platform_tags": ["win_amd64"],
+        "python_tag": "cp312"
       },
-      "format": "zip",
+      "format": "whl",
       "lib_pattern": "onnxruntime",
       "install_subdir": "onnxruntime-cuda",
       "requirements": "CUDA 13, cuDNN 9"

--- a/tools/ai/install-ort-gpu.ps1
+++ b/tools/ai/install-ort-gpu.ps1
@@ -197,12 +197,14 @@ function Resolve-GitHubReleaseSource($source) {
         $code = $null
         if ($_.Exception.Response) { $code = [int]$_.Exception.Response.StatusCode }
         if ($code -eq 403 -or $code -eq 429) {
+            $installSubdir = if ($Package.install_subdir) { $Package.install_subdir } else { 'onnxruntime' }
+            $hintDir = Join-Path $env:LOCALAPPDATA $installSubdir
             Write-Host @"
 
 GitHub API rate limit hit (60 req/hr per IP, unauthenticated).
 
 You're seeing this because the install script needs api.github.com to
-discover the latest CUDA 13 release. Shared NAT (corporate networks,
+discover the latest ONNX Runtime release. Shared NAT (corporate networks,
 VPNs, cloud VMs) often blows through 60/hr from one source IP.
 
 Workarounds, easiest first:
@@ -222,7 +224,7 @@ Workarounds, easiest first:
        d. Expand-Archive <file>.zip -DestinationPath .
        e. Copy the extracted lib\onnxruntime.dll (and LICENSE,
           ThirdPartyNotices.txt from the extracted root) into:
-            $InstallDir
+            $hintDir
        f. Open darktable -> Preferences -> AI tab -> point at the .dll
 
 "@ -ForegroundColor Yellow

--- a/tools/ai/install-ort-gpu.sh
+++ b/tools/ai/install-ort-gpu.sh
@@ -239,17 +239,24 @@ resolve_github_release_source() {
   [ -n "${GITHUB_TOKEN:-}" ] && hdr=(-H "Authorization: Bearer $GITHUB_TOKEN")
 
   tmp=$(mktemp)
-  http_code=$(curl -fsS -o "$tmp" -w '%{http_code}' \
-    "${hdr[@]}" -H 'Accept: application/vnd.github+json' "$api_url" || echo "$?")
+  http_code=$(curl -sS -o "$tmp" -w '%{http_code}' \
+    "${hdr[@]}" -H 'Accept: application/vnd.github+json' "$api_url") || {
+    echo "Error: failed to reach $api_url" >&2
+    rm -f "$tmp"
+    exit 1
+  }
 
   if [ "$http_code" = "403" ] || [ "$http_code" = "429" ]; then
     rm -f "$tmp"
+    local install_subdir hint_dir
+    install_subdir=$(echo "$PKG_JSON" | jq -r '.install_subdir // "onnxruntime"')
+    hint_dir="$HOME/.local/lib/$install_subdir"
     cat <<EOF >&2
 
 GitHub API rate limit hit (60 req/hr per IP, unauthenticated).
 
 You're seeing this because the install script needs api.github.com to
-discover the latest CUDA 13 release. Shared NAT (corporate networks,
+discover the latest ONNX Runtime release. Shared NAT (corporate networks,
 VPNs, cloud VMs) often blows through 60/hr from one source IP.
 
 Workarounds, easiest first:
@@ -268,7 +275,7 @@ Workarounds, easiest first:
        d. tar xzf <file>.tgz
        e. Copy the extracted lib/libonnxruntime.so.* (and LICENSE,
           ThirdPartyNotices.txt from the extracted root) into:
-            $INSTALL_DIR
+            $hint_dir
        f. Open darktable -> Preferences -> AI tab -> point at the .so
 
 EOF


### PR DESCRIPTION
Fixes #21527

Since ORT 1.27, PyPI `onnxruntime-gpu` quietly switched from bundling CUDA 12 to CUDA 13 without a rename – so the install script was handing CUDA 12 users a wheel that won't load. CUDA 12 binaries are still shipped, just as explicitly-named GitHub release assets (`onnxruntime-*-gpu_cuda12-*`).

**Manifest** – swap the two paths: CUDA 12 now pulls the GitHub `_cuda12-` asset, CUDA 13 stays on PyPI (which is CUDA 13 now anyway). Cleaner than pinning ORT to 1.26 and doesn't need any version-conditional branching.

**Install scripts** – while re-testing I hit the rate-limit branch and found two bugs hiding behind it:

- `install-ort-gpu.sh` was building the HTTP code as `curl -fsS -w '%{http_code}' ... || echo "$?"`, which concatenated curl's exit code onto the status and produced `"40322"` instead of `"403"`. Dropped `-f` so 4xx doesn't error curl out.
- Both scripts referenced `$INSTALL_DIR` / `$InstallDir` in the rate-limit help text before those variables were assigned – fatal under `set -u` on the shell side. Compute a local hint path from `install_subdir` inside the branch.
- Reworded the "CUDA 13 release" line in the same help text to just "ONNX Runtime release" since GitHub is now the CUDA 12 path.

Sanity-checked: JSON parses, `bash -n` clean, rate-limit branch now prints the friendly help instead of crashing.