### PR TITLE
Add preference to disable automatic AI model update checks

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -455,6 +455,13 @@
     <longdescription>enable AI-powered features such as denoising and upscaling using neural networks</longdescription>
   </dtconfig>
   <dtconfig>
+    <name>plugins/ai/auto_check_updates</name>
+    <type>bool</type>
+    <default>true</default>
+    <shortdescription>automatically check for model updates</shortdescription>
+    <longdescription>contact the model repositories to look for newer versions of the installed AI models. when off, updates are only looked for when you ask for them in the AI preferences</longdescription>
+  </dtconfig>
+  <dtconfig>
     <name>plugins/ai/provider</name>
     <type>string</type>
     <default>auto</default>

--- a/src/common/ai_models.c
+++ b/src/common/ai_models.c
@@ -46,6 +46,8 @@ struct dt_ai_registry_t
   gboolean ai_enabled;        // global AI enable/disable
   dt_ai_provider_t provider;  // selected execution provider
   gboolean updates_checked;   // TRUE after first check_updates call
+  int updates_in_flight;      // repositories still to report back
+  int updates_failed;         // of those, how many never answered
   struct dt_ai_environment_t *env;  // lazily created backend environment
   GMutex lock;                // thread safety for registry access
 };
@@ -53,6 +55,7 @@ struct dt_ai_registry_t
 // config keys
 #define CONF_AI_ENABLED "plugins/ai/enabled"
 #define CONF_AI_REPOSITORY "plugins/ai/repository"
+#define CONF_AI_AUTO_CHECK_UPDATES "plugins/ai/auto_check_updates"
 #define CONF_AI_THIRD_PARTY_REPOSITORIES "plugins/ai/third_party_repositories"
 #define CONF_MODEL_ENABLED_PREFIX "plugins/ai/models/"
 #define CONF_ACTIVE_MODEL_PREFIX "plugins/ai/models/active/"
@@ -822,7 +825,11 @@ void dt_ai_models_refresh_status(void)
   g_mutex_lock(&registry->lock);
 
   // remove previously-discovered local models (no github_asset)
-  // these will be re-discovered from disk below if still present
+  // these will be re-discovered from disk below if still present.
+  //
+  // nothing needs carrying across: UPDATE_AVAILABLE is only ever set by
+  // _apply_updates, which skips models without a github_asset precisely
+  // because their update could not be downloaded anyway
   GList *l = registry->models;
   while(l)
   {
@@ -852,6 +859,12 @@ void dt_ai_models_refresh_status(void)
     if(g_file_test(model_dir, G_FILE_TEST_IS_DIR)
        && g_file_test(config_path, G_FILE_TEST_EXISTS))
     {
+      // the update flag comes from the remote versions.json, which this
+      // rescan knows nothing about; clobbering it would undo every check the
+      // moment the list refreshes. keep it while the version is unchanged
+      const dt_ai_model_status_t prev_status = model->status;
+      char *prev_version = g_strdup(model->version);
+
       model->status = DT_AI_MODEL_DOWNLOADED;
       // read version from the model's own config.json
       dt_ai_model_t *local = _parse_local_model_config(config_path, model->id);
@@ -898,6 +911,16 @@ void dt_ai_models_refresh_status(void)
                    model->min_version);
         }
       }
+
+      // restore a remote-derived flag the rescan just overwrote, unless the
+      // installed version moved (the update was applied) or the local state
+      // is now worse than what the remote said
+      if(model->status == DT_AI_MODEL_DOWNLOADED
+         && prev_status == DT_AI_MODEL_UPDATE_AVAILABLE
+         && !g_strcmp0(prev_version, model->version))
+        model->status = DT_AI_MODEL_UPDATE_AVAILABLE;
+
+      g_free(prev_version);
     }
     else
     {
@@ -975,16 +998,46 @@ static void _updates_free(dt_ai_updates_t *upd)
   g_free(upd);
 }
 
