### PR TITLE
Refactor checkboxes to bauhaus widgets

### DIFF
--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -88,6 +88,13 @@ typedef struct dt_bauhaus_combobox_data_t
   dt_bauhaus_combobox_entry_select_fct entry_select; // function to select an entry based on context
 } dt_bauhaus_combobox_data_t;
 
+// data portion for a toggle
+typedef struct dt_bauhaus_toggle_data_t
+{
+  gboolean active;  // current value
+  gboolean defpos;  // default value
+} dt_bauhaus_toggle_data_t;
+
 struct _DtBauhausWidget
 {
   // gtk base widget
@@ -130,6 +137,7 @@ struct _DtBauhausWidget
   {
     dt_bauhaus_slider_data_t slider;
     dt_bauhaus_combobox_data_t combobox;
+    dt_bauhaus_toggle_data_t toggle;
   };
 };
 
@@ -149,6 +157,7 @@ enum
 };
 
 static const dt_action_def_t _action_def_slider, _action_def_combo,
+                             _action_def_toggle,
                              _action_def_focus_slider, _action_def_focus_combo,
                              _action_def_focus_button;
 
@@ -166,6 +175,8 @@ static void _combobox_set(dt_bauhaus_widget_t *w,
                           const gboolean mute);
 static void _slider_set_normalized(dt_bauhaus_widget_t *w,
                                    const float pos);
+static void _toggle_set(dt_bauhaus_widget_t *w,
+                        const gboolean active);
 
 static void _request_focus(dt_bauhaus_widget_t *w)
 {
@@ -766,7 +777,7 @@ static void _widget_finalize(GObject *widget)
     free(d->grad_col);
     free(d->grad_pos);
   }
-  else
+  else if(w->type == DT_BAUHAUS_COMBOBOX)
   {
     dt_bauhaus_combobox_data_t *d = &w->combobox;
     g_ptr_array_free(d->entries, TRUE);
@@ -802,6 +813,22 @@ void dt_bauhaus_load_theme()
                                  &bh->color_border);
   gtk_style_context_lookup_color(ctx, "bauhaus_fill",
                                  &bh->color_fill);
+
+  // a context that css sees as the check node of a check button inside a
+  // module, so that gtk_render_check() below draws exactly what every other
+  // checkbox in the panels looks like, in whichever theme is loaded
+  if(bh->check_context) g_object_unref(bh->check_context);
+  bh->check_context = gtk_style_context_new();
+  GtkWidgetPath *check_path = gtk_widget_path_new();
+  const int plugin_pos = gtk_widget_path_append_type(check_path, GTK_TYPE_WIDGET);
+  gtk_widget_path_iter_add_class(check_path, plugin_pos, "dt_plugin_ui");
+  gtk_widget_path_append_type(check_path, GTK_TYPE_CHECK_BUTTON);
+  const int check_pos = gtk_widget_path_append_type(check_path, G_TYPE_NONE);
+  gtk_widget_path_iter_set_object_name(check_path, check_pos, "check");
+  gtk_style_context_set_path(bh->check_context, check_path);
+  gtk_style_context_set_screen(bh->check_context,
+                               gtk_widget_get_screen(root_window));
+  gtk_widget_path_unref(check_path);
   gtk_style_context_lookup_color(ctx, "bauhaus_indicator_border",
                                  &bh->indicator_border);
 
@@ -884,6 +911,31 @@ void dt_bauhaus_load_theme()
     bh->border_width = 2.0f;
     bh->marker_size = (bh->baseline_size + bh->border_width) * 0.95f;
   }
+
+  // size a toggle's tick box the way gtk sizes a check button's indicator:
+  // the minimum the css asks for, plus the border and padding it draws
+  // around it
+  gint min_width = 0, min_height = 0;
+  GtkBorder check_padding = { 0 }, check_border = { 0 };
+  if(bh->check_context)
+  {
+    const GtkStateFlags check_state = gtk_style_context_get_state(bh->check_context);
+    gtk_style_context_get(bh->check_context, check_state,
+                          "min-width", &min_width,
+                          "min-height", &min_height,
+                          NULL);
+    gtk_style_context_get_padding(bh->check_context, check_state, &check_padding);
+    gtk_style_context_get_border(bh->check_context, check_state, &check_border);
+  }
+  const gint css_width = min_width + check_padding.left + check_padding.right
+                                   + check_border.left + check_border.right;
+  const gint css_height = min_height + check_padding.top + check_padding.bottom
+                                     + check_border.top + check_border.bottom;
+  // a theme that leaves the size to gtk still gets a box that follows the
+  // font, and the row is only one line tall whatever the css asks for
+  bh->check_size = CLAMP(MAX(css_width, css_height),
+                         round(bh->quad_width * 0.75),
+                         bh->line_height);
 }
 
 void dt_bauhaus_init()
@@ -950,6 +1002,11 @@ void dt_bauhaus_init()
 
 void dt_bauhaus_cleanup()
 {
+  if(darktable.bauhaus->check_context)
+  {
+    g_object_unref(darktable.bauhaus->check_context);
+    darktable.bauhaus->check_context = NULL;
+  }
 }
 
 // end static init/cleanup
