### PR TITLE
New collection filter for (original) image dimensions

### DIFF
--- a/src/common/collection.c
+++ b/src/common/collection.c
@@ -656,6 +656,8 @@ const char *dt_collection_name_untranslated(const dt_collection_properties_t pro
       return N_("group");
     case DT_COLLECTION_PROP_DUPLICATES:
       return N_("duplicates");
+    case DT_COLLECTION_PROP_DIMENSIONS:
+      return N_("image dimensions");
     case DT_COLLECTION_PROP_LOCAL_COPY:
       return N_("local copy");
     case DT_COLLECTION_PROP_MODULE:
@@ -1600,10 +1602,22 @@ static gchar *get_query_string(const dt_collection_properties_t property, const 
           ("(mi.version > (SELECT MIN(version) FROM main.images"
            "               WHERE film_id = mi.film_id AND filename = mi.filename)) ");
       }
-      else // by default, we select all the images
+      break;
+
+    case DT_COLLECTION_PROP_DIMENSIONS: // image dimensions
+      query = g_strdup("(");
+      // handle the possibility of multiple values
+      elems = _strsplit_quotes(escaped_text, ",", -1);
+      for(int i = 0; i < g_strv_length(elems); i++)
       {
-        query = g_strdup("1 = 1");
+          gchar *dims = _add_wildcards(elems[i]);
+          dt_util_str_cat(&query,
+                          "%smi.width || 'x' || mi.height LIKE '%%%s%%'",
+                          i>0?" OR ":"", dims);
+          g_free(dims);
       }
+      g_strfreev(elems);
+      dt_util_str_cat(&query, ")");
       break;
 
     case DT_COLLECTION_PROP_ASPECT_RATIO: // aspect ratio

--- a/src/common/collection.h
+++ b/src/common/collection.h
@@ -119,9 +119,10 @@ typedef enum dt_collection_properties_t
 
   DT_COLLECTION_PROP_EXPOSURE_BIAS,
 
+  DT_COLLECTION_PROP_DUPLICATES,
+
   DT_COLLECTION_PROP_MONTH,
 
-  DT_COLLECTION_PROP_DUPLICATES,
   DT_COLLECTION_PROP_DIMENSIONS,
 
   // all new collection types need to be added before DT_COLLECTION_PROP_LAST,

--- a/src/common/collection.h
+++ b/src/common/collection.h
@@ -119,9 +119,10 @@ typedef enum dt_collection_properties_t
 
   DT_COLLECTION_PROP_EXPOSURE_BIAS,
 
-  DT_COLLECTION_PROP_DUPLICATES,
-
   DT_COLLECTION_PROP_MONTH,
+
+  DT_COLLECTION_PROP_DUPLICATES,
+  DT_COLLECTION_PROP_DIMENSIONS,
 
   // all new collection types need to be added before DT_COLLECTION_PROP_LAST,
   // which separates actual collection types from special flag values

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -4369,7 +4369,9 @@ void init(struct dt_lib_module_t *self)
   luaA_enum_value(L, dt_collection_properties_t, DT_COLLECTION_PROP_LOCAL_COPY);
   luaA_enum_value(L, dt_collection_properties_t, DT_COLLECTION_PROP_MODULE);
   luaA_enum_value(L, dt_collection_properties_t, DT_COLLECTION_PROP_ORDER);
+  luaA_enum_value(L, dt_collection_properties_t, DT_COLLECTION_PROP_DUPLICATES);
   luaA_enum_value(L, dt_collection_properties_t, DT_COLLECTION_PROP_MONTH);
+  luaA_enum_value(L, dt_collection_properties_t, DT_COLLECTION_PROP_DIMENSIONS);
 }
 #endif
 #undef MAX_RULES

--- a/src/libs/filtering.c
+++ b/src/libs/filtering.c
@@ -242,6 +242,7 @@ static _filter_t filters[]
         { DT_COLLECTION_PROP_EXPOSURE_BIAS, _exposure_bias_widget_init, _exposure_bias_update },
         { DT_COLLECTION_PROP_GROUP_ID, _misc_widget_init, _misc_update },
         { DT_COLLECTION_PROP_DUPLICATES, _duplicates_widget_init, _duplicates_update },
+        { DT_COLLECTION_PROP_DIMENSIONS, _misc_widget_init, _misc_update },
         { DT_COLLECTION_PROP_LOCAL_COPY, _local_copy_widget_init, _local_copy_update },
         { DT_COLLECTION_PROP_HISTORY, _history_widget_init, _history_update },
         { DT_COLLECTION_PROP_ORDER, _module_order_widget_init, _module_order_update },
