### PR TITLE
iop_profile: never alias source and target of a GPU colorspace conversion

### DIFF
--- a/src/common/iop_profile.c
+++ b/src/common/iop_profile.c
@@ -1483,6 +1483,55 @@ void dt_ioppr_free_iccprofile_params_cl(dt_colorspaces_iccprofile_info_cl_t **_p
   *_dev_profile_lut = NULL;
 }
 
+/** Converts an image whose source and target are the same buffer.
+
+    The conversion kernels take their source as read_only and their target as write_only,
+    and OpenCL leaves the result undefined when one image object is bound as both (see
+    clSetKernelArg). Rather than converting a buffer onto itself, this allocates a second
+    image, converts into it, and hands it back in place of the original, which is then
+    released. Callers therefore end up with converted contents in a different object.
+
+    Peak use is two images for the duration of the call, so callers close to the device
+    memory limit should account for the extra one.
+
+    On failure the original buffer is left untouched and still owned by the caller. */
+gboolean dt_ioppr_transform_image_colorspace_replace_cl
+  (struct dt_iop_module_t *self,
+   const int devid,
+   cl_mem *dev_img,
+   const int width,
+   const int height,
+   const dt_iop_colorspace_type_t cst_from,
+   const dt_iop_colorspace_type_t cst_to,
+   dt_iop_colorspace_type_t *converted_cst,
+   const dt_iop_order_iccprofile_info_t *const profile_info)
+{
+  if(dev_img == NULL || *dev_img == NULL) return FALSE;
+
+  // Nothing to do, and no reason to spend an allocation on it.
+  if(cst_from == cst_to)
+  {
+    *converted_cst = cst_to;
+    return TRUE;
+  }
+
+  cl_mem replacement = dt_opencl_alloc_device(devid, width, height, 4 * sizeof(float));
+  if(replacement == NULL) return FALSE;
+
+  const gboolean ok = dt_ioppr_transform_image_colorspace_cl(self, devid, *dev_img, replacement,
+                                                             width, height, cst_from, cst_to,
+                                                             converted_cst, profile_info);
+  if(!ok)
+  {
+    dt_opencl_release_mem_object(replacement);
+    return FALSE;
+  }
+
+  dt_opencl_release_mem_object(*dev_img);
+  *dev_img = replacement;
+  return TRUE;
+}
+
 gboolean dt_ioppr_transform_image_colorspace_cl(struct dt_iop_module_t *self,
                                                 const int devid,
                                                 cl_mem dev_img_in,

--- a/src/common/iop_profile.h
+++ b/src/common/iop_profile.h
@@ -236,6 +236,22 @@ gboolean dt_ioppr_transform_image_colorspace_cl
    dt_iop_colorspace_type_t *converted_cst,
    const dt_iop_order_iccprofile_info_t *const profile_info);
 
+/** Convert an image whose source and target are the same buffer.
+ * A kernel may not take one image object as both its read_only source and its write_only
+ * target, so these convert into a second image and hand it back in place of the original,
+ * releasing the original. Peak use is two images for the duration of the call.
+ * On failure the original is left untouched and still owned by the caller. */
+gboolean dt_ioppr_transform_image_colorspace_replace_cl
+  (struct dt_iop_module_t *self,
+   const int devid,
+   cl_mem *dev_img,
+   const int width,
+   const int height,
+   const dt_iop_colorspace_type_t cst_from,
+   const dt_iop_colorspace_type_t cst_to,
+   dt_iop_colorspace_type_t *converted_cst,
+   const dt_iop_order_iccprofile_info_t *const profile_info);
+
 gboolean dt_ioppr_transform_image_colorspace_rgb_cl
   (const int devid,
    cl_mem dev_img_in,

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -2375,9 +2375,17 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
         && !(dt_pipe_is_preview(pipe) && (module->flags() & IOP_FLAGS_PREVIEW_NON_OPENCL))
         && !_avoid_cl_module(piece);
 
+    /* A colorspace conversion of the input is done before the module runs, into a second
+       image that replaces the original, so one extra full-size buffer is live while it
+       happens. Reserve it in the untiled decision only: if the module has to tile, the
+       conversion is done on the host instead and no device buffer is needed. */
+    const gboolean converting_cl =
+      input_cst_cl != module->input_colorspace(module, pipe, piece);
+    const float untiled_factor_cl = tiling.factor_cl + (converting_cl ? 1.0f : 0.0f);
+
     const dt_opencl_tilemode_t fitter =
       dt_opencl_image_fits_device(pipe->devid, roi_in.width, roi_in.height,
-                                  in_bpp, bpp, tiling.factor_cl, tiling.overhead, tiling.overlap);
+                                  in_bpp, bpp, untiled_factor_cl, tiling.overhead, tiling.overlap);
 
     const gboolean no_tiling = fitter == DT_OPENCL_NO_TILING;
     const gboolean fast_tiling = fitter == DT_OPENCL_FAST_TILING
