### PR TITLE
gtk4-prep: update copyright years in previously touched files

### DIFF
--- a/src/control/control.c
+++ b/src/control/control.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2009-2025 darktable developers.
+    Copyright (C) 2009-2026 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/src/gui/styles_dialog.c
+++ b/src/gui/styles_dialog.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2010-2025 darktable developers.
+    Copyright (C) 2010-2026 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/src/libs/tools/darktable.c
+++ b/src/libs/tools/darktable.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2011-2025 darktable developers.
+    Copyright (C) 2011-2026 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/src/lua/widget/button.c
+++ b/src/lua/widget/button.c
@@ -1,6 +1,6 @@
 /*
    This file is part of darktable,
-   Copyright (C) 2015-2020 darktable developers.
+   Copyright (C) 2015-2026 darktable developers.
 
    darktable is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Update copyright year ranges in 4 source files that were modified in previous gtk4-prep PRs but whose copyright headers were not updated:

- `src/control/control.c` — 2009-2025 → 2009-2026 (PR #21642)
- `src/gui/styles_dialog.c` — 2010-2025 → 2010-2026 (PR #21546)
- `src/libs/tools/darktable.c` — 2011-2025 → 2011-2026 (PR #21643)
- `src/lua/widget/button.c` — 2015-2020 → 2015-2026 (PR #21541)

Changes are in comments only — no code behavior change.

Related: #15920 #20433