### PR TITLE
Add opt-in SHA-1 checksum + size tracking for images

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -365,6 +365,13 @@
     <longdescription>entries in XMP tags can get rather large and may exceed the available space to store the history stack in output files.\nthis option allows XMP tags to be compressed and save space.</longdescription>
   </dtconfig>
   <dtconfig prefs="storage" section="XMP">
+    <name>plugins/darkroom/compute_checksum</name>
+    <type>bool</type>
+    <default>false</default>
+    <shortdescription>identify images by checksum</shortdescription>
+    <longdescription>compute a SHA-1 checksum and file size for each image the first time it is fully loaded, and store them in the database and (if XMP sidecar files are enabled) in the .xmp file; lets external tools match a sidecar to its image after the image has been renamed or moved. computed lazily, so images never opened in darkroom are not covered; has no effect on collections where this is left off.</longdescription>
+  </dtconfig>
+  <dtconfig prefs="storage" section="XMP">
     <name>autosave_interval</name>
     <type>int</type>
     <default>10</default>

--- a/src/common/database.c
+++ b/src/common/database.c
@@ -51,7 +51,7 @@
 #define LAST_FULL_DATABASE_VERSION_DATA    10
 
 // You HAVE TO bump THESE versions whenever you add an update branches to _upgrade_*_schema_step()!
-#define CURRENT_DATABASE_VERSION_LIBRARY 57
+#define CURRENT_DATABASE_VERSION_LIBRARY 58
 #define CURRENT_DATABASE_VERSION_DATA    13
 
 #define USE_NESTED_TRANSACTIONS
@@ -2966,6 +2966,23 @@ static int _upgrade_library_schema_step(dt_database_t *db,
     TRY_EXEC("ALTER TABLE main.images ADD COLUMN flash_tagvalue INTEGER DEFAULT -1",
              "[init] can't add `flash_tagvalue' column to images table in database\n");
     new_version = 57;
+  }
+  else if(version == 57)
+  {
+    // image identity: raw SHA-1 digest + file size, computed lazily on
+    // first full read (opt-in via plugins/darkroom/compute_checksum),
+    // used to match a sidecar to its image after a rename/move.
+    // BLOB(20), not CHAR(20): CHAR would give the column TEXT affinity
+    // (misleading for binary data, even though a bound BLOB value still
+    // round-trips through it unconverted); the trailing comment is kept
+    // by SQLite as part of the column definition, so it stays visible in
+    // `.schema images` for anyone inspecting the live database, not just
+    // in this source file.
+    TRY_EXEC("ALTER TABLE main.images ADD COLUMN sha1sum BLOB(20) /* 20-byte binary SHA-1 digest, not hex text */",
+             "[init] can't add `sha1sum' column to images table in database\n");
+    TRY_EXEC("ALTER TABLE main.images ADD COLUMN filesize INTEGER",
+             "[init] can't add `filesize' column to images table in database\n");
+    new_version = 58;
   }
   else
     new_version = version; // should be the fallback so that calling code sees that we are in an infinite loop

--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -408,6 +408,9 @@ static void _read_xmp_timestamps(Exiv2::XmpData &xmpData,
                                  dt_image_t *img,
                                  const int xmp_version);
 
+static void _read_xmp_checksum(Exiv2::XmpData &xmpData,
+                               dt_image_t *img);
+
 static void _read_xmp_harmony_guide(Exiv2::XmpData &xmpData,
                                     dt_image_t *img,
                                     const int xmp_version);