@@ -2482,9 +2490,14 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
 
         if(cl_mem_input)
         {
-          success_opencl = dt_ioppr_transform_image_colorspace_cl(module, pipe->devid,
-                                                                cl_mem_input, cl_mem_input, roi_in.width, roi_in.height,
+          /* The conversion hands back a different buffer holding the converted contents,
+             so the original is released for us and cl_mem_input has to follow it. On
+             failure it is left pointing at the untouched original. */
+          cl_mem converted = cl_mem_input;
+          success_opencl = dt_ioppr_transform_image_colorspace_replace_cl(module, pipe->devid,
+                                                                &converted, roi_in.width, roi_in.height,
                                                                 cst_from, cst_to, &cst_tmp, work_profile);
+          cl_mem_input = converted;
         }
         else // data for tiling have already been written to host so we transform but have to invalidate
         {
@@ -2687,17 +2700,25 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
            && _transform_for_blend(module, piece))
         {
 
-          success_opencl = dt_ioppr_transform_image_colorspace_cl(module, pipe->devid,
-                                                                  cl_mem_input, cl_mem_input,
+          cl_mem blend_in = cl_mem_input;
+          cl_mem blend_out = *cl_mem_output;
+
+          success_opencl = dt_ioppr_transform_image_colorspace_replace_cl(module, pipe->devid,
+                                                                  &blend_in,
                                                                   roi_in.width, roi_in.height,
                                                                   cst_tmp, blend_cst, &cst_tmp,
                                                                   work_profile);
 
-          success_opencl &= dt_ioppr_transform_image_colorspace_cl(module, pipe->devid,
-                                                                   *cl_mem_output, *cl_mem_output,
+          success_opencl &= dt_ioppr_transform_image_colorspace_replace_cl(module, pipe->devid,
+                                                                   &blend_out,
                                                                    roi_out->width, roi_out->height,
                                                                    pipe->dsc.cst, blend_cst, &pipe->dsc.cst,
                                                                    work_profile);
+
+          /* Each conversion that succeeded replaced its buffer; the ones that did not
+             left theirs alone. Either way these now hold the buffers to carry on with. */
+          cl_mem_input = blend_in;
+          *cl_mem_output = blend_out;
           if(success_opencl && blend_picking)
           {
             _pixelpipe_picker_cl(pipe->devid, module, piece, &piece->dsc_in,

--- a/src/iop/atrous.c
+++ b/src/iop/atrous.c
@@ -454,12 +454,21 @@ int process_cl(dt_iop_module_t *self,
     }
   }
 
-  // add the residue (the coarse scale from the final decomposition)
-  // to the accumulated details
-  // work around CL 1.20 restriction is safe with the kernel,
+  /* Add the residue, the coarse scale from the final decomposition, to the accumulated
+     details. The kernel reads its accumulator and writes the sum, so the two cannot be
+     the same image: clSetKernelArg leaves the result undefined when one image object is
+     bound as both a read_only and a write_only argument.
+
+     After the loop pp_coarse holds the residue and is one of the two scratch buffers,
+     which leaves the other free to receive the sum before it is copied out. */
+  cl_mem residue_dst = (pp_coarse == dev_tmp) ? dev_tmp2 : dev_tmp;
   err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_addbuffers, width, height,
-          CLARG(dev_out), CLARG(dev_out), CLARG(pp_coarse),
+          CLARG(residue_dst), CLARG(dev_out), CLARG(pp_coarse),
           CLARG(width), CLARG(height));
+  if(err != CL_SUCCESS) goto error;
+
+  err = dt_opencl_enqueue_copy_image(devid, residue_dst, dev_out,
+                                     CLIMG_ORIGIN, CLIMG_ORIGIN, area);
 error:
   dt_opencl_release_mem_object(dev_filter);
   dt_opencl_release_mem_object(dev_tmp);

--- a/src/iop/lut3d.c
+++ b/src/iop/lut3d.c
@@ -25,6 +25,7 @@
 #include "common/iop_profile.h"
 #include "common/utility.h"
 #include "develop/imageop.h"
+#include "develop/tiling.h"
 #include "develop/imageop_gui.h"
 #include "dtgtk/button.h"
 #include "gui/gtk.h"
@@ -1032,6 +1033,7 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
     = dt_ioppr_get_iop_work_profile_info(self, self->dev->iop);
   gboolean transform = (work_profile != NULL && lut_profile != NULL) ? TRUE : FALSE;
   cl_mem clut_cl = NULL;
+  cl_mem scratch = NULL;
   const int devid = piece->pipe->devid;
   const int width = roi_in->width;
   const int height = roi_in->height;
@@ -1044,18 +1046,28 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
       err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
       goto cleanup;
     }
+    /* A kernel may not take one image object as both its read_only source and its
+       write_only target, so the profile conversions and the lookup cannot pass dev_out
+       for both. dev_out belongs to the caller and cannot be swapped for another buffer,
+       so a scratch image carries the intermediate: convert into it, apply the lookup
+       from it back into dev_out, then convert dev_out into it and back once more. */
     if(transform)
     {
-      const gboolean success = dt_ioppr_transform_image_colorspace_rgb_cl(devid,
-        dev_in, dev_out, width, height,
-        work_profile, lut_profile, "work profile to LUT profile");
-      if(!success)
-       transform = FALSE;
+      scratch = dt_opencl_alloc_device(devid, width, height, 4 * sizeof(float));
+      if(scratch == NULL)
+      {
+        err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
+        goto cleanup;
+      }
+
+      if(!dt_ioppr_transform_image_colorspace_rgb_cl(devid, dev_in, scratch, width, height,
+        work_profile, lut_profile, "work profile to LUT profile"))
+        transform = FALSE;
     }
+
     if(transform)
-      // FIXME OPENCL is this safe here ?
       err = dt_opencl_enqueue_kernel_2d_args(devid, kernel, width, height,
-              CLARG(dev_out), CLARG(dev_out), CLARG(width), CLARG(height), CLARG(clut_cl), CLARG(level));
+              CLARG(scratch), CLARG(dev_out), CLARG(width), CLARG(height), CLARG(clut_cl), CLARG(level));
     else
       err = dt_opencl_enqueue_kernel_2d_args(devid, kernel, width, height,
               CLARG(dev_in), CLARG(dev_out), CLARG(width), CLARG(height), CLARG(clut_cl), CLARG(level));
@@ -1064,9 +1076,15 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
 
     if(transform)
     {
-      if(!dt_ioppr_transform_image_colorspace_rgb_cl(devid, dev_out, dev_out, width, height,
-        lut_profile, work_profile, "LUT profile to work profile"))
+      if(!dt_ioppr_transform_image_colorspace_rgb_cl(devid, dev_out, scratch, width, height,
+           lut_profile, work_profile, "LUT profile to work profile"))
         err = DT_OPENCL_PROCESS_CL;
+      else
+      {
+        const size_t region[2] = { width, height };
+        err = dt_opencl_enqueue_copy_image(devid, scratch, dev_out,
+                                           CLIMG_ORIGIN, CLIMG_ORIGIN, region);
+      }
     }
   }
   else
@@ -1077,9 +1095,32 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
 
 cleanup:
   dt_opencl_release_mem_object(clut_cl);
+  dt_opencl_release_mem_object(scratch);
   return err;
 }
 #endif
