### PR TITLE
fix nested styles auto applying on hover

### DIFF
--- a/src/dtgtk/stylemenu.c
+++ b/src/dtgtk/stylemenu.c
@@ -97,7 +97,6 @@ static void _build_style_submenus(GtkMenuShell *menu,
 {
   // localize the name of the current level in the hierarchy
   const char *split0 = dt_util_localize_string(splits[index]);
-  GtkMenuItem *mi = GTK_MENU_ITEM(gtk_menu_item_new_with_label(split0[0] ? split0 : _("none")));
 
   // check if we already have an item or sub-menu with this name
   GtkMenu *sm = NULL;
@@ -113,35 +112,44 @@ static void _build_style_submenus(GtkMenuShell *menu,
   }
   g_list_free(children);
 
-  if(!splits[index+1])
+  if(splits[index+1])
   {
-    // we've reached the bottom level, so build a final menu item with preview popup
-    // need a tooltip for the signal below to be raised
-    gtk_menu_shell_append(menu, GTK_WIDGET(mi));
-    if(style_name && style_name[0]) // don't add tooltip for "none" style
-    {
-      gtk_widget_set_has_tooltip(GTK_WIDGET(mi), TRUE);
-      g_signal_connect_data(mi, "query-tooltip",
-                            G_CALLBACK(_styles_tooltip_callback),
-                            g_strdup(style_name), (GClosureNotify)g_free, 0);
-      dt_action_define(&darktable.control->actions_global, "styles", style_name, GTK_WIDGET(mi), NULL);
-    }
-    else
-      gtk_widget_set_has_tooltip(GTK_WIDGET(mi), FALSE);
-  }
-  else
-  {
+    // an intermediate level of the hierarchy: reuse the sub-menu built for an
+    // earlier style in the same group, or create the item that opens it
     if(!sm)
     {
-      // we need a sub-menu, but it doesn't exist yet
+      GtkMenuItem *node = GTK_MENU_ITEM(gtk_menu_item_new_with_label(split0));
       sm = (GtkMenu*)gtk_menu_new();
-      gtk_menu_item_set_submenu(mi, GTK_WIDGET(sm));
-      gtk_menu_shell_append(menu, GTK_WIDGET(mi));
+      gtk_menu_item_set_submenu(node, GTK_WIDGET(sm));
+      gtk_menu_shell_append(menu, GTK_WIDGET(node));
+      gtk_widget_show(GTK_WIDGET(node));
     }
     _build_style_submenus(GTK_MENU_SHELL(sm), style_name, splits, index+1,
                           activate_callback, button_callback, user_data);
+    return;
   }
 
+  // we've reached the bottom level, so build a final menu item with preview popup
+  // need a tooltip for the signal below to be raised
+  GtkMenuItem *mi = GTK_MENU_ITEM(gtk_menu_item_new_with_label(split0[0] ? split0 : _("none")));
+  gtk_menu_shell_append(menu, GTK_WIDGET(mi));
+  if(style_name && style_name[0]) // don't add tooltip for "none" style
+  {
+    gtk_widget_set_has_tooltip(GTK_WIDGET(mi), TRUE);
+    g_signal_connect_data(mi, "query-tooltip",
+                          G_CALLBACK(_styles_tooltip_callback),
+                          g_strdup(style_name), (GClosureNotify)g_free, 0);
+    dt_action_define(&darktable.control->actions_global, "styles", style_name, GTK_WIDGET(mi), NULL);
+  }
+  else
+    gtk_widget_set_has_tooltip(GTK_WIDGET(mi), FALSE);
+
+  /* Only the leaf item of a "group|style" hierarchy applies a style.  The
+   * intermediate items merely open their sub-menu, and GtkMenuShell activates
+   * an item that owns a sub-menu as soon as that item is *selected*
+   * (gtk_menu_shell_select_item() calls gtk_widget_activate() on it), so a
+   * style bound there would be applied by moving the pointer over the group
+   * entry, without any click. */
   if(activate_callback)
   {
     dt_stylemenu_data_t *menu_data = malloc(sizeof(dt_stylemenu_data_t));


### PR DESCRIPTION
Hovering over a "group|style" entry in the styles menus applied the style without a click, stacking another copy onto the history every time the pointer crossed the entry again.

_build_style_submenus() connected the "activate" handler and the press gesture to every item it creates, intermediate hierarchy items included, and bound them to the full style name.  GtkMenuShell activates an item that owns a sub-menu as soon as the item is selected:

  gtk_menu_shell_select_item()
    if (GTK_MENU_ITEM (priv->active_menu_item)->priv->submenu)
      gtk_widget_activate (priv->active_menu_item);

so the group item emits "activate" on plain mouse-over.  Connect the callbacks to the leaf items only, which is where they belong anyway: an item whose job is to open a sub-menu never applies a style, by mouse or by keyboard.

Flat style names are unaffected, which is why this only shows up for users who group their styles.  The darkroom, export and print style menus all share this builder.

Fixes #21836 @Arecsu 

Co-Created with Claude Opus 5.0 