### PR TITLE
fix import progress count message

### DIFF
--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -3058,8 +3058,8 @@ static int32_t _control_import_job_run(dt_job_t *job)
     if(currtime - last_prog_update > PROGRESS_UPDATE_INTERVAL)
     {
       last_prog_update = currtime;
-      dt_control_job_set_progress_message(job, ngettext("importing %d/%d image",
-                                                        "importing %d/%d images", cntr), cntr, total);
+      dt_control_job_set_progress_message(job, _("importing image %d/%d"),
+                                               cntr, total);
       dt_control_job_set_progress(job, fraction);
       g_usleep(100);
     }


### PR DESCRIPTION
`ngettext()` allows only one variable.

fixes #21815
