### PR TITLE
Windows Installer: Always ask for install location

### DIFF
--- a/packaging/windows/darktable.iss.in
+++ b/packaging/windows/darktable.iss.in
@@ -32,6 +32,12 @@ AppSupportURL={#MyAppURL}
 AppUpdatesURL={#MyAppURL}
 DefaultDirName={autopf}\{#MyAppName}{code:SuffixIfNotRelease}
 
+; If left unset, this defaults to "auto", which makes Setup silently skip
+; the destination-directory page whenever it detects a previous install
+; with a matching AppId (e.g. when upgrading in place). Always show the
+; page instead, so the install location is confirmable.
+DisableDirPage=no
+
 UninstallDisplayIcon={app}\bin\{#MyAppExeName}
 
 WizardSmallImageFile=${CMAKE_SOURCE_DIR}\data\pixmaps\256x256\darktable.png


### PR DESCRIPTION
There have been numerous mentions on pixls.us (e.g. [here](https://discuss.pixls.us/t/how-to-test-darktable-nightly-alongside-stable-installation-guide/59883/10) that the new installer doesn't ask for the install location if a previous installation is detected. This is inconsistent with the previous NSIS installer (still available for self compilation and in the weekly builds). 

This PR proposes to set `DisableDirPage=no` to ensure the install location-page is always shown (defaults to auto). 

@wpferguson any objections?

Co-Created with Claude.ai Sonnet.