### PR TITLE
[imageio] Prevent possible OOM crashing in JXL exporter

### DIFF
--- a/src/imageio/format/jxl.c
+++ b/src/imageio/format/jxl.c
@@ -386,7 +386,7 @@ int write_image(struct dt_imageio_module_data_t *data,
         chunk_size *= 2;
 
       out_len += chunk_size;
-      out_buf = g_realloc(out_buf, out_len);
+      out_buf = g_try_realloc(out_buf, out_len);
       if(!out_buf)
       {
         JXL_FAIL("could not reallocate codestream buffer to size %zu", out_len);

--- a/src/imageio/format/jxl.c
+++ b/src/imageio/format/jxl.c
@@ -388,10 +388,8 @@ int write_image(struct dt_imageio_module_data_t *data,
       out_len += chunk_size;
       out_buf = g_try_realloc(out_buf, out_len);
       if(!out_buf)
-      {
         JXL_FAIL("could not reallocate codestream buffer to size %zu", out_len);
-        goto end;
-      }
+
       out_cur = out_buf + offset;
       out_avail = out_len - offset;
     }


### PR DESCRIPTION
If allocation fails when using g_realloc (because the system runs out of memory), the program terminates. This PR replaces the unsafe function with g_try_realloc which returns NULL on failure.

Interestingly, the NULL check and the exit path were already here in the code, but the problem is that at some point someone replaced the realloc call (which was there before) with g_realloc, hoping that they had the same semantics... but they don't.

Since the size of the file being written, and therefore the size of the allocated buffer, can be quite large, the out-of-memory scenario is real, not just theoretical. So it might be worth considering this for 5.6.1, the change is clearly safe.

