### PR TITLE
Refuse raw denoise on legacy Fuji Super CCD sensors

### DIFF
--- a/src/common/ai/restore.c
+++ b/src/common/ai/restore.c
@@ -433,6 +433,10 @@ dt_restore_sensor_class_t dt_restore_classify_sensor(const dt_image_t *img)
     return DT_RESTORE_SENSOR_CLASS_UNSUPPORTED;
   if(img->flags & DT_IMAGE_4BAYER)
     return DT_RESTORE_SENSOR_CLASS_LINEAR;
+  // legacy Fuji Super CCD: diamond-in-square CFA layout that neither
+  // path can process correctly; marker set by rawspeed's `fuji_rotate`
+  if(img->fuji_rotation_pos != 0)
+    return DT_RESTORE_SENSOR_CLASS_UNSUPPORTED;
   const uint32_t filters = img->buf_dsc.filters;
   if(filters == 9u) return DT_RESTORE_SENSOR_CLASS_XTRANS;
   if(filters != 0u) return DT_RESTORE_SENSOR_CLASS_BAYER;


### PR DESCRIPTION
Fixes #21703

Neural restore models weren't trained on legacy Fuji Super CCD's diamond‑in‑square CFA, and adding proper support would be non‑trivial plumbing for 16 discontinued models. Refuse cleanly instead.

One line in `dt_restore_classify_sensor` keyed off `fuji_rotation_pos` (rawspeed's `fuji_rotate` marker). The existing generic toast covers both batch and preview paths; no new strings.