### PR TITLE
bauhaus: fix scroll step calculation for large-range sliders

### DIFF
--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -3607,20 +3607,13 @@ float dt_bauhaus_slider_get_step(GtkWidget *widget)
     const float max = zoom ? d->max : d->soft_max;
 
     const float top = fminf(max-min, fmaxf(fabsf(min), fabsf(max)));
-    if(top >= 100)
-    {
-      step = 1.f;
-    }
-    else
-    {
-      step = top * fabsf(d->factor) / 100;
-      const float log10step = log10f(step);
-      const float fdigits = floorf(log10step+.1);
-      step = powf(10.f,fdigits);
-      if(log10step - fdigits > .5)
-        step *= 5;
-      step /= fabsf(d->factor);
-    }
+    step = top * fabsf(d->factor) / 100;
+    const float log10step = log10f(step);
+    const float fdigits = floorf(log10step+.1);
+    step = powf(10.f,fdigits);
+    if(log10step - fdigits > .5)
+      step *= 5;
+    step /= fabsf(d->factor);
   }
 
   return copysignf(step, d->factor);


### PR DESCRIPTION
## Problem

The `dt_bauhaus_slider_get_step()` function computes how much a slider value
changes per scroll-wheel tick. Since the February 2022 refactor
(commit `f7561c5e79`), the function contains this branch:

```c
if(top >= 100)
    step = 1.f;
```

For any slider whose visible span (soft range) is ≥ 100, the step is always
hardcoded to 1 — bypassing the logarithmic formula that produces a proportional,
round-number step.

This is unnoticeable for sliders where "1 unit" is a natural granularity (e.g.
a 0–100 % slider, a 0–360° hue slider). However it produces unusable behaviour
for sliders measured in large-valued units. The clearest example is the
**color temperature** parameter in the *color calibration* module
(soft range 3000–7000 K, span = 4000):

- **Actual**: 1 scroll tick = 1 K — 100 ticks needed to change by 100 K, barely perceptible.
- **Expected**: a proportional step, comparable to how the *sigmoid* contrast
  slider (soft range ~0.7–3.0, span ~2.3) scrolls at 0.01 per tick (~0.4 % of span).

## Root cause

The log formula correctly produces "~1 % of visible span, rounded to the nearest
1/2/5 × 10ⁿ". It was always intended to cover all ranges; the `>= 100` guard
is an unnecessary short-circuit that happens to give the same answer as the
formula for spans 100–315, but diverges above that.

## Fix

Remove the `>= 100` guard. The formula now runs for all ranges:

```c
// before
const float top = fminf(max-min, fmaxf(fabsf(min), fabsf(max)));
if(top >= 100)
{
    step = 1.f;
}
else
{
    step = top * fabsf(d->factor) / 100;
    // … log rounding …
}

// after
const float top = fminf(max-min, fmaxf(fabsf(min), fabsf(max)));
step = top * fabsf(d->factor) / 100;
// … log rounding …
```

## Impact

| Soft-range span | Step (before) | Step (after) | Example |
|---|---|---|---|
| 100 – 315 | 1 | **1** (no change) | percentage 0-100 %, hue −180…+180° |
| 316 – 794 | 1 | **5** | 0-360° hue (colorbalancergb), radius 0-500 px |
| 795 – 3162 | 1 | **10** | sigmoid white target 20-1600 nits |
| 3163 + | 1 | **50 / 100 / …** | temperature soft 3000-7000 K → **50 K** ✓ |

Modules that need a non-formula step can still call `dt_bauhaus_slider_set_step()`
to override (as `contrastntexture.c` already does for a very fine 0.0001 step).

Fix #21855 

## Testing

- Color calibration temperature slider: scroll wheel now moves in 50 K increments
  (soft range 3000–7000 K active), comparable to Lightroom's default WB step.
- Old white balance module temperature slider (hard range 1901–25000 K, no soft
  range): scroll moves in 100 K increments.
- Sigmoid contrast slider (soft range 0.7–3.0): step unchanged at 0.01 ✓
- Exposure compensation (range ±18 EV, span ≤ 36 < 100): step unchanged ✓
- 0–100 % sliders: step unchanged at 1 ✓
