### PR TITLE
gtk4-prep: preserve history end during darkroom setup

### DIFF
--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -1214,6 +1214,10 @@ static void _update_module_active_class(dt_iop_module_t *module)
 static void _gui_off_callback(GtkToggleButton *togglebutton,
                               dt_iop_module_t *module)
 {
+  /* Always-on modules have no user-toggleable switch.  A toggled signal
+   * during an internal state synchronisation must not create history. */
+  if(module->hide_enable_button) return;
+
   const gboolean basics =
     (dt_dev_modulegroups_get_activated(module->dev) == DT_MODULEGROUP_BASICS);
   const gboolean special = module->flags() & IOP_FLAGS_GUIDES_SPECIAL_DRAW;
@@ -1358,9 +1362,15 @@ void dt_iop_gui_update_header(dt_iop_module_t *module)
   if(!module->header) /* some modules such as overexposed don't actually have a header */
     return;
 
+  /* Updating the toggle state is an internal synchronisation, not a user
+   * action.  Keep it from generating a history item. */
+  DT_ENTER_GUI_UPDATE();
+
   // set panel name to display correct multi-instance
   _iop_panel_name(module);
   dt_iop_gui_set_enable_button(module);
+
+  DT_LEAVE_GUI_UPDATE();
 }
 
 void dt_iop_gui_set_enable_button_icon(GtkWidget *w, dt_iop_module_t *module)
@@ -3314,10 +3324,10 @@ GtkWidget *dt_iop_gui_header_button(dt_iop_module_t *module,
     button = dtgtk_togglebutton_new_full(paint, 0, module,
         &(dtgtk_button_config_t){
           .tooltip = tooltip,
+          .active = module->enabled,
           .toggled_cb = G_CALLBACK(_gui_off_callback),
           .toggled_data = module,
         });
-    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(button), module->enabled);
     gtk_box_pack_start(GTK_BOX(header), button, FALSE, FALSE, 0);
   }
   else
@@ -3453,6 +3463,10 @@ static gboolean _on_drag_drop(GtkWidget *widget,
 
 void dt_iop_gui_set_expander(dt_iop_module_t *module)
 {
+  /* Header construction synchronises the enable button state.  Suppress
+   * those signals while the widget hierarchy is being built. */
+  DT_ENTER_GUI_UPDATE();
+
   GtkWidget *header = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
   gtk_widget_set_name(GTK_WIDGET(header), "module-header");
 
@@ -3606,6 +3620,8 @@ void dt_iop_gui_set_expander(dt_iop_module_t *module)
   dt_ui_container_add_widget(darktable.gui->ui,
                              DT_UI_CONTAINER_PANEL_RIGHT_CENTER, expander);
   dt_iop_show_hide_header_buttons(module, NULL, FALSE, FALSE);
+
+  DT_LEAVE_GUI_UPDATE();
 }
 
 GtkWidget *dt_iop_gui_get_widget(dt_iop_module_t *module)

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -1214,16 +1214,16 @@ static void _update_module_active_class(dt_iop_module_t *module)
 static void _gui_off_callback(GtkToggleButton *togglebutton,
                               dt_iop_module_t *module)
 {
-  /* Always-on modules have no user-toggleable switch.  A toggled signal
-   * during an internal state synchronisation must not create history. */
-  if(module->hide_enable_button) return;
+  /* Always-on modules can still emit toggled during synchronization; only
+   * user-toggleable modules may change processing state or history. */
+  const gboolean user_toggleable = !module->hide_enable_button;
 
-  const gboolean basics =
-    (dt_dev_modulegroups_get_activated(module->dev) == DT_MODULEGROUP_BASICS);
-  const gboolean special = module->flags() & IOP_FLAGS_GUIDES_SPECIAL_DRAW;
-
-  if(!DT_IN_GUI_UPDATE())
+  if(user_toggleable && !DT_IN_GUI_UPDATE())
   {
+    const gboolean basics =
+      (dt_dev_modulegroups_get_activated(module->dev) == DT_MODULEGROUP_BASICS);
+    const gboolean special = module->flags() & IOP_FLAGS_GUIDES_SPECIAL_DRAW;
+
     /* modules with IOP_FLAGS_GUIDES_SPECIAL_DRAW flag like crop & ashift need special care.
         If in expanded state we request focus to let it's gui_focus() callback
         handle this gracefully.
@@ -1472,8 +1472,9 @@ void dt_iop_reload_defaults(dt_iop_module_t *module)
   if(darktable.gui)
     DT_LEAVE_GUI_UPDATE();
 
-  if(module->header)
-    dt_iop_gui_update_header(module);
+  /* This helper owns its GUI-update scope because it is also called
+   * independently from other header synchronization paths. */
+  dt_iop_gui_update_header(module);
 }
 
 void dt_iop_cleanup_histogram(gpointer data, gpointer user_data)
@@ -3328,6 +3329,7 @@ GtkWidget *dt_iop_gui_header_button(dt_iop_module_t *module,
           .toggled_cb = G_CALLBACK(_gui_off_callback),
           .toggled_data = module,
         });
+    gtk_widget_set_sensitive(button, !module->hide_enable_button);
     gtk_box_pack_start(GTK_BOX(header), button, FALSE, FALSE, 0);
   }
   else
