### PR TITLE
Fix pixel corruption in 2x2 blocks for 4:2:0 subsampled JPEG 2000 images

### DIFF
--- a/src/imageio/imageio_j2k.c
+++ b/src/imageio/imageio_j2k.c
@@ -505,7 +505,7 @@ static void sycc420_to_rgb(opj_image_t *img)
       sycc_to_rgb(offset, upb, y[rowstart+j], curr_cb, curr_cr, r+rowstart+j, g+rowstart+j, b+rowstart+j);
       sycc_to_rgb(offset, upb, y[rowstart+j+1], curr_cb, curr_cr, r+rowstart+j+1, g+rowstart+j+1, b+rowstart+j+1);
       sycc_to_rgb(offset, upb, y[nextrow+j], curr_cb, curr_cr, r+nextrow+j, g+nextrow+j, b+nextrow+j);
-      sycc_to_rgb(offset, upb, y[nextrow+j+1], curr_cb, *cr, r+nextrow+j+1, g+nextrow+j+1, b+nextrow+j+1);
+      sycc_to_rgb(offset, upb, y[nextrow+j+1], curr_cb, curr_cr, r+nextrow+j+1, g+nextrow+j+1, b+nextrow+j+1);
     }
   }
   free(img->comps[0].data);


### PR DESCRIPTION
The fixed `sycc_to_rgb` call is part of a loop that processes image data for `4:2:0` subsampled images, converting each `2x2` block of pixels. Instead of the cached chroma value as for all other pixels, the first `Cr` value of the entire image was used, which is definitely wrong and probably an undetected typo during code refactoring.