-// takes ownership of `upd`
-static gboolean _apply_updates_idle(gpointer user_data)
+// one repository has reported back. announce completion once the last one
+// has, so a listener can count results rather than guessing when to look
+static void _updates_one_done(void)
 {
-  dt_ai_updates_t *upd = (dt_ai_updates_t *)user_data;
+  dt_ai_registry_t *registry = darktable.ai_registry;
+  if(!registry) return;
+
+  g_mutex_lock(&registry->lock);
+  const gboolean last = (--registry->updates_in_flight <= 0);
+  if(last) registry->updates_in_flight = 0;
+  g_mutex_unlock(&registry->lock);
+
+  if(last) DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_AI_UPDATE_CHECK_DONE);
+}
+
+// a worker that fetched nothing still has to report in, or the count never
+// reaches zero and the caller waits forever. it is counted separately so the
+// summary can tell "nothing newer published" from "could not ask"
+static gboolean _updates_failed_idle(gpointer user_data)
+{
+  dt_ai_registry_t *registry = darktable.ai_registry;
+  if(registry)
+  {
+    g_mutex_lock(&registry->lock);
+    registry->updates_failed++;
+    g_mutex_unlock(&registry->lock);
+  }
+  _updates_one_done();
+  return G_SOURCE_REMOVE;
+}
+
+// takes ownership of `upd`
+static void _apply_updates(dt_ai_updates_t *upd)
+{
   JsonParser *parser = upd->parser;
   dt_ai_registry_t *registry = darktable.ai_registry;
   if(!registry)
   {
     _updates_free(upd);
-    return G_SOURCE_REMOVE;
+    return;
   }
 
   JsonNode *root = json_parser_get_root(parser);
@@ -1000,7 +1053,7 @@ static gboolean _apply_updates_idle(gpointer user_data)
              "[ai_models] check_updates: no 'models' object in %s's "
              "versions.json", upd->repository);
     _updates_free(upd);
-    return G_SOURCE_REMOVE;
+    return;
   }
 
   // populate model->checksum from sha256 so downloads skip re-fetching
@@ -1034,7 +1087,11 @@ static gboolean _apply_updates_idle(gpointer user_data)
       model->checksum = g_strdup(remote_sha256);
     }
 
+    // an update nobody can apply is not worth flagging: a model installed
+    // by hand has no github_asset, so the download refuses it outright and
+    // the offer would only abort whatever batch it appeared in
     if(remote_version
+       && model->github_asset
        && model->status == DT_AI_MODEL_DOWNLOADED
        && _version_compare(model->version, remote_version) < 0)
     {
@@ -1050,6 +1107,15 @@ static gboolean _apply_updates_idle(gpointer user_data)
   _updates_free(upd);
 
   DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_AI_MODELS_CHANGED);
+}
+
+// reporting in lives here rather than on each exit inside _apply_updates:
+// three returns already meant one of them forgot, and a repository that
+// never reports blocks every later check for the session
+static gboolean _apply_updates_idle(gpointer user_data)
+{
+  _apply_updates((dt_ai_updates_t *)user_data);
+  _updates_one_done();
   return G_SOURCE_REMOVE;
 }
 
@@ -1069,6 +1135,7 @@ static gpointer _check_updates_worker(gpointer data)
              error_msg ? ": " : "", error_msg ? error_msg : "");
     g_free(error_msg);
     g_free(repository);
+    g_idle_add(_updates_failed_idle, NULL);
     return NULL;
   }
   g_free(error_msg);
@@ -1084,6 +1151,7 @@ static gpointer _check_updates_worker(gpointer data)
     g_free(url);
     g_free(release_tag);
     g_free(repository);
+    g_idle_add(_updates_failed_idle, NULL);
     return NULL;
   }
   dt_curl_init(curl, FALSE);
@@ -1111,6 +1179,7 @@ static gpointer _check_updates_worker(gpointer data)
              repository, res, http_code);
     g_string_free(response, TRUE);
     g_free(repository);
+    g_idle_add(_updates_failed_idle, NULL);
     return NULL;
   }
 
@@ -1125,6 +1194,7 @@ static gpointer _check_updates_worker(gpointer data)
              "[ai_models] check_updates: failed to parse %s's versions.json",
              repository);
     g_free(repository);
+    g_idle_add(_updates_failed_idle, NULL);
     return NULL;
   }
   g_string_free(response, TRUE);
@@ -1146,25 +1216,68 @@ static gpointer _check_updates_worker(gpointer data)
   return NULL;
 }
 
