### PR TITLE
fix xmp serialization with Umlauts in more free text exif fields

### DIFF
--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -1977,12 +1977,16 @@ static bool _exif_decode_exif_data(dt_image_t *img, Exiv2::ExifData &exifData)
     if(FIND_EXIF_TAG("Exif.Image.Artist"))
     {
       std::string str = pos->print(&exifData);
-      dt_metadata_set_import_lock(img->id, "Xmp.dc.creator", str.c_str());
+      gchar *utf8 = dt_util_foo_to_utf8(str.c_str());
+      dt_metadata_set_import_lock(img->id, "Xmp.dc.creator", utf8);
+      g_free(utf8);
     }
     else if(FIND_EXIF_TAG("Exif.Canon.OwnerName"))
     {
       std::string str = pos->print(&exifData);
-      dt_metadata_set_import_lock(img->id, "Xmp.dc.creator", str.c_str());
+      gchar *utf8 = dt_util_foo_to_utf8(str.c_str());
+      dt_metadata_set_import_lock(img->id, "Xmp.dc.creator", utf8);
+      g_free(utf8);
     }
 
     // FIXME: Should the UserComment go into the description? Or do we
@@ -1998,13 +2002,17 @@ static bool _exif_decode_exif_data(dt_image_t *img, Exiv2::ExifData &exifData)
     else if(FIND_EXIF_TAG("Exif.Image.ImageDescription"))
     {
       std::string str = pos->print(&exifData);
-      dt_metadata_set_import_lock(img->id, "Xmp.dc.description", str.c_str());
+      gchar *utf8 = dt_util_foo_to_utf8(str.c_str());
+      dt_metadata_set_import_lock(img->id, "Xmp.dc.description", utf8);
+      g_free(utf8);
     }
 
     if(FIND_EXIF_TAG("Exif.Image.Copyright"))
     {
       std::string str = pos->print(&exifData);
-      dt_metadata_set_import_lock(img->id, "Xmp.dc.rights", str.c_str());
+      gchar *utf8 = dt_util_foo_to_utf8(str.c_str());
+      dt_metadata_set_import_lock(img->id, "Xmp.dc.rights", utf8);
+      g_free(utf8);
     }
 
     if(!dt_conf_get_bool("ui_last/ignore_exif_rating"))


### PR DESCRIPTION
Some free-text Exif "Ascii" fields (Artist, Copyright, ImageDescription, Canon.OwnerName, ...) are not guaranteed to
actually be ASCII: many cameras write whatever bytes the user typed in the camera's local codepage, most commonly Windows-1252/ISO-8859-1 for accented/umlaut characters. 

Unlike Maker/Model/Lens/DateTime (see _strlcpy_to_utf8 above), these fields were being copied straight into Xmp.dc.* with no UTF-8 validation/conversion at all. Since XMP requires well-formed UTF-8, invalid bytes reaching Exiv2's XMP serializer make it throw '[xmp_write] failed to serialize xmp data', silently aborting the sidecar write for the whole image on every load/edit.

Note this deliberately tries Windows-1252 explicitly rather than relying on g_locale_to_utf8() (as _strlcpy_to_utf8 does): on modern systems LC_CTYPE is almost always already UTF-8, so g_locale_to_utf8 treats the source as UTF-8 too, fails to convert genuinely Windows-1252-encoded bytes, and we'd fall straight through to the lossy g_utf8_make_valid() replacement-character path instead of actually recovering the intended character.

