### PR TITLE
Fix infinite recursion when switching lens correction methods

### DIFF
--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -4374,8 +4374,10 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
       img->exif_correction_type != CORRECTION_TYPE_DNG
       && p->md_version >= DT_IOP_LENS_EMBEDDED_METADATA_VERSION_2;
 
-    dt_bauhaus_toggle_set(g->use_latest_md_algo,
-                                 FALSE);
+    // guard: the callback re-enters gui_changed -> infinite recursion
+    DT_ENTER_GUI_UPDATE();
+    dt_bauhaus_toggle_set(g->use_latest_md_algo, FALSE);
+    DT_LEAVE_GUI_UPDATE();
     gtk_widget_set_visible
       (g->use_latest_md_algo,
        p->md_version != DT_IOP_LENS_EMBEDDED_METADATA_VERSION_2);


### PR DESCRIPTION
**Bug:** open an image that has embedded lens correction data (Sony ARW, Fujifilm RAF, Olympus ORF, or a DNG with lens opcodes). In the lens correction module, switch the method from "embedded metadata" to "Lensfun" and then back. darktable crashes.

The `gui_changed` function in the lens module always resets a toggle widget when it enters the embedded-metadata branch. That reset triggers the toggle's callback, which calls `gui_changed` again, which resets the toggle, which triggers the callback ... until the stack runs out.

**Fix:** wrap the toggle reset in `DT_ENTER_GUI_UPDATE()` / `DT_LEAVE_GUI_UPDATE()`. This tells the bauhaus widget "we're only syncing the UI, don't fire the callback". Same pattern already used in `agx.c`, `crop.c`, `spots.c`.

Latent bug – present since embedded metadata was added, but the "switch method away and back" sequence is rare so nobody had tripped it.