### PR TITLE
Fix zoomable lighttable trackpad pan/pinch and persist pan position

### DIFF
--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -1118,6 +1118,51 @@ static gboolean _event_scroll_compressed(gpointer user_data)
   return FALSE;
 }
 
+static gboolean _event_gesture(GtkWidget *widget,
+                               GdkEvent *event,
+                               gpointer user_data)
+{
+  dt_thumbtable_t *table = user_data;
+  if(dt_gdk_event_get_type(event) != GDK_TOUCHPAD_PINCH) return FALSE;
+  if(table->mode != DT_THUMBTABLE_MODE_ZOOM) return FALSE;
+
+  const GdkEventTouchpadPinch *pinch = &event->touchpad_pinch;
+
+  static int begin_zoom = 1;
+
+  if(pinch->phase == GDK_TOUCHPAD_GESTURE_PHASE_BEGIN)
+  {
+    begin_zoom = dt_view_lighttable_get_zoom(darktable.view_manager);
+    return TRUE;
+  }
+
+  if(pinch->phase == GDK_TOUCHPAD_GESTURE_PHASE_END
+     || pinch->phase == GDK_TOUCHPAD_GESTURE_PHASE_CANCEL)
+  {
+    begin_zoom = 1;
+    return TRUE;
+  }
+
+  if(pinch->phase != GDK_TOUCHPAD_GESTURE_PHASE_UPDATE)
+    return FALSE;
+
+  if(pinch->scale <= 0.0)
+    return FALSE;
+
+  const int old = dt_view_lighttable_get_zoom(darktable.view_manager);
+  const int newzoom = CLAMP((int)roundf(begin_zoom / pinch->scale), 1, DT_LIGHTTABLE_MAX_ZOOM);
+
+  // Anchor the zoom at the pinch focal point.
+  table->last_x = (int)pinch->x_root;
+  table->last_y = (int)pinch->y_root;
+  table->mouse_inside = TRUE;
+
+  if(newzoom != old)
+    dt_thumbtable_zoom_changed(table, old, newzoom);
+
+  return TRUE;
+}
+
 static void _event_scroll(GtkEventControllerScroll *controller,
                            gdouble dx,
                            gdouble dy,
@@ -1176,6 +1221,25 @@ static void _event_scroll(GtkEventControllerScroll *controller,
 #if !GTK_CHECK_VERSION(4, 0, 0)
     gdk_event_free(event);
 #endif
+    return;
+  }
+
+  // In zoomable mode a touchpad two-finger swipe pans the grid instead of
+  // zooming (pinch handles zoom). Mouse wheels and ctrl+scroll still zoom
+  // through the unit-delta path below.
+  if(table->mode == DT_THUMBTABLE_MODE_ZOOM
+     && dt_gui_scroll_should_pan(e))
+  {
+    gdouble ddx = 0.0, ddy = 0.0;
+    if(dt_gui_get_scroll_deltas(e, &ddx, &ddy)
+       && (ddx != 0.0 || ddy != 0.0))
+    {
+      const int pdx = (int)roundf(-ddx * DT_UI_SCROLL_SMOOTH_DELTA_SCALE);
+      const int pdy = (int)roundf(-ddy * DT_UI_SCROLL_SMOOTH_DELTA_SCALE);
+      if(pdx != 0 || pdy != 0)
+        _move(table, pdx, pdy, TRUE);
+    }
+    gdk_event_free(event);
     return;
   }
 
@@ -2659,7 +2723,8 @@ dt_thumbtable_t *dt_thumbtable_new()
                         GDK_EXPOSURE_MASK | GDK_POINTER_MOTION_MASK
                         | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK
                         | GDK_STRUCTURE_MASK
-                        | GDK_ENTER_NOTIFY_MASK | GDK_LEAVE_NOTIFY_MASK);
+                        | GDK_ENTER_NOTIFY_MASK | GDK_LEAVE_NOTIFY_MASK
+                        | GDK_TOUCHPAD_GESTURE_MASK);
 #endif
   dt_gui_add_class(table->widget, "dt_transparent_background");
   gtk_widget_set_can_focus(table->widget, TRUE);
@@ -2681,6 +2746,8 @@ dt_thumbtable_t *dt_thumbtable_new()
 
   dt_gui_connect_scroll(table->widget, GTK_EVENT_CONTROLLER_SCROLL_BOTH_AXES,
                         _event_scroll, table);
