### PR TITLE
fix display of internal tags after import

### DIFF
--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -3067,6 +3067,7 @@ static int32_t _control_import_job_run(dt_job_t *job)
   g_free(prev_output);
 
   dt_control_log(ngettext("imported %d image", "imported %d images", cntr), cntr);
+  dt_set_darktable_tags();
   dt_control_queue_redraw_center();
   DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_TAG_CHANGED);
   DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_GEOTAG_CHANGED, imgs, 0);


### PR DESCRIPTION
When importing images with existing xmp files, and these files contain internal darktable tags `darktable|...` which do not yet exist in the database, these tags are created on import. 

This is ok so far. The problem is, that these newly created internal tags are shown in the tagging module and not treated as internal tags, so the toggle button for showing/hiding internal tags does not work on these tags. Restarting darktable fixes that.

Solution is to recreate the list of internal tags after import.

Fixes #21712
