### PR TITLE
Install AI models from additional repositories

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -426,6 +426,13 @@
     <longdescription>GitHub repository for downloading AI models (format: owner/repo)</longdescription>
   </dtconfig>
   <dtconfig>
+    <name>plugins/ai/third_party_repositories</name>
+    <type>string</type>
+    <default></default>
+    <shortdescription>additional AI model repositories</shortdescription>
+    <longdescription>comma-separated list of additional GitHub repositories offering AI models (format: owner/repo,owner/repo). these are not maintained or reviewed by the darktable project; a model installed from one replaces any installed model of the same name. each listed repository is contacted when checking for model updates.</longdescription>
+  </dtconfig>
+  <dtconfig>
     <name>plugins/ai/models_path</name>
     <type>string</type>
     <default></default>

--- a/src/common/ai_models.c
+++ b/src/common/ai_models.c
@@ -104,6 +104,7 @@ static dt_ai_model_t *_model_copy(const dt_ai_model_t *src)
   copy->spatial_dim_w = g_strdup(src->spatial_dim_w);
   copy->is_default = src->is_default;
   copy->from_catalog = src->from_catalog;
+  copy->from_file = src->from_file;
   copy->enabled = src->enabled;
   copy->status = src->status;
   copy->download_progress = src->download_progress;
@@ -652,10 +653,45 @@ gboolean dt_ai_models_load_registry(void)
   return TRUE;
 }
 
-// where a model's publisher is recorded, alongside its /enabled sibling
+// where a model's origin is recorded, alongside its /enabled sibling
 static char *_origin_conf_key(const char *model_id)
 {
   return g_strdup_printf("%s%s/repository", CONF_MODEL_ENABLED_PREFIX, model_id);
+}
+
+// validate that a model_id is a plain directory name with no path separators
+// or ".." components that could escape the models directory
+static gboolean _valid_model_id(const char *model_id);
+
+// the key holds either an "owner/repo" or this word. a repository always
+// contains a slash, so the two can never be read for one another
+#define DT_AI_ORIGIN_FILE "file"
+
+// restore what was recorded when the model was installed. caller must hold
+// registry->lock, or own `model` outright
+static void _apply_origin(dt_ai_model_t *model)
+{
+  if(!model || model->repository || model->from_file
+     || !_valid_model_id(model->id))
+    return;
+
+  char *key = _origin_conf_key(model->id);
+  char *origin = dt_conf_key_exists(key) ? dt_conf_get_string(key) : NULL;
+  g_free(key);
+
+  if(!origin || !*origin)
+  {
+    g_free(origin);
+    return;
+  }
+
+  if(!g_strcmp0(origin, DT_AI_ORIGIN_FILE))
+  {
+    model->from_file = TRUE;
+    g_free(origin);
+  }
+  else
+    model->repository = origin;  // takes ownership
 }
 
 // a recorded publisher outlives the download support that fetched it, so
@@ -679,9 +715,6 @@ gboolean dt_ai_models_is_official_repository(const char *repository)
   return repository && official && !g_strcmp0(repository, official);
 }
 
-// validate that a model_id is a plain directory name with no path separators
-// or ".." components that could escape the models directory
-static gboolean _valid_model_id(const char *model_id);
 static dt_ai_model_t *_find_model_unlocked(dt_ai_registry_t *registry,
                                             const char *model_id);
 
@@ -857,20 +890,9 @@ void dt_ai_models_refresh_status(void)
     g_free(model_dir);
   }
 
-  // recover the publisher recorded at install time
+  // recover the origin recorded at install time
   for(GList *l3 = registry->models; l3; l3 = g_list_next(l3))
-  {
-    dt_ai_model_t *model = (dt_ai_model_t *)l3->data;
-    if(model->repository || !_valid_model_id(model->id)) continue;
-    char *key = _origin_conf_key(model->id);
-    if(dt_conf_key_exists(key))
-    {
-      char *origin = dt_conf_get_string(key);
-      if(origin && *origin) model->repository = origin;
-      else g_free(origin);
-    }
-    g_free(key);
-  }
+    _apply_origin((dt_ai_model_t *)l3->data);
 
   // pass 2: discover locally-installed models not in registry
   if(registry->models_dir)
