### PR TITLE
fix crash when resetting a Lua module

### DIFF
--- a/src/lua/lualib.c
+++ b/src/lua/lualib.c
@@ -156,6 +156,12 @@ static void view_leave_wrapper(struct dt_lib_module_t *self,struct dt_view_t *ol
       LUA_ASYNC_DONE);
 }
 
+static gboolean has_preset_label_wrapper(struct dt_lib_module_t *self)
+{
+  //Lua modules do not support presets
+  return FALSE;
+}
+
 static dt_lib_module_t ref_lib = {
   .module = NULL,
   .data = NULL,
@@ -164,6 +170,7 @@ static dt_lib_module_t ref_lib = {
   .expander = NULL,
   .version = version_wrapper,
   .name = name_wrapper,
+  .has_preset_label = has_preset_label_wrapper,
   .views = view_wrapper,
   .container = container_wrapper,
   .expandable = expandable_wrapper,


### PR DESCRIPTION
When resetting a Lua module in release 5.6.0 darktable crashes. For details see issue #21600 and https://github.com/darktable-org/lua-scripts/issues/703
@wpferguson I just noticed that you have assigned the issue to yourself. Maybe this proposal saves you some work.

closes #21600 