@@ -3463,8 +3465,9 @@ static gboolean _on_drag_drop(GtkWidget *widget,
 
 void dt_iop_gui_set_expander(dt_iop_module_t *module)
 {
-  /* Header construction synchronises the enable button state.  Suppress
-   * those signals while the widget hierarchy is being built. */
+  /* Build and synchronise the module UI under a GUI-update guard. Widget
+   * construction can emit state-change signals after callbacks are connected;
+   * none of those signals represent user actions. */
   DT_ENTER_GUI_UPDATE();
 
   GtkWidget *header = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
@@ -3578,7 +3581,6 @@ void dt_iop_gui_set_expander(dt_iop_module_t *module)
                                          header);
   dt_gui_add_class(module->off, "dt_transparent_background");
   dt_iop_gui_set_enable_button_icon(module->off, module);
-  gtk_widget_set_sensitive(module->off, !module->hide_enable_button);
 
   gtk_box_pack_start(GTK_BOX(header), icon, FALSE, FALSE, 0);
   gtk_box_pack_start(GTK_BOX(header), lab, FALSE, FALSE, 0);

--- a/src/dtgtk/button.h
+++ b/src/dtgtk/button.h
@@ -84,7 +84,8 @@ typedef struct dtgtk_button_config_t
   GCallback toggled_cb;
   /** user data passed to toggled_cb */
   gpointer toggled_data;
-  /** initial active state for dtgtk_togglebutton_new_full() */
+  /** initial active state for dtgtk_togglebutton_new_full(); applied before
+   * clicked/toggled callbacks are connected, so initialization is silent */
   gboolean active;
 } dtgtk_button_config_t;
 

--- a/src/dtgtk/button.h
+++ b/src/dtgtk/button.h
@@ -84,6 +84,8 @@ typedef struct dtgtk_button_config_t
   GCallback toggled_cb;
   /** user data passed to toggled_cb */
   gpointer toggled_data;
+  /** initial active state for dtgtk_togglebutton_new_full() */
+  gboolean active;
 } dtgtk_button_config_t;
 
 GtkWidget *dtgtk_button_new_full(DTGTKCairoPaintIconFunc paint,

--- a/src/dtgtk/togglebutton.c
+++ b/src/dtgtk/togglebutton.c
@@ -163,8 +163,7 @@ GtkWidget *dtgtk_togglebutton_new_full(DTGTKCairoPaintIconFunc paint,
                      config->action_label, button, config->action_def);
   /* Set the state before connecting callbacks so initialisation does not
    * look like a user action. */
-  if(config->active)
-    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(button), TRUE);
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(button), config->active);
   /* g_signal_connect() is a type-checking macro that token-pastes the
    * handler name, so the generic factory has to go through
    * g_signal_connect_data() directly. */

--- a/src/dtgtk/togglebutton.c
+++ b/src/dtgtk/togglebutton.c
@@ -161,6 +161,10 @@ GtkWidget *dtgtk_togglebutton_new_full(DTGTKCairoPaintIconFunc paint,
   if(config->action)
     dt_action_define(config->action, config->action_section,
                      config->action_label, button, config->action_def);
+  /* Set the state before connecting callbacks so initialisation does not
+   * look like a user action. */
+  if(config->active)
+    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(button), TRUE);
   /* g_signal_connect() is a type-checking macro that token-pastes the
    * handler name, so the generic factory has to go through
    * g_signal_connect_data() directly. */

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -485,6 +485,9 @@ static void _basics_add_widget(dt_lib_module_t *self, dt_lib_modulegroups_basic_
       gtk_label_set_xalign(GTK_LABEL(lb), 0.0);
       gtk_widget_set_name(lb, "basics-iop_name");
       gtk_container_add(GTK_CONTAINER(evb), lb);
+      /* Keep the label proxy in sync with the enable button.  In particular,
+       * an insensitive button can still be toggled by set_active(). */
+      gtk_widget_set_sensitive(evb, gtk_widget_get_sensitive(btn));
       dt_gui_connect_click(evb, _basics_on_off_label_callback, NULL, btn);
       gtk_box_pack_start(GTK_BOX(item->box), evb, FALSE, TRUE, 0);
 


### PR DESCRIPTION
Fixes #21943 — reopening an image in the darkroom, or restarting darktable after selecting an earlier history step, could move the history end to the top. In some cases an unchanged `output color profile` entry was appended to the history.

This was caused by the IOP enable button being initialized in the wrong order:

- **The toggle callback was connected before the initial state was applied.** Since `dtgtk_togglebutton_new_full()` connected `toggled_cb` before `gtk_toggle_button_set_active()`, initializing an enabled always-on module could look like a user action and append a history item.
- **Always-on modules were not protected from that signal.** Their enable buttons are insensitive, but GTK still emits `toggled` when their state is synchronized. The callback now skips processing-state and history changes for non-user-toggleable modules while still refreshing the button UI.
- **Header synchronization was not consistently marked as a GUI update.** IOP UI construction and header state updates now use the existing `DT_ENTER_GUI_UPDATE()` / `DT_LEAVE_GUI_UPDATE()` pattern, with the synchronization helper owning its own scope where needed.

The shared toggle-button factory now applies the initial active state, including `FALSE`, before connecting callbacks. The configuration documentation makes the silent initialization ordering explicit for future GTK3-to-GTK4 migration work.

Quick-access enable buttons now respect `hide_enable_button` as well, including their label proxies, so always-on modules cannot appear to be toggled off while remaining enabled.

No behavior changes are made to genuine user toggles.

Tested with a complete build. The original restart/history-end test and the darkroom re-entry test both pass.