### PR TITLE
gtk4-prep: presets refresh pixelpipes after GUI synchronization

### DIFF
--- a/src/gui/presets.c
+++ b/src/gui/presets.c
@@ -1114,6 +1114,11 @@ void dt_gui_presets_apply_preset(const gchar* name,
 
   sqlite3_finalize(stmt);
   dt_iop_gui_update(module);
+  // dt_iop_gui_update() runs inside the GUI-update guard, so module GUI
+  // callbacks cannot refresh the pixelpipes there.  Apply the preset's
+  // parameter changes after leaving that guard; tone equalizer needs this
+  // synchronization to rebuild its luminance cache and histogram.
+  dt_iop_refresh_all(module);
   dt_dev_add_history_item(darktable.develop, module, FALSE);
   gtk_widget_queue_draw(module->widget);
 


### PR DESCRIPTION
Fixes #21946

Applying a preset during GUI synchronization dropped the pixelpipe refresh needed by tone equalizer, leaving its histogram and pickers stale and the cursor at `? EV`. Refresh all pixelpipes after the GUI update guard has ended so the preset rebuilds the luminance cache.