@@ -4699,6 +4702,8 @@ gboolean dt_exif_xmp_read(dt_image_t *img,
 
     _read_xmp_timestamps(xmpData, img, xmp_version);
 
+    _read_xmp_checksum(xmpData, img);
+
     _read_xmp_harmony_guide(xmpData, img, xmp_version);
 
     if(stmt)
@@ -4994,6 +4999,46 @@ static void _set_xmp_timestamps(Exiv2::XmpData &xmpData,
   sqlite3_finalize(stmt);
 }
 
+// Add the sha1sum + filesize identity fields to XmpData, if computed
+// (see plugins/darkroom/compute_checksum). Written as an uppercase hex
+// string, "sha1:<40 hex chars>" -- plain text, no base64/zlib encoding
+// needed since it's already a short scalar value.
+static void _set_xmp_checksum(Exiv2::XmpData &xmpData,
+                              const dt_imgid_t imgid)
+{
+  static const char *keys[] =
+  {
+    "Xmp.darktable.image_checksum",
+    "Xmp.darktable.image_size"
+  };
+  static const guint n_keys = G_N_ELEMENTS(keys);
+  _remove_xmp_keys(xmpData, keys, n_keys);
+
+  sqlite3_stmt *stmt;
+  // clang-format off
+  DT_DEBUG_SQLITE3_PREPARE_V2(
+      dt_database_get(darktable.db),
+      "SELECT sha1sum, filesize"
+      " FROM main.images"
+      " WHERE id = ?1",
+      -1, &stmt, NULL);
+  DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, imgid);
+  // clang-format on
+
+  if(sqlite3_step(stmt) == SQLITE_ROW
+     && sqlite3_column_type(stmt, 0) != SQLITE_NULL
+     && sqlite3_column_bytes(stmt, 0) == 20)
+  {
+    const unsigned char *digest = (const unsigned char *)sqlite3_column_blob(stmt, 0);
+    char hex[41];
+    for(int i = 0; i < 20; i++)
+      snprintf(hex + i * 2, 3, "%02X", digest[i]);
+    xmpData["Xmp.darktable.image_checksum"] = std::string("sha1:") + hex;
+    xmpData["Xmp.darktable.image_size"] = sqlite3_column_int64(stmt, 1);
+  }
+  sqlite3_finalize(stmt);
+}
+
 static void _set_xmp_harmony_guide(Exiv2::XmpData &xmpData,
                                    const dt_imgid_t imgid)
 {
@@ -5060,6 +5105,47 @@ void _read_xmp_timestamps(Exiv2::XmpData &xmpData,
     else if(pos->toLong() >= 1)
       img->print_timestamp = _convert_unix_to_gtimespan(pos->toLong());
   }
+}
+
+// Read sha1sum + filesize identity fields from XmpData. Tolerant: an
+// absent or unparseable value is simply skipped, same as every other
+// optional darktable: field -- this lets old sidecars (written before
+// this feature existed) load without error or warning.
+void _read_xmp_checksum(Exiv2::XmpData &xmpData,
+                        dt_image_t *img)
+{
+  Exiv2::XmpData::iterator pos;
+  if((pos = xmpData.findKey(Exiv2::XmpKey("Xmp.darktable.image_checksum")))
+     != xmpData.end())
+  {
+    const std::string val = pos->toString();
+    // accept "sha1:<40 hex chars>" or a bare 40-char hex string; hex
+    // decoding is inherently case-insensitive regardless of how the
+    // value was written.
+    const size_t hex_start = (val.size() >= 5 && val.compare(0, 5, "sha1:") == 0) ? 5 : 0;
+    if(val.size() - hex_start == 40)
+    {
+      unsigned char digest[20];
+      gboolean valid = TRUE;
+      for(int i = 0; i < 20 && valid; i++)
+      {
+        const int hi = g_ascii_xdigit_value(val[hex_start + i * 2]);
+        const int lo = g_ascii_xdigit_value(val[hex_start + i * 2 + 1]);
+        if(hi < 0 || lo < 0)
+          valid = FALSE;
+        else
+          digest[i] = (unsigned char)((hi << 4) | lo);
+      }
+      if(valid)
+      {
+        memcpy(img->sha1sum, digest, sizeof(digest));
+        img->flags |= DT_IMAGE_HAS_SHA1SUM;
+      }
+    }
+  }
+
+  if((pos = xmpData.findKey(Exiv2::XmpKey("Xmp.darktable.image_size"))) != xmpData.end())
+    img->filesize = pos->toLong();
 }
 
 // Read color harmony guides from XmpData
