### PR TITLE
Free local_laplacian kernels when exiting OpenCL

### DIFF
--- a/src/common/locallaplaciancl.c
+++ b/src/common/locallaplaciancl.c
@@ -44,6 +44,19 @@ dt_local_laplacian_cl_global_t *dt_local_laplacian_init_cl_global()
   return g;
 }
 
+void dt_local_laplacian_free_cl_global(dt_local_laplacian_cl_global_t *b)
+{
+  if(!b) return;
+  // destroy kernels
+  dt_opencl_free_kernel(b->kernel_pad_input);
+  dt_opencl_free_kernel(b->kernel_gauss_reduce);
+  dt_opencl_free_kernel(b->kernel_laplacian_assemble);
+  dt_opencl_free_kernel(b->kernel_process_curve);
+  dt_opencl_free_kernel(b->kernel_write_back);
+  free(b);
+}
+
+
 void dt_local_laplacian_free_cl(dt_local_laplacian_cl_t *g)
 {
   if(!g) return;

--- a/src/common/locallaplaciancl.h
+++ b/src/common/locallaplaciancl.h
@@ -50,6 +50,8 @@ typedef struct dt_local_laplacian_cl_t
 dt_local_laplacian_cl_t;
 
 dt_local_laplacian_cl_global_t *dt_local_laplacian_init_cl_global();
+void dt_local_laplacian_free_cl_global(dt_local_laplacian_cl_global_t *b);
+
 dt_local_laplacian_cl_t *dt_local_laplacian_init_cl(
     const int devid,
     const int width,            // width of input image

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -1629,7 +1629,7 @@ void dt_opencl_cleanup(dt_opencl_t *cl)
     dt_heal_free_cl_global(cl->heal);
     dt_colorspaces_free_cl_global(cl->colorspaces);
     dt_guided_filter_free_cl_global(cl->guided_filter);
-
+    dt_local_laplacian_free_cl_global(cl->local_laplacian);
     for(int i = 0; i < cl->num_devs; i++)
     {
       _cleanup_cl_device_context(cl, i);


### PR DESCRIPTION
Dont't mem leak. Also 5.6.1