### PR TITLE
Fall back to finite-diff tangent when analytic derivative is zero

### DIFF
--- a/src/develop/masks/path.c
+++ b/src/develop/masks/path.c
@@ -110,22 +110,39 @@ static void _path_border_get_XY(const float p0x,
   // paths with sharp corners we get the point
   _path_get_XY(p0x, p0y, p1x, p1y, p2x, p2y, p3x, p3y, t, xc, yc);
 
-  // finite-difference tangent — the analytic derivative loses precision
-  // when ctrls are near corners (potrace output)
-  const double dt = 0.1;
-  float xc2, yc2;
-  double dx, dy;
-  if((double)t + dt <= 1.0)
+  // now we get derivative points
+  const double ti = 1.0 - (double)t;
+
+  const double t_t = (double)t * t;
+  const double ti_ti = ti * ti;
+  const double t_ti = t * ti;
+
+  const double a = 3.0 * ti_ti;
+  const double b = 3.0 * (ti_ti - 2.0 * t_ti);
+  const double c = 3.0 * (2.0 * t_ti - t_t);
+  const double d = 3.0 * t_t;
+
+  double dx = -p0x * a + p1x * b + p2x * c + p3x * d;
+  double dy = -p0y * a + p1y * b + p2y * c + p3y * d;
+
+  // ctrl coincides with corner (common in potrace output): fall back to
+  // a finite-difference sample of the curve for a valid tangent direction
+  if(dx == 0 && dy == 0)
   {
-    _path_get_XY(p0x, p0y, p1x, p1y, p2x, p2y, p3x, p3y, t + (float)dt, &xc2, &yc2);
-    dx = (double)xc2 - (double)*xc;
-    dy = (double)yc2 - (double)*yc;
-  }
-  else
-  {
-    _path_get_XY(p0x, p0y, p1x, p1y, p2x, p2y, p3x, p3y, t - (float)dt, &xc2, &yc2);
-    dx = (double)*xc - (double)xc2;
-    dy = (double)*yc - (double)yc2;
+    const double dt = 0.1;
+    float xc2, yc2;
+    if((double)t + dt <= 1.0)
+    {
+      _path_get_XY(p0x, p0y, p1x, p1y, p2x, p2y, p3x, p3y, t + (float)dt, &xc2, &yc2);
+      dx = (double)xc2 - (double)*xc;
+      dy = (double)yc2 - (double)*yc;
+    }
+    else
+    {
+      _path_get_XY(p0x, p0y, p1x, p1y, p2x, p2y, p3x, p3y, t - (float)dt, &xc2, &yc2);
+      dx = (double)*xc - (double)xc2;
+      dy = (double)*yc - (double)yc2;
+    }
   }
 
   // so we can have the resulting point


### PR DESCRIPTION
Fixes #21525 and #21557

Path masks with `ctrl == corner` at a segment endpoint (potrace routinely emits this) hit the exact-zero branch in `_path_border_get_XY`, which returned `DT_INVALID_COORDINATE`. Gap-fill then bailed on invalid input and the border polyline connected surviving points across huge distances - the chaotic wide crossing lines reported.

Fall back to a finite-difference sample of the curve for those cases. Non-degenerate paths hit the analytic branch as before, so existing masks and the integration tests are byte-identical.

Replaces the earlier attempt in be7259b546 (which switched to finite-diff unconditionally and shifted every path mask by a few pixels)