### PR TITLE
fix: mouse wheel responds on the first tick after a direction change

### DIFF
--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -5007,10 +5007,29 @@ static void _scroll_proxy_real(GtkEventControllerScroll* controller,
      && !gdk_event_get_pointer_emulated(event)
      && !_scroll_sidebar(controller, dy, event))
   {
-    if(dt_gdk_event_get_scroll_direction(event) == GDK_SCROLL_SMOOTH)
+    const GdkScrollDirection direction = dt_gdk_event_get_scroll_direction(event);
+    if(direction == GDK_SCROLL_SMOOTH)
     {
+      // Wheel notches arrive here as GDK_SCROLL_SMOOTH events with
+      // |delta| == 1.0.  For the discrete proxy a notch must be exactly
+      // one step, so keep those deltas unattenuated: attenuating a notch
+      // to 0.95 (the Linux/Windows scale) left it below the 1.0 emit
+      // threshold, so the first notch of a direction silently did
+      // nothing, and the fractional remainder it built up made the first
+      // tick after a direction change do nothing either.  The non-
+      // discrete (smooth/touchpad) proxy keeps the attenuation.  macOS
+      // scroll deltas are distance-based (several units per event), so it
+      // keeps the compression on both paths.
+#ifdef GDK_WINDOWING_QUARTZ
       dx = _scroll_attenuate(dx);
       dy = _scroll_attenuate(dy);
+#else
+      if(!discrete)
+      {
+        dx = _scroll_attenuate(dx);
+        dy = _scroll_attenuate(dy);
+      }
+#endif
       if(discrete)
       {
         // a change in scroll direction must not be spent cancelling the

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -600,16 +600,27 @@ gboolean dt_gui_get_scroll_unit_deltas(const GdkEventScroll *event,
         acc_x = acc_y = 0.0;
         break;
       }
-      // accumulate trackpad/touch scrolls until they make a unit
-      // scroll, and only then tell caller that there is a scroll to
-      // handle
+      {
+        // same direction-change handling as the discrete scroll proxy:
+        // drop the remainder accumulated in the previous direction so the
+        // first tick of the new direction is not spent cancelling it
+        const gdouble scroll_delta_x = dt_gdk_event_get_scroll_delta_x(event);
+        const gdouble scroll_delta_y = dt_gdk_event_get_scroll_delta_y(event);
+        if((scroll_delta_x < 0.0 && acc_x > 0.0) || (scroll_delta_x > 0.0 && acc_x < 0.0))
+          acc_x = 0.0;
+        if((scroll_delta_y < 0.0 && acc_y > 0.0) || (scroll_delta_y > 0.0 && acc_y < 0.0))
+          acc_y = 0.0;
+        // accumulate trackpad/touch scrolls until they make a unit
+        // scroll, and only then tell caller that there is a scroll to
+        // handle
 #ifdef GDK_WINDOWING_QUARTZ // on macOS deltas need to be scaled
-      acc_x += dt_gdk_event_get_scroll_delta_x(event) / DT_UI_SCROLL_SMOOTH_DELTA_SCALE;
-      acc_y += dt_gdk_event_get_scroll_delta_y(event) / DT_UI_SCROLL_SMOOTH_DELTA_SCALE;
+        acc_x += scroll_delta_x / DT_UI_SCROLL_SMOOTH_DELTA_SCALE;
+        acc_y += scroll_delta_y / DT_UI_SCROLL_SMOOTH_DELTA_SCALE;
 #else
-      acc_x += dt_gdk_event_get_scroll_delta_x(event);
-      acc_y += dt_gdk_event_get_scroll_delta_y(event);
+        acc_x += scroll_delta_x;
+        acc_y += scroll_delta_y;
 #endif
+      }
       const gdouble amt_x = trunc(acc_x);
       const gdouble amt_y = trunc(acc_y);
       if(amt_x != 0 || amt_y != 0)
@@ -5002,6 +5013,15 @@ static void _scroll_proxy_real(GtkEventControllerScroll* controller,
       dy = _scroll_attenuate(dy);
       if(discrete)
       {
+        // a change in scroll direction must not be spent cancelling the
+        // remainder accumulated in the previous direction: if it is kept,
+        // the first tick of the new direction does nothing and a second
+        // one is needed before the value changes.  Drop the stale
+        // remainder so the new direction responds on its very first tick.
+        if((dx < 0.0 && _scroll_discrete_dx > 0.0) || (dx > 0.0 && _scroll_discrete_dx < 0.0))
+          _scroll_discrete_dx = 0.0;
+        if((dy < 0.0 && _scroll_discrete_dy > 0.0) || (dy > 0.0 && _scroll_discrete_dy < 0.0))
+          _scroll_discrete_dy = 0.0;
         _scroll_discrete_dx += dx;
         _scroll_discrete_dy += dy;
         dx = dy = 0.0;

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -5020,16 +5020,13 @@ static void _scroll_proxy_real(GtkEventControllerScroll* controller,
       // discrete (smooth/touchpad) proxy keeps the attenuation.  macOS
       // scroll deltas are distance-based (several units per event), so it
       // keeps the compression on both paths.
-#ifdef GDK_WINDOWING_QUARTZ
-      dx = _scroll_attenuate(dx);
-      dy = _scroll_attenuate(dy);
-#else
+#ifndef GDK_WINDOWING_QUARTZ
       if(!discrete)
+#endif
       {
         dx = _scroll_attenuate(dx);
         dy = _scroll_attenuate(dy);
       }
-#endif
       if(discrete)
       {
         // a change in scroll direction must not be spent cancelling the


### PR DESCRIPTION
Scrolling a bauhaus slider or dropdown with the mouse wheel was eating ticks: scroll a few notches up, then one down, and the first down notch did nothing — you had to scroll down twice to move the value. The very first notch of a scroll could get lost too (scroll three times, only two register). It affected sliders, dropdowns, and the alt/ctrl/shift zoom-range shortcuts.

## Why

A wheel notch arrives at the scroll controller as a smooth event with delta ±1. The discrete scroll proxy was attenuating that to 0.95, and its accumulator only emits a step once it crosses ±1.0. So a single notch could never register by itself, and the leftover 0.95-ish remainder meant the first notch of the opposite direction was silently spent cancelling it. Released versions passed wheel notches straight through as exact ±1 steps, which is why this only showed up with the new proxy.

## What changed

- Sliders, dropdowns and their popups: wheel notches are no longer attenuated, so each notch is exactly one step and registers immediately. Smooth/touchpad scrolling keeps its attenuation, and macOS keeps its compression (its scroll deltas are distance-based).
- If a fractional remainder does exist (touchpad-style input), it's dropped when the scroll direction changes, so the first tick of the new direction counts.
- `dt_gui_get_scroll_unit_deltas()` (thumbtable, gradientslider, darkroom scroll-zoom, scroll shortcuts) gets the same direction-change handling.

Single-direction scrolling behaves exactly as before.

Fixes #21390