+  g_signal_connect(G_OBJECT(table->widget), "event",
+                   G_CALLBACK(_event_gesture), table);
   g_signal_connect(G_OBJECT(table->widget), "draw",
                    G_CALLBACK(_event_draw), table);
   dt_gui_connect_motion(table->widget, _event_motion_notify_cb, _event_enter_cb, _event_leave_cb, table);

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -410,7 +410,11 @@ static gboolean _compute_sizes(dt_thumbtable_t *table,
   }
   else if(table->mode == DT_THUMBTABLE_MODE_ZOOM)
   {
-    const int npr = dt_view_lighttable_get_zoom(darktable.view_manager);
+    // seed the continuous zoom from the slider the first time; afterwards the
+    // pinch/scroll gestures drive it directly
+    if(table->zoom <= 0.0f)
+      table->zoom = dt_view_lighttable_get_zoom(darktable.view_manager);
+    table->zoom = CLAMP(table->zoom, 1.0f, DT_LIGHTTABLE_MAX_ZOOM);
 
     if(force
        || allocation.width != table->view_width
@@ -419,7 +423,7 @@ static gboolean _compute_sizes(dt_thumbtable_t *table,
       table->thumbs_per_row = DT_ZOOMABLE_NB_PER_ROW;
       table->view_width = allocation.width;
       table->view_height = allocation.height;
-      table->thumb_size = table->view_width / npr;
+      table->thumb_size = (int)roundf(table->view_width / table->zoom);
       table->rows = (table->view_height - table->thumbs_area.y) / table->thumb_size + 1;
       table->center_offset = 0;
       ret = TRUE;
@@ -869,8 +873,8 @@ static dt_thumbnail_t *_thumbtable_get_thumb(dt_thumbtable_t *table,
 
 // change zoom value for the zoomable thumbtable
 static void _zoomable_zoom(dt_thumbtable_t *table,
-                           const int oldzoom,
-                           const int newzoom)
+                           const float oldzoom,
+                           const float newzoom)
 {
   // nothing to do if thumbtable is empty
   if(!table->list)
@@ -893,7 +897,7 @@ static void _zoomable_zoom(dt_thumbtable_t *table,
     y = table->view_height / 2;
   }
 
-  const int new_size = table->view_width / newzoom;
+  const int new_size = (int)roundf(table->view_width / newzoom);
   const double ratio = (double)new_size / (double)table->thumb_size;
 
   // we get row/column numbers of the image under cursor
@@ -931,6 +935,7 @@ static void _zoomable_zoom(dt_thumbtable_t *table,
 
   // we update table values
   table->thumb_size = new_size;
+  table->zoom = newzoom;
   _pos_compute_area(table);
 
   // we ensure there's still some visible thumbnails
@@ -978,7 +983,7 @@ static void _zoomable_zoom(dt_thumbtable_t *table,
   dt_conf_set_int("lighttable/zoomable/last_pos_x", table->thumbs_area.x);
   dt_conf_set_int("lighttable/zoomable/last_pos_y", table->thumbs_area.y);
 
-  dt_view_lighttable_set_zoom(darktable.view_manager, newzoom);
+  dt_view_lighttable_set_zoom(darktable.view_manager, (gint)roundf(newzoom));
   gtk_widget_queue_draw(table->widget);
 }
 
@@ -1043,8 +1048,8 @@ static void _filemanager_zoom(dt_thumbtable_t *table,
 }
 
 void dt_thumbtable_zoom_changed(dt_thumbtable_t *table,
-                                const int oldzoom,
-                                const int newzoom)
+                                const float oldzoom,
+                                const float newzoom)
 {
   if(oldzoom == newzoom)
     return;
@@ -1054,7 +1059,7 @@ void dt_thumbtable_zoom_changed(dt_thumbtable_t *table,
 
   if(table->mode == DT_THUMBTABLE_MODE_FILEMANAGER)
   {
-    _filemanager_zoom(table, oldzoom, newzoom);
+    _filemanager_zoom(table, (int)oldzoom, (int)newzoom);
   }
   else if(table->mode == DT_THUMBTABLE_MODE_ZOOM)
   {
@@ -1125,49 +1130,59 @@ static gboolean _event_scroll_compressed(gpointer user_data)
   return FALSE;
 }
 
-static gboolean _event_gesture(GtkWidget *widget,
-                               GdkEvent *event,
-                               gpointer user_data)
+/* touchpad pinch for the zoomable lighttable, via dt_gui_connect_pinch().
+ * The old GTK3-only "event" signal handler forwarded raw GDK_TOUCHPAD_PINCH
+ * events; GtkGestureZoom turns the phase field into the begin / update /
+ * end signals (and "end" fires on cancel as well), the same wiring the
+ * culling/lighttable views use. */
+static void _event_pinch(GtkGesture *gesture,
+                         const dt_gui_pinch_event_t *e,
+                         gpointer user_data)
 {
   dt_thumbtable_t *table = user_data;
-  if(dt_gdk_event_get_type(event) != GDK_TOUCHPAD_PINCH) return FALSE;
-  if(table->mode != DT_THUMBTABLE_MODE_ZOOM) return FALSE;
+  if(table->mode != DT_THUMBTABLE_MODE_ZOOM) return;
 
-  const GdkEventTouchpadPinch *pinch = &event->touchpad_pinch;
+  static float begin_zoom = 1.0f;
 
-  static int begin_zoom = 1;
-
-  if(pinch->phase == GDK_TOUCHPAD_GESTURE_PHASE_BEGIN)
+  if(e->phase == GDK_TOUCHPAD_GESTURE_PHASE_BEGIN)
   {
-    begin_zoom = dt_view_lighttable_get_zoom(darktable.view_manager);
-    return TRUE;
+    begin_zoom = (table->zoom > 0.0f) ? table->zoom
+                                      : dt_view_lighttable_get_zoom(darktable.view_manager);
+    return;
   }
 
-  if(pinch->phase == GDK_TOUCHPAD_GESTURE_PHASE_END
-     || pinch->phase == GDK_TOUCHPAD_GESTURE_PHASE_CANCEL)
+  if(e->phase == GDK_TOUCHPAD_GESTURE_PHASE_END)
   {
-    begin_zoom = 1;
-    return TRUE;
+    begin_zoom = 1.0f;
+    return;
   }
 
-  if(pinch->phase != GDK_TOUCHPAD_GESTURE_PHASE_UPDATE)
-    return FALSE;
+  if(e->phase != GDK_TOUCHPAD_GESTURE_PHASE_UPDATE)
+    return;
 
-  if(pinch->scale <= 0.0)
-    return FALSE;
-
-  const int old = dt_view_lighttable_get_zoom(darktable.view_manager);
-  const int newzoom = CLAMP((int)roundf(begin_zoom / pinch->scale), 1, DT_LIGHTTABLE_MAX_ZOOM);
-
-  // Anchor the zoom at the pinch focal point.
-  table->last_x = (int)pinch->x_root;
-  table->last_y = (int)pinch->y_root;
+  // Anchor the pinch at the focal point so the zoom keeps the spot under the
+  // fingers stable and the pan delta is measured from there.
+  table->last_x = (int)e->x;
+  table->last_y = (int)e->y;
   table->mouse_inside = TRUE;
 
-  if(newzoom != old)
-    dt_thumbtable_zoom_changed(table, old, newzoom);
+  // Combined pan component, mirroring the two-finger scroll pan (content
+  // moves against the finger motion) and the culling gesture_pinch.  This is
+  // what lets the user translate the grid without lifting their fingers.
+  if(e->dx != 0.0 || e->dy != 0.0)
+  {
+    const int pdx = (int)-roundf(e->dx);
+    const int pdy = (int)-roundf(e->dy);
+    if(pdx != 0 || pdy != 0)
+      _move(table, pdx, pdy, TRUE);
+  }
 
-  return TRUE;
+  // Continuous zoom component.
+  if(e->scale <= 0.0)
+    return;
+
+  const float newzoom = CLAMP(begin_zoom / e->scale, 1.0f, DT_LIGHTTABLE_MAX_ZOOM);
+  dt_thumbtable_zoom_changed(table, table->zoom, newzoom);
 }
 
 static void _event_scroll(GtkEventControllerScroll *controller,
@@ -1235,10 +1250,10 @@ static void _event_scroll(GtkEventControllerScroll *controller,
   // zooming (pinch handles zoom). Mouse wheels and ctrl+scroll still zoom
   // through the unit-delta path below.
   if(table->mode == DT_THUMBTABLE_MODE_ZOOM
-     && dt_gui_scroll_should_pan(e))
+     && dt_gui_scroll_should_pan((const GdkEvent *)e))
   {
     gdouble ddx = 0.0, ddy = 0.0;
-    if(dt_gui_get_scroll_deltas(e, &ddx, &ddy)
+    if(dt_gui_get_scroll_deltas((const GdkEvent *)e, &ddx, &ddy)
        && (ddx != 0.0 || ddy != 0.0))
     {
       const int pdx = (int)roundf(-ddx * DT_UI_SCROLL_SMOOTH_DELTA_SCALE);
@@ -1263,19 +1278,27 @@ static void _event_scroll(GtkEventControllerScroll *controller,
       // (a rotated wheel step) and right-without-shift (tilt/swipe) zoom in;
       // keep the accumulated magnitude for the step size
       const int dominant = abs(delta_x) > abs(delta_y) ? delta_x : delta_y;
-      const int delta =
-        dt_gui_scroll_zoom_delta((const GdkEvent *)e, delta_x, delta_y) > 0.0f
-          ? -abs(dominant)
-          : abs(dominant);
+      const gboolean zoom_in =
+        dt_gui_scroll_zoom_delta((const GdkEvent *)e, delta_x, delta_y) > 0.0f;
       if(table->mode == DT_THUMBTABLE_MODE_FILMSTRIP)
       {
+        const int delta = zoom_in ? -abs(dominant) : abs(dominant);
         const int sx = CLAMP(table->view_width / ((table->view_width / table->thumb_size / 2 + delta) * 2 + 1),
                              dt_conf_get_int("min_panel_height"),
                              dt_conf_get_int("max_panel_height"));
         dt_ui_panel_set_size(darktable.gui->ui, DT_UI_PANEL_BOTTOM, sx);
       }
+      else if(table->mode == DT_THUMBTABLE_MODE_ZOOM)
+      {
+        // continuous zoom: a wheel notch / smooth step moves the level by a
+        // fraction, keeping scroll consistent with the continuous pinch
+        const float delta = (zoom_in ? -1.0f : 1.0f) * (float)abs(dominant) * 0.25f;
+        const float new = CLAMP(table->zoom + delta, 1.0f, DT_LIGHTTABLE_MAX_ZOOM);
+        dt_thumbtable_zoom_changed(table, table->zoom, new);
+      }
       else
       {
+        const int delta = zoom_in ? -abs(dominant) : abs(dominant);
         const int old = dt_view_lighttable_get_zoom(darktable.view_manager);
         const int new = CLAMP(old + delta, 1, DT_LIGHTTABLE_MAX_ZOOM);
         dt_thumbtable_zoom_changed(table, old, new);
@@ -1634,12 +1657,27 @@ static void _event_button_press_cb(GtkGestureSingle *gesture,
 
   if(button == GDK_BUTTON_PRIMARY && n_press == 1)
   {
+    // Anchor the pan at the pointer position where the press landed.  Motion
+    // over thumbnails is delivered to the child thumbnails rather than to
+    // this motion controller, so last_x/y can be left pointing at the
+    // previous gesture when a drag starts on top of a thumbnail; using that
+    // stale position would make the first motion jump by the gap between the
+    // two (see #21826).
+    GdkEvent *event = dt_gui_get_current_event(GTK_EVENT_CONTROLLER(gesture));
+    gdouble rx = 0, ry = 0;
+    if(event) dt_gui_get_event_coords(event, &rx, &ry);
+    table->last_x = ceil(rx);
+    table->last_y = ceil(ry);
+
     table->dragging = TRUE;
     table->drag_dx = table->drag_dy = 0;
     table->drag_initial_imgid = id;
     table->drag_thumb = _thumbtable_get_thumb(table, id);
     if(table->drag_thumb)
       table->drag_thumb->moved = FALSE;
+#if !GTK_CHECK_VERSION(4, 0, 0)
+    if(event) gdk_event_free(event);
+#endif
   }
 }
 
@@ -2730,8 +2768,7 @@ dt_thumbtable_t *dt_thumbtable_new()
                         GDK_EXPOSURE_MASK | GDK_POINTER_MOTION_MASK
                         | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK
                         | GDK_STRUCTURE_MASK
-                        | GDK_ENTER_NOTIFY_MASK | GDK_LEAVE_NOTIFY_MASK
-                        | GDK_TOUCHPAD_GESTURE_MASK);
+                        | GDK_ENTER_NOTIFY_MASK | GDK_LEAVE_NOTIFY_MASK);
 #endif
   dt_gui_add_class(table->widget, "dt_transparent_background");
   gtk_widget_set_can_focus(table->widget, TRUE);
@@ -2753,12 +2790,27 @@ dt_thumbtable_t *dt_thumbtable_new()
 
   dt_gui_connect_scroll(table->widget, GTK_EVENT_CONTROLLER_SCROLL_BOTH_AXES,
                         _event_scroll, table);
-  g_signal_connect(G_OBJECT(table->widget), "event",
-                   G_CALLBACK(_event_gesture), table);
+  dt_gui_connect_pinch(table->widget, _event_pinch, table);
   g_signal_connect(G_OBJECT(table->widget), "draw",
                    G_CALLBACK(_event_draw), table);
-  dt_gui_connect_motion(table->widget, _event_motion_notify_cb, _event_enter_cb, _event_leave_cb, table);
-  dt_gui_connect_click_all(table->widget, _event_button_press_cb, _event_button_release_cb, table);
+  GtkEventController *motion_controller =
+    dt_gui_connect_motion(table->widget, _event_motion_notify_cb, _event_enter_cb, _event_leave_cb, table);
+  /* The padding around a thumbnail's image is covered by an event box with
+   * its own window, so motion there targets that event box and never
+   * reaches a TARGET-phase controller on the table.  Run in the BUBBLE
+   * phase so the table sees motion bubbling up from the thumbnails and can
+   * pan even when the drag starts on the letterboxing padding
+   * (see #21826). */
+  gtk_event_controller_set_propagation_phase(motion_controller, GTK_PHASE_BUBBLE);
+  GtkGestureSingle *click_gesture =
+    dt_gui_connect_click_all(table->widget, _event_button_press_cb, _event_button_release_cb, table);
+  /* The thumbnail widgets (in particular the event box covering the area
+   * around the image surface) consume button presses, so a bubble-phase
+   * click on a thumbnail would never reach the table.  Run the click in the
+   * capture phase so the zoomable lighttable can start panning from a press
+   * on any part of a thumbnail, including its letterboxing padding
+   * (see #21826). */
+  gtk_event_controller_set_propagation_phase(GTK_EVENT_CONTROLLER(click_gesture), GTK_PHASE_CAPTURE);
 
   // we register globals signals
   DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_COLLECTION_CHANGED,

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -836,7 +836,14 @@ static gboolean _move(dt_thumbtable_t *table,
   dt_conf_set_int("plugins/lighttable/collect/history_pos0", table->offset);
   if(table->mode == DT_THUMBTABLE_MODE_ZOOM)
   {
+    // Persist the pan position as soon as it changes. Depending on the
+    // platform/backend a mouse drag may be reported as a gesture cancel
+    // rather than a real button release, so relying on the release handler
+    // alone can leave a stale last_pos behind and make the next redraw snap
+    // back to the pre-pan position.
     dt_conf_set_int("lighttable/zoomable/last_offset", table->offset);
+    dt_conf_set_int("lighttable/zoomable/last_pos_x", table->thumbs_area.x);
+    dt_conf_set_int("lighttable/zoomable/last_pos_y", table->thumbs_area.y);
   }
 
   // update scrollbars

--- a/src/dtgtk/thumbtable.h
+++ b/src/dtgtk/thumbtable.h
@@ -69,6 +69,7 @@ typedef struct dt_thumbtable_t
   int thumbs_per_row; // number of image in a row (1 for filmstrip ; MAX_ZOOM for zoomable)
   int rows; // number of rows (the last one is not fully visible) for filmstrip it's the number of columns
   int thumb_size;              // demanded thumb size (real size can differ of 1 due to rounding)
+  float zoom;                  // continuous zoom level of the zoomable lighttable (thumb_size = view_width / zoom)
   int prefs_size;              // size value to determine overlays mode and css class
   int view_width, view_height; // last main widget size
   GdkRectangle thumbs_area;    // coordinate of all the currently loaded thumbs area
@@ -130,10 +131,11 @@ gboolean dt_thumbtable_set_offset_image(dt_thumbtable_t *table,
                                         const dt_imgid_t imgid,
                                         const gboolean redraw);
 
-// fired when the zoom level change
+// fired when the zoom level change.  Zoomable layout accepts a continuous
+// (float) zoom; filemanager/culling stay integer.
 void dt_thumbtable_zoom_changed(dt_thumbtable_t *table,
-                                const int oldzoom,
-                                const int newzoom);
+                                const float oldzoom,
+                                const float newzoom);
 
 // ensure that the mentioned image is visible by moving the view if needed
 gboolean dt_thumbtable_ensure_imgid_visibility(dt_thumbtable_t *table,

--- a/src/libs/tools/lighttable.c
+++ b/src/libs/tools/lighttable.c
@@ -42,6 +42,7 @@ typedef struct dt_lib_tool_lighttable_t
   GtkWidget *layout_preview;
   dt_lighttable_layout_t layout, base_layout;
   int current_zoom;
+  gboolean updating_zoom;  // true while we programmatically push a zoom value to the slider (avoid echo back)
   gboolean fullpreview_focus;
   dt_lighttable_culling_restriction_t culling_init_restriction;
 } dt_lib_tool_lighttable_t;
@@ -597,7 +598,8 @@ static void _lib_lighttable_zoom_slider_changed(GtkWidget *widget, dt_lib_module
   dt_lib_tool_lighttable_t *d = self->data;
 
   const int i = gtk_spin_button_get_value_as_int(GTK_SPIN_BUTTON(widget));
-  _set_zoom(self, i);
+  if(!d->updating_zoom)
+    _set_zoom(self, i);
   d->current_zoom = i;
 }
 
@@ -611,8 +613,15 @@ static dt_lighttable_layout_t _lib_lighttable_get_layout(dt_lib_module_t *self)
 static void _lib_lighttable_set_zoom(dt_lib_module_t *self, gint zoom)
 {
   dt_lib_tool_lighttable_t *d = self->data;
+  /* Setting the spin button emits "value-changed", which would echo the value
+   * back through _set_zoom()/dt_thumbtable_zoom_changed() and snap a
+   * continuous zoomable zoom to the rounded integer.  Suppress that echo
+   * while we push a programmatic value; the slider still displays the value,
+   * it just doesn't re-trigger the zoom. */
+  d->updating_zoom = TRUE;
   gtk_spin_button_set_value(GTK_SPIN_BUTTON(d->zoom), zoom);
   d->current_zoom = zoom;
+  d->updating_zoom = FALSE;
 }
 
 static gint _lib_lighttable_get_zoom(dt_lib_module_t *self)


### PR DESCRIPTION
Zoomable lighttable ignored trackpad gestures, and its pan position was only saved on button release, which could make the view snap back to where it was before the pan on some platforms.

This brings the zoomable lighttable's touchpad and mouse interaction in line with the culling/preview views, and makes panning actually stick:

- **Two-finger scrolling pans the grid, and pinch zooms.** A two-finger swipe moves the grid 1:1, while pinch-to-zoom works around the pinch focal point (mouse wheel and ctrl+scroll keep their previous zoom behavior).
- **Pinch can pan *and* zoom at the same time.** Following the same pattern as the culling/lighttable views, a single pinch now handles both the pan component (sliding your fingers in parallel) and the zoom component (spreading/pinching) without lifting your fingers. Note this functionality of pinch and zoom at the same time does NOT work on macOS, but seems to work right under Linux. This is due to GTK3. A GTK4 *should* fix this, unsure.
- **Zoom is now continuous, not stepped.** The zoomable grid used to jump between integer "thumbnails per row" levels. It now tracks a smooth, continuous zoom level, so pinch and scroll-wheel zoom feel fluid instead of snapping. The integer zoom box in the bottom toolbar stays as a convenient discrete control for mouse/keyboard users: it shows the rounded level and snaps to a level when you adjust it.
- **Panning works even when you start the drag on top of a thumbnail.** Pressing in the letterboxing padding around a photo used to do nothing (and dragging on a thumbnail could jump to a stale position). Drags now start cleanly from anywhere on a thumbnail and pan smoothly.
- **Pan position is persisted as the view moves, not only on release.** On some backends a drag can be delivered as a gesture cancel rather than a real button release, leaving a stale saved position; the next redraw would then restore the pre-pan view. The position is now written together with the offset as soon as the grid moves.
- **Reworked on the gtk4-prep event-controller infrastructure.** The pinch handler was migrated off the GTK3-only `"event"` signal onto the shared `dt_gui_connect_pinch()` helper, and the pan paths use the controller propagation phases, so the behavior holds up under GTK4.

### Known limitation

When pinch-zooming, the thumbnail *boxes* resize immediately, but the *image* inside each box catches up a frame or two later and briefly lags behind. That's because resizing a thumbnail re-renders its image surface at the new size (a full reload of the mipmap). Making it perfectly fluid would need the culling view's trick — a cheap scale during the gesture, then a real reload only when you lift your fingers — which is a larger change to how the grid renders thumbnails. It's left as a follow-up for now.