### PR TITLE
gtk4-prep: fix shortcut activation for gesture-driven toggle buttons

### DIFF
--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -1358,7 +1358,7 @@ static void _blendop_blendif_showmask_clicked(GtkGestureSingle *gesture,
 {
   DT_GUARD_GUI_UPDATE();
 
-  if(gtk_gesture_single_get_current_button(gesture) != GDK_BUTTON_PRIMARY) return;
+  if(dt_gui_current_button(gesture) != GDK_BUTTON_PRIMARY) return;
 
   GtkWidget *button = dt_gui_get_widget(gesture);
 
@@ -1416,7 +1416,7 @@ static void _blendop_masks_modes_none_clicked(GtkGestureSingle *gesture,
   GtkWidget *button = dt_gui_get_widget(gesture);
   dt_iop_gui_blend_data_t *data = module->blend_data;
 
-  if(gtk_gesture_single_get_current_button(gesture) == GDK_BUTTON_PRIMARY
+  if(dt_gui_current_button(gesture) == GDK_BUTTON_PRIMARY
      && data->selected_mask_mode != button)
   {
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(data->selected_mask_mode),

--- a/src/develop/imageop_gui.c
+++ b/src/develop/imageop_gui.c
@@ -270,6 +270,9 @@ GtkWidget *dt_iop_togglebutton_new(dt_iop_module_t *self, const char *section, c
     g_signal_connect_data(gesture, "pressed", callback, self, NULL, 0);
     g_signal_connect(gesture, "begin", G_CALLBACK(_gesture_begin_claim), NULL);
     gtk_gesture_single_set_button(GTK_GESTURE_SINGLE(gesture), 0);
+    /* shortcut activation routes through this gesture (DT_ACTION_GESTURE_KEY,
+     * see _action_process_toggle in accelerators.c) */
+    g_object_set_data(G_OBJECT(w), DT_ACTION_GESTURE_KEY, gesture);
   }
 
   if(!ctrl_label)

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -219,27 +219,39 @@ static float _action_process_toggle(gpointer target,
   if(DT_ACTION_TOGGLE_NEEDED(effect, move_size, value)
      && gtk_widget_get_ancestor(target, GTK_TYPE_WINDOW))
   {
-    GdkEvent *event = gdk_event_new(GDK_BUTTON_PRESS);
-    event->button.state = (effect == DT_ACTION_EFFECT_TOGGLE_CTRL
-                           || effect == DT_ACTION_EFFECT_ON_CTRL)
-                        ? GDK_CONTROL_MASK : 0;
-    event->button.button = (effect == DT_ACTION_EFFECT_TOGGLE_RIGHT
-                            || effect == DT_ACTION_EFFECT_ON_RIGHT)
-                         ? GDK_BUTTON_SECONDARY : GDK_BUTTON_PRIMARY;
+    GtkGestureSingle *const gesture = g_object_get_data(G_OBJECT(target), DT_ACTION_GESTURE_KEY);
+    if(gesture)
+    {
+      /* the widget's activation lives in a gesture controller, which
+       * synthetic GdkEvents never reach: invoke it through the same
+       * "pressed" signal a real click produces (the callback manages the
+       * button states itself, as for a real click) */
+      g_signal_emit_by_name(gesture, "pressed", 1, 0.0, 0.0);
+    }
+    else
+    {
+      GdkEvent *event = gdk_event_new(GDK_BUTTON_PRESS);
+      event->button.state = (effect == DT_ACTION_EFFECT_TOGGLE_CTRL
+                             || effect == DT_ACTION_EFFECT_ON_CTRL)
+                          ? GDK_CONTROL_MASK : 0;
+      event->button.button = (effect == DT_ACTION_EFFECT_TOGGLE_RIGHT
+                              || effect == DT_ACTION_EFFECT_ON_RIGHT)
+                           ? GDK_BUTTON_SECONDARY : GDK_BUTTON_PRIMARY;
 
-    if(!gtk_widget_get_realized(target)) gtk_widget_realize(target);
-    event->button.window = gtk_widget_get_window(target);
-    g_object_ref(event->button.window);
+      if(!gtk_widget_get_realized(target)) gtk_widget_realize(target);
+      event->button.window = gtk_widget_get_window(target);
+      g_object_ref(event->button.window);
 
-    // some togglebuttons connect to the clicked signal, others to toggled or button-press-event
-    // gtk_widget_event does not work when widgets are hidden in event boxes or some other conditions
-    gboolean handled;
-    g_signal_emit_by_name(G_OBJECT(target), "button-press-event", event, &handled);
-    if(!handled) gtk_button_clicked(GTK_BUTTON(target));
-    event->type = GDK_BUTTON_RELEASE;
-    g_signal_emit_by_name(G_OBJECT(target), "button-release-event", event, &handled);
+      // some togglebuttons connect to the clicked signal, others to toggled or button-press-event
+      // gtk_widget_event does not work when widgets are hidden in event boxes or some other conditions
+      gboolean handled;
+      g_signal_emit_by_name(G_OBJECT(target), "button-press-event", event, &handled);
+      if(!handled) gtk_button_clicked(GTK_BUTTON(target));
+      event->type = GDK_BUTTON_RELEASE;
+      g_signal_emit_by_name(G_OBJECT(target), "button-release-event", event, &handled);
 
-    gdk_event_free(event);
+      gdk_event_free(event);
+    }
 
     value = gtk_toggle_button_get_active(target);
 
@@ -261,28 +273,38 @@ static float _action_process_button(gpointer target,
      && gtk_widget_is_sensitive(target)
      && gtk_widget_get_ancestor(target, GTK_TYPE_WINDOW))
   {
-    if(!gtk_widget_get_realized(target)) gtk_widget_realize(target);
-
-    if(effect != DT_ACTION_EFFECT_ACTIVATE
-      || !g_signal_handler_find(target, G_SIGNAL_MATCH_ID,
-                                g_signal_lookup("clicked", gtk_button_get_type()),
-                                0, NULL, NULL, NULL)
-      || !gtk_widget_activate(GTK_WIDGET(target)))
+    GtkGestureSingle *const gesture = g_object_get_data(G_OBJECT(target), DT_ACTION_GESTURE_KEY);
+    if(gesture)
     {
-      GdkEvent *event = gdk_event_new(GDK_BUTTON_PRESS);
-      event->button.state = effect == DT_ACTION_EFFECT_ACTIVATE_CTRL
-                          ? GDK_CONTROL_MASK : 0;
-      event->button.button = effect == DT_ACTION_EFFECT_ACTIVATE_RIGHT
-                          ? GDK_BUTTON_SECONDARY : GDK_BUTTON_PRIMARY;
+      /* same as _action_process_toggle: the widget's activation lives in a
+       * gesture controller, which synthetic GdkEvents never reach */
+      g_signal_emit_by_name(gesture, "pressed", 1, 0.0, 0.0);
+    }
+    else
+    {
+      if(!gtk_widget_get_realized(target)) gtk_widget_realize(target);
 
-      event->button.window = gtk_widget_get_window(target);
-      g_object_ref(event->button.window);
+      if(effect != DT_ACTION_EFFECT_ACTIVATE
+        || !g_signal_handler_find(target, G_SIGNAL_MATCH_ID,
+                                  g_signal_lookup("clicked", gtk_button_get_type()),
+                                  0, NULL, NULL, NULL)
+        || !gtk_widget_activate(GTK_WIDGET(target)))
+      {
+        GdkEvent *event = gdk_event_new(GDK_BUTTON_PRESS);
+        event->button.state = effect == DT_ACTION_EFFECT_ACTIVATE_CTRL
+                            ? GDK_CONTROL_MASK : 0;
+        event->button.button = effect == DT_ACTION_EFFECT_ACTIVATE_RIGHT
+                            ? GDK_BUTTON_SECONDARY : GDK_BUTTON_PRIMARY;
 
-      gtk_widget_event(target, event);
-      event->type = GDK_BUTTON_RELEASE;
-      gtk_widget_event(target, event);
+        event->button.window = gtk_widget_get_window(target);
+        g_object_ref(event->button.window);
 
-      gdk_event_free(event);
+        gtk_widget_event(target, event);
+        event->type = GDK_BUTTON_RELEASE;
+        gtk_widget_event(target, event);
+
+        gdk_event_free(event);
+      }
     }
   }
 

--- a/src/gui/accelerators.h
+++ b/src/gui/accelerators.h
@@ -225,6 +225,20 @@ void dt_action_cleanup_instance_iop(dt_iop_module_t *module);
 // UX miscellaneous functions
 void dt_action_widget_toast(dt_action_t *action, GtkWidget *widget, const gchar *msg, ...);
 
+/* Widgets whose activation lives in a gesture controller (a GtkGesture*
+ * "pressed"/"released" handler instead of widget class vfuncs or "clicked"/
+ * "toggled" signals) register their gesture here so the shortcut machinery
+ * can invoke the same code path as a real click: synthetic GdkEvents never
+ * reach gesture controllers, so without this a shortcut would flip the
+ * widget's visual state without activating it.  See _action_process_toggle
+ * and _action_process_button in accelerators.c.
+ *
+ * GTK4: this stored-gesture path survives the switch -- "button-press-event"
+ * does not exist in GTK4 and GdkEvent is opaque
+ * (https://docs.gtk.org/gtk4/migrating-3to4.html, "Event controllers and
+ * gestures replace event signals"). */
+#define DT_ACTION_GESTURE_KEY "_dt_action_gesture"
+
 // check if widget intentionally hidden (to disable it)
 gboolean dt_action_widget_invisible(GtkWidget *w);
 

--- a/src/gui/gtk.h
+++ b/src/gui/gtk.h
@@ -643,6 +643,16 @@ GtkEventController *(dt_gui_connect_key)(GtkWidget *widget,
 #define dt_gui_get_widget(controller) \
       gtk_event_controller_get_widget(GTK_EVENT_CONTROLLER(controller))
 
+/* button of the current gesture press; 0 when the press was synthesized by
+ * the shortcut machinery (DT_ACTION_GESTURE_KEY), which stands for a primary
+ * click (GtkGestureSingle resets current-button to 0 on release, so a 0 is
+ * never a real press) */
+static inline guint dt_gui_current_button(GtkGestureSingle *gesture)
+{
+  const guint button = gtk_gesture_single_get_current_button(gesture);
+  return button ? button : GDK_BUTTON_PRIMARY;
+}
+
 #define dt_gui_claim(gesture) \
       gtk_gesture_set_state(GTK_GESTURE(gesture), GTK_EVENT_SEQUENCE_CLAIMED)
 #define dt_gui_deny(gesture) \

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -5326,7 +5326,7 @@ static void _event_fit_v_button_clicked(GtkGestureSingle *gesture,
 {
   DT_GUARD_GUI_UPDATE();
 
-  if(gtk_gesture_single_get_current_button(gesture) == GDK_BUTTON_PRIMARY)
+  if(dt_gui_current_button(gesture) == GDK_BUTTON_PRIMARY)
   {
     dt_iop_ashift_params_t *p = self->params;
     dt_iop_ashift_gui_data_t *g = self->gui_data;
@@ -5375,7 +5375,7 @@ static void _event_fit_h_button_clicked(GtkGestureSingle *gesture,
 {
   DT_GUARD_GUI_UPDATE();
 
-  if(gtk_gesture_single_get_current_button(gesture) == GDK_BUTTON_PRIMARY)
+  if(dt_gui_current_button(gesture) == GDK_BUTTON_PRIMARY)
   {
     dt_iop_ashift_params_t *p = self->params;
     dt_iop_ashift_gui_data_t *g = self->gui_data;
@@ -5424,7 +5424,7 @@ static void _event_fit_both_button_clicked(GtkGestureSingle *gesture,
 {
   DT_GUARD_GUI_UPDATE();
 
-  if(gtk_gesture_single_get_current_button(gesture) == GDK_BUTTON_PRIMARY)
+  if(dt_gui_current_button(gesture) == GDK_BUTTON_PRIMARY)
   {
     dt_iop_ashift_params_t *p = self->params;
     dt_iop_ashift_gui_data_t *g = self->gui_data;
@@ -5476,7 +5476,7 @@ static void _event_structure_auto_clicked(GtkGestureSingle *gesture,
   GtkWidget *widget = dt_gui_get_widget(gesture);
   DT_GUARD_GUI_UPDATE();
 
-  if(gtk_gesture_single_get_current_button(gesture) == GDK_BUTTON_PRIMARY)
+  if(dt_gui_current_button(gesture) == GDK_BUTTON_PRIMARY)
   {
     dt_iop_ashift_params_t *p = self->params;
     dt_iop_ashift_gui_data_t *g = self->gui_data;
@@ -6117,12 +6117,18 @@ void gui_init(dt_iop_module_t *self)
     (g->structure_quad, _("manually define perspective rectangle"));
   gtk_widget_set_tooltip_text(g->structure_lines, _("manually draw structure lines"));
 
-  dt_gui_connect_click(g->fit_v, _event_fit_v_button_clicked, NULL, self);
-  dt_gui_connect_click(g->fit_h, _event_fit_h_button_clicked, NULL, self);
-  dt_gui_connect_click(g->fit_both, _event_fit_both_button_clicked, NULL, self);
-  dt_gui_connect_click(g->structure_quad, _event_structure_quad_clicked, NULL, self);
-  dt_gui_connect_click(g->structure_lines, _event_structure_lines_clicked, NULL, self);
-  dt_gui_connect_click(g->structure_auto, _event_structure_auto_clicked, NULL, self);
+  g_object_set_data(G_OBJECT(g->fit_v), DT_ACTION_GESTURE_KEY,
+                    dt_gui_connect_click(g->fit_v, _event_fit_v_button_clicked, NULL, self));
+  g_object_set_data(G_OBJECT(g->fit_h), DT_ACTION_GESTURE_KEY,
+                    dt_gui_connect_click(g->fit_h, _event_fit_h_button_clicked, NULL, self));
+  g_object_set_data(G_OBJECT(g->fit_both), DT_ACTION_GESTURE_KEY,
+                    dt_gui_connect_click(g->fit_both, _event_fit_both_button_clicked, NULL, self));
+  g_object_set_data(G_OBJECT(g->structure_quad), DT_ACTION_GESTURE_KEY,
+                    dt_gui_connect_click(g->structure_quad, _event_structure_quad_clicked, NULL, self));
+  g_object_set_data(G_OBJECT(g->structure_lines), DT_ACTION_GESTURE_KEY,
+                    dt_gui_connect_click(g->structure_lines, _event_structure_lines_clicked, NULL, self));
+  g_object_set_data(G_OBJECT(g->structure_auto), DT_ACTION_GESTURE_KEY,
+                    dt_gui_connect_click(g->structure_auto, _event_structure_auto_clicked, NULL, self));
   g_signal_connect(G_OBJECT(self->widget), "draw", G_CALLBACK(_event_draw), self);
 
   dt_action_define_iop(self, N_("fit"),

--- a/src/libs/masks.c
+++ b/src/libs/masks.c
@@ -667,7 +667,7 @@ static void _tree_add_shape(GtkButton *button, gpointer shape)
 static void _bt_add_shape_cb(GtkGestureSingle *gesture, int n_press, double x, double y, gpointer shape)
 {
 
-  if(gtk_gesture_single_get_current_button(gesture) == GDK_BUTTON_PRIMARY)
+  if(dt_gui_current_button(gesture) == GDK_BUTTON_PRIMARY)
   {
 #ifdef HAVE_AI
     if(GPOINTER_TO_INT(shape) == DT_MASKS_OBJECT && !dt_masks_object_available())
@@ -2274,35 +2274,45 @@ void gui_init(dt_lib_module_t *self)
   d->bt_gradient = dtgtk_togglebutton_new(dtgtk_cairo_paint_masks_gradient, 0, NULL);
   dt_action_define(DT_ACTION(self), N_("shapes"), N_("add gradient"),
                    d->bt_gradient, &dt_action_def_toggle);
-  dt_gui_connect_click(d->bt_gradient, _bt_add_shape_cb, NULL, GINT_TO_POINTER(DT_MASKS_GRADIENT));
+  g_object_set_data(G_OBJECT(d->bt_gradient), DT_ACTION_GESTURE_KEY,
+                    dt_gui_connect_click(d->bt_gradient, _bt_add_shape_cb, NULL,
+                                         GINT_TO_POINTER(DT_MASKS_GRADIENT)));
   gtk_widget_set_tooltip_text(d->bt_gradient, _("add gradient"));
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->bt_gradient), FALSE);
 
   d->bt_path = dtgtk_togglebutton_new(dtgtk_cairo_paint_masks_path, 0, NULL);
   dt_action_define(DT_ACTION(self), N_("shapes"), N_("add path"),
                    d->bt_path, &dt_action_def_toggle);
-  dt_gui_connect_click(d->bt_path, _bt_add_shape_cb, NULL, GINT_TO_POINTER(DT_MASKS_PATH));
+  g_object_set_data(G_OBJECT(d->bt_path), DT_ACTION_GESTURE_KEY,
+                    dt_gui_connect_click(d->bt_path, _bt_add_shape_cb, NULL,
+                                         GINT_TO_POINTER(DT_MASKS_PATH)));
   gtk_widget_set_tooltip_text(d->bt_path, _("add path"));
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->bt_path), FALSE);
 
   d->bt_ellipse = dtgtk_togglebutton_new(dtgtk_cairo_paint_masks_ellipse, 0, NULL);
   dt_action_define(DT_ACTION(self), N_("shapes"), N_("add ellipse"),
                    d->bt_ellipse, &dt_action_def_toggle);
-  dt_gui_connect_click(d->bt_ellipse, _bt_add_shape_cb, NULL, GINT_TO_POINTER(DT_MASKS_ELLIPSE));
+  g_object_set_data(G_OBJECT(d->bt_ellipse), DT_ACTION_GESTURE_KEY,
+                    dt_gui_connect_click(d->bt_ellipse, _bt_add_shape_cb, NULL,
+                                         GINT_TO_POINTER(DT_MASKS_ELLIPSE)));
   gtk_widget_set_tooltip_text(d->bt_ellipse, _("add ellipse"));
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->bt_ellipse), FALSE);
 
   d->bt_circle = dtgtk_togglebutton_new(dtgtk_cairo_paint_masks_circle, 0, NULL);
   dt_action_define(DT_ACTION(self), N_("shapes"), N_("add circle"),
                    d->bt_circle, &dt_action_def_toggle);
-  dt_gui_connect_click(d->bt_circle, _bt_add_shape_cb, NULL, GINT_TO_POINTER(DT_MASKS_CIRCLE));
+  g_object_set_data(G_OBJECT(d->bt_circle), DT_ACTION_GESTURE_KEY,
+                    dt_gui_connect_click(d->bt_circle, _bt_add_shape_cb, NULL,
+                                         GINT_TO_POINTER(DT_MASKS_CIRCLE)));
   gtk_widget_set_tooltip_text(d->bt_circle, _("add circle"));
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->bt_circle), FALSE);
 
   d->bt_brush = dtgtk_togglebutton_new(dtgtk_cairo_paint_masks_brush, 0, NULL);
   dt_action_define(DT_ACTION(self), N_("shapes"), N_("add brush"),
                    d->bt_brush, &dt_action_def_toggle);
-  dt_gui_connect_click(d->bt_brush, _bt_add_shape_cb, NULL, GINT_TO_POINTER(DT_MASKS_BRUSH));
+  g_object_set_data(G_OBJECT(d->bt_brush), DT_ACTION_GESTURE_KEY,
+                    dt_gui_connect_click(d->bt_brush, _bt_add_shape_cb, NULL,
+                                         GINT_TO_POINTER(DT_MASKS_BRUSH)));
   gtk_widget_set_tooltip_text(d->bt_brush, _("add brush"));
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->bt_brush), FALSE);
 
@@ -2310,7 +2320,9 @@ void gui_init(dt_lib_module_t *self)
   d->bt_object = dtgtk_togglebutton_new(dtgtk_cairo_paint_masks_object, 0, NULL);
   dt_action_define(DT_ACTION(self), N_("shapes"), N_("add object"),
                    d->bt_object, &dt_action_def_toggle);
-  dt_gui_connect_click(d->bt_object, _bt_add_shape_cb, NULL, GINT_TO_POINTER(DT_MASKS_OBJECT));
+  g_object_set_data(G_OBJECT(d->bt_object), DT_ACTION_GESTURE_KEY,
+                    dt_gui_connect_click(d->bt_object, _bt_add_shape_cb, NULL,
+                                         GINT_TO_POINTER(DT_MASKS_OBJECT)));
   gtk_widget_set_tooltip_text(d->bt_object, _("add AI object"));
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->bt_object), FALSE);
 #endif


### PR DESCRIPTION
Since #21659 moved these buttons' actions onto gesture controllers, shortcuts stopped working for them: the icon would light up, but the tool never activated — e.g. a custom "add gradient to mask" binding highlighted the gradient button without actually entering gradient mode.

The reason: the shortcut layer activates widgets by synthesizing fake mouse-press events, and gesture controllers never receive synthetic events. So the shortcut only reached the button's visual toggle, never the code that does the work.

This makes widgets opt in: a widget whose action lives in a gesture registers that gesture (`DT_ACTION_GESTURE_KEY`), and the shortcut layer then fires the gesture's press signal — the exact same path a real click takes. Everything else is untouched.

One change fixes all of them: the mask shape buttons and "edit mask elements", filmicrgb, temperature, liquify, spots, retouch, the Masks module sidebar buttons, and the rotate-and-perspective fit/structure buttons.

Related: #15920 #20433

CC: @masterpiga