### PR TITLE
control/crawler: examine sidecar files in parallel and in the background

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -3856,6 +3856,20 @@
     <longdescription>check file modification times of all XMP files on startup to check if any got updated in the meantime</longdescription>
   </dtconfig>
   <dtconfig>
+    <name>run_crawler_in_background</name>
+    <type>bool</type>
+    <default>true</default>
+    <shortdescription>look for updated XMP files in the background</shortdescription>
+    <longdescription>examine one film roll at a time from a background job, most recently opened film roll first, instead of examining the whole library before the user interface appears. opening a film roll that has not been examined yet moves it to the front of the queue.</longdescription>
+  </dtconfig>
+  <dtconfig>
+    <name>crawler_threads</name>
+    <type>int</type>
+    <default>16</default>
+    <shortdescription>number of threads used to look for updated XMP files</shortdescription>
+    <longdescription>the search for updated XMP files is limited by filesystem latency rather than by processing power, so using considerably more threads than there are CPU cores is beneficial, especially when the images are stored on a network share. set to 1 to search serially.</longdescription>
+  </dtconfig>
+  <dtconfig>
     <name>colorlabel/red</name>
     <type>string</type>
     <default></default>

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1810,7 +1810,11 @@ int dt_init(int argc,
   GList *changed_xmp_files = NULL;
   if(init_gui)
   {
-    if(dt_conf_get_bool("run_crawler_on_start") && !dt_gimpmode())
+    // when crawling in the background the scan is started once the gui is
+    // up, so nothing happens here and startup is not delayed by it
+    if(dt_conf_get_bool("run_crawler_on_start")
+       && !dt_conf_get_bool("run_crawler_in_background")
+       && !dt_gimpmode())
     {
       dt_splash_screen_allow_create(TRUE); // allow splash screen if a message is to be displayed
       // scan for cases where the database and xmp files have different timestamps
@@ -2097,6 +2101,11 @@ int dt_init(int argc,
         // files are newer than the db entry
         dt_control_crawler_show_image_list(changed_xmp_files);
       }
+
+      // the gui is up, so the crawl can now proceed out of the user's way,
+      // starting with the most recently opened film rolls
+      if(dt_conf_get_bool("run_crawler_in_background"))
+        dt_control_crawler_start_background();
     }
 
     // show the main window and restore its geometry to that saved in the config file
@@ -2179,6 +2188,8 @@ void dt_cleanup()
   const gboolean init_gui = (darktable.gui != NULL);
 
   dt_stop_backthumbs_crawler(TRUE);
+  // must finish before the database is closed underneath it
+  dt_control_crawler_stop(TRUE);
 
   // last chance to ask user for any input...
 

--- a/src/common/film.c
+++ b/src/common/film.c
@@ -166,11 +166,11 @@ gboolean dt_film_open(const dt_filmid_t id)
   }
   sqlite3_finalize(stmt);
 
-  // the user is about to look at this film roll, so have the background
-  // crawler examine it next instead of whenever its turn would come up.
-  // this does not block: the images are shown from the database right
-  // away, exactly as before.
-  dt_control_crawler_prioritize_filmroll(id);
+  // the user is about to look at this film roll, so make sure its sidecar
+  // files have been checked before its images can be edited.  this waits,
+  // but only for this one film roll rather than for the whole library,
+  // and only until the background crawl has reached it.
+  dt_control_crawler_ensure_filmroll(id);
 
   // TODO: prefetch to cache using image_open
   dt_film_set_query(id);

--- a/src/common/film.c
+++ b/src/common/film.c
@@ -24,6 +24,7 @@
 #include "common/tags.h"
 #include "control/conf.h"
 #include "control/control.h"
+#include "control/crawler.h"
 #include "control/jobs.h"
 #include "views/view.h"
 
@@ -164,6 +165,13 @@ gboolean dt_film_open(const dt_filmid_t id)
     sqlite3_step(stmt);
   }
   sqlite3_finalize(stmt);
+
+  // the user is about to look at this film roll, so have the background
+  // crawler examine it next instead of whenever its turn would come up.
+  // this does not block: the images are shown from the database right
+  // away, exactly as before.
+  dt_control_crawler_prioritize_filmroll(id);
+
   // TODO: prefetch to cache using image_open
   dt_film_set_query(id);
   dt_control_queue_redraw_center();

--- a/src/control/crawler.c
+++ b/src/control/crawler.c
@@ -135,7 +135,8 @@ typedef struct dt_crawler_item_t
   time_t timestamp_db;
   int version;
   int flags;
-  char *image_path;
+  const char *folder;           // shared, owned by the directory list
+  char *filename;               // owned, basename within `folder'
 
   int new_flags;
   char *xmp_path;               // only set when xmp_newer is TRUE
@@ -144,14 +145,31 @@ typedef struct dt_crawler_item_t
   gboolean xmp_newer;
 } dt_crawler_item_t;
 
+// one directory holding a contiguous run of the items above.  a film
+// roll is exactly one directory -- image filenames never contain a path
+// separator -- so this is also the unit the background crawl works in.
+typedef struct dt_crawler_dir_t
+{
+  char *folder;                 // owned
+  int first;                    // index of its first item
+  int count;
+  GHashTable *entries;          // set of the names the directory holds
+} dt_crawler_dir_t;
+
 typedef struct dt_crawler_scan_t
 {
   dt_crawler_item_t *items;
   int num_items;
+  dt_crawler_dir_t *dirs;
+  int num_dirs;
   gboolean look_for_xmp;
   gint next;                    // atomic: next index to hand out
   gint completed;               // atomic: items finished, drives progress
   const gint *abort;            // optional, checked atomically by the workers
+
+  // the directory currently being examined, set by the driver before it
+  // releases the workers on to that directory's range of items
+  const dt_crawler_dir_t *dir;
 } dt_crawler_scan_t;
 
 static inline gboolean _crawler_aborted(const dt_crawler_scan_t *scan)
@@ -159,16 +177,49 @@ static inline gboolean _crawler_aborted(const dt_crawler_scan_t *scan)
   return scan->abort && g_atomic_int_get(scan->abort);
 }
 
