### PR TITLE
Fix raw denoise picker offset after cropping

### DIFF
--- a/src/common/ai/restore.c
+++ b/src/common/ai/restore.c
@@ -30,6 +30,7 @@
 #include "develop/pixelpipe_hb.h"
 #include "imageio/imageio_common.h"
 
+#include <float.h>
 #include <math.h>
 #include <string.h>
 
@@ -626,6 +627,197 @@ gboolean dt_restore_reload_session_cpu(dt_restore_context_t *ctx)
   }
   ctx->ai_ctx = new_ctx;
   return TRUE;
+}
+
+// snap a patch centred on (px, py) to an aligned origin inside the
+// sensor buffer
+static void _sensor_place(const float px,
+                          const float py,
+                          const int roi_w,
+                          const int roi_h,
+                          const int iw,
+                          const int ih,
+                          const int align,
+                          int *out_x,
+                          int *out_y)
+{
+  int x = (int)px - roi_w / 2;
+  int y = (int)py - roi_h / 2;
+  x = CLAMP(x, 0, iw - roi_w);
+  y = CLAMP(y, 0, ih - roi_h);
+  *out_x = (x / align) * align;
+  *out_y = (y / align) * align;
+}
+
+// does this sensor rect still render? mirrors the ROI mapping in
+// dt_restore_run_user_pipe_roi exactly — forward-transform the corners,
+// inscribed AABB, clamp to the processed extent — so a rect that passes
+// here is one the pipe can actually deliver
+static gboolean _sensor_roi_renders(dt_develop_t *dev,
+                                    dt_dev_pixelpipe_t *pipe,
+                                    const int pw,
+                                    const int ph,
+                                    const int x,
+                                    const int y,
+                                    const int w,
+                                    const int h)
+{
+  float c[8] = {
+    (float)x,       (float)y,
+    (float)(x + w), (float)y,
+    (float)x,       (float)(y + h),
+    (float)(x + w), (float)(y + h),
+  };
+  if(!dt_dev_distort_transform_plus(dev, pipe, 0.0,
+                                    DT_DEV_TRANSFORM_DIR_ALL_GEOMETRY, c, 4))
+    return FALSE;
+
+  float xs[4] = { c[0], c[2], c[4], c[6] };
+  float ys[4] = { c[1], c[3], c[5], c[7] };
+  for(int i = 0; i < 3; i++)
+    for(int j = i + 1; j < 4; j++)
+    {
+      if(xs[i] > xs[j]) { const float t = xs[i]; xs[i] = xs[j]; xs[j] = t; }
+      if(ys[i] > ys[j]) { const float t = ys[i]; ys[i] = ys[j]; ys[j] = t; }
+    }
+
+  int rx = (int)ceilf(xs[1]);
+  int ry = (int)ceilf(ys[1]);
+  int rw = (int)floorf(xs[2]) - rx;
+  int rh = (int)floorf(ys[2]) - ry;
+  if(rx < 0) { rw += rx; rx = 0; }
+  if(ry < 0) { rh += ry; ry = 0; }
+  if(rx + rw > pw) rw = pw - rx;
+  if(ry + rh > ph) rh = ph - ry;
+  return rw > 0 && rh > 0;
+}
+
+// inverse of the ROI bridge below: display-normalised click -> a sensor
+// rect the pipe can render. the worker used to invert only the flip
+// iop, so any crop shifted the sampled patch by
+// u * (sensor_w - crop_w) - crop_origin and border picks back-projected
+// into discarded pixels (issue #21879). contract documented in restore.h
+int dt_restore_display_to_sensor(dt_imgid_t imgid,
+                                 int iw,
+                                 int ih,
+                                 float u,
+                                 float v,
+                                 int roi_w,
+                                 int roi_h,
+                                 int align,
+                                 int *out_roi_x,
+                                 int *out_roi_y)
+{
+  if(iw <= 0 || ih <= 0 || roi_w <= 0 || roi_h <= 0) return 1;
+  if(roi_w > iw || roi_h > ih) return 1;
+  const int a = MAX(1, align);
+
+  dt_develop_t dev;
+  dt_dev_init(&dev, FALSE);
+  dt_dev_load_image(&dev, imgid);
+
+  // init_dummy, not init_export: it skips the pixel cache entirely
+  // ("all but the pixel caches, so you can't actually process an
+  // image — just get dimensions and distortions"), which is exactly
+  // this pipe. init_export would preallocate DT_PIPECACHE_MIN
+  // full-frame cachelines — hundreds of MB on a big raw — for a pipe
+  // that never processes a pixel. the type is then restored to EXPORT
+  // so the geometry chain sees the same pipe kind as the render path
+  dt_dev_pixelpipe_t pipe;
+  if(!dt_dev_pixelpipe_init_dummy(&pipe, iw, ih))
+  {
+    dt_dev_pixelpipe_cleanup(&pipe);
+    dt_dev_cleanup(&dev);
+    return 1;
+  }
+  pipe.type = DT_DEV_PIXELPIPE_EXPORT;
+
+  dt_ioppr_resync_modules_order(&dev);
+  // geometry only: nothing is processed, so the pipe needs no input
+  // buffer — get_dimensions fills the per-piece buf_in / buf_out that
+  // the transforms walk
+  dt_dev_pixelpipe_set_input(&pipe, &dev, NULL, iw, ih, 1.0f);
+  dt_dev_pixelpipe_create_nodes(&pipe, &dev);
+  dt_dev_pixelpipe_synch_all(&pipe, &dev);
+
+  int pw = 0, ph = 0;
+  dt_dev_pixelpipe_get_dimensions(&pipe, &dev, iw, ih, &pw, &ph);
+  if(pw <= 0 || ph <= 0)
+  {
+    dt_dev_pixelpipe_cleanup(&pipe);
+    dt_dev_cleanup(&dev);
+    return 1;
+  }
+  pipe.processed_width = pw;
+  pipe.processed_height = ph;
+
+  // point 0 is the click, point 1 the image centre — the retreat
+  // target when the click sits too close to a geometry-trimmed border
+  float pts[4] = {
+    CLAMP(u, 0.0f, 1.0f) * pw, CLAMP(v, 0.0f, 1.0f) * ph,
+    0.5f * pw,                 0.5f * ph,
+  };
+  if(!dt_dev_distort_backtransform_plus(&dev, &pipe, 0.0,
+                                        DT_DEV_TRANSFORM_DIR_ALL_GEOMETRY,
+                                        pts, 2))
+  {
+    dt_dev_pixelpipe_cleanup(&pipe);
+    dt_dev_cleanup(&dev);
+    return 1;
+  }
+
+  // validate by round trip rather than by reasoning about the visible
+  // sensor region: the chain may swap or mirror axes (flip) and bow
+  // edges (lens, ashift), so there is no side-labelling of the
+  // back-projected boundary that holds in general. walking the rect
+  // back toward the image centre until it renders needs no such
+  // assumption — it asks the forward transform the same question the
+  // pipe will ask
+  int rx = 0, ry = 0;
+  _sensor_place(pts[0], pts[1], roi_w, roi_h, iw, ih, a, &rx, &ry);
+  if(!_sensor_roi_renders(&dev, &pipe, pw, ph, rx, ry, roi_w, roi_h))
+  {
+    int cx = 0, cy = 0;
+    _sensor_place(pts[2], pts[3], roi_w, roi_h, iw, ih, a, &cx, &cy);
+    if(_sensor_roi_renders(&dev, &pipe, pw, ph, cx, cy, roi_w, roi_h))
+    {
+      // bisect for the smallest retreat that renders, so the patch
+      // stays as close to the click as the geometry allows
+      float lo = 0.0f, hi = 1.0f;
+      rx = cx;
+      ry = cy;
+      for(int i = 0; i < 8; i++)
+      {
+        const float t = 0.5f * (lo + hi);
+        int tx = 0, ty = 0;
+        _sensor_place(pts[0] + t * (pts[2] - pts[0]),
+                      pts[1] + t * (pts[3] - pts[1]),
+                      roi_w, roi_h, iw, ih, a, &tx, &ty);
+        if(_sensor_roi_renders(&dev, &pipe, pw, ph, tx, ty, roi_w, roi_h))
+        {
+          hi = t;
+          rx = tx;
+          ry = ty;
+        }
+        else
+          lo = t;
+      }
+    }
+    else
+    {
+      // nothing renders (degenerate history): hand back the centred
+      // rect and let the caller's error path report it
+      rx = cx;
+      ry = cy;
+    }
+  }
+
+  dt_dev_pixelpipe_cleanup(&pipe);
+  dt_dev_cleanup(&dev);
+
+  if(out_roi_x) *out_roi_x = rx;
+  if(out_roi_y) *out_roi_y = ry;
+  return 0;
 }
 
 // shared bridge: run the user's darktable pixelpipe on an arbitrary sensor

