### PR TITLE
Faster OpenCL pixelpipe-internal tiling

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -246,6 +246,10 @@ static int usage(const char *argv0)
          "--disable-opencl\n"
          "    Prevent darktable from initializing the OpenCL subsystem.\n"
          "\n"
+         "--opencl-tiling\n"
+         "    Enforce fast opencl tiling even if not required.\n"
+         "    Use for performance/debugging sessions only.\n"
+         "\n"
 #endif
          "--disable-pipecache\n"
          "    Disable the pixelpipe cache. This option allows only\n"
@@ -1332,6 +1336,13 @@ int dt_init(int argc,
       {
 #ifdef HAVE_OPENCL
         options |= DT_OPENCL_OPTION_EXCLUDE;
+#endif
+        argv[k] = NULL;
+      }
+      else if(!strcmp(argv[k], "--opencl-tiling"))
+      {
+#ifdef HAVE_OPENCL
+        options |= DT_OPENCL_OPTION_FAST_TILE;
 #endif
         argv[k] = NULL;
       }

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -323,12 +323,6 @@ void dt_opencl_micro_nap(const int devid)
     dt_iop_nap(cl->dev[devid].micro_nap);
 }
 
-gboolean dt_opencl_use_pinned_memory(const int devid)
-{
-  dt_opencl_t *cl = darktable.opencl;
-  return (!_cldev_running(devid)) ? FALSE : cl->dev[devid].pinned_memory;
-}
-
 gboolean dt_opencl_unified_memory(const int devid)
 {
   dt_opencl_t *cl = darktable.opencl;
@@ -366,7 +360,7 @@ static void _opencl_write_device_config(const int devid)
   g_snprintf(key, sizeof(key), "%s%s", DT_CLDEVICE_HEAD, cl->dev[devid].cname);
   g_snprintf(dat, sizeof(dat), "%i %i %i %i %i %.3f %.3f",
     cl->dev[devid].micro_nap,
-    cl->dev[devid].pinned_memory,
+    0,
 
     // this used to define the number of slots, now a bool and using DT_OPENCL_EVENTS if true
     cl->dev[devid].use_events ? 1 : 0,
@@ -443,7 +437,6 @@ static gboolean _opencl_read_device_config(const int devid)
 
     cldid->use_events = events ? TRUE : FALSE;
     cldid->micro_nap = micro_nap;
-    cldid->pinned_memory = pinned_memory ? TRUE : FALSE;
     cldid->asyncmode = asyncmode ? TRUE : FALSE;
     cldid->disabled = disabled && dt_conf_get_int("performance_configuration_version_completed") != 19 ? TRUE : FALSE;
     cldid->unified_fraction = unified_fraction;
@@ -535,9 +528,7 @@ static gboolean _opencl_device_init(dt_opencl_t *cl,
   // setting sane/conservative defaults at first
   cl->dev[dev].unified_fraction = 0.25f;
   cl->dev[dev].micro_nap = 250;
-  cl->dev[dev].pinned_memory = FALSE;
   cl->dev[dev].unified_memory = FALSE;
-  cl->dev[dev].pinned_error = FALSE;
   cl->dev[dev].clmem_error = FALSE;
   cl->dev[dev].clroundup_wd = 16;
   cl->dev[dev].clroundup_ht = 16;
@@ -932,8 +923,6 @@ static gboolean _opencl_device_init(dt_opencl_t *cl,
 
   dt_print_nts(DT_DEBUG_OPENCL,
                "   ASYNC PIXELPIPE:          %s\n", STR_YESNO(cl->dev[dev].asyncmode));
-  dt_print_nts(DT_DEBUG_OPENCL,
-               "   PINNED MEMORY TILING:     %s\n", STR_YESNO(cl->dev[dev].pinned_memory));
   dt_print_nts(DT_DEBUG_OPENCL,
                "   SUPPORTED ATOMICS:        %s%s%s\n",
                cl->dev[dev].atomic_support == DT_OPENCL_ATOMIC_NONE ? "none" : "",
@@ -3677,29 +3666,47 @@ cl_ulong dt_opencl_get_device_memalloc(const int devid)
   return _opencl_get_device_memalloc(devid);
 }
 
-gboolean dt_opencl_image_fits_device(const int devid,
-                                     const size_t width,
-                                     const size_t height,
-                                     const uint32_t bpp,
-                                     const float factor,
-                                     const size_t overhead)
+/* result for fitting the OpenCL device returns
+    DT_OPENCL_NO_TILING: image data can be fully processed in available cl_mem
+    DT_OPENCL_FAST_TILING: image data vs available cl_mem ratio is not bad so we
+        can do pixelpipe internal tiling keep in&out cl_mem and just copy cl_mem parts.
+    DT_OPENCL_TILING: We must do classical tiling going the hard & slow way
+        via host <-> device transfers either because
+      - the device supported image dimension is smaller than
+        the processed image
+      - the maximum supported size of an image/buffer is smaller
+        than the processed image
+      - the "not bad ratio" test for DT_OPENCL_FAST_TILING failed.
+*/
+dt_opencl_tilemode_t dt_opencl_image_fits_device(const int devid,
+                                                 const int width,
+                                                 const int height,
+                                                 const uint32_t bpp,
+                                                 const float factor,
+                                                 const size_t overhead,
+                                                 const int overlap)
 {
   dt_opencl_t *cl = darktable.opencl;
-  if(!_cldev_running(devid)) return FALSE;
+  if(!_cldev_running(devid)) return DT_OPENCL_TILING;
 
-  const size_t required  = width * height * bpp;
-  const size_t total = factor * required + overhead;
+  const int64_t plane = width * height * bpp;
+  const int64_t total = factor * plane + overhead;
 
-  if(cl->dev[devid].max_image_width < width || cl->dev[devid].max_image_height < height)
-    return FALSE;
+  // always tile as processed image is larger than device is providing
+  if(cl->dev[devid].max_image_width < width
+      || cl->dev[devid].max_image_height < height
+      || _opencl_get_device_memalloc(devid) < plane)
+    return DT_OPENCL_TILING;
 
-  if(_opencl_get_device_memalloc(devid) < required)
-    return FALSE;
-  if(dt_opencl_get_device_available(devid) < total)
-    return FALSE;
-  // We know here that total memory fits and if so the buffersize will
-  // also fit as there is a factor of >=2
-  return TRUE;
+  const int64_t avail = dt_opencl_get_device_available(devid);
+
+  // available clm_em allows processing whole image in one bunch
+  if(avail > total)
+    return cl->fast_tiling ? DT_OPENCL_FAST_TILING : DT_OPENCL_NO_TILING;
+  const int64_t perline = width * bpp;
+  const int64_t remains = avail - overhead - 2*plane;
+  // fast internal OpenCL tiling possible and with a good bet on performance?
+  return (remains / perline - overlap) > height / 10 ? DT_OPENCL_FAST_TILING : DT_OPENCL_TILING;
 }
 
 /** round size to a multiple of the value given in the device specifig
@@ -3807,10 +3814,9 @@ void dt_opencl_update_settings(void)
       res->cl_uni_memory += cl->dev[i].used_available;
     }
     dt_print_nts(DT_DEBUG_OPENCL,
-         "   AVAILABLE CLMEM SIZE:     %zu MB%s%s\n",
+         "   AVAILABLE CLMEM SIZE:     %zu MB%s\n",
               (size_t)(cl->dev[i].used_available / DT_MEGA),
-              cl->dev[i].tunehead ? ", tuned" : "",
-              cl->dev[i].pinned_memory ? ", pinned": "");
+              cl->dev[i].tunehead ? ", tuned" : "");
   }
   if(res->cl_uni_memory)
     dt_print_nts(DT_DEBUG_OPENCL,

--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -94,6 +94,13 @@ typedef enum dt_opencl_scheduling_profile_t
   OPENCL_PROFILE_VERYFAST_GPU
 } dt_opencl_scheduling_profile_t;
 
+typedef enum dt_opencl_tilemode_t
+{
+  DT_OPENCL_NO_TILING,
+  DT_OPENCL_FAST_TILING,
+  DT_OPENCL_TILING,
+} dt_opencl_tilemode_t;
+
 /**
  * Accounting information used for OpenCL events.
  */
@@ -166,25 +173,12 @@ typedef struct dt_opencl_device_t
   // to time
   int micro_nap;
 
-  // During tiling huge amounts of memory need to be transferred
-  // between host and device.  For some OpenCL implementations direct
-  // memory transfers give a drastic performance penalty, this can
-  // often be avoided by using indirect transfers via pinned memory,
-  // other devices have more efficient direct memory transfer
-  // implementations.  We can't predict on solid grounds if a device
-  // belongs to the first or second group, also pinned mem transfer
-  // requires slightly more video ram plus system memory.  If TRUE in
-  // the device-specific conf pinned transfer is enabled
-  gboolean pinned_memory;
-
   // keep track of devices using unified memory so we can adopt
   // runtime code
   gboolean unified_memory;
   // fraction of system memory allowed for a device in percent
   float unified_fraction;
 
-  // flags reporting cl runtime error conditions
-  gboolean pinned_error;
   gboolean clmem_error;
 
   // in OpenCL processing round width/height of global work groups to
@@ -576,13 +570,14 @@ void dt_opencl_memory_statistics(int devid,
                                  const cl_mem mem,
                                  dt_opencl_memory_t action);
 
-/** check if image size fit into limits given by OpenCL runtime */
-gboolean dt_opencl_image_fits_device(const int devid,
-                                     const size_t width,
-                                     const size_t height,
-                                     const uint32_t bpp,
-                                     const float factor,
-                                     const size_t overhead);
+/** check if image size fits into limits given by OpenCL runtime */
+dt_opencl_tilemode_t dt_opencl_image_fits_device(const int devid,
+                                                 const int width,
+                                                 const int height,
+                                                 const uint32_t bpp,
+                                                 const float factor,
+                                                 const size_t overhead,
+                                                 const int overlap);
 /** get available memory for the device */
 cl_ulong dt_opencl_get_device_available(const int devid);
 
@@ -615,7 +610,6 @@ cl_int dt_opencl_local_buffer_opt(const int devid,
 /** utility functions handling device specific properties */
 gboolean dt_opencl_avoid_atomics(const int devid);
 void dt_opencl_micro_nap(const int devid);
-gboolean dt_opencl_use_pinned_memory(const int devid);
 gboolean dt_opencl_unified_memory(const int devid);
 unsigned int dt_opencl_tiling_align(const int devid);
 
@@ -723,15 +717,6 @@ static inline gboolean dt_opencl_running_fast(void)
 static inline void dt_opencl_update_settings(void)
 {
   return ;
-}
-static inline gboolean dt_opencl_image_fits_device(const int devid,
-                                                   const size_t width,
-                                                   const size_t height,
-                                                   const unsigned bpp,
-                                                   const float factor,
-                                                   const size_t overhead)
-{
-  return FALSE;
 }
 static inline size_t dt_opencl_get_device_available(const int devid)
 {

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -2280,9 +2280,15 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
     const size_t m_width = MAX(roi_in.width, roi_out->width);
     const size_t m_height = MAX(roi_in.height, roi_out->height);
 
-    const gboolean fits_on_device =
+    const dt_opencl_tilemode_t fitter =
       dt_opencl_image_fits_device(pipe->devid, m_width, m_height,
-                                  m_bpp, tiling.factor_cl, tiling.overhead);
+                                  m_bpp, tiling.factor_cl, tiling.overhead, tiling.overlap);
+
+    const gboolean no_tiling = fitter == DT_OPENCL_NO_TILING;
+    const gboolean fast_tiling = fitter == DT_OPENCL_FAST_TILING
+        && !memcmp(&roi_in, roi_out, sizeof(roi_in))
+        && !(module->flags() & (IOP_FLAGS_WRITE_RASTER | IOP_FLAGS_WRITE_DETAILS));
+    const gboolean fits_on_device = no_tiling || fast_tiling;
 
     if(possible_cl && !fits_on_device)
     {
@@ -2395,12 +2401,11 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
       }
 
       dt_print_pipe(DT_DEBUG_PIPE,
-                        bcaching ? "from blend cache" : "process",
-                        pipe, module, pipe->devid, &roi_in, roi_out, "%s%s%s%s %zuMB",
+          bcaching ? "from blend cache" : no_tiling ? "process" : fast_tiling ? "process fast tiled" : "process tiled",
+                        pipe, module, pipe->devid, &roi_in, roi_out, "%s%s%s %zuMB",
                         dt_iop_colorspace_to_name(cst_to),
                         cst_to != cst_out ? " -> " : "",
                         cst_to != cst_out ? dt_iop_colorspace_to_name(cst_out) : "",
-                        fits_on_device ? "" : ", tiled",
                         (size_t)(tiling.factor_cl * (m_width * m_height * m_bpp) + tiling.overhead) / DT_MEGA);
 
       if(fits_on_device)
@@ -2442,7 +2447,7 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
            meaningful messages in case of error */
         if(success_opencl)
         {
-          if(_is_debug_pipe(pipe))
+          if(_is_debug_pipe(pipe) && no_tiling)
           {
             if(darktable.bench_module && dt_str_commasubstring(darktable.bench_module, module->op))
               _opencl_benchmark(pipe, module, piece, cl_mem_input, roi_out, &roi_in, bpp);
@@ -2467,8 +2472,10 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
           else
           {
             *cl_mem_output = dt_opencl_alloc_device(pipe->devid, roi_out->width, roi_out->height, bpp);
-            if(*cl_mem_output)
+            if(*cl_mem_output && no_tiling)
               err = module->process_cl(module, piece, cl_mem_input, *cl_mem_output, &roi_in, roi_out);
+            else if(*cl_mem_output && fast_tiling)
+              err = process_tiling_cl_fast(piece, cl_mem_input, *cl_mem_output, &roi_in, roi_out, in_bpp, bpp, &tiling);
             else
               err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
 

--- a/src/develop/tiling.c
+++ b/src/develop/tiling.c
@@ -717,7 +717,7 @@ static void _default_process_tiling_ptp(dt_iop_module_t *self,
 
   piece->pipe->tiling = TRUE;
   dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_TILING,
-                        "default *tiled* ptp", piece->pipe, piece->module, DT_DEVICE_CPU, roi_in, roi_out,
+                        "  *tiled* ptp", piece->pipe, piece->module, DT_DEVICE_CPU, roi_in, roi_out,
                         "%dx%d tiles, size=%dx%d, overlap=%d",
                         tiles_x, tiles_y, tile_wd, tile_ht, overlap);
 
@@ -745,7 +745,7 @@ static void _default_process_tiling_ptp(dt_iop_module_t *self,
       size_t ooffs = (ty * tile_ht) * opitch + (tx * tile_wd) * out_bpp;
 
       dt_print_pipe(DT_DEBUG_TILING,
-               skipped ? "  tile ptp skipped" : "  tile ptp", piece->pipe, piece->module, DT_DEVICE_CPU, &iroi, &oroi,
+               skipped ? "    tile skipped" : "    tile", piece->pipe, piece->module, DT_DEVICE_CPU, &iroi, &oroi,
                "tile (%zu,%zu)", tx, ty);
       if(skipped) continue;
 
@@ -755,7 +755,7 @@ static void _default_process_tiling_ptp(dt_iop_module_t *self,
         memcpy((char *)input + j * wd * in_bpp, (char *)ivoid + ioffs + j * ipitch, (size_t)wd * in_bpp);
 
       /* take original processed_maximum as starting point */
-      for(int k = 0; k < 4; k++) piece->pipe->dsc.processed_maximum[k] = processed_maximum_saved[k];
+      for_four_channels(k) piece->pipe->dsc.processed_maximum[k] = processed_maximum_saved[k];
       dt_dev_prepare_piece_cfa(piece, &iroi);
 
       /* call process() of module */
@@ -764,12 +764,12 @@ static void _default_process_tiling_ptp(dt_iop_module_t *self,
       /* aggregate resulting processed_maximum */
       /* TODO: check if there really can be differences between tiles and take
                appropriate action (calculate minimum, maximum, average, ...?) */
-      for(int k = 0; k < 4; k++)
+      for_four_channels(k)
       {
         if(tx + ty > 0 && fabs(processed_maximum_new[k] - piece->pipe->dsc.processed_maximum[k]) > 1.0e-6f)
           dt_print(DT_DEBUG_TILING,
                    "[default_process_tiling_ptp] [%s] processed_maximum[%d] differs between tiles in module '%s%s'",
-                   dt_dev_pixelpipe_type_to_str(piece->pipe->type), k,
+                   dt_dev_pixelpipe_type_to_str(piece->pipe->type), (int)k,
                    self->op, dt_iop_get_instance_id(self));
         processed_maximum_new[k] = piece->pipe->dsc.processed_maximum[k];
       }
@@ -798,7 +798,7 @@ static void _default_process_tiling_ptp(dt_iop_module_t *self,
   }
 
   /* copy back final processed_maximum */
-  for(int k = 0; k < 4; k++) piece->pipe->dsc.processed_maximum[k] = processed_maximum_new[k];
+  for_four_channels(k) piece->pipe->dsc.processed_maximum[k] = processed_maximum_new[k];
 
   dt_free_align(input);
   dt_free_align(output);
@@ -974,7 +974,7 @@ static void _default_process_tiling_roi(dt_iop_module_t *self,
       roi_out->height % tiles_y == 0 ? roi_out->height / tiles_y : roi_out->height / tiles_y + 1, align);
 
   dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_TILING,
-                        "process *tiled* roi", piece->pipe, piece->module, DT_DEVICE_CPU, roi_in, roi_out,
+                        "  *tiled* roi", piece->pipe, piece->module, DT_DEVICE_CPU, roi_in, roi_out,
                         "%dx%d tiles, size=%dx%d",
                         tiles_x, tiles_y, tile_wd, tile_ht);
 
@@ -1075,7 +1075,7 @@ static void _default_process_tiling_roi(dt_iop_module_t *self,
             size_t ooffs = ((size_t)oroi_good.y - roi_out->y) * opitch + ((size_t)oroi_good.x - roi_out->x) * out_bpp;
 
       dt_print_pipe(DT_DEBUG_TILING,
-               "  tile roi", piece->pipe, piece->module, DT_DEVICE_CPU, &iroi_full, &oroi_full,
+               "    tile", piece->pipe, piece->module, DT_DEVICE_CPU, &iroi_full, &oroi_full,
                "tile (%zu,%zu)", tx, ty);
 
       /* prepare input tile buffer */
@@ -1102,7 +1102,7 @@ static void _default_process_tiling_roi(dt_iop_module_t *self,
                (size_t)iroi_full.width * in_bpp);
 
       /* take original processed_maximum as starting point */
-      for(int k = 0; k < 4; k++) piece->pipe->dsc.processed_maximum[k] = processed_maximum_saved[k];
+      for_four_channels(k) piece->pipe->dsc.processed_maximum[k] = processed_maximum_saved[k];
       dt_dev_prepare_piece_cfa(piece, &iroi_full);
 
       /* call process() of module */
@@ -1111,12 +1111,12 @@ static void _default_process_tiling_roi(dt_iop_module_t *self,
       /* aggregate resulting processed_maximum */
       /* TODO: check if there really can be differences between tiles and take
                appropriate action (calculate minimum, maximum, average, ...?) */
-      for(int k = 0; k < 4; k++)
+      for_four_channels(k)
       {
         if(tx + ty > 0 && fabs(processed_maximum_new[k] - piece->pipe->dsc.processed_maximum[k]) > 1.0e-6f)
           dt_print(DT_DEBUG_TILING,
                    "[default_process_tiling_roi] processed_maximum[%d] differs between tiles in module '%s%s'",
-                   k, self->op, dt_iop_get_instance_id(self));
+                   (int)k, self->op, dt_iop_get_instance_id(self));
         processed_maximum_new[k] = piece->pipe->dsc.processed_maximum[k];
       }
 
@@ -1135,7 +1135,7 @@ static void _default_process_tiling_roi(dt_iop_module_t *self,
     }
 
   /* copy back final processed_maximum */
-  for(int k = 0; k < 4; k++) piece->pipe->dsc.processed_maximum[k] = processed_maximum_new[k];
+  for_four_channels(k) piece->pipe->dsc.processed_maximum[k] = processed_maximum_new[k];
 
   dt_free_align(input);
   dt_free_align(output);
@@ -1197,11 +1197,6 @@ static int _default_process_tiling_cl_ptp(dt_iop_module_t *self,
   size_t cltile_w = 0;
   size_t cltile_h = 0;
 
-  cl_mem pinned_input = NULL;
-  cl_mem pinned_output = NULL;
-  void *input_buffer = NULL;
-  void *output_buffer = NULL;
-
   dt_iop_buffer_dsc_t dsc;
   self->output_format(self, piece->pipe, piece, &dsc);
   const int out_bpp = dt_iop_buffer_dsc_to_bpp(&dsc);
@@ -1218,19 +1213,10 @@ static int _default_process_tiling_cl_ptp(dt_iop_module_t *self,
   if(tiling.factor_cl < 0.0f) tiling.factor_cl = tiling.factor;
   if(tiling.maxbuf_cl < 0.0f) tiling.maxbuf_cl = tiling.maxbuf;
 
-  /* shall we use pinned memory transfers? */
-  gboolean use_pinned_memory = dt_opencl_use_pinned_memory(devid);
-  /* If using pinned transfer on devices with dedicated GPU mem there is an additional
-     mem pressure as they will allocate also on device as cache for performance
-  */
-  const float pinned_buffer_overhead = use_pinned_memory && !dt_opencl_unified_memory(devid) ? 2.0f : 0.0f;
-
-  // avoid problems when pinned buffer size gets too close to max_mem_alloc size
-  const float pinned_buffer_slack = use_pinned_memory ? 0.85f : 1.0f;
   const float available = (float)dt_opencl_get_device_available(devid);
-  const float factor = fmaxf(tiling.factor_cl + pinned_buffer_overhead, 1.0f);
+  const float factor = fmaxf(tiling.factor_cl -1.0f, 1.0f);
   const float singlebuffer = fminf(fmaxf((available - tiling.overhead) / factor, 0.0f),
-                                  pinned_buffer_slack * (float)(dt_opencl_get_device_memalloc(devid)));
+                                  (float)(dt_opencl_get_device_memalloc(devid)));
   const float maxbuf = fmaxf(tiling.maxbuf_cl, 1.0f);
   int width = MIN(roi_in->width, darktable.opencl->dev[devid].max_image_width);
   int height = MIN(roi_in->height, darktable.opencl->dev[devid].max_image_height);
@@ -1311,45 +1297,10 @@ static int _default_process_tiling_cl_ptp(dt_iop_module_t *self,
   dt_aligned_pixel_t processed_maximum_new = { 1.0f };
   for_four_channels(k) processed_maximum_saved[k] = piece->pipe->dsc.processed_maximum[k];
 
-  /* reserve pinned input and output memory for host<->device data transfer */
-  if(use_pinned_memory)
-  {
-    const size_t bsize = (size_t)width * height * in_bpp;
-    pinned_input = dt_opencl_alloc_device_buffer_with_flags(devid, bsize, CL_MEM_READ_ONLY | CL_MEM_ALLOC_HOST_PTR);
-
-    if(pinned_input)
-      input_buffer = dt_opencl_map_buffer(devid, pinned_input, TRUE, CL_MAP_WRITE, 0, bsize);
-    if(input_buffer == NULL)
-    {
-      dt_print(DT_DEBUG_OPENCL | DT_DEBUG_TILING,
-               "[default_process_tiling_cl_ptp] [%s] could not map pinned input buffer to host "
-               "memory for module '%s%s'",
-               dt_dev_pixelpipe_type_to_str(piece->pipe->type), self->op, dt_iop_get_instance_id(self));
-      use_pinned_memory = FALSE;
-    }
-  }
-
-  if(use_pinned_memory)
-  {
-    const size_t bsize = (size_t)width * height * out_bpp;
-    pinned_output = dt_opencl_alloc_device_buffer_with_flags(devid, bsize, CL_MEM_WRITE_ONLY | CL_MEM_ALLOC_HOST_PTR);
-    if(pinned_output)
-      output_buffer = dt_opencl_map_buffer(devid, pinned_output, TRUE, CL_MAP_READ, 0, bsize);
-
-    if(output_buffer == NULL)
-    {
-      dt_print(DT_DEBUG_OPENCL | DT_DEBUG_TILING,
-               "[default_process_tiling_cl_ptp] [%s] could not map pinned output buffer to host "
-               "memory for module '%s%s'",
-               dt_dev_pixelpipe_type_to_str(piece->pipe->type), self->op, dt_iop_get_instance_id(self));
-      use_pinned_memory = FALSE;
-    }
-  }
-
   dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_TILING,
-                        "default *tiled* cl_ptp", piece->pipe, piece->module, devid, roi_in, roi_out,
-                        "%dx%d tiles%s, size=%dx%d, overlap=%d",
-                        tiles_x, tiles_y, (use_pinned_memory) ? ", pinned" : "", tile_wd, tile_ht, overlap);
+                        "  *tiled* ptp", piece->pipe, piece->module, devid, roi_in, roi_out,
+                        "%dx%d tiles, size=%dx%d, overlap=%d",
+                        tiles_x, tiles_y, tile_wd, tile_ht, overlap);
   /* iterate over tiles */
   piece->pipe->tiling = TRUE;
   for(size_t tx = 0; tx < tiles_x; tx++)
@@ -1376,7 +1327,7 @@ static int _default_process_tiling_cl_ptp(dt_iop_module_t *self,
       size_t ooffs = (ty * tile_ht) * opitch + (tx * tile_wd) * out_bpp;
 
       dt_print_pipe(DT_DEBUG_TILING,
-               skipped ? "  tile cl_ptp skipped" : "  tile cl_ptp", piece->pipe, piece->module, devid, &iroi, &oroi,
+               skipped ? "    tile skipped" : "    tile", piece->pipe, piece->module, devid, &iroi, &oroi,
                "tile (%zu,%zu)", tx, ty);
       if(skipped) continue;
 
@@ -1396,28 +1347,12 @@ static int _default_process_tiling_cl_ptp(dt_iop_module_t *self,
         cltile_h = ht;
       }
 
-      if(use_pinned_memory)
-      {
-        /* prepare pinned input tile buffer: copy part of input image */
-        DT_OMP_FOR()
-        for(size_t j = 0; j < ht; j++)
-          memcpy((char *)input_buffer + j * wd * in_bpp, (char *)ivoid + ioffs + j * ipitch,
-                 (size_t)wd * in_bpp);
-
-        /* blocking memory transfer: pinned host input buffer -> opencl/device tile */
-        err = dt_opencl_write_host_to_image_raw(devid, (char *)input_buffer, input, origin, region,
-                                                 wd * in_bpp, TRUE);
-        if(err != CL_SUCCESS) use_pinned_memory = FALSE;
-      }
-      else
-      {
-        /* blocking direct memory transfer: host input image -> opencl/device tile */
-        err = dt_opencl_write_host_to_image_raw(devid, (char *)ivoid + ioffs, input, origin, region, ipitch, TRUE);
-      }
+      /* blocking direct memory transfer: host input image -> opencl/device tile */
+      err = dt_opencl_write_host_to_image_raw(devid, (char *)ivoid + ioffs, input, origin, region, ipitch, TRUE);
       if(err != CL_SUCCESS) goto error;
 
       /* take original processed_maximum as starting point */
-      for(int k = 0; k < 4; k++) piece->pipe->dsc.processed_maximum[k] = processed_maximum_saved[k];
+      for_four_channels(k) piece->pipe->dsc.processed_maximum[k] = processed_maximum_saved[k];
       dt_dev_prepare_piece_cfa(piece, &iroi);
       /* call process_cl of module */
       err = self->process_cl(self, piece, input, output, &iroi, &oroi);
@@ -1427,25 +1362,13 @@ static int _default_process_tiling_cl_ptp(dt_iop_module_t *self,
       /* aggregate resulting processed_maximum */
       /* TODO: check if there really can be differences between tiles and take
                appropriate action (calculate minimum, maximum, average, ...?) */
-      for(int k = 0; k < 4; k++)
+      for_four_channels(k)
       {
         if(tx + ty > 0 && fabs(processed_maximum_new[k] - piece->pipe->dsc.processed_maximum[k]) > 1.0e-6f)
           dt_print(DT_DEBUG_TILING,
                    "[default_process_tiling_cl_ptp] [%s] processed_maximum[%d] differs between tiles in module '%s%s'",
-                   dt_dev_pixelpipe_type_to_str(piece->pipe->type), k, self->op, dt_iop_get_instance_id(self));
+                   dt_dev_pixelpipe_type_to_str(piece->pipe->type), (int)k, self->op, dt_iop_get_instance_id(self));
         processed_maximum_new[k] = piece->pipe->dsc.processed_maximum[k];
-      }
-
-      if(use_pinned_memory)
-      {
-        /* blocking memory transfer: complete opencl/device tile -> pinned host output buffer */
-        err = dt_opencl_read_host_from_image_raw(devid, (char *)output_buffer, output, origin, region,
-                                                  wd * out_bpp, TRUE);
-        if(err != CL_SUCCESS)
-        {
-          use_pinned_memory = FALSE;
-          goto error;
-        }
       }
 
       /* correct origin and region of tile for overlap.
@@ -1463,22 +1386,10 @@ static int _default_process_tiling_cl_ptp(dt_iop_module_t *self,
         ooffs += (size_t)overlap * opitch;
       }
 
-      if(use_pinned_memory)
-      {
-        /* copy "good" part of tile from pinned output buffer to output image */
-        //        DT_OMP_FOR(shared(origin, region))
-        for(size_t j = 0; j < region[1]; j++)
-          memcpy((char *)ovoid + ooffs + j * opitch,
-                 (char *)output_buffer + ((j + origin[1]) * wd + origin[0]) * out_bpp,
-                 (size_t)region[0] * out_bpp);
-      }
-      else
-      {
-        /* blocking direct memory transfer: good part of opencl/device tile -> host output image */
-        err = dt_opencl_read_host_from_image_raw(devid, (char *)ovoid + ooffs, output, origin, region,
+      /* blocking direct memory transfer: good part of opencl/device tile -> host output image */
+      err = dt_opencl_read_host_from_image_raw(devid, (char *)ovoid + ooffs, output, origin, region,
                                                   opitch, TRUE);
-        if(err != CL_SUCCESS) goto error;
-      }
+      if(err != CL_SUCCESS) goto error;
 
       /* block until opencl queue has finished to free all used event handlers */
       dt_opencl_finish_sync_pipe(devid, piece->pipe->type);
@@ -1486,12 +1397,8 @@ static int _default_process_tiling_cl_ptp(dt_iop_module_t *self,
   }
 
   /* copy back final processed_maximum */
-  for(int k = 0; k < 4; k++) piece->pipe->dsc.processed_maximum[k] = processed_maximum_new[k];
+  for_four_channels(k) piece->pipe->dsc.processed_maximum[k] = processed_maximum_new[k];
 
-  if(input_buffer != NULL) dt_opencl_unmap_mem_object(devid, pinned_input, input_buffer);
-  dt_opencl_release_mem_object(pinned_input);
-  if(output_buffer != NULL) dt_opencl_unmap_mem_object(devid, pinned_output, output_buffer);
-  dt_opencl_release_mem_object(pinned_output);
   dt_opencl_release_mem_object(input);
   dt_opencl_release_mem_object(output);
   piece->pipe->tiling = FALSE;
@@ -1499,22 +1406,16 @@ static int _default_process_tiling_cl_ptp(dt_iop_module_t *self,
 
 error:
   /* copy back stored processed_maximum */
-  for(int k = 0; k < 4; k++) piece->pipe->dsc.processed_maximum[k] = processed_maximum_saved[k];
-  if(input_buffer != NULL) dt_opencl_unmap_mem_object(devid, pinned_input, input_buffer);
-  dt_opencl_release_mem_object(pinned_input);
-  if(output_buffer != NULL) dt_opencl_unmap_mem_object(devid, pinned_output, output_buffer);
-  dt_opencl_release_mem_object(pinned_output);
+  for_four_channels(k) piece->pipe->dsc.processed_maximum[k] = processed_maximum_saved[k];
   dt_opencl_release_mem_object(input);
   dt_opencl_release_mem_object(output);
   piece->pipe->tiling = FALSE;
-  const gboolean pinning_error = !use_pinned_memory && dt_opencl_use_pinned_memory(devid);
   dt_print(DT_DEBUG_TILING | DT_DEBUG_OPENCL,
            "[default_process_tiling_opencl_ptp] [%s] couldn't run process_cl() for "
-           "module '%s%s' in tiling mode:%s %s",
+           "module '%s%s' in tiling mode: %s",
            dt_dev_pixelpipe_type_to_str(piece->pipe->type), self->op, dt_iop_get_instance_id(self),
-           (pinning_error) ? " pinning problem" : "", cl_errstr(err));
+           cl_errstr(err));
 
-  if(pinning_error) darktable.opencl->dev[devid].pinned_error = TRUE;
   return err;
 }
 
@@ -1535,10 +1436,6 @@ static int _default_process_tiling_cl_roi(dt_iop_module_t *self,
   size_t cltile_oh = 0;
   size_t cltile_iw = 0;
   size_t cltile_ih = 0;
-  cl_mem pinned_input = NULL;
-  cl_mem pinned_output = NULL;
-  void *input_buffer = NULL;
-  void *output_buffer = NULL;
 
   dt_iop_buffer_dsc_t dsc;
   self->output_format(self, piece->pipe, piece, &dsc);
@@ -1565,19 +1462,10 @@ static int _default_process_tiling_cl_roi(dt_iop_module_t *self,
   if(tiling.factor_cl < 0) tiling.factor_cl = tiling.factor;
   if(tiling.maxbuf_cl < 0) tiling.maxbuf_cl = tiling.maxbuf;
 
-  /* shall we use pinned memory transfers? */
-  gboolean use_pinned_memory = dt_opencl_use_pinned_memory(devid);
-
-  /* If using pinned transfer on devices with dedicated GPU mem there is an additional
-     mem pressure as they will allocate also on device as cache for performance
-  */
-  const float pinned_buffer_overhead = use_pinned_memory && !dt_opencl_unified_memory(devid) ? 2.0f : 0.0f;
-  // avoid problems when pinned buffer size gets too close to max_mem_alloc size
-  const float pinned_buffer_slack = use_pinned_memory ? 0.85f : 1.0f;
   const float available = (float)dt_opencl_get_device_available(devid);
-  const float factor = fmaxf(tiling.factor_cl + pinned_buffer_overhead, 1.0f);
+  const float factor = fmaxf(tiling.factor_cl - 1.0f, 1.0f);
   const float singlebuffer = fminf(fmaxf((available - tiling.overhead) / factor, 0.0f),
-                                  pinned_buffer_slack * (float)(dt_opencl_get_device_memalloc(devid)));
+                                  (float)(dt_opencl_get_device_memalloc(devid)));
   const float maxbuf = fmaxf(tiling.maxbuf_cl, 1.0f);
 
   int width = MIN(MAX(roi_in->width, roi_out->width), darktable.opencl->dev[devid].max_image_width);
@@ -1662,47 +1550,13 @@ static int _default_process_tiling_cl_roi(dt_iop_module_t *self,
       roi_out->height % tiles_y == 0 ? roi_out->height / tiles_y : roi_out->height / tiles_y + 1, align);
 
   dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_TILING,
-                        "process *tiled* roi", piece->pipe, piece->module, devid, roi_in, roi_out,
-                        "%dx%d tiles%s, size=%dx%d",
-                        tiles_x, tiles_y, (use_pinned_memory) ? ", pinned" : "", tile_wd, tile_ht);
+                        "  *tiled* roi", piece->pipe, piece->module, devid, roi_in, roi_out,
+                        "%dx%d tiles, size=%dx%d",
+                        tiles_x, tiles_y, tile_wd, tile_ht);
   /* store processed_maximum to be re-used and aggregated */
   dt_aligned_pixel_t processed_maximum_saved;
   dt_aligned_pixel_t processed_maximum_new = { 1.0f, 1.0f, 1.0f, 1.0f };
   for_four_channels(k) processed_maximum_saved[k] = piece->pipe->dsc.processed_maximum[k];
-
-  /* reserve pinned input and output memory for host<->device data transfer */
-  if(use_pinned_memory)
-  {
-    const size_t bsize = (size_t)width * height * in_bpp;
-    pinned_input = dt_opencl_alloc_device_buffer_with_flags(devid, bsize, CL_MEM_READ_ONLY | CL_MEM_ALLOC_HOST_PTR);
-    if(pinned_input)
-      input_buffer = dt_opencl_map_buffer(devid, pinned_input, TRUE, CL_MAP_WRITE, 0, bsize);
-    if(input_buffer == NULL)
-    {
-      dt_print(DT_DEBUG_OPENCL | DT_DEBUG_TILING,
-               "[default_process_tiling_cl_roi] [%s] could not map pinned input buffer to host "
-               "memory for module '%s%s'",
-               dt_dev_pixelpipe_type_to_str(piece->pipe->type), self->op, dt_iop_get_instance_id(self));
-      use_pinned_memory = FALSE;
-    }
-  }
-
-  if(use_pinned_memory)
-  {
-    const size_t bsize = (size_t)width * height * out_bpp;
-    pinned_output = dt_opencl_alloc_device_buffer_with_flags(devid, bsize, CL_MEM_WRITE_ONLY | CL_MEM_ALLOC_HOST_PTR);
-    if(pinned_output)
-      output_buffer = dt_opencl_map_buffer(devid, pinned_output, TRUE, CL_MAP_READ, 0, bsize);
-    if(output_buffer == NULL)
-    {
-      dt_print(DT_DEBUG_OPENCL | DT_DEBUG_TILING,
-               "[default_process_tiling_cl_roi] [%s] could not map pinned output buffer to host "
-               "memory for module '%s%s'",
-               dt_dev_pixelpipe_type_to_str(piece->pipe->type), self->op, dt_iop_get_instance_id(self));
-      use_pinned_memory = FALSE;
-    }
-  }
-
 
   /* iterate over tiles */
   piece->pipe->tiling = TRUE;
@@ -1803,18 +1657,15 @@ static int _default_process_tiling_cl_roi(dt_iop_module_t *self,
       /* region of full input tile */
       const size_t iregion[2] = { iroi_full.width, iroi_full.height };
 
-      /* region of full output tile */
-      const size_t ofregion[2] = { oroi_full.width, oroi_full.height };
-
       /* origin and region of good part of output tile */
       const size_t oorigin[2] = { oroi_good.x - oroi_full.x, oroi_good.y - oroi_full.y };
       const size_t oregion[2] = { oroi_good.width, oroi_good.height };
 
       dt_print_pipe(DT_DEBUG_TILING,
-              "  tile cl_roi", piece->pipe, piece->module, devid, &iroi_full, &oroi_full,
+              "    tile", piece->pipe, piece->module, devid, &iroi_full, &oroi_full,
               "tile (%zu,%zu)", tx, ty);
       dt_print_pipe(DT_DEBUG_TILING | DT_DEBUG_VERBOSE,
-             "  tile cl_roi", piece->pipe, piece->module, devid, &iroi_full, &oroi_full,
+              "    tile", piece->pipe, piece->module, devid, &iroi_full, &oroi_full,
               "tile (%zu,%zu)  offsets=[%i,%i] delta=%i", tx, ty, out_dx, out_dy, delta);
 
       /* get opencl input and output buffers */
@@ -1840,29 +1691,13 @@ static int _default_process_tiling_cl_roi(dt_iop_module_t *self,
         goto error;
       }
 
-      if(use_pinned_memory)
-      {
-        /* prepare pinned input tile buffer: copy part of input image */
-        DT_OMP_FOR(shared(iroi_full))
-        for(size_t j = 0; j < iroi_full.height; j++)
-          memcpy((char *)input_buffer + j * iroi_full.width * in_bpp, (char *)ivoid + ioffs + j * ipitch,
-                 (size_t)iroi_full.width * in_bpp);
-
-        /* blocking memory transfer: pinned host input buffer -> opencl/device tile */
-        err = dt_opencl_write_host_to_image_raw(devid, (char *)input_buffer, input, CLIMG_ORIGIN, iregion,
-                                                 (size_t)iroi_full.width * in_bpp, TRUE);
-        if(err != CL_SUCCESS) use_pinned_memory = FALSE;
-      }
-      else
-      {
-        /* blocking direct memory transfer: host input image -> opencl/device tile */
-        err = dt_opencl_write_host_to_image_raw(devid, (char *)ivoid + ioffs, input, CLIMG_ORIGIN, iregion,
+      /* blocking direct memory transfer: host input image -> opencl/device tile */
+      err = dt_opencl_write_host_to_image_raw(devid, (char *)ivoid + ioffs, input, CLIMG_ORIGIN, iregion,
                                                  ipitch, TRUE);
-      }
       if(err != CL_SUCCESS) goto error;
 
       /* take original processed_maximum as starting point */
-      for(int k = 0; k < 4; k++) piece->pipe->dsc.processed_maximum[k] = processed_maximum_saved[k];
+      for_four_channels(k) piece->pipe->dsc.processed_maximum[k] = processed_maximum_saved[k];
 
       dt_dev_prepare_piece_cfa(piece, &iroi_full);
       /* call process_cl of module */
@@ -1873,51 +1708,27 @@ static int _default_process_tiling_cl_roi(dt_iop_module_t *self,
       /* aggregate resulting processed_maximum */
       /* TODO: check if there really can be differences between tiles and take
                appropriate action (calculate minimum, maximum, average, ...?) */
-      for(int k = 0; k < 4; k++)
+      for_four_channels(k)
       {
         if(tx + ty > 0 && fabs(processed_maximum_new[k] - piece->pipe->dsc.processed_maximum[k]) > 1.0e-6f)
           dt_print(DT_DEBUG_TILING,
                    "[default_process_tiling_cl_roi] [%s] processed_maximum[%d] "
                    "differs between tiles in module '%s%s'",
-                   dt_dev_pixelpipe_type_to_str(piece->pipe->type), k, self->op, dt_iop_get_instance_id(self));
+                   dt_dev_pixelpipe_type_to_str(piece->pipe->type), (int)k, self->op, dt_iop_get_instance_id(self));
         processed_maximum_new[k] = piece->pipe->dsc.processed_maximum[k];
       }
 
-      if(use_pinned_memory)
-      {
-        /* blocking memory transfer: complete opencl/device tile -> pinned host output buffer */
-        err = dt_opencl_read_host_from_image_raw(devid, (char *)output_buffer, output, CLIMG_ORIGIN, ofregion,
-                                                  (size_t)oroi_full.width * out_bpp, TRUE);
-        if(err != CL_SUCCESS)
-        {
-          use_pinned_memory = FALSE;
-          goto error;
-        }
-        /* copy "good" part of tile from pinned output buffer to output image */
-        DT_OMP_FOR(shared(oroi_full, oorigin, oregion))
-        for(size_t j = 0; j < oregion[1]; j++)
-          memcpy((char *)ovoid + ooffs + j * opitch,
-                 (char *)output_buffer + ((j + oorigin[1]) * oroi_full.width + oorigin[0]) * out_bpp,
-                 (size_t)oregion[0] * out_bpp);
-      }
-      else
-      {
-        /* blocking direct memory transfer: good part of opencl/device tile -> host output image */
-        err = dt_opencl_read_host_from_image_raw(devid, (char *)ovoid + ooffs, output, oorigin, oregion,
+      /* blocking direct memory transfer: good part of opencl/device tile -> host output image */
+      err = dt_opencl_read_host_from_image_raw(devid, (char *)ovoid + ooffs, output, oorigin, oregion,
                                                   opitch, TRUE);
-        if(err != CL_SUCCESS) goto error;
-      }
+      if(err != CL_SUCCESS) goto error;
 
       /* block until opencl queue has finished to free all used event handlers */
       dt_opencl_finish_sync_pipe(devid, piece->pipe->type);
     }
   }
   /* copy back final processed_maximum */
-  for(int k = 0; k < 4; k++) piece->pipe->dsc.processed_maximum[k] = processed_maximum_new[k];
-  if(input_buffer != NULL) dt_opencl_unmap_mem_object(devid, pinned_input, input_buffer);
-  dt_opencl_release_mem_object(pinned_input);
-  if(output_buffer != NULL) dt_opencl_unmap_mem_object(devid, pinned_output, output_buffer);
-  dt_opencl_release_mem_object(pinned_output);
+  for_four_channels(k) piece->pipe->dsc.processed_maximum[k] = processed_maximum_new[k];
   dt_opencl_release_mem_object(input);
   dt_opencl_release_mem_object(output);
   piece->pipe->tiling = FALSE;
@@ -1925,21 +1736,14 @@ static int _default_process_tiling_cl_roi(dt_iop_module_t *self,
 
 error:
   /* copy back stored processed_maximum */
-  for(int k = 0; k < 4; k++) piece->pipe->dsc.processed_maximum[k] = processed_maximum_saved[k];
-  if(input_buffer != NULL) dt_opencl_unmap_mem_object(devid, pinned_input, input_buffer);
-  dt_opencl_release_mem_object(pinned_input);
-  if(output_buffer != NULL) dt_opencl_unmap_mem_object(devid, pinned_output, output_buffer);
-  dt_opencl_release_mem_object(pinned_output);
+  for_four_channels(k) piece->pipe->dsc.processed_maximum[k] = processed_maximum_saved[k];
   dt_opencl_release_mem_object(input);
   dt_opencl_release_mem_object(output);
   piece->pipe->tiling = FALSE;
-  const gboolean pinning_error = (use_pinned_memory == FALSE) && dt_opencl_use_pinned_memory(devid);
   dt_print_pipe(DT_DEBUG_OPENCL | DT_DEBUG_TILING,
            "default tiling_cl_roi error", piece->pipe, piece->module, devid, roi_in, roi_out,
-           "%serror=%s",
-           (pinning_error) ? "pinning problem " : "", cl_errstr(err));
+           "error=%s", cl_errstr(err));
 
-  if(pinning_error) darktable.opencl->dev[devid].pinned_error = TRUE;
   return err;
 }
 
@@ -1962,6 +1766,105 @@ int default_process_tiling_cl(dt_iop_module_t *self,
     return _default_process_tiling_cl_ptp(self, piece, ivoid, ovoid, roi_in, roi_out, in_bpp);
 }
 
+int process_tiling_cl_fast(dt_dev_pixelpipe_iop_t *piece,
+                           void *cl_in,
+                           void *cl_out,
+                           const dt_iop_roi_t *roi_in,
+                           const dt_iop_roi_t *roi_out,
+                           const int in_bpp,
+                           const int bpp,
+                           const dt_develop_tiling_t *tiling)
+{
+  dt_dev_pixelpipe_t *pipe = piece->pipe;
+  dt_iop_module_t *module = piece->module;
+  const int devid = pipe->devid;
+  const int width = roi_in->width;
+  const int height = roi_in->height;
+  const int aligner = MAX(tiling->align, dt_opencl_tiling_align(devid));
+  const int border = _align_up(tiling->overlap, aligner);
+  const int64_t overhead = tiling->overhead;
+  const int64_t allmem = dt_opencl_get_device_available(devid);
+  const int64_t avail = allmem - (int64_t)(in_bpp + bpp)*width*height - overhead;
+  const int per_row = in_bpp * width * tiling->factor_cl;
+  const int possible = avail / per_row;
+  const int tile_height = darktable.opencl->fast_tiling
+        ? _align_up(MIN(300+3*border, possible), aligner)
+        : _align_up(possible, aligner);
+  const int valid_rows = tile_height - 2*border;
+  const int num_tiles = (height + valid_rows - 1) / valid_rows;
+  dt_print_pipe(DT_DEBUG_OPENCL | DT_DEBUG_TILING | DT_DEBUG_VERBOSE,
+    "  fast tiling", pipe, module, devid, roi_in, roi_out,
+    "tiles=%d validrows=%d border=%d", num_tiles, valid_rows, border);
+
+  cl_int err = CL_SUCCESS;
+  cl_mem t_in = dt_opencl_alloc_device(devid, width, tile_height, in_bpp);
+  cl_mem t_out = dt_opencl_alloc_device(devid, width, tile_height, bpp);
+  if(!t_in || !t_out)
+  {
+    err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
+    goto finish;
+  }
+
+  dt_aligned_pixel_t processed_maximum_saved;
+  for_four_channels(k) processed_maximum_saved[k] = piece->pipe->dsc.processed_maximum[k];
+  dt_aligned_pixel_t processed_maximum_new = { 1.0f, 1.0f, 1.0f, 1.0f };
+
+  for(int tile_nr = 0; tile_nr < num_tiles; tile_nr++)
+  {
+    const int group = tile_nr * valid_rows ;
+    const int last_in = MIN(height, group + valid_rows + border);
+    const int topline = group - border;
+    const int first_in = MAX(0, topline);
+    const int t_rows = last_in - first_in;
+    const int missing = topline < 0 ? -topline : 0;
+    const int first_out = border - missing;
+    const int out_height = t_rows - first_out;
+
+    if(out_height > 0)
+    {
+      /* roi_in and roi_out for process_cl on subbuffer */
+      const dt_iop_roi_t iroi = { roi_in->x, roi_in->y + first_in, width, t_rows, roi_in->scale };
+      const dt_iop_roi_t oroi = { roi_out->x, roi_out->y + first_in, width, t_rows, roi_out->scale };
+      dt_dev_prepare_piece_cfa(piece, &iroi);
+      for_four_channels(k) piece->pipe->dsc.processed_maximum[k] = processed_maximum_saved[k];
+
+      dt_print_pipe(DT_DEBUG_OPENCL | DT_DEBUG_TILING | DT_DEBUG_VERBOSE,
+        "    tile", pipe, module, devid, &iroi, &oroi,
+        "tile=%.3d/%.3d, group=%.5d first=%.5d last=%.5d rows=%.4d",
+        tile_nr, num_tiles, group, first_in, last_in, t_rows);
+      const size_t insrc[2]  = { 0, first_in };
+      const size_t iarea[2]  = { width, t_rows };
+      err = dt_opencl_enqueue_copy_image(devid, (cl_mem)cl_in, t_in, insrc, CLIMG_ORIGIN, iarea);
+      if(err != CL_SUCCESS) goto finish;
+
+      err = module->process_cl(module, piece, t_in, t_out, &iroi, &oroi);
+      if(err != CL_SUCCESS) goto finish;
+
+      for_four_channels(k)
+      {
+        if(tile_nr > 0 && fabs(processed_maximum_new[k] - piece->pipe->dsc.processed_maximum[k]) > 1.0e-6f)
+          dt_print_pipe(DT_DEBUG_OPENCL | DT_DEBUG_TILING,
+            "changed procmax", pipe, module, devid, &iroi, &oroi,
+            "tile=%d channel=%d procmax=%.3f", tile_nr, (int)k, piece->pipe->dsc.processed_maximum[k]);
+        processed_maximum_new[k] = piece->pipe->dsc.processed_maximum[k];
+      }
+
+      const size_t tsrc[2]   = { 0, first_out };
+      const size_t odest[2]  = { 0, group };
+      const size_t oarea[2]  = { width, out_height };
+      err = dt_opencl_enqueue_copy_image(devid, t_out, (cl_mem)cl_out, tsrc, odest, oarea);
+      if(err != CL_SUCCESS) goto finish;
+    }
+  }
+  for_four_channels(k)
+    pipe->dsc.processed_maximum[k] = processed_maximum_new[k];
+
+finish:
+  dt_opencl_release_mem_object(t_in);
+  dt_opencl_release_mem_object(t_out);
+  return err;
+}
+
 #else
 int default_process_tiling_cl(dt_iop_module_t *self,
                               dt_dev_pixelpipe_iop_t *piece,
@@ -1970,6 +1873,18 @@ int default_process_tiling_cl(dt_iop_module_t *self,
                               const dt_iop_roi_t *const roi_in,
                               const dt_iop_roi_t *const roi_out,
                               const int in_bpp)
+{
+  return DT_OPENCL_DEFAULT_ERROR;
+}
+
+int process_tiling_cl_fast(dt_dev_pixelpipe_iop_t *piece,
+                        void *cl_in,
+                        void *cl_out,
+                        const dt_iop_roi_t *roi_in,
+                        const dt_iop_roi_t *roi_out,
+                        const int in_bpp,
+                        const int bpp,
+                        const dt_develop_tiling_t *tiling)
 {
   return DT_OPENCL_DEFAULT_ERROR;
 }

--- a/src/develop/tiling.h
+++ b/src/develop/tiling.h
@@ -48,6 +48,10 @@ int process_tiling_cl(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_
                       const void *const ivoid, void *const ovoid, const dt_iop_roi_t *const roi_in,
                       const dt_iop_roi_t *const roi_out, const int bpp);
 
+int process_tiling_cl_fast(struct dt_dev_pixelpipe_iop_t *piece, void *cl_in, void *cl_out,
+                        const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out,
+                        const int in_bpp, const int bpp, const dt_develop_tiling_t *tiling);
+
 void default_process_tiling(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece,
                             const void *const ivoid, void *const ovid, const dt_iop_roi_t *const roi_in,
                             const dt_iop_roi_t *const roi_out, const int bpp);

--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -662,7 +662,7 @@ int process_cl(dt_iop_module_t *self,
       // note: tiling takes care about processed_maximum
       pipe->dsc.processed_maximum[k] *= coeffs[k];
     }
-    dt_print_pipe(DT_DEBUG_PIPE, "coeff correction",
+    dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_VERBOSE, "coeff correction",
       pipe, self, devid, roi_in, roi_out, "`%s' %.3f(*%.3f) %.3f(*%.3f) %.3f(*%.3f)",
       dt_colorspaces_get_name(d->type, NULL),
       pipe->dsc.temperature.coeffs[0], coeffs[0],
@@ -1209,7 +1209,7 @@ void process(dt_iop_module_t *self,
       // note: tiling takes care about processed_maximum
       pipe->dsc.processed_maximum[k] *= coeffs[k];
     }
-    dt_print_pipe(DT_DEBUG_PIPE, "coeff correction",
+    dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_VERBOSE, "coeff correction",
       pipe, self, DT_DEVICE_CPU, roi_in, roi_out, "`%s' %.3f(*%.3f) %.3f(*%.3f) %.3f(*%.3f)",
       dt_colorspaces_get_name(d->type, NULL),
       pipe->dsc.temperature.coeffs[0], coeffs[0],


### PR DESCRIPTION
1. Introduce pixelpipe internal OpenCL tiling. In many cases we can avoid the fallback to current tiling code if these requirements are met:
   - the ratio of required and available cl_mem for a module processing is ok
   - roi_in/out match so we wouldn't use the roi tiling mode
   - the largest requested image/buffer can be handled by driver/hardware

   To test for above conditions `dt_opencl_image_fits_device()` had to be updated, it now returns a `dt_opencl_tilemode_t` enum value telling if old-style tiling is required or if we can do without tiling or use the new internal mode.

   The internal tiling gets a performance boost for all pipes as
   - two costly host/device transfers per tile are replaced by faster on-device copy of cl_mem image. The algorithm works as the internal demosaic and feathering tiling on vertical tiles as performance has proven to be very good this way on most hardware.
   - if we blend or take pickers we do that in OpenCL instead of CPU and host memory.

   We have a new cli option `--opencl-tiling` enforcing OpenCL tiling in almost all cases.
   Can be used to verify for debugging sessions or to measure the penalty for internal tiling.

2. pinned tiling mode has been removed as there was no reliable performance gain - we couldn't avoid the fragmented CPU bound copy and couldn't make use of zero-copy. Tested on unified mem systems and dedicated graphics card - so let's reduce code burden. Note: currently under investigation if mapping cl_mem in/output can improve performance.

3. Consequent use of for_four_channels() in tiling.c while being here.

Integration suite tests without any issue