### PR TITLE
always show the duplicate history button in duplicate manager

### DIFF
--- a/src/libs/duplicate.c
+++ b/src/libs/duplicate.c
@@ -356,9 +356,7 @@ static void _lib_duplicate_init_callback(gpointer instance, dt_lib_module_t *sel
     GtkWidget *lb = gtk_label_new(chl);
     gtk_widget_set_hexpand(lb, TRUE);
 
-    // duplicate this image with its history stack; only useful once the image
-    // has actually been developed - otherwise it is equivalent to "original"
-    const gboolean altered = dt_image_altered(imgid);
+    // duplicate this image with its history stack
     GtkWidget *bt_dup = dtgtk_button_new_full(dtgtk_cairo_paint_multiinstance, 0, NULL,
       &(dtgtk_button_config_t){
         .tooltip = _("create a duplicate of this image with same history stack"),
@@ -398,7 +396,7 @@ static void _lib_duplicate_init_callback(gpointer instance, dt_lib_module_t *sel
     gtk_widget_show(hb);
     gtk_widget_show(lb);
     gtk_widget_show(tb);
-    gtk_widget_set_visible(bt_dup, altered);
+    gtk_widget_show(bt_dup);
     gtk_widget_show(bt_orig);
     gtk_widget_show(bt);
 


### PR DESCRIPTION
In duplicate manager the _duplicate with same history_ button is hidden by default and only visible when the image has modifications in the history.

When working with a "fresh" image without changes the button is hidden. And it stays hidden during editing until you exit and re-enter darkroom.

Having this button always visible doesn't hurt, it simply creates a duplicate of the image with the same history stack.

My first approach was to make this dynamically by catching the `DT_SIGNAL_DEVELOP_HISTORY_CHANGE` signal and in the event handler check for `dt_image_altered()` to make the button visible when the image is altered.
This works basically but `dt_image_altered()` gives very unreliable results: Dragging a slider in a module (simply check with the exposure module) sometimes results in `4`, sometimes `0`. Same for any other module. I couldn't see the logic behind that.

So to keep things simple, this PR changes the button to be always visible.

<img width="355" height="149" alt="Bildschirmfoto 2026-08-15 um 08 39 10" src="https://github.com/user-attachments/assets/5067bf36-d810-496d-b710-d439171c6f0f" />

fixes #21822
