### PR TITLE
AppImage: fix application icon under wayland

### DIFF
--- a/data/org.darktable.darktable.desktop.in
+++ b/data/org.darktable.darktable.desktop.in
@@ -20,7 +20,7 @@ StartupNotify=true
 MimeType=application/x-darktable;image/x-dcraw;image/x-adobe-dng;image/x-canon-cr2;image/x-canon-crw;image/x-fuji-raf;image/x-kodak-dcr;image/x-kodak-kdc;image/x-minolta-mrw;image/x-nikon-nef;image/x-nikon-nrw;image/x-olympus-orf;image/x-panasonic-rw;image/x-panasonic-rw2;image/x-pentax-pef;image/x-sony-arw;image/x-sony-sr2;image/x-sony-srf;image/jpeg;image/png;image/tiff;image/x-portable-bitmap;image/x-portable-graymap;image/x-portable-pixmap;image/x-portable-floatmap;image/vnd.radiance;${DESKTOP_MIME_TYPES}
 
 Icon=darktable
-StartupWMClass=darktable
+StartupWMClass=org.darktable.darktable
 
 X-Unity-IconBackgroundColor=#252525
 


### PR DESCRIPTION
Using a self compiled AppImage with https://github.com/darktable-org/darktable/pull/21223 in place I noticed a bit of an obscure issue, which will (I guess) affect other users of the darktable AppImage under Wayland as well when/if https://github.com/darktable-org/darktable/pull/21223 gets merged and the AppImage gains the ability to actually launch into native Wayland instead of XWayland.

**Issue**:
I tested on both KDE and Gnome (Ubuntu): They both expect the .desktop file name to match the program name. `src/common/darktable.c` sets `org.darktable.darktable`, so the WM looks for a desktop file named `org.darktable.darktable.desktop` in order for the taskbar/dock and titlebar to display the correct icon. If the name doesn't match, it falls back to the `StartupWMClass` entry from the .desktop file, and if that doesn't match either, it defaults to a generic icon, which is cumbersome:

KDE:
<img width="220" height="114" alt="grafik" src="https://github.com/user-attachments/assets/4877e188-2938-4fda-8e37-5eb0ff8b0e8a" />
<img width="351" height="125" alt="grafik" src="https://github.com/user-attachments/assets/ca636854-c364-4258-8eb1-1917c2527070" />

Ubuntu:
<img width="144" height="331" alt="grafik" src="https://github.com/user-attachments/assets/2bf85a7c-3cea-45b9-a0bd-5de3b6ad18f0" />

**Cause**:
This mismatch between program name and .desktop file name will occur when the .desktop file is created by e.g. an AppImage integrator:
 * Gear Lever will name the file `darktable.desktop`
 * Shelly (tested on CachyOS) will name the file whatever the AppImage was named (e.g. `Darktable-5.7.0+75.g0eba994d63-x86_64.desktop`).

The issue of the titlebar icon under KDE is as far as I understand not fixable for us, as it stems from the peculiarities of how KDE assigns the icon to the titlebar. The taskbar/dock mismatch can however be fixed:

GTK derives the window identity from the program name:
* X11: `WM_CLASS(STRING) = "org.darktable.darktable", "Org.darktable.darktable"` (per `xprop`)
* Wayland: `app_id = org.darktable.darktable`

If the .desktop file doesn't name-match the window identity, `StartupWMClass` from within the .desktop file is consulted. However, `StartupWMClass` in `data/org.darktable.darktable.desktop.in` still carries `darktable`, leading to a further mismatch and the generic icon being displayed.

Note that this does not change anything for regular package-manager-installs: there the desktop file is named `org.darktable.darktable.desktop`; matching happens on the file name and `StartupWMClass` is never consulted in the first place. The entry only ever comes into play when the file has been renamed.

I tested this fix in combination with https://github.com/darktable-org/darktable/pull/21223 on both KDE/Wayland and Ubuntu/Wayland: in both it fixes the generic icon appearing in taskbar/dock. I also checked Linux Mint Cinnamon for side effects and didn't find any; which is expected, since `StartupWMClass` is merely a hint in the .desktop file and has no influence on the window's actual identity. Under X11 the instance part of `WM_CLASS` is derived from `g_set_prgname()` and reads `org.darktable.darktable` regardless of what this entry says (checked with `xprop`).
