### PR TITLE
[GTK4 prep]: remove gtk_window_set_position() calls

### DIFF
--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -3317,16 +3317,7 @@ gboolean dt_gui_show_standalone_yes_no_dialog(const char *title,
     if(win && gtk_widget_get_visible(GTK_WIDGET(win)))
     {
       gtk_window_set_transient_for(GTK_WINDOW(window), win);
-      gtk_window_set_position(GTK_WINDOW(window), GTK_WIN_POS_CENTER_ON_PARENT);
     }
-    else
-    {
-      gtk_window_set_position(GTK_WINDOW(window), GTK_WIN_POS_MOUSE);
-    }
-  }
-  else
-  {
-    gtk_window_set_position(GTK_WINDOW(window), GTK_WIN_POS_MOUSE);
   }
 
   GtkWidget *vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, padding);
@@ -3406,18 +3397,6 @@ char *dt_gui_show_standalone_string_dialog(const char *title,
   {
     GtkWindow *win = GTK_WINDOW(dt_ui_main_window(darktable.gui->ui));
     gtk_window_set_transient_for(GTK_WINDOW(window), win);
-    if(gtk_widget_get_visible(GTK_WIDGET(win)))
-    {
-      gtk_window_set_position(GTK_WINDOW(window), GTK_WIN_POS_CENTER_ON_PARENT);
-    }
-    else
-    {
-      gtk_window_set_position(GTK_WINDOW(window), GTK_WIN_POS_MOUSE);
-    }
-  }
-  else
-  {
-    gtk_window_set_position(GTK_WINDOW(window), GTK_WIN_POS_MOUSE);
   }
 
   GtkWidget *vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 5);
@@ -5076,8 +5055,6 @@ void dt_gui_dialog_restore_size(GtkDialog *dialog, const char *conf)
   const int y = dt_conf_get_int(dt_buf_printf(buf, "ui_last/%s_dialog_y", conf));
   if(x && y)
     gtk_window_move(GTK_WINDOW(dialog), x, y);
-  else
-    gtk_window_set_position(GTK_WINDOW(dialog), GTK_WIN_POS_CENTER_ON_PARENT);
   g_signal_connect(dialog, "configure-event", G_CALLBACK(_resize_dialog), (gpointer)conf);
 }
 

--- a/src/gui/metadata_tags.c
+++ b/src/gui/metadata_tags.c
@@ -95,7 +95,6 @@ GtkWidget *dt_metadata_tags_dialog(GtkWidget *parent,
                                                   _("_done"), GTK_RESPONSE_NONE, NULL);
   gtk_dialog_set_default_response(GTK_DIALOG(dialog), GTK_RESPONSE_NONE);
   gtk_window_set_default_size(GTK_WINDOW(dialog), DT_PIXEL_APPLY_DPI(500), DT_PIXEL_APPLY_DPI(300));
-  gtk_window_set_position(GTK_WINDOW(dialog), GTK_WIN_POS_CENTER_ON_PARENT);
 
   // keep a reference to the "add" button to toggle its sensitivity
   add_button = gtk_dialog_get_widget_for_response(GTK_DIALOG(dialog), GTK_RESPONSE_ACCEPT);

--- a/src/gui/presets.c
+++ b/src/gui/presets.c
@@ -1528,7 +1528,6 @@ static void _menuitem_manage_quick_presets(GtkMenuItem *menuitem,
 
   gtk_window_set_resizable(GTK_WINDOW(dialog), TRUE);
 
-  gtk_window_set_position(GTK_WINDOW(dialog), GTK_WIN_POS_CENTER_ON_PARENT);
   gtk_widget_show_all(dialog);
 }
 

--- a/src/gui/splash.c
+++ b/src/gui/splash.c
@@ -112,7 +112,6 @@ void dt_splash_screen_create(const gboolean force)
   darktable.splash.start_screen = gtk_window_new(GTK_WINDOW_TOPLEVEL);
   gtk_window_set_decorated(GTK_WINDOW(darktable.splash.start_screen), FALSE);
   gtk_window_set_resizable(GTK_WINDOW(darktable.splash.start_screen), FALSE);
