### PR TITLE
exif: fix O(n^2) XMP tag removal on write-out

### DIFF
--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -37,6 +37,7 @@
 #include <iostream>
 #include <sstream>
 #include <string>
+#include <vector>
 
 // avoid error reported when including exiv2.hpp on macOS (XCode 15.2)
 #pragma GCC diagnostic push
@@ -477,53 +478,60 @@ static void _exif_value_str(const int value,
   g_free(str_value);
 }
 
-static void _deleteXmpTag(Exiv2::XmpData &xmp, const char *tag)
+// Returns true if `key` is exactly `tag`, or an array element of it
+// (`tag[n]`).
+static bool _xmp_key_matches_tag(const std::string &key,
+                                  const char *tag,
+                                  const size_t tag_len)
 {
-  try {
-    Exiv2::XmpData::iterator pos = xmp.findKey(Exiv2::XmpKey(tag));
-
-    while(pos != xmp.end())
-    {
-      std::string key = pos->key();
-      const char *ckey = key.c_str();
-      size_t len = key.size();
-
-      // Stop iterating once the key no longer matches what we are
-      // trying to delete. This assumes sorted input.
-      if(!(g_str_has_prefix(ckey, tag)
-        && (ckey[len] == '[' || ckey[len] == '\0')))
-        break;
-      pos = xmp.erase(pos);
-    }
-  }
-  catch(const Exiv2::AnyError &e)
-  {
-    // The only exception we may get is "invalid" tag, which is not
-    // important enough to either stop the function, or even display
-    // a message (it's probably the tag that is not implemented in
-    // the Exiv2 version used).
-  }
+  return key.compare(0, tag_len, tag) == 0
+    && (key.size() == tag_len || key[tag_len] == '[');
 }
 
 // Function to remove known dt keys and subtrees from xmpdata, so not
 // to append them twice. This should work because dt first reads all
 // known keys.
+//
+// Exiv2::XmpData is vector-backed, so erasing one element at a time
+// (the previous implementation) is O(n) per erase due to the shift of
+// all following elements -- for a history stack with many entries (and
+// therefore many array elements per key, e.g. history_params[1..N])
+// that makes this function O(n^2). Instead, do a single pass and copy
+// over only the entries we want to keep.
 static void _remove_known_keys(Exiv2::XmpData &xmp)
 {
-  xmp.sortByKey();
-
-  // dt internal tags
-  for(unsigned int i = 0; i < dt_xmp_keys_n; i++)
-    _deleteXmpTag(xmp, dt_xmp_keys[i]);
-
-  // now the tags from the metadata editor
+  std::vector<std::string> metadata_tags;
   dt_pthread_mutex_lock(&darktable.metadata_threadsafe);
   for(GList *iter = dt_metadata_get_list(); iter; iter = iter->next)
   {
     const dt_metadata_t *metadata = (dt_metadata_t *)iter->data;
-    _deleteXmpTag(xmp, metadata->tagname);
+    metadata_tags.emplace_back(metadata->tagname);
   }
   dt_pthread_mutex_unlock(&darktable.metadata_threadsafe);
+
+  const bool use_packet = xmp.usePacket();
+  const std::string packet = xmp.xmpPacket();
+
+  Exiv2::XmpData filtered;
+  for(Exiv2::XmpData::const_iterator pos = xmp.begin(); pos != xmp.end(); ++pos)
+  {
+    const std::string key = pos->key();
+
+    bool known = false;
+    for(unsigned int i = 0; !known && i < dt_xmp_keys_n; i++)
+      known = _xmp_key_matches_tag(key, dt_xmp_keys[i], strlen(dt_xmp_keys[i]));
+    for(const std::string &tag : metadata_tags)
+    {
+      if(known) break;
+      known = _xmp_key_matches_tag(key, tag.c_str(), tag.size());
+    }
+
+    if(!known) filtered.add(*pos);
+  }
+
+  xmp = filtered;
+  xmp.setPacket(packet);
+  xmp.usePacket(use_packet);
 }
 
 static void _remove_exif_keys(Exiv2::ExifData &exif,


### PR DESCRIPTION

### Problem

-   `_deleteXmpTag`  erased matching entries one at a time from a vector-backed  `Exiv2::XmpData`; each erase shifts every following element, so for a history stack with many entries (many  `history_params[1..N]`-style array elements per key),  `_remove_known_keys`  was O(n²) in the number of XMP entries.

### Fix

-   Replaced the per-tag erase loop with a single O(n) pass that copies only the non-matching entries into a fresh  `XmpData`, preserving  `packet`/`usePacket`  state across the rebuild.
-   Behavior-preserving: same set of keys removed (dt internal tags + metadata-editor tags), same exact-or-array-element matching semantics.

### Relevance

 `dt_image_write_sidecar_file` (which calls this) isn't on the per-edit hot path — it's debounced to darktable's `autosave_interval` (default 10s) while editing, and otherwise runs async on a single serial background job thread (`sidecar_jobs.c`). So this isn't about UI lag on every keystroke. It matters for two independent reasons:

-   **CPU cycles, regardless of visibility.**  The sync job is one thread processing images sequentially — seconds spent in an O(n²) write is that thread doing nothing else for that span, delaying every other queued image, and it's real contention/power draw against pixelpipe rendering happening concurrently. Fewer cycles is a win on its own merits.
-   **Two genuinely synchronous, user-visible paths.**  Quitting darktable while in darkroom (`gtk.c`'s  `_quit_callback`) and "compress history" both call the write directly, blocking the calling thread — on a deep history these are the concrete, perceptible stalls (see the benchmark below).

Benchmarked against real `Exiv2::XmpData`, matching darktable's actual sidecar structure (8 sub-fields per `history[n]`, 8 per `masks_history[n]`), at increasing history depth N:

```markdown
| N (history steps = mask rows) | XMP entries | old | new | speedup |
|---:|---:|---:|---:|---:|
| 10 | 165 | 2.9 ms | 0.05 ms | 61x |
| 25 | 405 | 10.3 ms | 0.08 ms | 131x |
| 50 | 805 | 27.4 ms | 0.11 ms | 248x |
| 100 | 1,605 | 93.7 ms | 0.19 ms | 486x |
| 200 | 3,205 | 367.7 ms | 0.42 ms | 879x |
| 400 | 6,405 | 1,471 ms | 0.78 ms | 1,882x |
| 800 | 12,805 | 5,772 ms | 1.66 ms | 3,473x |
```