--- a/src/common/ai/restore.h
+++ b/src/common/ai/restore.h
@@ -320,6 +320,38 @@ int dt_restore_get_tile_size(const dt_restore_context_t *ctx);
 // @return TRUE on success, FALSE if the CPU session also fails to load
 gboolean dt_restore_reload_session_cpu(dt_restore_context_t *ctx);
 
+// @brief map a click on the displayed image to a sensor-space patch.
+//
+// Inverse of the ROI mapping in dt_restore_run_user_pipe_roi below:
+// the picker normalises clicks against the fully processed image
+// (post crop / rotation / lens / flip), while the raw-denoise preview
+// needs a sensor-space rectangle to pack its inference tile from.
+//
+// The returned rect is validated by round trip — its corners are
+// forward-transformed the way the bridge below does — and walked back
+// toward the image centre until it renders, so a pick near a
+// geometry-trimmed border yields a usable patch instead of failing.
+//
+// @param imgid      image whose geometry chain to invert
+// @param iw, ih     sensor (pipe input) dimensions
+// @param u, v       click, normalised to the processed image
+// @param roi_w      patch width in sensor pixels
+// @param roi_h      patch height in sensor pixels
+// @param align      origin alignment, e.g. 2 to stay on the CFA grid
+// @param out_roi_x  receives the patch origin in sensor coords
+// @param out_roi_y  as out_roi_x
+// @return 0 on success; outputs untouched on failure
+int dt_restore_display_to_sensor(dt_imgid_t imgid,
+                                 int iw,
+                                 int ih,
+                                 float u,
+                                 float v,
+                                 int roi_w,
+                                 int roi_h,
+                                 int align,
+                                 int *out_roi_x,
+                                 int *out_roi_y);
+
 // @brief run darktable's real user pixelpipe on a sensor buffer, ROI-clipped.
 //
 // Shared bridge for the raw-denoise preview paths. Both Bayer and

