### PR TITLE
fix(build): amend CMake warning

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -447,7 +447,12 @@ include_directories(SYSTEM ${LensFun_INCLUDE_DIRS})
 list(APPEND LIBS ${LensFun_LIBRARIES})
 
 find_package(SQLite3 3.26 REQUIRED)
-list(APPEND LIBS SQLite::SQLite3)
+
+if(NOT TARGET SQLite3::SQLite3) # Compatibility with CMake < 4.3
+  add_library(SQLite3::SQLite3 ALIAS SQLite::SQLite3)
+endif()
+
+list(APPEND LIBS SQLite3::SQLite3)
 
 foreach(lib ${OUR_LIBS} GIO GThread GModule PangoCairo Rsvg2 PNG JPEG TIFF LCMS2 JsonGlib)
   find_package(${lib} REQUIRED)


### PR DESCRIPTION
_CMake 4.3.4_ produced a `SQLite::SQLite3` deprecation warning.

The compatibility was verified by a successful build using Debian 12 with _CMake 3.25.1_.