### PR TITLE
fix: refresh lighttable layout buttons when leaving full preview

### DIFF
--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -110,6 +110,12 @@ static void _preview_quit(dt_view_t *self)
   // restore panels
   dt_ui_restore_panels(darktable.gui->ui);
 
+  // refresh the layout buttons: exiting full preview via a path that doesn't
+  // go through the layout button handlers (e.g. closing the main window while
+  // in preview, which exits preview instead of quitting dt) would otherwise
+  // leave the full preview icon stuck in its active state.
+  dt_view_lighttable_update_layout_buttons(darktable.view_manager);
+
   // show/hide filmstrip & timeline when entering the view
   if(lib->current_layout == DT_LIGHTTABLE_LAYOUT_CULLING
      || lib->current_layout == DT_LIGHTTABLE_LAYOUT_CULLING_DYNAMIC)


### PR DESCRIPTION
Fixes the side observation in #21782 — closing the main window while in full preview (which exits preview instead of quitting darktable) left the full-preview layout icon stuck in its active state, even though the view had dropped back to the file manager. The icon only corrected itself after the next layout button interaction.

The icons are driven declaratively from the view state: `dt_view_lighttable_update_layout_buttons()` → `_lib_lighttable_update_btn()` re-declares the active button from the layout and preview flags, so any state change that skips that refresh leaves the icons stale. `_preview_quit()` clears the preview flag and restores the thumbtable but never refreshed the buttons.

The fix calls `dt_view_lighttable_update_layout_buttons()` from `_preview_quit()` — the single canonical "preview off" path — so window close, the layout buttons and the accelerators all keep the toolbar in sync.

Note: the buggy code path exists identically in 5.6, so this predates the event-controller conversion; the conversion (where the icons became purely declarative) just made the missing refresh observable.

CC @wpferguson 