### PR TITLE
gtk4-prep: fix "prioritize hovered image" acting on the selection

### DIFF
--- a/src/dtgtk/culling.c
+++ b/src/dtgtk/culling.c
@@ -832,17 +832,34 @@ static void _event_leave_cb(GtkEventControllerMotion *controller,
 
   table->mouse_inside = FALSE;
 
-  // check crossing detail: don't clear mouse_over_id when leaving to
-  // a child widget (thumbnail) or due to a grab
+  /* Don't clear the mouse-over when leaving to a child widget (thumbnail),
+   * or while the pointer is grabbed: the shortcut machinery's synthetic
+   * crossings must not lose the hovered image (see #21729). */
   GdkEvent *event = gtk_get_current_event();
   if(event)
   {
     if(event->crossing.detail != GDK_NOTIFY_INFERIOR
        && event->crossing.mode != GDK_CROSSING_GTK_GRAB
-       && event->crossing.mode != GDK_CROSSING_GRAB)
+       && event->crossing.mode != GDK_CROSSING_GRAB
+       && !dt_gui_pointer_is_grabbed())
       dt_control_set_mouse_over_id(NO_IMGID);
     gdk_event_free(event);
   }
+}
+
+// the image under the pointer, or NO_IMGID if the pointer is in an empty area
+static dt_imgid_t _culling_image_at_pos(const dt_culling_t *table,
+                                        const gdouble x,
+                                        const gdouble y)
+{
+  for(const GList *l = table->list; l; l = g_list_next(l))
+  {
+    const dt_thumbnail_t *th = l->data;
+    if(th->x <= x && th->x + th->width > x
+       && th->y <= y && th->y + th->height > y)
+      return th->imgid;
+  }
+  return NO_IMGID;
 }
 
 static void _event_enter_cb(GtkEventControllerMotion *controller,
@@ -850,13 +867,17 @@ static void _event_enter_cb(GtkEventControllerMotion *controller,
                               gdouble y,
                               dt_culling_t *table)
 {
-  // when entering the culling area from a child thumbnail (INFERIOR),
-  // clear the mouse-over id since we're now in the empty area
+  /* The pointer entered the culling area (from the filmstrip, a panel, or
+   * after a redraw).  Set the mouse-over to the image under the pointer, if
+   * any, else clear it.  Hit-testing the pointer instead of trusting the
+   * crossing detail is required: redraws under the pointer make GDK report
+   * VIRTUAL/NONLINEAR details instead of INFERIOR, which would otherwise
+   * leave a stale hovered image (see #21729). */
   GdkEvent *event = gtk_get_current_event();
   if(event)
   {
-    if(event->crossing.detail == GDK_NOTIFY_INFERIOR)
-      dt_control_set_mouse_over_id(NO_IMGID);
+    if(!dt_gui_pointer_is_grabbed())
+      dt_control_set_mouse_over_id(_culling_image_at_pos(table, x, y));
     gdk_event_free(event);
   }
 }
@@ -938,6 +959,14 @@ static void _event_motion_notify_cb(GtkEventControllerMotion *controller,
   if(current) gdk_event_get_root_coords(current, &root_x, &root_y);
 
   table->mouse_inside = TRUE;
+
+  /* keep the mouse-over in sync with the image under the pointer; this is
+   * what makes 'prioritize hovered image' work over the culling area.  The
+   * enter/leave crossings cannot be relied on alone -- redraws under the
+   * pointer make GDK miss them (see #21729). */
+  if(!table->panning && !dt_gui_pointer_is_grabbed())
+    dt_control_set_mouse_over_id(_culling_image_at_pos(table, x, y));
+
   if(!table->panning)
   {
     table->pan_x = root_x;

--- a/src/dtgtk/culling.c
+++ b/src/dtgtk/culling.c
@@ -834,7 +834,9 @@ static void _event_leave_cb(GtkEventControllerMotion *controller,
 
   /* Don't clear the mouse-over when leaving to a child widget (thumbnail),
    * or while the pointer is grabbed: the shortcut machinery's synthetic
-   * crossings must not lose the hovered image (see #21729). */
+   * crossings must not lose the hovered image (see #21729).
+   * GTK4 migration: drop the pointer-grab check (see
+   * dt_gui_pointer_is_grabbed()) -- GTK4 has no grabs. */
   GdkEvent *event = gtk_get_current_event();
   if(event)
   {
@@ -876,6 +878,8 @@ static void _event_enter_cb(GtkEventControllerMotion *controller,
   GdkEvent *event = gtk_get_current_event();
   if(event)
   {
+    /* GTK4 migration: drop the pointer-grab check (see
+     * dt_gui_pointer_is_grabbed()) -- GTK4 has no grabs. */
     if(!dt_gui_pointer_is_grabbed())
       dt_control_set_mouse_over_id(_culling_image_at_pos(table, x, y));
     gdk_event_free(event);
@@ -963,7 +967,9 @@ static void _event_motion_notify_cb(GtkEventControllerMotion *controller,
   /* keep the mouse-over in sync with the image under the pointer; this is
    * what makes 'prioritize hovered image' work over the culling area.  The
    * enter/leave crossings cannot be relied on alone -- redraws under the
-   * pointer make GDK miss them (see #21729). */
+   * pointer make GDK miss them (see #21729).
+   * GTK4 migration: drop the pointer-grab check (see
+   * dt_gui_pointer_is_grabbed()) -- GTK4 has no grabs. */
   if(!table->panning && !dt_gui_pointer_is_grabbed())
     dt_control_set_mouse_over_id(_culling_image_at_pos(table, x, y));
 

--- a/src/dtgtk/culling.c
+++ b/src/dtgtk/culling.c
@@ -1239,10 +1239,23 @@ dt_culling_t *dt_culling_new(const dt_culling_mode_t mode)
   g_free(otxt);
 
   // set widget signals
+#if !GTK_CHECK_VERSION(4, 0, 0)
+  /* GTK3: event controllers don't request input events from GDK -- the
+   * motion controller's event mask is 0 and gestures only request touch
+   * events -- so the widget must keep its own event mask or it never
+   * receives enter/leave/motion/button events at all (the GtkLayout bin
+   * window only adds exposure/scroll masks on top of this).  Without
+   * them, hover tracking (mouse_inside / mouse_over_id) breaks in the
+   * culling layout, and clicks on empty areas are dropped.
+   * GTK4 migration: delete this call -- GTK4 delivers all input events
+   * to every widget automatically. */
   gtk_widget_set_events(table->widget,
-                        GDK_EXPOSURE_MASK
+                        GDK_EXPOSURE_MASK | GDK_POINTER_MOTION_MASK
+                        | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK
                         | GDK_STRUCTURE_MASK
+                        | GDK_ENTER_NOTIFY_MASK | GDK_LEAVE_NOTIFY_MASK
                         | GDK_TOUCHPAD_GESTURE_MASK);
+#endif
 
   dt_gui_add_class(table->widget, "dt_transparent_background");
   gtk_widget_set_can_focus(table->widget, TRUE);

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -1395,7 +1395,9 @@ static void _event_leave_cb(GtkEventControllerMotion *controller,
 
   /* Don't clear the mouse-over when leaving to a child widget (thumbnail),
    * or while the pointer is grabbed: the shortcut machinery's synthetic
-   * crossings must not lose the hovered image (see #21729). */
+   * crossings must not lose the hovered image (see #21729).
+   * GTK4 migration: drop the pointer-grab check (see
+   * dt_gui_pointer_is_grabbed()) -- GTK4 has no grabs. */
   GdkEvent *event = gtk_get_current_event();
   if(event)
   {
@@ -1425,6 +1427,8 @@ static void _event_enter_cb(GtkEventControllerMotion *controller,
   GdkEvent *event = gtk_get_current_event();
   if(event)
   {
+    /* GTK4 migration: drop the pointer-grab check (see
+     * dt_gui_pointer_is_grabbed()) -- GTK4 has no grabs. */
     if(!dt_gui_pointer_is_grabbed()
        && !_thumb_get_at_pos(table, (int)x, (int)y))
       dt_control_set_mouse_over_id(NO_IMGID);
@@ -1568,7 +1572,9 @@ static void _event_motion_notify_cb(GtkEventControllerMotion *controller,
   /* The pointer is over the table itself (not a thumbnail): make sure no
    * stale image stays hovered.  The enter/leave crossings cannot be relied
    * on here -- redraws under the pointer make GDK miss the crossing from a
-   * thumbnail into the table area (see #21729). */
+   * thumbnail into the table area (see #21729).
+   * GTK4 migration: drop the pointer-grab check (see
+   * dt_gui_pointer_is_grabbed()) -- GTK4 has no grabs. */
   if(!table->dragging
      && !dt_gui_pointer_is_grabbed()
      && !_thumb_get_at_pos(table, (int)x, (int)y))

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -31,6 +31,7 @@
 #include "control/control.h"
 #include "gui/accelerators.h"
 #include "gui/drag_and_drop.h"
+#include "gui/gtk.h"
 #include "views/view.h"
 #include "bauhaus/bauhaus.h"
 
@@ -1392,14 +1393,16 @@ static void _event_leave_cb(GtkEventControllerMotion *controller,
 
   table->mouse_inside = FALSE;
 
-  // check crossing detail: don't clear mouse_over_id when leaving to
-  // a child widget (thumbnail) or due to a grab
+  /* Don't clear the mouse-over when leaving to a child widget (thumbnail),
+   * or while the pointer is grabbed: the shortcut machinery's synthetic
+   * crossings must not lose the hovered image (see #21729). */
   GdkEvent *event = gtk_get_current_event();
   if(event)
   {
     if(event->crossing.detail != GDK_NOTIFY_INFERIOR
        && event->crossing.mode != GDK_CROSSING_GTK_GRAB
-       && event->crossing.mode != GDK_CROSSING_GRAB)
+       && event->crossing.mode != GDK_CROSSING_GRAB
+       && !dt_gui_pointer_is_grabbed())
       dt_control_set_mouse_over_id(NO_IMGID);
     gdk_event_free(event);
   }
@@ -1412,12 +1415,18 @@ static void _event_enter_cb(GtkEventControllerMotion *controller,
 {
   dt_set_backthumb_time(0.0);
 
-  // when entering the thumbtable area from a child thumbnail (INFERIOR),
-  // clear the mouse-over id since we're now in the empty area
+  /* The pointer entered the thumbtable area (from a thumbnail, a panel, or
+   * after a redraw of the table).  Clear the mouse-over only if the pointer
+   * landed on the table itself; if it landed on a thumbnail, the thumbnail's
+   * own enter handler sets it.  Hit-testing the pointer instead of trusting
+   * the crossing detail is required: redraws under the pointer make GDK
+   * report VIRTUAL/NONLINEAR details instead of INFERIOR, which would
+   * otherwise leave a stale hovered image (see #21729). */
   GdkEvent *event = gtk_get_current_event();
   if(event)
   {
-    if(event->crossing.detail == GDK_NOTIFY_INFERIOR)
+    if(!dt_gui_pointer_is_grabbed()
+       && !_thumb_get_at_pos(table, (int)x, (int)y))
       dt_control_set_mouse_over_id(NO_IMGID);
     gdk_event_free(event);
   }
@@ -1555,6 +1564,15 @@ static void _event_motion_notify_cb(GtkEventControllerMotion *controller,
   dt_set_backthumb_time(0.0);
 
   table->mouse_inside = TRUE;
+
+  /* The pointer is over the table itself (not a thumbnail): make sure no
+   * stale image stays hovered.  The enter/leave crossings cannot be relied
+   * on here -- redraws under the pointer make GDK miss the crossing from a
+   * thumbnail into the table area (see #21729). */
+  if(!table->dragging
+     && !dt_gui_pointer_is_grabbed()
+     && !_thumb_get_at_pos(table, (int)x, (int)y))
+    dt_control_set_mouse_over_id(NO_IMGID);
 
   // get root coordinates for drag tracking
   const GdkEvent *current = gtk_get_current_event();

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -2600,9 +2600,23 @@ dt_thumbtable_t *dt_thumbtable_new()
   table->offset = MAX(1, dt_conf_get_int("plugins/lighttable/collect/history_pos0"));
 
   // set widget signals
+#if !GTK_CHECK_VERSION(4, 0, 0)
+  /* GTK3: event controllers don't request input events from GDK -- the
+   * motion controller's event mask is 0 and gestures only request touch
+   * events -- so the widget must keep its own event mask or it never
+   * receives enter/leave/motion/button events at all (the GtkLayout bin
+   * window only adds exposure/scroll masks on top of this).  Without
+   * them, hover tracking (mouse_inside / mouse_over_id) breaks in the
+   * culling and file-manager layouts, and clicks on empty areas are
+   * dropped.
+   * GTK4 migration: delete this call -- GTK4 delivers all input events
+   * to every widget automatically. */
   gtk_widget_set_events(table->widget,
-                        GDK_EXPOSURE_MASK
-                        | GDK_STRUCTURE_MASK);
+                        GDK_EXPOSURE_MASK | GDK_POINTER_MOTION_MASK
+                        | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK
+                        | GDK_STRUCTURE_MASK
+                        | GDK_ENTER_NOTIFY_MASK | GDK_LEAVE_NOTIFY_MASK);
+#endif
   dt_gui_add_class(table->widget, "dt_transparent_background");
   gtk_widget_set_can_focus(table->widget, TRUE);
 

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -3646,6 +3646,12 @@ void dt_shortcuts_select_view(dt_view_type_flags_t view)
 
 static GSList *_pressed_keys = NULL, *_hold_keys = NULL; // lists of currently pressed and held keys
 static guint _pressed_button = 0;
+#if !GTK_CHECK_VERSION(4, 0, 0)
+static gboolean _pointer_grabbed = FALSE; // seat grab held by the shortcut machinery
+                                          // (kept in sync with gdk_seat_grab/ungrab:
+                                          //  the Quartz backend cannot be trusted to
+                                          //  report it, see dt_gui_pointer_is_grabbed)
+#endif
 static guint _last_time = 0; // time of key or button press
                              // used to determine if release should trigger action
                              // set to 0 by any intermediate move (so no action on release)
@@ -4050,7 +4056,14 @@ lua_end:
 
 static void _ungrab_grab_widget()
 {
+#if !GTK_CHECK_VERSION(4, 0, 0)
+  /* GTK3 only: releasing the grab (see the grab in dt_shortcut_key_press).
+   * GTK4 migration: delete -- GTK4 removed the grab APIs (see migration
+   * guide "Stop using grabs"), so there is nothing to release and no
+   * synthetic crossings to guard against (see dt_gui_pointer_is_grabbed). */
   gdk_seat_ungrab(gdk_display_get_default_seat(gdk_display_get_default()));
+  _pointer_grabbed = FALSE;
+#endif
 
   g_slist_free_full(_pressed_keys, g_free);
   _pressed_keys = NULL;
@@ -4064,6 +4077,21 @@ static void _ungrab_grab_widget()
     _grab_widget = NULL;
   }
 }
+
+#if !GTK_CHECK_VERSION(4, 0, 0)
+// the shortcut machinery keeps its own track of the seat grab it performs
+// (set in dt_shortcut_key_press, cleared in _ungrab_grab_widget): the
+// Quartz backend (macOS) doesn't implement device grabs and GDK's
+// serial-based grab bookkeeping (serials are always 0 there) can silently
+// drop the grab before it is released, so callers wanting to tell apart
+// genuine pointer crossings from the synthetic ones generated around
+// shortcuts should use dt_gui_pointer_is_grabbed(), which combines this
+// flag with the GDK state
+gboolean dt_shortcut_pointer_grabbed(void)
+{
+  return _pointer_grabbed;
+}
+#endif
 
 static void _ungrab_at_focus_loss()
 {
@@ -4345,11 +4373,18 @@ static gboolean _key_release_delayed(gpointer timed_out)
 {
   _timeout_source = 0;
 
-  if(!_pressed_keys)
-    _ungrab_grab_widget();
-
+  /* Run the shortcut action while the seat grab is still held, then
+   * ungrab.  Releasing the grab first makes GDK (and on macOS the
+   * Quartz tracking-area machinery behind it) emit phantom crossing
+   * events between the ungrab and the action, which clear the
+   * mouse-over id and make 'prioritize hovered image' fall back to the
+   * selection (see #21729).  This also matches the double/triple-press
+   * path, which processes the action while the grab is held. */
   if(!timed_out)
     dt_shortcut_move(DT_SHORTCUT_DEVICE_KEYBOARD_MOUSE, 0, DT_SHORTCUT_MOVE_NONE, 1);
+
+  if(!_pressed_keys)
+    _ungrab_grab_widget();
 
   if(!_pressed_keys)
     _sc = (dt_shortcut_t) { 0 };
@@ -4459,10 +4494,22 @@ void dt_shortcut_key_press(const dt_input_device_t id,
     {
       _lookup_mapping_widget();
 
+#if !GTK_CHECK_VERSION(4, 0, 0)
+      /* GTK3 only: grabbing the pointer on every key press makes GDK (and
+       * the Quartz tracking areas behind it on macOS) synthesize phantom
+       * crossing events; the hover tracking in the lighttable filters them
+       * with dt_gui_pointer_is_grabbed() so that 'prioritize hovered image'
+       * keeps working (see #21729).
+       * GTK4 migration: delete -- GTK4 removed gdk_seat_grab() and
+       * gdk_device_grab() (see migration guide "Stop using grabs"), so the
+       * shortcut machinery no longer grabs anything and no synthetic
+       * crossings exist to filter. */
       gdk_seat_grab(gdk_display_get_default_seat(gdk_display_get_default()),
                     gtk_widget_get_window(_grab_window ? _grab_window
                                                        : dt_ui_main_window(darktable.gui->ui)),
                     GDK_SEAT_CAPABILITY_ALL, FALSE, NULL, NULL, NULL, NULL);
+      _pointer_grabbed = TRUE;
+#endif
     }
     else
     {

--- a/src/gui/accelerators.h
+++ b/src/gui/accelerators.h
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2011-2025 darktable developers.
+    Copyright (C) 2011-2026 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -93,6 +93,13 @@ void dt_shortcut_key_press(dt_input_device_t id, const guint time, const guint k
 void dt_shortcut_key_release(dt_input_device_t id, const guint time, const guint key);
 gboolean dt_shortcut_key_active(dt_input_device_t id, const guint key);
 float dt_shortcut_move(dt_input_device_t id, const guint time, const guint move, const float move_size);
+
+// shortcut machinery seat-grab tracking (see dt_gui_pointer_is_grabbed):
+// the shortcut machinery keeps its own flag because the Quartz backend
+// cannot be trusted to report the grab state (GDK serials are always 0 there)
+#if !GTK_CHECK_VERSION(4, 0, 0)
+gboolean dt_shortcut_pointer_grabbed(void);
+#endif
 
 typedef enum dt_shortcut_flag_t
 {

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -164,12 +164,35 @@ void dt_gui_remove_class(GtkWidget *widget, const gchar *class_name)
 
 gboolean dt_gui_pointer_is_grabbed()
 {
+#if GTK_CHECK_VERSION(4, 0, 0)
+  /* GTK4 migration: delete this function and every !dt_gui_pointer_is_grabbed()
+   * check in the culling/thumbtable hover handlers (they become no-ops).
+   * GTK4 removed gdk_seat_grab()/gdk_device_grab() (see migration guide
+   * "Stop using grabs"), so darktable never grabs the pointer and no phantom
+   * crossing events exist to filter.  More fundamentally, GtkLayout and
+   * GtkEventBox were removed in GTK4 ("GtkLayout ... has been removed in
+   * favor of the existing GtkFixed", "GtkEventBox is no longer needed and
+   * has been removed"), so the lighttable/culling widgets must be reworked
+   * anyway -- a GtkGridView with one widget per thumbnail gives native
+   * per-image enter/leave events, which supersedes both the manual
+   * hit-testing and this guard entirely. */
+  return FALSE;
+#else
   /* the keyboard shortcut machinery grabs the pointer on every key press
-   * (gdk_seat_grab()), which makes GDK synthesize crossing events that are
-   * not real pointer movements; this lets callers tell those apart from
-   * genuine crossings */
-  return gdk_display_device_is_grabbed(gdk_display_get_default(),
+   * (gdk_seat_grab()), which makes GDK (and the Quartz tracking areas
+   * behind it on macOS) synthesize crossing events that are not real
+   * pointer movements; this lets callers tell those apart from genuine
+   * crossings
+   *
+   * the shortcut machinery's own flag is checked first: on macOS the
+   * Quartz backend doesn't implement device grabs and GDK's serial-based
+   * grab bookkeeping (serials are always 0 there) can silently drop the
+   * grab before it is released, making gdk_display_device_is_grabbed()
+   * return FALSE while a shortcut action is still running */
+  return dt_shortcut_pointer_grabbed()
+      || gdk_display_device_is_grabbed(gdk_display_get_default(),
                                        gdk_seat_get_pointer(gdk_display_get_default_seat(gdk_display_get_default())));
+#endif
 }
 
 /*

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -162,6 +162,16 @@ void dt_gui_remove_class(GtkWidget *widget, const gchar *class_name)
   gtk_style_context_remove_class(context, class_name);
 }
 
+gboolean dt_gui_pointer_is_grabbed()
+{
+  /* the keyboard shortcut machinery grabs the pointer on every key press
+   * (gdk_seat_grab()), which makes GDK synthesize crossing events that are
+   * not real pointer movements; this lets callers tell those apart from
+   * genuine crossings */
+  return gdk_display_device_is_grabbed(gdk_display_get_default(),
+                                       gdk_seat_get_pointer(gdk_display_get_default_seat(gdk_display_get_default())));
+}
+
 /*
  * OLD UI API
  */

--- a/src/gui/gtk.h
+++ b/src/gui/gtk.h
@@ -202,6 +202,9 @@ static inline GdkPixbuf *dt_gdk_pixbuf_new_from_file_at_size(const char *filenam
 // call class function to add or remove CSS classes (need to be set on top of this file as first function is used in this file)
 void dt_gui_add_class(GtkWidget *widget, const gchar *class_name);
 void dt_gui_remove_class(GtkWidget *widget, const gchar *class_name);
+/* true while the pointer is grabbed by our own shortcut machinery; used to
+ * ignore the synthetic crossing events GDK generates for those grabs */
+gboolean dt_gui_pointer_is_grabbed(void);
 
 void dt_open_url(const char *url);
 int dt_gui_theme_init(dt_gui_gtk_t *gui);


### PR DESCRIPTION
Fixes a bug where, with "prioritize hovered image over the selected images" turned on, rating/rejecting via keyboard would hit the *selected* image instead of the one you were actually hovering over (fixes #21729).

Heads up: the first two commits here fixed it on Linux but not macOS. The last commit gets macOS too. I can't test on Windows, and unsure about x11 vs Wayland (I just happen to run Gnome on Wayland), so if you're on those, let me know how it goes.

**What was actually happening**

Turns out the mouse-over id was getting wiped out by fake crossing events right before the shortcut even had a chance to read it. Here's the chain of events:

- Every key press grabs the pointer (`gdk_seat_grab()`), and that grab/ungrab dance generates crossing events that *look* like real pointer movement but aren't — GDK fires synthetic ones on Linux, and on macOS the Quartz backend's tracking areas do something similar when the ungrab happens (can't speak for other backends, didn't test them).
- The shortcut code was releasing the grab *before* running the action, which left a window where these phantom crossings could sneak in, and the leave handlers would clear the hovered image right before "prioritize hovered image" needed it.
- To make things messier, GDK's own grab-state tracking isn't reliable — on macOS, Quartz always reports serials as 0, so `gdk_display_device_is_grabbed()` can claim the grab is released even while a shortcut is mid-flight. That broke the "only while grabbed" guard.

**How it's fixed**

- Shortcut actions now run *while the grab is still held*, and we ungrab afterwards — so the phantom crossings show up after the action instead of during it. This also lines up with how double/triple-press already worked (it processed the action while still grabbed).
- Added our own flag to track the grab state (`dt_shortcut_pointer_grabbed()`), and `dt_gui_pointer_is_grabbed()` now checks that flag OR the GDK state — so we're not solely at the mercy of GDK's bookkeeping.
- The hovered image is now kept in sync by hit-testing the pointer position directly in the enter/motion handlers, since redraws happening right under the pointer can make GDK straight-up miss crossing events.
- Restored event masks on the culling/thumbtable widgets — a GTK3 quirk where event controllers alone don't request input events there.

**Other notes**

- The `gtk4-prep` migration may have already fixed #21385 as a side effect. If it hasn't, this PR should.
- None of the grab stuff applies to GTK4 — it's GTK3-only and version-guarded, since GTK4 dropped `gdk_seat_grab()`/`gdk_device_grab()` entirely (see the ["Stop using grabs"](https://docs.gtk.org/gtk4/migrating-3to4.html) section of the migration guide).
- GtkLayout and GtkEventBox are also gone in GTK4, so the lighttable/culling widgets need a rework regardless — probably a GtkGridView with one widget per thumbnail, which would give native per-image enter/leave events in the grid; the culling layout keeps drawn thumbnails, so the manual hit-testing stays there (the grab guard and event masks are what go away).

Related: #15920, #20433