@@ -1080,8 +1137,8 @@ dt_action_t *dt_bauhaus_widget_set_label(GtkWidget *widget,
     if(!darktable.bauhaus->skip_accel || w->module->type != DT_ACTION_TYPE_IOP_INSTANCE)
     {
       ac = dt_action_define(w->module, section, label, widget,
-                            w->type == DT_BAUHAUS_SLIDER
-                            ? &_action_def_slider
+                            w->type == DT_BAUHAUS_SLIDER   ? &_action_def_slider
+                            : w->type == DT_BAUHAUS_TOGGLE ? &_action_def_toggle
                             : &_action_def_combo);
       if(w->module->type != DT_ACTION_TYPE_IOP_INSTANCE)
         w->module = ac;
@@ -1239,6 +1296,8 @@ static void _highlight_changed_notebook_tab(GtkWidget *w, gpointer user_data)
         is_changed = fabsf(d->pos - d->curve((d->defpos - d->min) / (d->max - d->min),
                                              DT_BAUHAUS_SET)) > 0.001f;
       }
+      else if(b->type == DT_BAUHAUS_TOGGLE)
+        is_changed = b->toggle.active != b->toggle.defpos;
       else
         is_changed = b->combobox.entries->len
           && b->combobox.active != b->combobox.defpos;
@@ -1251,6 +1310,36 @@ static void _highlight_changed_notebook_tab(GtkWidget *w, gpointer user_data)
     dt_gui_add_class(label, "changed");
   else
     dt_gui_remove_class(label, "changed");
+}
+
+static void _toggle_set(dt_bauhaus_widget_t *w,
+                        const gboolean active)
+{
+  dt_bauhaus_toggle_data_t *d = &w->toggle;
+  d->active = active ? TRUE : FALSE;
+  gtk_widget_queue_draw(GTK_WIDGET(w));
+
+  // while the gui is being brought in line with the params there is
+  // nothing to write back and no history item to add; the redraw above is
+  // all that is wanted. Same as for the slider and combobox setters
+  if(DT_IN_GUI_UPDATE()) return;
+
+  if(w->field)
+  {
+    if(w->field_type == DT_INTROSPECTION_TYPE_BOOL)
+    {
+      gboolean *b = w->field, prevb = *b;
+      *b = d->active;
+      if(*b != prevb) dt_iop_gui_changed(w->module, GTK_WIDGET(w), &prevb);
+    }
+    else
+      dt_print(DT_DEBUG_ALWAYS, "[_toggle_set] unsupported toggle data type");
+  }
+
+  _highlight_changed_notebook_tab(GTK_WIDGET(w),
+                                  GINT_TO_POINTER(d->active != d->defpos));
+  g_signal_emit(G_OBJECT(w),
+                darktable.bauhaus->signals[DT_BAUHAUS_VALUE_CHANGED_SIGNAL], 0);
 }
 
 void dt_bauhaus_update_from_field(dt_iop_module_t *module,
@@ -1319,6 +1408,13 @@ void dt_bauhaus_update_from_field(dt_iop_module_t *module,
             dt_print(DT_DEBUG_ALWAYS,
                      "[dt_bauhaus_update_from_field] unsupported combo data type");
         }
+        break;
+      case DT_BAUHAUS_TOGGLE:
+        if(bhw->field_type == DT_INTROSPECTION_TYPE_BOOL)
+          dt_bauhaus_toggle_set(widget, *(gboolean *)field);
+        else
+          dt_print(DT_DEBUG_ALWAYS,
+                   "[dt_bauhaus_update_from_field] unsupported toggle data type");
         break;
       default:
         dt_print
@@ -1552,6 +1648,61 @@ GtkWidget *dt_bauhaus_combobox_from_widget(dt_bauhaus_widget_t* w,
   gtk_widget_set_name(GTK_WIDGET(w), "bauhaus-combobox");
 
   return GTK_WIDGET(w);
+}
+
+GtkWidget *dt_bauhaus_toggle_new(dt_iop_module_t *self)
+{
+  dt_bauhaus_widget_t *w = DT_BAUHAUS_WIDGET(g_object_new(DT_BAUHAUS_WIDGET_TYPE, NULL));
+  return dt_bauhaus_toggle_from_widget(w, self);
+}
+
+GtkWidget *dt_bauhaus_toggle_from_widget(dt_bauhaus_widget_t *w,
+                                         dt_iop_module_t *self)
+{
+  w->type = DT_BAUHAUS_TOGGLE;
+  DT_IOP_SECTION_FOR_PARAMS_UNWIND(self);
+  w->module = DT_ACTION(self);
+  dt_bauhaus_toggle_data_t *d = &w->toggle;
+  d->active = FALSE;
+  d->defpos = FALSE;
+
+  // the tick box is drawn in front of the label, so the column that the
+  // other types keep free on the right would only be wasted width here
+  w->show_quad = FALSE;
+
+  gtk_widget_set_name(GTK_WIDGET(w), "bauhaus-toggle");
+
+  return GTK_WIDGET(w);
+}
+
+void dt_bauhaus_toggle_set(GtkWidget *widget,
+                           const gboolean active)
+{
+  dt_bauhaus_widget_t *w = DT_BAUHAUS_WIDGET(widget);
+  if(w->type != DT_BAUHAUS_TOGGLE) return;
+  _toggle_set(w, active);
+}
+
+gboolean dt_bauhaus_toggle_get(GtkWidget *widget)
+{
+  const dt_bauhaus_widget_t *w = DT_BAUHAUS_WIDGET(widget);
+  if(w->type != DT_BAUHAUS_TOGGLE) return FALSE;
+  return w->toggle.active;
+}
+
+void dt_bauhaus_toggle_set_default(GtkWidget *widget,
+                                   const gboolean def)
+{
+  dt_bauhaus_widget_t *w = DT_BAUHAUS_WIDGET(widget);
+  if(w->type != DT_BAUHAUS_TOGGLE) return;
+  w->toggle.defpos = def ? TRUE : FALSE;
+}
+
+gboolean dt_bauhaus_toggle_get_default(GtkWidget *widget)
+{
+  const dt_bauhaus_widget_t *w = DT_BAUHAUS_WIDGET(widget);
+  if(w->type != DT_BAUHAUS_TOGGLE) return FALSE;
+  return w->toggle.defpos;
 }
 
 static dt_bauhaus_combobox_data_t *_combobox_data(GtkWidget *widget)
@@ -2139,6 +2290,7 @@ static void _draw_quad(dt_bauhaus_widget_t *w,
         cairo_stroke(cr);
         gdk_rgba_free(text_color);
         break;
+      case DT_BAUHAUS_TOGGLE:
       case DT_BAUHAUS_SLIDER:
         break;
       default:
@@ -2324,6 +2476,37 @@ static void _popup_reject(void)
   if(w->type == DT_BAUHAUS_SLIDER)
     _slider_set_normalized(w, darktable.bauhaus->popup.oldpos);
   _popup_hide();
+}
+
+// side of the square tick box, computed from the check node's css when the
+// theme is loaded
+static float _toggle_box_size()
+{
+  return darktable.bauhaus->check_size;
+}
+
+static void _draw_toggle_box(dt_bauhaus_widget_t *w,
+                             cairo_t *cr,
+                             const float x,
+                             const int height,
+                             const float size)
+{
+  GtkStyleContext *check = darktable.bauhaus->check_context;
+  if(!check) return;
+
+  GtkStateFlags state = GTK_STATE_FLAG_NORMAL;
+  if(w->toggle.active) state |= GTK_STATE_FLAG_CHECKED;
+  if(!gtk_widget_is_sensitive(GTK_WIDGET(w))) state |= GTK_STATE_FLAG_INSENSITIVE;
+  if(darktable.bauhaus->hovered == GTK_WIDGET(w)) state |= GTK_STATE_FLAG_PRELIGHT;
+  gtk_style_context_set_state(check, state);
+
+  const double y = round(height * 0.5 - size * 0.5);
+
+  cairo_save(cr);
+  gtk_render_background(check, cr, x, y, size, size);
+  gtk_render_frame(check, cr, x, y, size, size);
+  gtk_render_check(check, cr, x, y, size, size);
+  cairo_restore(cr);
 }
 
 static gchar *_build_label(const dt_bauhaus_widget_t *w)
@@ -2768,6 +2951,24 @@ static gboolean _widget_draw(GtkWidget *widget,
       g_free(label_text);
     }
     break;
+    case DT_BAUHAUS_TOGGLE:
+    {
+      // box first, then the label beside it, so the pair reads as one
+      // control the way a check button does
+      const float size = _toggle_box_size();
+      const float indent = size + INNER_PADDING * 2;
+      _draw_toggle_box(w, cr, 0, h3, size);
+
+      gchar *label_text = _build_label(w);
+      if(label_text && w->show_label && w3 > indent)
+      {
+        set_color(cr, *text_color);
+        _show_pango_text(w, context, cr, label_text, indent, 0, w3 - indent,
+                         FALSE, FALSE, PANGO_ELLIPSIZE_END, FALSE, TRUE, NULL, NULL);
+      }
+      g_free(label_text);
+    }
+    break;
     default:
       break;
   }