--- a/src/common/ai/restore_raw_linear.c
+++ b/src/common/ai/restore_raw_linear.c
@@ -1160,20 +1160,26 @@ int dt_restore_raw_linear_preview_piped(dt_restore_context_t *ctx,
 
   g_free(tile_out);
 
-  // run pipe twice on raw-sensor-sized buffers
-  // ROI is in sensor coords (matching the patched region we built
-  // above); dt_restore_run_user_pipe_roi forward-transforms it
-  // through the user's geometry chain before handing to the pipe
+  // run pipe twice on raw-sensor-sized buffers. the ROI must be in
+  // sensor coords, matching the region patched above, so that
+  // dt_restore_run_user_pipe_roi's forward transform lands on it —
+  // but crop_x / crop_y arrive in prepared-buffer coords (the
+  // post-rawprepare visible area returned by
+  // dt_restore_raw_linear_prepare). shift by the same raw_off_* the
+  // patch loop uses, or the render drifts by the rawprepare border
+  const int roi_x = crop_x + raw_off_x;
+  const int roi_y = crop_y + raw_off_y;
+
   int dw = 0, dh = 0, bw = 0, bh = 0;
   int err = dt_restore_run_user_pipe_roi(imgid, patched, raw_w, raw_h,
-                                 crop_x, crop_y, crop_w, crop_h,
+                                 roi_x, roi_y, crop_w, crop_h,
                                  &dw, &dh, out_denoised_rgb);
   g_free(patched);
 
   if(err == 0)
   {
     err = dt_restore_run_user_pipe_roi(imgid, (void *)mbuf.buf, raw_w, raw_h,
-                               crop_x, crop_y, crop_w, crop_h,
+                               roi_x, roi_y, crop_w, crop_h,
                                &bw, &bh, out_before_rgb);
   }
   dt_mipmap_cache_release(&mbuf);

--- a/src/libs/neural_restore.c
+++ b/src/libs/neural_restore.c
@@ -200,6 +200,7 @@
 #include "common/exif.h"
 #include "common/film.h"
 #include "common/grouping.h"
+#include "common/history.h"
 #include "common/image_cache.h"
 #include "common/colorlabels.h"
 #include "common/metadata.h"
@@ -320,6 +321,11 @@ typedef struct dt_lib_neural_restore_t
   int export_h;
   unsigned char *export_cairo;
   int export_cairo_stride;
+  // fingerprint of the history the cached preview + export were built
+  // from, so an edit between two previews invalidates both
+  guint8 *preview_hash;
+  int preview_hash_len;
+  dt_imgid_t preview_hash_imgid;
 
   // raw denoise preview state — disjoint from the export-based preview
   // above. cached per-image (CFA for Bayer, demosaicked lin_rec2020 for
@@ -437,12 +443,13 @@ typedef struct dt_neural_preview_data_t
   int preview_w;
   int preview_h;
   float patch_center[2];
-  // when re-picking, borrow cached export instead of re-exporting.
-  // pointer is valid for the thread's lifetime (main thread joins
-  // before freeing). thread must NOT free this
-  const float *reuse_pixels;
+  // when re-picking, a private copy of the cached export saves a
+  // re-export. owned by the worker, which frees it on every exit
+  float *reuse_pixels;
   int reuse_w;
   int reuse_h;
+  // whether a picker thumbnail existed when this worker was launched
+  gboolean have_export;
 } dt_neural_preview_data_t;
 
 typedef struct dt_neural_preview_result_t
