### PR TITLE
Fix export filename extension case handling (fixes #19050)

### DIFF
--- a/src/common/utility.c
+++ b/src/common/utility.c
@@ -1150,6 +1150,26 @@ char *dt_filename_change_extension(const char *filename,
   return output;
 }
 
+gboolean dt_util_str_ends_with_extension(const char *filename,
+                                         const char *ext)
+{
+  if(!filename || !ext) return FALSE;
+  const size_t fn_len = strlen(filename);
+  const size_t ext_len = strlen(ext);
+  return fn_len > ext_len + 1
+    && filename[fn_len - ext_len - 1] == '.'
+    && !g_ascii_strcasecmp(filename + fn_len - ext_len, ext);
+}
+
+size_t dt_util_str_extension_offset(const char *filename,
+                                    const char *ext)
+{
+  const size_t fn_len = strlen(filename);
+  return dt_util_str_ends_with_extension(filename, ext)
+    ? fn_len - strlen(ext) - 1
+    : fn_len;
+}
+
 GList *dt_read_file_pattern(const char *dir_path,
                             const char *pattern_str)
 {

--- a/src/common/utility.h
+++ b/src/common/utility.h
@@ -168,6 +168,15 @@ char *dt_copy_filename_extension(const char *filename1,
 char *dt_filename_change_extension(const char *filename,
                                    const char *ext);
 
+// true if filename already ends in ".ext" (case-insensitive)
+gboolean dt_util_str_ends_with_extension(const char *filename,
+                                         const char *ext);
+
+// offset into filename where ".ext" is (if already present, case-insensitively)
+// or would go if appended -- always the boundary right before the extension
+size_t dt_util_str_extension_offset(const char *filename,
+                                    const char *ext);
+
 //  returns a list of filenames read from dir_path and matching pattern_str
 GList *dt_read_file_pattern(const char *dir_path, const char *pattern_str);
 

--- a/src/common/variables.c
+++ b/src/common/variables.c
@@ -685,6 +685,8 @@ static char *_get_base_value(dt_variables_params_t *params, char **variable)
   else if(_has_prefix(variable, "FILE.EXTENSION")
           || _has_prefix(variable, "FILE_EXTENSION"))
     result = g_strdup(params->data->file_ext);
+  else if(_has_prefix(variable, "EXPORT_EXTENSION"))
+    result = g_strdup(params->export_extension);
   else if(_has_prefix(variable, "SEQUENCE"))
   {
     uint8_t nb_digit = 4;

--- a/src/common/variables.h
+++ b/src/common/variables.h
@@ -32,6 +32,9 @@ typedef struct dt_variables_params_t
   /** used for expanding variable $(JOBCODE) */
   const gchar *jobcode;
 
+  /** used for expanding variable $(EXPORT_EXTENSION) */
+  const gchar *export_extension;
+
   /** used for expanding variables such as $(IMAGE_WIDTH) $(IMAGE_HEIGHT). */
   dt_imgid_t imgid;
 

--- a/src/gui/gtkentry.c
+++ b/src/gui/gtkentry.c
@@ -38,6 +38,7 @@ static dt_gtkentry_completion_spec _default_path_compl_list[]
       { "FILE.FOLDER", N_("$(FILE.FOLDER) - folder containing the input image") },
       { "FILE.NAME", N_("$(FILE.NAME) - basename of the input image") },
       { "FILE.EXTENSION", N_("$(FILE.EXTENSION) - extension of the input image") },
+      { "EXPORT_EXTENSION", N_("$(EXPORT_EXTENSION) - extension of the export format") },
       { "VERSION", N_("$(VERSION) - duplicate version") },
       { "VERSION.IF_MULTI", N_("$(VERSION.IF_MULTI) - same as $(VERSION) but null string if only one version exists") },
       { "VERSION.NAME", N_("$(VERSION.NAME) - version name from metadata") },

--- a/src/imageio/storage/disk.c
+++ b/src/imageio/storage/disk.c
@@ -383,6 +383,7 @@ try_again:
     d->vp->jobcode = "export";
     d->vp->imgid = imgid;
     d->vp->sequence = num;
+    d->vp->export_extension = format->extension(fdata);
 
     if(variable_expand)
     {
@@ -437,10 +438,17 @@ try_again:
       goto failed;
     }
 
-    const char *ext = format->extension(fdata);
-    char *c = filename + strlen(filename);
+    // if the pattern already produced the correct extension (in any case),
+    // don't append a second, implicit one -- this lets users control the
+    // case of the extension, e.g. via $(FILE_NAME).JPG
+    // "c" always ends up pointing at where ".ext" starts (or would start),
+    // so the unique-filename conflict handling below can overwrite from
+    // there regardless of whether the pattern already had an extension.
+    const char *ext = d->vp->export_extension;
+    char *c = filename + dt_util_str_extension_offset(filename, ext);
     size_t filename_free_space = sizeof(filename) - (c - filename);
-    snprintf(c, filename_free_space, ".%s", ext);
+    if(!dt_util_str_ends_with_extension(filename, ext))
+      snprintf(c, filename_free_space, ".%s", ext);
 
   /* prevent overwrite of files */
   failed:

--- a/src/imageio/storage/gallery.c
+++ b/src/imageio/storage/gallery.c
@@ -282,6 +282,7 @@ int store(dt_imageio_module_storage_t *self,
   d->vp->jobcode = "export";
   d->vp->imgid = imgid;
   d->vp->sequence = num;
+  d->vp->export_extension = format->extension(fdata);
 
   gchar *result_tmp_dir = dt_variables_expand(d->vp, d->filename, TRUE);
   g_strlcpy(tmp_dir, result_tmp_dir, sizeof(tmp_dir));
@@ -311,7 +312,7 @@ int store(dt_imageio_module_storage_t *self,
 
   g_strlcpy(dirname, filename, sizeof(dirname));
 
-  const char *ext = format->extension(fdata);
+  const char *ext = d->vp->export_extension;
   char *c = dirname + strlen(dirname);
   for(; c > dirname && *c != '/' && *c != G_DIR_SEPARATOR; c--)
     ;
@@ -327,12 +328,16 @@ int store(dt_imageio_module_storage_t *self,
   // store away dir.
   g_strlcpy(d->cached_dirname, dirname, sizeof(d->cached_dirname));
 
-  c = filename + strlen(filename);
-  for(; c > filename && *c != '.' && *c != '/' && *c != G_DIR_SEPARATOR; c--)
-    ;
-  if(c <= filename || *c == '/' || *c == G_DIR_SEPARATOR) c = filename + strlen(filename);
+  if(!dt_util_str_ends_with_extension(filename, ext))
+  {
+    c = filename + strlen(filename);
+    for(; c > filename && *c != '.' && *c != '/' && *c != G_DIR_SEPARATOR; c--)
+      ;
+    if(c <= filename || *c == '/' || *c == G_DIR_SEPARATOR)
+      c = filename + strlen(filename);
 
-  sprintf(c, ".%s", ext);
+    sprintf(c, ".%s", ext);
+  }
 
   // save image to list, in order:
   pair_t *pair = malloc(sizeof(pair_t));

--- a/src/imageio/storage/latex.c
+++ b/src/imageio/storage/latex.c
@@ -264,6 +264,7 @@ int store(dt_imageio_module_storage_t *self, dt_imageio_module_data_t *sdata, co
     d->vp->jobcode = "export";
     d->vp->imgid = imgid;
     d->vp->sequence = num;
+    d->vp->export_extension = format->extension(fdata);
 
     gchar *result_filename = dt_variables_expand(d->vp, d->filename, TRUE);
     g_strlcpy(filename, result_filename, sizeof(filename));
@@ -271,7 +272,7 @@ int store(dt_imageio_module_storage_t *self, dt_imageio_module_data_t *sdata, co
 
     g_strlcpy(dirname, filename, sizeof(dirname));
 
-    const char *ext = format->extension(fdata);
+    const char *ext = d->vp->export_extension;
     char *c = dirname + strlen(dirname);
     for(; c > dirname && *c != '/'; c--)
       ;
@@ -287,11 +288,14 @@ int store(dt_imageio_module_storage_t *self, dt_imageio_module_data_t *sdata, co
     // store away dir.
     g_strlcpy(d->cached_dirname, dirname, sizeof(d->cached_dirname));
 
-    c = filename + strlen(filename);
-    //     for(; c>filename && *c != '.' && *c != '/' ; c--);
-    //     if(c <= filename || *c=='/') c = filename + strlen(filename);
+    if(!dt_util_str_ends_with_extension(filename, ext))
+    {
+      c = filename + strlen(filename);
+      //     for(; c>filename && *c != '.' && *c != '/' ; c--);
+      //     if(c <= filename || *c=='/') c = filename + strlen(filename);
 
-    sprintf(c, ".%s", ext);
+      sprintf(c, ".%s", ext);
+    }
 
     // save image to list, in order:
     pair_t *pair = malloc(sizeof(pair_t));

--- a/src/imageio/storage/piwigo.c
+++ b/src/imageio/storage/piwigo.c
@@ -1311,6 +1311,7 @@ int store(dt_imageio_module_storage_t *self,
     p->vp->jobcode = "export";
     p->vp->imgid = imgid;
     p->vp->sequence = num;
+    p->vp->export_extension = format->extension(fdata);
 
     gchar *result_filename = dt_variables_expand(p->vp, p->preset_data.filename_pattern, TRUE);
     g_free(filename);

--- a/src/tests/unittests/CMakeLists.txt
+++ b/src/tests/unittests/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_subdirectory(iop)
+add_subdirectory(util)
 
 if(USE_AI)
   add_subdirectory(ai)

--- a/src/tests/unittests/util/CMakeLists.txt
+++ b/src/tests/unittests/util/CMakeLists.txt
@@ -3,6 +3,5 @@ add_cmocka_test(test_utility
                 LINK_LIBRARIES lib_darktable cmocka)
 
 if(WIN32)
-    target_link_libraries(test_utility PRIVATE lib_darktable)
     _copy_required_library(test_utility lib_darktable)
 endif(WIN32)

--- a/src/tests/unittests/util/CMakeLists.txt
+++ b/src/tests/unittests/util/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_cmocka_test(test_utility
+                SOURCES test_utility.c
+                LINK_LIBRARIES lib_darktable cmocka)
+
+if(WIN32)
+    target_link_libraries(test_utility PRIVATE lib_darktable)
+    _copy_required_library(test_utility lib_darktable)
+endif(WIN32)

--- a/src/tests/unittests/util/test_utility.c
+++ b/src/tests/unittests/util/test_utility.c
@@ -1,0 +1,80 @@
+/*
+    This file is part of darktable,
+    Copyright (C) 2026 darktable developers.
+
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    darktable is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/*
+ * cmocka unit tests for the extension-handling helpers in common/utility.c
+ */
+#include <limits.h>
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <string.h>
+
+#include <cmocka.h>
+
+#include "common/utility.h"
+
+#ifdef _WIN32
+#include "win/main_wrapper.h"
+#endif
+
+static void test_ends_with_extension(void **state)
+{
+  assert_true(dt_util_str_ends_with_extension("name.jpg", "jpg"));
+  assert_true(dt_util_str_ends_with_extension("name.JPG", "jpg"));
+  assert_true(dt_util_str_ends_with_extension("name.JpG", "jpg"));
+  assert_false(dt_util_str_ends_with_extension("name.png", "jpg"));
+  assert_false(dt_util_str_ends_with_extension("namejpg", "jpg"));
+  assert_false(dt_util_str_ends_with_extension(".jpg", "jpg")); // no basename before the dot
+  assert_false(dt_util_str_ends_with_extension("jpg", "jpg")); // no dot at all
+  assert_false(dt_util_str_ends_with_extension(NULL, "jpg"));
+  assert_false(dt_util_str_ends_with_extension("name.jpg", NULL));
+}
+
+static void test_extension_offset(void **state)
+{
+  // no extension present yet: offset is the end of the string, i.e. where
+  // the caller should append ".ext"
+  assert_int_equal(dt_util_str_extension_offset("name", "jpg"), strlen("name"));
+
+  // extension already present, any case: offset is the boundary right
+  // before it. This is what the disk storage export's "generate unique
+  // filename on conflict" handling relies on to insert a "_01" suffix in
+  // the right place for patterns like "$(FILE_NAME).JPG" -- getting this
+  // wrong produced "name.JPG_01.jpg" instead of "name_01.jpg".
+  assert_int_equal(dt_util_str_extension_offset("name.jpg", "jpg"), strlen("name"));
+  assert_int_equal(dt_util_str_extension_offset("name.JPG", "jpg"), strlen("name"));
+
+  // mismatched extension: treated as "not present", offset is the full
+  // (mismatched) string end
+  assert_int_equal(dt_util_str_extension_offset("name.png", "jpg"), strlen("name.png"));
+}
+
+int main(int argc, char *argv[])
+{
+  const struct CMUnitTest tests[] = {
+    cmocka_unit_test(test_ends_with_extension),
+    cmocka_unit_test(test_extension_offset),
+  };
+
+  return cmocka_run_group_tests(tests, NULL, NULL);
+}
+// clang-format off
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
+// clang-format on

--- a/src/tests/variables.c
+++ b/src/tests/variables.c
@@ -14,7 +14,7 @@ typedef struct test_case_t
 
 typedef struct test_t
 {
-  char *filename, *jobcode, sequence;
+  char *filename, *jobcode, sequence, *export_extension;
   test_case_t test_cases[];
 } test_t;
 
@@ -25,6 +25,7 @@ int run_test(const test_t *test, int *n_tests, int *n_failed)
   params->filename = test->filename;//"abcdef12345abcdef";
   params->jobcode = test->jobcode;//"ABCDEF12345ABCDEF";
   params->sequence = test->sequence;
+  params->export_extension = test->export_extension;
 
   *n_failed = 0;
   *n_tests = 0;
@@ -47,7 +48,7 @@ int run_test(const test_t *test, int *n_tests, int *n_failed)
 }
 
 static const test_t test_variables = {
-  "abcdef12345abcdef", "ABCDEF12345ABCDEF", 23,
+  "abcdef12345abcdef", "ABCDEF12345ABCDEF", 23, NULL,
   {
     {"$(FILE_NAME)", "abcdef12345abcdef"},
     {"foo-$(FILE_NAME)-bar", "foo-abcdef12345abcdef-bar"},
@@ -61,7 +62,7 @@ static const test_t test_variables = {
 };
 
 static const test_t test_simple_substitutions = {
-  "abcdef12345abcdef", "ABCDEF12345ABCDEF", 23,
+  "abcdef12345abcdef", "ABCDEF12345ABCDEF", 23, NULL,
   {
     {"$(NONEXISTANT-invälid)", "invälid"},
     {"$(FILE_NAME-invälid)", "abcdef12345abcdef"},
@@ -116,7 +117,7 @@ static const test_t test_simple_substitutions = {
 };
 
 static const test_t test_recursive_substitutions = {
-  "abcdef12345abcdef", "ABCDEF12345ABCDEF", 23,
+  "abcdef12345abcdef", "ABCDEF12345ABCDEF", 23, NULL,
   {
     {"x$(TITLE-$(FILE_NAME))y", "xabcdef12345abcdefy"},
     {"x$(TITLE-a-$(FILE_NAME)-b)y", "xa-abcdef12345abcdef-by"},
@@ -128,8 +129,30 @@ static const test_t test_recursive_substitutions = {
   }
 };
 
+static const test_t test_export_extension = {
+  "IMG_1234.CR3", "ABCDEF12345ABCDEF", 23, "jpg",
+  {
+    // $(FILE_EXTENSION) is the *source* file's extension; $(EXPORT_EXTENSION)
+    // is the extension of the format actually being exported to. These are
+    // independent -- this is the exact confusion behind darktable issue
+    // #19050, where $(FILE_EXTENSION^^) was expected to give the export
+    // extension but instead gives the (uppercased) source extension.
+    {"$(FILE_EXTENSION)", "CR3"},
+    {"$(EXPORT_EXTENSION)", "jpg"},
+
+    {"$(EXPORT_EXTENSION^)", "Jpg"},
+    {"$(EXPORT_EXTENSION^^)", "JPG"},
+    {"$(EXPORT_EXTENSION,)", "jpg"},
+    {"$(EXPORT_EXTENSION,,)", "jpg"},
+
+    {"$(FILE_NAME).$(EXPORT_EXTENSION^^)", "IMG_1234.JPG"},
+
+    {NULL, NULL}
+  }
+};
+
 static const test_t test_broken_variables = {
-  "abcdef12345abcdef", "ABCDEF12345ABCDEF", 23,
+  "abcdef12345abcdef", "ABCDEF12345ABCDEF", 23, NULL,
   {
     {"$(NONEXISTANT", "$(NONEXISTANT"},
     {"x(NONEXISTANT23", "x(NONEXISTANT23"},
@@ -142,7 +165,7 @@ static const test_t test_broken_variables = {
 };
 
 static const test_t test_escapes = {
-  "/home/test/Images/IMG_0123.CR2", "/home/test/", 23,
+  "/home/test/Images/IMG_0123.CR2", "/home/test/", 23, NULL,
   {
     {"foobarbaz", "foobarbaz"},
     {"foo/bar/baz", "foo/bar/baz"},
@@ -161,7 +184,7 @@ static const test_t test_escapes = {
 };
 
 static const test_t test_real_paths = {
-  "/home/test/Images/0023/IMG_0123.CR2", "/home/test", 23,
+  "/home/test/Images/0023/IMG_0123.CR2", "/home/test", 23, NULL,
   {
     {"$(FILE_FOLDER#$(JOBCODE))", "/Images/0023"},
     {"$(FILE_FOLDER#$(JOBCODE)/Images)", "/0023"},
@@ -212,6 +235,8 @@ int main(int argc, char* argv[])
   TEST(test_simple_substitutions)
 
   TEST(test_recursive_substitutions)
+
+  TEST(test_export_extension)
 
   TEST(test_broken_variables)
 


### PR DESCRIPTION
# Export filename extension case (fixes #19050)

## Problem

Exported filenames always got a hard-coded lowercase extension (`.jpg`,
`.png`, ...) appended by the storage module, regardless of what the
filename pattern already produced. Two consequences:

- No way to control the case of the export extension (e.g. get `.JPG`
  to match camera-style naming like `IMG_1234.CR3`).
- Embedding an extension explicitly in the pattern (e.g.
  `$(FILE_NAME).JPG`) produced a duplicated extension:
  `IMG_1234.JPG.jpg`.

There was also no variable exposing the *export format's* extension.
`$(FILE_EXTENSION)` reflects the *source* file's extension only, so
`$(FILE_NAME).$(FILE_EXTENSION^^)` does not give the export extension
at all — for a CR3 processed to JPEG it expands to `IMG_1234.CR3`.

## Changes

**1. Don't double-append a matching extension**
(`common/utility.c/.h`, `imageio/storage/{disk,gallery,latex}.c`)

Added `dt_util_str_ends_with_extension()`, a case-insensitive
"does this filename already end in `.ext`" check. Each storage
module now skips appending its implicit extension when the expanded
pattern already ends with it (in any case). Patterns without an
extension behave exactly as before.

In `disk.c`, the "generate unique filename on conflict" handling
reuses the same insertion point to write `_01`, `_02`, ... suffixes
before the extension on repeated exports to the same target. That
insertion point is now computed consistently whether the extension
was already present in the pattern or just appended, so conflict
suffixes land in the right place (`name_01.jpg`) instead of after an
already-present extension (`name.JPG_01.jpg`).

**2. New `$(EXPORT_EXTENSION)` variable**
(`common/variables.c/.h`, `gui/gtkentry.c`,
`imageio/storage/{disk,gallery,latex,piwigo}.c`)

Exposes the extension of the *export format actually being used*
(`format->extension(fdata)`), as opposed to `$(FILE_EXTENSION)`
which is the source file's extension. Works with the existing
`^`/`^^`/`,`/`,,` case operators like any other variable.

## Result

```
$(FILE_NAME).$(EXPORT_EXTENSION^^)
```

now expands correctly and dynamically for whatever format is being
exported to, e.g. `IMG_1234.CR3` → `IMG_1234.JPG` when exporting to
JPEG, with no duplicated extension.

## Scope

`disk` (file export) and the GUI's `EXPORT_EXTENSION` availability
cover the reported case. `gallery` and `latex` storage got the same
double-append fix for consistency (same underlying pattern, same
bug). `piwigo`'s pattern-driven path doesn't append an extension
itself, so it only gained `$(EXPORT_EXTENSION)` support, not the
double-append fix (nothing to fix there). `email` storage builds its
filename internally, not from a user pattern, so it's unaffected.

## Testing

All changed files compile cleanly under the project's CI flags
(`gcc-16`, `-Werror -Wfatal-errors`, Ubuntu 26.04 toolchain).
Verified end-to-end with `darktable-cli` exporting a real Canon CR3
sample:

- `$(FILE_NAME).JPG` (JPEG export) → single correctly-cased
  extension, no duplication.
- Default pattern, no explicit extension (JPEG export) → unchanged
  `.jpg` behavior, no regression.
- `$(FILE_NAME).$(EXPORT_EXTENSION^^)` (JPEG export) →
  `IMG_1234.JPG`.
- `$(FILE_NAME).$(EXPORT_EXTENSION^^)` (PNG export, same source
  file) → `IMG_1234.PNG` — confirms the variable tracks the actual
  export format rather than being hard-coded to one.
- `$(FILE_NAME).$(EXPORT_EXTENSION,,)` (JPEG export) →
  `IMG_1234.jpg` — lowercase operator works as expected.
- `$(FILE_NAME).JPG` (JPEG export) exported three times to the same
  location with "generate unique filename" conflict handling →
  `IMG_1234.JPG`, `IMG_1234_01.jpg`, `IMG_1234_02.jpg`.

Automated tests added:

- `src/tests/variables.c` gained a `test_export_extension` case
  covering `$(EXPORT_EXTENSION)` with all four case operators, and
  the `$(FILE_NAME).$(EXPORT_EXTENSION^^)` combination, including a
  case confirming `$(FILE_EXTENSION)` and `$(EXPORT_EXTENSION)` stay
  independent (source vs. export format extension).
- New cmocka unit test `src/tests/unittests/util/test_utility.c`
  for `dt_util_str_ends_with_extension()` and the extracted
  `dt_util_str_extension_offset()` helper, including the exact
  matching-extension-plus-conflict-suffix case that caused the
  `disk.c` bug above.