+
+void tiling_callback(dt_iop_module_t *self,
+                     dt_dev_pixelpipe_iop_t *piece,
+                     const dt_iop_roi_t *roi_in,
+                     const dt_iop_roi_t *roi_out,
+                     dt_develop_tiling_t *tiling)
+{
+  const float ioratio = ((float)roi_out->width * roi_out->height)
+                      / ((float)roi_in->width * roi_in->height);
+
+  tiling->factor = 1.0f + ioratio;
+  /* The OpenCL path carries the profile-converted intermediates in a scratch image the
+     size of the input, since the lookup kernel and the conversions cannot read and write
+     one image object. Only allocated when a profile conversion is needed, so this is the
+     worst case. */
+  tiling->factor_cl = tiling->factor + 1.0f;
+  tiling->maxbuf = 1.0f;
+  tiling->maxbuf_cl = tiling->maxbuf;
+  tiling->overhead = 0;
+  tiling->overlap = 0;
+  tiling->align = 1;
+}
 
 void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ibuf, void *const obuf,
              const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)


### PR DESCRIPTION
While playing around with the strange history stack I created with the nested style bug I found another case of NaNs in the image when running the HQ pipe with rusticl:
[opencl_log.txt](https://github.com/user-attachments/files/31097864/opencl_log.txt)

Tagging @jenshannoschwalm. This fixes the issue for me but I am no opencl expert. According to Claude's output OpenCL spec 1.2 §6.12.14 says a kernel cannot both read from and write to the same image object which makes this a darktable bug rather than a rusticl one.

From Claude:
dt_ioppr_transform_image_colorspace_cl() and dt_ioppr_transform_image_colorspace_rgb_cl() passed the caller's buffer
as both the read_only source and the write_only target of the conversion kernels whenever the caller handed in one buffer for both, which is what all call sites in tree do.
 
OpenCL does not define the result of reading from and writing to the same image object inside one kernel. Sampler reads and image writes are separate, non-coherent paths within a launch and work items are not ordered, so a work item can read a texel another work item has already replaced, or a stale copy of one. Being pointwise does not make the kernels safe here; it only means drivers that keep both paths in sync happen to hide the problem. 

Where they do not, the conversion leaves scattered corrupt pixels behind and whatever consumes the buffer inherits them. Feeding such a buffer to the lanczos3 resample in 'scale into final size' turns single bad texels into non-finite output, reported by -d nan as:
 
  [dev_pixelpipe] module `finalscale' outputs NaNs! [full]
 
Observed with rusticl on a Radeon RX 6700 XT; the same pipeline is clean under ROCm, which is why this went unnoticed.
 
Convert into a scratch image and copy the result into place instead.

Co-created with Claude Opus 5.0.
