### PR TITLE
tests: fix unit test link error in Debug builds

### DIFF
--- a/src/tests/unittests/util/testimg.h
+++ b/src/tests/unittests/util/testimg.h
@@ -54,7 +54,7 @@ void testimg_free(Testimg *const ti);
  */
 
 // access pixel (x -> width, y -> height):
-inline float* get_pixel(const Testimg *const ti, const int x, const int y)
+static inline float* get_pixel(const Testimg *const ti, const int x, const int y)
 {
   // y * width + x, so pixel at index 2 is top row, 2nd from left:
   return ti->pixels + (y * ti->width + x) * 4;


### PR DESCRIPTION
Background: get_pixel() was defined as a plain C99 `inline` in testimg.h, which is not an external definition.
Release builds inline it away, but at -O0 or when enabling debug symbols every call site emits a reference to an out-of-line symbol that no translation unit provides, breaking the link of test_filmicrgb.
Solution: Make it `static inline`.

This hasn't been caught by our [newly added unit test to the gitlab ci](https://github.com/darktable-org/darktable/pull/21761), because it builds darktable via `-O3 -DNDEBUG`.