### PR TITLE
ci: untap aws/tap on macOS runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -368,6 +368,9 @@ jobs:
           cd -
       - name: Install Base Dependencies
         run: |
+          # The GitHub runner images ship aws/tap, which Homebrew does not trust and
+          # thus warns about on every invocation. We don't use it, so drop it.
+          brew untap --force aws/tap || true
           brew update > /dev/null || true
           cd src/.ci
           export HOMEBREW_NO_INSTALL_UPGRADE=1

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -376,6 +376,9 @@ jobs:
           popd
       - name: Install Base Dependencies
         run: |
+          # The GitHub runner images ship aws/tap, which Homebrew does not trust and
+          # thus warns about on every invocation. We don't use it, so drop it.
+          brew untap --force aws/tap || true
           brew update > /dev/null || true
           cd src/.ci
           export HOMEBREW_NO_INSTALL_UPGRADE=1


### PR DESCRIPTION
The GitHub runner images ship aws/tap, which Homebrew doesn't trust and warns about on every invocation. We don't use it, so drop it before installing dependencies.

This is going to prevent those superfluous warnings on our github ci runs:
<img width="1646" height="1256" alt="image" src="https://github.com/user-attachments/assets/3e327eb5-449d-400a-8a55-0fbd3b76a542" />
