### PR TITLE
Fix lighttable scroll on rate

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -146,6 +146,10 @@ changes (where available).
   rejecting with filmstrip auto-scroll disabled and the collection
   filtered to hide rejected images.
 
+- Fixed lighttable filemanager scrolling to the top when assigning
+  a star rating or color label while the first row was only partly
+  visible.
+
 ## Lua
 
 ### API Version

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -2684,6 +2684,15 @@ void dt_thumbtable_full_redraw(dt_thumbtable_t *table,
       // in filemanager, we need to take care of the center offset
       posx = table->center_offset;
 
+      // keep partial first-row scroll across forced redraws
+      // (rating/colorlabel → collection RELOAD)
+      if(table->thumb_size > 0)
+      {
+        posy = table->thumbs_area.y % table->thumb_size;
+        // cover the viewport when the first row is only partly shown
+        table->rows = (table->view_height - posy) / table->thumb_size + 1;
+      }
+
       // ensure that the overall layout doesn't change
       // (i.e. we don't get empty spaces in the very first row)
       offset = (table->offset - 1) / table->thumbs_per_row * table->thumbs_per_row + 1;


### PR DESCRIPTION
Fixes #21663 

Rating or color-labeling an image raises a collection RELOAD, which force-redraws the filemanager grid from y=0 and snaps a partially visible first row to the top of the view.
Preserve the residual thumbs_area.y across the redraw, and recompute rows so the viewport stays filled when the first row is only partly shown.