### PR TITLE
Fix segmentation preprocessing to pixel-centre sampling

### DIFF
--- a/src/common/ai/segmentation.c
+++ b/src/common/ai/segmentation.c
@@ -125,17 +125,20 @@ _preprocess_image(const uint8_t *rgb_data,
   if(!output)
     return NULL;
 
-  // bilinear resize + normalize + HWC->CHW in one pass
+  // bilinear resize + normalize + HWC->CHW in one pass, sampling on the
+  // pixel-centre convention like _crop_resize_mask. y / scale would shift the
+  // image by 0.5/scale - 0.5 source px (2.4 px at 6000 -> 1024), which the
+  // encoder bakes into the mask. the clamp keeps (int) a floor and fy >= 0
   for(int y = 0; y < new_h; y++)
   {
-    const float src_y = (float)y / scale;
+    const float src_y = MAX(((float)y + 0.5f) / scale - 0.5f, 0.0f);
     const int y0 = (int)src_y;
     const int y1 = (y0 + 1 < height) ? y0 + 1 : y0;
     const float fy = src_y - y0;
 
     for(int x = 0; x < new_w; x++)
     {
-      const float src_x = (float)x / scale;
+      const float src_x = MAX(((float)x + 0.5f) / scale - 0.5f, 0.0f);
       const int x0 = (int)src_x;
       const int x1 = (x0 + 1 < width) ? x0 + 1 : x0;
       const float fx = src_x - x0;
@@ -1180,9 +1183,12 @@ void dt_seg_reset_encoding(dt_seg_context_t *ctx)
 
 /* --- disk cache for encoder embeddings --- */
 
-// file format: magic + version + metadata + encoder outputs + RGB
+// file format: magic + version + metadata + encoder outputs + RGB.
+// bump the version when anything upstream of the encoder changes: the key
+// (imgid, distort hash, model) would not notice, and stale embeddings would
+// be reused forever. v2 = _preprocess_image moved to pixel-centre sampling
 #define SEG_CACHE_MAGIC 0x44545347  // "DTSG"
-#define SEG_CACHE_VERSION 1
+#define SEG_CACHE_VERSION 2
 #define SEG_CACHE_SUBDIR "objmasks"
 
 // build the per-database cache directory path.


### PR DESCRIPTION
Follow-up to #21764 

That PR fixed the mask side, but `_preprocess_image()` still samples at `y / scale`, so the encoder sees the image shifted by `0.5/scale - 0.5` source pixels and bakes that into every mask. It is a uniform shift, so it does not cancel anywhere: 1.5 px at 4000 → 1024, 2.4 px at 6000 → 1024, 5.4 px at 6000 → 512.

With both ends on the same convention the round trip is exact. The `MAX(..., 0.0f)` keeps `(int)` a floor and `fy >= 0`, same as in `_crop_resize_mask`; I swept the usual sizes and found no index outside the source and no weight outside `[0, 1)`.

`SEG_CACHE_VERSION` goes to 2 because the cache stores encoder outputs, which are now different numbers. Its key (imgid, distort hash, model) cannot notice a code change, so otherwise previously opened images would keep serving embeddings from the old sampling. Cost is one re-encode per cached image.
