### PR TITLE
5.6.x tests: stop using cmocka's deprecated check_expected()

### DIFF
--- a/src/tests/unittests/iop/test_filmicrgb.c
+++ b/src/tests/unittests/iop/test_filmicrgb.c
@@ -54,7 +54,15 @@
 void __wrap_dt_iop_color_picker_reset(dt_iop_module_t *module, gboolean update)
 {
   check_expected_ptr(module);
+  /* cmocka 1.1.8 deprecated the untyped check_expected() in favour of the
+     width-explicit variants, and the tests are built with -Werror, so the old
+     spelling is a hard build failure there. Keep both spellings: the typed
+     macro does not exist in cmocka 1.1.0, which the build still accepts. */
+#ifdef check_expected_int
+  check_expected_int(update);
+#else
   check_expected(update);
+#endif
 }
 
 


### PR DESCRIPTION
For newer cmocka versions. Fixes build on e.g. Arch