@@ -898,14 +920,7 @@ void dt_ai_models_refresh_status(void)
           if(model)
           {
             model->status = DT_AI_MODEL_DOWNLOADED;
-            char *key = _origin_conf_key(entry_name);
-            if(dt_conf_key_exists(key))
-            {
-              char *origin = dt_conf_get_string(key);
-              if(origin && *origin) model->repository = origin;
-              else g_free(origin);
-            }
-            g_free(key);
+            _apply_origin(model);
             registry->models = g_list_append(registry->models, model);
             dt_print(DT_DEBUG_AI,
                      "[ai_models] discovered local model: %s (%s)",
@@ -1664,6 +1679,13 @@ char *dt_ai_models_install_local(const char *filepath)
     return g_strdup(_("failed to extract model archive"));
   }
 
+  // a file install is all we will ever know about where this came from:
+  // there is no repository to check back with and no digest to verify
+  // against. record it before the rescan, which reads the key back
+  char *origin_key = _origin_conf_key(installed_id);
+  dt_conf_set_string(origin_key, DT_AI_ORIGIN_FILE);
+  g_free(origin_key);
+
   // rescan models directory to pick up newly installed model
   dt_ai_models_refresh_status();
 
@@ -1745,6 +1767,9 @@ char *dt_ai_models_download_sync(const char *model_id,
   // copy fields we need outside the lock (repository can be replaced by reload)
   char *asset = g_strdup(model->github_asset);
   char *checksum_copy = g_strdup(model->checksum);
+  // the fallback below hides whether the model names a publisher of its
+  // own, which is what gets recorded once the download lands
+  const gboolean has_own_repository = model->repository != NULL;
   char *repository = g_strdup(model->repository ? model->repository
                                                 : registry->repository);
   g_mutex_unlock(&registry->lock);
@@ -2050,6 +2075,10 @@ retry_done:
   // compile, not a stale artifact from the previous model file
   dt_ai_backend_cache_invalidate(model_id);
 
+  // a download supersedes whatever was recorded before, so an id that was
+  // once installed from a file stops claiming to be one
+  dt_ai_models_record_origin(model_id, has_own_repository ? repository : NULL);
+
   // mark success
   g_mutex_lock(&registry->lock);
   dt_ai_model_t *m = _find_model_unlocked(registry, model_id);
@@ -2057,6 +2086,7 @@ retry_done:
   {
     m->status = DT_AI_MODEL_DOWNLOADED;
     m->download_progress = 1.0;
+    m->from_file = FALSE;
   }
   g_mutex_unlock(&registry->lock);
 

--- a/src/common/ai_models.c
+++ b/src/common/ai_models.c
@@ -53,6 +53,7 @@ struct dt_ai_registry_t
 // config keys
 #define CONF_AI_ENABLED "plugins/ai/enabled"
 #define CONF_AI_REPOSITORY "plugins/ai/repository"
+#define CONF_AI_THIRD_PARTY_REPOSITORIES "plugins/ai/third_party_repositories"
 #define CONF_MODEL_ENABLED_PREFIX "plugins/ai/models/"
 #define CONF_ACTIVE_MODEL_PREFIX "plugins/ai/models/active/"
 
@@ -76,6 +77,7 @@ static void _model_free(dt_ai_model_t *model)
   g_free(model->description);
   g_free(model->task);
   g_free(model->github_asset);
+  g_free(model->repository);
   g_free(model->checksum);
   g_free(model->version);
   g_free(model->min_version);
@@ -94,10 +96,14 @@ static dt_ai_model_t *_model_copy(const dt_ai_model_t *src)
   copy->description = g_strdup(src->description);
   copy->task = g_strdup(src->task);
   copy->github_asset = g_strdup(src->github_asset);
+  copy->repository = g_strdup(src->repository);
   copy->checksum = g_strdup(src->checksum);
   copy->version = g_strdup(src->version);
   copy->min_version = g_strdup(src->min_version);
+  copy->spatial_dim_h = g_strdup(src->spatial_dim_h);
+  copy->spatial_dim_w = g_strdup(src->spatial_dim_w);
   copy->is_default = src->is_default;
+  copy->from_catalog = src->from_catalog;
   copy->enabled = src->enabled;
   copy->status = src->status;
   copy->download_progress = src->download_progress;
@@ -265,16 +271,15 @@ static char *_find_latest_compatible_release(const char *repository, char **erro
   return tag;
 }
 
-// Fallback SHA lookup for downloads when check_updates hasn't run yet.
-// Fetches versions.json from the release (CDN, not api.github.com).
-static char *_fetch_asset_digest(
+// fetch a release's versions.json (CDN, not api.github.com) and return its
+// parsed "models" object, or NULL; the parser owns the object, so it is
+// returned through `out_parser` for the caller to unref when done
+static JsonObject *_fetch_versions_json(
   const char *repository,
   const char *release_tag,
-  const char *asset_name)
+  JsonParser **out_parser)
 {
-  char *model_id = g_strdup(asset_name);
-  char *ext = strrchr(model_id, '.');
-  if(ext && g_strcmp0(ext, ".dtmodel") == 0) *ext = '\0';
+  *out_parser = NULL;
 
   char *url = g_strdup_printf(
     "https://github.com/%s/releases/download/%s/versions.json",
@@ -284,7 +289,6 @@ static char *_fetch_asset_digest(
   if(!curl)
   {
     g_free(url);
-    g_free(model_id);
     return NULL;
   }
   dt_curl_init(curl, FALSE);
@@ -294,7 +298,7 @@ static char *_fetch_asset_digest(
   curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, _curl_write_string);
   curl_easy_setopt(curl, CURLOPT_WRITEDATA, response);
   curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, 5L);
-  curl_easy_setopt(curl, CURLOPT_TIMEOUT, 5L);
+  curl_easy_setopt(curl, CURLOPT_TIMEOUT, 15L);
 
   CURLcode res = curl_easy_perform(curl);
   long http_code = 0;
@@ -308,7 +312,6 @@ static char *_fetch_asset_digest(
              "[ai_models] failed to fetch versions.json: curl=%d, http=%ld",
              res, http_code);
     g_string_free(response, TRUE);
-    g_free(model_id);
     return NULL;
   }
 
@@ -317,44 +320,78 @@ static char *_fetch_asset_digest(
   {
     g_object_unref(parser);
     g_string_free(response, TRUE);
-    g_free(model_id);
     return NULL;
   }
   g_string_free(response, TRUE);
 
   JsonNode *root = json_parser_get_root(parser);
-  char *digest = NULL;
-  if(root && JSON_NODE_HOLDS_OBJECT(root))
+  if(!root || !JSON_NODE_HOLDS_OBJECT(root))
   {
-    JsonObject *root_obj = json_node_get_object(root);
-    if(json_object_has_member(root_obj, "models"))
-    {
-      JsonObject *models_obj = json_object_get_object_member(root_obj, "models");
-      if(json_object_has_member(models_obj, model_id))
-      {
-        JsonNode *m_node = json_object_get_member(models_obj, model_id);
-        if(JSON_NODE_HOLDS_OBJECT(m_node))
-        {
-          JsonObject *m_obj = json_node_get_object(m_node);
-          if(json_object_has_member(m_obj, "sha256"))
-          {
-            const char *s = json_object_get_string_member(m_obj, "sha256");
-            if(s && g_str_has_prefix(s, "sha256:"))
-            {
-              digest = g_strdup(s);
-              dt_print(DT_DEBUG_AI,
-                       "[ai_models] asset %s digest from versions.json: %s",
-                       asset_name, digest);
-            }
-          }
-        }
-      }
-    }
+    g_object_unref(parser);
+    return NULL;
   }
 
-  g_object_unref(parser);
+  JsonObject *root_obj = json_node_get_object(root);
+  if(!json_object_has_member(root_obj, "models"))
+  {
+    dt_print(DT_DEBUG_AI, "[ai_models] versions.json has no 'models' object");
+    g_object_unref(parser);
+    return NULL;
+  }
 
-  if(!digest)
+  *out_parser = parser;
+  return json_object_get_object_member(root_obj, "models");
+}
+
+// optional string member, NULL when absent or empty. everything beyond
+// "version" and "sha256" arrived with schema 1
+static char *_versions_string(JsonObject *m_obj, const char *key)
+{
+  if(!m_obj || !json_object_has_member(m_obj, key))
+    return NULL;
+  const char *s = json_object_get_string_member(m_obj, key);
+  return (s && *s) ? g_strdup(s) : NULL;
+}
+
+// one model's "sha256" from a parsed versions.json "models" object;
+// NULL when absent or not sha256-prefixed
+static char *_digest_from_versions(JsonObject *models_obj, const char *model_id)
+{
+  if(!models_obj || !json_object_has_member(models_obj, model_id))
+    return NULL;
+
+  JsonNode *m_node = json_object_get_member(models_obj, model_id);
+  if(!m_node || !JSON_NODE_HOLDS_OBJECT(m_node))
+    return NULL;
+
+  JsonObject *m_obj = json_node_get_object(m_node);
+  if(!json_object_has_member(m_obj, "sha256"))
+    return NULL;
+
+  const char *s = json_object_get_string_member(m_obj, "sha256");
+  return (s && g_str_has_prefix(s, "sha256:")) ? g_strdup(s) : NULL;
+}
+
+// fallback SHA lookup for downloads when check_updates hasn't run yet
+static char *_fetch_asset_digest(
+  const char *repository,
+  const char *release_tag,
+  const char *asset_name)
+{
+  char *model_id = g_strdup(asset_name);
+  char *ext = strrchr(model_id, '.');
+  if(ext && g_strcmp0(ext, ".dtmodel") == 0) *ext = '\0';
+
+  JsonParser *parser = NULL;
+  JsonObject *models_obj = _fetch_versions_json(repository, release_tag, &parser);
+  char *digest = _digest_from_versions(models_obj, model_id);
+  if(parser) g_object_unref(parser);
+
+  if(digest)
+    dt_print(DT_DEBUG_AI,
+             "[ai_models] asset %s digest from versions.json: %s",
+             asset_name, digest);
+  else
     dt_print(DT_DEBUG_AI,
              "[ai_models] no sha256 for %s in versions.json (release %s)",
              model_id, release_tag);
@@ -489,6 +526,7 @@ static dt_ai_model_t *_parse_model_json(JsonObject *obj)
     return NULL;
 
   dt_ai_model_t *model = _model_new();
+  model->from_catalog = TRUE;
   model->id = g_strdup(json_object_get_string_member(obj, "id"));
   model->name = g_strdup(json_object_get_string_member(obj, "name"));
   model->github_asset = g_strdup_printf("%s.dtmodel", model->id);
@@ -612,6 +650,33 @@ gboolean dt_ai_models_load_registry(void)
   dt_ai_models_refresh_status();
 
   return TRUE;
+}
+
+// where a model's publisher is recorded, alongside its /enabled sibling
+static char *_origin_conf_key(const char *model_id)
+{
+  return g_strdup_printf("%s%s/repository", CONF_MODEL_ENABLED_PREFIX, model_id);
+}
+
+// a recorded publisher outlives the download support that fetched it, so
+// asking who published a model must not depend on HAVE_AI_DOWNLOAD.
+//
+// there is one definition of "official" and plugins/ai/repository holds it,
+// defaulting to darktable-org/darktable-ai from darktableconfig.xml. an
+// installation pointed at a mirror is still being served official models,
+// so nothing here compares against a second, pinned name.
+// no lock: the string is written once at load and freed at cleanup, the
+// same treatment models_dir gets
+const char *dt_ai_models_official_repository(void)
+{
+  const dt_ai_registry_t *registry = darktable.ai_registry;
+  return registry ? registry->repository : NULL;
+}
+
+gboolean dt_ai_models_is_official_repository(const char *repository)
+{
+  const char *official = dt_ai_models_official_repository();
+  return repository && official && !g_strcmp0(repository, official);
 }
 
 // validate that a model_id is a plain directory name with no path separators
@@ -750,6 +815,23 @@ void dt_ai_models_refresh_status(void)
         g_free(model->spatial_dim_w);
         model->spatial_dim_h = g_strdup(local->spatial_dim_h);
         model->spatial_dim_w = g_strdup(local->spatial_dim_w);
+
+        // for anything not from the bundled catalog, the installed
+        // config.json is the only description we have. catalog entries keep
+        // their curated name and task
+        if(!model->from_catalog)
+        {
+          if(local->name && local->name[0])
+          {
+            g_free(model->name);
+            model->name = g_strdup(local->name);
+          }
+          if(local->task && local->task[0])
+          {
+            g_free(model->task);
+            model->task = g_strdup(local->task);
+          }
+        }
         _model_free(local);
 
         // check if installed version meets minimum requirement
@@ -773,6 +855,21 @@ void dt_ai_models_refresh_status(void)
 
     g_free(config_path);
     g_free(model_dir);
+  }
+
+  // recover the publisher recorded at install time
+  for(GList *l3 = registry->models; l3; l3 = g_list_next(l3))
+  {
+    dt_ai_model_t *model = (dt_ai_model_t *)l3->data;
+    if(model->repository || !_valid_model_id(model->id)) continue;
+    char *key = _origin_conf_key(model->id);
+    if(dt_conf_key_exists(key))
+    {
+      char *origin = dt_conf_get_string(key);
+      if(origin && *origin) model->repository = origin;
+      else g_free(origin);
+    }
+    g_free(key);
   }
 
   // pass 2: discover locally-installed models not in registry
@@ -801,6 +898,14 @@ void dt_ai_models_refresh_status(void)
           if(model)
           {
             model->status = DT_AI_MODEL_DOWNLOADED;
+            char *key = _origin_conf_key(entry_name);
+            if(dt_conf_key_exists(key))
+            {
+              char *origin = dt_conf_get_string(key);
+              if(origin && *origin) model->repository = origin;
+              else g_free(origin);
+            }
+            g_free(key);
             registry->models = g_list_append(registry->models, model);
             dt_print(DT_DEBUG_AI,
                      "[ai_models] discovered local model: %s (%s)",
@@ -818,14 +923,34 @@ void dt_ai_models_refresh_status(void)
   g_mutex_unlock(&registry->lock);
 }
 
-// takes ownership of `parser`
+#ifdef HAVE_AI_DOWNLOAD
+// one repository's versions.json, on its way to the main thread. which
+// repository it came from decides who it speaks for
+typedef struct dt_ai_updates_t
+{
+  JsonParser *parser;
+  char *repository;          // where these versions were published
+  char *default_repository;  // what an unrecorded publisher resolves to
+} dt_ai_updates_t;
+
+static void _updates_free(dt_ai_updates_t *upd)
+{
+  if(!upd) return;
+  if(upd->parser) g_object_unref(upd->parser);
+  g_free(upd->repository);
+  g_free(upd->default_repository);
+  g_free(upd);
+}
+
+// takes ownership of `upd`
 static gboolean _apply_updates_idle(gpointer user_data)
 {
-  JsonParser *parser = (JsonParser *)user_data;
+  dt_ai_updates_t *upd = (dt_ai_updates_t *)user_data;
+  JsonParser *parser = upd->parser;
   dt_ai_registry_t *registry = darktable.ai_registry;
   if(!registry)
   {
-    g_object_unref(parser);
+    _updates_free(upd);
     return G_SOURCE_REMOVE;
   }
 
@@ -838,10 +963,10 @@ static gboolean _apply_updates_idle(gpointer user_data)
 
   if(!models_obj)
   {
-    g_object_unref(parser);
     dt_print(DT_DEBUG_AI,
-             "[ai_models] check_updates: no 'models' object in "
-             "versions.json");
+             "[ai_models] check_updates: no 'models' object in %s's "
+             "versions.json", upd->repository);
+    _updates_free(upd);
     return G_SOURCE_REMOVE;
   }
 
@@ -850,6 +975,15 @@ static gboolean _apply_updates_idle(gpointer user_data)
   for(GList *l = registry->models; l; l = g_list_next(l))
   {
     dt_ai_model_t *model = (dt_ai_model_t *)l->data;
+
+    // a versions.json speaks only for its own repository. an id another
+    // repository happens to reuse is a different model: its digest would
+    // fail verification and its version means nothing here. a model with
+    // no recorded publisher follows whatever plugins/ai/repository points at
+    const char *owner = model->repository ? model->repository
+                                          : upd->default_repository;
+    if(g_strcmp0(owner, upd->repository) != 0) continue;
+
     if(!json_object_has_member(models_obj, model->id)) continue;
 
     JsonNode *m_node = json_object_get_member(models_obj, model->id);
@@ -880,7 +1014,7 @@ static gboolean _apply_updates_idle(gpointer user_data)
     }
   }
   g_mutex_unlock(&registry->lock);
-  g_object_unref(parser);
+  _updates_free(upd);
 
   DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_AI_MODELS_CHANGED);
   return G_SOURCE_REMOVE;
@@ -935,15 +1069,15 @@ static gpointer _check_updates_worker(gpointer data)
   curl_easy_cleanup(curl);
   g_free(url);
   g_free(release_tag);
-  g_free(repository);
 
   if(res != CURLE_OK || http_code != 200)
   {
     dt_print(DT_DEBUG_AI,
-             "[ai_models] check_updates: failed to fetch versions.json"
+             "[ai_models] check_updates: failed to fetch %s's versions.json"
              " (curl=%d, http=%ld)",
-             res, http_code);
+             repository, res, http_code);
     g_string_free(response, TRUE);
+    g_free(repository);
     return NULL;
   }
 
@@ -955,12 +1089,27 @@ static gpointer _check_updates_worker(gpointer data)
     g_object_unref(parser);
     g_string_free(response, TRUE);
     dt_print(DT_DEBUG_AI,
-             "[ai_models] check_updates: failed to parse versions.json");
+             "[ai_models] check_updates: failed to parse %s's versions.json",
+             repository);
+    g_free(repository);
     return NULL;
   }
   g_string_free(response, TRUE);
 
