### PR TITLE
gtk4-prep: replace `GtkWidget.destroy` vfunc with `GObject.dispose`

### DIFF
--- a/src/dtgtk/gradientslider.c
+++ b/src/dtgtk/gradientslider.c
@@ -43,7 +43,7 @@ static void _gradient_slider_get_preferred_width(GtkWidget *widget,
                                                  gint *min_width,
                                                  gint *nat_width);
 static gboolean _gradient_slider_draw(GtkWidget *widget, cairo_t *cr);
-static void _gradient_slider_destroy(GtkWidget *widget);
+static void _gradient_slider_dispose(GObject *object);
 
 // Events
 static gboolean _gradient_slider_enter_notify_event(GtkWidget *widget,
@@ -482,7 +482,8 @@ static void _gradient_slider_class_init(GtkDarktableGradientSliderClass *klass)
   widget_class->get_preferred_height = _gradient_slider_get_preferred_height;
   widget_class->get_preferred_width = _gradient_slider_get_preferred_width;
   widget_class->draw = _gradient_slider_draw;
-  widget_class->destroy = _gradient_slider_destroy;
+  GObjectClass *object_class = (GObjectClass *)klass;
+  object_class->dispose = _gradient_slider_dispose;
 
   widget_class->enter_notify_event = _gradient_slider_enter_notify_event;
   widget_class->leave_notify_event = _gradient_slider_leave_notify_event;
@@ -565,11 +566,11 @@ static void _gradient_slider_get_preferred_width(GtkWidget *widget,
   DTGTK_GRADIENT_SLIDER(widget)->margin_right = padding.right + border.right + margin.right;
 }
 
-static void _gradient_slider_destroy(GtkWidget *widget)
+static void _gradient_slider_dispose(GObject *object)
 {
-  g_return_if_fail(DTGTK_IS_GRADIENT_SLIDER(widget));
+  g_return_if_fail(DTGTK_IS_GRADIENT_SLIDER(object));
 
-  GtkDarktableGradientSlider *gslider = DTGTK_GRADIENT_SLIDER(widget);
+  GtkDarktableGradientSlider *gslider = DTGTK_GRADIENT_SLIDER(object);
 
   if(gslider->timeout_handle)
     g_source_remove(gslider->timeout_handle);
@@ -581,7 +582,7 @@ static void _gradient_slider_destroy(GtkWidget *widget)
 
   gslider->colors = NULL;
 
-  GTK_WIDGET_CLASS(parent_class)->destroy(widget);
+  G_OBJECT_CLASS(parent_class)->dispose(object);
 }
 
 static gboolean _gradient_slider_draw(GtkWidget *widget,

--- a/src/dtgtk/range.c
+++ b/src/dtgtk/range.c
@@ -143,11 +143,11 @@ static void _dt_pref_changed(gpointer instance, gpointer user_data)
 }
 
 // cleanup everything when the widget is destroyed
-static void _range_select_destroy(GtkWidget *widget)
+static void _range_select_dispose(GObject *object)
 {
-  g_return_if_fail(DTGTK_IS_RANGE_SELECT(widget));
+  g_return_if_fail(DTGTK_IS_RANGE_SELECT(object));
 
-  GtkDarktableRangeSelect *range = DTGTK_RANGE_SELECT(widget);
+  GtkDarktableRangeSelect *range = DTGTK_RANGE_SELECT(object);
 
   DT_CONTROL_SIGNAL_DISCONNECT(_dt_pref_changed, range);
 
@@ -171,13 +171,13 @@ static void _range_select_destroy(GtkWidget *widget)
     g_free(range->cur_help);
   range->cur_help = NULL;
 
-  GTK_WIDGET_CLASS(dtgtk_range_select_parent_class)->destroy(widget);
+  G_OBJECT_CLASS(dtgtk_range_select_parent_class)->dispose(object);
 }
 
 static void dtgtk_range_select_class_init(GtkDarktableRangeSelectClass *klass)
 {
-  GtkWidgetClass *widget_class = (GtkWidgetClass *)klass;
-  widget_class->destroy = _range_select_destroy;
+  GObjectClass *object_class = (GObjectClass *)klass;
+  object_class->dispose = _range_select_dispose;
 
   _signals[VALUE_CHANGED] = g_signal_new("value-changed", G_TYPE_FROM_CLASS(klass), G_SIGNAL_RUN_LAST, 0, NULL,
                                          NULL, g_cclosure_marshal_VOID__VOID, G_TYPE_NONE, 0);


### PR DESCRIPTION
`GtkWidget.destroy` vfunc override is removed in GTK4. The migration guide recommends using `GObject.dispose` instead.

Two custom widgets override the destroy vfunc:
- `gradientslider.c`: `_gradient_slider_destroy` -> `_gradient_slider_dispose`
- `range.c`: `_range_select_destroy` -> `_range_select_dispose`

Both now implement `GObjectClass->dispose`, take `GObject *` parameter, and chain to `G_OBJECT_CLASS(parent_class)->dispose(object)`.

Related: "Stop using the GtkWidget.destroy vfunc" https://github.com/darktable-org/darktable/issues/15920 #20433

>Stop using the GtkWidget.destroy vfunc
>
>Instead of implementing GtkWidget.destroy, you can implement GObject.dispose.

https://docs.gtk.org/gtk4/migrating-3to4.html