@@ -2834,6 +3035,11 @@ static gint _natural_width(GtkWidget *widget,
 
       natural_size = MAX(natural_size, label_width + entry_width / PANGO_SCALE);
     }
+  }
+  else if(w->type == DT_BAUHAUS_TOGGLE)
+  {
+    // the box sits in front of the label rather than in the quad column
+    natural_size += _toggle_box_size() + INNER_PADDING * 2;
   }
   else
   {
@@ -2912,6 +3118,10 @@ static void _popup_show(GtkWidget *widget)
   dt_bauhaus_widget_t *w = DT_BAUHAUS_WIDGET(widget);
   dt_bauhaus_t *bh = darktable.bauhaus;
   dt_bauhaus_popup_t *pop = &bh->popup;
+
+  // a toggle has two states and both are visible on the widget itself,
+  // so there is nothing a popup could offer
+  if(w->type == DT_BAUHAUS_TOGGLE) return;
 
   if(bh->current) _popup_hide();
   bh->current = w;
@@ -3124,6 +3334,13 @@ static void _widget_scroll(GtkEventControllerScroll *controller,
         else
           _slider_add_step(widget, - delta, dt_gdk_event_get_state(event), force);
       }
+      else if(w->type == DT_BAUHAUS_TOGGLE)
+      {
+        // up and right switch on, down and left switch off, in the same
+        // direction as scrolling a slider up raises its value
+        const int delta = magnitude_x > magnitude_y ? -dx : dy;
+        _toggle_set(w, delta < 0);
+      }
       else
       {
         // match keyboard: right & down -> next
@@ -3158,13 +3375,28 @@ static gboolean _widget_key_press(GtkWidget *widget, GdkEventKey *event)
 
       if(w->type == DT_BAUHAUS_SLIDER)
         _slider_add_step(widget, delta, dt_gdk_event_get_state(event), FALSE);
+      else if(w->type == DT_BAUHAUS_TOGGLE)
+        _toggle_set(w, delta > 0);
       else
         _combobox_next_sensitive(w, delta, 0, FALSE);
 
       return TRUE;
     case GDK_KEY_Return:
     case GDK_KEY_KP_Enter:
-      _popup_show(widget);
+      if(w->type == DT_BAUHAUS_TOGGLE)
+        _toggle_set(w, !w->toggle.active);
+      else
+        _popup_show(widget);
+      return TRUE;
+    case GDK_KEY_space:
+    case GDK_KEY_KP_Space:
+      // gtk activates any button with space, so a checkbox is expected to
+      // respond to it wherever one appears. The other types have nothing to
+      // activate and leave the key to whatever handles it next
+      if(w->type != DT_BAUHAUS_TOGGLE) return FALSE;
+
+      _request_focus(w);
+      _toggle_set(w, !w->toggle.active);
       return TRUE;
     default:
       return FALSE;
@@ -3323,20 +3555,30 @@ void dt_bauhaus_widget_reset(GtkWidget *widget)
 {
   dt_bauhaus_widget_t *w = DT_BAUHAUS_WIDGET(widget);
 
-  if(w->type == DT_BAUHAUS_SLIDER)
+  // an explicit switch rather than "slider or else combobox": reading the
+  // wrong member of the data union would be silent corruption
+  switch(w->type)
   {
-    dt_bauhaus_slider_data_t *d = &w->slider;
-    d->is_dragging = 0;
+    case DT_BAUHAUS_SLIDER:
+    {
+      dt_bauhaus_slider_data_t *d = &w->slider;
+      d->is_dragging = 0;
 
-    d->min = d->soft_min;
-    d->max = d->soft_max;
+      d->min = d->soft_min;
+      d->max = d->soft_max;
 
-    dt_bauhaus_slider_set(widget, d->defpos);
+      dt_bauhaus_slider_set(widget, d->defpos);
+      break;
+    }
+    case DT_BAUHAUS_COMBOBOX:
+      dt_bauhaus_combobox_set_from_value(widget, w->combobox.defpos);
+      break;
+    case DT_BAUHAUS_TOGGLE:
+      _toggle_set(w, w->toggle.defpos);
+      break;
+    default:
+      break;
   }
-  else
-    dt_bauhaus_combobox_set_from_value(widget, w->combobox.defpos);
-
-  return;
 }
 
 void dt_bauhaus_slider_set_format(GtkWidget *widget,
@@ -3595,6 +3837,13 @@ static void _widget_button_press(GtkGestureSingle *gesture,
     // (except in weird corner cases where the popup is under the -1st entry
     _popup_hide();
   }
+  else if(w->type == DT_BAUHAUS_TOGGLE)
+  {
+    // any other button is left to the widget below, as a toggle has no
+    // popup to open and no range to drag
+    if(button == GDK_BUTTON_PRIMARY)
+      _toggle_set(w, !w->toggle.active);
+  }
   else if(button == GDK_BUTTON_SECONDARY || w->type == DT_BAUHAUS_COMBOBOX)
   {
     GdkEvent *const event = gtk_get_current_event();
@@ -3646,7 +3895,9 @@ static void _widget_button_release(GtkGestureSingle *gesture,
 static void _widget_button_stopped(GtkGestureSingle *gesture,
                                    dt_bauhaus_widget_t *w)
 {
-  if(w->slider.timeout_handle == G_MAXUINT)
+  // reading slider.timeout_handle for another type would read whatever the
+  // data union happens to hold there
+  if(w->type == DT_BAUHAUS_SLIDER && w->slider.timeout_handle == G_MAXUINT)
     _slider_value_change_dragging(w);
 }
 
@@ -3667,6 +3918,12 @@ static void _widget_motion(GtkEventControllerMotion *controller,
     darktable.control->element =
       pos > 1.0f && w->quad_paint
       ? DT_ACTION_ELEMENT_BUTTON : DT_ACTION_ELEMENT_SELECTION;
+  }
+  else if(w->type == DT_BAUHAUS_TOGGLE)
+  {
+    darktable.control->element =
+      pos > 1.0f && w->quad_paint
+      ? DT_ACTION_ELEMENT_BUTTON : DT_ACTION_ELEMENT_VALUE;
   }
   else if(d->is_dragging)
   {
@@ -4050,6 +4307,30 @@ static float _action_process_focus_button(gpointer widget,
   return DT_ACTION_NOT_VALID;
 }
 
+static float _action_process_toggle(gpointer target,
+                                    const dt_action_element_t element,
+                                    const dt_action_effect_t effect,
+                                    const float move_size)
+{
+  GtkWidget *widget = GTK_WIDGET(target);
+  dt_bauhaus_widget_t *w = DT_BAUHAUS_WIDGET(widget);
+
+  float value = w->toggle.active;
+
+  // the macro filters out the requests that ask for a state the widget is
+  // already in, so "on" twice in a row does not add a second history item
+  if(DT_ACTION_TOGGLE_NEEDED(effect, move_size, value))
+  {
+    _toggle_set(w, !w->toggle.active);
+    value = w->toggle.active;
+
+    if(!gtk_widget_is_visible(widget))
+      dt_action_widget_toast(w->module, widget, value ? _("on") : _("off"));
+  }
+
+  return value;
+}
+
 static const dt_action_element_def_t _action_elements_slider[]
   = { { N_("value"), dt_action_effect_value },
       { N_("button"), dt_action_effect_toggle },
@@ -4106,6 +4387,26 @@ static const dt_action_def_t _action_def_combo
       _action_process_combo,
       _action_elements_combo,
       _action_fallbacks_combo };
+
+// deliberately the same single unnamed element, effect vocabulary, name and
+// fallbacks as the plain GtkToggleButton definition in gui/accelerators.c.
+// Shortcuts are stored by action path plus element and effect name, so
+// keeping all three identical means shortcuts that users already bound to
+// these checkboxes keep resolving to the same thing
+static const dt_action_element_def_t _action_elements_toggle[]
+  = { { NULL, dt_action_effect_toggle } };
+
+static const dt_shortcut_fallback_t _action_fallbacks_toggle[]
+  = { { .mods   = GDK_CONTROL_MASK   , .effect = DT_ACTION_EFFECT_TOGGLE_CTRL  },
+      { .button = DT_SHORTCUT_RIGHT  , .effect = DT_ACTION_EFFECT_TOGGLE_RIGHT },
+      { .press  = DT_SHORTCUT_LONG   , .effect = DT_ACTION_EFFECT_TOGGLE_RIGHT },
+      { } };
+
+static const dt_action_def_t _action_def_toggle
+  = { N_("toggle"),
+      _action_process_toggle,
+      _action_elements_toggle,
+      _action_fallbacks_toggle };
 
 static const dt_action_def_t _action_def_focus_slider
   = { N_("sliders"),

--- a/src/bauhaus/bauhaus.h
+++ b/src/bauhaus/bauhaus.h
@@ -48,6 +48,7 @@ typedef enum dt_bauhaus_type_t
   DT_BAUHAUS_BUTTON = 0,
   DT_BAUHAUS_SLIDER = 1,
   DT_BAUHAUS_COMBOBOX = 2,
+  DT_BAUHAUS_TOGGLE = 3,
   // TODO: all the fancy color sliders..
 } dt_bauhaus_type_t;
 
@@ -127,6 +128,11 @@ typedef struct dt_bauhaus_t
   int unique_match;
   // our custom signals
   guint signals[DT_BAUHAUS_LAST_SIGNAL];
+
+  // resolves to the same css as the check part of a gtk check button, so
+  // that toggles are drawn by the theme rather than from hardcoded colours
+  GtkStyleContext *check_context;
+  float check_size;                      // side of a toggle's tick box
 
   // initialise or connect accelerators in set_label
   int skip_accel;
@@ -225,6 +231,23 @@ void dt_bauhaus_update_from_field(dt_iop_module_t *module,
                                   gpointer blend_params);
 // reset widget to default value
 void dt_bauhaus_widget_reset(GtkWidget *widget);
+
+// toggle:
+GtkWidget *dt_bauhaus_toggle_new(dt_iop_module_t *self);
+GtkWidget *dt_bauhaus_toggle_from_widget(dt_bauhaus_widget_t *w,
+                                         dt_iop_module_t *self);
+// setting the value writes through to the linked field and adds a history
+// item, just like the slider and combobox setters do
+void dt_bauhaus_toggle_set(GtkWidget *widget,
+                           const gboolean active);
+gboolean dt_bauhaus_toggle_get(GtkWidget *widget);
+// the value a reset returns to, and the value the notebook tab "changed"
+// indicator compares against. Modules that compute a bool default per
+// image in reload_defaults() have to keep this up to date, as they already
+// do for sliders and comboboxes
+void dt_bauhaus_toggle_set_default(GtkWidget *widget,
+                                   const gboolean def);
+gboolean dt_bauhaus_toggle_get_default(GtkWidget *widget);
 
 // slider:
 GtkWidget *dt_bauhaus_slider_new(dt_iop_module_t *self);

--- a/src/develop/imageop_gui.c
+++ b/src/develop/imageop_gui.c
@@ -35,28 +35,6 @@
 #include <strings.h>
 #include <time.h>
 
-typedef struct dt_module_param_t
-{
-  dt_iop_module_t *module;
-  void            *param;
-} dt_module_param_t;
-
-static void _iop_toggle_callback(GtkWidget *togglebutton, dt_module_param_t *data)
-{
-  DT_GUARD_GUI_UPDATE();
-
-  dt_iop_module_t *self = data->module;
-  gboolean *field = (gboolean*)(data->param);
-
-  gboolean previous = *field;
-  *field = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(togglebutton));
-
-  if(*field != previous)
-  {
-    dt_iop_gui_changed(DT_ACTION(self), togglebutton, &previous);
-  }
-}
-
 static gchar *_iop_section_for_params(dt_iop_module_t *self)
 {
   if(!self->widget) self->widget = dt_gui_vbox();
@@ -224,43 +202,43 @@ GtkWidget *dt_bauhaus_toggle_from_params(dt_iop_module_t *self, const char *para
   gchar *section = _iop_section_for_params(self);
 
   dt_iop_params_t *p = self->params;
+  dt_iop_params_t *d = self->default_params;
   dt_introspection_field_t *f = self->get_f(param);
 
-  GtkWidget *button = NULL;
+  GtkWidget *toggle = dt_bauhaus_toggle_new(self);
   gchar *str = NULL;
 
   if(f && f->header.type == DT_INTROSPECTION_TYPE_BOOL)
   {
+    // the field has to be attached before the label is set: setting the
+    // label is what registers the widget as an action, and only widgets
+    // that already carry a field are collected for the automatic
+    // params-to-gui updates
+    dt_bauhaus_widget_set_field(toggle, (uint8_t *)p + f->header.offset,
+                                DT_INTROSPECTION_TYPE_BOOL);
+
     // we do not want to support a context as it break all translations see #5498
-    // button = gtk_check_button_new_with_label(g_dpgettext2(NULL, "introspection description", f->header.description));
     str = *f->header.description
         ? g_strdup(f->header.description)
         : dt_util_str_replace(param, "_", " ");
 
-    GtkWidget *label = gtk_label_new(_(str));
-    gtk_label_set_ellipsize(GTK_LABEL(label), PANGO_ELLIPSIZE_END);
-    button = gtk_check_button_new();
-    gtk_container_add(GTK_CONTAINER(button), label);
-    dt_module_param_t *module_param = g_malloc(sizeof(dt_module_param_t));
-    module_param->module = self;
-    DT_IOP_SECTION_FOR_PARAMS_UNWIND(module_param->module);
-    module_param->param = (uint8_t *)p + f->header.offset;
-    g_signal_connect_data(G_OBJECT(button), "toggled", G_CALLBACK(_iop_toggle_callback), module_param, (GClosureNotify)g_free, 0);
+    dt_bauhaus_widget_set_label(toggle, section, str);
 
-    dt_action_define_iop(module_param->module, section, str, button, &dt_action_def_toggle);
+    dt_bauhaus_toggle_set_default(toggle,
+                                  *(gboolean *)((uint8_t *)d + f->header.offset));
   }
   else
   {
     str = g_strdup_printf("'%s' is not a bool/togglebutton parameter", param);
 
-    button = gtk_check_button_new_with_label(str);
+    dt_bauhaus_widget_set_label(toggle, section, str);
   }
 
   g_free(str);
 
-  dt_gui_box_add(self->widget, button);
+  dt_gui_box_add(self->widget, toggle);
 
-  return button;
+  return toggle;
 }
 
 GtkWidget *dt_iop_togglebutton_new(dt_iop_module_t *self, const char *section, const gchar *label, const gchar *ctrl_label,

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -3840,12 +3840,21 @@ GdkModifierType dt_key_modifier_state()
 static void _reset_all_bauhaus(GtkNotebook *notebook,
                                GtkWidget *box)
 {
-  for(GList *c = gtk_container_get_children(GTK_CONTAINER(box));
-      c;
-      c = g_list_delete_link(c, c))
+  // toggles go last rather than in widget order: a module may switch one of
+  // its own checkboxes on in reaction to one of its sliders changing, so a
+  // checkbox reset while sliders are still to come could be undone again by
+  // a slider that is reset after it
+  for(int toggles_pass = 0; toggles_pass < 2; toggles_pass++)
   {
-    if(DT_IS_BAUHAUS_WIDGET(c->data))
-      dt_bauhaus_widget_reset(GTK_WIDGET(c->data));
+    for(GList *c = gtk_container_get_children(GTK_CONTAINER(box));
+        c;
+        c = g_list_delete_link(c, c))
+    {
+      if(DT_IS_BAUHAUS_WIDGET(c->data)
+         && (dt_bauhaus_widget_get_type(c->data) == DT_BAUHAUS_TOGGLE)
+            == (toggles_pass == 1))
+        dt_bauhaus_widget_reset(GTK_WIDGET(c->data));
+    }
   }
 
   dt_gui_remove_class(gtk_notebook_get_tab_label(GTK_NOTEBOOK(notebook), box), "changed");

--- a/src/iop/agx.c
+++ b/src/iop/agx.c
@@ -2241,12 +2241,12 @@ void gui_update(dt_iop_module_t *self)
 
   _update_pivot_slider_settings(g->basic_curve_controls.curve_pivot_x, p);
 
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->auto_gamma),
-                               p->auto_gamma);
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->disable_primaries_adjustments),
-                               p->disable_primaries_adjustments);
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->completely_reverse_primaries),
-                               p->completely_reverse_primaries);
+  dt_bauhaus_toggle_set(g->auto_gamma,
+                        p->auto_gamma);
+  dt_bauhaus_toggle_set(g->disable_primaries_adjustments,
+                        p->disable_primaries_adjustments);
+  dt_bauhaus_toggle_set(g->completely_reverse_primaries,
+                        p->completely_reverse_primaries);
 
   _update_redraw_dynamic_gui(self, g, p);
 

--- a/src/iop/cacorrect.c
+++ b/src/iop/cacorrect.c
@@ -1291,7 +1291,7 @@ void gui_update(dt_iop_module_t *self)
   if(!supported) self->default_enabled = FALSE;
 
   gtk_stack_set_visible_child_name(GTK_STACK(self->widget), supported ? "bayer" : "other");
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->avoidshift), p->avoidshift);
+  dt_bauhaus_toggle_set(g->avoidshift, p->avoidshift);
 
   gtk_widget_set_visible(g->avoidshift, supported);
   gtk_widget_set_visible(g->iterations, supported);

