### PR TITLE
Some helper additions

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -246,8 +246,8 @@ static int usage(const char *argv0)
          "--disable-opencl\n"
          "    Prevent darktable from initializing the OpenCL subsystem.\n"
          "\n"
-         "--opencl-tiling\n"
-         "    Enforce fast opencl tiling even if not required.\n"
+         "--opencl-tiling --opencl-no-tiling\n"
+         "    Enforce or disable fast opencl tiling even if not required.\n"
          "    Use for performance/debugging sessions only.\n"
          "\n"
          "--opencl-migrate\n"
@@ -1347,6 +1347,13 @@ int dt_init(int argc,
       {
 #ifdef HAVE_OPENCL
         options |= DT_OPENCL_OPTION_FAST_TILE;
+#endif
+        argv[k] = NULL;
+      }
+      else if(!strcmp(argv[k], "--opencl-no-tiling"))
+      {
+#ifdef HAVE_OPENCL
+        options |= DT_OPENCL_OPTION_NOFAST_TILE;
 #endif
         argv[k] = NULL;
       }

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -179,12 +179,13 @@ typedef int32_t dt_filmid_t;
 #define DT_DEVICE_NONE -2
 
 // We have several bitmask opencl start options passed to dt_opencl_init()
-#define DT_OPENCL_OPTION_NONE 0       // default
-#define DT_OPENCL_OPTION_EXCLUDE 1    // --disable-opencl:  disables OpenCL for the session
+#define DT_OPENCL_OPTION_NONE 0         // default
+#define DT_OPENCL_OPTION_EXCLUDE 1      // --disable-opencl:  disables OpenCL for the session
 // some reserved options, mentioned cli options might not be available depending on build
-#define DT_OPENCL_OPTION_FAST_TILE 2  // --cl-tiling:       use OpenCL tiling mode (debugging session)
-#define DT_OPENCL_OPTION_SPURIOS 4    // --cl-spurious:     insert random OpenCL errors while processing modules (debugging session)
-#define DT_OPENCL_OPTION_MIGRATE 8    // --cl-migrate:      enforce cl_mem migration while allocating cl_mem (debugging session)
+#define DT_OPENCL_OPTION_FAST_TILE 2    // --opencl-tiling:   use OpenCL tiling mode (debugging session)
+#define DT_OPENCL_OPTION_SPURIOS 4      // --opencl-spurious: insert random OpenCL errors while processing modules (debugging session)
+#define DT_OPENCL_OPTION_MIGRATE 8      // --opencl-migrate:  enforce cl_mem migration while allocating cl_mem (debugging session)
+#define DT_OPENCL_OPTION_NOFAST_TILE 16 // --opencl-notiling: disable OpenCL fast tiling mode (debugging session)
 
 typedef int32_t dt_mask_id_t;
 #define INVALID_MASKID (-1)

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -1223,6 +1223,7 @@ void dt_opencl_init(dt_opencl_t *cl,
   cl->error_count = 0;
   cl->fastcl = dt_conf_get_bool("opencl_fast");
   cl->fast_tiling = options & DT_OPENCL_OPTION_FAST_TILE;
+  cl->no_fast_tiling = (options & DT_OPENCL_OPTION_NOFAST_TILE) || dt_conf_get_bool("no_opencl_fast_tiling");
   cl->spurious = options & DT_OPENCL_OPTION_SPURIOS;
   cl->migrate = options & DT_OPENCL_OPTION_MIGRATE;
 #if CL_TARGET_OPENCL_VERSION == 300
@@ -3776,7 +3777,7 @@ dt_opencl_tilemode_t dt_opencl_image_fits_device(const int devid,
 
   // fast internal OpenCL tiling possible and with a good bet on performance?
   const gboolean good_bet = (tlines - 2*overlap) > (tlines / 5);
-  return good_bet ? DT_OPENCL_FAST_TILING : DT_OPENCL_TILING;
+  return good_bet && !cl->no_fast_tiling ? DT_OPENCL_FAST_TILING : DT_OPENCL_TILING;
 }
 
 /** round size to a multiple of the value given in the device specifig

--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -227,6 +227,7 @@ typedef struct dt_opencl_t
   gboolean stopped;
   gboolean fastcl;  // for fast runtime checks instead of reading the conf
   gboolean fast_tiling;
+  gboolean no_fast_tiling;
   gboolean spurious;
   gboolean migrate;
   int num_devs;

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -2328,7 +2328,7 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
       c) modules having the IOP_FLAGS_WRITE_PIPECACHE_IN
 
   */
-  const gboolean has_focus = module == dt_dev_gui_module();
+  const gboolean has_focus = module == dt_dev_gui_module() && module->enabled;
   const gboolean last_history = darktable.develop->history_last_module == module;
   const gboolean iop_wanting = module->flags() & IOP_FLAGS_WRITE_PIPECACHE_IN;
   const gboolean important_input =

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -3058,63 +3058,72 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
   }
 
   // warn on NaN or infinity
-  if((darktable.unmuted & DT_DEBUG_NAN) && !dt_iop_module_is_gamma(module))
+  if((darktable.unmuted & DT_DEBUG_NAN)
+      && !dt_iop_module_is_gamma(module)
+      && ((*out_format)->datatype == TYPE_FLOAT)
+      && (bpp == sizeof(float) || bpp == 4*sizeof(float)))
   {
     gboolean valid_output = TRUE;
+    float *analyse = (float *)*output;
+    const int ch = (*out_format)->channels;
+
 #ifdef HAVE_OPENCL
     if(*cl_mem_output != NULL)
-      valid_output = _copy_image_to_host_err(pipe->devid, *output, *cl_mem_output, roi_out->width, roi_out->height, bpp, "NaN analysis")
+    {
+      analyse = dt_alloc_align_float((size_t)roi_out->width * roi_out->height * ch);
+      valid_output = _copy_image_to_host_err(pipe->devid, analyse, *cl_mem_output, roi_out->width, roi_out->height, bpp, "NaN analysis")
         == CL_SUCCESS;
-
+      if(!valid_output)
+        dt_print_pipe(DT_DEBUG_ALWAYS, "invalid NaN analysis", pipe, module, pipe->devid, &roi_in, roi_out);
+    }
 #endif
 
-    const int ch = (*out_format)->channels;
-    if(valid_output && (*out_format)->datatype == TYPE_FLOAT && (ch == 1 || ch == 4))
+    if(valid_output)
     {
       const int m = ch - 1;
 
-      gboolean hasinf = FALSE, hasnan = FALSE;
-      dt_aligned_pixel_t min = { FLT_MAX, FLT_MAX, FLT_MAX };
-      dt_aligned_pixel_t max = { -FLT_MAX, -FLT_MAX, -FLT_MAX };
+      int hasinf = 0;
+      int hasnan = 0;
+      int ch3 = 0;
+      dt_aligned_pixel_t vmin = { FLT_MAX, FLT_MAX, FLT_MAX };
+      dt_aligned_pixel_t vmax = { -FLT_MAX, -FLT_MAX, -FLT_MAX };
 
+      DT_OMP_FOR(reduction(+ : hasinf,hasnan,ch3) reduction(max : vmax[0:4]) reduction(min : vmin[0:4]) )
       for(int k = 0; k < ch * roi_out->width * roi_out->height; k++)
       {
+        const float f = analyse[k];
         if((k & m) < 3)
         {
-          const float f = ((float *)(*output))[k];
           if(dt_isnan(f))
-            hasnan = TRUE;
+            hasnan = hasnan +1;
           else if(dt_isinf(f))
-            hasinf = TRUE;
+            hasinf = hasinf +1;
           else
           {
-            min[k & m] = fminf(f, min[k & m]);
-            max[k & m] = fmaxf(f, max[k & m]);
+            vmin[k & m] = fminf(f, vmin[k & m]);
+            vmax[k & m] = fmaxf(f, vmax[k & m]);
           }
         }
+        else if((k & m) == 3)
+        {
+          if(dt_isnan(f) || dt_isinf(f))
+            ch3 = ch3 +1;
+        }
       }
-      if(hasnan)
-        dt_print(DT_DEBUG_ALWAYS,
-                 "[dev_pixelpipe] module `%s%s' outputs NaNs! [%s]",
-                 module->op, dt_iop_get_instance_id(module),
-                 dt_dev_pixelpipe_type_to_str(pipe->type));
-      if(hasinf)
-        dt_print(DT_DEBUG_ALWAYS,
-                 "[dev_pixelpipe] module `%s%s' outputs non-finite floats! [%s]",
-                 module->op, dt_iop_get_instance_id(module),
-                 dt_dev_pixelpipe_type_to_str(pipe->type));
+
       if(ch == 4)
-        dt_print(DT_DEBUG_ALWAYS,
-                "[dev_pixelpipe] module `%s%s' min: (%f; %f; %f) max: (%f; %f; %f) [%s]",
-                  module->op, dt_iop_get_instance_id(module),
-                  min[0], min[1], min[2], max[0], max[1], max[2],
-                  dt_dev_pixelpipe_type_to_str(pipe->type));
+        dt_print_pipe(DT_DEBUG_ALWAYS, hasinf > 0 || hasnan > 0 ? "NaN/INFINITE" : "out range",
+          pipe, module, pipe->devid, &roi_in, roi_out,
+          "NaNs=%d Infinites=%d ch3=%d min: (%.4f; %.4f; %.4f) max: (%.4f; %.4f; %.4f)",
+          hasnan, hasinf, ch3, vmin[0], vmin[1], vmin[2], vmax[0], vmax[1], vmax[2]);
       else
-        dt_print(DT_DEBUG_ALWAYS,
-                "[dev_pixelpipe] module `%s%s' min: (%f) max: (%f) [%s]",
-                module->op, dt_iop_get_instance_id(module), min[0], max[0],
-                dt_dev_pixelpipe_type_to_str(pipe->type));
+        dt_print_pipe(DT_DEBUG_ALWAYS, hasinf > 0 || hasnan > 0 ? "NaN/INFINITE" : "out range",
+          pipe, module, pipe->devid, &roi_in, roi_out,
+          "NaNs=%d Infinites=%d min: (%.4f) max: (%.4f)",
+          hasnan, hasinf, vmin[0], vmax[0]);
     }
+    if(analyse != *output)
+      dt_free_align(analyse);
   }
 
   // 4) colorpicker and scopes:


### PR DESCRIPTION
**Provide `--opencl-no-tiling`**

Added the cli option `--opencl-no-tiling` to disable fast internal opencl tiling in case this recent OpenCL pipe feature doesn't work correctly. (Can also be switched on via dt_conf_get_bool("no_opencl_fast_tiling")
________________________________________
**Improved importance cache hint**

The module-in-focus should only give a performance hint if enabled so the OpenCL code might avoid the write-back to host.
______________________________________
**Improved analysis of NaN pipe data**

1. If analyzing data from OpenCL cl_mem we should not overwrite data in output cacheline as that might be used otherwise but to a temp buffer.
2. The analysing happens in OMP code for performance
3. At least in OpenCL code some drivers might behave in a strange way if there are NaNs or infinites in channel 3 so we analyse and report that too.
4. Simplified log output