### PR TITLE
gtk4-prep: stop using `GtkButton` image API (#15920)

### DIFF
--- a/src/lua/widget/button.c
+++ b/src/lua/widget/button.c
@@ -23,17 +23,14 @@
   sometimes we have to store the ellipsize|halign mode until the
   label is created.
 */
-struct dt_lua_ellipsize_mode_info
+typedef struct dt_lua_pending_property_t
 {
   gboolean used;
-  dt_lua_ellipsize_mode_t mode;
-};
+  int value;
+} dt_lua_pending_property_t;
 
-struct dt_lua_halign_info
-{
-  gboolean used;
-  dt_lua_align_t halign;
-};
+static dt_lua_pending_property_t ellipsize_store = { .used = FALSE };
+static dt_lua_pending_property_t halign_store = { .used = FALSE };
 
 /*
   we can't guarantee the order of image and position_type calls so
@@ -44,16 +41,6 @@ struct dt_lua_position_type_info
 {
   gboolean used;
   dt_lua_position_type_t position;
-};
-
-static struct dt_lua_ellipsize_mode_info ellipsize_store =
-{
-  .used = FALSE
-};
-
-static struct dt_lua_halign_info halign_store =
-{
-  .used = FALSE
 };
 
 static struct dt_lua_position_type_info position_type_store =
@@ -79,25 +66,80 @@ static void clicked_callback(GtkButton *widget, gpointer user_data)
       LUA_ASYNC_DONE);
 }
 
+/* Find the first child of `box` that is an instance of `type` (e.g.
+   GTK_TYPE_LABEL or GTK_TYPE_IMAGE), or NULL if none is found. */
+static GtkWidget *dt_lua_button_get_widget_in_box(GtkWidget *box, GType type)
+{
+  GList *children = gtk_container_get_children(GTK_CONTAINER(box));
+  GtkWidget *found = NULL;
+  for(GList *l = children; l; l = l->next)
+  {
+    if(G_TYPE_CHECK_INSTANCE_TYPE(l->data, type))
+    {
+      found = GTK_WIDGET(l->data);
+      break;
+    }
+  }
+  g_list_free(children);
+  return found;
+}
+
+/* Return the index of `widget` among `box`'s children, or -1 if
+   `widget` is not a child of `box`. */
+static int dt_lua_button_get_child_index(GtkWidget *box, GtkWidget *widget)
+{
+  GList *children = gtk_container_get_children(GTK_CONTAINER(box));
+  int idx = -1;
+  int i = 0;
+  for(GList *l = children; l; l = l->next, i++)
+  {
+    if(l->data == (gpointer)widget)
+    {
+      idx = i;
+      break;
+    }
+  }
+  g_list_free(children);
+  return idx;
+}
+
+/* Return the button's current label widget, or NULL if it doesn't
+   have one yet (e.g. right after creation, before label/image is
+   set). Used by ellipsize_member and halign_member, which both need
+   to find the label before they can get/set a property on it. */
+static GtkWidget *dt_lua_button_get_current_label(lua_button button)
+{
+  GtkWidget *child = gtk_bin_get_child(GTK_BIN(button->widget));
+  if(GTK_IS_BOX(child))
+    return dt_lua_button_get_widget_in_box(child, GTK_TYPE_LABEL);
+  if(gtk_button_get_label(GTK_BUTTON(button->widget)))
+    return child;
+  return NULL;
+}
+
 static int ellipsize_member(lua_State *L)
 {
   lua_button button;
   luaA_to(L, lua_button, &button, 1);
-  dt_lua_ellipsize_mode_t ellipsize;
+  GtkWidget *label = dt_lua_button_get_current_label(button);
+
   if(lua_gettop(L) > 2)
   {
+    dt_lua_ellipsize_mode_t ellipsize;
     luaA_to(L, dt_lua_ellipsize_mode_t, &ellipsize, 3);
-    // check for label before trying to ellipsize it
-    if(gtk_button_get_label(GTK_BUTTON(button->widget)))
-      gtk_label_set_ellipsize(GTK_LABEL(gtk_bin_get_child(GTK_BIN(button->widget))), ellipsize);
+    if(label)
+      gtk_label_set_ellipsize(GTK_LABEL(label), ellipsize);
     else
     {
-      ellipsize_store.mode = ellipsize;
+      ellipsize_store.value = ellipsize;
       ellipsize_store.used = TRUE;
     }
     return 0;
   }
-  ellipsize = gtk_label_get_ellipsize(GTK_LABEL(gtk_bin_get_child(GTK_BIN(button->widget))));
+
+  dt_lua_ellipsize_mode_t ellipsize = label
+    ? gtk_label_get_ellipsize(GTK_LABEL(label))
+    : PANGO_ELLIPSIZE_NONE;
   luaA_push(L, dt_lua_ellipsize_mode_t, &ellipsize);
   return 1;
 }
