### PR TITLE
Fix workspace selection not remembered at startup

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -208,6 +208,13 @@
     <shortdescription>database location</shortdescription>
     <longdescription>filename relative to ~/.config/darktable or starting with a slash (restart required)</longdescription>
   </dtconfig>
+  <dtconfig common="yes">
+    <name>workspace/label</name>
+    <type>string</type>
+    <default></default>
+    <shortdescription>selected workspace</shortdescription>
+    <longdescription>label of the workspace to open at startup; empty for the default workspace</longdescription>
+  </dtconfig>
   <dtconfig>
     <name>storage/piwigo/last_album</name>
     <type>string</type>

--- a/src/gui/workspace.c
+++ b/src/gui/workspace.c
@@ -40,6 +40,9 @@ typedef struct _workspace_t {
   GtkWidget *template_radio_leader;
   const char *datadir;
   char *selected_template;
+  // TRUE once the user picks or creates a workspace; closing the dialog
+  // without choosing leaves it FALSE
+  gboolean selected;
 } dt_workspace_t;
 
 static gboolean _workspace_label_is_default(const char *label)
@@ -386,6 +389,7 @@ static void _workspace_select_db(GtkWidget *button,
   if(gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(session->remember_selection_check)))
     dt_conf_set_bool("database/multiple_workspace", FALSE);
 
+  session->selected = TRUE;
   _workspace_screen_destroy(session);
 }
 
@@ -444,6 +448,7 @@ static void _workspace_new_db(GtkWidget *button,
     dt_conf_set_bool("database/multiple_workspace", FALSE);
 
   g_free(label);
+  session->selected = TRUE;
   _workspace_screen_destroy(session);
 }
 
@@ -672,10 +677,13 @@ gboolean dt_workspace_create(const char *datadir)
      gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(session->copy_template_check)));
   while(gtk_dialog_run(GTK_DIALOG(session->db_screen)) == GTK_RESPONSE_ACCEPT);
 
+  // only an actual choice may override the per-workspace rc
+  const gboolean selected = session->selected;
+
   _workspace_screen_destroy(session);
   g_free(session);
 
-  return TRUE;
+  return selected;
 }
 
 // clang-format off


### PR DESCRIPTION
Fixes #21928

Pick a workspace, tick "remember selection and don't ask again", restart – and darktable opens the default workspace instead of the one you chose.

Config is read in two passes: `darktablerc-common` first, then `darktablerc-<label>` for whichever workspace we're opening. The label that decides which one to load was only ever written to the second file, so it could only be read once you already knew the answer. With the dialog disabled there was nothing left to tell darktable where to go, and it fell back to the default. Marking `workspace/label` as common puts it in the first file, where it is available in time.

That alone brings a second problem into reach. Now that the label survives a restart, closing the dialog without choosing anything leaves it set while `dt_workspace_create()` still reports a selection was made, and `darktable.c` restores a default `database` over the value the workspace's own rc just supplied – one workspace's settings against another's library. So the dialog now reports whether the user actually picked or created something.