### PR TITLE
Protection in dt_masks_reset_form_gui against possible NULL dereference

### DIFF
--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -1472,9 +1472,13 @@ void dt_masks_reset_form_gui(void)
   {
     dt_iop_gui_blend_data_t *bd = m->blend_data;
     bd->masks_shown = DT_MASKS_EDIT_OFF;
-    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(bd->masks_edit), 0);
+
+    if(bd->masks_edit)
+      gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(bd->masks_edit), 0);
+
     for(int n = 0; n < DEVELOP_MASKS_NB_SHAPES; n++)
-      gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(bd->masks_shapes[n]), 0);
+      if(bd->masks_shapes[n])
+        gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(bd->masks_shapes[n]), 0);
   }
 }
 


### PR DESCRIPTION
This PR adds protection against NULL dereference and should prevent the crash reported in #21050. I was unable to reproduce either the situation with the loss of guidelines and the resulting crash, but the backtrace in this case gives clear information about where and what happened. Relevant backtrace fragments:

```
this is darktable 5.4.1 reporting a segfault:

...

#2  <signal handler called>
#3  0x0000607a1c325f80 in ?? ()
#4  0x000078367347a83e in dt_masks_reset_form_gui () from /usr/bin/../lib/x86_64-linux-gnu/darktable/libdarktable.so
```

So, we see here a segfault inside a call to an external library function. In this case, it is the `gtk_toggle_button_set_active` (this is the only _external_ function called in `dt_masks_reset_form_gui`), in which NULL dereference is possible when passing it as a widget argument.

Examining the source code of the [gtk_toggle_button_set_active](https://gitlab.gnome.org/GNOME/gtk/blob/3.24.52/gtk%2Fgtktogglebutton.c?plain=1#L466-482) function would seem to show that this should not happen, since in fact the safety check is in place:
```
g_return_if_fail (GTK_IS_TOGGLE_BUTTON (toggle_button));
```
But the problem is that `g_return_if_fail` in the source code does not guarantee the presence of this check in the compiled code. These checks can be completely removed when gtk is compiled with `--enable-debug=no`.

This PR does not auto-close the mentioned issue as it only intendedd to fix the crash, but the root cause of this (which manifests itself in the disappearance of the guide lines) remains unclear.

