### PR TITLE
darkroom: refresh image info and stabilize panel layout

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -612,10 +612,24 @@ dialog .sidebar row:selected:hover label,
   margin: 0;
 }
 
-/* space the delete button apart from the duplicate buttons */
+/* Keep a fixed action area so its buttons do not move when the delete action
+ * is unavailable for a single image.  See
+ * https://github.com/darktable-org/darktable/pull/21955 for the discussion
+ * of reserving this space to avoid sidebar width changes. */
+.dt_duplicate_ui .dt_duplicate_actions
+{
+  min-width: 4.5em;
+}
+
+.dt_duplicate_ui .dt_duplicate_delete_slot
+{
+  min-width: 1.5em;
+  margin-right: 0.5em;
+}
+
 .dt_duplicate_ui .dt_duplicate_delete
 {
-  margin-left: 0.5em;
+  margin: 0;
 }
 
 /* Set modules name header */

--- a/src/libs/duplicate.c
+++ b/src/libs/duplicate.c
@@ -383,17 +383,35 @@ static void _lib_duplicate_init_callback(gpointer instance, dt_lib_module_t *sel
         .clicked_data = self,
       });
     dt_gui_add_class(bt, "dt_duplicate_delete");
-    //    gtk_widget_set_halign(bt, GTK_ALIGN_END);
     g_object_set_data(G_OBJECT(bt), "imgid", GINT_TO_POINTER(imgid));
 
+    /* Keep the number and actions in a single top row.  The delete slot is
+     * retained when its button is unavailable, so the two active buttons do
+     * not move when switching between images with and without duplicates.
+     * See https://github.com/darktable-org/darktable/pull/21955 for the
+     * discussion of reserving this space to avoid sidebar width changes. */
+    GtkWidget *delete_slot = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
+    dt_gui_add_class(delete_slot, "dt_duplicate_delete_slot");
+    gtk_box_pack_start(GTK_BOX(delete_slot), bt, FALSE, FALSE, 0);
+
+    GtkWidget *buttons = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
+    dt_gui_add_class(buttons, "dt_duplicate_actions");
+    gtk_box_pack_start(GTK_BOX(buttons), delete_slot, FALSE, FALSE, 0);
+    gtk_box_pack_start(GTK_BOX(buttons), bt_dup, FALSE, FALSE, 0);
+    gtk_box_pack_start(GTK_BOX(buttons), bt_orig, FALSE, FALSE, 0);
+
+    GtkWidget *top = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
+    gtk_box_pack_start(GTK_BOX(top), lb, TRUE, TRUE, 0);
+    gtk_box_pack_end(GTK_BOX(top), buttons, FALSE, FALSE, 0);
+
     gtk_grid_attach(GTK_GRID(hb), thumb->w_main, 0, 0, 1, 2);
-    gtk_grid_attach(GTK_GRID(hb), lb, 1, 0, 1, 1);
-    gtk_grid_attach(GTK_GRID(hb), bt_dup, 2, 0, 1, 1);
-    gtk_grid_attach(GTK_GRID(hb), bt_orig, 3, 0, 1, 1);
-    gtk_grid_attach(GTK_GRID(hb), bt, 4, 0, 1, 1);
+    gtk_grid_attach(GTK_GRID(hb), top, 1, 0, 4, 1);
     gtk_grid_attach(GTK_GRID(hb), tb, 1, 1, 4, 1);
 
     gtk_widget_show(hb);
+    gtk_widget_show(top);
+    gtk_widget_show(buttons);
+    gtk_widget_show(delete_slot);
     gtk_widget_show(lb);
     gtk_widget_show(tb);
     gtk_widget_show(bt_dup);
