### PR TITLE
Fixes #21602: zoom position not kept between images

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -762,7 +762,30 @@ restart:
         dt_dev_zoom_move() possibly leaves port->pipe->changed DT_DEV_PIPE_ZOOMED;
         and might redraw the widgets as a side effect
     */
-    if(port_loading || require_zoom_test)
+    if(port->restore_zoom && port_loading && pipe->processed_width && pipe->processed_height)
+    {
+      /* An image switch just happened. port->zoom_x/zoom_y are in input pixel
+         coordinates of the *previous* image, so reprojecting them through this
+         image's geometry modules would drop the viewport at an arbitrary spot
+         (typically an edge or corner once clamped). Re-apply the normalised
+         centre snapshotted before the switch instead.
+      */
+      const float rx = port->restore_zoom_x;
+      const float ry = port->restore_zoom_y;
+      port->restore_zoom = FALSE;
+      dt_print_pipe(DT_DEBUG_PIPE,
+                    "dt_dev_zoom_move",
+                    pipe,
+                    NULL,
+                    DT_DEVICE_NONE,
+                    NULL,
+                    NULL,
+                    "restore centre %.4f/%.4f",
+                    rx,
+                    ry);
+      dt_dev_zoom_move(port, DT_ZOOM_POSITION, 0.0f, 0, rx, ry, TRUE);
+    }
+    else if(port_loading || require_zoom_test)
     {
       dt_print_pipe(DT_DEBUG_PIPE, "dt_dev_zoom_move", pipe, NULL, DT_DEVICE_NONE, NULL, NULL, "%s%s",
         port_loading ? "port_loading " : "",
@@ -3478,13 +3501,45 @@ void dt_dev_get_viewport_params(dt_dev_viewport_t *port,
 
   if(x && y && port->pipe)
   {
-    float pts[2] = { port->zoom_x, port->zoom_y };
-    dt_dev_distort_transform_plus(port->dev ? port->dev : darktable.develop, port->pipe,
-                                  0.0f, DT_DEV_TRANSFORM_DIR_ALL_GEOMETRY, pts, 1);
-    *x = pts[0] / (float)port->pipe->processed_width - 0.5f;
-    *y = pts[1] / (float)port->pipe->processed_height - 0.5f;
+    // A pipe that hasn't produced dimensions yet (never processed, or in the
+    // middle of an image switch) would turn the normalisation below into a
+    // division by zero and send the viewport off to infinity.
+    if(port->pipe->processed_width && port->pipe->processed_height)
+    {
+      float pts[2] = { port->zoom_x, port->zoom_y };
+      dt_dev_distort_transform_plus(port->dev ? port->dev : darktable.develop,
+                                    port->pipe,
+                                    0.0f,
+                                    DT_DEV_TRANSFORM_DIR_ALL_GEOMETRY,
+                                    pts,
+                                    1);
+      *x = pts[0] / (float)port->pipe->processed_width - 0.5f;
+      *y = pts[1] / (float)port->pipe->processed_height - 0.5f;
+    }
+    else
+      *x = *y = 0.0f;
   }
   dt_pthread_mutex_unlock(&(darktable.control->global_mutex));
+}
+
+void dt_dev_snapshot_zoom_pos(dt_dev_viewport_t *port)
+{
+  if(!port || !port->pipe)
+    return;
+
+  // Nothing worth carrying over when the image is shown at fit: the centre is
+  // forced home anyway, and a stale snapshot would fight the next fit.
+  if(port->zoom == DT_ZOOM_FIT || !port->pipe->processed_width || !port->pipe->processed_height)
+  {
+    port->restore_zoom = FALSE;
+    return;
+  }
+
+  float zx = 0.0f, zy = 0.0f;
+  dt_dev_get_viewport_params(port, NULL, NULL, &zx, &zy);
+  port->restore_zoom_x = CLAMP(zx, -0.5f, 0.5f);
+  port->restore_zoom_y = CLAMP(zy, -0.5f, 0.5f);
+  port->restore_zoom = TRUE;
 }
 
 gboolean dt_dev_is_current_image(const dt_develop_t *dev,

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -125,6 +125,15 @@ typedef struct dt_dev_viewport_t
   float zoom_x, zoom_y;
   float zoom_scale;
 
+  /* Viewport centre carried over to the next image, as a fraction of the
+     image in [-0.5, 0.5]. zoom_x/zoom_y themselves live in *input pixel*
+     coordinates of the currently loaded image (so they survive geometry
+     module changes), which makes them meaningless once another image with a
+     different geometry is loaded. So we snapshot the normalised centre before
+     the switch and re-apply it once the new pipe dimensions are known. */
+  gboolean restore_zoom;
+  float restore_zoom_x, restore_zoom_y;
+
   // image processing pipeline with caching
   struct dt_dev_pixelpipe_t *pipe;
   
@@ -463,6 +472,10 @@ void dt_dev_zoom_move(dt_dev_viewport_t *port,
                       const float x,
                       const float y,
                       const gboolean constrain);
+/* Snapshot the current viewport centre as a fraction of the image so it can be
+   re-applied to the next image, see restore_zoom in dt_dev_viewport_t. Call
+   right before changing image, while the current pipe is still valid. */
+void dt_dev_snapshot_zoom_pos(dt_dev_viewport_t *port);
 float dt_dev_get_zoom_scale(dt_dev_viewport_t *port,
                             const dt_dev_zoom_t zoom,
                             const int closeup_factor,

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -1276,6 +1276,13 @@ static void _dev_change_image(dt_develop_t *dev,
   // Pipe reset needed when changing image
   // FIXME: synch with dev_init() and dev_cleanup() instead of redoing it
 
+  // Remember where we are looking, as a fraction of the image, while the
+  // current pipe can still be asked. The next image gets the same framing
+  // once its own dimensions are known (see restore_zoom handling in
+  // dt_dev_process_image_job).
+  dt_dev_snapshot_zoom_pos(&dev->full);
+  dt_dev_snapshot_zoom_pos(&dev->preview2);
+
   // change active image
   g_slist_free(darktable.view_manager->active_images);
   darktable.view_manager->active_images = g_slist_prepend(NULL, GINT_TO_POINTER(imgid));
@@ -4030,6 +4037,10 @@ void leave(dt_view_t *self)
   dt_iop_color_picker_cleanup();
   if(darktable.lib->proxy.colorpicker.picker_proxy)
     dt_iop_color_picker_reset(darktable.lib->proxy.colorpicker.picker_proxy->module, FALSE);
+
+  // Drop any pending viewport centre carry-over: re-entering the darkroom
+  // starts from whatever zoom state the new session sets up.
+  darktable.develop->full.restore_zoom = darktable.develop->preview2.restore_zoom = FALSE;
 
   // Clear cached surface so the loading screen shows on next darkroom entry
   if(darktable.gui->surface)


### PR DESCRIPTION
### Analysis

`port->zoom_x/zoom_y` are stored in **absolute input-image pixel coordinates**
(written back through the distortion chain in `dt_dev_zoom_move`, read forward
and normalised in `dt_dev_get_viewport_params`). That is deliberate: it anchors
the viewport to a *scene point*, so toggling crop or rotate keeps you looking at
the same place.

Changing image never resets those fields — that is how "keep the zoom" is meant
to work. But the re-validation that runs for the new image
(`dt_dev_zoom_move(DT_ZOOM_MOVE, 0, 0)` in `dt_dev_process_image_job`)
reprojects the *previous* image's input pixels through the *new* image's
geometry modules and pipe dimensions. Different sensor geometry, a different
`rawprepare` crop, a different EXIF orientation in `flip`, or a stale
`processed_width` mid-reprocess all move the centre somewhere unrelated, and the
clamp then parks it against a border. It only round-trips correctly when the two
images happen to share geometry — hence the "sometimes it works".

Not caused by a0d25790ea, despite the grouping in the issue: `_clamp_zoom_to_mask`
is algebraically identical to the clamp it replaced when no mask overlay exists.

Also not caused by #21132, which was a culling fix on a different path.

### Fix

Snapshot the viewport centre as a **fraction of the image** before the switch,
re-apply it once the new pipe's dimensions are known.

- `dt_dev_viewport_t` gains `restore_zoom` + `restore_zoom_x/y`.
- `dt_dev_snapshot_zoom_pos()` captures the normalised centre; no-ops at
  `DT_ZOOM_FIT` or when the pipe has no dimensions yet.
- `_dev_change_image()` snapshots `full` and `preview2` while the old pipe is
  still valid.
- `dt_dev_process_image_job()` consumes the snapshot via `DT_ZOOM_POSITION`
  in place of the usual re-validation, gated on `port_loading` so a pipe job
  running between the snapshot and the actual load can't eat the flag.
- `dt_dev_get_viewport_params()` no longer divides by `processed_width == 0`,
  which previously produced an ±inf centre during a reprocess.

`DT_ZOOM_POSITION` is safe in this slot: it leaves `zoom`/`closeup`/`zoom_scale`
untouched (100% stays 100%), and its mouse-anchor term cancels because
`cur_scale == new_scale`.

In-image behaviour is unchanged — `zoom_x/zoom_y` keep their input-pixel
semantics, so crop/rotate edits still anchor the same scene point.

### Demo

https://github.com/user-attachments/assets/03504b33-ed47-4a9f-b9e5-6200571d732b

Fixes #21602.
Co-authored with Claude.

@ralfbrown @anoderay @jenshannoschwalm 