--- a/src/iop/cacorrectrgb.c
+++ b/src/iop/cacorrectrgb.c
@@ -685,7 +685,7 @@ void gui_update(dt_iop_module_t *self)
   dt_iop_cacorrectrgb_gui_data_t *g = self->gui_data;
   dt_iop_cacorrectrgb_params_t *p = self->params;
 
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->refine_manifolds), p->refine_manifolds);
+  dt_bauhaus_toggle_set(g->refine_manifolds, p->refine_manifolds);
 }
 
 void reload_defaults(dt_iop_module_t *self)
@@ -706,7 +706,7 @@ void reload_defaults(dt_iop_module_t *self)
     dt_bauhaus_slider_set_soft_range(g->radius, 1.0, 20.0);
     dt_bauhaus_slider_set_default(g->strength, d->strength);
     dt_bauhaus_combobox_set_default(g->mode, d->mode);
-    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->refine_manifolds), d->refine_manifolds);
+    dt_bauhaus_toggle_set_default(g->refine_manifolds, d->refine_manifolds);
   }
 }
 

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -3803,19 +3803,19 @@ void gui_update(dt_iop_module_t *self)
 
   dt_iop_gui_leave_critical_section(self);
 
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->clip), p->clip);
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->normalize_R), p->normalize_R);
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->normalize_G), p->normalize_G);
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->normalize_B), p->normalize_B);
+  dt_bauhaus_toggle_set(g->clip, p->clip);
+  dt_bauhaus_toggle_set(g->normalize_R, p->normalize_R);
+  dt_bauhaus_toggle_set(g->normalize_G, p->normalize_G);
+  dt_bauhaus_toggle_set(g->normalize_B, p->normalize_B);
 
   if(p->version != CHANNELMIXERRGB_V_3)
     dt_bauhaus_combobox_set(g->saturation_version, p->version);
   else
     gtk_widget_hide(GTK_WIDGET(g->saturation_version));
 
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->normalize_sat), p->normalize_sat);
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->normalize_light), p->normalize_light);
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->normalize_grey), p->normalize_grey);
+  dt_bauhaus_toggle_set(g->normalize_sat, p->normalize_sat);
+  dt_bauhaus_toggle_set(g->normalize_light, p->normalize_light);
+  dt_bauhaus_toggle_set(g->normalize_grey, p->normalize_grey);
 
   dt_iop_gui_enter_critical_section(self);
 

