### PR TITLE
gtk4-prep: replace direct `GdkEvent` struct access with accessor functions

### DIFF
--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "common/gdk_event_utils.h"
 
 #include "bauhaus/bauhaus.h"
 #include "common/calculator.h"
@@ -598,10 +599,10 @@ static gboolean _window_motion_notify(GtkWidget *widget,
   // recalculate event coords so we get useful values outside window
   GdkWindow *window = gtk_widget_get_window(pop->area);
   gdk_window_get_origin(window, &allocation.x, &allocation.y);
-  const gint ex = event->x_root - allocation.x;
-  const gint ey = event->y_root - allocation.y;
+  const gint ex = dt_gdk_event_get_root_x(event) - allocation.x;
+  const gint ey = dt_gdk_event_get_root_y(event) - allocation.y;
 
-  const int tol = DT_PIXEL_APPLY_DPI(event->state & GDK_BUTTON1_MASK ? 400 : 50);
+  const int tol = DT_PIXEL_APPLY_DPI(dt_gdk_event_get_state(event) & GDK_BUTTON1_MASK ? 400 : 50);
   if(ex < - tol || ex > allocation.width + tol
      || ey + pop->offcut < - tol
      || ey + pop->offcut > pop->position.height + tol)
@@ -644,7 +645,7 @@ static gboolean _window_motion_notify(GtkWidget *widget,
                           : _slider_get_line_offset
       (pop->oldpos, 5.0 * powf(10.0f, -d->digits) / (d->max - d->min) / fabsf(d->factor),
        bh->mouse_x / (width - _widget_get_quad_width(w)), bh->mouse_y / width, ht / width);
-    if(event->state & GDK_BUTTON1_MASK
+    if(dt_gdk_event_get_state(event) & GDK_BUTTON1_MASK
        || (bh->mouse_line_distance
            && ((bh->mouse_line_distance * mouse_off <= 0) ^
                (fabsf(bh->mouse_line_distance - mouse_off) > .5f))))
@@ -659,7 +660,7 @@ static gboolean _window_motion_notify(GtkWidget *widget,
     const int active = (bh->mouse_y - w->top_gap) / bh->line_height;
     if(active >= 0 && active < d->entries->len)
     {
-      if(_combobox_entry(d, active)->sensitive && event->state & GDK_BUTTON1_MASK)
+      if(_combobox_entry(d, active)->sensitive && dt_gdk_event_get_state(event) & GDK_BUTTON1_MASK)
       {
         if(active != d->active)
           _combobox_set(w, active, w->combobox.mute_scrolling);
@@ -683,7 +684,7 @@ static gboolean _popup_button_release(GtkWidget *widget,
                                       GdkEventButton *event,
                                       gpointer user_data)
 {
-  if(darktable.bauhaus->change_active && event->button != GDK_BUTTON_MIDDLE)
+  if(darktable.bauhaus->change_active && dt_gdk_event_get_button(event) != GDK_BUTTON_MIDDLE)
     _popup_hide();
 
   return TRUE;
@@ -693,7 +694,7 @@ static gboolean _popup_button_press(GtkWidget *widget,
                                     GdkEventButton *event,
                                     gpointer user_data)
 {
-  if(event->window != gtk_widget_get_window(widget))
+  if(dt_gdk_event_get_window(event) != gtk_widget_get_window(widget))
   {
     _popup_reject();
     return TRUE;
@@ -702,17 +703,17 @@ static gboolean _popup_button_press(GtkWidget *widget,
   dt_bauhaus_t *bh = darktable.bauhaus;
   dt_bauhaus_widget_t *w = bh->current;
 
-  if(event->button == GDK_BUTTON_PRIMARY)
+  if(dt_gdk_event_get_button(event) == GDK_BUTTON_PRIMARY)
   {
     // only accept left mouse click
     gtk_widget_set_state_flags(GTK_WIDGET(w),
                                GTK_STATE_FLAG_FOCUSED, FALSE);
 
     if(w->type == DT_BAUHAUS_COMBOBOX
-       && !dt_gui_long_click(event->time, bh->opentime))
+       && !dt_gui_long_click(dt_gdk_event_get_time(event), bh->opentime))
     {
       // counts as double click, reset:
-      if(!(dt_modifier_is(event->state, GDK_CONTROL_MASK) && w->field
+      if(!(dt_modifier_is(dt_gdk_event_get_state(event), GDK_CONTROL_MASK) && w->field
           && dt_gui_presets_autoapply_for_module((dt_iop_module_t *)w->module,
                                                  GTK_WIDGET(w))))
         dt_bauhaus_widget_reset(GTK_WIDGET(w));
@@ -722,7 +723,7 @@ static gboolean _popup_button_press(GtkWidget *widget,
     event->state |= GDK_BUTTON1_MASK;
     _window_motion_notify(widget, (GdkEventMotion*)event, user_data);
   }
-  else if(event->button == GDK_BUTTON_MIDDLE && w->type == DT_BAUHAUS_SLIDER)
+  else if(dt_gdk_event_get_button(event) == GDK_BUTTON_MIDDLE && w->type == DT_BAUHAUS_SLIDER)
     _slider_zoom_range(w, 0);
   else
     _popup_reject();
@@ -3114,14 +3115,14 @@ static void _widget_scroll(GtkEventControllerScroll *controller,
       {
         int delta = magnitude_x > magnitude_y ? -dx : dy;
         const gboolean force = darktable.control->element == DT_ACTION_ELEMENT_FORCE
-                            && event->scroll.window == gtk_widget_get_window(widget);
-        if(force && dt_modifier_is(event->scroll.state, GDK_SHIFT_MASK | GDK_CONTROL_MASK))
+                            && dt_gdk_event_get_window(event) == gtk_widget_get_window(widget);
+        if(force && dt_modifier_is(dt_gdk_event_get_state(event), GDK_SHIFT_MASK | GDK_CONTROL_MASK))
         {
           _slider_zoom_range(w, delta);
           _slider_zoom_toast(w);
         }
         else
-          _slider_add_step(widget, - delta, event->scroll.state, force);
+          _slider_add_step(widget, - delta, dt_gdk_event_get_state(event), force);
       }
       else
       {
@@ -3140,7 +3141,7 @@ static gboolean _widget_key_press(GtkWidget *widget, GdkEventKey *event)
   dt_bauhaus_widget_t *w = (dt_bauhaus_widget_t *)widget;
 
   int delta = -1;
-  switch(event->keyval)
+  switch(dt_gdk_event_get_keyval(event))
   {
     case GDK_KEY_Right:
     case GDK_KEY_KP_Right:
@@ -3156,7 +3157,7 @@ static gboolean _widget_key_press(GtkWidget *widget, GdkEventKey *event)
       _request_focus(w);
 
       if(w->type == DT_BAUHAUS_SLIDER)
-        _slider_add_step(widget, delta, event->state, FALSE);
+        _slider_add_step(widget, delta, dt_gdk_event_get_state(event), FALSE);
       else
         _combobox_next_sensitive(w, delta, 0, FALSE);
 
@@ -3470,7 +3471,7 @@ static gboolean _popup_key_press(GtkWidget *widget,
   const gboolean is_combo = w->type == DT_BAUHAUS_COMBOBOX;
   int delta = -1;
 
-  switch(event->keyval)
+  switch(dt_gdk_event_get_keyval(event))
   {
     case GDK_KEY_BackSpace:
     case GDK_KEY_Delete:
@@ -3536,7 +3537,7 @@ static gboolean _popup_key_press(GtkWidget *widget,
       if(is_combo)
         _combobox_next_sensitive(w, delta, 0, w->combobox.mute_scrolling);
       else
-        _slider_add_step(GTK_WIDGET(w), delta, event->state, FALSE);
+        _slider_add_step(GTK_WIDGET(w), delta, dt_gdk_event_get_state(event), FALSE);
       break;
     default:
       if(!event->string || !g_utf8_validate(event->string, -1, NULL)) return FALSE;
@@ -3683,7 +3684,7 @@ static void _widget_motion(GtkEventControllerMotion *controller,
       const float steps = floorf((x - bh->mouse_x) / scaled_step);
       GdkEvent *const event = gtk_get_current_event(); // TODO cleanup
       _slider_add_step(widget, copysignf(1, d->factor) * steps,
-                       event->motion.state, FALSE);
+                       dt_gdk_event_get_state(event), FALSE);
       gdk_event_free(event);
 
       bh->mouse_x += steps * scaled_step;

--- a/src/chart/main.c
+++ b/src/chart/main.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2016-2024 darktable developers.
+    Copyright (C) 2016-2026 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "common/gdk_event_utils.h"
 
 #include "chart/dtcairo.h"
 #include "chart/colorchart.h"
@@ -195,7 +196,7 @@ static gboolean motion_notify_callback_reference(GtkWidget *widget, GdkEventMoti
 
 static gboolean handle_motion(GtkWidget *widget, GdkEventMotion *event, dt_lut_t *self, image_t *image)
 {
-  if(!(event->state & GDK_BUTTON1_MASK) || !image->image) return FALSE;
+  if(!(dt_gdk_event_get_state(event) & GDK_BUTTON1_MASK) || !image->image) return FALSE;
 
   // mouse -> 0..1
   float x, y;
@@ -259,8 +260,8 @@ static void map_mouse_to_0_1(GtkWidget *widget, GdkEventMotion *event, image_t *
   guint width = gtk_widget_get_allocated_width(widget);
   guint height = gtk_widget_get_allocated_height(widget);
 
-  *x = (event->x - image->offset_x) / (width - 2.0 * image->offset_x);
-  *y = (event->y - image->offset_y) / (height - 2.0 * image->offset_y);
+  *x = (dt_gdk_event_get_x(event) - image->offset_x) / (width - 2.0 * image->offset_x);
+  *y = (dt_gdk_event_get_y(event) - image->offset_y) / (height - 2.0 * image->offset_y);
 }
 
 static void update_corner(image_t *image, int which, float *x, float *y)

--- a/src/common/gdk_event_utils.h
+++ b/src/common/gdk_event_utils.h
@@ -1,0 +1,172 @@
+/*
+    This file is part of darktable,
+    Copyright (C) 2026 darktable developers.
+
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    darktable is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <gtk/gtk.h>
+
+G_BEGIN_DECLS
+
+/* Inline wrappers around gdk_event_get_*() accessor functions.
+ *
+ * These provide direct-return access to GdkEvent fields without direct struct
+ * member access. They accept const void* so any typed event pointer
+ * (GdkEventButton*, GdkEventKey*, etc.) can be passed without a cast.
+ *
+ * This is preparation for the GTK4 migration where GdkEvent is no longer
+ * a publicly accessible struct.
+ */
+
+static inline GdkEventType dt_gdk_event_get_type(const void *e)
+{
+  return gdk_event_get_event_type((const GdkEvent *)e);
+}
+
+static inline guint32 dt_gdk_event_get_time(const void *e)
+{
+  return gdk_event_get_time((const GdkEvent *)e);
+}
+
+static inline guint dt_gdk_event_get_button(const void *e)
+{
+  guint b = 0;
+  gdk_event_get_button((const GdkEvent *)e, &b);
+  return b;
+}
+
+static inline guint dt_gdk_event_get_click_count(const void *e)
+{
+  guint c = 0;
+  gdk_event_get_click_count((const GdkEvent *)e, &c);
+  return c;
+}
+
+static inline GdkModifierType dt_gdk_event_get_state(const void *e)
+{
+  GdkModifierType s = 0;
+  gdk_event_get_state((const GdkEvent *)e, &s);
+  return s;
+}
+
+static inline gdouble dt_gdk_event_get_x(const void *e)
+{
+  gdouble x = 0, y = 0;
+  gdk_event_get_coords((const GdkEvent *)e, &x, &y);
+  (void)y;
+  return x;
+}
+
+static inline gdouble dt_gdk_event_get_y(const void *e)
+{
+  gdouble x = 0, y = 0;
+  gdk_event_get_coords((const GdkEvent *)e, &x, &y);
+  (void)x;
+  return y;
+}
+
+static inline gdouble dt_gdk_event_get_root_x(const void *e)
+{
+  gdouble x = 0, y = 0;
+  gdk_event_get_root_coords((const GdkEvent *)e, &x, &y);
+  (void)y;
+  return x;
+}
+
+static inline gdouble dt_gdk_event_get_root_y(const void *e)
+{
+  gdouble x = 0, y = 0;
+  gdk_event_get_root_coords((const GdkEvent *)e, &x, &y);
+  (void)x;
+  return y;
+}
+
+static inline guint dt_gdk_event_get_keyval(const void *e)
+{
+  guint k = 0;
+  gdk_event_get_keyval((const GdkEvent *)e, &k);
+  return k;
+}
+
+static inline guint16 dt_gdk_event_get_keycode(const void *e)
+{
+  guint16 k = 0;
+  gdk_event_get_keycode((const GdkEvent *)e, &k);
+  return k;
+}
+
+static inline GdkScrollDirection dt_gdk_event_get_scroll_direction(const void *e)
+{
+  GdkScrollDirection d = GDK_SCROLL_UP;
+  gdk_event_get_scroll_direction((const GdkEvent *)e, &d);
+  return d;
+}
+
+static inline gdouble dt_gdk_event_get_scroll_delta_x(const void *e)
+{
+  gdouble dx = 0, dy = 0;
+  gdk_event_get_scroll_deltas((const GdkEvent *)e, &dx, &dy);
+  (void)dy;
+  return dx;
+}
+
+static inline gdouble dt_gdk_event_get_scroll_delta_y(const void *e)
+{
+  gdouble dx = 0, dy = 0;
+  gdk_event_get_scroll_deltas((const GdkEvent *)e, &dx, &dy);
+  (void)dx;
+  return dy;
+}
+
+static inline GdkWindow *dt_gdk_event_get_window(const void *e)
+{
+  return gdk_event_get_window((const GdkEvent *)e);
+}
+
+static inline GdkDevice *dt_gdk_event_get_device(const void *e)
+{
+  return gdk_event_get_device((const GdkEvent *)e);
+}
+
+static inline GdkDevice *dt_gdk_event_get_source_device(const void *e)
+{
+  return gdk_event_get_source_device((const GdkEvent *)e);
+}
+
+static inline GdkScreen *dt_gdk_event_get_screen(const void *e)
+{
+  return gdk_event_get_screen((const GdkEvent *)e);
+}
+
+static inline GdkSeat *dt_gdk_event_get_seat(const void *e)
+{
+  return gdk_event_get_seat((const GdkEvent *)e);
+}
+
+static inline gboolean dt_gdk_event_get_pointer_emulated(void *e)
+{
+  return gdk_event_get_pointer_emulated((GdkEvent *)e);
+}
+
+static inline gboolean dt_gdk_event_get_axis(const void *e,
+                                              GdkAxisUse axis_use,
+                                              gdouble *value)
+{
+  return gdk_event_get_axis((const GdkEvent *)e, axis_use, value);
+}
+
+G_END_DECLS

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "common/gdk_event_utils.h"
 
 #include "develop/blend.h"
 #include "bauhaus/bauhaus.h"
@@ -1353,7 +1354,7 @@ static gboolean _blendop_blendif_showmask_clicked(GtkToggleButton *button,
 {
   DT_GUARD_GUI_UPDATE(TRUE);
 
-  if(event->button == GDK_BUTTON_PRIMARY)
+  if(dt_gdk_event_get_button(event) == GDK_BUTTON_PRIMARY)
   {
     const gboolean has_mask_display =
       module->request_mask_display
@@ -1365,12 +1366,12 @@ static gboolean _blendop_blendif_showmask_clicked(GtkToggleButton *button,
         | DT_DEV_PIXELPIPE_DISPLAY_CHANNEL
         | DT_DEV_PIXELPIPE_DISPLAY_ANY);
 
-    if(dt_modifier_is(event->state, GDK_CONTROL_MASK | GDK_SHIFT_MASK))
+    if(dt_modifier_is(dt_gdk_event_get_state(event), GDK_CONTROL_MASK | GDK_SHIFT_MASK))
       module->request_mask_display |=
         (DT_DEV_PIXELPIPE_DISPLAY_MASK | DT_DEV_PIXELPIPE_DISPLAY_CHANNEL);
-    else if(dt_modifier_is(event->state, GDK_SHIFT_MASK))
+    else if(dt_modifier_is(dt_gdk_event_get_state(event), GDK_SHIFT_MASK))
       module->request_mask_display |= DT_DEV_PIXELPIPE_DISPLAY_CHANNEL;
-    else if(dt_modifier_is(event->state, GDK_CONTROL_MASK))
+    else if(dt_modifier_is(dt_gdk_event_get_state(event), GDK_CONTROL_MASK))
       module->request_mask_display |= DT_DEV_PIXELPIPE_DISPLAY_MASK;
     else
       module->request_mask_display |=
@@ -1406,7 +1407,7 @@ static gboolean _blendop_masks_modes_none_clicked(GtkWidget *button,
   DT_GUARD_GUI_UPDATE(TRUE);
   dt_iop_gui_blend_data_t *data = module->blend_data;
 
-  if(event->button == GDK_BUTTON_PRIMARY && data->selected_mask_mode != button)
+  if(dt_gdk_event_get_button(event) == GDK_BUTTON_PRIMARY && data->selected_mask_mode != button)
   {
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(data->selected_mask_mode),
                                  FALSE); // unsets currently toggled if any
@@ -1606,12 +1607,12 @@ static gboolean _blendop_masks_add_shape(GtkWidget *widget,
                                          dt_iop_module_t *self)
 {
   if(DT_IN_GUI_UPDATE()
-     || event->button != GDK_BUTTON_PRIMARY)
+     || dt_gdk_event_get_button(event) != GDK_BUTTON_PRIMARY)
     return TRUE;
 
   dt_iop_gui_blend_data_t *bd = self->blend_data;
 
-  const gboolean continuous = dt_modifier_is(event->state, GDK_CONTROL_MASK);
+  const gboolean continuous = dt_modifier_is(dt_gdk_event_get_state(event), GDK_CONTROL_MASK);
 
   // find out who we are
   int this = -1;
@@ -1673,7 +1674,7 @@ static gboolean _blendop_masks_show_and_edit(GtkWidget *widget,
 
   dt_iop_gui_blend_data_t *bd = self->blend_data;
 
-  if(event->button == GDK_BUTTON_PRIMARY)
+  if(dt_gdk_event_get_button(event) == GDK_BUTTON_PRIMARY)
   {
     dt_iop_request_focus(self);
 
@@ -1686,7 +1687,7 @@ static gboolean _blendop_masks_show_and_edit(GtkWidget *widget,
     if(grp && (grp->type & DT_MASKS_GROUP) && grp->points)
     {
       const gboolean control_button_pressed =
-        dt_modifier_is(event->state, GDK_CONTROL_MASK);
+        dt_modifier_is(dt_gdk_event_get_state(event), GDK_CONTROL_MASK);
 
       switch(bd->masks_shown)
       {
@@ -2202,15 +2203,15 @@ static gboolean _blendop_blendif_enter(GtkWidget *widget,
   dt_dev_pixelpipe_display_mask_t mode = DT_DEV_PIXELPIPE_DISPLAY_NONE;
 
   // depending on shift modifiers we activate channel and/or mask display
-  if(dt_modifier_is(event->state, GDK_SHIFT_MASK | GDK_CONTROL_MASK))
+  if(dt_modifier_is(dt_gdk_event_get_state(event), GDK_SHIFT_MASK | GDK_CONTROL_MASK))
   {
     mode = (DT_DEV_PIXELPIPE_DISPLAY_MASK | DT_DEV_PIXELPIPE_DISPLAY_CHANNEL);
   }
-  else if(dt_modifier_is(event->state, GDK_SHIFT_MASK))
+  else if(dt_modifier_is(dt_gdk_event_get_state(event), GDK_SHIFT_MASK))
   {
     mode = DT_DEV_PIXELPIPE_DISPLAY_CHANNEL;
   }
-  else if(dt_modifier_is(event->state, GDK_CONTROL_MASK))
+  else if(dt_modifier_is(dt_gdk_event_get_state(event), GDK_CONTROL_MASK))
   {
     mode = DT_DEV_PIXELPIPE_DISPLAY_MASK;
   }
@@ -2299,7 +2300,7 @@ static gboolean _blendop_blendif_key_press(GtkWidget *widget,
   const int tab = data->tab;
   const int in_out = (widget == GTK_WIDGET(data->filter[1].slider)) ? 1 : 0;
 
-  switch(event->keyval)
+  switch(dt_gdk_event_get_keyval(event))
   {
     case GDK_KEY_a:
     case GDK_KEY_A:

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "common/gdk_event_utils.h"
 
 #include "develop/imageop.h"
 #include "bauhaus/bauhaus.h"
@@ -829,9 +830,9 @@ static gboolean _rename_module_key_press(GtkWidget *entry,
 {
   gboolean ended = FALSE;
 
-  if(event->type == GDK_FOCUS_CHANGE
-     || event->keyval == GDK_KEY_Return
-     || event->keyval == GDK_KEY_KP_Enter)
+  if(dt_gdk_event_get_type(event) == GDK_FOCUS_CHANGE
+     || dt_gdk_event_get_keyval(event) == GDK_KEY_Return
+     || dt_gdk_event_get_keyval(event) == GDK_KEY_KP_Enter)
   {
     if(gtk_entry_get_text_length(GTK_ENTRY(entry)) > 0)
     {
@@ -859,7 +860,7 @@ static gboolean _rename_module_key_press(GtkWidget *entry,
 
     ended = TRUE;
   }
-  else if(event->keyval == GDK_KEY_Escape)
+  else if(dt_gdk_event_get_keyval(event) == GDK_KEY_Escape)
   {
     ended = TRUE;
   }
@@ -984,13 +985,13 @@ static gboolean _gui_multiinstance_callback(GtkButton *button,
                                             GdkEventButton *event,
                                             dt_iop_module_t *module)
 {
-  if(event && event->button == GDK_BUTTON_SECONDARY)
+  if(event && dt_gdk_event_get_button(event) == GDK_BUTTON_SECONDARY)
   {
     if(!(module->flags() & IOP_FLAGS_ONE_INSTANCE))
       _gui_copy_callback(button, module);
     return TRUE;
   }
-  else if(event && event->button == GDK_BUTTON_MIDDLE)
+  else if(event && dt_gdk_event_get_button(event) == GDK_BUTTON_MIDDLE)
   {
     return FALSE;
   }
@@ -2315,7 +2316,7 @@ static gboolean _gui_reset_callback(GtkButton *button,
   // Ctrl is used to apply any auto-presets to the current module
   // If Ctrl was not pressed, or no auto-presets were applied, reset the module parameters
   if(!(event
-       && dt_modifier_is(event->state, GDK_CONTROL_MASK))
+       && dt_modifier_is(dt_gdk_event_get_state(event), GDK_CONTROL_MASK))
      || !dt_gui_presets_autoapply_for_module(module, NULL))
   {
     // if a drawn mask is set, remove it from the list

--- a/src/dtgtk/culling.c
+++ b/src/dtgtk/culling.c
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "common/gdk_event_utils.h"
 
 /** a class to manage a collection of zoomable thumbnails for culling
  * or full preview.  */
@@ -632,7 +633,7 @@ static gboolean _event_gesture(GtkWidget *widget,
                                GdkEvent *event,
                                gpointer user_data)
 {
-  if(event->type != GDK_TOUCHPAD_PINCH) return FALSE;
+  if(dt_gdk_event_get_type(event) != GDK_TOUCHPAD_PINCH) return FALSE;
   const GdkEventTouchpadPinch *pinch = &event->touchpad_pinch;
   dt_print(DT_DEBUG_INPUT,
            "[culling gesture] pinch phase=%d x=%.1f y=%.1f dx=%.3f dy=%.3f scale=%.6f state=0x%x",
@@ -852,25 +853,25 @@ static gboolean _event_button_press(GtkWidget *widget,
 {
   dt_culling_t *table = (dt_culling_t *)user_data;
 
-  if(event->button == GDK_BUTTON_PRIMARY
-     && event->type == GDK_BUTTON_PRESS)
+  if(dt_gdk_event_get_button(event) == GDK_BUTTON_PRIMARY
+     && dt_gdk_event_get_type(event) == GDK_BUTTON_PRESS)
   {
     // make sure any edition field loses the focus
     gtk_widget_grab_focus(dt_ui_center(darktable.gui->ui));
   }
 
-  if(event->button == GDK_BUTTON_MIDDLE)
+  if(dt_gdk_event_get_button(event) == GDK_BUTTON_MIDDLE)
   {
     // convert screen coordinates to culling coordinates
     int ox = 0, oy = 0;
     GdkWindow *win = gtk_widget_get_window(table->widget);
     if(win)
       gdk_window_get_origin(win, &ox, &oy);
-    const float x_culling = event->x_root - ox;
-    const float y_culling = event->y_root - oy;
+    const float x_culling = dt_gdk_event_get_root_x(event) - ox;
+    const float y_culling = dt_gdk_event_get_root_y(event) - oy;
 
     // if shift is pressed, we work only with image hovered
-    if(dt_modifier_is(event->state, GDK_SHIFT_MASK))
+    if(dt_modifier_is(dt_gdk_event_get_state(event), GDK_SHIFT_MASK))
       _toggle_zoom_current(table, x_culling, y_culling);
     else
       _toggle_zoom_all(table, x_culling, y_culling);
@@ -879,8 +880,8 @@ static gboolean _event_button_press(GtkWidget *widget,
 
   const dt_imgid_t id = dt_control_get_mouse_over_id();
   if(dt_is_valid_imgid(id)
-     && event->button == GDK_BUTTON_PRIMARY
-     && event->type == GDK_2BUTTON_PRESS)
+     && dt_gdk_event_get_button(event) == GDK_BUTTON_PRIMARY
+     && dt_gdk_event_get_type(event) == GDK_2BUTTON_PRESS)
   {
     // we have to set again the selected image, because it was deselected
     // during the previous GDK_BUTTON_PRESS event
@@ -896,8 +897,8 @@ static gboolean _event_button_press(GtkWidget *widget,
     return TRUE;
   }
 
-  table->pan_x = event->x_root;
-  table->pan_y = event->y_root;
+  table->pan_x = dt_gdk_event_get_root_x(event);
+  table->pan_y = dt_gdk_event_get_root_y(event);
   table->panning = TRUE;
   return TRUE;
 }
@@ -910,8 +911,8 @@ static gboolean _event_motion_notify(GtkWidget *widget,
   table->mouse_inside = TRUE;
   if(!table->panning)
   {
-    table->pan_x = event->x_root;
-    table->pan_y = event->y_root;
+    table->pan_x = dt_gdk_event_get_root_x(event);
+    table->pan_y = dt_gdk_event_get_root_y(event);
     return FALSE;
   }
 
@@ -930,14 +931,14 @@ static gboolean _event_motion_notify(GtkWidget *widget,
 
   if(table->panning && fz > 1.0f)
   {
-    const double x = event->x_root;
-    const double y = event->y_root;
+    const double x = dt_gdk_event_get_root_x(event);
+    const double y = dt_gdk_event_get_root_y(event);
     // we want the images to stay in the screen
     const float scale = darktable.gui->ppd_thb / darktable.gui->ppd;
     const float valx = (x - table->pan_x) * scale;
     const float valy = (y - table->pan_y) * scale;
 
-    if(dt_modifier_is(event->state, GDK_SHIFT_MASK))
+    if(dt_modifier_is(dt_gdk_event_get_state(event), GDK_SHIFT_MASK))
     {
       const dt_imgid_t mouseid = dt_control_get_mouse_over_id();
       for(GList *l = table->list; l; l = g_list_next(l))
@@ -1006,7 +1007,7 @@ static gboolean _event_button_release(GtkWidget *widget,
   // we use a very simple culling-specific selection
   if(dt_act_on_use_culling_selection()
      && dt_is_valid_imgid(overid)
-     && event->button == GDK_BUTTON_PRIMARY)
+     && dt_gdk_event_get_button(event) == GDK_BUTTON_PRIMARY)
   {
     const dt_imgid_t old_sel = table->selection;
     if(table->selection == overid)

--- a/src/dtgtk/gradientslider.c
+++ b/src/dtgtk/gradientslider.c
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "common/gdk_event_utils.h"
 
 #include <assert.h>
 #include <stdlib.h>
@@ -309,7 +310,7 @@ static gboolean _gradient_slider_button_press(GtkWidget *widget,
   GtkDarktableGradientSlider *gslider = DTGTK_GRADIENT_SLIDER(widget);
 
   // reset slider
-  if(event->button == GDK_BUTTON_PRIMARY && event->type == GDK_2BUTTON_PRESS && gslider->is_resettable)
+  if(dt_gdk_event_get_button(event) == GDK_BUTTON_PRIMARY && dt_gdk_event_get_type(event) == GDK_2BUTTON_PRESS && gslider->is_resettable)
   {
     gslider->is_dragging = FALSE;
     gslider->do_reset = TRUE;
@@ -319,19 +320,19 @@ static gboolean _gradient_slider_button_press(GtkWidget *widget,
     g_signal_emit_by_name(G_OBJECT(widget), "value-changed");
     g_signal_emit_by_name(G_OBJECT(widget), "value-reset");
   }
-  else if((event->button == GDK_BUTTON_PRIMARY || event->button == GDK_BUTTON_SECONDARY) && event->type == GDK_BUTTON_PRESS)
+  else if((dt_gdk_event_get_button(event) == GDK_BUTTON_PRIMARY || dt_gdk_event_get_button(event) == GDK_BUTTON_SECONDARY) && dt_gdk_event_get_type(event) == GDK_BUTTON_PRESS)
   {
-    const gint lselected = _get_active_marker_from_screen(widget, event->x, event->y);
+    const gint lselected = _get_active_marker_from_screen(widget, dt_gdk_event_get_x(event), dt_gdk_event_get_y(event));
 
     assert(lselected >= 0);
     assert(lselected <= gslider->positions - 1);
 
-    if(event->button == GDK_BUTTON_PRIMARY) // left mouse button : select and start dragging
+    if(dt_gdk_event_get_button(event) == GDK_BUTTON_PRIMARY) // left mouse button : select and start dragging
     {
       gslider->selected = lselected;
       gslider->do_reset = FALSE;
 
-      const gdouble newposition = _get_position_from_screen(widget, event->x);
+      const gdouble newposition = _get_position_from_screen(widget, dt_gdk_event_get_x(event));
       const gint direction = gslider->position[gslider->selected] <= newposition ? MOVE_RIGHT : MOVE_LEFT;
 
       _slider_move(widget, gslider->selected, newposition, direction);
@@ -373,7 +374,7 @@ static gboolean _gradient_slider_motion_notify(GtkWidget *widget,
   {
     assert(gslider->timeout_handle > 0);
 
-    const gdouble newposition = _get_position_from_screen(widget, event->x);
+    const gdouble newposition = _get_position_from_screen(widget, dt_gdk_event_get_x(event));
     const gint direction = gslider->position[gslider->selected] <= newposition ? MOVE_RIGHT : MOVE_LEFT;
 
     _slider_move(widget, gslider->selected, newposition, direction);
@@ -384,7 +385,7 @@ static gboolean _gradient_slider_motion_notify(GtkWidget *widget,
   }
   else
   {
-    gslider->active = _get_active_marker_from_screen(widget, event->x, event->y);
+    gslider->active = _get_active_marker_from_screen(widget, dt_gdk_event_get_x(event), dt_gdk_event_get_y(event));
   }
 
   if(gslider->selected != -1) gtk_widget_grab_focus(widget);
@@ -400,11 +401,11 @@ static gboolean _gradient_slider_button_release(GtkWidget *widget,
   GtkDarktableGradientSlider *gslider = DTGTK_GRADIENT_SLIDER(widget);
   const gint selected = _get_active_marker(gslider);
 
-  if(event->button == GDK_BUTTON_PRIMARY && selected != -1 && gslider->do_reset == FALSE)
+  if(dt_gdk_event_get_button(event) == GDK_BUTTON_PRIMARY && selected != -1 && gslider->do_reset == FALSE)
   {
     // First get some dimension info
     gslider->is_changed = TRUE;
-    const gdouble newposition = _get_position_from_screen(widget, event->x);
+    const gdouble newposition = _get_position_from_screen(widget, dt_gdk_event_get_x(event));
     const gint direction = gslider->position[selected] <= newposition ? MOVE_RIGHT : MOVE_LEFT;
 
     _slider_move(widget, selected, newposition, direction);
@@ -437,7 +438,7 @@ static gboolean _gradient_slider_scroll_event(GtkWidget *widget,
   {
     gdouble delta = delta_y * -gslider->increment;
     return _gradient_slider_add_delta_internal(widget, delta,
-                                               event->state, selected);
+                                               dt_gdk_event_get_state(event), selected);
   }
 
   return TRUE;
@@ -452,7 +453,7 @@ static gboolean _gradient_slider_key_press_event(GtkWidget *widget,
 
   int handled = FALSE;
   float delta = -gslider->increment;
-  switch(event->keyval)
+  switch(dt_gdk_event_get_keyval(event))
   {
     case GDK_KEY_Up:
     case GDK_KEY_KP_Up:
@@ -472,7 +473,7 @@ static gboolean _gradient_slider_key_press_event(GtkWidget *widget,
   if(selected == -1) return TRUE;
 
   return _gradient_slider_add_delta_internal(widget, delta,
-                                             event->state, selected);
+                                             dt_gdk_event_get_state(event), selected);
 }
 
 static void _gradient_slider_class_init(GtkDarktableGradientSliderClass *klass)

--- a/src/dtgtk/range.c
+++ b/src/dtgtk/range.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2022-2024 darktable developers.
+    Copyright (C) 2022-2026 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "common/gdk_event_utils.h"
 #include "range.h"
 #include "bauhaus/bauhaus.h"
 #include "control/control.h"
@@ -1511,7 +1512,7 @@ void dtgtk_range_select_redraw(GtkDarktableRangeSelect *range)
 static gboolean _event_band_motion(GtkWidget *widget, GdkEventMotion *event, gpointer user_data)
 {
   GtkDarktableRangeSelect *range = (GtkDarktableRangeSelect *)user_data;
-  range->current_x_px = event->x - range->alloc_padding.x;
+  range->current_x_px = dt_gdk_event_get_x(event) - range->alloc_padding.x;
 
   // if we are outside the graph, don't go further
   const gboolean inside = (range->current_x_px >= 0 && range->current_x_px <= range->alloc_padding.width);
@@ -1526,7 +1527,7 @@ static gboolean _event_band_motion(GtkWidget *widget, GdkEventMotion *event, gpo
   // point the popup to the current position
   gint wx, wy;
   gtk_widget_translate_coordinates(range->band, gtk_widget_get_toplevel(range->band), 0, 0, &wx, &wy);
-  GdkRectangle rect = { event->x, 0, 1, gtk_widget_get_allocated_height(range->band) };
+  GdkRectangle rect = { dt_gdk_event_get_x(event), 0, 1, gtk_widget_get_allocated_height(range->band) };
   gtk_popover_set_pointing_to(GTK_POPOVER(range->cur_window), &rect);
 
   const double smin_r = (range->bounds & DT_RANGE_BOUND_MIN) ? range->min_r : range->select_min_r;

--- a/src/dtgtk/resetlabel.c
+++ b/src/dtgtk/resetlabel.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2010-2020 darktable developers.
+    Copyright (C) 2010-2026 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "common/gdk_event_utils.h"
 
 #include "dtgtk/resetlabel.h"
 
@@ -30,7 +31,7 @@ static void dtgtk_reset_label_init(GtkDarktableResetLabel *label)
 
 static gboolean _reset_label_callback(GtkDarktableResetLabel *label, GdkEventButton *event, gpointer user_data)
 {
-  if(event->type == GDK_2BUTTON_PRESS)
+  if(dt_gdk_event_get_type(event) == GDK_2BUTTON_PRESS)
   {
     memcpy(((char *)label->module->params) + label->offset,
            ((char *)label->module->default_params) + label->offset, label->size);

--- a/src/dtgtk/thumbnail.c
+++ b/src/dtgtk/thumbnail.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2019-2024 darktable developers.
+    Copyright (C) 2019-2026 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "common/gdk_event_utils.h"
 /** this is the thumbnail class for the lighttable module.  */
 
 #include "common/extra_optimizations.h"
@@ -1055,7 +1056,7 @@ static gboolean _event_rating_release(GtkWidget *widget,
   if(dtgtk_thumbnail_btn_is_hidden(widget))
     return FALSE;
 
-  if(event->button == GDK_BUTTON_PRIMARY && !thumb->moved)
+  if(dt_gdk_event_get_button(event) == GDK_BUTTON_PRIMARY && !thumb->moved)
   {
     dt_view_image_over_t rating = DT_VIEW_DESERT;
     if(widget == thumb->w_reject)
@@ -1093,12 +1094,12 @@ static gboolean _event_grouping_release(GtkWidget *widget,
   if(dtgtk_thumbnail_btn_is_hidden(widget))
     return FALSE;
 
-  if(event->button == GDK_BUTTON_PRIMARY && !thumb->moved)
+  if(dt_gdk_event_get_button(event) == GDK_BUTTON_PRIMARY && !thumb->moved)
   {
     //TODO: will succeed if either or *both* of Shift and Control are
     //pressed.  Do we want this?
-    if(dt_modifier_is(event->state, GDK_SHIFT_MASK)
-       | dt_modifier_is(event->state, GDK_CONTROL_MASK))
+    if(dt_modifier_is(dt_gdk_event_get_state(event), GDK_SHIFT_MASK)
+       | dt_modifier_is(dt_gdk_event_get_state(event), GDK_CONTROL_MASK))
     {
       // just add the whole group to the selection. TODO: make this
       // also work for collapsed groups.
@@ -1143,7 +1144,7 @@ static gboolean _event_audio_release(GtkWidget *widget,
   if(dtgtk_thumbnail_btn_is_hidden(widget))
     return FALSE;
 
-  if(event->button == GDK_BUTTON_PRIMARY && !thumb->moved)
+  if(dt_gdk_event_get_button(event) == GDK_BUTTON_PRIMARY && !thumb->moved)
   {
     gboolean start_audio = TRUE;
     if(darktable.view_manager->audio.audio_player_id != -1)
@@ -1313,12 +1314,12 @@ static gboolean _event_box_enter_leave(GtkWidget *widget,
 {
   dt_thumbnail_t *thumb = (dt_thumbnail_t *)user_data;
 
-  if(event->type == GDK_ENTER_NOTIFY && !thumb->disable_mouseover)
+  if(dt_gdk_event_get_type(event) == GDK_ENTER_NOTIFY && !thumb->disable_mouseover)
     dt_control_set_mouse_over_id(thumb->imgid);
 
-  _set_flag(widget, GTK_STATE_FLAG_PRELIGHT, (event->type == GDK_ENTER_NOTIFY));
+  _set_flag(widget, GTK_STATE_FLAG_PRELIGHT, (dt_gdk_event_get_type(event) == GDK_ENTER_NOTIFY));
   _set_flag(thumb->w_image_box, GTK_STATE_FLAG_PRELIGHT,
-            (event->type == GDK_ENTER_NOTIFY));
+            (dt_gdk_event_get_type(event) == GDK_ENTER_NOTIFY));
   return FALSE;
 }
 
@@ -1328,11 +1329,11 @@ static gboolean _event_image_enter_leave(GtkWidget *widget,
 {
   dt_thumbnail_t *thumb = (dt_thumbnail_t *)user_data;
 
-  if(event->type == GDK_ENTER_NOTIFY && !thumb->disable_mouseover)
+  if(dt_gdk_event_get_type(event) == GDK_ENTER_NOTIFY && !thumb->disable_mouseover)
     dt_control_set_mouse_over_id(thumb->imgid);
 
   _set_flag(thumb->w_image_box, GTK_STATE_FLAG_PRELIGHT,
-            (event->type == GDK_ENTER_NOTIFY));
+            (dt_gdk_event_get_type(event) == GDK_ENTER_NOTIFY));
   return FALSE;
 }
 
@@ -1342,7 +1343,7 @@ static gboolean _event_btn_enter_leave(GtkWidget *widget,
 {
   dt_thumbnail_t *thumb = (dt_thumbnail_t *)user_data;
 
-  if(event->type == GDK_ENTER_NOTIFY)
+  if(dt_gdk_event_get_type(event) == GDK_ENTER_NOTIFY)
   {
     if(widget == thumb->w_reject)
       darktable.control->element = DT_VIEW_REJECT;
@@ -1355,7 +1356,7 @@ static gboolean _event_btn_enter_leave(GtkWidget *widget,
     _set_flag(thumb->w_image_box, GTK_STATE_FLAG_PRELIGHT, TRUE);
     _thumb_update_tags_tooltip(thumb);
   }
-  else if(event->type == GDK_LEAVE_NOTIFY)
+  else if(dt_gdk_event_get_type(event) == GDK_LEAVE_NOTIFY)
   {
     if(widget == thumb->w_reject)
       darktable.control->element = -1;

--- a/src/dtgtk/thumbnail_btn.c
+++ b/src/dtgtk/thumbnail_btn.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    copyright (c)2020 Aldric Renaudin.
+    copyright (c)2020-2026 Aldric Renaudin.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "common/gdk_event_utils.h"
 #include "thumbnail_btn.h"
 #include "gui/gtk.h"
 #include <string.h>
@@ -103,7 +104,7 @@ static gboolean _thumbnail_btn_enter_leave_notify_callback(GtkWidget *widget, Gd
 {
   g_return_val_if_fail(widget != NULL, FALSE);
 
-  if(event->type == GDK_ENTER_NOTIFY)
+  if(dt_gdk_event_get_type(event) == GDK_ENTER_NOTIFY)
     gtk_widget_set_state_flags(widget, GTK_STATE_FLAG_PRELIGHT, FALSE);
   else
     gtk_widget_unset_state_flags(widget, GTK_STATE_FLAG_PRELIGHT);

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "common/gdk_event_utils.h"
 /** a class to manage a table of thumbnail for lighttable and filmstrip.  */
 
 #include "dtgtk/thumbtable.h"
@@ -1434,10 +1435,10 @@ static gboolean _event_button_press(GtkWidget *widget,
 
   const dt_imgid_t id = dt_control_get_mouse_over_id();
 
-  if(dt_is_valid_imgid(id) && event->button == GDK_BUTTON_PRIMARY)
+  if(dt_is_valid_imgid(id) && dt_gdk_event_get_button(event) == GDK_BUTTON_PRIMARY)
   {
     //  double-click
-    if(event->type == GDK_2BUTTON_PRESS)
+    if(dt_gdk_event_get_type(event) == GDK_2BUTTON_PRESS)
     {
       switch(table->mode)
       {
@@ -1468,12 +1469,12 @@ static gboolean _event_button_press(GtkWidget *widget,
       }
     }
 
-    if(event->type == GDK_BUTTON_PRESS
+    if(dt_gdk_event_get_type(event) == GDK_BUTTON_PRESS
        && table->mode == DT_THUMBTABLE_MODE_FILMSTRIP)
       return FALSE;
   }
 
-  if(event->button == GDK_BUTTON_PRIMARY && event->type == GDK_BUTTON_PRESS)
+  if(dt_gdk_event_get_button(event) == GDK_BUTTON_PRIMARY && dt_gdk_event_get_type(event) == GDK_BUTTON_PRESS)
   {
     // make sure any edition field loses the focus
     gtk_widget_grab_focus(dt_ui_center(darktable.gui->ui));
@@ -1481,8 +1482,8 @@ static gboolean _event_button_press(GtkWidget *widget,
 
   if(table->mode != DT_THUMBTABLE_MODE_ZOOM
      && !dt_is_valid_imgid(id)
-     && event->button == GDK_BUTTON_PRIMARY
-     && event->type == GDK_BUTTON_PRESS)
+     && dt_gdk_event_get_button(event) == GDK_BUTTON_PRIMARY
+     && dt_gdk_event_get_type(event) == GDK_BUTTON_PRESS)
   {
     const dt_view_type_flags_t cv = dt_view_get_current();
 
@@ -1499,8 +1500,8 @@ static gboolean _event_button_press(GtkWidget *widget,
     }
 
     PangoRectangle *button = &table->manual_button;
-    if(event->x < button->x && event->x > button->x - button->width
-       && event->y < button->y && event->y > button->y - button->height)
+    if(dt_gdk_event_get_x(event) < button->x && dt_gdk_event_get_x(event) > button->x - button->width
+       && dt_gdk_event_get_y(event) < button->y && dt_gdk_event_get_y(event) > button->y - button->height)
     {
       dt_gui_show_help(NULL);
     }
@@ -1511,7 +1512,7 @@ static gboolean _event_button_press(GtkWidget *widget,
   if(table->mode != DT_THUMBTABLE_MODE_ZOOM)
     return TRUE;
 
-  if(event->button == GDK_BUTTON_PRIMARY && event->type == GDK_BUTTON_PRESS)
+  if(dt_gdk_event_get_button(event) == GDK_BUTTON_PRIMARY && dt_gdk_event_get_type(event) == GDK_BUTTON_PRESS)
   {
     table->dragging = TRUE;
     table->drag_dx = table->drag_dy = 0;
@@ -1534,8 +1535,8 @@ static gboolean _event_motion_notify(GtkWidget *widget,
   gboolean ret = FALSE;
   if(table->dragging && table->mode == DT_THUMBTABLE_MODE_ZOOM)
   {
-    const int dx = ceil(event->x_root) - table->last_x;
-    const int dy = ceil(event->y_root) - table->last_y;
+    const int dx = ceil(dt_gdk_event_get_root_x(event)) - table->last_x;
+    const int dy = ceil(dt_gdk_event_get_root_y(event)) - table->last_y;
     _move(table, dx, dy, TRUE);
     table->drag_dx += dx;
     table->drag_dy += dy;
@@ -1549,8 +1550,8 @@ static gboolean _event_motion_notify(GtkWidget *widget,
     ret = TRUE;
   }
 
-  table->last_x = ceil(event->x_root);
-  table->last_y = ceil(event->y_root);
+  table->last_x = ceil(dt_gdk_event_get_root_x(event));
+  table->last_y = ceil(dt_gdk_event_get_root_y(event));
   return ret;
 }
 
@@ -1571,15 +1572,15 @@ static gboolean _event_button_release(GtkWidget *widget,
   const dt_imgid_t id = dt_control_get_mouse_over_id();
 
   if(dt_is_valid_imgid(id)
-     && event->button == GDK_BUTTON_PRIMARY
-     && event->type == GDK_BUTTON_RELEASE)
+     && dt_gdk_event_get_button(event) == GDK_BUTTON_PRIMARY
+     && dt_gdk_event_get_type(event) == GDK_BUTTON_RELEASE)
   {
-    if(dt_modifier_is(event->state, GDK_CONTROL_MASK)
-       || dt_modifier_is(event->state, GDK_MOD2_MASK)) // CMD key on macOS
+    if(dt_modifier_is(dt_gdk_event_get_state(event), GDK_CONTROL_MASK)
+       || dt_modifier_is(dt_gdk_event_get_state(event), GDK_MOD2_MASK)) // CMD key on macOS
     {
       dt_selection_toggle(darktable.selection, id);
     }
-    else if(dt_modifier_is(event->state, GDK_SHIFT_MASK))
+    else if(dt_modifier_is(dt_gdk_event_get_state(event), GDK_SHIFT_MASK))
     {
       dt_selection_select_range(darktable.selection, id);
     }

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "common/gdk_event_utils.h"
 
 #include "gui/accelerators.h"
 #include "common/action.h"
@@ -2001,7 +2002,7 @@ static gboolean _view_key_pressed(GtkWidget *widget,
     if(!strcmp(gtk_widget_get_name(widget), "actions_view"))
     {
       // if control key pressed, copy lua command to clipboard (CTRL+C will work)
-      if(dt_modifier_is(event->state, GDK_CONTROL_MASK))
+      if(dt_modifier_is(dt_gdk_event_get_state(event), GDK_CONTROL_MASK))
       {
         dt_shortcut_t shortcut = { .speed = 1.0 };
         gtk_tree_model_get(model, &iter, 0, &shortcut.action, -1);
@@ -2019,13 +2020,13 @@ static gboolean _view_key_pressed(GtkWidget *widget,
         dt_shortcut_t *s = g_sequence_get(shortcut_iter);
 
         // if control key pressed, copy lua command to clipboard (CTRL+C will work)
-        if(dt_modifier_is(event->state, GDK_CONTROL_MASK) && s->views)
+        if(dt_modifier_is(dt_gdk_event_get_state(event), GDK_CONTROL_MASK) && s->views)
         {
           _shortcut_copy_lua(NULL, s, NULL);
         }
 
         // GDK_KEY_BackSpace moves to parent in tree
-        if(event->keyval == GDK_KEY_Delete || event->keyval == GDK_KEY_KP_Delete)
+        if(dt_gdk_event_get_keyval(event) == GDK_KEY_Delete || dt_gdk_event_get_keyval(event) == GDK_KEY_KP_Delete)
         {
           if(dt_gui_show_yes_no_dialog(_("removing shortcut"), "",
                                        s->is_default ? s->views ?
@@ -2266,15 +2267,15 @@ static gboolean _action_view_click(GtkWidget *widget,
   GtkTreeView *view = GTK_TREE_VIEW(widget);
   GtkTreeModel *model = gtk_tree_view_get_model(view);
 
-  if(event->button == GDK_BUTTON_PRIMARY)
+  if(dt_gdk_event_get_button(event) == GDK_BUTTON_PRIMARY)
   {
     GtkTreeSelection *selection = gtk_tree_view_get_selection(view);
 
     GtkTreePath *path = NULL;
-    if(gtk_tree_view_get_path_at_pos(view, (gint)event->x, (gint)event->y,
+    if(gtk_tree_view_get_path_at_pos(view, (gint)dt_gdk_event_get_x(event), (gint)dt_gdk_event_get_y(event),
                                      &path, NULL, NULL, NULL))
     {
-      if(event->type == GDK_DOUBLE_BUTTON_PRESS)
+      if(dt_gdk_event_get_type(event) == GDK_DOUBLE_BUTTON_PRESS)
       {
         gtk_tree_selection_select_path(selection, path);
         _action_row_activated(view, path, NULL, model);
@@ -2295,7 +2296,7 @@ static gboolean _action_view_click(GtkWidget *widget,
     else
       gtk_tree_selection_unselect_all(selection);
   }
-  else if(event->button == GDK_BUTTON_SECONDARY)
+  else if(dt_gdk_event_get_button(event) == GDK_BUTTON_SECONDARY)
   {
     GtkTreeIter iter;
     gtk_tree_model_get_iter_first(model, &iter);
@@ -4521,7 +4522,7 @@ static guint _fix_keyval(GdkEvent *event)
 {
   guint keyval = 0;
   GdkKeymap *keymap = gdk_keymap_get_for_display(gdk_display_get_default());
-  gdk_keymap_translate_keyboard_state(keymap, event->key.hardware_keycode, 0, 0,
+  gdk_keymap_translate_keyboard_state(keymap, dt_gdk_event_get_keycode(event), 0, 0,
                                       &keyval, NULL, NULL, NULL);
   return keyval;
 }
@@ -4530,16 +4531,16 @@ gboolean dt_shortcut_dispatcher(GtkWidget *w,
                                 GdkEvent *event,
                                 gpointer user_data)
 {
-  if((event->type ==  GDK_BUTTON_PRESS || event->type ==  GDK_BUTTON_RELEASE ||
-      event->type ==  GDK_DOUBLE_BUTTON_PRESS || event->type ==  GDK_TRIPLE_BUTTON_PRESS)
-     && event->button.button > 7)
+  if((dt_gdk_event_get_type(event) ==  GDK_BUTTON_PRESS || dt_gdk_event_get_type(event) ==  GDK_BUTTON_RELEASE ||
+      dt_gdk_event_get_type(event) ==  GDK_DOUBLE_BUTTON_PRESS || dt_gdk_event_get_type(event) ==  GDK_TRIPLE_BUTTON_PRESS)
+     && dt_gdk_event_get_button(event) > 7)
   {
-    if(event->type == GDK_BUTTON_RELEASE)
+    if(dt_gdk_event_get_type(event) == GDK_BUTTON_RELEASE)
       dt_shortcut_key_release(DT_SHORTCUT_DEVICE_TABLET,
-                              event->button.time, event->button.button - 7);
+                              dt_gdk_event_get_time(event), dt_gdk_event_get_button(event) - 7);
     else
       dt_shortcut_key_press  (DT_SHORTCUT_DEVICE_TABLET,
-                              event->button.time, event->button.button - 7);
+                              dt_gdk_event_get_time(event), dt_gdk_event_get_button(event) - 7);
 
     return TRUE;
   }
@@ -4547,10 +4548,10 @@ gboolean dt_shortcut_dispatcher(GtkWidget *w,
   if(_pressed_keys == NULL)
   {
     dt_shortcut_t s = { .action = _sc.action };
-    gboolean middle_click = event->type == GDK_BUTTON_PRESS
-      && event->button.button == GDK_BUTTON_MIDDLE;
+    gboolean middle_click = dt_gdk_event_get_type(event) == GDK_BUTTON_PRESS
+      && dt_gdk_event_get_button(event) == GDK_BUTTON_MIDDLE;
 
-    if((middle_click || event->type == GDK_SCROLL)
+    if((middle_click || dt_gdk_event_get_type(event) == GDK_SCROLL)
        && (s.action || (s.action = dt_action_widget(darktable.control->mapping_widget))))
     {
       int delta;
@@ -4568,19 +4569,19 @@ gboolean dt_shortcut_dispatcher(GtkWidget *w,
       return TRUE;
     }
 
-    if(_grab_widget && event->type == GDK_BUTTON_PRESS)
+    if(_grab_widget && dt_gdk_event_get_type(event) == GDK_BUTTON_PRESS)
     {
       _ungrab_grab_widget();
       _sc = (dt_shortcut_t) { 0 };
       return TRUE;
     }
 
-    if(event->type != GDK_KEY_PRESS && event->type != GDK_KEY_RELEASE &&
-       event->type != GDK_FOCUS_CHANGE)
+    if(dt_gdk_event_get_type(event) != GDK_KEY_PRESS && dt_gdk_event_get_type(event) != GDK_KEY_RELEASE &&
+       dt_gdk_event_get_type(event) != GDK_FOCUS_CHANGE)
       return FALSE;
 
     if(GTK_IS_WINDOW(w) &&
-       (event->type == GDK_KEY_PRESS || event->type == GDK_KEY_RELEASE))
+       (dt_gdk_event_get_type(event) == GDK_KEY_PRESS || dt_gdk_event_get_type(event) == GDK_KEY_RELEASE))
     {
       GtkWidget *focused_widget = gtk_window_get_focus(GTK_WINDOW(w));
       if(focused_widget)
@@ -4589,23 +4590,23 @@ gboolean dt_shortcut_dispatcher(GtkWidget *w,
           return TRUE;
 
         if((GTK_IS_ENTRY(focused_widget) || GTK_IS_TREE_VIEW(focused_widget)) &&
-           (event->key.keyval == GDK_KEY_Tab ||
-            event->key.keyval == GDK_KEY_KP_Tab ||
-            event->key.keyval == GDK_KEY_ISO_Left_Tab))
+           (dt_gdk_event_get_keyval(event) == GDK_KEY_Tab ||
+            dt_gdk_event_get_keyval(event) == GDK_KEY_KP_Tab ||
+            dt_gdk_event_get_keyval(event) == GDK_KEY_ISO_Left_Tab))
           return FALSE;
       }
     }
   }
 
-  switch(event->type)
+  switch(dt_gdk_event_get_type(event))
   {
   case GDK_KEY_PRESS:
     if(event->key.is_modifier
-    // || event->key.keyval >= GDK_KEY_ModeLock (all hardware event "keys", including extra "media" keys)
-       || event->key.keyval == GDK_KEY_VoidSymbol
-       || event->key.keyval == GDK_KEY_Meta_L
-       || event->key.keyval == GDK_KEY_Meta_R
-       || event->key.keyval == GDK_KEY_ISO_Level3_Shift)
+    // || dt_gdk_event_get_keyval(event) >= GDK_KEY_ModeLock (all hardware event "keys", including extra "media" keys)
+       || dt_gdk_event_get_keyval(event) == GDK_KEY_VoidSymbol
+       || dt_gdk_event_get_keyval(event) == GDK_KEY_Meta_L
+       || dt_gdk_event_get_keyval(event) == GDK_KEY_Meta_R
+       || dt_gdk_event_get_keyval(event) == GDK_KEY_ISO_Level3_Shift)
       return FALSE;
 
     dt_shortcut_t ko = { .key = _fix_keyval(event) - 1, .press = 0x7,
@@ -4620,23 +4621,23 @@ gboolean dt_shortcut_dispatcher(GtkWidget *w,
         return FALSE;
     }
 
-    _sc.mods = _key_modifiers_clean(event->key.state);
+    _sc.mods = _key_modifiers_clean(dt_gdk_event_get_state(event));
 
-    dt_shortcut_key_press(DT_SHORTCUT_DEVICE_KEYBOARD_MOUSE, event->key.time, ko.key + 1);
+    dt_shortcut_key_press(DT_SHORTCUT_DEVICE_KEYBOARD_MOUSE, dt_gdk_event_get_time(event), ko.key + 1);
     break;
   case GDK_KEY_RELEASE:
-    if(event->key.is_modifier || event->key.keyval == GDK_KEY_ISO_Level3_Shift)
+    if(event->key.is_modifier || dt_gdk_event_get_keyval(event) == GDK_KEY_ISO_Level3_Shift)
     {
       // are we defining shortcuts for fallbacks? just modifiers can be used.
       if(_sc.action && _sc.action->type == DT_ACTION_TYPE_FALLBACK)
       {
-        _sc.mods = _key_modifiers_clean(event->key.state);
+        _sc.mods = _key_modifiers_clean(dt_gdk_event_get_state(event));
         dt_shortcut_move(DT_SHORTCUT_DEVICE_KEYBOARD_MOUSE, 0, DT_SHORTCUT_MOVE_NONE, 1);
       }
       return FALSE;
     }
 
-    dt_shortcut_key_release(DT_SHORTCUT_DEVICE_KEYBOARD_MOUSE, event->key.time, _fix_keyval(event));
+    dt_shortcut_key_release(DT_SHORTCUT_DEVICE_KEYBOARD_MOUSE, dt_gdk_event_get_time(event), _fix_keyval(event));
     break;
   case GDK_GRAB_BROKEN:
     if(!event->grab_broken.implicit)
@@ -4653,16 +4654,16 @@ gboolean dt_shortcut_dispatcher(GtkWidget *w,
       _ungrab_at_focus_loss();
     return FALSE;
   case GDK_SCROLL:
-    _sc.mods = _key_modifiers_clean(event->scroll.state);
+    _sc.mods = _key_modifiers_clean(dt_gdk_event_get_state(event));
 
     int delta_x, delta_y;
     if(dt_gui_get_scroll_unit_deltas(&event->scroll, &delta_x, &delta_y))
     {
       if(delta_x)
-        dt_shortcut_move(DT_SHORTCUT_DEVICE_KEYBOARD_MOUSE, event->scroll.time,
+        dt_shortcut_move(DT_SHORTCUT_DEVICE_KEYBOARD_MOUSE, dt_gdk_event_get_time(event),
                          DT_SHORTCUT_MOVE_PAN, -delta_x);
       if(delta_y)
-        dt_shortcut_move(DT_SHORTCUT_DEVICE_KEYBOARD_MOUSE, event->scroll.time,
+        dt_shortcut_move(DT_SHORTCUT_DEVICE_KEYBOARD_MOUSE, dt_gdk_event_get_time(event),
                          DT_SHORTCUT_MOVE_SCROLL, -delta_y);
     }
     break;
@@ -4670,15 +4671,15 @@ gboolean dt_shortcut_dispatcher(GtkWidget *w,
     ;
     static gdouble move_start_x = 0, move_start_y = 0, last_distance = 0;
 
-    const gdouble x_move = event->motion.x - move_start_x;
-    const gdouble y_move = event->motion.y - move_start_y;
+    const gdouble x_move = dt_gdk_event_get_x(event) - move_start_x;
+    const gdouble y_move = dt_gdk_event_get_y(event) - move_start_y;
     const gdouble new_distance = x_move * x_move + y_move * y_move;
 
     static int move_last_time = 0;
     if(move_last_time != _last_time || new_distance < last_distance)
     {
-      move_start_x = event->motion.x;
-      move_start_y = event->motion.y;
+      move_start_x = dt_gdk_event_get_x(event);
+      move_start_y = dt_gdk_event_get_y(event);
       move_last_time = _last_time;
       last_distance = 0;
       break;
@@ -4686,11 +4687,11 @@ gboolean dt_shortcut_dispatcher(GtkWidget *w,
 
     // might just be an accidental move during a key press or button click
     // possibly different time sources from midi or other devices
-    if(event->motion.time > _last_time
-       && !dt_gui_long_click(event->motion.time, _last_time))
+    if(dt_gdk_event_get_time(event) > _last_time
+       && !dt_gui_long_click(dt_gdk_event_get_time(event), _last_time))
       break;
 
-    _sc.mods = _key_modifiers_clean(event->motion.state);
+    _sc.mods = _key_modifiers_clean(dt_gdk_event_get_state(event));
 
     const gdouble step_size = 10;
 
@@ -4704,7 +4705,7 @@ gboolean dt_shortcut_dispatcher(GtkWidget *w,
       if(fabs(angle) >= 2)
       {
         move_start_x += size * step_size;
-        move_start_y = event->motion.y;
+        move_start_y = dt_gdk_event_get_y(event);
       }
       else
       {
@@ -4712,7 +4713,7 @@ gboolean dt_shortcut_dispatcher(GtkWidget *w,
         move_start_y -= size * step_size;
         if(fabs(angle) < .5)
         {
-          move_start_x = event->motion.x;
+          move_start_x = dt_gdk_event_get_x(event);
           move = DT_SHORTCUT_MOVE_VERTICAL;
         }
         else
@@ -4724,19 +4725,19 @@ gboolean dt_shortcut_dispatcher(GtkWidget *w,
 
       if(_previous_move == move || _previous_move == DT_SHORTCUT_MOVE_NONE)
         dt_shortcut_move(DT_SHORTCUT_DEVICE_KEYBOARD_MOUSE,
-                         event->motion.time, move, size);
+                         dt_gdk_event_get_time(event), move, size);
       else
         _previous_move = move;
     }
     break;
   case GDK_BUTTON_PRESS:
-    _sc.mods = _key_modifiers_clean(event->button.state);
+    _sc.mods = _key_modifiers_clean(dt_gdk_event_get_state(event));
 
-    _pressed_button |= 1 << (event->button.button - 1);
+    _pressed_button |= 1 << (dt_gdk_event_get_button(event) - 1);
     _interrupt_delayed_release(_sc.button != _pressed_button);
     _sc.button = _pressed_button;
     _sc.click = 0;
-    _last_time = event->button.time;
+    _last_time = dt_gdk_event_get_time(event);
     break;
   case GDK_DOUBLE_BUTTON_PRESS:
     _sc.click |= DT_SHORTCUT_DOUBLE;
@@ -4745,11 +4746,11 @@ gboolean dt_shortcut_dispatcher(GtkWidget *w,
     _sc.click |= DT_SHORTCUT_TRIPLE;
     break;
   case GDK_BUTTON_RELEASE:
-    _pressed_button &= ~(1 << (event->button.button - 1));
+    _pressed_button &= ~(1 << (dt_gdk_event_get_button(event) - 1));
 
     _interrupt_delayed_release(FALSE);
 
-    _delay_for_double_triple(event->button.time, 0);
+    _delay_for_double_triple(dt_gdk_event_get_time(event), 0);
 
     _last_time = 0; // important; otherwise releasing two buttons will trigger two actions
                     // also, we seem to be receiving presses and releases twice!?! FIXME

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "common/gdk_event_utils.h"
 
 #include "common/darktable.h"
 #ifdef HAVE_GPHOTO2
@@ -430,7 +431,7 @@ gboolean dt_gui_ignore_scroll(GdkEventScroll *event)
   const gboolean ignore_without_mods =
     dt_conf_get_bool("darkroom/ui/sidebar_scroll_default");
   const GdkModifierType mods_pressed =
-    (event->state & gtk_accelerator_get_default_mod_mask());
+    (dt_gdk_event_get_state(event) & gtk_accelerator_get_default_mod_mask());
 
   if(mods_pressed == 0)
   {
@@ -457,7 +458,7 @@ gboolean dt_gui_get_scroll_deltas(const GdkEventScroll *event,
   if(gdk_event_get_pointer_emulated((GdkEvent*)event)) return FALSE;
 
   gboolean handled = FALSE;
-  switch(event->direction)
+  switch(dt_gdk_event_get_scroll_direction(event))
   {
     // is one-unit cardinal, e.g. from a mouse scroll wheel
     case GDK_SCROLL_LEFT:
@@ -494,14 +495,14 @@ gboolean dt_gui_get_scroll_deltas(const GdkEventScroll *event,
       break;
     // is trackpad (or touch) scroll
     case GDK_SCROLL_SMOOTH:
-      if((delta_x && event->delta_x != 0) || (delta_y && event->delta_y != 0))
+      if((delta_x && dt_gdk_event_get_scroll_delta_x(event) != 0) || (delta_y && dt_gdk_event_get_scroll_delta_y(event) != 0))
       {
 #ifdef GDK_WINDOWING_QUARTZ // on macOS deltas need to be scaled
-        if(delta_x) *delta_x = event->delta_x / DT_UI_SCROLL_SMOOTH_DELTA_SCALE;
-        if(delta_y) *delta_y = event->delta_y / DT_UI_SCROLL_SMOOTH_DELTA_SCALE;
+        if(delta_x) *delta_x = dt_gdk_event_get_scroll_delta_x(event) / DT_UI_SCROLL_SMOOTH_DELTA_SCALE;
+        if(delta_y) *delta_y = dt_gdk_event_get_scroll_delta_y(event) / DT_UI_SCROLL_SMOOTH_DELTA_SCALE;
 #else
-         if(delta_x) *delta_x = event->delta_x;
-         if(delta_y) *delta_y = event->delta_y;
+         if(delta_x) *delta_x = dt_gdk_event_get_scroll_delta_x(event);
+         if(delta_y) *delta_y = dt_gdk_event_get_scroll_delta_y(event);
 #endif
         handled = TRUE;
       }
@@ -524,7 +525,7 @@ gboolean dt_gui_get_scroll_unit_deltas(const GdkEventScroll *event,
 
   gboolean handled = FALSE;
 
-  switch(event->direction)
+  switch(dt_gdk_event_get_scroll_direction(event))
   {
     // is one-unit cardinal, e.g. from a mouse scroll wheel
     case GDK_SCROLL_LEFT:
@@ -571,11 +572,11 @@ gboolean dt_gui_get_scroll_unit_deltas(const GdkEventScroll *event,
       // scroll, and only then tell caller that there is a scroll to
       // handle
 #ifdef GDK_WINDOWING_QUARTZ // on macOS deltas need to be scaled
-      acc_x += event->delta_x / DT_UI_SCROLL_SMOOTH_DELTA_SCALE;
-      acc_y += event->delta_y / DT_UI_SCROLL_SMOOTH_DELTA_SCALE;
+      acc_x += dt_gdk_event_get_scroll_delta_x(event) / DT_UI_SCROLL_SMOOTH_DELTA_SCALE;
+      acc_y += dt_gdk_event_get_scroll_delta_y(event) / DT_UI_SCROLL_SMOOTH_DELTA_SCALE;
 #else
-      acc_x += event->delta_x;
-      acc_y += event->delta_y;
+      acc_x += dt_gdk_event_get_scroll_delta_x(event);
+      acc_y += dt_gdk_event_get_scroll_delta_y(event);
 #endif
       const gdouble amt_x = trunc(acc_x);
       const gdouble amt_y = trunc(acc_y);
@@ -744,7 +745,7 @@ static gboolean _input_event(GtkWidget *widget,
 {
   (void)user_data;
 
-  switch(event->type)
+  switch(dt_gdk_event_get_type(event))
   {
     case GDK_TOUCHPAD_PINCH:
     case GDK_TOUCHPAD_SWIPE:
@@ -753,7 +754,7 @@ static gboolean _input_event(GtkWidget *widget,
       {
         dt_print(DT_DEBUG_INPUT,
                  "[touchpad] gesture event type=%d source='%s' source_type=%d",
-                 event->type,
+                 dt_gdk_event_get_type(event),
                  gdk_device_get_name(_touchpad),
                  gdk_device_get_source(_touchpad));
       }
@@ -761,14 +762,14 @@ static gboolean _input_event(GtkWidget *widget,
       {
         dt_print(DT_DEBUG_INPUT,
                  "[touchpad] gesture event type=%d without source device",
-                 event->type);
+                 dt_gdk_event_get_type(event));
       }
       break;
     default:
       break;
   }
 
-  if(event->type == GDK_TOUCHPAD_PINCH && darktable.gui->touchpad_gestures_enabled)
+  if(dt_gdk_event_get_type(event) == GDK_TOUCHPAD_PINCH && darktable.gui->touchpad_gestures_enabled)
   {
     const GdkEventTouchpadPinch *pinch = &event->touchpad_pinch;
     dt_print(DT_DEBUG_INPUT,
@@ -785,7 +786,7 @@ static gboolean _input_event(GtkWidget *widget,
     dt_print(DT_DEBUG_INPUT,
              "[touchpad] pinch ignored by current view");
   }
-  else if(event->type == GDK_TOUCHPAD_PINCH)
+  else if(dt_gdk_event_get_type(event) == GDK_TOUCHPAD_PINCH)
   {
     dt_print(DT_DEBUG_INPUT,
              "[touchpad] pinch received but disabled by preference darkroom/ui/touchpad_gestures");
@@ -801,23 +802,23 @@ static gboolean _scrolled(GtkWidget *widget,
   (void)user_data;
   GdkDevice *device = gdk_event_get_source_device((GdkEvent *)event);
   const gboolean touchpad_enabled = darktable.gui->touchpad_gestures_enabled;
-  const gboolean ctrl_pressed = dt_modifier_is(event->state, GDK_CONTROL_MASK);
+  const gboolean ctrl_pressed = dt_modifier_is(dt_gdk_event_get_state(event), GDK_CONTROL_MASK);
 
   dt_print(DT_DEBUG_INPUT,
            "[scroll] direction=%d smooth=%s stop=%s ctrl=%s"
            " x=%.1f y=%.1f dx=%.3f dy=%.3f state=0x%x"
            " device='%s' source-type=%d",
-           event->direction,
-           event->direction == GDK_SCROLL_SMOOTH ? "yes" : "no",
+           dt_gdk_event_get_scroll_direction(event),
+           dt_gdk_event_get_scroll_direction(event) == GDK_SCROLL_SMOOTH ? "yes" : "no",
            event->is_stop ? "yes" : "no",
            ctrl_pressed ? "yes" : "no",
-           event->x, event->y, event->delta_x, event->delta_y, event->state,
+           dt_gdk_event_get_x(event), dt_gdk_event_get_y(event), dt_gdk_event_get_scroll_delta_x(event), dt_gdk_event_get_scroll_delta_y(event), dt_gdk_event_get_state(event),
            device ? gdk_device_get_name(device) : "<none>",
            device ? (int)gdk_device_get_source(device) : -1);
   const gboolean is_touchpad_source = device && gdk_device_get_source(device) == GDK_SOURCE_TOUCHPAD;
   const gboolean matches_last_gesture_device = (device == _touchpad);
 
-  const gboolean is_smooth = event->direction == GDK_SCROLL_SMOOTH && !event->is_stop;
+  const gboolean is_smooth = dt_gdk_event_get_scroll_direction(event) == GDK_SCROLL_SMOOTH && !event->is_stop;
 #ifdef GDK_WINDOWING_QUARTZ
   // On macOS/Quartz, the built-in trackpad reports as GDK_SOURCE_MOUSE, not
   // GDK_SOURCE_TOUCHPAD.  Route every non-ctrl smooth scroll to gesture_pan so
@@ -846,12 +847,12 @@ static gboolean _scrolled(GtkWidget *widget,
     delta_x *= DT_UI_SCROLL_SMOOTH_DELTA_SCALE;
     delta_y *= DT_UI_SCROLL_SMOOTH_DELTA_SCALE;
     if((delta_x != 0.0 || delta_y != 0.0)
-       && dt_view_manager_gesture_pan(darktable.view_manager, event->x, event->y,
-                                      delta_x, delta_y, event->state & 0xf))
+       && dt_view_manager_gesture_pan(darktable.view_manager, dt_gdk_event_get_x(event), dt_gdk_event_get_y(event),
+                                      delta_x, delta_y, dt_gdk_event_get_state(event) & 0xf))
     {
       dt_print(DT_DEBUG_INPUT,
                "[touchpad] pan x=%.2f y=%.2f dx=%.3f dy=%.3f source='%s'",
-               event->x, event->y, delta_x, delta_y,
+               dt_gdk_event_get_x(event), dt_gdk_event_get_y(event), delta_x, delta_y,
                device ? gdk_device_get_name(device) : "<none>");
       gtk_widget_queue_draw(widget);
       return TRUE;
@@ -882,12 +883,12 @@ static gboolean _scrolled(GtkWidget *widget,
   {
     dt_print(DT_DEBUG_INPUT,
              "[scroll] discrete fallback x=%.2f y=%.2f up=%d state=0x%x source='%s' source_type=%d",
-             event->x, event->y, delta_y < 0, event->state,
+             dt_gdk_event_get_x(event), dt_gdk_event_get_y(event), delta_y < 0, dt_gdk_event_get_state(event),
              device ? gdk_device_get_name(device) : "<none>",
              device ? gdk_device_get_source(device) : -1);
-    dt_view_manager_scrolled(darktable.view_manager, event->x, event->y,
+    dt_view_manager_scrolled(darktable.view_manager, dt_gdk_event_get_x(event), dt_gdk_event_get_y(event),
                              delta_y < 0,
-                             event->state & 0xf);
+                             dt_gdk_event_get_state(event) & 0xf);
     gtk_widget_queue_draw(widget);
   }
 
@@ -1220,19 +1221,19 @@ static gboolean _window_configure(GtkWidget *da,
 
 guint dt_gui_translated_key_state(const GdkEventKey *event)
 {
-  if(gdk_keyval_to_lower(event->keyval) == gdk_keyval_to_upper(event->keyval) )
+  if(gdk_keyval_to_lower(dt_gdk_event_get_keyval(event)) == gdk_keyval_to_upper(dt_gdk_event_get_keyval(event)) )
   {
     //not an alphabetic character
     //find any modifiers consumed to produce keyval
     guint consumed;
     gdk_keymap_translate_keyboard_state
       (gdk_keymap_get_for_display(gdk_display_get_default()),
-       event->hardware_keycode, event->state, event->group,
+       dt_gdk_event_get_keycode(event), dt_gdk_event_get_state(event), event->group,
        NULL, NULL, NULL, &consumed);
-    return event->state & ~consumed & gtk_accelerator_get_default_mod_mask();
+    return dt_gdk_event_get_state(event) & ~consumed & gtk_accelerator_get_default_mod_mask();
   }
   else
-    return event->state & gtk_accelerator_get_default_mod_mask();
+    return dt_gdk_event_get_state(event) & gtk_accelerator_get_default_mod_mask();
 }
 
 static gboolean _button_pressed(GtkWidget *w,
@@ -1246,8 +1247,8 @@ static gboolean _button_pressed(GtkWidget *w,
   {
     gdk_event_get_axis((GdkEvent *)event, GDK_AXIS_PRESSURE, &pressure);
   }
-  dt_control_button_pressed(event->x, event->y, pressure,
-                            event->button, event->type, event->state & 0xf);
+  dt_control_button_pressed(dt_gdk_event_get_x(event), dt_gdk_event_get_y(event), pressure,
+                            dt_gdk_event_get_button(event), dt_gdk_event_get_type(event), dt_gdk_event_get_state(event) & 0xf);
   gtk_widget_grab_focus(w);
   gtk_widget_queue_draw(w);
   return FALSE;
@@ -1257,7 +1258,7 @@ static gboolean _button_released(GtkWidget *w,
                                  const GdkEventButton *event,
                                  gpointer user_data)
 {
-  dt_control_button_released(event->x, event->y, event->button, event->state & 0xf);
+  dt_control_button_released(dt_gdk_event_get_x(event), dt_gdk_event_get_y(event), dt_gdk_event_get_button(event), dt_gdk_event_get_state(event) & 0xf);
   gtk_widget_queue_draw(w);
   return TRUE;
 }
@@ -1274,7 +1275,7 @@ static gboolean _mouse_moved(GtkWidget *w,
     gdk_event_get_axis((GdkEvent *)event, GDK_AXIS_PRESSURE, &pressure);
     gui->have_pen_pressure = pressure != 1.0;
   }
-  dt_control_mouse_moved(event->x, event->y, pressure, event->state & 0xf);
+  dt_control_mouse_moved(dt_gdk_event_get_x(event), dt_gdk_event_get_y(event), pressure, dt_gdk_event_get_state(event) & 0xf);
   return FALSE;
 }
 
@@ -2614,7 +2615,7 @@ static gboolean _ui_init_panel_container_center_scroll_event(GtkWidget *widget,
                                                              const GdkEventScroll *event)
 {
   // just make sure nothing happens unless ctrl-alt are pressed:
-  return (((event->state & gtk_accelerator_get_default_mod_mask())
+  return (((dt_gdk_event_get_state(event) & gtk_accelerator_get_default_mod_mask())
            != darktable.gui->sidebar_scroll_mask)
           != dt_conf_get_bool("darkroom/ui/sidebar_scroll_default"));
   // GTK4: return GDK_EVENT_PROPAGATE/GDK_EVENT_STOP
@@ -2712,7 +2713,7 @@ static gboolean _side_panel_press(GtkWidget *widget,
                                   const GdkEvent *event,
                                   gpointer user_data)
 {
-  if(event->button.button == GDK_BUTTON_SECONDARY)
+  if(dt_gdk_event_get_button(event) == GDK_BUTTON_SECONDARY)
     _add_remove_modules(NULL);
   return TRUE;
 }
@@ -3910,7 +3911,7 @@ static gboolean _notebook_motion_notify_callback(GtkNotebook *notebook,
     gtk_widget_get_allocation(gtk_notebook_get_tab_label
                               (notebook, gtk_notebook_get_nth_page(notebook, i)),
                               &label_alloc);
-    if(event->x + notebook_alloc.x < label_alloc.x + label_alloc.width)
+    if(dt_gdk_event_get_x(event) + notebook_alloc.x < label_alloc.x + label_alloc.width)
     {
       darktable.control->element = i;
       break;
@@ -4043,7 +4044,7 @@ static gboolean _notebook_button_press_callback(GtkNotebook *notebook,
                                                 const GdkEventButton *event,
                                                 gpointer user_data)
 {
-  if(event->type == GDK_2BUTTON_PRESS && gtk_get_event_widget((GdkEvent*)event) == GTK_WIDGET(notebook))
+  if(dt_gdk_event_get_type(event) == GDK_2BUTTON_PRESS && gtk_get_event_widget((GdkEvent*)event) == GTK_WIDGET(notebook))
     _reset_all_bauhaus(notebook, gtk_notebook_get_nth_page(notebook, gtk_notebook_get_current_page(notebook)));
 
   return FALSE;
@@ -4238,7 +4239,7 @@ static gboolean _resize_wrap_scroll(GtkScrolledWindow *sw,
 
   const gint increment = _get_container_row_heigth(w);
 
-  if(dt_modifier_is(event->state, GDK_SHIFT_MASK | GDK_MOD1_MASK))
+  if(dt_modifier_is(dt_gdk_event_get_state(event), GDK_SHIFT_MASK | GDK_MOD1_MASK))
   {
     const gint new_size = dt_conf_get_int(config_str) + increment*delta_y;
 
@@ -4270,7 +4271,7 @@ static gboolean _scroll_wrap_height(GtkWidget *w,
                                     const GdkEventScroll *event,
                                     const char *config_str)
 {
-  if(dt_modifier_is(event->state, GDK_SHIFT_MASK | GDK_MOD1_MASK))
+  if(dt_modifier_is(dt_gdk_event_get_state(event), GDK_SHIFT_MASK | GDK_MOD1_MASK))
   {
     int delta_y;
     if(dt_gui_get_scroll_unit_delta(event, &delta_y))
@@ -4321,7 +4322,7 @@ static gboolean _resize_wrap_motion(GtkWidget *widget,
   {
     // keeps resize box from shrinking when user clicks above very
     // bottom of handle
-    const int new_height = round(event->y + 0.5*DT_RESIZE_HANDLE_SIZE);
+    const int new_height = round(dt_gdk_event_get_y(event) + 0.5*DT_RESIZE_HANDLE_SIZE);
     if(DTGTK_IS_DRAWING_AREA(widget))
     {
       // enforce configuration limits
@@ -4338,11 +4339,11 @@ static gboolean _resize_wrap_motion(GtkWidget *widget,
   }
 
   const gboolean prior = _resize_wrap_handle_hover;
-  if(!(event->state & GDK_BUTTON1_MASK)
-     && event->window == gtk_widget_get_window(widget))
+  if(!(dt_gdk_event_get_state(event) & GDK_BUTTON1_MASK)
+     && dt_gdk_event_get_window(event) == gtk_widget_get_window(widget))
   {
     _resize_wrap_handle_hover =
-      event->y >= gtk_widget_get_allocated_height(widget) - DT_RESIZE_HANDLE_SIZE;
+      dt_gdk_event_get_y(event) >= gtk_widget_get_allocated_height(widget) - DT_RESIZE_HANDLE_SIZE;
     if(_resize_wrap_handle_hover != prior)
     {
       if(_resize_wrap_handle_hover)
@@ -4362,15 +4363,15 @@ static gboolean _resize_wrap_button(GtkWidget *widget,
                                     const char *config_str)
 {
   if(_resize_wrap_dragging
-     && event->type == GDK_BUTTON_RELEASE)
+     && dt_gdk_event_get_type(event) == GDK_BUTTON_RELEASE)
   {
     _resize_wrap_dragging = FALSE;
     dt_control_clear_temp_cursor();
     return TRUE;
   }
-  else if(event->y >= gtk_widget_get_allocated_height(widget) - DT_RESIZE_HANDLE_SIZE
-          && event->type == GDK_BUTTON_PRESS
-          && event->button == GDK_BUTTON_PRIMARY)
+  else if(dt_gdk_event_get_y(event) >= gtk_widget_get_allocated_height(widget) - DT_RESIZE_HANDLE_SIZE
+          && dt_gdk_event_get_type(event) == GDK_BUTTON_PRESS
+          && dt_gdk_event_get_button(event) == GDK_BUTTON_PRIMARY)
   {
     _resize_wrap_dragging = TRUE;
     return TRUE;
@@ -4384,13 +4385,13 @@ static gboolean _resize_wrap_enter_leave(GtkWidget *widget,
                                          const char *config_str)
 {
   _resize_wrap_hovered =
-    event->type == GDK_ENTER_NOTIFY
+    dt_gdk_event_get_type(event) == GDK_ENTER_NOTIFY
     || event->detail == GDK_NOTIFY_INFERIOR
     || _resize_wrap_dragging ? widget : NULL;
 
   // When leave handle and widget, remove temp resize cursor. When
   // enter widget, motion event will handle cursor change for handle.
-  if(event->type == GDK_LEAVE_NOTIFY
+  if(dt_gdk_event_get_type(event) == GDK_LEAVE_NOTIFY
      && !_resize_wrap_dragging
      && _resize_wrap_handle_hover)
   {
@@ -4850,7 +4851,7 @@ static void _scroll_proxy_real(GtkEventControllerScroll* controller,
      && !gdk_event_get_pointer_emulated(event)
      && !_scroll_sidebar(controller, dy, event))
   {
-    if(event->scroll.direction == GDK_SCROLL_SMOOTH)
+    if(dt_gdk_event_get_scroll_direction(event) == GDK_SCROLL_SMOOTH)
     {
       dx = _scroll_attenuate(dx);
       dy = _scroll_attenuate(dy);

--- a/src/gui/import_metadata.c
+++ b/src/gui/import_metadata.c
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "common/gdk_event_utils.h"
 
 #include "common/debug.h"
 #include "common/metadata.h"
@@ -70,7 +71,7 @@ static gboolean _import_metadata_reset(GtkWidget *label,
                                        GdkEventButton *event,
                                        GtkWidget *widget)
 {
-  if(event->type == GDK_2BUTTON_PRESS)
+  if(dt_gdk_event_get_type(event) == GDK_2BUTTON_PRESS)
   {
     gtk_entry_set_text(GTK_ENTRY(widget), "");
   }
@@ -108,7 +109,7 @@ static gboolean _import_metadata_reset_all(GtkWidget *label,
                                            GdkEventButton *event,
                                            dt_import_metadata_t *metadata)
 {
-  if(event->type == GDK_2BUTTON_PRESS)
+  if(dt_gdk_event_get_type(event) == GDK_2BUTTON_PRESS)
   {
     _metadata_reset_all(metadata, FALSE);
   }

--- a/src/gui/preferences.c
+++ b/src/gui/preferences.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2010-2025 darktable developers.
+    Copyright (C) 2010-2026 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "common/gdk_event_utils.h"
 
 #include <gdk/gdkkeysyms.h>
 #include <strings.h>
@@ -284,7 +285,7 @@ static gboolean reset_language_widget(GtkWidget *label,
                                       GdkEventButton *event,
                                       GtkWidget *widget)
 {
-  if(event->type == GDK_2BUTTON_PRESS)
+  if(dt_gdk_event_get_type(event) == GDK_2BUTTON_PRESS)
   {
     dt_bauhaus_combobox_set(widget, darktable.l10n->sys_default);
     return TRUE;
@@ -1163,7 +1164,7 @@ static gboolean tree_key_press_presets(GtkWidget *widget,
   // We can just ignore mod key presses outright
   if(event->is_modifier) return FALSE;
 
-  if(event->keyval == GDK_KEY_Delete || event->keyval == GDK_KEY_BackSpace)
+  if(dt_gdk_event_get_keyval(event) == GDK_KEY_Delete || dt_gdk_event_get_keyval(event) == GDK_KEY_BackSpace)
   {
     // If a leaf node is selected, delete that preset
 
@@ -1349,13 +1350,13 @@ _gui_preferences_bool_click(GtkWidget *label,
                             GdkEventButton *event,
                             GtkWidget *widget)
 {
-  if(event->type == GDK_BUTTON_PRESS)
+  if(dt_gdk_event_get_type(event) == GDK_BUTTON_PRESS)
   {
     const gboolean cur = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), !cur);
     return TRUE;
   }
-  if(event->type == GDK_2BUTTON_PRESS)
+  if(dt_gdk_event_get_type(event) == GDK_2BUTTON_PRESS)
   {
     dt_gui_preferences_bool_reset(widget);
     return TRUE;
@@ -1414,7 +1415,7 @@ _gui_preferences_int_reset(GtkWidget *label,
                            GdkEventButton *event,
                            GtkWidget *widget)
 {
-  if(event->type == GDK_2BUTTON_PRESS)
+  if(dt_gdk_event_get_type(event) == GDK_2BUTTON_PRESS)
   {
     dt_gui_preferences_int_reset(widget);
     return TRUE;
@@ -1525,7 +1526,7 @@ _gui_preferences_string_reset(GtkWidget *label,
                               GdkEventButton *event,
                               GtkWidget *widget)
 {
-  if(event->type == GDK_2BUTTON_PRESS)
+  if(dt_gdk_event_get_type(event) == GDK_2BUTTON_PRESS)
   {
     dt_gui_preferences_string_reset(widget);
     return TRUE;

--- a/src/gui/preferences_ai.c
+++ b/src/gui/preferences_ai.c
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "common/gdk_event_utils.h"
 
 #include "gui/preferences_ai.h"
 #include "bauhaus/bauhaus.h"
@@ -612,7 +613,7 @@ static void _on_provider_changed(GtkWidget *widget, gpointer user_data)
 static gboolean
 _reset_enable_click(GtkWidget *label, GdkEventButton *event, GtkWidget *widget)
 {
-  if(event->type == GDK_2BUTTON_PRESS)
+  if(dt_gdk_event_get_type(event) == GDK_2BUTTON_PRESS)
   {
     const gboolean def = dt_confgen_get_bool("plugins/ai/enabled", DT_DEFAULT);
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), def);
@@ -625,7 +626,7 @@ _reset_enable_click(GtkWidget *label, GdkEventButton *event, GtkWidget *widget)
 static gboolean
 _reset_provider_click(GtkWidget *label, GdkEventButton *event, gpointer user_data)
 {
-  if(event->type == GDK_2BUTTON_PRESS)
+  if(dt_gdk_event_get_type(event) == GDK_2BUTTON_PRESS)
   {
     dt_prefs_ai_data_t *data = (dt_prefs_ai_data_t *)user_data;
     const char *def = dt_confgen_get(DT_AI_CONF_PROVIDER, DT_DEFAULT);
@@ -1267,15 +1268,15 @@ static gboolean _on_tree_motion(GtkWidget *widget,
   GdkWindow *bin = gtk_tree_view_get_bin_window(tv);
   if(!bin) return FALSE;
   gint bx, by;
-  if(event->window == bin)
+  if(dt_gdk_event_get_window(event) == bin)
   {
-    bx = (gint)event->x;
-    by = (gint)event->y;
+    bx = (gint)dt_gdk_event_get_x(event);
+    by = (gint)dt_gdk_event_get_y(event);
   }
   else
   {
     gtk_tree_view_convert_widget_to_bin_window_coords(
-      tv, (gint)event->x, (gint)event->y, &bx, &by);
+      tv, (gint)dt_gdk_event_get_x(event), (gint)dt_gdk_event_get_y(event), &bx, &by);
   }
   if(_info_active_at_bin(user_data, tv, bx, by))
   {
@@ -1295,8 +1296,8 @@ static gboolean _on_info_button_press(GtkWidget *widget,
                                       GdkEventButton *event,
                                       gpointer user_data)
 {
-  if(event->type != GDK_BUTTON_PRESS
-     || event->button != 1)
+  if(dt_gdk_event_get_type(event) != GDK_BUTTON_PRESS
+     || dt_gdk_event_get_button(event) != 1)
     return FALSE;
 
   dt_prefs_ai_data_t *data = (dt_prefs_ai_data_t *)user_data;
@@ -1304,7 +1305,7 @@ static gboolean _on_info_button_press(GtkWidget *widget,
   GtkTreePath *path = NULL;
   GtkTreeViewColumn *column = NULL;
 
-  if(!gtk_tree_view_get_path_at_pos(tv, (gint)event->x, (gint)event->y,
+  if(!gtk_tree_view_get_path_at_pos(tv, (gint)dt_gdk_event_get_x(event), (gint)dt_gdk_event_get_y(event),
                                     &path, &column, NULL, NULL))
     return FALSE;
 

--- a/src/gui/presets.c
+++ b/src/gui/presets.c
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "common/gdk_event_utils.h"
 
 #include "bauhaus/bauhaus.h"
 #include "common/darktable.h"
@@ -1274,13 +1275,13 @@ static gboolean _menuitem_button_preset(GtkMenuItem *menuitem,
                                         GdkEventButton *event,
                                         dt_iop_module_t *module)
 {
-  gboolean long_click = dt_gui_long_click(event->time, _click_time);
+  gboolean long_click = dt_gui_long_click(dt_gdk_event_get_time(event), _click_time);
 
   gchar *name = g_object_get_data(G_OBJECT(menuitem), "dt-preset-name");
 
-  if(event->button == GDK_BUTTON_PRIMARY)
+  if(dt_gdk_event_get_button(event) == GDK_BUTTON_PRIMARY)
   {
-    if(_click_time > event->time)
+    if(_click_time > dt_gdk_event_get_time(event))
     {
       if(_active_menu_item)
         gtk_check_menu_item_set_active(_active_menu_item, FALSE);
@@ -1290,8 +1291,8 @@ static gboolean _menuitem_button_preset(GtkMenuItem *menuitem,
       dt_gui_presets_apply_preset(name, module);
     }
   }
-  else if(event->button == GDK_BUTTON_SECONDARY
-          && event->type == GDK_BUTTON_RELEASE
+  else if(dt_gdk_event_get_button(event) == GDK_BUTTON_SECONDARY
+          && dt_gdk_event_get_type(event) == GDK_BUTTON_RELEASE
           && _click_time)
   {
     if(long_click || (module->flags() & IOP_FLAGS_ONE_INSTANCE))
@@ -1313,7 +1314,7 @@ static gboolean _menuitem_button_preset(GtkMenuItem *menuitem,
     dt_iop_connect_accels_multi(module->so);
   }
 
-  _click_time = event->type == GDK_BUTTON_PRESS ? event->time : G_MAXUINT;
+  _click_time = dt_gdk_event_get_type(event) == GDK_BUTTON_PRESS ? dt_gdk_event_get_time(event) : G_MAXUINT;
   return long_click; // keep menu open on long click
 }
 
@@ -1322,7 +1323,7 @@ static void _menuitem_activate_preset(GtkMenuItem *menuitem,
                                       dt_iop_module_t *module)
 {
   GdkEvent *event = gtk_get_current_event();
-  if(event->type == GDK_KEY_PRESS)
+  if(dt_gdk_event_get_type(event) == GDK_KEY_PRESS)
     dt_gui_presets_apply_preset(g_object_get_data(G_OBJECT(menuitem),
                                                   "dt-preset-name"), module);
   gdk_event_free(event);

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -15,6 +15,7 @@
   You should have received a copy of the GNU General Public License
   along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "common/gdk_event_utils.h"
 
 #include "bauhaus/bauhaus.h"
 #include "common/bilateral.h"
@@ -5323,13 +5324,13 @@ static int _event_fit_v_button_clicked(GtkWidget *widget,
 {
   DT_GUARD_GUI_UPDATE(FALSE);
 
-  if(event->button == GDK_BUTTON_PRIMARY)
+  if(dt_gdk_event_get_button(event) == GDK_BUTTON_PRIMARY)
   {
     dt_iop_ashift_params_t *p = self->params;
     dt_iop_ashift_gui_data_t *g = self->gui_data;
 
-    const int control = dt_modifiers_include(event->state, GDK_CONTROL_MASK);
-    const int shift = dt_modifiers_include(event->state, GDK_SHIFT_MASK);
+    const int control = dt_modifiers_include(dt_gdk_event_get_state(event), GDK_CONTROL_MASK);
+    const int shift = dt_modifiers_include(dt_gdk_event_get_state(event), GDK_SHIFT_MASK);
 
     dt_iop_ashift_fitaxis_t fitaxis = ASHIFT_FIT_NONE;
 
@@ -5371,13 +5372,13 @@ static int _event_fit_h_button_clicked(GtkWidget *widget,
 {
   DT_GUARD_GUI_UPDATE(FALSE);
 
-  if(event->button == GDK_BUTTON_PRIMARY)
+  if(dt_gdk_event_get_button(event) == GDK_BUTTON_PRIMARY)
   {
     dt_iop_ashift_params_t *p = self->params;
     dt_iop_ashift_gui_data_t *g = self->gui_data;
 
-    const int control = dt_modifiers_include(event->state, GDK_CONTROL_MASK);
-    const int shift = dt_modifiers_include(event->state, GDK_SHIFT_MASK);
+    const int control = dt_modifiers_include(dt_gdk_event_get_state(event), GDK_CONTROL_MASK);
+    const int shift = dt_modifiers_include(dt_gdk_event_get_state(event), GDK_SHIFT_MASK);
 
     dt_iop_ashift_fitaxis_t fitaxis = ASHIFT_FIT_NONE;
 
@@ -5419,13 +5420,13 @@ static int _event_fit_both_button_clicked(GtkWidget *widget,
 {
   DT_GUARD_GUI_UPDATE(FALSE);
 
-  if(event->button == GDK_BUTTON_PRIMARY)
+  if(dt_gdk_event_get_button(event) == GDK_BUTTON_PRIMARY)
   {
     dt_iop_ashift_params_t *p = self->params;
     dt_iop_ashift_gui_data_t *g = self->gui_data;
 
-    const int control = dt_modifiers_include(event->state, GDK_CONTROL_MASK);
-    const int shift = dt_modifiers_include(event->state, GDK_SHIFT_MASK);
+    const int control = dt_modifiers_include(dt_gdk_event_get_state(event), GDK_CONTROL_MASK);
+    const int shift = dt_modifiers_include(dt_gdk_event_get_state(event), GDK_SHIFT_MASK);
 
     dt_iop_ashift_fitaxis_t fitaxis = ASHIFT_FIT_NONE;
 
@@ -5469,15 +5470,15 @@ static int _event_structure_auto_clicked(GtkWidget *widget,
 {
   DT_GUARD_GUI_UPDATE(FALSE);
 
-  if(event->button == GDK_BUTTON_PRIMARY)
+  if(dt_gdk_event_get_button(event) == GDK_BUTTON_PRIMARY)
   {
     dt_iop_ashift_params_t *p = self->params;
     dt_iop_ashift_gui_data_t *g = self->gui_data;
 
     _do_clean_structure(self, p, TRUE);
 
-    const int control = dt_modifiers_include(event->state, GDK_CONTROL_MASK);
-    const int shift = dt_modifiers_include(event->state, GDK_SHIFT_MASK);
+    const int control = dt_modifiers_include(dt_gdk_event_get_state(event), GDK_CONTROL_MASK);
+    const int shift = dt_modifiers_include(dt_gdk_event_get_state(event), GDK_SHIFT_MASK);
 
     dt_iop_ashift_enhance_t enhance;
 

--- a/src/iop/atrous.c
+++ b/src/iop/atrous.c
@@ -14,6 +14,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "common/gdk_event_utils.h"
 
 #include "bauhaus/bauhaus.h"
 #include "common/debug.h"
@@ -1029,7 +1030,7 @@ static gboolean area_enter_leave_notify(GtkWidget *widget,
                                         dt_iop_module_t *self)
 {
   dt_iop_atrous_gui_data_t *g = self->gui_data;
-  g->in_curve = event->type == GDK_ENTER_NOTIFY;
+  g->in_curve = dt_gdk_event_get_type(event) == GDK_ENTER_NOTIFY;
   if(!g->dragging)
     g->x_move = -1;
 
@@ -1382,8 +1383,8 @@ static gboolean area_motion_notify(GtkWidget *widget,
   gtk_widget_get_allocation(widget, &allocation);
   const int height = allocation.height - 2 * inset - DT_RESIZE_HANDLE_SIZE;
   const int width = allocation.width - 2 * inset;
-  if(!g->dragging) g->mouse_x = CLAMP(event->x - inset, 0, width) / (float)width;
-  g->mouse_y = 1.0 - CLAMP(event->y - inset, 0, height) / (float)height;
+  if(!g->dragging) g->mouse_x = CLAMP(dt_gdk_event_get_x(event) - inset, 0, width) / (float)width;
+  g->mouse_y = 1.0 - CLAMP(dt_gdk_event_get_y(event) - inset, 0, height) / (float)height;
 
   darktable.control->element = 0;
 
@@ -1397,7 +1398,7 @@ static gboolean area_motion_notify(GtkWidget *widget,
     *p = g->drag_params;
     if(g->x_move >= 0)
     {
-      const float mx = CLAMP(event->x - inset, 0, width) / (float)width;
+      const float mx = CLAMP(dt_gdk_event_get_x(event) - inset, 0, width) / (float)width;
       if(g->x_move > 0 && g->x_move < BANDS - 1)
       {
         const float minx = p->x[g->channel][g->x_move - 1] + 0.001f;
@@ -1412,7 +1413,7 @@ static gboolean area_motion_notify(GtkWidget *widget,
     gtk_widget_queue_draw(widget);
     dt_dev_add_history_item_target(darktable.develop, self, TRUE, widget + g->channel);
   }
-  else if(event->y > height)
+  else if(dt_gdk_event_get_y(event) > height)
   {
     // move x-positions
     g->x_move = 0;
@@ -1458,7 +1459,7 @@ static gboolean area_button_press(GtkWidget *widget,
                                   GdkEventButton *event,
                                   dt_iop_module_t *self)
 {
-  if(event->button == GDK_BUTTON_PRIMARY && event->type == GDK_2BUTTON_PRESS)
+  if(dt_gdk_event_get_button(event) == GDK_BUTTON_PRIMARY && dt_gdk_event_get_type(event) == GDK_2BUTTON_PRESS)
   {
     // reset current curve
     dt_iop_atrous_params_t *p = self->params;
@@ -1472,7 +1473,7 @@ static gboolean area_button_press(GtkWidget *widget,
     }
     dt_dev_add_history_item_target(darktable.develop, self, TRUE, widget + g->channel2);
   }
-  else if(event->button == GDK_BUTTON_PRIMARY)
+  else if(dt_gdk_event_get_button(event) == GDK_BUTTON_PRIMARY)
   {
     // set active point
     dt_iop_atrous_gui_data_t *g = self->gui_data;
@@ -1484,8 +1485,8 @@ static gboolean area_button_press(GtkWidget *widget,
     const int width = allocation.width - 2 * inset;
     g->mouse_pick
         = dt_draw_curve_calc_value(g->minmax_curve,
-                                   CLAMP(event->x - inset, 0, width) / (float)width);
-    g->mouse_pick -= 1.0 - CLAMP(event->y - inset, 0, height) / (float)height;
+                                   CLAMP(dt_gdk_event_get_x(event) - inset, 0, width) / (float)width);
+    g->mouse_pick -= 1.0 - CLAMP(dt_gdk_event_get_y(event) - inset, 0, height) / (float)height;
     g->dragging = 1;
     return TRUE;
   }
@@ -1496,7 +1497,7 @@ static gboolean area_button_release(GtkWidget *widget,
                                     GdkEventButton *event,
                                     dt_iop_module_t *self)
 {
-  if(event->button == GDK_BUTTON_PRIMARY)
+  if(dt_gdk_event_get_button(event) == GDK_BUTTON_PRIMARY)
   {
     dt_iop_atrous_gui_data_t *g = self->gui_data;
     g->dragging = 0;
@@ -1514,7 +1515,7 @@ static gboolean area_scrolled(GtkWidget *widget,
 
   if(dt_gui_ignore_scroll(event)) return FALSE;
 
-  if(dt_modifier_is(event->state, GDK_MOD1_MASK))
+  if(dt_modifier_is(dt_gdk_event_get_state(event), GDK_MOD1_MASK))
     return gtk_widget_event(GTK_WIDGET(g->channel_tabs), (GdkEvent*)event);
 
   int delta_y;

--- a/src/iop/basecurve.c
+++ b/src/iop/basecurve.c
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "common/gdk_event_utils.h"
 
 #include "bauhaus/bauhaus.h"
 #include "common/colorspaces_inline_conversions.h"
@@ -1534,7 +1535,7 @@ static gboolean dt_iop_basecurve_leave_notify(GtkWidget *widget,
                                               dt_iop_module_t *self)
 {
   dt_iop_basecurve_gui_data_t *g = self->gui_data;
-  if(!(event->state & GDK_BUTTON1_MASK))
+  if(!(dt_gdk_event_get_state(event) & GDK_BUTTON1_MASK))
     g->selected = -1;
   gtk_widget_queue_draw(widget);
   return FALSE;
@@ -1790,14 +1791,14 @@ static gboolean dt_iop_basecurve_motion_notify(GtkWidget *widget,
   int height = allocation.height - 2 * inset, width = allocation.width - 2 * inset;
   const double old_m_x = g->mouse_x;
   const double old_m_y = g->mouse_y;
-  g->mouse_x = event->x - inset;
-  g->mouse_y = event->y - inset;
+  g->mouse_x = dt_gdk_event_get_x(event) - inset;
+  g->mouse_y = dt_gdk_event_get_y(event) - inset;
 
   const float mx = CLAMP(g->mouse_x, 0, width) / (float)width;
   const float my = 1.0f - CLAMP(g->mouse_y, 0, height) / (float)height;
   const float linx = to_lin(mx, g->loglogscale), liny = to_lin(my, g->loglogscale);
 
-  if(event->state & GDK_BUTTON1_MASK)
+  if(dt_gdk_event_get_state(event) & GDK_BUTTON1_MASK)
   {
     // got a vertex selected:
     if(g->selected >= 0)
@@ -1811,7 +1812,7 @@ static gboolean dt_iop_basecurve_motion_notify(GtkWidget *widget,
       const float dy = to_lin(1 - g->mouse_y / height - translate_mouse_y, g->loglogscale)
                        - to_lin(1 - old_m_y / height - translate_mouse_y, g->loglogscale);
 
-      return _move_point_internal(self, widget, dx, dy, event->state);
+      return _move_point_internal(self, widget, dx, dy, dt_gdk_event_get_state(event));
     }
     else if(nodes < MAXNODES && g->selected >= -1)
     {
@@ -1856,9 +1857,9 @@ static gboolean dt_iop_basecurve_button_press(GtkWidget *widget,
   int nodes = p->basecurve_nodes[ch];
   dt_iop_basecurve_node_t *basecurve = p->basecurve[ch];
 
-  if(event->button == GDK_BUTTON_PRIMARY)
+  if(dt_gdk_event_get_button(event) == GDK_BUTTON_PRIMARY)
   {
-    if(event->type == GDK_BUTTON_PRESS && dt_modifier_is(event->state, GDK_CONTROL_MASK)
+    if(dt_gdk_event_get_type(event) == GDK_BUTTON_PRESS && dt_modifier_is(dt_gdk_event_get_state(event), GDK_CONTROL_MASK)
       && nodes < MAXNODES && g->selected == -1)
     {
       // if we are not on a node -> add a new node at the current x of the pointer and y of the curve at that x
@@ -1866,8 +1867,8 @@ static gboolean dt_iop_basecurve_button_press(GtkWidget *widget,
       GtkAllocation allocation;
       gtk_widget_get_allocation(widget, &allocation);
       int width = allocation.width - 2 * inset;
-      g->mouse_x = event->x - inset;
-      g->mouse_y = event->y - inset;
+      g->mouse_x = dt_gdk_event_get_x(event) - inset;
+      g->mouse_y = dt_gdk_event_get_y(event) - inset;
 
       const float mx = CLAMP(g->mouse_x, 0, width) / (float)width;
       const float linx = to_lin(mx, g->loglogscale);
@@ -1917,7 +1918,7 @@ static gboolean dt_iop_basecurve_button_press(GtkWidget *widget,
       }
       return TRUE;
     }
-    else if(event->type == GDK_2BUTTON_PRESS)
+    else if(dt_gdk_event_get_type(event) == GDK_2BUTTON_PRESS)
     {
       // reset current curve
       p->basecurve_nodes[ch] = d->basecurve_nodes[ch];
@@ -1933,7 +1934,7 @@ static gboolean dt_iop_basecurve_button_press(GtkWidget *widget,
       return TRUE;
     }
   }
-  else if(event->button == GDK_BUTTON_SECONDARY && g->selected >= 0)
+  else if(dt_gdk_event_get_button(event) == GDK_BUTTON_SECONDARY && g->selected >= 0)
   {
     if(g->selected == 0 || g->selected == nodes - 1)
     {
@@ -1999,7 +2000,7 @@ static gboolean _scrolled(GtkWidget *widget, GdkEventScroll *event, dt_iop_modul
   if(dt_gui_get_scroll_delta(event, &delta_y))
   {
     delta_y *= -BASECURVE_DEFAULT_STEP;
-    return _move_point_internal(self, widget, 0.0, delta_y, event->state);
+    return _move_point_internal(self, widget, 0.0, delta_y, dt_gdk_event_get_state(event));
   }
 
   return TRUE;
@@ -2015,22 +2016,22 @@ static gboolean dt_iop_basecurve_key_press(GtkWidget *widget,
 
   int handled = 0;
   float dx = 0.0f, dy = 0.0f;
-  if(event->keyval == GDK_KEY_Up || event->keyval == GDK_KEY_KP_Up)
+  if(dt_gdk_event_get_keyval(event) == GDK_KEY_Up || dt_gdk_event_get_keyval(event) == GDK_KEY_KP_Up)
   {
     handled = 1;
     dy = BASECURVE_DEFAULT_STEP;
   }
-  else if(event->keyval == GDK_KEY_Down || event->keyval == GDK_KEY_KP_Down)
+  else if(dt_gdk_event_get_keyval(event) == GDK_KEY_Down || dt_gdk_event_get_keyval(event) == GDK_KEY_KP_Down)
   {
     handled = 1;
     dy = -BASECURVE_DEFAULT_STEP;
   }
-  else if(event->keyval == GDK_KEY_Right || event->keyval == GDK_KEY_KP_Right)
+  else if(dt_gdk_event_get_keyval(event) == GDK_KEY_Right || dt_gdk_event_get_keyval(event) == GDK_KEY_KP_Right)
   {
     handled = 1;
     dx = BASECURVE_DEFAULT_STEP;
   }
-  else if(event->keyval == GDK_KEY_Left || event->keyval == GDK_KEY_KP_Left)
+  else if(dt_gdk_event_get_keyval(event) == GDK_KEY_Left || dt_gdk_event_get_keyval(event) == GDK_KEY_KP_Left)
   {
     handled = 1;
     dx = -BASECURVE_DEFAULT_STEP;
@@ -2038,7 +2039,7 @@ static gboolean dt_iop_basecurve_key_press(GtkWidget *widget,
 
   if(!handled) return FALSE;
 
-  return _move_point_internal(self, widget, dx, dy, event->state);
+  return _move_point_internal(self, widget, dx, dy, dt_gdk_event_get_state(event));
 }
 
 #undef BASECURVE_DEFAULT_STEP

--- a/src/iop/colorchecker.c
+++ b/src/iop/colorchecker.c
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "common/gdk_event_utils.h"
 
 #include "bauhaus/bauhaus.h"
 #include "common/colorspaces_inline_conversions.h"
@@ -1393,8 +1394,8 @@ static gboolean checker_motion_notify(
   const int width = allocation.width;
   const int height = allocation.height;
 
-  const float mouse_x = CLAMP(event->x, 0, width);
-  const float mouse_y = CLAMP(event->y, 0, height);
+  const float mouse_x = CLAMP(dt_gdk_event_get_x(event), 0, width);
+  const float mouse_y = CLAMP(dt_gdk_event_get_y(event), 0, height);
   int cells_x = 6, cells_y = 4;
   if(p->num_patches > 24)
   {
@@ -1428,8 +1429,8 @@ static gboolean checker_button_press(
   GtkAllocation allocation;
   gtk_widget_get_allocation(widget, &allocation);
   int width = allocation.width, height = allocation.height;
-  const float mouse_x = CLAMP(event->x, 0, width);
-  const float mouse_y = CLAMP(event->y, 0, height);
+  const float mouse_x = CLAMP(dt_gdk_event_get_x(event), 0, width);
+  const float mouse_y = CLAMP(dt_gdk_event_get_y(event), 0, height);
   int cells_x = 6, cells_y = 4;
   if(p->num_patches > 24)
   {
@@ -1439,7 +1440,7 @@ static gboolean checker_button_press(
   const float mx = mouse_x * cells_x / (float)width;
   const float my = mouse_y * cells_y / (float)height;
   int patch = (int)mx + cells_x*(int)my;
-  if(event->button == GDK_BUTTON_PRIMARY && event->type == GDK_2BUTTON_PRESS)
+  if(dt_gdk_event_get_button(event) == GDK_BUTTON_PRIMARY && dt_gdk_event_get_type(event) == GDK_2BUTTON_PRESS)
   { // reset on double click
     if(patch < 0 || patch >= p->num_patches) return FALSE;
     p->target_L[patch] = p->source_L[patch];
@@ -1452,7 +1453,7 @@ static gboolean checker_button_press(
     gtk_widget_queue_draw(g->area);
     return TRUE;
   }
-  else if(event->button == GDK_BUTTON_SECONDARY && (patch < p->num_patches))
+  else if(dt_gdk_event_get_button(event) == GDK_BUTTON_SECONDARY && (patch < p->num_patches))
   {
     // right click: delete patch, move others up
     if(patch < 0 || patch >= p->num_patches) return FALSE;
@@ -1477,8 +1478,8 @@ static gboolean checker_button_press(
     gtk_widget_queue_draw(g->area);
     return TRUE;
   }
-  else if((event->button == GDK_BUTTON_PRIMARY) &&
-          dt_modifier_is(event->state, GDK_SHIFT_MASK) &&
+  else if((dt_gdk_event_get_button(event) == GDK_BUTTON_PRIMARY) &&
+          dt_modifier_is(dt_gdk_event_get_state(event), GDK_SHIFT_MASK) &&
           (self->request_color_pick == DT_REQUEST_COLORPICK_MODULE))
   {
     // shift-left while colour picking: replace source colour

--- a/src/iop/colorcorrection.c
+++ b/src/iop/colorcorrection.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2009-2023 darktable developers.
+    Copyright (C) 2009-2026 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "common/gdk_event_utils.h"
 #include "bauhaus/bauhaus.h"
 #include "common/colorspaces.h"
 #include "common/opencl.h"
@@ -355,11 +356,11 @@ static gboolean dt_iop_colorcorrection_motion_notify(GtkWidget *widget, GdkEvent
   GtkAllocation allocation;
   gtk_widget_get_allocation(widget, &allocation);
   int width = allocation.width - 2 * inset, height = allocation.height - 2 * inset;
-  const float mouse_x = CLAMP(event->x - inset, 0, width);
-  const float mouse_y = CLAMP(height - 1 - event->y + inset, 0, height);
+  const float mouse_x = CLAMP(dt_gdk_event_get_x(event) - inset, 0, width);
+  const float mouse_y = CLAMP(height - 1 - dt_gdk_event_get_y(event) + inset, 0, height);
   const float ma = (2.0 * mouse_x - width) * DT_COLORCORRECTION_MAX / (float)width;
   const float mb = (2.0 * mouse_y - height) * DT_COLORCORRECTION_MAX / (float)height;
-  if(event->state & GDK_BUTTON1_MASK)
+  if(dt_gdk_event_get_state(event) & GDK_BUTTON1_MASK)
   {
     if(g->selected == 1)
     {
@@ -393,7 +394,7 @@ static gboolean dt_iop_colorcorrection_motion_notify(GtkWidget *widget, GdkEvent
 static gboolean dt_iop_colorcorrection_button_press(GtkWidget *widget, GdkEventButton *event,
                                                     dt_iop_module_t *self)
 {
-  if(event->button == GDK_BUTTON_PRIMARY && event->type == GDK_2BUTTON_PRESS)
+  if(dt_gdk_event_get_button(event) == GDK_BUTTON_PRIMARY && dt_gdk_event_get_type(event) == GDK_2BUTTON_PRESS)
   {
     // double click resets:
     dt_iop_colorcorrection_gui_data_t *g = self->gui_data;
@@ -456,22 +457,22 @@ static gboolean dt_iop_colorcorrection_key_press(GtkWidget *widget, GdkEventKey 
 
   int handled = 0;
   float dx = 0.0f, dy = 0.0f;
-  if(event->keyval == GDK_KEY_Up || event->keyval == GDK_KEY_KP_Up)
+  if(dt_gdk_event_get_keyval(event) == GDK_KEY_Up || dt_gdk_event_get_keyval(event) == GDK_KEY_KP_Up)
   {
     handled = 1;
     dy = COLORCORRECTION_DEFAULT_STEP;
   }
-  else if(event->keyval == GDK_KEY_Down || event->keyval == GDK_KEY_KP_Down)
+  else if(dt_gdk_event_get_keyval(event) == GDK_KEY_Down || dt_gdk_event_get_keyval(event) == GDK_KEY_KP_Down)
   {
     handled = 1;
     dy = -COLORCORRECTION_DEFAULT_STEP;
   }
-  else if(event->keyval == GDK_KEY_Right || event->keyval == GDK_KEY_KP_Right)
+  else if(dt_gdk_event_get_keyval(event) == GDK_KEY_Right || dt_gdk_event_get_keyval(event) == GDK_KEY_KP_Right)
   {
     handled = 1;
     dx = COLORCORRECTION_DEFAULT_STEP;
   }
-  else if(event->keyval == GDK_KEY_Left || event->keyval == GDK_KEY_KP_Left)
+  else if(dt_gdk_event_get_keyval(event) == GDK_KEY_Left || dt_gdk_event_get_keyval(event) == GDK_KEY_KP_Left)
   {
     handled = 1;
     dx = -COLORCORRECTION_DEFAULT_STEP;
@@ -479,7 +480,7 @@ static gboolean dt_iop_colorcorrection_key_press(GtkWidget *widget, GdkEventKey 
 
   if(!handled) return FALSE;
 
-  float multiplier = dt_accel_get_speed_multiplier(widget, event->state);
+  float multiplier = dt_accel_get_speed_multiplier(widget, dt_gdk_event_get_state(event));
   dx *= multiplier;
   dy *= multiplier;
 

--- a/src/iop/colorequal.c
+++ b/src/iop/colorequal.c
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "common/gdk_event_utils.h"
 
 /* Midi mapping is supported, here is the reference for loupedeck+
 midi:D7=iop/colorequal/page;hue
@@ -2702,7 +2703,7 @@ static gboolean _area_scrolled_callback(GtkWidget *widget,
 {
   const dt_iop_colorequal_gui_data_t *g = self->gui_data;
 
-  GtkWidget *w = dt_modifier_is(event->state, GDK_MOD1_MASK)
+  GtkWidget *w = dt_modifier_is(dt_gdk_event_get_state(event), GDK_MOD1_MASK)
                ? GTK_WIDGET(g->notebook)
                : _get_slider(g, g->selected);
   return gtk_widget_event(w, (GdkEvent*)event);
@@ -2715,16 +2716,16 @@ static gboolean _area_motion_notify_callback(GtkWidget *widget,
   dt_iop_colorequal_gui_data_t *g = self->gui_data;
 
   if(g->dragging && g->on_node)
-    _area_set_pos(g, event->y);
+    _area_set_pos(g, dt_gdk_event_get_y(event));
   else
   {
     // look if close to a node
     const float epsilon = DT_PIXEL_APPLY_DPI(10.0);
     const int oldsel = g->selected;
     const int oldon = g->on_node;
-    g->selected = (int)(((float)event->x - g->points[0][0])
+    g->selected = (int)(((float)dt_gdk_event_get_x(event) - g->points[0][0])
                         / (g->points[1][0] - g->points[0][0]) + 0.5f) % NODES;
-    g->on_node = fabsf(g->points[g->selected][1] - (float)event->y) < epsilon;
+    g->on_node = fabsf(g->points[g->selected][1] - (float)dt_gdk_event_get_y(event)) < epsilon;
     darktable.control->element = g->selected;
     if(oldsel != g->selected || oldon != g->on_node)
       gtk_widget_queue_draw(GTK_WIDGET(g->area));
@@ -2739,17 +2740,17 @@ static gboolean _area_button_press_callback(GtkWidget *widget,
 {
   dt_iop_colorequal_gui_data_t *g = self->gui_data;
 
-  if(event->button == GDK_BUTTON_MIDDLE
-     || (event->button == GDK_BUTTON_PRIMARY // Ctrl+Click alias for macOS
-         && dt_modifier_is(event->state, GDK_CONTROL_MASK)))
+  if(dt_gdk_event_get_button(event) == GDK_BUTTON_MIDDLE
+     || (dt_gdk_event_get_button(event) == GDK_BUTTON_PRIMARY // Ctrl+Click alias for macOS
+         && dt_modifier_is(dt_gdk_event_get_state(event), GDK_CONTROL_MASK)))
   {
     dt_conf_set_bool("plugins/darkroom/colorequal/show_sliders",
                      gtk_notebook_get_n_pages(g->notebook) != 4);
     gui_update(self);
   }
-  else if(event->button == GDK_BUTTON_PRIMARY)
+  else if(dt_gdk_event_get_button(event) == GDK_BUTTON_PRIMARY)
   {
-    if(event->type == GDK_2BUTTON_PRESS)
+    if(dt_gdk_event_get_type(event) == GDK_2BUTTON_PRESS)
     {
       _area_reset_nodes(g);
       return TRUE;
@@ -2771,7 +2772,7 @@ static gboolean _area_button_release_callback(GtkWidget *widget,
 {
   dt_iop_colorequal_gui_data_t *g = self->gui_data;
 
-  if(event->button == GDK_BUTTON_PRIMARY)
+  if(dt_gdk_event_get_button(event) == GDK_BUTTON_PRIMARY)
   {
     g->dragging = FALSE;
     return TRUE;

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "common/gdk_event_utils.h"
 
 #include "bauhaus/bauhaus.h"
 #include "common/iop_profile.h"
@@ -1662,7 +1663,7 @@ static gboolean _bottom_area_button_press_callback(GtkWidget *widget,
 {
   dt_iop_colorzones_gui_data_t *g = self->gui_data;
 
-  if(event->button == GDK_BUTTON_PRIMARY && event->type == GDK_2BUTTON_PRESS)
+  if(dt_gdk_event_get_button(event) == GDK_BUTTON_PRIMARY && dt_gdk_event_get_type(event) == GDK_2BUTTON_PRESS)
   {
     // reset zoom level
     g->zoom_factor = 1.f;
@@ -1865,7 +1866,7 @@ static gboolean _area_scrolled_callback(GtkWidget *widget,
 
   if(dt_gui_ignore_scroll(event)) return FALSE;
 
-  if(dt_modifier_is(event->state, GDK_MOD1_MASK))
+  if(dt_modifier_is(dt_gdk_event_get_state(event), GDK_MOD1_MASK))
     return gtk_widget_event(GTK_WIDGET(g->channel_tabs), (GdkEvent*)event);
 
   int delta_y;
@@ -1912,7 +1913,7 @@ static gboolean _area_scrolled_callback(GtkWidget *widget,
     else
     {
       const float dy = delta_y * -DT_IOP_COLORZONES_DEFAULT_STEP;
-      return _move_point_internal(self, widget, g->selected, 0.f, dy, event->state);
+      return _move_point_internal(self, widget, g->selected, 0.f, dy, dt_gdk_event_get_state(event));
     }
   }
 
@@ -1940,10 +1941,10 @@ static gboolean _area_motion_notify_callback(GtkWidget *widget,
     const float mx = g->mouse_x;
     const float my = g->mouse_y;
 
-    g->mouse_x = CLAMP(event->x - inset, 0, width) / (float)width;
-    g->mouse_y = 1.0 - CLAMP(event->y - inset, 0, height) / (float)height;
+    g->mouse_x = CLAMP(dt_gdk_event_get_x(event) - inset, 0, width) / (float)width;
+    g->mouse_y = 1.0 - CLAMP(dt_gdk_event_get_y(event) - inset, 0, height) / (float)height;
 
-    if(event->state & GDK_BUTTON1_MASK)
+    if(dt_gdk_event_get_state(event) & GDK_BUTTON1_MASK)
     {
       g->offset_x += (mx - g->mouse_x) / g->zoom_factor;
       g->offset_y += (my - g->mouse_y) / g->zoom_factor;
@@ -1963,8 +1964,8 @@ static gboolean _area_motion_notify_callback(GtkWidget *widget,
   const double old_m_x = g->mouse_x;
   const double old_m_y = fabs(g->mouse_y);
 
-  g->mouse_x = CLAMP(event->x - inset, 0, width) / (float)width;
-  g->mouse_y = 1.0 - CLAMP(event->y - inset, 0, height) / (float)height;
+  g->mouse_x = CLAMP(dt_gdk_event_get_x(event) - inset, 0, width) / (float)width;
+  g->mouse_y = 1.0 - CLAMP(dt_gdk_event_get_y(event) - inset, 0, height) / (float)height;
 
   darktable.control->element =
     (int)(8.0 *
@@ -1972,7 +1973,7 @@ static gboolean _area_motion_notify_callback(GtkWidget *widget,
                           g->zoom_factor, g->offset_x) + 0.5f) % 8;
 
   // move a node
-  if(event->state & GDK_BUTTON1_MASK)
+  if(dt_gdk_event_get_state(event) & GDK_BUTTON1_MASK)
   {
     if(g->edit_by_area)
     {
@@ -2003,7 +2004,7 @@ static gboolean _area_motion_notify_callback(GtkWidget *widget,
                                          g->zoom_factor, g->offset_y);
 
       dt_iop_color_picker_reset(self, TRUE);
-      return _move_point_internal(self, widget, g->selected, dx, dy, event->state);
+      return _move_point_internal(self, widget, g->selected, dx, dy, dt_gdk_event_get_state(event));
     }
   }
 
@@ -2019,7 +2020,7 @@ static gboolean _area_motion_notify_callback(GtkWidget *widget,
         dt_dev_add_history_item_target(darktable.develop, self, TRUE, widget + ch);
       }
     }
-    else if(event->y > height)
+    else if(dt_gdk_event_get_y(event) > height)
     {
       g->x_move = 0;
       const int bands = p->curve_num_nodes[g->channel];
@@ -2042,7 +2043,7 @@ static gboolean _area_motion_notify_callback(GtkWidget *widget,
   }
   else
   {
-    if(event->state & GDK_BUTTON1_MASK)
+    if(dt_gdk_event_get_state(event) & GDK_BUTTON1_MASK)
     {
       if(nodes < DT_IOP_COLORZONES_MAXNODES && g->selected == -1)
       {
@@ -2102,16 +2103,16 @@ static gboolean _area_button_press_callback(GtkWidget *widget,
   int nodes = p->curve_num_nodes[ch];
   dt_iop_colorzones_node_t *curve = p->curve[ch];
 
-  if(event->button == GDK_BUTTON_PRIMARY)
+  if(dt_gdk_event_get_button(event) == GDK_BUTTON_PRIMARY)
   {
-    if(g->edit_by_area && event->type != GDK_2BUTTON_PRESS
-       && !dt_modifier_is(event->state, GDK_CONTROL_MASK))
+    if(g->edit_by_area && dt_gdk_event_get_type(event) != GDK_2BUTTON_PRESS
+       && !dt_modifier_is(dt_gdk_event_get_state(event), GDK_CONTROL_MASK))
     {
       g->dragging = 1;
       return TRUE;
     }
-    else if(event->type == GDK_BUTTON_PRESS
-            && dt_modifier_is(event->state, GDK_CONTROL_MASK)
+    else if(dt_gdk_event_get_type(event) == GDK_BUTTON_PRESS
+            && dt_modifier_is(dt_gdk_event_get_state(event), GDK_CONTROL_MASK)
             && nodes < DT_IOP_COLORZONES_MAXNODES
             && (g->selected == -1 || g->edit_by_area))
     {
@@ -2123,8 +2124,8 @@ static gboolean _area_button_press_callback(GtkWidget *widget,
       const int height = allocation.height - 2 * inset;
       const int width = allocation.width - 2 * inset;
 
-      g->mouse_x = CLAMP(event->x - inset, 0, width) / (float)width;
-      g->mouse_y = 1.0 - CLAMP(event->y - inset, 0, height) / (float)height;
+      g->mouse_x = CLAMP(dt_gdk_event_get_x(event) - inset, 0, width) / (float)width;
+      g->mouse_y = 1.0 - CLAMP(dt_gdk_event_get_y(event) - inset, 0, height) / (float)height;
 
       const float mx = _mouse_to_curve(g->mouse_x, g->zoom_factor, g->offset_x);
 
@@ -2172,7 +2173,7 @@ static gboolean _area_button_press_callback(GtkWidget *widget,
 
       return TRUE;
     }
-    else if(event->type == GDK_2BUTTON_PRESS)
+    else if(dt_gdk_event_get_type(event) == GDK_2BUTTON_PRESS)
     {
       // reset current curve
       p->curve_num_nodes[ch] = d->curve_num_nodes[ch];
@@ -2191,7 +2192,7 @@ static gboolean _area_button_press_callback(GtkWidget *widget,
       return TRUE;
     }
   }
-  else if(event->button == GDK_BUTTON_SECONDARY && g->selected >= 0)
+  else if(dt_gdk_event_get_button(event) == GDK_BUTTON_SECONDARY && g->selected >= 0)
   {
     if((g->selected == 0 || g->selected == nodes - 1)
        && p->splines_version == DT_IOP_COLORZONES_SPLINES_V1)
@@ -2218,7 +2219,7 @@ static gboolean _area_button_press_callback(GtkWidget *widget,
 
     // right click deletes the node, ctrl+right click reset the node to y-zero
     _delete_node(self, curve, &p->curve_num_nodes[ch],
-                 g->selected, dt_modifier_is(event->state, GDK_CONTROL_MASK));
+                 g->selected, dt_modifier_is(dt_gdk_event_get_state(event), GDK_CONTROL_MASK));
     g->selected = -2; // avoid re-insertion of that point immediately after this
 
     return TRUE;
@@ -2233,7 +2234,7 @@ static gboolean _area_button_release_callback(GtkWidget *widget,
 {
   if(darktable.develop->darkroom_skip_mouse_events) return TRUE;
 
-  if(event->button == GDK_BUTTON_PRIMARY)
+  if(dt_gdk_event_get_button(event) == GDK_BUTTON_PRIMARY)
   {
     dt_iop_colorzones_gui_data_t *g = self->gui_data;
     g->dragging = 0;
@@ -2251,7 +2252,7 @@ static gboolean _area_leave_notify_callback(GtkWidget *widget,
   dt_iop_colorzones_gui_data_t *g = self->gui_data;
   // for fluxbox
   g->mouse_y = -fabs(g->mouse_y);
-  if(!(event->state & GDK_BUTTON1_MASK))
+  if(!(dt_gdk_event_get_state(event) & GDK_BUTTON1_MASK))
     g->selected = -1;
   gtk_widget_queue_draw(widget);
   return TRUE;
@@ -2269,22 +2270,22 @@ static gboolean _area_key_press_callback(GtkWidget *widget,
 
   int handled = 0;
   float dx = 0.0f, dy = 0.0f;
-  if(event->keyval == GDK_KEY_Up || event->keyval == GDK_KEY_KP_Up)
+  if(dt_gdk_event_get_keyval(event) == GDK_KEY_Up || dt_gdk_event_get_keyval(event) == GDK_KEY_KP_Up)
   {
     handled = 1;
     dy = DT_IOP_COLORZONES_DEFAULT_STEP;
   }
-  else if(event->keyval == GDK_KEY_Down || event->keyval == GDK_KEY_KP_Down)
+  else if(dt_gdk_event_get_keyval(event) == GDK_KEY_Down || dt_gdk_event_get_keyval(event) == GDK_KEY_KP_Down)
   {
     handled = 1;
     dy = -DT_IOP_COLORZONES_DEFAULT_STEP;
   }
-  else if(event->keyval == GDK_KEY_Right || event->keyval == GDK_KEY_KP_Right)
+  else if(dt_gdk_event_get_keyval(event) == GDK_KEY_Right || dt_gdk_event_get_keyval(event) == GDK_KEY_KP_Right)
   {
     handled = 1;
     dx = DT_IOP_COLORZONES_DEFAULT_STEP;
   }
-  else if(event->keyval == GDK_KEY_Left || event->keyval == GDK_KEY_KP_Left)
+  else if(dt_gdk_event_get_keyval(event) == GDK_KEY_Left || dt_gdk_event_get_keyval(event) == GDK_KEY_KP_Left)
   {
     handled = 1;
     dx = -DT_IOP_COLORZONES_DEFAULT_STEP;
@@ -2293,7 +2294,7 @@ static gboolean _area_key_press_callback(GtkWidget *widget,
   if(!handled) return FALSE;
 
   dt_iop_color_picker_reset(self, TRUE);
-  return _move_point_internal(self, widget, g->selected, dx, dy, event->state);
+  return _move_point_internal(self, widget, g->selected, dx, dy, dt_gdk_event_get_state(event));
 }
 
 static void _channel_tabs_switch_callback(GtkNotebook *notebook,

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "common/gdk_event_utils.h"
 
 #include "bauhaus/bauhaus.h"
 #include "common/eaw.h"
@@ -3447,8 +3448,8 @@ static gboolean denoiseprofile_motion_notify(GtkWidget *widget,
   GtkAllocation allocation;
   gtk_widget_get_allocation(widget, &allocation);
   int height = allocation.height - 2 * inset, width = allocation.width - 2 * inset;
-  if(!g->dragging) g->mouse_x = CLAMP(event->x - inset, 0, width) / (float)width;
-  g->mouse_y = 1.0 - CLAMP(event->y - inset, 0, height) / (float)height;
+  if(!g->dragging) g->mouse_x = CLAMP(dt_gdk_event_get_x(event) - inset, 0, width) / (float)width;
+  g->mouse_y = 1.0 - CLAMP(dt_gdk_event_get_y(event) - inset, 0, height) / (float)height;
   if(g->dragging)
   {
     *p = g->drag_params;
@@ -3474,7 +3475,7 @@ static gboolean denoiseprofile_button_press(GtkWidget *widget,
 {
   dt_iop_denoiseprofile_gui_data_t *g = self->gui_data;
   const int ch = g->channel;
-  if(event->button == 1 && event->type == GDK_2BUTTON_PRESS)
+  if(dt_gdk_event_get_button(event) == 1 && dt_gdk_event_get_type(event) == GDK_2BUTTON_PRESS)
   {
     // reset current curve
     dt_iop_denoiseprofile_params_t *p = self->params;
@@ -3488,7 +3489,7 @@ static gboolean denoiseprofile_button_press(GtkWidget *widget,
     dt_dev_add_history_item(darktable.develop, self, TRUE);
     gtk_widget_queue_draw(GTK_WIDGET(g->area));
   }
-  else if(event->button == GDK_BUTTON_PRIMARY)
+  else if(dt_gdk_event_get_button(event) == GDK_BUTTON_PRIMARY)
   {
     g->drag_params = *(dt_iop_denoiseprofile_params_t *)self->params;
     const int inset = DT_IOP_DENOISE_PROFILE_INSET;
@@ -3497,8 +3498,8 @@ static gboolean denoiseprofile_button_press(GtkWidget *widget,
     int height = allocation.height - 2 * inset, width = allocation.width - 2 * inset;
     g->mouse_pick
         = dt_draw_curve_calc_value(g->transition_curve,
-                                   CLAMP(event->x - inset, 0, width) / (float)width);
-    g->mouse_pick -= 1.0 - CLAMP(event->y - inset, 0, height) / (float)height;
+                                   CLAMP(dt_gdk_event_get_x(event) - inset, 0, width) / (float)width);
+    g->mouse_pick -= 1.0 - CLAMP(dt_gdk_event_get_y(event) - inset, 0, height) / (float)height;
     g->dragging = 1;
     return TRUE;
   }
@@ -3509,7 +3510,7 @@ static gboolean denoiseprofile_button_release(GtkWidget *widget,
                                               GdkEventButton *event,
                                               dt_iop_module_t *self)
 {
-  if(event->button == GDK_BUTTON_PRIMARY)
+  if(dt_gdk_event_get_button(event) == GDK_BUTTON_PRIMARY)
   {
     dt_iop_denoiseprofile_gui_data_t *g = self->gui_data;
     g->dragging = 0;
@@ -3536,7 +3537,7 @@ static gboolean denoiseprofile_scrolled(GtkWidget *widget,
 
   if(dt_gui_ignore_scroll(event)) return FALSE;
 
-  if(dt_modifier_is(event->state, GDK_MOD1_MASK))
+  if(dt_modifier_is(dt_gdk_event_get_state(event), GDK_MOD1_MASK))
     return gtk_widget_event(GTK_WIDGET(g->channel > DT_DENOISE_PROFILE_B ? g->channel_tabs_Y0U0V0 : g->channel_tabs), (GdkEvent*)event);
 
   int delta_y;

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -15,6 +15,7 @@
    You should have received a copy of the GNU General Public License
    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "common/gdk_event_utils.h"
 
 /** Note :
  * we use finite-math-only and fast-math because divisions by zero are manually avoided in the code
@@ -4175,7 +4176,7 @@ static gboolean area_button_press(GtkWidget *widget, const GdkEventButton *event
   if(g->active_button != DT_FILMIC_GUI_BUTTON_LAST)
   {
 
-    if(event->button == GDK_BUTTON_PRIMARY && event->type == GDK_2BUTTON_PRESS)
+    if(dt_gdk_event_get_button(event) == GDK_BUTTON_PRIMARY && dt_gdk_event_get_type(event) == GDK_2BUTTON_PRESS)
     {
       // double click resets view
       if(g->active_button == DT_FILMIC_GUI_BUTTON_TYPE)
@@ -4190,7 +4191,7 @@ static gboolean area_button_press(GtkWidget *widget, const GdkEventButton *event
         return FALSE;
       }
     }
-    else if(event->button == GDK_BUTTON_PRIMARY)
+    else if(dt_gdk_event_get_button(event) == GDK_BUTTON_PRIMARY)
     {
       // simple left click cycles through modes in positive direction
       if(g->active_button == DT_FILMIC_GUI_BUTTON_TYPE)
@@ -4219,7 +4220,7 @@ static gboolean area_button_press(GtkWidget *widget, const GdkEventButton *event
         return FALSE;
       }
     }
-    else if(event->button == GDK_BUTTON_SECONDARY)
+    else if(dt_gdk_event_get_button(event) == GDK_BUTTON_SECONDARY)
     {
       // simple right click cycles through modes in negative direction
       if(g->active_button == DT_FILMIC_GUI_BUTTON_TYPE)
@@ -4253,7 +4254,7 @@ static gboolean area_button_press(GtkWidget *widget, const GdkEventButton *event
 static gboolean area_enter_leave_notify(GtkWidget *widget, const GdkEventCrossing *event, const dt_iop_module_t *self)
 {
   dt_iop_filmicrgb_gui_data_t *g = self->gui_data;
-  g->gui_hover = event->type == GDK_ENTER_NOTIFY;
+  g->gui_hover = dt_gdk_event_get_type(event) == GDK_ENTER_NOTIFY;
   gtk_widget_queue_draw(GTK_WIDGET(g->area));
   return FALSE;
 }
@@ -4266,8 +4267,8 @@ static gboolean area_motion_notify(GtkWidget *widget, const GdkEventMotion *even
   if(!g->gui_sizes_inited) return FALSE;
 
   // get in-widget coordinates
-  const float y = event->y;
-  const float x = event->x;
+  const float y = dt_gdk_event_get_y(event);
+  const float x = dt_gdk_event_get_x(event);
 
   if(x > 0. && x < g->allocation.width && y > 0. && y < g->allocation.height) g->gui_hover = TRUE;
 

--- a/src/iop/levels.c
+++ b/src/iop/levels.c
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "common/gdk_event_utils.h"
 #include <assert.h>
 #include <math.h>
 #include <stdint.h>
@@ -872,16 +873,16 @@ static gboolean dt_iop_levels_motion_notify(GtkWidget *widget, GdkEventMotion *e
   int height = allocation.height - 2 * inset - DT_RESIZE_HANDLE_SIZE, width = allocation.width - 2 * inset;
   if(!g->dragging)
   {
-    g->mouse_x = CLAMP(event->x - inset, 0, width);
+    g->mouse_x = CLAMP(dt_gdk_event_get_x(event) - inset, 0, width);
     g->drag_start_percentage = (p->levels[1] - p->levels[0]) / (p->levels[2] - p->levels[0]);
   }
-  g->mouse_y = CLAMP(event->y - inset, 0, height);
+  g->mouse_y = CLAMP(dt_gdk_event_get_y(event) - inset, 0, height);
 
   if(g->dragging)
   {
     if(g->handle_move >= 0 && g->handle_move < 3)
     {
-      const float mx = (CLAMP(event->x - inset, 0, width)) / (float)width;
+      const float mx = (CLAMP(dt_gdk_event_get_x(event) - inset, 0, width)) / (float)width;
 
       dt_iop_levels_move_handle(self, g->handle_move, mx, p->levels, g->drag_start_percentage);
     }
@@ -890,7 +891,7 @@ static gboolean dt_iop_levels_motion_notify(GtkWidget *widget, GdkEventMotion *e
   else
   {
     g->handle_move = 0;
-    const float mx = CLAMP(event->x - inset, 0, width) / (float)width;
+    const float mx = CLAMP(dt_gdk_event_get_x(event) - inset, 0, width) / (float)width;
     float dist = fabsf(p->levels[0] - mx);
     for(int k = 1; k < 3; k++)
     {
@@ -910,11 +911,11 @@ static gboolean dt_iop_levels_motion_notify(GtkWidget *widget, GdkEventMotion *e
 static gboolean dt_iop_levels_button_press(GtkWidget *widget, GdkEventButton *event, dt_iop_module_t *self)
 {
   // set active point
-  if(event->button == GDK_BUTTON_PRIMARY)
+  if(dt_gdk_event_get_button(event) == GDK_BUTTON_PRIMARY)
   {
     if(darktable.develop->gui_module != self) dt_iop_request_focus(self);
 
-    if(event->type == GDK_2BUTTON_PRESS)
+    if(dt_gdk_event_get_type(event) == GDK_2BUTTON_PRESS)
     {
       // Reset
       dt_iop_levels_gui_data_t *g = self->gui_data;
@@ -938,7 +939,7 @@ static gboolean dt_iop_levels_button_press(GtkWidget *widget, GdkEventButton *ev
 
 static gboolean dt_iop_levels_button_release(GtkWidget *widget, GdkEventButton *event, dt_iop_module_t *self)
 {
-  if(event->button == GDK_BUTTON_PRIMARY)
+  if(dt_gdk_event_get_button(event) == GDK_BUTTON_PRIMARY)
   {
     dt_iop_levels_gui_data_t *g = self->gui_data;
     g->dragging = 0;
@@ -963,7 +964,7 @@ static gboolean dt_iop_levels_scroll(GtkWidget *widget, GdkEventScroll *event, d
 
   if(darktable.develop->gui_module != self) dt_iop_request_focus(self);
 
-  const float interval = 0.002 * dt_accel_get_speed_multiplier(widget, event->state); // Distance moved for each scroll event
+  const float interval = 0.002 * dt_accel_get_speed_multiplier(widget, dt_gdk_event_get_state(event)); // Distance moved for each scroll event
   int delta_y;
   if(dt_gui_get_scroll_unit_delta(event, &delta_y))
   {

--- a/src/iop/liquify.c
+++ b/src/iop/liquify.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2014-2025 darktable developers.
+    Copyright (C) 2014-2026 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "common/gdk_event_utils.h"
 
 #include "bauhaus/bauhaus.h"
 #include "common/imagebuf.h"
@@ -3535,7 +3536,7 @@ static gboolean btn_make_radio_callback(GtkToggleButton *btn,
     return TRUE;
   }
 
-  g->creation_continuous = event != NULL && dt_modifier_is(event->state, GDK_CONTROL_MASK);
+  g->creation_continuous = event != NULL && dt_modifier_is(dt_gdk_event_get_state(event), GDK_CONTROL_MASK);
 
   dt_control_hinter_message("");
 

--- a/src/iop/lowlight.c
+++ b/src/iop/lowlight.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2011-2024 darktable developers.
+    Copyright (C) 2011-2026 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "common/gdk_event_utils.h"
 #include "bauhaus/bauhaus.h"
 #include "common/colorspaces_inline_conversions.h"
 #include "common/darktable.h"
@@ -671,14 +672,14 @@ static gboolean lowlight_motion_notify(GtkWidget *widget, GdkEventMotion *event,
   GtkAllocation allocation;
   gtk_widget_get_allocation(widget, &allocation);
   int height = allocation.height - 2 * inset - DT_RESIZE_HANDLE_SIZE, width = allocation.width - 2 * inset;
-  if(!g->dragging) g->mouse_x = CLAMP(event->x - inset, 0, width) / (float)width;
-  g->mouse_y = 1.0 - CLAMP(event->y - inset, 0, height) / (float)height;
+  if(!g->dragging) g->mouse_x = CLAMP(dt_gdk_event_get_x(event) - inset, 0, width) / (float)width;
+  g->mouse_y = 1.0 - CLAMP(dt_gdk_event_get_y(event) - inset, 0, height) / (float)height;
   if(g->dragging)
   {
     *p = g->drag_params;
     if(g->x_move >= 0)
     {
-      const float mx = CLAMP(event->x - inset, 0, width) / (float)width;
+      const float mx = CLAMP(dt_gdk_event_get_x(event) - inset, 0, width) / (float)width;
       if(g->x_move > 0 && g->x_move < DT_IOP_LOWLIGHT_BANDS - 1)
       {
         const float minx = p->transition_x[g->x_move - 1] + 0.001f;
@@ -693,7 +694,7 @@ static gboolean lowlight_motion_notify(GtkWidget *widget, GdkEventMotion *event,
     gtk_widget_queue_draw(widget);
     dt_dev_add_history_item_target(darktable.develop, self, TRUE, widget);
   }
-  else if(event->y > height)
+  else if(dt_gdk_event_get_y(event) > height)
   {
     g->x_move = 0;
     float dist = fabs(p->transition_x[0] - g->mouse_x);
@@ -719,7 +720,7 @@ static gboolean lowlight_motion_notify(GtkWidget *widget, GdkEventMotion *event,
 static gboolean lowlight_button_press(GtkWidget *widget, GdkEventButton *event, dt_iop_module_t *self)
 {
   dt_iop_lowlight_gui_data_t *g = self->gui_data;
-  if(event->button == GDK_BUTTON_PRIMARY && event->type == GDK_2BUTTON_PRESS)
+  if(dt_gdk_event_get_button(event) == GDK_BUTTON_PRIMARY && dt_gdk_event_get_type(event) == GDK_2BUTTON_PRESS)
   {
     // reset current curve
     dt_iop_lowlight_params_t *p = self->params;
@@ -732,7 +733,7 @@ static gboolean lowlight_button_press(GtkWidget *widget, GdkEventButton *event, 
     dt_dev_add_history_item_target(darktable.develop, self, TRUE, widget);
     gtk_widget_queue_draw(GTK_WIDGET(g->area));
   }
-  else if(event->button == GDK_BUTTON_PRIMARY)
+  else if(dt_gdk_event_get_button(event) == GDK_BUTTON_PRIMARY)
   {
     g->drag_params = *(dt_iop_lowlight_params_t *)self->params;
     const int inset = DT_IOP_LOWLIGHT_INSET;
@@ -740,8 +741,8 @@ static gboolean lowlight_button_press(GtkWidget *widget, GdkEventButton *event, 
     gtk_widget_get_allocation(widget, &allocation);
     int height = allocation.height - 2 * inset - DT_RESIZE_HANDLE_SIZE, width = allocation.width - 2 * inset;
     g->mouse_pick
-        = dt_draw_curve_calc_value(g->transition_curve, CLAMP(event->x - inset, 0, width) / (float)width);
-    g->mouse_pick -= 1.0 - CLAMP(event->y - inset, 0, height) / (float)height;
+        = dt_draw_curve_calc_value(g->transition_curve, CLAMP(dt_gdk_event_get_x(event) - inset, 0, width) / (float)width);
+    g->mouse_pick -= 1.0 - CLAMP(dt_gdk_event_get_y(event) - inset, 0, height) / (float)height;
     g->dragging = 1;
     return TRUE;
   }
@@ -750,7 +751,7 @@ static gboolean lowlight_button_press(GtkWidget *widget, GdkEventButton *event, 
 
 static gboolean lowlight_button_release(GtkWidget *widget, GdkEventButton *event, dt_iop_module_t *self)
 {
-  if(event->button == GDK_BUTTON_PRIMARY)
+  if(dt_gdk_event_get_button(event) == GDK_BUTTON_PRIMARY)
   {
     dt_iop_lowlight_gui_data_t *g = self->gui_data;
     g->dragging = 0;

--- a/src/iop/lut3d.c
+++ b/src/iop/lut3d.c
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "common/gdk_event_utils.h"
 
 #include "bauhaus/bauhaus.h"
 #include "common/imagebuf.h"
@@ -1480,7 +1481,7 @@ static gboolean _mouse_scroll(GtkWidget *view, GdkEventScroll *event, dt_lib_mod
   if(gtk_tree_selection_get_selected(selection, &model, &iter))
   {
     gboolean next = FALSE;
-    if(event->delta_y > 0)
+    if(dt_gdk_event_get_scroll_delta_y(event) > 0)
       next = gtk_tree_model_iter_next(model, &iter);
     else
       next = gtk_tree_model_iter_previous(model, &iter);

--- a/src/iop/monochrome.c
+++ b/src/iop/monochrome.c
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "common/gdk_event_utils.h"
 
 #include "bauhaus/bauhaus.h"
 #include "common/bilateral.h"
@@ -459,8 +460,8 @@ static gboolean _monochrome_motion_notify(GtkWidget *widget, GdkEventMotion *eve
     GtkAllocation allocation;
     gtk_widget_get_allocation(widget, &allocation);
     int width = allocation.width - 2 * inset, height = allocation.height - 2 * inset;
-    const float mouse_x = CLAMP(event->x - inset, 0, width);
-    const float mouse_y = CLAMP(height - 1 - event->y + inset, 0, height);
+    const float mouse_x = CLAMP(dt_gdk_event_get_x(event) - inset, 0, width);
+    const float mouse_y = CLAMP(height - 1 - dt_gdk_event_get_y(event) + inset, 0, height);
     p->a = PANEL_WIDTH * (mouse_x - width * 0.5f) / (float)width;
     p->b = PANEL_WIDTH * (mouse_y - height * 0.5f) / (float)height;
 
@@ -472,12 +473,12 @@ static gboolean _monochrome_motion_notify(GtkWidget *widget, GdkEventMotion *eve
 
 static gboolean _monochrome_button_press(GtkWidget *widget, GdkEventButton *event, dt_iop_module_t *self)
 {
-  if(event->button == GDK_BUTTON_PRIMARY)
+  if(dt_gdk_event_get_button(event) == GDK_BUTTON_PRIMARY)
   {
     dt_iop_monochrome_gui_data_t *g = self->gui_data;
     dt_iop_monochrome_params_t *p = self->params;
     dt_iop_color_picker_reset(self, TRUE);
-    if(event->type == GDK_2BUTTON_PRESS)
+    if(dt_gdk_event_get_type(event) == GDK_2BUTTON_PRESS)
     {
       // reset
       const dt_iop_monochrome_params_t *const p0 = self->default_params;
@@ -491,8 +492,8 @@ static gboolean _monochrome_button_press(GtkWidget *widget, GdkEventButton *even
       GtkAllocation allocation;
       gtk_widget_get_allocation(widget, &allocation);
       int width = allocation.width - 2 * inset, height = allocation.height - 2 * inset;
-      const float mouse_x = CLAMP(event->x - inset, 0, width);
-      const float mouse_y = CLAMP(height - 1 - event->y + inset, 0, height);
+      const float mouse_x = CLAMP(dt_gdk_event_get_x(event) - inset, 0, width);
+      const float mouse_y = CLAMP(height - 1 - dt_gdk_event_get_y(event) + inset, 0, height);
       p->a = PANEL_WIDTH * (mouse_x - width * 0.5f) / (float)width;
       p->b = PANEL_WIDTH * (mouse_y - height * 0.5f) / (float)height;
       g->dragging = 1;
@@ -506,7 +507,7 @@ static gboolean _monochrome_button_press(GtkWidget *widget, GdkEventButton *even
 
 static gboolean _monochrome_button_release(GtkWidget *widget, GdkEventButton *event, dt_iop_module_t *self)
 {
-  if(event->button == GDK_BUTTON_PRIMARY)
+  if(dt_gdk_event_get_button(event) == GDK_BUTTON_PRIMARY)
   {
     dt_iop_monochrome_gui_data_t *g = self->gui_data;
     dt_iop_color_picker_reset(self, TRUE);

--- a/src/iop/rawdenoise.c
+++ b/src/iop/rawdenoise.c
@@ -16,6 +16,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "common/gdk_event_utils.h"
 #include "bauhaus/bauhaus.h"
 #include "common/darktable.h"
 #include "common/imagebuf.h"
@@ -773,8 +774,8 @@ static gboolean rawdenoise_motion_notify(GtkWidget *widget, GdkEventMotion *even
   GtkAllocation allocation;
   gtk_widget_get_allocation(widget, &allocation);
   int height = allocation.height - 2 * inset, width = allocation.width - 2 * inset;
-  if(!g->dragging) g->mouse_x = CLAMP(event->x - inset, 0, width) / (float)width;
-  g->mouse_y = 1.0 - CLAMP(event->y - inset, 0, height) / (float)height;
+  if(!g->dragging) g->mouse_x = CLAMP(dt_gdk_event_get_x(event) - inset, 0, width) / (float)width;
+  g->mouse_y = 1.0 - CLAMP(dt_gdk_event_get_y(event) - inset, 0, height) / (float)height;
   if(g->dragging)
   {
     *p = g->drag_params;
@@ -797,7 +798,7 @@ static gboolean rawdenoise_button_press(GtkWidget *widget, GdkEventButton *event
 {
   dt_iop_rawdenoise_gui_data_t *g = self->gui_data;
   const int ch = g->channel;
-  if(event->button == GDK_BUTTON_PRIMARY && event->type == GDK_2BUTTON_PRESS)
+  if(dt_gdk_event_get_button(event) == GDK_BUTTON_PRIMARY && dt_gdk_event_get_type(event) == GDK_2BUTTON_PRESS)
   {
     // reset current curve
     dt_iop_rawdenoise_params_t *p = self->params;
@@ -810,7 +811,7 @@ static gboolean rawdenoise_button_press(GtkWidget *widget, GdkEventButton *event
     dt_dev_add_history_item_target(darktable.develop, self, TRUE, widget + ch);
     gtk_widget_queue_draw(GTK_WIDGET(g->area));
   }
-  else if(event->button == GDK_BUTTON_PRIMARY)
+  else if(dt_gdk_event_get_button(event) == GDK_BUTTON_PRIMARY)
   {
     g->drag_params = *(dt_iop_rawdenoise_params_t *)self->params;
     const int inset = DT_IOP_RAWDENOISE_INSET;
@@ -818,8 +819,8 @@ static gboolean rawdenoise_button_press(GtkWidget *widget, GdkEventButton *event
     gtk_widget_get_allocation(widget, &allocation);
     int height = allocation.height - 2 * inset, width = allocation.width - 2 * inset;
     g->mouse_pick
-        = dt_draw_curve_calc_value(g->transition_curve, CLAMP(event->x - inset, 0, width) / (float)width);
-    g->mouse_pick -= 1.0 - CLAMP(event->y - inset, 0, height) / (float)height;
+        = dt_draw_curve_calc_value(g->transition_curve, CLAMP(dt_gdk_event_get_x(event) - inset, 0, width) / (float)width);
+    g->mouse_pick -= 1.0 - CLAMP(dt_gdk_event_get_y(event) - inset, 0, height) / (float)height;
     g->dragging = 1;
     return TRUE;
   }
@@ -828,7 +829,7 @@ static gboolean rawdenoise_button_press(GtkWidget *widget, GdkEventButton *event
 
 static gboolean rawdenoise_button_release(GtkWidget *widget, GdkEventButton *event, dt_iop_module_t *self)
 {
-  if(event->button == GDK_BUTTON_PRIMARY)
+  if(dt_gdk_event_get_button(event) == GDK_BUTTON_PRIMARY)
   {
     dt_iop_rawdenoise_gui_data_t *g = self->gui_data;
     g->dragging = 0;
@@ -851,7 +852,7 @@ static gboolean rawdenoise_scrolled(GtkWidget *widget, GdkEventScroll *event, dt
 
   if(dt_gui_ignore_scroll(event)) return FALSE;
 
-  if(dt_modifier_is(event->state, GDK_MOD1_MASK))
+  if(dt_modifier_is(dt_gdk_event_get_state(event), GDK_MOD1_MASK))
     return gtk_widget_event(GTK_WIDGET(g->channel_tabs), (GdkEvent*)event);
 
   int delta_y;

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "common/gdk_event_utils.h"
 
 #include "bauhaus/bauhaus.h"
 #include "common/bilateral.h"
@@ -1258,7 +1259,7 @@ static gboolean rt_wdbar_button_press(GtkWidget *widget,
   const int inset = round(RT_WDBAR_INSET * allocation.height);
   const float box_w = (allocation.width - 2.0f * inset) / (float)RETOUCH_NO_SCALES;
 
-  if(event->button == GDK_BUTTON_PRIMARY)
+  if(dt_gdk_event_get_button(event) == GDK_BUTTON_PRIMARY)
   {
     if(g->lower_margin) // bottom slider
     {
@@ -1288,7 +1289,7 @@ static gboolean rt_wdbar_button_release(GtkWidget *widget,
 {
   dt_iop_retouch_gui_data_t *g = self->gui_data;
 
-  if(event->button == GDK_BUTTON_PRIMARY)
+  if(dt_gdk_event_get_button(event) == GDK_BUTTON_PRIMARY)
     g->is_dragging = 0;
 
   gtk_widget_queue_draw(g->wd_bar);
@@ -1340,8 +1341,8 @@ static gboolean rt_wdbar_motion_notify(GtkWidget *widget,
 
 
   /* record mouse position within control */
-  g->wdbar_mouse_x = CLAMP(event->x - inset, 0, allocation.width - 2.0f * inset - 1.0f);
-  g->wdbar_mouse_y = event->y;
+  g->wdbar_mouse_x = CLAMP(dt_gdk_event_get_x(event) - inset, 0, allocation.width - 2.0f * inset - 1.0f);
+  g->wdbar_mouse_y = dt_gdk_event_get_y(event);
 
   g->curr_scale = g->wdbar_mouse_x / box_w;
   g->lower_cursor = g->upper_cursor = FALSE;
@@ -1844,7 +1845,7 @@ static gboolean rt_edit_masks_callback(GtkWidget *widget,
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_ellipse), FALSE);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_brush), FALSE);
 
-  if(event->button == GDK_BUTTON_PRIMARY)
+  if(dt_gdk_event_get_button(event) == GDK_BUTTON_PRIMARY)
   {
     DT_ENTER_GUI_UPDATE();
 
@@ -1855,7 +1856,7 @@ static gboolean rt_edit_masks_callback(GtkWidget *widget,
     if(grp && (grp->type & DT_MASKS_GROUP) && grp->points)
     {
       const gboolean control_button_pressed =
-        dt_modifier_is(event->state, GDK_CONTROL_MASK);
+        dt_modifier_is(dt_gdk_event_get_state(event), GDK_CONTROL_MASK);
 
       switch(bd->masks_shown)
       {

--- a/src/iop/rgbcurve.c
+++ b/src/iop/rgbcurve.c
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "common/gdk_event_utils.h"
 
 #include "bauhaus/bauhaus.h"
 #include "common/iop_profile.h"
@@ -692,7 +693,7 @@ static gboolean _area_scrolled_callback(GtkWidget *widget,
   if(dt_gui_get_scroll_delta(event, &delta_y))
   {
     delta_y *= -RGBCURVE_DEFAULT_STEP;
-    return _move_point_internal(self, widget, 0.0, delta_y, event->state);
+    return _move_point_internal(self, widget, 0.0, delta_y, dt_gdk_event_get_state(event));
   }
 
   return TRUE;
@@ -716,22 +717,22 @@ static gboolean _area_key_press_callback(GtkWidget *widget,
 
   int handled = 0;
   float dx = 0.0f, dy = 0.0f;
-  if(event->keyval == GDK_KEY_Up || event->keyval == GDK_KEY_KP_Up)
+  if(dt_gdk_event_get_keyval(event) == GDK_KEY_Up || dt_gdk_event_get_keyval(event) == GDK_KEY_KP_Up)
   {
     handled = 1;
     dy = RGBCURVE_DEFAULT_STEP;
   }
-  else if(event->keyval == GDK_KEY_Down || event->keyval == GDK_KEY_KP_Down)
+  else if(dt_gdk_event_get_keyval(event) == GDK_KEY_Down || dt_gdk_event_get_keyval(event) == GDK_KEY_KP_Down)
   {
     handled = 1;
     dy = -RGBCURVE_DEFAULT_STEP;
   }
-  else if(event->keyval == GDK_KEY_Right || event->keyval == GDK_KEY_KP_Right)
+  else if(dt_gdk_event_get_keyval(event) == GDK_KEY_Right || dt_gdk_event_get_keyval(event) == GDK_KEY_KP_Right)
   {
     handled = 1;
     dx = RGBCURVE_DEFAULT_STEP;
   }
-  else if(event->keyval == GDK_KEY_Left || event->keyval == GDK_KEY_KP_Left)
+  else if(dt_gdk_event_get_keyval(event) == GDK_KEY_Left || dt_gdk_event_get_keyval(event) == GDK_KEY_KP_Left)
   {
     handled = 1;
     dx = -RGBCURVE_DEFAULT_STEP;
@@ -740,7 +741,7 @@ static gboolean _area_key_press_callback(GtkWidget *widget,
   if(!handled) return FALSE;
 
   dt_iop_color_picker_reset(self, TRUE);
-  return _move_point_internal(self, widget, dx, dy, event->state);
+  return _move_point_internal(self, widget, dx, dy, dt_gdk_event_get_state(event));
 }
 
 #undef RGBCURVE_DEFAULT_STEP
@@ -750,7 +751,7 @@ static gboolean _area_leave_notify_callback(GtkWidget *widget,
                                             dt_iop_module_t *self)
 {
   dt_iop_rgbcurve_gui_data_t *g = self->gui_data;
-  if(!(event->state & GDK_BUTTON1_MASK))
+  if(!(dt_gdk_event_get_state(event) & GDK_BUTTON1_MASK))
     g->selected = -1;
 
   gtk_widget_queue_draw(widget);
@@ -1185,10 +1186,10 @@ static gboolean _area_motion_notify_callback(GtkWidget *widget,
     const float mx = g->mouse_x;
     const float my = g->mouse_y;
 
-    g->mouse_x = CLAMP(event->x - inset, 0, width) / (float)width;
-    g->mouse_y = 1.0 - CLAMP(event->y - inset, 0, height) / (float)height;
+    g->mouse_x = CLAMP(dt_gdk_event_get_x(event) - inset, 0, width) / (float)width;
+    g->mouse_y = 1.0 - CLAMP(dt_gdk_event_get_y(event) - inset, 0, height) / (float)height;
 
-    if(event->state & GDK_BUTTON1_MASK)
+    if(dt_gdk_event_get_state(event) & GDK_BUTTON1_MASK)
     {
       g->offset_x += (mx - g->mouse_x) / g->zoom_factor;
       g->offset_y += (my - g->mouse_y) / g->zoom_factor;
@@ -1217,15 +1218,15 @@ static gboolean _area_motion_notify_callback(GtkWidget *widget,
   const double old_m_x = g->mouse_x;
   const double old_m_y = g->mouse_y;
 
-  g->mouse_x = CLAMP(event->x - inset, 0, width) / (float)width;
-  g->mouse_y = 1.0 - CLAMP(event->y - inset, 0, height) / (float)height;
+  g->mouse_x = CLAMP(dt_gdk_event_get_x(event) - inset, 0, width) / (float)width;
+  g->mouse_y = 1.0 - CLAMP(dt_gdk_event_get_y(event) - inset, 0, height) / (float)height;
 
   const float mx = g->mouse_x;
   const float my = g->mouse_y;
   const float linx = _mouse_to_curve(mx, g->zoom_factor, g->offset_x),
               liny = _mouse_to_curve(my, g->zoom_factor, g->offset_y);
 
-  if(event->state & GDK_BUTTON1_MASK)
+  if(dt_gdk_event_get_state(event) & GDK_BUTTON1_MASK)
   {
     // got a vertex selected:
     if(g->selected >= 0)
@@ -1249,7 +1250,7 @@ static gboolean _area_motion_notify_callback(GtkWidget *widget,
                                          g->zoom_factor, g->offset_y);
 
       dt_iop_color_picker_reset(self, TRUE);
-      return _move_point_internal(self, widget, dx, dy, event->state);
+      return _move_point_internal(self, widget, dx, dy, dt_gdk_event_get_state(event));
     }
     else if(nodes < DT_IOP_RGBCURVE_MAXNODES && g->selected >= -1)
     {
@@ -1304,10 +1305,10 @@ static gboolean _area_button_press_callback(GtkWidget *widget,
   const int nodes = p->curve_num_nodes[ch];
   dt_iop_rgbcurve_node_t *curve_nodes = p->curve_nodes[ch];
 
-  if(event->button == GDK_BUTTON_PRIMARY)
+  if(dt_gdk_event_get_button(event) == GDK_BUTTON_PRIMARY)
   {
-    if(event->type == GDK_BUTTON_PRESS
-       && dt_modifier_is(event->state, GDK_CONTROL_MASK)
+    if(dt_gdk_event_get_type(event) == GDK_BUTTON_PRESS
+       && dt_modifier_is(dt_gdk_event_get_state(event), GDK_CONTROL_MASK)
        && nodes < DT_IOP_RGBCURVE_MAXNODES && g->selected == -1)
     {
       // if we are not on a node -> add a new node at the current x of
@@ -1318,8 +1319,8 @@ static gboolean _area_button_press_callback(GtkWidget *widget,
       const int width = allocation.width - 2 * inset;
       const int height = allocation.height - 2 * inset;
 
-      g->mouse_x = CLAMP(event->x - inset, 0, width) / (float)width;
-      g->mouse_y = 1.0 - CLAMP(event->y - inset, 0, height) / (float)height;
+      g->mouse_x = CLAMP(dt_gdk_event_get_x(event) - inset, 0, width) / (float)width;
+      g->mouse_y = 1.0 - CLAMP(dt_gdk_event_get_y(event) - inset, 0, height) / (float)height;
 
       const float mx = g->mouse_x;
       const float linx = _mouse_to_curve(mx, g->zoom_factor, g->offset_x);
@@ -1369,7 +1370,7 @@ static gboolean _area_button_press_callback(GtkWidget *widget,
 
       return TRUE;
     }
-    else if(event->type == GDK_2BUTTON_PRESS)
+    else if(dt_gdk_event_get_type(event) == GDK_2BUTTON_PRESS)
     {
       // reset current curve
       // if autoscale is on: allow only reset of L curve
@@ -1403,7 +1404,7 @@ static gboolean _area_button_press_callback(GtkWidget *widget,
       return TRUE;
     }
   }
-  else if(event->button == GDK_BUTTON_SECONDARY && g->selected >= 0)
+  else if(dt_gdk_event_get_button(event) == GDK_BUTTON_SECONDARY && g->selected >= 0)
   {
     if(g->selected == 0 || g->selected == nodes - 1)
     {

--- a/src/iop/rgblevels.c
+++ b/src/iop/rgblevels.c
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "common/gdk_event_utils.h"
 
 #include "common/iop_profile.h"
 #include "bauhaus/bauhaus.h"
@@ -560,16 +561,16 @@ static gboolean _area_motion_notify_callback(GtkWidget *widget,
   int height = allocation.height - 2 * inset - DT_RESIZE_HANDLE_SIZE, width = allocation.width - 2 * inset;
   if(!g->dragging)
   {
-    g->mouse_x = CLAMP(event->x - inset, 0, width);
+    g->mouse_x = CLAMP(dt_gdk_event_get_x(event) - inset, 0, width);
     g->drag_start_percentage = (p->levels[g->channel][1] - p->levels[g->channel][0]) / (p->levels[g->channel][2] - p->levels[g->channel][0]);
   }
-  g->mouse_y = CLAMP(event->y - inset, 0, height);
+  g->mouse_y = CLAMP(dt_gdk_event_get_y(event) - inset, 0, height);
 
   if(g->dragging)
   {
     if(g->handle_move >= 0 && g->handle_move < 3)
     {
-      const float mx = (CLAMP(event->x - inset, 0, width)) / (float)width;
+      const float mx = (CLAMP(dt_gdk_event_get_x(event) - inset, 0, width)) / (float)width;
 
       _rgblevels_move_handle(self, g->handle_move, mx, p->levels[g->channel], g->drag_start_percentage);
     }
@@ -577,7 +578,7 @@ static gboolean _area_motion_notify_callback(GtkWidget *widget,
   else
   {
     g->handle_move = 0;
-    const float mx = CLAMP(event->x - inset, 0, width) / (float)width;
+    const float mx = CLAMP(dt_gdk_event_get_x(event) - inset, 0, width) / (float)width;
     float dist = fabsf(p->levels[g->channel][0] - mx);
     for(int k = 1; k < 3; k++)
     {
@@ -602,11 +603,11 @@ static gboolean _area_button_press_callback(GtkWidget *widget,
                                             dt_iop_module_t *self)
 {
   // set active point
-  if(event->button == GDK_BUTTON_PRIMARY)
+  if(dt_gdk_event_get_button(event) == GDK_BUTTON_PRIMARY)
   {
     if(darktable.develop->gui_module != self) dt_iop_request_focus(self);
 
-    if(event->type == GDK_2BUTTON_PRESS)
+    if(dt_gdk_event_get_type(event) == GDK_2BUTTON_PRESS)
     {
       _turn_selregion_picker_off(self);
 
@@ -640,7 +641,7 @@ static gboolean _area_button_release_callback(GtkWidget *widget,
                                               GdkEventButton *event,
                                               dt_iop_module_t *self)
 {
-  if(event->button == GDK_BUTTON_PRIMARY)
+  if(dt_gdk_event_get_button(event) == GDK_BUTTON_PRIMARY)
   {
     dt_iop_rgblevels_gui_data_t *g = self->gui_data;
     g->dragging = 0;
@@ -667,7 +668,7 @@ static gboolean _area_scroll_callback(GtkWidget *widget,
 
   if(darktable.develop->gui_module != self) dt_iop_request_focus(self);
 
-  const float interval = 0.002 * dt_accel_get_speed_multiplier(widget, event->state);
+  const float interval = 0.002 * dt_accel_get_speed_multiplier(widget, dt_gdk_event_get_state(event));
   // Distance moved for each scroll event
   int delta_y;
   if(dt_gui_get_scroll_unit_delta(event, &delta_y))

--- a/src/iop/tonecurve.c
+++ b/src/iop/tonecurve.c
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "common/gdk_event_utils.h"
 #include <assert.h>
 #include <math.h>
 #include <stdint.h>
@@ -1181,7 +1182,7 @@ static gboolean _scrolled(GtkWidget *widget,
   if(dt_gui_get_scroll_delta(event, &delta_y))
   {
     delta_y *= -TONECURVE_DEFAULT_STEP;
-    return _move_point_internal(self, widget, 0.0, delta_y, event->state);
+    return _move_point_internal(self, widget, 0.0, delta_y, dt_gdk_event_get_state(event));
   }
 
   return TRUE;
@@ -1206,22 +1207,22 @@ static gboolean dt_iop_tonecurve_key_press(GtkWidget *widget,
   int handled = 0;
   float dx = 0.0f, dy = 0.0f;
 
-  if(event->keyval == GDK_KEY_Up || event->keyval == GDK_KEY_KP_Up)
+  if(dt_gdk_event_get_keyval(event) == GDK_KEY_Up || dt_gdk_event_get_keyval(event) == GDK_KEY_KP_Up)
   {
     handled = 1;
     dy = TONECURVE_DEFAULT_STEP;
   }
-  else if(event->keyval == GDK_KEY_Down || event->keyval == GDK_KEY_KP_Down)
+  else if(dt_gdk_event_get_keyval(event) == GDK_KEY_Down || dt_gdk_event_get_keyval(event) == GDK_KEY_KP_Down)
   {
     handled = 1;
     dy = -TONECURVE_DEFAULT_STEP;
   }
-  else if(event->keyval == GDK_KEY_Right || event->keyval == GDK_KEY_KP_Right)
+  else if(dt_gdk_event_get_keyval(event) == GDK_KEY_Right || dt_gdk_event_get_keyval(event) == GDK_KEY_KP_Right)
   {
     handled = 1;
     dx = TONECURVE_DEFAULT_STEP;
   }
-  else if(event->keyval == GDK_KEY_Left || event->keyval == GDK_KEY_KP_Left)
+  else if(dt_gdk_event_get_keyval(event) == GDK_KEY_Left || dt_gdk_event_get_keyval(event) == GDK_KEY_KP_Left)
   {
     handled = 1;
     dx = -TONECURVE_DEFAULT_STEP;
@@ -1229,7 +1230,7 @@ static gboolean dt_iop_tonecurve_key_press(GtkWidget *widget,
 
   if(!handled) return FALSE;
 
-  return _move_point_internal(self, widget, dx, dy, event->state);
+  return _move_point_internal(self, widget, dx, dy, dt_gdk_event_get_state(event));
 }
 
 #undef TONECURVE_DEFAULT_STEP
@@ -1348,7 +1349,7 @@ static gboolean dt_iop_tonecurve_leave_notify(GtkWidget *widget,
                                               dt_iop_module_t *self)
 {
   dt_iop_tonecurve_gui_data_t *g = self->gui_data;
-  if(!(event->state & GDK_BUTTON1_MASK))
+  if(!(dt_gdk_event_get_state(event) & GDK_BUTTON1_MASK))
     g->selected = -1;
   gtk_widget_queue_draw(widget);
   return FALSE;
@@ -1772,15 +1773,15 @@ static gboolean dt_iop_tonecurve_motion_notify(GtkWidget *widget,
   int height = allocation.height - 2 * inset, width = allocation.width - 2 * inset;
   double old_m_x = g->mouse_x;
   double old_m_y = g->mouse_y;
-  g->mouse_x = event->x - inset;
-  g->mouse_y = event->y - inset;
+  g->mouse_x = dt_gdk_event_get_x(event) - inset;
+  g->mouse_y = dt_gdk_event_get_y(event) - inset;
 
   const float mx = CLAMP(g->mouse_x, 0, width) / width;
   const float my = 1.0f - CLAMP(g->mouse_y, 0, height) / height;
   const float linx = to_lin(mx, g->loglogscale, ch, g->semilog, 0),
               liny = to_lin(my, g->loglogscale, ch, g->semilog, 1);
 
-  if(event->state & GDK_BUTTON1_MASK)
+  if(dt_gdk_event_get_state(event) & GDK_BUTTON1_MASK)
   {
     // got a vertex selected:
     if(g->selected >= 0)
@@ -1794,7 +1795,7 @@ static gboolean dt_iop_tonecurve_motion_notify(GtkWidget *widget,
                        - to_lin(old_m_x / width - translate_mouse_x, g->loglogscale, ch, g->semilog, 0);
       const float dy = to_lin(1 - g->mouse_y / height - translate_mouse_y, g->loglogscale, ch, g->semilog, 1)
                        - to_lin(1 - old_m_y / height - translate_mouse_y, g->loglogscale, ch, g->semilog, 1);
-      return _move_point_internal(self, widget, dx, dy, event->state);
+      return _move_point_internal(self, widget, dx, dy, dt_gdk_event_get_state(event));
     }
     else if(nodes < DT_IOP_TONECURVE_MAXNODES && g->selected >= -1)
     {
@@ -1841,10 +1842,10 @@ static gboolean dt_iop_tonecurve_button_press(GtkWidget *widget,
   int nodes = p->tonecurve_nodes[ch];
   dt_iop_tonecurve_node_t *tonecurve = p->tonecurve[ch];
 
-  if(event->button == GDK_BUTTON_PRIMARY)
+  if(dt_gdk_event_get_button(event) == GDK_BUTTON_PRIMARY)
   {
-    if(event->type == GDK_BUTTON_PRESS
-       && dt_modifier_is(event->state, GDK_CONTROL_MASK)
+    if(dt_gdk_event_get_type(event) == GDK_BUTTON_PRESS
+       && dt_modifier_is(dt_gdk_event_get_state(event), GDK_CONTROL_MASK)
        && nodes < DT_IOP_TONECURVE_MAXNODES
        && g->selected == -1)
     {
@@ -1854,8 +1855,8 @@ static gboolean dt_iop_tonecurve_button_press(GtkWidget *widget,
       GtkAllocation allocation;
       gtk_widget_get_allocation(widget, &allocation);
       int width = allocation.width - 2 * inset;
-      g->mouse_x = event->x - inset;
-      g->mouse_y = event->y - inset;
+      g->mouse_x = dt_gdk_event_get_x(event) - inset;
+      g->mouse_y = dt_gdk_event_get_y(event) - inset;
 
       const float mx = CLAMP(g->mouse_x, 0, width) / (float)width;
       const float linx = to_lin(mx, g->loglogscale, ch, g->semilog, 0);
@@ -1905,7 +1906,7 @@ static gboolean dt_iop_tonecurve_button_press(GtkWidget *widget,
       }
       return TRUE;
     }
-    else if(event->type == GDK_2BUTTON_PRESS)
+    else if(dt_gdk_event_get_type(event) == GDK_2BUTTON_PRESS)
     {
       // reset current curve
       // if autoscale_ab is on: allow only reset of L curve
@@ -1937,7 +1938,7 @@ static gboolean dt_iop_tonecurve_button_press(GtkWidget *widget,
       return TRUE;
     }
   }
-  else if(event->button == GDK_BUTTON_SECONDARY && g->selected >= 0)
+  else if(dt_gdk_event_get_button(event) == GDK_BUTTON_SECONDARY && g->selected >= 0)
   {
     if(g->selected == 0 || g->selected == nodes - 1)
     {

--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "common/gdk_event_utils.h"
 
 /*** DOCUMENTATION
  *
@@ -2959,8 +2960,8 @@ static gboolean area_enter_leave_notify(GtkWidget *widget,
     dt_dev_add_history_item(darktable.develop, self, FALSE);
   }
   dt_iop_gui_enter_critical_section(self);
-  g->area_x = (event->x - g->inset);
-  g->area_y = (event->y - g->inset);
+  g->area_x = (dt_gdk_event_get_x(event) - g->inset);
+  g->area_y = (dt_gdk_event_get_y(event) - g->inset);
   g->area_dragging = FALSE;
   g->area_active_node = -1;
   g->area_cursor_valid = (g->area_x > 0.0f
@@ -2985,7 +2986,7 @@ static gboolean area_button_press(GtkWidget *widget,
 
   dt_iop_request_focus(self);
 
-  if(event->button == GDK_BUTTON_PRIMARY && event->type == GDK_2BUTTON_PRESS)
+  if(dt_gdk_event_get_button(event) == GDK_BUTTON_PRIMARY && dt_gdk_event_get_type(event) == GDK_2BUTTON_PRESS)
   {
     dt_iop_toneequalizer_params_t *p = self->params;
     const dt_iop_toneequalizer_params_t *const d = self->default_params;
@@ -3009,7 +3010,7 @@ static gboolean area_button_press(GtkWidget *widget,
     dt_dev_add_history_item(darktable.develop, self, TRUE);
     return TRUE;
   }
-  else if(event->button == GDK_BUTTON_PRIMARY)
+  else if(dt_gdk_event_get_button(event) == GDK_BUTTON_PRIMARY)
   {
     if(self->enabled)
     {
@@ -3045,7 +3046,7 @@ static gboolean area_motion_notify(GtkWidget *widget,
     // vertical distance travelled since button_pressed event
     dt_iop_gui_enter_critical_section(self);
     // graph spans over 4 EV
-    const float offset = (-event->y + g->area_y) / g->graph_height * 4.0f;
+    const float offset = (-dt_gdk_event_get_y(event) + g->area_y) / g->graph_height * 4.0f;
     const float cursor_exposure = g->area_x / g->graph_width * 8.0f - 8.0f;
 
     // Get the desired correction on exposure channels
@@ -3055,8 +3056,8 @@ static gboolean area_motion_notify(GtkWidget *widget,
   }
 
   dt_iop_gui_enter_critical_section(self);
-  g->area_x = event->x - g->inset;
-  g->area_y = event->y;
+  g->area_x = dt_gdk_event_get_x(event) - g->inset;
+  g->area_y = dt_gdk_event_get_y(event);
   g->area_cursor_valid = (g->area_x > 0.0f
                           && g->area_x < g->graph_width
                           && g->area_y > 0.0f
@@ -3096,7 +3097,7 @@ static gboolean area_button_release(GtkWidget *widget,
   // Give focus to module
   dt_iop_request_focus(self);
 
-  if(event->button == GDK_BUTTON_PRIMARY)
+  if(dt_gdk_event_get_button(event) == GDK_BUTTON_PRIMARY)
   {
     const dt_iop_toneequalizer_params_t *p = self->params;
 

--- a/src/iop/zonesystem.c
+++ b/src/iop/zonesystem.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2010-2024 darktable developers.
+    Copyright (C) 2010-2026 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "common/gdk_event_utils.h"
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>
@@ -591,7 +592,7 @@ static gboolean dt_iop_zonesystem_bar_button_press(GtkWidget *widget, GdkEventBu
   if((g->mouse_x / width) > zonemap[k] + (zw / 2)) k++;
 
 
-  if(event->button == GDK_BUTTON_PRIMARY)
+  if(dt_gdk_event_get_button(event) == GDK_BUTTON_PRIMARY)
   {
     if(p->zone[k] == -1)
     {
@@ -601,7 +602,7 @@ static gboolean dt_iop_zonesystem_bar_button_press(GtkWidget *widget, GdkEventBu
     g->is_dragging = TRUE;
     g->current_zone = k;
   }
-  else if(event->button == GDK_BUTTON_SECONDARY)
+  else if(dt_gdk_event_get_button(event) == GDK_BUTTON_SECONDARY)
   {
     /* clear the controlpoint */
     p->zone[k] = -1;
@@ -615,7 +616,7 @@ static gboolean dt_iop_zonesystem_bar_button_release(GtkWidget *widget, GdkEvent
                                                      dt_iop_module_t *self)
 {
   dt_iop_zonesystem_gui_data_t *g = self->gui_data;
-  if(event->button == GDK_BUTTON_PRIMARY)
+  if(dt_gdk_event_get_button(event) == GDK_BUTTON_PRIMARY)
   {
     g->is_dragging = FALSE;
   }
@@ -665,8 +666,8 @@ static gboolean dt_iop_zonesystem_bar_motion_notify(GtkWidget *widget, GdkEventM
   _iop_zonesystem_calculate_zonemap(p, zonemap);
 
   /* record mouse position within control */
-  g->mouse_x = CLAMP(event->x - inset, 0, width);
-  g->mouse_y = CLAMP(height - 1 - event->y + inset, 0, height);
+  g->mouse_x = CLAMP(dt_gdk_event_get_x(event) - inset, 0, width);
+  g->mouse_y = CLAMP(height - 1 - dt_gdk_event_get_y(event) + inset, 0, height);
 
   if(g->is_dragging)
   {

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "common/gdk_event_utils.h"
 
 #include "libs/collect.h"
 #include "bauhaus/bauhaus.h"
@@ -638,24 +639,24 @@ static gboolean view_onButtonPressed(GtkWidget *treeview,
   /* Get tree path for row that was clicked */
   GtkTreePath *path = NULL;
   const gboolean get_path = gtk_tree_view_get_path_at_pos(GTK_TREE_VIEW(treeview),
-                                                          (gint)event->x, (gint)event->y,
+                                                          (gint)dt_gdk_event_get_x(event), (gint)dt_gdk_event_get_y(event),
                                                           &path, NULL, NULL, NULL);
 
-  if(event->type == GDK_DOUBLE_BUTTON_PRESS || d->singleclick)
+  if(dt_gdk_event_get_type(event) == GDK_DOUBLE_BUTTON_PRESS || d->singleclick)
   {
-    if(event->state == last_state && path)
+    if(dt_gdk_event_get_state(event) == last_state && path)
     {
       if(gtk_tree_view_row_expanded(GTK_TREE_VIEW(treeview), path))
         gtk_tree_view_collapse_row(GTK_TREE_VIEW(treeview), path);
       else
         gtk_tree_view_expand_row(GTK_TREE_VIEW(treeview), path, FALSE);
     }
-    last_state = event->state;
+    last_state = dt_gdk_event_get_state(event);
   }
 
   // case of a range selection
   GtkTreeSelection *selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(treeview));
-  if(get_path && dt_modifier_is(event->state, GDK_SHIFT_MASK)
+  if(get_path && dt_modifier_is(dt_gdk_event_get_state(event), GDK_SHIFT_MASK)
      && gtk_tree_selection_count_selected_rows(selection) > 0
      && (d->view_rule == DT_COLLECTION_PROP_DAY
          || d->view_rule == DT_COLLECTION_PROP_MONTH
@@ -692,9 +693,9 @@ static gboolean view_onButtonPressed(GtkWidget *treeview,
   // case of a context-menu (folder/filmroll)
   if(((d->view_rule == DT_COLLECTION_PROP_FOLDERS)
       || (d->view_rule == DT_COLLECTION_PROP_FILMROLL))
-     && (event->type == GDK_BUTTON_PRESS && event->button == GDK_BUTTON_SECONDARY)
-     && !(dt_modifier_is(event->state, GDK_SHIFT_MASK)
-          || dt_modifier_is(event->state, GDK_CONTROL_MASK)))
+     && (dt_gdk_event_get_type(event) == GDK_BUTTON_PRESS && dt_gdk_event_get_button(event) == GDK_BUTTON_SECONDARY)
+     && !(dt_modifier_is(dt_gdk_event_get_state(event), GDK_SHIFT_MASK)
+          || dt_modifier_is(dt_gdk_event_get_state(event), GDK_CONTROL_MASK)))
   {
     row_activated_with_event(GTK_TREE_VIEW(treeview), path, NULL, event, d);
     view_popup_menu(treeview, event, d);
@@ -704,13 +705,13 @@ static gboolean view_onButtonPressed(GtkWidget *treeview,
   }
 
   // case of a activation
-  if((!d->singleclick && event->type == GDK_2BUTTON_PRESS && event->button == GDK_BUTTON_PRIMARY)
-     || (d->singleclick && event->type == GDK_BUTTON_PRESS && event->button == GDK_BUTTON_PRIMARY)
-     || (!d->singleclick && event->type == GDK_BUTTON_PRESS && event->button == GDK_BUTTON_PRIMARY
-         && (dt_modifier_is(event->state, GDK_SHIFT_MASK)
-             || dt_modifier_is(event->state, GDK_CONTROL_MASK)))
+  if((!d->singleclick && dt_gdk_event_get_type(event) == GDK_2BUTTON_PRESS && dt_gdk_event_get_button(event) == GDK_BUTTON_PRIMARY)
+     || (d->singleclick && dt_gdk_event_get_type(event) == GDK_BUTTON_PRESS && dt_gdk_event_get_button(event) == GDK_BUTTON_PRIMARY)
+     || (!d->singleclick && dt_gdk_event_get_type(event) == GDK_BUTTON_PRESS && dt_gdk_event_get_button(event) == GDK_BUTTON_PRIMARY
+         && (dt_modifier_is(dt_gdk_event_get_state(event), GDK_SHIFT_MASK)
+             || dt_modifier_is(dt_gdk_event_get_state(event), GDK_CONTROL_MASK)))
      || (d->view_rule == DT_COLLECTION_PROP_MONTH
-         && event->type == GDK_BUTTON_PRESS && event->button == GDK_BUTTON_PRIMARY))
+         && dt_gdk_event_get_type(event) == GDK_BUTTON_PRESS && dt_gdk_event_get_button(event) == GDK_BUTTON_PRIMARY))
   {
     row_activated_with_event(GTK_TREE_VIEW(treeview), path, NULL, event, d);
 
@@ -3063,7 +3064,7 @@ static void row_activated_with_event(GtkTreeView *view,
 
   if(text && strlen(text) > 0)
   {
-    if(dt_modifier_is(event->state, GDK_SHIFT_MASK | GDK_CONTROL_MASK))
+    if(dt_modifier_is(dt_gdk_event_get_state(event), GDK_SHIFT_MASK | GDK_CONTROL_MASK))
     {
       if(item == DT_COLLECTION_PROP_FILMROLL)
       {
@@ -3115,7 +3116,7 @@ static void row_activated_with_event(GtkTreeView *view,
       {
         /* if a tag has children, ctrl-clicking on a parent node
          * should display all images under this hierarchy. */
-        if(dt_modifier_is(event->state, GDK_CONTROL_MASK))
+        if(dt_modifier_is(dt_gdk_event_get_state(event), GDK_CONTROL_MASK))
         {
           gchar *n_text = g_strconcat(text, "|%", NULL);
           g_free(text);
@@ -3123,7 +3124,7 @@ static void row_activated_with_event(GtkTreeView *view,
         }
         /* if a tag has children, left-clicking on a parent node
          * should display all images in and under this hierarchy. */
-        else if(!dt_modifier_is(event->state, GDK_SHIFT_MASK))
+        else if(!dt_modifier_is(dt_gdk_event_get_state(event), GDK_SHIFT_MASK))
         {
           gchar *n_text = g_strconcat(text, "*", NULL);
           g_free(text);
@@ -3593,7 +3594,7 @@ static gboolean popup_button_callback(GtkWidget *widget,
                                       GdkEventButton *event,
                                       dt_lib_collect_rule_t *d)
 {
-  if(event->button != 1)
+  if(dt_gdk_event_get_button(event) != 1)
     return FALSE;
 
   GtkWidget *menu = gtk_menu_new();

--- a/src/libs/colorpicker.c
+++ b/src/libs/colorpicker.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2011-2025 darktable developers.
+    Copyright (C) 2011-2026 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "common/gdk_event_utils.h"
 
 #include "bauhaus/bauhaus.h"
 #include "libs/colorpicker.h"
@@ -524,12 +525,12 @@ static gboolean _live_sample_button(GtkWidget *widget,
                                     GdkEventButton *event,
                                     dt_colorpicker_sample_t *sample)
 {
-  if(event->button == GDK_BUTTON_PRIMARY)
+  if(dt_gdk_event_get_button(event) == GDK_BUTTON_PRIMARY)
   {
     sample->locked = !sample->locked;
     gtk_widget_queue_draw(widget);
   }
-  else if(event->button == GDK_BUTTON_SECONDARY)
+  else if(dt_gdk_event_get_button(event) == GDK_BUTTON_SECONDARY)
   {
     // copy to active picker
     dt_lib_module_t *self = darktable.lib->proxy.colorpicker.module;

--- a/src/libs/duplicate.c
+++ b/src/libs/duplicate.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2015-2025 darktable developers.
+    Copyright (C) 2015-2026 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "common/gdk_event_utils.h"
 
 #include "common/collection.h"
 #include "common/darktable.h"
@@ -183,14 +184,14 @@ static gboolean _lib_duplicate_thumb_press_callback(GtkWidget *widget,
   dt_thumbnail_t *thumb = (dt_thumbnail_t *)g_object_get_data(G_OBJECT(widget), "thumb");
   const dt_imgid_t imgid = thumb->imgid;
 
-  if(event->button == GDK_BUTTON_PRIMARY)
+  if(dt_gdk_event_get_button(event) == GDK_BUTTON_PRIMARY)
   {
-    if(event->type == GDK_BUTTON_PRESS)
+    if(dt_gdk_event_get_type(event) == GDK_BUTTON_PRESS)
     {
       d->imgid = imgid;
       dt_control_queue_redraw_center();
     }
-    else if(event->type == GDK_2BUTTON_PRESS)
+    else if(dt_gdk_event_get_type(event) == GDK_2BUTTON_PRESS)
     {
       // let's switch to the new image
       DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_VIEWMANAGER_THUMBTABLE_ACTIVATE, imgid);

--- a/src/libs/export.c
+++ b/src/libs/export.c
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "common/gdk_event_utils.h"
 
 #include "bauhaus/bauhaus.h"
 #include "common/collection.h"
@@ -570,7 +571,7 @@ static gboolean _scale_mdlclick(GtkEntry *spin,
                                 GdkEventButton *event,
                                 dt_lib_export_t *d)
 {
-  if(event->button == GDK_BUTTON_MIDDLE)
+  if(dt_gdk_event_get_button(event) == GDK_BUTTON_MIDDLE)
   {
     dt_conf_set_string(CONFIG_PREFIX "resizing_factor", "1");
     g_signal_handlers_block_by_func(spin, _scale_changed, d);
@@ -588,7 +589,7 @@ static gboolean _widht_mdlclick(GtkEntry *spin,
                                 GdkEventButton *event,
                                 gpointer user_data)
 {
-  if(event->button == GDK_BUTTON_MIDDLE)
+  if(dt_gdk_event_get_button(event) == GDK_BUTTON_MIDDLE)
   {
     dt_conf_set_int(CONFIG_PREFIX "width", 0);
     g_signal_handlers_block_by_func(spin, _width_changed, user_data);
@@ -607,7 +608,7 @@ static gboolean _height_mdlclick(GtkEntry *spin,
                                  GdkEventButton *event,
                                  gpointer user_data)
 {
-  if(event->button == GDK_BUTTON_MIDDLE)
+  if(dt_gdk_event_get_button(event) == GDK_BUTTON_MIDDLE)
   {
     dt_conf_set_int(CONFIG_PREFIX "height", 0);
     g_signal_handlers_block_by_func(spin, _height_changed, user_data);
@@ -1188,7 +1189,7 @@ static void _apply_style_activate_callback(GtkMenuItem *menuitem,
                                            const dt_stylemenu_data_t *menu_data)
 {
   GdkEvent *event = gtk_get_current_event();
-  if(event && event->type == GDK_KEY_PRESS)
+  if(event && dt_gdk_event_get_type(event) == GDK_KEY_PRESS)
   {
     _update_style(menu_data);
   }
@@ -1199,7 +1200,7 @@ static gboolean _apply_style_button_callback(GtkMenuItem *menuitem,
                                              GdkEventButton *event,
                                              const dt_stylemenu_data_t *menu_data)
 {
-  if(event->button == GDK_BUTTON_PRIMARY)
+  if(dt_gdk_event_get_button(event) == GDK_BUTTON_PRIMARY)
   {
     _update_style(menu_data);
   }

--- a/src/libs/export_metadata.c
+++ b/src/libs/export_metadata.c
@@ -16,6 +16,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "common/gdk_event_utils.h"
 #include "common/darktable.h"
 #include "dtgtk/button.h"
 #include "gui/gtk.h"
@@ -131,7 +132,7 @@ static void _delete_tag_button_clicked(GtkButton *button, dt_lib_export_metadata
 
 static gboolean _key_press_on_list(GtkWidget *widget, GdkEventKey *event, dt_lib_export_metadata_t *d)
 {
-  if(event->type == GDK_KEY_PRESS && event->keyval == GDK_KEY_Delete && !event->state)
+  if(dt_gdk_event_get_type(event) == GDK_KEY_PRESS && dt_gdk_event_get_keyval(event) == GDK_KEY_Delete && !dt_gdk_event_get_state(event))
   {
     _remove_tag_from_list(d);
     return TRUE;

--- a/src/libs/geotagging.c
+++ b/src/libs/geotagging.c
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "common/gdk_event_utils.h"
 
 #include "common/debug.h"
 #include "common/file_location.h"
@@ -564,7 +565,7 @@ static void _refresh_display_all_tracks(GtkWidget *widget, dt_lib_module_t *self
 
 static gboolean _click_for_entire_track(GtkEntry *spin, GdkEventButton *event, dt_lib_module_t *self)
 {
-  if(event->button == GDK_BUTTON_PRIMARY && event->type == GDK_2BUTTON_PRESS)
+  if(dt_gdk_event_get_button(event) == GDK_BUTTON_PRIMARY && dt_gdk_event_get_type(event) == GDK_2BUTTON_PRESS)
   {
     _refresh_display_all_tracks(NULL, self);
   }
@@ -1567,7 +1568,7 @@ static GtkWidget *_gui_init_datetime(gchar *text,
 static gboolean _datetime_key_pressed(GtkWidget *entry, GdkEventKey *event, dt_lib_module_t *self)
 {
   dt_lib_geotagging_t *d = self->data;
-  switch(event->keyval)
+  switch(dt_gdk_event_get_keyval(event))
   {
     case GDK_KEY_Escape:
     {
@@ -1656,7 +1657,7 @@ static void _timezone_save(dt_lib_module_t *self)
 
 static gboolean _timezone_key_pressed(GtkWidget *entry, GdkEventKey *event, dt_lib_module_t *self)
 {
-  switch(event->keyval)
+  switch(dt_gdk_event_get_keyval(event))
   {
     case GDK_KEY_Return:
     case GDK_KEY_KP_Enter:

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "common/gdk_event_utils.h"
 
 #include "common/darktable.h"
 #include "common/color_picker.h"
@@ -350,7 +351,7 @@ static void _drawable_drag_update(GtkGestureDrag* gesture,
     const gdouble ox = offset_x - s->last_offset_x;
     const gdouble oy = offset_y - s->last_offset_y;
     const double delta = dt_scopes_call(cur_mode, get_exposure_delta, ox, oy);
-    dt_dev_exposure_handle_event(1, delta, event->motion.state,
+    dt_dev_exposure_handle_event(1, delta, dt_gdk_event_get_state(event),
                                  s->highlight == DT_SCOPES_HIGHLIGHT_BLACK_POINT);
     s->last_offset_x = offset_x;
     s->last_offset_y = offset_y;
@@ -490,7 +491,7 @@ static void _eventbox_scroll_callback(GtkEventControllerScroll* self,
     // FIXME: so long as we have event, test its flags -- and for GTK 4 we can
     // use gtk_get_current_event() and get flags -- make a helper function to do
     // this.
-    if(dt_modifier_is(event->scroll.state,
+    if(dt_modifier_is(dt_gdk_event_get_state(event),
                       GDK_SHIFT_MASK | GDK_MOD1_MASK))
     {
       // bubble to adjusting the overall widget size
@@ -512,16 +513,16 @@ static void _eventbox_scroll_callback(GtkEventControllerScroll* self,
       // dt_dev_exposure_handle_event requires 'delta' in the 'brighten' > 0 convention, that is also what
       // drag events emit
 
-      dt_dev_exposure_handle_event(0, - delta, event->scroll.state,
+      dt_dev_exposure_handle_event(0, - delta, dt_gdk_event_get_state(event),
                                    s->highlight == DT_SCOPES_HIGHLIGHT_BLACK_POINT);
     }
     else
     {
       int ebx, eby;
       gtk_widget_translate_coordinates(gtk_get_event_widget(event), s->scope_draw,
-                                       (int)event->scroll.x, (int)event->scroll.y, &ebx, &eby);
+                                       (int)dt_gdk_event_get_x(event), (int)dt_gdk_event_get_y(event), &ebx, &eby);
       dt_scopes_call_if_exists(s->cur_mode, eventbox_scroll, ebx, eby,
-                               dx, dy, event->scroll.state);
+                               dx, dy, dt_gdk_event_get_state(event));
     }
   }
   gdk_event_free(event);

--- a/src/libs/import.c
+++ b/src/libs/import.c
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "common/gdk_event_utils.h"
 
 #include "common/collection.h"
 #include "common/darktable.h"
@@ -562,13 +563,13 @@ static gboolean _files_button_press(GtkWidget *view,
                                     dt_lib_module_t *self)
 {
   dt_lib_import_t *d = self->data;
-  if((event->type == GDK_BUTTON_PRESS && event->button == GDK_BUTTON_PRIMARY))
+  if((dt_gdk_event_get_type(event) == GDK_BUTTON_PRESS && dt_gdk_event_get_button(event) == GDK_BUTTON_PRIMARY))
   {
     GtkTreePath *path = NULL;
     GtkTreeViewColumn *column = NULL;
     // Get tree path for row that was clicked
     if(gtk_tree_view_get_path_at_pos(GTK_TREE_VIEW(view),
-                                     (gint)event->x, (gint)event->y,
+                                     (gint)dt_gdk_event_get_x(event), (gint)dt_gdk_event_get_y(event),
                                      &path, &column, NULL, NULL))
     {
       if(column == d->from.pixcol)
@@ -585,12 +586,12 @@ static gboolean _files_button_press(GtkWidget *view,
     }
     gtk_tree_path_free(path);
   }
-  else if((event->type == GDK_2BUTTON_PRESS && event->button == GDK_BUTTON_PRIMARY))
+  else if((dt_gdk_event_get_type(event) == GDK_2BUTTON_PRESS && dt_gdk_event_get_button(event) == GDK_BUTTON_PRIMARY))
   {
     GtkTreePath *path = NULL;
     // Get tree path for row that was clicked
     if(gtk_tree_view_get_path_at_pos(GTK_TREE_VIEW(view),
-                                     (gint)event->x, (gint)event->y,
+                                     (gint)dt_gdk_event_get_x(event), (gint)dt_gdk_event_get_y(event),
                                      &path, NULL, NULL, NULL))
     {
       GtkTreeSelection *selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(view));
@@ -1270,7 +1271,7 @@ static gboolean _places_button_press(GtkWidget *view,
   gboolean res = FALSE;
   GtkTreePath *path = NULL;
   if(gtk_tree_view_get_path_at_pos(GTK_TREE_VIEW(view),
-                                   (gint)event->x, (gint)event->y, &path, NULL, NULL, NULL))
+                                   (gint)dt_gdk_event_get_x(event), (gint)dt_gdk_event_get_y(event), &path, NULL, NULL, NULL))
   {
     GtkTreeModel *model = gtk_tree_view_get_model(GTK_TREE_VIEW(view));
     GtkTreeIter iter;
@@ -1279,7 +1280,7 @@ static gboolean _places_button_press(GtkWidget *view,
     char *folder_name, *folder_path;
     gtk_tree_model_get(model, &iter, 0, &folder_name, 1, &folder_path, -1);
 
-    const int button_pressed = (event->type == GDK_BUTTON_PRESS) ? event->button : 0;
+    const int button_pressed = (dt_gdk_event_get_type(event) == GDK_BUTTON_PRESS) ? dt_gdk_event_get_button(event) : 0;
 
     // left-click: set as new root
     if(button_pressed == GDK_BUTTON_PRIMARY)
@@ -1309,21 +1310,21 @@ static gboolean _folders_button_press(GtkWidget *view,
 {
   dt_lib_import_t *d = self->data;
   gboolean res = FALSE;
-  const int button_pressed = (event->type == GDK_BUTTON_PRESS) ? event->button : 0;
-  const gboolean modifier = dt_modifier_is(event->state, GDK_SHIFT_MASK | GDK_CONTROL_MASK);
+  const int button_pressed = (dt_gdk_event_get_type(event) == GDK_BUTTON_PRESS) ? dt_gdk_event_get_button(event) : 0;
+  const gboolean modifier = dt_modifier_is(dt_gdk_event_get_state(event), GDK_SHIFT_MASK | GDK_CONTROL_MASK);
   if((button_pressed == GDK_BUTTON_PRIMARY) && !modifier)
   {
     GtkTreePath *path = NULL;
     if(gtk_tree_view_get_path_at_pos(GTK_TREE_VIEW(view),
-                                     event->x, event->y, &path, NULL, NULL, NULL))
+                                     dt_gdk_event_get_x(event), dt_gdk_event_get_y(event), &path, NULL, NULL, NULL))
     {
       GdkRectangle rect;
       gtk_tree_view_get_cell_area(GTK_TREE_VIEW(view), path, d->from.foldercol, &rect);
       const gboolean blank = gtk_tree_view_is_blank_at_pos(GTK_TREE_VIEW(view),
-                                                           event->x, event->y,
+                                                           dt_gdk_event_get_x(event), dt_gdk_event_get_y(event),
                                                            NULL, NULL, NULL, NULL);
       // select and save new folder only if not click on expander
-      if(blank || (event->x > rect.x))
+      if(blank || (dt_gdk_event_get_x(event) > rect.x))
       {
         GtkTreeSelection *selection = gtk_tree_view_get_selection(d->from.folderview);
         gtk_tree_selection_select_path(selection, path);
@@ -1342,11 +1343,11 @@ static gboolean _folders_button_press(GtkWidget *view,
     gtk_tree_path_free(path);
   }
 
-  if(event->type == GDK_DOUBLE_BUTTON_PRESS)
+  if(dt_gdk_event_get_type(event) == GDK_DOUBLE_BUTTON_PRESS)
   {
     GtkTreePath *path = NULL;
     gtk_tree_view_get_path_at_pos(GTK_TREE_VIEW(view),
-                                  event->x, event->y, &path, NULL, NULL, NULL);
+                                  dt_gdk_event_get_x(event), dt_gdk_event_get_y(event), &path, NULL, NULL, NULL);
     if(gtk_tree_view_row_expanded(d->from.folderview, path))
       gtk_tree_view_collapse_row (d->from.folderview, path);
     else

--- a/src/libs/lib.c
+++ b/src/libs/lib.c
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "common/gdk_event_utils.h"
 
 #include "libs/lib.h"
 #include "common/debug.h"
@@ -452,7 +453,7 @@ static gboolean _menuitem_button_preset(GtkMenuItem *menuitem,
                                         GdkEventButton *event,
                                         dt_lib_module_info_t *minfo)
 {
-  if(event->button == GDK_BUTTON_PRIMARY) return FALSE;
+  if(dt_gdk_event_get_button(event) == GDK_BUTTON_PRIMARY) return FALSE;
 
   dt_shortcut_copy_lua((dt_action_t*)minfo->module,
                         g_object_get_data(G_OBJECT(menuitem), "dt-preset-name"));
@@ -1750,7 +1751,7 @@ gboolean dt_handle_dialog_enter(GtkWidget *widget,
                                 GdkEventKey *event,
                                 gpointer data)
 {
-  if(event->keyval == GDK_KEY_Return || event->keyval == GDK_KEY_KP_Enter)
+  if(dt_gdk_event_get_keyval(event) == GDK_KEY_Return || dt_gdk_event_get_keyval(event) == GDK_KEY_KP_Enter)
   {
     gtk_dialog_response(GTK_DIALOG(widget), GTK_RESPONSE_ACCEPT);
     return TRUE;

--- a/src/libs/location.c
+++ b/src/libs/location.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2011-2024 darktable developers.
+    Copyright (C) 2011-2026 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "common/gdk_event_utils.h"
 
 #include "common/darktable.h"
 #include "common/geo.h"
@@ -159,7 +160,7 @@ static gboolean _event_box_enter_leave(GtkWidget *widget,
                                        GdkEventCrossing *event,
                                        gpointer user_data)
 {
-  if(event->type == GDK_ENTER_NOTIFY)
+  if(dt_gdk_event_get_type(event) == GDK_ENTER_NOTIFY)
     gtk_widget_set_state_flags(widget, GTK_STATE_FLAG_PRELIGHT, FALSE);
   else
     gtk_widget_unset_state_flags(widget, GTK_STATE_FLAG_PRELIGHT);

--- a/src/libs/map_locations.c
+++ b/src/libs/map_locations.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2012-2022 darktable developers.
+    Copyright (C) 2012-2026 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "common/gdk_event_utils.h"
 #include "common/collection.h"
 #include "common/debug.h"
 #include "common/map_locations.h"
@@ -842,15 +843,15 @@ static gboolean _click_on_view(GtkWidget *view, GdkEventButton *event, dt_lib_mo
     return TRUE;
   }
 
-  const int button_pressed = (event->type == GDK_BUTTON_PRESS) ? event->button : 0;
-  const gboolean ctrl_pressed = dt_modifier_is(event->state, GDK_CONTROL_MASK);
+  const int button_pressed = (dt_gdk_event_get_type(event) == GDK_BUTTON_PRESS) ? dt_gdk_event_get_button(event) : 0;
+  const gboolean ctrl_pressed = dt_modifier_is(dt_gdk_event_get_state(event), GDK_CONTROL_MASK);
   if(button_pressed == GDK_BUTTON_SECONDARY || button_pressed == GDK_BUTTON_PRIMARY)
   {
     GtkTreeSelection *selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(view));
     GtkTreePath *path = NULL;
     // Get tree path for row that was clicked
-    if(gtk_tree_view_get_path_at_pos(GTK_TREE_VIEW(view), (gint)event->x,
-                                     (gint)event->y, &path, NULL, NULL, NULL))
+    if(gtk_tree_view_get_path_at_pos(GTK_TREE_VIEW(view), (gint)dt_gdk_event_get_x(event),
+                                     (gint)dt_gdk_event_get_y(event), &path, NULL, NULL, NULL))
     {
       if(button_pressed == GDK_BUTTON_SECONDARY)
       {

--- a/src/libs/masks.c
+++ b/src/libs/masks.c
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "common/gdk_event_utils.h"
 
 #include "develop/masks.h"
 #include "bauhaus/bauhaus.h"
@@ -601,7 +602,7 @@ static gboolean _bt_add_shape(GtkWidget *widget, GdkEventButton *event, gpointer
 {
   DT_GUARD_GUI_UPDATE(FALSE);
 
-  if(event->button == GDK_BUTTON_PRIMARY)
+  if(dt_gdk_event_get_button(event) == GDK_BUTTON_PRIMARY)
   {
 #ifdef HAVE_AI
     if(GPOINTER_TO_INT(shape) == DT_MASKS_OBJECT && !dt_masks_object_available())
@@ -612,7 +613,7 @@ static gboolean _bt_add_shape(GtkWidget *widget, GdkEventButton *event, gpointer
 #endif
     _tree_add_shape(NULL, shape);
 
-    if(dt_modifier_is(event->state, GDK_CONTROL_MASK))
+    if(dt_modifier_is(dt_gdk_event_get_state(event), GDK_CONTROL_MASK))
     {
       darktable.develop->form_gui->creation_continuous = TRUE;
       darktable.develop->form_gui->creation_continuous_module =
@@ -1168,7 +1169,7 @@ static int _tree_button_pressed(GtkWidget *treeview,
   dt_iop_module_t *module = NULL;
   gboolean on_row = FALSE;
   if(gtk_tree_view_get_path_at_pos(GTK_TREE_VIEW(treeview),
-                                   (gint)event->x, (gint)event->y, &mouse_path, NULL,
+                                   (gint)dt_gdk_event_get_x(event), (gint)dt_gdk_event_get_y(event), &mouse_path, NULL,
                                    NULL, NULL))
   {
     on_row = TRUE;
@@ -1179,7 +1180,7 @@ static int _tree_button_pressed(GtkWidget *treeview,
     }
   }
   /* single click with the right mouse button? */
-  if(event->type == GDK_BUTTON_PRESS && event->button == GDK_BUTTON_PRIMARY)
+  if(dt_gdk_event_get_type(event) == GDK_BUTTON_PRESS && dt_gdk_event_get_button(event) == GDK_BUTTON_PRIMARY)
   {
     // if click on a blank space, then deselect all
     if(!on_row)
@@ -1187,13 +1188,13 @@ static int _tree_button_pressed(GtkWidget *treeview,
       gtk_tree_selection_unselect_all(selection);
     }
   }
-  else if(event->type == GDK_BUTTON_PRESS && event->button == GDK_BUTTON_SECONDARY)
+  else if(dt_gdk_event_get_type(event) == GDK_BUTTON_PRESS && dt_gdk_event_get_button(event) == GDK_BUTTON_SECONDARY)
   {
     // if we are already inside the selection, no change
     if(on_row
        && !gtk_tree_selection_path_is_selected(selection, mouse_path))
     {
-      if(!dt_modifier_is(event->state, GDK_CONTROL_MASK))
+      if(!dt_modifier_is(dt_gdk_event_get_state(event), GDK_CONTROL_MASK))
         gtk_tree_selection_unselect_all(selection);
 
       gtk_tree_selection_select_path(selection, mouse_path);

--- a/src/libs/metadata.c
+++ b/src/libs/metadata.c
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "common/gdk_event_utils.h"
 
 #include "common/metadata.h"
 #include "common/collection.h"
@@ -425,18 +426,18 @@ static gboolean _key_pressed(GtkWidget *textview,
 {
   dt_lib_metadata_t *d = self->data;
 
-  switch(event->keyval)
+  switch(dt_gdk_event_get_keyval(event))
   {
     case GDK_KEY_Return:
     case GDK_KEY_KP_Enter:
-      if(!dt_modifier_is(event->state, GDK_CONTROL_MASK))
+      if(!dt_modifier_is(dt_gdk_event_get_state(event), GDK_CONTROL_MASK))
       {
         gtk_button_clicked(GTK_BUTTON(d->apply_button));
         return TRUE;
       }
       break;
     case GDK_KEY_Escape:
-      if(dt_modifier_is(event->state, 0))
+      if(dt_modifier_is(dt_gdk_event_get_state(event), 0))
       {
         gtk_button_clicked(GTK_BUTTON(d->cancel_button));
         return TRUE;
@@ -572,7 +573,7 @@ static gboolean _metadata_reset(GtkWidget *label,
                                 GdkEventButton *event,
                                 GtkWidget *widget)
 {
-  if(event->type == GDK_2BUTTON_PRESS)
+  if(dt_gdk_event_get_type(event) == GDK_2BUTTON_PRESS)
   {
     g_object_set_data(G_OBJECT(widget), "tv_multiple", GINT_TO_POINTER(FALSE));
     GtkTextBuffer *buffer = gtk_text_view_get_buffer(GTK_TEXT_VIEW(widget));

--- a/src/libs/metadata_view.c
+++ b/src/libs/metadata_view.c
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "common/gdk_event_utils.h"
 
 #include "common/collection.h"
 #include "common/darktable.h"
@@ -1155,7 +1156,7 @@ static void _jump_to()
 
 static gboolean _filmroll_clicked(GtkWidget *widget, GdkEventButton *event, gpointer null)
 {
-  if(event->type != GDK_2BUTTON_PRESS) return FALSE;
+  if(dt_gdk_event_get_type(event) != GDK_2BUTTON_PRESS) return FALSE;
   _jump_to();
   return TRUE;
 }

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "common/gdk_event_utils.h"
 
 #include "bauhaus/bauhaus.h"
 #include "common/darktable.h"
@@ -2661,7 +2662,7 @@ static gboolean _presets_pressed(GtkWidget *widget,
                                  GdkEventButton *event,
                                  dt_lib_module_t *self)
 {
-  if(dt_modifier_is(event->state, GDK_CONTROL_MASK))
+  if(dt_modifier_is(dt_gdk_event_get_state(event), GDK_CONTROL_MASK))
   {
     manage_presets(self);
     return TRUE;
@@ -2673,7 +2674,7 @@ static gboolean _manage_direct_popup(GtkWidget *widget,
                                      GdkEventButton *event,
                                      dt_lib_module_t *self)
 {
-  if(event->type == GDK_BUTTON_PRESS && event->button == GDK_BUTTON_SECONDARY)
+  if(dt_gdk_event_get_type(event) == GDK_BUTTON_PRESS && dt_gdk_event_get_button(event) == GDK_BUTTON_SECONDARY)
   {
     dt_lib_modulegroups_group_t *gr = g_object_get_data(G_OBJECT(widget), "group");
     if(!g_strcmp0(gr->name, C_("modulegroup", "deprecated"))) return FALSE;
@@ -2688,7 +2689,7 @@ static gboolean _manage_direct_basic_popup(GtkWidget *widget,
                                            GdkEventButton *event,
                                            dt_lib_module_t *self)
 {
-  if(event->type == GDK_BUTTON_PRESS && event->button == GDK_BUTTON_SECONDARY)
+  if(dt_gdk_event_get_type(event) == GDK_BUTTON_PRESS && dt_gdk_event_get_button(event) == GDK_BUTTON_SECONDARY)
   {
     _manage_basics_add_popup(widget, self, TRUE);
     return TRUE;
@@ -2702,7 +2703,7 @@ static gboolean _manage_direct_module_popup(GtkWidget *widget,
 {
   dt_action_t *module = g_object_get_data(G_OBJECT(widget), "module");
 
-  if(event->type == GDK_BUTTON_PRESS && event->button == GDK_BUTTON_SECONDARY)
+  if(dt_gdk_event_get_type(event) == GDK_BUTTON_PRESS && dt_gdk_event_get_button(event) == GDK_BUTTON_SECONDARY)
   {
     int nba = 0; // nb of already present items
     GtkWidget *pop = gtk_menu_new();
@@ -2733,7 +2734,7 @@ static gboolean _manage_direct_active_popup(GtkWidget *widget,
                                             GdkEventButton *event,
                                             dt_lib_module_t *self)
 {
-  if(event->type == GDK_BUTTON_PRESS && event->button == GDK_BUTTON_SECONDARY)
+  if(dt_gdk_event_get_type(event) == GDK_BUTTON_PRESS && dt_gdk_event_get_button(event) == GDK_BUTTON_SECONDARY)
   {
     dt_lib_modulegroups_t *d = self->data;
     GtkWidget *pop = gtk_menu_new();

--- a/src/libs/navigation.c
+++ b/src/libs/navigation.c
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "common/gdk_event_utils.h"
 
 #include "bauhaus/bauhaus.h"
 #include "common/darktable.h"
@@ -427,7 +428,7 @@ static gboolean _lib_navigation_motion_notify_callback(GtkWidget *widget,
 {
   GtkAllocation allocation;
   gtk_widget_get_allocation(widget, &allocation);
-  _lib_navigation_set_position(self, event->x, event->y,
+  _lib_navigation_set_position(self, dt_gdk_event_get_x(event), dt_gdk_event_get_y(event),
                                allocation.width, allocation.height);
   return TRUE;
 }
@@ -532,7 +533,7 @@ static void _lib_navigation_scroll_callback(GtkEventControllerScroll *controller
     GdkDevice *device = gdk_event_get_source_device(event);
     if(device
        && gdk_device_get_source(device) == GDK_SOURCE_TOUCHPAD
-       && event->scroll.direction == GDK_SCROLL_SMOOTH)
+       && dt_gdk_event_get_scroll_direction(event) == GDK_SCROLL_SMOOTH)
     {
       dt_dev_zoom_move(&darktable.develop->full, DT_ZOOM_MOVE,
                        15.0, 0, dx, dy, TRUE);
@@ -542,7 +543,7 @@ static void _lib_navigation_scroll_callback(GtkEventControllerScroll *controller
       const gboolean constrain = !dt_modifier_eq(controller, GDK_CONTROL_MASK);
       gdouble x, y;
       if(_lib_navigation_widget_to_center(GTK_EVENT_CONTROLLER(controller),
-                                          event->scroll.x, event->scroll.y,
+                                          dt_gdk_event_get_x(event), dt_gdk_event_get_y(event),
                                           &x, &y))
       {
         const double delta = fabs(dx) > fabs(dy) ? -dx : dy;
@@ -598,10 +599,10 @@ static gboolean _lib_navigation_button_press_callback(GtkWidget *widget,
   dt_lib_navigation_t *d = self->data;
   GtkAllocation allocation;
   gtk_widget_get_allocation(widget, &allocation);
-  if(event->type == GDK_BUTTON_PRESS && event->button.button != 2)
+  if(dt_gdk_event_get_type(event) == GDK_BUTTON_PRESS && dt_gdk_event_get_button(event) != 2)
   {
     d->dragging = 1;
-    _lib_navigation_set_position(self, event->button.x, event->button.y,
+    _lib_navigation_set_position(self, dt_gdk_event_get_x(event), dt_gdk_event_get_y(event),
                                  allocation.width, allocation.height);
 
     return TRUE;
@@ -611,8 +612,8 @@ static gboolean _lib_navigation_button_press_callback(GtkWidget *widget,
     GtkWidget *center = dt_ui_center(darktable.gui->ui);
     GtkAllocation center_alloc;
     gtk_widget_get_allocation(center, &center_alloc);
-    event->button.x *= (gdouble)center_alloc.width / allocation.width;
-    event->button.y *= (gdouble)center_alloc.height / allocation.height;
+    event->scroll.x *= (gdouble)center_alloc.width / allocation.width;
+    event->scroll.y *= (gdouble)center_alloc.height / allocation.height;
 
     return gtk_widget_event(center, event);
   }

--- a/src/libs/neural_restore.c
+++ b/src/libs/neural_restore.c
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "common/gdk_event_utils.h"
 
 // neural restore — lighttable module for AI-based image restoration
 //
@@ -3504,7 +3505,7 @@ static gboolean _pick_double_click(GtkWidget *widget,
                                    GdkEventButton *event,
                                    dt_lib_module_t *self)
 {
-  if(event->type != GDK_2BUTTON_PRESS) return FALSE;
+  if(dt_gdk_event_get_type(event) != GDK_2BUTTON_PRESS) return FALSE;
   dt_lib_neural_restore_t *d = self->data;
   d->patch_center[0] = 0.5f;
   d->patch_center[1] = 0.5f;

--- a/src/libs/print_settings.c
+++ b/src/libs/print_settings.c
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "common/gdk_event_utils.h"
 
 #include <glib.h>
 
@@ -1211,7 +1212,7 @@ static void _apply_style_activate_callback(GtkMenuItem *menuitem,
                                            const dt_stylemenu_data_t *menu_data)
 {
   GdkEvent *event = gtk_get_current_event();
-  if(event && event->type == GDK_KEY_PRESS)
+  if(event && dt_gdk_event_get_type(event) == GDK_KEY_PRESS)
   {
     _update_style(menu_data);
   }
@@ -1222,7 +1223,7 @@ static gboolean _apply_style_button_callback(GtkMenuItem *menuitem,
                                              GdkEventButton *event,
                                              const dt_stylemenu_data_t *menu_data)
 {
-  if(event->button == GDK_BUTTON_PRIMARY)
+  if(dt_gdk_event_get_button(event) == GDK_BUTTON_PRIMARY)
   {
     _update_style(menu_data);
   }

--- a/src/libs/snapshots.c
+++ b/src/libs/snapshots.c
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "common/gdk_event_utils.h"
 
 #include "common/darktable.h"
 #include "bauhaus/bauhaus.h"
@@ -569,7 +570,7 @@ static gboolean _lib_button_button_pressed_callback(GtkWidget *widget,
 
   const int index = _look_for_widget(self, widget, FALSE);
 
-  if(dt_modifier_is(event->state, GDK_CONTROL_MASK))
+  if(dt_modifier_is(dt_gdk_event_get_state(event), GDK_CONTROL_MASK))
   {
     gtk_widget_hide(d->snapshot[index].name);
     gtk_widget_show(d->snapshot[index].entry);

--- a/src/libs/tagging.c
+++ b/src/libs/tagging.c
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "common/gdk_event_utils.h"
 
 #include "common/collection.h"
 #include "common/selection.h"
@@ -1475,15 +1476,15 @@ static gboolean _click_on_view_attached(GtkWidget *view,
   dt_lib_tagging_t *d = self->data;
   _unselect_all_in_view(d->dictionary_view);
 
-  if((event->type == GDK_BUTTON_PRESS && event->button == GDK_BUTTON_SECONDARY)
-    || (event->type == GDK_2BUTTON_PRESS && event->button == GDK_BUTTON_PRIMARY)
-    || (event->type == GDK_BUTTON_PRESS && event->button == GDK_BUTTON_PRIMARY))
+  if((dt_gdk_event_get_type(event) == GDK_BUTTON_PRESS && dt_gdk_event_get_button(event) == GDK_BUTTON_SECONDARY)
+    || (dt_gdk_event_get_type(event) == GDK_2BUTTON_PRESS && dt_gdk_event_get_button(event) == GDK_BUTTON_PRIMARY)
+    || (dt_gdk_event_get_type(event) == GDK_BUTTON_PRESS && dt_gdk_event_get_button(event) == GDK_BUTTON_PRIMARY))
   {
     GtkTreeSelection *selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(view));
     GtkTreePath *path = NULL;
     // Get tree path for row that was clicked
     if(gtk_tree_view_get_path_at_pos(GTK_TREE_VIEW(view),
-                                     (gint)event->x, (gint)event->y,
+                                     (gint)dt_gdk_event_get_x(event), (gint)dt_gdk_event_get_y(event),
                                      &path, NULL, NULL, NULL))
     {
       gboolean valid_tag = FALSE;
@@ -1496,15 +1497,15 @@ static gboolean _click_on_view_attached(GtkWidget *view,
       {
         gtk_tree_selection_select_path(selection, path);
         dt_lib_gui_queue_update(self);
-        if(event->type == GDK_BUTTON_PRESS
-           && event->button == GDK_BUTTON_SECONDARY)
+        if(dt_gdk_event_get_type(event) == GDK_BUTTON_PRESS
+           && dt_gdk_event_get_button(event) == GDK_BUTTON_SECONDARY)
         {
           _pop_menu_attached(view, event, self);
           gtk_tree_path_free(path);
           return TRUE;
         }
-        else if(event->type == GDK_2BUTTON_PRESS
-                && event->button == GDK_BUTTON_PRIMARY)
+        else if(dt_gdk_event_get_type(event) == GDK_2BUTTON_PRESS
+                && dt_gdk_event_get_button(event) == GDK_BUTTON_PRIMARY)
         {
           _detach_selected_tag(d->attached_view, self);
           gtk_tree_path_free(path);
@@ -1535,7 +1536,7 @@ static gboolean _attached_key_pressed(GtkWidget *view,
   if(gtk_tree_selection_get_selected(selection, &model, &iter))
   {
     GtkTreePath *path = gtk_tree_model_get_path(model, &iter);
-    switch(event->keyval)
+    switch(dt_gdk_event_get_keyval(event))
     {
       case GDK_KEY_Delete:
       case GDK_KEY_KP_Delete:
@@ -1547,13 +1548,13 @@ static gboolean _attached_key_pressed(GtkWidget *view,
     }
     gtk_tree_path_free(path);
   }
-  if(event->keyval == GDK_KEY_Tab)
+  if(dt_gdk_event_get_keyval(event) == GDK_KEY_Tab)
   {
     gtk_tree_selection_unselect_all(selection);
     gtk_widget_grab_focus(GTK_WIDGET(d->entry));
     return TRUE;
   }
-  else if(event->keyval == GDK_KEY_ISO_Left_Tab)
+  else if(dt_gdk_event_get_keyval(event) == GDK_KEY_ISO_Left_Tab)
   {
     gtk_tree_selection_unselect_all(selection);
     return TRUE;
@@ -1607,7 +1608,7 @@ static gboolean _enter_key_pressed(GtkWidget *entry,
                                    dt_lib_module_t *self)
 {
   dt_lib_tagging_t *d = self->data;
-  switch(event->keyval)
+  switch(dt_gdk_event_get_keyval(event))
   {
     case GDK_KEY_Return:
     case GDK_KEY_KP_Enter:
@@ -2641,17 +2642,17 @@ static gboolean _click_on_view_dictionary(GtkWidget *view,
   dt_lib_tagging_t *d = self->data;
   _unselect_all_in_view(d->attached_view);
 
-  const int button_pressed = (event->type == GDK_BUTTON_PRESS) ? event->button : 0;
-  const gboolean shift_pressed = dt_modifier_is(event->state, GDK_SHIFT_MASK);
+  const int button_pressed = (dt_gdk_event_get_type(event) == GDK_BUTTON_PRESS) ? dt_gdk_event_get_button(event) : 0;
+  const gboolean shift_pressed = dt_modifier_is(dt_gdk_event_get_state(event), GDK_SHIFT_MASK);
   if((button_pressed == GDK_BUTTON_SECONDARY)                     // contextual menu
      || (d->tree_flag && button_pressed == GDK_BUTTON_PRIMARY)    // expand & drag
-     || (event->type == GDK_2BUTTON_PRESS && event->button == GDK_BUTTON_PRIMARY)) // attach
+     || (dt_gdk_event_get_type(event) == GDK_2BUTTON_PRESS && dt_gdk_event_get_button(event) == GDK_BUTTON_PRIMARY)) // attach
   {
     GtkTreeSelection *selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(view));
     GtkTreePath *path = NULL;
     // Get tree path for row that was clicked
     if(gtk_tree_view_get_path_at_pos(GTK_TREE_VIEW(view),
-                                     (gint)event->x, (gint)event->y,
+                                     (gint)dt_gdk_event_get_x(event), (gint)dt_gdk_event_get_y(event),
                                      &path, NULL, NULL, NULL))
     {
       if(d->tree_flag
@@ -2690,8 +2691,8 @@ static gboolean _click_on_view_dictionary(GtkWidget *view,
           gtk_tree_path_free(path);
           return TRUE;
         }
-        else if(event->type == GDK_2BUTTON_PRESS
-                && event->button == GDK_BUTTON_PRIMARY)
+        else if(dt_gdk_event_get_type(event) == GDK_2BUTTON_PRESS
+                && dt_gdk_event_get_button(event) == GDK_BUTTON_PRIMARY)
         {
           _attach_selected_tag(self, d);
           gtk_tree_path_free(path);
@@ -2717,13 +2718,13 @@ static gboolean _dictionary_key_pressed(GtkWidget *view,
   if(gtk_tree_selection_get_selected(selection, &model, &iter))
   {
     GtkTreePath *path = gtk_tree_model_get_path(model, &iter);
-    switch(event->keyval)
+    switch(dt_gdk_event_get_keyval(event))
     {
       case GDK_KEY_Return:
       case GDK_KEY_KP_Enter:
       {
         _attach_selected_tag(self, d);
-        if(dt_modifier_is(event->state, GDK_SHIFT_MASK))
+        if(dt_modifier_is(dt_gdk_event_get_state(event), GDK_SHIFT_MASK))
         {
           gtk_tree_selection_unselect_all(selection);
           gtk_entry_set_text(GTK_ENTRY(d->entry), "");
@@ -2735,7 +2736,7 @@ static gboolean _dictionary_key_pressed(GtkWidget *view,
       case GDK_KEY_Left:
         if(path)
         {
-          if(dt_modifier_is(event->state, GDK_SHIFT_MASK))
+          if(dt_modifier_is(dt_gdk_event_get_state(event), GDK_SHIFT_MASK))
             gtk_tree_view_collapse_all(GTK_TREE_VIEW(view));
           else
             gtk_tree_view_collapse_row(GTK_TREE_VIEW(view), path);
@@ -2746,7 +2747,7 @@ static gboolean _dictionary_key_pressed(GtkWidget *view,
         if(path)
         {
           gtk_tree_view_expand_row(GTK_TREE_VIEW(view), path,
-                                   dt_modifier_is(event->state, GDK_SHIFT_MASK));
+                                   dt_modifier_is(dt_gdk_event_get_state(event), GDK_SHIFT_MASK));
           res = TRUE;
         }
         break;
@@ -2755,12 +2756,12 @@ static gboolean _dictionary_key_pressed(GtkWidget *view,
     }
     gtk_tree_path_free(path);
   }
-  if(event->keyval == GDK_KEY_Tab)
+  if(dt_gdk_event_get_keyval(event) == GDK_KEY_Tab)
   {
     gtk_tree_selection_unselect_all(selection);
     res = TRUE;
   }
-  else if(event->keyval == GDK_KEY_ISO_Left_Tab)
+  else if(dt_gdk_event_get_keyval(event) == GDK_KEY_ISO_Left_Tab)
   {
     gtk_tree_selection_unselect_all(selection);
     gtk_widget_grab_focus(GTK_WIDGET(d->entry));
@@ -3771,7 +3772,7 @@ static gboolean _lib_tagging_tag_key_press(GtkWidget *entry,
                                            dt_lib_module_t *self)
 {
   dt_lib_tagging_t *d = self->data;
-  switch(event->keyval)
+  switch(dt_gdk_event_get_keyval(event))
   {
     case GDK_KEY_Escape:
       g_list_free(d->floating_tag_imgs);

--- a/src/libs/tools/colorlabels.c
+++ b/src/libs/tools/colorlabels.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2011-2024 darktable developers.
+    Copyright (C) 2011-2026 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "common/gdk_event_utils.h"
 
 #include "bauhaus/bauhaus.h"
 #include "common/colorlabels.h"
@@ -169,7 +170,7 @@ static gboolean _lib_colorlabels_key_press(GtkWidget *entry,
 {
   dt_lib_colorlabels_t *d = self->data;
 
-  switch(event->keyval)
+  switch(dt_gdk_event_get_keyval(event))
   {
     case GDK_KEY_Escape:
       gtk_widget_destroy(d->floating_window);
@@ -247,8 +248,8 @@ static void _lib_colorlabels_edit(dt_lib_module_t *self,
   else
   {
     // Legacy/X11 path: keep undecorated popup GtkWindow
-    const gint x = event->x_root;
-    const gint y = event->y_root - DT_PIXEL_APPLY_DPI(50);
+    const gint x = dt_gdk_event_get_root_x(event);
+    const gint y = dt_gdk_event_get_root_y(event) - DT_PIXEL_APPLY_DPI(50);
 
     d->floating_window = gtk_window_new(GTK_WINDOW_TOPLEVEL);
 #ifdef GDK_WINDOWING_QUARTZ
@@ -275,8 +276,8 @@ static gboolean _lib_colorlabels_button_clicked_callback(GtkWidget *w,
 
   const gint colorlabel = _get_colorlabel(self, w);
 
-  if(event->type == GDK_BUTTON_PRESS
-     && event->button == GDK_BUTTON_SECONDARY
+  if(dt_gdk_event_get_type(event) == GDK_BUTTON_PRESS
+     && dt_gdk_event_get_button(event) == GDK_BUTTON_SECONDARY
      && colorlabel != 5)  // The button to reset colorlabels needs no description
   {
     d->colorlabel = colorlabel;

--- a/src/libs/tools/global_toolbox.c
+++ b/src/libs/tools/global_toolbox.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2011-2024 darktable developers.
+    Copyright (C) 2011-2026 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "common/gdk_event_utils.h"
 
 #include "common/collection.h"
 #include "common/darktable.h"
@@ -562,7 +563,7 @@ static void _main_do_event_help(GdkEvent *event, gpointer data)
 
   gboolean handled = FALSE;
 
-  switch(event->type)
+  switch(dt_gdk_event_get_type(event))
   {
     case GDK_BUTTON_PRESS:
     {
@@ -597,7 +598,7 @@ static void _main_do_event_help(GdkEvent *event, gpointer data)
         if(dt_gui_get_help_url(event_widget))
         {
           // TODO: find a better way to tell the user that the hovered widget has a help link
-          const char *cursor = event->type == GDK_ENTER_NOTIFY ? "help" : "not-allowed";
+          const char *cursor = dt_gdk_event_get_type(event) == GDK_ENTER_NOTIFY ? "help" : "not-allowed";
           dt_control_allow_change_cursor();
           dt_control_set_temp_cursor(cursor);
           dt_control_forbid_change_cursor();
@@ -686,7 +687,7 @@ static void _main_do_event_keymap(GdkEvent *event, gpointer data)
   GtkWidget *event_widget = gtk_get_event_widget(event);
   static guint click_time = 0;
 
-  switch(event->type)
+  switch(dt_gdk_event_get_type(event))
   {
   case GDK_LEAVE_NOTIFY:
   case GDK_ENTER_NOTIFY:
@@ -699,7 +700,7 @@ static void _main_do_event_keymap(GdkEvent *event, gpointer data)
     _set_mapping_mode_cursor(event_widget);
     break;
   case GDK_BUTTON_PRESS:
-    if(gdk_display_device_is_grabbed(gdk_window_get_display(event->button.window), event->button.device))
+    if(gdk_display_device_is_grabbed(gdk_window_get_display(dt_gdk_event_get_window(event)), dt_gdk_event_get_device(event)))
       break;
 
     GtkWidget *main_window = dt_ui_main_window(darktable.gui->ui);
@@ -715,13 +716,13 @@ static void _main_do_event_keymap(GdkEvent *event, gpointer data)
     if(GTK_IS_ENTRY(event_widget))
       break;
 
-    if(event->button.button == GDK_BUTTON_SECONDARY)
-      click_time = event->button.time;
-    else if(event->button.button == GDK_BUTTON_MIDDLE)
+    if(dt_gdk_event_get_button(event) == GDK_BUTTON_SECONDARY)
+      click_time = dt_gdk_event_get_time(event);
+    else if(dt_gdk_event_get_button(event) == GDK_BUTTON_MIDDLE)
       dt_shortcut_dispatcher(event_widget, event, data);
-    else if(event->button.button > 7)
+    else if(dt_gdk_event_get_button(event) > 7)
       break;
-    else if(dt_modifier_is(event->button.state, GDK_CONTROL_MASK))
+    else if(dt_modifier_is(dt_gdk_event_get_state(event), GDK_CONTROL_MASK))
     {
       if(darktable.develop)
       {
@@ -742,10 +743,10 @@ static void _main_do_event_keymap(GdkEvent *event, gpointer data)
 
     return;
   case GDK_BUTTON_RELEASE:
-    if(event->button.button != GDK_BUTTON_SECONDARY)
+    if(dt_gdk_event_get_button(event) != GDK_BUTTON_SECONDARY)
       break;
 
-    if(dt_gui_long_click(event->button.time, click_time))
+    if(dt_gui_long_click(dt_gdk_event_get_time(event), click_time))
       dt_shortcut_copy_lua(NULL, NULL);
     else
       gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->keymap_button), FALSE);
@@ -795,20 +796,20 @@ static gboolean _lib_keymap_button_press_release(GtkWidget *button, GdkEventButt
 {
   static guint start_time = 0;
 
-  darktable.control->confirm_mapping = !dt_modifier_is(event->state, GDK_CONTROL_MASK);
+  darktable.control->confirm_mapping = !dt_modifier_is(dt_gdk_event_get_state(event), GDK_CONTROL_MASK);
 
   int delay = 0;
   g_object_get(gtk_settings_get_default(), "gtk-long-press-time", &delay, NULL);
 
-  if((event->type == GDK_BUTTON_PRESS && event->button == GDK_BUTTON_SECONDARY) ||
-     (event->type == GDK_BUTTON_RELEASE && event->time - start_time > delay))
+  if((dt_gdk_event_get_type(event) == GDK_BUTTON_PRESS && dt_gdk_event_get_button(event) == GDK_BUTTON_SECONDARY) ||
+     (dt_gdk_event_get_type(event) == GDK_BUTTON_RELEASE && dt_gdk_event_get_time(event) - start_time > delay))
   {
     _show_shortcuts_prefs(NULL);
     return TRUE;
   }
   else
   {
-    start_time = event->time;
+    start_time = dt_gdk_event_get_time(event);
     return FALSE;
   }
 }

--- a/src/libs/tools/lighttable.c
+++ b/src/libs/tools/lighttable.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2011-2025 darktable developers.
+    Copyright (C) 2011-2026 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "common/gdk_event_utils.h"
 
 #include <gdk/gdkkeysyms.h>
 
@@ -222,12 +223,12 @@ static gboolean _lib_lighttable_layout_btn_release(GtkWidget *w, GdkEventButton 
     // that means we want to activate the button
     if(w == d->layout_preview)
     {
-      d->fullpreview_focus = dt_modifier_is(event->state, GDK_CONTROL_MASK);
+      d->fullpreview_focus = dt_modifier_is(dt_gdk_event_get_state(event), GDK_CONTROL_MASK);
       new_layout = DT_LIGHTTABLE_LAYOUT_PREVIEW;
     }
     else if(w == d->layout_culling_fix)
     {
-      if(dt_modifier_is(event->state, GDK_CONTROL_MASK))
+      if(dt_modifier_is(dt_gdk_event_get_state(event), GDK_CONTROL_MASK))
         d->culling_init_restriction = DT_LIGHTTABLE_CULLING_RESTRICTION_COLLECTION;
       else
         d->culling_init_restriction = DT_LIGHTTABLE_CULLING_RESTRICTION_AUTO;

--- a/src/libs/tools/log_history.c
+++ b/src/libs/tools/log_history.c
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "common/gdk_event_utils.h"
 
 #include "control/signal.h"
 #include "control/control.h"
@@ -140,7 +141,7 @@ static gboolean _label_button_press(GtkWidget *widget,
                                     GdkEventButton *event,
                                     gpointer user_data)
 {
-  if(event->button == GDK_BUTTON_SECONDARY)
+  if(dt_gdk_event_get_button(event) == GDK_BUTTON_SECONDARY)
     return TRUE;
   return FALSE;
 }
@@ -154,11 +155,11 @@ static gboolean _button_press_release(GtkWidget *button,
   int delay = 0;
   g_object_get(gtk_settings_get_default(), "gtk-long-press-time", &delay, NULL);
 
-  if((event->type == GDK_BUTTON_PRESS
-      && (event->button == GDK_BUTTON_PRIMARY
-          || event->button == GDK_BUTTON_SECONDARY))
-     || (event->type == GDK_BUTTON_RELEASE
-         && event->time - start_time > delay))
+  if((dt_gdk_event_get_type(event) == GDK_BUTTON_PRESS
+      && (dt_gdk_event_get_button(event) == GDK_BUTTON_PRIMARY
+          || dt_gdk_event_get_button(event) == GDK_BUTTON_SECONDARY))
+     || (dt_gdk_event_get_type(event) == GDK_BUTTON_RELEASE
+         && dt_gdk_event_get_time(event) - start_time > delay))
   {
     dt_lib_log_history_t *d = self->data;
     if(gtk_widget_is_visible(d->popover))
@@ -174,7 +175,7 @@ static gboolean _button_press_release(GtkWidget *button,
   }
   else
   {
-    start_time = event->time;
+    start_time = dt_gdk_event_get_time(event);
     return FALSE;
   }
 }

--- a/src/libs/tools/ratings.c
+++ b/src/libs/tools/ratings.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2011-2021 darktable developers.
+    Copyright (C) 2011-2026 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "common/gdk_event_utils.h"
 
 #include "common/ratings.h"
 #include "common/collection.h"
@@ -184,8 +185,8 @@ static gboolean _lib_ratings_motion_notify_callback(GtkWidget *widget, GdkEventM
 {
   dt_lib_ratings_t *d = self->data;
 
-  d->pointerx = event->x;
-  d->pointery = event->y;
+  d->pointerx = dt_gdk_event_get_x(event);
+  d->pointery = dt_gdk_event_get_y(event);
   gtk_widget_queue_draw(self->widget);
   return TRUE;
 }

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "common/gdk_event_utils.h"
 /** this is the view for the darkroom module.  */
 
 #include "common/extra_optimizations.h"
@@ -1798,7 +1799,7 @@ static void _darkroom_ui_apply_style_activate_callback(GtkMenuItem *menuitem,
                                                        const dt_stylemenu_data_t *menu_data)
 {
   GdkEvent *event = gtk_get_current_event();
-  if(event->type == GDK_KEY_PRESS)
+  if(dt_gdk_event_get_type(event) == GDK_KEY_PRESS)
     dt_styles_apply_to_dev(menu_data->name, darktable.develop->image_storage.id);
   gdk_event_free(event);
 }
@@ -1808,7 +1809,7 @@ static gboolean _darkroom_ui_apply_style_button_callback
    GdkEventButton *event,
    const dt_stylemenu_data_t *menu_data)
 {
-  if(event->button == GDK_BUTTON_PRIMARY)
+  if(dt_gdk_event_get_button(event) == GDK_BUTTON_PRIMARY)
     dt_styles_apply_to_dev(menu_data->name, darktable.develop->image_storage.id);
   else
     dt_shortcut_copy_lua(NULL, menu_data->name);
@@ -2764,8 +2765,8 @@ static gboolean _quickbutton_press_release(GtkWidget *button,
   int delay = 0;
   g_object_get(gtk_settings_get_default(), "gtk-long-press-time", &delay, NULL);
 
-  if((event->type == GDK_BUTTON_PRESS && event->button == GDK_BUTTON_SECONDARY) ||
-     (event->type == GDK_BUTTON_RELEASE && event->time - start_time > delay))
+  if((dt_gdk_event_get_type(event) == GDK_BUTTON_PRESS && dt_gdk_event_get_button(event) == GDK_BUTTON_SECONDARY) ||
+     (dt_gdk_event_get_type(event) == GDK_BUTTON_RELEASE && dt_gdk_event_get_time(event) - start_time > delay))
   {
     gtk_popover_set_relative_to(GTK_POPOVER(popover), button);
 
@@ -2776,7 +2777,7 @@ static gboolean _quickbutton_press_release(GtkWidget *button,
   }
   else
   {
-    start_time = event->time;
+    start_time = dt_gdk_event_get_time(event);
     return FALSE;
   }
 }
@@ -4999,9 +5000,9 @@ static gboolean _second_window_scrolled_callback(GtkWidget *widget,
     dt_dev_viewport_t *port = pinned_dev ? &pinned_dev->preview2 : &dev->preview2;
 
     const gboolean constrained =
-      dev->constrain_zoom && !dt_modifier_is(event->state, GDK_CONTROL_MASK);
+      dev->constrain_zoom && !dt_modifier_is(dt_gdk_event_get_state(event), GDK_CONTROL_MASK);
     dt_dev_zoom_move(port, DT_ZOOM_SCROLL, 0.0f, delta_y < 0,
-                     event->x, event->y, constrained);
+                     dt_gdk_event_get_x(event), dt_gdk_event_get_y(event), constrained);
   }
 
   return TRUE;
@@ -5020,24 +5021,24 @@ static gboolean _second_window_button_pressed_callback(GtkWidget *w,
   dt_dev_viewport_t *port = pinned_dev ? &pinned_dev->preview2 : &dev->preview2;
 
   // Handle double-click to reset zoom and center
-  if(event->type == GDK_2BUTTON_PRESS && event->button == GDK_BUTTON_PRIMARY)
+  if(dt_gdk_event_get_type(event) == GDK_2BUTTON_PRESS && dt_gdk_event_get_button(event) == GDK_BUTTON_PRIMARY)
   {
     dt_dev_zoom_move(port, DT_ZOOM_FIT, 0.0f, 0,
-                     event->x, event->y, TRUE);
+                     dt_gdk_event_get_x(event), dt_gdk_event_get_y(event), TRUE);
     return TRUE;
   }
-  if(event->button == GDK_BUTTON_PRIMARY)
+  if(dt_gdk_event_get_button(event) == GDK_BUTTON_PRIMARY)
   {
     // store coordinates in logical pixels (as delivered by event)
-    darktable.control->button_x = event->x;
-    darktable.control->button_y = event->y;
+    darktable.control->button_x = dt_gdk_event_get_x(event);
+    darktable.control->button_y = dt_gdk_event_get_y(event);
     _dt_second_window_change_cursor(dev, "grabbing");
     return TRUE;
   }
-  if(event->button == GDK_BUTTON_MIDDLE)
+  if(dt_gdk_event_get_button(event) == GDK_BUTTON_MIDDLE)
   {
     dt_dev_zoom_move(port, DT_ZOOM_1, 0.0f, -2,
-                     event->x, event->y, !dt_modifier_is(event->state, GDK_CONTROL_MASK));
+                     dt_gdk_event_get_x(event), dt_gdk_event_get_y(event), !dt_modifier_is(dt_gdk_event_get_state(event), GDK_CONTROL_MASK));
     return TRUE;
   }
   return FALSE;
@@ -5047,7 +5048,7 @@ static gboolean _second_window_button_released_callback(GtkWidget *w,
                                                         GdkEventButton *event,
                                                         dt_develop_t *dev)
 {
-  if(event->button == GDK_BUTTON_PRIMARY) _dt_second_window_change_cursor(dev, "default");
+  if(dt_gdk_event_get_button(event) == GDK_BUTTON_PRIMARY) _dt_second_window_change_cursor(dev, "default");
 
   gtk_widget_queue_draw(w);
   return TRUE;
@@ -5059,7 +5060,7 @@ static gboolean _second_window_mouse_moved_callback(GtkWidget *w,
 {
   if(dev->gui_leaving) return FALSE;
 
-  if(event->state & GDK_BUTTON1_MASK)
+  if(dt_gdk_event_get_state(event) & GDK_BUTTON1_MASK)
   {
     dt_control_t *ctl = darktable.control;
 
@@ -5070,9 +5071,9 @@ static gboolean _second_window_mouse_moved_callback(GtkWidget *w,
     dt_dev_viewport_t *port = pinned_dev ? &pinned_dev->preview2 : &dev->preview2;
 
     dt_dev_zoom_move(port, DT_ZOOM_MOVE, -1.f, 0,
-                     event->x - ctl->button_x, event->y - ctl->button_y, TRUE);
-    ctl->button_x = event->x;
-    ctl->button_y = event->y;
+                     dt_gdk_event_get_x(event) - ctl->button_x, dt_gdk_event_get_y(event) - ctl->button_y, TRUE);
+    ctl->button_x = dt_gdk_event_get_x(event);
+    ctl->button_y = dt_gdk_event_get_y(event);
     return TRUE;
   }
   return FALSE;

--- a/src/views/map.c
+++ b/src/views/map.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2011-2025 darktable developers.
+    Copyright (C) 2011-2026 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "common/gdk_event_utils.h"
 
 #include "common/collection.h"
 #include "common/darktable.h"
@@ -2008,10 +2009,10 @@ static gboolean _view_map_scroll_event(GtkWidget *w,
 {
   dt_map_t *lib = self->data;
   // check if the click was on image(s) or just some random position
-  dt_map_image_t *entry = _view_map_get_entry_at_pos(self, event->x, event->y);
+  dt_map_image_t *entry = _view_map_get_entry_at_pos(self, dt_gdk_event_get_x(event), dt_gdk_event_get_y(event));
   if(entry)
   {
-    if(_display_next_image(self, entry, event->direction == GDK_SCROLL_DOWN))
+    if(_display_next_image(self, entry, dt_gdk_event_get_scroll_direction(event) == GDK_SCROLL_DOWN))
       return TRUE;
   }
 
@@ -2020,18 +2021,20 @@ static gboolean _view_map_scroll_event(GtkWidget *w,
   osm_gps_map_point_get_degrees(p, &lat, &lon);
   if(lib->loc.main.id > 0)
   {
-    const gboolean increase = event->direction == GDK_SCROLL_UP || event->direction == GDK_SCROLL_RIGHT;
-    const gboolean decrease = event->direction == GDK_SCROLL_DOWN || event->direction == GDK_SCROLL_LEFT;
+    const gboolean increase = dt_gdk_event_get_scroll_direction(event) == GDK_SCROLL_UP
+                           || dt_gdk_event_get_scroll_direction(event) == GDK_SCROLL_RIGHT;
+    const gboolean decrease = dt_gdk_event_get_scroll_direction(event) == GDK_SCROLL_DOWN
+                           || dt_gdk_event_get_scroll_direction(event) == GDK_SCROLL_LEFT;
     if(dt_map_location_included(lon, lat, &lib->loc.main.data))
     {
-      if(dt_modifier_is(event->state, GDK_SHIFT_MASK))
+      if(dt_modifier_is(dt_gdk_event_get_state(event), GDK_SHIFT_MASK))
       {
         if(increase)
           lib->loc.main.data.delta1 *= 1.1;
         else if(decrease)
           lib->loc.main.data.delta1 /= 1.1;
       }
-      else if(dt_modifier_is(event->state, GDK_CONTROL_MASK))
+      else if(dt_modifier_is(dt_gdk_event_get_state(event), GDK_CONTROL_MASK))
       {
         if(increase)
           lib->loc.main.data.delta2 *= 1.1;
@@ -2059,13 +2062,13 @@ static gboolean _view_map_scroll_event(GtkWidget *w,
     else  // scroll on the map. try to keep the map where it is
     {
       _toast_log_lat_lon(lat, lon);
-      return _zoom_and_center(event->x, event->y, event->direction, self);
+      return _zoom_and_center(dt_gdk_event_get_x(event), dt_gdk_event_get_y(event), dt_gdk_event_get_scroll_direction(event), self);
     }
   }
   else
   {
     _toast_log_lat_lon(lat, lon);
-    return _zoom_and_center(event->x, event->y, event->direction, self);
+    return _zoom_and_center(dt_gdk_event_get_x(event), dt_gdk_event_get_y(event), dt_gdk_event_get_scroll_direction(event), self);
   }
   return FALSE;
 }


### PR DESCRIPTION
Replace all direct GdkEvent struct member accesses:

- `event->type`
- `event->button`
- `event->x`
- `event->y`
- `event->state`
- `event->keyval`
- `event->time`
- `event->window`
- `event->scroll.direction`
- `event->delta_x`/`event->delta_y`
- `event->direction`
- `event->hardware_keycode`
- etc. 
 
With the corresponding `gdk_event_get_*()` accessor functions via thin inline wrappers in `src/common/gdk_event_utils.h`.

The wrapper functions (`dt_gdk_event_get_*`) accept `const void*` so any typed event pointer (`GdkEventButton*`, `GdkEventKey*`, etc.) can be passed without an explicit cast. They return the field value directly instead of using out-parameters.

This removes ~500 direct struct accesses across 65 files. Remaining direct accesses are limited to:
- Synthetic event construction (writing to `gdk_event_new()` events)
- Event mutation before forwarding
- Fields without GTK3 accessor functions (`configure.width`/`configure.height`, `crossing.mode`/`crossing.detail`, `key.is_modifier`)

See https://docs.gtk.org/gtk4/migrating-3to4.html

>Stop using direct access to GdkEvent structs
>
>In GTK 4, event structs are opaque and immutable. Many fields already have accessors in GTK 3, and you should use those to reduce the amount of porting work you have to do at the time of the switch.

Related: "Stop using direct access to GdkEvent structs" https://github.com/darktable-org/darktable/issues/15920 #20433