### PR TITLE
Gamma corrected input scaling should support negatives

### DIFF
--- a/data/kernels/colorspaces.cl
+++ b/data/kernels/colorspaces.cl
@@ -108,9 +108,9 @@ colorspaces_transform_gamma(read_only image2d_t in,
   if(x >= width || y >= height) return;
 
   float4 pixel = Areadpixel(in, x, y);
-  // avoid NaN in possibly undefined channel
-  pixel.w = 0.0f;
-  pixel = fmax(0.0f, pixel);
+  // sanitize and fix NaN as we do for CPU
+  pixel = select(fmax(pixel, -1e6f), (float4)(0.0f), isnan(pixel));
+
   pixel = dtcl_pow(pixel, gamma);
   write_imagef(out, (int2)(x, y), pixel);
 }

--- a/src/develop/imageop_math.c
+++ b/src/develop/imageop_math.c
@@ -161,19 +161,16 @@ void dt_iop_clip_and_zoom(float *out,
   if(!linear)
     return dt_interpolation_resample(itor, out, roi_out, in, roi_in);
 
-  static const dt_aligned_pixel_t two_point_four = { 2.4f, 2.4f, 2.4f, 2.4f };
-  static const dt_aligned_pixel_t rev_two_point_four = { 1.0f / 2.4f, 1.0f / 2.4f, 1.0f / 2.4f, 1.0f / 2.4f };
-
   DT_OMP_SIMD(aligned(in, linear : 16))
   for(size_t k = 0; k < (size_t)roi_in->width * roi_in->height*4; k += 4)
-    dt_vector_powf(&in[k], two_point_four, &linear[k]);
+    for_each_channel(c) linear[k+c] = powf(fmaxf(in[k+c], -1e6f), 2.4f);  // fmaxf sanitizes NaN
 
   dt_interpolation_resample(itor, out, roi_out, linear, roi_in);
   dt_free_align(linear);
 
   DT_OMP_SIMD(aligned(out : 16))
   for(size_t k = 0; k < (size_t)roi_out->width * roi_out->height * 4; k += 4)
-    dt_vector_powf(&out[k], rev_two_point_four, &out[k]);
+    for_each_channel(c) out[k+c] = powf(out[k+c], 1.0f / 2.4f);
 }
 
 // apply clip and zoom on the image region supplied in the input buffer.


### PR DESCRIPTION
While feeding image data into the pipe we scale with gamma correction if no specific colorspace has been provided.
As some image types (like tiff float) can have valid negatives we have to respect that in CPU path so use powf() instead of the fast vector variant which doesn't correct for sign.

As some OpenCL cards/drivers go crazy for NaNs (old AMD) we check that and sanitize input data range to (never reached) above -1e6 both for CPU and GPU.

So both code paths provide identical data and avoid feeding NaNs into the pipe.