-  gtk_window_set_position(GTK_WINDOW(darktable.splash.start_screen), GTK_WIN_POS_CENTER);
 
   gtk_widget_set_name(darktable.splash.start_screen, "splashscreen");
   darktable.splash.progress_text = gtk_label_new(_("initializing"));

--- a/src/gui/welcome.c
+++ b/src/gui/welcome.c
@@ -677,7 +677,6 @@ void dt_welcome_screen_show(dt_welcome_screen_t *ws)
 #endif
 
   gtk_window_set_default_size(GTK_WINDOW(window), 500, -1);
-  gtk_window_set_position(GTK_WINDOW(window), GTK_WIN_POS_CENTER_ON_PARENT);
 
   GtkWidget *content = dt_gui_vbox();
   gtk_widget_set_name(content, "welcome-content");

--- a/src/gui/workspace.c
+++ b/src/gui/workspace.c
@@ -572,8 +572,6 @@ gboolean dt_workspace_create(const char *datadir)
                                 GTK_RESPONSE_NONE,
                                 NULL);
 
-  gtk_window_set_position(GTK_WINDOW(session->db_screen), GTK_WIN_POS_CENTER);
-
   GList *dbs = dt_read_file_pattern(datadir, "library-*.db");
   if(dbs)
     dbs = g_list_sort(dbs, _workspace_library_db_compare);

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -4189,7 +4189,6 @@ static void _manage_show_window(dt_lib_module_t *self)
   g_signal_connect(d->dialog, "destroy", G_CALLBACK(_manage_editor_destroy), self);
   gtk_window_set_resizable(GTK_WINDOW(d->dialog), TRUE);
 
-  gtk_window_set_position(GTK_WINDOW(d->dialog), GTK_WIN_POS_CENTER_ON_PARENT);
   gtk_widget_show(d->dialog);
 }
 

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -1684,8 +1684,6 @@ void dt_view_accels_show(dt_view_manager_t *vm)
                            GDK_WINDOW_TYPE_HINT_POPUP_MENU);
 
   gtk_window_set_gravity(GTK_WINDOW(vm->accels_window.window), GDK_GRAVITY_STATIC);
-  gtk_window_set_position(GTK_WINDOW(vm->accels_window.window),
-                          GTK_WIN_POS_CENTER_ON_PARENT);
   gtk_widget_show_all(vm->accels_window.window);
 }
 


### PR DESCRIPTION
Remove all calls to `gtk_window_set_position()`, which is removed in GTK4.

In GTK3 these calls provided placement hints to the window manager. Without them, the WM handles placement (centering, cascading, etc.) based on its own policy.

Affects 9 files, 14 call sites:

| File | Line | Old position |
|------|------|-------------|
| `src/gui/gtk.c` | 3320,3324,3329 | CENTER_ON_PARENT / MOUSE |
| `src/gui/gtk.c` | 3411,3415,3420 | CENTER_ON_PARENT / MOUSE |
| `src/gui/gtk.c` | 5080 | CENTER_ON_PARENT |
| `src/gui/splash.c` | 115 | CENTER |
| `src/gui/workspace.c` | 575 | CENTER |
| `src/gui/welcome.c` | 680 | CENTER_ON_PARENT |
| `src/gui/presets.c` | 1531 | CENTER_ON_PARENT |
| `src/gui/metadata_tags.c` | 98 | CENTER_ON_PARENT |
| `src/views/view.c` | 1687 | CENTER_ON_PARENT |
| `src/libs/modulegroups.c` | 4192 | CENTER_ON_PARENT |

Part of the GTK4 migration checklist (#15920, "Review your window creation flags").
Reference: https://docs.gtk.org/gtk4/migrating-3to4.html#review-your-window-creation-flags
