### PR TITLE
Fix full preview reject jump with filmstrip auto-scroll off

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -70,6 +70,9 @@ changes (where available).
 
 - Clarified multi-image rating toasts for un-reject and for mixed
   upgrade/downgrade results across the selection.
+- Fixed lighttable full preview jumping to the first image when
+  rejecting with filmstrip auto-scroll disabled and the collection
+  filtered to hide rejected images.
 
 ## Lua
 

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -2098,7 +2098,9 @@ static void _dt_collection_changed_callback(gpointer instance,
       if(tmpoff != table->offset_imgid)
       {
         old_offset = table->offset_imgid;
-        table->offset = _thumb_get_rowid(tmpoff);
+        const int active_rowid = _thumb_get_rowid(tmpoff);
+        if(active_rowid > 0)
+          table->offset = active_rowid;
         table->offset_imgid = tmpoff;
         dt_thumbtable_full_redraw(table, TRUE);
       }


### PR DESCRIPTION
Fixes #21664 

Only update the filmstrip offset from the active image when that image is still in the collection after a reload. If it was filtered out, keep the previous rowid so the existing advance-to-next path can run.