### PR TITLE
Safer calculation of available tiling memory

### DIFF
--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -320,10 +320,30 @@ gboolean dt_dev_pixelpipe_init_cached(dt_dev_pixelpipe_t *pipe,
   return dt_dev_pixelpipe_cache_init(pipe, entries, size, memlimit);
 }
 
+static inline size_t _dev_used_cachemem(void)
+{
+  const dt_develop_t *dev = darktable.develop;
+  // FIXME take care about other caches not defined by resource levels?
+  return  dev->full.pipe->cache.allmem
+        + dev->preview2.pipe->cache.allmem
+        + dev->preview_pipe->cache.allmem;
+}
+
 size_t dt_get_available_pipe_mem(const dt_dev_pixelpipe_t *pipe)
 {
+  const size_t cachemem = _dev_used_cachemem();
   const size_t allmem = dt_get_available_mem();
-  return MAX(DT_MEGA, allmem / (dt_pipe_is_thumb(pipe) ? 3 : 1));
+  const size_t safemem = allmem > cachemem ? allmem - cachemem : 0;
+  const size_t granted = MAX(safemem, DT_MEGA * 128);
+
+  const gboolean warn = (cachemem > allmem / 2) || (granted < DT_MEGA * 1024);
+  if(warn)
+    dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_TILING, "pipemem warning",
+      pipe, NULL, DT_DEVICE_NONE, NULL, NULL,
+      "allmem=%zuMB, cachemem=%zuMB, granted=%zuMB",
+      allmem / DT_MEGA, cachemem / DT_MEGA, granted / DT_MEGA);
+
+  return granted / (dt_pipe_is_thumb(pipe) ? 3 : 1);
 }
 
 static void get_output_format(dt_iop_module_t *module,

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -4025,6 +4025,19 @@ void enter(dt_view_t *self)
 
 }
 
+static inline void _clear_pipecache(dt_dev_pixelpipe_t *pipe)
+{
+  // As log as we don't have a better trim ...
+  dt_dev_pixelpipe_cache_checkmem(pipe);
+
+  if(pipe->bcache_data)
+  {
+    dt_free_align(pipe->bcache_data);
+    pipe->bcache_data = NULL;
+    pipe->bcache_hash = DT_INVALID_HASH;
+  }
+}
+
 void leave(dt_view_t *self)
 {
   dt_iop_color_picker_cleanup();
@@ -4149,6 +4162,11 @@ void leave(dt_view_t *self)
   dev->gui_leaving = TRUE;
 
   dt_pthread_mutex_lock(&dev->history_mutex);
+
+  // cleanup pipe caches leaving most important stuff available for darkroom re-enter
+  _clear_pipecache(dev->full.pipe);
+  _clear_pipecache(dev->preview2.pipe);
+  _clear_pipecache(dev->preview_pipe);
 
   dt_dev_pixelpipe_cleanup_nodes(dev->full.pipe);
   dt_dev_pixelpipe_cleanup_nodes(dev->preview2.pipe);


### PR DESCRIPTION
When we test for "tiling-required?" we use dt_get_available_pipe_mem(), this did not take allocated pipe cache memory into account thus overestimating available mem.

We now only provide for tiling what is left from available taking pipi caches into account and give a log warning for problematic situations.

Reduces chance for OOM kills on low mem systems.

See #21705 
