### PR TITLE
gui: guard dereferences of progress_system.proxy.module

### DIFF
--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -4082,8 +4082,12 @@ static float _process_shortcut(float move_size)
             "  [_process_shortcut] processing shortcut: %s",
             _shortcut_description(&_sc));
 
-  if(DT_PERFORM_ACTION(move_size) &&
-     gtk_widget_has_grab(darktable.control->progress_system.proxy.module->widget))
+  // the progress proxy is only set while the backgroundjobs lib module is alive,
+  // so it is NULL early in startup and again after that module is cleaned up.
+  // no proxy means nothing holds the grab.
+  if(DT_PERFORM_ACTION(move_size)
+     && darktable.control->progress_system.proxy.module
+     && gtk_widget_has_grab(darktable.control->progress_system.proxy.module->widget))
   {
     if(_sc.key_device == DT_SHORTCUT_DEVICE_KEYBOARD_MOUSE && _sc.key == GDK_KEY_Escape)
       dt_print(DT_DEBUG_ALWAYS, "this should cancel the running blocking job"); // TODO

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -5140,9 +5140,12 @@ void dt_gui_cursor_set_busy()
     // since the main reason for calling this function is that we won't be running the Gtk main
     // loop for a while, ensure that the mouse cursor gets updated
     dt_gui_process_events();
-    GtkWidget *progress_widget = darktable.control->progress_system.proxy.module->widget;
-    gtk_widget_realize(progress_widget);
-    gtk_grab_add(progress_widget);
+    if(darktable.control->progress_system.proxy.module)
+    {
+      GtkWidget *progress_widget = darktable.control->progress_system.proxy.module->widget;
+      gtk_widget_realize(progress_widget);
+      gtk_grab_add(progress_widget);
+    }
   }
 }
 
@@ -5158,7 +5161,8 @@ void dt_gui_cursor_clear_busy()
       // to restore the original mouse cursor
       dt_control_allow_change_cursor();
       dt_control_clear_temp_cursor();
-      gtk_grab_remove(darktable.control->progress_system.proxy.module->widget);
+      if(darktable.control->progress_system.proxy.module)
+        gtk_grab_remove(darktable.control->progress_system.proxy.module->widget);
     }
   }
 }


### PR DESCRIPTION
Fixes #21700.

The progress proxy is set by the `backgroundjobs` lib module's `gui_init()` (`src/libs/backgroundjobs.c:84`) and cleared again by its `gui_cleanup()` (`:112`), so it is NULL early during startup and again during shutdown. Three places dereference it without checking, and a shortcut dispatched in either window crashes darktable.

`_process_shortcut()` is the one I saw crash: input device polling can dispatch a shortcut while the splash screen pumps the main loop, before `backgroundjobs` has been initialised. An absent proxy simply means nothing holds the grab, so the check short-circuits.

The two in `dt_gui_cursor_set_busy()` and `dt_gui_cursor_clear_busy()` are guarded the same way — with no proxy there is no grab to add or remove.

@jenshannoschwalm suggested the guarding PR in the issue. As noted there, this is the conservative fix rather than necessarily the correct one: someone who knows the startup ordering may prefer to stop shortcuts being dispatched before the GUI is fully up. This is cheap and safe in the meantime.

@gi-man asked in the issue whether this could explain the intermittent Windows startup crashes. It might — the window is timing dependent and widens with anything that slows startup or delivers input early — but I have no evidence either way, and I would not want the issue closed on the assumption that it is the same bug unless someone can confirm it.

I could not produce a reliable recipe; the crash was a one-off during startup and I have not reproduced it since guarding. The lifetime problem is visible from the source regardless.

---

*Disclosure: diagnosed and written with AI assistance (Claude Code with Claude Opus 5). Verified against current master and builds clean.*