-void dt_ai_models_check_updates(void)
+void dt_ai_models_check_updates(const gboolean force)
 {
   dt_ai_registry_t *registry = darktable.ai_registry;
-  if(!registry) return;
 
-  // only check once per session
-  g_mutex_lock(&registry->lock);
-  if(registry->updates_checked)
+  // a caller that greyed out its button waits for
+  // DT_SIGNAL_AI_UPDATE_CHECK_DONE, so a bail-out an explicit check can
+  // reach has to announce it. the automatic-only bail-outs below stay
+  // silent: nobody is waiting on them, and raising there would re-enter
+  // through _refresh_model_list, which calls back into this function
+  if(!registry)
   {
-    g_mutex_unlock(&registry->lock);
+    DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_AI_UPDATE_CHECK_DONE);
     return;
   }
-  registry->updates_checked = TRUE;
+
+  // an automatic check reaches the network unasked, so it needs AI switched
+  // on as well as the preference — which is greyed out when AI is off, so it
+  // could not be used to stop this. an explicit check is the user asking
+  if(!force
+     && (!dt_ai_registry_is_enabled()
+         || !dt_conf_get_bool(CONF_AI_AUTO_CHECK_UPDATES)))
+    return;
+
+  // automatic checks happen once per session; an explicit one repeats.
+  // a run already in flight is never doubled up: pressing the button twice
+  // would otherwise spawn a second thread per repository
+  g_mutex_lock(&registry->lock);
+  const gboolean in_flight = registry->updates_in_flight > 0;
+  const gboolean already_done = !force && registry->updates_checked;
+  g_mutex_unlock(&registry->lock);
+
+  if(in_flight || already_done) return;
+
+  // this run's tally starts clean, including on the no-repositories path
+  // below, which would otherwise report the previous run's failures
+  g_mutex_lock(&registry->lock);
+  registry->updates_failed = 0;
   g_mutex_unlock(&registry->lock);
 
   // every repository publishes its own versions.json, so a model only
   // learns about updates from the one it came from. checking just the
   // official repository would leave everything else on its install version
   GList *repositories = dt_ai_models_get_repositories();
+  const int n = (int)g_list_length(repositories);
+
+  if(n == 0)
+  {
+    g_list_free(repositories);
+    DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_AI_UPDATE_CHECK_DONE);
+    return;
+  }
+
+  // set before spawning: a fast worker could otherwise report in and drive
+  // the count negative while the rest are still being created.
+  //
+  // updates_checked is marked here rather than on entry, so a session that
+  // begins with no usable repository does not burn its one automatic check
+  // before the user has had a chance to configure one
+  g_mutex_lock(&registry->lock);
+  registry->updates_in_flight = n;
+  registry->updates_checked = TRUE;
+  g_mutex_unlock(&registry->lock);
 
   for(GList *l = repositories; l; l = g_list_next(l))
   {
@@ -1180,7 +1293,7 @@ void dt_ai_models_check_updates(void)
 #else
 // checking for updates is entirely network work, so a build without
 // download support has nothing to do here
-void dt_ai_models_check_updates(void) {}
+void dt_ai_models_check_updates(const gboolean force) {}
 #endif // HAVE_AI_DOWNLOAD
 
 void dt_ai_models_cleanup(void)
@@ -1230,6 +1343,17 @@ int dt_ai_models_get_count(void)
   int count = g_list_length(registry->models);
   g_mutex_unlock(&registry->lock);
   return count;
+}
+
+int dt_ai_models_last_check_failures(void)
+{
+  dt_ai_registry_t *registry = darktable.ai_registry;
+  if(!registry) return 0;
+
+  g_mutex_lock(&registry->lock);
+  const int failed = registry->updates_failed;
+  g_mutex_unlock(&registry->lock);
+  return failed;
 }
 
 dt_ai_model_t *dt_ai_models_get_by_index(const int index)

--- a/src/common/ai_models.h
+++ b/src/common/ai_models.h
@@ -159,8 +159,21 @@ void dt_ai_models_refresh_status(void);
  *        UPDATE_REQUIRED means darktable cannot use the installed
  *        model with the current code; UPDATE_AVAILABLE is a soft
  *        nudge — the installed model still works.
+ *
+ * @param force TRUE for a check the user explicitly asked for: it runs
+ *        regardless of plugins/ai/auto_check_updates and repeats within
+ *        a session. FALSE for automatic checks, which honour the
+ *        preference and run at most once per session.
  */
