### PR TITLE
Fixes #21594 and #21606 by gating on `off_image` geometry

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -3093,10 +3093,19 @@ _dev_mask_overlay_bounds(const dt_develop_t *dev, float *x0, float *y0, float *x
     if(!gpt)
       continue;
 
-    // points[], border[] and source[] are interleaved (x, y) pairs
-    const float *const arrays[3] = { gpt->points, gpt->border, gpt->source };
-    const int counts[3] = { gpt->points_count, gpt->border_count, gpt->source_count };
-    for(int a = 0; a < 3; a++)
+    // points[] (shape outline) and source[] (clone source) are interleaved
+    // (x, y) pairs. The feather border[] is deliberately excluded: it is not a
+    // drag target, so it shouldn't enlarge the pannable region, and its
+    // degenerate segments are flagged with DT_INVALID_COORDINATE (== -FLT_MAX)
+    // sentinels. Folding those (or any other stray non-finite / extreme value)
+    // into the box would blow it up to ~1e35 and let the viewport pan away from
+    // the image without bound. Reject anything outside a generous window around
+    // the image (32x its size — far more than any reachable handle) so a single
+    // bad coordinate can't defeat the clamp.
+    const float *const arrays[2] = { gpt->points, gpt->source };
+    const int counts[2] = { gpt->points_count, gpt->source_count };
+    const float limx = 32.0f * wd, limy = 32.0f * ht;
+    for(int a = 0; a < 2; a++)
     {
       const float *p = arrays[a];
       if(!p)
@@ -3105,6 +3114,8 @@ _dev_mask_overlay_bounds(const dt_develop_t *dev, float *x0, float *y0, float *x
       {
         const float px = p[i * 2];
         const float py = p[i * 2 + 1];
+        if(!isfinite(px) || !isfinite(py) || px <= -limx || px >= limx || py <= -limy || py >= limy)
+          continue;
         minx = fminf(minx, px);
         maxx = fmaxf(maxx, px);
         miny = fminf(miny, py);

--- a/src/develop/masks.h
+++ b/src/develop/masks.h
@@ -650,6 +650,13 @@ void dt_masks_gui_form_create(dt_masks_form_t *form,
 void dt_masks_gui_form_remove(dt_masks_form_t *form,
                               dt_masks_form_gui_t *gui,
                               const int index);
+// Constrain a drag target (in preview/processed-pipe pixel coords, wd/ht =
+// processed image size) so it stays within the image expanded by
+// DT_MASKS_MOVE_MARGIN. Used when translating a whole form / its anchor / clone
+// source so the dragged control point stays within the image or reasonably
+// close, instead of being movable to an arbitrary distance where the shape
+// would be lost.
+void dt_masks_clamp_move_pts(float *pts, const float wd, const float ht);
 void dt_masks_gui_form_test_create(dt_masks_form_t *form,
                                    dt_masks_form_gui_t *gui,
                                    const struct dt_iop_module_t *module);

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -2141,6 +2141,7 @@ static int _brush_events_button_released(dt_iop_module_t *module,
     // we get point0 new values
     dt_masks_point_brush_t *point = (form->points)->data;
     float pts[2] = { pzx * wd + gui->dx, pzy * ht + gui->dy };
+    dt_masks_clamp_move_pts(pts, wd, ht);
     dt_dev_distort_backtransform(darktable.develop, pts, 1);
     float dx = pts[0] / iwidth - point->corner[0];
     float dy = pts[1] / iheight - point->corner[1];
@@ -2171,6 +2172,7 @@ static int _brush_events_button_released(dt_iop_module_t *module,
 
     // we change the source value
     float pts[2] = { pzx * wd + gui->dx, pzy * ht + gui->dy };
+    dt_masks_clamp_move_pts(pts, wd, ht);
     dt_dev_distort_backtransform(darktable.develop, pts, 1);
     form->source[0] = pts[0] / iwidth;
     form->source[1] = pts[1] / iheight;
@@ -2546,6 +2548,7 @@ static int _brush_events_mouse_moved(struct dt_iop_module_t *module,
   else if(gui->form_dragging || gui->source_dragging)
   {
     float pts[2] = { pzx * wd + gui->dx, pzy * ht + gui->dy };
+    dt_masks_clamp_move_pts(pts, wd, ht);
     dt_dev_distort_backtransform(darktable.develop, pts, 1);
 
     // we move all points

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -440,6 +440,7 @@ static int _circle_events_button_released(dt_iop_module_t *module,
 
     // we change the center value
     float pts[2] = { pzx * wd + gui->dx, pzy * ht + gui->dy };
+    dt_masks_clamp_move_pts(pts, wd, ht);
     dt_dev_distort_backtransform(darktable.develop, pts, 1);
     circle->center[0] = pts[0] / iwidth;
     circle->center[1] = pts[1] / iheight;
@@ -470,6 +471,7 @@ static int _circle_events_button_released(dt_iop_module_t *module,
     {
       // we change the center value
       float pts[2] = { pzx * wd + gui->dx, pzy * ht + gui->dy };
+      dt_masks_clamp_move_pts(pts, wd, ht);
 
       dt_dev_distort_backtransform(darktable.develop, pts, 1);
 
@@ -523,6 +525,7 @@ static int _circle_events_mouse_moved(dt_iop_module_t *module,
     float wd, ht, iwidth, iheight;
     dt_masks_get_image_size(&wd, &ht, &iwidth, &iheight);
     float pts[2] = { pzx * wd + gui->dx, pzy * ht + gui->dy };
+    dt_masks_clamp_move_pts(pts, wd, ht);
     dt_dev_distort_backtransform(darktable.develop, pts, 1);
 
     if(gui->form_dragging)

--- a/src/develop/masks/ellipse.c
+++ b/src/develop/masks/ellipse.c
@@ -840,6 +840,7 @@ static int _ellipse_events_button_released(dt_iop_module_t *module,
 
     // we change the center value
     float pts[2] = { pzx * wd + gui->dx, pzy * ht + gui->dy };
+    dt_masks_clamp_move_pts(pts, wd, ht);
     dt_dev_distort_backtransform(darktable.develop, pts, 1);
     ellipse->center[0] = pts[0] / iwidth;
     ellipse->center[1] = pts[1] / iheight;
@@ -1012,6 +1013,7 @@ static int _ellipse_events_button_released(dt_iop_module_t *module,
     {
       // we change the center value
       float pts[2] = { pzx * wd + gui->dx, pzy * ht + gui->dy };
+      dt_masks_clamp_move_pts(pts, wd, ht);
 
       dt_dev_distort_backtransform(darktable.develop, pts, 1);
 
@@ -1057,6 +1059,7 @@ static int _ellipse_events_mouse_moved(dt_iop_module_t *module,
     float wd, ht, iwidth, iheight;
     dt_masks_get_image_size(&wd, &ht, &iwidth, &iheight);
     float pts[2] = { pzx * wd + gui->dx, pzy * ht + gui->dy };
+    dt_masks_clamp_move_pts(pts, wd, ht);
     dt_dev_distort_backtransform(darktable.develop, pts, 1);
 
     if(gui->form_dragging)

--- a/src/develop/masks/gradient.c
+++ b/src/develop/masks/gradient.c
@@ -387,6 +387,7 @@ static int _gradient_events_button_released(dt_iop_module_t *module,
 
     // we change the center value
     float pts[2] = { pzx * wd + gui->dx, pzy * ht + gui->dy };
+    dt_masks_clamp_move_pts(pts, wd, ht);
     dt_dev_distort_backtransform(darktable.develop, pts, 1);
 
     gradient->anchor[0] = pts[0] / iwidth;
@@ -558,6 +559,7 @@ static int _gradient_events_mouse_moved(dt_iop_module_t *module,
     dt_masks_get_image_size(&wd, &ht, &iwidth, &iheight);
 
     float pts[2] = { pzx * wd + gui->dx, pzy * ht + gui->dy };
+    dt_masks_clamp_move_pts(pts, wd, ht);
     dt_dev_distort_backtransform(darktable.develop, pts, 1);
 
     gradient->anchor[0] = pts[0] / iwidth;

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -243,6 +243,18 @@ void dt_masks_gui_form_remove(dt_masks_form_t *form,
   }
 }
 
+// Maximum fraction of the image dimension by which a dragged mask node /
+// anchor / clone source may be pushed outside the image.
+#define DT_MASKS_MOVE_MARGIN 0.5f
+
+void dt_masks_clamp_move_pts(float *pts, const float wd, const float ht)
+{
+  const float mx = DT_MASKS_MOVE_MARGIN * wd;
+  const float my = DT_MASKS_MOVE_MARGIN * ht;
+  pts[0] = fminf(fmaxf(pts[0], -mx), wd + mx);
+  pts[1] = fminf(fmaxf(pts[1], -my), ht + my);
+}
+
 void dt_masks_gui_form_test_create(dt_masks_form_t *form,
                                    dt_masks_form_gui_t *gui,
                                    const dt_iop_module_t *module)

--- a/src/develop/masks/path.c
+++ b/src/develop/masks/path.c
@@ -3518,6 +3518,7 @@ static int _path_events_button_released(dt_iop_module_t *module,
     // we get point0 new values
     dt_masks_point_path_t *point = form->points->data;
     float pts[2] = { pzx * wd + gui->dx, pzy * ht + gui->dy };
+    dt_masks_clamp_move_pts(pts, wd, ht);
     dt_dev_distort_backtransform(darktable.develop, pts, 1);
     const float dx = pts[0] / iwidth - point->corner[0];
     const float dy = pts[1] / iheight - point->corner[1];
@@ -3571,6 +3572,7 @@ static int _path_events_button_released(dt_iop_module_t *module,
 
     // we change the source value
     float pts[2] = { pzx * wd + gui->dx, pzy * ht + gui->dy };
+    dt_masks_clamp_move_pts(pts, wd, ht);
     dt_dev_distort_backtransform(darktable.develop, pts, 1);
     form->source[0] = pts[0] / iwidth;
     form->source[1] = pts[1] / iheight;
@@ -3823,6 +3825,7 @@ static int _path_events_mouse_moved(dt_iop_module_t *module,
   else if(gui->form_dragging || gui->source_dragging)
   {
     float pts[2] = { pzx * wd + gui->dx, pzy * ht + gui->dy };
+    dt_masks_clamp_move_pts(pts, wd, ht);
     dt_dev_distort_backtransform(darktable.develop, pts, 1);
 
     // we move all points

--- a/src/libs/navigation.c
+++ b/src/libs/navigation.c
@@ -307,6 +307,68 @@ void gui_cleanup(dt_lib_module_t *self)
   self->data = NULL;
 }
 
+// Draw a small arrow on the thumbnail border pointing toward the viewport
+// centre when it has been panned outside the image (e.g. reaching off-image
+// mask handles), where the view box would otherwise shrink to nothing and
+// vanish. Expects the current transform to map the thumbnail image to
+// [0,wd]x[0,ht]; scale is that transform's scale (to keep the outline 1px).
+static void _draw_offview_arrow(cairo_t *cr,
+                                const int wd,
+                                const int ht,
+                                const float zoom_x,
+                                const float zoom_y,
+                                const float scale)
+{
+  const float cx = wd * (0.5f + zoom_x);
+  const float cy = ht * (0.5f + zoom_y);
+  if(cx >= 0.0f && cx <= wd && cy >= 0.0f && cy <= ht)
+    return; // view centre still inside the thumbnail: the box itself suffices
+
+  const float ox = 0.5f * wd, oy = 0.5f * ht;
+  float dx = cx - ox, dy = cy - oy;
+  const float dlen = hypotf(dx, dy);
+  if(dlen <= 1e-3f)
+    return;
+
+  dx /= dlen;
+  dy /= dlen;
+  // where the centre->view ray exits the image rectangle
+  float t = 1e9f;
+  if(dx > 0.0f)
+    t = fminf(t, (wd - ox) / dx);
+  else if(dx < 0.0f)
+    t = fminf(t, (0.0f - ox) / dx);
+  if(dy > 0.0f)
+    t = fminf(t, (ht - oy) / dy);
+  else if(dy < 0.0f)
+    t = fminf(t, (0.0f - oy) / dy);
+  t = fmaxf(0.0f, t);
+
+  // Draw a chevron ( ">" shape ) whose apex points outward along the view
+  // direction: an open two-armed stroke reads its direction more clearly than
+  // a solid triangle.
+  const float a = fminf(wd, ht) * 0.08f;          // chevron reach in thumbnail units
+  const float tipx = ox + dx * t - dx * a * 0.3f; // apex just inside the border
+  const float tipy = oy + dy * t - dy * a * 0.3f;
+  const float perpx = -dy, perpy = dx;
+  const float spread = a * 0.85f; // half-width of the arms (~90 deg opening)
+  const float ax1 = tipx - dx * a + perpx * spread, ay1 = tipy - dy * a + perpy * spread;
+  const float ax2 = tipx - dx * a - perpx * spread, ay2 = tipy - dy * a - perpy * spread;
+
+  cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
+  cairo_set_line_join(cr, CAIRO_LINE_JOIN_ROUND);
+  cairo_move_to(cr, ax1, ay1);
+  cairo_line_to(cr, tipx, tipy);
+  cairo_line_to(cr, ax2, ay2);
+  // dark halo first, then a white core, so it reads on any background
+  cairo_set_source_rgba(cr, 0., 0., 0., 0.7);
+  cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(4) / scale);
+  cairo_stroke_preserve(cr);
+  cairo_set_source_rgb(cr, 1., 1., 1.);
+  cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(2) / scale);
+  cairo_stroke(cr);
+}
+
 static gboolean _lib_navigation_draw_callback(GtkWidget *widget,
                                               cairo_t *crf,
                                               gpointer user_data)
@@ -358,7 +420,10 @@ static gboolean _lib_navigation_draw_callback(GtkWidget *widget,
       cairo_set_source_rgba(cr, 0, 0, 0, 0.5);
       cairo_fill(cr);
 
-      // Repaint the original image in the area of interest
+      // Repaint the original image in the area of interest. Isolate the box
+      // clip/translate in its own save so the off-view arrow below is drawn in
+      // plain thumbnail coordinates.
+      cairo_save(cr);
       cairo_set_source_surface(cr, surface, 0, 0);
       cairo_translate(cr, wd * (.5f + zoom_x), ht * (.5f + zoom_y));
       boxw *= wd;
@@ -376,6 +441,12 @@ static gboolean _lib_navigation_draw_callback(GtkWidget *widget,
       cairo_set_source_rgb(cr, 1., 1., 1.);
       cairo_rectangle(cr, -boxw / 2, -boxh / 2, boxw, boxh);
       cairo_stroke(cr);
+      cairo_restore(cr);
+
+      // While editing a mask the viewport can be panned outside the image; the
+      // view box then shrinks against the thumbnail edge and disappears, losing
+      // any sense of where one is looking. Point an arrow the way it has gone.
+      _draw_offview_arrow(cr, wd, ht, zoom_x, zoom_y, scale);
     }
     cairo_restore(cr);
 

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -706,24 +706,39 @@ void expose(dt_view_t *self,
       force a resizing in next expose.  So we disable in cases close
       to full.
 
-      This near-fit centring is applied only to the values handed to the
-      scrollbar; the real zoom_x/zoom_y are kept for rendering so the mask
-      overlay (and guides/pickers) follow the image exactly even when the
-      user has deliberately panned off-canvas below the fit zoom to reach
-      mask handles outside the image. Zeroing them here would pin the
-      overlay at the image centre while the image itself (and raster mask
-      overlay) follow the pan, breaking alignment below fit.
+      The scrollbar always gets this near-fit centring (sb_zoom_*). The real
+      zoom_x/zoom_y feeding the overlay coordinate frame below are kept
+      un-centred ONLY while a mask is being edited: there the user may
+      deliberately pan off-canvas below the fit zoom to reach mask handles
+      outside the image, and zeroing them would pin the overlay at the image
+      centre while the image itself (and raster mask overlay) follow the pan,
+      breaking alignment. When no mask is being edited we centre them exactly
+      as darktable did before the off-canvas panning was added, so guides,
+      colour pickers and the crop module's dimming can't drift off the image
+      on a nonzero stored viewport centre -- e.g. entering the crop module
+      shows the uncropped image, reprojecting port->zoom_x against the larger
+      processed size into a nonzero centre that would otherwise shift the crop
+      overlay into a grey band beside the picture.
   */
+  // Mask editing (including creation) is the only state that relaxes the pan
+  // clamp to allow the viewport past the image; it is disabled while the crop
+  // overlay is active, so form_visible is NULL there.
+  const gboolean mask_editing = dev->form_visible != NULL;
+
   float sb_zoom_x = zoom_x, sb_zoom_y = zoom_y, sb_boxw = boxw, sb_boxh = boxh;
   if(boxw > 0.95f)
   {
     sb_zoom_x = .0f;
     sb_boxw = 1.01f;
+    if(!mask_editing)
+      zoom_x = .0f;
   }
   if(boxh > 0.95f)
   {
     sb_zoom_y = .0f;
     sb_boxh = 1.01f;
+    if(!mask_editing)
+      zoom_y = .0f;
   }
 
   dt_view_set_scrollbar(self,
@@ -1010,13 +1025,17 @@ void expose(dt_view_t *self,
         "expose masks",
          port->pipe, dev->gui_module, DT_DEVICE_NONE, NULL, NULL, "%dx%d, px=%d py=%d",
          width, height, pointerx, pointery);
-    // Clip to viewport (excluding border) so mask overlays don't
-    // bleed into the grey border when the image is zoomed in.
+    // Clip the mask overlay to the full viewport. Mask control points can be
+    // placed outside the image, in the expanded grey canvas around it; insetting
+    // the clip by the grey border (tb) as we used to would hide those off-image
+    // handles and segments behind an invisible border a few pixels in from the
+    // window edge. The grey-border containment the inset provided no longer
+    // applies now that masks legitimately extend past the image.
     cairo_save(cri);
-    const float vp_w = (width - 2.0f * tb) / zoom_scale;
-    const float vp_h = (height - 2.0f * tb) / zoom_scale;
-    const float vp_x = (tb - 0.5f * width) / zoom_scale + 0.5f * wd + zoom_x * wd;
-    const float vp_y = (tb - 0.5f * height) / zoom_scale + 0.5f * ht + zoom_y * ht;
+    const float vp_w = width / zoom_scale;
+    const float vp_h = height / zoom_scale;
+    const float vp_x = -0.5f * width / zoom_scale + 0.5f * wd + zoom_x * wd;
+    const float vp_y = -0.5f * height / zoom_scale + 0.5f * ht + zoom_y * ht;
     cairo_rectangle(cri, vp_x, vp_y, vp_w, vp_h);
     cairo_clip(cri);
     // Mask overlay points are in preview-pipe output space; shift the

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -1946,36 +1946,106 @@ void dt_view_paint_surface(cairo_t *cr,
   const int maxw = MIN(port->width, backbuf_scale * processed_width * (1<<closeup) / ppd);
   const int maxh = MIN(port->height, backbuf_scale * processed_height * (1<<closeup) / ppd);
 
-  // Position the clip (and assessment frame) from the viewport centre (zoom) and
-  // the IMAGE's own geometry, NOT from the backbuf ROI centre (offset). The ROI
-  // centre is clamped to the image, and while the viewport is panned outside the
-  // picture to reach off-image mask handles it lags the live zoom in discrete
-  // re-render steps. Driving the clip from it made the clip sawtooth back and
-  // forth on every re-render, even though the image content -- scaled from the
-  // backbuf to the live zoom by back_scale below -- stays put. img_w/img_h are
-  // the full image in screen pixels; on screen the image spans
+  // img_w/img_h are the full image in screen pixels; on screen the image spans
   // [(-0.5 - zoom) * img .. (0.5 - zoom) * img] about the viewport centre.
   const double img_w = processed_width * backbuf_scale * (1 << closeup) / ppd;
   const double img_h = processed_height * backbuf_scale * (1 << closeup) / ppd;
 
+  // Visible image rectangle: the image, panned by zoom_x/zoom_y, intersected
+  // with the viewport. Used for the color-assessment frame (always) and, when
+  // panned off-image, for the clip.
+  const double vis_x0 = fmax(-0.5 * port->width, (-0.5 - zoom_x) * img_w);
+  const double vis_x1 = fmin(0.5 * port->width, (0.5 - zoom_x) * img_w);
+  const double vis_y0 = fmax(-0.5 * port->height, (-0.5 - zoom_y) * img_h);
+  const double vis_y1 = fmin(0.5 * port->height, (0.5 - zoom_y) * img_h);
+
+  // Whether the viewport is panned beyond the image, i.e. off-image content is
+  // deliberately in view. In normal use the pan clamp keeps the viewport inside
+  // the picture, so this is FALSE; it only becomes TRUE while editing a mask,
+  // where the clamp is relaxed to reach handles outside the image (see
+  // _clamp_zoom_to_mask). We keep darktable's original clip and coverage
+  // behaviour in the normal case so a stale backbuf lagging a drag can't leave a
+  // grey seam at the border (#21606) or a growing frame over the grey
+  // background (#21594); the viewport-centre-driven geometry is used only for
+  // the off-image mask-editing case it was introduced for.
+  const float halfw_img = img_w > 0 ? 0.5f * port->width / (float)img_w : 0.5f;
+  const float halfh_img = img_h > 0 ? 0.5f * port->height / (float)img_h : 0.5f;
+  const gboolean off_image =
+       fabsf(zoom_x) > fmaxf(0.0f, 0.5f - halfw_img) + 1e-4f
+    || fabsf(zoom_y) > fmaxf(0.0f, 0.5f - halfh_img) + 1e-4f;
+
   if(port->color_assessment
      && window != DT_WINDOW_SLIDESHOW)
   {
-    // draw the white frame around picture
+    // draw the white frame hugging the visible image edge. Sized from the
+    // visible rectangle (image intersected with viewport) so it can't grow out
+    // across the grey background as you zoom in (#21594).
     const double ratio = dt_conf_get_float("darkroom/ui/color_assessment_border_white_ratio");
-    const double borw = img_w + 2.0 * tb * ratio;
-    const double borh = img_h + 2.0 * tb * ratio;
-    cairo_rectangle(cr, -0.5 * borw - zoom_x * img_w, -0.5 * borh - zoom_y * img_h, borw, borh);
+    const double borw = fmax(0.0, vis_x1 - vis_x0) + 2.0 * tb * ratio;
+    const double borh = fmax(0.0, vis_y1 - vis_y0) + 2.0 * tb * ratio;
+    cairo_rectangle(cr, vis_x0 - tb * ratio, vis_y0 - tb * ratio, borw, borh);
     dt_gui_gtk_set_source_rgb(cr, DT_GUI_COLOR_COLOR_ASSESSMENT_FG);
     cairo_fill(cr);
+
+    // The frame keeps a full white surround on all four sides even when the
+    // viewport shows only part of the image (zoomed past fit, or the canvas
+    // scrolled off the picture while editing a mask). A solid white border on
+    // every side then wrongly implies the whole image is present. So on any
+    // side whose *real* image edge is scrolled out of view, mark that side's
+    // white margin with a dashed line (in the assessment background grey) to
+    // signal "the image continues beyond here". A side whose real edge is in
+    // view keeps its crisp, solid white border.
+    const double rx0 = (-0.5 - zoom_x) * img_w, rx1 = (0.5 - zoom_x) * img_w;
+    const double ry0 = (-0.5 - zoom_y) * img_h, ry1 = (0.5 - zoom_y) * img_h;
+    const double eps = 1.0;
+    const gboolean cut_l = rx0 < -0.5 * port->width - eps;
+    const gboolean cut_r = rx1 > 0.5 * port->width + eps;
+    const gboolean cut_t = ry0 < -0.5 * port->height - eps;
+    const gboolean cut_b = ry1 > 0.5 * port->height + eps;
+    if(cut_l || cut_r || cut_t || cut_b)
+    {
+      cairo_save(cr);
+      dt_gui_gtk_set_source_rgb(cr, DT_GUI_COLOR_COLOR_ASSESSMENT_BG);
+      const double d = DT_PIXEL_APPLY_DPI(6.0);
+      const double dashes[2] = { d, d };
+      cairo_set_dash(cr, dashes, 2, 0.0);
+      cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(2.0));
+      const double m = 0.5 * tb * ratio; // centre the dash in the white margin
+      if(cut_l)
+      {
+        cairo_move_to(cr, vis_x0 - m, vis_y0);
+        cairo_line_to(cr, vis_x0 - m, vis_y1);
+      }
+      if(cut_r)
+      {
+        cairo_move_to(cr, vis_x1 + m, vis_y0);
+        cairo_line_to(cr, vis_x1 + m, vis_y1);
+      }
+      if(cut_t)
+      {
+        cairo_move_to(cr, vis_x0, vis_y0 - m);
+        cairo_line_to(cr, vis_x1, vis_y0 - m);
+      }
+      if(cut_b)
+      {
+        cairo_move_to(cr, vis_x0, vis_y1 + m);
+        cairo_line_to(cr, vis_x1, vis_y1 + m);
+      }
+      cairo_stroke(cr);
+      cairo_restore(cr);
+    }
   }
 
-  // clip to the image rectangle intersected with the viewport
-  const double clip_x0 = fmax(-0.5 * port->width, (-0.5 - zoom_x) * img_w);
-  const double clip_x1 = fmin(0.5 * port->width, (0.5 - zoom_x) * img_w);
-  const double clip_y0 = fmax(-0.5 * port->height, (-0.5 - zoom_y) * img_h);
-  const double clip_y1 = fmin(0.5 * port->height, (0.5 - zoom_y) * img_h);
-  cairo_rectangle(cr, clip_x0, clip_y0, fmax(0.0, clip_x1 - clip_x0), fmax(0.0, clip_y1 - clip_y0));
+  if(off_image)
+    // Editing a mask with the viewport panned past the picture: clip to the
+    // image's true border (intersected with the viewport) so the off-image
+    // background shows where the handles are being placed.
+    cairo_rectangle(cr, vis_x0, vis_y0, fmax(0.0, vis_x1 - vis_x0), fmax(0.0, vis_y1 - vis_y0));
+  else
+    // Original darktable clip: MIN(viewport, image) centred on the viewport. It
+    // never sits exactly on the image border while zoomed in, so a backbuf that
+    // lags a drag can't leave a grey seam at the border (#21606).
+    cairo_rectangle(cr, -0.5 * maxw, -0.5 * maxh, maxw, maxh);
   cairo_clip(cr);
   const double back_scale = (buf_scale == 0 ? 1.0 : backbuf_scale / buf_scale) * (1<<closeup) / ppd;
   const double trans_x = (offset_x - zoom_x) * processed_width * buf_scale - 0.5 * buf_width;
@@ -1987,15 +2057,20 @@ void dt_view_paint_surface(cairo_t *cr,
   // handles, the backbuf centre (offset) can get no closer to the viewport centre
   // (zoom) than the image edge. Measuring against the raw zoom centre would keep
   // reporting the off-image (background) margin as "not covered" and re-trigger
-  // the pipe every frame, making the clip jitter. So measure against reach_*, the
-  // closest centre the renderer can actually reach: when offset already sits there
-  // a re-render cannot improve coverage, and the residual is harmless background.
-  const float rhx = 0.5f * buf_width / fmaxf(1.0f, (float)processed_width * buf_scale);
-  const float rhy = 0.5f * buf_height / fmaxf(1.0f, (float)processed_height * buf_scale);
-  const float reach_x = rhx >= 0.5f ? 0.0f : CLAMP(zoom_x, -(0.5f - rhx), 0.5f - rhx);
-  const float reach_y = rhy >= 0.5f ? 0.0f : CLAMP(zoom_y, -(0.5f - rhy), 0.5f - rhy);
-  const double cov_trans_x = (offset_x - reach_x) * processed_width * buf_scale - 0.5 * buf_width;
-  const double cov_trans_y = (offset_y - reach_y) * processed_height * buf_scale - 0.5 * buf_height;
+  // the pipe every frame. So in that case measure against the closest centre the
+  // renderer can actually reach. In normal use we measure against the real zoom
+  // centre, so a drag that brings the border into view still re-renders to fill
+  // it instead of leaving it grey.
+  float cov_zoom_x = zoom_x, cov_zoom_y = zoom_y;
+  if(off_image)
+  {
+    const float rhx = 0.5f * buf_width / fmaxf(1.0f, (float)processed_width * buf_scale);
+    const float rhy = 0.5f * buf_height / fmaxf(1.0f, (float)processed_height * buf_scale);
+    cov_zoom_x = rhx >= 0.5f ? 0.0f : CLAMP(zoom_x, -(0.5f - rhx), 0.5f - rhx);
+    cov_zoom_y = rhy >= 0.5f ? 0.0f : CLAMP(zoom_y, -(0.5f - rhy), 0.5f - rhy);
+  }
+  const double cov_trans_x = (offset_x - cov_zoom_x) * processed_width * buf_scale - 0.5 * buf_width;
+  const double cov_trans_y = (offset_y - cov_zoom_y) * processed_height * buf_scale - 0.5 * buf_height;
 
   // Check if we should use the preview pipe for fallback rendering
   // This is only valid for the main develop (not for pinned images which have dev != darktable.develop)


### PR DESCRIPTION
Both issues stem from PR #21382 driving the clip/frame/coverage from the _live_ viewport centre instead of the rendered backbuf position. I fixed them by **gating the new geometry on `off_image`** — whether the viewport is actually panned past the image, which the pan clamp only allows during off-image mask editing:

-   **`off_image == FALSE`  (all normal use):**  restores darktable's original clip (`MIN(viewport,image)`  centred, never sits on the border → no grey seam) and original coverage test (measured against real  `zoom`, so a drag that brings the border into view still re-renders to fill it).
-   **`off_image == TRUE`  (mask handle pushed off-image):**  keeps the new viewport-centre geometry it was introduced for.
-   **The color-assessment frame**  is now always sized from the visible rect (image ∩ viewport) + border, so it can't grow across the grey background (#21594) — and this matches the original geometry in normal use.

Fixes  #21594 and #21606.