### PR TITLE
fix: duplicate module history entries on duplicate and reset

### DIFF
--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -704,9 +704,6 @@ static void _gui_moveup_callback(GtkButton *button, dt_iop_module_t *module)
 dt_iop_module_t *dt_iop_gui_duplicate(dt_iop_module_t *base,
                                       const gboolean copy_params)
 {
-  // make sure the duplicated module appears in the history
-  dt_dev_add_history_item(base->dev, base, FALSE);
-
   // first we create the new module
   DT_ENTER_GUI_UPDATE();
   dt_iop_module_t *module = dt_dev_module_duplicate(base->dev, base);

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -2486,8 +2486,6 @@ static void _gui_reset_clicked(GtkGestureSingle *gesture,
     dt_iop_gui_update(module);
 
     dt_dev_add_history_item(module->dev, module, TRUE);
-
-    dt_dev_add_history_item(module->dev, module, TRUE);
   }
 
   // rebuild the accelerators


### PR DESCRIPTION
A duplicated module (or new instance) appeared twice in the history whenever the last history entry was a different module; the reset button also recorded two history items.

- drop the redundant base-module history entry in `dt_iop_gui_duplicate()`
- drop the duplicated history item in the reset handler

CC @TurboGit I recall having seen a discussion with somebody here in darktable, or might have been a fever dream I don't know. The discussion was related to this *issue*, I guess?

Still, this is something I've noticed too. I don't know if this was intended. But I'm open for this to be merged or leave it as intended behavior. Undo Redo works great, everything seems to be working good, it's just the double history thing.

This double call was my bad when doing the event controller port, so I fixed that as well:

```
    dt_dev_add_history_item(module->dev, module, TRUE);

    dt_dev_add_history_item(module->dev, module, TRUE);
 ```

But the one that made it appear as double was:

```
 // make sure the duplicated module appears in the history
  dt_dev_add_history_item(base->dev, base, FALSE);
```

2013-12-06 (time flies indeed) to be precise 4c0628ed2c0 added this because:

```
Make sure the duplicated module is saved in the history.
We do not want to save the new instance without having the previous
instance saved even when the first instance is not yet activated.

Fixes last issues reported in https://github.com/darktable-org/darktable/pull/9704.
```

According to my pseudo trust worthy deepseek, in a research:

```
 But is that still reachable today? In current darktable the history list and the pipe are kept in sync
 — every module in dev->iop has its own history row, added by dt_dev_add_history_item() at creation
 time. You can only duplicate a module that's already a live, recorded instance, so the "first instance
 not yet activated" case the 2013 commit protected against no longer happens — the base is always in
 history. Which is exactly why the call now only does harm: it re-adds the base as a redundant row
 whenever it isn't the last entry.

 So: the rationale was true in 2013; it's vestigial in 2026. Your empirical tests back that up — with
 the call removed, the duplicate shows once and undo/redo still behave correctly. The only honest
 caveat: if some future path ever added a module to the pipe without a history row and immediately
 duplicated it, the new instance would be recorded without the base — but that path doesn't exist today,
 and modern undo snapshots the full state anyway, making the old failure mode unlikely regardless.
 ```
 
 Hmmm. At least, from my primitive undo redo, duplicate, new instance, many times, going back and forth, it seems that it holds up pretty well without this double history workaround