### PR TITLE
Protection against dereferencing NULL that dt_bilateral_init can return

### DIFF
--- a/src/common/bilateral.c
+++ b/src/common/bilateral.c
@@ -201,13 +201,14 @@ dt_bilateral_t *dt_bilateral_init(const int width,     // width of input image
 DT_OMP_DECLARE_SIMD(aligned(in:64))
 void dt_bilateral_splat(const dt_bilateral_t *b, const float *const in)
 {
+  if(!b || !b->buf) return;
+
   const int ox = b->size_z;
   const int oy = b->size_x * b->size_z;
   const int oz = 1;
   const float sigma_s = b->sigma_s * b->sigma_s;
   float *const buf = b->buf;
 
-  if(!buf) return;
   // splat into downsampled grid
   const int nthreads = dt_get_num_threads();
   const size_t offsets[8] =
@@ -379,8 +380,7 @@ static void blur_line(float *buf,
 
 void dt_bilateral_blur(const dt_bilateral_t *b)
 {
-  if(!b || !b->buf)
-    return;
+  if(!b || !b->buf) return;
 
   const int ox = b->size_z;
   const int oy = b->size_x * b->size_z;
@@ -400,6 +400,8 @@ void dt_bilateral_slice(const dt_bilateral_t *const b,
                         float *out,
                         const float detail)
 {
+  if(!b || !b->buf) return;
+
   // detail: 0 is leave as is, -1 is bilateral filtered, +1 is contrast boost
   const float norm = -detail * b->sigma_r * 0.04f;
   const int ox = b->size_z;
@@ -409,7 +411,6 @@ void dt_bilateral_slice(const dt_bilateral_t *const b,
   const int width = b->width;
   const int height = b->height;
 
-  if(!buf) return;
   DT_OMP_FOR(collapse(2))
   for(int j = 0; j < height; j++)
   {
@@ -442,6 +443,8 @@ void dt_bilateral_slice_to_output(const dt_bilateral_t *const b,
                                   float *out,
                                   const float detail)
 {
+  if(!b || !b->buf) return;
+
   // detail: 0 is leave as is, -1 is bilateral filtered, +1 is contrast boost
   const float norm = -detail * b->sigma_r * 0.04f;
   const int ox = b->size_z;
@@ -451,7 +454,6 @@ void dt_bilateral_slice_to_output(const dt_bilateral_t *const b,
   const int width = b->width;
   const int height = b->height;
 
-  if(!buf) return;
   DT_OMP_FOR(collapse(2))
   for(int j = 0; j < height; j++)
   {

--- a/src/iop/globaltonemap.c
+++ b/src/iop/globaltonemap.c
@@ -298,6 +298,17 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
   if(data->detail != 0.0f)
   {
     b = dt_bilateral_init(roi_in->width, roi_in->height, sigma_s, sigma_r);
+    if(!b)
+    {
+      dt_print(DT_DEBUG_ALWAYS, "[globaltonemap] error: memory allocation failed for bilateral filter, the module does nothing");
+      dt_control_log(_("error: bilateral filter failed to allocate memory, check your RAM usage!"));
+      // Copy the input buffer to the output buffer, making the processing no-op
+      // Another possible option is to not copy the buffer so that the garbage
+      // output will be more likely to draw the user's attention to the warning
+      // that the operation cannot be performed
+      dt_iop_copy_image_roi(ovoid, ivoid, piece->colors, roi_in, roi_out);
+      return;
+    }
     // get detail from unchanged input buffer
     dt_bilateral_splat(b, (float *)ivoid);
   }

--- a/src/iop/monochrome.c
+++ b/src/iop/monochrome.c
@@ -225,6 +225,17 @@ void process(dt_iop_module_t *self,
   const float detail = -1.0f; // bilateral base layer
 
   dt_bilateral_t *b = dt_bilateral_init(roi_in->width, roi_in->height, sigma_s, sigma_r);
+  if(!b)
+  {
+    dt_print(DT_DEBUG_ALWAYS, "[monochrome] error: memory allocation failed for bilateral filter, the module does nothing");
+    dt_control_log(_("error: bilateral filter failed to allocate memory, check your RAM usage!"));
+    // Copy the input buffer to the output buffer, making the processing no-op
+    // Another possible option is to not copy the buffer so that the garbage
+    // output will be more likely to draw the user's attention to the warning
+    // that the operation cannot be performed
+    dt_iop_copy_image_roi(o, i, piece->colors, roi_in, roi_out);
+    return;
+  }
   dt_bilateral_splat(b, (float *)o);
   dt_bilateral_blur(b);
   dt_bilateral_slice(b, (float *)o, (float *)o, detail);


### PR DESCRIPTION
When we see that `dt_bilateral_init` failed, we need to exit processing. In two modules, such a check was not performed and as a result, when memory allocation in `dt_bilateral_init` failed, the code further called a function that was not NULL-safe and crashed.

The second commit makes `dt_bilateral_*` functions NULL-safe, which is also desirable, but does not eliminate the need for the first commit. A safer programming style is to check for an error situation and react accordingly (bailout) as early as possible.

It is also worth writing to the log and warning the user in the UI about the error situation. But this will be in the next PR, since this PR makes sense to merge in 5.6.1, where we do not add new strings to the UI.