### PR TITLE
tests: stop using cmocka's deprecated check_expected()

### DIFF
--- a/src/tests/unittests/iop/test_filmicrgb.c
+++ b/src/tests/unittests/iop/test_filmicrgb.c
@@ -54,7 +54,15 @@
 void __wrap_dt_iop_color_picker_reset(dt_iop_module_t *module, gboolean update)
 {
   check_expected_ptr(module);
+  /* cmocka 1.1.8 deprecated the untyped check_expected() in favour of the
+     width-explicit variants, and the tests are built with -Werror, so the old
+     spelling is a hard build failure there. Keep both spellings: the typed
+     macro does not exist in cmocka 1.1.0, which the build still accepts. */
+#ifdef check_expected_int
+  check_expected_int(update);
+#else
   check_expected(update);
+#endif
 }
 
 


### PR DESCRIPTION
While building unit tests for the spektrafilm module I hit a compilation error. cmocka 1.1.8 deprecated the untyped check_expected() in favour of the width-explicit check_expected_int() / check_expected_uint(). The unit tests are built with -Werror, so on any distribution shipping that version test_filmicrgb no longer compiles, and with it every -DBUILD_TESTING=ON build fails.
 
Use the typed macro where it exists and keep the old spelling behind an #ifdef: the minimum cmocka the build accepts is 1.1.0, which has no typed variants, so dropping the old spelling outright would break the other end of the supported range.
