### PR TITLE
Fix IOP order list for styles.

### DIFF
--- a/src/common/styles.c
+++ b/src/common/styles.c
@@ -230,7 +230,6 @@ GList *dt_styles_module_order_list(const char *name)
                               -1, &stmt, NULL);
   // clang-format on
   DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 1, name, -1, SQLITE_TRANSIENT);
-  sqlite3_step(stmt);
   if(sqlite3_step(stmt) == SQLITE_ROW)
   {
     if(sqlite3_column_type(stmt, 0) != SQLITE_NULL)


### PR DESCRIPTION
In 17ec53f a check has been made to ensure that a column was present. But it turns out that the previous sqlite3_step(stmt) was not removed.

Fix an issue where the styles having iop order list are broken.

Note that this issue has been introduced after 5.6.0 so it has never been in a stable versions.