### PR TITLE
Scale the amount of cache memory with the `resources` settings

### DIFF
--- a/src/develop/pixelpipe_cache.c
+++ b/src/develop/pixelpipe_cache.c
@@ -23,6 +23,15 @@
 #include "libs/colorpicker.h"
 #include <stdlib.h>
 
+// The darkroom pipe cache holds at most cache->entries full-canvas lines, so its
+// interactively useful size is bounded by that slot count and the canvas
+// resolution. Size the eviction limit from the memory darktable is allowed to use
+// (which tracks the 'resources' setting) rather than the static mipmap-derived
+// base, but never claim more than a 1/DT_PIPECACHE_BUDGET_DIVISOR share of that
+// budget for cachelines, and never collapse below a few working buffers.
+#define DT_PIPECACHE_BUDGET_DIVISOR 2
+#define DT_PIPECACHE_MIN_LINES 4
+
 gboolean dt_dev_pixelpipe_cache_init(dt_dev_pixelpipe_t *pipe,
                                      const int entries,
                                      const size_t size,
@@ -486,7 +495,30 @@ void dt_dev_pixelpipe_cache_checkmem(dt_dev_pixelpipe_t *pipe)
     }
   }
 
-  while(cache->memlimit && (cache->memlimit < cache->allmem))
+  /* The static memlimit (set at init from the mipmap fraction) tracks neither the
+     'resources' setting -- 'large' raises the overall budget but not the mipmap
+     fraction -- nor the canvas resolution, where a single full-canvas line can be
+     most of it, collapsing the cache to the alternating buffers and forcing a full
+     pipe recompute on every edit. Size the eviction limit from the memory darktable
+     is allowed to use instead (which does scale with 'resources'), capped to what
+     the cache can actually hold (the pipe only ever fills cache->entries lines) and
+     to a share of the budget, and floored so it never collapses. This runs on the
+     full (darkroom) pipe only; leaving darkroom trims it back via cache_trim(). */
+  size_t effective = cache->memlimit;
+  if(effective)
+  {
+    // largest buffer currently held == the working canvas size
+    size_t maxline = 0;
+    for(int k = DT_PIPECACHE_MIN; k < cache->entries; k++)
+      maxline = MAX(maxline, cache->size[k]);
+    const size_t budget = dt_get_available_mem();
+    const size_t saturate = (size_t)cache->entries * maxline;      // all slots filled
+    const size_t share = budget / DT_PIPECACHE_BUDGET_DIVISOR;     // affordable slice
+    const size_t floor = MIN((size_t)DT_PIPECACHE_MIN_LINES * maxline, budget);
+    effective = MAX(cache->memlimit, MAX(floor, MIN(saturate, share)));
+  }
+
+  while(effective && (effective < cache->allmem))
   {
     const int k = _get_oldest_cacheline(cache, DT_CACHETEST_USED);
     if(k == 0) break;
@@ -497,9 +529,34 @@ void dt_dev_pixelpipe_cache_checkmem(dt_dev_pixelpipe_t *pipe)
 
   if(free_cnt + free_invalid_cnt)
     dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_MEMORY, "pipe cache check", pipe, NULL, DT_DEVICE_NONE, NULL, NULL,
-      "Freed lines invalid=%i used=%i. Freed mem invalid %zuMB used %zuMB. Now %zuMB limit=%zuMB max=%zuMB",
+      "Freed lines invalid=%i used=%i. Freed mem invalid %zuMB used %zuMB. Now %zuMB limit=%zuMB (base %zuMB) max=%zuMB",
       free_invalid_cnt, free_cnt, freed_invalid/DT_MEGA, freed / DT_MEGA,
-      cache->allmem / DT_MEGA, cache->memlimit / DT_MEGA, cache->max_allmem / DT_MEGA);
+      cache->allmem / DT_MEGA, effective / DT_MEGA, cache->memlimit / DT_MEGA, cache->max_allmem / DT_MEGA);
+}
+
+void dt_dev_pixelpipe_cache_trim(dt_dev_pixelpipe_t *pipe, const size_t reserve)
+{
+  dt_dev_pixelpipe_cache_t *cache = &pipe->cache;
+  // alternating-buffer pipes (export/thumbnail) have nothing to trim
+  if(cache->entries == DT_PIPECACHE_MIN) return;
+
+  size_t freed = 0;
+  int cnt = 0;
+  // free oldest non-important lines until we fit the reserve; important lines
+  // (e.g. the focused module input) are skipped so returning to the same image
+  // stays a cache hit
+  while(reserve < cache->allmem)
+  {
+    const int k = _get_oldest_cacheline(cache, DT_CACHETEST_USED);
+    if(k == 0) break;
+    freed += _free_cacheline(cache, k);
+    cnt++;
+  }
+
+  if(cnt)
+    dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_MEMORY, "pipe cache trim", pipe, NULL, DT_DEVICE_NONE, NULL, NULL,
+      "freed %i lines %zuMB, now %zuMB (reserve %zuMB)",
+      cnt, freed / DT_MEGA, cache->allmem / DT_MEGA, reserve / DT_MEGA);
 }
 
 void dt_dev_pixelpipe_cache_report(dt_dev_pixelpipe_t *pipe)

