### PR TITLE
Remove tautological comparison to avoid compiler warning

### DIFF
--- a/src/ai/backend_common.c
+++ b/src/ai/backend_common.c
@@ -936,7 +936,7 @@ _resolve_ort_optimization(const dt_ai_model_info_t *info,
   }
 
   // per-provider override first
-  if(info->ort_optimization_provider && provider >= 0 && provider < DT_AI_PROVIDER_COUNT)
+  if(info->ort_optimization_provider && provider < DT_AI_PROVIDER_COUNT)
   {
     JsonParser *parser = json_parser_new();
     if(json_parser_load_from_data(parser, info->ort_optimization_provider, -1, NULL))


### PR DESCRIPTION
A very minor change, just to avoid a compiler warning:
```
C:/msys64/home/victor/darktable/src/ai/backend_common.c:939:50: warning: result of comparison of unsigned enum expression >= 0 is always true [-Wtautological-unsigned-enum-zero-compare]
  939 |   if(info->ort_optimization_provider && provider >= 0 && provider < DT_AI_PROVIDER_COUNT)
      |                                         ~~~~~~~~ ^  ~
1 warning generated.
```
