### PR TITLE
tests: fix linking of ai unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
 
   Linux:
     if: github.repository == 'darktable-org/darktable' || github.event_name == 'workflow_dispatch'
-    name: Linux_${{ matrix.distro }}_${{ matrix.compiler.compiler }}_${{ matrix.btype }}
+    name: Linux_${{ matrix.distro }}_${{ matrix.compiler.compiler }}_${{ matrix.btype }}${{ matrix.name_suffix }}
     runs-on: ubuntu-latest
     container:
       image: ${{ matrix.distro }}
@@ -77,6 +77,16 @@ jobs:
             target: skiptest
             generator: Ninja
             eco: -DDONT_USE_INTERNAL_LIBRAW=OFF
+          # The other entries use the skiptest target, which never configures
+          # BUILD_TESTING and so never even compiles the unit tests. This one
+          # builds them and runs ctest.
+          - distro: "ubuntu:26.04"
+            btype: Release
+            compiler: { compiler: GNU16, CC: gcc-16, CXX: g++-16, packages: gcc-16 g++-16 }
+            target: build
+            generator: Ninja
+            eco: -DDONT_USE_INTERNAL_LIBRAW=ON
+            name_suffix: _tests
     env:
       DISTRO: ${{ matrix.distro }}
       CC: ${{ matrix.compiler.CC }}
@@ -125,6 +135,7 @@ jobs:
             libatk1.0-dev \
             libavif-dev \
             libcairo2-dev \
+            libcmocka-dev \
             libcolord-dev \
             libcolord-gtk-dev \
             libcups2-dev \

--- a/src/tests/unittests/ai/CMakeLists.txt
+++ b/src/tests/unittests/ai/CMakeLists.txt
@@ -4,3 +4,16 @@ add_cmocka_test(test_ai_backend
 
 target_compile_definitions(test_ai_backend PRIVATE
   TEST_MODEL_DIR="${CMAKE_CURRENT_SOURCE_DIR}/models")
+
+# the backend always scans $XDG_DATA_HOME/darktable/models on top of the
+# search paths it is given, so point it at an empty directory -- otherwise
+# models the developer has installed leak into the discovery assertions
+set(_AI_TEST_ENV "XDG_DATA_HOME=${CMAKE_CURRENT_BINARY_DIR}/xdg-data")
+
+# ORT is lazy-loaded by bare filename here, so the build-tree copy has to be
+# on the loader search path (installed builds find it via plugindir instead)
+if(UNIX AND NOT APPLE AND NOT ONNXRuntime_SYSTEM_PACKAGE)
+  list(APPEND _AI_TEST_ENV "LD_LIBRARY_PATH=${ONNXRuntime_LIB_DIR}")
+endif()
+
+set_tests_properties(test_ai_backend PROPERTIES ENVIRONMENT "${_AI_TEST_ENV}")

--- a/src/tests/unittests/ai/dt_stubs.c
+++ b/src/tests/unittests/ai/dt_stubs.c
@@ -10,6 +10,8 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "ai/backend.h"
+
 /* darktable global — the AI backend accesses darktable.unmuted
    via the dt_debug_if macro.  Set all bits so debug output is enabled. */
 char darktable[8192] __attribute__((aligned(16)));
@@ -34,12 +36,50 @@ void dt_print_ext(const char *msg, ...)
   fputc('\n', stderr);
 }
 
+void dt_control_log(const char *msg, ...)
+{
+  va_list ap;
+  va_start(ap, msg);
+  vfprintf(stderr, msg, ap);
+  va_end(ap);
+  fputc('\n', stderr);
+}
+
 gchar *dt_conf_get_string(const char *name)
 {
-  return g_strdup("cpu");
+  /* only the provider key gets a value — every other key (models_path,
+     ort_library_path) must come back empty so the backend keeps its
+     compiled-in defaults instead of treating "cpu" as a path */
+  if(!g_strcmp0(name, DT_AI_CONF_PROVIDER)) return g_strdup("cpu");
+  return g_strdup("");
+}
+
+gboolean dt_conf_get_bool(const char *name)
+{
+  /* env init and model loading are gated on plugins/ai/enabled */
+  return !g_strcmp0(name, "plugins/ai/enabled");
+}
+
+int dt_conf_get_int(const char *name)
+{
+  return 0;
+}
+
+gboolean dt_conf_key_exists(const char *key)
+{
+  /* no darktablerc under test: callers fall back to their defaults */
+  return FALSE;
 }
 
 void dt_loc_get_user_config_dir(char *configdir, size_t bufsize)
 {
   if(configdir && bufsize > 0) configdir[0] = '\0';
+}
+
+void dt_loc_get_user_cache_dir(char *cachedir, size_t bufsize)
+{
+  /* keep EP cache writes out of the user's real cache directory */
+  gchar *dir = g_build_filename(g_get_tmp_dir(), "darktable-test-ai-cache", NULL);
+  g_strlcpy(cachedir, dir, bufsize);
+  g_free(dir);
 }


### PR DESCRIPTION
The ai unit tests have grown since a while, however five stubs in the AI backend had been missing for a successful unit test build (dt_conf_get_bool/get_int/key_exists, dt_control_log, dt_loc_get_user_cache_dir). This requires building darktable via `-DBUILD_TESTING=ON -DUSE_AI=ON`.
Also made dt_conf_get_string key-aware so ort_library_path isn't mistaken for a real path, and pinned the test's XDG_DATA_HOME and LD_LIBRARY_PATH so it doesn't depend on the developer's machine.

To prevent such a breakage I went ahead and added one Linux matrix entry in our gitlab ci pipenline with target "build", the branch of ci-script.sh that sets `BUILD_TESTING=ON` and calls ctest, which no matrix entry had ever selected.

See successful run in CI:

<img width="2702" height="1227" alt="image" src="https://github.com/user-attachments/assets/cbd1f6bb-1093-449d-aae7-d1d625b81b5c" />


CC: @andriiryzhkov 

Disclaimer: this work has been co-created with Claude.