### PR TITLE
gtk4-prep: fix UI regressions and develop GUI lifetime races

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -2273,6 +2273,7 @@ void dt_cleanup()
     dt_control_cleanup(TRUE);
     dt_undo_cleanup(darktable.undo);
     darktable.undo = NULL;
+    dt_gui_gtk_cleanup(darktable.gui);
     free(darktable.gui);
     darktable.gui = NULL;
   }

--- a/src/control/control.c
+++ b/src/control/control.c
@@ -251,93 +251,109 @@ void dt_control_init(const gboolean withgui)
 
 void dt_control_forbid_change_cursor()
 {
+  dt_control_cursor_debug("control/lock", "forbid", NULL, NULL);
   darktable.control->lock_cursor_shape = TRUE;
 }
 
 void dt_control_allow_change_cursor()
 {
+  dt_control_cursor_debug("control/lock", "allow", NULL, NULL);
   darktable.control->lock_cursor_shape = FALSE;
 }
 
-// last cursor set by dt_control_change_cursor() or a direct call to
-// gdk_window_set_cursor() outside of functions below
+// Last cursor set by dt_control_change_cursor(). Widget-local cursors use
+// dt_gui_cursor_set() and do not participate in this temporary override.
 static GdkCursor* _prev_cursor = NULL;
 
-void _change_cursor_with_fallback(const char *cursor_name,
-                                  gboolean is_temp)
+void dt_control_cursor_debug(const char *owner,
+                             const char *action,
+                             GtkWidget *widget,
+                             const char *cursor_name)
 {
-  GdkWindow *window = gtk_widget_get_window(dt_ui_main_window(darktable.gui->ui));
-  if(!window) return;
-  GdkDisplay *display = gdk_window_get_display(window);
-  GdkCursor *cursor = gdk_cursor_new_from_name(display, cursor_name);
+  const GdkCursor *current = dt_gui_cursor_get(widget);
+  dt_print(DT_DEBUG_INPUT,
+           "[cursor] owner=%s action=%s target=%p requested=%s current=%p temp=%s locked=%d thread=%p",
+           owner ? owner : "?",
+           action ? action : "?",
+           (void *)widget,
+           cursor_name ? cursor_name : "<clear>",
+           (void *)current,
+           _prev_cursor ? "yes" : "no",
+           darktable.control ? darktable.control->lock_cursor_shape : FALSE,
+           (void *)g_thread_self());
+}
 
-  // GTK3 fallback: some CSS cursor names are not supported by all
-  // backends (e.g. "wait" and "help" are missing from the GTK3 Win32
-  // mapping table despite Windows having IDC_WAIT and IDC_HELP;
-  // "none" is missing from both the Win32 and X11 backends).
-  // Fall back to the legacy GdkCursorType enum API for these cases.
-  // TODO(GTK4): remove this fallback when migrating to GTK4, where
-  // all backends support the full CSS cursor name spec.
-  if(!cursor)
-  {
-    GdkCursorType type = GDK_LEFT_PTR;
-    if(!strcmp(cursor_name, "none"))           type = GDK_BLANK_CURSOR;
-    else if(!strcmp(cursor_name, "wait"))      type = GDK_WATCH;
-    else if(!strcmp(cursor_name, "grab"))      type = GDK_HAND1;
-    else if(!strcmp(cursor_name, "cell"))      type = GDK_PLUS;
-    else if(!strcmp(cursor_name, "help"))      type = GDK_QUESTION_ARROW;
-    else if(!strcmp(cursor_name, "ns-resize")) type = GDK_DOUBLE_ARROW;
-    cursor = gdk_cursor_new_for_display(display, type);
-  }
+static void _change_cursor_with_fallback(const char *cursor_name,
+                                         gboolean is_temp,
+                                         const char *owner)
+{
+  GtkWidget *widget = dt_ui_main_window(darktable.gui->ui);
+  if(!widget) return;
+  GdkCursor *cursor = dt_gui_cursor_new_for_name(gtk_widget_get_display(widget), cursor_name);
 
+  dt_control_cursor_debug(owner,
+                          !is_temp && _prev_cursor ? "change-deferred" : "set",
+                          widget,
+                          cursor_name);
   if(!is_temp && _prev_cursor)
   {
-    // cursor change request via dt_control_change_cursor() is overriden
-    // by temp cursor, save new cursor to use when clear temp cursor
+    // A cursor change request is overridden by the temporary cursor; save
+    // the new cursor to use when the temporary cursor is cleared.
     g_object_unref(_prev_cursor);
     _prev_cursor = g_object_ref(cursor);
   }
   else if(!darktable.control->lock_cursor_shape)
   {
-    gdk_window_set_cursor(window, cursor);
+    dt_gui_cursor_apply(widget, cursor);
+    g_object_unref(cursor);
+  }
+  else
+  {
     g_object_unref(cursor);
   }
 }
 
 void dt_control_set_temp_cursor(const char *cursor_name)
 {
-  GdkWindow *window = gtk_widget_get_window(dt_ui_main_window(darktable.gui->ui));
-  if(!window) return;
-  // store cursor to return to once clear temp cursor if this is the
-  // initial setup of this temp cursor (as can call this multiple
-  // times to vary a temp cursor)
+  GtkWidget *widget = dt_ui_main_window(darktable.gui->ui);
+  dt_control_cursor_debug("control/temp", "request", widget, cursor_name);
+  if(!widget) return;
+  // Store the cursor to restore when this is the initial setup of this
+  // temporary cursor. Subsequent calls may vary the temporary cursor.
   if(!_prev_cursor)
   {
-    _prev_cursor = gdk_window_get_cursor(window);
+    _prev_cursor = dt_gui_cursor_get(widget);
     if(_prev_cursor)
       g_object_ref(_prev_cursor);
   }
-  _change_cursor_with_fallback(cursor_name, TRUE);
+  _change_cursor_with_fallback(cursor_name, TRUE, "control/temp");
 }
 
 void dt_control_clear_temp_cursor()
 {
-  GdkWindow *window = gtk_widget_get_window(dt_ui_main_window(darktable.gui->ui));
+  GtkWidget *widget = dt_ui_main_window(darktable.gui->ui);
+  dt_control_cursor_debug("control/temp", "clear", widget, NULL);
   if(!_prev_cursor)
   {
-    if(window)
-      gdk_window_set_cursor(window, NULL);
+    if(widget)
+    {
+      dt_control_cursor_debug("control/temp", "clear-default", widget, NULL);
+      dt_gui_cursor_apply(widget, NULL);
+    }
     return;
   }
-  if(window)
-    gdk_window_set_cursor(window, _prev_cursor);
+  if(widget)
+  {
+    dt_control_cursor_debug("control/temp", "restore", widget, "<saved>");
+    dt_gui_cursor_apply(widget, _prev_cursor);
+  }
   g_object_unref(_prev_cursor);
   _prev_cursor = NULL;
 }
 
 void dt_control_change_cursor(const char *cursor_name)
 {
-  _change_cursor_with_fallback(cursor_name, FALSE);
+  _change_cursor_with_fallback(cursor_name, FALSE, "control/change");
 }
 
 /* Some implementation and how-to use notes about control->running

--- a/src/control/control.c
+++ b/src/control/control.c
@@ -606,6 +606,48 @@ static gboolean _dt_ctl_switch_mode_to_by_view(gpointer user_data)
   return G_SOURCE_REMOVE;
 }
 
+static gboolean _dt_ctl_reload_view(gpointer user_data)
+{
+  const dt_view_t *view = (const dt_view_t*)user_data;
+  dt_view_manager_switch_by_view(darktable.view_manager, view);
+  return G_SOURCE_REMOVE;
+}
+
+/* Run a view switch now when it is safe, but never while GTK is propagating an
+ * event.  A view switch removes the old view's widgets from their containers
+ * and can therefore unrealize a widget which GTK still has to visit for the
+ * current event.  g_main_context_invoke() is not enough here: when called by
+ * the GUI thread that owns the default context it invokes the callback
+ * synchronously.  A high-priority idle is genuinely deferred until the
+ * current event has returned to GTK, while still running before the next
+ * normal-priority input source. */
+static void _dt_ctl_switch_mode_invoke(GSourceFunc callback,
+                                       gpointer data,
+                                       GDestroyNotify notify)
+{
+  GMainContext *context = g_main_context_default();
+
+#if GTK_CHECK_VERSION(4, 0, 0)
+  /* GTK4 has no process-wide current event.  Keep the invariant unconditional
+   * rather than trying to infer event delivery from the main-context owner. */
+  g_idle_add_full(G_PRIORITY_HIGH, callback, data, notify);
+  return;
+#else
+  if(g_main_context_is_owner(context))
+  {
+    GdkEvent *event = gtk_get_current_event();
+    if(event)
+    {
+      gdk_event_free(event);
+      g_idle_add_full(G_PRIORITY_HIGH, callback, data, notify);
+      return;
+    }
+  }
+
+  g_main_context_invoke_full(context, G_PRIORITY_DEFAULT, callback, data, notify);
+#endif
+}
+
 void dt_ctl_switch_mode_to(const char *mode)
 {
   const dt_view_t *cv = dt_view_manager_get_current_view(darktable.view_manager);
@@ -617,14 +659,21 @@ void dt_ctl_switch_mode_to(const char *mode)
     return;
   }
 
