### PR TITLE
Fix dt_cache_get_with_caller to not crash with invalid argument

### DIFF
--- a/src/common/cache.c
+++ b/src/common/cache.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2011-2025 darktable developers.
+    Copyright (C) 2011-2026 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -136,6 +136,14 @@ dt_cache_entry_t *dt_cache_get_with_caller(dt_cache_t *cache,
                                            const char *file,
                                            const int line)
 {
+  if(!cache)
+  {
+    dt_print(DT_DEBUG_ALWAYS,
+             "[dt_cache_get] called with NULL cache, this should not happen; "
+             "caller: %s, %d", file, line);
+    return NULL;
+  }
+
   gpointer orig_key, value;
   const double start = dt_get_debug_wtime();
 restart:

--- a/src/common/image_cache.c
+++ b/src/common/image_cache.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2009-2025 darktable developers.
+    Copyright (C) 2009-2026 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -252,6 +252,9 @@ dt_image_t *dt_image_cache_get(const dt_imgid_t imgid,
     return NULL;
 
   dt_cache_entry_t *entry = dt_cache_get(&cache->cache, imgid, mode);
+  if(!entry)
+    return NULL;
+
   ASAN_UNPOISON_MEMORY_REGION(entry->data, sizeof(dt_image_t));
   dt_image_t *img = entry->data;
   img->cache_entry = entry;

--- a/src/common/mipmap_cache.c
+++ b/src/common/mipmap_cache.c
@@ -961,6 +961,8 @@ void dt_mipmap_cache_get_with_caller(dt_mipmap_buffer_t *buf,
     // simple case: blocking get
     dt_cache_entry_t *entry =
       dt_cache_get_with_caller(&_get_cache(cache, mip)->cache, key, mode, file, line);
+    if(!entry)
+      return;
 
     ASAN_UNPOISON_MEMORY_REGION(entry->data, dt_mipmap_buffer_dsc_size);
 
@@ -1069,6 +1071,9 @@ void dt_mipmap_cache_get_with_caller(dt_mipmap_buffer_t *buf,
       dt_cache_release(&_get_cache(cache, mip)->cache, entry);
       // get a read lock
       buf->cache_entry = entry = dt_cache_get(&_get_cache(cache, mip)->cache, key, mode);
+      if(!entry)
+        return;
+
       ASAN_UNPOISON_MEMORY_REGION(entry->data, dt_mipmap_buffer_dsc_size);
       entry->_lock_demoting = FALSE;
       dsc = (dt_mipmap_buffer_dsc_t *)buf->cache_entry->data;


### PR DESCRIPTION
The problem this PR fixes is actually happening to users, as confirmed by many issues over the years, including the latest release. Due to some yet-to-be-discovered root cause, some calls to functions that return a cache key (dt_cache_get_with_caller or dt_cache_get, which are just a wrapper to hide irrelevant arguments) pass NULL as the cache reference argument to that function.

Unprepared for the possibility of such an erroneous call, the function was not protected against this and, without checking, dereferenced the received argument, which led to a crash.

Issues: #17114, #17848, #20976, #21108, #21790.

This problem could also be the cause of crashes in other issues that described data-dependent crashes, i.e., which did not occur when running with an empty configuration. However, without a provided backtrace pointing to dt_cache_get_with_caller before the crash, it's impossible to know for sure.

### What this PR does:
- Avoids the specific crash described above. Logs information from where the bad call was made.

### What this PR doesn't do:
- It doesn't guarantee that the crash won't happen somewhere else after we fix this specific thing.
- It doesn't fix the root cause (which remains unknown) of why the call with the invalid parameter occurred.

So far, I can't even be sure if this situation can be reproduced deterministically when importing specific files whose features trigger the buggy path in the program. I can't rule out that this happens due to a race condition, for example. None of the issues I read had this information. Even where the bug reporter provided the alleged culprit files, he did not write that he tried and repeatedly got the program to crash after importing the files.

For 5.6.1, it eliminates crashes that are actually happening to users and is obviously safe.
