### PR TITLE
Skip auto-applied denoise presets on AI denoised output

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -4009,6 +4009,13 @@
     <longdescription>this folder (and sub-folders) contains PFM/PNG files used by the raster mask import module. (restart required)</longdescription>
   </dtconfig>
 <dtconfig>
+    <name>plugins/lighttable/neural_restore/mark_output</name>
+    <type>bool</type>
+    <default>true</default>
+    <shortdescription>mark AI raw denoise output as denoised</shortdescription>
+    <longdescription>record in the generated DNG that it has already been denoised, so darktable skips auto-applied denoise presets on it. without this an auto-applied denoise preset matches the output as it matched the original, since the file keeps the source ISO, and denoises it a second time</longdescription>
+  </dtconfig>
+  <dtconfig>
     <name>plugins/lighttable/neural_restore/preview_export_size</name>
     <type min="0">int</type>
     <default>0</default>

--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -644,6 +644,14 @@ static bool _exif_decode_xmp_data(dt_image_t *img,
       dt_pthread_mutex_unlock(&darktable.metadata_threadsafe);
     }
 
+    // neural restore stamps its output; this is the only durable record
+    // that the file has already been denoised (issue #21391)
+    if(FIND_XMP_TAG("Xmp.darktable.neural_restore"))
+    {
+      if(pos->toString() == "raw-denoise")
+        img->flags |= DT_IMAGE_AI_DENOISED;
+    }
+
     // If XMP file(s) are found, read the rating from here.
     if(FIND_XMP_TAG("Xmp.darktable.xmp_version")
        || !dt_conf_get_bool("ui_last/ignore_exif_rating"))
@@ -2711,6 +2719,29 @@ gboolean dt_exif_read(dt_image_t *img,
              path,
              e.what());
     return TRUE;
+  }
+}
+
+// must run AFTER dt_exif_write_blob(), which merges the source image's
+// metadata into the output and would otherwise overwrite this
+gboolean dt_exif_xmp_write_neural_restore(const char *path, const char *task)
+{
+  if(!path || !task) return FALSE;
+  try
+  {
+    std::unique_ptr<Exiv2::Image> image(Exiv2::ImageFactory::open(WIDEN(path)));
+    if(!image.get()) return FALSE;
+    read_metadata_threadsafe(image);
+    image->xmpData()["Xmp.darktable.neural_restore"] = task;
+    write_metadata_threadsafe(image);
+    return TRUE;
+  }
+  catch(Exiv2::AnyError &e)
+  {
+    std::string s(e.what());
+    dt_print(DT_DEBUG_ALWAYS,
+             "[exif] dt_exif_xmp_write_neural_restore: %s", s.c_str());
+    return FALSE;
   }
 }
 

--- a/src/common/exif.h
+++ b/src/common/exif.h
@@ -95,6 +95,11 @@ void dt_exif_img_check_additional_tags(dt_image_t *img, const char *filename);
 /** write blob to file exif. merges with existing exif information.*/
 int dt_exif_write_blob(uint8_t *blob, uint32_t size, const char *path, const int compressed);
 
+/** stamp the file as neural restore output. call AFTER
+ * dt_exif_write_blob(), which would otherwise overwrite it with the
+ * source image's metadata. */
+gboolean dt_exif_xmp_write_neural_restore(const char *path, const char *task);
+
 /** write xmp sidecar file. */
 /** if force_write is FALSE, the current contents of the sidecar file are compared against what
     would be written, and the write is skipped if they are the same.  This preserves the sidecar

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -153,6 +153,11 @@ gboolean dt_image_is_ldr(const dt_image_t *img)
             || !strcasecmp(c, ".ppm"));
 }
 
+gboolean dt_image_is_ai_denoised(const dt_image_t *img)
+{
+  return img && (img->flags & DT_IMAGE_AI_DENOISED);
+}
+
 gboolean dt_image_is_hdr(const dt_image_t *img)
 {
   const char *c = img->filename + strlen(img->filename);

--- a/src/common/image.h
+++ b/src/common/image.h
@@ -101,6 +101,9 @@ typedef enum
   DT_IMAGE_MONOCHROME_BAYER = 1 << 19,
   // image has a flag set to use the monochrome workflow in the modules supporting it
   DT_IMAGE_MONOCHROME_WORKFLOW = 1 << 20,
+  // produced by neural restore raw denoise; derived at import from
+  // Xmp.darktable.neural_restore in the file
+  DT_IMAGE_AI_DENOISED = 1 << 21,
 } dt_image_flags_t;
 
 typedef enum dt_image_colorspace_t
@@ -401,6 +404,10 @@ gboolean dt_image_is_bayerRGB(const dt_image_t *img);
 gboolean dt_image_is_matrix_correction_supported(const dt_image_t *img);
 /** returns TRUE if the image supports the rawprepare module */
 gboolean dt_image_is_rawprepare_supported(const dt_image_t *img);
