### PR TITLE
cmake: link libwayland-client when GTK3 has the Wayland backend

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -315,6 +315,20 @@ add_definitions("-DGDK_VERSION_MIN_REQUIRED=GDK_VERSION_3_24")
 include_directories(SYSTEM ${GTK3_INCLUDE_DIRS})
 list(APPEND LIBS ${GTK3_LIBRARIES})
 
+# When GTK3 carries the Wayland backend, gui/gtk.c calls into libwayland-client
+# directly (registry roundtrip for server-side decoration support), so we have to
+# link it ourselves. gtk+-3.0.pc does not list it, and relying on libgdk-3 to drag
+# it in breaks with linkers using --no-undefined (e.g. openSUSE's default LDFLAGS).
+if(NOT WIN32 AND NOT APPLE)
+  pkg_check_modules(GTK3_WAYLAND QUIET gtk+-wayland-3.0)
+  if(GTK3_WAYLAND_FOUND)
+    pkg_check_modules(WAYLAND_CLIENT REQUIRED wayland-client)
+    include_directories(SYSTEM ${WAYLAND_CLIENT_INCLUDE_DIRS})
+    link_directories(${WAYLAND_CLIENT_LIBRARY_DIRS})
+    list(APPEND LIBS ${WAYLAND_CLIENT_LIBRARIES})
+  endif()
+endif()
+
 # Check for libxml2 / broken cmake module can't be included in the foreach() below
 find_package(LibXml2 2.6 REQUIRED)
 include_directories(SYSTEM ${LIBXML2_INCLUDE_DIR})


### PR DESCRIPTION
This is a first step of fixing the currently failing [SuSE OBS builds](https://build.opensuse.org/package/show/graphics:darktable:master/darktable), by explicitly linking against wayland client when GTK3 has the wayland backend.
gui/gtk.c calls into libwayland-client directly to detect server-side decoration support, but gtk+-3.0.pc does not list wayland-client. The symbols were only resolved by accident, via libgdk-3's own DT_NEEDED, which breaks on distros linking with `-Wl,--no-undefined`, e.g. openSUSE puts it in the default LDFLAGS.

The following builds are failing since around 2026-02-07 due to this issue:
* openSUSE_Tumbleweed
* openSUSE_Tumbleweed_ARM
* openSUSE_Tumbleweed_PowerPC
* openSUSE_Tumbleweed_RISCV

------------

I'm currently also looking into fixing the issue that darktable-mcp is built but not packaged within the OBS builds:
```
Fedora / RPM
error: Installed (but unpackaged) file(s) found:
   /usr/bin/darktable-mcp
   /usr/lib/debug/usr/bin/darktable-mcp-5.7.0~git520...debug

Debian / Ubuntu
dh_missing: warning: usr/bin/darktable-mcp exists in debian/tmp but is not installed to anywhere
dh_missing: warning: usr/share/darktable/mcp-tools.json exists in debian/tmp but is not installed to anywhere
dh_missing: error: missing files, aborting
```
This is going to be fixed within the OBS repo, by adding darktable-mcp to the darktable.spec, darktable.dsc and debian.tar.xz files, see change request: https://build.opensuse.org/request/show/1371329