@@ -2358,6 +2365,7 @@ static gpointer _preview_thread(gpointer data)
   result->patch_center[0] = pd->patch_center[0];
   result->patch_center[1] = pd->patch_center[1];
   g_idle_add(_preview_result_idle, result);
+  g_free(pd->reuse_pixels);
   g_free(pd);
   return NULL;
 
@@ -2365,6 +2373,7 @@ cleanup:
   // bail: clear preview_generating on UI thread (stale-sequence bails dropped)
   if(pd->sequence == g_atomic_int_get(&d->preview_sequence))
     _schedule_preview_failed(pd->self, err);
+  g_free(pd->reuse_pixels);
   g_free(pd);
   return NULL;
 }
@@ -2377,12 +2386,11 @@ static void _cancel_preview(dt_lib_module_t *self)
   // bump sequence so any in-flight worker (and its idle callback)
   // discards its result. we DO NOT join here — that would block the
   // UI for the full duration of a running inference. the worker
-  // keeps running in the background and exits silently. but: we DO
-  // need to wait for it before freeing export_pixels below, since the
-  // worker may still be reading from them. take + release the
-  // inference lock as a synchronisation barrier — the worker holds
-  // it during the heavy work, so once we get it we know it's done
-  // touching shared buffers
+  // keeps running in the background and exits silently. the barrier
+  // below (take + release the inference lock, which the worker holds
+  // for its whole run) is kept as a conservative serialisation point
+  // on image change; its original reason — waiting before freeing
+  // export_pixels — no longer applies now that workers copy those
   g_atomic_int_inc(&d->preview_sequence);
   if(d->preview_trigger_timer)
   {
@@ -2759,6 +2767,9 @@ static gpointer _preview_thread_raw(gpointer data)
 
   // bail reason for cleanup path; unsupported-sensor branch overrides
   dt_nr_preview_err_t bail_err = DT_NR_PREVIEW_ERR_INIT_FAILED;
+  // declared up here so every `goto cleanup` below can free it: the
+  // export is expensive to redo and large enough to matter
+  float *take_export_pixels = NULL;
 
   // 1. load source image metadata to determine sensor type.
   //    on a fresh session dt_image_cache_get returns img_meta with a
@@ -2972,10 +2983,15 @@ static gpointer _preview_thread_raw(gpointer data)
   //      full pipeline at ~1024 long edge, giving a display-accurate
   //      thumbnail whose colours match what the user sees in darkroom
   //      (and match our before/after ROI pipe outputs).
-  float *take_export_pixels = NULL;
-  int    export_thumb_w = 0;
-  int    export_thumb_h = 0;
-  if(!cache_matches)
+  int export_thumb_w = 0;
+  int export_thumb_h = 0;
+  // NB: also gated on the thumbnail itself. _cancel_preview frees
+  // export_pixels but leaves preview_full_cfa alone, so keying this on
+  // cache_matches alone left the picker (which tests export_pixels)
+  // insensitive until restart — issue #21879. the flag is a snapshot
+  // taken on the main thread at launch, so this never reads
+  // d->export_pixels from the worker
+  if(!cache_matches || !pd->have_export)
   {
     dt_neural_preview_capture_t cap = {0};
     const int export_size = dt_conf_get_int(CONF_PREVIEW_EXPORT_SIZE);
@@ -3060,21 +3076,47 @@ static gpointer _preview_thread_raw(gpointer data)
     goto cleanup;
   }
 
-  // display-normalised click (u, v) -> sensor pixel, inverting whatever
-  // combination of swap/flip the flip iop will apply during display.
-  // matches dt_iop_flip:distort_backtransform semantics
-  const int disp_w = swap_xy ? full_h : full_w;
-  const int disp_h = swap_xy ? full_w : full_h;
-  float dx_disp = pd->patch_center[0] * disp_w;
-  float dy_disp = pd->patch_center[1] * disp_h;
-  float sx, sy;
-  if(swap_xy) { sx = dy_disp; sy = dx_disp; }
-  else        { sx = dx_disp; sy = dy_disp; }
-  if(ori & ORIENTATION_FLIP_X) sx = (float)full_w - sx;
-  if(ori & ORIENTATION_FLIP_Y) sy = (float)full_h - sy;
+  // display-normalised click (u, v) -> sensor patch. the picker
+  // normalises against the exported thumbnail — the fully processed
+  // image — so the whole geometry chain has to be inverted, not just
+  // the flip iop (issue #21879). the helper also validates the rect
+  // against the forward transform, so a pick near a cropped border
+  // retreats inward instead of rendering nothing.
+  //
+  // it answers in raw sensor coords. the Bayer buffer is the raw
+  // sensor, but the linear one is the post-rawprepare visible area,
+  // so shift into whichever space full_w / full_h are
+  const int buf_off_x = use_linear ? img_meta.crop_x : 0;
+  const int buf_off_y = use_linear ? img_meta.crop_y : 0;
 
-  int crop_x = (int)sx - crop_w / 2;
-  int crop_y = (int)sy - crop_h / 2;
+  int crop_x = 0, crop_y = 0;
+  if(dt_restore_display_to_sensor(pd->imgid, img_meta.width, img_meta.height,
+                                  pd->patch_center[0], pd->patch_center[1],
+                                  crop_w, crop_h, use_linear ? 1 : 2,
+                                  &crop_x, &crop_y) == 0)
+  {
+    crop_x -= buf_off_x;
+    crop_y -= buf_off_y;
+  }
+  else
+  {
+    // no geometry chain: fall back to orientation-only, correct for
+    // an uncropped image and better than failing outright
+    dt_print(DT_DEBUG_AI,
+             "[neural_restore] raw preview: geometry backtransform "
+             "failed, falling back to orientation-only mapping");
+    const int disp_w = swap_xy ? full_h : full_w;
+    const int disp_h = swap_xy ? full_w : full_h;
+    const float dx_disp = pd->patch_center[0] * disp_w;
+    const float dy_disp = pd->patch_center[1] * disp_h;
+    float sx, sy;
+    if(swap_xy) { sx = dy_disp; sy = dx_disp; }
+    else        { sx = dx_disp; sy = dy_disp; }
+    if(ori & ORIENTATION_FLIP_X) sx = (float)full_w - sx;
+    if(ori & ORIENTATION_FLIP_Y) sy = (float)full_h - sy;
+    crop_x = (int)sx - crop_w / 2;
+    crop_y = (int)sy - crop_h / 2;
+  }
   crop_x = CLAMP(crop_x, 0, full_w - crop_w);
   crop_y = CLAMP(crop_y, 0, full_h - crop_h);
   if(!use_linear)
@@ -3159,11 +3201,14 @@ static gpointer _preview_thread_raw(gpointer data)
   res->export_thumb_w = export_thumb_w;
   res->export_thumb_h = export_thumb_h;
   g_idle_add(_preview_raw_result_idle, res);
+  g_free(pd->reuse_pixels);
   g_free(pd);
   return NULL;
 
 cleanup:
   // bail: clear preview_generating on UI thread (stale-sequence bails dropped)
+  g_free(take_export_pixels);
+  g_free(pd->reuse_pixels);
   if(pd->sequence == g_atomic_int_get(&d->preview_sequence))
     _schedule_preview_failed(pd->self, bail_err);
   g_free(pd);
@@ -3188,6 +3233,7 @@ static gpointer _preview_thread_dispatch(gpointer data)
   if(pd->sequence != g_atomic_int_get(&d->preview_sequence))
   {
     g_mutex_unlock(&d->preview_inference_lock);
+    g_free(pd->reuse_pixels);
     g_free(pd);
     return NULL;
   }
@@ -3249,6 +3295,61 @@ static void _trigger_preview(dt_lib_module_t *self)
 
   if(!dt_is_valid_imgid(imgid)) return;
 
+  // an edit since the last preview invalidates the cached results AND
+  // the exported thumbnail. the thumbnail matters beyond freshness:
+  // the picker normalises clicks against it while the raw worker
+  // inverts the CURRENT geometry chain, so a stale export would
+  // reintroduce the #21879 offset from the other side. the history
+  // write above has already brought the DB hash up to date
+  dt_history_hash_values_t hh = { 0 };
+  dt_history_hash_read(imgid, &hh);
+  if(d->preview_hash_imgid != imgid
+     || d->preview_hash_len != hh.current_len
+     || (hh.current_len > 0
+         && (!d->preview_hash
+             || memcmp(d->preview_hash, hh.current, hh.current_len) != 0)))
+  {
+    // bump the sequence first: in-flight results then discard
+    // themselves on delivery, and a worker that has not started yet
+    // exits before touching any of the state below
+    g_atomic_int_inc(&d->preview_sequence);
+    _preview_cache_invalidate_all(d);
+    // the export needs no barrier: workers get their own copy of the
+    // pixels, and their own snapshot of whether one existed at launch
+    g_free(d->export_pixels);
+    d->export_pixels = NULL;
+    g_free(d->export_cairo);
+    d->export_cairo = NULL;
+    // NB: preview_full_lin is deliberately NOT dropped here, though
+    // it is history-dependent (it comes out of rawprepare +
+    // highlights). an in-flight raw worker borrows it for the whole of
+    // its run, so freeing it needs either a barrier — which would
+    // block the GTK thread for an entire inference — or a deferred
+    // ownership scheme. neither belongs in a mapping fix. the cost is
+    // that on linear / X-Trans, editing highlight reconstruction or
+    // the raw black/white point leaves the model reading a stale
+    // demosaic while the un-prepare math uses current metadata, which
+    // can show as a level step in the patched region
+    g_free(d->preview_hash);
+    d->preview_hash = NULL;
+    if(hh.current && hh.current_len > 0)
+    {
+      d->preview_hash = g_malloc(hh.current_len);
+      memcpy(d->preview_hash, hh.current, hh.current_len);
+    }
+    d->preview_hash_len = hh.current_len;
+    d->preview_hash_imgid = imgid;
+    // the picker draws from the export we just dropped: close it
+    // through the toggle so the button visual follows, and refresh
+    // sensitivity now that export_pixels is NULL
+    if(d->picking_thumbnail)
+      gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->pick_button), FALSE);
+    _update_button_sensitivity(d);
+  }
+  g_free(hh.basic);
+  g_free(hh.auto_apply);
+  g_free(hh.current);
+
   // per-task cache lookup: if we already have a result for this exact
   // (task, imgid, patch_center) tuple, install it and skip the worker
   if(_preview_cache_hit(d, d->task, imgid))