-  g_main_context_invoke(NULL, _dt_ctl_switch_mode_to, (gpointer)mode);
+  // Own the string: a genuinely deferred callback cannot borrow a caller's
+  // stack or temporary storage.
+  _dt_ctl_switch_mode_invoke(_dt_ctl_switch_mode_to, g_strdup(mode), g_free);
 }
 
 void dt_ctl_switch_mode_to_by_view(const dt_view_t *view)
 {
   if(view == dt_view_manager_get_current_view(darktable.view_manager))
     return;
-  g_main_context_invoke(NULL, _dt_ctl_switch_mode_to_by_view, (gpointer)view);
+  _dt_ctl_switch_mode_invoke(_dt_ctl_switch_mode_to_by_view, (gpointer)view, NULL);
+}
+
+void dt_ctl_reload_view(const dt_view_t *view)
+{
+  _dt_ctl_switch_mode_invoke(_dt_ctl_reload_view, (gpointer)view, NULL);
 }
 
 void dt_ctl_switch_mode()

--- a/src/control/control.h
+++ b/src/control/control.h
@@ -69,6 +69,11 @@ void dt_control_set_temp_cursor(const char *cursor_name);
 // return to the cursor most rececently set by dt_control_change_cursor
 void dt_control_clear_temp_cursor();
 void dt_control_change_cursor(const char *cursor_name);
+/** Log cursor ownership/lifecycle state when -d input is enabled. */
+void dt_control_cursor_debug(const char *owner,
+                            const char *action,
+                            GtkWidget *widget,
+                            const char *cursor_name);
 void dt_control_write_sidecar_files(void);
 void dt_control_delete_images(void);
 

--- a/src/control/control.h
+++ b/src/control/control.h
@@ -99,6 +99,8 @@ void dt_control_navigation_redraw(void);
 void dt_ctl_switch_mode(void);
 void dt_ctl_switch_mode_to(const char *mode);
 void dt_ctl_switch_mode_to_by_view(const dt_view_t *view);
+/* Rebuild an existing view without changing the selected mode. */
+void dt_ctl_reload_view(const dt_view_t *view);
 
 struct dt_control_t;
 

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -608,6 +608,32 @@ static void _dev_average_delay_update(const dt_times_t *start,
                      - *average_delay / DT_DEV_AVERAGE_DELAY_COUNT);
 }
 
+void dt_dev_pixelpipe_stop_and_lock_all(dt_develop_t *dev)
+  ACQUIRE(&dev->preview_pipe->mutex, &dev->preview2.pipe->mutex, &dev->full.pipe->mutex)
+{
+  assert(dev && dev->preview_pipe && dev->preview2.pipe && dev->full.pipe);
+
+  dt_dev_pixelpipe_set_shutdown(dev->preview_pipe, DT_DEV_PIXELPIPE_STOP_NODES);
+  dt_dev_pixelpipe_set_shutdown(dev->preview2.pipe, DT_DEV_PIXELPIPE_STOP_NODES);
+  dt_dev_pixelpipe_set_shutdown(dev->full.pipe, DT_DEV_PIXELPIPE_STOP_NODES);
+
+  // Canonical all-screen-pipe lock order. Workers hold at most one pipe mutex,
+  // then may take history_mutex while synchronizing nodes.
+  dt_pthread_mutex_lock(&dev->preview_pipe->mutex);
+  dt_pthread_mutex_lock(&dev->preview2.pipe->mutex);
+  dt_pthread_mutex_lock(&dev->full.pipe->mutex);
+}
+
+void dt_dev_pixelpipe_unlock_all(dt_develop_t *dev)
+  RELEASE(&dev->preview_pipe->mutex, &dev->preview2.pipe->mutex, &dev->full.pipe->mutex)
+{
+  assert(dev && dev->preview_pipe && dev->preview2.pipe && dev->full.pipe);
+
+  dt_pthread_mutex_unlock(&dev->full.pipe->mutex);
+  dt_pthread_mutex_unlock(&dev->preview2.pipe->mutex);
+  dt_pthread_mutex_unlock(&dev->preview_pipe->mutex);
+}
+
 void dt_dev_process_image_job(dt_develop_t *dev,
                               dt_dev_viewport_t *port,
                               dt_dev_pixelpipe_t *pipe,

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -634,6 +634,15 @@ void dt_dev_pixelpipe_unlock_all(dt_develop_t *dev)
   dt_pthread_mutex_unlock(&dev->preview_pipe->mutex);
 }
 
+static void _dev_zoom_move(dt_dev_viewport_t *port,
+                           dt_dev_zoom_t zoom,
+                           float scale,
+                           int closeup,
+                           const float x,
+                           const float y,
+                           const gboolean constrain,
+                           const gboolean use_mask_overlay);
+
 void dt_dev_process_image_job(dt_develop_t *dev,
                               dt_dev_viewport_t *port,
                               dt_dev_pixelpipe_t *pipe,
@@ -809,14 +818,16 @@ restart:
                     "restore centre %.4f/%.4f",
                     rx,
                     ry);
-      dt_dev_zoom_move(port, DT_ZOOM_POSITION, 0.0f, 0, rx, ry, TRUE);
+      // Worker validation must not traverse GUI-owned mask overlay arrays.
+      _dev_zoom_move(port, DT_ZOOM_POSITION, 0.0f, 0, rx, ry, TRUE, FALSE);
     }
     else if(port_loading || require_zoom_test)
     {
       dt_print_pipe(DT_DEBUG_PIPE, "dt_dev_zoom_move", pipe, NULL, DT_DEVICE_NONE, NULL, NULL, "%s%s",
         port_loading ? "port_loading " : "",
         require_zoom_test ? "required_test" : "");
-      dt_dev_zoom_move(port, DT_ZOOM_MOVE, 0.0f, 0, 0.0f, 0.0f, TRUE);
+      // Clamp to image geometry only; mask overlays are mutable GUI state.
+      _dev_zoom_move(port, DT_ZOOM_MOVE, 0.0f, 0, 0.0f, 0.0f, TRUE, FALSE);
     }
 
     // determine scale according to current dimensions
