### PR TITLE
Improve crop module performance

### DIFF
--- a/src/iop/crop.c
+++ b/src/iop/crop.c
@@ -115,6 +115,8 @@ typedef struct dt_iop_crop_data_t
   float cx, cy, cw, ch; // crop window
   int ratio_n;
   int ratio_d;
+  float crop_left;      // cached crop left offset (computed in modify_roi_out, < 0.0f means uncached)
+  float crop_top;       // cached crop top offset (computed in modify_roi_out, < 0.0f means uncached)
 } dt_iop_crop_data_t;
 
 const char *name()
@@ -448,16 +450,26 @@ static gboolean _set_max_clip(dt_iop_module_t *self)
 // (A factor=100 scaling was previously used here to reduce float truncation error, but it
 // produced non-integer offsets like 446.69 while the pipeline crops at integer pixel 446,
 // causing a ~0.7 pixel misalignment visible as ~11 screen pixels at 1600% zoom.)
+//
+// To prevent slowdown caused by running modify_roi_out repeatedly on hot path coordinate
+// transformations, computed offsets are cached in piece->data. Cache values less than 0.0f indicate
+// no cached data, triggering a dynamic fallback to modify_roi_out.
 static void _get_crop_offset(dt_iop_module_t *self,
                               dt_dev_pixelpipe_iop_t *piece,
                               float *crop_left,
                               float *crop_top)
 {
-  dt_iop_roi_t roi_in = piece->buf_in, roi_out;
-  self->modify_roi_out(self, piece, &roi_out, &roi_in);
-
-  *crop_left = roi_out.x;
-  *crop_top  = roi_out.y;
+  dt_iop_crop_data_t *d = piece->data;
+  // check the cache and skip the modify_roi_out() call if cached values exist.
+  if(d->crop_left < 0.0f)
+  {
+    dt_iop_roi_t roi_in = piece->buf_in, roi_out;
+    self->modify_roi_out(self, piece, &roi_out, &roi_in);
+    d->crop_left = roi_out.x;
+    d->crop_top  = roi_out.y;
+  }
+  *crop_left = d->crop_left;
+  *crop_top  = d->crop_top;
 }
 
 gboolean distort_transform(dt_iop_module_t *self,
@@ -622,6 +634,10 @@ void commit_params(dt_iop_module_t *self,
   dt_iop_crop_params_t *p = (dt_iop_crop_params_t *)p1;
   dt_iop_crop_data_t *d = piece->data;
 
+  // Invalidate cached offsets to trigger recalculation on the next frame/transform
+  d->crop_left = -1.0f;
+  d->crop_top = -1.0f;
+
   if(dt_iop_has_focus(self) && dt_pipe_is_basic(pipe))
   {
     d->cx = 0.0f;
@@ -711,6 +727,10 @@ void init_pipe(dt_iop_module_t *self,
                dt_dev_pixelpipe_iop_t *piece)
 {
   piece->data = malloc(sizeof(dt_iop_crop_data_t));
+  dt_iop_crop_data_t *d = piece->data;
+  // Initialize crop offset cache as empty (-1.0f)
+  d->crop_left = -1.0f;
+  d->crop_top = -1.0f;
 }
 
 void cleanup_pipe(dt_iop_module_t *self,


### PR DESCRIPTION
**tl;dr** - crop was being laggy for me on some images. This change caches calls to `modify_roi_out()` from `_get_crop_offset()`. This seems to fix the issue.

In the current `master` build of darktable, I noticed that on lots of images, when I enabled the `crop` module, the guides would immediately appear but a `working...` message would pop up. Any changes I made to the guides would snap back to their defaults after `working...` finished, which often took 5 seconds or more.

I couldn't figure out a reliable way to reproduce the issue, so I did the modern thing and used an LLM to look for the culprit. It identified that the combination of the fixes in #20556 and #20575 may have introduced a performance regression by calling `modify_roi_out()` on every mouse move, pan/zoom, or mask point redraw/update. Indeed, when I added a log statement in `modify_roi_out()`, I saw it being called every few milliseconds whenever I moved the mouse with the crop guides active. By adding in this caching, it only happens a few times.

-------

**I admit I'm a bit skeptical** that the several seconds of lag could be caused only by doing a bunch of floating point math, even if it is being repeated a few thousand times per second. On the other hand, I haven't seen the issue since I made this change. Even if it doesn't fix the issue, it will certainly increase performance with relatively little added complexity