+/** returns TRUE if the image is the output of AI raw denoise, so
+ * denoising it again would be a second pass over denoised data */
+gboolean dt_image_is_ai_denoised(const dt_image_t *img);
+
 /** returns the bitmask containing info about monochrome images */
 int dt_image_monochrome_flags(const dt_image_t *img);
 /** returns TRUE if the image has been tested to be monochrome and the

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -2046,6 +2046,15 @@ static gboolean _dev_auto_apply_presets(dt_develop_t *dev)
 
   const gboolean auto_module = dt_conf_get_bool("darkroom/ui/auto_module_name_update");
 
+  // operations that must not auto-apply on this particular image
+  GString *skip_ops = g_string_new("");
+  if(!is_display_referred)
+    g_string_append(skip_ops, ", 'basecurve'");
+  // already denoised: the output keeps the source ISO, so an ISO-ranged
+  // denoise preset still matches it (issue #21391)
+  if(dt_image_is_ai_denoised(image))
+    g_string_append(skip_ops, ", 'denoiseprofile', 'rawdenoise'");
+
   snprintf(query, sizeof(query),
            "INSERT OR REPLACE INTO memory.history"
            " SELECT ?1, 0, op_version, operation AS op, op_params,"
@@ -2065,7 +2074,7 @@ static gboolean _dev_auto_apply_presets(dt_develop_t *dev)
            // skip non iop modules:
            "   AND operation NOT IN"
            "       ('ioporder', 'metadata', 'modulegroups', 'export',"
-           "        'tagging', 'collect', '%s')"
+           "        'tagging', 'collect'%s)"
            // select all user's auto presets or the hard-coded presets (for the workflow)
            // if non auto-presets for the same operation and matching
            // camera/lens/focal/format/exposure found.
@@ -2094,7 +2103,8 @@ static gboolean _dev_auto_apply_presets(dt_develop_t *dev)
                "  THEN multi_name"
                "  ELSE (ROW_NUMBER() OVER (PARTITION BY operation ORDER BY operation) - 1)"
                " END",
-           is_display_referred ? "" : "basecurve");
+           skip_ops->str);
+  g_string_free(skip_ops, TRUE);
   // clang-format on
 
   // query for all modules at once:

--- a/src/libs/neural_restore.c
+++ b/src/libs/neural_restore.c
@@ -233,6 +233,7 @@ DT_MODULE(1)
 #define CONF_BIT_DEPTH "plugins/lighttable/neural_restore/bit_depth"
 #define CONF_COMPRESSION "plugins/lighttable/neural_restore/compression"
 #define CONF_ADD_CATALOG "plugins/lighttable/neural_restore/add_to_catalog"
+#define CONF_MARK_OUTPUT "plugins/lighttable/neural_restore/mark_output"
 #define CONF_OUTPUT_DIR "plugins/lighttable/neural_restore/output_directory"
 #define CONF_ICC_TYPE "plugins/lighttable/neural_restore/icc_type"
 #define CONF_ICC_FILE "plugins/lighttable/neural_restore/icc_filename"
@@ -545,6 +546,18 @@ static inline float _linear_to_srgb(const float v)
   if(v <= 0.0f) return 0.0f;
   if(v >= 1.0f) return 1.0f;
   return (v <= 0.0031308f) ? 12.92f * v : 1.055f * powf(v, 1.0f / 2.4f) - 0.055f;
+}
+
+// stamp the finished DNG as already denoised. after the writer, which
+// merges the source exif blob in and would overwrite an earlier stamp
+static void _mark_neural_restore_output(const char *path)
+{
+  if(!dt_conf_get_bool(CONF_MARK_OUTPUT)) return;
+
+  if(!dt_exif_xmp_write_neural_restore(path, "raw-denoise"))
+    dt_print(DT_DEBUG_AI,
+             "[neural_restore] could not mark %s as denoised; an "
+             "auto-applied denoise preset may run on it", path);
 }
 
 // pull the camera's embedded JPEG preview from the source raw, to embed
@@ -1335,6 +1348,7 @@ static int _process_raw_denoise_bayer(dt_neural_job_t *j,
   g_free(exif_blob);
   g_free(cfa_out);
   if(res != 0) g_unlink(out_filename);
+  if(res == 0) _mark_neural_restore_output(out_filename);
   return res;
 }
 
@@ -1387,6 +1401,7 @@ static int _process_raw_denoise_linear(dt_neural_job_t *j,
   g_free(exif_blob);
   dt_free_align(rgb);
   if(res != 0) g_unlink(out_filename);
+  if(res == 0) _mark_neural_restore_output(out_filename);
   return res;
 }
 


### PR DESCRIPTION
Fixes #21391

If you have denoise (profiled) as an auto-apply preset, it fires again on the DNG that AI raw denoise produces. The output keeps the source ISO, so an ISO-ranged preset matches it exactly as it matched the original raw – darktable has no way of knowing the work has already been done.

So the DNG now says so itself. The writer stamps `Xmp.darktable.neural_restore = "raw-denoise"` into the file, `dt_exif_read` picks it up at import and sets a new `DT_IMAGE_AI_DENOISED` flag, and `_dev_auto_apply_presets` leaves `denoiseprofile` and `rawdenoise` out of its query for those images – the same trick already used for `basecurve` in a display-referred workflow. Keeping the marker in the file rather than the database means it survives a manual import, a film roll rescan or a rebuilt library.

Only automatic application is suppressed; you can still enable the module yourself, which is what the thread asked for. A preference switches the stamping off for anyone who doesn't want darktable writing that into their files, and says plainly that this also removes the protection.

Astrophoto denoise deliberately stays out of the skip list – auto-applying it is usually a choice. IPTC `DigitalSourceType` would be the standards-correct way to announce this to other software, but it's single-valued and sharpening elsewhere sets the same code, so it can't drive the decision and belongs in its own change.