### PR TITLE
Fix OpenCL fast tiling

### DIFF
--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -513,7 +513,6 @@ static gboolean _opencl_device_init(dt_opencl_t *cl,
   cl->dev[dev].summary = CL_COMPLETE;
   cl->dev[dev].used_global_mem = 0;
   cl->dev[dev].max_mem_constant = 0;
-  cl->dev[dev].alignsize = 0;
   cl->dev[dev].compute_units = 0;
   cl->dev[dev].workgroup_size = 0;
   cl->dev[dev].local_size = 0;
@@ -737,36 +736,25 @@ static gboolean _opencl_device_init(dt_opencl_t *cl,
   (cl->dlocl->symbols->dt_clGetDeviceInfo)(devid, CL_DEVICE_IMAGE_SUPPORT,
                                            sizeof(cl_bool), &image_support, NULL);
   (cl->dlocl->symbols->dt_clGetDeviceInfo)(devid, CL_DEVICE_IMAGE2D_MAX_HEIGHT,
-                                           sizeof(size_t),
-                                           &(cl->dev[dev].max_image_height), NULL);
+                                           sizeof(size_t), &cl->dev[dev].max_image_height, NULL);
   (cl->dlocl->symbols->dt_clGetDeviceInfo)(devid, CL_DEVICE_IMAGE2D_MAX_WIDTH,
-                                           sizeof(size_t),
-                                           &(cl->dev[dev].max_image_width), NULL);
+                                           sizeof(size_t), &cl->dev[dev].max_image_width, NULL);
   (cl->dlocl->symbols->dt_clGetDeviceInfo)(devid, CL_DEVICE_MAX_MEM_ALLOC_SIZE,
-                                           sizeof(cl_ulong),
-                                           &(cl->dev[dev].max_mem_alloc), NULL);
+                                           sizeof(cl_ulong), &cl->dev[dev].max_mem_alloc, NULL);
   (cl->dlocl->symbols->dt_clGetDeviceInfo)(devid, CL_DEVICE_ENDIAN_LITTLE,
                                            sizeof(cl_bool), &little_endian, NULL);
   (cl->dlocl->symbols->dt_clGetDeviceInfo)(devid, CL_DEVICE_MAX_CONSTANT_BUFFER_SIZE,
-                                           sizeof(cl_ulong),
-                                           &(cl->dev[dev].max_mem_constant), NULL);
-  (cl->dlocl->symbols->dt_clGetDeviceInfo)(devid, CL_DEVICE_MEM_BASE_ADDR_ALIGN,
-                                           sizeof(cl_uint),
-                                           &(cl->dev[dev].alignsize), NULL);
+                                           sizeof(cl_ulong), &cl->dev[dev].max_mem_constant, NULL);
   (cl->dlocl->symbols->dt_clGetDeviceInfo)(devid, CL_DEVICE_MAX_COMPUTE_UNITS,
-                                           sizeof(cl_uint),
-                                           &(cl->dev[dev].compute_units), NULL);
+                                           sizeof(cl_uint), &cl->dev[dev].compute_units, NULL);
   (cl->dlocl->symbols->dt_clGetDeviceInfo)(devid, CL_DEVICE_MAX_WORK_GROUP_SIZE,
-                                           sizeof(size_t),
-                                           &(cl->dev[dev].workgroup_size), NULL);
+                                           sizeof(size_t), &cl->dev[dev].workgroup_size, NULL);
   (cl->dlocl->symbols->dt_clGetDeviceInfo)(devid, CL_DEVICE_LOCAL_MEM_SIZE,
-                                           sizeof(size_t),
-                                           &(cl->dev[dev].local_size), NULL);
+                                           sizeof(size_t), &cl->dev[dev].local_size, NULL);
 
 #if CL_TARGET_OPENCL_VERSION >= 300
   (cl->dlocl->symbols->dt_clGetDeviceInfo)(devid, CL_DEVICE_PREFERRED_WORK_GROUP_SIZE_MULTIPLE,
-                                           sizeof(size_t),
-                                           &(cl->dev[dev].workgroup_size_rec), NULL);
+                                           sizeof(size_t), &cl->dev[dev].workgroup_size_rec, NULL);
 #endif
 
   // FIXME This test is deprecated for post 1.2 versions so if we do some cl version bump
