### PR TITLE
gtk4-prep: stop using widget style properties (#15920)

### DIFF
--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -4144,10 +4144,7 @@ static gint _get_container_row_heigth(GtkWidget *w)
                                         NULL, NULL, NULL, NULL, &cell_height);
       if(cell_height > row_height) row_height = cell_height;
     }
-    GValue separation = { G_TYPE_INT };
-    gtk_widget_style_get_property(w, "vertical-separator", &separation);
-
-    if(row_height > 0) height = row_height + g_value_get_int(&separation);
+    if(row_height > 0) height = row_height + 2;
   }
   else if(GTK_IS_TEXT_VIEW(w))
   {

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -4144,6 +4144,7 @@ static gint _get_container_row_heigth(GtkWidget *w)
                                         NULL, NULL, NULL, NULL, &cell_height);
       if(cell_height > row_height) row_height = cell_height;
     }
+    /* GtkTreeView's vertical-separator style property defaults to 2 (GTK3 source: #define _TREE_VIEW_VERTICAL_SEPARATOR 2) */
     if(row_height > 0) height = row_height + 2;
   }
   else if(GTK_IS_TEXT_VIEW(w))


### PR DESCRIPTION
Replace the only `gtk_widget_style_get_property()` call with a hardcoded 2 - the GTK3 default for `GtkTreeView:vertical-separator`. Style properties are removed in GTK4 and this call was the last remaining use in the codebase.

Related: #15920 #20433