### PR TITLE
Fix cache clobbering and opencl nans on rusticl

### DIFF
--- a/data/kernels/colorspaces.cl
+++ b/data/kernels/colorspaces.cl
@@ -110,7 +110,6 @@ colorspaces_transform_gamma(read_only image2d_t in,
   float4 pixel = Areadpixel(in, x, y);
   // sanitize and fix NaN as we do for CPU
   pixel = select(fmax(pixel, -1e6f), (float4)(0.0f), isnan(pixel));
-
-  pixel = dtcl_pow(pixel, gamma);
+  pixel = copysign(dtcl_pow(fabs(pixel), gamma), pixel);
   write_imagef(out, (int2)(x, y), pixel);
 }

--- a/src/develop/imageop_math.c
+++ b/src/develop/imageop_math.c
@@ -163,14 +163,22 @@ void dt_iop_clip_and_zoom(float *out,
 
   DT_OMP_SIMD(aligned(in, linear : 16))
   for(size_t k = 0; k < (size_t)roi_in->width * roi_in->height*4; k += 4)
-    for_each_channel(c) linear[k+c] = powf(fmaxf(in[k+c], -1e6f), 2.4f);  // fmaxf sanitizes NaN
+    for_each_channel(c)
+    {
+      const float value = fmaxf(in[k+c], -1e6f);
+      linear[k+c] = copysignf(powf(fabsf(value), 2.4f), value);
+    }
 
   dt_interpolation_resample(itor, out, roi_out, linear, roi_in);
   dt_free_align(linear);
 
   DT_OMP_SIMD(aligned(out : 16))
   for(size_t k = 0; k < (size_t)roi_out->width * roi_out->height * 4; k += 4)
-    for_each_channel(c) out[k+c] = powf(out[k+c], 1.0f / 2.4f);
+    for_each_channel(c)
+    {
+      const float value = fmaxf(out[k+c], -1e6f);
+      out[k+c] = copysignf(powf(fabsf(value), 1.0f / 2.4f), value);
+    }
 }
 
 // apply clip and zoom on the image region supplied in the input buffer.

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -2277,11 +2277,16 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
 
         if(cl_mem_input)
         {
-          didconvert = success_opencl = dt_ioppr_transform_image_colorspace_cl(module, pipe->devid,
+          success_opencl = dt_ioppr_transform_image_colorspace_cl(module, pipe->devid,
                                                                   cl_mem_input, cl_mem_input,
                                                                   roi_in.width, roi_in.height,
                                                                   input_cst_cl, cst_to, &input_cst_cl,
                                                                   work_profile);
+          /* didconvert must mean the buffer contents actually changed colorspace.
+             transform_image_colorspace_cl() returns TRUE on success even when
+             cst_from == cst_to (no-op). Using that boolean alone would skip
+             legitimate unconverted input writebacks. */
+          didconvert = success_opencl && (cst_from != input_cst_cl);
         }
         else
         {
@@ -2544,6 +2549,12 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
           dt_opencl_release_mem_object(cl_mem_input);
           cl_mem_input = NULL;
           valid_input_on_gpu_only = FALSE;
+
+          /* In-place GPU colorspace convert + host writeback poisons the
+             upstream cache hash (same bug as the non-tiled important_cl_input
+             path). Drop the lying cacheline. */
+          if(didconvert)
+            dt_dev_pixelpipe_invalidate_cacheline(pipe, input);
         }
 
         // transform to module input colorspace if not done already
@@ -2723,8 +2734,22 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
 
         if(important_cl_input)
         {
-          /* write back input into cache for faster re-usal (full pipe or preview) */
-          if(cl_mem_input != NULL)
+          /* write back input into cache for faster re-usal (full pipe or preview).
+
+             IMPORTANT: cl_mem_input may have been colorspace-converted *in place*
+             on the GPU (see didconvert above). Copying that buffer back over the
+             upstream module's host cache line while keeping the upstream hash
+             poisons the pipecache: the same hash later returns data whose
+             colorspace no longer matches what that hash was created for. On the
+             next run, modules then either skip a needed conversion or apply the
+             wrong one, which shows up as black frames / burned colors when
+             enabling atrous, bilat, diffuse, etc.
+
+             Only write back when we did *not* convert. If we did convert, leave
+             valid_input_on_gpu_only set so the upstream cacheline is invalidated
+             below instead of keeping a lying hash.
+          */
+          if(cl_mem_input != NULL && !didconvert)
           {
             /* copy input to host memory, so we can find it in cache and wait via blocking flag */
             if(dt_opencl_copy_image_to_host(pipe->devid, input, cl_mem_input, roi_in.width, roi_in.height, in_bpp)
@@ -2745,6 +2770,13 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
 
               input_format->cst = input_cst_cl;
             }
+          }
+          else if(cl_mem_input != NULL && didconvert)
+          {
+            dt_print_pipe(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE,
+              "skip CL input cache writeback after colorspace convert",
+              pipe, module, pipe->devid, &roi_in, NULL);
+            important_cl_input = FALSE;
           }
         }
 


### PR DESCRIPTION
Hello all, I have a R9700 running RustICL for Darktable OpenCL.

Since the last few nightlies, I've noticed a lot of image corruption as I applied various effects, etc.

I put Grok-4.5 and GPT-5.6-Sol to work on these bugs and they seem to have been squashed now, across these two commits. A little less sure about the storyline behind the first one; that was found by Grok 4.5 and it just sounds like a really long time for the defect to go unnoticed.

More confident in GPT-5.6-Sol's response, it sounds and look reasonable enough, and the proof is in the pudding -- I now no longer get corrupted outputs when applying the `diffuse` module, `Contrast Equalizer`, etc.