### PR TITLE
Reduce OpenCL pipe host-mem pressure

### DIFF
--- a/src/develop/pixelpipe_cache.c
+++ b/src/develop/pixelpipe_cache.c
@@ -441,6 +441,23 @@ static size_t _free_cacheline(dt_dev_pixelpipe_cache_t *cache, const int k)
   return removed;
 }
 
+void dt_dev_pixelpipe_clear_cacheline(dt_dev_pixelpipe_t *pipe,
+                                      const void *data,
+                                      const char *info)
+{
+  dt_dev_pixelpipe_cache_t *cache = &pipe->cache;
+  for(int k = DT_PIPECACHE_MIN; k < cache->entries; k++)
+  {
+    if(cache->data[k] == data)
+    {
+      _free_cacheline(cache, k);
+      if(info)
+        dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_VERBOSE,
+          "clear cacheline", pipe, NULL, pipe->devid, NULL, NULL, "'%s'", info);
+    }
+  }
+}
+
 static inline int _used(const dt_dev_pixelpipe_cache_t *cache)
 {
   int cnt = 0;

--- a/src/develop/pixelpipe_cache.h
+++ b/src/develop/pixelpipe_cache.h
@@ -90,6 +90,9 @@ void dt_dev_pixelpipe_important_cacheline(const struct dt_dev_pixelpipe_t *pipe,
 /** mark the given cache line as invalid or to be ignored */
 void dt_dev_pixelpipe_invalidate_cacheline(const struct dt_dev_pixelpipe_t *pipe, const void *data, const char *info);
 
+/** removes cacheline and deallocates from pool. Note: use with great care! */
+void dt_dev_pixelpipe_clear_cacheline(struct dt_dev_pixelpipe_t *pipe, const void *data, const char *info);
+
 /** print out cache lines/hashes and do a cache cleanup */
 void dt_dev_pixelpipe_cache_report(struct dt_dev_pixelpipe_t *pipe);
 void dt_dev_pixelpipe_cache_checkmem(struct dt_dev_pixelpipe_t *pipe);

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -2887,8 +2887,8 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
         return TRUE;
     }
 
-    if(valid_input_on_gpu_only) // can't we clear/dealloc the cachline ?
-      dt_dev_pixelpipe_invalidate_cacheline(pipe, input, NULL);
+    if(valid_input_on_gpu_only)
+      dt_dev_pixelpipe_clear_cacheline(pipe, input, "input=valid_input_on_gpu_only");
   }
   else
 #endif // HAVE_OPENCL


### PR DESCRIPTION
While processing an OpenCL pipe we *always* have an allocated input cacheline which is used if
- we pass module input data via host mem (last module was CPU bound)
- cl_mem data is written back to host for important cachelines
- a shutdown mode suggested this
- we do tiling via host mem
- we have to fallback to cpu code because of errors

**but** in many cases that cacheline is not used at all and will not be used in other pipe runs. This can be tested *after all processing* has been done via `valid_input_on_gpu_only`, in that case we can clear the cacheline - `dt_dev_pixelpipe_clear_cacheline()` has been introduced to do that.

By doing so we can reduce host-memory footprint when processing an OpenCL bound pipe for stability on low-mem systems.