@@ -3293,14 +3394,24 @@ static void _trigger_preview(dt_lib_module_t *self)
   pd->patch_center[0] = d->patch_center[0];
   pd->patch_center[1] = d->patch_center[1];
 
-  // borrow cached export pixels if available (re-pick scenario).
-  // the pointer is valid for the thread's lifetime because
-  // _cancel_preview joins before freeing export_pixels
-  if(d->export_pixels)
+  // hand the worker its OWN copy of the cached export (re-pick
+  // scenario). aliasing d->export_pixels would tie every invalidation
+  // to a barrier against the in-flight reader; a copy costs one memcpy
+  // and lets the main thread replace the buffer whenever it likes.
+  // the raw worker exports its own thumbnail and never reads this
+  pd->have_export = (d->export_pixels != NULL);
+  if(d->task != NEURAL_TASK_RAW_DENOISE
+     && d->export_pixels && d->export_w > 0 && d->export_h > 0)
   {
-    pd->reuse_pixels = d->export_pixels;
-    pd->reuse_w = d->export_w;
-    pd->reuse_h = d->export_h;
+    const size_t n = (size_t)d->export_w * d->export_h * 4;
+    float *dup = g_try_malloc(n * sizeof(float));
+    if(dup)
+    {
+      memcpy(dup, d->export_pixels, n * sizeof(float));
+      pd->reuse_pixels = dup;
+      pd->reuse_w = d->export_w;
+      pd->reuse_h = d->export_h;
+    }
   }
   // detach the previous worker (don't join — that would block the
   // UI thread for the duration of the in-flight inference / pipe