@@ -5281,6 +5367,9 @@ static void _exif_xmp_read_data(Exiv2::XmpData &xmpData,
 
   // Timestamps
   _set_xmp_timestamps(xmpData, imgid);
+
+  // Image identity (sha1sum + filesize), if computed
+  _set_xmp_checksum(xmpData, imgid);
 
   _set_xmp_harmony_guide(xmpData, imgid);
 

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -1387,7 +1387,8 @@ static dt_imgid_t _image_duplicate_with_version_ext(const dt_imgid_t imgid,
      "   orientation, longitude, latitude, altitude, color_matrix,"
      "   colorspace, version, max_version,"
      "   history_end, position, aspect_ratio, exposure_bias, import_timestamp,"
-     "   whitebalance_id, flash_id, exposure_program_id, metering_mode_id, flash_tagvalue)"
+     "   whitebalance_id, flash_id, exposure_program_id, metering_mode_id, flash_tagvalue,"
+     "   sha1sum, filesize)"
      " SELECT NULL, group_id, film_id, width, height, filename,"
      "        maker_id, model_id, camera_id, lens_id,"
      "        exposure, aperture, iso, focal_length, focus_distance, datetime_taken,"
@@ -1395,7 +1396,10 @@ static dt_imgid_t _image_duplicate_with_version_ext(const dt_imgid_t imgid,
      "        raw_black, raw_maximum, orientation,"
      "        longitude, latitude, altitude, color_matrix, colorspace, NULL, NULL, 0, ?1,"
      "        aspect_ratio, exposure_bias, import_timestamp,"
-     "        whitebalance_id, flash_id, exposure_program_id, metering_mode_id, flash_tagvalue"
+     "        whitebalance_id, flash_id, exposure_program_id, metering_mode_id, flash_tagvalue,"
+     // same physical file as the image being duplicated, so its
+     // identity carries forward unchanged
+     "        sha1sum, filesize"
      " FROM main.images WHERE id = ?2",
      -1, &stmt, NULL);
   // clang-format on
@@ -2202,6 +2206,8 @@ void dt_image_init(dt_image_t *img)
   img->film_id = -1;
   img->group_id = NO_IMGID;
   img->flags = 0;
+  img->filesize = 0;
+  memset(img->sha1sum, 0, sizeof(img->sha1sum));
   img->id = NO_IMGID;
   img->version = -1;
   img->loader = LOADER_UNKNOWN;
@@ -2623,6 +2629,9 @@ dt_imgid_t dt_image_copy_rename(const dt_imgid_t imgid,
          "   longitude, latitude, altitude, color_matrix, colorspace, version, max_version,"
          "   position, aspect_ratio, exposure_bias,"
          "   whitebalance_id, flash_id, exposure_program_id, metering_mode_id, flash_tagvalue)"
+         // sha1sum/filesize deliberately not copied here: this creates a
+         // new physical file at a new path, so the new row's identity
+         // must be recomputed lazily, not inherited from the source
          " SELECT NULL, group_id, ?1 as film_id, width, height, ?2 as filename,"
          "        maker_id, model_id, lens_id,"
          "        exposure, aperture, iso, focal_length, focus_distance, datetime_taken,"

--- a/src/common/image.h
+++ b/src/common/image.h
@@ -101,6 +101,10 @@ typedef enum
   DT_IMAGE_MONOCHROME_BAYER = 1 << 19,
   // image has a flag set to use the monochrome workflow in the modules supporting it
   DT_IMAGE_MONOCHROME_WORKFLOW = 1 << 20,
+  // set once sha1sum/filesize have been computed for this image (see
+  // plugins/darkroom/compute_checksum) -- guards against rehashing the
+  // file on every open
+  DT_IMAGE_HAS_SHA1SUM = 1 << 21,
 } dt_image_flags_t;
 
 typedef enum dt_image_colorspace_t
@@ -312,6 +316,11 @@ typedef struct dt_image_t
   dt_imgid_t group_id;
   //timestamps
   GTimeSpan import_timestamp, change_timestamp, export_timestamp, print_timestamp;
+  // image identity: raw 20-byte binary SHA-1 digest of the source file
+  // (not a hex string) and its size in bytes, valid only when
+  // flags & DT_IMAGE_HAS_SHA1SUM
+  unsigned char sha1sum[20];
+  uint64_t filesize;
 
   dt_image_loader_t loader;
 

--- a/src/common/image_cache.c
+++ b/src/common/image_cache.c
@@ -49,7 +49,8 @@ static void _image_cache_allocate(void *data,
       "       raw_black, raw_maximum, aspect_ratio, exposure_bias,"
       "       import_timestamp, change_timestamp, export_timestamp, print_timestamp,"
       "       output_width, output_height, cm.maker, cm.model, cm.alias,"
-      "       wb.name, fl.name, ep.name, mm.name, flash_tagvalue"
+      "       wb.name, fl.name, ep.name, mm.name, flash_tagvalue,"
+      "       sha1sum, filesize"
       "  FROM main.images AS mi"
       "       LEFT JOIN main.cameras AS cm ON cm.id = mi.camera_id"
       "       LEFT JOIN main.makers AS mk ON mk.id = mi.maker_id"
@@ -155,6 +156,20 @@ static void _image_cache_allocate(void *data,
     if(str) g_strlcpy(img->exif_metering_mode, str, sizeof(img->exif_metering_mode));
 
     img->exif_flash_tagvalue = sqlite3_column_int(stmt, 42);
+
+    const void *sha1sum = sqlite3_column_blob(stmt, 43);
+    if(sha1sum && sqlite3_column_bytes(stmt, 43) == sizeof(img->sha1sum))
+    {
+      memcpy(img->sha1sum, sha1sum, sizeof(img->sha1sum));
+      img->filesize = sqlite3_column_int64(stmt, 44);
+      img->flags |= DT_IMAGE_HAS_SHA1SUM;
+    }
+    else
+    {
+      memset(img->sha1sum, 0, sizeof(img->sha1sum));
+      img->filesize = 0;
+      img->flags &= ~DT_IMAGE_HAS_SHA1SUM;
+    }
 
     dt_color_harmony_get(entry->key, &img->color_harmony_guide);
 
@@ -347,7 +362,8 @@ void dt_image_cache_write_release_info(dt_image_t *img,
      "     import_timestamp = ?28, change_timestamp = ?29, export_timestamp = ?30,"
      "     print_timestamp = ?31, output_width = ?32, output_height = ?33,"
      "     whitebalance_id = ?36, flash_id = ?37,"
-     "     exposure_program_id = ?38, metering_mode_id = ?39, flash_tagvalue = ?41"
+     "     exposure_program_id = ?38, metering_mode_id = ?39, flash_tagvalue = ?41,"
+     "     sha1sum = ?42, filesize = ?43"
      " WHERE id = ?40",
      -1, &stmt, NULL);
 
@@ -414,6 +430,16 @@ void dt_image_cache_write_release_info(dt_image_t *img,
   DT_DEBUG_SQLITE3_BIND_INT(stmt, 39, metering_mode_id);
   DT_DEBUG_SQLITE3_BIND_INT(stmt, 40, img->id);
   DT_DEBUG_SQLITE3_BIND_INT(stmt, 41, img->exif_flash_tagvalue);
+  if(img->flags & DT_IMAGE_HAS_SHA1SUM)
+  {
+    DT_DEBUG_SQLITE3_BIND_BLOB(stmt, 42, img->sha1sum, sizeof(img->sha1sum), SQLITE_STATIC);
+    DT_DEBUG_SQLITE3_BIND_INT64(stmt, 43, img->filesize);
+  }
+  else
+  {
+    sqlite3_bind_null(stmt, 42);
+    sqlite3_bind_null(stmt, 43);
+  }
 
   const int rc = sqlite3_step(stmt);
   if(rc != SQLITE_DONE)

--- a/src/imageio/imageio.c
+++ b/src/imageio/imageio.c
@@ -1660,6 +1660,23 @@ static gboolean _compute_sha1sum(const char *filename,
   return ok;
 }
 
+// Whether dt_imageio_open() should (re)compute the sha1sum + filesize
+// identity for an image: yes if none is recorded yet, or if the
+// file's current size no longer matches what was recorded -- catches
+// a stale/foreign checksum (e.g. copied from another image's sidecar)
+// as well as a genuinely replaced file. If stat() itself failed we
+// can't tell either way, so an existing value is trusted rather than
+// unnecessarily rehashed.
+gboolean dt_imageio_identity_needs_recompute(const gboolean has_checksum,
+                                             const uint64_t recorded_filesize,
+                                             const gboolean stat_ok,
+                                             const uint64_t actual_filesize)
+{
+  if(!has_checksum)
+    return TRUE;
+  return stat_ok && (recorded_filesize != actual_filesize);
+}
+
 dt_imageio_retval_t dt_imageio_open(dt_image_t *img,
                                     const char *filename,
                                     dt_mipmap_buffer_t *buf)
@@ -1714,13 +1731,18 @@ dt_imageio_retval_t dt_imageio_open(dt_image_t *img,
   img->p_height = img->height - img->crop_y - img->crop_bottom;
 
   // lazily compute image identity (sha1sum + filesize) on first
-  // successful full read, opt-in only, and only once per image -- a
-  // failed/unsupported load has nothing worth identifying.
-  if((ret == DT_IMAGEIO_OK)
-     && !(img->flags & DT_IMAGE_HAS_SHA1SUM)
-     && dt_conf_get_bool("plugins/darkroom/compute_checksum"))
+  // successful full read, opt-in only -- a failed/unsupported load has
+  // nothing worth identifying. Also recomputed if the size on disk no
+  // longer matches a previously recorded value (see
+  // dt_imageio_identity_needs_recompute()).
+  if((ret == DT_IMAGEIO_OK) && dt_conf_get_bool("plugins/darkroom/compute_checksum"))
   {
-    if(_compute_sha1sum(filename, img->sha1sum, &img->filesize))
+    GStatBuf st;
+    const gboolean stat_ok = (g_stat(filename, &st) == 0);
+    if(dt_imageio_identity_needs_recompute(img->flags & DT_IMAGE_HAS_SHA1SUM,
+                                           img->filesize, stat_ok,
+                                           (uint64_t)st.st_size)
+       && _compute_sha1sum(filename, img->sha1sum, &img->filesize))
       img->flags |= DT_IMAGE_HAS_SHA1SUM;
   }
 

--- a/src/imageio/imageio.c
+++ b/src/imageio/imageio.c
@@ -1622,6 +1622,44 @@ void dt_imageio_set_hdr_tag(dt_image_t *img)
 //   combined reading
 // =================================================
 
+// Compute the raw 20-byte SHA-1 digest and exact byte count of a file, for
+// image identity tracking (see plugins/darkroom/compute_checksum). This is
+// a dedicated, sequential second read pass rather than a hook into a
+// loader's own I/O: only rawspeed reads the whole file into one buffer up
+// front, libraw/tiff/jpeg/the magick fallback all stream via their own
+// internal (partly vendored/third-party) I/O with no buffer we could tap.
+// Size is derived from bytes actually read here, not a separate stat(),
+// so the two values are always consistent with each other.
+static gboolean _compute_sha1sum(const char *filename,
+                                 unsigned char sha1sum_out[20],
+                                 uint64_t *filesize_out)
+{
+  FILE *f = g_fopen(filename, "rb");
+  if(!f)
+    return FALSE;
+
+  GChecksum *chk = g_checksum_new(G_CHECKSUM_SHA1);
+  unsigned char buf[65536];
+  size_t n;
+  uint64_t total = 0;
+  while((n = fread(buf, 1, sizeof(buf), f)) > 0)
+  {
+    g_checksum_update(chk, buf, n);
+    total += n;
+  }
+  const gboolean ok = !ferror(f);
+  fclose(f);
+
+  if(ok)
+  {
+    gsize digest_len = 20;
+    g_checksum_get_digest(chk, sha1sum_out, &digest_len);
+    *filesize_out = total;
+  }
+  g_checksum_free(chk);
+  return ok;
+}
+
 dt_imageio_retval_t dt_imageio_open(dt_image_t *img,
                                     const char *filename,
                                     dt_mipmap_buffer_t *buf)
@@ -1674,6 +1712,17 @@ dt_imageio_retval_t dt_imageio_open(dt_image_t *img,
 
   img->p_width = img->width - img->crop_x - img->crop_right;
   img->p_height = img->height - img->crop_y - img->crop_bottom;
+
+  // lazily compute image identity (sha1sum + filesize) on first
+  // successful full read, opt-in only, and only once per image -- a
+  // failed/unsupported load has nothing worth identifying.
+  if((ret == DT_IMAGEIO_OK)
+     && !(img->flags & DT_IMAGE_HAS_SHA1SUM)
+     && dt_conf_get_bool("plugins/darkroom/compute_checksum"))
+  {
+    if(_compute_sha1sum(filename, img->sha1sum, &img->filesize))
+      img->flags |= DT_IMAGE_HAS_SHA1SUM;
+  }
 
   return ret;
 }

--- a/src/imageio/imageio_common.h
+++ b/src/imageio/imageio_common.h
@@ -78,6 +78,12 @@ dt_imageio_retval_t dt_imageio_open_ldr(dt_image_t *img,
 dt_imageio_retval_t dt_imageio_open(dt_image_t *img,
                                     const char *filename,
                                     dt_mipmap_buffer_t *buf);
+// decides whether dt_imageio_open() should (re)compute an image's
+// sha1sum + filesize identity, see plugins/darkroom/compute_checksum
+gboolean dt_imageio_identity_needs_recompute(const gboolean has_checksum,
+                                             const uint64_t recorded_filesize,
+                                             const gboolean stat_ok,
+                                             const uint64_t actual_filesize);
 // tries to open the files not opened by the other routines using
 // GraphicsMagick (if supported)
 dt_imageio_retval_t dt_imageio_open_exotic(dt_image_t *img, const char *filename,

--- a/src/tests/unittests/CMakeLists.txt
+++ b/src/tests/unittests/CMakeLists.txt
@@ -1,3 +1,4 @@
+add_subdirectory(common)
 add_subdirectory(iop)
 
 if(USE_AI)

--- a/src/tests/unittests/common/CMakeLists.txt
+++ b/src/tests/unittests/common/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_cmocka_mock_test(test_imageio
+                     SOURCES test_imageio.c
+                     LINK_LIBRARIES lib_darktable cmocka)
+
+# Windows: libs have to be copied next to the executable
+if(WIN32)
+    _copy_required_library(test_imageio lib_darktable)
+endif(WIN32)

--- a/src/tests/unittests/common/test_imageio.c
+++ b/src/tests/unittests/common/test_imageio.c
@@ -1,0 +1,83 @@
+/*
+    This file is part of darktable,
+    Copyright (C) 2026 darktable developers.
+
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    darktable is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/*
+ * cmocka unit tests for dt_imageio_identity_needs_recompute()
+ * (imageio/imageio.c), which decides whether dt_imageio_open() should
+ * (re)compute an image's sha1sum + filesize identity
+ * (plugins/darkroom/compute_checksum).
+ *
+ * Please see README.md for more detailed documentation.
+ */
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include <cmocka.h>
+
+#include "imageio/imageio_common.h"
+
+#ifdef _WIN32
+#include "win/main_wrapper.h"
+#endif
+
+// no checksum on record yet: always (re)compute, regardless of stat()
+static void test_no_checksum_always_recomputes(void **state)
+{
+  assert_true(dt_imageio_identity_needs_recompute(FALSE, 0, TRUE, 12345));
+  assert_true(dt_imageio_identity_needs_recompute(FALSE, 0, FALSE, 0));
+}
+
+// checksum recorded, size on disk matches: trust the existing value
+static void test_matching_size_keeps_checksum(void **state)
+{
+  assert_false(dt_imageio_identity_needs_recompute(TRUE, 12345, TRUE, 12345));
+}
+
+// checksum recorded, size on disk differs: stale/foreign value, force a
+// recompute -- covers both a sidecar carrying another image's identity
+// (e.g. shared/copied PlayRaw edits) and the underlying file having
+// been replaced since it was last hashed
+static void test_size_mismatch_forces_recompute(void **state)
+{
+  assert_true(dt_imageio_identity_needs_recompute(TRUE, 12345, TRUE, 99999));
+}
+
+// checksum recorded but stat() itself failed: can't tell either way,
+// so don't force an unnecessary rehash -- trust the existing value
+static void test_stat_failure_keeps_checksum(void **state)
+{
+  assert_false(dt_imageio_identity_needs_recompute(TRUE, 12345, FALSE, 0));
+}
+
+int main(int argc, char* argv[])
+{
+  const struct CMUnitTest tests[] = {
+    cmocka_unit_test(test_no_checksum_always_recomputes),
+    cmocka_unit_test(test_matching_size_keeps_checksum),
+    cmocka_unit_test(test_size_mismatch_forces_recompute),
+    cmocka_unit_test(test_stat_failure_keeps_checksum),
+  };
+
+  return cmocka_run_group_tests(tests, NULL, NULL);
+}
+// clang-format off
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
+// clang-format on


### PR DESCRIPTION
**Context:** sidecar files can get lost or separated from their original images and then reconciling those differences can be hard.  Adding a size/checksum allows for relocating sidecars against the original image they were generated against. Also deduplication of duplicate images will be easier as the size/checksums can be compared so even files named differently with matching values can most likely be considered to be identical.

**Patch**

Stores a raw 20-byte SHA-1 digest and file size per image, so a .xmp sidecar can still be matched to its source image after a rename or directory reorganization -- not possible today, since sidecars only record a filename. Revives darktable-org/darktable#2492 (opened 2019, closed by stale-bot, never implemented), discussed on #21864.

- New images.sha1sum BLOB(20) and images.filesize INTEGER columns (schema version 57->58), both nullable, added via plain ALTER TABLE ADD COLUMN (metadata-only in SQLite for nullable, no-default columns -- doesn't rewrite existing rows).
- New plugins/darkroom/compute_checksum preference, default off. Computed lazily on first successful full read via dt_imageio_open(), only once per image (guarded by a new DT_IMAGE_HAS_SHA1SUM flag bit), via a dedicated sequential read pass (GChecksum) rather than hooking into any one loader's own I/O, since only rawspeed exposes a single read buffer.
- Written to the DB immediately; written to the .xmp sidecar (Xmp.darktable.image_checksum as "sha1:<40 uppercase hex chars>", Xmp.darktable.image_size) at the next natural xmp-sync point, gated by the existing write_sidecar_files preference like any other field -- so it's a no-op for users who keep sidecars off.
- Duplicate-with-version carries the identity forward (same physical file); copy-rename does not (new physical file, must recompute lazily).

Transparency: Code generated with help from AI