### PR TITLE
Fix blending visualizing masks

### DIFF
--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -1488,6 +1488,9 @@ static inline gboolean _piece_wants_blending(const dt_dev_pixelpipe_iop_t *piece
   if(piece->pipe->bypass_blendif && dt_iop_has_focus(piece->module))
     return FALSE;
 
+  if(piece->pipe->mask_display == DT_DEV_PIXELPIPE_DISPLAY_PASSTHRU)
+    return FALSE;
+
   const dt_develop_blend_params_t *const d = piece->blendop_data;
   return d && (d->mask_mode & DEVELOP_MASK_ENABLED);
 }


### PR DESCRIPTION
Some modules can show masks or false-colors to visualize it's effect, color- and tone equalizer as examples.
Those masks should not be altered by any blending, we missed the do-blending check for mask passthru mode.

Fixes #21779