-void dt_ai_models_check_updates(void);
+void dt_ai_models_check_updates(const gboolean force);
+
+/**
+ * @brief How many repositories failed to answer the last update check.
+ *        Only meaningful once DT_SIGNAL_AI_UPDATE_CHECK_DONE has fired.
+ *        Non-zero means "we could not ask", which is not the same as
+ *        "nothing newer was published".
+ */
+int dt_ai_models_last_check_failures(void);
 
 /**
  * @brief Clean up and free the registry singleton (sets it to NULL).

--- a/src/control/signal.c
+++ b/src/control/signal.c
@@ -147,6 +147,8 @@ static dt_signal_description _signal_description[DT_SIGNAL_COUNT] = {
   /* AI models related signals */
   [DT_SIGNAL_AI_MODELS_CHANGED] = { "dt-ai-models-changed",
     NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__VOID, 0, NULL, NULL, FALSE },
+  [DT_SIGNAL_AI_UPDATE_CHECK_DONE] = { "dt-ai-update-check-done",
+    NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__VOID, 0, NULL, NULL, FALSE },
 
   /* Develop related signals */
   [DT_SIGNAL_DEVELOP_INITIALIZE] = { "dt-develop-initialized",

--- a/src/control/signal.h
+++ b/src/control/signal.h
@@ -287,6 +287,14 @@ typedef enum dt_signal_t
     */
   DT_SIGNAL_AI_MODELS_CHANGED,
 
+  /** \brief This signal is raised when every repository queried by
+    dt_ai_models_check_updates() has reported back, successfully or not.
+    Model statuses are settled by the time it fires, so a listener can
+    count what was found.
+    no param, no returned value
+    */
+  DT_SIGNAL_AI_UPDATE_CHECK_DONE,
+
   /* do not touch !*/
   DT_SIGNAL_COUNT
 } dt_signal_t;

--- a/src/gui/preferences_ai.c
+++ b/src/gui/preferences_ai.c
@@ -108,6 +108,10 @@ typedef struct dt_prefs_ai_data_t
   GtkWidget *ort_path_indicator;
   GtkWidget *settings_grid;
   int controls_start_row;   // first row to grey out when AI disabled
+  GtkWidget *auto_check_toggle;
+  GtkWidget *auto_check_indicator;
+  GtkWidget *check_updates_btn;
+  gboolean   check_updates_pending;  // report the result of this run
   guint supported_providers;
 } dt_prefs_ai_data_t;
 
@@ -210,7 +214,7 @@ static void _refresh_model_list(dt_prefs_ai_data_t *data)
   gtk_list_store_clear(data->model_store);
 
   dt_ai_models_refresh_status();
-  dt_ai_models_check_updates();
+  dt_ai_models_check_updates(FALSE);
 
   const int count = dt_ai_models_get_count();
   dt_print(DT_DEBUG_AI, "[preferences_ai] refreshing model list, count=%d", count);
@@ -307,10 +311,19 @@ static void _ai_models_changed_cb(gpointer instance, gpointer user_data)
   if(data) _refresh_model_list(data);
 }
 
+#ifdef HAVE_AI_DOWNLOAD
+static void _ai_update_check_done_cb(gpointer instance, gpointer user_data);
+static gboolean _download_model_with_dialog(dt_prefs_ai_data_t *data,
+                                            const char *model_id);
+#endif
+
 // disconnect before free so a late signal dispatch can't touch freed data
 static void _prefs_ai_data_free(gpointer user_data)
 {
   DT_CONTROL_SIGNAL_DISCONNECT(_ai_models_changed_cb, user_data);
+#ifdef HAVE_AI_DOWNLOAD
+  DT_CONTROL_SIGNAL_DISCONNECT(_ai_update_check_done_cb, user_data);
+#endif
   g_free(user_data);
 }
 
@@ -643,6 +656,174 @@ static void _reset_enable_click_cb(GtkGestureSingle *gesture, int n_press,
   const gboolean def = dt_confgen_get_bool("plugins/ai/enabled", DT_DEFAULT);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), def);
 }
