### PR TITLE
Invalidate input cachelines also if colorspace changed for blending

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -90,7 +90,7 @@ changes (where available).
 - Fixed an out-of-bounds read in the code responsible for raster
   mask caching.
 
-- Enforce darktable loading screen on windowes system to avoid
+- Enforce darktable loading screen on windows systems to avoid
   darkroom refreshing issues.
 
 - Fixed a bug in CPU opposed highlights code that could lead to out of
@@ -135,6 +135,8 @@ changes (where available).
 - Fix feather rendering on path masks whose control points coincide
   with their corners; previously produced wildly displaced border
   lines instead of a proper offset outline.
+
+- Fixed a bug leading to subtle color errors after history changes.
 
 ## Lua
 

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -1567,6 +1567,9 @@ static gboolean _pixelpipe_process_on_CPU(dt_dev_pixelpipe_t *pipe,
                                         roi_in->width, roi_in->height,
                                         input_format->cst, blend_cst, &input_format->cst,
                                         work_profile);
+    if(input_format->cst != blend_cst)
+      dt_dev_pixelpipe_invalidate_cacheline(pipe, input);
+
     dt_ioppr_transform_image_colorspace(module, *output, *output,
                                         roi_out->width, roi_out->height,
                                         pipe->dsc.cst, blend_cst, &pipe->dsc.cst,
@@ -2576,6 +2579,9 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
                                               roi_in.width, roi_in.height,
                                               input_format->cst, blend_cst, &input_format->cst,
                                               work_profile);
+          if(input_format->cst != blend_cst)
+            dt_dev_pixelpipe_invalidate_cacheline(pipe, input);
+
           dt_ioppr_transform_image_colorspace(module, *output, *output,
                                               roi_out->width, roi_out->height,
                                               pipe->dsc.cst, blend_cst, &pipe->dsc.cst,


### PR DESCRIPTION
An explanation why we currently **must** invalidate input cachelines in some cases

We have in-place changed the input data cacheline (cst_from != cst_to). Please note that cacheline dt_dev_pixelpipe_cache_t dsc has been updated via &input_format->cst so a cache hit in a following pipe won't convert again.

Reminders:
Above is principally safe since we have the pipe profiles integrated in basic hash so any profile change means the cacheline won't be used.

But check this scenario having three modules A,B and C
1. A outputs RGB to cacheline X
2. B converts X to LAB this might include RGB clipping (hash does not change) and writes RGB output to cacheline Y
3. C expects RGB and takes Y as input

Now disable B -> hash for X stays, piece hash for C changes. When restarting the pipe we might get a cache hit for line X as input for C,

4. C gets X and as finding LAB converts it to RGB, now we have different RGB data in X compared with starting point 1. Amount of diffs depends on conversions (non-linear, clipping).

Now enable B again ... input cacheline data are not stable! So for now we have to disable the input cacheline for stability whenever we transform colorspace inplace on cachelines.

@kofa73 @masterpiga you might be interested in above example