@@ -890,8 +878,6 @@ static gboolean _opencl_device_init(dt_opencl_t *cl,
                "   MAX CONSTANT BUFFER:      %zu KB\n", (size_t)(cl->dev[dev].max_mem_constant / 1024));
   dt_print_nts(DT_DEBUG_OPENCL,
                "   LOCAL MEM SIZE:           %zu KB\n", (size_t)(cl->dev[dev].local_size / 1024));
-  dt_print_nts(DT_DEBUG_OPENCL,
-               "   ADDRESS ALIGN:            %d B\n", cl->dev[dev].alignsize / 8);
   dt_print_nts(DT_DEBUG_OPENCL,
                "   COMPUTE UNITS:            %d\n", cl->dev[dev].compute_units);
   dt_print_nts(DT_DEBUG_OPENCL,
@@ -3898,13 +3884,13 @@ void dt_opencl_update_settings(void)
       res->cl_uni_memory += cl->dev[i].used_available;
     }
     dt_print_nts(DT_DEBUG_OPENCL,
-         "   AVAILABLE CLMEM SIZE:     %zu MB%s\n",
+         "   AVAILABLE MEM SIZE:       %zu MB%s\n",
               (size_t)(cl->dev[i].used_available / DT_MEGA),
               cl->dev[i].tunehead ? ", tuned" : "");
   }
   if(res->cl_uni_memory)
     dt_print_nts(DT_DEBUG_OPENCL,
-         "   UNIFIED SYSMEM SIZE:      %zu MB\n", (size_t)(res->cl_uni_memory / DT_MEGA));
+         "   UNIFIED MEM SIZE:         %zu MB\n", (size_t)(res->cl_uni_memory / DT_MEGA));
 }
 
 /** read scheduling profile for config variables */

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -3760,27 +3760,34 @@ dt_opencl_tilemode_t dt_opencl_image_fits_device(const int devid,
 
   const int64_t iplane = (int64_t)width * height * ibpp;
   const int64_t oplane = (int64_t)width * height * obpp;
+  const int64_t avail = cl->dev[devid].used_available;
 
-  // always tile as processed image is larger than what device or dt are providing
-  if(cl->dev[devid].max_image_width < width
-      || cl->dev[devid].max_image_height < height
-      || cl->dev[devid].used_available < MAX(iplane, oplane))
-    return DT_OPENCL_TILING;
-
-  const int64_t avail = dt_opencl_get_device_available(devid);
   // total amount of used cl_mem as requested by module tiling code
-  const int64_t tiling_total = iplane * factor + overhead;
+  const int64_t tiling_total = sizeof(float) * 4 * width * height * factor + overhead;
 
-  // available cl_mem allows processing whole image in one bunch
-  if(avail > tiling_total)
-    return cl->fast_tiling ? DT_OPENCL_FAST_TILING : DT_OPENCL_NO_TILING;
+  const gboolean miss_minimal =
+         cl->dev[devid].max_image_width < width
+      || cl->dev[devid].max_image_height < height
+      || avail < (iplane + oplane);
+  const gboolean total_fit = avail > tiling_total;
 
   // how much is available for each fast tile
-  const int64_t tile_mem = avail - overhead - iplane - oplane;
-  if(tile_mem < DT_MEGA) return DT_OPENCL_TILING;
+  const int64_t tilemem = avail - overhead - iplane - oplane;
+  const int64_t perline = sizeof(float) * 4 * width * factor;
+  const int64_t tlines = tilemem / perline;
 
-  const int64_t per_line = width * (ibpp + obpp);
-  const int64_t tlines = tile_mem / per_line;
+  dt_print(DT_DEBUG_TILING | DT_DEBUG_VERBOSE,
+    "test cl tiling: dim=%dx%d, avail=%dMB overhead=%zuMB factor=%.3f tmem=%dMB perline=%dkB tlines=%d",
+    width, height, (int)(avail/DT_MEGA), overhead, factor, (int)(tilemem/DT_MEGA), (int)(perline/1024), (int)tlines);
+
+  // always tile as processed image is larger than what device or dt are providing
+  if(miss_minimal || tilemem < DT_MEGA)
+    return DT_OPENCL_TILING;
+
+  // available cl_mem allows processing whole image in one bunch
+  if(total_fit)
+    return cl->fast_tiling ? DT_OPENCL_FAST_TILING : DT_OPENCL_NO_TILING;
+
   // fast internal OpenCL tiling possible and with a good bet on performance?
   const gboolean good_bet = (tlines - 2*overlap) > (tlines / 5);
   return good_bet ? DT_OPENCL_FAST_TILING : DT_OPENCL_TILING;

--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -134,7 +134,6 @@ typedef struct dt_opencl_device_t
   cl_ulong max_global_mem;
   cl_ulong used_global_mem;
   cl_ulong max_mem_constant;
-  cl_uint alignsize; 
   cl_uint compute_units;
   size_t workgroup_size; 
   size_t workgroup_size_rec;

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -2375,12 +2375,8 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
         && !(dt_pipe_is_preview(pipe) && (module->flags() & IOP_FLAGS_PREVIEW_NON_OPENCL))
         && !_avoid_cl_module(piece);
 
-    const uint32_t m_bpp = MAX(in_bpp, bpp);
-    const size_t m_width = MAX(roi_in.width, roi_out->width);
-    const size_t m_height = MAX(roi_in.height, roi_out->height);
-
     const dt_opencl_tilemode_t fitter =
-      dt_opencl_image_fits_device(pipe->devid, m_width, m_height,
+      dt_opencl_image_fits_device(pipe->devid, roi_in.width, roi_in.height,
                                   in_bpp, bpp, tiling.factor_cl, tiling.overhead, tiling.overlap);
 
     const gboolean no_tiling = fitter == DT_OPENCL_NO_TILING;
@@ -2501,11 +2497,12 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
 
       dt_print_pipe(DT_DEBUG_PIPE,
           bcaching ? "from blend cache" : no_tiling ? "process" : fast_tiling ? "process fast tiled" : "process tiled",
-                        pipe, module, pipe->devid, &roi_in, roi_out, "%s%s%s %zuMB",
+                        pipe, module, pipe->devid, &roi_in, roi_out, "%s%s%s %zuMB avail=%zuMB",
                         dt_iop_colorspace_to_name(cst_to),
                         cst_to != cst_out ? " -> " : "",
                         cst_to != cst_out ? dt_iop_colorspace_to_name(cst_out) : "",
-                        (size_t)(tiling.factor_cl * (m_width * m_height * m_bpp) + tiling.overhead) / DT_MEGA);
+                        (size_t)(sizeof(float) * 4 * roi_in.width * roi_in.height * tiling.factor_cl + tiling.overhead) / DT_MEGA,
+                        (size_t)dt_opencl_get_device_available(pipe->devid) / DT_MEGA);
 
       if(fits_on_device)
       {

--- a/src/develop/tiling.c
+++ b/src/develop/tiling.c
@@ -1783,8 +1783,8 @@ int process_tiling_cl_fast(dt_dev_pixelpipe_iop_t *piece,
   const int64_t allmem = dt_opencl_get_device_available(devid);
   const int64_t avail = allmem - (int64_t)(in_bpp + bpp)*width*height - overhead;
 
-  const int per_row = (in_bpp + bpp) * width;
-  const int tile_height = MIN(_align_up((int)(avail / per_row), aligner), height);
+  const int64_t per_line = sizeof(float) * 4 * width * tiling->factor;
+  const int tile_height = MIN(_align_up((int)(avail / per_line), aligner), height);
   const int valid_rows = tile_height - 2*border;
   if(valid_rows < 1) // should never happen - just make sure, see dt_opencl_image_fits_device()
     return DT_OPENCL_PROCESS_CL;
@@ -1792,7 +1792,8 @@ int process_tiling_cl_fast(dt_dev_pixelpipe_iop_t *piece,
   const int num_tiles = (height + valid_rows - 1) / valid_rows;
   dt_print_pipe(DT_DEBUG_TILING,
     "  fast tiling", pipe, module, devid, roi, NULL,
-    "tiles=%d validrows=%d border=%d", num_tiles, valid_rows, border);
+    "tavail=%dMB tiles=%d validrows=%d border=%d perline=%dKB",
+    (int)(avail/DT_MEGA), num_tiles, valid_rows, border, (int)(per_line / 1024));
 
   cl_int err = CL_SUCCESS;
   cl_mem t_in = dt_opencl_alloc_device(devid, width, tile_height, in_bpp);

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -2033,11 +2033,8 @@ static void _set_trouble_messages(dt_iop_module_t *self)
                             && !temperature_enabled
                             && chr->temperature->default_enabled;
 
-  const gboolean anyproblem = problem1 || problem2 || problem3;
-
-  const dt_image_t *img = &dev->image_storage;
-  dt_print_pipe(DT_DEBUG_PIPE, anyproblem ? "chroma trouble" : "chroma data",
-      NULL, self, DT_DEVICE_NONE, NULL, NULL,
+  if(problem1 || problem2 || problem3)
+    dt_print_pipe(DT_DEBUG_PIPE, "chroma trouble", NULL, self, DT_DEVICE_NONE, NULL, NULL,
       "%s%s%sD65=%s.  D65 %.3f %.3f %.3f, AS-SHOT %.3f %.3f %.3f ID=%i",
       problem1 ? "white balance applied twice, " : "",
       problem2 ? "double CAT applied, " : "",
@@ -2045,7 +2042,7 @@ static void _set_trouble_messages(dt_iop_module_t *self)
       STR_YESNO(_dev_is_D65_chroma(dev)),
       chr->D65coeffs[0], chr->D65coeffs[1], chr->D65coeffs[2],
       chr->as_shot[0], chr->as_shot[1], chr->as_shot[2],
-      img->id);
+      dev->image_storage.id);
 
   if(problem2)
   {

--- a/src/iop/hlreconstruct/opposed.c
+++ b/src/iop/hlreconstruct/opposed.c
@@ -187,7 +187,7 @@ static void _process_linear_opposed(dt_iop_module_t *self,
           img_opphash = opphash;
           img_oppclipped = anyclipped;
         }
-        dt_print_pipe(DT_DEBUG_PIPE,
+        dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_VERBOSE,
             "opposed chroma", piece->pipe, self, DT_DEVICE_CPU, roi_in, NULL,
             "RGB %3.4f %3.4f %3.4f%s%s",
             chrominance[0], chrominance[1], chrominance[2],
@@ -344,7 +344,7 @@ static float *_process_opposed(dt_iop_module_t *self,
         img_oppclipped = anyclipped;
       }
 
-      dt_print_pipe(DT_DEBUG_PIPE,
+      dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_VERBOSE,
           "opposed chroma", piece->pipe, self, DT_DEVICE_CPU, NULL, NULL,
            "%12.7f (%d)%12.7f (%d)%12.7f (%d)%s%s",
           chrominance[0], (int)cnts[0],
@@ -544,7 +544,7 @@ static cl_int process_opposed_cl(dt_iop_module_t *self,
       img_oppclipped = clipped > 0.0f;
     }
 
-    dt_print_pipe(DT_DEBUG_PIPE,
+    dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_VERBOSE,
         "opposed chroma", piece->pipe, self, piece->pipe->devid, NULL, NULL,
         "%12.7f (%d)%12.7f (%d)%12.7f (%d)%s%s",
         chrominance[0], (int)cnts[0],


### PR DESCRIPTION
1. The cl_mem requirements per_line for the OpenCL internal tiling got fixed.
2. Some -d pipe logs got fixed

Fixes #21824