--- a/src/iop/colorequal.c
+++ b/src/iop/colorequal.c
@@ -2870,7 +2870,7 @@ void gui_update(dt_iop_module_t *self)
 {
   const dt_iop_colorequal_params_t *p = self->params;
   dt_iop_colorequal_gui_data_t *g = self->gui_data;
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->use_filter), p->use_filter);
+  dt_bauhaus_toggle_set(g->use_filter, p->use_filter);
   gui_changed(self, NULL, NULL);
 
   const gboolean show_sliders = dt_conf_get_bool("plugins/darkroom/colorequal/show_sliders");

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -1542,7 +1542,7 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
   gtk_widget_set_visible(g->cs_center, do_capture && p->cs_boost);
   gtk_widget_set_visible(g->cs_iter, do_capture);
 
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->cs_enabled), p->cs_enabled);
+  dt_bauhaus_toggle_set(g->cs_enabled, p->cs_enabled);
   gtk_widget_set_visible(g->cs_enabled, capture_support);
   gtk_widget_set_visible(GTK_WIDGET(g->capture.expander), do_capture);
 

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -2730,6 +2730,10 @@ void reload_defaults(dt_iop_module_t *self)
     }
     dt_bauhaus_combobox_set(g->profile, 0);
 
+    // depends on the image, unlike the other bool defaults set above
+    dt_bauhaus_toggle_set_default(g->compensate_hilite_pres,
+                                  d->compensate_hilite_pres);
+
     gui_update(self);
   }
 }
