### PR TITLE
Improvements for pixelpipe cache

### DIFF
--- a/src/develop/pixelpipe_cache.c
+++ b/src/develop/pixelpipe_cache.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2009-2025 darktable developers.
+    Copyright (C) 2009-2026 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -26,13 +26,13 @@
 gboolean dt_dev_pixelpipe_cache_init(dt_dev_pixelpipe_t *pipe,
                                      const int entries,
                                      const size_t size,
-                                     const size_t limit)
+                                     const int32_t fraction)
 {
   dt_dev_pixelpipe_cache_t *cache = &pipe->cache;
 
   cache->entries = entries;
   cache->allmem = cache->max_allmem = cache->hits = cache->calls = cache->tests = 0;
-  cache->memlimit = limit;
+  cache->mem_fraction = fraction;
 
   const size_t csize = sizeof(void *) + sizeof(size_t) + sizeof(dt_iop_buffer_dsc_t) + 2*sizeof(int32_t) + sizeof(uint64_t);
   cache->data = (void **) calloc(entries, csize);
@@ -480,7 +480,7 @@ static inline int _invalid(const dt_dev_pixelpipe_cache_t *cache)
   return cnt;
 }
 
-void dt_dev_pixelpipe_cache_checkmem(dt_dev_pixelpipe_t *pipe)
+void dt_dev_pixelpipe_cache_checkmem(dt_dev_pixelpipe_t *pipe, const gboolean trim)
 {
   dt_dev_pixelpipe_cache_t *cache = &pipe->cache;
 
@@ -503,7 +503,12 @@ void dt_dev_pixelpipe_cache_checkmem(dt_dev_pixelpipe_t *pipe)
     }
   }
 
-  while(cache->memlimit && (cache->memlimit < cache->allmem))
+  size_t trim_limit = cache->mem_fraction == 0 ? 0 : dt_get_available_mem() / cache->mem_fraction;
+  const gboolean lowmem = dt_get_available_mem() < DT_MEGA * 6000;
+  if(lowmem && trim) trim_limit = 0;
+  if(trim) trim_limit /= 4;
+
+  while(cache->mem_fraction && (trim_limit < cache->allmem))
   {
     const int k = _get_oldest_cacheline(cache, DT_CACHETEST_USED);
     if(k == 0) break;
@@ -513,19 +518,23 @@ void dt_dev_pixelpipe_cache_checkmem(dt_dev_pixelpipe_t *pipe)
   }
 
   if(free_cnt + free_invalid_cnt)
-    dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_MEMORY, "pipe cache check", pipe, NULL, DT_DEVICE_NONE, NULL, NULL,
-      "Freed lines invalid=%i used=%i. Freed mem invalid %zuMB used %zuMB. Now %zuMB limit=%zuMB max=%zuMB",
+    dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_MEMORY, trim ? "pipe cache trim" : "pipe cache check",
+      pipe, NULL, DT_DEVICE_NONE, NULL, NULL,
+      "%sFreed lines invalid=%i used=%i. Freed mem invalid %zuMB used %zuMB. Now %zuMB limit=%zuMB max=%zuMB",
+      lowmem & trim ? "lowmem" : "",
       free_invalid_cnt, free_cnt, freed_invalid/DT_MEGA, freed / DT_MEGA,
-      cache->allmem / DT_MEGA, cache->memlimit / DT_MEGA, cache->max_allmem / DT_MEGA);
+      cache->allmem / DT_MEGA, trim_limit / DT_MEGA, cache->max_allmem / DT_MEGA);
 }
 
 void dt_dev_pixelpipe_cache_report(dt_dev_pixelpipe_t *pipe)
 {
   dt_dev_pixelpipe_cache_t *cache = &pipe->cache;
+  const size_t limit = cache->mem_fraction == 0 ? 0 : dt_get_available_mem() / cache->mem_fraction;
+
   dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_MEMORY, "cache report", pipe, NULL, DT_DEVICE_NONE, NULL, NULL,
     "Lines=%i important=%i used=%i invalid=%i. Now=%zuMB limit=%zuMB max=%zuMB. Hits/run=%.2f. Hits/test=%.3f",
     cache->entries, _important(cache), _used(cache), _invalid(cache),
-    cache->allmem / DT_MEGA, cache->memlimit / DT_MEGA, cache->max_allmem / DT_MEGA,
+    cache->allmem / DT_MEGA, limit / DT_MEGA, cache->max_allmem / DT_MEGA,
     (double)(cache->hits) / fmax(1.0, pipe->runs),
     (double)(cache->hits) / fmax(1.0, cache->tests));
 }

