### PR TITLE
gtk4-prep: normalize scroll pan/zoom handling across views with shared helpers

### DIFF
--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -3980,8 +3980,11 @@ static void _widget_button_press(GtkGestureSingle *gesture,
   else if(button == GDK_BUTTON_SECONDARY || w->type == DT_BAUHAUS_COMBOBOX)
   {
     GdkEvent *const event = gtk_get_current_event();
-    bh->opentime = gdk_event_get_time(event);
-    gdk_event_free(event);
+    if(event)
+    {
+      bh->opentime = gdk_event_get_time(event);
+      gdk_event_free(event);
+    }
     bh->mouse_x = x;
     bh->mouse_y = y;
     _popup_show(widget);
@@ -4072,10 +4075,14 @@ static void _widget_motion(GtkEventControllerMotion *controller,
       const float scaled_step =
         width * dt_bauhaus_slider_get_step(widget) / (d->max - d->min);
       const float steps = floorf((x - bh->mouse_x) / scaled_step);
-      GdkEvent *const event = gtk_get_current_event(); // TODO cleanup
+      // the current event may be NULL for synthetic motions; fall back to
+      // the global keyboard state in that case
+      GdkEvent *const event = gtk_get_current_event();
+      const GdkModifierType motion_state = event ? dt_gdk_event_get_state(event)
+                                                 : dt_key_modifier_state();
+      if(event) gdk_event_free(event);
       _slider_add_step(widget, copysignf(1, d->factor) * steps,
-                       dt_gdk_event_get_state(event), FALSE);
-      gdk_event_free(event);
+                       motion_state, FALSE);
 
       bh->mouse_x += steps * scaled_step;
     }

--- a/src/dtgtk/culling.c
+++ b/src/dtgtk/culling.c
@@ -651,6 +651,33 @@ static gboolean _event_gesture(GtkWidget *widget,
   return TRUE;
 }
 
+// zoom direction for a scroll: up and left (the backward scrolls) zoom in,
+// down and right zoom out — the same convention as the darkroom and the
+// lighttable zoomable mode.  discrete wheels carry a normalized direction,
+// so left/right is resolved from that rather than the raw horizontal delta:
+// some macos bluetooth mice deliver shift+wheel with inverted delta signs,
+// but GDK still reports the correct LEFT/RIGHT direction.  smooth (fractional)
+// scrolls have no direction, so their deltas are used, with up/left (negative)
+// zooming in.
+static float _scroll_zoom_delta(const GdkEventScroll *event,
+                                const gdouble dx, const gdouble dy)
+{
+  switch(dt_gdk_event_get_scroll_direction(event))
+  {
+    case GDK_SCROLL_UP:
+    case GDK_SCROLL_LEFT:
+      return 0.5f;
+    case GDK_SCROLL_DOWN:
+    case GDK_SCROLL_RIGHT:
+      return -0.5f;
+    default: // GDK_SCROLL_SMOOTH
+    {
+      const gdouble dominant = fabs(dx) > fabs(dy) ? dx : dy;
+      return (float)(-dominant * 0.5);
+    }
+  }
+}
+
 static void _event_scroll(GtkEventControllerScroll *controller,
                            gdouble dx,
                            gdouble dy,
@@ -707,8 +734,7 @@ static void _event_scroll(GtkEventControllerScroll *controller,
     if(dt_gui_get_scroll_deltas((const GdkEventScroll *)event, &ddx, &ddy)
        && (ddx != 0.0 || ddy != 0.0))
     {
-      const gdouble delta = fabs(ddx) > fabs(ddy) ? -ddx : ddy;
-      const float zoom_delta = (float)(-delta * 0.5);
+      const float zoom_delta = _scroll_zoom_delta((const GdkEventScroll *)event, ddx, ddy);
       // convert screen to culling coordinates
       int ox = 0, oy = 0;
       GdkWindow *win = gtk_widget_get_window(table->widget);
@@ -774,9 +800,8 @@ static void _event_scroll(GtkEventControllerScroll *controller,
     const gboolean is_horizontal = abs(delta_x) > abs(delta_y);
     if(dt_modifiers_include(state, GDK_CONTROL_MASK))
     {
-      // zooming: right==up==zoom-in
-      const int delta = is_horizontal ? -delta_x : delta_y;
-      const float zoom_delta = delta < 0 ? 0.5f : -0.5f;
+      // zooming: up==left==zoom-in, down==right==zoom-out
+      const float zoom_delta = _scroll_zoom_delta(scroll_event, delta_x, delta_y);
       // convert screen to culling coordinates
       int ox = 0, oy = 0;
       GdkWindow *win = gtk_widget_get_window(table->widget);

--- a/src/dtgtk/culling.c
+++ b/src/dtgtk/culling.c
@@ -1341,6 +1341,27 @@ dt_culling_t *dt_culling_new(const dt_culling_mode_t mode)
   return table;
 }
 
+void dt_culling_destroy(dt_culling_t *table)
+{
+  if(!table) return;
+  // cancel a pending deferred-zoom finalisation so the timer cannot fire
+  // on a freed table
+  if(table->zoom_finalize_timeout_id)
+  {
+    g_source_remove(table->zoom_finalize_timeout_id);
+    table->zoom_finalize_timeout_id = 0;
+  }
+  // drop the control-signal connections that use this table as user_data
+  DT_CONTROL_SIGNAL_DISCONNECT_ALL(table, "culling");
+  // destroy the widget (tears down the event-controller callbacks that use
+  // the table as user_data) and drop the extra reference taken in dt_culling_new
+  if(table->widget)
+  {
+    gtk_widget_destroy(table->widget);
+    g_object_unref(table->widget);
+  }
+}
+
 // initialize offset, ... values
 // to be used when reentering culling
 void dt_culling_init(dt_culling_t *table,

--- a/src/dtgtk/culling.c
+++ b/src/dtgtk/culling.c
@@ -651,33 +651,9 @@ static gboolean _event_gesture(GtkWidget *widget,
   return TRUE;
 }
 
-// zoom direction for a scroll: up and left (the backward scrolls) zoom in,
-// down and right zoom out — the same convention as the darkroom and the
-// lighttable zoomable mode.  discrete wheels carry a normalized direction,
-// so left/right is resolved from that rather than the raw horizontal delta:
-// some macos bluetooth mice deliver shift+wheel with inverted delta signs,
-// but GDK still reports the correct LEFT/RIGHT direction.  smooth (fractional)
-// scrolls have no direction, so their deltas are used, with up/left (negative)
-// zooming in.
-static float _scroll_zoom_delta(const GdkEventScroll *event,
-                                const gdouble dx, const gdouble dy)
-{
-  switch(dt_gdk_event_get_scroll_direction(event))
-  {
-    case GDK_SCROLL_UP:
-    case GDK_SCROLL_LEFT:
-      return 0.5f;
-    case GDK_SCROLL_DOWN:
-    case GDK_SCROLL_RIGHT:
-      return -0.5f;
-    default: // GDK_SCROLL_SMOOTH
-    {
-      const gdouble dominant = fabs(dx) > fabs(dy) ? dx : dy;
-      return (float)(-dominant * 0.5);
-    }
-  }
-}
-
+// zoom direction for a scroll: see dt_gui_scroll_zoom_delta() in gtk.c for
+// the convention (up/left-with-shift zooms in, down zooms out; without shift
+// right is the increase direction for tilt/two-finger-swipes).
 static void _event_scroll(GtkEventControllerScroll *controller,
                            gdouble dx,
                            gdouble dy,
@@ -734,7 +710,7 @@ static void _event_scroll(GtkEventControllerScroll *controller,
     if(dt_gui_get_scroll_deltas((const GdkEventScroll *)event, &ddx, &ddy)
        && (ddx != 0.0 || ddy != 0.0))
     {
-      const float zoom_delta = _scroll_zoom_delta((const GdkEventScroll *)event, ddx, ddy);
+      const float zoom_delta = dt_gui_scroll_zoom_delta((const GdkEventScroll *)event, ddx, ddy);
       // convert screen to culling coordinates
       int ox = 0, oy = 0;
       GdkWindow *win = gtk_widget_get_window(table->widget);
@@ -800,8 +776,8 @@ static void _event_scroll(GtkEventControllerScroll *controller,
     const gboolean is_horizontal = abs(delta_x) > abs(delta_y);
     if(dt_modifiers_include(state, GDK_CONTROL_MASK))
     {
-      // zooming: up==left==zoom-in, down==right==zoom-out
-      const float zoom_delta = _scroll_zoom_delta(scroll_event, delta_x, delta_y);
+      // zooming: see dt_gui_scroll_zoom_delta() for the direction convention
+      const float zoom_delta = dt_gui_scroll_zoom_delta(scroll_event, delta_x, delta_y);
       // convert screen to culling coordinates
       int ox = 0, oy = 0;
       GdkWindow *win = gtk_widget_get_window(table->widget);

--- a/src/dtgtk/culling.c
+++ b/src/dtgtk/culling.c
@@ -673,7 +673,7 @@ static void _event_scroll(GtkEventControllerScroll *controller,
            direction,
            direction == GDK_SCROLL_SMOOTH ? "yes" : "no",
            is_stop ? "yes" : "no",
-           dt_modifier_is(state, GDK_CONTROL_MASK) ? "yes" : "no",
+           dt_modifiers_include(state, GDK_CONTROL_MASK) ? "yes" : "no",
            device ? gdk_device_get_name(device) : "<none>",
            device ? (int)gdk_device_get_source(device) : -1,
            x_root, y_root,
@@ -726,11 +726,12 @@ static void _event_scroll(GtkEventControllerScroll *controller,
     return;
   }
 
-  // Smooth scroll (touchpad two-finger swipe): pan zoomed images or navigate images.
-  // We check before the unit-delta path so fractional smooth scroll is used for panning
-  // with full fidelity rather than being accumulated into integer steps.
-  if(direction == GDK_SCROLL_SMOOTH && !is_stop
-     && !dt_modifiers_include(state, GDK_CONTROL_MASK))
+  // Smooth scroll without ctrl: a touchpad two-finger swipe pans zoomed images,
+  // checked before the unit-delta path so fractional deltas keep full fidelity.
+  // dt_gui_scroll_should_pan() restricts this to touchpad-sourced events, so
+  // mouse wheels always navigate between images, even at 100% zoom (GTK4 can
+  // deliver wheel scrolls as smooth events too).
+  if(dt_gui_scroll_should_pan((const GdkEventScroll *)event))
   {
     // Check if any thumbnail is zoomed in; if so, pan instead of navigate.
     float fz = 1.0f;
@@ -752,8 +753,9 @@ static void _event_scroll(GtkEventControllerScroll *controller,
         // used by the center-widget pan path).
         dt_print(DT_DEBUG_INPUT,
                  "[culling scroll] panning dx=%.3f dy=%.3f (scaled: dx=%.1f dy=%.1f)",
-                 ddx, ddy, ddx * 50.0, ddy * 50.0);
-        dt_culling_pan_move(table, (float)(-ddx * 50.0), (float)(-ddy * 50.0), state);
+                 ddx, ddy, ddx * DT_UI_SCROLL_SMOOTH_DELTA_SCALE, ddy * DT_UI_SCROLL_SMOOTH_DELTA_SCALE);
+        dt_culling_pan_move(table, (float)(-ddx * DT_UI_SCROLL_SMOOTH_DELTA_SCALE),
+                            (float)(-ddy * DT_UI_SCROLL_SMOOTH_DELTA_SCALE), state);
       }
       else
       {

--- a/src/dtgtk/culling.h
+++ b/src/dtgtk/culling.h
@@ -88,6 +88,9 @@ typedef struct dt_culling_t
 } dt_culling_t;
 
 dt_culling_t *dt_culling_new(const dt_culling_mode_t mode);
+// release the resources owned by a culling table (pending timers, widget,
+// signal connections); the caller frees the table itself afterwards.
+void dt_culling_destroy(dt_culling_t *table);
 // reload all thumbs from scratch.
 void dt_culling_full_redraw(dt_culling_t *table,
                             const gboolean force);

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -1184,9 +1184,14 @@ static void _event_scroll(GtkEventControllerScroll *controller,
     if(table->mode == DT_THUMBTABLE_MODE_ZOOM
        || dt_modifier_is(state, GDK_CONTROL_MASK))
     {
-      // up==left==zoom in, down==right==zoom out (left/right resolved from the
-      // GDK direction, so shift+wheel works even with inverted horizontal deltas)
-      const int delta = abs(delta_x) > abs(delta_y) ? delta_x : delta_y;
+      // zoom sign follows dt_gui_scroll_zoom_delta(): up, left-with-shift
+      // (a rotated wheel step) and right-without-shift (tilt/swipe) zoom in;
+      // keep the accumulated magnitude for the step size
+      const int dominant = abs(delta_x) > abs(delta_y) ? delta_x : delta_y;
+      const int delta =
+        dt_gui_scroll_zoom_delta((const GdkEventScroll *)e, delta_x, delta_y) > 0.0f
+          ? -abs(dominant)
+          : abs(dominant);
       if(table->mode == DT_THUMBTABLE_MODE_FILMSTRIP)
       {
         const int sx = CLAMP(table->view_width / ((table->view_width / table->thumb_size / 2 + delta) * 2 + 1),

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -1184,8 +1184,9 @@ static void _event_scroll(GtkEventControllerScroll *controller,
     if(table->mode == DT_THUMBTABLE_MODE_ZOOM
        || dt_modifier_is(state, GDK_CONTROL_MASK))
     {
-      // up==right==zoom in
-      const int delta = abs(delta_x) > abs(delta_y) ? -delta_x : delta_y;
+      // up==left==zoom in, down==right==zoom out (left/right resolved from the
+      // GDK direction, so shift+wheel works even with inverted horizontal deltas)
+      const int delta = abs(delta_x) > abs(delta_y) ? delta_x : delta_y;
       if(table->mode == DT_THUMBTABLE_MODE_FILMSTRIP)
       {
         const int sx = CLAMP(table->view_width / ((table->view_width / table->thumb_size / 2 + delta) * 2 + 1),

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -827,14 +827,37 @@ static gboolean _input_event(GtkWidget *widget,
   return FALSE;
 }
 
+gboolean dt_gui_scroll_should_pan(const GdkEventScroll *event)
+{
+  if(!darktable.gui->touchpad_gestures_enabled) return FALSE;
+  if(dt_modifiers_include(dt_gdk_event_get_state(event), GDK_CONTROL_MASK)) return FALSE;
+  if(dt_gdk_event_get_scroll_direction(event) != GDK_SCROLL_SMOOTH) return FALSE;
+  if(gdk_event_is_scroll_stop_event((GdkEvent *)event)) return FALSE;
+#ifdef GDK_WINDOWING_QUARTZ
+  // On macOS/Quartz, the built-in trackpad reports as GDK_SOURCE_MOUSE, not
+  // GDK_SOURCE_TOUCHPAD.  Route every non-ctrl smooth scroll to pan so that
+  // two-finger panning works in views like darkroom (both standalone and
+  // interleaved with a pinch-zoom gesture whose translational component macOS
+  // delivers as a separate scroll stream).
+  return TRUE;
+#else
+  GdkDevice *const device = dt_gdk_event_get_source_device(event);
+  // Also accept the device that last produced a touchpad pinch/swipe gesture:
+  // some touchpads report the follow-up scroll stream from a different device.
+  return device && (gdk_device_get_source(device) == GDK_SOURCE_TOUCHPAD
+                    || device == _touchpad);
+#endif
+}
+
 static gboolean _scrolled(GtkWidget *widget,
                           const GdkEventScroll *event,
                           gpointer user_data)
 {
   (void)user_data;
   GdkDevice *device = gdk_event_get_source_device((GdkEvent *)event);
-  const gboolean touchpad_enabled = darktable.gui->touchpad_gestures_enabled;
   const gboolean ctrl_pressed = dt_modifier_is(dt_gdk_event_get_state(event), GDK_CONTROL_MASK);
+  const gboolean is_smooth = dt_gdk_event_get_scroll_direction(event) == GDK_SCROLL_SMOOTH
+                             && !gdk_event_is_scroll_stop_event((GdkEvent *)event);
 
   dt_print(DT_DEBUG_INPUT,
            "[scroll] direction=%d smooth=%s stop=%s ctrl=%s"
@@ -842,29 +865,12 @@ static gboolean _scrolled(GtkWidget *widget,
            " device='%s' source-type=%d",
            dt_gdk_event_get_scroll_direction(event),
            dt_gdk_event_get_scroll_direction(event) == GDK_SCROLL_SMOOTH ? "yes" : "no",
-           event->is_stop ? "yes" : "no",
+           gdk_event_is_scroll_stop_event((GdkEvent *)event) ? "yes" : "no",
            ctrl_pressed ? "yes" : "no",
            dt_gdk_event_get_x(event), dt_gdk_event_get_y(event), dt_gdk_event_get_scroll_delta_x(event), dt_gdk_event_get_scroll_delta_y(event), dt_gdk_event_get_state(event),
            device ? gdk_device_get_name(device) : "<none>",
            device ? (int)gdk_device_get_source(device) : -1);
-  const gboolean is_touchpad_source = device && gdk_device_get_source(device) == GDK_SOURCE_TOUCHPAD;
-  const gboolean matches_last_gesture_device = (device == _touchpad);
-
-  const gboolean is_smooth = dt_gdk_event_get_scroll_direction(event) == GDK_SCROLL_SMOOTH && !event->is_stop;
-#ifdef GDK_WINDOWING_QUARTZ
-  // On macOS/Quartz, the built-in trackpad reports as GDK_SOURCE_MOUSE, not
-  // GDK_SOURCE_TOUCHPAD.  Route every non-ctrl smooth scroll to gesture_pan so
-  // that two-finger panning works in views like darkroom (both standalone and
-  // interleaved with a pinch-zoom gesture whose translational component macOS
-  // delivers as a separate scroll stream).
-  const gboolean route_as_pan = touchpad_enabled && !ctrl_pressed && is_smooth;
-#else
-  const gboolean route_as_pan = touchpad_enabled
-                                && !ctrl_pressed
-                                && (is_touchpad_source || matches_last_gesture_device)
-                                && is_smooth;
-#endif
-  if(route_as_pan)
+  if(dt_gui_scroll_should_pan(event))
   {
     gdouble delta_x = 0.0, delta_y = 0.0;
     if(!dt_gui_get_scroll_deltas(event, &delta_x, &delta_y))
@@ -900,14 +906,11 @@ static gboolean _scrolled(GtkWidget *widget,
   else if(is_smooth)
   {
     dt_print(DT_DEBUG_INPUT,
-             "[touchpad] smooth scroll not treated as pan: enabled=%d ctrl=%d touchpad_source=%d matches_last_gesture=%d route_as_pan=%d source='%s' source_type=%d",
-             touchpad_enabled,
+             "[touchpad] smooth scroll not treated as pan: gestures_enabled=%d ctrl=%d source='%s' source_type=%d",
+             darktable.gui->touchpad_gestures_enabled,
              ctrl_pressed,
-             is_touchpad_source,
-             matches_last_gesture_device,
-             route_as_pan,
              device ? gdk_device_get_name(device) : "<none>",
-             device ? gdk_device_get_source(device) : -1);
+             device ? (int)gdk_device_get_source(device) : -1);
   }
 
   int delta_y;

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -849,6 +849,42 @@ gboolean dt_gui_scroll_should_pan(const GdkEventScroll *event)
 #endif
 }
 
+float dt_gui_scroll_zoom_delta(const GdkEventScroll *event,
+                               const gdouble dx, const gdouble dy)
+{
+  // zoom direction convention: up (the backward scroll) zooms in, down zooms
+  // out.  The horizontal axis depends on how the scroll was produced: with the
+  // shift modifier still set, the OS has rotated a vertical wheel step into a
+  // left/right scroll (on macOS, Windows and X11 alike), so LEFT keeps meaning
+  // "wheel up" and zooms in, preserving the wheel's muscle memory.  Without
+  // shift (wheel tilt, two-finger swipe) RIGHT is the positive direction and
+  // zooms in, LEFT zooms out.
+  //
+  // Discrete wheels carry a normalized direction, so left/right is resolved
+  // from that rather than from the raw delta sign, whose polarity is not
+  // canonical across platforms.  Smooth (fractional) scrolls have no
+  // direction; their dominant delta is used with the same convention.
+  const gboolean shift = dt_modifiers_include(dt_gdk_event_get_state(event),
+                                              GDK_SHIFT_MASK);
+  switch(dt_gdk_event_get_scroll_direction(event))
+  {
+    case GDK_SCROLL_UP:
+      return 0.5f;
+    case GDK_SCROLL_DOWN:
+      return -0.5f;
+    case GDK_SCROLL_LEFT:
+      return shift ? 0.5f : -0.5f;
+    case GDK_SCROLL_RIGHT:
+      return shift ? -0.5f : 0.5f;
+    default: // GDK_SCROLL_SMOOTH
+    {
+      if(fabs(dx) > fabs(dy))
+        return shift ? (dx < 0 ? 0.5f : -0.5f) : (dx > 0 ? 0.5f : -0.5f);
+      return dy < 0 ? 0.5f : -0.5f;
+    }
+  }
+}
+
 static gboolean _scrolled(GtkWidget *widget,
                           const GdkEventScroll *event,
                           gpointer user_data)
@@ -913,16 +949,17 @@ static gboolean _scrolled(GtkWidget *widget,
              device ? (int)gdk_device_get_source(device) : -1);
   }
 
-  int delta_y;
-  if(dt_gui_get_scroll_unit_delta(event, &delta_y))
+  int delta_x, delta_y;
+  if(dt_gui_get_scroll_unit_deltas(event, &delta_x, &delta_y))
   {
+    const gboolean up = dt_gui_scroll_zoom_delta(event, delta_x, delta_y) > 0.0f;
     dt_print(DT_DEBUG_INPUT,
              "[scroll] discrete fallback x=%.2f y=%.2f up=%d state=0x%x source='%s' source_type=%d",
-             dt_gdk_event_get_x(event), dt_gdk_event_get_y(event), delta_y < 0, dt_gdk_event_get_state(event),
+             dt_gdk_event_get_x(event), dt_gdk_event_get_y(event), up, dt_gdk_event_get_state(event),
              device ? gdk_device_get_name(device) : "<none>",
              device ? gdk_device_get_source(device) : -1);
     dt_view_manager_scrolled(darktable.view_manager, dt_gdk_event_get_x(event), dt_gdk_event_get_y(event),
-                             delta_y < 0,
+                             up,
                              dt_gdk_event_get_state(event) & 0xf);
     gtk_widget_queue_draw(widget);
   }

--- a/src/gui/gtk.h
+++ b/src/gui/gtk.h
@@ -254,6 +254,15 @@ gboolean dt_gui_get_scroll_delta(const GdkEventScroll *event, gdouble *delta);
  * scroll events. */
 gboolean dt_gui_get_scroll_unit_delta(const GdkEventScroll *event, int *delta);
 
+/* Return TRUE if a scroll event should be treated as a touchpad pan gesture
+ * (two-finger swipe) rather than a plain scroll: requires the touchpad-gestures
+ * preference, a smooth non-stop scroll without ctrl, and a touchpad source
+ * device (on macOS any smooth non-ctrl scroll qualifies, as the built-in
+ * trackpad reports as a mouse; a device that just produced a pinch/swipe
+ * gesture also qualifies).  Mouse wheels therefore never pan, even where GTK
+ * delivers wheel scrolls as smooth events. */
+gboolean dt_gui_scroll_should_pan(const GdkEventScroll *event);
+
 /*
  * new ui api
  */

--- a/src/gui/gtk.h
+++ b/src/gui/gtk.h
@@ -263,6 +263,15 @@ gboolean dt_gui_get_scroll_unit_delta(const GdkEventScroll *event, int *delta);
  * delivers wheel scrolls as smooth events. */
 gboolean dt_gui_scroll_should_pan(const GdkEventScroll *event);
 
+/* Return the zoom delta (+/-0.5, positive = zoom in) for a scroll event.
+ * Vertical scrolls zoom in on up.  Horizontal scrolls zoom in on LEFT when
+ * the shift modifier is set (the OS rotated a vertical wheel step into a
+ * left/right scroll, so LEFT keeps meaning "wheel up") and on RIGHT
+ * otherwise (wheel tilt, two-finger swipe).  Discrete events are resolved
+ * from the normalized GDK direction; smooth (fractional) scrolls use their
+ * dominant delta.  dx/dy are the caller's deltas (raw or accumulated units). */
+float dt_gui_scroll_zoom_delta(const GdkEventScroll *event, gdouble dx, gdouble dy);
+
 /*
  * new ui api
  */

--- a/src/libs/navigation.c
+++ b/src/libs/navigation.c
@@ -610,11 +610,11 @@ static void _lib_navigation_scroll_callback(GtkEventControllerScroll *controller
                                           dt_gdk_event_get_x(event), dt_gdk_event_get_y(event),
                                           &x, &y))
       {
-        const double delta = fabs(dx) > fabs(dy) ? -dx : dy;
-        const int zoom_in = delta < 0.0 ? 1 : 0;
+        const gboolean zoom_in = dt_gui_scroll_zoom_delta((const GdkEventScroll *)event,
+                                                          dx, dy) > 0.0f;
 
         dt_dev_zoom_move(&darktable.develop->full, DT_ZOOM_SCROLL,
-                         0.0f, zoom_in, x, y, constrain);
+                         0.0f, zoom_in ? 1 : 0, x, y, constrain);
       }
     }
     gdk_event_free(event);

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -5098,19 +5098,21 @@ static void _second_window_scrolled_callback(GtkEventControllerScroll *controlle
     return;
   }
 
-  int delta_y;
-  if(!dt_gui_get_scroll_unit_delta((const GdkEventScroll *)current, &delta_y))
+  int delta_x, delta_y;
+  if(!dt_gui_get_scroll_unit_deltas((const GdkEventScroll *)current, &delta_x, &delta_y))
   {
     gdk_event_free(current);
     return;
   }
+  const gboolean zoom_in = dt_gui_scroll_zoom_delta((const GdkEventScroll *)current,
+                                                    delta_x, delta_y) > 0.0f;
   const gboolean constrained =
     dev->constrain_zoom && !dt_modifier_is(state, GDK_CONTROL_MASK);
   gdouble x = 0.0, y = 0.0;
   gdk_event_get_coords(current, &x, &y);
   dt_print(DT_DEBUG_INPUT,
-           "[darkroom second window] scroll zoom delta_y=%d", delta_y);
-  dt_dev_zoom_move(port, DT_ZOOM_SCROLL, 0.0f, delta_y < 0 ? 1 : 0,
+           "[darkroom second window] scroll zoom zoom_in=%d", zoom_in);
+  dt_dev_zoom_move(port, DT_ZOOM_SCROLL, 0.0f, zoom_in ? 1 : 0,
                    x, y, constrained);
   gdk_event_free(current);
 }

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -5075,11 +5075,11 @@ static void _second_window_scrolled_callback(GtkEventControllerScroll *controlle
   GdkModifierType state;
   gtk_get_current_event_state(&state);
 
-  // Two-finger trackpad scroll pans the image, like the main darkroom view's
-  // _scrolled()/gesture_pan path.  The mouse wheel zooms.  Ctrl forces zoom
-  // even for smooth scrolls.
-  if(dt_gdk_event_get_scroll_direction(current) == GDK_SCROLL_SMOOTH
-     && !dt_modifier_is(state, GDK_CONTROL_MASK))
+  // A touchpad two-finger swipe pans the image, like the main darkroom view's
+  // _scrolled()/gesture_pan path.  dt_gui_scroll_should_pan() restricts this to
+  // touchpad-sourced events, so the mouse wheel zooms even where GTK delivers
+  // wheel scrolls as smooth events.
+  if(dt_gui_scroll_should_pan((const GdkEventScroll *)current))
   {
     const GdkEventScroll *scroll = (const GdkEventScroll *)current;
     gdouble pan_dx = 0.0, pan_dy = 0.0;

--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -450,7 +450,9 @@ static gboolean is_image_visible_cb(lua_State *L)
 void cleanup(dt_view_t *self)
 {
   dt_library_t *lib = self->data;
+  dt_culling_destroy(lib->culling);
   free(lib->culling);
+  dt_culling_destroy(lib->preview);
   free(lib->preview);
   free(self->data);
 }


### PR DESCRIPTION
Follow-up to the touchpad seamless zoom/pan work (#20888) and its ctrl+shift fix (#21201). The scroll handling those landed with left the pan decision duplicated in three places (main view, culling layouts, darkroom second window), the zoom direction inconsistent between the culling/filmstrip paths and the darkroom, and a few leaks and NULL-derefs on the touched paths. This PR cleans that up and makes the pan/zoom decisions one shared, documented convention.

What changed:

- **One helper decides whether a scroll pans.** Each view previously repeated its own "smooth scroll without ctrl" check, which treats high-resolution mouse wheels as touchpads — GTK reports their scrolls as smooth events too. The new `dt_gui_scroll_should_pan()` centralizes the decision: touchpad-gestures preference, no ctrl, a smooth non-stop scroll, and a touchpad source device (or the device that just produced a pinch/swipe gesture, as some touchpads report the follow-up scroll stream from a different device). Mouse wheels therefore never pan; macOS Quartz trackpads still do, as they report as mice there. The main view, the culling layouts and the darkroom second window all use it now.
- **Ctrl+scroll zoom direction is consistent everywhere.** Up zooms in, down zooms out — in the culling layouts, the lighttable filmstrip/zoomable modes, the darkroom main view and second window, and the navigation widget. Horizontal scrolls are resolved from the normalized GDK direction rather than the raw delta sign, and respect the shift modifier: with shift held, the OS turns a vertical wheel step into a left/right scroll (macOS, Windows and X11 alike), so LEFT keeps meaning "wheel up" and zooms in, preserving the wheel's muscle memory. Without shift (wheel tilt, two-finger swipe), RIGHT is the increase direction and zooms in. Previously the culling layouts and filmstrip zoomed the opposite way from the darkroom for horizontal scrolls, and the shift+wheel case was inverted in places. The logic lives in one `dt_gui_scroll_zoom_delta()` helper.
- **Leak and NULL-deref fixes on the touched paths.** `gtk_get_current_event()` can return NULL for synthetic motions; the bauhaus slider handlers now guard it and fall back to the global keyboard state. The culling tables gained a `dt_culling_destroy()` — cancels a pending deferred-zoom timer, disconnects the control-signal connections and destroys the widget — used at lighttable cleanup.

No new defaults, no behavior changes for vertical wheel scrolling or pinch zoom — this is the cleanup and normalization pass on top of #21201.

Related: #21201 #21765 #20843