@@ -3110,14 +3114,14 @@ void gui_update(dt_iop_module_t *self)
     }
   }
 
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->wb_adaptive_anscombe),
-                               p->wb_adaptive_anscombe);
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->compensate_hilite_pres), p->compensate_hilite_pres);
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->fix_anscombe_and_nlmeans_norm),
-                               p->fix_anscombe_and_nlmeans_norm);
+  dt_bauhaus_toggle_set(g->wb_adaptive_anscombe,
+                        p->wb_adaptive_anscombe);
+  dt_bauhaus_toggle_set(g->compensate_hilite_pres, p->compensate_hilite_pres);
+  dt_bauhaus_toggle_set(g->fix_anscombe_and_nlmeans_norm,
+                        p->fix_anscombe_and_nlmeans_norm);
   gtk_widget_set_visible(g->fix_anscombe_and_nlmeans_norm,
                          !p->fix_anscombe_and_nlmeans_norm);
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->use_new_vst), p->use_new_vst);
+  dt_bauhaus_toggle_set(g->use_new_vst, p->use_new_vst);
   gtk_widget_set_visible(g->use_new_vst, !p->use_new_vst);
 
   const int iso_shift = _get_iso_highlight_preservation_shift(&self->dev->image_storage);

--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -369,6 +369,17 @@ void reload_defaults(dt_iop_module_t *self)
   // the new default is to compensate for highlight preservation mode,
   // but ONLY if we're the first instance (to avoid multiple application)
   d->compensate_hilite_pres = dt_iop_is_first_instance(self->dev->iop, self);
