### PR TITLE
gui: keep background jobs on GTK thread and avoid Windows attention spam

### DIFF
--- a/src/control/jobs/camera_jobs.c
+++ b/src/control/jobs/camera_jobs.c
@@ -266,9 +266,13 @@ void _camera_import_image_downloaded(const dt_camera_t *camera,
   dt_control_queue_redraw_center();
   gchar *basename = g_path_get_basename(filename);
   const int num_images = g_list_length(t->images);
+#ifndef _WIN32
+  /* #21829 / PR #21949: avoid taskbar attention from per-image import
+   * status overlays on Windows. */
   dt_control_log(ngettext("%d/%d imported to %s", "%d/%d imported to %s",
                           t->import_count + 1),
                  t->import_count + 1, num_images, basename);
+#endif
   g_free(basename);
 
   t->fraction += 1.0 / num_images;

--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -3277,7 +3277,12 @@ static int32_t _control_import_job_run(dt_job_t *job)
   }
   g_free(prev_output);
 
+#ifndef _WIN32
+  /* #21829 / PR #21949: this completion overlay can trigger Windows taskbar
+   * attention after an import. The background-job progress already reports
+   * the operation there. */
   dt_control_log(ngettext("imported %d image", "imported %d images", cntr), cntr);
+#endif
   dt_set_darktable_tags();
   dt_control_queue_redraw_center();
   DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_TAG_CHANGED);

--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -2077,8 +2077,16 @@ static int32_t _control_export_job_run(dt_job_t *job)
 
   const guint total = g_list_length(params->index);
   if(total > 0)
+  {
+#ifndef _WIN32
+    /* #21829 / PR #21949: this transient GTK log overlay causes Windows
+     * taskbar attention during inactive background exports. The sidebar job
+     * progress already reports the export on Windows. */
     dt_control_log(ngettext("exporting %d image..", "exporting %d images..", total), total);
+#endif
+  }
   else
+    /* Keep this actionable message on every platform, including Windows. */
     dt_control_log(_("no image to export"));
 
   double fraction = 0;

--- a/src/imageio/storage/disk.c
+++ b/src/imageio/storage/disk.c
@@ -543,8 +543,13 @@ try_again:
   }
 
   dt_print(DT_DEBUG_ALWAYS, "[export_job] exported to `%s'", filename);
+#ifndef _WIN32
+  /* #21829 / PR #21949: keep the per-image success message on platforms
+   * where it is harmless; on Windows the GTK log overlay causes taskbar
+   * attention while darktable is inactive. */
   dt_control_log(ngettext("%d/%d exported to `%s'", "%d/%d exported to `%s'", num),
                  num, total, filename);
+#endif
   return 0;
 }
 

--- a/src/imageio/storage/disk.c
+++ b/src/imageio/storage/disk.c
@@ -469,8 +469,12 @@ try_again:
         // file exists, skip
         dt_pthread_mutex_unlock(&darktable.plugin_threadsafe);
         dt_print(DT_DEBUG_ALWAYS, "[export_job] skipping `%s'", filename);
+#ifndef _WIN32
+        /* #21829 / PR #21949: avoid taskbar attention from per-image export
+         * status overlays on Windows. */
         dt_control_log(ngettext("%d/%d skipping `%s'", "%d/%d skipping `%s'", num),
                        num, total, filename);
+#endif
         return 0;
       }
     }
@@ -517,9 +521,13 @@ try_again:
         {
           dt_pthread_mutex_unlock(&darktable.plugin_threadsafe);
           dt_print(DT_DEBUG_ALWAYS, "[export_job] skipping (not modified since export) `%s'", filename);
+#ifndef _WIN32
+          /* #21829 / PR #21949: avoid taskbar attention from per-image export
+           * status overlays on Windows. */
           dt_control_log(ngettext("%d/%d skipping (not modified since export) `%s'",
                                   "%d/%d skipping (not modified since export) `%s'", num),
                          num, total, filename);
+#endif
           return 0;
         }
       }

