### PR TITLE
Skip value-changed emit when bauhaus toggle state is unchanged

### DIFF
--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -1362,7 +1362,10 @@ static void _toggle_set(dt_bauhaus_widget_t *w,
                         const gboolean active)
 {
   dt_bauhaus_toggle_data_t *d = &w->toggle;
-  d->active = active ? TRUE : FALSE;
+  const gboolean new_active = active ? TRUE : FALSE;
+  // match GtkToggleButton: skip when the state does not change
+  if(d->active == new_active) return;
+  d->active = new_active;
   gtk_widget_queue_draw(GTK_WIDGET(w));
 
   // while the gui is being brought in line with the params there is


### PR DESCRIPTION
`_toggle_set` in bauhaus emits `value-changed` on every call, even when the value didn't actually change – unlike `GtkToggleButton::set_active`, which is a no-op on same-value calls. The divergence was introduced in 2964a720c0 ("more checkbox refactoring", cc @piratenpanda) when several GTK check buttons were migrated to bauhaus toggles.

The visible consequence was a stack overflow when switching lens correction methods, fixed at the callsite by #21698. Full breakdown of that specific case in [this comment](https://github.com/darktable-org/darktable/pull/21698#issuecomment-5177075986) – shows the exact GtkCheckButton → bauhaus toggle diff and how the semantic change turned a silent no-op into unbounded recursion.

The same pattern exists in ~27 other callers of `dt_bauhaus_toggle_set`, mostly `gui_update` functions that resync widgets to params. Each fires spurious `value-changed` signals whenever the widget's stored value happens to match – firing callbacks, queuing redraws, potentially adding history noise, or in the wrong context, crashing.

Three-line change at the top of `_toggle_set` – matches GTK's semantics. Verified, it stops the #21697 crash on its own without #21698 in place.