+
+#ifdef HAVE_AI_DOWNLOAD
+// the check is asynchronous, so the button reports nothing here — it goes
+// insensitive until DT_SIGNAL_AI_UPDATE_CHECK_DONE arrives, and the result
+// is summarised there. without that, a network failure and a clean result
+// look identical
+static void _on_check_updates(GtkWidget *widget, gpointer user_data)
+{
+  dt_prefs_ai_data_t *data = (dt_prefs_ai_data_t *)user_data;
+
+  // insensitive is the whole in-flight indication: a label swap would
+  // resize the button
+  data->check_updates_pending = TRUE;
+  gtk_widget_set_sensitive(data->check_updates_btn, FALSE);
+
+  dt_ai_models_check_updates(TRUE);
+}
+
+// every repository has reported back; statuses are settled
+static void _ai_update_check_done_cb(gpointer instance, gpointer user_data)
+{
+  dt_prefs_ai_data_t *data = (dt_prefs_ai_data_t *)user_data;
+  if(!data) return;
+
+  if(data->check_updates_btn)
+    gtk_widget_set_sensitive(data->check_updates_btn, TRUE);
+
+  // deliberately no _refresh_model_list here: it calls back into
+  // dt_ai_models_check_updates, which raises this signal on its no-op paths,
+  // which would land us straight back in this handler. anything that
+  // actually changed a status already raised AI_MODELS_CHANGED and got its
+  // refresh from there; a check that found nothing has nothing to redraw
+
+  // only speak up for a check the user asked for; the automatic one on
+  // opening this page should stay quiet
+  if(!data->check_updates_pending) return;
+  data->check_updates_pending = FALSE;
+
+  // collect rather than just count: the update below must act on exactly
+  // what was reported, not on whatever the registry looks like afterwards
+  // two different claims. UPDATE_AVAILABLE is what this check found on the
+  // remote; UPDATE_REQUIRED is a local min_version verdict the check never
+  // looks at, since _apply_updates only compares DOWNLOADED models. both
+  // want downloading, but only one of them is news
+  GList *outdated = NULL;
+  guint n_available = 0, n_required = 0;
+  const int count = dt_ai_models_get_count();
+  for(int i = 0; i < count; i++)
+  {
+    dt_ai_model_t *m = dt_ai_models_get_by_index(i);
+    if(!m) continue;
+    if(m->status == DT_AI_MODEL_UPDATE_AVAILABLE
+       || m->status == DT_AI_MODEL_UPDATE_REQUIRED)
+    {
+      if(m->status == DT_AI_MODEL_UPDATE_AVAILABLE) n_available++;
+      else n_required++;
+      outdated = g_list_prepend(outdated, g_strdup(m->id));
+    }
+    dt_ai_model_free(m);  // get_by_index hands over a copy
+  }
+  outdated = g_list_reverse(outdated);
+  const guint n = n_available + n_required;
+
+  // a repository that could not be reached tells us nothing, so "nothing
+  // found" from a failed check must not be reported as "up to date"
+  const int failed = dt_ai_models_last_check_failures();
+
+  if(!n)
+  {
+    gchar *none = failed
+      ? g_strdup_printf(ngettext("could not reach %d model repository",
+                                 "could not reach %d model repositories",
+                                 failed), failed)
+      : g_strdup(_("all installed models are up to date"));
+
+    GtkWidget *msg = gtk_message_dialog_new(
+      GTK_WINDOW(data->parent_dialog),
+      GTK_DIALOG_MODAL,
+      failed ? GTK_MESSAGE_WARNING : GTK_MESSAGE_INFO,
+      GTK_BUTTONS_OK,
+      "%s", none);
+    gtk_window_set_title(GTK_WINDOW(msg), _("check for updates"));
+    gtk_dialog_run(GTK_DIALOG(msg));
+    gtk_widget_destroy(msg);
+    g_free(none);
+    return;
+  }
+
+  gchar *avail_txt = n_available
+    ? g_strdup_printf(ngettext("%u model has an update available",
+                               "%u models have updates available",
+                               n_available), n_available)
+    : NULL;
+
+  gchar *req_txt = n_required
+    ? g_strdup_printf(ngettext("%u model is too old for this version of"
+                               " darktable and must be updated",
+                               "%u models are too old for this version of"
+                               " darktable and must be updated",
+                               n_required), n_required)
+    : NULL;
+
+  gchar *found = (avail_txt && req_txt)
+    ? g_strdup_printf("%s\n\n%s", avail_txt, req_txt)
+    : g_strdup(avail_txt ? avail_txt : req_txt);
+  g_free(avail_txt);
+  g_free(req_txt);
+
+  // partial failure: what was found is real, but the list may be short
+  gchar *text = failed
+    ? g_strdup_printf(ngettext("%s\n\n%d repository could not be reached,"
+                               " so there may be more",
+                               "%s\n\n%d repositories could not be reached,"
+                               " so there may be more", failed),
+                      found, failed)
+    : g_strdup(found);
+  g_free(found);
+
+  GtkWidget *msg = gtk_message_dialog_new(
+    GTK_WINDOW(data->parent_dialog),
+    GTK_DIALOG_MODAL,
+    GTK_MESSAGE_QUESTION,
+    GTK_BUTTONS_NONE,
+    "%s", text);
+  gtk_dialog_add_buttons(GTK_DIALOG(msg),
+                         _("_later"), GTK_RESPONSE_CLOSE,
+                         _("_update now"), GTK_RESPONSE_ACCEPT, NULL);
+  gtk_dialog_set_default_response(GTK_DIALOG(msg), GTK_RESPONSE_ACCEPT);
+  gtk_window_set_title(GTK_WINDOW(msg), _("check for updates"));
+  const gint response = gtk_dialog_run(GTK_DIALOG(msg));
+  // destroyed before downloading: each download runs its own modal dialog,
+  // which must not be nested inside this one's run loop
+  gtk_widget_destroy(msg);
+  g_free(text);
+
+  if(response == GTK_RESPONSE_ACCEPT)
+  {
+    for(GList *l = outdated; l; l = g_list_next(l))
+      if(!_download_model_with_dialog(data, (const char *)l->data))
+        break;  // failed or cancelled — leave the rest alone
+    _refresh_model_list(data);
+  }
+
+  g_list_free_full(outdated, g_free);
+}
+#endif // HAVE_AI_DOWNLOAD
+
+#ifdef HAVE_AI_DOWNLOAD
+static void _on_auto_check_toggled(GtkWidget *widget, gpointer user_data)
+{
+  dt_prefs_ai_data_t *data = (dt_prefs_ai_data_t *)user_data;
+  const gboolean on = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
+  dt_conf_set_bool("plugins/ai/auto_check_updates", on);
+  if(data->auto_check_indicator)
+    _update_string_indicator(data->auto_check_indicator,
+                             "plugins/ai/auto_check_updates");
+}
+
+static void _reset_auto_check_click_cb(GtkGestureSingle *gesture, int n_press,
+                                       double x, double y,
+                                       GtkWidget *widget)
+{
+  if(n_press < 2) return;
+  const gboolean def =
+    dt_confgen_get_bool("plugins/ai/auto_check_updates", DT_DEFAULT);
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), def);
+}
+#endif // HAVE_AI_DOWNLOAD
 
 // double-click on label resets the provider combo to default
 static void
