### PR TITLE
NEEDS WINDOWS TESTING - #21829 darktable steals focus when export progress messages update

### DIFF
--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -1979,6 +1979,7 @@ end:
   // all threads free their fdata
   mformat->free_params(mformat, fdata);
 
+  dt_print(DT_DEBUG_ALWAYS, "[21829] EXPORT ENDED");
   // notify the user via the window manager
   dt_ui_notify_user();
 
@@ -2560,6 +2561,7 @@ void dt_control_export(GList *imgid_list,
 {
   dt_job_t *job = dt_control_job_create(&_control_export_job_run, "export");
   if(!job) return;
+  dt_print(DT_DEBUG_ALWAYS, "[21829] EXPORT STARTED (%d images)", g_list_length(imgid_list));
   dt_control_image_enumerator_t *params = _control_export_alloc();
   if(!params)
   {

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -2371,6 +2371,7 @@ void dt_ui_notify_user()
   if(darktable.gui
      && !gtk_window_is_active(GTK_WINDOW(dt_ui_main_window(darktable.gui->ui))))
   {
+    dt_print(DT_DEBUG_ALWAYS, "[21829] dt_ui_notify_user setting urgency hint (window inactive)");
     gtk_window_set_urgency_hint(GTK_WINDOW(dt_ui_main_window(darktable.gui->ui)), TRUE);
 #ifdef MAC_INTEGRATION
 #ifdef GTK_TYPE_OSX_APPLICATION
@@ -5598,6 +5599,7 @@ void dt_gui_cursor_set_busy()
     {
       GtkWidget *progress_widget = darktable.control->progress_system.proxy.module->widget;
       gtk_widget_realize(progress_widget);
+      dt_print(DT_DEBUG_ALWAYS, "[21829] dt_gui_cursor_set_busy gtk_grab_add on progress widget");
       gtk_grab_add(progress_widget);
     }
   }

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -2030,6 +2030,8 @@ static gboolean _focus_in_out_event(GtkWidget *widget,
                                     GdkEvent *event,
                                     const gpointer user_data)
 {
+  dt_print(DT_DEBUG_ALWAYS, "[21829] main window focus-%s",
+           event->focus_change.in ? "IN" : "OUT");
   gtk_window_set_urgency_hint(GTK_WINDOW(user_data), FALSE);
   return FALSE;
 }

--- a/src/libs/backgroundjobs.c
+++ b/src/libs/backgroundjobs.c
@@ -321,6 +321,7 @@ static void _lib_backgroundjobs_message_updated(dt_lib_module_t *self, dt_lib_ba
 {
   // update the progress bar
   if(!dt_control_running()) return;
+  dt_print(DT_DEBUG_ALWAYS, "[21829] _lib_backgroundjobs_message_updated `%s'", message);
 
   _update_label_gui_thread_t *params = malloc(sizeof(_update_label_gui_thread_t));
   if(!params) return;


### PR DESCRIPTION
## NEEDS WINDOWS TESTING

This PR is a **diagnosis build** for #21829 — on Windows, darktable steals the input focus (and can switch the active virtual desktop) each time an export progress message updates while you're working in another window.

**Please help reproduce it — a macOS/Linux developer can't trigger this.** Any Windows tester is welcome to run the steps below and paste the terminal output.

### Why this build

Static analysis of the export path found **no explicit focus-grabbing call** (`gtk_window_present` / `grab_focus` / `SetForegroundWindow`) — GTK3 on Windows can only steal focus via `gdk_window_focus` (from `gtk_window_present`/`grab_focus`) and transient-window restore, none of which fire during a progress update. The only WM interaction is `dt_ui_notify_user()` → `gtk_window_set_urgency_hint(TRUE)` → `FlashWindowEx(FLASHW_ALL|FLASHW_TIMER)` at the end of a job.

So we need real data. This branch logs the whole export lifecycle plus window focus changes. **Every line already has a timestamp (seconds since darktable started)** and is prefixed `[21829]`:

```
[21829] EXPORT STARTED (N images)
[21829] _lib_backgroundjobs_message_updated 'exporting x / N to …'   (per image)
[21829] main window focus-OUT                                         (you switch to another app)
[21829] main window focus-IN                                          (darktable steals focus back)
[21829] EXPORT ENDED
[21829] dt_ui_notify_user setting urgency hint (window inactive)
[21829] dt_gui_cursor_set_busy gtk_grab_add on progress widget
```

### How to test (Windows)

1. Build this branch, then run it from a **terminal** (a GUI app launched without a console has no stdout):
   ```
   darktable -d dev
   ```
2. Select several images and start a **batch export**.
3. While it runs, **switch to another window / another virtual desktop** and keep typing there, as normal.
4. When the export finishes, quit darktable and **paste the whole terminal output** here — we'll correlate it ourselves.

That's it — no need to time anything manually. The `focus-IN` lines mark exactly when darktable grabs focus, and their timestamps let us match them to the export/progress/notify lines.

### What we're checking

- Do focus steals line up with per-image `_lib_backgroundjobs_message_updated`, or with `dt_ui_notify_user` (once at job end)?
- Does `dt_gui_cursor_set_busy` / `gtk_grab_add` fire during export at all?
- Are focus steals happening even with no progress bar visible (i.e. not a "pops-up" visual)?

Not for merge — temporary diagnostics, will be removed once the cause is pinned down.
