### PR TITLE
fix 2168: collections crash in folders mode for top-level directories

### DIFF
--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -1794,8 +1794,9 @@ static void _tree_view(dt_lib_collect_rule_t *dr)
             dt_util_str_cat(&pth, format_separator, tokens[i]);
 
           // if we are at the end of the path, and this is a folder, we need to
-          // add the count to all parents.
-          if(!tokens[common_length]
+          // add the count to all parents. common_length == 0 means 'parent' was
+          // never set to a valid node, and there is no node to update anyway.
+          if(common_length > 0 && !tokens[common_length]
              && property == DT_COLLECTION_PROP_FOLDERS)
           {
             _update_parent_count(model, &parent, count);
@@ -1824,8 +1825,11 @@ static void _tree_view(dt_lib_collect_rule_t *dr)
                 || _is_time_property(property)) && !*(token + 1))
             {
               GtkTreeIter p;
-              gtk_tree_model_iter_parent(model, &p, &iter);
-              _update_parent_count(model, &p, count);
+              // a top-level node has no parent: gtk_tree_model_iter_parent
+              // then returns FALSE and leaves 'p' uninitialized, so passing it
+              // on would cause a crash when dereferenced later
+              if(gtk_tree_model_iter_parent(model, &p, &iter))
+                _update_parent_count(model, &p, count);
             }
 
             common_length++;


### PR DESCRIPTION
The folders tree propagates each folder's image count up to its ancestors, but _update_parent_count() reads the iterator it is handed before anything validates it. A directory one component deep (e.g. /tmp) has no parent node in the tree, so gtk_tree_model_iter_parent() returns FALSE and leaves the iterator unusable, and the count walk then dereferences it.

Regression from 982f0be80f, which added folders to the set of properties that propagate counts.
  
Closes #21680