@@ -106,21 +148,25 @@ static int halign_member(lua_State *L)
 {
   lua_button button;
   luaA_to(L, lua_button, &button, 1);
-  dt_lua_align_t halign;
+  GtkWidget *label = dt_lua_button_get_current_label(button);
+
   if(lua_gettop(L) > 2)
   {
+    dt_lua_align_t halign;
     luaA_to(L, dt_lua_align_t, &halign, 3);
-    // check for label before trying to ellipsize it
-    if(gtk_button_get_label(GTK_BUTTON(button->widget)))
-      gtk_widget_set_halign(GTK_WIDGET(GTK_LABEL(gtk_bin_get_child(GTK_BIN(button->widget)))), halign);
+    if(label)
+      gtk_widget_set_halign(GTK_WIDGET(label), halign);
     else
     {
-      halign_store.halign = halign;
+      halign_store.value = halign;
       halign_store.used = TRUE;
     }
     return 0;
   }
-  halign = gtk_widget_get_halign(GTK_WIDGET(GTK_LABEL(gtk_bin_get_child(GTK_BIN(button->widget)))));
+
+  dt_lua_align_t halign = label
+    ? gtk_widget_get_halign(GTK_WIDGET(label))
+    : GTK_ALIGN_FILL;
   luaA_push(L, dt_lua_align_t, &halign);
   return 1;
 }
@@ -132,18 +178,59 @@ static int label_member(lua_State *L)
   if(lua_gettop(L) > 2)
   {
     const char * label = luaL_checkstring(L, 3);
+    GtkWidget *child = gtk_bin_get_child(GTK_BIN(button->widget));
+    gboolean had_box = child && GTK_IS_BOX(child);
+    if(had_box) g_object_ref(G_OBJECT(child));
+
     gtk_button_set_label(GTK_BUTTON(button->widget), label);
-    if(ellipsize_store.used)
+
+    if(had_box)
     {
-      gtk_label_set_ellipsize(GTK_LABEL(gtk_bin_get_child(GTK_BIN(button->widget))), ellipsize_store.mode);
+      GtkWidget *new_child = gtk_bin_get_child(GTK_BIN(button->widget));
+      if(new_child != child)
+      {
+        gtk_container_remove(GTK_CONTAINER(button->widget), new_child);
+        gtk_container_add(GTK_CONTAINER(button->widget), child);
+      }
+      g_object_unref(G_OBJECT(child));
+    }
+    child = gtk_bin_get_child(GTK_BIN(button->widget));
+    if(GTK_IS_BOX(child))
+    {
+      GtkWidget *label_widget = dt_lua_button_get_widget_in_box(child, GTK_TYPE_LABEL);
+      if(label_widget)
+      {
+        gtk_label_set_text(GTK_LABEL(label_widget), label);
+      }
+      else
+      {
+        label_widget = gtk_label_new(label);
+        GtkWidget *image_widget = dt_lua_button_get_widget_in_box(child, GTK_TYPE_IMAGE);
+        gtk_box_pack_start(GTK_BOX(child), label_widget, FALSE, FALSE, 0);
+        if(image_widget && dt_lua_button_get_child_index(child, image_widget) == 1)
+          gtk_box_reorder_child(GTK_BOX(child), label_widget, 0);
+        gtk_widget_show(label_widget);
+      }
+
+      gtk_label_set_ellipsize(GTK_LABEL(label_widget),
+                              ellipsize_store.used ? (PangoEllipsizeMode)ellipsize_store.value : PANGO_ELLIPSIZE_END);
       ellipsize_store.used = FALSE;
+      if(halign_store.used)
+      {
+        gtk_widget_set_halign(GTK_WIDGET(label_widget), (GtkAlign)halign_store.value);
+        halign_store.used = FALSE;
+      }
     }
     else
-      gtk_label_set_ellipsize(GTK_LABEL(gtk_bin_get_child(GTK_BIN(button->widget))), PANGO_ELLIPSIZE_END);
-    if(halign_store.used)
     {
-      gtk_widget_set_halign(GTK_WIDGET(GTK_LABEL(gtk_bin_get_child(GTK_BIN(button->widget)))), halign_store.halign);
-      halign_store.used = FALSE;
+      gtk_label_set_ellipsize(GTK_LABEL(child),
+                              ellipsize_store.used ? (PangoEllipsizeMode)ellipsize_store.value : PANGO_ELLIPSIZE_END);
+      ellipsize_store.used = FALSE;
+      if(halign_store.used)
+      {
+        gtk_widget_set_halign(GTK_WIDGET(GTK_LABEL(child)), (GtkAlign)halign_store.value);
+        halign_store.used = FALSE;
+      }
     }
     return 0;
   }