@@ -408,11 +426,13 @@ static void _lib_duplicate_init_callback(gpointer instance, dt_lib_module_t *sel
 
   gtk_widget_show(d->duplicate_box);
 
-  // we have a single image, do not allow it to be removed so hide last bt
-  if(count==1)
+  // We have a single image, so the delete action is not available.  Keep its
+  // slot allocated so adding/removing duplicate versions does not move the
+  // other actions in the row.
+  if(count == 1)
   {
     gtk_widget_set_sensitive(bt, FALSE);
-    gtk_widget_set_visible(bt, FALSE);
+    gtk_widget_hide(bt);
   }
 
   //unblock signals

--- a/src/libs/tools/image_infos.c
+++ b/src/libs/tools/image_infos.c
@@ -33,6 +33,7 @@ DT_MODULE(1)
 typedef struct dt_lib_imageinfo_t
 {
   GtkWidget *tview;
+  dt_imgid_t imgid;
 } dt_lib_imageinfo_t;
 
 const char *name(dt_lib_module_t *self)
@@ -106,8 +107,22 @@ void _lib_imageinfo_update_message(gpointer instance, dt_lib_module_t *self)
 
   // we change the label
   gtk_label_set_markup(GTK_LABEL(d->tview), msg);
+  d->imgid = imgid;
 
   g_free(msg);
+}
+
+/* The image-changed signal is intentionally asynchronous.  A pipe completion
+ * can therefore be the first callback that observes the new image after a
+ * rapid image switch.  Use it as a cheap one-shot consistency check rather
+ * than allowing the line to remain stale until another metadata event. */
+static void _lib_imageinfo_update_message_if_needed(gpointer instance,
+                                                    dt_lib_module_t *self)
+{
+  dt_lib_imageinfo_t *d = self->data;
+  const dt_imgid_t imgid = darktable.develop->image_storage.id;
+  if(dt_is_valid_imgid(imgid) && d->imgid != imgid)
+    _lib_imageinfo_update_message(instance, self);
 }
 
 static void _lib_imageinfo_update_message2(gpointer instance, gpointer imgs, dt_lib_module_t *self)
@@ -138,6 +153,8 @@ void gui_init(dt_lib_module_t *self)
 
   /* lets signup for develop image changed signals */
   DT_CONTROL_SIGNAL_HANDLE(DT_SIGNAL_DEVELOP_IMAGE_CHANGED, _lib_imageinfo_update_message);
+  DT_CONTROL_SIGNAL_HANDLE(DT_SIGNAL_DEVELOP_UI_PIPE_FINISHED,
+                           _lib_imageinfo_update_message_if_needed);
 
   /* signup for develop initialize to update info of current
      image in darkroom when enter */

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -1896,8 +1896,17 @@ static void _darkroom_schedule_footer_redraw(void)
       g_idle_add_full(G_PRIORITY_LOW, _darkroom_footer_redraw_idle, NULL, NULL);
 }
 
-static void _darkroom_ui_redraw_callback(gpointer instance,
-                                          gpointer data)
+static void _darkroom_ui_image_changed_callback(gpointer instance,
+                                                  gpointer data)
+{
+  /* The new pipes are not ready yet.  Redrawing the center here recalculates
+   * viewport bounds and scrollbars against intermediate dimensions, which can
+   * resize the side panels during an image switch. */
+  _darkroom_schedule_footer_redraw();
+}
+
+static void _darkroom_ui_pipe_finish_signal_callback(gpointer instance,
+                                                      gpointer data)
 {
   dt_control_queue_redraw_center();
   _darkroom_schedule_footer_redraw();
@@ -3989,9 +3998,9 @@ void enter(dt_view_t *self)
 
   /* connect to ui pipe finished signal for redraw */
   DT_CONTROL_SIGNAL_HANDLE(DT_SIGNAL_DEVELOP_IMAGE_CHANGED,
-                           _darkroom_ui_redraw_callback);
+                           _darkroom_ui_image_changed_callback);
   DT_CONTROL_SIGNAL_HANDLE(DT_SIGNAL_DEVELOP_UI_PIPE_FINISHED,
-                           _darkroom_ui_redraw_callback);
+                           _darkroom_ui_pipe_finish_signal_callback);
   DT_CONTROL_SIGNAL_HANDLE(DT_SIGNAL_DEVELOP_PREVIEW2_PIPE_FINISHED,
                            _darkroom_ui_preview2_pipe_finish_signal_callback);
   DT_CONTROL_SIGNAL_HANDLE(DT_SIGNAL_TROUBLE_MESSAGE,

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -1822,16 +1822,54 @@ static void skip_b_key_accel_callback(dt_action_t *action)
   _dev_jump_image(dt_action_view(action)->data, -1, TRUE);
 }
 
