### PR TITLE
Reset auto-applied presets flag and edit timestamp when restoring a snapshot with empty history

### DIFF
--- a/src/common/history_snapshot.c
+++ b/src/common/history_snapshot.c
@@ -166,7 +166,7 @@ static void _history_snapshot_restore(const dt_imgid_t imgid,
 
   dt_database_start_transaction(darktable.db);
 
-  dt_history_delete_on_image_ext(imgid, FALSE, FALSE);
+  dt_history_delete_on_image_ext(imgid, FALSE, history_end == 0);
   DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_TAG_CHANGED);
 
   // if no history end it means the image history was discarded,

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -1306,6 +1306,27 @@ gboolean dt_image_set_history_end(const dt_imgid_t imgid,
   return ok;
 }
 
+int dt_image_get_history_end(const dt_imgid_t imgid)
+{
+  if(!dt_is_valid_imgid(imgid))
+    return 0;
+
+  int history_end = 0;
+  sqlite3_stmt *stmt;
+  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
+                              "SELECT history_end FROM main.images WHERE id = ?1",
+                              -1, &stmt, NULL);
+  DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, imgid);
+  if(sqlite3_step(stmt) == SQLITE_ROW)
+  {
+    if(sqlite3_column_type(stmt, 0) != SQLITE_NULL)
+      history_end = sqlite3_column_int(stmt, 0);
+  }
+  sqlite3_finalize(stmt);
+
+  return history_end;
+}
+
 int32_t dt_image_duplicate(const dt_imgid_t imgid)
 {
   return dt_image_duplicate_with_version(imgid, -1);

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -1299,6 +1299,27 @@ gboolean dt_image_set_history_end(const dt_imgid_t imgid,
   return ok;
 }
 
+int dt_image_get_history_end(const dt_imgid_t imgid)
+{
+  if(!dt_is_valid_imgid(imgid))
+    return 0;
+
+  int history_end = 0;
+  sqlite3_stmt *stmt;
+  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
+                              "SELECT history_end FROM main.images WHERE id = ?1",
+                              -1, &stmt, NULL);
+  DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, imgid);
+  if(sqlite3_step(stmt) == SQLITE_ROW)
+  {
+    if(sqlite3_column_type(stmt, 0) != SQLITE_NULL)
+      history_end = sqlite3_column_int(stmt, 0);
+  }
+  sqlite3_finalize(stmt);
+
+  return history_end;
+}
+
 int32_t dt_image_duplicate(const dt_imgid_t imgid)
 {
   return dt_image_duplicate_with_version(imgid, -1);

--- a/src/common/image.h
+++ b/src/common/image.h
@@ -535,6 +535,8 @@ void dt_image_reset_aspect_ratio(const dt_imgid_t imgid,
 /** reset the image final/cropped aspect ratio to 0.0 */
 gboolean dt_image_set_history_end(const dt_imgid_t imgid,
                                   const int history_end);
+/** get the history end index of the image */
+int dt_image_get_history_end(const dt_imgid_t imgid);
 /** get the ratio of cropped raw sensor data */
 float dt_image_get_sensor_ratio(const dt_image_t *img);
 

--- a/src/common/image.h
+++ b/src/common/image.h
@@ -519,6 +519,8 @@ void dt_image_reset_aspect_ratio(const dt_imgid_t imgid,
 /** reset the image final/cropped aspect ratio to 0.0 */
 gboolean dt_image_set_history_end(const dt_imgid_t imgid,
                                   const int history_end);
+/** get the history end index of the image */
+int dt_image_get_history_end(const dt_imgid_t imgid);
 /** get the ratio of cropped raw sensor data */
 float dt_image_get_sensor_ratio(const dt_image_t *img);
 

--- a/src/common/undo.c
+++ b/src/common/undo.c
@@ -281,8 +281,16 @@ static void _undo_do_undo_redo(dt_undo_t *self,
     // remove duplicates
     for(const GList *img = imgs; img; img = g_list_next(img))
     {
-      // udpate xmp is done via set_change_timestamp
-      dt_image_cache_set_change_timestamp(GPOINTER_TO_INT(img->data));
+      const dt_imgid_t imgid = GPOINTER_TO_INT(img->data);
+      const int history_end = dt_image_get_history_end(imgid);
+
+      // if history is empty, revert modification timestamp to unset (-1)
+      // so that the image is no longer treated as edited/modified.
+      // update xmp is done via set/unset change timestamp.
+      if(history_end == 0)
+        dt_image_cache_unset_change_timestamp(imgid);
+      else
+        dt_image_cache_set_change_timestamp(imgid);
       while(img->next && img->data == img->next->data)
         imgs = g_list_delete_link(imgs, img->next);
     }


### PR DESCRIPTION
This fixes a bug I encountered when I do the following steps:

1. Edit image A
2. Copy image A's history stack (full or partial) and paste onto image B, which was previously unedited
3. Undo that paste operation

Before this change, if I opened image B for editing, none of the my automatically-applied presets would be applied. This change resets the "auto-apply presets" flag and the edit timestamp when undoing the last remaining change in the history stack. This properly resets image B to an "unedited" state, and it properly gets presets applied when it's opened for editing.