### PR TITLE
Log strerror on AI models/cache directory creation failure

### DIFF
--- a/src/common/ai_models.c
+++ b/src/common/ai_models.c
@@ -27,6 +27,7 @@
 #include <archive.h>
 #include <archive_entry.h>
 #include <curl/curl.h>
+#include <errno.h>
 #include <json-glib/json-glib.h>
 #include <stdlib.h>
 #include <string.h>
@@ -397,12 +398,14 @@ static gboolean _setup_registry(dt_ai_registry_t *registry)
   gboolean ok = TRUE;
   if(!_ensure_directory(models))
   {
-    dt_print(DT_DEBUG_ALWAYS, "[ai_models] cannot create models dir: %s", models);
+    dt_print(DT_DEBUG_ALWAYS, "[ai_models] cannot create models dir %s: %s",
+             models, strerror(errno));
     ok = FALSE;
   }
   if(!_ensure_directory(cache))
   {
-    dt_print(DT_DEBUG_ALWAYS, "[ai_models] cannot create cache dir: %s", cache);
+    dt_print(DT_DEBUG_ALWAYS, "[ai_models] cannot create cache dir %s: %s",
+             cache, strerror(errno));
     ok = FALSE;
   }
 


### PR DESCRIPTION
Related to #21651

When `_setup_registry` fails to create the AI models or cache dir, we currently log just `cannot create models dir: <path>` – no reason. In the linked issue the reporter's `.local` was root-owned, so the mkdir failed with EACCES, but the log didn't say so and it took a round of back-and-forth to identify the cause.

Append `strerror(errno)` to both messages so the log now reads `cannot create models dir <path>: Permission denied` (or whatever the actual OS error is). Doesn't fix the underlying permission issue – darktable can't chown paths outside its own tree – just makes the next reporter's log self-explanatory.
