### PR TITLE
masks: fix path/brush shape and node drag snapping on release

### DIFF
--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -2135,28 +2135,18 @@ static int _brush_events_button_released(dt_iop_module_t *module,
   }
   else if(gui->form_dragging)
   {
-    // we end the form dragging
+    // the move was already applied incrementally, tick by tick, in
+    // mouse_moved (each tick recomputes its own delta from the *current*
+    // corner, so the shape is already at the correct final position by the
+    // time the button comes up) -- just finalise. Do NOT recompute pts from
+    // this release event's own pzx/pzy and re-apply a second, independent
+    // delta here: that used the constant press-time anchor (gui->dx/dy)
+    // against whatever position this one event happens to carry, so any
+    // discrepancy between it and the last mouse_moved tick's position -- a
+    // slightly stale/short release event is enough -- silently re-moved the
+    // already-correctly-placed shape a second time (observed live as the
+    // shape snapping to a wrong position right on mouse-up).
     gui->form_dragging = FALSE;
-
-    // we get point0 new values
-    dt_masks_point_brush_t *point = (form->points)->data;
-    float pts[2] = { pzx * wd + gui->dx, pzy * ht + gui->dy };
-    dt_masks_clamp_move_pts(pts, wd, ht);
-    dt_dev_distort_backtransform(darktable.develop, pts, 1);
-    float dx = pts[0] / iwidth - point->corner[0];
-    float dy = pts[1] / iheight - point->corner[1];
-
-    // we move all points
-    for(GList *points = form->points; points; points = g_list_next(points))
-    {
-      point = (dt_masks_point_brush_t *)points->data;
-      point->corner[0] += dx;
-      point->corner[1] += dy;
-      point->ctrl1[0] += dx;
-      point->ctrl1[1] += dy;
-      point->ctrl2[0] += dx;
-      point->ctrl2[1] += dy;
-    }
 
     dt_dev_add_masks_history_item(darktable.develop, module, TRUE);
 
@@ -2167,15 +2157,13 @@ static int _brush_events_button_released(dt_iop_module_t *module,
   }
   else if(gui->source_dragging)
   {
-    // we end the form dragging
+    // same reasoning as gui->form_dragging above: mouse_moved already set
+    // form->source fresh on every tick, so recomputing it again here from
+    // this release event's own pzx/pzy is redundant and risks re-moving the
+    // already-correctly-placed source a second time if this event's
+    // position ever diverges from the last tick's.
     gui->source_dragging = FALSE;
 
-    // we change the source value
-    float pts[2] = { pzx * wd + gui->dx, pzy * ht + gui->dy };
-    dt_masks_clamp_move_pts(pts, wd, ht);
-    dt_dev_distort_backtransform(darktable.develop, pts, 1);
-    form->source[0] = pts[0] / iwidth;
-    form->source[1] = pts[1] / iheight;
     dt_dev_add_masks_history_item(darktable.develop, module, TRUE);
 
     // we recreate the form points
@@ -2191,8 +2179,15 @@ static int _brush_events_button_released(dt_iop_module_t *module,
   }
   else if(gui->point_dragging >= 0)
   {
-    dt_masks_point_brush_t *point
-        = (dt_masks_point_brush_t *)g_list_nth_data(form->points, gui->point_dragging);
+    // same reasoning as gui->form_dragging/source_dragging above, just at
+    // node granularity: mouse_moved already set point->corner/ctrl1/ctrl2 to
+    // their fresh absolute position on every tick, so recomputing pts from
+    // this release event's own pzx/pzy and re-applying another delta here is
+    // redundant -- and if this event's position ever diverges from the last
+    // tick's (e.g. a spurious/stale release carrying a leftover (0,0)), it
+    // silently re-moves the already-correctly-placed node a second time,
+    // observed live as the node snapping to the image's top-left corner
+    // right on mouse-up.
     gui->point_dragging = -1;
     if(gui->scrollx != 0.0f || gui->scrolly != 0.0f)
     {
@@ -2200,19 +2195,6 @@ static int _brush_events_button_released(dt_iop_module_t *module,
       return 1;
     }
     gui->scrollx = gui->scrolly = 0;
-    float pts[2] = { pzx * wd, pzy * ht };
-    dt_dev_distort_backtransform(darktable.develop, pts, 1);
-    float dx = pts[0] / iwidth - point->corner[0];
-    float dy = pts[1] / iheight - point->corner[1];
-
-    point->corner[0] += dx;
-    point->corner[1] += dy;
-    point->ctrl1[0] += dx;
-    point->ctrl1[1] += dy;
-    point->ctrl2[0] += dx;
-    point->ctrl2[1] += dy;
-
-    _brush_init_ctrl_points(form);
 
     dt_dev_add_masks_history_item(darktable.develop, module, TRUE);
 

--- a/src/develop/masks/path.c
+++ b/src/develop/masks/path.c
@@ -3587,30 +3587,20 @@ static int _path_events_button_released(dt_iop_module_t *module,
 
   if(gui->form_dragging)
   {
-    // we end the form dragging
+    // the move was already applied incrementally, tick by tick, in
+    // mouse_moved (each tick recomputes its own delta from the *current*
+    // corner, so the shape is already at the correct final position by the
+    // time the button comes up) -- just finalise. Do NOT recompute pts from
+    // this release event's own pzx/pzy and re-apply a second, independent
+    // delta here: that used the constant press-time anchor (gui->dx/dy)
+    // against whatever position this one event happens to carry, so any
+    // discrepancy between it and the last mouse_moved tick's position -- a
+    // slightly stale/short release event is enough -- silently re-moved the
+    // already-correctly-placed shape a second time, observed live as the
+    // shape snapping to a wrong position (typically the image's top-left
+    // corner) right on mouse-up.
     gui->form_dragging = FALSE;
 
-    // we get point0 new values
-    dt_masks_point_path_t *point = form->points->data;
-    float pts[2] = { pzx * wd + gui->dx, pzy * ht + gui->dy };
-    dt_masks_clamp_move_pts(pts, wd, ht);
-    dt_dev_distort_backtransform(darktable.develop, pts, 1);
-    const float dx = pts[0] / iwidth - point->corner[0];
-    const float dy = pts[1] / iheight - point->corner[1];
-
-    // we move all points
-    for(GList *points = form->points; points; points = g_list_next(points))
-    {
-      point = (dt_masks_point_path_t *)points->data;
-      point->corner[0] += dx;
-      point->corner[1] += dy;
-      point->ctrl1[0] += dx;
-      point->ctrl1[1] += dy;
-      point->ctrl2[0] += dx;
-      point->ctrl2[1] += dy;
-    }
-
-    _resize_state_invalidate(form->formid);
     dt_dev_add_masks_history_item(darktable.develop, module, TRUE);
 
     // we recreate the form points
@@ -3642,15 +3632,13 @@ static int _path_events_button_released(dt_iop_module_t *module,
   }
   else if(gui->source_dragging)
   {
-    // we end the form dragging
+    // same reasoning as gui->form_dragging just above: mouse_moved already
+    // set form->source fresh on every tick, so recomputing it again here
+    // from this release event's own pzx/pzy is redundant and risks
+    // re-moving the already-correctly-placed source a second time if this
+    // event's position ever diverges from the last tick's.
     gui->source_dragging = FALSE;
 
-    // we change the source value
-    float pts[2] = { pzx * wd + gui->dx, pzy * ht + gui->dy };
-    dt_masks_clamp_move_pts(pts, wd, ht);
-    dt_dev_distort_backtransform(darktable.develop, pts, 1);
-    form->source[0] = pts[0] / iwidth;
-    form->source[1] = pts[1] / iheight;
     dt_dev_add_masks_history_item(darktable.develop, module, TRUE);
 
     // we recreate the form points
@@ -3668,8 +3656,16 @@ static int _path_events_button_released(dt_iop_module_t *module,
   }
   else if(gui->point_dragging >= 0)
   {
-    dt_masks_point_path_t *point
-        = (dt_masks_point_path_t *)g_list_nth_data(form->points, gui->point_dragging);
+    // the move was already applied, tick by tick, in mouse_moved (each tick
+    // sets point->corner/ctrl1/ctrl2 to their fresh absolute position) -- the
+    // node is already at the correct final position by the time the button
+    // comes up. Do NOT recompute pts from this release event's own pzx/pzy
+    // and re-apply a second, independent delta on top here: same anti-pattern
+    // as gui->form_dragging above, just at node granularity -- an event whose
+    // position happens to differ from the last mouse_moved tick (e.g. a
+    // spurious/stale release carrying a leftover (0,0)) silently re-moved the
+    // already-correctly-placed node a second time, observed live as the node
+    // snapping to the image's top-left corner right on mouse-up.
     gui->point_dragging = -1;
     if(gui->scrollx != 0.0f || gui->scrolly != 0.0f)
     {
@@ -3677,19 +3673,6 @@ static int _path_events_button_released(dt_iop_module_t *module,
       return 1;
     }
     gui->scrollx = gui->scrolly = 0;
-    float pts[2] = { pzx * wd, pzy * ht };
-    dt_dev_distort_backtransform(darktable.develop, pts, 1);
-    const float dx = pts[0] / iwidth - point->corner[0];
-    const float dy = pts[1] / iheight - point->corner[1];
-
-    point->corner[0] += dx;
-    point->corner[1] += dy;
-    point->ctrl1[0] += dx;
-    point->ctrl1[1] += dy;
-    point->ctrl2[0] += dx;
-    point->ctrl2[1] += dy;
-
-    _path_init_ctrl_points(form);
 
     _resize_state_invalidate(form->formid);
     dt_dev_add_masks_history_item(darktable.develop, module, TRUE);


### PR DESCRIPTION

Fixes #21964.

`_path_events_mouse_moved` and `_brush_events_mouse_moved` already move the dragged shape, clone/heal source, or individual node to its correct absolute position on every tick, recomputing the delta from the _current_ position each time. The matching `_*_events_button_released` handlers for `gui->form_dragging`, `gui->source_dragging`, and `gui->point_dragging` then redundantly recomputed a target position from the release event's own `pzx`/`pzy` (for form/source, combined with the stale press-time `gui->dx`/`gui->dy` anchor) and applied it as a second, independent delta on top of the already-correct position.

Whenever the release event's coordinates diverged even slightly from the last `mouse_moved` tick's — e.g. a short/stale release event carrying a leftover `(0, 0)` — this silently moved the shape or node a second time, observed as it snapping to the image's top-left corner right on mouse-up.

**Fix:** on release, just finalize (history item + form recreation) without recomputing/reapplying a delta — mirroring the pattern already used by `form_rotating`/`source_rotating` in the same functions.

Co-authored with Claude.