### PR TITLE
[maintenance] Remove unused <assert.h> from source files

### DIFF
--- a/src/bauhaus/bauhaus.h
+++ b/src/bauhaus/bauhaus.h
@@ -26,7 +26,6 @@
 #include "gui/draw.h"
 #include "gui/gtk.h"
 
-#include <assert.h>
 #include <gdk/gdkkeysyms.h>
 #include <gtk/gtk.h>
 #include <inttypes.h>

--- a/src/common/box_filters.cc
+++ b/src/common/box_filters.cc
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2009-2024 darktable developers.
+    Copyright (C) 2009-2026 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -20,7 +20,6 @@
 #pragma GCC optimize ("finite-math-only", "no-math-errno", "fp-contract=fast", "fast-math")
 #endif
 
-#include <assert.h>
 #include <math.h>
 #include <stdlib.h>
 

--- a/src/common/dlopencl.c
+++ b/src/common/dlopencl.c
@@ -26,7 +26,6 @@
 #include <dlfcn.h>
 #endif
 
-#include <assert.h>
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/common/fast_guided_filter.h
+++ b/src/common/fast_guided_filter.h
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2019-2024 darktable developers.
+    Copyright (C) 2019-2026 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -18,7 +18,6 @@
 
 #pragma once
 
-#include <assert.h>
 #include <math.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -346,4 +345,3 @@ clean:
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/common/film.c
+++ b/src/common/film.c
@@ -1,6 +1,6 @@
 /*
    This file is part of darktable,
-   Copyright (C) 2009-2025 darktable developers.
+   Copyright (C) 2009-2026 darktable developers.
 
    darktable is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -27,7 +27,6 @@
 #include "control/jobs.h"
 #include "views/view.h"
 
-#include <assert.h>
 #include <errno.h>
 #include <limits.h>
 #include <math.h>
@@ -38,10 +37,12 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
+
 #ifdef USE_LUA
 #include "lua/glist.h"
 #include "lua/lua.h"
 #endif
+
 #ifdef GDK_WINDOWING_QUARTZ
 #include "osx/osx.h"
 #endif

--- a/src/common/gaussian.h
+++ b/src/common/gaussian.h
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2012-2020 darktable developers.
+    Copyright (C) 2012-2026 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -19,7 +19,6 @@
 #pragma once
 
 #include "common/opencl.h"
-#include <assert.h>
 #include <math.h>
 
 typedef enum dt_gaussian_order_t

--- a/src/common/histogram.c
+++ b/src/common/histogram.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2014-2023 darktable developers.
+    Copyright (C) 2014-2026 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -18,7 +18,6 @@
 #include <math.h>
 #include <stddef.h>
 #include <stdint.h>
-#include <assert.h>
 #include <stdlib.h>
 
 #include "common/colorspaces_inline_conversions.h"

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -1,6 +1,6 @@
 /*
   This file is part of darktable,
-  Copyright (C) 2009-2025 darktable developers.
+  Copyright (C) 2009-2026 darktable developers.
 
   darktable is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -42,16 +42,18 @@
 #include "imageio/imageio_rawspeed.h"
 #include "imageio/imageio_libraw.h"
 #include "win/filepath.h"
+
 #ifdef USE_LUA
 #include "lua/image.h"
 #endif
-#include <assert.h>
+
 #include <ctype.h>
 #include <math.h>
 #include <sqlite3.h>
 #include <stdlib.h>
 #include <string.h>
 #include <strings.h>
+
 #ifndef _WIN32
 #include <glob.h>
 #endif

--- a/src/common/luminance_mask.h
+++ b/src/common/luminance_mask.h
@@ -1,7 +1,7 @@
 
 /*
     This file is part of darktable,
-    Copyright (C) 2019-2023 darktable developers.
+    Copyright (C) 2019-2026 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -17,7 +17,6 @@
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <assert.h>
 #include <math.h>
 #include <stdlib.h>
 #include <stdio.h>

--- a/src/control/control.c
+++ b/src/control/control.c
@@ -31,7 +31,6 @@
 #include "imageio/imageio_common.h"
 #include "views/view.h"
 
-#include <assert.h>
 #include <gdk/gdkkeysyms.h>
 #include <glib/gstdio.h>
 #include <lcms2.h>

--- a/src/develop/imageop_gui.c
+++ b/src/develop/imageop_gui.c
@@ -27,7 +27,6 @@
 #include "osx/osx.h"
 #endif
 
-#include <assert.h>
 #include <gmodule.h>
 #include <math.h>
 #include <stdlib.h>
@@ -344,4 +343,3 @@ GtkWidget *dt_bauhaus_combobox_new_interpolation(dt_iop_module_t *self)
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+
 #include "common/gdk_event_utils.h"
 
 #include "gui/accelerators.h"
@@ -27,7 +28,6 @@
 #include "dtgtk/expander.h"
 #include "bauhaus/bauhaus.h"
 
-#include <assert.h>
 #include <gtk/gtk.h>
 #include <math.h>
 

--- a/src/gui/presets.c
+++ b/src/gui/presets.c
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+
 #include "common/gdk_event_utils.h"
 
 #include "bauhaus/bauhaus.h"
@@ -29,10 +30,11 @@
 #include "gui/guides.h"
 #include "gui/presets.h"
 #include "libs/modulegroups.h"
+
 #ifdef GDK_WINDOWING_QUARTZ
 #include "osx/osx.h"
 #endif
-#include <assert.h>
+
 #include <stdlib.h>
 
 #define MAX_FOCAL_LEN 100000

--- a/src/imageio/imageio.c
+++ b/src/imageio/imageio.c
@@ -82,7 +82,6 @@
   #endif
 #endif
 
-#include <assert.h>
 #include <glib/gstdio.h>
 #include <inttypes.h>
 #include <math.h>

--- a/src/imageio/imageio_gm.c
+++ b/src/imageio/imageio_gm.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2012-2025 darktable developers.
+    Copyright (C) 2012-2026 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -22,7 +22,6 @@
 #include "common/exif.h"
 #include "imageio_common.h"
 
-#include <assert.h>
 #include <inttypes.h>
 #include <magick/api.h>
 #include <memory.h>

--- a/src/imageio/imageio_im.c
+++ b/src/imageio/imageio_im.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2020-2025 darktable developers.
+    Copyright (C) 2020-2026 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -28,7 +28,6 @@
 #include <stdio.h>
 #include <inttypes.h>
 #include <strings.h>
-#include <assert.h>
 
 #ifdef HAVE_IMAGEMAGICK7
 #include <MagickWand/MagickWand.h>

--- a/src/imageio/imageio_j2k.c
+++ b/src/imageio/imageio_j2k.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2012-2024 darktable developers.
+    Copyright (C) 2012-2026 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -20,7 +20,6 @@
 #include "common/exif.h"
 #include "imageio/imageio_j2k.h"
 
-#include <assert.h>
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/imageio/imageio_libraw.c
+++ b/src/imageio/imageio_libraw.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2021-2024 darktable developers.
+    Copyright (C) 2021-2026 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -29,7 +29,6 @@
 
 #include <libraw/libraw.h>
 
-#include <assert.h>
 #include <inttypes.h>
 #include <memory.h>
 #include <stdio.h>

--- a/src/imageio/imageio_pfm.c
+++ b/src/imageio/imageio_pfm.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2009-2024 darktable developers.
+    Copyright (C) 2009-2026 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -22,7 +22,6 @@
 #include "common/pfm.h"
 #include "common/imagebuf.h"
 
-#include <assert.h>
 #include <errno.h>
 #include <math.h>
 #include <stdio.h>

--- a/src/imageio/imageio_png.c
+++ b/src/imageio/imageio_png.c
@@ -16,7 +16,6 @@
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <assert.h>
 #include <inttypes.h>
 #include <memory.h>
 #include <png.h>

--- a/src/imageio/imageio_pnm.c
+++ b/src/imageio/imageio_pnm.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2018-2024 darktable developers.
+    Copyright (C) 2018-2026 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -20,7 +20,6 @@
 #include "develop/imageop.h"         // for IOP_CS_RGB
 #include "imageio/imageio_pfm.h"
 
-#include <assert.h>
 #include <errno.h>
 #include <math.h>
 #include <stdio.h>

--- a/src/iop/basecurve.c
+++ b/src/iop/basecurve.c
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+
 #include "common/gdk_event_utils.h"
 
 #include "bauhaus/bauhaus.h"
@@ -38,7 +39,6 @@
 #include "iop/iop_api.h"
 
 #include <regex.h>
-#include <assert.h>
 #include <gtk/gtk.h>
 #include <inttypes.h>
 #include <stdlib.h>

--- a/src/iop/bloom.c
+++ b/src/iop/bloom.c
@@ -31,7 +31,6 @@
 #include "gui/gtk.h"
 #include "iop/iop_api.h"
 
-#include <assert.h>
 #include <gtk/gtk.h>
 #include <inttypes.h>
 #include <stdlib.h>

--- a/src/iop/censorize.c
+++ b/src/iop/censorize.c
@@ -1,6 +1,6 @@
 /*
   This file is part of darktable,
-  Copyright (C) 2020-2024 darktable developers.
+  Copyright (C) 2020-2026 darktable developers.
 
   darktable is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -32,7 +32,7 @@
 #include "gui/gtk.h"
 #include "gui/presets.h"
 #include "iop/iop_api.h"
-#include <assert.h>
+
 #include <gtk/gtk.h>
 #include <math.h>
 #include <stdlib.h>

--- a/src/iop/channelmixer.c
+++ b/src/iop/channelmixer.c
@@ -30,7 +30,6 @@
 #include "gui/presets.h"
 #include "iop/iop_api.h"
 
-#include <assert.h>
 #include <gtk/gtk.h>
 #include <inttypes.h>
 #include <math.h>

--- a/src/iop/clahe.c
+++ b/src/iop/clahe.c
@@ -28,7 +28,6 @@
 #include "gui/gtk.h"
 #include "iop/iop_api.h"
 
-#include <assert.h>
 #include <gtk/gtk.h>
 #include <inttypes.h>
 #include <stdlib.h>

--- a/src/iop/clipping.c
+++ b/src/iop/clipping.c
@@ -34,7 +34,6 @@
 #include "gui/presets.h"
 #include "iop/iop_api.h"
 
-#include <assert.h>
 #include <gdk/gdkkeysyms.h>
 #include <gtk/gtk.h>
 #include <inttypes.h>

--- a/src/iop/colisa.c
+++ b/src/iop/colisa.c
@@ -30,7 +30,6 @@
 #include "gui/presets.h"
 #include "iop/iop_api.h"
 
-#include <assert.h>
 #include <math.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/iop/colorcontrast.c
+++ b/src/iop/colorcontrast.c
@@ -1,7 +1,6 @@
-/* -*- Mode: c; c-basic-offset: 2; -*- */
 /*
     This file is part of darktable,
-    Copyright (C) 2011-2023 darktable developers.
+    Copyright (C) 2011-2026 darktable developers.
 
 
     darktable is free software: you can redistribute it and/or modify
@@ -27,7 +26,6 @@
 #include "gui/gtk.h"
 #include "iop/iop_api.h"
 
-#include <assert.h>
 #include <gtk/gtk.h>
 #include <stdlib.h>
 

--- a/src/iop/colorcorrection.c
+++ b/src/iop/colorcorrection.c
@@ -29,7 +29,6 @@
 #include "gui/presets.h"
 #include "iop/iop_api.h"
 
-#include <assert.h>
 #include <math.h>
 #include <stdlib.h>
 #include <string.h>
@@ -516,4 +515,3 @@ static gboolean dt_iop_colorcorrection_key_press(GtkEventControllerKey *controll
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/iop/colorequal.c
+++ b/src/iop/colorequal.c
@@ -49,7 +49,6 @@ None;midi:CC24=iop/colorequal/brightness/magenta
 
 //#include "common/extra_optimizations.h" // results in crashes on some systems
 
-#include <assert.h>
 #include <math.h>
 #include <stdlib.h>
 #include <stdio.h>

--- a/src/iop/colorize.c
+++ b/src/iop/colorize.c
@@ -30,7 +30,6 @@
 #include "osx/osx.h"
 #endif
 
-#include <assert.h>
 #include <gtk/gtk.h>
 #include <inttypes.h>
 #include <math.h>

--- a/src/iop/colorout.c
+++ b/src/iop/colorout.c
@@ -33,7 +33,6 @@
 #include "gui/gtk.h"
 #include "iop/iop_api.h"
 
-#include <assert.h>
 #include <gdk/gdkkeysyms.h>
 #include <math.h>
 #include <stdlib.h>

--- a/src/iop/colorreconstruction.c
+++ b/src/iop/colorreconstruction.c
@@ -31,7 +31,6 @@
 #include "gui/presets.h"
 #include "iop/iop_api.h"
 
-#include <assert.h>
 #include <gtk/gtk.h>
 #include <inttypes.h>
 #include <math.h>

--- a/src/iop/contrastntexture.c
+++ b/src/iop/contrastntexture.c
@@ -35,7 +35,6 @@ Current status as implemented by Jandren:
 
 #include "common/extra_optimizations.h"
 
-#include <assert.h>
 #include <math.h>
 #include <stdlib.h>
 #include <stdio.h>

--- a/src/iop/crop.c
+++ b/src/iop/crop.c
@@ -34,7 +34,6 @@
 #include "gui/presets.h"
 #include "iop/iop_api.h"
 
-#include <assert.h>
 #include <gdk/gdkkeysyms.h>
 #include <gtk/gtk.h>
 #include <inttypes.h>

--- a/src/iop/equalizer.c
+++ b/src/iop/equalizer.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2009-2024 darktable developers.
+    Copyright (C) 2009-2026 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+
 #include "common/darktable.h"
 #include "common/debug.h"
 #include "common/imagebuf.h"
@@ -25,12 +26,12 @@
 #include "gui/gtk.h"
 #include "gui/presets.h"
 #include "iop/iop_api.h"
-#include <assert.h>
+#include "iop/equalizer_eaw.h"
+
 #include <math.h>
 #include <stdlib.h>
 #include <string.h>
 
-#include "iop/equalizer_eaw.h"
 
 // #define DT_GUI_EQUALIZER_INSET 5
 // #define DT_GUI_CURVE_INFL .3f
@@ -242,4 +243,3 @@ void gui_init(dt_iop_module_t *self)
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -16,7 +16,6 @@
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <assert.h>
 #include <math.h>
 #include <stdint.h>
 #include <stdlib.h>

--- a/src/iop/filmic.c
+++ b/src/iop/filmic.c
@@ -39,7 +39,6 @@
 #include "develop/imageop.h"
 #include "gui/draw.h"
 
-#include <assert.h>
 #include <math.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -15,6 +15,7 @@
    You should have received a copy of the GNU General Public License
    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+
 #include "common/gdk_event_utils.h"
 
 /** Note :
@@ -53,7 +54,6 @@
 
 #include "gui/draw.h"
 
-#include <assert.h>
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>

--- a/src/iop/flip.c
+++ b/src/iop/flip.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2011-2025 darktable developers.
+    Copyright (C) 2011-2026 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -15,7 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
-#include <assert.h>
+
 #include <gdk/gdkkeysyms.h>
 #include <gtk/gtk.h>
 #include <inttypes.h>

--- a/src/iop/gamma.c
+++ b/src/iop/gamma.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2009-2024 darktable developers.
+    Copyright (C) 2009-2026 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -16,7 +16,6 @@
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <assert.h>
 #include <math.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/iop/globaltonemap.c
+++ b/src/iop/globaltonemap.c
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+
 #include "bauhaus/bauhaus.h"
 #include "common/bilateral.h"
 #include "common/bilateralcl.h"
@@ -29,10 +30,9 @@
 #include "gui/accelerators.h"
 #include "gui/gtk.h"
 #include "iop/iop_api.h"
-#include <assert.h>
+
 #include <stdlib.h>
 #include <string.h>
-
 #include <gtk/gtk.h>
 #include <inttypes.h>
 

--- a/src/iop/graduatednd.c
+++ b/src/iop/graduatednd.c
@@ -15,7 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
-#include <assert.h>
+
 #include <math.h>
 #include <stdlib.h>
 #include <string.h>
@@ -1078,9 +1078,9 @@ GSList *mouse_actions(dt_iop_module_t *self)
                                      _("[%s on line] change hardness"), self->name());
   return lm;
 }
+
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/iop/grain.c
+++ b/src/iop/grain.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2010-2024 darktable developers.
+    Copyright (C) 2010-2026 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -16,7 +16,8 @@
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <assert.h>
+#include <gtk/gtk.h>
+#include <inttypes.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -29,8 +30,6 @@
 #include "gui/accelerators.h"
 #include "gui/gtk.h"
 #include "iop/iop_api.h"
-#include <gtk/gtk.h>
-#include <inttypes.h>
 
 #define GRAIN_LIGHTNESS_STRENGTH_SCALE 0.15f
 

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -16,10 +16,12 @@
    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <assert.h>
+#include <gtk/gtk.h>
+#include <inttypes.h>
 #include <math.h>
 #include <stdlib.h>
 #include <string.h>
+
 #include "bauhaus/bauhaus.h"
 #include "common/box_filters.h"
 #include "common/bspline.h"
@@ -39,8 +41,6 @@
 #include "gui/accelerators.h"
 #include "gui/gtk.h"
 
-#include <gtk/gtk.h>
-#include <inttypes.h>
 
 // Downsampling factor for guided-laplacian
 #define DS_FACTOR 4

--- a/src/iop/highpass.c
+++ b/src/iop/highpass.c
@@ -15,7 +15,9 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
-#include <assert.h>
+
+#include <gtk/gtk.h>
+#include <inttypes.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -31,8 +33,7 @@
 #include "gui/accelerators.h"
 #include "gui/gtk.h"
 #include "iop/iop_api.h"
-#include <gtk/gtk.h>
-#include <inttypes.h>
+
 
 #define MAX_RADIUS 16
 
@@ -357,9 +358,9 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_slider_set_format(g->contrast, "%");
   gtk_widget_set_tooltip_text(g->contrast, _("the contrast of highpass filter"));
 }
+
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -43,7 +43,7 @@
 #include "gui/draw.h"
 #include "gui/gtk.h"
 #include "iop/iop_api.h"
-#include <assert.h>
+
 #include <ctype.h>
 #include <gtk/gtk.h>
 #include <inttypes.h>
@@ -51,6 +51,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <lensfun.h>
+
 
 #define MAXKNOTS 16
 #define VIGSPLINES 512

--- a/src/iop/levels.c
+++ b/src/iop/levels.c
@@ -15,8 +15,9 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+
 #include "common/gdk_event_utils.h"
-#include <assert.h>
+
 #include <math.h>
 #include <stdint.h>
 #include <stdlib.h>
@@ -38,6 +39,7 @@
 #include "gui/presets.h"
 #include "iop/iop_api.h"
 #include "libs/colorpicker.h"
+
 
 #define DT_GUI_CURVE_EDITOR_INSET DT_PIXEL_APPLY_DPI(5)
 // special marker value for uninitialized (and thus invalid) levels.  Use this in preference

--- a/src/iop/lowpass.c
+++ b/src/iop/lowpass.c
@@ -1,6 +1,6 @@
 /*
   This file is part of darktable,
-  Copyright (C) 2011-2023 darktable developers.
+  Copyright (C) 2011-2026 darktable developers.
 
   darktable is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -34,12 +34,12 @@
 #include "gui/gtk.h"
 #include "gui/presets.h"
 #include "iop/iop_api.h"
-#include <assert.h>
+
 #include <gtk/gtk.h>
+#include <inttypes.h>
 #include <stdlib.h>
 #include <string.h>
 
-#include <inttypes.h>
 
 DT_MODULE_INTROSPECTION(4, dt_iop_lowpass_params_t)
 

--- a/src/iop/monochrome.c
+++ b/src/iop/monochrome.c
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+
 #include "common/gdk_event_utils.h"
 
 #include "bauhaus/bauhaus.h"
@@ -34,9 +35,10 @@
 #include "gui/presets.h"
 #include "gui/accelerators.h"
 #include "iop/iop_api.h"
-#include <assert.h>
+
 #include <stdlib.h>
 #include <string.h>
+
 
 DT_MODULE_INTROSPECTION(2, dt_iop_monochrome_params_t)
 

--- a/src/iop/overlay.c
+++ b/src/iop/overlay.c
@@ -33,7 +33,6 @@
 #include "gui/gtk.h"
 #include "iop/iop_api.h"
 
-#include <assert.h>
 #include <gtk/gtk.h>
 #include <inttypes.h>
 #include <stdlib.h>

--- a/src/iop/profile_gamma.c
+++ b/src/iop/profile_gamma.c
@@ -31,7 +31,7 @@
 #include "gui/presets.h"
 #include "gui/color_picker_proxy.h"
 #include "iop/iop_api.h"
-#include <assert.h>
+
 #include <math.h>
 #include <stdlib.h>
 #include <string.h>
@@ -651,7 +651,6 @@ void gui_init(dt_iop_module_t *self)
 
   dt_gui_box_add(self->widget, g->mode_stack);
 }
-
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/iop/relight.c
+++ b/src/iop/relight.c
@@ -24,7 +24,6 @@
 #pragma GCC optimize ("finite-math-only", "no-math-errno", "fast-math", "fp-contract=fast")
 #endif
 
-#include <assert.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -270,4 +269,3 @@ void gui_init(dt_iop_module_t *self)
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/iop/shadhi.c
+++ b/src/iop/shadhi.c
@@ -1,6 +1,6 @@
 /*
   This file is part of darktable,
-  Copyright (C) 2012-2025 darktable developers.
+  Copyright (C) 2012-2026 darktable developers.
 
   darktable is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -15,6 +15,7 @@
   You should have received a copy of the GNU General Public License
   along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+
 #include "bauhaus/bauhaus.h"
 #include "common/bilateral.h"
 #include "common/bilateralcl.h"
@@ -32,13 +33,12 @@
 #include "gui/gtk.h"
 #include "gui/presets.h"
 #include "iop/iop_api.h"
-#include <assert.h>
+
 #include <math.h>
+#include <inttypes.h>
 #include <stdlib.h>
 #include <string.h>
-
 #include <gtk/gtk.h>
-#include <inttypes.h>
 
 #define UNBOUND_L 1
 #define UNBOUND_A 2

--- a/src/iop/sharpen.c
+++ b/src/iop/sharpen.c
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+
 #include "bauhaus/bauhaus.h"
 #include "common/imagebuf.h"
 #include "common/opencl.h"
@@ -28,13 +29,13 @@
 #include "gui/gtk.h"
 #include "gui/presets.h"
 #include "iop/iop_api.h"
-#include <assert.h>
+
 #include <math.h>
+#include <inttypes.h>
 #include <stdlib.h>
 #include <string.h>
 
 #include <gtk/gtk.h>
-#include <inttypes.h>
 
 DT_MODULE_INTROSPECTION(1, dt_iop_sharpen_params_t)
 

--- a/src/iop/soften.c
+++ b/src/iop/soften.c
@@ -16,10 +16,11 @@
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <assert.h>
 #include <math.h>
+#include <inttypes.h>
 #include <stdlib.h>
 #include <string.h>
+#include <gtk/gtk.h>
 
 #include "bauhaus/bauhaus.h"
 #include "common/box_filters.h"
@@ -36,8 +37,6 @@
 #include "gui/accelerators.h"
 #include "gui/gtk.h"
 #include "iop/iop_api.h"
-#include <gtk/gtk.h>
-#include <inttypes.h>
 
 DT_MODULE_INTROSPECTION(1, dt_iop_soften_params_t)
 

--- a/src/iop/splittoning.c
+++ b/src/iop/splittoning.c
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+
 #include "bauhaus/bauhaus.h"
 #include "common/colorspaces.h"
 #include "common/debug.h"
@@ -32,7 +33,7 @@
 #include "gui/presets.h"
 #include "gui/color_picker_proxy.h"
 #include "iop/iop_api.h"
-#include <assert.h>
+
 #include <gtk/gtk.h>
 #include <inttypes.h>
 #include <stdlib.h>

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -16,7 +16,6 @@
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <assert.h>
 #include <lcms2.h>
 #include <math.h>
 #include <stdlib.h>

--- a/src/iop/tonecurve.c
+++ b/src/iop/tonecurve.c
@@ -15,8 +15,9 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+
 #include "common/gdk_event_utils.h"
-#include <assert.h>
+
 #include <math.h>
 #include <stdint.h>
 #include <stdlib.h>

--- a/src/iop/tonemap.cc
+++ b/src/iop/tonemap.cc
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2010-2021 darktable developers.
+    Copyright (C) 2010-2026 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -26,10 +26,11 @@
 
 #define __STDC_FORMAT_MACROS
 
-#include <assert.h>
 #include <math.h>
+#include <inttypes.h>
 #include <stdlib.h>
 #include <string.h>
+#include <gtk/gtk.h>
 
 #include "bauhaus/bauhaus.h"
 #include "control/control.h"
@@ -39,8 +40,6 @@
 #include "gui/accelerators.h"
 #include "gui/gtk.h"
 #include "iop/iop_api.h"
-#include <gtk/gtk.h>
-#include <inttypes.h>
 
 #include "iop/Permutohedral.h"
 
@@ -236,4 +235,3 @@ G_END_DECLS
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/iop/velvia.c
+++ b/src/iop/velvia.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2010-2025 darktable developers.
+    Copyright (C) 2010-2026 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -16,10 +16,11 @@
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <assert.h>
 #include <math.h>
+#include <inttypes.h>
 #include <stdlib.h>
 #include <string.h>
+#include <gtk/gtk.h>
 
 #include "bauhaus/bauhaus.h"
 #include "common/imagebuf.h"
@@ -33,8 +34,6 @@
 #include "gui/gtk.h"
 #include "iop/iop_api.h"
 
-#include <gtk/gtk.h>
-#include <inttypes.h>
 
 DT_MODULE_INTROSPECTION(2, dt_iop_velvia_params_t)
 

--- a/src/iop/vibrance.c
+++ b/src/iop/vibrance.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2011-2024 darktable developers.
+    Copyright (C) 2011-2026 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -15,10 +15,12 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
-#include <assert.h>
+
 #include <math.h>
+#include <inttypes.h>
 #include <stdlib.h>
 #include <string.h>
+#include <gtk/gtk.h>
 
 #include "bauhaus/bauhaus.h"
 #include "common/opencl.h"
@@ -29,8 +31,6 @@
 #include "gui/accelerators.h"
 #include "gui/gtk.h"
 #include "iop/iop_api.h"
-#include <gtk/gtk.h>
-#include <inttypes.h>
 
 DT_MODULE_INTROSPECTION(2, dt_iop_vibrance_params_t)
 
@@ -198,9 +198,9 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_slider_set_format(g->amount_scale, "%");
   gtk_widget_set_tooltip_text(g->amount_scale, _("the amount of vibrance"));
 }
+
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/iop/vignette.c
+++ b/src/iop/vignette.c
@@ -16,9 +16,10 @@
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <assert.h>
+#include <inttypes.h>
 #include <stdlib.h>
 #include <string.h>
+#include <gtk/gtk.h>
 
 #include "bauhaus/bauhaus.h"
 #include "common/math.h"
@@ -34,8 +35,6 @@
 #include "gui/gtk.h"
 #include "gui/presets.h"
 #include "iop/iop_api.h"
-#include <gtk/gtk.h>
-#include <inttypes.h>
 
 DT_MODULE_INTROSPECTION(4, dt_iop_vignette_params_t)
 

--- a/src/iop/watermark.c
+++ b/src/iop/watermark.c
@@ -35,7 +35,7 @@
 #include "gui/gtk.h"
 #include "gui/gtkentry.h"
 #include "iop/iop_api.h"
-#include <assert.h>
+
 #include <gtk/gtk.h>
 #include <inttypes.h>
 #include <math.h>

--- a/src/iop/zonesystem.c
+++ b/src/iop/zonesystem.c
@@ -15,8 +15,9 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+
 #include "common/gdk_event_utils.h"
-#include <assert.h>
+
 #include <stdlib.h>
 #include <string.h>
 
@@ -803,4 +804,3 @@ void _iop_zonesystem_redraw_preview_callback(gpointer instance, dt_iop_module_t 
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -50,7 +50,6 @@
 #include "lua/image.h"
 #endif
 
-#include <assert.h>
 #include <dirent.h>
 #include <errno.h>
 #include <gdk/gdkkeysyms.h>


### PR DESCRIPTION
In some cases the source code did use assert(), but later when the call to this function was removed the include was not and it became stale and unused.

In other cases the include was not actually used from the very first version of the code. It looks like <assert.h> was sometimes included as a copy-paste of an includes block from some similar code...

This PR fixes 67 instances of unnecessary include (plus 1 in the previous PR, so there were 68 in total).
