### PR TITLE
Fix 21811 tone eq curve solution precision and error handling

### DIFF
--- a/src/iop/choleski.h
+++ b/src/iop/choleski.h
@@ -62,10 +62,11 @@
  * order, maybe one day, to have a general linear solving lib that
  * could for example iterate over methods until one succeed.
  *
- * We didn't bother to parallelize the code nor to make it use double
- * floating point precision because it's already fast enough (2 to 45
- * ms for 16×16 matrix on Xeon) and used for properly conditioned
- * matrices.
+ * We didn't bother to parallelize the code because it's already
+ * fast enough. Double precision is required to limit rounding error
+ * accumulation in the summing loops: forming A'A squares the condition
+ * number, and the last Cholesky pivot is then a difference of nearly
+ * equal quantities that float cannot resolve.
  *
  * Vectorization leads to slow-downs here since we access matrices
  * row-wise and column-wise, in a non-contiguous fashion.
@@ -83,8 +84,8 @@
 
 
 __DT_CLONE_TARGETS__
-static inline gboolean _choleski_decompose(const float *const restrict A,
-                                           float *const restrict L,
+static inline gboolean _choleski_decompose(const double *const restrict A,
+                                           double *const restrict L,
                                            size_t n,
                                            const gboolean verbose)
 {
@@ -92,35 +93,35 @@ static inline gboolean _choleski_decompose(const float *const restrict A,
   // slow and safe variant : we check values for negatives in sqrt and
   // divisions by 0.
 
-  if(A[0] <= 0.0f) return FALSE; // failure : non positive definite matrice
+  if(A[0] <= 0.0) return FALSE; // failure : non positive definite matrix
 
   gboolean valid = TRUE;
 
   for(size_t i = 0; i < n; i++)
     for(size_t j = 0; j < (i + 1); j++)
     {
-      float sum = 0.0f;
+      double sum = 0.0;
 
       for(size_t k = 0; k < j; k++)
         sum += L[i * n + k] * L[j * n + k];
 
       if(i == j)
       {
-        const float temp = A[i * n + i] - sum;
+        const double temp = A[i * n + i] - sum;
 
-        if(temp < 0.0f)
+        if(temp < 0.0)
         {
           valid = FALSE;
           L[i * n + j] = NAN;
         }
         else
-          L[i * n + j] = sqrtf(A[i * n + i] - sum);
+          L[i * n + j] = sqrt(temp);
       }
       else
       {
-        const float temp = L[j * n + j];
+        const double temp = L[j * n + j];
 
-        if(temp == 0.0f)
+        if(temp == 0.0)
         {
           valid = FALSE;
           L[i * n + j] = NAN;
@@ -137,9 +138,9 @@ static inline gboolean _choleski_decompose(const float *const restrict A,
 
 
 __DT_CLONE_TARGETS__
-static inline gboolean _triangular_descent(const float *const restrict L,
-                                           const float *const restrict y,
-                                           float *const restrict b,
+static inline gboolean _triangular_descent(const double *const restrict L,
+                                           const double *const restrict y,
+                                           double *const restrict b,
                                            const size_t n,
                                            const gboolean verbose)
 {
@@ -150,13 +151,13 @@ static inline gboolean _triangular_descent(const float *const restrict L,
 
   for(size_t i = 0; i < n; ++i)
   {
-    float sum = y[i];
+    double sum = y[i];
     for(size_t j = 0; j < i; ++j)
       sum -= L[i * n + j] * b[j];
 
-    const float temp = L[i * n + i];
+    const double temp = L[i * n + i];
 
-    if(temp != 0.0f)
+    if(temp != 0.0)
       b[i] = sum / temp;
     else
     {
@@ -170,9 +171,9 @@ static inline gboolean _triangular_descent(const float *const restrict L,
 }
 
 __DT_CLONE_TARGETS__
-static inline gboolean _triangular_ascent(const float *const restrict L,
-                                          const float *const restrict b,
-                                          float *const restrict x,
+static inline gboolean _triangular_ascent(const double *const restrict L,
+                                          const double *const restrict b,
+                                          double *const restrict x,
                                           const size_t n,
                                           const gboolean verbose)
 {
@@ -183,12 +184,12 @@ static inline gboolean _triangular_ascent(const float *const restrict L,
 
   for(int i = (n - 1); i > -1 ; --i)
   {
-    float sum = b[i];
+    double sum = b[i];
     for(int j = (n - 1); j > i; --j)
       sum -= L[j * n + i] * x[j];
 
-    const float temp = L[i * n + i];
-    if(temp != 0.0f)
+    const double temp = L[i * n + i];
+    if(temp != 0.0)
       x[i] = sum / temp;
     else
     {
@@ -204,16 +205,16 @@ static inline gboolean _triangular_ascent(const float *const restrict L,
 
 
 __DT_CLONE_TARGETS__
-static inline gboolean _solve_hermitian(const float *const restrict A,
-                                        float *const restrict y,
+static inline gboolean _solve_hermitian(const double *const restrict A,
+                                        double *const restrict y,
                                         const size_t n,
                                         const gboolean verbose)
 {
   // Solve A x = y where A an hermitian positive definite matrix n × n
   // x and y are n vectors. Output the result in y
 
-  float *const restrict x = dt_alloc_align_float(n);
-  float *const restrict L = dt_alloc_align_float(n * n);
+  double *const restrict x = dt_alloc_align_double(n);
+  double *const restrict L = dt_alloc_align_double(n * n);
 
   if(!x || !L)
   {
@@ -247,7 +248,7 @@ static inline gboolean _solve_hermitian(const float *const restrict A,
 
 __DT_CLONE_TARGETS__
 static inline void _transpose_dot_matrix(float *const restrict A, // input
-                                         float *const restrict A_square, // output
+                                         double *const restrict A_square, // output
                                          const size_t m,
                                          const size_t n)
 {
@@ -257,9 +258,9 @@ static inline void _transpose_dot_matrix(float *const restrict A, // input
   for(size_t i = 0; i < n; ++i)
     for(size_t j = 0; j < (i + 1); ++j)
     {
-      float sum = 0.0f;
+      double sum = 0.0;
       for(size_t k = 0; k < m; ++k)
-        sum += A[k * n + i] * A[k * n + j];
+        sum += (double)A[k * n + i] * (double)A[k * n + j];
 
       A_square[i * n + j] = sum;
     }
@@ -269,16 +270,16 @@ static inline void _transpose_dot_matrix(float *const restrict A, // input
 __DT_CLONE_TARGETS__
 static inline void _transpose_dot_vector(float *const restrict A, // input
                                          float *const restrict y, // input
-                                         float *const restrict y_square, // output
+                                         double *const restrict y_square, // output
                                          const size_t m,
                                          const size_t n)
 {
   // Construct the vector A' y
   for(size_t i = 0; i < n; ++i)
   {
-    float sum = 0.0f;
+    double sum = 0.0;
     for(size_t k = 0; k < m; ++k)
-      sum += A[k * n + i] * y[k];
+      sum += (double)A[k * n + i] * (double)y[k];
 
     y_square[i] = sum;
   }
@@ -302,8 +303,8 @@ static inline gboolean pseudo_solve(float *const restrict A,
     return FALSE;
   }
 
-  float *const restrict A_square = dt_alloc_align_float(n * n);
-  float *const restrict y_square = dt_alloc_align_float(n);
+  double *const restrict A_square = dt_alloc_align_double(n * n);
+  double *const restrict y_square = dt_alloc_align_double(n);
 
   if(!A_square || !y_square)
   {
@@ -331,7 +332,11 @@ static inline gboolean pseudo_solve(float *const restrict A,
 
   // Solve A' A x = A' y for x
   gboolean valid = _solve_hermitian(A_square, y_square, n, verbose);
-  if(valid) dt_simd_memcpy(y_square, y, n);
+  if(valid)
+  {
+    for(size_t i = 0; i < n; i++)
+      y[i] = (float) y_square[i];
+  }
 
   dt_free_align(y_square);
   dt_free_align(A_square);

--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -1519,7 +1519,15 @@ static inline void compute_lut_correction(dt_iop_toneequalizer_gui_data_t *g,
   }
 }
 
-
+// Mark g->interpolation_matrix as invalid to force a recompute, and update g->sigma
+// which the matrix computation in update_curve_lut uses.
+// Important: the caller must hold the GUI critical section.
+static inline void _invalidate_interpolation_matrix_on_sigma_change(dt_iop_toneequalizer_gui_data_t *g,
+                                                                    const float smoothing)
+{
+  if(g->sigma != smoothing) g->interpolation_valid = FALSE;
+  g->sigma = smoothing;
+}
 
 static inline gboolean update_curve_lut(dt_iop_module_t *self)
 {
@@ -1622,9 +1630,7 @@ void commit_params(dt_iop_module_t *self,
   if(self->dev->gui_attached && g)
   {
     dt_iop_gui_enter_critical_section(self);
-    if(g->sigma != p->smoothing)
-      g->interpolation_valid = FALSE;
-    g->sigma = p->smoothing;
+    _invalidate_interpolation_matrix_on_sigma_change(g, p->smoothing);
     g->user_param_valid = FALSE; // force updating channels factors
     dt_iop_gui_leave_critical_section(self);
 
@@ -1780,12 +1786,14 @@ static void smoothing_callback(GtkWidget *slider, dt_iop_module_t *self)
 {
   DT_GUARD_GUI_UPDATE();
   dt_iop_toneequalizer_params_t *p = self->params;
-  const dt_iop_toneequalizer_gui_data_t *g = self->gui_data;
+  dt_iop_toneequalizer_gui_data_t *g = self->gui_data;
 
   p->smoothing= powf(M_SQRT2_F, 1.0f +  dt_bauhaus_slider_get(slider));
 
-  float factors[CHANNELS] DT_ALIGNED_ARRAY;
-  get_channels_factors(factors, p);
+  // avoid stale matrix; commit_params(), which also performs the invalidation, has not run yet
+  dt_iop_gui_enter_critical_section(self);
+  _invalidate_interpolation_matrix_on_sigma_change(g, p->smoothing);
+  dt_iop_gui_leave_critical_section(self);
 
   // Solve the interpolation by least-squares to check the validity of the smoothing param
   if(!update_curve_lut(self))

--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -1349,7 +1349,7 @@ static void gui_cache_init(dt_iop_module_t *self)
   g->lut_valid = FALSE;            // TRUE if the gui_lut is ready
   g->graph_valid = FALSE;          // TRUE if the UI graph view is ready
   g->user_param_valid = FALSE;     // TRUE if users params set in interactive view are in bounds
-  g->factors_valid = TRUE;         // TRUE if radial-basis coeffs are ready
+  g->factors_valid = FALSE;        // TRUE once radial-basis coeffs have been successfully solved
 
   g->valid_nodes_x = FALSE;        // TRUE if x coordinates of graph nodes have been inited
   g->valid_nodes_y = FALSE;        // TRUE if y coordinates of graph nodes have been inited
@@ -1499,6 +1499,13 @@ static inline void compute_lut_correction(dt_iop_toneequalizer_gui_data_t *g,
   if(g == NULL) return;
 
   float *const restrict LUT = g->gui_lut;
+
+  if(!g->factors_valid)
+  {
+    for(size_t i = 0; i < UI_SAMPLES; i++) LUT[i] = offset;
+    return;
+  }
+
   const float *const restrict factors = g->factors;
   const float sigma = g->sigma;
 
@@ -1609,6 +1616,9 @@ void commit_params(dt_iop_module_t *self,
   /*
    * Perform a radial-based interpolation using a series gaussian functions
    */
+
+  gboolean curve_valid;
+
   if(self->dev->gui_attached && g)
   {
     dt_iop_gui_enter_critical_section(self);
@@ -1618,7 +1628,7 @@ void commit_params(dt_iop_module_t *self,
     g->user_param_valid = FALSE; // force updating channels factors
     dt_iop_gui_leave_critical_section(self);
 
-    update_curve_lut(self);
+    curve_valid = update_curve_lut(self);
 
     dt_iop_gui_enter_critical_section(self);
     dt_simd_memcpy(g->factors, d->factors, PIXEL_CHAN);
@@ -1632,14 +1642,23 @@ void commit_params(dt_iop_module_t *self,
 
     float A[CHANNELS * PIXEL_CHAN] DT_ALIGNED_ARRAY;
     build_interpolation_matrix(A, p->smoothing);
-    pseudo_solve(A, factors, CHANNELS, PIXEL_CHAN, TRUE);
+    curve_valid = pseudo_solve(A, factors, CHANNELS, PIXEL_CHAN, TRUE);
 
     dt_simd_memcpy(factors, d->factors, PIXEL_CHAN);
   }
 
   // compute the correction LUT here to spare some time in process
   // when computing several times toneequalizer with same parameters
-  compute_correction_lut(d->correction_lut, d->smoothing, d->factors);
+  if(curve_valid)
+  {
+    compute_correction_lut(d->correction_lut, d->smoothing, d->factors);
+  }
+  else
+  {
+    // solver failed; make sure the operation is a no-op with/without darkroom GUI
+    for(size_t i = 0; i < LUT_RESOLUTION * PIXEL_CHAN + 1; i++)
+      d->correction_lut[i] = 1.0f;
+  }
 }
 
 
@@ -2392,8 +2411,15 @@ void gui_post_expose(dt_iop_module_t *self,
     exposure_in = g->cursor_exposure;
     luminance_in = exp2f(exposure_in);
 
-    // Get the corresponding correction and compute resulting exposure
-    correction = log2f(pixel_correction(exposure_in, g->factors, g->sigma));
+    // avoid stale g->factors: only set correction if factors were successfully solved;
+    // otherwise, leave correction = 0 EV, which is what the pixels get — commit_params() fills
+    // correction_lut with 1.0 when there is no valid solution.
+    if(g->factors_valid)
+    {
+      // Get the corresponding correction and compute resulting exposure
+      correction = log2f(pixel_correction(exposure_in, g->factors, g->sigma));
+    }
+
     exposure_out = exposure_in + correction;
     luminance_out = exp2f(exposure_out);
   }


### PR DESCRIPTION
The root cause of the issue, as identified in [#21811 ](https://github.com/darktable-org/darktable/issues/21811#issuecomment-5272710381), was a lack of numeric precision in the maths of `choleski.h`. This was complicated by different compiler settings triggering the issue at the smoothing soft limit, or only at the hard limit. Upgrading the maths to double-precision fixes the precision issue.

Two further problems:
- the error handling path in `toneequal.c` differed for darkroom and lighttable/export
- there was an issue in the invalidation/recalculation of parameters that caused the warning message to be delayed.

To keep this testable, the actual fixes is committed last; otherwise, the error-handling behaviour (such the fix prove insufficient/ineffective in a certain environment/with certain build options) would not be testable, at least not on my machine (where the main fix works perfectly).

Evidence of neutral behaviour (if the main fix is ineffective, testable by only using the 1st 2 commits):
<img width="594" height="476" alt="fix1-zero-out-correction-if-solution-failed" src="https://github.com/user-attachments/assets/490250ea-78fb-4041-8b6c-6997c1395a72" />

With all the fixes applied:
<img width="587" height="479" alt="image" src="https://github.com/user-attachments/assets/e5146f7e-a36c-4b22-863b-3b2ebc02eebf" />
