### PR TITLE
darkroom: fall back to first collection image when nothing is selected

### DIFF
--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -1140,7 +1140,22 @@ void reset(dt_view_t *self)
 
 gboolean try_enter(dt_view_t *self)
 {
-  const dt_imgid_t imgid = dt_act_on_get_main_image();
+  dt_imgid_t imgid = dt_act_on_get_main_image();
+
+  // nothing hovered/active/selected: fall back to the first image
+  // of the current lighttable collection, so switching to darkroom
+  // from the tab bar always opens whatever is visible there.
+  if(!dt_is_valid_imgid(imgid))
+  {
+    sqlite3_stmt *stmt;
+    DT_DEBUG_SQLITE3_PREPARE_V2
+      (dt_database_get(darktable.db),
+       "SELECT imgid FROM memory.collected_images ORDER BY rowid LIMIT 1",
+       -1, &stmt, NULL);
+    if(stmt != NULL && sqlite3_step(stmt) == SQLITE_ROW)
+      imgid = sqlite3_column_int(stmt, 0);
+    if(stmt) sqlite3_finalize(stmt);
+  }
 
   if(!dt_is_valid_imgid(imgid))
   {


### PR DESCRIPTION
Switching to the darkroom view without an actively hovered, active, or selected image (e.g. clicking the darkroom tab directly rather than double-clicking a thumbnail) currently fails with "no image to open!" via dt_act_on_get_main_image(), even when images are visible in the current lighttable collection.

Add a fallback in darkroom's own try_enter() (not the shared act-on helper, which is also used for delete/rate/copy-history/etc. actions where silently acting on an unselected image would be surprising) that opens the first image of the current collection instead.