### PR TITLE
Pixelpipe 5.8 overhaul for efficacy

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -282,7 +282,7 @@ void dt_dev_cleanup(dt_develop_t *dev)
 
 void dt_dev_process_image(dt_develop_t *dev)
 {
-  if(!dev->gui_attached || dev->full.pipe->processing) return;
+  if(!dev->gui_attached || dt_pipe_started(dev->full.pipe)) return;
   const gboolean err = dt_control_add_job_res(dt_dev_process_image_job_create(dev), DT_CTL_WORKER_ZOOM_1);
   if(err) dt_print(DT_DEBUG_ALWAYS, "[dev_process_image] job queue exceeded!");
 }
@@ -622,7 +622,7 @@ void dt_dev_process_image_job(dt_develop_t *dev,
 
   dt_pthread_mutex_lock(&pipe->mutex);
 
-  if(dev->gui_leaving || (dt_atomic_get_int(&pipe->shutdown) != DT_DEV_PIXELPIPE_STOP_NO))
+  if(dev->gui_leaving || dt_pipe_started(pipe))
   {
     dt_pthread_mutex_unlock(&pipe->mutex);
     return;
@@ -787,7 +787,7 @@ restart:
 
   const gboolean early = dt_dev_pixelpipe_process(pipe, dev, x, y, wd, ht, scale, devid);
   const dt_dev_pixelpipe_stopper_t shutdown = dt_atomic_exch_int(&pipe->shutdown, DT_DEV_PIXELPIPE_STOP_NO);
-  const gboolean stopped = early || shutdown != DT_DEV_PIXELPIPE_STOP_NO;
+  const gboolean stopped = early || shutdown > DT_DEV_PIXELPIPE_PROCESSING;
 
   const dt_iop_roi_t proi = (dt_iop_roi_t) {.x = x, .y = y, .width = wd, .height = ht, .scale = scale };
   dt_print_pipe(DT_DEBUG_PIPE, stopped ? "pixelpipe_process stopped" : "pixelpipe_process good",
@@ -822,7 +822,7 @@ restart:
     /* pixelpipe stopped due to changed pipe nodes, HQ mode changes or module aborts
         while processing the pipe. All require restarts as pipe status is not valid yet.
     */
-    if(shutdown != DT_DEV_PIXELPIPE_STOP_NO)
+    if(shutdown > DT_DEV_PIXELPIPE_PROCESSING)
     {
       dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_VERBOSE, "image_job restart", pipe, NULL, DT_DEVICE_NONE, &proi, NULL);
       goto restart;
@@ -870,6 +870,8 @@ restart:
   dt_mipmap_cache_release(&buf);
   // if a widget needs to be redrawn there's the DT_SIGNAL_*_PIPE_FINISHED signals
   dt_control_busy_leave();
+  if(dt_pipe_is_full(pipe))
+    dev->history_last_module = NULL;
   dt_pthread_mutex_unlock(&pipe->mutex);
 
   const gboolean signalling = dev->gui_attached && !dev->gui_leaving && signal != -1;
@@ -3916,7 +3918,7 @@ static gboolean _dev_wait_hash(dt_develop_t *dev,
 
   for(int n = 0; n < nloop; n++)
   {
-    if(dt_atomic_get_int(&pipe->shutdown) != DT_DEV_PIXELPIPE_STOP_NO)
+    if(dt_atomic_get_int(&pipe->shutdown) > DT_DEV_PIXELPIPE_PROCESSING)
       return TRUE;  // stop waiting if pipe shuts down
 
     dt_hash_t probehash;

--- a/src/develop/pixelpipe_cache.c
+++ b/src/develop/pixelpipe_cache.c
@@ -23,11 +23,6 @@
 #include "libs/colorpicker.h"
 #include <stdlib.h>
 
-static inline int _to_mb(size_t m)
-{
-  return (int)((m + 0x80000lu) / 0x400lu / 0x400lu);
-}
-
 gboolean dt_dev_pixelpipe_cache_init(dt_dev_pixelpipe_t *pipe,
                                      const int entries,
                                      const size_t size,
@@ -36,7 +31,7 @@ gboolean dt_dev_pixelpipe_cache_init(dt_dev_pixelpipe_t *pipe,
   dt_dev_pixelpipe_cache_t *cache = &pipe->cache;
 
   cache->entries = entries;
-  cache->allmem = cache->hits = cache->calls = cache->tests = 0;
+  cache->allmem = cache->max_allmem = cache->hits = cache->calls = cache->tests = 0;
   cache->memlimit = limit;
 
   const size_t csize = sizeof(void *) + sizeof(size_t) + sizeof(dt_iop_buffer_dsc_t) + 2*sizeof(int32_t) + sizeof(uint64_t);
@@ -86,9 +81,10 @@ void dt_dev_pixelpipe_cache_cleanup(dt_dev_pixelpipe_t *pipe)
 
   if(dt_pipe_is_full(pipe))
   {
-    dt_print(DT_DEBUG_PIPE, "Session fullpipe cache report. hits/run=%.2f, hits/test=%.3f",
-    (double)(cache->hits) / fmax(1.0, pipe->runs),
-    (double)(cache->hits) / fmax(1.0, cache->tests));
+    dt_print(DT_DEBUG_PIPE, "Session fullpipe cache report. Maximum=%zuMB. hits/run=%.2f, hits/test=%.3f",
+      cache->max_allmem / DT_MEGA,
+      (double)(cache->hits) / fmax(1.0, pipe->runs),
+      (double)(cache->hits) / fmax(1.0, cache->tests));
   }
 
   for(int k = 0; k < cache->entries; k++)
@@ -311,7 +307,7 @@ gboolean dt_dev_pixelpipe_cache_get(dt_dev_pixelpipe_t *pipe,
      && _get_by_hash(pipe, module, hash, size, data, dsc))
   {
     const dt_iop_buffer_dsc_t *cdsc = *dsc;
-    dt_print_pipe(DT_DEBUG_PIPE, "cache HIT",
+    dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_VERBOSE, "cache HIT",
           pipe, module, DT_DEVICE_NONE, NULL, NULL,
           "%s %.3f %.3f %.3f, hash=%" PRIx64,
           dt_iop_colorspace_to_name(cdsc->cst), cdsc->temperature.coeffs[0], cdsc->temperature.coeffs[1], cdsc->temperature.coeffs[2],
@@ -368,12 +364,9 @@ gboolean dt_dev_pixelpipe_cache_get(dt_dev_pixelpipe_t *pipe,
   return TRUE;
 }
 
-static void _mark_invalid_cacheline(const dt_dev_pixelpipe_cache_t *cache, const int k)
-{
-  cache->hash[k] = DT_INVALID_HASH;
-  cache->ioporder[k] = 0;
-}
-
+/* Note about cacheline invalidation, once allocated they will stay until the next
+   pipe run to be possibly freed via dt_dev_pixelpipe_cache_checkmem().
+*/
 void dt_dev_pixelpipe_cache_invalidate_later(dt_dev_pixelpipe_t *pipe,
                                              const int32_t order,
                                              const char *info)
@@ -384,21 +377,19 @@ void dt_dev_pixelpipe_cache_invalidate_later(dt_dev_pixelpipe_t *pipe,
   {
     if((cache->ioporder[k] >= order) && (cache->hash[k] != DT_INVALID_HASH))
     {
-      _mark_invalid_cacheline(cache, k);
+      cache->hash[k] = DT_INVALID_HASH;
       invalidated++;
     }
   }
 
-  const gboolean bcache = pipe->bcache_data != NULL && pipe->bcache_hash != DT_INVALID_HASH;
   pipe->bcache_hash = DT_INVALID_HASH;
-
-  if(invalidated || bcache)
+  if(invalidated)
     dt_print_pipe(DT_DEBUG_PIPE,
     order ? "pipecache invalidate" : "pipecache flush",
     pipe, NULL, DT_DEVICE_NONE, NULL, NULL,
-    "%s%i cachelines after ioporder=%i%s",
+    "%s%i cachelines after ioporder=%i",
     info ? info : "",
-    invalidated, order, bcache ? ", blend cache" : "");
+    invalidated, order);
 }
 
 void dt_dev_pixelpipe_cache_flush(dt_dev_pixelpipe_t *pipe)
@@ -421,12 +412,19 @@ void dt_dev_pixelpipe_important_cacheline(const dt_dev_pixelpipe_t *pipe,
 }
 
 void dt_dev_pixelpipe_invalidate_cacheline(const dt_dev_pixelpipe_t *pipe,
-                                           const void *data)
+                                           const void *data,
+                                           const char *info)
 {
   const dt_dev_pixelpipe_cache_t *cache = &pipe->cache;
   for(int k = DT_PIPECACHE_MIN; k < cache->entries; k++)
   {
-    if(cache->data[k] == data) _mark_invalid_cacheline(cache, k);
+    if(cache->data[k] == data && cache->hash[k] != DT_INVALID_HASH)
+    {
+      cache->hash[k] = DT_INVALID_HASH;
+      if(info)
+        dt_print_pipe(DT_DEBUG_PIPE, "invalidate cacheline", pipe, NULL, pipe->devid, NULL, NULL,
+          "iop_order=%d '%s'", cache->ioporder[k], info);
+    }
   }
 }
 
@@ -438,25 +436,38 @@ static size_t _free_cacheline(dt_dev_pixelpipe_cache_t *cache, const int k)
   cache->allmem -= removed;
   cache->size[k] = 0;
   cache->data[k] = NULL;
-  _mark_invalid_cacheline(cache, k);
+  cache->hash[k] = DT_INVALID_HASH;
+  cache->ioporder[k] = 0;
   return removed;
 }
 
-static void _cline_stats(dt_dev_pixelpipe_cache_t *cache)
+static inline int _used(const dt_dev_pixelpipe_cache_t *cache)
 {
-  cache->lused = cache->linvalid = cache->limportant = 0;
+  int cnt = 0;
   for(int k = DT_PIPECACHE_MIN; k < cache->entries; k++)
-  {
-    if(cache->data[k]) cache->lused++;
-    if(cache->data[k] && (cache->hash[k] == DT_INVALID_HASH)) cache->linvalid++;
-    if(cache->used[k] < 0) cache->limportant++;
-  }
+    if(cache->data[k] && cache->hash[k] != DT_INVALID_HASH) cnt++;
+  return cnt;
+}
+static inline int _important(const dt_dev_pixelpipe_cache_t *cache)
+{
+  int cnt = 0;
+  for(int k = DT_PIPECACHE_MIN; k < cache->entries; k++)
+    if(cache->used[k] < 0 && cache->data[k] && cache->hash[k] != DT_INVALID_HASH) cnt++;
+  return cnt;
+}
+static inline int _invalid(const dt_dev_pixelpipe_cache_t *cache)
+{
+  int cnt = 0;
+  for(int k = DT_PIPECACHE_MIN; k < cache->entries; k++)
+    if(cache->data[k] && cache->hash[k] == DT_INVALID_HASH) cnt++;
+  return cnt;
 }
 
 void dt_dev_pixelpipe_cache_checkmem(dt_dev_pixelpipe_t *pipe)
 {
   dt_dev_pixelpipe_cache_t *cache = &pipe->cache;
 
+  cache->max_allmem = MAX(cache->max_allmem, cache->allmem);
   // we have pixelpipes like export & thumbnail that just use
   // alternating buffers so no cleanup
   if(cache->entries == DT_PIPECACHE_MIN) return;
@@ -464,10 +475,15 @@ void dt_dev_pixelpipe_cache_checkmem(dt_dev_pixelpipe_t *pipe)
   // We always free cachelines marked as not valid
   size_t freed = 0;
   size_t freed_invalid = 0;
+  int free_cnt = 0;
+  int free_invalid_cnt = 0;
   for(int k = DT_PIPECACHE_MIN; k < cache->entries; k++)
   {
-    if((cache->hash[k] == DT_INVALID_HASH) && cache->data)
+    if(cache->hash[k] == DT_INVALID_HASH && cache->data[k])
+    {
       freed_invalid += _free_cacheline(cache, k);
+      free_invalid_cnt++;
+    }
   }
 
   while(cache->memlimit && (cache->memlimit < cache->allmem))
@@ -476,24 +492,23 @@ void dt_dev_pixelpipe_cache_checkmem(dt_dev_pixelpipe_t *pipe)
     if(k == 0) break;
 
     freed += _free_cacheline(cache, k);
+    free_cnt++;
   }
 
-  _cline_stats(cache);
-  dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_MEMORY, "pipe cache check", pipe, NULL, DT_DEVICE_NONE, NULL, NULL,
-    "%i lines (important=%i, used=%i). Freed: invalid %iMB used %iMB. Using %iMB, limit=%iMB",
-    cache->entries, cache->limportant, cache->lused,
-    _to_mb(freed_invalid), _to_mb(freed), _to_mb(cache->allmem), _to_mb(cache->memlimit));
+  if(free_cnt + free_invalid_cnt)
+    dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_MEMORY, "pipe cache check", pipe, NULL, DT_DEVICE_NONE, NULL, NULL,
+      "Freed lines invalid=%i used=%i. Freed mem invalid %zuMB used %zuMB. Now %zuMB limit=%zuMB max=%zuMB",
+      free_invalid_cnt, free_cnt, freed_invalid/DT_MEGA, freed / DT_MEGA,
+      cache->allmem / DT_MEGA, cache->memlimit / DT_MEGA, cache->max_allmem / DT_MEGA);
 }
 
 void dt_dev_pixelpipe_cache_report(dt_dev_pixelpipe_t *pipe)
 {
   dt_dev_pixelpipe_cache_t *cache = &pipe->cache;
-
-  _cline_stats(cache);
   dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_MEMORY, "cache report", pipe, NULL, DT_DEVICE_NONE, NULL, NULL,
-    "%i lines (important=%i, used=%i, invalid=%i). Using %iMB, limit=%iMB. Hits/run=%.2f. Hits/test=%.3f",
-    cache->entries, cache->limportant, cache->lused, cache->linvalid,
-    _to_mb(cache->allmem), _to_mb(cache->memlimit),
+    "Lines=%i important=%i used=%i invalid=%i. Now=%zuMB limit=%zuMB max=%zuMB. Hits/run=%.2f. Hits/test=%.3f",
+    cache->entries, _important(cache), _used(cache), _invalid(cache),
+    cache->allmem / DT_MEGA, cache->memlimit / DT_MEGA, cache->max_allmem / DT_MEGA,
     (double)(cache->hits) / fmax(1.0, pipe->runs),
     (double)(cache->hits) / fmax(1.0, cache->tests));
 }
@@ -503,4 +518,3 @@ void dt_dev_pixelpipe_cache_report(dt_dev_pixelpipe_t *pipe)
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/develop/pixelpipe_cache.h
+++ b/src/develop/pixelpipe_cache.h
@@ -28,12 +28,13 @@ struct dt_iop_roi_t;
  * implements a simple pixel cache suitable for caching float images
  * corresponding to history items and zoom/pan settings in the develop module.
  * correctness is secured via the hash so make sure everything is included here.
- * No caching if cl_mem, instead copied cache buffers are used.
+ * No caching cl_mem, instead copied cache buffers are used.
  */
 typedef struct dt_dev_pixelpipe_cache_t
 {
   int32_t entries;
   size_t allmem;
+  size_t max_allmem;
   size_t memlimit;
   void **data;
   size_t *size;
@@ -43,12 +44,9 @@ typedef struct dt_dev_pixelpipe_cache_t
   int32_t *ioporder;
   uint64_t calls;
   int32_t lastline;
-  // profiling & stats:
+  // profiling
   uint64_t tests;
   uint64_t hits;
-  uint32_t lused;
-  uint32_t linvalid;
-  uint32_t limportant;
 } dt_dev_pixelpipe_cache_t;
 
 typedef enum dt_dev_pixelpipe_cache_test_t
@@ -90,7 +88,7 @@ void dt_dev_pixelpipe_cache_invalidate_later(struct dt_dev_pixelpipe_t *pipe, co
 void dt_dev_pixelpipe_important_cacheline(const struct dt_dev_pixelpipe_t *pipe, const void *data, const size_t size);
 
 /** mark the given cache line as invalid or to be ignored */
-void dt_dev_pixelpipe_invalidate_cacheline(const struct dt_dev_pixelpipe_t *pipe, const void *data);
+void dt_dev_pixelpipe_invalidate_cacheline(const struct dt_dev_pixelpipe_t *pipe, const void *data, const char *info);
 
 /** print out cache lines/hashes and do a cache cleanup */
 void dt_dev_pixelpipe_cache_report(struct dt_dev_pixelpipe_t *pipe);

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -47,17 +47,24 @@
 #define DT_DEV_AVERAGE_DELAY_START 250
 #define DT_DEV_PREVIEW_AVERAGE_DELAY_START 50
 
+/*
+  As this test is used in the early phase of a pixelpipe run we don't want to shutdown
+  the pipe for changed data or zoom.
+*/
 static inline gboolean _pipe_has_shutdown(dt_dev_pixelpipe_t *pipe)
 {
-  return dt_atomic_get_int(&pipe->shutdown) != DT_DEV_PIXELPIPE_STOP_NO;
+  const dt_dev_pixelpipe_stopper_t stopper = dt_atomic_get_int(&pipe->shutdown);
+  return stopper > DT_DEV_PIXELPIPE_PROCESSING
+      && stopper != DT_DEV_PIXELPIPE_STOP_ZOOM
+      && stopper != DT_DEV_PIXELPIPE_STOP_DATA;
 }
 
 // benchmarking and pfm dumps should happen for these pipes if there is no shutdown request
 static inline gboolean _is_debug_pipe(dt_dev_pixelpipe_t *pipe)
 {
-  return (dt_pipe_is_full(pipe) || dt_pipe_is_export(pipe)) && !_pipe_has_shutdown(pipe);
+  return (dt_pipe_is_full(pipe) || dt_pipe_is_export(pipe))
+      && (dt_atomic_get_int(&pipe->shutdown) == DT_DEV_PIXELPIPE_PROCESSING);
 }
-
 
 // forward declarations for mask cache helpers
 static void _clear_piece_mask_caches(dt_dev_pixelpipe_iop_t *piece);
@@ -106,9 +113,11 @@ const char *dt_dev_pixelpipe_shutdown_to_str(const dt_dev_pixelpipe_stopper_t st
   switch(stopper)
   {
   case DT_DEV_PIXELPIPE_STOP_NO:    return "DT_DEV_PIXELPIPE_STOP_NO";
+  case DT_DEV_PIXELPIPE_PROCESSING: return "DT_DEV_PIXELPIPE_PROCESSING";
   case DT_DEV_PIXELPIPE_STOP_NODES: return "DT_DEV_PIXELPIPE_STOP_NODES";
   case DT_DEV_PIXELPIPE_STOP_HQ:    return "DT_DEV_PIXELPIPE_STOP_HQ";
-  case DT_DEV_PIXELPIPE_STOP_LAST:  return "DT_DEV_PIXELPIPE_STOP_LAST";
+  case DT_DEV_PIXELPIPE_STOP_ZOOM:  return "DT_DEV_PIXELPIPE_STOP_ZOOM";
+  case DT_DEV_PIXELPIPE_STOP_DATA:  return "DT_DEV_PIXELPIPE_STOP_DATA";
   default:                          return "DT_DEV_PIXELPIPE_STOP_MODULE";
   }
 }
@@ -282,7 +291,6 @@ gboolean dt_dev_pixelpipe_init_cached(dt_dev_pixelpipe_t *pipe,
   memset(&pipe->scharr, 0, sizeof(dt_dev_detail_mask_t));
   pipe->want_detail_mask = FALSE;
 
-  pipe->processing = FALSE;
   dt_atomic_set_int(&pipe->shutdown, DT_DEV_PIXELPIPE_STOP_NO);
   pipe->opencl_error = FALSE;
   pipe->tiling = FALSE;
@@ -321,7 +329,6 @@ size_t dt_get_available_pipe_mem(const dt_dev_pixelpipe_t *pipe)
 static void get_output_format(dt_iop_module_t *module,
                               dt_dev_pixelpipe_t *pipe,
                               dt_dev_pixelpipe_iop_t *piece,
-                              dt_develop_t *dev,
                               dt_iop_buffer_dsc_t *dsc)
 {
   if(module) return module->output_format(module, pipe, piece, dsc);
@@ -348,7 +355,7 @@ void dt_dev_pixelpipe_set_input(dt_dev_pixelpipe_t *pipe,
   pipe->iscale = iscale;
   pipe->input = input;
   pipe->image = dev->image_storage;
-  get_output_format(NULL, pipe, NULL, dev, &pipe->dsc);
+  get_output_format(NULL, pipe, NULL, &pipe->dsc);
 }
 
 void dt_dev_pixelpipe_set_icc(dt_dev_pixelpipe_t *pipe,
@@ -363,25 +370,21 @@ void dt_dev_pixelpipe_set_icc(dt_dev_pixelpipe_t *pipe,
 }
 
 void dt_dev_pixelpipe_set_shutdown(dt_dev_pixelpipe_t *pipe,
-                                       const dt_dev_pixelpipe_stopper_t stopper)
+                                   const dt_dev_pixelpipe_stopper_t stopper)
 {
-#ifndef DT_PIPE_CAS_SHUTDOWN
-
-  dt_atomic_set_int(&pipe->shutdown, stopper);
-  dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_VERBOSE, "pipe shutdown request",
-      pipe, NULL, pipe->devid, NULL, NULL, "%s", dt_dev_pixelpipe_shutdown_to_str(stopper));
-
- #else
-
-  int expected = DT_DEV_PIXELPIPE_STOP_NO;
+  int expected = DT_DEV_PIXELPIPE_PROCESSING;
   const gboolean new = dt_atomic_CAS_int(&pipe->shutdown, &expected, stopper);
-  dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_VERBOSE, "pipe shutdown request",
+  if(new)
+    dt_print_pipe(DT_DEBUG_PIPE, "pipe shutdown request",
       pipe, NULL, pipe->devid, NULL, NULL,
-      "%s %s",
-      new ? "" : "failed, was",
-      new ? dt_dev_pixelpipe_shutdown_to_str(stopper)
-          : dt_dev_pixelpipe_shutdown_to_str(expected));
-#endif
+      "%s", dt_dev_pixelpipe_shutdown_to_str(stopper));
+  else
+    dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_VERBOSE, "pipe shutdown request",
+      pipe, NULL, pipe->devid, NULL, NULL,
+      "to %s %s. was %s",
+      dt_dev_pixelpipe_shutdown_to_str(stopper),
+      expected == DT_DEV_PIXELPIPE_STOP_NO ? "ignored" : "failed",
+      dt_dev_pixelpipe_shutdown_to_str(expected));
 }
 
 void dt_dev_pixelpipe_cleanup(dt_dev_pixelpipe_t *pipe)
@@ -924,6 +927,23 @@ static void _histogram_collect(dt_dev_pixelpipe_iop_t *piece,
 }
 
 #ifdef HAVE_OPENCL
+// helper for copy image to host with local error message
+static int _copy_image_to_host_err(const int devid,
+                                   void *host,
+                                   cl_mem img,
+                                   const int wd,
+                                   const int ht,
+                                   const int bpp,
+                                   const char *msg)
+{
+  const size_t reg[2] = { wd, ht };
+  const int err = dt_opencl_read_host_from_image_raw(devid, host, img, CLIMG_ORIGIN, reg, (size_t)wd * bpp, TRUE);
+  if(err != CL_SUCCESS)
+    dt_print(DT_DEBUG_ALWAYS, "[dt_opencl_copy_image_to_host '%s'] devid=%d %dx%d bpp=%d failed: '%s'",
+      msg, devid, wd, ht, bpp, cl_errstr(err));
+  return err;
+}
+
 // helper to get per module histogram for OpenCL
 //
 // this algorithm is inefficient as hell when it comes to larger
@@ -949,13 +969,10 @@ static void _histogram_collect_cl(const int devid,
 
   if(!pixel) return;
 
-  if(dt_opencl_copy_image_to_host(devid, pixel, img, roi->width, roi->height, sizeof(float) * 4)
+  if(_copy_image_to_host_err(devid, pixel, img, roi->width, roi->height, sizeof(float) * 4, "histogramm collect")
     != CL_SUCCESS)
   {
     dt_free_align(tmpbuf);
-    dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_OPENCL, "[histogram_collect]",
-                  piece->pipe, piece->module, devid, roi, NULL,
-                  "Couldn't read histogramm data");
     return;
   }
 
@@ -1300,11 +1317,11 @@ static void _collect_histogram_on_CPU(dt_dev_pixelpipe_t *pipe,
   As modules might change internal mask visualizing modes not visible via parameters
   we clear the blending cache line whenever we invalidate pixelpipe cache lines.
 */
-static inline dt_hash_t _piece_process_hash(const dt_dev_pixelpipe_iop_t *piece,
-                                            const dt_iop_roi_t *roi,
-                                            const dt_iop_module_t *module,
-                                            const int position)
+static inline dt_hash_t _bcache_hash(const dt_dev_pixelpipe_iop_t *piece,
+                                     const dt_iop_roi_t *roi,
+                                     const int position)
 {
+  const dt_iop_module_t *module = piece->module;
   dt_hash_t phash = dt_dev_pixelpipe_cache_hash(roi, piece->pipe, position -1);
   phash = dt_hash(phash, roi, sizeof(dt_iop_roi_t));
   phash = dt_hash(phash, &module->so->op, strlen(module->so->op));
@@ -1313,9 +1330,9 @@ static inline dt_hash_t _piece_process_hash(const dt_dev_pixelpipe_iop_t *piece,
   return phash;
 }
 
-static inline gboolean _piece_fast_blend(const dt_dev_pixelpipe_iop_t *piece,
-                                         const dt_iop_module_t *module)
+static inline gboolean _piece_fast_blend(const dt_dev_pixelpipe_iop_t *piece)
 {
+  const dt_iop_module_t *module = piece->module;
   return dt_pipe_is_canvas(piece->pipe)
          && darktable.pipe_cache
          && dt_iop_has_focus(module)
@@ -1336,31 +1353,34 @@ static inline float *_get_fast_blendcache(const size_t nfloats,
   return pipe->bcache_data;
 }
 
-/* use _module_pipe_stop to test for the just processed module leaving a flag to shutdown the pipeline
-   immediately.
-   This requires extra care as we want pipecache data after the module and it's input data to be invalidated.
-   All dt_dev_pixelpipe_stopper_t enums must be served.
+/* use _module_pipe_stop() to test for the just processed module leaving a flag
+   to shutdown the pipeline immediately.
+   All dt_dev_pixelpipe_stopper_t enums are served here,
+   taking care about cacheline invalidations.
 */
-static inline gboolean _module_pipe_stop(dt_dev_pixelpipe_t *pipe,
-                                         const dt_iop_module_t *module,
-                                         float *input)
+static inline dt_dev_pixelpipe_stopper_t _module_pipe_stop(dt_dev_pixelpipe_t *pipe,
+                                                           const dt_iop_module_t *module,
+                                                           float *outcacheline)
 {
   const dt_dev_pixelpipe_stopper_t stopper = dt_atomic_get_int(&pipe->shutdown);
-  if(stopper <= DT_DEV_PIXELPIPE_STOP_NO)
-    return FALSE;
+
+  if(stopper <= DT_DEV_PIXELPIPE_PROCESSING)
+    return DT_DEV_PIXELPIPE_STOP_NO;    // as being zero we can do simple if()
 
   dt_print_pipe(DT_DEBUG_PIPE, "module pipe stop",
       pipe, module, pipe->devid, NULL, NULL, "%s",
       dt_dev_pixelpipe_shutdown_to_str(stopper));
 
-  // These case don't require any caretaking of cachelines
-  if(stopper == DT_DEV_PIXELPIPE_STOP_NODES || stopper == DT_DEV_PIXELPIPE_STOP_HQ)
-    return TRUE;
+  dt_dev_pixelpipe_invalidate_cacheline(pipe, outcacheline, NULL);
 
-  // stopper reflects the iop_order of the stopping mode so we must invalidate.
-  dt_dev_pixelpipe_invalidate_cacheline(pipe, input);
-  dt_dev_pixelpipe_cache_invalidate_later(pipe, stopper, "module pipe stop: ");
-  return TRUE;
+  if(stopper == DT_DEV_PIXELPIPE_STOP_NODES
+        || stopper == DT_DEV_PIXELPIPE_STOP_HQ
+        || stopper == DT_DEV_PIXELPIPE_STOP_ZOOM)
+    return stopper;
+
+  if(stopper == DT_DEV_PIXELPIPE_STOP_DATA)
+    dt_dev_pixelpipe_cache_invalidate_later(pipe, module->iop_order, "module pipe stop: ");
+  return stopper;
 }
 
 void dt_dev_prepare_piece_cfa(dt_dev_pixelpipe_iop_t *piece, const dt_iop_roi_t *roi)
@@ -1433,10 +1453,12 @@ static gboolean _pixelpipe_process_on_CPU(dt_dev_pixelpipe_t *pipe,
                                           dt_pixelpipe_flow_t *pixelpipe_flow,
                                           const int position)
 {
-  if(_pipe_has_shutdown(pipe))
-    return TRUE;
-
-  // the data buffers must always have an alignment to DT_CACHELINE_BYTES
+  /*  The data buffers **must always have** an alignment to DT_CACHELINE_BYTES.
+      Any not aligned buffer means there is a major architecture problem within
+      the dt_alloc_() variants and requires investigation.
+      We can't correct/fix anything here but must avoid any further processing
+      so dt won't crash and will be able to write to the log.
+  */
   if(!dt_check_aligned(input) || !dt_check_aligned(*output))
   {
     dt_print_pipe(DT_DEBUG_ALWAYS,
@@ -1448,8 +1470,6 @@ static gboolean _pixelpipe_process_on_CPU(dt_dev_pixelpipe_t *pipe,
     dt_control_log(_("fatal pixelpipe abort due to non-aligned buffers\n"
                      "in module '%s'\nplease report on GitHub"),
                      module->op);
-    // this is a fundamental problem with severe problems ahead so good to finish
-    // the pipe as if good to avoid reprocessing in an endless loop.
     return FALSE;
   }
 
@@ -1467,6 +1487,17 @@ static gboolean _pixelpipe_process_on_CPU(dt_dev_pixelpipe_t *pipe,
 
   dt_dev_prepare_piece_cfa(piece, roi_in);
 
+  /* We don't want to modify the input cacheline data via colorspace transforms for less
+     required invalidations and thus more cacheline hits for the next pipe run.
+     So we use a temporary buffer for transformed content.
+     If allocation of that buffer fails, we fallback to invalidation.
+  */
+  dt_iop_colorspace_type_t cst_tmp = cst_from;
+  float *tmp = cst_from != cst_to && dt_pipe_is_screen(pipe)
+                  ? dt_iop_image_alloc(roi_in->width, roi_in->height, piece->colors)
+                  : input;
+  if(tmp == NULL) tmp = input;
+
   if(cst_from != cst_to)
   {
     dt_print_pipe(DT_DEBUG_PIPE,
@@ -1477,30 +1508,16 @@ static gboolean _pixelpipe_process_on_CPU(dt_dev_pixelpipe_t *pipe,
                   work_profile
                     ? dt_colorspaces_get_name(work_profile->type, work_profile->filename)
                     : "no work profile");
-  }
 
-  // transform to module input colorspace
-  dt_ioppr_transform_image_colorspace(module, input, input,
+    // transform input cacheline to module input colorspace
+    dt_ioppr_transform_image_colorspace(module, input, tmp,
                                       roi_in->width, roi_in->height,
-                                      cst_from, cst_to, &input_format->cst,
+                                      cst_tmp, cst_to, &cst_tmp,
                                       work_profile);
-  /*  We just have changed the input data if cst_from != cst_to so
-      the cacheline cst does not reflect the module input colorspace any more!
-      Note: in opencl code path this is different as the in-data colorspace conversion
-      is always done in cl_mem and thus does not affect pipecache.
-
-      Possible ways to handle this:
-      1. for now we just invalidate that cacheline so if the pipe is reprocessed we won't
-          use wrong data.
-      2. we should implement code for the pipe cache that modifies the data cst.
-  */
-  if(cst_from != cst_to)
-    dt_dev_pixelpipe_invalidate_cacheline(pipe, input);
-
-  if(_pipe_has_shutdown(pipe))
-    return TRUE;
-
-  _collect_histogram_on_CPU(pipe, dev, input, roi_in, module, piece, pixelpipe_flow);
+    if(tmp == input) // sorry, buffer allocation failed
+      dt_dev_pixelpipe_invalidate_cacheline(pipe, input, "inspace transform colorspace, no tmp");
+  }
+  _collect_histogram_on_CPU(pipe, dev, tmp, roi_in, module, piece, pixelpipe_flow);
 
   const size_t in_bpp = dt_iop_buffer_dsc_to_bpp(input_format);
   const size_t bpp = dt_iop_buffer_dsc_to_bpp(*out_format);
@@ -1516,15 +1533,13 @@ static gboolean _pixelpipe_process_on_CPU(dt_dev_pixelpipe_t *pipe,
   const gboolean pfm_dump = darktable.dump_pfm_pipe && _is_debug_pipe(pipe);
 
   if(pfm_dump)
-    dt_dump_pipe_pfm(module->op, input,
+    dt_dump_pipe_pfm(module->op, tmp,
                      roi_in->width, roi_in->height, in_bpp,
                      TRUE, dt_dev_pixelpipe_type_to_str(pipe->type));
 
   const size_t nfloats = bpp * roi_out->width * roi_out->height / sizeof(float);
-  const gboolean want_bcache = _piece_fast_blend(piece, module);
-  const dt_hash_t phash = want_bcache
-    ? _piece_process_hash(piece, roi_out, module, position)
-    : DT_INVALID_HASH;
+  const gboolean want_bcache = _piece_fast_blend(piece);
+  const dt_hash_t phash = want_bcache ? _bcache_hash(piece, roi_out, position) : DT_INVALID_HASH;
   const gboolean bcaching = want_bcache
     ? pipe->bcache_data && phash == pipe->bcache_hash && phash != DT_INVALID_HASH
     : FALSE;
@@ -1544,7 +1559,7 @@ static gboolean _pixelpipe_process_on_CPU(dt_dev_pixelpipe_t *pipe,
     }
     else
     {
-      module->process_tiling(module, piece, input, *output, roi_in, roi_out, in_bpp);
+      module->process_tiling(module, piece, tmp, *output, roi_in, roi_out, in_bpp);
       if(want_bcache)
       {
         if(dt_pipe_no_mask_display(pipe))
@@ -1564,14 +1579,14 @@ static gboolean _pixelpipe_process_on_CPU(dt_dev_pixelpipe_t *pipe,
   {
     dt_print_pipe(DT_DEBUG_PIPE,
        bcaching ? "from blend cache" : "process",
-       pipe, module, DT_DEVICE_CPU, roi_in, roi_out, "%s%s%s%s %.fMB",
+       pipe, module, DT_DEVICE_CPU, roi_in, roi_out, "%s%s%s%s %zuMB",
        dt_iop_colorspace_to_name(cst_to),
        cst_to != cst_out ? " -> " : "",
        cst_to != cst_out ? dt_iop_colorspace_to_name(cst_out) : "",
        (fitting)
        ? ""
        : " Warning: processed without tiling even if memory requirements are not met",
-       1e-6 * (tiling->factor * (m_width * m_height * m_bpp) + tiling->overhead));
+       (size_t)(tiling->factor * (m_width * m_height * m_bpp) + tiling->overhead) / DT_MEGA);
 
     if(bcaching)
     {
@@ -1580,9 +1595,9 @@ static gboolean _pixelpipe_process_on_CPU(dt_dev_pixelpipe_t *pipe,
     else
     {
       if(darktable.bench_module && _is_debug_pipe(pipe) && dt_str_commasubstring(darktable.bench_module, module->op))
-        _cpu_benchmark(pipe, module, piece, input, *output, roi_out, roi_in);
+        _cpu_benchmark(pipe, module, piece, tmp, *output, roi_out, roi_in);
 
-      module->process(module, piece, input, *output, roi_in, roi_out);
+      module->process(module, piece, tmp, *output, roi_in, roi_out);
       if(want_bcache)
       {
         if(dt_pipe_no_mask_display(pipe))
@@ -1600,11 +1615,21 @@ static gboolean _pixelpipe_process_on_CPU(dt_dev_pixelpipe_t *pipe,
                          | PIXELPIPE_FLOW_PROCESSED_WITH_TILING);
   }
 
+  if(_module_pipe_stop(pipe, module, *output) != DT_DEV_PIXELPIPE_STOP_NO)
+  {
+    if(input != tmp)
+    {
+      dt_free_align(tmp);
+      tmp = NULL;
+    }
+    return TRUE;
+  }
+
   if(pfm_dump)
   {
     dt_dump_pipe_pfm(module->op, *output, roi_out->width, roi_out->height, bpp,
                      FALSE, dt_dev_pixelpipe_type_to_str(pipe->type));
-    _dump_pipe_pfm_diff(module->op, input, roi_in, in_bpp, *output, roi_out, bpp,
+    _dump_pipe_pfm_diff(module->op, tmp, roi_in, in_bpp, *output, roi_out, bpp,
                         dt_dev_pixelpipe_type_to_str(pipe->type));
   }
 
@@ -1618,11 +1643,11 @@ static gboolean _pixelpipe_process_on_CPU(dt_dev_pixelpipe_t *pipe,
   // color picking for module
   if(_request_color_pick(pipe, dev, module) && !blend_picking)
   {
-    _pixelpipe_picker(module, piece, &piece->dsc_in, (float *)input, roi_in,
+    _pixelpipe_picker(module, piece, &piece->dsc_in, tmp, roi_in,
                       module->picked_color,
                       module->picked_color_min,
                       module->picked_color_max,
-                      input_format->cst, PIXELPIPE_PICKER_INPUT);
+                      cst_tmp, PIXELPIPE_PICKER_INPUT);
 
     _pixelpipe_picker(module, piece, &pipe->dsc, (float *)(*output), roi_out,
                       module->picked_output_color,
@@ -1633,23 +1658,26 @@ static gboolean _pixelpipe_process_on_CPU(dt_dev_pixelpipe_t *pipe,
     DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_CONTROL_PICKERDATA_READY, module, pipe);
   }
 
-  if(_pipe_has_shutdown(pipe))
-    return TRUE;
-
   // blend needs input/output images with default colorspace
   if(_transform_for_blend(module, piece))
   {
-    dt_ioppr_transform_image_colorspace(module, input, input,
+    if(cst_tmp != blend_cst)
+    {
+      dt_ioppr_transform_image_colorspace(module, tmp, tmp,
                                         roi_in->width, roi_in->height,
-                                        input_format->cst, blend_cst, &input_format->cst,
+                                        cst_tmp, blend_cst, &cst_tmp,
                                         work_profile);
+      if(tmp == input) // sorry, buffer allocation failed
+        dt_dev_pixelpipe_invalidate_cacheline(pipe, input, "inspace transform colorspace, no tmp");
+    }
+
     dt_ioppr_transform_image_colorspace(module, *output, *output,
                                         roi_out->width, roi_out->height,
                                         pipe->dsc.cst, blend_cst, &pipe->dsc.cst,
                                         work_profile);
     if(blend_picking)
     {
-      _pixelpipe_picker(module, piece, &piece->dsc_in, (float *)input, roi_in,
+      _pixelpipe_picker(module, piece, &piece->dsc_in, tmp, roi_in,
                         module->picked_color,
                         module->picked_color_min,
                         module->picked_color_max,
@@ -1667,12 +1695,16 @@ static gboolean _pixelpipe_process_on_CPU(dt_dev_pixelpipe_t *pipe,
   /* process blending on CPU */
   if(_piece_wants_blending(piece))
   {
-    dt_develop_blend_process(module, piece, input, *output, roi_in, roi_out);
+    dt_develop_blend_process(module, piece, tmp, *output, roi_in, roi_out);
     *pixelpipe_flow |= PIXELPIPE_FLOW_BLENDED_ON_CPU;
     *pixelpipe_flow &= ~PIXELPIPE_FLOW_BLENDED_ON_GPU;
   }
-
-  return _pipe_has_shutdown(pipe);
+  if(tmp != input)
+  {
+    dt_free_align(tmp);
+    tmp = NULL;
+  }
+  return FALSE;
 }
 
 #ifdef HAVE_OPENCL
@@ -1681,7 +1713,7 @@ static inline gboolean _opencl_pipe_isok(const dt_dev_pixelpipe_t *pipe)
   return darktable.opencl->inited
          && !darktable.opencl->stopped
          && pipe->opencl_enabled
-         && (pipe->devid > DT_DEVICE_CPU);
+          && (pipe->devid > DT_DEVICE_CPU);
 }
 
 static cl_int _opencl_benchmark(dt_dev_pixelpipe_t *pipe,
@@ -1813,12 +1845,6 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
                                            GList *pieces,
                                            const int pos)
 {
-  /* As this is done recursively we check for any dt_dev_pixelpipe_stopper_t
-     signal that might have been set.
-  */
-  if(_pipe_has_shutdown(pipe))
-    return TRUE;
-
   dt_iop_roi_t roi_in = *roi_out;
 
   char module_name[256] = { 0 };
@@ -1840,6 +1866,7 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
   else
     pipe->type &= ~DT_DEV_PIXELPIPE_FAST;
 
+  // recursively calling myself skipping the modules list
   if(modules)
   {
     module = modules->data;
@@ -1856,7 +1883,9 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
 
   if(module)
     g_strlcpy(module_name, module->op, MIN(sizeof(module_name), sizeof(module->op)));
-  get_output_format(module, pipe, piece, dev, *out_format);
+
+  // also handles the last run with no module provided
+  get_output_format(module, pipe, piece, *out_format);
   const size_t bpp = dt_iop_buffer_dsc_to_bpp(*out_format);
   const size_t bufsize = (size_t)bpp * roi_out->width * roi_out->height;
 
@@ -1883,7 +1912,7 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
     dt_dev_pixelpipe_cache_get(pipe, hash, bufsize,
                                output, out_format, module, TRUE);
     dt_print_pipe(DT_DEBUG_PIPE,
-                  "pipe data: from cache",
+                  "pipe data: cache HIT",
                   pipe, module, DT_DEVICE_NONE, &roi_in, NULL);
     // we're done! as colorpicker/scopes only work on gamma iop
     // input -- which is unavailable via cache -- there's no need to
@@ -1891,17 +1920,16 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
     return FALSE;
   }
 
-  // 2) if history changed, zoomed ... stop pipe processing, reasons will be handled in dt_dev_process_image_job()
+  // if history changed, zoomed ... stop pipe processing, reasons will be handled in dt_dev_process_image_job()
   if(_dev_pixelpipe_early_exit(dev, pipe))
     return TRUE;
 
-  // 3) input -> output
+  /* The modules list is empty now after the list of unskipped modules has been traversed
+     and we did not get input from the pipe cache so we need pipe input
+  */
   if(!modules)
   {
-    // 3a) import input array with given scale and roi
-    if(_pipe_has_shutdown(pipe))
-      return TRUE;
-
+    // import input array with given scale and roi
     dt_times_t start;
     dt_get_perf_times(&start);
 
@@ -2009,7 +2037,7 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
                     CLARG(clout), CLARG(clout), CLARG(roi_out->width), CLARG(roi_out->height), CLARGFLOAT(0.41666666666666666667f));
 
               if(err == CL_SUCCESS)
-                err = dt_opencl_copy_image_to_host(pipe->devid, *output, clout, roi_out->width, roi_out->height, bpp);
+                err = _copy_image_to_host_err(pipe->devid, *output, clout, roi_out->width, roi_out->height, bpp, "copy back gamma corrected");
               if(err == CL_SUCCESS)
                 done = TRUE;
               else
@@ -2051,10 +2079,7 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
     return FALSE;
   }
 
-  if(_pipe_has_shutdown(pipe))
-    return TRUE;
-
-  // 3b) recurse and obtain output array in &input
+  // 3b) still recurse from end of list to first, obtain output array in &input
 
   // get region of interest which is needed in input
   module->modify_roi_in(module, piece, roi_out, &roi_in);
@@ -2081,32 +2106,51 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
                                 g_list_previous(pieces), pos - 1))
     return TRUE;
 
+  /*  finally we don't recurse any longer but process modules in correct iop_order.
+
+      Before actually processing a module we can use a simplified test for a
+      shutdown request ensuring input cl_mem is released.
+  */
+  if(_pipe_has_shutdown(pipe))
+  {
+    dt_print_pipe(DT_DEBUG_PIPE, "pipe has shutdown",
+      pipe, module, pipe->devid, &roi_in, roi_out, "%s",
+      dt_dev_pixelpipe_shutdown_to_str(dt_atomic_get_int(&pipe->shutdown)));
+#ifdef HAVE_OPENCL
+      dt_opencl_release_mem_object(cl_mem_input);
+      cl_mem_input = NULL;
+#endif
+    return TRUE;
+  }
+
   const size_t in_bpp = dt_iop_buffer_dsc_to_bpp(input_format);
-
   piece->dsc_out = piece->dsc_in = *input_format;
-
   module->output_format(module, pipe, piece, &piece->dsc_out);
 
   **out_format = pipe->dsc = piece->dsc_out;
-
   const size_t out_bpp = dt_iop_buffer_dsc_to_bpp(*out_format);
 
-  if(_pipe_has_shutdown(pipe))
-    return TRUE;
+  const gboolean important_out = dt_pipe_is_screen(pipe) && (module->flags() & IOP_FLAGS_WRITE_PIPECACHE);
+  /* special case: user requests to see channel data in the parametric
+      mask of a module or the blending mask - only in full pipe.
+      In that case we skip all modules manipulating pixel content and only
+      process image distorting modules.
+      Finally "gamma" is responsible for displaying channel/mask data accordingly.
+    Note: As pipe->mask_display is intentionally not included in the piece hash
+      ensuring pixelpipe cacheline integrity, gamma is responsible to invalidate
+      it's input data.
+    FIXME: cpu bound bypassing is costly, just pointer handling?
+  */
+  const gboolean visualize_mask = dt_pipe_is_full(pipe)
+                                && dt_pipe_mask_display(pipe)
+                                && !(module->operation_tags() & IOP_TAG_DISTORT)
+                                && (in_bpp == out_bpp)
+                                && !dt_iop_module_is_gamma(module)
+                                && !memcmp(&roi_in, roi_out, sizeof(struct dt_iop_roi_t));
 
-  // reserve new cache line: output
-  const gboolean important = module
-      && dt_pipe_no_mask_display(pipe)
-      && dt_pipe_is_screen(pipe)
-      && (module->flags() & IOP_FLAGS_WRITE_PIPECACHE);
-
+  // reserve new cache line for output
   dt_dev_pixelpipe_cache_get(pipe, hash, bufsize,
-                             output, out_format, module, important);
-
-  if(_pipe_has_shutdown(pipe))
-    return TRUE;
-
-  gboolean important_cl_input = FALSE;
+                             output, out_format, module, important_out && !visualize_mask);
 
   dt_times_t start;
   dt_get_perf_times(&start);
@@ -2114,20 +2158,7 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
   dt_pixelpipe_flow_t pixelpipe_flow =
     (PIXELPIPE_FLOW_NONE | PIXELPIPE_FLOW_HISTOGRAM_NONE);
 
-  /* special case: user requests to see channel data in the parametric
-      mask of a module or the blending mask.
-      In that case we skip all modules manipulating pixel content and only
-      process image distorting modules.
-      Finally "gamma" is responsible for displaying channel/mask data accordingly.
-    Note: As pipe->mask_display is intentionally not included in the piece hash
-      ensuring pixelpipe cacheline integrity, gamma is responsible to invalidate
-      it's input data.
-  */
-  if(!dt_iop_module_is_gamma(module)
-     && dt_pipe_mask_display(pipe)
-     && !(module->operation_tags() & IOP_TAG_DISTORT)
-     && (in_bpp == out_bpp)
-     && !memcmp(&roi_in, roi_out, sizeof(struct dt_iop_roi_t)))
+  if(visualize_mask)
   {
     dt_print_pipe(DT_DEBUG_PIPE,
                     "pipe bypass", pipe, module, DT_DEVICE_NONE, &roi_in, roi_out);
@@ -2184,10 +2215,29 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
   assert(tiling.factor > 0.0f);
   assert(tiling.factor_cl > 0.0f);
 
-  if(_pipe_has_shutdown(pipe))
-    return TRUE;
-
   piece->module->position = pos;
+
+  /* For a good UI responsiveness we try to keep "important" data with a higher
+      priority in the pixelpipe cache.
+      For CPU bound module processing we simply call dt_dev_pixelpipe_important_cacheline()
+      for the cacheline.
+      As the gpu memory is more limited we currently use host memory for the iop cache
+      too but have to make sure cl_mem bound data are backcopied to host. As this is an
+      expensive operation we only do that if of importance for a resonsive UI:
+      a) for the currently focused module, as that is most likely to change again
+      b) if there is a hint for changed parameters in history via the flag
+      c) modules having the IOP_FLAGS_WRITE_PIPECACHE_IN
+
+  */
+  const gboolean has_focus = module == dt_dev_gui_module();
+  const gboolean last_history = darktable.develop->history_last_module == module;
+  const gboolean iop_wanting = module->flags() & IOP_FLAGS_WRITE_PIPECACHE_IN;
+  const gboolean important_input =
+          dt_pipe_no_mask_display(pipe)
+            && dt_pipe_is_screen(pipe)
+            && !dt_pipe_is_fast(pipe)
+            && dev->gui_attached
+            && (has_focus || last_history || iop_wanting);
 
 #ifdef HAVE_OPENCL
 
@@ -2205,8 +2255,7 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
     gboolean success_opencl = TRUE;
     dt_iop_colorspace_type_t input_cst_cl = input_format->cst;
 
-    /* if input is on gpu memory only, remember this fact to later
-     * take appropriate action */
+    /* if input is on gpu memory only, remember this fact to later take appropriate action */
     gboolean valid_input_on_gpu_only = (cl_mem_input != NULL);
 
     /* general remark: in case of opencl errors within modules or
@@ -2241,7 +2290,7 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
         possible_cl = FALSE;
     }
 
-    if(possible_cl)
+    if(possible_cl) // either direct or via tiling
     {
       dt_develop_blend_params_t *const bd = piece->blendop_data;
       if(bd)
@@ -2256,59 +2305,103 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
       }
     }
 
+    if(*cl_mem_output) // release stale cl_mem image as soon as possible for less mem pressure
+    {
+      dt_opencl_release_mem_object(*cl_mem_output);
+      *cl_mem_output = NULL;
+    }
+
+    if(possible_cl && cl_mem_input == NULL && fits_on_device)
+    {
+      cl_mem_input = dt_opencl_copy_host_to_image(pipe->devid, input, roi_in.width, roi_in.height, in_bpp);
+      if(cl_mem_input == NULL)
+      {
+        // This should not happen at all as fitting test was ok
+        dt_print(DT_DEBUG_OPENCL | DT_DEBUG_PIPE, "requested host to device %d failed", pipe->devid);
+        possible_cl = FALSE;
+      }
+    }
+
     if(possible_cl)
     {
       const dt_iop_colorspace_type_t cst_from = input_cst_cl;
       const dt_iop_colorspace_type_t cst_to = module->input_colorspace(module, pipe, piece);
       const dt_iop_colorspace_type_t cst_out = module->output_colorspace(module, pipe, piece);
+      const gboolean convert = cst_from != cst_to;
+      dt_iop_colorspace_type_t cst_tmp = cst_from;  // keep track on converted colorspace
 
-      if(cst_from != cst_to)
-        dt_print_pipe(DT_DEBUG_PIPE, "transform colorspace",
-                          pipe, module, pipe->devid, &roi_in, NULL, "%s -> %s `%s'",
+      const gboolean want_bcache = _piece_fast_blend(piece);
+      const dt_hash_t phash = want_bcache ? _bcache_hash(piece, roi_out, pos) : DT_INVALID_HASH;
+      const gboolean bcaching = want_bcache && pipe->bcache_data && phash == pipe->bcache_hash && phash != DT_INVALID_HASH;
+
+      /* if we are valid_input_on_gpu_only we want to copy back to host and update input_format->cst
+          - if input is marked as important
+          - if we later have to tile as cl_mem_input won't be used.
+      */
+      if((important_input || !fits_on_device) && valid_input_on_gpu_only)
+      {
+        if(_copy_image_to_host_err(pipe->devid, input, cl_mem_input, roi_in.width, roi_in.height, in_bpp, "input cacheline")
+            == CL_SUCCESS)
+        {
+          input_format->cst = input_cst_cl;
+          valid_input_on_gpu_only = FALSE;
+          if(!fits_on_device) // we have to opencl tile so won't need it
+          {
+            dt_opencl_release_mem_object(cl_mem_input);
+            cl_mem_input = NULL;
+          }
+        }
+        else
+        {
+          if(!fits_on_device)
+          {
+            /*  we couldn't copy to host - very likely a severe driver/cl_device problem -
+                so we can't do host bound tiling later on and will leave this for
+                final caretaking code to disable opencl for severe problems
+            */
+            success_opencl = FALSE;
+          }
+          dt_dev_pixelpipe_invalidate_cacheline(pipe, input, "backcopy to host failed");
+        }
+      }
+
+      // make sure colorspace transforms happen on a temporary buffer
+      float *tmp = convert && cl_mem_input == NULL && dt_pipe_is_screen(pipe)
+                  ? dt_iop_image_alloc(roi_in.width, roi_in.height, piece->colors)
+                  : input;
+      if(tmp == NULL) tmp = input;
+
+      if(convert)
+      {
+        dt_print_pipe(DT_DEBUG_PIPE, "transform colorspace", pipe, module, pipe->devid, &roi_in, NULL, "%s. %s -> %s `%s'",
+                          cl_mem_input ? "cl_mem" : "host",
                           dt_iop_colorspace_to_name(cst_from),
                           dt_iop_colorspace_to_name(cst_to),
                           work_profile ? dt_colorspaces_get_name(work_profile->type, work_profile->filename) : "no work profile");
 
-      gboolean didconvert = FALSE;
-      if(cl_mem_input != NULL || fits_on_device)
-      {
-        if(cl_mem_input == NULL)
-          cl_mem_input = dt_opencl_copy_host_to_image(pipe->devid, input, roi_in.width, roi_in.height, in_bpp);
-
         if(cl_mem_input)
         {
-          didconvert = success_opencl = dt_ioppr_transform_image_colorspace_cl(module, pipe->devid,
-                                                                  cl_mem_input, cl_mem_input,
-                                                                  roi_in.width, roi_in.height,
-                                                                  input_cst_cl, cst_to, &input_cst_cl,
-                                                                  work_profile);
+          success_opencl = dt_ioppr_transform_image_colorspace_cl(module, pipe->devid,
+                                                                cl_mem_input, cl_mem_input, roi_in.width, roi_in.height,
+                                                                cst_from, cst_to, &cst_tmp, work_profile);
         }
-        else
+        else // data for tiling have already been written to host so we transform but have to invalidate
         {
-          success_opencl = FALSE;
+          dt_ioppr_transform_image_colorspace(module, input, tmp, roi_in.width, roi_in.height,
+                                              cst_from, cst_to, &cst_tmp, work_profile);
+          if(input == tmp)
+            dt_dev_pixelpipe_invalidate_cacheline(pipe, input, "**inspace** transform colorspace after copy to host");
         }
       }
 
-      const gboolean want_bcache = _piece_fast_blend(piece, module);
-      const dt_hash_t phash = want_bcache
-            ? _piece_process_hash(piece, roi_out, module, pos)
-            : DT_INVALID_HASH;
-      const gboolean bcaching = want_bcache && pipe->bcache_data && phash == pipe->bcache_hash && phash != DT_INVALID_HASH;
-
       dt_print_pipe(DT_DEBUG_PIPE,
                         bcaching ? "from blend cache" : "process",
-                        pipe, module, pipe->devid, &roi_in, roi_out, "%s%s%s%s%s %.1fMB",
+                        pipe, module, pipe->devid, &roi_in, roi_out, "%s%s%s%s %zuMB",
                         dt_iop_colorspace_to_name(cst_to),
                         cst_to != cst_out ? " -> " : "",
                         cst_to != cst_out ? dt_iop_colorspace_to_name(cst_out) : "",
                         fits_on_device ? "" : ", tiled",
-                        *cl_mem_output ? ", stale outimage" : "",
-                        1e-6 * (tiling.factor_cl * (m_width * m_height * m_bpp) + tiling.overhead));
-      if(*cl_mem_output)
-      {
-        dt_opencl_release_mem_object(*cl_mem_output);
-        *cl_mem_output = NULL;
-      }
+                        (size_t)(tiling.factor_cl * (m_width * m_height * m_bpp) + tiling.overhead) / DT_MEGA);
 
       if(fits_on_device)
       {
@@ -2387,7 +2480,7 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
                 float *cache = _get_fast_blendcache(out_bpp * roi_out->width * roi_out->height / sizeof(float), phash, pipe);
                 if(cache)
                 {
-                  err = dt_opencl_copy_image_to_host(pipe->devid, cache, *cl_mem_output, roi_out->width, roi_out->height, out_bpp);
+                  err = _copy_image_to_host_err(pipe->devid, cache, *cl_mem_output, roi_out->width, roi_out->height, out_bpp, "fast blendcache");
                   if(err != CL_SUCCESS)
                   {
                     // for some reason writing to bcache failed so let's clear/invalidate it now and leave the error condition
@@ -2429,16 +2522,36 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
           pipe->dsc.cst = module->output_colorspace(module, pipe, piece);
         }
 
-        if(_module_pipe_stop(pipe, module, input))
+        const dt_dev_pixelpipe_stopper_t cl_stopper = _module_pipe_stop(pipe, module, *output);
+        if(cl_stopper != DT_DEV_PIXELPIPE_STOP_NO)
         {
+          /*  In case of a DT_DEV_PIXELPIPE_STOP_DATA shutdown we have invalidated all following
+              cachelines but we try to make input cacheline valid for next pipe run.
+          */
+          if(valid_input_on_gpu_only
+              && cl_stopper == DT_DEV_PIXELPIPE_STOP_DATA
+              && !convert
+              && _copy_image_to_host_err(pipe->devid, input, cl_mem_input, roi_in.width, roi_in.height, in_bpp, "input cacheline")
+                    == CL_SUCCESS)
+          {
+            input_format->cst = input_cst_cl;
+            valid_input_on_gpu_only = FALSE;
+          }
+
+          if(valid_input_on_gpu_only)
+             dt_dev_pixelpipe_invalidate_cacheline(pipe, input, "shutdown for GPU only");
+
+          dt_opencl_release_mem_object(*cl_mem_output);
+          *cl_mem_output = NULL;
           dt_opencl_release_mem_object(cl_mem_input);
+          cl_mem_input = NULL;
           return TRUE;
         }
 
         const dt_iop_colorspace_type_t blend_cst = dt_develop_blend_colorspace(piece, pipe->dsc.cst);
         const gboolean blend_picking = _request_color_pick(pipe, dev, module)
                                     && _transform_for_blend(module, piece)
-                                    && blend_cst != cst_to;
+                                    && blend_cst != cst_tmp;
         const size_t outbufsize = bpp * roi_out->width * roi_out->height;
 
         // color picking for module
@@ -2452,7 +2565,7 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
                                cl_mem_input, &roi_in,
                                module->picked_color, module->picked_color_min,
                                module->picked_color_max,
-                               *output, outbufsize, input_cst_cl,
+                               *output, outbufsize, cst_tmp,
                                PIXELPIPE_PICKER_INPUT);
           _pixelpipe_picker_cl(pipe->devid, module, piece, &pipe->dsc,
                                *cl_mem_output, roi_out,
@@ -2472,7 +2585,7 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
           success_opencl = dt_ioppr_transform_image_colorspace_cl(module, pipe->devid,
                                                                   cl_mem_input, cl_mem_input,
                                                                   roi_in.width, roi_in.height,
-                                                                  input_cst_cl, blend_cst, &input_cst_cl,
+                                                                  cst_tmp, blend_cst, &cst_tmp,
                                                                   work_profile);
 
           success_opencl &= dt_ioppr_transform_image_colorspace_cl(module, pipe->devid,
@@ -2511,58 +2624,21 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
         /* synchronization point for opencl pipe */
         if(success_opencl)
           success_opencl = dt_opencl_finish_sync_pipe(pipe->devid, pipe->type);
-
-        if(_pipe_has_shutdown(pipe))
-        {
-          dt_opencl_release_mem_object(cl_mem_input);
-          return TRUE;
-        }
       }
-      else if(piece->process_tiling_ready)
+      else if(piece->process_tiling_ready && success_opencl)
       {
-        /* image is too big for direct opencl processing -> try to
-         * process image via tiling */
-
-        /* we might need to copy back valid image from device to host */
-        if(cl_mem_input != NULL)
-        {
-          /* copy back to CPU buffer, then clean unneeded buffer */
-          if(dt_opencl_copy_image_to_host(pipe->devid, input, cl_mem_input, roi_in.width, roi_in.height, in_bpp)
-            != CL_SUCCESS)
-          {
-            dt_print_pipe(DT_DEBUG_OPENCL,
-                          "process",
-                          pipe, module, pipe->devid, &roi_in, roi_out, "%s",
-                          "couldn't copy input data back to host memory");
-            dt_opencl_release_mem_object(cl_mem_input);
-            pipe->opencl_error = TRUE;
-            return TRUE;
-          }
-          else
-            input_format->cst = input_cst_cl;
-
-          dt_opencl_release_mem_object(cl_mem_input);
-          cl_mem_input = NULL;
-          valid_input_on_gpu_only = FALSE;
-        }
-
-        // transform to module input colorspace if not done already
-        if(success_opencl && !didconvert)
-        {
-          dt_ioppr_transform_image_colorspace(module, input, input,
-                                              roi_in.width, roi_in.height,
-                                              input_format->cst, cst_to, &input_format->cst,
-                                              work_profile);
-          // the cacheline cst does not reflect the module input colorspace any more!
-          // FIXME let's invalidate for now
-          dt_dev_pixelpipe_invalidate_cacheline(pipe, input);
-        }
+        /* Image is too big for direct opencl processing -> try to process image via tiling.
+           Original cl_mem data has already been written to host cacheline.
+           If an input colorspace transform was required, the transformed data are in tmp
+           buffer and colorspace is cst_tst.
+        */
+        dt_opencl_release_mem_object(cl_mem_input);
+        cl_mem_input = NULL;
 
         // histogram collection for module
         if(success_opencl)
         {
-          _collect_histogram_on_CPU(pipe, dev, input, &roi_in,
-                                    module, piece, &pixelpipe_flow);
+          _collect_histogram_on_CPU(pipe, dev, tmp, &roi_in, module, piece, &pixelpipe_flow);
         }
 
         /* now call process_tiling_cl of module; module should emit
@@ -2578,7 +2654,7 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
           }
           else
           {
-            err = module->process_tiling_cl(module, piece, input,
+            err = module->process_tiling_cl(module, piece, tmp,
                                             *output, &roi_in, roi_out, in_bpp);
             if(want_bcache && (err == CL_SUCCESS))
             {
@@ -2609,22 +2685,28 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
           pipe->dsc.cst = module->output_colorspace(module, pipe, piece);
         }
 
-        if(_module_pipe_stop(pipe, module, input))
+        if(_module_pipe_stop(pipe, module, *output) != DT_DEV_PIXELPIPE_STOP_NO)
+        {
+          if(input != tmp)
+          {
+            dt_free_align(tmp);
+            tmp = NULL;
+          }
           return TRUE;
+        }
 
-        dt_iop_colorspace_type_t blend_cst =
-          dt_develop_blend_colorspace(piece, pipe->dsc.cst);
+        dt_iop_colorspace_type_t blend_cst = dt_develop_blend_colorspace(piece, pipe->dsc.cst);
         const gboolean blend_picking = _request_color_pick(pipe, dev, module)
                                     && _transform_for_blend(module, piece)
                                     && blend_cst != cst_to;
         // color picking for module
         if(success_opencl && !blend_picking && _request_color_pick(pipe, dev, module))
         {
-          _pixelpipe_picker(module, piece, &piece->dsc_in, (float *)input,
+          _pixelpipe_picker(module, piece, &piece->dsc_in, tmp,
                             &roi_in, module->picked_color,
                             module->picked_color_min,
                             module->picked_color_max,
-                            input_format->cst,
+                            cst_tmp,
                             PIXELPIPE_PICKER_INPUT);
           _pixelpipe_picker(module, piece, &pipe->dsc, (float *)(*output),
                             roi_out, module->picked_output_color,
@@ -2638,17 +2720,23 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
         // blend needs input/output images with default colorspace
         if(success_opencl && _transform_for_blend(module, piece))
         {
-          dt_ioppr_transform_image_colorspace(module, input, input,
+          if(cst_tmp != blend_cst)
+          {
+            dt_ioppr_transform_image_colorspace(module, tmp, tmp,
                                               roi_in.width, roi_in.height,
-                                              input_format->cst, blend_cst, &input_format->cst,
+                                              cst_tmp, blend_cst, &cst_tmp,
                                               work_profile);
+            if(tmp == input)
+              dt_dev_pixelpipe_invalidate_cacheline(pipe, input, "inplace colorspace transform for blend");
+          }
+
           dt_ioppr_transform_image_colorspace(module, *output, *output,
                                               roi_out->width, roi_out->height,
                                               pipe->dsc.cst, blend_cst, &pipe->dsc.cst,
                                               work_profile);
           if(blend_picking)
           {
-            _pixelpipe_picker(module, piece, &piece->dsc_in, (float *)input,
+            _pixelpipe_picker(module, piece, &piece->dsc_in, tmp,
                               &roi_in, module->picked_color,
                               module->picked_color_min,
                               module->picked_color_max,
@@ -2667,17 +2755,19 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
         /* do process blending on cpu (this is anyhow fast enough) */
         if(success_opencl && _piece_wants_blending(piece))
         {
-          dt_develop_blend_process(module, piece, input, *output, &roi_in, roi_out);
+          dt_develop_blend_process(module, piece, tmp, *output, &roi_in, roi_out);
           pixelpipe_flow |= PIXELPIPE_FLOW_BLENDED_ON_CPU;
           pixelpipe_flow &= ~PIXELPIPE_FLOW_BLENDED_ON_GPU;
+        }
+        if(tmp != input)
+        {
+          dt_free_align(tmp);
+          tmp = NULL;
         }
 
         /* synchronization point for opencl pipe */
         if(success_opencl)
           success_opencl = dt_opencl_finish_sync_pipe(pipe->devid, pipe->type);
-
-        if(_pipe_has_shutdown(pipe))
-          return TRUE;
       }
       else
       {
@@ -2686,69 +2776,12 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
         success_opencl = FALSE;
       }
 
-      if(_pipe_has_shutdown(pipe))
-      {
-        dt_opencl_release_mem_object(cl_mem_input);
-        return TRUE;
-      }
-
-      /* finally check, if we were successful processing this module either in tiled mode or not */
+      /* finally check if we were successful processing this module either in tiled mode or not */
       if(success_opencl)
       {
-        /* Nice, everything went fine
-
-           Copying device buffers back to host memory is an expensive
-           operation but is required for the iop cache.
-           As the gpu memory is very restricted we currently don't use that for a cache.
-
-           The iop cache hit rate is much more important for the UI responsiveness so we make
-           sure relevant cache line buffers are kept as input for reprocessing.
-           This is true
-             a) for the currently focused iop, as that is the iop which is most likely to change next
-             b) if there is a hint for changed parameters in history via the flag
-             c) modules having the IOP_FLAGS_WRITE_PIPECACHE_IN
-             d) in all a-c cases only for screen pipes and no mask_display
-
-           Note: we miss writing output for cache for now to be tested via IOP_FLAGS_WRITE_PIPECACHECL_OUT
+        /* Nice, everything went fine, we can now release cl_mem_input.
+           For opencl tiling this has been done before but dt_release is safe.
         */
-        const gboolean cachewrite = dt_pipe_no_mask_display(pipe)
-                                && dt_pipe_is_screen(pipe)
-                                && !dt_pipe_is_fast(pipe)
-                                && dev->gui_attached;
-
-        important_cl_input = cachewrite
-            && ((module == dt_dev_gui_module())
-                || darktable.develop->history_last_module == module
-                || (module->flags() & IOP_FLAGS_WRITE_PIPECACHE_IN));
-
-        if(important_cl_input)
-        {
-          /* write back input into cache for faster re-usal (full pipe or preview) */
-          if(cl_mem_input != NULL)
-          {
-            /* copy input to host memory, so we can find it in cache and wait via blocking flag */
-            if(dt_opencl_copy_image_to_host(pipe->devid, input, cl_mem_input, roi_in.width, roi_in.height, in_bpp)
-              != CL_SUCCESS)
-            {
-              important_cl_input = FALSE;
-              dt_print_pipe(DT_DEBUG_OPENCL,
-                "process", pipe, module, pipe->devid, &roi_in, roi_out, "%s",
-                  "couldn't copy input data back to host memory for caching");
-              /* that's all we do here, we later make sure to invalidate cache line */
-            }
-            else
-            {
-              dt_print_pipe(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE,
-                "copied CL input to host for pixelpipe cache", pipe, module, pipe->devid, &roi_in, NULL);
-              /* success: cache line is valid now, no need to invalidate it later */
-              valid_input_on_gpu_only = FALSE;
-
-              input_format->cst = input_cst_cl;
-            }
-          }
-        }
-
-        /* we can now release cl_mem_input */
         dt_opencl_release_mem_object(cl_mem_input);
         cl_mem_input = NULL;
         // we speculate on the next module to possibly copy back
@@ -2757,9 +2790,9 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
       }
       else
       {
-        /* Bad luck, opencl failed. Let's clean up and fall back to cpu module */
+        /* Bad luck, opencl failed. Let's clean up and fall back to cpu process module */
         dt_print_pipe(DT_DEBUG_OPENCL,
-           "pipe aborts", pipe, module, pipe->devid, &roi_in, roi_out, "%s",
+           "process failure", pipe, module, pipe->devid, &roi_in, roi_out, "%s",
                 "couldn't run module on GPU, falling back to CPU");
 
         /* we might need to free unused output buffer */
@@ -2770,89 +2803,116 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
         if(cl_mem_input != NULL)
         {
           /* copy back input to host memory, then clean no longer needed opencl buffer.
-             important info: in order to make this possible, opencl modules must
+             Important info: in order to make this possible, opencl modules must
              not spoil their input buffer, even in case of errors.
-             In-place colorspace conversion to input cst is good as the cpu fallback
-             won't do that conversion again.
+
+             The input_cl_mem might have some colorspace transforms applied before processing
+             or while blending so if we are valid_input_on_gpu_only we write transformed cl_mem
+             data to be written for later CPU processing.
+             As RGB->LAB->RGB transforms might introduce diffs we invalidate the cacheline
           */
-          if(dt_opencl_copy_image_to_host(pipe->devid, input, cl_mem_input, roi_in.width, roi_in.height, in_bpp)
-            != CL_SUCCESS)
+          if(valid_input_on_gpu_only)
           {
-            dt_print_pipe(DT_DEBUG_OPENCL,
-                          "process", pipe, module, pipe->devid, &roi_in, roi_out, "%s",
-                          "couldn't copy input data back to host memory for caching for CPU fallback");
-            dt_opencl_release_mem_object(cl_mem_input);
-            pipe->opencl_error = TRUE;
-            return TRUE;
+            if(_copy_image_to_host_err(pipe->devid, input, cl_mem_input, roi_in.width, roi_in.height, in_bpp, "opencl failed so write back to host")
+              != CL_SUCCESS)
+            {
+              dt_opencl_release_mem_object(cl_mem_input);
+              cl_mem_input = NULL;
+              pipe->opencl_error = TRUE;
+              return TRUE;
+            }
+            else
+            {
+              input_format->cst = cst_tmp;
+            }
+
+            // safe to use for this CPU process but not for next pixelpipe run.
+            if(cst_tmp != cst_from)
+              dt_dev_pixelpipe_invalidate_cacheline(pipe, input, "converted GPU to CPU fallback");
           }
-          else
-            input_format->cst = input_cst_cl;
 
           /* this is a good place to release event handles as we move from gpu to cpu here */
           dt_opencl_finish(pipe->devid);
           dt_opencl_release_mem_object(cl_mem_input);
+          cl_mem_input = NULL;
           valid_input_on_gpu_only = FALSE;
         }
+
+        if(input != tmp)
+        {
+          dt_free_align(tmp);
+          tmp = NULL;
+        }
+
         if(_pixelpipe_process_on_CPU(pipe, dev, input, input_format, &roi_in, output,
                                      out_format,
                                      roi_out, module, piece, &tiling, &pixelpipe_flow, pos))
           return TRUE;
       }
     }
-    else
+    else // OpenCL path had been detected as impossible
     {
-      /* we are not allowed to use opencl for this module */
       *cl_mem_output = NULL;
 
       /* cleanup unneeded opencl input buffer, and copy back to CPU */
       if(cl_mem_input != NULL)
       {
-        if(dt_opencl_copy_image_to_host(pipe->devid, input, cl_mem_input, roi_in.width, roi_in.height, in_bpp)
-          != CL_SUCCESS)
+        if(valid_input_on_gpu_only)
         {
-          dt_print_pipe(DT_DEBUG_OPENCL,
-                        "process", pipe, module, pipe->devid, &roi_in, roi_out, "%s",
-                        "couldn't copy input data back to host memory for CPU processing");
-          dt_opencl_release_mem_object(cl_mem_input);
-          pipe->opencl_error = TRUE;
-          return TRUE;
+          if(_copy_image_to_host_err(pipe->devid, input, cl_mem_input, roi_in.width, roi_in.height, in_bpp, "opencl not allowed")
+            != CL_SUCCESS)
+          {
+            dt_opencl_release_mem_object(cl_mem_input);
+            cl_mem_input = NULL;
+            pipe->opencl_error = TRUE;
+            return TRUE;
+          }
+          else
+          {
+            // Note: this copy to host bound input cacheline is safe as there was no colorspace transform.
+            input_format->cst = input_cst_cl;
+            dt_opencl_release_mem_object(cl_mem_input);
+            cl_mem_input = NULL;
+            valid_input_on_gpu_only = FALSE;
+          }
         }
-        else
-          input_format->cst = input_cst_cl;
 
         /* this is a good place to release event handles as we anyhow move from gpu to cpu here */
         dt_opencl_finish(pipe->devid);
-        dt_opencl_release_mem_object(cl_mem_input);
-        valid_input_on_gpu_only = FALSE;
       }
 
       if(_pixelpipe_process_on_CPU(pipe, dev, input, input_format, &roi_in,
-                                   output, out_format,
-                                   roi_out, module, piece, &tiling, &pixelpipe_flow, pos))
+                                   output, out_format, roi_out,
+                                   module, piece, &tiling, &pixelpipe_flow, pos))
         return TRUE;
     }
 
-    /* input is still only on GPU? Let's invalidate CPU input buffer then */
-    if(valid_input_on_gpu_only)
-      dt_dev_pixelpipe_invalidate_cacheline(pipe, input);
+    if(valid_input_on_gpu_only) // can't we clear/dealloc the cachline ?
+      dt_dev_pixelpipe_invalidate_cacheline(pipe, input, NULL);
   }
   else
+#endif // HAVE_OPENCL
   {
-    /* opencl is not inited or not enabled or we got no resource/device -> everything runs on cpu */
+    /* opencl is not included, not inited, not enabled or we got no resource/device -> everything runs on cpu */
     if(_pixelpipe_process_on_CPU(pipe, dev, input, input_format, &roi_in,
                                  output, out_format, roi_out,
                                  module, piece, &tiling, &pixelpipe_flow, pos))
       return TRUE;
   }
-#else // HAVE_OPENCL
-  if(_pixelpipe_process_on_CPU(pipe, dev, input, input_format, &roi_in,
-                               output, out_format, roi_out,
-                               module, piece, &tiling, &pixelpipe_flow, pos))
-    return TRUE;
-#endif // HAVE_OPENCL
+
+  if(important_input && input)
+  {
+    dt_print_pipe(DT_DEBUG_PIPE,
+                "importance hint", pipe, module, pipe->devid, &roi_in, NULL, "%s%s%s",
+                last_history ? "last_history " : "",
+                has_focus ? "focus " : "",
+                iop_wanting ? "iop_flags " : "");
+
+    dt_dev_pixelpipe_important_cacheline(pipe, input, roi_in.width * roi_in.height * in_bpp);
+  }
 
   if(dt_pipe_mask_display(pipe))
-    dt_dev_pixelpipe_invalidate_cacheline(pipe, *output);
+    dt_dev_pixelpipe_invalidate_cacheline(pipe, *output, "pipe mask display");
 
   char histogram_log[32] = "";
   if(!(pixelpipe_flow & PIXELPIPE_FLOW_HISTOGRAM_NONE))
@@ -2869,11 +2929,9 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
           ? "GPU"
           : pixelpipe_flow & PIXELPIPE_FLOW_PROCESSED_ON_CPU ? "CPU" : "",
      pixelpipe_flow & PIXELPIPE_FLOW_PROCESSED_WITH_TILING ? " with tiling" : "",
-     (!(pixelpipe_flow & PIXELPIPE_FLOW_HISTOGRAM_NONE)
-      && (piece->request_histogram & DT_REQUEST_ON))
+     (!(pixelpipe_flow & PIXELPIPE_FLOW_HISTOGRAM_NONE) && (piece->request_histogram & DT_REQUEST_ON))
           ? histogram_log
           : "",
-
      _piece_wants_blending(piece) ? ", blended on " : "",
      pixelpipe_flow & PIXELPIPE_FLOW_BLENDED_ON_GPU
           ? "GPU"
@@ -2884,39 +2942,14 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
 
   // special cases for active modules with available gui
   if(module
-     && darktable.develop->gui_attached
-     && module->enabled)
+      && darktable.develop->gui_attached
+      && module->enabled
+      && module->expanded
+      && dt_pipe_is_basic(pipe)
+      && (module->request_histogram & DT_REQUEST_EXPANDED))
   {
-    // Possibly give the input buffer of the current module more weight
-    // as the user is likely to change that one soon (again), so keep it in cache.
-    // Also do this if the clbuffer has been actively written
-    const gboolean has_focus = module == dt_dev_gui_module();
-    const gboolean last_history = darktable.develop->history_last_module == module;
-    if(dt_pipe_is_screen(pipe)
-        && dt_pipe_no_mask_display(pipe)
-        && (has_focus || last_history || important_cl_input || (module->flags() & IOP_FLAGS_WRITE_PIPECACHE_IN)))
-    {
-      dt_print_pipe(DT_DEBUG_PIPE,
-                    "importance hints",
-                    pipe, module, pipe->devid, &roi_in, NULL, "%s%s%s",
-                    last_history ? "input_hint " : "",
-                    has_focus ? "focus " : "",
-                    important_cl_input ? "important_in" : "");
-      dt_dev_pixelpipe_important_cacheline(pipe, input,
-                                           roi_in.width * roi_in.height * in_bpp);
-      if(dt_pipe_is_full(pipe) && last_history)
-        darktable.develop->history_last_module = NULL;
-    }
-
-    if(module->expanded
-       && dt_pipe_is_basic(pipe)
-       && (module->request_histogram & DT_REQUEST_EXPANDED))
-    {
-      dt_print_pipe(DT_DEBUG_PIPE, "internal histogram",
-                    pipe, module, DT_DEVICE_NONE, &roi_in, roi_out);
-      pipe->nocache = TRUE;
-      dt_dev_pixelpipe_invalidate_cacheline(pipe, *output);
-    }
+    pipe->nocache = TRUE;
+    dt_dev_pixelpipe_invalidate_cacheline(pipe, *output, "internal histogram");
   }
 
   // warn on NaN or infinity
@@ -2925,7 +2958,7 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
     gboolean valid_output = TRUE;
 #ifdef HAVE_OPENCL
     if(*cl_mem_output != NULL)
-      valid_output = dt_opencl_copy_image_to_host(pipe->devid, *output, *cl_mem_output, roi_out->width, roi_out->height, bpp)
+      valid_output = _copy_image_to_host_err(pipe->devid, *output, *cl_mem_output, roi_out->width, roi_out->height, bpp, "NaN analysis")
         == CL_SUCCESS;
 
 #endif
@@ -2980,19 +3013,17 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
   }
 
   // 4) colorpicker and scopes:
-  if(_pipe_has_shutdown(pipe))
-    return TRUE;
-
-  if(dev->gui_attached && !dev->gui_leaving
-     && pipe == dev->preview_pipe
-     && dt_iop_module_is_gamma(module)) // only gamma provides meaningful RGB data
+  if(dev->gui_attached
+      && !dev->gui_leaving
+      && pipe == dev->preview_pipe
+      && dt_iop_module_is_gamma(module)
+      && input) // gamma provides meaningful host bound RGB data as not having OpenCL code
   {
     // Pick RGB/Lab for the primary colorpicker and live samples
     if(darktable.lib->proxy.colorpicker.picker_proxy
        || darktable.lib->proxy.colorpicker.live_samples)
     {
-      _pixelpipe_pick_samples(dev, module, *out_format,
-                              (const float *const )input, &roi_in);
+      _pixelpipe_pick_samples(dev, module, *out_format, input, &roi_in);
     }
 
     // FIXME: read this from dt_ioppr_get_pipe_output_profile_info()?
@@ -3010,7 +3041,7 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
                                            display_profile,
                                            dt_ioppr_get_histogram_profile_info(dev));
   }
-  return _pipe_has_shutdown(pipe);
+  return FALSE;
 }
 
 
@@ -3095,8 +3126,8 @@ static gboolean _dev_pixelpipe_process_rec_and_backcopy(dt_dev_pixelpipe_t *pipe
   {
     if(*cl_mem_output != NULL)
     {
-      cl_int err = dt_opencl_copy_image_to_host(pipe->devid, *output, *cl_mem_output,
-                    roi_out->width, roi_out->height, dt_iop_buffer_dsc_to_bpp(*out_format));
+      cl_int err = _copy_image_to_host_err(pipe->devid, *output, *cl_mem_output,
+                    roi_out->width, roi_out->height, dt_iop_buffer_dsc_to_bpp(*out_format), "final backcopy");
       dt_opencl_release_mem_object(*cl_mem_output);
       *cl_mem_output = NULL;
 
@@ -3127,7 +3158,12 @@ gboolean dt_dev_pixelpipe_process(dt_dev_pixelpipe_t *pipe,
                                   const float scale,
                                   const int devid)
 {
-  pipe->processing = TRUE;
+  /* If there was a recent unserved DT_DEV_PIXELPIPE_STOP_NODES shutdown request
+     we should respect that for an early pipe exit,
+     otherwise we mark the pipe as processing
+  */
+  if(dt_atomic_get_int(&pipe->shutdown) !=  DT_DEV_PIXELPIPE_STOP_NODES)
+    dt_atomic_set_int(&pipe->shutdown, DT_DEV_PIXELPIPE_PROCESSING);
   pipe->nocache = dt_pipe_is_image(pipe);
   pipe->runs++;
   pipe->opencl_enabled = dt_opencl_running();
@@ -3270,10 +3306,7 @@ restart:
 
   // ... and in case of other errors ...
   if(err)
-  {
-    pipe->processing = FALSE;
     return TRUE;
-  }
 
   // terminate
   dt_pthread_mutex_lock(&pipe->backbuf_mutex);
@@ -3317,7 +3350,6 @@ restart:
                 pipe->image.filename, pipe->image.id);
   dt_print_mem_usage("after pixelpipe process");
 
-  pipe->processing = FALSE;
   return FALSE;
 }
 

--- a/src/develop/pixelpipe_hb.h
+++ b/src/develop/pixelpipe_hb.h
@@ -31,8 +31,6 @@ G_BEGIN_DECLS
 
 #define DT_PIPECACHE_MIN 2
 
-// #define DT_PIPE_CAS_SHUTDOWN
-
 /** cached distorted mask at a geometric module's output boundary.
  *  used to avoid re-distorting masks from scratch when multiple
  *  downstream modules request the same mask type. */
@@ -100,46 +98,51 @@ typedef enum dt_dev_pixelpipe_status_t
   DT_DEV_PIXELPIPE_INVALID = 3  // pixelpipe has finished; invalid result
 } dt_dev_pixelpipe_status_t;
 
-/* dt_dev_pixelpipe_stopper_t is used as shutdown in dt_dev_pixelpipe_t.
+/* dt_dev_pixelpipe_stopper_t is used for shutdown in dt_dev_pixelpipe_t.
     By design we can write atomically on a pipe->shutdown to request an early exit
     of the pixepipe process _dev_pixelpipe_process_rec().
 
-    This requires special care in
-      - _dev_pixelpipe_process_rec()
-      - dt_dev_process_image_job()
-    possibly invalidating wrong module input/output data in the pixelpipe cache,
-    ensure either an immediate restart of the pipe or exit of dt_dev_process_image_job()
-    with an error flag.
-    A reminder, when setting pipe->shutdown we might have to do that via dt_atomic_CAS_int()
-    with wxpected DT_DEV_PIXELPIPE_STOP_NO to avoid overwriting an earlier shutdown writing.
+    When setting pipe->shutdown we should use dt_dev_pixelpipe_set_shutdown(),
+    it uses dt_atomic_CAS_int so having only one shutdown request per pipe run.
+    The "expected" state is DT_DEV_PIXELPIPE_PROCESSING, in other states the
+    set_shutdown() request is ignored.
+    As we never have valid output data we always invalidate output cacheline.
 
-    A summary about how these shutdown modes are supposed to work.
+    A summary about how these shutdown modes are supposed to work:
 
     DT_DEV_PIXELPIPE_STOP_NO
-    Set whenever a pipe is started in _dev_pixelpipe_process_rec() as default.
+    Set whenever we initialize or clean up the pipe, means "pipe is idle"
+
+    DT_DEV_PIXELPIPE_PROCESSING
+    Set whenever a pipe is started making this different from idling mode STOP_NO.
+    Please note there is a very small timelap after the pipe thread has started.
 
     DT_DEV_PIXELPIPE_STOP_NODES
-    Set if the pipe should stop as the pipe nodes are changed so a restart is desired asap.
-    As nodes are recreated, we don't have to fiddle with pixelpipe cache.
+    Set if the pipe should stop as the pipe nodes are changed.
 
     DT_DEV_PIXELPIPE_STOP_HQ
     Used to switch between darkroom HQ modes.
-    Requires a restart of the pipe but pixelpipe cache can stay.
 
-    DT_DEV_PIXELPIPE_STOP_LAST
-    If the shutdown value is >= DT_DEV_PIXELPIPE_STOP_LAST it is understood as the iop_order
-    of a module.
-    Any module might set pipe->shutdown to it's iop_order, this is checked while processing
-    the pipe and if detected the piece input data and all pipe cachelines with at least
-    this iop_order will be invalidated.
+    DT_DEV_PIXELPIPE_STOP_ZOOM
+    A request to restart with different darkroom position or scale.
+    We might get back to last zoom setting pretty soon so we keep cachlines
+    as we do for above shutdown modes.
+
+    DT_DEV_PIXELPIPE_STOP_DATA
+    A request to restart with different module parameters.
+    As we missed processing the correct output and all following modules
+    will give different results accordingly we clear cachelines for following
+    modules (possibly writing back input cl_mem to host for a faster restart).
 */
 
 typedef enum dt_dev_pixelpipe_stopper_t
 {
   DT_DEV_PIXELPIPE_STOP_NO = 0,
+  DT_DEV_PIXELPIPE_PROCESSING,
   DT_DEV_PIXELPIPE_STOP_NODES,
   DT_DEV_PIXELPIPE_STOP_HQ,
-  DT_DEV_PIXELPIPE_STOP_LAST,
+  DT_DEV_PIXELPIPE_STOP_ZOOM,
+  DT_DEV_PIXELPIPE_STOP_DATA,
 } dt_dev_pixelpipe_stopper_t;
 
 typedef struct dt_dev_detail_mask_t
@@ -211,9 +214,7 @@ typedef struct dt_dev_pixelpipe_t
   gboolean nocache;
 
   dt_imgid_t output_imgid;
-  // working?
-  gboolean processing;
-  /* shutting down?
+  /* Testing for shutting down and a running pixelpipe
      can be used in various ways defined in dt_dev_pixelpipe_stopper_t, in all cases the
        running pipe is stopped asap
      If we don't use one of the enum values this is interpreted as the iop_order of the module
@@ -317,14 +318,21 @@ static inline gboolean dt_pipe_mask_display(const dt_dev_pixelpipe_t *pipe)
 {
   return pipe->mask_display != DT_DEV_PIXELPIPE_DISPLAY_NONE;
 }
+static inline gboolean dt_pipe_processing(dt_dev_pixelpipe_t *pipe)
+{
+  return dt_atomic_get_int(&pipe->shutdown) == DT_DEV_PIXELPIPE_PROCESSING;
+}
+static inline gboolean dt_pipe_started(dt_dev_pixelpipe_t *pipe)
+{
+  return dt_atomic_get_int(&pipe->shutdown) >= DT_DEV_PIXELPIPE_PROCESSING;
+}
 
 // report pipe->type as textual string
 const char *dt_dev_pixelpipe_type_to_str(const dt_dev_pixelpipe_type_t pipe_type);
 // return pipe->shutdown as textual
 const char *dt_dev_pixelpipe_shutdown_to_str(const dt_dev_pixelpipe_stopper_t stopper);
 
-// sets pipe->shutdown in atomic mode
-// If DT_PIPE_CAS_SHUTDOWN is defined do that only if shutdown was DT_DEV_PIXELPIPE_STOP_NO
+// sets pipe->shutdown in atomic CAS mode so only one mode is possible per pipe run
 void dt_dev_pixelpipe_set_shutdown(dt_dev_pixelpipe_t *pipe, const dt_dev_pixelpipe_stopper_t stopper);
 
 // inits the pixelpipe with plain passthrough input/output and empty input and default caching settings.

--- a/src/iop/gamma.c
+++ b/src/iop/gamma.c
@@ -336,7 +336,7 @@ void process(dt_iop_module_t *self,
   }
 
   if(mask_display)
-    dt_dev_pixelpipe_invalidate_cacheline(piece->pipe, i);
+    dt_dev_pixelpipe_invalidate_cacheline(piece->pipe, i, "gamma mask display");
 }
 
 void init(dt_iop_module_t *self)

--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -1803,7 +1803,7 @@ static void auto_adjust_exposure_boost(GtkWidget *quad, dt_iop_module_t *self)
     return;
   }
 
-  if(!g->luminance_valid || self->dev->full.pipe->processing || !g->histogram_valid)
+  if(!g->luminance_valid || dt_pipe_processing(self->dev->full.pipe) || !g->histogram_valid)
   {
     dt_control_log(_("wait for the preview to finish recomputing"));
     return;
@@ -1869,7 +1869,7 @@ static void auto_adjust_contrast_boost(GtkWidget *quad, dt_iop_module_t *self)
     return;
   }
 
-  if(!g->luminance_valid || self->dev->full.pipe->processing || !g->histogram_valid)
+  if(!g->luminance_valid || dt_pipe_processing(self->dev->full.pipe) || !g->histogram_valid)
   {
     dt_control_log(_("wait for the preview to finish recomputing"));
     return;
@@ -1994,7 +1994,7 @@ static void switch_cursors(dt_iop_module_t *self)
     // do nothing and let the app decide
     return;
   }
-  else if((self->dev->full.pipe->processing
+  else if((dt_pipe_processing(self->dev->full.pipe)
            || self->dev->full.pipe->status == DT_DEV_PIXELPIPE_DIRTY
            || self->dev->preview_pipe->status == DT_DEV_PIXELPIPE_DIRTY)
           && g->cursor_valid)
@@ -2007,7 +2007,7 @@ static void switch_cursors(dt_iop_module_t *self)
 
     dt_control_queue_redraw_center();
   }
-  else if(g->cursor_valid && !self->dev->full.pipe->processing)
+  else if(g->cursor_valid && !dt_pipe_processing(self->dev->full.pipe))
   {
     // if pipe is clean and idle and cursor is on preview,
     // hide GTK cursor because we display our custom one
@@ -2079,7 +2079,7 @@ int mouse_moved(dt_iop_module_t *self,
   dt_iop_gui_leave_critical_section(self);
 
   // store the actual exposure too, to spare I/O op
-  if(g->cursor_valid && !dev->full.pipe->processing && g->luminance_valid)
+  if(g->cursor_valid && !dt_pipe_processing(dev->full.pipe) && g->luminance_valid)
     g->cursor_exposure = log2f(_luminance_from_module_buffer(self));
 
   switch_cursors(self);
@@ -2197,7 +2197,7 @@ int scrolled(dt_iop_module_t *self,
                      || !g->luminance_valid
                      || !g->interpolation_valid
                      || !g->user_param_valid
-                     || dev->full.pipe->processing
+                     || dt_pipe_processing(dev->full.pipe)
                      || !g->has_focus;
 
   dt_iop_gui_leave_critical_section(self);
@@ -2358,7 +2358,7 @@ void gui_post_expose(dt_iop_module_t *self,
 
   const gboolean fail = !g->cursor_valid
                      || !g->interpolation_valid
-                     || dev->full.pipe->processing
+                     || dt_pipe_processing(dev->full.pipe)
                      || !g->has_focus;
 
   dt_iop_gui_leave_critical_section(self);

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -1943,13 +1943,10 @@ static void _latescaling_quickbutton_clicked(GtkWidget *w,
   dt_conf_set_bool("darkroom/ui/late_scaling/enabled", dev->late_scaling.enabled);
 
   // we just toggled off and had one of HQ pipelines running
-  if(!dev->late_scaling.enabled
-      && (dev->full.pipe->processing
-          || (dev->second_wnd && dev->preview2.pipe->processing)))
+  if(!dev->late_scaling.enabled)
   {
-    if(dev->full.pipe->processing)
-      dt_dev_pixelpipe_set_shutdown(dev->full.pipe, DT_DEV_PIXELPIPE_STOP_HQ);
-    if(dev->second_wnd && dev->preview2.pipe->processing)
+    dt_dev_pixelpipe_set_shutdown(dev->full.pipe, DT_DEV_PIXELPIPE_STOP_HQ);
+    if(dev->second_wnd)
       dt_dev_pixelpipe_set_shutdown(dev->preview2.pipe, DT_DEV_PIXELPIPE_STOP_HQ);
 
     // do it the hard way for safety
@@ -3828,14 +3825,6 @@ void enter(dt_view_t *self)
   dt_print(DT_DEBUG_CONTROL, "[run_job+] 11 %f in darkroom mode", dt_get_wtime());
   dt_develop_t *dev = self->data;
 
-  // Reset shutdown flags on all pipes - they may still be set from previous session
-  if(dev->full.pipe)
-    dt_atomic_set_int(&dev->full.pipe->shutdown, DT_DEV_PIXELPIPE_STOP_NO);
-  if(dev->preview_pipe)
-    dt_atomic_set_int(&dev->preview_pipe->shutdown, DT_DEV_PIXELPIPE_STOP_NO);
-  if(dev->preview2.pipe)
-    dt_atomic_set_int(&dev->preview2.pipe->shutdown, DT_DEV_PIXELPIPE_STOP_NO);
-
   if(!dev->form_gui)
   {
     dev->form_gui = (dt_masks_form_gui_t *)calloc(1, sizeof(dt_masks_form_gui_t));
@@ -5281,10 +5270,14 @@ static void _darkroom_ui_second_window_write_config(GtkWidget *widget)
 // Helper to clean up second window state - called before destroying window
 static void _darkroom_ui_second_window_cleanup(dt_develop_t *dev)
 {
-  // Signal main preview2 pipe to stop and wait for any pending jobs
+  /* Signal main preview2 pipe to stop and wait for any pending jobs.
+     Note: setting shutdown to DT_DEV_PIXELPIPE_STOP_NODES might be ignored
+     if pipe has just been started but not registered as running so we might
+     see a superfluous full pixelpipe run.
+  */
   if(dev->preview2.pipe)
   {
-    dt_atomic_set_int(&dev->preview2.pipe->shutdown, DT_DEV_PIXELPIPE_STOP_NODES);
+    dt_dev_pixelpipe_set_shutdown(dev->preview2.pipe, DT_DEV_PIXELPIPE_STOP_NODES);
     dt_pthread_mutex_lock(&dev->preview2.pipe->mutex);
     dt_pthread_mutex_unlock(&dev->preview2.pipe->mutex);
     dt_pthread_mutex_lock(&dev->preview2.pipe->busy_mutex);
@@ -5381,7 +5374,6 @@ static void _darkroom_display_second_window(dt_develop_t *dev)
     dt_pthread_mutex_unlock(&dev->preview2.pipe->mutex);
     dt_pthread_mutex_lock(&dev->preview2.pipe->busy_mutex);
     dt_pthread_mutex_unlock(&dev->preview2.pipe->busy_mutex);
-    dt_atomic_set_int(&dev->preview2.pipe->shutdown, DT_DEV_PIXELPIPE_STOP_NO);
   }
 
   if(dev->second_wnd == NULL)


### PR DESCRIPTION
A short summary: **How does current dt pixelpipe work?**
Pixelpipe processing happens in `_dev_pixelpipe_process_rec()`, it is responsible for preparing zoom scale and area, piece roi_in&out, cacheline allocations and invalidations, importance hints, cacheline integrity after colorspace conversions, mask blending, process a piece in tiling mode and some special cases as fast blending, mask visualizing and providing picker and histogram data. This is valid for all sort of pipes - some pipes modify stuff for performance (preview and thumbs) or have to respect visualizing (like for masks).

1. In it's first part - terminated by `_dev_pixelpipe_early_exit()` it checks for position and output dimension of the pipe.
2. We recursively traverse the module list from last to first preparing roi for each piece and as the last step read the pipe input data.
3. After that, we walk & process the prepared list of pieces.

The UI resonsiveness in darkroom mode is determined by three factors:
1. an efficient and reliable caching of in- and output data (besides that we have special caches for mipmaps, raster&detail masks and for fast blending). If a pixelpipe is started, it tries to find a starting point by a cacheline hit instead of costly processing all modules.
2. a pipe shutdown mechanism for a running pipe due to user actions in above 1-3 phases.
When handling such a shutdown request, we must ensure integrity of cachelines so only valid cachelines are used as a pixelpipe starting point.
3. If we process the pipe via OpenCL, we minimize host/device transfers.
As cachelines are currently only in host memory, we have to balance costly transfers vs hit rate, thus we have an importance strategy. Important cachelines should always be on host and have a smaller chance of being evicted.

**About cachelines**
Until now we had to invalidate input cachelines after colorspace transforms requested by the module for stable results as we transformed the cacheline data "inspace".
This possibly came with a hefty UI responsiveness penalty as cache hits for a reprocessed pipe never happened for modules that had to transform input colorspace, this depends of course on the selection of used modules.
This commit modifies the host-data bound processing - both CPU processed modules and OpenCL modules in tiling mode - for the screen pipes. 
We now keep input cacheline intact by using a temporary buffer for colorspace transformed data. So - cacheline invalidations are now required only for some rare conditions. The OpenCL path takes care that only untransformed GPU-only data are written to host.
Because of invalidation importance the related logs have been improved. Also fixed a bug in pixelpipe cache cleanup leading to stale cachelines.

**About shutdown**
In 5.6 we used the shutdown mechanism only for changing pipe nodes or toggling the HQ processing mode. This commit introduces these new modes:
  `DT_DEV_PIXELPIPE_PROCESSING`
  `DT_DEV_PIXELPIPE_STOP_ZOOM`
  `DT_DEV_PIXELPIPE_STOP_DATA`
all served by `_module_pipe_stop()` and it's caller. Please note that the ZOOM and DATA shutdowns are not used yet but are fully functional. We use `dt_atomic_CAS_int` to set shutdown so there is only one shutdown mode per pixelpipe run.

We had `processing` as a gboolean flag in the pipe struct. Now we use `DT_DEV_PIXELPIPE_PROCESSING` in `pipe->shutdown` instead,
- this allows us to distinguish between a processing and a stale pipe
- we have an atomic state switch including processing state
- `dt_pipe_started()` and `dt_pipe_processing()` are provided helpers.

Clear the history_last_module hint for important cachelines *after* the full pipe has been fully processed instead of doing so while processing the pipe for less interference for both preview pipe caches.

Some comments about pixelpipe workflow have been added/corrected. Some log improvements for shutdown mode handling and cacheline invalidations.