### PR TITLE
lighttable: don't let a cancelled gesture re-select the hovered image

### DIFF
--- a/src/dtgtk/culling.c
+++ b/src/dtgtk/culling.c
@@ -1061,6 +1061,17 @@ static void _event_button_release_cb(GtkGestureSingle *gesture,
 {
   table->panning = FALSE;
 
+  /* A gesture cancel is relayed to this handler so widgets can clean up
+   * their pressed state, but it is not a click (issue #21813).  Only a
+   * real GDK button release may toggle the culling selection. */
+  GdkEvent *release_event = gtk_get_current_event();
+  if(!release_event || release_event->type != GDK_BUTTON_RELEASE)
+  {
+    gdk_event_free(release_event);
+    return;
+  }
+  gdk_event_free(release_event);
+
   const dt_imgid_t overid = dt_control_get_mouse_over_id();
   // if the act_on algorithm need a specific culling "selection",
   // we use a very simple culling-specific selection

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -1621,6 +1621,20 @@ static void _event_button_release_cb(GtkGestureSingle *gesture,
      && cv != DT_VIEW_PRINT)
     return;
 
+  /* A gesture cancel is relayed to this handler so widgets can clean up
+   * their pressed state, but it is not a click: cancels can also fire for
+   * a long-dead press while merely hovering (issue #21813 -- the thumbtable
+   * re-selected the hovered image).  Only a real GDK button release may
+   * select/toggle, exactly like the pre-gesture button-release-event
+   * handler. */
+  GdkEvent *release_event = gtk_get_current_event();
+  if(!release_event || release_event->type != GDK_BUTTON_RELEASE)
+  {
+    gdk_event_free(release_event);
+    return;
+  }
+  gdk_event_free(release_event);
+
   dt_set_backthumb_time(0.0);
   const dt_imgid_t id = dt_control_get_mouse_over_id();
 


### PR DESCRIPTION
Fixes #21813 — hovering over the thumbtable after returning from the darkroom changed the selected image. Move the mouse over an unselected thumbnail and the selection jumped to it, even with "prioritize hovered image over the selected images" disabled.

This was a regression from the event-signal → event-controller conversion (#21659), which changed how a click is delivered to the lighttable and culling views:

- **Hovering could fake a click.** The old button-release-event handler only ever ran on a real mouse-button release. The gesture machinery relays a cancelled press to the release handler so widgets can let go of their pressed state — the bauhaus sliders rely on that relay. But a press whose release never arrives (e.g. the second press of a double-click, which jumps to the darkroom on press) leaves a stale press behind, and the next pointer crossing into a thumbnail cancels it. The relayed release then ran the thumbtable's click logic and re-selected whatever image happened to be under the cursor.
- **The culling view had the same problem** and gets the same fix: a relayed release could silently toggle the culling selection while the pointer was just moving.

The release handlers now require a real `GDK_BUTTON_RELEASE` — the same guarantee the old signal-based handlers had — while the cancel→release relay stays for the pressed-state cleanup it was added for.

No behavior changes for actual clicks: single-click selection, double-click into the darkroom, and zoomable dragging all work as before.

Related: #21813 #21659