### PR TITLE
Lua Options: use natural row heights for custom preferences

### DIFF
--- a/src/lua/preferences.c
+++ b/src/lua/preferences.c
@@ -168,7 +168,7 @@ static GtkWidget *_make_pref_grid(void)
   GtkWidget *grid = gtk_grid_new();
   gtk_grid_set_row_spacing(GTK_GRID(grid), DT_PIXEL_APPLY_DPI(5));
   gtk_grid_set_column_spacing(GTK_GRID(grid), DT_PIXEL_APPLY_DPI(5));
-  gtk_grid_set_row_homogeneous(GTK_GRID(grid), TRUE);
+  gtk_grid_set_row_homogeneous(GTK_GRID(grid), FALSE);
   gtk_widget_set_valign(grid, GTK_ALIGN_START);
   return grid;
 }


### PR DESCRIPTION
Fixes #21906.

Lua Options currently makes every row of a script's preference grid homogeneous. A tall custom `"lua"` widget therefore expands every ordinary preference row.

Keep the existing spacing but use GTK's natural row heights so only the custom-widget row grows.

Validated with the standalone Lua reproducer and before/after screenshots in #21906, using the Windows development build.