@@ -921,6 +922,7 @@ static gboolean _rule_show_popup(GtkWidget *widget, dt_lib_filtering_rule_t *rul
   ADD_COLLECT_ENTRY(spop, DT_COLLECTION_PROP_FLASH);
   ADD_COLLECT_ENTRY(spop, DT_COLLECTION_PROP_EXPOSURE_PROGRAM);
   ADD_COLLECT_ENTRY(spop, DT_COLLECTION_PROP_METERING_MODE);
+  ADD_COLLECT_ENTRY(spop, DT_COLLECTION_PROP_DIMENSIONS);
 
   _popup_add_item(spop, _("darktable"), 0, TRUE, NULL, NULL, self, 0.0);
   ADD_COLLECT_ENTRY(spop, DT_COLLECTION_PROP_GROUP_ID);
@@ -982,6 +984,7 @@ static void _populate_rules_combo(GtkWidget *w)
   ADD_COLLECT_ENTRY(DT_COLLECTION_PROP_FLASH);
   ADD_COLLECT_ENTRY(DT_COLLECTION_PROP_EXPOSURE_PROGRAM);
   ADD_COLLECT_ENTRY(DT_COLLECTION_PROP_METERING_MODE);
+  ADD_COLLECT_ENTRY(DT_COLLECTION_PROP_DIMENSIONS);
 
   dt_bauhaus_combobox_add_section(w, _("darktable"));
   ADD_COLLECT_ENTRY(DT_COLLECTION_PROP_GROUP_ID);
@@ -1648,6 +1651,7 @@ static void _topbar_populate_rules_combo(GtkWidget *w, dt_lib_filtering_t *d)
   ADD_COLLECT_ENTRY(DT_COLLECTION_PROP_FLASH);
   ADD_COLLECT_ENTRY(DT_COLLECTION_PROP_EXPOSURE_PROGRAM);
   ADD_COLLECT_ENTRY(DT_COLLECTION_PROP_METERING_MODE);
+  ADD_COLLECT_ENTRY(DT_COLLECTION_PROP_DIMENSIONS);
   // if we have not added any entry, remove the section
   if(nb == dt_bauhaus_combobox_length(w)) dt_bauhaus_combobox_remove_at(w, nb - 1);
 

--- a/src/libs/filters/misc.c
+++ b/src/libs/filters/misc.c
@@ -470,7 +470,10 @@ static void _misc_widget_init(dt_lib_filtering_rule_t *rule,
   {
     name = g_strdup(_("image dimensions"));
     tooltip = g_strdup(_("enter the image dimensions to search.\n"
-                         "use the format widthxheight, i.e. 6000x4000.\n"
+                         "use the format widthxheight, i.e.\n"
+                         "'6000x4000' for a full match,\n"
+                         "'6000x' for width only,\n"
+                         "'x4000' for height only.\n"
                          "multiple values can be separated by ','\n"
                          "\nright-click to get existing image dimensions"));
   }

--- a/src/libs/filters/misc.c
+++ b/src/libs/filters/misc.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2024 darktable developers.
+    Copyright (C) 2024-2026 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -20,6 +20,7 @@
   This file implements the necessary routines for all text baseed filters for the filtering module
 */
 
+#include "common/collection.h"
 typedef struct _widgets_misc_t
 {
   dt_lib_filtering_rule_t *rule;
@@ -113,6 +114,10 @@ void _misc_tree_update(_widgets_misc_t *misc)
     table = g_strdup("metering_mode");
     tooltip = g_strdup(_("no metering mode defined"));
   }
+  else if(misc->prop == DT_COLLECTION_PROP_DIMENSIONS)
+  {
+    tooltip = g_strdup(_("no image dimensions defined"));
+  }
 
   // SQL
   if(misc->prop == DT_COLLECTION_PROP_CAMERA)
@@ -152,6 +157,18 @@ void _misc_tree_update(_widgets_misc_t *misc)
                " GROUP BY group_id"
                " HAVING COUNT(*) > 1"
                " ORDER BY group_id",
+               d->last_where_ext);
+    // clang-format on
+  }
+  else if(misc->prop == DT_COLLECTION_PROP_DIMENSIONS)
+  {
+    // clang-format off
+    g_snprintf(query, sizeof(query),
+               "SELECT mi.width || 'x' || mi.height AS dim, COUNT(*) AS count"
+               " FROM main.images AS mi"
+               " WHERE %s"
+               " GROUP BY dim"
+               " ORDER BY dim",
                d->last_where_ext);
     // clang-format on
   }
@@ -448,6 +465,14 @@ static void _misc_widget_init(dt_lib_filtering_rule_t *rule,
     tooltip = g_strdup(_("enter group id to search.\n"
                          "multiple values can be separated by ','\n"
                          "\nright-click to get existing group ids"));
+  }
+  else if(prop == DT_COLLECTION_PROP_DIMENSIONS)
+  {
+    name = g_strdup(_("image dimensions"));
+    tooltip = g_strdup(_("enter the image dimensions to search.\n"
+                         "use the format widthxheight, i.e. 6000x4000.\n"
+                         "multiple values can be separated by ','\n"
+                         "\nright-click to get existing image dimensions"));
   }
 
   gtk_entry_set_placeholder_text(GTK_ENTRY(misc->name), name);


### PR DESCRIPTION
This PR adds a new collection filter for the image dimensions.

<img width="200" height="598" alt="Bildschirmfoto 2026-08-01 um 08 06 42" src="https://github.com/user-attachments/assets/cfd7c9b0-33ce-43e9-baed-2f5c20917d6c" />

<img width="225" height="384" alt="Bildschirmfoto 2026-08-01 um 08 05 54" src="https://github.com/user-attachments/assets/5878d81b-d89e-4fb5-aa62-c6235fbf24e5" />

<img width="258" height="50" alt="Bildschirmfoto 2026-08-01 um 08 06 23" src="https://github.com/user-attachments/assets/ffc71789-8576-42c0-a1d4-767f7d15d83b" />

Search is performed using wildcards, so one can enter the full dimensions like `6000x4000` or only parts of that:

- `6000x4000` - full match
- `6000x` - all images with 6000 width
- `x4000` - all images with 4000 height
- ...

closes #21577 
