### PR TITLE
Further shutdown improving for UI responsiveness

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -804,7 +804,7 @@ restart:
                 pipe->input_changed ? "pipe_input_changed " : "",
                 pipe->changed & DT_DEV_PIPE_ZOOMED ? "zoomed " : "",
                 pipe->changed & DT_DEV_PIPE_SYNCH ? "synch" : "");
-  if(shutdown != DT_DEV_PIXELPIPE_STOP_ZOOM && shutdown != DT_DEV_PIXELPIPE_STOP_DATA)
+  if(shutdown <= DT_DEV_PIXELPIPE_PROCESSING)
     restarts++;
 
   if(stopped)

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -118,6 +118,7 @@ const char *dt_dev_pixelpipe_shutdown_to_str(const dt_dev_pixelpipe_stopper_t st
   case DT_DEV_PIXELPIPE_STOP_HQ:    return "DT_DEV_PIXELPIPE_STOP_HQ";
   case DT_DEV_PIXELPIPE_STOP_ZOOM:  return "DT_DEV_PIXELPIPE_STOP_ZOOM";
   case DT_DEV_PIXELPIPE_STOP_DATA:  return "DT_DEV_PIXELPIPE_STOP_DATA";
+  case DT_DEV_PIXELPIPE_STOP_PIECE: return "DT_DEV_PIXELPIPE_STOP_PIECE";
   default:                          return "DT_DEV_PIXELPIPE_STOP_UNDEFINED";
   }
 }
@@ -1379,12 +1380,40 @@ static inline dt_dev_pixelpipe_stopper_t _module_pipe_stop(dt_dev_pixelpipe_t *p
         || stopper == DT_DEV_PIXELPIPE_STOP_DATA)
     return stopper;
 
+  if(stopper == DT_DEV_PIXELPIPE_STOP_PIECE)
+  {
+    dt_dev_pixelpipe_cache_invalidate_later(pipe, module->iop_order, "piece shutdown: ");
+    return stopper;
+  }
+
   /** There was no valid shutdown mode, this should never happen and would be a
       definite bug.
       Just in case we fetch this and flush the pipe cache
   */
   dt_dev_pixelpipe_cache_invalidate_later(pipe, 0, "module pipe abort: ");
   return stopper;
+}
+
+gboolean dt_dev_piece_shutdown(dt_dev_pixelpipe_iop_t *piece, const gboolean test)
+{
+  /** If the remaining payload of the testing piece is small, we prefer to continue processing
+      and thus return FALSE to possibly avoid the costly DT_DEV_PIXELPIPE_STOP_PIECE shutdown
+      mode (invalidating all following cachelines).
+  */
+  if(!test)
+    return FALSE;
+
+  const dt_dev_pixelpipe_stopper_t stopper = dt_atomic_get_int(&piece->pipe->shutdown);
+  if(stopper <= DT_DEV_PIXELPIPE_PROCESSING)
+    return FALSE;
+
+  /** There is a pending shutdown request while processing a piece with high payload.
+      By setting shutdown to DT_DEV_PIXELPIPE_STOP_PIECE we deligate the shutdown to
+      _module_pipe_stop() and enforce cacheline invalidations for iop_orders following
+      the testing module.
+  */
+  dt_atomic_set_int(&piece->pipe->shutdown, DT_DEV_PIXELPIPE_STOP_PIECE);
+  return TRUE;
 }
 
 void dt_dev_prepare_piece_cfa(dt_dev_pixelpipe_iop_t *piece, const dt_iop_roi_t *roi)
@@ -2536,11 +2565,11 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
         const dt_dev_pixelpipe_stopper_t cl_stopper = _module_pipe_stop(pipe, module, *output);
         if(cl_stopper != DT_DEV_PIXELPIPE_STOP_NO)
         {
-          /*  In case of a DT_DEV_PIXELPIPE_STOP_DATA shutdown
+          /*  In case of a DT_DEV_PIXELPIPE_STOP_DATA or DT_DEV_PIXELPIPE_STOP_PIECE shutdown
               we try to make input cacheline valid for next pipe run.
           */
           if(valid_input_on_gpu_only
-              && cl_stopper == DT_DEV_PIXELPIPE_STOP_DATA
+              && (cl_stopper == DT_DEV_PIXELPIPE_STOP_DATA || cl_stopper == DT_DEV_PIXELPIPE_STOP_PIECE)
               && !convert
               && _copy_image_to_host_err(pipe->devid, input, cl_mem_input, roi_in.width, roi_in.height, in_bpp, "input cacheline")
                     == CL_SUCCESS)

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -1375,11 +1375,15 @@ static inline dt_dev_pixelpipe_stopper_t _module_pipe_stop(dt_dev_pixelpipe_t *p
 
   if(stopper == DT_DEV_PIXELPIPE_STOP_NODES
         || stopper == DT_DEV_PIXELPIPE_STOP_HQ
-        || stopper == DT_DEV_PIXELPIPE_STOP_ZOOM)
+        || stopper == DT_DEV_PIXELPIPE_STOP_ZOOM
+        || stopper == DT_DEV_PIXELPIPE_STOP_DATA)
     return stopper;
 
-  if(stopper == DT_DEV_PIXELPIPE_STOP_DATA)
-    dt_dev_pixelpipe_cache_invalidate_later(pipe, module->iop_order, "module pipe stop: ");
+  /** There was no valid shutdown mode, this should never happen and would be a
+      definite bug.
+      Just in case we fetch this and flush the pipe cache
+  */
+  dt_dev_pixelpipe_cache_invalidate_later(pipe, 0, "module pipe abort: ");
   return stopper;
 }
 
