### PR TITLE
gtk4-prep: restore motion events to widgets with motion controllers

### DIFF
--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -4911,7 +4911,19 @@ GtkEventController *(dt_gui_connect_motion)(GtkWidget *widget,
   dt_gui_add_controller(widget, controller);
   // GTK4 gtk_widget_add_controller(widget, GTK_EVENT_CONTROLLER(controller));
 
-  gtk_widget_add_events(widget, GDK_ENTER_NOTIFY_MASK | GDK_LEAVE_NOTIFY_MASK); // still needed for now by _main_do_event_keymap
+  /* GTK3: event controllers don't request input events from GDK -- the
+   * motion controller's event mask is 0 -- so the widget must keep its own
+   * event mask or it never receives enter/leave/motion events at all.  The
+   * pointer-motion mask is what makes the "motion" signal fire: without
+   * it, motion over a child window goes to the parent layout instead and
+   * hover-triggered updates (e.g. the thumbnail block overlays re-showing
+   * after their timeout) stop working (see #21782).
+   * The enter/leave masks are also still needed by _main_do_event_keymap.
+   * GTK4 migration: delete this call -- GTK4 delivers all input events
+   * to every widget automatically. */
+  gtk_widget_add_events(widget,
+                        GDK_ENTER_NOTIFY_MASK | GDK_LEAVE_NOTIFY_MASK
+                        | GDK_POINTER_MOTION_MASK);
 
   if(motion) g_signal_connect(controller, "motion", G_CALLBACK(motion), data);
   if(enter) g_signal_connect(controller, "enter", G_CALLBACK(enter), data);


### PR DESCRIPTION
Fixes #21782 — in culling, the rating overlay no longer reappeared when moving the mouse after its timeout; only losing and regaining window focus brought it back.

This was a regression from the event-signal → event-controller conversion (#21659). The GTK3 bridge `dt_gui_connect_motion()` added only the enter/leave event masks to the widget, not the pointer-motion mask. GTK3 event controllers don't request input from GDK themselves, so the thumbnail motion handlers never fired over the event-box-based thumb widgets — motion went to the parent layout instead. Enter/leave still worked, which is why moving the pointer out of the window and back in (a crossing) did bring the overlay back.

The fix restores the pointer-motion mask on every widget with a motion controller, as 5.6 did. The other controller helpers were checked: scroll controllers request their own mask, and click/drag gestures land on drawing-area/event-box widgets that request button events by default — no other spot needs the same change.

Related: #15920 #20433