### PR TITLE
Fixes race condition with mask resizing.

### DIFF
--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -1182,9 +1182,16 @@ gboolean dt_masks_events_mouse_moved(dt_iop_module_t *module,
     gui->posy = pzy * ht;
   }
 
+  // form->points can be mutated below (dragging a node); pixelpipe worker
+  // threads deep-copy dev->forms concurrently in dt_dev_pixelpipe_process, so
+  // this must be serialized against that read (see history_mutex there).
+  dt_pthread_mutex_lock(&darktable.develop->history_mutex);
+
   int rep = 0;
   if(form->functions)
     rep = form->functions->mouse_moved(module, pzx, pzy, pressure, which, zoom_scale, form, 0, gui, 0);
+
+  dt_pthread_mutex_unlock(&darktable.develop->history_mutex);
 
   if(gui) _set_hinter_message(gui, form);
 
@@ -1207,15 +1214,18 @@ gboolean dt_masks_events_button_released(dt_iop_module_t *module,
     dt_dev_masks_selection_change(dev, module, dev->mask_form_selected_id);
   DT_LEAVE_GUI_UPDATE();
 
+  gboolean ret = FALSE;
   if(form->functions)
   {
-    const int ret =
-      form->functions->button_released(module, pzx, pzy, which, state, form, 0, gui, 0);
+    // serialized against the pixelpipe's dt_masks_dup_forms_deep read of
+    // dev->forms/form->points, see history_mutex use in dt_dev_pixelpipe_process.
+    dt_pthread_mutex_lock(&dev->history_mutex);
+    ret = form->functions->button_released(module, pzx, pzy, which, state, form, 0, gui, 0);
     form->functions->mouse_moved(module, pzx, pzy, 0, which, zoom_scale, form, 0, gui, 0);
-    return ret;
+    dt_pthread_mutex_unlock(&dev->history_mutex);
   }
 
-  return FALSE;
+  return ret;
 }
 
 gboolean dt_masks_events_button_pressed(dt_iop_module_t *module,
@@ -1253,9 +1263,16 @@ gboolean dt_masks_events_button_pressed(dt_iop_module_t *module,
   }
 
   if(form->functions)
-    return form->functions->button_pressed(module, pzx, pzy, pressure,
-                                           which, type, state, form, 0, gui, 0)
-      || which == 3; // swallow right-clicks so right-drag rotate is disabled
+  {
+    // serialized against the pixelpipe's dt_masks_dup_forms_deep read of
+    // dev->forms/form->points, see history_mutex use in dt_dev_pixelpipe_process.
+    dt_pthread_mutex_lock(&darktable.develop->history_mutex);
+    const gboolean ret = form->functions->button_pressed(
+                           module, pzx, pzy, pressure, which, type, state, form, 0, gui, 0) ||
+                         which == 3; // swallow right-clicks so right-drag rotate is disabled
+    dt_pthread_mutex_unlock(&darktable.develop->history_mutex);
+    return ret;
+  }
   return FALSE;
 }
 
@@ -1289,9 +1306,15 @@ gboolean dt_masks_events_mouse_scrolled(dt_iop_module_t *module,
   const gboolean incr = dt_mask_scroll_increases(up);
 
   if(form->functions)
+  {
+    // serialized against the pixelpipe's dt_masks_dup_forms_deep read of
+    // dev->forms/form->points, see history_mutex use in dt_dev_pixelpipe_process.
+    dt_pthread_mutex_lock(&darktable.develop->history_mutex);
     ret = (form->functions->mouse_scrolled(module, pzx, pzy,
                                           incr ? 1 : 0,
                                           state, form, 0, gui, 0)) != 0;
+    dt_pthread_mutex_unlock(&darktable.develop->history_mutex);
+  }
 
   if(gui)
   {

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -3151,9 +3151,14 @@ gboolean dt_dev_pixelpipe_process(dt_dev_pixelpipe_t *pipe,
   dt_dev_zoom_pos_t pts = { zx, zy, zx + 1000.f, zy, zx, zy + 1000.f };
   dt_dev_distort_backtransform_plus(dev, pipe, 0.0f, DT_DEV_TRANSFORM_DIR_ALL_GEOMETRY, pts, 3);
 
-  // get a snapshot of mask list
+  // get a snapshot of mask list. Serialized against GUI-thread mutation of
+  // dev->forms/form->points (mask editing) via the same history_mutex used
+  // there, since g_list_copy_deep would otherwise walk a list that the GUI
+  // thread can concurrently free and replace (e.g. path grow/shrink).
+  dt_pthread_mutex_lock(&dev->history_mutex);
   if(pipe->forms) g_list_free_full(pipe->forms, (void (*)(void *))dt_masks_free_form);
   pipe->forms = dt_masks_dup_forms_deep(dev->forms, NULL);
+  dt_pthread_mutex_unlock(&dev->history_mutex);
 
   //  go through list of modules from the end:
   const guint pos = g_list_length(pipe->iop);


### PR DESCRIPTION
### Problem

The recently merged path grow/shrink could crash with a `SIGSEGV` in `_platform_memmove` on a pixelpipe worker thread. The GUI thread mutates `dev->forms` / `form->points` with no locking, while worker threads concurrently deep-copy that same data via `dt_masks_dup_forms_deep` → `g_list_copy_deep` in `dt_dev_pixelpipe_process`. When the GUI thread frees and rebuilds a form's point list mid-copy, the worker walks freed memory.

This is a long-standing latent race, but the new path grow/shrink feature makes it easy to trigger, as each scroll tick does a full `g_list_free_full` + rebuild of the entire point list (rather than a single-node edit).

### Fix

Serialize GUI-side mask mutation against the worker's forms snapshot using the existing recursive `dev->history_mutex` (already the guard for `hist->forms` writes):

-   **Worker read**  — guard the  `pipe->forms`  snapshot in  `dt_dev_pixelpipe_process`. This is the only point a worker touches the shared  `dev->forms`; all downstream processing reads the private  `pipe->forms`  copy.
-   **GUI writes**  — guard the four  `dt_masks_events_*`  dispatchers (`button_pressed`,  `button_released`,  `mouse_moved`,  `mouse_scrolled`), which wrap every  `form->functions->*`  call and thus cover all shape-type mutation sites at once.

`dt_dev_add_masks_history_item`'s own lock nests safely (recursive mutex). No lock-order inversion is introduced: the codebase invariant is history→busy, and both new acquisitions hold no `busy_mutex`.

Co-authored with Claude.