### PR TITLE
Some fixes and a workaround for freeze on history compression

### DIFF
--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -1568,7 +1568,15 @@ void dt_masks_set_edit_mode(dt_iop_module_t *module,
   // stale. Re-validate it: this no-op clamp snaps the pan back into bounds so
   // the picture re-centres immediately instead of lingering off-centre (which
   // also leaves the renderer churning) until the next manual pan.
-  dt_dev_zoom_move(&darktable.develop->full, DT_ZOOM_MOVE, 0.0f, 0, 0.0f, 0.0f, TRUE);
+  //
+  // Not during a bulk history refresh: that reaches us from the
+  // dt_iop_gui_update() loop in dt_dev_pop_history_items(), which holds
+  // dev->history_mutex, whereas dt_dev_zoom_move() takes global_mutex and then
+  // history_mutex -- the reverse of the order a pixelpipe worker uses, so the
+  // two deadlock.  Nothing is lost: after a history reload the pipe is dirty,
+  // so dt_dev_process_image_job() runs the very same clamp itself.
+  if(!darktable.develop->history_updating)
+    dt_dev_zoom_move(&darktable.develop->full, DT_ZOOM_MOVE, 0.0f, 0, 0.0f, 0.0f, TRUE);
 
   dt_control_queue_redraw_center();
 }

--- a/src/libs/history.c
+++ b/src/libs/history.c
@@ -1249,6 +1249,14 @@ static void _lib_history_compress_pressed_callback(GtkGestureSingle *gesture,
                                                    gdouble y,
                                                    dt_lib_module_t *self)
 {
+  /* Claim the sequence, replacing the `return TRUE` of the button-press-event
+   * handler this gesture was converted from.  Without it GtkButton's own
+   * gesture still completes the click and emits "clicked", so
+   * _lib_history_compress_clicked_callback would run _lib_history_truncate()
+   * a second time -- on release, while the pixelpipe job started by this call
+   * is still running -- and ctrl+click would truncate and then compress. */
+  dt_gui_claim(gesture);
+
   const gboolean compress = !(dt_key_modifier_state() & GDK_CONTROL_MASK);
   _lib_history_truncate(compress);
 }