+static void _darkroom_queue_redraw_tree(GtkWidget *widget);
+
+#if GTK_CHECK_VERSION(4, 0, 0)
+static void _darkroom_queue_redraw_children(GtkWidget *widget)
+{
+  for(GtkWidget *child = gtk_widget_get_first_child(widget);
+      child;
+      child = gtk_widget_get_next_sibling(child))
+    _darkroom_queue_redraw_tree(child);
+}
+#else
+static void _darkroom_queue_redraw_child(GtkWidget *widget, gpointer data)
+{
+  (void)data;
+  _darkroom_queue_redraw_tree(widget);
+}
+#endif
+
+/* Queue every widget in a toolbar, not only its GtkBox.  The darktable
+ * buttons draw their icons from their own draw handler; invalidating just the
+ * parent does not reliably invalidate those child windows on GTK3.  This is
+ * also the GTK4-compatible equivalent of walking a container's children. */
+static void _darkroom_queue_redraw_tree(GtkWidget *widget)
+{
+  if(!widget) return;
+
+  gtk_widget_queue_draw(widget);
+
+#if GTK_CHECK_VERSION(4, 0, 0)
+  _darkroom_queue_redraw_children(widget);
+#else
+  if(GTK_IS_CONTAINER(widget))
+    gtk_container_foreach(GTK_CONTAINER(widget), _darkroom_queue_redraw_child, NULL);
+#endif
+}
+
 static void _darkroom_ui_redraw_callback(gpointer instance,
                                           gpointer data)
 {
   dt_control_queue_redraw_center();
 
-  /* The darkroom image repaint does not invalidate the custom-drawn buttons
-   * in the bottom toolboxes.  Hovering a button does, which made the controls
-   * appear to recover only when the pointer passed over them. */
-  gtk_widget_queue_draw(darktable.view_manager->view_toolbox);
-  gtk_widget_queue_draw(darktable.view_manager->module_toolbox);
+  /* Image changes can invalidate the footer before the asynchronous pipe
+   * completion arrives.  Redraw the actual controls as well as their boxes so
+   * they remain visible while the new image is loading. */
+  _darkroom_queue_redraw_tree(darktable.view_manager->view_toolbox);
+  _darkroom_queue_redraw_tree(darktable.view_manager->module_toolbox);
+  _darkroom_queue_redraw_tree(GTK_WIDGET(dt_ui_get_container(
+    darktable.gui->ui, DT_UI_CONTAINER_PANEL_CENTER_BOTTOM_CENTER)));
 }
 
 // Keep darktable.darkroom_active_imgid_rowid in sync with collection changes. While the active

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -1858,18 +1858,49 @@ static void _darkroom_queue_redraw_tree(GtkWidget *widget)
 #endif
 }
 
+static guint _darkroom_footer_redraw_source = 0;
+
+static void _darkroom_queue_footer_redraw(void)
+{
+  GtkWidget *const widgets[] = {
+    darktable.view_manager->view_toolbox,
+    darktable.view_manager->module_toolbox,
+    GTK_WIDGET(dt_ui_get_container(darktable.gui->ui,
+                                    DT_UI_CONTAINER_PANEL_CENTER_BOTTOM_CENTER))
+  };
+
+  for(guint i = 0; i < G_N_ELEMENTS(widgets); i++)
+    _darkroom_queue_redraw_tree(widgets[i]);
+}
+
+static gboolean _darkroom_footer_redraw_idle(gpointer user_data)
+{
+  _darkroom_footer_redraw_source = 0;
+
+  /* The image-changed signal has several handlers which can resize or
+   * invalidate the footer after this callback runs.  Do not redraw against
+   * those intermediate allocations. */
+  if(dt_view_get_current() != DT_VIEW_DARKROOM) return G_SOURCE_REMOVE;
+
+  _darkroom_queue_footer_redraw();
+  return G_SOURCE_REMOVE;
+}
+
+static void _darkroom_schedule_footer_redraw(void)
+{
+  /* Coalesce image-change and pipe-finished requests.  A low-priority idle
+   * runs after the high-priority signal callbacks and lets GTK settle any
+   * footer layout changes before invalidating the custom-drawn children. */
+  if(!_darkroom_footer_redraw_source)
+    _darkroom_footer_redraw_source =
+      g_idle_add_full(G_PRIORITY_LOW, _darkroom_footer_redraw_idle, NULL, NULL);
+}
+
 static void _darkroom_ui_redraw_callback(gpointer instance,
                                           gpointer data)
 {
   dt_control_queue_redraw_center();
-
-  /* Image changes can invalidate the footer before the asynchronous pipe
-   * completion arrives.  Redraw the actual controls as well as their boxes so
-   * they remain visible while the new image is loading. */
-  _darkroom_queue_redraw_tree(darktable.view_manager->view_toolbox);
-  _darkroom_queue_redraw_tree(darktable.view_manager->module_toolbox);
-  _darkroom_queue_redraw_tree(GTK_WIDGET(dt_ui_get_container(
-    darktable.gui->ui, DT_UI_CONTAINER_PANEL_CENTER_BOTTOM_CENTER)));
+  _darkroom_schedule_footer_redraw();
 }
 
 // Keep darktable.darkroom_active_imgid_rowid in sync with collection changes. While the active

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -1822,10 +1822,16 @@ static void skip_b_key_accel_callback(dt_action_t *action)
   _dev_jump_image(dt_action_view(action)->data, -1, TRUE);
 }
 
