### PR TITLE
iop/colorequal : fix crosshair flickering & mask-editor visibility in interactive editing

### DIFF
--- a/src/gui/draw.h
+++ b/src/gui/draw.h
@@ -161,20 +161,29 @@ static inline void _dt_draw_cursor_circle(cairo_t *cr,
 /**
  * dt_draw_backbuf_contrast — sample the display pixel under the cursor
  * from the preview pipe backbuf at normalized image position (x, y)
- * into rgb[], and derive frame_color[] used for the overlay lines
+ * into rgb[] exactly (the color equalizer shows it as the in/out circle
+ * fill, so a tiny detail spanning a few pixels must report its true
+ * color), and derive frame_color[] used for the overlay lines
  * (crosshair, wedge outline, circle outlines): white over dark content,
  * black over bright content, so they stay legible on any background.
- * Falls back to mid-grey / white when no backbuf is available.  Shared
- * by all modules drawing the correction cursor so they use identical
- * colors.
+ * The black/white switch is decided from the mean luminance of a square
+ * area covering the drawn cursor instead of a single pixel, so detailed
+ * textures don't flip the lines at every pixel (#21969); callers pass
+ * that area's normalized half-size, e.g. outer_radius / (zoom_scale *
+ * width) to match dt_draw_correction_cursor()'s circle.  Falls back to
+ * mid-grey when no backbuf is available.  Shared by all modules drawing
+ * the correction cursor so they use identical colors.
  */
 static inline void dt_draw_backbuf_contrast(const dt_develop_t *dev,
                                             const float x_norm,
                                             const float y_norm,
                                             float rgb[3],
-                                            float frame_color[3])
+                                            float frame_color[3],
+                                            const float area_half_norm)
 {
-  float r = 0.5f, g = 0.5f, b = 0.5f; // fallback mid-grey
+  float r = 0.5f, g = 0.5f, b = 0.5f;   // exact pixel fallback: mid-grey
+  float luma_sum = 0.0f;
+  int samples = 0;
 
   if(dev && dev->preview_pipe)
   {
@@ -186,13 +195,30 @@ static inline void dt_draw_backbuf_contrast(const dt_develop_t *dev,
     {
       const int px = CLAMP((int)(x_norm * buf_w), 0, buf_w - 1);
       const int py = CLAMP((int)(y_norm * buf_h), 0, buf_h - 1);
+      // the window tracks the cursor footprint and stays an odd size so
+      // px/py remain its exact center and rgb[] the true sampled pixel
+      const int rad = CLAMP((int)lroundf(area_half_norm * buf_w), 1, 48);
+      const int x0 = MAX(px - rad, 0), x1 = MIN(px + rad, buf_w - 1);
+      const int y0 = MAX(py - rad, 0), y1 = MIN(py + rad, buf_h - 1);
 
       dt_pthread_mutex_lock(&dev->preview_pipe->backbuf_mutex);
-      const size_t idx = (size_t)py * buf_w * 4 + px * 4;
-      // backbuf is CAIRO_FORMAT_ARGB32: B, G, R, A byte order on little-endian
-      b = backbuf[idx + 0] / 255.0f;
-      g = backbuf[idx + 1] / 255.0f;
-      r = backbuf[idx + 2] / 255.0f;
+      for(int iy = y0; iy <= y1; iy++)
+        for(int ix = x0; ix <= x1; ix++)
+        {
+          const size_t idx = ((size_t)iy * buf_w + ix) * 4;
+          // backbuf is CAIRO_FORMAT_ARGB32: B, G, R, A byte order on little-endian
+          const float pr = backbuf[idx + 2] / 255.0f;
+          const float pg = backbuf[idx + 1] / 255.0f;
+          const float pb = backbuf[idx + 0] / 255.0f;
+          if(ix == px && iy == py)
+          {
+            r = pr;
+            g = pg;
+            b = pb;
+          }
+          luma_sum += 0.3f * pr + 0.59f * pg + 0.11f * pb;
+          samples++;
+        }
       dt_pthread_mutex_unlock(&dev->preview_pipe->backbuf_mutex);
     }
   }
@@ -201,8 +227,9 @@ static inline void dt_draw_backbuf_contrast(const dt_develop_t *dev,
   rgb[1] = g;
   rgb[2] = b;
 
-  // Rec.601 luma of the sampled background: pick the contrasting shade
-  const float bg_luma = 0.3f * r + 0.59f * g + 0.11f * b;
+  // Rec.601 mean luminance of the window: the plain switch keeps maximal
+  // contrast, the averaging alone is what removes the texture flicker
+  const float bg_luma = samples > 0 ? luma_sum / samples : 0.5f;
   const float shade = (bg_luma > 0.5f) ? 0.0f : 1.0f; // black over bright, white over dark
   frame_color[0] = shade;
   frame_color[1] = shade;

--- a/src/gui/draw.h
+++ b/src/gui/draw.h
@@ -159,6 +159,57 @@ static inline void _dt_draw_cursor_circle(cairo_t *cr,
 }
 
 /**
+ * dt_draw_backbuf_contrast — sample the display pixel under the cursor
+ * from the preview pipe backbuf at normalized image position (x, y)
+ * into rgb[], and derive frame_color[] used for the overlay lines
+ * (crosshair, wedge outline, circle outlines): white over dark content,
+ * black over bright content, so they stay legible on any background.
+ * Falls back to mid-grey / white when no backbuf is available.  Shared
+ * by all modules drawing the correction cursor so they use identical
+ * colors.
+ */
+static inline void dt_draw_backbuf_contrast(const dt_develop_t *dev,
+                                            const float x_norm,
+                                            const float y_norm,
+                                            float rgb[3],
+                                            float frame_color[3])
+{
+  float r = 0.5f, g = 0.5f, b = 0.5f; // fallback mid-grey
+
+  if(dev && dev->preview_pipe)
+  {
+    uint8_t *backbuf = dev->preview_pipe->backbuf;
+    const int buf_w = dev->preview_pipe->backbuf_width;
+    const int buf_h = dev->preview_pipe->backbuf_height;
+
+    if(backbuf && buf_w > 0 && buf_h > 0)
+    {
+      const int px = CLAMP((int)(x_norm * buf_w), 0, buf_w - 1);
+      const int py = CLAMP((int)(y_norm * buf_h), 0, buf_h - 1);
+
+      dt_pthread_mutex_lock(&dev->preview_pipe->backbuf_mutex);
+      const size_t idx = (size_t)py * buf_w * 4 + px * 4;
+      // backbuf is CAIRO_FORMAT_ARGB32: B, G, R, A byte order on little-endian
+      b = backbuf[idx + 0] / 255.0f;
+      g = backbuf[idx + 1] / 255.0f;
+      r = backbuf[idx + 2] / 255.0f;
+      dt_pthread_mutex_unlock(&dev->preview_pipe->backbuf_mutex);
+    }
+  }
+
+  rgb[0] = r;
+  rgb[1] = g;
+  rgb[2] = b;
+
+  // Rec.601 luma of the sampled background: pick the contrasting shade
+  const float bg_luma = 0.3f * r + 0.59f * g + 0.11f * b;
+  const float shade = (bg_luma > 0.5f) ? 0.0f : 1.0f; // black over bright, white over dark
+  frame_color[0] = shade;
+  frame_color[1] = shade;
+  frame_color[2] = shade;
+}
+
+/**
  * dt_draw_correction_cursor — the on-canvas cursor shown by iop modules
  * that let the user adjust a per-pixel correction by hovering/scrolling
  * over the image (tone equalizer, color equalizer, ...): a crosshair

--- a/src/iop/colorequal.c
+++ b/src/iop/colorequal.c
@@ -2321,16 +2321,12 @@ static void _switch_cursors(dt_iop_module_t *self)
   dt_iop_colorequal_gui_data_t *g = self->gui_data;
   if(!g || !self->dev->gui_attached) return;
 
-  GtkWidget *widget = dt_ui_main_window(darktable.gui->ui);
-
   // Editing a mask (brush/path/etc.) or canvas otherwise not interactive:
   // leave the default cursor alone.
   if((self->dev->form_gui && self->dev->form_gui->creation)
      || dt_iop_canvas_not_sensitive(self->dev))
   {
-    GdkCursor *const cursor = gdk_cursor_new_from_name(gdk_display_get_default(), "default");
-    gdk_window_set_cursor(gtk_widget_get_window(widget), cursor);
-    g_object_unref(cursor);
+    dt_control_change_cursor("default");
     return;
   }
 
@@ -2346,9 +2342,7 @@ static void _switch_cursors(dt_iop_module_t *self)
   }
   else
   {
-    GdkCursor *const cursor = gdk_cursor_new_from_name(gdk_display_get_default(), "default");
-    gdk_window_set_cursor(gtk_widget_get_window(widget), cursor);
-    g_object_unref(cursor);
+    dt_control_change_cursor("default");
   }
 }
 

--- a/src/iop/colorequal.c
+++ b/src/iop/colorequal.c
@@ -2309,6 +2309,16 @@ void init_presets(dt_iop_module_so_t *self)
                              TRUE, DEVELOP_BLEND_CS_RGB_SCENE);
 }
 
+/* in_mask_editing — returns TRUE when the mask editor UI is visible
+ * (form_gui exists and form_visible is set), so that the correction
+ * cursor can be hidden consistently with tone equalizer behavior.
+ */
+static gboolean in_mask_editing(const dt_iop_module_t *self)
+{
+  const dt_develop_t *dev = self->dev;
+  return dev->form_gui && dev->form_visible;
+}
+
 /* _switch_cursors — mirrors the tone equalizer's on-canvas cursor
  * handling: hide the native GTK cursor so only our own indicator
  * (gui_post_expose) is visible while a valid reading is available,
@@ -2323,8 +2333,7 @@ static void _switch_cursors(dt_iop_module_t *self)
 
   // Editing a mask (brush/path/etc.) or canvas otherwise not interactive:
   // leave the default cursor alone.
-  if((self->dev->form_gui && self->dev->form_gui->creation)
-     || dt_iop_canvas_not_sensitive(self->dev))
+  if(in_mask_editing(self) || dt_iop_canvas_not_sensitive(self->dev))
   {
     dt_control_change_cursor("default");
     return;
@@ -2712,8 +2721,8 @@ int mouse_moved(dt_iop_module_t *self,
   dt_iop_colorequal_gui_data_t *g = self->gui_data;
   if(!g) return 0;
 
-  // Disable cursor tracking when drawing a mask (brush/path/etc.)
-  if(self->dev->form_gui && self->dev->form_gui->creation)
+  // Disable cursor tracking when mask editor is visible
+  if(in_mask_editing(self))
   {
     g->cursor_valid = FALSE;
     _switch_cursors(self);
@@ -2835,8 +2844,8 @@ void gui_post_expose(dt_iop_module_t *self,
   dt_iop_colorequal_gui_data_t *g = self->gui_data;
   if(!g || !g->cursor_valid) return;
 
-  // Hide cursor indicator when drawing a mask (brush/path/etc.)
-  if(self->dev->form_gui && self->dev->form_gui->creation) return;
+  // Hide cursor indicator when mask editor is visible
+  if(in_mask_editing(self)) return;
 
   // Sampled display color under the cursor + contrasting line color,
   // shared with the tone equalizer's cursor via gui/draw.h.

--- a/src/iop/colorequal.c
+++ b/src/iop/colorequal.c
@@ -2844,28 +2844,12 @@ void gui_post_expose(dt_iop_module_t *self,
   // Hide cursor indicator when drawing a mask (brush/path/etc.)
   if(self->dev->form_gui && self->dev->form_gui->creation) return;
 
-  // Read the color from the preview pipe backbuf
-  dt_develop_t *dev = self->dev;
-  dt_pthread_mutex_t *mutex = &dev->preview_pipe->backbuf_mutex;
-  uint8_t *backbuf = dev->preview_pipe->backbuf;
-  const int buf_w = dev->preview_pipe->backbuf_width;
-  const int buf_h = dev->preview_pipe->backbuf_height;
-
-  float cr_f = 0.5f, cg_f = 0.5f, cb_f = 0.5f; // fallback grey
-
-  if(backbuf && buf_w > 0 && buf_h > 0)
-  {
-    const int px = CLAMP((int)(g->cursor_pos_x * buf_w), 0, buf_w - 1);
-    const int py = CLAMP((int)(g->cursor_pos_y * buf_h), 0, buf_h - 1);
-
-    dt_pthread_mutex_lock(mutex);
-    const size_t idx = (size_t)py * buf_w * 4 + px * 4;
-    // backbuf is CAIRO_FORMAT_ARGB32: B, G, R, A byte order on little-endian
-    cb_f = backbuf[idx + 0] / 255.0f;
-    cg_f = backbuf[idx + 1] / 255.0f;
-    cr_f = backbuf[idx + 2] / 255.0f;
-    dt_pthread_mutex_unlock(mutex);
-  }
+  // Sampled display color under the cursor + contrasting line color,
+  // shared with the tone equalizer's cursor via gui/draw.h.
+  float bg_rgb[3];
+  float frame_color[3];
+  dt_draw_backbuf_contrast(self->dev, g->cursor_pos_x, g->cursor_pos_y,
+                           bg_rgb, frame_color);
 
   // Position in full image coordinates
   const float cx = g->cursor_pos_x * width;
@@ -2897,8 +2881,8 @@ void gui_post_expose(dt_iop_module_t *self,
   // and scrolled use, stored by process() from the pre-correction values).
   // The "out" color replays the exact process() correction math — the three
   // RBF LUTs from the current params combined as in STEP 4/5 of process().
-  float in_color[3]  = { cr_f, cg_f, cb_f };
-  float out_color[3] = { cr_f, cg_f, cb_f };
+  float in_color[3]  = { bg_rgb[0], bg_rgb[1], bg_rgb[2] };
+  float out_color[3] = { bg_rgb[0], bg_rgb[1], bg_rgb[2] };
 
   if(g->pd.buf && g->pd.width > 0 && g->pd.height > 0 && g->gamut_LUT)
   {
@@ -2966,13 +2950,6 @@ void gui_post_expose(dt_iop_module_t *self,
       out_color[2] = RGB[2];
     }
   }
-
-  // Crosshair/wedge/outline color adapts to the sampled background, same
-  // spirit as the tone equalizer's cursor: white over dark content, black
-  // over light content, so it stays legible everywhere.
-  const float bg_luma = 0.3f * cr_f + 0.59f * cg_f + 0.11f * cb_f;
-  const float frame_shade = (bg_luma > 0.5f) ? 0.0f : 1.0f;
-  const float frame_color[3] = { frame_shade, frame_shade, frame_shade };
 
   dt_draw_correction_cursor(cr, cx, cy, zoom_scale, correction_norm,
                             frame_color,

--- a/src/iop/colorequal.c
+++ b/src/iop/colorequal.c
@@ -2843,7 +2843,7 @@ void gui_post_expose(dt_iop_module_t *self,
   float bg_rgb[3];
   float frame_color[3];
   dt_draw_backbuf_contrast(self->dev, g->cursor_pos_x, g->cursor_pos_y,
-                           bg_rgb, frame_color);
+                           bg_rgb, frame_color, 16.0f / (zoom_scale * width));
 
   // Position in full image coordinates
   const float cx = g->cursor_pos_x * width;

--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -1971,17 +1971,12 @@ static void switch_cursors(dt_iop_module_t *self)
   if(!g || !self->dev->gui_attached)
     return;
 
-  GtkWidget *widget = dt_ui_main_window(darktable.gui->ui);
-
   // if we are editing masks or using colour-pickers, do not display controls
   if(in_mask_editing(self)
      || dt_iop_canvas_not_sensitive(self->dev))
   {
     // display default cursor
-    GdkCursor *const cursor =
-      gdk_cursor_new_from_name(gdk_display_get_default(), "default");
-    gdk_window_set_cursor(gtk_widget_get_window(widget), cursor);
-    g_object_unref(cursor);
+    dt_control_change_cursor("default");
 
     return;
   }
@@ -2013,10 +2008,7 @@ static void switch_cursors(dt_iop_module_t *self)
   {
     // if module is active and opened but cursor is out of the preview,
     // display default cursor
-    GdkCursor *const cursor =
-      gdk_cursor_new_from_name(gdk_display_get_default(), "default");
-    gdk_window_set_cursor(gtk_widget_get_window(widget), cursor);
-    g_object_unref(cursor);
+    dt_control_change_cursor("default");
 
     dt_control_queue_redraw_center();
   }
@@ -2024,10 +2016,7 @@ static void switch_cursors(dt_iop_module_t *self)
   {
     // in any other situation where module has focus,
     // reset the cursor but don't launch a redraw
-    GdkCursor *const cursor =
-      gdk_cursor_new_from_name(gdk_display_get_default(), "default");
-    gdk_window_set_cursor(gtk_widget_get_window(widget), cursor);
-    g_object_unref(cursor);
+    dt_control_change_cursor("default");
   }
 }
 
@@ -2091,10 +2080,7 @@ int mouse_leave(dt_iop_module_t *self)
   dt_iop_gui_leave_critical_section(self);
 
   // display default cursor
-  GtkWidget *widget = dt_ui_main_window(darktable.gui->ui);
-  GdkCursor *cursor = gdk_cursor_new_from_name(gdk_display_get_default(), "default");
-  gdk_window_set_cursor(gtk_widget_get_window(widget), cursor);
-  g_object_unref(cursor);
+  dt_control_change_cursor("default");
   dt_control_queue_redraw_center();
   gtk_widget_queue_draw(GTK_WIDGET(g->area));
 

--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -2317,7 +2317,8 @@ void gui_post_expose(dt_iop_module_t *self,
   // to convey the before/after luminance.
   float bg_rgb[3];
   float frame_color[3];
-  dt_draw_backbuf_contrast(dev, pointerx, pointery, bg_rgb, frame_color);
+  dt_draw_backbuf_contrast(dev, pointerx, pointery, bg_rgb, frame_color,
+                           16.0f / (zoom_scale * width));
   const float outer_shade = _shade_from_luminance(luminance_in);
   const float inner_shade = _shade_from_luminance(luminance_out);
   const float outer_color[3] = { outer_shade, outer_shade, outer_shade };

--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -2243,7 +2243,9 @@ static inline gboolean _init_drawing(dt_iop_module_t *const restrict self,
 
 // The on-canvas correction cursor itself (crosshair, wedge, circles, text
 // label) is shared with other modules via dt_draw_correction_cursor() in
-// gui/draw.h; only the exposure-specific grey shades fed into it stay here.
+// gui/draw.h, and its contrasting frame color via dt_draw_backbuf_contrast()
+// in the same header; only the exposure-specific grey shades fed into it
+// stay here.
 
 static float _shade_from_luminance(const float luminance)
 {
@@ -2322,29 +2324,14 @@ void gui_post_expose(dt_iop_module_t *self,
   else
     snprintf(text, sizeof(text), "? EV");
 
-  // Sample the pixel under the cursor from the preview pipe backbuf:
-  // white frame lines over dark content, black over bright content,
-  // like the color equalizer's cursor.  The circles keep the
-  // exposure-specific shades below to convey the before/after luminance.
-  uint8_t *backbuf = dev->preview_pipe->backbuf;
-  const int buf_w = dev->preview_pipe->backbuf_width;
-  const int buf_h = dev->preview_pipe->backbuf_height;
-  float cr_f = 0.5f, cg_f = 0.5f, cb_f = 0.5f; // fallback mid-grey
-  if(backbuf && buf_w > 0 && buf_h > 0)
-  {
-    const int px = CLAMP((int)x_pointer, 0, buf_w - 1);
-    const int py = CLAMP((int)y_pointer, 0, buf_h - 1);
-    dt_pthread_mutex_lock(&dev->preview_pipe->backbuf_mutex);
-    const size_t idx = (size_t)py * buf_w * 4 + px * 4;
-    // backbuf is CAIRO_FORMAT_ARGB32: B, G, R, A byte order on little-endian
-    cb_f = backbuf[idx + 0] / 255.0f;
-    cg_f = backbuf[idx + 1] / 255.0f;
-    cr_f = backbuf[idx + 2] / 255.0f;
-    dt_pthread_mutex_unlock(&dev->preview_pipe->backbuf_mutex);
-  }
-  const float bg_luma = 0.3f * cr_f + 0.59f * cg_f + 0.11f * cb_f;
-  const float frame_shade = (bg_luma > 0.5f) ? 0.0f : 1.0f;
-  const float frame_color[3] = { frame_shade, frame_shade, frame_shade };
+  // Sample the display pixel under the cursor from the preview pipe
+  // backbuf and pick the contrasting frame color, shared with the
+  // color equalizer's cursor via dt_draw_backbuf_contrast() in
+  // gui/draw.h.  The circles keep the exposure-specific shades below
+  // to convey the before/after luminance.
+  float bg_rgb[3];
+  float frame_color[3];
+  dt_draw_backbuf_contrast(dev, pointerx, pointery, bg_rgb, frame_color);
   const float outer_shade = _shade_from_luminance(luminance_in);
   const float inner_shade = _shade_from_luminance(luminance_out);
   const float outer_color[3] = { outer_shade, outer_shade, outer_shade };


### PR DESCRIPTION
This PR fixes both issues from ticket #21969, plus a related mask-editor bug in the color equalizer's interactive editing mode (the tone equalizer also benefits via the shared drawing service).

Fixes
Crosshair flickering on high-contrast textures (#21969 part 2)
The crosshair color was decided from a single display pixel, causing rapid black↔white flicker on detailed textures.
-> Now samples a dynamic square area matching the cursor's on-screen footprint (scales with zoom) and uses the mean luminance with the same binary decision. Averaging eliminates flicker while keeping pure white/black contrast on uniform backgrounds.
Crosshair stuck when picker armed via keyboard shortcut (#21969 part 1)
Fixed — the cursor now correctly hides when the picker is activated by shortcut. The root cause was a focus/state issue, resolved by switching to the centralized dt_control_change_cursor() API which respects the lock_cursor_shape guard.
Crosshair not hidden when mask editor is open
Color equalizer only hid the cursor during active brush/path drawing (form_gui->creation). Tone equalizer correctly hides it whenever the mask editor UI is visible (form_visible).
-> Added in_mask_editing() helper (matching tone equalizer) and used it in all three cursor-management sites in colorequal.c.