@@ -2532,8 +2536,8 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
         const dt_dev_pixelpipe_stopper_t cl_stopper = _module_pipe_stop(pipe, module, *output);
         if(cl_stopper != DT_DEV_PIXELPIPE_STOP_NO)
         {
-          /*  In case of a DT_DEV_PIXELPIPE_STOP_DATA shutdown we have invalidated all following
-              cachelines but we try to make input cacheline valid for next pipe run.
+          /*  In case of a DT_DEV_PIXELPIPE_STOP_DATA shutdown
+              we try to make input cacheline valid for next pipe run.
           */
           if(valid_input_on_gpu_only
               && cl_stopper == DT_DEV_PIXELPIPE_STOP_DATA

--- a/src/develop/pixelpipe_hb.h
+++ b/src/develop/pixelpipe_hb.h
@@ -131,6 +131,12 @@ typedef enum dt_dev_pixelpipe_status_t
     DT_DEV_PIXELPIPE_STOP_DATA
     A request to restart with different module parameters,
     writing back input cl_mem to host for a faster restart if possible.
+
+    DT_DEV_PIXELPIPE_STOP_PIECE
+    A module has stopped within the piece process() variants.
+    As we missed processing the correct output and all following modules
+    will give different results accordingly we clear cachelines for following
+    modules (possibly writing back input cl_mem to host for a faster restart).
 */
 
 typedef enum dt_dev_pixelpipe_stopper_t
@@ -141,6 +147,7 @@ typedef enum dt_dev_pixelpipe_stopper_t
   DT_DEV_PIXELPIPE_STOP_HQ,
   DT_DEV_PIXELPIPE_STOP_ZOOM,
   DT_DEV_PIXELPIPE_STOP_DATA,
+  DT_DEV_PIXELPIPE_STOP_PIECE,
 } dt_dev_pixelpipe_stopper_t;
 
 typedef struct dt_dev_detail_mask_t
@@ -332,6 +339,8 @@ const char *dt_dev_pixelpipe_shutdown_to_str(const dt_dev_pixelpipe_stopper_t st
 
 // sets pipe->shutdown in atomic CAS mode so only one mode is possible per pipe run
 void dt_dev_pixelpipe_set_shutdown(dt_dev_pixelpipe_t *pipe, const dt_dev_pixelpipe_stopper_t stopper);
+// Is there a pending shutdown request for the piece's pipe?
+gboolean dt_dev_piece_shutdown(dt_dev_pixelpipe_iop_t *piece, const gboolean test);
 
 // inits the pixelpipe with plain passthrough input/output and empty input and default caching settings.
 gboolean dt_dev_pixelpipe_init(dt_dev_pixelpipe_t *pipe);

--- a/src/develop/pixelpipe_hb.h
+++ b/src/develop/pixelpipe_hb.h
@@ -129,10 +129,8 @@ typedef enum dt_dev_pixelpipe_status_t
     as we do for above shutdown modes.
 
     DT_DEV_PIXELPIPE_STOP_DATA
-    A request to restart with different module parameters.
-    As we missed processing the correct output and all following modules
-    will give different results accordingly we clear cachelines for following
-    modules (possibly writing back input cl_mem to host for a faster restart).
+    A request to restart with different module parameters,
+    writing back input cl_mem to host for a faster restart if possible.
 */
 
 typedef enum dt_dev_pixelpipe_stopper_t

--- a/src/iop/diffuse.c
+++ b/src/iop/diffuse.c
@@ -1414,7 +1414,7 @@ void process(dt_iop_module_t *self,
     in = temp1;
   }
 
-  for(int it = 0; it < iterations; it++)
+  for(int it = 0; it < iterations && !dt_dev_piece_shutdown(piece, (iterations-it) > 5); it++)
   {
     if(it == 0)
     {
@@ -1680,7 +1680,7 @@ int process_cl(dt_iop_module_t *self,
     in = temp1;
   }
 
-  for(int it = 0; it < iterations && err == CL_SUCCESS; it++)
+  for(int it = 0; it < iterations && err == CL_SUCCESS && !dt_dev_piece_shutdown(piece, (iterations-it)>5); it++)
   {
     if(it == 0)
     {


### PR DESCRIPTION
**Refine `DT_DEV_PIXELPIPE_STOP_DATA` shutdown**

In case of a `DT_DEV_PIXELPIPE_STOP_DATA` shutdown we don't have to invalidate the cachelines with a higher iop_order as following piece hashes are good.

Make sure we flush the whole pipe cache if shutdown was not a defined mode.

_____________________________________________________________________________________

**Introduce and use `dt_dev_piece_shutdown()`**

Modules - most notably diffuse - can take very long due to a large number of iterations thus leading to a bad UI responsiveness as all shutdown requests are tested within `_module_pipe_stop()` _after_ the `process()` variants have finished.

For these cases we now have a new shutdown mode `DT_DEV_PIXELPIPE_STOP_PIECE` handled in `_module_pipe_stop()`, we try to write a valid input cacheline if in OpenCL mode and invalidate cachelines with a higher iop_order for safety.

The module testing helper for this is `gboolean dt_dev_piece_shutdown()`, it tests for a pending shutdown request and if found, it modifies the shutdown mode to `DT_DEV_PIXELPIPE_STOP_PIECE`.
It takes `gboolean test` to possibly avoid the costly `DT_DEV_PIXELPIPE_STOP_PIECE` mode if the remaining workload is small.

The diffuse & sharpen module makes use of it for now with a payload of 5 pending iterations.

Comment: So if there is a shutdown request while processing D&S (parameters or zoom changed, HQ toggle ...) we don't have to wait as long as before for a pipe restart.