### PR TITLE
Korean translation based on pot file

### DIFF
--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -1,16 +1,16 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT ZHOLDER
-# This file is distributed under the same license as the DarkTable package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# Korean translation of darktable.
+# This file is distributed under the same license as the darktable package.
+# Hwanyong Lee <hwan@ajou.ac.kr>, 2025.
+# Ajou University (함도혁, 윤하윤, 정채영, 김민채, 김윤중), 2025.
+# 94tiger <94tiger@naver.com>, 2026.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: DarkTable\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-11-13 23:08+0100\n"
-"PO-Revision-Date: 2025-11-15 18:44+0900\n"
-"Last-Translator: Hwanyong Lee <hwan@ajou.ac.kr>\n"
+"POT-Creation-Date: 2026-07-24 20:50+0200\n"
+"PO-Revision-Date: 2026-07-27 13:46+0900\n"
+"Last-Translator: 94tiger <94tiger@naver.com>\n"
 "Language-Team: Ajou Univ.(함도혁,윤하윤,정채영,김민채,김윤중)\n"
 "Language: ko_KR\n"
 "MIME-Version: 1.0\n"
@@ -19,263 +19,273 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Poedit 3.8\n"
 
-#: ../build/bin/conf_gen.h:97
+#: ../build/bin/conf_gen.h:111
 msgctxt "preferences"
 msgid "first instance"
 msgstr "첫번째 인스턴스"
 
-#: ../build/bin/conf_gen.h:98 ../build/bin/preferences_gen.h:8226
+#: ../build/bin/conf_gen.h:112 ../build/bin/preferences_gen.h:4903
 msgctxt "preferences"
 msgid "last instance"
 msgstr "마지막 인스턴스"
 
-#: ../build/bin/conf_gen.h:179 ../build/bin/preferences_gen.h:7741
+#: ../build/bin/conf_gen.h:212 ../build/bin/preferences_gen.h:4559
 msgctxt "preferences"
 msgid "triangle"
 msgstr "삼각형"
 
-#: ../build/bin/conf_gen.h:180
+#: ../build/bin/conf_gen.h:213
 msgctxt "preferences"
 msgid "circle"
 msgstr "원"
 
-#: ../build/bin/conf_gen.h:181
+#: ../build/bin/conf_gen.h:214
 msgctxt "preferences"
 msgid "diamond"
 msgstr "다이아몬드"
 
-#: ../build/bin/conf_gen.h:182
+#: ../build/bin/conf_gen.h:215
 msgctxt "preferences"
 msgid "bar"
 msgstr "bar"
 
-#: ../build/bin/conf_gen.h:231 ../build/bin/conf_gen.h:359
-#: ../build/bin/conf_gen.h:370 ../build/bin/conf_gen.h:1509
-#: ../build/bin/conf_gen.h:1526 ../build/bin/conf_gen.h:1559
-#: ../build/bin/preferences_gen.h:4895 ../build/bin/preferences_gen.h:5067
+#: ../build/bin/conf_gen.h:288 ../build/bin/conf_gen.h:440
+#: ../build/bin/conf_gen.h:453 ../build/bin/conf_gen.h:1824
+#: ../build/bin/conf_gen.h:1845 ../build/bin/conf_gen.h:1882
+#: ../build/bin/preferences_gen.h:2953 ../build/bin/preferences_gen.h:3040
 msgctxt "preferences"
 msgid "never"
 msgstr "사용 안함"
 
-#: ../build/bin/conf_gen.h:232
+#: ../build/bin/conf_gen.h:289
 msgctxt "preferences"
 msgid "once a month"
 msgstr "한달에 한번"
 
-#: ../build/bin/conf_gen.h:233 ../build/bin/preferences_gen.h:7378
+#: ../build/bin/conf_gen.h:290 ../build/bin/preferences_gen.h:4343
 msgctxt "preferences"
 msgid "once a week"
 msgstr "일주일에 한번"
 
-#: ../build/bin/conf_gen.h:234
+#: ../build/bin/conf_gen.h:291
 msgctxt "preferences"
 msgid "once a day"
 msgstr "하루에 한번"
 
-#: ../build/bin/conf_gen.h:235
+#: ../build/bin/conf_gen.h:292
 msgctxt "preferences"
 msgid "on close"
 msgstr "종료시"
 
-#: ../build/bin/conf_gen.h:292 ../build/bin/conf_gen.h:1502
-#: ../build/bin/conf_gen.h:1519 ../build/bin/conf_gen.h:1560
+#: ../build/bin/conf_gen.h:365 ../build/bin/conf_gen.h:1815
+#: ../build/bin/conf_gen.h:1836 ../build/bin/conf_gen.h:1883
 msgctxt "preferences"
 msgid "small"
 msgstr "작게"
 
-#: ../build/bin/conf_gen.h:293 ../build/bin/conf_gen.h:423
-#: ../build/bin/preferences_gen.h:6314 ../build/bin/preferences_gen.h:6401
+#: ../build/bin/conf_gen.h:366 ../build/bin/conf_gen.h:593
+#: ../build/bin/preferences_gen.h:3776 ../build/bin/preferences_gen.h:3844
 msgctxt "preferences"
 msgid "default"
 msgstr "기본값"
 
-#: ../build/bin/conf_gen.h:294 ../build/bin/conf_gen.h:3655
+#: ../build/bin/conf_gen.h:367 ../build/bin/conf_gen.h:4346
 msgctxt "preferences"
 msgid "large"
 msgstr "크게"
 
-#: ../build/bin/conf_gen.h:360
+#: ../build/bin/conf_gen.h:441
 msgctxt "preferences"
 msgid "after edit"
 msgstr "편집 후"
 
-#: ../build/bin/conf_gen.h:361 ../build/bin/preferences_gen.h:7464
+#: ../build/bin/conf_gen.h:442 ../build/bin/preferences_gen.h:4395
 msgctxt "preferences"
 msgid "on import"
 msgstr "가져오기"
 
-#: ../build/bin/conf_gen.h:371 ../build/bin/conf_gen.h:1501
-#: ../build/bin/conf_gen.h:1518 ../build/bin/conf_gen.h:4195
-#: ../build/bin/preferences_gen.h:5820
+#: ../build/bin/conf_gen.h:454 ../build/bin/conf_gen.h:1814
+#: ../build/bin/conf_gen.h:1835 ../build/bin/conf_gen.h:5091
+#: ../build/bin/preferences_gen.h:3425
 msgctxt "preferences"
 msgid "always"
 msgstr "항상"
 
-#: ../build/bin/conf_gen.h:372 ../build/bin/preferences_gen.h:7499
+#: ../build/bin/conf_gen.h:455 ../build/bin/preferences_gen.h:4413
 msgctxt "preferences"
 msgid "only large entries"
 msgstr "큰 항목만"
 
-#: ../build/bin/conf_gen.h:405
+#: ../build/bin/conf_gen.h:492
 msgctxt "preferences"
 msgid "sensitive"
 msgstr "구분"
 
-#: ../build/bin/conf_gen.h:406 ../build/bin/preferences_gen.h:8436
+#: ../build/bin/conf_gen.h:493 ../build/bin/preferences_gen.h:5028
 msgctxt "preferences"
 msgid "insensitive"
 msgstr "구분 안함"
 
-#: ../build/bin/conf_gen.h:424
+#: ../build/bin/conf_gen.h:594
 msgctxt "preferences"
 msgid "multiple GPUs"
 msgstr "다중 GPU"
 
-#: ../build/bin/conf_gen.h:425
+#: ../build/bin/conf_gen.h:595
 msgctxt "preferences"
 msgid "very fast GPU"
 msgstr "매우 빠른 GPU"
 
-#: ../build/bin/conf_gen.h:834 ../build/bin/preferences_gen.h:8561
+#: ../build/bin/conf_gen.h:1064 ../build/bin/preferences_gen.h:5102
 msgctxt "preferences"
 msgid "import time"
 msgstr "가져온 시간"
 
-#: ../build/bin/conf_gen.h:835
+#: ../build/bin/conf_gen.h:1065
 msgctxt "preferences"
 msgid "folder name"
 msgstr "폴더 이름"
 
-#: ../build/bin/conf_gen.h:852
+#: ../build/bin/conf_gen.h:1066
+msgctxt "preferences"
+msgid "display name"
+msgstr "표시 이름"
+
+#: ../build/bin/conf_gen.h:1085
 msgctxt "preferences"
 msgid "RGB"
 msgstr "RGB"
 
-#: ../build/bin/conf_gen.h:853
+#: ../build/bin/conf_gen.h:1086
 msgctxt "preferences"
 msgid "Lab"
 msgstr "Lab"
 
-#: ../build/bin/conf_gen.h:854
+#: ../build/bin/conf_gen.h:1087
 msgctxt "preferences"
 msgid "LCh"
 msgstr "LCh"
 
-#: ../build/bin/conf_gen.h:855
+#: ../build/bin/conf_gen.h:1088
 msgctxt "preferences"
 msgid "HSL"
 msgstr "HSL"
 
-#: ../build/bin/conf_gen.h:856
+#: ../build/bin/conf_gen.h:1089
 msgctxt "preferences"
 msgid "Hex"
 msgstr "Hex"
 
-#: ../build/bin/conf_gen.h:857 ../build/bin/conf_gen.h:2393
-#: ../build/bin/conf_gen.h:3246 ../build/bin/conf_gen.h:3628
-#: ../build/bin/conf_gen.h:3980
+#: ../build/bin/conf_gen.h:1090 ../build/bin/conf_gen.h:2862
+#: ../build/bin/conf_gen.h:3889 ../build/bin/conf_gen.h:4317
+#: ../build/bin/conf_gen.h:4858
 msgctxt "preferences"
 msgid "none"
 msgstr "없음"
 
-#: ../build/bin/conf_gen.h:866
+#: ../build/bin/conf_gen.h:1100
 msgctxt "preferences"
 msgid "mean"
 msgstr "평균"
 
-#: ../build/bin/conf_gen.h:867
+#: ../build/bin/conf_gen.h:1101
 msgctxt "preferences"
 msgid "min"
 msgstr "최소"
 
-#: ../build/bin/conf_gen.h:868
+#: ../build/bin/conf_gen.h:1102
 msgctxt "preferences"
 msgid "max"
 msgstr "최대"
 
-#: ../build/bin/conf_gen.h:1166
+#: ../build/bin/conf_gen.h:1437
 msgid "select only new images"
 msgstr "새 이미지만 선택"
 
-#: ../build/bin/conf_gen.h:1167
+#: ../build/bin/conf_gen.h:1438
 msgid "only select images that have not already been imported"
 msgstr "가져온적이 없는 이미지만 선택합니다"
 
-#: ../build/bin/conf_gen.h:1174
+#: ../build/bin/conf_gen.h:1446
 msgid "ignore non-raw images"
 msgstr "RAW가 아닌 이미지는 무시"
 
-#: ../build/bin/conf_gen.h:1175
-msgid "if enabled, only raw files will be allowed to import. non-raw files will not be visible in the dialog and will not be imported."
+#: ../build/bin/conf_gen.h:1447
+msgid ""
+"if enabled, only raw files will be allowed to import. non-raw files will not "
+"be visible in the dialog and will not be imported."
 msgstr "활성화하면 RAW 파일만 가져올 수 있습니다. RAW가 아닌 파일은대화상자에 표시되지 않으며 가져올 수 없습니다."
 
-#: ../build/bin/conf_gen.h:1182
+#: ../build/bin/conf_gen.h:1455
 msgid "apply metadata"
 msgstr "메타데이터 적용"
 
-#: ../build/bin/conf_gen.h:1183
+#: ../build/bin/conf_gen.h:1456
 msgid "apply some metadata to all newly imported images."
 msgstr "새로 가져온 모든 이미지에 일부 메타데이터를 적용합니다."
 
-#: ../build/bin/conf_gen.h:1190
+#: ../build/bin/conf_gen.h:1464
 msgid "recursive directory"
 msgstr "모든 하위 디렉토리 포함"
 
-#: ../build/bin/conf_gen.h:1191
+#: ../build/bin/conf_gen.h:1465
 msgid "recursive directory traversal when importing filmrolls"
 msgstr "필름롤을 가져오기 시 하위 디렉토리 탐색"
 
-#: ../build/bin/conf_gen.h:1198
+#: ../build/bin/conf_gen.h:1473
 msgid "creator to be applied when importing"
 msgstr "가져오기 시 적용할 작성자"
 
-#: ../build/bin/conf_gen.h:1206
+#: ../build/bin/conf_gen.h:1482
 msgid "publisher to be applied when importing"
 msgstr "가져오기 시 적용할 발행자"
 
-#: ../build/bin/conf_gen.h:1214
+#: ../build/bin/conf_gen.h:1491
 msgid "rights to be applied when importing"
 msgstr "가져오기 시 적용할 저작권 정보"
 
-#: ../build/bin/conf_gen.h:1222
+#: ../build/bin/conf_gen.h:1500
 msgid "comma separated tags to be applied when importing"
 msgstr "가져오기 시 적용할 태그 (쉼표로 구분)"
 
-#: ../build/bin/conf_gen.h:1230
+#: ../build/bin/conf_gen.h:1509
 msgid "import tags from XMP"
 msgstr "XMP에서 태그 가져오기"
 
-#: ../build/bin/conf_gen.h:1262
+#: ../build/bin/conf_gen.h:1545
 msgid "initial rating"
 msgstr "초기 등급"
 
-#: ../build/bin/conf_gen.h:1263
+#: ../build/bin/conf_gen.h:1546
 msgid "initial star rating for all images when importing a filmroll"
 msgstr "필름롤을 가져오기 시 모든 이미지에 적용할 초기 등급"
 
-#: ../build/bin/conf_gen.h:1270
+#: ../build/bin/conf_gen.h:1554
 msgid "ignore EXIF rating"
 msgstr "EXIF 등급 무시"
 
-#: ../build/bin/conf_gen.h:1271
-msgid "ignore EXIF rating. if not set and EXIF rating is found, it overrides 'initial rating'"
+#: ../build/bin/conf_gen.h:1555
+msgid ""
+"ignore EXIF rating. if not set and EXIF rating is found, it overrides "
+"'initial rating'"
 msgstr "EXIF 등급을 무시합니다. 설정하지 않으면 EXIF 등급이 있을 경우'초기 등급'을 덮어씁니다"
 
-#: ../build/bin/conf_gen.h:1278
+#: ../build/bin/conf_gen.h:1563
 msgid "import job"
 msgstr "작업 가져오기"
 
-#: ../build/bin/conf_gen.h:1279
+#: ../build/bin/conf_gen.h:1564
 msgid "name of the import job"
 msgstr "작업 가져오기 이름"
 
-#: ../build/bin/conf_gen.h:1286
+#: ../build/bin/conf_gen.h:1572
 msgid "override today's date"
 msgstr "오늘 날짜 재정의"
 
-#: ../build/bin/conf_gen.h:1287
+#: ../build/bin/conf_gen.h:1573
 msgid ""
-"type a date in the form: YYYY:MM:DD[ hh:mm:ss[.sss]] if you want to override the current date/time used when expanding variables:\n"
+"type a date in the form: YYYY:MM:DD[ hh:mm:ss[.sss]] if you want to override "
+"the current date/time used when expanding variables:\n"
 "$(YEAR), $(MONTH), $(DAY), $(HOUR), $(MINUTE), $(SECONDS), $(MSEC).\n"
 "let the field empty otherwise"
 msgstr ""
@@ -283,840 +293,901 @@ msgstr ""
 "$(YEAR), $(MONTH), $(DAY), $(HOUR), $(MINUTE), $(SECONDS), $(MSEC)변수에 적용됩니다.\n"
 "필요 없으면 필드를 비워 둡니다"
 
-#: ../build/bin/conf_gen.h:1294
+#: ../build/bin/conf_gen.h:1581
 msgid "keep this window open"
 msgstr "현재 창을 계속 열어두기"
 
-#: ../build/bin/conf_gen.h:1295
+#: ../build/bin/conf_gen.h:1582
 msgid "keep this window open to run several imports"
 msgstr "여러 번 가져오기를 실행할 수 있도록 이 창을 열어둡니다"
 
-#: ../build/bin/conf_gen.h:1503 ../build/bin/conf_gen.h:1520
-#: ../build/bin/conf_gen.h:1561
+#: ../build/bin/conf_gen.h:1816 ../build/bin/conf_gen.h:1837
+#: ../build/bin/conf_gen.h:1884
 msgctxt "preferences"
 msgid "VGA"
 msgstr "VGA"
 
-#: ../build/bin/conf_gen.h:1504 ../build/bin/conf_gen.h:1521
-#: ../build/bin/conf_gen.h:1562 ../build/bin/preferences_gen.h:4930
+#: ../build/bin/conf_gen.h:1817 ../build/bin/conf_gen.h:1838
+#: ../build/bin/conf_gen.h:1885 ../build/bin/preferences_gen.h:2971
 msgctxt "preferences"
 msgid "720p"
 msgstr "720p"
 
-#: ../build/bin/conf_gen.h:1505 ../build/bin/conf_gen.h:1522
-#: ../build/bin/conf_gen.h:1563
+#: ../build/bin/conf_gen.h:1818 ../build/bin/conf_gen.h:1839
+#: ../build/bin/conf_gen.h:1886
 msgctxt "preferences"
 msgid "1080p"
 msgstr "1080p"
 
-#: ../build/bin/conf_gen.h:1506 ../build/bin/conf_gen.h:1523
-#: ../build/bin/conf_gen.h:1564
+#: ../build/bin/conf_gen.h:1819 ../build/bin/conf_gen.h:1840
+#: ../build/bin/conf_gen.h:1887
 msgctxt "preferences"
 msgid "WQXGA"
 msgstr "WQXGA"
 
-#: ../build/bin/conf_gen.h:1507 ../build/bin/conf_gen.h:1524
-#: ../build/bin/conf_gen.h:1565
+#: ../build/bin/conf_gen.h:1820 ../build/bin/conf_gen.h:1841
+#: ../build/bin/conf_gen.h:1888
 msgctxt "preferences"
 msgid "4K"
 msgstr "4K"
 
-#: ../build/bin/conf_gen.h:1508 ../build/bin/conf_gen.h:1525
-#: ../build/bin/conf_gen.h:1566
+#: ../build/bin/conf_gen.h:1821 ../build/bin/conf_gen.h:1842
+#: ../build/bin/conf_gen.h:1889
 msgctxt "preferences"
 msgid "5K"
 msgstr "5K"
 
-#: ../build/bin/conf_gen.h:1607
+#: ../build/bin/conf_gen.h:1822 ../build/bin/conf_gen.h:1843
+#: ../build/bin/conf_gen.h:1890
 msgctxt "preferences"
-msgid "off"
-msgstr "꺼짐"
+msgid "6K"
+msgstr "6K"
 
-#: ../build/bin/conf_gen.h:1608
+#: ../build/bin/conf_gen.h:1823 ../build/bin/conf_gen.h:1844
+#: ../build/bin/conf_gen.h:1891
 msgctxt "preferences"
-msgid "hardness (relative)"
-msgstr "경도 (상대)"
+msgid "8K"
+msgstr "8K"
 
-#: ../build/bin/conf_gen.h:1609
-msgctxt "preferences"
-msgid "hardness (absolute)"
-msgstr "경도 (절대)"
-
-#: ../build/bin/conf_gen.h:1610
-msgctxt "preferences"
-msgid "opacity (relative)"
-msgstr "불투명도 (상대)"
-
-#: ../build/bin/conf_gen.h:1611
-msgctxt "preferences"
-msgid "opacity (absolute)"
-msgstr "불투명도 (절대)"
-
-#: ../build/bin/conf_gen.h:1612
-msgctxt "preferences"
-msgid "brush size (relative)"
-msgstr "브러시 크기 (상대)"
-
-#: ../build/bin/conf_gen.h:1621
-msgctxt "preferences"
-msgid "low"
-msgstr "낮음"
-
-#: ../build/bin/conf_gen.h:1622
-msgctxt "preferences"
-msgid "medium"
-msgstr "중간"
-
-#: ../build/bin/conf_gen.h:1623
-msgctxt "preferences"
-msgid "high"
-msgstr "높음"
-
-#: ../build/bin/conf_gen.h:1648 ../build/bin/preferences_gen.h:5547
-msgctxt "preferences"
-msgid "false color"
-msgstr "거짓 색상"
-
-#: ../build/bin/conf_gen.h:1649
-msgctxt "preferences"
-msgid "grayscale"
-msgstr "회색조"
-
-#: ../build/bin/conf_gen.h:1666
-msgctxt "preferences"
-msgid "top left"
-msgstr "왼쪽 상단"
-
-#: ../build/bin/conf_gen.h:1667
-msgctxt "preferences"
-msgid "top right"
-msgstr "오른쪽 상단"
-
-#: ../build/bin/conf_gen.h:1668
-msgctxt "preferences"
-msgid "top center"
-msgstr "중앙 상단"
-
-#: ../build/bin/conf_gen.h:1669 ../build/bin/preferences_gen.h:5394
-msgctxt "preferences"
-msgid "bottom"
-msgstr "하단"
-
-#: ../build/bin/conf_gen.h:1670
-msgctxt "preferences"
-msgid "hidden"
-msgstr "숨김"
-
-#: ../build/bin/conf_gen.h:2352
-msgid "show OSD"
-msgstr "OSD 표시"
-
-#: ../build/bin/conf_gen.h:2353
-msgid "toggle the visibility of the map overlays"
-msgstr "지도 오버레이의 표시 여부를 전환합니다"
-
-#: ../build/bin/conf_gen.h:2360 ../src/libs/map_settings.c:119
-msgid "filtered images"
-msgstr "필터링된 이미지"
-
-#: ../build/bin/conf_gen.h:2361
-msgid "when set limit the images drawn to the current filmstrip"
-msgstr "설정 시 현재 필름스트립에 표시된 이미지로 제한합니다"
-
-#: ../build/bin/conf_gen.h:2368
-msgid "max images"
-msgstr "최대 이미지 개수"
-
-#: ../build/bin/conf_gen.h:2369
-msgid "the maximum number of image thumbnails drawn on the map"
-msgstr "지도에 표시할 이미지 썸네일의 최대 개수"
-
-#: ../build/bin/conf_gen.h:2376
-msgid "group size factor"
-msgstr "그룹 크기 배율"
-
-#: ../build/bin/conf_gen.h:2377
-msgid "increase or decrease the spatial size of images groups on the map. can influence the calculation time"
-msgstr "지도에서 이미지 그룹의 공간 크기를 늘리거나 줄입니다.계산 시간에 영향을 줄 수 있습니다"
-
-#: ../build/bin/conf_gen.h:2384
-msgid "min images per group"
-msgstr "그룹당 최소 이미지 개수"
-
-#: ../build/bin/conf_gen.h:2385
-msgid "the minimum number of images to set up an images group. can influence the calculation time."
-msgstr "이미지 그룹을 구성하는 데 필요한 최소 이미지 수입니다.계산 시간에 영향을 줄 수 있습니다."
-
-#: ../build/bin/conf_gen.h:2391
-msgctxt "preferences"
-msgid "thumbnail"
-msgstr "썸네일"
-
-#: ../build/bin/conf_gen.h:2392
-msgctxt "preferences"
-msgid "count"
-msgstr "개수"
-
-#: ../build/bin/conf_gen.h:2395
-msgid "thumbnail display"
-msgstr "썸네일 표시"
-
-#: ../build/bin/conf_gen.h:2396
-msgid "three options are available: images thumbnails, only the count of images of the group or nothing"
-msgstr "세 가지 옵션이 있습니다: 이미지 썸네일, 그룹의 이미지 개수만 표시, 또는 아무것도 표시하지 않기"
-
-#: ../build/bin/conf_gen.h:2411
-msgid "max polygon points"
-msgstr "최대 다각형 꼭짓점 수"
-
-#: ../build/bin/conf_gen.h:2412
-msgid "limit the number of points imported with polygon in find location module"
-msgstr "위치 찾기 모듈에서 다각형으로 가져오기 시 꼭짓점 수를 제한합니다"
-
-#: ../build/bin/conf_gen.h:2818
-msgctxt "preferences"
-msgid "original"
-msgstr "원본"
-
-#: ../build/bin/conf_gen.h:2819
-msgctxt "preferences"
-msgid "to 1/2"
-msgstr "1/2로"
-
-#: ../build/bin/conf_gen.h:2820
-msgctxt "preferences"
-msgid "to 1/3"
-msgstr "1/3로"
-
-#: ../build/bin/conf_gen.h:2821
-msgctxt "preferences"
-msgid "to 1/4"
-msgstr "1/4로"
-
-#: ../build/bin/conf_gen.h:2846 ../build/bin/conf_gen.h:2857
-msgctxt "preferences"
-msgid "bilinear"
-msgstr "쌍선형"
-
-#: ../build/bin/conf_gen.h:2847 ../build/bin/conf_gen.h:2858
-#: ../build/bin/preferences_gen.h:6018
-msgctxt "preferences"
-msgid "bicubic"
-msgstr "쌍입방"
-
-#: ../build/bin/conf_gen.h:2848 ../build/bin/conf_gen.h:2859
-msgctxt "preferences"
-msgid "lanczos2"
-msgstr "란초스2"
-
-#: ../build/bin/conf_gen.h:2860 ../build/bin/preferences_gen.h:6053
-msgctxt "preferences"
-msgid "lanczos3"
-msgstr "란초스3"
-
-#: ../build/bin/conf_gen.h:3245 ../build/bin/conf_gen.h:4198
-#: ../build/bin/preferences_gen.h:7209
+#: ../build/bin/conf_gen.h:1825 ../build/bin/conf_gen.h:3888
+#: ../build/bin/conf_gen.h:5094 ../build/bin/preferences_gen.h:4253
 msgctxt "preferences"
 msgid "auto"
 msgstr "자동"
 
-#: ../build/bin/conf_gen.h:3247
+#: ../build/bin/conf_gen.h:1937
 msgctxt "preferences"
-msgid "libsecret"
-msgstr "libsecret"
+msgid "off"
+msgstr "꺼짐"
 
-#: ../build/bin/conf_gen.h:3248
+#: ../build/bin/conf_gen.h:1938
 msgctxt "preferences"
-msgid "kwallet"
-msgstr "kwallet"
+msgid "hardness (relative)"
+msgstr "경도 (상대)"
 
-#: ../build/bin/conf_gen.h:3249
+#: ../build/bin/conf_gen.h:1939
 msgctxt "preferences"
-msgid "apple_keychain"
-msgstr "apple_keychain"
+msgid "hardness (absolute)"
+msgstr "경도 (절대)"
 
-#: ../build/bin/conf_gen.h:3250
+#: ../build/bin/conf_gen.h:1940
 msgctxt "preferences"
-msgid "windows_credentials"
-msgstr "windows_credentials"
+msgid "opacity (relative)"
+msgstr "불투명도 (상대)"
 
-#: ../build/bin/conf_gen.h:3515
+#: ../build/bin/conf_gen.h:1941
 msgctxt "preferences"
-msgid "vectorscope"
-msgstr "벡터스코프"
+msgid "opacity (absolute)"
+msgstr "불투명도 (절대)"
 
-#: ../build/bin/conf_gen.h:3516
+#: ../build/bin/conf_gen.h:1942
 msgctxt "preferences"
-msgid "waveform"
-msgstr "웨이브폼"
+msgid "brush size (relative)"
+msgstr "브러시 크기 (상대)"
 
-#: ../build/bin/conf_gen.h:3517
+#: ../build/bin/conf_gen.h:1952
 msgctxt "preferences"
-msgid "RGB parade"
-msgstr "RGB 퍼레이드"
+msgid "low"
+msgstr "낮음"
 
-#: ../build/bin/conf_gen.h:3518
+#: ../build/bin/conf_gen.h:1953
 msgctxt "preferences"
-msgid "histogram"
-msgstr "히스토그램"
+msgid "medium"
+msgstr "중간"
 
-#: ../build/bin/conf_gen.h:3527
+#: ../build/bin/conf_gen.h:1954
 msgctxt "preferences"
-msgid "left"
-msgstr "왼쪽"
+msgid "high"
+msgstr "높음"
 
-#: ../build/bin/conf_gen.h:3528 ../build/bin/preferences_gen.h:7923
+#: ../build/bin/conf_gen.h:1982 ../build/bin/preferences_gen.h:3511
 msgctxt "preferences"
-msgid "right"
-msgstr "오른쪽"
+msgid "pixels"
+msgstr "픽셀"
 
-#: ../build/bin/conf_gen.h:3545 ../build/bin/conf_gen.h:3586
+#: ../build/bin/conf_gen.h:1983
 msgctxt "preferences"
-msgid "logarithmic"
-msgstr "로그"
+msgid "% of path size"
+msgstr "경로 크기의 %"
 
-#: ../build/bin/conf_gen.h:3546 ../build/bin/conf_gen.h:3587
+#: ../build/bin/conf_gen.h:2002
 msgctxt "preferences"
-msgid "linear"
-msgstr "선형"
+msgid "sharp"
+msgstr "뾰족하게"
 
-#: ../build/bin/conf_gen.h:3555
+#: ../build/bin/conf_gen.h:2003 ../build/bin/preferences_gen.h:3548
 msgctxt "preferences"
-msgid "horizontal"
-msgstr "수평"
+msgid "balanced"
+msgstr "균형"
 
-#: ../build/bin/conf_gen.h:3556
-msgctxt "preferences"
-msgid "vertical"
-msgstr "수직"
-
-#: ../build/bin/conf_gen.h:3565
-msgctxt "preferences"
-msgid "overlaid"
-msgstr "오버레이"
-
-#: ../build/bin/conf_gen.h:3566
-msgctxt "preferences"
-msgid "parade"
-msgstr "퍼레이드"
-
-#: ../build/bin/conf_gen.h:3575
-msgctxt "preferences"
-msgid "u*v*"
-msgstr "u*v*"
-
-#: ../build/bin/conf_gen.h:3576
-msgctxt "preferences"
-msgid "AzBz"
-msgstr "AzBz"
-
-#: ../build/bin/conf_gen.h:3577
-msgctxt "preferences"
-msgid "RYB"
-msgstr "RYB"
-
-#: ../build/bin/conf_gen.h:3629
-msgctxt "preferences"
-msgid "monochromatic"
-msgstr "단색조"
-
-#: ../build/bin/conf_gen.h:3630
-msgctxt "preferences"
-msgid "analogous"
-msgstr "유사색"
-
-#: ../build/bin/conf_gen.h:3631
-msgctxt "preferences"
-msgid "analogous complementary"
-msgstr "유사 보색"
-
-#: ../build/bin/conf_gen.h:3632
-msgctxt "preferences"
-msgid "complementary"
-msgstr "보색"
-
-#: ../build/bin/conf_gen.h:3633
-msgctxt "preferences"
-msgid "split complementary"
-msgstr "분할 보색"
-
-#: ../build/bin/conf_gen.h:3634
-msgctxt "preferences"
-msgid "dyad"
-msgstr "2색 조합 (Dyad)"
-
-#: ../build/bin/conf_gen.h:3635
-msgctxt "preferences"
-msgid "triad"
-msgstr "3색 조합 (Triad)"
-
-#: ../build/bin/conf_gen.h:3636
-msgctxt "preferences"
-msgid "tetrad"
-msgstr "4색 조합 (Tetrad)"
-
-#: ../build/bin/conf_gen.h:3637
-msgctxt "preferences"
-msgid "square"
-msgstr "정사각형"
-
-#: ../build/bin/conf_gen.h:3654
-msgctxt "preferences"
-msgid "normal"
-msgstr "일반"
-
-#: ../build/bin/conf_gen.h:3656
-msgctxt "preferences"
-msgid "narrow"
-msgstr "좁게"
-
-#: ../build/bin/conf_gen.h:3657
-msgctxt "preferences"
-msgid "line"
-msgstr "선"
-
-#: ../build/bin/conf_gen.h:3834
-msgctxt "preferences"
-msgid "mm"
-msgstr "mm"
-
-#: ../build/bin/conf_gen.h:3835
-msgctxt "preferences"
-msgid "cm"
-msgstr "cm"
-
-#: ../build/bin/conf_gen.h:3836
-msgctxt "preferences"
-msgid "inch"
-msgstr "inch"
-
-#: ../build/bin/conf_gen.h:3885 ../build/bin/preferences_gen.h:7958
-msgctxt "preferences"
-msgid "all"
-msgstr "all"
-
-#: ../build/bin/conf_gen.h:3886
-msgctxt "preferences"
-msgid "xatom"
-msgstr "xatom"
-
-#: ../build/bin/conf_gen.h:3887
-msgctxt "preferences"
-msgid "colord"
-msgstr "colord"
-
-#: ../build/bin/conf_gen.h:3976 ../build/bin/preferences_gen.h:6170
-msgctxt "preferences"
-msgid "scene-referred (sigmoid)"
-msgstr "장면 기준 (시그모이드)"
-
-#: ../build/bin/conf_gen.h:3977
-msgctxt "preferences"
-msgid "scene-referred (filmic)"
-msgstr "장면 기준 (필믹)"
-
-#: ../build/bin/conf_gen.h:3978
-msgctxt "preferences"
-msgid "scene-referred (AgX)"
-msgstr "장면-참조 (AgX)"
-
-#: ../build/bin/conf_gen.h:3979
-msgctxt "preferences"
-msgid "display-referred (legacy)"
-msgstr "디스플레이 기준 (레거시)"
-
-#: ../build/bin/conf_gen.h:4110
-msgid "camera time zone"
-msgstr "카메라 시간대"
-
-#: ../build/bin/conf_gen.h:4111
-msgid "most cameras don't store the time zone in EXIF. give the correct time zone so the GPX data can be correctly matched"
-msgstr "대부분의 카메라는 EXIF에 시간대를 저장하지 않습니다.GPX 데이터를 올바르게 일치시키기 위해 올바른 시간대를 입력합니다"
-
-#: ../build/bin/conf_gen.h:4125
-msgctxt "preferences"
-msgid "no color"
-msgstr "무색"
-
-#: ../build/bin/conf_gen.h:4126
-msgctxt "preferences"
-msgid "illuminant color"
-msgstr "광원 색상"
-
-#: ../build/bin/conf_gen.h:4127
-msgctxt "preferences"
-msgid "effect emulation"
-msgstr "효과 에뮬레이션"
-
-#: ../build/bin/conf_gen.h:4184
-msgctxt "preferences"
-msgid "list"
-msgstr "목록"
-
-#: ../build/bin/conf_gen.h:4185
-msgctxt "preferences"
-msgid "tabs"
-msgstr "탭"
-
-#: ../build/bin/conf_gen.h:4186
-msgctxt "preferences"
-msgid "columns"
-msgstr "열"
-
-#: ../build/bin/conf_gen.h:4196
-msgctxt "preferences"
-msgid "active"
-msgstr "활성"
-
-#: ../build/bin/conf_gen.h:4197
-msgctxt "preferences"
-msgid "dim"
-msgstr "어둡게"
-
-#: ../build/bin/conf_gen.h:4199
-msgctxt "preferences"
-msgid "fade"
-msgstr "페이드"
-
-#: ../build/bin/conf_gen.h:4200
-msgctxt "preferences"
-msgid "fit"
-msgstr "맞춤"
-
-#: ../build/bin/conf_gen.h:4201
+#: ../build/bin/conf_gen.h:2004 ../build/bin/conf_gen.h:5097
 msgctxt "preferences"
 msgid "smooth"
 msgstr "부드럽게"
 
-#: ../build/bin/conf_gen.h:4202
+#: ../build/bin/conf_gen.h:2023 ../build/bin/preferences_gen.h:3288
+msgctxt "preferences"
+msgid "false color"
+msgstr "거짓 색상"
+
+#: ../build/bin/conf_gen.h:2024
+msgctxt "preferences"
+msgid "grayscale"
+msgstr "회색조"
+
+#: ../build/bin/conf_gen.h:2043
+msgctxt "preferences"
+msgid "top left"
+msgstr "왼쪽 상단"
+
+#: ../build/bin/conf_gen.h:2044
+msgctxt "preferences"
+msgid "top right"
+msgstr "오른쪽 상단"
+
+#: ../build/bin/conf_gen.h:2045
+msgctxt "preferences"
+msgid "top center"
+msgstr "중앙 상단"
+
+#: ../build/bin/conf_gen.h:2046 ../build/bin/preferences_gen.h:3203
+msgctxt "preferences"
+msgid "bottom"
+msgstr "하단"
+
+#: ../build/bin/conf_gen.h:2047
+msgctxt "preferences"
+msgid "hidden"
+msgstr "숨김"
+
+#: ../build/bin/conf_gen.h:2816
+msgid "show OSD"
+msgstr "OSD 표시"
+
+#: ../build/bin/conf_gen.h:2817
+msgid "toggle the visibility of the map overlays"
+msgstr "지도 오버레이의 표시 여부를 전환합니다"
+
+#: ../build/bin/conf_gen.h:2825 ../src/libs/map_settings.c:119
+msgid "filtered images"
+msgstr "필터링된 이미지"
+
+#: ../build/bin/conf_gen.h:2826
+msgid "when set limit the images drawn to the current filmstrip"
+msgstr "설정 시 현재 필름스트립에 표시된 이미지로 제한합니다"
+
+#: ../build/bin/conf_gen.h:2834
+msgid "max images"
+msgstr "최대 이미지 개수"
+
+#: ../build/bin/conf_gen.h:2835
+msgid "the maximum number of image thumbnails drawn on the map"
+msgstr "지도에 표시할 이미지 썸네일의 최대 개수"
+
+#: ../build/bin/conf_gen.h:2843
+msgid "group size factor"
+msgstr "그룹 크기 배율"
+
+#: ../build/bin/conf_gen.h:2844
+msgid ""
+"increase or decrease the spatial size of images groups on the map. can "
+"influence the calculation time"
+msgstr "지도에서 이미지 그룹의 공간 크기를 늘리거나 줄입니다.계산 시간에 영향을 줄 수 있습니다"
+
+#: ../build/bin/conf_gen.h:2852
+msgid "min images per group"
+msgstr "그룹당 최소 이미지 개수"
+
+#: ../build/bin/conf_gen.h:2853
+msgid ""
+"the minimum number of images to set up an images group. can influence the "
+"calculation time."
+msgstr "이미지 그룹을 구성하는 데 필요한 최소 이미지 수입니다.계산 시간에 영향을 줄 수 있습니다."
+
+#: ../build/bin/conf_gen.h:2860
+msgctxt "preferences"
+msgid "thumbnail"
+msgstr "썸네일"
+
+#: ../build/bin/conf_gen.h:2861
+msgctxt "preferences"
+msgid "count"
+msgstr "개수"
+
+#: ../build/bin/conf_gen.h:2864
+msgid "thumbnail display"
+msgstr "썸네일 표시"
+
+#: ../build/bin/conf_gen.h:2865
+msgid ""
+"three options are available: images thumbnails, only the count of images of "
+"the group or nothing"
+msgstr "세 가지 옵션이 있습니다: 이미지 썸네일, 그룹의 이미지 개수만 표시, 또는 아무것도 표시하지 않기"
+
+#: ../build/bin/conf_gen.h:2882
+msgid "max polygon points"
+msgstr "최대 다각형 꼭짓점 수"
+
+#: ../build/bin/conf_gen.h:2883
+msgid ""
+"limit the number of points imported with polygon in find location module"
+msgstr "위치 찾기 모듈에서 다각형으로 가져오기 시 꼭짓점 수를 제한합니다"
+
+#: ../build/bin/conf_gen.h:3395 ../build/bin/conf_gen.h:3407
+msgctxt "preferences"
+msgid "bilinear"
+msgstr "쌍선형"
+
+#: ../build/bin/conf_gen.h:3396 ../build/bin/conf_gen.h:3408
+#: ../build/bin/preferences_gen.h:3616
+msgctxt "preferences"
+msgid "bicubic"
+msgstr "쌍입방"
+
+#: ../build/bin/conf_gen.h:3397 ../build/bin/conf_gen.h:3409
+msgctxt "preferences"
+msgid "lanczos2"
+msgstr "란초스2"
+
+#: ../build/bin/conf_gen.h:3410 ../build/bin/preferences_gen.h:3634
+msgctxt "preferences"
+msgid "lanczos3"
+msgstr "란초스3"
+
+#: ../build/bin/conf_gen.h:3890
+msgctxt "preferences"
+msgid "libsecret"
+msgstr "libsecret"
+
+#: ../build/bin/conf_gen.h:3891
+msgctxt "preferences"
+msgid "kwallet"
+msgstr "kwallet"
+
+#: ../build/bin/conf_gen.h:3892
+msgctxt "preferences"
+msgid "apple_keychain"
+msgstr "apple_keychain"
+
+#: ../build/bin/conf_gen.h:3893
+msgctxt "preferences"
+msgid "windows_credentials"
+msgstr "windows_credentials"
+
+#: ../build/bin/conf_gen.h:4191
+msgctxt "preferences"
+msgid "vectorscope"
+msgstr "벡터스코프"
+
+#: ../build/bin/conf_gen.h:4192
+msgctxt "preferences"
+msgid "waveform"
+msgstr "웨이브폼"
+
+#: ../build/bin/conf_gen.h:4193
+msgctxt "preferences"
+msgid "split"
+msgstr "분할"
+
+#: ../build/bin/conf_gen.h:4194
+msgctxt "preferences"
+msgid "RGB parade"
+msgstr "RGB 퍼레이드"
+
+#: ../build/bin/conf_gen.h:4195
+msgctxt "preferences"
+msgid "histogram"
+msgstr "히스토그램"
+
+#: ../build/bin/conf_gen.h:4205
+msgctxt "preferences"
+msgid "left"
+msgstr "왼쪽"
+
+#: ../build/bin/conf_gen.h:4206 ../build/bin/preferences_gen.h:4742
+msgctxt "preferences"
+msgid "right"
+msgstr "오른쪽"
+
+#: ../build/bin/conf_gen.h:4225 ../build/bin/conf_gen.h:4270
+msgctxt "preferences"
+msgid "logarithmic"
+msgstr "로그"
+
+#: ../build/bin/conf_gen.h:4226 ../build/bin/conf_gen.h:4271
+msgctxt "preferences"
+msgid "linear"
+msgstr "선형"
+
+#: ../build/bin/conf_gen.h:4236
+msgctxt "preferences"
+msgid "horizontal"
+msgstr "수평"
+
+#: ../build/bin/conf_gen.h:4237
+msgctxt "preferences"
+msgid "vertical"
+msgstr "수직"
+
+#: ../build/bin/conf_gen.h:4247
+msgctxt "preferences"
+msgid "overlaid"
+msgstr "오버레이"
+
+#: ../build/bin/conf_gen.h:4248
+msgctxt "preferences"
+msgid "parade"
+msgstr "퍼레이드"
+
+#: ../build/bin/conf_gen.h:4258
+msgctxt "preferences"
+msgid "u*v*"
+msgstr "u*v*"
+
+#: ../build/bin/conf_gen.h:4259
+msgctxt "preferences"
+msgid "AzBz"
+msgstr "AzBz"
+
+#: ../build/bin/conf_gen.h:4260
+msgctxt "preferences"
+msgid "RYB"
+msgstr "RYB"
+
+#: ../build/bin/conf_gen.h:4318
+msgctxt "preferences"
+msgid "monochromatic"
+msgstr "단색조"
+
+#: ../build/bin/conf_gen.h:4319
+msgctxt "preferences"
+msgid "analogous"
+msgstr "유사색"
+
+#: ../build/bin/conf_gen.h:4320
+msgctxt "preferences"
+msgid "analogous complementary"
+msgstr "유사 보색"
+
+#: ../build/bin/conf_gen.h:4321
+msgctxt "preferences"
+msgid "complementary"
+msgstr "보색"
+
+#: ../build/bin/conf_gen.h:4322
+msgctxt "preferences"
+msgid "split complementary"
+msgstr "분할 보색"
+
+#: ../build/bin/conf_gen.h:4323
+msgctxt "preferences"
+msgid "dyad"
+msgstr "2색 조합 (Dyad)"
+
+#: ../build/bin/conf_gen.h:4324
+msgctxt "preferences"
+msgid "triad"
+msgstr "3색 조합 (Triad)"
+
+#: ../build/bin/conf_gen.h:4325
+msgctxt "preferences"
+msgid "tetrad"
+msgstr "4색 조합 (Tetrad)"
+
+#: ../build/bin/conf_gen.h:4326
+msgctxt "preferences"
+msgid "square"
+msgstr "정사각형"
+
+#: ../build/bin/conf_gen.h:4345
+msgctxt "preferences"
+msgid "normal"
+msgstr "일반"
+
+#: ../build/bin/conf_gen.h:4347
+msgctxt "preferences"
+msgid "narrow"
+msgstr "좁게"
+
+#: ../build/bin/conf_gen.h:4348
+msgctxt "preferences"
+msgid "line"
+msgstr "선"
+
+#: ../build/bin/conf_gen.h:4655
+msgctxt "preferences"
+msgid "mm"
+msgstr "mm"
+
+#: ../build/bin/conf_gen.h:4656
+msgctxt "preferences"
+msgid "cm"
+msgstr "cm"
+
+#: ../build/bin/conf_gen.h:4657
+msgctxt "preferences"
+msgid "inch"
+msgstr "inch"
+
+#: ../build/bin/conf_gen.h:4707 ../build/bin/preferences_gen.h:237
+msgctxt "preferences"
+msgid "grey"
+msgstr "회색"
+
+#: ../build/bin/conf_gen.h:4708 ../build/bin/preferences_gen.h:238
+msgctxt "preferences"
+msgid "dark"
+msgstr "어두움"
+
+#: ../build/bin/conf_gen.h:4709 ../build/bin/preferences_gen.h:239
+msgctxt "preferences"
+msgid "darker"
+msgstr "더 어두움"
+
+#: ../build/bin/conf_gen.h:4716 ../build/bin/preferences_gen.h:4760
+msgctxt "preferences"
+msgid "all"
+msgstr "all"
+
+#: ../build/bin/conf_gen.h:4717
+msgctxt "preferences"
+msgid "xatom"
+msgstr "xatom"
+
+#: ../build/bin/conf_gen.h:4718
+msgctxt "preferences"
+msgid "colord"
+msgstr "colord"
+
+#: ../build/bin/conf_gen.h:4854 ../build/bin/preferences_gen.h:3700
+msgctxt "preferences"
+msgid "scene-referred (sigmoid)"
+msgstr "장면 기준 (시그모이드)"
+
+#: ../build/bin/conf_gen.h:4855
+msgctxt "preferences"
+msgid "scene-referred (filmic)"
+msgstr "장면 기준 (필믹)"
+
+#: ../build/bin/conf_gen.h:4856
+msgctxt "preferences"
+msgid "scene-referred (AgX)"
+msgstr "장면-참조 (AgX)"
+
+#: ../build/bin/conf_gen.h:4857
+msgctxt "preferences"
+msgid "display-referred (legacy)"
+msgstr "디스플레이 기준 (레거시)"
+
+#: ../build/bin/conf_gen.h:4996
+msgid "camera time zone"
+msgstr "카메라 시간대"
+
+#: ../build/bin/conf_gen.h:4997
+msgid ""
+"most cameras don't store the time zone in EXIF. give the correct time zone "
+"so the GPX data can be correctly matched"
+msgstr "대부분의 카메라는 EXIF에 시간대를 저장하지 않습니다.GPX 데이터를 올바르게 일치시키기 위해 올바른 시간대를 입력합니다"
+
+#: ../build/bin/conf_gen.h:5013
+msgctxt "preferences"
+msgid "no color"
+msgstr "무색"
+
+#: ../build/bin/conf_gen.h:5014
+msgctxt "preferences"
+msgid "illuminant color"
+msgstr "광원 색상"
+
+#: ../build/bin/conf_gen.h:5015
+msgctxt "preferences"
+msgid "effect emulation"
+msgstr "효과 에뮬레이션"
+
+#: ../build/bin/conf_gen.h:5079
+msgctxt "preferences"
+msgid "list"
+msgstr "목록"
+
+#: ../build/bin/conf_gen.h:5080
+msgctxt "preferences"
+msgid "tabs"
+msgstr "탭"
+
+#: ../build/bin/conf_gen.h:5081
+msgctxt "preferences"
+msgid "columns"
+msgstr "열"
+
+#: ../build/bin/conf_gen.h:5092
+msgctxt "preferences"
+msgid "active"
+msgstr "활성"
+
+#: ../build/bin/conf_gen.h:5093
+msgctxt "preferences"
+msgid "dim"
+msgstr "어둡게"
+
+#: ../build/bin/conf_gen.h:5095
+msgctxt "preferences"
+msgid "fade"
+msgstr "페이드"
+
+#: ../build/bin/conf_gen.h:5096
+msgctxt "preferences"
+msgid "fit"
+msgstr "맞춤"
+
+#: ../build/bin/conf_gen.h:5098
 msgctxt "preferences"
 msgid "glide"
 msgstr "글라이드"
 
-#: ../build/bin/preferences_gen.h:77 ../build/bin/preferences_gen.h:4424
-#: ../build/bin/preferences_gen.h:4463 ../build/bin/preferences_gen.h:4502
-#: ../build/bin/preferences_gen.h:4536 ../build/bin/preferences_gen.h:4602
-#: ../build/bin/preferences_gen.h:4636 ../build/bin/preferences_gen.h:4670
-#: ../build/bin/preferences_gen.h:4704 ../build/bin/preferences_gen.h:4738
-#: ../build/bin/preferences_gen.h:4772 ../build/bin/preferences_gen.h:4806
-#: ../build/bin/preferences_gen.h:4840 ../build/bin/preferences_gen.h:4881
-#: ../build/bin/preferences_gen.h:4916 ../build/bin/preferences_gen.h:4951
-#: ../build/bin/preferences_gen.h:4985 ../build/bin/preferences_gen.h:5019
-#: ../build/bin/preferences_gen.h:5053 ../build/bin/preferences_gen.h:5088
-#: ../build/bin/preferences_gen.h:5122 ../build/bin/preferences_gen.h:5161
-#: ../build/bin/preferences_gen.h:5202 ../build/bin/preferences_gen.h:5270
-#: ../build/bin/preferences_gen.h:5304 ../build/bin/preferences_gen.h:5339
-#: ../build/bin/preferences_gen.h:5380 ../build/bin/preferences_gen.h:5414
-#: ../build/bin/preferences_gen.h:5458 ../build/bin/preferences_gen.h:5492
-#: ../build/bin/preferences_gen.h:5533 ../build/bin/preferences_gen.h:5568
-#: ../build/bin/preferences_gen.h:5602 ../build/bin/preferences_gen.h:5636
-#: ../build/bin/preferences_gen.h:5670 ../build/bin/preferences_gen.h:5704
-#: ../build/bin/preferences_gen.h:5738 ../build/bin/preferences_gen.h:5772
-#: ../build/bin/preferences_gen.h:5806 ../build/bin/preferences_gen.h:5841
-#: ../build/bin/preferences_gen.h:5875 ../build/bin/preferences_gen.h:5909
-#: ../build/bin/preferences_gen.h:5970 ../build/bin/preferences_gen.h:6004
-#: ../build/bin/preferences_gen.h:6039 ../build/bin/preferences_gen.h:6074
-#: ../build/bin/preferences_gen.h:6115 ../build/bin/preferences_gen.h:6156
-#: ../build/bin/preferences_gen.h:6191 ../build/bin/preferences_gen.h:6225
-#: ../build/bin/preferences_gen.h:6259 ../build/bin/preferences_gen.h:6300
-#: ../build/bin/preferences_gen.h:6343 ../build/bin/preferences_gen.h:6387
-#: ../build/bin/preferences_gen.h:6432 ../build/bin/preferences_gen.h:6483
-#: ../build/bin/preferences_gen.h:6527 ../build/bin/preferences_gen.h:6571
-#: ../build/bin/preferences_gen.h:6615 ../build/bin/preferences_gen.h:6659
-#: ../build/bin/preferences_gen.h:6703 ../build/bin/preferences_gen.h:6747
-#: ../build/bin/preferences_gen.h:6808 ../build/bin/preferences_gen.h:6842
-#: ../build/bin/preferences_gen.h:6876 ../build/bin/preferences_gen.h:6910
-#: ../build/bin/preferences_gen.h:6944 ../build/bin/preferences_gen.h:6978
-#: ../build/bin/preferences_gen.h:7012 ../build/bin/preferences_gen.h:7046
-#: ../build/bin/preferences_gen.h:7079 ../build/bin/preferences_gen.h:7112
-#: ../build/bin/preferences_gen.h:7146 ../build/bin/preferences_gen.h:7187
-#: ../build/bin/preferences_gen.h:7230 ../build/bin/preferences_gen.h:7264
-#: ../build/bin/preferences_gen.h:7330 ../build/bin/preferences_gen.h:7364
-#: ../build/bin/preferences_gen.h:7399 ../build/bin/preferences_gen.h:7450
-#: ../build/bin/preferences_gen.h:7485 ../build/bin/preferences_gen.h:7520
-#: ../build/bin/preferences_gen.h:7564 ../build/bin/preferences_gen.h:7625
-#: ../build/bin/preferences_gen.h:7659 ../build/bin/preferences_gen.h:7693
-#: ../build/bin/preferences_gen.h:7727 ../build/bin/preferences_gen.h:7762
-#: ../build/bin/preferences_gen.h:7796 ../build/bin/preferences_gen.h:7830
-#: ../build/bin/preferences_gen.h:7864 ../build/bin/preferences_gen.h:7909
-#: ../build/bin/preferences_gen.h:7944 ../build/bin/preferences_gen.h:7979
-#: ../build/bin/preferences_gen.h:8035 ../build/bin/preferences_gen.h:8076
-#: ../build/bin/preferences_gen.h:8110 ../build/bin/preferences_gen.h:8144
-#: ../build/bin/preferences_gen.h:8178 ../build/bin/preferences_gen.h:8212
-#: ../build/bin/preferences_gen.h:8247 ../build/bin/preferences_gen.h:8288
-#: ../build/bin/preferences_gen.h:8329 ../build/bin/preferences_gen.h:8388
-#: ../build/bin/preferences_gen.h:8422 ../build/bin/preferences_gen.h:8457
-#: ../build/bin/preferences_gen.h:8502 ../build/bin/preferences_gen.h:8547
-#: ../build/bin/preferences_gen.h:8599 ../build/bin/preferences_gen.h:8678
-#: ../build/bin/preferences_gen.h:8724
+#: ../build/bin/preferences_gen.h:80 ../build/bin/preferences_gen.h:120
+#: ../src/gui/preferences_ai.c:48 ../src/gui/preferences_ai.c:62
 msgid "this setting has been modified"
 msgstr "이 설정이 변경됨"
 
-#: ../build/bin/preferences_gen.h:4398 ../build/bin/preferences_gen.h:4576
-#: ../build/bin/preferences_gen.h:5244 ../build/bin/preferences_gen.h:5944
-#: ../build/bin/preferences_gen.h:6782 ../build/bin/preferences_gen.h:7304
-#: ../build/bin/preferences_gen.h:7599 ../src/gui/accelerators.c:3066
-#: ../src/gui/gtk.c:3245 ../src/gui/preferences.c:516
-#: ../src/gui/preferences.c:1001 ../src/libs/modulegroups.c:4087
+#. help button (right-anchored, matches other prefs tabs)
+#: ../build/bin/preferences_gen.h:95 ../src/gui/accelerators.c:3067
+#: ../src/gui/gtk.c:3554 ../src/gui/preferences.c:538
+#: ../src/gui/preferences.c:1030 ../src/gui/preferences_ai.c:1933
+#: ../src/libs/modulegroups.c:4171
 msgid "?"
 msgstr "?"
 
-#: ../build/bin/preferences_gen.h:4406 ../src/control/jobs/control_jobs.c:3085
-#: ../src/libs/import.c:188
+#: ../build/bin/preferences_gen.h:136
+msgid "not available"
+msgstr "사용 불가"
+
+#: ../build/bin/preferences_gen.h:138 ../build/bin/preferences_gen.h:139
+msgid "not available on this system"
+msgstr "이 시스템에서 사용 불가"
+
+#: ../build/bin/preferences_gen.h:235
+msgid "darktable theme"
+msgstr "darktable 테마"
+
+#: ../build/bin/preferences_gen.h:236
+msgid ""
+"the shade around your photo affects how you see its colors and tones while "
+"editing. grey is recommended because it's the most neutral – it doesn't push "
+"your eye in any direction\n"
+"\n"
+"<b>grey:</b> best for accurate color work\n"
+"\n"
+"<b>dark:</b> less distracting around your image\n"
+"\n"
+"<b>darker:</b> good for dimly-lit rooms"
+msgstr ""
+"사진 주변의 명암은 편집 중에 색상과 톤을 인지하는 방식에 영향을 줍니다. 회색은 가장 중립적이어서 시각을 어느 방향으로도 치우치게 하지 않으므로 권장됩니다\n"
+"\n"
+"<b>회색:</b> 정확한 색상 작업에 가장 적합\n"
+"\n"
+"<b>어두움:</b> 이미지 주변의 방해가 적음\n"
+"\n"
+"<b>더 어두움:</b> 조명이 어두운 방에 적합"
+
+#: ../build/bin/preferences_gen.h:2689 ../src/control/jobs/control_jobs.c:3118
+#: ../src/libs/import.c:183
 msgid "import"
 msgstr "가져오기"
 
-#: ../build/bin/preferences_gen.h:4408
+#: ../build/bin/preferences_gen.h:2694
 msgid "session options"
 msgstr "세션 옵션"
 
-#: ../build/bin/preferences_gen.h:4427
+#: ../build/bin/preferences_gen.h:2704
 msgid "base filmroll's directory"
 msgstr "기본 필름롤 디렉토리"
 
-#: ../build/bin/preferences_gen.h:4442 ../build/bin/preferences_gen.h:4481
-#: ../build/bin/preferences_gen.h:4515 ../build/bin/preferences_gen.h:4554
-#: ../build/bin/preferences_gen.h:4615 ../build/bin/preferences_gen.h:4649
-#: ../build/bin/preferences_gen.h:4683 ../build/bin/preferences_gen.h:4717
-#: ../build/bin/preferences_gen.h:4751 ../build/bin/preferences_gen.h:4785
-#: ../build/bin/preferences_gen.h:4819 ../build/bin/preferences_gen.h:4853
-#: ../build/bin/preferences_gen.h:4895 ../build/bin/preferences_gen.h:4930
-#: ../build/bin/preferences_gen.h:4964 ../build/bin/preferences_gen.h:4998
-#: ../build/bin/preferences_gen.h:5032 ../build/bin/preferences_gen.h:5067
-#: ../build/bin/preferences_gen.h:5101 ../build/bin/preferences_gen.h:5140
-#: ../build/bin/preferences_gen.h:5181 ../build/bin/preferences_gen.h:5222
-#: ../build/bin/preferences_gen.h:5283 ../build/bin/preferences_gen.h:5317
-#: ../build/bin/preferences_gen.h:5359 ../build/bin/preferences_gen.h:5394
-#: ../build/bin/preferences_gen.h:5471 ../build/bin/preferences_gen.h:5505
-#: ../build/bin/preferences_gen.h:5547 ../build/bin/preferences_gen.h:5581
-#: ../build/bin/preferences_gen.h:5615 ../build/bin/preferences_gen.h:5649
-#: ../build/bin/preferences_gen.h:5683 ../build/bin/preferences_gen.h:5717
-#: ../build/bin/preferences_gen.h:5751 ../build/bin/preferences_gen.h:5785
-#: ../build/bin/preferences_gen.h:5820 ../build/bin/preferences_gen.h:5854
-#: ../build/bin/preferences_gen.h:5888 ../build/bin/preferences_gen.h:5922
-#: ../build/bin/preferences_gen.h:5983 ../build/bin/preferences_gen.h:6018
-#: ../build/bin/preferences_gen.h:6053 ../build/bin/preferences_gen.h:6093
-#: ../build/bin/preferences_gen.h:6134 ../build/bin/preferences_gen.h:6170
-#: ../build/bin/preferences_gen.h:6204 ../build/bin/preferences_gen.h:6238
-#: ../build/bin/preferences_gen.h:6272 ../build/bin/preferences_gen.h:6314
-#: ../build/bin/preferences_gen.h:6356 ../build/bin/preferences_gen.h:6401
-#: ../build/bin/preferences_gen.h:6445 ../build/bin/preferences_gen.h:6496
-#: ../build/bin/preferences_gen.h:6540 ../build/bin/preferences_gen.h:6584
-#: ../build/bin/preferences_gen.h:6628 ../build/bin/preferences_gen.h:6672
-#: ../build/bin/preferences_gen.h:6716 ../build/bin/preferences_gen.h:6760
-#: ../build/bin/preferences_gen.h:6821 ../build/bin/preferences_gen.h:6855
-#: ../build/bin/preferences_gen.h:6889 ../build/bin/preferences_gen.h:6923
-#: ../build/bin/preferences_gen.h:6957 ../build/bin/preferences_gen.h:6991
-#: ../build/bin/preferences_gen.h:7025 ../build/bin/preferences_gen.h:7059
-#: ../build/bin/preferences_gen.h:7092 ../build/bin/preferences_gen.h:7125
-#: ../build/bin/preferences_gen.h:7159 ../build/bin/preferences_gen.h:7209
-#: ../build/bin/preferences_gen.h:7243 ../build/bin/preferences_gen.h:7282
-#: ../build/bin/preferences_gen.h:7343 ../build/bin/preferences_gen.h:7378
-#: ../build/bin/preferences_gen.h:7464 ../build/bin/preferences_gen.h:7499
-#: ../build/bin/preferences_gen.h:7577 ../build/bin/preferences_gen.h:7638
-#: ../build/bin/preferences_gen.h:7672 ../build/bin/preferences_gen.h:7706
-#: ../build/bin/preferences_gen.h:7741 ../build/bin/preferences_gen.h:7775
-#: ../build/bin/preferences_gen.h:7809 ../build/bin/preferences_gen.h:7843
-#: ../build/bin/preferences_gen.h:7923 ../build/bin/preferences_gen.h:7958
-#: ../build/bin/preferences_gen.h:7997 ../build/bin/preferences_gen.h:8048
-#: ../build/bin/preferences_gen.h:8089 ../build/bin/preferences_gen.h:8123
-#: ../build/bin/preferences_gen.h:8157 ../build/bin/preferences_gen.h:8191
-#: ../build/bin/preferences_gen.h:8226 ../build/bin/preferences_gen.h:8260
-#: ../build/bin/preferences_gen.h:8301 ../build/bin/preferences_gen.h:8401
-#: ../build/bin/preferences_gen.h:8436 ../build/bin/preferences_gen.h:8561
+#: ../build/bin/preferences_gen.h:2715 ../build/bin/preferences_gen.h:2737
+#: ../build/bin/preferences_gen.h:2754 ../build/bin/preferences_gen.h:2776
+#: ../build/bin/preferences_gen.h:2809 ../build/bin/preferences_gen.h:2826
+#: ../build/bin/preferences_gen.h:2843 ../build/bin/preferences_gen.h:2860
+#: ../build/bin/preferences_gen.h:2877 ../build/bin/preferences_gen.h:2894
+#: ../build/bin/preferences_gen.h:2911 ../build/bin/preferences_gen.h:2928
+#: ../build/bin/preferences_gen.h:2953 ../build/bin/preferences_gen.h:2971
+#: ../build/bin/preferences_gen.h:2988 ../build/bin/preferences_gen.h:3005
+#: ../build/bin/preferences_gen.h:3022 ../build/bin/preferences_gen.h:3040
+#: ../build/bin/preferences_gen.h:3057 ../build/bin/preferences_gen.h:3079
+#: ../build/bin/preferences_gen.h:3103 ../build/bin/preferences_gen.h:3127
+#: ../build/bin/preferences_gen.h:3160 ../build/bin/preferences_gen.h:3185
+#: ../build/bin/preferences_gen.h:3203 ../build/bin/preferences_gen.h:3246
+#: ../build/bin/preferences_gen.h:3263 ../build/bin/preferences_gen.h:3288
+#: ../build/bin/preferences_gen.h:3305 ../build/bin/preferences_gen.h:3322
+#: ../build/bin/preferences_gen.h:3339 ../build/bin/preferences_gen.h:3356
+#: ../build/bin/preferences_gen.h:3373 ../build/bin/preferences_gen.h:3390
+#: ../build/bin/preferences_gen.h:3407 ../build/bin/preferences_gen.h:3425
+#: ../build/bin/preferences_gen.h:3442 ../build/bin/preferences_gen.h:3466
+#: ../build/bin/preferences_gen.h:3511 ../build/bin/preferences_gen.h:3530
+#: ../build/bin/preferences_gen.h:3548 ../build/bin/preferences_gen.h:3565
+#: ../build/bin/preferences_gen.h:3598 ../build/bin/preferences_gen.h:3616
+#: ../build/bin/preferences_gen.h:3634 ../build/bin/preferences_gen.h:3657
+#: ../build/bin/preferences_gen.h:3681 ../build/bin/preferences_gen.h:3700
+#: ../build/bin/preferences_gen.h:3717 ../build/bin/preferences_gen.h:3734
+#: ../build/bin/preferences_gen.h:3751 ../build/bin/preferences_gen.h:3776
+#: ../build/bin/preferences_gen.h:3801 ../build/bin/preferences_gen.h:3822
+#: ../build/bin/preferences_gen.h:3844 ../build/bin/preferences_gen.h:3865
+#: ../build/bin/preferences_gen.h:3893 ../build/bin/preferences_gen.h:3914
+#: ../build/bin/preferences_gen.h:3935 ../build/bin/preferences_gen.h:3956
+#: ../build/bin/preferences_gen.h:3977 ../build/bin/preferences_gen.h:3998
+#: ../build/bin/preferences_gen.h:4019 ../build/bin/preferences_gen.h:4052
+#: ../build/bin/preferences_gen.h:4069 ../build/bin/preferences_gen.h:4086
+#: ../build/bin/preferences_gen.h:4103 ../build/bin/preferences_gen.h:4120
+#: ../build/bin/preferences_gen.h:4137 ../build/bin/preferences_gen.h:4154
+#: ../build/bin/preferences_gen.h:4171 ../build/bin/preferences_gen.h:4187
+#: ../build/bin/preferences_gen.h:4203 ../build/bin/preferences_gen.h:4220
+#: ../build/bin/preferences_gen.h:4253 ../build/bin/preferences_gen.h:4270
+#: ../build/bin/preferences_gen.h:4292 ../build/bin/preferences_gen.h:4325
+#: ../build/bin/preferences_gen.h:4343 ../build/bin/preferences_gen.h:4395
+#: ../build/bin/preferences_gen.h:4413 ../build/bin/preferences_gen.h:4457
+#: ../build/bin/preferences_gen.h:4490 ../build/bin/preferences_gen.h:4507
+#: ../build/bin/preferences_gen.h:4524 ../build/bin/preferences_gen.h:4541
+#: ../build/bin/preferences_gen.h:4559 ../build/bin/preferences_gen.h:4576
+#: ../build/bin/preferences_gen.h:4593 ../build/bin/preferences_gen.h:4610
+#: ../build/bin/preferences_gen.h:4627 ../build/bin/preferences_gen.h:4644
+#: ../build/bin/preferences_gen.h:4661 ../build/bin/preferences_gen.h:4679
+#: ../build/bin/preferences_gen.h:4724 ../build/bin/preferences_gen.h:4742
+#: ../build/bin/preferences_gen.h:4760 ../build/bin/preferences_gen.h:4782
+#: ../build/bin/preferences_gen.h:4810 ../build/bin/preferences_gen.h:4834
+#: ../build/bin/preferences_gen.h:4851 ../build/bin/preferences_gen.h:4868
+#: ../build/bin/preferences_gen.h:4885 ../build/bin/preferences_gen.h:4903
+#: ../build/bin/preferences_gen.h:4920 ../build/bin/preferences_gen.h:4944
+#: ../build/bin/preferences_gen.h:5010 ../build/bin/preferences_gen.h:5028
+#: ../build/bin/preferences_gen.h:5102
 #, c-format
 msgid "double click to reset to `%s'"
 msgstr "`%s' 으로 초기화하려면 더블 클릭"
 
-#: ../build/bin/preferences_gen.h:4445
-msgid "directory where new imported filmrolls are created"
-msgstr "새로 가져온 필름롤이 생성되는 디렉토리"
+#: ../build/bin/preferences_gen.h:2717
+msgid ""
+"directory where newly imported filmrolls are stored; the default uses <b>$"
+"(PICTURES_FOLDER)</b>, which expands to your system's pictures folder: <i>~/"
+"Pictures</i> on macOS and Linux, <i>C:/Users/username/Pictures</i> on Windows"
+msgstr "새로 가져온 필름롤이 저장되는 디렉토리입니다. 기본값은 <b>$(PICTURES_FOLDER)</b>를 사용하며, 이는 시스템의 사진 폴더로 확장됩니다: macOS와 Linux에서는 <i>~/Pictures</i>, Windows에서는 <i>C:/Users/username/Pictures</i>"
 
-#: ../build/bin/preferences_gen.h:4466
+#: ../build/bin/preferences_gen.h:2726
 msgid "filmroll name"
 msgstr "필름롤 이름"
 
-#: ../build/bin/preferences_gen.h:4484
+#: ../build/bin/preferences_gen.h:2739
 msgid "name of the imported filmroll"
 msgstr "가져온 필름롤 이름"
 
-#: ../build/bin/preferences_gen.h:4505
+#: ../build/bin/preferences_gen.h:2748
 msgid "keep original filename"
 msgstr "원본 파일 이름 유지"
 
-#: ../build/bin/preferences_gen.h:4515 ../build/bin/preferences_gen.h:4615
-#: ../build/bin/preferences_gen.h:4649 ../build/bin/preferences_gen.h:4717
-#: ../build/bin/preferences_gen.h:4751 ../build/bin/preferences_gen.h:4785
-#: ../build/bin/preferences_gen.h:4853 ../build/bin/preferences_gen.h:4998
-#: ../build/bin/preferences_gen.h:5032 ../build/bin/preferences_gen.h:5101
-#: ../build/bin/preferences_gen.h:5283 ../build/bin/preferences_gen.h:5471
-#: ../build/bin/preferences_gen.h:5581 ../build/bin/preferences_gen.h:5717
-#: ../build/bin/preferences_gen.h:5785 ../build/bin/preferences_gen.h:5888
-#: ../build/bin/preferences_gen.h:5983 ../build/bin/preferences_gen.h:6204
-#: ../build/bin/preferences_gen.h:6238 ../build/bin/preferences_gen.h:6445
-#: ../build/bin/preferences_gen.h:6628 ../build/bin/preferences_gen.h:6672
-#: ../build/bin/preferences_gen.h:6716 ../build/bin/preferences_gen.h:6760
-#: ../build/bin/preferences_gen.h:7025 ../build/bin/preferences_gen.h:7243
-#: ../build/bin/preferences_gen.h:7343 ../build/bin/preferences_gen.h:7577
-#: ../build/bin/preferences_gen.h:7809 ../build/bin/preferences_gen.h:8048
-#: ../build/bin/preferences_gen.h:8123 ../build/bin/preferences_gen.h:8157
-#: ../build/bin/preferences_gen.h:8191 ../build/bin/preferences_gen.h:8260
-#: ../build/bin/preferences_gen.h:8401
+#: ../build/bin/preferences_gen.h:2754 ../build/bin/preferences_gen.h:2809
+#: ../build/bin/preferences_gen.h:2826 ../build/bin/preferences_gen.h:2860
+#: ../build/bin/preferences_gen.h:2877 ../build/bin/preferences_gen.h:2894
+#: ../build/bin/preferences_gen.h:2928 ../build/bin/preferences_gen.h:3005
+#: ../build/bin/preferences_gen.h:3022 ../build/bin/preferences_gen.h:3057
+#: ../build/bin/preferences_gen.h:3246 ../build/bin/preferences_gen.h:3305
+#: ../build/bin/preferences_gen.h:3373 ../build/bin/preferences_gen.h:3407
+#: ../build/bin/preferences_gen.h:3442 ../build/bin/preferences_gen.h:3466
+#: ../build/bin/preferences_gen.h:3598 ../build/bin/preferences_gen.h:3717
+#: ../build/bin/preferences_gen.h:3734 ../build/bin/preferences_gen.h:3822
+#: ../build/bin/preferences_gen.h:3865 ../build/bin/preferences_gen.h:3935
+#: ../build/bin/preferences_gen.h:3977 ../build/bin/preferences_gen.h:3998
+#: ../build/bin/preferences_gen.h:4019 ../build/bin/preferences_gen.h:4154
+#: ../build/bin/preferences_gen.h:4270 ../build/bin/preferences_gen.h:4325
+#: ../build/bin/preferences_gen.h:4457 ../build/bin/preferences_gen.h:4576
+#: ../build/bin/preferences_gen.h:4627 ../build/bin/preferences_gen.h:4810
+#: ../build/bin/preferences_gen.h:4851 ../build/bin/preferences_gen.h:4868
+#: ../build/bin/preferences_gen.h:4885 ../build/bin/preferences_gen.h:4920
+#: ../build/bin/preferences_gen.h:5010
 msgctxt "preferences"
 msgid "FALSE"
 msgstr "FALSE"
 
-#: ../build/bin/preferences_gen.h:4518
-msgid "keep original filename instead of a pattern while importing from camera or card"
+#: ../build/bin/preferences_gen.h:2756
+msgid ""
+"keep original filename instead of a pattern while importing from camera or "
+"card"
 msgstr "카메라나 카드에서 가져오기 시 패턴 대신 원본 파일 이름을 유지합니다"
 
-#: ../build/bin/preferences_gen.h:4539
+#: ../build/bin/preferences_gen.h:2765
 msgid "file naming pattern"
 msgstr "파일 이름 패턴"
 
-#: ../build/bin/preferences_gen.h:4557
+#: ../build/bin/preferences_gen.h:2778
 msgid "file naming pattern used for a import session"
 msgstr "가져오기 세션에 사용되는 파일 이름 패턴"
 
-#: ../build/bin/preferences_gen.h:4584 ../src/gui/gtk.c:1509
-#: ../src/gui/preferences.c:603 ../src/libs/tools/lighttable.c:64
+#: ../build/bin/preferences_gen.h:2788 ../src/gui/gtk.c:1703
+#: ../src/gui/preferences.c:631 ../src/libs/tools/lighttable.c:64
 #: ../src/views/lighttable.c:91
 msgid "lighttable"
 msgstr "lighttable"
 
-#: ../build/bin/preferences_gen.h:4586 ../build/bin/preferences_gen.h:5254
-#: ../build/bin/preferences_gen.h:6792 ../src/gui/preferences.c:328
+#: ../build/bin/preferences_gen.h:2793 ../build/bin/preferences_gen.h:3144
+#: ../build/bin/preferences_gen.h:4036 ../src/gui/preferences.c:344
+#: ../src/gui/preferences_ai.c:1574
 msgid "general"
 msgstr "일반"
 
-#: ../build/bin/preferences_gen.h:4605
+#: ../build/bin/preferences_gen.h:2803
 msgid "hide built-in presets for utility modules"
 msgstr "유틸리티 모듈의 내장 프리셋 숨기기"
 
-#: ../build/bin/preferences_gen.h:4618
+#: ../build/bin/preferences_gen.h:2811
 msgid "hide built-in presets of utility modules in presets menu."
 msgstr "프리셋 메뉴에서 유틸리티 모듈의 내장 프리셋을 숨깁니다."
 
-#: ../build/bin/preferences_gen.h:4639
+#: ../build/bin/preferences_gen.h:2820
 msgid "use single-click in the collections module"
 msgstr "컬렉션 모듈에서 단일 클릭 사용"
 
-#: ../build/bin/preferences_gen.h:4652
-msgid "check this option to use single-click to select items in the collections module. this will allow you to do range selections for date-time and numeric values."
+#: ../build/bin/preferences_gen.h:2828
+msgid ""
+"check this option to use single-click to select items in the collections "
+"module. this will allow you to do range selections for date-time and numeric "
+"values."
 msgstr "이 옵션을 선택하면 컬렉션 모듈에서 항목을 단일 클릭으로 선택할 수 있습니다.날짜-시간 및 숫자 값에 대해 범위 선택이 가능합니다."
 
-#: ../build/bin/preferences_gen.h:4673
+#: ../build/bin/preferences_gen.h:2837
 msgid "prioritize the hovered image over the selected images"
 msgstr "선택된 이미지보다 마우스를 올린 이미지를 우선"
 
-#: ../build/bin/preferences_gen.h:4683 ../build/bin/preferences_gen.h:4819
-#: ../build/bin/preferences_gen.h:4964 ../build/bin/preferences_gen.h:5317
-#: ../build/bin/preferences_gen.h:5505 ../build/bin/preferences_gen.h:5615
-#: ../build/bin/preferences_gen.h:5649 ../build/bin/preferences_gen.h:5683
-#: ../build/bin/preferences_gen.h:5751 ../build/bin/preferences_gen.h:5854
-#: ../build/bin/preferences_gen.h:5922 ../build/bin/preferences_gen.h:6272
-#: ../build/bin/preferences_gen.h:6356 ../build/bin/preferences_gen.h:6496
-#: ../build/bin/preferences_gen.h:6540 ../build/bin/preferences_gen.h:6584
-#: ../build/bin/preferences_gen.h:6821 ../build/bin/preferences_gen.h:6855
-#: ../build/bin/preferences_gen.h:6889 ../build/bin/preferences_gen.h:6923
-#: ../build/bin/preferences_gen.h:6957 ../build/bin/preferences_gen.h:6991
-#: ../build/bin/preferences_gen.h:7059 ../build/bin/preferences_gen.h:7092
-#: ../build/bin/preferences_gen.h:7125 ../build/bin/preferences_gen.h:7159
-#: ../build/bin/preferences_gen.h:7638 ../build/bin/preferences_gen.h:7672
-#: ../build/bin/preferences_gen.h:7706 ../build/bin/preferences_gen.h:7775
-#: ../build/bin/preferences_gen.h:7843 ../build/bin/preferences_gen.h:8089
-#: ../build/bin/preferences_gen.h:8301
+#: ../build/bin/preferences_gen.h:2843 ../build/bin/preferences_gen.h:2911
+#: ../build/bin/preferences_gen.h:2988 ../build/bin/preferences_gen.h:3160
+#: ../build/bin/preferences_gen.h:3263 ../build/bin/preferences_gen.h:3322
+#: ../build/bin/preferences_gen.h:3339 ../build/bin/preferences_gen.h:3356
+#: ../build/bin/preferences_gen.h:3390 ../build/bin/preferences_gen.h:3565
+#: ../build/bin/preferences_gen.h:3751 ../build/bin/preferences_gen.h:3801
+#: ../build/bin/preferences_gen.h:3893 ../build/bin/preferences_gen.h:3914
+#: ../build/bin/preferences_gen.h:3956 ../build/bin/preferences_gen.h:4052
+#: ../build/bin/preferences_gen.h:4069 ../build/bin/preferences_gen.h:4086
+#: ../build/bin/preferences_gen.h:4103 ../build/bin/preferences_gen.h:4120
+#: ../build/bin/preferences_gen.h:4137 ../build/bin/preferences_gen.h:4171
+#: ../build/bin/preferences_gen.h:4187 ../build/bin/preferences_gen.h:4203
+#: ../build/bin/preferences_gen.h:4220 ../build/bin/preferences_gen.h:4490
+#: ../build/bin/preferences_gen.h:4507 ../build/bin/preferences_gen.h:4524
+#: ../build/bin/preferences_gen.h:4541 ../build/bin/preferences_gen.h:4593
+#: ../build/bin/preferences_gen.h:4610 ../build/bin/preferences_gen.h:4644
+#: ../build/bin/preferences_gen.h:4661 ../build/bin/preferences_gen.h:4679
+#: ../build/bin/preferences_gen.h:4724 ../build/bin/preferences_gen.h:4834
+#: ../build/bin/preferences_gen.h:4944
 msgctxt "preferences"
 msgid "TRUE"
 msgstr "TRUE"
 
-#: ../build/bin/preferences_gen.h:4686
-msgid "this defines how the list of images to act on is constructed."
-msgstr "작업할 이미지 목록이 어떻게 구성되는지 정의합니다."
+#: ../build/bin/preferences_gen.h:2845
+msgid ""
+"in the lighttable, where culling takes place, you can apply actions (e.g., "
+"setting ratings) to the hovered image or to the selected ones\n"
+"\n"
+"<b>enabled</b> actions apply to the hovered image (less clicking)\n"
+"\n"
+"<b>disabled</b> actions apply to the current selection (less error prone)"
+msgstr ""
+"선별이 이루어지는 lighttable에서는 마우스를 올린 이미지 또는 선택한 이미지에 작업(예: 등급 설정)을 적용할 수 있습니다\n"
+"\n"
+"<b>활성화</b> 마우스를 올린 이미지에 작업을 적용합니다 (클릭이 줄어듦)\n"
+"\n"
+"<b>비활성화</b> 현재 선택 항목에 작업을 적용합니다 (실수가 줄어듦)"
 
-#: ../build/bin/preferences_gen.h:4707
+#: ../build/bin/preferences_gen.h:2854
 msgid "expand a single utility module at a time"
 msgstr "한 번에 하나의 유틸리티 모듈만 펼침"
 
-#: ../build/bin/preferences_gen.h:4720
+#: ../build/bin/preferences_gen.h:2862
 msgid "this option toggles the behavior of shift clicking in lighttable mode"
 msgstr "이 옵션은 lighttable 모드에서 Shift 클릭의 동작 방식을 전환합니다"
 
-#: ../build/bin/preferences_gen.h:4741
+#: ../build/bin/preferences_gen.h:2871
 msgid "scroll utility modules to the top when expanded"
 msgstr "유틸리티 모듈 펼치면 맨위로 스크롤"
 
-#: ../build/bin/preferences_gen.h:4754 ../build/bin/preferences_gen.h:5754
-msgid "when this option is enabled then darktable will try to scroll the module to the top of the visible list"
+#: ../build/bin/preferences_gen.h:2879 ../build/bin/preferences_gen.h:3392
+msgid ""
+"when this option is enabled then darktable will try to scroll the module to "
+"the top of the visible list"
 msgstr "이 옵션이 활성화 되면, darktable은 모듈을 보이는 리스트의 최상단으로 스크롤 합니다"
 
-#: ../build/bin/preferences_gen.h:4775
+#: ../build/bin/preferences_gen.h:2888
 msgid "rating an image one star twice will not zero out the rating"
 msgstr "이미지를 두 번 연속 1점으로 평가해도 등급이 0이 되지 않습니다"
 
-#: ../build/bin/preferences_gen.h:4788
-msgid "defines whether rating an image one star twice will zero out star rating"
+#: ../build/bin/preferences_gen.h:2896
+msgid ""
+"defines whether rating an image one star twice will zero out star rating"
 msgstr "이미지에 두 번 연속 1점으로 평가하면 별점 등급이 0점이 되는지 여부를 정의합니다"
 
-#: ../build/bin/preferences_gen.h:4809 ../build/bin/preferences_gen.h:5461
+#: ../build/bin/preferences_gen.h:2905 ../build/bin/preferences_gen.h:3240
 msgid "show scrollbars for central view"
 msgstr "중앙 화면에 스크롤바 표시"
 
-#: ../build/bin/preferences_gen.h:4822 ../build/bin/preferences_gen.h:5474
+#: ../build/bin/preferences_gen.h:2913 ../build/bin/preferences_gen.h:3248
 msgid "defines whether scrollbars should be displayed"
 msgstr "스크롤바를 표시할지 여부를 정의합니다"
 
-#: ../build/bin/preferences_gen.h:4843
+#: ../build/bin/preferences_gen.h:2922
 msgid "show image time with milliseconds"
 msgstr "이미지 시간에 밀리초 표시"
 
-#: ../build/bin/preferences_gen.h:4856
+#: ../build/bin/preferences_gen.h:2930
 msgid "defines whether time should be displayed with milliseconds"
 msgstr "시간을 밀리초 단위까지 표시할지 여부를 정의합니다"
 
-#: ../build/bin/preferences_gen.h:4865
+#: ../build/bin/preferences_gen.h:2936
 msgid "thumbnails"
 msgstr "썸네일"
 
-#: ../build/bin/preferences_gen.h:4884
-msgid "use raw file instead of embedded JPEG from size"
-msgstr "크기에 따라 내장 JPEG 대신 RAW 파일 사용"
+#: ../build/bin/preferences_gen.h:2946
+msgid "for unaltered images, use raw file instead of embedded JPEG from size"
+msgstr "편집되지 않은 이미지의 경우, 크기에 따라 내장 JPEG 대신 RAW 파일 사용"
 
-#: ../build/bin/preferences_gen.h:4898
+#: ../build/bin/preferences_gen.h:2955
 msgid ""
-"if the thumbnail size is greater than this value, it will be processed using raw file instead of the embedded preview JPEG (better but slower).\n"
-"if you want all thumbnails and pre-rendered images in best quality you should choose the *always* option.\n"
-"(more comments in the manual)"
+"if the thumbnail size is greater than this value, it will be processed using "
+"raw file instead of the embedded preview JPEG (better but slower).\n"
+"if you want all thumbnails and pre-rendered images in best quality you "
+"should choose the 'always' option.\n"
+"for the quickest display, choose the 'never' option\n"
+"the 'auto' option prefers the embedded JPEG except when the thumb size "
+"exceeds the resolution of the embedded JPEG\n"
+"(more details in the manual)"
 msgstr ""
-"썸네일 크기가 이 값보다 크면 내장 미리보기 JPEG 대신RAW 파일로 처리됩니다(높은 품질, 낮은 성능).\n"
-"모든 썸네일과 미리 렌더링된 이미지를 최상의 품질로 원하는 경우*항상* 옵션을 선택해야 합니다.\n"
-"(자세한 내용은 매뉴얼을 참고)"
+"썸네일 크기가 이 값보다 크면 내장 미리보기 JPEG 대신 RAW 파일로 처리됩니다(품질은 좋지만 느립니다).\n"
+"모든 썸네일과 미리 렌더링된 이미지를 최상의 품질로 원한다면 '항상' 옵션을 선택하세요.\n"
+"가장 빠른 표시를 원한다면 '사용 안함' 옵션을 선택하세요\n"
+"'자동' 옵션은 썸네일 크기가 내장 JPEG의 해상도를 초과하는 경우를 제외하고 내장 JPEG을 우선합니다\n"
+"(자세한 내용은 매뉴얼 참고)"
 
-#: ../build/bin/preferences_gen.h:4919
+#: ../build/bin/preferences_gen.h:2964
 msgid "high quality processing from size"
 msgstr "크기에 따라 고품질 처리"
 
-#: ../build/bin/preferences_gen.h:4933
+#: ../build/bin/preferences_gen.h:2973
 msgid ""
-"if the thumbnail size is greater than this value, it will be processed using the full quality rendering path (better but slower).\n"
-"if you want all thumbnails and pre-rendered images in best quality you should choose the *always* option.\n"
-"(more comments in the manual)"
+"if the thumbnail size is greater than this value, it will be processed using "
+"the full quality rendering path (better but slower).\n"
+"if you want all thumbnails and pre-rendered images in best quality you "
+"should choose the 'always' option.\n"
+"(more details in the manual)"
 msgstr ""
-"썸네일 크기가 이 값보다 크면 전체 품질 렌더링 경로로 처리됩니다(높은 품질, 낮은 성능).\n"
-"모든 썸네일과 미리 렌더링된 이미지를 최상의 품질로 원한다면*항상* 옵션을 선택합니다.\n"
-"(자세한 내용은 매뉴얼을 참고)"
+"썸네일 크기가 이 값보다 크면 전체 품질 렌더링 경로로 처리됩니다(품질은 좋지만 느립니다).\n"
+"모든 썸네일과 미리 렌더링된 이미지를 최상의 품질로 원한다면 '항상' 옵션을 선택하세요.\n"
+"(자세한 내용은 매뉴얼 참고)"
 
-#: ../build/bin/preferences_gen.h:4954
+#: ../build/bin/preferences_gen.h:2982
 msgid "enable disk backend for thumbnail cache"
 msgstr "썸네일 캐시에 디스크 백엔드 사용"
 
-#: ../build/bin/preferences_gen.h:4967
+#: ../build/bin/preferences_gen.h:2990
 msgid ""
-"if enabled, write thumbnails to disk (.cache/darktable/) when evicted from the memory cache.\n"
-"note that this can take a lot of memory (several gigabytes for 20k images) and will never delete cached thumbnails again.\n"
+"if enabled, write thumbnails to disk (.cache/darktable/) when evicted from "
+"the memory cache.\n"
+"note that this can take a lot of memory (several gigabytes for 20k images) "
+"and will never delete cached thumbnails again.\n"
 "it's safe though to delete these manually, if you want.\n"
 "light table performance will be increased greatly when browsing a lot.\n"
-"to generate all thumbnails of your entire collection offline, run 'darktable-generate-cache'."
+"to generate all thumbnails of your entire collection offline, run 'darktable-"
+"generate-cache'."
 msgstr ""
 "이 옵션을 활성화하면 썸네일이 메모리 캐시에서 제거될 때디스크(.cache/darktable/)에 저장됩니다.\n"
 "참고: 이 기능은 많은 메모리를 사용할 수 있으며 (20k 이미지에 수 기가바이트 필요)한 번 저장된 캐시 썸네일은 자동으로 삭제되지 않습니다.\n"
@@ -1124,134 +1195,139 @@ msgstr ""
 "많은 이미지를 탐색할 때 light table 성능이 크게 향상됩니다.\n"
 "전체 컬렉션의 모든 썸네일을 오프라인으로 생성하려면'darktable-generate-cache'를 실행합니다."
 
-#: ../build/bin/preferences_gen.h:4988
+#: ../build/bin/preferences_gen.h:2999
 msgid "enable disk backend for full preview cache"
 msgstr "전체 미리보기 캐시에 디스크 백엔드 활성화"
 
-#: ../build/bin/preferences_gen.h:5001
+#: ../build/bin/preferences_gen.h:3007
 msgid ""
-"if enabled, write full preview to disk (.cache/darktable/) when evicted from the memory cache.\n"
-"note that this can take a lot of memory (several gigabytes for 20k images) and will never delete cached full previews again.\n"
+"if enabled, write full preview to disk (.cache/darktable/) when evicted from "
+"the memory cache.\n"
+"note that this can take a lot of memory (several gigabytes for 20k images) "
+"and will never delete cached full previews again.\n"
 "it's safe though to delete these manually, if you want.\n"
-"light table performance will be increased greatly when zooming image in full preview mode."
+"light table performance will be increased greatly when zooming image in full "
+"preview mode."
 msgstr ""
 "이 옵션을 활성화하면 전체 미리보기가 메모리 캐시에서 제거될 때디스크(.cache/darktable/)에 저장됩니다.\n"
 "참고: 이 기능은 많은 메모리를 사용할 수 있으며 (20k 이미지에 수 기가바이트 필요) 한 번 저장된 캐시 전체 미리보기는 자동으로 삭제되지 않습니다.\n"
 "원한다면 수동으로 삭제해도 안전합니다.\n"
 "전체 미리보기 모드에서 이미지를 확대할 때 lighttable 성능이 크게 향상됩니다."
 
-#: ../build/bin/preferences_gen.h:5022
+#: ../build/bin/preferences_gen.h:3016
 msgid "enable smooth scrolling for lighttable thumbnails"
 msgstr "lighttable 썸네일 부드러운 스크롤 활성화"
 
-#: ../build/bin/preferences_gen.h:5035
+#: ../build/bin/preferences_gen.h:3024
 msgid ""
-"if enabled, scrolling the lighttable scrolls by some number of pixels, as expected with a touch pad.\n"
-"disabled, the lighttable scrolls full rows of thumbnails, as befits a scroll wheel."
+"if enabled, scrolling the lighttable scrolls by some number of pixels, as "
+"expected with a touch pad.\n"
+"disabled, the lighttable scrolls full rows of thumbnails, as befits a scroll "
+"wheel."
 msgstr ""
 "이 옵션을 활성화하면 터치패드처럼 lighttable이 픽셀 단위로 스크롤됩니다.\n"
 "비활성화 시에는 스크롤 휠처럼 썸네일의 전체 행 단위로 스크롤됩니다."
 
-#: ../build/bin/preferences_gen.h:5056
+#: ../build/bin/preferences_gen.h:3033
 msgid "generate thumbnails in background"
 msgstr "배경에서 썸네일 생성"
 
-#: ../build/bin/preferences_gen.h:5070
-msgid "if 'enable disk backend for thumbnail cache' is enabled thumbnails/mipmaps up to the selected size are generated while user is inactive in lighttable."
+#: ../build/bin/preferences_gen.h:3042
+msgid ""
+"if 'enable disk backend for thumbnail cache' is enabled thumbnails/mipmaps "
+"up to the selected size are generated while user is inactive in lighttable."
 msgstr "'썸네일 캐시에 디스크 백엔드 사용'이 활성화되어 있으면, 사용자가 lighttable에서 비활성 상태일 때 선택한 크기까지 썸네일/밉맵이 생성됩니다."
 
-#: ../build/bin/preferences_gen.h:5091
+#: ../build/bin/preferences_gen.h:3051
 msgid "reset cached thumbnails"
 msgstr "캐시된 썸네일 재설정"
 
-#: ../build/bin/preferences_gen.h:5104
-msgid "force thumbnails to be regenerated by resetting the database. this may be needed in case some thumbnails have been manually removed or corrupted."
+#: ../build/bin/preferences_gen.h:3059
+msgid ""
+"force thumbnails to be regenerated by resetting the database. this may be "
+"needed in case some thumbnails have been manually removed or corrupted."
 msgstr "데이터베이스를 재설정하여 썸네일을 강제로 다시 생성합니다.일부 썸네일이 수동으로 삭제되었거나 손상된 경우 필요할 수 있습니다."
 
-#: ../build/bin/preferences_gen.h:5125
+#: ../build/bin/preferences_gen.h:3068
 msgid "delimiters for size categories"
 msgstr "크기 범주 구분자"
 
-#: ../build/bin/preferences_gen.h:5143
+#: ../build/bin/preferences_gen.h:3081
 msgid ""
-"size categories are used to be able to set different overlays and CSS values depending of the size of the thumbnail, separated by |.\n"
-"for example, 120|400 means 3 categories of thumbnails: <120px, 120-400px, >400px"
+"size categories are used to be able to set different overlays and CSS values "
+"depending on the size of the thumbnail, separated by |.\n"
+"for example, 120|400 means 3 categories of thumbnails: up to 120px, "
+"120-400px, more than 400px"
 msgstr ""
-"크기별로 서로 다른 오버레이와 CSS 값을 설정할 수 있도록크기 구분자를 |로 구분하여 사용합니다.\n"
-"예, 120|400은 3개의 썸네일 크기 범주를 의미: <120px, 120-400px, >400px"
+"썸네일 크기에 따라 서로 다른 오버레이와 CSS 값을 설정할 수 있도록 크기 범주를 |로 구분하여 지정합니다.\n"
+"예를 들어 120|400은 3개의 썸네일 범주를 의미합니다: 120px 이하, 120-400px, 400px 초과"
 
-#: ../build/bin/preferences_gen.h:5164
+#: ../build/bin/preferences_gen.h:3090
 msgid "pattern for the thumbnail extended overlay text"
 msgstr "썸네일 확장 오버레이 텍스트 패턴"
 
-#: ../build/bin/preferences_gen.h:5184 ../build/bin/preferences_gen.h:5225
+#: ../build/bin/preferences_gen.h:3105 ../build/bin/preferences_gen.h:3129
 msgid "see manual to know all the tags you can use."
 msgstr "사용 가능한 모든 태그는 매뉴얼을 참고합니다."
 
-#: ../build/bin/preferences_gen.h:5205
+#: ../build/bin/preferences_gen.h:3114
 msgid "pattern for the thumbnail tooltip (empty to disable)"
 msgstr "썸네일 툴팁 패턴 (비우면 비활성화)"
 
-#: ../build/bin/preferences_gen.h:5252 ../src/gui/gtk.c:1511
-#: ../src/gui/preferences.c:602 ../src/views/darkroom.c:91
+#: ../build/bin/preferences_gen.h:3139 ../src/gui/gtk.c:1705
+#: ../src/gui/preferences.c:630 ../src/views/darkroom.c:111
 msgid "darkroom"
 msgstr "darkroom"
 
-#: ../build/bin/preferences_gen.h:5273
-msgid "scroll down to increase mask parameters"
-msgstr "아래로 스크롤하여 마스크 파라메터 증가"
-
-#: ../build/bin/preferences_gen.h:5286
-msgid ""
-"when using the mouse scroll wheel to change mask parameters, scroll down to increase the mask size, feather size, opacity, brush hardness and gradient curvature\n"
-"by default scrolling up increases these parameters"
-msgstr ""
-"마우스 휠로 마스크 파라메터를 변경할 때, 아래로 스크롤하면 마스크 크기,페더 크기, 불투명도, 브러시 경도, 그라디언트 곡률이 증가합니다.\n"
-"기본적으로는 스크롤을 올릴 때 이 파라메터 값들이 증가합니다"
-
-#: ../build/bin/preferences_gen.h:5307
+#: ../build/bin/preferences_gen.h:3154
 msgid "middle mouse button zooms to 200%"
 msgstr "마우스 가운데 버튼 200% 확대"
 
-#: ../build/bin/preferences_gen.h:5321
+#: ../build/bin/preferences_gen.h:3163
 #, no-c-format
-msgid "if enabled, the zoom level will cycle between 100%, 200% and fit to viewport on middle mouse clicks. if disabled, it will toggle between viewport size and 100%, and the 'ctrl' key can be used to control the zoom level."
+msgid ""
+"if enabled, the zoom level will cycle between 100%, 200% and fit to viewport "
+"on middle mouse clicks. if disabled, it will toggle between viewport size "
+"and 100%, and the 'ctrl' key can be used to control the zoom level."
 msgstr "활성화하면 중간 마우스 클릭 시 확대 수준이 100%, 200%, 뷰포트 맞춤 순으로 바뀝니다.비활성화하면 뷰포트 크기와 100% 사이를 전환하며,'ctrl' 키로 확대 수준을 조절할 수 있습니다."
 
-#: ../build/bin/preferences_gen.h:5342
+#: ../build/bin/preferences_gen.h:3172
 msgid "pattern for the image information line"
 msgstr "이미지 정보 라인용 패턴"
 
-#: ../build/bin/preferences_gen.h:5362
+#: ../build/bin/preferences_gen.h:3187
 msgid "see manual for a list of the tags you can use."
 msgstr "사용 가능한 태그 목록은 매뉴얼을 참조합니다."
 
-#: ../build/bin/preferences_gen.h:5383
+#: ../build/bin/preferences_gen.h:3196
 msgid "position of the image information line"
 msgstr "이미지 정보 라인 위치"
 
-#: ../build/bin/preferences_gen.h:5417
+#: ../build/bin/preferences_gen.h:3213
 msgid "border around image in darkroom mode"
 msgstr "darkroom 모드에서 이미지 테두리"
 
-#: ../build/bin/preferences_gen.h:5437 ../build/bin/preferences_gen.h:7422
-#: ../build/bin/preferences_gen.h:7543 ../build/bin/preferences_gen.h:7888
-#: ../build/bin/preferences_gen.h:8352 ../build/bin/preferences_gen.h:8481
-#: ../build/bin/preferences_gen.h:8526 ../build/bin/preferences_gen.h:8623
-#: ../build/bin/preferences_gen.h:8702 ../build/bin/preferences_gen.h:8748
+#: ../build/bin/preferences_gen.h:3229 ../build/bin/preferences_gen.h:3493
+#: ../build/bin/preferences_gen.h:4370 ../build/bin/preferences_gen.h:4440
+#: ../build/bin/preferences_gen.h:4707 ../build/bin/preferences_gen.h:4978
+#: ../build/bin/preferences_gen.h:5056 ../build/bin/preferences_gen.h:5084
+#: ../build/bin/preferences_gen.h:5147 ../build/bin/preferences_gen.h:5209
+#: ../build/bin/preferences_gen.h:5238
 #, c-format
 msgid "double click to reset to `%d'"
 msgstr "더블 클릭하여 `%d'로 재설정"
 
-#: ../build/bin/preferences_gen.h:5440
-msgid "process the image in darkroom mode with a small border. set to 0 if you don't want any border."
+#: ../build/bin/preferences_gen.h:3231
+msgid ""
+"process the image in darkroom mode with a small border. set to 0 if you "
+"don't want any border."
 msgstr "darkroom 모드에서 작은 테두리로 이미지를 처리합니다. 테두리가 필요 없다면 0으로 설정합니다."
 
-#: ../build/bin/preferences_gen.h:5495
+#: ../build/bin/preferences_gen.h:3257
 msgid "show loading screen between images"
 msgstr "이미지 간 로딩 화면 표시"
 
-#: ../build/bin/preferences_gen.h:5508
+#: ../build/bin/preferences_gen.h:3265
 msgid ""
 "show gray loading screen when navigating between images in the darkroom\n"
 "disable to just show a toast message"
@@ -1259,73 +1335,80 @@ msgstr ""
 "darkroom에서 이미지 간 이동 시 회색 로딩 화면을 표시합니다\n"
 "비활성화하면 토스트 메시지만 표시됩니다"
 
-#: ../build/bin/preferences_gen.h:5517
+#: ../build/bin/preferences_gen.h:3271
 msgid "modules"
 msgstr "모듈"
 
-#: ../build/bin/preferences_gen.h:5536
+#: ../build/bin/preferences_gen.h:3281
 msgid "display of individual color channels"
 msgstr "개별 색상 채널 표시"
 
-#: ../build/bin/preferences_gen.h:5550
-msgid "defines how color channels are displayed when activated in the parametric masks feature."
+#: ../build/bin/preferences_gen.h:3290
+msgid ""
+"defines how color channels are displayed when activated in the parametric "
+"masks feature."
 msgstr "파라메트릭 마스크 기능에서 활성화 시 색상 채널 표시 방식을 정의합니다."
 
-#: ../build/bin/preferences_gen.h:5571
+#: ../build/bin/preferences_gen.h:3299
 msgid "hide built-in presets for processing modules"
 msgstr "처리 모듈의 내장 프리셋 숨기기"
 
-#: ../build/bin/preferences_gen.h:5584
+#: ../build/bin/preferences_gen.h:3307
 msgid "hide built-in presets of processing modules in presets menu."
 msgstr "프리셋 메뉴에서 처리 모듈의 내장 프리셋 숨기기."
 
-#: ../build/bin/preferences_gen.h:5605 ../build/bin/preferences_gen.h:5618
+#: ../build/bin/preferences_gen.h:3316 ../build/bin/preferences_gen.h:3324
 msgid "show the guides widget in modules UI"
 msgstr "모듈 UI에서 가이드 위젯 표시"
 
-#: ../build/bin/preferences_gen.h:5639
+#: ../build/bin/preferences_gen.h:3333
 msgid "expand a single processing module at a time"
 msgstr "한 번에 하나의 처리 모듈만 펼침"
 
-#: ../build/bin/preferences_gen.h:5652
+#: ../build/bin/preferences_gen.h:3341
 msgid "this option toggles the behavior of shift clicking in darkroom mode"
 msgstr "이 옵션은 darkroom 모드에서 Shift 클릭 동작을 전환합니다"
 
-#: ../build/bin/preferences_gen.h:5673
+#: ../build/bin/preferences_gen.h:3350
 msgid "only collapse modules in current group"
 msgstr "현재 그룹 내 모듈만 접기"
 
-#: ../build/bin/preferences_gen.h:5686
-msgid "if only expanding a single module at a time, only collapse other modules in the current group - ignore modules in other groups"
+#: ../build/bin/preferences_gen.h:3358
+msgid ""
+"if only expanding a single module at a time, only collapse other modules in "
+"the current group - ignore modules in other groups"
 msgstr "한 번에 하나의 모듈만 펼칠 경우, 현재 그룹 내 다른 모듈만 접히고 다른 그룹의 모듈은 무시됩니다"
 
-#: ../build/bin/preferences_gen.h:5707
+#: ../build/bin/preferences_gen.h:3367
 msgid "expand the module when it is activated, and collapse it when disabled"
 msgstr "모듈 활성화 시 펼침, 비활성화 시 접힘"
 
-#: ../build/bin/preferences_gen.h:5720
-msgid "this option allows to expand or collapse automatically the module when it is enabled or disabled."
+#: ../build/bin/preferences_gen.h:3375
+msgid ""
+"this option allows to expand or collapse automatically the module when it is "
+"enabled or disabled."
 msgstr "이 옵션을 사용하면 모듈이 활성화 또는 비활성화될 때 자동으로펼침, 접힘이 됩니다."
 
-#: ../build/bin/preferences_gen.h:5741
+#: ../build/bin/preferences_gen.h:3384
 msgid "scroll processing modules to the top when expanded"
 msgstr "처리 모듈 펼칠때, 맨 위로 스크롤"
 
-#: ../build/bin/preferences_gen.h:5775
+#: ../build/bin/preferences_gen.h:3401
 msgid "swap the utility and processing modules panels"
 msgstr "유틸리티 및 처리 모듈 패널 위치 교체"
 
-#: ../build/bin/preferences_gen.h:5788
+#: ../build/bin/preferences_gen.h:3409
 msgid "move the list of processing modules to the left of the screen"
 msgstr "처리 모듈 목록을 화면 왼쪽으로 이동"
 
-#: ../build/bin/preferences_gen.h:5809
+#: ../build/bin/preferences_gen.h:3418
 msgid "show right-side buttons in processing module headers"
 msgstr "처리 모듈 헤더에 오른쪽 버튼 표시"
 
-#: ../build/bin/preferences_gen.h:5823
+#: ../build/bin/preferences_gen.h:3427
 msgid ""
-"when the mouse is not over a module, the multi-instance, reset and preset buttons can be hidden:\n"
+"when the mouse is not over a module, the multi-instance, reset and preset "
+"buttons can be hidden:\n"
 " - 'always': always show all buttons,\n"
 " - 'active': only show the buttons when the mouse is over the module,\n"
 " - 'dim': buttons are dimmed when mouse is away,\n"
@@ -1345,203 +1428,298 @@ msgstr ""
 " - '부드럽게': 한 헤더 내 모든 버튼을 동시에 점차 사라짐\n"
 " - '글라이드': 필요에 따라 개별 버튼을 점차 숨김"
 
-#: ../build/bin/preferences_gen.h:5844
-msgid "show mask indicator in module headers"
-msgstr "모듈 헤더에 마스크 인디케이터 표시"
-
-#: ../build/bin/preferences_gen.h:5857
-msgid "if enabled, an icon will be shown in the header of any processing modules that have a mask applied"
-msgstr "활성화 시 마스크가 적용된 처리 모듈 헤더에 아이콘이 표시됩니다"
-
-#: ../build/bin/preferences_gen.h:5878
+#: ../build/bin/preferences_gen.h:3436
 msgid "prompt for name on addition of new instance"
 msgstr "새 인스턴스 추가 시 이름 입력 요청"
 
-#: ../build/bin/preferences_gen.h:5891
-msgid "if enabled, a rename prompt will be present for each new module instance (either new instance or duplicate)"
+#: ../build/bin/preferences_gen.h:3444
+msgid ""
+"if enabled, a rename prompt will be present for each new module instance "
+"(either new instance or duplicate)"
 msgstr "활성화하면, 새 모듈 인스턴스 (신규 또는 복제) 마다 이름 변경 요청이 표시됩니다"
 
-#: ../build/bin/preferences_gen.h:5912
-msgid "automatically update module name"
-msgstr "모듈 이름 자동 업데이트"
+#. Masking options
+#: ../build/bin/preferences_gen.h:3450 ../src/iop/toneequal.c:3343
+msgid "masking"
+msgstr "마스킹"
 
-#: ../build/bin/preferences_gen.h:5925
-msgid "if enabled, the module name will be automatically updated to match a preset name or a preset instance name if present."
-msgstr "활성화하면 모듈 이름이 프리셋 이름 또는 프리셋 인스턴스 이름과자동으로 일치하도록 업데이트됩니다."
+#: ../build/bin/preferences_gen.h:3460
+msgid "scroll down to increase mask parameters"
+msgstr "아래로 스크롤하여 마스크 파라메터 증가"
 
-#: ../build/bin/preferences_gen.h:5952
+#: ../build/bin/preferences_gen.h:3468
+msgid ""
+"when using the mouse scroll wheel to change mask parameters, scroll down to "
+"increase the mask size, feather size, opacity, brush hardness and gradient "
+"curvature\n"
+"by default scrolling up increases these parameters"
+msgstr ""
+"마우스 휠로 마스크 파라메터를 변경할 때, 아래로 스크롤하면 마스크 크기,페더 크기, 불투명도, 브러시 경도, 그라디언트 곡률이 증가합니다.\n"
+"기본적으로는 스크롤을 올릴 때 이 파라메터 값들이 증가합니다"
+
+#: ../build/bin/preferences_gen.h:3477
+msgid "path mask resize step amount"
+msgstr "경로 마스크 크기 조절 단계량"
+
+#: ../build/bin/preferences_gen.h:3495
+msgid ""
+"amount to grow or shrink a path mask per scroll wheel tick when resizing. "
+"the unit is set by the 'path mask resize unit' preference."
+msgstr "크기 조절 시 스크롤 휠 한 칸당 경로 마스크를 확대 또는 축소할 양입니다. 단위는 '경로 마스크 크기 조절 단위' 설정으로 지정합니다."
+
+#: ../build/bin/preferences_gen.h:3504
+msgid "unit for path mask resize step amount"
+msgstr "경로 마스크 크기 조절 단계량의 단위"
+
+#: ../build/bin/preferences_gen.h:3514
+#, no-c-format
+msgid ""
+"unit for the path mask resize step: 'pixels' uses image pixels, '% of path "
+"size' uses a percentage of the path's largest bounding box dimension."
+msgstr "경로 마스크 크기 조절 단계의 단위입니다. '픽셀'은 이미지 픽셀을 사용하고, '경로 크기의 %'는 경로의 가장 큰 경계 상자 치수에 대한 백분율을 사용합니다."
+
+#: ../build/bin/preferences_gen.h:3523
+msgid "path mask resize tracing resolution"
+msgstr "경로 마스크 크기 조절 추적 해상도"
+
+#: ../build/bin/preferences_gen.h:3530
+msgctxt "preferences"
+msgid "2048"
+msgstr "2048"
+
+#: ../build/bin/preferences_gen.h:3532
+msgid ""
+"internal raster resolution (in pixels on the longest side) used when re-"
+"vectorizing a resized path mask. higher values preserve more detail and "
+"nodes at the cost of speed."
+msgstr "크기가 조절된 경로 마스크를 다시 벡터화할 때 사용하는 내부 래스터 해상도(가장 긴 변의 픽셀 수)입니다. 값이 클수록 세부 정보와 노드가 더 많이 보존되지만 속도가 느려집니다."
+
+#: ../build/bin/preferences_gen.h:3541
+msgid "path mask resize curve smoothing"
+msgstr "경로 마스크 크기 조절 커브 부드럽기"
+
+#: ../build/bin/preferences_gen.h:3550
+msgid ""
+"controls how corners are handled when re-vectorizing a resized path mask. "
+"'sharp' preserves more nodes and corners; 'smooth' produces fewer, rounder "
+"control points."
+msgstr "크기가 조절된 경로 마스크를 다시 벡터화할 때 모서리를 처리하는 방식을 제어합니다. '뾰족하게'는 노드와 모서리를 더 많이 보존하고, '부드럽게'는 더 적고 둥근 제어점을 생성합니다."
+
+#: ../build/bin/preferences_gen.h:3559
+msgid "show mask indicator in module headers"
+msgstr "모듈 헤더에 마스크 인디케이터 표시"
+
+#: ../build/bin/preferences_gen.h:3567
+msgid ""
+"if enabled, an icon will be shown in the header of any processing modules "
+"that have a mask applied"
+msgstr "활성화 시 마스크가 적용된 처리 모듈 헤더에 아이콘이 표시됩니다"
+
+#: ../build/bin/preferences_gen.h:3577
 msgid "processing"
 msgstr "처리"
 
-#: ../build/bin/preferences_gen.h:5954
+#: ../build/bin/preferences_gen.h:3582
 msgid "image processing"
 msgstr "이미지 처리"
 
-#: ../build/bin/preferences_gen.h:5973
+#: ../build/bin/preferences_gen.h:3592
 msgid "always use LittleCMS 2 to apply output color profile"
 msgstr "출력 색상 프로파일을 적용할 때 항상 LittleCMS 2를 사용"
 
-#: ../build/bin/preferences_gen.h:5986
+#: ../build/bin/preferences_gen.h:3600
 msgid "this is slower than the default."
 msgstr "이 설정은 기본값보다 느립니다."
 
-#: ../build/bin/preferences_gen.h:6007
+#: ../build/bin/preferences_gen.h:3609
 msgid "pixel interpolator (warp)"
 msgstr "픽셀 보간기 (워핑)"
 
-#: ../build/bin/preferences_gen.h:6021
-msgid "pixel interpolator used in modules for rotation, lens correction, liquify, cropping and final scaling (bilinear, bicubic, lanczos2)."
+#: ../build/bin/preferences_gen.h:3618
+msgid ""
+"pixel interpolator used in modules for rotation, lens correction, liquify, "
+"cropping and final scaling (bilinear, bicubic, lanczos2)."
 msgstr "회전, 렌즈 보정, 유동화, 자르기, 최종 크기 조정 모듈에 사용되는 픽셀 보간기 (쌍선형, 쌍입방형, 란초스2)."
 
-#: ../build/bin/preferences_gen.h:6042
+#: ../build/bin/preferences_gen.h:3627
 msgid "pixel interpolator (scaling)"
 msgstr "픽셀 보간기 (스케일링)"
 
-#: ../build/bin/preferences_gen.h:6056
-msgid "pixel interpolator used for scaling (bilinear, bicubic, lanczos2, lanczos3)."
+#: ../build/bin/preferences_gen.h:3636
+msgid ""
+"pixel interpolator used for scaling (bilinear, bicubic, lanczos2, lanczos3)."
 msgstr "크기 조정에 사용되는 픽셀 보간기(쌍선형, 쌍입방형, 란초스2)."
 
-#: ../build/bin/preferences_gen.h:6077
+#: ../build/bin/preferences_gen.h:3645
 msgid "LUT 3D root folder"
 msgstr "LUT 3D 루트 폴더"
 
-#: ../build/bin/preferences_gen.h:6083 ../build/bin/preferences_gen.h:6124
-#: ../src/control/jobs/control_jobs.c:2189
-#: ../src/control/jobs/control_jobs.c:2245 ../src/gui/preferences.c:1233
-#: ../src/gui/presets.c:429 ../src/imageio/storage/disk.c:197
-#: ../src/imageio/storage/disk.c:283 ../src/imageio/storage/gallery.c:148
-#: ../src/imageio/storage/gallery.c:207 ../src/imageio/storage/latex.c:144
-#: ../src/imageio/storage/latex.c:193 ../src/libs/import.c:1845
-#: ../src/libs/import.c:1957 ../src/libs/import.c:2015 ../src/libs/styles.c:456
-#: ../src/lua/preferences.c:668
+#: ../build/bin/preferences_gen.h:3647 ../build/bin/preferences_gen.h:3671
+#: ../src/control/jobs/control_jobs.c:2204
+#: ../src/control/jobs/control_jobs.c:2260 ../src/gui/preferences.c:1260
+#: ../src/gui/presets.c:429 ../src/gui/welcome.c:169 ../src/gui/welcome.c:337
+#: ../src/imageio/storage/disk.c:199 ../src/imageio/storage/disk.c:285
+#: ../src/imageio/storage/gallery.c:148 ../src/imageio/storage/gallery.c:207
+#: ../src/imageio/storage/latex.c:144 ../src/imageio/storage/latex.c:193
+#: ../src/libs/import.c:1815 ../src/libs/import.c:1927
+#: ../src/libs/import.c:1985 ../src/libs/styles.c:456
+#: ../src/lua/preferences.c:695
 msgid "select directory"
 msgstr "디렉토리 선택"
 
-#: ../build/bin/preferences_gen.h:6097
-msgid "this folder (and sub-folders) contains LUT files used by LUT 3D module. (restart required)"
+#: ../build/bin/preferences_gen.h:3660
+msgid ""
+"this folder (and sub-folders) contains LUT files used by LUT 3D module. "
+"(restart required)"
 msgstr "이 폴더(및 하위 폴더)에는 LUT 3D 모듈에서 사용하는 LUT 파일이 포함되어 있습니다.(재시작 필요)"
 
-#: ../build/bin/preferences_gen.h:6118
+#: ../build/bin/preferences_gen.h:3669
 msgid "raster mask files root folder"
 msgstr "래스터 마스크 파일 루트 폴더"
 
-#: ../build/bin/preferences_gen.h:6138
-msgid "this folder (and sub-folders) contains PFM files used by the raster mask import module. (restart required)"
-msgstr "이 폴더(및 하위 폴더)에는 래스터 마스크 가져오기 모듈에서 사용하는 PFM 파일이 포함되어 있습니다. (재시작 필요)"
+#: ../build/bin/preferences_gen.h:3684
+msgid ""
+"this folder (and sub-folders) contains PFM/PNG files used by the raster mask "
+"import module. (restart required)"
+msgstr "이 폴더(및 하위 폴더)에는 래스터 마스크 가져오기 모듈에서 사용하는 PFM/PNG 파일이 포함되어 있습니다. (재시작 필요)"
 
-#: ../build/bin/preferences_gen.h:6159
+#: ../build/bin/preferences_gen.h:3693
 msgid "auto-apply pixel workflow defaults"
 msgstr "픽셀 워크플로우 기본값 자동 적용"
 
-#: ../build/bin/preferences_gen.h:6173
+#: ../build/bin/preferences_gen.h:3702
 msgid ""
-"scene-referred workflow is based on linear modules and will auto-apply filmic or sigmoid, color calibration and exposure,\n"
-"display-referred workflow is based on Lab modules and will auto-apply base curve, white balance and the legacy module pipe order."
+"selects which workflow will be used by default in the darkroom\n"
+"\n"
+"<b>scene-referred (sigmoid)</b> modern workflow, fewer tonemapper controls\n"
+"\n"
+"<b>scene-referred (filmic)</b> modern workflow, more tone mapping controls\n"
+"\n"
+"<b>scene-referred (AgX)</b> modern workflow, maximum tone mapping control\n"
+"\n"
+"<b>display-referred (legacy)</b> legacy workflow (not recommended)\n"
+"\n"
+"<b>none</b> do not use a predefined workflow"
 msgstr ""
-"장면 기준 워크플로우는 선형 모듈을 기반으로 하며 필믹 또는 시그모이드, 색상 보정, 노출을 자동 적용합니다.\n"
-"디스플레이 기준 워크플로우는 Lab 모듈을 기반으로 하며 기본 커브, 화이트 밸런스, 레거시 모듈 파이프 순서를 자동 적용합니다."
+"darkroom에서 기본으로 사용할 워크플로우를 선택합니다\n"
+"\n"
+"<b>장면 기준 (시그모이드)</b> 최신 워크플로우, 톤매퍼 컨트롤이 적음\n"
+"\n"
+"<b>장면 기준 (필믹)</b> 최신 워크플로우, 톤 매핑 컨트롤이 많음\n"
+"\n"
+"<b>장면 기준 (AgX)</b> 최신 워크플로우, 톤 매핑 제어가 가장 풍부함\n"
+"\n"
+"<b>디스플레이 기준 (레거시)</b> 레거시 워크플로우 (권장하지 않음)\n"
+"\n"
+"<b>없음</b> 미리 정의된 워크플로우를 사용하지 않음"
 
-#: ../build/bin/preferences_gen.h:6194
+#: ../build/bin/preferences_gen.h:3711
 msgid "auto-apply per camera basecurve presets"
 msgstr "카메라별 기본 커브 프리셋 자동 적용"
 
-#: ../build/bin/preferences_gen.h:6207
+#: ../build/bin/preferences_gen.h:3719
 msgid ""
-"use the per-camera basecurve by default instead of the generic manufacturer one if there is one available. (restart required)\n"
-"this option is taken into account when the \"auto-apply pixel workflow defaults\" is set to \"display-referred\".\n"
-"to prevent auto-apply basecurve presets \"auto-apply pixel workflow defaults\" should be set to \"none\""
+"use the per-camera basecurve by default instead of the generic manufacturer "
+"one if there is one available. (restart required)\n"
+"this option is taken into account when the \"auto-apply pixel workflow "
+"defaults\" is set to \"display-referred\".\n"
+"to prevent auto-apply basecurve presets \"auto-apply pixel workflow "
+"defaults\" should be set to \"none\""
 msgstr ""
 "사용 가능한 경우 제조사 기본값 대신 카메라별 기본 곡선을 기본값으로 사용합니다.(재시작 필요)\n"
 "이 옵션은 \"픽셀 워크플로우 기본값 자동 적용\"이 \"디스플레이 기준\"으로 설정된 경우에 적용됩니다.\n"
 "기본 커브 프리셋 자동 적용을 방지하려면 \"픽셀 워크플로우 기본값 자동 적용\"을\"없음\"으로 설정하세요."
 
-#: ../build/bin/preferences_gen.h:6228
+#: ../build/bin/preferences_gen.h:3728
 msgid "detect monochrome previews"
 msgstr "모노크롬 미리보기 검출"
 
-#: ../build/bin/preferences_gen.h:6241
-msgid "many monochrome images can be identified via EXIF and preview data. beware: this slows down imports and reading of EXIF data"
+#: ../build/bin/preferences_gen.h:3736
+msgid ""
+"many monochrome images can be identified via EXIF and preview data. beware: "
+"this slows down imports and reading of EXIF data"
 msgstr "많은 모노크롬 이미지는 EXIF 및 미리보기 데이터를 통해 식별할 수 있습니다.참고: 이 옵션은 가져오기 및 EXIF 데이터 읽기 속도를 저하시킬 수 있습니다"
 
-#: ../build/bin/preferences_gen.h:6262
+#: ../build/bin/preferences_gen.h:3745
 msgid "show warning messages"
 msgstr "경고 메시지 표시"
 
-#: ../build/bin/preferences_gen.h:6275
+#: ../build/bin/preferences_gen.h:3753
 msgid ""
-"display messages in modules to warn beginner users when non-standard and possibly harmful settings are used in the pipeline.\n"
-"these messages can be false-positive and should be disregarded if you know what you are doing. this option will hide them all the time."
+"display messages in modules to warn beginner users when non-standard and "
+"possibly harmful settings are used in the pipeline.\n"
+"these messages can be false-positive and should be disregarded if you know "
+"what you are doing. this option will hide them all the time."
 msgstr ""
 "파이프라인에서 비표준이거나 잠재적으로 위험한 설정이 사용될 때 초보 사용자를 위해 모듈에 경고 메시지를 표시합니다.\n"
 "이 메시지는 실제로 문제가 없는 경우에도 표시될 수 있으니, 사용법을 잘 알고 있다면 무시해도 됩니다. 이 옵션을 켜면 항상 메시지가 숨겨집니다."
 
-#: ../build/bin/preferences_gen.h:6284
+#: ../build/bin/preferences_gen.h:3759
 msgid "CPU / memory"
 msgstr "CPU / 메모리"
 
-#: ../build/bin/preferences_gen.h:6303
+#: ../build/bin/preferences_gen.h:3769
 msgid "darktable resources"
 msgstr "darktable 리소스"
 
-#: ../build/bin/preferences_gen.h:6318
+#: ../build/bin/preferences_gen.h:3779
 #, no-c-format
 msgid ""
 "defines how much darktable may take from your system resources:\n"
-" - 'default': darktable takes ~50% of your systems resources, which is enough to be performant.\n"
-" - 'small': should be used if you are simultaneously running applications taking large parts of your systems memory or OpenCL/GL applications like games or Hugin.\n"
-" - 'large': is the best option if you are not running other applications at the same time as darktable and want it to take most of your systems resources for performance."
+" - 'default': darktable takes ~50% of your systems resources, which is "
+"enough to be performant.\n"
+" - 'small': should be used if you are simultaneously running applications "
+"taking large parts of your systems memory or OpenCL/GL applications like "
+"games or Hugin.\n"
+" - 'large': is the best option if you are not running other applications at "
+"the same time as darktable and want it to take most of your systems "
+"resources for performance."
 msgstr ""
 "darktable이 시스템 리소스를 얼마나 사용할지 정의합니다:\n"
 " - 'defalt': 시스템 리소스의 약 50%를 사용하여 충분한 성능을 제공합니다.\n"
 " - 'small': 다른 대용량 메모리 사용 프로그램이나 OpenCL/GL 응용프로그램 (게임, Hugin)과 동시에 실행할 때 사용하세요.\n"
 " - 'large': darktable만 실행하며 최대 성능을 원할 때 선택하세요."
 
-#: ../build/bin/preferences_gen.h:6327
+#: ../build/bin/preferences_gen.h:3785
 msgid "OpenCL GPU acceleration"
 msgstr "OpenCL GPU 가속"
 
-#: ../build/bin/preferences_gen.h:6346
+#: ../build/bin/preferences_gen.h:3795
 msgid "activate OpenCL support"
 msgstr "OpenCL 지원 활성화"
 
-#: ../build/bin/preferences_gen.h:6359
+#: ../build/bin/preferences_gen.h:3803
 msgid ""
-"if found, use OpenCL runtime on your system to speed up processing by using your graphics card(s).\n"
+"if found, use OpenCL runtime on your system to speed up processing by using "
+"your graphics card(s).\n"
 "can be switched on and off at any time."
 msgstr ""
 "시스템에서 OpenCL 런타임을 찾으면 그래픽 카드(들)을 사용해 처리 속도를 높입니다.\n"
 "언제든지 켜거나 끌 수 있습니다."
 
-#: ../build/bin/preferences_gen.h:6363 ../build/bin/preferences_gen.h:6408
-#: ../build/bin/preferences_gen.h:6452 ../build/bin/preferences_gen.h:6503
-#: ../build/bin/preferences_gen.h:6547 ../build/bin/preferences_gen.h:6591
-#: ../build/bin/preferences_gen.h:6635 ../build/bin/preferences_gen.h:6679
-#: ../build/bin/preferences_gen.h:6723 ../build/bin/preferences_gen.h:8004
-msgid "not available"
-msgstr "사용 불가"
+#: ../build/bin/preferences_gen.h:3816
+msgid "OpenCL fast mode"
+msgstr "OpenCL 빠른 모드"
 
-#: ../build/bin/preferences_gen.h:6365 ../build/bin/preferences_gen.h:6366
-#: ../build/bin/preferences_gen.h:6410 ../build/bin/preferences_gen.h:6411
-#: ../build/bin/preferences_gen.h:6454 ../build/bin/preferences_gen.h:6455
-#: ../build/bin/preferences_gen.h:6505 ../build/bin/preferences_gen.h:6506
-#: ../build/bin/preferences_gen.h:6549 ../build/bin/preferences_gen.h:6550
-#: ../build/bin/preferences_gen.h:6593 ../build/bin/preferences_gen.h:6594
-#: ../build/bin/preferences_gen.h:6637 ../build/bin/preferences_gen.h:6638
-#: ../build/bin/preferences_gen.h:6681 ../build/bin/preferences_gen.h:6682
-#: ../build/bin/preferences_gen.h:6725 ../build/bin/preferences_gen.h:6726
-#: ../build/bin/preferences_gen.h:8006 ../build/bin/preferences_gen.h:8007
-msgid "not available on this system"
-msgstr "이 시스템에서 사용 불가"
+#: ../build/bin/preferences_gen.h:3824
+msgid ""
+"if set the OpenCL compiler uses aggressive optimizing for better performance "
+"with reduced precision so more differences between CPU and OpenCL are "
+"expected."
+msgstr "설정하면 OpenCL 컴파일러가 정밀도를 낮추고 성능을 높이는 적극적인 최적화를 사용하므로 CPU와 OpenCL 간의 차이가 더 커질 수 있습니다."
 
-#: ../build/bin/preferences_gen.h:6390
+#: ../build/bin/preferences_gen.h:3837
 msgid "OpenCL scheduling profile"
 msgstr "OpenCL 스케줄링 프로파일"
 
-#: ../build/bin/preferences_gen.h:6404
+#: ../build/bin/preferences_gen.h:3846
 msgid ""
-"defines how preview and full pixelpipe tasks are scheduled on OpenCL enabled systems:\n"
-" - 'default': GPU processes full and CPU processes preview pipe (adaptable by config parameters),\n"
-" - 'multiple GPUs': process both pixelpipes in parallel on two different GPUs,\n"
+"defines how preview and full pixelpipe tasks are scheduled on OpenCL enabled "
+"systems:\n"
+" - 'default': GPU processes full and CPU processes preview pipe (adaptable "
+"by config parameters),\n"
+" - 'multiple GPUs': process both pixelpipes in parallel on two different "
+"GPUs,\n"
 " - 'very fast GPU': process both pixelpipes sequentially on the GPU."
 msgstr ""
 "OpenCL이 활성화된 시스템에서 미리보기 및 전체 픽셀 파이프 작업의 스케줄 방식을 정의합니다:\n"
@@ -1549,211 +1727,232 @@ msgstr ""
 " - 'multiple GPUs': 두 개의 다른 GPU에서 두 픽셀 파이프를 병렬 처리\n"
 " - 'very fast GPU': 두 픽셀 파이프를 GPU에서 순차 처리."
 
-#: ../build/bin/preferences_gen.h:6435
+#: ../build/bin/preferences_gen.h:3859
 msgid "tuned GPU memory"
 msgstr "튜닝된 GPU 메모리"
 
-#: ../build/bin/preferences_gen.h:6448
-msgid "if enabled on a system with multiple OpenCL devices you may specify a safety margin per device (headroom, default is 600MB)"
+#: ../build/bin/preferences_gen.h:3867
+msgid ""
+"if enabled on a system with multiple OpenCL devices you may specify a safety "
+"margin per device (headroom, default is 600MB)"
 msgstr "여러 OpenCL 장치가 있는 시스템에서 이 옵션을 활성화하면, 각 장치별로안전 여유 메모리 (헤드룸, 기본값 600MB)를 지정할 수 있습니다"
 
-#: ../build/bin/preferences_gen.h:6467
+#: ../build/bin/preferences_gen.h:3877
 msgid "OpenCL drivers"
 msgstr "OpenCL 드라이버"
 
-#: ../build/bin/preferences_gen.h:6486
+#: ../build/bin/preferences_gen.h:3887
 msgid "Intel GPU"
 msgstr "Intel GPU"
 
-#: ../build/bin/preferences_gen.h:6499
+#: ../build/bin/preferences_gen.h:3895
 msgid "Intel(R) OpenCL Graphics for all supported platforms (vendor provided)"
 msgstr "모든 지원 플랫폼용 Intel(R) OpenCL 그래픽스 (공급업체 제공)"
 
-#: ../build/bin/preferences_gen.h:6530
+#: ../build/bin/preferences_gen.h:3908
 msgid "Nvidia CUDA"
 msgstr "Nvidia CUDA"
 
-#: ../build/bin/preferences_gen.h:6543
+#: ../build/bin/preferences_gen.h:3916
 msgid "Nvidia CUDA based OpenCL (vendor provided)"
 msgstr "Nvidia CUDA 기반 OpenCL (공급업체 제공)"
 
-#: ../build/bin/preferences_gen.h:6574
+#: ../build/bin/preferences_gen.h:3929
 msgid "AMD ROCm"
 msgstr "AMD ROCm"
 
-#: ../build/bin/preferences_gen.h:6587
+#: ../build/bin/preferences_gen.h:3937
 msgid "AMD Accelerated Parallel Processing (vendor provided)"
 msgstr "AMD 가속 병렬 처리 (공급업체 제공)"
 
-#: ../build/bin/preferences_gen.h:6618
-msgid "RustiCL (experimental)"
-msgstr "RustiCL (실험실)"
+#: ../build/bin/preferences_gen.h:3950
+msgid "RustiCL"
+msgstr "RustiCL"
 
-#: ../build/bin/preferences_gen.h:6631
-msgid "RustiCL Mesa OpenCL, still unstable. if you want to use this, you should disable the vendor driver"
-msgstr "RustiCL Mesa OpenCL (아직 불안정). 사용하려면 공급업체 드라이버를 비활성화해야 합니다"
+#: ../build/bin/preferences_gen.h:3958
+msgid ""
+"RustiCL Mesa OpenCL. if you want to use this, you should disable the vendor "
+"driver"
+msgstr "RustiCL Mesa OpenCL. 사용하려면 공급업체 드라이버를 비활성화해야 합니다"
 
-#: ../build/bin/preferences_gen.h:6662
+#: ../build/bin/preferences_gen.h:3971
 msgid "Apple"
 msgstr "Apple"
 
-#: ../build/bin/preferences_gen.h:6675
+#: ../build/bin/preferences_gen.h:3979
 msgid "Apple OpenCL (vendor provided)"
 msgstr "Apple OpenCL (공급업체 제공)"
 
-#: ../build/bin/preferences_gen.h:6706
+#: ../build/bin/preferences_gen.h:3992
 msgid "Microsoft OpenCLOn12"
 msgstr "Microsoft OpenCLOn12"
 
-#: ../build/bin/preferences_gen.h:6719
-msgid "Microsoft OpenCLOn12, only use this if the vendor provided driver does not work or there is none provided."
+#: ../build/bin/preferences_gen.h:4000
+msgid ""
+"Microsoft OpenCLOn12, only use this if the vendor provided driver does not "
+"work or there is none provided."
 msgstr "Microsoft OpenCLOn12 - 공급업체 드라이버가 작동하지 않거나 없는 경우에만 사용하세요."
 
-#: ../build/bin/preferences_gen.h:6750
+#: ../build/bin/preferences_gen.h:4013
 msgid "other platforms"
 msgstr "기타 플랫폼"
 
-#: ../build/bin/preferences_gen.h:6763
-msgid "if set, all unspecified platforms are accepted. only do this if no vendor driver is available"
+#: ../build/bin/preferences_gen.h:4021
+msgid ""
+"if set, all unspecified platforms are accepted. only do this if no vendor "
+"driver is available"
 msgstr "설정 시, 지정되지 않은 모든 플랫폼을 허용합니다.공급업체 드라이버가 없을 때에만 사용하세요"
 
-#: ../build/bin/preferences_gen.h:6790
+#: ../build/bin/preferences_gen.h:4031
 msgid "security"
 msgstr "보안"
 
-#: ../build/bin/preferences_gen.h:6811
+#: ../build/bin/preferences_gen.h:4046
 msgid "ask before removing images from the library"
 msgstr "라이브러리에서 이미지 제거 전 확인"
 
-#: ../build/bin/preferences_gen.h:6824
+#: ../build/bin/preferences_gen.h:4054
 msgid "always ask the user before removing image information from the library"
 msgstr "라이브러리에서 이미지 정보를 제거하기 전에 항상 사용자에게 확인"
 
-#: ../build/bin/preferences_gen.h:6845
+#: ../build/bin/preferences_gen.h:4063
 msgid "ask before deleting images from disk"
 msgstr "디스크에서 이미지 삭제 전 확인"
 
-#: ../build/bin/preferences_gen.h:6858
+#: ../build/bin/preferences_gen.h:4071
 msgid "always ask the user before any image file is deleted"
 msgstr "이미지 파일 삭제 전 항상 사용자에게 확인"
 
-#: ../build/bin/preferences_gen.h:6879
+#: ../build/bin/preferences_gen.h:4080
 msgid "ask before discarding history stack"
 msgstr "히스토리 스택 폐기 전 확인"
 
-#: ../build/bin/preferences_gen.h:6892
+#: ../build/bin/preferences_gen.h:4088
 msgid "always ask the user before history stack is discarded on any image"
 msgstr "어떤 이미지든 히스토리 스택을 폐기하기 전에 항상 사용자에게 확인"
 
-#: ../build/bin/preferences_gen.h:6913
+#: ../build/bin/preferences_gen.h:4097
 msgid "try to use trash when deleting images"
 msgstr "이미지를 삭제할 때 휴지통 사용 시도"
 
-#: ../build/bin/preferences_gen.h:6926
-msgid "send files to trash instead of permanently deleting files on system that supports it"
+#: ../build/bin/preferences_gen.h:4105
+msgid ""
+"send files to trash instead of permanently deleting files on system that "
+"supports it"
 msgstr "지원되는 시스템에서는 파일을 영구 삭제하지 않고 휴지통으로 보냄"
 
-#: ../build/bin/preferences_gen.h:6947
+#: ../build/bin/preferences_gen.h:4114
 msgid "ask before moving images from film roll folder"
 msgstr "필름롤 폴더에서 이미지 이동 전 확인"
 
-#: ../build/bin/preferences_gen.h:6960
+#: ../build/bin/preferences_gen.h:4122
 msgid "always ask the user before any image file is moved."
 msgstr "이미지 파일 이동 전 항상 사용자에게 확인."
 
-#: ../build/bin/preferences_gen.h:6981
+#: ../build/bin/preferences_gen.h:4131
 msgid "ask before copying images to new film roll folder"
 msgstr "새 필름롤 폴더로 이미지 복사 전 확인"
 
-#: ../build/bin/preferences_gen.h:6994
+#: ../build/bin/preferences_gen.h:4139
 msgid "always ask the user before any image file is copied."
 msgstr "이미지 파일 복사 전 항상 사용자에게 확인."
 
-#: ../build/bin/preferences_gen.h:7015
+#: ../build/bin/preferences_gen.h:4148
 msgid "ask before removing empty folders"
 msgstr "빈 폴더 제거 전 확인"
 
-#: ../build/bin/preferences_gen.h:7028
-msgid "always ask the user before removing any empty folder. this can happen after moving or deleting images."
+#: ../build/bin/preferences_gen.h:4156
+msgid ""
+"always ask the user before removing any empty folder. this can happen after "
+"moving or deleting images."
 msgstr "빈 폴더를 제거하기 전에 항상 사용자에게 확인. 이미지를 이동하거나 삭제한 후 에 발생할 수 있습니다."
 
-#: ../build/bin/preferences_gen.h:7049
+#: ../build/bin/preferences_gen.h:4165
 msgid "ask before deleting a tag"
 msgstr "태그 삭제 전 확인"
 
-#: ../build/bin/preferences_gen.h:7082
+#: ../build/bin/preferences_gen.h:4181
 msgid "ask before deleting a style"
 msgstr "스타일 삭제 전 확인"
 
-#: ../build/bin/preferences_gen.h:7115
+#: ../build/bin/preferences_gen.h:4197
 msgid "ask before deleting a preset"
 msgstr "프리셋 삭제 전 확인"
 
-#: ../build/bin/preferences_gen.h:7128
+#: ../build/bin/preferences_gen.h:4205
 msgid "will ask for confirmation before deleting or overwriting a preset"
 msgstr "프리셋을 삭제하거나 덮어쓰기 전에 확인을 요청합니다"
 
-#: ../build/bin/preferences_gen.h:7149
+#: ../build/bin/preferences_gen.h:4214
 msgid "ask before exporting in overwrite mode"
 msgstr "덮어쓰기 모드로 내보내기 전 확인"
 
-#: ../build/bin/preferences_gen.h:7162
+#: ../build/bin/preferences_gen.h:4222
 msgid "will ask for confirmation before exporting files in overwrite mode"
 msgstr "덮어쓰기 모드로 파일을 내보내기 전에 확인을 요청합니다"
 
-#: ../build/bin/preferences_gen.h:7171 ../src/libs/tools/viewswitcher.c:151
+#: ../build/bin/preferences_gen.h:4228 ../src/libs/tools/viewswitcher.c:151
 msgid "other"
 msgstr "기타"
 
-#: ../build/bin/preferences_gen.h:7190
+#: ../build/bin/preferences_gen.h:4238
 msgid "password storage backend to use"
 msgstr "사용할 비밀번호 저장 백엔드"
 
-#: ../build/bin/preferences_gen.h:7212
-msgid "the storage backend for password storage: auto, none, libsecret, kwallet, apple_keychain, windows_credentials"
+#: ../build/bin/preferences_gen.h:4255
+msgid ""
+"the storage backend for password storage: auto, none, libsecret, kwallet, "
+"apple_keychain, windows_credentials"
 msgstr "비밀번호 저장을 위한 백엔드: 자동, 없음, libsecret, kwallet, apple_keychain, windows_credentials"
 
-#: ../build/bin/preferences_gen.h:7233
+#: ../build/bin/preferences_gen.h:4264
 msgid "auto login to storage server"
 msgstr "스토리지 서버 자동 로그인"
 
-#: ../build/bin/preferences_gen.h:7246
-msgid "automatically login to the configured storage server. this requires that a password storage backend is set."
+#: ../build/bin/preferences_gen.h:4272
+msgid ""
+"automatically login to the configured storage server. this requires that a "
+"password storage backend is set."
 msgstr "설정된 저장소 서버에 자동으로 로그인합니다. 비밀번호 저장 백엔드가 설정되어 있어야 합니다."
 
-#: ../build/bin/preferences_gen.h:7267
+#: ../build/bin/preferences_gen.h:4281
 msgid "executable for playing audio files"
 msgstr "오디오 파일 재생 실행 파일"
 
-#: ../build/bin/preferences_gen.h:7285
-msgid "this external program is used to play audio files some cameras record to keep notes for images"
+#: ../build/bin/preferences_gen.h:4294
+msgid ""
+"this external program is used to play audio files some cameras record to "
+"keep notes for images"
 msgstr "일부 카메라가 이미지 메모용으로 녹음한 오디오 파일을 재생하는 데 사용되는 외부 프로그램입니다"
 
-#: ../build/bin/preferences_gen.h:7312
+#: ../build/bin/preferences_gen.h:4304
 msgid "storage"
 msgstr "저장공간"
 
-#: ../build/bin/preferences_gen.h:7314 ../src/control/crawler.c:746
+#: ../build/bin/preferences_gen.h:4309 ../src/control/crawler.c:747
 msgid "database"
 msgstr "데이터베이스"
 
-#: ../build/bin/preferences_gen.h:7333
+#: ../build/bin/preferences_gen.h:4319
 msgid "allow for multiple workspaces"
 msgstr "여러개의 워크스페이스 허용"
 
-#: ../build/bin/preferences_gen.h:7346
+#: ../build/bin/preferences_gen.h:4327
 msgid "allow multiple workspaces which can be selected at startup"
 msgstr "시작 시 선택할 수 있는 여러 워크스페이스 허용"
 
-#: ../build/bin/preferences_gen.h:7367
+#: ../build/bin/preferences_gen.h:4336
 msgid "create database snapshot"
 msgstr "데이터베이스 스냅샷 생성"
 
-#: ../build/bin/preferences_gen.h:7381
+#: ../build/bin/preferences_gen.h:4345
 msgid ""
-"database snapshots are created right before closing darktable. options allow you to choose how often to make snapshots:\n"
-" - 'never': simply don't do snapshots. that way the only snapshots done are mandatory version-upgrade snapshots\n"
-" - 'once a month': create snapshot if a month has passed since last snapshot\n"
+"database snapshots are created right before closing darktable. options allow "
+"you to choose how often to make snapshots:\n"
+" - 'never': simply don't do snapshots. that way the only snapshots done are "
+"mandatory version-upgrade snapshots\n"
+" - 'once a month': create snapshot if a month has passed since last "
+"snapshot\n"
 " - 'once a week': create snapshot if 7 days had passed since last snapshot\n"
 " - 'once a day': create snapshot if over 24h passed since last snapshot\n"
 " - 'on close': create snapshot every time darktable is closed"
@@ -1765,188 +1964,301 @@ msgstr ""
 " - '하루에 한 번': 마지막 스냅샷 이후 24시간이 지나면 생성\n"
 " - '종료 시': darktable을 종료할 때마다 생성"
 
-#: ../build/bin/preferences_gen.h:7402
+#: ../build/bin/preferences_gen.h:4354
 msgid "how many snapshots to keep"
 msgstr "스냅샷 보관 개수"
 
-#: ../build/bin/preferences_gen.h:7425
+#: ../build/bin/preferences_gen.h:4372
 msgid ""
-"after successfully creating snapshot, how many older snapshots to keep (excluding mandatory version update ones). enter -1 to keep all snapshots\n"
-"keep in mind that snapshots do take some space and you only need the most recent one for successful restore"
+"after successfully creating snapshot, how many older snapshots to keep "
+"(excluding mandatory version update ones). enter -1 to keep all snapshots\n"
+"keep in mind that snapshots do take some space and you only need the most "
+"recent one for successful restore"
 msgstr ""
 "스냅샷 생성 후 이전 스냅샷을 몇 개까지 보관할지 설정합니다. (필수 버전 업그레이드 스냅샷 제외). 모두 보관하려면 -1을 입력하세요.\n"
 "스냅샷은 저장 공간을 차지하므로, 복원을 위해 가장 최근 스냅샷만 있으면 됩니다"
 
-#: ../build/bin/preferences_gen.h:7434 ../src/libs/copy_history.c:148
+#: ../build/bin/preferences_gen.h:4378 ../src/libs/copy_history.c:148
 msgid "XMP sidecar files"
 msgstr "XMP 사이드카 파일"
 
-#: ../build/bin/preferences_gen.h:7453
+#: ../build/bin/preferences_gen.h:4388
 msgid "create XMP files"
 msgstr "XMP 파일 생성"
 
-#: ../build/bin/preferences_gen.h:7467
+#: ../build/bin/preferences_gen.h:4397
 msgid ""
-"XMP sidecar files hold information about all your development steps to allow flawless re-importing of image files.\n"
+"XMP sidecar files store all editing steps, ratings, tags and color labels "
+"alongside your images in an open format readable by other applications, and "
+"provide an emergency backup if the database and its backups are lost\n"
 "\n"
-"depending on the selected mode sidecar files will be created:\n"
-" - 'never': all development information will be stored only in the library database\n"
-" - 'on import': immediately after importing the image\n"
-" - 'after edit': after any user change on the image or adding tags."
+"<b>never:</b> information is stored only in darktable's database; if it is "
+"lost or corrupted, your edits cannot be recovered from the files\n"
+"\n"
+"<b>after edit:</b> the XMP file is created after the first intentional "
+"(i.e., non auto-applied) edit and updated after each editing session\n"
+"\n"
+"<b>on import:</b> an XMP file is created when the image is imported, and "
+"updated after each change"
 msgstr ""
-"XMP 사이드카 파일에는 모든 보정 단계 정보가 저장되어 이미지 파일을 완벽하게 다시 가져올 수 있습니다.\n"
+"XMP 사이드카 파일은 모든 편집 단계, 등급, 태그, 색상 라벨을 다른 응용 프로그램에서도 읽을 수 있는 공개 형식으로 이미지와 함께 저장하며, 데이터베이스와 그 백업이 모두 손실된 경우 비상 백업 역할을 합니다\n"
 "\n"
-"선택한 모드에 따라 사이드카 파일이 생성됩니다:\n"
-" - '안 함': 모든 보정 정보가 라이브러리 데이터베이스에만 저장됩니다\n"
-" - '가져오기 시': 이미지를 가져오자마자 생성됩니다\n"
-" - '편집 후': 이미지에 변경을 하거나 태그를 추가한 후 생성됩니다."
+"<b>사용 안함:</b> 정보가 darktable의 데이터베이스에만 저장됩니다. 데이터베이스가 손실되거나 손상되면 편집 내용을 파일에서 복구할 수 없습니다\n"
+"\n"
+"<b>편집 후:</b> 첫 번째 의도적인(즉, 자동 적용이 아닌) 편집 후에 XMP 파일이 생성되고 이후 각 편집 세션이 끝날 때마다 업데이트됩니다\n"
+"\n"
+"<b>가져오기:</b> 이미지를 가져올 때 XMP 파일이 생성되고 변경할 때마다 업데이트됩니다"
 
-#: ../build/bin/preferences_gen.h:7488
+#: ../build/bin/preferences_gen.h:4406
 msgid "store XMP tags in compressed format"
 msgstr "XMP 태그를 압축 형식으로 저장"
 
-#: ../build/bin/preferences_gen.h:7502
+#: ../build/bin/preferences_gen.h:4415
 msgid ""
-"entries in XMP tags can get rather large and may exceed the available space to store the history stack in output files.\n"
+"entries in XMP tags can get rather large and may exceed the available space "
+"to store the history stack in output files.\n"
 "this option allows XMP tags to be compressed and save space."
 msgstr ""
 "XMP 태그의 항목이 매우 커질 수 있어, 출력 파일에 히스토리 스택을 저장할 공간을 초과할 수 있습니다.\n"
 "이 옵션을 사용하면 XMP 태그를 압축하여 공간을 절약할 수 있습니다."
 
-#: ../build/bin/preferences_gen.h:7523
+#: ../build/bin/preferences_gen.h:4424
 msgid "auto-save interval"
 msgstr "자동 저장 간격"
 
-#: ../build/bin/preferences_gen.h:7546
-msgid "automatically save history while developing using the given interval (in seconds); set to zero to disable auto-saving. auto-saving might be disabled on slow drives."
+#: ../build/bin/preferences_gen.h:4442
+msgid ""
+"automatically save history while developing using the given interval (in "
+"seconds); set to zero to disable auto-saving. auto-saving might be disabled "
+"on slow drives."
 msgstr "지정한 간격(초)마다 현상 작업 히스토리를 자동 저장합니다. 0으로 설정하면 자동 저장이 비활성화됩니다. 느린 드라이브에서는 자동 저장이 비활성화될 수 있습니다."
 
-#: ../build/bin/preferences_gen.h:7567
+#: ../build/bin/preferences_gen.h:4451
 msgid "look for updated XMP files on startup"
 msgstr "시작 시 XMP 파일 변경 여부 확인"
 
-#: ../build/bin/preferences_gen.h:7580
-msgid "check file modification times of all XMP files on startup to check if any got updated in the meantime"
+#: ../build/bin/preferences_gen.h:4459
+msgid ""
+"check file modification times of all XMP files on startup to check if any "
+"got updated in the meantime"
 msgstr "시작 시 모든 XMP 파일의 수정 시간을 확인하여 변경된 파일이 있는지 검사합니다"
 
-#: ../build/bin/preferences_gen.h:7607
+#: ../build/bin/preferences_gen.h:4469
 msgid "miscellaneous"
 msgstr "기타"
 
-#: ../build/bin/preferences_gen.h:7609
+#: ../build/bin/preferences_gen.h:4474
 msgid "interface"
 msgstr "인터페이스"
 
-#: ../build/bin/preferences_gen.h:7628
+#: ../build/bin/preferences_gen.h:4484
 msgid "show splash screen at startup"
 msgstr "시작 시 스플래시 화면 표시"
 
-#: ../build/bin/preferences_gen.h:7641
-msgid "display a small window showing the progress of darktable startup before the main window appears"
+#: ../build/bin/preferences_gen.h:4492
+msgid ""
+"display a small window showing the progress of darktable startup before the "
+"main window appears"
 msgstr "darktable이 시작될 때 메인 창이 나타나기 전에 진행 상황을 보여주는 작은 창을 표시합니다"
 
-#: ../build/bin/preferences_gen.h:7662
+#: ../build/bin/preferences_gen.h:4501
+msgid "show welcome screen on next run"
+msgstr "다음 실행 시 시작 화면 표시"
+
+#: ../build/bin/preferences_gen.h:4509
+msgid "display the welcome setup screen the next time darktable is launched"
+msgstr "darktable을 다음에 시작할 때 시작 설정 화면을 표시합니다"
+
+#: ../build/bin/preferences_gen.h:4518
 msgid "load default shortcuts at startup"
 msgstr "시작 시 기본 단축키 불러오기"
 
-#: ../build/bin/preferences_gen.h:7675
-msgid "load default shortcuts before user settings. switch off to prevent deleted defaults returning"
+#: ../build/bin/preferences_gen.h:4526
+msgid ""
+"load default shortcuts before user settings. switch off to prevent deleted "
+"defaults returning"
 msgstr "사용자 설정 전에 기본 단축키를 불러옵니다. 비활성화하면 삭제한 기본값이 다시 나타나지 않습니다"
 
-#: ../build/bin/preferences_gen.h:7696
+#: ../build/bin/preferences_gen.h:4535
 msgid "scale slider step with min/max"
 msgstr "슬라이더 단계 min/max에 맞춤"
 
-#: ../build/bin/preferences_gen.h:7709
+#: ../build/bin/preferences_gen.h:4543
 msgid "vary slider step size with min/max range"
 msgstr "슬라이더 단계 크기를 min/max 범위에 따라 조정"
 
-#: ../build/bin/preferences_gen.h:7730
+#: ../build/bin/preferences_gen.h:4552
 msgid "marker shape"
 msgstr "마커 모양"
 
-#: ../build/bin/preferences_gen.h:7744
+#: ../build/bin/preferences_gen.h:4561
 msgid "the shape of the slider marker"
 msgstr "슬라이더 마커의 모양"
 
-#: ../build/bin/preferences_gen.h:7765
+#: ../build/bin/preferences_gen.h:4570
+msgid "condensed panels' controls"
+msgstr "압축된 패널 컨트롤"
+
+#: ../build/bin/preferences_gen.h:4578
+msgid "use condensed panels' controls in all views"
+msgstr "모든 표시에서 압축된 패널 컨트롤 사용"
+
+#: ../build/bin/preferences_gen.h:4587
+msgid "automatically update module name"
+msgstr "모듈 이름 자동 업데이트"
+
+#: ../build/bin/preferences_gen.h:4595
+msgid ""
+"if enabled, the module name will be automatically updated to match a preset "
+"name or a preset instance name if present."
+msgstr "활성화하면 모듈 이름이 프리셋 이름 또는 프리셋 인스턴스 이름과자동으로 일치하도록 업데이트됩니다."
+
+#: ../build/bin/preferences_gen.h:4604
 msgid "sort built-in presets first"
 msgstr "내장 프리셋을 먼저 정렬"
 
-#: ../build/bin/preferences_gen.h:7778
-msgid "whether to show built-in presets first before user's presets in presets menu."
+#: ../build/bin/preferences_gen.h:4612
+msgid ""
+"whether to show built-in presets first before user's presets in presets menu."
 msgstr "프리셋 메뉴에서 사용자 프리셋보다 내장 프리셋을 먼저 표시할지 여부."
 
-#: ../build/bin/preferences_gen.h:7799
+#: ../build/bin/preferences_gen.h:4621
 msgid "mouse wheel scrolls modules side panel by default"
 msgstr "기본적으로 마우스 휠로 모듈 사이드 패널 스크롤"
 
-#: ../build/bin/preferences_gen.h:7812
-msgid "when enabled, use mouse wheel to scroll modules side panel.  use ctrl+alt to use mouse wheel for data entry.  when disabled, this behavior is reversed"
-msgstr "활성화하면 마우스 휠로 모듈 사이드 패널을 스크롤합니다. ctrl+alt를 누르면 마우스 휠로 값 입력이 가능합니다. 비활성화하면 동작이 반대로 적용됩니다"
+#: ../build/bin/preferences_gen.h:4629
+msgid ""
+"in darktable's darkroom, where you do your edits, all controls are listed on "
+"a panel on the right; you can choose whether you want to use the scroll "
+"wheel or scroll gesture on your touchpad to scroll the panel, or to change "
+"the values of the control under the pointer; this latter modality enables "
+"faster editing, but this can be dangerous because you can change the values ​​"
+"of the module controls without noticing if you are not used to it\n"
+"\n"
+"<b>enabled:</b> the mouse wheel scrolls the modules panel and with "
+"<i>Ctrl+Alt</i> adjusts a control's value\n"
+"\n"
+"<b>disabled:</b> the mouse wheel adjusts the control under the pointer and "
+"with <i>Ctrl+Alt</i> scrolls the panel."
+msgstr ""
+"편집을 수행하는 darktable의 darkroom에서는 모든 컨트롤이 오른쪽 패널에 나열됩니다. 마우스 휠 또는 터치패드의 스크롤 제스처로 패널을 스크롤할지, 아니면 포인터 아래 컨트롤의 값을 변경할지 선택할 수 있습니다. 후자는 편집 속도를 높여 주지만, 익숙하지 않으면 모듈 컨트롤 값을 알아채지 못한 채 변경할 수 있어 위험할 수 있습니다\n"
+"\n"
+"<b>활성화:</b> 마우스 휠이 모듈 패널을 스크롤하고 <i>Ctrl+Alt</i>로 컨트롤 값을 조정합니다\n"
+"\n"
+"<b>비활성화:</b> 마우스 휠이 포인터 아래 컨트롤 값을 조정하고 <i>Ctrl+Alt</i>로 패널을 스크롤합니다."
 
-#: ../build/bin/preferences_gen.h:7833
+#: ../build/bin/preferences_gen.h:4638
+msgid "enable touchpad gestures in darkroom"
+msgstr "darkroom에서 터치패드 제스처 사용"
+
+#: ../build/bin/preferences_gen.h:4646
+msgid ""
+"use two-finger touchpad gestures in darkroom for panning and pinch-to-zoom. "
+"<b>enabled:</b> touchpad pinch gestures zoom the image and two-finger "
+"touchpad scrolling pans it; <i>Ctrl+scroll</i> still uses the legacy zoom "
+"behavior. <b>disabled:</b> touchpad gestures are ignored and darkroom falls "
+"back to the legacy scroll behavior, including <i>Ctrl+scroll</i> for zooming "
+"in and out."
+msgstr "darkroom에서 두 손가락 터치패드 제스처로 화면 이동과 핀치 확대/축소를 사용합니다. <b>활성화:</b> 터치패드 핀치 제스처로 이미지를 확대/축소하고 두 손가락 스크롤로 이동합니다. <i>Ctrl+스크롤</i>은 여전히 기존 확대/축소 방식으로 동작합니다. <b>비활성화:</b> 터치패드 제스처를 무시하고 darkroom은 확대/축소를 위한 <i>Ctrl+스크롤</i>을 포함한 기존 스크롤 동작으로 되돌아갑니다."
+
+#: ../build/bin/preferences_gen.h:4655
+msgid "constrain darkroom zoom between screen fit and 100%"
+msgstr "darkroom 확대/축소를 화면 맞춤과 100% 사이로 제한"
+
+#: ../build/bin/preferences_gen.h:4664
+#, no-c-format
+msgid ""
+"limits scroll-wheel and pinch-to-zoom in the darkroom to the range between "
+"screen fit (zoom out) and 100% (zoom in). <b>enabled:</b> zoom is "
+"constrained; hold <i>Ctrl</i> while zooming to temporarily lift the limit "
+"and zoom beyond 100%. <b>disabled:</b> zoom is never constrained and the "
+"additional <i>Ctrl</i> key press is not needed to zoom beyond 100%."
+msgstr "darkroom에서 스크롤 휠과 핀치 확대/축소를 화면 맞춤(축소)과 100%(확대) 사이의 범위로 제한합니다. <b>활성화:</b> 확대/축소가 제한됩니다. 확대/축소 중 <i>Ctrl</i>을 누르고 있으면 일시적으로 제한이 해제되어 100%를 넘어 확대할 수 있습니다. <b>비활성화:</b> 확대/축소가 전혀 제한되지 않으며 100%를 넘어 확대할 때 <i>Ctrl</i> 키를 누를 필요가 없습니다."
+
+#: ../build/bin/preferences_gen.h:4673
 msgid "always show panels' scrollbars"
 msgstr "패널 스크롤바 항상 표시"
 
-#: ../build/bin/preferences_gen.h:7846
-msgid "defines whether the panel scrollbars should be always visible or activated only depending on the content. (restart required)"
+#: ../build/bin/preferences_gen.h:4681
+msgid ""
+"defines whether the panel scrollbars should be always visible or activated "
+"only depending on the content. (restart required)"
 msgstr "패널 스크롤바를 항상 표시할지, 내용에 따라 표시할지 설정합니다. (재시작 필요)"
 
-#: ../build/bin/preferences_gen.h:7867
+#: ../build/bin/preferences_gen.h:4690
 msgid "duration of the UI transitions in ms"
 msgstr "UI 전환 시간 ms"
 
-#: ../build/bin/preferences_gen.h:7891
-msgid "how long the transitions take (in ms) for expanding or collapsing modules and other UI elements"
+#: ../build/bin/preferences_gen.h:4709
+msgid ""
+"how long the transitions take (in ms) for expanding or collapsing modules "
+"and other UI elements"
 msgstr "모듈이나 기타 UI 요소를 펼침/접힘할 때 전환에 걸리는 시간 (ms)"
 
-#: ../build/bin/preferences_gen.h:7912
+#: ../build/bin/preferences_gen.h:4718
+msgid "auto-scroll filmstrip to center on selected image"
+msgstr "선택한 이미지를 중앙에 맞춰 필름스트립 자동 스크롤"
+
+#: ../build/bin/preferences_gen.h:4726
+msgid ""
+"when enabled, the filmstrip in culling mode and in the darkroom "
+"automatically scrolls to center on the selected image"
+msgstr "활성화하면 선별 모드와 darkroom의 필름스트립이 선택한 이미지를 중앙에 두도록 자동으로 스크롤합니다"
+
+#: ../build/bin/preferences_gen.h:4735
 msgid "position of the scopes module"
 msgstr "스코프 모듈 위치"
 
-#: ../build/bin/preferences_gen.h:7926
+#: ../build/bin/preferences_gen.h:4744
 msgid "position the scopes at the top-left or top-right of the screen"
 msgstr "스코프를 화면 좌측 상단 또는 우측 상단에 배치"
 
-#: ../build/bin/preferences_gen.h:7947
+#: ../build/bin/preferences_gen.h:4753
 msgid "method to use for getting the display profile"
 msgstr "디스플레이 프로파일을 가져오는 방법"
 
-#: ../build/bin/preferences_gen.h:7961
+#: ../build/bin/preferences_gen.h:4762
 msgid ""
-"this option allows to force a specific means of getting the current display profile.\n"
+"this option allows to force a specific means of getting the current display "
+"profile.\n"
 "this is useful when one alternative gives wrong results"
 msgstr ""
 "이 옵션을 사용하면 현재 디스플레이 프로파일을 가져오는 방식을 강제로 지정할 수 있습니다.\n"
 "특정 방식이 잘못된 결과를 줄 때 유용합니다"
 
-#: ../build/bin/preferences_gen.h:7982
+#: ../build/bin/preferences_gen.h:4771
 msgid "order or exclude MIDI devices"
 msgstr "MIDI 장치 순서 지정 또는 제외"
 
-#: ../build/bin/preferences_gen.h:8000
+#: ../build/bin/preferences_gen.h:4784
 msgid ""
-"comma-separated list of device name fragments that if matched load MIDI device at id given by location in list\n"
-"or if preceded by '-' prevent matching devices from loading. add encoding and number of knobs like 'BeatStep:63:16'"
+"comma-separated list of device name fragments that if matched load MIDI "
+"device at id given by location in list\n"
+"add encoding and number of knobs like 'Loupedeck:127,BeatStep:63:16'\n"
+"prefix with '-' to ignore matching devices\n"
+"just '-' stops loading all further devices or on its own disables MIDI "
+"completely"
 msgstr ""
-"쉼표로 구분된 장치 이름 일부의 목록입니다. 목록의 각 항목이 일치할 경우 해당 위치의 id로 지정된 MIDI 장치를 불러옵니다\n"
-"'-'를 앞에 붙이면 해당 장치는 불러오지 않습니다. 'BeatStep:63:16'처럼 인코딩 및 노브 개수도 추가할 수 있습니다."
+"쉼표로 구분된 장치 이름 조각 목록입니다. 일치하면 목록의 위치에 해당하는 id로 MIDI 장치를 로드합니다\n"
+"'Loupedeck:127,BeatStep:63:16'처럼 인코딩과 노브 개수를 추가할 수 있습니다\n"
+"앞에 '-'를 붙이면 일치하는 장치를 무시합니다\n"
+"'-'만 지정하면 이후 모든 장치 로드를 중단하며, 단독으로 사용하면 MIDI를 완전히 비활성화합니다"
 
 #. tags
-#: ../build/bin/preferences_gen.h:8019 ../src/develop/lightroom.c:1573
-#: ../src/gui/import_metadata.c:490 ../src/libs/export_metadata.c:196
+#: ../build/bin/preferences_gen.h:4794 ../src/develop/lightroom.c:1573
+#: ../src/gui/import_metadata.c:519 ../src/libs/export_metadata.c:196
 #: ../src/libs/image.c:622 ../src/libs/metadata_view.c:174
 msgid "tags"
 msgstr "태그"
 
-#: ../build/bin/preferences_gen.h:8038
+#: ../build/bin/preferences_gen.h:4804
 msgid "omit hierarchy in simple tag lists"
 msgstr "단순 태그 목록에서 계층 구조 생략"
 
-#: ../build/bin/preferences_gen.h:8051
+#: ../build/bin/preferences_gen.h:4812
 msgid ""
-"when creating an XMP sidecar file the hierarchical tags are also added as a simple list\n"
+"when creating an XMP sidecar file the hierarchical tags are also added as a "
+"simple list\n"
 "of non-hierarchical ones to make them visible to some other programs.\n"
 "when this option is checked darktable will only include their last part\n"
 "and ignore the rest. so 'foo|bar|baz' will only add 'baz'."
@@ -1956,143 +2268,164 @@ msgstr ""
 "이 옵션을 선택하면 darktable은 마지막 부분만 포함합니다\n"
 "그리고 나머지는 무시합니다. 'foo|bar|baz'의 예시에서 'baz'만 추가됩니다."
 
-#: ../build/bin/preferences_gen.h:8060
+#: ../build/bin/preferences_gen.h:4818
 msgid "shortcuts with multiple instances"
 msgstr "다중 인스턴스 단축키"
 
-#: ../build/bin/preferences_gen.h:8079
+#: ../build/bin/preferences_gen.h:4828
 msgid "prefer focused instance"
 msgstr "포커스된 인스턴스 우선"
 
-#: ../build/bin/preferences_gen.h:8092
+#: ../build/bin/preferences_gen.h:4836
 msgid ""
-"where multiple instances of a module are present, apply shortcuts to the instance that has focus\n"
-"if none are focused, the preferences below control rules that are followed (in order) to decide which module instance shortcuts will be applied to.\n"
+"where multiple instances of a module are present, apply shortcuts to the "
+"instance that has focus\n"
+"if none are focused, the preferences below control rules that are followed "
+"(in order) to decide which module instance shortcuts will be applied to.\n"
 "note: blending shortcuts always apply to the focused instance"
 msgstr ""
 "모듈에 여러 인스턴스가 있을 때, 단축키는 포커스된 인스턴스에 적용됩니다\n"
 "포커스된 인스턴스가 없으면 아래 환경설정에 따라 (순서대로) 단축키가 적용될 모듈 인스턴스가 결정됩니다.\n"
 "참고: 블렌딩 단축키는 항상 포커스된 인스턴스에 적용됩니다"
 
-#: ../build/bin/preferences_gen.h:8113
+#: ../build/bin/preferences_gen.h:4845
 msgid "prefer expanded instances"
 msgstr "확장된 인스턴스 우선"
 
-#: ../build/bin/preferences_gen.h:8126
+#: ../build/bin/preferences_gen.h:4853
 msgid "if instances of the module are expanded, ignore collapsed instances"
 msgstr "모듈 인스턴스가 펼침 되어 있으면, 접힌 인스턴스는 무시합니다"
 
-#: ../build/bin/preferences_gen.h:8147
+#: ../build/bin/preferences_gen.h:4862
 msgid "prefer enabled instances"
 msgstr "활성화된 인스턴스 우선"
 
-#: ../build/bin/preferences_gen.h:8160
-msgid "after applying the above rule, if instances of the module are active, ignore inactive instances"
+#: ../build/bin/preferences_gen.h:4870
+msgid ""
+"after applying the above rule, if instances of the module are active, ignore "
+"inactive instances"
 msgstr "위 규칙 적용 후 모듈 인스턴스가 활성 상태라면 비활성 인스턴스는 무시합니다"
 
-#: ../build/bin/preferences_gen.h:8181
+#: ../build/bin/preferences_gen.h:4879
 msgid "prefer unmasked instances"
 msgstr "마스크 해제된 인스턴스 우선"
 
-#: ../build/bin/preferences_gen.h:8194
-msgid "after applying the above rules, if instances of the module are unmasked, ignore masked instances"
+#: ../build/bin/preferences_gen.h:4887
+msgid ""
+"after applying the above rules, if instances of the module are unmasked, "
+"ignore masked instances"
 msgstr "위 규칙 적용 후 마스크가 해제된 인스턴스가 있으면 마스크된 인스턴스는 무시합니다"
 
-#: ../build/bin/preferences_gen.h:8215
+#: ../build/bin/preferences_gen.h:4896
 msgid "selection order"
 msgstr "선택 순서"
 
-#: ../build/bin/preferences_gen.h:8229
-msgid "after applying the above rules, apply the shortcut based on its position in the pixelpipe"
+#: ../build/bin/preferences_gen.h:4905
+msgid ""
+"after applying the above rules, apply the shortcut based on its position in "
+"the pixelpipe"
 msgstr "위 규칙 적용 후 픽셀 파이프 내 위치에 따라 단축키를 적용합니다"
 
-#: ../build/bin/preferences_gen.h:8250
+#: ../build/bin/preferences_gen.h:4914
 msgid "allow visual assignment to specific instances"
 msgstr "특정 인스턴스에 대한 시각적 할당 허용"
 
-#: ../build/bin/preferences_gen.h:8263
+#: ../build/bin/preferences_gen.h:4922
 msgid ""
-"when multiple instances are present on an image this allows shortcuts to be visually assigned to those specific instances\n"
+"when multiple instances are present on an image this allows shortcuts to be "
+"visually assigned to those specific instances\n"
 "otherwise shortcuts will always be assigned to the preferred instance"
 msgstr ""
 "이미지에 여러 인스턴스가 있을 때, 단축키를 특정 인스턴스에 시각적으로 할당할 수 있습니다.\n"
 "이 옵션이 꺼져 있으면 단축키는 항상 우선 인스턴스에 할당됩니다"
 
-#: ../build/bin/preferences_gen.h:8272
+#: ../build/bin/preferences_gen.h:4928
 msgid "map / geolocalization view"
 msgstr "지도 / 위치 보기"
 
-#: ../build/bin/preferences_gen.h:8291
+#: ../build/bin/preferences_gen.h:4938
 msgid "pretty print the image location"
 msgstr "이미지 위치 정보 가독성 높게 표시"
 
-#: ../build/bin/preferences_gen.h:8304
-msgid "show a more readable representation of the location in the image information module"
+#: ../build/bin/preferences_gen.h:4946
+msgid ""
+"show a more readable representation of the location in the image information "
+"module"
 msgstr "이미지 정보 모듈에서 위치를 더 읽기 쉽게 표시합니다"
 
-#: ../build/bin/preferences_gen.h:8313
+#: ../build/bin/preferences_gen.h:4952
 msgid "slideshow view"
 msgstr "슬라이드쇼 보기"
 
-#: ../build/bin/preferences_gen.h:8332
+#: ../build/bin/preferences_gen.h:4962
 msgid "waiting time between each image in slideshow"
 msgstr "슬라이드쇼 이미지 간 대기 시간"
 
-#: ../build/bin/preferences_gen.h:8391
+#: ../build/bin/preferences_gen.h:5004
 msgid "do not set the 'uncategorized' entry for tags"
 msgstr "'uncategorized' 태그 항목 설정 안 함"
 
-#: ../build/bin/preferences_gen.h:8404
-msgid "do not set the 'uncategorized' entry for tags which do not have children"
+#: ../build/bin/preferences_gen.h:5012
+msgid ""
+"do not set the 'uncategorized' entry for tags which do not have children"
 msgstr "하위 태그가 없는 태그를 'uncategorized' 항목으로 설정하지 않습니다"
 
-#: ../build/bin/preferences_gen.h:8425
+#: ../build/bin/preferences_gen.h:5021
 msgid "tags case sensitivity"
 msgstr "태그 대소문자 구분"
 
-#: ../build/bin/preferences_gen.h:8439
-msgid "tags case sensitivity. without the Sqlite ICU extension, insensitivity works only for the 26 latin letters"
+#: ../build/bin/preferences_gen.h:5030
+msgid ""
+"tags case sensitivity. without the Sqlite ICU extension, insensitivity works "
+"only for the 26 latin letters"
 msgstr "태그 대소문자 구분. Sqlite ICU 확장 없이 비구분 기능은 영문자 26자에만 적용됩니다"
 
-#: ../build/bin/preferences_gen.h:8460 ../build/bin/preferences_gen.h:8602
+#: ../build/bin/preferences_gen.h:5039 ../build/bin/preferences_gen.h:5130
 msgid "number of collections to be stored"
 msgstr "저장할 컬렉션 개수"
 
-#: ../build/bin/preferences_gen.h:8484 ../build/bin/preferences_gen.h:8626
+#: ../build/bin/preferences_gen.h:5058 ../build/bin/preferences_gen.h:5149
 msgid "the number of recent collections to store and show in this list"
 msgstr "이 목록에 저장 및 표시할 최근 컬렉션 개수"
 
-#: ../build/bin/preferences_gen.h:8505
+#: ../build/bin/preferences_gen.h:5067
 msgid "number of folder levels to show in lists"
 msgstr "목록에 표시할 폴더 단계 수"
 
-#: ../build/bin/preferences_gen.h:8529
-msgid "the number of folder levels to show in film roll names, starting from the right"
+#: ../build/bin/preferences_gen.h:5086
+msgid ""
+"the number of folder levels to show in film roll names, starting from the "
+"right"
 msgstr "필름롤 이름에 표시할 폴더 단계 수 (오른쪽부터 시작)"
 
-#: ../build/bin/preferences_gen.h:8550
+#: ../build/bin/preferences_gen.h:5095
 msgid "sort film rolls by"
 msgstr "필름롤 정렬 기준"
 
-#: ../build/bin/preferences_gen.h:8564
+#: ../build/bin/preferences_gen.h:5104
 msgid "sets the collections-list order for film rolls"
 msgstr "필름롤의 컬렉션 목록 정렬 순서 설정"
 
-#: ../build/bin/preferences_gen.h:8681
+#: ../build/bin/preferences_gen.h:5192
 msgid "suggested tags level of confidence"
 msgstr "추천 태그 신뢰도 수준"
 
-#: ../build/bin/preferences_gen.h:8706
+#: ../build/bin/preferences_gen.h:5212
 #, no-c-format
-msgid "level of confidence to include the tag in the suggestions list, 0: all associated tags, 99: 99% matching associated tags, 100: no matching tag to show only recent tags (faster)"
+msgid ""
+"level of confidence to include the tag in the suggestions list, 0: all "
+"associated tags, 99: 99% matching associated tags, 100: no matching tag to "
+"show only recent tags (faster)"
 msgstr "추천 목록에 태그를 포함할 신뢰도 수준입니다. 0: 모든 연관 태그, 99: 99% 일치하는 연관 태그, 100: 일치하는 태그 없이 최근 태그만 표시 (더 빠름)"
 
-#: ../build/bin/preferences_gen.h:8727
+#: ../build/bin/preferences_gen.h:5221
 msgid "number of recently attached tags"
 msgstr "최근에 추가된 태그 개수"
 
-#: ../build/bin/preferences_gen.h:8751
-msgid "number of recently attached tags which are included in the suggestions list. the value `-1' disables the recent list"
+#: ../build/bin/preferences_gen.h:5240
+msgid ""
+"number of recently attached tags which are included in the suggestions list. "
+"the value `-1' disables the recent list"
 msgstr "추천 목록에 포함할 최근 추가 태그의 개수입니다. `-1'로 설정하면 최근 목록이 비활성화됩니다"
 
 #. Not to be compiled, generated for translation only
@@ -2117,15 +2450,15 @@ msgstr "가을"
 #: ../build/lib/darktable/plugins/introspection_colorequal.c:527
 #: ../build/lib/darktable/plugins/introspection_colorequal.c:559
 #: ../build/lib/darktable/plugins/introspection_enlargecanvas.c:161
-#: ../src/common/collection.c:1479 ../src/common/color_vocabulary.c:324
-#: ../src/common/colorlabels.c:383 ../src/develop/blend_gui.c:2392
-#: ../src/develop/blend_gui.c:2440 ../src/develop/lightroom.c:893
-#: ../src/gui/gtk.c:3848 ../src/iop/bilateral.cc:382
+#: ../src/common/collection.c:1483 ../src/common/color_vocabulary.c:324
+#: ../src/common/colorlabels.c:384 ../src/develop/blend_gui.c:2393
+#: ../src/develop/blend_gui.c:2441 ../src/develop/lightroom.c:893
+#: ../src/gui/gtk.c:4106 ../src/iop/bilateral.cc:381
 #: ../src/iop/channelmixer.c:612 ../src/iop/channelmixer.c:632
-#: ../src/iop/channelmixerrgb.c:4619 ../src/iop/colorequal.c:2962
-#: ../src/iop/colorzones.c:2490 ../src/iop/temperature.c:2000
-#: ../src/iop/temperature.c:2184 ../src/libs/collect.c:1964
-#: ../src/libs/filters/colors.c:263 ../src/libs/histogram.c:2611
+#: ../src/iop/channelmixerrgb.c:4647 ../src/iop/colorequal.c:2927
+#: ../src/iop/colorzones.c:2490 ../src/iop/temperature.c:1984
+#: ../src/iop/temperature.c:2169 ../src/libs/collect.c:2044
+#: ../src/libs/filters/colors.c:263 ../src/libs/histogram.c:49
 msgid "blue"
 msgstr "파랑"
 
@@ -2146,7 +2479,9 @@ msgid "colors"
 msgstr "색상"
 
 #: ../build/bin/styles_string.h:11
-msgid "composite four images plus a caption into an image which can be printed borderless on 8.5x11 paper"
+msgid ""
+"composite four images plus a caption into an image which can be printed "
+"borderless on 8.5x11 paper"
 msgstr "4장의 이미지와 캡션을 합성하여 8.5x11 용지에 테두리 없이 인쇄할 수 있는 이미지로 만듭니다"
 
 #: ../build/bin/styles_string.h:12
@@ -2161,14 +2496,14 @@ msgstr "대비 및 선명도"
 #: ../build/lib/darktable/plugins/introspection_colorequal.c:523
 #: ../build/lib/darktable/plugins/introspection_colorequal.c:555
 #: ../src/common/color_vocabulary.c:298 ../src/gui/guides.c:855
-#: ../src/iop/colorequal.c:2961 ../src/iop/temperature.c:1984
+#: ../src/iop/colorequal.c:2926 ../src/iop/temperature.c:1968
 msgid "cyan"
 msgstr "시안"
 
-#: ../build/bin/styles_string.h:14 ../src/libs/collect.c:3364
-#: ../src/libs/filtering.c:921 ../src/libs/filtering.c:980
-#: ../src/libs/filtering.c:1644 ../src/libs/filtering.c:1950
-#: ../src/libs/tools/darktable.c:61
+#: ../build/bin/styles_string.h:14 ../src/libs/collect.c:3723
+#: ../src/libs/filtering.c:925 ../src/libs/filtering.c:986
+#: ../src/libs/filtering.c:1654 ../src/libs/filtering.c:1961
+#: ../src/libs/tools/darktable.c:64
 msgid "darktable"
 msgstr "darktable"
 
@@ -2185,7 +2520,9 @@ msgid "dehaze (strong, luminance only)"
 msgstr "안개 제거 (강하게, 휘도만)"
 
 #: ../build/bin/styles_string.h:18
-msgid "desaturate and darken red pupils in flash photos.  add drawn masks to limit affected areas to just the eyes if necessary."
+msgid ""
+"desaturate and darken red pupils in flash photos.  add drawn masks to limit "
+"affected areas to just the eyes if necessary."
 msgstr "플래시 사진에서 붉은 눈동자를 채도 감소 및 어둡게 처리합니다. 필요하다면 마스크를 추가해 눈동자에만 적용할 수 있습니다."
 
 #: ../build/bin/styles_string.h:19
@@ -2193,7 +2530,7 @@ msgid "effects"
 msgstr "효과"
 
 #: ../build/bin/styles_string.h:20
-#: ../src/external/lua-scripts/tools/script_manager.lua:411
+#: ../src/external/lua-scripts/tools/script_manager.lua:457
 msgid "examples"
 msgstr "예시"
 
@@ -2206,12 +2543,14 @@ msgid "extreme saturation"
 msgstr "극단적 채도"
 
 #. cubic spline
-#: ../build/bin/styles_string.h:23 ../src/iop/filmic.c:1568
+#: ../build/bin/styles_string.h:23 ../src/iop/filmic.c:1585
 msgid "faded"
 msgstr "바랜 효과"
 
 #: ../build/bin/styles_string.h:24
-msgid "fine-tune the selected color by adjusting the 'node placement' slider in color equalizer"
+msgid ""
+"fine-tune the selected color by adjusting the 'node placement' slider in "
+"color equalizer"
 msgstr "컬러 이퀄라이저의 '노드 위치' 슬라이더를 조정해 선택한 색상을 미세 조정"
 
 #: ../build/bin/styles_string.h:25
@@ -2233,16 +2572,16 @@ msgstr "일반"
 #: ../build/lib/darktable/plugins/introspection_colorequal.c:519
 #: ../build/lib/darktable/plugins/introspection_colorequal.c:551
 #: ../build/lib/darktable/plugins/introspection_enlargecanvas.c:159
-#: ../src/common/collection.c:1477 ../src/common/color_vocabulary.c:277
-#: ../src/common/colorlabels.c:382 ../src/develop/blend_gui.c:2386
-#: ../src/develop/blend_gui.c:2434 ../src/develop/lightroom.c:891
-#: ../src/gui/gtk.c:3847 ../src/gui/guides.c:853 ../src/iop/bilateral.cc:377
+#: ../src/common/collection.c:1481 ../src/common/color_vocabulary.c:277
+#: ../src/common/colorlabels.c:383 ../src/develop/blend_gui.c:2387
+#: ../src/develop/blend_gui.c:2435 ../src/develop/lightroom.c:891
+#: ../src/gui/gtk.c:4105 ../src/gui/guides.c:853 ../src/iop/bilateral.cc:376
 #: ../src/iop/channelmixer.c:611 ../src/iop/channelmixer.c:626
-#: ../src/iop/channelmixerrgb.c:4618 ../src/iop/colorequal.c:2960
-#: ../src/iop/colorzones.c:2488 ../src/iop/temperature.c:1980
-#: ../src/iop/temperature.c:1998 ../src/iop/temperature.c:2183
-#: ../src/libs/collect.c:1964 ../src/libs/filters/colors.c:262
-#: ../src/libs/histogram.c:2620
+#: ../src/iop/channelmixerrgb.c:4646 ../src/iop/colorequal.c:2925
+#: ../src/iop/colorzones.c:2488 ../src/iop/temperature.c:1964
+#: ../src/iop/temperature.c:1982 ../src/iop/temperature.c:2168
+#: ../src/libs/collect.c:2044 ../src/libs/filters/colors.c:262
+#: ../src/libs/histogram.c:48
 msgid "green"
 msgstr "녹색"
 
@@ -2254,8 +2593,8 @@ msgstr "녹색"
 #: ../build/lib/darktable/plugins/introspection_colorequal.c:535
 #: ../build/lib/darktable/plugins/introspection_colorequal.c:567
 #: ../src/common/color_vocabulary.c:341 ../src/gui/guides.c:856
-#: ../src/iop/colorequal.c:2964 ../src/iop/colorzones.c:2492
-#: ../src/iop/temperature.c:1982
+#: ../src/iop/colorequal.c:2929 ../src/iop/colorzones.c:2492
+#: ../src/iop/temperature.c:1966
 msgid "magenta"
 msgstr "마젠타"
 
@@ -2264,7 +2603,9 @@ msgid "make a photo taken in daylight look like it was taken in twilight"
 msgstr "낮에 촬영한 사진을 해질녘에 촬영한 것처럼 보이게 만듭니다"
 
 #: ../build/bin/styles_string.h:30
-msgid "make a photo taken in full daylight look like it was taken at night.  emulates the cinematic technique of the same name."
+msgid ""
+"make a photo taken in full daylight look like it was taken at night.  "
+"emulates the cinematic technique of the same name."
 msgstr "밝은 낮에 찍은 사진을 밤에 촬영한 것처럼 만듭니다. 영화 촬영에서 사용하는 기법을 모방합니다."
 
 #: ../build/bin/styles_string.h:31
@@ -2278,7 +2619,7 @@ msgstr "모션 블러"
 #: ../build/lib/darktable/plugins/introspection_colorequal.c:479
 #: ../build/lib/darktable/plugins/introspection_colorequal.c:511
 #: ../build/lib/darktable/plugins/introspection_colorequal.c:543
-#: ../src/iop/colorequal.c:2958 ../src/iop/colorzones.c:2486
+#: ../src/iop/colorequal.c:2923 ../src/iop/colorzones.c:2486
 msgid "orange"
 msgstr "주황"
 
@@ -2286,9 +2627,9 @@ msgstr "주황"
 msgid "pastels"
 msgstr "파스텔"
 
-#: ../build/bin/styles_string.h:34 ../src/common/collection.c:1481
-#: ../src/common/color_vocabulary.c:339 ../src/common/colorlabels.c:384
-#: ../src/iop/colorzones.c:2491 ../src/libs/collect.c:1964
+#: ../build/bin/styles_string.h:34 ../src/common/collection.c:1485
+#: ../src/common/color_vocabulary.c:339 ../src/common/colorlabels.c:385
+#: ../src/iop/colorzones.c:2491 ../src/libs/collect.c:2044
 #: ../src/libs/filters/colors.c:264
 msgid "purple"
 msgstr "보라"
@@ -2302,15 +2643,15 @@ msgstr "보라"
 #: ../build/lib/darktable/plugins/introspection_colorequal.c:507
 #: ../build/lib/darktable/plugins/introspection_colorequal.c:539
 #: ../build/lib/darktable/plugins/introspection_enlargecanvas.c:160
-#: ../src/common/collection.c:1473 ../src/common/color_vocabulary.c:232
-#: ../src/common/colorlabels.c:380 ../src/develop/blend_gui.c:2380
-#: ../src/develop/blend_gui.c:2428 ../src/develop/lightroom.c:887
-#: ../src/gui/gtk.c:3846 ../src/gui/guides.c:852 ../src/iop/bilateral.cc:372
+#: ../src/common/collection.c:1477 ../src/common/color_vocabulary.c:232
+#: ../src/common/colorlabels.c:381 ../src/develop/blend_gui.c:2381
+#: ../src/develop/blend_gui.c:2429 ../src/develop/lightroom.c:887
+#: ../src/gui/gtk.c:4104 ../src/gui/guides.c:852 ../src/iop/bilateral.cc:371
 #: ../src/iop/channelmixer.c:610 ../src/iop/channelmixer.c:620
-#: ../src/iop/channelmixerrgb.c:4617 ../src/iop/colorequal.c:2957
-#: ../src/iop/colorzones.c:2485 ../src/iop/temperature.c:1996
-#: ../src/iop/temperature.c:2182 ../src/libs/collect.c:1964
-#: ../src/libs/filters/colors.c:260 ../src/libs/histogram.c:2629
+#: ../src/iop/channelmixerrgb.c:4645 ../src/iop/colorequal.c:2922
+#: ../src/iop/colorzones.c:2485 ../src/iop/temperature.c:1980
+#: ../src/iop/temperature.c:2167 ../src/libs/collect.c:2044
+#: ../src/libs/filters/colors.c:260 ../src/libs/histogram.c:47
 msgid "red"
 msgstr "빨강"
 
@@ -2341,10 +2682,10 @@ msgstr "스팟 컬러"
 #: ../build/lib/darktable/plugins/introspection_colorequal.c:483
 #: ../build/lib/darktable/plugins/introspection_colorequal.c:515
 #: ../build/lib/darktable/plugins/introspection_colorequal.c:547
-#: ../src/common/collection.c:1475 ../src/common/colorlabels.c:381
+#: ../src/common/collection.c:1479 ../src/common/colorlabels.c:382
 #: ../src/develop/lightroom.c:889 ../src/gui/guides.c:854
-#: ../src/iop/colorequal.c:2959 ../src/iop/colorzones.c:2487
-#: ../src/iop/temperature.c:1986 ../src/libs/collect.c:1964
+#: ../src/iop/colorequal.c:2924 ../src/iop/colorzones.c:2487
+#: ../src/iop/temperature.c:1970 ../src/libs/collect.c:2044
 #: ../src/libs/filters/colors.c:261
 msgid "yellow"
 msgstr "노랑"
@@ -2369,283 +2710,284 @@ msgstr "통합 기여자"
 msgid "lua-scripts contributors"
 msgstr "lua-scripts 기여자"
 
-#: ../build/lib/darktable/plugins/introspection_agx.c:247
-#: ../build/lib/darktable/plugins/introspection_agx.c:500
+#: ../build/lib/darktable/plugins/introspection_agx.c:245
+#: ../build/lib/darktable/plugins/introspection_agx.c:498
 #: ../src/iop/colorbalancergb.c:1899
 msgid "lift"
 msgstr "리프트"
 
-#: ../build/lib/darktable/plugins/introspection_agx.c:253
-#: ../build/lib/darktable/plugins/introspection_agx.c:504
+#: ../build/lib/darktable/plugins/introspection_agx.c:251
+#: ../build/lib/darktable/plugins/introspection_agx.c:502
 msgid "slope"
 msgstr "슬로프"
 
-#: ../build/lib/darktable/plugins/introspection_agx.c:259
-#: ../build/lib/darktable/plugins/introspection_agx.c:508
+#: ../build/lib/darktable/plugins/introspection_agx.c:257
+#: ../build/lib/darktable/plugins/introspection_agx.c:506
 #: ../build/lib/darktable/plugins/introspection_retouch.c:285
 #: ../build/lib/darktable/plugins/introspection_retouch.c:426
-#: ../src/iop/basicadj.c:644 ../src/iop/channelmixerrgb.c:4625
-#: ../src/iop/colisa.c:278 ../src/iop/colorequal.c:3103
-#: ../src/iop/lowpass.c:577 ../src/iop/soften.c:389 ../src/iop/vignette.c:1045
+#: ../src/iop/basicadj.c:643 ../src/iop/channelmixerrgb.c:4653
+#: ../src/iop/colisa.c:273 ../src/iop/colorequal.c:3066
+#: ../src/iop/lowpass.c:575 ../src/iop/soften.c:380 ../src/iop/vignette.c:1045
 #: ../src/libs/history.c:959
 msgid "brightness"
 msgstr "밝기"
 
-#: ../build/lib/darktable/plugins/introspection_agx.c:265
-#: ../build/lib/darktable/plugins/introspection_agx.c:512
+#: ../build/lib/darktable/plugins/introspection_agx.c:263
+#: ../build/lib/darktable/plugins/introspection_agx.c:510
 #: ../build/lib/darktable/plugins/introspection_graduatednd.c:93
 #: ../build/lib/darktable/plugins/introspection_graduatednd.c:156
 #: ../build/lib/darktable/plugins/introspection_splittoning.c:67
 #: ../build/lib/darktable/plugins/introspection_splittoning.c:79
 #: ../build/lib/darktable/plugins/introspection_splittoning.c:138
 #: ../build/lib/darktable/plugins/introspection_splittoning.c:146
-#: ../src/develop/blend_gui.c:2360 ../src/iop/basicadj.c:648
-#: ../src/iop/channelmixer.c:608 ../src/iop/colisa.c:279
+#: ../src/develop/blend_gui.c:2361 ../src/iop/basicadj.c:647
+#: ../src/iop/channelmixer.c:608 ../src/iop/colisa.c:274
 #: ../src/iop/colorbalance.c:1953 ../src/iop/colorbalancergb.c:1827
 #: ../src/iop/colorchecker.c:1602 ../src/iop/colorcontrast.c:79
-#: ../src/iop/colorcorrection.c:260 ../src/iop/colorequal.c:3085
-#: ../src/iop/colorize.c:347 ../src/iop/lowpass.c:578 ../src/iop/soften.c:385
-#: ../src/iop/velvia.c:73 ../src/iop/vibrance.c:69 ../src/iop/vignette.c:1046
+#: ../src/iop/colorcorrection.c:260 ../src/iop/colorequal.c:3048
+#: ../src/iop/colorharmonizer.c:1605 ../src/iop/colorize.c:358
+#: ../src/iop/lowpass.c:576 ../src/iop/soften.c:376 ../src/iop/velvia.c:73
+#: ../src/iop/vibrance.c:69 ../src/iop/vignette.c:1046
 msgid "saturation"
 msgstr "채도"
 
-#: ../build/lib/darktable/plugins/introspection_agx.c:271
-#: ../build/lib/darktable/plugins/introspection_agx.c:516
+#: ../build/lib/darktable/plugins/introspection_agx.c:269
+#: ../build/lib/darktable/plugins/introspection_agx.c:514
 #: ../build/lib/darktable/plugins/introspection_sigmoid.c:146
 #: ../build/lib/darktable/plugins/introspection_sigmoid.c:257
 msgid "preserve hue"
 msgstr "색조 보존"
 
-#: ../build/lib/darktable/plugins/introspection_agx.c:277
-#: ../build/lib/darktable/plugins/introspection_agx.c:520
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:218
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:427
+#: ../build/lib/darktable/plugins/introspection_agx.c:275
+#: ../build/lib/darktable/plugins/introspection_agx.c:518
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:219
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:428
 #: ../build/lib/darktable/plugins/introspection_profile_gamma.c:97
 #: ../build/lib/darktable/plugins/introspection_profile_gamma.c:166
-#: ../src/iop/filmic.c:1490
+#: ../src/iop/filmic.c:1493
 msgid "black relative exposure"
 msgstr "검정 상대 노출"
 
-#: ../build/lib/darktable/plugins/introspection_agx.c:283
-#: ../build/lib/darktable/plugins/introspection_agx.c:524
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:224
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:431
-#: ../src/iop/filmic.c:1478
+#: ../build/lib/darktable/plugins/introspection_agx.c:281
+#: ../build/lib/darktable/plugins/introspection_agx.c:522
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:225
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:432
+#: ../src/iop/filmic.c:1480
 msgid "white relative exposure"
 msgstr "흰색 상대 노출"
 
-#: ../build/lib/darktable/plugins/introspection_agx.c:289
-#: ../build/lib/darktable/plugins/introspection_agx.c:528
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:260
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:455
+#: ../build/lib/darktable/plugins/introspection_agx.c:287
+#: ../build/lib/darktable/plugins/introspection_agx.c:526
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:261
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:456
 msgid "dynamic range scaling"
 msgstr "다이나믹 레인지 스케일링"
 
-#: ../build/lib/darktable/plugins/introspection_agx.c:295
-#: ../build/lib/darktable/plugins/introspection_agx.c:532
+#: ../build/lib/darktable/plugins/introspection_agx.c:293
+#: ../build/lib/darktable/plugins/introspection_agx.c:530
 msgid "pivot relative exposure"
 msgstr "피봇 상대 노출"
 
-#: ../build/lib/darktable/plugins/introspection_agx.c:301
-#: ../build/lib/darktable/plugins/introspection_agx.c:536
+#: ../build/lib/darktable/plugins/introspection_agx.c:299
+#: ../build/lib/darktable/plugins/introspection_agx.c:534
 msgid "pivot target output"
 msgstr "피봇 대상 출력"
 
-#: ../build/lib/darktable/plugins/introspection_agx.c:307
-#: ../build/lib/darktable/plugins/introspection_agx.c:540
+#: ../build/lib/darktable/plugins/introspection_agx.c:305
+#: ../build/lib/darktable/plugins/introspection_agx.c:538
 #: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:412
 #: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:585
 #: ../build/lib/darktable/plugins/introspection_colorequal.c:230
 #: ../build/lib/darktable/plugins/introspection_colorequal.c:455
 #: ../build/lib/darktable/plugins/introspection_sigmoid.c:116
 #: ../build/lib/darktable/plugins/introspection_sigmoid.c:237
-#: ../src/gui/guides.c:862 ../src/iop/basicadj.c:631 ../src/iop/bilat.c:468
-#: ../src/iop/colisa.c:277 ../src/iop/colorbalance.c:1889
-#: ../src/iop/colorbalance.c:1895 ../src/iop/filmic.c:1519
-#: ../src/iop/filmicrgb.c:4507 ../src/iop/lowpass.c:576
+#: ../src/gui/guides.c:862 ../src/iop/basicadj.c:630 ../src/iop/bilat.c:464
+#: ../src/iop/colisa.c:272 ../src/iop/colorbalance.c:1889
+#: ../src/iop/colorbalance.c:1895 ../src/iop/filmic.c:1527
+#: ../src/iop/filmicrgb.c:4495 ../src/iop/lowpass.c:574
 msgid "contrast"
 msgstr "대비"
 
-#: ../build/lib/darktable/plugins/introspection_agx.c:313
-#: ../build/lib/darktable/plugins/introspection_agx.c:544
+#: ../build/lib/darktable/plugins/introspection_agx.c:311
+#: ../build/lib/darktable/plugins/introspection_agx.c:542
 msgid "toe start"
 msgstr "toe 스타트"
 
-#: ../build/lib/darktable/plugins/introspection_agx.c:319
-#: ../build/lib/darktable/plugins/introspection_agx.c:548
+#: ../build/lib/darktable/plugins/introspection_agx.c:317
+#: ../build/lib/darktable/plugins/introspection_agx.c:546
 msgid "shoulder start"
 msgstr "숄더 시작"
 
-#: ../build/lib/darktable/plugins/introspection_agx.c:325
-#: ../build/lib/darktable/plugins/introspection_agx.c:552
+#: ../build/lib/darktable/plugins/introspection_agx.c:323
+#: ../build/lib/darktable/plugins/introspection_agx.c:550
 msgid "toe power"
 msgstr "toe 파워"
 
-#: ../build/lib/darktable/plugins/introspection_agx.c:331
-#: ../build/lib/darktable/plugins/introspection_agx.c:556
+#: ../build/lib/darktable/plugins/introspection_agx.c:329
+#: ../build/lib/darktable/plugins/introspection_agx.c:554
 msgid "shoulder power"
 msgstr "숄더 파워"
 
-#: ../build/lib/darktable/plugins/introspection_agx.c:337
-#: ../build/lib/darktable/plugins/introspection_agx.c:560
+#: ../build/lib/darktable/plugins/introspection_agx.c:335
+#: ../build/lib/darktable/plugins/introspection_agx.c:558
 msgid "curve y gamma"
 msgstr "커브 y 감마"
 
-#: ../build/lib/darktable/plugins/introspection_agx.c:343
-#: ../build/lib/darktable/plugins/introspection_agx.c:564
+#: ../build/lib/darktable/plugins/introspection_agx.c:341
+#: ../build/lib/darktable/plugins/introspection_agx.c:562
 msgid "keep the pivot on the diagonal"
 msgstr "대각선 방향으로 피봇 유지"
 
-#: ../build/lib/darktable/plugins/introspection_agx.c:349
-#: ../build/lib/darktable/plugins/introspection_agx.c:568
+#: ../build/lib/darktable/plugins/introspection_agx.c:347
+#: ../build/lib/darktable/plugins/introspection_agx.c:566
 #: ../build/lib/darktable/plugins/introspection_sigmoid.c:134
 #: ../build/lib/darktable/plugins/introspection_sigmoid.c:249
 msgid "target black"
 msgstr "지정 검정"
 
-#: ../build/lib/darktable/plugins/introspection_agx.c:355
-#: ../build/lib/darktable/plugins/introspection_agx.c:572
+#: ../build/lib/darktable/plugins/introspection_agx.c:353
+#: ../build/lib/darktable/plugins/introspection_agx.c:570
 #: ../build/lib/darktable/plugins/introspection_sigmoid.c:128
 #: ../build/lib/darktable/plugins/introspection_sigmoid.c:245
 msgid "target white"
 msgstr "지정 흰색"
 
-#: ../build/lib/darktable/plugins/introspection_agx.c:361
-#: ../build/lib/darktable/plugins/introspection_agx.c:576
+#: ../build/lib/darktable/plugins/introspection_agx.c:359
+#: ../build/lib/darktable/plugins/introspection_agx.c:574
 #: ../build/lib/darktable/plugins/introspection_sigmoid.c:194
 #: ../build/lib/darktable/plugins/introspection_sigmoid.c:289
 msgid "base primaries"
 msgstr "기반 기본색상"
 
-#: ../build/lib/darktable/plugins/introspection_agx.c:367
-#: ../build/lib/darktable/plugins/introspection_agx.c:580
+#: ../build/lib/darktable/plugins/introspection_agx.c:365
+#: ../build/lib/darktable/plugins/introspection_agx.c:578
 msgid "disable adjustments"
 msgstr "조정 비활성화"
 
-#: ../build/lib/darktable/plugins/introspection_agx.c:373
-#: ../build/lib/darktable/plugins/introspection_agx.c:584
+#: ../build/lib/darktable/plugins/introspection_agx.c:371
+#: ../build/lib/darktable/plugins/introspection_agx.c:582
 #: ../build/lib/darktable/plugins/introspection_sigmoid.c:152
 #: ../build/lib/darktable/plugins/introspection_sigmoid.c:261
 msgid "red attenuation"
 msgstr "빨강 감쇠"
 
-#: ../build/lib/darktable/plugins/introspection_agx.c:379
-#: ../build/lib/darktable/plugins/introspection_agx.c:588
+#: ../build/lib/darktable/plugins/introspection_agx.c:377
+#: ../build/lib/darktable/plugins/introspection_agx.c:586
 #: ../build/lib/darktable/plugins/introspection_sigmoid.c:158
 #: ../build/lib/darktable/plugins/introspection_sigmoid.c:265
 msgid "red rotation"
 msgstr "빨강 회전"
 
-#: ../build/lib/darktable/plugins/introspection_agx.c:385
-#: ../build/lib/darktable/plugins/introspection_agx.c:592
+#: ../build/lib/darktable/plugins/introspection_agx.c:383
+#: ../build/lib/darktable/plugins/introspection_agx.c:590
 #: ../build/lib/darktable/plugins/introspection_sigmoid.c:164
 #: ../build/lib/darktable/plugins/introspection_sigmoid.c:269
 msgid "green attenuation"
 msgstr "녹색 감쇠"
 
-#: ../build/lib/darktable/plugins/introspection_agx.c:391
-#: ../build/lib/darktable/plugins/introspection_agx.c:596
+#: ../build/lib/darktable/plugins/introspection_agx.c:389
+#: ../build/lib/darktable/plugins/introspection_agx.c:594
 #: ../build/lib/darktable/plugins/introspection_sigmoid.c:170
 #: ../build/lib/darktable/plugins/introspection_sigmoid.c:273
 msgid "green rotation"
 msgstr "녹색 회전"
 
-#: ../build/lib/darktable/plugins/introspection_agx.c:397
-#: ../build/lib/darktable/plugins/introspection_agx.c:600
+#: ../build/lib/darktable/plugins/introspection_agx.c:395
+#: ../build/lib/darktable/plugins/introspection_agx.c:598
 #: ../build/lib/darktable/plugins/introspection_sigmoid.c:176
 #: ../build/lib/darktable/plugins/introspection_sigmoid.c:277
 msgid "blue attenuation"
 msgstr "파랑 감쇠"
 
-#: ../build/lib/darktable/plugins/introspection_agx.c:403
-#: ../build/lib/darktable/plugins/introspection_agx.c:604
+#: ../build/lib/darktable/plugins/introspection_agx.c:401
+#: ../build/lib/darktable/plugins/introspection_agx.c:602
 #: ../build/lib/darktable/plugins/introspection_sigmoid.c:182
 #: ../build/lib/darktable/plugins/introspection_sigmoid.c:281
 msgid "blue rotation"
 msgstr "파랑 회전"
 
-#: ../build/lib/darktable/plugins/introspection_agx.c:409
-#: ../build/lib/darktable/plugins/introspection_agx.c:608
+#: ../build/lib/darktable/plugins/introspection_agx.c:407
+#: ../build/lib/darktable/plugins/introspection_agx.c:606
 msgid "master purity boost"
 msgstr "마스터 순도 강화"
 
-#: ../build/lib/darktable/plugins/introspection_agx.c:415
-#: ../build/lib/darktable/plugins/introspection_agx.c:612
+#: ../build/lib/darktable/plugins/introspection_agx.c:413
+#: ../build/lib/darktable/plugins/introspection_agx.c:610
 msgid "master rotation reversal"
 msgstr "마스터 회전 복원"
 
-#: ../build/lib/darktable/plugins/introspection_agx.c:421
-#: ../build/lib/darktable/plugins/introspection_agx.c:616
+#: ../build/lib/darktable/plugins/introspection_agx.c:419
+#: ../build/lib/darktable/plugins/introspection_agx.c:614
 msgid "red purity boost"
 msgstr "적색 순도 증강"
 
-#: ../build/lib/darktable/plugins/introspection_agx.c:427
-#: ../build/lib/darktable/plugins/introspection_agx.c:620
+#: ../build/lib/darktable/plugins/introspection_agx.c:425
+#: ../build/lib/darktable/plugins/introspection_agx.c:618
 msgid "red reverse rotation"
 msgstr "적색 반대 회전"
 
-#: ../build/lib/darktable/plugins/introspection_agx.c:433
-#: ../build/lib/darktable/plugins/introspection_agx.c:624
+#: ../build/lib/darktable/plugins/introspection_agx.c:431
+#: ../build/lib/darktable/plugins/introspection_agx.c:622
 msgid "green purity boost"
 msgstr "녹색 순도 증강"
 
-#: ../build/lib/darktable/plugins/introspection_agx.c:439
-#: ../build/lib/darktable/plugins/introspection_agx.c:628
+#: ../build/lib/darktable/plugins/introspection_agx.c:437
+#: ../build/lib/darktable/plugins/introspection_agx.c:626
 msgid "green reverse rotation"
 msgstr "녹색 반대 회전"
 
-#: ../build/lib/darktable/plugins/introspection_agx.c:445
-#: ../build/lib/darktable/plugins/introspection_agx.c:632
+#: ../build/lib/darktable/plugins/introspection_agx.c:443
+#: ../build/lib/darktable/plugins/introspection_agx.c:630
 msgid "blue purity boost"
 msgstr "파랑 순도 중강"
 
-#: ../build/lib/darktable/plugins/introspection_agx.c:451
-#: ../build/lib/darktable/plugins/introspection_agx.c:636
+#: ../build/lib/darktable/plugins/introspection_agx.c:449
+#: ../build/lib/darktable/plugins/introspection_agx.c:634
 msgid "blue reverse rotation"
 msgstr "청색 반대 회전"
 
-#: ../build/lib/darktable/plugins/introspection_agx.c:457
-#: ../build/lib/darktable/plugins/introspection_agx.c:640
+#: ../build/lib/darktable/plugins/introspection_agx.c:455
+#: ../build/lib/darktable/plugins/introspection_agx.c:638
 msgid "reverse all"
 msgstr "전체 반전"
 
-#: ../build/lib/darktable/plugins/introspection_agx.c:654
-#: ../src/common/colorspaces.c:1421 ../src/common/colorspaces.c:1769
-#: ../src/iop/colorout.c:852
+#: ../build/lib/darktable/plugins/introspection_agx.c:652
+#: ../src/common/colorspaces.c:1453 ../src/common/colorspaces.c:1801
+#: ../src/iop/colorout.c:856
 msgid "export profile"
 msgstr "프로파일 내보내기"
 
-#: ../build/lib/darktable/plugins/introspection_agx.c:655
+#: ../build/lib/darktable/plugins/introspection_agx.c:653
 #: ../build/lib/darktable/plugins/introspection_sigmoid.c:308
-#: ../src/iop/colorin.c:2040
+#: ../src/iop/colorin.c:2065
 msgid "working profile"
 msgstr "작업 프로파일"
 
-#: ../build/lib/darktable/plugins/introspection_agx.c:656
+#: ../build/lib/darktable/plugins/introspection_agx.c:654
 #: ../build/lib/darktable/plugins/introspection_sigmoid.c:309
 msgid "Rec2020"
 msgstr "Rec2020"
 
-#: ../build/lib/darktable/plugins/introspection_agx.c:657
+#: ../build/lib/darktable/plugins/introspection_agx.c:655
 #: ../build/lib/darktable/plugins/introspection_sigmoid.c:310
-#: ../src/common/colorspaces.c:1789
+#: ../src/common/colorspaces.c:1821
 msgid "Display P3"
 msgstr "Display P3"
 
-#: ../build/lib/darktable/plugins/introspection_agx.c:658
+#: ../build/lib/darktable/plugins/introspection_agx.c:656
 #: ../build/lib/darktable/plugins/introspection_colorin.c:305
 #: ../build/lib/darktable/plugins/introspection_sigmoid.c:311
-#: ../src/common/colorspaces.c:1460 ../src/common/colorspaces.c:1741
-#: ../src/libs/print_settings.c:1420
+#: ../src/common/colorspaces.c:1492 ../src/common/colorspaces.c:1773
+#: ../src/libs/print_settings.c:1440
 msgid "Adobe RGB (compatible)"
 msgstr "Adobe RGB (호환)"
 
-#: ../build/lib/darktable/plugins/introspection_agx.c:659
+#: ../build/lib/darktable/plugins/introspection_agx.c:657
 #: ../build/lib/darktable/plugins/introspection_colorin.c:304
 #: ../build/lib/darktable/plugins/introspection_lut3d.c:202
 #: ../build/lib/darktable/plugins/introspection_sigmoid.c:312
-#: ../src/common/colorspaces.c:1449 ../src/common/colorspaces.c:1739
-#: ../src/libs/print_settings.c:1413
+#: ../src/common/colorspaces.c:1481 ../src/common/colorspaces.c:1771
+#: ../src/libs/print_settings.c:1433
 msgid "sRGB"
 msgstr "sRGB"
 
@@ -2667,8 +3009,8 @@ msgstr "기울임"
 #. focal length
 #: ../build/lib/darktable/plugins/introspection_ashift.c:148
 #: ../build/lib/darktable/plugins/introspection_ashift.c:291
-#: ../src/common/collection.c:638 ../src/gui/preferences.c:962
-#: ../src/gui/presets.c:729 ../src/iop/lens.cc:4409 ../src/libs/camera.c:574
+#: ../src/common/collection.c:640 ../src/gui/preferences.c:991
+#: ../src/gui/presets.c:729 ../src/iop/lens.cc:4403 ../src/libs/camera.c:574
 #: ../src/libs/metadata_view.c:157
 msgid "focal length"
 msgstr "초점 거리"
@@ -2692,7 +3034,7 @@ msgstr "종횡 조정"
 #. lens selector
 #: ../build/lib/darktable/plugins/introspection_ashift.c:172
 #: ../build/lib/darktable/plugins/introspection_ashift.c:307
-#: ../src/iop/lens.cc:4396
+#: ../src/iop/lens.cc:4390
 msgid "lens model"
 msgstr "렌즈 모델"
 
@@ -2713,18 +3055,22 @@ msgstr "특정"
 #: ../build/lib/darktable/plugins/introspection_highlights.c:310
 #: ../build/lib/darktable/plugins/introspection_vignette.c:264
 #: ../src/develop/blend_gui.c:153 ../src/develop/blend_gui.c:182
-#: ../src/develop/blend_gui.c:3418 ../src/gui/accelerators.c:148
-#: ../src/gui/accelerators.c:158 ../src/gui/accelerators.c:246
-#: ../src/imageio/format/avif.c:973 ../src/imageio/format/j2k.c:713
-#: ../src/libs/live_view.c:424
+#: ../src/develop/blend_gui.c:3429
+#: ../src/external/lua-scripts/official/auto_straighten.lua:141
+#: ../src/gui/accelerators.c:153 ../src/gui/accelerators.c:163
+#: ../src/gui/accelerators.c:246 ../src/imageio/format/avif.c:973
+#: ../src/imageio/format/j2k.c:713 ../src/libs/live_view.c:424
 msgid "off"
 msgstr "끔"
 
 #: ../build/lib/darktable/plugins/introspection_ashift.c:367
+#: ../src/external/lua-scripts/official/auto_straighten.lua:141
 msgid "largest area"
 msgstr "최대 영역"
 
 #: ../build/lib/darktable/plugins/introspection_ashift.c:368
+#: ../src/external/lua-scripts/official/auto_straighten.lua:140
+#: ../src/external/lua-scripts/official/auto_straighten.lua:141
 msgid "original format"
 msgstr "원본 포맷"
 
@@ -2740,7 +3086,7 @@ msgstr "노출 이동"
 
 #: ../build/lib/darktable/plugins/introspection_basecurve.c:146
 #: ../build/lib/darktable/plugins/introspection_basecurve.c:239
-#: ../src/common/collection.c:646 ../src/libs/metadata_view.c:152
+#: ../src/common/collection.c:648 ../src/libs/metadata_view.c:152
 msgid "exposure bias"
 msgstr "노출 보정"
 
@@ -2764,14 +3110,15 @@ msgstr "색상 보존"
 #: ../build/lib/darktable/plugins/introspection_rgbcurve.c:251
 #: ../build/lib/darktable/plugins/introspection_rgblevels.c:153
 #: ../build/lib/darktable/plugins/introspection_tonecurve.c:270
-#: ../src/dtgtk/stylemenu.c:69 ../src/gui/guides.c:833
-#: ../src/iop/basecurve.c:2135 ../src/iop/channelmixerrgb.c:4670
-#: ../src/iop/clipping.c:1922 ../src/iop/clipping.c:2104
-#: ../src/iop/clipping.c:2119 ../src/iop/retouch.c:499
-#: ../src/libs/collect.c:2160 ../src/libs/colorpicker.c:52
-#: ../src/libs/export.c:1148 ../src/libs/filters/module_order.c:158
-#: ../src/libs/histogram.c:111 ../src/libs/live_view.c:369
-#: ../src/libs/print_settings.c:1169
+#: ../src/common/colorspaces.c:1767 ../src/dtgtk/stylemenu.c:69
+#: ../src/gui/guides.c:833 ../src/iop/basecurve.c:2099
+#: ../src/iop/channelmixerrgb.c:4698 ../src/iop/clipping.c:1916
+#: ../src/iop/clipping.c:2098 ../src/iop/clipping.c:2113
+#: ../src/iop/retouch.c:499 ../src/libs/collect.c:2240
+#: ../src/libs/colorpicker.c:52 ../src/libs/export.c:103
+#: ../src/libs/export.c:1166 ../src/libs/filters/module_order.c:158
+#: ../src/libs/live_view.c:369 ../src/libs/print_settings.c:1171
+#: ../src/libs/print_settings.c:1189 ../src/libs/scopes/vectorscope.c:62
 msgid "none"
 msgstr "없음"
 
@@ -2788,13 +3135,13 @@ msgstr "없음"
 #: ../build/lib/darktable/plugins/introspection_rgbcurve.c:252
 #: ../build/lib/darktable/plugins/introspection_rgblevels.c:154
 #: ../build/lib/darktable/plugins/introspection_tonecurve.c:271
-#: ../src/develop/blend_gui.c:2413 ../src/develop/blend_gui.c:2447
+#: ../src/develop/blend_gui.c:2414 ../src/develop/blend_gui.c:2448
 msgid "luminance"
 msgstr "휘도"
 
 #: ../build/lib/darktable/plugins/introspection_basecurve.c:264
 #: ../build/lib/darktable/plugins/introspection_basicadj.c:251
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:550
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:551
 #: ../build/lib/darktable/plugins/introspection_rgbcurve.c:253
 #: ../build/lib/darktable/plugins/introspection_rgblevels.c:155
 #: ../build/lib/darktable/plugins/introspection_tonecurve.c:272
@@ -2896,11 +3243,11 @@ msgstr "선형성"
 #: ../build/lib/darktable/plugins/introspection_blurs.c:194
 #: ../build/lib/darktable/plugins/introspection_graduatednd.c:75
 #: ../build/lib/darktable/plugins/introspection_graduatednd.c:144
-#: ../build/lib/darktable/plugins/introspection_overlay.c:136
-#: ../build/lib/darktable/plugins/introspection_overlay.c:253
+#: ../build/lib/darktable/plugins/introspection_overlay.c:139
+#: ../build/lib/darktable/plugins/introspection_overlay.c:256
 #: ../build/lib/darktable/plugins/introspection_watermark.c:136
 #: ../build/lib/darktable/plugins/introspection_watermark.c:265
-#: ../src/iop/ashift.c:5963 ../src/libs/masks.c:110
+#: ../src/iop/ashift.c:5959 ../src/libs/masks.c:190
 msgid "rotation"
 msgstr "회전"
 
@@ -2911,7 +3258,7 @@ msgstr "방향"
 
 #: ../build/lib/darktable/plugins/introspection_blurs.c:125
 #: ../build/lib/darktable/plugins/introspection_blurs.c:202
-#: ../src/libs/masks.c:111
+#: ../src/libs/masks.c:191
 msgid "curvature"
 msgstr "곡률"
 
@@ -2924,8 +3271,9 @@ msgid "offset"
 msgstr "오프셋"
 
 #: ../build/lib/darktable/plugins/introspection_blurs.c:220
-#: ../src/common/collection.c:636 ../src/gui/preferences.c:938
-#: ../src/gui/presets.c:671 ../src/libs/metadata_view.c:149
+#: ../src/common/collection.c:638 ../src/gui/preferences.c:967
+#: ../src/gui/presets.c:671 ../src/libs/filters/misc.c:412
+#: ../src/libs/metadata_view.c:149
 msgid "lens"
 msgstr "렌즈"
 
@@ -2934,7 +3282,7 @@ msgid "motion"
 msgstr "모션"
 
 #: ../build/lib/darktable/plugins/introspection_blurs.c:222
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:567
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:568
 #: ../build/lib/darktable/plugins/introspection_lowpass.c:189
 #: ../build/lib/darktable/plugins/introspection_retouch.c:452
 #: ../build/lib/darktable/plugins/introspection_shadhi.c:267
@@ -2945,20 +3293,20 @@ msgstr "가우시안"
 #: ../build/lib/darktable/plugins/introspection_borders.c:118
 #: ../build/lib/darktable/plugins/introspection_borders.c:263
 #: ../build/lib/darktable/plugins/introspection_borders.c:267
-#: ../src/iop/borders.c:1012 ../src/iop/borders.c:1021
+#: ../src/iop/borders.c:1010 ../src/iop/borders.c:1019
 msgid "border color"
 msgstr "테두리 색상"
 
 #: ../build/lib/darktable/plugins/introspection_borders.c:124
 #: ../build/lib/darktable/plugins/introspection_borders.c:271
-#: ../src/common/collection.c:648 ../src/libs/filtering.c:50
+#: ../src/common/collection.c:650 ../src/libs/filtering.c:50
 msgid "aspect ratio"
 msgstr "종횡비"
 
 #. // portrait / landscape
 #: ../build/lib/darktable/plugins/introspection_borders.c:142
 #: ../build/lib/darktable/plugins/introspection_borders.c:283
-#: ../src/iop/flip.c:73 ../src/libs/print_settings.c:2595
+#: ../src/iop/flip.c:73 ../src/libs/print_settings.c:2615
 msgid "orientation"
 msgstr "방향"
 
@@ -2991,7 +3339,7 @@ msgstr "프레임 선 오프셋"
 #: ../build/lib/darktable/plugins/introspection_borders.c:208
 #: ../build/lib/darktable/plugins/introspection_borders.c:323
 #: ../build/lib/darktable/plugins/introspection_borders.c:327
-#: ../src/iop/borders.c:1025 ../src/iop/borders.c:1035
+#: ../src/iop/borders.c:1023 ../src/iop/borders.c:1033
 msgid "frame line color"
 msgstr "프레임 선 색상"
 
@@ -3002,36 +3350,37 @@ msgstr "기준"
 
 #: ../build/lib/darktable/plugins/introspection_borders.c:349
 #: ../build/lib/darktable/plugins/introspection_borders.c:355
-#: ../src/gui/preferences.c:969 ../src/imageio/format/avif.c:1026
-#: ../src/imageio/format/jpeg.c:597 ../src/iop/ashift.c:6145
-#: ../src/iop/basicadj.c:654 ../src/iop/flip.c:448 ../src/iop/levels.c:645
+#: ../src/gui/preferences.c:998 ../src/gui/preferences_ai.c:400
+#: ../src/imageio/format/avif.c:1026 ../src/imageio/format/heif.c:731
+#: ../src/imageio/format/jpeg.c:597 ../src/iop/ashift.c:6141
+#: ../src/iop/basicadj.c:653 ../src/iop/flip.c:448 ../src/iop/levels.c:645
 #: ../src/iop/rgblevels.c:1081
 msgid "auto"
 msgstr "자동"
 
 #: ../build/lib/darktable/plugins/introspection_borders.c:350
-#: ../src/imageio/format/pdf.c:621 ../src/libs/filtering.c:318
-#: ../src/libs/filters/ratio.c:120 ../src/libs/print_settings.c:2597
+#: ../src/imageio/format/pdf.c:621 ../src/libs/filtering.c:321
+#: ../src/libs/filters/ratio.c:120 ../src/libs/print_settings.c:2617
 msgid "portrait"
 msgstr "세로"
 
 #: ../build/lib/darktable/plugins/introspection_borders.c:351
-#: ../src/imageio/format/pdf.c:621 ../src/libs/filtering.c:314
-#: ../src/libs/filters/ratio.c:122 ../src/libs/print_settings.c:2597
+#: ../src/imageio/format/pdf.c:621 ../src/libs/filtering.c:317
+#: ../src/libs/filters/ratio.c:122 ../src/libs/print_settings.c:2617
 msgid "landscape"
 msgstr "가로"
 
 #: ../build/lib/darktable/plugins/introspection_borders.c:356
-#: ../src/iop/relight.c:264 ../src/libs/export.c:1499
-#: ../src/libs/metadata_view.c:163 ../src/libs/print_settings.c:2615
+#: ../src/iop/relight.c:264 ../src/libs/export.c:1517
+#: ../src/libs/metadata_view.c:163 ../src/libs/print_settings.c:2635
 msgid "width"
 msgstr "너비"
 
 #: ../build/lib/darktable/plugins/introspection_borders.c:357
-#: ../build/lib/darktable/plugins/introspection_overlay.c:306
+#: ../build/lib/darktable/plugins/introspection_overlay.c:309
 #: ../build/lib/darktable/plugins/introspection_watermark.c:326
-#: ../src/libs/export.c:1505 ../src/libs/metadata_view.c:164
-#: ../src/libs/print_settings.c:2619
+#: ../src/libs/export.c:1523 ../src/libs/metadata_view.c:164
+#: ../src/libs/print_settings.c:2639
 msgid "height"
 msgstr "높이"
 
@@ -3095,8 +3444,8 @@ msgstr "가이드"
 #: ../build/lib/darktable/plugins/introspection_demosaic.c:259
 #: ../build/lib/darktable/plugins/introspection_lens.cc:340
 #: ../build/lib/darktable/plugins/introspection_lens.cc:501
-#: ../src/iop/atrous.c:1628 ../src/iop/bilateral.cc:368 ../src/iop/clahe.c:324
-#: ../src/iop/lowpass.c:574 ../src/iop/shadhi.c:685 ../src/iop/sharpen.c:427
+#: ../src/iop/atrous.c:1573 ../src/iop/bilateral.cc:367 ../src/iop/clahe.c:324
+#: ../src/iop/lowpass.c:572 ../src/iop/shadhi.c:683 ../src/iop/sharpen.c:416
 msgid "radius"
 msgstr "반지름"
 
@@ -3106,9 +3455,10 @@ msgstr "반지름"
 #: ../build/lib/darktable/plugins/introspection_highlights.c:240
 #: ../build/lib/darktable/plugins/introspection_lens.cc:334
 #: ../build/lib/darktable/plugins/introspection_lens.cc:497
-#: ../src/iop/bloom.c:422 ../src/iop/denoiseprofile.c:3867
+#: ../src/iop/bloom.c:390 ../src/iop/denoiseprofile.c:3691
 #: ../src/iop/grain.c:545 ../src/iop/hazeremoval.c:272
-#: ../src/iop/hotpixels.c:446 ../src/iop/nlmeans.c:457 ../src/iop/velvia.c:281
+#: ../src/iop/hotpixels.c:449 ../src/iop/nlmeans.c:438 ../src/iop/velvia.c:280
+#: ../src/libs/neural_restore.c:4291 ../src/libs/neural_restore.c:4308
 msgid "strength"
 msgstr "강도"
 
@@ -3225,6 +3575,7 @@ msgid "Planckian (black body)"
 msgstr "플랑크 (흑체)"
 
 #: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:514
+#: ../build/lib/darktable/plugins/introspection_colorharmonizer.c:256
 #: ../src/common/iop_order.c:56
 msgid "custom"
 msgstr "사용자 정의"
@@ -3351,33 +3702,33 @@ msgstr "버전 3 (2021년 4월)"
 
 #: ../build/lib/darktable/plugins/introspection_clipping.c:142
 #: ../build/lib/darktable/plugins/introspection_clipping.c:303
-#: ../build/lib/darktable/plugins/introspection_crop.c:65
-#: ../build/lib/darktable/plugins/introspection_crop.c:144
-#: ../src/gui/gtk.c:1469 ../src/iop/atrous.c:1624
+#: ../build/lib/darktable/plugins/introspection_crop.c:61
+#: ../build/lib/darktable/plugins/introspection_crop.c:134
+#: ../src/gui/gtk.c:1663 ../src/iop/atrous.c:1569
 msgid "left"
 msgstr "왼쪽"
 
 #: ../build/lib/darktable/plugins/introspection_clipping.c:148
 #: ../build/lib/darktable/plugins/introspection_clipping.c:307
-#: ../build/lib/darktable/plugins/introspection_crop.c:71
-#: ../build/lib/darktable/plugins/introspection_crop.c:148
-#: ../src/gui/accelerators.c:131 ../src/gui/gtk.c:1479
+#: ../build/lib/darktable/plugins/introspection_crop.c:67
+#: ../build/lib/darktable/plugins/introspection_crop.c:138
+#: ../src/gui/accelerators.c:132 ../src/gui/gtk.c:1673
 msgid "top"
 msgstr "위쪽"
 
 #: ../build/lib/darktable/plugins/introspection_clipping.c:154
 #: ../build/lib/darktable/plugins/introspection_clipping.c:311
-#: ../build/lib/darktable/plugins/introspection_crop.c:77
-#: ../build/lib/darktable/plugins/introspection_crop.c:152
-#: ../src/gui/gtk.c:1474 ../src/iop/atrous.c:1623
+#: ../build/lib/darktable/plugins/introspection_crop.c:73
+#: ../build/lib/darktable/plugins/introspection_crop.c:142
+#: ../src/gui/gtk.c:1668 ../src/iop/atrous.c:1568
 msgid "right"
 msgstr "오른쪽"
 
 #: ../build/lib/darktable/plugins/introspection_clipping.c:160
 #: ../build/lib/darktable/plugins/introspection_clipping.c:315
-#: ../build/lib/darktable/plugins/introspection_crop.c:83
-#: ../build/lib/darktable/plugins/introspection_crop.c:156
-#: ../src/gui/accelerators.c:132 ../src/gui/gtk.c:1483
+#: ../build/lib/darktable/plugins/introspection_crop.c:79
+#: ../build/lib/darktable/plugins/introspection_crop.c:146
+#: ../src/gui/accelerators.c:133 ../src/gui/gtk.c:1677
 msgid "bottom"
 msgstr "아래쪽"
 
@@ -3417,10 +3768,10 @@ msgstr "리프트, 감마, 게인 (sRGB)"
 #: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:489
 #: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:501
 #: ../build/lib/darktable/plugins/introspection_colorzones.c:256
-#: ../src/develop/blend_gui.c:2406 ../src/develop/blend_gui.c:2454
-#: ../src/iop/atrous.c:1793 ../src/iop/channelmixerrgb.c:4485
-#: ../src/iop/channelmixerrgb.c:4573 ../src/iop/colorbalancergb.c:1803
-#: ../src/iop/colorzones.c:2626 ../src/iop/nlmeans.c:465
+#: ../src/develop/blend_gui.c:2407 ../src/develop/blend_gui.c:2455
+#: ../src/iop/atrous.c:1752 ../src/iop/channelmixerrgb.c:4513
+#: ../src/iop/channelmixerrgb.c:4601 ../src/iop/colorbalancergb.c:1803
+#: ../src/iop/colorzones.c:2626 ../src/iop/nlmeans.c:446
 msgid "chroma"
 msgstr "채도(크로마)"
 
@@ -3440,11 +3791,11 @@ msgstr "채도(크로마)"
 #: ../build/lib/darktable/plugins/introspection_splittoning.c:73
 #: ../build/lib/darktable/plugins/introspection_splittoning.c:134
 #: ../build/lib/darktable/plugins/introspection_splittoning.c:142
-#: ../src/develop/blend_gui.c:2365 ../src/develop/blend_gui.c:2399
-#: ../src/develop/blend_gui.c:2461 ../src/iop/channelmixer.c:607
-#: ../src/iop/channelmixerrgb.c:4479 ../src/iop/channelmixerrgb.c:4566
-#: ../src/iop/colorbalance.c:1937 ../src/iop/colorequal.c:3067
-#: ../src/iop/colorize.c:334 ../src/iop/colorreconstruction.c:1233
+#: ../src/develop/blend_gui.c:2366 ../src/develop/blend_gui.c:2400
+#: ../src/develop/blend_gui.c:2462 ../src/iop/channelmixer.c:607
+#: ../src/iop/channelmixerrgb.c:4507 ../src/iop/channelmixerrgb.c:4594
+#: ../src/iop/colorbalance.c:1937 ../src/iop/colorequal.c:3030
+#: ../src/iop/colorize.c:345 ../src/iop/colorreconstruction.c:1226
 #: ../src/iop/colorzones.c:2627
 msgid "hue"
 msgstr "색조"
@@ -3472,8 +3823,8 @@ msgstr "하이라이트 감쇠"
 #: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:569
 #: ../build/lib/darktable/plugins/introspection_toneequal.c:157
 #: ../build/lib/darktable/plugins/introspection_toneequal.c:298
-#: ../src/iop/bilat.c:479 ../src/iop/colorbalance.c:1994
-#: ../src/iop/negadoctor.c:912 ../src/iop/shadhi.c:681
+#: ../src/iop/bilat.c:475 ../src/iop/colorbalance.c:1994
+#: ../src/iop/negadoctor.c:912 ../src/iop/shadhi.c:679
 #: ../src/iop/splittoning.c:488
 msgid "shadows"
 msgstr "쉐도우"
@@ -3486,8 +3837,8 @@ msgstr "쉐도우"
 #: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:561
 #: ../build/lib/darktable/plugins/introspection_toneequal.c:181
 #: ../build/lib/darktable/plugins/introspection_toneequal.c:314
-#: ../src/iop/bilat.c:473 ../src/iop/colorbalance.c:1996
-#: ../src/iop/monochrome.c:575 ../src/iop/shadhi.c:682
+#: ../src/iop/bilat.c:469 ../src/iop/colorbalance.c:1996
+#: ../src/iop/monochrome.c:573 ../src/iop/shadhi.c:680
 #: ../src/iop/splittoning.c:494
 msgid "highlights"
 msgstr "하이라이트"
@@ -3511,7 +3862,7 @@ msgstr "중간 톤"
 
 #: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:340
 #: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:537
-#: ../src/iop/filmic.c:1544
+#: ../src/iop/filmic.c:1557
 msgid "global saturation"
 msgstr "전역 채도"
 
@@ -3599,7 +3950,7 @@ msgstr "가이드 필터 사용"
 #: ../build/lib/darktable/plugins/introspection_colorequal.c:499
 #: ../build/lib/darktable/plugins/introspection_colorequal.c:531
 #: ../build/lib/darktable/plugins/introspection_colorequal.c:563
-#: ../src/common/color_vocabulary.c:343 ../src/iop/colorequal.c:2963
+#: ../src/common/color_vocabulary.c:343 ../src/iop/colorequal.c:2928
 msgid "lavender"
 msgstr "라벤더"
 
@@ -3608,6 +3959,104 @@ msgstr "라벤더"
 msgid "node placement"
 msgstr "노드 위치"
 
+#: ../build/lib/darktable/plugins/introspection_colorharmonizer.c:90
+#: ../build/lib/darktable/plugins/introspection_colorharmonizer.c:193
+msgid "harmony rule"
+msgstr "조화 규칙"
+
+#: ../build/lib/darktable/plugins/introspection_colorharmonizer.c:96
+#: ../build/lib/darktable/plugins/introspection_colorharmonizer.c:197
+#: ../src/iop/colorharmonizer.c:1438
+msgid "anchor hue"
+msgstr "기준 색조"
+
+#: ../build/lib/darktable/plugins/introspection_colorharmonizer.c:102
+#: ../build/lib/darktable/plugins/introspection_colorharmonizer.c:201
+msgid "pull strength"
+msgstr "끌어당김 강도"
+
+#: ../build/lib/darktable/plugins/introspection_colorharmonizer.c:108
+#: ../build/lib/darktable/plugins/introspection_colorharmonizer.c:205
+msgid "neutral color protection"
+msgstr "중립 색상 보호"
+
+#: ../build/lib/darktable/plugins/introspection_colorharmonizer.c:114
+#: ../build/lib/darktable/plugins/introspection_colorharmonizer.c:209
+msgid "pull width"
+msgstr "끌어당김 폭"
+
+#: ../build/lib/darktable/plugins/introspection_colorharmonizer.c:120
+#: ../build/lib/darktable/plugins/introspection_colorharmonizer.c:126
+#: ../build/lib/darktable/plugins/introspection_colorharmonizer.c:213
+#: ../build/lib/darktable/plugins/introspection_colorharmonizer.c:217
+msgid "custom node hue"
+msgstr "사용자 정의 노드 색조"
+
+#: ../build/lib/darktable/plugins/introspection_colorharmonizer.c:132
+#: ../build/lib/darktable/plugins/introspection_colorharmonizer.c:221
+msgid "nodes"
+msgstr "노드"
+
+#: ../build/lib/darktable/plugins/introspection_colorharmonizer.c:138
+#: ../build/lib/darktable/plugins/introspection_colorharmonizer.c:144
+#: ../build/lib/darktable/plugins/introspection_colorharmonizer.c:225
+#: ../build/lib/darktable/plugins/introspection_colorharmonizer.c:229
+msgid "node saturation"
+msgstr "노드 채도"
+
+#: ../build/lib/darktable/plugins/introspection_colorharmonizer.c:150
+#: ../build/lib/darktable/plugins/introspection_colorharmonizer.c:233
+#: ../src/libs/masks.c:194 ../src/libs/masks.c:2237
+msgid "smoothing"
+msgstr "부드럽게 처리"
+
+#: ../build/lib/darktable/plugins/introspection_colorharmonizer.c:247
+#: ../src/libs/scopes/vectorscope.c:63
+msgid "monochromatic"
+msgstr "단색조"
+
+#: ../build/lib/darktable/plugins/introspection_colorharmonizer.c:248
+#: ../src/libs/scopes/vectorscope.c:64
+msgid "analogous"
+msgstr "유사색"
+
+#: ../build/lib/darktable/plugins/introspection_colorharmonizer.c:249
+#: ../src/libs/scopes/vectorscope.c:65
+msgid "analogous complementary"
+msgstr "유사 보색"
+
+#: ../build/lib/darktable/plugins/introspection_colorharmonizer.c:250
+#: ../src/libs/scopes/vectorscope.c:66
+msgid "complementary"
+msgstr "보색"
+
+#: ../build/lib/darktable/plugins/introspection_colorharmonizer.c:251
+#: ../src/libs/scopes/vectorscope.c:67
+msgid "split complementary"
+msgstr "분할 보색(Split complementary)"
+
+#: ../build/lib/darktable/plugins/introspection_colorharmonizer.c:252
+#: ../src/libs/scopes/vectorscope.c:68
+msgid "dyad"
+msgstr "2색 조합(Dyad)"
+
+#: ../build/lib/darktable/plugins/introspection_colorharmonizer.c:253
+#: ../src/libs/scopes/vectorscope.c:69
+msgid "triad"
+msgstr "3색 조합(Triad)"
+
+#: ../build/lib/darktable/plugins/introspection_colorharmonizer.c:254
+#: ../src/libs/scopes/vectorscope.c:70
+msgid "tetrad"
+msgstr "4색 조합(Tetrad)"
+
+#: ../build/lib/darktable/plugins/introspection_colorharmonizer.c:255
+#: ../src/iop/borders.c:953 ../src/iop/clipping.c:2126 ../src/iop/crop.c:1270
+#: ../src/libs/filtering.c:313 ../src/libs/filters/ratio.c:124
+#: ../src/libs/scopes/vectorscope.c:71
+msgid "square"
+msgstr "사각형"
+
 #: ../build/lib/darktable/plugins/introspection_colorin.c:150
 #: ../build/lib/darktable/plugins/introspection_colorin.c:233
 msgid "gamut clipping"
@@ -3615,13 +4064,13 @@ msgstr "색역 클리핑"
 
 #: ../build/lib/darktable/plugins/introspection_colorin.c:306
 #: ../build/lib/darktable/plugins/introspection_lut3d.c:205
-#: ../src/common/colorspaces.c:1467 ../src/common/colorspaces.c:1743
+#: ../src/common/colorspaces.c:1499 ../src/common/colorspaces.c:1775
 msgid "linear Rec709 RGB"
 msgstr "선형 Rec709 RGB"
 
 #: ../build/lib/darktable/plugins/introspection_colorin.c:307
 #: ../build/lib/darktable/plugins/introspection_lut3d.c:206
-#: ../src/common/colorspaces.c:1481 ../src/common/colorspaces.c:1745
+#: ../src/common/colorspaces.c:1513 ../src/common/colorspaces.c:1777
 msgid "linear Rec2020 RGB"
 msgstr "선형 Rec2020 RGB"
 
@@ -3649,7 +4098,7 @@ msgstr "히스토그램 평활화"
 #: ../build/lib/darktable/plugins/introspection_colorreconstruction.c:127
 #: ../build/lib/darktable/plugins/introspection_tonemap.cc:45
 #: ../build/lib/darktable/plugins/introspection_tonemap.cc:92
-#: ../src/iop/shadhi.c:696
+#: ../src/iop/shadhi.c:694
 msgid "spatial extent"
 msgstr "공간 범위"
 
@@ -3659,7 +4108,7 @@ msgid "range extent"
 msgstr "범위 확장"
 
 #: ../build/lib/darktable/plugins/introspection_colorreconstruction.c:154
-#: ../src/iop/channelmixerrgb.c:4672
+#: ../src/iop/channelmixerrgb.c:4700
 msgid "saturated colors"
 msgstr "포화 색상"
 
@@ -3673,7 +4122,7 @@ msgstr "선택 기준"
 #: ../build/lib/darktable/plugins/introspection_colorzones.c:233
 #: ../build/lib/darktable/plugins/introspection_soften.c:66
 #: ../build/lib/darktable/plugins/introspection_soften.c:121
-#: ../src/iop/atrous.c:1829
+#: ../src/iop/atrous.c:1788
 msgid "mix"
 msgstr "혼합"
 
@@ -3683,17 +4132,17 @@ msgid "process mode"
 msgstr "처리 모드"
 
 #: ../build/lib/darktable/plugins/introspection_colorzones.c:255
-#: ../src/develop/blend_gui.c:2344 ../src/iop/channelmixer.c:609
-#: ../src/iop/channelmixerrgb.c:4558 ../src/iop/colorchecker.c:1567
-#: ../src/iop/colorize.c:353 ../src/iop/colorzones.c:2625
-#: ../src/iop/exposure.c:1315
+#: ../src/develop/blend_gui.c:2345 ../src/iop/channelmixer.c:609
+#: ../src/iop/channelmixerrgb.c:4586 ../src/iop/colorchecker.c:1567
+#: ../src/iop/colorize.c:364 ../src/iop/colorzones.c:2625
+#: ../src/iop/exposure.c:1317
 msgid "lightness"
 msgstr "명도"
 
 #: ../build/lib/darktable/plugins/introspection_colorzones.c:267
-#: ../src/iop/agx.c:2453 ../src/iop/atrous.c:1405 ../src/iop/atrous.c:1409
-#: ../src/iop/denoiseprofile.c:3597 ../src/iop/rawdenoise.c:747
-#: ../src/iop/sigmoid.c:294
+#: ../src/iop/agx.c:2109 ../src/iop/agx.c:2652 ../src/iop/atrous.c:1350
+#: ../src/iop/atrous.c:1354 ../src/iop/denoiseprofile.c:3421
+#: ../src/iop/rawdenoise.c:749 ../src/iop/sigmoid.c:294
 msgid "smooth"
 msgstr "부드럽게"
 
@@ -3708,11 +4157,11 @@ msgstr "가장자리 감지 반지름"
 
 #: ../build/lib/darktable/plugins/introspection_defringe.c:53
 #: ../build/lib/darktable/plugins/introspection_defringe.c:106
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:230
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:435
-#: ../src/iop/atrous.c:1689 ../src/iop/bloom.c:418
-#: ../src/iop/colorreconstruction.c:1229 ../src/iop/hotpixels.c:442
-#: ../src/iop/sharpen.c:436
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:231
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:436
+#: ../src/iop/atrous.c:1634 ../src/iop/bloom.c:386
+#: ../src/iop/colorreconstruction.c:1222 ../src/iop/hotpixels.c:445
+#: ../src/iop/sharpen.c:425
 msgid "threshold"
 msgstr "임계값"
 
@@ -3871,7 +4320,7 @@ msgstr "모노크롬"
 
 #. history
 #: ../build/lib/darktable/plugins/introspection_demosaic.c:329
-#: ../src/common/collection.c:1493 ../src/libs/collect.c:1905
+#: ../src/common/collection.c:1497 ../src/libs/collect.c:1985
 #: ../src/libs/filters/history.c:38
 msgid "basic"
 msgstr "기본"
@@ -3946,7 +4395,7 @@ msgstr "프로파일 변환 업그레이드"
 
 #: ../build/lib/darktable/plugins/introspection_denoiseprofile.c:262
 #: ../build/lib/darktable/plugins/introspection_denoiseprofile.c:399
-#: ../src/libs/colorpicker.c:762
+#: ../src/libs/colorpicker.c:765
 msgid "color mode"
 msgstr "색상 모드"
 
@@ -3988,7 +4437,7 @@ msgstr "Y0U0V0"
 
 #: ../build/lib/darktable/plugins/introspection_diffuse.c:123
 #: ../build/lib/darktable/plugins/introspection_diffuse.c:248
-#: ../src/iop/atrous.c:1679 ../src/iop/highpass.c:365
+#: ../src/iop/atrous.c:1624 ../src/iop/highpass.c:352
 msgid "sharpness"
 msgstr "선명도"
 
@@ -4152,9 +4601,9 @@ msgstr "아래쪽 비율"
 #: ../build/lib/darktable/plugins/introspection_enlargecanvas.c:86
 #: ../build/lib/darktable/plugins/introspection_enlargecanvas.c:145
 #: ../build/lib/darktable/plugins/introspection_retouch.c:458
-#: ../src/gui/presets.c:59 ../src/iop/watermark.c:1354
+#: ../src/gui/presets.c:59 ../src/iop/watermark.c:1455
 #: ../src/libs/colorpicker.c:396 ../src/libs/image.c:665
-#: ../src/libs/modulegroups.c:2360
+#: ../src/libs/modulegroups.c:2365
 msgid "color"
 msgstr "색상"
 
@@ -4195,207 +4644,213 @@ msgstr "수동"
 msgid "automatic"
 msgstr "자동"
 
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:212
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:423
-#: ../src/iop/filmic.c:1467
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:213
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:424
+#: ../src/iop/filmic.c:1468
 msgid "middle gray luminance"
 msgstr "중간 회색 휘도"
 
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:236
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:439
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:237
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:440
 msgid "transition"
 msgstr "전환"
 
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:242
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:443
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:243
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:444
 msgid "bloom ↔ reconstruct"
 msgstr "블룸 ↔ 복원"
 
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:248
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:447
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:249
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:448
 msgid "gray ↔ colorful details"
 msgstr "회색 ↔ 다채색 디테일"
 
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:254
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:451
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:255
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:452
 msgid "structure ↔ texture"
 msgstr "구조 ↔ 질감"
 
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:266
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:459
-#: ../src/iop/filmic.c:1592
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:267
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:460
+#: ../src/iop/filmic.c:1612
 msgid "target middle gray"
 msgstr "지정 중간 회색"
 
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:272
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:463
-#: ../src/iop/filmic.c:1584
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:273
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:464
+#: ../src/iop/filmic.c:1603
 msgid "target black luminance"
 msgstr "지정 검정 휘도"
 
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:278
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:467
-#: ../src/iop/filmic.c:1600
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:279
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:468
+#: ../src/iop/filmic.c:1621
 msgid "target white luminance"
 msgstr "지정 흰색 휘도"
 
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:284
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:471
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:285
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:472
 #: ../build/lib/darktable/plugins/introspection_graduatednd.c:69
 #: ../build/lib/darktable/plugins/introspection_graduatednd.c:140
-#: ../src/libs/masks.c:108
+#: ../src/libs/masks.c:188
 msgid "hardness"
 msgstr "경도"
 
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:302
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:483
-#: ../src/iop/filmic.c:1553 ../src/iop/filmicrgb.c:4681
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:291
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:476
+#: ../src/iop/filmic.c:1536
+msgid "linear region"
+msgstr "선형 구간"
+
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:303
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:484
+#: ../src/iop/filmic.c:1568 ../src/iop/filmicrgb.c:4680
 msgid "extreme luminance saturation"
 msgstr "극단적 휘도 채도"
 
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:308
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:487
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:309
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:488
 msgid "shadows ↔ highlights balance"
 msgstr "쉐도우 ↔ 하이라이트 균형"
 
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:314
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:491
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:315
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:492
 msgid "add noise in highlights"
 msgstr "하이라이트에 노이즈 추가"
 
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:320
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:495
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:321
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:496
 msgid "preserve chrominance"
 msgstr "색차 보존"
 
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:326
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:499
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:327
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:500
 msgid "color science"
 msgstr "색상 과학"
 
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:332
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:503
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:333
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:504
 msgid "auto adjust hardness"
 msgstr "경도 자동 조정"
 
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:338
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:507
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:339
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:508
 msgid "use custom middle-gray values"
 msgstr "사용자 정의 중간 회색 값 사용"
 
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:344
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:511
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:345
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:512
 msgid "iterations of high-quality reconstruction"
 msgstr "고품질 복원 반복 횟수"
 
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:350
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:515
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:351
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:516
 msgid "type of noise"
 msgstr "노이즈 유형"
 
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:356
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:519
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:357
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:520
 msgid "contrast in shadows"
 msgstr "쉐도우의 대비"
 
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:362
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:523
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:363
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:524
 msgid "contrast in highlights"
 msgstr "하이라이트의 대비"
 
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:368
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:527
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:369
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:528
 msgid "compensate output ICC profile black point"
 msgstr "출력 ICC 프로파일 검정점 보상"
 
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:374
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:531
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:375
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:532
 msgid "spline handling"
 msgstr "스플라인 처리"
 
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:380
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:535
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:381
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:536
 msgid "enable highlight reconstruction"
 msgstr "하이라이트 복원 활성화"
 
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:549
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:550
 #: ../build/lib/darktable/plugins/introspection_toneequal.c:372
 #: ../src/common/variables.c:197 ../src/common/variables.c:822
-#: ../src/develop/imageop_gui.c:194 ../src/imageio/format/avif.c:960
-#: ../src/imageio/format/pdf.c:653 ../src/imageio/format/pdf.c:672
-#: ../src/imageio/format/tiff.c:921 ../src/libs/export.c:1561
-#: ../src/libs/export.c:1569 ../src/libs/export.c:1577
-#: ../src/libs/metadata_view.c:734
+#: ../src/develop/imageop_gui.c:194 ../src/gui/preferences_ai.c:256
+#: ../src/imageio/format/avif.c:960 ../src/imageio/format/pdf.c:653
+#: ../src/imageio/format/pdf.c:672 ../src/imageio/format/tiff.c:921
+#: ../src/libs/export.c:1579 ../src/libs/export.c:1587
+#: ../src/libs/export.c:1595 ../src/libs/metadata_view.c:748
 msgid "no"
 msgstr "아니오"
 
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:551
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:552
 msgid "luminance Y"
 msgstr "휘도 Y"
 
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:552
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:553
 #: ../build/lib/darktable/plugins/introspection_toneequal.c:385
 msgid "RGB power norm"
 msgstr "RGB 파워 노름"
 
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:553
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:554
 msgid "RGB euclidean norm (legacy)"
 msgstr "RGB 유클리드 노름 (레거시)"
 
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:554
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:555
 #: ../build/lib/darktable/plugins/introspection_toneequal.c:384
 msgid "RGB euclidean norm"
 msgstr "RGB 유클리드 노름"
 
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:558
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:559
 msgid "v3 (2019)"
 msgstr "v3 (2019)"
 
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:559
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:560
 msgid "v4 (2020)"
 msgstr "v4 (2020)"
 
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:560
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:561
 msgid "v5 (2021)"
 msgstr "v5 (2021)"
 
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:561
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:562
 msgid "v6 (2022)"
 msgstr "v6 (2022)"
 
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:562
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:563
 msgid "v7 (2023)"
 msgstr "v7 (2023)"
 
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:566
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:567
 msgid "uniform"
 msgstr "균일"
 
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:568
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:569
 msgid "poissonian"
 msgstr "포아송"
 
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:572
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:573
 msgid "hard"
 msgstr "딱딱함"
 
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:573
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:574
 msgid "soft"
 msgstr "부드러움"
 
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:574
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:575
 msgid "safe"
 msgstr "안전함"
 
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:578
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:579
 msgid "v1 (2019)"
 msgstr "v1 (2019)"
 
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:579
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:580
 msgid "v2 (2020)"
 msgstr "v2 (2020)"
 
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:580
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:581
 msgid "v3 (2021)"
 msgstr "v3 (2021)"
 
@@ -4468,7 +4923,7 @@ msgstr "밀도"
 
 #: ../build/lib/darktable/plugins/introspection_grain.c:58
 #: ../build/lib/darktable/plugins/introspection_grain.c:117
-#: ../src/iop/bilat.c:460
+#: ../src/iop/bilat.c:456
 msgid "coarseness"
 msgstr "거칠기"
 
@@ -4481,7 +4936,7 @@ msgstr "중간 톤 보정"
 
 #: ../build/lib/darktable/plugins/introspection_highlights.c:143
 #: ../build/lib/darktable/plugins/introspection_highlights.c:244
-#: ../src/views/darkroom.c:2605
+#: ../src/views/darkroom.c:3230
 msgid "clipping threshold"
 msgstr "클리핑 임계값"
 
@@ -4638,18 +5093,18 @@ msgstr "보정"
 #: ../build/lib/darktable/plugins/introspection_rgbcurve.c:219
 #: ../build/lib/darktable/plugins/introspection_rgblevels.c:51
 #: ../build/lib/darktable/plugins/introspection_rgblevels.c:118
-#: ../src/develop/blend_gui.c:3522 ../src/iop/bilat.c:438
-#: ../src/iop/colorbalance.c:1853 ../src/iop/denoiseprofile.c:3856
-#: ../src/iop/exposure.c:1250 ../src/iop/levels.c:688
-#: ../src/iop/profile_gamma.c:654 ../src/libs/export.c:1628
-#: ../src/libs/image.c:646 ../src/libs/print_settings.c:2934
-#: ../src/libs/styles.c:875 ../src/views/darkroom.c:2579
+#: ../src/develop/blend_gui.c:3533 ../src/iop/bilat.c:434
+#: ../src/iop/colorbalance.c:1853 ../src/iop/denoiseprofile.c:3680
+#: ../src/iop/exposure.c:1252 ../src/iop/levels.c:688
+#: ../src/iop/profile_gamma.c:649 ../src/libs/export.c:1646
+#: ../src/libs/image.c:646 ../src/libs/print_settings.c:2954
+#: ../src/libs/styles.c:910 ../src/views/darkroom.c:3204
 msgid "mode"
 msgstr "모드"
 
 #: ../build/lib/darktable/plugins/introspection_lens.cc:238
 #: ../build/lib/darktable/plugins/introspection_lens.cc:433
-#: ../src/iop/lens.cc:4456
+#: ../src/iop/lens.cc:4450
 msgid "target geometry"
 msgstr "지정 지오메트리"
 
@@ -4713,12 +5168,14 @@ msgstr "수동 비네팅만"
 #. get nice text for bounds
 #. Side-border hide/show
 #: ../build/lib/darktable/plugins/introspection_lens.cc:534
-#: ../src/dtgtk/range.c:1735 ../src/gui/accelerators.c:2625
-#: ../src/gui/accelerators.c:2697 ../src/gui/gtk.c:1532 ../src/gui/gtk.c:3845
-#: ../src/imageio/format/pdf.c:662 ../src/iop/denoiseprofile.c:3773
-#: ../src/iop/rawdenoise.c:882 ../src/libs/collect.c:3550
-#: ../src/libs/filtering.c:1510 ../src/libs/filters/colors.c:157
-#: ../src/libs/filters/colors.c:265 ../src/libs/filters/rating.c:210
+#: ../src/dtgtk/range.c:1755 ../src/gui/accelerators.c:2626
+#: ../src/gui/accelerators.c:2698 ../src/gui/gtk.c:1726 ../src/gui/gtk.c:4103
+#: ../src/imageio/format/pdf.c:662 ../src/iop/denoiseprofile.c:3597
+#: ../src/iop/rawdenoise.c:884 ../src/libs/collect.c:3909
+#: ../src/libs/filtering.c:1520 ../src/libs/filters/colors.c:157
+#: ../src/libs/filters/colors.c:265 ../src/libs/filters/date.c:112
+#: ../src/libs/filters/date.c:125 ../src/libs/filters/rating.c:210
+#: ../src/libs/modulegroups.c:2861 ../src/libs/modulegroups.c:2865
 msgid "all"
 msgstr "전체"
 
@@ -4747,7 +5204,7 @@ msgid "only vignetting"
 msgstr "비네팅만"
 
 #: ../build/lib/darktable/plugins/introspection_lens.cc:544
-#: ../src/libs/modulegroups.c:2362
+#: ../src/libs/modulegroups.c:2367
 msgid "correct"
 msgstr "보정"
 
@@ -4793,11 +5250,11 @@ msgstr "무효화됨"
 
 #. move left/right/up/down
 #: ../build/lib/darktable/plugins/introspection_liquify.c:429
-#: ../src/views/darkroom.c:2405 ../src/views/darkroom.c:2931
-#: ../src/views/darkroom.c:2935 ../src/views/lighttable.c:839
-#: ../src/views/lighttable.c:848 ../src/views/lighttable.c:1324
-#: ../src/views/lighttable.c:1328 ../src/views/lighttable.c:1332
-#: ../src/views/lighttable.c:1336 ../src/views/lighttable.c:1340
+#: ../src/views/darkroom.c:2753 ../src/views/darkroom.c:3551
+#: ../src/views/darkroom.c:3555 ../src/views/lighttable.c:1029
+#: ../src/views/lighttable.c:1038 ../src/views/lighttable.c:1567
+#: ../src/views/lighttable.c:1574 ../src/views/lighttable.c:1581
+#: ../src/views/lighttable.c:1588 ../src/views/lighttable.c:1595
 msgid "move"
 msgstr "이동"
 
@@ -4806,7 +5263,7 @@ msgid "line"
 msgstr "선"
 
 #: ../build/lib/darktable/plugins/introspection_liquify.c:431
-#: ../src/iop/agx.c:2296 ../src/iop/agx.c:2814 ../src/iop/basecurve.c:2127
+#: ../src/iop/agx.c:1954 ../src/iop/agx.c:2472 ../src/iop/basecurve.c:2091
 #: ../src/iop/rgbcurve.c:1523 ../src/iop/tonecurve.c:1288
 msgid "curve"
 msgstr "커브"
@@ -4857,7 +5314,7 @@ msgid "gamma Rec709 RGB"
 msgstr "감마 Rec709 RGB"
 
 #: ../build/lib/darktable/plugins/introspection_lut3d.c:207
-#: ../src/common/colorspaces.c:1525 ../src/common/colorspaces.c:1779
+#: ../src/common/colorspaces.c:1557 ../src/common/colorspaces.c:1811
 msgid "linear ProPhoto RGB"
 msgstr "선형 ProPhoto RGB"
 
@@ -4913,96 +5370,96 @@ msgstr "흑백 필름"
 msgid "color film"
 msgstr "색상 필름"
 
-#: ../build/lib/darktable/plugins/introspection_overlay.c:118
-#: ../build/lib/darktable/plugins/introspection_overlay.c:241
+#: ../build/lib/darktable/plugins/introspection_overlay.c:121
+#: ../build/lib/darktable/plugins/introspection_overlay.c:244
 #: ../build/lib/darktable/plugins/introspection_watermark.c:118
 #: ../build/lib/darktable/plugins/introspection_watermark.c:253
 msgid "x offset"
 msgstr "X 오프셋"
 
-#: ../build/lib/darktable/plugins/introspection_overlay.c:124
-#: ../build/lib/darktable/plugins/introspection_overlay.c:245
+#: ../build/lib/darktable/plugins/introspection_overlay.c:127
+#: ../build/lib/darktable/plugins/introspection_overlay.c:248
 #: ../build/lib/darktable/plugins/introspection_watermark.c:124
 #: ../build/lib/darktable/plugins/introspection_watermark.c:257
 msgid "y offset"
 msgstr "Y 오프셋"
 
-#: ../build/lib/darktable/plugins/introspection_overlay.c:142
-#: ../build/lib/darktable/plugins/introspection_overlay.c:257
+#: ../build/lib/darktable/plugins/introspection_overlay.c:145
+#: ../build/lib/darktable/plugins/introspection_overlay.c:260
 #: ../build/lib/darktable/plugins/introspection_watermark.c:142
 #: ../build/lib/darktable/plugins/introspection_watermark.c:269
 msgid "scale on"
 msgstr "기준 스케일"
 
-#: ../build/lib/darktable/plugins/introspection_overlay.c:148
-#: ../build/lib/darktable/plugins/introspection_overlay.c:261
+#: ../build/lib/darktable/plugins/introspection_overlay.c:151
+#: ../build/lib/darktable/plugins/introspection_overlay.c:264
 #: ../build/lib/darktable/plugins/introspection_watermark.c:148
 #: ../build/lib/darktable/plugins/introspection_watermark.c:273
 msgid "scale marker to"
 msgstr "마커 스케일링"
 
-#: ../build/lib/darktable/plugins/introspection_overlay.c:154
-#: ../build/lib/darktable/plugins/introspection_overlay.c:265
+#: ../build/lib/darktable/plugins/introspection_overlay.c:157
+#: ../build/lib/darktable/plugins/introspection_overlay.c:268
 #: ../build/lib/darktable/plugins/introspection_watermark.c:154
 #: ../build/lib/darktable/plugins/introspection_watermark.c:277
 msgid "scale marker reference"
 msgstr "마커 참조 스케일링"
 
-#: ../build/lib/darktable/plugins/introspection_overlay.c:160
-#: ../build/lib/darktable/plugins/introspection_overlay.c:269
+#: ../build/lib/darktable/plugins/introspection_overlay.c:163
+#: ../build/lib/darktable/plugins/introspection_overlay.c:272
 #: ../src/common/database.c:3243 ../src/libs/live_view.c:378
 #: ../src/libs/metadata_view.c:134
 msgid "image id"
 msgstr "이미지 id"
 
-#: ../build/lib/darktable/plugins/introspection_overlay.c:303
+#: ../build/lib/darktable/plugins/introspection_overlay.c:306
 #: ../build/lib/darktable/plugins/introspection_watermark.c:323
 #: ../src/imageio/format/tiff.c:125 ../src/imageio/format/xcf.c:164
-#: ../src/iop/borders.c:937
+#: ../src/iop/borders.c:935
 msgid "image"
 msgstr "이미지"
 
-#: ../build/lib/darktable/plugins/introspection_overlay.c:304
+#: ../build/lib/darktable/plugins/introspection_overlay.c:307
 #: ../build/lib/darktable/plugins/introspection_watermark.c:324
 msgid "larger border"
 msgstr "더 넓은 테두리"
 
-#: ../build/lib/darktable/plugins/introspection_overlay.c:305
+#: ../build/lib/darktable/plugins/introspection_overlay.c:308
 #: ../build/lib/darktable/plugins/introspection_watermark.c:325
 msgid "smaller border"
 msgstr "더 좁은 테두리"
 
-#: ../build/lib/darktable/plugins/introspection_overlay.c:307
+#: ../build/lib/darktable/plugins/introspection_overlay.c:310
 #: ../build/lib/darktable/plugins/introspection_watermark.c:327
 msgid "advanced options"
 msgstr "고급 옵션"
 
-#: ../build/lib/darktable/plugins/introspection_overlay.c:311
+#: ../build/lib/darktable/plugins/introspection_overlay.c:314
 #: ../build/lib/darktable/plugins/introspection_watermark.c:331
 msgid "image width"
 msgstr "이미지 너비"
 
-#: ../build/lib/darktable/plugins/introspection_overlay.c:312
+#: ../build/lib/darktable/plugins/introspection_overlay.c:315
 #: ../build/lib/darktable/plugins/introspection_watermark.c:332
 msgid "image height"
 msgstr "이미지 높이"
 
-#: ../build/lib/darktable/plugins/introspection_overlay.c:313
+#: ../build/lib/darktable/plugins/introspection_overlay.c:316
 #: ../build/lib/darktable/plugins/introspection_watermark.c:333
 msgid "larger image border"
 msgstr "더 넓은 이미지 테두리"
 
-#: ../build/lib/darktable/plugins/introspection_overlay.c:314
+#: ../build/lib/darktable/plugins/introspection_overlay.c:317
 #: ../build/lib/darktable/plugins/introspection_watermark.c:334
 msgid "smaller image border"
 msgstr "더 좁은 이미지 테두리"
 
-#: ../build/lib/darktable/plugins/introspection_overlay.c:318
+#: ../build/lib/darktable/plugins/introspection_overlay.c:321
 #: ../build/lib/darktable/plugins/introspection_watermark.c:338
 msgid "marker width"
 msgstr "마커 너비"
 
-#: ../build/lib/darktable/plugins/introspection_overlay.c:319
+#: ../build/lib/darktable/plugins/introspection_overlay.c:322
 #: ../build/lib/darktable/plugins/introspection_watermark.c:339
 msgid "marker height"
 msgstr "마커 높이"
@@ -5061,7 +5518,7 @@ msgstr "중간 회색 밝기"
 
 #: ../build/lib/darktable/plugins/introspection_profile_gamma.c:103
 #: ../build/lib/darktable/plugins/introspection_profile_gamma.c:170
-#: ../src/iop/filmic.c:1501
+#: ../src/iop/filmic.c:1506
 msgid "safety factor"
 msgstr "안전 계수"
 
@@ -5070,7 +5527,7 @@ msgid "logarithmic"
 msgstr "로그형"
 
 #: ../build/lib/darktable/plugins/introspection_profile_gamma.c:185
-#: ../src/iop/profile_gamma.c:611
+#: ../src/iop/profile_gamma.c:606
 msgid "gamma"
 msgstr "감마"
 
@@ -5152,9 +5609,9 @@ msgstr "내장 GainMap"
 #. exposure
 #: ../build/lib/darktable/plugins/introspection_relight.c:43
 #: ../build/lib/darktable/plugins/introspection_relight.c:98
-#: ../src/common/collection.c:644 ../src/gui/preferences.c:950
-#: ../src/gui/presets.c:695 ../src/iop/basicadj.c:622 ../src/iop/exposure.c:121
-#: ../src/iop/exposure.c:1212 ../src/libs/metadata_view.c:151
+#: ../src/common/collection.c:646 ../src/gui/preferences.c:979
+#: ../src/gui/presets.c:695 ../src/iop/basicadj.c:621 ../src/iop/exposure.c:121
+#: ../src/iop/exposure.c:1214 ../src/libs/metadata_view.c:151
 msgid "exposure"
 msgstr "노출"
 
@@ -5169,7 +5626,7 @@ msgid "max_iter"
 msgstr "최대 반복"
 
 #: ../build/lib/darktable/plugins/introspection_retouch.c:444
-#: ../src/libs/metadata_view.c:358
+#: ../src/libs/metadata_view.c:374
 msgid "unused"
 msgstr "미사용"
 
@@ -5182,12 +5639,12 @@ msgid "heal"
 msgstr "복원"
 
 #: ../build/lib/darktable/plugins/introspection_retouch.c:447
-#: ../src/iop/retouch.c:2038
+#: ../src/iop/retouch.c:2037
 msgid "blur"
 msgstr "블러"
 
 #: ../build/lib/darktable/plugins/introspection_retouch.c:448
-#: ../src/iop/retouch.c:2036
+#: ../src/iop/retouch.c:2035
 msgid "fill"
 msgstr "채우기"
 
@@ -5391,7 +5848,7 @@ msgstr "대비 압축"
 
 #: ../build/lib/darktable/plugins/introspection_vibrance.c:33
 #: ../build/lib/darktable/plugins/introspection_vibrance.c:76
-#: ../src/iop/basicadj.c:651 ../src/iop/vibrance.c:64
+#: ../src/iop/basicadj.c:650 ../src/iop/vibrance.c:64
 msgid "vibrance"
 msgstr "생동감"
 
@@ -5457,15 +5914,21 @@ msgid "graphics;photography;raw;"
 msgstr "그래픽스;사진;RAW;"
 
 #: ../data/org.darktable.darktable.appdata.xml.in.h:2
-msgid "darktable manages your camera raw files and images in a database, lets you view them through lighttable mode and develop/enhance them in darkroom mode."
+msgid ""
+"darktable manages your camera raw files and images in a database, lets you "
+"view them through lighttable mode and develop/enhance them in darkroom mode."
 msgstr "darktable은 카메라 RAW 파일과 이미지를 데이터베이스로 관리하며, lighttable모드에서 이미지를 보고 darkroom 모드에서 현상 및 보정할 수 있습니다."
 
 #: ../data/org.darktable.darktable.appdata.xml.in.h:3
-msgid "Other modes besides lighttable and darkroom are a map for geotagging, tethering, print and a slideshow."
+msgid ""
+"Other modes besides lighttable and darkroom are a map for geotagging, "
+"tethering, print and a slideshow."
 msgstr "lighttable과 darkroom 외에도 지도(지오태깅), 테더링, 인쇄, 슬라이드쇼 모드를 지원합니다."
 
 #: ../data/org.darktable.darktable.appdata.xml.in.h:4
-msgid "darktable supports most modern cameras' raw formats, and does all of its processing at very high precision."
+msgid ""
+"darktable supports most modern cameras' raw formats, and does all of its "
+"processing at very high precision."
 msgstr "darktable은 대부분의 최신 카메라 RAW 포맷을 지원하며, 모든 처리를 매우 높은 정밀도로 수행합니다."
 
 #: ../data/org.darktable.darktable.appdata.xml.in.h:5
@@ -5488,20 +5951,20 @@ msgstr "지도에 이미지 표시"
 msgid "Print your images"
 msgstr "이미지 인쇄"
 
-#: ../src/bauhaus/bauhaus.c:910 ../src/bauhaus/bauhaus.c:4067
-#: ../src/iop/colorequal.c:3053
+#: ../src/bauhaus/bauhaus.c:942 ../src/bauhaus/bauhaus.c:4110
+#: ../src/iop/colorequal.c:3016
 msgid "sliders"
 msgstr "슬라이더"
 
-#: ../src/bauhaus/bauhaus.c:912 ../src/bauhaus/bauhaus.c:4072
+#: ../src/bauhaus/bauhaus.c:944 ../src/bauhaus/bauhaus.c:4115
 msgid "dropdowns"
 msgstr "드롭다운"
 
-#: ../src/bauhaus/bauhaus.c:914 ../src/bauhaus/bauhaus.c:4077
+#: ../src/bauhaus/bauhaus.c:946 ../src/bauhaus/bauhaus.c:4120
 msgid "buttons"
 msgstr "버튼"
 
-#: ../src/bauhaus/bauhaus.c:1150
+#: ../src/bauhaus/bauhaus.c:1184
 #, c-format
 msgid ""
 "%sright-click to type a specific value between <b>%s</b> and <b>%s</b>\n"
@@ -5510,98 +5973,103 @@ msgstr ""
 "%s를 우클릭 하여 <b>%s</b>와 <b>%s</b> 사이의 특정한 값을 입력할 수 있습니다. \n"
 "또는 드래그하는 동안 Ctrl+Shift 유지하여 소프트 제한을 무시합니다."
 
-#: ../src/bauhaus/bauhaus.c:3737
+#: ../src/bauhaus/bauhaus.c:3778
 msgid "button on"
 msgstr "버튼 켜짐"
 
-#: ../src/bauhaus/bauhaus.c:3737
+#: ../src/bauhaus/bauhaus.c:3778
 msgid "button off"
 msgstr "버튼 꺼짐"
 
-#: ../src/bauhaus/bauhaus.c:3738
+#: ../src/bauhaus/bauhaus.c:3779
 msgid "button pressed"
 msgstr "버튼 눌림"
 
-#: ../src/bauhaus/bauhaus.c:3974
+#: ../src/bauhaus/bauhaus.c:4015
 msgid "not that many sliders"
 msgstr "슬라이더가 부족합니다"
 
-#: ../src/bauhaus/bauhaus.c:3987
+#: ../src/bauhaus/bauhaus.c:4029
 msgid "not that many dropdowns"
 msgstr "드롭다운이 부족합니다"
 
-#: ../src/bauhaus/bauhaus.c:4005
+#: ../src/bauhaus/bauhaus.c:4048
 msgid "not that many buttons"
 msgstr "버튼이 부족합니다"
 
-#: ../src/bauhaus/bauhaus.c:4010 ../src/gui/accelerators.c:392
+#: ../src/bauhaus/bauhaus.c:4053 ../src/gui/accelerators.c:392
 msgid "value"
 msgstr "값"
 
-#: ../src/bauhaus/bauhaus.c:4011 ../src/bauhaus/bauhaus.c:4017
+#: ../src/bauhaus/bauhaus.c:4054 ../src/bauhaus/bauhaus.c:4060
 #: ../src/gui/accelerators.c:371
 msgid "button"
 msgstr "버튼"
 
-#: ../src/bauhaus/bauhaus.c:4012
+#: ../src/bauhaus/bauhaus.c:4055
 msgid "force"
 msgstr "강제"
 
-#: ../src/bauhaus/bauhaus.c:4013 ../src/libs/navigation.c:246
-#: ../src/libs/navigation.c:263
+#: ../src/bauhaus/bauhaus.c:4056 ../src/libs/navigation.c:265
+#: ../src/libs/navigation.c:282
 msgid "zoom"
 msgstr "확대/축소"
 
-#: ../src/bauhaus/bauhaus.c:4016 ../src/libs/select.c:40
+#: ../src/bauhaus/bauhaus.c:4059 ../src/libs/select.c:40
 msgid "selection"
 msgstr "선택"
 
-#: ../src/bauhaus/bauhaus.c:4056
+#: ../src/bauhaus/bauhaus.c:4099
 msgid "slider"
 msgstr "슬라이더"
 
-#: ../src/bauhaus/bauhaus.c:4061
+#: ../src/bauhaus/bauhaus.c:4104
 msgid "dropdown"
 msgstr "드롭다운"
 
-#: ../src/chart/main.c:504 ../src/common/database.c:3875
-#: ../src/control/jobs/control_jobs.c:2190
-#: ../src/control/jobs/control_jobs.c:2248 ../src/gui/accelerators.c:2536
-#: ../src/gui/accelerators.c:2615 ../src/gui/accelerators.c:2658
-#: ../src/gui/accelerators.c:2687 ../src/gui/accelerators.c:2744
-#: ../src/gui/accelerators.c:2796 ../src/gui/hist_dialog.c:236
-#: ../src/gui/hist_dialog.c:248 ../src/gui/preferences.c:1194
-#: ../src/gui/preferences.c:1234 ../src/gui/presets.c:430
-#: ../src/gui/presets.c:573 ../src/gui/styles_dialog.c:557
-#: ../src/imageio/storage/disk.c:198 ../src/imageio/storage/gallery.c:149
-#: ../src/imageio/storage/latex.c:145 ../src/iop/lut3d.c:1570
-#: ../src/iop/rasterfile.c:262 ../src/libs/collect.c:433
-#: ../src/libs/collect.c:3381 ../src/libs/copy_history.c:114
-#: ../src/libs/export_metadata.c:166 ../src/libs/geotagging.c:951
-#: ../src/libs/import.c:1846 ../src/libs/import.c:1958
-#: ../src/libs/import.c:2057 ../src/libs/metadata.c:843
-#: ../src/libs/metadata_view.c:1435 ../src/libs/modulegroups.c:3643
+#: ../src/chart/main.c:504 ../src/common/database.c:3883
+#: ../src/control/jobs/control_jobs.c:2205
+#: ../src/control/jobs/control_jobs.c:2263 ../src/gui/accelerators.c:2537
+#: ../src/gui/accelerators.c:2616 ../src/gui/accelerators.c:2659
+#: ../src/gui/accelerators.c:2688 ../src/gui/accelerators.c:2745
+#: ../src/gui/accelerators.c:2797 ../src/gui/hist_dialog.c:236
+#: ../src/gui/hist_dialog.c:248 ../src/gui/preferences.c:1221
+#: ../src/gui/preferences.c:1261 ../src/gui/preferences_ai.c:852
+#: ../src/gui/preferences_ai.c:1013 ../src/gui/preferences_ai.c:1400
+#: ../src/gui/preferences_ai.c:1484 ../src/gui/presets.c:430
+#: ../src/gui/presets.c:573 ../src/gui/styles_dialog.c:554
+#: ../src/gui/welcome.c:170 ../src/imageio/storage/disk.c:200
+#: ../src/imageio/storage/gallery.c:149 ../src/imageio/storage/latex.c:145
+#: ../src/iop/lut3d.c:1583 ../src/iop/rasterfile.c:383
+#: ../src/libs/collect.c:463 ../src/libs/collect.c:3740
+#: ../src/libs/copy_history.c:114 ../src/libs/export_metadata.c:166
+#: ../src/libs/geotagging.c:952 ../src/libs/import.c:1816
+#: ../src/libs/import.c:1928 ../src/libs/import.c:2020
+#: ../src/libs/metadata.c:845 ../src/libs/metadata_view.c:1464
+#: ../src/libs/modulegroups.c:3727 ../src/libs/neural_restore.c:4236
 #: ../src/libs/recentcollect.c:232 ../src/libs/styles.c:457
 #: ../src/libs/styles.c:503 ../src/libs/styles.c:595 ../src/libs/styles.c:656
-#: ../src/libs/tagging.c:1671 ../src/libs/tagging.c:1760
-#: ../src/libs/tagging.c:1852 ../src/libs/tagging.c:1981
-#: ../src/libs/tagging.c:2290 ../src/libs/tagging.c:2805
-#: ../src/libs/tagging.c:2847 ../src/libs/tagging.c:3944
+#: ../src/libs/styles.c:1019 ../src/libs/tagging.c:1701
+#: ../src/libs/tagging.c:1790 ../src/libs/tagging.c:1882
+#: ../src/libs/tagging.c:2011 ../src/libs/tagging.c:2320
+#: ../src/libs/tagging.c:2835 ../src/libs/tagging.c:2877
+#: ../src/libs/tagging.c:3981 ../src/views/darkroom.c:3703
+#: ../src/views/darkroom.c:3739
 msgid "_cancel"
 msgstr "취소 (&C)"
 
-#: ../src/chart/main.c:504 ../src/gui/preferences.c:1234
-#: ../src/gui/styles_dialog.c:558 ../src/libs/collect.c:3382
-#: ../src/libs/export_metadata.c:167 ../src/libs/metadata.c:844
-#: ../src/libs/metadata_view.c:1436 ../src/libs/recentcollect.c:233
-#: ../src/libs/styles.c:457 ../src/libs/tagging.c:1853
-#: ../src/libs/tagging.c:1982 ../src/libs/tagging.c:2291
-#: ../src/libs/tagging.c:3945
+#: ../src/chart/main.c:504 ../src/gui/preferences.c:1261
+#: ../src/gui/styles_dialog.c:555 ../src/libs/collect.c:3741
+#: ../src/libs/export_metadata.c:167 ../src/libs/metadata.c:846
+#: ../src/libs/metadata_view.c:1465 ../src/libs/recentcollect.c:233
+#: ../src/libs/styles.c:457 ../src/libs/styles.c:1020
+#: ../src/libs/tagging.c:1883 ../src/libs/tagging.c:2012
+#: ../src/libs/tagging.c:2321 ../src/libs/tagging.c:3982
 msgid "_save"
 msgstr "저장 (&S)"
 
 #. TODO: is the rank interesting, too?
-#: ../src/chart/main.c:1064
+#: ../src/chart/main.c:1070
 #, c-format
 msgid ""
 "average dE: %.02f\n"
@@ -5610,134 +6078,312 @@ msgstr ""
 "평균 dE: %.02f\n"
 "최대 dE: %.02f"
 
-#: ../src/cli/main.c:269
+#: ../src/cli/main.c:284
 msgid "TODO: sorry, due to API restrictions we currently cannot set the BPP to"
 msgstr "알림: API 제한으로 인해 현재 BPP를 설정할 수 없습니다"
 
-#: ../src/cli/main.c:281
+#: ../src/cli/main.c:296
 msgid "unknown option for --hq"
 msgstr "--hq에 대한 알 수 없는 옵션"
 
-#: ../src/cli/main.c:297
+#: ../src/cli/main.c:312
 msgid "unknown option for --export_masks"
 msgstr "--export_masks에 대한 알 수 없는 옵션"
 
-#: ../src/cli/main.c:313
+#: ../src/cli/main.c:328
 msgid "unknown option for --upscale"
 msgstr "--upscale에 대한 알 수 없는 옵션"
 
-#: ../src/cli/main.c:338
+#: ../src/cli/main.c:353
 msgid "unknown option for --apply-custom-presets"
 msgstr "--apply-custom-presets에 대한 알 수 없는 옵션"
 
-#: ../src/cli/main.c:349
+#: ../src/cli/main.c:364
 msgid "too long ext for --out-ext"
 msgstr "--out-ext의 확장자가 너무 깁니다"
 
-#: ../src/cli/main.c:366
+#: ../src/cli/main.c:381
 #, c-format
 msgid "notice: input file or dir '%s' doesn't exist, skipping\n"
-msgstr "알림: 입력 파일 또는 디렉토리 '%s'가 존재하지 않아 건너뜁니다\n"
+msgstr ""
+"알림: 입력 파일 또는 디렉토리 '%s'가 존재하지 않아 건너뜁니다\n"
 
-#: ../src/cli/main.c:375
+#: ../src/cli/main.c:395
 #, c-format
 msgid "incorrect ICC type for --icc-type: '%s'\n"
-msgstr "--icc-type에 잘못된 ICC 타입: '%s'\n"
+msgstr ""
+"--icc-type에 잘못된 ICC 타입: '%s'\n"
 
-#: ../src/cli/main.c:391
+#: ../src/cli/main.c:411
 #, c-format
 msgid "notice: ICC file '%s' doesn't exist, skipping\n"
-msgstr "알림: ICC 파일 '%s'가 존재하지 않아 건너뜁니다\n"
+msgstr ""
+"알림: ICC 파일 '%s'가 존재하지 않아 건너뜁니다\n"
 
-#: ../src/cli/main.c:400
+#: ../src/cli/main.c:420
 #, c-format
 msgid "incorrect ICC intent for --icc-intent: '%s'\n"
-msgstr "--icc-intent에 잘못된 ICC 인텐트: '%s'\n"
+msgstr ""
+"--icc-intent에 잘못된 ICC 인텐트: '%s'\n"
 
-#: ../src/cli/main.c:418
+#: ../src/cli/main.c:438
 #, c-format
 msgid "warning: unknown option '%s'\n"
-msgstr "경고: 알 수 없는 옵션 '%s'\n"
+msgstr ""
+"경고: 알 수 없는 옵션 '%s'\n"
 
-#: ../src/cli/main.c:476
+#: ../src/cli/main.c:468 ../src/cli/main.c:476
+#, c-format
+msgid ""
+"error: output file or directory must be specified\n"
+"\n"
+msgstr ""
+"오류: 출력 파일 또는 디렉토리를 지정해야 합니다\n"
+"\n"
+
+#: ../src/cli/main.c:474
+#, c-format
+msgid ""
+"error: input file and output file must be specified\n"
+"\n"
+msgstr ""
+"오류: 입력 파일과 출력 파일을 지정해야 합니다\n"
+"\n"
+
+#: ../src/cli/main.c:481
+#, c-format
+msgid ""
+"error: too many positional arguments\n"
+"\n"
+msgstr ""
+"오류: 위치 인수가 너무 많습니다\n"
+"\n"
+
+#: ../src/cli/main.c:486
 #, c-format
 msgid "error: input file and import opts specified! that's not supported!\n"
-msgstr "오류: 입력 파일과 가져오기 옵션이 모두 지정되었습니다! 지원되지 않습니다!\n"
+msgstr ""
+"오류: 입력 파일과 가져오기 옵션이 모두 지정되었습니다! 지원되지 않습니다!\n"
 
-#: ../src/cli/main.c:509
+#: ../src/cli/main.c:536
+msgid ""
+"notice: no XMP sidecar file nor library path provided, using default "
+"settings for export"
+msgstr "알림: XMP 사이드카 파일이나 라이브러리 경로가 제공되지 않았습니다. 내보내기에 기본 설정을 사용합니다"
+
+#: ../src/cli/main.c:545
 #, c-format
-msgid "notice: output location is a directory. assuming '%s/$(FILE_NAME).%s' output pattern"
+msgid ""
+"notice: output location is a directory. assuming '%s/$(FILE_NAME).%s' output "
+"pattern"
 msgstr "알림: 출력 위치가 디렉토리입니다. '%s/$(FILE_NAME).%s' 출력 패턴을 사용합니다"
 
 #. output file exists or there's output ext specified and it's same as file...
-#: ../src/cli/main.c:524
+#: ../src/cli/main.c:560
 msgid "output file already exists, it will get renamed"
 msgstr "출력 파일이 이미 존재하여 이름이 변경됩니다"
 
-#: ../src/cli/main.c:556
+#: ../src/cli/main.c:592
 #, c-format
 msgid "error: can't open folder %s"
 msgstr "오류: 폴더 %s를 열 수 없습니다"
 
-#: ../src/cli/main.c:579
+#: ../src/cli/main.c:615
 #, c-format
 msgid "error: can't import file %s"
 msgstr "오류: 파일 %s를 가져올 수 없습니다"
 
-#: ../src/cli/main.c:589
+#: ../src/cli/main.c:625
 #, c-format
 msgid "error: can't read directory %s"
 msgstr "오류: 디렉토리 %s를 읽을 수 없습니다"
 
-#: ../src/cli/main.c:605
+#: ../src/cli/main.c:641
 #, c-format
 msgid "error: can't open file %s"
 msgstr "오류: 파일 %s를 열 수 없습니다"
 
-#: ../src/cli/main.c:622
+#: ../src/cli/main.c:658
 #, c-format
 msgid "no images to export, aborting\n"
-msgstr "내보낼 이미지가 없어 중단합니다\n"
+msgstr ""
+"내보낼 이미지가 없어 중단합니다\n"
 
-#: ../src/cli/main.c:639
+#: ../src/cli/main.c:675
 #, c-format
 msgid "error: can't open XMP file %s"
 msgstr "오류: XMP 파일 %s를 열 수 없습니다"
 
-#: ../src/cli/main.c:660
+#: ../src/cli/main.c:696
 msgid "empty history stack"
 msgstr "히스토리 스택이 비어 있습니다"
 
 #. too long ext, no point in wasting time
-#: ../src/cli/main.c:672
+#: ../src/cli/main.c:708
 #, c-format
 msgid "too long output file extension: %s\n"
-msgstr "출력 파일 확장자가 너무 깁니다: %s\n"
+msgstr ""
+"출력 파일 확장자가 너무 깁니다: %s\n"
 
 #. no ext or empty ext, no point in wasting time
-#: ../src/cli/main.c:680
+#: ../src/cli/main.c:716
 #, c-format
 msgid "no output file extension given\n"
-msgstr "출력 파일 확장자가 지정되지 않았습니다\n"
+msgstr ""
+"출력 파일 확장자가 지정되지 않았습니다\n"
 
-#: ../src/cli/main.c:725
-msgid "cannot find disk storage module. please check your installation, something seems to be broken."
+#: ../src/cli/main.c:761
+msgid ""
+"cannot find disk storage module. please check your installation, something "
+"seems to be broken."
 msgstr "디스크 저장소 모듈을 찾을 수 없습니다. 설치 상태를 확인해 주세요.문제가 있는 것 같습니다."
 
-#: ../src/cli/main.c:735
+#: ../src/cli/main.c:771
 msgid "failed to get parameters from storage module, aborting export ..."
 msgstr "저장소 모듈에서 파라메터를 가져오지 못해 내보내기를 중단합니다..."
 
-#: ../src/cli/main.c:751
+#: ../src/cli/main.c:787
 #, c-format
 msgid "unknown extension '.%s'"
 msgstr "알 수 없는 확장자 '.%s'"
 
-#: ../src/cli/main.c:761
+#: ../src/cli/main.c:797
 msgid "failed to get parameters from format module, aborting export ..."
 msgstr "포맷 모듈에서 파라메터를 가져오지 못해 내보내기를 중단합니다..."
 
-#: ../src/common/camera_control.c:204
+#: ../src/common/ai/restore.c:278
+#, c-format
+msgid "raw denoise model %s: incompatible input_kind"
+msgstr "RAW 노이즈 감소 모델 %s: 호환되지 않는 input_kind"
+
+#: ../src/common/ai/restore.c:309
+#, c-format
+msgid "AI model %s: missing input_sizes in manifest"
+msgstr "AI 모델 %s: 매니페스트에 input_sizes가 없습니다"
+
+#: ../src/common/ai/restore_raw_bayer.c:523
+#: ../src/common/ai/restore_raw_bayer.c:870
+#: ../src/common/ai/restore_raw_linear.c:584
+#: ../src/common/ai/restore_raw_linear.c:1008
+msgid "AI raw denoise: GPU inference failed, falling back to CPU"
+msgstr "AI RAW 노이즈 감소: GPU 추론에 실패하여 CPU로 대체합니다"
+
+#: ../src/common/ai/restore_rgb.c:668
+msgid "AI denoise: GPU inference failed, falling back to CPU"
+msgstr "AI 노이즈 감소: GPU 추론에 실패하여 CPU로 대체합니다"
+
+#: ../src/common/ai_models.c:200
+#, c-format
+msgid "network error: %s"
+msgstr "네트워크 오류: %s"
+
+#: ../src/common/ai_models.c:203
+#, c-format
+msgid "model repository \"%s\" missing releases-index.json"
+msgstr "모델 저장소 \"%s\"에 releases-index.json이 없습니다"
+
+#: ../src/common/ai_models.c:207
+#, c-format
+msgid "could not fetch releases-index.json (HTTP %ld)"
+msgstr "releases-index.json을 가져올 수 없습니다 (HTTP %ld)"
+
+#: ../src/common/ai_models.c:1427 ../src/common/ai_models.c:1492
+msgid "invalid parameters"
+msgstr "잘못된 파라메터"
+
+#: ../src/common/ai_models.c:1430
+#, c-format
+msgid "file not found: %s"
+msgstr "파일을 찾을 수 없음: %s"
+
+#: ../src/common/ai_models.c:1438
+#, c-format
+msgid "archive top-level directory is not a valid model id: \"%s\""
+msgstr "아카이브 최상위 디렉토리가 유효한 모델 id가 아닙니다: \"%s\""
+
+#: ../src/common/ai_models.c:1447
+msgid "failed to extract model archive"
+msgstr "모델 아카이브 추출에 실패하였습니다"
+
+#: ../src/common/ai_models.c:1500
+msgid "model not found in registry"
+msgstr "레지스트리에서 모델을 찾을 수 없습니다"
+
+#: ../src/common/ai_models.c:1506
+msgid "model has no download asset defined"
+msgstr "모델에 정의된 다운로드 자산이 없습니다"
+
+#: ../src/common/ai_models.c:1517
+msgid "invalid asset filename"
+msgstr "잘못된 자산 파일명"
+
+#: ../src/common/ai_models.c:1523
+msgid "model is already downloading"
+msgstr "모델을 이미 다운로드하고 있습니다"
+
+#: ../src/common/ai_models.c:1554
+msgid "invalid repository format"
+msgstr "잘못된 저장소 형식"
+
+#: ../src/common/ai_models.c:1579
+#, c-format
+msgid "no compatible ai model release found for darktable %s"
+msgstr "darktable %s에 호환되는 AI 모델 릴리스를 찾을 수 없습니다"
+
+#: ../src/common/ai_models.c:1595
+#, c-format
+msgid ""
+"could not obtain checksum for %s — refusing to download without integrity "
+"verification"
+msgstr "%s의 체크섬을 가져올 수 없습니다 — 무결성 검증 없이는 다운로드하지 않습니다"
+
+#: ../src/common/ai_models.c:1613
+msgid "failed to build download url"
+msgstr "다운로드 URL 생성에 실패하였습니다"
+
+#: ../src/common/ai_models.c:1639
+msgid "failed to initialize download"
+msgstr "다운로드 초기화에 실패하였습니다"
+
+#: ../src/common/ai_models.c:1694
+#, c-format
+msgid "failed to open %s"
+msgstr "%s을(를) 열 수 없습니다"
+
+#: ../src/common/ai_models.c:1740
+msgid "download cancelled"
+msgstr "다운로드가 취소됨"
+
+#: ../src/common/ai_models.c:1742
+#, c-format
+msgid "download failed after %d attempts: %s"
+msgstr "%d번 시도 후 다운로드에 실패하였습니다: %s"
+
+#: ../src/common/ai_models.c:1745
+#, c-format
+msgid "http error: %ld"
+msgstr "HTTP 오류: %ld"
+
+#: ../src/common/ai_models.c:1767
+msgid "checksum verification failed"
+msgstr "체크섬 검증에 실패하였습니다"
+
+#: ../src/common/ai_models.c:1778
+#, c-format
+msgid ""
+"no checksum available for %s — refusing to install without integrity "
+"verification"
+msgstr "%s에 사용 가능한 체크섬이 없습니다 — 무결성 검증 없이는 설치하지 않습니다"
+
+#: ../src/common/ai_models.c:1791
+msgid "failed to finalize downloaded file"
+msgstr "다운로드한 파일을 마무리하는 데 실패하였습니다"
+
+#: ../src/common/ai_models.c:1803
+msgid "failed to extract archive"
+msgstr "아카이브 추출에 실패하였습니다"
+
+#: ../src/common/camera_control.c:205
 #, c-format
 msgid ""
 "camera `%s' on port `%s' error %s\n"
@@ -5748,22 +6394,26 @@ msgstr ""
 "\n"
 "카메라에 접근 권한이 있고, 다른 방식으로 마운트되어 있지 않은지 확인하세요"
 
-#: ../src/common/camera_control.c:947
-#, c-format
-msgid "failed to initialize `%s' on port `%s', likely causes are: locked by another application, no access to devices etc"
-msgstr "`%s' - 포트 `%s'의 초기화 실패, 가능한 원인: 다른 프로그램에서 사용 중이거나,장치 접근 권한 없음 등"
-
 #: ../src/common/camera_control.c:960
 #, c-format
-msgid "`%s' on port `%s' is not interesting because it supports neither tethering nor import"
+msgid ""
+"failed to initialize `%s' on port `%s', likely causes are: locked by another "
+"application, no access to devices etc"
+msgstr "`%s' - 포트 `%s'의 초기화 실패, 가능한 원인: 다른 프로그램에서 사용 중이거나,장치 접근 권한 없음 등"
+
+#: ../src/common/camera_control.c:973
+#, c-format
+msgid ""
+"`%s' on port `%s' is not interesting because it supports neither tethering "
+"nor import"
 msgstr "`%s' - 포트 `%s'는 테더링 및 가져오기를 지원하지 않아 사용할 수 없습니다"
 
-#: ../src/common/camera_control.c:1020
+#: ../src/common/camera_control.c:1033
 #, c-format
 msgid "camera `%s' on port `%s' disconnected while mounted"
 msgstr "카메라 `%s' - 포트 `%s'가 마운트된 상태에서 연결이 끊어졌습니다"
 
-#: ../src/common/camera_control.c:1028
+#: ../src/common/camera_control.c:1041
 #, c-format
 msgid ""
 "camera `%s' on port `%s' needs to be remounted\n"
@@ -5782,16 +6432,16 @@ msgstr "필름롤"
 
 #. manage the scripts
 #: ../src/common/collection.c:614
-#: ../src/external/lua-scripts/tools/script_manager.lua:1429
+#: ../src/external/lua-scripts/tools/script_manager.lua:1521
 msgid "folder"
 msgstr "폴더"
 
-#: ../src/common/collection.c:616
+#: ../src/common/collection.c:616 ../src/libs/filters/misc.c:405
 msgid "camera"
 msgstr "카메라"
 
-#: ../src/common/collection.c:618 ../src/gui/metadata_tags.c:114
-#: ../src/libs/tagging.c:3721
+#: ../src/common/collection.c:618 ../src/gui/metadata_tags.c:116
+#: ../src/libs/tagging.c:3751
 msgid "tag"
 msgstr "태그"
 
@@ -5799,178 +6449,199 @@ msgstr "태그"
 msgid "capture date"
 msgstr "촬영 날짜"
 
-#: ../src/common/collection.c:622 ../src/libs/filtering.c:52
+#: ../src/common/collection.c:622
+msgid "capture month"
+msgstr "촬영 월"
+
+#: ../src/common/collection.c:624 ../src/libs/filtering.c:52
 msgid "capture time"
 msgstr "촬영 시간"
 
-#: ../src/common/collection.c:624 ../src/libs/filtering.c:53
+#: ../src/common/collection.c:626 ../src/libs/filtering.c:53
 msgid "import time"
 msgstr "가져오기 시간"
 
-#: ../src/common/collection.c:626 ../src/libs/filtering.c:54
+#: ../src/common/collection.c:628 ../src/libs/filtering.c:54
 msgid "modification time"
 msgstr "수정 시각"
 
-#: ../src/common/collection.c:628 ../src/libs/filtering.c:55
+#: ../src/common/collection.c:630 ../src/libs/filtering.c:55
 msgid "export time"
 msgstr "내보내기 시간"
 
-#: ../src/common/collection.c:630 ../src/libs/filtering.c:56
+#: ../src/common/collection.c:632 ../src/libs/filtering.c:56
 msgid "print time"
 msgstr "인쇄 시간"
 
-#: ../src/common/collection.c:632 ../src/libs/collect.c:3737
-#: ../src/libs/filtering.c:2213 ../src/libs/filtering.c:2233
+#: ../src/common/collection.c:634 ../src/libs/collect.c:4096
+#: ../src/libs/filtering.c:2224 ../src/libs/filtering.c:2244
 #: ../src/libs/filters/history.c:153 ../src/libs/history.c:98
 msgid "history"
 msgstr "히스토리"
 
-#: ../src/common/collection.c:634 ../src/common/colorlabels.c:388
-#: ../src/develop/lightroom.c:1607 ../src/dtgtk/thumbnail.c:1567
+#: ../src/common/collection.c:636 ../src/common/colorlabels.c:389
+#: ../src/develop/lightroom.c:1607 ../src/dtgtk/thumbnail.c:1637
 #: ../src/libs/filtering.c:59 ../src/libs/filters/colors.c:301
 #: ../src/libs/filters/colors.c:312 ../src/libs/tools/colorlabels.c:146
 msgid "color label"
 msgstr "색상 레이블"
 
 #. iso
-#: ../src/common/collection.c:640 ../src/gui/preferences.c:944
+#: ../src/common/collection.c:642 ../src/gui/preferences.c:973
 #: ../src/gui/presets.c:677 ../src/libs/camera.c:582
 #: ../src/libs/metadata_view.c:161
 msgid "ISO"
 msgstr "ISO"
 
 #. aperture
-#: ../src/common/collection.c:642 ../src/gui/preferences.c:956
-#: ../src/gui/presets.c:712 ../src/iop/lens.cc:4416 ../src/libs/camera.c:569
+#: ../src/common/collection.c:644 ../src/gui/preferences.c:985
+#: ../src/gui/presets.c:712 ../src/iop/lens.cc:4410 ../src/libs/camera.c:569
 #: ../src/libs/camera.c:571 ../src/libs/metadata_view.c:150
 msgid "aperture"
 msgstr "조리개"
 
-#: ../src/common/collection.c:650 ../src/libs/filtering.c:48
+#: ../src/common/collection.c:652 ../src/libs/filtering.c:48
 #: ../src/libs/filters/filename.c:367 ../src/libs/metadata_view.c:136
 msgid "filename"
 msgstr "파일명"
 
-#: ../src/common/collection.c:652 ../src/develop/lightroom.c:1598
-#: ../src/libs/geotagging.c:142
+#: ../src/common/collection.c:654 ../src/develop/lightroom.c:1598
+#: ../src/libs/geotagging.c:143
 msgid "geotagging"
 msgstr "지오태깅"
 
-#: ../src/common/collection.c:654 ../src/libs/filtering.c:63
+#: ../src/common/collection.c:656 ../src/libs/filtering.c:63
 msgid "group"
 msgstr "그룹"
 
-#: ../src/common/collection.c:656 ../src/dtgtk/thumbnail.c:1582
+#: ../src/common/collection.c:658 ../src/libs/filters/duplicates.c:157
+msgid "duplicates"
+msgstr "복제본"
+
+#: ../src/common/collection.c:660 ../src/dtgtk/thumbnail.c:1652
 #: ../src/libs/filters/local_copy.c:142 ../src/libs/metadata_view.c:139
-#: ../src/libs/metadata_view.c:365
+#: ../src/libs/metadata_view.c:381
 msgid "local copy"
 msgstr "부분 복사"
 
-#: ../src/common/collection.c:658 ../src/gui/preferences.c:908
+#: ../src/common/collection.c:662 ../src/gui/preferences.c:937
 msgid "module"
 msgstr "모듈"
 
-#: ../src/common/collection.c:660 ../src/gui/hist_dialog.c:359
-#: ../src/gui/styles_dialog.c:749 ../src/gui/styles_dialog.c:796
-#: ../src/libs/filters/module_order.c:161 ../src/libs/ioporder.c:39
+#: ../src/common/collection.c:664 ../src/gui/hist_dialog.c:359
+#: ../src/gui/styles_dialog.c:746 ../src/gui/styles_dialog.c:793
+#: ../src/libs/filters/module_order.c:161 ../src/libs/ioporder.c:38
 msgid "module order"
 msgstr "모듈 순서"
 
-#: ../src/common/collection.c:662
+#: ../src/common/collection.c:666
 msgid "range rating"
 msgstr "등급 범위"
 
-#: ../src/common/collection.c:664 ../src/common/ratings.c:337
+#: ../src/common/collection.c:668 ../src/common/ratings.c:403
 #: ../src/develop/lightroom.c:1582 ../src/libs/filtering.c:58
 #: ../src/libs/tools/ratings.c:110
 msgid "rating"
 msgstr "등급"
 
-#: ../src/common/collection.c:666
+#: ../src/common/collection.c:670
 msgid "search"
 msgstr "검색"
 
-#: ../src/common/collection.c:668 ../src/libs/metadata_view.c:154
+#: ../src/common/collection.c:672 ../src/libs/filters/misc.c:419
+#: ../src/libs/metadata_view.c:154
 msgid "white balance"
 msgstr "화이트 밸런스"
 
-#: ../src/common/collection.c:670 ../src/common/wb_presets.c:83
-#: ../src/libs/metadata_view.c:155
+#: ../src/common/collection.c:674 ../src/common/wb_presets.c:83
+#: ../src/libs/filters/misc.c:426 ../src/libs/metadata_view.c:155
 msgid "flash"
 msgstr "플래시"
 
-#: ../src/common/collection.c:672 ../src/libs/metadata_view.c:153
+#: ../src/common/collection.c:676 ../src/libs/filters/misc.c:433
+#: ../src/libs/metadata_view.c:153
 msgid "exposure program"
 msgstr "노출 프로그램"
 
-#: ../src/common/collection.c:674 ../src/libs/metadata_view.c:156
+#: ../src/common/collection.c:678 ../src/libs/filters/misc.c:440
+#: ../src/libs/metadata_view.c:156
 msgid "metering mode"
 msgstr "측광 모드"
 
-#: ../src/common/collection.c:1499 ../src/libs/collect.c:1905
+#: ../src/common/collection.c:1503 ../src/libs/collect.c:1985
 #: ../src/libs/filters/history.c:38
 msgid "auto applied"
 msgstr "자동 적용"
 
-#: ../src/common/collection.c:1505 ../src/libs/collect.c:1905
+#: ../src/common/collection.c:1509 ../src/libs/collect.c:1985
 #: ../src/libs/filters/history.c:38
 msgid "altered"
 msgstr "수정됨"
 
-#: ../src/common/collection.c:1523 ../src/common/collection.c:1634
-#: ../src/libs/collect.c:1272 ../src/libs/collect.c:1460
-#: ../src/libs/collect.c:1486 ../src/libs/collect.c:1630
-#: ../src/libs/collect.c:2793
+#: ../src/common/collection.c:1527 ../src/common/collection.c:1668
+#: ../src/libs/collect.c:1306 ../src/libs/collect.c:1516
+#: ../src/libs/collect.c:1542 ../src/libs/collect.c:1709
+#: ../src/libs/collect.c:3133
 msgid "not tagged"
 msgstr "태그 없음"
 
-#: ../src/common/collection.c:1524 ../src/libs/collect.c:1486
+#: ../src/common/collection.c:1528 ../src/libs/collect.c:1542
 #: ../src/libs/map_locations.c:740
 msgid "tagged"
 msgstr "태그됨"
 
-#: ../src/common/collection.c:1525
+#: ../src/common/collection.c:1529
 msgid "tagged*"
 msgstr "태그됨*"
 
 #. local copy
-#: ../src/common/collection.c:1559 ../src/libs/collect.c:1927
+#: ../src/common/collection.c:1563 ../src/libs/collect.c:2007
 #: ../src/libs/filters/local_copy.c:38
 msgid "not copied locally"
 msgstr "부분적으로 복사 안 됨"
 
-#: ../src/common/collection.c:1564 ../src/libs/collect.c:1926
+#: ../src/common/collection.c:1568 ../src/libs/collect.c:2006
 #: ../src/libs/filters/local_copy.c:38
 msgid "copied locally"
 msgstr "부분적으로 복사됨"
 
+#. duplicates
+#: ../src/common/collection.c:1580 ../src/libs/filters/duplicates.c:38
+msgid "images with duplicates"
+msgstr "복제본이 있는 이미지"
+
+#: ../src/common/collection.c:1596 ../src/libs/filters/duplicates.c:38
+msgid "duplicates only"
+msgstr "복제본만"
+
 #. if its undefined
-#: ../src/common/collection.c:1606 ../src/common/collection.c:1718
-#: ../src/common/collection.c:1745 ../src/common/collection.c:1772
-#: ../src/common/collection.c:1798 ../src/common/collection.c:1824
-#: ../src/common/collection.c:2622 ../src/libs/collect.c:2320
-#: ../src/libs/collect.c:2321
+#: ../src/common/collection.c:1640 ../src/common/collection.c:1752
+#: ../src/common/collection.c:1779 ../src/common/collection.c:1806
+#: ../src/common/collection.c:1832 ../src/common/collection.c:1858
+#: ../src/common/collection.c:2769 ../src/libs/collect.c:2432
+#: ../src/libs/collect.c:2433 ../src/libs/filters/misc.c:206
+#: ../src/libs/filters/misc.c:208
 msgid "unnamed"
 msgstr "이름 없음"
 
-#: ../src/common/collection.c:2273 ../src/libs/collect.c:2211
+#: ../src/common/collection.c:2375 ../src/libs/collect.c:2307
 msgid "not defined"
 msgstr "정의되지 않음"
 
-#: ../src/common/collection.c:2772
+#: ../src/common/collection.c:2919
 #, c-format
 msgid "<b>%d</b> image (#<b>%d</b>) selected of <b>%d</b>"
 msgstr "(<b>%d</b>)번 이미지 <b>%d</b>개가  <b>%d</b>개 중 선택됨"
 
-#: ../src/common/collection.c:2779
+#: ../src/common/collection.c:2926
 #, c-format
 msgid "<b>%d</b> image selected of <b>%d</b>"
 msgid_plural "<b>%d</b> images selected of <b>%d</b>"
 msgstr[0] "<b>%d</b>개 이미지가 <b>%d</b>개 중 선택됨"
 
-#: ../src/common/color_vocabulary.c:38 ../src/develop/blend_gui.c:2374
-#: ../src/develop/blend_gui.c:2422 ../src/gui/guides.c:851
-#: ../src/iop/channelmixerrgb.c:4628 ../src/iop/levels.c:675
+#: ../src/common/color_vocabulary.c:38 ../src/develop/blend_gui.c:2375
+#: ../src/develop/blend_gui.c:2423 ../src/gui/guides.c:851
+#: ../src/iop/channelmixerrgb.c:4656 ../src/iop/levels.c:675
 #: ../src/iop/rgblevels.c:963 ../src/iop/rgblevels.c:1078
 msgid "gray"
 msgstr "회색"
@@ -6019,7 +6690,8 @@ msgstr "뺨"
 #: ../src/common/color_vocabulary.c:202
 #, c-format
 msgid "average %s skin tone\n"
-msgstr "평균 %s 피부 톤\n"
+msgstr ""
+"평균 %s 피부 톤\n"
 
 #. 0° - pinkish red
 #: ../src/common/color_vocabulary.c:222
@@ -6258,121 +6930,126 @@ msgstr "색상 레이블이 %s로 설정됨"
 msgid "all colorlabels removed"
 msgstr "모든 색상 레이블이 제거됨"
 
-#: ../src/common/colorlabels.c:379
+#: ../src/common/colorlabels.c:380
 #: ../src/external/lua-scripts/tools/executable_manager.lua:224
-#: ../src/gui/accelerators.c:188 ../src/libs/image.c:640
+#: ../src/gui/accelerators.c:193 ../src/libs/image.c:640
 msgid "clear"
 msgstr "지우기"
 
-#: ../src/common/colorspaces.c:1416 ../src/common/colorspaces.c:1773
+#: ../src/common/colorspaces.c:1448 ../src/common/colorspaces.c:1805
 msgid "work profile"
 msgstr "작업 프로파일"
 
-#: ../src/common/colorspaces.c:1426 ../src/common/colorspaces.c:1771
-#: ../src/views/darkroom.c:2780
+#: ../src/common/colorspaces.c:1458 ../src/common/colorspaces.c:1803
+#: ../src/views/darkroom.c:3405
 msgid "softproof profile"
 msgstr "소프트프루프 프로파일"
 
-#: ../src/common/colorspaces.c:1436 ../src/common/colorspaces.c:1753
+#: ../src/common/colorspaces.c:1468 ../src/common/colorspaces.c:1785
 msgid "system display profile"
 msgstr "시스템 디스플레이 프로파일"
 
-#: ../src/common/colorspaces.c:1441 ../src/common/colorspaces.c:1775
+#: ../src/common/colorspaces.c:1473 ../src/common/colorspaces.c:1807
 msgid "system display profile (second window)"
 msgstr "시스템 디스플레이 프로파일 (두 번째 창)"
 
-#: ../src/common/colorspaces.c:1454
+#: ../src/common/colorspaces.c:1486
 msgid "sRGB (web-safe)"
 msgstr "sRGB (웹 안전 색상)"
 
-#: ../src/common/colorspaces.c:1474 ../src/common/colorspaces.c:1777
+#: ../src/common/colorspaces.c:1506 ../src/common/colorspaces.c:1809
 msgid "Rec709 RGB"
 msgstr "Rec709 RGB"
 
-#: ../src/common/colorspaces.c:1489
+#: ../src/common/colorspaces.c:1521
 msgid "PQ Rec2020 RGB"
 msgstr "PQ Rec2020 RGB"
 
-#: ../src/common/colorspaces.c:1497
+#: ../src/common/colorspaces.c:1529
 msgid "HLG Rec2020 RGB"
 msgstr "HLG Rec2020 RGB"
 
-#: ../src/common/colorspaces.c:1504
+#: ../src/common/colorspaces.c:1536
 msgid "PQ P3 RGB"
 msgstr "PQ P3 RGB"
 
-#: ../src/common/colorspaces.c:1510
+#: ../src/common/colorspaces.c:1542
 msgid "HLG P3 RGB"
 msgstr "HLG P3 RGB"
 
-#: ../src/common/colorspaces.c:1517
+#: ../src/common/colorspaces.c:1549
 msgid "Display P3 RGB"
 msgstr "Display P3 RGB"
 
-#: ../src/common/colorspaces.c:1532 ../src/common/colorspaces.c:1747
+#: ../src/common/colorspaces.c:1564 ../src/common/colorspaces.c:1779
 msgid "linear XYZ"
 msgstr "선형 XYZ"
 
-#: ../src/common/colorspaces.c:1539 ../src/common/colorspaces.c:1749
-#: ../src/develop/blend_gui.c:144 ../src/develop/blend_gui.c:2050
+#: ../src/common/colorspaces.c:1571 ../src/common/colorspaces.c:1781
+#: ../src/develop/blend_gui.c:144 ../src/develop/blend_gui.c:2051
 #: ../src/libs/colorpicker.c:52 ../src/libs/colorpicker.c:369
 msgid "Lab"
 msgstr "Lab"
 
-#: ../src/common/colorspaces.c:1547 ../src/common/colorspaces.c:1751
+#: ../src/common/colorspaces.c:1579 ../src/common/colorspaces.c:1783
 msgid "linear infrared BGR"
 msgstr "선형 적외선 BGR"
 
-#: ../src/common/colorspaces.c:1552
+#: ../src/common/colorspaces.c:1584
 msgid "BRG (for testing)"
 msgstr "BRG (테스트용)"
 
-#: ../src/common/colorspaces.c:1658
+#: ../src/common/colorspaces.c:1690
 #, c-format
-msgid "profile `%s' not usable as histogram profile. it has been replaced by sRGB!"
+msgid ""
+"profile `%s' not usable as histogram profile. it has been replaced by sRGB!"
 msgstr "프로파일 `%s'은 히스토그램 프로파일로 사용할 수 없습니다. sRGB로 대체되었습니다!"
 
-#: ../src/common/colorspaces.c:1755
+#: ../src/common/colorspaces.c:1769
+msgid "no filename"
+msgstr "파일명 없음"
+
+#: ../src/common/colorspaces.c:1787
 msgid "embedded ICC profile"
 msgstr "내장 ICC 프로파일"
 
-#: ../src/common/colorspaces.c:1757
+#: ../src/common/colorspaces.c:1789
 msgid "embedded matrix"
 msgstr "내장 매트릭스"
 
-#: ../src/common/colorspaces.c:1759
+#: ../src/common/colorspaces.c:1791
 msgid "standard color matrix"
 msgstr "표준 색상 매트릭스"
 
-#: ../src/common/colorspaces.c:1761
+#: ../src/common/colorspaces.c:1793
 msgid "enhanced color matrix"
 msgstr "향상된 색상 매트릭스"
 
-#: ../src/common/colorspaces.c:1763
+#: ../src/common/colorspaces.c:1795
 msgid "vendor color matrix"
 msgstr "제조사 색상 매트릭스"
 
-#: ../src/common/colorspaces.c:1765
+#: ../src/common/colorspaces.c:1797
 msgid "alternate color matrix"
 msgstr "대체 색상 매트릭스"
 
-#: ../src/common/colorspaces.c:1767
+#: ../src/common/colorspaces.c:1799
 msgid "BRG (experimental)"
 msgstr "BRG (실험실)"
 
-#: ../src/common/colorspaces.c:1781
+#: ../src/common/colorspaces.c:1813
 msgid "PQ Rec2020"
 msgstr "PQ Rec2020"
 
-#: ../src/common/colorspaces.c:1783
+#: ../src/common/colorspaces.c:1815
 msgid "HLG Rec2020"
 msgstr "HLG Rec2020"
 
-#: ../src/common/colorspaces.c:1785
+#: ../src/common/colorspaces.c:1817
 msgid "PQ P3"
 msgstr "PQ P3"
 
-#: ../src/common/colorspaces.c:1787
+#: ../src/common/colorspaces.c:1819
 msgid "HLG P3"
 msgstr "HLG P3"
 
@@ -6390,43 +7067,43 @@ msgstr "인쇄 옵션의 임시 파일 생성에 실패하였습니다"
 msgid "printing on `%s' cancelled"
 msgstr "`%s'로의 인쇄가 취소됨"
 
-#: ../src/common/cups_print.c:602
+#: ../src/common/cups_print.c:626
 #, c-format
 msgid "error while printing `%s' on `%s'"
 msgstr "`%s'을 `%s'에서 인쇄하는 중 오류가 발생하였습니다"
 
-#: ../src/common/cups_print.c:604
+#: ../src/common/cups_print.c:628
 #, c-format
 msgid "printing `%s' on `%s'"
 msgstr "`%s'을 `%s'로 인쇄 중"
 
-#: ../src/common/darktable.c:425
+#: ../src/common/darktable.c:432
 #, c-format
 msgid "found strange path `%s'"
 msgstr "비정상적인 경로 `%s'이 발견되었습니다"
 
-#: ../src/common/darktable.c:440
+#: ../src/common/darktable.c:447
 #, c-format
 msgid "error loading directory `%s'"
 msgstr "디렉토리 `%s'을 로딩하는 중 오류가 발생하였습니다"
 
-#: ../src/common/darktable.c:464
+#: ../src/common/darktable.c:471
 #, c-format
 msgid "file `%s' has unsupported format!"
 msgstr "파일 `%s'은 지원되지 않는 형식입니다!"
 
-#: ../src/common/darktable.c:466
+#: ../src/common/darktable.c:473
 #, c-format
 msgid "file `%s' has unknown format!"
 msgstr "파일 `%s'은 알 수 없는 형식입니다!"
 
-#: ../src/common/darktable.c:479 ../src/control/jobs/control_jobs.c:2844
-#: ../src/control/jobs/control_jobs.c:2899
+#: ../src/common/darktable.c:486 ../src/control/jobs/control_jobs.c:2877
+#: ../src/control/jobs/control_jobs.c:2932
 #, c-format
 msgid "error loading file `%s'"
 msgstr "파일 `%s'을 로딩하는 중 오류가 발생하였습니다"
 
-#: ../src/common/darktable.c:1562
+#: ../src/common/darktable.c:1622
 #, c-format
 msgid ""
 "you do not have write access to create one of the user directories:\n"
@@ -6441,173 +7118,202 @@ msgstr ""
 "\n"
 "이 문제를 해결한 후 darktable을 다시 실행하세요"
 
-#: ../src/common/darktable.c:1567
+#: ../src/common/darktable.c:1627
 msgid "darktable - unable to create directories"
 msgstr "darktable - 디렉토리를 생성할 수 없습니다"
 
-#: ../src/common/darktable.c:1569 ../src/common/database.c:4121
-#: ../src/common/database.c:4323
+#: ../src/common/darktable.c:1629 ../src/common/database.c:4137
+#: ../src/common/database.c:4339
 msgid "_quit darktable"
 msgstr "darktable 종료 (&Q)"
 
 #. initialize the database
-#: ../src/common/darktable.c:1625
+#: ../src/common/darktable.c:1703
 msgid "opening image library"
 msgstr "이미지 라이브러리 여는 중"
 
-#: ../src/common/darktable.c:1638
+#: ../src/common/darktable.c:1716
 msgid "forwarding image(s) to running instance"
 msgstr "이미지를 실행 중인 인스턴스로 전달 중"
 
-#: ../src/common/darktable.c:1669
+#: ../src/common/darktable.c:1747
 msgid "preparing database"
 msgstr "데이터베이스 준비 중"
 
 #. init darktable tags table
-#: ../src/common/darktable.c:1673
+#: ../src/common/darktable.c:1751
 msgid "setting up tags table"
 msgstr "태그 테이블 설정 중"
 
 #. Initialize the signal system
-#: ../src/common/darktable.c:1677
+#: ../src/common/darktable.c:1755
 msgid "initializing signals and control"
 msgstr "신호 및 제어 초기화 중"
 
-#: ../src/common/darktable.c:1696
+#: ../src/common/darktable.c:1773
 msgid "importing default styles"
 msgstr "기본 스타일 가져오는 중"
 
-#: ../src/common/darktable.c:1796
+#: ../src/common/darktable.c:1876
 msgid "initializing GraphicsMagick"
 msgstr "GraphicsMagick 초기화 중"
 
 #. ImageMagick init
-#: ../src/common/darktable.c:1808
+#: ../src/common/darktable.c:1888
 msgid "initializing ImageMagick"
 msgstr "ImageMagick 초기화 중"
 
-#: ../src/common/darktable.c:1813
+#: ../src/common/darktable.c:1893
 msgid "initializing libheif"
 msgstr "libheif 초기화 중"
 
-#: ../src/common/darktable.c:1817
-msgid "starting OpenCL"
-msgstr "OpenCL 시작 중"
+#: ../src/common/darktable.c:1897
+msgid "initializing WB presets"
+msgstr "화이트 밸런스 프리셋 초기화 중"
 
-#: ../src/common/darktable.c:1829
+#. Do locale-sensitive init BEFORE starting any background worker jobs
+#: ../src/common/darktable.c:1901
 msgid "loading noise profiles"
 msgstr "노이즈 프로파일 로딩 중"
 
-#: ../src/common/darktable.c:1846
+#: ../src/common/darktable.c:1904
+msgid "starting OpenCL"
+msgstr "OpenCL 시작 중"
+
+#: ../src/common/darktable.c:1928
 msgid "synchronizing local copies"
 msgstr "로컬 복사본 동기화 중"
 
 #. Initialize the camera control.  this is done late so that the
 #. gui can react to the signal sent but before switching to
 #. lighttable!
-#: ../src/common/darktable.c:1853
+#: ../src/common/darktable.c:1935
 msgid "initializing camera control"
 msgstr "카메라 제어 초기화 중"
 
-#: ../src/common/darktable.c:1863
+#: ../src/common/darktable.c:1948
 msgid "initializing GUI"
 msgstr "GUI 초기화 중"
 
-#: ../src/common/darktable.c:1893
+#: ../src/common/darktable.c:1965
+msgid "loading image formats"
+msgstr "이미지 형식 로딩 중"
+
+#: ../src/common/darktable.c:1970 ../src/develop/imageop.c:1719
 msgid "loading processing modules"
 msgstr "처리 모듈 로딩 중"
 
-#: ../src/common/darktable.c:1928
-msgid "loading utility modules"
-msgstr "유틸리티 모듈 로딩 중"
-
-#. init the gui part of views
-#: ../src/common/darktable.c:1933
+#: ../src/common/darktable.c:2002
 msgid "loading views"
 msgstr "보기 로딩 중"
 
-#: ../src/common/darktable.c:1939
+#: ../src/common/darktable.c:2006 ../src/libs/lib.c:944
+msgid "loading utility modules"
+msgstr "유틸리티 모듈 로딩 중"
+
+#: ../src/common/darktable.c:2013
 msgid "initializing Lua"
 msgstr "Lua 초기화 중"
 
-#: ../src/common/darktable.c:1971
+#. If only one image is listed, attempt to load it in darkroom
+#: ../src/common/darktable.c:2042
 msgid "importing image"
 msgstr "이미지 가져오는 중"
 
-#: ../src/common/darktable.c:1991
+#: ../src/common/darktable.c:2061
 msgid "configuration information"
 msgstr "구성 정보"
 
-#: ../src/common/darktable.c:1993
+#: ../src/common/darktable.c:2063
 msgid "_show this message again"
 msgstr "이 메세지를 다시 표시 (&S)"
 
-#: ../src/common/darktable.c:1993
+#: ../src/common/darktable.c:2063
 msgid "_dismiss"
 msgstr "닫기 (&D)"
 
-#: ../src/common/darktable.c:2486
-msgid "the RCD demosaicer has been defined as default instead of PPG because of better quality and performance."
+#: ../src/common/darktable.c:2554
+msgid ""
+"the RCD demosaicer has been defined as default instead of PPG because of "
+"better quality and performance."
 msgstr "더 나은 품질과 성능을 위해 PPG 대신 RCD 모자이크 제거기가 기본값으로 설정되었습니다."
 
-#: ../src/common/darktable.c:2488
+#: ../src/common/darktable.c:2556
 msgid "see preferences/darkroom/demosaicing for zoomed out darkroom mode"
 msgstr "축소된 darkroom 모드 설정은 환경설정/darkroom/demosaicing을 참조하세요"
 
-#: ../src/common/darktable.c:2494
-msgid "the user interface and the underlying internals for tuning darktable performance have changed."
+#: ../src/common/darktable.c:2562
+msgid ""
+"the user interface and the underlying internals for tuning darktable "
+"performance have changed."
 msgstr "darktable 성능 조정을 위해 사용자 인터페이스 및 내부 시스템이 변경되었습니다."
 
-#: ../src/common/darktable.c:2496
-msgid "you won't find headroom and friends any longer, instead in preferences/processing use:"
+#: ../src/common/darktable.c:2564
+msgid ""
+"you won't find headroom and friends any longer, instead in preferences/"
+"processing use:"
 msgstr "더 이상 헤드룸과 친구를 찾을 수 없고, 대신 환경설정/프로세싱 사용: 에 있습니다:"
 
-#: ../src/common/darktable.c:2498
+#: ../src/common/darktable.c:2566
 msgid "1) darktable resources"
 msgstr "1) darktable 리소스"
 
-#: ../src/common/darktable.c:2500
+#: ../src/common/darktable.c:2568
 msgid "2) tune OpenCL performance"
 msgstr "2) OpenCL 성능 조정"
 
-#: ../src/common/darktable.c:2507
-msgid "some global config parameters relevant for OpenCL performance are not used any longer."
+#: ../src/common/darktable.c:2575
+msgid ""
+"some global config parameters relevant for OpenCL performance are not used "
+"any longer."
 msgstr "OpenCL 성능과 관련된 전역 구성 파라메터 일부는 더 이상 사용되지 않습니다."
 
-#: ../src/common/darktable.c:2509
-msgid "instead you will find 'per device' data in 'cldevice_v5_canonical-name'. content is:"
+#: ../src/common/darktable.c:2577
+msgid ""
+"instead you will find 'per device' data in 'cldevice_v5_canonical-name'. "
+"content is:"
 msgstr "대신 'cldevice_v5_canonical-name'에서 'per device' 데이터를 찾을 수 있습니다.내용은 다음과 같습니다:"
 
-#: ../src/common/darktable.c:2511 ../src/common/darktable.c:2530
-#: ../src/common/darktable.c:2545
-msgid " 'avoid_atomics' 'micro_nap' 'pinned_memory' 'roundupwd' 'roundupht' 'eventhandles' 'async' 'disable' 'magic' 'advantage' 'unified'"
+#: ../src/common/darktable.c:2579 ../src/common/darktable.c:2598
+#: ../src/common/darktable.c:2613
+msgid ""
+" 'avoid_atomics' 'micro_nap' 'pinned_memory' 'roundupwd' 'roundupht' "
+"'eventhandles' 'async' 'disable' 'magic' 'advantage' 'unified'"
 msgstr " 'avoid_atomics' 'micro_nap' 'pinned_memory' 'roundupwd' 'roundupht' 'eventhandles' 'async' 'disable' 'magic' 'advantage' 'unified'"
 
-#: ../src/common/darktable.c:2513 ../src/common/darktable.c:2532
+#: ../src/common/darktable.c:2581 ../src/common/darktable.c:2600
 msgid "you may tune as before except 'magic'"
 msgstr "'magic' 설정을 제외하고는 이전과 같이 조정할 수 있습니다"
 
-#: ../src/common/darktable.c:2519
-msgid "your OpenCL compiler settings for all devices have been reset to default."
+#: ../src/common/darktable.c:2587
+msgid ""
+"your OpenCL compiler settings for all devices have been reset to default."
 msgstr "모든 장치의 OpenCL 컴파일러 설정이 기본값으로 초기화되었습니다."
 
-#: ../src/common/darktable.c:2526
-msgid "OpenCL global config parameters 'per device' data has been recreated with an updated name."
+#: ../src/common/darktable.c:2594
+msgid ""
+"OpenCL global config parameters 'per device' data has been recreated with an "
+"updated name."
 msgstr "OpenCL 전역 구성 파라메터 'per device' 데이터가 업데이트된 이름으로 다시 생성 되었습니다."
 
-#: ../src/common/darktable.c:2528 ../src/common/darktable.c:2543
-msgid "you will find 'per device' data in 'cldevice_v5_canonical-name'. content is:"
+#: ../src/common/darktable.c:2596 ../src/common/darktable.c:2611
+msgid ""
+"you will find 'per device' data in 'cldevice_v5_canonical-name'. content is:"
 msgstr "'cldevice_v5_canonical-name'에서 'per device' 데이터를 찾을 수 있습니다. 내용은 다음과 같습니다:"
 
-#: ../src/common/darktable.c:2534
-msgid "If you're using device names in 'opencl_device_priority' you should update them to the new names."
+#: ../src/common/darktable.c:2602
+msgid ""
+"If you're using device names in 'opencl_device_priority' you should update "
+"them to the new names."
 msgstr "'opencl_device_priority'에 장치 이름을 설정했다면, 새 이름으로 업데이트하세요."
 
-#: ../src/common/darktable.c:2541
-msgid "OpenCL 'per device' config data have been automatically extended by 'unified-fraction'."
+#: ../src/common/darktable.c:2609
+msgid ""
+"OpenCL 'per device' config data have been automatically extended by 'unified-"
+"fraction'."
 msgstr "OpenCL 'per device' 구성 데이터가 'unified-fraction'에 의해 자동으로 확장되었습니다."
 
-#: ../src/common/darktable.c:2552
+#: ../src/common/darktable.c:2620
 msgid ""
 "OpenCL 'per device' compiler settings might have been updated.\n"
 "\n"
@@ -6615,13 +7321,32 @@ msgstr ""
 "OpenCL 'per device' 컴파일러 설정이 업데이트되었을 수 있습니다.\n"
 "\n"
 
-#: ../src/common/darktable.c:2557
+#: ../src/common/darktable.c:2625
 msgid ""
 "OpenCL mandatory timeout has been updated to 1000.\n"
 "\n"
 msgstr ""
 "OpenCL 필수 시간 제한이 1000으로 업데이트되었습니다.\n"
 "\n"
+
+#: ../src/common/darktable.c:2631
+msgid ""
+"OpenCL 'per device' settings have changed.\n"
+"\n"
+msgstr ""
+"OpenCL 'per device' 설정이 변경되었습니다.\n"
+"\n"
+
+#: ../src/common/darktable.c:2632
+msgid ""
+"you will find 'per device' data in 'cldevice_v6_canonical-name'. content is:"
+msgstr "'cldevice_v6_canonical-name'에서 'per device' 데이터를 찾을 수 있습니다. 내용은 다음과 같습니다:"
+
+#: ../src/common/darktable.c:2634
+msgid ""
+" 'micro_nap' 'pinned_memory' 'eventhandles' 'async' 'disabled' 'advantage' "
+"'unified_fraction'"
+msgstr " 'micro_nap' 'pinned_memory' 'eventhandles' 'async' 'disabled' 'advantage' 'unified_fraction'"
 
 #: ../src/common/database.c:3236
 msgid "creator"
@@ -6633,7 +7358,7 @@ msgstr "발행자"
 
 #. title
 #: ../src/common/database.c:3238
-#: ../src/external/lua-scripts/official/selection_to_pdf.lua:70
+#: ../src/external/lua-scripts/official/selection_to_pdf.lua:74
 #: ../src/imageio/format/pdf.c:591 ../src/imageio/format/pdf.c:593
 #: ../src/imageio/storage/gallery.c:212 ../src/imageio/storage/gallery.c:219
 #: ../src/imageio/storage/latex.c:202 ../src/imageio/storage/piwigo.c:1150
@@ -6641,7 +7366,7 @@ msgstr "발행자"
 msgid "title"
 msgstr "제목"
 
-#: ../src/common/database.c:3239 ../src/gui/styles_dialog.c:581
+#: ../src/common/database.c:3239 ../src/gui/styles_dialog.c:578
 #: ../src/libs/filtering.c:61
 msgid "description"
 msgstr "설명"
@@ -6650,7 +7375,7 @@ msgstr "설명"
 msgid "rights"
 msgstr "권리"
 
-#: ../src/common/database.c:3241
+#: ../src/common/database.c:3241 ../src/gui/preferences_ai.c:1175
 msgid "notes"
 msgstr "주석"
 
@@ -6662,7 +7387,7 @@ msgstr "버전 이름"
 msgid "preserved filename"
 msgstr "보존된 파일 이름"
 
-#: ../src/common/database.c:3846
+#: ../src/common/database.c:3854
 #, c-format
 msgid ""
 "\n"
@@ -6671,24 +7396,34 @@ msgid ""
 "  How to solve this problem?\n"
 "\n"
 "  1 - If another darktable instance is already open, \n"
-"      click cancel and either use that instance or close it before attempting to rerun darktable \n"
+"      click cancel and either use that instance or close it before "
+"attempting to rerun darktable \n"
 "      (process ID <i><b>%d</b></i> created the database locks)\n"
 "\n"
-"  2 - If you closed darktable within the past few minutes, it may still be running in the background \n"
-"      to export images, update sidecar files, or perform database maintenance. Try again once \n"
+"  2 - If you closed darktable within the past few minutes, it may still be "
+"running in the background \n"
+"      to export images, update sidecar files, or perform database "
+"maintenance. Try again once \n"
 "      this processing finishes.\n"
 "\n"
-"  3 - If you are not confident in your ability to correctly deal with processes in the OS, \n"
-"      it would be safer to restart the session or reboot your computer after some time (few minutes). \n"
-"      This will close all running programs and hopefully close the databases correctly. \n"
+"  3 - If you are not confident in your ability to correctly deal with "
+"processes in the OS, \n"
+"      it would be safer to restart the session or reboot your computer after "
+"some time (few minutes). \n"
+"      This will close all running programs and hopefully close the databases "
+"correctly. \n"
 "\n"
-"  4 - If you have done this or are certain that no other instances of darktable are running, \n"
+"  4 - If you have done this or are certain that no other instances of "
+"darktable are running, \n"
 "      this probably means that the last instance was ended abnormally. \n"
-"      Click on the \"delete database lock files\" button to delete the files <i>data.db.lock</i> and <i>library.db.lock</i>. \n"
+"      Click on the \"delete database lock files\" button to delete the files "
+"<i>data.db.lock</i> and <i>%s</i>. \n"
 "\n"
 "\n"
-"      <i><u>Caution!</u> Do not delete these files without first undertaking the above checks, \n"
-"      otherwise you risk generating serious inconsistencies in your database.</i>\n"
+"      <i><u>Caution!</u> Do not delete these files without first undertaking "
+"the above checks, \n"
+"      otherwise you risk generating serious inconsistencies in your database."
+"</i>\n"
 msgstr ""
 "\n"
 "죄송합니다. darktable을 시작할 수 없습니다 (데이터베이스가 잠김).\n"
@@ -6696,7 +7431,7 @@ msgstr ""
 " 이 문제를 어떻게 해결하나요?\n"
 "\n"
 " 1 - 다른 darktable 인스턴스가 이미 열려 있는 경우,\n"
-"     취소를 클릭하고 Darktable을 다시 실행하기 전에 해당 인스턴스를 사용하거나 닫으세요.\n"
+"     취소를 클릭하고 darktable을 다시 실행하기 전에 해당 인스턴스를 사용하거나 닫으세요.\n"
 "     (프로세스 ID <i><b>%d</b></i>이(가) 데이터베이스 잠금을 생성했습니다.)\n"
 "\n"
 " 2 - 지난 몇 분 동안 darktable을 닫았다면, 이미지 내보내기, 사이드카 파일 업데이트 또는 데이터베이스 유지 관리를 위해 백그라운드에서 아직 실행 중일 수 있습니다.\n"
@@ -6708,24 +7443,24 @@ msgstr ""
 "\n"
 " 4 - 이 작업을 수행했거나 다른 darktable 인스턴스가 실행 중이 아니라고 확신하는 경우,\n"
 "     마지막 인스턴스가 비정상적으로 종료되었을 가능성이 높습니다.\n"
-"     \"데이터베이스 잠금 파일 삭제\" 버튼을 클릭하여 <i>data.db.lock</i> 및 <i>library.db.lock</i> 파일을 삭제하세요.\n"
+"     \"데이터베이스 잠금 파일 삭제\" 버튼을 클릭하여 <i>data.db.lock</i> 및 <i>%s</i> 파일을 삭제하세요.\n"
 "\n"
 "     <i><u>주의!</u> 위의 검사를 먼저 수행하지 않고 이러한 파일을 삭제하지 마세요.\n"
 "     그렇지 않으면 데이터베이스에 심각한 불일치가 발생할 위험이 있습니다.</i>\n"
 
-#: ../src/common/database.c:3873
+#: ../src/common/database.c:3881
 msgid "error starting darktable"
 msgstr "darktable 시작 중 오류가 발생하였습니다"
 
-#: ../src/common/database.c:3876
+#: ../src/common/database.c:3884
 msgid "_delete database lock files"
 msgstr "데이터베이스 잠금 파일 삭제 (&D)"
 
-#: ../src/common/database.c:3882
+#: ../src/common/database.c:3890
 msgid "are you sure?"
 msgstr "정말로 진행하시겠습니까?"
 
-#: ../src/common/database.c:3883
+#: ../src/common/database.c:3891
 msgid ""
 "\n"
 "do you really want to delete the lock files?\n"
@@ -6733,19 +7468,19 @@ msgstr ""
 "\n"
 "정말로 잠금 파일을 삭제하시겠습니까?\n"
 
-#: ../src/common/database.c:3883 ../src/gui/gtk.c:3196
+#: ../src/common/database.c:3891 ../src/gui/gtk.c:3505
 msgid "_no"
 msgstr "아니오 (&N)"
 
-#: ../src/common/database.c:3883 ../src/gui/gtk.c:3195
+#: ../src/common/database.c:3891 ../src/gui/gtk.c:3504
 msgid "_yes"
 msgstr "예 (&Y)"
 
-#: ../src/common/database.c:3900
+#: ../src/common/database.c:3907
 msgid "done"
 msgstr "완료"
 
-#: ../src/common/database.c:3901
+#: ../src/common/database.c:3908
 msgid ""
 "\n"
 "successfully deleted the lock files.\n"
@@ -6755,53 +7490,56 @@ msgstr ""
 "잠금 파일이 성공적으로 삭제되었습니다.\n"
 "이제 darktable을 다시 시작할 수 있습니다\n"
 
-#: ../src/common/database.c:3902 ../src/common/database.c:3909
-#: ../src/gui/accelerators.c:2616 ../src/gui/accelerators.c:2688
-#: ../src/gui/accelerators.c:2797 ../src/gui/hist_dialog.c:237
+#: ../src/common/database.c:3909 ../src/common/database.c:3916
+#: ../src/gui/accelerators.c:2617 ../src/gui/accelerators.c:2689
+#: ../src/gui/accelerators.c:2798 ../src/gui/hist_dialog.c:237
 #: ../src/gui/presets.c:574
 msgid "_ok"
 msgstr "확인 (&O)"
 
-#: ../src/common/database.c:3905
+#: ../src/common/database.c:3912 ../src/gui/preferences_ai.c:172
 msgid "error"
 msgstr "오류"
 
-#: ../src/common/database.c:3906
+#: ../src/common/database.c:3913
 #, c-format
 msgid ""
 "\n"
 "at least one file could not be deleted.\n"
-"you may try to manually delete the files <i>data.db.lock</i> and <i>library.db.lock</i>\n"
+"you may try to manually delete the files <i>data.db.lock</i> and <i>%s</i>\n"
 "in folder <a href=\"file:///%s\">%s</a>.\n"
 msgstr ""
 "\n"
 "일부 파일을 삭제할 수 없습니다.\n"
-"<i>data.db.lock</i> 및 <i>library.db.lock</i> 파일을 수동으로 삭제해 볼 수도 있습니다\n"
+"<i>data.db.lock</i> 및 <i>%s</i> 파일을 수동으로 삭제해 볼 수도 있습니다\n"
 "폴더 <a href=\"file:///%s\">%s</a>에 있습니다.\n"
 
-#: ../src/common/database.c:4025
+#: ../src/common/database.c:4040
 #, c-format
-msgid "the database lock file contains a pid that seems to be alive in your system: %d"
+msgid ""
+"the database lock file contains a pid that seems to be alive in your system: "
+"%d"
 msgstr "데이터베이스 잠금 파일에 시스템에서 실행 중인 것으로 보이는 pid가 포함되어 있습니다: %d"
 
-#: ../src/common/database.c:4032
+#: ../src/common/database.c:4048
 #, c-format
 msgid "the database lock file seems to be empty"
 msgstr "데이터베이스 잠금 파일이 비어 있는 것 같습니다"
 
-#: ../src/common/database.c:4042
+#: ../src/common/database.c:4058
 #, c-format
 msgid "error opening the database lock file for reading: %s"
 msgstr "데이터베이스 잠금 파일을 읽기 위해 여는 중 오류가 발생하였습니다: %s"
 
-#: ../src/common/database.c:4113
+#: ../src/common/database.c:4129
 #, c-format
 msgid ""
 "the database schema version of\n"
 "\n"
 "<span style='italic'>%s</span>\n"
 "\n"
-"is too new for this build of darktable (this means the database was created or upgraded by a newer darktable version)\n"
+"is too new for this build of darktable (this means the database was created "
+"or upgraded by a newer darktable version)\n"
 msgstr ""
 "데이터베이스 스키마 버전\n"
 "\n"
@@ -6809,12 +7547,12 @@ msgstr ""
 "\n"
 "이 darktable의 현재 빌드에서 지원하는 버전보다 높습니다 (데이터베이스가 최신 darktable 버전에서 생성 또는 업그레이드되었음을 의미합니다)\n"
 
-#: ../src/common/database.c:4120
+#: ../src/common/database.c:4136
 msgid "darktable - too new db version"
 msgstr "darktable - 데이터베이스 버전이 너무 높습니다"
 
 #. the database has to be upgraded, let's ask user
-#: ../src/common/database.c:4137
+#: ../src/common/database.c:4153
 #, c-format
 msgid ""
 "the database schema has to be upgraded for\n"
@@ -6833,21 +7571,21 @@ msgstr ""
 "\n"
 "계속 진행하시겠습니까 아니면 지금 종료하여 백업하시겠습니까\n"
 
-#: ../src/common/database.c:4145
+#: ../src/common/database.c:4161
 msgid "darktable - schema migration"
 msgstr "darktable - 스키마 마이그레이션"
 
-#: ../src/common/database.c:4146 ../src/common/database.c:4504
-#: ../src/common/database.c:4519 ../src/common/database.c:4678
-#: ../src/common/database.c:4693
+#: ../src/common/database.c:4162 ../src/common/database.c:4520
+#: ../src/common/database.c:4535 ../src/common/database.c:4694
+#: ../src/common/database.c:4709
 msgid "_close darktable"
 msgstr "darktable 닫기 (&C)"
 
-#: ../src/common/database.c:4146
+#: ../src/common/database.c:4162
 msgid "_upgrade database"
 msgstr "데이터베이스 업그레이드 (&U)"
 
-#: ../src/common/database.c:4313
+#: ../src/common/database.c:4329
 #, c-format
 msgid ""
 "you do not have write access to at least one of the darktable databases:\n"
@@ -6864,11 +7602,11 @@ msgstr ""
 "\n"
 "이 문제를 해결하고 darktable을 다시 시작하세요"
 
-#: ../src/common/database.c:4321
+#: ../src/common/database.c:4337
 msgid "darktable - read-only database detected"
 msgstr "darktable - 읽기 전용 데이터베이스가 감지되었습니다"
 
-#: ../src/common/database.c:4484 ../src/common/database.c:4658
+#: ../src/common/database.c:4500 ../src/common/database.c:4674
 #, c-format
 msgid ""
 "quick_check said:\n"
@@ -6877,21 +7615,21 @@ msgstr ""
 "quick_check 결과:\n"
 "%s \n"
 
-#: ../src/common/database.c:4501 ../src/common/database.c:4516
-#: ../src/common/database.c:4675 ../src/common/database.c:4690
+#: ../src/common/database.c:4517 ../src/common/database.c:4532
+#: ../src/common/database.c:4691 ../src/common/database.c:4706
 msgid "darktable - error opening database"
 msgstr "darktable - 데이터베이스를 여는 중 오류가 발생하였습니다"
 
-#: ../src/common/database.c:4505 ../src/common/database.c:4679
+#: ../src/common/database.c:4521 ../src/common/database.c:4695
 msgid "_attempt restore"
 msgstr "복원 시도 (&A)"
 
-#: ../src/common/database.c:4506 ../src/common/database.c:4520
-#: ../src/common/database.c:4680 ../src/common/database.c:4694
+#: ../src/common/database.c:4522 ../src/common/database.c:4536
+#: ../src/common/database.c:4696 ../src/common/database.c:4710
 msgid "_delete database"
 msgstr "데이터베이스 삭제 (&D)"
 
-#: ../src/common/database.c:4509 ../src/common/database.c:4683
+#: ../src/common/database.c:4525 ../src/common/database.c:4699
 msgid ""
 "do you want to close darktable now to manually restore\n"
 "the database from a backup, attempt an automatic restore\n"
@@ -6902,7 +7640,7 @@ msgstr ""
 "최신 스냅샷에서 자동 복원을 시도하거나, 손상된 데이터베이스를 삭제하고 \n"
 "새 데이터베이스로 시작하시겠습니까?"
 
-#: ../src/common/database.c:4523 ../src/common/database.c:4697
+#: ../src/common/database.c:4539 ../src/common/database.c:4713
 msgid ""
 "do you want to close darktable now to manually restore\n"
 "the database from a backup or delete the corrupted database\n"
@@ -6911,7 +7649,7 @@ msgstr ""
 "darktable을 닫고 백업에서 데이터베이스를 수동으로 복원하거나 \n"
 "손상된 데이터베이스를 삭제하고 새 데이터베이스로 시작하시겠습니까?"
 
-#: ../src/common/database.c:4530 ../src/common/database.c:4702
+#: ../src/common/database.c:4546 ../src/common/database.c:4718
 #, c-format
 msgid ""
 "an error has occurred while trying to open the database from\n"
@@ -6929,15 +7667,17 @@ msgstr ""
 "%s%s"
 
 #: ../src/common/eigf.h:260
-msgid "fast exposure independent guided filter failed to allocate memory, check your RAM settings"
+msgid ""
+"fast exposure independent guided filter failed to allocate memory, check "
+"your RAM settings"
 msgstr "고속 노출 비의존 가이드 필터에서 메모리 할당에 실패하였습니다, RAM 설정을 확인하세요"
 
-#: ../src/common/exif.cc:6027
+#: ../src/common/exif.cc:6098
 #, c-format
 msgid "cannot read XMP file '%s': '%s'"
 msgstr "XMP 파일'%s': '%s'을 읽을 수 없습니다"
 
-#: ../src/common/exif.cc:6086
+#: ../src/common/exif.cc:6157 ../src/common/exif.cc:6170
 #, c-format
 msgid "cannot write XMP file '%s': '%s'"
 msgstr "XMP 파일 '%s': '%s'에 기록할 수 없습니다"
@@ -6956,9 +7696,9 @@ msgid "delete empty directory?"
 msgid_plural "delete empty directories?"
 msgstr[0] "빈 디렉토리를 삭제하시겠습니까?"
 
-#: ../src/common/film.c:361 ../src/gui/preferences.c:920
-#: ../src/gui/styles_dialog.c:574 ../src/libs/geotagging.c:845
-#: ../src/libs/import.c:1894
+#: ../src/common/film.c:361 ../src/gui/preferences.c:949
+#: ../src/gui/preferences_ai.c:1786 ../src/gui/styles_dialog.c:571
+#: ../src/libs/geotagging.c:846 ../src/libs/import.c:1864
 msgid "name"
 msgstr "이름"
 
@@ -6966,105 +7706,107 @@ msgstr "이름"
 msgid "cannot remove film roll having local copies with inaccessible originals"
 msgstr "원본에 접근할 수 없는 로컬 복사본에 대한 필름 롤은 제거할 수 없습니다"
 
-#: ../src/common/gpx.c:259 ../src/control/jobs/control_jobs.c:1383
+#: ../src/common/gpx.c:259 ../src/control/jobs/control_jobs.c:1403
 #, c-format
 msgid "failed to parse GPX file"
 msgstr "GPX 파일의 구문 분석에 실패하였습니다"
 
-#: ../src/common/history.c:917
+#: ../src/common/history.c:927
 msgid "you need to copy history from an image before you paste it onto another"
 msgstr "다른 이미지에 붙여넣기 전에 먼저 해당 이미지에서 편집 내역을 복사해야 합니다"
 
-#: ../src/common/image.c:345
+#: ../src/common/image.c:346
 msgid "orphaned image"
 msgstr "존재하지 않는 이미지"
 
-#: ../src/common/image.c:669
+#: ../src/common/image.c:688
 #, c-format
 msgid "geo-location undone for %d image"
 msgid_plural "geo-location undone for %d images"
 msgstr[0] "%d개 이미지의 위치 정보가 취소됨"
 
-#: ../src/common/image.c:671
+#: ../src/common/image.c:690
 #, c-format
 msgid "geo-location re-applied to %d image"
 msgid_plural "geo-location re-applied to %d images"
 msgstr[0] "%d개 이미지의 위치 정보가 다시 적용됨"
 
-#: ../src/common/image.c:693
+#: ../src/common/image.c:712
 #, c-format
 msgid "date/time undone for %d image"
 msgid_plural "date/time undone for %d images"
 msgstr[0] "%d개 이미지의 날짜/시간 정보가 취소됨"
 
-#: ../src/common/image.c:695
+#: ../src/common/image.c:714
 #, c-format
 msgid "date/time re-applied to %d image"
 msgid_plural "date/time re-applied to %d images"
 msgstr[0] "%d개 이미지의 날짜/시간 정보가 다시 적용됨"
 
 #. FIXME make GIMP handle duplicates
-#: ../src/common/image.c:1326
+#: ../src/common/image.c:1345
 msgid "can't create a duplicate in GIMP mode"
 msgstr "GIMP 모드에서는 복제본을 만들 수 없습니다."
 
-#: ../src/common/image.c:2423
+#: ../src/common/image.c:2442
 #, c-format
 msgid "cannot access local copy `%s'"
 msgstr "로컬 복사본 `%s'에 접근할 수 없습니다"
 
-#: ../src/common/image.c:2430
+#: ../src/common/image.c:2449
 #, c-format
 msgid "cannot write local copy `%s'"
 msgstr "로컬 복사본 `%s'에 기록할 수 없습니다"
 
-#: ../src/common/image.c:2437
+#: ../src/common/image.c:2456
 #, c-format
 msgid "error moving local copy `%s' -> `%s'"
 msgstr "로컬 복사본 `%s' -> `%s' 이동 중 오류가 발생하였습니다"
 
-#: ../src/common/image.c:2482
+#: ../src/common/image.c:2501
 #, c-format
 msgid "error moving `%s': file not found"
 msgstr "파일 `%s' 이동 오류: 파일을 찾을 수 없습니다"
 
-#: ../src/common/image.c:2492
+#: ../src/common/image.c:2511
 #, c-format
 msgid "error moving `%s' -> `%s': file exists"
 msgstr "파일 `%s' -> `%s' 이동 오류: 파일이 이미 존재합니다"
 
-#: ../src/common/image.c:2496 ../src/common/image.c:2505
+#: ../src/common/image.c:2515 ../src/common/image.c:2524
 #, c-format
 msgid "error moving `%s' -> `%s'"
 msgstr "`%s' -> `%s' 이동 중 오류가 발생하였습니다"
 
-#: ../src/common/image.c:2807
+#: ../src/common/image.c:2826
 msgid "cannot create local copy when the original file is not accessible."
 msgstr "원본 파일에 접근할 수 없는 경우 로컬 복사본을 만들 수 없습니다."
 
-#: ../src/common/image.c:2821
+#: ../src/common/image.c:2840
 msgid "cannot create local copy."
 msgstr "로컬 복사본을 만들 수 없습니다."
 
-#: ../src/common/image.c:2900 ../src/control/jobs/control_jobs.c:935
+#: ../src/common/image.c:2919 ../src/control/jobs/control_jobs.c:955
 msgid "cannot remove local copy when the original file is not accessible."
 msgstr "원본 파일에 접근할 수 없는 경우 로컬 복사본을 제거할 수 없습니다."
 
-#: ../src/common/image.c:3076
+#: ../src/common/image.c:3095
 #, c-format
 msgid "%d local copy has been synchronized"
 msgid_plural "%d local copies have been synchronized"
 msgstr[0] "%d개 로컬 복사본이 동기화됨"
 
-#: ../src/common/image.c:3274
+#: ../src/common/image.c:3293
 msgid "<b>WARNING</b>: camera is missing samples!"
 msgstr "<b>경고</b>: 해당 카메라는 샘플이 제공되지 않습니다!"
 
-#: ../src/common/image.c:3275
-msgid "You must provide samples in <a href='https://raw.pixls.us/'>https://raw.pixls.us/</a>"
+#: ../src/common/image.c:3294
+msgid ""
+"You must provide samples in <a href='https://raw.pixls.us/'>https://"
+"raw.pixls.us/</a>"
 msgstr "샘플을 <a href='https://raw.pixls.us/'>https://raw.pixls.us/</a>에 제공해야 합니다"
 
-#: ../src/common/image.c:3276
+#: ../src/common/image.c:3295
 #, c-format
 msgid ""
 "for `%s' `%s'\n"
@@ -7073,82 +7815,83 @@ msgstr ""
 "`%s' `%s'에 대해\n"
 "가능한 많은 형식/압축률/비트 심도의 샘플을 제공해 주십시오"
 
-#: ../src/common/image.c:3279
+#: ../src/common/image.c:3298
 msgid "or the <b>RAW won't be readable</b> in next version."
 msgstr "샘플을 제공하지 않으면 다음 버전에서 <b>RAW 파일을 읽을 수 없습니다.</b>"
 
-#: ../src/common/image.h:217 ../src/common/ratings.c:297
-#: ../src/imageio/format/avif.c:120 ../src/libs/history.c:838
-#: ../src/libs/snapshots.c:925
+#: ../src/common/image.h:218 ../src/common/ratings.c:363
+#: ../src/imageio/format/avif.c:120 ../src/libs/collect.c:1640
+#: ../src/libs/collect.c:2415 ../src/libs/history.c:838
+#: ../src/libs/modulegroups.c:2867 ../src/libs/snapshots.c:936
 msgid "unknown"
 msgstr "알 수 없음"
 
 #. EMPTY_FIELD
-#: ../src/common/image.h:218 ../src/imageio/format/tiff.c:813
+#: ../src/common/image.h:219 ../src/imageio/format/tiff.c:813
 msgid "TIFF"
 msgstr "TIFF"
 
-#: ../src/common/image.h:219 ../src/imageio/format/png.c:650
+#: ../src/common/image.h:220 ../src/imageio/format/png.c:650
 msgid "PNG"
 msgstr "PNG"
 
-#: ../src/common/image.h:220
+#: ../src/common/image.h:221
 msgid "JPEG 2000"
 msgstr "JPEG 2000"
 
-#: ../src/common/image.h:221
+#: ../src/common/image.h:222
 msgid "JPEG"
 msgstr "JPEG"
 
-#: ../src/common/image.h:222
+#: ../src/common/image.h:223
 msgid "EXR"
 msgstr "EXR"
 
-#: ../src/common/image.h:223
+#: ../src/common/image.h:224
 msgid "RGBE"
 msgstr "RGBE"
 
-#: ../src/common/image.h:224 ../src/imageio/format/pfm.c:120
+#: ../src/common/image.h:225 ../src/imageio/format/pfm.c:120
 msgid "PFM"
 msgstr "PFM"
 
-#: ../src/common/image.h:225
+#: ../src/common/image.h:226
 msgid "GraphicsMagick"
 msgstr "GraphicsMagick"
 
-#: ../src/common/image.h:226
+#: ../src/common/image.h:227
 msgid "RawSpeed"
 msgstr "RawSpeed"
 
-#: ../src/common/image.h:227
+#: ../src/common/image.h:228
 msgid "Netpbm"
 msgstr "Netpbm"
 
-#: ../src/common/image.h:228 ../src/imageio/format/avif.c:860
+#: ../src/common/image.h:229 ../src/imageio/format/avif.c:860
 msgid "AVIF"
 msgstr "AVIF"
 
-#: ../src/common/image.h:229
+#: ../src/common/image.h:230
 msgid "ImageMagick"
 msgstr "ImageMagick"
 
-#: ../src/common/image.h:230
+#: ../src/common/image.h:231 ../src/imageio/format/heif.c:599
 msgid "HEIF"
 msgstr "HEIF"
 
-#: ../src/common/image.h:231
+#: ../src/common/image.h:232
 msgid "LibRaw"
 msgstr "LibRaw"
 
-#: ../src/common/image.h:232 ../src/imageio/format/webp.c:377
+#: ../src/common/image.h:233 ../src/imageio/format/webp.c:377
 msgid "WebP"
 msgstr "WebP"
 
-#: ../src/common/image.h:233 ../src/imageio/format/jxl.c:510
+#: ../src/common/image.h:234 ../src/imageio/format/jxl.c:512
 msgid "JPEG XL"
 msgstr "JPEG XL"
 
-#: ../src/common/image.h:234
+#: ../src/common/image.h:235
 msgid "QOI"
 msgstr "QOI"
 
@@ -7169,14 +7912,16 @@ msgstr ""
 "생략되었습니다."
 
 #: ../src/common/import_session.c:296
-msgid "couldn't expand to a unique filename for session, please check your import session settings"
+msgid ""
+"couldn't expand to a unique filename for session, please check your import "
+"session settings"
 msgstr "세션에 대한 고유한 파일 이름으로 확장할 수 없습니다.가져오기 세션 설정을 확인하세요."
 
 #: ../src/common/import_session.c:389
 msgid "requested session path not available. device not mounted?"
 msgstr "요청된 세션 경로를 사용할 수 없습니다. 장치가 마운트되지 않았습니까?"
 
-#: ../src/common/iop_order.c:57 ../src/libs/ioporder.c:192
+#: ../src/common/iop_order.c:57 ../src/libs/ioporder.c:190
 msgid "legacy"
 msgstr "레거시"
 
@@ -7196,7 +7941,22 @@ msgstr "v5.0 RAW"
 msgid "v5.0 JPEG"
 msgstr "v5.0 JPEG"
 
-#: ../src/common/iop_profile.c:1137
+#: ../src/common/iop_profile.c:883
+#, c-format
+msgid "work icc profile '%s' missing"
+msgstr "작업 ICC 프로파일 '%s'이(가) 없습니다"
+
+#: ../src/common/iop_profile.c:914
+#, c-format
+msgid "input icc profile '%s' missing"
+msgstr "입력 ICC 프로파일 '%s'이(가) 없습니다"
+
+#: ../src/common/iop_profile.c:967
+#, c-format
+msgid "output icc profile '%s' missing"
+msgstr "출력 ICC 프로파일 '%s'이(가) 없습니다"
+
+#: ../src/common/iop_profile.c:1190
 #, c-format
 msgid ""
 "darktable loads %s from\n"
@@ -7209,17 +7969,17 @@ msgstr ""
 "또는, 이 디렉토리가 없으면, 다음 위치에서 로딩합니다\n"
 "<b>%s</b>"
 
-#: ../src/common/mipmap_cache.c:1327 ../src/imageio/imageio.c:1086
+#: ../src/common/mipmap_cache.c:1386 ../src/imageio/imageio.c:1086
 #, c-format
 msgid "image `%s' is not available!"
 msgstr "이미지 `%s'을 사용할 수 없습니다!"
 
-#: ../src/common/mipmap_cache.c:1330 ../src/imageio/imageio.c:1094
+#: ../src/common/mipmap_cache.c:1390 ../src/imageio/imageio.c:1094
 #, c-format
 msgid "unable to load image `%s'!"
 msgstr "이미지 `%s'을 로딩할 수 없습니다!"
 
-#: ../src/common/mipmap_cache.c:1332 ../src/imageio/imageio.c:1097
+#: ../src/common/mipmap_cache.c:1392 ../src/imageio/imageio.c:1097
 #, c-format
 msgid "image '%s' not supported"
 msgstr "이미지 '%s'은 지원되지 않습니다"
@@ -7233,11 +7993,11 @@ msgstr "제네릭 푸아송"
 msgid "noiseprofile file `%s' is not valid"
 msgstr "노이즈 프로파일 파일 `%s'이 유효하지 않습니다"
 
-#: ../src/common/opencl.c:1161
+#: ../src/common/opencl.c:1294
 msgid "no working OpenCL library found"
 msgstr "작동하는 OpenCL 라이브러리를 찾을 수 없습니다"
 
-#: ../src/common/opencl.c:1181
+#: ../src/common/opencl.c:1314
 msgid ""
 "platform detection failed. some possible causes:\n"
 "  - OpenCL ICD (ocl-icd) missing,\n"
@@ -7255,23 +8015,23 @@ msgstr ""
 "  - OpenCL 드라이버 미설치,\n"
 "  - 플랫폼별 다중 드라이버 설치\n"
 
-#: ../src/common/opencl.c:1296
+#: ../src/common/opencl.c:1429
 msgid "no devices found for unknown platform"
 msgstr "알 수 없는 플랫폼에 대한 장치를 찾을 수 없습니다"
 
-#: ../src/common/opencl.c:1343
+#: ../src/common/opencl.c:1476
 msgid "not enough memory for OpenCL devices"
 msgstr "OpenCL 장치에 사용할 메모리가 부족합니다"
 
-#: ../src/common/opencl.c:1381
+#: ../src/common/opencl.c:1514
 msgid "no OpenCL devices found"
 msgstr "OpenCL 장치를 찾을 수 없습니다"
 
-#: ../src/common/opencl.c:1424
+#: ../src/common/opencl.c:1557
 msgid "no suitable OpenCL devices found"
 msgstr "적합한 OpenCL 장치를 찾을 수 없습니다"
 
-#: ../src/common/opencl.c:1448
+#: ../src/common/opencl.c:1581
 #, c-format
 msgid ""
 "OpenCL initializing problem:\n"
@@ -7282,187 +8042,204 @@ msgstr ""
 "%s\n"
 "OpenCL을 일시적으로 비활성화합니다"
 
-#: ../src/common/opencl.c:1484
+#: ../src/common/opencl.c:1617
 msgid "OpenCL scheduling profile set to default, setup has changed"
 msgstr "OpenCL 스케줄링 프로파일은 기본값으로 설정되며, 설정이 변경됨"
 
-#: ../src/common/opencl.c:2335
+#: ../src/common/opencl.c:2400
 #, c-format
 msgid "building OpenCL program %s for %s"
 msgstr "OpenCL 프로그램 %s을 %s용으로 빌드하는 중"
 
-#: ../src/common/pdf.h:88 ../src/iop/lens.cc:4054
+#: ../src/common/pdf.h:89 ../src/iop/lens.cc:4048
 #: ../src/libs/filters/focal.c:74 ../src/libs/print_settings.c:84
 msgid "mm"
 msgstr "mm"
 
-#: ../src/common/pdf.h:89 ../src/libs/export.c:663 ../src/libs/export.c:1517
+#: ../src/common/pdf.h:90 ../src/libs/export.c:685 ../src/libs/export.c:1535
 #: ../src/libs/print_settings.c:84
 msgid "cm"
 msgstr "cm"
 
-#: ../src/common/pdf.h:90 ../src/libs/print_settings.c:84
+#: ../src/common/pdf.h:91 ../src/libs/print_settings.c:84
 msgid "inch"
 msgstr "inch"
 
-#: ../src/common/pdf.h:91
+#: ../src/common/pdf.h:92
 msgid "\""
 msgstr "\""
 
-#: ../src/common/pdf.h:104 ../src/iop/borders.c:948
+#: ../src/common/pdf.h:105 ../src/iop/borders.c:946
 msgid "A4"
 msgstr "A4"
 
-#: ../src/common/pdf.h:105
+#: ../src/common/pdf.h:106
 msgid "A3"
 msgstr "A3"
 
-#: ../src/common/pdf.h:106
+#: ../src/common/pdf.h:107
 msgid "Letter"
 msgstr "Letter"
 
-#: ../src/common/pdf.h:107
+#: ../src/common/pdf.h:108
 msgid "Legal"
 msgstr "Legal"
+
+#: ../src/common/presets.c:537
+msgid "(default)"
+msgstr "(기본값)"
 
 #: ../src/common/pwstorage/pwstorage.c:109
 msgid "GNOME Keyring backend is no longer supported. configure a different one"
 msgstr "GNOME 키링 백엔드는 지원이 종료되었습니다. 다른 백엔드를 설정하세요"
 
-#: ../src/common/ratings.c:140
+#. all were rejected → un-reject
+#: ../src/common/ratings.c:150
+#, c-format
+msgid "unrejecting %d image"
+msgid_plural "unrejecting %d images"
+msgstr[0] "%d개 이미지의 거부를 해제하는 중"
+
+#: ../src/common/ratings.c:153
 #, c-format
 msgid "rejecting %d image"
 msgid_plural "rejecting %d images"
 msgstr[0] "%d개 이미지가 거부됨"
 
-#: ../src/common/ratings.c:142
+#: ../src/common/ratings.c:158
+#, c-format
+msgid "applying ratings to %d image"
+msgid_plural "applying ratings to %d images"
+msgstr[0] "%d개 이미지에 등급 적용 중"
+
+#: ../src/common/ratings.c:168
 #, c-format
 msgid "applying rating %d to %d image"
 msgid_plural "applying rating %d to %d images"
 msgstr[0] "등급 %d를 %d개 이미지에 적용 중"
 
-#: ../src/common/ratings.c:231
+#: ../src/common/ratings.c:290
 msgid "no images selected to apply rating"
 msgstr "등급을 적용할 이미지가 선택되지 않았습니다"
 
-#: ../src/common/ratings.c:288 ../src/libs/metadata_view.c:380
+#: ../src/common/ratings.c:354 ../src/libs/metadata_view.c:396
 msgid "image rejected"
 msgstr "이미지 거부됨"
 
-#: ../src/common/ratings.c:290
+#: ../src/common/ratings.c:356
 msgid "image rated to 0 star"
 msgstr "이미지 등급 0점 부여됨"
 
-#: ../src/common/ratings.c:292
+#: ../src/common/ratings.c:358
 #, c-format
 msgid "image rated to %s"
 msgstr "이미지에 등급 %s점 부여됨"
 
-#: ../src/common/ratings.c:321
+#: ../src/common/ratings.c:387
 #: ../src/external/lua-scripts/tools/executable_manager.lua:220
-#: ../src/views/lighttable.c:840
+#: ../src/views/lighttable.c:1030
 msgid "select"
 msgstr "선택"
 
-#: ../src/common/ratings.c:322
+#: ../src/common/ratings.c:388
 msgid "upgrade"
 msgstr "업그레이드"
 
-#: ../src/common/ratings.c:323
+#: ../src/common/ratings.c:389
 msgid "downgrade"
 msgstr "다운그레이드"
 
-#: ../src/common/ratings.c:327
+#: ../src/common/ratings.c:393
 msgid "zero"
 msgstr "0"
 
-#: ../src/common/ratings.c:328 ../src/libs/filters/rating_range.c:304
+#: ../src/common/ratings.c:394 ../src/libs/filters/rating_range.c:304
 msgid "one"
 msgstr "1"
 
-#: ../src/common/ratings.c:329 ../src/libs/filters/rating_range.c:305
+#: ../src/common/ratings.c:395 ../src/libs/filters/rating_range.c:305
 msgid "two"
 msgstr "2"
 
-#: ../src/common/ratings.c:330 ../src/libs/filters/rating_range.c:306
+#: ../src/common/ratings.c:396 ../src/libs/filters/rating_range.c:306
 msgid "three"
 msgstr "3"
 
-#: ../src/common/ratings.c:331 ../src/libs/filters/rating_range.c:307
+#: ../src/common/ratings.c:397 ../src/libs/filters/rating_range.c:307
 msgid "four"
 msgstr "4"
 
-#: ../src/common/ratings.c:332 ../src/libs/filters/rating_range.c:308
+#: ../src/common/ratings.c:398 ../src/libs/filters/rating_range.c:308
 msgid "five"
 msgstr "5"
 
-#: ../src/common/ratings.c:333
+#: ../src/common/ratings.c:399
 msgid "reject"
 msgstr "거부"
 
-#: ../src/common/styles.c:250
+#: ../src/common/styles.c:257
 #, c-format
 msgid "style with name '%s' already exists"
 msgstr "이름이 '%s'인 스타일이 이미 존재합니다"
 
-#: ../src/common/styles.c:277 ../src/common/styles.c:1719
+#: ../src/common/styles.c:284 ../src/common/styles.c:1726
 #: ../src/libs/styles.c:53
 msgid "styles"
 msgstr "스타일"
 
-#: ../src/common/styles.c:555 ../src/gui/styles_dialog.c:251
+#: ../src/common/styles.c:562 ../src/gui/styles_dialog.c:252
 #, c-format
 msgid "style named '%s' successfully created"
 msgstr "스타일 '%s'이 성공적으로 생성됨"
 
-#: ../src/common/styles.c:659 ../src/dtgtk/culling.c:1079
+#: ../src/common/styles.c:666 ../src/dtgtk/culling.c:1343
 msgid "no image selected!"
 msgstr "선택된 이미지가 없습니다!"
 
-#: ../src/common/styles.c:739
+#: ../src/common/styles.c:746
 #, c-format
 msgid "module `%s' version mismatch: %d != %d"
 msgstr "모듈 `%s' 버전 불일치: %d != %d"
 
-#: ../src/common/styles.c:1031
+#: ../src/common/styles.c:1038
 #, c-format
 msgid "applied style `%s' on current image"
 msgstr "현재 이미지에 스타일 `%s' 적용됨"
 
-#: ../src/common/styles.c:1295
+#: ../src/common/styles.c:1302
 #, c-format
 msgid "failed to overwrite style file for %s"
 msgstr "%s에 대한 스타일 파일을 덮어쓸 수 없습니다"
 
-#: ../src/common/styles.c:1301
+#: ../src/common/styles.c:1308
 #, c-format
 msgid "style file for %s exists"
 msgstr "%s에 대한 스타일 파일이 존재합니다"
 
-#: ../src/common/styles.c:1476 ../src/common/styles.c:1800
+#: ../src/common/styles.c:1483 ../src/common/styles.c:1807
 msgid "imported-style"
 msgstr "가져온-스타일"
 
-#: ../src/common/styles.c:1609
+#: ../src/common/styles.c:1616
 #, c-format
 msgid "style %s was successfully imported"
 msgstr "스타일 %s을 성공적으로 가져왔습니다"
 
 #. Failed to open file, clean up.
-#: ../src/common/styles.c:1654
+#: ../src/common/styles.c:1661
 #, c-format
 msgid "could not read file `%s'"
 msgstr "파일 `%s'을 읽을 수 없습니다"
 
-#: ../src/common/utility.c:588
+#: ../src/common/utility.c:608
 msgid "above sea level"
 msgstr "해발 고도"
 
-#: ../src/common/utility.c:589
+#: ../src/common/utility.c:609
 msgid "below sea level"
 msgstr "해수면 아래"
 
-#: ../src/common/utility.c:640 ../src/libs/metadata_view.c:981
+#: ../src/common/utility.c:660 ../src/libs/metadata_view.c:995
 msgid "m"
 msgstr "m"
 
@@ -7471,11 +8248,11 @@ msgid "no info"
 msgstr "정보 없음"
 
 #: ../src/common/variables.c:197 ../src/common/variables.c:820
-#: ../src/develop/imageop_gui.c:195 ../src/imageio/format/avif.c:960
-#: ../src/imageio/format/pdf.c:653 ../src/imageio/format/pdf.c:672
-#: ../src/imageio/format/tiff.c:921 ../src/libs/export.c:1561
-#: ../src/libs/export.c:1569 ../src/libs/export.c:1577
-#: ../src/libs/metadata_view.c:734
+#: ../src/develop/imageop_gui.c:195 ../src/gui/preferences_ai.c:256
+#: ../src/imageio/format/avif.c:960 ../src/imageio/format/pdf.c:653
+#: ../src/imageio/format/pdf.c:672 ../src/imageio/format/tiff.c:921
+#: ../src/libs/export.c:1579 ../src/libs/export.c:1587
+#: ../src/libs/export.c:1595 ../src/libs/metadata_view.c:748
 msgid "yes"
 msgstr "예"
 
@@ -7587,7 +8364,7 @@ msgstr "석양"
 msgid "underwater"
 msgstr "수중"
 
-#: ../src/common/wb_presets.c:88 ../src/views/darkroom.c:2663
+#: ../src/common/wb_presets.c:88 ../src/views/darkroom.c:3288
 msgid "black & white"
 msgstr "흑백"
 
@@ -7607,109 +8384,111 @@ msgstr "카메라 설정"
 msgid "auto WB"
 msgstr "자동"
 
-#: ../src/control/control.c:66 ../src/gui/accelerators.c:156
-#: ../src/views/darkroom.c:2310
+#: ../src/control/control.c:68 ../src/gui/accelerators.c:161
+#: ../src/views/darkroom.c:2658
 msgid "hold"
 msgstr "유지"
 
-#: ../src/control/control.c:105 ../src/control/control.c:218
+#: ../src/control/control.c:107 ../src/control/control.c:220
 msgid "modifiers"
 msgstr "조절 키"
 
-#: ../src/control/control.c:119
+#: ../src/control/control.c:121
 msgctxt "accel"
 msgid "global"
 msgstr "전역"
 
-#: ../src/control/control.c:126
+#: ../src/control/control.c:128
 msgctxt "accel"
 msgid "views"
 msgstr "보기"
 
-#: ../src/control/control.c:133
+#: ../src/control/control.c:135
 msgctxt "accel"
 msgid "thumbtable"
 msgstr "썸네일"
 
-#: ../src/control/control.c:140
+#: ../src/control/control.c:142
 msgctxt "accel"
 msgid "utility modules"
 msgstr "유틸리티 모듈"
 
-#: ../src/control/control.c:147
+#: ../src/control/control.c:149
 msgctxt "accel"
 msgid "format"
 msgstr "형식"
 
-#: ../src/control/control.c:154
+#: ../src/control/control.c:156
 msgctxt "accel"
 msgid "storage"
 msgstr "저장"
 
-#: ../src/control/control.c:161
+#: ../src/control/control.c:163
 msgctxt "accel"
 msgid "processing modules"
 msgstr "처리 모듈"
 
-#: ../src/control/control.c:168
+#: ../src/control/control.c:170
 msgctxt "accel"
 msgid "<blending>"
 msgstr "<블랜딩>"
 
-#: ../src/control/control.c:175
+#: ../src/control/control.c:177
 msgctxt "accel"
 msgid "Lua scripts"
 msgstr "Lua 스크립트"
 
-#: ../src/control/control.c:182
+#: ../src/control/control.c:184
 msgctxt "accel"
 msgid "fallbacks"
 msgstr "대체 기능"
 
-#: ../src/control/control.c:191
+#: ../src/control/control.c:193
 msgctxt "accel"
 msgid "<focused>"
 msgstr "<선택됨>"
 
-#: ../src/control/control.c:213
+#: ../src/control/control.c:215
 msgid "show accels window"
 msgstr "단축키 창 표시"
 
-#: ../src/control/control.c:312
+#: ../src/control/control.c:387
 msgid "darktable will be locked until background work has been done"
 msgstr "백그라운드 작업이 완료되기 전까지 darktable을 사용할 수 없습니다"
 
-#: ../src/control/control.c:415
+#: ../src/control/control.c:497
 msgid "working..."
 msgstr "작업 중..."
 
-#: ../src/control/crawler.c:167
+#: ../src/control/crawler.c:168
 #, c-format
 msgid "checking for updated sidecar files (%d%%)"
 msgstr "업데이트된 사이드카 파일 확인 중 (%d%%)"
 
-#: ../src/control/crawler.c:453
+#: ../src/control/crawler.c:454
 #, c-format
 msgid "ERROR: %s NOT synced XMP → DB"
 msgstr "오류: %s XMP → DB 동기화되지 않음"
 
-#: ../src/control/crawler.c:454 ../src/control/crawler.c:520
-#: ../src/control/crawler.c:589
-msgid "ERROR: cannot write the database. the destination may be full, offline or read-only."
+#: ../src/control/crawler.c:455 ../src/control/crawler.c:521
+#: ../src/control/crawler.c:590
+msgid ""
+"ERROR: cannot write the database. the destination may be full, offline or "
+"read-only."
 msgstr "오류: 데이터베이스에 쓸 수 없습니다. 대상에 공간이 부족하거나, 오프라인 상태이거나, 읽기 전용으로 설정되어 있을 수 있습니다."
 
-#: ../src/control/crawler.c:461
+#: ../src/control/crawler.c:462
 #, c-format
 msgid "SUCCESS: %s synced XMP → DB"
 msgstr "성공: %s XMP → DB 동기화됨"
 
-#: ../src/control/crawler.c:483
+#: ../src/control/crawler.c:484
 #, c-format
 msgid "ERROR: %s NOT synced DB → XMP"
 msgstr "오류: %s DB → XMP 동기화되지 않음"
 
-#: ../src/control/crawler.c:485 ../src/control/crawler.c:544
-#: ../src/control/crawler.c:610
+#: ../src/control/crawler.c:486 ../src/control/crawler.c:545
+#: ../src/control/crawler.c:611
 #, c-format
 msgid ""
 "ERROR: cannot write %s \n"
@@ -7718,133 +8497,133 @@ msgstr ""
 "오류: %s을 쓸 수 없습니다\n"
 "대상에 공간이 부족하거나, 오프라인 상태이거나 읽기 전용으로 설정되어 있을 수 있습니다."
 
-#: ../src/control/crawler.c:491
+#: ../src/control/crawler.c:492
 #, c-format
 msgid "SUCCESS: %s synced DB → XMP"
 msgstr "성공: %s DB → XMP 동기화됨"
 
-#: ../src/control/crawler.c:517
+#: ../src/control/crawler.c:518
 #, c-format
 msgid "ERROR: %s NOT synced new (XMP) → old (DB)"
 msgstr "오류: %s 새 (XMP) → 이전 (DB) 동기화되지 않음"
 
-#: ../src/control/crawler.c:527
+#: ../src/control/crawler.c:528
 #, c-format
 msgid "SUCCESS: %s synced new (XMP) → old (DB)"
 msgstr "성공: %s 새 (XMP) → 이전 (DB) 동기화됨"
 
-#: ../src/control/crawler.c:541
+#: ../src/control/crawler.c:542
 #, c-format
 msgid "ERROR: %s NOT synced new (DB) → old (XMP)"
 msgstr "오류: %s 새 (DB) → 이전 (XMP) 동기화되지 않음"
 
-#: ../src/control/crawler.c:549
+#: ../src/control/crawler.c:550
 #, c-format
 msgid "SUCCESS: %s synced new (DB) → old (XMP)"
 msgstr "성공: %s 새 (DB) → 이전 (XMP) 동기화됨"
 
-#: ../src/control/crawler.c:558 ../src/control/crawler.c:626
+#: ../src/control/crawler.c:559 ../src/control/crawler.c:627
 #, c-format
 msgid "EXCEPTION: %s has inconsistent timestamps"
 msgstr "오류: %s의 타임스탬프가 불일치합니다"
 
-#: ../src/control/crawler.c:586
+#: ../src/control/crawler.c:587
 #, c-format
 msgid "ERROR: %s NOT synced old (XMP) → new (DB)"
 msgstr "오류: %s 이전 (XMP) → 새 (DB) 동기화되지 않음"
 
-#: ../src/control/crawler.c:595
+#: ../src/control/crawler.c:596
 #, c-format
 msgid "SUCCESS: %s synced old (XMP) → new (DB)"
 msgstr "성공: %s 이전 (XMP) → 새 (DB) 동기화됨"
 
-#: ../src/control/crawler.c:607
+#: ../src/control/crawler.c:608
 #, c-format
 msgid "ERROR: %s NOT synced old (DB) → new (XMP)"
 msgstr "오류: %s 이전 (DB) → 새 (XMP) 동기화되지 않음"
 
-#: ../src/control/crawler.c:616
+#: ../src/control/crawler.c:617
 #, c-format
 msgid "SUCCESS: %s synced old (DB) → new (XMP)"
 msgstr "성공: %s 이전 (DB) → 새 (XMP) 동기화됨"
 
-#: ../src/control/crawler.c:698
+#: ../src/control/crawler.c:699
 #, c-format
 msgid "%id %02dh %02dm %02ds"
 msgstr "%id %02dh %02dm %02ds"
 
-#: ../src/control/crawler.c:745
+#: ../src/control/crawler.c:746
 msgid "XMP"
 msgstr "XMP"
 
-#: ../src/control/crawler.c:762 ../src/imageio/storage/disk.c:273
+#: ../src/control/crawler.c:763 ../src/imageio/storage/disk.c:275
 #: ../src/imageio/storage/gallery.c:197 ../src/imageio/storage/latex.c:185
 #: ../src/imageio/storage/latex.c:196
 msgid "path"
 msgstr "경로"
 
-#: ../src/control/crawler.c:771
+#: ../src/control/crawler.c:772
 msgid "XMP timestamp"
 msgstr "XMP 타임스탬프"
 
-#: ../src/control/crawler.c:776
+#: ../src/control/crawler.c:777
 msgid "database timestamp"
 msgstr "데이터베이스 타임스탬프"
 
-#: ../src/control/crawler.c:781
+#: ../src/control/crawler.c:782
 msgid "newest"
 msgstr "최신"
 
-#: ../src/control/crawler.c:787
+#: ../src/control/crawler.c:788
 msgid "time difference"
 msgstr "시간 차이"
 
-#: ../src/control/crawler.c:799
+#: ../src/control/crawler.c:800
 msgid "updated XMP sidecar files found"
 msgstr "업데이트된 XMP 사이드카 파일을 찾았습니다"
 
-#: ../src/control/crawler.c:800
+#: ../src/control/crawler.c:801 ../src/gui/welcome.c:745
 msgid "_close"
 msgstr "닫기 (&C)"
 
 #. setup selection accelerators
 #. action-box
-#: ../src/control/crawler.c:810 ../src/dtgtk/thumbtable.c:2970
-#: ../src/libs/import.c:2075 ../src/libs/select.c:142
+#: ../src/control/crawler.c:811 ../src/dtgtk/thumbtable.c:3113
+#: ../src/libs/import.c:2038 ../src/libs/select.c:142
 msgid "select all"
 msgstr "전체 선택"
 
-#: ../src/control/crawler.c:811 ../src/dtgtk/thumbtable.c:2972
-#: ../src/libs/import.c:2079 ../src/libs/select.c:146
+#: ../src/control/crawler.c:812 ../src/dtgtk/thumbtable.c:3115
+#: ../src/libs/import.c:2042 ../src/libs/select.c:146
 msgid "select none"
 msgstr "선택 해제"
 
-#: ../src/control/crawler.c:812 ../src/dtgtk/thumbtable.c:2974
+#: ../src/control/crawler.c:813 ../src/dtgtk/thumbtable.c:3117
 #: ../src/libs/select.c:150
 msgid "invert selection"
 msgstr "선택 반전"
 
-#: ../src/control/crawler.c:817
+#: ../src/control/crawler.c:818
 msgid "on the selection:"
 msgstr "선택한 항목:"
 
-#: ../src/control/crawler.c:818
+#: ../src/control/crawler.c:819
 msgid "keep the XMP edit"
 msgstr "XMP 편집 내용 유지"
 
-#: ../src/control/crawler.c:819
+#: ../src/control/crawler.c:820
 msgid "keep the database edit"
 msgstr "데이터베이스 편집 내용 유지"
 
-#: ../src/control/crawler.c:820
+#: ../src/control/crawler.c:821
 msgid "keep the newest edit"
 msgstr "최신 편집 내용 유지"
 
-#: ../src/control/crawler.c:821
+#: ../src/control/crawler.c:822
 msgid "keep the oldest edit"
 msgstr "과거 편집 내용 유지"
 
-#: ../src/control/crawler.c:835
+#: ../src/control/crawler.c:836
 msgid "synchronization log"
 msgstr "동기화 로그"
 
@@ -7878,80 +8657,80 @@ msgid "importing %d image from camera"
 msgid_plural "importing %d images from camera"
 msgstr[0] "카메라에서 %d개 이미지 가져오는 중"
 
-#: ../src/control/jobs/camera_jobs.c:396
+#: ../src/control/jobs/camera_jobs.c:398
 msgid "import images from camera"
 msgstr "카메라에서 이미지 가져오기"
 
-#: ../src/control/jobs/control_jobs.c:211
-msgid "failed to create film roll for destination directory, aborting move.."
-msgstr "대상 디렉토리에 필름 롤을 생성에 실패하였습니다, 이동을 중단합니다.."
+#: ../src/control/jobs/control_jobs.c:214
+msgid "failed to create film roll for destination directory, aborting move."
+msgstr "대상 디렉토리에 필름롤을 생성하지 못했습니다. 이동을 중단합니다."
 
-#: ../src/control/jobs/control_jobs.c:343
+#: ../src/control/jobs/control_jobs.c:363
 #, c-format
 msgid "writing sidecar file"
 msgid_plural "writing %zu sidecar files"
 msgstr[0] "사이드카 파일 %zu개 기록 중"
 
-#: ../src/control/jobs/control_jobs.c:510
+#: ../src/control/jobs/control_jobs.c:530
 msgid "unable to allocate memory for HDR merge"
 msgstr "HDR 병합에 메모리를 할당할 수 없습니다"
 
-#: ../src/control/jobs/control_jobs.c:519
+#: ../src/control/jobs/control_jobs.c:539
 msgid "exposure bracketing only works on raw images."
 msgstr "노출 브라케팅은 RAW 이미지에서만 작동합니다."
 
-#: ../src/control/jobs/control_jobs.c:527
+#: ../src/control/jobs/control_jobs.c:547
 msgid "images have to be of same size and orientation!"
 msgstr "이미지 크기와 방향이 동일해야 합니다!"
 
-#: ../src/control/jobs/control_jobs.c:620
+#: ../src/control/jobs/control_jobs.c:640
 #, c-format
 msgid "merging %d image"
 msgid_plural "merging %d images"
 msgstr[0] "%d개 이미지 병합 중"
 
-#: ../src/control/jobs/control_jobs.c:692
+#: ../src/control/jobs/control_jobs.c:712
 #, c-format
 msgid "wrote merged HDR `%s'"
 msgstr "병합된 HDR `%s'에 저장됨"
 
-#: ../src/control/jobs/control_jobs.c:724
+#: ../src/control/jobs/control_jobs.c:744
 #, c-format
 msgid "duplicating %d image"
 msgid_plural "duplicating %d images"
 msgstr[0] "%d개 이미지 복제 중"
 
-#: ../src/control/jobs/control_jobs.c:766
+#: ../src/control/jobs/control_jobs.c:786
 #, c-format
 msgid "flipping %d image"
 msgid_plural "flipping %d images"
 msgstr[0] "%d개 이미지 반전 중"
 
-#: ../src/control/jobs/control_jobs.c:798
+#: ../src/control/jobs/control_jobs.c:818
 #, c-format
 msgid "set %d color image"
 msgid_plural "setting %d color images"
 msgstr[0] "%d개 이미지 컬러로 설정 중"
 
-#: ../src/control/jobs/control_jobs.c:800
+#: ../src/control/jobs/control_jobs.c:820
 #, c-format
 msgid "set %d monochrome image"
 msgid_plural "setting %d monochrome images"
 msgstr[0] "%d개 이미지 모노크롬으로 설정 중"
 
-#: ../src/control/jobs/control_jobs.c:908
+#: ../src/control/jobs/control_jobs.c:928
 #, c-format
 msgid "removing %d image"
 msgid_plural "removing %d images"
 msgstr[0] "%d개 이미지 제거 중"
 
-#: ../src/control/jobs/control_jobs.c:952
+#: ../src/control/jobs/control_jobs.c:972
 #, c-format
 msgid "not removing image '%s' used as overlay in %d image"
 msgid_plural "not removing image '%s' used as overlay in %d images"
 msgstr[0] "제거되지 않은 이미지 '%s'는 %d개 이미지가 오버레이로 사용 중입니다"
 
-#: ../src/control/jobs/control_jobs.c:1035
+#: ../src/control/jobs/control_jobs.c:1055
 #, c-format
 msgid ""
 "could not send %s to trash%s\n"
@@ -7964,7 +8743,7 @@ msgstr ""
 "\n"
 "휴지통을 사용하지 않고 디스크에서 파일을 삭제하시겠습니까?"
 
-#: ../src/control/jobs/control_jobs.c:1037
+#: ../src/control/jobs/control_jobs.c:1057
 #, c-format
 msgid ""
 "could not delete from disk %s%s\n"
@@ -7973,198 +8752,198 @@ msgstr ""
 "디스크 %s%s에서 삭제할 수 없습니다\n"
 "%s"
 
-#: ../src/control/jobs/control_jobs.c:1045
+#: ../src/control/jobs/control_jobs.c:1065
 msgid "_apply to all"
 msgstr "전체 적용 (&A)"
 
-#: ../src/control/jobs/control_jobs.c:1053
+#: ../src/control/jobs/control_jobs.c:1073
 msgid "_delete permanently"
 msgstr "영구적으로 삭제 (&D)"
 
-#: ../src/control/jobs/control_jobs.c:1055
-#: ../src/control/jobs/control_jobs.c:1060
+#: ../src/control/jobs/control_jobs.c:1075
+#: ../src/control/jobs/control_jobs.c:1080
 msgid "_remove from library"
 msgstr "라이브러리에서 제거 (&R)"
 
-#: ../src/control/jobs/control_jobs.c:1063 ../src/libs/styles.c:504
+#: ../src/control/jobs/control_jobs.c:1083 ../src/libs/styles.c:504
 #: ../src/libs/styles.c:657
 msgid "_skip"
 msgstr "건너뛰기 (&S)"
 
-#: ../src/control/jobs/control_jobs.c:1064
+#: ../src/control/jobs/control_jobs.c:1084
 msgid "abort"
 msgstr "중단"
 
-#: ../src/control/jobs/control_jobs.c:1070
+#: ../src/control/jobs/control_jobs.c:1090
 msgid "trashing error"
 msgstr "휴지통으로 이동 실패"
 
-#: ../src/control/jobs/control_jobs.c:1071
+#: ../src/control/jobs/control_jobs.c:1091
 msgid "deletion error"
 msgstr "삭제 오류"
 
-#: ../src/control/jobs/control_jobs.c:1223
+#: ../src/control/jobs/control_jobs.c:1243
 #, c-format
 msgid "trashing %d image"
 msgid_plural "trashing %d images"
 msgstr[0] "%d개 이미지 휴지통으로 이동 중"
 
-#: ../src/control/jobs/control_jobs.c:1225
+#: ../src/control/jobs/control_jobs.c:1245
 #, c-format
 msgid "deleting %d image"
 msgid_plural "deleting %d images"
 msgstr[0] "%d개 이미지 삭제 중"
 
-#: ../src/control/jobs/control_jobs.c:1259
+#: ../src/control/jobs/control_jobs.c:1279
 #, c-format
 msgid "not deleting image '%s' used as overlay in %d image"
 msgid_plural "not deleting image '%s' used as overlay in %d images"
 msgstr[0] "이미지 '%s'는 %d개의 이미지에서 오버레이로 사용되어 삭제되지 않습니다"
 
-#: ../src/control/jobs/control_jobs.c:1393
+#: ../src/control/jobs/control_jobs.c:1413
 #, c-format
 msgid "setting GPS information"
 msgid_plural "setting GPS information for %u images"
 msgstr[0] "%u 이미지의 GPS 정보 설정"
 
-#: ../src/control/jobs/control_jobs.c:1438
+#: ../src/control/jobs/control_jobs.c:1458
 #, c-format
 msgid "applied matched GPX location onto %d image"
 msgid_plural "applied matched GPX location onto %d images"
 msgstr[0] "일치하는 GPX 위치 정보를 %d개 이미지에 적용하였습니다"
 
-#: ../src/control/jobs/control_jobs.c:1456
+#: ../src/control/jobs/control_jobs.c:1476
 #, c-format
 msgid "moving %d image"
 msgstr "%d개 이미지 이동 중"
 
-#: ../src/control/jobs/control_jobs.c:1457
+#: ../src/control/jobs/control_jobs.c:1477
 #, c-format
 msgid "moving %d images"
 msgstr "%d개 이미지 이동 중"
 
-#: ../src/control/jobs/control_jobs.c:1463
+#: ../src/control/jobs/control_jobs.c:1484
 #, c-format
 msgid "copying %d image"
 msgstr "%d개 이미지 복사 중"
 
-#: ../src/control/jobs/control_jobs.c:1464
+#: ../src/control/jobs/control_jobs.c:1485
 #, c-format
 msgid "copying %d images"
 msgstr "%d개 이미지 복사 중"
 
-#: ../src/control/jobs/control_jobs.c:1479
+#: ../src/control/jobs/control_jobs.c:1501
 #, c-format
 msgid "creating local copy of %d image"
 msgid_plural "creating local copies of %d images"
 msgstr[0] "%d개 이미지의 로컬 복사본 생성 중"
 
-#: ../src/control/jobs/control_jobs.c:1483
+#: ../src/control/jobs/control_jobs.c:1505
 #, c-format
 msgid "removing local copy of %d image"
 msgid_plural "removing local copies of %d images"
 msgstr[0] "%d개 이미지의 로컬 복사본 제거 중"
 
-#: ../src/control/jobs/control_jobs.c:1532
+#: ../src/control/jobs/control_jobs.c:1554
 #, c-format
 msgid "refreshing info for %d image"
 msgid_plural "refreshing info for %d images"
 msgstr[0] "%d개 이미지 정보 새로 고침 중"
 
-#: ../src/control/jobs/control_jobs.c:1604
+#: ../src/control/jobs/control_jobs.c:1626
 #, c-format
 msgid "pasting history to %d image"
 msgid_plural "pasting history to %d images"
 msgstr[0] "%d개 이미지에 히스토리를 붙여넣는 중"
 
-#: ../src/control/jobs/control_jobs.c:1626
+#: ../src/control/jobs/control_jobs.c:1648
 msgid "skipped pasting history into image being edited"
 msgstr "편집중인 이미지에 히스토리 붙여넣기를 건너뛰었습니다"
 
-#: ../src/control/jobs/control_jobs.c:1667
+#: ../src/control/jobs/control_jobs.c:1690
 #, c-format
 msgid "compressing history for %d image"
 msgid_plural "compressing history for %d images"
 msgstr[0] "%d개 이미지의 히스토리 압축 중"
 
-#: ../src/control/jobs/control_jobs.c:1684
+#: ../src/control/jobs/control_jobs.c:1707
 msgid "skipped compressing history for image being edited"
 msgstr "편집중인 이미지의 히스토리 압축을 건너뛰었습니다"
 
-#: ../src/control/jobs/control_jobs.c:1695
+#: ../src/control/jobs/control_jobs.c:1719
 #, c-format
 msgid "no history compression of %d image"
 msgid_plural "no history compression of %d images"
 msgstr[0] "%d개 이미지의 히스토리를 압축할 수 없습니다"
 
-#: ../src/control/jobs/control_jobs.c:1708
+#: ../src/control/jobs/control_jobs.c:1732
 #, c-format
 msgid "discarding history for %d image"
 msgid_plural "discarding history for %d images"
 msgstr[0] "%d개 이미지의 히스토리 버리는 중"
 
-#: ../src/control/jobs/control_jobs.c:1721
+#: ../src/control/jobs/control_jobs.c:1745
 msgid "skipped discarding history for image being edited"
 msgstr "편집중인 이미지의 히스토리 삭제를 건너뛰었습니다"
 
-#: ../src/control/jobs/control_jobs.c:1753
+#: ../src/control/jobs/control_jobs.c:1778
 #, c-format
 msgid "applying style(s) for %d image"
 msgid_plural "applying style(s) for %d images"
 msgstr[0] "%d개 이미지에 스타일 적용 중"
 
-#: ../src/control/jobs/control_jobs.c:1854
+#: ../src/control/jobs/control_jobs.c:1877
 #, c-format
 msgid "exporting %d image.."
 msgid_plural "exporting %d images.."
 msgstr[0] "%d개 이미지 내보내는 중..."
 
-#: ../src/control/jobs/control_jobs.c:1856
+#: ../src/control/jobs/control_jobs.c:1879
 msgid "no image to export"
 msgstr "내보낼 이미지가 없습니다"
 
 #. progress message
 #. update the message. initialize_store() might have changed the number of images
-#: ../src/control/jobs/control_jobs.c:1915
+#: ../src/control/jobs/control_jobs.c:1930
 #, c-format
 msgid "exporting %d / %d to %s"
 msgstr "%d/%d, %s로 내보내는 중"
 
-#: ../src/control/jobs/control_jobs.c:1927 ../src/views/darkroom.c:882
+#: ../src/control/jobs/control_jobs.c:1942 ../src/views/darkroom.c:1164
 #: ../src/views/print.c:331
 #, c-format
 msgid "image `%s' is currently unavailable"
 msgstr "이미지 `%s'은 현재 사용할 수 없습니다"
 
-#: ../src/control/jobs/control_jobs.c:2036
+#: ../src/control/jobs/control_jobs.c:2051
 msgid "merge HDR image"
 msgstr "HDR 이미지 병합"
 
-#: ../src/control/jobs/control_jobs.c:2052
+#: ../src/control/jobs/control_jobs.c:2067
 msgid "duplicate images"
 msgstr "이미지 복제"
 
-#: ../src/control/jobs/control_jobs.c:2061
+#: ../src/control/jobs/control_jobs.c:2076
 msgid "flip images"
 msgstr "이미지 반전"
 
-#: ../src/control/jobs/control_jobs.c:2069
+#: ../src/control/jobs/control_jobs.c:2084
 msgid "set monochrome images"
 msgstr "이미지를 모노크롬으로 설정"
 
-#: ../src/control/jobs/control_jobs.c:2077
+#: ../src/control/jobs/control_jobs.c:2092
 msgid "remove images"
 msgstr "이미지 제거"
 
-#: ../src/control/jobs/control_jobs.c:2090
+#: ../src/control/jobs/control_jobs.c:2105
 msgid "remove image?"
 msgstr "이미지를 제거하시겠습니까?"
 
-#: ../src/control/jobs/control_jobs.c:2090
+#: ../src/control/jobs/control_jobs.c:2105
 msgid "remove images?"
 msgstr "이미지를 제거하시겠습니까?"
 
-#: ../src/control/jobs/control_jobs.c:2091
+#: ../src/control/jobs/control_jobs.c:2106
 #, c-format
 msgid ""
 "do you really want to remove %d image from darktable\n"
@@ -8176,19 +8955,19 @@ msgstr[0] ""
 "정말로 %d개 이미지를 darktable에서 제거하시겠습니까?\n"
 "(디스크의 파일은 삭제되지 않습니다)"
 
-#: ../src/control/jobs/control_jobs.c:2107
+#: ../src/control/jobs/control_jobs.c:2122
 msgid "delete images"
 msgstr "이미지 삭제"
 
-#: ../src/control/jobs/control_jobs.c:2123
+#: ../src/control/jobs/control_jobs.c:2138
 msgid "delete image?"
 msgstr "이미지를 삭제하시겠습니까?"
 
-#: ../src/control/jobs/control_jobs.c:2123
+#: ../src/control/jobs/control_jobs.c:2138
 msgid "delete images?"
 msgstr "이미지를 삭제하시겠습니까?"
 
-#: ../src/control/jobs/control_jobs.c:2124
+#: ../src/control/jobs/control_jobs.c:2139
 #, c-format
 msgid ""
 "do you really want to physically delete %d image\n"
@@ -8200,39 +8979,41 @@ msgstr[0] ""
 "정말로 %d개 이미지를 물리적으로 삭제하시겠습니까?\n"
 "(가능하면 휴지통 사용)"
 
-#: ../src/control/jobs/control_jobs.c:2126
+#: ../src/control/jobs/control_jobs.c:2141
 #, c-format
 msgid "do you really want to physically delete %d image from disk?"
 msgid_plural "do you really want to physically delete %d images from disk?"
 msgstr[0] "정말로 %d개 이미지를 디스크에서 물리적으로 삭제하시겠습니까?"
 
-#: ../src/control/jobs/control_jobs.c:2144
+#: ../src/control/jobs/control_jobs.c:2159
 msgid "delete duplicate"
 msgstr "복제 삭제"
 
-#: ../src/control/jobs/control_jobs.c:2160
+#: ../src/control/jobs/control_jobs.c:2175
 msgid "delete duplicate?"
 msgstr "복제 삭제?"
 
-#: ../src/control/jobs/control_jobs.c:2161
-msgid "do you really want to delete the duplicate (without deleting the source image file on disk)?"
-msgstr "정말로 %d개 이미지를 darktable에서 제거하시겠습니까? (디스크의 원본 파일은 삭제되지 않습니다)"
+#: ../src/control/jobs/control_jobs.c:2176
+msgid ""
+"do you really want to delete the duplicate (without deleting the source "
+"image file on disk)?"
+msgstr "정말로 복제본을 삭제하시겠습니까? (디스크의 원본 이미지 파일은 삭제되지 않습니다)"
 
-#: ../src/control/jobs/control_jobs.c:2178
+#: ../src/control/jobs/control_jobs.c:2193
 msgid "move images"
 msgstr "이미지 이동"
 
-#: ../src/control/jobs/control_jobs.c:2190
-#: ../src/control/jobs/control_jobs.c:2247
+#: ../src/control/jobs/control_jobs.c:2205
+#: ../src/control/jobs/control_jobs.c:2262
 msgid "_select as destination"
 msgstr "대상으로 선택 (&S)"
 
-#: ../src/control/jobs/control_jobs.c:2210
+#: ../src/control/jobs/control_jobs.c:2225
 msgid "move image?"
 msgid_plural "move images?"
 msgstr[0] "이미지를 이동하시겠습니까?"
 
-#: ../src/control/jobs/control_jobs.c:2211
+#: ../src/control/jobs/control_jobs.c:2226
 #, c-format
 msgid ""
 "do you really want to physically move %d image to %s?\n"
@@ -8244,130 +9025,135 @@ msgstr[0] ""
 "정말로 %d개 이미지를 %s로 이동하시겠습니까?\n"
 "(모든 복제본이 함께 이동됩니다)"
 
-#: ../src/control/jobs/control_jobs.c:2234
+#: ../src/control/jobs/control_jobs.c:2249
 msgid "copy images"
 msgstr "이미지 복사"
 
-#: ../src/control/jobs/control_jobs.c:2270
+#: ../src/control/jobs/control_jobs.c:2285
 msgid "copy image?"
 msgid_plural "copy images?"
 msgstr[0] "이미지를 복사하시겠습니까?"
 
-#: ../src/control/jobs/control_jobs.c:2271
+#: ../src/control/jobs/control_jobs.c:2286
 #, c-format
 msgid "do you really want to physically copy %d image to %s?"
 msgid_plural "do you really want to physically copy %d images to %s?"
 msgstr[0] "정말로 %d개 이미지를 %s로 물리적으로 복사하시겠습니까?"
 
-#: ../src/control/jobs/control_jobs.c:2289
-#: ../src/control/jobs/control_jobs.c:2298
+#: ../src/control/jobs/control_jobs.c:2304
+#: ../src/control/jobs/control_jobs.c:2313
 msgid "local copy images"
 msgstr "이미지 로컬 복사"
 
-#: ../src/control/jobs/control_jobs.c:2307 ../src/libs/image.c:654
+#: ../src/control/jobs/control_jobs.c:2322 ../src/libs/image.c:654
 msgid "refresh EXIF"
 msgstr "EXIF 새로 고침"
 
-#: ../src/control/jobs/control_jobs.c:2400
-#: ../src/control/jobs/control_jobs.c:2432 ../src/dtgtk/thumbtable.c:2957
+#: ../src/control/jobs/control_jobs.c:2415
+#: ../src/control/jobs/control_jobs.c:2447 ../src/dtgtk/thumbtable.c:3100
 msgid "paste history"
 msgstr "히스토리 붙여넣기"
 
-#: ../src/control/jobs/control_jobs.c:2448 ../src/libs/copy_history.c:324
+#: ../src/control/jobs/control_jobs.c:2463 ../src/libs/copy_history.c:324
 msgid "compress history"
 msgstr "히스토리 압축"
 
-#: ../src/control/jobs/control_jobs.c:2460 ../src/dtgtk/thumbtable.c:2961
+#: ../src/control/jobs/control_jobs.c:2475 ../src/dtgtk/thumbtable.c:3104
 #: ../src/libs/copy_history.c:329
 msgid "discard history"
 msgstr "히스토리 버리기"
 
-#: ../src/control/jobs/control_jobs.c:2468
+#: ../src/control/jobs/control_jobs.c:2483
 msgid "no images nor styles selected!"
 msgstr "선택된 이미지 및 스타일이 없습니다!"
 
-#: ../src/control/jobs/control_jobs.c:2472
+#: ../src/control/jobs/control_jobs.c:2487
 msgid "no styles selected!"
 msgstr "선택된 스타일이 없습니다!"
 
-#: ../src/control/jobs/control_jobs.c:2476
+#: ../src/control/jobs/control_jobs.c:2491
 msgid "no images selected!"
 msgstr "선택된 이미지가 없습니다!"
 
-#: ../src/control/jobs/control_jobs.c:2489
+#: ../src/control/jobs/control_jobs.c:2504
 msgid "apply style(s)"
 msgstr "스타일 적용"
 
-#: ../src/control/jobs/control_jobs.c:2567
+#: ../src/control/jobs/control_jobs.c:2585
 #, c-format
-msgid "failed to get parameters from storage module `%s', aborting export.."
-msgstr "저장 모듈 `%s'에서 파라메터를 가져올 수 없습니다, 내보내기를 중단합니다.."
+msgid "failed to get parameters from storage module `%s', aborting export."
+msgstr "저장 모듈 `%s'에서 파라메터를 가져올 수 없습니다. 내보내기를 중단합니다."
 
-#: ../src/control/jobs/control_jobs.c:2584
+#: ../src/control/jobs/control_jobs.c:2597
+#, c-format
+msgid "failed to get parameters from format module `%s', aborting export."
+msgstr "형식 모듈 `%s'에서 파라메터를 가져올 수 없습니다. 내보내기를 중단합니다."
+
+#: ../src/control/jobs/control_jobs.c:2617
 msgid "export images"
 msgstr "이미지 내보내기"
 
-#: ../src/control/jobs/control_jobs.c:2637
+#: ../src/control/jobs/control_jobs.c:2670
 #, c-format
 msgid "adding time offset to %d image"
 msgstr "%d개 이미지에 시간 오프셋 추가 중"
 
-#: ../src/control/jobs/control_jobs.c:2638
+#: ../src/control/jobs/control_jobs.c:2671
 #, c-format
 msgid "setting date/time of %d image"
 msgstr "%d개 이미지의 날짜/시간 정보 설정 중"
 
-#: ../src/control/jobs/control_jobs.c:2640
+#: ../src/control/jobs/control_jobs.c:2673
 #, c-format
 msgid "adding time offset to %d images"
 msgstr "%d개 이미지에 시간 오프셋 추가 중"
 
-#: ../src/control/jobs/control_jobs.c:2641
+#: ../src/control/jobs/control_jobs.c:2674
 #, c-format
 msgid "setting date/time of %d images"
 msgstr "%d개 이미지의 날짜/시간 정보 설정 중"
 
-#: ../src/control/jobs/control_jobs.c:2687
+#: ../src/control/jobs/control_jobs.c:2720
 #, c-format
 msgid "added time offset to %d image"
 msgstr "%d개 이미지에 시간 오프셋 추가됨"
 
-#: ../src/control/jobs/control_jobs.c:2688
+#: ../src/control/jobs/control_jobs.c:2721
 #, c-format
 msgid "set date/time of %d image"
 msgstr "%d개 이미지의 날짜/시간 정보 설정됨"
 
-#: ../src/control/jobs/control_jobs.c:2690
+#: ../src/control/jobs/control_jobs.c:2723
 #, c-format
 msgid "added time offset to %d images"
 msgstr "%d개 이미지에 시간 오프셋 추가됨"
 
-#: ../src/control/jobs/control_jobs.c:2691
+#: ../src/control/jobs/control_jobs.c:2724
 #, c-format
 msgid "set date/time of %d images"
 msgstr "%d개 이미지의 날짜/시간 정보 설정됨"
 
-#: ../src/control/jobs/control_jobs.c:2734
+#: ../src/control/jobs/control_jobs.c:2767
 msgid "time offset"
 msgstr "시간 오프셋"
 
-#: ../src/control/jobs/control_jobs.c:2764 ../src/libs/copy_history.c:339
+#: ../src/control/jobs/control_jobs.c:2797 ../src/libs/copy_history.c:339
 msgid "write sidecar files"
 msgstr "사이드카 파일 저장"
 
-#: ../src/control/jobs/control_jobs.c:2977 ../src/control/jobs/film_jobs.c:297
+#: ../src/control/jobs/control_jobs.c:3010 ../src/control/jobs/film_jobs.c:297
 #, c-format
 msgid "importing %d image"
 msgid_plural "importing %d images"
 msgstr[0] "%d개 이미지 가져오는 중"
 
-#: ../src/control/jobs/control_jobs.c:3028
+#: ../src/control/jobs/control_jobs.c:3061
 #, c-format
 msgid "importing %d/%d image"
 msgid_plural "importing %d/%d images"
 msgstr[0] "%d/%d 이미지 가져오는 중"
 
-#: ../src/control/jobs/control_jobs.c:3036
+#: ../src/control/jobs/control_jobs.c:3069
 #, c-format
 msgid "imported %d image"
 msgid_plural "imported %d images"
@@ -8394,11 +9180,11 @@ msgstr "이미지 가져오기"
 msgid "synchronize sidecars"
 msgstr "사이드카 동기화"
 
-#: ../src/develop/blend.c:299
+#: ../src/develop/blend.c:302
 msgid "detail mask blending error"
 msgstr "디테일 마스크 블랜딩 오류"
 
-#: ../src/develop/blend.c:845
+#: ../src/develop/blend.c:849
 msgid "detail mask CL blending problem"
 msgstr "디테일 마스크 CL 블랜딩에 문제가 있습니다"
 
@@ -8599,8 +9385,10 @@ msgctxt "blendoperation"
 msgid "reverse"
 msgstr "반전"
 
-#: ../src/develop/blend_gui.c:140 ../src/gui/workspace.c:98
-#: ../src/gui/workspace.c:189 ../src/imageio/format/webp.c:435
+#. add default workspace
+#: ../src/develop/blend_gui.c:140 ../src/gui/preferences_ai.c:1852
+#: ../src/gui/workspace.c:48 ../src/gui/workspace.c:588
+#: ../src/imageio/format/webp.c:435 ../src/libs/styles.c:1029
 msgid "default"
 msgstr "기본값"
 
@@ -8608,35 +9396,35 @@ msgstr "기본값"
 msgid "RAW"
 msgstr "RAW"
 
-#: ../src/develop/blend_gui.c:146 ../src/develop/blend_gui.c:2064
+#: ../src/develop/blend_gui.c:146 ../src/develop/blend_gui.c:2065
 msgid "RGB (display)"
 msgstr "RGB (디스플레이)"
 
-#: ../src/develop/blend_gui.c:148 ../src/develop/blend_gui.c:2077
+#: ../src/develop/blend_gui.c:148 ../src/develop/blend_gui.c:2078
 msgid "RGB (scene)"
 msgstr "RGB (장면)"
 
 #. DEVELOP_MASK_ENABLED
-#: ../src/develop/blend_gui.c:155 ../src/develop/blend_gui.c:3426
+#: ../src/develop/blend_gui.c:155 ../src/develop/blend_gui.c:3437
 msgid "uniformly"
 msgstr "균일하게"
 
-#: ../src/develop/blend_gui.c:157 ../src/develop/blend_gui.c:2765
-#: ../src/develop/blend_gui.c:3435 ../src/develop/imageop.c:2802
+#: ../src/develop/blend_gui.c:157 ../src/develop/blend_gui.c:2766
+#: ../src/develop/blend_gui.c:3446 ../src/develop/imageop.c:2859
 msgid "drawn mask"
 msgstr "드로잉 마스크"
 
-#: ../src/develop/blend_gui.c:159 ../src/develop/blend_gui.c:2559
-#: ../src/develop/blend_gui.c:3444 ../src/develop/imageop.c:2804
+#: ../src/develop/blend_gui.c:159 ../src/develop/blend_gui.c:2560
+#: ../src/develop/blend_gui.c:3455 ../src/develop/imageop.c:2861
 msgid "parametric mask"
 msgstr "파라메트릭 마스크"
 
-#: ../src/develop/blend_gui.c:161 ../src/develop/blend_gui.c:2971
-#: ../src/develop/blend_gui.c:3467 ../src/develop/imageop.c:2806
+#: ../src/develop/blend_gui.c:161 ../src/develop/blend_gui.c:2982
+#: ../src/develop/blend_gui.c:3478 ../src/develop/imageop.c:2863
 msgid "raster mask"
 msgstr "래스터 마스크"
 
-#: ../src/develop/blend_gui.c:163 ../src/develop/blend_gui.c:3456
+#: ../src/develop/blend_gui.c:163 ../src/develop/blend_gui.c:3467
 msgid "drawn & parametric mask"
 msgstr "드로잉 & 파라메트릭 마스크"
 
@@ -8672,19 +9460,19 @@ msgstr "블러 후 출력"
 msgid "input after blur"
 msgstr "블러 후 입력"
 
-#: ../src/develop/blend_gui.c:183 ../src/gui/accelerators.c:147
-#: ../src/gui/accelerators.c:157 ../src/gui/accelerators.c:246
+#: ../src/develop/blend_gui.c:183 ../src/gui/accelerators.c:152
+#: ../src/gui/accelerators.c:162 ../src/gui/accelerators.c:246
 #: ../src/imageio/format/avif.c:973 ../src/libs/live_view.c:425
 msgid "on"
 msgstr "켜짐"
 
-#: ../src/develop/blend_gui.c:1018 ../src/develop/blend_gui.c:2624
-#: ../src/develop/imageop.c:2930
+#: ../src/develop/blend_gui.c:1018 ../src/develop/blend_gui.c:2625
+#: ../src/develop/imageop.c:2987
 msgid "input"
 msgstr "입력"
 
-#: ../src/develop/blend_gui.c:1018 ../src/develop/blend_gui.c:2624
-#: ../src/develop/imageop.c:2930
+#: ../src/develop/blend_gui.c:1018 ../src/develop/blend_gui.c:2625
+#: ../src/develop/imageop.c:2987
 msgid "output"
 msgstr "출력"
 
@@ -8696,153 +9484,157 @@ msgstr " (줌)"
 msgid " (log)"
 msgstr " (로그)"
 
-#: ../src/develop/blend_gui.c:2038
+#: ../src/develop/blend_gui.c:1632 ../src/libs/masks.c:609
+msgid "AI model is not available. Check preferences > AI"
+msgstr "AI 모델을 사용할 수 없습니다. 환경설정 > AI를 확인하세요"
+
+#: ../src/develop/blend_gui.c:2039
 msgid "reset to default blend colorspace"
 msgstr "기본 블랜딩 색상 공간으로 초기화"
 
-#: ../src/develop/blend_gui.c:2094
+#: ../src/develop/blend_gui.c:2095
 msgid "reset and hide output channels"
 msgstr "출력 채널 초기화 및 숨기기"
 
-#: ../src/develop/blend_gui.c:2101
+#: ../src/develop/blend_gui.c:2102
 msgid "show output channels"
 msgstr "출력 채널 표시"
 
-#: ../src/develop/blend_gui.c:2340 ../src/develop/blend_gui.c:2407
+#: ../src/develop/blend_gui.c:2341 ../src/develop/blend_gui.c:2408
 #: ../src/iop/tonecurve.c:1270
 msgid "L"
 msgstr "L"
 
-#: ../src/develop/blend_gui.c:2340
+#: ../src/develop/blend_gui.c:2341
 msgid "sliders for L channel"
 msgstr "L 채널 슬라이더"
 
-#: ../src/develop/blend_gui.c:2345 ../src/iop/tonecurve.c:1271
+#: ../src/develop/blend_gui.c:2346 ../src/iop/tonecurve.c:1271
 msgid "a"
 msgstr "a"
 
-#: ../src/develop/blend_gui.c:2345
+#: ../src/develop/blend_gui.c:2346
 msgid "sliders for a channel"
 msgstr "a 채널 슬라이더"
 
-#: ../src/develop/blend_gui.c:2349
+#: ../src/develop/blend_gui.c:2350
 msgid "green/red"
 msgstr "녹색/빨강"
 
-#: ../src/develop/blend_gui.c:2350 ../src/iop/tonecurve.c:1272
+#: ../src/develop/blend_gui.c:2351 ../src/iop/tonecurve.c:1272
 msgid "b"
 msgstr "b"
 
-#: ../src/develop/blend_gui.c:2350
+#: ../src/develop/blend_gui.c:2351
 msgid "sliders for b channel"
 msgstr "b 채널 슬라이더"
 
-#: ../src/develop/blend_gui.c:2354
+#: ../src/develop/blend_gui.c:2355
 msgid "blue/yellow"
 msgstr "파랑/노랑"
 
-#: ../src/develop/blend_gui.c:2355
+#: ../src/develop/blend_gui.c:2356
 msgid "C"
 msgstr "C"
 
-#: ../src/develop/blend_gui.c:2355
+#: ../src/develop/blend_gui.c:2356
 msgid "sliders for chroma channel (of LCh)"
 msgstr "채도 채널 슬라이더 (LCh)"
 
-#: ../src/develop/blend_gui.c:2361
+#: ../src/develop/blend_gui.c:2362
 msgid "h"
 msgstr "h"
 
-#: ../src/develop/blend_gui.c:2361
+#: ../src/develop/blend_gui.c:2362
 msgid "sliders for hue channel (of LCh)"
 msgstr "색조 채널 슬라이더 (LCh)"
 
-#: ../src/develop/blend_gui.c:2369 ../src/develop/blend_gui.c:2417
+#: ../src/develop/blend_gui.c:2370 ../src/develop/blend_gui.c:2418
 msgid "g"
 msgstr "g"
 
-#: ../src/develop/blend_gui.c:2369 ../src/develop/blend_gui.c:2417
+#: ../src/develop/blend_gui.c:2370 ../src/develop/blend_gui.c:2418
 msgid "sliders for gray value"
 msgstr "회색조 슬라이더"
 
-#: ../src/develop/blend_gui.c:2375 ../src/develop/blend_gui.c:2423
-#: ../src/iop/channelmixerrgb.c:4617 ../src/iop/denoiseprofile.c:3774
-#: ../src/iop/rawdenoise.c:883 ../src/iop/rgbcurve.c:1489
+#: ../src/develop/blend_gui.c:2376 ../src/develop/blend_gui.c:2424
+#: ../src/iop/channelmixerrgb.c:4645 ../src/iop/denoiseprofile.c:3598
+#: ../src/iop/rawdenoise.c:885 ../src/iop/rgbcurve.c:1489
 #: ../src/iop/rgblevels.c:1039 ../src/libs/filters/colors.c:137
 msgid "R"
 msgstr "R"
 
-#: ../src/develop/blend_gui.c:2375 ../src/develop/blend_gui.c:2423
+#: ../src/develop/blend_gui.c:2376 ../src/develop/blend_gui.c:2424
 msgid "sliders for red channel"
 msgstr "R 채널 슬라이더"
 
-#: ../src/develop/blend_gui.c:2381 ../src/develop/blend_gui.c:2429
-#: ../src/iop/channelmixerrgb.c:4618 ../src/iop/denoiseprofile.c:3775
-#: ../src/iop/rawdenoise.c:884 ../src/iop/rgbcurve.c:1490
+#: ../src/develop/blend_gui.c:2382 ../src/develop/blend_gui.c:2430
+#: ../src/iop/channelmixerrgb.c:4646 ../src/iop/denoiseprofile.c:3599
+#: ../src/iop/rawdenoise.c:886 ../src/iop/rgbcurve.c:1490
 #: ../src/iop/rgblevels.c:1040 ../src/libs/filters/colors.c:143
 msgid "G"
 msgstr "G"
 
-#: ../src/develop/blend_gui.c:2381 ../src/develop/blend_gui.c:2429
+#: ../src/develop/blend_gui.c:2382 ../src/develop/blend_gui.c:2430
 msgid "sliders for green channel"
 msgstr "G 채널 슬라이더"
 
-#: ../src/develop/blend_gui.c:2387 ../src/develop/blend_gui.c:2435
-#: ../src/iop/channelmixerrgb.c:4619 ../src/iop/denoiseprofile.c:3776
-#: ../src/iop/rawdenoise.c:885 ../src/iop/rgbcurve.c:1491
+#: ../src/develop/blend_gui.c:2388 ../src/develop/blend_gui.c:2436
+#: ../src/iop/channelmixerrgb.c:4647 ../src/iop/denoiseprofile.c:3600
+#: ../src/iop/rawdenoise.c:887 ../src/iop/rgbcurve.c:1491
 #: ../src/iop/rgblevels.c:1041 ../src/libs/filters/colors.c:146
 msgid "B"
 msgstr "B"
 
-#: ../src/develop/blend_gui.c:2387 ../src/develop/blend_gui.c:2435
+#: ../src/develop/blend_gui.c:2388 ../src/develop/blend_gui.c:2436
 msgid "sliders for blue channel"
 msgstr "B 채널 슬라이더"
 
-#: ../src/develop/blend_gui.c:2393
+#: ../src/develop/blend_gui.c:2394
 msgid "H"
 msgstr "H"
 
-#: ../src/develop/blend_gui.c:2393
+#: ../src/develop/blend_gui.c:2394
 msgid "sliders for hue channel (of HSL)"
 msgstr "색조 채널 슬라이더 (HSL)"
 
-#: ../src/develop/blend_gui.c:2400
+#: ../src/develop/blend_gui.c:2401
 msgid "S"
 msgstr "S"
 
-#: ../src/develop/blend_gui.c:2400
+#: ../src/develop/blend_gui.c:2401
 msgid "sliders for chroma channel (of HSL)"
 msgstr "채도 채널 슬라이더 (HSL)"
 
-#: ../src/develop/blend_gui.c:2407
+#: ../src/develop/blend_gui.c:2408
 msgid "sliders for value channel (of HSL)"
 msgstr "명도 채널 슬라이더 (HSL)"
 
-#: ../src/develop/blend_gui.c:2441
+#: ../src/develop/blend_gui.c:2442
 msgid "Jz"
 msgstr "Jz"
 
-#: ../src/develop/blend_gui.c:2441
+#: ../src/develop/blend_gui.c:2442
 msgid "sliders for value channel (of JzCzhz)"
 msgstr "명도 채널 슬라이더 (JzCzhz)"
 
-#: ../src/develop/blend_gui.c:2448
+#: ../src/develop/blend_gui.c:2449
 msgid "Cz"
 msgstr "Cz"
 
-#: ../src/develop/blend_gui.c:2448
+#: ../src/develop/blend_gui.c:2449
 msgid "sliders for chroma channel (of JzCzhz)"
 msgstr "채도 채널 슬라이더 (JzCzhz)"
 
-#: ../src/develop/blend_gui.c:2455
+#: ../src/develop/blend_gui.c:2456
 msgid "hz"
 msgstr "hz"
 
-#: ../src/develop/blend_gui.c:2455
+#: ../src/develop/blend_gui.c:2456
 msgid "sliders for hue channel (of JzCzhz)"
 msgstr "색조 채널 슬라이더 (JzCzhz)"
 
-#: ../src/develop/blend_gui.c:2465
+#: ../src/develop/blend_gui.c:2466
 msgid ""
 "adjustment based on input received by this module:\n"
 "* range defined by upper markers: blend fully\n"
@@ -8854,7 +9646,7 @@ msgstr ""
 "* 하단 마커로 지정된 영역: 블랜딩 미적용\n"
 "* 인접한 상/하단 마커 사이의 영역: 점진적 블랜딩"
 
-#: ../src/develop/blend_gui.c:2469
+#: ../src/develop/blend_gui.c:2470
 msgid ""
 "adjustment based on unblended output of this module:\n"
 "* range defined by upper markers: blend fully\n"
@@ -8866,18 +9658,18 @@ msgstr ""
 "* 하단 마커로 지정된 범위: 블랜딩 미적용\n"
 "* 인접한 상/하단 마커 사이의 범위: 점진적 블랜딩"
 
-#: ../src/develop/blend_gui.c:2563
+#: ../src/develop/blend_gui.c:2564
 msgid "reset blend mask settings"
 msgstr "블랜딩 마스크 설정 초기화"
 
-#: ../src/develop/blend_gui.c:2570 ../src/iop/atrous.c:1789
-#: ../src/iop/colorzones.c:2622 ../src/iop/denoiseprofile.c:3771
-#: ../src/iop/rawdenoise.c:880 ../src/iop/rgbcurve.c:1487
+#: ../src/develop/blend_gui.c:2571 ../src/iop/atrous.c:1748
+#: ../src/iop/colorzones.c:2622 ../src/iop/denoiseprofile.c:3595
+#: ../src/iop/rawdenoise.c:882 ../src/iop/rgbcurve.c:1487
 #: ../src/iop/rgblevels.c:1037 ../src/iop/tonecurve.c:1268
 msgid "channel"
 msgstr "채널"
 
-#: ../src/develop/blend_gui.c:2582 ../src/iop/colorzones.c:2639
+#: ../src/develop/blend_gui.c:2583 ../src/iop/colorzones.c:2639
 #: ../src/iop/rgbcurve.c:1500 ../src/iop/tonecurve.c:1280
 msgid ""
 "pick GUI color from image\n"
@@ -8886,12 +9678,12 @@ msgstr ""
 "이미지에서 GUI 색상 추출\n"
 "Ctrl+클릭 또는 우클릭으로 영역 선택"
 
-#: ../src/develop/blend_gui.c:2585 ../src/iop/colorzones.c:2641
+#: ../src/develop/blend_gui.c:2586 ../src/iop/colorzones.c:2641
 #: ../src/iop/rgbcurve.c:1503
 msgid "show color"
 msgstr "색상 표시"
 
-#: ../src/develop/blend_gui.c:2594
+#: ../src/develop/blend_gui.c:2595
 msgid ""
 "set the range based on an area from the image\n"
 "drag to use the input image\n"
@@ -8901,19 +9693,19 @@ msgstr ""
 "드래그하여 입력 이미지 사용\n"
 "Ctrl+드래그하여 출력 이미지 사용"
 
-#: ../src/develop/blend_gui.c:2597
+#: ../src/develop/blend_gui.c:2598
 msgid "set range"
 msgstr "범위 설정"
 
-#: ../src/develop/blend_gui.c:2600
+#: ../src/develop/blend_gui.c:2601
 msgid "invert all channel's polarities"
 msgstr "모든 채널의 극성 반전"
 
-#: ../src/develop/blend_gui.c:2619
+#: ../src/develop/blend_gui.c:2620
 msgid "toggle polarity. best seen by enabling 'display mask'"
 msgstr "극성 전환. '마스크 표시'를 활성화할 때 잘 보임"
 
-#: ../src/develop/blend_gui.c:2647
+#: ../src/develop/blend_gui.c:2648
 msgid ""
 "double-click to reset.\n"
 "press 'a' to toggle available slider modes.\n"
@@ -8925,174 +9717,182 @@ msgstr ""
 "'c' 키를 눌러 채널 데이터 보기 전환.\n"
 "'m' 키를 눌러 마스크 보기 전환."
 
-#: ../src/develop/blend_gui.c:2671 ../src/develop/blend_gui.c:3548
-#: ../src/iop/agx.c:2169 ../src/iop/agx.c:2389 ../src/iop/agx.c:2398
-#: ../src/iop/basicadj.c:624 ../src/iop/colorbalancergb.c:2000
-#: ../src/iop/colorequal.c:3134 ../src/iop/exposure.c:1215
-#: ../src/iop/exposure.c:1231 ../src/iop/filmic.c:1479 ../src/iop/filmic.c:1491
-#: ../src/iop/filmic.c:1528 ../src/iop/filmicrgb.c:4400
-#: ../src/iop/filmicrgb.c:4411 ../src/iop/filmicrgb.c:4444
-#: ../src/iop/filmicrgb.c:4454 ../src/iop/graduatednd.c:1065
-#: ../src/iop/negadoctor.c:1004 ../src/iop/profile_gamma.c:629
-#: ../src/iop/profile_gamma.c:635 ../src/iop/relight.c:249
-#: ../src/iop/soften.c:390 ../src/iop/toneequal.c:3236
-#: ../src/iop/toneequal.c:3239 ../src/iop/toneequal.c:3242
-#: ../src/iop/toneequal.c:3245 ../src/iop/toneequal.c:3248
-#: ../src/iop/toneequal.c:3251 ../src/iop/toneequal.c:3254
-#: ../src/iop/toneequal.c:3257 ../src/iop/toneequal.c:3260
-#: ../src/iop/toneequal.c:3317 ../src/iop/toneequal.c:3327
-#: ../src/iop/toneequal.c:3387 ../src/views/darkroom.c:2672
+#: ../src/develop/blend_gui.c:2672 ../src/develop/blend_gui.c:3559
+#: ../src/iop/agx.c:1825 ../src/iop/agx.c:2045 ../src/iop/agx.c:2054
+#: ../src/iop/basicadj.c:623 ../src/iop/colorbalancergb.c:2021
+#: ../src/iop/colorequal.c:3097 ../src/iop/exposure.c:1217
+#: ../src/iop/exposure.c:1233 ../src/iop/filmic.c:1481 ../src/iop/filmic.c:1494
+#: ../src/iop/filmic.c:1537 ../src/iop/filmicrgb.c:4385
+#: ../src/iop/filmicrgb.c:4396 ../src/iop/filmicrgb.c:4432
+#: ../src/iop/filmicrgb.c:4442 ../src/iop/graduatednd.c:1032
+#: ../src/iop/negadoctor.c:1004 ../src/iop/profile_gamma.c:624
+#: ../src/iop/profile_gamma.c:630 ../src/iop/relight.c:249
+#: ../src/iop/soften.c:381 ../src/iop/toneequal.c:3240
+#: ../src/iop/toneequal.c:3243 ../src/iop/toneequal.c:3246
+#: ../src/iop/toneequal.c:3249 ../src/iop/toneequal.c:3252
+#: ../src/iop/toneequal.c:3255 ../src/iop/toneequal.c:3258
+#: ../src/iop/toneequal.c:3261 ../src/iop/toneequal.c:3264
+#: ../src/iop/toneequal.c:3321 ../src/iop/toneequal.c:3331
+#: ../src/iop/toneequal.c:3391 ../src/views/darkroom.c:3297
 msgid " EV"
 msgstr " EV"
 
-#: ../src/develop/blend_gui.c:2673 ../src/develop/blend_gui.c:2765
-#: ../src/develop/blend_gui.c:3033 ../src/develop/blend_gui.c:3521
-#: ../src/develop/blend_gui.c:3547 ../src/develop/blend_gui.c:3557
-#: ../src/develop/blend_gui.c:3574 ../src/develop/blend_gui.c:3595
-#: ../src/develop/blend_gui.c:3604 ../src/develop/blend_gui.c:3613
-#: ../src/develop/blend_gui.c:3622
+#: ../src/develop/blend_gui.c:2674 ../src/develop/blend_gui.c:2766
+#: ../src/develop/blend_gui.c:3044 ../src/develop/blend_gui.c:3532
+#: ../src/develop/blend_gui.c:3558 ../src/develop/blend_gui.c:3568
+#: ../src/develop/blend_gui.c:3585 ../src/develop/blend_gui.c:3606
+#: ../src/develop/blend_gui.c:3615 ../src/develop/blend_gui.c:3624
+#: ../src/develop/blend_gui.c:3633
 msgid "blend"
 msgstr "블랜딩"
 
-#: ../src/develop/blend_gui.c:2673
+#: ../src/develop/blend_gui.c:2674
 msgid "boost factor"
 msgstr "부스트 계수"
 
-#: ../src/develop/blend_gui.c:2676
-msgid "adjust the boost factor of the channel mask"
-msgstr "채널 마스크의 부스트 계수 조정"
+#: ../src/develop/blend_gui.c:2677
+msgid ""
+"adjust the channel boost factor.\n"
+"increase to allow matching values over 100%"
+msgstr ""
+"채널 부스트 계수를 조정합니다.\n"
+"100%를 넘는 값을 맞추려면 값을 올리세요"
 
-#: ../src/develop/blend_gui.c:2713
+#: ../src/develop/blend_gui.c:2714
 #, c-format
 msgid "%d shape used"
 msgid_plural "%d shapes used"
 msgstr[0] "%d개 도형 사용됨"
 
-#: ../src/develop/blend_gui.c:2718 ../src/develop/blend_gui.c:2767
-#: ../src/develop/blend_gui.c:2856 ../src/develop/blend_gui.c:2980
+#: ../src/develop/blend_gui.c:2719 ../src/develop/blend_gui.c:2768
+#: ../src/develop/blend_gui.c:2867 ../src/develop/blend_gui.c:2991
 msgid "no mask used"
 msgstr "사용하는 마스크 없음"
 
-#: ../src/develop/blend_gui.c:2777
+#: ../src/develop/blend_gui.c:2778
 msgid "toggle polarity of drawn mask"
 msgstr "드로잉 마스크의 극성 전환"
 
-#: ../src/develop/blend_gui.c:2786
+#: ../src/develop/blend_gui.c:2787
 msgid "show and edit mask elements"
 msgstr "마스크 요소 표시 및 편집"
 
-#: ../src/develop/blend_gui.c:2787
+#: ../src/develop/blend_gui.c:2788
 msgid "show and edit in restricted mode (no moving/resizing of shapes)"
 msgstr "제한 모드에서 보기 및 편집 (도형 이동/크기 변경 불가)"
 
-#: ../src/develop/blend_gui.c:2794 ../src/libs/masks.c:1004
-#: ../src/libs/masks.c:1795 ../src/libs/masks.c:1799
+#: ../src/develop/blend_gui.c:2796 ../src/libs/masks.c:2141
+msgid "add AI object"
+msgstr "AI 객체 추가"
+
+#: ../src/develop/blend_gui.c:2805 ../src/libs/masks.c:1302
+#: ../src/libs/masks.c:2096 ../src/libs/masks.c:2100
 msgid "add gradient"
 msgstr "그라디언트 추가"
 
-#: ../src/develop/blend_gui.c:2795
+#: ../src/develop/blend_gui.c:2806
 msgid "add multiple gradients"
 msgstr "여러 개의 그라디언트 추가"
 
-#: ../src/develop/blend_gui.c:2802 ../src/iop/retouch.c:2447
-#: ../src/libs/masks.c:984 ../src/libs/masks.c:1827 ../src/libs/masks.c:1831
-msgid "add brush"
-msgstr "브러시 추가"
-
-#: ../src/develop/blend_gui.c:2803 ../src/iop/retouch.c:2447
-msgid "add multiple brush strokes"
-msgstr "여러 개의 브러시 스트로크 추가"
-
-#: ../src/develop/blend_gui.c:2810 ../src/iop/retouch.c:2452
-#: ../src/iop/spots.c:877 ../src/libs/masks.c:999 ../src/libs/masks.c:1803
-#: ../src/libs/masks.c:1807
+#: ../src/develop/blend_gui.c:2813 ../src/iop/retouch.c:2450
+#: ../src/iop/spots.c:877 ../src/libs/masks.c:1297 ../src/libs/masks.c:2104
+#: ../src/libs/masks.c:2108
 msgid "add path"
 msgstr "경로 추가"
 
-#: ../src/develop/blend_gui.c:2811 ../src/iop/retouch.c:2452
+#: ../src/develop/blend_gui.c:2814 ../src/iop/retouch.c:2450
 #: ../src/iop/spots.c:877
 msgid "add multiple paths"
 msgstr "여러 개의 경로 추가"
 
-#: ../src/develop/blend_gui.c:2818 ../src/iop/retouch.c:2457
-#: ../src/iop/spots.c:882 ../src/libs/masks.c:994 ../src/libs/masks.c:1811
-#: ../src/libs/masks.c:1815
+#: ../src/develop/blend_gui.c:2821 ../src/iop/retouch.c:2455
+#: ../src/iop/spots.c:882 ../src/libs/masks.c:1292 ../src/libs/masks.c:2112
+#: ../src/libs/masks.c:2116
 msgid "add ellipse"
 msgstr "타원 추가"
 
-#: ../src/develop/blend_gui.c:2819 ../src/iop/retouch.c:2457
+#: ../src/develop/blend_gui.c:2822 ../src/iop/retouch.c:2455
 #: ../src/iop/spots.c:882
 msgid "add multiple ellipses"
 msgstr "여러 개의 타원 추가"
 
-#: ../src/develop/blend_gui.c:2826 ../src/iop/retouch.c:2462
-#: ../src/iop/spots.c:887 ../src/libs/masks.c:989 ../src/libs/masks.c:1819
-#: ../src/libs/masks.c:1823
+#: ../src/develop/blend_gui.c:2829 ../src/iop/retouch.c:2460
+#: ../src/iop/spots.c:887 ../src/libs/masks.c:1287 ../src/libs/masks.c:2120
+#: ../src/libs/masks.c:2124
 msgid "add circle"
 msgstr "원 추가"
 
-#: ../src/develop/blend_gui.c:2827 ../src/iop/retouch.c:2462
+#: ../src/develop/blend_gui.c:2830 ../src/iop/retouch.c:2460
 #: ../src/iop/spots.c:887
 msgid "add multiple circles"
 msgstr "여러 개의 원 추가"
 
-#: ../src/develop/blend_gui.c:2973
+#: ../src/develop/blend_gui.c:2837 ../src/iop/retouch.c:2445
+#: ../src/libs/masks.c:1282 ../src/libs/masks.c:2128 ../src/libs/masks.c:2132
+msgid "add brush"
+msgstr "브러시 추가"
+
+#: ../src/develop/blend_gui.c:2838 ../src/iop/retouch.c:2445
+msgid "add multiple brush strokes"
+msgstr "여러 개의 브러시 스트로크 추가"
+
+#: ../src/develop/blend_gui.c:2984
 msgid "toggle polarity of raster mask"
 msgstr "래스터 마스크의 극성 전환"
 
-#: ../src/develop/blend_gui.c:3123
+#: ../src/develop/blend_gui.c:3134
 msgid "normal & difference"
 msgstr "표준 및 차이"
 
-#: ../src/develop/blend_gui.c:3128
+#: ../src/develop/blend_gui.c:3139
 msgid "lighten"
 msgstr "밝게"
 
-#: ../src/develop/blend_gui.c:3135
+#: ../src/develop/blend_gui.c:3146
 msgid "darken"
 msgstr "어둡게"
 
-#: ../src/develop/blend_gui.c:3142
+#: ../src/develop/blend_gui.c:3153
 msgid "contrast enhancing"
 msgstr "대비 향상"
 
-#: ../src/develop/blend_gui.c:3149 ../src/develop/blend_gui.c:3172
+#: ../src/develop/blend_gui.c:3160 ../src/develop/blend_gui.c:3183
 msgid "color channel"
 msgstr "색상 채널"
 
-#: ../src/develop/blend_gui.c:3160 ../src/develop/blend_gui.c:3175
+#: ../src/develop/blend_gui.c:3171 ../src/develop/blend_gui.c:3186
 msgid "chromaticity & lightness"
 msgstr "색조 및 명도"
 
-#: ../src/develop/blend_gui.c:3167
+#: ../src/develop/blend_gui.c:3178
 msgid "normal & arithmetic"
 msgstr "표준 및 산술"
 
 #. add deprecated blend mode
-#: ../src/develop/blend_gui.c:3187
+#: ../src/develop/blend_gui.c:3198
 msgid "deprecated"
 msgstr "지원 중단"
 
 #. should never happen: unknown blend mode
-#: ../src/develop/blend_gui.c:3191
+#: ../src/develop/blend_gui.c:3202
 #, c-format
 msgid "unknown blend mode '%d' in module '%s'"
 msgstr "알 수 없는 블랜딩 모드 '%d'이 모듈 '%s'에서 사용 중 입니다"
 
-#: ../src/develop/blend_gui.c:3476
+#: ../src/develop/blend_gui.c:3487
 msgid "blending options"
 msgstr "블랜딩 옵션"
 
 #. global section holding the eye and showmask buttons
-#: ../src/develop/blend_gui.c:3494
+#: ../src/develop/blend_gui.c:3505
 msgid "blend mask"
 msgstr "블랜딩 마스크"
 
-#: ../src/develop/blend_gui.c:3498
+#: ../src/develop/blend_gui.c:3509
 msgid "display mask and/or color channel"
 msgstr "마스크 및/또는 색상 채널 표시"
 
-#: ../src/develop/blend_gui.c:3503
+#: ../src/develop/blend_gui.c:3514
 msgid ""
 "display mask and/or color channel.\n"
 "ctrl+click to display mask,\n"
@@ -9104,11 +9904,11 @@ msgstr ""
 "Shift+클릭으로 컬러 채널 표시합니다.\n"
 "파라메트릭 마스크 슬라이더 위에 마우스를 올려 표시할 채널 선택"
 
-#: ../src/develop/blend_gui.c:3510
+#: ../src/develop/blend_gui.c:3521
 msgid "temporarily switch off blend mask"
 msgstr "블랜딩 마스크 일시 비활성화"
 
-#: ../src/develop/blend_gui.c:3515
+#: ../src/develop/blend_gui.c:3526
 msgid ""
 "temporarily switch off blend mask.\n"
 "only for module in focus"
@@ -9116,15 +9916,15 @@ msgstr ""
 "블랜딩 마스크를 일시적으로 비활성화합니다.\n"
 "현재 선택된 모듈에만 해당"
 
-#: ../src/develop/blend_gui.c:3525
+#: ../src/develop/blend_gui.c:3536
 msgid "choose blending mode"
 msgstr "블랜딩 모드를 선택하세요"
 
-#: ../src/develop/blend_gui.c:3534
+#: ../src/develop/blend_gui.c:3545
 msgid "toggle blend order"
 msgstr "블랜딩 순서 전환"
 
-#: ../src/develop/blend_gui.c:3540
+#: ../src/develop/blend_gui.c:3551
 msgid ""
 "toggle the blending order between the input and the output of the module,\n"
 "by default the output will be blended on top of the input,\n"
@@ -9134,37 +9934,39 @@ msgstr ""
 "기본적으로 출력은 입력 위에 블랜딩됩니다,\n"
 "아이콘을 클릭하여 순서를 반전할 수 있습니다 (입력이 출력 위에)"
 
-#: ../src/develop/blend_gui.c:3547
+#: ../src/develop/blend_gui.c:3558
 msgid "fulcrum"
 msgstr "기준점"
 
-#: ../src/develop/blend_gui.c:3551
+#: ../src/develop/blend_gui.c:3562
 msgid "adjust the fulcrum used by some blending operations"
 msgstr "일부 블랜딩 연산의 기준점 조정"
 
 #. Add opacity/scale sliders to table
-#: ../src/develop/blend_gui.c:3557 ../src/iop/overlay.c:1109
-#: ../src/iop/watermark.c:1370 ../src/libs/masks.c:106
+#: ../src/develop/blend_gui.c:3568 ../src/iop/overlay.c:1497
+#: ../src/iop/watermark.c:1473 ../src/libs/masks.c:186
 msgid "opacity"
 msgstr "불투명도"
 
-#: ../src/develop/blend_gui.c:3560
+#: ../src/develop/blend_gui.c:3571
 msgid "set the opacity of the blending"
 msgstr "블랜딩 불투명도 설정"
 
-#: ../src/develop/blend_gui.c:3565 ../src/libs/history.c:952
+#: ../src/develop/blend_gui.c:3576 ../src/libs/history.c:952
 msgid "combine masks"
 msgstr "마스크 결합"
 
-#: ../src/develop/blend_gui.c:3567
-msgid "how to combine individual drawn mask and different channels of parametric mask"
+#: ../src/develop/blend_gui.c:3578
+msgid ""
+"how to combine individual drawn mask and different channels of parametric "
+"mask"
 msgstr "개별 드로잉 마스크와 파라메트릭 마스크 여러 채널 결합 방법"
 
-#: ../src/develop/blend_gui.c:3574
+#: ../src/develop/blend_gui.c:3585
 msgid "details threshold"
 msgstr "디테일 임계값"
 
-#: ../src/develop/blend_gui.c:3578
+#: ../src/develop/blend_gui.c:3589
 msgid ""
 "adjust the threshold for the details mask (using raw data),\n"
 "positive values select areas with strong details,\n"
@@ -9174,11 +9976,11 @@ msgstr ""
 "양수 값은 디테일이 강한 영역을 선택합니다,\n"
 "음수 값은 디테일이 약한 (평탄한) 영역을 선택합니다"
 
-#: ../src/develop/blend_gui.c:3586 ../src/libs/history.c:955
+#: ../src/develop/blend_gui.c:3597 ../src/libs/history.c:955
 msgid "feathering guide"
 msgstr "페더링 가이드"
 
-#: ../src/develop/blend_gui.c:3589
+#: ../src/develop/blend_gui.c:3600
 msgid ""
 "choose to guide mask by input or output image and\n"
 "choose to apply feathering before or after mask blur"
@@ -9186,36 +9988,36 @@ msgstr ""
 "마스크를 입력 또는 출력 이미지를 기반으로 선택하고\n"
 "페더링 적용 시점을 마스크 블러 전 또는 후로 선택하세요"
 
-#: ../src/develop/blend_gui.c:3595 ../src/libs/history.c:954
+#: ../src/develop/blend_gui.c:3606 ../src/libs/history.c:954
 msgid "feathering radius"
 msgstr "페더링 반지름"
 
-#: ../src/develop/blend_gui.c:3596 ../src/develop/blend_gui.c:3605
-#: ../src/iop/colorbalancergb.c:2022 ../src/iop/colorequal.c:3149
-#: ../src/iop/colorequal.c:3176 ../src/iop/demosaic.c:1817
-#: ../src/iop/demosaic.c:1836 ../src/iop/diffuse.c:1782
-#: ../src/iop/diffuse.c:1792 ../src/iop/retouch.c:2677
+#: ../src/develop/blend_gui.c:3607 ../src/develop/blend_gui.c:3616
+#: ../src/iop/colorbalancergb.c:2043 ../src/iop/colorequal.c:3112
+#: ../src/iop/colorequal.c:3139 ../src/iop/demosaic.c:1790
+#: ../src/iop/demosaic.c:1809 ../src/iop/diffuse.c:1775
+#: ../src/iop/diffuse.c:1785 ../src/iop/retouch.c:2675
 msgid " px"
 msgstr " px"
 
-#: ../src/develop/blend_gui.c:3598
+#: ../src/develop/blend_gui.c:3609
 msgid "spatial radius of feathering"
 msgstr "페더링 공간 반지름"
 
-#: ../src/develop/blend_gui.c:3604
+#: ../src/develop/blend_gui.c:3615
 msgid "blurring radius"
 msgstr "블러 반지름"
 
-#: ../src/develop/blend_gui.c:3607
+#: ../src/develop/blend_gui.c:3618
 msgid "radius for gaussian blur of blend mask"
 msgstr "블랜딩 마스크 가우시안 블러 반지름"
 
-#: ../src/develop/blend_gui.c:3613 ../src/iop/retouch.c:2682
+#: ../src/develop/blend_gui.c:3624 ../src/iop/retouch.c:2680
 #: ../src/libs/history.c:950
 msgid "mask opacity"
 msgstr "마스크 불투명도"
 
-#: ../src/develop/blend_gui.c:3617
+#: ../src/develop/blend_gui.c:3628
 msgid ""
 "shifts and tilts the tone curve of the blend mask to adjust its brightness\n"
 "without affecting fully transparent/fully opaque regions"
@@ -9223,107 +10025,145 @@ msgstr ""
 "완전히 투명한/완전히 불투명한 영역에 영향을 주지 않고\n"
 "블렌드 마스크의 톤 곡선을 이동하고 기울여 밝기를 조정합니다"
 
-#: ../src/develop/blend_gui.c:3622 ../src/libs/history.c:958
+#: ../src/develop/blend_gui.c:3633 ../src/libs/history.c:958
 msgid "mask contrast"
 msgstr "마스크 대비"
 
-#: ../src/develop/blend_gui.c:3626
-msgid "gives the tone curve of the blend mask an s-like shape to adjust its contrast"
+#: ../src/develop/blend_gui.c:3637
+msgid ""
+"gives the tone curve of the blend mask an s-like shape to adjust its contrast"
 msgstr "블렌드 마스크의 톤 커브를 S자 형태로 변경하여 대비를 조정합니다"
 
-#: ../src/develop/blend_gui.c:3629
+#: ../src/develop/blend_gui.c:3640
 msgid "mask refinement"
 msgstr "마스크 세밀 조정"
 
-#: ../src/develop/develop.c:773
-msgid "autosaving history has been disabled for this image because of a very large history or a slow drive being used"
+#: ../src/develop/develop.c:459
+msgid "unpin image"
+msgstr "이미지 고정 해제"
+
+#: ../src/develop/develop.c:462
+msgid "image pinned"
+msgstr "이미지가 고정됨"
+
+#: ../src/develop/develop.c:473 ../src/develop/develop.c:575
+msgid "failed to create pinned develop"
+msgstr "고정된 현상 작업을 생성하지 못했습니다"
+
+#: ../src/develop/develop.c:521 ../src/views/darkroom.c:5201
+msgid "pin current image"
+msgstr "현재 이미지 고정"
+
+#: ../src/develop/develop.c:524
+msgid "image unpinned"
+msgstr "이미지 고정이 해제됨"
+
+#: ../src/develop/develop.c:536
+msgid "no valid image to pin"
+msgstr "고정할 유효한 이미지가 없습니다"
+
+#: ../src/develop/develop.c:542
+msgid "please wait for image to load"
+msgstr "이미지가 로드될 때까지 기다려 주세요"
+
+#: ../src/develop/develop.c:1144
+msgid ""
+"autosaving history has been disabled for this image because of a very large "
+"history or a slow drive being used"
 msgstr "히스토리 크기가 너무 크거나 느린 드라이브가 사용되고 있어 이 이미지의 히스토리 자동 저장이 비활성화되었습니다"
 
-#: ../src/develop/develop.c:2269
+#: ../src/develop/develop.c:2648
 #, c-format
 msgid "%s: module `%s' version mismatch: %d != %d"
 msgstr "%s: 모듈 `%s' 버전 불일치: %d != %d"
 
-#: ../src/develop/develop.c:3174
+#: ../src/develop/develop.c:3713
 msgid "duplicate module, can't move new instance after the base one\n"
-msgstr "모듈 복제, 새 인스턴스를 기본 인스턴스 뒤로 이동할 수 없습니다\n"
+msgstr ""
+"모듈 복제, 새 인스턴스를 기본 인스턴스 뒤로 이동할 수 없습니다\n"
 
-#: ../src/develop/imageop.c:995
+#: ../src/develop/imageop.c:1004 ../src/views/darkroom.c:3105
 msgid "new instance"
 msgstr "새 인스턴스"
 
-#: ../src/develop/imageop.c:1002
+#: ../src/develop/imageop.c:1011
 msgid "duplicate instance"
 msgstr "인스턴스 복제"
 
-#: ../src/develop/imageop.c:1009 ../src/develop/imageop.c:4079
-#: ../src/libs/masks.c:1136
+#: ../src/develop/imageop.c:1018 ../src/develop/imageop.c:4123
+#: ../src/libs/masks.c:1434
 msgid "move up"
 msgstr "위로 이동"
 
-#: ../src/develop/imageop.c:1016 ../src/develop/imageop.c:4080
-#: ../src/libs/masks.c:1141
+#: ../src/develop/imageop.c:1025 ../src/develop/imageop.c:4124
+#: ../src/libs/masks.c:1439
 msgid "move down"
 msgstr "아래로 이동"
 
 #. delete button label and tooltip will be updated based on trash pref
-#: ../src/develop/imageop.c:1023 ../src/develop/imageop.c:4082
-#: ../src/gui/accelerators.c:173 ../src/libs/image.c:307
+#: ../src/develop/imageop.c:1032 ../src/develop/imageop.c:4126
+#: ../src/gui/accelerators.c:178 ../src/libs/image.c:307
 #: ../src/libs/image.c:522
 msgid "delete"
 msgstr "삭제"
 
-#: ../src/develop/imageop.c:1031 ../src/develop/imageop.c:4083
-#: ../src/libs/modulegroups.c:4002
+#: ../src/develop/imageop.c:1040 ../src/develop/imageop.c:4127
+#: ../src/libs/modulegroups.c:4086
 msgid "rename"
 msgstr "이름 변경"
 
-#: ../src/develop/imageop.c:1122 ../src/develop/imageop.c:2978
+#: ../src/develop/imageop.c:1152 ../src/develop/imageop.c:3035
 #, c-format
 msgid "'%s' is switched on"
 msgstr "'%s'이 켜져 있습니다"
 
-#: ../src/develop/imageop.c:1122 ../src/develop/imageop.c:2978
+#: ../src/develop/imageop.c:1152 ../src/develop/imageop.c:3035
 #, c-format
 msgid "'%s' is switched off"
 msgstr "'%s'이 꺼져 있습니다"
 
-#: ../src/develop/imageop.c:2168
+#: ../src/develop/imageop.c:1718 ../src/libs/lib.c:943
+#, c-format
+msgid "%s: %s"
+msgstr "%s: %s"
+
+#: ../src/develop/imageop.c:2210
 #, c-format
 msgid "'%s' has an introspection error"
 msgstr "'%s'에 내부 오류가 있습니다"
 
-#: ../src/develop/imageop.c:2796
+#: ../src/develop/imageop.c:2853
 msgid "unknown mask"
 msgstr "알 수 없는 마스크"
 
-#: ../src/develop/imageop.c:2800
+#: ../src/develop/imageop.c:2857
 msgid "drawn + parametric mask"
 msgstr "드로잉 + 파라메트릭 마스크"
 
-#: ../src/develop/imageop.c:2809
+#: ../src/develop/imageop.c:2866
 #, c-format
 msgid "this module has a `%s'"
 msgstr "이 모듈에는 `%s'이 있습니다"
 
-#: ../src/develop/imageop.c:2814
+#: ../src/develop/imageop.c:2871
 #, c-format
 msgid "taken from module %s"
 msgstr "%s 모듈에서 가져옴"
 
-#: ../src/develop/imageop.c:2819
+#: ../src/develop/imageop.c:2876
 msgid "click to display (module must be activated first)"
 msgstr "클릭하여 표시 (모듈을 먼저 활성화해야 함)"
 
-#: ../src/develop/imageop.c:2930
+#: ../src/develop/imageop.c:2987
 msgid "purpose"
 msgstr "용도"
 
-#: ../src/develop/imageop.c:2930
+#. process button
+#: ../src/develop/imageop.c:2987 ../src/libs/neural_restore.c:4369
 msgid "process"
 msgstr "처리"
 
-#: ../src/develop/imageop.c:2994
+#: ../src/develop/imageop.c:3051
 msgid ""
 "reset parameters\n"
 "ctrl+click to reapply any automatic presets"
@@ -9331,7 +10171,7 @@ msgstr ""
 "파라메터 초기화\n"
 "Ctrl+클릭하여 자동 프리셋 다시 적용"
 
-#: ../src/develop/imageop.c:3201
+#: ../src/develop/imageop.c:3258
 msgid ""
 "multiple instance actions\n"
 "right-click creates new instance"
@@ -9339,7 +10179,7 @@ msgstr ""
 "다중 인스턴스 작업\n"
 "우클릭하여 새 인스턴스 생성"
 
-#: ../src/develop/imageop.c:3205
+#: ../src/develop/imageop.c:3262
 msgid ""
 "presets\n"
 "right-click to apply on new instance"
@@ -9347,15 +10187,15 @@ msgstr ""
 "프리셋\n"
 "우클릭하여 새 인스턴스에 적용"
 
-#: ../src/develop/imageop.c:3417 ../src/develop/imageop.c:3439
+#: ../src/develop/imageop.c:3455 ../src/develop/imageop.c:3477
 msgid "ERROR"
 msgstr "오류"
 
-#: ../src/develop/imageop.c:3941
+#: ../src/develop/imageop.c:3979
 msgid "unsupported input"
 msgstr "지원되지 않는 입력"
 
-#: ../src/develop/imageop.c:3942
+#: ../src/develop/imageop.c:3980
 msgid ""
 "you have placed this module at\n"
 "a position in the pipeline where\n"
@@ -9363,50 +10203,52 @@ msgid ""
 "its requirements."
 msgstr "이 모듈을 데이터 형식이 요구 사항과 일치하지 않는 파이프라인의 위치로 이동하였습니다."
 
-#: ../src/develop/imageop.c:4078 ../src/develop/imageop.c:4088
-#: ../src/gui/accelerators.c:169 ../src/libs/lib.c:1580
+#: ../src/develop/imageop.c:4122 ../src/develop/imageop.c:4132
+#: ../src/gui/accelerators.c:174 ../src/libs/lib.c:1728
+#: ../src/views/darkroom.c:3103
 msgid "show"
 msgstr "표시"
 
-#: ../src/develop/imageop.c:4081 ../src/libs/modulegroups.c:3484
-#: ../src/libs/modulegroups.c:3615 ../src/libs/modulegroups.c:4006
-#: ../src/libs/tagging.c:3678
+#: ../src/develop/imageop.c:4125 ../src/libs/modulegroups.c:3568
+#: ../src/libs/modulegroups.c:3699 ../src/libs/modulegroups.c:4090
+#: ../src/libs/tagging.c:3708
 msgid "new"
 msgstr "새로 만들기"
 
-#: ../src/develop/imageop.c:4084 ../src/libs/duplicate.c:402
-#: ../src/libs/image.c:543 ../src/libs/modulegroups.c:3998
+#: ../src/develop/imageop.c:4128 ../src/libs/duplicate.c:467
+#: ../src/libs/image.c:543 ../src/libs/modulegroups.c:4082
 msgid "duplicate"
 msgstr "복제"
 
-#: ../src/develop/imageop.c:4089
+#: ../src/develop/imageop.c:4133
 #: ../src/external/lua-scripts/tools/executable_manager.lua:222
-#: ../src/gui/accelerators.c:130 ../src/gui/accelerators.c:140
-#: ../src/gui/gtk.c:3693 ../src/gui/gtk.c:3748 ../src/gui/hist_dialog.c:289
-#: ../src/gui/styles_dialog.c:632 ../src/gui/styles_dialog.c:654
-#: ../src/iop/atrous.c:1618 ../src/libs/lib.c:1581
-#: ../src/libs/modulegroups.c:4082
+#: ../src/gui/accelerators.c:131 ../src/gui/accelerators.c:145
+#: ../src/gui/gtk.c:3948 ../src/gui/gtk.c:4003 ../src/gui/hist_dialog.c:289
+#: ../src/gui/styles_dialog.c:629 ../src/gui/styles_dialog.c:651
+#: ../src/iop/atrous.c:1563 ../src/libs/lib.c:1729
+#: ../src/libs/modulegroups.c:4166
 msgid "reset"
 msgstr "초기화"
 
-#: ../src/develop/imageop.c:4090 ../src/gui/preferences.c:1024
-#: ../src/libs/lib.c:1582
+#: ../src/develop/imageop.c:4134 ../src/gui/preferences.c:1053
+#: ../src/libs/lib.c:1730
 msgid "presets"
 msgstr "프리셋"
 
-#: ../src/develop/imageop.c:4091
+#. global <focused> shortcuts
+#: ../src/develop/imageop.c:4135 ../src/views/darkroom.c:3102
 msgid "enable"
 msgstr "활성화"
 
-#: ../src/develop/imageop.c:4092 ../src/gui/accelerators.c:185
+#: ../src/develop/imageop.c:4136 ../src/gui/accelerators.c:190
 msgid "focus"
 msgstr "포커스"
 
-#: ../src/develop/imageop.c:4093 ../src/gui/accelerators.c:2956
+#: ../src/develop/imageop.c:4137 ../src/gui/accelerators.c:2957
 msgid "instance"
 msgstr "인스턴스"
 
-#: ../src/develop/imageop.c:4113
+#: ../src/develop/imageop.c:4157
 msgid "processing module"
 msgstr "처리 모듈"
 
@@ -9453,52 +10295,84 @@ msgid "%s has been imported"
 msgid_plural "%s have been imported"
 msgstr[0] "%s를 가져왔습니다"
 
-#: ../src/develop/masks/brush.c:1341 ../src/develop/masks/brush.c:1395
+#: ../src/develop/masks/brush.c:1390 ../src/develop/masks/brush.c:1444
 #, c-format
 msgid "hardness: %3.2f%%"
 msgstr "경도: %3.2f%%"
 
-#: ../src/develop/masks/brush.c:1357 ../src/develop/masks/brush.c:1455
+#: ../src/develop/masks/brush.c:1406 ../src/develop/masks/brush.c:1504
 #: ../src/develop/masks/circle.c:147 ../src/develop/masks/circle.c:192
-#: ../src/develop/masks/ellipse.c:479 ../src/develop/masks/ellipse.c:540
-#: ../src/develop/masks/path.c:1885
+#: ../src/develop/masks/ellipse.c:482 ../src/develop/masks/ellipse.c:543
+#: ../src/develop/masks/path.c:2308
 #, c-format
 msgid "size: %3.2f%%"
 msgstr "크기: %3.2f%%"
 
-#: ../src/develop/masks/brush.c:3146
+#: ../src/develop/masks/brush.c:3406
+msgid "[BRUSH on segment] add node"
+msgstr "[선분의 브러시] 노드 추가"
+
+#: ../src/develop/masks/brush.c:3410
+msgid "[BRUSH] rotate shape (source only on a clone source)"
+msgstr "[브러시] 도형 회전 (복제 원본에서는 원본만)"
+
+#: ../src/develop/masks/brush.c:3414
+msgid "[BRUSH] rotate shape and source together"
+msgstr "[브러시] 도형과 원본을 함께 회전"
+
+#: ../src/develop/masks/brush.c:3416
 msgid "[BRUSH] change size"
 msgstr "[브러시] 크기 변경"
 
-#: ../src/develop/masks/brush.c:3148
+#: ../src/develop/masks/brush.c:3418
 msgid "[BRUSH] change hardness"
 msgstr "[브러시] 경도 변경"
 
-#: ../src/develop/masks/brush.c:3150
+#: ../src/develop/masks/brush.c:3420
 msgid "[BRUSH] change opacity"
 msgstr "[브러시] 불투명도 변경"
 
-#: ../src/develop/masks/brush.c:3162
+#: ../src/develop/masks/brush.c:3432
 #, c-format
 msgid "brush #%d"
 msgstr "브러시 #%d"
 
-#: ../src/develop/masks/brush.c:3175
+#: ../src/develop/masks/brush.c:3447
 #, c-format
 msgid ""
 "<b>size</b>: scroll, <b>hardness</b>: shift+scroll\n"
-"<b>opacity</b>: ctrl+scroll (%d%%)"
+"<b>opacity</b>: ctrl+scroll (%d%%), <b>rotate</b>: ctrl+drag"
 msgstr ""
 "<b>크기</b>: 스크롤, <b>경도</b>: Shift+스크롤\n"
-"<b>불투명도</b>: Ctrl+스크롤 (%d%%)"
+"<b>불투명도</b>: Ctrl+스크롤 (%d%%), <b>회전</b>: Ctrl+드래그"
 
-#: ../src/develop/masks/brush.c:3178
+#: ../src/develop/masks/brush.c:3453 ../src/develop/masks/brush.c:3468
+#: ../src/develop/masks/path.c:5345
+msgid ", <b>rotate both</b>: shift+ctrl+drag"
+msgstr ", <b>둘 다 회전</b>: Shift+Ctrl+드래그"
+
+#: ../src/develop/masks/brush.c:3458 ../src/develop/masks/ellipse.c:2148
+#: ../src/develop/masks/path.c:5331
+msgid ""
+"<b>move</b>: drag, <b>rotate source</b>: ctrl+drag, <b>rotate both</b>: "
+"shift+ctrl+drag"
+msgstr "<b>이동</b>: 드래그, <b>원본 회전</b>: Ctrl+드래그, <b>둘 다 회전</b>: Shift+Ctrl+드래그"
+
+#: ../src/develop/masks/brush.c:3464
+msgid ""
+"<b>move segment</b>: drag, <b>add node</b>: shift+click\n"
+"<b>rotate</b>: ctrl+drag"
+msgstr ""
+"<b>선분 이동</b>: 드래그, <b>노드 추가</b>: Shift+클릭\n"
+"<b>회전</b>: Ctrl+드래그"
+
+#: ../src/develop/masks/brush.c:3471
 msgid "<b>size</b>: scroll"
 msgstr "<b>크기</b>: 스크롤"
 
 #: ../src/develop/masks/circle.c:136 ../src/develop/masks/circle.c:180
-#: ../src/develop/masks/ellipse.c:465 ../src/develop/masks/ellipse.c:525
-#: ../src/develop/masks/path.c:1819
+#: ../src/develop/masks/ellipse.c:468 ../src/develop/masks/ellipse.c:528
+#: ../src/develop/masks/path.c:2957
 #, c-format
 msgid "feather size: %3.2f%%"
 msgstr "페더 반지름: %3.2f%%"
@@ -9520,7 +10394,7 @@ msgstr "[원] 불투명도 변경"
 msgid "circle #%d"
 msgstr "원 #%d"
 
-#: ../src/develop/masks/circle.c:1421 ../src/develop/masks/path.c:4011
+#: ../src/develop/masks/circle.c:1421
 #, c-format
 msgid ""
 "<b>size</b>: scroll, <b>feather size</b>: shift+scroll\n"
@@ -9529,37 +10403,45 @@ msgstr ""
 "<b>크기</b>: 스크롤, <b>페더 반지름</b>: Shift+스크롤\n"
 "<b>불투명도</b>: Ctrl+스크롤 (%d%%)"
 
-#: ../src/develop/masks/ellipse.c:451 ../src/develop/masks/ellipse.c:509
+#: ../src/develop/masks/ellipse.c:454 ../src/develop/masks/ellipse.c:512
 #, c-format
 msgid "rotation: %3.f°"
 msgstr "회전: %3.f°"
 
-#: ../src/develop/masks/ellipse.c:1955
+#: ../src/develop/masks/ellipse.c:2076
 msgid "[ELLIPSE] change size"
 msgstr "[타원] 크기 변경"
 
-#: ../src/develop/masks/ellipse.c:1958
+#: ../src/develop/masks/ellipse.c:2079
 msgid "[ELLIPSE] change feather size"
 msgstr "[타원] 페더 반지름 변경"
 
-#: ../src/develop/masks/ellipse.c:1961 ../src/develop/masks/ellipse.c:1970
+#: ../src/develop/masks/ellipse.c:2082
 msgid "[ELLIPSE] rotate shape"
 msgstr "[타원] 도형 회전"
 
-#: ../src/develop/masks/ellipse.c:1964
+#: ../src/develop/masks/ellipse.c:2085
 msgid "[ELLIPSE] change opacity"
 msgstr "[타원] 불투명도 변경"
 
-#: ../src/develop/masks/ellipse.c:1967
+#: ../src/develop/masks/ellipse.c:2088
 msgid "[ELLIPSE] switch feathering mode"
 msgstr "[타원] 페더링 모드 변경"
 
-#: ../src/develop/masks/ellipse.c:1977
+#: ../src/develop/masks/ellipse.c:2092
+msgid "[ELLIPSE] rotate shape (source only on a clone source)"
+msgstr "[타원] 도형 회전 (복제 원본에서는 원본만)"
+
+#: ../src/develop/masks/ellipse.c:2096
+msgid "[ELLIPSE] rotate shape and source together"
+msgstr "[타원] 도형과 원본을 함께 회전"
+
+#: ../src/develop/masks/ellipse.c:2103
 #, c-format
 msgid "ellipse #%d"
 msgstr "타원 #%d"
 
-#: ../src/develop/masks/ellipse.c:2014
+#: ../src/develop/masks/ellipse.c:2140
 #, c-format
 msgid ""
 "<b>size</b>: scroll, <b>feather size</b>: shift+scroll\n"
@@ -9568,18 +10450,27 @@ msgstr ""
 "<b>크기</b>: 스크롤, <b>페더 반지름</b>: Shift+스크롤\n"
 "<b>회전</b>: Ctrl+Shift+스크롤, <b>불투명도</b>: Ctrl+스크롤 (%d%%)"
 
-#: ../src/develop/masks/ellipse.c:2018
+#: ../src/develop/masks/ellipse.c:2144
 msgid "<b>rotate</b>: ctrl+drag"
 msgstr "<b>회전</b>: Ctrl+드래그"
 
-#: ../src/develop/masks/ellipse.c:2021
+#: ../src/develop/masks/ellipse.c:2154
 #, c-format
 msgid ""
-"<b>feather mode</b>: shift+click, <b>rotate</b>: ctrl+drag\n"
-"<b>size</b>: scroll, <b>feather size</b>: shift+scroll, <b>opacity</b>: ctrl+scroll (%d%%)"
+"<b>feather mode</b>: alt+click, <b>rotate</b>: ctrl+drag\n"
+"<b>size</b>: scroll, <b>feather size</b>: shift+scroll, <b>opacity</b>: "
+"ctrl+scroll (%d%%)"
 msgstr ""
-"<b>페더 모드</b>: Shift+클릭, <b>회전</b>: Ctrl+드래그\n"
+"<b>페더 모드</b>: Alt+클릭, <b>회전</b>: Ctrl+드래그\n"
 "<b>크기</b>: 스크롤, <b>페더 반지름</b>: Shift+스크롤, <b>불투명도</b>: Ctrl+스크롤 (%d%%)"
+
+#: ../src/develop/masks/ellipse.c:2160
+msgid ""
+"\n"
+"<b>rotate both</b>: shift+ctrl+drag"
+msgstr ""
+"\n"
+"<b>둘 다 회전</b>: Shift+Ctrl+드래그"
 
 #: ../src/develop/masks/gradient.c:131 ../src/develop/masks/gradient.c:174
 #, c-format
@@ -9591,32 +10482,36 @@ msgstr "압축: %3.2f%%"
 msgid "curvature: %3.2f%%"
 msgstr "곡률: %3.2f%%"
 
-#: ../src/develop/masks/gradient.c:1418
+#: ../src/develop/masks/gradient.c:1421
 msgid "[GRADIENT on pivot] rotate shape"
 msgstr "[피봇상 그라디언트] 도형 회전"
 
-#: ../src/develop/masks/gradient.c:1420
+#: ../src/develop/masks/gradient.c:1423
+msgid "[GRADIENT] rotate shape"
+msgstr "[그라디언트] 도형 회전"
+
+#: ../src/develop/masks/gradient.c:1425
 msgid "[GRADIENT creation] set rotation"
 msgstr "[그라디언트 생성] 회전 설정"
 
-#: ../src/develop/masks/gradient.c:1422
+#: ../src/develop/masks/gradient.c:1427
 msgid "[GRADIENT] change curvature"
 msgstr "[그라디언트] 곡률 변경"
 
-#: ../src/develop/masks/gradient.c:1424
+#: ../src/develop/masks/gradient.c:1429
 msgid "[GRADIENT] change compression"
 msgstr "[그라디언트] 압축 변경"
 
-#: ../src/develop/masks/gradient.c:1426
+#: ../src/develop/masks/gradient.c:1431
 msgid "[GRADIENT] change opacity"
 msgstr "[그라디언트] 불투명도 변경"
 
-#: ../src/develop/masks/gradient.c:1439
+#: ../src/develop/masks/gradient.c:1444
 #, c-format
 msgid "gradient #%d"
 msgstr "그라디언트 #%d"
 
-#: ../src/develop/masks/gradient.c:1450
+#: ../src/develop/masks/gradient.c:1455
 #, c-format
 msgid ""
 "<b>curvature</b>: scroll, <b>compression</b>: shift+scroll\n"
@@ -9625,16 +10520,16 @@ msgstr ""
 "<b>곡률</b>: 스크롤, <b>압축</b>: Shift+스크롤\n"
 "<b>회전</b>: 클릭+드래그, <b>불투명도</b>: Ctrl+스크롤 (%d%%)"
 
-#: ../src/develop/masks/gradient.c:1455
+#: ../src/develop/masks/gradient.c:1460
 #, c-format
 msgid ""
 "<b>curvature</b>: scroll, <b>compression</b>: shift+scroll\n"
-"<b>opacity</b>: ctrl+scroll (%d%%)"
+"<b>rotate</b>: ctrl+drag, <b>opacity</b>: ctrl+scroll (%d%%)"
 msgstr ""
 "<b>곡률</b>: 스크롤, <b>압축</b>: Shift+스크롤\n"
-"<b>불투명도</b>: Ctrl+스크롤 (%d%%)"
+"<b>회전</b>: Ctrl+드래그, <b>불투명도</b>: Ctrl+스크롤 (%d%%)"
 
-#: ../src/develop/masks/gradient.c:1458
+#: ../src/develop/masks/gradient.c:1463
 msgid "<b>rotate</b>: drag"
 msgstr "<b>회전</b>: 드래그"
 
@@ -9642,84 +10537,213 @@ msgstr "<b>회전</b>: 드래그"
 msgid "[SHAPE] remove shape"
 msgstr "[도형] 도형 제거"
 
-#: ../src/develop/masks/masks.c:300
+#: ../src/develop/masks/masks.c:303
 #, c-format
 msgid "group `%s'"
 msgstr "그룹 `%s'"
 
-#: ../src/develop/masks/masks.c:418
+#: ../src/develop/masks/masks.c:467
 #, c-format
 msgid "copy of `%s'"
 msgstr "`%s'의 사본"
 
-#: ../src/develop/masks/masks.c:984
+#: ../src/develop/masks/masks.c:1055
 #, c-format
 msgid "%s: mask version mismatch: %d != %d"
 msgstr "%s: 마스크 버전 불일치: %d != %d"
 
-#: ../src/develop/masks/masks.c:1244 ../src/develop/masks/masks.c:1894
+#: ../src/develop/masks/masks.c:1352 ../src/develop/masks/masks.c:2021
 #, c-format
 msgid "opacity: %.0f%%"
 msgstr "불투명도: %.0f%%"
 
-#: ../src/develop/masks/masks.c:1640 ../src/libs/masks.c:1074
+#: ../src/develop/masks/masks.c:1767 ../src/libs/masks.c:1372
 msgid "add existing shape"
 msgstr "기존 도형 추가"
 
-#: ../src/develop/masks/masks.c:1667
+#: ../src/develop/masks/masks.c:1794
 msgid "use same shapes as"
 msgstr "다음과 동일한 도형 사용"
 
-#: ../src/develop/masks/masks.c:1977
+#: ../src/develop/masks/masks.c:2104
 msgid "masks can not contain themselves"
 msgstr "마스크는 자기 자신을 포함할 수 없습니다"
 
-#: ../src/develop/masks/path.c:3944
+#: ../src/develop/masks/object.c:852
+msgid "set raster mask root folder in preferences"
+msgstr "환경설정에서 래스터 마스크 루트 폴더를 설정하세요"
+
+#: ../src/develop/masks/object.c:860
+msgid "cannot create raster mask folder"
+msgstr "래스터 마스크 폴더를 생성할 수 없습니다"
+
+#: ../src/develop/masks/object.c:923
+msgid "raster mask saved"
+msgstr "래스터 마스크가 저장됨"
+
+#: ../src/develop/masks/object.c:928
+msgid "failed to save raster mask"
+msgstr "래스터 마스크 저장에 실패하였습니다"
+
+#: ../src/develop/masks/object.c:1009
+msgid "no mask extracted from AI segmentation"
+msgstr "AI 분할에서 마스크를 추출하지 못했습니다"
+
+#: ../src/develop/masks/object.c:1017
+msgid "ai object group"
+msgstr "AI 객체 그룹"
+
+#: ../src/develop/masks/object.c:1018
+msgid "ai object"
+msgstr "AI 객체"
+
+#: ../src/develop/masks/object.c:1146
+#, c-format
+msgid "smoothing: %3.2f"
+msgstr "부드럽기: %3.2f"
+
+#: ../src/develop/masks/object.c:1157
+#, c-format
+msgid "cleanup: %d"
+msgstr "정리: %d"
+
+#: ../src/develop/masks/object.c:1170
+#, c-format
+msgid "opacity: %d%%"
+msgstr "불투명도: %d%%"
+
+#: ../src/develop/masks/object.c:1293
+#, c-format
+msgid "group '%s'"
+msgstr "그룹 '%s'"
+
+#. keep the message visible while the thread is working
+#: ../src/develop/masks/object.c:1541 ../src/develop/masks/object.c:1578
+msgid "object mask: analyzing image..."
+msgstr "객체 마스크: 이미지 분석 중..."
+
+#: ../src/develop/masks/object.c:1588
+msgid "click on object to create mask"
+msgstr "객체를 클릭하여 마스크를 생성하세요"
+
+#. log only once when the thread is first joined
+#: ../src/develop/masks/object.c:1598
+msgid "object mask preparation failed"
+msgstr "객체 마스크 준비에 실패하였습니다"
+
+#: ../src/develop/masks/object.c:1803
+msgid "[OBJECT] select / add foreground point"
+msgstr "[객체] 전경 점 선택/추가"
+
+#: ../src/develop/masks/object.c:1808
+msgid "[OBJECT] add background point"
+msgstr "[객체] 배경 점 추가"
+
+#: ../src/develop/masks/object.c:1813
+msgid "[OBJECT] clear selection"
+msgstr "[객체] 선택 지우기"
+
+#: ../src/develop/masks/object.c:1818
+msgid "[OBJECT] apply mask"
+msgstr "[객체] 마스크 적용"
+
+#: ../src/develop/masks/object.c:1823
+msgid "[OBJECT] change smoothing"
+msgstr "[객체] 부드럽기 변경"
+
+#: ../src/develop/masks/object.c:1828
+msgid "[OBJECT] change cleanup"
+msgstr "[객체] 정리 변경"
+
+#: ../src/develop/masks/object.c:1833
+msgid "[OBJECT] change opacity"
+msgstr "[객체] 불투명도 변경"
+
+#: ../src/develop/masks/object.c:1840
+#, c-format
+msgid "object #%d"
+msgstr "객체 #%d"
+
+#: ../src/develop/masks/object.c:1858
+#, c-format
+msgid ""
+"<b>add</b>: click, <b>subtract</b>: shift+click, <b>clear</b>: "
+"ctrl+shift+click, <b>apply</b>: right-click, <b>apply+save raster</b>: "
+"shift+right-click\n"
+"<b>smoothing</b>: scroll (%3.2f), <b>cleanup</b>: shift+scroll (%d), "
+"<b>opacity</b>: ctrl+scroll (%d%%)"
+msgstr ""
+"<b>추가</b>: 클릭, <b>제외</b>: Shift+클릭, <b>지우기</b>: Ctrl+Shift+클릭, <b>적용</b>: 우클릭, <b>적용+래스터 저장</b>: Shift+우클릭\n"
+"<b>부드럽기</b>: 스크롤 (%3.2f), <b>정리</b>: Shift+스크롤 (%d), <b>불투명도</b>: Ctrl+스크롤 (%d%%)"
+
+#: ../src/develop/masks/object.c:1869
+#, c-format
+msgid "<b>select</b>: click on object, <b>opacity</b>: ctrl+scroll (%d%%)"
+msgstr "<b>선택</b>: 객체 클릭, <b>불투명도</b>: Ctrl+스크롤 (%d%%)"
+
+#: ../src/develop/masks/path.c:2839
+#, c-format
+msgid "resize: %+d %s"
+msgstr "크기 조절: %+d %s"
+
+#: ../src/develop/masks/path.c:5255
 msgid "[PATH creation] add a smooth node"
 msgstr "[경로 생성] 부드러운 노드 추가"
 
-#: ../src/develop/masks/path.c:3946
+#: ../src/develop/masks/path.c:5257
 msgid "[PATH creation] add a sharp node"
 msgstr "[경로 생성] 뾰족한 노드 추가"
 
-#: ../src/develop/masks/path.c:3948
+#: ../src/develop/masks/path.c:5259
 msgid "[PATH creation] terminate path creation"
 msgstr "[경로 생성] 경로 생성 종료"
 
-#: ../src/develop/masks/path.c:3950
+#: ../src/develop/masks/path.c:5261
 msgid "[PATH on node] switch between smooth/sharp node"
 msgstr "[노드의 경로] 부드러운/뾰족한 노드 간 전환"
 
-#: ../src/develop/masks/path.c:3952
+#: ../src/develop/masks/path.c:5263
 msgid "[PATH on node] remove the node"
 msgstr "[노드의 경로] 노드 제거"
 
-#: ../src/develop/masks/path.c:3954
+#: ../src/develop/masks/path.c:5265
 msgid "[PATH on feather] reset curvature"
 msgstr "[페더의 경로] 곡률 초기화"
 
-#: ../src/develop/masks/path.c:3956
+#: ../src/develop/masks/path.c:5267
 msgid "[PATH on segment] add node"
 msgstr "[선분의 경로] 노드 추가"
 
-#: ../src/develop/masks/path.c:3958
-msgid "[PATH] change size"
-msgstr "[경로] 크기 변경"
+#: ../src/develop/masks/path.c:5271
+msgid "[PATH] rotate shape (source only on a clone source)"
+msgstr "[경로] 도형 회전 (복제 원본에서는 원본만)"
 
-#: ../src/develop/masks/path.c:3960
+#: ../src/develop/masks/path.c:5275
+msgid "[PATH] rotate shape and source together"
+msgstr "[경로] 도형과 원본을 함께 회전"
+
+#: ../src/develop/masks/path.c:5276
+msgid "[PATH] grow/shrink"
+msgstr "[경로] 확대/축소"
+
+#: ../src/develop/masks/path.c:5278
+msgid "[PATH] resize"
+msgstr "[경로] 크기 조절"
+
+#: ../src/develop/masks/path.c:5280
 msgid "[PATH] change feather size"
 msgstr "[경로] 페더 반지름 변경"
 
-#: ../src/develop/masks/path.c:3962
+#: ../src/develop/masks/path.c:5282
 msgid "[PATH] change opacity"
 msgstr "[경로] 불투명도 변경"
 
-#: ../src/develop/masks/path.c:3974
+#: ../src/develop/masks/path.c:5294
 #, c-format
 msgid "path #%d"
 msgstr "경로 #%d"
 
-#: ../src/develop/masks/path.c:3985
+#: ../src/develop/masks/path.c:5305
 msgid ""
 "<b>add node</b>: click, <b>add sharp node</b>: ctrl+click\n"
 "<b>cancel</b>: right-click"
@@ -9727,7 +10751,7 @@ msgstr ""
 "<b>노드 추가</b>: 클릭, <b>뾰족한 노드 추가</b>: Ctrl+클릭\n"
 "<b>취소</b>: 우클릭"
 
-#: ../src/develop/masks/path.c:3990
+#: ../src/develop/masks/path.c:5310
 msgid ""
 "<b>add node</b>: click, <b>add sharp node</b>: ctrl+click\n"
 "<b>finish path</b>: right-click"
@@ -9735,7 +10759,7 @@ msgstr ""
 "<b>노드 추가</b>: 클릭, <b>뾰족한 노드 추가</b>: Ctrl+클릭\n"
 "<b>경로 완료</b>: 우클릭"
 
-#: ../src/develop/masks/path.c:3995
+#: ../src/develop/masks/path.c:5315
 msgid ""
 "<b>move node</b>: drag, <b>remove node</b>: right-click\n"
 "<b>switch smooth/sharp mode</b>: ctrl+click"
@@ -9743,7 +10767,7 @@ msgstr ""
 "<b>노드 이동</b>: 드래그, <b>노드 제거</b>: 우클릭\n"
 "<b>부드러운/뾰족한 노드 간 전환</b>: Ctrl+클릭"
 
-#: ../src/develop/masks/path.c:4000
+#: ../src/develop/masks/path.c:5320
 msgid ""
 "<b>node curvature</b>: drag, <b>force symmetry</b>: ctrl+drag,\n"
 "<b>move single handle</b>: shift+drag, <b>reset curvature</b>: right-click"
@@ -9751,19 +10775,29 @@ msgstr ""
 "<b>노드 곡률</b>: 드래그, <b>대칭 유지</b>: Ctrl+드래그,\n"
 "<b>단일 핸들 이동</b>: Shift+드래그, <b>곡률 초기화</b>: 우클릭"
 
-#: ../src/develop/masks/path.c:4005
+#: ../src/develop/masks/path.c:5325
 msgid ""
-"<b>move segment</b>: drag, <b>add node</b>: ctrl+click\n"
+"<b>move segment</b>: drag, <b>add node</b>: shift+click\n"
 "<b>remove path</b>: right-click"
 msgstr ""
-"<b>선분 이동</b>: 드래그, <b>노드 추가</b>: Ctrl+클릭\n"
+"<b>선분 이동</b>: 드래그, <b>노드 추가</b>: Shift+클릭\n"
 "<b>경로 제거</b>: 우클릭"
 
-#: ../src/develop/pixelpipe_hb.c:517
+#: ../src/develop/masks/path.c:5338
+#, c-format
+msgid ""
+"<b>grow/shrink</b>: scroll, <b>resize</b>: ctrl+shift+scroll\n"
+"<b>feather size</b>: shift+scroll, <b>opacity</b>: ctrl+scroll (%d%%), "
+"<b>rotate</b>: ctrl+drag"
+msgstr ""
+"<b>확대/축소</b>: 스크롤, <b>크기 조절</b>: Ctrl+Shift+스크롤\n"
+"<b>페더 반지름</b>: Shift+스크롤, <b>불투명도</b>: Ctrl+스크롤 (%d%%), <b>회전</b>: Ctrl+드래그"
+
+#: ../src/develop/pixelpipe_hb.c:572
 msgid "enabled as required"
 msgstr "필요에 따라 활성화됨"
 
-#: ../src/develop/pixelpipe_hb.c:518
+#: ../src/develop/pixelpipe_hb.c:573
 msgid ""
 "history had module disabled but it is required for this type of image.\n"
 "likely introduced by applying a preset, style or history copy&paste"
@@ -9771,11 +10805,11 @@ msgstr ""
 "히스토리에 모듈이 비활성화되어 있지만, 이 이미지 유형에는 필요합니다.\n"
 "이는 프리셋, 스타일 또는 히스토리 복사&붙여넣기 적용으로 인한 것으로 보입니다"
 
-#: ../src/develop/pixelpipe_hb.c:525
+#: ../src/develop/pixelpipe_hb.c:580
 msgid "disabled as not appropriate"
 msgstr "적합하지 않아 비활성화됨"
 
-#: ../src/develop/pixelpipe_hb.c:526
+#: ../src/develop/pixelpipe_hb.c:581
 msgid ""
 "history had module enabled but it is not allowed for this type of image.\n"
 "likely introduced by applying a preset, style or history copy&paste"
@@ -9783,7 +10817,7 @@ msgstr ""
 "히스토리에 모듈이 활성화되어 있지만, 이 이미지 형식에는 허용되지 않습니다.\n"
 "이는 프리셋, 스타일 또는 히스토리 복사&붙여넣기 적용으로 인한 것으로 보입니다"
 
-#: ../src/develop/pixelpipe_hb.c:1258
+#: ../src/develop/pixelpipe_hb.c:1361
 #, c-format
 msgid ""
 "fatal pixelpipe abort due to non-aligned buffers\n"
@@ -9793,15 +10827,19 @@ msgstr ""
 "모듈 '%s'에서 비정렬 버퍼 문제로 치명적인 픽셀파이프 중단 발생\n"
 "GitHub에 보고해 주시기 바랍니다"
 
-#: ../src/develop/pixelpipe_hb.c:1742
+#: ../src/develop/pixelpipe_hb.c:1950
 msgid "fatal input misalignment, please report on GitHub\n"
-msgstr "치명적인 입력 정렬 오류, GitHub에 보고해 주시기 바랍니다\n"
+msgstr ""
+"치명적인 입력 정렬 오류, GitHub에 보고해 주시기 바랍니다\n"
 
-#: ../src/develop/pixelpipe_hb.c:3113
+#: ../src/develop/pixelpipe_hb.c:3150
 msgid ""
-"OpenCL errors encountered; disabling OpenCL for this session! some possible causes:\n"
-"  - OpenCL out of resources due to preference settings. please try with defaults,\n"
-"  - buggy driver for some device. please run darktable with `-d opencl' to identify,\n"
+"OpenCL errors encountered; disabling OpenCL for this session! some possible "
+"causes:\n"
+"  - OpenCL out of resources due to preference settings. please try with "
+"defaults,\n"
+"  - buggy driver for some device. please run darktable with `-d opencl' to "
+"identify,\n"
 "  - some drivers don't support needed number of events,\n"
 "  - too small headroom settings while using 'use all device memory'."
 msgstr ""
@@ -9811,7 +10849,7 @@ msgstr ""
 "  - 일부 드라이버가 필요한 이벤트 수를 지원하지 않음,\n"
 "  - '모든 장치 메모리 사용'을 선택할 때 헤드룸 설정이 너무 작음."
 
-#: ../src/develop/pixelpipe_hb.c:3305
+#: ../src/develop/pixelpipe_hb.c:3458
 #, c-format
 msgid ""
 "module '%s' can't get raster mask from module\n"
@@ -9822,42 +10860,44 @@ msgstr ""
 "모듈 '%s'에서 래스터 마스크를 가져올 수 없습니다.\n"
 "래스터 마스크는 무시합니다."
 
-#: ../src/develop/tiling.c:817 ../src/develop/tiling.c:1157
+#: ../src/develop/tiling.c:809 ../src/develop/tiling.c:1146
 #, c-format
-msgid "tiling failed for module '%s'. the output most likely will be OK, but you might want to check."
-msgstr "모듈 '%s'의 타일링에 실패하였습니다. 출력은 괜찮을 듯하지만, 확인해 보시는 것이 좋습니다."
+msgid ""
+"tiling failed for module '%s%s'. the output most likely will be OK, but you "
+"might want to check."
+msgstr "모듈 '%s%s'의 타일링에 실패하였습니다. 출력은 괜찮을 듯하지만, 확인해 보시는 것이 좋습니다."
 
-#: ../src/dtgtk/culling.c:223
+#: ../src/dtgtk/culling.c:225
 msgid "you have reached the start of your selection"
 msgstr "선택 항목의 시작에 도달하였습니다"
 
-#: ../src/dtgtk/culling.c:232
+#: ../src/dtgtk/culling.c:234
 msgid "you have reached the start of your collection"
 msgstr "컬렉션의 시작에 도달하였습니다"
 
-#: ../src/dtgtk/culling.c:279
+#: ../src/dtgtk/culling.c:281
 msgid "you have reached the end of your selection"
 msgstr "선택 항목의 끝에 도달하였습니다"
 
-#: ../src/dtgtk/culling.c:306
+#: ../src/dtgtk/culling.c:308
 msgid "you have reached the end of your collection"
 msgstr "컬렉션의 끝에 도달하였습니다"
 
-#: ../src/dtgtk/culling.c:415
+#: ../src/dtgtk/culling.c:467
 #, c-format
 msgid "zooming is limited to %d images"
 msgstr "줌은 %d개의 이미지로 제한됨"
 
-#: ../src/dtgtk/range.c:218 ../src/dtgtk/range.c:223
+#: ../src/dtgtk/range.c:238 ../src/dtgtk/range.c:243
 msgid "invalid"
 msgstr "유효하지 않음"
 
-#: ../src/dtgtk/range.c:331
+#: ../src/dtgtk/range.c:351
 #, c-format
 msgid "year %s"
 msgstr "%s년"
 
-#: ../src/dtgtk/range.c:409
+#: ../src/dtgtk/range.c:429
 msgid ""
 "enter the minimal value\n"
 "use 'min' if no bound\n"
@@ -9867,7 +10907,7 @@ msgstr ""
 "제한이 없다면 'min'을 입력하세요\n"
 "우클릭하여 기존 값에서 선택하세요"
 
-#: ../src/dtgtk/range.c:415
+#: ../src/dtgtk/range.c:435
 msgid ""
 "enter the maximal value\n"
 "use 'max' if no bound\n"
@@ -9877,7 +10917,7 @@ msgstr ""
 "제한이 없다면 'max'을 입력하세요\n"
 "우클릭하여 기존 값에서 선택하세요"
 
-#: ../src/dtgtk/range.c:421
+#: ../src/dtgtk/range.c:441
 msgid ""
 "enter the value\n"
 "right-click to select from existing values"
@@ -9885,7 +10925,7 @@ msgstr ""
 "값을 입력하세요\n"
 "우클릭하여 기존 값에서 선택하세요"
 
-#: ../src/dtgtk/range.c:426
+#: ../src/dtgtk/range.c:446
 msgid ""
 "enter the minimal date\n"
 "in the form YYYY:MM:DD hh:mm:ss.sss (only the year is mandatory)\n"
@@ -9899,7 +10939,7 @@ msgstr ""
 "상대 날짜는 앞에 '-'를 붙여 입력하세요\n"
 "우클릭하여 캘린더 또는 기존 값에서 선택하세요"
 
-#: ../src/dtgtk/range.c:434
+#: ../src/dtgtk/range.c:454
 msgid ""
 "enter the maximal date\n"
 "in the form YYYY:MM:DD hh:mm:ss.sss (only the year is mandatory)\n"
@@ -9914,7 +10954,7 @@ msgstr ""
 "상대 날짜는 앞에 '-'를 붙여 입력하세요\n"
 "우클릭하여 캘린더 또는 기존 값에서 선택하세요"
 
-#: ../src/dtgtk/range.c:443
+#: ../src/dtgtk/range.c:463
 msgid ""
 "enter the date\n"
 "in the form YYYY:MM:DD hh:mm:ss.sss (only the year is mandatory)\n"
@@ -9924,46 +10964,46 @@ msgstr ""
 "YYYY:MM:DD hh:mm:ss.sss 형식 (년도만 필수)\n"
 "우클릭하여 캘린더 또는 기존 값에서 선택하세요"
 
-#: ../src/dtgtk/range.c:465
+#: ../src/dtgtk/range.c:485
 msgid "date-time interval to subtract from the max value"
 msgstr "최대값에서 빼는 날짜/시간 간격"
 
-#: ../src/dtgtk/range.c:469
+#: ../src/dtgtk/range.c:489
 msgid "date-time interval to add to the min value"
 msgstr "최소값에서 빼는 날짜/시간 간격"
 
-#: ../src/dtgtk/range.c:490
+#: ../src/dtgtk/range.c:510
 msgid "fixed"
 msgstr "고정"
 
-#: ../src/dtgtk/range.c:491 ../src/iop/colorchecker.c:1612
+#: ../src/dtgtk/range.c:511 ../src/iop/colorchecker.c:1612
 msgid "relative"
 msgstr "상대적"
 
-#: ../src/dtgtk/range.c:581
+#: ../src/dtgtk/range.c:601
 msgid "selected"
 msgstr "선택됨"
 
-#: ../src/dtgtk/range.c:627 ../src/dtgtk/range.c:1740 ../src/dtgtk/range.c:1791
+#: ../src/dtgtk/range.c:647 ../src/dtgtk/range.c:1760 ../src/dtgtk/range.c:1811
 #: ../src/libs/colorpicker.c:54
 msgid "min"
 msgstr "최소"
 
-#: ../src/dtgtk/range.c:633 ../src/dtgtk/range.c:1752 ../src/dtgtk/range.c:1803
+#: ../src/dtgtk/range.c:653 ../src/dtgtk/range.c:1772 ../src/dtgtk/range.c:1823
 #: ../src/libs/colorpicker.c:54 ../src/libs/filters/rating_range.c:309
 msgid "max"
 msgstr "최대"
 
-#: ../src/dtgtk/range.c:939
+#: ../src/dtgtk/range.c:959
 msgid "date type"
 msgstr "날짜 유형"
 
 #. the date section
-#: ../src/dtgtk/range.c:948 ../src/libs/geotagging.c:1533
+#: ../src/dtgtk/range.c:968 ../src/libs/geotagging.c:1537
 msgid "date"
 msgstr "날짜"
 
-#: ../src/dtgtk/range.c:954 ../src/dtgtk/range.c:1008
+#: ../src/dtgtk/range.c:974 ../src/dtgtk/range.c:1028
 msgid ""
 "click to select date\n"
 "double-click to use the date directly"
@@ -9971,46 +11011,46 @@ msgstr ""
 "클릭하여 날짜 선택\n"
 "더블 클릭하여 날짜 바로 사용"
 
-#: ../src/dtgtk/range.c:963
+#: ../src/dtgtk/range.c:983
 msgid "years: "
 msgstr "년: "
 
-#: ../src/dtgtk/range.c:971
+#: ../src/dtgtk/range.c:991
 msgid "months: "
 msgstr "월: "
 
-#: ../src/dtgtk/range.c:979
+#: ../src/dtgtk/range.c:999
 msgid "days: "
 msgstr "일: "
 
 #. the time section
-#: ../src/dtgtk/range.c:991 ../src/libs/geotagging.c:1533
+#: ../src/dtgtk/range.c:1011 ../src/libs/geotagging.c:1537
 msgid "time"
 msgstr "시간"
 
-#: ../src/dtgtk/range.c:1025 ../src/dtgtk/range.c:1759
-#: ../src/dtgtk/range.c:1810
+#: ../src/dtgtk/range.c:1045 ../src/dtgtk/range.c:1779
+#: ../src/dtgtk/range.c:1830
 msgid "now"
 msgstr "지금"
 
-#: ../src/dtgtk/range.c:1027
+#: ../src/dtgtk/range.c:1047
 msgid "set the value to always match current datetime"
 msgstr "값을 현재 날짜/시간과 항상 일치하도록 설정"
 
-#: ../src/dtgtk/range.c:1029 ../src/gui/accelerators.c:180
-#: ../src/libs/metadata.c:1140 ../src/libs/styles.c:913
+#: ../src/dtgtk/range.c:1049 ../src/gui/accelerators.c:185
+#: ../src/libs/metadata.c:1142 ../src/libs/styles.c:948
 msgid "apply"
 msgstr "적용"
 
-#: ../src/dtgtk/range.c:1030
+#: ../src/dtgtk/range.c:1050
 msgid "set the range bound with this value"
 msgstr "이 값을 범위 제한으로 설정"
 
-#: ../src/dtgtk/range.c:1041
+#: ../src/dtgtk/range.c:1061
 msgid "current date: "
 msgstr "현재 날짜: "
 
-#: ../src/dtgtk/resetlabel.c:64 ../src/libs/metadata.c:595
+#: ../src/dtgtk/resetlabel.c:64 ../src/libs/metadata.c:597
 msgid "double-click to reset"
 msgstr "더블 클릭하여 초기화"
 
@@ -10037,98 +11077,100 @@ msgstr ""
 msgid "grouped images"
 msgstr "그룹 이미지"
 
-#: ../src/dtgtk/thumbnail.c:859 ../src/dtgtk/thumbnail.c:1654
-#: ../src/iop/ashift.c:6047 ../src/iop/ashift.c:6134 ../src/iop/ashift.c:6136
-#: ../src/iop/ashift.c:6138 ../src/libs/navigation.c:112
-#: ../src/libs/navigation.c:249
+#: ../src/dtgtk/thumbnail.c:348 ../src/dtgtk/thumbnail.c:1724
+#: ../src/iop/ashift.c:6043 ../src/iop/ashift.c:6130 ../src/iop/ashift.c:6132
+#: ../src/iop/ashift.c:6134 ../src/libs/navigation.c:124
+#: ../src/libs/navigation.c:268
 msgid "fit"
 msgstr "맞춤"
 
-#: ../src/dtgtk/thumbtable.c:1256
+#: ../src/dtgtk/thumbtable.c:1279
 msgid "here"
 msgstr "여기"
 
-#: ../src/dtgtk/thumbtable.c:1257 ../src/views/slideshow.c:426
+#: ../src/dtgtk/thumbtable.c:1280 ../src/views/slideshow.c:426
 msgid "there are no images in this collection"
 msgstr "이 컬렉션에 이미지가 없습니다"
 
-#: ../src/dtgtk/thumbtable.c:1259
+#: ../src/dtgtk/thumbtable.c:1282
 msgid "need help?"
 msgstr "도움이 필요하신가요?"
 
-#: ../src/dtgtk/thumbtable.c:1260
+#: ../src/dtgtk/thumbtable.c:1283
 msgid "if you have not imported any images yet"
 msgstr "아직 이미지를 가져오지 않았다면"
 
-#: ../src/dtgtk/thumbtable.c:1261
+#: ../src/dtgtk/thumbtable.c:1284
 msgid "click on <b>?</b> then an on-screen item to open manual page"
 msgstr "<b>?</b>를 클릭한 다음 화면의 항목을 클릭하여 매뉴얼 페이지 열기"
 
-#: ../src/dtgtk/thumbtable.c:1262
+#: ../src/dtgtk/thumbtable.c:1285
 msgid "you can do so in the import module"
 msgstr "가져오기 모듈에서도 이미지를 가져올 수 있습니다"
 
-#: ../src/dtgtk/thumbtable.c:1263
+#: ../src/dtgtk/thumbtable.c:1286
 msgid "press and hold '<b>h</b>' to show all active keyboard shortcuts"
 msgstr "'<b>h</b>' 키를 누르고 있으면 모든 활성 키보드 단축키가 표시됩니다"
 
-#: ../src/dtgtk/thumbtable.c:1264
+#: ../src/dtgtk/thumbtable.c:1287
 msgid "to open the online manual click "
 msgstr "클릭하여 온라인 매뉴얼 열기 "
 
-#: ../src/dtgtk/thumbtable.c:1265
+#: ../src/dtgtk/thumbtable.c:1288
 msgid "try to relax the filter settings in the top panel"
 msgstr "상단 패널에서 필터 설정을 완화해 보세요"
 
-#: ../src/dtgtk/thumbtable.c:1266
+#: ../src/dtgtk/thumbtable.c:1289
 msgid "or add images in the collections module"
 msgstr "또는 컬렉션 모듈에서 이미지를 추가하세요"
 
-#: ../src/dtgtk/thumbtable.c:1267
+#: ../src/dtgtk/thumbtable.c:1290
 msgid "personalize darktable"
 msgstr "darktable 개인 설정"
 
-#: ../src/dtgtk/thumbtable.c:1268
+#: ../src/dtgtk/thumbtable.c:1291
 msgid "click on the gear icon for global preferences"
 msgstr "톱니바퀴 아이콘을 클릭하여 전역 환경설정 변경"
 
-#: ../src/dtgtk/thumbtable.c:1270
+#: ../src/dtgtk/thumbtable.c:1293
 msgid "click on the keyboard icon to define shortcuts"
 msgstr "키보드 아이콘을 클릭하여 단축키 정의"
 
-#: ../src/dtgtk/thumbtable.c:1272
+#: ../src/dtgtk/thumbtable.c:1295
 msgid "try the 'no-click' workflow"
 msgstr "'클릭 없는' 워크 플로우를 사용해 보세요"
 
-#: ../src/dtgtk/thumbtable.c:1273
+#: ../src/dtgtk/thumbtable.c:1296
 msgid "set module-specific preferences through module's menu"
 msgstr "모듈 메뉴에서 모듈별 환경설정"
 
-#: ../src/dtgtk/thumbtable.c:1274
+#: ../src/dtgtk/thumbtable.c:1297
 msgid "hover over an image and use keyboard shortcuts"
 msgstr "이미지에 마우스를 올리고 키보드 단축키 사용"
 
-#: ../src/dtgtk/thumbtable.c:1275
+#: ../src/dtgtk/thumbtable.c:1298
 msgid "to apply ratings, colors, styles, etc."
 msgstr "등급, 색상, 스타일 등을 적용하려면."
 
-#: ../src/dtgtk/thumbtable.c:1276
+#: ../src/dtgtk/thumbtable.c:1299
 msgid "make default raw development look more like your"
 msgstr "기본 RAW 현상 설정을 다음과 같이 변경"
 
-#: ../src/dtgtk/thumbtable.c:1277
+#: ../src/dtgtk/thumbtable.c:1300
 msgid "hover over any button for its description and shortcuts"
 msgstr "설명 및 단축키를 확인하기 위해 버튼 위에 마우스를 올리세요"
 
-#: ../src/dtgtk/thumbtable.c:1278
+#: ../src/dtgtk/thumbtable.c:1301
 msgid "camera's JPEG by applying a camera-specific style"
 msgstr "카메라 전용 스타일을 적용하여 카메라 JPEG처럼 보이게 하세요"
 
-#: ../src/dtgtk/thumbtable.c:1695
-msgid "you have changed the settings related to how thumbnails are generated.\n"
-msgstr "썸네일 생성 방식 관련 설정을 변경하였습니다.\n"
+#: ../src/dtgtk/thumbtable.c:1728
+msgid ""
+"you have changed the settings related to how thumbnails are generated.\n"
+msgstr ""
+"썸네일 생성 방식 관련 설정을 변경하였습니다.\n"
 
-#: ../src/dtgtk/thumbtable.c:1698
+#: ../src/dtgtk/thumbtable.c:1731
 msgid ""
 "all cached thumbnails need to be invalidated.\n"
 "\n"
@@ -10136,7 +11178,7 @@ msgstr ""
 "캐시된 썸네일을 모두 무효화해야 합니다.\n"
 "\n"
 
-#: ../src/dtgtk/thumbtable.c:1702
+#: ../src/dtgtk/thumbtable.c:1735
 #, c-format
 msgid ""
 "cached thumbnails starting from level %d need to be invalidated.\n"
@@ -10145,7 +11187,7 @@ msgstr ""
 "레벨 %d부터 시작하는 캐시된 썸네일을 무효화해야 합니다.\n"
 "\n"
 
-#: ../src/dtgtk/thumbtable.c:1707
+#: ../src/dtgtk/thumbtable.c:1740
 #, c-format
 msgid ""
 "cached thumbnails below level %d need to be invalidated.\n"
@@ -10154,7 +11196,7 @@ msgstr ""
 "레벨 %d 미만의 캐시된 썸네일을 무효화해야 합니다.\n"
 "\n"
 
-#: ../src/dtgtk/thumbtable.c:1712
+#: ../src/dtgtk/thumbtable.c:1745
 #, c-format
 msgid ""
 "cached thumbnails between level %d and %d need to be invalidated.\n"
@@ -10163,40 +11205,40 @@ msgstr ""
 "레벨 %d와 %d 사이의 캐시된 썸네일을 무효화해야 합니다.\n"
 "\n"
 
-#: ../src/dtgtk/thumbtable.c:1715
+#: ../src/dtgtk/thumbtable.c:1748
 msgid "do you want to do that now?"
 msgstr "지금 실행하시겠습니까?"
 
-#: ../src/dtgtk/thumbtable.c:1717
+#: ../src/dtgtk/thumbtable.c:1750
 msgid "cached thumbnails invalidation"
 msgstr "캐시된 썸네일 무효화"
 
 #. setup history key accelerators
-#: ../src/dtgtk/thumbtable.c:2953
+#: ../src/dtgtk/thumbtable.c:3096
 msgid "copy history"
 msgstr "히스토리 복사"
 
-#: ../src/dtgtk/thumbtable.c:2955
+#: ../src/dtgtk/thumbtable.c:3098
 msgid "copy history parts"
 msgstr "히스토리 일부 복사"
 
-#: ../src/dtgtk/thumbtable.c:2959
+#: ../src/dtgtk/thumbtable.c:3102
 msgid "paste history parts"
 msgstr "히스토리 일부 붙여넣기"
 
-#: ../src/dtgtk/thumbtable.c:2964
+#: ../src/dtgtk/thumbtable.c:3107
 msgid "duplicate image"
 msgstr "이미지 복제"
 
-#: ../src/dtgtk/thumbtable.c:2966
+#: ../src/dtgtk/thumbtable.c:3109
 msgid "duplicate image virgin"
 msgstr "원본 이미지 복제"
 
-#: ../src/dtgtk/thumbtable.c:2976 ../src/libs/select.c:154
+#: ../src/dtgtk/thumbtable.c:3119 ../src/libs/select.c:154
 msgid "select film roll"
 msgstr "필름 롤 선택"
 
-#: ../src/dtgtk/thumbtable.c:2978 ../src/libs/select.c:158
+#: ../src/dtgtk/thumbtable.c:3121 ../src/libs/select.c:158
 msgid "select untouched"
 msgstr "편집되지 않은 이미지 선택"
 
@@ -10391,6 +11433,10 @@ msgstr "편집되지 않은 이미지 선택"
 #. Not Implemented
 #. Not Implemented
 #. Not Implemented
+#. handle the ROLL.NAME[n] case
+#. grab each complete variable
+#. strip of the leading $( and trailing )
+#. add one because c arrays are 0 based and lua are 1 based
 #. find the $CATEGORYn and $CATEGORY[n,m] requests and add them to the substitute list
 #. grab each complete variable
 #. strip of the leading $( and trailing )
@@ -10405,10 +11451,13 @@ msgstr "편집되지 않은 이미지 선택"
 #. FILE.NAME
 #. FILE.EXTENSION
 #. ID
+#. IMAGE.ID
+#. IMAGE.ID.NEXT
 #. VERSION
 #. VERSION.IF_MULTI
 #. VERSION.NAME
 #. DARKTABLE.VERSION
+#. Xmp.darktable.version
 #. DARKTABLE.NAME
 #. SEQUENCE
 #. WIDTH.SENSOR
@@ -10474,10 +11523,15 @@ msgstr "편집되지 않은 이미지 선택"
 #. LABELS
 #. LABELS.ICONS - wont be implemented
 #. TITLE
+#. Xmp.dc.title
 #. DESCRIPTION
+#. Xmp.dc.description
 #. CREATOR
+#. Xmp.dc.creator
 #. PUBLISHER
+#. Xmp.dc.publisher
 #. RIGHTS
+#. Xmp.dc.rights
 #. TAGS - wont be implemented
 #. SIDECAR.TXT - wont be implemented
 #. FOLDER.PICTURES
@@ -10489,272 +11543,292 @@ msgstr "편집되지 않은 이미지 선택"
 #. JOBCODE - wont be implemented
 #. populate the substitution list
 #. do category substitutions separately
-#: ../src/external/lua-scripts/lib/dtutils/string.lua:870
+#: ../src/external/lua-scripts/lib/dtutils/string.lua:931
 msgid "$(ROLL.NAME) - roll of the input image"
 msgstr "$(ROLL.NAME) - 입력 이미지 롤"
 
-#: ../src/external/lua-scripts/lib/dtutils/string.lua:871
+#: ../src/external/lua-scripts/lib/dtutils/string.lua:932
 #: ../src/gui/gtkentry.c:38
 msgid "$(FILE.FOLDER) - folder containing the input image"
 msgstr "$(FILE.FOLDER) - 입력 이미지 폴더"
 
-#: ../src/external/lua-scripts/lib/dtutils/string.lua:872
+#: ../src/external/lua-scripts/lib/dtutils/string.lua:933
 #: ../src/gui/gtkentry.c:39
 msgid "$(FILE.NAME) - basename of the input image"
 msgstr "$(FILE.NAME) - 입력 이미지 파일 이름"
 
-#: ../src/external/lua-scripts/lib/dtutils/string.lua:873
+#: ../src/external/lua-scripts/lib/dtutils/string.lua:934
 #: ../src/gui/gtkentry.c:40
 msgid "$(FILE.EXTENSION) - extension of the input image"
 msgstr "$(FILE.EXTENSION) - 입력 이미지 확장자"
 
-#: ../src/external/lua-scripts/lib/dtutils/string.lua:874
+#: ../src/external/lua-scripts/lib/dtutils/string.lua:935
 #: ../src/gui/gtkentry.c:111
 msgid "$(ID) - image ID"
 msgstr "$(ID) - 이미지 ID"
 
-#: ../src/external/lua-scripts/lib/dtutils/string.lua:875
+#: ../src/external/lua-scripts/lib/dtutils/string.lua:936
+#: ../src/gui/gtkentry.c:109
+msgid "$(IMAGE.ID) - image ID"
+msgstr "$(IMAGE.ID) - 이미지 ID"
+
+#: ../src/external/lua-scripts/lib/dtutils/string.lua:937
+#: ../src/gui/gtkentry.c:110
+msgid "$(IMAGE.ID.NEXT) - next image ID to be assigned on import"
+msgstr "$(IMAGE.ID.NEXT) - 가져오기 시 할당될 다음 이미지 ID"
+
+#: ../src/external/lua-scripts/lib/dtutils/string.lua:938
 #: ../src/gui/gtkentry.c:41
 msgid "$(VERSION) - duplicate version"
 msgstr "$(VERSION) - 복제 버전"
 
-#: ../src/external/lua-scripts/lib/dtutils/string.lua:876
+#: ../src/external/lua-scripts/lib/dtutils/string.lua:939
 #: ../src/gui/gtkentry.c:42
-msgid "$(VERSION.IF_MULTI) - same as $(VERSION) but null string if only one version exists"
+msgid ""
+"$(VERSION.IF_MULTI) - same as $(VERSION) but null string if only one version "
+"exists"
 msgstr "$(VERSION.IF_MULTI) - $(VERSION)과 동일, 버전이 하나뿐이면 빈 문자열"
 
-#: ../src/external/lua-scripts/lib/dtutils/string.lua:877
+#: ../src/external/lua-scripts/lib/dtutils/string.lua:940
 #: ../src/gui/gtkentry.c:43
 msgid "$(VERSION.NAME) - version name from metadata"
 msgstr "$(VERSION.NAME) - 메타데이터의 버전 이름"
 
-#: ../src/external/lua-scripts/lib/dtutils/string.lua:878
+#: ../src/external/lua-scripts/lib/dtutils/string.lua:941
 #: ../src/gui/gtkentry.c:120
 msgid "$(DARKTABLE.VERSION) - current darktable version"
 msgstr "$(DARKTABLE.VERSION) - 현재 darktable 버전"
 
+#: ../src/external/lua-scripts/lib/dtutils/string.lua:942
+msgid "$(Xmp.darktable.version) - current darktable version"
+msgstr "$(Xmp.darktable.version) - 현재 darktable 버전"
+
 #. _("$(DARKTABLE.NAME) - darktable name"),  -- not implemented
-#: ../src/external/lua-scripts/lib/dtutils/string.lua:880
+#: ../src/external/lua-scripts/lib/dtutils/string.lua:944
 #: ../src/gui/gtkentry.c:45
-msgid "$(SEQUENCE[n,m]) - sequence number, n: number of digits, m: start number"
+msgid ""
+"$(SEQUENCE[n,m]) - sequence number, n: number of digits, m: start number"
 msgstr "$(SEQUENCE[n,m]) - 순서 번호, n: 자릿수, m: 시작 번호"
 
-#: ../src/external/lua-scripts/lib/dtutils/string.lua:881
+#: ../src/external/lua-scripts/lib/dtutils/string.lua:945
 #: ../src/gui/gtkentry.c:47
 msgid "$(WIDTH.SENSOR) - image sensor width"
 msgstr "$(WIDTH.SENSOR) - 이미지 센서 너비"
 
-#: ../src/external/lua-scripts/lib/dtutils/string.lua:882
+#: ../src/external/lua-scripts/lib/dtutils/string.lua:946
 #: ../src/gui/gtkentry.c:52
 msgid "$(HEIGHT.SENSOR) - image sensor height"
 msgstr "$(HEIGHT.SENSOR) - 이미지 센서 높이"
 
-#: ../src/external/lua-scripts/lib/dtutils/string.lua:883
+#: ../src/external/lua-scripts/lib/dtutils/string.lua:947
 #: ../src/gui/gtkentry.c:48
 msgid "$(WIDTH.RAW) - RAW image width"
 msgstr "$(WIDTH. RAW) - RAW 이미지 너비"
 
-#: ../src/external/lua-scripts/lib/dtutils/string.lua:884
+#: ../src/external/lua-scripts/lib/dtutils/string.lua:948
 #: ../src/gui/gtkentry.c:53
 msgid "$(HEIGHT.RAW) - RAW image height"
 msgstr "$(HEIGHT.RAW) - RAW 이미지 높이"
 
-#: ../src/external/lua-scripts/lib/dtutils/string.lua:885
+#: ../src/external/lua-scripts/lib/dtutils/string.lua:949
 #: ../src/gui/gtkentry.c:49
 msgid "$(WIDTH.CROP) - image width after crop"
 msgstr "$(WIDTH.CROP) - 자르기 후 이미지 너비"
 
-#: ../src/external/lua-scripts/lib/dtutils/string.lua:886
+#: ../src/external/lua-scripts/lib/dtutils/string.lua:950
 #: ../src/gui/gtkentry.c:54
 msgid "$(HEIGHT.CROP) - image height after crop"
 msgstr "$(HEIGHT.CROP) - 자르기 후 이미지 높이"
 
-#: ../src/external/lua-scripts/lib/dtutils/string.lua:887
+#: ../src/external/lua-scripts/lib/dtutils/string.lua:951
 #: ../src/gui/gtkentry.c:50
 msgid "$(WIDTH.EXPORT) - exported image width"
 msgstr "$(WIDTH.EXPORT) - 내보낸 이미지 너비"
 
-#: ../src/external/lua-scripts/lib/dtutils/string.lua:888
+#: ../src/external/lua-scripts/lib/dtutils/string.lua:952
 #: ../src/gui/gtkentry.c:55
 msgid "$(HEIGHT.EXPORT) - exported image height"
 msgstr "$(HEIGHT.EXPORT) - 내보낸 이미지 높이"
 
 #. _("$(WIDTH.MAX) - maximum image export width"),  -- not implemented
 #. _("$(HEIGHT.MAX) - maximum image export height"),  -- not implemented
-#: ../src/external/lua-scripts/lib/dtutils/string.lua:891
+#: ../src/external/lua-scripts/lib/dtutils/string.lua:955
 #: ../src/gui/gtkentry.c:56
 msgid "$(YEAR) - year"
 msgstr "$(YEAR) - 년도"
 
-#: ../src/external/lua-scripts/lib/dtutils/string.lua:892
+#: ../src/external/lua-scripts/lib/dtutils/string.lua:956
 #: ../src/gui/gtkentry.c:57
 msgid "$(YEAR.SHORT) - year without century"
 msgstr "$(YEAR.SHORT) - 세기 없는 년도"
 
-#: ../src/external/lua-scripts/lib/dtutils/string.lua:893
+#: ../src/external/lua-scripts/lib/dtutils/string.lua:957
 #: ../src/gui/gtkentry.c:58
 msgid "$(MONTH) - month"
 msgstr "$(MONTH) - 월"
 
-#: ../src/external/lua-scripts/lib/dtutils/string.lua:894
+#: ../src/external/lua-scripts/lib/dtutils/string.lua:958
 #: ../src/gui/gtkentry.c:60
 msgid "$(MONTH.LONG) - full month name according to the current locale"
 msgstr "$(MONTH.LONG) - 현재 로케일에 따른 전체 월 이름"
 
-#: ../src/external/lua-scripts/lib/dtutils/string.lua:895
+#: ../src/external/lua-scripts/lib/dtutils/string.lua:959
 #: ../src/gui/gtkentry.c:59
 msgid "$(MONTH.SHORT) - abbreviated month name according to the current locale"
 msgstr "$(MONTH.SHORT) - 현재 로케일에 따른 축약된 월 이름"
 
-#: ../src/external/lua-scripts/lib/dtutils/string.lua:896
+#: ../src/external/lua-scripts/lib/dtutils/string.lua:960
 #: ../src/gui/gtkentry.c:61
 msgid "$(DAY) - day"
 msgstr "$(DAY) - 일"
 
-#: ../src/external/lua-scripts/lib/dtutils/string.lua:897
+#: ../src/external/lua-scripts/lib/dtutils/string.lua:961
 #: ../src/gui/gtkentry.c:62
 msgid "$(HOUR) - hour"
 msgstr "$(HOUR) - 시"
 
 #. _("$(HOUR.AMPM) - hour, 12-hour clock"),  -- not implemented
-#: ../src/external/lua-scripts/lib/dtutils/string.lua:899
+#: ../src/external/lua-scripts/lib/dtutils/string.lua:963
 #: ../src/gui/gtkentry.c:64
 msgid "$(MINUTE) - minute"
 msgstr "$(MINUTE) - 분"
 
-#: ../src/external/lua-scripts/lib/dtutils/string.lua:900
+#: ../src/external/lua-scripts/lib/dtutils/string.lua:964
 #: ../src/gui/gtkentry.c:65
 msgid "$(SECOND) - second"
 msgstr "$(SECOND) - 초"
 
-#: ../src/external/lua-scripts/lib/dtutils/string.lua:901
+#: ../src/external/lua-scripts/lib/dtutils/string.lua:965
 #: ../src/gui/gtkentry.c:66
 msgid "$(MSEC) - millisecond"
 msgstr "$(MSEC) - 밀리초"
 
-#: ../src/external/lua-scripts/lib/dtutils/string.lua:902
+#: ../src/external/lua-scripts/lib/dtutils/string.lua:966
 #: ../src/gui/gtkentry.c:69
 msgid "$(EXIF.YEAR) - EXIF year"
 msgstr "$(EXIF.YEAR) - EXIF 년도"
 
-#: ../src/external/lua-scripts/lib/dtutils/string.lua:903
+#: ../src/external/lua-scripts/lib/dtutils/string.lua:967
 #: ../src/gui/gtkentry.c:70
 msgid "$(EXIF.YEAR.SHORT) - EXIF year without century"
 msgstr "$(EXIF.YEAR.SHORT) - EXIF 세기 없는 년도"
 
-#: ../src/external/lua-scripts/lib/dtutils/string.lua:904
+#: ../src/external/lua-scripts/lib/dtutils/string.lua:968
 #: ../src/gui/gtkentry.c:71
 msgid "$(EXIF.MONTH) - EXIF month"
 msgstr "$(EXIF.MONTH) - EXIF 월"
 
-#: ../src/external/lua-scripts/lib/dtutils/string.lua:905
+#: ../src/external/lua-scripts/lib/dtutils/string.lua:969
 #: ../src/gui/gtkentry.c:73
-msgid "$(EXIF.MONTH.LONG) - full EXIF month name according to the current locale"
+msgid ""
+"$(EXIF.MONTH.LONG) - full EXIF month name according to the current locale"
 msgstr "$(EXIF.MONTH.LONG) - 현재 로케일에 따른 전체 EXIF 월 이름"
 
-#: ../src/external/lua-scripts/lib/dtutils/string.lua:906
+#: ../src/external/lua-scripts/lib/dtutils/string.lua:970
 #: ../src/gui/gtkentry.c:72
-msgid "$(EXIF.MONTH.SHORT) - abbreviated EXIF month name according to the current locale"
+msgid ""
+"$(EXIF.MONTH.SHORT) - abbreviated EXIF month name according to the current "
+"locale"
 msgstr "$(EXIF.MONTH.SHORT) - 현재 로케일에 따른 축약된 EXIF 월 이름"
 
-#: ../src/external/lua-scripts/lib/dtutils/string.lua:907
+#: ../src/external/lua-scripts/lib/dtutils/string.lua:971
 #: ../src/gui/gtkentry.c:74
 msgid "$(EXIF.DAY) - EXIF day"
 msgstr "$(EXIF.DAY) - EXIF 일"
 
-#: ../src/external/lua-scripts/lib/dtutils/string.lua:908
+#: ../src/external/lua-scripts/lib/dtutils/string.lua:972
 #: ../src/gui/gtkentry.c:75
 msgid "$(EXIF.HOUR) - EXIF hour"
 msgstr "$(EXIF.HOUR) - EXIF 시"
 
 #. _("$(EXIF.HOUR.AMPM) - EXIF hour, 12-hour clock") ..  "\n" .. -- not implemented
-#: ../src/external/lua-scripts/lib/dtutils/string.lua:910
+#: ../src/external/lua-scripts/lib/dtutils/string.lua:974
 #: ../src/gui/gtkentry.c:77
 msgid "$(EXIF.MINUTE) - EXIF minute"
 msgstr "$(EXIF.MINUTE) - EXIF 분"
 
-#: ../src/external/lua-scripts/lib/dtutils/string.lua:911
+#: ../src/external/lua-scripts/lib/dtutils/string.lua:975
 #: ../src/gui/gtkentry.c:78
 msgid "$(EXIF.SECOND) - EXIF second"
 msgstr "$(EXIF.SECOND) - EXIF 초"
 
-#: ../src/external/lua-scripts/lib/dtutils/string.lua:912
+#: ../src/external/lua-scripts/lib/dtutils/string.lua:976
 #: ../src/gui/gtkentry.c:79
 msgid "$(EXIF.MSEC) - EXIF millisecond"
 msgstr "$(EXIF.MSEC) - EXIF 밀리초"
 
 #. _("$(EXIF.DATE.REGIONAL) - localized EXIF date"),  -- not implemented
 #. _("$(EXIF.TIME.REGIONAL) - localized EXIF time"),  -- not implemented
-#: ../src/external/lua-scripts/lib/dtutils/string.lua:915
+#: ../src/external/lua-scripts/lib/dtutils/string.lua:979
 #: ../src/gui/gtkentry.c:80
 msgid "$(EXIF.ISO) - ISO value"
 msgstr "$(EXIF.ISO) - ISO 값"
 
-#: ../src/external/lua-scripts/lib/dtutils/string.lua:916
+#: ../src/external/lua-scripts/lib/dtutils/string.lua:980
 #: ../src/gui/gtkentry.c:83
 msgid "$(EXIF.EXPOSURE) - EXIF exposure"
 msgstr "$(EXIF.EXPOSURE) - EXIF 노출"
 
-#: ../src/external/lua-scripts/lib/dtutils/string.lua:917
+#: ../src/external/lua-scripts/lib/dtutils/string.lua:981
 #: ../src/gui/gtkentry.c:81
 msgid "$(EXIF.EXPOSURE.BIAS) - EXIF exposure bias"
 msgstr "$(EXIF.EXPOSURE) - EXIF 노출 바이어스"
 
 #. _("$(EXIF.EXPOSURE.PROGRAM) - EXIF exposure program"),  -- not implemented
-#: ../src/external/lua-scripts/lib/dtutils/string.lua:919
+#: ../src/external/lua-scripts/lib/dtutils/string.lua:983
 #: ../src/gui/gtkentry.c:84
 msgid "$(EXIF.APERTURE) - EXIF aperture"
 msgstr "$(EXIF.APERTURE) - EXIF 조리개"
 
-#: ../src/external/lua-scripts/lib/dtutils/string.lua:920
+#: ../src/external/lua-scripts/lib/dtutils/string.lua:984
 #: ../src/gui/gtkentry.c:85
 msgid "$(EXIF.CROP_FACTOR) - EXIF crop factor"
 msgstr "$(EXIF.CROP_FACTOR) - EXIF 크롭 계수"
 
-#: ../src/external/lua-scripts/lib/dtutils/string.lua:921
+#: ../src/external/lua-scripts/lib/dtutils/string.lua:985
 #: ../src/gui/gtkentry.c:86
 msgid "$(EXIF.FOCAL.LENGTH) - EXIF focal length"
 msgstr "$(EXIF.FOCAL.LENGTH) - EXIF 초점 길이"
 
-#: ../src/external/lua-scripts/lib/dtutils/string.lua:922
+#: ../src/external/lua-scripts/lib/dtutils/string.lua:986
 #: ../src/gui/gtkentry.c:87
 msgid "$(EXIF.FOCAL.LENGTH.EQUIV) - EXIF 35 mm equivalent focal length"
 msgstr "$(EXIF.FOCAL.LENGTH.EQUIV) - EXIF 35mm 환산 초점 길이"
 
-#: ../src/external/lua-scripts/lib/dtutils/string.lua:923
+#: ../src/external/lua-scripts/lib/dtutils/string.lua:987
 #: ../src/gui/gtkentry.c:88
 msgid "$(EXIF.FOCUS.DISTANCE) - EXIF focal distance"
 msgstr "$(EXIF.FOCUS.DISTANCE) - EXIF 초점 거리"
 
-#: ../src/external/lua-scripts/lib/dtutils/string.lua:924
+#: ../src/external/lua-scripts/lib/dtutils/string.lua:988
 #: ../src/gui/gtkentry.c:89
 msgid "$(EXIF.MAKER) - camera maker"
 msgstr "$(EXIF.MAKER) - 카메라 제조사"
 
-#: ../src/external/lua-scripts/lib/dtutils/string.lua:925
+#: ../src/external/lua-scripts/lib/dtutils/string.lua:989
 #: ../src/gui/gtkentry.c:90
 msgid "$(EXIF.MODEL) - camera model"
 msgstr "$(EXIF.MODEL) - 카메라 모델"
 
-#: ../src/external/lua-scripts/lib/dtutils/string.lua:926
+#: ../src/external/lua-scripts/lib/dtutils/string.lua:990
 #: ../src/gui/gtkentry.c:91
 msgid "$(EXIF.WHITEBALANCE) - EXIF selected white balance"
 msgstr "$(EXIF.WHITEBALANCE) - EXIF 선택된 화이트 밸런스"
 
 #. not implemented
-#: ../src/external/lua-scripts/lib/dtutils/string.lua:927
+#: ../src/external/lua-scripts/lib/dtutils/string.lua:991
 #: ../src/gui/gtkentry.c:92
 msgid "$(EXIF.METERING) - EXIF exposure metering mode"
 msgstr "$(EXIF.METERING) - EXIF 노출 측광 모드"
 
 #. not implemented
-#: ../src/external/lua-scripts/lib/dtutils/string.lua:928
+#: ../src/external/lua-scripts/lib/dtutils/string.lua:992
 #: ../src/gui/gtkentry.c:93
 msgid "$(EXIF.LENS) - lens"
 msgstr "$(EXIF.LENS) - 렌즈"
 
 #. _("$(EXIF.FLASH.ICON) - icon indicating whether flash was used") ..  -- not implemented
-#: ../src/external/lua-scripts/lib/dtutils/string.lua:930
+#: ../src/external/lua-scripts/lib/dtutils/string.lua:994
 #: ../src/gui/gtkentry.c:95
 msgid "$(EXIF.FLASH) - was flash used (yes/no/--)"
 msgstr "$(EXIF.FLASH) - 플래시 사용 여부 (예/아니오/--)"
@@ -10764,81 +11838,101 @@ msgstr "$(EXIF.FLASH) - 플래시 사용 여부 (예/아니오/--)"
 #. _("$(GPS.LATITUDE) - latitude"),-- not implemented
 #. _("$(GPS.ELEVATION) - elevation"),-- not implemented
 #. _("$(GPS.LOCATION.ICON) - icon indicating whether GPS location is known"),-- not implemented
-#: ../src/external/lua-scripts/lib/dtutils/string.lua:935
+#: ../src/external/lua-scripts/lib/dtutils/string.lua:999
 #: ../src/gui/gtkentry.c:100
 msgid "$(LONGITUDE) - longitude"
 msgstr "$(LONGITUDE) - 경도"
 
-#: ../src/external/lua-scripts/lib/dtutils/string.lua:936
+#: ../src/external/lua-scripts/lib/dtutils/string.lua:1000
 #: ../src/gui/gtkentry.c:101
 msgid "$(LATITUDE) - latitude"
 msgstr "$(LATITUDE) - 위도"
 
-#: ../src/external/lua-scripts/lib/dtutils/string.lua:937
+#: ../src/external/lua-scripts/lib/dtutils/string.lua:1001
 #: ../src/gui/gtkentry.c:102
 msgid "$(ELEVATION) - elevation"
 msgstr "$(ELEVATION) - 고도"
 
-#: ../src/external/lua-scripts/lib/dtutils/string.lua:938
+#: ../src/external/lua-scripts/lib/dtutils/string.lua:1002
 #: ../src/gui/gtkentry.c:103
 msgid "$(STARS) - star rating as number (-1 for rejected)"
 msgstr "$(STARS) - 별점 등급을 숫자로 표시 (제외된 이미지는 -1)"
 
 #. _("$(RATING.ICONS) - star/reject rating in icon form"),-- not implemented
-#: ../src/external/lua-scripts/lib/dtutils/string.lua:940
+#: ../src/external/lua-scripts/lib/dtutils/string.lua:1004
 #: ../src/gui/gtkentry.c:105
 msgid "$(LABELS) - color labels as text"
 msgstr "$(LABELS) - 색상 레이블을 텍스트로 표시"
 
 #. _("$(LABELS.ICONS) - color labels as icons"),-- not implemented
-#: ../src/external/lua-scripts/lib/dtutils/string.lua:942
+#: ../src/external/lua-scripts/lib/dtutils/string.lua:1006
 msgid "$(TITLE) - title from metadata"
 msgstr "$(TITLE) - 메타데이터의 제목"
 
-#: ../src/external/lua-scripts/lib/dtutils/string.lua:943
+#: ../src/external/lua-scripts/lib/dtutils/string.lua:1007
+msgid "$(Xmp.dc.title) - title from metadata"
+msgstr "$(Xmp.dc.title) - 메타데이터의 제목"
+
+#: ../src/external/lua-scripts/lib/dtutils/string.lua:1008
 msgid "$(DESCRIPTION) - description from metadata"
 msgstr "$(DESCRIPTION) - 메타데이터의 설명"
 
-#: ../src/external/lua-scripts/lib/dtutils/string.lua:944
+#: ../src/external/lua-scripts/lib/dtutils/string.lua:1009
+msgid "$(Xmp.dc.description) - description from metadata"
+msgstr "$(Xmp.dc.description) - 메타데이터의 설명"
+
+#: ../src/external/lua-scripts/lib/dtutils/string.lua:1010
 msgid "$(CREATOR) - creator from metadata"
 msgstr "$(CREATOR) - 메타데이터의 저작자"
 
-#: ../src/external/lua-scripts/lib/dtutils/string.lua:945
+#: ../src/external/lua-scripts/lib/dtutils/string.lua:1011
+msgid "$(Xmp.dc.creator) - creator from metadata"
+msgstr "$(Xmp.dc.creator) - 메타데이터의 작성자"
+
+#: ../src/external/lua-scripts/lib/dtutils/string.lua:1012
 msgid "$(PUBLISHER) - publisher from metadata"
 msgstr "$(PUBLISHER) - 메타데이터의 발행자"
 
-#: ../src/external/lua-scripts/lib/dtutils/string.lua:946
+#: ../src/external/lua-scripts/lib/dtutils/string.lua:1013
+msgid "$(Xmp.dc.publisher) - publisher from metadata"
+msgstr "$(Xmp.dc.publisher) - 메타데이터의 발행자"
+
+#: ../src/external/lua-scripts/lib/dtutils/string.lua:1014
 msgid "$(RIGHTS) - rights from metadata"
 msgstr "$(RIGHTS) - 메타데이터의 권리"
 
+#: ../src/external/lua-scripts/lib/dtutils/string.lua:1015
+msgid "$(Xmp.dc.rights) - rights from metadata"
+msgstr "$(Xmp.dc.rights) - 메타데이터의 저작권 정보"
+
 #. _("$(TAGS) - tags as set in metadata settings"),
-#: ../src/external/lua-scripts/lib/dtutils/string.lua:948
+#: ../src/external/lua-scripts/lib/dtutils/string.lua:1017
 #: ../src/gui/gtkentry.c:117
 msgid "$(CATEGORY[n,category]) - subtag of level n in hierarchical tags"
 msgstr "$(CATEGORY[n,category]) - 계층적 태그에서 레벨 n의 하위 태그"
 
-#: ../src/external/lua-scripts/lib/dtutils/string.lua:949
+#: ../src/external/lua-scripts/lib/dtutils/string.lua:1018
 #: ../src/gui/gtkentry.c:121
 msgid "$(SIDECAR_TXT) - contents of .txt sidecar file, if present"
 msgstr "$(SIDECAR_TXT) - 존재하는 경우, .txt 사이드카 파일의 내용"
 
-#: ../src/external/lua-scripts/lib/dtutils/string.lua:950
+#: ../src/external/lua-scripts/lib/dtutils/string.lua:1019
 #: ../src/gui/gtkentry.c:113
 msgid "$(FOLDER.PICTURES) - pictures folder"
 msgstr "$(FOLDER.PICTURES) - 사진 폴더"
 
-#: ../src/external/lua-scripts/lib/dtutils/string.lua:951
+#: ../src/external/lua-scripts/lib/dtutils/string.lua:1020
 #: ../src/gui/gtkentry.c:114
 msgid "$(FOLDER.HOME) - home folder"
 msgstr "$(FOLDER.HOME) - 홈 폴더"
 
-#: ../src/external/lua-scripts/lib/dtutils/string.lua:952
+#: ../src/external/lua-scripts/lib/dtutils/string.lua:1021
 #: ../src/gui/gtkentry.c:115
 msgid "$(FOLDER.DESKTOP) - desktop folder"
 msgstr "$(FOLDER.DESKTOP) - 바탕 화면 폴더"
 
 #. _("$(OPENCL.ACTIVATED) - whether OpenCL is activated"),
-#: ../src/external/lua-scripts/lib/dtutils/string.lua:954
+#: ../src/external/lua-scripts/lib/dtutils/string.lua:1023
 #: ../src/gui/gtkentry.c:112
 msgid "$(USERNAME) - login name"
 msgstr "$(USERNAME) - 로그인 이름"
@@ -10850,7 +11944,11 @@ msgstr "$(USERNAME) - 로그인 이름"
 #. remove the var from the string
 #. string modifications
 #. replace the substitution variables in a string
+#. catch everything below 0.3 seconds
+#. catch 1/2, 1/3, ...
+#. catch 1/1.3, 1/1.6, ...
 #. change the encoding of the terminal to handle non-english characters in path
+#. otherwise, when the real command fails, script will still return "good" error code of chcp
 #. On Windows we don't need any command. (start e.g. has problems with spaces in the filename, even if we put quoter around them.) https://stackoverflow.com/questions/13691827/opening-file-with-spaces-in-windows-via-command-prompt
 #.
 #.
@@ -10889,8 +11987,12 @@ msgstr "$(USERNAME) - 로그인 이름"
 #.
 #. CHANGES
 #.
+#. 20251202 - fixed pattern matching bugs affecting Canon EOS R? series
+#. styles and styles being applied twice if images are reimported
+#.
+#. Added more debugging statements to pattern matching functions
+#.
 #. local df = require "lib/dtutils.file"
-#. local ds = require "lib/dtutils.string"
 #. local dtsys = require "lib/dtutils.system"
 #. local debug = require "darktable.debug"
 #. - - - - - - - - - - - - - - - - - - - - - - -
@@ -10912,12 +12014,12 @@ msgstr "$(USERNAME) - 로그인 이름"
 #. set to hide for libs since we can't destroy them commpletely yet
 #. how to restart the (lib) script after it's been hidden - i.e. make it visible again
 #. only required for libs since the destroy_method only hides them
-#: ../src/external/lua-scripts/official/apply_camera_style.lua:92
+#: ../src/external/lua-scripts/official/apply_camera_style.lua:99
 msgid "apply camera style"
 msgstr "카메라 스타일 적용"
 
 #. name of script
-#: ../src/external/lua-scripts/official/apply_camera_style.lua:93
+#: ../src/external/lua-scripts/official/apply_camera_style.lua:100
 msgid "apply darktable camera style to matching images"
 msgstr "일치하는 이미지에 darktable 카메라 스타일 적용"
 
@@ -10952,7 +12054,9 @@ msgstr "일치하는 이미지에 darktable 카메라 스타일 적용"
 #. match a character
 #. handle EOS R case
 #. escape dashes
+#. make spaces optional
 #. until we end up with a set, I'll defer set processing, i.e. [...]
+#. log.msg(log.debug, "make spaces conditional again? pattern is " .. pattern)
 #. anchor the pattern to ensure we don't short match
 #. separate the styles into
 #.
@@ -10961,7 +12065,7 @@ msgstr "일치하는 이미지에 darktable 카메라 스타일 적용"
 #. styles {}
 #. patterns {}
 #. strip off the maker name
-#: ../src/external/lua-scripts/official/apply_camera_style.lua:377
+#: ../src/external/lua-scripts/official/apply_camera_style.lua:396
 msgid "applying camera styles to images"
 msgstr "이미지에 카메라 스타일 적용 중"
 
@@ -10977,14 +12081,165 @@ msgstr "이미지에 카메라 스타일 적용 중"
 #. - - - - - - - - - - - - - - - - - - - - - - -
 #. E V E N T S
 #. - - - - - - - - - - - - - - - - - - - - - - -
-#: ../src/external/lua-scripts/official/apply_camera_style.lua:470
+#: ../src/external/lua-scripts/official/apply_camera_style.lua:490
 msgid "apply darktable camera styles to collection"
 msgstr "컬렉션에 darktable 카메라 스타일 적용"
 
-#: ../src/external/lua-scripts/official/apply_camera_style.lua:476
+#: ../src/external/lua-scripts/official/apply_camera_style.lua:496
 msgid "apply darktable camera styles to selection"
 msgstr "선택 항목에 darktable 카메라 스타일 적용"
 
+#.
+#.
+#. auto_straighten.lua - straighten an image in darkroom using image metadata
+#.
+#. Copyright (C) 2025 Bill Ferguson <wpferguson@gmail.com>.
+#.
+#. This program is free software: you can redistribute it and/or modify
+#. it under the terms of the GNU General Public License as published by
+#. the Free Software Foundation; either version 3 of the License, or
+#. (at your option) any later version.
+#.
+#. This program is distributed in the hope that it will be useful,
+#. but WITHOUT ANY WARRANTY; without even the implied warranty of
+#. MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#. GNU General Public License for more details.
+#.
+#. You should have received a copy of the GNU General Public License
+#. along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#.
+#.
+#. auto_straighten - straighten an image in darkroom using image metadata
+#.
+#. auto_straighten reads the roll and pitch angle imformation captured when
+#. an image is captured.  A correction is computed and applied to correct the
+#. roll to the nearest vertical or horizontal axis using the rotate and
+#. perspective module.
+#.
+#. ADDITIONAL SOFTWARE NEEDED FOR THIS SCRIPT
+#. exiftool - https://exiftool.org
+#.
+#. USAGE
+#. * add it sowewhere in your scripts directory
+#. * ensure exiftool is installed and accessible
+#. * enable it using script manager
+#.
+#. BUGS, COMMENTS, SUGGESTIONS
+#. Bill Ferguson <wpferguson@gmail.com>
+#.
+#. CHANGES
+#.
+#. LIMITATIONS
+#. * Roll and pitch angles are taken when an image is captured.  If you shoot
+#. in burst mode, the roll and pitch angles of the first image are used in
+#. the rest of the burst (at least for Canon).
+#. * If you are running multiple scripts that trigger on an image being opened
+#. in darkroom then the auto crop may not work.  There is a shortcut included
+#. that can have a key sequence assigned so that the auto crop will be reapplied.
+#. * Currently oply roll angle is corrected
+#.
+#. LIEENSE
+#. GPL V2
+#.
+#. local da = require "lib/dtutils.action"
+#. local ds = require "lib/dtutils.string"
+#. local dtsys = require "lib/dtutils.system"
+#. local debug = require "darktable.debug"
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. C O N S T A N T S
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. path separator
+#. command separator
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. A P I  C H E C K
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. choose the minimum version that contains the features you need
+#. - - - - - - - - - - - - - - - - - - - - - - - - -
+#. I 1 8 N
+#. - - - - - - - - - - - - - - - - - - - - - - - - -
+#. - - - - - - - - - - - - - - - - - - - - - - - - -
+#. S C R I P T  M A N A G E R  I N T E G R A T I O N
+#. - - - - - - - - - - - - - - - - - - - - - - - - -
+#. function to destory the script
+#. set to hide for libs since we can't destroy them commpletely yet
+#. how to restart the (lib) script after it's been hidden - i.e. make it visible again
+#. only required for libs since the destroy_method only hides them
+#: ../src/external/lua-scripts/official/auto_straighten.lua:108
+msgid "auto_straighten"
+msgstr "auto_straighten"
+
+#. visible name of script
+#: ../src/external/lua-scripts/official/auto_straighten.lua:109
+msgid "straighten an image in darkroom using image metadata"
+msgstr "이미지 메타데이터를 사용하여 darkroom에서 이미지 수평 맞추기"
+
+#. purpose of script
+#. your name and optionally e-mail address
+#. URL to help/documentation
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. L O G  L E V E L
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. N A M E  S P A C E
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. G L O B A L  V A R I A B L E S
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. P R E F E R E N C E S
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#: ../src/external/lua-scripts/official/auto_straighten.lua:138
+msgid "automatic_cropping"
+msgstr "자동 자르기"
+
+#: ../src/external/lua-scripts/official/auto_straighten.lua:139
+msgid "what automatic cropping to perform"
+msgstr "수행할 자동 자르기 방식"
+
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. A L I A S E S
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. F U N C T I O N S
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#.
+#. Canon camera roll angle is as foillows
+#. * landscape orientation camera upright = 0
+#. * camera rolled to the left (shutter button up) portrait = -90
+#. * camera inverted landscape = +/- 180
+#. * camera rolled to the right (shutter button down) portrait = 90
+#.
+#. rotate and perspective corrections
+#. * rotate the image to the right is a negative correction
+#. * rotate the image left is a positive correction
+#.
+#. landscape
+#. roll left portrait
+#. inverted landscape
+#. roll right portrait
+#. Roll Angle 0 is landscape, -90 is rolled to the left in portrait, +- 180 is landscape inverted, 90 is portrait rolled to the right
+#. check for Nidon and change the sign
+#. dt.gui.action("iop/ashift/automatic cropping", "selection", "item:" .. crop, 1.000)
+#. da.wait_until_pixelpipe_complete()
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. M A I N  P R O G R A M
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#: ../src/external/lua-scripts/official/auto_straighten.lua:249
+msgid "exiftool not found, exiting..."
+msgstr "exiftool을 찾을 수 없습니다. 종료합니다..."
+
+#. da.register_events(MODULE, straighten_image)
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. U S E R  I N T E R F A C E
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. D A R K T A B L E  I N T E G R A T I O N
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. E V E N T S
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. -[[
+#. ]]
 #.
 #. This file is part of darktable,
 #. copyright (c) 2015 Tobias Ellinghaus
@@ -11095,7 +12350,8 @@ msgid "copy paste metadata"
 msgstr "메타데이터 복사 및 붙여넣기"
 
 #: ../src/external/lua-scripts/official/copy_paste_metadata.lua:44
-msgid "adds keyboard shortcuts and buttons to copy/paste metadata between images"
+msgid ""
+"adds keyboard shortcuts and buttons to copy/paste metadata between images"
 msgstr "이미지 간 메타데이터 복사/붙여넣기를 위한 단축키 및 버튼 추가"
 
 #. function to destory the script
@@ -11271,7 +12527,9 @@ msgid "exposure mu"
 msgstr "노출 mu"
 
 #: ../src/external/lua-scripts/official/enfuse.lua:139
-msgid "center also known as mean of gaussian weighting function (0 <= mean <= 1); default: 0.5"
+msgid ""
+"center also known as mean of gaussian weighting function (0 <= mean <= 1); "
+"default: 0.5"
 msgstr "중심은 가우시안 가중치 함수의 평균이라고도 합니다(0 <= 평균 <= 1); 기본값: 0.5"
 
 #: ../src/external/lua-scripts/official/enfuse.lua:147
@@ -11279,7 +12537,9 @@ msgid "exposure optimum"
 msgstr "최적 노출"
 
 #: ../src/external/lua-scripts/official/enfuse.lua:148
-msgid "optimum exposure value, usually the maximum of the weighting function (0 <= optimum <=1); default 0.5"
+msgid ""
+"optimum exposure value, usually the maximum of the weighting function (0 <= "
+"optimum <=1); default 0.5"
 msgstr "최적 노출 값, 일반적으로 가중 함수의 최대값 (0 <= 최적값 <= 1); 기본값: 0.5"
 
 #: ../src/external/lua-scripts/official/enfuse.lua:157
@@ -11367,6 +12627,228 @@ msgstr "enfuse 실행 파일을 찾을 수 없습니다, enfuse 내보내기를 
 #. vim: shiftwidth=2 expandtab tabstop=2 cindent syntax=lua
 #. kate: hl Lua;
 #.
+#.
+#. extract_burst_roll_images.lua - extract burst images from a burst roll file
+#.
+#. Copyright (C) 2026 Bill Ferguson <wpferguson@gmail.com>.
+#.
+#. This program is free software: you can redistribute it and/or modify
+#. it under the terms of the GNU General Public License as published by
+#. the Free Software Foundation; either version 3 of the License, or
+#. (at your option) any later version.
+#.
+#. This program is distributed in the hope that it will be useful,
+#. but WITHOUT ANY WARRANTY; without even the implied warranty of
+#. MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#. GNU General Public License for more details.
+#.
+#. You should have received a copy of the GNU General Public License
+#. along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#.
+#.
+#. extract_burst_roll_images - extract burst images from a burst roll file
+#.
+#. Canon cameras are capable of shooting in burst mode.  When the shutter
+#. button is half pressed the camera starts "recording".  When the shutter is
+#. fully pressed the pervious 1/2 second of imformation is recorded as individual
+#. images stored in one file as well as images captured at 30 frames/sec until
+#. the buffer fills or the shutter button is released.  So a Canon R7 burst file
+#. could contain ~90 images.
+#.
+#. Extracting the images from this file required use of Canon proprietary software
+#. until recently when dnglab got the capability to extract the embedded images as
+#. DNG raws.
+#.
+#. This script can be set to run on import, scanning for burst roll containers,
+#. extracting the embedded images and grouping them with the burst roll container.
+#. The script can alsu be utilized via a short cut and applied to selected images.
+#.
+#. When set to on import the script scans each image after import using exiv2 or exiftool
+#. to check the image EXIF information to see if the file is a busrt roll container.
+#. Once the import images are scanned, the detected burst roll containers are processed,
+#. the embedded images extracted as DNSs, and grouped with the container image.
+#.
+#. In shortcut mode the user selects the burst roll containers manually and uses the shortcut
+#. to extract the embedded images as DNGs
+#.
+#. ADDITIONAL SOFTWARE NEEDED FOR THIS SCRIPT
+#. - exiv2 - https://exiv2.org
+#. - exiftool - https://exiftool.org
+#. - dnglab - https://github.com/dnglab/dnglab
+#.
+#. USAGE
+#. - add the script to your lua scripts
+#. - enable in script manager
+#. - set the preferences in perferences->Lua options
+#.
+#. LIMITATIONS
+#. extract_burst_roll_images makes heavy use of external programs to identify burst roll
+#. containters and to extract the images.  Windows users may want to use it in shortcut mode
+#. to lessen the number of windows popping up.
+#.
+#. BUGS, COMMENTS, SUGGESTIONS
+#. Bill Ferguson <wpferguson@gmail.com>
+#.
+#. CHANGES
+#.
+#. local debug = require "darktable.debug"
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. A P I  C H E C K
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. choose the minimum version that contains the features you need
+#. - - - - - - - - - - - - - - - - - - - - - - - - -
+#. I 1 8 N
+#. - - - - - - - - - - - - - - - - - - - - - - - - -
+#. - - - - - - - - - - - - - - - - - - - - - - - - -
+#. S C R I P T  M A N A G E R  I N T E G R A T I O N
+#. - - - - - - - - - - - - - - - - - - - - - - - - -
+#. function to destory the script
+#. set to hide for libs since we can't destroy them commpletely yet
+#. how to restart the (lib) script after it's been hidden - i.e. make it visible again
+#. only required for libs since the destroy_method only hides them
+#: ../src/external/lua-scripts/official/extract_burst_roll_images.lua:106
+#: ../src/external/lua-scripts/official/extract_burst_roll_images.lua:494
+msgid "extract burst roll images"
+msgstr "버스트 롤 이미지 추출"
+
+#. visible name of script
+#: ../src/external/lua-scripts/official/extract_burst_roll_images.lua:107
+msgid "extract burst images from a burst roll file"
+msgstr "버스트 롤 파일에서 버스트 이미지 추출"
+
+#. purpose of script
+#. your name and optionally e-mail address
+#. URL to help/documentation
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. C O N S T A N T S
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. path separator
+#. command separator
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. L O G  L E V E L
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. N A M E  S P A C E
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. G L O B A L  V A R I A B L E S
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. P R E F E R E N C E S
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. exiv2 or exiftool
+#. script: This is a string used to avoid name collision in preferences (i.e namespace). Set it to something unique, usually the name of the script handling the preference.
+#. name
+#. type
+#: ../src/external/lua-scripts/official/extract_burst_roll_images.lua:168
+msgid "preferred exif tag reader"
+msgstr "선호하는 EXIF 태그 리더"
+
+#. label
+#: ../src/external/lua-scripts/official/extract_burst_roll_images.lua:169
+msgid "use exiftool or exiv2 to read exif tags"
+msgstr "EXIF 태그를 읽는 데 exiftool 또는 exiv2 사용"
+
+#. tooltip
+#. default
+#. values
+#. run on import
+#. script: This is a string used to avoid name collision in preferences (i.e namespace). Set it to something unique, usually the name of the script handling the preference.
+#. name
+#. type
+#. label
+#: ../src/external/lua-scripts/official/extract_burst_roll_images.lua:177
+#: ../src/external/lua-scripts/official/extract_burst_roll_images.lua:178
+msgid "extract burst roll images on import"
+msgstr "가져올 때 버스트 롤 이미지 추출"
+
+#. tooltip
+#. default
+#. display selection button
+#. script: This is a string used to avoid name collision in preferences (i.e namespace). Set it to something unique, usually the name of the script handling the preference.
+#. name
+#. type
+#: ../src/external/lua-scripts/official/extract_burst_roll_images.lua:185
+msgid "display select burst roll images button"
+msgstr "버스트 롤 이미지 선택 버튼 표시"
+
+#. label
+#: ../src/external/lua-scripts/official/extract_burst_roll_images.lua:186
+msgid "add a button to the select module to select burst roll images"
+msgstr "버스트 롤 이미지를 선택하는 버튼을 선택 모듈에 추가"
+
+#. tooltip
+#. default
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. A L I A S E S
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. F U N C T I O N S
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. -----------------
+#. helper functions
+#. -----------------
+#. skip blank lines created by forfiles
+#: ../src/external/lua-scripts/official/extract_burst_roll_images.lua:332
+#, lua-format
+msgid "extracted %d dng files from %s"
+msgstr "%d개의 DNG 파일을 %s에서 추출하였습니다"
+
+#: ../src/external/lua-scripts/official/extract_burst_roll_images.lua:372
+#: ../src/external/lua-scripts/official/extract_burst_roll_images.lua:390
+msgid "scanning for burst roll images"
+msgstr "버스트 롤 이미지 검색 중"
+
+#: ../src/external/lua-scripts/official/extract_burst_roll_images.lua:407
+msgid "extracting burst roll images"
+msgstr "버스트 롤 이미지 추출 중"
+
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. M A I N  P R O G R A M
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#: ../src/external/lua-scripts/official/extract_burst_roll_images.lua:457
+msgid "dnglab executable not found"
+msgstr "dnglab 실행 파일을 찾을 수 없습니다"
+
+#: ../src/external/lua-scripts/official/extract_burst_roll_images.lua:458
+msgid ": dnglab executable not found, exiting..."
+msgstr ": dnglab 실행 파일을 찾을 수 없습니다. 종료합니다..."
+
+#: ../src/external/lua-scripts/official/extract_burst_roll_images.lua:466
+msgid "no exif tag reader available"
+msgstr "사용 가능한 EXIF 태그 리더가 없습니다"
+
+#: ../src/external/lua-scripts/official/extract_burst_roll_images.lua:467
+msgid " no exif tag reader available, exiting..."
+msgstr " 사용 가능한 EXIF 태그 리더가 없습니다. 종료합니다..."
+
+#: ../src/external/lua-scripts/official/extract_burst_roll_images.lua:475
+#, lua-format
+msgid " selected tag reader %s not available"
+msgstr " 선택한 태그 리더 %s을(를) 사용할 수 없습니다"
+
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. U S E R  I N T E R F A C E
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#: ../src/external/lua-scripts/official/extract_burst_roll_images.lua:488
+msgid "select burst roll images"
+msgstr "버스트 롤 이미지 선택"
+
+#: ../src/external/lua-scripts/official/extract_burst_roll_images.lua:489
+msgid "select burst roll image containers"
+msgstr "버스트 롤 이미지 컨테이너 선택"
+
+#: ../src/external/lua-scripts/official/extract_burst_roll_images.lua:498
+msgid "extract and group burst roll images with container"
+msgstr "버스트 롤 이미지를 추출하여 컨테이너와 함께 그룹화"
+
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. D A R K T A B L E  I N T E G R A T I O N
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. E V E N T S
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#.
 #. This file is part of darktable,
 #. copyright (c) 2014 Tobias Ellinghaus
 #.
@@ -11418,7 +12900,9 @@ msgid "create txt sidecars to display with images"
 msgstr "이미지와 함께 표시할 txt 사이드카 생성"
 
 #: ../src/external/lua-scripts/official/generate_image_txt.lua:69
-msgid "the txt files created get shown when the lighttable is zoomed in to one image. also enable the txt overlay setting in the gui tab"
+msgid ""
+"the txt files created get shown when the lighttable is zoomed in to one "
+"image. also enable the txt overlay setting in the gui tab"
 msgstr "생성된 txt 파일은 lighttable에서 한 이미지로 확대될 때 표시됩니다. 또한 GUI 탭에서 txt 오버레이 설정을 활성화하세요"
 
 #: ../src/external/lua-scripts/official/generate_image_txt.lua:75
@@ -11426,7 +12910,9 @@ msgid "command to generate the txt sidecar"
 msgstr "txt 사이드카 생성 명령"
 
 #: ../src/external/lua-scripts/official/generate_image_txt.lua:76
-msgid "the output of this command gets written to the txt file. use $(FILE_NAME) for the image file"
+msgid ""
+"the output of this command gets written to the txt file. use $(FILE_NAME) "
+"for the image file"
 msgstr "이 명령에 대한 출력은 txt 파일에 저장됩니다. 이미지 파일에 대해 $(FILE_NAME)을 사용하세요"
 
 #: ../src/external/lua-scripts/official/generate_image_txt.lua:82
@@ -11443,6 +12929,162 @@ msgstr "txt 사이드카 명령에 문제가 있는 것 같습니다. 환경설�
 #. finally, run it
 #. vim: shiftwidth=2 expandtab tabstop=2 cindent
 #. kate: tab-indents: off; indent-width 2; replace-tabs on; remove-trailing-space on;
+#.
+#.
+#. group_persistence.lua - preserve groups between darktable instances
+#.
+#. Copyright (C) 2024-2026 Bill Ferguson <wpferguson@gmail.com>.
+#.
+#. This program is free software: you can redistribute it and/or modify
+#. it under the terms of the GNU General Public License as published by
+#. the Free Software Foundation; either version 3 of the License, or
+#. (at your option) any later version.
+#.
+#. This program is distributed in the hope that it will be useful,
+#. but WITHOUT ANY WARRANTY; without even the implied warranty of
+#. MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#. GNU General Public License for more details.
+#.
+#. You should have received a copy of the GNU General Public License
+#. along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#.
+#.
+#. group_persistence - preserve groups between darktable instances
+#.
+#. group_persistence uses "functional" tagging to maintain image groups
+#. across database instances, allowing image grouping to be restored when
+#. the database is rebuilt from the XMP sidecar files.
+#.
+#. Once the script is started it "listens" for changes in image grouping and
+#. applies or removes the necessary tags automatically.
+#.
+#. A shortcut can be assigned to read a collection and apply the necessary
+#. grouping tags so that existing collections can be maintained.
+#.
+#. If the database is lost and needs to be rebuilt then start the script before
+#. importing any images.  As images are imported the tags will be read and the
+#. grouping applied in the database.
+#.
+#. ADDITIONAL SOFTWARE NEEDED FOR THIS SCRIPT
+#.
+#. None
+#.
+#. USAGE
+#.
+#. * Enable the script using script manager
+#. * Optionally, create a keystroke combination for the shortcut
+#.
+#. LIMITATIONS
+#.
+#. In normal use you wont notice that the script is running.
+#.
+#. However if you do something like import 4000+ images, then
+#. run the autogrouper script to create groups whenever there is
+#. a 5 second difference between 2 images, your system will be busy
+#. for awhile.  If for some reason you need to do something like this
+#. turn off group_persistence, run the autogrouper, turn on group_persistence
+#. and use the shortcut to read all the grouping information and apply
+#. the necessary tags.  It will still be an impact, but less than trying
+#. to do both at once.  Learned from experience :-)
+#.
+#. BUGS, COMMENTS, SUGGESTIONS
+#. Bill Ferguson <wpferguson@gmail.com>
+#.
+#. CHANGES
+#.
+#. local df = require "lib/dtutils.file"
+#. local ds = require "lib/dtutils.string"
+#. local dtsys = require "lib/dtutils.system"
+#. local debug = require "darktable.debug"
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. C O N S T A N T S
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. path separator
+#. command separator
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. A P I  C H E C K
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. choose the minimum version that contains the features you need
+#. - - - - - - - - - - - - - - - - - - - - - - - - -
+#. I 1 8 N
+#. - - - - - - - - - - - - - - - - - - - - - - - - -
+#. - - - - - - - - - - - - - - - - - - - - - - - - -
+#. S C R I P T  M A N A G E R  I N T E G R A T I O N
+#. - - - - - - - - - - - - - - - - - - - - - - - - -
+#. function to destory the script
+#. set to hide for libs since we can't destroy them commpletely yet
+#. how to restart the (lib) script after it's been hidden - i.e. make it visible again
+#. only required for libs since the destroy_method only hides them
+#: ../src/external/lua-scripts/official/group_persistence.lua:120
+msgid "group persistence"
+msgstr "그룹 유지"
+
+#. name of script
+#: ../src/external/lua-scripts/official/group_persistence.lua:121
+msgid "preserve groups between darktable instances"
+msgstr "darktable 인스턴스 간에 그룹 유지"
+
+#. purpose of script
+#. your name and optionally e-mail address
+#. URL to help/documentation
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. L O G  L E V E L
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. N A M E  S P A C E
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. A L I A S E S
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. G L O B A L  V A R I A B L E S
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. table of imported images that need grouping rebuilt
+#. uuid to group leader mapping
+#. group leader to uuid mapping
+#. uuid to group tag mapping
+#. uuid to group leader tag mapping
+#. when the groups are rebuilt after import they
+#. cause the group change events to fire but the
+#. events are queued until after rebuilding completes
+#. so we need to build a table of images to ignore when
+#. the queued events catch up.  As the event fires for an
+#. image, the image is removed.
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. P R E F E R E N C E S
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. F U N C T I O N S
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. utilities for building/debugging
+#. rebuild grouping on import
+#. rebuild grouping on command (shortcut)
+#. handle grouping changes in the UI
+#. tag image as group leader
+#. create the uuid and leader/group tags if necessary
+#. add an image to a group
+#. create the group if necessary
+#. handle duplicate getting deleted
+#. there's either 1 or 0, so no group
+#. remove image group leader tag
+#. if it's the last image, then remove the leader/group tags
+#. remove an image from a group
+#. if it's the last image then remove the tags
+#. image.id > group_leder.id - simple remove
+#. image.id < group_leader.id - deleting old group_leader (image) with new group_leader (group_leader)
+#. remove the group leader tag from the old leader
+#. replace the old group leader tag with a group tag
+#. add the group leader tag to the new image
+#. event handling
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. M A I N  P R O G R A M
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. D A R K T A B L E  I N T E G R A T I O N
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. E V E N T S
+#. - - - - - - - - - - - - - - - - - - - - - - -
 #.
 #. This file is part of darktable,
 #. copyright (c) 2014 Jérémy Rosen
@@ -11610,6 +13252,247 @@ msgstr "가져오기 필터링"
 #. vim: shiftwidth=2 expandtab tabstop=2 cindent
 #. kate: tab-indents: off; indent-width 2; replace-tabs on; remove-trailing-space on;
 #.
+#.
+#. recent_bookmarks.lua - add recently edited and exported images to system recent bookmarks
+#.
+#. Copyright (C) 2026 Bill Ferguson <wpferguson@gmail.com>.
+#.
+#. This program is free software: you can redistribute it and/or modify
+#. it under the terms of the GNU General Public License as published by
+#. the Free Software Foundation; either version 3 of the License, or
+#. (at your option) any later version.
+#.
+#. This program is distributed in the hope that it will be useful,
+#. but WITHOUT ANY WARRANTY; without even the implied warranty of
+#. MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#. GNU General Public License for more details.
+#.
+#. You should have received a copy of the GNU General Public License
+#. along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#.
+#.
+#. recent_bookmarks - add recently edited and exported images to system recently used files
+#.
+#. recent_bookmarks adds images edited in darktable and the directory of images exported from
+#. darktable to the reccently-used.xbel file so that they show up in the recently used system
+#. shortcuts.
+#.
+#. Currently recent_bookmarks only works on Linux
+#.
+#. ADDITIONAL SOFTWARE NEEDED FOR THIS SCRIPT
+#.
+#. file - linux system file utility to get mime-type
+#.
+#. USAGE
+#.
+#. eanble from script manager
+#.
+#. BUGS, COMMENTS, SUGGESTIONS
+#. Bill Ferguson <wpferguson@gmail.com>
+#.
+#. CHANGES
+#.
+#. local ds = require "lib/dtutils.string"
+#. local dtsys = require "lib/dtutils.system"
+#. local debug = require "darktable.debug"
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. A P I  C H E C K
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. choose the minimum version that contains the features you need
+#. - - - - - - - - - - - - - - - - - - - - - - - - -
+#. I 1 8 N
+#. - - - - - - - - - - - - - - - - - - - - - - - - -
+#. - - - - - - - - - - - - - - - - - - - - - - - - -
+#. S C R I P T  M A N A G E R  I N T E G R A T I O N
+#. - - - - - - - - - - - - - - - - - - - - - - - - -
+#. function to destory the script
+#. set to hide for libs since we can't destroy them commpletely yet
+#. how to restart the (lib) script after it's been hidden - i.e. make it visible again
+#. only required for libs since the destroy_method only hides them
+#: ../src/external/lua-scripts/official/recent_bookmarks.lua:82
+msgid "recent_bookmarks"
+msgstr "recent_bookmarks"
+
+#. visible name of script
+#: ../src/external/lua-scripts/official/recent_bookmarks.lua:83
+msgid "add recently edited and exported images to system recent bookmarks"
+msgstr "최근에 편집하고 내보낸 이미지를 시스템 최근 북마크에 추가"
+
+#. purpose of script
+#. your name and optionally e-mail address
+#. URL to help/documentation
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. C O N S T A N T S
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. path separator
+#. command separator
+#. format strings for writing the bookmarks
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. L O G  L E V E L
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. N A M E  S P A C E
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. G L O B A L  V A R I A B L E S
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. P R E F E R E N C E S
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. A L I A S E S
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. F U N C T I O N S
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. -----------------
+#. helper functions
+#. -----------------
+#. ------------------
+#. program functions
+#. ------------------
+#: ../src/external/lua-scripts/official/recent_bookmarks.lua:243
+#: ../src/external/lua-scripts/official/recent_bookmarks.lua:246
+msgid "failed to open bookmark file"
+msgstr "북마크 파일을 열지 못했습니다"
+
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. M A I N  P R O G R A M
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#: ../src/external/lua-scripts/official/recent_bookmarks.lua:275
+msgid " only  runs on Linux"
+msgstr " Linux에서만 실행됩니다"
+
+#: ../src/external/lua-scripts/official/recent_bookmarks.lua:281
+msgid "recent bookmarks file not found"
+msgstr "최근 북마크 파일을 찾을 수 없습니다"
+
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. U S E R  I N T E R F A C E
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. D A R K T A B L E  I N T E G R A T I O N
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. E V E N T S
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#.
+#.
+#. regenerate_thumbnails.lua - regenerate mipmap cache for selected images
+#.
+#. Copyright (C) 2025 Bill Ferguson <wpferguson@gmail.com>.
+#.
+#. This program is free software: you can redistribute it and/or modify
+#. it under the terms of the GNU General Public License as published by
+#. the Free Software Foundation; either version 3 of the License, or
+#. (at your option) any later version.
+#.
+#. This program is distributed in the hope that it will be useful,
+#. but WITHOUT ANY WARRANTY; without even the implied warranty of
+#. MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#. GNU General Public License for more details.
+#.
+#. You should have received a copy of the GNU General Public License
+#. along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#.
+#.
+#. regenerate_thumbnails - regenerate mipmap cache for selected images
+#.
+#. regenerate_thumbnails drops the cached thumbnail for each selected image
+#. and generates a new thumbnail.
+#.
+#. ADDITIONAL SOFTWARE NEEDED FOR THIS SCRIPT
+#. None
+#.
+#. USAGE
+#. * enable the script in script_manager
+#. * assign a shortcut, if desired, to apply the script by hovering
+#. over a skull and using the shortcut to regenerate the thumbnail
+#.
+#. BUGS, COMMENTS, SUGGESTIONS
+#. Bill Ferguson <wpferguson@gmail.com>
+#.
+#. CHANGES
+#.
+#. local df = require "lib/dtutils.file"
+#. local ds = require "lib/dtutils.string"
+#. local dtsys = require "lib/dtutils.system"
+#. local debug = require "darktable.debug"
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. A P I  C H E C K
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. choose the minimum version that contains the features you need
+#. - - - - - - - - - - - - - - - - - - - - - - - - -
+#. I 1 8 N
+#. - - - - - - - - - - - - - - - - - - - - - - - - -
+#. - - - - - - - - - - - - - - - - - - - - - - - - -
+#. S C R I P T  M A N A G E R  I N T E G R A T I O N
+#. - - - - - - - - - - - - - - - - - - - - - - - - -
+#. function to destory the script
+#. set to hide for libs since we can't destroy them commpletely yet
+#. how to restart the (lib) script after it's been hidden - i.e. make it visible again
+#. only required for libs since the destroy_method only hides them
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. D A R K T A B L E  I N T E G R A T I O N
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. E V E N T S
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#: ../src/external/lua-scripts/official/regenerate_thumbnails.lua:79
+#: ../src/external/lua-scripts/official/regenerate_thumbnails.lua:246
+msgid "regenerate thumbnails"
+msgstr "썸네일 재생성"
+
+#. visible name of script
+#: ../src/external/lua-scripts/official/regenerate_thumbnails.lua:80
+msgid "regenerate mipmap cache for selected images"
+msgstr "선택한 이미지의 밉맵 캐시 재생성"
+
+#. purpose of script
+#. your name and optionally e-mail address
+#. URL to help/documentation
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. C O N S T A N T S
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. path separator
+#. command separator
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. L O G  L E V E L
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. N A M E  S P A C E
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. G L O B A L  V A R I A B L E S
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. P R E F E R E N C E S
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. A L I A S E S
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. F U N C T I O N S
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. -----------------
+#. helper functions
+#. -----------------
+#: ../src/external/lua-scripts/official/regenerate_thumbnails.lua:176
+msgid "regenerating thumbnails"
+msgstr "썸네일 재생성 중"
+
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. M A I N  P R O G R A M
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. U S E R  I N T E R F A C E
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#: ../src/external/lua-scripts/official/regenerate_thumbnails.lua:215
+#: ../src/external/lua-scripts/official/regenerate_thumbnails.lua:219
+msgid "generate thumbnails"
+msgstr "썸네일 생성"
+
+#.
 #. This file is part of darktable,
 #. copyright (c) 2014 Jérémy Rosen
 #.
@@ -11674,6 +13557,623 @@ msgstr "선택 영역을 임시 버퍼와 교체"
 #.
 #. vim: shiftwidth=2 expandtab tabstop=2 cindent syntax=lua
 #.
+#.
+#. scheduler.lua - provide scheduler services for multitasking
+#.
+#. Copyright (C) 2024 Bill Ferguson <wpferguson@gmail.com>.
+#.
+#. This program is free software: you can redistribute it and/or modify
+#. it under the terms of the GNU General Public License as published by
+#. the Free Software Foundation; either version 3 of the License, or
+#. (at your option) any later version.
+#.
+#. This program is distributed in the hope that it will be useful,
+#. but WITHOUT ANY WARRANTY; without even the implied warranty of
+#. MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#. GNU General Public License for more details.
+#.
+#. You should have received a copy of the GNU General Public License
+#. along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#.
+#.
+#. scheduler - provide scheduler services for multitasking
+#.
+#. scheduler implements a sinple first in first out (FIFO) scheduler
+#. necessary for lua script multitasking.
+#.
+#. Scripts voluntarily yield to the scheduler and they are placed at
+#. the end of the run queue.  The first item in the run queue is told
+#. to resume.
+#.
+#. ADDITIONAL SOFTWARE NEEDED FOR THIS SCRIPT
+#. None
+#.
+#. USAGE
+#. start script from script_manager
+#.
+#. BUGS, COMMENTS, SUGGESTIONS
+#. Bill Ferguson <wpferguson@gmail.com>
+#.
+#. CHANGES
+#.
+#. local df = require "lib/dtutils.file"
+#. local ds = require "lib/dtutils.string"
+#. local dtsys = require "lib/dtutils.system"
+#. local debug = require "darktable.debug"
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. C O N S T A N T S
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. path separator
+#. command separator
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. A P I  C H E C K
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. choose the minimum version that contains the features you need
+#. - - - - - - - - - - - - - - - - - - - - - - - - -
+#. I 1 8 N
+#. - - - - - - - - - - - - - - - - - - - - - - - - -
+#. - - - - - - - - - - - - - - - - - - - - - - - - -
+#. S C R I P T  M A N A G E R  I N T E G R A T I O N
+#. - - - - - - - - - - - - - - - - - - - - - - - - -
+#. function to destory the script
+#. set to hide for libs since we can't destroy them commpletely yet
+#. how to restart the (lib) script after it's been hidden - i.e. make it visible again
+#. only required for libs since the destroy_method only hides them
+#: ../src/external/lua-scripts/official/scheduler.lua:98
+msgid "scheduler"
+msgstr "스케줄러"
+
+#. name of script
+#: ../src/external/lua-scripts/official/scheduler.lua:99
+msgid "provide scheduler services for multitasking"
+msgstr "멀티태스킹을 위한 스케줄러 서비스 제공"
+
+#. purpose of script
+#. your name and optionally e-mail address
+#. URL to help/documentation
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. L O G  L E V E L
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. N A M E  S P A C E
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. G L O B A L  V A R I A B L E S
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. P R E F E R E N C E S
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#: ../src/external/lua-scripts/official/scheduler.lua:130
+msgid "scheduler preferred time slice"
+msgstr "스케줄러 선호 시간 조각"
+
+#: ../src/external/lua-scripts/official/scheduler.lua:130
+msgid "target time slice before interrupt"
+msgstr "인터럽트 전 목표 시간 조각"
+
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. A L I A S E S
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. F U N C T I O N S
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. allow time for waiting scripts to start
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. M A I N  P R O G R A M
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. U S E R  I N T E R F A C E
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. D A R K T A B L E  I N T E G R A T I O N
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. put things to destroy (events, storages, etc) here
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. E V E N T S
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. do nothing
+#.
+#.
+#. select_duplicates.lua - select duplicate images from a collection
+#.
+#. Copyright (C) 2026 Bill Ferguson <wpferguson@gmail.com>.
+#.
+#. This program is free software: you can redistribute it and/or modify
+#. it under the terms of the GNU General Public License as published by
+#. the Free Software Foundation; either version 3 of the License, or
+#. (at your option) any later version.
+#.
+#. This program is distributed in the hope that it will be useful,
+#. but WITHOUT ANY WARRANTY; without even the implied warranty of
+#. MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#. GNU General Public License for more details.
+#.
+#. You should have received a copy of the GNU General Public License
+#. along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#.
+#.
+#. select_duplicates - select duplicate images from a collection
+#.
+#. select_duplicates adds a button to the select module to select
+#. duplicate images from a collection.  If the selection2collection
+#. script is also active an option is available to have the selected
+#. duplicates appear as a temporary collection.
+#.
+#. A shortcut is available to select the duplicates from the collection
+#. but it is somewhat slower because it doesn't have access to the current
+#. image cache and therfore has to open each image separately.
+#.
+#. ADDITIONAL SOFTWARE NEEDED FOR THIS SCRIPT
+#.
+#. None
+#.
+#. USAGE
+#.
+#. * enable in script manager
+#. * Press the button
+#.
+#. BUGS, COMMENTS, SUGGESTIONS
+#. Bill Ferguson <wpferguson@gmail.com>
+#.
+#. CHANGES
+#.
+#. local df = require "lib/dtutils.file"
+#. local ds = require "lib/dtutils.string"
+#. local dtsys = require "lib/dtutils.system"
+#. local debug = require "darktable.debug"
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. A P I  C H E C K
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. choose the minimum version that contains the features you need
+#. - - - - - - - - - - - - - - - - - - - - - - - - -
+#. I 1 8 N
+#. - - - - - - - - - - - - - - - - - - - - - - - - -
+#. - - - - - - - - - - - - - - - - - - - - - - - - -
+#. S C R I P T  M A N A G E R  I N T E G R A T I O N
+#. - - - - - - - - - - - - - - - - - - - - - - - - -
+#. function to destory the script
+#. set to hide for libs since we can't destroy them commpletely yet
+#. how to restart the (lib) script after it's been hidden - i.e. make it visible again
+#. only required for libs since the destroy_method only hides them
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. A L I A S E S
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. F U N C T I O N S
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. -----------------
+#. helper functions
+#. -----------------
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. M A I N  P R O G R A M
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. U S E R  I N T E R F A C E
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. D A R K T A B L E  I N T E G R A T I O N
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. E V E N T S
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. skip if shortcut already registered
+#: ../src/external/lua-scripts/official/select_duplicates.lua:86
+#: ../src/external/lua-scripts/official/select_duplicates.lua:238
+#: ../src/external/lua-scripts/official/select_duplicates.lua:262
+msgid "select duplicates"
+msgstr "복제본 선택"
+
+#. visible name of script
+#: ../src/external/lua-scripts/official/select_duplicates.lua:87
+msgid "select duplicate images from a collection"
+msgstr "컬렉션에서 복제 이미지 선택"
+
+#. purpose of script
+#. your name and optionally e-mail address
+#. URL to help/documentation
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. C O N S T A N T S
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. path separator
+#. command separator
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. L O G  L E V E L
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. N A M E  S P A C E
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. G L O B A L  V A R I A B L E S
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. P R E F E R E N C E S
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#: ../src/external/lua-scripts/official/select_duplicates.lua:131
+msgid " create collection from selection"
+msgstr " 선택 항목으로 컬렉션 생성"
+
+#: ../src/external/lua-scripts/official/select_duplicates.lua:132
+msgid "create collection of selected duplicates"
+msgstr "선택한 복제본으로 컬렉션 생성"
+
+#: ../src/external/lua-scripts/official/select_duplicates.lua:239
+msgid "select duplicated images"
+msgstr "복제된 이미지 선택"
+
+#.
+#.
+#. select_raw_non_raw.lua - select raw or non raw files from a collection
+#.
+#. Copyright (C) 2025 Bill Ferguson <wpferguson@gmail.com>.
+#.
+#. This program is free software: you can redistribute it and/or modify
+#. it under the terms of the GNU General Public License as published by
+#. the Free Software Foundation; either version 3 of the License, or
+#. (at your option) any later version.
+#.
+#. This program is distributed in the hope that it will be useful,
+#. but WITHOUT ANY WARRANTY; without even the implied warranty of
+#. MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#. GNU General Public License for more details.
+#.
+#. You should have received a copy of the GNU General Public License
+#. along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#.
+#.
+#. select_raw_non_raw - select raw or non raw files from a collection
+#.
+#. select_raw_non_raw adds two selection buttons, one to select raw
+#. images and one to select non raw images.
+#.
+#. ADDITIONAL SOFTWARE NEEDED FOR THIS SCRIPT
+#. None
+#.
+#. USAGE
+#. * enable the script with script_manager
+#.
+#. BUGS, COMMENTS, SUGGESTIONS
+#. Bill Ferguson <wpferguson@gmail.com>
+#.
+#. CHANGES
+#.
+#. local df = require "lib/dtutils.file"
+#. local ds = require "lib/dtutils.string"
+#. local dtsys = require "lib/dtutils.system"
+#. local debug = require "darktable.debug"
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. C O N S T A N T S
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. path separator
+#. command separator
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. A P I  C H E C K
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. choose the minimum version that contains the features you need
+#. - - - - - - - - - - - - - - - - - - - - - - - - -
+#. I 1 8 N
+#. - - - - - - - - - - - - - - - - - - - - - - - - -
+#. - - - - - - - - - - - - - - - - - - - - - - - - -
+#. S C R I P T  M A N A G E R  I N T E G R A T I O N
+#. - - - - - - - - - - - - - - - - - - - - - - - - -
+#. function to destory the script
+#. set to hide for libs since we can't destroy them commpletely yet
+#. how to restart the (lib) script after it's been hidden - i.e. make it visible again
+#. only required for libs since the destroy_method only hides them
+#: ../src/external/lua-scripts/official/select_raw_non_raw.lua:91
+msgid "select raw/non-raw"
+msgstr "RAW/비 RAW 선택"
+
+#. name of script
+#: ../src/external/lua-scripts/official/select_raw_non_raw.lua:92
+msgid "select raw or non raw files from collection"
+msgstr "컬렉션에서 RAW 또는 비 RAW 파일 선택"
+
+#. purpose of script
+#. your name and optionally e-mail address
+#. URL to help/documentation
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. L O G  L E V E L
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. N A M E  S P A C E
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. G L O B A L  V A R I A B L E S
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. P R E F E R E N C E S
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. A L I A S E S
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. F U N C T I O N S
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. M A I N  P R O G R A M
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. U S E R  I N T E R F A C E
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#: ../src/external/lua-scripts/official/select_raw_non_raw.lua:159
+msgid "select raw"
+msgstr "RAW 선택"
+
+#: ../src/external/lua-scripts/official/select_raw_non_raw.lua:160
+msgid "select raw files"
+msgstr "RAW 파일 선택"
+
+#: ../src/external/lua-scripts/official/select_raw_non_raw.lua:161
+msgid "select non-raw"
+msgstr "비 RAW 선택"
+
+#: ../src/external/lua-scripts/official/select_raw_non_raw.lua:162
+msgid "select non-raw files"
+msgstr "비 RAW 파일 선택"
+
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. D A R K T A B L E  I N T E G R A T I O N
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. put things to destroy (events, storages, etc) here
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. E V E N T S
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#.
+#.
+#. select_unaltered.lua - select images that have not been altered in any way
+#.
+#. Copyright (C) 2026 Bill Ferguson <wpferguson@gmail.com>.
+#.
+#. This program is free software: you can redistribute it and/or modify
+#. it under the terms of the GNU General Public License as published by
+#. the Free Software Foundation; either version 3 of the License, or
+#. (at your option) any later version.
+#.
+#. This program is distributed in the hope that it will be useful,
+#. but WITHOUT ANY WARRANTY; without even the implied warranty of
+#. MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#. GNU General Public License for more details.
+#.
+#. You should have received a copy of the GNU General Public License
+#. along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#.
+#.
+#. select_unaltered - select images that have not been altered in any way
+#.
+#. select_unaltered selects images from the current collection that have not
+#. been altered in any way.  In other words just imported into darktable, not
+#. loaded into darkroom nor having any style applied.
+#.
+#. ADDITIONAL SOFTWARE NEEDED FOR THIS SCRIPT
+#. None
+#.
+#. USAGE
+#. * enable with script_manager
+#.
+#. BUGS, COMMENTS, SUGGESTIONS
+#. Bill Ferguson <wpferguson@gmail.com>
+#.
+#. CHANGES
+#.
+#. local df = require "lib/dtutils.file"
+#. local ds = require "lib/dtutils.string"
+#. local dtsys = require "lib/dtutils.system"
+#. local debug = require "darktable.debug"
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. A P I  C H E C K
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. choose the minimum version that contains the features you need
+#. - - - - - - - - - - - - - - - - - - - - - - - - -
+#. I 1 8 N
+#. - - - - - - - - - - - - - - - - - - - - - - - - -
+#. - - - - - - - - - - - - - - - - - - - - - - - - -
+#. S C R I P T  M A N A G E R  I N T E G R A T I O N
+#. - - - - - - - - - - - - - - - - - - - - - - - - -
+#. function to destory the script
+#. set to hide for libs since we can't destroy them commpletely yet
+#. how to restart the (lib) script after it's been hidden - i.e. make it visible again
+#. only required for libs since the destroy_method only hides them
+#. purpose of script
+#. your name and optionally e-mail address
+#. URL to help/documentation
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. C O N S T A N T S
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. path separator
+#. command separator
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. L O G  L E V E L
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. N A M E  S P A C E
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. G L O B A L  V A R I A B L E S
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. P R E F E R E N C E S
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. A L I A S E S
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. F U N C T I O N S
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. M A I N  P R O G R A M
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. U S E R  I N T E R F A C E
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#: ../src/external/lua-scripts/official/select_unaltered.lua:78
+#: ../src/external/lua-scripts/official/select_unaltered.lua:151
+msgid "select unaltered"
+msgstr "편집되지 않은 이미지 선택"
+
+#. visible name of script
+#: ../src/external/lua-scripts/official/select_unaltered.lua:79
+msgid "select images that have not been altered in any way"
+msgstr "전혀 편집되지 않은 이미지 선택"
+
+#: ../src/external/lua-scripts/official/select_unaltered.lua:152
+msgid "select unaltered files"
+msgstr "편집되지 않은 파일 선택"
+
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. D A R K T A B L E  I N T E G R A T I O N
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. E V E N T S
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#.
+#.
+#. selection2collection.lua - create a temporary collection from a selection
+#.
+#. Copyright (C) 2026 Bill Ferguson <wpferguson@gmail.com>.
+#.
+#. This program is free software: you can redistribute it and/or modify
+#. it under the terms of the GNU General Public License as published by
+#. the Free Software Foundation; either version 3 of the License, or
+#. (at your option) any later version.
+#.
+#. This program is distributed in the hope that it will be useful,
+#. but WITHOUT ANY WARRANTY; without even the implied warranty of
+#. MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#. GNU General Public License for more details.
+#.
+#. You should have received a copy of the GNU General Public License
+#. along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#.
+#.
+#. selection2collection - create a temporary collection from a selection
+#.
+#. selection2collection creates a temporary collection, using functional
+#. tagging, from a selection. The collection lasts until darktable exits
+#. and then the collections are removed, but not the images.
+#.
+#. To create the temporary collection, a function tag (darktable|functional|s2c)
+#. tag with a date and a time is applied to the selected images.  The collection
+#. module filters on the tag to display the connection.  More than one temporary
+#. collection can be created and collections can be changed by selecting the
+#. appropriate tag.
+#.
+#. The tags are autmatically destroyed when darktable exits, thus removing the
+#. collections.  There is a preference in the Lua options to keep the collections
+#. across darktable runs.
+#.
+#. ADDITIONAL SOFTWARE NEEDED FOR THIS SCRIPT
+#.
+#. None
+#.
+#. USAGE
+#.
+#. * start from script_manager
+#. * make a selection
+#. * click the create temporary collection button the the actions on selected images
+#. module
+#.
+#. BUGS, COMMENTS, SUGGESTIONS
+#.
+#. Bill Ferguson <wpferguson@gmail.com>
+#.
+#. CHANGES
+#.
+#. local df = require "lib/dtutils.file"
+#. local ds = require "lib/dtutils.string"
+#. local dtsys = require "lib/dtutils.system"
+#. local debug = require "darktable.debug"
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. A P I  C H E C K
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. choose the minimum version that contains the features you need
+#. - - - - - - - - - - - - - - - - - - - - - - - - -
+#. I 1 8 N
+#. - - - - - - - - - - - - - - - - - - - - - - - - -
+#. - - - - - - - - - - - - - - - - - - - - - - - - -
+#. S C R I P T  M A N A G E R  I N T E G R A T I O N
+#. - - - - - - - - - - - - - - - - - - - - - - - - -
+#. function to destory the script
+#. set to hide for libs since we can't destroy them commpletely yet
+#. how to restart the (lib) script after it's been hidden - i.e. make it visible again
+#. only required for libs since the destroy_method only hides them
+#: ../src/external/lua-scripts/official/selection2collection.lua:94
+msgid "selection to collection"
+msgstr "선택 항목을 컬렉션으로"
+
+#. visible name of script
+#: ../src/external/lua-scripts/official/selection2collection.lua:95
+msgid "create a temporary collection from a selection"
+msgstr "선택 항목으로 임시 컬렉션 생성"
+
+#. purpose of script
+#. your name and optionally e-mail address
+#. URL to help/documentation
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. C O N S T A N T S
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. path separator
+#. command separator
+#. script specific
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. L O G  L E V E L
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. N A M E  S P A C E
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. G L O B A L  V A R I A B L E S
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. P R E F E R E N C E S
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#: ../src/external/lua-scripts/official/selection2collection.lua:144
+msgid " keep collections created from selection"
+msgstr " 선택 항목으로 생성한 컬렉션 유지"
+
+#: ../src/external/lua-scripts/official/selection2collection.lua:145
+msgid "keep collections created from selections"
+msgstr "선택 항목으로 생성한 컬렉션 유지"
+
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. A L I A S E S
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. F U N C T I O N S
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. -----------------
+#. helper functions
+#. -----------------
+#. -----------------
+#. program functions
+#. -----------------
+#. dt.gui.libs.collect.filter returns the previous rule set when you install another
+#: ../src/external/lua-scripts/official/selection2collection.lua:269
+msgid "not enough images to create a collection"
+msgstr "컬렉션을 생성할 이미지가 충분하지 않습니다"
+
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. M A I N  P R O G R A M
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. U S E R  I N T E R F A C E
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#: ../src/external/lua-scripts/official/selection2collection.lua:300
+msgid "create temporary collection"
+msgstr "임시 컬렉션 생성"
+
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. D A R K T A B L E  I N T E G R A T I O N
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. E V E N T S
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. skip if shortcut already registered
+#: ../src/external/lua-scripts/official/selection2collection.lua:304
+#: ../src/external/lua-scripts/official/selection2collection.lua:335
+msgid "convert selection to collection"
+msgstr "선택 항목을 컬렉션으로 변환"
+
+#.
 #. This file is part of darktable,
 #. copyright (c) 2015 Jérémy Rosen & Pascal Obry
 #. edited 2016 Tejovanth N
@@ -11709,27 +14209,31 @@ msgstr "선택 영역을 임시 버퍼와 교체"
 #.
 #.
 #. return data structure for script_manager
-#: ../src/external/lua-scripts/official/selection_to_pdf.lua:52
+#: ../src/external/lua-scripts/official/selection_to_pdf.lua:56
 msgid "selection to PDF"
 msgstr "선택 항목 PDF로 변환"
 
-#: ../src/external/lua-scripts/official/selection_to_pdf.lua:53
-msgid "generate a pdf file of selected images"
+#: ../src/external/lua-scripts/official/selection_to_pdf.lua:57
+msgid "generate a PDF file of selected images"
 msgstr "선택된 이미지의 PDF 생성"
 
 #. function to destory the script
 #. set to hide for libs since we can't destroy them commpletely yet
 #. how to restart the (lib) script after it's been hidden - i.e. make it visible again
 #. only required for libs since the destroy_method only hides them
-#: ../src/external/lua-scripts/official/selection_to_pdf.lua:65
-msgid "a pdf viewer"
+#: ../src/external/lua-scripts/official/selection_to_pdf.lua:69
+msgid "a PDF viewer"
 msgstr "PDF 뷰어"
 
-#: ../src/external/lua-scripts/official/selection_to_pdf.lua:66
-msgid "can be an absolute pathname or the tool may be in the PATH"
-msgstr "절대 경로명을 사용하거나 도구를 PATH에 추가할 수 있습니다"
+#: ../src/external/lua-scripts/official/selection_to_pdf.lua:70
+msgid ""
+"can be an absolute pathname or the tool may be in the PATH\n"
+"if not specified the system default will be used to open the PDF"
+msgstr ""
+"절대 경로명이거나 도구가 PATH에 있을 수 있습니다\n"
+"지정하지 않으면 시스템 기본 프로그램으로 PDF를 엽니다"
 
-#: ../src/external/lua-scripts/official/selection_to_pdf.lua:74
+#: ../src/external/lua-scripts/official/selection_to_pdf.lua:78
 msgid "thumbs per line"
 msgstr "한 줄당 썸네일"
 
@@ -11738,36 +14242,166 @@ msgstr "한 줄당 썸네일"
 #. The hard minimum value for the slider, the user can't manually enter a value beyond this point
 #. The hard maximum value for the slider, the user can't manually enter a value beyond this point
 #. The current value of the slider
-#: ../src/external/lua-scripts/official/selection_to_pdf.lua:83
+#: ../src/external/lua-scripts/official/selection_to_pdf.lua:87
 msgid "title:"
 msgstr "제목:"
 
-#: ../src/external/lua-scripts/official/selection_to_pdf.lua:85
+#: ../src/external/lua-scripts/official/selection_to_pdf.lua:89
 msgid "thumbnails per row:"
 msgstr "행당 썸네일:"
 
 #. fact is that latex will get confused if the filename has multiple dots.
 #. so \includegraphics{file.01.jpg} wont work. We need to output the filename
 #. and extention separated, e.g: \includegraphics{{file.01}.jpg}
-#: ../src/external/lua-scripts/official/selection_to_pdf.lua:132
-msgid "export thumbnails to pdf"
+#: ../src/external/lua-scripts/official/selection_to_pdf.lua:137
+msgid "export thumbnails to PDF"
 msgstr "썸네일을 PDF로 내보내기"
 
 #. convert to PDF
-#: ../src/external/lua-scripts/official/selection_to_pdf.lua:179
+#: ../src/external/lua-scripts/official/selection_to_pdf.lua:184
 msgid "problem running pdflatex"
 msgstr "pdflatex를 실행하는 동안 문제가 발생하였습니다"
 
 #. this one is probably usefull to the user
 #. open the PDF
-#: ../src/external/lua-scripts/official/selection_to_pdf.lua:189
-msgid "problem running pdf viewer"
+#: ../src/external/lua-scripts/official/selection_to_pdf.lua:203
+msgid "problem running PDF viewer"
 msgstr "PDF 뷰어를 실행하는 동안 문제가 발생하였습니다"
 
 #. this one is probably usefull to the user
 #. finally do some clean-up
 #.
 #. vim: shiftwidth=2 expandtab tabstop=2 cindent syntax=lua
+#.
+#.
+#. use_paired_jpg_as_mipmap.lua - Use the JPG from the RAW JPG pair as the full size mipmap
+#.
+#. Copyright (C) 2026 Bill Ferguson <wpferguson@gmail.com>.
+#.
+#. This program is free software: you can redistribute it and/or modify
+#. it under the terms of the GNU General Public License as published by
+#. the Free Software Foundation; either version 3 of the License, or
+#. (at your option) any later version.
+#.
+#. This program is distributed in the hope that it will be useful,
+#. but WITHOUT ANY WARRANTY; without even the implied warranty of
+#. MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#. GNU General Public License for more details.
+#.
+#. You should have received a copy of the GNU General Public License
+#. along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#.
+#.
+#. use_paired_jpg_as_mipmap - Use the JPG from the RAW JPG pair as the full size mipmap
+#.
+#. use_paired_jpg_as_mipmap looks for RAW+JPEG image pairs as images are imported.  After
+#. import the JPEG image is copied to the mipmap cache as the full resolution mipmap. Requests
+#. for smaller mipmap sizes can be satisfied by down sampling the full resolution mipmap.  User's can
+#. decide whether or not to keep the paired JPEG files.  The default is to keep them.  If the
+#. user doesn't want them, they are deleted after being copied to the mipmap cache.
+#.
+#. ADDITIONAL SOFTWARE NEEDED FOR THIS SCRIPT
+#.
+#. None
+#.
+#. USAGE
+#.
+#. - Add the script to the lua-scripts
+#. - Enable the script
+#. - Turn off the keep_jpgs preference if the JPEGS are not wanted
+#.
+#. BUGS, COMMENTS, SUGGESTIONS
+#. Bill Ferguson <wpferguson@gmail.com>
+#.
+#. CHANGES
+#.
+#. local ds = require "lib/dtutils.string"
+#. local dtsys = require "lib/dtutils.system"
+#. local debug = require "darktable.debug"
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. A P I  C H E C K
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. choose the minimum version that contains the features you need
+#. - - - - - - - - - - - - - - - - - - - - - - - - -
+#. I 1 8 N
+#. - - - - - - - - - - - - - - - - - - - - - - - - -
+#. - - - - - - - - - - - - - - - - - - - - - - - - -
+#. S C R I P T  M A N A G E R  I N T E G R A T I O N
+#. - - - - - - - - - - - - - - - - - - - - - - - - -
+#. function to destory the script
+#. set to hide for libs since we can't destroy them commpletely yet
+#. how to restart the (lib) script after it's been hidden - i.e. make it visible again
+#. only required for libs since the destroy_method only hides them
+#: ../src/external/lua-scripts/official/use_paired_jpg_as_mipmap.lua:84
+msgid "use paired jpg as mipmap"
+msgstr "짝지어진 JPG를 밉맵으로 사용"
+
+#. visible name of script
+#: ../src/external/lua-scripts/official/use_paired_jpg_as_mipmap.lua:85
+msgid "Use the JPG from the RAW JPG pair as the full size mipmap"
+msgstr "RAW+JPG 쌍의 JPG를 전체 크기 밉맵으로 사용"
+
+#. purpose of script
+#. your name and optionally e-mail address
+#. URL to help/documentation
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. C O N S T A N T S
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. path separator
+#. command separator
+#. max mipmap size - 5.4.x = 8, after is 10
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. L O G  L E V E L
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. N A M E  S P A C E
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. G L O B A L  V A R I A B L E S
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. P R E F E R E N C E S
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#: ../src/external/lua-scripts/official/use_paired_jpg_as_mipmap.lua:134
+msgid "keep JPEG files"
+msgstr "JPEG 파일 유지"
+
+#: ../src/external/lua-scripts/official/use_paired_jpg_as_mipmap.lua:135
+msgid "don't delete JPEGs after copying them to mipmap folder"
+msgstr "밉맵 폴더로 복사한 후 JPEG을 삭제하지 않음"
+
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. A L I A S E S
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. F U N C T I O N S
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. -----------------
+#. helper functions
+#. -----------------
+#. if dt.collection is equal to count there are no
+#. RAW+JPEG pairs
+#: ../src/external/lua-scripts/official/use_paired_jpg_as_mipmap.lua:240
+msgid "No RAW+JPEG pairs to process"
+msgstr "처리할 RAW+JPEG 쌍이 없습니다"
+
+#: ../src/external/lua-scripts/official/use_paired_jpg_as_mipmap.lua:244
+msgid "Generating cache from jpgs"
+msgstr "JPG에서 캐시 생성 중"
+
+#. v["raw"]:generate_cache(true, 6, 6)
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. M A I N  P R O G R A M
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. U S E R  I N T E R F A C E
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. D A R K T A B L E  I N T E G R A T I O N
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. - - - - - - - - - - - - - - - - - - - - - - -
+#. E V E N T S
+#. - - - - - - - - - - - - - - - - - - - - - - -
 #.
 #. This file is part of darktable,
 #. copyright (c) 2018 Bill Ferguson
@@ -11948,6 +14582,15 @@ msgstr "문서를 검색하여 콘솔에 출력"
 #. file to luarc and the scripts will run.
 #.
 #.
+#. re-entrancy guard
+#.
+#. when script_manager runs from the system (bundled) lua-scripts directory it
+#. re-runs the user's luarc near the end of this file.  if that luarc contains
+#. `require "tools/script_manager"` (the standard bootstrap line) we would
+#. recurse infinitely, eventually overflowing the C stack.  bail out if we are
+#. already in the middle of loading.
+#. figure out where we are running from
+#. assume user based
 #. api check
 #. du.check_min_api_version("9.3.0", "script_manager")
 #. - - - - - - - - - - - - - - - - - - - - - - -
@@ -11960,11 +14603,19 @@ msgstr "문서를 검색하여 콘솔에 출력"
 #. - - - - - - - - - - - - - - - - - - - - - - -
 #. P R E F E R E N C E S
 #. - - - - - - - - - - - - - - - - - - - - - - -
-#: ../src/external/lua-scripts/tools/script_manager.lua:104
+#: ../src/external/lua-scripts/tools/script_manager.lua:141
+msgid "disable Lua scripts"
+msgstr "Lua 스크립트 비활성화"
+
+#: ../src/external/lua-scripts/tools/script_manager.lua:142
+msgid "do not run the Lua scripts"
+msgstr "Lua 스크립트를 실행하지 않음"
+
+#: ../src/external/lua-scripts/tools/script_manager.lua:150
 msgid "check for updated scripts on start up"
 msgstr "시작할 때 업데이트된 스크립트 확인"
 
-#: ../src/external/lua-scripts/tools/script_manager.lua:105
+#: ../src/external/lua-scripts/tools/script_manager.lua:151
 msgid "automatically update scripts to correct version"
 msgstr "스크립트를 올바른 버전으로 자동 업데이트"
 
@@ -12034,17 +14685,17 @@ msgstr "스크립트를 올바른 버전으로 자동 업데이트"
 #. ----------------
 #. script handling
 #. ----------------
-#: ../src/external/lua-scripts/tools/script_manager.lua:409
+#: ../src/external/lua-scripts/tools/script_manager.lua:455
 msgid "contributed"
 msgstr "기여"
 
-#: ../src/external/lua-scripts/tools/script_manager.lua:413
+#: ../src/external/lua-scripts/tools/script_manager.lua:459
 msgid "official"
 msgstr "공식"
 
-#: ../src/external/lua-scripts/tools/script_manager.lua:415
-#: ../src/iop/retouch.c:2470 ../src/iop/retouch.c:2475
-#: ../src/iop/retouch.c:2480 ../src/iop/retouch.c:2485
+#: ../src/external/lua-scripts/tools/script_manager.lua:461
+#: ../src/iop/retouch.c:2468 ../src/iop/retouch.c:2473
+#: ../src/iop/retouch.c:2478 ../src/iop/retouch.c:2483
 msgid "tools"
 msgstr "도구"
 
@@ -12055,7 +14706,7 @@ msgstr "도구"
 #. break up the lines into key value pairs
 #. slurp the file
 #. assume that the second block comment is the documentation
-#: ../src/external/lua-scripts/tools/script_manager.lua:503
+#: ../src/external/lua-scripts/tools/script_manager.lua:549
 msgid "no documentation available"
 msgstr "사용할 수 있는 문서가 없습니다"
 
@@ -12081,6 +14732,7 @@ msgstr "사용할 수 있는 문서가 없습니다"
 #. change the path separator from / to \ for windows
 #. add the script data
 #. scan the scripts
+#. add a string.match to figure out which lua dir to use
 #. strip the lua dir off
 #. strip off .lua\n
 #. let's not include ourself
@@ -12088,6 +14740,16 @@ msgstr "사용할 수 있는 문서가 없습니다"
 #. let's not try and run libraries
 #. don't match files in the .git directory
 #. but let's make sure libraries can be found
+#: ../src/external/lua-scripts/tools/script_manager.lua:802
+#: ../src/external/lua-scripts/tools/script_manager.lua:928
+msgid ""
+"ERROR: git not found.  Install or specify the location of the git executable."
+msgstr "오류: git을 찾을 수 없습니다. git 실행 파일을 설치하거나 위치를 지정하세요."
+
+#: ../src/external/lua-scripts/tools/script_manager.lua:816
+msgid "lua scripts successfully updated"
+msgstr "lua 스크립트 성공적으로 업데이트됨"
+
 #. ------------
 #. UI handling
 #. ------------
@@ -12095,24 +14757,30 @@ msgstr "사용할 수 있는 문서가 없습니다"
 #. get everything to the first /
 #. if we have a folder (.git doesn't)
 #. skip plugins
-#: ../src/external/lua-scripts/tools/script_manager.lua:751
-#: ../src/external/lua-scripts/tools/script_manager.lua:866
-msgid "ERROR: git not found.  Install or specify the location of the git executable."
-msgstr "오류: git을 찾을 수 없습니다. git 실행 파일을 설치하거나 위치를 지정하세요."
+#: ../src/external/lua-scripts/tools/script_manager.lua:911
+msgid ""
+"unable to create user lua directory, installing additional scripts failed"
+msgstr "사용자 Lua 디렉토리를 생성할 수 없어 추가 스크립트 설치에 실패하였습니다"
 
-#: ../src/external/lua-scripts/tools/script_manager.lua:765
-msgid "lua scripts successfully updated"
-msgstr "lua 스크립트 성공적으로 업데이트됨"
+#: ../src/external/lua-scripts/tools/script_manager.lua:917
+#, lua-format
+msgid "folder %s is already in use. Please specify a different folder name."
+msgstr "폴더 %s은(는) 이미 사용 중입니다. 다른 폴더 이름을 지정하세요."
 
-#: ../src/external/lua-scripts/tools/script_manager.lua:905
+#: ../src/external/lua-scripts/tools/script_manager.lua:949
+#, lua-format
+msgid "scripts successfully installed into folder %s"
+msgstr "스크립트를 폴더 %s에 성공적으로 설치하였습니다"
+
+#: ../src/external/lua-scripts/tools/script_manager.lua:967
 msgid "no scripts found to install"
 msgstr "설치할 스크립트가 없습니다"
 
-#: ../src/external/lua-scripts/tools/script_manager.lua:910
+#: ../src/external/lua-scripts/tools/script_manager.lua:972
 msgid "failed to download scripts"
 msgstr "스크립트 다운로드를 실패하였습니다"
 
-#: ../src/external/lua-scripts/tools/script_manager.lua:1062
+#: ../src/external/lua-scripts/tools/script_manager.lua:1125
 #, lua-format
 msgid "page %d of %d"
 msgstr "%d/%d 페이지"
@@ -12126,8 +14794,8 @@ msgstr "%d/%d 페이지"
 #. num_buttons
 #. main menu
 #. Module name
-#: ../src/external/lua-scripts/tools/script_manager.lua:1217
-#: ../src/external/lua-scripts/tools/script_manager.lua:1492
+#: ../src/external/lua-scripts/tools/script_manager.lua:1280
+#: ../src/external/lua-scripts/tools/script_manager.lua:1584
 msgid "scripts"
 msgstr "스크립트"
 
@@ -12144,7 +14812,7 @@ msgstr "스크립트"
 #. only make changes to clean branches
 #. probably upgraded from an earlier api version so get back to master
 #. to use the latest version of script_manager to get the proper API
-#: ../src/external/lua-scripts/tools/script_manager.lua:1263
+#: ../src/external/lua-scripts/tools/script_manager.lua:1326
 msgid "lua API version reset, please restart darktable"
 msgstr "lua API 버전이 초기화되었습니다. darktable을 재시작하세요"
 
@@ -12153,74 +14821,79 @@ msgstr "lua API 버전이 초기화되었습니다. darktable을 재시작하세
 #. api version or checkout/stay on master
 #. stay on master
 #. checkout the appropriate branch for API version if it exists
-#: ../src/external/lua-scripts/tools/script_manager.lua:1310
-msgid "you must restart darktable to use the correct version of the lua scripts"
+#: ../src/external/lua-scripts/tools/script_manager.lua:1373
+msgid ""
+"you must restart darktable to use the correct version of the lua scripts"
 msgstr "lua 스크립트의 올바른 버전을 사용하려면 darktable을 재시작하세요"
 
+#. exec user luarc file if it exists
+#. guard against the luarc re-requiring script_manager (see top of file)
+#. scan_script(USER_LUA_DIR)
 #. - - - - - - - - - - - - - - - - - - - - - - -
 #. U S E R  I N T E R F A C E
 #. - - - - - - - - - - - - - - - - - - - - - - -
 #. update the scripts
-#: ../src/external/lua-scripts/tools/script_manager.lua:1336
+#: ../src/external/lua-scripts/tools/script_manager.lua:1421
 msgid "scripts to update"
 msgstr "업데이트할 스크립트"
 
-#: ../src/external/lua-scripts/tools/script_manager.lua:1337
+#: ../src/external/lua-scripts/tools/script_manager.lua:1422
 msgid "select the scripts installation to update"
 msgstr "업데이트할 스크립트 설치 선택"
 
-#: ../src/external/lua-scripts/tools/script_manager.lua:1346
-#: ../src/external/lua-scripts/tools/script_manager.lua:1408
+#: ../src/external/lua-scripts/tools/script_manager.lua:1438
+#: ../src/external/lua-scripts/tools/script_manager.lua:1500
 msgid "update scripts"
 msgstr "스크립트 업데이트"
 
-#: ../src/external/lua-scripts/tools/script_manager.lua:1347
+#: ../src/external/lua-scripts/tools/script_manager.lua:1439
 msgid "update the lua scripts from the repository"
 msgstr "리포지토리에서 lua 스크립트 업데이트"
 
 #. add additional scripts
-#: ../src/external/lua-scripts/tools/script_manager.lua:1358
-msgid "enter the URL of the git repository containing the scripts you wish to add"
+#: ../src/external/lua-scripts/tools/script_manager.lua:1450
+msgid ""
+"enter the URL of the git repository containing the scripts you wish to add"
 msgstr "추가할 스크립트가 있는 git 리포지토리 URL을 입력하세요"
 
-#: ../src/external/lua-scripts/tools/script_manager.lua:1363
+#: ../src/external/lua-scripts/tools/script_manager.lua:1455
 msgid "name of new folder"
 msgstr "새 폴더 이름"
 
-#: ../src/external/lua-scripts/tools/script_manager.lua:1364
+#: ../src/external/lua-scripts/tools/script_manager.lua:1456
 msgid "enter a folder name for the additional scripts"
 msgstr "추가 스크립트에 사용할 폴더 이름을 입력하세요"
 
-#: ../src/external/lua-scripts/tools/script_manager.lua:1369
+#: ../src/external/lua-scripts/tools/script_manager.lua:1461
 msgid "URL to download additional scripts from"
 msgstr "추가 스크립트 다운로드 URL"
 
-#: ../src/external/lua-scripts/tools/script_manager.lua:1371
+#: ../src/external/lua-scripts/tools/script_manager.lua:1463
 msgid "new folder to place scripts in"
 msgstr "스크립트를 넣을 새 폴더"
 
-#: ../src/external/lua-scripts/tools/script_manager.lua:1374
+#: ../src/external/lua-scripts/tools/script_manager.lua:1466
 msgid "install additional scripts"
 msgstr "추가 스크립트 설치"
 
-#: ../src/external/lua-scripts/tools/script_manager.lua:1382
+#: ../src/external/lua-scripts/tools/script_manager.lua:1474
 msgid "enable \"disable scripts\" button"
 msgstr "\"스크립트 비활성화\" 버튼 활성화"
 
-#: ../src/external/lua-scripts/tools/script_manager.lua:1394
-#: ../src/external/lua-scripts/tools/script_manager.lua:1419
+#: ../src/external/lua-scripts/tools/script_manager.lua:1486
+#: ../src/external/lua-scripts/tools/script_manager.lua:1511
 msgid "disable scripts"
 msgstr "스크립트 비활성화"
 
-#: ../src/external/lua-scripts/tools/script_manager.lua:1400
+#: ../src/external/lua-scripts/tools/script_manager.lua:1492
 msgid "lua scripts will not run the next time darktable is started"
 msgstr "다음에 darktable을 시작할 때 lua 스크립트가 실행되지 않습니다"
 
-#: ../src/external/lua-scripts/tools/script_manager.lua:1414
+#: ../src/external/lua-scripts/tools/script_manager.lua:1506
 msgid "add more scripts"
 msgstr "더 많은 스크립트 추가"
 
-#: ../src/external/lua-scripts/tools/script_manager.lua:1430
+#: ../src/external/lua-scripts/tools/script_manager.lua:1522
 msgid "select the script folder"
 msgstr "스크립트 폴더 선택"
 
@@ -12228,82 +14901,89 @@ msgstr "스크립트 폴더 선택"
 #. a button to start and stop the script
 #. a label that contains the name of the script
 #. a horizontal box that contains the button and the label
-#: ../src/external/lua-scripts/tools/script_manager.lua:1461
-#: ../src/iop/agx.c:2798 ../src/iop/channelmixerrgb.c:4426
-#: ../src/iop/clipping.c:2098 ../src/iop/colorbalancergb.c:1781
-#: ../src/iop/colorequal.c:3007 ../src/iop/filmicrgb.c:4379
-#: ../src/iop/negadoctor.c:837 ../src/iop/toneequal.c:3229
-#: ../src/libs/image.c:499 ../src/views/lighttable.c:1336
+#: ../src/external/lua-scripts/tools/script_manager.lua:1553
+#: ../src/iop/agx.c:2456 ../src/iop/channelmixerrgb.c:4454
+#: ../src/iop/clipping.c:2092 ../src/iop/colorbalancergb.c:1781
+#: ../src/iop/colorequal.c:2972 ../src/iop/filmicrgb.c:4364
+#: ../src/iop/negadoctor.c:837 ../src/iop/toneequal.c:3233
+#: ../src/libs/image.c:499 ../src/libs/neural_restore.c:4271
+#: ../src/views/lighttable.c:1588
 msgid "page"
 msgstr "페이지"
 
 #. configure options
-#: ../src/external/lua-scripts/tools/script_manager.lua:1501
+#: ../src/external/lua-scripts/tools/script_manager.lua:1593
 msgid "scripts per page"
 msgstr "페이지 당 스크립트"
 
-#: ../src/external/lua-scripts/tools/script_manager.lua:1502
+#: ../src/external/lua-scripts/tools/script_manager.lua:1594
 msgid "select number of start/stop buttons to display"
 msgstr "표시할 시작/정지 버튼 개수 선택"
 
-#: ../src/external/lua-scripts/tools/script_manager.lua:1513
+#: ../src/external/lua-scripts/tools/script_manager.lua:1605
 msgid "change number of buttons"
 msgstr "버튼 개수 변경"
 
-#: ../src/external/lua-scripts/tools/script_manager.lua:1523
+#: ../src/external/lua-scripts/tools/script_manager.lua:1615
 msgid "configuration"
 msgstr "구성"
 
 #. stack for the options
 #. main menu
-#: ../src/external/lua-scripts/tools/script_manager.lua:1545
-#: ../src/gui/accelerators.c:2921 ../src/gui/accelerators.c:3021
-#: ../src/views/view.c:1611
+#: ../src/external/lua-scripts/tools/script_manager.lua:1637
+#: ../src/gui/accelerators.c:2922 ../src/gui/accelerators.c:3022
+#: ../src/views/view.c:1767
 msgid "action"
 msgstr "동작"
 
-#: ../src/external/lua-scripts/tools/script_manager.lua:1551
+#: ../src/external/lua-scripts/tools/script_manager.lua:1643
 msgid "install/update scripts"
 msgstr "스크립트 설치/업데이트"
 
-#: ../src/external/lua-scripts/tools/script_manager.lua:1551
+#: ../src/external/lua-scripts/tools/script_manager.lua:1643
 msgid "configure"
 msgstr "구성"
 
-#: ../src/external/lua-scripts/tools/script_manager.lua:1551
+#: ../src/external/lua-scripts/tools/script_manager.lua:1643
 msgid "start/stop scripts"
 msgstr "스크립트 시작/정지"
 
 #: ../src/generate-cache/main.c:49
 #, c-format
 msgid "creating cache directories\n"
-msgstr "캐시 디렉토리 생성 중\n"
+msgstr ""
+"캐시 디렉토리 생성 중\n"
 
 #: ../src/generate-cache/main.c:55
 #, c-format
 msgid "creating cache directory '%s'\n"
-msgstr "캐시 디렉토리 '%s' 생성 중\n"
+msgstr ""
+"캐시 디렉토리 '%s' 생성 중\n"
 
 #: ../src/generate-cache/main.c:58
 #, c-format
 msgid "could not create directory '%s'!\n"
-msgstr "디렉토리 '%s'을 생성할 수 없습니다!\n"
+msgstr ""
+"디렉토리 '%s'을 생성할 수 없습니다!\n"
 
 #: ../src/generate-cache/main.c:82
 #, c-format
 msgid "warning: no images are matching the requested image id range\n"
-msgstr "경고: 요청한 이미지 ID 범위와 일치하는 이미지가 없습니다\n"
+msgstr ""
+"경고: 요청한 이미지 ID 범위와 일치하는 이미지가 없습니다\n"
 
 #: ../src/generate-cache/main.c:85
 #, c-format
 msgid "warning: did you want to swap these boundaries?\n"
-msgstr "경고: 이 경계들을 바꾸시겠습니까?\n"
+msgstr ""
+"경고: 이 경계들을 바꾸시겠습니까?\n"
 
 #: ../src/generate-cache/main.c:226
 #, c-format
 msgid ""
 "warning: disk backend for thumbnail cache is disabled (cache_disk_backend).\n"
-"if you want to pre-generate thumbnails and for darktable to use them, you need to enable disk backend for thumbnail cache.\n"
+"if you want to pre-generate thumbnails and for darktable to use them, you "
+"need to enable disk backend for thumbnail cache.\n"
 "no thumbnails to be generated, done.\n"
 msgstr ""
 "경고: 썸네일 캐시의 디스크 백엔드가 비활성화되었습니다 (cache_disk_backend).\n"
@@ -12313,8 +14993,10 @@ msgstr ""
 #: ../src/generate-cache/main.c:237
 #, c-format
 msgid ""
-"warning: disk backend for full preview cache is disabled (cache_disk_backend_full).\n"
-"if you want to pre-generate full previews and for darktable to use them, you need to enable disk backend for full preview cache.\n"
+"warning: disk backend for full preview cache is disabled "
+"(cache_disk_backend_full).\n"
+"if you want to pre-generate full previews and for darktable to use them, you "
+"need to enable disk backend for full preview cache.\n"
 "no full previews to be generated, done.\n"
 msgstr ""
 "경고: 전체 미리보기 캐시의 디스크 백엔드가 비활성화되었습니다 (cache_disk_backend_full).\n"
@@ -12324,12 +15006,14 @@ msgstr ""
 #: ../src/generate-cache/main.c:247
 #, c-format
 msgid "error: ensure that min_mip <= max_mip\n"
-msgstr "오류: min_mip <= max_mip 인지 확인하세요\n"
+msgstr ""
+"오류: min_mip <= max_mip 인지 확인하세요\n"
 
 #: ../src/generate-cache/main.c:252
 #, c-format
 msgid "creating complete lighttable thumbnail cache\n"
-msgstr "lighttable 썸네일 캐시 전체 생성 중\n"
+msgstr ""
+"lighttable 썸네일 캐시 전체 생성 중\n"
 
 #: ../src/gui/about.c:34
 #, c-format
@@ -12372,7 +15056,7 @@ msgstr "속도 조절"
 msgid "disabled defaults"
 msgstr "바활성화된 기본값"
 
-#: ../src/gui/accelerators.c:91 ../src/views/view.c:1419
+#: ../src/gui/accelerators.c:91 ../src/views/view.c:1576
 msgid "scroll"
 msgstr "스크롤"
 
@@ -12380,19 +15064,19 @@ msgstr "스크롤"
 msgid "pan"
 msgstr "이동"
 
-#: ../src/gui/accelerators.c:93 ../src/iop/ashift.c:5704
-#: ../src/iop/ashift.c:5706 ../src/iop/ashift.c:5810 ../src/iop/ashift.c:5812
-#: ../src/iop/ashift.c:6137 ../src/iop/clipping.c:1924
-#: ../src/iop/clipping.c:2105 ../src/iop/clipping.c:2121
-#: ../src/views/darkroom.c:2931 ../src/views/lighttable.c:1328
+#: ../src/gui/accelerators.c:93 ../src/iop/ashift.c:5700
+#: ../src/iop/ashift.c:5702 ../src/iop/ashift.c:5806 ../src/iop/ashift.c:5808
+#: ../src/iop/ashift.c:6133 ../src/iop/clipping.c:1918
+#: ../src/iop/clipping.c:2099 ../src/iop/clipping.c:2115
+#: ../src/views/darkroom.c:3551 ../src/views/lighttable.c:1574
 msgid "horizontal"
 msgstr "수평"
 
-#: ../src/gui/accelerators.c:94 ../src/iop/ashift.c:5704
-#: ../src/iop/ashift.c:5706 ../src/iop/ashift.c:5810 ../src/iop/ashift.c:5812
-#: ../src/iop/ashift.c:6135 ../src/iop/clipping.c:1923
-#: ../src/iop/clipping.c:2106 ../src/iop/clipping.c:2120
-#: ../src/views/darkroom.c:2935 ../src/views/lighttable.c:1332
+#: ../src/gui/accelerators.c:94 ../src/iop/ashift.c:5700
+#: ../src/iop/ashift.c:5702 ../src/iop/ashift.c:5806 ../src/iop/ashift.c:5808
+#: ../src/iop/ashift.c:6131 ../src/iop/clipping.c:1917
+#: ../src/iop/clipping.c:2100 ../src/iop/clipping.c:2114
+#: ../src/views/darkroom.c:3555 ../src/views/lighttable.c:1581
 msgid "vertical"
 msgstr "수직"
 
@@ -12412,19 +15096,19 @@ msgstr "위아래"
 msgid "pgupdown"
 msgstr "PgUpDown"
 
-#: ../src/gui/accelerators.c:107 ../src/views/view.c:1397
+#: ../src/gui/accelerators.c:107 ../src/views/view.c:1554
 msgid "shift"
 msgstr "Shift"
 
-#: ../src/gui/accelerators.c:108 ../src/views/view.c:1399
+#: ../src/gui/accelerators.c:108 ../src/views/view.c:1556
 msgid "ctrl"
 msgstr "Ctrl"
 
-#: ../src/gui/accelerators.c:110 ../src/views/view.c:1402
+#: ../src/gui/accelerators.c:110 ../src/views/view.c:1559
 msgid "option"
 msgstr "옵션"
 
-#: ../src/gui/accelerators.c:112 ../src/views/view.c:1404
+#: ../src/gui/accelerators.c:112 ../src/views/view.c:1561
 msgid "alt"
 msgstr "Alt"
 
@@ -12436,104 +15120,123 @@ msgstr "cmd"
 msgid "altgr"
 msgstr "Altgr"
 
-#: ../src/gui/accelerators.c:127 ../src/gui/accelerators.c:174
-#: ../src/libs/tagging.c:1979
+#: ../src/gui/accelerators.c:128 ../src/gui/accelerators.c:179
+#: ../src/libs/tagging.c:2009
 msgid "edit"
 msgstr "편집"
 
-#: ../src/gui/accelerators.c:128 ../src/gui/accelerators.c:775
-#: ../src/gui/accelerators.c:1465
+#: ../src/gui/accelerators.c:129 ../src/gui/accelerators.c:778
+#: ../src/gui/accelerators.c:1466
 msgid "up"
 msgstr "위"
 
-#: ../src/gui/accelerators.c:129 ../src/gui/accelerators.c:775
-#: ../src/gui/accelerators.c:1465
+#: ../src/gui/accelerators.c:130 ../src/gui/accelerators.c:778
+#: ../src/gui/accelerators.c:1466
 msgid "down"
 msgstr "아래"
 
-#: ../src/gui/accelerators.c:133
+#: ../src/gui/accelerators.c:134
 msgid "set"
 msgstr "설정"
 
-#: ../src/gui/accelerators.c:137
-msgid "popup"
-msgstr "팝업"
-
-#: ../src/gui/accelerators.c:138 ../src/gui/accelerators.c:171
-#: ../src/gui/gtk.c:3746 ../src/views/lighttable.c:834
-msgid "next"
-msgstr "다음"
-
-#: ../src/gui/accelerators.c:139 ../src/gui/accelerators.c:170
-#: ../src/gui/gtk.c:3747 ../src/views/lighttable.c:835
-msgid "previous"
-msgstr "이전"
-
-#: ../src/gui/accelerators.c:141 ../src/gui/accelerators.c:1609
-msgid "last"
-msgstr "마지막"
-
-#: ../src/gui/accelerators.c:142 ../src/gui/accelerators.c:1608
-msgid "first"
-msgstr "처음"
-
-#: ../src/gui/accelerators.c:146 ../src/gui/accelerators.c:159
-#: ../src/gui/accelerators.c:359 ../src/libs/filters/rating_range.c:295
-#: ../src/libs/tagging.c:3521 ../src/views/darkroom.c:2555
-#: ../src/views/darkroom.c:2621 ../src/views/darkroom.c:2897
+#: ../src/gui/accelerators.c:137 ../src/gui/accelerators.c:151
+#: ../src/gui/accelerators.c:164 ../src/gui/accelerators.c:359
+#: ../src/libs/filters/rating_range.c:295 ../src/libs/modulegroups.c:2937
+#: ../src/libs/tagging.c:3551 ../src/views/darkroom.c:3180
+#: ../src/views/darkroom.c:3246 ../src/views/darkroom.c:3517
 msgid "toggle"
 msgstr "전환"
 
-#: ../src/gui/accelerators.c:149
+#: ../src/gui/accelerators.c:137
+msgid "previous module"
+msgstr "이전 모듈"
+
+#: ../src/gui/accelerators.c:138
+msgid "next module"
+msgstr "다음 모듈"
+
+#: ../src/gui/accelerators.c:138
+msgid "previous instance"
+msgstr "이전 인스턴스"
+
+#: ../src/gui/accelerators.c:139
+msgid "next instance"
+msgstr "다음 인스턴스"
+
+#: ../src/gui/accelerators.c:142
+msgid "popup"
+msgstr "팝업"
+
+#: ../src/gui/accelerators.c:143 ../src/gui/accelerators.c:176
+#: ../src/gui/gtk.c:4001 ../src/libs/modulegroups.c:2937
+#: ../src/views/lighttable.c:1024
+msgid "next"
+msgstr "다음"
+
+#: ../src/gui/accelerators.c:144 ../src/gui/accelerators.c:175
+#: ../src/gui/gtk.c:4002 ../src/libs/modulegroups.c:2937
+#: ../src/views/lighttable.c:1025
+msgid "previous"
+msgstr "이전"
+
+#: ../src/gui/accelerators.c:146 ../src/gui/accelerators.c:1610
+msgid "last"
+msgstr "마지막"
+
+#: ../src/gui/accelerators.c:147 ../src/gui/accelerators.c:1609
+msgid "first"
+msgstr "처음"
+
+#: ../src/gui/accelerators.c:154
 msgid "ctrl-toggle"
 msgstr "Ctrl-전환"
 
-#: ../src/gui/accelerators.c:150
+#: ../src/gui/accelerators.c:155
 msgid "ctrl-on"
 msgstr "Ctrl-켜기"
 
-#: ../src/gui/accelerators.c:151
+#: ../src/gui/accelerators.c:156
 msgid "right-toggle"
 msgstr "우클릭-전환"
 
-#: ../src/gui/accelerators.c:152
+#: ../src/gui/accelerators.c:157
 msgid "right-on"
 msgstr "우클릭-켜기"
 
-#: ../src/gui/accelerators.c:163 ../src/gui/gtk.c:3745
+#: ../src/gui/accelerators.c:168 ../src/gui/gtk.c:4000
 msgid "activate"
 msgstr "활성화"
 
-#: ../src/gui/accelerators.c:164
+#: ../src/gui/accelerators.c:169
 msgid "ctrl-activate"
 msgstr "Ctrl-활성화"
 
-#: ../src/gui/accelerators.c:165
+#: ../src/gui/accelerators.c:170
 msgid "right-activate"
 msgstr "우클릭-활성화"
 
-#: ../src/gui/accelerators.c:172
+#: ../src/gui/accelerators.c:177
 msgid "store"
 msgstr "저장"
 
-#: ../src/gui/accelerators.c:175 ../src/gui/styles_dialog.c:668
+#: ../src/gui/accelerators.c:180 ../src/gui/styles_dialog.c:665
 msgid "update"
 msgstr "업데이트"
 
-#: ../src/gui/accelerators.c:176 ../src/libs/tools/global_toolbox.c:60
+#: ../src/gui/accelerators.c:181 ../src/libs/tools/global_toolbox.c:60
 #: ../src/libs/tools/global_toolbox.c:512
 msgid "preferences"
 msgstr "환경설정"
 
-#: ../src/gui/accelerators.c:181
+#: ../src/gui/accelerators.c:186
 msgid "apply on new instance"
 msgstr "신규 인스턴스에 적용"
 
-#: ../src/gui/accelerators.c:186
+#: ../src/gui/accelerators.c:191
 msgid "start"
 msgstr "시작"
 
-#: ../src/gui/accelerators.c:187
+#: ../src/gui/accelerators.c:192
 msgid "end"
 msgstr "종료"
 
@@ -12545,86 +15248,86 @@ msgstr "항목"
 msgid "combo effect not found"
 msgstr "콤보 효과를 찾지 못함"
 
-#: ../src/gui/accelerators.c:665
+#: ../src/gui/accelerators.c:668
 msgid "(keypad)"
 msgstr "(키패드)"
 
-#: ../src/gui/accelerators.c:674
+#: ../src/gui/accelerators.c:677
 msgid "tablet button"
 msgstr "태블릿 버튼"
 
-#: ../src/gui/accelerators.c:683
+#: ../src/gui/accelerators.c:686
 msgid "unknown driver"
 msgstr "알 수 없는 드라이버"
 
-#: ../src/gui/accelerators.c:756
+#: ../src/gui/accelerators.c:759
 msgid "long"
 msgstr "길게 누르기"
 
-#: ../src/gui/accelerators.c:757
+#: ../src/gui/accelerators.c:760
 msgid "double-press"
 msgstr "두 번 누르기"
 
-#: ../src/gui/accelerators.c:758
+#: ../src/gui/accelerators.c:761
 msgid "triple-press"
 msgstr "세 번 누르기"
 
-#: ../src/gui/accelerators.c:759
+#: ../src/gui/accelerators.c:762
 msgid "press"
 msgstr "누르기"
 
-#: ../src/gui/accelerators.c:763
+#: ../src/gui/accelerators.c:766
 msgctxt "accel"
 msgid "left"
 msgstr "왼쪽"
 
-#: ../src/gui/accelerators.c:764
+#: ../src/gui/accelerators.c:767
 msgctxt "accel"
 msgid "right"
 msgstr "오른쪽"
 
-#: ../src/gui/accelerators.c:765
+#: ../src/gui/accelerators.c:768
 msgctxt "accel"
 msgid "middle"
 msgstr "가운데"
 
-#: ../src/gui/accelerators.c:766
+#: ../src/gui/accelerators.c:769
 msgctxt "accel"
 msgid "long"
 msgstr "길게 누르기"
 
-#: ../src/gui/accelerators.c:767
+#: ../src/gui/accelerators.c:770
 msgctxt "accel"
 msgid "double-click"
 msgstr "더블 클릭"
 
-#: ../src/gui/accelerators.c:768
+#: ../src/gui/accelerators.c:771
 msgctxt "accel"
 msgid "triple-click"
 msgstr "트리플 클릭"
 
-#: ../src/gui/accelerators.c:769
+#: ../src/gui/accelerators.c:772
 msgid "click"
 msgstr "클릭"
 
-#: ../src/gui/accelerators.c:797
+#: ../src/gui/accelerators.c:800
 msgid "first instance"
 msgstr "첫 번째 인스턴스"
 
-#: ../src/gui/accelerators.c:799
+#: ../src/gui/accelerators.c:802
 msgid "last instance"
 msgstr "마지막 인스턴스"
 
-#: ../src/gui/accelerators.c:801
+#: ../src/gui/accelerators.c:804
 msgid "relative instance"
 msgstr "상대 인스턴스"
 
-#: ../src/gui/accelerators.c:818 ../src/gui/accelerators.c:2946
-#: ../src/gui/accelerators.c:3913
+#: ../src/gui/accelerators.c:821 ../src/gui/accelerators.c:2947
+#: ../src/gui/accelerators.c:3910
 msgid "speed"
 msgstr "속도"
 
-#: ../src/gui/accelerators.c:960
+#: ../src/gui/accelerators.c:963
 #, c-format
 msgid ""
 "Lua script command copied to clipboard:\n"
@@ -12635,11 +15338,11 @@ msgstr ""
 "\n"
 "<tt>%s</tt>"
 
-#: ../src/gui/accelerators.c:1063 ../src/gui/accelerators.c:1082
+#: ../src/gui/accelerators.c:1066 ../src/gui/accelerators.c:1085
 msgid "start typing for incremental search"
 msgstr "글자를 입력하여 실시간 입력 반영 검색 시작"
 
-#: ../src/gui/accelerators.c:1066
+#: ../src/gui/accelerators.c:1069
 msgid ""
 "\n"
 "press Delete to delete selected shortcut"
@@ -12647,7 +15350,7 @@ msgstr ""
 "\n"
 "Delete 키를 눌러 선택된 단축키 삭제"
 
-#: ../src/gui/accelerators.c:1068
+#: ../src/gui/accelerators.c:1071
 msgid ""
 "\n"
 "press Delete to disable selected default shortcut"
@@ -12655,7 +15358,7 @@ msgstr ""
 "\n"
 "Delete 키를 눌러 선택된 기본 단축키 비활성화"
 
-#: ../src/gui/accelerators.c:1069
+#: ../src/gui/accelerators.c:1072
 msgid ""
 "\n"
 "press Delete to restore selected default shortcut"
@@ -12663,7 +15366,7 @@ msgstr ""
 "\n"
 "Delete 키를 눌러 선택된 기본 단축키 복원"
 
-#: ../src/gui/accelerators.c:1071
+#: ../src/gui/accelerators.c:1074
 msgid ""
 "\n"
 "double-click to add new shortcut"
@@ -12671,11 +15374,11 @@ msgstr ""
 "\n"
 "두 번 클릭하여 새 단축키 등록"
 
-#: ../src/gui/accelerators.c:1083
+#: ../src/gui/accelerators.c:1086
 msgid "click to filter shortcuts list"
 msgstr "클릭하여 단축키 목록 필터링"
 
-#: ../src/gui/accelerators.c:1085
+#: ../src/gui/accelerators.c:1088
 msgid ""
 "\n"
 "right-click to show action of selected shortcut"
@@ -12683,7 +15386,7 @@ msgstr ""
 "\n"
 "우클릭으로 선택된 단축키의 동작 보기"
 
-#: ../src/gui/accelerators.c:1088
+#: ../src/gui/accelerators.c:1091
 msgid ""
 "\n"
 "double-click to define new shortcut"
@@ -12691,51 +15394,82 @@ msgstr ""
 "\n"
 "더블 클릭하여 새 단축키 정의"
 
-#: ../src/gui/accelerators.c:1104
+#: ../src/gui/accelerators.c:1094
+msgid ""
+"\n"
+"\n"
+"multiple shortcuts can be defined for the same action;\n"
+"a different element, effect, speed or instance can be set for each in the "
+"shortcuts list."
+msgstr ""
+"\n"
+"\n"
+"같은 동작에 여러 개의 단축키를 정의할 수 있습니다.\n"
+"단축키 목록에서 각각에 대해 다른 요소, 효과, 속도 또는 인스턴스를 설정할 수 있습니다."
+
+#: ../src/gui/accelerators.c:1098
+msgid ""
+"\n"
+"\n"
+"with fallbacks enabled, the same shortcut can be used with additional "
+"modifiers\n"
+"or mouse scroll/clicks/moves to affect a different element or change the "
+"effect or speed."
+msgstr ""
+"\n"
+"\n"
+"폴백을 활성화하면 같은 단축키에 추가 수정자 키나 마우스 스크롤/클릭/이동을 조합하여\n"
+"다른 요소에 영향을 주거나 효과 또는 속도를 변경할 수 있습니다."
+
+#: ../src/gui/accelerators.c:1107
 msgid "shift+alt+scroll to change height"
 msgstr "Shift+Alt+스크롤로 높이 변경"
 
-#: ../src/gui/accelerators.c:1124
-msgid "press keys with mouse click and scroll or move combinations to create a shortcut"
+#: ../src/gui/accelerators.c:1127
+msgid ""
+"press keys with mouse click and scroll or move combinations to create a "
+"shortcut"
 msgstr "키보드 입력과 마우스 클릭 및 스크롤 또는 이동 조합으로 단축키를 생성합니다"
 
-#: ../src/gui/accelerators.c:1125
+#: ../src/gui/accelerators.c:1128
 msgid "click to open shortcut configuration"
 msgstr "클릭하여 단축키 설정 열기"
 
-#: ../src/gui/accelerators.c:1126
+#: ../src/gui/accelerators.c:1129
 msgid "ctrl+click to add to quick access panel\n"
-msgstr "Ctrl+클릭하여 빠른 접근 패널 등록\n"
+msgstr ""
+"Ctrl+클릭하여 빠른 접근 패널 등록\n"
 
-#: ../src/gui/accelerators.c:1127
+#: ../src/gui/accelerators.c:1130
 msgid "ctrl+click to remove from quick access panel\n"
-msgstr "Ctrl+클릭하여 빠른 접근 패널 삭제\n"
+msgstr ""
+"Ctrl+클릭하여 빠른 접근 패널 삭제\n"
 
-#: ../src/gui/accelerators.c:1128
+#: ../src/gui/accelerators.c:1131
 msgid "scroll to change default speed"
 msgstr "스크롤하여 기본 속도 변경"
 
-#: ../src/gui/accelerators.c:1129
+#: ../src/gui/accelerators.c:1132
 msgid "right-click to exit mapping mode"
 msgstr "우클릭하여 맵핑 모드 종료"
 
-#: ../src/gui/accelerators.c:1188
+#: ../src/gui/accelerators.c:1191
 msgid "ctrl+v"
 msgstr "Ctrl+v"
 
-#: ../src/gui/accelerators.c:1188
+#: ../src/gui/accelerators.c:1191
 msgid "right long click"
 msgstr "오른쪽 길게 클릭"
 
-#: ../src/gui/accelerators.c:1188
+#: ../src/gui/accelerators.c:1191
 msgid "to copy Lua command"
 msgstr "Lua 명령어 복사"
 
-#: ../src/gui/accelerators.c:1460
+#: ../src/gui/accelerators.c:1461
 msgid "shortcut for move exists with single effect"
 msgstr "이동 단축키가 단일 효과로 존재합니다"
 
-#: ../src/gui/accelerators.c:1462
+#: ../src/gui/accelerators.c:1463
 #, c-format
 msgid ""
 "%s\n"
@@ -12746,67 +15480,70 @@ msgstr ""
 "\n"
 "(%s를 %s에 할당)"
 
-#: ../src/gui/accelerators.c:1463
+#: ../src/gui/accelerators.c:1464
 msgid "create separate shortcuts for up and down move?"
 msgstr "상하 이동에 대해 별도의 단축키를 생성하시겠습니까?"
 
-#: ../src/gui/accelerators.c:1489
+#: ../src/gui/accelerators.c:1490
 #, c-format
 msgid "%s, speed reset"
 msgstr "%s, 속도 초기화"
 
-#: ../src/gui/accelerators.c:1508
+#: ../src/gui/accelerators.c:1509
 msgid "shortcut exists with different settings"
 msgstr "단축키가 다른 설정으로 존재합니다"
 
-#: ../src/gui/accelerators.c:1509
+#: ../src/gui/accelerators.c:1510
 msgid "reset the settings of the shortcut?"
 msgstr "단축키 설정을 초기화하시겠습니까?"
 
-#: ../src/gui/accelerators.c:1518
+#: ../src/gui/accelerators.c:1519
 msgid "shortcut already exists"
 msgstr "단축키가 이미 존재합니다"
 
-#: ../src/gui/accelerators.c:1520
+#: ../src/gui/accelerators.c:1521
 msgid "disable this default shortcut?"
 msgstr "이 기존 단축키를 비활성화하시겠습니까?"
 
-#: ../src/gui/accelerators.c:1521
+#: ../src/gui/accelerators.c:1522
 msgid "remove the shortcut?"
 msgstr "단축키를 제거하시겠습니까?"
 
-#: ../src/gui/accelerators.c:1561
+#: ../src/gui/accelerators.c:1562
 msgid "clashing shortcuts exist"
 msgstr "충돌하는 단축키가 존재합니다"
 
-#: ../src/gui/accelerators.c:1562
+#: ../src/gui/accelerators.c:1563
 msgid "remove these existing shortcuts?"
 msgstr "기존 단축키들을 제거하시겠습니까?"
 
 #. or 3, but change char relative[] = "-2" to "-1"
 #. NUM_INSTANCES
-#: ../src/gui/accelerators.c:1607
+#: ../src/gui/accelerators.c:1608
 msgid "preferred"
 msgstr "선호됨"
 
-#: ../src/gui/accelerators.c:1610
+#: ../src/gui/accelerators.c:1611
 msgid "second"
 msgstr "2순위 단축키"
 
-#: ../src/gui/accelerators.c:1611
+#: ../src/gui/accelerators.c:1612
 msgid "last but one"
 msgstr "끝에서 두 번째"
 
-#: ../src/gui/accelerators.c:1774 ../src/gui/accelerators.c:1839
+#: ../src/gui/accelerators.c:1775 ../src/gui/accelerators.c:1840
 msgid "(unchanged)"
 msgstr "(변경 없음)"
 
-#: ../src/gui/accelerators.c:1956
+#: ../src/gui/accelerators.c:1957
 msgid ""
-"define a shortcut by pressing a key, optionally combined with modifier keys (ctrl/shift/alt)\n"
+"define a shortcut by pressing a key, optionally combined with modifier keys "
+"(ctrl/shift/alt)\n"
 "a key can be double or triple pressed, with a long last press\n"
-"while the key is held, a combination of mouse buttons can be (double/triple/long) clicked\n"
-"still holding the key (and modifiers and/or buttons) a scroll or mouse move can be added\n"
+"while the key is held, a combination of mouse buttons can be (double/triple/"
+"long) clicked\n"
+"still holding the key (and modifiers and/or buttons) a scroll or mouse move "
+"can be added\n"
 "connected devices can send keys or moves using their physical controllers\n"
 "\n"
 "right-click to cancel"
@@ -12819,47 +15556,47 @@ msgstr ""
 "\n"
 "우클릭으로 취소합니다"
 
-#: ../src/gui/accelerators.c:2029
+#: ../src/gui/accelerators.c:2030
 msgid "removing shortcut"
 msgstr "단축키 삭제 중"
 
-#: ../src/gui/accelerators.c:2031
+#: ../src/gui/accelerators.c:2032
 msgid "disable the selected default shortcut?"
 msgstr "선택한 기본 단축키를 비활성화하시겠습니까?"
 
-#: ../src/gui/accelerators.c:2032
+#: ../src/gui/accelerators.c:2033
 msgid "restore the selected default shortcut?"
 msgstr "선택한 기본 단축키를 복원하시겠습니까?"
 
-#: ../src/gui/accelerators.c:2033
+#: ../src/gui/accelerators.c:2034
 msgid "remove the selected shortcut?"
 msgstr "선택한 단축키를 제거하시겠습니까?"
 
-#: ../src/gui/accelerators.c:2148
+#: ../src/gui/accelerators.c:2149
 msgid "command"
 msgstr "명령"
 
-#: ../src/gui/accelerators.c:2149
+#: ../src/gui/accelerators.c:2150
 msgid "preset"
 msgstr "프리셋"
 
-#: ../src/gui/accelerators.c:2530
+#: ../src/gui/accelerators.c:2531
 msgid "restore shortcuts"
 msgstr "단축키 복원"
 
-#: ../src/gui/accelerators.c:2533
+#: ../src/gui/accelerators.c:2534
 msgid "_defaults"
 msgstr "기본값 (&D)"
 
-#: ../src/gui/accelerators.c:2534
+#: ../src/gui/accelerators.c:2535
 msgid "_startup"
 msgstr "시작 (&S)"
 
-#: ../src/gui/accelerators.c:2535
+#: ../src/gui/accelerators.c:2536
 msgid "_edits"
 msgstr "편집 (&E)"
 
-#: ../src/gui/accelerators.c:2540
+#: ../src/gui/accelerators.c:2541
 msgid ""
 "restore shortcuts from one of these states:\n"
 "  - default\n"
@@ -12871,7 +15608,7 @@ msgstr ""
 "  - 가동 시점\n"
 "  - 이 대화의 시작 시점\n"
 
-#: ../src/gui/accelerators.c:2546
+#: ../src/gui/accelerators.c:2547
 msgid ""
 "clear all newer shortcuts\n"
 "(instead of just restoring changed ones)"
@@ -12879,17 +15616,17 @@ msgstr ""
 "새로 작성된 모든 단축키 초기화\n"
 "(바뀐 단축키는 복원하지 않습니다)"
 
-#: ../src/gui/accelerators.c:2603 ../src/gui/preferences.c:1033
+#: ../src/gui/accelerators.c:2604 ../src/gui/preferences.c:1062
 #: ../src/libs/tools/global_toolbox.c:487
 #: ../src/libs/tools/global_toolbox.c:662
 msgid "shortcuts"
 msgstr "단축키"
 
-#: ../src/gui/accelerators.c:2613
+#: ../src/gui/accelerators.c:2614
 msgid "export shortcuts"
 msgstr "단축키 내보내기"
 
-#: ../src/gui/accelerators.c:2620
+#: ../src/gui/accelerators.c:2621
 msgid ""
 "export all shortcuts to a file\n"
 "or just for one selected device\n"
@@ -12897,27 +15634,27 @@ msgstr ""
 "모든 단축키를 파일로 내보내기\n"
 "또는 하나의 선택된 장치 단축키에서 내보내기\n"
 
-#: ../src/gui/accelerators.c:2626 ../src/gui/accelerators.c:2698
+#: ../src/gui/accelerators.c:2627 ../src/gui/accelerators.c:2699
 msgid "keyboard"
 msgstr "키보드"
 
-#: ../src/gui/accelerators.c:2639
+#: ../src/gui/accelerators.c:2640
 msgid "device id"
 msgstr "장치 ID"
 
-#: ../src/gui/accelerators.c:2657
+#: ../src/gui/accelerators.c:2658
 msgid "select file to export"
 msgstr "내보낼 파일 선택"
 
-#: ../src/gui/accelerators.c:2658 ../src/libs/tagging.c:2847
+#: ../src/gui/accelerators.c:2659 ../src/libs/tagging.c:2877
 msgid "_export"
 msgstr "내보내기 (&E)"
 
-#: ../src/gui/accelerators.c:2685
+#: ../src/gui/accelerators.c:2686
 msgid "import shortcuts"
 msgstr "단축키 가져오기"
 
-#: ../src/gui/accelerators.c:2692
+#: ../src/gui/accelerators.c:2693
 msgid ""
 "import all shortcuts from a file\n"
 "or just for one selected device\n"
@@ -12925,31 +15662,31 @@ msgstr ""
 "파일로부터 모든 단축키 가져오기\n"
 "또는 하나의 선택된 장치 단축키에서 가져오기\n"
 
-#: ../src/gui/accelerators.c:2709
+#: ../src/gui/accelerators.c:2710
 msgid "id in file"
 msgstr "파일 내 ID"
 
-#: ../src/gui/accelerators.c:2715
+#: ../src/gui/accelerators.c:2716
 msgid "id when loaded"
 msgstr "로딩될 때 ID"
 
-#: ../src/gui/accelerators.c:2718
+#: ../src/gui/accelerators.c:2719
 msgid "clear device first"
 msgstr "장치 읽기 전 초기화"
 
-#: ../src/gui/accelerators.c:2743
+#: ../src/gui/accelerators.c:2744
 msgid "select file to import"
 msgstr "가져올 파일 선택"
 
-#: ../src/gui/accelerators.c:2744 ../src/libs/tagging.c:2805
+#: ../src/gui/accelerators.c:2745 ../src/libs/tagging.c:2835
 msgid "_import"
 msgstr "가져오기 (&I)"
 
-#: ../src/gui/accelerators.c:2794
+#: ../src/gui/accelerators.c:2795
 msgid "import sample shortcuts"
 msgstr "샘플 단축키 가져오기"
 
-#: ../src/gui/accelerators.c:2800
+#: ../src/gui/accelerators.c:2801
 msgid ""
 "add darktable sample shortcuts?\n"
 "\n"
@@ -12973,11 +15710,11 @@ msgstr ""
 "이 단축기를 추가하기 전에\n"
 "현재 단축키를 내보내는 것이 좋습니다\n"
 
-#: ../src/gui/accelerators.c:2896
+#: ../src/gui/accelerators.c:2897
 msgid "search shortcuts list"
 msgstr "단축키 목록 검색"
 
-#: ../src/gui/accelerators.c:2898
+#: ../src/gui/accelerators.c:2899
 msgid ""
 "incrementally search the list of shortcuts\n"
 "press up or down keys to cycle through matches"
@@ -12985,23 +15722,23 @@ msgstr ""
 "한 글자 입력할 때마다 단축키 목록에서 검색\n"
 "위 혹은 아래 화살표 키를 눌러 일치하는 항목으로 이동합니다"
 
-#: ../src/gui/accelerators.c:2918 ../src/views/view.c:1609
+#: ../src/gui/accelerators.c:2919 ../src/views/view.c:1765
 msgid "shortcut"
 msgstr "단축키"
 
-#: ../src/gui/accelerators.c:2931
+#: ../src/gui/accelerators.c:2932
 msgid "element"
 msgstr "요소"
 
-#: ../src/gui/accelerators.c:2939
+#: ../src/gui/accelerators.c:2940
 msgid "effect"
 msgstr "효과"
 
-#: ../src/gui/accelerators.c:2997
+#: ../src/gui/accelerators.c:2998
 msgid "search actions list"
 msgstr "동작 목록 검색"
 
-#: ../src/gui/accelerators.c:2999
+#: ../src/gui/accelerators.c:3000
 msgid ""
 "incrementally search the list of actions\n"
 "press up or down keys to cycle through matches"
@@ -13009,16 +15746,16 @@ msgstr ""
 "한 글자 입력할 때마다 동작 목록에서 검색\n"
 "위 또는 아래 화살표 키를 눌러 일치하는 항목으로 이동합니다"
 
-#: ../src/gui/accelerators.c:3029 ../src/gui/guides.c:840
-#: ../src/gui/metadata_tags.c:117
+#: ../src/gui/accelerators.c:3030 ../src/gui/guides.c:840
+#: ../src/gui/metadata_tags.c:119
 msgid "type"
 msgstr "유형"
 
-#: ../src/gui/accelerators.c:3059
+#: ../src/gui/accelerators.c:3060
 msgid "enable fallbacks"
 msgstr "실패 시 대체 기능 활성화"
 
-#: ../src/gui/accelerators.c:3060
+#: ../src/gui/accelerators.c:3061
 msgid ""
 "enables default meanings for additional buttons, modifiers or moves\n"
 "when used in combination with a base shortcut"
@@ -13026,50 +15763,58 @@ msgstr ""
 "기본 단축키 조합으로 사용할 때,\n"
 "추가 버튼, 수정 키 또는 마우스 이동의 기본 의미를 활성화합니다"
 
-#: ../src/gui/accelerators.c:3067
+#: ../src/gui/accelerators.c:3068
 msgid "open help page for shortcuts"
 msgstr "단축키 도움말 페이지 열기"
 
-#: ../src/gui/accelerators.c:3071
+#: ../src/gui/accelerators.c:3072
 msgid "restore..."
 msgstr "복원..."
 
-#: ../src/gui/accelerators.c:3072
+#: ../src/gui/accelerators.c:3073
 msgid "restore default shortcuts or previous state"
 msgstr "기본 단축키 혹은 또는 상태를 복원"
 
-#: ../src/gui/accelerators.c:3075
+#: ../src/gui/accelerators.c:3076
 msgid "import extras"
 msgstr "추가 가져오기"
 
-#: ../src/gui/accelerators.c:3076
+#: ../src/gui/accelerators.c:3077
 msgid "import extended default shortcuts"
 msgstr "확장 기본 단축키 가져오기"
 
-#: ../src/gui/accelerators.c:3079 ../src/libs/styles.c:901
-#: ../src/libs/tagging.c:3683
+#: ../src/gui/accelerators.c:3080 ../src/libs/styles.c:936
+#: ../src/libs/tagging.c:3713
 msgid "import..."
 msgstr "가져오기..."
 
-#: ../src/gui/accelerators.c:3080
+#: ../src/gui/accelerators.c:3081
 msgid "fully or partially import shortcuts from file"
 msgstr "파일로부터 단축키 전체 또는 부분적으로 가져오기"
 
-#: ../src/gui/accelerators.c:3083 ../src/libs/styles.c:907
-#: ../src/libs/tagging.c:3690
+#: ../src/gui/accelerators.c:3084 ../src/libs/styles.c:942
+#: ../src/libs/tagging.c:3720
 msgid "export..."
 msgstr "내보내기..."
 
-#: ../src/gui/accelerators.c:3084
+#: ../src/gui/accelerators.c:3085
 msgid "fully or partially export shortcuts to file"
 msgstr "파일로부터 단축키 전체 또는 부분적으로 내보내기"
 
-#: ../src/gui/accelerators.c:3096
+#: ../src/gui/accelerators.c:3097
 msgid ""
-"the recommended way to assign shortcuts to visual elements is the <b>visual shortcut mapping</b> mode.\n"
-"this is switched on by toggling the <i>\"keyboard\"</i> button next to preferences in the top panel. in this mode, clicking on a widget or area will open this dialog with the appropriate selection for advanced configuration.\n"
+"the recommended way to assign shortcuts to visual elements is the <b>visual "
+"shortcut mapping</b> mode.\n"
+"this is switched on by toggling the <i>\"keyboard\"</i> button next to "
+"preferences in the top panel. in this mode, clicking on a widget or area "
+"will open this dialog with the appropriate selection for advanced "
+"configuration.\n"
 "\n"
-"multiple shortcuts can be assigned to the same action. this is especially useful if it has multiple <i>elements</i>, like the module buttons or the colorpickers attached to sliders. however, with <i>fallbacks</i> enabled one can use the same simple shortcuts and change their <i>element</i> or <i>effect</i> by adding mouse clicks.\n"
+"multiple shortcuts can be assigned to the same action. this is especially "
+"useful if it has multiple <i>elements</i>, like the module buttons or the "
+"colorpickers attached to sliders. however, with <i>fallbacks</i> enabled one "
+"can use the same simple shortcuts and change their <i>element</i> or "
+"<i>effect</i> by adding mouse clicks.\n"
 "\n"
 "<i>click <b> three times </b> to dismiss this notice permanently</i>"
 msgstr ""
@@ -13080,31 +15825,31 @@ msgstr ""
 "\n"
 "<i><b>세 번 </b> 클릭하면 이 알림은 다시 표시되지 않습니다</i>"
 
-#: ../src/gui/accelerators.c:3526
+#: ../src/gui/accelerators.c:3527
 msgid "reinitialising input devices"
 msgstr "입력 장치 재초기화"
 
-#: ../src/gui/accelerators.c:3615
+#: ../src/gui/accelerators.c:3616
 msgid "move not assigned"
 msgstr "이동이 할당되지 않음"
 
-#: ../src/gui/accelerators.c:3615
+#: ../src/gui/accelerators.c:3616
 msgid "fallback to earlier move"
 msgstr "이전 이동으로 되돌림"
 
-#: ../src/gui/accelerators.c:3695
+#: ../src/gui/accelerators.c:3696
 msgid "down move"
 msgstr "아래로 이동"
 
-#: ../src/gui/accelerators.c:3695
+#: ../src/gui/accelerators.c:3696
 msgid "flip top/bottom first/last"
 msgstr "상/하, 처음/마지막 교체"
 
-#: ../src/gui/accelerators.c:3776
+#: ../src/gui/accelerators.c:3775
 msgid "fallback to move"
 msgstr "이동 실패 시 대체 기능"
 
-#: ../src/gui/accelerators.c:3882
+#: ../src/gui/accelerators.c:3881
 #, c-format
 msgid ""
 "\n"
@@ -13113,7 +15858,12 @@ msgstr ""
 "\n"
 "프리셋 '%s'에 할당"
 
-#: ../src/gui/accelerators.c:4032
+#. TODO
+#: ../src/gui/accelerators.c:3997
+msgid "ignoring shortcuts while blocking jobs running"
+msgstr "차단 작업이 실행되는 동안 단축키를 무시합니다"
+
+#: ../src/gui/accelerators.c:4031
 #, c-format
 msgid "%s not assigned"
 msgstr "할당되지 않은 %s"
@@ -13123,231 +15873,195 @@ msgstr "할당되지 않은 %s"
 msgid "%s assigned to %s"
 msgstr "%s는 %s에 할당됨"
 
-#: ../src/gui/accelerators.c:4430
+#: ../src/gui/accelerators.c:4424
 msgid "short key press resets stuck keys"
 msgstr "키를 짧게 눌러 키 고정을 해제합니다"
 
-#: ../src/gui/workspace.c:59
-msgid "delete workspace"
-msgstr "워크스페이스 삭제"
+#: ../src/gui/color_picker_proxy.c:415 ../src/iop/watermark.c:1462
+msgid "pick color from image"
+msgstr "이미지에서 색상 선택"
 
-#: ../src/gui/workspace.c:60
-#, c-format
-msgid ""
-"WARNING\n"
-"\n"
-"do you really want to delete the '%s' workspace?\n"
-"\n"
-"if XMP writing is not activated, the editing work will be lost."
-msgstr ""
-"경고\n"
-"\n"
-"'%s' 워크스페이스를 정말 삭제하시겠습니까?\n"
-"\n"
-"XMP 쓰기가 활성화되어 있지 않으면 편집 작업이 손실됩니다."
-
-#. add a memory workspace just after default one
-#: ../src/gui/workspace.c:103 ../src/gui/workspace.c:209
-msgid "memory"
-msgstr "메모리"
-
-#: ../src/gui/workspace.c:165
-msgid "darktable - select a workspace"
-msgstr "darktable - 워크스페이스 선택"
-
-#: ../src/gui/workspace.c:175
-msgid "select an existing workspace"
-msgstr "기존 워크스페이스 선택"
-
-#: ../src/gui/workspace.c:234
-msgid "or create a new one"
-msgstr "또는 새로 생성"
-
-#: ../src/gui/workspace.c:242 ../src/libs/session.c:104
-msgid "create"
-msgstr "생성"
-
-#: ../src/gui/gtk.c:189 ../src/views/darkroom.c:4001
+#: ../src/gui/gtk.c:195 ../src/views/darkroom.c:5397
 msgid "darktable - darkroom preview"
 msgstr "darktable - darkroom 미리보기"
 
-#: ../src/gui/gtk.c:198
+#: ../src/gui/gtk.c:204
 msgid "tooltips off"
 msgstr "툴팁 끄기"
 
-#: ../src/gui/gtk.c:198
+#: ../src/gui/gtk.c:204
 msgid "tooltips on"
 msgstr "툴팁 켜기"
 
-#: ../src/gui/gtk.c:893
+#: ../src/gui/gtk.c:1037
 msgid "closing darktable..."
 msgstr "darktable을 닫는 중..."
 
-#: ../src/gui/gtk.c:923
+#: ../src/gui/gtk.c:1067
 msgid "exporting to GIMP"
 msgstr "GIMP로 내보내기"
 
-#: ../src/gui/gtk.c:1163
+#: ../src/gui/gtk.c:1348
 msgid "URL opened in web browser"
 msgstr "URL이 웹 브라우저에서 열림"
 
-#: ../src/gui/gtk.c:1167
+#: ../src/gui/gtk.c:1352
 msgid "error while opening URL in web browser"
 msgstr "URL이 웹 브라우저에서 열리는 동안 오류가 발생하였습니다"
 
 #. View menu
-#: ../src/gui/gtk.c:1303
+#: ../src/gui/gtk.c:1533
 msgctxt "menu"
 msgid "Views"
 msgstr "보기"
 
-#: ../src/gui/gtk.c:1307
+#: ../src/gui/gtk.c:1537
 msgctxt "menu"
 msgid "Lighttable"
 msgstr "Lighttable"
 
-#: ../src/gui/gtk.c:1308
+#: ../src/gui/gtk.c:1538
 msgctxt "menu"
 msgid "Darkroom"
 msgstr "Darkroom"
 
-#: ../src/gui/gtk.c:1314
+#: ../src/gui/gtk.c:1544
 msgctxt "menu"
 msgid "Slideshow"
 msgstr "슬라이드 쇼"
 
-#: ../src/gui/gtk.c:1316
+#: ../src/gui/gtk.c:1546
 msgctxt "menu"
 msgid "Map"
 msgstr "맵"
 
-#: ../src/gui/gtk.c:1318
+#: ../src/gui/gtk.c:1548
 msgctxt "menu"
 msgid "Print"
 msgstr "인쇄"
 
-#: ../src/gui/gtk.c:1320
+#: ../src/gui/gtk.c:1550
 msgctxt "menu"
 msgid "Tethering"
 msgstr "테더링"
 
 #. Window menu
-#: ../src/gui/gtk.c:1326
+#: ../src/gui/gtk.c:1556
 msgctxt "menu"
 msgid "Window"
 msgstr "윈도우"
 
 #. Help menu
-#: ../src/gui/gtk.c:1334
+#: ../src/gui/gtk.c:1564
 msgctxt "menu"
 msgid "Help"
 msgstr "도움말"
 
-#: ../src/gui/gtk.c:1338
+#: ../src/gui/gtk.c:1568
 msgctxt "menu"
 msgid "darktable Manual"
 msgstr "darktable 매뉴얼"
 
-#: ../src/gui/gtk.c:1345
+#: ../src/gui/gtk.c:1575
 msgctxt "menu"
 msgid "darktable Homepage"
 msgstr "darktable 홈페이지"
 
-#: ../src/gui/gtk.c:1370
+#: ../src/gui/gtk.c:1607
 msgctxt "menu"
 msgid "Preferences"
 msgstr "환경설정"
 
-#: ../src/gui/gtk.c:1467
+#: ../src/gui/gtk.c:1661
 msgid "panels"
 msgstr "패널"
 
-#: ../src/gui/gtk.c:1506
+#: ../src/gui/gtk.c:1700
 msgid "switch views"
 msgstr "보기 전환"
 
-#: ../src/gui/gtk.c:1507 ../src/views/tethering.c:104
+#: ../src/gui/gtk.c:1701 ../src/views/tethering.c:104
 msgid "tethering"
 msgstr "테더링"
 
-#: ../src/gui/gtk.c:1513 ../src/views/map.c:275
+#: ../src/gui/gtk.c:1707 ../src/views/map.c:275
 msgid "map"
 msgstr "맵"
 
-#: ../src/gui/gtk.c:1515 ../src/views/slideshow.c:394
+#: ../src/gui/gtk.c:1709 ../src/views/slideshow.c:394
 msgid "slideshow"
 msgstr "슬라이드 쇼"
 
 #. Print button
-#: ../src/gui/gtk.c:1517 ../src/libs/print_settings.c:2946
+#: ../src/gui/gtk.c:1711 ../src/libs/print_settings.c:2967
 msgid "print"
 msgstr "인쇄"
 
 #. register ctrl-q to quit:
-#: ../src/gui/gtk.c:1524
+#: ../src/gui/gtk.c:1718
 msgid "quit"
 msgstr "중지"
 
 #. Full-screen accelerator (no ESC handler here to enable quit-slideshow using ESC)
-#: ../src/gui/gtk.c:1528
+#: ../src/gui/gtk.c:1722
 msgid "fullscreen"
 msgstr "전체화면"
 
-#: ../src/gui/gtk.c:1533
+#: ../src/gui/gtk.c:1727
 msgid "collapsing controls"
 msgstr "제어 접기"
 
 #. specific top/bottom toggles
-#: ../src/gui/gtk.c:1536
+#: ../src/gui/gtk.c:1730
 msgid "header"
 msgstr "헤더"
 
-#: ../src/gui/gtk.c:1538
+#: ../src/gui/gtk.c:1732
 msgid "filmstrip and timeline"
 msgstr "필름 스트립과 타임라인"
 
-#: ../src/gui/gtk.c:1540
+#: ../src/gui/gtk.c:1734
 msgid "top toolbar"
 msgstr "상단 도구모음"
 
-#: ../src/gui/gtk.c:1541
+#: ../src/gui/gtk.c:1735
 msgid "bottom toolbar"
 msgstr "하단 도구모음"
 
-#: ../src/gui/gtk.c:1542
+#: ../src/gui/gtk.c:1736
 msgid "all top"
 msgstr "전부 상단"
 
-#: ../src/gui/gtk.c:1543
+#: ../src/gui/gtk.c:1737
 msgid "all bottom"
 msgstr "전부 하단"
 
-#: ../src/gui/gtk.c:1545
+#: ../src/gui/gtk.c:1739
 msgid "toggle tooltip visibility"
 msgstr "툴팁 표시 전환"
 
-#: ../src/gui/gtk.c:1548
+#: ../src/gui/gtk.c:1742
 msgid "reinitialise input devices"
 msgstr "입력 장치 재초기화"
 
-#: ../src/gui/gtk.c:1589
+#: ../src/gui/gtk.c:1783
 msgid "toggle focus-peaking mode"
 msgstr "포커스 피킹 모드 전환"
 
-#: ../src/gui/gtk.c:1596
+#: ../src/gui/gtk.c:1790
 msgid "toggle focus peaking"
 msgstr "포커스 피킹 전환"
 
-#: ../src/gui/gtk.c:1934 ../src/gui/gtk.c:3852 ../src/gui/gtk.c:3857
-#: ../src/gui/gtk.c:3862 ../src/gui/gtk.c:3867
+#: ../src/gui/gtk.c:2132 ../src/gui/gtk.c:4110 ../src/gui/gtk.c:4115
+#: ../src/gui/gtk.c:4120 ../src/gui/gtk.c:4125
 msgid "tabs"
 msgstr "탭"
 
-#: ../src/gui/gtk.c:2020
+#: ../src/gui/gtk.c:2218
 msgid "collapsing panels"
 msgstr "패널 접기"
 
-#: ../src/gui/gtk.c:2021
+#: ../src/gui/gtk.c:2219
 msgid ""
 "this is the first time you pressed the shortcut\n"
 "to collapse all side and top/bottom panels.\n"
@@ -13363,53 +16077,53 @@ msgstr ""
 "\n"
 "지금 모든 패널을 접겠습니까?"
 
-#: ../src/gui/gtk.c:2422
+#: ../src/gui/gtk.c:2687
 msgid "restore defaults"
 msgstr "기본값 복원"
 
-#: ../src/gui/gtk.c:2423
+#: ../src/gui/gtk.c:2688
 msgid "restore the default visibility and position of all modules in this view"
 msgstr "이 보기에서 모든 모듈의 표시 및 위치를 기본값으로 복원"
 
-#: ../src/gui/gtk.c:2505
+#: ../src/gui/gtk.c:2772
 msgid "right-click to show/hide modules"
 msgstr "우클릭하여 모듈 보기/숨기기"
 
-#: ../src/gui/gtk.c:2514
+#: ../src/gui/gtk.c:2781
 msgid "show/hide modules"
 msgstr "모듈 보기/숨기기"
 
 #. ask the user if darktable.org may be accessed
-#: ../src/gui/gtk.c:3312
+#: ../src/gui/gtk.c:3585
 msgid "access the online user manual?"
 msgstr "온라인 사용자 매뉴얼에 접근하시겠습니까?"
 
-#: ../src/gui/gtk.c:3313
+#: ../src/gui/gtk.c:3586
 #, c-format
 msgid "do you want to access `%s'?"
 msgstr "`%s'에 접근하시겠습니까?"
 
-#: ../src/gui/gtk.c:3386
+#: ../src/gui/gtk.c:3608
 msgid "there is no help available for this element"
 msgstr "해당 항목에 대한 도움말이 존재하지 않습니다"
 
 #. font name can only use period as decimal separator
 #. but printf format strings use comma for some locales, so replace comma with period
-#: ../src/gui/gtk.c:3406 ../src/libs/metadata_view.c:839
+#: ../src/gui/gtk.c:3653 ../src/libs/metadata_view.c:853
 #, c-format
 msgid "%.1f"
 msgstr "%.1f"
 
-#: ../src/gui/gtk.c:3408
+#: ../src/gui/gtk.c:3655
 #, c-format
 msgid "Sans %s"
 msgstr "Sans %s"
 
-#: ../src/gui/gtk.c:3740
+#: ../src/gui/gtk.c:3995
 msgid "does not contain pages"
 msgstr "페이지를 포함하지 않음"
 
-#: ../src/gui/gtk.c:3989
+#: ../src/gui/gtk.c:4245
 #, c-format
 msgid "never show more than %d lines"
 msgstr "%d줄 이상을 표시하지 않음"
@@ -13479,20 +16193,14 @@ msgid "$(LABELS.ICONS) - color labels as icons"
 msgstr "$(LABELS.ICONS) - 아이콘 형태의 색상 레이블"
 
 #: ../src/gui/gtkentry.c:107
-msgid "$(IMAGE.TAGS.HIERARCHY) - tags as set in metadata settings, preserving hierarchy"
+msgid ""
+"$(IMAGE.TAGS.HIERARCHY) - tags as set in metadata settings, preserving "
+"hierarchy"
 msgstr "$(IMAGE.TAGS.HIERARCHY) - 메타데이터에서 설정의 태그, 계층 유지"
 
 #: ../src/gui/gtkentry.c:108
 msgid "$(IMAGE.TAGS) - tags as set in metadata settings, flattened"
 msgstr "$(IMAGE.TAGS) - 메타데이터 설정의 태그, 평탄화됨"
-
-#: ../src/gui/gtkentry.c:109
-msgid "$(IMAGE.ID) - image ID"
-msgstr "$(IMAGE.ID) - 이미지 ID"
-
-#: ../src/gui/gtkentry.c:110
-msgid "$(IMAGE.ID.NEXT) - next image ID to be assigned on import"
-msgstr "$(IMAGE.ID.NEXT) - 가져오기 시 할당될 다음 이미지 ID"
 
 #: ../src/gui/gtkentry.c:116
 msgid "$(OPENCL.ACTIVATED) - whether OpenCL is activated"
@@ -13515,7 +16223,7 @@ msgid "from metadata"
 msgstr "메타데이터로 부터"
 
 #: ../src/gui/guides.c:30 ../src/iop/colorcorrection.c:241
-#: ../src/iop/monochrome.c:560
+#: ../src/iop/monochrome.c:558
 msgid "grid"
 msgstr "그리드"
 
@@ -13585,11 +16293,11 @@ msgid "global guide overlay settings"
 msgstr "전체 가이드 오버레이 설정"
 
 #: ../src/gui/guides.c:831 ../src/gui/guides.c:840 ../src/gui/guides.c:847
-#: ../src/gui/guides.c:862 ../src/views/darkroom.c:2897
+#: ../src/gui/guides.c:862 ../src/views/darkroom.c:3517
 msgid "guide lines"
 msgstr "가이드선"
 
-#: ../src/gui/guides.c:831 ../src/iop/clipping.c:2103
+#: ../src/gui/guides.c:831 ../src/iop/clipping.c:2097
 msgid "flip"
 msgstr "반전"
 
@@ -13605,7 +16313,7 @@ msgstr "수평으로"
 msgid "vertically"
 msgstr "수직으로"
 
-#: ../src/gui/guides.c:836 ../src/iop/ashift.c:6139 ../src/iop/clipping.c:2107
+#: ../src/gui/guides.c:836 ../src/iop/ashift.c:6135 ../src/iop/clipping.c:2101
 #: ../src/iop/colorbalance.c:1861
 msgid "both"
 msgstr "양방향"
@@ -13623,7 +16331,8 @@ msgid "set overlay color"
 msgstr "오버레이 색상 설정"
 
 #: ../src/gui/guides.c:865
-msgid "set the contrast between the lightest and darkest part of the guide overlays"
+msgid ""
+"set the contrast between the lightest and darkest part of the guide overlays"
 msgstr "가이드 오버레이의 가장 밝은 부분과 어두운 부분 간 대비를 설정합니다"
 
 #: ../src/gui/guides.c:983 ../src/gui/guides.c:1032
@@ -13637,7 +16346,8 @@ msgstr "이 모듈이 선택된 경우에만 가이드 오버레이를 표시합
 #: ../src/gui/guides.c:1044
 msgid ""
 "change global guide settings\n"
-"note that these settings are applied globally and will impact any module that shows guide overlays"
+"note that these settings are applied globally and will impact any module "
+"that shows guide overlays"
 msgstr ""
 "전체 가이드 설정 변경\n"
 "이 설정은 모든 모듈에 공통으로 적용되며, 가이드 오버레이를 표시하는 모든 모듈에 영향을 줍니다"
@@ -13647,12 +16357,12 @@ msgid "select parts to copy"
 msgstr "복사할 부분 선택"
 
 #: ../src/gui/hist_dialog.c:234 ../src/gui/hist_dialog.c:246
-#: ../src/gui/styles_dialog.c:555
+#: ../src/gui/styles_dialog.c:552
 msgid "select _all"
 msgstr "전체 선택 (&A)"
 
 #: ../src/gui/hist_dialog.c:235 ../src/gui/hist_dialog.c:247
-#: ../src/gui/styles_dialog.c:556
+#: ../src/gui/styles_dialog.c:553
 msgid "select _none"
 msgstr "선택 없음 (&N)"
 
@@ -13669,18 +16379,18 @@ msgstr "덮어쓰기 (&O)"
 msgid "appen_d"
 msgstr "appen_d"
 
-#: ../src/gui/hist_dialog.c:280 ../src/gui/styles_dialog.c:622
-#: ../src/gui/styles_dialog.c:644
+#: ../src/gui/hist_dialog.c:280 ../src/gui/styles_dialog.c:619
+#: ../src/gui/styles_dialog.c:641
 msgid "include"
 msgstr "포함"
 
-#: ../src/gui/hist_dialog.c:308 ../src/gui/styles_dialog.c:698
-#: ../src/gui/styles_dialog.c:704
+#: ../src/gui/hist_dialog.c:308 ../src/gui/styles_dialog.c:695
+#: ../src/gui/styles_dialog.c:701
 msgid "item"
 msgstr "항목"
 
-#: ../src/gui/hist_dialog.c:314 ../src/gui/styles_dialog.c:711
-#: ../src/gui/styles_dialog.c:720
+#: ../src/gui/hist_dialog.c:314 ../src/gui/styles_dialog.c:708
+#: ../src/gui/styles_dialog.c:717
 msgid "mask"
 msgstr "마스크"
 
@@ -13689,11 +16399,11 @@ msgid "can't copy history out of unaltered image"
 msgstr "변경 사항이 없는 이미지에서는 히스토리 복사 불가"
 
 #. grid headers
-#: ../src/gui/import_metadata.c:456
+#: ../src/gui/import_metadata.c:485
 msgid "metadata presets"
 msgstr "메타데이터 프리셋"
 
-#: ../src/gui/import_metadata.c:459
+#: ../src/gui/import_metadata.c:488
 msgid ""
 "metadata to be applied per default\n"
 "double-click on a label to clear the corresponding entry\n"
@@ -13703,14 +16413,15 @@ msgstr ""
 "레이블을 두 번 클릭하여 관련 항목을 지웁니다\n"
 "'프리셋'을 두 번 클릭하여 모든 항목을 지웁니다"
 
-#: ../src/gui/import_metadata.c:469
+#: ../src/gui/import_metadata.c:498
 msgid "from XMP"
 msgstr "XMP로 부터"
 
-#: ../src/gui/import_metadata.c:472
+#: ../src/gui/import_metadata.c:501
 msgid ""
 "selected metadata are imported from image and override the default value.\n"
-"this drives also the 'look for updated XMP files' and 'load sidecar file' actions.\n"
+"this drives also the 'look for updated XMP files' and 'load sidecar file' "
+"actions.\n"
 "CAUTION: not selected metadata are cleaned up when XMP file is updated."
 msgstr ""
 "선택된 메타데이터는 이미지에서 가져오며, 기본값을 덮어씁니다.\n"
@@ -13718,86 +16429,90 @@ msgstr ""
 "주의: XMP 파일이 업데이트 될 때, 선택되지 않은 메타데이터는 제거됩니다."
 
 #. tags
-#: ../src/gui/import_metadata.c:483
+#: ../src/gui/import_metadata.c:512
 msgid "tag presets"
 msgstr "태그 프리셋"
 
-#: ../src/gui/import_metadata.c:497
+#: ../src/gui/import_metadata.c:526
 msgid "comma separated list of tags"
 msgstr "쉼표로 구분된 태그 목록"
 
-#: ../src/gui/metadata_tags.c:90
+#: ../src/gui/metadata_tags.c:92
 msgid "select tag"
 msgstr "선택된 태그"
 
-#: ../src/gui/metadata_tags.c:92
+#: ../src/gui/metadata_tags.c:94
 msgid "_add"
 msgstr "추가 (&A)"
 
-#: ../src/gui/metadata_tags.c:93 ../src/libs/geotagging.c:832
+#: ../src/gui/metadata_tags.c:95 ../src/libs/geotagging.c:833
 msgid "_done"
 msgstr "완료 (&D)"
 
-#: ../src/gui/metadata_tags.c:103
+#: ../src/gui/metadata_tags.c:105
 msgid "list filter"
 msgstr "목록 필터"
 
-#: ../src/gui/metadata_tags.c:109
-msgid "list of available tags. click 'add' button or double-click on tag to add the selected one"
+#: ../src/gui/metadata_tags.c:111
+msgid ""
+"list of available tags. click 'add' button or double-click on tag to add the "
+"selected one"
 msgstr "사용 가능한 태그 목록. '추가' 버튼을 클릭하거나, 태그를 더블 클릭하여 선택된 태그를 추가합니다."
 
-#: ../src/gui/preferences.c:304
+#: ../src/gui/preferences.c:314
 msgid "reset panels in all views"
 msgstr "모든 표시의 패널을 초기화"
 
-#: ../src/gui/preferences.c:305
+#: ../src/gui/preferences.c:315
 msgid ""
 "are you sure?\n"
 "\n"
-"you will not be able to restore your current panel layout and module selection."
+"you will not be able to restore your current panel layout and module "
+"selection."
 msgstr ""
 "확실합니까?\n"
 "\n"
 "현재 패널 레이아웃과 모듈 선택을 복원하실 수 없습니다."
 
 #. language
-#: ../src/gui/preferences.c:332
+#: ../src/gui/preferences.c:348
 msgid "interface language"
 msgstr "인터페이스 언어"
 
-#: ../src/gui/preferences.c:352
+#: ../src/gui/preferences.c:368
 msgid "double-click to reset to the system language"
 msgstr "더블 클릭하여 시스템 언어 초기화"
 
-#: ../src/gui/preferences.c:355
+#: ../src/gui/preferences.c:371
 msgid ""
-"set the language of the user interface. the system default is marked with an * \n"
+"set the language of the user interface. the system default is marked with an "
+"* \n"
 "(restart required)"
 msgstr ""
 "사용자 인터페이스 언어를 설정합니다. 시스템 기본값에는 * 표시가 남겨집니다\n"
 "(재시작 필요)"
 
-#: ../src/gui/preferences.c:367
+#: ../src/gui/preferences.c:383
 msgid "theme"
 msgstr "테마"
 
-#: ../src/gui/preferences.c:398
+#: ../src/gui/preferences.c:414
 msgid "set the theme for the user interface"
 msgstr "사용자 인터페이스의 테마 설정"
 
-#: ../src/gui/preferences.c:412 ../src/gui/preferences.c:419
+#: ../src/gui/preferences.c:429 ../src/gui/preferences.c:436
 msgid "use system font size"
 msgstr "사용자 시스템 폰트 크기"
 
-#: ../src/gui/preferences.c:433 ../src/gui/preferences.c:440
+#: ../src/gui/preferences.c:452 ../src/gui/preferences.c:459
 msgid "font size in points"
 msgstr "포인트 단위의 폰트 크기"
 
-#: ../src/gui/preferences.c:446
+#: ../src/gui/preferences.c:465
 msgid "GUI controls and text DPI"
 msgstr "GUI 제어 및 텍스트 DPI"
 
-#: ../src/gui/preferences.c:456
+#: ../src/gui/preferences.c:475
 msgid ""
 "adjust the global GUI resolution to rescale controls, buttons, labels, etc.\n"
 "increase for a magnified GUI, decrease to fit more content in window.\n"
@@ -13811,70 +16526,70 @@ msgstr ""
 "대부분의 시스템 정의 기본값은 96 DPI입니다.\n"
 "(재시작 필요)"
 
-#: ../src/gui/preferences.c:466
+#: ../src/gui/preferences.c:485
 msgid "reset view panels"
 msgstr "표시 패널 리셋"
 
-#: ../src/gui/preferences.c:468
+#: ../src/gui/preferences.c:487
 msgid "reset hidden panels, their sizes and selected modules in all views"
 msgstr "숨겨진 패널 리셋, 모든 보기에서 패널 사이즈와 선택된 모듈이 리셋됩니다"
 
 #. checkbox to allow user to modify theme with user.css
-#: ../src/gui/preferences.c:475
+#: ../src/gui/preferences.c:494
 msgid "modify selected theme with CSS tweaks below"
 msgstr "아래 CSS 조정하여 선택된 테마 수정"
 
-#: ../src/gui/preferences.c:484
+#: ../src/gui/preferences.c:504
 msgid "modify theme with CSS keyed below (saved to user.css)"
 msgstr "아래 입력한 CSS로 테마 수정 (user.css에 저장됨)"
 
-#: ../src/gui/preferences.c:506
+#: ../src/gui/preferences.c:528
 msgctxt "usercss"
 msgid "save CSS and apply"
 msgstr "CSS 저장 및 적용"
 
-#: ../src/gui/preferences.c:514
+#: ../src/gui/preferences.c:536
 msgid "click to save and apply the CSS tweaks entered in this editor"
 msgstr "클릭하여 에디터에 입력된 CSS 조정 사항 저장 및 적용"
 
-#: ../src/gui/preferences.c:517
+#: ../src/gui/preferences.c:539
 msgid "open help page for CSS tweaks"
 msgstr "CSS 조정에 대한 도움말 페이지 열기"
 
 #. load default text with some pointers
-#: ../src/gui/preferences.c:539
+#: ../src/gui/preferences.c:561
 msgid "ERROR Loading user.css"
 msgstr "user.css를 불러오는 동안 오류가 발생하였습니다"
 
 #. load default text
-#: ../src/gui/preferences.c:548
+#: ../src/gui/preferences.c:570
 msgid "Enter CSS theme tweaks here"
 msgstr "CSS 테마 조정을 이곳에 입력"
 
-#: ../src/gui/preferences.c:562
+#: ../src/gui/preferences.c:585
 msgid "darktable preferences"
 msgstr "darktable 환경설정"
 
-#: ../src/gui/preferences.c:620
+#: ../src/gui/preferences.c:648
 msgid "darktable needs to be restarted for settings to take effect"
 msgstr "설정을 적용하려면 darktable을 재시작해야 합니다"
 
 #. exif
-#: ../src/gui/preferences.c:926 ../src/gui/presets.c:655
+#: ../src/gui/preferences.c:955 ../src/gui/presets.c:655
 #: ../src/libs/metadata_view.c:147
 msgid "model"
 msgstr "모델"
 
-#: ../src/gui/preferences.c:932 ../src/gui/presets.c:663
+#: ../src/gui/preferences.c:961 ../src/gui/presets.c:663
 #: ../src/libs/metadata_view.c:148
 msgid "maker"
 msgstr "메이커"
 
-#: ../src/gui/preferences.c:978
+#: ../src/gui/preferences.c:1007
 msgid "search presets list"
 msgstr "프리셋 목록 검색"
 
-#: ../src/gui/preferences.c:981
+#: ../src/gui/preferences.c:1010
 msgid ""
 "incrementally search the list of presets\n"
 "press up or down keys to cycle through matches"
@@ -13882,55 +16597,332 @@ msgstr ""
 "한 글자 입력할 때마다 프리셋 목록에서 검색\n"
 "위 혹은 아래 화살표 키를 눌러 일치하는 항목으로 이동합니다"
 
-#: ../src/gui/preferences.c:991
+#: ../src/gui/preferences.c:1020
 msgctxt "preferences"
 msgid "import..."
 msgstr "가져오기..."
 
-#: ../src/gui/preferences.c:996
+#: ../src/gui/preferences.c:1025
 msgctxt "preferences"
 msgid "export..."
 msgstr "내보내기..."
 
-#: ../src/gui/preferences.c:1181
+#: ../src/gui/preferences.c:1208
 #, c-format
 msgid "failed to import preset %s"
 msgstr "프리셋 %s를 가져오는 데 실패함"
 
-#: ../src/gui/preferences.c:1193
+#: ../src/gui/preferences.c:1220
 msgid "select preset(s) to import"
 msgstr "가져올 프리셋을 선택 (복수 가능)"
 
-#: ../src/gui/preferences.c:1194 ../src/libs/collect.c:433
-#: ../src/libs/copy_history.c:114 ../src/libs/geotagging.c:952
-#: ../src/libs/import.c:1846 ../src/libs/import.c:1958 ../src/libs/styles.c:595
+#: ../src/gui/preferences.c:1221 ../src/gui/preferences_ai.c:1013
+#: ../src/gui/preferences_ai.c:1484 ../src/gui/welcome.c:170
+#: ../src/libs/collect.c:463 ../src/libs/copy_history.c:114
+#: ../src/libs/geotagging.c:953 ../src/libs/import.c:1816
+#: ../src/libs/import.c:1928 ../src/libs/styles.c:595
 msgid "_open"
 msgstr "열기 (&O)"
 
-#: ../src/gui/preferences.c:1203
+#: ../src/gui/preferences.c:1230
 msgid "darktable preset files"
 msgstr "darktable 프리셋 파일"
 
-#: ../src/gui/preferences.c:1208 ../src/iop/lut3d.c:1601
-#: ../src/libs/copy_history.c:153 ../src/libs/geotagging.c:968
-#: ../src/libs/styles.c:609
+#: ../src/gui/preferences.c:1235 ../src/gui/preferences_ai.c:1498
+#: ../src/iop/lut3d.c:1614 ../src/libs/copy_history.c:153
+#: ../src/libs/geotagging.c:969 ../src/libs/styles.c:609
 msgid "all files"
 msgstr "모든 파일"
+
+#: ../src/gui/preferences_ai.c:164
+msgid "downloaded"
+msgstr "다운로드됨"
+
+#: ../src/gui/preferences_ai.c:166
+msgid "update available"
+msgstr "업데이트 사용 가능"
+
+#: ../src/gui/preferences_ai.c:168
+msgid "update required"
+msgstr "업데이트 필요"
+
+#: ../src/gui/preferences_ai.c:170
+msgid "downloading..."
+msgstr "다운로드 중..."
+
+#: ../src/gui/preferences_ai.c:174
+msgid "not downloaded"
+msgstr "다운로드되지 않음"
+
+#: ../src/gui/preferences_ai.c:395
+msgid "select hardware acceleration for AI inference:"
+msgstr "AI 추론에 사용할 하드웨어 가속을 선택하세요:"
+
+#: ../src/gui/preferences_ai.c:585
+msgid "<i>restart to apply</i>"
+msgstr "<i>적용하려면 재시작하세요</i>"
+
+#: ../src/gui/preferences_ai.c:597
+msgid "<i>not available, will fall back to CPU</i>"
+msgstr "<i>사용할 수 없어 CPU로 대체됩니다</i>"
+
+#: ../src/gui/preferences_ai.c:849
+msgid "downloading AI model"
+msgstr "AI 모델 다운로드 중"
+
+#: ../src/gui/preferences_ai.c:864
+#, c-format
+msgid "downloading: %s"
+msgstr "다운로드 중: %s"
+
+#: ../src/gui/preferences_ai.c:935
+msgid "model download failed"
+msgstr "모델 다운로드에 실패하였습니다"
+
+#: ../src/gui/preferences_ai.c:1010
+msgid "install AI models"
+msgstr "AI 모델 설치"
+
+#: ../src/gui/preferences_ai.c:1018
+msgid "AI model packages (*.dtmodel)"
+msgstr "AI 모델 패키지 (*.dtmodel)"
+
+#: ../src/gui/preferences_ai.c:1109
+msgid "delete model?"
+msgid_plural "delete models?"
+msgstr[0] "모델을 삭제하시겠습니까?"
+
+#: ../src/gui/preferences_ai.c:1111
+#, c-format
+msgid "do you really want to delete %d selected model?"
+msgid_plural "do you really want to delete %d selected models?"
+msgstr[0] "선택한 모델 %d개를 정말로 삭제하시겠습니까?"
+
+#: ../src/gui/preferences_ai.c:1172
+msgid "scope"
+msgstr "범위"
+
+#: ../src/gui/preferences_ai.c:1172
+msgid "author"
+msgstr "작성자"
+
+#: ../src/gui/preferences_ai.c:1173
+msgid "source"
+msgstr "출처"
+
+#: ../src/gui/preferences_ai.c:1173
+msgid "paper"
+msgstr "논문"
+
+#: ../src/gui/preferences_ai.c:1174
+msgid "license"
+msgstr "라이선스"
+
+#: ../src/gui/preferences_ai.c:1174
+msgid "training data"
+msgstr "학습 데이터"
+
+#: ../src/gui/preferences_ai.c:1175
+msgid "data license"
+msgstr "데이터 라이선스"
+
+#: ../src/gui/preferences_ai.c:1257
+msgid "click for model details"
+msgstr "모델 세부 정보를 보려면 클릭"
+
+#: ../src/gui/preferences_ai.c:1341
+#, c-format
+msgid ""
+"ONNX Runtime %s detected.\n"
+"Restart darktable to apply."
+msgstr ""
+"ONNX Runtime %s이(가) 감지되었습니다.\n"
+"적용하려면 darktable을 재시작하세요."
+
+#: ../src/gui/preferences_ai.c:1346
+#, c-format
+msgid ""
+"not a valid ONNX Runtime library:\n"
+"%s"
+msgstr ""
+"유효한 ONNX Runtime 라이브러리가 아닙니다:\n"
+"%s"
+
+#: ../src/gui/preferences_ai.c:1374
+msgid ""
+"no system ONNX Runtime library found.\n"
+"\n"
+"install one via your package manager or use\n"
+"the browse button to select a custom build."
+msgstr ""
+"시스템에 설치된 ONNX Runtime 라이브러리를 찾을 수 없습니다.\n"
+"\n"
+"패키지 관리자로 설치하거나 찾아보기 버튼으로\n"
+"사용자 지정 빌드를 선택하세요."
+
+#: ../src/gui/preferences_ai.c:1389
+#, c-format
+msgid ""
+"ONNX Runtime %s [%s]\n"
+"%s\n"
+"\n"
+"Restart darktable to apply."
+msgstr ""
+"ONNX Runtime %s [%s]\n"
+"%s\n"
+"\n"
+"적용하려면 darktable을 재시작하세요."
+
+#: ../src/gui/preferences_ai.c:1397 ../src/gui/preferences_ai.c:1481
+msgid "select ONNX Runtime library"
+msgstr "ONNX Runtime 라이브러리 선택"
+
+#: ../src/gui/preferences_ai.c:1401 ../src/iop/lut3d.c:1583
+#: ../src/iop/rasterfile.c:383 ../src/libs/neural_restore.c:4237
+msgid "_select"
+msgstr "선택 (&S)"
+
+#: ../src/gui/preferences_ai.c:1407
+msgid "multiple ONNX Runtime libraries found:"
+msgstr "여러 개의 ONNX Runtime 라이브러리를 찾았습니다:"
+
+#: ../src/gui/preferences_ai.c:1489
+msgid "ONNX Runtime (onnxruntime*.dll)"
+msgstr "ONNX Runtime (onnxruntime*.dll)"
+
+#: ../src/gui/preferences_ai.c:1492
+msgid "ONNX Runtime (libonnxruntime.so*)"
+msgstr "ONNX Runtime (libonnxruntime.so*)"
+
+#. enable AI toggle
+#: ../src/gui/preferences_ai.c:1545
+msgid "enable AI features"
+msgstr "AI 기능 활성화"
+
+#. provider dropdown
+#: ../src/gui/preferences_ai.c:1590
+msgid "AI acceleration"
+msgstr "AI 가속"
+
+#: ../src/gui/preferences_ai.c:1601
+msgid "select which GPU to use when the active provider supports more than one"
+msgstr "활성 제공자가 여러 GPU를 지원할 때 사용할 GPU를 선택합니다"
+
+#: ../src/gui/preferences_ai.c:1647
+msgid "ONNX Runtime library"
+msgstr "ONNX Runtime 라이브러리"
+
+#: ../src/gui/preferences_ai.c:1661
+msgid "bundled (DirectML)"
+msgstr "내장 (DirectML)"
+
+#: ../src/gui/preferences_ai.c:1664
+msgid "bundled (CPU only)"
+msgstr "내장 (CPU 전용)"
+
+#: ../src/gui/preferences_ai.c:1667
+msgid ""
+"path to a GPU-enabled ONNX Runtime library.\n"
+"leave empty to use the bundled library.\n"
+"requires restart to take effect."
+msgstr ""
+"GPU를 지원하는 ONNX Runtime 라이브러리의 경로입니다.\n"
+"비워 두면 내장 라이브러리를 사용합니다.\n"
+"적용하려면 재시작이 필요합니다."
+
+#: ../src/gui/preferences_ai.c:1676
+msgid "select a custom ONNX Runtime shared library"
+msgstr "사용자 지정 ONNX Runtime 공유 라이브러리 선택"
+
+#: ../src/gui/preferences_ai.c:1678
+msgid "detect"
+msgstr "감지"
+
+#: ../src/gui/preferences_ai.c:1680
+msgid "search for a system-installed ONNX Runtime library"
+msgstr "시스템에 설치된 ONNX Runtime 라이브러리 검색"
+
+#: ../src/gui/preferences_ai.c:1715
+msgid "models"
+msgstr "모델"
+
+#: ../src/gui/preferences_ai.c:1762
+msgid "select/deselect all"
+msgstr "전체 선택/해제"
+
+#: ../src/gui/preferences_ai.c:1809 ../src/libs/metadata_view.c:137
+msgid "version"
+msgstr "버전"
+
+#: ../src/gui/preferences_ai.c:1818
+msgid "task"
+msgstr "작업"
+
+#: ../src/gui/preferences_ai.c:1833
+msgid "enabled"
+msgstr "활성화됨"
+
+#: ../src/gui/preferences_ai.c:1843
+msgid "status"
+msgstr "상태"
+
+#: ../src/gui/preferences_ai.c:1889
+msgid "download / update default"
+msgstr "기본 모델 다운로드/업데이트"
+
+#: ../src/gui/preferences_ai.c:1891
+msgid "download or update all default models"
+msgstr "모든 기본 모델을 다운로드하거나 업데이트"
+
+#: ../src/gui/preferences_ai.c:1901
+msgid "download / update selected"
+msgstr "선택 항목 다운로드/업데이트"
+
+#: ../src/gui/preferences_ai.c:1903
+msgid "download or update the selected models"
+msgstr "선택한 모델을 다운로드하거나 업데이트"
+
+#. import from file button
+#: ../src/gui/preferences_ai.c:1913
+msgid "import from file…"
+msgstr "파일에서 가져오기…"
+
+#: ../src/gui/preferences_ai.c:1915
+msgid "install a model from a local .dtmodel file"
+msgstr "로컬 .dtmodel 파일에서 모델 설치"
+
+#. delete selected button
+#: ../src/gui/preferences_ai.c:1921
+msgid "delete selected"
+msgstr "선택 항목 삭제"
+
+#: ../src/gui/preferences_ai.c:1923
+msgid "remove the selected models from disk"
+msgstr "선택한 모델을 디스크에서 제거"
+
+#: ../src/gui/preferences_ai.c:1934
+msgid "open help page for AI settings"
+msgstr "AI 설정 도움말 페이지 열기"
+
+#. add to stack
+#: ../src/gui/preferences_ai.c:1946
+msgid "AI"
+msgstr "AI"
 
 #: ../src/gui/presets.c:59
 msgid "non-raw"
 msgstr "RAW가 아님"
 
-#: ../src/gui/presets.c:59 ../src/libs/metadata_view.c:361
+#: ../src/gui/presets.c:59 ../src/libs/metadata_view.c:377
 msgid "raw"
 msgstr "RAW"
 
-#: ../src/gui/presets.c:59 ../src/libs/metadata_view.c:362
+#: ../src/gui/presets.c:59 ../src/libs/metadata_view.c:378
 msgid "HDR"
 msgstr "HDR"
 
 #: ../src/gui/presets.c:59 ../src/iop/monochrome.c:75 ../src/libs/image.c:661
-#: ../src/libs/metadata_view.c:368
+#: ../src/libs/metadata_view.c:384
 msgid "monochrome"
 msgstr "모노크롬"
 
@@ -13939,13 +16931,13 @@ msgstr "모노크롬"
 msgid "preset `%s' is write-protected, can't delete!"
 msgstr "프리셋 `%s'는 쓰기 보호 되어있습니다. 삭제할 수 없습니다!"
 
-#: ../src/gui/presets.c:159 ../src/gui/presets.c:471 ../src/libs/lib.c:236
-#: ../src/libs/modulegroups.c:3890
+#: ../src/gui/presets.c:159 ../src/gui/presets.c:471 ../src/libs/lib.c:271
+#: ../src/libs/modulegroups.c:3974
 msgid "delete preset?"
 msgstr "프리셋을 삭제합니까?"
 
-#: ../src/gui/presets.c:160 ../src/gui/presets.c:472 ../src/libs/lib.c:237
-#: ../src/libs/modulegroups.c:3891
+#: ../src/gui/presets.c:160 ../src/gui/presets.c:472 ../src/libs/lib.c:272
+#: ../src/libs/modulegroups.c:3975
 #, c-format
 msgid "do you really want to delete the preset `%s'?"
 msgstr "정말로 프리셋 `%s'를 삭제하시겠습니까?"
@@ -13956,9 +16948,9 @@ msgstr "정말로 프리셋 `%s'를 삭제하시겠습니까?"
 #. clang-format on
 #. create a shortcut for the new entry
 #. then show edit dialog
-#: ../src/gui/presets.c:208 ../src/gui/presets.c:1031 ../src/gui/presets.c:1034
-#: ../src/gui/presets.c:1037 ../src/libs/lib.c:186 ../src/libs/lib.c:203
-#: ../src/libs/lib.c:211 ../src/libs/lib.c:214
+#: ../src/gui/presets.c:208 ../src/gui/presets.c:1035 ../src/gui/presets.c:1038
+#: ../src/gui/presets.c:1041 ../src/libs/lib.c:221 ../src/libs/lib.c:238
+#: ../src/libs/lib.c:246 ../src/libs/lib.c:249
 msgid "new preset"
 msgstr "새 프리셋"
 
@@ -13983,7 +16975,7 @@ msgstr ""
 "프리셋 `%s'가 이미 존재합니다.\n"
 "덮어쓰시겠습니까?"
 
-#: ../src/gui/presets.c:430 ../src/imageio/storage/disk.c:198
+#: ../src/gui/presets.c:430 ../src/imageio/storage/disk.c:200
 #: ../src/imageio/storage/gallery.c:149 ../src/imageio/storage/latex.c:145
 msgid "_select as output destination"
 msgstr "출력할 위치 선택 (&S)"
@@ -13993,7 +16985,7 @@ msgstr "출력할 위치 선택 (&S)"
 msgid "preset %s was successfully exported"
 msgstr "프리셋 %s가 성공적으로 내보내짐"
 
-#: ../src/gui/presets.c:567
+#: ../src/gui/presets.c:566
 #, c-format
 msgid "edit `%s' for module `%s'"
 msgstr "`%s'를 모듈 `%s'에서 수정"
@@ -14002,8 +16994,8 @@ msgstr "`%s'를 모듈 `%s'에서 수정"
 msgid "_export..."
 msgstr "내보내기... (&E)"
 
-#: ../src/gui/presets.c:572 ../src/libs/tagging.c:1672
-#: ../src/libs/tagging.c:1761
+#: ../src/gui/presets.c:572 ../src/libs/tagging.c:1702
+#: ../src/libs/tagging.c:1791
 msgid "_delete"
 msgstr "삭제 (&D)"
 
@@ -14020,7 +17012,9 @@ msgid "reset all module parameters to their default values"
 msgstr "모든 모듈 파라메터를 기본값으로 초기화"
 
 #: ../src/gui/presets.c:605
-msgid "the parameters will be reset to their default values, which may be automatically set based on image metadata"
+msgid ""
+"the parameters will be reset to their default values, which may be "
+"automatically set based on image metadata"
 msgstr "모든 파라메터를 기본값으로 초기화하며, 이 기본값은 이미지 메타데이터에 따라 자동으로 결정됩니다"
 
 #: ../src/gui/presets.c:610
@@ -14032,7 +17026,9 @@ msgid "only show this preset for matching images"
 msgstr "오직 일치하는 이미지에만 이 프리셋 표시"
 
 #: ../src/gui/presets.c:615
-msgid "be very careful with this option. this might be the last time you see your preset."
+msgid ""
+"be very careful with this option. this might be the last time you see your "
+"preset."
 msgstr "이 옵션은 매우 조심해서 사용하세요. 당신의 프리셋을 마지막으로 보게 될 수도 있습니다."
 
 #: ../src/gui/presets.c:654
@@ -14095,7 +17091,7 @@ msgstr "형식"
 msgid "select image types you want this preset to be available for"
 msgstr "이 프리셋으로 사용할 이미지 유형을 선택"
 
-#: ../src/gui/presets.c:762 ../src/libs/filtering.c:1250
+#: ../src/gui/presets.c:762 ../src/libs/filtering.c:1257
 msgid "and"
 msgstr "그리고"
 
@@ -14103,79 +17099,75 @@ msgstr "그리고"
 msgid "∞"
 msgstr "∞"
 
-#: ../src/gui/presets.c:975
+#: ../src/gui/presets.c:979
 #, c-format
 msgid "preset `%s' is write-protected! can't edit it!"
 msgstr "프리셋 `%s'는 쓰기 보호 되어있습니다! 수정할 수 없습니다!"
 
-#: ../src/gui/presets.c:999 ../src/libs/lib.c:156
+#: ../src/gui/presets.c:1003 ../src/libs/lib.c:191
 msgid "update preset?"
 msgstr "프리셋을 업데이트합니까?"
 
-#: ../src/gui/presets.c:1000 ../src/libs/lib.c:157
+#: ../src/gui/presets.c:1004 ../src/libs/lib.c:192
 #, c-format
 msgid "do you really want to update the preset `%s'?"
 msgstr "정말로 프리셋 `%s'를 업데이트합니까?"
 
-#: ../src/gui/presets.c:1126
+#: ../src/gui/presets.c:1130
 msgid "(first)"
 msgstr "(처음)"
 
-#: ../src/gui/presets.c:1126
+#: ../src/gui/presets.c:1130
 msgid "(last)"
 msgstr "(마지막)"
 
-#: ../src/gui/presets.c:1161
+#: ../src/gui/presets.c:1165
 #, c-format
 msgid "preset '%s' %s"
 msgstr "프리셋 '%s' %s"
 
-#: ../src/gui/presets.c:1162
+#: ../src/gui/presets.c:1166
 msgid "no presets"
 msgstr "프리셋 없음"
 
-#: ../src/gui/presets.c:1426 ../src/libs/modulegroups.c:3966
-#: ../src/libs/modulegroups.c:3974
+#: ../src/gui/presets.c:1425 ../src/libs/modulegroups.c:4050
+#: ../src/libs/modulegroups.c:4058
 msgid "manage module layouts"
 msgstr "모듈 레이아웃 관리"
 
-#: ../src/gui/presets.c:1435
+#: ../src/gui/presets.c:1434
 msgid "manage quick presets"
 msgstr "빠른 프리셋 관리"
 
-#: ../src/gui/presets.c:1613
+#: ../src/gui/presets.c:1616
 msgid "manage quick presets list..."
 msgstr "빠른 프리셋 목록 관리..."
 
-#: ../src/gui/presets.c:1780
+#: ../src/gui/presets.c:1771
 msgid "disabled: wrong module version"
 msgstr "불가능: 잘못된 모듈 버전"
 
-#: ../src/gui/presets.c:1799 ../src/libs/lib.c:547
+#: ../src/gui/presets.c:1790 ../src/libs/lib.c:587
 msgid "edit this preset.."
 msgstr "이 프리셋을 편집.."
 
-#: ../src/gui/presets.c:1804 ../src/libs/lib.c:551
+#: ../src/gui/presets.c:1795 ../src/libs/lib.c:591
 msgid "delete this preset"
 msgstr "이 프리셋을 삭제"
 
-#: ../src/gui/presets.c:1811 ../src/libs/lib.c:559
+#: ../src/gui/presets.c:1802 ../src/libs/lib.c:599
 msgid "store new preset.."
 msgstr "새 프리셋 저장.."
 
-#: ../src/gui/presets.c:1821 ../src/libs/lib.c:573
+#: ../src/gui/presets.c:1812 ../src/libs/lib.c:613
 msgid "update preset"
 msgstr "프리셋 업데이트"
 
-#: ../src/gui/splash.c:153
-msgid "darktable starting"
-msgstr "darktable 시작 중"
-
-#: ../src/gui/splash.c:160
+#: ../src/gui/splash.c:118
 msgid "initializing"
 msgstr "초기화 중"
 
-#: ../src/gui/splash.c:193 ../src/gui/splash.c:202
+#: ../src/gui/splash.c:150 ../src/gui/splash.c:161
 msgid ""
 "Photography workflow application\n"
 "and RAW developer"
@@ -14183,24 +17175,12 @@ msgstr ""
 "사진 워크플로우 애플리케이션\n"
 "및 RAW 현상 애플리케이션"
 
-#: ../src/gui/splash.c:328
-msgid "darktable shutdown"
-msgstr "darktable 종료"
-
-#: ../src/gui/splash.c:341
-msgid "darktable is now shutting down"
-msgstr "darktable이 지금 종료되는 중입니다"
-
-#: ../src/gui/splash.c:343
-msgid "please wait while background jobs finish"
-msgstr "백그라운드 작업이 끝날 때까지 기다려 주세요"
-
-#: ../src/gui/styles_dialog.c:233 ../src/libs/styles.c:501
+#: ../src/gui/styles_dialog.c:234 ../src/libs/styles.c:501
 #: ../src/libs/styles.c:654
 msgid "overwrite style?"
 msgstr "스타일을 덮어쓰시겠습니까?"
 
-#: ../src/gui/styles_dialog.c:234
+#: ../src/gui/styles_dialog.c:235
 #, c-format
 msgid ""
 "style `%s' already exists.\n"
@@ -14209,78 +17189,223 @@ msgstr ""
 "스타일 `%s'가 이미 존재합니다.\n"
 "덮어쓰시겠습니까까?"
 
-#: ../src/gui/styles_dialog.c:263 ../src/gui/styles_dialog.c:344
+#: ../src/gui/styles_dialog.c:264 ../src/gui/styles_dialog.c:343
 msgid "please give style a name"
 msgstr "스타일 이름을 입력하세요"
 
-#: ../src/gui/styles_dialog.c:267 ../src/gui/styles_dialog.c:348
+#: ../src/gui/styles_dialog.c:268 ../src/gui/styles_dialog.c:347
 msgid "unnamed style"
 msgstr "이름이 없는 스타일"
 
-#: ../src/gui/styles_dialog.c:333
+#: ../src/gui/styles_dialog.c:332
 #, c-format
 msgid "style %s was successfully saved"
 msgstr "스타일 %s가 성공적으로 저장되었습니다"
 
-#: ../src/gui/styles_dialog.c:541
+#: ../src/gui/styles_dialog.c:538
 msgid "edit style"
 msgstr "스타일 수정"
 
-#: ../src/gui/styles_dialog.c:542
+#: ../src/gui/styles_dialog.c:539
 msgid "duplicate style"
 msgstr "스타일 복제"
 
-#: ../src/gui/styles_dialog.c:545
+#: ../src/gui/styles_dialog.c:542
 msgid "creates a duplicate of the style before applying changes"
 msgstr "변경을 적용하기 전에 스타일 복제 제작"
 
-#: ../src/gui/styles_dialog.c:549
+#: ../src/gui/styles_dialog.c:546
 msgid "create new style"
 msgstr "새 스타일 제작"
 
-#: ../src/gui/styles_dialog.c:575
+#: ../src/gui/styles_dialog.c:572
 msgid "enter a name for the new style"
 msgstr "새 스타일의 이름을 입력하세요"
 
-#: ../src/gui/styles_dialog.c:584
+#: ../src/gui/styles_dialog.c:581
 msgid "enter a description for the new style, this description is searchable"
 msgstr "새 스타일에 대한 설명을 입력. 이 설명은 검색 가능합니다"
 
-#: ../src/gui/styles_dialog.c:622
+#: ../src/gui/styles_dialog.c:619
 msgid "keep"
 msgstr "유지"
 
-#: ../src/gui/styles_dialog.c:842
+#: ../src/gui/styles_dialog.c:839
 msgid "can't create style out of unaltered image"
 msgstr "변경되지 않은 이미지에서는 스타일 생성이 불가능합니다"
 
-#: ../src/imageio/format/avif.c:95 ../src/imageio/format/jxl.c:581
-#: ../src/imageio/format/pdf.c:80 ../src/imageio/format/png.c:690
-#: ../src/imageio/format/tiff.c:884 ../src/imageio/format/xcf.c:361
+#: ../src/gui/welcome.c:669 ../src/gui/welcome.c:689
+msgid "Welcome to darktable!"
+msgstr "darktable에 오신 것을 환영합니다!"
+
+#. Navigation buttons (right-aligned)
+#: ../src/gui/welcome.c:739
+msgid "_prev"
+msgstr "이전"
+
+#: ../src/gui/welcome.c:742
+msgid "_next"
+msgstr "다음"
+
+#: ../src/gui/welcome.c:796
+msgid "let's set up a few options to get you started."
+msgstr "시작하기 위해 몇 가지 옵션을 설정해 보겠습니다."
+
+#: ../src/gui/welcome.c:799
+msgid ""
+"if you are unsure, don't worry! just go ahead with the default, you can "
+"always change all values later in the <b>preferences</b>."
+msgstr "확실하지 않아도 걱정하지 마세요! 기본값으로 진행하면 되고, 모든 값은 나중에 <b>환경설정</b>에서 언제든지 변경할 수 있습니다."
+
+#: ../src/gui/welcome.c:804
+msgid ""
+"you can close this window at any time, in which case the defaults will be "
+"applied."
+msgstr "이 창은 언제든지 닫을 수 있으며, 그럴 경우 기본값이 적용됩니다."
+
+#: ../src/gui/welcome.c:837
+msgid "<b>You are all set!</b>"
+msgstr "<b>모든 준비가 끝났습니다!</b>"
+
+#: ../src/gui/welcome.c:840
+msgid ""
+"darktable is extremely configurable and has a wealth of options. Here we "
+"covered just the most essential ones — make sure to explore the "
+"<b>preferences</b> to get the full picture."
+msgstr "darktable은 매우 유연하게 설정할 수 있고 수많은 옵션을 제공합니다. 여기서는 가장 핵심적인 것만 다루었으니, <b>환경설정</b>을 꼭 살펴보고 전체를 파악해 보세요."
+
+#. xgettext: %s is a URL; keep <a href="%s"> and </a> unchanged
+#: ../src/gui/welcome.c:849
+#, c-format
+msgid ""
+"Read the <a href=\"%s\">user manual</a> to learn more and make the most of "
+"darktable."
+msgstr "<a href=\"%s\">사용자 매뉴얼</a>을 읽고 darktable을 더 깊이 이해하여 최대한 활용해 보세요."
+
+#: ../src/gui/welcome.c:859
+msgid ""
+"And remember that you can always click on the <b>?</b> on the top toolbar to "
+"get help right where you need it."
+msgstr "그리고 상단 툴바의 <b>?</b>를 클릭하면 필요한 곳에서 바로 도움말을 볼 수 있다는 점을 기억하세요."
+
+#: ../src/gui/welcome.c:864
+msgid "Happy editing with darktable!"
+msgstr "darktable과 함께 즐거운 편집이 되기를 바랍니다!"
+
+#. add a memory workspace just after default one
+#: ../src/gui/workspace.c:54 ../src/gui/workspace.c:590
+msgid "memory"
+msgstr "메모리"
+
+#: ../src/gui/workspace.c:297
+msgid "delete workspace"
+msgstr "워크스페이스 삭제"
+
+#: ../src/gui/workspace.c:298
+#, c-format
+msgid ""
+"WARNING\n"
+"\n"
+"do you really want to delete the '%s' workspace?\n"
+"\n"
+"if XMP writing is not activated, the editing work will be lost."
+msgstr ""
+"경고\n"
+"\n"
+"'%s' 워크스페이스를 정말 삭제하시겠습니까?\n"
+"\n"
+"XMP 쓰기가 활성화되어 있지 않으면 편집 작업이 손실됩니다."
+
+#: ../src/gui/workspace.c:409 ../src/gui/workspace.c:422
+msgid "create workspace"
+msgstr "워크스페이스 생성"
+
+#: ../src/gui/workspace.c:410
+msgid ""
+"WARNING\n"
+"\n"
+"the names \"default\" and \"memory\" are reserved.\n"
+"\n"
+"choose a different name."
+msgstr ""
+"경고\n"
+"\n"
+"\"default\"와 \"memory\"라는 이름은 예약되어 있습니다.\n"
+"\n"
+"다른 이름을 선택하세요."
+
+#: ../src/gui/workspace.c:419
+#, c-format
+msgid ""
+"WARNING\n"
+"\n"
+"a workspace named \"%s\" already exists.\n"
+"\n"
+"choose a different name."
+msgstr ""
+"경고\n"
+"\n"
+"\"%s\"(이)라는 워크스페이스가 이미 존재합니다.\n"
+"\n"
+"다른 이름을 선택하세요."
+
+#: ../src/gui/workspace.c:569
+msgid "darktable - select a workspace"
+msgstr "darktable - 워크스페이스 선택"
+
+#: ../src/gui/workspace.c:581
+msgid "select an existing workspace"
+msgstr "기존 워크스페이스 선택"
+
+#: ../src/gui/workspace.c:617
+msgid "remember selection and don't ask again"
+msgstr "선택을 기억하고 다시 묻지 않기"
+
+#: ../src/gui/workspace.c:632
+msgid "or create a new one"
+msgstr "또는 새로 생성"
+
+#: ../src/gui/workspace.c:640 ../src/libs/session.c:104
+msgid "create"
+msgstr "생성"
+
+#: ../src/gui/workspace.c:655
+msgid "copy settings from existing workspace"
+msgstr "기존 워크스페이스에서 설정 복사"
+
+#: ../src/imageio/format/avif.c:95 ../src/imageio/format/heif.c:689
+#: ../src/imageio/format/jxl.c:587 ../src/imageio/format/pdf.c:80
+#: ../src/imageio/format/png.c:690 ../src/imageio/format/tiff.c:884
+#: ../src/imageio/format/xcf.c:361 ../src/libs/neural_restore.c:4402
 msgid "8 bit"
 msgstr "8 비트"
 
-#: ../src/imageio/format/avif.c:99 ../src/imageio/format/jxl.c:581
+#: ../src/imageio/format/avif.c:99 ../src/imageio/format/heif.c:689
+#: ../src/imageio/format/jxl.c:587
 msgid "10 bit"
 msgstr "10 비트"
 
-#: ../src/imageio/format/avif.c:103 ../src/imageio/format/jxl.c:581
+#: ../src/imageio/format/avif.c:103 ../src/imageio/format/heif.c:689
+#: ../src/imageio/format/jxl.c:587
 msgid "12 bit"
 msgstr "12 비트"
 
-#: ../src/imageio/format/avif.c:116 ../src/imageio/format/webp.c:411
+#: ../src/imageio/format/avif.c:116 ../src/imageio/format/heif.c:693
+#: ../src/imageio/format/webp.c:411
 msgid "lossless"
 msgstr "무손실"
 
-#: ../src/imageio/format/avif.c:118 ../src/imageio/format/webp.c:411
+#: ../src/imageio/format/avif.c:118 ../src/imageio/format/heif.c:693
+#: ../src/imageio/format/webp.c:411
 msgid "lossy"
 msgstr "손실"
 
 #. Bit depth combo box
-#: ../src/imageio/format/avif.c:936 ../src/imageio/format/exr.cc:589
-#: ../src/imageio/format/jxl.c:579 ../src/imageio/format/pdf.c:678
-#: ../src/imageio/format/png.c:688 ../src/imageio/format/tiff.c:880
-#: ../src/imageio/format/xcf.c:358
+#: ../src/imageio/format/avif.c:936 ../src/imageio/format/exr.cc:621
+#: ../src/imageio/format/heif.c:687 ../src/imageio/format/jxl.c:585
+#: ../src/imageio/format/pdf.c:678 ../src/imageio/format/png.c:688
+#: ../src/imageio/format/tiff.c:880 ../src/imageio/format/xcf.c:358
+#: ../src/libs/neural_restore.c:4399
 msgid "bit depth"
 msgstr "비트 깊이"
 
@@ -14311,7 +17436,8 @@ msgstr "타일링"
 msgid ""
 "tile an image into segments.\n"
 "\n"
-"makes encoding faster, but increases the file size. the loss of image quality is negligible."
+"makes encoding faster, but increases the file size. the loss of image "
+"quality is negligible."
 msgstr ""
 "이미지를 여러 부분으로 분할합니다.\n"
 "\n"
@@ -14319,10 +17445,10 @@ msgstr ""
 
 #. compression
 #. Compression method combo box
-#: ../src/imageio/format/avif.c:981 ../src/imageio/format/exr.cc:599
-#: ../src/imageio/format/pdf.c:693 ../src/imageio/format/png.c:702
-#: ../src/imageio/format/tiff.c:900 ../src/imageio/format/webp.c:409
-#: ../src/libs/masks.c:112
+#: ../src/imageio/format/avif.c:981 ../src/imageio/format/exr.cc:631
+#: ../src/imageio/format/heif.c:691 ../src/imageio/format/pdf.c:693
+#: ../src/imageio/format/png.c:702 ../src/imageio/format/tiff.c:900
+#: ../src/imageio/format/webp.c:409 ../src/libs/masks.c:192
 msgid "compression"
 msgstr "압축"
 
@@ -14335,17 +17461,19 @@ msgstr "이미지 압축"
 #. step
 #. default
 #. digits
-#: ../src/imageio/format/avif.c:1003 ../src/imageio/format/j2k.c:707
-#: ../src/imageio/format/jpeg.c:578 ../src/imageio/format/jxl.c:605
-#: ../src/imageio/format/webp.c:419 ../src/libs/camera.c:588
+#: ../src/imageio/format/avif.c:1003 ../src/imageio/format/heif.c:706
+#: ../src/imageio/format/j2k.c:707 ../src/imageio/format/jpeg.c:578
+#: ../src/imageio/format/jxl.c:611 ../src/imageio/format/webp.c:419
+#: ../src/libs/camera.c:588
 msgid "quality"
 msgstr "품질"
 
-#: ../src/imageio/format/avif.c:1006
+#: ../src/imageio/format/avif.c:1006 ../src/imageio/format/heif.c:709
 msgid "the quality of an image, less quality means fewer details"
 msgstr "이미지의 품질, 품질값이 낮으면 상세함이 낮음"
 
-#: ../src/imageio/format/avif.c:1018 ../src/imageio/format/jpeg.c:587
+#: ../src/imageio/format/avif.c:1018 ../src/imageio/format/heif.c:722
+#: ../src/imageio/format/jpeg.c:587
 msgid "chroma subsampling"
 msgstr "채도(크로마) 서브샘플링"
 
@@ -14365,15 +17493,18 @@ msgstr ""
 "4:2:2: 색상 샘플링 비율을 수평으로 절반으로 줄임\n"
 "4:2:0: 색상 샘플링 비율을 수평 및 수직으로 절반으로 줄임"
 
-#: ../src/imageio/format/avif.c:1026 ../src/imageio/format/jpeg.c:597
+#: ../src/imageio/format/avif.c:1026 ../src/imageio/format/heif.c:731
+#: ../src/imageio/format/jpeg.c:597
 msgid "4:4:4"
 msgstr "4:4:4"
 
-#: ../src/imageio/format/avif.c:1026 ../src/imageio/format/jpeg.c:597
+#: ../src/imageio/format/avif.c:1026 ../src/imageio/format/heif.c:731
+#: ../src/imageio/format/jpeg.c:597
 msgid "4:2:2"
 msgstr "4:2:2"
 
-#: ../src/imageio/format/avif.c:1026 ../src/imageio/format/jpeg.c:597
+#: ../src/imageio/format/avif.c:1026 ../src/imageio/format/heif.c:731
+#: ../src/imageio/format/jpeg.c:597
 msgid "4:2:0"
 msgstr "4:2:0"
 
@@ -14390,63 +17521,88 @@ msgstr ""
 "선택한 파일을 1:1로 복사합니다.\n"
 "아래의 전역 옵션은 적용되지 않습니다!"
 
-#: ../src/imageio/format/exr.cc:215
-msgid "the selected output profile doesn't work well with EXR"
-msgstr "선택된 출력 프로파일은 EXR 형식과 잘 호환되지 않습니다"
+#: ../src/imageio/format/exr.cc:246
+msgid ""
+"the selected output profile isn't linear, expect incorrect display by image "
+"viewers"
+msgstr "선택한 출력 프로파일이 선형이 아니므로 이미지 뷰어에서 잘못 표시될 수 있습니다"
 
-#: ../src/imageio/format/exr.cc:564
+#: ../src/imageio/format/exr.cc:596
 msgid "OpenEXR"
 msgstr "OpenEXR"
 
-#: ../src/imageio/format/exr.cc:591
+#: ../src/imageio/format/exr.cc:623
 msgid "16 bit (float)"
 msgstr "16 비트 (실수)"
 
-#: ../src/imageio/format/exr.cc:591 ../src/imageio/format/jxl.c:582
+#: ../src/imageio/format/exr.cc:623 ../src/imageio/format/jxl.c:588
 #: ../src/imageio/format/tiff.c:884 ../src/imageio/format/xcf.c:361
+#: ../src/libs/neural_restore.c:4402
 msgid "32 bit (float)"
 msgstr "32 비트 (실수)"
 
-#: ../src/imageio/format/exr.cc:601 ../src/imageio/format/pdf.c:699
+#: ../src/imageio/format/exr.cc:633 ../src/imageio/format/pdf.c:699
 #: ../src/imageio/format/tiff.c:901
 msgid "uncompressed"
 msgstr "비압축"
 
-#: ../src/imageio/format/exr.cc:602
+#: ../src/imageio/format/exr.cc:634
 msgid "RLE"
 msgstr "RLE"
 
-#: ../src/imageio/format/exr.cc:603
+#: ../src/imageio/format/exr.cc:635
 msgid "ZIPS"
 msgstr "ZIPS"
 
-#: ../src/imageio/format/exr.cc:604
+#: ../src/imageio/format/exr.cc:636
 msgid "ZIP"
 msgstr "ZIP"
 
-#: ../src/imageio/format/exr.cc:605
+#: ../src/imageio/format/exr.cc:637
 msgid "PIZ"
 msgstr "PIZ"
 
-#: ../src/imageio/format/exr.cc:606
+#: ../src/imageio/format/exr.cc:638
 msgid "PXR24"
 msgstr "PXR24"
 
-#: ../src/imageio/format/exr.cc:607
+#: ../src/imageio/format/exr.cc:639
 msgid "B44"
 msgstr "B44"
 
-#: ../src/imageio/format/exr.cc:608
+#: ../src/imageio/format/exr.cc:640
 msgid "B44A"
 msgstr "B44A"
 
-#: ../src/imageio/format/exr.cc:609
+#: ../src/imageio/format/exr.cc:641
 msgid "DWAA"
 msgstr "DWAA"
 
-#: ../src/imageio/format/exr.cc:610
+#: ../src/imageio/format/exr.cc:642
 msgid "DWAB"
 msgstr "DWAB"
+
+#: ../src/imageio/format/exr.cc:645
+msgid "HTJ2K256"
+msgstr "HTJ2K256"
+
+#: ../src/imageio/format/exr.cc:646
+msgid "HTJ2K32"
+msgstr "HTJ2K32"
+
+#: ../src/imageio/format/heif.c:723
+msgid ""
+"chroma subsampling setting for HEIF encoder.\n"
+"auto - use subsampling determined by the quality value\n"
+"4:4:4 - no chroma subsampling\n"
+"4:2:2 - color sampling rate halved horizontally\n"
+"4:2:0 - color sampling rate halved horizontally and vertically"
+msgstr ""
+"HEIF 인코더의 크로마 서브샘플링 설정입니다.\n"
+"자동 - 품질 값에 따라 결정된 서브샘플링 사용\n"
+"4:4:4 - 크로마 서브샘플링 없음\n"
+"4:2:2 - 색상 샘플링 비율을 수평으로 절반\n"
+"4:2:0 - 색상 샘플링 비율을 수평과 수직으로 절반"
 
 #: ../src/imageio/format/j2k.c:448
 msgid "unable to attach output profile to JP2"
@@ -14496,26 +17652,26 @@ msgstr ""
 msgid "4:4:0"
 msgstr "4:4:0"
 
-#: ../src/imageio/format/jxl.c:582 ../src/imageio/format/pdf.c:81
+#: ../src/imageio/format/jxl.c:588 ../src/imageio/format/pdf.c:81
 #: ../src/imageio/format/png.c:690 ../src/imageio/format/tiff.c:884
-#: ../src/imageio/format/xcf.c:361
+#: ../src/imageio/format/xcf.c:361 ../src/libs/neural_restore.c:4402
 msgid "16 bit"
 msgstr "16 비트"
 
 #. Pixel format combo box
-#: ../src/imageio/format/jxl.c:587 ../src/imageio/format/tiff.c:887
+#: ../src/imageio/format/jxl.c:593 ../src/imageio/format/tiff.c:887
 msgid "pixel type"
 msgstr "픽셀 타입"
 
-#: ../src/imageio/format/jxl.c:589 ../src/imageio/format/tiff.c:888
+#: ../src/imageio/format/jxl.c:595 ../src/imageio/format/tiff.c:888
 msgid "unsigned integer"
 msgstr "부호 없는 정수"
 
-#: ../src/imageio/format/jxl.c:589 ../src/imageio/format/tiff.c:888
+#: ../src/imageio/format/jxl.c:595 ../src/imageio/format/tiff.c:888
 msgid "floating point"
 msgstr "부동소수점"
 
-#: ../src/imageio/format/jxl.c:607
+#: ../src/imageio/format/jxl.c:613
 msgid ""
 "the quality of the output image\n"
 "0-29 = very lossy\n"
@@ -14527,42 +17683,21 @@ msgstr ""
 "30-99 = JPEG 수준의 품질\n"
 "100 = 무손실"
 
-#: ../src/imageio/format/jxl.c:615
-msgid "encoding color profile"
-msgstr "인코딩 색상 프로파일"
-
-#: ../src/imageio/format/jxl.c:616
-msgid ""
-"the color profile used by the encoder\n"
-"permit internal XYB color space conversion for more efficient lossy compression,\n"
-"or ensure no conversion to keep original image color space (implied for lossless)"
-msgstr ""
-"인코더가 사용하는 색상 프로파일입니다\n"
-"손실 압축의 높은 효율성을 위해 내부 XYB 색공간 변환을 허용할 수 있으며,\n"
-"또는 색상 공간의 변화 없이 원본 색상 공간을 유지할 수 있습니다. (무손실 압축)"
-
-#: ../src/imageio/format/jxl.c:619
-msgid "internal"
-msgstr "내부"
-
-#: ../src/imageio/format/jxl.c:619 ../src/libs/duplicate.c:405
-#: ../src/libs/history.c:1141 ../src/libs/snapshots.c:928
-msgid "original"
-msgstr "원본"
-
-#: ../src/imageio/format/jxl.c:633
+#: ../src/imageio/format/jxl.c:649
 msgid "encoding effort"
 msgstr "인코딩 수준"
 
-#: ../src/imageio/format/jxl.c:635
-msgid "the effort used to encode the image, higher efforts will have better results at the expense of longer encoding times"
+#: ../src/imageio/format/jxl.c:651
+msgid ""
+"the effort used to encode the image, higher efforts will have better results "
+"at the expense of longer encoding times"
 msgstr "이미지를 인코딩하기 위해 사용되는 수준. 수준이 높아질 수록 인코딩 시간은 길어지지만, 더 좋은 결과를 가져옵니다"
 
-#: ../src/imageio/format/jxl.c:645
+#: ../src/imageio/format/jxl.c:661
 msgid "decoding speed"
 msgstr "디코딩 속도"
 
-#: ../src/imageio/format/jxl.c:647
+#: ../src/imageio/format/jxl.c:663
 msgid "the preferred decoding speed with some sacrifice of quality"
 msgstr "품질 손상을 감수하면서 우선적으로 사용할 디코딩 속도"
 
@@ -14574,7 +17709,7 @@ msgstr "잘못된 용지 크기"
 msgid "invalid border size, using 0"
 msgstr "잘못된 테두리 크기, 0을 사용합니다"
 
-#: ../src/imageio/format/pdf.c:257 ../src/imageio/storage/disk.c:489
+#: ../src/imageio/format/pdf.c:257 ../src/imageio/storage/disk.c:538
 #: ../src/imageio/storage/email.c:188 ../src/imageio/storage/gallery.c:406
 #: ../src/imageio/storage/gallery.c:448 ../src/imageio/storage/piwigo.c:1366
 #, c-format
@@ -14591,7 +17726,7 @@ msgstr "PDF의 제목을 입력하세요"
 
 #. paper size
 #. // papers
-#: ../src/imageio/format/pdf.c:602 ../src/libs/print_settings.c:2588
+#: ../src/imageio/format/pdf.c:602 ../src/libs/print_settings.c:2608
 msgid "paper size"
 msgstr "용지 크기"
 
@@ -14630,8 +17765,8 @@ msgstr ""
 "예: 10 mm, 1 inch"
 
 #. dpi
-#: ../src/imageio/format/pdf.c:638 ../src/libs/export.c:1494
-#: ../src/libs/export.c:1522
+#: ../src/imageio/format/pdf.c:638 ../src/libs/export.c:1512
+#: ../src/libs/export.c:1540
 msgid "dpi"
 msgstr "dpi"
 
@@ -14645,7 +17780,9 @@ msgid "rotate images"
 msgstr "이미지 회전"
 
 #: ../src/imageio/format/pdf.c:649
-msgid "images can be rotated to match the PDF orientation to waste less space when printing"
+msgid ""
+"images can be rotated to match the PDF orientation to waste less space when "
+"printing"
 msgstr "인쇄 시 공간 낭비를 줄이기 위해 이미지는 PDF 방향에 맞춰 회전될 수 있습니다"
 
 #. pages all|single images|contact sheet
@@ -14776,7 +17913,9 @@ msgstr "XCF"
 
 #: ../src/imageio/imageio.c:1114
 #, c-format
-msgid "failed to allocate memory for %s, please lower the threads used for export or buy more memory."
+msgid ""
+"failed to allocate memory for %s, please lower the threads used for export "
+"or buy more memory."
 msgstr "%s에 대한 메모리 할당에 실패했습니다, 내보내기에 사용하는 스레드 수를 줄이거나 더 많은 메모리를 구매하세요."
 
 #: ../src/imageio/imageio.c:1116
@@ -14794,8 +17933,14 @@ msgstr "내보내기"
 msgid "cannot find the style '%s' to apply during export"
 msgstr "내보내는 중 적용할 스타일 '%s'를 찾지 못했습니다"
 
+#: ../src/imageio/imageio.c:1320
+#, c-format
+msgid "export reduced to %dx%d because of memory restrictions"
+msgstr "메모리 제한으로 인해 내보내기 크기가 %dx%d로 축소되었습니다"
+
 #: ../src/imageio/imageio_libraw.c:348
-msgid "<span foreground='red'><b>WARNING</b></span>: camera is not fully supported!"
+msgid ""
+"<span foreground='red'><b>WARNING</b></span>: camera is not fully supported!"
 msgstr "<span foreground='red'><b>경고</b></span>: 카메라가 완전히 지원되지 않습니다!"
 
 #: ../src/imageio/imageio_libraw.c:350
@@ -14807,11 +17952,11 @@ msgstr ""
 "`%s'의 색상이 제대로 표현되지 않을 수 있으며,\n"
 "편집은 미래 버전과 호환되지 않을 수도 있습니다."
 
-#: ../src/imageio/storage/disk.c:75 ../src/libs/export.c:1265
+#: ../src/imageio/storage/disk.c:77 ../src/libs/export.c:1283
 msgid "file on disk"
 msgstr "디스크 파일"
 
-#: ../src/imageio/storage/disk.c:274 ../src/imageio/storage/gallery.c:199
+#: ../src/imageio/storage/disk.c:276 ../src/imageio/storage/gallery.c:199
 #: ../src/imageio/storage/latex.c:186
 msgid ""
 "enter the path where to put exported images\n"
@@ -14822,60 +17967,61 @@ msgstr ""
 "변수는 bash 스타일 문자열 조작을 지원합니다\n"
 "'$('를 입력하여 입력 보완을 활성화하고 변수 목록을 볼 수 있습니다"
 
-#: ../src/imageio/storage/disk.c:286 ../src/imageio/storage/piwigo.c:1172
+#: ../src/imageio/storage/disk.c:288 ../src/imageio/storage/piwigo.c:1172
 msgid "on conflict"
 msgstr "동일한 이름의 파일이 있는 경우"
 
-#: ../src/imageio/storage/disk.c:289
+#: ../src/imageio/storage/disk.c:291
 msgid "create unique filename"
 msgstr "새 파일명 생성"
 
-#: ../src/imageio/storage/disk.c:290 ../src/imageio/storage/piwigo.c:1176
-#: ../src/libs/image.c:650 ../src/libs/styles.c:879
+#: ../src/imageio/storage/disk.c:292 ../src/imageio/storage/piwigo.c:1176
+#: ../src/libs/image.c:650 ../src/libs/styles.c:914
 msgid "overwrite"
 msgstr "덮어쓰기"
 
-#: ../src/imageio/storage/disk.c:291
+#: ../src/imageio/storage/disk.c:293
 msgid "overwrite if changed"
 msgstr "변경된 경우에만 덮어쓰기"
 
-#: ../src/imageio/storage/disk.c:292 ../src/imageio/storage/piwigo.c:1174
+#: ../src/imageio/storage/disk.c:294 ../src/imageio/storage/piwigo.c:1174
 msgid "skip"
 msgstr "건너뛰기"
 
-#: ../src/imageio/storage/disk.c:394 ../src/imageio/storage/gallery.c:320
+#: ../src/imageio/storage/disk.c:421 ../src/imageio/storage/gallery.c:320
 #: ../src/imageio/storage/latex.c:279
 #, c-format
 msgid "could not create directory `%s'!"
 msgstr "경로 `%s'를 생성할 수 없습니다!"
 
-#: ../src/imageio/storage/disk.c:405
+#: ../src/imageio/storage/disk.c:432
 #, c-format
 msgid "could not write to directory `%s'!"
 msgstr "경로 `%s'에 쓸 수 없습니다!"
 
-#: ../src/imageio/storage/disk.c:442
+#: ../src/imageio/storage/disk.c:469
 #, c-format
 msgid "%d/%d skipping `%s'"
 msgid_plural "%d/%d skipping `%s'"
 msgstr[0] "%d/%d, `%s' 건너뜀"
 
-#: ../src/imageio/storage/disk.c:468
+#: ../src/imageio/storage/disk.c:517
 #, c-format
 msgid "%d/%d skipping (not modified since export) `%s'"
 msgid_plural "%d/%d skipping (not modified since export) `%s'"
 msgstr[0] "%d/%d 건너뜀 (내보낸 이후 수정되지 않음) `%s'"
 
-#: ../src/imageio/storage/disk.c:494 ../src/imageio/storage/email.c:195
+#: ../src/imageio/storage/disk.c:543 ../src/imageio/storage/email.c:195
 #: ../src/imageio/storage/gallery.c:456 ../src/imageio/storage/latex.c:371
 #, c-format
 msgid "%d/%d exported to `%s'"
 msgid_plural "%d/%d exported to `%s'"
 msgstr[0] "%d/%d을 `%s'로 내보냄"
 
-#: ../src/imageio/storage/disk.c:559
+#: ../src/imageio/storage/disk.c:608
 msgid ""
-"you are going to export in overwrite mode, this will overwrite any existing images\n"
+"you are going to export in overwrite mode, this will overwrite any existing "
+"images\n"
 "\n"
 "do you really want to continue?"
 msgstr ""
@@ -15100,11 +18246,11 @@ msgstr ""
 "톤 매핑 커브를 적용합니다.\n"
 "블렌더의 AgX 톤 매퍼에서 영감을 얻었습니다"
 
-#: ../src/iop/agx.c:58 ../src/iop/atrous.c:133 ../src/iop/bilateral.cc:103
-#: ../src/iop/colorequal.c:215 ../src/iop/diffuse.c:139
+#: ../src/iop/agx.c:58 ../src/iop/atrous.c:132 ../src/iop/bilateral.cc:103
+#: ../src/iop/colorequal.c:216 ../src/iop/diffuse.c:139
 #: ../src/iop/enlargecanvas.c:80 ../src/iop/exposure.c:130
-#: ../src/iop/filmicrgb.c:350 ../src/iop/graduatednd.c:143
-#: ../src/iop/negadoctor.c:142 ../src/iop/overlay.c:155
+#: ../src/iop/filmicrgb.c:344 ../src/iop/graduatednd.c:143
+#: ../src/iop/negadoctor.c:142 ../src/iop/overlay.c:177
 #: ../src/iop/rgbcurve.c:142 ../src/iop/rgblevels.c:121 ../src/iop/shadhi.c:141
 #: ../src/iop/sigmoid.c:206 ../src/iop/tonecurve.c:179
 #: ../src/iop/toneequal.c:329
@@ -15113,19 +18259,21 @@ msgstr "교정적 그리고 창의적"
 
 #: ../src/iop/agx.c:59 ../src/iop/ashift.c:125 ../src/iop/ashift.c:127
 #: ../src/iop/basicadj.c:169 ../src/iop/bilateral.cc:104
-#: ../src/iop/bilateral.cc:106 ../src/iop/blurs.c:90 ../src/iop/blurs.c:91
+#: ../src/iop/bilateral.cc:106 ../src/iop/blurs.c:94 ../src/iop/blurs.c:95
+#: ../src/iop/cacorrectrgb.c:167 ../src/iop/cacorrectrgb.c:169
 #: ../src/iop/channelmixerrgb.c:239 ../src/iop/channelmixerrgb.c:241
 #: ../src/iop/clipping.c:357 ../src/iop/clipping.c:359
-#: ../src/iop/colorbalancergb.c:182 ../src/iop/colorequal.c:216
-#: ../src/iop/colorin.c:130 ../src/iop/crop.c:137 ../src/iop/crop.c:139
-#: ../src/iop/demosaic.c:330 ../src/iop/denoiseprofile.c:821
+#: ../src/iop/colorbalancergb.c:182 ../src/iop/colorequal.c:217
+#: ../src/iop/colorharmonizer.c:134 ../src/iop/colorharmonizer.c:136
+#: ../src/iop/colorin.c:131 ../src/iop/crop.c:135 ../src/iop/crop.c:137
+#: ../src/iop/demosaic.c:318 ../src/iop/denoiseprofile.c:821
 #: ../src/iop/denoiseprofile.c:823 ../src/iop/diffuse.c:140
 #: ../src/iop/diffuse.c:142 ../src/iop/enlargecanvas.c:81
 #: ../src/iop/enlargecanvas.c:83 ../src/iop/exposure.c:131
 #: ../src/iop/exposure.c:133 ../src/iop/flip.c:109 ../src/iop/flip.c:110
 #: ../src/iop/hazeremoval.c:111 ../src/iop/hazeremoval.c:113
-#: ../src/iop/lens.cc:264 ../src/iop/lens.cc:266 ../src/iop/liquify.c:295
-#: ../src/iop/liquify.c:297 ../src/iop/overlay.c:156 ../src/iop/overlay.c:158
+#: ../src/iop/lens.cc:265 ../src/iop/lens.cc:267 ../src/iop/liquify.c:295
+#: ../src/iop/liquify.c:297 ../src/iop/overlay.c:178 ../src/iop/overlay.c:180
 #: ../src/iop/primaries.c:74 ../src/iop/primaries.c:76 ../src/iop/retouch.c:208
 #: ../src/iop/retouch.c:210 ../src/iop/scalepixels.c:86
 #: ../src/iop/scalepixels.c:88 ../src/iop/sigmoid.c:206
@@ -15135,18 +18283,18 @@ msgstr "교정적 그리고 창의적"
 msgid "linear, RGB, scene-referred"
 msgstr "선형, RGB, 장면 기준"
 
-#: ../src/iop/agx.c:60 ../src/iop/basecurve.c:374 ../src/iop/basicadj.c:170
+#: ../src/iop/agx.c:60 ../src/iop/basecurve.c:373 ../src/iop/basicadj.c:170
 #: ../src/iop/colorbalance.c:162 ../src/iop/colorbalancergb.c:183
-#: ../src/iop/dither.c:118 ../src/iop/filmicrgb.c:352
+#: ../src/iop/dither.c:118 ../src/iop/filmicrgb.c:346
 #: ../src/iop/graduatednd.c:145 ../src/iop/negadoctor.c:144
 #: ../src/iop/profile_gamma.c:101 ../src/iop/rgbcurve.c:144
 #: ../src/iop/rgblevels.c:123 ../src/iop/sigmoid.c:207
-#: ../src/iop/vignette.c:119 ../src/iop/watermark.c:417
+#: ../src/iop/vignette.c:119 ../src/iop/watermark.c:470
 msgid "non-linear, RGB"
 msgstr "비선형, RGB"
 
-#: ../src/iop/agx.c:61 ../src/iop/basecurve.c:373 ../src/iop/channelmixer.c:137
-#: ../src/iop/channelmixer.c:139 ../src/iop/lut3d.c:139
+#: ../src/iop/agx.c:61 ../src/iop/basecurve.c:372 ../src/iop/channelmixer.c:137
+#: ../src/iop/channelmixer.c:139 ../src/iop/lut3d.c:140
 #: ../src/iop/negadoctor.c:143 ../src/iop/profile_gamma.c:100
 #: ../src/iop/rgbcurve.c:143 ../src/iop/rgbcurve.c:145
 #: ../src/iop/rgblevels.c:122 ../src/iop/sigmoid.c:207 ../src/iop/soften.c:100
@@ -15154,31 +18302,31 @@ msgstr "비선형, RGB"
 msgid "linear, RGB, display-referred"
 msgstr "선형, RGB, 디스플레이 기준"
 
-#: ../src/iop/agx.c:2161
+#: ../src/iop/agx.c:1817
 msgctxt "section"
 msgid "basic curve parameters"
 msgstr "기본 커브 파라메터"
 
-#: ../src/iop/agx.c:2163 ../src/iop/agx.c:2317
+#: ../src/iop/agx.c:1819 ../src/iop/agx.c:1975
 msgctxt "section"
 msgid "curve"
 msgstr "커브"
 
-#: ../src/iop/agx.c:2171
+#: ../src/iop/agx.c:1827
 msgid "set the pivot's input exposure in EV relative to mid-gray"
 msgstr "피벗의 입력 노출을 중간 회색을 기준으로 EV 값으로 설정합니다."
 
-#: ../src/iop/agx.c:2172
+#: ../src/iop/agx.c:1828
 msgid ""
 "the average luminance of the selected region will be\n"
 "used to set the pivot relative to mid-gray"
-msgstr "선택한 영역의 평균 휘도가 중간 회색(middle gray)을 \v기준으로 피벗을 설정하는 데 사용됩니다."
+msgstr "선택한 영역의 평균 휘도가 중간 회색(middle gray)을 \\v기준으로 피벗을 설정하는 데 사용됩니다."
 
-#: ../src/iop/agx.c:2182
+#: ../src/iop/agx.c:1837
 msgid "darken or brighten the pivot (linear output power)"
 msgstr "피봇을 어둡게 또는 밝게 (선형 출력 파워)"
 
-#: ../src/iop/agx.c:2183
+#: ../src/iop/agx.c:1838
 msgid ""
 "the average luminance of the selected region will be\n"
 "used to set the pivot relative to mid-gray,\n"
@@ -15190,11 +18338,11 @@ msgstr ""
 "출력은 기본 중간 회색에서 \n"
 "중간 회색 매핑을 기반으로 조정됩니다."
 
-#: ../src/iop/agx.c:2192
+#: ../src/iop/agx.c:1847
 msgid "slope of the linear section around the pivot"
 msgstr "피봇 주변에서의 선형 부분의 슬로프"
 
-#: ../src/iop/agx.c:2198
+#: ../src/iop/agx.c:1853
 msgid ""
 "contrast in highlights\n"
 "higher values keep the slope nearly constant for longer,\n"
@@ -15204,25 +18352,30 @@ msgstr ""
 "값이 높을수록 기울기가 더 오랫동안 거의 일정하게 유지됩니다,\n"
 "흰색 근처에서 더 급격하게 떨어지는 효과가 납니다"
 
-#: ../src/iop/agx.c:2202
+#: ../src/iop/agx.c:1857
 msgid ""
-"the curve has lost its 'S' shape, shoulder power cannot be applied.\n"
-"target white cannot be reached with the selected contrast and pivot position.\n"
-"increase contrast, move the pivot higher (increase pivot target output\n"
-"or curve y gamma), or increase the distance between the pivot and the right\n"
-"edge (decrease the pivot shift, move the white point farther from the pivot by\n"
-"increasing relative white exposure or move the black point closer to the pivot\n"
-"by lowering relative black exposure)."
+"shoulder power cannot be applied because the curve has lost its 'S' shape\n"
+"due to the current settings for white relative exposure, contrast, and "
+"pivot.\n"
+"to re-enable, do one of the following:\n"
+" - increase contrast\n"
+" - increase pivot target output\n"
+" - increase white relative exposure\n"
+" - increase curve y gamma (in the advanced curve parameters section)\n"
+"\n"
+"open the 'show curve' section to see the effects of the above settings."
 msgstr ""
-"곡선이 'S' 형태를 잃었으며, 숄더 전력을 적용할 수 없습니다. \n"
-"선택된 대비와 피벗 위치로는 목표 화이트에 도달할 수 없습니다. \n"
-"대비를 증가시키거나, 피벗을 더 높이 이동시키거나(피벗 목표 출력을 증가시키거나 \n"
-"곡선 y 감마를 증가시키기), 피벗과 오른쪽 가장자리 사이의 거리를 증가시켜야 합니다.\n"
-"(피벗 이동을 줄이거나, 상대적인 화이트 노출을 증가시켜 \n"
-"피벗에서 화이트 포인트를 더 멀리 이동시키거나, \n"
-"상대적인 블랙 노출을 낮춰 피벗에 더 가깝게 블랙 포인트를 이동시킵니다)"
+"화이트 상대 노출, 대비, 피벗의 현재 설정 때문에 커브가 'S' 형태를 잃어\n"
+"숄더 파워를 적용할 수 없습니다.\n"
+"다시 사용하려면 다음 중 하나를 수행하세요:\n"
+" - 대비 증가\n"
+" - 피벗 목표 출력 증가\n"
+" - 화이트 상대 노출 증가\n"
+" - 커브 y 감마 증가 (고급 커브 파라메터 섹션)\n"
+"\n"
+"위 설정의 효과를 보려면 '커브 표시' 섹션을 여세요."
 
-#: ../src/iop/agx.c:2214
+#: ../src/iop/agx.c:1871
 msgid ""
 "contrast in shadows\n"
 "higher values keep the slope nearly constant for longer,\n"
@@ -15232,71 +18385,75 @@ msgstr ""
 "값이 높을수록 기울기가 더 오랫동안 거의 일정하게 유지됩니다,\n"
 "검은색에 근처에서 기울기가 급격히 떨어지는 효과가 납니다,"
 
-#: ../src/iop/agx.c:2218
+#: ../src/iop/agx.c:1875
 msgid ""
-"the curve has lost its 'S' shape, toe power cannot be applied.\n"
-"target black cannot be reached with the selected contrast and pivot position.\n"
-"increase contrast, move the pivot lower (reduce the pivot target output or\n"
-"curve y gamma), or increase the distance between the pivot and the left edge\n"
-"(increase the pivot shift, move the black point farther from the pivot by raising\n"
-"the relative black exposure or move the white point closer to the pivot\n"
-"by decreasing relative white exposure)."
+"toe power cannot be applied because the curve has lost its 'S' shape due\n"
+"to the current settings for white relative exposure, contrast, and pivot.\n"
+"to re-enable, do one of the following:\n"
+" - increase contrast\n"
+" - decrease pivot target output\n"
+" - decrease black relative exposure (make more negative)\n"
+" - decrease curve y gamma (in the advanced curve parameters section)\n"
+"\n"
+"open the 'show curve' section to see the effects of the above settings."
 msgstr ""
-"곡선이 'S' 형태를 잃었으며, 토 전력을 적용할 수 없습니다. \n"
-"선택된 대비와 피벗 위치로는 목표 블랙에 도달할 수 없습니다. \n"
-"대비를 증가시키거나, 피벗을 더 낮게 이동시키거나\n"
-"(피벗 목표 출력을 줄이거나 곡선 y 감마를 감소시키기), \n"
-"피벗과 왼쪽 가장자리 사이의 거리를 증가시켜야 합니다.\n"
-"(피벗 이동을 증가시키거나, 상대적인 블랙 노출을 높여 피벗에서 블랙 포인트를 더 멀리 이동시키거나, \n"
-"상대적인 화이트 노출을 줄여 화이트 포인트를 피벗에 더 가깝게 이동시킵니다)"
+"화이트 상대 노출, 대비, 피벗의 현재 설정 때문에 커브가 'S' 형태를 잃어\n"
+"토 파워를 적용할 수 없습니다.\n"
+"다시 사용하려면 다음 중 하나를 수행하세요:\n"
+" - 대비 증가\n"
+" - 피벗 목표 출력 감소\n"
+" - 블랙 상대 노출 감소 (더 큰 음수로)\n"
+" - 커브 y 감마 감소 (고급 커브 파라메터 섹션)\n"
+"\n"
+"위 설정의 효과를 보려면 '커브 표시' 섹션을 여세요."
 
-#: ../src/iop/agx.c:2236
+#: ../src/iop/agx.c:1895
 msgid "decrease or increase contrast and brightness"
 msgstr "대비 및 밝기 감소 또는 증가"
 
-#: ../src/iop/agx.c:2241
+#: ../src/iop/agx.c:1900
 msgid "deepen or lift shadows"
 msgstr "쉐도우 강화 또는 약화"
 
-#: ../src/iop/agx.c:2245
+#: ../src/iop/agx.c:1904
 msgid "increase or decrease brightness"
 msgstr "밝기 증가 또는 감소"
 
-#: ../src/iop/agx.c:2252
+#: ../src/iop/agx.c:1911
 msgid "decrease or increase saturation"
 msgstr "채도 감소 또는 증가"
 
-#: ../src/iop/agx.c:2259
+#: ../src/iop/agx.c:1917
 msgid "increase to bring hues closer to the original"
 msgstr "증가시키면 원본에 가까운 색상을 가져옵니다"
 
-#: ../src/iop/agx.c:2269
+#: ../src/iop/agx.c:1927
 msgctxt "section"
 msgid "look"
 msgstr "모양"
 
-#: ../src/iop/agx.c:2292
+#: ../src/iop/agx.c:1950
 msgid "show curve"
 msgstr "커브 표시"
 
-#: ../src/iop/agx.c:2296 ../src/iop/atrous.c:1810
-#: ../src/iop/colorbalancergb.c:1974 ../src/iop/colorequal.c:3018
-#: ../src/iop/colorzones.c:2708 ../src/iop/denoiseprofile.c:3803
-#: ../src/iop/filmicrgb.c:4367 ../src/iop/lowlight.c:807
-#: ../src/iop/rawdenoise.c:908 ../src/iop/toneequal.c:3280
+#: ../src/iop/agx.c:1954 ../src/iop/atrous.c:1769
+#: ../src/iop/colorbalancergb.c:1974 ../src/iop/colorequal.c:2981
+#: ../src/iop/colorzones.c:2708 ../src/iop/denoiseprofile.c:3627
+#: ../src/iop/filmicrgb.c:4352 ../src/iop/lowlight.c:807
+#: ../src/iop/rawdenoise.c:910 ../src/iop/toneequal.c:3284
 msgid "graph"
 msgstr "그래프"
 
-#: ../src/iop/agx.c:2299
+#: ../src/iop/agx.c:1957
 msgid "tone mapping curve"
 msgstr "톤 매핑 커브"
 
-#: ../src/iop/agx.c:2312
+#: ../src/iop/agx.c:1970
 msgctxt "section"
 msgid "advanced curve parameters"
 msgstr "고급 커브 파라메터"
 
-#: ../src/iop/agx.c:2330
+#: ../src/iop/agx.c:1987
 msgid ""
 "length to keep curve linear above the pivot.\n"
 "may clip highlights"
@@ -15304,11 +18461,11 @@ msgstr ""
 "피봇 상단 커브의 선형 유지 부분의 길이.\n"
 "하이라이트가 클리핑 될 수 있음"
 
-#: ../src/iop/agx.c:2339
+#: ../src/iop/agx.c:1996
 msgid "max linear output power"
 msgstr "최대 선형 출력 파워"
 
-#: ../src/iop/agx.c:2348
+#: ../src/iop/agx.c:2004
 msgid ""
 "length to keep curve linear below the pivot.\n"
 "may crush shadows"
@@ -15316,11 +18473,11 @@ msgstr ""
 "피봇 하단 커브의 선형 유지 부분의 길이.\n"
 "쉐도우가 클리핑 될 수 있음"
 
-#: ../src/iop/agx.c:2357
+#: ../src/iop/agx.c:2013
 msgid "raise for a faded look"
 msgstr "올리면 어둡게 보임"
 
-#: ../src/iop/agx.c:2363
+#: ../src/iop/agx.c:2019
 msgid ""
 "adjusts the gamma automatically, trying to make sure\n"
 "the curve always remains S-shaped (given that contrast\n"
@@ -15330,7 +18487,7 @@ msgstr ""
 "커브가 항상 S자 모양으로 유지되도록\n"
 "(대비가 충분히 높으면) 토엔 숄더를 효과적으로 제어할 수 있습니다."
 
-#: ../src/iop/agx.c:2372
+#: ../src/iop/agx.c:2028
 msgid ""
 "shifts the representation (but not the output power) of the pivot\n"
 "along the y axis of the curve.\n"
@@ -15344,28 +18501,28 @@ msgstr ""
 "그림자와 하이라이트에는 영향을 미칩니다. \n"
 "대비 슬라이더나 토/숄더 컨트롤로 이를 보정해야 할 수 있습니다."
 
-#: ../src/iop/agx.c:2383
+#: ../src/iop/agx.c:2039
 msgctxt "section"
 msgid "input exposure range"
 msgstr "입력 노출 영역"
 
-#: ../src/iop/agx.c:2391
+#: ../src/iop/agx.c:2047
 msgid "relative exposure above mid-gray (white point)"
 msgstr "중간-회색 (화이트 포인트) 윗 부분의 상대 노출"
 
-#: ../src/iop/agx.c:2392
+#: ../src/iop/agx.c:2048
 msgid "pick the white point"
 msgstr "화이트 포인트 선택"
 
-#: ../src/iop/agx.c:2400
+#: ../src/iop/agx.c:2056
 msgid "relative exposure below mid-gray (black point)"
 msgstr "중간-회색 (화이트 포인트) 아랫 부분의 상대 노출"
 
-#: ../src/iop/agx.c:2401
+#: ../src/iop/agx.c:2057
 msgid "pick the black point"
 msgstr "블랙 포인트 선택"
 
-#: ../src/iop/agx.c:2409 ../src/iop/filmicrgb.c:4421
+#: ../src/iop/agx.c:2065 ../src/iop/filmicrgb.c:4408
 msgid ""
 "symmetrically increase or decrease the computed dynamic range.\n"
 "useful to give a safety margin to extreme luminances."
@@ -15373,44 +18530,52 @@ msgstr ""
 "계산된 다이나믹 레인지를 대칭적으로 늘리거나 줄입니다.\n"
 "극단적인 휘도 값에 여유 범위를 주는 데 유용합니다."
 
-#: ../src/iop/agx.c:2415 ../src/iop/agx.c:2418 ../src/iop/filmic.c:1509
-#: ../src/iop/filmicrgb.c:4427 ../src/iop/profile_gamma.c:645
+#: ../src/iop/agx.c:2071 ../src/iop/agx.c:2074 ../src/iop/filmic.c:1515
+#: ../src/iop/filmicrgb.c:4414 ../src/iop/profile_gamma.c:640
 msgid "auto tune levels"
 msgstr "자동 레벨 조정"
 
-#: ../src/iop/agx.c:2417
+#: ../src/iop/agx.c:2073
 msgid "set black and white relative exposure using the selected area"
 msgstr "선택한 영역을 사용하여 화이트와 블랙 상대 노출 설정"
 
-#: ../src/iop/agx.c:2418 ../src/iop/agx.c:2425
+#: ../src/iop/agx.c:2074 ../src/iop/agx.c:2081
 msgid "exposure range"
 msgstr "노출 영역"
 
-#: ../src/iop/agx.c:2423
+#: ../src/iop/agx.c:2079
 msgid "read exposure from metadata and exposure module"
 msgstr "메타데이터 및 노출 모듈로부터 노출값 읽기"
 
-#: ../src/iop/agx.c:2425
+#: ../src/iop/agx.c:2081
 msgid "read exposure"
 msgstr "노출 읽기"
 
-#: ../src/iop/agx.c:2448
+#: ../src/iop/agx.c:2104
 msgid "blender-like"
 msgstr "블렌더-유사"
 
-#: ../src/iop/agx.c:2458
+#: ../src/iop/agx.c:2114
 msgid "unmodified"
 msgstr "수정되지않음"
 
-#: ../src/iop/agx.c:2605 ../src/iop/sigmoid.c:923 ../src/iop/sigmoid.c:927
+#: ../src/iop/agx.c:2260 ../src/iop/sigmoid.c:914 ../src/iop/sigmoid.c:918
 msgid "primaries"
 msgstr "기본색상"
 
-#: ../src/iop/agx.c:2605
+#: ../src/iop/agx.c:2260
 msgid "color primaries adjustments"
 msgstr "기본색상 조정"
 
-#: ../src/iop/agx.c:2614
+#: ../src/iop/agx.c:2266
+msgid ""
+"color space primaries to use as the base for below adjustments.\n"
+"'export profile' uses the profile set in 'output color profile'."
+msgstr ""
+"색공간 기본색상은 이후 조정을 위한 기반으로 사용됩니다.\n"
+"'프로파일 내보내기'는 '출력 색상 프로파일'에 설정된 프로파일을 사용합니다."
+
+#: ../src/iop/agx.c:2274
 msgid ""
 "disable purity adjustments and rotations, only applying the curve.\n"
 "note that those adjustments are at the heart of AgX,\n"
@@ -15424,57 +18589,49 @@ msgstr ""
 "특히 밝고 포화 상태인 조명(예: LED)에서는 더욱 그렇습니다.\n"
 "주로 실험용으로 사용됩니다."
 
-#: ../src/iop/agx.c:2622
+#: ../src/iop/agx.c:2281
 msgid "reset primaries to a predefined configuration"
 msgstr "기존 정의된 구성으로 기본색상 리셋"
 
-#: ../src/iop/agx.c:2625
+#: ../src/iop/agx.c:2283 ../src/iop/agx.c:2286
 msgid "reset primaries"
 msgstr "기본색상 리셋"
 
-#: ../src/iop/agx.c:2633
-msgid ""
-"color space primaries to use as the base for below adjustments.\n"
-"'export profile' uses the profile set in 'output color profile'."
-msgstr ""
-"색공간 기본색상은 이후 조정을 위한 기반으로 사용됩니다.\n"
-"'프로파일 내보내기'는 '출력 색상 프로파일'에 설정된 프로파일을 사용합니다."
-
-#: ../src/iop/agx.c:2636
+#: ../src/iop/agx.c:2292
 msgctxt "section"
 msgid "before tone mapping"
 msgstr "톤 매핑 이전"
 
-#: ../src/iop/agx.c:2646
+#: ../src/iop/agx.c:2302
 msgid "increase to desaturate reds in highlights faster"
 msgstr "하이라이트에서 적색의 채도를 빠르게 낮추려면 증가시킵니다"
 
-#: ../src/iop/agx.c:2653
+#: ../src/iop/agx.c:2309
 msgid "shift the red primary towards yellow (+) or magenta (-)"
 msgstr "적색 기본색상을 노란색(+) 또는 마젠타(-) 방향으로 이동"
 
-#: ../src/iop/agx.c:2659
+#: ../src/iop/agx.c:2315
 msgid "increase to desaturate greens in highlights faster"
 msgstr "하이라이트에서 녹색의 채도를 빠르게 낮추려면 증가시킵니다"
 
-#: ../src/iop/agx.c:2666
+#: ../src/iop/agx.c:2322
 msgid "shift the green primary towards cyan (+) or yellow (-)"
 msgstr "녹색 기본색상을 시안(+) 또는 노란색(-) 방향으로 이동"
 
-#: ../src/iop/agx.c:2672
+#: ../src/iop/agx.c:2328
 msgid "increase to desaturate blues in highlights faster"
 msgstr "하이라이트에서 청색의 채도를 빠르게 낮추려면 증가시킵니다"
 
-#: ../src/iop/agx.c:2679
+#: ../src/iop/agx.c:2335
 msgid "shift the blue primary towards magenta (+) or cyan (-)"
 msgstr "청색 기본색상을 마젠타(+) 또는 시안(-) 방향으로 이동"
 
-#: ../src/iop/agx.c:2685
+#: ../src/iop/agx.c:2341
 msgctxt "section"
 msgid "after tone mapping"
 msgstr "톤 매핑 이후"
 
-#: ../src/iop/agx.c:2690
+#: ../src/iop/agx.c:2346
 msgid ""
 "completely restore purity, undo all rotations, and hide\n"
 "the controls below. uncheck to restore the previous state."
@@ -15482,11 +18639,11 @@ msgstr ""
 "완전히 순도를 복원하고, 모든 회전을 실행 취소하며, 아래의 컨트롤을 숨깁니다. \n"
 "체크 해제하면 이전 상태로 복원됩니다."
 
-#: ../src/iop/agx.c:2693
+#: ../src/iop/agx.c:2349
 msgid "set from above"
 msgstr "위쪽으로부터 설정"
 
-#: ../src/iop/agx.c:2695
+#: ../src/iop/agx.c:2351
 msgid ""
 "set parameters to completely reverse primaries modifications,\n"
 "but allow subsequent editing"
@@ -15494,80 +18651,84 @@ msgstr ""
 "기본 색상 수정 사항을 완전히 되돌리도록 매개변수를 설정\n"
 "이후 편집은 가능합니다."
 
-#: ../src/iop/agx.c:2708
+#: ../src/iop/agx.c:2354
+msgid "reverse pre-mapping primaries"
+msgstr "사전 매핑 원색 되돌리기"
+
+#: ../src/iop/agx.c:2366
 msgid "overall purity boost"
 msgstr "전체 순도 강화"
 
-#: ../src/iop/agx.c:2716
+#: ../src/iop/agx.c:2374
 msgid "overall unrotation ratio"
 msgstr "전체 비회전 비율"
 
-#: ../src/iop/agx.c:2720
+#: ../src/iop/agx.c:2378
 msgid "restore the purity of red, mostly in midtones and shadows"
 msgstr "주로 중간 톤과 그림자에서 적색의 순도를 복원합니다"
 
-#: ../src/iop/agx.c:2727
+#: ../src/iop/agx.c:2385
 msgid "reverse the color shift in reds"
 msgstr "적색에서 색상 이동 반전"
 
-#: ../src/iop/agx.c:2733
+#: ../src/iop/agx.c:2391
 msgid "restore the purity of green, mostly in midtones and shadows"
 msgstr "주로 중간 톤과 그림자에서 녹색의 순도를 복원합니다"
 
-#: ../src/iop/agx.c:2740
+#: ../src/iop/agx.c:2398
 msgid "reverse the color shift in greens"
 msgstr "녹색의 색상 이동 반전"
 
-#: ../src/iop/agx.c:2746
+#: ../src/iop/agx.c:2404
 msgid "restore the purity of blue, mostly in midtones and shadows"
 msgstr "주로 중간 톤과 그림자에서 청색의 순도를 복원합니다"
 
-#: ../src/iop/agx.c:2753
+#: ../src/iop/agx.c:2411
 msgid "reverse the color shift in blues"
 msgstr "파란색의 색상 이동 반전"
 
 #. relabel to settings to remove confusion between module presets
 #. and white balance settings
-#: ../src/iop/agx.c:2805 ../src/iop/temperature.c:2077
-#: ../src/iop/temperature.c:2090 ../src/iop/temperature.c:2097
-#: ../src/iop/temperature.c:2103 ../src/iop/temperature.c:2111
-#: ../src/iop/temperature.c:2130
+#: ../src/iop/agx.c:2463 ../src/iop/temperature.c:2062
+#: ../src/iop/temperature.c:2075 ../src/iop/temperature.c:2082
+#: ../src/iop/temperature.c:2088 ../src/iop/temperature.c:2096
+#: ../src/iop/temperature.c:2115
 msgid "settings"
 msgstr "설정"
 
-#: ../src/iop/agx.c:2806
+#: ../src/iop/agx.c:2464
 msgid "main look and curve settings"
 msgstr "메인 보기 및 커브 설정"
 
-#: ../src/iop/agx.c:2815
+#: ../src/iop/agx.c:2473
 msgid "detailed curve settings"
 msgstr "상세 커브 설정"
 
-#: ../src/iop/agx.c:2912
+#: ../src/iop/agx.c:2571
 msgid "unmodified base primaries"
 msgstr "수정되지 않은 기본색상"
 
-#: ../src/iop/agx.c:2921
+#: ../src/iop/agx.c:2582
 msgid "blender-like|base"
 msgstr "블렌더-유사|베이스"
 
-#: ../src/iop/agx.c:2927
+#: ../src/iop/agx.c:2587
 msgid "blender-like|punchy"
 msgstr "블렌더-유사|펀치"
 
-#: ../src/iop/agx.c:2942 ../src/iop/channelmixerrgb.c:397
-#: ../src/iop/exposure.c:334 ../src/iop/filmicrgb.c:3209
+#: ../src/iop/agx.c:2608
+msgid "sigmoid-like|default"
+msgstr "시그모이드 유사|기본값"
+
+#: ../src/iop/agx.c:2621
+msgid "sigmoid-like|smooth"
+msgstr "시그모이드 유사|부드럽게"
+
+#: ../src/iop/agx.c:2636 ../src/iop/channelmixerrgb.c:397
+#: ../src/iop/exposure.c:334 ../src/iop/filmicrgb.c:3190
 #: ../src/iop/sigmoid.c:237
 msgid "scene-referred default"
 msgstr "장면 기준 기본값"
-
-#: ../src/iop/agx.c:2958
-msgid "smooth|base"
-msgstr "부드럽게|기본"
-
-#: ../src/iop/agx.c:2962
-msgid "smooth|punchy"
-msgstr "부드럽게|펑키"
 
 #: ../src/iop/ashift.c:113
 msgid "rotate and perspective"
@@ -15585,38 +18746,41 @@ msgstr "회전 혹은 원근 왜곡"
 #: ../src/iop/channelmixerrgb.c:238 ../src/iop/clipping.c:356
 #: ../src/iop/colorbalance.c:160 ../src/iop/colorbalancergb.c:181
 #: ../src/iop/colorchecker.c:130 ../src/iop/colorcorrection.c:74
-#: ../src/iop/crop.c:136 ../src/iop/lut3d.c:138 ../src/iop/primaries.c:73
-#: ../src/iop/rasterfile.c:100
+#: ../src/iop/crop.c:134 ../src/iop/lut3d.c:139 ../src/iop/primaries.c:73
+#: ../src/iop/rasterfile.c:106
 msgid "corrective or creative"
 msgstr "교정적 또는 창의적"
 
 #: ../src/iop/ashift.c:126 ../src/iop/borders.c:319 ../src/iop/clipping.c:358
-#: ../src/iop/crop.c:138 ../src/iop/flip.c:109 ../src/iop/liquify.c:296
+#: ../src/iop/crop.c:136 ../src/iop/flip.c:109 ../src/iop/liquify.c:296
 msgid "geometric, RGB"
 msgstr "기하학, RGB"
 
 #: ../src/iop/ashift.c:1202 ../src/iop/clipping.c:913
 #, c-format
-msgid "module '%s' has insane data so it is bypassed for now. you should disable it or change parameters\n"
-msgstr "모듈 '%s'에 비정상적인 데이터가 있어 현재 무시되었습니다. 비활성화하거나 파라메터를 변경하세요\n"
+msgid ""
+"module '%s' has insane data so it is bypassed for now. you should disable it "
+"or change parameters\n"
+msgstr ""
+"모듈 '%s'에 비정상적인 데이터가 있어 현재 무시되었습니다. 비활성화하거나 파라메터를 변경하세요\n"
 
 #: ../src/iop/ashift.c:2804
 msgid "automatic cropping failed"
 msgstr "자동 자르기 실패"
 
-#: ../src/iop/ashift.c:3213 ../src/iop/ashift.c:3265 ../src/iop/ashift.c:3312
+#: ../src/iop/ashift.c:3213 ../src/iop/ashift.c:3264 ../src/iop/ashift.c:3310
 msgid "data pending - please repeat"
 msgstr "데이터 보류 중 - 다시 시도하세요"
 
-#: ../src/iop/ashift.c:3222
+#: ../src/iop/ashift.c:3221
 msgid "could not detect structural data in image"
 msgstr "이미지에서 구조 데이터를 찾을 수 없습니다"
 
-#: ../src/iop/ashift.c:3234
+#: ../src/iop/ashift.c:3233
 msgid "could not run outlier removal"
 msgstr "이상치를 제거할 수 없습니다"
 
-#: ../src/iop/ashift.c:3411
+#: ../src/iop/ashift.c:3408
 #, c-format
 msgid ""
 "not enough structure for automatic correction\n"
@@ -15625,81 +18789,88 @@ msgstr ""
 "자동 보정을 위한 구조가 충분하지 않습니다\n"
 "수평 방향 선과 수직 방향 선이 각각 최소 %d개 필요합니다"
 
-#: ../src/iop/ashift.c:3417
+#: ../src/iop/ashift.c:3414
 msgid "automatic correction failed, please correct manually"
 msgstr "자동 보정에 실패했습니다, 수동으로 조정해주세요"
 
-#: ../src/iop/ashift.c:4992
+#: ../src/iop/ashift.c:4988
 #, c-format
 msgid "only %d lines can be saved in parameters"
 msgstr "오직 %d개의 선만 파라메터로 지정할 수 있습니다"
 
-#: ../src/iop/ashift.c:5071
+#: ../src/iop/ashift.c:5067
 #, c-format
 msgid "rotation adjusted by %3.2f° to %3.2f°"
 msgstr "%3.2f°만큼 회전하여 %3.2f°로 조정되었습니다"
 
-#: ../src/iop/ashift.c:5704 ../src/iop/ashift.c:5706 ../src/iop/ashift.c:5810
-#: ../src/iop/ashift.c:5812
+#: ../src/iop/ashift.c:5700 ../src/iop/ashift.c:5702 ../src/iop/ashift.c:5806
+#: ../src/iop/ashift.c:5808
 #, c-format
 msgid "lens shift (%s)"
 msgstr "렌즈 이동 (%s)"
 
-#: ../src/iop/ashift.c:5981
+#: ../src/iop/ashift.c:5977
 msgid "manual perspective"
 msgstr "수동 원근"
 
-#: ../src/iop/ashift.c:6027
+#: ../src/iop/ashift.c:6023
 msgctxt "section"
 msgid "perspective"
 msgstr "원근"
 
-#: ../src/iop/ashift.c:6033 ../src/iop/ashift.c:6140 ../src/iop/ashift.c:6142
-#: ../src/iop/ashift.c:6144
+#: ../src/iop/ashift.c:6029 ../src/iop/ashift.c:6136 ../src/iop/ashift.c:6138
+#: ../src/iop/ashift.c:6140
 msgid "structure"
 msgstr "구조"
 
-#: ../src/iop/ashift.c:6066
+#: ../src/iop/ashift.c:6062
 msgid ""
 "rotate image\n"
-"right-click and drag to define a horizontal or vertical line by drawing on the image"
+"right-click and drag to define a horizontal or vertical line by drawing on "
+"the image"
 msgstr ""
 "이미지 회전\n"
 "이미지 위에 우클릭 후 드래그 하여 수평선 혹은 수직선을 정의할 수 있습니다"
 
-#: ../src/iop/ashift.c:6069 ../src/iop/ashift.c:6071
+#: ../src/iop/ashift.c:6065 ../src/iop/ashift.c:6067
 msgid "apply lens shift correction in one direction"
 msgstr "렌즈 이동 보정을 한 방향으로 적용"
 
-#: ../src/iop/ashift.c:6073
+#: ../src/iop/ashift.c:6069
 msgid "shear the image along one diagonal"
 msgstr "대각선 방향으로 이미지 기울이기"
 
-#: ../src/iop/ashift.c:6074 ../src/iop/clipping.c:2128
+#: ../src/iop/ashift.c:6070 ../src/iop/clipping.c:2122
 msgid "automatically crop to avoid black edges"
 msgstr "검은 테두리를 없에기 위한 자동 자르기"
 
-#: ../src/iop/ashift.c:6075
-msgid "lens model of the perspective correction: generic or according to the focal length"
+#: ../src/iop/ashift.c:6071
+msgid ""
+"lens model of the perspective correction: generic or according to the focal "
+"length"
 msgstr "원근 보정을 위한 렌즈 모델: 일반 또는 초점 거리 기반"
 
-#: ../src/iop/ashift.c:6078
+#: ../src/iop/ashift.c:6074
 msgid "focal length of the lens, default value set from EXIF data if available"
 msgstr "렌즈의 초점거리, EXIF 데이터가 사용 가능하다면 기본값으로 설정됩니다"
 
-#: ../src/iop/ashift.c:6081
-msgid "crop factor of the camera sensor, default value set from EXIF data if available, manual setting is often required"
+#: ../src/iop/ashift.c:6077
+msgid ""
+"crop factor of the camera sensor, default value set from EXIF data if "
+"available, manual setting is often required"
 msgstr "카메라 센서의 크롭 계수. EXIF 데이터가 사용 가능하다면 기본값으로 설정되지만, 수동 설정이 필요할 때도 있습니다"
 
-#: ../src/iop/ashift.c:6085
-msgid "the level of lens dependent correction, set to maximum for full lens dependency, set to zero for the generic case"
+#: ../src/iop/ashift.c:6081
+msgid ""
+"the level of lens dependent correction, set to maximum for full lens "
+"dependency, set to zero for the generic case"
 msgstr "렌즈 의존 보정의 수준. 최댓값은 렌즈에 의존해 설정됩니다, 일반 보정을 위해 0으로 설정할 수 있습니다."
 
-#: ../src/iop/ashift.c:6089
+#: ../src/iop/ashift.c:6085
 msgid "adjust aspect ratio of image by horizontal and vertical scaling"
 msgstr "수평 방향과 수직 방향 스케일링을 통해 이미지 종횡비 조정"
 
-#: ../src/iop/ashift.c:6091
+#: ../src/iop/ashift.c:6087
 msgid ""
 "automatically correct for vertical perspective distortion\n"
 "ctrl+click to only fit rotation\n"
@@ -15709,7 +18880,7 @@ msgstr ""
 "Ctrl+클릭: 회전만 보정\n"
 "Shift+클릭: 렌즈 이동만 보정"
 
-#: ../src/iop/ashift.c:6095
+#: ../src/iop/ashift.c:6091
 msgid ""
 "automatically correct for horizontal perspective distortion\n"
 "ctrl+click to only fit rotation\n"
@@ -15719,9 +18890,10 @@ msgstr ""
 "Ctrl+클릭: 회전만 보정\n"
 "Shift+클릭: 렌즈 이동만 보정"
 
-#: ../src/iop/ashift.c:6099
+#: ../src/iop/ashift.c:6095
 msgid ""
-"automatically correct for vertical and horizontal perspective distortions, fitting rotation, lens shift in both directions, and shear\n"
+"automatically correct for vertical and horizontal perspective distortions, "
+"fitting rotation, lens shift in both directions, and shear\n"
 "ctrl+click to only fit rotation\n"
 "shift+click to only fit lens shift\n"
 "ctrl+shift+click to only fit rotation and lens shift"
@@ -15731,7 +18903,7 @@ msgstr ""
 "Shift+클릭: 렌즈 이동만 보정\n"
 "Ctrl+Shift+클릭: 회전과 렌즈 이동만 보정"
 
-#: ../src/iop/ashift.c:6106
+#: ../src/iop/ashift.c:6102
 msgid ""
 "automatically analyse line structure in image\n"
 "ctrl+click for an additional edge enhancement\n"
@@ -15743,216 +18915,217 @@ msgstr ""
 "Shift+클릭: 디테일 향상 추가\n"
 "Ctrl+Shift+클릭: 둘 다 적용"
 
-#: ../src/iop/ashift.c:6111
+#: ../src/iop/ashift.c:6107
 msgid "manually define perspective rectangle"
 msgstr "수동으로 원근 사각형 정의"
 
-#: ../src/iop/ashift.c:6112
+#: ../src/iop/ashift.c:6108
 msgid "manually draw structure lines"
 msgstr "수동으로 구조 선 작성"
 
-#: ../src/iop/ashift.c:6141
+#: ../src/iop/ashift.c:6137
 msgid "rectangle"
 msgstr "사각형"
 
-#: ../src/iop/ashift.c:6143
+#: ../src/iop/ashift.c:6139
 msgid "lines"
 msgstr "선"
 
-#: ../src/iop/ashift.c:6169 ../src/iop/clipping.c:3338
+#: ../src/iop/ashift.c:6165 ../src/iop/clipping.c:3332
 #, c-format
 msgid "[%s] define/rotate horizon"
 msgstr "[%s] 수평선 정의/회전"
 
-#: ../src/iop/ashift.c:6172
+#: ../src/iop/ashift.c:6168
 #, c-format
 msgid "[%s on segment] select segment"
 msgstr "[선분에서 %s] 선분을 선택"
 
-#: ../src/iop/ashift.c:6176
+#: ../src/iop/ashift.c:6172
 #, c-format
 msgid "[%s on segment] unselect segment"
 msgstr "[선분에서 %s] 선분을 해제"
 
-#: ../src/iop/ashift.c:6180
+#: ../src/iop/ashift.c:6176
 #, c-format
 msgid "[%s] select all segments from zone"
 msgstr "[%s] 영역에 있는 모든 선분 선택"
 
-#: ../src/iop/ashift.c:6184
+#: ../src/iop/ashift.c:6180
 #, c-format
 msgid "[%s] unselect all segments from zone"
 msgstr "[%s] 영역에 있는 모든 선분 해제"
 
-#: ../src/iop/atrous.c:122 ../src/iop/atrous.c:1764
+#: ../src/iop/atrous.c:121 ../src/iop/atrous.c:1709
 msgid "contrast equalizer"
 msgstr "대비 이퀄라이저"
 
-#: ../src/iop/atrous.c:127
+#: ../src/iop/atrous.c:126
 msgid "sharpness|acutance|local contrast|clarity"
 msgstr "선명도|선예도|부분 대비|명료도"
 
-#: ../src/iop/atrous.c:132
+#: ../src/iop/atrous.c:131
 msgid "add or remove local contrast, sharpness, acutance"
 msgstr "부분 대비, 선명도, 선예도를 추가하거나 제거"
 
-#: ../src/iop/atrous.c:134 ../src/iop/atrous.c:136
+#: ../src/iop/atrous.c:133 ../src/iop/atrous.c:135
 #: ../src/iop/colorbalance.c:161
 msgid "linear, Lab, scene-referred"
 msgstr "선형, Lab, 장면 기준"
 
-#: ../src/iop/atrous.c:135 ../src/iop/censorize.c:85
+#: ../src/iop/atrous.c:134 ../src/iop/censorize.c:85
 #: ../src/iop/hazeremoval.c:112
 msgid "frequential, RGB"
 msgstr "주파수 기반, RGB"
 
-#: ../src/iop/atrous.c:795
+#: ../src/iop/atrous.c:740
 msgid "coarse"
 msgstr "거칠기 정도"
 
-#: ../src/iop/atrous.c:811
+#: ../src/iop/atrous.c:756
 msgid "denoise & sharpen"
 msgstr "노이즈 감소 & 샤프닝"
 
 #. add the preset.
-#: ../src/iop/atrous.c:827 ../src/iop/sharpen.c:103
+#: ../src/iop/atrous.c:772 ../src/iop/sharpen.c:103
 msgid "sharpen"
 msgstr "샤프닝"
 
-#: ../src/iop/atrous.c:843
+#: ../src/iop/atrous.c:788
 msgid "denoise chroma"
 msgstr "채도(크로마) 노이즈 감소"
 
-#: ../src/iop/atrous.c:859
+#: ../src/iop/atrous.c:804 ../src/libs/neural_restore.c:1435
+#: ../src/libs/neural_restore.c:4279
 msgid "denoise"
 msgstr "노이즈 감소"
 
-#: ../src/iop/atrous.c:876 ../src/iop/bloom.c:75
+#: ../src/iop/atrous.c:821 ../src/iop/bloom.c:75
 msgid "bloom"
 msgstr "블룸"
 
-#: ../src/iop/atrous.c:892 ../src/iop/bilat.c:79 ../src/iop/bilat.c:186
+#: ../src/iop/atrous.c:837 ../src/iop/bilat.c:79 ../src/iop/bilat.c:186
 msgid "clarity"
 msgstr "명료도"
 
-#: ../src/iop/atrous.c:913
+#: ../src/iop/atrous.c:858
 msgid "deblur | large blur | strength 3"
 msgstr "블러 감소 | 강한 블러 | 강도 3"
 
-#: ../src/iop/atrous.c:931
+#: ../src/iop/atrous.c:876
 msgid "deblur | medium blur | strength 3"
 msgstr "블러 감소 | 중간 블러 | 강도 3"
 
-#: ../src/iop/atrous.c:948
+#: ../src/iop/atrous.c:893
 msgid "deblur | fine blur | strength 3"
 msgstr "블러 감소 | 약한 블러 | 강도 3"
 
-#: ../src/iop/atrous.c:967
+#: ../src/iop/atrous.c:912
 msgid "deblur | large blur | strength 2"
 msgstr "블러 감소 | 강한 블러 | 강도 2"
 
-#: ../src/iop/atrous.c:985
+#: ../src/iop/atrous.c:930
 msgid "deblur | medium blur | strength 2"
 msgstr "블러 감소 | 중간 블러 | 강도 2"
 
-#: ../src/iop/atrous.c:1002
+#: ../src/iop/atrous.c:947
 msgid "deblur | fine blur | strength 2"
 msgstr "블러 감소 | 약한 블러 | 강도 2"
 
-#: ../src/iop/atrous.c:1021
+#: ../src/iop/atrous.c:966
 msgid "deblur | large blur | strength 1"
 msgstr "블러 감소 | 강한 블러 | 강도 1"
 
-#: ../src/iop/atrous.c:1039
+#: ../src/iop/atrous.c:984
 msgid "deblur | medium blur | strength 1"
 msgstr "블러 감소 | 중간 블러 | 강도 1"
 
-#: ../src/iop/atrous.c:1056
+#: ../src/iop/atrous.c:1001
 msgid "deblur | fine blur | strength 1"
 msgstr "블러 감소 | 약한 블러 | 강도 1"
 
-#: ../src/iop/atrous.c:1385 ../src/iop/atrous.c:1631
-#: ../src/iop/denoiseprofile.c:3580 ../src/iop/rawdenoise.c:730
+#: ../src/iop/atrous.c:1330 ../src/iop/atrous.c:1576
+#: ../src/iop/denoiseprofile.c:3404 ../src/iop/rawdenoise.c:732
 msgctxt "graph"
 msgid "coarse"
 msgstr "거침"
 
-#: ../src/iop/atrous.c:1392 ../src/iop/atrous.c:1632
-#: ../src/iop/denoiseprofile.c:3588 ../src/iop/rawdenoise.c:738
+#: ../src/iop/atrous.c:1337 ../src/iop/atrous.c:1577
+#: ../src/iop/denoiseprofile.c:3412 ../src/iop/rawdenoise.c:740
 msgid "fine"
 msgstr "약함"
 
-#: ../src/iop/atrous.c:1404
+#: ../src/iop/atrous.c:1349
 msgid "contrasty"
 msgstr "대조"
 
-#: ../src/iop/atrous.c:1410 ../src/iop/denoiseprofile.c:3602
-#: ../src/iop/rawdenoise.c:752
+#: ../src/iop/atrous.c:1355 ../src/iop/denoiseprofile.c:3426
+#: ../src/iop/rawdenoise.c:754
 msgid "noisy"
 msgstr "노이즈 정도"
 
 #. case atrous_s:
-#: ../src/iop/atrous.c:1413
+#: ../src/iop/atrous.c:1358
 msgid "bold"
 msgstr "굵게"
 
-#: ../src/iop/atrous.c:1414
+#: ../src/iop/atrous.c:1359
 msgid "dull"
 msgstr "흐릿함"
 
-#: ../src/iop/atrous.c:1619 ../src/iop/atrous.c:1679
+#: ../src/iop/atrous.c:1564 ../src/iop/atrous.c:1624
 msgid "boost"
 msgstr "강조"
 
-#: ../src/iop/atrous.c:1620
+#: ../src/iop/atrous.c:1565
 msgid "reduce"
 msgstr "감소"
 
-#: ../src/iop/atrous.c:1621
+#: ../src/iop/atrous.c:1566
 msgid "raise"
 msgstr "높이기"
 
-#: ../src/iop/atrous.c:1622
+#: ../src/iop/atrous.c:1567
 msgid "lower"
 msgstr "낮추기"
 
-#: ../src/iop/atrous.c:1629
+#: ../src/iop/atrous.c:1574
 msgid "coarsest"
 msgstr "가장 거칠게"
 
-#: ../src/iop/atrous.c:1630
+#: ../src/iop/atrous.c:1575
 msgid "coarser"
 msgstr "더 거칠게"
 
-#: ../src/iop/atrous.c:1633
+#: ../src/iop/atrous.c:1578
 msgid "finer"
 msgstr "더 연하게"
 
-#: ../src/iop/atrous.c:1634
+#: ../src/iop/atrous.c:1579
 msgid "finest"
 msgstr "가장 연하게"
 
-#: ../src/iop/atrous.c:1704 ../src/libs/export.c:1515 ../src/libs/export.c:1531
+#: ../src/iop/atrous.c:1649 ../src/libs/export.c:1533 ../src/libs/export.c:1549
 msgid "x"
 msgstr "x"
 
-#: ../src/iop/atrous.c:1791 ../src/iop/nlmeans.c:462
+#: ../src/iop/atrous.c:1750 ../src/iop/nlmeans.c:443
 msgid "luma"
 msgstr "휘도(루마)"
 
-#: ../src/iop/atrous.c:1792
+#: ../src/iop/atrous.c:1751
 msgid "change lightness at each feature size"
 msgstr "각각의 특징 크기에서 명도를 조절"
 
-#: ../src/iop/atrous.c:1794
+#: ../src/iop/atrous.c:1753
 msgid "change color saturation at each feature size"
 msgstr "각각의 특징 크기에서 색상 채도를 조절"
 
-#: ../src/iop/atrous.c:1796
+#: ../src/iop/atrous.c:1755
 msgid "edges"
 msgstr "윤곽"
 
-#: ../src/iop/atrous.c:1797
+#: ../src/iop/atrous.c:1756
 msgid ""
 "change edge halos at each feature size\n"
 "only changes results of luma and chroma tabs"
@@ -15960,7 +19133,7 @@ msgstr ""
 "각각의 특징 크기에서 에지의 헤일로 변경\n"
 "휘도(루마)나 채도(크로마) 탭의 결과를 바꿉니다"
 
-#: ../src/iop/atrous.c:1830 ../src/iop/colorzones.c:2705
+#: ../src/iop/atrous.c:1789 ../src/iop/colorzones.c:2705
 msgid "make effect stronger or weaker"
 msgstr "효과를 강하게 혹은 약하게 만들기"
 
@@ -16032,11 +19205,11 @@ msgstr "후지필름"
 msgid "nokia like"
 msgstr "노키아"
 
-#: ../src/iop/basecurve.c:363
+#: ../src/iop/basecurve.c:362
 msgid "base curve"
 msgstr "기본 커브"
 
-#: ../src/iop/basecurve.c:370
+#: ../src/iop/basecurve.c:369
 msgid ""
 "apply a view transform based on personal or camera maker look,\n"
 "for corrective purposes, to prepare images for display"
@@ -16044,62 +19217,66 @@ msgstr ""
 "개인 또는 카메라 메이커에 기반한 뷰 변환을 적용합니다,\n"
 "이미지를 화면에 표시할 때, 준비를 위한 보정 목적입니다"
 
-#: ../src/iop/basecurve.c:372 ../src/iop/cacorrect.c:81
+#: ../src/iop/basecurve.c:371 ../src/iop/cacorrect.c:81
 #: ../src/iop/cacorrectrgb.c:166 ../src/iop/colorreconstruction.c:117
 #: ../src/iop/defringe.c:80 ../src/iop/denoiseprofile.c:820
 #: ../src/iop/flip.c:108 ../src/iop/hazeremoval.c:110
 #: ../src/iop/highlights.c:176 ../src/iop/hotpixels.c:73
-#: ../src/iop/invert.c:131 ../src/iop/lens.cc:263 ../src/iop/nlmeans.c:87
+#: ../src/iop/invert.c:131 ../src/iop/lens.cc:264 ../src/iop/nlmeans.c:88
 #: ../src/iop/profile_gamma.c:99 ../src/iop/rawdenoise.c:140
 #: ../src/iop/retouch.c:207 ../src/iop/scalepixels.c:85 ../src/iop/sharpen.c:93
 #: ../src/iop/spots.c:66 ../src/iop/temperature.c:249
 msgid "corrective"
 msgstr "보정"
 
-#: ../src/iop/basecurve.c:375 ../src/iop/dither.c:117 ../src/iop/dither.c:119
-#: ../src/iop/filmicrgb.c:353 ../src/iop/graduatednd.c:146
+#: ../src/iop/basecurve.c:374 ../src/iop/dither.c:117 ../src/iop/dither.c:119
+#: ../src/iop/filmicrgb.c:347 ../src/iop/graduatednd.c:146
 #: ../src/iop/negadoctor.c:145 ../src/iop/profile_gamma.c:102
 #: ../src/iop/rgblevels.c:124 ../src/iop/vignette.c:118
-#: ../src/iop/vignette.c:120 ../src/iop/watermark.c:416
-#: ../src/iop/watermark.c:418
+#: ../src/iop/vignette.c:120 ../src/iop/watermark.c:469
+#: ../src/iop/watermark.c:471
 msgid "non-linear, RGB, display-referred"
 msgstr "비선형, RGB, 디스플레이 기준"
 
-#: ../src/iop/basecurve.c:553
+#: ../src/iop/basecurve.c:552
 msgid "display-referred default"
 msgstr "디스플레이 기준 기본값"
 
-#: ../src/iop/basecurve.c:2125
+#: ../src/iop/basecurve.c:2089
 msgid "abscissa: input, ordinate: output. works on RGB channels"
 msgstr "가로축: 입력, 세로축: 출력. RGB 채널에서 동작"
 
-#: ../src/iop/basecurve.c:2132 ../src/iop/basicadj.c:636
+#: ../src/iop/basecurve.c:2096 ../src/iop/basicadj.c:635
 #: ../src/iop/rgbcurve.c:1569 ../src/iop/rgblevels.c:1106
 #: ../src/iop/tonecurve.c:1323
 msgid "method to preserve colors when applying contrast"
 msgstr "대비를 적용할 때 색상을 보존하는 방법"
 
-#: ../src/iop/basecurve.c:2136
+#: ../src/iop/basecurve.c:2100
 msgid "two exposures"
 msgstr "이중 노출"
 
-#: ../src/iop/basecurve.c:2137
+#: ../src/iop/basecurve.c:2101
 msgid "three exposures"
 msgstr "삼중 노출"
 
-#: ../src/iop/basecurve.c:2138
-msgid "fuse this image stopped up/down a couple of times with itself, to compress high dynamic range. expose for the highlights before use."
+#: ../src/iop/basecurve.c:2102
+msgid ""
+"fuse this image stopped up/down a couple of times with itself, to compress "
+"high dynamic range. expose for the highlights before use."
 msgstr "이미지를 몇 번 위/아래로 멈춘 후 합성하여, 높은 다이나믹 레인지를 압축합니다. 사용하기 전 하이라이트를 노출시키세요."
 
-#: ../src/iop/basecurve.c:2143
+#: ../src/iop/basecurve.c:2107
 msgid "how many stops to shift the individual exposures apart"
 msgstr "개별 노출 간격을 몇 스톱으로 지정하시겠습니까"
 
-#: ../src/iop/basecurve.c:2152
-msgid "whether to shift exposure up or down (-1: reduce highlight, +1: reduce shadows)"
+#: ../src/iop/basecurve.c:2116
+msgid ""
+"whether to shift exposure up or down (-1: reduce highlight, +1: reduce "
+"shadows)"
 msgstr "노출을 증가시킬지 혹은 감소시킬지 여부 (-1: 하이라이트 감소, +1: 쉐도우 감소)"
 
-#: ../src/iop/basecurve.c:2158 ../src/iop/tonecurve.c:1326
+#: ../src/iop/basecurve.c:2122 ../src/iop/tonecurve.c:1326
 msgid "scale for graph"
 msgstr "그래프의 범위"
 
@@ -16116,14 +19293,14 @@ msgid "apply usual image adjustments"
 msgstr "일반적인 이미지 조정을 적용"
 
 #: ../src/iop/basicadj.c:168 ../src/iop/bilat.c:85 ../src/iop/bloom.c:81
-#: ../src/iop/blurs.c:90 ../src/iop/borders.c:317 ../src/iop/censorize.c:83
+#: ../src/iop/blurs.c:94 ../src/iop/borders.c:317 ../src/iop/censorize.c:83
 #: ../src/iop/colisa.c:87 ../src/iop/colorcontrast.c:86
 #: ../src/iop/colorize.c:95 ../src/iop/colormapping.c:152
 #: ../src/iop/colorzones.c:142 ../src/iop/grain.c:391 ../src/iop/highpass.c:75
 #: ../src/iop/levels.c:137 ../src/iop/liquify.c:294 ../src/iop/lowlight.c:89
 #: ../src/iop/lowpass.c:103 ../src/iop/monochrome.c:99 ../src/iop/soften.c:99
 #: ../src/iop/splittoning.c:102 ../src/iop/velvia.c:97 ../src/iop/vibrance.c:94
-#: ../src/iop/vignette.c:117 ../src/iop/watermark.c:415
+#: ../src/iop/vignette.c:117 ../src/iop/watermark.c:468
 msgid "creative"
 msgstr "창의력"
 
@@ -16131,7 +19308,7 @@ msgstr "창의력"
 msgid "non-linear, RGB, scene-referred"
 msgstr "비선형, RGB, 장면 기준"
 
-#: ../src/iop/basicadj.c:617
+#: ../src/iop/basicadj.c:616
 msgid ""
 "adjust the black level to unclip negative RGB values.\n"
 "you should never use it to add more density in blacks!\n"
@@ -16143,39 +19320,39 @@ msgstr ""
 "부적절하게 설정한 경우, RGB 값이 음수가 되기 때문에 \n"
 "거의 검정에 가까운 색이 색상 공간을 벗어나 잘릴 수 있습니다."
 
-#: ../src/iop/basicadj.c:625 ../src/iop/exposure.c:1213
+#: ../src/iop/basicadj.c:624 ../src/iop/exposure.c:1215
 msgid "adjust the exposure correction"
 msgstr "노출 보정 조정"
 
-#: ../src/iop/basicadj.c:629
+#: ../src/iop/basicadj.c:628
 msgid "highlight compression adjustment"
 msgstr "하이라이트 압축 조정"
 
-#: ../src/iop/basicadj.c:633 ../src/iop/colisa.c:281
+#: ../src/iop/basicadj.c:632 ../src/iop/colisa.c:276
 msgid "contrast adjustment"
 msgstr "대비 조정"
 
-#: ../src/iop/basicadj.c:641
+#: ../src/iop/basicadj.c:640
 msgid "middle gray adjustment"
 msgstr "중간 회색 조정"
 
-#: ../src/iop/basicadj.c:646 ../src/iop/colisa.c:282
+#: ../src/iop/basicadj.c:645 ../src/iop/colisa.c:277
 msgid "brightness adjustment"
 msgstr "명도 조정"
 
-#: ../src/iop/basicadj.c:649
+#: ../src/iop/basicadj.c:648
 msgid "saturation adjustment"
 msgstr "채도 조정"
 
-#: ../src/iop/basicadj.c:652
+#: ../src/iop/basicadj.c:651
 msgid "vibrance adjustment"
 msgstr "생동감 조정"
 
-#: ../src/iop/basicadj.c:654
+#: ../src/iop/basicadj.c:653
 msgid "apply auto exposure based on the entire image"
 msgstr "전체 이미지에 기반하여 자동 노출을 적용"
 
-#: ../src/iop/basicadj.c:660
+#: ../src/iop/basicadj.c:659
 msgid ""
 "apply auto exposure based on a region defined by the user\n"
 "click and drag to draw the area\n"
@@ -16185,15 +19362,15 @@ msgstr ""
 "클릭 후 드래그하여 영역을 지정, \n"
 "우클릭으로 해제"
 
-#: ../src/iop/basicadj.c:667
+#: ../src/iop/basicadj.c:666
 msgid "clip"
 msgstr "클리핑"
 
-#: ../src/iop/basicadj.c:669
+#: ../src/iop/basicadj.c:668
 msgid "adjusts clipping value for auto exposure calculation"
 msgstr "자동 노출 계산 시 사용될 클리핑 값을 조정합니다"
 
-#: ../src/iop/bilat.c:74 ../src/iop/clahe.c:61
+#: ../src/iop/bilat.c:74
 msgid "local contrast"
 msgstr "부분 대비"
 
@@ -16209,7 +19386,7 @@ msgstr "전체 대비와 부분 대비를 개별적으로 조절"
 #: ../src/iop/colorreconstruction.c:120 ../src/iop/colorzones.c:145
 #: ../src/iop/defringe.c:83 ../src/iop/grain.c:392 ../src/iop/grain.c:394
 #: ../src/iop/levels.c:140 ../src/iop/lowlight.c:90 ../src/iop/lowlight.c:92
-#: ../src/iop/monochrome.c:102 ../src/iop/nlmeans.c:88 ../src/iop/nlmeans.c:90
+#: ../src/iop/monochrome.c:102 ../src/iop/nlmeans.c:89 ../src/iop/nlmeans.c:91
 #: ../src/iop/shadhi.c:144 ../src/iop/tonecurve.c:182 ../src/iop/vibrance.c:97
 msgid "non-linear, Lab, display-referred"
 msgstr "비선형, Lab, 디스플레이 기준"
@@ -16219,7 +19396,7 @@ msgstr "비선형, Lab, 디스플레이 기준"
 #: ../src/iop/colorize.c:97 ../src/iop/colormapping.c:154
 #: ../src/iop/colorreconstruction.c:119 ../src/iop/colorzones.c:144
 #: ../src/iop/defringe.c:82 ../src/iop/grain.c:393 ../src/iop/levels.c:139
-#: ../src/iop/monochrome.c:101 ../src/iop/nlmeans.c:89 ../src/iop/shadhi.c:143
+#: ../src/iop/monochrome.c:101 ../src/iop/nlmeans.c:90 ../src/iop/shadhi.c:143
 #: ../src/iop/tonecurve.c:181 ../src/iop/vibrance.c:96
 msgid "non-linear, Lab"
 msgstr "비선형, Lab"
@@ -16228,36 +19405,41 @@ msgstr "비선형, Lab"
 msgid "HDR local tone-mapping"
 msgstr "HDR 부분 톤 매핑"
 
-#: ../src/iop/bilat.c:441
-msgid "the filter used for local contrast enhancement. bilateral is faster but can lead to artifacts around edges for extreme settings."
+#: ../src/iop/bilat.c:437
+msgid ""
+"the filter used for local contrast enhancement. bilateral is faster but can "
+"lead to artifacts around edges for extreme settings."
 msgstr "부분 대비를 향상시키기 위해 사용하는 필터입니다. 양방향 필터는 더 빠르지만, 극단적인 설정에서 윤곽 주변에 아티팩트가 생길 수 있습니다."
 
-#: ../src/iop/bilat.c:445 ../src/iop/globaltonemap.c:651
+#: ../src/iop/bilat.c:441 ../src/iop/globaltonemap.c:639
 msgid "detail"
 msgstr "세부 사항"
 
-#: ../src/iop/bilat.c:448
+#: ../src/iop/bilat.c:444
 msgid "changes the local contrast"
 msgstr "부분 대비를 변경합니다"
 
-#: ../src/iop/bilat.c:463
+#: ../src/iop/bilat.c:459
 msgid "feature size of local details (spatial sigma of bilateral filter)"
 msgstr "부분 세부 사항의 특징 크기 (양방향 필터의 공간 시그마)"
 
-#: ../src/iop/bilat.c:471
+#: ../src/iop/bilat.c:467
 msgid "L difference to detect edges (range sigma of bilateral filter)"
 msgstr "경계 감지를 위한 L 차이 (양방향 필터의 범위 시그마)"
 
-#: ../src/iop/bilat.c:477
+#: ../src/iop/bilat.c:473
 msgid "changes the local contrast of highlights"
 msgstr "하이라이트의 부분 대비를 변경합니다"
 
-#: ../src/iop/bilat.c:483
+#: ../src/iop/bilat.c:479
 msgid "changes the local contrast of shadows"
 msgstr "쉐도우의 부분 대비를 변경합니다"
 
-#: ../src/iop/bilat.c:489
-msgid "defines what counts as mid-tones. lower for better dynamic range compression (reduce shadow and highlight contrast), increase for more powerful local contrast"
+#: ../src/iop/bilat.c:485
+msgid ""
+"defines what counts as mid-tones. lower for better dynamic range compression "
+"(reduce shadow and highlight contrast), increase for more powerful local "
+"contrast"
 msgstr "중간 톤으로 여겨지는 범위를 정의합니다. 낮추는 경우 더 좋은 다이나믹 레인지 압축을,(여두운 영역과 하이라이트의 대비 감소), 증가시키는 경우 매우 강한 부분 대비가 됩니다."
 
 #: ../src/iop/bilateral.cc:72 ../src/iop/diffuse.c:442
@@ -16276,10 +19458,11 @@ msgstr ""
 "윤곽을 인식하는 표면 블러를 적용하여\n"
 "노이즈 감소 또는 텍스쳐 부드럽게 만들기"
 
-#: ../src/iop/bilateral.cc:105 ../src/iop/blurs.c:90
-#: ../src/iop/channelmixer.c:138 ../src/iop/denoiseprofile.c:822
-#: ../src/iop/diffuse.c:141 ../src/iop/enlargecanvas.c:82
-#: ../src/iop/exposure.c:132 ../src/iop/overlay.c:157 ../src/iop/primaries.c:75
+#: ../src/iop/bilateral.cc:105 ../src/iop/blurs.c:94
+#: ../src/iop/cacorrectrgb.c:168 ../src/iop/channelmixer.c:138
+#: ../src/iop/denoiseprofile.c:822 ../src/iop/diffuse.c:141
+#: ../src/iop/enlargecanvas.c:82 ../src/iop/exposure.c:132
+#: ../src/iop/overlay.c:179 ../src/iop/primaries.c:75
 #: ../src/iop/scalepixels.c:87 ../src/iop/soften.c:101
 #: ../src/iop/splittoning.c:104 ../src/iop/velvia.c:99
 msgid "linear, RGB"
@@ -16299,19 +19482,19 @@ msgstr ""
 "이미지를 처리할 수 없습니다.\n"
 "처리를 건너뛰었습니다."
 
-#: ../src/iop/bilateral.cc:369
+#: ../src/iop/bilateral.cc:368
 msgid "spatial extent of the gaussian"
 msgstr "가우시안 블러의 공간 범위"
 
-#: ../src/iop/bilateral.cc:373
+#: ../src/iop/bilateral.cc:372
 msgid "how much to blur red"
 msgstr "빨간색 블러 정도"
 
-#: ../src/iop/bilateral.cc:378
+#: ../src/iop/bilateral.cc:377
 msgid "how much to blur green"
 msgstr "초록색 블러 정도"
 
-#: ../src/iop/bilateral.cc:383
+#: ../src/iop/bilateral.cc:382
 msgid "how much to blur blue"
 msgstr "파란색 블러 정도"
 
@@ -16319,37 +19502,37 @@ msgstr "파란색 블러 정도"
 msgid "apply Orton effect for a dreamy ethereal look"
 msgstr "몽환적이고 신비로운 분위기를 위한 오튼 효과 적용"
 
-#: ../src/iop/bloom.c:414 ../src/iop/soften.c:381 ../src/libs/camera.c:591
-#: ../src/libs/masks.c:107
+#: ../src/iop/bloom.c:382 ../src/iop/soften.c:372 ../src/libs/camera.c:591
+#: ../src/libs/masks.c:187
 msgid "size"
 msgstr "크기"
 
-#: ../src/iop/bloom.c:416
+#: ../src/iop/bloom.c:384
 msgid "the size of bloom"
 msgstr "블룸 크기"
 
-#: ../src/iop/bloom.c:420
+#: ../src/iop/bloom.c:388
 msgid "the threshold of light"
 msgstr "빛의 임계값"
 
-#: ../src/iop/bloom.c:424
+#: ../src/iop/bloom.c:392
 msgid "the strength of bloom"
 msgstr "블룸 강도"
 
-#: ../src/iop/blurs.c:78
+#: ../src/iop/blurs.c:82
 msgid "blurs"
 msgstr "블러"
 
-#: ../src/iop/blurs.c:83
+#: ../src/iop/blurs.c:87
 msgid "blur|lens|motion"
 msgstr "블러|렌즈|모션"
 
-#: ../src/iop/blurs.c:89
+#: ../src/iop/blurs.c:93
 msgid "simulate physically-accurate lens and motion blurs"
 msgstr "물리적으로 정확한 렌즈와 모션 블러 시뮬레이션"
 
 #. add the tooltips
-#: ../src/iop/blurs.c:794
+#: ../src/iop/blurs.c:1007
 msgid ""
 "size of the blur in pixels\n"
 "<b>caution</b>: doubling the radius quadruples the run-time!"
@@ -16357,11 +19540,11 @@ msgstr ""
 "픽셀 단위의 블러 크기\n"
 "<b>주의</b>: 반지름을 두 배 키우면 실행 시간이 네 배 늘어납니다!"
 
-#: ../src/iop/blurs.c:796
+#: ../src/iop/blurs.c:1009
 msgid "shifts towards a star shape as value approaches blades-1"
 msgstr "값이 조리개 날의 값-1에 가까워질수록 별 모양에 가까워집니다"
 
-#: ../src/iop/blurs.c:798
+#: ../src/iop/blurs.c:1011
 msgid ""
 "adjust straightness of edges from 0=perfect circle\n"
 "to 1=completely straight"
@@ -16369,15 +19552,15 @@ msgstr ""
 "윤곽의 직선 정도를 조정합니다, 0=완벽한 원에서\n"
 "1=완전한 직선까지"
 
-#: ../src/iop/blurs.c:799
+#: ../src/iop/blurs.c:1012
 msgid "set amount by which to rotate shape around its center"
 msgstr "중심을 기준으로 도형이 회전하는 정도를 설정"
 
-#: ../src/iop/blurs.c:801
+#: ../src/iop/blurs.c:1014
 msgid "orientation of the motion's path"
 msgstr "모션 경로의 방향"
 
-#: ../src/iop/blurs.c:802
+#: ../src/iop/blurs.c:1015
 msgid ""
 "amount to curve the motion relative\n"
 "to its overall orientation"
@@ -16385,7 +19568,7 @@ msgstr ""
 "전체 방향에 대해 상대적인\n"
 "모션 커브의 정도"
 
-#: ../src/iop/blurs.c:803
+#: ../src/iop/blurs.c:1016
 msgid ""
 "select which portion of the path to use,\n"
 "allowing the path to become asymmetric"
@@ -16405,31 +19588,31 @@ msgstr "테두리|캔버스 확장|캔버스 확대"
 msgid "add solid borders or margins around the image"
 msgstr "이미지 주변에 단색 테두리 또는 여백 추가"
 
-#: ../src/iop/borders.c:318 ../src/iop/borders.c:320 ../src/iop/lut3d.c:141
+#: ../src/iop/borders.c:318 ../src/iop/borders.c:320 ../src/iop/lut3d.c:142
 msgid "linear or non-linear, RGB, display-referred"
 msgstr "선형 또는 비선형, RGB, 디스플레이 기준"
 
-#: ../src/iop/borders.c:715
+#: ../src/iop/borders.c:713
 msgid "15:10 postcard white"
 msgstr "15:10 엽서 흰색"
 
-#: ../src/iop/borders.c:720
+#: ../src/iop/borders.c:718
 msgid "15:10 postcard black"
 msgstr "15:10 엽서 검정"
 
-#: ../src/iop/borders.c:925
+#: ../src/iop/borders.c:923
 msgid "which dimension to use for the size calculation"
 msgstr "크기 계산에 사용될 기준 치수"
 
-#: ../src/iop/borders.c:931
+#: ../src/iop/borders.c:929
 msgid "size of the border in percent of the chosen basis"
 msgstr "선택된 기준의 백분율로 표시되는 테두리 크기"
 
-#: ../src/iop/borders.c:933 ../src/iop/clipping.c:2229 ../src/iop/crop.c:1262
+#: ../src/iop/borders.c:931 ../src/iop/clipping.c:2223 ../src/iop/crop.c:1379
 msgid "aspect"
 msgstr "비율"
 
-#: ../src/iop/borders.c:934
+#: ../src/iop/borders.c:932
 msgid ""
 "select the aspect ratio\n"
 "(right-click on slider below to type your own w:h)"
@@ -16437,85 +19620,79 @@ msgstr ""
 "화면 비율 선택\n"
 "(슬라이더에서 우클릭을 통해 w:h 형태의 타입을 직접 입력할 수 있습니다)"
 
-#: ../src/iop/borders.c:938
+#: ../src/iop/borders.c:936
 msgid "3:1"
 msgstr "3:1"
 
-#: ../src/iop/borders.c:939
+#: ../src/iop/borders.c:937
 msgid "95:33"
 msgstr "95:33"
 
-#: ../src/iop/borders.c:940
+#: ../src/iop/borders.c:938
 msgid "CinemaScope 2.39:1"
 msgstr "시네마스코프 2.39:1"
 
-#: ../src/iop/borders.c:941
+#: ../src/iop/borders.c:939
 msgid "2:1"
 msgstr "2:1"
 
-#: ../src/iop/borders.c:942
+#: ../src/iop/borders.c:940
 msgid "16:9"
 msgstr "16:9"
 
-#: ../src/iop/borders.c:943
+#: ../src/iop/borders.c:941
 msgid "5:3"
 msgstr "5:3"
 
-#: ../src/iop/borders.c:944
+#: ../src/iop/borders.c:942
 msgid "US Legal 8.5x14"
 msgstr "US 리갈 8.5x14"
 
-#: ../src/iop/borders.c:945 ../src/iop/clipping.c:2142 ../src/iop/crop.c:1164
+#: ../src/iop/borders.c:943 ../src/iop/clipping.c:2136 ../src/iop/crop.c:1281
 msgid "golden cut"
 msgstr "황금비"
 
-#: ../src/iop/borders.c:946
+#: ../src/iop/borders.c:944
 msgid "16:10"
 msgstr "16:10"
 
-#: ../src/iop/borders.c:947
+#: ../src/iop/borders.c:945
 msgid "3:2 (4x6, 10x15cm)"
 msgstr "3:2 (4x6, 10x15cm)"
 
-#: ../src/iop/borders.c:949
+#: ../src/iop/borders.c:947
 msgid "DIN"
 msgstr "DIN"
 
-#: ../src/iop/borders.c:950
+#: ../src/iop/borders.c:948
 msgid "7:5"
 msgstr "7:5"
 
-#: ../src/iop/borders.c:951
+#: ../src/iop/borders.c:949
 msgid "4:3"
 msgstr "4:3"
 
-#: ../src/iop/borders.c:952
+#: ../src/iop/borders.c:950
 msgid "US Letter 8.5x11"
 msgstr "US 종이 8.5x11"
 
-#: ../src/iop/borders.c:953
+#: ../src/iop/borders.c:951
 msgid "14:11"
 msgstr "14:11"
 
-#: ../src/iop/borders.c:954
+#: ../src/iop/borders.c:952
 msgid "5:4 (8x10)"
 msgstr "5:4 (8x10)"
 
-#: ../src/iop/borders.c:955 ../src/iop/clipping.c:2132 ../src/iop/crop.c:1153
-#: ../src/libs/filtering.c:310 ../src/libs/filters/ratio.c:124
-#: ../src/libs/histogram.c:120
-msgid "square"
-msgstr "사각형"
-
-#: ../src/iop/borders.c:956
+#: ../src/iop/borders.c:954
 msgid "constant border"
 msgstr "균일 테두리"
 
-#: ../src/iop/borders.c:957 ../src/iop/borders.c:973 ../src/iop/borders.c:984
+#: ../src/iop/borders.c:955 ../src/iop/borders.c:971 ../src/iop/borders.c:982
 msgid "custom..."
 msgstr "사용자 지정..."
 
-#: ../src/iop/borders.c:961
+#: ../src/iop/borders.c:959
 msgid ""
 "set the custom aspect ratio\n"
 "(right-click to enter number or w:h)"
@@ -16523,15 +19700,15 @@ msgstr ""
 "사용자 지정 종횡비를 설정합니다\n"
 "(우클릭을 통해 숫자 또는 w:h 형태로 입력할 수 있습니다h)"
 
-#: ../src/iop/borders.c:966
+#: ../src/iop/borders.c:964
 msgid "aspect ratio orientation of the image with border"
 msgstr "테두리가 포함된 이미지의 종횡비 방향"
 
-#: ../src/iop/borders.c:968
+#: ../src/iop/borders.c:966
 msgid "horizontal position"
 msgstr "수평 위치"
 
-#: ../src/iop/borders.c:969
+#: ../src/iop/borders.c:967
 msgid ""
 "select the horizontal position ratio relative to top\n"
 "(right-click on slider below to type your own x:w)"
@@ -16539,35 +19716,35 @@ msgstr ""
 "상단 기준 수평 위치 비율을 선택\n"
 "(슬라이더에서 우클릭을 통해 x:h 형태의 타입을 직접 입력할 수 있습니다)"
 
-#: ../src/iop/borders.c:972 ../src/iop/borders.c:983
+#: ../src/iop/borders.c:970 ../src/iop/borders.c:981
 msgid "center"
 msgstr "중앙"
 
-#: ../src/iop/borders.c:972 ../src/iop/borders.c:983
+#: ../src/iop/borders.c:970 ../src/iop/borders.c:981
 msgid "1/3"
 msgstr "1/3"
 
-#: ../src/iop/borders.c:972 ../src/iop/borders.c:983
+#: ../src/iop/borders.c:970 ../src/iop/borders.c:981
 msgid "3/8"
 msgstr "3/8"
 
-#: ../src/iop/borders.c:973 ../src/iop/borders.c:984
+#: ../src/iop/borders.c:971 ../src/iop/borders.c:982
 msgid "5/8"
 msgstr "5/8"
 
-#: ../src/iop/borders.c:973 ../src/iop/borders.c:984
+#: ../src/iop/borders.c:971 ../src/iop/borders.c:982
 msgid "2/3"
 msgstr "2/3"
 
-#: ../src/iop/borders.c:977
+#: ../src/iop/borders.c:975
 msgid "custom horizontal position"
 msgstr "사용자 지정 수평 위치"
 
-#: ../src/iop/borders.c:979
+#: ../src/iop/borders.c:977
 msgid "vertical position"
 msgstr "수직 위치"
 
-#: ../src/iop/borders.c:980
+#: ../src/iop/borders.c:978
 msgid ""
 "select the vertical position ratio relative to left\n"
 "(right-click on slider below to type your own y:h)"
@@ -16575,27 +19752,27 @@ msgstr ""
 "왼쪽 기준 수직 위치 비율을 선택\n"
 "(슬라이더에서 우클릭을 통해 y:h 형태의 타입을 직접 입력할 수 있습니다)"
 
-#: ../src/iop/borders.c:988
+#: ../src/iop/borders.c:986
 msgid "custom vertical position"
 msgstr "사용자 지정 수직 위치"
 
-#: ../src/iop/borders.c:994
+#: ../src/iop/borders.c:992
 msgid "size of the frame line in percent of min border width"
 msgstr "최소 테두리 너비의 백분율일 때, 프레임 선 크기"
 
-#: ../src/iop/borders.c:1000
+#: ../src/iop/borders.c:998
 msgid "offset of the frame line beginning on image side"
 msgstr "프레임 선이 이미지에서 시작되는 오프셋"
 
-#: ../src/iop/borders.c:1015
+#: ../src/iop/borders.c:1013
 msgid "select border color"
 msgstr "테두리 색상 선택"
 
-#: ../src/iop/borders.c:1020
+#: ../src/iop/borders.c:1018
 msgid "pick border color from image"
 msgstr "이미지에서 테두리 색상을 선택"
 
-#: ../src/iop/borders.c:1021 ../src/iop/borders.c:1035
+#: ../src/iop/borders.c:1019 ../src/iop/borders.c:1033
 #: ../src/iop/colorzones.c:2641 ../src/iop/colorzones.c:2656
 #: ../src/iop/negadoctor.c:850 ../src/iop/negadoctor.c:912
 #: ../src/iop/negadoctor.c:946 ../src/iop/rgbcurve.c:1503
@@ -16603,11 +19780,11 @@ msgstr "이미지에서 테두리 색상을 선택"
 msgid "pickers"
 msgstr "피커"
 
-#: ../src/iop/borders.c:1029
+#: ../src/iop/borders.c:1027
 msgid "select frame line color"
 msgstr "프레임 선 색상 선택"
 
-#: ../src/iop/borders.c:1034
+#: ../src/iop/borders.c:1032
 msgid "pick frame line color from image"
 msgstr "이미지에서 선 색상을 선택"
 
@@ -16621,20 +19798,18 @@ msgid "correct chromatic aberrations for Bayer sensors"
 msgstr "베이어 센서의 색수차 보정"
 
 #: ../src/iop/cacorrect.c:82 ../src/iop/cacorrect.c:84
-#: ../src/iop/cacorrectrgb.c:167 ../src/iop/cacorrectrgb.c:169
-#: ../src/iop/demosaic.c:328 ../src/iop/highlights.c:177
+#: ../src/iop/demosaic.c:316 ../src/iop/highlights.c:177
 #: ../src/iop/highlights.c:179 ../src/iop/hotpixels.c:74
-#: ../src/iop/hotpixels.c:76 ../src/iop/rawdenoise.c:141
-#: ../src/iop/rawdenoise.c:143 ../src/iop/rasterfile.c:101
-#: ../src/iop/rasterfile.c:103 ../src/iop/rawprepare.c:171
+#: ../src/iop/hotpixels.c:76 ../src/iop/rasterfile.c:107
+#: ../src/iop/rasterfile.c:109 ../src/iop/rawdenoise.c:141
+#: ../src/iop/rawdenoise.c:143 ../src/iop/rawprepare.c:171
 #: ../src/iop/rawprepare.c:173 ../src/iop/temperature.c:250
 #: ../src/iop/temperature.c:252
 msgid "linear, raw, scene-referred"
 msgstr "선형, raw, 장면 참조"
 
-#: ../src/iop/cacorrect.c:83 ../src/iop/cacorrectrgb.c:168
-#: ../src/iop/demosaic.c:329 ../src/iop/invert.c:133
-#: ../src/iop/rawdenoise.c:142 ../src/iop/rasterfile.c:102
+#: ../src/iop/cacorrect.c:83 ../src/iop/demosaic.c:317 ../src/iop/invert.c:133
+#: ../src/iop/rasterfile.c:108 ../src/iop/rawdenoise.c:142
 #: ../src/iop/rawprepare.c:172 ../src/iop/temperature.c:251
 msgid "linear, raw"
 msgstr "선형, raw"
@@ -16744,8 +19919,8 @@ msgstr "검열"
 msgid "censorize license plates and body parts for privacy"
 msgstr "사생활 보호를 위해 번호판 또는 신체 부위 검열"
 
-#: ../src/iop/censorize.c:84 ../src/iop/colorin.c:128
-#: ../src/iop/filmicrgb.c:351 ../src/iop/graduatednd.c:144
+#: ../src/iop/censorize.c:84 ../src/iop/colorin.c:129
+#: ../src/iop/filmicrgb.c:345 ../src/iop/graduatednd.c:144
 msgid "linear or non-linear, RGB, scene-referred"
 msgstr "선형 또는 비선형, RGB, 장면 참조"
 
@@ -16753,19 +19928,19 @@ msgstr "선형 또는 비선형, RGB, 장면 참조"
 msgid "special, RGB, scene-referred"
 msgstr "특수, RGB, 장면 참조"
 
-#: ../src/iop/censorize.c:425
+#: ../src/iop/censorize.c:424
 msgid "radius of gaussian blur before pixelization"
 msgstr "픽셀화 전 가우시안 블러 반지름"
 
-#: ../src/iop/censorize.c:426
+#: ../src/iop/censorize.c:425
 msgid "radius of gaussian blur after pixelization"
 msgstr "픽셀화 후 가우시안 블러 반지름"
 
-#: ../src/iop/censorize.c:427
+#: ../src/iop/censorize.c:426
 msgid "radius of the intermediate pixelization"
 msgstr "중간 픽셀화 반지름"
 
-#: ../src/iop/censorize.c:428
+#: ../src/iop/censorize.c:427
 msgid "amount of noise to add at the end"
 msgstr "마지막에 추가할 노이즈의 양"
 
@@ -16774,7 +19949,8 @@ msgid "channel mixer"
 msgstr "채널 혼합"
 
 #: ../src/iop/channelmixer.c:128
-msgid "this module is deprecated. please use the color calibration module instead."
+msgid ""
+"this module is deprecated. please use the color calibration module instead."
 msgstr "이 모듈은 더 이상 사용되지 않습니다. 색상 캘리브레이션 모듈을 대신 사용하세요."
 
 #: ../src/iop/channelmixer.c:133 ../src/iop/channelmixerrgb.c:235
@@ -17037,8 +20213,8 @@ msgstr ""
 "일관성이 유지되지 않을  있습니다."
 
 #: ../src/iop/channelmixerrgb.c:2067
-msgid "white balance applied twice"
-msgstr "화이트 밸런스가 중복 적용되었습니다"
+msgid "white balance applied twice (<u>details</u>)"
+msgstr "화이트 밸런스가 중복 적용되었습니다 (<u>자세히</u>)"
 
 #: ../src/iop/channelmixerrgb.c:2068
 msgid ""
@@ -17053,8 +20229,8 @@ msgstr ""
 "색상 캘리브레이션에서 색순응 보정을 비활성화하세요."
 
 #: ../src/iop/channelmixerrgb.c:2076
-msgid "white balance module error"
-msgstr "화이트 밸런스 모듈이 잘못되었습니다"
+msgid "white balance module error (<u>details</u>)"
+msgstr "화이트 밸런스 모듈이 잘못되었습니다 (<u>자세히</u>)"
 
 #: ../src/iop/channelmixerrgb.c:2077
 msgid ""
@@ -17069,8 +20245,8 @@ msgstr ""
 "이곳에서 색순응 보정을 비활성화하세요."
 
 #: ../src/iop/channelmixerrgb.c:2089 ../src/iop/channelmixerrgb.c:2098
-msgid "white balance missing"
-msgstr "화이트 밸런스가 누락되었습니다"
+msgid "white balance missing (<u>details</u>)"
+msgstr "화이트 밸런스가 없습니다 (<u>자세히</u>)"
 
 #: ../src/iop/channelmixerrgb.c:2090
 msgid ""
@@ -17104,12 +20280,12 @@ msgstr "화이트 밸런스 자동 감지가 완료되었습니다"
 msgid "channelmixerrgb works only on RGB input"
 msgstr "channelmixerrgb는 RGB 입력에서만 작동합니다"
 
-#: ../src/iop/channelmixerrgb.c:3647
+#: ../src/iop/channelmixerrgb.c:3675
 #, c-format
 msgid "CCT: %.0f K (daylight)"
 msgstr "상관 색온도: %.0f K (일광)"
 
-#: ../src/iop/channelmixerrgb.c:3650
+#: ../src/iop/channelmixerrgb.c:3678
 msgid ""
 "approximated correlated color temperature.\n"
 "this illuminant can be accurately modeled by a daylight spectrum,\n"
@@ -17119,12 +20295,12 @@ msgstr ""
 "이 광원은 일광 스펙트럼으로 정확히 모델링할 수 있으므로,\n"
 "광원의 온도는 D 광원과 관련이 있고 의미가 있습니다."
 
-#: ../src/iop/channelmixerrgb.c:3656
+#: ../src/iop/channelmixerrgb.c:3684
 #, c-format
 msgid "CCT: %.0f K (black body)"
 msgstr "상관 색온도: %.0f K (흑체)"
 
-#: ../src/iop/channelmixerrgb.c:3659
+#: ../src/iop/channelmixerrgb.c:3687
 msgid ""
 "approximated correlated color temperature.\n"
 "this illuminant can be accurately modeled by a black body spectrum,\n"
@@ -17134,27 +20310,29 @@ msgstr ""
 "이 광원은 흑체 스펙트럼으로 정확히 모델링할 수 있으므로,\n"
 "광원의 온도는 플랑크 광원과 관련이 있고 의미가 있습니다."
 
-#: ../src/iop/channelmixerrgb.c:3665
+#: ../src/iop/channelmixerrgb.c:3693
 #, c-format
 msgid "CCT: %.0f K (invalid)"
 msgstr "상관 색온도: %.0f K (유효하지 않음)"
 
-#: ../src/iop/channelmixerrgb.c:3668
+#: ../src/iop/channelmixerrgb.c:3696
 msgid ""
 "approximated correlated color temperature.\n"
-"this illuminant cannot be accurately modeled by a daylight or black body spectrum,\n"
-"so its temperature is not relevant and meaningful and you need to use a custom illuminant."
+"this illuminant cannot be accurately modeled by a daylight or black body "
+"spectrum,\n"
+"so its temperature is not relevant and meaningful and you need to use a "
+"custom illuminant."
 msgstr ""
 "근사된 상관 색온도입니다.\n"
 "이 광원은 일광이나 흑체 스펙트럼으로 정확하게 모델링할 수 없기 때문에,\n"
 "광원의 온도는 유의미하거나 의미있지 않으며 당신은 사용자 지정 광원을 사용해야 합니다."
 
-#: ../src/iop/channelmixerrgb.c:3677
+#: ../src/iop/channelmixerrgb.c:3705
 #, c-format
 msgid "CCT: undefined"
 msgstr "상관 색온도: 정의되지 않음"
 
-#: ../src/iop/channelmixerrgb.c:3680
+#: ../src/iop/channelmixerrgb.c:3708
 msgid ""
 "the approximated correlated color temperature\n"
 "cannot be computed at all so you need to use a custom illuminant."
@@ -17162,21 +20340,23 @@ msgstr ""
 "근사된 상관 색온도를 전혀 계산할 수 없습니다.\n"
 "그렇기 때문에 사용자 지정 광원을 사용해야 합니다."
 
-#: ../src/iop/channelmixerrgb.c:3998
+#: ../src/iop/channelmixerrgb.c:4026
 msgid "white balance successfully extracted from raw image"
 msgstr "raw 이미지에서 화이트 밸런스를 성공적으로 추출했습니다"
 
 #. We need to recompute only the full preview
-#: ../src/iop/channelmixerrgb.c:4005
+#: ../src/iop/channelmixerrgb.c:4033
 msgid "auto-detection of white balance started…"
 msgstr "화이트 밸런스 자동 감지를 시작했습니다..."
 
-#: ../src/iop/channelmixerrgb.c:4116
-msgid "color calibration: the sum of the gray channel parameters is zero, normalization will be disabled."
+#: ../src/iop/channelmixerrgb.c:4144
+msgid ""
+"color calibration: the sum of the gray channel parameters is zero, "
+"normalization will be disabled."
 msgstr "컬러 캘리브레이션: 회색 채널 파라메터의 합이 0이기 때문에, 정규화가 비활성화 됩니다."
 
 #. Write report in GUI
-#: ../src/iop/channelmixerrgb.c:4160
+#: ../src/iop/channelmixerrgb.c:4188
 #, c-format
 msgid ""
 "L: \t%.1f %%\n"
@@ -17188,19 +20368,19 @@ msgstr ""
 "c: \t%.1f"
 
 #. Page CAT
-#: ../src/iop/channelmixerrgb.c:4429
+#: ../src/iop/channelmixerrgb.c:4457
 msgid "CAT"
 msgstr "CAT"
 
-#: ../src/iop/channelmixerrgb.c:4430
+#: ../src/iop/channelmixerrgb.c:4458
 msgid "chromatic adaptation transform"
 msgstr "색순응 변환"
 
-#: ../src/iop/channelmixerrgb.c:4432
+#: ../src/iop/channelmixerrgb.c:4460
 msgid "adaptation"
 msgstr "순응"
 
-#: ../src/iop/channelmixerrgb.c:4435
+#: ../src/iop/channelmixerrgb.c:4463
 msgid ""
 "choose the method to adapt the illuminant\n"
 "and the colorspace in which the module works: \n"
@@ -17220,7 +20400,7 @@ msgstr ""
 "• XYZ: XYZ 공간에서 단순한 스케일링을 수행하며, 일반적으로 권장되지 않습니다.\n"
 "• none: 색순응을 비활성화하고 파이프라인 작업 RGB를 사용합니다."
 
-#: ../src/iop/channelmixerrgb.c:4452
+#: ../src/iop/channelmixerrgb.c:4480
 msgid ""
 "this is the color of the scene illuminant before chromatic adaptation\n"
 "this color will be turned into pure white by the adaptation."
@@ -17228,37 +20408,42 @@ msgstr ""
 "이 장면의 광원 색상은 색순응 이전 장면의 광원 색상입니다.\n"
 "순응에 의해 이 색상은 순백색으로 변환됩니다."
 
-#: ../src/iop/channelmixerrgb.c:4459
+#: ../src/iop/channelmixerrgb.c:4487
 msgid "picker"
 msgstr "피커"
 
-#: ../src/iop/channelmixerrgb.c:4461 ../src/iop/temperature.c:2095
+#: ../src/iop/channelmixerrgb.c:4489 ../src/iop/temperature.c:2080
 msgid "set white balance to detected from area"
 msgstr "영역에서 감지된 값으로 화이트 밸런스 설정"
 
-#: ../src/iop/channelmixerrgb.c:4465 ../src/iop/negadoctor.c:946
+#: ../src/iop/channelmixerrgb.c:4493 ../src/iop/negadoctor.c:946
 msgid "illuminant"
 msgstr "광원"
 
-#: ../src/iop/channelmixerrgb.c:4471 ../src/iop/temperature.c:2156
+#: ../src/iop/channelmixerrgb.c:4499 ../src/iop/temperature.c:2141
 msgid "temperature"
 msgstr "온도"
 
-#: ../src/iop/channelmixerrgb.c:4509
-msgid "define a target chromaticity (hue and chroma) for a particular region of the image (the control sample), which you then match against the same target chromaticity in other images. the control sample can either be a critical part of your subject or a non-moving and consistently-lit surface over your series of images."
+#: ../src/iop/channelmixerrgb.c:4537
+msgid ""
+"define a target chromaticity (hue and chroma) for a particular region of the "
+"image (the control sample), which you then match against the same target "
+"chromaticity in other images. the control sample can either be a critical "
+"part of your subject or a non-moving and consistently-lit surface over your "
+"series of images."
 msgstr "이미지의 특정 영역 (제어 샘플)에 대해 목표 색도 (색조와 채도)를 정의한 후, 다른 이미지에서 동일한 목표 색도와 정의한 특정 영역의 색도와 일치시킵니다. 제어 샘플은 이미지에 나타난 대상의 중요한 부분이거나 당신이 가지고 있는 일련의 이미지에서 움직이지 않고 일정하게 광원이 유지되는 표면일 수 있습니다."
 
-#: ../src/iop/channelmixerrgb.c:4516 ../src/iop/channelmixerrgb.c:4529
-#: ../src/iop/channelmixerrgb.c:4558 ../src/iop/channelmixerrgb.c:4566
-#: ../src/iop/channelmixerrgb.c:4573
+#: ../src/iop/channelmixerrgb.c:4544 ../src/iop/channelmixerrgb.c:4557
+#: ../src/iop/channelmixerrgb.c:4586 ../src/iop/channelmixerrgb.c:4594
+#: ../src/iop/channelmixerrgb.c:4601
 msgid "mapping"
 msgstr "매핑"
 
-#: ../src/iop/channelmixerrgb.c:4516 ../src/iop/exposure.c:1281
+#: ../src/iop/channelmixerrgb.c:4544 ../src/iop/exposure.c:1283
 msgid "area mode"
 msgstr "영역 모드"
 
-#: ../src/iop/channelmixerrgb.c:4517
+#: ../src/iop/channelmixerrgb.c:4545
 msgid ""
 "\"correction\" automatically adjust the illuminant\n"
 "such that the input color is mapped to the target.\n"
@@ -17270,19 +20455,19 @@ msgstr ""
 "\"측정\"은 CAT에 의해 입력 색상이 매핑되는 것을 보여주며\n"
 "이것은 목표 샘플을 만드는 데 사용될 수 있습니다."
 
-#: ../src/iop/channelmixerrgb.c:4522 ../src/iop/exposure.c:1287
+#: ../src/iop/channelmixerrgb.c:4550 ../src/iop/exposure.c:1289
 msgid "correction"
 msgstr "보정"
 
-#: ../src/iop/channelmixerrgb.c:4523 ../src/iop/exposure.c:1288
+#: ../src/iop/channelmixerrgb.c:4551 ../src/iop/exposure.c:1290
 msgid "measure"
 msgstr "측정"
 
-#: ../src/iop/channelmixerrgb.c:4527
+#: ../src/iop/channelmixerrgb.c:4555
 msgid "take channel mixing into account"
 msgstr "채널 혼합 효과를 계산에 포함"
 
-#: ../src/iop/channelmixerrgb.c:4534
+#: ../src/iop/channelmixerrgb.c:4562
 msgid ""
 "compute the target by taking the channel mixing into account.\n"
 "if disabled, only the CAT is considered."
@@ -17290,11 +20475,11 @@ msgstr ""
 "채널 혼합을 고려하여 목표 값을 계산합니다.\n"
 "비활성화할 경우, CAT만 고려됩니다."
 
-#: ../src/iop/channelmixerrgb.c:4542 ../src/iop/exposure.c:1296
+#: ../src/iop/channelmixerrgb.c:4570 ../src/iop/exposure.c:1298
 msgid "the input color that should be mapped to the target"
 msgstr "목표 색상에 매핑될 입력 색상"
 
-#: ../src/iop/channelmixerrgb.c:4546
+#: ../src/iop/channelmixerrgb.c:4574
 msgid ""
 "L: \tN/A\n"
 "h: \tN/A\n"
@@ -17304,124 +20489,125 @@ msgstr ""
 "h: \tN/A\n"
 "c: \tN/A"
 
-#: ../src/iop/channelmixerrgb.c:4549 ../src/iop/exposure.c:1303
+#: ../src/iop/channelmixerrgb.c:4577 ../src/iop/exposure.c:1305
 msgid "these LCh coordinates are computed from CIE Lab 1976 coordinates"
 msgstr "이 LCh 좌표는 CIE Lab 1976 좌표계에서 계산되었습니다"
 
-#: ../src/iop/channelmixerrgb.c:4554
+#: ../src/iop/channelmixerrgb.c:4582
 msgid "the desired target color after mapping"
 msgstr "매핑 후의 목표 색상"
 
-#: ../src/iop/channelmixerrgb.c:4581 ../src/iop/exposure.c:1322
+#: ../src/iop/channelmixerrgb.c:4609 ../src/iop/exposure.c:1324
 msgctxt "section"
 msgid "input"
 msgstr "입력"
 
 #. spacer
-#: ../src/iop/channelmixerrgb.c:4584 ../src/iop/exposure.c:1325
+#: ../src/iop/channelmixerrgb.c:4612 ../src/iop/exposure.c:1327
 msgctxt "section"
 msgid "target"
 msgstr "목표"
 
-#: ../src/iop/channelmixerrgb.c:4597
+#: ../src/iop/channelmixerrgb.c:4625
 msgid "input R"
 msgstr "입력 R"
 
-#: ../src/iop/channelmixerrgb.c:4602
+#: ../src/iop/channelmixerrgb.c:4630
 msgid "input G"
 msgstr "입력 G"
 
-#: ../src/iop/channelmixerrgb.c:4607
+#: ../src/iop/channelmixerrgb.c:4635
 msgid "input B"
 msgstr "입력 B"
 
-#: ../src/iop/channelmixerrgb.c:4617
+#: ../src/iop/channelmixerrgb.c:4645
 msgid "output R"
 msgstr "출력 R"
 
-#: ../src/iop/channelmixerrgb.c:4618
+#: ../src/iop/channelmixerrgb.c:4646
 msgid "output G"
 msgstr "출력 G"
 
-#: ../src/iop/channelmixerrgb.c:4619
+#: ../src/iop/channelmixerrgb.c:4647
 msgid "output B"
 msgstr "출력 B"
 
-#: ../src/iop/channelmixerrgb.c:4621
+#: ../src/iop/channelmixerrgb.c:4649
 msgid "colorfulness"
 msgstr "다채성"
 
-#: ../src/iop/channelmixerrgb.c:4621
+#: ../src/iop/channelmixerrgb.c:4649
 msgid "output colorfulness"
 msgstr "출력 다채성"
 
-#: ../src/iop/channelmixerrgb.c:4625
+#: ../src/iop/channelmixerrgb.c:4653
 msgid "output brightness"
 msgstr "출력 밝기"
 
-#: ../src/iop/channelmixerrgb.c:4628
+#: ../src/iop/channelmixerrgb.c:4656
 msgid "output gray"
 msgstr "출력 회색"
 
-#: ../src/iop/channelmixerrgb.c:4641
+#: ../src/iop/channelmixerrgb.c:4669
 msgid "calibrate with a color checker"
 msgstr "컬러체커 캘리브레이션"
 
-#: ../src/iop/channelmixerrgb.c:4646
+#: ../src/iop/channelmixerrgb.c:4674
 msgid "use a color checker target to autoset CAT and channels"
 msgstr "컬러체커 타겟을 사용하여 CAT과 채널을 자동 설정합니다"
 
-#: ../src/iop/channelmixerrgb.c:4651 ../src/iop/channelmixerrgb.c:4663
-#: ../src/iop/channelmixerrgb.c:4680 ../src/iop/channelmixerrgb.c:4694
-#: ../src/iop/channelmixerrgb.c:4702 ../src/iop/channelmixerrgb.c:4709
+#: ../src/iop/channelmixerrgb.c:4679 ../src/iop/channelmixerrgb.c:4691
+#: ../src/iop/channelmixerrgb.c:4708 ../src/iop/channelmixerrgb.c:4722
+#: ../src/iop/channelmixerrgb.c:4730 ../src/iop/channelmixerrgb.c:4737
 msgid "calibrate"
 msgstr "캘리브레이션"
 
-#: ../src/iop/channelmixerrgb.c:4651
+#: ../src/iop/channelmixerrgb.c:4679
 msgid "chart"
 msgstr "차트"
 
-#: ../src/iop/channelmixerrgb.c:4652
+#: ../src/iop/channelmixerrgb.c:4680
 msgid "choose the vendor and the type of your chart"
 msgstr "차트의 제조사와 종류를 선택하세요"
 
-#: ../src/iop/channelmixerrgb.c:4654
+#: ../src/iop/channelmixerrgb.c:4682
 msgid "Xrite ColorChecker 24 pre-2014"
 msgstr "Xrite ColorChecker 24 (2014년 이전)"
 
-#: ../src/iop/channelmixerrgb.c:4655
+#: ../src/iop/channelmixerrgb.c:4683
 msgid "Xrite/Calibrite ColorChecker 24 post-2014"
 msgstr "Xrite/Calibrite ColorChecker 24 (2014년 이후)"
 
-#: ../src/iop/channelmixerrgb.c:4656
+#: ../src/iop/channelmixerrgb.c:4684
 msgid "Datacolor SpyderCheckr 24 pre-2018"
 msgstr "Datacolor SpyderCheckr 24 (2018년 이전)"
 
-#: ../src/iop/channelmixerrgb.c:4657
+#: ../src/iop/channelmixerrgb.c:4685
 msgid "Datacolor SpyderCheckr 24 post-2018"
 msgstr "Datacolor SpyderCheckr 24 (2018년 이후)"
 
-#: ../src/iop/channelmixerrgb.c:4658
+#: ../src/iop/channelmixerrgb.c:4686
 msgid "Datacolor SpyderCheckr 48 pre-2018"
 msgstr "Datacolor SpyderCheckr 48 (2018년 이전)"
 
-#: ../src/iop/channelmixerrgb.c:4659
+#: ../src/iop/channelmixerrgb.c:4687
 msgid "Datacolor SpyderCheckr 48 post-2018"
 msgstr "Datacolor SpyderCheckr 48 (2018년 이후)"
 
-#: ../src/iop/channelmixerrgb.c:4660
+#: ../src/iop/channelmixerrgb.c:4688
 msgid "Datacolor SpyderCheckr Photo"
 msgstr "Datacolor SpyderCheckr Photo"
 
-#: ../src/iop/channelmixerrgb.c:4663
+#: ../src/iop/channelmixerrgb.c:4691
 msgid "optimize for"
 msgstr "최적화 대상"
 
-#: ../src/iop/channelmixerrgb.c:4664
+#: ../src/iop/channelmixerrgb.c:4692
 msgid ""
 "choose the colors that will be optimized with higher priority.\n"
 "neutral colors gives the lowest average delta E but a high maximum delta E\n"
-"saturated colors gives the lowest maximum delta E but a high average delta E\n"
+"saturated colors gives the lowest maximum delta E but a high average delta "
+"E\n"
 "none is a trade-off between both\n"
 "the others are special behaviors to protect some hues"
 msgstr ""
@@ -17431,35 +20617,35 @@ msgstr ""
 "없음은 두 기준 사이의 절충안입니다\n"
 "그 외 기준은 특정 색조를 보호하기 위한 특수 기준입니다"
 
-#: ../src/iop/channelmixerrgb.c:4671
+#: ../src/iop/channelmixerrgb.c:4699
 msgid "neutral colors"
 msgstr "중성색"
 
-#: ../src/iop/channelmixerrgb.c:4673
+#: ../src/iop/channelmixerrgb.c:4701
 msgid "skin and soil colors"
 msgstr "피부 및 토양 색상"
 
-#: ../src/iop/channelmixerrgb.c:4674
+#: ../src/iop/channelmixerrgb.c:4702
 msgid "foliage colors"
 msgstr "나뭇잎 색상"
 
-#: ../src/iop/channelmixerrgb.c:4675
+#: ../src/iop/channelmixerrgb.c:4703
 msgid "sky and water colors"
 msgstr "하늘 및 물 색상"
 
-#: ../src/iop/channelmixerrgb.c:4676
+#: ../src/iop/channelmixerrgb.c:4704
 msgid "average delta E"
 msgstr "평균 델타 E"
 
-#: ../src/iop/channelmixerrgb.c:4677
+#: ../src/iop/channelmixerrgb.c:4705
 msgid "maximum delta E"
 msgstr "최대 ΔE"
 
-#: ../src/iop/channelmixerrgb.c:4680
+#: ../src/iop/channelmixerrgb.c:4708
 msgid "patch scale"
 msgstr "패치 스케일"
 
-#: ../src/iop/channelmixerrgb.c:4683
+#: ../src/iop/channelmixerrgb.c:4711
 msgid ""
 "reduce the radius of the patches to select the more or less central part.\n"
 "useful when the perspective correction is sloppy or\n"
@@ -17469,43 +20655,49 @@ msgstr ""
 "투시 보정이 모호하거나\n"
 "패치 프레임이 패치의 경계선에 쉐도우를 만드는 경우에 유용합니다."
 
-#: ../src/iop/channelmixerrgb.c:4691
+#: ../src/iop/channelmixerrgb.c:4719
 msgid "the delta E is using the CIE 2000 formula"
 msgstr "delta E 값으로 CIE 2000 공식을 사용합니다"
 
-#: ../src/iop/channelmixerrgb.c:4694
+#: ../src/iop/channelmixerrgb.c:4722
 msgid "accept"
 msgstr "수락"
 
-#: ../src/iop/channelmixerrgb.c:4699
+#: ../src/iop/channelmixerrgb.c:4727
 msgid "accept the computed profile and set it in the module"
 msgstr "계산된 프로파일을 수락하고 모듈에 적용"
 
-#: ../src/iop/channelmixerrgb.c:4702
+#: ../src/iop/channelmixerrgb.c:4730
 msgid "recompute"
 msgstr "재계산"
 
-#: ../src/iop/channelmixerrgb.c:4706
+#: ../src/iop/channelmixerrgb.c:4734
 msgid "recompute the profile"
 msgstr "프로파일 재계산"
 
-#: ../src/iop/channelmixerrgb.c:4709
+#: ../src/iop/channelmixerrgb.c:4737
 msgid "validate"
 msgstr "검증"
 
-#: ../src/iop/channelmixerrgb.c:4713
+#: ../src/iop/channelmixerrgb.c:4741
 msgid "check the output delta E"
 msgstr "출력 ΔE 값을 확인"
 
-#: ../src/iop/choleski.h:303 ../src/iop/choleski.h:404
-msgid "Choleski decomposition failed to allocate memory, check your RAM settings"
+#: ../src/iop/choleski.h:222 ../src/iop/choleski.h:313
+msgid ""
+"Choleski decomposition failed to allocate memory, check your RAM settings"
 msgstr "숄레스키 분해가 메모리 할당에 실패했습니다. RAM 설정을 확인해 주세요"
 
+#: ../src/iop/clahe.c:61
+msgid "old local contrast"
+msgstr "예전 부분 대비"
+
 #: ../src/iop/clahe.c:71
-msgid "this module is deprecated. better use new local contrast module instead."
+msgid ""
+"this module is deprecated. better use new local contrast module instead."
 msgstr "이 모듈은 더 이상 사용되지 않습니다. 대신 새 부분 대비 모듈을 사용하세요."
 
-#: ../src/iop/clahe.c:325 ../src/iop/sharpen.c:432
+#: ../src/iop/clahe.c:325 ../src/iop/sharpen.c:421
 msgid "amount"
 msgstr "적용량"
 
@@ -17513,12 +20705,14 @@ msgstr "적용량"
 msgid "size of features to preserve"
 msgstr "보존할 세부 요소 크기"
 
-#: ../src/iop/clahe.c:327 ../src/iop/nlmeans.c:461
+#: ../src/iop/clahe.c:327 ../src/iop/nlmeans.c:442
 msgid "strength of the effect"
 msgstr "효과의 강도"
 
 #: ../src/iop/clipping.c:340
-msgid "this module is deprecated. please use the crop, orientation and/or rotate and perspective modules instead."
+msgid ""
+"this module is deprecated. please use the crop, orientation and/or rotate "
+"and perspective modules instead."
 msgstr "이 모듈은 더 이상 사용되지 않습니다. 자르기, 방향, 회전 및/또는 원근 모듈을 사용해 주세요."
 
 #: ../src/iop/clipping.c:345
@@ -17533,164 +20727,165 @@ msgstr "프레임 조정|투시|키스톤|왜곡"
 msgid "change the framing and correct the perspective"
 msgstr "프레임을 변경하고 투시를 보정합니다"
 
-#: ../src/iop/clipping.c:1416 ../src/iop/clipping.c:2131 ../src/iop/crop.c:613
-#: ../src/iop/crop.c:1152
+#: ../src/iop/clipping.c:1410 ../src/iop/clipping.c:2125 ../src/iop/crop.c:731
+#: ../src/iop/crop.c:1269
 msgid "original image"
 msgstr "원본 이미지"
 
-#: ../src/iop/clipping.c:1720 ../src/iop/crop.c:838
+#: ../src/iop/clipping.c:1714 ../src/iop/crop.c:955
 msgid "invalid ratio format. it should be \"number:number\""
 msgstr "비율 형식이 유효하지 않습니다. \"숫자:숫자\" 형식이어야 합니다"
 
-#: ../src/iop/clipping.c:1736 ../src/iop/crop.c:854
+#: ../src/iop/clipping.c:1730 ../src/iop/crop.c:971
 msgid "invalid ratio format. it should be a positive number"
 msgstr "비율 형식이 유효하지 않습니다. 양수여야 합니다"
 
-#: ../src/iop/clipping.c:1925 ../src/iop/clipping.c:2122
+#: ../src/iop/clipping.c:1919 ../src/iop/clipping.c:2116
 msgid "full"
 msgstr "전체"
 
-#: ../src/iop/clipping.c:1926
+#: ../src/iop/clipping.c:1920
 msgid "old system"
 msgstr "과거 시스템"
 
-#: ../src/iop/clipping.c:1927
+#: ../src/iop/clipping.c:1921
 msgid "correction applied"
 msgstr "보정 적용됨"
 
-#: ../src/iop/clipping.c:2100
+#: ../src/iop/clipping.c:2094
 msgid "main"
 msgstr "주요"
 
-#: ../src/iop/clipping.c:2109
+#: ../src/iop/clipping.c:2103
 msgid "mirror image horizontally and/or vertically"
 msgstr "이미지를 수평 및/또는 수직으로 반전합니다"
 
-#: ../src/iop/clipping.c:2112
+#: ../src/iop/clipping.c:2106
 msgid "angle"
 msgstr "각도"
 
-#: ../src/iop/clipping.c:2115
+#: ../src/iop/clipping.c:2109
 msgid "right-click and drag a line on the image to drag a straight line"
 msgstr "이미지 위에 우클릭 후 드래그 하여 직선을 그립니다"
 
-#: ../src/iop/clipping.c:2118
+#: ../src/iop/clipping.c:2112
 msgid "keystone"
 msgstr "키스톤"
 
-#: ../src/iop/clipping.c:2123
+#: ../src/iop/clipping.c:2117
 msgid "set perspective correction for your image"
 msgstr "이미지에 투시 보정 설정"
 
-#: ../src/iop/clipping.c:2130 ../src/iop/crop.c:1151
+#: ../src/iop/clipping.c:2124 ../src/iop/crop.c:1268
 msgid "freehand"
 msgstr "프리핸드"
 
-#: ../src/iop/clipping.c:2133 ../src/iop/crop.c:1154
+#: ../src/iop/clipping.c:2127 ../src/iop/crop.c:1271
 msgid "10:8 in print"
 msgstr "10:8 인쇄"
 
-#: ../src/iop/clipping.c:2134 ../src/iop/crop.c:1155
+#: ../src/iop/clipping.c:2128 ../src/iop/crop.c:1272
 msgid "5:4, 4x5, 8x10"
 msgstr "5:4, 4x5, 8x10"
 
-#: ../src/iop/clipping.c:2135 ../src/iop/crop.c:1156
+#: ../src/iop/clipping.c:2129 ../src/iop/crop.c:1273
 msgid "11x14"
 msgstr "11x14"
 
-#: ../src/iop/clipping.c:2136 ../src/iop/crop.c:1158
+#: ../src/iop/clipping.c:2130 ../src/iop/crop.c:1275
 msgid "8.5x11, letter"
 msgstr "8.5x11, 종이"
 
-#: ../src/iop/clipping.c:2137 ../src/iop/crop.c:1159
+#: ../src/iop/clipping.c:2131 ../src/iop/crop.c:1276
 msgid "4:3, VGA, TV"
 msgstr "4:3, VGA, TV"
 
-#: ../src/iop/clipping.c:2138 ../src/iop/crop.c:1160
+#: ../src/iop/clipping.c:2132 ../src/iop/crop.c:1277
 msgid "5x7"
 msgstr "5x7"
 
-#: ../src/iop/clipping.c:2139 ../src/iop/crop.c:1161
+#: ../src/iop/clipping.c:2133 ../src/iop/crop.c:1278
 msgid "ISO 216, DIN 476, A4"
 msgstr "ISO 216, DIN 476, A"
 
-#: ../src/iop/clipping.c:2140 ../src/iop/crop.c:1162
+#: ../src/iop/clipping.c:2134 ../src/iop/crop.c:1279
 msgid "3:2, 4x6, 35mm"
 msgstr "3:2, 4x6, 35mm"
 
-#: ../src/iop/clipping.c:2141 ../src/iop/crop.c:1163
+#: ../src/iop/clipping.c:2135 ../src/iop/crop.c:1280
 msgid "16:10, 8x5"
 msgstr "16:10, 8x5"
 
-#: ../src/iop/clipping.c:2143 ../src/iop/crop.c:1165
+#: ../src/iop/clipping.c:2137 ../src/iop/crop.c:1282
 msgid "16:9, HDTV"
 msgstr "16:9, HDTV"
 
-#: ../src/iop/clipping.c:2144 ../src/iop/crop.c:1166
+#: ../src/iop/clipping.c:2138 ../src/iop/crop.c:1283
 msgid "widescreen"
 msgstr "와이드스크린"
 
-#: ../src/iop/clipping.c:2145
+#: ../src/iop/clipping.c:2139
 msgid "2:1, univisium"
 msgstr "2:1, 유니비지엄"
 
-#: ../src/iop/clipping.c:2146
+#: ../src/iop/clipping.c:2140
 msgid "cinemascope"
 msgstr "시네마스코프"
 
-#: ../src/iop/clipping.c:2147 ../src/iop/crop.c:1169
+#: ../src/iop/clipping.c:2141 ../src/iop/crop.c:1286
 msgid "21:9"
 msgstr "21:9"
 
-#: ../src/iop/clipping.c:2148 ../src/iop/crop.c:1170
+#: ../src/iop/clipping.c:2142 ../src/iop/crop.c:1287
 msgid "anamorphic"
 msgstr "아나모픽"
 
-#: ../src/iop/clipping.c:2149 ../src/iop/crop.c:1172
+#: ../src/iop/clipping.c:2143 ../src/iop/crop.c:1289
 msgid "3:1, panorama"
 msgstr "3:1, 파라노마"
 
-#: ../src/iop/clipping.c:2181 ../src/iop/clipping.c:2193 ../src/iop/crop.c:1208
-#: ../src/iop/crop.c:1225
+#: ../src/iop/clipping.c:2175 ../src/iop/clipping.c:2187 ../src/iop/crop.c:1325
+#: ../src/iop/crop.c:1342
 #, c-format
 msgid "invalid ratio format for `%s'. it should be \"number:number\""
 msgstr "`%s'의 비율 형식이 유효하지 않습니다. \"숫자:숫자\" 형식이어야 합니다"
 
-#: ../src/iop/clipping.c:2240 ../src/iop/crop.c:1276
+#: ../src/iop/clipping.c:2234 ../src/iop/crop.c:1394
 msgid ""
 "set the aspect ratio\n"
 "the list is sorted: from most square to least square\n"
-"to enter custom aspect ratio open the combobox and type ratio in x:y or decimal format"
+"to enter custom aspect ratio open the combobox and type ratio in x:y or "
+"decimal format"
 msgstr ""
 "종횡비를 설정합니다\n"
 "목록 정렬: 정사각형에 가까운 순서대로 정렬되어 있음\n"
 "콤보박스를 열어 사용자 지정 종횡비를 x:y 형식 또는 소수 형식으로 입력"
 
-#: ../src/iop/clipping.c:2247 ../src/iop/crop.c:1288
+#: ../src/iop/clipping.c:2241 ../src/iop/crop.c:1411
 msgid "margins"
 msgstr "여백"
 
-#: ../src/iop/clipping.c:2252 ../src/iop/crop.c:1298
+#: ../src/iop/clipping.c:2246 ../src/iop/crop.c:1421
 msgid "the left margin cannot overlap with the right margin"
 msgstr "왼쪽 여백이 오른쪽 여백과 겹칠 수 없습니다"
 
-#: ../src/iop/clipping.c:2259 ../src/iop/crop.c:1306
+#: ../src/iop/clipping.c:2253 ../src/iop/crop.c:1429
 msgid "the right margin cannot overlap with the left margin"
 msgstr "오른쪽 여백이 왼쪽 여백과 겹칠 수 없습니다"
 
-#: ../src/iop/clipping.c:2264 ../src/iop/crop.c:1312
+#: ../src/iop/clipping.c:2258 ../src/iop/crop.c:1435
 msgid "the top margin cannot overlap with the bottom margin"
 msgstr "위쪽 여백이 아래쪽 여백과 겹칠 수 없습니다"
 
-#: ../src/iop/clipping.c:2271 ../src/iop/crop.c:1320
+#: ../src/iop/clipping.c:2265 ../src/iop/crop.c:1443
 msgid "the bottom margin cannot overlap with the top margin"
 msgstr "아래쪽 여백이 위쪽 여백과 겹칠 수 없습니다"
 
-#: ../src/iop/clipping.c:3014
+#: ../src/iop/clipping.c:3008
 msgid "<b>commit</b>: double-click, <b>straighten</b>: right-drag"
 msgstr "<b>저장</b>: 더블 클릭, <b>바로 세우기</b>: 오른쪽 드래그"
 
-#: ../src/iop/clipping.c:3018
+#: ../src/iop/clipping.c:3012
 msgid ""
 "<b>resize</b>: drag, <b>keep aspect ratio</b>: shift+drag\n"
 "<b>straighten</b>: right-drag"
@@ -17698,15 +20893,15 @@ msgstr ""
 "<b>크기 조절</b>: 드래그, <b>종횡비 유지</b>: Shift+드래그\n"
 "<b>바로 세우기</b>: 오른쪽 드래그"
 
-#: ../src/iop/clipping.c:3059
+#: ../src/iop/clipping.c:3053
 msgid "<b>move control point</b>: drag"
 msgstr "<b>제어점 이동</b>: 드래그"
 
-#: ../src/iop/clipping.c:3064
+#: ../src/iop/clipping.c:3058
 msgid "<b>move line</b>: drag, <b>toggle symmetry</b>: click ꝏ"
 msgstr "<b>선 이동</b>: 드래그, <b>대칭 전환</b>: ꝏ 클릭"
 
-#: ../src/iop/clipping.c:3069
+#: ../src/iop/clipping.c:3063
 msgid ""
 "<b>apply</b>: click <tt>ok</tt>, <b>toggle symmetry</b>: click ꝏ\n"
 "<b>move line/control point</b>: drag"
@@ -17714,20 +20909,21 @@ msgstr ""
 "<b>적용</b>: <tt>확인</tt> 클릭, <b>대칭 전환</b>: ꝏ 클릭\n"
 "<b>선/제어점 이동</b>: 드래그"
 
-#: ../src/iop/clipping.c:3076
+#: ../src/iop/clipping.c:3070
 msgid ""
-"<b>move</b>: drag, <b>move vertically</b>: shift+drag, <b>move horizontally</b>: ctrl+drag\n"
+"<b>move</b>: drag, <b>move vertically</b>: shift+drag, <b>move horizontally</"
+"b>: ctrl+drag\n"
 "<b>straighten</b>: right-drag, <b>commit</b>: double-click"
 msgstr ""
 "<b>이동</b>: 드래그, <b>수직 이동</b>: Shift+드래그, <b>수평 이동</b>: Ctrl+드래그\n"
 "<b>바로 세우기</b>: 오른쪽 드래그, <b>저장</b>: 더블 클릭"
 
-#: ../src/iop/clipping.c:3335 ../src/iop/crop.c:1818
+#: ../src/iop/clipping.c:3329 ../src/iop/crop.c:1951
 #, c-format
 msgid "[%s on borders] crop"
 msgstr "[테두리에 %s] 자르기"
 
-#: ../src/iop/clipping.c:3337 ../src/iop/crop.c:1820
+#: ../src/iop/clipping.c:3331 ../src/iop/crop.c:1953
 #, c-format
 msgid "[%s on borders] crop keeping ratio"
 msgstr "[테두리에 %s] 비율 유지하며 자르기"
@@ -17744,7 +20940,7 @@ msgstr "대비 밝기 채도"
 msgid "adjust the look of the image"
 msgstr "이미지의 보기를 조정"
 
-#: ../src/iop/colisa.c:283
+#: ../src/iop/colisa.c:278
 msgid "color saturation adjustment"
 msgstr "색상 채도 조정"
 
@@ -17789,68 +20985,68 @@ msgstr "Kodak Ektar와 유사함"
 msgid "similar to Kodachrome"
 msgstr "Kodachrome와 유사함"
 
-#: ../src/iop/colorbalance.c:935
+#: ../src/iop/colorbalance.c:934
 msgid "optimize luma from patches"
 msgstr "패치로부터 휘도(루마) 최적화"
 
-#: ../src/iop/colorbalance.c:937 ../src/iop/colorbalance.c:2001
+#: ../src/iop/colorbalance.c:936 ../src/iop/colorbalance.c:2001
 msgid "optimize luma"
 msgstr "휘도(루마) 최적화"
 
-#: ../src/iop/colorbalance.c:941
+#: ../src/iop/colorbalance.c:940
 msgid "neutralize colors from patches"
 msgstr "패치로부터 색상 중화"
 
-#: ../src/iop/colorbalance.c:943 ../src/iop/colorbalance.c:2006
+#: ../src/iop/colorbalance.c:942 ../src/iop/colorbalance.c:2006
 msgid "neutralize colors"
 msgstr "중화 색상"
 
-#: ../src/iop/colorbalance.c:1728
+#: ../src/iop/colorbalance.c:1727
 msgctxt "color"
 msgid "offset"
 msgstr "오프셋"
 
-#: ../src/iop/colorbalance.c:1728
+#: ../src/iop/colorbalance.c:1727
 msgctxt "color"
 msgid "power"
 msgstr "파워"
 
-#: ../src/iop/colorbalance.c:1728
+#: ../src/iop/colorbalance.c:1727
 msgctxt "color"
 msgid "slope"
 msgstr "슬로프"
 
-#: ../src/iop/colorbalance.c:1729
+#: ../src/iop/colorbalance.c:1728
 msgctxt "color"
 msgid "lift"
 msgstr "리프트"
 
-#: ../src/iop/colorbalance.c:1729
+#: ../src/iop/colorbalance.c:1728
 msgctxt "color"
 msgid "gamma"
 msgstr "감마"
 
-#: ../src/iop/colorbalance.c:1729
+#: ../src/iop/colorbalance.c:1728
 msgctxt "color"
 msgid "gain"
 msgstr "게인"
 
-#: ../src/iop/colorbalance.c:1732
+#: ../src/iop/colorbalance.c:1731
 msgctxt "section"
 msgid "shadows: lift / offset"
 msgstr "쉐도우: 리프트 / 오프셋"
 
-#: ../src/iop/colorbalance.c:1733
+#: ../src/iop/colorbalance.c:1732
 msgctxt "section"
 msgid "mid-tones: gamma / power"
 msgstr "중간 톤: 감마 / 파워"
 
-#: ../src/iop/colorbalance.c:1734
+#: ../src/iop/colorbalance.c:1733
 msgctxt "section"
 msgid "highlights: gain / slope"
 msgstr "하이라이트: 게인 / 슬로프"
 
-#: ../src/iop/colorbalance.c:1758
+#: ../src/iop/colorbalance.c:1757
 msgid "shadows / mid-tones / highlights"
 msgstr "쉐도우 / 중간톤 / 하이라이트"
 
@@ -17970,7 +21166,9 @@ msgid "color balance rgb"
 msgstr "RGB 색상 균형"
 
 #: ../src/iop/colorbalancergb.c:174
-msgid "offset power slope|cdl|color grading|contrast|chroma_highlights|hue|vibrance|saturation"
+msgid ""
+"offset power slope|cdl|color grading|contrast|chroma_highlights|hue|vibrance|"
+"saturation"
 msgstr "오프셋 파워 슬로프|CDL|컬러 그레이딩|대비|채도(크로마)_하이라이트|색조|생동감|채도"
 
 #: ../src/iop/colorbalancergb.c:179
@@ -18002,7 +21200,7 @@ msgid "colorbalance works only on RGB input"
 msgstr "색상 균형은 RGB 입력에서만 작동합니다"
 
 #: ../src/iop/colorbalancergb.c:1423 ../src/iop/colorzones.c:2381
-#: ../src/iop/retouch.c:2056 ../src/iop/toneequal.c:1942
+#: ../src/iop/retouch.c:2055 ../src/iop/toneequal.c:1942
 msgid "cannot display masks when the blending mask is displayed"
 msgstr "혼합 마스크가 표시되는 중에는 마스크를 표시할 수 없습니다"
 
@@ -18059,7 +21257,9 @@ msgstr "채도를 절대값 기준으로 추가하거나 제거합니다"
 
 #: ../src/iop/colorbalancergb.c:1837 ../src/iop/colorbalancergb.c:1842
 #: ../src/iop/colorbalancergb.c:1847
-msgid "increase or decrease saturation proportionally to the original pixel saturation"
+msgid ""
+"increase or decrease saturation proportionally to the original pixel "
+"saturation"
 msgstr "기존 픽셀의 채도에 비례하여 채도를 증가시키거나 감소시킵니다"
 
 #: ../src/iop/colorbalancergb.c:1849
@@ -18077,7 +21277,9 @@ msgstr "광채를 절대값 기준으로 추가하거나 제거합니다"
 
 #: ../src/iop/colorbalancergb.c:1860 ../src/iop/colorbalancergb.c:1865
 #: ../src/iop/colorbalancergb.c:1870
-msgid "increase or decrease brilliance proportionally to the original pixel brilliance"
+msgid ""
+"increase or decrease brilliance proportionally to the original pixel "
+"brilliance"
 msgstr "기존 픽셀의 광채에 비례하여 광채를 증가시키거나 감소시킵니다"
 
 #. Page 4-ways
@@ -18196,44 +21398,74 @@ msgid "weight of the shadows over the whole tonal range"
 msgstr "전체 톤 범위에서 쉐도우 가중치"
 
 #: ../src/iop/colorbalancergb.c:1987
+msgid ""
+"displays a shadows mask, overlaid as a checkerboard\n"
+"the still-visible area of the image (not hidden by the mask) is the area\n"
+"that will be affected by the shadows sliders in the other tabs"
+msgstr ""
+"쉐도우 마스크를 체커보드로 겹쳐 표시합니다\n"
+"마스크에 가려지지 않고 여전히 보이는 영역이\n"
+"다른 탭의 쉐도우 슬라이더에 영향을 받는 영역입니다"
+
+#: ../src/iop/colorbalancergb.c:1994
 msgid "position of the middle-gray reference for masking"
 msgstr "마스킹에 사용할 중간 회색 참조 위치"
 
-#: ../src/iop/colorbalancergb.c:1993
+#: ../src/iop/colorbalancergb.c:2000
+msgid ""
+"displays a mid-tones mask, overlaid as a checkerboard\n"
+"the still-visible area of the image (not hidden by the mask) is the area\n"
+"that will be affected by the mid-tones sliders in the other tabs"
+msgstr ""
+"중간 톤 마스크를 체커보드로 겹쳐 표시합니다\n"
+"마스크에 가려지지 않고 여전히 보이는 영역이\n"
+"다른 탭의 중간 톤 슬라이더에 영향을 받는 영역입니다"
+
+#: ../src/iop/colorbalancergb.c:2007
 msgid "weights of highlights over the whole tonal range"
 msgstr "전체 톤 범위에서 하이라이트 가중치"
 
-#: ../src/iop/colorbalancergb.c:1996
+#: ../src/iop/colorbalancergb.c:2013
+msgid ""
+"displays a highlights mask, overlaid as a checkerboard\n"
+"the still-visible area of the image (not hidden by the mask) is the area\n"
+"that will be affected by the highlights sliders in the other tabs"
+msgstr ""
+"하이라이트 마스크를 체커보드로 겹쳐 표시합니다\n"
+"마스크에 가려지지 않고 여전히 보이는 영역이\n"
+"다른 탭의 하이라이트 슬라이더에 영향을 받는 영역입니다"
+
+#: ../src/iop/colorbalancergb.c:2017
 msgctxt "section"
 msgid "threshold"
 msgstr "임계값"
 
-#: ../src/iop/colorbalancergb.c:2001
+#: ../src/iop/colorbalancergb.c:2022
 msgid "peak white luminance value used to normalize the power function"
 msgstr "파워 함수 정규화에 사용되는 최대 백색 휘도 값"
 
-#: ../src/iop/colorbalancergb.c:2007
+#: ../src/iop/colorbalancergb.c:2028
 msgid "peak gray luminance value used to normalize the power function"
 msgstr "파워 함수 정규화에 사용되는 최대 회색 휘도 값"
 
-#: ../src/iop/colorbalancergb.c:2009
+#: ../src/iop/colorbalancergb.c:2030
 msgctxt "section"
 msgid "mask preview settings"
 msgstr "마스크 미리보기 설정"
 
-#: ../src/iop/colorbalancergb.c:2013 ../src/iop/colorbalancergb.c:2018
+#: ../src/iop/colorbalancergb.c:2034 ../src/iop/colorbalancergb.c:2039
 msgid "select color of the checkerboard from a swatch"
 msgstr "견본에서 체커보드 색상 선택"
 
-#: ../src/iop/colorbalancergb.c:2023
+#: ../src/iop/colorbalancergb.c:2044
 msgid "checkerboard size"
 msgstr "체커보드 크기"
 
-#: ../src/iop/colorbalancergb.c:2027
+#: ../src/iop/colorbalancergb.c:2048
 msgid "checkerboard color 1"
 msgstr "체커보드 색상 1"
 
-#: ../src/iop/colorbalancergb.c:2028
+#: ../src/iop/colorbalancergb.c:2049
 msgid "checkerboard color 2"
 msgstr "체커보드 색상 2"
 
@@ -18251,7 +21483,7 @@ msgstr "색공간 보정을 수행하고 보기에 적용"
 
 #: ../src/iop/colorchecker.c:131 ../src/iop/colorchecker.c:133
 #: ../src/iop/colorize.c:96 ../src/iop/colormapping.c:153
-#: ../src/iop/colorout.c:87 ../src/iop/colorreconstruction.c:118
+#: ../src/iop/colorout.c:88 ../src/iop/colorreconstruction.c:118
 #: ../src/iop/colorzones.c:143 ../src/iop/defringe.c:81 ../src/iop/levels.c:138
 #: ../src/iop/monochrome.c:100 ../src/iop/shadhi.c:142
 #: ../src/iop/tonecurve.c:180 ../src/iop/vibrance.c:95
@@ -18333,7 +21565,8 @@ msgstr "대상 색상의 Lab 'L' 채널 조절값을 낮추면 대상 색상이 
 #: ../src/iop/colorchecker.c:1573
 msgid ""
 "adjust target color Lab 'a' channel\n"
-"lower values shift target color towards greens while higher shift towards magentas"
+"lower values shift target color towards greens while higher shift towards "
+"magentas"
 msgstr "대상 색상의 Lab 'a' 채널 조절값을 낮추면 대상 색상이 녹색 쪽으로,높이면 마젠타 쪽으로 색상이 이동합니다"
 
 #: ../src/iop/colorchecker.c:1576
@@ -18343,7 +21576,8 @@ msgstr "녹색-마젠타 오프셋"
 #: ../src/iop/colorchecker.c:1585
 msgid ""
 "adjust target color Lab 'b' channel\n"
-"lower values shift target color towards blues while higher shift towards yellows"
+"lower values shift target color towards blues while higher shift towards "
+"yellows"
 msgstr "대상 색상의 Lab 'b' 채널 조절값을 낮추면 대상 색상이 파란색 쪽으로,높이면 노란색 쪽으로 색상이 이동합니다"
 
 #: ../src/iop/colorchecker.c:1588
@@ -18354,7 +21588,8 @@ msgstr "파란색-노란색 오프셋"
 msgid ""
 "adjust target color saturation\n"
 "adjusts 'a' and 'b' channels of target color in Lab space simultaneously\n"
-"lower values scale towards lower saturation while higher scale towards higher saturation"
+"lower values scale towards lower saturation while higher scale towards "
+"higher saturation"
 msgstr ""
 "목표표 색상의 채도 조절\n"
 "Lab 공간에서 목표 색상의 'a'와 'b' 채널을 동시에 조절값을 낮추면채도가 줄고, 높이면 채도가 증가합니다"
@@ -18426,22 +21661,24 @@ msgid "cooling filter"
 msgstr "차가운 톤 필터"
 
 #: ../src/iop/colorcorrection.c:242
-msgid "drag the line for split-toning. bright means highlights, dark means shadows. use mouse wheel to change saturation."
+msgid ""
+"drag the line for split-toning. bright means highlights, dark means shadows. "
+"use mouse wheel to change saturation."
 msgstr "선을 드래그하여 스플릿 톤을 조절합니다. 밝음은 하이라이트, 어두움은 쉐도우를 의미합니다.마우스 휠로 채도를 변경합니다."
 
 #: ../src/iop/colorcorrection.c:261
 msgid "set the global saturation"
 msgstr "전체 채도 설정"
 
-#: ../src/iop/colorequal.c:201 ../src/iop/colorequal.c:2968
+#: ../src/iop/colorequal.c:202 ../src/iop/colorequal.c:2933
 msgid "color equalizer"
 msgstr "색상 이퀄라이저"
 
-#: ../src/iop/colorequal.c:206
+#: ../src/iop/colorequal.c:207
 msgid "color zones|hsl"
 msgstr "색상 존|hsl"
 
-#: ../src/iop/colorequal.c:213
+#: ../src/iop/colorequal.c:214
 msgid ""
 "change saturation, hue and brightness\n"
 "depending on local hue"
@@ -18449,37 +21686,37 @@ msgstr ""
 "로컬 색조에 따라\n"
 "채도, 색조, 밝기 조절"
 
-#: ../src/iop/colorequal.c:217 ../src/iop/toneequal.c:331
+#: ../src/iop/colorequal.c:218 ../src/iop/toneequal.c:331
 msgid "quasi-linear, RGB"
 msgstr "준선형, RGB"
 
-#: ../src/iop/colorequal.c:218 ../src/iop/toneequal.c:332
+#: ../src/iop/colorequal.c:219 ../src/iop/toneequal.c:332
 msgid "quasi-linear, RGB, scene-referred"
 msgstr "준선형, RGB, 장면 기준"
 
-#: ../src/iop/colorequal.c:2132
+#: ../src/iop/colorequal.c:2098
 msgid "bleach bypass"
 msgstr "블리치 바이패스"
 
-#: ../src/iop/colorequal.c:2176
+#: ../src/iop/colorequal.c:2142
 msgid "Kodachrome 64 like"
 msgstr "코닥크롬 64 스타일"
 
-#: ../src/iop/colorequal.c:2220
+#: ../src/iop/colorequal.c:2186
 msgid "Kodak Portra 400 like"
 msgstr "코닥 포트라 400 스타일"
 
-#: ../src/iop/colorequal.c:2264
+#: ../src/iop/colorequal.c:2230
 msgid "teal & orange"
 msgstr "틸 & 오렌지"
 
 #. Page OPTIONS
-#: ../src/iop/colorequal.c:2921 ../src/iop/colorequal.c:3126
-#: ../src/iop/filmicrgb.c:4567
+#: ../src/iop/colorequal.c:2886 ../src/iop/colorequal.c:3089
+#: ../src/iop/filmicrgb.c:4561
 msgid "options"
 msgstr "옵션"
 
-#: ../src/iop/colorequal.c:3019
+#: ../src/iop/colorequal.c:2982
 msgid ""
 "double-click to reset the curve\n"
 "middle-click to toggle sliders visibility\n"
@@ -18489,11 +21726,11 @@ msgstr ""
 "가운데 클릭 시 슬라이더 표시 전환\n"
 "Alt+스크롤로 페이지 변경"
 
-#: ../src/iop/colorequal.c:3045
+#: ../src/iop/colorequal.c:3008
 msgid "shift nodes to lower or higher hue"
 msgstr "노드를 더 낮거나 높은 색조로 이동"
 
-#: ../src/iop/colorequal.c:3048
+#: ../src/iop/colorequal.c:3011
 msgid ""
 "pick hue from image and visualize it\n"
 "ctrl+click to select an area"
@@ -18501,35 +21738,36 @@ msgstr ""
 "이미지에서 색조를 선택해 시각화\n"
 "Ctrl+클릭 시 영역 선택"
 
-#: ../src/iop/colorequal.c:3067
+#: ../src/iop/colorequal.c:3030
 msgid "change hue hue-wise"
 msgstr "색조 기준으로 색조 변경"
 
-#: ../src/iop/colorequal.c:3085
+#: ../src/iop/colorequal.c:3048
 msgid "change saturation hue-wise"
 msgstr "색조 기준으로 채도 변경"
 
-#: ../src/iop/colorequal.c:3103
+#: ../src/iop/colorequal.c:3066
 msgid "change brightness hue-wise"
 msgstr "색조 기준으로 밝기 변경"
 
-#: ../src/iop/colorequal.c:3136
+#: ../src/iop/colorequal.c:3099
 msgid ""
-"the white level set manually or via the picker restricts brightness corrections\n"
+"the white level set manually or via the picker restricts brightness "
+"corrections\n"
 "to stay below the defined level. the default is fine for most images."
 msgstr ""
 "수동 또는 선택 도구로 설정한 화이트 레벨은 밝기 보정을\n"
 "해당 값 이하로 제한합니다. 대부분의 이미지에는 기본값으로 충분합니다."
 
-#: ../src/iop/colorequal.c:3141
+#: ../src/iop/colorequal.c:3104
 msgid "change for sharper or softer hue curve"
 msgstr "색조 곡선을 더 날카롭거나 부드럽게 조정"
 
-#: ../src/iop/colorequal.c:3145
+#: ../src/iop/colorequal.c:3108
 msgid "restrict effect by using a guided filter based on hue and saturation"
 msgstr "색조와 채도를 기반으로 한 가이드 필터로 효과를 제한"
 
-#: ../src/iop/colorequal.c:3151
+#: ../src/iop/colorequal.c:3114
 msgid ""
 "set radius of the guided filter chroma analysis (hue).\n"
 "increase if there is large local variance of hue or strong chroma noise."
@@ -18537,7 +21775,7 @@ msgstr ""
 "가이드 필터의 색도 (색조) 분석 반지름을 설정합니다.\n"
 "색조 변화가 크거나 크로마 노이즈가 심할 경우, 값을 높이면 개선됩니다."
 
-#: ../src/iop/colorequal.c:3158
+#: ../src/iop/colorequal.c:3121
 msgid ""
 "visualize weighting function on changed output and view weighting curve.\n"
 "red shows possibly changed data, blueish parts will not be changed."
@@ -18545,7 +21783,7 @@ msgstr ""
 "변경된 출력에 적용된 가중치 함수를 시각화하고 가중치 곡선을 확인합니다.\n"
 "빨간색은 변경 가능성이 있는 데이터를, 파란색은 변경되지 않을 영역을 나타냅니다."
 
-#: ../src/iop/colorequal.c:3162
+#: ../src/iop/colorequal.c:3125
 msgid ""
 "set saturation threshold for the guided filter.\n"
 " - decrease to allow changes in areas with low chromaticity\n"
@@ -18557,21 +21795,22 @@ msgstr ""
 " - 채도 임계값을 높이면 고색조 영역에만 변경이 제한됩니다\n"
 "   색조가 낮은 영역에서는 명도 변화 없이 대비를 높여줍니다"
 
-#: ../src/iop/colorequal.c:3170
+#: ../src/iop/colorequal.c:3133
 msgid ""
 "set saturation contrast for the guided filter.\n"
-" - increase to favor sharp transitions between saturations leading to higher contrast\n"
+" - increase to favor sharp transitions between saturations leading to higher "
+"contrast\n"
 " - decrease for smoother transitions"
 msgstr ""
 "가이드 필터의 채도 대비를 설정합니다.\n"
 " - 값을 높이면 채도 간 경계가 뚜렷해져 대비가 증가합니다\n"
 " - 값을 낮추면 채도 간 전환이 부드러워집니다"
 
-#: ../src/iop/colorequal.c:3177
+#: ../src/iop/colorequal.c:3140
 msgid "set radius of applied parameters for the guided filter"
 msgstr "가이드 필터에 적용된 파라메터의 반지름을 설정"
 
-#: ../src/iop/colorequal.c:3180
+#: ../src/iop/colorequal.c:3143
 msgid ""
 "visualize changed output for the selected tab.\n"
 "red shows increased values, blue decreased."
@@ -18579,11 +21818,294 @@ msgstr ""
 "선택한 탭의 변경된 출력을 시각화합니다.\n"
 "빨간색은 값이 증가한 영역, 파란색은 감소한 영역을 나타냅니다."
 
-#: ../src/iop/colorin.c:120
+#: ../src/iop/colorharmonizer.c:125
+msgid "color harmonizer"
+msgstr "색상 조화 도구"
+
+#: ../src/iop/colorharmonizer.c:132
+msgid "harmonize colors toward a selected palette in perceptual space"
+msgstr "지각 공간에서 선택한 팔레트를 향해 색상을 조화시킵니다"
+
+#: ../src/iop/colorharmonizer.c:133
+msgid "creative color grading"
+msgstr "크리에이티브 색상 그레이딩"
+
+#: ../src/iop/colorharmonizer.c:135
+msgid "darktable UCS / JCH (perceptual)"
+msgstr "darktable UCS / JCH (지각)"
+
+#: ../src/iop/colorharmonizer.c:1337
+msgid ""
+"analyze the image's hue distribution and automatically suggest the harmony "
+"rule\n"
+"and anchor hue that best match its existing color palette.\n"
+"\n"
+"the detection scores every rule and anchor combination against a chroma-"
+"weighted\n"
+"histogram of the preview image, then selects the combination that already "
+"covers\n"
+"the most chromatic energy — i.e. requires the least correction.\n"
+"\n"
+"the result replaces the current rule and anchor hue. use pull strength to "
+"control\n"
+"how strongly the remaining off-palette colors are pulled toward the detected "
+"palette."
+msgstr ""
+"이미지의 색조 분포를 분석하여 기존 색상 팔레트에 가장 잘 맞는 조화 규칙과\n"
+"기준 색조를 자동으로 제안합니다.\n"
+"\n"
+"미리보기 이미지의 크로마 가중 히스토그램에 대해 모든 규칙과 기준의 조합을 채점한 뒤,\n"
+"이미 가장 많은 색채 에너지를 포함하는 — 즉 보정이 가장 적게 필요한 — 조합을\n"
+"선택합니다.\n"
+"\n"
+"결과는 현재 규칙과 기준 색조를 대체합니다. 팔레트에서 벗어난 나머지 색상을 감지된\n"
+"팔레트로 얼마나 강하게 끌어당길지는 끌어당김 강도로 조절하세요."
+
+#: ../src/iop/colorharmonizer.c:1418
+msgid "not yet available — wait for the preview to finish processing."
+msgstr "아직 사용할 수 없습니다 — 미리보기 처리가 끝날 때까지 기다리세요."
+
+#: ../src/iop/colorharmonizer.c:1423
+msgid ""
+"harmony rule that defines which hues are considered 'in harmony'.\n"
+"\n"
+"monochromatic: a single hue family — only one node.\n"
+"analogous: three adjacent hues spaced 30° apart — naturalistic, cohesive.\n"
+"analogous complementary: analogous triad plus its complement — rich but "
+"balanced.\n"
+"complementary: two hues opposite on the wheel — high contrast, vibrant.\n"
+"split complementary: one hue and the two hues flanking its complement — "
+"vivid yet less stark.\n"
+"dyad: two hues separated by 60° — gentle contrast.\n"
+"triad: three hues evenly spaced 120° apart — balanced, colorful.\n"
+"tetrad: four hues in two complementary pairs spaced 60° — complex, needs "
+"restraint.\n"
+"square: four hues evenly spaced 90° apart — strong and varied.\n"
+"custom: define all four harmony node hues independently."
+msgstr ""
+"어떤 색조를 '조화롭다'고 볼지 정의하는 조화 규칙입니다.\n"
+"\n"
+"단색조: 하나의 색조 계열 — 노드가 하나뿐입니다.\n"
+"유사색: 30° 간격의 인접한 세 색조 — 자연스럽고 통일감이 있습니다.\n"
+"유사 보색: 유사색 3화음과 그 보색 — 풍부하면서도 균형이 있습니다.\n"
+"보색: 색상환에서 마주보는 두 색조 — 대비가 강하고 선명합니다.\n"
+"분할 보색: 하나의 색조와 그 보색의 양옆 두 색조 — 생생하지만 덜 극단적입니다.\n"
+"2색 조합(Dyad): 60° 떨어진 두 색조 — 부드러운 대비입니다.\n"
+"3색 조합(Triad): 120° 간격으로 고르게 배치된 세 색조 — 균형 있고 다채롭습니다.\n"
+"4색 조합(Tetrad): 60° 간격의 두 보색 쌍으로 이루어진 네 색조 — 복잡하므로 절제가 필요합니다.\n"
+"정사각형: 90° 간격으로 고르게 배치된 네 색조 — 강렬하고 변화가 큽니다.\n"
+"사용자 정의: 네 개의 조화 노드 색조를 각각 직접 지정합니다."
+
+#: ../src/iop/colorharmonizer.c:1446 ../src/iop/colorharmonizer.c:1501
+msgid ""
+"pick hue from image.\n"
+"ctrl+click to select an area"
+msgstr ""
+"이미지에서 색조를 선택합니다.\n"
+"Ctrl+클릭 시 영역 선택"
+
+#: ../src/iop/colorharmonizer.c:1449
+msgid ""
+"the primary 'key' hue of the harmony — the first node from which all others "
+"are derived.\n"
+"\n"
+"drag the slider or use the color picker (eyedropper) to sample a dominant "
+"hue directly\n"
+"from the image. the remaining harmony nodes are computed automatically from "
+"this hue\n"
+"and the selected rule.\n"
+"\n"
+"tip: pick a skin tone, a sky, or another dominant subject color to anchor "
+"the palette."
+msgstr ""
+"조화의 기본 '키' 색조 — 다른 모든 색조가 파생되는 첫 번째 노드입니다.\n"
+"\n"
+"슬라이더를 드래그하거나 색상 선택기(스포이드)로 이미지에서 지배적인 색조를 직접\n"
+"추출하세요. 나머지 조화 노드는 이 색조와 선택한 규칙으로부터 자동으로 계산됩니다.\n"
+"\n"
+"팁: 피부톤, 하늘, 또는 다른 지배적인 피사체 색상을 골라 팔레트의 기준으로 삼으세요."
+
+#: ../src/iop/colorharmonizer.c:1464
+msgid ""
+"number of active harmony nodes in custom mode (2–4).\n"
+"nodes are numbered from the top; inactive nodes are hidden."
+msgstr ""
+"사용자 정의 모드에서 활성화된 조화 노드의 개수입니다 (2–4).\n"
+"노드는 위에서부터 번호가 매겨지며, 비활성 노드는 숨겨집니다."
+
+#: ../src/iop/colorharmonizer.c:1494
+msgid ""
+"hue of this harmony node (0°–360°).\n"
+"only active in 'custom' harmony mode.\n"
+"use the color picker to sample the desired hue from the image."
+msgstr ""
+"이 조화 노드의 색조입니다 (0°–360°).\n"
+"'사용자 정의' 조화 모드에서만 활성화됩니다.\n"
+"색상 선택기로 이미지에서 원하는 색조를 추출하세요."
+
+#: ../src/iop/colorharmonizer.c:1513
+msgid "vectorscope two-way sync"
+msgstr "벡터스코프 양방향 동기화"
+
+#: ../src/iop/colorharmonizer.c:1517
+msgid ""
+"when enabled, the vectorscope harmony overlay is kept in sync with\n"
+"the harmony rule and anchor hue controls in the module.\n"
+"disable to adjust the module without disturbing the vectorscope display, and "
+"vice-versa."
+msgstr ""
+"활성화하면 벡터스코프의 조화 오버레이가 모듈의 조화 규칙 및 기준 색조 컨트롤과\n"
+"동기화된 상태로 유지됩니다.\n"
+"벡터스코프 표시를 건드리지 않고 모듈을 조정하려면(또는 그 반대) 비활성화하세요."
+
+#: ../src/iop/colorharmonizer.c:1531
+msgid ""
+"import the harmony rule and anchor hue currently displayed in the "
+"vectorscope.\n"
+"also switches the histogram panel to the vectorscope view if it is not "
+"already active."
+msgstr ""
+"현재 벡터스코프에 표시된 조화 규칙과 기준 색조를 가져옵니다.\n"
+"히스토그램 패널이 벡터스코프 보기가 아니면 벡터스코프 보기로 전환합니다."
+
+#: ../src/iop/colorharmonizer.c:1552
+msgid ""
+"how strongly off-harmony hues are pulled toward the nearest harmony node.\n"
+"\n"
+"0: no effect — colors are left unchanged.\n"
+"low values (0.1–0.3): subtle nudge, colors lean toward the palette without\n"
+"  losing their original character.\n"
+"high values (0.7–1.0): aggressive correction, most hues converge noticeably\n"
+"  onto the harmony nodes.\n"
+"\n"
+"the shift is weighted by each pixel's chroma: fully desaturated pixels "
+"(grays)\n"
+"are never affected regardless of this setting."
+msgstr ""
+"조화에서 벗어난 색조를 가장 가까운 조화 노드로 얼마나 강하게 끌어당길지 결정합니다.\n"
+"\n"
+"0: 효과 없음 — 색상이 그대로 유지됩니다.\n"
+"낮은 값 (0.1–0.3): 살짝 밀어주는 정도로, 원래 특성을 잃지 않으면서\n"
+"  색상이 팔레트 쪽으로 기울어집니다.\n"
+"높은 값 (0.7–1.0): 적극적인 보정으로, 대부분의 색조가 눈에 띄게\n"
+"  조화 노드로 수렴합니다.\n"
+"\n"
+"이동량은 각 픽셀의 크로마로 가중되므로, 완전히 무채색인 픽셀(회색)은\n"
+"이 설정과 무관하게 영향을 받지 않습니다."
+
+#: ../src/iop/colorharmonizer.c:1566
+msgid ""
+"controls the angular reach of each harmony node's attraction.\n"
+"\n"
+"the attraction is Gaussian — strongest at the node center and tapering "
+"smoothly\n"
+"outward. zone width scales the standard deviation of this Gaussian "
+"linearly.\n"
+"\n"
+"narrow (< 1): only hues very close to a node are pulled — selective, "
+"precise.\n"
+"  useful when colors are already near-harmonic and need only a gentle "
+"correction.\n"
+"default (1): each node's influence tapers to near-zero at the midpoint "
+"between\n"
+"  adjacent nodes — clean separation with smooth transitions.\n"
+"wide (> 1): attraction zones overlap — broader, more global hue shift.\n"
+"  useful for strongly discordant images or when a painterly look is desired."
+msgstr ""
+"각 조화 노드가 끌어당기는 각도 범위를 제어합니다.\n"
+"\n"
+"끌어당김은 가우시안 형태로, 노드 중심에서 가장 강하고 바깥으로 갈수록 부드럽게\n"
+"약해집니다. 영역 폭은 이 가우시안의 표준편차를 선형으로 조절합니다.\n"
+"\n"
+"좁게 (< 1): 노드에 아주 가까운 색조만 끌어당깁니다 — 선택적이고 정밀합니다.\n"
+"  색상이 이미 거의 조화로워 가벼운 보정만 필요할 때 유용합니다.\n"
+"기본값 (1): 각 노드의 영향력이 인접 노드 사이의 중간 지점에서 거의 0에 가까워집니다\n"
+"  — 부드러운 전환과 함께 깔끔하게 분리됩니다.\n"
+"넓게 (> 1): 끌어당김 영역이 겹칩니다 — 더 넓고 전역적인 색조 이동입니다.\n"
+"  색상이 심하게 어긋난 이미지나 회화적인 느낌을 원할 때 유용합니다."
+
+#: ../src/iop/colorharmonizer.c:1581
+msgid ""
+"shields low-chroma (desaturated) colors from the hue correction.\n"
+"\n"
+"0: no protection — grays, skin highlights, and muted tones are all shifted.\n"
+"low values (0.1–0.3): only near-neutral grays are exempted; pastels are "
+"still affected.\n"
+"mid values (0.4–0.6): muted and pastel colors are increasingly spared.\n"
+"high values (0.7–1.0): only vivid, saturated colors are corrected; "
+"everything else\n"
+"  is left close to its original hue.\n"
+"\n"
+"the weighting is smooth and hyperbolic — there is no hard cutoff. protection "
+"grows\n"
+"gradually from zero and the slider response is distributed evenly across its "
+"range."
+msgstr ""
+"크로마가 낮은(무채색에 가까운) 색상을 색조 보정에서 보호합니다.\n"
+"\n"
+"0: 보호 없음 — 회색, 피부 하이라이트, 탁한 톤까지 모두 이동합니다.\n"
+"낮은 값 (0.1–0.3): 거의 무채색인 회색만 제외되고, 파스텔 색은 여전히 영향을 받습니다.\n"
+"중간 값 (0.4–0.6): 탁한 색과 파스텔 색이 점점 더 보호됩니다.\n"
+"높은 값 (0.7–1.0): 선명하고 채도가 높은 색만 보정되며, 나머지는\n"
+"  원래 색조에 가깝게 유지됩니다.\n"
+"\n"
+"가중은 부드러운 쌍곡선 형태이며 급격한 경계가 없습니다. 보호는 0에서 점진적으로\n"
+"커지고 슬라이더 반응은 전 구간에 고르게 분포합니다."
+
+#: ../src/iop/colorharmonizer.c:1595
+msgid ""
+"controls the intensity of smoothing applied to the correction field.\n"
+"\n"
+"0: disable smoothing (recommended) — transitions are handled by smooth "
+"interpolation\n"
+"  in hue space, preserving the maximum amount of image detail.\n"
+"low values (0.1–0.5): subtle spatial averaging to reduce color noise in "
+"shadows.\n"
+"high values (> 1.0): broad spatial blending; creates a soft, painterly look "
+"but may\n"
+"  blur the grading across image edges, causing some visual separation."
+msgstr ""
+"보정 필드에 적용되는 부드럽게 처리의 강도를 제어합니다.\n"
+"\n"
+"0: 부드럽게 처리 비활성화 (권장) — 전환은 색조 공간의 부드러운 보간으로 처리되어\n"
+"  이미지 세부 정보가 최대한 보존됩니다.\n"
+"낮은 값 (0.1–0.5): 쉐도우의 색상 노이즈를 줄이기 위한 약한 공간 평균화입니다.\n"
+"높은 값 (> 1.0): 넓은 공간 혼합으로, 부드럽고 회화적인 느낌을 주지만 이미지\n"
+"  경계를 넘어 그레이딩이 번져 시각적 분리가 생길 수 있습니다."
+
+#: ../src/iop/colorharmonizer.c:1610
+msgid "hue 1"
+msgstr "색조 1"
+
+#: ../src/iop/colorharmonizer.c:1610
+msgid "hue 2"
+msgstr "색조 2"
+
+#: ../src/iop/colorharmonizer.c:1610
+msgid "hue 3"
+msgstr "색조 3"
+
+#: ../src/iop/colorharmonizer.c:1610
+msgid "hue 4"
+msgstr "색조 4"
+
+#: ../src/iop/colorharmonizer.c:1622
+msgid ""
+"saturation multiplier for colors near this harmony node.\n"
+"100% = unchanged. below 100% desaturates; above 100% boosts saturation.\n"
+"the effect is weighted by the pixel's proximity to this node\n"
+"and respects the 'neutral hue protection' setting."
+msgstr ""
+"이 조화 노드에 가까운 색상의 채도 배율입니다.\n"
+"100% = 변화 없음. 100% 미만은 채도를 낮추고, 100% 초과는 채도를 높입니다.\n"
+"효과는 픽셀이 이 노드에 얼마나 가까운지에 따라 가중되며\n"
+"'중립 색조 보호' 설정을 따릅니다."
+
+#: ../src/iop/colorin.c:121
 msgid "input color profile"
 msgstr "입력 색상 프로파일"
 
-#: ../src/iop/colorin.c:125
+#: ../src/iop/colorin.c:126
 msgid ""
 "convert any RGB input to pipeline reference RGB\n"
 "using color profiles to remap RGB values"
@@ -18591,38 +22113,40 @@ msgstr ""
 "모든 RGB 입력을 파이프라인 기준 RGB로 변환하며\n"
 "색상 프로파일을 사용해 RGB 값을 다시 매핑합니다"
 
-#: ../src/iop/colorin.c:127 ../src/iop/colorout.c:86 ../src/iop/demosaic.c:327
+#: ../src/iop/colorin.c:128 ../src/iop/colorout.c:87 ../src/iop/demosaic.c:315
 #: ../src/iop/rawprepare.c:170
 msgid "mandatory"
 msgstr "필수 항목"
 
-#: ../src/iop/colorin.c:129 ../src/iop/colorout.c:88
+#: ../src/iop/colorin.c:130 ../src/iop/colorout.c:89
 msgid "defined by profile"
 msgstr "프로파일에 따라 정의됨"
 
-#: ../src/iop/colorin.c:566
+#: ../src/iop/colorin.c:567
 #, c-format
-msgid "can't extract matrix from colorspace `%s', it will be replaced by Rec2020 RGB!"
+msgid ""
+"can't extract matrix from colorspace `%s', it will be replaced by Rec2020 "
+"RGB!"
 msgstr "`%s' 색공간에서 행렬을 추출할 수 없음, Rec2020 RGB로 대체됩니다!"
 
-#: ../src/iop/colorin.c:1384
+#: ../src/iop/colorin.c:1396
 #, c-format
 msgid "`%s' color matrix not found!"
 msgstr "`%s' 색상 매트릭스를 찾을 수 없습니다!"
 
-#: ../src/iop/colorin.c:1423
+#: ../src/iop/colorin.c:1434
 msgid "input profile could not be generated!"
 msgstr "입력 프로파일 생성 실패하였습니다!"
 
-#: ../src/iop/colorin.c:1520
+#: ../src/iop/colorin.c:1531
 msgid "unsupported input profile has been replaced by linear Rec709 RGB!"
 msgstr "지원되지 않는 입력 프로파일이 선형 Rec709 RGB로 대체됩니다!"
 
-#: ../src/iop/colorin.c:1794
+#: ../src/iop/colorin.c:1805
 msgid "external ICC profiles"
 msgstr "외부 ICC 프로파일"
 
-#: ../src/iop/colorin.c:1849
+#: ../src/iop/colorin.c:1860
 #, c-format
 msgid ""
 "embedded ICC profile properties:\n"
@@ -18645,15 +22169,31 @@ msgstr ""
 "저작권: <b>%s</b>\n"
 "\n"
 
-#: ../src/iop/colorin.c:2037
+#: ../src/iop/colorin.c:2047
+msgid "blue mapping"
+msgstr "블루 매핑"
+
+#: ../src/iop/colorin.c:2048
+msgid ""
+"the blue mapping mode has been deprecated since very long and has been "
+"removed.\n"
+"reset to defaults or switch to any colorin profile and check results. "
+"minimal\n"
+"visual differences might be possible."
+msgstr ""
+"블루 매핑 모드는 오래전에 폐기되었으며 제거되었습니다.\n"
+"기본값으로 초기화하거나 colorin 프로파일을 아무것으로든 전환한 뒤 결과를 확인하세요.\n"
+"약간의 시각적 차이가 있을 수 있습니다."
+
+#: ../src/iop/colorin.c:2062
 msgid "input profile"
 msgstr "입력 프로파일"
 
-#: ../src/iop/colorin.c:2050
+#: ../src/iop/colorin.c:2075
 msgid "working ICC profiles"
 msgstr "작업 ICC 프로파일"
 
-#: ../src/iop/colorin.c:2062
+#: ../src/iop/colorin.c:2087
 msgid "confine Lab values to gamut of RGB color space"
 msgstr "Lab 값을 RGB 색공간의 색역으로 제한"
 
@@ -18665,19 +22205,19 @@ msgstr "색상 입히기"
 msgid "overlay a solid color on the image"
 msgstr "이미지 위에 단색을 오버레이"
 
-#: ../src/iop/colorize.c:345 ../src/iop/splittoning.c:468
+#: ../src/iop/colorize.c:356 ../src/iop/splittoning.c:468
 msgid "select the hue tone"
 msgstr "색조 톤 선택"
 
-#: ../src/iop/colorize.c:351
+#: ../src/iop/colorize.c:362
 msgid "select the saturation shadow tone"
 msgstr "쉐도우 색상의 채도 선택"
 
-#: ../src/iop/colorize.c:355
+#: ../src/iop/colorize.c:366
 msgid "lightness of color"
 msgstr "색상의 명도"
 
-#: ../src/iop/colorize.c:359
+#: ../src/iop/colorize.c:370
 msgid "mix value of source lightness"
 msgstr "원본 명도와의 혼합 비율"
 
@@ -18693,49 +22233,51 @@ msgstr ""
 "색상 팔레트와 톤 분포를 \n"
 "한 이미지에서 다른 이미지에 적용하기"
 
-#: ../src/iop/colormapping.c:1002
+#: ../src/iop/colormapping.c:1000
 msgid "acquire as source"
 msgstr "원본으로 가져오기"
 
-#: ../src/iop/colormapping.c:1006
+#: ../src/iop/colormapping.c:1004
 msgid "analyze this image as a source image"
 msgstr "이 이미지를 원본 이미지로 분석하기"
 
-#: ../src/iop/colormapping.c:1008
+#: ../src/iop/colormapping.c:1006
 msgid "acquire as target"
 msgstr "대상으로 가져오기"
 
-#: ../src/iop/colormapping.c:1012
+#: ../src/iop/colormapping.c:1010
 msgid "analyze this image as a target image"
 msgstr "이 이미지를 대상 이미지로 분석하기"
 
-#: ../src/iop/colormapping.c:1014
+#: ../src/iop/colormapping.c:1012
 msgid "source clusters:"
 msgstr "원본 클러스터:"
 
-#: ../src/iop/colormapping.c:1015
+#: ../src/iop/colormapping.c:1013
 msgid "target clusters:"
 msgstr "대상 클러스터:"
 
-#: ../src/iop/colormapping.c:1018
+#: ../src/iop/colormapping.c:1016
 msgid "number of clusters to find in image. value change resets all clusters"
 msgstr "이미지에서 찾을 클러스터수 입니다. 값을 변경하면 모든 클러스터가 리셋됩니다"
 
-#: ../src/iop/colormapping.c:1021
-msgid "how clusters are mapped. low values: based on color proximity, high values: based on color dominance"
+#: ../src/iop/colormapping.c:1019
+msgid ""
+"how clusters are mapped. low values: based on color proximity, high values: "
+"based on color dominance"
 msgstr ""
 "클러스터 매핑 방식입니다. 낮은 값: 색상 유사도 기준, 높은 값:\n"
 " 색상 지배도 기준으로 매핑됩니다"
 
-#: ../src/iop/colormapping.c:1026
+#: ../src/iop/colormapping.c:1024
 msgid "level of histogram equalization"
 msgstr "히스토그램 이퀄리제이션 강도"
 
-#: ../src/iop/colorout.c:78
+#: ../src/iop/colorout.c:79
 msgid "output color profile"
 msgstr "출력 색상 프로파일"
 
-#: ../src/iop/colorout.c:84
+#: ../src/iop/colorout.c:85
 msgid ""
 "convert pipeline reference RGB to any display RGB\n"
 "using color profiles to remap RGB values"
@@ -18743,56 +22285,56 @@ msgstr ""
 "파이프라인 기준 RGB를 디스플레이용 RGB로 변환하며,\n"
 "색상 프로파일을 사용해 RGB 값을 다시 매핑합니다"
 
-#: ../src/iop/colorout.c:89
+#: ../src/iop/colorout.c:90
 msgid "non-linear, RGB or Lab, display-referred"
 msgstr "비선형 RGB 또는 Lab, 디스플레이 기준 색공간"
 
-#: ../src/iop/colorout.c:650
+#: ../src/iop/colorout.c:654
 msgid "missing output profile has been replaced by sRGB!"
 msgstr "출력 프로파일이 없어서 sRGB로 대체됩니다!"
 
-#: ../src/iop/colorout.c:672
+#: ../src/iop/colorout.c:676
 msgid "missing softproof profile has been replaced by sRGB!"
 msgstr "소프트프루프 프로파일이 없어서 sRGB로 대체됩니다!"
 
-#: ../src/iop/colorout.c:715
+#: ../src/iop/colorout.c:719
 msgid "unsupported output profile has been replaced by sRGB!"
 msgstr "지원되지 않는 출력 프로파일이 sRGB로 대체됩니다!"
 
-#: ../src/iop/colorout.c:837
+#: ../src/iop/colorout.c:841
 msgid "output intent"
 msgstr "출력 의도"
 
-#: ../src/iop/colorout.c:838
+#: ../src/iop/colorout.c:842
 msgid "rendering intent"
 msgstr "렌더링 의도"
 
-#: ../src/iop/colorout.c:840 ../src/libs/export.c:1619
-#: ../src/libs/print_settings.c:2553 ../src/libs/print_settings.c:2902
-#: ../src/views/darkroom.c:2743 ../src/views/lighttable.c:1256
+#: ../src/iop/colorout.c:844 ../src/libs/export.c:1637
+#: ../src/libs/print_settings.c:2573 ../src/libs/print_settings.c:2922
+#: ../src/views/darkroom.c:3368 ../src/views/lighttable.c:1488
 msgid "perceptual"
 msgstr "지각적"
 
-#: ../src/iop/colorout.c:841 ../src/libs/export.c:1620
-#: ../src/libs/print_settings.c:2554 ../src/libs/print_settings.c:2903
-#: ../src/views/darkroom.c:2744 ../src/views/lighttable.c:1257
+#: ../src/iop/colorout.c:845 ../src/libs/export.c:1638
+#: ../src/libs/print_settings.c:2574 ../src/libs/print_settings.c:2923
+#: ../src/views/darkroom.c:3369 ../src/views/lighttable.c:1489
 msgid "relative colorimetric"
 msgstr "상대 색도"
 
-#: ../src/iop/colorout.c:842 ../src/libs/export.c:1621
-#: ../src/libs/print_settings.c:2555 ../src/libs/print_settings.c:2904
-#: ../src/views/darkroom.c:2745 ../src/views/lighttable.c:1258
+#: ../src/iop/colorout.c:846 ../src/libs/export.c:1639
+#: ../src/libs/print_settings.c:2575 ../src/libs/print_settings.c:2924
+#: ../src/views/darkroom.c:3370 ../src/views/lighttable.c:1490
 msgctxt "rendering intent"
 msgid "saturation"
 msgstr "채도 우선"
 
-#: ../src/iop/colorout.c:843 ../src/libs/export.c:1622
-#: ../src/libs/print_settings.c:2556 ../src/libs/print_settings.c:2905
-#: ../src/views/darkroom.c:2746 ../src/views/lighttable.c:1259
+#: ../src/iop/colorout.c:847 ../src/libs/export.c:1640
+#: ../src/libs/print_settings.c:2576 ../src/libs/print_settings.c:2925
+#: ../src/views/darkroom.c:3371 ../src/views/lighttable.c:1491
 msgid "absolute colorimetric"
 msgstr "절대 색도계"
 
-#: ../src/iop/colorout.c:859
+#: ../src/iop/colorout.c:863
 msgid "export ICC profiles"
 msgstr "ICC 프로파일 내보내기"
 
@@ -18804,10 +22346,10 @@ msgstr "색상 복원"
 msgid "recover clipped highlights by propagating surrounding colors"
 msgstr "주변 색상을 확산시켜 클리핑된 하이라이트 복원"
 
-#: ../src/iop/colorreconstruction.c:632 ../src/iop/colorreconstruction.c:1038
+#: ../src/iop/colorreconstruction.c:632 ../src/iop/colorreconstruction.c:1033
 #: ../src/iop/globaltonemap.c:217 ../src/iop/globaltonemap.c:372
-#: ../src/iop/hazeremoval.c:631 ../src/iop/hazeremoval.c:643
-#: ../src/iop/hazeremoval.c:900 ../src/iop/hazeremoval.c:914
+#: ../src/iop/hazeremoval.c:631 ../src/iop/hazeremoval.c:642
+#: ../src/iop/hazeremoval.c:898 ../src/iop/hazeremoval.c:911
 #: ../src/iop/levels.c:354
 msgid "inconsistent output"
 msgstr "출력 불일치"
@@ -18816,44 +22358,44 @@ msgstr "출력 불일치"
 msgid "module `color reconstruction' failed"
 msgstr "`색상 복원' 모듈 실패"
 
-#: ../src/iop/colorreconstruction.c:1230
+#: ../src/iop/colorreconstruction.c:1223
 msgid "spatial"
 msgstr "공간"
 
-#: ../src/iop/colorreconstruction.c:1231
+#: ../src/iop/colorreconstruction.c:1224
 msgid "range"
 msgstr "범위"
 
-#: ../src/iop/colorreconstruction.c:1232
+#: ../src/iop/colorreconstruction.c:1225
 msgid "precedence"
 msgstr "우선순위"
 
-#: ../src/iop/colorreconstruction.c:1248
+#: ../src/iop/colorreconstruction.c:1241
 msgid "pixels with lightness values above this threshold are corrected"
 msgstr "명도 값이 이 임계값을 초과하는 픽셀을 보정합니다"
 
-#: ../src/iop/colorreconstruction.c:1249
+#: ../src/iop/colorreconstruction.c:1242
 msgid "how far to look for replacement colors in spatial dimensions"
 msgstr "공간 차원에서 대체 색상을 찾을 거리"
 
-#: ../src/iop/colorreconstruction.c:1250
+#: ../src/iop/colorreconstruction.c:1243
 msgid "how far to look for replacement colors in the luminance dimension"
 msgstr "휘도 차원에서 대체 색상을 찾을 거리"
 
-#: ../src/iop/colorreconstruction.c:1251
+#: ../src/iop/colorreconstruction.c:1244
 msgid "if and how to give precedence to specific replacement colors"
 msgstr "특정 대체 색상에 우선순위를 부여할지 여부와 방식"
 
-#: ../src/iop/colorreconstruction.c:1252
+#: ../src/iop/colorreconstruction.c:1245
 msgid "the hue tone which should be given precedence over other hue tones"
 msgstr "다른 색조 톤보다 우선되는 색조 톤"
 
-#: ../src/iop/colorreconstruction.c:1254 ../src/iop/demosaic.c:1850
-#: ../src/iop/highlights.c:1359
+#: ../src/iop/colorreconstruction.c:1247 ../src/iop/demosaic.c:1823
+#: ../src/iop/highlights.c:1338
 msgid "not applicable"
 msgstr "해당 없음"
 
-#: ../src/iop/colorreconstruction.c:1255
+#: ../src/iop/colorreconstruction.c:1248
 msgid "no highlights reconstruction for monochrome images"
 msgstr "모노크롬 이미지에는 하이라이트 복원 적용 안됨"
 
@@ -18865,7 +22407,7 @@ msgstr "색상 전달"
 msgid "this module is deprecated. better use color mapping module instead."
 msgstr "이 모듈은 더이상 사용되지 않습니다. 색상 매핑 모듈을 사용하는 것이 더 좋습니다."
 
-#: ../src/iop/colortransfer.c:413
+#: ../src/iop/colortransfer.c:406
 msgid ""
 "this module will be removed in the future\n"
 "and is only here so you can switch it off\n"
@@ -18947,49 +22489,58 @@ msgstr "효과를 더 부드럽게 또는 강하게 설정합니다"
 #: ../src/iop/tonecurve.c:1312
 msgid ""
 "change this method if you see oscillations or cusps in the curve\n"
-"- cubic spline is better to produce smooth curves but oscillates when nodes are too close\n"
-"- centripetal is better to avoids cusps and oscillations with close nodes but is less smooth\n"
-"- monotonic is better for accuracy of pure analytical functions (log, gamma, exp)"
+"- cubic spline is better to produce smooth curves but oscillates when nodes "
+"are too close\n"
+"- centripetal is better to avoids cusps and oscillations with close nodes "
+"but is less smooth\n"
+"- monotonic is better for accuracy of pure analytical functions (log, gamma, "
+"exp)"
 msgstr ""
 "커브에 진동이나 뾰족한 모양이 보이면 이 방법을 변경합니다\n"
 "- 큐빅 스플라인운 부드러운 커브 생성에 더 적합하지만 노드가 너무 가까울 때\n"
 "진동 현상이 발생할 수 있습니다- 구심 스플라인은 진동과 뾰족함 방지에 더 적합하지만 부드러움은 다소 떨어집니다\n"
 "- 단조 스플라인은 순수 해석 함수 (로그, 감마, 지수)의 정확도에 더 적합합니다"
 
-#: ../src/iop/crop.c:124
+#: ../src/iop/crop.c:122
 msgid "crop"
 msgstr "자르기"
 
-#: ../src/iop/crop.c:129
+#: ../src/iop/crop.c:127
 msgid "reframe|distortion"
 msgstr "재구성|왜곡 보정"
 
-#: ../src/iop/crop.c:135
+#: ../src/iop/crop.c:133
 msgid "change the framing"
 msgstr "프레임 구성 변경"
 
-#: ../src/iop/crop.c:1157
+#: ../src/iop/crop.c:1274
 msgid "45x35, portrait"
 msgstr "45x35, 인물"
 
-#: ../src/iop/crop.c:1167
+#: ../src/iop/crop.c:1284
 msgid "2:1, Univisium"
 msgstr "2:1, 유니비지움"
 
-#: ../src/iop/crop.c:1168
+#: ../src/iop/crop.c:1285
 msgid "CinemaScope"
 msgstr "시네마스코프"
 
-#: ../src/iop/crop.c:1171
+#: ../src/iop/crop.c:1288
 msgid "65:24, XPan"
 msgstr "65:24, XPan"
 
-#: ../src/iop/crop.c:1701
+#: ../src/iop/crop.c:1403
+msgid "flip crop orientation between horizontal and vertical"
+msgstr "자르기 방향을 가로와 세로로 전환"
+
+#: ../src/iop/crop.c:1834
 msgid "<b>resize</b>: drag, <b>keep aspect ratio</b>: shift+drag"
 msgstr "<b>크기 조절</b>: 드래그, <b>종횡비 유지</b>: Shift+드래그"
 
-#: ../src/iop/crop.c:1708
-msgid "<b>move</b>: drag, <b>move vertically</b>: shift+drag, <b>move horizontally</b>: ctrl+drag"
+#: ../src/iop/crop.c:1841
+msgid ""
+"<b>move</b>: drag, <b>move vertically</b>: shift+drag, <b>move horizontally</"
+"b>: ctrl+drag"
 msgstr "<b>이동</b>: 드래그, <b>수직 이동</b>: Shift+드래그, <b>수평 이동</b>: Ctrl+드래그"
 
 #: ../src/iop/defringe.c:69
@@ -19001,14 +22552,20 @@ msgid "attenuate chromatic aberration by desaturating edges"
 msgstr "가장자리의 채도를 줄여 색수차 완화"
 
 #: ../src/iop/defringe.c:99
-msgid "this module is deprecated. please use the chromatic aberration module instead."
+msgid ""
+"this module is deprecated. please use the chromatic aberration module "
+"instead."
 msgstr "이 모듈은 더 이상 사용되지 않습니다. 대신 색수차 모듈을 사용하세요."
 
-#: ../src/iop/defringe.c:403
+#: ../src/iop/defringe.c:402
 msgid ""
 "method for color protection:\n"
-" - global average: fast, might show slightly wrong previews in high magnification; might sometimes protect saturation too much or too low in comparison to local average\n"
-" - local average: slower, might protect saturation better than global average by using near pixels as color reference, so it can still allow for more desaturation where required\n"
+" - global average: fast, might show slightly wrong previews in high "
+"magnification; might sometimes protect saturation too much or too low in "
+"comparison to local average\n"
+" - local average: slower, might protect saturation better than global "
+"average by using near pixels as color reference, so it can still allow for "
+"more desaturation where required\n"
 " - static: fast, only uses the threshold as a static limit"
 msgstr ""
 "색상 보호 방식:\n"
@@ -19016,62 +22573,68 @@ msgstr ""
 " - 지역 평균: 느리지만 주변 픽셀을 색상 기준으로 사용해 전역 평균보다 채도를 더 정확하게 보호함. 필요한 경우 더 많은 채도 감소 허용\n"
 " - 정적: 빠르며 임계값만을 기준으로 고정된 한계를 사용함"
 
-#: ../src/iop/defringe.c:410
+#: ../src/iop/defringe.c:409
 msgid "radius for detecting fringe"
 msgstr "색수차 감지를 위한 반지름"
 
-#: ../src/iop/defringe.c:413
+#: ../src/iop/defringe.c:412
 msgid "threshold for defringe, higher values mean less defringing"
 msgstr "색수차 제거 임계값, 값이 높을수록 제거 정도가 낮아집니다"
 
-#: ../src/iop/demosaic.c:321
+#: ../src/iop/demosaic.c:309
 msgid "demosaic"
 msgstr "모자이크 제거"
 
-#: ../src/iop/demosaic.c:326
+#: ../src/iop/demosaic.c:314
 msgid "reconstruct full RGB pixels from a sensor color filter array reading"
 msgstr "센서의 색상 필터 배열을 기반으로 전체 RGB 픽셀을 복원합니다"
 
-#: ../src/iop/demosaic.c:773 ../src/iop/demosaic.c:820
+#: ../src/iop/demosaic.c:764 ../src/iop/demosaic.c:811
 msgid "can't allocate demosaic buffer"
 msgstr "디모자이크 버퍼를 할당할 수 없음"
 
-#: ../src/iop/demosaic.c:810
+#: ../src/iop/demosaic.c:801
 msgid "can't equilibrate greens"
 msgstr "녹색을 평탄화할 수 없음"
 
-#: ../src/iop/demosaic.c:1477
+#: ../src/iop/demosaic.c:1449
 #, c-format
 msgid "`%s' color matrix not found for 4bayer image!"
 msgstr "'%s' 색상 매트릭스를 4배이어 이미지에서 찾을 수 없습니다!"
 
-#: ../src/iop/demosaic.c:1765
+#: ../src/iop/demosaic.c:1738
 msgid ""
-"Bayer sensor demosaicing method, PPG and RCD are fast, AMaZE and LMMSE are slow.\n"
+"Bayer sensor demosaicing method, PPG and RCD are fast, AMaZE and LMMSE are "
+"slow.\n"
 "LMMSE is suited best for high ISO images.\n"
-"dual demosaicers increase processing time by blending a VNG variant in a second pass."
+"VNG4 is good in rare cases avoiding maze patterns.\n"
+"dual demosaicers increase processing time by blending a VNG variant in a "
+"second pass."
 msgstr ""
-"베이어 센서 모자이크 제거 방식, PPG와 RCD는 빠르고, AMaZE와 LMMSE는 느립니다.\n"
-"LMMSE는 고감도(ISO) 이미지에 적합합니다.\n"
-"듀얼 모자이크 제거는 두 번째 단계에서 VNG 변형을 혼합하여 처리 시간이 길어집니다."
+"베이어 센서 디모자이크 방식입니다. PPG와 RCD는 빠르고, AMaZE와 LMMSE는 느립니다.\n"
+"LMMSE는 고감도(ISO) 이미지에 가장 적합합니다.\n"
+"VNG4는 미로 패턴을 피해야 하는 드문 경우에 좋습니다.\n"
+"듀얼 디모자이커는 두 번째 패스에서 VNG 변형을 혼합하므로 처리 시간이 늘어납니다."
 
-#: ../src/iop/demosaic.c:1770
+#: ../src/iop/demosaic.c:1743
 msgid ""
-"X-Trans sensor demosaicing method, Markesteijn 3-pass and frequency domain chroma are slow.\n"
-"dual demosaicers increase processing time by blending a VNG variant in a second pass."
+"X-Trans sensor demosaicing method, Markesteijn 3-pass and frequency domain "
+"chroma are slow.\n"
+"dual demosaicers increase processing time by blending a VNG variant in a "
+"second pass."
 msgstr ""
 "X-Trans 센서의 모자이크 제거 방식 중 Markesteijn 3단계와 주파수 영역 색상 방식은 느립니다.\n"
 "듀얼 모자이크 제거는 두 번째 단계에서 VNG 변형을 혼합하므로 처리 시간이 증가합니다."
 
-#: ../src/iop/demosaic.c:1776
+#: ../src/iop/demosaic.c:1749
 msgid "Bayer4 sensor demosaicing methods."
 msgstr "배이어4 센서를 위한 모자이크 제거 방법."
 
-#: ../src/iop/demosaic.c:1781
+#: ../src/iop/demosaic.c:1754
 msgid "monochrome sensor demosaicing methods."
 msgstr "모노크롬 센서 모자이크 제거 방법."
 
-#: ../src/iop/demosaic.c:1785
+#: ../src/iop/demosaic.c:1758
 msgid ""
 "contrast threshold for dual demosaic.\n"
 "set to 0.0 for high frequency content\n"
@@ -19081,11 +22644,11 @@ msgstr ""
 "고주파 컨텐츠에는  0.0으로 설정\n"
 "평탄한 컨텐츠에는  1.0으로 설정"
 
-#: ../src/iop/demosaic.c:1788
+#: ../src/iop/demosaic.c:1761
 msgid "toggle mask visualization"
 msgstr "마스크 시각화 전환"
 
-#: ../src/iop/demosaic.c:1792
+#: ../src/iop/demosaic.c:1765
 msgid ""
 "threshold for edge-aware median.\n"
 "set to 0.0 to switch off\n"
@@ -19094,7 +22657,7 @@ msgstr ""
 "에지 인식 중앙값 필터 임계값\n"
 "0.0은 비활성화, 1.0은 에지를 무시"
 
-#: ../src/iop/demosaic.c:1795
+#: ../src/iop/demosaic.c:1768
 msgid ""
 "LMMSE refinement steps. the median steps average the output,\n"
 "refine adds some recalculation of red & blue channels"
@@ -19102,15 +22665,15 @@ msgstr ""
 "LMMSE 보정 단계.\n"
 "중앙값 단계는 출력을 평균화하고, 보정 단계는 빨강과 파랑 채널을 일부 재계산"
 
-#: ../src/iop/demosaic.c:1798
+#: ../src/iop/demosaic.c:1771
 msgid "how many color smoothing median steps after demosaicing"
 msgstr "모자이크 제거 후 색상 평활화를 위한 중앙값 필터 단계 수"
 
-#: ../src/iop/demosaic.c:1801
-msgid "green channels matching method"
-msgstr "녹색 채널 정렬 방식"
+#: ../src/iop/demosaic.c:1774
+msgid "green channels matching method. only applies for some old sensors"
+msgstr "녹색 채널 정합 방식입니다. 일부 구형 센서에만 적용됩니다"
 
-#: ../src/iop/demosaic.c:1804
+#: ../src/iop/demosaic.c:1777
 msgid ""
 "capture sharpen recovers details lost due to in-camera blurring\n"
 "which can be caused by diffraction, the anti-aliasing filter or other\n"
@@ -19120,22 +22683,23 @@ msgstr ""
 "세부 정보를 복구합니다. 이러한 블러는 회절, 안티 앨리어싱 필터 \n"
 "또는 기타 가우시안 유형의 블러 원인으로 인해 발생할 수 있습니다."
 
-#: ../src/iop/demosaic.c:1809
+#: ../src/iop/demosaic.c:1782
 msgid "capture sharpen controls"
 msgstr "캡처 샤프닝 제어"
 
-#: ../src/iop/demosaic.c:1813
+#: ../src/iop/demosaic.c:1786
 msgid "set effect strength by iterations"
 msgstr "반복으로 효과의 강도 설정"
 
-#: ../src/iop/demosaic.c:1818
+#: ../src/iop/demosaic.c:1791
 msgid ""
 "capture sharpen radius should reflect the overall gaussian type blur\n"
 "of the camera sensor, possibly the anti-aliasing filter and the lens.\n"
 "increasing this too far will soon lead to artifacts like halos and\n"
 "ringing especially when used with a large 'iterations' setting.\n"
 "\n"
-"Note: a radius set to zero will be recalculated automatically the next run. use for presets"
+"Note: a radius set to zero will be recalculated automatically the next run. "
+"use for presets"
 msgstr ""
 "캡처 샤프닝 반지름은 카메라 센서의 전체적인 가우시안 형태의 블러, \n"
 "안티앨리어싱 필터, 그리고 렌즈를 반영해야 합니다. \n"
@@ -19144,7 +22708,7 @@ msgstr ""
 "\n"
 "주의: 반경을 0으로 설정하면 다음 실행 시 자동으로 다시 계산됩니다. 리셋용으로 사용하세요"
 
-#: ../src/iop/demosaic.c:1824
+#: ../src/iop/demosaic.c:1797
 msgid ""
 "calculate the capture sharpen radius from available raw sensor data.\n"
 "for best results avoid cropping or darkroom zooming in"
@@ -19152,13 +22716,14 @@ msgstr ""
 "캡처 샤프닝 반지름을 센서 데이터로 부터 계산\n"
 "이 작업은 darkroom을 줌아웃 상태로 해야합니다"
 
-#: ../src/iop/demosaic.c:1828
+#: ../src/iop/demosaic.c:1801
 msgid ""
 "restrict capture sharpening to areas with high local contrast,\n"
 "increase to exclude flat areas in very dark or noisy images,\n"
 "decrease for well exposed and low noise images.\n"
 "\n"
-"Note: a threshold set to zero will be reset to defaults the next run. use for presets"
+"Note: a threshold set to zero will be reset to defaults the next run. use "
+"for presets"
 msgstr ""
 "부분 대비가 높은 영역에만 캡처 샤프닝을 제한합니다. \n"
 "매우 어둡거나 노이즈가 많은 이미지의 평탄한 영역을 제외하려면 증가시키고, \n"
@@ -19166,11 +22731,11 @@ msgstr ""
 "\n"
 "참고: 임계값이 0으로 설정되면 다음 실행 시 기본값으로 재설정됩니다. 재설정에 사용하세요"
 
-#: ../src/iop/demosaic.c:1832
+#: ../src/iop/demosaic.c:1805
 msgid "visualize sharpened areas"
 msgstr "선명화된 영역을 표시"
 
-#: ../src/iop/demosaic.c:1837
+#: ../src/iop/demosaic.c:1810
 msgid ""
 "further increase sharpen radius at image corners,\n"
 "the sharp center of the image will not be affected"
@@ -19178,20 +22743,22 @@ msgstr ""
 "이미지의 모서리 부분에서 샤프닝 반경을 더 증가시키면, \n"
 "중심부의 선명한 영역에는 영향을 주지 않습니다"
 
-#: ../src/iop/demosaic.c:1839
+#: ../src/iop/demosaic.c:1812
 msgid "visualize the overall radius"
 msgstr "전체 반지름을 표시"
 
-#: ../src/iop/demosaic.c:1844
+#: ../src/iop/demosaic.c:1817
 msgid "adjust to the sharp image center"
 msgstr "선명도 이미지 중심을 조정"
 
-#: ../src/iop/demosaic.c:1851
+#: ../src/iop/demosaic.c:1824
 msgid "demosaicing is only used for color raw images"
 msgstr "모자이크 제거는 컬러 RAW 이미지에만 사용됨"
 
-#: ../src/iop/demosaicing/capture.c:748
-msgid "imprecise radius calculation due to cropping or because you are zoomed in too much"
+#: ../src/iop/demosaicing/capture.c:795
+msgid ""
+"imprecise radius calculation due to cropping or because you are zoomed in "
+"too much"
 msgstr "자르기 또는 너무 많이 확대하여 반지름 계산이 부정확함"
 
 #: ../src/iop/denoiseprofile.c:807
@@ -19206,35 +22773,35 @@ msgstr "노이즈 제거 (프로파일 기반)"
 msgid "denoise using noise statistics profiled on sensors"
 msgstr "센서 기반 노이즈 통계를 사용해 노이즈 제거"
 
-#: ../src/iop/denoiseprofile.c:3020
+#: ../src/iop/denoiseprofile.c:2844
 #, c-format
 msgid "found ISO %d (ISO %d %+d EV)"
 msgstr "ISO %d 발견 (ISO %d %+d EV)"
 
-#: ../src/iop/denoiseprofile.c:3024
+#: ../src/iop/denoiseprofile.c:2848
 #, c-format
 msgid "found ISO %d"
 msgstr "ISO %d 발견"
 
-#: ../src/iop/denoiseprofile.c:3041
+#: ../src/iop/denoiseprofile.c:2865
 #, c-format
 msgid "interpolated ISO %d (ISO %d %+d EV)"
 msgstr "보간된 ISO %d (ISO %d %+d EV)"
 
-#: ../src/iop/denoiseprofile.c:3045
+#: ../src/iop/denoiseprofile.c:2869
 #, c-format
 msgid "interpolated ISO %d"
 msgstr "보간된 ISO  %d"
 
-#: ../src/iop/denoiseprofile.c:3781
+#: ../src/iop/denoiseprofile.c:3605
 msgid "Y0"
 msgstr "Y0"
 
-#: ../src/iop/denoiseprofile.c:3782
+#: ../src/iop/denoiseprofile.c:3606
 msgid "U0V0"
 msgstr "U0V0"
 
-#: ../src/iop/denoiseprofile.c:3820
+#: ../src/iop/denoiseprofile.c:3644
 msgid ""
 "use only with a perfectly\n"
 "uniform image if you want to\n"
@@ -19244,36 +22811,37 @@ msgstr ""
 "완전히 균일한 이미지에서만\n"
 "사용해야 합니다."
 
-#: ../src/iop/denoiseprofile.c:3826
+#: ../src/iop/denoiseprofile.c:3650
 msgid "variance computed on the red channel"
 msgstr "빨간색 채널에서 계산된 분산"
 
-#: ../src/iop/denoiseprofile.c:3830
+#: ../src/iop/denoiseprofile.c:3654
 msgid "variance computed on the green channel"
 msgstr "초록색 채널에서 계산된 분산"
 
-#: ../src/iop/denoiseprofile.c:3835
+#: ../src/iop/denoiseprofile.c:3659
 msgid "variance computed on the blue channel"
 msgstr "파란색 채널에서 계산된 분산"
 
-#: ../src/iop/denoiseprofile.c:3838
+#: ../src/iop/denoiseprofile.c:3662
 msgid "variance red: "
 msgstr "빨간색 분산: "
 
-#: ../src/iop/denoiseprofile.c:3839
+#: ../src/iop/denoiseprofile.c:3663
 msgid "variance green: "
 msgstr "초록색 분산: "
 
-#: ../src/iop/denoiseprofile.c:3840
+#: ../src/iop/denoiseprofile.c:3664
 msgid "variance blue: "
 msgstr "파란색 분산: "
 
-#: ../src/iop/denoiseprofile.c:3848 ../src/libs/export.c:1582
-#: ../src/libs/print_settings.c:2496 ../src/libs/print_settings.c:2852
+#: ../src/iop/denoiseprofile.c:3672 ../src/libs/export.c:1600
+#: ../src/libs/neural_restore.c:4410 ../src/libs/print_settings.c:2516
+#: ../src/libs/print_settings.c:2872
 msgid "profile"
 msgstr "프로파일"
 
-#: ../src/iop/denoiseprofile.c:3882
+#: ../src/iop/denoiseprofile.c:3706
 msgid ""
 "adapt denoising according to the\n"
 "white balance coefficients.\n"
@@ -19289,7 +22857,7 @@ msgstr ""
 "이전에 색상 혼합 모드가 사용된 인스턴스가 있다면\n"
 "비활성화하는 것이 좋습니다."
 
-#: ../src/iop/denoiseprofile.c:3888
+#: ../src/iop/denoiseprofile.c:3712
 msgid ""
 "if enabled, reduces the ISO used for denoise\n"
 "by the factor of the camera's hidden exposure\n"
@@ -19301,7 +22869,7 @@ msgstr ""
 "카메라의 숨겨진 노출 편향 계수를 적용하여 \n"
 "노이즈 제거에 사용되는 ISO를 해당 계수만큼 감소시킵니다."
 
-#: ../src/iop/denoiseprofile.c:3893
+#: ../src/iop/denoiseprofile.c:3717
 msgid ""
 "fix bugs in Anscombe transform resulting\n"
 "in undersmoothing of the green channel in\n"
@@ -19321,11 +22889,11 @@ msgstr ""
 "이 옵션을 활성화하면 노이즈 제거 방식이 변경됩니다.\n"
 "한 번 활성화하면 이전 알고리즘으로 되돌릴 수 없습니다."
 
-#: ../src/iop/denoiseprofile.c:3903
+#: ../src/iop/denoiseprofile.c:3727
 msgid "profile used for variance stabilization"
 msgstr "분산 안정화를 위해 사용되는 프로파일"
 
-#: ../src/iop/denoiseprofile.c:3905
+#: ../src/iop/denoiseprofile.c:3729
 msgid ""
 "method used in the denoising core.\n"
 "non-local means works best for `lightness' blending,\n"
@@ -19335,7 +22903,7 @@ msgstr ""
 "'명도' 블렌딩에는 비지역 평균 방식이 가장 적합하고,\n"
 "'색상' 블렌딩에는 웨이브릿 방식이 가장 효과적입니다"
 
-#: ../src/iop/denoiseprofile.c:3909
+#: ../src/iop/denoiseprofile.c:3733
 msgid ""
 "color representation used within the algorithm.\n"
 "RGB keeps the RGB channels separated,\n"
@@ -19347,21 +22915,26 @@ msgstr ""
 "Y0U0V0는 채널을 결합하여\n"
 "색차와 휘도를 분리하여 노이즈를 제거합니다."
 
-#: ../src/iop/denoiseprofile.c:3914
+#: ../src/iop/denoiseprofile.c:3738
 msgid ""
 "radius of the patches to match.\n"
-"increase for more sharpness on strong edges, and better denoising of smooth areas.\n"
-"if details are oversmoothed, reduce this value or increase the central pixel weight slider."
+"increase for more sharpness on strong edges, and better denoising of smooth "
+"areas.\n"
+"if details are oversmoothed, reduce this value or increase the central pixel "
+"weight slider."
 msgstr ""
 "매칭할 패치의 반지름 설정.\n"
 "값을 높이면 강한 경계에서 선명도가 증가하고, 부드러운 영역에서는 노이즈 제거 성능이 향상됩니다.\n"
 "세부 정보가 과도하게 부드러워지면 반지름 값을 줄이거나 중심 픽셀 가중치 슬라이더 값을 높이세요."
 
-#: ../src/iop/denoiseprofile.c:3920
-msgid "emergency use only: radius of the neighborhood to search patches in. increase for better denoising performance, but watch the long runtimes! large radii can be very slow. you have been warned"
+#: ../src/iop/denoiseprofile.c:3744
+msgid ""
+"emergency use only: radius of the neighborhood to search patches in. "
+"increase for better denoising performance, but watch the long runtimes! "
+"large radii can be very slow. you have been warned"
 msgstr "비상시에만 사용: 패치를 검색할 이웃 영역의 반지름을 설정합니다.값을 높이면 노이즈 제거 성능이 향상되지만, 처리 시간이 매우 길어질 수 있습니다. 큰 반지름은 속도를 크게 떨어뜨릴 수 있으니 주의하세요"
 
-#: ../src/iop/denoiseprofile.c:3926
+#: ../src/iop/denoiseprofile.c:3750
 msgid ""
 "scattering of the neighborhood to search patches in.\n"
 "increase for better coarse-grain noise reduction.\n"
@@ -19371,7 +22944,7 @@ msgstr ""
 "값을 높이면 거친 노이즈 제거 성능이 향상됩니다.\n"
 "실행 시간에는 영향을 주지 않습니다."
 
-#: ../src/iop/denoiseprofile.c:3930
+#: ../src/iop/denoiseprofile.c:3754
 msgid ""
 "increase the weight of the central pixel\n"
 "of the patch in the patch comparison.\n"
@@ -19381,11 +22954,11 @@ msgstr ""
 "패치 비교 시 중심 픽셀의 가중치를 높입니다.\n"
 "패치 크기가 클 때 세부 정보를 복원하는 데 유용합니다."
 
-#: ../src/iop/denoiseprofile.c:3934
+#: ../src/iop/denoiseprofile.c:3758
 msgid "finetune denoising strength"
 msgstr "노이즈 제거 강도를 미세 조정"
 
-#: ../src/iop/denoiseprofile.c:3936
+#: ../src/iop/denoiseprofile.c:3760
 msgid ""
 "controls the way parameters are autoset.\n"
 "increase if shadows are not denoised enough\n"
@@ -19397,7 +22970,7 @@ msgstr ""
 "색차 노이즈가 남아 있는 경우 값을 높이세요.\n"
 "이는 이미지가 노출 부족일 때 발생할 수 있습니다."
 
-#: ../src/iop/denoiseprofile.c:3941
+#: ../src/iop/denoiseprofile.c:3765
 msgid ""
 "finetune shadows denoising.\n"
 "decrease to denoise more aggressively\n"
@@ -19407,7 +22980,7 @@ msgstr ""
 "값을 낮추면 이미지의 어두운 영역의\n"
 "노이즈를 더 강하게 제거합니다."
 
-#: ../src/iop/denoiseprofile.c:3945
+#: ../src/iop/denoiseprofile.c:3769
 msgid ""
 "correct color cast in shadows.\n"
 "decrease if shadows are too purple.\n"
@@ -19417,7 +22990,7 @@ msgstr ""
 "쉐도우가 보라색에 가깝다면 감소합니다.\n"
 "녹색에 가깝다면 증가합니다."
 
-#: ../src/iop/denoiseprofile.c:3949
+#: ../src/iop/denoiseprofile.c:3773
 msgid ""
 "upgrade the variance stabilizing algorithm.\n"
 "new algorithm extends the current one.\n"
@@ -19434,7 +23007,9 @@ msgid "diffuse or sharpen"
 msgstr "확산 또는 샤프닝"
 
 #: ../src/iop/diffuse.c:129
-msgid "diffusion|deconvolution|blur|sharpening|bloom|clarity|dehaze|denoise|inpaint|watercolor"
+msgid ""
+"diffusion|deconvolution|blur|sharpening|bloom|clarity|dehaze|denoise|inpaint|"
+"watercolor"
 msgstr "확산|복원|블러|샤프닝|블룸 효과|명료도|안개 제거|노이즈 제거|보정 복원|수채화 효과"
 
 #: ../src/iop/diffuse.c:136
@@ -19531,19 +23106,19 @@ msgstr "선명도 | 강하게"
 msgid "local contrast | fast"
 msgstr "부분 대비 | 빠르게"
 
-#: ../src/iop/diffuse.c:1402
+#: ../src/iop/diffuse.c:1401
 msgid "diffuse/sharpen failed to allocate memory, check your RAM settings"
 msgstr "확산/샤프닝 메모리 할당에 실패했습니다, RAM 설정을 확인하세요"
 
 #. Additional parameters
 #. Camera settings
-#: ../src/iop/diffuse.c:1769 ../src/iop/splittoning.c:516
+#: ../src/iop/diffuse.c:1762 ../src/iop/splittoning.c:516
 #: ../src/libs/camera.c:509
 msgctxt "section"
 msgid "properties"
 msgstr "속성"
 
-#: ../src/iop/diffuse.c:1775
+#: ../src/iop/diffuse.c:1768
 msgid ""
 "more iterations make the effect stronger but the module slower.\n"
 "this is analogous to giving more time to the diffusion reaction.\n"
@@ -19555,7 +23130,7 @@ msgstr ""
 "샤프닝이나 복원을 계획 중이라면\n"
 "반복 횟수를 늘리는 것이 복원에 도움이 됩니다."
 
-#: ../src/iop/diffuse.c:1784
+#: ../src/iop/diffuse.c:1777
 msgid ""
 "main scale of the diffusion.\n"
 "zero makes diffusion act on the finest details more heavily.\n"
@@ -19569,7 +23144,7 @@ msgstr ""
 "블러 제거나 노이즈 제거에는 0으로 설정하세요.\n"
 "지역 대비에 작용하려면 값을 증가시키세요."
 
-#: ../src/iop/diffuse.c:1794
+#: ../src/iop/diffuse.c:1787
 msgid ""
 "width of the diffusion around the central radius.\n"
 "high values diffuse on a large band of radii.\n"
@@ -19583,12 +23158,12 @@ msgstr ""
 "블러를 제거하려는 경우,\n"
 "반지름은 렌즈 블러의 너비에 맞추는 것이 좋습니다."
 
-#: ../src/iop/diffuse.c:1800
+#: ../src/iop/diffuse.c:1793
 msgctxt "section"
 msgid "speed (sharpen ↔ diffuse)"
 msgstr "속도 (샤프닝 ↔ 확산)"
 
-#: ../src/iop/diffuse.c:1806
+#: ../src/iop/diffuse.c:1799
 msgid ""
 "diffusion speed of low-frequency wavelet layers\n"
 "in the direction of 1st order anisotropy (set below).\n"
@@ -19604,7 +23179,7 @@ msgstr ""
 "양수는 확산 및 블러,\n"
 "0은 무작용."
 
-#: ../src/iop/diffuse.c:1816
+#: ../src/iop/diffuse.c:1809
 msgid ""
 "diffusion speed of low-frequency wavelet layers\n"
 "in the direction of 2nd order anisotropy (set below).\n"
@@ -19620,7 +23195,7 @@ msgstr ""
 "양수는 확산 및 블러,\n"
 "0은 무작용."
 
-#: ../src/iop/diffuse.c:1826
+#: ../src/iop/diffuse.c:1819
 msgid ""
 "diffusion speed of high-frequency wavelet layers\n"
 "in the direction of 3rd order anisotropy (set below).\n"
@@ -19636,7 +23211,7 @@ msgstr ""
 "양수는 확산 및 블러,\n"
 "0은 무작용."
 
-#: ../src/iop/diffuse.c:1836
+#: ../src/iop/diffuse.c:1829
 msgid ""
 "diffusion speed of high-frequency wavelet layers\n"
 "in the direction of 4th order anisotropy (set below).\n"
@@ -19652,12 +23227,12 @@ msgstr ""
 "양수는 확산 및 블러,\n"
 "0은 변화 없음."
 
-#: ../src/iop/diffuse.c:1842
+#: ../src/iop/diffuse.c:1835
 msgctxt "section"
 msgid "direction"
 msgstr "방향"
 
-#: ../src/iop/diffuse.c:1848
+#: ../src/iop/diffuse.c:1841
 msgid ""
 "direction of 1st order speed (set above).\n"
 "\n"
@@ -19671,7 +23246,7 @@ msgstr ""
 "양수는 가장자리 (등광선)를 피하려는 경향이 있습니다.\n"
 "0은 양쪽에 동일하게 작용합니다 (등방성)."
 
-#: ../src/iop/diffuse.c:1857
+#: ../src/iop/diffuse.c:1850
 msgid ""
 "direction of 2nd order speed (set above).\n"
 "\n"
@@ -19685,7 +23260,7 @@ msgstr ""
 "양수는 가장자리 (등광선)를 피하려는 경향이 있습니다.\n"
 "0은 양쪽에 동일하게 작용합니다 (등방성)."
 
-#: ../src/iop/diffuse.c:1866
+#: ../src/iop/diffuse.c:1859
 msgid ""
 "direction of 3rd order speed (set above).\n"
 "\n"
@@ -19699,7 +23274,7 @@ msgstr ""
 "양수는 가장자리 (등광선)를 피하려는 경향이 있습니다.\n"
 "0은 양쪽에 동일하게 작용합니다 (등방성)."
 
-#: ../src/iop/diffuse.c:1875
+#: ../src/iop/diffuse.c:1868
 msgid ""
 "direction of 4th order speed (set above).\n"
 "\n"
@@ -19713,12 +23288,12 @@ msgstr ""
 "양수는 가장자리 (등광선)를 피하려는 경향이 있습니다.\n"
 "0은 양쪽에 동일하게 작용합니다 (등방성)."
 
-#: ../src/iop/diffuse.c:1880
+#: ../src/iop/diffuse.c:1873
 msgctxt "section"
 msgid "edge management"
 msgstr "가장자리 처리"
 
-#: ../src/iop/diffuse.c:1888
+#: ../src/iop/diffuse.c:1881
 msgid ""
 "increase or decrease the sharpness of the highest frequencies.\n"
 "can be used to keep details after blooming,\n"
@@ -19728,7 +23303,7 @@ msgstr ""
 "이 설정은 블룸 효과 이후에도 디테일을 유지하는 데 사용할 수 있으며,\n"
 "단독으로 선명화를 적용하려는 경우 속도를 음수로 설정하면 됩니다."
 
-#: ../src/iop/diffuse.c:1895
+#: ../src/iop/diffuse.c:1888
 msgid ""
 "define the sensitivity of the variance penalty for edges.\n"
 "increase to exclude more edges from diffusion,\n"
@@ -19738,7 +23313,7 @@ msgstr ""
 "프린지나 헤일로가 나타나는 경우 값을 높이면\n"
 "더 많은 가장자리를 확산 대상에서 제외할 수 있습니다."
 
-#: ../src/iop/diffuse.c:1902
+#: ../src/iop/diffuse.c:1895
 msgid ""
 "define the variance threshold between edge amplification and penalty.\n"
 "decrease if you want pixels on smooth surfaces get a boost,\n"
@@ -19750,15 +23325,16 @@ msgstr ""
 "부드러운 영역에 노이즈가 생기거나 쉐도우가 하이라이트에 비해\n"
 "과도하게 선명해 보인다면 값을 높이세요."
 
-#: ../src/iop/diffuse.c:1907
+#: ../src/iop/diffuse.c:1900
 msgctxt "section"
 msgid "diffusion spatiality"
 msgstr "확산 공간성"
 
-#: ../src/iop/diffuse.c:1913
+#: ../src/iop/diffuse.c:1906
 msgid ""
 "luminance threshold for the mask.\n"
-"0. disables the luminance masking and applies the module on the whole image.\n"
+"0. disables the luminance masking and applies the module on the whole "
+"image.\n"
 "any higher value excludes pixels with luminance lower than the threshold.\n"
 "this can be used to inpaint highlights."
 msgstr ""
@@ -19808,23 +23384,31 @@ msgstr "왼쪽, 위, 오른쪽 또는 아래에 빈 공간 추가"
 msgid "composition|expand|extend"
 msgstr "컴포지션|확장|연장"
 
-#: ../src/iop/enlargecanvas.c:417
-msgid "how much to enlarge the canvas to the left as a percentage of the original image width"
+#: ../src/iop/enlargecanvas.c:422
+msgid ""
+"how much to enlarge the canvas to the left as a percentage of the original "
+"image width"
 msgstr "원본 이미지 너비 대비 왼쪽으로 확장할 캔버스 비율"
 
-#: ../src/iop/enlargecanvas.c:423
-msgid "how much to enlarge the canvas to the right as a percentage of the original image width"
+#: ../src/iop/enlargecanvas.c:428
+msgid ""
+"how much to enlarge the canvas to the right as a percentage of the original "
+"image width"
 msgstr "원본 이미지 너비 대비 오른쪽으로 확장할 캔버스 비율"
 
-#: ../src/iop/enlargecanvas.c:429
-msgid "how much to enlarge the canvas to the top as a percentage of the original image height"
+#: ../src/iop/enlargecanvas.c:434
+msgid ""
+"how much to enlarge the canvas to the top as a percentage of the original "
+"image height"
 msgstr "원본 이미지 높이 대비 위쪽으로 확장할 캔버스 비율"
 
-#: ../src/iop/enlargecanvas.c:435
-msgid "how much to enlarge the canvas to the bottom as a percentage of the original image height"
+#: ../src/iop/enlargecanvas.c:440
+msgid ""
+"how much to enlarge the canvas to the bottom as a percentage of the original "
+"image height"
 msgstr "원본 이미지 높이 대비 아래쪽으로 확장할 캔버스 비율"
 
-#: ../src/iop/enlargecanvas.c:439
+#: ../src/iop/enlargecanvas.c:444
 msgid "select the color of the enlarged canvas"
 msgstr "확장된 캔버스의 색상 선택"
 
@@ -19833,7 +23417,8 @@ msgid "legacy equalizer"
 msgstr "레거시 이퀄라이저"
 
 #: ../src/iop/equalizer.c:109
-msgid "this module is deprecated. better use contrast equalizer module instead."
+msgid ""
+"this module is deprecated. better use contrast equalizer module instead."
 msgstr "이 모듈은 더 이상 사용되지 않습니다. 대신 대비 이퀄라이저 모듈을 사용하는 것이 좋습니다."
 
 #: ../src/iop/equalizer.c:236
@@ -19858,8 +23443,8 @@ msgstr ""
 msgid "magic lantern defaults"
 msgstr "매직 랜턴 기본값"
 
-#: ../src/iop/exposure.c:388 ../src/iop/rawoverexposed.c:133
-#: ../src/iop/rawoverexposed.c:244
+#: ../src/iop/exposure.c:388 ../src/iop/rawoverexposed.c:137
+#: ../src/iop/rawoverexposed.c:239
 #, c-format
 msgid "failed to get raw buffer from image `%s'"
 msgstr "이미지 `%s'에서 RAW 버퍼를 가져오는 데 실패함"
@@ -19875,17 +23460,17 @@ msgid "highlight preservation mode (%.1f EV)"
 msgstr "하이라이트 보존 모드 (%.1f EV)"
 
 #. Write report in GUI
-#: ../src/iop/exposure.c:894
+#: ../src/iop/exposure.c:896
 #, c-format
 msgid "L : \t%.1f %%"
 msgstr "L : \t%.1f %%"
 
-#: ../src/iop/exposure.c:1034 ../src/libs/history.c:949
+#: ../src/iop/exposure.c:1036 ../src/libs/history.c:949
 #, c-format
 msgid "%.2f EV"
 msgstr "%.2f EV"
 
-#: ../src/iop/exposure.c:1199
+#: ../src/iop/exposure.c:1201
 msgid ""
 "automatically remove the camera exposure bias\n"
 "this is useful if you exposed the image to the right."
@@ -19893,7 +23478,7 @@ msgstr ""
 "카메라의 노출 바이어스를 자동으로 제거\n"
 "이미지를 오른쪽으로 노출시킨 경우에 유용합니다."
 
-#: ../src/iop/exposure.c:1205
+#: ../src/iop/exposure.c:1207
 msgid ""
 "remove the camera's hidden exposure bias in\n"
 "HDR / highlight preservation / dynamic range / HLG tone mode.\n"
@@ -19907,28 +23492,29 @@ msgstr ""
 "0이 아닌 바이어스가 있는 이미지에서 활성화하면 톤 매핑\n"
 "(예: 시그모이드)이 필요하므로 하이라이트가 잘려나가는 것을 막을 수 있습니다."
 
-#: ../src/iop/exposure.c:1217
+#: ../src/iop/exposure.c:1219
 msgid "set the exposure adjustment using the selected area"
 msgstr "선택한 영역을 기준으로 노출 조정 설정"
 
-#: ../src/iop/exposure.c:1228
+#: ../src/iop/exposure.c:1230
 #, no-c-format
 msgid "where in the histogram to meter for deflicking. E.g. 50% is median"
 msgstr "디플리커링을 위한 측광 기준을 히스토그램에서 어디에 둘지 설정합니다. 예: 50%는 중앙값입니다"
 
-#: ../src/iop/exposure.c:1234
-msgid "where to place the exposure level for processed pics, EV below overexposure."
+#: ../src/iop/exposure.c:1236
+msgid ""
+"where to place the exposure level for processed pics, EV below overexposure."
 msgstr "처리된 이미지의 노출 수준을 어느 위치에 둘지 설정합니다. EV 값은 과노출보다 낮게 설정됩니다."
 
-#: ../src/iop/exposure.c:1238
+#: ../src/iop/exposure.c:1240
 msgid "what exposure correction has actually been used"
 msgstr "실제로 적용된 노출 보정값"
 
-#: ../src/iop/exposure.c:1244
+#: ../src/iop/exposure.c:1246
 msgid "computed EC: "
 msgstr "계산된 EC: "
 
-#: ../src/iop/exposure.c:1257
+#: ../src/iop/exposure.c:1259
 msgid ""
 "adjust the black level to unclip negative RGB values.\n"
 "you should never use it to add more density in blacks!\n"
@@ -19940,11 +23526,11 @@ msgstr ""
 "잘못 설정하면 RGB 값이 음수로 밀리며\n"
 "암부 색상이 색상 영역 밖으로 클리핑될 수 있습니다."
 
-#: ../src/iop/exposure.c:1267
+#: ../src/iop/exposure.c:1269
 msgid "area exposure mapping"
 msgstr "영역 노출 매핑"
 
-#: ../src/iop/exposure.c:1273
+#: ../src/iop/exposure.c:1275
 msgid ""
 "define a target brightness, in terms of exposure,\n"
 "for a selected region of the image (the control sample),\n"
@@ -19961,7 +23547,7 @@ msgstr ""
 "시리즈 이미지 전체에서 움직이지 않고\n"
 "일정하게 광원된 표면일 수 있습니다."
 
-#: ../src/iop/exposure.c:1282
+#: ../src/iop/exposure.c:1284
 msgid ""
 "\"correction\" automatically adjust exposure\n"
 "such that the input lightness is mapped to the target.\n"
@@ -19973,11 +23559,11 @@ msgstr ""
 "\"측정\"은 입력 색상이 노출 보정에 의해 어떻게 매핑되는지를 보여주며,\n"
 "이를 통해 목표 값을 정의할 수 있습니다."
 
-#: ../src/iop/exposure.c:1300
+#: ../src/iop/exposure.c:1302
 msgid "L : \tN/A"
 msgstr "L : \tN/A"
 
-#: ../src/iop/exposure.c:1310
+#: ../src/iop/exposure.c:1312
 msgid "the desired target exposure after mapping"
 msgstr "매핑 후 원하는 목표 노출"
 
@@ -20021,11 +23607,11 @@ msgstr "16 EV (HDR)"
 msgid "18 EV (HDR++)"
 msgstr "16 EV (HDR++)"
 
-#: ../src/iop/filmic.c:1461
+#: ../src/iop/filmic.c:1462
 msgid "read-only graph, use the parameters below to set the nodes"
 msgstr "읽기 전용 그래프, 아래 파라메터를 사용하여 노드를 설정하세요"
 
-#: ../src/iop/filmic.c:1469
+#: ../src/iop/filmic.c:1471
 msgid ""
 "adjust to match the average luminance of the subject.\n"
 "except in back-lighting situations, this should be around 18%."
@@ -20033,7 +23619,7 @@ msgstr ""
 "피사체의 평균 휘도에 맞게 조정.\n"
 "역광 상황이 아니라면 일반적으로 약 18% 정도가 적절합니다."
 
-#: ../src/iop/filmic.c:1480 ../src/iop/filmicrgb.c:4402
+#: ../src/iop/filmic.c:1483 ../src/iop/filmicrgb.c:4387
 msgid ""
 "number of stops between middle gray and pure white.\n"
 "this is a reading a lightmeter would give you on the scene.\n"
@@ -20043,7 +23629,7 @@ msgstr ""
 "현장에서 노출계가 보여주는 값에 해당합니다.\n"
 "하이라이트 클리핑이 발생하지 않도록 조정해야 합니다"
 
-#: ../src/iop/filmic.c:1492 ../src/iop/filmicrgb.c:4413
+#: ../src/iop/filmic.c:1496 ../src/iop/filmicrgb.c:4398
 msgid ""
 "number of stops between middle gray and pure black.\n"
 "this is a reading a lightmeter would give you on the scene.\n"
@@ -20055,7 +23641,7 @@ msgstr ""
 "값을 높이면 대비가 증가합니다.\n"
 "값을 낮추면 암부 디테일을 더 많이 복원할 수 있습니다."
 
-#: ../src/iop/filmic.c:1503
+#: ../src/iop/filmic.c:1509
 msgid ""
 "increase or decrease the computed dynamic range.\n"
 "useful in conjunction with \"auto tune levels\"."
@@ -20063,7 +23649,7 @@ msgstr ""
 "계산된 다이나믹 레인지를 증가 또는 감소시킵니다.\n"
 "\"자동 레벨 조정\"과 함께 사용하면 효과적입니다."
 
-#: ../src/iop/filmic.c:1512
+#: ../src/iop/filmic.c:1519
 msgid ""
 "try to optimize the settings with some guessing.\n"
 "this will fit the luminance range inside the histogram bounds.\n"
@@ -20075,7 +23661,7 @@ msgstr ""
 "풍경이나 고르게 광원된 이미지에서 효과적이나\n"
 "하이 키나 로우 키 이미지에는 적합하지 않습니다."
 
-#: ../src/iop/filmic.c:1520 ../src/iop/filmicrgb.c:4510
+#: ../src/iop/filmic.c:1529 ../src/iop/filmicrgb.c:4499
 msgid ""
 "slope of the linear part of the curve\n"
 "affects mostly the mid-tones"
@@ -20083,13 +23669,7 @@ msgstr ""
 "커브의 선형 구간 기울기\n"
 "주로 중간 톤에 영향을 줍니다"
 
-#. geotagging
-#: ../src/iop/filmic.c:1527 ../src/iop/filmicrgb.c:4519
-#: ../src/libs/metadata_view.c:169
-msgid "latitude"
-msgstr "노출 관용도"
-
-#: ../src/iop/filmic.c:1529
+#: ../src/iop/filmic.c:1539
 msgid ""
 "width of the linear domain in the middle of the curve.\n"
 "increase to get more contrast at the extreme luminances.\n"
@@ -20099,11 +23679,11 @@ msgstr ""
 "값을 높이면 극단적인 밝기에서 더 큰 휘도를 얻을 수 있습니다.\n"
 "중간 톤에는 영향 없습니다."
 
-#: ../src/iop/filmic.c:1536
+#: ../src/iop/filmic.c:1546
 msgid "shadows/highlights balance"
 msgstr "쉐도우/하이라이트 균형"
 
-#: ../src/iop/filmic.c:1538 ../src/iop/filmicrgb.c:4530
+#: ../src/iop/filmic.c:1549 ../src/iop/filmicrgb.c:4521
 msgid ""
 "slides the latitude along the slope\n"
 "to give more room to shadows or highlights.\n"
@@ -20114,7 +23694,7 @@ msgstr ""
 "쉐도우나 하이라이트 영역에 더 많은 공간을 부여합니다.\n"
 "히스토그램의 한쪽 끝에서 디테일을 보호하고 싶을 때 사용하세요."
 
-#: ../src/iop/filmic.c:1547
+#: ../src/iop/filmic.c:1561
 msgid ""
 "desaturates the input of the module globally.\n"
 "you need to set this value below 100%\n"
@@ -20123,7 +23703,7 @@ msgstr ""
 "입력을 전체적으로 채도를 감소시킵니다.\n"
 "색차 보존이 활성화된 경우 100% 이하로 설정해야 합니다."
 
-#: ../src/iop/filmic.c:1556
+#: ../src/iop/filmic.c:1572
 msgid ""
 "desaturates the output of the module\n"
 "specifically at extreme luminances.\n"
@@ -20133,37 +23713,36 @@ msgstr ""
 "쉐도우나 하이라이트의 채도가 지나칠 경우 값을 낮춥니다."
 
 #. Add export intent combo
-#: ../src/iop/filmic.c:1566 ../src/libs/export.c:1600
-#: ../src/libs/print_settings.c:2551 ../src/libs/print_settings.c:2898
-#: ../src/views/darkroom.c:2751 ../src/views/lighttable.c:1262
+#: ../src/iop/filmic.c:1583 ../src/libs/export.c:1618
+#: ../src/libs/print_settings.c:2571 ../src/libs/print_settings.c:2918
+#: ../src/views/darkroom.c:3376 ../src/views/lighttable.c:1495
 msgid "intent"
 msgstr "방식"
 
-#: ../src/iop/filmic.c:1567
+#: ../src/iop/filmic.c:1584
 msgid "contrasted"
 msgstr "고대비"
 
 #. centripetal spline
-#: ../src/iop/filmic.c:1569 ../src/iop/profile_gamma.c:607
+#: ../src/iop/filmic.c:1586 ../src/iop/profile_gamma.c:602
 msgid "linear"
 msgstr "선형"
 
 #. monotonic spline
-#: ../src/iop/filmic.c:1570
+#: ../src/iop/filmic.c:1587
 msgid "optimized"
 msgstr "최적 설정"
 
-#. monotonic spline
-#: ../src/iop/filmic.c:1571
+#: ../src/iop/filmic.c:1589
 msgid "change this method if you see reversed contrast or faded blacks"
 msgstr "대비가 반전되거나 검은색이 흐릿해 보일 경우 이 방법을 변경하세요"
 
 #. Preserve color
-#: ../src/iop/filmic.c:1575
+#: ../src/iop/filmic.c:1593
 msgid "preserve the chrominance"
 msgstr "색도 유지"
 
-#: ../src/iop/filmic.c:1577
+#: ../src/iop/filmic.c:1596
 msgid ""
 "ensure the original color are preserved.\n"
 "may reinforce chromatic aberrations.\n"
@@ -20173,7 +23752,7 @@ msgstr ""
 "색수차가 강조될 수 있습니다.\n"
 "이 모드를 사용할 경우 채도를 수동으로 조정해야 합니다,"
 
-#: ../src/iop/filmic.c:1586 ../src/iop/filmicrgb.c:4549
+#: ../src/iop/filmic.c:1606 ../src/iop/filmicrgb.c:4542
 msgid ""
 "luminance of output pure black, this should be 0%\n"
 "except if you want a faded look"
@@ -20181,7 +23760,7 @@ msgstr ""
 "출력 순수 흑색의 휘도는 일반적으로 0%로 설정하지만,\n"
 "바랜 느낌을 원할 경우 예외적으로 조정할 수 있습니다"
 
-#: ../src/iop/filmic.c:1594 ../src/iop/filmicrgb.c:4556
+#: ../src/iop/filmic.c:1615 ../src/iop/filmicrgb.c:4549
 msgid ""
 "middle gray value of the target display or color space.\n"
 "you should never touch that unless you know what you are doing."
@@ -20189,7 +23768,7 @@ msgstr ""
 "목표 디스플레이나 색공간의 중간 회색 값입니다.\n"
 "특별한 목적이 없다면 변경하지 않는 것이 좋습니다."
 
-#: ../src/iop/filmic.c:1602 ../src/iop/filmicrgb.c:4563
+#: ../src/iop/filmic.c:1624 ../src/iop/filmicrgb.c:4557
 msgid ""
 "luminance of output pure white, this should be 100%\n"
 "except if you want a faded look"
@@ -20197,11 +23776,11 @@ msgstr ""
 "출력 순백색의 휘도는 일반적으로는 100%로 설정해야 하며,\n"
 "흐릿한 느낌을 원할 경우에만 조정합니다"
 
-#: ../src/iop/filmic.c:1608
+#: ../src/iop/filmic.c:1630
 msgid "target gamma"
 msgstr "목표 감마"
 
-#: ../src/iop/filmic.c:1609
+#: ../src/iop/filmic.c:1632
 msgid ""
 "power or gamma of the transfer function\n"
 "of the display or color space.\n"
@@ -20211,30 +23790,30 @@ msgstr ""
 "거듭제곱 또는 감마 값입니다.\n"
 "이 항목은 특별한 목적이 있는 경우가 아니라면 변경하지 않는 것이 좋습니다."
 
-#: ../src/iop/filmic.c:1616
+#: ../src/iop/filmic.c:1640
 msgctxt "section"
 msgid "destination/display"
 msgstr "대상/디스플레이"
 
-#: ../src/iop/filmic.c:1625
+#: ../src/iop/filmic.c:1649
 msgctxt "section"
 msgid "logarithmic shaper"
 msgstr "로그 셰이퍼"
 
-#: ../src/iop/filmic.c:1631
+#: ../src/iop/filmic.c:1655
 msgctxt "section"
 msgid "filmic S curve"
 msgstr "필믹 S 커브"
 
-#: ../src/iop/filmicrgb.c:337
+#: ../src/iop/filmicrgb.c:331
 msgid "filmic rgb"
 msgstr "필믹 rgb"
 
-#: ../src/iop/filmicrgb.c:342
+#: ../src/iop/filmicrgb.c:336
 msgid "tone mapping|curve|view transform|contrast|saturation|highlights"
 msgstr "톤 매핑|커브|장면 변환|대비|채도|하이라이트"
 
-#: ../src/iop/filmicrgb.c:347
+#: ../src/iop/filmicrgb.c:341
 msgid ""
 "apply a view transform to prepare the scene-referred pipeline\n"
 "for display on SDR screens and paper prints\n"
@@ -20244,75 +23823,76 @@ msgstr ""
 "출력할 수 있도록 보기 변환을 적용합니다\n"
 "클리핑 없이 출력할 수 있도록 비파괴 방식으로 처리합니다"
 
-#: ../src/iop/filmicrgb.c:1316
-msgid "filmic highlights reconstruction failed to allocate memory, check your RAM settings"
+#: ../src/iop/filmicrgb.c:1305
+msgid ""
+"filmic highlights reconstruction failed to allocate memory, check your RAM "
+"settings"
 msgstr "필믹 하이라이트 복원에 필요한 메모리 할당에 실패했습니다, RAM 설정을 확인하세요"
 
-#: ../src/iop/filmicrgb.c:2262
+#: ../src/iop/filmicrgb.c:2250
 msgid "filmic highlights reconstruction failed to allocate memory on GPU"
 msgstr "필믹 하이라이트 복원에서 GPU에서 메모리 할당에 실패했습니다"
 
-#: ../src/iop/filmicrgb.c:2380
+#: ../src/iop/filmicrgb.c:2366
 msgid "filmic works only on RGB input"
 msgstr "필믹은 RGB 입력에서만 작동합니다"
 
-#: ../src/iop/filmicrgb.c:3444
+#: ../src/iop/filmicrgb.c:3425
 msgid "look only"
 msgstr "보기 전용"
 
-#: ../src/iop/filmicrgb.c:3446
+#: ../src/iop/filmicrgb.c:3427
 msgid "look + mapping (lin)"
 msgstr "룩 + 매핑 (선형)"
 
-#: ../src/iop/filmicrgb.c:3448
+#: ../src/iop/filmicrgb.c:3429
 msgid "look + mapping (log)"
 msgstr "룩 + 매핑 (로그)"
 
-#: ../src/iop/filmicrgb.c:3450
+#: ../src/iop/filmicrgb.c:3431
 msgid "dynamic range mapping"
 msgstr "다이나믹 레인지 매핑"
 
-#: ../src/iop/filmicrgb.c:3817
+#: ../src/iop/filmicrgb.c:3798
 #, c-format
 msgid "(%.0f %%)"
 msgstr "(%.0f %%)"
 
-#: ../src/iop/filmicrgb.c:3833
+#: ../src/iop/filmicrgb.c:3814
 #, no-c-format
 msgid "% display"
 msgstr "% 디스플레이"
 
-#: ../src/iop/filmicrgb.c:3845
+#: ../src/iop/filmicrgb.c:3826
 msgid "EV scene"
 msgstr "EV 장면"
 
-#: ../src/iop/filmicrgb.c:3849
+#: ../src/iop/filmicrgb.c:3830
 #, no-c-format
 msgid "% camera"
 msgstr "% 카메라"
 
 #. Page DISPLAY
-#: ../src/iop/filmicrgb.c:3885 ../src/iop/filmicrgb.c:4543
+#: ../src/iop/filmicrgb.c:3866 ../src/iop/filmicrgb.c:4535
 msgid "display"
 msgstr "디스플레이"
 
 #. axis legend
-#: ../src/iop/filmicrgb.c:3894
+#: ../src/iop/filmicrgb.c:3875
 msgid "(%)"
 msgstr "(%)"
 
 #. Page SCENE
-#: ../src/iop/filmicrgb.c:3903 ../src/iop/filmicrgb.c:4382
+#: ../src/iop/filmicrgb.c:3884 ../src/iop/filmicrgb.c:4367
 msgid "scene"
 msgstr "장면"
 
 #. axis legend
-#: ../src/iop/filmicrgb.c:3912
+#: ../src/iop/filmicrgb.c:3893
 msgid "(EV)"
 msgstr "(EV)"
 
-#. we are over the graph area
-#: ../src/iop/filmicrgb.c:4322
+#: ../src/iop/filmicrgb.c:4305
 msgid ""
 "use the parameters below to set the nodes.\n"
 "the bright curve is the filmic tone mapping curve\n"
@@ -20322,11 +23902,11 @@ msgstr ""
 "밝은 곡선은 필믹 톤 매핑 곡선입니다.\n"
 "어두운 곡선은 채도 감소 곡선입니다."
 
-#: ../src/iop/filmicrgb.c:4328
+#: ../src/iop/filmicrgb.c:4312
 msgid "toggle axis labels and values display"
 msgstr "축 레이블과 값 표시 전환"
 
-#: ../src/iop/filmicrgb.c:4332
+#: ../src/iop/filmicrgb.c:4317
 msgid ""
 "cycle through graph views.\n"
 "left-click: cycle forward.\n"
@@ -20338,7 +23918,7 @@ msgstr ""
 "우클릭: 이전 보기로 이동합니다.\n"
 "더블 클릭: 룩 보기로 리셋합니다."
 
-#: ../src/iop/filmicrgb.c:4391
+#: ../src/iop/filmicrgb.c:4376
 #, no-c-format
 msgid ""
 "adjust to match the average luminance of the image's subject.\n"
@@ -20349,7 +23929,7 @@ msgstr ""
 "여기에 입력한 값은 이후 18.45%에 다시 매핑됨됩니다.\n"
 "값을 낮추면 전체 밝기가 증가합니다."
 
-#: ../src/iop/filmicrgb.c:4428
+#: ../src/iop/filmicrgb.c:4416
 msgid ""
 "try to optimize the settings with some statistical assumptions.\n"
 "this will fit the luminance range inside the histogram bounds.\n"
@@ -20366,16 +23946,16 @@ msgstr ""
 "사용 전 그 가정을 충분히 이해한 상태에서 활용해야 합니다."
 
 #. Page RECONSTRUCT
-#: ../src/iop/filmicrgb.c:4437
+#: ../src/iop/filmicrgb.c:4425
 msgid "reconstruct"
 msgstr "복원"
 
-#: ../src/iop/filmicrgb.c:4439
+#: ../src/iop/filmicrgb.c:4427
 msgctxt "section"
 msgid "highlights clipping"
 msgstr "하이라이트 클리핑"
 
-#: ../src/iop/filmicrgb.c:4446
+#: ../src/iop/filmicrgb.c:4434
 msgid ""
 "set the exposure threshold upon which\n"
 "clipped highlights get reconstructed.\n"
@@ -20390,7 +23970,7 @@ msgstr ""
 "값을 줄이면 더 넓은 영역을 포함하고\n"
 "값을 늘리면 더 많은 영역을 제외합니다."
 
-#: ../src/iop/filmicrgb.c:4456
+#: ../src/iop/filmicrgb.c:4444
 msgid ""
 "soften the transition between clipped highlights and valid pixels.\n"
 "decrease to make the transition harder and sharper,\n"
@@ -20401,16 +23981,16 @@ msgstr ""
 "값을 늘리면 경계가 더 부드럽고 흐릿하게 나타납니다."
 
 #. Highlight Reconstruction Mask
-#: ../src/iop/filmicrgb.c:4461 ../src/iop/filmicrgb.c:4462
+#: ../src/iop/filmicrgb.c:4449 ../src/iop/filmicrgb.c:4450
 msgid "display highlight reconstruction mask"
 msgstr "하이라이트 복원 마스크 표시"
 
-#: ../src/iop/filmicrgb.c:4468
+#: ../src/iop/filmicrgb.c:4456
 msgctxt "section"
 msgid "balance"
 msgstr "균형"
 
-#: ../src/iop/filmicrgb.c:4474
+#: ../src/iop/filmicrgb.c:4462
 #, no-c-format
 msgid ""
 "decide which reconstruction strategy to favor,\n"
@@ -20427,7 +24007,7 @@ msgstr ""
 "RGB 채널 중 하나라도 클리핑되지 않은 경우 이 값을 증가시키고,\n"
 "모든 RGB 채널이 넓은 영역에서 클리핑된 경우 이 값을 감소시키는 것이 좋습니다."
 
-#: ../src/iop/filmicrgb.c:4485
+#: ../src/iop/filmicrgb.c:4473
 #, no-c-format
 msgid ""
 "decide which reconstruction strategy to favor,\n"
@@ -20444,7 +24024,7 @@ msgstr ""
 "값을 높이면 더 많은 디테일이 보존되고,\n"
 "낮추면 더 부드럽고 흐릿한 표현이 됩니다."
 
-#: ../src/iop/filmicrgb.c:4497
+#: ../src/iop/filmicrgb.c:4485
 #, no-c-format
 msgid ""
 "decide which reconstruction strategy to favor,\n"
@@ -20462,11 +24042,11 @@ msgstr ""
 "낮추면 마젠타 색조나 색공간을 벗어난 하이라이트를 줄일 수 있습니다."
 
 #. Page LOOK
-#: ../src/iop/filmicrgb.c:4505
+#: ../src/iop/filmicrgb.c:4493
 msgid "look"
 msgstr "룩"
 
-#: ../src/iop/filmicrgb.c:4515
+#: ../src/iop/filmicrgb.c:4505
 msgid ""
 "equivalent to paper grade in analog.\n"
 "increase to make highlights brighter and less compressed.\n"
@@ -20476,7 +24056,7 @@ msgstr ""
 "값을 높이면 하이라이트가 더 밝고 압축이 덜 되며,\n"
 "값을 낮추면 하이라이트가 부드러워집니다."
 
-#: ../src/iop/filmicrgb.c:4523
+#: ../src/iop/filmicrgb.c:4513
 msgid ""
 "width of the linear domain in the middle of the curve,\n"
 "increase to get more contrast and less desaturation at extreme luminances,\n"
@@ -20488,7 +24068,7 @@ msgstr ""
 "낮추면 그 반대 효과가 납니다.\n"
 "이 범위 내에서는 채도 감소가 발생하지 않으며, 중간 톤에는 영향을 주지 않습니다."
 
-#: ../src/iop/filmicrgb.c:4538 ../src/iop/filmicrgb.c:4682
+#: ../src/iop/filmicrgb.c:4530 ../src/iop/filmicrgb.c:4682
 msgid ""
 "desaturates the output of the module\n"
 "specifically at extreme luminances.\n"
@@ -20497,7 +24077,7 @@ msgstr ""
 "모듈 출력에서 극단적인 휘도 영역의 채도를 감소시킵니다.\n"
 "쉐도우나 하이라이트가 채도 감소 상태라면 값을 증가시키세요."
 
-#: ../src/iop/filmicrgb.c:4572
+#: ../src/iop/filmicrgb.c:4566
 msgid ""
 "v3 is darktable 3.0 desaturation method, same as color balance.\n"
 "v4 is a newer desaturation method, based on spectral purity of light."
@@ -20505,7 +24085,7 @@ msgstr ""
 "v3는 darktable 3.0의 채도 감소 방법으로, 색상 균형과 동일한 방식입니다.\n"
 "v4는 빛의 스펙트럼 순도를 기반으로 한 새로운 채도 감소 방법입니다."
 
-#: ../src/iop/filmicrgb.c:4576
+#: ../src/iop/filmicrgb.c:4571
 msgid ""
 "ensure the original colors are preserved.\n"
 "may reinforce chromatic aberrations and chroma noise,\n"
@@ -20515,7 +24095,7 @@ msgstr ""
 "색수차와 색도 노이즈가 더 뚜렷해질 수 있으므로,\n"
 "다른 곳에서 적절히 보정되었는지 확인하세요."
 
-#: ../src/iop/filmicrgb.c:4585
+#: ../src/iop/filmicrgb.c:4581
 msgid ""
 "choose the desired curvature of the filmic spline in highlights.\n"
 "hard uses a high curvature resulting in more tonal compression.\n"
@@ -20525,7 +24105,7 @@ msgstr ""
 "하드 모드는 곡률이 높아져 톤 압축이 더 강하게 나타납니다.\n"
 "소프트 모드는 곡률이 낮아져 톤 압축이 덜 발생합니다."
 
-#: ../src/iop/filmicrgb.c:4590
+#: ../src/iop/filmicrgb.c:4587
 msgid ""
 "choose the desired curvature of the filmic spline in shadows.\n"
 "hard uses a high curvature resulting in more tonal compression.\n"
@@ -20535,7 +24115,7 @@ msgstr ""
 "하드 모드는 곡률이 높아져 톤 압축이 더 강하게 발생합니다.\n"
 "소프트 모드는 곡률이 낮아져 톤 압축이 덜 발생합니다."
 
-#: ../src/iop/filmicrgb.c:4597
+#: ../src/iop/filmicrgb.c:4594
 #, no-c-format
 msgid ""
 "enable to input custom middle-gray values.\n"
@@ -20548,9 +24128,10 @@ msgstr ""
 "대신 노출 모듈에서 전체 노출을 조정하세요.\n"
 "비활성화하면 표준 18.45% 중간 회색값을 사용합니다."
 
-#: ../src/iop/filmicrgb.c:4604
+#: ../src/iop/filmicrgb.c:4601
 msgid ""
-"enable to auto-set the look hardness depending on the scene white and black points.\n"
+"enable to auto-set the look hardness depending on the scene white and black "
+"points.\n"
 "this keeps the middle gray on the identity line and improves fast tuning.\n"
 "disable if you want a manual control."
 msgstr ""
@@ -20558,7 +24139,7 @@ msgstr ""
 "이 설정은 중간 회색 값을 동일성선 상에 유지하여 빠른 조정을 돕습니다.\n"
 "수동 조정을 원하면 비활성화하세요."
 
-#: ../src/iop/filmicrgb.c:4610
+#: ../src/iop/filmicrgb.c:4607
 msgid ""
 "run extra passes of chromaticity reconstruction.\n"
 "more iterations means more color propagation from neighborhood.\n"
@@ -20570,7 +24151,7 @@ msgstr ""
 "처리 속도는 느려지지만 더 중성적인 하이라이트 결과를 얻을 수 있습니다.\n"
 "또한 마젠타 하이라이트가 나타나는 어려운 경우에도 도움이 됩니다."
 
-#: ../src/iop/filmicrgb.c:4617
+#: ../src/iop/filmicrgb.c:4615
 msgid ""
 "add statistical noise in reconstructed highlights.\n"
 "this avoids highlights to look too smooth\n"
@@ -20582,7 +24163,7 @@ msgstr ""
 "하이라이트가 너무 부드럽게 보이는 것을 방지하여,\n"
 "나머지 이미지와 자연스럽게 어우러지도록 합니다."
 
-#: ../src/iop/filmicrgb.c:4624
+#: ../src/iop/filmicrgb.c:4623
 msgid ""
 "choose the statistical distribution of noise.\n"
 "this is useful to match natural sensor noise pattern."
@@ -20594,7 +24175,7 @@ msgstr ""
 msgid "mid-tones saturation"
 msgstr "중간 톤 채도"
 
-#: ../src/iop/filmicrgb.c:4689
+#: ../src/iop/filmicrgb.c:4690
 msgid ""
 "desaturates the output of the module\n"
 "specifically at medium luminances.\n"
@@ -20603,11 +24184,11 @@ msgstr ""
 "모듈 출력에서 중간 밝기 영역의 휘도를 감소시킵니다.\n"
 "중간 톤이 채도 부족일 경우 값을 높이세요."
 
-#: ../src/iop/filmicrgb.c:4695
+#: ../src/iop/filmicrgb.c:4696
 msgid "highlights saturation mix"
 msgstr "하이라이트 채도 혼합"
 
-#: ../src/iop/filmicrgb.c:4696
+#: ../src/iop/filmicrgb.c:4698
 msgid ""
 "positive values ensure saturation is kept unchanged over the whole range.\n"
 "negative values bleach highlights at constant hue and luminance.\n"
@@ -20654,7 +24235,7 @@ msgstr "시계 반대 방향으로 90도 회전"
 msgid "rotate 90 degrees CW"
 msgstr "시계 방향으로 90도 회전"
 
-#: ../src/iop/gamma.c:41
+#: ../src/iop/gamma.c:42
 msgctxt "modulename"
 msgid "display encoding"
 msgstr "디스플레이 인코딩"
@@ -20667,19 +24248,21 @@ msgstr "글로벌 톤맵"
 msgid "this module is deprecated. please use the filmic rgb module instead."
 msgstr "이 모듈은 더 이상 사용되지 않습니다. 대신 필믹 rgb 모듈을 사용하세요."
 
-#: ../src/iop/globaltonemap.c:641 ../src/libs/filters/colors.c:259
+#: ../src/iop/globaltonemap.c:629 ../src/libs/filters/colors.c:259
 msgid "operator"
 msgstr "연산자"
 
-#: ../src/iop/globaltonemap.c:642
+#: ../src/iop/globaltonemap.c:630
 msgid "the global tonemap operator"
 msgstr "글로벌 톤맵 연산자"
 
-#: ../src/iop/globaltonemap.c:645
-msgid "the bias for tonemapper controls the linearity, the higher the more details in blacks"
+#: ../src/iop/globaltonemap.c:633
+msgid ""
+"the bias for tonemapper controls the linearity, the higher the more details "
+"in blacks"
 msgstr "톤매퍼의 바이어스는 선형성을 제어하며, 값이 높을수록 암부 디테일이 더 잘 표현됩니다"
 
-#: ../src/iop/globaltonemap.c:649
+#: ../src/iop/globaltonemap.c:637
 msgid "the target light for tonemapper specified as cd/m2"
 msgstr "톤매퍼의 목표 밝기는 cd/m² 단위로 지정됩니다"
 
@@ -20743,11 +24326,11 @@ msgstr "그라데이션 밀도"
 msgid "simulate an optical graduated neutral density filter"
 msgstr "광학 그라데이션 중성 밀도 필터를 시뮬레이션합니다"
 
-#: ../src/iop/graduatednd.c:1066
+#: ../src/iop/graduatednd.c:1033
 msgid "the density in EV for the filter"
 msgstr "필터의 EV 단위 밀도"
 
-#: ../src/iop/graduatednd.c:1071
+#: ../src/iop/graduatednd.c:1038
 #, no-c-format
 msgid ""
 "hardness of graduation:\n"
@@ -20756,34 +24339,34 @@ msgstr ""
 "그라데이션 경도:\n"
 "0% = 부드러움, 100% = 단단함"
 
-#: ../src/iop/graduatednd.c:1076
+#: ../src/iop/graduatednd.c:1043
 msgid "rotation of filter -180 to 180 degrees"
 msgstr "필터 회전 각도: -180도에서 180도까지"
 
-#: ../src/iop/graduatednd.c:1089
+#: ../src/iop/graduatednd.c:1056
 msgid "select the hue tone of filter"
 msgstr "필터의 색조 톤 선택"
 
-#: ../src/iop/graduatednd.c:1095
+#: ../src/iop/graduatednd.c:1062
 msgid "select the saturation of filter"
 msgstr "필터의 채도 선택"
 
-#: ../src/iop/graduatednd.c:1106
+#: ../src/iop/graduatednd.c:1073
 #, c-format
 msgid "[%s on nodes] change line rotation"
 msgstr "[%s 노드에서] 선 회전 변경"
 
-#: ../src/iop/graduatednd.c:1107
+#: ../src/iop/graduatednd.c:1074
 #, c-format
 msgid "[%s on line] move line"
 msgstr "[%s 선에서] 선 이동"
 
-#: ../src/iop/graduatednd.c:1109
+#: ../src/iop/graduatednd.c:1076
 #, c-format
 msgid "[%s on line] change density"
 msgstr "[%s 선에서] 밀도 변경"
 
-#: ../src/iop/graduatednd.c:1111
+#: ../src/iop/graduatednd.c:1078
 #, c-format
 msgid "[%s on line] change hardness"
 msgstr "[%s 선에서] 경도 변경"
@@ -20805,7 +24388,10 @@ msgid "the strength of applied grain"
 msgstr "적용된 그레인 강도"
 
 #: ../src/iop/grain.c:551
-msgid "amount of mid-tones bias from the photographic paper response modeling. the greater the bias, the more pronounced the fall off of the grain in shadows and highlights"
+msgid ""
+"amount of mid-tones bias from the photographic paper response modeling. the "
+"greater the bias, the more pronounced the fall off of the grain in shadows "
+"and highlights"
 msgstr "사진 인화지 반응 모델링에서 중간 톤 편향량. 편향이 클수록 쉐도우와 하이라이트에서 그레인의 감소가 더 뚜렷해집니다"
 
 #: ../src/iop/hazeremoval.c:98
@@ -20824,7 +24410,7 @@ msgstr "이미지에서 안개와 대기 블러 현상을 제거"
 msgid "amount of haze reduction"
 msgstr "안개 감소 정도"
 
-#: ../src/iop/hazeremoval.c:275 ../src/iop/lens.cc:4423
+#: ../src/iop/hazeremoval.c:275 ../src/iop/lens.cc:4417
 msgid "distance"
 msgstr "거리"
 
@@ -20832,7 +24418,7 @@ msgstr "거리"
 msgid "limit haze removal up to a specific spatial depth"
 msgstr "특정 공간 깊이까지 안개 제거 제한"
 
-#: ../src/iop/hazeremoval.c:661 ../src/iop/hazeremoval.c:932
+#: ../src/iop/hazeremoval.c:660 ../src/iop/hazeremoval.c:929
 msgid "haze removal could not calculate ambient light due to image content"
 msgstr "이미지 내용 때문에 주변 광 계산이 불가능하여 안개 제거를 수행할 수 없습니다"
 
@@ -20848,25 +24434,29 @@ msgstr "마젠타 하이라이트를 피하고 하이라이트 색상을 복원 
 msgid "reconstruction, raw"
 msgstr "복원, RAW"
 
-#: ../src/iop/highlights.c:1177
-msgid "highlights: mode not available for this type of image. falling back to inpaint opposed."
+#: ../src/iop/highlights.c:1156
+msgid ""
+"highlights: mode not available for this type of image. falling back to "
+"inpaint opposed."
 msgstr "하이라이트: 이 이미지 유형에서는 사용할 수 없는 모드입니다. 대신 보정 복원 모드로 전환됩니다."
 
-#: ../src/iop/highlights.c:1302
+#: ../src/iop/highlights.c:1281
 msgid "highlight reconstruction method"
 msgstr "하이라이트 복원 방법"
 
-#: ../src/iop/highlights.c:1307
+#: ../src/iop/highlights.c:1286
 msgid ""
-"manually adjust the clipping threshold mostly used against magenta highlights.\n"
-"you might use this for tuning 'laplacian', 'inpaint opposed' or 'segmentation' modes,\n"
+"manually adjust the clipping threshold mostly used against magenta "
+"highlights.\n"
+"you might use this for tuning 'laplacian', 'inpaint opposed' or "
+"'segmentation' modes,\n"
 "especially if camera white point is incorrect."
 msgstr ""
 "주로 마젠타 하이라이트에 대응하기 위한 클리핑 임계값을 수동으로 조정합니다.\n"
 "특히 카메라 화이트트 포인트가 올바르지 않은 경우\n"
 "'라플라시안', '보정 복원', '분할' 모드 조정에 사용될 수 있습니다."
 
-#: ../src/iop/highlights.c:1311
+#: ../src/iop/highlights.c:1290
 msgid ""
 "visualize clipped highlights in a false color representation.\n"
 "the effective clipping level also depends on the reconstruction method."
@@ -20874,51 +24464,59 @@ msgstr ""
 "클리핑된 하이라이트를 거짓 색상으로 시각화합니다.\n"
 "실제 클리핑 수준은 복원 방법에 따라서도 달라집니다."
 
-#: ../src/iop/highlights.c:1316
+#: ../src/iop/highlights.c:1295
 msgid ""
 "combine closely related clipped segments by morphological operations.\n"
-"this often leads to improved color reconstruction for tiny segments before dark background."
+"this often leads to improved color reconstruction for tiny segments before "
+"dark background."
 msgstr ""
 "형태학적 연산으로 밀접하게 연결된 클리핑된 구간을 병합합니다.\n"
 "이 작업은 어두운 배경 앞의 작은 구간에서 색상 복원을 향상시키는 경우가 많습니다."
 
-#: ../src/iop/highlights.c:1319
+#: ../src/iop/highlights.c:1298
 msgid "visualize the combined segments in a false color representation."
 msgstr "병합된 구간을 거짓 색상으로 시각화합니다."
 
-#: ../src/iop/highlights.c:1322
+#: ../src/iop/highlights.c:1301
 msgid ""
 "select inpainting after segmentation analysis.\n"
-"increase to favor candidates found in segmentation analysis, decrease for opposed means inpainting."
+"increase to favor candidates found in segmentation analysis, decrease for "
+"opposed means inpainting."
 msgstr ""
 "분할 분석 후 보정 복원을 선택합니다.\n"
 "값을 높이면 분할 분석에서 찾은 후보를 우선시하고, 값을 낮추면 반대 방식의 보정 복원을 적용합니다."
 
-#: ../src/iop/highlights.c:1327
-msgid "visualize segments that are considered to have a good candidate in a false color representation."
+#: ../src/iop/highlights.c:1306
+msgid ""
+"visualize segments that are considered to have a good candidate in a false "
+"color representation."
 msgstr "좋은 후보가 있다고 판단된 구간을 거짓 색상으로 시각화합니다."
 
-#: ../src/iop/highlights.c:1330
+#: ../src/iop/highlights.c:1309
 msgid ""
-"approximate lost data in regions with all photosites clipped, the effect depends on segment size and border gradients.\n"
-"choose a mode tuned for segment size or the generic mode that tries to find best settings for every segment.\n"
-"small means areas with a diameter less than 25 pixels, large is best for greater than 100.\n"
-"the flat modes ignore narrow unclipped structures (like powerlines) to keep highlights rebuilt and avoid gradients."
+"approximate lost data in regions with all photosites clipped, the effect "
+"depends on segment size and border gradients.\n"
+"choose a mode tuned for segment size or the generic mode that tries to find "
+"best settings for every segment.\n"
+"small means areas with a diameter less than 25 pixels, large is best for "
+"greater than 100.\n"
+"the flat modes ignore narrow unclipped structures (like powerlines) to keep "
+"highlights rebuilt and avoid gradients."
 msgstr ""
 "모든 화소가 클리핑된 영역의 손실 데이터를 근사 복원합니다. 효과는 구간 크기와경계 그라디언트에 따라 달라집니다.\n"
 "구간 크기에 맞춰 튜닝된 모드 또는 모든 구간에 최적 설정을 찾는 일반 모드를 선택하세요.\n"
 "작은 구간은 직경 25픽셀 미만, 큰 구간은 100픽셀 이상에 적합합니다.\n"
 "플랫 모드는 전선과 같은 좁은 비클립 구조를 무시하여 하이라이트 복원을 유지하고그라디언트 생성을 방지합니다."
 
-#: ../src/iop/highlights.c:1336
+#: ../src/iop/highlights.c:1315
 msgid "set strength of rebuilding in regions with all photosites clipped."
 msgstr "모든 화소가 클리핑된 영역에서 재구성 강도를 설정합니다."
 
-#: ../src/iop/highlights.c:1340
+#: ../src/iop/highlights.c:1319
 msgid "show the effect that is added to already reconstructed data."
 msgstr "이미 복원된 데이터에 추가될 효과를 표시합니다."
 
-#: ../src/iop/highlights.c:1343
+#: ../src/iop/highlights.c:1322
 msgid ""
 "add noise to visually blend the reconstructed areas\n"
 "into the rest of the noisy image. useful at high ISO."
@@ -20926,7 +24524,7 @@ msgstr ""
 "복원된 영역에 노이즈를 추가하여 전체 노이즈가 있는 이미지와\n"
 "각적으로 자연스럽게 어우러지도록 합니다. ISO 촬영 시 유용합니다."
 
-#: ../src/iop/highlights.c:1347
+#: ../src/iop/highlights.c:1326
 msgid ""
 "increase if magenta highlights don't get fully corrected\n"
 "each new iteration brings a performance penalty."
@@ -20934,7 +24532,7 @@ msgstr ""
 "마젠타 하이라이트가 완전히 보정되지 않을 경우 값을 높이세요.\n"
 "반복 횟수가 늘어날수록 처리 속도가 느려집니다."
 
-#: ../src/iop/highlights.c:1352
+#: ../src/iop/highlights.c:1331
 msgid ""
 "increase if magenta highlights don't get fully corrected.\n"
 "this may produce non-smooth boundaries between valid and clipped regions."
@@ -20942,7 +24540,7 @@ msgstr ""
 "마젠타 하이라이트가 완전히 보정되지 않을 경우 값을 높이세요.\n"
 "이로 인해 유효 영역과 클리핑된 영역 사이에 경계가 부드럽지 않게 나타날 수 있습니다."
 
-#: ../src/iop/highlights.c:1356
+#: ../src/iop/highlights.c:1335
 msgid ""
 "increase to correct larger clipped areas.\n"
 "large values bring huge performance penalties"
@@ -20950,7 +24548,7 @@ msgstr ""
 "더 넓은 클리핑 영역을 보정하려면 값을 높이세요.\n"
 "값이 클수록 처리 속도가 크게 느려집니다"
 
-#: ../src/iop/highlights.c:1360
+#: ../src/iop/highlights.c:1339
 msgid "this module does not work with monochrome RAW files"
 msgstr "이 모듈은 모노크롬 RAW 파일에서는 작동하지 않습니다"
 
@@ -20974,11 +24572,11 @@ msgstr "주파수 기반, Lab"
 msgid "special, Lab, scene-referred"
 msgstr "특수, Lab, 장면 기준"
 
-#: ../src/iop/highpass.c:367
+#: ../src/iop/highpass.c:354
 msgid "the sharpness of highpass filter"
 msgstr "하이패스 필터의 선명도"
 
-#: ../src/iop/highpass.c:371
+#: ../src/iop/highpass.c:358
 msgid "the contrast of highpass filter"
 msgstr "하이패스 필터의 대비"
 
@@ -20994,21 +24592,21 @@ msgstr ""
 "비정상적으로 밝은 픽셀을\n"
 "주변 픽셀과 조합해 감소시켜 제거합니다"
 
-#: ../src/iop/hotpixels.c:421
+#: ../src/iop/hotpixels.c:424
 #, c-format
 msgid "fixed %d pixel"
 msgid_plural "fixed %d pixels"
 msgstr[0] "고정된 %d 픽셀"
 
-#: ../src/iop/hotpixels.c:444
+#: ../src/iop/hotpixels.c:447
 msgid "lower threshold for hot pixel"
 msgstr "핫 픽셀의 하한 임계값"
 
-#: ../src/iop/hotpixels.c:448
+#: ../src/iop/hotpixels.c:451
 msgid "strength of hot pixel correction"
 msgstr "핫 픽셀 보정 강도"
 
-#: ../src/iop/hotpixels.c:464
+#: ../src/iop/hotpixels.c:467
 msgid ""
 "hot pixel correction\n"
 "only works for raw images."
@@ -21053,23 +24651,23 @@ msgstr "이미지에서 필름 소재의 색상 선택"
 msgid "select color of film material"
 msgstr "필름 소재 색상 선택"
 
-#: ../src/iop/lens.cc:252
+#: ../src/iop/lens.cc:253
 msgid "lens correction"
 msgstr "렌즈 보정"
 
-#: ../src/iop/lens.cc:257
+#: ../src/iop/lens.cc:258
 msgid "vignette|chromatic aberrations|distortion"
 msgstr "비네팅|색수차|왜곡"
 
-#: ../src/iop/lens.cc:262
+#: ../src/iop/lens.cc:263
 msgid "correct lenses optical flaws"
 msgstr "렌즈의 광학적 결함을 보정"
 
-#: ../src/iop/lens.cc:265
+#: ../src/iop/lens.cc:266
 msgid "geometric and reconstruction, RGB"
 msgstr "기하학적 및 복원, RGB"
 
-#: ../src/iop/lens.cc:3764
+#: ../src/iop/lens.cc:3755
 #, c-format
 msgid ""
 "maker:\t\t%s\n"
@@ -21082,7 +24680,7 @@ msgstr ""
 "마운트:\t%s\n"
 "크롭 팩터:\t%.1f"
 
-#: ../src/iop/lens.cc:4006
+#: ../src/iop/lens.cc:3997
 #, c-format
 msgid ""
 "maker:\t\t%s\n"
@@ -21101,19 +24699,19 @@ msgstr ""
 "유형:\t%s\n"
 "마운트:\t%s"
 
-#: ../src/iop/lens.cc:4076
+#: ../src/iop/lens.cc:4070
 msgid "f/"
 msgstr "f/"
 
-#: ../src/iop/lens.cc:4091
+#: ../src/iop/lens.cc:4085
 msgid "d"
 msgstr "d"
 
-#: ../src/iop/lens.cc:4239
+#: ../src/iop/lens.cc:4233
 msgid "camera/lens not found"
 msgstr "카메라/렌즈를 찾을 수 없음"
 
-#: ../src/iop/lens.cc:4240
+#: ../src/iop/lens.cc:4234
 msgid ""
 "please select your lens manually\n"
 "you might also want to check if your Lensfun database is up-to-date\n"
@@ -21125,61 +24723,63 @@ msgstr ""
 
 #. Lensfun widget
 #. camera selector
-#: ../src/iop/lens.cc:4384
+#: ../src/iop/lens.cc:4378
 msgid "camera model"
 msgstr "카메라 모델"
 
-#: ../src/iop/lens.cc:4389
+#: ../src/iop/lens.cc:4383
 msgid "find camera"
 msgstr "카메라 찾기"
 
-#: ../src/iop/lens.cc:4401
+#: ../src/iop/lens.cc:4395
 msgid "find lens"
 msgstr "렌즈 찾기"
 
-#: ../src/iop/lens.cc:4410
+#: ../src/iop/lens.cc:4404
 msgid "focal length (mm)"
 msgstr "초점 거리 (mm)"
 
-#: ../src/iop/lens.cc:4417
+#: ../src/iop/lens.cc:4411
 msgid "f-number (aperture)"
 msgstr "f-값 (조리개)"
 
-#: ../src/iop/lens.cc:4424
+#: ../src/iop/lens.cc:4418
 msgid "distance to subject"
 msgstr "피사체까지 거리"
 
 #. scale
-#: ../src/iop/lens.cc:4459 ../src/iop/overlay.c:1120 ../src/iop/vignette.c:1043
-#: ../src/iop/watermark.c:1381 ../src/libs/export.c:1540
+#. upscale page: scale factor selector
+#: ../src/iop/lens.cc:4453 ../src/iop/overlay.c:1508 ../src/iop/vignette.c:1043
+#: ../src/iop/watermark.c:1484 ../src/libs/export.c:1558
+#: ../src/libs/neural_restore.c:4320
 msgid "scale"
 msgstr "스케일"
 
-#: ../src/iop/lens.cc:4461
+#: ../src/iop/lens.cc:4455
 msgid "auto scale"
 msgstr "자동 스케일"
 
-#: ../src/iop/lens.cc:4463
+#: ../src/iop/lens.cc:4457
 msgid "automatic scale to available image size due to Lensfun data"
 msgstr "Lensfun 데이터에 따라 사용 가능한 이미지 크기에 자동으로 스케일 조정"
 
-#: ../src/iop/lens.cc:4468
+#: ../src/iop/lens.cc:4462
 msgid "correct distortions or apply them"
 msgstr "왜곡 보정 또는 적용"
 
-#: ../src/iop/lens.cc:4476
+#: ../src/iop/lens.cc:4470
 msgid "transversal chromatic aberration red"
 msgstr "적색 횡방향 색수차"
 
-#: ../src/iop/lens.cc:4481
+#: ../src/iop/lens.cc:4475
 msgid "transversal chromatic aberration blue"
 msgstr "청색 횡방향 색수차"
 
-#: ../src/iop/lens.cc:4488
+#: ../src/iop/lens.cc:4482
 msgid "use latest algorithm"
 msgstr "최신 알고리즘 사용"
 
-#: ../src/iop/lens.cc:4491
+#: ../src/iop/lens.cc:4485
 msgid ""
 "you're using an old version of the algorithm.\n"
 "once enabled, you won't be able to\n"
@@ -21188,40 +24788,40 @@ msgstr ""
 "현재 구버전 알고리즘을 사용 중입니다.\n"
 "활성화하면 이전 알고리즘으로 되돌릴 수 없습니다."
 
-#: ../src/iop/lens.cc:4502
+#: ../src/iop/lens.cc:4496
 msgid "fine-tuning"
 msgstr "미세 조정"
 
 #. DT_IOP_SECTION_FOR_PARAMS doesn't work in C++ so declare local first
-#: ../src/iop/lens.cc:4506
+#: ../src/iop/lens.cc:4500
 msgid "fine-tune"
 msgstr "미세 조정"
 
-#: ../src/iop/lens.cc:4514
+#: ../src/iop/lens.cc:4508
 msgid "tune the warp and chromatic aberration correction"
 msgstr "왜곡 및 색수차 보정을 조절하기"
 
-#: ../src/iop/lens.cc:4519
+#: ../src/iop/lens.cc:4513
 msgid "tune the vignette correction"
 msgstr "비네팅 보정을 조절하기"
 
-#: ../src/iop/lens.cc:4524
+#: ../src/iop/lens.cc:4518
 msgid "tune the TCA red correction"
 msgstr "적색 TCA 보정을 조절하기"
 
-#: ../src/iop/lens.cc:4529
+#: ../src/iop/lens.cc:4523
 msgid "tune the TCA blue correction"
 msgstr "청색 TCA 보정을 조절하기"
 
-#: ../src/iop/lens.cc:4533
+#: ../src/iop/lens.cc:4527
 msgid "image scaling"
 msgstr "이미지 스케일 조정"
 
-#: ../src/iop/lens.cc:4535
+#: ../src/iop/lens.cc:4529
 msgid "automatic scale to available image size"
 msgstr "사용 가능한 이미지 크기에 자동 스케일 조정"
 
-#: ../src/iop/lens.cc:4545
+#: ../src/iop/lens.cc:4539
 msgid ""
 "select a correction mode either based on\n"
 " a) data and algorithms provided by the Lensfun project\n"
@@ -21231,46 +24831,46 @@ msgstr ""
 " a) Lensfun 프로젝트에서 제공하는 데이터 및 알고리즘\n"
 " b) 카메라 또는 소프트웨어 공급업체가 제공하는 내장 메타데이터"
 
-#: ../src/iop/lens.cc:4552
+#: ../src/iop/lens.cc:4546
 msgid "which corrections to apply"
 msgstr "적용할 보정 항목"
 
 #. message box to inform user what corrections have been done. this
 #. is useful as depending on Lensfun's profile only some of the lens
 #. flaws can be corrected
-#: ../src/iop/lens.cc:4557
+#: ../src/iop/lens.cc:4551
 msgid "corrections done: "
 msgstr "적용된 보정: "
 
-#: ../src/iop/lens.cc:4560
+#: ../src/iop/lens.cc:4554
 msgid "which corrections have actually been done"
 msgstr "실제로 수행된 보정 항목"
 
-#: ../src/iop/lens.cc:4577
+#: ../src/iop/lens.cc:4571
 msgid "manual vignette correction"
 msgstr "수동 비네팅 보정"
 
-#: ../src/iop/lens.cc:4581
+#: ../src/iop/lens.cc:4575
 msgid "additional manually controlled optical vignetting correction"
 msgstr "추가 수동 제어 광학 비네팅 보정"
 
-#: ../src/iop/lens.cc:4584
+#: ../src/iop/lens.cc:4578
 msgid "vignette"
 msgstr "비네팅"
 
-#: ../src/iop/lens.cc:4588
+#: ../src/iop/lens.cc:4582
 msgid "amount of the applied optical vignetting correction"
 msgstr "적용된 광학 비네팅 보정의 정도"
 
-#: ../src/iop/lens.cc:4592
+#: ../src/iop/lens.cc:4586
 msgid "show applied optical vignette correction mask"
 msgstr "적용된 광학 비네팅 보정 마스크 표시"
 
-#: ../src/iop/lens.cc:4596
+#: ../src/iop/lens.cc:4590
 msgid "radius of uncorrected center"
 msgstr "보정되지 않은 중심의 반지름"
 
-#: ../src/iop/lens.cc:4602
+#: ../src/iop/lens.cc:4596
 msgid "steepness of the correction effect outside of radius"
 msgstr "반지름 외부에서 보정 효과의 급격함"
 
@@ -21288,7 +24888,8 @@ msgid "adjust black, white and mid-gray points"
 msgstr "흑색, 백색, 중간 회색점을 조절합니다"
 
 #: ../src/iop/levels.c:634 ../src/iop/rgblevels.c:1053
-msgid "drag handles to set black, gray, and white points. operates on L channel."
+msgid ""
+"drag handles to set black, gray, and white points. operates on L channel."
 msgstr "핸들을 드래그하여 흑색, 회색, 백색 포인트를 설정하세요. L 채널에 적용됩니다."
 
 #: ../src/iop/levels.c:646 ../src/iop/rgblevels.c:1084
@@ -21327,39 +24928,42 @@ msgstr "리퀴파이"
 msgid "distort parts of the image"
 msgstr "이미지 일부를 왜곡합니다"
 
-#: ../src/iop/liquify.c:2863
+#: ../src/iop/liquify.c:2862
 msgid "click to edit nodes"
 msgstr "노드를 편집하려면 클릭하세요"
 
-#: ../src/iop/liquify.c:3565
+#: ../src/iop/liquify.c:3564
 msgid ""
 "<b>add point</b>: click and drag\n"
-"<b>size</b>: scroll - <b>strength</b>: shift+scroll - <b>direction</b>: ctrl+scroll"
+"<b>size</b>: scroll - <b>strength</b>: shift+scroll - <b>direction</b>: "
+"ctrl+scroll"
 msgstr ""
 "<b>포인트 추가</b>: 클릭 후 드래그\n"
 "<b>크기</b>: 스크롤 - <b>강도</b>: Shift+스크롤 - <b>방향</b>: Ctrl+스크롤"
 
-#: ../src/iop/liquify.c:3568
+#: ../src/iop/liquify.c:3567
 msgid ""
 "<b>add line</b>: click\n"
-"<b>size</b>: scroll - <b>strength</b>: shift+scroll - <b>direction</b>: ctrl+scroll"
+"<b>size</b>: scroll - <b>strength</b>: shift+scroll - <b>direction</b>: "
+"ctrl+scroll"
 msgstr ""
 "<b>선 추가</b>: 클릭\n"
 "<b>크기</b>: 스크롤 - <b>강도</b>: Shift+스크롤 - <b>방향</b>: Ctrl+스크롤"
 
-#: ../src/iop/liquify.c:3571
+#: ../src/iop/liquify.c:3570
 msgid ""
 "<b>add curve</b>: click\n"
-"<b>size</b>: scroll - <b>strength</b>: shift+scroll - <b>direction</b>: ctrl+scroll"
+"<b>size</b>: scroll - <b>strength</b>: shift+scroll - <b>direction</b>: "
+"ctrl+scroll"
 msgstr ""
 "<b>커브 추가</b>: 클릭\n"
 "<b>크기</b>: 스크롤 - <b>강도</b>: Shift+스크롤 - <b>방향</b>: Ctrl+스크롤"
 
-#: ../src/iop/liquify.c:3617
+#: ../src/iop/liquify.c:3616
 msgid "warps|nodes count:"
 msgstr "변형|노드 개수:"
 
-#: ../src/iop/liquify.c:3622
+#: ../src/iop/liquify.c:3621
 msgid ""
 "use a tool to add warps\n"
 "<b>remove a warp</b>: right-click"
@@ -21367,44 +24971,45 @@ msgstr ""
 "변형을 추가하려면 도구를 사용하세요\n"
 "변형 제거: 우클릭"
 
-#: ../src/iop/liquify.c:3628
+#: ../src/iop/liquify.c:3627
 msgid "edit, add and delete nodes"
 msgstr "노드 편집, 추가 및 삭제"
 
-#: ../src/iop/liquify.c:3633 ../src/iop/liquify.c:3639
-#: ../src/iop/liquify.c:3645 ../src/iop/retouch.c:2446
-#: ../src/iop/retouch.c:2452 ../src/iop/retouch.c:2457
-#: ../src/iop/retouch.c:2462 ../src/iop/spots.c:876 ../src/iop/spots.c:881
-#: ../src/iop/spots.c:886 ../src/libs/masks.c:1795 ../src/libs/masks.c:1803
-#: ../src/libs/masks.c:1811 ../src/libs/masks.c:1819 ../src/libs/masks.c:1827
+#: ../src/iop/liquify.c:3632 ../src/iop/liquify.c:3638
+#: ../src/iop/liquify.c:3644 ../src/iop/retouch.c:2444
+#: ../src/iop/retouch.c:2450 ../src/iop/retouch.c:2455
+#: ../src/iop/retouch.c:2460 ../src/iop/spots.c:876 ../src/iop/spots.c:881
+#: ../src/iop/spots.c:886 ../src/libs/masks.c:2096 ../src/libs/masks.c:2104
+#: ../src/libs/masks.c:2112 ../src/libs/masks.c:2120 ../src/libs/masks.c:2128
+#: ../src/libs/masks.c:2137
 msgid "shapes"
 msgstr "모양"
 
-#: ../src/iop/liquify.c:3634
+#: ../src/iop/liquify.c:3633
 msgid "draw curves"
 msgstr "커브 그리기"
 
-#: ../src/iop/liquify.c:3634
+#: ../src/iop/liquify.c:3633
 msgid "draw multiple curves"
 msgstr "다중 커브 그리기"
 
-#: ../src/iop/liquify.c:3640
+#: ../src/iop/liquify.c:3639
 msgid "draw lines"
 msgstr "선 그리기"
 
-#: ../src/iop/liquify.c:3640
+#: ../src/iop/liquify.c:3639
 msgid "draw multiple lines"
 msgstr "다중 선 그리기"
 
-#: ../src/iop/liquify.c:3646
+#: ../src/iop/liquify.c:3645
 msgid "draw points"
 msgstr "점 그리기"
 
-#: ../src/iop/liquify.c:3646
+#: ../src/iop/liquify.c:3645
 msgid "draw multiple points"
 msgstr "다중 점 그리기"
 
-#: ../src/iop/liquify.c:3652
+#: ../src/iop/liquify.c:3651
 msgid ""
 "<b>add node</b>: ctrl+click - <b>remove path</b>: right-click\n"
 "<b>toggle line/curve</b>: ctrl+alt+click"
@@ -21412,31 +25017,32 @@ msgstr ""
 "<b>노드 추가</b>: Ctrl+좌클릭 - <b>경로 제거</b>: 우클릭\n"
 "<b>선/곡선 전환</b>: Ctrl+Alt+좌클릭"
 
-#: ../src/iop/liquify.c:3655
+#: ../src/iop/liquify.c:3654
 msgid ""
 "<b>move</b>: click and drag - <b>show/hide feathering controls</b>: click\n"
-"<b>autosmooth, cusp, smooth, symmetrical</b>: ctrl+click - <b>remove</b>: right-click"
+"<b>autosmooth, cusp, smooth, symmetrical</b>: ctrl+click - <b>remove</b>: "
+"right-click"
 msgstr ""
 "<b>이동</b>:클릭 후 드래그 - <b>페더링 컨트롤 표시/숨기기</b>: 클릭\n"
 "<b>자동 스무스, 첨점, 스무스, 대칭</b>: Ctrl+클릭 - <b>제거</b>: 우클릭"
 
-#: ../src/iop/liquify.c:3659 ../src/iop/liquify.c:3661
+#: ../src/iop/liquify.c:3658 ../src/iop/liquify.c:3660
 msgid "<b>shape of path</b>: drag"
 msgstr "<b>경로 모양</b>: 드래그"
 
-#: ../src/iop/liquify.c:3663
+#: ../src/iop/liquify.c:3662
 msgid "<b>radius</b>: drag"
 msgstr "<b>반지름</b>: 드래그"
 
-#: ../src/iop/liquify.c:3665
+#: ../src/iop/liquify.c:3664
 msgid "<b>hardness (center)</b>: drag"
 msgstr "<b>경도 (중앙)</b>: 드래그"
 
-#: ../src/iop/liquify.c:3667
+#: ../src/iop/liquify.c:3666
 msgid "<b>hardness (feather)</b>: drag"
 msgstr "<b>경도 (페더링)</b>: 드래그"
 
-#: ../src/iop/liquify.c:3669
+#: ../src/iop/liquify.c:3668
 msgid ""
 "<b>strength</b>: drag\n"
 "<b>linear, grow, and shrink</b>: ctrl+click"
@@ -21516,216 +25122,221 @@ msgstr "로우패스"
 msgid "isolate low frequencies in the image"
 msgstr "이미지에서 저주파 분리"
 
-#: ../src/iop/lowpass.c:555
+#: ../src/iop/lowpass.c:553
 msgid "local contrast mask"
 msgstr "부분 대비 마스크"
 
-#: ../src/iop/lowpass.c:580
+#: ../src/iop/lowpass.c:578
 msgid "radius of gaussian/bilateral blur"
 msgstr "가우시안/양방향 블러 반지름"
 
-#: ../src/iop/lowpass.c:581
+#: ../src/iop/lowpass.c:579
 msgid "contrast of lowpass filter"
 msgstr "로우패스 필터 대비"
 
-#: ../src/iop/lowpass.c:582
+#: ../src/iop/lowpass.c:580
 msgid "brightness adjustment of lowpass filter"
 msgstr "로우패스 필터 밝기 조절"
 
-#: ../src/iop/lowpass.c:583
+#: ../src/iop/lowpass.c:581
 msgid "color saturation of lowpass filter"
 msgstr "로우패스 필터 채도"
 
-#: ../src/iop/lowpass.c:584
+#: ../src/iop/lowpass.c:582
 msgid "which filter to use for blurring"
 msgstr "블러에 사용할 필터 선택"
 
-#: ../src/iop/lut3d.c:132
+#: ../src/iop/lut3d.c:133
 msgid "LUT 3D"
 msgstr "LUT 3D"
 
-#: ../src/iop/lut3d.c:137
+#: ../src/iop/lut3d.c:138
 msgid "perform color space corrections and apply look"
 msgstr "색공간 보정 수행 및 룩 적용"
 
-#: ../src/iop/lut3d.c:140
+#: ../src/iop/lut3d.c:141
 msgid "defined by profile, RGB"
 msgstr "프로파일 기반 정의, RGB"
 
-#: ../src/iop/lut3d.c:487
+#: ../src/iop/lut3d.c:491
 msgid "error allocating buffer for gmz LUT"
 msgstr "gmz LUT 버퍼 할당 오류"
 
-#: ../src/iop/lut3d.c:514
+#: ../src/iop/lut3d.c:520
 #, c-format
 msgid "invalid png file %s"
 msgstr "잘못된 PNG 파일 %s"
 
-#: ../src/iop/lut3d.c:522
+#: ../src/iop/lut3d.c:528
 #, c-format
 msgid "png bit depth %d is not supported"
 msgstr "PNG 비트 깊이 %d는 지원되지 않음"
 
-#: ../src/iop/lut3d.c:536 ../src/iop/lut3d.c:546
+#: ../src/iop/lut3d.c:542 ../src/iop/lut3d.c:552
 #, c-format
 msgid "invalid level in png file %d %d"
 msgstr "PNG 파일 내 잘못된 레벨 %d %d"
 
-#: ../src/iop/lut3d.c:541
+#: ../src/iop/lut3d.c:547
 msgid "this darktable build is not compatible with compressed CLUT"
 msgstr "이 darktable 빌드는 압축된 CLUT와 호환되지 않음"
 
-#: ../src/iop/lut3d.c:558 ../src/iop/lut3d.c:810
+#: ../src/iop/lut3d.c:564 ../src/iop/lut3d.c:819
 #, c-format
 msgid "error - LUT 3D size %d exceeds the maximum supported"
 msgstr "에러 - 3D LUT 크기 %d가 최대 지원 크기를 초과함"
 
-#: ../src/iop/lut3d.c:570
+#: ../src/iop/lut3d.c:576
 msgid "error allocating buffer for png LUT"
 msgstr "PNG LUT 버퍼 할당 오류"
 
-#: ../src/iop/lut3d.c:578
+#: ../src/iop/lut3d.c:584
 #, c-format
 msgid "error - could not read png image %s"
 msgstr "에러 - PNG 이미지 %s를 읽을 수 없음"
 
-#: ../src/iop/lut3d.c:588
+#: ../src/iop/lut3d.c:596
 msgid "error - allocating buffer for png LUT"
 msgstr "에러 - PNG LUT 버퍼 할당 실패"
 
-#: ../src/iop/lut3d.c:763
+#: ../src/iop/lut3d.c:772
 #, c-format
 msgid "error - invalid cube file: %s"
 msgstr "잘못된 큐브 파일 오류: %s"
 
-#: ../src/iop/lut3d.c:777
+#: ../src/iop/lut3d.c:786
 msgid "DOMAIN MIN other than 0 is not supported"
 msgstr "0 이외의 DOMAIN MIN은 지원되지 않음"
 
-#: ../src/iop/lut3d.c:789
+#: ../src/iop/lut3d.c:798
 msgid "DOMAIN MAX other than 1 is not supported"
 msgstr "1 이외의 DOMAIN MAX는 지원되지 않음"
 
-#: ../src/iop/lut3d.c:799
+#: ../src/iop/lut3d.c:808
 msgid "1D cube LUT is not supported"
 msgstr "1D 큐브 LUT는 지원되지 않음"
 
-#: ../src/iop/lut3d.c:821
+#: ../src/iop/lut3d.c:831
 msgid "error - allocating buffer for cube LUT"
 msgstr "에러 - 큐브 LUT 버퍼 할당 실패"
 
-#: ../src/iop/lut3d.c:832
+#: ../src/iop/lut3d.c:843
 msgid "error - cube LUT size is not defined"
 msgstr "에러 - 큐브 LUT 크기가 정의되지 않음"
 
-#: ../src/iop/lut3d.c:843
+#: ../src/iop/lut3d.c:854
 #, c-format
 msgid "error - cube LUT invalid number line %d"
 msgstr "에러 - 큐브 LUT 잘못된 번호 라인 %d"
 
-#: ../src/iop/lut3d.c:859
+#: ../src/iop/lut3d.c:870
 #, c-format
 msgid "error - cube LUT lines number %d is not correct, should be %d"
 msgstr "에러 - 큐브 LUT 라인 수 %d가 올바르지 않음, %d이어야 함"
 
-#: ../src/iop/lut3d.c:869
+#: ../src/iop/lut3d.c:880
 #, c-format
 msgid "warning - cube LUT has %d values out of range [0,1]"
 msgstr "경고 - 큐브 LUT에 [0,1] 범위를 벗어난 값 %d개가 있음"
 
-#: ../src/iop/lut3d.c:894
+#: ../src/iop/lut3d.c:906
 #, c-format
 msgid "error - invalid 3dl file: %s"
 msgstr "에러 - 잘못된 3dl 파일: %s"
 
-#: ../src/iop/lut3d.c:915
+#: ../src/iop/lut3d.c:927
 #, c-format
 msgid "error - the maximum shaper LUT value %d is too low"
 msgstr "에러 - 최대 셰이퍼 LUT 값 %d가 너무 낮음"
 
-#: ../src/iop/lut3d.c:926
+#: ../src/iop/lut3d.c:939
 msgid "error - allocating buffer for 3dl LUT"
 msgstr "에러 - 3dl LUT 버퍼 할당 실패"
 
-#: ../src/iop/lut3d.c:939
+#: ../src/iop/lut3d.c:952
 msgid "error - 3dl LUT size is not defined"
 msgstr "에러 - 3dl LUT 크기가 정의되지 않음"
 
-#: ../src/iop/lut3d.c:967
+#: ../src/iop/lut3d.c:980
 msgid "error - 3dl LUT lines number is not correct"
 msgstr "에러 - 3dl LUT 라인 수가 올바르지 않음"
 
-#: ../src/iop/lut3d.c:983
+#: ../src/iop/lut3d.c:996
 msgid "error - the maximum LUT value does not match any valid bit depth"
 msgstr "에러 - 최대 LUT 값이 유효한 비트 깊이와 일치하지 않음"
 
-#: ../src/iop/lut3d.c:1563
+#: ../src/iop/lut3d.c:1576
 msgid "LUT root folder not defined"
 msgstr "LUT 루트 폴더가 정의되지 않음"
 
-#: ../src/iop/lut3d.c:1569
+#: ../src/iop/lut3d.c:1582
 msgid "select LUT file"
 msgstr "LUT 파일 선택"
 
-#: ../src/iop/lut3d.c:1570 ../src/iop/rasterfile.c:262
-msgid "_select"
-msgstr "선택 (&S)"
-
-#: ../src/iop/lut3d.c:1590
+#: ../src/iop/lut3d.c:1603
 msgid "hald CLUT (png), 3D LUT (cube or 3dl) or gmic compressed LUT (gmz)"
 msgstr "hald CLUT (png), 3D LUT (큐브 또는 3dl), 또는 gmic 압축 LUT (gmz)"
 
-#: ../src/iop/lut3d.c:1592
+#: ../src/iop/lut3d.c:1605
 msgid "hald CLUT (png) or 3D LUT (cube or 3dl)"
 msgstr "hald CLUT (png) 또는 3D LUT (큐브 또는 3dl)"
 
-#: ../src/iop/lut3d.c:1616
+#: ../src/iop/lut3d.c:1629
 msgid "select file outside LUT root folder is not allowed"
 msgstr "LUT 루트 폴더 외부의 파일 선택은 허용되지 않음"
 
-#: ../src/iop/lut3d.c:1684
-msgid "select a png (haldclut), a cube, a 3dl or a gmz (compressed LUT) file CAUTION: 3D LUT folder must be set in preferences/processing before choosing the LUT file"
+#: ../src/iop/lut3d.c:1697
+msgid ""
+"select a png (haldclut), a cube, a 3dl or a gmz (compressed LUT) file "
+"CAUTION: 3D LUT folder must be set in preferences/processing before choosing "
+"the LUT file"
 msgstr ""
 "png (haldclut), 큐브, 3dl 또는 gmz(압축된 LUT) 파일을 선택하세요\n"
 "주의: LUT 파일을 선택하기 전에 환경설정 > 처리에서 3D LUT 폴더를 반드시 설정해야 합니다"
 
-#: ../src/iop/lut3d.c:1688
-msgid "select a png (haldclut), a cube or a 3dl file CAUTION: 3D LUT folder must be set in preferences/processing before choosing the LUT file"
+#: ../src/iop/lut3d.c:1701
+msgid ""
+"select a png (haldclut), a cube or a 3dl file CAUTION: 3D LUT folder must be "
+"set in preferences/processing before choosing the LUT file"
 msgstr ""
 "png (haldclut), 큐브 또는 3dl 파일을 선택하세요\n"
 "주의: LUT 파일을 선택하기 전에 환경설정 > 처리에서 3D LUT 폴더를 반드시 설정해야 합니다"
 
-#: ../src/iop/lut3d.c:1697
-msgid "the file path (relative to LUT folder) is saved with image along with the LUT data if it's a compressed LUT (gmz)"
+#: ../src/iop/lut3d.c:1710
+msgid ""
+"the file path (relative to LUT folder) is saved with image along with the "
+"LUT data if it's a compressed LUT (gmz)"
 msgstr ""
 "파일 경로 (LUT 폴더 기준 상대 경로)는 이미지와 함께 저장되며,\n"
 "압축된 LUT(gmz)의 경우 LUT 데이터도 함께 저장됩니다"
 
-#: ../src/iop/lut3d.c:1700
-msgid "the file path (relative to LUT folder) is saved with image (and not the LUT data themselves)"
+#: ../src/iop/lut3d.c:1713
+msgid ""
+"the file path (relative to LUT folder) is saved with image (and not the LUT "
+"data themselves)"
 msgstr "파일 경로 (LUT 폴더 기준 상대 경로)는 이미지 (LUT 데이터 자체는 제외)와 함께 저장됩니다"
 
-#: ../src/iop/lut3d.c:1709
+#: ../src/iop/lut3d.c:1722
 msgid "enter LUT name"
 msgstr "LUT 이름 입력"
 
-#: ../src/iop/lut3d.c:1724
+#: ../src/iop/lut3d.c:1737
 msgid "select the LUT"
 msgstr "LUT 선택"
 
-#: ../src/iop/lut3d.c:1741
+#: ../src/iop/lut3d.c:1754
 msgid "select the color space in which the LUT has to be applied"
 msgstr "LUT가 적용될 색공간 선택"
 
-#: ../src/iop/lut3d.c:1743
+#: ../src/iop/lut3d.c:1756
 msgid "interpolation"
 msgstr "보간"
 
-#: ../src/iop/lut3d.c:1744
+#: ../src/iop/lut3d.c:1757
 msgid "select the interpolation method"
 msgstr "보간 방법 선택"
 
-#: ../src/iop/mask_manager.c:42 ../src/libs/masks.c:58
+#: ../src/iop/mask_manager.c:42 ../src/libs/masks.c:74
 msgid "mask manager"
 msgstr "마스크 관리자"
 
@@ -21741,11 +25352,11 @@ msgstr ""
 msgid "red filter"
 msgstr "적색 필터"
 
-#: ../src/iop/monochrome.c:559
+#: ../src/iop/monochrome.c:557
 msgid "drag and scroll mouse wheel to adjust the virtual color filter"
 msgstr "가상 색상 필터 조정을 위해 마우스 휠을 드래그 및 스크롤"
 
-#: ../src/iop/monochrome.c:576
+#: ../src/iop/monochrome.c:574
 msgid "how much to keep highlights"
 msgstr "하이라이트 유지 정도"
 
@@ -21965,15 +25576,15 @@ msgstr ""
 msgid "toggle on or off the color controls"
 msgstr "색상 컨트롤 켜기/끄기 전환"
 
-#: ../src/iop/nlmeans.c:75
+#: ../src/iop/nlmeans.c:76
 msgid "astrophoto denoise"
 msgstr "천체 사진 노이즈 제거"
 
-#: ../src/iop/nlmeans.c:80
+#: ../src/iop/nlmeans.c:81
 msgid "denoise (non-local means)"
 msgstr "노이즈 제거 (비지역 평균)"
 
-#: ../src/iop/nlmeans.c:85
+#: ../src/iop/nlmeans.c:86
 msgid ""
 "apply a poisson noise removal\n"
 "best suited for astrophotography"
@@ -21981,22 +25592,22 @@ msgstr ""
 "푸아송 노이즈 제거 적용\n"
 "천체 사진에 적합함"
 
-#: ../src/iop/nlmeans.c:456
+#: ../src/iop/nlmeans.c:437
 msgid "radius of the patches to match"
 msgstr "일치시킬 패치 반지름"
 
-#: ../src/iop/nlmeans.c:464
+#: ../src/iop/nlmeans.c:445
 msgid "how much to smooth brightness"
 msgstr "밝기 평활 정도"
 
-#: ../src/iop/nlmeans.c:467
+#: ../src/iop/nlmeans.c:448
 msgid "how much to smooth colors"
 msgstr "색상 평활 정도"
 
 #. color scheme
-#: ../src/iop/overexposed.c:68 ../src/views/darkroom.c:2620
-#: ../src/views/darkroom.c:2646 ../src/views/darkroom.c:2658
-#: ../src/views/darkroom.c:2673 ../src/views/darkroom.c:2691
+#: ../src/iop/overexposed.c:68 ../src/views/darkroom.c:3245
+#: ../src/views/darkroom.c:3271 ../src/views/darkroom.c:3283
+#: ../src/views/darkroom.c:3298 ../src/views/darkroom.c:3316
 msgid "overexposed"
 msgstr "과다 노출"
 
@@ -22008,23 +25619,19 @@ msgstr "과다 노출 모듈이 버퍼 할당에 실패함"
 msgid "module overexposed failed in color conversion"
 msgstr "과다 노출 모듈이 색상 변환에 실패함"
 
-#: ../src/iop/overlay.c:146
+#: ../src/iop/overlay.c:170
 msgid "composite"
 msgstr "합성"
 
-#: ../src/iop/overlay.c:153
-msgid ""
-"combine the image with elements from another processed image\n"
-"(move this module to after output color profile if you see banding)"
-msgstr ""
-"다른 처리된 이미지의 요소와 현재 이미지를 합성합니다.\n"
-"(밴딩 현상이 발생하면 이 모듈을 출력 색상 프로파일 이후로 이동하세요)"
+#: ../src/iop/overlay.c:176
+msgid "combine the image with elements from another processed image"
+msgstr "이미지를 다른 처리된 이미지의 요소와 결합"
 
-#: ../src/iop/overlay.c:163
+#: ../src/iop/overlay.c:185
 msgid "layer|stack|overlay"
 msgstr "레이어|스택|오버레이"
 
-#: ../src/iop/overlay.c:299
+#: ../src/iop/overlay.c:327
 #, c-format
 msgid ""
 "overlay image missing from database\n"
@@ -22032,13 +25639,13 @@ msgid ""
 "'%s'"
 msgstr "데이터베이스에서 오버레이 이미지 '%s'를 찾을 수 없음"
 
-#: ../src/iop/overlay.c:333
+#: ../src/iop/overlay.c:387
 #, c-format
 msgid "image %d does not exist"
 msgstr "이미지 %d가 존재하지 않음"
 
 #. TRANSLATORS: This text must be very narrow, check in the GUI that it is not truncated
-#: ../src/iop/overlay.c:797
+#: ../src/iop/overlay.c:1109
 msgid ""
 "drop\n"
 "image\n"
@@ -22050,22 +25657,26 @@ msgstr ""
 "여기로\n"
 "드롭하세요"
 
-#: ../src/iop/overlay.c:1018
+#: ../src/iop/overlay.c:1403
 #, c-format
-msgid "cannot use image %d as an overlay as it is using the current image as an overlay, directly or indirectly"
+msgid ""
+"cannot use image %d as an overlay as it is using the current image as an "
+"overlay, directly or indirectly"
 msgstr "이미지 %d는 현재 이미지를 오버레이로 직접 또는 간접적으로 사용 중이므로오버레이로 사용할 수 없습니다"
 
-#: ../src/iop/overlay.c:1112 ../src/iop/watermark.c:1373
+#: ../src/iop/overlay.c:1500 ../src/iop/watermark.c:1476
 msgctxt "section"
 msgid "placement"
 msgstr "배치"
 
-#: ../src/iop/overlay.c:1128
+#: ../src/iop/overlay.c:1516
 msgid ""
 "choose how to scale the overlay\n"
 "• image: scale overlay relative to whole image\n"
-"• larger border: scale larger overlay border relative to larger image border\n"
-"• smaller border: scale larger overlay border relative to smaller image border\n"
+"• larger border: scale larger overlay border relative to larger image "
+"border\n"
+"• smaller border: scale larger overlay border relative to smaller image "
+"border\n"
 "• height: scale overlay height to image height\n"
 "• advanced options: choose overlay and image dimensions independently"
 msgstr ""
@@ -22076,29 +25687,29 @@ msgstr ""
 "• 높이: 오버레이 높이를 이미지 높이에 맞게 조절\n"
 "• 고급 옵션: 오버레이와 이미지 크기를 독립적으로 선택"
 
-#: ../src/iop/overlay.c:1139
+#: ../src/iop/overlay.c:1527
 msgid "reference image dimension against which to scale the overlay"
 msgstr "오버레이를 스케일할 참조 이미지 크기"
 
-#: ../src/iop/overlay.c:1143
+#: ../src/iop/overlay.c:1531
 msgid "overlay dimension to scale"
 msgstr "스케일할 오버레이 크기"
 
-#: ../src/iop/overlay.c:1147 ../src/iop/watermark.c:1404
-#: ../src/libs/print_settings.c:2753
+#: ../src/iop/overlay.c:1535 ../src/iop/watermark.c:1511
+#: ../src/libs/print_settings.c:2773
 msgid "alignment"
 msgstr "정렬"
 
 #. Let's add some tooltips and hook up some signals...
-#: ../src/iop/overlay.c:1171
+#: ../src/iop/overlay.c:1559
 msgid "the opacity of the overlay"
 msgstr "오버레이 불투명도"
 
-#: ../src/iop/overlay.c:1172
+#: ../src/iop/overlay.c:1560
 msgid "the scale of the overlay"
 msgstr "오버레이 스케일"
 
-#: ../src/iop/overlay.c:1173
+#: ../src/iop/overlay.c:1561
 msgid "the rotation of the overlay"
 msgstr "오버레이 회전"
 
@@ -22162,19 +25773,19 @@ msgstr "10 EV 다이나믹 레인지 (일반)"
 msgid "08 EV dynamic range (generic)"
 msgstr "08 EV 다이나믹 레인지 (일반)"
 
-#: ../src/iop/profile_gamma.c:609
+#: ../src/iop/profile_gamma.c:604
 msgid "linear part"
 msgstr "선형 부분"
 
-#: ../src/iop/profile_gamma.c:613
+#: ../src/iop/profile_gamma.c:608
 msgid "gamma exponential factor"
 msgstr "감마 지수 계수"
 
-#: ../src/iop/profile_gamma.c:624
+#: ../src/iop/profile_gamma.c:619
 msgid "adjust to match the average luma of the subject"
 msgstr "피사체 평균 휘도에 맞게 조정"
 
-#: ../src/iop/profile_gamma.c:630
+#: ../src/iop/profile_gamma.c:625
 msgid ""
 "number of stops between middle gray and pure black\n"
 "this is a reading a light meter would give you on the scene"
@@ -22182,7 +25793,7 @@ msgstr ""
 "중간 회색값과 순 사이의 스톱 수\n"
 "이는 장면에서 측광기가 제공하는 측정값입니다"
 
-#: ../src/iop/profile_gamma.c:636
+#: ../src/iop/profile_gamma.c:631
 msgid ""
 "number of stops between pure black and pure white\n"
 "this is a reading a light meter would give you on the scene"
@@ -22190,12 +25801,12 @@ msgstr ""
 "순흑색과 순백색 사이의 노출 스톱 수\n"
 "이는 장면에서 측광기가 제공하는 측정값입니다"
 
-#: ../src/iop/profile_gamma.c:638
+#: ../src/iop/profile_gamma.c:633
 msgctxt "section"
 msgid "optimize automatically"
 msgstr "자동 최적화"
 
-#: ../src/iop/profile_gamma.c:642
+#: ../src/iop/profile_gamma.c:637
 msgid ""
 "increase or decrease the computed dynamic range\n"
 "this is useful when noise distorts the measurement"
@@ -22203,15 +25814,91 @@ msgstr ""
 "계산된 다이나믹 레인지를 늘리거나 줄입니다\n"
 "노이즈로 인해 측정값이 왜곡될 때 유용합니다"
 
-#: ../src/iop/profile_gamma.c:646
+#: ../src/iop/profile_gamma.c:641
 msgid "make an optimization with some guessing"
 msgstr "일부 추정을 기반으로 최적화를 수행합니다"
 
-#: ../src/iop/profile_gamma.c:655
+#: ../src/iop/profile_gamma.c:650
 msgid "tone mapping method"
 msgstr "톤 매핑 방식"
 
-#: ../src/iop/rawdenoise.c:134
+#: ../src/iop/rasterfile.c:94
+msgid "external raster masks"
+msgstr "외부 래스터 마스크"
+
+#: ../src/iop/rasterfile.c:99
+msgid "raster|mask"
+msgstr "래스터|마스크"
+
+#: ../src/iop/rasterfile.c:105
+msgid "read PFM/PNG files recorded for use as raster masks"
+msgstr "래스터 마스크로 사용할 PFM/PNG 파일을 읽기"
+
+#: ../src/iop/rasterfile.c:178
+msgid ""
+"no mask extracted from the raster file\n"
+"make sure the masks have proper contrast"
+msgstr ""
+"래스터 파일에서 마스크를 추출하지 못했습니다\n"
+"마스크에 충분한 대비가 있는지 확인하세요"
+
+#: ../src/iop/rasterfile.c:183
+#, c-format
+msgid "%d mask extracted from the raster file"
+msgid_plural "%d masks extracted from the raster file"
+msgstr[0] "래스터 파일에서 마스크 %d개를 추출하였습니다"
+
+#: ../src/iop/rasterfile.c:210 ../src/iop/rasterfile.c:221
+#: ../src/iop/rasterfile.c:229 ../src/iop/rasterfile.c:240
+#: ../src/iop/rasterfile.c:289
+#, c-format
+msgid "can't read raster mask file '%s'"
+msgstr "래스터 마스크 파일 '%s'을(를) 읽을 수 없습니다"
+
+#: ../src/iop/rasterfile.c:375
+msgid "raster mask files root folder not defined"
+msgstr "래스터 마스크 파일의 루트 폴더가 정의되지 않았습니다"
+
+#: ../src/iop/rasterfile.c:382
+msgid "select raster mask file"
+msgstr "래스터 마스크 파일 선택"
+
+#: ../src/iop/rasterfile.c:416
+msgid "selected file not within raster masks root folder"
+msgstr "선택한 파일이 래스터 마스크 루트 폴더 내에 없습니다"
+
+#: ../src/iop/rasterfile.c:743
+msgid "select the RGB channels taken into account to generate the raster mask"
+msgstr "래스터 마스크 생성을 위해 고려할 RGB 채널을 선택합니다"
+
+#: ../src/iop/rasterfile.c:749
+msgid ""
+"select the PFM/PNG file recorded as a raster mask,\n"
+"CAUTION: path must be set in preferences/processing before choosing"
+msgstr ""
+"래스터 마스크로 기록된 PFM/PNG 파일을 선택하세요\n"
+"주의: 선택 전에 환경설정/처리에서 경로를 설정해야 합니다"
+
+#: ../src/iop/rasterfile.c:758
+msgid "the mask file path is saved with the image history"
+msgstr "마스크 파일 경로는 이미지 히스토리와 함께 저장됩니다"
+
+#. Vectorize button
+#: ../src/iop/rasterfile.c:764
+msgid "vectorize"
+msgstr "벡터화"
+
+#: ../src/iop/rasterfile.c:767
+msgid ""
+"vectorize the current bitmap and create corresponding path masks in the mask "
+"manager"
+msgstr "현재 비트맵을 벡터화하여 마스크 관리자에 해당하는 경로 마스크를 생성합니다"
+
+#. raw denoise sits first: it runs earliest in the denoise workflow
+#. (before demosaic-stage processing). bayer / linear variant selection
+#. is driven by the active "rawdenoise" model rather than a UI toggle
+#: ../src/iop/rawdenoise.c:134 ../src/libs/neural_restore.c:1436
+#: ../src/libs/neural_restore.c:4277
 msgid "raw denoise"
 msgstr "RAW 노이즈 제거"
 
@@ -22219,7 +25906,7 @@ msgstr "RAW 노이즈 제거"
 msgid "denoise the raw image early in the pipeline"
 msgstr "RAW 이미지에서 초기에 노이즈를 제거합니다"
 
-#: ../src/iop/rawdenoise.c:927
+#: ../src/iop/rawdenoise.c:929
 msgid ""
 "raw denoising\n"
 "only works for raw images."
@@ -22227,56 +25914,11 @@ msgstr ""
 "RAW 노이즈 제거는\n"
 "RAW 이미지에만 작동합니다."
 
-#: ../src/iop/rasterfile.c:88
-msgid "external raster masks"
-msgstr "외부 래스터 마스크"
-
-#: ../src/iop/rasterfile.c:93
-msgid "raster|mask"
-msgstr "래스터|마스크"
-
-#: ../src/iop/rasterfile.c:99
-msgid "read PFM files recorded for use as raster masks"
-msgstr "래스터 마스크로 사용할 PFM 파일을 읽기"
-
-#: ../src/iop/rasterfile.c:168
-#, c-format
-msgid "can't read raster mask file '%s'"
-msgstr "래스터 마스크 파일 '%s'을(를) 읽을 수 없습니다"
-
-#: ../src/iop/rasterfile.c:254
-msgid "raster mask files root folder not defined"
-msgstr "래스터 마스크 파일의 루트 폴더가 정의되지 않았습니다"
-
-#: ../src/iop/rasterfile.c:261
-msgid "select raster mask file"
-msgstr "래스터 마스크 파일 선택"
-
-#: ../src/iop/rasterfile.c:295
-msgid "selected file not within raster masks root folder"
-msgstr "선택한 파일이 래스터 마스크 루트 폴더 내에 없습니다"
-
-#: ../src/iop/rasterfile.c:591
-msgid "select the RGB channels taken into account to generate the raster mask"
-msgstr "래스터 마스크 생성을 위해 고려할 RGB 채널을 선택합니다"
-
-#: ../src/iop/rasterfile.c:595
-msgid ""
-"select the PFM file recorded as a raster mask,\n"
-"CAUTION: path must be set in preferences/processing before choosing"
-msgstr ""
-"래스터 마스크로 녹화된 PFM 파일을 선택하세요\n"
-"주의: 선택 전에 환경설정/처리에서 경로를 설정해야 합니다"
-
-#: ../src/iop/rasterfile.c:601
-msgid "the mask file path is saved with the image history"
-msgstr "마스크 파일 경로는 이미지 히스토리와 함께 저장됩니다"
-
 #. * let's fill the encapsulating widgets
 #. mode of operation
-#: ../src/iop/rawoverexposed.c:65 ../src/views/darkroom.c:2555
-#: ../src/views/darkroom.c:2578 ../src/views/darkroom.c:2588
-#: ../src/views/darkroom.c:2604
+#: ../src/iop/rawoverexposed.c:65 ../src/views/darkroom.c:3180
+#: ../src/views/darkroom.c:3203 ../src/views/darkroom.c:3213
+#: ../src/views/darkroom.c:3229
 msgid "raw overexposed"
 msgstr "RAW 과다노출"
 
@@ -22304,7 +25946,8 @@ msgid "invalid crop parameters"
 msgstr "잘못된 자르기 파라메터"
 
 #: ../src/iop/rawprepare.c:608
-msgid "please reset to defaults, update your preset or set to something correct"
+msgid ""
+"please reset to defaults, update your preset or set to something correct"
 msgstr "기본값으로 리셋하거나, 프리셋을 업데이트하거나, 올바른 값으로 설정하세요"
 
 #: ../src/iop/rawprepare.c:877
@@ -22367,7 +26010,8 @@ msgid "fill light"
 msgstr "밝기 보정"
 
 #: ../src/iop/relight.c:93 ../src/iop/zonesystem.c:104
-msgid "this module is deprecated. please use the tone equalizer module instead."
+msgid ""
+"this module is deprecated. please use the tone equalizer module instead."
 msgstr "이 모듈은 더 이상 사용되지 않습니다. 톤 이퀄라이저 모듈을 대신 사용하세요."
 
 #: ../src/iop/relight.c:250
@@ -22410,29 +26054,29 @@ msgstr ""
 msgid "geometric and frequential, RGB"
 msgstr "기하학적 및 주파수 기반, RGB"
 
-#: ../src/iop/retouch.c:1678
+#: ../src/iop/retouch.c:1679
 msgid "cannot display scales when the blending mask is displayed"
 msgstr "블렌딩 마스크가 표시될 때 눈금 표시 불가"
 
-#: ../src/iop/retouch.c:2032 ../src/iop/retouch.c:2034
-#: ../src/iop/retouch.c:2036 ../src/iop/retouch.c:2038
+#: ../src/iop/retouch.c:2031 ../src/iop/retouch.c:2033
+#: ../src/iop/retouch.c:2035 ../src/iop/retouch.c:2037
 #, c-format
 msgid "default tool changed to %s"
 msgstr "기본 도구가 %s로 변경됨"
 
-#: ../src/iop/retouch.c:2032
+#: ../src/iop/retouch.c:2031
 msgid "cloning"
 msgstr "복제"
 
-#: ../src/iop/retouch.c:2034
+#: ../src/iop/retouch.c:2033
 msgid "healing"
 msgstr "힐링"
 
-#: ../src/iop/retouch.c:2432
+#: ../src/iop/retouch.c:2430
 msgid "shapes:"
 msgstr "도형:"
 
-#: ../src/iop/retouch.c:2435
+#: ../src/iop/retouch.c:2433
 msgid ""
 "to add a shape select an algorithm and a shape type and click on the image.\n"
 "shapes are added to the current scale"
@@ -22440,63 +26084,63 @@ msgstr ""
 "도형을 추가하려면 알고리즘과 도형 종류를 선택한 뒤 이미지에 클릭하세요.\n"
 "도형은 현재 눈금에 추가됩니다"
 
-#: ../src/iop/retouch.c:2439 ../src/iop/retouch.c:2557
-#: ../src/iop/retouch.c:2563 ../src/iop/retouch.c:2571
-#: ../src/iop/retouch.c:2576 ../src/iop/retouch.c:2583
-#: ../src/iop/retouch.c:2614
+#: ../src/iop/retouch.c:2437 ../src/iop/retouch.c:2555
+#: ../src/iop/retouch.c:2561 ../src/iop/retouch.c:2569
+#: ../src/iop/retouch.c:2574 ../src/iop/retouch.c:2581
+#: ../src/iop/retouch.c:2612
 msgid "editing"
 msgstr "편집"
 
-#: ../src/iop/retouch.c:2440
+#: ../src/iop/retouch.c:2438
 msgid "show and edit shapes on the current scale"
 msgstr "현재 눈금에서 도형 표시 및 편집"
 
-#: ../src/iop/retouch.c:2441
+#: ../src/iop/retouch.c:2439
 msgid "show and edit shapes in restricted mode"
 msgstr "제한 모드에서 도형 표시 및 편집"
 
 #. algorithm toolbar
-#: ../src/iop/retouch.c:2467
+#: ../src/iop/retouch.c:2465
 msgid "algorithms:"
 msgstr "알고리즘:"
 
-#: ../src/iop/retouch.c:2470 ../src/iop/retouch.c:2493
+#: ../src/iop/retouch.c:2468 ../src/iop/retouch.c:2491
 msgid "activate blur tool"
 msgstr "블러 도구 활성화"
 
-#: ../src/iop/retouch.c:2475 ../src/iop/retouch.c:2494
+#: ../src/iop/retouch.c:2473 ../src/iop/retouch.c:2492
 msgid "activate fill tool"
 msgstr "채우기 도구 활성화"
 
-#: ../src/iop/retouch.c:2480 ../src/iop/retouch.c:2495
+#: ../src/iop/retouch.c:2478 ../src/iop/retouch.c:2493
 msgid "activate cloning tool"
 msgstr "복제 도구 활성화"
 
-#: ../src/iop/retouch.c:2485 ../src/iop/retouch.c:2496
+#: ../src/iop/retouch.c:2483 ../src/iop/retouch.c:2494
 msgid "activate healing tool"
 msgstr "힐링 도구 활성화"
 
-#: ../src/iop/retouch.c:2491
+#: ../src/iop/retouch.c:2489
 msgid "ctrl+click to change tool for current form"
 msgstr "Ctrl+클릭으로 현재 도형에 사용할 도구 변경"
 
-#: ../src/iop/retouch.c:2492
+#: ../src/iop/retouch.c:2490
 msgid "shift+click to set the tool as default"
 msgstr "Shift+클릭으로 해당 도구를 기본값으로 설정"
 
-#: ../src/iop/retouch.c:2503
+#: ../src/iop/retouch.c:2501
 msgid "scales:"
 msgstr "눈금:"
 
-#: ../src/iop/retouch.c:2510
+#: ../src/iop/retouch.c:2508
 msgid "current:"
 msgstr "현재:"
 
-#: ../src/iop/retouch.c:2517
+#: ../src/iop/retouch.c:2515
 msgid "merge from:"
 msgstr "병합 대상:"
 
-#: ../src/iop/retouch.c:2528
+#: ../src/iop/retouch.c:2526
 msgid ""
 "top slider adjusts where the merge scales start\n"
 "bottom slider adjusts the number of scales\n"
@@ -22510,45 +26154,45 @@ msgstr ""
 "윗줄은 현재 확대 수준에서 눈금이 보이는 것을 나타냅니다\n"
 "아랫줄은 해당 눈금에 도형이 포함되어 있음을 나타냅니다"
 
-#: ../src/iop/retouch.c:2557
+#: ../src/iop/retouch.c:2555
 msgid "display masks"
 msgstr "마스크 표시"
 
-#: ../src/iop/retouch.c:2563
+#: ../src/iop/retouch.c:2561
 msgid "temporarily switch off shapes"
 msgstr "도형 일시적으로 비활성화"
 
-#: ../src/iop/retouch.c:2571
+#: ../src/iop/retouch.c:2569
 msgid "paste cut shapes to current scale"
 msgstr "잘라낸 도형을 현재 눈금에 붙여넣기"
 
-#: ../src/iop/retouch.c:2576
+#: ../src/iop/retouch.c:2574
 msgid "cut shapes from current scale"
 msgstr "현재 눈금에서 도형 잘라내기"
 
-#: ../src/iop/retouch.c:2583
+#: ../src/iop/retouch.c:2581
 msgid "display wavelet scale"
 msgstr "웨이블릿 눈금 표시"
 
-#: ../src/iop/retouch.c:2597
+#: ../src/iop/retouch.c:2595
 msgid "adjust preview levels"
 msgstr "미리보기 단계 조절"
 
-#: ../src/iop/retouch.c:2614 ../src/iop/rgblevels.c:1082
+#: ../src/iop/retouch.c:2612 ../src/iop/rgblevels.c:1082
 msgid "auto levels"
 msgstr "자동 레벨"
 
-#: ../src/iop/retouch.c:2618
+#: ../src/iop/retouch.c:2616
 msgctxt "section"
 msgid "preview single scale"
 msgstr "단일 눈금 미리보기"
 
 #. shapes selected (label)
-#: ../src/iop/retouch.c:2622
+#: ../src/iop/retouch.c:2620
 msgid "shape selected:"
 msgstr "선택된 도형:"
 
-#: ../src/iop/retouch.c:2628
+#: ../src/iop/retouch.c:2626
 msgid ""
 "click on a shape to select it,\n"
 "to unselect click on an empty space"
@@ -22556,58 +26200,58 @@ msgstr ""
 "도형을 클릭해 선택하고,\n"
 "선택 해제하려면 빈 공간을 클릭하세요"
 
-#: ../src/iop/retouch.c:2635
+#: ../src/iop/retouch.c:2633
 msgid "erase the detail or fills with chosen color"
 msgstr "선택한 색으로 디테일 또는 채우기 지우기"
 
-#: ../src/iop/retouch.c:2646 ../src/iop/retouch.c:2647
+#: ../src/iop/retouch.c:2644 ../src/iop/retouch.c:2645
 msgid "select fill color"
 msgstr "채우기 색상 선택"
 
-#: ../src/iop/retouch.c:2655
+#: ../src/iop/retouch.c:2653
 msgid "pick fill color from image"
 msgstr "이미지에서 채우기 색상 선택"
 
-#: ../src/iop/retouch.c:2656
+#: ../src/iop/retouch.c:2654
 msgid "pick fill color"
 msgstr "채우기 색상 고르기"
 
-#: ../src/iop/retouch.c:2659
+#: ../src/iop/retouch.c:2657
 msgid "fill color: "
 msgstr "채우기 색상: "
 
-#: ../src/iop/retouch.c:2668
+#: ../src/iop/retouch.c:2666
 msgid "adjusts color brightness to fine-tune it. works with erase as well"
 msgstr "색상의 밝기를 조절해 미세하게 조정합니다. 지우기 도구에서도 작동합니다"
 
-#: ../src/iop/retouch.c:2674
+#: ../src/iop/retouch.c:2672
 msgid "type for the blur algorithm"
 msgstr "블러 알고리즘 타입"
 
-#: ../src/iop/retouch.c:2678
+#: ../src/iop/retouch.c:2676
 msgid "radius of the selected blur type"
 msgstr "선택한 블러 타입의 반지름"
 
-#: ../src/iop/retouch.c:2685
+#: ../src/iop/retouch.c:2683
 msgid "set the opacity on the selected shape"
 msgstr "선택한 도형의 불투명도 설정"
 
-#: ../src/iop/retouch.c:2691
+#: ../src/iop/retouch.c:2689
 msgctxt "section"
 msgid "retouch tools"
 msgstr "리터치 도구"
 
-#: ../src/iop/retouch.c:2693
+#: ../src/iop/retouch.c:2691
 msgctxt "section"
 msgid "wavelet decompose"
 msgstr "웨이블릿 분해"
 
-#: ../src/iop/retouch.c:2697
+#: ../src/iop/retouch.c:2695
 msgctxt "section"
 msgid "shapes"
 msgstr "도형"
 
-#: ../src/iop/retouch.c:3840 ../src/iop/retouch.c:4662
+#: ../src/iop/retouch.c:3979 ../src/iop/retouch.c:4810
 #, c-format
 msgid "max scale is %i for this image size"
 msgstr "이 이미지 크기에서 최대 눈금은 %i입니다"
@@ -22730,7 +26374,7 @@ msgstr ""
 "특정 센서 종류와 \n"
 "아나모픽 디스퀴즈에 유용함"
 
-#: ../src/iop/scalepixels.c:259
+#: ../src/iop/scalepixels.c:280
 msgid "adjust pixel aspect ratio"
 msgstr "픽셀 종횡비 조정"
 
@@ -22746,27 +26390,27 @@ msgstr ""
 "쉐도우 및 하이라이트의 톤 범위를 조정하여 \n"
 "부분 대비 향상"
 
-#: ../src/iop/shadhi.c:686 ../src/iop/splittoning.c:527
+#: ../src/iop/shadhi.c:684 ../src/iop/splittoning.c:527
 msgid "compress"
 msgstr "압축"
 
-#: ../src/iop/shadhi.c:693
+#: ../src/iop/shadhi.c:691
 msgid "correct shadows"
 msgstr "쉐도우 보정"
 
-#: ../src/iop/shadhi.c:694
+#: ../src/iop/shadhi.c:692
 msgid "correct highlights"
 msgstr "하이라이트 보정"
 
-#: ../src/iop/shadhi.c:695
+#: ../src/iop/shadhi.c:693
 msgid "shift white point"
 msgstr "화이트 포인트 이동"
 
-#: ../src/iop/shadhi.c:697
+#: ../src/iop/shadhi.c:695
 msgid "filter to use for softening. bilateral avoids halos"
 msgstr "소프트닝에 사용할 필터. 양방향 필터는 헤일로를 방지합니다"
 
-#: ../src/iop/shadhi.c:698
+#: ../src/iop/shadhi.c:696
 msgid ""
 "compress the effect on shadows/highlights and\n"
 "preserve mid-tones"
@@ -22774,11 +26418,11 @@ msgstr ""
 "쉐도우와 하이라이트에 대한 효과를 압축하고\n"
 "중간 톤은 보존합니다"
 
-#: ../src/iop/shadhi.c:699
+#: ../src/iop/shadhi.c:697
 msgid "adjust saturation of shadows"
 msgstr "쉐도우 채도 조정"
 
-#: ../src/iop/shadhi.c:700
+#: ../src/iop/shadhi.c:698
 msgid "adjust saturation of highlights"
 msgstr "하이라이트 채도 조정"
 
@@ -22799,15 +26443,15 @@ msgstr "선형 또는 비선형, Lab, 디스플레이 또는 장면 기준"
 msgid "quasi-linear, Lab, display or scene-referred"
 msgstr "준선형, Lab, 디스플레이 또는 장면 기준"
 
-#: ../src/iop/sharpen.c:430
+#: ../src/iop/sharpen.c:419
 msgid "spatial extent of the unblurring"
 msgstr "언블러링이 적용되는 공간 범위"
 
-#: ../src/iop/sharpen.c:434
+#: ../src/iop/sharpen.c:423
 msgid "strength of the sharpen"
 msgstr "샤프닝 강도"
 
-#: ../src/iop/sharpen.c:438
+#: ../src/iop/sharpen.c:427
 msgid "threshold to activate sharpen"
 msgstr "샤프닝 활성화 임계값"
 
@@ -22837,7 +26481,7 @@ msgstr "ACES 100니트 유사"
 msgid "Reinhard"
 msgstr "레인하드"
 
-#: ../src/iop/sigmoid.c:904
+#: ../src/iop/sigmoid.c:895
 msgid ""
 "compression of the applied curve\n"
 "implicitly defines the supported input dynamic range"
@@ -22845,7 +26489,7 @@ msgstr ""
 "적용된 곡선의 압축 정도는\n"
 "지원되는 입력 다이나믹 레인지를 간접적으로 정의합니다"
 
-#: ../src/iop/sigmoid.c:907
+#: ../src/iop/sigmoid.c:898
 msgid ""
 "shift the compression towards shadows or highlights.\n"
 "negative values increase contrast in shadows.\n"
@@ -22857,7 +26501,7 @@ msgstr ""
 "양수 값은 하이라이트의 대비를 높입니다.\n"
 "반대 쪽 영역에서는 대비가 감소합니다."
 
-#: ../src/iop/sigmoid.c:916
+#: ../src/iop/sigmoid.c:907
 msgid ""
 "optional correction of the hue twist introduced by\n"
 "the per-channel processing method."
@@ -22865,11 +26509,11 @@ msgstr ""
 "채널별 처리 방식에서 발생할 수 있는\n"
 "색조 왜곡을 선택적으로 보정합니다."
 
-#: ../src/iop/sigmoid.c:924
+#: ../src/iop/sigmoid.c:915
 msgid "set custom primaries"
 msgstr "사용자 지정 기본색상 설정"
 
-#: ../src/iop/sigmoid.c:930
+#: ../src/iop/sigmoid.c:921
 msgid ""
 "primaries to use as the base for below adjustments\n"
 "'working profile' uses the profile set in 'input color profile'"
@@ -22877,43 +26521,43 @@ msgstr ""
 "이후 조정을 위한 기반이되는 기본색상을 설정합니다\n"
 "'작업 프로파일'은 '입력 색상 프로파일'에 지정된 프로파일을 사용합니다"
 
-#: ../src/iop/sigmoid.c:950
+#: ../src/iop/sigmoid.c:941
 msgid "attenuate the purity of the red primary"
 msgstr "빨강 원색의 채도 감소"
 
-#: ../src/iop/sigmoid.c:951
+#: ../src/iop/sigmoid.c:942
 msgid "rotate the red primary"
 msgstr "빨강 원색 회전"
 
-#: ../src/iop/sigmoid.c:952
+#: ../src/iop/sigmoid.c:943
 msgid "attenuate the purity of the green primary"
 msgstr "녹색 원색의 채도 감소"
 
-#: ../src/iop/sigmoid.c:953
+#: ../src/iop/sigmoid.c:944
 msgid "rotate the green primary"
 msgstr "녹색 원색 회전"
 
-#: ../src/iop/sigmoid.c:954
+#: ../src/iop/sigmoid.c:945
 msgid "attenuate the purity of the blue primary"
 msgstr "파랑 원색의 채도 감소"
 
-#: ../src/iop/sigmoid.c:955
+#: ../src/iop/sigmoid.c:946
 msgid "rotate the blue primary"
 msgstr "파랑 원색 회전"
 
-#: ../src/iop/sigmoid.c:962
+#: ../src/iop/sigmoid.c:953
 msgid "recover some of the original purity after the inset"
 msgstr "삽입 이후 일부 원래의 채도를 복원"
 
-#: ../src/iop/sigmoid.c:966
+#: ../src/iop/sigmoid.c:957
 msgid "display luminance"
 msgstr "디스플레이 휘도"
 
-#: ../src/iop/sigmoid.c:967
+#: ../src/iop/sigmoid.c:958
 msgid "set display black/white targets"
 msgstr "디스플레이 흑/백 기준 설정"
 
-#: ../src/iop/sigmoid.c:975
+#: ../src/iop/sigmoid.c:966
 msgid ""
 "the black luminance of the target display or print.\n"
 "can be used creatively for a faded look."
@@ -22921,7 +26565,7 @@ msgstr ""
 "대상 디스플레이 또는 인쇄물의 검은색 휘도입니다.\n"
 "바랜 느낌을 연출할 때 창의적으로 활용할 수 있습니다."
 
-#: ../src/iop/sigmoid.c:980
+#: ../src/iop/sigmoid.c:971
 msgid ""
 "the white luminance of the target display or print.\n"
 "can be used creatively for a faded look or blowing out whites earlier."
@@ -22937,19 +26581,19 @@ msgstr "소프트 효과"
 msgid "create a softened image using the Orton effect"
 msgstr "오톤 효과를 이용해 부드러운 이미지를 생성"
 
-#: ../src/iop/soften.c:383
+#: ../src/iop/soften.c:374
 msgid "the size of blur"
 msgstr "블러 크기"
 
-#: ../src/iop/soften.c:387
+#: ../src/iop/soften.c:378
 msgid "the saturation of blur"
 msgstr "블러 채도"
 
-#: ../src/iop/soften.c:391
+#: ../src/iop/soften.c:382
 msgid "the brightness of blur"
 msgstr "블러 밝기"
 
-#: ../src/iop/soften.c:395
+#: ../src/iop/soften.c:386
 msgid "the mix of effect"
 msgstr "효과 혼합 비율"
 
@@ -23062,102 +26706,102 @@ msgstr "화이트 밸런스"
 msgid "scale raw RGB channels to balance white and help demosaicing"
 msgstr "RAW RGB 채널의 균형을 맞추고 모자이크 제거를 돕습니다"
 
-#: ../src/iop/temperature.c:1444
+#: ../src/iop/temperature.c:1428
 #, c-format
 msgid "`%s' color matrix not found for image"
 msgstr "`%s' 색상 매트릭스를 이미지에서 찾을 수 없습니다"
 
-#: ../src/iop/temperature.c:1500
+#: ../src/iop/temperature.c:1484
 #, c-format
 msgid "failed to read camera white balance information from `%s'!"
 msgstr "`%s'에서 카메라 화이트 밸런스 정보를 읽는 데 실패했습니다!"
 
 #. old "camera". reason for change: all other RAW development
 #. tools use "As Shot" or "shot"
-#: ../src/iop/temperature.c:1668
+#: ../src/iop/temperature.c:1652
 msgctxt "white balance"
 msgid "as shot"
 msgstr "촬영 당시"
 
 #. old "spot", reason: describes exactly what'll happen
-#: ../src/iop/temperature.c:1671
+#: ../src/iop/temperature.c:1655
 msgctxt "white balance"
 msgid "from image area"
 msgstr "이미지 영역에서"
 
-#: ../src/iop/temperature.c:1672
+#: ../src/iop/temperature.c:1656
 msgctxt "white balance"
 msgid "user modified"
 msgstr "사용자 수정"
 
 #. old "camera neutral", reason: better matches intent
-#: ../src/iop/temperature.c:1674
+#: ../src/iop/temperature.c:1658
 msgctxt "white balance"
 msgid "camera reference"
 msgstr "카메라 기준값"
 
-#: ../src/iop/temperature.c:1675
+#: ../src/iop/temperature.c:1659
 msgctxt "white balance"
 msgid "as shot to reference"
 msgstr "촬영 당시 설정을 기준값으로 변환"
 
-#: ../src/iop/temperature.c:1981 ../src/iop/temperature.c:1999
+#: ../src/iop/temperature.c:1965 ../src/iop/temperature.c:1983
 msgid "green channel coefficient"
 msgstr "녹색 채널 계수"
 
-#: ../src/iop/temperature.c:1983
+#: ../src/iop/temperature.c:1967
 msgid "magenta channel coefficient"
 msgstr "마젠타 채널 계수"
 
-#: ../src/iop/temperature.c:1985
+#: ../src/iop/temperature.c:1969
 msgid "cyan channel coefficient"
 msgstr "시안 채널 계수"
 
-#: ../src/iop/temperature.c:1987
+#: ../src/iop/temperature.c:1971
 msgid "yellow channel coefficient"
 msgstr "노랑 채널 계수"
 
-#: ../src/iop/temperature.c:1997
+#: ../src/iop/temperature.c:1981
 msgid "red channel coefficient"
 msgstr "빨강 채널 계수"
 
-#: ../src/iop/temperature.c:2001
+#: ../src/iop/temperature.c:1985
 msgid "blue channel coefficient"
 msgstr "파랑 채널 계수"
 
-#: ../src/iop/temperature.c:2002
+#: ../src/iop/temperature.c:1986
 msgid "emerald"
 msgstr "에메랄드"
 
-#: ../src/iop/temperature.c:2003
+#: ../src/iop/temperature.c:1987
 msgid "emerald channel coefficient"
 msgstr "에메랄드 채널 계수"
 
-#: ../src/iop/temperature.c:2077
+#: ../src/iop/temperature.c:2062
 msgid "as shot"
 msgstr "촬영 당시"
 
-#: ../src/iop/temperature.c:2080
+#: ../src/iop/temperature.c:2065
 msgid "set white balance to as shot"
 msgstr "화이트 밸런스를 촬영 당시 설정으로 설정"
 
-#: ../src/iop/temperature.c:2090
+#: ../src/iop/temperature.c:2075
 msgid "from image area"
 msgstr "이미지 영역에서"
 
-#: ../src/iop/temperature.c:2097
+#: ../src/iop/temperature.c:2082
 msgid "user modified"
 msgstr "사용자 수정"
 
-#: ../src/iop/temperature.c:2100
+#: ../src/iop/temperature.c:2085
 msgid "set white balance to user modified"
 msgstr "화이트 밸런스를 사용자 수정값으로 설정"
 
-#: ../src/iop/temperature.c:2103
+#: ../src/iop/temperature.c:2088
 msgid "camera reference"
 msgstr "카메라 기준"
 
-#: ../src/iop/temperature.c:2108
+#: ../src/iop/temperature.c:2093
 msgid ""
 "set white balance to camera reference point\n"
 "in most cases it should be D65"
@@ -23165,11 +26809,11 @@ msgstr ""
 "화이트 밸런스를 카메라 기준점으로 설정합니다\n"
 "대부분의 경우 D65가 사용됩니다"
 
-#: ../src/iop/temperature.c:2112
+#: ../src/iop/temperature.c:2097
 msgid "as shot to reference"
 msgstr "촬영 당시 설정을 기준값으로 변환"
 
-#: ../src/iop/temperature.c:2117
+#: ../src/iop/temperature.c:2102
 msgid ""
 "set white balance to as shot and later correct to camera reference point,\n"
 "in most cases it should be D65"
@@ -23177,48 +26821,48 @@ msgstr ""
 "화이트 밸런스를 촬영 당시 설정으로 적용한 후,\n"
 "카메라 기준점으로 보정합니다. 대부분의 경우 D65가 사용됩니다"
 
-#: ../src/iop/temperature.c:2131
+#: ../src/iop/temperature.c:2116
 msgid "choose white balance setting"
 msgstr "화이트 밸런스 설정 선택"
 
-#: ../src/iop/temperature.c:2135
+#: ../src/iop/temperature.c:2120
 msgid "finetune"
 msgstr "미세 조정"
 
-#: ../src/iop/temperature.c:2137
+#: ../src/iop/temperature.c:2122
 msgid "fine tune camera's white balance setting"
 msgstr "카메라의 화이트 밸런스 설정을 미세하게 조정합니다"
 
-#: ../src/iop/temperature.c:2144
+#: ../src/iop/temperature.c:2129
 msgctxt "section"
 msgid "scene illuminant temp"
 msgstr "장면 광원 온도"
 
-#: ../src/iop/temperature.c:2145
+#: ../src/iop/temperature.c:2130
 msgid "click to cycle color mode on sliders"
 msgstr "슬라이더에서 색상 모드를 순환하려면 클릭하세요"
 
-#: ../src/iop/temperature.c:2157
+#: ../src/iop/temperature.c:2142
 msgid "color temperature (in Kelvin)"
 msgstr "색온도 (켈빈 단위)"
 
-#: ../src/iop/temperature.c:2162
+#: ../src/iop/temperature.c:2147
 msgid "tint"
 msgstr "색조"
 
-#: ../src/iop/temperature.c:2165
+#: ../src/iop/temperature.c:2150
 msgid "color tint of the image, from magenta (value < 1) to green (value > 1)"
 msgstr "이미지의 색조 기울기, (값 < 1) 마젠타, (값 > 1) 녹색 쪽으로 이동합니다"
 
-#: ../src/iop/temperature.c:2176
+#: ../src/iop/temperature.c:2161
 msgid "channel coefficients"
 msgstr "채널 계수"
 
-#: ../src/iop/temperature.c:2185
+#: ../src/iop/temperature.c:2170
 msgid "various"
 msgstr "다양한 값"
 
-#: ../src/iop/temperature.c:2210
+#: ../src/iop/temperature.c:2195
 msgid "white balance disabled for camera"
 msgstr "해당 카메라의 화이트 밸런스가 비활성화"
 
@@ -23267,7 +26911,10 @@ msgid "exponential (base 2)"
 msgstr "지수 (밑 2)"
 
 #: ../src/iop/tonecurve.c:1261
-msgid "if set to auto, a and b curves have no effect and are not displayed. chroma values (a and b) of each pixel are then adjusted based on L curve data. auto XYZ is similar but applies the saturation changes in XYZ space."
+msgid ""
+"if set to auto, a and b curves have no effect and are not displayed. chroma "
+"values (a and b) of each pixel are then adjusted based on L curve data. auto "
+"XYZ is similar but applies the saturation changes in XYZ space."
 msgstr "자동으로 설정하면 a 및 b 곡선은 적용되지 않으며 표시되지 않습니다.이 경우 각 픽셀의 색상값(a와 b)은 L 커브 데이터를 기반으로 조정됩니다. auto XYZ는 이와 유사하지만,채도 변경을 XYZ 색상 공간에서 적용합니다."
 
 #: ../src/iop/tonecurve.c:1270
@@ -23282,8 +26929,8 @@ msgstr "a 채널 톤 커브"
 msgid "tonecurve for b channel"
 msgstr "b 채널 톤 커브"
 
-#: ../src/iop/tonecurve.c:1281 ../src/iop/watermark.c:1361
-#: ../src/libs/colorpicker.c:779
+#: ../src/iop/tonecurve.c:1281 ../src/iop/watermark.c:1463
+#: ../src/libs/colorpicker.c:783
 msgid "pick color"
 msgstr "색상 선택"
 
@@ -23380,80 +27027,80 @@ msgstr "일부 파라메터가 범위를 벗어났습니다"
 msgid "%+.1f EV"
 msgstr "%+.1f EV"
 
-#: ../src/iop/toneequal.c:3144
+#: ../src/iop/toneequal.c:3148
 #, c-format
 msgid "[%s over image] change tone exposure"
 msgstr "[%s 위치에서] 톤 노출 변경"
 
-#: ../src/iop/toneequal.c:3147
+#: ../src/iop/toneequal.c:3151
 #, c-format
 msgid "[%s over image] change tone exposure in large steps"
 msgstr "[%s 위치에서] 톤 노출을 큰 단계로 변경"
 
-#: ../src/iop/toneequal.c:3150
+#: ../src/iop/toneequal.c:3154
 #, c-format
 msgid "[%s over image] change tone exposure in small steps"
 msgstr "[%s 위치에서] 톤 노출을 작은 단계로 변경"
 
 #. Simple view
-#: ../src/iop/toneequal.c:3233 ../src/iop/toneequal.c:3262
-#: ../src/iop/toneequal.c:3263 ../src/iop/toneequal.c:3264
-#: ../src/iop/toneequal.c:3265 ../src/iop/toneequal.c:3266
+#: ../src/iop/toneequal.c:3237 ../src/iop/toneequal.c:3266
 #: ../src/iop/toneequal.c:3267 ../src/iop/toneequal.c:3268
 #: ../src/iop/toneequal.c:3269 ../src/iop/toneequal.c:3270
+#: ../src/iop/toneequal.c:3271 ../src/iop/toneequal.c:3272
+#: ../src/iop/toneequal.c:3273 ../src/iop/toneequal.c:3274
 msgid "simple"
 msgstr "단순"
 
-#: ../src/iop/toneequal.c:3262
+#: ../src/iop/toneequal.c:3266
 msgid "-8 EV"
 msgstr "-8 EV"
 
-#: ../src/iop/toneequal.c:3263
+#: ../src/iop/toneequal.c:3267
 msgid "-7 EV"
 msgstr "-7 EV"
 
-#: ../src/iop/toneequal.c:3264
+#: ../src/iop/toneequal.c:3268
 msgid "-6 EV"
 msgstr "-6 EV"
 
-#: ../src/iop/toneequal.c:3265
+#: ../src/iop/toneequal.c:3269
 msgid "-5 EV"
 msgstr "-5 EV"
 
-#: ../src/iop/toneequal.c:3266
+#: ../src/iop/toneequal.c:3270
 msgid "-4 EV"
 msgstr "-4 EV"
 
-#: ../src/iop/toneequal.c:3267
+#: ../src/iop/toneequal.c:3271
 msgid "-3 EV"
 msgstr "-3 EV"
 
-#: ../src/iop/toneequal.c:3268
+#: ../src/iop/toneequal.c:3272
 msgid "-2 EV"
 msgstr "-2 EV"
 
-#: ../src/iop/toneequal.c:3269
+#: ../src/iop/toneequal.c:3273
 msgid "-1 EV"
 msgstr "-1 EV"
 
-#: ../src/iop/toneequal.c:3270
+#: ../src/iop/toneequal.c:3274
 msgid "+0 EV"
 msgstr "+0 EV"
 
 #. Advanced view
-#: ../src/iop/toneequal.c:3274
+#: ../src/iop/toneequal.c:3278
 msgid "advanced"
 msgstr "고급"
 
-#: ../src/iop/toneequal.c:3300
+#: ../src/iop/toneequal.c:3304
 msgid "double-click to reset the curve"
 msgstr "더블 클릭하여 곡선을 리셋"
 
-#: ../src/iop/toneequal.c:3304
+#: ../src/iop/toneequal.c:3308
 msgid "curve smoothing"
 msgstr "커브 부드럽기"
 
-#: ../src/iop/toneequal.c:3307
+#: ../src/iop/toneequal.c:3311
 msgid ""
 "positive values will produce more progressive tone transitions\n"
 "but the curve might become oscillatory in some settings.\n"
@@ -23465,7 +27112,7 @@ msgstr ""
 "음수 값을 사용하면 출렁임을 방지하고 더 견고하게 작동하지만\n"
 "톤 전환이 급격해지고 지역 대비가 손상될 수 있습니다."
 
-#: ../src/iop/toneequal.c:3320
+#: ../src/iop/toneequal.c:3324
 msgid ""
 "use this to slide the mask average exposure along channels\n"
 "for a better control of the exposure correction with the available nodes."
@@ -23473,11 +27120,11 @@ msgstr ""
 "사용 가능한 노드를 통해 노출 보정을 더 잘 제어할 수 있도록\n"
 "마스크의 평균 노출을 채널별로 이동시키는 데 사용합니다."
 
-#: ../src/iop/toneequal.c:3323
+#: ../src/iop/toneequal.c:3327
 msgid "auto-adjust the average exposure"
 msgstr "평균 노출을 자동으로 조정"
 
-#: ../src/iop/toneequal.c:3330
+#: ../src/iop/toneequal.c:3334
 msgid ""
 "use this to counter the averaging effect of the guided filter\n"
 "and dilate the mask contrast around -4EV\n"
@@ -23489,16 +27136,11 @@ msgstr ""
 "이를 통해 노출 히스토그램을 더 많은 채널에 분산시켜\n"
 "노출 보정을 더 정밀하게 제어할 수 있습니다."
 
-#: ../src/iop/toneequal.c:3335
+#: ../src/iop/toneequal.c:3339
 msgid "auto-adjust the contrast"
 msgstr "대비를 자동 조정"
 
-#. Masking options
-#: ../src/iop/toneequal.c:3339
-msgid "masking"
-msgstr "마스킹"
-
-#: ../src/iop/toneequal.c:3344
+#: ../src/iop/toneequal.c:3348
 msgid ""
 "preview the mask and chose the estimator that gives you the\n"
 "higher contrast between areas to dodge and areas to burn"
@@ -23506,17 +27148,22 @@ msgstr ""
 "마스크를 미리 보고, 밝게 할 영역과 어둡게 할 영역 간의\n"
 "대비가 더 높은 추정기를 선택하세요"
 
-#: ../src/iop/toneequal.c:3347
+#: ../src/iop/toneequal.c:3351
 msgid "details"
 msgstr "디테일"
 
-#: ../src/iop/toneequal.c:3350
+#: ../src/iop/toneequal.c:3354
 msgid ""
 "'no' affects global and local contrast (safe if you only add contrast)\n"
-"'guided filter' only affects global contrast and tries to preserve local contrast\n"
-"'averaged guided filter' is a geometric mean of 'no' and 'guided filter' methods\n"
-"'EIGF' (exposure-independent guided filter) is a guided filter that is exposure-independent, it smooths shadows and highlights the same way (contrary to guided filter which smooths less the highlights)\n"
-"'averaged EIGF' is a geometric mean of 'no' and 'exposure-independent guided filter' methods"
+"'guided filter' only affects global contrast and tries to preserve local "
+"contrast\n"
+"'averaged guided filter' is a geometric mean of 'no' and 'guided filter' "
+"methods\n"
+"'EIGF' (exposure-independent guided filter) is a guided filter that is "
+"exposure-independent, it smooths shadows and highlights the same way "
+"(contrary to guided filter which smooths less the highlights)\n"
+"'averaged EIGF' is a geometric mean of 'no' and 'exposure-independent guided "
+"filter' methods"
 msgstr ""
 "'없음'은 글로벌 및 부분 대비 모두에 영향을 줍니다 (대비만 추가할 경우 안전함)\n"
 "'가이드 필터'는 글로벌 대비에만 영향을 주며 지역 대비는 보존하려고 시도합니다\n"
@@ -23524,7 +27171,7 @@ msgstr ""
 "'EIGF'(노출 독립 가이드 필터)는 노출에 관계없이 작동하는 가이드 필터로, 쉐도우와하이라이트를 동일하게 부드럽게 처리합니다(일반 가이드 필터는 하이라이트를 덜 부드럽게 처리함)\n"
 "'평균 EIGF'는 '없음'과 '노출 독립 가이드 필터' 방법의 기하 평균입니다"
 
-#: ../src/iop/toneequal.c:3363
+#: ../src/iop/toneequal.c:3367
 msgid ""
 "number of passes of guided filter to apply\n"
 "helps diffusing the edges of the filter at the expense of speed"
@@ -23532,7 +27179,7 @@ msgstr ""
 "가이드 필터를 적용할 반복 횟수입니다\n"
 "반복 횟수를 늘리면 경계 확산에는 도움이 되지만 속도는 느려질 수 있습니다"
 
-#: ../src/iop/toneequal.c:3371
+#: ../src/iop/toneequal.c:3375
 msgid ""
 "diameter of the blur in percent of the largest image size\n"
 "warning: big values of this parameter can make the darkroom\n"
@@ -23542,7 +27189,7 @@ msgstr ""
 "경고: 이 파라메터 값을 크게 설정하면 프로파일 기반 노이즈 제거 사용 시\n"
 "darkroom 미리보기가 매우 느려질 수 있습니다."
 
-#: ../src/iop/toneequal.c:3379
+#: ../src/iop/toneequal.c:3383
 msgid ""
 "precision of the feathering:\n"
 "higher values force the mask to follow edges more closely\n"
@@ -23556,7 +27203,7 @@ msgstr ""
 "낮은 값은 더 부드러운 그라디언트와 효과적인 스무딩을 제공하지만\n"
 "경계가 정확하지 않거나 헤일로가 생길 수 있습니다"
 
-#: ../src/iop/toneequal.c:3390
+#: ../src/iop/toneequal.c:3394
 msgid ""
 "0 disables the quantization.\n"
 "higher values posterize the luminance mask to help the guiding\n"
@@ -23566,7 +27213,7 @@ msgstr ""
 "높은 값으로 설정하면 휘도 마스크가 포스터화되어 페더링 값을 크게 사용할 때\n"
 "조절 마스크가 구간별로 부드러운 영역을 생성하는 데 도움이 됩니다"
 
-#: ../src/iop/toneequal.c:3404 ../src/iop/toneequal.c:3411
+#: ../src/iop/toneequal.c:3408 ../src/iop/toneequal.c:3415
 msgid "display exposure mask"
 msgstr "노출 마스크 표시"
 
@@ -23575,7 +27222,9 @@ msgid "tone mapping"
 msgstr "톤 매핑"
 
 #: ../src/iop/tonemap.cc:85
-msgid "this module is deprecated. please use the local contrast or tone equalizer module instead."
+msgid ""
+"this module is deprecated. please use the local contrast or tone equalizer "
+"module instead."
 msgstr "이 모듈은 더 이상 사용되지 않습니다. 부분 대비 또는 톤 이퀄라이저 모듈을 대신 사용하세요."
 
 #: ../src/iop/velvia.c:68
@@ -23590,16 +27239,18 @@ msgstr ""
 "검은색 및 저채도 픽셀에 더 많은 가중치를 두어\n"
 "채도를 다시 부여합니다"
 
-#: ../src/iop/velvia.c:283
+#: ../src/iop/velvia.c:282
 msgid "the strength of saturation boost"
 msgstr "채도 증가 강도"
 
-#: ../src/iop/velvia.c:286
+#: ../src/iop/velvia.c:285
 msgid "how much to spare highlights and shadows"
 msgstr "쉐도우와 하이라이트의 여유 크기"
 
 #: ../src/iop/vibrance.c:59
-msgid "this module is deprecated. please use the vibrance slider in the color balance rgb module instead."
+msgid ""
+"this module is deprecated. please use the vibrance slider in the color "
+"balance rgb module instead."
 msgstr "이 모듈은 더 이상 사용되지 않습니다. 색상 밸런스 RGB 모듈의 생동감 슬라이더를 사용하세요."
 
 #: ../src/iop/vibrance.c:92
@@ -23694,29 +27345,29 @@ msgstr "[%s 노드에서] 비율 유지하며 비네트/페더 크기 변경"
 msgid "[%s on center] move vignette"
 msgstr "[%s 중심에서] 비네트 이동"
 
-#: ../src/iop/watermark.c:409
+#: ../src/iop/watermark.c:460
 msgid "watermark"
 msgstr "워터마크"
 
-#: ../src/iop/watermark.c:414
+#: ../src/iop/watermark.c:467
 msgid "overlay an SVG watermark like a signature on the image"
 msgstr "이미지 위에 서명처럼 SVG 워터마크를 오버레이"
 
-#: ../src/iop/watermark.c:1312
+#: ../src/iop/watermark.c:1407
 msgid "marker"
 msgstr "마커"
 
-#: ../src/iop/watermark.c:1315
+#: ../src/iop/watermark.c:1411
 #, c-format
 msgid "SVG watermarks in %s/watermarks or %s/watermarks"
 msgstr "SVG 워터마크는 %s/watermarks 또는 %s/watermarks 경로에 있습니다"
 
 #. Simple text
-#: ../src/iop/watermark.c:1325 ../src/iop/watermark.c:1326
+#: ../src/iop/watermark.c:1422 ../src/iop/watermark.c:1424
 msgid "text"
 msgstr "텍스트"
 
-#: ../src/iop/watermark.c:1327
+#: ../src/iop/watermark.c:1426
 msgid ""
 "text string, tag: $(WATERMARK_TEXT)\n"
 "use $(NL) to insert a line break"
@@ -23724,16 +27375,16 @@ msgstr ""
 "텍스트 문자열, 태그: $(WATERMARK_TEXT)\n"
 "줄바꿈을 삽입하려면 $(NL) 사용하세요"
 
-#: ../src/iop/watermark.c:1331
+#: ../src/iop/watermark.c:1430
 msgid "content"
 msgstr "내용"
 
 #. Text font
-#: ../src/iop/watermark.c:1336
+#: ../src/iop/watermark.c:1435
 msgid "font"
 msgstr "글꼴"
 
-#: ../src/iop/watermark.c:1341
+#: ../src/iop/watermark.c:1442
 msgid ""
 "text font, tags:\n"
 "$(WATERMARK_FONT_FAMILY)\n"
@@ -23745,7 +27396,7 @@ msgstr ""
 "$(WATERMARK_FONT_STYLE)\n"
 "$(WATERMARK_FONT_WEIGHT)"
 
-#: ../src/iop/watermark.c:1356
+#: ../src/iop/watermark.c:1457
 msgid ""
 "watermark color, tag:\n"
 "$(WATERMARK_COLOR)"
@@ -23753,20 +27404,18 @@ msgstr ""
 "워터마크 색상, 태그:\n"
 "$(WATERMARK_COLOR)"
 
-#: ../src/iop/watermark.c:1358
+#: ../src/iop/watermark.c:1459
 msgid "select watermark color"
 msgstr "워터마크 색상 선택"
 
-#: ../src/iop/watermark.c:1360
-msgid "pick color from image"
-msgstr "이미지에서 색상 선택"
-
-#: ../src/iop/watermark.c:1387
+#: ../src/iop/watermark.c:1492
 msgid ""
 "choose how to scale the watermark\n"
 "• image: scale watermark relative to whole image\n"
-"• larger border: scale larger watermark border relative to larger image border\n"
-"• smaller border: scale larger watermark border relative to smaller image border\n"
+"• larger border: scale larger watermark border relative to larger image "
+"border\n"
+"• smaller border: scale larger watermark border relative to smaller image "
+"border\n"
 "• height: scale watermark height to image height\n"
 "• advanced options: choose watermark and image dimensions independently"
 msgstr ""
@@ -23777,24 +27426,24 @@ msgstr ""
 "• 높이: 워터마크 높이를 이미지 높이에 맞춰 조정\n"
 "• 고급 옵션: 워터마크와 이미지의 크기를 독립적으로 설정"
 
-#: ../src/iop/watermark.c:1396
+#: ../src/iop/watermark.c:1503
 msgid "reference image dimension against which to scale the watermark"
 msgstr "워터마크 크기 조정을 위한 기준 이미지 크기"
 
-#: ../src/iop/watermark.c:1400
+#: ../src/iop/watermark.c:1507
 msgid "watermark dimension to scale"
 msgstr "크기 조정할 워터마크의 실제 크기"
 
 #. Let's add some tooltips and hook up some signals...
-#: ../src/iop/watermark.c:1425
+#: ../src/iop/watermark.c:1534
 msgid "the opacity of the watermark"
 msgstr "워터마크 불투명도"
 
-#: ../src/iop/watermark.c:1426
+#: ../src/iop/watermark.c:1535
 msgid "the scale of the watermark"
 msgstr "워터마크 스케일링"
 
-#: ../src/iop/watermark.c:1427
+#: ../src/iop/watermark.c:1536
 msgid "the rotation of the watermark"
 msgstr "워터마크 회전"
 
@@ -23844,7 +27493,7 @@ msgctxt "section"
 msgid "camera control"
 msgstr "카메라 제어"
 
-#: ../src/libs/camera.c:444 ../src/libs/histogram.c:2584
+#: ../src/libs/camera.c:444 ../src/libs/histogram.c:826
 msgid "modes"
 msgstr "모드"
 
@@ -23887,18 +27536,22 @@ msgstr "실제 촬영이 시작되기 전까지 대기할 시간 초"
 #: ../src/libs/camera.c:489
 msgid ""
 "the amount of images to capture in a sequence,\n"
-"you can use this in conjunction with delayed mode to create stop-motion sequences"
+"you can use this in conjunction with delayed mode to create stop-motion "
+"sequences"
 msgstr ""
 "연속 촬영 시 촬영할 이미지 수입니다\n"
 "지연 모드와 함께 사용하면 스톱모션 시퀀스를 만들 수 있습니다"
 
 #: ../src/libs/camera.c:492
-msgid "the amount of brackets on each side of centered shoot, amount of images = (brackets*2) + 1"
+msgid ""
+"the amount of brackets on each side of centered shoot, amount of images = "
+"(brackets*2) + 1"
 msgstr "중앙 노출을 기준으로 양쪽에 설정할 브래킷 수, 전체 이미지 수 = (브래킷 수×2) + 1"
 
 #: ../src/libs/camera.c:494
 msgid ""
-"the amount of steps per bracket, steps is camera configurable and usually 3 steps per stop\n"
+"the amount of steps per bracket, steps is camera configurable and usually 3 "
+"steps per stop\n"
 "with other words, 3 steps is 1EV exposure step between brackets"
 msgstr ""
 "브래킷당 스텝 수입니다. 스텝은 카메라에서 설정 가능하며, 일반적으로 1EV 당 3 스텝입니다\n"
@@ -23942,55 +27595,55 @@ msgstr "셔터 속도"
 msgid "WB"
 msgstr "화이트 밸런스"
 
-#: ../src/libs/collect.c:162
+#: ../src/libs/collect.c:192
 msgid "collections"
 msgstr "컬렉션"
 
-#: ../src/libs/collect.c:167
+#: ../src/libs/collect.c:197
 msgid ""
 "define search criteria for images\n"
 "to be displayed or edited"
 msgstr "표시하거나 편집할 이미지를 위한 검색 조건 정의"
 
-#: ../src/libs/collect.c:431
+#: ../src/libs/collect.c:461
 msgid "update path to files"
 msgstr "파일 경로 업데이트"
 
-#: ../src/libs/collect.c:515
+#: ../src/libs/collect.c:545
 #, c-format
 msgid "problem selecting new path for the filmroll in %s"
 msgstr "%s에서 필름롤의 새 경로를 선택하는 데 문제가 발생했습니다"
 
-#: ../src/libs/collect.c:589
+#: ../src/libs/collect.c:619
 msgid "update path to files..."
 msgstr "파일 경로 업데이트..."
 
-#: ../src/libs/collect.c:594
+#: ../src/libs/collect.c:624
 msgid "remove..."
 msgstr "제거..."
 
-#: ../src/libs/collect.c:1346
+#: ../src/libs/collect.c:1382
 msgid "uncategorized"
 msgstr "분류되지 않음"
 
-#: ../src/libs/collect.c:2283 ../src/libs/filters/rating_range.c:120
+#: ../src/libs/collect.c:2387 ../src/libs/filters/rating_range.c:120
 #: ../src/libs/filters/rating_range.c:146
 #: ../src/libs/filters/rating_range.c:151
 #: ../src/libs/filters/rating_range.c:302
 msgid "rejected"
 msgstr "거부됨"
 
-#: ../src/libs/collect.c:2286 ../src/libs/filters/rating_range.c:122
+#: ../src/libs/collect.c:2390 ../src/libs/filters/rating_range.c:122
 #: ../src/libs/filters/rating_range.c:146
 #: ../src/libs/filters/rating_range.c:303
 msgid "not rated"
 msgstr "평점 없음"
 
-#: ../src/libs/collect.c:2470
+#: ../src/libs/collect.c:2638
 msgid "use <, <=, >, >=, <>, =, [;] as operators"
 msgstr "연산자로 <, <=, >, >=, <>, =, [;] 사용"
 
-#: ../src/libs/collect.c:2474
+#: ../src/libs/collect.c:2642
 msgid ""
 "use <, <=, >, >=, <>, =, [;] as operators\n"
 "star rating: 0-5\n"
@@ -24000,7 +27653,7 @@ msgstr ""
 "별점 등급: 0~5\n"
 "거부된 이미지: -1"
 
-#: ../src/libs/collect.c:2482
+#: ../src/libs/collect.c:2650
 msgid ""
 "use <, <=, >, >=, <>, =, [;] as operators\n"
 "type dates in the form: YYYY:MM:DD hh:mm:ss.sss (only the year is mandatory)"
@@ -24008,12 +27661,12 @@ msgstr ""
 "연산자 <, <=, >, >=, <>, =, [;] 사용\n"
 "날짜는 YYYY:MM:DD hh:mm:ss.sss 형식으로 입력 (연도만 필수)"
 
-#: ../src/libs/collect.c:2489
+#: ../src/libs/collect.c:2657
 #, no-c-format
 msgid "use `%' as wildcard and `,' to separate values"
 msgstr "%는 와일드카드로로 사용하고, `,'는 값 구분자로 사용합니다"
 
-#: ../src/libs/collect.c:2496
+#: ../src/libs/collect.c:2664
 #, no-c-format
 msgid ""
 "use `%' as wildcard\n"
@@ -24026,7 +27679,7 @@ msgstr ""
 "Shift+클릭: 현재 계층만 포함 (접미사 없음)\n"
 "Ctrl+클릭: 하위 계층만 포함 (`|%' 접미사)"
 
-#: ../src/libs/collect.c:2506
+#: ../src/libs/collect.c:2674
 #, no-c-format
 msgid ""
 "use `%' as wildcard\n"
@@ -24039,7 +27692,7 @@ msgstr ""
 "Shift+클릭: 현재 위치만 포함 (접미사 없음)\n"
 "Ctrl+클릭: 하위 위치만 포함 (`|%' 접미사)"
 
-#: ../src/libs/collect.c:2516
+#: ../src/libs/collect.c:2684
 #, no-c-format
 msgid ""
 "use `%' as wildcard\n"
@@ -24052,103 +27705,201 @@ msgstr ""
 "Shift+클릭: 현재 폴더만 포함 (접미사 없음)\n"
 "Ctrl+클릭: 하위 폴더만 포함 (`|%' 접미사)"
 
-#: ../src/libs/collect.c:2524
+#: ../src/libs/collect.c:2692
 #, no-c-format
 msgid "use `%' as wildcard"
 msgstr "`%'는 와일드카드로 사용"
 
-#: ../src/libs/collect.c:2595 ../src/libs/collect.c:2616
-#: ../src/libs/collect.c:3246
+#: ../src/libs/collect.c:2763 ../src/libs/collect.c:2784
+#: ../src/libs/collect.c:3604
 msgid "clear this rule"
 msgstr "이 규칙 지우기"
 
-#: ../src/libs/collect.c:2600
+#: ../src/libs/collect.c:2768
 msgid "clear this rule or add new rules"
 msgstr "이 규칙을 지우거나 새 규칙 추가"
 
-#: ../src/libs/collect.c:3252
+#: ../src/libs/collect.c:3610
 msgid "narrow down search"
 msgstr "검색 범위 좁히기"
 
-#: ../src/libs/collect.c:3259
+#: ../src/libs/collect.c:3617
 msgid "add more images"
 msgstr "이미지 더 추가"
 
-#: ../src/libs/collect.c:3266
+#: ../src/libs/collect.c:3624
 msgid "exclude images"
 msgstr "이미지 제외"
 
-#: ../src/libs/collect.c:3275
+#: ../src/libs/collect.c:3633
 msgid "change to: and"
 msgstr "다음으로 변경: 그리고"
 
-#: ../src/libs/collect.c:3282
+#: ../src/libs/collect.c:3640
 msgid "change to: or"
 msgstr "다음으로 변경: 또는"
 
-#: ../src/libs/collect.c:3289
+#: ../src/libs/collect.c:3647
 msgid "change to: except"
 msgstr "다음으로 변경: 제외"
 
 #. the different categories
-#: ../src/libs/collect.c:3318 ../src/libs/filtering.c:886
-#: ../src/libs/filtering.c:945 ../src/libs/filtering.c:1608
-#: ../src/libs/filtering.c:1944
+#: ../src/libs/collect.c:3676 ../src/libs/filtering.c:889
+#: ../src/libs/filtering.c:950 ../src/libs/filtering.c:1618
+#: ../src/libs/filtering.c:1955
 msgid "files"
 msgstr "파일"
 
-#: ../src/libs/collect.c:3323 ../src/libs/export_metadata.c:178
-#: ../src/libs/filtering.c:891 ../src/libs/filtering.c:950
-#: ../src/libs/filtering.c:1616 ../src/libs/filtering.c:1948
+#: ../src/libs/collect.c:3681 ../src/libs/export_metadata.c:178
+#: ../src/libs/filtering.c:894 ../src/libs/filtering.c:955
+#: ../src/libs/filtering.c:1626 ../src/libs/filtering.c:1959
 #: ../src/libs/image.c:504 ../src/libs/image.c:605 ../src/libs/image.c:624
-#: ../src/libs/metadata_view.c:1459
+#: ../src/libs/metadata_view.c:1489
 msgid "metadata"
 msgstr "메타데이터"
 
-#: ../src/libs/collect.c:3342 ../src/libs/filtering.c:899
-#: ../src/libs/filtering.c:958 ../src/libs/filtering.c:1946
+#: ../src/libs/collect.c:3700 ../src/libs/filtering.c:902
+#: ../src/libs/filtering.c:963 ../src/libs/filtering.c:1957
 msgid "times"
 msgstr "시간"
 
-#: ../src/libs/collect.c:3350 ../src/libs/filtering.c:907
-#: ../src/libs/filtering.c:966 ../src/libs/filtering.c:1627
+#: ../src/libs/collect.c:3709 ../src/libs/filtering.c:911
+#: ../src/libs/filtering.c:972 ../src/libs/filtering.c:1637
 msgid "capture details"
 msgstr "캡처 세부사항"
 
-#: ../src/libs/collect.c:3379
+#: ../src/libs/collect.c:3738
 msgid "collections settings"
 msgstr "컬렉션 설정"
 
-#: ../src/libs/collect.c:3401 ../src/libs/export.c:1410
-#: ../src/libs/metadata.c:1121 ../src/libs/metadata_view.c:1543
-#: ../src/libs/recentcollect.c:297 ../src/libs/tagging.c:3968
+#: ../src/libs/collect.c:3760 ../src/libs/export.c:1428
+#: ../src/libs/metadata.c:1123 ../src/libs/metadata_view.c:1576
+#: ../src/libs/recentcollect.c:297 ../src/libs/styles.c:1048
+#: ../src/libs/tagging.c:4005
 msgid "preferences..."
 msgstr "환경설정..."
 
-#: ../src/libs/collect.c:3525 ../src/libs/filtering.c:1483
+#: ../src/libs/collect.c:3884 ../src/libs/filtering.c:1491
 msgid "AND"
 msgstr "그리고"
 
-#: ../src/libs/collect.c:3530 ../src/libs/filtering.c:1488
+#: ../src/libs/collect.c:3889 ../src/libs/filtering.c:1496
 msgid "OR"
 msgstr "또는"
 
 #. case DT_LIB_COLLECT_MODE_AND_NOT:
-#: ../src/libs/collect.c:3535 ../src/libs/filtering.c:1493
+#: ../src/libs/collect.c:3894 ../src/libs/filtering.c:1501
 msgid "BUT NOT"
 msgstr "제외"
 
-#: ../src/libs/collect.c:3641
+#: ../src/libs/collect.c:4000
 msgid "toggle collection sort order ascending/descending"
 msgstr "컬렉션 정렬 순서 오름차순/내림차순 전환"
 
-#: ../src/libs/collect.c:3739 ../src/libs/filtering.c:2214
+#: ../src/libs/collect.c:4098 ../src/libs/filtering.c:2225
 msgid "revert to a previous set of rules"
 msgstr "이전 규칙으로 되돌리기"
 
-#: ../src/libs/collect.c:3793
+#: ../src/libs/collect.c:4152
 msgid "jump back to previous collection"
 msgstr "이전 컬렉션으로 돌아가기기"
+
+#: ../src/libs/collect.h:32
+msgid "January"
+msgstr "1월"
+
+#: ../src/libs/collect.h:33
+msgid "February"
+msgstr "2월"
+
+#: ../src/libs/collect.h:34
+msgid "March"
+msgstr "3월"
+
+#: ../src/libs/collect.h:35
+msgid "April"
+msgstr "4월"
+
+#: ../src/libs/collect.h:36
+msgid "May"
+msgstr "5월"
+
+#: ../src/libs/collect.h:37
+msgid "June"
+msgstr "6월"
+
+#: ../src/libs/collect.h:38
+msgid "July"
+msgstr "7월"
+
+#: ../src/libs/collect.h:39
+msgid "August"
+msgstr "8월"
+
+#: ../src/libs/collect.h:40
+msgid "September"
+msgstr "9월"
+
+#: ../src/libs/collect.h:41
+msgid "October"
+msgstr "10월"
+
+#: ../src/libs/collect.h:42
+msgid "November"
+msgstr "11월"
+
+#: ../src/libs/collect.h:43
+msgid "December"
+msgstr "12월"
+
+#: ../src/libs/collect.h:48
+msgid "Jan"
+msgstr "1월"
+
+#: ../src/libs/collect.h:49
+msgid "Feb"
+msgstr "2월"
+
+#: ../src/libs/collect.h:50
+msgid "Mar"
+msgstr "3월"
+
+#: ../src/libs/collect.h:51
+msgid "Apr"
+msgstr "4월"
+
+#: ../src/libs/collect.h:52
+msgctxt "short_month_name"
+msgid "May"
+msgstr "5월"
+
+#: ../src/libs/collect.h:53
+msgid "Jun"
+msgstr "6월"
+
+#: ../src/libs/collect.h:54
+msgid "Jul"
+msgstr "7월"
+
+#: ../src/libs/collect.h:55
+msgid "Aug"
+msgstr "8월"
+
+#: ../src/libs/collect.h:56
+msgid "Sep"
+msgstr "9월"
+
+#: ../src/libs/collect.h:57
+msgid "Oct"
+msgstr "10월"
+
+#: ../src/libs/collect.h:58
+msgid "Nov"
+msgstr "11월"
+
+#: ../src/libs/collect.h:59
+msgid "Dec"
+msgstr "12월"
 
 #: ../src/libs/colorpicker.c:52
 msgid "RGB%"
@@ -24184,51 +27935,53 @@ msgstr ""
 "마우스 클릭 시, 현재 색상 샘플을 고정합니다\n"
 "마우스 우클릭 시, 해당 샘플 영역을 현재 활성화된 색상 피커에 불러옵니다"
 
-#: ../src/libs/colorpicker.c:732 ../src/libs/colorpicker.c:791
+#: ../src/libs/colorpicker.c:735 ../src/libs/colorpicker.c:795
 msgid "click to (un)hide large color patch"
 msgstr "클릭하여 큰 색상 견본 숨기기"
 
-#: ../src/libs/colorpicker.c:753
+#: ../src/libs/colorpicker.c:756
 msgid "statistic"
 msgstr "색상 통계"
 
-#: ../src/libs/colorpicker.c:754
+#: ../src/libs/colorpicker.c:757
 msgid "select which statistic to show"
 msgstr "표시할 색상 통계 선택"
 
-#: ../src/libs/colorpicker.c:763
+#: ../src/libs/colorpicker.c:766
 msgid "select which color mode to use"
 msgstr "사용할 색상 모드 선택"
 
-#: ../src/libs/colorpicker.c:775
+#: ../src/libs/colorpicker.c:778
 msgid ""
 "turn on color picker\n"
-"ctrl+click or right-click to select an area"
+"ctrl+click or right-click to select an area\n"
+"ctrl+click on canvas to switch between point/area"
 msgstr ""
-"색상 선택 도구 실행 후,\n"
-"Ctrl+클릭 또는 우클릭으로 영역 선택"
+"색상 선택기를 켭니다\n"
+"Ctrl+클릭 또는 우클릭으로 영역 선택\n"
+"캔버스에서 Ctrl+클릭으로 점/영역 모드 전환"
 
-#: ../src/libs/colorpicker.c:816
+#: ../src/libs/colorpicker.c:820
 msgid "add sample"
 msgstr "샘플 추가하기"
 
-#: ../src/libs/colorpicker.c:827
+#: ../src/libs/colorpicker.c:831
 msgid "display samples on image/vectorscope"
 msgstr "샘플을 이미지/벡터스코프 위에 표시"
 
-#: ../src/libs/colorpicker.c:828
+#: ../src/libs/colorpicker.c:832
 msgid "display samples"
 msgstr "화면에 샘플 표시"
 
-#: ../src/libs/colorpicker.c:839
+#: ../src/libs/colorpicker.c:843
 msgid "restrict scope to selection"
 msgstr "선택한 영역으로 범위 제한"
 
-#: ../src/libs/colorpicker.c:840
+#: ../src/libs/colorpicker.c:844
 msgid "restrict scope"
 msgstr "범위 제한"
 
-#: ../src/libs/colorpicker.c:855
+#: ../src/libs/colorpicker.c:859
 msgctxt "section"
 msgid "live samples"
 msgstr "실시간 샘플"
@@ -24334,11 +28087,11 @@ msgstr ""
 msgid "write history stack and tags to XMP sidecar files"
 msgstr "히스토리 스택과 태그를 XMP 사이드카 파일에 기록"
 
-#: ../src/libs/duplicate.c:59
+#: ../src/libs/duplicate.c:60
 msgid "duplicate manager"
 msgstr "복제 관리자"
 
-#: ../src/libs/duplicate.c:64
+#: ../src/libs/duplicate.c:65
 msgid ""
 "create/rename/remove multiple\n"
 "edits of the current image"
@@ -24346,57 +28099,62 @@ msgstr ""
 "현재 이미지에 대한 여러 개의 편집본을\n"
 "생성, 이름 변경, 또는 삭제"
 
-#: ../src/libs/duplicate.c:327
+#: ../src/libs/duplicate.c:364
+msgid "create a duplicate of this image with same history stack"
+msgstr "같은 히스토리 스택을 가진 이 이미지의 복제본 생성"
+
+#: ../src/libs/duplicate.c:373
+msgid "create a 'virgin' duplicate of this image without any development"
+msgstr "편집이 전혀 되지 않은 이 이미지의 '순수 복제본'을 생성"
+
+#: ../src/libs/duplicate.c:380
 msgid "delete this duplicate"
 msgstr "이 복제를 삭제"
 
-#: ../src/libs/duplicate.c:403
-msgid "create a duplicate of the image with same history stack"
-msgstr "같은 히스토리 스택을 가진 이미지 복제본 생성"
+#: ../src/libs/duplicate.c:469 ../src/libs/history.c:1141
+#: ../src/libs/snapshots.c:939
+msgid "original"
+msgstr "원본"
 
-#: ../src/libs/duplicate.c:407
-msgid "create a 'virgin' duplicate of the image without any development"
-msgstr "편집이 전혀 되지 않은 '순수 복제본'을 생성"
-
-#: ../src/libs/export.c:170
+#: ../src/libs/export.c:175
 msgid "export"
 msgstr "내보내기"
 
-#: ../src/libs/export.c:175
+#: ../src/libs/export.c:185
 msgid ""
 "create new files for the\n"
 "currently selected images\n"
 "which apply your edits"
 msgstr "현재 선택된 이미지에 대해 편집 내용이 적용된 새 파일 생성"
 
-#: ../src/libs/export.c:336
+#: ../src/libs/export.c:346
 msgid "invalid format for export selected"
 msgstr "유효하지 않은 형식이 선택됨"
 
-#: ../src/libs/export.c:341
+#: ../src/libs/export.c:351
 msgid "invalid storage for export selected"
 msgstr "유효하지 않은 저장소가 선택됨"
 
-#: ../src/libs/export.c:353
+#: ../src/libs/export.c:363
 msgid "export to disk"
 msgstr "디스크로 내보내기"
 
-#: ../src/libs/export.c:447
+#: ../src/libs/export.c:466
 #, c-format
 msgid "could not login to storage `%s'!"
 msgstr "저장소 `%s'에 로그인할 수 없습니다!"
 
-#: ../src/libs/export.c:616
+#: ../src/libs/export.c:638
 #, c-format
 msgid "which is equal to %s × %s px"
 msgstr "%s × %s 픽셀과 동일"
 
-#: ../src/libs/export.c:663
+#: ../src/libs/export.c:685
 msgctxt "unit"
 msgid "in"
 msgstr "in"
 
-#: ../src/libs/export.c:1154
+#: ../src/libs/export.c:1172
 #, c-format
 msgid ""
 "style to be applied on export:\n"
@@ -24405,20 +28163,20 @@ msgstr ""
 "내보내기에 적용될 스타일:\n"
 "<b>%s</b>"
 
-#: ../src/libs/export.c:1207 ../src/libs/print_settings.c:1228
-#: ../src/views/darkroom.c:1497
+#: ../src/libs/export.c:1225 ../src/libs/print_settings.c:1248
+#: ../src/views/darkroom.c:1833
 msgid "no styles have been created yet"
 msgstr "아직 생성된 스타일이 없음"
 
-#: ../src/libs/export.c:1425
+#: ../src/libs/export.c:1443
 msgid "target storage"
 msgstr "타겟 저장소"
 
-#: ../src/libs/export.c:1449
+#: ../src/libs/export.c:1467
 msgid "file format"
 msgstr "파일 형식"
 
-#: ../src/libs/export.c:1451
+#: ../src/libs/export.c:1469
 msgid ""
 "images will be exported according to the format specified here\n"
 "\n"
@@ -24437,35 +28195,35 @@ msgstr ""
 "내보내기 모듈의 환경설정에서 메타데이터 항목을 <b>모두</b> 선택하지 않는 한,\n"
 "어떠한 메타데이터도 포함되지 않습니다"
 
-#: ../src/libs/export.c:1472
+#: ../src/libs/export.c:1490
 msgid "set size"
 msgstr "크기 설정"
 
-#: ../src/libs/export.c:1473
+#: ../src/libs/export.c:1491
 msgid "choose a method for setting the output size"
 msgstr "출력 크기를 설정할 방법을 선택"
 
-#: ../src/libs/export.c:1476
+#: ../src/libs/export.c:1494
 msgid "in pixels (for file)"
 msgstr "픽셀 단위 (파일용)"
 
-#: ../src/libs/export.c:1477
+#: ../src/libs/export.c:1495
 msgid "in cm (for print)"
 msgstr "센티미터 단위 (인쇄용)"
 
-#: ../src/libs/export.c:1478
+#: ../src/libs/export.c:1496
 msgid "in inch (for print)"
 msgstr "인치 단위 (인쇄용)"
 
-#: ../src/libs/export.c:1479
+#: ../src/libs/export.c:1497
 msgid "by scale (for file)"
 msgstr "배율로 설정 (파일용)"
 
-#: ../src/libs/export.c:1482
+#: ../src/libs/export.c:1500
 msgid "print width"
 msgstr "인쇄 너비"
 
-#: ../src/libs/export.c:1484 ../src/libs/export.c:1501
+#: ../src/libs/export.c:1502 ../src/libs/export.c:1519
 msgid ""
 "maximum output width limit.\n"
 "click middle mouse button to reset to 0."
@@ -24473,11 +28231,11 @@ msgstr ""
 "최대 출력 너비를 제한합니다.\n"
 "마우스 가운데 버튼(스크롤 휠 버튼)을 클릭하면 0으로 리셋됩니다."
 
-#: ../src/libs/export.c:1488
+#: ../src/libs/export.c:1506
 msgid "print height"
 msgstr "인쇄 높이"
 
-#: ../src/libs/export.c:1490 ../src/libs/export.c:1507
+#: ../src/libs/export.c:1508 ../src/libs/export.c:1525
 msgid ""
 "maximum output height limit.\n"
 "click middle mouse button to reset to 0."
@@ -24485,19 +28243,19 @@ msgstr ""
 "최대 출력 높이를 제한합니다.\n"
 "마우스 가운데 버튼(스크롤 휠 버튼)을 클릭하면 0으로 리셋됩니다."
 
-#: ../src/libs/export.c:1496
+#: ../src/libs/export.c:1514
 msgid "resolution in dot per inch"
 msgstr "DPI 해상도"
 
-#: ../src/libs/export.c:1520
+#: ../src/libs/export.c:1538
 msgid "@"
 msgstr "@"
 
-#: ../src/libs/export.c:1534 ../src/libs/tools/global_toolbox.c:214
+#: ../src/libs/export.c:1552 ../src/libs/tools/global_toolbox.c:214
 msgid "px"
 msgstr "픽셀"
 
-#: ../src/libs/export.c:1542
+#: ../src/libs/export.c:1560
 msgid ""
 "it can be an integer, decimal number or simple fraction.\n"
 "zero or empty values are equal to 1.\n"
@@ -24507,48 +28265,53 @@ msgstr ""
 "0 또는 빈 값(공백)은 1로 간주합니다.\n"
 "마우스 가운데 버튼(스크롤 휠 버튼)을 클릭하면 1으로 리셋됩니다."
 
-#: ../src/libs/export.c:1557
+#: ../src/libs/export.c:1575
 msgid "allow upscaling"
 msgstr "업스케일링 허용"
 
-#: ../src/libs/export.c:1565
+#: ../src/libs/export.c:1583
 msgid "high quality resampling"
 msgstr "고품질 리샘플링"
 
-#: ../src/libs/export.c:1566
+#: ../src/libs/export.c:1584
 msgid "do high quality resampling during export"
 msgstr "내보내기 시 고품질 리샘플링 적용"
 
-#: ../src/libs/export.c:1573
+#: ../src/libs/export.c:1591
 msgid "store masks"
 msgstr "마스크 저장"
 
-#: ../src/libs/export.c:1574
+#: ../src/libs/export.c:1592
 msgid "store masks as layers in exported images. only works for some formats."
 msgstr "마스크를 내보낸 이미지에 레이어 형태로 저장합니다. 일부 형식에서만 가능합니다."
 
-#: ../src/libs/export.c:1583 ../src/libs/export.c:1618
-#: ../src/libs/print_settings.c:2855 ../src/libs/print_settings.c:2901
+#: ../src/libs/export.c:1601 ../src/libs/export.c:1636
+#: ../src/libs/neural_restore.c:4411 ../src/libs/print_settings.c:2875
+#: ../src/libs/print_settings.c:2921
 msgid "image settings"
 msgstr "이미지 설정"
 
-#: ../src/libs/export.c:1593 ../src/libs/print_settings.c:2889
+#: ../src/libs/export.c:1611 ../src/libs/print_settings.c:2909
 msgid "output ICC profiles"
 msgstr "출력 ICC 프로파일"
 
-#: ../src/libs/export.c:1601
+#: ../src/libs/export.c:1619
 msgid ""
-"• perceptual: smoothly moves out-of-gamut colors into gamut, preserving gradations,\n"
+"• perceptual: smoothly moves out-of-gamut colors into gamut, preserving "
+"gradations,\n"
 "but distorts in-gamut colors in the process.\n"
-"note that perceptual is often a proprietary LUT that depends on the destination space.\n"
+"note that perceptual is often a proprietary LUT that depends on the "
+"destination space.\n"
 "\n"
-"• relative colorimetric: keeps luminance while reducing as little as possible\n"
+"• relative colorimetric: keeps luminance while reducing as little as "
+"possible\n"
 "saturation until colors fit in gamut.\n"
 "\n"
 "• saturation: designed to present eye-catching business graphics\n"
 "by preserving the saturation. (not suited for photography).\n"
 "\n"
-"• absolute colorimetric: adapt white point of the image to the white point of the\n"
+"• absolute colorimetric: adapt white point of the image to the white point "
+"of the\n"
 "destination medium and do nothing else. mainly used when proofing colors.\n"
 "(not suited for photography)."
 msgstr ""
@@ -24564,59 +28327,60 @@ msgstr ""
 "• 절대 색도: 이미지의 화이트 포인트를 출력 매체의 화이트 포인트에 맞추고, 그외의 작업은 없습니다.\n"
 " 주로 색상 교정 용도로 사용됩니다. (사진에는 적합하지 않습니다)"
 
-#: ../src/libs/export.c:1629 ../src/libs/print_settings.c:2935
-msgid "whether the style items are appended to the history or replacing the history"
+#: ../src/libs/export.c:1647 ../src/libs/print_settings.c:2955
+msgid ""
+"whether the style items are appended to the history or replacing the history"
 msgstr "스타일 항목을 기존 히스토리에 추가할지, 기존 히스토리를 덮어쓸지 여부 설정"
 
-#: ../src/libs/export.c:1632 ../src/libs/print_settings.c:2937
+#: ../src/libs/export.c:1650 ../src/libs/print_settings.c:2957
 msgid "replace history"
 msgstr "히스토리 덮어쓰기"
 
-#: ../src/libs/export.c:1632 ../src/libs/print_settings.c:2937
+#: ../src/libs/export.c:1650 ../src/libs/print_settings.c:2957
 msgid "append history"
 msgstr "기존 히스토리에 추가"
 
-#: ../src/libs/export.c:1639
+#: ../src/libs/export.c:1657
 msgid "select style to be applied on export"
 msgstr "내보내기에 적용할 스타일을 선택"
 
-#: ../src/libs/export.c:1642
+#: ../src/libs/export.c:1660
 msgid "temporary style to use while exporting"
 msgstr "내보내기 중 사용할 임시 스타일"
 
-#: ../src/libs/export.c:1643 ../src/libs/print_settings.c:2918
+#: ../src/libs/export.c:1661 ../src/libs/print_settings.c:2938
 msgid "style"
 msgstr "스타일"
 
-#: ../src/libs/export.c:1663
+#: ../src/libs/export.c:1681
 msgctxt "actionbutton"
 msgid "start export"
 msgstr "내보내기 시작"
 
-#: ../src/libs/export.c:1669
+#: ../src/libs/export.c:1687
 msgctxt "section"
 msgid "storage options"
 msgstr "저장소 옵션"
 
-#: ../src/libs/export.c:1671
+#: ../src/libs/export.c:1689
 msgctxt "section"
 msgid "format options"
 msgstr "포멧 옵션"
 
-#: ../src/libs/export.c:1673
+#: ../src/libs/export.c:1691
 msgctxt "section"
 msgid "global options"
 msgstr "전역 옵션"
 
-#: ../src/libs/export.c:1683
+#: ../src/libs/export.c:1701
 msgid "multi-preset export"
 msgstr "다중 사전설정 내보내기"
 
-#: ../src/libs/export.c:1686
+#: ../src/libs/export.c:1704
 msgid "export the selected images with multiple presets"
 msgstr "선택한 이미지를 여러 사전설정으로 내보내기"
 
-#: ../src/libs/export.c:1712
+#: ../src/libs/export.c:1730
 msgctxt "actionbutton"
 msgid "start batch export"
 msgstr "일괄 내보내기 시작"
@@ -24644,9 +28408,12 @@ msgstr "내장 데이터만 포함"
 
 #: ../src/libs/export_metadata.c:185
 msgid ""
-"per default the interface sends some (limited) metadata beside the image to remote storage.\n"
-"to avoid this and let only image embedded darktable XMP metadata, check this flag.\n"
-"if remote storage doesn't understand darktable XMP metadata, you can use calculated metadata instead"
+"per default the interface sends some (limited) metadata beside the image to "
+"remote storage.\n"
+"to avoid this and let only image embedded darktable XMP metadata, check this "
+"flag.\n"
+"if remote storage doesn't understand darktable XMP metadata, you can use "
+"calculated metadata instead"
 msgstr ""
 "기본적으로 인터페이스가 이미지 옆에 있는 (제한된) 일부 메타데이터를 원격 저장공간으로 전송합니다.\n"
 "만약 이미지에 내장된 darktable XMP 메타데이터만 사용하려면 이 플래그를 선택하세요.\n"
@@ -24686,7 +28453,9 @@ msgid "omit hierarchy"
 msgstr "계층 구조 생략"
 
 #: ../src/libs/export_metadata.c:207
-msgid "only the last part of the hierarchical tags is included. can be useful if categories are not used"
+msgid ""
+"only the last part of the hierarchical tags is included. can be useful if "
+"categories are not used"
 msgstr "계층형 태그의 마지막 부분만 포함됩니다. 카테고리를 사용하지 않을 경우 유용합니다"
 
 #: ../src/libs/export_metadata.c:210
@@ -24702,7 +28471,9 @@ msgid "develop history"
 msgstr "편집 히스토리"
 
 #: ../src/libs/export_metadata.c:213
-msgid "export darktable development data (recovery purpose in case of loss of database or XMP file)"
+msgid ""
+"export darktable development data (recovery purpose in case of loss of "
+"database or XMP file)"
 msgstr "darktable 현상 데이터 내보내기 (데이터베이스나 XMP 파일 손상 시 복구용으로 사용)"
 
 #: ../src/libs/export_metadata.c:219
@@ -24717,9 +28488,12 @@ msgstr "수식"
 msgid ""
 "list of calculated metadata\n"
 "click on '+' button to select and add new metadata\n"
-"if formula is empty, the corresponding metadata is removed from exported file,\n"
-"if formula is '=', the EXIF metadata is exported even if EXIF data are disabled\n"
-"otherwise the corresponding metadata is calculated and added to exported file\n"
+"if formula is empty, the corresponding metadata is removed from exported "
+"file,\n"
+"if formula is '=', the EXIF metadata is exported even if EXIF data are "
+"disabled\n"
+"otherwise the corresponding metadata is calculated and added to exported "
+"file\n"
 "click on formula cell to edit\n"
 "type '$(' to activate the completion and see the list of variables"
 msgstr ""
@@ -24735,7 +28509,7 @@ msgstr ""
 msgid "add an output metadata tag"
 msgstr "출력 메타데이터 태그 추가"
 
-#: ../src/libs/export_metadata.c:284 ../src/libs/metadata.c:938
+#: ../src/libs/export_metadata.c:284 ../src/libs/metadata.c:940
 msgid "delete metadata tag"
 msgstr "메타데이터 태그 삭제"
 
@@ -24763,11 +28537,11 @@ msgstr "사용자 지정 정렬"
 msgid "shuffle"
 msgstr "무작위로 섞기"
 
-#: ../src/libs/filtering.c:265
+#: ../src/libs/filtering.c:268
 msgid "collection filters"
 msgstr "컬렉션 필터"
 
-#: ../src/libs/filtering.c:270
+#: ../src/libs/filtering.c:273
 msgid ""
 "refine the set of images to display or edit.\n"
 "filters can be pinned to the top toolbar, where\n"
@@ -24777,44 +28551,44 @@ msgstr ""
 "필터는 상단 도구 모음에 고정할 수 있으며,\n"
 "darkroom에서도 표시됩니다"
 
-#: ../src/libs/filtering.c:305
+#: ../src/libs/filtering.c:308
 msgid "initial setting"
 msgstr "초기 설정"
 
-#: ../src/libs/filtering.c:324
+#: ../src/libs/filtering.c:327
 msgid "imported: last 24h"
 msgstr "가져온 항목: 최근 24시간 이내"
 
-#: ../src/libs/filtering.c:329
+#: ../src/libs/filtering.c:332
 msgid "imported: last 30 days"
 msgstr "가져온 항목: 최근 30일 이내"
 
-#: ../src/libs/filtering.c:335
+#: ../src/libs/filtering.c:338
 msgid "taken: last 24h"
 msgstr "촬영일: 최근 24시간 이내"
 
-#: ../src/libs/filtering.c:339
+#: ../src/libs/filtering.c:342
 msgid "taken: last 30 days"
 msgstr "촬영일: 최근 30일 이내"
 
-#: ../src/libs/filtering.c:731
+#: ../src/libs/filtering.c:734
 msgid "click or click&#38;drag to select one or multiple values"
 msgstr "클릭 또는 클릭+드래그하여 하나 또는 여러 값을 선택"
 
-#: ../src/libs/filtering.c:732
+#: ../src/libs/filtering.c:735
 msgid "right-click opens a menu to select the available values"
 msgstr "우클릭하여 선택 가능한 값을 고르는 메뉴 열기"
 
-#: ../src/libs/filtering.c:829
+#: ../src/libs/filtering.c:832
 #, c-format
 msgid "you can't have more than %d rules"
 msgstr "규칙은 %d개를 초과할 수 없습니다"
 
-#: ../src/libs/filtering.c:943 ../src/libs/filtering.c:1606
+#: ../src/libs/filtering.c:948 ../src/libs/filtering.c:1616
 msgid "rule property"
 msgstr "규칙 속성"
 
-#: ../src/libs/filtering.c:1000
+#: ../src/libs/filtering.c:1007
 msgid ""
 "rule property\n"
 "this can't be changed as the rule is pinned to the toolbar"
@@ -24822,12 +28596,12 @@ msgstr ""
 "규칙 속성\n"
 "이 규칙은 도구모음에 고정되어 있어 변경할 수 없습니다"
 
-#: ../src/libs/filtering.c:1082
+#: ../src/libs/filtering.c:1089
 msgctxt "quickfilter"
 msgid "filter"
 msgstr "필터"
 
-#: ../src/libs/filtering.c:1111
+#: ../src/libs/filtering.c:1118
 msgid ""
 "this rule is pinned to the top toolbar\n"
 "click to un-pin"
@@ -24835,122 +28609,122 @@ msgstr ""
 "이 규칙은 상단 도구모음에 고정되어 있습니다\n"
 "클릭하여 고정 해제"
 
-#: ../src/libs/filtering.c:1112
+#: ../src/libs/filtering.c:1119
 msgid "you can't disable the rule as it is pinned to the toolbar"
 msgstr "이 규칙은 도구모음에 고정되어 있어 비활성화할 수 없습니다"
 
-#: ../src/libs/filtering.c:1113
+#: ../src/libs/filtering.c:1120
 msgid "you can't remove the rule as it is pinned to the toolbar"
 msgstr "이 규칙은 도구모음에 고정되어 있어 제거할 수 없습니다"
 
-#: ../src/libs/filtering.c:1118
+#: ../src/libs/filtering.c:1125
 msgid "click to pin this rule to the top toolbar"
 msgstr "클릭하여 이 규칙을 상단 도구모음에 고정"
 
-#: ../src/libs/filtering.c:1119
+#: ../src/libs/filtering.c:1126
 msgid "remove this collect rule"
 msgstr "이 수집 규칙 제거"
 
-#: ../src/libs/filtering.c:1121
+#: ../src/libs/filtering.c:1128
 msgid "this rule is enabled"
 msgstr "이 규칙은 활성화되어 있습니다"
 
-#: ../src/libs/filtering.c:1123
+#: ../src/libs/filtering.c:1130
 msgid "this rule is disabled"
 msgstr "이 규칙은 비활성화되어 있습니다"
 
-#: ../src/libs/filtering.c:1251
+#: ../src/libs/filtering.c:1258
 msgid "or"
 msgstr "또는"
 
-#: ../src/libs/filtering.c:1252
+#: ../src/libs/filtering.c:1259
 msgid "and not"
 msgstr "그리고 아님"
 
-#: ../src/libs/filtering.c:1254
+#: ../src/libs/filtering.c:1261
 msgid "define how this rule should interact with the previous one"
 msgstr "이 규칙이 이전 규칙과 어떻게 상호작용할지 정의"
 
-#: ../src/libs/filtering.c:1517
+#: ../src/libs/filtering.c:1527
 msgid " (off)"
 msgstr " (off)"
 
-#: ../src/libs/filtering.c:1705
+#: ../src/libs/filtering.c:1716
 msgid "you can't add more rules."
 msgstr "더 이상 규칙을 추가할 수 없습니다."
 
-#: ../src/libs/filtering.c:1739
+#: ../src/libs/filtering.c:1750
 msgid "shown filters"
 msgstr "표시된 필터"
 
-#: ../src/libs/filtering.c:1754
+#: ../src/libs/filtering.c:1765
 msgid "new filter"
 msgstr "새 필터"
 
 #. the actions part of the popover
-#: ../src/libs/filtering.c:1761
+#: ../src/libs/filtering.c:1772
 msgid "actions"
 msgstr "작업"
 
-#: ../src/libs/filtering.c:1764
+#: ../src/libs/filtering.c:1775
 msgid "reset quickfilters"
 msgstr "퀵필터 초기화"
 
-#: ../src/libs/filtering.c:1937
+#: ../src/libs/filtering.c:1948
 msgid "sort order"
 msgstr "정렬 순서"
 
-#: ../src/libs/filtering.c:1940
+#: ../src/libs/filtering.c:1951
 msgid "determine the sort order of shown images"
 msgstr "표시된 이미지의 정렬 순서 결정"
 
-#: ../src/libs/filtering.c:1960
+#: ../src/libs/filtering.c:1971
 msgid "sort direction"
 msgstr "정렬 방향"
 
-#: ../src/libs/filtering.c:1965
+#: ../src/libs/filtering.c:1976
 msgid "remove this sort order"
 msgstr "이 정렬 기준 제거"
 
-#: ../src/libs/filtering.c:2049
+#: ../src/libs/filtering.c:2060
 #, c-format
 msgid "you can't have more than %d sort orders"
 msgstr "정렬 기준은 %d개를 초과할 수 없습니다"
 
-#: ../src/libs/filtering.c:2102
+#: ../src/libs/filtering.c:2113
 msgid "DESC"
 msgstr "내림차순"
 
-#: ../src/libs/filtering.c:2102
+#: ../src/libs/filtering.c:2113
 msgid "ASC"
 msgstr "오름차순"
 
-#: ../src/libs/filtering.c:2210
+#: ../src/libs/filtering.c:2221
 msgid "new rule"
 msgstr "새 규칙"
 
-#: ../src/libs/filtering.c:2211
+#: ../src/libs/filtering.c:2222
 msgid "append new rule to collect images"
 msgstr "이미지 수집에 새 규칙을 추가"
 
-#: ../src/libs/filtering.c:2222 ../src/libs/tools/filter.c:116
+#: ../src/libs/filtering.c:2233 ../src/libs/tools/filter.c:116
 msgid "sort by"
 msgstr "정렬 기준"
 
-#: ../src/libs/filtering.c:2230
+#: ../src/libs/filtering.c:2241
 msgid "new sort"
 msgstr "새 정렬"
 
-#: ../src/libs/filtering.c:2231
+#: ../src/libs/filtering.c:2242
 msgid "append new sort to order images"
 msgstr "이미지 정렬에 새 규칙을 추가"
 
-#: ../src/libs/filtering.c:2234
+#: ../src/libs/filtering.c:2245
 msgid "revert to a previous set of sort orders"
 msgstr "이전 정렬 기준으로 되돌리기"
 
 #. we change the tooltip of the reset button here, as we are sure the header is defined now
-#: ../src/libs/filtering.c:2281
+#: ../src/libs/filtering.c:2292
 msgid ""
 "reset\n"
 "ctrl+click to remove pinned rules too"
@@ -24984,9 +28758,10 @@ msgstr ""
 
 #. create the filter combobox
 #: ../src/libs/filters/colors.c:301 ../src/libs/filters/colors.c:312
-#: ../src/libs/filters/history.c:153 ../src/libs/filters/local_copy.c:142
-#: ../src/libs/filters/module_order.c:161 ../src/libs/filters/rating.c:198
-#: ../src/libs/filters/rating.c:209 ../src/libs/filters/rating_range.c:356
+#: ../src/libs/filters/duplicates.c:157 ../src/libs/filters/history.c:153
+#: ../src/libs/filters/local_copy.c:142 ../src/libs/filters/module_order.c:161
+#: ../src/libs/filters/rating.c:198 ../src/libs/filters/rating.c:209
+#: ../src/libs/filters/rating_range.c:356
 msgid "rules"
 msgstr "규칙"
 
@@ -24999,6 +28774,27 @@ msgstr ""
 "이미지의 색상 레이블로 필터링\n"
 "교집합: 선택된 모든 색상 레이블이 있는 이미지\n"
 "합집합: 선택된 색상 레이블 중 하나라도 있는 이미지"
+
+#: ../src/libs/filters/date.c:187
+msgid ""
+"filter by capture month\n"
+"click to toggle month selection"
+msgstr ""
+"촬영 월로 필터링\n"
+"클릭하여 월 선택을 전환"
+
+#. predefined selections
+#: ../src/libs/filters/duplicates.c:38 ../src/libs/filters/history.c:38
+#: ../src/libs/filters/local_copy.c:38 ../src/libs/filters/module_order.c:155
+#: ../src/libs/filters/rating_range.c:59 ../src/libs/filters/rating_range.c:83
+#: ../src/libs/filters/rating_range.c:131 ../src/libs/filters/ratio.c:70
+#: ../src/libs/filters/ratio.c:83
+msgid "all images"
+msgstr "모든 이미지"
+
+#: ../src/libs/filters/duplicates.c:157
+msgid "duplicates state filter"
+msgstr "복제본 상태 필터"
 
 #: ../src/libs/filters/filename.c:368
 msgid ""
@@ -25047,17 +28843,9 @@ msgstr ""
 "Ctrl+클릭으로 여러 항목을 선택"
 
 #. the button to close the popup
-#: ../src/libs/filters/filename.c:452
+#: ../src/libs/filters/filename.c:452 ../src/libs/filters/misc.c:501
 msgid "ok"
 msgstr "ok"
-
-#. predefined selections
-#: ../src/libs/filters/history.c:38 ../src/libs/filters/local_copy.c:38
-#: ../src/libs/filters/module_order.c:155 ../src/libs/filters/rating_range.c:59
-#: ../src/libs/filters/rating_range.c:83 ../src/libs/filters/rating_range.c:131
-#: ../src/libs/filters/ratio.c:70 ../src/libs/filters/ratio.c:83
-msgid "all images"
-msgstr "모든 이미지"
 
 #: ../src/libs/filters/history.c:153
 msgid "filter on history state"
@@ -25066,6 +28854,130 @@ msgstr "히스토리 상태로 필터링"
 #: ../src/libs/filters/local_copy.c:142
 msgid "local copied state filter"
 msgstr "로컬 복사본 상태 필터"
+
+#: ../src/libs/filters/misc.c:86
+msgid "no camera defined"
+msgstr "카메라가 정의되지 않음"
+
+#: ../src/libs/filters/misc.c:90
+msgid "no lens defined"
+msgstr "렌즈가 정의되지 않음"
+
+#: ../src/libs/filters/misc.c:94
+msgid "no group id defined"
+msgstr "그룹 ID가 정의되지 않음"
+
+#: ../src/libs/filters/misc.c:99
+msgid "no white balance defined"
+msgstr "화이트 밸런스가 정의되지 않음"
+
+#: ../src/libs/filters/misc.c:104
+msgid "no flash defined"
+msgstr "플래시가 정의되지 않음"
+
+#: ../src/libs/filters/misc.c:109
+msgid "no exposure program defined"
+msgstr "노출 프로그램이 정의되지 않음"
+
+#: ../src/libs/filters/misc.c:114
+msgid "no metering mode defined"
+msgstr "측광 모드가 정의되지 않음"
+
+#: ../src/libs/filters/misc.c:406
+msgid ""
+"enter camera to search.\n"
+"multiple values can be separated by ','\n"
+"\n"
+"right-click to get existing cameras"
+msgstr ""
+"검색할 카메라를 입력하세요.\n"
+"쉼표(,)로 여러 항목을 구분\n"
+"\n"
+"우클릭으로 기존 카메라들 보기"
+
+#: ../src/libs/filters/misc.c:413
+msgid ""
+"enter lens to search.\n"
+"multiple values can be separated by ','\n"
+"\n"
+"right-click to get existing lenses"
+msgstr ""
+"검색할 렌즈를 입력하세요.\n"
+"쉼표(,)로 여러 항목을 구분\n"
+"\n"
+"우클릭으로 기존 렌즈들 보기"
+
+#: ../src/libs/filters/misc.c:420
+msgid ""
+"enter white balance to search.\n"
+"multiple values can be separated by ','\n"
+"\n"
+"right-click to get existing white balances"
+msgstr ""
+"검색할 화이트 밸런스를 입력하세요.\n"
+"쉼표(,)로 여러 항목을 구분\n"
+"\n"
+"우클릭으로 기존 화이트 밸런스들 보기"
+
+#: ../src/libs/filters/misc.c:427
+msgid ""
+"enter flash to search.\n"
+"multiple values can be separated by ','\n"
+"\n"
+"right-click to get existing flashes"
+msgstr ""
+"검색할 플래시를 입력하세요.\n"
+"쉼표(,)로 여러 항목을 구분\n"
+"\n"
+"우클릭으로 기존 플래시들 보기"
+
+#: ../src/libs/filters/misc.c:434
+msgid ""
+"enter exposure program to search.\n"
+"multiple values can be separated by ','\n"
+"\n"
+"right-click to get existing exposure programs"
+msgstr ""
+"검색할 노출 프로그램을 입력하세요.\n"
+"쉼표(,)로 여러 항목을 구분\n"
+"\n"
+"우클릭으로 기존 노출 프로그램들 보기"
+
+#: ../src/libs/filters/misc.c:441
+msgid ""
+"enter metering mode to search.\n"
+"multiple values can be separated by ','\n"
+"\n"
+"right-click to get existing metering modes"
+msgstr ""
+"검색할 측광 모드를 입력하세요.\n"
+"쉼표(,)로 여러 항목을 구분\n"
+"\n"
+"우클릭으로 기존 측광 모드들 보기"
+
+#: ../src/libs/filters/misc.c:447 ../src/libs/metadata_view.c:135
+msgid "group id"
+msgstr "그룹 ID"
+
+#: ../src/libs/filters/misc.c:448
+msgid ""
+"enter group id to search.\n"
+"multiple values can be separated by ','\n"
+"\n"
+"right-click to get existing group ids"
+msgstr ""
+"검색할 그룹 ID를 입력하세요.\n"
+"쉼표(,)로 여러 항목을 구분\n"
+"\n"
+"우클릭으로 기존 그룹 ID들 보기"
+
+#: ../src/libs/filters/misc.c:481
+msgid ""
+"click to select\n"
+"ctrl+click to select multiple values"
+msgstr ""
+"클릭하여 선택\n"
+"Ctrl+클릭으로 여러 항목을 선택"
 
 #: ../src/libs/filters/module_order.c:161
 msgid "filter images based on their module order"
@@ -25133,7 +29045,8 @@ msgstr "가로 이미지"
 #: ../src/libs/filters/search.c:180
 #, no-c-format
 msgid ""
-"filter by text from images metadata, camera brand/model, tags, file path and name\n"
+"filter by text from images metadata, camera brand/model, tags, file path and "
+"name\n"
 "`%' is the wildcard character\n"
 "by default start and end wildcards are auto-applied\n"
 "starting or ending with a double quote disables the corresponding wildcard\n"
@@ -25145,7 +29058,7 @@ msgstr ""
 "큰따옴표로 시작하거나 끝나는 것은 검색 실행 중에\n"
 " 해당 와일드카드가 흐려지는 것을 비활성화합니다"
 
-#: ../src/libs/geotagging.c:147
+#: ../src/libs/geotagging.c:148
 msgid ""
 "set geolocation information for\n"
 "the currently selected images"
@@ -25153,15 +29066,15 @@ msgstr ""
 "현재 선택한 이미지에\n"
 "위치 정보를 설정합니다"
 
-#: ../src/libs/geotagging.c:377
+#: ../src/libs/geotagging.c:378
 msgid "apply offset and geo-location"
 msgstr "오프셋 및 위치 정보 적용"
 
-#: ../src/libs/geotagging.c:378 ../src/libs/geotagging.c:1968
+#: ../src/libs/geotagging.c:379 ../src/libs/geotagging.c:1975
 msgid "apply geo-location"
 msgstr "위치 정보 적용"
 
-#: ../src/libs/geotagging.c:380
+#: ../src/libs/geotagging.c:381
 msgid ""
 "apply offset and geo-location to matching images\n"
 "double operation: two ctrl+z to undo"
@@ -25169,49 +29082,49 @@ msgstr ""
 "오프셋과 위치 정보를 일치하는 이미지에 적용\n"
 "두번의 작업으로서, 되돌리려면 두 번의 Ctrl+z 필요"
 
-#: ../src/libs/geotagging.c:382 ../src/libs/geotagging.c:1969
+#: ../src/libs/geotagging.c:383 ../src/libs/geotagging.c:1976
 msgid "apply geo-location to matching images"
 msgstr "위치 정보를 일치하는 이미지에 적용"
 
-#: ../src/libs/geotagging.c:830
+#: ../src/libs/geotagging.c:831
 msgid "GPX file track segments"
 msgstr "GPX 파일 트랙 세그먼트"
 
-#: ../src/libs/geotagging.c:846 ../src/libs/geotagging.c:1914
+#: ../src/libs/geotagging.c:847 ../src/libs/geotagging.c:1921
 msgid "start time"
 msgstr "시작 시간"
 
-#: ../src/libs/geotagging.c:847
+#: ../src/libs/geotagging.c:848
 msgid "end time"
 msgstr "종료 시간"
 
-#: ../src/libs/geotagging.c:848 ../src/libs/geotagging.c:1916
+#: ../src/libs/geotagging.c:849 ../src/libs/geotagging.c:1923
 msgid "points"
 msgstr "포인트"
 
-#: ../src/libs/geotagging.c:849 ../src/libs/geotagging.c:1918
+#: ../src/libs/geotagging.c:850 ../src/libs/geotagging.c:1925
 #: ../src/libs/image.c:503
 msgid "images"
 msgstr "이미지"
 
-#: ../src/libs/geotagging.c:949
+#: ../src/libs/geotagging.c:950
 msgid "open GPX file"
 msgstr "GPX 파일 열기"
 
-#: ../src/libs/geotagging.c:950 ../src/libs/tools/lighttable.c:419
-#: ../src/libs/tools/lighttable.c:491 ../src/views/darkroom.c:2374
+#: ../src/libs/geotagging.c:951 ../src/libs/tools/lighttable.c:419
+#: ../src/libs/tools/lighttable.c:491 ../src/views/darkroom.c:2722
 msgid "preview"
 msgstr "미리보기"
 
-#: ../src/libs/geotagging.c:963
+#: ../src/libs/geotagging.c:964
 msgid "GPS data exchange format"
 msgstr "GPS 데이터 교환 형식"
 
-#: ../src/libs/geotagging.c:1787
+#: ../src/libs/geotagging.c:1791
 msgid "date/time"
 msgstr "날짜/시간"
 
-#: ../src/libs/geotagging.c:1788
+#: ../src/libs/geotagging.c:1792
 msgid ""
 "enter the new date/time (YYYY:MM:DD hh:mm:ss[.sss])\n"
 "key in the new numbers or scroll over the cell"
@@ -25219,40 +29132,40 @@ msgstr ""
 "새 날짜/시간을 입력하세요 (형식: YYYY:MM:DD hh:mm:ss[.sss])\n"
 "새 숫자를 입력하거나 셀 위로 스크롤"
 
-#: ../src/libs/geotagging.c:1792
+#: ../src/libs/geotagging.c:1796
 msgid "original date/time"
 msgstr "원본 날짜/시간"
 
-#: ../src/libs/geotagging.c:1796
+#: ../src/libs/geotagging.c:1801
 msgid "lock date/time offset value to apply it onto another selection"
 msgstr "다른 선택에도 적용하기 위해 날짜/시간 오프셋 값 잠금"
 
-#: ../src/libs/geotagging.c:1800
+#: ../src/libs/geotagging.c:1805
 msgid "date/time offset"
 msgstr "날짜/시간 오프셋"
 
-#: ../src/libs/geotagging.c:1801
+#: ../src/libs/geotagging.c:1806
 msgid "offset or difference ([-]dd hh:mm:ss[.sss])"
 msgstr "오프셋 또는 차이 값 ([-]dd hh:mm:ss[.sss])"
 
 #. apply
-#: ../src/libs/geotagging.c:1805
+#: ../src/libs/geotagging.c:1810
 msgid "apply offset"
 msgstr "오프셋 적용"
 
-#: ../src/libs/geotagging.c:1806
+#: ../src/libs/geotagging.c:1811
 msgid "apply offset to selected images"
 msgstr "선택한 이미지에 오프셋 적용"
 
-#: ../src/libs/geotagging.c:1809
+#: ../src/libs/geotagging.c:1814
 msgid "apply date/time"
 msgstr "날짜/시간 적용"
 
-#: ../src/libs/geotagging.c:1810
+#: ../src/libs/geotagging.c:1815
 msgid "apply the same date/time to selected images"
 msgstr "선택한 이미지에 동일한 날짜/시간 적용"
 
-#: ../src/libs/geotagging.c:1820
+#: ../src/libs/geotagging.c:1826
 msgid ""
 "start typing to show a list of permitted values and select your timezone.\n"
 "press enter to confirm, so that the asterisk * disappears"
@@ -25261,29 +29174,30 @@ msgstr ""
 "Enter 키를 눌러 선택을 확정하면 별표(*)가 사라집니다"
 
 #. gpx
-#: ../src/libs/geotagging.c:1860
+#: ../src/libs/geotagging.c:1867
 msgid "apply GPX track file..."
 msgstr "GPX 트랙 파일 적용..."
 
-#: ../src/libs/geotagging.c:1861
+#: ../src/libs/geotagging.c:1868
 msgid "parses a GPX file and updates location of selected images"
 msgstr "GPX 파일을 분석하여 선택된 이미지의 위치 정보를 업데이트"
 
-#: ../src/libs/geotagging.c:1872
+#: ../src/libs/geotagging.c:1879
 msgctxt "section"
 msgid "GPX file"
 msgstr "GPX 파일"
 
-#: ../src/libs/geotagging.c:1879
+#: ../src/libs/geotagging.c:1886
 msgid "select a GPX track file..."
 msgstr "GPX 트랙 파일 선택..."
 
-#: ../src/libs/geotagging.c:1896
+#: ../src/libs/geotagging.c:1903
 msgid ""
 "list of track segments in the GPX file, for each segment:\n"
 "- the start date/time in local time (LT)\n"
 "- the number of track points\n"
-"- the number of matching images based on images date/time, offset and time zone\n"
+"- the number of matching images based on images date/time, offset and time "
+"zone\n"
 "- more detailed time information hovering the row"
 msgstr ""
 "GPX 파일에 포함된 트랙 세그먼트 목록입니다, 각 세그먼트에는:\n"
@@ -25294,200 +29208,86 @@ msgstr ""
 
 #. the gpx_view_button is invisible and the label and tooltip of cannot be displayed on GUI.
 #. but label is use in "shortcuts" dialog.
-#: ../src/libs/geotagging.c:1933
+#: ../src/libs/geotagging.c:1940
 msgid "view entire track"
 msgstr "전체 트랙 보기"
 
-#: ../src/libs/geotagging.c:1934
+#: ../src/libs/geotagging.c:1941
 msgid "refresh map to view entire selected track segments"
 msgstr "지도를 새로 고침하여 선택한 트랙 세그먼트 전체 보기"
 
-#: ../src/libs/geotagging.c:1948
+#: ../src/libs/geotagging.c:1955
 msgid "preview images"
 msgstr "이미지 미리보기"
 
-#: ../src/libs/geotagging.c:1953
+#: ../src/libs/geotagging.c:1960
 msgid "show on map matching images"
 msgstr "일치하는 이미지를 지도에 표시"
 
-#: ../src/libs/geotagging.c:1956
+#: ../src/libs/geotagging.c:1963
 msgid "select images"
 msgstr "이미지 선택"
 
-#: ../src/libs/geotagging.c:1957
+#: ../src/libs/geotagging.c:1964
 msgid "select matching images"
 msgstr "일치하는 이미지 선택"
 
-#: ../src/libs/geotagging.c:1965
+#: ../src/libs/geotagging.c:1972
 msgid "number of matching images versus selected images"
 msgstr "선택된 이미지 수 대비 일치하는 이미지 수"
 
-#: ../src/libs/histogram.c:112
-msgid "monochromatic"
-msgstr "단색조"
-
-#: ../src/libs/histogram.c:113
-msgid "analogous"
-msgstr "유사색"
-
-#: ../src/libs/histogram.c:114
-msgid "analogous complementary"
-msgstr "유사 보색"
-
-#: ../src/libs/histogram.c:115
-msgid "complementary"
-msgstr "보색"
-
-#: ../src/libs/histogram.c:116
-msgid "split complementary"
-msgstr "분할 보색(Split complementary)"
-
-#: ../src/libs/histogram.c:117
-msgid "dyad"
-msgstr "2색 조합(Dyad)"
-
-#: ../src/libs/histogram.c:118
-msgid "triad"
-msgstr "3색 조합(Triad)"
-
-#: ../src/libs/histogram.c:119
-msgid "tetrad"
-msgstr "4색 조합(Tetrad)"
-
-#: ../src/libs/histogram.c:125
-msgid "vectorscope"
-msgstr "벡터스코프"
-
-#: ../src/libs/histogram.c:126
-msgid "waveform"
-msgstr "웨이브폼"
-
-#: ../src/libs/histogram.c:127
-msgid "RGB parade"
-msgstr "RGB 퍼레이드"
-
-#: ../src/libs/histogram.c:128 ../src/libs/histogram.c:2525
-msgid "histogram"
-msgstr "히스토그램"
-
-#: ../src/libs/histogram.c:216
+#: ../src/libs/histogram.c:54
 msgid "scopes"
 msgstr "스코프 도구"
 
-#: ../src/libs/histogram.c:1012
-msgid "unsupported profile selected for histogram, it will be replaced with linear Rec2020"
+#: ../src/libs/histogram.c:172
+msgid ""
+"unsupported profile selected for histogram, it will be replaced with linear "
+"Rec2020"
 msgstr ""
 "히스토그램에 지원되지 않는 색상 프로파일이 선택되어, \n"
 "선형 Rec2020으로 대체됩니다"
 
-#: ../src/libs/histogram.c:1663
+#: ../src/libs/histogram.c:293
 msgid "use buttons at top of graph to change type"
 msgstr "그래프 상단의 버튼을 사용하여 유형 변경"
 
-#: ../src/libs/histogram.c:1664
+#: ../src/libs/histogram.c:294
 msgid "click on ❓ and then graph for documentation"
 msgstr "❓를 클릭한 후 그래프를 클릭하여 설명서 확인"
 
-#: ../src/libs/histogram.c:1665
+#: ../src/libs/histogram.c:295
 msgid "use color picker module to restrict area"
 msgstr "색상피커 모듈을 사용하여 영역 제한"
 
-#: ../src/libs/histogram.c:1673
-msgid "scroll to coarse-rotate"
-msgstr "스크롤하여 거친 회전"
-
-#: ../src/libs/histogram.c:1674
-msgid "ctrl+scroll to fine rotate"
-msgstr "Ctrl+스크롤하여 미세한 회전"
-
-#: ../src/libs/histogram.c:1675
-msgid "shift+scroll to change width"
-msgstr "Shift+스크롤로 너비 조절"
-
-#: ../src/libs/histogram.c:1676
-msgid "alt+scroll to cycle"
-msgstr "Alt+스크롤로 모드 순차 전환"
-
-#: ../src/libs/histogram.c:1688
+#: ../src/libs/histogram.c:298
 msgid "drag to change black point"
 msgstr "드래그하여 블랙 포인트 조절"
 
-#: ../src/libs/histogram.c:1689 ../src/libs/histogram.c:1696
+#: ../src/libs/histogram.c:299 ../src/libs/histogram.c:303
 msgid "double-click resets"
 msgstr "더블 클릭으로 리셋"
 
-#: ../src/libs/histogram.c:1695
+#: ../src/libs/histogram.c:302
 msgid "drag to change exposure"
 msgstr "드래그하여 노출 조절"
 
-#: ../src/libs/histogram.c:1835 ../src/libs/histogram.c:1877
-msgid "set scale to linear"
-msgstr "스케일을 선형으로 설정"
+#: ../src/libs/histogram.c:751 ../src/libs/scopes/histogram.c:50
+msgid "histogram"
+msgstr "히스토그램"
 
-#: ../src/libs/histogram.c:1840 ../src/libs/histogram.c:1882
-msgid "set scale to logarithmic"
-msgstr "스케일을 로그로 설정"
-
-#: ../src/libs/histogram.c:1858
-msgid "set scope to vertical"
-msgstr "스코프를 수직으로 설정"
-
-#: ../src/libs/histogram.c:1863
-msgid "set scope to horizontal"
-msgstr "스코프를 수평으로 설정"
-
-#: ../src/libs/histogram.c:1892
-msgid "set view to AzBz"
-msgstr "보기 모드를 AzBz로 설정"
-
-#: ../src/libs/histogram.c:1898
-msgid "set view to RYB"
-msgstr "보기 모드를 RYB로 설정"
-
-#: ../src/libs/histogram.c:1904
-msgid "set view to u*v*"
-msgstr "보기 모드를 u*v*로 설정"
-
-#: ../src/libs/histogram.c:2528 ../src/libs/histogram.c:2596
-msgid "cycle histogram modes"
-msgstr "히스토그램 모드 순차 전환"
-
-#: ../src/libs/histogram.c:2535 ../src/libs/histogram.c:2598
+#: ../src/libs/histogram.c:757 ../src/libs/histogram.c:855
 msgid "hide histogram"
 msgstr "히스토그램 숨기기"
 
-#: ../src/libs/histogram.c:2601 ../src/libs/histogram.c:2634
-msgid "switch histogram view"
-msgstr "히스토그램 보기 전환"
+#: ../src/libs/histogram.c:867
+#, c-format
+msgid "toggle %s channel"
+msgstr "%s 채널 전환"
 
-#: ../src/libs/histogram.c:2609
-msgid "toggle blue channel"
-msgstr "파랑 채널 전환"
-
-#: ../src/libs/histogram.c:2611 ../src/libs/histogram.c:2620
-#: ../src/libs/histogram.c:2629
+#: ../src/libs/histogram.c:875
 msgid "toggle colors"
 msgstr "색상 표시 전환"
-
-#: ../src/libs/histogram.c:2618
-msgid "toggle green channel"
-msgstr "녹색 채널 전환"
-
-#: ../src/libs/histogram.c:2627
-msgid "toggle red channel"
-msgstr "빨강 채널 전환"
-
-#: ../src/libs/histogram.c:2639
-msgid "cycle vectorscope types"
-msgstr "벡터스코프 유형 순차 전환"
-
-#: ../src/libs/histogram.c:2650
-msgid "color harmonies"
-msgstr "색상 조화"
-
-#: ../src/libs/histogram.c:2664
-msgid "cycle color harmonies"
-msgstr "색상 조화 방식 순차 전환"
 
 #: ../src/libs/history.c:103
 msgid ""
@@ -25602,11 +29402,11 @@ msgstr "파라메트릭 출력 마스크:"
 msgid "parametric input mask:"
 msgstr "파라메트릭 입력 마스크:"
 
-#: ../src/libs/history.c:1342
+#: ../src/libs/history.c:1333
 msgid "delete image's history?"
 msgstr "이미지 히스토리를 삭제하시겠습니까?"
 
-#: ../src/libs/history.c:1343
+#: ../src/libs/history.c:1334
 msgid "do you really want to clear history of current image?"
 msgstr "현재 이미지의 히스토리를 정말 지우시겠습니까?"
 
@@ -25626,8 +29426,8 @@ msgstr "디스크에서 물리적으로로 삭제 (가능하면 휴지통 사용
 msgid "physically delete from disk immediately"
 msgstr "디스크에서 물리적으로 즉시 삭제"
 
-#: ../src/libs/image.c:515 ../src/libs/modulegroups.c:3994
-#: ../src/libs/styles.c:895
+#: ../src/libs/image.c:515 ../src/libs/modulegroups.c:4078
+#: ../src/libs/styles.c:930
 msgid "remove"
 msgstr "제거"
 
@@ -25778,24 +29578,32 @@ msgstr "선택 항목을 컬러 이미지로 설정"
 msgid "duplicate virgin"
 msgstr "초기 상태로 복제"
 
-#: ../src/libs/import.c:284
+#: ../src/libs/import.c:122
+msgid "add to library"
+msgstr "라이브러리에 추가"
+
+#: ../src/libs/import.c:123
+msgid "copy & import"
+msgstr "복사 및 가져오기"
+
+#: ../src/libs/import.c:124
+msgid "copy & import from camera"
+msgstr "카메라에서 복사 및 가져오기"
+
+#: ../src/libs/import.c:125
+msgid "tethered shoot"
+msgstr "테더 촬영"
+
+#: ../src/libs/import.c:287
 #, c-format
 msgid "device \"%s\" connected on port \"%s\"."
 msgstr "장치 \"%s\"가 포트 \"%s\"에 연결되었습니다."
 
-#: ../src/libs/import.c:296 ../src/libs/import.c:371 ../src/libs/import.c:2046
-msgid "copy & import from camera"
-msgstr "카메라에서 복사 및 가져오기"
-
-#: ../src/libs/import.c:310 ../src/libs/import.c:375
-msgid "tethered shoot"
-msgstr "테더 촬영"
-
-#: ../src/libs/import.c:320 ../src/libs/import.c:377
+#: ../src/libs/import.c:313 ../src/libs/import.c:2410
 msgid "unmount camera"
 msgstr "카메라 연결 해제"
 
-#: ../src/libs/import.c:345
+#: ../src/libs/import.c:332
 msgid ""
 "camera is locked by another application\n"
 "make sure it is no longer mounted\n"
@@ -25805,107 +29613,100 @@ msgstr ""
 "카메라 연결이 해제되었는지 확인하거나\n"
 "해당 어플리케이션을 종료하세요"
 
-#: ../src/libs/import.c:350
+#: ../src/libs/import.c:337
 msgid "tethering and importing is disabled for this camera"
 msgstr "이 카메라는 테더 촬영 및 가져오기 미지원"
 
-#: ../src/libs/import.c:352 ../src/libs/import.c:373
+#: ../src/libs/import.c:339 ../src/libs/import.c:2409
 msgid "mount camera"
 msgstr "카메라 마운트"
 
-#: ../src/libs/import.c:998
+#: ../src/libs/import.c:970
 #, c-format
 msgid "%d image out of %d selected"
 msgid_plural "%d images out of %d selected"
 msgstr[0] "%d개의 이미지가 %d개 중 선택됨"
 
-#: ../src/libs/import.c:1450
+#: ../src/libs/import.c:1420
 msgid "choose the root of the folder tree below"
 msgstr "아래 폴더 트리의 루트를 선택하세요"
 
-#: ../src/libs/import.c:1453
+#: ../src/libs/import.c:1423
 msgid "places"
 msgstr "위치"
 
-#: ../src/libs/import.c:1461
+#: ../src/libs/import.c:1431
 msgid "restore all default places you have removed"
 msgstr "제거한 모든 기본값 위치 복원"
 
-#: ../src/libs/import.c:1468
+#: ../src/libs/import.c:1438
 msgid "remove the selected custom place"
 msgstr "선택된 사용자 지정 위치 제거"
 
-#: ../src/libs/import.c:1475
+#: ../src/libs/import.c:1445
 msgid "add a custom place"
 msgstr "사용자 지정 위치 추가"
 
-#: ../src/libs/import.c:1483
+#: ../src/libs/import.c:1453
 msgid "you can add custom places using the plus icon"
 msgstr "플러스 아이콘을 사용하여 사용자 지정 위치를 추가할 수 있습니다"
 
-#: ../src/libs/import.c:1511
+#: ../src/libs/import.c:1481
 msgid "select a folder to see the content"
 msgstr "내용을 보려면 폴더를 선택하세요"
 
-#: ../src/libs/import.c:1514
+#: ../src/libs/import.c:1484
 msgid "folders"
 msgstr "폴더"
 
-#: ../src/libs/import.c:1590
+#: ../src/libs/import.c:1560
 msgid "home"
 msgstr "홈"
 
-#: ../src/libs/import.c:1604
+#: ../src/libs/import.c:1574
 msgid "pictures"
 msgstr "사진"
 
-#: ../src/libs/import.c:1891
+#: ../src/libs/import.c:1861
 msgid "mark already imported images"
 msgstr "이미 가져온 이미지 마킹"
 
-#: ../src/libs/import.c:1905
+#: ../src/libs/import.c:1875
 msgid "modified"
 msgstr "수정됨"
 
-#: ../src/libs/import.c:1912
+#: ../src/libs/import.c:1882
 msgid "file 'modified date/time', may be different from 'Exif date/time'"
 msgstr "파일의 '수정된 날짜/시간'은, 'EXIF 날짜/시간'과 다를 수 있음"
 
-#: ../src/libs/import.c:1924
+#: ../src/libs/import.c:1894
 msgid "show/hide thumbnails"
 msgstr "썸네일 표시/숨기기"
 
-#: ../src/libs/import.c:1998
+#: ../src/libs/import.c:1968
 msgid "naming rules"
 msgstr "이름 규칙"
 
-#: ../src/libs/import.c:2044
-msgid "add to library"
-msgstr "라이브러리에 추가"
-
-#: ../src/libs/import.c:2045
-msgid "copy & import"
-msgstr "복사 및 가져오기"
-
-#: ../src/libs/import.c:2083
+#: ../src/libs/import.c:2046
 msgid "select new"
 msgstr "새 항목 선택"
 
-#: ../src/libs/import.c:2134
+#: ../src/libs/import.c:2097
 msgid "please wait while prefetching the list of images from camera..."
 msgstr "카메라에서 이미지 목록을 불러오는 중입니다 잠시만 기다려주세요..."
 
-#: ../src/libs/import.c:2284
+#: ../src/libs/import.c:2247
 msgid "invalid override date/time format"
 msgstr "잘못된 날짜/시간 형식"
 
-#: ../src/libs/import.c:2352
+#: ../src/libs/import.c:2315
 msgid "import base directory"
 msgstr "베이스 디렉토리 가져오기"
 
-#: ../src/libs/import.c:2353
+#: ../src/libs/import.c:2316
 msgid ""
-"before copying images to the darktable base directory make sure it is defined as you prefer.\n"
+"before copying images to the darktable base directory make sure it is "
+"defined as you prefer.\n"
 "further information can be found in the darktable manual.\n"
 "\n"
 "inspect darktable preferences -> import.\n"
@@ -25918,76 +29719,77 @@ msgstr ""
 "[환경설정] -> [가져오기]에서\n"
 "'베이스 디렉토리 작명 규칙'을 확인하고 필요시 수정하세요"
 
-#: ../src/libs/import.c:2357
+#: ../src/libs/import.c:2320
 msgid "_come back & check"
 msgstr "_돌아가서 체크 (&C)"
 
-#: ../src/libs/import.c:2357
+#: ../src/libs/import.c:2320
 msgid "_understood & done"
 msgstr "_이해하고 완료 (&U)"
 
 #. add import buttons
-#: ../src/libs/import.c:2420
+#: ../src/libs/import.c:2383
 msgid "add to library..."
 msgstr "라이브러리에 추가..."
 
-#: ../src/libs/import.c:2422
+#: ../src/libs/import.c:2385
 msgid "add existing images to the library"
 msgstr "기존 이미지를 라이브러리에 추가"
 
-#: ../src/libs/import.c:2428
+#: ../src/libs/import.c:2391
 msgid "copy & import..."
 msgstr "복사 및 가져오기..."
 
-#: ../src/libs/import.c:2430
+#: ../src/libs/import.c:2393
 msgid ""
 "copy and optionally rename images before adding them to the library\n"
-"patterns can be defined to rename the images and specify the destination folders"
+"patterns can be defined to rename the images and specify the destination "
+"folders"
 msgstr ""
 "라이브러리에 추가하기 전에 이미지를 복사하거나 선택적으로 이름을 바꿀 수 있습니다\n"
 "패턴을 정의하여 파일 이름 변경과 대상 폴더 지정이 가능합니다"
 
-#: ../src/libs/import.c:2452
+#: ../src/libs/import.c:2416
 msgid "parameters"
 msgstr "파라메터"
 
-#: ../src/libs/ioporder.c:200
+#: ../src/libs/ioporder.c:198
 msgid "v3.0 for RAW input"
 msgstr "RAW 입력 v3.0"
 
-#: ../src/libs/ioporder.c:208
+#: ../src/libs/ioporder.c:206
 msgid "v3.0 for JPEG/non-RAW input"
 msgstr "JPEG/non-RAW 입력 v3.0"
 
-#: ../src/libs/ioporder.c:217
+#: ../src/libs/ioporder.c:215
 msgid "v5.0 for RAW input"
 msgstr "RAW 입력 v5.0"
 
-#: ../src/libs/ioporder.c:226
+#: ../src/libs/ioporder.c:224
 msgid "v5.0 for JPEG/non-RAW input"
 msgstr "JPEG/non-RAW 입력 v5.0"
 
-#: ../src/libs/lib.c:374
+#: ../src/libs/lib.c:412
 msgid "deleting preset for obsolete module"
 msgstr "사용 중단된 모듈의 사전설정 삭제 중"
 
-#: ../src/libs/lib.c:538
+#: ../src/libs/lib.c:578
 msgid "manage presets..."
 msgstr "사전설정 관리..."
 
-#: ../src/libs/lib.c:563
+#: ../src/libs/lib.c:603
 msgid "nothing to save"
 msgstr "저장할 항목 없음"
 
-#: ../src/libs/lib.c:1264
+#: ../src/libs/lib.c:1326
 msgid "show module"
 msgstr "모듈 표시"
 
-#: ../src/libs/lib.c:1289
+#: ../src/libs/lib.c:1359
 msgid "presets and preferences"
 msgstr "사전설정 및 환경설정"
 
-#: ../src/libs/lib.c:1596
+#: ../src/libs/lib.c:1744
 msgid "utility module"
 msgstr "유틸리티 모듈"
 
@@ -26158,7 +29960,8 @@ msgid "go to collection (lighttable)"
 msgstr "컬렉션으로 이동 (lighttable)"
 
 #: ../src/libs/map_locations.c:841
-msgid "terminate edit (press enter or escape) before selecting another location"
+msgid ""
+"terminate edit (press enter or escape) before selecting another location"
 msgstr "다른 위치를 선택하기 전에 (Enter 또는 Esc 키로) 편집을 종료하세요"
 
 #: ../src/libs/map_locations.c:925
@@ -26190,7 +29993,8 @@ msgstr ""
 #: ../src/libs/map_locations.c:951
 msgid ""
 "select the shape of the location's limits on the map, circle or rectangle\n"
-"or even polygon if available (select first a polygon place in 'find location' module)"
+"or even polygon if available (select first a polygon place in 'find "
+"location' module)"
 msgstr ""
 "지도 상의 위치 경계 모양을 선택하세요 (원, 사각형 등)\n"
 "또는 '위치 찾기' 모듈에서 다각형 장소를 먼저 선택한 경우, 다각형도 사용 가능합니다"
@@ -26219,89 +30023,117 @@ msgstr "지도 소스"
 msgid "select the source of the map. some entries might not work"
 msgstr "지도의 소스를 선택하세요. 일부는 작동하지 않을 수 있습니다"
 
-#: ../src/libs/masks.c:63
+#: ../src/libs/masks.c:79
 msgid ""
 "manipulate the drawn shapes used\n"
 "for masks on the processing modules"
 msgstr "처리 모듈에서 사용하는 마스크 도형 편집"
 
-#: ../src/libs/masks.c:109
+#: ../src/libs/masks.c:189
 msgid "feather"
 msgstr "가장자리 블러"
 
-#: ../src/libs/masks.c:356
+#: ../src/libs/masks.c:193
+msgid "cleanup"
+msgstr "정리"
+
+#: ../src/libs/masks.c:195
+msgid "refine mask boundary"
+msgstr "마스크 경계 다듬기"
+
+#: ../src/libs/masks.c:451
+msgid "shrink amount too large: the path would disappear"
+msgstr "축소량이 너무 큽니다: 경로가 사라집니다"
+
+#: ../src/libs/masks.c:652
 #, c-format
 msgid "group #%d"
 msgstr "그룹 #%d"
 
-#: ../src/libs/masks.c:1087
+#: ../src/libs/masks.c:1385
 msgid "duplicate this shape"
 msgstr "이 도형 복제"
 
-#: ../src/libs/masks.c:1091
+#: ../src/libs/masks.c:1389
 msgid "delete this shape"
 msgstr "이 도형 삭제"
 
-#: ../src/libs/masks.c:1097
+#: ../src/libs/masks.c:1395
 msgid "delete group"
 msgstr "그룹 삭제"
 
-#: ../src/libs/masks.c:1104
+#: ../src/libs/masks.c:1402
 msgid "remove from group"
 msgstr "그룹에서 제거"
 
-#: ../src/libs/masks.c:1112
+#: ../src/libs/masks.c:1410
 msgid "group the forms"
 msgstr "도형 그룹화"
 
-#: ../src/libs/masks.c:1120
+#: ../src/libs/masks.c:1418
 msgid "use inverted shape"
 msgstr "도형 반전 사용"
 
-#: ../src/libs/masks.c:1124
+#: ../src/libs/masks.c:1422
 msgid "mode: union"
 msgstr "모드: 합집합"
 
-#: ../src/libs/masks.c:1126
+#: ../src/libs/masks.c:1424
 msgid "mode: intersection"
 msgstr "모드: 교집합"
 
-#: ../src/libs/masks.c:1128
+#: ../src/libs/masks.c:1426
 msgid "mode: difference"
 msgstr "모드: 차집합"
 
-#: ../src/libs/masks.c:1130
+#: ../src/libs/masks.c:1428
 msgid "mode: sum"
 msgstr "모드: 덧셈"
 
-#: ../src/libs/masks.c:1132
+#: ../src/libs/masks.c:1430
 msgid "mode: exclusion"
 msgstr "모드: 제외"
 
-#: ../src/libs/masks.c:1148
+#: ../src/libs/masks.c:1446
 msgid "delete unused shapes"
 msgstr "사용되지 않은 도형 삭제"
 
-#: ../src/libs/masks.c:1872
+#: ../src/libs/masks.c:2137
+msgid "add object"
+msgstr "객체 추가"
+
+#: ../src/libs/masks.c:2181
 msgid "created shapes"
 msgstr "생성된 도형"
 
-#: ../src/libs/masks.c:1879 ../src/libs/masks.c:1894 ../src/libs/masks.c:1908
-#: ../src/libs/masks.c:1910
+#: ../src/libs/masks.c:2194 ../src/libs/masks.c:2208 ../src/libs/masks.c:2220
+#: ../src/libs/masks.c:2235 ../src/libs/masks.c:2237 ../src/libs/masks.c:2247
 msgid "properties"
 msgstr "속성"
 
-#: ../src/libs/masks.c:1882
+#: ../src/libs/masks.c:2197
 msgid "no shapes selected"
 msgstr "선택된 도형 없음"
 
-#: ../src/libs/masks.c:1908
+#: ../src/libs/masks.c:2235
 msgid "pressure"
 msgstr "필압"
 
-#: ../src/libs/masks.c:1910
-msgid "smoothing"
-msgstr "부드럽게 처리"
+#: ../src/libs/masks.c:2247
+msgid "shrink or grow"
+msgstr "축소 또는 확대"
+
+#: ../src/libs/masks.c:2251
+msgid ""
+"grow (positive) or shrink (negative) the selected path,\n"
+"relative to its shape when selected; 0 restores the original"
+msgstr ""
+"선택한 경로를 선택 당시의 모양을 기준으로\n"
+"확대(양수) 또는 축소(음수)합니다. 0은 원래대로 되돌립니다"
+
+#: ../src/libs/masks.c:2264
+msgid "shrink/grow unit: image pixels (px) or % of path size — click to toggle"
+msgstr "축소/확대 단위: 이미지 픽셀(px) 또는 경로 크기의 % — 클릭하여 전환"
 
 #: ../src/libs/metadata.c:65
 msgid "metadata editor"
@@ -26313,10 +30145,11 @@ msgid ""
 "the currently selected images"
 msgstr "현재 선택한 이미지의 텍스트 메타데이터 필드 수정"
 
-#: ../src/libs/metadata.c:604
+#: ../src/libs/metadata.c:606
 msgid ""
 "metadata text\n"
-"ctrl+enter inserts a new line (caution, may not be compatible with standard metadata)\n"
+"ctrl+enter inserts a new line (caution, may not be compatible with standard "
+"metadata)\n"
 "if <leave unchanged> selected images have different metadata\n"
 "in that case, right-click gives the possibility to choose one of them\n"
 "escape to exit the popup window"
@@ -26327,31 +30160,31 @@ msgstr ""
 "이 경우, 우클릭으로 하나를 선택할 수 있습니다\n"
 "Esc를 누르면 창을 닫습니다"
 
-#: ../src/libs/metadata.c:615
+#: ../src/libs/metadata.c:617
 msgid "<leave unchanged>"
 msgstr "<변경하지 않음>"
 
-#: ../src/libs/metadata.c:841 ../src/libs/metadata_view.c:1432
+#: ../src/libs/metadata.c:843 ../src/libs/metadata_view.c:1461
 msgid "metadata settings"
 msgstr "메타데이터 설정"
 
-#: ../src/libs/metadata.c:884
+#: ../src/libs/metadata.c:886
 msgid "XMP tag name"
 msgstr "XMP 태그 이름"
 
-#: ../src/libs/metadata.c:890
+#: ../src/libs/metadata.c:892
 msgid "display name"
 msgstr "표시 이름"
 
-#: ../src/libs/metadata.c:900 ../src/libs/metadata_view.c:1470
+#: ../src/libs/metadata.c:902 ../src/libs/metadata_view.c:1500
 msgid "visible"
 msgstr "표시됨"
 
-#: ../src/libs/metadata.c:907
+#: ../src/libs/metadata.c:909
 msgid "drag and drop one row at a time until you get the desired order"
 msgstr "원하는 순서가 될 때까지 한 행씩 드래그 앤 드롭"
 
-#: ../src/libs/metadata.c:915
+#: ../src/libs/metadata.c:917
 msgid ""
 "tick if the corresponding metadata is of interest for you\n"
 "it will be visible from metadata editor, collection and import module\n"
@@ -26361,24 +30194,25 @@ msgstr ""
 "메타데이터 편집기, 컬렉션, 가져오기 모듈에서 표시되고,\n"
 "이미지를 내보낼 때도 함께 내보내집니다"
 
-#: ../src/libs/metadata.c:920 ../src/libs/tagging.c:1873
-#: ../src/libs/tagging.c:2021
+#: ../src/libs/metadata.c:922 ../src/libs/tagging.c:1903
+#: ../src/libs/tagging.c:2051
 msgid "private"
 msgstr "비공개"
 
-#: ../src/libs/metadata.c:925
-msgid "tick if you want to keep this information private (not exported with images)"
+#: ../src/libs/metadata.c:927
+msgid ""
+"tick if you want to keep this information private (not exported with images)"
 msgstr "이 정보를 비공개로 유지하려면 체크하세요 (내보내기에 포함되지 않음)"
 
-#: ../src/libs/metadata.c:934
+#: ../src/libs/metadata.c:936
 msgid "add metadata tags"
 msgstr "메타데이터 태그 추가"
 
-#: ../src/libs/metadata.c:985
+#: ../src/libs/metadata.c:987
 msgid "delete metadata"
 msgstr "메타데이터 삭제"
 
-#: ../src/libs/metadata.c:986
+#: ../src/libs/metadata.c:988
 msgid ""
 "you are about to delete metadata which is currently assigned to images.\n"
 "the assignments will be removed."
@@ -26386,67 +30220,67 @@ msgstr ""
 "현재 이미지에 할당된 메타데이터를 삭제하려고 합니다.\n"
 "메타데이터 할당이 제거됩니다."
 
-#: ../src/libs/metadata.c:1141
+#: ../src/libs/metadata.c:1143
 msgid "write metadata for selected images"
 msgstr "선택한 이미지에 메타데이터 기록"
 
-#: ../src/libs/metadata.c:1142
+#: ../src/libs/metadata.c:1144
 msgid "cancel"
 msgstr "취소"
 
-#: ../src/libs/metadata.c:1143
+#: ../src/libs/metadata.c:1145
 msgid "ignore changed metadata"
 msgstr "변경된 메타데이터 무시"
 
-#: ../src/libs/metadata.c:1204
+#: ../src/libs/metadata.c:1206
 msgid "CC BY"
 msgstr "CC BY"
 
-#: ../src/libs/metadata.c:1205
+#: ../src/libs/metadata.c:1207
 msgid "Creative Commons Attribution (CC BY)"
 msgstr "크리에이티브 커먼 라이센스 (CC BY)"
 
-#: ../src/libs/metadata.c:1206
+#: ../src/libs/metadata.c:1208
 msgid "CC BY-SA"
 msgstr "CC BY-SA"
 
-#: ../src/libs/metadata.c:1207
+#: ../src/libs/metadata.c:1209
 msgid "Creative Commons Attribution-ShareAlike (CC BY-SA)"
 msgstr "크리에이티브 커먼 라이센스-동일조건변경허락 (CC BY-SA)"
 
-#: ../src/libs/metadata.c:1208
+#: ../src/libs/metadata.c:1210
 msgid "CC BY-ND"
 msgstr "CC BY-ND"
 
-#: ../src/libs/metadata.c:1209
+#: ../src/libs/metadata.c:1211
 msgid "Creative Commons Attribution-NoDerivs (CC BY-ND)"
 msgstr "크리에이티브 커먼 라이센스-변경금지 (CC BY-ND)"
 
-#: ../src/libs/metadata.c:1210
+#: ../src/libs/metadata.c:1212
 msgid "CC BY-NC"
 msgstr "CC BY-NC"
 
-#: ../src/libs/metadata.c:1211
+#: ../src/libs/metadata.c:1213
 msgid "Creative Commons Attribution-NonCommercial (CC BY-NC)"
 msgstr "크리에이티브 커먼 라이센스-비영리 (CC BY-NC)"
 
-#: ../src/libs/metadata.c:1212
+#: ../src/libs/metadata.c:1214
 msgid "CC BY-NC-SA"
 msgstr "CC BY-NC-SA"
 
-#: ../src/libs/metadata.c:1213
+#: ../src/libs/metadata.c:1215
 msgid "Creative Commons Attribution-NonCommercial-ShareAlike (CC BY-NC-SA)"
 msgstr "크리에이티브 커먼 라이센스-비영리-동일조건변경허락 (CC BY-NC-SA)"
 
-#: ../src/libs/metadata.c:1214
+#: ../src/libs/metadata.c:1216
 msgid "CC BY-NC-ND"
 msgstr "CC BY-NC-ND"
 
-#: ../src/libs/metadata.c:1215
+#: ../src/libs/metadata.c:1217
 msgid "Creative Commons Attribution-NonCommercial-NoDerivs (CC BY-NC-ND)"
 msgstr "크리에이티브 커먼 라이센스-비영리-변경금지 (CC BY-NC-ND)"
 
-#: ../src/libs/metadata.c:1216 ../src/libs/metadata.c:1217
+#: ../src/libs/metadata.c:1218 ../src/libs/metadata.c:1219
 msgid "all rights reserved"
 msgstr "모든 권리는 저작권자에게 있습니다"
 
@@ -26454,14 +30288,6 @@ msgstr "모든 권리는 저작권자에게 있습니다"
 #: ../src/libs/metadata_view.c:133
 msgid "filmroll"
 msgstr "필름롤"
-
-#: ../src/libs/metadata_view.c:135
-msgid "group id"
-msgstr "그룹 ID"
-
-#: ../src/libs/metadata_view.c:137
-msgid "version"
-msgstr "버전"
 
 #: ../src/libs/metadata_view.c:140
 msgid "import timestamp"
@@ -26499,6 +30325,11 @@ msgstr "내보내기 너비"
 msgid "export height"
 msgstr "내보내기 높이"
 
+#. geotagging
+#: ../src/libs/metadata_view.c:169
+msgid "latitude"
+msgstr "노출 관용도"
+
 #: ../src/libs/metadata_view.c:170
 msgid "longitude"
 msgstr "경도"
@@ -26515,46 +30346,46 @@ msgstr "카테고리"
 msgid "image information"
 msgstr "이미지 정보"
 
-#: ../src/libs/metadata_view.c:359
+#: ../src/libs/metadata_view.c:375
 msgid "unused/deprecated"
 msgstr "사용 중단/지원 중단"
 
-#: ../src/libs/metadata_view.c:360
+#: ../src/libs/metadata_view.c:376
 msgid "LDR"
 msgstr "LDR"
 
-#: ../src/libs/metadata_view.c:363
+#: ../src/libs/metadata_view.c:379
 msgid "marked for deletion"
 msgstr "삭제 대상으로 마킹됨"
 
-#: ../src/libs/metadata_view.c:364
+#: ../src/libs/metadata_view.c:380
 msgid "auto-applying presets applied"
 msgstr "자동 적용 사전설정 적용됨"
 
-#: ../src/libs/metadata_view.c:366
+#: ../src/libs/metadata_view.c:382
 msgid "has .txt"
 msgstr ".txt 파일 있음"
 
-#: ../src/libs/metadata_view.c:367
+#: ../src/libs/metadata_view.c:383
 msgid "has .wav"
 msgstr ".wav 파일 있음"
 
-#: ../src/libs/metadata_view.c:385
+#: ../src/libs/metadata_view.c:403
 #, c-format
 msgid "image has %d star"
 msgid_plural "image has %d stars"
 msgstr[0] "이미지에 별이 %d개 있음"
 
-#: ../src/libs/metadata_view.c:461
+#: ../src/libs/metadata_view.c:470
 #, c-format
 msgid "loader: %s"
 msgstr "로더: %s"
 
-#: ../src/libs/metadata_view.c:688
+#: ../src/libs/metadata_view.c:702
 msgid "<various values>"
 msgstr "<여러 값 존재>"
 
-#: ../src/libs/metadata_view.c:701
+#: ../src/libs/metadata_view.c:715
 #, c-format
 msgid ""
 "double-click to jump to film roll\n"
@@ -26563,32 +30394,32 @@ msgstr ""
 "더블 클릭하여 필름롤로 이동\n"
 "%s"
 
-#: ../src/libs/metadata_view.c:792
+#: ../src/libs/metadata_view.c:806
 #, c-format
 msgid "%+.2f EV"
 msgstr "%+.2f EV"
 
-#: ../src/libs/metadata_view.c:814 ../src/libs/metadata_view.c:826
-#: ../src/libs/metadata_view.c:831
+#: ../src/libs/metadata_view.c:828 ../src/libs/metadata_view.c:840
+#: ../src/libs/metadata_view.c:845
 #, c-format
 msgid "%.1f mm"
 msgstr "%.1f mm"
 
-#: ../src/libs/metadata_view.c:855
+#: ../src/libs/metadata_view.c:869
 #, c-format
 msgid "infinity"
 msgstr "무한대"
 
-#: ../src/libs/metadata_view.c:859
+#: ../src/libs/metadata_view.c:873
 #, c-format
 msgid "%.2f m"
 msgstr "%.2f m"
 
-#: ../src/libs/metadata_view.c:1434
+#: ../src/libs/metadata_view.c:1463
 msgid "_default"
 msgstr "기본값 (&D)"
 
-#: ../src/libs/metadata_view.c:1465
+#: ../src/libs/metadata_view.c:1495
 msgid ""
 "drag and drop one row at a time until you get the desired order\n"
 "untick to hide metadata which are not of interest for you\n"
@@ -26598,203 +30429,225 @@ msgstr ""
 "불필요한 메타데이터는 체크 해제하여 숨길 수 있습니다\n"
 "다른 설정이 필요하다면 사전설정을 사용하세요"
 
-#: ../src/libs/metadata_view.c:1619
+#: ../src/libs/metadata_view.c:1657
 msgid "jump to film roll"
 msgstr "필름롤로 이동"
 
-#: ../src/libs/modulegroups.c:42 ../src/libs/modulegroups.c:1789
+#: ../src/libs/modulegroups.c:43 ../src/libs/modulegroups.c:1796
 msgid "workflow: scene-referred"
 msgstr "워크플로우: 장면 기준"
 
-#: ../src/libs/modulegroups.c:45
+#: ../src/libs/modulegroups.c:46
 msgid "modules: deprecated"
 msgstr "모듈: 지원 중단됨"
 
-#: ../src/libs/modulegroups.c:48
+#: ../src/libs/modulegroups.c:49
 msgid "last modified layout"
 msgstr "마지막으로 수정된 레이아웃"
 
-#: ../src/libs/modulegroups.c:192
+#: ../src/libs/modulegroups.c:193
 msgid "modulegroups"
 msgstr "모듈 그룹"
 
 #. FIXME don't check here if on/off is enabled, because it
 #. depends on image (reload_defaults) respond later to image
 #. changed signal
-#: ../src/libs/modulegroups.c:306 ../src/libs/modulegroups.c:318
-#: ../src/libs/modulegroups.c:2481 ../src/libs/modulegroups.c:2483
+#: ../src/libs/modulegroups.c:307 ../src/libs/modulegroups.c:319
+#: ../src/libs/modulegroups.c:2486 ../src/libs/modulegroups.c:2488
 msgid "on-off"
 msgstr "켜기-끄기"
 
-#: ../src/libs/modulegroups.c:480 ../src/libs/modulegroups.c:483
-msgid "this quick access widget is disabled as there are multiple instances of this module present. Please use the full module to access this widget..."
+#: ../src/libs/modulegroups.c:487 ../src/libs/modulegroups.c:490
+msgid ""
+"this quick access widget is disabled as there are multiple instances of this "
+"module present. Please use the full module to access this widget..."
 msgstr ""
 "이 빠른 액세스 위젯은 이 모듈의 인스턴스가 여러 개 존재하여 비활성화되었습니다.\n"
 "전체 모듈을 사용하여 액세스해주세요..."
 
-#: ../src/libs/modulegroups.c:572
+#: ../src/libs/modulegroups.c:579
 msgid "(some features may only be available in the full module interface)"
 msgstr "(일부 기능은 전체 모듈 인터페이스에서만 제공)"
 
-#: ../src/libs/modulegroups.c:610
+#: ../src/libs/modulegroups.c:617
 #, c-format
 msgid "go to the full version of the %s module"
 msgstr "%s 모듈의 전체 버전으로 이동"
 
-#: ../src/libs/modulegroups.c:1558 ../src/libs/modulegroups.c:1650
-#: ../src/libs/modulegroups.c:1687 ../src/libs/modulegroups.c:1741
-#: ../src/libs/modulegroups.c:1855
+#: ../src/libs/modulegroups.c:1563 ../src/libs/modulegroups.c:1656
+#: ../src/libs/modulegroups.c:1693 ../src/libs/modulegroups.c:1747
+#: ../src/libs/modulegroups.c:1862
 msgctxt "modulegroup"
 msgid "base"
 msgstr "기본"
 
-#: ../src/libs/modulegroups.c:1577
+#: ../src/libs/modulegroups.c:1582
 msgctxt "modulegroup"
 msgid "tone"
 msgstr "톤"
 
-#: ../src/libs/modulegroups.c:1587 ../src/libs/modulegroups.c:1701
-#: ../src/libs/modulegroups.c:1757
+#: ../src/libs/modulegroups.c:1592 ../src/libs/modulegroups.c:1707
+#: ../src/libs/modulegroups.c:1763
 msgctxt "modulegroup"
 msgid "color"
 msgstr "색상"
 
-#: ../src/libs/modulegroups.c:1604 ../src/libs/modulegroups.c:1709
-#: ../src/libs/modulegroups.c:1763
+#: ../src/libs/modulegroups.c:1610 ../src/libs/modulegroups.c:1715
+#: ../src/libs/modulegroups.c:1770
 msgctxt "modulegroup"
 msgid "correct"
 msgstr "보정"
 
-#: ../src/libs/modulegroups.c:1623 ../src/libs/modulegroups.c:1722
-#: ../src/libs/modulegroups.c:1776 ../src/libs/modulegroups.c:2366
+#: ../src/libs/modulegroups.c:1629 ../src/libs/modulegroups.c:1728
+#: ../src/libs/modulegroups.c:1783 ../src/libs/modulegroups.c:2371
 msgctxt "modulegroup"
 msgid "effect"
 msgstr "이펙트"
 
-#: ../src/libs/modulegroups.c:1643
+#: ../src/libs/modulegroups.c:1649
 msgid "modules: all"
 msgstr "모듈: 전체"
 
-#: ../src/libs/modulegroups.c:1665
+#: ../src/libs/modulegroups.c:1671
 msgctxt "modulegroup"
 msgid "grading"
 msgstr "그레이딩"
 
-#: ../src/libs/modulegroups.c:1673 ../src/libs/modulegroups.c:2372
+#: ../src/libs/modulegroups.c:1679 ../src/libs/modulegroups.c:2377
 msgctxt "modulegroup"
 msgid "effects"
 msgstr "이펙트"
 
-#: ../src/libs/modulegroups.c:1681
+#: ../src/libs/modulegroups.c:1687
 msgid "workflow: beginner"
 msgstr "워크플로우: 초보자"
 
-#: ../src/libs/modulegroups.c:1734
+#: ../src/libs/modulegroups.c:1740
 msgid "workflow: display-referred"
 msgstr "워크플로우: 디스플레이 기준"
 
-#: ../src/libs/modulegroups.c:1794
+#: ../src/libs/modulegroups.c:1801
 msgid "search only"
 msgstr "검색 전용"
 
-#: ../src/libs/modulegroups.c:1808 ../src/libs/modulegroups.c:2111
-#: ../src/libs/modulegroups.c:2676
+#: ../src/libs/modulegroups.c:1815 ../src/libs/modulegroups.c:2116
+#: ../src/libs/modulegroups.c:2679
 msgctxt "modulegroup"
 msgid "deprecated"
 msgstr "지원 중단됨"
 
-#: ../src/libs/modulegroups.c:1823
+#: ../src/libs/modulegroups.c:1830
 msgid "previous config"
 msgstr "이전 구성"
 
-#: ../src/libs/modulegroups.c:1825
+#: ../src/libs/modulegroups.c:1832
 msgid "previous layout"
 msgstr "이전 레이아웃"
 
-#: ../src/libs/modulegroups.c:1829
+#: ../src/libs/modulegroups.c:1836
 msgid "previous config with new layout"
 msgstr "이전 구성으로 새 레이아웃"
 
-#: ../src/libs/modulegroups.c:2007 ../src/libs/modulegroups.c:2535
-#: ../src/libs/modulegroups.c:2548
+#: ../src/libs/modulegroups.c:2013 ../src/libs/modulegroups.c:2540
+#: ../src/libs/modulegroups.c:2553
 msgid "remove this widget"
 msgstr "이 위젯 제거"
 
-#: ../src/libs/modulegroups.c:2130 ../src/libs/modulegroups.c:2394
+#: ../src/libs/modulegroups.c:2135 ../src/libs/modulegroups.c:2399
 msgid "remove this module"
 msgstr "이 모듈 제거"
 
-#: ../src/libs/modulegroups.c:2358
+#: ../src/libs/modulegroups.c:2363
 msgid "base"
 msgstr "기본"
 
-#: ../src/libs/modulegroups.c:2364
+#: ../src/libs/modulegroups.c:2369
 msgid "tone"
 msgstr "톤"
 
-#: ../src/libs/modulegroups.c:2368
+#: ../src/libs/modulegroups.c:2373
 msgid "technical"
 msgstr "테크니컬"
 
-#: ../src/libs/modulegroups.c:2370
+#: ../src/libs/modulegroups.c:2375
 msgid "grading"
 msgstr "그레이딩"
 
-#: ../src/libs/modulegroups.c:2376 ../src/libs/modulegroups.c:2384
+#: ../src/libs/modulegroups.c:2381 ../src/libs/modulegroups.c:2389
 msgid "add this module"
 msgstr "이 모듈 추가"
 
 #. show the submenu with all the modules
-#: ../src/libs/modulegroups.c:2406 ../src/libs/modulegroups.c:2627
+#: ../src/libs/modulegroups.c:2411 ../src/libs/modulegroups.c:2632
 msgid "all available modules"
 msgstr "사용 가능한 모든 모듈"
 
-#: ../src/libs/modulegroups.c:2414
+#: ../src/libs/modulegroups.c:2419
 msgid "add module"
 msgstr "모듈 추가"
 
-#: ../src/libs/modulegroups.c:2419
+#: ../src/libs/modulegroups.c:2424
 msgid "remove module"
 msgstr "모듈 제거"
 
-#: ../src/libs/modulegroups.c:2542
+#: ../src/libs/modulegroups.c:2547
 msgid "header needed for other widgets"
 msgstr "다른 위젯에 헤더가 필요함"
 
-#: ../src/libs/modulegroups.c:2558 ../src/libs/modulegroups.c:2565
+#: ../src/libs/modulegroups.c:2563 ../src/libs/modulegroups.c:2570
 msgid "add this widget"
 msgstr "이 위젯 추가"
 
-#: ../src/libs/modulegroups.c:2578
+#: ../src/libs/modulegroups.c:2583
 msgid "currently invisible"
 msgstr "현재 숨김 상태"
 
-#: ../src/libs/modulegroups.c:2611
+#: ../src/libs/modulegroups.c:2616
 msgid "add widget"
 msgstr "위젯 추가"
 
-#: ../src/libs/modulegroups.c:2616
+#: ../src/libs/modulegroups.c:2621
 msgid "remove widget"
 msgstr "위젯 제거"
 
-#: ../src/libs/modulegroups.c:2739
+#: ../src/libs/modulegroups.c:2742
 msgid "show all history modules"
 msgstr "모든 히스토리 모듈 추가"
 
-#: ../src/libs/modulegroups.c:2742 ../src/libs/modulegroups.c:4028
-msgid "show modules that are present in the history stack, regardless of whether or not they are currently enabled"
+#: ../src/libs/modulegroups.c:2745 ../src/libs/modulegroups.c:4112
+msgid ""
+"show modules that are present in the history stack, regardless of whether or "
+"not they are currently enabled"
 msgstr "히스토리 스택에 존재하는 모듈들을 표시, 현재 활성화 여부와 관계없이"
 
-#: ../src/libs/modulegroups.c:2837 ../src/libs/modulegroups.c:2943
+#: ../src/libs/modulegroups.c:2829 ../src/libs/modulegroups.c:3032
 msgid ""
-"the following modules are deprecated because they have internal design mistakes that can't be corrected and alternative modules that correct them.\n"
+"the following modules are deprecated because they have internal design "
+"mistakes that can't be corrected and alternative modules that correct them.\n"
 "they will be removed for new edits in the next release."
 msgstr ""
 "다음 모듈들은 해결할 수 없는 설계상의 문제가 있고,\n"
 "그것을 해결하는 대체 모듈이 있기 때문에 지원 중단되었습니다.\n"
 "향후 릴리스의 새 편집 방식을 위해 이 모듈들이 제거될 예정입니다."
 
-#: ../src/libs/modulegroups.c:2890
+#: ../src/libs/modulegroups.c:2863 ../src/libs/modulegroups.c:3410
+msgid "quick access"
+msgstr "빠른 액세스"
+
+#: ../src/libs/modulegroups.c:2865
+msgid "active pipeline"
+msgstr "활성 파이프라인"
+
+#: ../src/libs/modulegroups.c:2909 ../src/libs/modulegroups.c:2927
+#, c-format
+msgid "module group: '%s'"
+msgstr "모듈 그룹: '%s'"
+
+#: ../src/libs/modulegroups.c:2943 ../src/libs/modulegroups.c:2997
+msgid "cycle module groups"
+msgstr "모듈 그룹 순환"
+
+#: ../src/libs/modulegroups.c:2975
 msgid ""
 "quick access panel\n"
 "right-click tab icon to add/remove widgets"
@@ -26802,19 +30655,19 @@ msgstr ""
 "빠른 액세스 패널\n"
 "탭 아이콘을 우클릭하여 위젯을 추가 또는 제거"
 
-#: ../src/libs/modulegroups.c:2893
+#: ../src/libs/modulegroups.c:2978
 msgid "quick access panel"
 msgstr "빠른 액세스 패널"
 
-#: ../src/libs/modulegroups.c:2905
+#: ../src/libs/modulegroups.c:2990
 msgid "show only active modules"
 msgstr "활성화된 모듈만 보기"
 
-#: ../src/libs/modulegroups.c:2906
+#: ../src/libs/modulegroups.c:2991
 msgid "active modules"
 msgstr "활성화된 모듈"
 
-#: ../src/libs/modulegroups.c:2912
+#: ../src/libs/modulegroups.c:3001
 msgid ""
 "presets\n"
 "ctrl+click to manage"
@@ -26822,164 +30675,170 @@ msgstr ""
 "사전설정\n"
 "Ctrl+클릭으로 관리"
 
-#: ../src/libs/modulegroups.c:2919
+#: ../src/libs/modulegroups.c:3008
 msgid "search modules"
 msgstr "모듈 검색"
 
-#: ../src/libs/modulegroups.c:2921
+#: ../src/libs/modulegroups.c:3010
 msgid "search modules by name or tag"
 msgstr "이름 또는 태그로 모듈 검색"
 
-#: ../src/libs/modulegroups.c:2936
+#: ../src/libs/modulegroups.c:3025
 msgid "clear text"
 msgstr "텍스트 지우기"
 
-#: ../src/libs/modulegroups.c:3200
+#: ../src/libs/modulegroups.c:3142
+#, c-format
+msgid ""
+"%s\n"
+"right-click tab icon to add/remove modules"
+msgstr ""
+"%s\n"
+"탭 아이콘을 우클릭하여 모듈을 추가 또는 제거"
+
+#: ../src/libs/modulegroups.c:3286
 msgid "basic icon"
 msgstr "기본 아이콘"
 
-#: ../src/libs/modulegroups.c:3211
+#: ../src/libs/modulegroups.c:3297
 msgid "active icon"
 msgstr "활성화된 아이콘"
 
-#: ../src/libs/modulegroups.c:3222
+#: ../src/libs/modulegroups.c:3308
 msgid "color icon"
 msgstr "색상 아이콘"
 
-#: ../src/libs/modulegroups.c:3233
+#: ../src/libs/modulegroups.c:3319
 msgid "correct icon"
 msgstr "보정 아이콘"
 
-#: ../src/libs/modulegroups.c:3244
+#: ../src/libs/modulegroups.c:3330
 msgid "effect icon"
 msgstr "이펙트 아이콘"
 
-#: ../src/libs/modulegroups.c:3255
+#: ../src/libs/modulegroups.c:3341
 msgid "favorites icon"
 msgstr "즐겨찾기 아이콘"
 
-#: ../src/libs/modulegroups.c:3266
+#: ../src/libs/modulegroups.c:3352
 msgid "tone icon"
 msgstr "톤 아이콘"
 
-#: ../src/libs/modulegroups.c:3277
+#: ../src/libs/modulegroups.c:3363
 msgid "grading icon"
 msgstr "그레이딩 아이콘"
 
-#: ../src/libs/modulegroups.c:3288
+#: ../src/libs/modulegroups.c:3374
 msgid "technical icon"
 msgstr "테크니컬 아이콘"
 
-#: ../src/libs/modulegroups.c:3322
+#: ../src/libs/modulegroups.c:3408
 msgid "quick access panel widgets"
 msgstr "빠른 액세스 패널 위젯"
 
-#: ../src/libs/modulegroups.c:3324
-msgid "quick access"
-msgstr "빠른 액세스"
-
-#: ../src/libs/modulegroups.c:3346
+#: ../src/libs/modulegroups.c:3432
 msgid "add widget to the quick access panel"
 msgstr "빠른 액세스 패널에 위젯 추가"
 
-#: ../src/libs/modulegroups.c:3379
+#: ../src/libs/modulegroups.c:3465
 msgid "group icon"
 msgstr "그룹 아이콘"
 
-#: ../src/libs/modulegroups.c:3389
+#: ../src/libs/modulegroups.c:3475
 msgid "group name"
 msgstr "그룹 이름"
 
-#: ../src/libs/modulegroups.c:3401
+#: ../src/libs/modulegroups.c:3487
 msgid "remove group"
 msgstr "그룹 제거"
 
-#: ../src/libs/modulegroups.c:3429
+#: ../src/libs/modulegroups.c:3515
 msgid "move group to the left"
 msgstr "그룹을 왼쪽으로 이동"
 
-#: ../src/libs/modulegroups.c:3439
+#: ../src/libs/modulegroups.c:3525
 msgid "add module to the group"
 msgstr "그룹에 모듈을 추가"
 
-#: ../src/libs/modulegroups.c:3451
+#: ../src/libs/modulegroups.c:3537
 msgid "move group to the right"
 msgstr "그룹을 오른쪽으로 이동"
 
-#: ../src/libs/modulegroups.c:3641
+#: ../src/libs/modulegroups.c:3725
 msgid "rename preset"
 msgstr "사전설정 이름 변경"
 
-#: ../src/libs/modulegroups.c:3644
+#: ../src/libs/modulegroups.c:3728
 msgid "_rename"
 msgstr "이름 변경 (&R)"
 
-#: ../src/libs/modulegroups.c:3649
+#: ../src/libs/modulegroups.c:3733
 msgid "a preset with this name already exists!"
 msgstr "같은 이름의 사전설정이 이미 존재합니다!"
 
-#: ../src/libs/modulegroups.c:3658
+#: ../src/libs/modulegroups.c:3742
 msgid "new preset name:"
 msgstr "새 사전설정 이름:"
 
-#: ../src/libs/modulegroups.c:3986
+#: ../src/libs/modulegroups.c:4070
 msgid "preset: "
 msgstr "사전설정: "
 
-#: ../src/libs/modulegroups.c:3996
+#: ../src/libs/modulegroups.c:4080
 msgid "remove the preset"
 msgstr "사전설정 삭제"
 
-#: ../src/libs/modulegroups.c:4000
+#: ../src/libs/modulegroups.c:4084
 msgid "duplicate the preset"
 msgstr "사전설정 복제"
 
-#: ../src/libs/modulegroups.c:4004
+#: ../src/libs/modulegroups.c:4088
 msgid "rename the preset"
 msgstr "사전설정 이름 변경"
 
-#: ../src/libs/modulegroups.c:4008
+#: ../src/libs/modulegroups.c:4092
 msgid "create a new empty preset"
 msgstr "새 비어있는 사전설정 만들기"
 
-#: ../src/libs/modulegroups.c:4016
+#: ../src/libs/modulegroups.c:4100
 msgid "show search line"
 msgstr "검색창 표시"
 
-#: ../src/libs/modulegroups.c:4020
+#: ../src/libs/modulegroups.c:4104
 msgid "show quick access panel"
 msgstr "빠른 액세스 패널 표시"
 
-#: ../src/libs/modulegroups.c:4025
+#: ../src/libs/modulegroups.c:4109
 msgid "show all history modules in active group"
 msgstr "활성화된 그룹의 모든 히스토리 모듈 표시"
 
-#: ../src/libs/modulegroups.c:4039
+#: ../src/libs/modulegroups.c:4123
 msgid "auto-apply this preset"
 msgstr "이 사전설정 자동 적용"
 
-#: ../src/libs/modulegroups.c:4055
+#: ../src/libs/modulegroups.c:4139
 msgid "module groups"
 msgstr "모듈 그룹"
 
-#: ../src/libs/modulegroups.c:4074
-msgid "this is a built-in read-only preset. duplicate it if you want to make changes"
+#: ../src/libs/modulegroups.c:4158
+msgid ""
+"this is a built-in read-only preset. duplicate it if you want to make changes"
 msgstr "이 사전설정은 내장된 읽기 전용입니다. 수정하려면 먼저 복제하세요"
 
-#: ../src/libs/navigation.c:76
+#: ../src/libs/navigation.c:88
 msgid "navigation"
 msgstr "내비게이션"
 
-#: ../src/libs/navigation.c:113 ../src/libs/navigation.c:250
+#: ../src/libs/navigation.c:125 ../src/libs/navigation.c:269
 msgctxt "navigationbox"
 msgid "fill"
 msgstr "채우기"
 
-#: ../src/libs/navigation.c:116 ../src/libs/navigation.c:248
+#: ../src/libs/navigation.c:128 ../src/libs/navigation.c:267
 msgid "small"
 msgstr "작게"
 
-#: ../src/libs/navigation.c:213
+#: ../src/libs/navigation.c:225
 msgid ""
 "navigation\n"
 "click or drag to position zoomed area in center view"
@@ -26987,44 +30846,295 @@ msgstr ""
 "내비게이션\n"
 "클릭하거나 드래그하여 확대된 영역을 중앙 뷰에 배치"
 
-#: ../src/libs/navigation.c:235
+#: ../src/libs/navigation.c:254
 msgid "hide navigation thumbnail"
 msgstr "내비게이션 썸네일 숨기기"
 
-#: ../src/libs/navigation.c:246
+#: ../src/libs/navigation.c:265
 msgid "image zoom level"
 msgstr "이미지 확대 비율"
 
-#: ../src/libs/navigation.c:251
+#: ../src/libs/navigation.c:270
 msgid "50%"
 msgstr "50%"
 
-#: ../src/libs/navigation.c:252
+#: ../src/libs/navigation.c:271
 msgid "100%"
 msgstr "100%"
 
-#: ../src/libs/navigation.c:253
+#: ../src/libs/navigation.c:272
 msgid "200%"
 msgstr "200%"
 
-#: ../src/libs/navigation.c:254
+#: ../src/libs/navigation.c:273
 msgid "400%"
 msgstr "400%"
 
-#: ../src/libs/navigation.c:255
+#: ../src/libs/navigation.c:274
 msgid "800%"
 msgstr "800%"
 
-#: ../src/libs/navigation.c:256
+#: ../src/libs/navigation.c:275
 msgid "1600%"
 msgstr "1600%"
+
+#: ../src/libs/neural_restore.c:461 ../src/libs/neural_restore.c:3419
+msgid "neural restore"
+msgstr "뉴럴 복원"
+
+#: ../src/libs/neural_restore.c:466
+msgid "AI-based image restoration: denoise and upscale"
+msgstr "AI 기반 이미지 복원: 노이즈 감소 및 업스케일"
+
+#: ../src/libs/neural_restore.c:855
+#, c-format
+msgid "failed to open TIFF for writing: %s"
+msgstr "쓰기용으로 TIFF를 열지 못했습니다: %s"
+
+#: ../src/libs/neural_restore.c:906
+msgid "out of memory for detail recovery buffer"
+msgstr "세부 복원 버퍼용 메모리가 부족합니다"
+
+#: ../src/libs/neural_restore.c:1174
+msgid "failed to load AI model for Bayer raw denoising"
+msgstr "베이어 RAW 노이즈 감소용 AI 모델을 로드하지 못했습니다"
+
+#: ../src/libs/neural_restore.c:1178
+msgid "failed to load AI model for X-Trans raw denoising"
+msgstr "X-Trans RAW 노이즈 감소용 AI 모델을 로드하지 못했습니다"
+
+#: ../src/libs/neural_restore.c:1182
+msgid "failed to load AI model for linear raw denoising"
+msgstr "선형 RAW 노이즈 감소용 AI 모델을 로드하지 못했습니다"
+
+#: ../src/libs/neural_restore.c:1236
+msgid "raw denoise: unsupported raw datatype"
+msgstr "RAW 노이즈 감소: 지원되지 않는 RAW 데이터 형식"
+
+#: ../src/libs/neural_restore.c:1367
+msgid "raw denoise: cannot load source image"
+msgstr "RAW 노이즈 감소: 원본 이미지를 로드할 수 없습니다"
+
+#: ../src/libs/neural_restore.c:1393
+msgid "raw denoise: image is not in a supported raw sensor format"
+msgstr "RAW 노이즈 감소: 이미지가 지원되는 RAW 센서 형식이 아닙니다"
+
+#: ../src/libs/neural_restore.c:1421 ../src/libs/neural_restore.c:2791
+msgid ""
+"raw denoise: this image is already pre-demosaiced (sRaw / computational "
+"raw); results may be limited"
+msgstr "RAW 노이즈 감소: 이 이미지는 이미 디모자이크가 적용되었습니다(sRaw / 연산 RAW). 결과가 제한될 수 있습니다"
+
+#: ../src/libs/neural_restore.c:1437 ../src/libs/neural_restore.c:4281
+msgid "upscale"
+msgstr "업스케일"
+
+#: ../src/libs/neural_restore.c:1439
+#, c-format
+msgid "loading %s model..."
+msgstr "%s 모델 로딩 중..."
+
+#: ../src/libs/neural_restore.c:1469
+#, c-format
+msgid "failed to load AI %s model"
+msgstr "AI %s 모델을 로드하지 못했습니다"
+
+#: ../src/libs/neural_restore.c:1539
+msgid "neural restore: cannot create output directory"
+msgstr "뉴럴 복원: 출력 디렉토리를 생성할 수 없습니다"
+
+#: ../src/libs/neural_restore.c:1571
+msgid "neural restore: too many output files"
+msgstr "뉴럴 복원: 출력 파일이 너무 많습니다"
+
+#: ../src/libs/neural_restore.c:1580
+#, c-format
+msgid "denoising image %d/%d..."
+msgstr "이미지 노이즈 감소 중 %d/%d..."
+
+#: ../src/libs/neural_restore.c:1581
+#, c-format
+msgid "raw denoising image %d/%d..."
+msgstr "RAW 이미지 노이즈 감소 중 %d/%d..."
+
+#: ../src/libs/neural_restore.c:1582
+#, c-format
+msgid "upscaling 2x image %d/%d..."
+msgstr "이미지 2배 업스케일 중 %d/%d..."
+
+#: ../src/libs/neural_restore.c:1583
+#, c-format
+msgid "upscaling 4x image %d/%d..."
+msgstr "이미지 4배 업스케일 중 %d/%d..."
+
+#: ../src/libs/neural_restore.c:1592
+#, c-format
+msgid "raw denoise failed for image %d"
+msgstr "이미지 %d의 RAW 노이즈 감소에 실패하였습니다"
+
+#: ../src/libs/neural_restore.c:1621
+msgid "neural restore: export failed"
+msgstr "뉴럴 복원: 내보내기에 실패하였습니다"
+
+#: ../src/libs/neural_restore.c:1644
+#, c-format
+msgid "neural %s: %d image processed"
+msgid_plural "neural %s: %d images processed"
+msgstr[0] "뉴럴 %s: 이미지 %d개 처리됨"
+
+#: ../src/libs/neural_restore.c:1726
+msgid "large output - processing will be slow"
+msgstr "출력이 큽니다 - 처리가 느려집니다"
+
+#: ../src/libs/neural_restore.c:1742
+msgid "output: Bayer CFA DNG"
+msgstr "출력: 베이어 CFA DNG"
+
+#: ../src/libs/neural_restore.c:1743
+msgid "output: LinearRaw DNG"
+msgstr "출력: LinearRaw DNG"
+
+#: ../src/libs/neural_restore.c:1754
+msgid "preview unavailable – process to save result"
+msgstr "미리보기를 사용할 수 없습니다 – 결과를 저장하려면 처리하세요"
+
+#: ../src/libs/neural_restore.c:1775
+msgid "wide-gamut preserved, not denoised"
+msgstr "광색역 보존됨, 노이즈 감소 안 함"
+
+#: ../src/libs/neural_restore.c:1776
+msgid "wide-gamut clipped"
+msgstr "광색역 클리핑됨"
+
+#: ../src/libs/neural_restore.c:3603
+#, c-format
+msgid "zoom %.0f%%"
+msgstr "확대 %.0f%%"
+
+#: ../src/libs/neural_restore.c:3766
+msgid "click to select preview area"
+msgstr "클릭하여 미리보기 영역 선택"
+
+#: ../src/libs/neural_restore.c:3791
+msgid "model not available"
+msgstr "모델을 사용할 수 없음"
+
+#: ../src/libs/neural_restore.c:3793 ../src/libs/neural_restore.c:3987
+msgid "generating preview..."
+msgstr "미리보기 생성 중..."
+
+#: ../src/libs/neural_restore.c:3795
+msgid "click to generate preview"
+msgstr "클릭하여 미리보기 생성"
+
+#: ../src/libs/neural_restore.c:3797
+msgid "image not supported by this task"
+msgstr "이 작업에서 지원하지 않는 이미지입니다"
+
+#: ../src/libs/neural_restore.c:3799
+msgid "preview initialization failed"
+msgstr "미리보기 초기화에 실패하였습니다"
+
+#: ../src/libs/neural_restore.c:3800
+msgid "select an image to preview"
+msgstr "미리보기할 이미지를 선택하세요"
+
+#: ../src/libs/neural_restore.c:4233 ../src/libs/neural_restore.c:4497
+msgid "select output folder"
+msgstr "출력 폴더 선택"
+
+#: ../src/libs/neural_restore.c:4278
+msgid "AI raw denoising"
+msgstr "AI RAW 노이즈 감소"
+
+#: ../src/libs/neural_restore.c:4280
+msgid "AI denoising"
+msgstr "AI 노이즈 감소"
+
+#: ../src/libs/neural_restore.c:4282
+msgid "AI upscaling"
+msgstr "AI 업스케일"
+
+#: ../src/libs/neural_restore.c:4294
+msgid "blend between the source CFA (0%) and the denoised output (100%)"
+msgstr "원본 CFA(0%)와 노이즈가 감소된 출력(100%) 사이를 혼합합니다"
+
+#: ../src/libs/neural_restore.c:4312
+#, no-c-format
+msgid ""
+"100% applies the full AI model output; lower values bring back luminance "
+"texture and grain while keeping color noise suppressed"
+msgstr "100%는 AI 모델 출력을 그대로 적용합니다. 값을 낮추면 색상 노이즈는 억제한 채 휘도 텍스처와 그레인을 되살립니다"
+
+#: ../src/libs/neural_restore.c:4321
+msgid "upscale factor"
+msgstr "업스케일 배율"
+
+#: ../src/libs/neural_restore.c:4323
+msgid "2x"
+msgstr "2배"
+
+#: ../src/libs/neural_restore.c:4323
+msgid "4x"
+msgstr "4배"
+
+#: ../src/libs/neural_restore.c:4340
+msgid ""
+"click to pick preview area on the image thumbnail\n"
+"double-click to reset to center"
+msgstr ""
+"이미지 썸네일에서 클릭하여 미리보기 영역을 선택\n"
+"더블클릭하면 중앙으로 초기화"
+
+#: ../src/libs/neural_restore.c:4371
+msgid "process selected images"
+msgstr "선택한 이미지 처리"
+
+#: ../src/libs/neural_restore.c:4389
+msgid "output parameters"
+msgstr "출력 파라메터"
+
+#: ../src/libs/neural_restore.c:4400
+msgid "output TIFF bit depth"
+msgstr "출력 TIFF 비트 심도"
+
+#: ../src/libs/neural_restore.c:4442
+msgid "color profile embedded in the output TIFF"
+msgstr "출력 TIFF에 내장되는 색상 프로파일"
+
+#: ../src/libs/neural_restore.c:4452
+msgid "preserve wide-gamut colors"
+msgstr "광색역 색상 보존"
+
+#: ../src/libs/neural_restore.c:4459
+msgid ""
+"when on, pixels outside sRGB gamut pass through without being denoised; when "
+"off, all pixels are denoised but wide-gamut colors may be clipped; only "
+"affects denoise"
+msgstr "켜면 sRGB 색역을 벗어난 픽셀은 노이즈 감소 없이 통과합니다. 끄면 모든 픽셀에 노이즈 감소가 적용되지만 광색역 색상이 클리핑될 수 있습니다. 노이즈 감소에만 영향을 줍니다"
+
+#: ../src/libs/neural_restore.c:4468
+msgid "add to the current collection"
+msgstr "현재 컬렉션에 추가"
+
+#: ../src/libs/neural_restore.c:4474
+msgid "automatically import the output image into the current collection"
+msgstr "출력 이미지를 현재 컬렉션으로 자동 가져오기"
+
+#: ../src/libs/neural_restore.c:4490
+msgid ""
+"output folder — supports darktable variables\n"
+"$(FILE_FOLDER) = source image folder"
+msgstr ""
+"출력 폴더 — darktable 변수를 지원합니다\n"
+"$(FILE_FOLDER) = 원본 이미지 폴더"
 
 #: ../src/libs/print_settings.c:48
 msgid "print settings"
 msgstr "인쇄 설정"
 
 #. FIXME: ellipsize title/printer as the export completed message is ellipsized
-#: ../src/libs/print_settings.c:368 ../src/libs/print_settings.c:763
+#: ../src/libs/print_settings.c:368 ../src/libs/print_settings.c:771
 #, c-format
 msgid "processing `%s' for `%s'"
 msgstr "`%s'를 `%s'로 처리 중"
@@ -27044,38 +31154,38 @@ msgstr "이미지 %d의 출력 프로파일을 가져오는 데 오류가 발생
 msgid "cannot apply printer profile `%s'"
 msgstr "프린터 프로파일 `%s'을 적용할 수 없습니다"
 
-#: ../src/libs/print_settings.c:586
+#: ../src/libs/print_settings.c:594
 msgid "failed to create temporary PDF for printing"
 msgstr "인쇄용 임시 PDF 생성에 실패했습니다"
 
-#: ../src/libs/print_settings.c:632
+#: ../src/libs/print_settings.c:640
 msgid "maximum image per page reached"
 msgstr "페이지당 최대 이미지 수에 도달했습니다"
 
-#: ../src/libs/print_settings.c:717
+#: ../src/libs/print_settings.c:725
 msgid "cannot print until a picture is selected"
 msgstr "사진을 선택하기 전까지는 인쇄할 수 없습니다"
 
-#: ../src/libs/print_settings.c:722
+#: ../src/libs/print_settings.c:730
 msgid "cannot print until a printer is selected"
 msgstr "프린터를 선택하기 전까지는 인쇄할 수 없습니다"
 
-#: ../src/libs/print_settings.c:727
+#: ../src/libs/print_settings.c:735
 msgid "cannot print until a paper is selected"
 msgstr "용지를 선택하기 전까지는 인쇄할 수 없습니다"
 
 #. in this case no need to release from cache what we couldn't get
-#: ../src/libs/print_settings.c:755
+#: ../src/libs/print_settings.c:763
 #, c-format
 msgid "cannot get image %d for printing"
 msgstr "인쇄를 위해 이미지 %d을 불러올 수 없습니다"
 
-#: ../src/libs/print_settings.c:927
+#: ../src/libs/print_settings.c:942
 #, c-format
 msgid "%3.2f (dpi:%d)"
 msgstr "%3.2f (dpi:%d)"
 
-#: ../src/libs/print_settings.c:1175
+#: ../src/libs/print_settings.c:1195
 #, c-format
 msgid ""
 "style to be applied on print:\n"
@@ -27084,59 +31194,59 @@ msgstr ""
 "인쇄 시 적용될 스타일:\n"
 "<b>%s</b>"
 
-#: ../src/libs/print_settings.c:2474
+#: ../src/libs/print_settings.c:2494
 msgctxt "section"
 msgid "printer"
 msgstr "프린터"
 
-#: ../src/libs/print_settings.c:2487 ../src/libs/print_settings.c:2496
-#: ../src/libs/print_settings.c:2551
+#: ../src/libs/print_settings.c:2507 ../src/libs/print_settings.c:2516
+#: ../src/libs/print_settings.c:2571
 msgid "printer"
 msgstr "프린터"
 
-#: ../src/libs/print_settings.c:2487
+#: ../src/libs/print_settings.c:2507
 msgid "media"
 msgstr "매체"
 
-#: ../src/libs/print_settings.c:2508
+#: ../src/libs/print_settings.c:2528
 msgid "color management in printer driver"
 msgstr "프린트 드라이버에서의 색상 관리"
 
-#: ../src/libs/print_settings.c:2541
+#: ../src/libs/print_settings.c:2561
 msgid "printer ICC profiles"
 msgstr "프린터 ICC 프로파일"
 
-#: ../src/libs/print_settings.c:2562
+#: ../src/libs/print_settings.c:2582
 msgid "black point compensation"
 msgstr "블랙 포인트 보정"
 
-#: ../src/libs/print_settings.c:2575
+#: ../src/libs/print_settings.c:2595
 msgid "activate black point compensation when applying the printer profile"
 msgstr "프린터 프로파일을 적용할 때 블랙 포인트 보정을 활성화"
 
 #. //////////////////////// PAGE SETTINGS
-#: ../src/libs/print_settings.c:2582
+#: ../src/libs/print_settings.c:2602
 msgctxt "section"
 msgid "page"
 msgstr "페이지"
 
-#: ../src/libs/print_settings.c:2604
+#: ../src/libs/print_settings.c:2624
 msgid "measurement units"
 msgstr "측정 단위"
 
-#: ../src/libs/print_settings.c:2612
+#: ../src/libs/print_settings.c:2632
 msgid "image width/height"
 msgstr "이미지 가로/세로"
 
-#: ../src/libs/print_settings.c:2617
+#: ../src/libs/print_settings.c:2637
 msgid " x "
 msgstr " x "
 
-#: ../src/libs/print_settings.c:2625
+#: ../src/libs/print_settings.c:2645
 msgid "scale factor"
 msgstr "스케일 계수"
 
-#: ../src/libs/print_settings.c:2631
+#: ../src/libs/print_settings.c:2651
 msgid ""
 "image scale factor from native printer DPI:\n"
 " < 1 means that it is downscaled (best quality)\n"
@@ -27149,46 +31259,46 @@ msgstr ""
 "너무 큰 값은 인쇄 품질 저하를 야기할 수 있습니다"
 
 #. d->b_top  = gtk_spin_button_new_with_range(0, 10000, 1);
-#: ../src/libs/print_settings.c:2645
+#: ../src/libs/print_settings.c:2665
 msgid "top margin"
 msgstr "상단 여백"
 
 #. d->b_left  = gtk_spin_button_new_with_range(0, 10000, 1);
-#: ../src/libs/print_settings.c:2649
+#: ../src/libs/print_settings.c:2669
 msgid "left margin"
 msgstr "왼쪽 여백"
 
-#: ../src/libs/print_settings.c:2652
+#: ../src/libs/print_settings.c:2672
 msgid "lock"
 msgstr "잠금"
 
-#: ../src/libs/print_settings.c:2654
+#: ../src/libs/print_settings.c:2674
 msgid "change all margins uniformly"
 msgstr "모든 여백을 동일하게 조정"
 
 #. d->b_right  = gtk_spin_button_new_with_range(0, 10000, 1);
-#: ../src/libs/print_settings.c:2658
+#: ../src/libs/print_settings.c:2678
 msgid "right margin"
 msgstr "오른쪽 여백"
 
 #. d->b_bottom  = gtk_spin_button_new_with_range(0, 10000, 1);
-#: ../src/libs/print_settings.c:2662
+#: ../src/libs/print_settings.c:2682
 msgid "bottom margin"
 msgstr "하단 여백"
 
-#: ../src/libs/print_settings.c:2695
+#: ../src/libs/print_settings.c:2715
 msgid "display grid"
 msgstr "격자 표시"
 
-#: ../src/libs/print_settings.c:2706
+#: ../src/libs/print_settings.c:2726
 msgid "snap to grid"
 msgstr "격자에 맞춤"
 
-#: ../src/libs/print_settings.c:2719
+#: ../src/libs/print_settings.c:2739
 msgid "borderless mode required"
 msgstr "무테 모드 필요"
 
-#: ../src/libs/print_settings.c:2722
+#: ../src/libs/print_settings.c:2742
 msgid ""
 "indicates that the borderless mode should be activated\n"
 "in the printer driver because the selected margins are\n"
@@ -27198,16 +31308,16 @@ msgstr ""
 "프린터 드라이버에서 무테 모드를 활성화해야 함을 나타냅니다"
 
 #. pack image dimension hbox here
-#: ../src/libs/print_settings.c:2729
+#: ../src/libs/print_settings.c:2749
 msgctxt "section"
 msgid "image layout"
 msgstr "이미지 레이아웃"
 
-#: ../src/libs/print_settings.c:2770
+#: ../src/libs/print_settings.c:2790
 msgid "new image area"
 msgstr "새 이미지 영역"
 
-#: ../src/libs/print_settings.c:2772
+#: ../src/libs/print_settings.c:2792
 msgid ""
 "add a new image area on the page\n"
 "click and drag on the page to place the area\n"
@@ -27217,57 +31327,57 @@ msgstr ""
 "페이지에서 클릭하고 드래그하여 영역을 배치하고,\n"
 "필름 스트립에서 이미지를 드래그 앤 드롭하세요"
 
-#: ../src/libs/print_settings.c:2776
+#: ../src/libs/print_settings.c:2796
 msgid "delete image area"
 msgstr "이미지 영역 삭제"
 
-#: ../src/libs/print_settings.c:2778
+#: ../src/libs/print_settings.c:2798
 msgid "delete the currently selected image area"
 msgstr "현재 선택된 이미지 영역 삭제"
 
-#: ../src/libs/print_settings.c:2781
+#: ../src/libs/print_settings.c:2801
 msgid "clear layout"
 msgstr "레이아웃 지우기"
 
-#: ../src/libs/print_settings.c:2783
+#: ../src/libs/print_settings.c:2803
 msgid "remove all image areas from the page"
 msgstr "페이지에서 모든 이미지 영역 제거"
 
 #. d->b_x = gtk_spin_button_new_with_range(0, 1000, 1);
-#: ../src/libs/print_settings.c:2800
+#: ../src/libs/print_settings.c:2820
 msgid "image area x origin (in current unit)"
 msgstr "이미지 영역 x 원점 (현재 단위 기준)"
 
 #. d->b_y = gtk_spin_button_new_with_range(0, 1000, 1);
-#: ../src/libs/print_settings.c:2804
+#: ../src/libs/print_settings.c:2824
 msgid "image area y origin (in current unit)"
 msgstr "이미지 영역 y 원점 (현재 단위 기준)"
 
 #. d->b_width = gtk_spin_button_new_with_range(0, 1000, 1);
-#: ../src/libs/print_settings.c:2815
+#: ../src/libs/print_settings.c:2835
 msgid "image area width (in current unit)"
 msgstr "이미지 영역 너비 (현재 단위 기준)"
 
 #. d->b_height = gtk_spin_button_new_with_range(0, 1000, 1);
-#: ../src/libs/print_settings.c:2819
+#: ../src/libs/print_settings.c:2839
 msgid "image area height (in current unit)"
 msgstr "이미지 영역 높이 (현재 단위 기준)"
 
 #. //////////////////////// PRINT SETTINGS
-#: ../src/libs/print_settings.c:2845
+#: ../src/libs/print_settings.c:2865
 msgctxt "section"
 msgid "print settings"
 msgstr "인쇄 설정"
 
-#: ../src/libs/print_settings.c:2915
+#: ../src/libs/print_settings.c:2935
 msgid "select style to be applied on printing"
 msgstr "인쇄 시 적용할 스타일 선택"
 
-#: ../src/libs/print_settings.c:2917
+#: ../src/libs/print_settings.c:2937
 msgid "temporary style to use while printing"
 msgstr "인쇄 중 사용할 임시 스타일"
 
-#: ../src/libs/print_settings.c:2948
+#: ../src/libs/print_settings.c:2969
 msgid "print with current settings"
 msgstr "현재 설정으로 인쇄"
 
@@ -27299,6 +31409,92 @@ msgstr " 제외 "
 #: ../src/libs/recentcollect.c:230
 msgid "recent collections settings"
 msgstr "최근 컬렉션 설정"
+
+#: ../src/libs/scopes/histogram.c:207 ../src/libs/scopes/vectorscope.c:1023
+msgid "set scale to linear"
+msgstr "스케일을 선형으로 설정"
+
+#: ../src/libs/scopes/histogram.c:212 ../src/libs/scopes/vectorscope.c:1028
+msgid "set scale to logarithmic"
+msgstr "스케일을 로그로 설정"
+
+#: ../src/libs/scopes/histogram.c:244
+msgid "switch histogram scale"
+msgstr "히스토그램 스케일 전환"
+
+#. FIXME: this could depend on values of left/right scopes
+#: ../src/libs/scopes/split.c:30
+msgid "split"
+msgstr "분할"
+
+#: ../src/libs/scopes/vectorscope.c:135
+msgid "vectorscope"
+msgstr "벡터스코프"
+
+#: ../src/libs/scopes/vectorscope.c:1038
+msgid "set view to AzBz"
+msgstr "보기 모드를 AzBz로 설정"
+
+#: ../src/libs/scopes/vectorscope.c:1044
+msgid "set view to RYB"
+msgstr "보기 모드를 RYB로 설정"
+
+#: ../src/libs/scopes/vectorscope.c:1050
+msgid "set view to u*v*"
+msgstr "보기 모드를 u*v*로 설정"
+
+#: ../src/libs/scopes/vectorscope.c:1160
+msgid "scroll to coarse-rotate"
+msgstr "스크롤하여 거친 회전"
+
+#: ../src/libs/scopes/vectorscope.c:1161
+msgid "ctrl+scroll to fine rotate"
+msgstr "Ctrl+스크롤하여 미세한 회전"
+
+#: ../src/libs/scopes/vectorscope.c:1162
+msgid "shift+scroll to change width"
+msgstr "Shift+스크롤로 너비 조절"
+
+#: ../src/libs/scopes/vectorscope.c:1163
+msgid "alt+scroll to cycle"
+msgstr "Alt+스크롤로 모드 순차 전환"
+
+#: ../src/libs/scopes/vectorscope.c:1424
+msgid "cycle vectorscope types"
+msgstr "벡터스코프 유형 순차 전환"
+
+#: ../src/libs/scopes/vectorscope.c:1429
+msgid "switch vectorscope scale"
+msgstr "벡터스코프 스케일 전환"
+
+#: ../src/libs/scopes/vectorscope.c:1446
+msgid "color harmonies"
+msgstr "색상 조화"
+
+#. FIXME: do we need this action, or is it vestigial?
+#: ../src/libs/scopes/vectorscope.c:1464
+msgid "cycle color harmonies"
+msgstr "색상 조화 방식 순차 전환"
+
+#: ../src/libs/scopes/waveform.c:55
+msgid "waveform"
+msgstr "웨이브폼"
+
+#: ../src/libs/scopes/waveform.c:308
+msgid "set scope to vertical"
+msgstr "스코프를 수직으로 설정"
+
+#: ../src/libs/scopes/waveform.c:313
+msgid "set scope to horizontal"
+msgstr "스코프를 수평으로 설정"
+
+#: ../src/libs/scopes/waveform.c:404
+msgid "switch scope orientation"
+msgstr "스코프 방향 전환"
+
+#: ../src/libs/scopes/waveform.c:446
+msgid "RGB parade"
+msgstr "RGB 퍼레이드"
 
 #: ../src/libs/select.c:45
 msgid ""
@@ -27364,36 +31560,44 @@ msgctxt "snapshot sign"
 msgid "S"
 msgstr "S"
 
-#: ../src/libs/snapshots.c:604
+#: ../src/libs/snapshots.c:613
 msgid "restore snapshot into current history"
 msgstr "스냅샷을 현재 히스토리로 복원"
 
-#: ../src/libs/snapshots.c:719
+#: ../src/libs/snapshots.c:728
 msgid "snapshots for removed image have been deleted"
 msgstr "삭제된 이미지의 스냅샷이 제거되었습니다"
 
-#: ../src/libs/snapshots.c:760
+#: ../src/libs/snapshots.c:769
 #, c-format
 msgid "↗ %s '%s'"
 msgstr "↗ %s '%s'"
 
-#: ../src/libs/snapshots.c:760
+#: ../src/libs/snapshots.c:769
 msgid "this snapshot was taken from"
 msgstr "이 스냅샷은 다음에서 가져왔습니다"
 
-#: ../src/libs/snapshots.c:810
+#: ../src/libs/snapshots.c:819
 msgid "take snapshot"
 msgstr "스냅샷 촬영"
 
-#: ../src/libs/snapshots.c:812
-msgid "take snapshot to compare with another image or the same image at another stage of development"
+#: ../src/libs/snapshots.c:821
+msgid ""
+"take snapshot to compare with another image or the same image at another "
+"stage of development"
 msgstr "다른 이미지나 동일한 이미지의 다른 편집 단계와 비교하기 위한 스냅샷 촬영"
 
-#: ../src/libs/snapshots.c:871
-msgid "place the snapshot side-by-side / above-below the current image instead of overlaying"
+#: ../src/libs/snapshots.c:876
+msgid "side-by-side"
+msgstr "나란히 보기"
+
+#: ../src/libs/snapshots.c:882
+msgid ""
+"place the snapshot side-by-side / above-below the current image instead of "
+"overlaying"
 msgstr "스냅샷을 오버레이하지 않고 나란히 또는 위아래로 배치"
 
-#: ../src/libs/snapshots.c:875
+#: ../src/libs/snapshots.c:886
 msgid "toggle last snapshot"
 msgstr "마지막 스냅샷 전환"
 
@@ -27447,7 +31651,7 @@ msgstr "스타일 선택"
 msgid "darktable style files"
 msgstr "darktable 스타일 파일"
 
-#: ../src/libs/styles.c:851
+#: ../src/libs/styles.c:876
 msgid ""
 "available styles,\n"
 "double-click to apply"
@@ -27455,57 +31659,81 @@ msgstr ""
 "사용 가능한 스타일 목록\n"
 "더블 클릭하여 적용"
 
-#: ../src/libs/styles.c:859 ../src/libs/styles.c:860
+#: ../src/libs/styles.c:884 ../src/libs/styles.c:885
 msgid "filter style names"
 msgstr "스타일 검색"
 
-#: ../src/libs/styles.c:865 ../src/libs/styles.c:866
+#: ../src/libs/styles.c:889 ../src/libs/styles.c:890
+msgid "hide preview"
+msgstr "미리보기 숨기기"
+
+#: ../src/libs/styles.c:897
+msgid "hide preview of style on tooltip"
+msgstr "툴팁에서 스타일 미리보기 숨기기"
+
+#: ../src/libs/styles.c:899 ../src/libs/styles.c:900
 msgid "create duplicate"
 msgstr "복제 생성"
 
-#: ../src/libs/styles.c:873
+#: ../src/libs/styles.c:907
 msgid "creates a duplicate of the image before applying style"
 msgstr "스타일을 적용하기 전에 이미지 복제본을 생성"
 
-#: ../src/libs/styles.c:876
+#: ../src/libs/styles.c:911
 msgid "how to handle existing history"
 msgstr "기존 히스토리 처리 방식 설정"
 
-#: ../src/libs/styles.c:879
+#: ../src/libs/styles.c:914
 msgid "append"
 msgstr "추가"
 
-#: ../src/libs/styles.c:883
+#: ../src/libs/styles.c:918
 msgid "create..."
 msgstr "생성..."
 
-#: ../src/libs/styles.c:885
+#: ../src/libs/styles.c:920
 msgid "create styles from history stack of selected images"
 msgstr "선택한 이미지의 히스토리 스택에서 스타일 생성"
 
-#: ../src/libs/styles.c:889 ../src/libs/tagging.c:2531
+#: ../src/libs/styles.c:924 ../src/libs/tagging.c:2561
 msgid "edit..."
 msgstr "편집..."
 
-#: ../src/libs/styles.c:891
+#: ../src/libs/styles.c:926
 msgid "edit the selected styles in list above"
 msgstr "위 목록에서 선택한 이미지 편집"
 
-#: ../src/libs/styles.c:897
+#: ../src/libs/styles.c:932
 msgid "removes the selected styles in list above"
 msgstr "위 목록에서 선택한 이미지 삭제"
 
-#: ../src/libs/styles.c:903
+#: ../src/libs/styles.c:938
 msgid "import styles from a style files"
 msgstr "스타일 파일에서 스타일 가져오기"
 
-#: ../src/libs/styles.c:909
+#: ../src/libs/styles.c:944
 msgid "export the selected styles into a style files"
 msgstr "선택한 스타일을 스타일 파일로 내보내기"
 
-#: ../src/libs/styles.c:915
+#: ../src/libs/styles.c:950
 msgid "apply the selected styles in list above to selected images"
 msgstr "위 목록에서 선택한 스타일을 선택된 이미지에 적용"
+
+#: ../src/libs/styles.c:1017
+msgid "style preview settings"
+msgstr "스타일 미리보기 설정"
+
+#: ../src/libs/styles.c:1025
+msgid "preview size"
+msgstr "미리보기 크기"
+
+#: ../src/libs/styles.c:1026
+msgid "change size of preview on tooltip of style"
+msgstr "스타일 툴팁의 미리보기 크기 변경"
+
+#: ../src/libs/styles.c:1029
+msgid "large"
+msgstr "크게"
 
 #: ../src/libs/tagging.c:110
 msgid "tagging"
@@ -27519,33 +31747,33 @@ msgstr ""
 "현재 선택한 이미지에\n"
 "키워드를 추가하거나 제거"
 
-#: ../src/libs/tagging.c:1415
+#: ../src/libs/tagging.c:1446
 msgid "attach tag to all"
 msgstr "전부 태그 붙이기"
 
-#: ../src/libs/tagging.c:1424 ../src/libs/tagging.c:2500
+#: ../src/libs/tagging.c:1455 ../src/libs/tagging.c:2530
 msgid "detach tag"
 msgstr "태그 제거"
 
-#: ../src/libs/tagging.c:1428
+#: ../src/libs/tagging.c:1459
 msgid "find tag"
 msgstr "태그 찾기"
 
-#: ../src/libs/tagging.c:1432 ../src/libs/tagging.c:2567
+#: ../src/libs/tagging.c:1462 ../src/libs/tagging.c:2597
 msgid "copy to clipboard"
 msgstr "클립보드에 복사"
 
-#: ../src/libs/tagging.c:1669
+#: ../src/libs/tagging.c:1699
 msgid "delete tag?"
 msgstr "태그를 삭제하시겠습니까?"
 
-#: ../src/libs/tagging.c:1675 ../src/libs/tagging.c:1764
-#: ../src/libs/tagging.c:1985 ../src/libs/tagging.c:2294
+#: ../src/libs/tagging.c:1705 ../src/libs/tagging.c:1794
+#: ../src/libs/tagging.c:2015 ../src/libs/tagging.c:2324
 #, c-format
 msgid "selected: %s"
 msgstr "선택됨: %s"
 
-#: ../src/libs/tagging.c:1680
+#: ../src/libs/tagging.c:1710
 #, c-format
 msgid ""
 "do you really want to delete the tag `%s'?\n"
@@ -27557,70 +31785,70 @@ msgstr[0] ""
 "정말로 태그 `%s'을 삭제하시겠습니까?\n"
 "이 태그는 %d개의 이미지에 지정되어 있습니다!"
 
-#: ../src/libs/tagging.c:1718
+#: ../src/libs/tagging.c:1748
 #, c-format
 msgid "tag %s removed"
 msgstr "태그 %s이 삭제됨"
 
-#: ../src/libs/tagging.c:1758
+#: ../src/libs/tagging.c:1788
 msgid "delete node?"
 msgstr "노드를 삭제하시겠습니까?"
 
-#: ../src/libs/tagging.c:1768
+#: ../src/libs/tagging.c:1798
 #, c-format
 msgid "<u>%d</u> tag will be deleted"
 msgid_plural "<u>%d</u> tags will be deleted"
 msgstr[0] "<u>%d</u>개의 태그가 삭제됩니다"
 
-#: ../src/libs/tagging.c:1775 ../src/libs/tagging.c:1995
-#: ../src/libs/tagging.c:2304
+#: ../src/libs/tagging.c:1805 ../src/libs/tagging.c:2025
+#: ../src/libs/tagging.c:2334
 #, c-format
 msgid "<u>%d</u> image will be updated"
 msgid_plural "<u>%d</u> images will be updated"
 msgstr[0] "<u>%d</u>개의 이미지가 업데이트됩니다"
 
-#: ../src/libs/tagging.c:1806
+#: ../src/libs/tagging.c:1836
 #, c-format
 msgid "%d tags removed"
 msgstr "%d개의 태그가 제거되었습니다"
 
-#: ../src/libs/tagging.c:1850
+#: ../src/libs/tagging.c:1880
 msgid "create tag"
 msgstr "태그 생성"
 
-#: ../src/libs/tagging.c:1866
+#: ../src/libs/tagging.c:1896
 #, c-format
 msgid "add to: \"%s\" "
 msgstr "\"%s\" 에 추가 "
 
-#: ../src/libs/tagging.c:1871 ../src/libs/tagging.c:2019
+#: ../src/libs/tagging.c:1901 ../src/libs/tagging.c:2049
 msgid "category"
 msgstr "카테고리"
 
-#: ../src/libs/tagging.c:1884 ../src/libs/tagging.c:2010
+#: ../src/libs/tagging.c:1914 ../src/libs/tagging.c:2040
 msgid "name: "
 msgstr "이름: "
 
-#: ../src/libs/tagging.c:1887 ../src/libs/tagging.c:2030
+#: ../src/libs/tagging.c:1917 ../src/libs/tagging.c:2060
 msgid "synonyms: "
 msgstr "동의어: "
 
-#: ../src/libs/tagging.c:1895 ../src/libs/tagging.c:2047
-#: ../src/libs/tagging.c:2330
+#: ../src/libs/tagging.c:1925 ../src/libs/tagging.c:2077
+#: ../src/libs/tagging.c:2360
 msgid "empty tag is not allowed, aborting"
 msgstr "빈 태그는 허용되지 않습니다, 작업을 중단합니다"
 
-#: ../src/libs/tagging.c:1906
+#: ../src/libs/tagging.c:1936
 msgid "tag name already exists. aborting."
 msgstr "태그 이름이 이미 존재합니다. 작업을 중단합니다."
 
-#: ../src/libs/tagging.c:1989 ../src/libs/tagging.c:2298
+#: ../src/libs/tagging.c:2019 ../src/libs/tagging.c:2328
 #, c-format
 msgid "<u>%d</u> tag will be updated"
 msgid_plural "<u>%d</u> tags will be updated"
 msgstr[0] "<u>%d</u>개의 태그가 업데이트됩니다"
 
-#: ../src/libs/tagging.c:2049
+#: ../src/libs/tagging.c:2079
 msgid ""
 "'|' character is not allowed for renaming tag.\n"
 "to modify the hierarchy use rename path instead. Aborting."
@@ -27628,100 +31856,100 @@ msgstr ""
 "태그 이름 변경에는 '|' 문자를 사용할 수 없습니다.\n"
 "계층 구조를 수정하려면 경로 이름 변경을 사용하세요. 작업을 중단합니다."
 
-#: ../src/libs/tagging.c:2098 ../src/libs/tagging.c:2232
+#: ../src/libs/tagging.c:2128 ../src/libs/tagging.c:2262
 #, c-format
 msgid "at least one new tag name (%s) already exists, aborting"
 msgstr "새 태그 이름(%s)이 하나 이상 이미 존재합니다, 작업을 중단합니다"
 
-#: ../src/libs/tagging.c:2288
+#: ../src/libs/tagging.c:2318
 msgid "change path"
 msgstr "경로 변경"
 
-#: ../src/libs/tagging.c:2334
+#: ../src/libs/tagging.c:2364
 msgid "'|' misplaced, empty tag is not allowed, aborting"
 msgstr "'|' 문자가 잘못 사용되었거나 빈 태그가 있습니다, 작업을 중단합니다"
 
-#: ../src/libs/tagging.c:2466
+#: ../src/libs/tagging.c:2496
 #, c-format
 msgid "tag %s created"
 msgstr "태그 %s이 생성됨"
 
-#: ../src/libs/tagging.c:2495
+#: ../src/libs/tagging.c:2525
 msgid "attach tag"
 msgstr "태그 붙이기"
 
-#: ../src/libs/tagging.c:2510
+#: ../src/libs/tagging.c:2540
 msgid "create tag..."
 msgstr "태그 생성..."
 
-#: ../src/libs/tagging.c:2517
+#: ../src/libs/tagging.c:2547
 msgid "delete tag"
 msgstr "태그 삭제"
 
-#: ../src/libs/tagging.c:2525
+#: ../src/libs/tagging.c:2555
 msgid "delete node"
 msgstr "노드 삭제"
 
-#: ../src/libs/tagging.c:2539
+#: ../src/libs/tagging.c:2569
 msgid "change path..."
 msgstr "경로 변경..."
 
-#: ../src/libs/tagging.c:2550
+#: ../src/libs/tagging.c:2580
 msgid "set as a tag"
 msgstr "태그로 설정"
 
-#: ../src/libs/tagging.c:2562
+#: ../src/libs/tagging.c:2592
 msgid "copy to entry"
 msgstr "엔트리에 복사"
 
-#: ../src/libs/tagging.c:2588
+#: ../src/libs/tagging.c:2618
 msgid "go to tag collection"
 msgstr "태그 컬렉션으로 이동"
 
-#: ../src/libs/tagging.c:2595
+#: ../src/libs/tagging.c:2625
 msgid "go back to work"
 msgstr "작업 화면으로 돌아가기"
 
-#: ../src/libs/tagging.c:2771
+#: ../src/libs/tagging.c:2801
 #, c-format
 msgid "%s"
 msgstr "%s"
 
-#: ../src/libs/tagging.c:2773
+#: ../src/libs/tagging.c:2803
 msgid "(private)"
 msgstr "(비공개)"
 
-#: ../src/libs/tagging.c:2802
+#: ../src/libs/tagging.c:2832
 msgid "select a keyword file"
 msgstr "키워드 파일 선택"
 
-#: ../src/libs/tagging.c:2817
+#: ../src/libs/tagging.c:2847
 msgid "error importing tags"
 msgstr "태그 가져오기 중 오류 발생"
 
-#: ../src/libs/tagging.c:2819
+#: ../src/libs/tagging.c:2849
 #, c-format
 msgid "%zd tags imported"
 msgstr "%zd개의 태그 가져옴"
 
-#: ../src/libs/tagging.c:2844
+#: ../src/libs/tagging.c:2874
 msgid "select file to export to"
 msgstr "내보내기할 파일 선택"
 
-#: ../src/libs/tagging.c:2860
+#: ../src/libs/tagging.c:2890
 msgid "error exporting tags"
 msgstr "태그 내보내기 중 오류 발생"
 
-#: ../src/libs/tagging.c:2862
+#: ../src/libs/tagging.c:2892
 #, c-format
 msgid "%zd tags exported"
 msgstr "%zd개의 태그 내보내짐"
 
-#: ../src/libs/tagging.c:3340
+#: ../src/libs/tagging.c:3370
 msgid "drop to root"
 msgstr "루트에 놓기"
 
-#: ../src/libs/tagging.c:3497
+#: ../src/libs/tagging.c:3527
 msgid ""
 "attached tags\n"
 "press Delete or double-click to detach\n"
@@ -27733,47 +31961,47 @@ msgstr ""
 "우클릭으로 다른 작업 수행\n"
 "Tab키로 입력란에 초점 맞추기"
 
-#: ../src/libs/tagging.c:3511
+#: ../src/libs/tagging.c:3541
 msgid "attach"
 msgstr "붙이기"
 
-#: ../src/libs/tagging.c:3513
+#: ../src/libs/tagging.c:3543
 msgid "attach tag to all selected images"
 msgstr "선택된 모든 이미지에 태그 붙이기"
 
-#: ../src/libs/tagging.c:3516
+#: ../src/libs/tagging.c:3546
 msgid "detach"
 msgstr "태그 제거"
 
-#: ../src/libs/tagging.c:3518
+#: ../src/libs/tagging.c:3548
 msgid "detach tag from all selected images"
 msgstr "선택된 모든 이미지에서 태그 제거"
 
-#: ../src/libs/tagging.c:3532
+#: ../src/libs/tagging.c:3562
 msgid "toggle list with / without hierarchy"
 msgstr "목록 계층 표시 전환"
 
-#: ../src/libs/tagging.c:3532
+#: ../src/libs/tagging.c:3562
 msgid "hide"
 msgstr "숨기기"
 
-#: ../src/libs/tagging.c:3535
+#: ../src/libs/tagging.c:3565
 msgid "toggle sort by name or by count"
 msgstr "이름순/사용 횟수순 정렬 전환"
 
-#: ../src/libs/tagging.c:3535
+#: ../src/libs/tagging.c:3565
 msgid "sort"
 msgstr "정렬"
 
-#: ../src/libs/tagging.c:3538
+#: ../src/libs/tagging.c:3568
 msgid "toggle show or not darktable tags"
 msgstr "darktable 태그 보기 전환"
 
-#: ../src/libs/tagging.c:3538
+#: ../src/libs/tagging.c:3568
 msgid "dttags"
 msgstr "dt태그"
 
-#: ../src/libs/tagging.c:3555
+#: ../src/libs/tagging.c:3585
 msgid ""
 "enter tag name\n"
 "press Enter to create a new tag and attach it on selected images\n"
@@ -27785,11 +32013,11 @@ msgstr ""
 "Tab키 또는 Down키: 일치하는 첫 번째 태그로 이동\n"
 "Shift+Tab: 붙여진 사용자 태그 중 첫 번째 항목 선택"
 
-#: ../src/libs/tagging.c:3568 ../src/libs/tagging.c:3575
+#: ../src/libs/tagging.c:3598 ../src/libs/tagging.c:3605
 msgid "clear entry"
 msgstr "입력 지우기"
 
-#: ../src/libs/tagging.c:3634
+#: ../src/libs/tagging.c:3664
 msgid ""
 "tag dictionary,\n"
 "Enter or double-click to attach selected tag on selected images\n"
@@ -27805,7 +32033,7 @@ msgstr ""
 "우클릭: 선택한 태그의 기타 작업\n"
 "Shift+Tab: 입력한에 초점 맞추기"
 
-#: ../src/libs/tagging.c:3680
+#: ../src/libs/tagging.c:3710
 msgid ""
 "create a new tag with the\n"
 "name you entered"
@@ -27813,39 +32041,40 @@ msgstr ""
 "입력한 이름으로\n"
 "새 태그 생성"
 
-#: ../src/libs/tagging.c:3686
+#: ../src/libs/tagging.c:3716
 msgid "import tags from a Lightroom keyword file"
 msgstr "Lightroom 키워드 파일에서 태그 가져오기"
 
-#: ../src/libs/tagging.c:3693
+#: ../src/libs/tagging.c:3723
 msgid "export all tags to a Lightroom keyword file"
 msgstr "모든 태그를 Lightroom 키워드 파일로 내보내기"
 
-#: ../src/libs/tagging.c:3699
+#: ../src/libs/tagging.c:3729
 msgid "toggle list / tree view"
 msgstr "목록/트리 보기 전환"
 
-#: ../src/libs/tagging.c:3699
+#: ../src/libs/tagging.c:3729
 msgid "tree"
 msgstr "트리"
 
-#: ../src/libs/tagging.c:3703
+#: ../src/libs/tagging.c:3733
 msgid "toggle list with / without suggestion"
 msgstr "목록에 제안 전환"
 
-#: ../src/libs/tagging.c:3704
+#: ../src/libs/tagging.c:3734
 msgid "suggestion"
 msgstr "제안"
 
-#: ../src/libs/tagging.c:3723
+#: ../src/libs/tagging.c:3753
 msgid "redo last tag"
 msgstr "마지막 태그 다시 적용"
 
-#: ../src/libs/tagging.c:3810
-msgid "tag shortcut is not active with tag tree view. please switch to list view"
+#: ../src/libs/tagging.c:3840
+msgid ""
+"tag shortcut is not active with tag tree view. please switch to list view"
 msgstr "태그 트리 보기에서는 태그 단축키가 비활성화됩니다. 목록 보기로 전환하세요"
 
-#: ../src/libs/tagging.c:3942
+#: ../src/libs/tagging.c:3979
 msgid "tagging settings"
 msgstr "태그 설정"
 
@@ -27874,9 +32103,36 @@ msgstr "선택한 이미지의 색상 레이블 지우기"
 msgid "enter a description of how you use this color label"
 msgstr "이 색상 레이블의 사용 방식에 대한 설명 입력"
 
-#: ../src/libs/tools/filmstrip.c:45
+#: ../src/libs/tools/filmstrip.c:46
 msgid "filmstrip"
 msgstr "필름스트립"
+
+#: ../src/libs/tools/filmstrip.c:102
+msgid "filmstrip auto-scroll enabled"
+msgstr "필름스트립 자동 스크롤이 활성화됨"
+
+#: ../src/libs/tools/filmstrip.c:106
+msgid "filmstrip auto-scroll disabled"
+msgstr "필름스트립 자동 스크롤이 비활성화됨"
+
+#: ../src/libs/tools/filmstrip.c:128
+#, c-format
+msgid "pinned in second window: %s"
+msgstr "두 번째 창에 고정됨: %s"
+
+#. register action and attach it to self->widget so the quick-shortcut
+#. button can discover it by hovering anywhere over the filmstrip
+#: ../src/libs/tools/filmstrip.c:147 ../src/libs/tools/filmstrip.c:149
+msgid "pin in second window"
+msgstr "두 번째 창에 고정"
+
+#: ../src/libs/tools/filmstrip.c:152
+msgid "auto-scroll to selected image"
+msgstr "선택한 이미지로 자동 스크롤"
+
+#: ../src/libs/tools/filmstrip.c:154
+msgid "center on selected image"
+msgstr "선택한 이미지를 중앙에 맞추기"
 
 #: ../src/libs/tools/filter.c:42
 msgid "filter"
@@ -28031,7 +32287,8 @@ msgstr "썸네일에 크기 오버레이"
 #: ../src/libs/tools/global_toolbox.c:246
 #: ../src/libs/tools/global_toolbox.c:310
 msgid ""
-"duration before the block overlay is hidden after each mouse movement on the image\n"
+"duration before the block overlay is hidden after each mouse movement on the "
+"image\n"
 "set -1 to never hide the overlay"
 msgstr ""
 "이미지 위에서 마우스가 움직인 후 블록 오버레이가 사라질 때까지의 시간\n"
@@ -28269,6 +32526,14 @@ msgstr "선별 확대 모드 전환"
 msgid "exit current layout"
 msgstr "현재 레이아웃 종료"
 
+#: ../src/libs/tools/log_history.c:50
+msgid "log history"
+msgstr "로그 히스토리"
+
+#: ../src/libs/tools/log_history.c:188
+msgid "view log history"
+msgstr "로그 히스토리 보기"
+
 #: ../src/libs/tools/midi.c:41
 msgid "midi"
 msgstr "midi"
@@ -28287,12 +32552,12 @@ msgstr "상대 인코딩으로 전환하려면 동일한 (아래쪽) 이동이 %
 msgid "switching encoding to relative (down = %d)"
 msgstr "상대 인코딩으로 전환 중 (아래쪽 = %d)"
 
-#: ../src/libs/tools/midi.c:558
+#: ../src/libs/tools/midi.c:559
 #, c-format
 msgid "%s opened as midi%d"
 msgstr "%s를 midi%d로 열었습니다"
 
-#: ../src/libs/tools/module_toolbox.c:48
+#: ../src/libs/tools/module_toolbox.c:26
 msgid "module toolbox"
 msgstr "모듈 도구상자"
 
@@ -28305,15 +32570,15 @@ msgstr "선택된 이미지에 별점 등급 설정"
 msgid "timeline"
 msgstr "타임라인"
 
-#: ../src/libs/tools/timeline.c:1421
+#: ../src/libs/tools/timeline.c:1422
 msgid "start selection"
 msgstr "선택 시작"
 
-#: ../src/libs/tools/timeline.c:1422
+#: ../src/libs/tools/timeline.c:1423
 msgid "stop selection"
 msgstr "선택 중지"
 
-#: ../src/libs/tools/view_toolbox.c:48
+#: ../src/libs/tools/view_toolbox.c:29
 msgid "view toolbox"
 msgstr "보기 도구상자"
 
@@ -28321,37 +32586,46 @@ msgstr "보기 도구상자"
 msgid "viewswitcher"
 msgstr "보기 전환 모듈"
 
-#: ../src/lua/preferences.c:656 ../src/lua/preferences.c:671
-#: ../src/lua/preferences.c:683 ../src/lua/preferences.c:696
-#: ../src/lua/preferences.c:712 ../src/lua/preferences.c:776
+#: ../src/lua/preferences.c:683 ../src/lua/preferences.c:698
+#: ../src/lua/preferences.c:710 ../src/lua/preferences.c:723
+#: ../src/lua/preferences.c:739 ../src/lua/preferences.c:803
 #, c-format
 msgid "double-click to reset to `%s'"
 msgstr "더블 클릭하여 `%s'로 리셋"
 
-#: ../src/lua/preferences.c:681
+#: ../src/lua/preferences.c:708
 msgid "select file"
 msgstr "파일 선택"
 
-#: ../src/lua/preferences.c:735
+#: ../src/lua/preferences.c:762
 #, c-format
 msgid "double-click to reset to `%d'"
 msgstr "더블 클릭하여 `%d'로 리셋"
 
-#: ../src/lua/preferences.c:762
+#: ../src/lua/preferences.c:789
 #, c-format
 msgid "double-click to reset to `%f'"
 msgstr "더블 클릭하여 `%f'로 리셋"
 
-#: ../src/lua/preferences.c:837
+#: ../src/lua/preferences.c:868
 msgid "Lua options"
 msgstr "Lua 옵션"
 
-#: ../src/views/darkroom.c:565
+#: ../src/lua/preferences.c:919
+msgid "per-script configuration options"
+msgstr "스크립트별 설정 옵션"
+
+#: ../src/views/darkroom.c:656
+msgid "drop image files here to add them to the collection"
+msgstr "컬렉션에 추가하려면 이미지 파일을 여기에 놓으세요"
+
+#: ../src/views/darkroom.c:790
 #, c-format
 msgid ""
 "file `%s' is not available, switching to lighttable now.\n"
 "\n"
-"if stored on an external drive, ensure that the drive is connected and files\n"
+"if stored on an external drive, ensure that the drive is connected and "
+"files\n"
 "can be accessed in the same locations as when you imported this image."
 msgstr ""
 "파일 `%s'을 찾을 수 없어 lighttable로 전환합니다.\n"
@@ -28359,7 +32633,7 @@ msgstr ""
 "이 파일이 외장 드라이브에 저장되어 있었다면, 해당 드라이브가 연결되어 있고\n"
 "파일이 가져올 당시와 동일한 위치에 있는지 확인해 주세요."
 
-#: ../src/views/darkroom.c:572
+#: ../src/views/darkroom.c:797
 #, c-format
 msgid ""
 "file `%s' appears corrupt, switching to lighttable now.\n"
@@ -28370,23 +32644,26 @@ msgstr ""
 "\n"
 "카메라에서 완전히 복사되었는지 확인해 주세요."
 
-#: ../src/views/darkroom.c:578
+#: ../src/views/darkroom.c:803
 #, c-format
 msgid "file `%s' is not in any recognized format, switching to lighttable now."
 msgstr "파일 `%s'은 인식할 수 없는 형식입니다, lighttable로 전환합니다."
 
-#: ../src/views/darkroom.c:583
+#: ../src/views/darkroom.c:808
 #, c-format
-msgid "file `%s' is from an unsupported camera model, switching to lighttable now."
+msgid ""
+"file `%s' is from an unsupported camera model, switching to lighttable now."
 msgstr "파일 `%s'은 지원되지 않는 카메라 모델에서 생성되었습니다, lighttable로 전환합니다."
 
-#: ../src/views/darkroom.c:588
+#: ../src/views/darkroom.c:813
 #, c-format
 msgid ""
 "file `%s' uses an unsupported feature, switching to lighttable now.\n"
 "\n"
-"please check that the image format and compression mode you selected in your\n"
-"camera's menus is supported (see https://www.darktable.org/resources/camera-support/\n"
+"please check that the image format and compression mode you selected in "
+"your\n"
+"camera's menus is supported (see https://www.darktable.org/resources/camera-"
+"support/\n"
 "and the release notes for this version of darktable)"
 msgstr ""
 "파일 `%s'에서 지원되지 않는 기능이 사용되었습니다, lighttable로 전환합니다.\n"
@@ -28394,7 +32671,7 @@ msgstr ""
 "카메라의 메뉴에서 선택한 이미지 형식 및 압축 방식이 지원되는지 확인해 주세요.\n"
 "(https://www.darktable.org/resources/camera-support/ 및 이 darktable 버전의 릴리스 노트를 참고하세요)"
 
-#: ../src/views/darkroom.c:596
+#: ../src/views/darkroom.c:821
 #, c-format
 msgid ""
 "error while reading file `%s', switching to lighttable now.\n"
@@ -28405,14 +32682,17 @@ msgstr ""
 "\n"
 "파일이 손상되거나 일부 누락되지 않았는지 확인해 주세요."
 
-#: ../src/views/darkroom.c:602
+#: ../src/views/darkroom.c:827
 #, c-format
 msgid ""
 "darktable could not load `%s', switching to lighttable now.\n"
 "\n"
-"please check that the camera model that produced the image is supported in darktable\n"
-"(list of supported cameras is at https://www.darktable.org/resources/camera-support/).\n"
-"if you are sure that the camera model is supported, please consider opening an issue\n"
+"please check that the camera model that produced the image is supported in "
+"darktable\n"
+"(list of supported cameras is at https://www.darktable.org/resources/camera-"
+"support/).\n"
+"if you are sure that the camera model is supported, please consider opening "
+"an issue\n"
 "at https://github.com/darktable-org/darktable"
 msgstr ""
 "darktable에서 `%s' 파일을 로딩할 수 없습니다, lighttable로 전환합니다.\n"
@@ -28422,58 +32702,62 @@ msgstr ""
 "카메라가 지원되는 모델이 확실하다면, 다음 링크에 이슈를 등록해 주세요:\n"
 "https://github.com/darktable-org/darktable"
 
-#: ../src/views/darkroom.c:630
+#: ../src/views/darkroom.c:855
 #, c-format
 msgctxt "darkroom"
 msgid "loading `%s' ..."
 msgstr "`%s' 로딩 중..."
 
-#: ../src/views/darkroom.c:823 ../src/views/darkroom.c:2718
+#: ../src/views/darkroom.c:1101 ../src/views/darkroom.c:3343
 msgid "gamut check"
 msgstr "색영역(gamut) 확인"
 
-#: ../src/views/darkroom.c:824
+#: ../src/views/darkroom.c:1102
 msgid "soft proof"
 msgstr "소프트 프루프"
 
+#: ../src/views/darkroom.c:1133
+msgid "drop XMP sidecar files here to apply edits"
+msgstr "편집 내용을 적용하려면 XMP 사이드카 파일을 여기에 놓으세요"
+
 #. fail :(
-#: ../src/views/darkroom.c:866 ../src/views/print.c:318
+#: ../src/views/darkroom.c:1148 ../src/views/print.c:318
 msgid "no image to open!"
 msgstr "열 수 있는 이미지가 없습니다!"
 
-#: ../src/views/darkroom.c:892
+#: ../src/views/darkroom.c:1174
 msgid "file not found"
 msgstr "파일을 찾을 수 없음"
 
-#: ../src/views/darkroom.c:896
+#: ../src/views/darkroom.c:1178
 msgid "unspecified failure"
 msgstr "알 수 없는 오류"
 
-#: ../src/views/darkroom.c:899
+#: ../src/views/darkroom.c:1181
 msgid "unsupported file format"
 msgstr "지원되지 않는 파일 형식"
 
-#: ../src/views/darkroom.c:902
+#: ../src/views/darkroom.c:1184
 msgid "unsupported camera model"
 msgstr "지원되지 않는 파일 형식"
 
-#: ../src/views/darkroom.c:905
+#: ../src/views/darkroom.c:1187
 msgid "unsupported feature in file"
 msgstr "파일에 지원되지 않는 기능이 포함됨"
 
-#: ../src/views/darkroom.c:908
+#: ../src/views/darkroom.c:1190
 msgid "file appears corrupt"
 msgstr "파일이 손상된 것으로 보임"
 
-#: ../src/views/darkroom.c:911
+#: ../src/views/darkroom.c:1193
 msgid "I/O error"
 msgstr "I/O 오류"
 
-#: ../src/views/darkroom.c:914
+#: ../src/views/darkroom.c:1196
 msgid "cache full"
 msgstr "캐시가 가득 참"
 
-#: ../src/views/darkroom.c:917
+#: ../src/views/darkroom.c:1199
 #, c-format
 msgid ""
 "image `%s' could not be loaded\n"
@@ -28482,35 +32766,135 @@ msgstr ""
 "이미지 `%s'을 로딩할 수 없음\n"
 "%s"
 
-#: ../src/views/darkroom.c:956 ../src/views/darkroom.c:1340
+#: ../src/views/darkroom.c:1238 ../src/views/darkroom.c:1631
 msgid "can't change image in GIMP plugin mode"
 msgstr "GIMP 플러그인 모드에서 이미지를 변경할 수 없습니다"
 
-#: ../src/views/darkroom.c:2456 ../src/views/darkroom.c:2458
+#: ../src/views/darkroom.c:1694
+msgid "past end of collection, looped to first image"
+msgstr "컬렉션의 끝을 지나 첫 번째 이미지로 돌아왔습니다"
+
+#: ../src/views/darkroom.c:1696
+msgid "past beginning of collection, looped to last image"
+msgstr "컬렉션의 처음을 지나 마지막 이미지로 돌아왔습니다"
+
+#: ../src/views/darkroom.c:2810
+msgid "no visible modules"
+msgstr "표시된 모듈이 없습니다"
+
+#: ../src/views/darkroom.c:2840 ../src/views/darkroom.c:2995
+#, c-format
+msgid "focused instance '%s' of '%s'"
+msgstr "포커스된 인스턴스 '%s' (모듈 '%s')"
+
+#: ../src/views/darkroom.c:2842 ../src/views/darkroom.c:2999
+#, c-format
+msgid "focused module '%s'"
+msgstr "포커스된 모듈 '%s'"
+
+#: ../src/views/darkroom.c:2850 ../src/views/darkroom.c:2880
+#: ../src/views/darkroom.c:2889 ../src/views/darkroom.c:2913
+#: ../src/views/darkroom.c:2955
+msgid "no focused module"
+msgstr "포커스된 모듈이 없습니다"
+
+#: ../src/views/darkroom.c:2852
+#, c-format
+msgid "'%s' cannot be enabled or disabled"
+msgstr "'%s'은(는) 활성화하거나 비활성화할 수 없습니다"
+
+#: ../src/views/darkroom.c:2862
+#, c-format
+msgid "enabled instance '%s' of '%s'"
+msgstr "인스턴스 '%s' (모듈 '%s')을(를) 활성화하였습니다"
+
+#: ../src/views/darkroom.c:2864
+#, c-format
+msgid "disabled instance '%s' of '%s'"
+msgstr "인스턴스 '%s' (모듈 '%s')을(를) 비활성화하였습니다"
+
+#: ../src/views/darkroom.c:2869
+#, c-format
+msgid "enabled module '%s'"
+msgstr "모듈 '%s'을(를) 활성화하였습니다"
+
+#: ../src/views/darkroom.c:2871
+#, c-format
+msgid "disabled module '%s'"
+msgstr "모듈 '%s'을(를) 비활성화하였습니다"
+
+#: ../src/views/darkroom.c:2891 ../src/views/darkroom.c:2915
+#, c-format
+msgid "'%s' does not support multiple instances"
+msgstr "'%s'은(는) 여러 인스턴스를 지원하지 않습니다"
+
+#: ../src/views/darkroom.c:2900
+#, c-format
+msgid "added instance '%s' of '%s'"
+msgstr "인스턴스 '%s' (모듈 '%s')을(를) 추가하였습니다"
+
+#: ../src/views/darkroom.c:2904
+#, c-format
+msgid "added instance of '%s'"
+msgstr "'%s'의 인스턴스를 추가하였습니다"
+
+#: ../src/views/darkroom.c:2923
+#, c-format
+msgid "deleted instance '%s' of '%s'"
+msgstr "인스턴스 '%s' (모듈 '%s')을(를) 삭제하였습니다"
+
+#: ../src/views/darkroom.c:2925
+#, c-format
+msgid "deleted instance of '%s'"
+msgstr "'%s'의 인스턴스를 삭제하였습니다"
+
+#: ../src/views/darkroom.c:2972
+#, c-format
+msgid "only one instance of '%s'"
+msgstr "'%s'의 인스턴스가 하나뿐입니다"
+
+#. cycle through visible modules and their instances
+#: ../src/views/darkroom.c:3037 ../src/views/darkroom.c:3099
+msgid "cycle modules"
+msgstr "모듈 순환"
+
+#: ../src/views/darkroom.c:3060 ../src/views/darkroom.c:3062
 msgid "quick access to presets"
 msgstr "사전설정 빠른 접근"
 
-#: ../src/views/darkroom.c:2468
+#: ../src/views/darkroom.c:3072
 msgid "quick access to styles"
 msgstr "스타일 빠른 접근"
 
-#: ../src/views/darkroom.c:2471
+#: ../src/views/darkroom.c:3075
 msgid "quick access for applying any of your styles"
 msgstr "저장된 스타일 적용 빠른 접근"
 
-#: ../src/views/darkroom.c:2478
+#: ../src/views/darkroom.c:3082
 msgid "second window"
 msgstr "두 번째 창"
 
-#: ../src/views/darkroom.c:2483
+#: ../src/views/darkroom.c:3087
 msgid "display a second darkroom image window"
 msgstr "두 번째 darkroom 이미지 창을 표시"
 
-#: ../src/views/darkroom.c:2491
+#. Register a toggle-pin action for the second window as a command so the
+#. shortcut works independently of the pin button widget.  The pin button
+#. is wired to this same action in _darkroom_ui_second_window_init() for
+#. right-click shortcut assignment and tooltip display.
+#: ../src/views/darkroom.c:3095 ../src/views/darkroom.c:5211
+msgid "toggle pinned state in second window"
+msgstr "두 번째 창의 고정 상태 전환"
+
+#: ../src/views/darkroom.c:3107
+msgid "delete instance"
+msgstr "인스턴스 삭제"
+
+#: ../src/views/darkroom.c:3116
 msgid "color assessment"
 msgstr "색상 평가"
 
-#: ../src/views/darkroom.c:2493
+#: ../src/views/darkroom.c:3118
 msgid ""
 "toggle color assessment conditions\n"
 "right-click for options"
@@ -28518,15 +32902,15 @@ msgstr ""
 "색상 평가 조건 전환\n"
 "우클릭으로 옵션 보기"
 
-#: ../src/views/darkroom.c:2510 ../src/views/darkroom.c:2523
+#: ../src/views/darkroom.c:3135 ../src/views/darkroom.c:3148
 msgid "color_assessment"
 msgstr "색상_평가"
 
-#: ../src/views/darkroom.c:2510
+#: ../src/views/darkroom.c:3135
 msgid "total border width relative to screen"
 msgstr "화면 기준 전체 테두리 너비"
 
-#: ../src/views/darkroom.c:2512
+#: ../src/views/darkroom.c:3137
 msgid ""
 "total border width in relation to the screen size for the assessment mode.\n"
 "this includes the outer gray part plus the inner white frame."
@@ -28534,25 +32918,28 @@ msgstr ""
 "색상 평가 모드에서 화면 크기에 대한 전체 테두리 너비입니다.\n"
 "회색 외곽 부분과 흰색 내부 프레임을 모두 포함합니다."
 
-#: ../src/views/darkroom.c:2523
+#: ../src/views/darkroom.c:3148
 msgid "white border ratio"
 msgstr "흰색 테두리 비율"
 
-#: ../src/views/darkroom.c:2525
-msgid "the border ratio specifies the fraction of the white part of the border."
+#: ../src/views/darkroom.c:3150
+msgid ""
+"the border ratio specifies the fraction of the white part of the border."
 msgstr "테두리 비율은 흰색 부분이 전체 테두리에서 차지하는 비율을 지정합니다."
 
-#: ../src/views/darkroom.c:2536
+#: ../src/views/darkroom.c:3161
 msgid "high quality processing"
 msgstr "고품질 처리"
 
-#: ../src/views/darkroom.c:2540
-msgid "toggle high quality processing. if activated darktable processes image data as it does while exporting"
+#: ../src/views/darkroom.c:3165
+msgid ""
+"toggle high quality processing. if activated darktable processes image data "
+"as it does while exporting"
 msgstr ""
 "고품질 처리를 전환합니다. 활성화하면 내보내기 시와 동일한 방식으로\n"
 "darktable이 이미지 데이터를 처리합니다"
 
-#: ../src/views/darkroom.c:2559
+#: ../src/views/darkroom.c:3184
 msgid ""
 "toggle indication of raw overexposure\n"
 "right-click for options"
@@ -28560,27 +32947,27 @@ msgstr ""
 "raw 과다노출 표시 전환\n"
 "우클릭하여 옵션 보기"
 
-#: ../src/views/darkroom.c:2580
+#: ../src/views/darkroom.c:3205
 msgid "select how to mark the clipped pixels"
 msgstr "클리핑된 픽셀을 표시하는 방식을 선택"
 
-#: ../src/views/darkroom.c:2583
+#: ../src/views/darkroom.c:3208
 msgid "mark with CFA color"
 msgstr "CFA 색상으로 마킹"
 
-#: ../src/views/darkroom.c:2583
+#: ../src/views/darkroom.c:3208
 msgid "mark with solid color"
 msgstr "단색으로 마킹"
 
-#: ../src/views/darkroom.c:2584
+#: ../src/views/darkroom.c:3209
 msgid "false color"
 msgstr "가짜 색상"
 
-#: ../src/views/darkroom.c:2589 ../src/views/darkroom.c:2659
+#: ../src/views/darkroom.c:3214 ../src/views/darkroom.c:3284
 msgid "color scheme"
 msgstr "컬러 스킴"
 
-#: ../src/views/darkroom.c:2590
+#: ../src/views/darkroom.c:3215
 msgid ""
 "select the solid color to indicate overexposure.\n"
 "will only be used if mode = mark with solid color"
@@ -28588,27 +32975,27 @@ msgstr ""
 "과다노출을 표시하는 단색을 선택합니다.\n"
 "단색으로 마킹 모드에서만 사용됩니다"
 
-#: ../src/views/darkroom.c:2593
+#: ../src/views/darkroom.c:3218
 msgctxt "solidcolor"
 msgid "red"
 msgstr "빨간색"
 
-#: ../src/views/darkroom.c:2594
+#: ../src/views/darkroom.c:3219
 msgctxt "solidcolor"
 msgid "green"
 msgstr "초록색"
 
-#: ../src/views/darkroom.c:2595
+#: ../src/views/darkroom.c:3220
 msgctxt "solidcolor"
 msgid "blue"
 msgstr "파란색"
 
-#: ../src/views/darkroom.c:2596
+#: ../src/views/darkroom.c:3221
 msgctxt "solidcolor"
 msgid "black"
 msgstr "검정색"
 
-#: ../src/views/darkroom.c:2607
+#: ../src/views/darkroom.c:3232
 msgid ""
 "threshold of what shall be considered overexposed\n"
 "1.0 - white level\n"
@@ -28618,7 +33005,7 @@ msgstr ""
 "1.0 - 화이트 레벨\n"
 "0.0 - 블랙 레벨"
 
-#: ../src/views/darkroom.c:2626
+#: ../src/views/darkroom.c:3251
 msgid ""
 "toggle clipping indication\n"
 "right-click for options"
@@ -28626,11 +33013,11 @@ msgstr ""
 "클리핑 표시 전환\n"
 "우클릭하여 옵션 보기"
 
-#: ../src/views/darkroom.c:2647
+#: ../src/views/darkroom.c:3272
 msgid "clipping preview mode"
 msgstr "클리핑 미리보기 모드"
 
-#: ../src/views/darkroom.c:2648
+#: ../src/views/darkroom.c:3273
 msgid ""
 "select the metric you want to preview\n"
 "full gamut is the combination of all other modes"
@@ -28638,39 +33025,39 @@ msgstr ""
 "미리보기할 기준을 선택하세요.\n"
 "'전체 색영역(gamut)'은 다른 모든 모드의 조합입니다"
 
-#: ../src/views/darkroom.c:2652
+#: ../src/views/darkroom.c:3277
 msgid "full gamut"
 msgstr "전체 색영역(gamut)"
 
-#: ../src/views/darkroom.c:2653
+#: ../src/views/darkroom.c:3278
 msgid "any RGB channel"
 msgstr "모든 RGB 채널"
 
-#: ../src/views/darkroom.c:2654
+#: ../src/views/darkroom.c:3279
 msgid "luminance only"
 msgstr "밝기만"
 
-#: ../src/views/darkroom.c:2654
+#: ../src/views/darkroom.c:3279
 msgid "saturation only"
 msgstr "채도만"
 
-#: ../src/views/darkroom.c:2660
+#: ../src/views/darkroom.c:3285
 msgid "select colors to indicate clipping"
 msgstr "클리핑 표시 색상 선택"
 
-#: ../src/views/darkroom.c:2664
+#: ../src/views/darkroom.c:3289
 msgid "red & blue"
 msgstr "빨간색 & 파란색"
 
-#: ../src/views/darkroom.c:2665
+#: ../src/views/darkroom.c:3290
 msgid "purple & green"
 msgstr "보라색 & 초록색"
 
-#: ../src/views/darkroom.c:2673
+#: ../src/views/darkroom.c:3298
 msgid "lower threshold"
 msgstr "하한 임계값"
 
-#: ../src/views/darkroom.c:2674
+#: ../src/views/darkroom.c:3299
 msgid ""
 "clipping threshold for the black point,\n"
 "in EV, relatively to white (0 EV).\n"
@@ -28690,11 +33077,11 @@ msgstr ""
 "일반 유광 컬러 프린트는 -8.00 EV에서 검은색을 생성하고,\n"
 "일반 유광 흑백 프린트는 -9.00 EV에서 검은색을 생성합니다."
 
-#: ../src/views/darkroom.c:2691
+#: ../src/views/darkroom.c:3316
 msgid "upper threshold"
 msgstr "상한 임계값"
 
-#: ../src/views/darkroom.c:2693
+#: ../src/views/darkroom.c:3318
 #, no-c-format
 msgid ""
 "clipping threshold for the white point.\n"
@@ -28703,11 +33090,11 @@ msgstr ""
 "화이트 포인트의 클리핑 임계값을 설정합니다.\n"
 "100%는 최대 밝기 수준을 의미합니다."
 
-#: ../src/views/darkroom.c:2705
+#: ../src/views/darkroom.c:3330
 msgid "softproof"
 msgstr "소프트프루프"
 
-#: ../src/views/darkroom.c:2709
+#: ../src/views/darkroom.c:3334
 msgid ""
 "toggle softproofing\n"
 "right-click for profile options"
@@ -28715,7 +33102,7 @@ msgstr ""
 "소프트프루프 전환\n"
 "우클릭하여 옵션 보기"
 
-#: ../src/views/darkroom.c:2722
+#: ../src/views/darkroom.c:3347
 msgid ""
 "toggle gamut checking\n"
 "right-click for profile options"
@@ -28723,54 +33110,54 @@ msgstr ""
 "색영역(gamut) 확인 전환\n"
 "우클릭하여 프로파일 옵션 보기"
 
-#: ../src/views/darkroom.c:2750 ../src/views/darkroom.c:2757
-#: ../src/views/darkroom.c:2776 ../src/views/darkroom.c:2778
-#: ../src/views/darkroom.c:2780 ../src/views/darkroom.c:2782
-#: ../src/views/lighttable.c:1262 ../src/views/lighttable.c:1264
+#: ../src/views/darkroom.c:3375 ../src/views/darkroom.c:3382
+#: ../src/views/darkroom.c:3401 ../src/views/darkroom.c:3403
+#: ../src/views/darkroom.c:3405 ../src/views/darkroom.c:3407
+#: ../src/views/lighttable.c:1495 ../src/views/lighttable.c:1499
 msgid "profiles"
 msgstr "프로파일"
 
-#: ../src/views/darkroom.c:2758 ../src/views/lighttable.c:1264
+#: ../src/views/darkroom.c:3383 ../src/views/lighttable.c:1499
 msgid "preview intent"
 msgstr "미리보기 의도"
 
-#: ../src/views/darkroom.c:2776 ../src/views/lighttable.c:1268
+#: ../src/views/darkroom.c:3401 ../src/views/lighttable.c:1504
 msgid "display profile"
 msgstr "디스플레이 프로파일"
 
-#: ../src/views/darkroom.c:2778 ../src/views/lighttable.c:1271
+#: ../src/views/darkroom.c:3403 ../src/views/lighttable.c:1507
 msgid "preview display profile"
 msgstr "미리보기 디스플레이 프로파일"
 
-#: ../src/views/darkroom.c:2782
+#: ../src/views/darkroom.c:3407
 msgid "histogram profile"
 msgstr "히스토그램 프로파일"
 
-#: ../src/views/darkroom.c:2789
+#: ../src/views/darkroom.c:3414
 msgid "second preview window color assessment"
 msgstr "두번째 미리보기 창 색상 평가"
 
-#: ../src/views/darkroom.c:2792
+#: ../src/views/darkroom.c:3417
 msgid "color assessment second preview"
 msgstr "색상 평가 세컨드 프리뷰"
 
-#: ../src/views/darkroom.c:2840 ../src/views/lighttable.c:1305
+#: ../src/views/darkroom.c:3465 ../src/views/lighttable.c:1544
 msgid "display ICC profiles"
 msgstr "디스플레이 ICC 프로파일"
 
-#: ../src/views/darkroom.c:2844 ../src/views/lighttable.c:1309
+#: ../src/views/darkroom.c:3469 ../src/views/lighttable.c:1548
 msgid "preview display ICC profiles"
 msgstr "미리보기 디스플레이 ICC 프로파일"
 
-#: ../src/views/darkroom.c:2848
+#: ../src/views/darkroom.c:3473
 msgid "softproof ICC profiles"
 msgstr "소프트프루프 ICC 프로파일"
 
-#: ../src/views/darkroom.c:2853
+#: ../src/views/darkroom.c:3478
 msgid "histogram and color picker ICC profiles"
 msgstr "히스토그램 및 색상 피커 ICC 프로파일"
 
-#: ../src/views/darkroom.c:2902
+#: ../src/views/darkroom.c:3522
 msgid ""
 "toggle guide lines\n"
 "right-click for guides options"
@@ -28779,306 +33166,365 @@ msgstr ""
 "우클릭하여 가이드 옵션 보기"
 
 #. Fullscreen preview key
-#: ../src/views/darkroom.c:2921
+#: ../src/views/darkroom.c:3541
 msgid "full preview"
 msgstr "전체 화면 미리보기"
 
 #. add an option to allow skip mouse events while other overlays are
 #. consuming mouse actions
-#: ../src/views/darkroom.c:2926
+#: ../src/views/darkroom.c:3546
 msgid "force pan/zoom/rotate with mouse"
 msgstr "마우스로 강제 이동/확대/회전"
 
 #. Zoom shortcuts
-#: ../src/views/darkroom.c:2941
+#: ../src/views/darkroom.c:3561
 msgid "zoom close-up"
 msgstr "클로즈업 확대"
 
 #. zoom in/out
 #. zoom in/out/min/max
-#: ../src/views/darkroom.c:2945 ../src/views/lighttable.c:1361
+#: ../src/views/darkroom.c:3565 ../src/views/lighttable.c:1626
 msgid "zoom in"
 msgstr "확대"
 
-#: ../src/views/darkroom.c:2947 ../src/views/lighttable.c:1363
+#: ../src/views/darkroom.c:3567 ../src/views/lighttable.c:1630
 msgid "zoom out"
 msgstr "축소"
 
 #. Shortcut to skip images
-#: ../src/views/darkroom.c:2951
+#: ../src/views/darkroom.c:3571
 msgid "image forward"
 msgstr "다음 이미지"
 
-#: ../src/views/darkroom.c:2953
+#: ../src/views/darkroom.c:3573
 msgid "image back"
 msgstr "이전 이미지"
 
 #. cycle overlay colors
-#: ../src/views/darkroom.c:2957
+#: ../src/views/darkroom.c:3577
 msgid "cycle overlay colors"
 msgstr "오버레이 색상 순차 전환"
 
 #. toggle visibility of drawn masks for current gui module
-#: ../src/views/darkroom.c:2961
+#: ../src/views/darkroom.c:3581
 msgid "show drawn masks"
 msgstr "그리기 마스크 표시"
 
 #. brush size +/-
-#: ../src/views/darkroom.c:2965
+#: ../src/views/darkroom.c:3585
 msgid "increase brush size"
 msgstr "브러시 크기 확대"
 
-#: ../src/views/darkroom.c:2967
+#: ../src/views/darkroom.c:3587
 msgid "decrease brush size"
 msgstr "브러시 크기 축소"
 
 #. brush hardness +/-
-#: ../src/views/darkroom.c:2971
+#: ../src/views/darkroom.c:3591
 msgid "increase brush hardness"
 msgstr "브러시 경도 증가"
 
-#: ../src/views/darkroom.c:2973
+#: ../src/views/darkroom.c:3593
 msgid "decrease brush hardness"
 msgstr "브러시 경도 감소"
 
 #. brush opacity +/-
-#: ../src/views/darkroom.c:2977
+#: ../src/views/darkroom.c:3597
 msgid "increase brush opacity"
 msgstr "브러시 불투명도 증가"
 
-#: ../src/views/darkroom.c:2979
+#: ../src/views/darkroom.c:3599
 msgid "decrease brush opacity"
 msgstr "브러시 불투명도 감소"
 
 #. undo/redo
-#: ../src/views/darkroom.c:2983 ../src/views/lighttable.c:1353
-#: ../src/views/map.c:2400
+#: ../src/views/darkroom.c:3603 ../src/views/lighttable.c:1614
+#: ../src/views/map.c:2402
 msgid "undo"
 msgstr "되돌리기"
 
-#: ../src/views/darkroom.c:2985 ../src/views/lighttable.c:1354
-#: ../src/views/map.c:2402
+#: ../src/views/darkroom.c:3605 ../src/views/lighttable.c:1616
+#: ../src/views/map.c:2404
 msgid "redo"
 msgstr "다시 실행"
 
 #. change the precision for adjusting sliders with keyboard shortcuts
-#: ../src/views/darkroom.c:2989
+#: ../src/views/darkroom.c:3609
 msgid "change keyboard shortcut slider precision"
 msgstr "단축키 슬라이더 정밀도 변경"
 
-#: ../src/views/darkroom.c:2992
+#: ../src/views/darkroom.c:3612
 msgid "synchronize selection"
 msgstr "선택 동기화"
 
-#: ../src/views/darkroom.c:3711
+#: ../src/views/darkroom.c:3696
+#, c-format
+msgid "apply the dropped sidecar '%s'?"
+msgstr "놓은 사이드카 '%s'을(를) 적용하시겠습니까?"
+
+#: ../src/views/darkroom.c:3697
+msgid "apply sidecar"
+msgstr "사이드카 적용"
+
+#: ../src/views/darkroom.c:3701
+msgid ""
+"replace the history of the current image, or create a duplicate and apply "
+"the history to it?"
+msgstr "현재 이미지의 히스토리를 덮어쓸까요, 아니면 복제본을 만들어 히스토리를 적용할까요?"
+
+#: ../src/views/darkroom.c:3704
+msgid "create _duplicate"
+msgstr "복제 생성"
+
+#: ../src/views/darkroom.c:3705
+msgid "_replace history"
+msgstr "히스토리 덮어쓰기"
+
+#: ../src/views/darkroom.c:3715 ../src/views/darkroom.c:3725
+#, c-format
+msgid "error loading sidecar '%s'"
+msgstr "사이드카 '%s'을(를) 불러오는 중 오류 발생"
+
+#: ../src/views/darkroom.c:3717
+#, c-format
+msgid "applied '%s' to the current image"
+msgstr "현재 이미지에 '%s'을(를) 적용하였습니다"
+
+#: ../src/views/darkroom.c:3731
+#, c-format
+msgid ""
+"%d duplicate of the current image will be created, one per dropped sidecar."
+msgid_plural ""
+"%d duplicates of the current image will be created, one per dropped sidecar."
+msgstr[0] "놓은 사이드카 하나당 하나씩, 현재 이미지의 복제본 %d개가 생성됩니다."
+
+#: ../src/views/darkroom.c:3737
+msgid "create duplicates"
+msgstr "복제본 생성"
+
+#: ../src/views/darkroom.c:3740
+msgid "_create"
+msgstr "생성"
+
+#: ../src/views/darkroom.c:3755
+#, c-format
+msgid "created %u duplicate from dropped sidecars"
+msgid_plural "created %u duplicates from dropped sidecars"
+msgstr[0] "놓은 사이드카에서 복제본 %u개를 생성하였습니다"
+
+#: ../src/views/darkroom.c:3760
+msgid "error loading the dropped sidecars"
+msgstr "놓은 사이드카를 불러오는 중 오류 발생"
+
+#: ../src/views/darkroom.c:4813
 msgid "keyboard shortcut slider precision: fine"
 msgstr "단축키 슬라이더 정밀도: 정밀"
 
-#: ../src/views/darkroom.c:3713
+#: ../src/views/darkroom.c:4815
 msgid "keyboard shortcut slider precision: normal"
 msgstr "단축키 슬라이더 정밀도: 보통"
 
-#: ../src/views/darkroom.c:3715
+#: ../src/views/darkroom.c:4817
 msgid "keyboard shortcut slider precision: coarse"
 msgstr "단축키 슬라이더 정밀도: 거친"
 
-#: ../src/views/darkroom.c:3731
+#: ../src/views/darkroom.c:4833
 msgid "switch to lighttable"
 msgstr "lighttable로 전환"
 
-#: ../src/views/darkroom.c:3733 ../src/views/lighttable.c:956
+#: ../src/views/darkroom.c:4835 ../src/views/lighttable.c:1157
 msgid "zoom in the image"
 msgstr "이미지 확대"
 
-#: ../src/views/darkroom.c:3735
+#: ../src/views/darkroom.c:4837
 msgid "unbounded zoom in the image"
 msgstr "제한 없는 이미지 확대"
 
-#: ../src/views/darkroom.c:3737
+#: ../src/views/darkroom.c:4839
 msgid "zoom to 100% 200% and back"
 msgstr "100%, 200%로 확대 및 되돌리기"
 
-#: ../src/views/darkroom.c:3739 ../src/views/lighttable.c:959
+#: ../src/views/darkroom.c:4841 ../src/views/lighttable.c:1162
 msgid "pan a zoomed image"
 msgstr "확대된 이미지 이동"
 
-#: ../src/views/darkroom.c:3742 ../src/views/lighttable.c:1001
+#: ../src/views/darkroom.c:4844 ../src/views/lighttable.c:1215
 msgid "[modules] expand module without closing others"
 msgstr "[모듈] 다른 모듈을 닫지 않고 펼치기"
 
-#: ../src/views/darkroom.c:3743 ../src/views/lighttable.c:1002
+#: ../src/views/darkroom.c:4845 ../src/views/lighttable.c:1216
 msgid "[modules] expand module and close others"
 msgstr "[모듈] 현재 모듈만 펼치고 나머지 닫기"
 
-#: ../src/views/darkroom.c:3745
+#: ../src/views/darkroom.c:4847
 msgid "[modules] rename module"
 msgstr "[모듈] 이름 바꾸기"
 
-#: ../src/views/darkroom.c:3748
+#: ../src/views/darkroom.c:4850
 msgid "[modules] change module position in pipe"
 msgstr "[모듈] 파이프라인 내 처리 순서 변경"
 
 #. Show infos key
-#: ../src/views/lighttable.c:730 ../src/views/lighttable.c:1344
+#: ../src/views/lighttable.c:916 ../src/views/lighttable.c:1601
 msgid "show infos"
 msgstr "정보 표시"
 
-#: ../src/views/lighttable.c:833
+#: ../src/views/lighttable.c:1023
 msgid "middle"
 msgstr "가운데"
 
-#: ../src/views/lighttable.c:951
+#: ../src/views/lighttable.c:1150
 msgid "open image in darkroom"
 msgstr "darkroom에서 이미지 열기"
 
-#: ../src/views/lighttable.c:955
+#: ../src/views/lighttable.c:1155
 msgid "switch to next/previous image"
 msgstr "이전/다음 이미지로 전환"
 
-#: ../src/views/lighttable.c:958 ../src/views/lighttable.c:989
+#: ../src/views/lighttable.c:1160 ../src/views/lighttable.c:1200
 #, no-c-format
 msgid "zoom to 100% and back"
 msgstr "100% 확대/돌아오기"
 
-#: ../src/views/lighttable.c:963 ../src/views/lighttable.c:982
+#: ../src/views/lighttable.c:1167 ../src/views/lighttable.c:1188
 msgid "scroll the collection"
 msgstr "컬렉션 스크롤"
 
-#: ../src/views/lighttable.c:965
+#: ../src/views/lighttable.c:1169
 msgid "change number of images per row"
 msgstr "한 행당 이미지 수 변경"
 
-#: ../src/views/lighttable.c:968
+#: ../src/views/lighttable.c:1172
 msgid "select an image"
 msgstr "이미지 선택"
 
-#: ../src/views/lighttable.c:970
+#: ../src/views/lighttable.c:1174
 msgid "select range from last image"
 msgstr "마지막 이미지부터 범위 선택"
 
-#: ../src/views/lighttable.c:972
+#: ../src/views/lighttable.c:1176
 msgid "add image to or remove it from a selection"
 msgstr "선택에 이미지 추가 또는 제거"
 
-#: ../src/views/lighttable.c:976
+#: ../src/views/lighttable.c:1181
 msgid "change image order"
 msgstr "이미지 순서 변경"
 
-#: ../src/views/lighttable.c:983
+#: ../src/views/lighttable.c:1190
 msgid "zoom all the images"
 msgstr "모든 이미지 확대"
 
-#: ../src/views/lighttable.c:984
+#: ../src/views/lighttable.c:1192
 msgid "pan inside all the images"
 msgstr "모든 이미지 내부 이동"
 
-#: ../src/views/lighttable.c:986
+#: ../src/views/lighttable.c:1195
 msgid "zoom current image"
 msgstr "현재 이미지 확대"
 
-#: ../src/views/lighttable.c:987
+#: ../src/views/lighttable.c:1197
 msgid "pan inside current image"
 msgstr "현재 이미지 내부 이동"
 
-#: ../src/views/lighttable.c:992
+#: ../src/views/lighttable.c:1203
 #, no-c-format
 msgid "zoom current image to 100% and back"
 msgstr "현재 이미지 100% 확대/돌아오기"
 
-#: ../src/views/lighttable.c:996
+#: ../src/views/lighttable.c:1208
 msgid "zoom the main view"
 msgstr "메인 보기 확대"
 
-#: ../src/views/lighttable.c:997
+#: ../src/views/lighttable.c:1210
 msgid "pan inside the main view"
 msgstr "메인 보기 내에서 이동"
 
-#: ../src/views/lighttable.c:1239
+#: ../src/views/lighttable.c:1470
 msgid "set display profile"
 msgstr "디스플레이 프로파일 설정"
 
-#: ../src/views/lighttable.c:1324
+#: ../src/views/lighttable.c:1567
 msgid "whole"
 msgstr "전체"
 
-#: ../src/views/lighttable.c:1340
+#: ../src/views/lighttable.c:1595
 msgid "leave"
 msgstr "나가기"
 
-#: ../src/views/lighttable.c:1347
+#: ../src/views/lighttable.c:1604
 msgid "align images to grid"
 msgstr "이미지를 격자에 정렬"
 
-#: ../src/views/lighttable.c:1348
+#: ../src/views/lighttable.c:1606
 msgid "reset first image offset"
 msgstr "첫 이미지 오프셋 리셋"
 
-#: ../src/views/lighttable.c:1349
+#: ../src/views/lighttable.c:1608
 msgid "select toggle image"
 msgstr "이미지 선택 전환"
 
-#: ../src/views/lighttable.c:1350
+#: ../src/views/lighttable.c:1610
 msgid "select single image"
 msgstr "단일 이미지 선택"
 
 #. zoom for full culling & preview
-#: ../src/views/lighttable.c:1357
+#: ../src/views/lighttable.c:1620
 msgid "preview zoom 100%"
 msgstr "미리보기 100% 확대"
 
-#: ../src/views/lighttable.c:1358
+#: ../src/views/lighttable.c:1622
 msgid "preview zoom fit"
 msgstr "미리보기 화면 맞춤"
 
-#: ../src/views/lighttable.c:1362
+#: ../src/views/lighttable.c:1628
 msgid "zoom max"
 msgstr "최대 확대"
 
-#: ../src/views/lighttable.c:1364
+#: ../src/views/lighttable.c:1632
 msgid "zoom min"
 msgstr "최소 확대"
 
-#: ../src/views/map.c:2405
+#: ../src/views/map.c:2407
 msgid "scroll right"
 msgstr "오른쪽으로 스크롤"
 
-#: ../src/views/map.c:2407
+#: ../src/views/map.c:2409
 msgid "scroll right wide"
 msgstr "오른쪽으로 크게 스크롤"
 
-#: ../src/views/map.c:2409
+#: ../src/views/map.c:2411
 msgid "scroll left"
 msgstr "왼쪽으로 스크롤"
 
-#: ../src/views/map.c:2411
+#: ../src/views/map.c:2413
 msgid "scroll left wide"
 msgstr "왼쪽으로 크게 스크롤"
 
-#: ../src/views/map.c:2413
+#: ../src/views/map.c:2415
 msgid "scroll up"
 msgstr "위로 스크롤"
 
-#: ../src/views/map.c:2415
+#: ../src/views/map.c:2417
 msgid "scroll up wide"
 msgstr "위로 크게 스크롤"
 
-#: ../src/views/map.c:2417
+#: ../src/views/map.c:2419
 msgid "scroll down"
 msgstr "아래로 스크롤"
 
-#: ../src/views/map.c:2419
+#: ../src/views/map.c:2421
 msgid "scroll down wide"
 msgstr "아래로 크게 스크롤"
 
-#: ../src/views/map.c:3206
+#: ../src/views/map.c:3208
 msgid "[on image] open in darkroom"
 msgstr "[이미지] darkroom에서 열기"
 
-#: ../src/views/map.c:3208
+#: ../src/views/map.c:3210
 msgid "[on map] zoom map"
 msgstr "[지도] 지도 확대/축소"
 
-#: ../src/views/map.c:3210
+#: ../src/views/map.c:3212
 msgid "move image location"
 msgstr "이미지 위치 이동"
 
@@ -29155,47 +33601,47 @@ msgstr "새 세션 시작됨: '%s'"
 msgid "no camera with tethering support available for use..."
 msgstr "테더링을 지원하는 사용 가능한 카메라가 없습니다..."
 
-#: ../src/views/view.c:1410
+#: ../src/views/view.c:1567
 msgid "left-click"
 msgstr "클릭"
 
-#: ../src/views/view.c:1413
+#: ../src/views/view.c:1570
 msgid "right-click"
 msgstr "우클릭"
 
-#: ../src/views/view.c:1416
+#: ../src/views/view.c:1573
 msgid "middle-click"
 msgstr "가운데 클릭"
 
-#: ../src/views/view.c:1422
+#: ../src/views/view.c:1579
 msgid "left double-click"
 msgstr "더블 클릭"
 
-#: ../src/views/view.c:1425
+#: ../src/views/view.c:1582
 msgid "right double-click"
 msgstr "더블 우클릭"
 
-#: ../src/views/view.c:1428
+#: ../src/views/view.c:1585
 msgid "drag and drop"
 msgstr "드래그 앤 드롭"
 
-#: ../src/views/view.c:1431
+#: ../src/views/view.c:1588
 msgid "left-click+drag"
 msgstr "좌클릭 후 드래그"
 
-#: ../src/views/view.c:1434
+#: ../src/views/view.c:1591
 msgid "right-click+drag"
 msgstr "우클릭 후 드래그"
 
-#: ../src/views/view.c:1456
+#: ../src/views/view.c:1612
 msgid "darktable - accels window"
 msgstr "darktable - 단축키 창"
 
-#: ../src/views/view.c:1503
+#: ../src/views/view.c:1659
 msgid "switch to a classic window which will stay open after key release"
 msgstr "키를 뗀 후에도 창이 닫히지 않는 클래식 창으로 전환"
 
 #. we add the mouse actions too
-#: ../src/views/view.c:1569
+#: ../src/views/view.c:1725
 msgid "mouse actions"
 msgstr "마우스 동작"


### PR DESCRIPTION
Updated the Korean catalogue against the 2026-07-24 POT.

- 543 newly translated strings, 61 obsolete entries dropped
- 0 untranslated, 0 fuzzy, so it now meets the entry criteria in
  `doc/TRANSLATORS.md`. It had drifted from the 2025-11-13 POT, which is
  why it was dropped from recent releases.
- Terminology follows the existing translation; lighttable / darkroom /
  darktable are left untranslated as before
- Header: filled in the unedited template comment block, listing previous
  contributors by year; updated `Last-Translator` and `PO-Revision-Date`.
  `Language-Team` left untouched.

Two fixes beyond the merge:

- `do you really want to delete the duplicate (without deleting the source
  image file on disk)?` carried a stray `%d` and text copied from another
  message. It is used as a printf format by `dt_gui_show_yes_no_dialog()`,
  so it read an undefined argument.
- Removed the leftover template `fuzzy` flag on the header entry — some
  msgfmt implementations skip fuzzy entries and thus discard the header
  along with the charset and plural-forms metadata.

Tested as described on the wiki: built the .mo, placed it in
`share/locale/ko_KR/LC_MESSAGES/`, and confirmed the UI in darktable 5.6.0.