@@ -1272,6 +1280,12 @@ static void _lib_history_button_clicked_callback(GtkGestureSingle *gesture,
   // shift-click just show the corresponding module in modulegroups
   if(dt_key_modifier_state() & GDK_SHIFT_MASK)
   {
+    /* Claim the sequence, replacing the `return TRUE` of the button-press-event
+     * handler this gesture was converted from: the history entry must only be
+     * revealed in modulegroups, not selected, so GtkToggleButton must not get
+     * to complete the click and flip its state. */
+    dt_gui_claim(gesture);
+
     const int num = GPOINTER_TO_INT(g_object_get_data(G_OBJECT(widget), "history-number"));
     dt_dev_history_item_t *hist = g_list_nth_data(darktable.develop->history, num - 1);
     if(hist)


### PR DESCRIPTION
Fixes work for me locally, but received minimal testing, I'm rushing off to work. Analysis and fix/workaround by Claude.

Sorry, as noted in #21793, this may be unrelated - they also had an issue with history stack, but that was a crash; and they had a freeze, but not related to the history stack.

# Fix/workaround for darkroom freezing on "compress history stack"

## Symptom

In darkroom, with an unmodified (default) history stack, clicking *compress history stack* leaves "working..." on the centre view (sometimes I needed multiple click, but usually the freeze is immediate). CPU and GPU go idle, the whole UI stops responding, the process has to be killed.

## Root cause: lock-order inversion between `global_mutex` and `history_mutex`

Two threads take `darktable.control->global_mutex` and `dev->history_mutex` in opposite
orders and deadlock. Confirmed by `thread apply all bt` on a hung process (see [dt-hang.txt](https://github.com/user-attachments/files/31014390/dt-hang.txt)
).

**GUI thread — holds `history_mutex`, blocks on `global_mutex`:**

| frame | location |
| --- | --- |
| `_lib_history_truncate` | `libs/history.c:1211` |
| `dt_dev_reload_history_items` | `develop.c:1587` |
| `dt_dev_pop_history_items` | `develop.c:1739` — `history_mutex` taken at `develop.c:1726` |
| `dt_iop_gui_update` | `imageop.c:2452` |
| `dt_iop_gui_update_blending` | `blend_gui.c:3260` |
| `dt_iop_gui_update_masks` | `blend_gui.c:2743` |
| `dt_masks_set_edit_mode` | `masks.c:1571` |
| `dt_dev_zoom_move` | `develop.c:3243` — **blocks on `global_mutex`** |

**Full-pipe worker — holds `global_mutex`, blocks on `history_mutex`:**

| frame | location |
| --- | --- |
| `dt_dev_process_image_job` | `develop.c:793` |
| `dt_dev_zoom_move` | `global_mutex` at `develop.c:3243`, **blocks on `history_mutex` at `develop.c:3244`** |

The preview-pipe worker is also parked on `history_mutex`
(`dt_dev_distort_backtransform_plus`, `develop.c:3917`) — collateral, not part of the
cycle. `dt_control_busy_leave()` (`develop.c:899`) is never reached, which is why
"working..." stays on screen.

### Why it triggers on a default history stack

`dt_iop_gui_update_masks()` calls `dt_masks_set_edit_mode(module, DT_MASKS_EDIT_OFF)`
for every module that has no mask (`blend_gui.c:2739-2743`). On a default stack that is
essentially every module, so the GUI thread reaches `dt_dev_zoom_move()` many times
during the refresh. It only needs a pipe job in flight — which the compress itself
starts.

### Commit attribution

The commit that closes the cycle:

@masterpiga 
| commit | date | author | subject |
| --- | --- | --- | --- |
| `a0d25790ea` | 2026-06-06 | Daniele Pighin | Better mask editing near/outside image borders |

It added the `dt_dev_zoom_move()` call to `dt_masks_set_edit_mode()`, connecting the
module-GUI refresh path (which runs under `history_mutex`) to `global_mutex`. Before it,
the function ended at `dt_control_queue_redraw_center()` and took no locks.

It did not create the inversion — both halves predate it:

| commit | date | author | what it established |
| --- | --- | --- | --- |
| `135d5a62d9` | 2023-10-07 | Diederik ter Rahe | `dt_dev_zoom_move()` takes `history_mutex` (`develop.c:3244`) |
| `7ae37409b4` | 2024-11-30 | Hanno Schwalm | `global_mutex` added *in front of* it (`develop.c:3243`), fixing the order as global → history |
| `44f777cac9` | 2018-11-12 | edgardoh | `dt_dev_pop_history_items()` holds `history_mutex` across the `dt_iop_gui_update()` loop (the call itself dates to 2009) |

## Changes

### 1. `src/develop/masks/masks.c` — fixes the freeze

Skip the viewport clamp during a bulk history refresh, using the flag
`dt_dev_pop_history_items()` already sets around exactly that loop
(`develop.c:1732`/`1743`; `imageop.c:2460` uses the same discriminator):

```c
if(!darktable.develop->history_updating)
  dt_dev_zoom_move(&darktable.develop->full, DT_ZOOM_MOVE, 0.0f, 0, 0.0f, 0.0f, TRUE);
```

No behaviour is lost:

- After a history reload the pipe is dirty, so `dt_dev_process_image_job()` runs the
  identical clamp itself at `develop.c:793`.
- Manual toggling of the mask overlay still clamps synchronously — the handler
  `_blendop_masks_show_and_edit` is outside the `history_updating` window.

`DT_IN_GUI_UPDATE()` would **not** work as the discriminator: that handler wraps itself
in `DT_ENTER_GUI_UPDATE()` (`blend_gui.c:1701`), so the user path would be suppressed too.

### 2. `src/libs/history.c` — two unrelated GTK4-prep regressions

Both from:

@Arecsu 
| commit | date | author | subject |
| --- | --- | --- | --- |
| `050bfe23a8` | 2026-07-27 | Arecsu | gtk4-prep: lib module event controllers |

It converted `button-press-event` handlers returning `TRUE` into `GtkGestureMultiPress`
"pressed" handlers without claiming the sequence. The widget's own gesture therefore
still completes the click.

| site | effect | fix |
| --- | --- | --- |
| `_lib_history_compress_pressed_callback` | `"clicked"` still fires → `_lib_history_truncate()` runs twice per click; ctrl+click truncates and then compresses | `dt_gui_claim(gesture)` |
| `_lib_history_button_clicked_callback`, shift-click branch | the history entry is revealed in modulegroups *and* selected | `dt_gui_claim(gesture)` |

These are real bugs but **not** the freeze: the backtrace shows the GUI thread stuck
inside the *first* invocation.

## Why change 1 is not the root-cause fix

It removes the one call site that currently completes the cycle. The inversion itself
remains:

- `dt_dev_pop_history_items()` runs `dt_iop_gui_update()` for every module while holding
  `history_mutex` (`develop.c:1726-1778`).
- Any GUI-update side effect that reaches `global_mutex` — directly, or via
  `dt_dev_zoom_move()` / `dt_dev_get_viewport_params()` / `dt_control_get_mouse_over_id()`
  — re-creates the same deadlock.
- The required order (`global_mutex` before `history_mutex`) is documented only as a
  comment at `develop.c:1455`; nothing enforces it.

## Suggested follow-up

Move the module-GUI refresh loop out of the `history_mutex` region in
`dt_dev_pop_history_items()`. That needs an analysis of what the pipe workers may observe
between `dt_dev_pop_history_items_ext()` and the end of the GUI refresh, so it was not
attempted here.
