### PR TITLE
fix #21837: Ctrl+A (select all) works when the selection module is collapsed

### DIFF
--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -291,6 +291,12 @@ static float _action_process_toggle(gpointer target,
         case DT_ACTION_EFFECT_ON_CTRL:
         case DT_ACTION_EFFECT_TOGGLE_RIGHT:
         case DT_ACTION_EFFECT_ON_RIGHT:
+          /* gtk_widget_activate() only acts on a realized widget, so a
+           * toggle in a module that has never been expanded (never realized)
+           * would be a silent no-op.  Realize it first, as the pre-gtk4-prep
+           * code did before the synthetic press+release was dropped. */
+          if(!gtk_widget_get_realized(GTK_WIDGET(target)))
+            gtk_widget_realize(GTK_WIDGET(target));
           gtk_widget_activate(GTK_WIDGET(target));
           break;
         default:
@@ -339,9 +345,18 @@ static float _action_process_button(gpointer target,
        * stored-gesture branch above), so on a plain button a right-click
        * shortcut has nothing left to reach and stays a no-op.
        * gtk_widget_activate() is the GTK4-compatible equivalent of the
-       * primary press+release. */
+       * primary press+release.  However it only schedules a click when the
+       * button is realized, so a button in a module that has never been
+       * expanded (and thus never realized) would be a silent no-op (see
+       * #21837: Ctrl+A on a collapsed selection module).  Realize it first,
+       * as the pre-gtk4-prep code did before the synthetic press+release
+       * was dropped. */
       if(effect == DT_ACTION_EFFECT_ACTIVATE || effect == DT_ACTION_EFFECT_ACTIVATE_CTRL)
+      {
+        if(!gtk_widget_get_realized(GTK_WIDGET(target)))
+          gtk_widget_realize(GTK_WIDGET(target));
         gtk_widget_activate(GTK_WIDGET(target));
+      }
     }
   }
 


### PR DESCRIPTION
Fixes #21837 — Ctrl+A (select all) stopped working when the selection module was collapsed at startup. It only came back after expanding and re-collapsing the module once.

This was a regression from the shortcut-activation rework in the gtk4-prep series, which switched module actions from a synthetic press+release to `gtk_widget_activate()`. That broke two things:

- **Buttons in a module that has never been expanded became silent no-ops.** `gtk_widget_activate()` — through GTK3's `gtk_real_button_activate()` — only schedules a click when the widget is *realized*. A button in a collapsed module that has never been expanded is never realized, so nothing happened. Expanding the module once realizes it (and it stays realized), which is exactly why "expand once" fixed it. The old synthetic press+release emitted `clicked` directly and had no such requirement.
- **Toggle buttons (a module's on/off switch) had the same latent problem.** `GtkToggleButton` inherits GtkButton's activate handler, so the same realization gate applied and a shortcut couldn't flip a toggle until the module had been shown.

The fix realizes the widget first (as the pre-gtk4-prep code did before the synthetic press+release was dropped) and then calls `gtk_widget_activate()`. A module action now works via shortcut whether or not its UI has ever been shown.

No behavior change for visible/realized buttons, and nothing new is turned on by default — this restores how module shortcuts behaved before the rework.

Related: #21837
