### PR TITLE
gtk4-prep: pass current state to all GtkStyleContext getters

### DIFF
--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -2536,6 +2536,21 @@ static gchar *_build_label(const dt_bauhaus_widget_t *w)
     return g_strdup(w->label);
 }
 
+// Helper: query CSS color for a specific pseudo-class state without passing a
+// non-current state to gtk_style_context_get_color() (which GTK4 rejects).
+//
+// GTK4 switch-time: remove the state argument from get_color() — the context
+// is already in the desired state via gtk_style_context_set_state().
+static void _popup_get_state_color(GtkStyleContext *context,
+                                    GtkStateFlags state,
+                                    GdkRGBA *color)
+{
+  gtk_style_context_save(context);
+  gtk_style_context_set_state(context, state);
+  gtk_style_context_get_color(context, state, color);
+  gtk_style_context_restore(context);
+}
+
 static gboolean _popup_draw(GtkWidget *widget,
                             cairo_t *cr,
                             gpointer user_data)
@@ -2553,19 +2568,18 @@ static gboolean _popup_draw(GtkWidget *widget,
 
   GtkStyleContext *context = gtk_widget_get_style_context(widget);
 
-  // look up some colors once
-  GdkRGBA text_color, text_color_selected, text_color_hover, text_color_insensitive;
-  gtk_style_context_get_color(context, GTK_STATE_FLAG_NORMAL, &text_color);
-  gtk_style_context_get_color(context, GTK_STATE_FLAG_SELECTED, &text_color_selected);
-  gtk_style_context_get_color(context, GTK_STATE_FLAG_PRELIGHT, &text_color_hover);
-  gtk_style_context_get_color(context, GTK_STATE_FLAG_INSENSITIVE, &text_color_insensitive);
-
   GdkRGBA *fg_color = _default_color_assign();
   GdkRGBA *bg_color;
   GtkStateFlags state = gtk_widget_get_state_flags(widget);
 
   gtk_style_context_get(context, state, "background-color", &bg_color, NULL);
   gtk_style_context_get_color(context, state, fg_color);
+
+  GdkRGBA text_color, text_color_selected, text_color_hover, text_color_insensitive;
+  _popup_get_state_color(context, GTK_STATE_FLAG_NORMAL, &text_color);
+  _popup_get_state_color(context, GTK_STATE_FLAG_SELECTED, &text_color_selected);
+  _popup_get_state_color(context, GTK_STATE_FLAG_PRELIGHT, &text_color_hover);
+  _popup_get_state_color(context, GTK_STATE_FLAG_INSENSITIVE, &text_color_insensitive);
 
   // draw background
   gtk_render_background(context, cr, 0, - pop->offcut, width, pop->position.height);

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -1396,7 +1396,7 @@ static void _window_set_titlebar_color_callback(GtkWidget *widget)
     if(style)
     {
       GdkRGBA *bg_color = NULL;
-      gtk_style_context_get(style, GTK_STATE_FLAG_NORMAL,
+      gtk_style_context_get(style, gtk_widget_get_state_flags(widget),
                             GTK_STYLE_PROPERTY_BACKGROUND_COLOR, &bg_color, NULL);
       if(bg_color)
       {

--- a/src/libs/tools/darktable.c
+++ b/src/libs/tools/darktable.c
@@ -208,11 +208,11 @@ static gboolean _lib_darktable_draw_callback(GtkWidget *widget,
   gtk_widget_get_allocation(widget, &allocation);
   gtk_render_background(context, cr, 0, 0, allocation.width, allocation.height);
 
-  // Get the normal foreground color from the CSS stylesheet
-  GdkRGBA *tmpcolor;
-  gtk_style_context_get(context, GTK_STATE_FLAG_NORMAL, "color", &tmpcolor, NULL);
-
   GtkStateFlags state = gtk_widget_get_state_flags(widget);
+
+  // Get the foreground color from the CSS stylesheet
+  GdkRGBA *tmpcolor;
+  gtk_style_context_get(context, state, "color", &tmpcolor, NULL);
 
   PangoFontDescription *font_desc = NULL;
   gtk_style_context_get(context, state, "font", &font_desc, NULL);


### PR DESCRIPTION
Fix 3 call sites where `gtk_style_context_get()` / `gtk_style_context_get_color()` were called with a state different from the context's current state — something GTK4 rejects outright.

`src/bauhaus/bauhaus.c` — `_popup_draw` queried colors for `GTK_STATE_FLAG_SELECTED`, `GTK_STATE_FLAG_PRELIGHT`, and `GTK_STATE_FLAG_INSENSITIVE` while the context was still in its widget's current state. Replace with a helper that saves the context, sets the desired state, calls `get_color()`, then restores.

`src/gui/gtk.c` — `_window_set_titlebar_color_callback` passed hardcoded `GTK_STATE_FLAG_NORMAL` instead of the widget's actual state.

`src/libs/tools/darktable.c` — same pattern: `_lib_darktable_draw_callback` queried `"color"` with `GTK_STATE_FLAG_NORMAL` before retrieving the actual widget state, so the state parameter didn't match the context.

See https://docs.gtk.org/gtk4/migrating-3to4.html

>Stop using the state argument of GtkStyleContext getters
>
>The getters in the GtkStyleContext API, such as `gtk_style_context_get_property()`, `gtk_style_context_get()`, or `gtk_style_context_get_color()` only accept the context's current state for their state argument. You should update all callers to pass the current state.

Related: #15920 #20433