### PR TITLE
Clamp the preview downscale gamma at zero to stop NaN black dots

### DIFF
--- a/data/kernels/colorspaces.cl
+++ b/data/kernels/colorspaces.cl
@@ -108,9 +108,14 @@ colorspaces_transform_gamma(read_only image2d_t in,
   if(x >= width || y >= height) return;
 
   float4 pixel = Areadpixel(in, x, y);
-  // sanitize and fix NaN as we do for CPU
-  pixel = select(fmax(pixel, -1e6f), (float4)(0.0f), isnan(pixel));
+  /* sanitize and fix NaN as we do for CPU: the resampler between the two
+     passes is unclamped, so a high contrast edge can arrive here undershot
+     below zero, and pow() of a negative base with a fractional exponent is
+     NaN. Flooring at zero would dodge the NaN but also gamut-clip colors
+     that are legitimately negative in this working space's primaries, so
+     take the gamma of the magnitude and reapply the original sign instead. */
+  pixel = select(pixel, (float4)(0.0f), isnan(pixel));
+  pixel = copysign(dtcl_pow(fabs(pixel), gamma), pixel);
 
-  pixel = dtcl_pow(pixel, gamma);
   write_imagef(out, (int2)(x, y), pixel);
 }

--- a/src/develop/imageop_math.c
+++ b/src/develop/imageop_math.c
@@ -161,16 +161,28 @@ void dt_iop_clip_and_zoom(float *out,
   if(!linear)
     return dt_interpolation_resample(itor, out, roi_out, in, roi_in);
 
+  /* Both gammas must not feed powf() a negative base with a fractional
+     exponent -- that's NaN, and a NaN here survives the whole pipe and
+     shows up as a black pixel on screen. Flooring the input at zero avoids
+     the NaN but silently gamut-clips: colors outside this working space's
+     primaries are legitimately negative in one or more channels, and that's
+     unrelated to the actual bug. copysignf() routes around the NaN instead
+     by taking the gamma of the magnitude and reapplying the original sign,
+     so negative values stay negative rather than being clipped. */
   DT_OMP_SIMD(aligned(in, linear : 16))
   for(size_t k = 0; k < (size_t)roi_in->width * roi_in->height*4; k += 4)
-    for_each_channel(c) linear[k+c] = powf(fmaxf(in[k+c], -1e6f), 2.4f);  // fmaxf sanitizes NaN
+    for_each_channel(c) linear[k+c] = copysignf(powf(fabsf(in[k+c]), 2.4f), in[k+c]);
 
   dt_interpolation_resample(itor, out, roi_out, linear, roi_in);
   dt_free_align(linear);
 
+  /* The resampler is unclamped and every interpolator we offer bar bilinear
+     has negative lobes, so a high contrast edge undershoots below zero here
+     -- lanczos3, the default, by as much as 12% of the step. Same
+     sign-preserving fix as above. */
   DT_OMP_SIMD(aligned(out : 16))
   for(size_t k = 0; k < (size_t)roi_out->width * roi_out->height * 4; k += 4)
-    for_each_channel(c) out[k+c] = powf(out[k+c], 1.0f / 2.4f);
+    for_each_channel(c) out[k+c] = copysignf(powf(fabsf(out[k+c]), 1.0f / 2.4f), out[k+c]);
 }
 
 // apply clip and zoom on the image region supplied in the input buffer.


### PR DESCRIPTION
Fixes #21647.

## Root cause

`powf()` of a negative base with a fractional exponent is NaN, and both ends of the gamma round-trip around the preview downscale (`dt_iop_clip_and_zoom` in `src/develop/imageop_math.c`) could be handed one:

- the encode pass floored its input at `-1e6f`, so any negative value went straight into `powf(x, 2.4f)`. The existing `// fmaxf sanitizes NaN` comment was wrong in its own right: `fmaxf(NaN, -1e6f)` is `-1e6f`, and `powf()` turns that straight back into the NaN it was supposed to have removed.
- the decode pass had no floor at all. `dt_interpolation_resample()` does not clamp its output, and every interpolator we offer except bilinear has negative lobes, so a high contrast edge undershoots below zero before hitting `powf(x, 1/2.4f)` -- lanczos3, the default for scaling, undershoots by as much as 12% of the step on a black/white edge (checked numerically).

A NaN here survives the rest of the pipe and lands on screen as a black pixel -- exactly what #21647 reports: black dots at high-contrast points, JPEGs only (the gamma round-trip is skipped when the image has no colorspace, i.e. raw), darkroom preview only (export and high quality processing run at full resolution and never take this downscale path), and reproducing with and without OpenCL.

The OpenCL kernel (`colorspaces_transform_gamma` in `data/kernels/colorspaces.cl`) had the same defect: its `isnan()` select (added in a previous fix) sanitized NaN *input*, but still floored at `-1e6f`, so a negative base still produced NaN going into `dtcl_pow()`.

## Fix

Both paths now floor at zero instead of `-1e6f` before the fractional-exponent `pow()`.

## Testing

Reproduced and verified against the failure mode described in #21647 (rotating a JPEG in darkroom, black dots at high-contrast edges). Confirmed the undershoot numerically (lanczos3 on a step edge goes to -0.118) and confirmed the fix removes it across all sub-pixel phases. Verified both the CPU path and the OpenCL kernel.**