+
+  // both defaults above depend on the image and on the instance, so the
+  // widgets have to be told about them again, as for sliders and comboboxes
+  dt_iop_exposure_gui_data_t *g = self->gui_data;
+  if(g)
+  {
+    dt_bauhaus_toggle_set_default(g->compensate_exposure_bias,
+                                  d->compensate_exposure_bias);
+    dt_bauhaus_toggle_set_default(g->compensate_hilite_preserv,
+                                  d->compensate_hilite_pres);
+  }
 }
 
 static void _deflicker_prepare_histogram(dt_iop_module_t *self,
@@ -682,8 +693,8 @@ void gui_update(dt_iop_module_t *self)
 
   dt_iop_color_picker_reset(self, TRUE);
 
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->compensate_exposure_bias),
-                               p->compensate_exposure_bias);
+  dt_bauhaus_toggle_set(g->compensate_exposure_bias,
+                        p->compensate_exposure_bias);
   gchar *label = g_strdup_printf(_("compensate camera exposure (%+.1f EV)"),
                                  _get_exposure_bias(self));
   gtk_button_set_label(GTK_BUTTON(g->compensate_exposure_bias), label);
@@ -693,8 +704,8 @@ void gui_update(dt_iop_module_t *self)
   g_free(label);
 
   const float hlbias = _get_highlight_bias(self);
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->compensate_hilite_preserv),
-                               p->compensate_hilite_pres);
+  dt_bauhaus_toggle_set(g->compensate_hilite_preserv,
+                        p->compensate_hilite_pres);
   /* xgettext:no-c-format */
   label = g_strdup_printf(_("highlight preservation mode (%.1f EV)"), hlbias);
   gtk_button_set_label(GTK_BUTTON(g->compensate_hilite_preserv), label);

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -3142,9 +3142,9 @@ void gui_update(dt_iop_module_t *self)
 
   // fetch last view in dartablerc
 
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->auto_hardness), p->auto_hardness);
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->custom_grey), p->custom_grey);
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->enable_highlight_reconstruction), p->enable_highlight_reconstruction);
+  dt_bauhaus_toggle_set(g->auto_hardness, p->auto_hardness);
+  dt_bauhaus_toggle_set(g->custom_grey, p->custom_grey);
+  dt_bauhaus_toggle_set(g->enable_highlight_reconstruction, p->enable_highlight_reconstruction);
 
   gui_changed(self, NULL, NULL);
 }
@@ -4715,7 +4715,7 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
     gtk_widget_set_sensitive(g->reconstruct_structure_vs_texture, TRUE);
 
     DT_ENTER_GUI_UPDATE();
-    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->enable_highlight_reconstruction), TRUE);
+    dt_bauhaus_toggle_set(g->enable_highlight_reconstruction, TRUE);
     p->enable_highlight_reconstruction = TRUE;
     DT_LEAVE_GUI_UPDATE();
   }

