### PR TITLE
Restore empty tmp cursor to parent window cursor

### DIFF
--- a/src/control/control.c
+++ b/src/control/control.c
@@ -324,7 +324,12 @@ void dt_control_set_temp_cursor(const char *cursor_name)
 void dt_control_clear_temp_cursor()
 {
   GdkWindow *window = gtk_widget_get_window(dt_ui_main_window(darktable.gui->ui));
-  if(!_prev_cursor) return;
+  if(!_prev_cursor)
+  {
+    if(window)
+      gdk_window_set_cursor(window, NULL);
+    return;
+  }
   if(window)
     gdk_window_set_cursor(window, _prev_cursor);
   g_object_unref(_prev_cursor);

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -3526,7 +3526,7 @@ dt_iop_module_t *dt_dev_module_duplicate_ext(dt_develop_t *dev,
   dt_iop_module_t *module = calloc(1, sizeof(dt_iop_module_t));
   if(dt_iop_load_module(module, base->so, base->dev))
   {
-    free(module);
+    // failed module already freed while failing to load
     return NULL;
   }
   module->instance = base->instance;


### PR DESCRIPTION
If we had an undefined cursor when setting a temp cursor (cursor from parent window) we have to restore to parent window cursor when clearing the temp cursor.

Reported by @kofa73