-static void _darkroom_ui_pipe_finish_signal_callback(gpointer instance,
-                                                     gpointer data)
+static void _darkroom_ui_redraw_callback(gpointer instance,
+                                          gpointer data)
 {
   dt_control_queue_redraw_center();
+
+  /* The darkroom image repaint does not invalidate the custom-drawn buttons
+   * in the bottom toolboxes.  Hovering a button does, which made the controls
+   * appear to recover only when the pointer passed over them. */
+  gtk_widget_queue_draw(darktable.view_manager->view_toolbox);
+  gtk_widget_queue_draw(darktable.view_manager->module_toolbox);
 }
 
 // Keep darktable.darkroom_active_imgid_rowid in sync with collection changes. While the active
@@ -3913,8 +3919,10 @@ void enter(dt_view_t *self)
   dt_undo_clear(darktable.undo, DT_UNDO_DEVELOP);
 
   /* connect to ui pipe finished signal for redraw */
+  DT_CONTROL_SIGNAL_HANDLE(DT_SIGNAL_DEVELOP_IMAGE_CHANGED,
+                           _darkroom_ui_redraw_callback);
   DT_CONTROL_SIGNAL_HANDLE(DT_SIGNAL_DEVELOP_UI_PIPE_FINISHED,
-                           _darkroom_ui_pipe_finish_signal_callback);
+                           _darkroom_ui_redraw_callback);
   DT_CONTROL_SIGNAL_HANDLE(DT_SIGNAL_DEVELOP_PREVIEW2_PIPE_FINISHED,
                            _darkroom_ui_preview2_pipe_finish_signal_callback);
   DT_CONTROL_SIGNAL_HANDLE(DT_SIGNAL_TROUBLE_MESSAGE,


### PR DESCRIPTION
Fixes #20018

Refresh the image information line after asynchronous image switches, and redraw the darkroom bottom toolboxes on image changes and UI-pipe completion so their custom-drawn buttons do not remain stale until hover.

Follow-up: queue redraws for all footer toolbar descendants, not only the toolbar containers. GTK3 does not reliably invalidate the custom-drawn child buttons when the footer is repainted, which could leave the bottom controls and image info line blank until hover or image processing completed. The child traversal uses GTK3/GTK4-appropriate APIs.

The footer redraw is now deferred and coalesced until image-change signal handlers and pending layout updates have completed, avoiding repainting against intermediate footer allocations and reducing visible flicker when switching images, especially while zoomed in.

Finally, center redraws are deferred until UI-pipe completion. Redrawing the center from the image-change callback could recalculate viewport bounds and scrollbars while the new pixelpipe dimensions were still intermediate, causing transient side-panel resizing and scrollbar jumps during image switches.

The duplicate manager now keeps a fixed action area for each row. When an image has no duplicate versions, the delete action is unavailable, but its slot remains reserved so the duplicate and virgin-duplicate buttons do not move or cause unwanted sidebar width changes when switching images.