### PR TITLE
[imageio] Avoid double free in WebP loader

### DIFF
--- a/src/imageio/imageio_webp.c
+++ b/src/imageio/imageio_webp.c
@@ -148,8 +148,10 @@ dt_imageio_retval_t dt_imageio_open_webp(dt_image_t *img,
   for(int i = 0; i < npixels; i++)
   {
     dt_aligned_pixel_t pix = {0.0f, 0.0f, 0.0f, 0.0f};
+
     for_three_channels(c)
-      pix[c] = *(int_RGBA_buffer + i * 4 + c) / 255.f;
+      pix[c] = int_RGBA_buffer[i * 4 + c] / 255.f;
+
     copy_pixel_nontemporal(&mipbuf[i * 4], pix);
   }
 

--- a/src/imageio/imageio_webp.c
+++ b/src/imageio/imageio_webp.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2022-2024 darktable developers.
+    Copyright (C) 2022-2026 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -137,7 +137,6 @@ dt_imageio_retval_t dt_imageio_open_webp(dt_image_t *img,
   float *mipbuf = (float *)dt_mipmap_cache_alloc(mbuf, img);
   if(!mipbuf)
   {
-    g_free(read_buffer);
     dt_free_align(int_RGBA_buffer);
     dt_print(DT_DEBUG_ALWAYS,
              "[webp_open] could not alloc full buffer for image: %s",


### PR DESCRIPTION
Double free is possible in the WebP loader, although fortunately this will only happen in the case of a failed buffer allocation, i.e. under normal operating conditions this will not happen...