-  g_idle_add(_apply_updates_idle, parser);
+  dt_ai_updates_t *upd = g_malloc0(sizeof(dt_ai_updates_t));
+  upd->parser = parser;
+  upd->repository = repository;  // takes ownership
+  // read here rather than on the main thread: it is what the model list
+  // was built against, and re-reading later could disagree
+  dt_ai_registry_t *registry = darktable.ai_registry;
+  if(registry)
+  {
+    g_mutex_lock(&registry->lock);
+    upd->default_repository = g_strdup(registry->repository);
+    g_mutex_unlock(&registry->lock);
+  }
+
+  g_idle_add(_apply_updates_idle, upd);
   return NULL;
 }
 
@@ -977,20 +1126,29 @@ void dt_ai_models_check_updates(void)
     return;
   }
   registry->updates_checked = TRUE;
-  char *repository = g_strdup(registry->repository);
   g_mutex_unlock(&registry->lock);
 
-  if(!repository || !repository[0])
+  // every repository publishes its own versions.json, so a model only
+  // learns about updates from the one it came from. checking just the
+  // official repository would leave everything else on its install version
+  GList *repositories = dt_ai_models_get_repositories();
+
+  for(GList *l = repositories; l; l = g_list_next(l))
   {
-    g_free(repository);
-    return;
+    // detached: worker owns its repository string, off the GTK main thread
+    GThread *t = g_thread_new("ai-model-updates", _check_updates_worker,
+                              l->data);
+    g_thread_unref(t);
   }
 
-  // detached: worker owns `repository`, off the GTK main thread
-  GThread *t = g_thread_new("ai-model-updates",
-                            _check_updates_worker, repository);
-  g_thread_unref(t);
+  // the strings themselves belong to the workers now
+  g_list_free(repositories);
 }