@@ -160,13 +247,66 @@ static int image_member(lua_State *L)
   if(lua_gettop(L) > 2)
   {
     const char * imagefile = luaL_checkstring(L, 3);
-    image = gtk_image_new_from_file (imagefile);
-    gtk_button_set_image(GTK_BUTTON(button->widget), image);
-    gtk_button_set_always_show_image(GTK_BUTTON(button->widget), TRUE);
-    if(position_type_store.used)
+    image = gtk_image_new_from_file(imagefile);
+
+    GtkWidget *child = gtk_bin_get_child(GTK_BIN(button->widget));
+
+    if(GTK_IS_BOX(child))
     {
-      gtk_button_set_image_position(GTK_BUTTON(button->widget), position_type_store.position);
+      GtkWidget *old_image = dt_lua_button_get_widget_in_box(child, GTK_TYPE_IMAGE);
+      int old_idx = old_image ? dt_lua_button_get_child_index(child, old_image) : -1;
+
+      if(old_image)
+        gtk_container_remove(GTK_CONTAINER(child), old_image);
+      gtk_box_pack_start(GTK_BOX(child), image, FALSE, FALSE, 0);
+      if(old_idx >= 0)
+        gtk_box_reorder_child(GTK_BOX(child), image, old_idx);
+      gtk_widget_show(image);
+    }
+    else
+    {
+      const gchar *label_text = gtk_button_get_label(GTK_BUTTON(button->widget));
+      GtkWidget *old_label = (child && GTK_IS_LABEL(child)) ? child : NULL;
+
+      PangoEllipsizeMode ellipsize_mode = PANGO_ELLIPSIZE_END;
+      GtkAlign halign_val = GTK_ALIGN_FILL;
+      gboolean has_label_style = (old_label != NULL);
+      if(old_label)
+      {
+        ellipsize_mode = gtk_label_get_ellipsize(GTK_LABEL(old_label));
+        halign_val = gtk_widget_get_halign(GTK_WIDGET(old_label));
+      }
+
+      GtkPositionType pos = position_type_store.used ? position_type_store.position : GTK_POS_LEFT;
+      GtkOrientation orientation = (pos == GTK_POS_TOP || pos == GTK_POS_BOTTOM)
+        ? GTK_ORIENTATION_VERTICAL : GTK_ORIENTATION_HORIZONTAL;
+      gboolean image_first = (pos == GTK_POS_LEFT || pos == GTK_POS_TOP);
+
+      GtkWidget *box = gtk_box_new(orientation, 0);
+      GtkWidget *new_label = (label_text && label_text[0]) ? gtk_label_new(label_text) : NULL;
+
+      if(image_first)
+        gtk_box_pack_start(GTK_BOX(box), image, FALSE, FALSE, 0);
+      if(new_label)
+      {
+        gtk_box_pack_start(GTK_BOX(box), new_label, FALSE, FALSE, 0);
+        if(has_label_style)
+        {
+          gtk_label_set_ellipsize(GTK_LABEL(new_label), ellipsize_mode);
+          gtk_widget_set_halign(GTK_WIDGET(new_label), halign_val);
+        }
+      }
+      if(!image_first)
+        gtk_box_pack_start(GTK_BOX(box), image, FALSE, FALSE, 0);
+
+      g_object_set_data(G_OBJECT(box), "dt-image-pos", GINT_TO_POINTER(pos));
       position_type_store.used = FALSE;
+
+      if(child)
+        gtk_container_remove(GTK_CONTAINER(button->widget), child);
+      gtk_widget_set_halign(GTK_WIDGET(box), GTK_ALIGN_CENTER);
+      gtk_container_add(GTK_CONTAINER(button->widget), box);
+      gtk_widget_show_all(GTK_WIDGET(button->widget));
     }
     return 0;
   }
@@ -181,9 +321,29 @@ static int image_position_member(lua_State *L)
   if(lua_gettop(L) > 2)
   {
     luaA_to(L, dt_lua_position_type_t, &image_position, 3);
-    // check for image before trying to ellipsize it
-    if(gtk_button_get_image(GTK_BUTTON(button->widget)))
-      gtk_button_set_image_position(GTK_BUTTON(button->widget), image_position);
+    GtkWidget *child = gtk_bin_get_child(GTK_BIN(button->widget));
+    if(GTK_IS_BOX(child))
+    {
+      GtkWidget *image = dt_lua_button_get_widget_in_box(child, GTK_TYPE_IMAGE);
+      GtkWidget *label = dt_lua_button_get_widget_in_box(child, GTK_TYPE_LABEL);
+      if(image)
+      {
+        GtkOrientation new_orient = (image_position == GTK_POS_LEFT
+                                      || image_position == GTK_POS_RIGHT)
+          ? GTK_ORIENTATION_HORIZONTAL : GTK_ORIENTATION_VERTICAL;
+        gtk_orientable_set_orientation(GTK_ORIENTABLE(child), new_orient);
+
+        gboolean image_should_be_first = (image_position == GTK_POS_LEFT
+                                           || image_position == GTK_POS_TOP);
+        if(image_should_be_first)
+          gtk_box_reorder_child(GTK_BOX(child), image, 0);
+        else if(label)
+          gtk_box_reorder_child(GTK_BOX(child), label, 0);
+
+        g_object_set_data(G_OBJECT(child), "dt-image-pos", GINT_TO_POINTER(image_position));
+        gtk_widget_queue_resize(GTK_WIDGET(child));
+      }
+    }
     else
     {
       position_type_store.position = image_position;
@@ -191,7 +351,35 @@ static int image_position_member(lua_State *L)
     }
     return 0;
   }
