### PR TITLE
fix signal callback description for DT_SIGNAL_DEVELOP_HISTORY_WILL_CHANGE

### DIFF
--- a/src/control/signal.h
+++ b/src/control/signal.h
@@ -160,10 +160,7 @@ typedef enum dt_signal_t
   DT_SIGNAL_DEVELOP_UI_PIPE_FINISHED,
 
   /** \brief This signal is raised when develop history is about to be changed
-    1 : GList *  the current history
-    2 : uint32_t the correpsing history end
-    3 : GList *  the current iop-order list
-  no returned value
+  no param, no returned value
     */
   DT_SIGNAL_DEVELOP_HISTORY_WILL_CHANGE,
 


### PR DESCRIPTION
While digging into history signals I noticed that the callback function description is wrong here.
