### PR TITLE
gtk4-prep: fix lighttable keyboard selection

### DIFF
--- a/src/common/selection.c
+++ b/src/common/selection.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2011-2023 darktable developers.
+    Copyright (C) 2011-2026 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -207,6 +207,11 @@ void dt_selection_select(dt_selection_t *selection,
   selection->last_single_id = imgid;
 }
 
+dt_imgid_t dt_selection_get_last_single_id(const dt_selection_t *selection)
+{
+  return selection->last_single_id;
+}
+
 void dt_selection_deselect(dt_selection_t *selection,
                            const dt_imgid_t imgid)
 {
@@ -373,13 +378,19 @@ void dt_selection_select_range(dt_selection_t *selection,
     sqlite3_finalize(stmt);
   }
 
-  /* select the images in range from start to end */
+  /* set the selection to the range between the anchor (last_single_id) and
+   * imgid: clear the previous selection first, then select the new range.
+   * This allows shrinking the selection by moving back towards the anchor
+   * while keeping the anchor fixed. */
   const uint32_t old_flags = dt_collection_get_query_flags(selection->collection);
 
   /* use the limit to select range of images */
   dt_collection_set_query_flags(selection->collection, (old_flags | COLLECTION_QUERY_USE_LIMIT));
 
   dt_collection_update(selection->collection);
+
+  DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db),
+                        "DELETE FROM main.selected_images", NULL, NULL, NULL);
 
   gchar *fullq = g_strdup_printf
     ("INSERT OR IGNORE INTO main.selected_images (imgid) %s",
@@ -397,10 +408,11 @@ void dt_selection_select_range(dt_selection_t *selection,
   dt_collection_set_query_flags(selection->collection, old_flags);
   dt_collection_update(selection->collection);
 
-  // The logic above doesn't handle groups, so explicitly select the
-  // beginning and end to make sure those are selected properly
-  dt_selection_select(selection, srid);
-  dt_selection_select(selection, imgid);
+  /* the range query can miss the endpoints with grouped images, so select
+   * them explicitly; unlike dt_selection_select() this does not move the
+   * range anchor (last_single_id) */
+  _selection_select(selection, srid);
+  _selection_select(selection, imgid);
 
   g_free(fullq);
 }

--- a/src/common/selection.h
+++ b/src/common/selection.h
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2011-2021 darktable developers.
+    Copyright (C) 2011-2026 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -32,6 +32,9 @@ void dt_selection_invert(struct dt_selection_t *selection);
 void dt_selection_clear(struct dt_selection_t *selection);
 /** adds imgid to the current selection */
 void dt_selection_select(struct dt_selection_t *selection, dt_imgid_t imgid);
+/** get the imgid of the last image selected with a single selection (click,
+ *  keyboard navigation, ...) ; it is the anchor used for range selection */
+dt_imgid_t dt_selection_get_last_single_id(const struct dt_selection_t *selection);
 /** removes imgid from the current selection */
 void dt_selection_deselect(struct dt_selection_t *selection, dt_imgid_t imgid);
 /** clears current selection and adds imgid */

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -1628,6 +1628,9 @@ static void _event_button_release_cb(GtkGestureSingle *gesture,
 
   if(dt_is_valid_imgid(id))
   {
+    /* the keyboard cursor continues from the image we clicked on */
+    table->key_pos = id;
+
     if(dt_modifier_is(state, GDK_CONTROL_MASK)
        || dt_modifier_is(state, GDK_MOD2_MASK)) // CMD key on macOS
     {
@@ -2622,6 +2625,7 @@ dt_thumbtable_t *dt_thumbtable_new()
   g_free(cl);
 
   table->offset = MAX(1, dt_conf_get_int("plugins/lighttable/collect/history_pos0"));
+  table->key_pos = NO_IMGID;
 
   // set widget signals
 #if !GTK_CHECK_VERSION(4, 0, 0)
@@ -3383,17 +3387,42 @@ gboolean dt_thumbtable_check_imgid_visibility(dt_thumbtable_t *table,
   return FALSE;
 }
 
+// get the image the keyboard navigation should continue from: the last image
+// the keyboard navigated to (key_pos), falling back to the last single-selected
+// image, then the mouse hover -- so a stationary mouse cannot move the keyboard
+// cursor
+static dt_imgid_t _thumb_key_base(dt_thumbtable_t *table)
+{
+  const dt_imgid_t keyid = table->key_pos;
+  const dt_imgid_t selid = dt_selection_get_last_single_id(darktable.selection);
+  return dt_is_valid_imgid(keyid) && _thumb_get_rowid(keyid) > 0 ? keyid
+       : dt_is_valid_imgid(selid) && _thumb_get_rowid(selid) > 0 ? selid
+       : dt_control_get_mouse_over_id();
+}
+
+// move the selection to imgid (plain navigation) or extend it from the fixed
+// anchor (shift navigation), keeping the keyboard cursor on it
+static void _thumb_key_select(dt_thumbtable_t *table,
+                              const dt_imgid_t imgid,
+                              const gboolean select)
+{
+  if(!dt_is_valid_imgid(imgid)) return;
+  if(select)
+    dt_selection_select_range(darktable.selection, imgid);
+  else
+    dt_selection_select_single(darktable.selection, imgid);
+  table->key_pos = imgid;
+}
+
 static gboolean _filemanager_key_move(dt_thumbtable_t *table,
                                       const dt_thumbtable_move_t move,
                                       const gboolean select)
 {
-  // base point
-  dt_imgid_t baseid = dt_control_get_mouse_over_id();
+  /* the keyboard cursor is anchored on the real selection, not the mouse
+   * hover */
+  dt_imgid_t baseid = _thumb_key_base(table);
   const gboolean first_move = (baseid <= 0);
   int newrowid = -1;
-  // let's be sure that the current image is selected
-  if(dt_is_valid_imgid(baseid) && select)
-    dt_selection_select(darktable.selection, baseid);
 
   int baserowid = 1;
 
@@ -3476,9 +3505,8 @@ static gboolean _filemanager_key_move(dt_thumbtable_t *table,
   if(newrowid != -1)
     _filemanager_ensure_rowid_visibility(table, newrowid);
 
-  // if needed, we set the selection
-  if(select && dt_is_valid_imgid(imgid))
-    dt_selection_select_range(darktable.selection, imgid);
+  // move the selection with the keyboard
+  _thumb_key_select(table, imgid, select);
   return TRUE;
 }
 
@@ -3486,11 +3514,6 @@ static gboolean _zoomable_key_move(dt_thumbtable_t *table,
                                    const dt_thumbtable_move_t move,
                                    const gboolean select)
 {
-  // let's be sure that the current image is selected
-  const dt_imgid_t baseid = dt_control_get_mouse_over_id();
-  if(dt_is_valid_imgid(baseid) && select)
-    dt_selection_select(darktable.selection, baseid);
-
   // first, we move the view by 1 thumb_size
   // move step
   const int step = table->thumb_size;
@@ -3539,10 +3562,11 @@ static gboolean _zoomable_key_move(dt_thumbtable_t *table,
   // and we set mouseover if we can
   dt_thumbnail_t *thumb = _thumb_get_under_mouse(table);
   if(thumb)
+  {
     dt_control_set_mouse_over_id(thumb->imgid);
-  // if needed, we set the selection
-  if(thumb && select)
-    dt_selection_select_range(darktable.selection, thumb->imgid);
+    // move the selection with the keyboard
+    _thumb_key_select(table, thumb->imgid, select);
+  }
 
   // and we record new positions values
   const dt_thumbnail_t *first = table->list->data;

--- a/src/dtgtk/thumbtable.h
+++ b/src/dtgtk/thumbtable.h
@@ -84,6 +84,7 @@ typedef struct dt_thumbtable_t
 
   gboolean mouse_inside; // is the mouse pointer inside thumbtable widget ?
   gboolean key_inside;   // is the key move pointer inside thumbtable widget ?
+  dt_imgid_t key_pos;    // last image the keyboard navigated to (selection act_on algorithm)
 
   // when performing a drag, we store the list of items to drag here
   // as this can change during the drag and drop (esp. because of the image_over_id)

--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -1574,29 +1574,45 @@ void gui_init(dt_view_t *self)
                         GINT_TO_POINTER(_ACTION_TABLE_MOVE_STARTEND), &_action_def_move);
   dt_shortcut_register(ac, DT_ACTION_ELEMENT_MOVE, DT_ACTION_EFFECT_PREVIOUS,
                        GDK_KEY_Home, 0);
+  dt_shortcut_register(ac, DT_ACTION_ELEMENT_SELECT, DT_ACTION_EFFECT_PREVIOUS,
+                       GDK_KEY_Home, GDK_SHIFT_MASK);
   dt_shortcut_register(ac, DT_ACTION_ELEMENT_MOVE, DT_ACTION_EFFECT_NEXT,
                        GDK_KEY_End, 0);
+  dt_shortcut_register(ac, DT_ACTION_ELEMENT_SELECT, DT_ACTION_EFFECT_NEXT,
+                       GDK_KEY_End, GDK_SHIFT_MASK);
 
   ac = dt_action_define(sa, N_("move"), N_("horizontal"),
                         GINT_TO_POINTER(_ACTION_TABLE_MOVE_LEFTRIGHT), &_action_def_move);
   dt_shortcut_register(ac, DT_ACTION_ELEMENT_MOVE, DT_ACTION_EFFECT_PREVIOUS,
                        GDK_KEY_Left, 0);
+  dt_shortcut_register(ac, DT_ACTION_ELEMENT_SELECT, DT_ACTION_EFFECT_PREVIOUS,
+                       GDK_KEY_Left, GDK_SHIFT_MASK);
   dt_shortcut_register(ac, DT_ACTION_ELEMENT_MOVE, DT_ACTION_EFFECT_NEXT,
                        GDK_KEY_Right, 0);
+  dt_shortcut_register(ac, DT_ACTION_ELEMENT_SELECT, DT_ACTION_EFFECT_NEXT,
+                       GDK_KEY_Right, GDK_SHIFT_MASK);
 
   ac = dt_action_define(sa, N_("move"), N_("vertical"),
                         GINT_TO_POINTER(_ACTION_TABLE_MOVE_UPDOWN), &_action_def_move);
   dt_shortcut_register(ac, DT_ACTION_ELEMENT_MOVE, DT_ACTION_EFFECT_PREVIOUS,
                        GDK_KEY_Down, 0);
+  dt_shortcut_register(ac, DT_ACTION_ELEMENT_SELECT, DT_ACTION_EFFECT_PREVIOUS,
+                       GDK_KEY_Down, GDK_SHIFT_MASK);
   dt_shortcut_register(ac, DT_ACTION_ELEMENT_MOVE, DT_ACTION_EFFECT_NEXT,
                        GDK_KEY_Up, 0);
+  dt_shortcut_register(ac, DT_ACTION_ELEMENT_SELECT, DT_ACTION_EFFECT_NEXT,
+                       GDK_KEY_Up, GDK_SHIFT_MASK);
 
   ac = dt_action_define(sa, N_("move"), N_("page"),
                         GINT_TO_POINTER(_ACTION_TABLE_MOVE_PAGE), &_action_def_move);
   dt_shortcut_register(ac, DT_ACTION_ELEMENT_MOVE, DT_ACTION_EFFECT_PREVIOUS,
                        GDK_KEY_Page_Down, 0);
+  dt_shortcut_register(ac, DT_ACTION_ELEMENT_SELECT, DT_ACTION_EFFECT_PREVIOUS,
+                       GDK_KEY_Page_Down, GDK_SHIFT_MASK);
   dt_shortcut_register(ac, DT_ACTION_ELEMENT_MOVE, DT_ACTION_EFFECT_NEXT,
                        GDK_KEY_Page_Up, 0);
+  dt_shortcut_register(ac, DT_ACTION_ELEMENT_SELECT, DT_ACTION_EFFECT_NEXT,
+                       GDK_KEY_Page_Up, GDK_SHIFT_MASK);
 
   ac = dt_action_define(sa, N_("move"), N_("leave"),
                         GINT_TO_POINTER(_ACTION_TABLE_MOVE_LEAVE), &_action_def_move);


### PR DESCRIPTION
Arrow-key navigation in the lighttable grid was anchored on the mouse hover instead of the selection, whether the "prioritize hovered image over the selected images" option was on or off. If you navigated to an image with the keyboard and then moved the mouse over another image (or out of the grid), the next arrow would continue from there, jumping away from where you were. Shift+arrows also didn't extend the selection unless the "enable shortcut fallbacks" preference was turned on.

This makes the keyboard behave the same regardless of the option:

- arrows move the selection from where the keyboard last navigated, never from the mouse hover
- shift+arrows extend the selection from a fixed anchor, and moving back shrinks it again
- hovering with the mouse no longer moves the keyboard position
- shift+arrows now work out of the box (explicit shortcuts instead of relying on the fallbacks preference)

Related: #21385
Fixes #21067