-  image_position = gtk_button_get_image_position(GTK_BUTTON(button->widget));
+  GtkWidget *child = gtk_bin_get_child(GTK_BIN(button->widget));
+  if(GTK_IS_BOX(child))
+  {
+    GtkWidget *image = dt_lua_button_get_widget_in_box(child, GTK_TYPE_IMAGE);
+    GtkWidget *label = dt_lua_button_get_widget_in_box(child, GTK_TYPE_LABEL);
+    int image_idx = image ? dt_lua_button_get_child_index(child, image) : -1;
+    int label_idx = label ? dt_lua_button_get_child_index(child, label) : -1;
+
+    if(image_idx >= 0 && label_idx >= 0)
+    {
+      GtkOrientation orient = gtk_orientable_get_orientation(GTK_ORIENTABLE(child));
+      if(image_idx < label_idx)
+        image_position = (orient == GTK_ORIENTATION_HORIZONTAL) ? GTK_POS_LEFT : GTK_POS_TOP;
+      else
+        image_position = (orient == GTK_ORIENTATION_HORIZONTAL) ? GTK_POS_RIGHT : GTK_POS_BOTTOM;
+    }
+    else
+    {
+      /* No image, or its position within the box couldn't be
+         determined from ordering alone (e.g. image-only button):
+         fall back to whatever position was last recorded. */
+      gpointer data = g_object_get_data(G_OBJECT(child), "dt-image-pos");
+      image_position = data ? GPOINTER_TO_INT(data) : GTK_POS_LEFT;
+    }
+  }
+  else
+  {
+    image_position = GTK_POS_LEFT;
+  }
   luaA_push(L, dt_lua_position_type_t, &image_position);
   return 1;
 }
@@ -238,4 +426,3 @@ int dt_lua_init_widget_button(lua_State* L)
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-


### PR DESCRIPTION
Replace:
- `gtk_button_set_image()`
- `gtk_button_set_always_show_image()`
- `gtk_button_set_image_position()`
- `gtk_button_get_image()`
- `gtk_button_get_image_position()`

with manual GtkBox packing for the Lua button widget. These are all removed in GTK4.

Guard against `gtk_button_set_label()` replacing our box (GTK3 creates a new label child and destroys the custom child), show newly replaced images, and force relayout after orientation changes.

Also refactored the code to clean things up.

I used this lua script to test it, no errors. Even solved some pre existent assertion errors:

```lua
local dt = require "darktable"
local logo = "./build/share/darktable/pixmaps/dt_logo_128x128.png"
local cb = function() print("ok") end
local b1 = dt.new_widget("button"){label="a", image=logo}
b1.image = logo  -- set same image again
local b2 = dt.new_widget("button"){label="b"}
b2.image = logo
b2.label = "b2"  -- set label after image
b2.image_position = "right"
local b3 = dt.new_widget("button"){image=logo, label="c"}
b3.image_position = "left"
b3.image_position = "top"  -- change position twice
local b4 = dt.new_widget("button"){label="", image=logo}
dt.register_lib("test_final","test final",true,false,{[dt.gui.views.lighttable]={"DT_UI_CONTAINER_PANEL_RIGHT_CENTER",5}},
  dt.new_widget("box"){orientation="vertical",
    dt.new_widget("button"){label="no image", clicked_callback=cb},
    dt.new_widget("button"){label="left", image=logo, image_position="left", clicked_callback=cb},
    dt.new_widget("button"){label="right", image=logo, image_position="right", clicked_callback=cb},
    dt.new_widget("button"){label="top", image=logo, image_position="top", clicked_callback=cb},
    dt.new_widget("button"){label="bottom", image=logo, image_position="bottom", clicked_callback=cb},
    dt.new_widget("button"){image=logo, clicked_callback=cb},
    b1, b2, b3, b4
  }
)
```

Related: #15920 #20433