### PR TITLE
gtk4-prep: fix heap corruption from event controller ownership

### DIFF
--- a/src/develop/imageop_gui.c
+++ b/src/develop/imageop_gui.c
@@ -266,7 +266,7 @@ GtkWidget *dt_iop_togglebutton_new(dt_iop_module_t *self, const char *section, c
     GtkGesture *gesture = gtk_gesture_multi_press_new(w);
     gtk_event_controller_set_propagation_phase(GTK_EVENT_CONTROLLER(gesture),
                                                GTK_PHASE_CAPTURE);
-    g_object_weak_ref(G_OBJECT(w), (GWeakNotify)g_object_unref, gesture);
+    dt_gui_add_controller(w, gesture);
     g_signal_connect_data(gesture, "pressed", callback, self, NULL, 0);
     g_signal_connect(gesture, "begin", G_CALLBACK(_gesture_begin_claim), NULL);
     gtk_gesture_single_set_button(GTK_GESTURE_SINGLE(gesture), 0);

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -3099,7 +3099,7 @@ GtkWidget *dt_shortcuts_prefs(GtkWidget *widget)
     GtkGesture *gesture = gtk_gesture_multi_press_new(GTK_WIDGET(actions_view));
     gtk_event_controller_set_propagation_phase(GTK_EVENT_CONTROLLER(gesture),
                                                GTK_PHASE_CAPTURE);
-    g_object_weak_ref(G_OBJECT(actions_view), (GWeakNotify)g_object_unref, gesture);
+    dt_gui_add_controller(GTK_WIDGET(actions_view), gesture);
     gtk_gesture_single_set_button(GTK_GESTURE_SINGLE(gesture), 0);
     g_signal_connect(gesture, "pressed", G_CALLBACK(_action_view_click_cb), _actions_store);
     g_signal_connect(gesture, "begin", G_CALLBACK(_gesture_begin_claim), NULL);

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -4771,6 +4771,20 @@ gboolean dt_gui_long_click(const guint second,
   return second - delay > first;
 }
 
+void dt_gui_add_controller(GtkWidget *widget,
+                           gpointer controller)
+{
+#if GTK_CHECK_VERSION(4, 0, 0)
+  gtk_widget_add_controller(widget, GTK_EVENT_CONTROLLER(controller));
+#else
+  // GTK3 has no gtk_widget_add_controller(): the widget only keeps a
+  // weak pointer to the controller, so release our reference when the
+  // widget is destroyed.  This must not be done from a weak notify on
+  // the widget, see the comment on the declaration.
+  g_signal_connect_swapped(widget, "destroy", G_CALLBACK(g_object_unref), controller);
+#endif
+}
+
 static void _gesture_cancel(GtkGestureSingle *gesture,
                             GdkEventSequence *sequence,
                             GtkWidget *widget)
@@ -4784,7 +4798,7 @@ GtkGestureSingle *(dt_gui_connect_click)(GtkWidget *widget,
                                          gpointer data)
 {
   GtkGesture *gesture = gtk_gesture_multi_press_new(widget);
-  g_object_weak_ref(G_OBJECT (widget), (GWeakNotify) g_object_unref, gesture);
+  dt_gui_add_controller(widget, gesture);
   // GTK4 GtkGesture *gesture = gtk_gesture_click_new();
   //      gtk_widget_add_controller(widget, GTK_EVENT_CONTROLLER(gesture));
 
@@ -4869,7 +4883,7 @@ GtkGesture *(dt_gui_connect_drag)(GtkWidget *widget,
                                   gpointer data)
 {
   GtkGesture *gesture = gtk_gesture_drag_new(widget);
-  g_object_weak_ref(G_OBJECT (widget), (GWeakNotify) g_object_unref, gesture);
+  dt_gui_add_controller(widget, gesture);
   // GTK4 GtkGesture *gesture = gtk_gesture_drag_new();
   //      gtk_widget_add_controller(widget, GTK_EVENT_CONTROLLER(gesture));
   if(drag_begin) g_signal_connect(gesture, "drag-begin", G_CALLBACK(drag_begin), data);
@@ -4887,7 +4901,7 @@ GtkEventController *(dt_gui_connect_motion)(GtkWidget *widget,
 {
   GtkEventController *controller = gtk_event_controller_motion_new(widget);
   gtk_event_controller_set_propagation_phase(controller, GTK_PHASE_TARGET);
-  g_object_weak_ref(G_OBJECT (widget), (GWeakNotify) g_object_unref, controller);
+  dt_gui_add_controller(widget, controller);
   // GTK4 gtk_widget_add_controller(widget, GTK_EVENT_CONTROLLER(controller));
 
   gtk_widget_add_events(widget, GDK_ENTER_NOTIFY_MASK | GDK_LEAVE_NOTIFY_MASK); // still needed for now by _main_do_event_keymap
@@ -5031,7 +5045,7 @@ GtkEventController *(dt_gui_connect_scroll)(GtkWidget *widget,
 
   GtkEventController *const controller = gtk_event_controller_scroll_new(widget, flags);
   gtk_event_controller_set_propagation_phase(controller, GTK_PHASE_TARGET);
-  g_object_weak_ref(G_OBJECT(widget), (GWeakNotify) g_object_unref, controller);
+  dt_gui_add_controller(widget, controller);
   // GTK4 gtk_widget_add_controller(widget, GTK_EVENT_CONTROLLER(controller));
   g_signal_connect(controller, "scroll", G_CALLBACK(proxy), data);
   g_object_set_data(G_OBJECT(controller), _scroll_real_handler_key, scroll);
@@ -5085,7 +5099,7 @@ GtkEventController *(dt_gui_connect_key)(GtkWidget *widget,
 {
   GtkEventController *controller = gtk_event_controller_key_new(widget);
   gtk_event_controller_set_propagation_phase(controller, GTK_PHASE_TARGET);
-  g_object_weak_ref(G_OBJECT(widget), (GWeakNotify) g_object_unref, controller);
+  dt_gui_add_controller(widget, controller);
   // GTK4 gtk_widget_add_controller(widget, GTK_EVENT_CONTROLLER(controller));
 
   if(pressed)

--- a/src/gui/gtk.h
+++ b/src/gui/gtk.h
@@ -555,6 +555,19 @@ gboolean dt_gui_long_click(const guint second,
 
 #define ASSERT_FUNC_TYPE(func, expected_type) (void)((expected_type)(func))
 
+/*
+ * Give our controller reference to the widget, like GTK4's
+ * gtk_widget_add_controller() (transfer full).  On GTK3 the widget only weakly
+ * points at the controller, so we unref on "destroy" — never from a weak
+ * notify on the widget: the controller's dispose removes its own weak pointer,
+ * which reenters the weak reference list being torn down and corrupts the heap.
+ *
+ * GTK4 migration: keep the calls, drop the widget argument from the
+ * gtk_gesture_*_new() / gtk_event_controller_*_new() calls above them.
+ */
+void dt_gui_add_controller(GtkWidget *widget,
+                           gpointer controller);
+
 GtkGestureSingle *(dt_gui_connect_click)(GtkWidget *widget,
                                          GCallback pressed,
                                          GCallback released,

--- a/src/libs/navigation.c
+++ b/src/libs/navigation.c
@@ -235,7 +235,7 @@ void gui_init(dt_lib_module_t *self)
   //        as here is a well-used pattern, make proxy which handles
   //        this so don't need to implement a "begin" handler here.
   GtkGesture *zoom_gesture = gtk_gesture_zoom_new(thumbnail);
-  g_object_weak_ref(G_OBJECT(thumbnail), (GWeakNotify) g_object_unref, zoom_gesture);
+  dt_gui_add_controller(thumbnail, zoom_gesture);
   g_signal_connect(zoom_gesture, "begin", G_CALLBACK(_lib_navigation_pinch_begin_callback), self);
   g_signal_connect(zoom_gesture, "scale-changed", G_CALLBACK(_lib_navigation_pinch_scale_callback), self);
   dt_gui_connect_motion(thumbnail, _lib_navigation_motion_notify_callback, NULL, _lib_navigation_leave_notify_callback, self);


### PR DESCRIPTION
This is a fix for a regression caused by 311734915e.
On GTK3 a widget only keeps a weak pointer to its event controllers, so we own the reference from gtk_gesture_*_new()/gtk_event_controller_*_new(). We dropped it from a weak notify on the widget, but weak notifies run while g_object_real_dispose() is tearing down the widget's weak reference list: disposing the controller there makes it remove its own weak pointer from that very list, which logs "g_object_weak_unref: couldn't find weak ref" and corrupts the heap, aborting in an unrelated later malloc.  GMIC builds crashed on startup, where lut3d attaches a scroll controller to its GtkTreeView and dt_iop_load_modules_so() destroys the module GUI right after creating it.

Add dt_gui_add_controller(), which hands the reference over on the widget's "destroy" signal and calls gtk_widget_add_controller() under GTK4, and use it at all call sites.

Fixes https://github.com/darktable-org/darktable/issues/21717

CC: @Arecsu 

Disclaimer: this work has been co-created with Claude.