### PR TITLE
Translate task names in AI preferences

### DIFF
--- a/src/common/ai_models.c
+++ b/src/common/ai_models.c
@@ -56,6 +56,24 @@ struct dt_ai_registry_t
 #define CONF_MODEL_ENABLED_PREFIX "plugins/ai/models/"
 #define CONF_ACTIVE_MODEL_PREFIX "plugins/ai/models/active/"
 
+// what each task darktable dispatches on is called on screen. ADD A LINE
+// HERE WHEN ADDING A TASK, or it will show its identifier
+//
+// tasks are identifiers, not prose: they come from a model's config.json
+// and end up in conf keys, so nothing translates them in place. only the
+// label below is localized, and a task missing from this table keeps its
+// own name rather than being hidden or guessed at
+static const struct
+{
+  const char *task;
+  const char *label;
+} _task_labels[] = {
+  { "denoise",    N_("denoise")     },
+  { "rawdenoise", N_("raw denoise") },
+  { "upscale",    N_("upscale")     },
+  { "mask",       N_("mask")        },
+};
+
 // compare version strings "X.Y", returns -1 if a<b, 0 if a==b, 1 if a>b
 static int _version_compare(const char *a, const char *b)
 {
@@ -2072,6 +2090,19 @@ void dt_ai_models_set_enabled(const char *model_id, gboolean enabled)
   char *conf_key = g_strdup_printf("%s%s/enabled", CONF_MODEL_ENABLED_PREFIX, model_id);
   dt_conf_set_bool(conf_key, enabled);
   g_free(conf_key);
+}
+
+// _task_labels is at the top of this file, next to the other constants
+const char *dt_ai_task_label(const char *task)
+{
+  if(!task || !task[0])
+    return "";
+
+  for(size_t i = 0; i < sizeof(_task_labels) / sizeof(_task_labels[0]); i++)
+    if(!strcmp(task, _task_labels[i].task))
+      return _(_task_labels[i].label);
+
+  return task;
 }
 
 char *dt_ai_models_get_active_for_task(const char *task)

--- a/src/common/ai_models.h
+++ b/src/common/ai_models.h
@@ -281,6 +281,15 @@ void dt_ai_models_set_enabled(const char *model_id, gboolean enabled);
 char *dt_ai_models_get_active_for_task(const char *task);
 
 /**
+ * @brief A task identifier as it should be shown to the user
+ *
+ * @param task The task type (e.g. "mask", "denoise"), may be NULL
+ * @return Translated label, or `task` unchanged when it is not one of the
+ *         tasks darktable dispatches on; never NULL. Do not free.
+ */
+const char *dt_ai_task_label(const char *task);
+
+/**
  * @brief Get the version string of a model by ID.
  * @return Version string (e.g. "1.0"), or "0.0" if not set.
  *         Pointer valid until next registry refresh. Do not free.

--- a/src/gui/preferences_ai.c
+++ b/src/gui/preferences_ai.c
@@ -71,7 +71,8 @@ enum
   COL_NAME,
   COL_INFO,     // info icon visibility flag (TRUE on downloaded rows)
   COL_VERSION,
-  COL_TASK,
+  COL_TASK,       // the identifier, which reaches conf keys — never shown
+  COL_TASK_LABEL, // what the task column displays
   COL_ENABLED,
   COL_ENABLED_SENSITIVE, // whether the enabled checkbox is clickable
   COL_STATUS,
@@ -249,6 +250,8 @@ static void _refresh_model_list(dt_prefs_ai_data_t *data)
       model->name ? model->name : model->id,
       COL_TASK,
       model->task ? model->task : "",
+      COL_TASK_LABEL,
+      dt_ai_task_label(model->task),
       COL_STATUS,
       _status_to_string(model->status),
       COL_DEFAULT,
@@ -1709,6 +1712,7 @@ void init_tab_ai(GtkWidget *dialog, GtkWidget *stack)
     G_TYPE_BOOLEAN, // info icon visible
     G_TYPE_STRING,  // version
     G_TYPE_STRING,  // task
+    G_TYPE_STRING,  // task label
     G_TYPE_BOOLEAN, // enabled
     G_TYPE_BOOLEAN, // enabled_sensitive
     G_TYPE_STRING,  // status
@@ -1801,7 +1805,7 @@ void init_tab_ai(GtkWidget *dialog, GtkWidget *stack)
     _("task"),
     text_renderer,
     "text",
-    COL_TASK,
+    COL_TASK_LABEL,
     NULL);
   gtk_tree_view_append_column(GTK_TREE_VIEW(data->model_list), task_col);
 


### PR DESCRIPTION
loses #21219. Reimplements #21252, which was abandoned – same goal, different approach.

The task column showed raw identifiers (`denoise`, `rawdenoise`) whatever the UI language, because the string comes from a model's `config.json` and nothing in darktable's sources carried it for `xgettext` to find.

Tasks stay identifiers – they reach conf keys, and translating one in place would localize the key. Instead there is a small table in `ai_models.c` mapping the tasks darktable dispatches on to a label, and the models table shows the label while keeping the identifier for everything else.

## Why not just `_(task)`

The shorter fix is a static `N_()` array so `xgettext` sees the strings, then `_(model->task)` at display. Two things pushed me off it.

`_(task)` makes the identifier the msgid, so `rawdenoise` stays `rawdenoise` in English and translators are asked to localize a run-together token. The table gives it a real label, `raw denoise`.

The table is also easier to maintain: it is the lookup itself rather than a list kept in sync by hand, and adding a task means adding one line to it. That was the objection to #21252.

A task that isn't listed – one a Lua script added, say – keeps its identifier, which is the honest answer when darktable has no name for it.

## Note on the diff

Most of it isn't the design choice. `COL_TASK` is read back and passed to `dt_ai_models_set_active_for_task()`, which writes a conf key, so the raw value has to survive next to the displayed one. Either approach needs that.

Three of the four labels already exist as msgids elsewhere in darktable, so translators should get them for free. Only `raw denoise` is new.