### PR TITLE
gtk4-prep: version-guard `GdkVisual` APIs for GTK4

### DIFF
--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -544,12 +544,19 @@ static void _window_position(const int offset)
       pop->offcut += offset;
       return;
     }
+    pop->offcut = -height;
+    height *= 2;
+    // In GTK4 all visuals are RGBA and GdkVisual/GdkScreen no longer exist.
+    // The RGBA visual setup below is only needed on GTK3 Wayland where
+    // gdk_screen_is_composited() returns TRUE but popups would otherwise be
+    // opaque. At switch time the entire Wayland workaround block must be
+    // reworked (GdkWindow -> GdkSurface, gdk_window_resize removed, etc.).
+#if !GTK_CHECK_VERSION(4, 0, 0)
     gtk_widget_set_app_paintable(pop->window, TRUE);
     GdkScreen *screen = gtk_widget_get_screen(pop->window);
     GdkVisual *visual = gdk_screen_get_rgba_visual(screen);
-    pop->offcut = -height;
-    height *= 2;
     gtk_widget_set_visual(pop->window, visual);
+#endif
   }
 #endif
 


### PR DESCRIPTION
Related: "Stop using non-RGBA visuals" https://github.com/darktable-org/darktable/issues/15920 #20433

There is no other place across darktable's current source code other than this one at `bauhaus.c` when it comes to non-RGBA visuals, AFAIK. According to https://docs.gtk.org/gtk4/migrating-3to4.html:

> Stop using non-RGBA visuals
> 
> GTK 4 always uses RGBA visuals for its windows; you should make sure that your code works with such visuals. At the same time, you should stop using `GdkVisual` APIs, since this object no longer exists in GTK 4. Most of its APIs are deprecated already and not useful when dealing with RGBA visuals.

In preparation for GTK4, guard the Wayland-specific GdkVisual setup (gdk_screen_get_rgba_visual, gtk_widget_set_visual, GdkVisual type, gtk_widget_set_app_paintable, GdkScreen) with `#if !GTK_CHECK_VERSION(4, 0, 0)`. 

Move the `pop->offcut` /  `height` updates outside the guard since they are not GTK API calls.

Something should be done here when the actual transition to GTK4 happens. Hopefully this serves as a reminder!