### PR TITLE
imageop: fix blank module instance names when not on top of history

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -1633,6 +1633,11 @@ void dt_dev_pop_history_items_ext(dt_develop_t *dev, const int32_t cnt)
     dt_iop_commit_blend_params(module, module->default_blendop_params, NULL);
     module->enabled = module->default_enabled;
 
+    // reset the instance name too: per-position state restored from
+    // history below, else a later rename would leak into earlier positions
+    module->multi_name_hand_edited = FALSE;
+    g_strlcpy(module->multi_name, "", sizeof(module->multi_name));
+
     if(module->multi_priority == 0)
       module->iop_order =
         dt_ioppr_get_iop_order(dev->iop_order_list, module->op, module->multi_priority);

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -1319,9 +1319,7 @@ static void _iop_panel_name(dt_iop_module_t *module)
 {
   // IOP instance name if any
 
-  // do not mess with panel name if we are not on the top of the history
-  if(darktable.develop->history_end < g_list_length(darktable.develop->history)
-    || !module->instance_name)
+  if(!module->instance_name)
     return;
 
   GtkLabel *iname = GTK_LABEL(module->instance_name);


### PR DESCRIPTION
Currently, when you have IOP modules with custom names, they disappear once you go back in editing history, switch back to lighttable and open the same image again, see screencast:

https://github.com/user-attachments/assets/3892ad3b-cef9-4e5b-a69e-95dcaa20fec0


The reason: `_iop_panel_name()` skipped painting the header label whenever history_end < the number of history entries, so every module's instance name stayed blank when an image was opened with its history slider below the top of the stack. multi_name is already restored per history position by dt_dev_pop_history_items(), so the label is correct at any position.

After the fix:

https://github.com/user-attachments/assets/fe7e91d8-2acf-4e54-b1a7-019635e55b36

CC: @TurboGit 
It might be good to get your feedback on this change, as you added it a long time ago in commit e93ec95a9c
I assume you treated the panel name as the module's current identity and you didn't want it flickering/blanking during history navigation, so the guard froze the labels while browsing a non-top state. This was solving a cosmetic concern (stable names during scrubbing) in a way that both displayed stale names and left names permanently blank on a non-top open. Since multi_name is always kept correct for the current position, unconditionally painting it is both simpler and more accurate — which is what the change does.

Disclaimer: this work has been co-created with Claude.