### PR TITLE
Check seg->tmp allocation in dt_segmentation_init_struct

### DIFF
--- a/src/iop/hlreconstruct/segmentation.c
+++ b/src/iop/hlreconstruct/segmentation.c
@@ -637,7 +637,7 @@ gboolean dt_segmentation_init_struct(dt_iop_segmentation_t *seg,
   seg->val1 =   dt_alloc_align_float(slots);
   seg->val2 =   dt_alloc_align_float(slots);
 
-  if(!seg->data || !seg->size
+  if(!seg->data || !seg->tmp  || !seg->size
                 || !seg->xmin || !seg->xmax || !seg->ymin || !seg->ymax
                 || !seg->val1 || !seg->val2)
   {


### PR DESCRIPTION
Follow-up to #21516: the guard in `dt_segmentation_init_struct` still misses `seg->tmp`. If that allocation fails while the others succeed, the function returns `FALSE` (success) and `_dilating`/`_eroding` segfault on a NULL write. Adds `!seg->tmp` to the guard.