@@ -2299,6 +2480,39 @@ void init_tab_ai(GtkWidget *dialog, GtkWidget *stack)
   data->controls_start_row = row;
   const gboolean ai_on = dt_conf_get_bool("plugins/ai/enabled");
 
+#ifdef HAVE_AI_DOWNLOAD
+  // with the other global switches rather than beside the model list: it
+  // governs whether darktable reaches the network on its own
+  GtkWidget *auto_check_label =
+    gtk_label_new(_("automatically check for model updates"));
+  gtk_widget_set_halign(auto_check_label, GTK_ALIGN_START);
+  GtkWidget *auto_check_labelev = gtk_event_box_new();
+  gtk_container_add(GTK_CONTAINER(auto_check_labelev), auto_check_label);
+  gtk_event_box_set_visible_window(GTK_EVENT_BOX(auto_check_labelev), FALSE);
+  gtk_widget_set_tooltip_text(auto_check_labelev,
+                              _("contact the model repositories to look for"
+                                " newer versions of the installed models.\n"
+                                "when off, updates are only looked for when"
+                                " you press the button below"));
+
+  data->auto_check_indicator =
+    _create_indicator("plugins/ai/auto_check_updates");
+  data->auto_check_toggle = gtk_check_button_new();
+  gtk_toggle_button_set_active(
+    GTK_TOGGLE_BUTTON(data->auto_check_toggle),
+    dt_conf_get_bool("plugins/ai/auto_check_updates"));
+  g_signal_connect(data->auto_check_toggle, "toggled",
+                   G_CALLBACK(_on_auto_check_toggled), data);
+  dt_gui_connect_click_all(auto_check_labelev, _reset_auto_check_click_cb,
+                           NULL, data->auto_check_toggle);
+
+  gtk_grid_attach(GTK_GRID(settings_grid), auto_check_labelev, 0, row, 1, 1);
+  gtk_grid_attach(GTK_GRID(settings_grid), data->auto_check_indicator,
+                  1, row, 1, 1);
+  gtk_grid_attach(GTK_GRID(settings_grid), data->auto_check_toggle,
+                  2, row++, 1, 1);
+#endif // HAVE_AI_DOWNLOAD
+
   // provider dropdown
   GtkWidget *provider_label = gtk_label_new(_("AI acceleration"));
   gtk_widget_set_halign(provider_label, GTK_ALIGN_START);