--- a/src/iop/hotpixels.c
+++ b/src/iop/hotpixels.c
@@ -43,8 +43,8 @@ typedef struct dt_iop_hotpixels_params_t
 typedef struct dt_iop_hotpixels_gui_data_t
 {
   GtkWidget *threshold, *strength;
-  GtkToggleButton *markfixed;
-  GtkToggleButton *permissive;
+  GtkWidget *markfixed;
+  GtkWidget *permissive;
   GtkLabel *message;
   int pixels_fixed;
 } dt_iop_hotpixels_gui_data_t;
@@ -400,8 +400,8 @@ void gui_update(dt_iop_module_t *self)
 {
   dt_iop_hotpixels_gui_data_t *g = self->gui_data;
   dt_iop_hotpixels_params_t *p = self->params;
-  gtk_toggle_button_set_active(g->markfixed, p->markfixed);
-  gtk_toggle_button_set_active(g->permissive, p->permissive);
+  dt_bauhaus_toggle_set(g->markfixed, p->markfixed);
+  dt_bauhaus_toggle_set(g->permissive, p->permissive);
   g->pixels_fixed = -1;
   gtk_label_set_text(g->message, "");
 
@@ -451,11 +451,11 @@ void gui_init(dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->strength, _("strength of hot pixel correction"));
 
   // 3 neighbours
-  g->permissive = GTK_TOGGLE_BUTTON(dt_bauhaus_toggle_from_params(self, "permissive"));
+  g->permissive = dt_bauhaus_toggle_from_params(self, "permissive");
 
   // mark fixed pixels
   GtkWidget *hbox = self->widget = dt_gui_hbox();
-  g->markfixed = GTK_TOGGLE_BUTTON(dt_bauhaus_toggle_from_params(self, "markfixed"));
+  g->markfixed = dt_bauhaus_toggle_from_params(self, "markfixed");
   g->message = GTK_LABEL(gtk_label_new("")); // This gets filled in by process
   dt_gui_box_add(hbox, g->message);
   dt_gui_box_add(box_raw, hbox);

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -4646,8 +4646,8 @@ void gui_update(dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->camera_model, "");
   gtk_widget_set_tooltip_text(g->lens_model, "");
 
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->tca_override),
-                               p->tca_override);
+  dt_bauhaus_toggle_set(g->tca_override,
+                        p->tca_override);
 
   const lfCamera **cam = NULL;
   g->camera = NULL;

--- a/src/iop/rgbcurve.c
+++ b/src/iop/rgbcurve.c
@@ -1577,8 +1577,8 @@ void gui_update(dt_iop_module_t *self)
 
   dt_bauhaus_combobox_set(g->autoscale, p->curve_autoscale);
   dt_bauhaus_combobox_set(g->interpolator, p->curve_type[DT_IOP_RGBCURVE_R]);
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->chk_compensate_middle_grey),
-                               p->compensate_middle_grey);
+  dt_bauhaus_toggle_set(g->chk_compensate_middle_grey,
+                        p->compensate_middle_grey);
   dt_bauhaus_combobox_set(g->cmb_preserve_colors, p->preserve_colors);
 
   _rgbcurve_show_hide_controls(p, g);

--- a/src/iop/useless.c
+++ b/src/iop/useless.c
@@ -555,14 +555,11 @@ void gui_update(dt_iop_module_t *self)
   dt_iop_useless_params_t *p = self->params;
 
   // introspection based bauhaus widgets, created with
-  // dt_bauhaus_slider_from_params or dt_bauhaus_combobox_from_params,
-  // get updated automatically.
+  // dt_bauhaus_slider_from_params, dt_bauhaus_combobox_from_params or
+  // dt_bauhaus_toggle_from_params, get updated automatically.
   // they cannot use any transformations here (for example *100 for
   // percentages) because that will break enforcement of $MIN/$MAX.
   // Use dt_bauhaus_slider_set_factor/offset in gui_init instead.
-
-  // dt_bauhaus_toggle_from_params creates a standard gtk_toggle_button.
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->check), p->check);
 
   dt_bauhaus_slider_set(g->extra, 0.0f);
 

--- a/src/iop/vignette.c
+++ b/src/iop/vignette.c
@@ -1032,7 +1032,7 @@ void gui_update(dt_iop_module_t *self)
 {
   dt_iop_vignette_gui_data_t *g = self->gui_data;
   dt_iop_vignette_params_t *p = self->params;
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->autoratio), p->autoratio);
+  dt_bauhaus_toggle_set(g->autoratio, p->autoratio);
   gtk_widget_set_sensitive(GTK_WIDGET(g->whratio), !p->autoratio);
 }
 


### PR DESCRIPTION
Add DT_BAUHAUS_TOGGLE as a third bauhaus widget type and build the introspection checkbox on it. The tick box is drawn in front of the label, where a check button puts it, by a style context that css resolves the same way as the check node of a check button inside a module: the box is drawn, and sized, the way the loaded theme draws and sizes any other checkbox, and it follows a theme change. Nothing is drawn in the column the other types keep free on the right, so that width goes to the label. Click, space, return, the arrow keys and scrolling all reach the value, and space in particular is what a check button is activated by.

Modules that recompute a bool default per image now keep the widget's default up to date the way they already do for sliders and comboboxes.

Also added a double pass for filmic's special checkbox. 

Tested to confirm no breaking changes so far that I noticed.

They currently look like:
<img width="359" height="529" alt="grafik" src="https://github.com/user-attachments/assets/e2be75f0-820b-4953-8266-9e0730bfae72" />


Things to discuss:
- Collapsibles still use their own version of checkboxes that still don't reset when the module is reset. Should this be added to this PR?

Transparency note: Co-edited with Claude