### PR TITLE
gtk4-prep: restore color picker activation for WB presets and saved samples

### DIFF
--- a/src/gui/color_picker_proxy.c
+++ b/src/gui/color_picker_proxy.c
@@ -577,6 +577,11 @@ gboolean dt_iop_color_picker_is_active(GtkWidget *w)
   return p && p->colorpick == w;
 }
 
+void dt_color_picker_toggle(GtkWidget *target)
+{
+  _color_picker_widget_toggle(target, DT_ACTION_EFFECT_TOGGLE, 1.0f);
+}
+
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/gui/color_picker_proxy.c
+++ b/src/gui/color_picker_proxy.c
@@ -579,7 +579,17 @@ gboolean dt_iop_color_picker_is_active(GtkWidget *w)
 
 void dt_color_picker_toggle(GtkWidget *target)
 {
-  _color_picker_widget_toggle(target, DT_ACTION_EFFECT_TOGGLE, 1.0f);
+  dt_color_picker_click(target, FALSE);
+}
+
+void dt_color_picker_click(GtkWidget *target, const gboolean right)
+{
+  /* same shared entry as real clicks and shortcuts; right activates the
+   * picker in area mode, left in point mode */
+  _color_picker_widget_toggle(target,
+                              right ? DT_ACTION_EFFECT_TOGGLE_RIGHT
+                                    : DT_ACTION_EFFECT_TOGGLE,
+                              1.0f);
 }
 
 // clang-format off

--- a/src/gui/color_picker_proxy.h
+++ b/src/gui/color_picker_proxy.h
@@ -111,6 +111,10 @@ gboolean dt_iop_color_picker_is_active(GtkWidget *w);
  * (dt_action_def_color_picker -> _color_picker_widget_toggle) */
 void dt_color_picker_toggle(GtkWidget *target);
 
+/* activate a standalone picker toggle button like a real click, with the
+ * right button selecting area mode and the left one point mode */
+void dt_color_picker_click(GtkWidget *target, const gboolean right);
+
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/gui/color_picker_proxy.h
+++ b/src/gui/color_picker_proxy.h
@@ -106,6 +106,11 @@ GtkWidget *dt_color_picker_new_with_cst(dt_iop_module_t *module,
 
 gboolean dt_iop_color_picker_is_active(GtkWidget *w);
 
+/* toggle a standalone picker toggle button programmatically; routes through
+ * the same shared entry as real clicks and shortcuts
+ * (dt_action_def_color_picker -> _color_picker_widget_toggle) */
+void dt_color_picker_toggle(GtkWidget *target);
+
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -5200,40 +5200,6 @@ void dt_gui_process_events()
     continue;
 }
 
-void dt_gui_simulate_button_event(GtkWidget *widget,
-                                  const GdkEventType eventtype,
-                                  const int button)
-{
-  gboolean res = FALSE;
-
-  // Create the event GdkEventButton
-  GdkEventButton event;
-  memset(&event, 0, sizeof(event));
-
-  event.type = eventtype;
-  event.window = gtk_widget_get_window(widget);
-  event.send_event = TRUE;
-  event.time = GDK_CURRENT_TIME;
-  event.x = 0;  // not important in this case
-  event.y = 0;  // not important in this case
-  event.button = button;
-  event.device =
-    gdk_seat_get_pointer(gdk_display_get_default_seat(gdk_display_get_default()));
-
-  if(event.window != NULL)
-  {
-    g_object_ref(event.window);
-  }
-
-  // send signal
-  g_signal_emit_by_name(G_OBJECT(widget), "button-press-event", &event, &res, NULL);
-
-  if(event.window != NULL)
-  {
-    g_object_unref(event.window);
-  }
-}
-
 GtkWidget *(dt_gui_box_add)(const char *file, const int line, const char *function, GtkBox *box, gpointer list[])
 {
   if(!GTK_IS_BOX(box)) dt_print(DT_DEBUG_ALWAYS, "%s:%d %s: trying to add widgets to non-box container using dt_gui_box_add", file, line, function);

--- a/src/gui/gtk.h
+++ b/src/gui/gtk.h
@@ -740,11 +740,6 @@ static inline GtkWidget *dt_gui_scroll_wrap(GtkWidget *widget)
   return scrolled_window;
 }
 
-// Simulate a mouse button event (button is 1, 2, 3 - mouse button) sent to a Widget
-void dt_gui_simulate_button_event(GtkWidget *widget,
-                                  const GdkEventType eventtype,
-                                  const int button);
-
 // Setup auto-commit on focus loss for editable renderers
 void dt_gui_commit_on_focus_loss(GtkCellRenderer *renderer,
                                  GtkCellEditable **active_editable);

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -1802,11 +1802,7 @@ static void _preset_tune_callback(GtkWidget *widget, dt_iop_module_t *self)
       break;
     case DT_IOP_TEMP_SPOT: // from image area wb, expose callback will set p->rgbg2.
       if(!gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(g->colorpicker)))
-      {
-        gboolean ret_val;
-        g_signal_emit_by_name(G_OBJECT(g->colorpicker), "button-press-event",
-                              NULL, &ret_val);
-      }
+        dt_color_picker_toggle(g->colorpicker);
       break;
     case DT_IOP_TEMP_USER: // directly changing one of the coeff
                            // sliders also changes the mod_coeff so it

--- a/src/libs/colorpicker.c
+++ b/src/libs/colorpicker.c
@@ -571,13 +571,11 @@ static void _live_sample_button_cb(GtkGestureSingle *gesture,
 
     if(simulate_event)
     {
-      dt_gui_simulate_button_event
-        (data->picker_button,
-         GDK_BUTTON_PRESS,
-         /* button 1 to create use a point and 3 for a box */
-         data->primary_sample.size == DT_LIB_COLORPICKER_SIZE_POINT
-         ? 1
-         : 3);
+      /* the primary picker button's activation is a CAPTURE-phase gesture
+       * that synthetic button-press-event signals cannot reach; use the
+       * shared click entry instead (left button -> point, right -> area) */
+      dt_color_picker_click(data->picker_button,
+                            data->primary_sample.size != DT_LIB_COLORPICKER_SIZE_POINT);
     }
 
     if(picker && picker->module)


### PR DESCRIPTION
Fixes #21786 — darktable crashed when switching the white balance module's preset to "from image area", and the colorpicker's "copy to active picker" (right-click a saved sample) quietly stopped working.

Both regressions came from the gtk4-prep event-controller conversion: picker buttons now handle clicks through a CAPTURE-phase gesture that synthetic `button-press-event` signals can't reach, but two code paths still "faked" that old signal:

- **Selecting the "from image area" WB preset** synthesized a press with a NULL event, which used to be swallowed by darktable's own handler; now it fell through to GTK's default button handler and crashed inside libgtk.
- **Right-clicking a saved colorpicker sample** synthesized a press to turn the picker on; the picker silently never activated, and the button was left holding a press without a release.

Both now activate the picker through the same path as a real click. Nothing else changes.

Related: #21786
