### PR TITLE
gtk4-prep: fix shortcut-grab dialog lock and module body right-click menu

### DIFF
--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -2857,13 +2857,13 @@ static void _iop_plugin_body_pressed(GtkGestureSingle *gesture,
                                      gdouble y,
                                      dt_iop_module_t *module)
 {
+  /* the body only reacts to a primary click (focus); right-clicks -- on
+   * the body background or bubbled up from a child widget without its own
+   * right-click handling -- must not open the preset menu, that is the
+   * header's job (see #21778) */
   if(gtk_gesture_single_get_current_button(gesture) == GDK_BUTTON_PRIMARY)
   {
     dt_iop_request_focus(module);
-  }
-  else if(gtk_gesture_single_get_current_button(gesture) == GDK_BUTTON_SECONDARY)
-  {
-    _presets_popup_callback(NULL, NULL, module);
   }
 }
 

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -4462,13 +4462,22 @@ static gboolean _key_release_delayed(gpointer timed_out)
 {
   _timeout_source = 0;
 
-  /* Run the shortcut action while the seat grab is still held, then
-   * ungrab.  Releasing the grab first makes GDK (and on macOS the
-   * Quartz tracking-area machinery behind it) emit phantom crossing
-   * events between the ungrab and the action, which clear the
-   * mouse-over id and make 'prioritize hovered image' fall back to the
-   * selection (see #21729).  This also matches the double/triple-press
-   * path, which processes the action while the grab is held.
+  /* Run the shortcut action after releasing the seat grab, but keep the
+   * grabbed flag set while the action runs.  Releasing the grab first
+   * lets modal dialogs opened by the action receive mouse events: on
+   * Windows the grab is implemented as SetCapture() on the main window
+   * and swallows every mouse event for as long as it is held, so a dialog
+   * opened synchronously inside the action (selective copy/paste, ...)
+   * would be dead to the mouse for its whole lifetime (see #21777).
+   * The flag is what dt_gui_pointer_is_grabbed() checks first, so the
+   * lighttable hover handlers keep filtering the phantom crossing events
+   * that the ungrab makes GDK (and on macOS the Quartz tracking-area
+   * machinery behind it) synthesize around the action -- both while the
+   * action runs and while a dialog's nested main loop is dispatching
+   * them -- and 'prioritize hovered image' keeps working (see #21729).
+   * The flag is cleared right after the action: any crossings still in
+   * the queue then settle to the correct mouse-over (the enter event
+   * re-sets it), so filtering them is no longer needed.
    *
    * A released hold key's action was already dispatched by the hold
    * machinery (DT_ACTION_EFFECT_ON at engage, OFF at release), so for it
@@ -4477,7 +4486,23 @@ static gboolean _key_release_delayed(gpointer timed_out)
   _hold_release_pending = FALSE;
 
   if(!timed_out && !hold_release)
+  {
+#if !GTK_CHECK_VERSION(4, 0, 0)
+    /* GTK3 only: releasing the grab is done here (not in
+     * _ungrab_grab_widget()) so it happens before the action runs; the
+     * flag stays set until the action returns (see comment above).
+     * GTK4 migration: delete -- GTK4 removed the grab APIs, so there is
+     * nothing to release and no flag to keep. */
+    if(_pointer_grabbed)
+      gdk_seat_ungrab(gdk_display_get_default_seat(gdk_display_get_default()));
+#endif
+
     dt_shortcut_move(DT_SHORTCUT_DEVICE_KEYBOARD_MOUSE, 0, DT_SHORTCUT_MOVE_NONE, 1);
+
+#if !GTK_CHECK_VERSION(4, 0, 0)
+    _pointer_grabbed = FALSE;
+#endif
+  }
 
   if(!_pressed_keys)
     _ungrab_grab_widget();


### PR DESCRIPTION
Fixes #21777 — the selective copy/paste history dialog was unresponsive to the mouse when opened by a keyboard shortcut (ctrl+shift+c / ctrl+shift+v) in darkroom. Fixes #21778 — right-clicking a module's body background, or any widget inside it without its own right-click handling, popped up the preset menu.

**#21777 — dialog dead to the mouse on Windows.** The shortcut machinery keeps a seat grab while a shortcut action runs (that's the hovered-image fix, #21729). On Windows the grab is implemented as SetCapture() on the main window, so every mouse event went there and a modal dialog opened inside the action never got any. The grab is now released before the action runs, while the grabbed flag stays set during it so the lighttable hover handlers still filter the synthetic crossings — hovered-image behavior is unchanged.

**#21778 — right-click opened the preset menu from the module body.** The module body's click gesture reacted to any button, so a right-click on the background — or one bubbling up from a child widget without its own right-click handling (tabs, labels, …) — opened the preset menu. Only the module header should do that; the body now only reacts to left clicks (focus).

Both fixes verified on macOS. @dtrtuser since I don't have a Windows machine here, could you give #21777 (ctrl+shift+c in darkroom) a try with this branch? It should now be fully interactive :). We do need to test this on Windows to know if the fix really goes through

Edit: tests done below, all good!

Related: #15920 #20433