### PR TITLE
[uk.po] Some Ukrainian translation fixes for 5.6.1

### DIFF
--- a/po/uk.po
+++ b/po/uk.po
@@ -3078,7 +3078,7 @@ msgstr "Обертання синього"
 #: ../build/lib/darktable/plugins/introspection_agx.c:407
 #: ../build/lib/darktable/plugins/introspection_agx.c:606
 msgid "master purity boost"
-msgstr "Головне підвищення чистоти"
+msgstr "Головне підсилення чистоти"
 
 #: ../build/lib/darktable/plugins/introspection_agx.c:413
 #: ../build/lib/darktable/plugins/introspection_agx.c:610

--- a/po/uk.po
+++ b/po/uk.po
@@ -119,12 +119,12 @@ msgstr "лише великі записи"
 #: ../build/bin/conf_gen.h:492
 msgctxt "preferences"
 msgid "sensitive"
-msgstr "чутливо"
+msgstr "Чутливо"
 
 #: ../build/bin/conf_gen.h:493 ../build/bin/preferences_gen.h:4848
 msgctxt "preferences"
 msgid "insensitive"
-msgstr "нечутливо"
+msgstr "Нечутливо"
 
 #: ../build/bin/conf_gen.h:594
 msgctxt "preferences"
@@ -144,12 +144,12 @@ msgstr "Час імпорту"
 #: ../build/bin/conf_gen.h:1065
 msgctxt "preferences"
 msgid "folder name"
-msgstr "імена каталогів"
+msgstr "Імена каталогів"
 
 #: ../build/bin/conf_gen.h:1066
 msgctxt "preferences"
 msgid "display name"
-msgstr "відображувані імена"
+msgstr "Відображувані імена"
 
 #: ../build/bin/conf_gen.h:1085
 msgctxt "preferences"

--- a/po/uk.po
+++ b/po/uk.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: darktable\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2026-06-10 23:06+0200\n"
-"PO-Revision-Date: 2026-06-11 00:30+0300\n"
+"PO-Revision-Date: 2026-07-14 16:50+0300\n"
 "Last-Translator: Victor Forsiuk <vvforce@gmail.com>\n"
 "Language-Team: \n"
 "Language: uk\n"
@@ -2955,7 +2955,7 @@ msgstr "Масштабування динамічного діапазону"
 #: ../build/lib/darktable/plugins/introspection_agx.c:293
 #: ../build/lib/darktable/plugins/introspection_agx.c:530
 msgid "pivot relative exposure"
-msgstr "Експозиція відносно опорної точки"
+msgstr "Відносна експозиція опорної точки"
 
 #: ../build/lib/darktable/plugins/introspection_agx.c:299
 #: ../build/lib/darktable/plugins/introspection_agx.c:534


### PR DESCRIPTION
At least one of these fixes is an urgent matter and not about consistency or better wording, as the previous translation was incorrect (there was a wrong word order which distorted the meaning).