### PR TITLE
Add --print-paths / --print-paths-as-flags

### DIFF
--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -102,6 +102,11 @@ fprintf(stderr, "darktable %s\n"
                 "   --icc-file <file> specify icc filename, default to NONE\n"
                 "   --icc-intent <intent> specify icc intent, default to LAST\n"
                 "                     use --help icc-intent for list of supported intents\n"
+                "   --print-paths     print the resolved configdir, cachedir, tmpdir,\n"
+                "                     datadir, moduledir, localedir and library paths\n"
+                "                     for this install, then exit\n"
+                "   --print-paths-as-flags  like --print-paths, printed as a single\n"
+                "                     line of --flag value pairs\n"
                 "   --verbose\n"
                 "   -h, --help [option]\n"
                 "   -v, --version\n",
@@ -238,6 +243,7 @@ int main(int argc, char *arg[])
   gboolean verbose = FALSE, high_quality = TRUE, upscale = FALSE,
            style_overwrite = FALSE, custom_presets = TRUE, export_masks = FALSE,
            output_to_dir = FALSE;
+  gboolean print_paths = FALSE, print_paths_as_flags = FALSE;
 
   GList* inputs = NULL;
 
@@ -442,6 +448,16 @@ int main(int argc, char *arg[])
         k++;
         break;
       }
+      else if(!strcmp(arg[k], "--print-paths"))
+      {
+        print_paths = TRUE;
+        print_paths_as_flags = FALSE;
+      }
+      else if(!strcmp(arg[k], "--print-paths-as-flags"))
+      {
+        print_paths_as_flags = TRUE;
+        print_paths = FALSE;
+      }
       else
       {
         fprintf(stderr, _("warning: unknown option '%s'\n"), arg[k]);
@@ -462,14 +478,26 @@ int main(int argc, char *arg[])
   }
 
   int m_argc = 0;
-  char **m_arg = malloc(sizeof(char *) * (5 + argc - k + 1));
+  char **m_arg = malloc(sizeof(char *) * (6 + argc - k + 1));
   m_arg[m_argc++] = "darktable-cli";
   m_arg[m_argc++] = "--library";
   m_arg[m_argc++] = library ? library : ":memory:";
   m_arg[m_argc++] = "--conf";
   m_arg[m_argc++] = "write_sidecar_files=never";
   for(; k < argc; k++) m_arg[m_argc++] = arg[k];
+  if(print_paths_as_flags)
+    m_arg[m_argc++] = "--print-paths-as-flags";
+  else if(print_paths)
+    m_arg[m_argc++] = "--print-paths";
   m_arg[m_argc] = NULL;
+
+  if(print_paths || print_paths_as_flags)
+  {
+    // dt_init() resolves and prints the paths, then exit()s directly -
+    // skip the input/output file requirements below, they don't apply
+    // to a paths query.
+    dt_init(m_argc, m_arg, FALSE, custom_presets, NULL);
+  }
 
   gboolean args_error = FALSE;
   if(inputs && file_counter < 1)

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -222,6 +222,15 @@ static int usage(const char *argv0)
          "    Typical locations are /opt/darktable/share/darktable/noiseprofile.json\n"
          "    and /usr/share/darktable/noiseprofile.json\n"
          "\n"
+         "--print-paths\n"
+         "    Print the resolved configdir, cachedir, tmpdir, datadir,\n"
+         "    moduledir, localedir and library paths for this install,\n"
+         "    honoring any of the above overrides, then exit.\n"
+         "\n"
+         "--print-paths-as-flags\n"
+         "    Like --print-paths, but printed as a single line of\n"
+         "    --flag value pairs ready to splice into another invocation.\n"
+         "\n"
          "-t, --threads NUM\n"
          "    Limit number of openmp threads to use in openmp parallel sections\n"
          "\n"