+#else
+// checking for updates is entirely network work, so a build without
+// download support has nothing to do here
+void dt_ai_models_check_updates(void) {}
+#endif // HAVE_AI_DOWNLOAD
 
 void dt_ai_models_cleanup(void)
 {
@@ -1587,7 +1745,8 @@ char *dt_ai_models_download_sync(const char *model_id,
   // copy fields we need outside the lock (repository can be replaced by reload)
   char *asset = g_strdup(model->github_asset);
   char *checksum_copy = g_strdup(model->checksum);
-  char *repository = g_strdup(registry->repository);
+  char *repository = g_strdup(model->repository ? model->repository
+                                                : registry->repository);
   g_mutex_unlock(&registry->lock);
 
 // helper macro: set model status under lock and return error
@@ -1659,6 +1818,21 @@ char *dt_ai_models_download_sync(const char *model_id,
     }
   }
 
+  // this string is about to name a file, and versions.json comes from a
+  // repository that need not be trusted
+  const char *digest = g_str_has_prefix(checksum_copy, "sha256:")
+    ? checksum_copy + strlen("sha256:")
+    : NULL;
+  if(!digest
+     || strspn(digest, "0123456789abcdefABCDEF") != 64
+     || digest[64])
+  {
+    g_free(release_tag);
+    SET_STATUS_AND_RETURN(
+      DT_AI_MODEL_ERROR,
+      g_strdup_printf(_("malformed checksum for %s"), asset));
+  }
+
   // build github download url using local copies (not model pointer)
   char *url = g_strdup_printf(
     "https://github.com/%s/releases/download/%s/%s",
@@ -1675,8 +1849,14 @@ char *dt_ai_models_download_sync(const char *model_id,
   dt_print(DT_DEBUG_AI, "[ai_models] downloading: %s", url);
 
   // write to a .part temp file so interrupted transfers can resume from
-  // the partial bytes; rename to final path only on success
-  char *final_path = g_build_filename(registry->cache_dir, asset, NULL);
+  // the partial bytes; rename to final path only on success.
+  // named for the content, not the asset: two repositories publish the
+  // same <id>.dtmodel, and so do two releases of one. resuming across them
+  // splices unrelated bytes into a file that then fails verification for
+  // no reason the user can act on
+  char *cache_name = g_strdup_printf("%s.dtmodel", digest);
+  char *final_path = g_build_filename(registry->cache_dir, cache_name, NULL);
+  g_free(cache_name);
   char *download_path = g_strconcat(final_path, ".part", NULL);
 
   dt_ai_download_data_t dl = {
@@ -1967,6 +2147,407 @@ gboolean dt_ai_models_download_all(dt_ai_progress_callback callback,
   g_list_free_full(ids, g_free);
   return any_started;
 }
+
+// "owner/repo" reaches a URL, and the list comes from a file anyone can
+// edit, so every entry gets the same check the download applies
+static gboolean _valid_repository(const char *repo)
+{
+  return repo
+    && g_regex_match_simple("^[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+$", repo, 0, 0);
+}
+
+GList *dt_ai_models_get_third_party_repositories(void)
+{
+  GList *repos = NULL;
+
+  char *configured = dt_conf_get_string(CONF_AI_THIRD_PARTY_REPOSITORIES);
+  if(configured && *configured)
+  {
+    gchar **parts = g_strsplit(configured, ",", 0);
+    for(gchar **p = parts; p && *p; p++)
+    {
+      gchar *repo = g_strstrip(*p);
+      if(!_valid_repository(repo))
+      {
+        if(*repo)
+          dt_print(DT_DEBUG_AI,
+                   "[ai_models] ignoring malformed repository: \"%s\"", repo);
+        continue;
+      }
+      // listed twice would fetch twice and offer duplicates
+      if(!g_list_find_custom(repos, repo, (GCompareFunc)g_strcmp0))
+        repos = g_list_append(repos, g_strdup(repo));
+    }
+    g_strfreev(parts);
+  }
+  g_free(configured);
+
+  return repos;
+}
+
+void dt_ai_models_set_third_party_repositories(GList *repositories)
+{
+  GString *joined = g_string_new(NULL);
+  for(GList *l = repositories; l; l = g_list_next(l))
+  {
+    if(joined->len) g_string_append_c(joined, ',');
+    g_string_append(joined, (const char *)l->data);
+  }
+  dt_conf_set_string(CONF_AI_THIRD_PARTY_REPOSITORIES, joined->str);
+  g_string_free(joined, TRUE);
+}
+
+GList *dt_ai_models_get_repositories(void)
+{
+  GList *repos = NULL;
+
+  char *configured = dt_conf_get_string(CONF_AI_REPOSITORY);
+  if(_valid_repository(configured))
+    repos = g_list_append(repos, g_strdup(configured));
+  g_free(configured);
+
+  for(GList *l = dt_ai_models_get_third_party_repositories(); l; )
+  {
+    GList *next = g_list_next(l);
+    if(g_list_find_custom(repos, l->data, (GCompareFunc)g_strcmp0))
+      g_free(l->data);
+    else
+      repos = g_list_append(repos, l->data);  // takes ownership
+    g_list_free_1(l);
+    l = next;
+  }
+
+  return repos;
+}
+
+static void _repo_model_free(gpointer data)
+{
+  dt_ai_repo_model_t *entry = (dt_ai_repo_model_t *)data;
+  if(!entry) return;
+  g_free(entry->id);
+  g_free(entry->repository);
+  g_free(entry->version);
+  g_free(entry->checksum);
+  g_free(entry->name);
+  g_free(entry->description);
+  g_free(entry->task);
+  g_free(entry->license);
+  g_free(entry);
+}
+
+void dt_ai_repo_model_list_free(GList *list)
+{
+  g_list_free_full(list, _repo_model_free);
+}
+
+static int _repo_model_cmp_id(gconstpointer a, gconstpointer b)
+{
+  const dt_ai_repo_model_t *ma = (const dt_ai_repo_model_t *)a;
+  const dt_ai_repo_model_t *mb = (const dt_ai_repo_model_t *)b;
+  return g_strcmp0(ma->id, mb->id);
+}
+
+GList *dt_ai_models_fetch_repository_list(const char *requested,
+                                          char **error_msg)
+{
+  if(error_msg) *error_msg = NULL;
+
+  dt_ai_registry_t *registry = darktable.ai_registry;
+  if(!registry)
+  {
+    if(error_msg) *error_msg = g_strdup(_("ai subsystem is not available"));
+    return NULL;
+  }
+
+  char *repository = NULL;
+  if(requested)
+  {
+    repository = g_strdup(requested);
+  }
+  else
+  {
+    g_mutex_lock(&registry->lock);
+    repository = g_strdup(registry->repository);
+    g_mutex_unlock(&registry->lock);
+  }
+
+  if(!_valid_repository(repository))
+  {
+    if(error_msg) *error_msg = g_strdup(_("invalid repository format"));
+    g_free(repository);
+    return NULL;
+  }
+
+  char *release_error = NULL;
+  char *release_tag = _find_latest_compatible_release(repository, &release_error);
+  if(!release_tag)
+  {
+    if(error_msg)
+    {
+      if(release_error)
+      {
+        *error_msg = release_error;
+        release_error = NULL;
+      }
+      else
+      {
+        char *dt_ver = _get_darktable_version_prefix();
+        *error_msg = g_strdup_printf(
+          _("no compatible ai model release found for darktable %s"),
+          dt_ver ? dt_ver : darktable_package_version);
+        g_free(dt_ver);
+      }
+    }
+    g_free(release_error);
+    g_free(repository);
+    return NULL;
+  }
+
+  JsonParser *parser = NULL;
+  JsonObject *models_obj = _fetch_versions_json(repository, release_tag, &parser);
+  if(!models_obj)
+  {
+    if(error_msg)
+      *error_msg = g_strdup_printf(
+        _("could not read the model list published by %s (release %s)"),
+        repository, release_tag);
+    if(parser) g_object_unref(parser);
+    g_free(release_tag);
+    g_free(repository);
+    return NULL;
+  }
+
+  const gboolean official = dt_ai_models_is_official_repository(repository);
+  GList *result = NULL;
+  GList *members = json_object_get_members(models_obj);
+
+  for(GList *m = members; m; m = g_list_next(m))
+  {
+    const char *id = (const char *)m->data;
+
+    // the id becomes a directory name and a conf key
+    if(!_valid_model_id(id))
+    {
+      dt_print(DT_DEBUG_AI,
+               "[ai_models] repository lists an invalid model id: \"%s\"", id);
+      continue;
+    }
+
+    // no digest means the download would refuse it anyway
+    char *checksum = _digest_from_versions(models_obj, id);
+    if(!checksum)
+    {
+      dt_print(DT_DEBUG_AI,
+               "[ai_models] skipping %s: no sha256 in versions.json", id);
+      continue;
+    }
+
+    JsonObject *m_obj
+      = json_node_get_object(json_object_get_member(models_obj, id));
+
+    dt_ai_repo_model_t *entry = g_new0(dt_ai_repo_model_t, 1);
+    entry->id = g_strdup(id);
+    entry->repository = g_strdup(repository);
+    entry->checksum = checksum;
+    entry->version = _versions_string(m_obj, "version");
+
+    // schema 1 publishes display metadata; older releases carry only
+    // version and sha256, so all of this is optional
+    entry->name = _versions_string(m_obj, "name");
+    entry->description = _versions_string(m_obj, "description");
+    entry->task = _versions_string(m_obj, "task");
+    entry->license = _versions_string(m_obj, "license");
+    if(json_object_has_member(m_obj, "size"))
+      entry->size = json_object_get_int_member(m_obj, "size");
+
+    // fall back to the catalog for anything the release omits
+    char *local_version = NULL;
+    g_mutex_lock(&registry->lock);
+    const dt_ai_model_t *known = _find_model_unlocked(registry, id);
+    if(known)
+    {
+      // the registry also holds models found on disk, so being known is
+      // not the same as being cataloged
+      entry->in_catalog = known->from_catalog;
+      local_version = g_strdup(known->version);
+      if(!entry->name) entry->name = g_strdup(known->name);
+      if(!entry->description) entry->description = g_strdup(known->description);
+      if(!entry->task) entry->task = g_strdup(known->task);
+    }
+    g_mutex_unlock(&registry->lock);
+
+    // an install the release has moved past is an update, not done
+    char *path = dt_ai_models_get_path(id);
+    if(!path)
+    {
+      entry->status = DT_AI_MODEL_NOT_DOWNLOADED;
+    }
+    else
+    {
+      entry->status = (local_version && entry->version
+                       && _version_compare(local_version, entry->version) < 0)
+        ? DT_AI_MODEL_UPDATE_AVAILABLE
+        : DT_AI_MODEL_DOWNLOADED;
+      g_free(path);
+    }
+    g_free(local_version);
+
+    // the main list already downloads and updates every cataloged model,
+    // but only from the official repository. an id another repository
+    // happens to reuse is a different model and must still be listed
+    if(entry->in_catalog && official)
+    {
+      _repo_model_free(entry);
+      continue;
+    }
+
+    result = g_list_prepend(result, entry);
+  }
+
+  g_list_free(members);
+  g_object_unref(parser);
+
+  dt_print(DT_DEBUG_AI,
+           "[ai_models] %s release %s offers %d model(s) beyond the catalog",
+           repository, release_tag, g_list_length(result));
+
+  g_free(release_tag);
+  g_free(repository);
+
+  return g_list_sort(result, _repo_model_cmp_id);
+}
+
+gboolean dt_ai_models_register_repository_model(const dt_ai_repo_model_t *entry)
+{
+  dt_ai_registry_t *registry = darktable.ai_registry;
+  if(!registry || !entry || !_valid_model_id(entry->id) || !entry->checksum)
+    return FALSE;
+
+  g_mutex_lock(&registry->lock);
+  dt_ai_model_t *model = _find_model_unlocked(registry, entry->id);
+  if(!model)
+  {
+    model = _model_new();
+    model->id = g_strdup(entry->id);
+    model->name = g_strdup(entry->name ? entry->name : entry->id);
+    model->task = g_strdup(entry->task);
+    model->enabled = TRUE;
+    registry->models = g_list_append(registry->models, model);
+    dt_print(DT_DEBUG_AI,
+             "[ai_models] registered %s from the repository listing", entry->id);
+  }
+
+  // both say how to fetch this release's copy, so refresh them however the
+  // entry reached the registry. a model found on disk carries no asset at
+  // all, and without one the download refuses outright
+  g_free(model->github_asset);
+  model->github_asset = g_strdup_printf("%s.dtmodel", entry->id);
+  // the download must go to the repository the user picked, not whichever
+  // one happens to be configured globally
+  g_free(model->repository);
+  model->repository = g_strdup(entry->repository);
+  // the release's digest wins over anything cached earlier
+  g_free(model->checksum);
+  model->checksum = g_strdup(entry->checksum);
+  g_mutex_unlock(&registry->lock);
+
+  // the origin conf key is deliberately left alone: a registration says
+  // only what the user asked for, and until the download lands it still
+  // holds what is actually true. that makes it the rollback's snapshot
+  return TRUE;
+}
+
+void dt_ai_models_record_origin(const char *model_id, const char *repository)
+{
+  if(!_valid_model_id(model_id)) return;
+
+  char *origin_key = _origin_conf_key(model_id);
+  dt_conf_set_string(origin_key, repository ? repository : "");
+  g_free(origin_key);
+}
+
+void dt_ai_models_unregister_repository_model(const char *model_id)
+{
+  dt_ai_registry_t *registry = darktable.ai_registry;
+  if(!registry || !_valid_model_id(model_id)) return;
+
+  // the registration never wrote this, so it still describes the install
+  // that is actually on disk — or is absent, for one that never was
+  char *origin_key = _origin_conf_key(model_id);
+  char *origin = dt_conf_get_string(origin_key);
+  g_free(origin_key);
+  if(origin && !*origin)
+  {
+    g_free(origin);
+    origin = NULL;
+  }
+
+  // never drop a catalog entry or one backed by files on disk, whatever the
+  // caller's bookkeeping says — only a transient registration can go. the
+  // status is no guide here: a cancelled update leaves it at ERROR while
+  // the previous install is still on disk and working
+  char *config = g_build_filename(registry->models_dir, model_id,
+                                  "config.json", NULL);
+  const gboolean installed = g_file_test(config, G_FILE_TEST_EXISTS);
+  g_free(config);
+
+  g_mutex_lock(&registry->lock);
+  dt_ai_model_t *stale = _find_model_unlocked(registry, model_id);
+  if(stale)
+  {
+    if(!stale->from_catalog && !installed)
+    {
+      registry->models = g_list_remove(registry->models, stale);
+      _model_free(stale);
+    }
+    else
+    {
+      // an entry that outlives the registration must not keep pointing at
+      // the repository we failed to install from
+      g_free(stale->repository);
+      stale->repository = origin;  // takes ownership
+      origin = NULL;
+      // the digest described a release that never landed. NULL only costs
+      // the next download one API call to ask GitHub for the real one
+      g_free(stale->checksum);
+      stale->checksum = NULL;
+    }
+  }
+  g_mutex_unlock(&registry->lock);
+
+  g_free(origin);
+}
+
+char *dt_ai_models_install_from_repository(const dt_ai_repo_model_t *entry,
+                                           dt_ai_progress_callback callback,
+                                           gpointer user_data,
+                                           const gboolean *cancel_flag)
+{
+  if(!entry)
+    return g_strdup(_("invalid parameters"));
+
+  if(!dt_ai_models_register_repository_model(entry))
+    return g_strdup(_("invalid parameters"));
+
+  char *error = dt_ai_models_download_sync(entry->id, callback,
+                                           user_data, cancel_flag);
+
+  if(error)
+  {
+    // nothing installed, so put back whatever the registration replaced
+    dt_ai_models_unregister_repository_model(entry->id);
+  }
+  else
+  {
+    // an install that landed is the only evidence of where it came from,
+    // and refresh_status reads the key back
+    dt_ai_models_record_origin(entry->id, entry->repository);
+    // config.json now describes the model; rescan to pick it up
+    dt_ai_models_refresh_status();
+  }
+
+  return error;
+}
 #endif // HAVE_AI_DOWNLOAD
 
 static gboolean _rmdir_recursive(const char *path)
@@ -2018,6 +2599,12 @@ gboolean dt_ai_models_delete(const char *model_id)
   g_free(model_dir);
 
   dt_ai_backend_cache_invalidate(model_id);
+
+  // the recorded publisher describes files that no longer exist; leaving it
+  // would mislabel a later install of the same id from somewhere else
+  char *origin_key = _origin_conf_key(model_id);
+  dt_conf_set_string(origin_key, "");
+  g_free(origin_key);
 
   char *task_copy = NULL;
   g_mutex_lock(&registry->lock);

--- a/src/common/ai_models.h
+++ b/src/common/ai_models.h
@@ -44,6 +44,8 @@ typedef struct dt_ai_model_t
   char *description;     // Short description
   char *task;            // Task type: "denoise", "upscale", etc.
   char *github_asset;    // Asset filename in GitHub release
+  char *repository;      // "owner/repo" this model comes from; NULL for
+                         // the repository configured globally
   char *checksum;        // checksum string, format "<algo>:<hex>"
                          // (today only "sha256:..." is produced by the
                          // GitHub asset digest API; parser tolerates
@@ -53,6 +55,9 @@ typedef struct dt_ai_model_t
   char *spatial_dim_h;   // symbolic name of height dimension (default "height")
   char *spatial_dim_w;   // symbolic name of width dimension (default "width")
   gboolean is_default;   // TRUE if model is a default model for its task
+  gboolean from_catalog;  // TRUE when parsed from the bundled
+                            // ai_models.json; FALSE when found on disk or
+                            // registered from a repository listing
   gboolean enabled;      // User preference (stored in darktablerc)
   dt_ai_model_status_t status;
   double download_progress;  // 0.0 to 1.0 during download
@@ -199,6 +204,28 @@ dt_ai_model_t *dt_ai_models_get_by_id(const char *model_id);
  */
 char *dt_ai_models_install_local(const char *filepath);
 
+// --- Provenance ---
+// a model keeps its recorded publisher whether or not this build can
+// download, so these stay outside HAVE_AI_DOWNLOAD
+
+/**
+ * @brief The official repository, for display
+ *
+ * plugins/ai/repository, which darktableconfig.xml defaults to
+ * darktable-org/darktable-ai. An installation pointed at a mirror is
+ * still being served official models, so that mirror is what "official"
+ * means for it.
+ *
+ * @return Borrowed "owner/repo", valid for the registry's lifetime, or
+ *         NULL before the registry exists
+ */
+const char *dt_ai_models_official_repository(void);
+
+/**
+ * @brief TRUE if `repository` is this installation's official repository
+ */
+gboolean dt_ai_models_is_official_repository(const char *repository);
+
 #ifdef HAVE_AI_DOWNLOAD
 // --- Download Operations ---
 
@@ -243,6 +270,130 @@ gboolean dt_ai_models_download_default(dt_ai_progress_callback callback,
  */
 gboolean dt_ai_models_download_all(dt_ai_progress_callback callback,
                                    gpointer user_data);
+
+/**
+ * @brief One model offered by the repository's compatible release
+ *
+ * versions.json lists everything in a release, a superset of the bundled
+ * catalog: a model released after this build appears there but not in
+ * ai_models.json.
+ */
+typedef struct dt_ai_repo_model_t
+{
+  char *id;               // model id, also the .dtmodel asset stem
+  char *repository;       // "owner/repo" that published it
+  char *version;          // version published in the release
+  char *checksum;         // "sha256:...", never NULL; entries without one
+                          // are dropped as unverifiable
+  char *name;             // display name, may be NULL
+  char *description;      // one-line summary, may be NULL
+  char *task;             // task the model serves, may be NULL
+  char *license;          // license of the weights, may be NULL
+  gint64 size;            // download size in bytes, 0 when unpublished
+  gboolean in_catalog;  // listed in darktable's bundled ai_models.json
+  dt_ai_model_status_t status;  // UPDATE_AVAILABLE when the release is
+                                // newer than what is on disk
+} dt_ai_repo_model_t;
+
+/**
+ * @brief List the models the repository offers beyond the bundled
+ *        catalog, which the main model list already manages
+ *
+ * Blocking network I/O — call from a worker thread.
+ *
+ * @param repository "owner/repo" to query; NULL uses the configured one
+ * @param error_msg Set to an error message on failure (caller must free);
+ *                  may be NULL
+ * @return List of dt_ai_repo_model_t*, sorted by id, or NULL on failure or
+ *         when nothing is offered. Free with dt_ai_repo_model_list_free().
+ */
+GList *dt_ai_models_fetch_repository_list(const char *repository,
+                                          char **error_msg);
+
+/**
+ * @brief The repositories models may be installed from
+ *
+ * plugins/ai/repository first, then any listed in
+ * plugins/ai/third_party_repositories. Malformed entries are dropped.
+ *
+ * @return List of newly allocated "owner/repo" strings; free with
+ *         g_list_free_full(list, g_free)
+ */
+GList *dt_ai_models_get_repositories(void);
+
+/**
+ * @brief Just the additional repositories, without the official one
+ * @return List of newly allocated "owner/repo" strings; free with
+ *         g_list_free_full(list, g_free)
+ */
+GList *dt_ai_models_get_third_party_repositories(void);
+
+/**
+ * @brief Replace the list of additional repositories
+ *
+ * Writes plugins/ai/third_party_repositories. Entries are not validated here —
+ * dt_ai_models_get_repositories() drops malformed ones when reading.
+ *
+ * @param repositories List of "owner/repo" strings (may be NULL to clear)
+ */
+void dt_ai_models_set_third_party_repositories(GList *repositories);
+
+/**
+ * @brief Free a list returned by dt_ai_models_fetch_repository_list()
+ */
+void dt_ai_repo_model_list_free(GList *list);
+
+/**
+ * @brief Make a repository-listed model downloadable
+ *
+ * The download path only operates on registry members, so this adds a
+ * transient entry carrying the release's digest. It lasts for the session;
+ * an installed model is rediscovered from its config.json on the next start.
+ *
+ * @param entry Entry from dt_ai_models_fetch_repository_list()
+ * @return TRUE if the model is now known to the registry
+ */
+gboolean dt_ai_models_register_repository_model(const dt_ai_repo_model_t *entry);
+
+/**
+ * @brief Record where an install actually came from
+ *
+ * Call only once the download has landed. dt_ai_models_refresh_status()
+ * reads this back to restore a model's publisher across sessions.
+ *
+ * @param model_id The model that was installed
+ * @param repository "owner/repo" it came from, or NULL to clear
+ */
+void dt_ai_models_record_origin(const char *model_id, const char *repository);
+
+/**
+ * @brief Undo a registration when the download did not happen
+ *
+ * Removes an entry the registration created, and restores the publisher
+ * and checksum of one it merely redirected, so it is safe to call without
+ * tracking whether the model was known beforehand.
+ *
+ * @param model_id The model to unregister
+ */
+void dt_ai_models_unregister_repository_model(const char *model_id);
+
+/**
+ * @brief Register and download a model listed by the repository
+ *
+ * Wrapper over dt_ai_models_register_repository_model() and
+ * dt_ai_models_download_sync() for callers without their own progress
+ * dialog. Blocking; unregisters again if the download fails.
+ *
+ * @param entry Entry from dt_ai_models_fetch_repository_list()
+ * @param callback Progress callback (may be NULL)
+ * @param user_data Data for callback
+ * @param cancel_flag Pointer to boolean checked for cancellation (may be NULL)
+ * @return Error message (caller must free) or NULL on success
+ */
+char *dt_ai_models_install_from_repository(const dt_ai_repo_model_t *entry,
+                                           dt_ai_progress_callback callback,
+                                           gpointer user_data,
+                                           const gboolean *cancel_flag);
 #endif /* HAVE_AI_DOWNLOAD */
 
 /**

--- a/src/common/ai_models.h
+++ b/src/common/ai_models.h
@@ -58,6 +58,8 @@ typedef struct dt_ai_model_t
   gboolean from_catalog;  // TRUE when parsed from the bundled
                             // ai_models.json; FALSE when found on disk or
                             // registered from a repository listing
+  gboolean from_file;    // TRUE when installed from a local .dtmodel; there
+                         // is no repository to go back to for updates
   gboolean enabled;      // User preference (stored in darktablerc)
   dt_ai_model_status_t status;
   double download_progress;  // 0.0 to 1.0 during download

--- a/src/gui/preferences_ai.c
+++ b/src/gui/preferences_ai.c
@@ -239,11 +239,18 @@ static void _refresh_model_list(dt_prefs_ai_data_t *data)
     }
 
     // only a non-official origin is worth naming; the column is hidden
-    // entirely when nothing here has one
-    const gboolean third_party
-      = model->repository
-        && !dt_ai_models_is_official_repository(model->repository);
-    if(third_party) any_third_party = TRUE;
+    // entirely when nothing here has one. a model with no origin at all
+    // was copied into the models directory by hand, which is worth saying
+    // rather than leaving it to look official
+    const char *source = "";
+    if(model->repository
+       && !dt_ai_models_is_official_repository(model->repository))
+      source = model->repository;
+    else if(model->from_file)
+      source = _("imported from file");
+    else if(!model->from_catalog && !model->repository)
+      source = _("local");
+    if(*source) any_third_party = TRUE;
 
     GtkTreeIter iter;
     gtk_list_store_append(data->model_store, &iter);
@@ -263,7 +270,7 @@ static void _refresh_model_list(dt_prefs_ai_data_t *data)
       COL_STATUS,
       _status_to_string(model->status),
       COL_REPOSITORY,
-      third_party ? model->repository : "",
+      source,
       COL_DEFAULT,
       model->is_default ? _("yes") : _("no"),
       COL_VERSION,
@@ -2495,7 +2502,7 @@ void init_tab_ai(GtkWidget *dialog, GtkWidget *stack)
   // repository column, shown only when something not from the official
   // repository is installed — otherwise it would be empty for everyone
   data->repo_col = gtk_tree_view_column_new_with_attributes(
-    _("repository"),
+    _("source"),
     text_renderer,
     "text",
     COL_REPOSITORY,

--- a/src/gui/preferences_ai.c
+++ b/src/gui/preferences_ai.c
@@ -75,6 +75,7 @@ enum
   COL_ENABLED,
   COL_ENABLED_SENSITIVE, // whether the enabled checkbox is clickable
   COL_STATUS,
+  COL_REPOSITORY,
   COL_DEFAULT,
   COL_ID,
   NUM_COLS
@@ -93,12 +94,14 @@ typedef struct dt_prefs_ai_data_t
 #ifdef HAVE_AI_DOWNLOAD
   GtkWidget *download_selected_btn;
   GtkWidget *download_default_btn;
+  GtkWidget *install_repo_btn;
 #endif
   GtkWidget *install_btn;
   GtkWidget *delete_selected_btn;
   GtkWidget *parent_dialog;
   GtkWidget *select_all_toggle;
   GtkTreeViewColumn *info_col;
+  GtkTreeViewColumn *repo_col;  // hidden unless a third-party model exists
   GtkWidget *controls_box;  // container for all controls below the enable toggle
   GtkWidget *ort_path_entry;
   GtkWidget *ort_path_indicator;
@@ -210,6 +213,7 @@ static void _refresh_model_list(dt_prefs_ai_data_t *data)
 
   const int count = dt_ai_models_get_count();
   dt_print(DT_DEBUG_AI, "[preferences_ai] refreshing model list, count=%d", count);
+  gboolean any_third_party = FALSE;
   for(int i = 0; i < count; i++)
   {
     dt_ai_model_t *model = dt_ai_models_get_by_index(i);
@@ -234,6 +238,13 @@ static void _refresh_model_list(dt_prefs_ai_data_t *data)
       g_free(active_id);
     }
 
+    // only a non-official origin is worth naming; the column is hidden
+    // entirely when nothing here has one
+    const gboolean third_party
+      = model->repository
+        && !dt_ai_models_is_official_repository(model->repository);
+    if(third_party) any_third_party = TRUE;
+
     GtkTreeIter iter;
     gtk_list_store_append(data->model_store, &iter);
     gtk_list_store_set(
@@ -251,6 +262,8 @@ static void _refresh_model_list(dt_prefs_ai_data_t *data)
       model->task ? model->task : "",
       COL_STATUS,
       _status_to_string(model->status),
+      COL_REPOSITORY,
+      third_party ? model->repository : "",
       COL_DEFAULT,
       model->is_default ? _("yes") : _("no"),
       COL_VERSION,
@@ -264,6 +277,10 @@ static void _refresh_model_list(dt_prefs_ai_data_t *data)
       -1);
     dt_ai_model_free(model);
   }
+
+  // an all-official install never sees this column
+  if(data->repo_col)
+    gtk_tree_view_column_set_visible(data->repo_col, any_third_party);
 
   // reset select-all toggle
   if(data->select_all_toggle)
@@ -994,6 +1011,707 @@ static void _on_download_default(GtkButton *button, gpointer user_data)
   _refresh_model_list(data);
 }
 
+// --- install from repository -----------------------------------------
+// the bundled catalog is fixed at build time, so a model released
+// afterwards is undownloadable until darktable ships again. the repository's
+// versions.json lists the whole release, which is what this dialog offers
+
+enum
+{
+  REPO_COL_SELECTED = 0,
+  REPO_COL_NAME,
+  REPO_COL_VERSION,
+  REPO_COL_TASK,
+  REPO_COL_STATUS,
+  REPO_COL_SELECTABLE,
+  REPO_COL_TOOLTIP,
+  REPO_COL_ENTRY,
+  REPO_NUM_COLS
+};
+
+typedef struct dt_repo_fetch_t
+{
+  char *repository;
+  GList *models;        // dt_ai_repo_model_t*, owned once finished
+  char *error;
+  gboolean finished;    // set last, read by the gui via g_atomic
+} dt_repo_fetch_t;
+
+typedef struct dt_repo_dialog_t
+{
+  dt_prefs_ai_data_t *prefs;
+  GtkWidget *dialog;
+  GtkWidget *combo;
+  GtkWidget *stack;    // "list" or "message"
+  GtkWidget *message;
+  GtkWidget *manage_btn;
+  GtkListStore *store;
+  GHashTable *cache;    // repository -> GList* of dt_ai_repo_model_t*,
+                        // so switching back does not refetch
+  gboolean busy;
+  guint idle_id;        // pending initial fetch, see _repo_initial_fetch
+} dt_repo_dialog_t;
+
+static gpointer _repo_fetch_thread(gpointer user_data)
+{
+  dt_repo_fetch_t *fetch = (dt_repo_fetch_t *)user_data;
+  fetch->models = dt_ai_models_fetch_repository_list(fetch->repository,
+                                                     &fetch->error);
+  g_atomic_int_set(&fetch->finished, TRUE);
+  return NULL;
+}
+
+// install acts on the ticked rows, so it stays insensitive until there is
+// at least one. mirrors _update_download_selected_sensitivity above
+static void _repo_update_install_sensitivity(dt_repo_dialog_t *rd)
+{
+  gboolean any = FALSE;
+  GtkTreeIter iter;
+  gboolean valid
+    = gtk_tree_model_get_iter_first(GTK_TREE_MODEL(rd->store), &iter);
+  while(valid)
+  {
+    gboolean sel = FALSE;
+    gtk_tree_model_get(GTK_TREE_MODEL(rd->store), &iter,
+                       REPO_COL_SELECTED, &sel, -1);
+    if(sel) { any = TRUE; break; }
+    valid = gtk_tree_model_iter_next(GTK_TREE_MODEL(rd->store), &iter);
+  }
+  gtk_dialog_set_response_sensitive(GTK_DIALOG(rd->dialog),
+                                    GTK_RESPONSE_ACCEPT, any);
+}
+
+static void _on_repo_toggle(GtkCellRendererToggle *renderer,
+                            gchar *path_str,
+                            gpointer user_data)
+{
+  dt_repo_dialog_t *rd = (dt_repo_dialog_t *)user_data;
+  GtkTreeIter iter;
+  GtkTreePath *path = gtk_tree_path_new_from_string(path_str);
+
+  if(gtk_tree_model_get_iter(GTK_TREE_MODEL(rd->store), &iter, path))
+  {
+    gboolean selected = FALSE, selectable = FALSE;
+    gtk_tree_model_get(GTK_TREE_MODEL(rd->store), &iter,
+                       REPO_COL_SELECTED, &selected,
+                       REPO_COL_SELECTABLE, &selectable, -1);
+    if(selectable)
+      gtk_list_store_set(rd->store, &iter, REPO_COL_SELECTED, !selected, -1);
+  }
+  gtk_tree_path_free(path);
+
+  _repo_update_install_sensitivity(rd);
+}
+
+// the table area shows either the list or a centered message, never both
+static void _repo_show_message(dt_repo_dialog_t *rd, const char *text)
+{
+  gtk_label_set_text(GTK_LABEL(rd->message), text);
+  gtk_stack_set_visible_child_name(GTK_STACK(rd->stack), "message");
+}
+
+// fill the table from a repository's listing, fetching it unless already
+// cached for this dialog
+static void _repo_populate(dt_repo_dialog_t *rd, const char *repository)
+{
+  gtk_list_store_clear(rd->store);
+
+  GList *models = g_hash_table_lookup(rd->cache, repository);
+  if(!models)
+  {
+    rd->busy = TRUE;
+    gtk_widget_set_sensitive(rd->combo, FALSE);
+    // editing the list mid-fetch would rebuild the combo under us, freeing
+    // the very string this call is holding. the busy flag cannot help: the
+    // button is a separate handler, and the event pump below runs it
+    gtk_widget_set_sensitive(rd->manage_btn, FALSE);
+    gtk_dialog_set_response_sensitive(GTK_DIALOG(rd->dialog),
+                                      GTK_RESPONSE_ACCEPT, FALSE);
+    _repo_show_message(rd, _("retrieving the list of models…"));
+    // paint the notice before blocking on the network, or the dialog just
+    // sits there looking hung
+    dt_gui_process_events();
+
+    dt_repo_fetch_t fetch = { (char *)repository, NULL, NULL, FALSE };
+    GThread *thread = g_thread_new("ai-repo-list", _repo_fetch_thread, &fetch);
+    while(!g_atomic_int_get(&fetch.finished))
+    {
+      dt_gui_process_events();
+      g_usleep(10000);
+    }
+    g_thread_join(thread);
+
+    rd->busy = FALSE;
+    gtk_widget_set_sensitive(rd->combo, TRUE);
+    gtk_widget_set_sensitive(rd->manage_btn, TRUE);
+
+    if(!fetch.models)
+    {
+      _repo_show_message(rd, fetch.error
+                               ? fetch.error
+                               : _("nothing to install from here"));
+      g_free(fetch.error);
+      return;
+    }
+    g_free(fetch.error);
+    g_hash_table_insert(rd->cache, g_strdup(repository), fetch.models);
+    models = fetch.models;
+  }
+
+  for(GList *l = models; l; l = g_list_next(l))
+  {
+    const dt_ai_repo_model_t *m = (const dt_ai_repo_model_t *)l->data;
+    const char *status = _status_to_string(m->status);
+    const gboolean actionable = m->status != DT_AI_MODEL_DOWNLOADED;
+
+    // description, license and size go in the tooltip, not the columns
+    GString *tip = g_string_new(NULL);
+    if(m->description) g_string_append_printf(tip, "%s\n\n", m->description);
+    g_string_append_printf(tip, "%s: %s", _("model"), m->id);
+    if(m->size > 0)
+    {
+      gchar *pretty = g_format_size((guint64)m->size);
+      g_string_append_printf(tip, "\n%s: %s", _("download size"), pretty);
+      g_free(pretty);
+    }
+    if(m->license)
+      g_string_append_printf(tip, "\n%s: %s", _("license"), m->license);
+
+    gtk_list_store_insert_with_values(
+      rd->store, NULL, -1,
+      REPO_COL_SELECTED, FALSE,
+      REPO_COL_NAME, m->name ? m->name : m->id,
+      REPO_COL_VERSION, m->version ? m->version : "",
+      REPO_COL_TASK, m->task ? m->task : "",
+      REPO_COL_STATUS, status,
+      REPO_COL_SELECTABLE, actionable,
+      REPO_COL_TOOLTIP, tip->str,
+      REPO_COL_ENTRY, m,
+      -1);
+    g_string_free(tip, TRUE);
+  }
+
+  // show what the repository holds even when all of it is installed: the
+  // versions and statuses are the point, and install is disabled anyway
+  gtk_stack_set_visible_child_name(GTK_STACK(rd->stack), "list");
+
+  // nothing is ticked in a freshly populated table
+  _repo_update_install_sensitivity(rd);
+}
+
+static void _on_repo_combo_changed(GtkWidget *combo, gpointer user_data)
+{
+  dt_repo_dialog_t *rd = (dt_repo_dialog_t *)user_data;
+  if(rd->busy) return;  // re-entry while the previous fetch pumps events
+
+  // the combo owns what it returns and repopulating frees it, so the fetch
+  // below must not be left holding a pointer into it
+  gchar *repository = g_strdup(dt_bauhaus_combobox_get_text(combo));
+  if(repository) _repo_populate(rd, repository);
+  g_free(repository);
+}
+
+// the first fetch must not run before gtk_dialog_run(): until its loop is
+// up, closing the window destroys the dialog outright, and the fetch pumps
+// events for as long as the network takes. from an idle the loop is
+// already running, and a close is a response rather than a destroy
+static gboolean _repo_initial_fetch(gpointer user_data)
+{
+  dt_repo_dialog_t *rd = (dt_repo_dialog_t *)user_data;
+  rd->idle_id = 0;
+  dt_bauhaus_combobox_set(rd->combo, 0);
+  return G_SOURCE_REMOVE;
+}
+
+// installing an id that already belongs elsewhere overwrites it on disk:
+// the archive extracts to <models>/<id>/, whoever published it
+static gboolean _confirm_replacement(const dt_ai_repo_model_t *m)
+{
+  dt_ai_model_t *existing = dt_ai_models_get_by_id(m->id);
+  if(!existing) return TRUE;
+
+  const gboolean same_source =
+    !g_strcmp0(existing->repository, m->repository)
+    || (existing->from_catalog
+        && dt_ai_models_is_official_repository(m->repository));
+  const gboolean on_disk = existing->status != DT_AI_MODEL_NOT_DOWNLOADED;
+
+  if(same_source || !on_disk)
+  {
+    dt_ai_model_free(existing);
+    return TRUE;
+  }
+
+  gchar *owner = g_strdup(existing->from_catalog
+                            ? _("the official repository")
+                            : (existing->repository ? existing->repository
+                                                    : _("a local install")));
+  dt_ai_model_free(existing);
+
+  const gboolean ok = dt_gui_show_yes_no_dialog(
+    _("replace installed model?"),
+    "ai_replace_model",
+    _("\"%s\" is already installed from %s.\n\n"
+      "installing it from %s replaces those files"),
+    m->id, owner, m->repository);
+  g_free(owner);
+  return ok;
+}
+
+// --- manage repositories --------------------------------------------
+// verifying means fetching the repository's listing — the same call the
+// combo makes. A repo that answers is usable; one that does not would only
+// fail later with less context
+static gboolean _verify_repository(GtkWindow *parent, const char *repository)
+{
+  dt_repo_fetch_t fetch = { (char *)repository, NULL, NULL, FALSE };
+  GThread *thread = g_thread_new("ai-repo-verify", _repo_fetch_thread, &fetch);
+  while(!g_atomic_int_get(&fetch.finished))
+  {
+    dt_gui_process_events();
+    g_usleep(10000);
+  }
+  g_thread_join(thread);
+
+  const int count = g_list_length(fetch.models);
+  char *error = fetch.error;
+  dt_ai_repo_model_list_free(fetch.models);
+
+  if(!count)
+  {
+    GtkWidget *err = gtk_message_dialog_new(
+      parent, GTK_DIALOG_MODAL, GTK_MESSAGE_ERROR, GTK_BUTTONS_OK,
+      "%s", error ? error
+                  : _("this repository offers no models for this version "
+                      "of darktable"));
+    gtk_window_set_title(GTK_WINDOW(err), _("repository not usable"));
+    gtk_dialog_run(GTK_DIALOG(err));
+    gtk_widget_destroy(err);
+    g_free(error);
+    return FALSE;
+  }
+  g_free(error);
+
+  // adding a repository is the moment the trust decision is made, so say
+  // what it means while the user is making it
+  return dt_gui_show_yes_no_dialog(
+    _("add this repository?"), "ai_add_repository",
+    _("%s offers %d model(s) for this version of darktable\n\n"
+      "it is not maintained or reviewed by the darktable project, and a "
+      "model installed from it replaces any installed model of the same "
+      "name"),
+    repository, count);
+}
+
+#define DT_AI_REPO_PATTERN "^[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+$"
+
+typedef struct dt_repo_edit_t
+{
+  GtkWidget *dialog;
+  GtkListStore *store;
+  GtkWidget *entry;
+  GtkWidget *view;
+  GtkWidget *add_btn;
+  GtkWidget *remove_btn;
+  gboolean busy;        // a verification is pumping events; ignore re-entry
+} dt_repo_edit_t;
+
+// add stays insensitive until the field holds something that could be a
+// repository, so the shape is taught by the button rather than by an error
+static void _on_repo_entry_changed(GtkEditable *editable, gpointer user_data)
+{
+  dt_repo_edit_t *ed = (dt_repo_edit_t *)user_data;
+  gchar *repo = g_strstrip(g_strdup(gtk_entry_get_text(GTK_ENTRY(ed->entry))));
+  gtk_widget_set_sensitive(ed->add_btn,
+                           g_regex_match_simple(DT_AI_REPO_PATTERN, repo, 0, 0));
+  g_free(repo);
+}
+
+// the official repository is listed for context but is a different setting
+static void _on_repo_selection_changed(GtkTreeSelection *sel, gpointer user_data)
+{
+  dt_repo_edit_t *ed = (dt_repo_edit_t *)user_data;
+  GtkTreeIter iter;
+  GtkTreeModel *model = NULL;
+  gboolean removable = FALSE;
+  if(gtk_tree_selection_get_selected(sel, &model, &iter))
+    gtk_tree_model_get(model, &iter, 1, &removable, -1);
+  gtk_widget_set_sensitive(ed->remove_btn, removable);
+}
+
+static gboolean _repo_already_listed(GtkListStore *store, const char *repo)
+{
+  GtkTreeIter iter;
+  gboolean valid = gtk_tree_model_get_iter_first(GTK_TREE_MODEL(store), &iter);
+  while(valid)
+  {
+    gchar *existing = NULL;
+    gtk_tree_model_get(GTK_TREE_MODEL(store), &iter, 0, &existing, -1);
+    const gboolean same = !g_strcmp0(existing, repo);
+    g_free(existing);
+    if(same) return TRUE;
+    valid = gtk_tree_model_iter_next(GTK_TREE_MODEL(store), &iter);
+  }
+  return FALSE;
+}
+
+// the work, so each signal gets a correctly typed callback below rather
+// than one handler doing duty for two different first arguments
+static void _repo_add(dt_repo_edit_t *ed)
+{
+  // _verify_repository pumps events, so add stays clickable; a second
+  // click would start a second verification
+  if(ed->busy) return;
+
+  GtkWindow *parent = GTK_WINDOW(ed->dialog);
+
+  gchar *repo = g_strstrip(g_strdup(gtk_entry_get_text(GTK_ENTRY(ed->entry))));
+
+  // shape is already guaranteed by the button's sensitivity; a duplicate
+  // still needs saying, since it looks perfectly valid
+  if(_repo_already_listed(ed->store, repo))
+  {
+    GtkWidget *err = gtk_message_dialog_new(
+      parent, GTK_DIALOG_MODAL, GTK_MESSAGE_ERROR, GTK_BUTTONS_OK,
+      "%s", _("that repository is already listed"));
+    gtk_dialog_run(GTK_DIALOG(err));
+    gtk_widget_destroy(err);
+  }
+  else
+  {
+    ed->busy = TRUE;
+    const gboolean accepted = _verify_repository(parent, repo);
+    ed->busy = FALSE;
+    if(accepted)
+    {
+      gtk_list_store_insert_with_values(ed->store, NULL, -1,
+                                        0, repo, 1, TRUE, -1);
+      gtk_entry_set_text(GTK_ENTRY(ed->entry), "");
+    }
+  }
+  g_free(repo);
+}
+
+static void _on_repo_add_clicked(GtkButton *button, gpointer user_data)
+{
+  _repo_add((dt_repo_edit_t *)user_data);
+}
+
+static void _on_repo_entry_activate(GtkEntry *entry, gpointer user_data)
+{
+  dt_repo_edit_t *ed = (dt_repo_edit_t *)user_data;
+  // enter should do nothing when add itself is unavailable
+  if(gtk_widget_get_sensitive(ed->add_btn)) _repo_add(ed);
+}
+
+static void _on_repo_remove(GtkButton *button, gpointer user_data)
+{
+  dt_repo_edit_t *ed = (dt_repo_edit_t *)user_data;
+  GtkTreeSelection *sel
+    = gtk_tree_view_get_selection(GTK_TREE_VIEW(ed->view));
+
+  GtkTreeIter iter;
+  GtkTreeModel *model = NULL;
+  if(!gtk_tree_selection_get_selected(sel, &model, &iter)) return;
+
+  gboolean removable = FALSE;
+  gtk_tree_model_get(model, &iter, 1, &removable, -1);
+  if(removable) gtk_list_store_remove(ed->store, &iter);
+}
+
+static void _on_manage_repositories(GtkButton *button, gpointer user_data)
+{
+  dt_repo_dialog_t *rd = (dt_repo_dialog_t *)user_data;
+
+  GtkWidget *dialog = gtk_dialog_new_with_buttons(
+    _("repositories"),
+    GTK_WINDOW(rd->dialog),
+    GTK_DIALOG_MODAL | GTK_DIALOG_DESTROY_WITH_PARENT,
+    _("_cancel"), GTK_RESPONSE_CANCEL,
+    _("_ok"), GTK_RESPONSE_ACCEPT,
+    NULL);
+  gtk_window_set_default_size(GTK_WINDOW(dialog), DT_PIXEL_APPLY_DPI(460),
+                              DT_PIXEL_APPLY_DPI(300));
+
+  GtkListStore *store = gtk_list_store_new(2,
+                                           G_TYPE_STRING,   // repository
+                                           G_TYPE_BOOLEAN); // removable
+
+  gtk_list_store_insert_with_values(
+    store, NULL, -1,
+    0, dt_ai_models_official_repository(),
+    1, FALSE, -1);
+
+  GList *third_party = dt_ai_models_get_third_party_repositories();
+  for(GList *l = third_party; l; l = g_list_next(l))
+    gtk_list_store_insert_with_values(store, NULL, -1,
+                                      0, (const char *)l->data, 1, TRUE, -1);
+  g_list_free_full(third_party, g_free);
+
+  GtkWidget *view = gtk_tree_view_new_with_model(GTK_TREE_MODEL(store));
+  g_object_unref(store);
+  gtk_tree_view_set_headers_visible(GTK_TREE_VIEW(view), FALSE);
+  gtk_tree_view_append_column(
+    GTK_TREE_VIEW(view),
+    gtk_tree_view_column_new_with_attributes(
+      "", gtk_cell_renderer_text_new(), "text", 0, NULL));
+  dt_gui_dialog_add(dialog, dt_gui_scroll_wrap(view));
+
+  GtkWidget *entry = gtk_entry_new();
+  gtk_entry_set_placeholder_text(GTK_ENTRY(entry), "owner/repo");
+  GtkWidget *add_btn = gtk_button_new_with_label(_("add"));
+  GtkWidget *remove_btn = gtk_button_new_with_label(_("remove"));
+  dt_gui_dialog_add(dialog,
+                    dt_gui_hbox(dt_gui_expand(entry), add_btn, remove_btn));
+
+  dt_repo_edit_t ed = { dialog, store, entry, view, add_btn, remove_btn, FALSE };
+  g_signal_connect(add_btn, "clicked", G_CALLBACK(_on_repo_add_clicked), &ed);
+  g_signal_connect(remove_btn, "clicked", G_CALLBACK(_on_repo_remove), &ed);
+  g_signal_connect(entry, "changed", G_CALLBACK(_on_repo_entry_changed), &ed);
+  // enter in the field does what the button does
+  g_signal_connect(entry, "activate", G_CALLBACK(_on_repo_entry_activate), &ed);
+  g_signal_connect(gtk_tree_view_get_selection(GTK_TREE_VIEW(view)), "changed",
+                   G_CALLBACK(_on_repo_selection_changed), &ed);
+
+  // empty field, nothing selected
+  gtk_widget_set_sensitive(add_btn, FALSE);
+  gtk_widget_set_sensitive(remove_btn, FALSE);
+
+  gtk_widget_show_all(dialog);
+  const gint response = gtk_dialog_run(GTK_DIALOG(dialog));
+
+  if(response == GTK_RESPONSE_ACCEPT)
+  {
+    // the official repository is row zero and not ours to write
+    GList *edited = NULL;
+    GtkTreeIter iter;
+    gboolean valid = gtk_tree_model_get_iter_first(GTK_TREE_MODEL(store), &iter);
+    while(valid)
+    {
+      gchar *repo = NULL;
+      gboolean removable = FALSE;
+      gtk_tree_model_get(GTK_TREE_MODEL(store), &iter,
+                         0, &repo, 1, &removable, -1);
+      if(removable && repo) edited = g_list_append(edited, repo);
+      else g_free(repo);
+      valid = gtk_tree_model_iter_next(GTK_TREE_MODEL(store), &iter);
+    }
+    dt_ai_models_set_third_party_repositories(edited);
+    g_list_free_full(edited, g_free);
+  }
+
+  gtk_widget_destroy(dialog);
+
+  if(response != GTK_RESPONSE_ACCEPT) return;
+
+  // rebuild the combo so an added repository is selectable straight away.
+  // the handler is blocked meanwhile: repopulating fires value-changed for
+  // every entry, and each one would start a fetch
+  const char *current = dt_bauhaus_combobox_get_text(rd->combo);
+  gchar *keep = g_strdup(current);
+
+  g_signal_handlers_block_by_func(rd->combo, _on_repo_combo_changed, rd);
+  dt_bauhaus_combobox_clear(rd->combo);
+
+  GList *repos = dt_ai_models_get_repositories();
+  int index = 0, restore = 0;
+  for(GList *l = repos; l; l = g_list_next(l), index++)
+  {
+    dt_bauhaus_combobox_add(rd->combo, (const char *)l->data);
+    if(!g_strcmp0((const char *)l->data, keep)) restore = index;
+  }
+  g_list_free_full(repos, g_free);
+  g_signal_handlers_unblock_by_func(rd->combo, _on_repo_combo_changed, rd);
+
+  // a removed repository leaves the selection elsewhere, so repopulate
+  dt_bauhaus_combobox_set(rd->combo, restore);
+  g_free(keep);
+}
+
+static void _on_install_from_repository(GtkButton *button, gpointer user_data)
+{
+  dt_prefs_ai_data_t *data = (dt_prefs_ai_data_t *)user_data;
+
+  GList *repositories = dt_ai_models_get_repositories();
+  if(!repositories)
+  {
+    dt_gui_show_yes_no_dialog(_("no repository configured"), "ai_no_repo",
+                              "%s", _("set plugins/ai/repository first"));
+    return;
+  }
+
+  GtkWidget *dialog = gtk_dialog_new_with_buttons(
+    _("install models from repository"),
+    GTK_WINDOW(data->parent_dialog),
+    GTK_DIALOG_MODAL | GTK_DIALOG_DESTROY_WITH_PARENT,
+    _("_cancel"), GTK_RESPONSE_CANCEL,
+    _("_install"), GTK_RESPONSE_ACCEPT,
+    NULL);
+  gtk_window_set_default_size(GTK_WINDOW(dialog), DT_PIXEL_APPLY_DPI(520),
+                              DT_PIXEL_APPLY_DPI(400));
+
+  GtkListStore *store = gtk_list_store_new(REPO_NUM_COLS,
+                                           G_TYPE_BOOLEAN,  // selected
+                                           G_TYPE_STRING,   // name
+                                           G_TYPE_STRING,   // version
+                                           G_TYPE_STRING,   // task
+                                           G_TYPE_STRING,   // status
+                                           G_TYPE_BOOLEAN,  // selectable
+                                           G_TYPE_STRING,   // tooltip
+                                           G_TYPE_POINTER); // entry, owned
+                                                            // by the cache
+
+  // handlers need the dialog state, and some are connected while widgets
+  // are still being built, so it is declared up front and filled in as it
+  // goes rather than assembled at the end
+  dt_repo_dialog_t rd = { 0 };
+  rd.prefs = data;
+  rd.dialog = dialog;
+  rd.store = store;
+  rd.cache = g_hash_table_new_full(
+    g_str_hash, g_str_equal, g_free,
+    (GDestroyNotify)dt_ai_repo_model_list_free);
+
+  GtkWidget *combo = dt_bauhaus_combobox_new(NULL);
+  dt_bauhaus_widget_set_label(combo, NULL, N_("repository"));
+  for(GList *r = repositories; r; r = g_list_next(r))
+    dt_bauhaus_combobox_add(combo, (const char *)r->data);
+
+  rd.combo = combo;
+  // a bauhaus widget carries its own label and expects the full row
+  dt_gui_dialog_add(dialog, combo);
+
+  GtkWidget *view = gtk_tree_view_new_with_model(GTK_TREE_MODEL(store));
+  g_object_unref(store);  // the view holds its own reference now
+  gtk_tree_view_set_headers_visible(GTK_TREE_VIEW(view), TRUE);
+  gtk_tree_view_set_tooltip_column(GTK_TREE_VIEW(view), REPO_COL_TOOLTIP);
+
+  GtkCellRenderer *toggle = gtk_cell_renderer_toggle_new();
+  g_signal_connect(toggle, "toggled", G_CALLBACK(_on_repo_toggle), &rd);
+  gtk_tree_view_append_column(
+    GTK_TREE_VIEW(view),
+    gtk_tree_view_column_new_with_attributes(
+      "", toggle,
+      "active", REPO_COL_SELECTED,
+      "activatable", REPO_COL_SELECTABLE, NULL));
+  gtk_tree_view_append_column(
+    GTK_TREE_VIEW(view),
+    gtk_tree_view_column_new_with_attributes(
+      _("name"), gtk_cell_renderer_text_new(),
+      "text", REPO_COL_NAME, NULL));
+  gtk_tree_view_append_column(
+    GTK_TREE_VIEW(view),
+    gtk_tree_view_column_new_with_attributes(
+      _("version"), gtk_cell_renderer_text_new(),
+      "text", REPO_COL_VERSION, NULL));
+  gtk_tree_view_append_column(
+    GTK_TREE_VIEW(view),
+    gtk_tree_view_column_new_with_attributes(
+      _("task"), gtk_cell_renderer_text_new(),
+      "text", REPO_COL_TASK, NULL));
+  gtk_tree_view_append_column(
+    GTK_TREE_VIEW(view),
+    gtk_tree_view_column_new_with_attributes(
+      _("status"), gtk_cell_renderer_text_new(),
+      "text", REPO_COL_STATUS, NULL));
+
+  // a message replaces the table rather than sitting above it, so the
+  // dialog never shows an empty grid with an explanation floating over it
+  GtkWidget *message = gtk_label_new("");
+  gtk_label_set_line_wrap(GTK_LABEL(message), TRUE);
+  gtk_label_set_justify(GTK_LABEL(message), GTK_JUSTIFY_CENTER);
+  gtk_widget_set_halign(message, GTK_ALIGN_CENTER);
+  gtk_widget_set_valign(message, GTK_ALIGN_CENTER);
+
+  GtkWidget *stack = gtk_stack_new();
+  gtk_widget_set_vexpand(stack, TRUE);
+  gtk_stack_add_named(GTK_STACK(stack), dt_gui_scroll_wrap(view), "list");
+  gtk_stack_add_named(GTK_STACK(stack), message, "message");
+  dt_gui_dialog_add(dialog, stack);
+
+  // editing the list is rare and its effect outlives this dialog, so it
+  // goes to the left of the action row, away from install. same treatment
+  // as the help button in dt_gui_dialog_add_help: GTK_RESPONSE_NONE with
+  // the dialog's own handler disconnected, so clicking does not close it
+  GtkWidget *manage_btn = gtk_dialog_add_button(
+    GTK_DIALOG(dialog), _("manage repositories…"), GTK_RESPONSE_NONE);
+  gtk_widget_set_tooltip_text(manage_btn,
+    _("add or remove the repositories models can be installed from"));
+  // the action row packs to the end, so reordering alone would only move
+  // it within the right-hand cluster; secondary puts it at the far left
+  GtkWidget *action_box = gtk_widget_get_parent(manage_btn);
+  gtk_button_box_set_child_non_homogeneous(GTK_BUTTON_BOX(action_box),
+                                           manage_btn, TRUE);
+  gtk_button_box_set_child_secondary(GTK_BUTTON_BOX(action_box),
+                                     manage_btn, TRUE);
+  g_signal_handlers_disconnect_by_data(manage_btn, dialog);
+  g_signal_connect(manage_btn, "clicked",
+                   G_CALLBACK(_on_manage_repositories), &rd);
+
+  rd.stack = stack;
+  rd.message = message;
+  rd.manage_btn = manage_btn;
+
+  g_signal_connect(combo, "value-changed",
+                   G_CALLBACK(_on_repo_combo_changed), &rd);
+
+  gtk_widget_show_all(dialog);
+  rd.idle_id = g_idle_add(_repo_initial_fetch, &rd);  // fetches the first
+
+  const gint response = gtk_dialog_run(GTK_DIALOG(dialog));
+
+  // rd lives on this stack, so nothing may reference it past here
+  if(rd.idle_id) g_source_remove(rd.idle_id);
+
+  // collect the selection before tearing the dialog down
+  GList *to_install = NULL;
+  if(response == GTK_RESPONSE_ACCEPT)
+  {
+    GtkTreeIter iter;
+    gboolean valid = gtk_tree_model_get_iter_first(GTK_TREE_MODEL(store), &iter);
+    while(valid)
+    {
+      gboolean selected = FALSE;
+      dt_ai_repo_model_t *entry = NULL;
+      gtk_tree_model_get(GTK_TREE_MODEL(store), &iter,
+                         REPO_COL_SELECTED, &selected,
+                         REPO_COL_ENTRY, &entry, -1);
+      if(selected && entry) to_install = g_list_append(to_install, entry);
+      valid = gtk_tree_model_iter_next(GTK_TREE_MODEL(store), &iter);
+    }
+  }
+
+  gtk_widget_destroy(dialog);
+
+  // register first so the shared download dialog applies unchanged
+  gboolean any = FALSE;
+  for(GList *l = to_install; l; l = g_list_next(l))
+  {
+    const dt_ai_repo_model_t *m = (const dt_ai_repo_model_t *)l->data;
+    if(!_confirm_replacement(m)) continue;
+    if(!dt_ai_models_register_repository_model(m)) continue;
+    if(!_download_model_with_dialog(data, m->id))
+    {
+      // nothing landed on disk, so put back what the registration replaced
+      dt_ai_models_unregister_repository_model(m->id);
+      break;  // error or cancel
+    }
+    // only now is the publisher a fact worth recording
+    dt_ai_models_record_origin(m->id, m->repository);
+    any = TRUE;
+  }
+
+  if(any)
+  {
+    dt_ai_models_refresh_status();
+    _refresh_model_list(data);
+  }
+
+  g_list_free(to_install);
+  g_hash_table_destroy(rd.cache);
+  g_list_free_full(repositories, g_free);
+}
+
 #endif // HAVE_AI_DOWNLOAD
 
 static void _on_install_model(GtkButton *button, gpointer user_data)
@@ -1711,6 +2429,7 @@ void init_tab_ai(GtkWidget *dialog, GtkWidget *stack)
     G_TYPE_BOOLEAN, // enabled
     G_TYPE_BOOLEAN, // enabled_sensitive
     G_TYPE_STRING,  // status
+    G_TYPE_STRING,  // repository
     G_TYPE_STRING,  // default
     G_TYPE_STRING); // id
 
@@ -1772,6 +2491,17 @@ void init_tab_ai(GtkWidget *dialog, GtkWidget *stack)
     NULL);
   gtk_tree_view_column_set_expand(name_col, TRUE);
   gtk_tree_view_append_column(GTK_TREE_VIEW(data->model_list), name_col);
+
+  // repository column, shown only when something not from the official
+  // repository is installed — otherwise it would be empty for everyone
+  data->repo_col = gtk_tree_view_column_new_with_attributes(
+    _("repository"),
+    text_renderer,
+    "text",
+    COL_REPOSITORY,
+    NULL);
+  gtk_tree_view_column_set_visible(data->repo_col, FALSE);
+  gtk_tree_view_append_column(GTK_TREE_VIEW(data->model_list), data->repo_col);
 
   // info icon column — click opens model card
   GtkCellRenderer *info_renderer
@@ -1886,6 +2616,7 @@ void init_tab_ai(GtkWidget *dialog, GtkWidget *stack)
     G_CALLBACK(_on_download_selected),
     data);
   dt_gui_box_add(button_box, data->download_selected_btn);
+
 #endif // HAVE_AI_DOWNLOAD
 
   // import from file button
@@ -1895,6 +2626,21 @@ void init_tab_ai(GtkWidget *dialog, GtkWidget *stack)
   gtk_widget_set_margin_start(data->install_btn, DT_PIXEL_APPLY_DPI(16));
   g_signal_connect(data->install_btn, "clicked", G_CALLBACK(_on_install_model), data);
   dt_gui_box_add(button_box, data->install_btn);
+
+#ifdef HAVE_AI_DOWNLOAD
+  // pairs with "import from file…", so no margin between the two
+  data->install_repo_btn
+    = gtk_button_new_with_label(_("install from repository…"));
+  gtk_widget_set_tooltip_text(data->install_repo_btn,
+    _("browse every model the configured repository offers for this version "
+      "of darktable, including any not listed above"));
+  g_signal_connect(
+    data->install_repo_btn,
+    "clicked",
+    G_CALLBACK(_on_install_from_repository),
+    data);
+  dt_gui_box_add(button_box, data->install_repo_btn);
+#endif // HAVE_AI_DOWNLOAD
 
   // delete selected button
   data->delete_selected_btn = gtk_button_new_with_label(_("delete selected"));


### PR DESCRIPTION
Adds "install from repository…" to AI preferences: pick a repository, tick the models you want from its published listing, install. Models installed this way remember where they came from and are included in the update check. Repositories beyond the official one can be added and removed from the dialog.

Models outside darktable's bundled catalog were already installable – "import from file…" takes any `.dtmodel`. But getting one there is a manual round trip: find the repository, open the right release, work out which asset you need, download it, then import it. And that is where it ends. darktable has no idea where the file came from, so it can never tell you a newer version has been published; you only find out by going back and checking by hand.

A repository already publishes a `versions.json` listing everything in its release, which is all darktable needs to do both jobs itself.

<img width="1876" height="1146" alt="pref1" src="https://github.com/user-attachments/assets/7fa0f15f-cc91-446f-8397-89bd026de008" />

## What's in it

A combo at the top of the dialog picks the repository, so two repositories publishing the same model id stay separate instead of merging into one ambiguous list.

<img width="1876" height="1146" alt="pref2" src="https://github.com/user-attachments/assets/a6bf045f-7c18-4a50-8f91-d970cda512a5" />

"manage repositories…" on the action row edits the list, and adding one verifies it first by fetching its listing – the same call the combo makes, so "it verified" and "it will work" mean the same thing. That is also the right moment to say the repository isn't reviewed by the darktable project and that installing a model from it replaces any installed model of the same name.

<img width="1876" height="1146" alt="pref3" src="https://github.com/user-attachments/assets/e718bb5b-ce00-4f6b-b8b7-e8c494503cf9" />

Each install records where it came from, so the models table can name a publisher. That column stays hidden until something is actually installed from outside the official repository – which is why it isn't in the first screenshot – so nothing changes for people who never touch this.

Update checks now cover every configured repository instead of only the official one, with each `versions.json` applying only to its own models – an id another repository happens to reuse is a different model, and giving it the wrong digest would break its next download.

The download cache is keyed on the asset digest rather than `<id>.dtmodel`, which two repositories and two releases both claim, so an interrupted transfer is never resumed into an unrelated one.

## New config

`plugins/ai/third_party_repositories` – comma-separated `owner/repo` list, empty by default. Everything above is inert until someone adds one.

`plugins/ai/repository` keeps the meaning it shipped with in 5.6.0: the repository models come from. A mirror set there is still official as far as this installation is concerned.

## Notes

Third-party repositories are now contacted during the update check, which is mentioned in the config description. Nothing is contacted unless the user has added one.

Installing a model that shadows an installed one asks first. Removing a repository doesn't touch models already installed from it.
