### PR TITLE
gtk4-prep: replace `gtk_widget_set_app_paintable()`-> `dt_transparent_background` CSS class

### DIFF
--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -560,7 +560,7 @@ static void _window_position(const int offset)
     // opaque. At switch time the entire Wayland workaround block must be
     // reworked (GdkWindow -> GdkSurface, gdk_window_resize removed, etc.).
 #if !GTK_CHECK_VERSION(4, 0, 0)
-    gtk_widget_set_app_paintable(pop->window, TRUE);
+    dt_gui_add_class(pop->window, "dt_transparent_background");
     GdkScreen *screen = gtk_widget_get_screen(pop->window);
     GdkVisual *visual = gdk_screen_get_rgba_visual(screen);
     gtk_widget_set_visual(pop->window, visual);

--- a/src/dtgtk/culling.c
+++ b/src/dtgtk/culling.c
@@ -1219,7 +1219,7 @@ dt_culling_t *dt_culling_new(const dt_culling_mode_t mode)
                         | GDK_LEAVE_NOTIFY_MASK
                         | GDK_TOUCHPAD_GESTURE_MASK);
 
-  gtk_widget_set_app_paintable(table->widget, TRUE);
+  dt_gui_add_class(table->widget, "dt_transparent_background");
   gtk_widget_set_can_focus(table->widget, TRUE);
 
   g_signal_connect(G_OBJECT(table->widget), "event",

--- a/src/dtgtk/thumbnail_btn.c
+++ b/src/dtgtk/thumbnail_btn.c
@@ -125,7 +125,7 @@ GtkWidget *dtgtk_thumbnail_btn_new(DTGTKCairoPaintIconFunc paint, gint paintflag
                                                 | GDK_POINTER_MOTION_MASK | GDK_BUTTON_PRESS_MASK
                                                 | GDK_BUTTON_RELEASE_MASK | GDK_STRUCTURE_MASK
                                                 | GDK_ENTER_NOTIFY_MASK | GDK_ALL_EVENTS_MASK);
-  gtk_widget_set_app_paintable(GTK_WIDGET(button), TRUE);
+  dt_gui_add_class(GTK_WIDGET(button), "dt_transparent_background");
   gtk_widget_set_name(GTK_WIDGET(button), "thumbnail_btn");
   return (GtkWidget *)button;
 }

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -2573,7 +2573,7 @@ dt_thumbtable_t *dt_thumbtable_new()
                         | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK
                         | GDK_STRUCTURE_MASK
                         | GDK_ENTER_NOTIFY_MASK | GDK_LEAVE_NOTIFY_MASK);
-  gtk_widget_set_app_paintable(table->widget, TRUE);
+  dt_gui_add_class(table->widget, "dt_transparent_background");
   gtk_widget_set_can_focus(table->widget, TRUE);
 
   // drag and drop : used for reordering, interactions with maps,

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -1682,7 +1682,7 @@ int dt_gui_gtk_init(dt_gui_gtk_t *gui)
   dt_gui_presets_init();
 
   widget = dt_ui_center(darktable.gui->ui);