-// examine a single image on disk.  this performs no database access and
-// no gui access whatsoever so that it is safe to run from a worker
-// thread.  the early returns mirror the `continue' statements of the
-// original serial implementation -- in particular an image whose xmp is
-// absent deliberately skips the .txt/.wav probe below.
+/* Read the names a directory holds.
+ *
+ * Listing the directory once replaces the six filesystem probes per
+ * image that this used to do -- an existence check, a stat() of the xmp
+ * and four probes for .txt/.wav sidecars -- with a single pass plus one
+ * stat() per xmp actually present.  On a library of ~85k images that is
+ * 506k filesystem calls reduced to 85k, which matters most when the
+ * images live on a network share.
+ *
+ * Returns NULL if the directory cannot be read, which is treated the
+ * same way as it was before: every image in it counts as missing.
+ */
+static GHashTable *_crawler_read_dir(const char *folder)
+{
+  GError *error = NULL;
+  GDir *dir = g_dir_open(folder, 0, &error);
+  if(!dir)
+  {
+    if(error) g_error_free(error);
+    return NULL;
+  }
+
+  GHashTable *entries = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, NULL);
+  const gchar *name;
+  while((name = g_dir_read_name(dir)))
+    g_hash_table_add(entries, g_strdup(name));
+
+  g_dir_close(dir);
+  return entries;
+}
+
+// examine a single image against the listing of the directory holding
+// it.  this performs no database access and no gui access whatsoever so
+// that it is safe to run from a worker thread.  the early returns mirror
+// the `continue' statements of the original serial implementation -- in
+// particular an image whose xmp is absent deliberately skips the
+// .txt/.wav probe below.
 static void _crawler_examine(dt_crawler_item_t *item,
+                             GHashTable *entries,
                              const gboolean look_for_xmp)
 {
   // if the image is missing we ignore it.
-  if(!g_file_test(item->image_path, G_FILE_TEST_EXISTS))
+  if(!entries || !g_hash_table_contains(entries, item->filename))
   {
     item->missing = TRUE;
     return;
@@ -178,16 +229,22 @@ static void _crawler_examine(dt_crawler_item_t *item,
   if(look_for_xmp)
   {
     // construct the xmp filename for this image
-    gchar xmp_path[PATH_MAX] = { 0 };
-    g_strlcpy(xmp_path, item->image_path, sizeof(xmp_path));
-    dt_image_path_append_version_no_db(item->version, xmp_path, sizeof(xmp_path));
-    size_t len = strlen(xmp_path);
+    gchar xmp_name[PATH_MAX] = { 0 };
+    g_strlcpy(xmp_name, item->filename, sizeof(xmp_name));
+    dt_image_path_append_version_no_db(item->version, xmp_name, sizeof(xmp_name));
+    size_t len = strlen(xmp_name);
     if(len + 4 >= PATH_MAX) return;
-    xmp_path[len++] = '.';
-    xmp_path[len++] = 'x';
-    xmp_path[len++] = 'm';
-    xmp_path[len++] = 'p';
-    xmp_path[len] = '\0';
+    xmp_name[len++] = '.';
+    xmp_name[len++] = 'x';
+    xmp_name[len++] = 'm';
+    xmp_name[len++] = 'p';
+    xmp_name[len] = '\0';
+
+    // the listing tells us whether it is there, so the only image we
+    // still have to touch is the one that is
+    if(!g_hash_table_contains(entries, xmp_name)) return;
+
+    gchar *xmp_path = g_build_filename(item->folder, xmp_name, NULL);
 
     // on Windows the encoding might not be UTF8
     gchar *xmp_path_locale = dt_util_normalize_path(xmp_path);
@@ -207,54 +264,62 @@ static void _crawler_examine(dt_crawler_item_t *item,
     stat_res = stat(xmp_path_locale, &statbuf);
 #endif
     g_free(xmp_path_locale);
-    if(stat_res) return; // TODO: shall we report these?
+    if(stat_res)
+    {
+      g_free(xmp_path);
+      return; // TODO: shall we report these?
+    }
 
     // step 1: check if the xmp is newer than our db entry
     if(item->timestamp_db + MAX_TIME_SKEW < statbuf.st_mtime)
     {
       item->xmp_newer = TRUE;
       item->timestamp_xmp = statbuf.st_mtime;
-      item->xmp_path = g_strdup(xmp_path);
+      item->xmp_path = xmp_path;
     }
+    else
+      g_free(xmp_path);
     // older timestamps are the case for all images after the db
     // upgrade. better not report these
   }
 
-  // step 2: check if the image has associated files (.txt, .wav)
-  size_t len = strlen(item->image_path);
-  const char *c = item->image_path + len;
-  while((c > item->image_path) && (*c != '.')) c--;
-  len = c - item->image_path + 1;
+  // step 2: check if the image has associated files (.txt, .wav).  these
+  // are now answered out of the directory listing rather than by probing
+  // the filesystem four more times.
+  size_t len = strlen(item->filename);
+  const char *c = item->filename + len;
+  while((c > item->filename) && (*c != '.')) c--;
+  len = c - item->filename + 1;
 
-  char *extra_path = calloc(len + 3 + 1, sizeof(char));
-  if(extra_path)
+  char *extra_name = calloc(len + 3 + 1, sizeof(char));
+  if(extra_name)
   {
-    g_strlcpy(extra_path, item->image_path, len + 1);
+    g_strlcpy(extra_name, item->filename, len + 1);
 
-    extra_path[len] = 't';
-    extra_path[len + 1] = 'x';
-    extra_path[len + 2] = 't';
-    gboolean has_txt = g_file_test(extra_path, G_FILE_TEST_EXISTS);
+    extra_name[len] = 't';
+    extra_name[len + 1] = 'x';
+    extra_name[len + 2] = 't';
+    gboolean has_txt = g_hash_table_contains(entries, extra_name);
 
     if(!has_txt)
     {
-      extra_path[len] = 'T';
-      extra_path[len + 1] = 'X';
-      extra_path[len + 2] = 'T';
-      has_txt = g_file_test(extra_path, G_FILE_TEST_EXISTS);
+      extra_name[len] = 'T';
+      extra_name[len + 1] = 'X';
+      extra_name[len + 2] = 'T';
+      has_txt = g_hash_table_contains(entries, extra_name);
     }
 
-    extra_path[len] = 'w';
-    extra_path[len + 1] = 'a';
-    extra_path[len + 2] = 'v';
-    gboolean has_wav = g_file_test(extra_path, G_FILE_TEST_EXISTS);
+    extra_name[len] = 'w';
+    extra_name[len + 1] = 'a';
+    extra_name[len + 2] = 'v';
+    gboolean has_wav = g_hash_table_contains(entries, extra_name);
 
     if(!has_wav)
     {
-      extra_path[len] = 'W';
-      extra_path[len + 1] = 'A';
-      extra_path[len + 2] = 'V';
-      has_wav = g_file_test(extra_path, G_FILE_TEST_EXISTS);
+      extra_name[len] = 'W';
+      extra_name[len + 1] = 'A';
+      extra_name[len + 2] = 'V';
+      has_wav = g_hash_table_contains(entries, extra_name);
     }
 
     // TODO: decide if we want to remove the flag for images that lost
@@ -270,19 +335,21 @@ static void _crawler_examine(dt_crawler_item_t *item,
       new_flags &= ~DT_IMAGE_HAS_WAV;
     item->new_flags = new_flags;
 
-    free(extra_path);
+    free(extra_name);
   }
 }
 
 static gpointer _crawler_scan_thread(gpointer arg)
 {
   dt_crawler_scan_t *scan = (dt_crawler_scan_t *)arg;
+  const dt_crawler_dir_t *dir = scan->dir;
+  const int last = dir->first + dir->count;
 
   while(!_crawler_aborted(scan))
   {
     const int idx = g_atomic_int_add(&scan->next, 1);
-    if(idx >= scan->num_items) break;
-    _crawler_examine(&scan->items[idx], scan->look_for_xmp);
+    if(idx >= last) break;
+    _crawler_examine(&scan->items[idx], dir->entries, scan->look_for_xmp);
     g_atomic_int_inc(&scan->completed);
   }
   return NULL;
@@ -295,16 +362,64 @@ static int _crawler_num_threads(void)
   return MIN(num_threads, MAX_CRAWLER_THREADS);
 }
 
-// run the filesystem examination over all collected items.  the calling
-// thread stays responsible for progress reporting so that no gui call is
-// ever made from a worker.
+// examine the items of one directory, spreading them over the worker
+// pool.  the directory listing itself is read by the calling thread.
+static void _crawler_scan_dir(dt_crawler_scan_t *scan,
+                              dt_crawler_dir_t *dir)
+{
+  dir->entries = _crawler_read_dir(dir->folder);
+
+  scan->dir = dir;
+  g_atomic_int_set(&scan->next, dir->first);
+
+  const int num_threads = MIN(_crawler_num_threads(), MAX(dir->count, 1));
+
+  if(num_threads <= 1)
+  {
+    // serial path, kept so that crawler_threads=1 reproduces the
+    // original behaviour exactly for comparison purposes
+    for(int i = dir->first; i < dir->first + dir->count && !_crawler_aborted(scan); i++)
+    {
+      _crawler_examine(&scan->items[i], dir->entries, scan->look_for_xmp);
+      g_atomic_int_inc(&scan->completed);
+    }
+  }
+  else
+  {
+    GThread **threads = calloc(num_threads, sizeof(GThread *));
+    if(threads)
+    {
+      for(int t = 0; t < num_threads; t++)
+        threads[t] = g_thread_new("crawler", _crawler_scan_thread, scan);
+      for(int t = 0; t < num_threads; t++)
+        if(threads[t]) g_thread_join(threads[t]);
+      free(threads);
+    }
+    else
+    {
+      // out of memory: fall back to examining everything inline
+      for(int i = dir->first; i < dir->first + dir->count; i++)
+        _crawler_examine(&scan->items[i], dir->entries, scan->look_for_xmp);
+      g_atomic_int_set(&scan->completed, dir->first + dir->count);
+    }
+  }
+
+  if(dir->entries)
+  {
+    // the listing is only needed while its own directory is examined
+    g_hash_table_destroy(dir->entries);
+    dir->entries = NULL;
+  }
+}
+
+// run the filesystem examination over all collected items, one directory
+// at a time.  the calling thread stays responsible for progress
+// reporting so that no gui call is ever made from a worker.
 static void _crawler_scan_items(dt_crawler_scan_t *scan,
                                 const dt_crawler_progress_cb progress,
                                 void *progress_data)
 {
   if(scan->num_items <= 0) return;
-
-  const int num_threads = MIN(_crawler_num_threads(), scan->num_items);
 
   const double start_time = dt_get_wtime();
   // set the "previous update" time to 10ms after a notional previous
@@ -312,45 +427,10 @@ static void _crawler_scan_items(dt_crawler_scan_t *scan,
   // appear when done with zero delay) while minimizing the delay
   double last_time = start_time - (FAST_UPDATE - 0.01);
 
-  if(num_threads <= 1)
+  for(int d = 0; d < scan->num_dirs && !_crawler_aborted(scan); d++)
   {
-    // serial path, kept so that crawler_threads=1 reproduces the
-    // original behaviour exactly for comparison purposes
-    for(int i = 0; i < scan->num_items && !_crawler_aborted(scan); i++)
-    {
-      _crawler_examine(&scan->items[i], scan->look_for_xmp);
-      scan->completed = i + 1;
+    _crawler_scan_dir(scan, &scan->dirs[d]);
 
-      const double curr_time = dt_get_wtime();
-      if(progress
-         && curr_time >= last_time + ((curr_time - start_time > 4.0)
-                                      ? SLOW_UPDATE : FAST_UPDATE))
-      {
-        progress((i + 1) / (double)scan->num_items,
-                 curr_time - start_time, progress_data);
-        last_time = curr_time;
-      }
-    }
-    return;
-  }
-
-  GThread **threads = calloc(num_threads, sizeof(GThread *));
-  if(!threads)
-  {
-    // out of memory: fall back to examining everything inline
-    for(int i = 0; i < scan->num_items; i++)
-      _crawler_examine(&scan->items[i], scan->look_for_xmp);
-    scan->completed = scan->num_items;
-    return;
-  }
-
-  for(int t = 0; t < num_threads; t++)
-    threads[t] = g_thread_new("crawler", _crawler_scan_thread, scan);
-
-  // drive the progress display while the workers do the waiting
-  while(g_atomic_int_get(&scan->completed) < scan->num_items
-        && !_crawler_aborted(scan))
-  {
     const double curr_time = dt_get_wtime();
     if(progress
        && curr_time >= last_time + ((curr_time - start_time > 4.0)
@@ -360,18 +440,15 @@ static void _crawler_scan_items(dt_crawler_scan_t *scan,
                curr_time - start_time, progress_data);
       last_time = curr_time;
     }
-    g_usleep(20000);
   }
-
-  for(int t = 0; t < num_threads; t++)
-    if(threads[t]) g_thread_join(threads[t]);
-  free(threads);
 }
 
 // collect the images to be examined.  when filmid is a valid film roll
 // only that roll is collected, otherwise the whole library is.
 static dt_crawler_item_t *_crawler_collect_items(const dt_filmid_t filmid,
-                                                 int *num_items)
+                                                 int *num_items,
+                                                 dt_crawler_dir_t **dirs_out,
+                                                 int *num_dirs_out)
 {
   sqlite3_stmt *stmt;
   int capacity = 1024;
@@ -395,14 +472,19 @@ static dt_crawler_item_t *_crawler_collect_items(const dt_filmid_t filmid,
   if(!items)
   {
     *num_items = 0;
+    *num_dirs_out = 0;
+    *dirs_out = NULL;
     return NULL;
   }
 
+  // ordering by film roll keeps the images of one directory in a
+  // contiguous run, which is what lets them be examined a directory at a
+  // time against a single listing of it
   // clang-format off
   if(dt_is_valid_filmid(filmid))
     sqlite3_prepare_v2(dt_database_get(darktable.db),
                        "SELECT i.id, write_timestamp, version,"
-                       "       folder || '" G_DIR_SEPARATOR_S "' || filename, flags"
+                       "       folder, filename, flags"
                        " FROM main.images i, main.film_rolls f"
                        " ON i.film_id = f.id"
                        " WHERE f.id = ?1"
@@ -411,7 +493,7 @@ static dt_crawler_item_t *_crawler_collect_items(const dt_filmid_t filmid,
   else
     sqlite3_prepare_v2(dt_database_get(darktable.db),
                        "SELECT i.id, write_timestamp, version,"
-                       "       folder || '" G_DIR_SEPARATOR_S "' || filename, flags"
+                       "       folder, filename, flags"
                        " FROM main.images i, main.film_rolls f"
                        " ON i.film_id = f.id"
                        " ORDER BY f.id, filename",
@@ -420,6 +502,9 @@ static dt_crawler_item_t *_crawler_collect_items(const dt_filmid_t filmid,
   if(dt_is_valid_filmid(filmid)) DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, filmid);
 
   int count = 0;
+  int num_dirs = 0, dirs_capacity = 0;
+  dt_crawler_dir_t *dirs = NULL;
+
   while(sqlite3_step(stmt) == SQLITE_ROW)
   {
     if(count >= capacity)
@@ -435,31 +520,68 @@ static dt_crawler_item_t *_crawler_collect_items(const dt_filmid_t filmid,
       capacity = new_capacity;
     }
 
+    const char *folder = (const char *)sqlite3_column_text(stmt, 3);
+    const char *filename = (const char *)sqlite3_column_text(stmt, 4);
+    if(!folder || !filename) continue;
+
+    // start a new directory whenever the folder changes
+    if(num_dirs == 0 || strcmp(dirs[num_dirs - 1].folder, folder))
+    {
+      if(num_dirs >= dirs_capacity)
+      {
+        const int new_capacity = MAX(16, dirs_capacity * 2);
+        dt_crawler_dir_t *grown =
+          realloc(dirs, new_capacity * sizeof(dt_crawler_dir_t));
+        if(!grown) break;
+        memset(grown + dirs_capacity, 0,
+               (new_capacity - dirs_capacity) * sizeof(dt_crawler_dir_t));
+        dirs = grown;
+        dirs_capacity = new_capacity;
+      }
+      dirs[num_dirs].folder = g_strdup(folder);
+      dirs[num_dirs].first = count;
+      dirs[num_dirs].count = 0;
+      dirs[num_dirs].entries = NULL;
+      num_dirs++;
+    }
+
     dt_crawler_item_t *item = &items[count];
     item->id = sqlite3_column_int(stmt, 0);
     item->timestamp_db = sqlite3_column_int64(stmt, 1);
     item->version = sqlite3_column_int(stmt, 2);
-    item->image_path = g_strdup((const char *)sqlite3_column_text(stmt, 3));
-    item->flags = sqlite3_column_int(stmt, 4);
+    item->folder = dirs[num_dirs - 1].folder;
+    item->filename = g_strdup(filename);
+    item->flags = sqlite3_column_int(stmt, 5);
     item->new_flags = item->flags;
-    if(!item->image_path) continue;
+    dirs[num_dirs - 1].count++;
     count++;
   }
   sqlite3_finalize(stmt);
 
   *num_items = count;
+  *num_dirs_out = num_dirs;
+  *dirs_out = dirs;
   return items;
 }
 
 static void _crawler_free_items(dt_crawler_item_t *items,
-                                const int num_items)
+                                const int num_items,
+                                dt_crawler_dir_t *dirs,
+                                const int num_dirs)
 {
   for(int i = 0; i < num_items; i++)
   {
-    g_free(items[i].image_path);
+    g_free(items[i].filename);
     g_free(items[i].xmp_path);
   }
   free(items);
+
+  for(int d = 0; d < num_dirs; d++)
+  {
+    g_free(dirs[d].folder);
+    if(dirs[d].entries) g_hash_table_destroy(dirs[d].entries);
+  }
+  free(dirs);
 }
 
 // apply the results gathered by the workers: write back changed flags
@@ -488,8 +610,10 @@ static GList *_crawler_apply_results(dt_crawler_item_t *items,
 
     if(item->missing)
     {
+      gchar *image_path = g_build_filename(item->folder, item->filename, NULL);
       dt_print(DT_DEBUG_CONTROL, "[crawler] `%s' (id: %d) is missing",
-               item->image_path, item->id);
+               image_path, item->id);
+      g_free(image_path);
       continue;
     }
 
@@ -501,7 +625,7 @@ static GList *_crawler_apply_results(dt_crawler_item_t *items,
         entry->id = item->id;
         entry->timestamp_xmp = item->timestamp_xmp;
         entry->timestamp_db = item->timestamp_db;
-        entry->image_path = g_strdup(item->image_path);
+        entry->image_path = g_build_filename(item->folder, item->filename, NULL);
         entry->xmp_path = g_strdup(item->xmp_path);
 
         result = g_list_prepend(result, entry);
@@ -549,7 +673,8 @@ static GList *_crawler_run_filmroll(const dt_filmid_t filmid,
   dt_crawler_scan_t scan = { 0 };
   scan.look_for_xmp = dt_image_get_xmp_mode() != DT_WRITE_XMP_NEVER;
   scan.abort = abort;
-  scan.items = _crawler_collect_items(filmid, &scan.num_items);
+  scan.items = _crawler_collect_items(filmid, &scan.num_items,
+                                      &scan.dirs, &scan.num_dirs);
   if(!scan.items) return NULL;
 
   const double start_time = dt_get_wtime();
@@ -557,7 +682,7 @@ static GList *_crawler_run_filmroll(const dt_filmid_t filmid,
   const double scan_time = dt_get_wtime() - start_time;
 
   GList *result = _crawler_apply_results(scan.items, scan.num_items, flags_changed);
-  _crawler_free_items(scan.items, scan.num_items);
+  _crawler_free_items(scan.items, scan.num_items, scan.dirs, scan.num_dirs);
 
   if(dt_is_valid_filmid(filmid))
     dt_print(DT_DEBUG_CONTROL,
@@ -566,9 +691,9 @@ static GList *_crawler_run_filmroll(const dt_filmid_t filmid,
              filmid, scan.num_items, scan_time, g_list_length(result));
   else
     dt_print(DT_DEBUG_CONTROL,
-             "[crawler] examined %d images in %.2fs using %d threads,"
-             " %d updated XMP files found",
-             scan.num_items, scan_time,
+             "[crawler] examined %d images in %d directories in %.2fs"
+             " using %d threads, %d updated XMP files found",
+             scan.num_items, scan.num_dirs, scan_time,
              MIN(_crawler_num_threads(), MAX(scan.num_items, 1)),
              g_list_length(result));
 

--- a/src/control/crawler.c
+++ b/src/control/crawler.c
@@ -22,6 +22,7 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "common/collection.h"
 #include "common/darktable.h"
 #include "common/database.h"
 #include "common/debug.h"
@@ -110,194 +111,788 @@ static void _set_modification_time(char *filename,
 #define FAST_UPDATE 0.2
 #define SLOW_UPDATE 1.0
 
-GList *dt_control_crawler_run(void)
-{
-  sqlite3_stmt *stmt, *inner_stmt;
-  GList *result = NULL;
-  const gboolean look_for_xmp = dt_image_get_xmp_mode() != DT_WRITE_XMP_NEVER;
+// number of concurrent workers used to examine the filesystem.  the
+// crawl is dominated by filesystem latency rather than cpu work --
+// overwhelmingly so for libraries stored on a network share -- so we
+// deliberately oversubscribe instead of scaling with the core count.
+#define DEFAULT_CRAWLER_THREADS 16
+#define MAX_CRAWLER_THREADS 64
 
-  int total_images = 1;
-  // clang-format off
-  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
-                              "SELECT COUNT(*) FROM main.images", -1, &stmt, 0);
-  // clang-format on
-  if(sqlite3_step(stmt) == SQLITE_ROW)
+// reported back to the caller while a scan is in progress.  the splash
+// screen uses this during startup, the background job uses it to drive
+// a progress bar in the gui.
+typedef void (*dt_crawler_progress_cb)(const double fraction,
+                                       const double elapsed,
+                                       void *data);
+
+// one image to be examined.  everything up to and including `flags' is
+// filled in by the collecting pass, the remaining fields are written by
+// the worker threads -- each worker touches only its own item, so no
+// locking is required.
+typedef struct dt_crawler_item_t
+{
+  dt_imgid_t id;
+  time_t timestamp_db;
+  int version;
+  int flags;
+  char *image_path;
+
+  int new_flags;
+  char *xmp_path;               // only set when xmp_newer is TRUE
+  time_t timestamp_xmp;
+  gboolean missing;
+  gboolean xmp_newer;
+} dt_crawler_item_t;
+
+typedef struct dt_crawler_scan_t
+{
+  dt_crawler_item_t *items;
+  int num_items;
+  gboolean look_for_xmp;
+  gint next;                    // atomic: next index to hand out
+  gint completed;               // atomic: items finished, drives progress
+  const gint *abort;            // optional, checked atomically by the workers
+} dt_crawler_scan_t;
+
+static inline gboolean _crawler_aborted(const dt_crawler_scan_t *scan)
+{
+  return scan->abort && g_atomic_int_get(scan->abort);
+}
+
+// examine a single image on disk.  this performs no database access and
+// no gui access whatsoever so that it is safe to run from a worker
+// thread.  the early returns mirror the `continue' statements of the
+// original serial implementation -- in particular an image whose xmp is
+// absent deliberately skips the .txt/.wav probe below.
+static void _crawler_examine(dt_crawler_item_t *item,
+                             const gboolean look_for_xmp)
+{
+  // if the image is missing we ignore it.
+  if(!g_file_test(item->image_path, G_FILE_TEST_EXISTS))
   {
-    total_images = sqlite3_column_int(stmt, 0);
-    sqlite3_finalize(stmt);
+    item->missing = TRUE;
+    return;
   }
 
-  // clang-format off
-  sqlite3_prepare_v2(dt_database_get(darktable.db),
-                     "SELECT i.id, write_timestamp, version,"
-                     "       folder || '" G_DIR_SEPARATOR_S "' || filename, flags"
-                     " FROM main.images i, main.film_rolls f"
-                     " ON i.film_id = f.id"
-                     " ORDER BY f.id, filename",
-                     -1, &stmt, NULL);
-  sqlite3_prepare_v2(dt_database_get(darktable.db),
-                     "UPDATE main.images SET flags = ?1 WHERE id = ?2", -1,
-                     &inner_stmt, NULL);
-  // clang-format on
+  // no need to look for xmp files if none get written anyway.
+  if(look_for_xmp)
+  {
+    // construct the xmp filename for this image
+    gchar xmp_path[PATH_MAX] = { 0 };
+    g_strlcpy(xmp_path, item->image_path, sizeof(xmp_path));
+    dt_image_path_append_version_no_db(item->version, xmp_path, sizeof(xmp_path));
+    size_t len = strlen(xmp_path);
+    if(len + 4 >= PATH_MAX) return;
+    xmp_path[len++] = '.';
+    xmp_path[len++] = 'x';
+    xmp_path[len++] = 'm';
+    xmp_path[len++] = 'p';
+    xmp_path[len] = '\0';
 
-  // let's wrap this into a transaction, it might make it a little faster.
-  dt_database_start_transaction(darktable.db);
+    // on Windows the encoding might not be UTF8
+    gchar *xmp_path_locale = dt_util_normalize_path(xmp_path);
+    int stat_res = -1;
+#ifdef _WIN32
+    // UTF8 paths fail in this context, but converting to UTF16 works
+    struct _stati64 statbuf;
+    if(xmp_path_locale) // in Windows dt_util_normalize_path returns
+                        // NULL if file does not exist
+    {
+      wchar_t *wfilename = g_utf8_to_utf16(xmp_path_locale, -1, NULL, NULL, NULL);
+      stat_res = _wstati64(wfilename, &statbuf);
+      g_free(wfilename);
+    }
+#else
+    struct stat statbuf;
+    stat_res = stat(xmp_path_locale, &statbuf);
+#endif
+    g_free(xmp_path_locale);
+    if(stat_res) return; // TODO: shall we report these?
 
-  int image_count = 0;
+    // step 1: check if the xmp is newer than our db entry
+    if(item->timestamp_db + MAX_TIME_SKEW < statbuf.st_mtime)
+    {
+      item->xmp_newer = TRUE;
+      item->timestamp_xmp = statbuf.st_mtime;
+      item->xmp_path = g_strdup(xmp_path);
+    }
+    // older timestamps are the case for all images after the db
+    // upgrade. better not report these
+  }
+
+  // step 2: check if the image has associated files (.txt, .wav)
+  size_t len = strlen(item->image_path);
+  const char *c = item->image_path + len;
+  while((c > item->image_path) && (*c != '.')) c--;
+  len = c - item->image_path + 1;
+
+  char *extra_path = calloc(len + 3 + 1, sizeof(char));
+  if(extra_path)
+  {
+    g_strlcpy(extra_path, item->image_path, len + 1);
+
+    extra_path[len] = 't';
+    extra_path[len + 1] = 'x';
+    extra_path[len + 2] = 't';
+    gboolean has_txt = g_file_test(extra_path, G_FILE_TEST_EXISTS);
+
+    if(!has_txt)
+    {
+      extra_path[len] = 'T';
+      extra_path[len + 1] = 'X';
+      extra_path[len + 2] = 'T';
+      has_txt = g_file_test(extra_path, G_FILE_TEST_EXISTS);
+    }
+
+    extra_path[len] = 'w';
+    extra_path[len + 1] = 'a';
+    extra_path[len + 2] = 'v';
+    gboolean has_wav = g_file_test(extra_path, G_FILE_TEST_EXISTS);
+
+    if(!has_wav)
+    {
+      extra_path[len] = 'W';
+      extra_path[len + 1] = 'A';
+      extra_path[len + 2] = 'V';
+      has_wav = g_file_test(extra_path, G_FILE_TEST_EXISTS);
+    }
+
+    // TODO: decide if we want to remove the flag for images that lost
+    // their extra file. currently we do (the else cases)
+    int new_flags = item->flags;
+    if(has_txt)
+      new_flags |= DT_IMAGE_HAS_TXT;
+    else
+      new_flags &= ~DT_IMAGE_HAS_TXT;
+    if(has_wav)
+      new_flags |= DT_IMAGE_HAS_WAV;
+    else
+      new_flags &= ~DT_IMAGE_HAS_WAV;
+    item->new_flags = new_flags;
+
+    free(extra_path);
+  }
+}
+
+static gpointer _crawler_scan_thread(gpointer arg)
+{
+  dt_crawler_scan_t *scan = (dt_crawler_scan_t *)arg;
+
+  while(!_crawler_aborted(scan))
+  {
+    const int idx = g_atomic_int_add(&scan->next, 1);
+    if(idx >= scan->num_items) break;
+    _crawler_examine(&scan->items[idx], scan->look_for_xmp);
+    g_atomic_int_inc(&scan->completed);
+  }
+  return NULL;
+}
+
+static int _crawler_num_threads(void)
+{
+  int num_threads = dt_conf_get_int("crawler_threads");
+  if(num_threads < 1) num_threads = DEFAULT_CRAWLER_THREADS;
+  return MIN(num_threads, MAX_CRAWLER_THREADS);
+}
+
+// run the filesystem examination over all collected items.  the calling
+// thread stays responsible for progress reporting so that no gui call is
+// ever made from a worker.
+static void _crawler_scan_items(dt_crawler_scan_t *scan,
+                                const dt_crawler_progress_cb progress,
+                                void *progress_data)
+{
+  if(scan->num_items <= 0) return;
+
+  const int num_threads = MIN(_crawler_num_threads(), scan->num_items);
+
   const double start_time = dt_get_wtime();
   // set the "previous update" time to 10ms after a notional previous
   // update to ensure visibility of the first update (which might not
   // appear when done with zero delay) while minimizing the delay
-  double last_time = start_time - (FAST_UPDATE-0.01);
+  double last_time = start_time - (FAST_UPDATE - 0.01);
 
-  while(sqlite3_step(stmt) == SQLITE_ROW)
+  if(num_threads <= 1)
   {
-    const dt_imgid_t id = sqlite3_column_int(stmt, 0);
-    const time_t timestamp = sqlite3_column_int64(stmt, 1);
-    const int version = sqlite3_column_int(stmt, 2);
-    const gchar *image_path = (char *)sqlite3_column_text(stmt, 3);
-    int flags = sqlite3_column_int(stmt, 4);
-    ++image_count;
-
-    // update the progress message - five times per second for first
-    // four seconds, then once per second.
-    const double curr_time = dt_get_wtime();
-    if(curr_time >= last_time + ((curr_time - start_time > 4.0) ? SLOW_UPDATE : FAST_UPDATE))
+    // serial path, kept so that crawler_threads=1 reproduces the
+    // original behaviour exactly for comparison purposes
+    for(int i = 0; i < scan->num_items && !_crawler_aborted(scan); i++)
     {
-      const double fraction = image_count / (double)total_images;
-      dt_splash_screen_set_progress_percent(_("checking for updated sidecar files (%d%%)"),
-                                            fraction,
-                                            curr_time - start_time);
+      _crawler_examine(&scan->items[i], scan->look_for_xmp);
+      scan->completed = i + 1;
+
+      const double curr_time = dt_get_wtime();
+      if(progress
+         && curr_time >= last_time + ((curr_time - start_time > 4.0)
+                                      ? SLOW_UPDATE : FAST_UPDATE))
+      {
+        progress((i + 1) / (double)scan->num_items,
+                 curr_time - start_time, progress_data);
+        last_time = curr_time;
+      }
+    }
+    return;
+  }
+
+  GThread **threads = calloc(num_threads, sizeof(GThread *));
+  if(!threads)
+  {
+    // out of memory: fall back to examining everything inline
+    for(int i = 0; i < scan->num_items; i++)
+      _crawler_examine(&scan->items[i], scan->look_for_xmp);
+    scan->completed = scan->num_items;
+    return;
+  }
+
+  for(int t = 0; t < num_threads; t++)
+    threads[t] = g_thread_new("crawler", _crawler_scan_thread, scan);
+
+  // drive the progress display while the workers do the waiting
+  while(g_atomic_int_get(&scan->completed) < scan->num_items
+        && !_crawler_aborted(scan))
+  {
+    const double curr_time = dt_get_wtime();
+    if(progress
+       && curr_time >= last_time + ((curr_time - start_time > 4.0)
+                                    ? SLOW_UPDATE : FAST_UPDATE))
+    {
+      progress(g_atomic_int_get(&scan->completed) / (double)scan->num_items,
+               curr_time - start_time, progress_data);
       last_time = curr_time;
     }
+    g_usleep(20000);
+  }
 
-    // if the image is missing we ignore it.
-    if(!g_file_test(image_path, G_FILE_TEST_EXISTS))
+  for(int t = 0; t < num_threads; t++)
+    if(threads[t]) g_thread_join(threads[t]);
+  free(threads);
+}
+
+// collect the images to be examined.  when filmid is a valid film roll
+// only that roll is collected, otherwise the whole library is.
+static dt_crawler_item_t *_crawler_collect_items(const dt_filmid_t filmid,
+                                                 int *num_items)
+{
+  sqlite3_stmt *stmt;
+  int capacity = 1024;
+
+  // reserve based on the number of images we expect to see
+  // clang-format off
+  if(dt_is_valid_filmid(filmid))
+    DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
+                                "SELECT COUNT(*) FROM main.images WHERE film_id = ?1",
+                                -1, &stmt, 0);
+  else
+    DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
+                                "SELECT COUNT(*) FROM main.images", -1, &stmt, 0);
+  // clang-format on
+  if(dt_is_valid_filmid(filmid)) DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, filmid);
+  if(sqlite3_step(stmt) == SQLITE_ROW)
+    capacity = MAX(1, sqlite3_column_int(stmt, 0));
+  sqlite3_finalize(stmt);
+
+  dt_crawler_item_t *items = calloc(capacity, sizeof(dt_crawler_item_t));
+  if(!items)
+  {
+    *num_items = 0;
+    return NULL;
+  }
+
+  // clang-format off
+  if(dt_is_valid_filmid(filmid))
+    sqlite3_prepare_v2(dt_database_get(darktable.db),
+                       "SELECT i.id, write_timestamp, version,"
+                       "       folder || '" G_DIR_SEPARATOR_S "' || filename, flags"
+                       " FROM main.images i, main.film_rolls f"
+                       " ON i.film_id = f.id"
+                       " WHERE f.id = ?1"
+                       " ORDER BY f.id, filename",
+                       -1, &stmt, NULL);
+  else
+    sqlite3_prepare_v2(dt_database_get(darktable.db),
+                       "SELECT i.id, write_timestamp, version,"
+                       "       folder || '" G_DIR_SEPARATOR_S "' || filename, flags"
+                       " FROM main.images i, main.film_rolls f"
+                       " ON i.film_id = f.id"
+                       " ORDER BY f.id, filename",
+                       -1, &stmt, NULL);
+  // clang-format on
+  if(dt_is_valid_filmid(filmid)) DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, filmid);
+
+  int count = 0;
+  while(sqlite3_step(stmt) == SQLITE_ROW)
+  {
+    if(count >= capacity)
     {
-      dt_print(DT_DEBUG_CONTROL, "[crawler] `%s' (id: %d) is missing", image_path, id);
+      // the database changed underneath us, grow to fit
+      const int new_capacity = capacity * 2;
+      dt_crawler_item_t *grown =
+        realloc(items, new_capacity * sizeof(dt_crawler_item_t));
+      if(!grown) break;
+      memset(grown + capacity, 0,
+             (new_capacity - capacity) * sizeof(dt_crawler_item_t));
+      items = grown;
+      capacity = new_capacity;
+    }
+
+    dt_crawler_item_t *item = &items[count];
+    item->id = sqlite3_column_int(stmt, 0);
+    item->timestamp_db = sqlite3_column_int64(stmt, 1);
+    item->version = sqlite3_column_int(stmt, 2);
+    item->image_path = g_strdup((const char *)sqlite3_column_text(stmt, 3));
+    item->flags = sqlite3_column_int(stmt, 4);
+    item->new_flags = item->flags;
+    if(!item->image_path) continue;
+    count++;
+  }
+  sqlite3_finalize(stmt);
+
+  *num_items = count;
+  return items;
+}
+
+static void _crawler_free_items(dt_crawler_item_t *items,
+                                const int num_items)
+{
+  for(int i = 0; i < num_items; i++)
+  {
+    g_free(items[i].image_path);
+    g_free(items[i].xmp_path);
+  }
+  free(items);
+}
+
+// apply the results gathered by the workers: write back changed flags
+// and build the list of images whose xmp is newer than the database.
+// this runs single threaded on the caller's thread and walks the items
+// in collection order, so the resulting list is identical to the one
+// produced by the original serial implementation.
+static GList *_crawler_apply_results(dt_crawler_item_t *items,
+                                     const int num_items,
+                                     int *flags_changed)
+{
+  GList *result = NULL;
+  sqlite3_stmt *inner_stmt;
+  int changed = 0;
+
+  sqlite3_prepare_v2(dt_database_get(darktable.db),
+                     "UPDATE main.images SET flags = ?1 WHERE id = ?2", -1,
+                     &inner_stmt, NULL);
+
+  // let's wrap this into a transaction, it might make it a little faster.
+  dt_database_start_transaction(darktable.db);
+
+  for(int i = 0; i < num_items; i++)
+  {
+    dt_crawler_item_t *item = &items[i];
+
+    if(item->missing)
+    {
+      dt_print(DT_DEBUG_CONTROL, "[crawler] `%s' (id: %d) is missing",
+               item->image_path, item->id);
       continue;
     }
 
-    // no need to look for xmp files if none get written anyway.
-    if(look_for_xmp)
+    if(item->xmp_newer)
     {
-      // construct the xmp filename for this image
-      gchar xmp_path[PATH_MAX] = { 0 };
-      g_strlcpy(xmp_path, image_path, sizeof(xmp_path));
-      dt_image_path_append_version_no_db(version, xmp_path, sizeof(xmp_path));
-      size_t len = strlen(xmp_path);
-      if(len + 4 >= PATH_MAX) continue;
-      xmp_path[len++] = '.';
-      xmp_path[len++] = 'x';
-      xmp_path[len++] = 'm';
-      xmp_path[len++] = 'p';
-      xmp_path[len] = '\0';
-
-      // on Windows the encoding might not be UTF8
-      gchar *xmp_path_locale = dt_util_normalize_path(xmp_path);
-      int stat_res = -1;
-#ifdef _WIN32
-      // UTF8 paths fail in this context, but converting to UTF16 works
-      struct _stati64 statbuf;
-      if(xmp_path_locale) // in Windows dt_util_normalize_path returns
-                          // NULL if file does not exist
+      dt_control_crawler_result_t *entry = malloc(sizeof(dt_control_crawler_result_t));
+      if(entry)
       {
-        wchar_t *wfilename = g_utf8_to_utf16(xmp_path_locale, -1, NULL, NULL, NULL);
-        stat_res = _wstati64(wfilename, &statbuf);
-        g_free(wfilename);
-      }
- #else
-      struct stat statbuf;
-      stat_res = stat(xmp_path_locale, &statbuf);
-#endif
-      g_free(xmp_path_locale);
-      if(stat_res) continue; // TODO: shall we report these?
+        entry->id = item->id;
+        entry->timestamp_xmp = item->timestamp_xmp;
+        entry->timestamp_db = item->timestamp_db;
+        entry->image_path = g_strdup(item->image_path);
+        entry->xmp_path = g_strdup(item->xmp_path);
 
-      // step 1: check if the xmp is newer than our db entry
-      if(timestamp + MAX_TIME_SKEW < statbuf.st_mtime)
-      {
-        dt_control_crawler_result_t *item = malloc(sizeof(dt_control_crawler_result_t));
-        item->id = id;
-        item->timestamp_xmp = statbuf.st_mtime;
-        item->timestamp_db = timestamp;
-        item->image_path = g_strdup(image_path);
-        item->xmp_path = g_strdup(xmp_path);
-
-        result = g_list_prepend(result, item);
+        result = g_list_prepend(result, entry);
         dt_print(DT_DEBUG_CONTROL,
-                 "[crawler] `%s' (id: %d) is a newer XMP file", xmp_path, id);
+                 "[crawler] `%s' (id: %d) is a newer XMP file",
+                 item->xmp_path, item->id);
       }
-      // older timestamps are the case for all images after the db
-      // upgrade. better not report these
     }
 
-    // step 2: check if the image has associated files (.txt, .wav)
-    size_t len = strlen(image_path);
-    const char *c = image_path + len;
-    while((c > image_path) && (*c != '.')) c--;
-    len = c - image_path + 1;
-
-    char *extra_path = calloc(len + 3 + 1, sizeof(char));
-    if(extra_path)
+    if(item->new_flags != item->flags)
     {
-      g_strlcpy(extra_path, image_path, len + 1);
-
-      extra_path[len] = 't';
-      extra_path[len + 1] = 'x';
-      extra_path[len + 2] = 't';
-      gboolean has_txt = g_file_test(extra_path, G_FILE_TEST_EXISTS);
-
-      if(!has_txt)
-      {
-        extra_path[len] = 'T';
-        extra_path[len + 1] = 'X';
-        extra_path[len + 2] = 'T';
-        has_txt = g_file_test(extra_path, G_FILE_TEST_EXISTS);
-      }
-
-      extra_path[len] = 'w';
-      extra_path[len + 1] = 'a';
-      extra_path[len + 2] = 'v';
-      gboolean has_wav = g_file_test(extra_path, G_FILE_TEST_EXISTS);
-
-      if(!has_wav)
-      {
-        extra_path[len] = 'W';
-        extra_path[len + 1] = 'A';
-        extra_path[len + 2] = 'V';
-        has_wav = g_file_test(extra_path, G_FILE_TEST_EXISTS);
-      }
-
-      // TODO: decide if we want to remove the flag for images that lost
-      // their extra file. currently we do (the else cases)
-      int new_flags = flags;
-      if(has_txt)
-        new_flags |= DT_IMAGE_HAS_TXT;
-      else
-        new_flags &= ~DT_IMAGE_HAS_TXT;
-      if(has_wav)
-        new_flags |= DT_IMAGE_HAS_WAV;
-      else
-        new_flags &= ~DT_IMAGE_HAS_WAV;
-      if(flags != new_flags)
-      {
-        sqlite3_bind_int(inner_stmt, 1, new_flags);
-        sqlite3_bind_int(inner_stmt, 2, id);
-        sqlite3_step(inner_stmt);
-        sqlite3_reset(inner_stmt);
-        sqlite3_clear_bindings(inner_stmt);
-      }
-
-      free(extra_path);
+      sqlite3_bind_int(inner_stmt, 1, item->new_flags);
+      sqlite3_bind_int(inner_stmt, 2, item->id);
+      sqlite3_step(inner_stmt);
+      sqlite3_reset(inner_stmt);
+      sqlite3_clear_bindings(inner_stmt);
+      changed++;
     }
   }
 
   dt_database_release_transaction(darktable.db);
-
-  sqlite3_finalize(stmt);
   sqlite3_finalize(inner_stmt);
 
+  if(flags_changed) *flags_changed = changed;
+
   return g_list_reverse(result); // list was built in reverse order, so un-reverse it
+}
+
+static void _splash_progress(const double fraction,
+                             const double elapsed,
+                             void *data)
+{
+  dt_splash_screen_set_progress_percent(_("checking for updated sidecar files (%d%%)"),
+                                        fraction, elapsed);
+}
+
+// examine one film roll (or the whole library when filmid is NO_FILMID)
+// and return the list of images with a newer xmp file on disk.
+static GList *_crawler_run_filmroll(const dt_filmid_t filmid,
+                                    const dt_crawler_progress_cb progress,
+                                    void *progress_data,
+                                    const gint *abort,
+                                    int *flags_changed)
+{
+  dt_crawler_scan_t scan = { 0 };
+  scan.look_for_xmp = dt_image_get_xmp_mode() != DT_WRITE_XMP_NEVER;
+  scan.abort = abort;
+  scan.items = _crawler_collect_items(filmid, &scan.num_items);
+  if(!scan.items) return NULL;
+
+  const double start_time = dt_get_wtime();
+  _crawler_scan_items(&scan, progress, progress_data);
+  const double scan_time = dt_get_wtime() - start_time;
+
+  GList *result = _crawler_apply_results(scan.items, scan.num_items, flags_changed);
+  _crawler_free_items(scan.items, scan.num_items);
+
+  if(dt_is_valid_filmid(filmid))
+    dt_print(DT_DEBUG_CONTROL,
+             "[crawler] film roll %d: examined %d images in %.2fs,"
+             " %d updated XMP files found",
+             filmid, scan.num_items, scan_time, g_list_length(result));
+  else
+    dt_print(DT_DEBUG_CONTROL,
+             "[crawler] examined %d images in %.2fs using %d threads,"
+             " %d updated XMP files found",
+             scan.num_items, scan_time,
+             MIN(_crawler_num_threads(), MAX(scan.num_items, 1)),
+             g_list_length(result));
+
+  return result;
+}
+
+GList *dt_control_crawler_run(void)
+{
+  return _crawler_run_filmroll(NO_FILMID, _splash_progress, NULL, NULL, NULL);
+}
+
+/******************** background crawling ********************/
+
+static void _crawler_show_image_list(GList *images, const gboolean modal);
+static void _crawler_prioritize_current_collection(void);
+static void _crawler_collection_changed(gpointer instance,
+                                        dt_collection_change_t query_change,
+                                        dt_collection_properties_t changed_property,
+                                        gpointer imgs,
+                                        const int next,
+                                        gpointer user_data);
+
+/* The crawl is split up per film roll so that its order can be changed
+ * while it is running: opening a film roll that has not been examined
+ * yet moves it to the front of the queue rather than making the user
+ * wait for the rolls queued ahead of it.
+ *
+ * The queue is deliberately not persisted across restarts.  An XMP file
+ * can be modified while darktable is not running, so every session has
+ * to examine every image eventually -- the point of this queue is to
+ * take that work off the critical path, not to skip it.
+ */
+typedef struct dt_crawler_bg_t
+{
+  GList *pending;       // film roll ids, head is examined next
+  GList *conflicts;     // dt_control_crawler_result_t *, accumulated
+  int num_rolls;
+  int num_done;
+  gint abort;           // read atomically by the scan workers
+  gboolean running;
+} dt_crawler_bg_t;
+
+// static storage, so the mutex is zero-initialised as glib requires
+static GMutex _crawler_bg_lock;
+static dt_crawler_bg_t _crawler_bg = { 0 };
+
+static void _crawler_free_result_full(gpointer data)
+{
+  dt_control_crawler_result_t *item = (dt_control_crawler_result_t *)data;
+  _free_crawler_result(item);
+  free(item);
+}
+
+// runs on the gui thread once the crawl has stopped, for whatever reason
+static gboolean _crawler_bg_finished(gpointer data)
+{
+  GList *conflicts = (GList *)data;
+
+  // nothing left to reprioritize
+  DT_CONTROL_SIGNAL_DISCONNECT(_crawler_collection_changed, NULL);
+
+  if(conflicts)
+  {
+    const guint count = g_list_length(conflicts);
+    dt_control_log(ngettext("%u updated XMP sidecar file found",
+                            "%u updated XMP sidecar files found", count), count);
+
+    // shown non-modally: the crawl finishes long after startup, so this
+    // must not interrupt whatever the user is currently doing
+    _crawler_show_image_list(conflicts, FALSE);
+  }
+  return G_SOURCE_REMOVE;
+}
+
+static int32_t _crawler_bg_job_run(dt_job_t *job)
+{
+  dt_control_job_set_progress_message(job, "%s",
+                                      _("checking for updated sidecar files"));
+
+  while(TRUE)
+  {
+    g_mutex_lock(&_crawler_bg_lock);
+    if(g_atomic_int_get(&_crawler_bg.abort) || !_crawler_bg.pending)
+    {
+      g_mutex_unlock(&_crawler_bg_lock);
+      break;
+    }
+    const dt_filmid_t filmid = GPOINTER_TO_INT(_crawler_bg.pending->data);
+    _crawler_bg.pending = g_list_delete_link(_crawler_bg.pending,
+                                             _crawler_bg.pending);
+    g_mutex_unlock(&_crawler_bg_lock);
+
+    int flags_changed = 0;
+    GList *found = _crawler_run_filmroll(filmid, NULL, NULL,
+                                         &_crawler_bg.abort, &flags_changed);
+
+    g_mutex_lock(&_crawler_bg_lock);
+    _crawler_bg.conflicts = g_list_concat(_crawler_bg.conflicts, found);
+    _crawler_bg.num_done++;
+    const double fraction =
+      _crawler_bg.num_done / (double)MAX(_crawler_bg.num_rolls, 1);
+    g_mutex_unlock(&_crawler_bg_lock);
+
+    dt_control_job_set_progress(job, fraction);
+
+    // the .txt/.wav flags are drawn as thumbnail overlays, so a change
+    // needs to reach the screen.  this practically never fires.
+    if(flags_changed) dt_control_queue_redraw_center();
+  }
+
+  g_mutex_lock(&_crawler_bg_lock);
+  GList *conflicts = _crawler_bg.conflicts;
+  _crawler_bg.conflicts = NULL;
+  const gboolean aborted = g_atomic_int_get(&_crawler_bg.abort) != 0;
+  const int num_done = _crawler_bg.num_done;
+  const int num_rolls = _crawler_bg.num_rolls;
+  _crawler_bg.running = FALSE;
+  g_mutex_unlock(&_crawler_bg_lock);
+
+  dt_print(DT_DEBUG_CONTROL,
+           "[crawler] background crawl %s after %d of %d film rolls",
+           aborted ? "cancelled" : "finished", num_done, num_rolls);
+
+  if(aborted)
+  {
+    // darktable is shutting down: drop the findings rather than trying
+    // to put a dialog on screen on the way out
+    g_list_free_full(conflicts, _crawler_free_result_full);
+    conflicts = NULL;
+  }
+  g_main_context_invoke(NULL, _crawler_bg_finished, conflicts);
+
+  return 0;
+}
+
+static dt_job_t *_crawler_bg_job_create(void)
+{
+  dt_job_t *job = dt_control_job_create(&_crawler_bg_job_run, "crawl for updated sidecar files");
+  if(!job) return NULL;
+  dt_control_job_set_params(job, NULL, NULL);
+  return job;
+}
+
+void dt_control_crawler_start_background(void)
+{
+  if(!dt_conf_get_bool("run_crawler_on_start") || dt_gimpmode()) return;
+
+  g_mutex_lock(&_crawler_bg_lock);
+  if(_crawler_bg.running)
+  {
+    g_mutex_unlock(&_crawler_bg_lock);
+    return;
+  }
+
+  // most recently opened film rolls first -- those are the ones the user
+  // is most likely to look at in this session.  rolls that have never
+  // been opened have a NULL access_timestamp and sort last.
+  sqlite3_stmt *stmt;
+  // clang-format off
+  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
+                              "SELECT id FROM main.film_rolls"
+                              " ORDER BY access_timestamp DESC, id DESC",
+                              -1, &stmt, NULL);
+  // clang-format on
+  GList *rolls = NULL;
+  while(sqlite3_step(stmt) == SQLITE_ROW)
+    rolls = g_list_prepend(rolls, GINT_TO_POINTER(sqlite3_column_int(stmt, 0)));
+  sqlite3_finalize(stmt);
+
+  _crawler_bg.pending = g_list_reverse(rolls);
+  _crawler_bg.num_rolls = g_list_length(_crawler_bg.pending);
+  _crawler_bg.num_done = 0;
+  _crawler_bg.conflicts = NULL;
+  g_atomic_int_set(&_crawler_bg.abort, 0);
+  _crawler_bg.running = _crawler_bg.num_rolls > 0;
+  const gboolean start = _crawler_bg.running;
+  const int num_rolls = _crawler_bg.num_rolls;
+  g_mutex_unlock(&_crawler_bg_lock);
+
+  if(!start) return;
+
+  dt_print(DT_DEBUG_CONTROL,
+           "[crawler] queued %d film rolls for background crawling", num_rolls);
+
+  // follow the user around the library while the crawl runs
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_COLLECTION_CHANGED,
+                            _crawler_collection_changed, NULL);
+
+  // the collection restored at startup was set up before the signal above
+  // was connected, and it is the one the user is looking at right now
+  _crawler_prioritize_current_collection();
+
+  // note: dt_control_add_job() returns TRUE to report a *failure*
+  if(dt_control_add_job(DT_JOB_QUEUE_SYSTEM_BG, _crawler_bg_job_create()))
+  {
+    // nothing will run, so do not leave the queue looking busy -- that
+    // would make dt_control_crawler_stop() wait for a job that never was
+    dt_print(DT_DEBUG_CONTROL, "[crawler] could not queue the background job");
+    DT_CONTROL_SIGNAL_DISCONNECT(_crawler_collection_changed, NULL);
+    g_mutex_lock(&_crawler_bg_lock);
+    g_list_free(_crawler_bg.pending);
+    _crawler_bg.pending = NULL;
+    _crawler_bg.running = FALSE;
+    g_mutex_unlock(&_crawler_bg_lock);
+  }
+}
+
+void dt_control_crawler_prioritize_filmroll(const dt_filmid_t filmid)
+{
+  if(!dt_is_valid_filmid(filmid)) return;
+
+  g_mutex_lock(&_crawler_bg_lock);
+  if(_crawler_bg.running)
+  {
+    GList *link = g_list_find(_crawler_bg.pending, GINT_TO_POINTER(filmid));
+    // if it is already the head, or no longer queued at all, there is
+    // nothing to do -- it is being examined right now or is done
+    if(link && link != _crawler_bg.pending)
+    {
+      _crawler_bg.pending = g_list_remove_link(_crawler_bg.pending, link);
+      _crawler_bg.pending = g_list_concat(link, _crawler_bg.pending);
+      dt_print(DT_DEBUG_CONTROL,
+               "[crawler] film roll %d moved to the head of the queue", filmid);
+    }
+  }
+  g_mutex_unlock(&_crawler_bg_lock);
+}
+
+// how many images of the current collection to look at, and how many
+// distinct film rolls to take from them, when deciding what the user is
+// about to browse.  sampling rather than reading the whole collection
+// keeps this cheap enough to run on every collection change.
+#define CRAWLER_COLLECTION_SAMPLE 200
+#define CRAWLER_COLLECTION_ROLLS 8
+
+/* Selecting a film roll in the collect module does not go through
+ * dt_film_open(), it just changes the collection.  So follow the
+ * collection as well: whichever film rolls the images now on screen
+ * belong to are the ones worth examining next.  This also covers
+ * collections that are not film roll based at all, such as a tag or a
+ * rating -- the user is looking at those images, so they get priority.
+ */
+static void _crawler_prioritize_current_collection(void)
+{
+  g_mutex_lock(&_crawler_bg_lock);
+  const gboolean running = _crawler_bg.running;
+  g_mutex_unlock(&_crawler_bg_lock);
+  if(!running) return;
+
+  GList *images = dt_collection_get_all(darktable.collection,
+                                        CRAWLER_COLLECTION_SAMPLE);
+  if(!images) return;
+
+  // collect the distinct film rolls, keeping the order in which they
+  // appear in the collection
+  GList *rolls = NULL;
+  int num_rolls = 0;
+  sqlite3_stmt *stmt;
+  // clang-format off
+  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
+                              "SELECT film_id FROM main.images WHERE id = ?1",
+                              -1, &stmt, NULL);
+  // clang-format on
+  for(GList *iter = images;
+      iter && num_rolls < CRAWLER_COLLECTION_ROLLS;
+      iter = g_list_next(iter))
+  {
+    DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, GPOINTER_TO_INT(iter->data));
+    if(sqlite3_step(stmt) == SQLITE_ROW)
+    {
+      gpointer filmid = GINT_TO_POINTER(sqlite3_column_int(stmt, 0));
+      if(!g_list_find(rolls, filmid))
+      {
+        rolls = g_list_prepend(rolls, filmid);
+        num_rolls++;
+      }
+    }
+    sqlite3_reset(stmt);
+    sqlite3_clear_bindings(stmt);
+  }
+  sqlite3_finalize(stmt);
+  g_list_free(images);
+
+  // `rolls' is in reverse order of appearance, and each call puts its
+  // film roll at the head, so this leaves the first film roll of the
+  // collection at the very front of the queue
+  for(GList *iter = rolls; iter; iter = g_list_next(iter))
+    dt_control_crawler_prioritize_filmroll(GPOINTER_TO_INT(iter->data));
+
+  g_list_free(rolls);
+}
+
+static void _crawler_collection_changed(gpointer instance,
+                                        dt_collection_change_t query_change,
+                                        dt_collection_properties_t changed_property,
+                                        gpointer imgs,
+                                        const int next,
+                                        gpointer user_data)
+{
+  _crawler_prioritize_current_collection();
+}
+
+void dt_control_crawler_stop(const gboolean wait)
+{
+  g_mutex_lock(&_crawler_bg_lock);
+  const gboolean running = _crawler_bg.running;
+  g_mutex_unlock(&_crawler_bg_lock);
+  if(!running) return;
+
+  g_atomic_int_set(&_crawler_bg.abort, 1);
+
+  if(wait)
+  {
+    // the workers check the abort flag per image, so this returns
+    // quickly unless a single stat() is stuck on an unresponsive mount
+    for(int i = 0; i < 1000; i++)
+    {
+      g_mutex_lock(&_crawler_bg_lock);
+      const gboolean still_running = _crawler_bg.running;
+      g_mutex_unlock(&_crawler_bg_lock);
+      if(!still_running) break;
+      g_usleep(10000);
+    }
+  }
 }
 
 
@@ -700,7 +1295,7 @@ static gchar* str_time_delta(const int time_delta)
 }
 
 // show a popup window with a list of updated images/xmp files and allow the user to tell dt what to do about them
-void dt_control_crawler_show_image_list(GList *images)
+static void _crawler_show_image_list(GList *images, const gboolean modal)
 {
   if(!images) return;
 
@@ -798,7 +1393,7 @@ void dt_control_crawler_show_image_list(GList *images)
   GtkWidget *win = dt_ui_main_window(darktable.gui->ui);
   GtkWidget *dialog = gtk_dialog_new_with_buttons
     (_("updated XMP sidecar files found"), GTK_WINDOW(win),
-     GTK_DIALOG_DESTROY_WITH_PARENT | GTK_DIALOG_MODAL, _("_close"),
+     GTK_DIALOG_DESTROY_WITH_PARENT | (modal ? GTK_DIALOG_MODAL : 0), _("_close"),
      GTK_RESPONSE_CLOSE, NULL);
 
 #ifdef GDK_WINDOWING_QUARTZ
@@ -850,6 +1445,12 @@ void dt_control_crawler_show_image_list(GList *images)
 
   g_signal_connect(dialog, "response",
                    G_CALLBACK(dt_control_crawler_response_callback), gui);
+}
+
+void dt_control_crawler_show_image_list(GList *images)
+{
+  // the synchronous startup crawl blocks the ui anyway, so keep it modal
+  _crawler_show_image_list(images, TRUE);
 }
 
 /* backthumb crawler */

--- a/src/control/crawler.c
+++ b/src/control/crawler.c
@@ -583,7 +583,7 @@ GList *dt_control_crawler_run(void)
 /******************** background crawling ********************/
 
 static void _crawler_show_image_list(GList *images, const gboolean modal);
-static void _crawler_prioritize_current_collection(void);
+static void _crawler_ensure_current_collection(void);
 static void _crawler_collection_changed(gpointer instance,
                                         dt_collection_change_t query_change,
                                         dt_collection_properties_t changed_property,
@@ -609,10 +609,20 @@ typedef struct dt_crawler_bg_t
   int num_done;
   gint abort;           // read atomically by the scan workers
   gboolean running;
+
+  /* Only one film roll may be examined at a time, by either the
+   * background job or a caller waiting for a specific roll.  Besides
+   * keeping the two from examining the same roll twice, this keeps all
+   * of the crawler's database work on one thread at a time so that its
+   * transactions are never interleaved with each other.
+   */
+  gboolean scanning;    // someone is inside a scan right now
+  dt_filmid_t current;  // which film roll that is, NO_FILMID if none
 } dt_crawler_bg_t;
 
-// static storage, so the mutex is zero-initialised as glib requires
+// static storage, so these are zero-initialised as glib requires
 static GMutex _crawler_bg_lock;
+static GCond _crawler_bg_cond;
 static dt_crawler_bg_t _crawler_bg = { 0 };
 
 static void _crawler_free_result_full(gpointer data)
@@ -643,6 +653,35 @@ static gboolean _crawler_bg_finished(gpointer data)
   return G_SOURCE_REMOVE;
 }
 
+/* Examine one film roll and fold the findings into the accumulated list.
+ * The caller must already have claimed the scan (scanning == TRUE and
+ * current == filmid) so that nothing else touches the database at the
+ * same time.  Returns the conflicts found for this film roll alone,
+ * still owned by the accumulated list unless `take' is TRUE.
+ */
+static GList *_crawler_scan_claimed_roll(const dt_filmid_t filmid,
+                                         const gboolean take)
+{
+  int flags_changed = 0;
+  GList *found = _crawler_run_filmroll(filmid, NULL, NULL,
+                                       &_crawler_bg.abort, &flags_changed);
+
+  g_mutex_lock(&_crawler_bg_lock);
+  if(!take)
+    _crawler_bg.conflicts = g_list_concat(_crawler_bg.conflicts, found);
+  _crawler_bg.num_done++;
+  _crawler_bg.scanning = FALSE;
+  _crawler_bg.current = NO_FILMID;
+  g_cond_broadcast(&_crawler_bg_cond);
+  g_mutex_unlock(&_crawler_bg_lock);
+
+  // the .txt/.wav flags are drawn as thumbnail overlays, so a change
+  // needs to reach the screen.  this practically never fires.
+  if(flags_changed) dt_control_queue_redraw_center();
+
+  return take ? found : NULL;
+}
+
 static int32_t _crawler_bg_job_run(dt_job_t *job)
 {
   dt_control_job_set_progress_message(job, "%s",
@@ -651,6 +690,10 @@ static int32_t _crawler_bg_job_run(dt_job_t *job)
   while(TRUE)
   {
     g_mutex_lock(&_crawler_bg_lock);
+    // let anyone waiting for a specific film roll go first
+    while(_crawler_bg.scanning && !g_atomic_int_get(&_crawler_bg.abort))
+      g_cond_wait(&_crawler_bg_cond, &_crawler_bg_lock);
+
     if(g_atomic_int_get(&_crawler_bg.abort) || !_crawler_bg.pending)
     {
       g_mutex_unlock(&_crawler_bg_lock);
@@ -659,24 +702,15 @@ static int32_t _crawler_bg_job_run(dt_job_t *job)
     const dt_filmid_t filmid = GPOINTER_TO_INT(_crawler_bg.pending->data);
     _crawler_bg.pending = g_list_delete_link(_crawler_bg.pending,
                                              _crawler_bg.pending);
-    g_mutex_unlock(&_crawler_bg_lock);
-
-    int flags_changed = 0;
-    GList *found = _crawler_run_filmroll(filmid, NULL, NULL,
-                                         &_crawler_bg.abort, &flags_changed);
-
-    g_mutex_lock(&_crawler_bg_lock);
-    _crawler_bg.conflicts = g_list_concat(_crawler_bg.conflicts, found);
-    _crawler_bg.num_done++;
+    _crawler_bg.scanning = TRUE;
+    _crawler_bg.current = filmid;
     const double fraction =
-      _crawler_bg.num_done / (double)MAX(_crawler_bg.num_rolls, 1);
+      (_crawler_bg.num_done + 1) / (double)MAX(_crawler_bg.num_rolls, 1);
     g_mutex_unlock(&_crawler_bg_lock);
+
+    _crawler_scan_claimed_roll(filmid, FALSE);
 
     dt_control_job_set_progress(job, fraction);
-
-    // the .txt/.wav flags are drawn as thumbnail overlays, so a change
-    // needs to reach the screen.  this practically never fires.
-    if(flags_changed) dt_control_queue_redraw_center();
   }
 
   g_mutex_lock(&_crawler_bg_lock);
@@ -759,7 +793,7 @@ void dt_control_crawler_start_background(void)
 
   // the collection restored at startup was set up before the signal above
   // was connected, and it is the one the user is looking at right now
-  _crawler_prioritize_current_collection();
+  _crawler_ensure_current_collection();
 
   // note: dt_control_add_job() returns TRUE to report a *failure*
   if(dt_control_add_job(DT_JOB_QUEUE_SYSTEM_BG, _crawler_bg_job_create()))
@@ -776,89 +810,125 @@ void dt_control_crawler_start_background(void)
   }
 }
 
-void dt_control_crawler_prioritize_filmroll(const dt_filmid_t filmid)
+/* Make sure a film roll has been examined before its images are shown.
+ *
+ * The images of a film roll must not be edited before its sidecar files
+ * have been checked: darktable does not re-read an xmp when an image is
+ * opened, and dt_image_write_sidecar_file() overwrites whatever is on
+ * disk, so editing an image whose xmp was updated elsewhere would
+ * silently discard those changes.  The blocking startup crawl this
+ * replaces guaranteed that could not happen, and so must this.
+ *
+ * Examining a single film roll is cheap -- a few tens of milliseconds
+ * for a typical roll -- so only the roll being opened is waited for,
+ * rather than the whole library.
+ */
+static GList *_crawler_ensure_roll(const dt_filmid_t filmid)
 {
-  if(!dt_is_valid_filmid(filmid)) return;
+  if(!dt_is_valid_filmid(filmid)) return NULL;
 
   g_mutex_lock(&_crawler_bg_lock);
-  if(_crawler_bg.running)
+  if(!_crawler_bg.running)
   {
-    GList *link = g_list_find(_crawler_bg.pending, GINT_TO_POINTER(filmid));
-    // if it is already the head, or no longer queued at all, there is
-    // nothing to do -- it is being examined right now or is done
-    if(link && link != _crawler_bg.pending)
-    {
-      _crawler_bg.pending = g_list_remove_link(_crawler_bg.pending, link);
-      _crawler_bg.pending = g_list_concat(link, _crawler_bg.pending);
-      dt_print(DT_DEBUG_CONTROL,
-               "[crawler] film roll %d moved to the head of the queue", filmid);
-    }
+    g_mutex_unlock(&_crawler_bg_lock);
+    return NULL;
   }
+
+  // if the background job is examining this very film roll, wait for it
+  while(_crawler_bg.current == filmid
+        && _crawler_bg.running
+        && !g_atomic_int_get(&_crawler_bg.abort))
+    g_cond_wait(&_crawler_bg_cond, &_crawler_bg_lock);
+
+  // claim it, waiting for any other roll being examined to finish first
+  while(_crawler_bg.scanning && !g_atomic_int_get(&_crawler_bg.abort))
+    g_cond_wait(&_crawler_bg_cond, &_crawler_bg_lock);
+
+  GList *link = g_list_find(_crawler_bg.pending, GINT_TO_POINTER(filmid));
+  if(!link || g_atomic_int_get(&_crawler_bg.abort))
+  {
+    // already examined in this session, or we are shutting down
+    g_mutex_unlock(&_crawler_bg_lock);
+    return NULL;
+  }
+  _crawler_bg.pending = g_list_delete_link(_crawler_bg.pending, link);
+  _crawler_bg.scanning = TRUE;
+  _crawler_bg.current = filmid;
   g_mutex_unlock(&_crawler_bg_lock);
+
+  const double start_time = dt_get_wtime();
+  GList *found = _crawler_scan_claimed_roll(filmid, TRUE);
+  dt_print(DT_DEBUG_CONTROL,
+           "[crawler] film roll %d examined on demand in %.2fs, %d updated"
+           " XMP files found",
+           filmid, dt_get_wtime() - start_time, g_list_length(found));
+  return found;
 }
 
-// how many images of the current collection to look at, and how many
-// distinct film rolls to take from them, when deciding what the user is
-// about to browse.  sampling rather than reading the whole collection
-// keeps this cheap enough to run on every collection change.
-#define CRAWLER_COLLECTION_SAMPLE 200
-#define CRAWLER_COLLECTION_ROLLS 8
+/* Report on demand findings straight away rather than leaving them for
+ * the end of the crawl: the whole point of having waited is to tell the
+ * user before they start editing these images.
+ */
+static void _crawler_report(GList *found)
+{
+  if(!found) return;
+
+  const guint count = g_list_length(found);
+  dt_control_log(ngettext("%u updated XMP sidecar file found",
+                          "%u updated XMP sidecar files found", count), count);
+  _crawler_show_image_list(found, FALSE);
+}
+
+void dt_control_crawler_ensure_filmroll(const dt_filmid_t filmid)
+{
+  _crawler_report(_crawler_ensure_roll(filmid));
+}
 
 /* Selecting a film roll in the collect module does not go through
  * dt_film_open(), it just changes the collection.  So follow the
- * collection as well: whichever film rolls the images now on screen
- * belong to are the ones worth examining next.  This also covers
- * collections that are not film roll based at all, such as a tag or a
- * rating -- the user is looking at those images, so they get priority.
+ * collection as well, and for the same reason wait for it: the images it
+ * contains are about to be shown and may be edited, so their sidecar
+ * files have to have been checked first.
+ *
+ * Every film roll the collection covers is waited for, not a sample of
+ * them, since the user can scroll to any of the images.  In the worst
+ * case -- a collection spanning the whole library, opened immediately at
+ * startup -- this costs the same as the blocking crawl it replaces, and
+ * in every other case far less.  Once the background crawl has finished
+ * this does nothing at all.
  */
-static void _crawler_prioritize_current_collection(void)
+static void _crawler_ensure_current_collection(void)
 {
   g_mutex_lock(&_crawler_bg_lock);
   const gboolean running = _crawler_bg.running;
   g_mutex_unlock(&_crawler_bg_lock);
   if(!running) return;
 
-  GList *images = dt_collection_get_all(darktable.collection,
-                                        CRAWLER_COLLECTION_SAMPLE);
-  if(!images) return;
-
-  // collect the distinct film rolls, keeping the order in which they
-  // appear in the collection
+  // the collection is materialised in memory.collected_images, so its
+  // film rolls come out of a single query
   GList *rolls = NULL;
-  int num_rolls = 0;
   sqlite3_stmt *stmt;
   // clang-format off
   DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
-                              "SELECT film_id FROM main.images WHERE id = ?1",
+                              "SELECT i.film_id"
+                              " FROM memory.collected_images AS c, main.images AS i"
+                              " ON i.id = c.imgid"
+                              " GROUP BY i.film_id"
+                              " ORDER BY MIN(c.rowid)",
                               -1, &stmt, NULL);
   // clang-format on
-  for(GList *iter = images;
-      iter && num_rolls < CRAWLER_COLLECTION_ROLLS;
-      iter = g_list_next(iter))
-  {
-    DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, GPOINTER_TO_INT(iter->data));
-    if(sqlite3_step(stmt) == SQLITE_ROW)
-    {
-      gpointer filmid = GINT_TO_POINTER(sqlite3_column_int(stmt, 0));
-      if(!g_list_find(rolls, filmid))
-      {
-        rolls = g_list_prepend(rolls, filmid);
-        num_rolls++;
-      }
-    }
-    sqlite3_reset(stmt);
-    sqlite3_clear_bindings(stmt);
-  }
+  while(sqlite3_step(stmt) == SQLITE_ROW)
+    rolls = g_list_prepend(rolls, GINT_TO_POINTER(sqlite3_column_int(stmt, 0)));
   sqlite3_finalize(stmt);
-  g_list_free(images);
+  rolls = g_list_reverse(rolls);
 
-  // `rolls' is in reverse order of appearance, and each call puts its
-  // film roll at the head, so this leaves the first film roll of the
-  // collection at the very front of the queue
+  GList *found = NULL;
   for(GList *iter = rolls; iter; iter = g_list_next(iter))
-    dt_control_crawler_prioritize_filmroll(GPOINTER_TO_INT(iter->data));
+    found = g_list_concat(found,
+                          _crawler_ensure_roll(GPOINTER_TO_INT(iter->data)));
 
   g_list_free(rolls);
+  _crawler_report(found);
 }
 
 static void _crawler_collection_changed(gpointer instance,
@@ -868,7 +938,7 @@ static void _crawler_collection_changed(gpointer instance,
                                         const int next,
                                         gpointer user_data)
 {
-  _crawler_prioritize_current_collection();
+  _crawler_ensure_current_collection();
 }
 
 void dt_control_crawler_stop(const gboolean wait)

--- a/src/control/crawler.h
+++ b/src/control/crawler.h
@@ -38,11 +38,12 @@ void dt_control_crawler_show_image_list(GList *images);
 // that startup does not have to wait for it
 void dt_control_crawler_start_background(void);
 
-// move a film roll to the head of the background crawler's queue.  called
-// when a film roll is opened so that the images the user is about to look
-// at are examined next.  does not block and does nothing if that film roll
-// has already been examined in this session
-void dt_control_crawler_prioritize_filmroll(const dt_filmid_t filmid);
+// examine a film roll now, waiting for it to finish, so that its images
+// are never shown or edited before their sidecar files have been checked.
+// called when a film roll is opened.  returns immediately once that film
+// roll has been examined in this session, which after the initial crawl
+// is the usual case
+void dt_control_crawler_ensure_filmroll(const dt_filmid_t filmid);
 
 // ask the background crawler to stop, optionally waiting for it to do so
 void dt_control_crawler_stop(const gboolean wait);

--- a/src/control/crawler.h
+++ b/src/control/crawler.h
@@ -20,21 +20,32 @@
 
 #include <glib.h>
 
-/** this isn't a background job on purpose. it has to be really fast so it shouldn't
- *  require locking from image cache or anything like that.
- *  should we find out that we want to have a background job that crawls over all images
- *  we can maybe refactor this, but for now it's good the way it is.
- */
+#include "common/darktable.h"
 
 // this function iterates over ALL images from the database and checks whether
 // - the XMP file on disk is newer than the timestamp from db
 // - there is a .txt or .wav file associated with the image and mark so in the db
 //   or if such a file no longer exists
 // it returns the list of images with a (supposedly) updated xmp file to let the user decide
+// this blocks the calling thread; see dt_control_crawler_start_background()
 GList *dt_control_crawler_run();
 
 // show a popup with the images, let the user decide what to do and free the list afterwards
 void dt_control_crawler_show_image_list(GList *images);
+
+// perform the same crawl as dt_control_crawler_run(), but from a background
+// job and one film roll at a time, most recently opened film roll first, so
+// that startup does not have to wait for it
+void dt_control_crawler_start_background(void);
+
+// move a film roll to the head of the background crawler's queue.  called
+// when a film roll is opened so that the images the user is about to look
+// at are examined next.  does not block and does nothing if that film roll
+// has already been examined in this session
+void dt_control_crawler_prioritize_filmroll(const dt_filmid_t filmid);
+
+// ask the background crawler to stop, optionally waiting for it to do so
+void dt_control_crawler_stop(const gboolean wait);
 
 // background thread updating all thumbnails is there is no user activity while being in lightroom
 void dt_update_thumbs_thread(void *ptr);


### PR DESCRIPTION
Fixes #21849.

The startup crawl asks the filesystem about every image in the library before the user
interface appears — an existence check, a `stat()` of the xmp, and four probes for
`.txt`/`.TXT`/`.wav`/`.WAV` — serially, and startup blocks until it has finished. It is
dominated by filesystem latency rather than cpu time, so on a library held on network
storage it dominates startup. On mine (84,924 images across 546 film rolls, on an NFS4 mount
of a NAS) that is 506,449 filesystem calls taking ~58 s from cold and ~12 s with warm caches,
of which only ~3 s is cpu. It reports nothing, every time.

This changes both what the crawl asks the filesystem and when it runs. There are three
commits and they are independent of each other.

## What the crawl does

**A directory at a time, instead of a probe per image.** Suggested by @ralfbrown. Each
directory is listed once and the questions are answered from that listing; the only call
that still has to reach the filesystem per image is the `stat()` of an xmp that is really
there, for its timestamp. Everything else becomes a hash lookup. That takes the library from
506,449 filesystem calls to 84,851.

This fits because a film roll is exactly one directory — `images.filename` never contains a
path separator, and on my library it is 546 film rolls to 546 distinct folders — so the
images of a film roll are collected as one contiguous run and examined against a single
listing of it.

**In parallel.** `dt_control_crawler_run()` is split into three phases: collect the rows from
the database, examine the filesystem from a pool of worker threads, then apply the results.
The workers touch neither the database nor the gui and each writes only its own array slot,
so no locking is needed. The result list is assembled single threaded afterwards, walking the
items in collection order, so **the reported list and the resulting database state are
identical regardless of how many threads are used**. That is what makes this checkable
against the old behaviour rather than merely plausible.

Because the work is latency bound, the pool deliberately oversubscribes rather than scaling
with the core count. `crawler_threads` defaults to 16; setting it to 1 restores a serial
examination.

The crawl's existing semantics are kept faithfully, including the slightly surprising one
where an image whose xmp is absent skips the `.txt`/`.wav` check entirely (the original
`continue`).

## When the crawl runs

**In the background, newest film roll first.** The crawl runs from a `DT_JOB_QUEUE_SYSTEM_BG`
job, one film roll at a time, ordered by `film_rolls.access_timestamp`. Startup does not wait
for it. `run_crawler_in_background` defaults to true; false restores the blocking startup
crawl.

**But it waits for the film roll you open.** @wpferguson pointed out that the blocking crawl
also protects against editing an image whose xmp was updated on another machine, and that is
right. The consequence is worse than a stale thumbnail: darktable does not re-read an xmp
when an image is opened, and `dt_image_write_sidecar_file()` overwrites whatever is on disk
without comparing timestamps. Editing an image before its film roll had been examined would
discard the other machine's changes — and because that write also updates `write_timestamp`,
the crawler would no longer report the file afterwards, so the loss would be silent.

So a film roll is examined on demand when it is opened, and its findings are reported
straight away rather than with the rest at the end of the crawl, so the user is told before
they can edit anything. Waiting for one film roll costs a median of 0.000 s and 0.09 s for
the worst of my 546, against ~58 s for the whole library.

The collect module does not open film rolls through `dt_film_open()`, so the collection is
followed as well, and every film roll a collection covers is waited for rather than a sample
of them, since the user can scroll to any image in it. Worst case — a collection spanning the
whole library, opened immediately at startup — that costs what the blocking crawl costs
today, and far less in every other case.

Only one film roll is examined at a time, by either the background job or a caller waiting on
a specific roll, which also keeps the crawler's database transactions from interleaving.

The conflict dialog is shown non-modally when it comes from the background crawl, since it
can appear long after startup; the synchronous path still shows it modally as before.

The queue is deliberately **not** persisted between sessions. An xmp can change while
darktable is not running, so every session still examines every image — this takes the work
off the critical path rather than skipping it.

## Results

On the library above, cold:

| | before | after |
|---|---|---|
| filesystem calls | 506,449 | **84,851** |
| startup blocked by the crawl | ~58 s | **none** |
| crawl begins | before the gui appears | ~1.8 s after launch, gui already up |
| time the crawl itself takes | ~58 s, blocking | **~2.8 s**, in the background |
| whole library in one pass, 16 threads | — | ~3.0 s |
| waiting for one film roll when opened | — | median 0.000 s, worst of 546 0.09 s |

## Testing

Verified against the original per-image implementation on the same library:

* the crawler's output for the whole library is identical **line for line and in the same
  order**, both with no updated sidecars (619 lines) and with 617 seeded ones (1,236 lines)
* the resulting `images.flags` column is identical across all 84,924 rows, in serial,
  parallel and background modes, and for both the per-image and per-directory examination
* the background crawl covers all 546 film rolls exactly once, 84,924 images, with no gaps
  and no duplicates
* with conflicts seeded in the film roll that is open at startup, they are reported 1.6 s in,
  on demand, rather than at the end of the crawl
* opening an old film roll moves it to the head: with a 2022 roll selected at startup it is
  examined before the newest ones

My library contains no genuine conflicts, so the conflict path was exercised by backdating
`write_timestamp` in a copy of the database rather than by touching any file on disk.

Quitting during the crawl behaves as it does for any other background job: if it is still
running you get the existing "darktable will be locked until background work has been done"
notice and the existing drain wait in `dt_control_quit()`, then it shuts down. The abort flag
is checked per image, and `dt_control_crawler_stop(TRUE)` in `dt_cleanup()` mirrors the
existing `dt_stop_backthumbs_crawler(TRUE)` placement.

## Deliberate differences in behaviour

* An image counts as present when its directory lists it, whereas `g_file_test()` follows
  symlinks — so a broken symlink now counts as present rather than missing.
* The `.txt`/`.wav` lookups match the names the directory actually holds, so on a case
  insensitive filesystem a spelling other than the four checked is no longer found by
  accident. On Linux nothing changes.
* Listing a directory reads every entry, so a directory holding a great many unrelated files
  beside very few images is slower than probing would have been. I did not think that worth
  special casing.

I have not tried this on Windows or macOS. The Windows `_wstati64` path is carried over
unchanged, but it now runs on a worker thread, so it is worth a look from someone who can
test there.

---

*Disclosure: designed, written and tested with AI assistance (Claude Code with Claude Opus 5).
Verified against current master and builds clean with no new warnings.*