--- a/src/develop/pixelpipe_cache.h
+++ b/src/develop/pixelpipe_cache.h
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2009-2025 darktable developers.
+    Copyright (C) 2009-2026 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -35,7 +35,7 @@ typedef struct dt_dev_pixelpipe_cache_t
   int32_t entries;
   size_t allmem;
   size_t max_allmem;
-  size_t memlimit;
+  size_t mem_fraction;
   void **data;
   size_t *size;
   struct dt_iop_buffer_dsc_t *dsc;
@@ -60,7 +60,7 @@ typedef enum dt_dev_pixelpipe_cache_test_t
 /** constructs a new cache with given cache line count (entries) and float buffer entry size in bytes.
   \param[out] returns 0 if fail to allocate mem cache.
 */
-gboolean dt_dev_pixelpipe_cache_init(struct dt_dev_pixelpipe_t *pipe, const int entries, const size_t size, const size_t limit);
+gboolean dt_dev_pixelpipe_cache_init(struct dt_dev_pixelpipe_t *pipe, const int entries, const size_t size, const int32_t fraction);
 void dt_dev_pixelpipe_cache_cleanup(struct dt_dev_pixelpipe_t *pipe);
 
 /** creates a hopefully unique hash from the complete module stack up to the module-th, including the roi. */