-  gtk_widget_set_app_paintable(widget, TRUE);
+  dt_gui_add_class(widget, "dt_transparent_background");
 
   // TODO: make this work as: libgnomeui testgnome.c
   /*  GtkContainer *box = GTK_CONTAINER(darktable.gui->widgets.plugins_vbox);
@@ -1910,7 +1910,7 @@ static GtkWidget *_init_outer_border(const gint width,
 {
   GtkWidget *widget = gtk_drawing_area_new();
   gtk_widget_set_size_request(widget, width, height);
-  gtk_widget_set_app_paintable(widget, TRUE);
+  dt_gui_add_class(widget, "dt_transparent_background");
   gtk_widget_set_events(widget,
                         GDK_EXPOSURE_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK
                         | GDK_ENTER_NOTIFY_MASK | GDK_LEAVE_NOTIFY_MASK | GDK_STRUCTURE_MASK
@@ -2038,7 +2038,7 @@ static void _init_main_table(GtkWidget *container)
   gtk_widget_set_size_request(cda, DT_PIXEL_APPLY_DPI(50), DT_PIXEL_APPLY_DPI(200));
   gtk_widget_set_hexpand(ocda, TRUE);
   gtk_widget_set_vexpand(ocda, TRUE);
-  gtk_widget_set_app_paintable(cda, TRUE);
+  dt_gui_add_class(cda, "dt_transparent_background");
   gtk_widget_set_can_focus(cda, TRUE);
   darktable.gui->ui->snapshot = gtk_drawing_area_new();
   gtk_widget_set_no_show_all(darktable.gui->ui->snapshot, TRUE);

--- a/src/gui/styles_dialog.c
+++ b/src/gui/styles_dialog.c
@@ -1040,7 +1040,7 @@ GtkWidget *dt_gui_style_content_dialog(char *name, const dt_imgid_t imgid)
       GtkWidget *da = gtk_drawing_area_new();
       gtk_widget_set_size_request(da, data.psize, data.psize);
       gtk_widget_set_halign(da, GTK_ALIGN_CENTER);
-      gtk_widget_set_app_paintable(da, TRUE);
+      dt_gui_add_class(da, "dt_transparent_background");
       gtk_box_pack_start(GTK_BOX(ht), da, TRUE, TRUE, 0);
       data.first_draw = TRUE;
       g_signal_connect(G_OBJECT(da), "draw", G_CALLBACK(_preview_draw), &data);

--- a/src/libs/navigation.c
+++ b/src/libs/navigation.c
@@ -225,7 +225,7 @@ void gui_init(dt_lib_module_t *self)
      _("navigation\nclick or drag to position zoomed area in center view"));
 
   /* connect callbacks */
-  gtk_widget_set_app_paintable(thumbnail, TRUE);
+  dt_gui_add_class(thumbnail, "dt_transparent_background");
   g_signal_connect(G_OBJECT(thumbnail), "draw",
                    G_CALLBACK(_lib_navigation_draw_callback), self);
   g_signal_connect(G_OBJECT(thumbnail), "button-press-event",

--- a/src/libs/tools/ratings.c
+++ b/src/libs/tools/ratings.c
@@ -95,7 +95,7 @@ void gui_init(dt_lib_module_t *self)
 
   /* connect callbacks */
   gtk_widget_set_tooltip_text(drawing, _("set star rating for selected images"));
-  gtk_widget_set_app_paintable(drawing, TRUE);
+  dt_gui_add_class(drawing, "dt_transparent_background");
   g_signal_connect(G_OBJECT(drawing), "draw", G_CALLBACK(_lib_ratings_draw_callback), self);
   g_signal_connect(G_OBJECT(drawing), "button-press-event", G_CALLBACK(_lib_ratings_button_press_callback), self);
   g_signal_connect(G_OBJECT(drawing), "button-release-event", G_CALLBACK(_lib_ratings_button_release_callback),

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -5416,7 +5416,7 @@ static void _darkroom_display_second_window(dt_develop_t *dev)
     gtk_widget_set_size_request(dev->preview2.widget, DT_PIXEL_APPLY_DPI_2ND_WND(dev, 50), DT_PIXEL_APPLY_DPI_2ND_WND(dev, 200));
     gtk_widget_set_hexpand(dev->preview2.widget, TRUE);
     gtk_widget_set_vexpand(dev->preview2.widget, TRUE);
-    gtk_widget_set_app_paintable(dev->preview2.widget, TRUE);
+    dt_gui_add_class(dev->preview2.widget, "dt_transparent_background");
 
     gtk_widget_set_events(dev->preview2.widget,
                           GDK_POINTER_MOTION_MASK


### PR DESCRIPTION
`gtk_widget_set_app_paintable()` is removed in GTK4 with no direct replacement. The migration guide recommends CSS `background: transparent` for widgets that need transparent backgrounds.

All 11 call sites across 9 files are custom-drawn widgets that handle their own painting via draw signal handlers. Replace each with the existing `dt_transparent_background` CSS class (`background-color: transparent; border: none`).

Related: "Stop using gtk_widget_set_app_paintable" https://github.com/darktable-org/darktable/issues/15920 #20433

>Stop using gtk_widget_set_app_paintable
>
>This is gone in GTK4 with no direct replacement. But for some usecases there are alternatives. If you want to make the background transparent, you can set the background color to, for example, rgba(255, 255, 255, 0) using CSS instead.

https://docs.gtk.org/gtk4/migrating-3to4.html