### PR TITLE
21758: check for active picker in exposure, channelmixerrgb

### DIFF
--- a/src/gui/color_picker_proxy.c
+++ b/src/gui/color_picker_proxy.c
@@ -571,6 +571,12 @@ GtkWidget *dt_color_picker_new_with_cst(dt_iop_module_t *module,
   return _color_picker_new(module, flags, w, TRUE, cst);
 }
 
+gboolean dt_iop_color_picker_is_active(GtkWidget *w)
+{
+  const dt_iop_color_picker_t *p = darktable.lib->proxy.colorpicker.picker_proxy;
+  return p && p->colorpick == w;
+}
+
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/gui/color_picker_proxy.h
+++ b/src/gui/color_picker_proxy.h
@@ -104,6 +104,8 @@ GtkWidget *dt_color_picker_new_with_cst(dt_iop_module_t *module,
                                         GtkWidget *w,
                                         const dt_iop_colorspace_type_t cst);
 
+gboolean dt_iop_color_picker_is_active(GtkWidget *w);
+
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -3971,7 +3971,7 @@ static void _spot_settings_changed_callback(GtkWidget *slider,
 
   // Re-run auto illuminant if color picker is active and mode is correct
   const dt_spot_mode_t mode = dt_bauhaus_combobox_get(g->spot_mode);
-  if(mode == DT_SPOT_MODE_CORRECT)
+  if(mode == DT_SPOT_MODE_CORRECT && dt_iop_color_picker_is_active(g->color_picker))
     _auto_set_illuminant(self, darktable.develop->full.pipe);
   // else : just record new values and do nothing
 }

--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -1176,7 +1176,7 @@ static void _spot_settings_changed_callback(GtkWidget *slider,
   const dt_spot_mode_t mode = dt_bauhaus_combobox_get(g->spot_mode);
   DT_LEAVE_GUI_UPDATE();
 
-  if(mode == DT_SPOT_MODE_CORRECT)
+  if(mode == DT_SPOT_MODE_CORRECT && dt_iop_color_picker_is_active(g->exposure))
     _auto_set_exposure(self, darktable.develop->full.pipe);
   // else : just record new values and do nothing
 }


### PR DESCRIPTION
Make sure adjustments (intended to match a target exposure / colour) are only made when the picker is active. Also adds a shared helper function, `color_picker_proxy::dt_iop_color_picker_is_active`.

Fixes #21758 