### PR TITLE
add auto-rotate button using detected guide lines

### DIFF
--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -5341,6 +5341,7 @@ static void _event_auto_rotate_quad_callback(GtkWidget *widget,
   _swap_shadow_crop_box(p, g);
   dt_dev_add_history_item(darktable.develop, self, TRUE);
   _swap_shadow_crop_box(p, g);
+  _commit_crop_box(p, g);
 }
 
 static int _event_fit_v_button_clicked(GtkWidget *widget,
@@ -5629,13 +5630,12 @@ void commit_params(dt_iop_module_t *self,
   d->orthocorr = (p->mode == ASHIFT_MODE_GENERIC) ? 0.0f : p->orthocorr;
   d->aspect = (p->mode == ASHIFT_MODE_GENERIC) ? 1.0f : p->aspect;
 
-  if(dt_iop_has_focus(self)
-     || dt_isnan(p->cl)
+  if(dt_isnan(p->cl)
      || dt_isnan(p->cr)
      || dt_isnan(p->ct)
      || dt_isnan(p->cb))
   {
-    // if gui has focus we want to see the full uncropped image
+    // if crop parameters are not yet known, show the full image
     d->cl = 0.0f;
     d->cr = 1.0f;
     d->ct = 0.0f;

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -5318,6 +5318,31 @@ static void cropmode_callback(GtkWidget *widget, dt_iop_module_t *self)
   _swap_shadow_crop_box(p,g);
 }
 
+static void _event_auto_rotate_quad_callback(GtkWidget *widget,
+                                             dt_iop_module_t *self)
+{
+  DT_GUARD_GUI_UPDATE();
+
+  dt_iop_ashift_params_t *p = self->params;
+  dt_iop_ashift_gui_data_t *g = self->gui_data;
+
+  dt_iop_request_focus(self);
+
+  if(self->enabled)
+  {
+    do_fit(self, p, ASHIFT_FIT_ROTATION_BOTH_LINES);
+  }
+  else
+  {
+    g->jobcode = ASHIFT_JOBCODE_FIT;
+    g->jobparams = ASHIFT_FIT_ROTATION_BOTH_LINES;
+  }
+
+  _swap_shadow_crop_box(p, g);
+  dt_dev_add_history_item(darktable.develop, self, TRUE);
+  _swap_shadow_crop_box(p, g);
+}
+
 static int _event_fit_v_button_clicked(GtkWidget *widget,
                                        const GdkEventButton *event,
                                        dt_iop_module_t *self)
@@ -5965,6 +5990,10 @@ void gui_init(dt_iop_module_t *self)
   dt_shortcut_register(ac, 0, DT_ACTION_EFFECT_UP, GDK_KEY_bracketleft, GDK_MOD1_MASK);
   dt_shortcut_register(ac, 0, DT_ACTION_EFFECT_DOWN, GDK_KEY_bracketright, GDK_MOD1_MASK);
   dt_shortcut_register(ac, 0, 0, GDK_KEY_r, GDK_MOD1_MASK);
+
+  dt_bauhaus_widget_set_quad(g->rotation, self, dtgtk_cairo_paint_wand, FALSE,
+                             _event_auto_rotate_quad_callback,
+                             _("auto-rotate the image using detected structure"));
 
   g->cropmode = dt_bauhaus_combobox_from_params(self, "cropmode");
   g_signal_connect(G_OBJECT(g->cropmode), "value-changed",


### PR DESCRIPTION
Add an auto rotate button to the rotation slider that uses detected structure lines to compute the best rotation angle.

Also always apply the crop values in commit_params so the result is visible immediately without needing to leave the module