### PR TITLE
fix focus peaking buffer overrun

### DIFF
--- a/src/common/focus_peaking.h
+++ b/src/common/focus_peaking.h
@@ -106,7 +106,7 @@ static inline void dt_focuspeaking(cairo_t *cr,
     for(size_t j = 0; j < buf_width; ++j)
     {
       size_t index = i * buf_width + j;
-      if (i < 2 || i >= buf_height - 2 || j < 2 || j > buf_width -2)
+      if (i < 2 || i >= buf_height - 2 || j < 2 || j >= buf_width - 2)
         // ensure defined value for borders
         luma_ds[index] = 0.0f;
       else


### PR DESCRIPTION
## Summary

- treat the rightmost two columns as border pixels before sampling two-pixel neighbours
- prevent focus peaking from reading past the end of the luma buffer

## Root cause

The border condition used `>` instead of `>=`, allowing `j == buf_width - 2` to reach `_get_indices()` with a neighbour distance of two. The resulting right-hand index equals `buf_width`, which can read one element beyond the allocation and crash when the allocation ends at a protected page boundary.

## Validation

- an AddressSanitizer reproducer using a 4416 x 2944 buffer reports a heap-buffer-overflow with the previous condition and completes cleanly with this change
- tested focus peaking with a 4416 x 2944 Fujifilm RAF on Apple Silicon macOS; the overlay renders without crashing

Fixes #19093
