### PR TITLE
gtk4-prep: fix right-click popups on filter and range entries

### DIFF
--- a/src/dtgtk/range.c
+++ b/src/dtgtk/range.c
@@ -1718,7 +1718,9 @@ GtkWidget *dtgtk_range_select_new(const gchar *property, const gboolean show_ent
     _entry_set_tooltip(range->entry_min, BOUND_MIN, range->type);
     g_signal_connect(G_OBJECT(range->entry_min), "activate", G_CALLBACK(_event_entry_activated), range);
     g_signal_connect(G_OBJECT(range->entry_min), "focus-out-event", G_CALLBACK(_event_entry_focus_out), range);
-    dt_gui_connect_click_all(range->entry_min, _event_entry_press_cb, NULL, range);
+    GtkGestureSingle *g_min = dt_gui_connect_click(range->entry_min, _event_entry_press_cb, NULL, range);
+    gtk_gesture_single_set_button(g_min, GDK_BUTTON_SECONDARY);
+    gtk_event_controller_set_propagation_phase(GTK_EVENT_CONTROLLER(g_min), GTK_PHASE_TARGET);
 
     range->entry_max = dt_ui_entry_new(0);
     gtk_widget_set_can_default(range->entry_max, TRUE);
@@ -1726,7 +1728,9 @@ GtkWidget *dtgtk_range_select_new(const gchar *property, const gboolean show_ent
     _entry_set_tooltip(range->entry_max, BOUND_MAX, range->type);
     g_signal_connect(G_OBJECT(range->entry_max), "activate", G_CALLBACK(_event_entry_activated), range);
     g_signal_connect(G_OBJECT(range->entry_max), "focus-out-event", G_CALLBACK(_event_entry_focus_out), range);
-    dt_gui_connect_click_all(range->entry_max, _event_entry_press_cb, NULL, range);
+    GtkGestureSingle *g_max = dt_gui_connect_click(range->entry_max, _event_entry_press_cb, NULL, range);
+    gtk_gesture_single_set_button(g_max, GDK_BUTTON_SECONDARY);
+    gtk_event_controller_set_propagation_phase(GTK_EVENT_CONTROLLER(g_max), GTK_PHASE_TARGET);
 
     dt_gui_box_add(vbox, dt_gui_hbox(dt_gui_expand(range->entry_min), dt_gui_expand(range->entry_max)));
   }

--- a/src/libs/filters/filename.c
+++ b/src/libs/filters/filename.c
@@ -372,7 +372,9 @@ static void _filename_widget_init(dt_lib_filtering_rule_t *rule, const dt_collec
   gtk_box_pack_start(GTK_BOX(hb), filename->name, TRUE, TRUE, 0);
   g_signal_connect(G_OBJECT(filename->name), "activate", G_CALLBACK(_filename_changed), filename);
   g_signal_connect(G_OBJECT(filename->name), "focus-out-event", G_CALLBACK(_filename_focus_out), filename);
-  dt_gui_connect_click(filename->name, _filename_press, NULL, filename);
+  GtkGestureSingle *g_name = dt_gui_connect_click(filename->name, _filename_press, NULL, filename);
+  gtk_gesture_single_set_button(g_name, GDK_BUTTON_SECONDARY);
+  gtk_event_controller_set_propagation_phase(GTK_EVENT_CONTROLLER(g_name), GTK_PHASE_TARGET);
 
   filename->ext = dt_ui_entry_new(top ? 5 : 0);
   gtk_widget_set_can_default(filename->ext, TRUE);
@@ -384,7 +386,9 @@ static void _filename_widget_init(dt_lib_filtering_rule_t *rule, const dt_collec
   gtk_box_pack_start(GTK_BOX(hb), filename->ext, TRUE, TRUE, 0);
   g_signal_connect(G_OBJECT(filename->ext), "activate", G_CALLBACK(_filename_changed), filename);
   g_signal_connect(G_OBJECT(filename->ext), "focus-out-event", G_CALLBACK(_filename_focus_out), filename);
-  dt_gui_connect_click(filename->ext, _filename_press, NULL, filename);
+  GtkGestureSingle *g_ext = dt_gui_connect_click(filename->ext, _filename_press, NULL, filename);
+  gtk_gesture_single_set_button(g_ext, GDK_BUTTON_SECONDARY);
+  gtk_event_controller_set_propagation_phase(GTK_EVENT_CONTROLLER(g_ext), GTK_PHASE_TARGET);
   if(top)
   {
     dt_gui_add_class(hb, "dt_quick_filter");

--- a/src/libs/filters/misc.c
+++ b/src/libs/filters/misc.c
@@ -268,8 +268,9 @@ static void _misc_press(GtkGestureSingle *gesture,
                         _widgets_misc_t *misc)
 {
   GtkWidget *w = dt_gui_get_widget(gesture);
+  const guint button = gtk_gesture_single_get_current_button(gesture);
 
-  if(gtk_gesture_single_get_current_button(gesture) == GDK_BUTTON_SECONDARY)
+  if(button == GDK_BUTTON_SECONDARY)
   {
     _misc_tree_update_visibility(w, misc);
     gtk_popover_set_default_widget(GTK_POPOVER(misc->pop), w);
@@ -280,7 +281,7 @@ static void _misc_press(GtkGestureSingle *gesture,
 
     gtk_widget_show_all(misc->pop);
   }
-  else if(gtk_gesture_single_get_current_button(gesture) == GDK_BUTTON_PRIMARY
+  else if(button == GDK_BUTTON_PRIMARY
           && n_press >= 2)
   {
     gtk_entry_set_text(GTK_ENTRY(misc->name), "");
@@ -462,7 +463,9 @@ static void _misc_widget_init(dt_lib_filtering_rule_t *rule,
   gtk_box_pack_start(GTK_BOX(hb), misc->name, TRUE, TRUE, 0);
   g_signal_connect(G_OBJECT(misc->name), "activate", G_CALLBACK(_misc_changed), misc);
   g_signal_connect(G_OBJECT(misc->name), "focus-out-event", G_CALLBACK(_misc_focus_out), misc);
-  dt_gui_connect_click(misc->name, _misc_press, NULL, misc);
+  GtkGestureSingle *misc_gesture = dt_gui_connect_click(misc->name, _misc_press, NULL, misc);
+  gtk_gesture_single_set_button(misc_gesture, GDK_BUTTON_SECONDARY);
+  gtk_event_controller_set_propagation_phase(GTK_EVENT_CONTROLLER(misc_gesture), GTK_PHASE_TARGET);
 
   if(top)
   {


### PR DESCRIPTION
Right-click on text filter entries (camera, lens, flash, filename, ISO, …) shows the default cut/copy menu instead of the "select existing values" popup.

Root cause: the event controller conversion (#21659) attached the entry press gesture with the default button and bubble phase, so GtkEntry's built-in context menu won over the custom popup handler.

Fix: attach the gesture with `GDK_BUTTON_SECONDARY` and `GTK_PHASE_TARGET`, so it claims right-clicks before the entry's default handling. Covers `misc.c` (camera/lens/flash/…), `filename.c` (filename/extension), and `range.c` (range-select entries).

Related: #15920 #20433

Fixes https://github.com/darktable-org/darktable/issues/21720