@@ -95,7 +95,7 @@ void dt_dev_pixelpipe_clear_cacheline(struct dt_dev_pixelpipe_t *pipe, const voi
 
 /** print out cache lines/hashes and do a cache cleanup */
 void dt_dev_pixelpipe_cache_report(struct dt_dev_pixelpipe_t *pipe);
-void dt_dev_pixelpipe_cache_checkmem(struct dt_dev_pixelpipe_t *pipe);
+void dt_dev_pixelpipe_cache_checkmem(struct dt_dev_pixelpipe_t *pipe, const gboolean trim);
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -211,8 +211,7 @@ gboolean dt_dev_pixelpipe_init_export(dt_dev_pixelpipe_t *pipe,
                                       const gboolean store_masks)
 {
   const gboolean res =
-    dt_dev_pixelpipe_init_cached(pipe, sizeof(float) * 4 * width * height,
-                                 DT_PIPECACHE_MIN, 0);
+    dt_dev_pixelpipe_init_cached(pipe, sizeof(float) * 4 * width * height, DT_PIPECACHE_MIN, 0);
   pipe->type = DT_DEV_PIXELPIPE_EXPORT;
   pipe->levels = levels;
   pipe->store_all_raster_masks = store_masks;
@@ -224,8 +223,7 @@ gboolean dt_dev_pixelpipe_init_thumbnail(dt_dev_pixelpipe_t *pipe,
                                          const int32_t height)
 {
   const gboolean res =
-    dt_dev_pixelpipe_init_cached(pipe, sizeof(float) * 4 * width * height,
-                                 DT_PIPECACHE_MIN, 0);
+    dt_dev_pixelpipe_init_cached(pipe, sizeof(float) * 4 * width * height, DT_PIPECACHE_MIN, 0);
   pipe->type = DT_DEV_PIXELPIPE_THUMBNAIL;
   return res;
 }
@@ -244,7 +242,7 @@ gboolean dt_dev_pixelpipe_init_dummy(dt_dev_pixelpipe_t *pipe,
 gboolean dt_dev_pixelpipe_init_preview(dt_dev_pixelpipe_t *pipe)
 {
   const gboolean res =
-    dt_dev_pixelpipe_init_cached(pipe, 0, darktable.pipe_cache ? 12 : DT_PIPECACHE_MIN, 0);
+    dt_dev_pixelpipe_init_cached(pipe, 0, darktable.pipe_cache ? 12 : DT_PIPECACHE_MIN, 32);
   pipe->type = DT_DEV_PIXELPIPE_PREVIEW;
   pipe->average_delay = DT_DEV_PREVIEW_AVERAGE_DELAY_START;
   return res;
@@ -253,7 +251,7 @@ gboolean dt_dev_pixelpipe_init_preview(dt_dev_pixelpipe_t *pipe)
 gboolean dt_dev_pixelpipe_init_preview2(dt_dev_pixelpipe_t *pipe)
 {
   const gboolean res =
-    dt_dev_pixelpipe_init_cached(pipe, 0, darktable.pipe_cache ? 5 : DT_PIPECACHE_MIN, 0);
+    dt_dev_pixelpipe_init_cached(pipe, 0, darktable.pipe_cache ? 5 : DT_PIPECACHE_MIN, 32);
   pipe->type = DT_DEV_PIXELPIPE_PREVIEW2;
   pipe->average_delay = DT_DEV_PREVIEW_AVERAGE_DELAY_START;
   return res;
@@ -261,10 +259,8 @@ gboolean dt_dev_pixelpipe_init_preview2(dt_dev_pixelpipe_t *pipe)
 
 gboolean dt_dev_pixelpipe_init(dt_dev_pixelpipe_t *pipe)
 {
-  const size_t csize = MAX(64*1024*1024, darktable.dtresources.mipmap_memory / 4);
   const gboolean res =
-    dt_dev_pixelpipe_init_cached(pipe, 0, darktable.pipe_cache ? 64 : DT_PIPECACHE_MIN,
-                                 csize);
+    dt_dev_pixelpipe_init_cached(pipe, 0, darktable.pipe_cache ? 64 : DT_PIPECACHE_MIN, 8);
   pipe->type = DT_DEV_PIXELPIPE_FULL;
   return res;
 }
@@ -272,7 +268,7 @@ gboolean dt_dev_pixelpipe_init(dt_dev_pixelpipe_t *pipe)
 gboolean dt_dev_pixelpipe_init_cached(dt_dev_pixelpipe_t *pipe,
                                       const size_t size,
                                       const int32_t entries,
-                                      const size_t memlimit)
+                                      const int32_t fraction)
 {
   pipe->devid = DT_DEVICE_CPU;
   pipe->loading = FALSE;
@@ -318,7 +314,7 @@ gboolean dt_dev_pixelpipe_init_cached(dt_dev_pixelpipe_t *pipe,
   pipe->bcache_hash = DT_INVALID_HASH;
   memset(pipe->mask_distort_buf, 0, sizeof(pipe->mask_distort_buf));
   memset(pipe->mask_distort_buf_size, 0, sizeof(pipe->mask_distort_buf_size));
-  return dt_dev_pixelpipe_cache_init(pipe, entries, size, memlimit);
+  return dt_dev_pixelpipe_cache_init(pipe, entries, size, fraction);
 }
 
 static inline size_t _dev_used_cachemem(void)
@@ -3261,7 +3257,7 @@ gboolean dt_dev_pixelpipe_process(dt_dev_pixelpipe_t *pipe,
     : DT_DEVICE_CPU;
 
   if(!claimed)  // don't free cachelines as the caller is using them
-    dt_dev_pixelpipe_cache_checkmem(pipe);
+    dt_dev_pixelpipe_cache_checkmem(pipe, FALSE);
 
   if(pipe->devid > DT_DEVICE_CPU) dt_opencl_events_reset(pipe->devid);
 

--- a/src/develop/pixelpipe_hb.h
+++ b/src/develop/pixelpipe_hb.h
@@ -370,7 +370,7 @@ gboolean dt_dev_pixelpipe_init_dummy(dt_dev_pixelpipe_t *pipe,
 gboolean dt_dev_pixelpipe_init_cached(dt_dev_pixelpipe_t *pipe,
                                       const size_t size,
                                       const int32_t entries,
-                                      const size_t memlimit);
+                                      const int32_t fraction);
 // returns available memory for the pipe
 size_t dt_get_available_pipe_mem(const dt_dev_pixelpipe_t *pipe);
 // constructs a new input buffer from given RGB float array.

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -4032,8 +4032,7 @@ void enter(dt_view_t *self)
 
 static inline void _clear_pipecache(dt_dev_pixelpipe_t *pipe)
 {
-  // As log as we don't have a better trim ...
-  dt_dev_pixelpipe_cache_checkmem(pipe);
+  dt_dev_pixelpipe_cache_checkmem(pipe, TRUE);
 
   if(pipe->bcache_data)
   {


### PR DESCRIPTION
1. As we take allocated cachemem into account while checking available memory for tiling we can safely use available memory to initialize cache memlimit.
2. Modified dt_dev_pixelpipe_cache_checkmem to support trimming when leaving darkroom

See #21705 @masterpiga this would be my simple but effective proposal.