@@ -4355,6 +4466,7 @@ void gui_init(dt_lib_module_t *self)
     gtk_notebook_set_current_page(d->notebook, saved_page);
   _update_task_from_ui(d);
   d->model_available = _check_model_available(d, d->task);
+  d->preview_hash_imgid = NO_IMGID;
 
   // pick area button
   d->patch_center[0] = 0.5f;
@@ -4590,6 +4702,7 @@ void gui_cleanup(dt_lib_module_t *self)
     g_free(d->cairo_after);
     g_free(d->export_pixels);
     g_free(d->export_cairo);
+    g_free(d->preview_hash);
 
     g_free(d->preview_full_cfa);
     dt_free_align(d->preview_full_lin);


### PR DESCRIPTION
Fixes #21879

After you crop a photo, the raw denoise preview showed a different part of the image than the one you picked. Picking close to the crop edge showed nothing at all, and the picker button was often greyed out until darktable was restarted.

You pick on a thumbnail of the finished image, so it is already cropped and rotated. To find the matching sensor pixels the code undid the rotation but not the crop, so the patch it sampled was off by roughly the amount cropped away. When the error was big enough the patch fell outside the visible image and there was nothing left to render.

`dt_restore_display_to_sensor()` now undoes the whole geometry chain – crop, rotation, lens, flip – and then checks that the patch it picked really renders, moving it inward if it does not.

Also fixed: the picker button depended on a thumbnail that was only rebuilt when an unrelated cache missed; nothing threw away the cached preview or thumbnail when you edited the photo; the linear/X-Trans preview used the wrong coordinate space for its ROI; and `take_export_pixels` leaked when the raw preview bailed out.