### PR TITLE
Fix chaotic feather on dense path masks

### DIFF
--- a/src/develop/masks/path.c
+++ b/src/develop/masks/path.c
@@ -110,20 +110,23 @@ static void _path_border_get_XY(const float p0x,
   // paths with sharp corners we get the point
   _path_get_XY(p0x, p0y, p1x, p1y, p2x, p2y, p3x, p3y, t, xc, yc);
 
-  // now we get derivative points
-  const double ti = 1.0 - (double)t;
-
-  const double t_t = (double)t * t;
-  const double ti_ti = ti * ti;
-  const double t_ti = t * ti;
-
-  const double a = 3.0 * ti_ti;
-  const double b = 3.0 * (ti_ti - 2.0 * t_ti);
-  const double c = 3.0 * (2.0 * t_ti - t_t);
-  const double d = 3.0 * t_t;
-
-  const double dx = -p0x * a + p1x * b + p2x * c + p3x * d;
-  const double dy = -p0y * a + p1y * b + p2y * c + p3y * d;
+  // finite-difference tangent — the analytic derivative loses precision
+  // when ctrls are near corners (potrace output)
+  const double dt = 0.1;
+  float xc2, yc2;
+  double dx, dy;
+  if((double)t + dt <= 1.0)
+  {
+    _path_get_XY(p0x, p0y, p1x, p1y, p2x, p2y, p3x, p3y, t + (float)dt, &xc2, &yc2);
+    dx = (double)xc2 - (double)*xc;
+    dy = (double)yc2 - (double)*yc;
+  }
+  else
+  {
+    _path_get_XY(p0x, p0y, p1x, p1y, p2x, p2y, p3x, p3y, t - (float)dt, &xc2, &yc2);
+    dx = (double)*xc - (double)xc2;
+    dy = (double)*yc - (double)yc2;
+  }
 
   // so we can have the resulting point
   if(dx == 0 && dy == 0)


### PR DESCRIPTION
Fixes #21525

**The bug:** AI object masks with dense potrace output render with the feather line jumping to random positions and drawing long chaotic lines instead of hugging the mask outline. Reproducer: 353 nodes, border ≈ 0.0005, ctrls essentially equal to their corners.

**Root cause:** `_path_border_get_XY` computes the tangent from the analytic bezier derivative, which at segment endpoints reduces to `3*(ctrl - corner)`. Potrace emits ctrls that sit sub-pixel from their corners, so that subtraction is dominated by float32 cancellation noise – the tangent direction ends up random, and scaling by the border radius scatters the border position anywhere on a large circle around the corner. When ctrls are exactly equal to the corner the derivative goes to zero, downstream gap-fill bails on the invalid input, and the border polyline connects surviving valid points across huge distances.

**The fix:** compute the tangent from a finite difference of the curve itself, `P(t + 0.1) - P(t)`, instead of the analytic derivative. `P(t)` is well-conditioned regardless of ctrl positions, so the tangent stays stable even when ctrls sit on their corners.

20 lines in one function, no signature change, no other file touched. Applies uniformly to fresh, edited, and stored-in-XMP masks with no migration.