@@ -1023,6 +1032,8 @@ int dt_init(int argc,
   char *tmpdir_from_command = NULL;
   char *configdir_from_command = NULL;
   char *cachedir_from_command = NULL;
+  gboolean print_paths = FALSE;
+  gboolean print_paths_as_flags = FALSE;
 
   darktable.dump_pfm_module = NULL;
   darktable.dump_pfm_pipe = NULL;
@@ -1102,6 +1113,18 @@ int dt_init(int argc,
       {
         dbfilename_from_command = argv[++k];
         argv[k-1] = NULL;
+        argv[k] = NULL;
+      }
+      else if(!strcmp(argv[k], "--print-paths"))
+      {
+        print_paths = TRUE;
+        print_paths_as_flags = FALSE;
+        argv[k] = NULL;
+      }
+      else if(!strcmp(argv[k], "--print-paths-as-flags"))
+      {
+        print_paths_as_flags = TRUE;
+        print_paths = FALSE;
         argv[k] = NULL;
       }
       else if(!strcmp(argv[k], "--datadir") && argc > k + 1)
@@ -1610,6 +1633,53 @@ int dt_init(int argc,
   // This files contains all preferences with the attribute common="true" in
   // darktableconfig.xml.in.
   dt_conf_init(darktable.conf, darktablerc_common, TRUE, config_override);
+
+  if(print_paths || print_paths_as_flags)
+  {
+    // Resolve the same darktablerc-<label>/database-key path real
+    // startup uses below, but before gtk_init()/dt_workspace_create()
+    // ever run - so this needs no display and never shows the
+    // workspace picker. Reports the current default, same as what a
+    // headless darktable-cli run (which skips that GUI code too) would use.
+    const char *dblabel = dt_conf_get_string_const("workspace/label");
+    const gboolean default_dbname = strcmp(dblabel, "") == 0;
+
+    char darktablerc[PATH_MAX] = { 0 };
+    snprintf(darktablerc, sizeof(darktablerc),
+             "%s/darktablerc%s%s", datadir,
+             default_dbname ? "" : "-",
+             default_dbname ? "" : dblabel);
+
+    dt_conf_init(darktable.conf, darktablerc, FALSE, config_override);
+
+    // mirrors the alternative/database-key/:memory:/relative/absolute
+    // resolution in dt_database_init() (database.c), without its
+    // migration and mipmap-cleanup side effects.
+    gchar library_path[PATH_MAX] = { 0 };
+    if(dbfilename_from_command)
+    {
+      g_strlcpy(library_path, dbfilename_from_command, sizeof(library_path));
+    }
+    else
+    {
+      const char *libname = dt_conf_get_string_const("database");
+      if(!libname)
+        snprintf(library_path, sizeof(library_path),
+                 "%s%slibrary.db", datadir, G_DIR_SEPARATOR_S);
+      else if(!strcmp(libname, ":memory:"))
+        g_strlcpy(library_path, libname, sizeof(library_path));
+      else if(libname[0] != '/')
+        snprintf(library_path, sizeof(library_path),
+                 "%s%s%s", datadir, G_DIR_SEPARATOR_S, libname);
+      else
+        g_strlcpy(library_path, libname, sizeof(library_path));
+    }
+    dt_loc_print_paths(stdout, library_path, print_paths_as_flags);
+    // dt_init()'s return value only signals error-vs-continue to its
+    // callers (0 means "keep starting up") - exit directly so we
+    // don't fall through into normal GUI/CLI startup.
+    exit(0);
+  }
 
   // set the interface language and prepare selection for prefs & confgen
   darktable.l10n = dt_l10n_init(init_gui);

--- a/src/common/file_location.c
+++ b/src/common/file_location.c
@@ -73,6 +73,29 @@ uint8_t dt_loc_init(const char *datadir,
   return 0;
 }
 
+void dt_loc_print_paths(FILE *out, const char *library_path, gboolean as_flags)
+{
+  if(as_flags)
+  {
+    fprintf(out,
+            "--configdir %s --cachedir %s --tmpdir %s --datadir %s"
+            " --moduledir %s --localedir %s --library %s\n",
+            darktable.configdir, darktable.cachedir, darktable.tmpdir,
+            darktable.datadir, darktable.plugindir, darktable.localedir,
+            library_path);
+  }
+  else
+  {
+    fprintf(out, "configdir   %s\n", darktable.configdir);
+    fprintf(out, "cachedir    %s\n", darktable.cachedir);
+    fprintf(out, "tmpdir      %s\n", darktable.tmpdir);
+    fprintf(out, "datadir     %s\n", darktable.datadir);
+    fprintf(out, "moduledir   %s\n", darktable.plugindir);
+    fprintf(out, "localedir   %s\n", darktable.localedir);
+    fprintf(out, "library     %s\n", library_path);
+  }
+}
+
 gchar *dt_loc_get_home_dir(const gchar *user)
 {
   if(user == NULL || g_strcmp0(user, g_get_user_name()) == 0)

--- a/src/common/file_location.h
+++ b/src/common/file_location.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include <gtk/gtk.h>
+#include <stdio.h>
 #include <string.h>
 
 G_BEGIN_DECLS
@@ -31,6 +32,11 @@ G_BEGIN_DECLS
 
 // Returns the users home directory
 gchar *dt_loc_get_home_dir(const gchar *user);
+
+// Print the already-resolved darktable.* paths plus library_path,
+// either as an aligned human-readable table or as a single line of
+// ready-to-splice --flag value pairs.
+void dt_loc_print_paths(FILE *out, const char *library_path, gboolean as_flags);
 
 // Init all dirs
 uint8_t dt_loc_init(const char *datadir,


### PR DESCRIPTION
Resolving `configdir`, `cachedir`, `datadir`, `moduledir`, `localedir` and `library.db` today means reading source or -d dev debug spew, since `--help` only says "depends on your installation". A direct query is needed to compare paths across an apt/from-source/flatpak install during migration, and to point a new install at an existing one's paths/database without hand-deriving them.

This patch exposes the paths in an easy to use way, thus simplifying actual paths used and thus making it easier to migrate from one of binaries to another or check the right location for binaries, configuration or database content in these paths.