### PR TITLE
[Nightly] Bump libheif version to the latest for AppImage build

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -128,7 +128,7 @@ jobs:
             libxfixes-dev
       - name: Build and install fresh libheif with built-in decoders
         run: |
-          git clone --branch v1.23.1 --depth 1 https://github.com/strukturag/libheif src-libheif
+          git clone --branch v1.23.2 --depth 1 https://github.com/strukturag/libheif src-libheif
           cd src-libheif
           cmake -S . -B build -G Ninja \
             -DCMAKE_BUILD_TYPE=Release \


### PR DESCRIPTION
v1.23.2 is a security release. Two of the fixed issues are rated critical, so all users are strongly advised to upgrade.