### PR TITLE
prefs: fix use-after-free when a preference is not available

### DIFF
--- a/tools/generate_prefs.xsl
+++ b/tools/generate_prefs.xsl
@@ -163,8 +163,13 @@ static GtkWidget *setup_pref(GtkWidget **label,
 }
 
 static void setup_not_available(GtkWidget **widget,
-                                GtkWidget *labelev)
+                                GtkWidget *labelev,
+                                GtkWidget *dialog)
 {
+  // the dialog's "response" handler holds this widget as user data; drop it
+  // before the destroy below, or it fires on close against freed memory
+  g_signal_handlers_disconnect_matched(G_OBJECT(dialog), G_SIGNAL_MATCH_DATA,
+                                       0, 0, NULL, NULL, *widget);
   gtk_widget_destroy(*widget);
   *widget = gtk_label_new(_("not available"));
   gtk_widget_set_halign(*widget, GTK_ALIGN_START);
@@ -450,7 +455,7 @@ static void init_tab_generated(GtkWidget *dialog, GtkWidget *stack)
       <xsl:text>
     if(!dt_capabilities_check("</xsl:text><xsl:value-of select="@capability"/><xsl:text>"))
     {
-      setup_not_available(&amp;widget, labelev);
+      setup_not_available(&amp;widget, labelev, dialog);
     }</xsl:text>
     </xsl:if>
     <xsl:text>


### PR DESCRIPTION
`setup_not_available()` destroys the widget the dialog's "response" handler was connected with as its user data, so closing the preferences dialog fired the handler against a disposed widget and wrote a bogus value back to the config. So we need to disconnect the handler before the widget goes away.