### PR TITLE
Fix culling selection index while navigating

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -146,6 +146,9 @@ changes (where available).
   rejecting with filmstrip auto-scroll disabled and the collection
   filtered to hide rejected images.
 
+- Fixed the image index and filmstrip selection in culling mode not
+  updating when navigating with the arrow keys.
+
 ## Lua
 
 ### API Version

--- a/src/dtgtk/culling.c
+++ b/src/dtgtk/culling.c
@@ -1062,6 +1062,9 @@ static void _dt_selection_changed_callback(gpointer instance,
   dt_culling_t *table = (dt_culling_t *)user_data;
   if(!gtk_widget_get_visible(table->widget)) return;
 
+  // if we are updating the selection ourselves, stay in synchronisation mode
+  if(table->select_desactivate) return;
+
   // if we are in selection synchronisation mode, we exit this mode
   if(table->selection_sync) table->selection_sync = FALSE;
 


### PR DESCRIPTION
Fixes #21688 

Keep selection_sync when we update selection ourselves, so arrow navigation updates # N and the filmstrip.