### PR TITLE
fix: zoomable lighttable greyed/rejected thumbnails drift out of sync while panning

### DIFF
--- a/src/dtgtk/thumbnail.c
+++ b/src/dtgtk/thumbnail.c
@@ -2425,12 +2425,15 @@ void dt_thumbnail_reload_infos(dt_thumbnail_t *thumb)
      || thumb->over == DT_THUMBNAIL_OVERLAYS_HOVER_BLOCK)
     _thumb_update_extended_infos_line(thumb);
 
-  // we read all other infos
+  // Always refresh the rating (and its greyed/rejected CSS class): when a
+  // thumbnail widget is reused for a different image while panning the
+  // zoomable lighttable, skipping this leaves the previous image's reject
+  // class in place and unrelated images look greyed out.  _image_get_infos()
+  // is safe when overlays are off -- it refreshes the rating and returns
+  // early -- only the on-screen overlay icons are gated on the overlay mode.
+  _image_get_infos(thumb);
   if(thumb->over != DT_THUMBNAIL_OVERLAYS_NONE)
-  {
-    _image_get_infos(thumb);
     _thumb_update_icons(thumb);
-  }
 
   _thumb_write_extension(thumb);
 


### PR DESCRIPTION
When you have rejected images, they are shown correctly (greyed/dimmed) in the filemanager layout. But when you switch to the zoomable lighttable and pan around, random non-rejected images start appearing greyed out, appearing and disappearing as you move.

### Cause

Panning the zoomable grid reuses thumbnail widgets for different images (`_thumb_move_or_create` -> `dt_thumbnail_reload_infos`). That reload only refreshed the rating — and therefore the greyed/rejected CSS class that dims rejected images — when overlay icons were enabled. With overlays turned off, a reused widget kept the previous image's reject class, so unrelated images looked greyed while moving.

### Fix

`_image_get_infos()` already updates the rating (and its CSS class) before returning early for the no-overlay case, so call it unconditionally and keep only the on-screen overlay-icon refresh gated on the overlay mode:

```c
_image_get_infos(thumb);              /* always refresh rating / reject class */
if(thumb->over != DT_THUMBNAIL_OVERLAYS_NONE)
  _thumb_update_icons(thumb);
```

Should fix https://github.com/darktable-org/darktable/issues/20354