--- a/src/imageio/storage/email.c
+++ b/src/imageio/storage/email.c
@@ -192,8 +192,12 @@ int store(dt_imageio_module_storage_t *self,
     return 1;
   }
 
+#ifndef _WIN32
+  /* #21829 / PR #21949: avoid taskbar attention from per-image export
+   * status overlays on Windows. */
   dt_control_log(ngettext("%d/%d exported to `%s'", "%d/%d exported to `%s'", num),
                  num, total, attachment->file);
+#endif
 
   DT_OMP_PRAGMA(critical) // store can be called in parallel, so synch access to shared memory
   d->images = g_list_append(d->images, attachment);

--- a/src/imageio/storage/gallery.c
+++ b/src/imageio/storage/gallery.c
@@ -456,8 +456,12 @@ int store(dt_imageio_module_storage_t *self,
   fdata->max_height = save_max_height;
 
   dt_print(DT_DEBUG_ALWAYS, "[export_job] exported to `%s'", filename);
+#ifndef _WIN32
+  /* #21829 / PR #21949: avoid taskbar attention from per-image export
+   * status overlays on Windows. */
   dt_control_log(ngettext("%d/%d exported to `%s'", "%d/%d exported to `%s'", num),
                  num, total, filename);
+#endif
   return 0;
 }
 

--- a/src/imageio/storage/latex.c
+++ b/src/imageio/storage/latex.c
@@ -371,9 +371,13 @@ int store(dt_imageio_module_storage_t *self, dt_imageio_module_data_t *sdata, co
                     icc_intent, self, sdata, num, total, metadata);
 
   dt_print(DT_DEBUG_ALWAYS, "[export_job] exported to `%s'", filename);
+#ifndef _WIN32
+  /* #21829 / PR #21949: avoid taskbar attention from per-image export
+   * status overlays on Windows. */
   dt_control_log(ngettext("%d/%d exported to `%s'", "%d/%d exported to `%s'",
                           num),
                  num, total, filename);
+#endif
   return 0;
 }
 

--- a/src/imageio/storage/piwigo.c
+++ b/src/imageio/storage/piwigo.c
@@ -1445,6 +1445,9 @@ cleanup:
   g_free(description);
   g_free(author);
 
+#ifndef _WIN32
+  /* #21829 / PR #21949: avoid taskbar attention from per-image export
+   * status overlays on Windows. */
   if(skipped)
   {
     dt_control_log(_("%d/%d skipped (already exists)"), num, total);
@@ -1457,6 +1460,7 @@ cleanup:
                 "%d/%d exported to Piwigo webalbum", num),
        num, total);
   }
+#endif
   return result;
 }
 

--- a/src/libs/backgroundjobs.c
+++ b/src/libs/backgroundjobs.c
@@ -33,8 +33,33 @@ DT_MODULE(1)
 
 typedef struct dt_lib_backgroundjob_element_t
 {
-  GtkWidget *widget, *label, *progressbar, *hbox;
+  /* GTK objects are created and accessed only from the GTK thread. */
+  GtkWidget *widget, *label, *progressbar, *hbox, *parent, *cancel_button;
+
+  dt_pthread_mutex_t mutex;
+  gint references;
+  gboolean destroyed;
+  gboolean has_progress_bar;
+  gboolean cancellable;
+  dt_progress_t *progress;
+  double value;
+  gchar *message;
 } dt_lib_backgroundjob_element_t;
+
+static void _backgroundjob_ref(dt_lib_backgroundjob_element_t *instance)
+{
+  g_atomic_int_inc(&instance->references);
+}
+
+static void _backgroundjob_unref(dt_lib_backgroundjob_element_t *instance)
+{
+  if(g_atomic_int_dec_and_test(&instance->references))
+  {
+    g_free(instance->message);
+    dt_pthread_mutex_destroy(&instance->mutex);
+    free(instance);
+  }
+}
 
 /* proxy functions */
 static void *_lib_backgroundjobs_added(dt_lib_module_t *self, gboolean has_progress_bar, const gchar *message);
