### PR TITLE
Fix incorrect NaN detection in gpx.c

### DIFF
--- a/src/common/gpx.c
+++ b/src/common/gpx.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2011-2025 darktable developers.
+    Copyright (C) 2011-2026 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+
 #include "common/gpx.h"
 #include "common/geo.h"
 #include "common/darktable.h"
@@ -238,7 +239,7 @@ gboolean dt_gpx_get_location(const dt_gpx_t *gpx, GDateTime *timestamp, dt_image
         geoloc->longitude = lon;
 
         /* make a simple linear interpolation on elevation */
-        if(tp_next->elevation == NAN || tp->elevation == NAN)
+        if(isnan(tp_next->elevation) || isnan(tp->elevation))
           geoloc->elevation = NAN;
         else
           geoloc->elevation = tp->elevation + (tp_next->elevation - tp->elevation) * f;


### PR DESCRIPTION
Any comparison using the `==` operator where at least one operand is `NaN` (Not-a-Number) will always evaluate to false in C. The standard and most readable approach is to use the `isnan()` macro provided in the `<math.h>` header.

After this fix when one of the points is NaN we immediately set the interpolated elevation to NaN. Previously, due to an error, we always went to the "else" branch and calculated the result according to the formula, but due to the infectivity of NaN, the result was still the same, NaN.

In fact, the point of the fix is ​​only to not have an erroneous pattern in the code, which could push someone to make a mistake when coding "as seen in the existing code".