--- a/src/develop/pixelpipe_cache.h
+++ b/src/develop/pixelpipe_cache.h
@@ -81,6 +81,11 @@ gboolean dt_dev_pixelpipe_cache_available(struct dt_dev_pixelpipe_t *pipe, const
 /** invalidates all cachelines. */
 void dt_dev_pixelpipe_cache_flush(struct dt_dev_pixelpipe_t *pipe);
 
+/** free the oldest non-important cachelines until the cache fits within 'reserve' bytes.
+    Used when leaving darkroom to hand memory back to the thumbnail cache while keeping a
+    small reserve for a fast return to the same image. */
+void dt_dev_pixelpipe_cache_trim(struct dt_dev_pixelpipe_t *pipe, const size_t reserve);
+
 /** invalidates all cachelines for modules with at least the same iop_order */
 void dt_dev_pixelpipe_cache_invalidate_later(struct dt_dev_pixelpipe_t *pipe, const int32_t order, const char *info);
 

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -4121,6 +4121,11 @@ void leave(dt_view_t *self)
 
   dt_pthread_mutex_lock(&dev->history_mutex);
 
+  // hand the darkroom pipe cache's memory back to the thumbnail cache for
+  // lighttable/culling work, keeping only the static base as a reserve so a
+  // quick return to the same image stays responsive
+  dt_dev_pixelpipe_cache_trim(dev->full.pipe, dev->full.pipe->cache.memlimit);
+
   dt_dev_pixelpipe_cleanup_nodes(dev->full.pipe);
   dt_dev_pixelpipe_cleanup_nodes(dev->preview2.pipe);
   dt_dev_pixelpipe_cleanup_nodes(dev->preview_pipe);


### PR DESCRIPTION

### TL;DR

The darkroom pixelpipe cache is sized from a static limit that ignores both the **resources** setting and the **canvas resolution**. On high‑DPI displays this collapses the cache to the two alternating buffers, so every parameter change re‑runs the _entire_ upstream pipe instead of just the edited module downstream.

This PR sizes the cache from the memory darktable is actually allowed to use (which scales with **resources**) and hands that memory back when you leave darkroom, so the cache is large while developing and out of the way while culling — with **no new user‑facing setting**.

### The problem

The full‑pipe cache eviction limit is `MAX(64MB, mipmap_memory / 4)`, and `mipmap_memory` derives from the **mipmap fraction** of the resource table (`fractions[]`, column 2). That column is identical for `default`, `large` and `unrestricted` (128/1024) — only `small` differs. So:

-   Switching  `default`→`large`  raises the  _overall_  budget (column 0, 512→700) but leaves the pipe‑cache limit unchanged — the cache is keyed to the wrong dial.
-   The limit is blind to canvas size. A full‑canvas RGBA‑float line is  `W·H·16`  bytes (≈130 MB at 4K, ≈310 MB at 6K) — a large fraction of, or exceeding, the static limit. The cache then holds ~2 lines and falls back to alternating buffers → full‑pipe recompute on every slider move.

### The proposed fix

1.  **Size the eviction limit from  `dt_get_available_mem()`**  (resource column 0, which  _does_  scale with the tier) instead of the mipmap fraction. Bounded by  `entries × canvas_line`  (64‑slot saturation),  `budget / DT_PIPECACHE_BUDGET_DIVISOR`  (½), an anti‑collapse floor, and never below the old static base.
2.  **Release the cache on leaving darkroom**  via a new  `dt_dev_pixelpipe_cache_trim()`, keeping the static base as a reserve. The full pipe's  `checkmem`  only runs in darkroom, so memory follows the workflow automatically:  **cachelines while developing, thumbnails while culling**  — no view‑polling, no user knob.

## Resulting cache size by tier and RAM

Effective cache = **GB (cache lines) · was <old static limit GB>**, for a 3840×2160 canvas (line ≈ 127 MB; 64‑slot saturation ≈ 7.9 GB). Larger canvases shift saturation up (≈14 GB at 5K, ≈19 GB at 6K).


| tier | 8 GB RAM | 16 GB RAM | 32 GB RAM | 64 GB RAM |
|---|---|---|---|---|
| **small** | 0.5 GB (4) · was 0.12 | 1.0 GB (8) · was 0.25 | 2.0 GB (16) · was 0.50 | 4.0 GB (32) · was 1.00 |
| **default** | 2.0 GB (16) · was 0.25 | 4.0 GB (32) · was 0.50 | 7.9 GB (64) · was 1.00 | 7.9 GB (64) · was 2.00 |
| **large** | 2.7 GB (22) · was 0.25 | 5.5 GB (44) · was 0.50 | 7.9 GB (64) · was 1.00 | 7.9 GB (64) · was 2.00 |
| **unrestricted** | 4.0 GB (32) · was 0.25 | 7.9 GB (64) · was 0.50 | 7.9 GB (64) · was 1.00 | 7.9 GB (64) · was 2.00 |


-   Self‑limits to the lines the pipe actually produces (~30–40 typical) — ceilings, not reservations.
-   On generous configs the  **64‑slot cap**  binds before the budget share, so size levels off at saturation.
-   `large`  now meaningfully exceeds  `default`  on constrained RAM, and both reach full‑pipe caching once the budget allows.
-   Assumes  `cl_uni_memory = 0`; an OpenCL unified reservation lowers the budget. _On unified-memory systems with OpenCL, `total − total×unified_fraction` (default 0.25) is used; the pipe cache is unaffected wherever the 64-slot saturation cap binds (generous configs) and only shrinks on low-RAM unified systems._

### Implementation

-   `pixelpipe_cache.c`: budget‑based  `effective`  in  `checkmem()`; new  `dt_dev_pixelpipe_cache_trim()`.
-   `pixelpipe_cache.h`: declare the trim.
-   `darkroom.c`  `leave()`: trim  `dev->full.pipe`  to its static base.

### Notes for reviewers

-   `DT_PIPECACHE_BUDGET_DIVISOR = 2`  and  `DT_PIPECACHE_MIN_LINES = 4`  are starting values. Alternative to the global ½ share: a dedicated pipe‑cache column in  `fractions[]`  (the four existing are cpu‑available / singlebuffer / mipmap / opencl‑available, all in use).
-   Trim reserve is the static base; could be lowered for a stronger culling hand‑off at the cost of slower same‑image re‑entry.

Co-authored with Claude.