@@ -45,6 +70,7 @@ static void _lib_backgroundjobs_updated(dt_lib_module_t *self, dt_lib_background
                                         double value);
 static void _lib_backgroundjobs_message_updated(dt_lib_module_t *self, dt_lib_backgroundjob_element_t *instance,
                                                 const gchar *message);
+static void _add_cancel_button(dt_lib_backgroundjob_element_t *instance, dt_progress_t *progress);
 
 
 const char *name(dt_lib_module_t *self)
@@ -93,8 +119,8 @@ void gui_init(dt_lib_module_t *self)
   for(const GList *iter = darktable.control->progress_system.list; iter; iter = g_list_next(iter))
   {
     dt_progress_t *progress = iter->data;
-    void *gui_data = dt_control_progress_get_gui_data(progress);
-    free(gui_data);
+    dt_lib_backgroundjob_element_t *gui_data = dt_control_progress_get_gui_data(progress);
+    if(gui_data) _backgroundjob_unref(gui_data);
     gui_data = _lib_backgroundjobs_added(self, dt_control_progress_has_progress_bar(progress),
                                          dt_control_progress_get_message(progress));
     dt_control_progress_set_gui_data(progress, gui_data);
@@ -107,13 +133,27 @@ void gui_init(dt_lib_module_t *self)
 
 void gui_cleanup(dt_lib_module_t *self)
 {
-  /* lets kill proxy */
   dt_pthread_mutex_lock(&darktable.control->progress_system.mutex);
+
+  /* Drain GUI instances before dropping the proxy. This also invalidates queued
+   * callbacks when the module is rebuilt while jobs are still running. */
+  for(GList *iter = darktable.control->progress_system.list; iter; iter = g_list_next(iter))
+  {
+    dt_progress_t *progress = iter->data;
+    dt_lib_backgroundjob_element_t *instance = dt_control_progress_get_gui_data(progress);
+    if(instance)
+    {
+      _lib_backgroundjobs_destroyed(self, instance);
+      dt_control_progress_set_gui_data(progress, NULL);
+    }
+  }
+
   darktable.control->progress_system.proxy.module = NULL;
   darktable.control->progress_system.proxy.added = NULL;
   darktable.control->progress_system.proxy.destroyed = NULL;
   darktable.control->progress_system.proxy.cancellable = NULL;
   darktable.control->progress_system.proxy.updated = NULL;
+  darktable.control->progress_system.proxy.message_updated = NULL;
   dt_pthread_mutex_unlock(&darktable.control->progress_system.mutex);
 }
 
@@ -121,104 +161,136 @@ void gui_cleanup(dt_lib_module_t *self)
 
 typedef struct _added_gui_thread_t
 {
-  GtkWidget *self_widget, *instance_widget;
+  dt_lib_module_t *self;
+  dt_lib_backgroundjob_element_t *instance;
 } _added_gui_thread_t;
 
 static gboolean _added_gui_thread(gpointer user_data)
 {
   _added_gui_thread_t *params = (_added_gui_thread_t *)user_data;
+  dt_lib_backgroundjob_element_t *instance = params->instance;
 
-  /* lets show jobbox if its hidden */
-  gtk_box_pack_start(GTK_BOX(params->self_widget), params->instance_widget, TRUE, FALSE, 0);
-  gtk_box_reorder_child(GTK_BOX(params->self_widget), params->instance_widget, 1);
-  gtk_widget_show_all(params->instance_widget);
-  gtk_widget_show(params->self_widget);
+  dt_pthread_mutex_lock(&instance->mutex);
+  if(instance->destroyed || !params->self || !GTK_IS_WIDGET(params->self->widget))
+  {
+    dt_pthread_mutex_unlock(&instance->mutex);
+    _backgroundjob_unref(instance);
+    free(params);
+    return G_SOURCE_REMOVE;
+  }
+
+  instance->parent = params->self->widget;
+  instance->widget = gtk_event_box_new();
+
+  /* initialize the UI elements for the job on the GTK thread */
+  gtk_widget_set_name(instance->widget, "background-job-eventbox");
+  dt_gui_add_class(instance->widget, "dt_big_btn_canvas");
+  GtkBox *vbox = GTK_BOX(gtk_box_new(GTK_ORIENTATION_VERTICAL, 0));
+  instance->hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
+  gtk_container_add(GTK_CONTAINER(instance->widget), GTK_WIDGET(vbox));
+
+  instance->label = gtk_label_new(instance->message);
+  gtk_widget_set_halign(instance->label, GTK_ALIGN_START);
+  gtk_label_set_ellipsize(GTK_LABEL(instance->label), PANGO_ELLIPSIZE_END);
+  gtk_box_pack_start(GTK_BOX(instance->hbox), instance->label, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(vbox), instance->hbox, TRUE, TRUE, 0);
+
+  if(instance->has_progress_bar)
+  {
+    instance->progressbar = gtk_progress_bar_new();
+    gtk_box_pack_start(GTK_BOX(vbox), instance->progressbar, TRUE, FALSE, 0);
+    gtk_progress_bar_set_fraction(GTK_PROGRESS_BAR(instance->progressbar), instance->value);
+  }
+
+  if(instance->cancellable && instance->progress)
+    _add_cancel_button(instance, instance->progress);
+
+  gtk_box_pack_start(GTK_BOX(instance->parent), instance->widget, TRUE, FALSE, 0);
+  gtk_box_reorder_child(GTK_BOX(instance->parent), instance->widget, 1);
+  gtk_widget_show_all(instance->widget);
+  gtk_widget_show(instance->parent);
 
   // instance cursor to tell user that, if this is a blocking job with
   // a global busy cursor, the cancel box in this widget can stop it
-  dt_gui_cursor_set(params->instance_widget, "default", "background-job/instance");
+  dt_gui_cursor_set(instance->widget, "default", "background-job/instance");
 
+  dt_pthread_mutex_unlock(&instance->mutex);
+  _backgroundjob_unref(instance);
   free(params);
   return G_SOURCE_REMOVE;
 }
 
 static void *_lib_backgroundjobs_added(dt_lib_module_t *self, gboolean has_progress_bar, const gchar *message)
 {
-  // add a new gui thingy
+  /* Keep this callback GTK-free: it can be called by a worker thread. */
   dt_lib_backgroundjob_element_t *instance = calloc(1, sizeof(dt_lib_backgroundjob_element_t));
   if(!instance) return NULL;
+
+  dt_pthread_mutex_init(&instance->mutex, NULL);
+  instance->references = 1; // ownership held by dt_progress_t::gui_data
+  instance->has_progress_bar = has_progress_bar;
+  instance->message = g_strdup(message);
+
   _added_gui_thread_t *params = malloc(sizeof(_added_gui_thread_t));
   if(!params)
   {
-    free(instance);
+    _backgroundjob_unref(instance);
     return NULL;
   }
 
-  instance->widget = gtk_event_box_new();
-
-  /* initialize the ui elements for job */
-  gtk_widget_set_name(GTK_WIDGET(instance->widget), "background-job-eventbox");
-  dt_gui_add_class(GTK_WIDGET(instance->widget), "dt_big_btn_canvas");
-  GtkBox *vbox = GTK_BOX(gtk_box_new(GTK_ORIENTATION_VERTICAL, 0));
-  instance->hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-  gtk_container_add(GTK_CONTAINER(instance->widget), GTK_WIDGET(vbox));
-
-  /* add job label */
-  instance->label = gtk_label_new(message);
-  gtk_widget_set_halign(instance->label, GTK_ALIGN_START);
-  gtk_label_set_ellipsize(GTK_LABEL(instance->label), PANGO_ELLIPSIZE_END);
-  gtk_box_pack_start(GTK_BOX(instance->hbox), GTK_WIDGET(instance->label), TRUE, TRUE, 0);
-  gtk_box_pack_start(GTK_BOX(vbox), GTK_WIDGET(instance->hbox), TRUE, TRUE, 0);
-
-  /* use progressbar ? */
-  if(has_progress_bar)
-  {
-    instance->progressbar = gtk_progress_bar_new();
-    gtk_box_pack_start(GTK_BOX(vbox), instance->progressbar, TRUE, FALSE, 0);
-  }
-
-  /* lets show jobbox if its hidden */
-  params->self_widget = self->widget;
-  params->instance_widget = instance->widget;
+  params->self = self;
+  params->instance = instance;
+  _backgroundjob_ref(instance);
   g_main_context_invoke(NULL, _added_gui_thread, params);
 
-  // return the gui thingy container
   return instance;
 }
 
 typedef struct _destroyed_gui_thread_t
 {
-  dt_lib_module_t *self;
   dt_lib_backgroundjob_element_t *instance;
 } _destroyed_gui_thread_t;
 
 static gboolean _destroyed_gui_thread(gpointer user_data)
 {
   _destroyed_gui_thread_t *params = (_destroyed_gui_thread_t *)user_data;
+  dt_lib_backgroundjob_element_t *instance = params->instance;
 
-  /* remove job widget from jobbox */
-  if(params->instance->widget && GTK_IS_WIDGET(params->instance->widget))
-    gtk_container_remove(GTK_CONTAINER(params->self->widget), params->instance->widget);
-  params->instance->widget = NULL;
+  dt_pthread_mutex_lock(&instance->mutex);
+  /* remove the job widget from its parent */
+  if(instance->widget && instance->parent && GTK_IS_WIDGET(instance->widget))
+    gtk_container_remove(GTK_CONTAINER(instance->parent), instance->widget);
+  instance->widget = NULL;
+  instance->label = NULL;
+  instance->progressbar = NULL;
+  instance->hbox = NULL;
 
-  /* if jobbox is empty let's hide */
-  if(!dt_gui_container_has_children(GTK_CONTAINER(params->self->widget)))
-    gtk_widget_hide(params->self->widget);
+  if(instance->parent && GTK_IS_WIDGET(instance->parent)
+     && !dt_gui_container_has_children(GTK_CONTAINER(instance->parent)))
+    gtk_widget_hide(instance->parent);
+  dt_pthread_mutex_unlock(&instance->mutex);
 
-  // free data
-  free(params->instance);
+  _backgroundjob_unref(instance);
   free(params);
   return G_SOURCE_REMOVE;
 }
 
-// remove the gui that is pointed to in instance
+// remove the GUI that is pointed to in instance
 static void _lib_backgroundjobs_destroyed(dt_lib_module_t *self, dt_lib_backgroundjob_element_t *instance)
 {
+  if(!instance) return;
+
+  dt_pthread_mutex_lock(&instance->mutex);
+  instance->destroyed = TRUE;
+  instance->progress = NULL;
+  dt_pthread_mutex_unlock(&instance->mutex);
+
   _destroyed_gui_thread_t *params = malloc(sizeof(_destroyed_gui_thread_t));
   if(!params) return;
-  params->self = self;
   params->instance = instance;
+  _backgroundjob_ref(instance);
   g_main_context_invoke(NULL, _destroyed_gui_thread, params);
+  _backgroundjob_unref(instance);
 }
 
 static void _lib_backgroundjobs_cancel_callback_new(GtkWidget *w, gpointer user_data)
@@ -227,25 +299,35 @@ static void _lib_backgroundjobs_cancel_callback_new(GtkWidget *w, gpointer user_
   dt_control_progress_cancel(progress);
 }
 
+static void _add_cancel_button(dt_lib_backgroundjob_element_t *instance, dt_progress_t *progress)
+{
+  if(!instance->hbox || instance->cancel_button || !progress) return;
+
+  instance->cancel_button = dtgtk_button_new_full(dtgtk_cairo_paint_cancel, 0, NULL,
+      &(dtgtk_button_config_t){
+        .clicked_cb = G_CALLBACK(_lib_backgroundjobs_cancel_callback_new),
+        .clicked_data = progress,
+      });
+  gtk_box_pack_start(GTK_BOX(instance->hbox), instance->cancel_button, FALSE, FALSE, 0);
+  gtk_widget_show_all(instance->cancel_button);
+}
+
 typedef struct _cancellable_gui_thread_t
 {
   dt_lib_backgroundjob_element_t *instance;
-  dt_progress_t *progress;
 } _cancellable_gui_thread_t;
 
 static gboolean _cancellable_gui_thread(gpointer user_data)
 {
   _cancellable_gui_thread_t *params = (_cancellable_gui_thread_t *)user_data;
+  dt_lib_backgroundjob_element_t *instance = params->instance;
 
-  GtkBox *hbox = GTK_BOX(params->instance->hbox);
-  GtkWidget *button = dtgtk_button_new_full(dtgtk_cairo_paint_cancel, 0, NULL,
-      &(dtgtk_button_config_t){
-        .clicked_cb = G_CALLBACK(_lib_backgroundjobs_cancel_callback_new),
-        .clicked_data = params->progress,
-      });
-  gtk_box_pack_start(hbox, GTK_WIDGET(button), FALSE, FALSE, 0);
-  gtk_widget_show_all(button);
+  dt_pthread_mutex_lock(&instance->mutex);
+  if(!instance->destroyed && instance->cancellable)
+    _add_cancel_button(instance, instance->progress);
+  dt_pthread_mutex_unlock(&instance->mutex);
 
+  _backgroundjob_unref(instance);
   free(params);
   return G_SOURCE_REMOVE;
 }
@@ -253,29 +335,38 @@ static gboolean _cancellable_gui_thread(gpointer user_data)
 static void _lib_backgroundjobs_cancellable(dt_lib_module_t *self, dt_lib_backgroundjob_element_t *instance,
                                             dt_progress_t *progress)
 {
-  // add a cancel button to the gui. when clicked we want dt_control_progress_cancel(darktable.control,
+  // add a cancel button to the GUI. when clicked we want dt_control_progress_cancel(darktable.control,
   // progress); to be called
-  if(!dt_control_running()) return;
+  if(!dt_control_running() || !instance) return;
+
+  dt_pthread_mutex_lock(&instance->mutex);
+  instance->cancellable = TRUE;
+  instance->progress = progress;
+  dt_pthread_mutex_unlock(&instance->mutex);
 
   _cancellable_gui_thread_t *params = malloc(sizeof(_cancellable_gui_thread_t));
   if(!params) return;
   params->instance = instance;
-  params->progress = progress;
+  _backgroundjob_ref(instance);
   g_main_context_invoke(NULL, _cancellable_gui_thread, params);
 }
 
 typedef struct _update_gui_thread_t
 {
   dt_lib_backgroundjob_element_t *instance;
-  double value;
 } _update_gui_thread_t;
 
 static gboolean _update_gui_thread(gpointer user_data)
 {
   _update_gui_thread_t *params = (_update_gui_thread_t *)user_data;
+  dt_lib_backgroundjob_element_t *instance = params->instance;
 
-  gtk_progress_bar_set_fraction(GTK_PROGRESS_BAR(params->instance->progressbar), CLAMP(params->value, 0, 1.0));
+  dt_pthread_mutex_lock(&instance->mutex);
+  if(!instance->destroyed && instance->progressbar)
+    gtk_progress_bar_set_fraction(GTK_PROGRESS_BAR(instance->progressbar), CLAMP(instance->value, 0, 1.0));
+  dt_pthread_mutex_unlock(&instance->mutex);
 
+  _backgroundjob_unref(instance);
   free(params);
   return G_SOURCE_REMOVE;
 }
@@ -284,28 +375,35 @@ static void _lib_backgroundjobs_updated(dt_lib_module_t *self, dt_lib_background
                                         double value)
 {
   // update the progress bar
-  if(!dt_control_running()) return;
+  if(!dt_control_running() || !instance) return;
+
+  dt_pthread_mutex_lock(&instance->mutex);
+  instance->value = CLAMP(value, 0, 1.0);
+  dt_pthread_mutex_unlock(&instance->mutex);
 
   _update_gui_thread_t *params = malloc(sizeof(_update_gui_thread_t));
   if(!params) return;
   params->instance = instance;
-  params->value = value;
+  _backgroundjob_ref(instance);
   g_main_context_invoke(NULL, _update_gui_thread, params);
 }
 
 typedef struct _update_label_gui_thread_t
 {
   dt_lib_backgroundjob_element_t *instance;
-  char *message;
 } _update_label_gui_thread_t;
 
 static gboolean _update_message_gui_thread(gpointer user_data)
 {
   _update_label_gui_thread_t *params = (_update_label_gui_thread_t *)user_data;
+  dt_lib_backgroundjob_element_t *instance = params->instance;
 
-  gtk_label_set_text(GTK_LABEL(params->instance->label), params->message);
+  dt_pthread_mutex_lock(&instance->mutex);
+  if(!instance->destroyed && instance->label)
+    gtk_label_set_text(GTK_LABEL(instance->label), instance->message);
+  dt_pthread_mutex_unlock(&instance->mutex);
 
-  g_free(params->message);
+  _backgroundjob_unref(instance);
   free(params);
   return G_SOURCE_REMOVE;
 }
@@ -313,13 +411,17 @@ static gboolean _update_message_gui_thread(gpointer user_data)
 static void _lib_backgroundjobs_message_updated(dt_lib_module_t *self, dt_lib_backgroundjob_element_t *instance,
                                                 const char *message)
 {
-  // update the progress bar
-  if(!dt_control_running()) return;
+  if(!dt_control_running() || !instance) return;
+
+  dt_pthread_mutex_lock(&instance->mutex);
+  g_free(instance->message);
+  instance->message = g_strdup(message);
+  dt_pthread_mutex_unlock(&instance->mutex);
 
   _update_label_gui_thread_t *params = malloc(sizeof(_update_label_gui_thread_t));
   if(!params) return;
   params->instance = instance;
-  params->message = g_strdup(message);
+  _backgroundjob_ref(instance);
   g_main_context_invoke(NULL, _update_message_gui_thread, params);
 }
 


### PR DESCRIPTION
Fixes #21829

The background-jobs panel was creating GTK widgets from worker threads and only queueing their packing/showing. This made widget creation, progress updates, and teardown timing-dependent, contributing to platform-specific focus problems.

The panel now keeps worker callbacks GTK-free: they update plain state, while widget creation, updates, cancellation controls, and removal run on the GTK thread. Queued callbacks also keep job data alive and are invalidated during cleanup.

On Windows, repetitive background status overlays are suppressed when they can appear after focus has moved away from darktable:

- **Exports:** per-image success and skip overlays are suppressed for disk, gallery, LaTeX, email, and Piwigo exports. The background-jobs panel still shows `exporting X / N to <storage>` together with the progress bar.
- **Imports:** per-image camera-import overlays and the final batch summary for regular imports are suppressed. The background-jobs panel still shows the import status and updates its progress bar as images are imported.
- **Immediate and actionable messages:** messages such as `no image to export`, import-start messages, and errors remain visible. Linux and macOS keep their original log-overlay behavior.
- **Completion notification:** where the job uses `dt_ui_notify_user()`, the one-time completion notification remains enabled. It is not triggered once per image.

This is a deliberate workaround: I could not find a clean GTK3/Win32 way to show the per-image status overlay without triggering taskbar attention. The sidebar provides the same useful progress information without using `dt_control_log()` for those repetitive updates. There should be one, but we need to dig further on this

Linux GTK3 builds and cancellation/lifecycle stress tests pass. Windows 11 testing confirms no per-image flashing or focus stealing during export while preserving the batch-completion notification.

Related: #21843