### PR TITLE
Do not exit darktable if mipmap buffer allocation fails

### DIFF
--- a/src/common/mipmap_cache.c
+++ b/src/common/mipmap_cache.c
@@ -496,8 +496,9 @@ static void _mipmap_cache_allocate_dynamic(void *data,
     // dt_print(DT_DEBUG_ALWAYS, "[mipmap cache] alloc dynamic for key %u %p", key, *buf);
     if(!(entry->data))
     {
+      entry->data = (void *)_mipmap_cache_static_dead_image;
       dt_print(DT_DEBUG_ALWAYS, "[mipmap_cache] memory allocation failed!");
-      exit(1);
+      return;
     }
 
     dsc = entry->data;


### PR DESCRIPTION
We terminate the process (and kill unsaved work) if we cannot allocate memory for the mipmap buffer.  This is a bad response to a (possibly temporary) memory shortage. And since we don't have `atexit()`, it's actually not much different from crashing in terms of saving the user's work.

The code that terminates the program on memory allocation failure is almost 15 years old, so you could say that it can wait a few more months. 🙂  OTOH, the fix is ​​safe and I suggest adding it to 5.6.1.

