### PR TITLE
[imageio] Fix a crash when reading corrupted EXR files

### DIFF
--- a/src/imageio/imageio_exr.cc
+++ b/src/imageio/imageio_exr.cc
@@ -16,7 +16,6 @@
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <assert.h>
 #include <inttypes.h>
 #include <memory>
 #include <stdio.h>
@@ -35,9 +34,7 @@
 #include "common/exif.h"
 #include "common/metadata.h"
 #include "common/datetime.h"
-#include "control/conf.h"
 #include "develop/develop.h"
-#include "imageio/imageio_common.h"
 #include "imageio/imageio_exr.h"
 #include "imageio/imageio_exr.hh"
 

--- a/src/imageio/imageio_exr.cc
+++ b/src/imageio/imageio_exr.cc
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2010-2024 darktable developers.
+    Copyright (C) 2010-2026 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -101,7 +101,7 @@ dt_imageio_retval_t dt_imageio_open_exr(dt_image_t *img,
   {
     dt_print(DT_DEBUG_ALWAYS,
              "[exr_open] error: only images with RGB(A) channels are supported,"
-             " skipping `%s'", img->filename);
+             " skipping '%s'", img->filename);
     return DT_IMAGEIO_UNSUPPORTED_FEATURE;
   }
 
@@ -232,7 +232,7 @@ dt_imageio_retval_t dt_imageio_open_exr(dt_image_t *img,
   if(!buf)
   {
     dt_print(DT_DEBUG_ALWAYS,
-             "[exr_open] error: could not alloc full buffer for image `%s'",
+             "[exr_open] error: could not alloc full buffer for image '%s'",
              img->filename);
     return DT_IMAGEIO_CACHE_FULL;
   }
@@ -255,15 +255,25 @@ dt_imageio_retval_t dt_imageio_open_exr(dt_image_t *img,
       "A", Imf::Slice(Imf::FLOAT, (char *)(buf - dx * 4 - dy * img->width * 4 + 3),
                       xstride, ystride, 1, 1, 0.0));
 
-  if(isTiled)
+  try
   {
-    fileTiled->setFrameBuffer(frameBuffer);
-    fileTiled->readTiles(0, fileTiled->numXTiles() - 1, 0, fileTiled->numYTiles() - 1);
+    if(isTiled)
+    {
+      fileTiled->setFrameBuffer(frameBuffer);
+      fileTiled->readTiles(0, fileTiled->numXTiles() - 1, 0, fileTiled->numYTiles() - 1);
+    }
+    else
+    {
+      file->setFrameBuffer(frameBuffer);
+      file->readPixels(dw.min.y, dw.max.y);
+    }
   }
-  else
+  catch(const std::exception &e)
   {
-    file->setFrameBuffer(frameBuffer);
-    file->readPixels(dw.min.y, dw.max.y);
+    dt_print(DT_DEBUG_ALWAYS,
+             "[exr_open] error: could not read from '%s' due to: %s",
+             img->filename, e.what());
+    return DT_IMAGEIO_FILE_CORRUPTED;
   }
 
   /* try to get the chromaticities and whitepoint. this will add the


### PR DESCRIPTION
Resolves #21763.

Reading image data can throw exceptions, so we really need to wrap the readPixels calls in a try/catch block.

Being here, I noticed and removed unnecessary includes and piggybacked this change to the PR.

Since the PR fixes a real crash, it is worth considering for 5.6.1.

I don't yet have an example of a corrupt file from the author of the mentioned issue, but I found a sample of such a file on which darktable crashed here: https://github.com/grizzlypeak3d/DJV/issues/308#issuecomment-683422927. It can be used for testing.