@@ -2666,12 +2880,32 @@ void init_tab_ai(GtkWidget *dialog, GtkWidget *stack)
     data);
   dt_gui_box_add(button_box, data->delete_selected_btn);
 
+#ifdef HAVE_AI_DOWNLOAD
+  // right-anchored with the help button: this refreshes state rather than
+  // acting on the models
+  data->check_updates_btn
+    = gtk_button_new_with_label(_("check for updates"));
+  gtk_widget_set_tooltip_text(data->check_updates_btn,
+    _("look for newer versions of the installed models"));
+  g_signal_connect(data->check_updates_btn, "clicked",
+                   G_CALLBACK(_on_check_updates), data);
+#endif // HAVE_AI_DOWNLOAD
+
   // help button (right-anchored, matches other prefs tabs)
   GtkWidget *help_btn = gtk_button_new_with_label(_("?"));
   gtk_widget_set_tooltip_text(help_btn, _("open help page for AI settings"));
   dt_gui_add_help_link(help_btn, "ai");
   g_signal_connect(help_btn, "clicked", G_CALLBACK(dt_gui_show_help), NULL);
-  dt_gui_box_add(button_box, dt_gui_align_right(help_btn));
+
+  // one box for the trailing pair, aligned once. dt_gui_align_right also
+  // expands the widget it is given, so aligning the two separately would
+  // split the free space between them and leave a gap
+#ifdef HAVE_AI_DOWNLOAD
+  GtkWidget *tail = dt_gui_hbox(data->check_updates_btn, help_btn);
+#else
+  GtkWidget *tail = dt_gui_hbox(help_btn);
+#endif
+  dt_gui_box_add(button_box, dt_gui_align_right(tail));
 
   dt_gui_box_add(data->controls_box, models_grid);
 
@@ -2687,6 +2921,10 @@ void init_tab_ai(GtkWidget *dialog, GtkWidget *stack)
 
   DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_AI_MODELS_CHANGED,
                             _ai_models_changed_cb, data);
+#ifdef HAVE_AI_DOWNLOAD
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_AI_UPDATE_CHECK_DONE,
+                            _ai_update_check_done_cb, data);
+#endif
 
   g_object_set_data_full(G_OBJECT(tab_box), "prefs-ai-data",
                          data, _prefs_ai_data_free);


### PR DESCRIPTION
Closes #21514

darktable checks the model repositories for newer versions whenever the AI preferences page is opened, with no way to stop it. This adds `plugins/ai/auto_check_updates` (default on, so nothing changes unless you ask) and a "check for updates" button for when it is off.

The toggle sits with the other global switches rather than beside the model list – it governs whether darktable reaches the network on its own, which is what someone auditing that page is looking for.

The check is asynchronous, so the button goes insensitive until every repository has reported back, then summarises: how many models have updates, or that everything is current, with an "update now" that runs the existing per-model download. A new `DT_SIGNAL_AI_UPDATE_CHECK_DONE` carries the completion.

Two pre-existing bugs had to be fixed for any of this to work, both in `ai_models.c` and both independent of the preference:

- `dt_ai_models_refresh_status()` reset every installed model to `DOWNLOADED`, wiping the `UPDATE_AVAILABLE` flag the check had just set – so no update check has ever been able to show a result.
- Models installed by hand have no `github_asset`, but were still flagged as updatable; the download refuses them, so the model list offered an update that could not be applied.