@@ -3202,10 +3213,18 @@ _dev_mask_overlay_bounds(const dt_develop_t *dev, float *x0, float *y0, float *x
 //   - by any overlay point already outside the image (e.g. a node dragged past
 //     the edge), plus MASK_HANDLE_MARGIN so it isn't flush to the border.
 // boxw/boxh are the viewport extents in image units along each axis.
-static void _clamp_zoom_to_mask(
-  const dt_develop_t *dev, const float boxw, const float boxh, float *zoom_x, float *zoom_y)
+static void _clamp_zoom_to_mask(const dt_develop_t *dev,
+                                const float boxw,
+                                const float boxh,
+                                float *zoom_x,
+                                float *zoom_y,
+                                const gboolean use_mask_overlay)
 {
-  const gboolean creating = dev->form_gui && dev->form_gui->creation;
+  // Pixelpipe workers use the image-only branch. form_gui and its point arrays
+  // are mutable presentation data owned by the GUI thread.
+  const gboolean creating = use_mask_overlay
+                            && dev->form_gui
+                            && dev->form_gui->creation;
 
   float lox = -0.5f, hix = 0.5f, loy = -0.5f, hiy = 0.5f;
   if(creating)
@@ -3216,7 +3235,8 @@ static void _clamp_zoom_to_mask(
     hiy += MASK_CREATION_MARGIN;
   }
   float mx0, my0, mx1, my1;
-  if(_dev_mask_overlay_bounds(dev, &mx0, &my0, &mx1, &my1))
+  if(use_mask_overlay
+     && _dev_mask_overlay_bounds(dev, &mx0, &my0, &mx1, &my1))
   {
     if(mx0 < -0.5f)
       lox = fminf(lox, mx0 - MASK_HANDLE_MARGIN);
@@ -3255,13 +3275,14 @@ static void _clamp_zoom_to_mask(
   *zoom_y = CLAMP(*zoom_y, cminy, cmaxy);
 }
 
-void dt_dev_zoom_move(dt_dev_viewport_t *port,
-                      dt_dev_zoom_t zoom,
-                      float scale,
-                      int closeup,
-                      const float x,
-                      const float y,
-                      const gboolean constrain)
+static void _dev_zoom_move(dt_dev_viewport_t *port,
+                           dt_dev_zoom_t zoom,
+                           float scale,
+                           int closeup,
+                           const float x,
+                           const float y,
+                           const gboolean constrain,
+                           const gboolean use_mask_overlay)
 {
   // Use the viewport's own develop, or fall back to global
   dt_develop_t *dev = port->dev ? port->dev : darktable.develop;
@@ -3422,7 +3443,7 @@ void dt_dev_zoom_move(dt_dev_viewport_t *port,
 
     // While editing a mask, allow panning beyond the canvas to reach
     // handles that lie outside the image (see helper for the details).
-    _clamp_zoom_to_mask(dev, boxw, boxh, &zoom_x, &zoom_y);
+    _clamp_zoom_to_mask(dev, boxw, boxh, &zoom_x, &zoom_y, use_mask_overlay);
   }
 
   pts[0] = (zoom_x + 0.5f) * procw;
@@ -3467,6 +3488,20 @@ void dt_dev_zoom_move(dt_dev_viewport_t *port,
   }
   if(port == &dev->full)
     dt_control_navigation_redraw();
+}
+
+void dt_dev_zoom_move(dt_dev_viewport_t *port,
+                      dt_dev_zoom_t zoom,
+                      float scale,
+                      int closeup,
+                      const float x,
+                      const float y,
+                      const gboolean constrain)
+{
+  // Public callers are GUI/input paths and retain off-image mask-handle
+  // panning. Worker-side viewport validation calls _dev_zoom_move() directly
+  // with use_mask_overlay=FALSE.
+  _dev_zoom_move(port, zoom, scale, closeup, x, y, constrain, TRUE);
 }
 
 void dt_dev_get_pointer_zoom_pos(dt_dev_viewport_t *port,

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -386,6 +386,13 @@ void dt_dev_process_image_job(dt_develop_t *dev,
                               struct dt_dev_pixelpipe_t *pipe,
                               const dt_signal_t signal,
                               const int devid);
+
+/** Stop and lock all three screen pixelpipes before changing module lifetime
+ * or topology. Locks are acquired preview -> preview2 -> full and must be
+ * released with dt_dev_pixelpipe_unlock_all(). */
+void dt_dev_pixelpipe_stop_and_lock_all(dt_develop_t *dev);
+void dt_dev_pixelpipe_unlock_all(dt_develop_t *dev);
+
 // launch jobs above
 void dt_dev_process_image(dt_develop_t *dev);
 void dt_dev_process_preview(dt_develop_t *dev);

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -1254,6 +1254,9 @@ static void _gui_off_callback(GtkToggleButton *togglebutton,
     // set mask indicator sensitive according to module activation and raster mask
     if(module->mask_indicator)
       gtk_widget_set_sensitive(module->mask_indicator, module->enabled);
+
+    if(!gtk_widget_is_visible(module->header))
+      dt_dev_modulegroups_update_visibility(darktable.develop);
   }
 
   char tooltip[512];
@@ -1269,9 +1272,6 @@ static void _gui_off_callback(GtkToggleButton *togglebutton,
 
   // rebuild the accelerators
   dt_iop_connect_accels_multi(module->so);
-
-  if(!gtk_widget_is_visible(module->header))
-    dt_dev_modulegroups_update_visibility(darktable.develop);
 }
 
 gboolean dt_iop_so_is_hidden(const dt_iop_module_so_t *module)

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -2416,6 +2416,10 @@ void dt_iop_gui_cleanup_module(dt_iop_module_t *module)
   DT_CONTROL_SIGNAL_DISCONNECT_ALL(module, module->so->op);
   if(module->gui_cleanup) module->gui_cleanup(module);
   gtk_widget_destroy(module->expander ? module->expander : module->widget);
+  // Do not leave borrowed GTK pointers behind while asynchronous signals can
+  // still carry this module until the GUI thread drains their queue.
+  module->expander = NULL;
+  module->widget = NULL;
   dt_iop_gui_cleanup_blending(module);
   dt_pthread_mutex_destroy(&module->gui_lock);
   dt_free_align(module->gui_data);

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -565,6 +565,11 @@ static void _gui_delete_callback(GtkButton *button, dt_iop_module_t *module)
 
   DT_ENTER_GUI_UPDATE();
 
+  // GUI teardown destroys data and a mutex that commit_params()/process()
+  // may use. Stop every screen pipe and keep them locked until the module is
+  // removed from develop state and all pipe topologies are marked for rebuild.
+  dt_dev_pixelpipe_stop_and_lock_all(dev);
+
   // we remove the plugin effectively
   if(!dt_iop_is_hidden(module))
   {
@@ -620,6 +625,8 @@ static void _gui_delete_callback(GtkButton *button, dt_iop_module_t *module)
   dev->alliop = g_list_append(dev->alliop, module);
 
   dt_dev_pixelpipe_rebuild(dev);
+
+  dt_dev_pixelpipe_unlock_all(dev);
 
   /* redraw */
   dt_control_queue_redraw_center();
@@ -2412,6 +2419,7 @@ void dt_iop_gui_cleanup_module(dt_iop_module_t *module)
   dt_iop_gui_cleanup_blending(module);
   dt_pthread_mutex_destroy(&module->gui_lock);
   dt_free_align(module->gui_data);
+  module->gui_data = NULL;
 }
 
 void dt_iop_gui_update(dt_iop_module_t *module)

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -1574,8 +1574,9 @@ void dt_masks_set_edit_mode(dt_iop_module_t *module,
   // dt_iop_gui_update() loop in dt_dev_pop_history_items(), which holds
   // dev->history_mutex, whereas dt_dev_zoom_move() takes global_mutex and then
   // history_mutex -- the reverse of the order a pixelpipe worker uses, so the
-  // two deadlock.  Nothing is lost: after a history reload the pipe is dirty,
-  // so dt_dev_process_image_job() runs the very same clamp itself.
+  // two deadlock. Nothing is lost when hiding the overlay: after a history
+  // reload the dirty pipe runs the image-only clamp itself. Worker validation
+  // deliberately does not inspect mutable GUI overlay points.
   // Also avoid if we didn't change edit mode
   if(!darktable.develop->history_updating && old_shown != value)
     dt_dev_zoom_move(&darktable.develop->full, DT_ZOOM_MOVE, 0.0f, 0, 0.0f, 0.0f, TRUE);

--- a/src/dtgtk/culling.c
+++ b/src/dtgtk/culling.c
@@ -948,7 +948,9 @@ static void _event_button_press_cb(GtkGestureSingle *gesture,
       // during the previous GDK_BUTTON_PRESS event
       const dt_imgid_t old_selection = table->selection;
       table->selection = id;
-      dt_view_manager_switch(darktable.view_manager, "darkroom");
+      // Leave GTK to finish propagating the double-click before the view
+      // switch tears down this widget hierarchy.
+      dt_ctl_switch_mode_to("darkroom");
       if(id != old_selection)
       {
         _update_selected_thumbnail(table, old_selection);

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -1588,7 +1588,9 @@ static void _event_button_press_cb(GtkGestureSingle *gesture,
       {
         case DT_THUMBTABLE_MODE_FILEMANAGER:
         case DT_THUMBTABLE_MODE_ZOOM:
-          dt_view_manager_switch(darktable.view_manager, "darkroom");
+          // Leave GTK to finish propagating the double-click before the view
+          // switch tears down this widget hierarchy.
+          dt_ctl_switch_mode_to("darkroom");
           return;
 
         case DT_THUMBTABLE_MODE_FILMSTRIP:

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -2517,29 +2517,27 @@ static void _event_dnd_get(GtkWidget *widget,
         GList *l = table->drag_list;
 
         int idx = 0;
-        // make sure that imgs[0] is the last selected imgid, that is the
-        // one clicked when starting the d&d.
-        if(dt_is_valid_imgid(darktable.control->last_clicked_filmstrip_id))
-        {
-          imgs[idx] = darktable.control->last_clicked_filmstrip_id;
-          idx++;
-        }
+        // Put the drag origin first only if it belongs to the stable drag set.
+        // A pointer grab can change the transient hover before drag-begin; it
+        // must never inject that unrelated image and displace a selected one.
+        const dt_imgid_t origin = darktable.control->last_clicked_filmstrip_id;
+        const gboolean have_origin =
+          dt_is_valid_imgid(origin)
+          && g_list_find(table->drag_list, GINT_TO_POINTER(origin));
+        if(have_origin)
+          imgs[idx++] = origin;
 
         while(l)
         {
           const dt_imgid_t id = GPOINTER_TO_INT(l->data);
-          if(id != imgs[0])
-          {
-            imgs[idx] = id;
-            idx++;
-            if(idx >= imgs_nb)
-              break;
-          }
+          if(!have_origin || id != origin)
+            imgs[idx++] = id;
           l = g_list_next(l);
         }
         gtk_selection_data_set(selection_data,
                                gtk_selection_data_get_target(selection_data),
-                               _DWORD, (guchar *)imgs, imgs_nb * sizeof(dt_imgid_t));
+                               _DWORD, (guchar *)imgs, idx * sizeof(dt_imgid_t));
+        free(imgs);
       }
       break;
     }
@@ -2593,9 +2591,23 @@ static void _event_dnd_begin(GtkWidget *widget,
 {
   const int ts = DT_PIXEL_APPLY_DPI(128);
 
-  darktable.control->last_clicked_filmstrip_id =
-    dt_control_get_mouse_over_id();
+  const dt_imgid_t hover = dt_control_get_mouse_over_id();
+  darktable.control->last_clicked_filmstrip_id = hover;
   table->drag_list = dt_act_on_get_images(FALSE, TRUE, TRUE);
+
+  GList *selection = dt_selection_get_list(darktable.selection, FALSE, TRUE);
+  // DnD owns a stable snapshot keyed by the actual drag origin. Dragging a
+  // selected image moves the selection; dragging an unselected image moves
+  // only that image. Do not let the generic act-on fallback substitute an
+  // unrelated selection if hover/grab state changes during GTK3 drag setup.
+  if(dt_is_valid_imgid(hover))
+  {
+    g_list_free(table->drag_list);
+    table->drag_list = g_list_find(selection, GINT_TO_POINTER(hover))
+                       ? g_list_copy(selection)
+                       : g_list_append(NULL, GINT_TO_POINTER(hover));
+  }
+  g_list_free(selection);
 
 #ifdef HAVE_MAP
   dt_view_manager_t *vm = darktable.view_manager;
@@ -2603,9 +2615,14 @@ static void _event_dnd_begin(GtkWidget *widget,
   if(!strcmp(view->module_name, "map"))
   {
     if(table->drag_list)
-      dt_view_map_drag_set_icon(darktable.view_manager, context,
-                                GPOINTER_TO_INT(table->drag_list->data),
+    {
+      const dt_imgid_t icon_id =
+        dt_is_valid_imgid(hover)
+        && g_list_find(table->drag_list, GINT_TO_POINTER(hover))
+        ? hover : GPOINTER_TO_INT(table->drag_list->data);
+      dt_view_map_drag_set_icon(darktable.view_manager, context, icon_id,
                                 g_list_length(table->drag_list));
+    }
   }
   else
 #endif

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -229,11 +229,47 @@ static void _fullscreen_key_accel_callback(dt_action_t *action)
 #endif
 }
 
+static void _set_tooltip_css(const gboolean hidden)
+{
+  if(!darktable.gui->tooltip_css_provider)
+  {
+    darktable.gui->tooltip_css_provider = gtk_css_provider_new();
+#if GTK_CHECK_VERSION(4, 0, 0)
+    gtk_style_context_add_provider_for_display
+      (gdk_display_get_default(),
+       GTK_STYLE_PROVIDER(darktable.gui->tooltip_css_provider),
+       GTK_STYLE_PROVIDER_PRIORITY_USER + 2);
+#else
+    gtk_style_context_add_provider_for_screen
+      (gdk_screen_get_default(),
+       GTK_STYLE_PROVIDER(darktable.gui->tooltip_css_provider),
+       GTK_STYLE_PROVIDER_PRIORITY_USER + 2);
+#endif
+  }
+
+  const char *css = hidden
+    ? "tooltip { opacity: 0; background: transparent; }"
+    : "";
+#if GTK_CHECK_VERSION(4, 0, 0)
+  gtk_css_provider_load_from_data(darktable.gui->tooltip_css_provider, css, -1);
+#else
+  GError *error = NULL;
+  if(!gtk_css_provider_load_from_data(darktable.gui->tooltip_css_provider,
+                                      css, -1, &error))
+  {
+    dt_print(DT_DEBUG_ALWAYS, "%s: error parsing tooltip CSS: %s",
+             G_STRFUNC, error->message);
+    g_clear_error(&error);
+  }
+#endif
+}
+
 static void _toggle_tooltip_visibility(dt_action_t *action)
 {
   const gboolean tooltip_hidden = !dt_conf_get_bool("ui/hide_tooltips");
   dt_conf_set_bool("ui/hide_tooltips", tooltip_hidden);
   darktable.gui->hide_tooltips += tooltip_hidden ? 1 : -1;
+  _set_tooltip_css(tooltip_hidden);
   dt_toast_log(tooltip_hidden ? _("tooltips off") : _("tooltips on"));
 }
 
@@ -1580,6 +1616,22 @@ static void _window_set_titlebar_color_callback(GtkWidget *widget)
   g_signal_chain_from_overridden_handler(widget);
 }
 #endif
+
+void dt_gui_gtk_cleanup(dt_gui_gtk_t *gui)
+{
+  if(gui->tooltip_css_provider)
+  {
+#if GTK_CHECK_VERSION(4, 0, 0)
+    gtk_style_context_remove_provider_for_display
+      (gdk_display_get_default(), GTK_STYLE_PROVIDER(gui->tooltip_css_provider));
+#else
+    gtk_style_context_remove_provider_for_screen
+      (gdk_screen_get_default(), GTK_STYLE_PROVIDER(gui->tooltip_css_provider));
+#endif
+    g_clear_object(&gui->tooltip_css_provider);
+  }
+  g_clear_pointer(&gui->last_preset, g_free);
+}
 
 int dt_gui_theme_init(dt_gui_gtk_t *gui)
 {
@@ -3989,14 +4041,6 @@ void dt_gui_load_theme(const char *theme)
   g_free(path_uri);
   g_free(path);
 
-  if(dt_conf_get_bool("ui/hide_tooltips"))
-  {
-    gchar *newcss = g_strjoin(NULL, themecss,
-                              " tooltip {opacity: 0; background: transparent;}", NULL);
-    g_free(themecss);
-    themecss = newcss;
-  }
-
   if(!gtk_css_provider_load_from_data(GTK_CSS_PROVIDER(themes_style_provider),
                                       themecss, -1, &error))
   {
@@ -4009,6 +4053,7 @@ void dt_gui_load_theme(const char *theme)
   g_free(themecss);
 
   g_object_unref(themes_style_provider);
+  _set_tooltip_css(dt_conf_get_bool("ui/hide_tooltips"));
 }
 
 void dt_gui_apply_theme()

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -2855,14 +2855,14 @@ static void _restore_default_modules(GtkMenuItem *menuitem,
   gchar *prefix = g_strdup_printf("plugins/%s/", cv->module_name);
   g_hash_table_foreach_remove(darktable.conf->table, _remove_modules_visibility, prefix);
   g_free(prefix);
-  dt_view_manager_switch_by_view(darktable.view_manager, cv);
+  dt_ctl_reload_view(cv);
 }
 
 static void _toggle_module_visibility(GtkMenuItem *menuitem,
                                       dt_lib_module_t *module)
 {
   dt_lib_set_visible(module, !dt_lib_is_visible(module));
-  dt_view_manager_switch_by_view(darktable.view_manager, dt_view_manager_get_current_view(darktable.view_manager));
+  dt_ctl_reload_view(dt_view_manager_get_current_view(darktable.view_manager));
 }
 
 static void _add_remove_modules(dt_action_t *action)

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -3216,7 +3216,7 @@ static void _ui_init_panel_left(dt_ui_t *ui,
 
   dt_gui_connect_click(handle, _panel_handle_button_pressed, _panel_handle_button_released, widget);
   dt_gui_connect_motion(handle, _panel_handle_motion_callback,
-                        _panel_handle_cursor_enter, _panel_handle_cursor_leave, NULL);
+                        _panel_handle_cursor_enter, _panel_handle_cursor_leave, widget);
   gtk_widget_show(handle);
 
   gtk_grid_attach(GTK_GRID(container), over, 1, 1, 1, 1);
@@ -3256,7 +3256,7 @@ static void _ui_init_panel_right(dt_ui_t *ui,
 
   dt_gui_connect_click(handle, _panel_handle_button_pressed, _panel_handle_button_released, widget);
   dt_gui_connect_motion(handle, _panel_handle_motion_callback,
-                        _panel_handle_cursor_enter, _panel_handle_cursor_leave, NULL);
+                        _panel_handle_cursor_enter, _panel_handle_cursor_leave, widget);
   gtk_widget_show(handle);
 
   gtk_grid_attach(GTK_GRID(container), over, 3, 1, 1, 1);
@@ -3332,7 +3332,7 @@ static void _ui_init_panel_bottom(dt_ui_t *ui,
 
   dt_gui_connect_click(handle, _panel_handle_button_pressed, _panel_handle_button_released, widget);
   dt_gui_connect_motion(handle, _panel_handle_motion_callback,
-                        _panel_handle_cursor_enter, _panel_handle_cursor_leave, NULL);
+                        _panel_handle_cursor_enter, _panel_handle_cursor_leave, widget);
   gtk_widget_show(handle);
 
   gtk_grid_attach(GTK_GRID(container), over, 1, 2, 3, 1);

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -5396,6 +5396,90 @@ GtkGesture *(dt_gui_connect_pinch)(GtkWidget *widget,
   return gesture;
 }
 
+#if !GTK_CHECK_VERSION(4, 0, 0)
+static GdkWindow *_dt_gui_cursor_window(GtkWidget *widget)
+{
+  if(!widget) return NULL;
+
+  GdkWindow *window = gtk_widget_get_window(widget);
+  if(GTK_IS_TREE_VIEW(widget))
+  {
+    GdkWindow *bin = gtk_tree_view_get_bin_window(GTK_TREE_VIEW(widget));
+    if(bin) window = bin;
+  }
+  return window;
+}
+#endif
+
+GdkCursor *dt_gui_cursor_new_for_name(GdkDisplay *display, const char *cursor_name)
+{
+  if(!display || !cursor_name) return NULL;
+
+  GdkCursor *cursor = gdk_cursor_new_from_name(display, cursor_name);
+
+#if !GTK_CHECK_VERSION(4, 0, 0)
+  // GTK3 fallback: some CSS cursor names are not supported by all
+  // backends (for example "wait", "help", and "none"). GTK4 supports
+  // the CSS cursor name API on all backends, so this branch disappears
+  // when the application moves to GTK4.
+  if(!cursor)
+  {
+    GdkCursorType type = GDK_LEFT_PTR;
+    if(!strcmp(cursor_name, "none"))           type = GDK_BLANK_CURSOR;
+    else if(!strcmp(cursor_name, "wait"))      type = GDK_WATCH;
+    else if(!strcmp(cursor_name, "grab"))      type = GDK_HAND1;
+    else if(!strcmp(cursor_name, "cell"))      type = GDK_PLUS;
+    else if(!strcmp(cursor_name, "help"))      type = GDK_QUESTION_ARROW;
+    else if(!strcmp(cursor_name, "ns-resize")) type = GDK_DOUBLE_ARROW;
+    cursor = gdk_cursor_new_for_display(display, type);
+  }
+#endif
+
+  return cursor;
+}
+
+GdkCursor *dt_gui_cursor_get(GtkWidget *widget)
+{
+  if(!widget) return NULL;
+#if GTK_CHECK_VERSION(4, 0, 0)
+  return gtk_widget_get_cursor(widget);
+#else
+  GdkWindow *window = _dt_gui_cursor_window(widget);
+  return window ? gdk_window_get_cursor(window) : NULL;
+#endif
+}
+
+void dt_gui_cursor_apply(GtkWidget *widget, GdkCursor *cursor)
+{
+  if(!widget) return;
+#if GTK_CHECK_VERSION(4, 0, 0)
+  gtk_widget_set_cursor(widget, cursor);
+#else
+  GdkWindow *window = _dt_gui_cursor_window(widget);
+  if(window) gdk_window_set_cursor(window, cursor);
+#endif
+}
+
+void dt_gui_cursor_set(GtkWidget *widget, const char *cursor_name, const char *owner)
+{
+  if(!widget) return;
+
+  dt_control_cursor_debug(owner,
+                          cursor_name ? "set" : "clear",
+                          widget,
+                          cursor_name);
+#if GTK_CHECK_VERSION(4, 0, 0)
+  if(cursor_name)
+    gtk_widget_set_cursor_from_name(widget, cursor_name);
+  else
+    gtk_widget_set_cursor(widget, NULL);
+#else
+  GdkCursor *cursor = dt_gui_cursor_new_for_name(gtk_widget_get_display(widget), cursor_name);
+  dt_gui_cursor_apply(widget, cursor);
+  if(cursor) g_object_unref(cursor);
+#endif
+}
+
 GtkEventController *(dt_gui_connect_motion)(GtkWidget *widget,
                                             GCallback motion,
                                             GCallback enter,

--- a/src/gui/gtk.h
+++ b/src/gui/gtk.h
@@ -126,6 +126,7 @@ typedef struct dt_gui_gtk_t
   GdkRGBA colors[DT_GUI_COLOR_LAST];
 
   int32_t hide_tooltips;
+  GtkCssProvider *tooltip_css_provider;
 
   gboolean grouping;
   dt_imgid_t expanded_group_id;

--- a/src/gui/gtk.h
+++ b/src/gui/gtk.h
@@ -764,6 +764,14 @@ GtkEventController *(dt_gui_connect_key)(GtkWidget *widget,
 #define dt_gui_get_widget(controller) \
       gtk_event_controller_get_widget(GTK_EVENT_CONTROLLER(controller))
 
+/* Cursor compatibility boundary. GTK3 applies cursors to the widget's
+ * backing window (using a TreeView's bin window when needed); GTK4 applies
+ * them to the widget itself. The owner string is used by -d input tracing. */
+GdkCursor *dt_gui_cursor_new_for_name(GdkDisplay *display, const char *cursor_name);
+GdkCursor *dt_gui_cursor_get(GtkWidget *widget);
+void dt_gui_cursor_apply(GtkWidget *widget, GdkCursor *cursor);
+void dt_gui_cursor_set(GtkWidget *widget, const char *cursor_name, const char *owner);
+
 /* object-data key on the gesture carrying a shortcut-activated press'
  * button+state, encoded as (state << 8) | button (see
  * _action_process_toggle/_action_process_button).  Set right before the

--- a/src/gui/preferences.c
+++ b/src/gui/preferences.c
@@ -367,8 +367,7 @@ static void _reset_panels_clicked(GtkButton *button, gpointer user_data)
     return;
 
   g_hash_table_foreach_remove(darktable.conf->table, _remove_panel_config, NULL);
-  dt_view_manager_switch_by_view(darktable.view_manager,
-                                 dt_view_manager_get_current_view(darktable.view_manager));
+  dt_ctl_reload_view(dt_view_manager_get_current_view(darktable.view_manager));
 }
 
 // forward declaration for use in init_tab_general

--- a/src/gui/preferences_ai.c
+++ b/src/gui/preferences_ai.c
@@ -1987,20 +1987,18 @@ static void _on_tree_motion_cb(GtkEventControllerMotion *controller,
 {
   GtkWidget *widget = dt_gui_get_widget(controller);
   GtkTreeView *tv = GTK_TREE_VIEW(widget);
-  GdkWindow *bin = gtk_tree_view_get_bin_window(tv);
-  if(!bin) return;
   gint bx, by;
   gtk_tree_view_convert_widget_to_bin_window_coords(tv, (gint)x, (gint)y, &bx, &by);
-  if(_info_active_at_bin(user_data, tv, bx, by))
-  {
-    GdkCursor *cursor = gdk_cursor_new_from_name(gdk_window_get_display(bin), "pointer");
-    gdk_window_set_cursor(bin, cursor);
-    g_object_unref(cursor);
-  }
-  else
-  {
-    gdk_window_set_cursor(bin, NULL);
-  }
+  dt_gui_cursor_set(widget,
+                    _info_active_at_bin(user_data, tv, bx, by) ? "pointer" : NULL,
+                    "preferences-ai/info");
+}
+
+static void _on_tree_leave_cb(GtkEventControllerMotion *controller,
+                              gpointer user_data)
+{
+  (void)user_data;
+  dt_gui_cursor_set(dt_gui_get_widget(controller), NULL, "preferences-ai/info");
 }
 
 // click on the ⓘ info column opens the model card
@@ -2583,7 +2581,7 @@ void init_tab_ai(GtkWidget *dialog, GtkWidget *stack)
   gtk_widget_set_has_tooltip(data->model_list, TRUE);
   g_signal_connect(data->model_list, "query-tooltip",
                    G_CALLBACK(_on_query_tooltip), data);
-  dt_gui_connect_motion(data->model_list, _on_tree_motion_cb, NULL, NULL, data);
+  dt_gui_connect_motion(data->model_list, _on_tree_motion_cb, NULL, _on_tree_leave_cb, data);
   dt_gui_connect_click(data->model_list, _on_info_button_press_cb, NULL, data);
 
   // scrolled window for the list

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -54,6 +54,7 @@
 #include "develop/openmp_maths.h"
 #include "gui/accelerators.h"
 #include "gui/color_picker_proxy.h"
+#include "control/control.h"
 #include "gui/gtk.h"
 #include "gui/presets.h"
 #include "iop/iop_api.h"
@@ -2585,11 +2586,7 @@ int mouse_moved(dt_iop_module_t *self,
   else
   {
     // fall back to default cursor
-    GdkCursor *const cursor =
-      gdk_cursor_new_from_name(gdk_display_get_default(), "default");
-    gdk_window_set_cursor(gtk_widget_get_window(dt_ui_main_window(darktable.gui->ui)),
-                          cursor);
-    g_object_unref(cursor);
+    dt_control_change_cursor("default");
   }
 
   dt_control_queue_redraw_center();

--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -1997,17 +1997,12 @@ static void switch_cursors(dt_iop_module_t *self)
   if(!g || !self->dev->gui_attached)
     return;
 
-  GtkWidget *widget = dt_ui_main_window(darktable.gui->ui);
-
   // if we are editing masks or using colour-pickers, do not display controls
   if(in_mask_editing(self)
      || dt_iop_canvas_not_sensitive(self->dev))
   {
     // display default cursor
-    GdkCursor *const cursor =
-      gdk_cursor_new_from_name(gdk_display_get_default(), "default");
-    gdk_window_set_cursor(gtk_widget_get_window(widget), cursor);
-    g_object_unref(cursor);
+    dt_control_change_cursor("default");
 
     return;
   }
@@ -2030,9 +2025,7 @@ static void switch_cursors(dt_iop_module_t *self)
   {
     // if pipe is busy or dirty but cursor is on preview,
     // display waiting cursor while pipe reprocesses
-    GdkCursor *const cursor = gdk_cursor_new_from_name(gdk_display_get_default(), "wait");
-    gdk_window_set_cursor(gtk_widget_get_window(widget), cursor);
-    g_object_unref(cursor);
+    dt_control_change_cursor("wait");
 
     dt_control_queue_redraw_center();
   }
@@ -2051,10 +2044,7 @@ static void switch_cursors(dt_iop_module_t *self)
   {
     // if module is active and opened but cursor is out of the preview,
     // display default cursor
-    GdkCursor *const cursor =
-      gdk_cursor_new_from_name(gdk_display_get_default(), "default");
-    gdk_window_set_cursor(gtk_widget_get_window(widget), cursor);
-    g_object_unref(cursor);
+    dt_control_change_cursor("default");
 
     dt_control_queue_redraw_center();
   }
@@ -2062,10 +2052,7 @@ static void switch_cursors(dt_iop_module_t *self)
   {
     // in any other situation where module has focus,
     // reset the cursor but don't launch a redraw
-    GdkCursor *const cursor =
-      gdk_cursor_new_from_name(gdk_display_get_default(), "default");
-    gdk_window_set_cursor(gtk_widget_get_window(widget), cursor);
-    g_object_unref(cursor);
+    dt_control_change_cursor("default");
   }
 }
 
@@ -2129,10 +2116,7 @@ int mouse_leave(dt_iop_module_t *self)
   dt_iop_gui_leave_critical_section(self);
 
   // display default cursor
-  GtkWidget *widget = dt_ui_main_window(darktable.gui->ui);
-  GdkCursor *cursor = gdk_cursor_new_from_name(gdk_display_get_default(), "default");
-  gdk_window_set_cursor(gtk_widget_get_window(widget), cursor);
-  g_object_unref(cursor);
+  dt_control_change_cursor("default");
   dt_control_queue_redraw_center();
   gtk_widget_queue_draw(GTK_WIDGET(g->area));
 

--- a/src/libs/backgroundjobs.c
+++ b/src/libs/backgroundjobs.c
@@ -136,13 +136,7 @@ static gboolean _added_gui_thread(gpointer user_data)
 
   // instance cursor to tell user that, if this is a blocking job with
   // a global busy cursor, the cancel box in this widget can stop it
-  GdkWindow *window = gtk_widget_get_window(params->instance_widget);
-  if(window)
-  {
-    GdkCursor *cursor = gdk_cursor_new_from_name(gdk_display_get_default(), "default");
-    gdk_window_set_cursor(window, cursor);
-    g_object_unref(cursor);
-  }
+  dt_gui_cursor_set(params->instance_widget, "default", "background-job/instance");
 
   free(params);
   return G_SOURCE_REMOVE;

--- a/src/libs/history.c
+++ b/src/libs/history.c
@@ -574,6 +574,11 @@ static void _pop_undo(gpointer user_data,
 
     GList *iop_temp = g_list_copy(dev->iop);
 
+    // Undo/redo can destroy module GUI data and alter the module topology.
+    // Keep all screen pipes quiescent until the replacement develop state is
+    // complete, so no old node can resume with a cleaned-up module GUI.
+    dt_dev_pixelpipe_stop_and_lock_all(dev);
+
     // topology has changed?
     gboolean pipe_remove = FALSE;
 
@@ -627,6 +632,8 @@ static void _pop_undo(gpointer user_data,
     dt_pthread_mutex_unlock(&dev->history_mutex);
 
     dt_ioppr_resync_modules_order(dev);
+
+    dt_dev_pixelpipe_unlock_all(dev);
 
     dt_dev_modulegroups_set(darktable.develop,
                             dt_dev_modulegroups_get(darktable.develop));

--- a/src/libs/map_locations.c
+++ b/src/libs/map_locations.c
@@ -755,7 +755,7 @@ static void _pop_menu_update_filmstrip(GtkWidget *menuitem, dt_lib_module_t *sel
 static void _pop_menu_goto_collection(GtkWidget *menuitem, dt_lib_module_t *self)
 {
   if(_set_location_collection(self))
-    dt_view_manager_switch(darktable.view_manager, "lighttable");
+    dt_ctl_switch_mode_to("lighttable");
 }
 
 static void _pop_menu_view(GtkWidget *view, GdkEventButton *event, dt_lib_module_t *self)

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -749,6 +749,13 @@ static void _basics_show(dt_lib_module_t *self)
 
   if(d->vbox_basic && gtk_widget_get_visible(d->vbox_basic)) return;
 
+  /* QAP construction creates activation buttons whose callbacks are already
+   * connected before their initial active state is synchronized. Every QAP
+   * rebuild must therefore be a programmatic GUI update, including the path
+   * reached when the last character is deleted from module search. Without
+   * this scope, that initial toggled signal can recursively rebuild QAP. */
+  DT_ENTER_GUI_UPDATE();
+
   if(!d->vbox_basic)
   {
     d->vbox_basic = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
@@ -791,6 +798,8 @@ static void _basics_show(dt_lib_module_t *self)
   }
 
   gtk_widget_show(d->vbox_basic);
+
+  DT_LEAVE_GUI_UPDATE();
 }
 
 static uint32_t _lib_modulegroups_get_activated(dt_lib_module_t *self)

--- a/src/libs/neural_restore.c
+++ b/src/libs/neural_restore.c
@@ -190,6 +190,7 @@
 #include "common/ai/restore_raw_bayer.h"
 #include "common/ai/restore_raw_linear.h"
 #include "control/conf.h"
+#include "control/control.h"
 #include "bauhaus/bauhaus.h"
 #include "common/act_on.h"
 #include "common/collection.h"
@@ -4177,6 +4178,7 @@ static void _preview_motion_cb(GtkEventControllerMotion *controller,
   // move crop rectangle while hovering in picking mode
   if(d->picking_thumbnail && d->export_cairo)
   {
+    dt_gui_cursor_set(widget, NULL, "neural-restore/divider");
     const int w = gtk_widget_get_allocated_width(widget);
     const int h = gtk_widget_get_allocated_height(widget);
     double img_w, img_h, ox, oy;
@@ -4206,6 +4208,7 @@ static void _preview_motion_cb(GtkEventControllerMotion *controller,
 
   if(d->dragging_split)
   {
+    dt_gui_cursor_set(widget, NULL, "neural-restore/divider");
     const int w = gtk_widget_get_allocated_width(widget);
     const int pw = d->preview_w;
     const int ph = d->preview_h;
@@ -4221,7 +4224,9 @@ static void _preview_motion_cb(GtkEventControllerMotion *controller,
     return;
   }
 
-  // change cursor near divider
+  // Change the cursor near the divider. The same helper also clears it
+  // when the preview is unavailable, so a completed/cancelled preview
+  // cannot leave the resize cursor behind.
   if(d->preview_ready
      && d->preview_w > 0
      && d->preview_h > 0)
@@ -4233,26 +4238,22 @@ static void _preview_motion_cb(GtkEventControllerMotion *controller,
     const double ox = (w - d->preview_w * scale) / 2.0;
     const double div_x
       = ox + d->split_pos * d->preview_w * scale;
-
-    GdkWindow *win = gtk_widget_get_window(widget);
-    if(win)
-    {
-      const gboolean near = fabs(ex - div_x) < PREVIEW_DIVIDER_NEAR_PX;
-      if(near)
-      {
-        GdkCursor *cursor = gdk_cursor_new_from_name(
-          gdk_display_get_default(), "col-resize");
-        gdk_window_set_cursor(win, cursor);
-        g_object_unref(cursor);
-      }
-      else
-      {
-        gdk_window_set_cursor(win, NULL);
-      }
-    }
+    const gboolean near = fabs(ex - div_x) < PREVIEW_DIVIDER_NEAR_PX;
+    dt_gui_cursor_set(widget,
+                      near ? "col-resize" : NULL,
+                      "neural-restore/divider");
   }
+  else
+    dt_gui_cursor_set(widget, NULL, "neural-restore/divider");
 
   return;
+}
+
+static void _preview_leave_cb(GtkEventControllerMotion *controller,
+                              gpointer user_data)
+{
+  (void)user_data;
+  dt_gui_cursor_set(dt_gui_get_widget(controller), NULL, "neural-restore/divider");
 }
 
 static void _selection_changed_callback(gpointer instance,
@@ -4487,7 +4488,7 @@ void gui_init(dt_lib_module_t *self)
   g_signal_connect(d->preview_area, "draw",
                    G_CALLBACK(_preview_draw), self);
   dt_gui_connect_click(d->preview_area, _preview_button_press_cb, _preview_button_release_cb, self);
-  dt_gui_connect_motion(d->preview_area, _preview_motion_cb, NULL, NULL, self);
+  dt_gui_connect_motion(d->preview_area, _preview_motion_cb, NULL, _preview_leave_cb, self);
   // hover-zoom tooltip: shows the same preview at 2x so the user can
   // see individual pixels. only fires when there's a valid preview;
   // suppressed during inference / picking / dragging

--- a/src/libs/tools/global_toolbox.c
+++ b/src/libs/tools/global_toolbox.c
@@ -648,14 +648,15 @@ static gboolean _resize_shortcuts_dialog(GtkWidget *widget, GdkEvent *event, gpo
 
 static void _set_mapping_mode_cursor(GtkWidget *widget)
 {
-  GdkDisplay *display = gdk_display_get_default();
-  GdkWindow *window = gtk_widget_get_window(dt_ui_main_window(darktable.gui->ui));
+  GtkWidget *main_window = dt_ui_main_window(darktable.gui->ui);
+  if(!main_window) return;
+  GdkDisplay *display = gtk_widget_get_display(main_window);
   GdkCursor *cursor = NULL;
 
   if(GTK_IS_EVENT_BOX(widget)) widget = gtk_bin_get_child(GTK_BIN(widget));
 
   if(widget && !strcmp(gtk_widget_get_name(widget), "module-header"))
-    cursor = gdk_cursor_new_from_name(display, "context-menu");
+    cursor = dt_gui_cursor_new_for_name(display, "context-menu");
   else if(dt_action_widget(darktable.control->mapping_widget)
           && darktable.develop)
   {
@@ -665,16 +666,21 @@ static void _set_mapping_mode_cursor(GtkWidget *widget)
 
     dtgtk_cairo_paint_flags_t flags = dt_dev_modulegroups_basics_module_toggle(darktable.develop, widget, FALSE);
     dtgtk_cairo_paint_shortcut(cr, 0, 0, size, size, flags, GINT_TO_POINTER(TRUE));
+    // GTK4 migration: replace this GTK3 cairo-surface cursor with a
+    // GdkTexture-backed cursor; application remains in dt_gui_cursor_apply().
     cursor = gdk_cursor_new_from_surface(display, surface, size/2, size/2);
     cairo_surface_destroy(surface);
 
-    gdk_window_set_cursor(window, NULL); // work around bug where gtk seems to buffer surface cursors
+    dt_control_cursor_debug("shortcut-mapping", "clear-before-custom", main_window, NULL);
+    dt_gui_cursor_apply(main_window, NULL); // work around bug where gtk seems to buffer surface cursors
   }
   else
-    cursor = gdk_cursor_new_from_name(display, "not-allowed");
+    cursor = dt_gui_cursor_new_for_name(display, "not-allowed");
 
-  gdk_window_set_cursor(window, cursor);
-  g_object_unref(cursor);
+  dt_control_cursor_debug("shortcut-mapping", "set", main_window,
+                          cursor ? "custom-or-not-allowed" : NULL);
+  dt_gui_cursor_apply(main_window, cursor);
+  if(cursor) g_object_unref(cursor);
 }
 
 static gboolean _shortcuts_dialog_open = FALSE;

--- a/src/lua/lib.c
+++ b/src/lua/lib.c
@@ -20,6 +20,7 @@
 #include "lua/call.h"
 #include "lua/modules.h"
 #include "lua/types.h"
+#include "control/control.h"
 
 static int expanded_member(lua_State *L)
 {
@@ -48,7 +49,7 @@ static int visible_member(lua_State *L)
   {
     dt_lib_set_visible(module, lua_toboolean(L, 3));
     // force a reload of visible modules
-    dt_view_manager_switch_by_view(darktable.view_manager, dt_view_manager_get_current_view(darktable.view_manager));
+    dt_ctl_reload_view(dt_view_manager_get_current_view(darktable.view_manager));
     return 0;
   }
 }

--- a/src/lua/lualib.c
+++ b/src/lua/lualib.c
@@ -289,7 +289,7 @@ static int register_lib(lua_State *L)
   darktable.lib->plugins = g_list_insert_sorted(darktable.lib->plugins, lib, dt_lib_sort_plugins);
   dt_lib_init_presets(lib);
 
-  dt_view_manager_switch_by_view(darktable.view_manager, dt_view_manager_get_current_view(darktable.view_manager));
+  dt_ctl_reload_view(dt_view_manager_get_current_view(darktable.view_manager));
   return 0;
 }
 

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -4994,10 +4994,7 @@ GSList *mouse_actions(const dt_view_t *self)
 static void _dt_second_window_change_cursor(dt_develop_t *dev,
                                             const gchar *curs)
 {
-  GtkWidget *widget = dev->second_wnd;
-  GdkCursor *cursor = gdk_cursor_new_from_name(gdk_display_get_default(), curs);
-  gdk_window_set_cursor(gtk_widget_get_window(widget), cursor);
-  g_object_unref(cursor);
+  dt_gui_cursor_set(dev->second_wnd, curs, "darkroom/second-window");
 }
 
 static void _second_window_leave(dt_develop_t *dev)

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -273,23 +273,49 @@ static dt_darkroom_layout_t _lib_darkroom_get_layout(dt_view_t *self)
   return DT_DARKROOM_LAYOUT_EDITING;
 }
 
+static gboolean _darkroom_module_is_active(const dt_view_t *view,
+                                           const dt_iop_module_t *module)
+{
+  if(!view || !module || view != dt_view_manager_get_current_view(darktable.view_manager)
+     || view->data != darktable.develop)
+    return FALSE;
+
+  // Trouble messages are delivered asynchronously and carry a borrowed module
+  // pointer.  Compare pointers while walking the live IOP list before reading
+  // anything from the payload; the old darkroom may have freed the module
+  // while its queued signal was waiting for the GUI thread.
+  const dt_develop_t *dev = view->data;
+  for(const GList *iter = dev->iop; iter; iter = g_list_next(iter))
+    if(iter->data == module)
+      return TRUE;
+
+  return FALSE;
+}
+
 void _display_module_trouble_message_callback(gpointer instance,
                                               dt_iop_module_t *module,
                                               const char *const trouble_msg,
                                               const char *const trouble_tooltip)
 {
-  GtkWidget *label_widget = NULL;
+  if(!_darkroom_module_is_active(instance, module)
+     || !module->gui_data
+     || !module->widget)
+    return;
 
-  if(module && module->has_trouble && module->widget)
+  GtkWidget *label_widget = NULL;
+  GtkWidget *module_widget = module->widget;
+  GtkWidget *module_parent = module_widget ? gtk_widget_get_parent(module_widget) : NULL;
+
+  if(module->has_trouble && module_parent && GTK_IS_CONTAINER(module_parent))
   {
-    label_widget = dt_gui_container_first_child(GTK_CONTAINER(gtk_widget_get_parent(module->widget)));
-    if(g_strcmp0(gtk_widget_get_name(label_widget), "iop-plugin-warning"))
+    label_widget = dt_gui_container_first_child(GTK_CONTAINER(module_parent));
+    if(!label_widget || g_strcmp0(gtk_widget_get_name(label_widget), "iop-plugin-warning"))
       label_widget = NULL;
   }
 
   if(trouble_msg && *trouble_msg)
   {
-    if(module && module->widget)
+    if(module_widget && module_parent && GTK_IS_BOX(module_parent))
     {
       if(label_widget)
       {
@@ -305,9 +331,8 @@ void _display_module_trouble_message_callback(gpointer instance,
         gtk_widget_set_name(label_widget, "iop-plugin-warning");
         dt_gui_add_class(label_widget, "dt_warning");
 
-        GtkWidget *iopw = gtk_widget_get_parent(module->widget);
-        gtk_box_pack_start(GTK_BOX(iopw), label_widget, TRUE, TRUE, 0);
-        gtk_box_reorder_child(GTK_BOX(iopw), label_widget, 0);
+        gtk_box_pack_start(GTK_BOX(module_parent), label_widget, TRUE, TRUE, 0);
+        gtk_box_reorder_child(GTK_BOX(module_parent), label_widget, 0);
         gtk_widget_show(label_widget);
       }
 
@@ -858,7 +883,9 @@ void expose(dt_view_t *self,
         if(dev->image_invalid_cnt > 8)
         {
           dev->image_invalid_cnt = 0;
-          dt_view_manager_switch(darktable.view_manager, "lighttable");
+          // Do not tear down the darkroom while its expose callback is
+          // still being delivered.
+          dt_ctl_switch_mode_to("lighttable");
           g_free(load_txt);
           return;
         }

--- a/src/views/map.c
+++ b/src/views/map.c
@@ -773,10 +773,12 @@ void init(dt_view_t *self)
 
     gtk_drag_dest_set(GTK_WIDGET(lib->map), GTK_DEST_DEFAULT_ALL,
                       target_list_internal, n_targets_internal, GDK_ACTION_MOVE);
-    dt_gui_connect_scroll(GTK_WIDGET(lib->map),
-                          GTK_EVENT_CONTROLLER_SCROLL_VERTICAL
-                          | GTK_EVENT_CONTROLLER_SCROLL_DISCRETE,
-                          _view_map_scroll_cb, self);
+    GtkEventController *scroll_controller =
+      dt_gui_connect_scroll(GTK_WIDGET(lib->map),
+                            GTK_EVENT_CONTROLLER_SCROLL_VERTICAL
+                            | GTK_EVENT_CONTROLLER_SCROLL_DISCRETE,
+                            _view_map_scroll_cb, self);
+    gtk_event_controller_set_propagation_phase(scroll_controller, GTK_PHASE_CAPTURE);
     g_signal_connect(GTK_WIDGET(lib->map), "drag-data-received",
                      G_CALLBACK(_drag_and_drop_received), self);
     g_signal_connect(GTK_WIDGET(lib->map), "drag-data-get",
@@ -2213,6 +2215,10 @@ static void _view_map_click_pressed_cb(GtkGestureSingle *gesture,
           lib->start_drag_x = root_x;
           lib->start_drag_y = root_y;
           lib->loc.drag = TRUE;
+          // This press starts darktable's location DnD, not map panning.
+          // The former signal handler returned TRUE here; preserve that
+          // consumed-event invariant with the capture-phase gesture.
+          dt_gui_claim(gesture);
           return;
         }
       }
@@ -2242,6 +2248,7 @@ static void _view_map_click_pressed_cb(GtkGestureSingle *gesture,
                                             G_CALLBACK(_view_map_collection_changed), self);
           dt_control_signal_unblock_by_func(darktable.signals,
                                             G_CALLBACK(_view_map_geotag_changed), self);
+          dt_gui_claim(gesture);
           return;
         }
       }
@@ -2262,6 +2269,11 @@ static void _view_map_click_pressed_cb(GtkGestureSingle *gesture,
         lib->start_drag_x = root_x;
         lib->start_drag_y = root_y;
         lib->start_drag = TRUE;
+        /* OsmGpsMap must not see this press and enter its own pan gesture.
+         * GTK DnD takes over after the motion threshold, so OsmGpsMap would
+         * otherwise miss the release and remain visually frozen until the
+         * next click. The pre-controller handler returned TRUE here. */
+        dt_gui_claim(gesture);
       }
     }
     else if(n_press == 2)
@@ -2269,6 +2281,7 @@ static void _view_map_click_pressed_cb(GtkGestureSingle *gesture,
       if(lib->selected_images)
       {
         // open the image in darkroom
+        dt_gui_claim(gesture);
         dt_control_set_mouse_over_id(GPOINTER_TO_INT(lib->selected_images->data));
         dt_ctl_switch_mode_to("darkroom");
       }
@@ -2284,6 +2297,7 @@ static void _view_map_click_pressed_cb(GtkGestureSingle *gesture,
         g_object_get(G_OBJECT(lib->map), "zoom", &zoom, "max-zoom", &max_zoom, NULL);
         zoom = MIN(zoom + 1, max_zoom);
         _view_map_center_on_location(self, longitude, latitude, zoom);
+        dt_gui_claim(gesture);
       }
     }
   }


### PR DESCRIPTION
Fixes #21823
Fixes #21840
Fixes #21862
Fixes #21871
Fixes #21889
Fixes #21891
Could fix #21846, maybe?

This restores several interactions that regressed during the GTK4-preparation work and closes two develop/GUI lifetime races. The fixes remain in separate commits, one per issue:

- **Tooltips now return immediately after Shift+T.** When darktable started with tooltips hidden, the hiding rule was baked into the main theme CSS. Changing the preference could not remove that rule, so tooltips stayed transparent until restart. The rule now lives in its own CSS provider, which is updated whenever the preference changes and kept in sync across theme reloads.

- **Map scrolling and drag-and-drop work normally again.** OsmGpsMap handles input in widget class handlers, before default-phase controllers can see it, so wheel events never reached darktable's map logic. The map controller now runs in the capture phase. Pin drags also claim their initial press so OsmGpsMap does not begin a competing pan and remain stuck after GTK takes over the drag. Filmstrip drag payloads are built from the actual drag origin: dragging a selected image carries the selection, while dragging an unselected image carries only that image.

- **QAP no longer recursively rebuilds itself.** Quick Access Panel activation buttons synchronize their initial state after callbacks are connected. Rebuilding QAP without a GUI-update guard could therefore trigger another visibility update, recursively destroy and recreate the panel, and hang or crash darktable. QAP construction is now treated as a programmatic GUI update on every entry path, including deleting the final character from module search.

- **Mask edits no longer race worker-side viewport validation.** Pixelpipe workers could enter `dt_dev_zoom_move()` and traverse mutable `form_gui` overlay point arrays while the GUI thread rebuilt or freed them. Viewport clamping now has an explicit ownership policy: worker validation uses image geometry only, while GUI/input paths retain overlay-aware bounds for off-image mask handles. This removes worker access to GUI-owned point arrays without introducing another broad lock.

- **Deleting or undoing/redoing IOP instances no longer races running pixelpipes.** Those paths could destroy a module's `gui_data` and `gui_lock` while full, preview, or second-window processing still used them. A shared barrier now requests node shutdown and locks all three screen pipes in one documented order. The barrier covers GUI cleanup, develop-state replacement, and the topology rebuild marker, so no worker can resume old nodes after cleanup. `gui_data` is nulled after synchronized cleanup as defensive stale-pointer hygiene.

- **View switches no longer tear down widgets during GTK event delivery.** PR #21867 deferred only the culling path; filemanager/zoomable thumbtable and other audited direct switch/rebuild callers remained synchronous. The control layer now defers active GTK3 event requests on a high-priority idle, keeps safe non-event requests synchronous, and uses an unconditional idle path for GTK4. Same-view rebuilds use a separate helper so their existing behavior is preserved.

- **Queued darkroom trouble messages no longer use stale IOP widgets.** Rapid switching exposed that asynchronous `DT_SIGNAL_TROUBLE_MESSAGE` payloads carry borrowed module pointers. The darkroom callback now validates active-view and live-IOP membership before dereferencing them, and GUI cleanup clears destroyed widget pointers.

The former Bauhaus popup-hover commit for #21866 was dropped during the rebase because upstream master commit `8ef046192b` now provides the same GTK3 raw-motion fallback and fully subsumes it.

Tested on Linux/Wayland with the full GTK3 build:

- repeated Shift+T tooltip hide/show cycles without restart;
- map wheel zoom, selected and unselected filmstrip drops, repeated pin moves, and immediate redraw/wheel response after dropping;
- QAP with inactive and active exposure controls, repeated group switching, history interaction, incremental module-search deletion, and clear-button use;
- busy tone equalizer and exposure instance duplicate/delete plus repeated Ctrl+Z/Ctrl+Y cycles, both in the main darkroom and with the second window active;
- repeated parametric and drawn-mask edits, geometry changes, off-image handle panning/recentering, OpenCL on/off, and second-window processing;
- `G_DEBUG=fatal-warnings` view-switch coverage for rapid lighttable/darkroom switching, filemanager, zoomable lighttable, culling/full preview, map pins, and keyboard/view switching. The initial rapid-switch run exposed the stale trouble-message lifetime bug; the follow-up run and the remaining matrix completed without crashes or warnings.