### PR TITLE
lua: stop dt.control.execute from flashing a console window on Windows

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -83,6 +83,7 @@ FILE(GLOB SOURCE_FILES
   "common/pdf.c"
   "common/pfm.c"
   "common/presets.c"
+  "common/process.c"
   "common/pwstorage/backend_kwallet.c"
   "common/pwstorage/pwstorage.c"
   "common/ras2vect.c"

--- a/src/common/process.c
+++ b/src/common/process.c
@@ -1,0 +1,61 @@
+/*
+  This file is part of darktable,
+  Copyright (C) 2026 darktable developers.
+
+  darktable is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  darktable is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "common/process.h"
+
+#include <glib.h>
+#include <stdlib.h>
+
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
+int dt_exec_command_sync(const char *cmd)
+{
+#ifdef _WIN32
+  if(!cmd) return -1;
+
+  // system() on Windows runs the command through cmd.exe and propagates its
+  // exit code. Keep that semantics (so cmd builtins, batch files, redirection
+  // and shell separators behave exactly as before), but use CREATE_NO_WINDOW so
+  // a console-subsystem child spawned from a console-less GUI parent
+  // (darktable.exe frees its console on startup) doesn't get a fresh, visible
+  // console window (issue #17193).
+  gchar *utf8 = g_strdup_printf("cmd.exe /d /s /c \"%s\"", cmd);
+  gunichar2 *wline = g_utf8_to_utf16(utf8, -1, NULL, NULL, NULL);
+  g_free(utf8);
+  if(!wline) return -1;
+
+  STARTUPINFOW si = { 0 };
+  si.cb = sizeof(si);
+  PROCESS_INFORMATION pi = { 0 };
+  // CreateProcessW writes into the buffer, so pass our copy, not `cmd`.
+  const BOOL ok = CreateProcessW(NULL, (LPWSTR)wline, NULL, NULL, FALSE,
+                                 CREATE_NO_WINDOW, NULL, NULL, &si, &pi);
+  g_free(wline);
+  if(!ok) return -1;
+
+  WaitForSingleObject(pi.hProcess, INFINITE);
+  DWORD exit_code = 0;
+  GetExitCodeProcess(pi.hProcess, &exit_code);
+  CloseHandle(pi.hThread);
+  CloseHandle(pi.hProcess);
+  return (int)exit_code;
+#else
+  return cmd ? system(cmd) : -1;
+#endif
+}

--- a/src/common/process.c
+++ b/src/common/process.c
@@ -19,9 +19,79 @@
 
 #include <glib.h>
 #include <stdlib.h>
+#include <string.h>
 
 #ifdef _WIN32
 #include <windows.h>
+#include <wchar.h>
+
+#define DT_COMMAND_PATH_MAX 32768
+
+static gboolean _resolve_command_interpreter(wchar_t *interpreter,
+                                             const DWORD capacity)
+{
+  DWORD length = GetEnvironmentVariableW(L"COMSPEC", interpreter, capacity);
+  if(length == 0)
+  {
+    length = GetSystemDirectoryW(interpreter, capacity);
+    if(length == 0 || length >= capacity) return FALSE;
+
+    static const wchar_t suffix[] = L"\\cmd.exe";
+    if(length + G_N_ELEMENTS(suffix) > capacity) return FALSE;
+    wcscat(interpreter, suffix);
+    return TRUE;
+  }
+  if(length >= capacity) return FALSE;
+
+  if(length >= 2 && interpreter[0] == L'"' && interpreter[length - 1] == L'"')
+  {
+    memmove(interpreter, interpreter + 1, (length - 2) * sizeof(wchar_t));
+    interpreter[length - 2] = L'\0';
+  }
+
+  wchar_t resolved[DT_COMMAND_PATH_MAX];
+  if(!wcschr(interpreter, L'\\') && !wcschr(interpreter, L'/')
+     && !wcschr(interpreter, L':'))
+  {
+    wchar_t search_path[DT_COMMAND_PATH_MAX];
+    const DWORD path_length = GetEnvironmentVariableW(L"PATH", search_path,
+                                                       G_N_ELEMENTS(search_path));
+    if(path_length == 0 || path_length >= G_N_ELEMENTS(search_path)) return FALSE;
+    const DWORD found = SearchPathW(search_path, interpreter, L".exe",
+                                    G_N_ELEMENTS(resolved), resolved, NULL);
+    if(found == 0 || found >= G_N_ELEMENTS(resolved)) return FALSE;
+  }
+  else
+  {
+    const DWORD full_length = GetFullPathNameW(interpreter, G_N_ELEMENTS(resolved),
+                                               resolved, NULL);
+    if(full_length == 0 || full_length >= G_N_ELEMENTS(resolved)) return FALSE;
+  }
+
+  wcscpy(interpreter, resolved);
+  return TRUE;
+}
+
+static wchar_t *_build_command_line(const wchar_t *interpreter,
+                                    const char *cmd)
+{
+  gunichar2 *wide_command = g_utf8_to_utf16(cmd, -1, NULL, NULL, NULL);
+  if(!wide_command) return NULL;
+
+  const size_t capacity = wcslen(interpreter)
+                          + wcslen((const wchar_t *)wide_command) + 32;
+  wchar_t *command_line = g_new(wchar_t, capacity);
+  const int written = swprintf(command_line, capacity,
+                               L"\"%ls\" /d /s /c \"%ls\"",
+                               interpreter, (const wchar_t *)wide_command);
+  g_free(wide_command);
+  if(written < 0)
+  {
+    g_free(command_line);
+    return NULL;
+  }
+  return command_line;
+}
 #endif
 
 int dt_exec_command_sync(const char *cmd)
@@ -29,24 +99,25 @@ int dt_exec_command_sync(const char *cmd)
 #ifdef _WIN32
   if(!cmd) return -1;
 
+  wchar_t interpreter[DT_COMMAND_PATH_MAX];
+  if(!_resolve_command_interpreter(interpreter, G_N_ELEMENTS(interpreter))) return -1;
+
   // system() on Windows runs the command through cmd.exe and propagates its
-  // exit code. Keep that semantics (so cmd builtins, batch files, redirection
+  // exit code; keep that semantics (so cmd builtins, batch files, redirection
   // and shell separators behave exactly as before), but use CREATE_NO_WINDOW so
   // a console-subsystem child spawned from a console-less GUI parent
   // (darktable.exe frees its console on startup) doesn't get a fresh, visible
-  // console window (issue #17193).
-  gchar *utf8 = g_strdup_printf("cmd.exe /d /s /c \"%s\"", cmd);
-  gunichar2 *wline = g_utf8_to_utf16(utf8, -1, NULL, NULL, NULL);
-  g_free(utf8);
-  if(!wline) return -1;
+  // console window (issue #17193)
+  wchar_t *command_line = _build_command_line(interpreter, cmd);
+  if(!command_line) return -1;
 
   STARTUPINFOW si = { 0 };
   si.cb = sizeof(si);
   PROCESS_INFORMATION pi = { 0 };
-  // CreateProcessW writes into the buffer, so pass our copy, not `cmd`.
-  const BOOL ok = CreateProcessW(NULL, (LPWSTR)wline, NULL, NULL, FALSE,
+  // CreateProcessW writes into the buffer, so pass our copy, not `cmd`
+  const BOOL ok = CreateProcessW(interpreter, command_line, NULL, NULL, FALSE,
                                  CREATE_NO_WINDOW, NULL, NULL, &si, &pi);
-  g_free(wline);
+  g_free(command_line);
   if(!ok) return -1;
 
   WaitForSingleObject(pi.hProcess, INFINITE);

--- a/src/common/process.h
+++ b/src/common/process.h
@@ -1,0 +1,38 @@
+/*
+    This file is part of darktable,
+    Copyright (C) 2026 darktable developers.
+
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    darktable is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <glib.h>
+
+G_BEGIN_DECLS
+
+/* Run a shell command synchronously and return its exit-code integer.
+
+   On Linux/macOS this is a thin wrapper around system(). On Windows it runs the
+   command through cmd.exe (so cmd builtins, batch files and redirection keep
+   working exactly as they did with system()) but uses the CREATE_NO_WINDOW
+   creation flag, so spawning a console child from a console-less GUI parent
+   (darktable.exe frees its console on startup) no longer flashes a console
+   window (issue #17193).
+
+   Returns the exit-code integer (like system()), or -1 if the command could not
+   be spawned, or if cmd is NULL. */
+int dt_exec_command_sync(const char *cmd);
+
+G_END_DECLS

--- a/src/common/process.h
+++ b/src/common/process.h
@@ -22,17 +22,15 @@
 
 G_BEGIN_DECLS
 
-/* Run a shell command synchronously and return its exit-code integer.
+/* run a shell command synchronously and return its exit-code integer
 
    On Linux/macOS this is a thin wrapper around system(). On Windows it runs the
-   command through cmd.exe (so cmd builtins, batch files and redirection keep
-   working exactly as they did with system()) but uses the CREATE_NO_WINDOW
-   creation flag, so spawning a console child from a console-less GUI parent
-   (darktable.exe frees its console on startup) no longer flashes a console
-   window (issue #17193).
+   command through the interpreter configured by COMSPEC, with a system-directory
+   cmd.exe fallback, but uses CREATE_NO_WINDOW so a console child spawned from a
+   console-less GUI parent no longer flashes a console window (issue #17193)
 
-   Returns the exit-code integer (like system()), or -1 if the command could not
-   be spawned, or if cmd is NULL. */
+   Returns the exit-code integer, or -1 if the command could not be spawned or
+   cmd is NULL */
 int dt_exec_command_sync(const char *cmd);
 
 G_END_DECLS

--- a/src/lua/call.c
+++ b/src/lua/call.c
@@ -18,6 +18,7 @@
 #include "lua/call.h"
 #include "control/control.h"
 #include "lua/lua.h"
+#include "common/process.h"
 #ifndef _WIN32
 #include <glib-unix.h>
 #endif
@@ -594,7 +595,7 @@ static int execute_cb(lua_State*L)
 {
   const char *cmd = luaL_optstring(L, 1, NULL);
   dt_lua_unlock();
-  int stat = system(cmd);
+  const int stat = dt_exec_command_sync(cmd);
   dt_lua_lock();
   lua_pushinteger(L,stat);
   return 1;

--- a/src/tests/unittests/CMakeLists.txt
+++ b/src/tests/unittests/CMakeLists.txt
@@ -14,6 +14,14 @@ if(WIN32)
     _copy_required_library(test_sample lib_darktable)
 endif(WIN32)
 
+# Exit-code / shell behavior of dt_exec_command_sync() (issue #17193).
+add_cmocka_test(test_process
+                SOURCES test_process.c
+                LINK_LIBRARIES lib_darktable cmocka)
+if(WIN32)
+    _copy_required_library(test_process lib_darktable)
+endif(WIN32)
+
 # HDR exposure-bracket auto-alignment. Calls the public dt_hdr_alignment_* API
 # exported from lib_darktable (which carries the OpenCV-linked objects); the test
 # itself adapts at runtime to OpenCV-present / -absent builds.

--- a/src/tests/unittests/test_process.c
+++ b/src/tests/unittests/test_process.c
@@ -1,0 +1,75 @@
+/*
+    This file is part of darktable,
+    Copyright (C) 2026 darktable developers.
+
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    darktable is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+
+    Regression tests for dt_exec_command_sync(): it must keep system()'s
+    observable contract -- success returns 0, a failing command returns a
+    non-zero integer, and a NULL command returns -1 -- and it must keep driving
+    the command through a shell, so cmd builtins / redirection that rely on the
+    shell layer don't start failing (see issue #17193).
+*/
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include <cmocka.h>
+
+#include "common/process.h"
+
+#ifdef _WIN32
+#include "win/main_wrapper.h"
+#endif
+
+static void test_exec_success(void **state)
+{
+  assert_int_equal(dt_exec_command_sync("exit 0"), 0);
+}
+
+static void test_exec_shell_builtin(void **state)
+{
+  // 'echo' is a shell builtin, not an executable. If the helper stops routing
+  // the command through the shell (e.g. it spawns the first token directly), it
+  // returns -1 on Windows because CreateProcess can't find an "echo.exe".
+  assert_int_equal(dt_exec_command_sync("echo darktable is fine"), 0);
+}
+
+static void test_exec_nonzero_exit(void **state)
+{
+  assert_int_not_equal(dt_exec_command_sync("exit 1"), 0);
+}
+
+static void test_exec_null(void **state)
+{
+  assert_int_equal(dt_exec_command_sync(NULL), -1);
+}
+
+int main(int argc, char *argv[])
+{
+  const struct CMUnitTest tests[] = {
+    cmocka_unit_test(test_exec_success),
+    cmocka_unit_test(test_exec_shell_builtin),
+    cmocka_unit_test(test_exec_nonzero_exit),
+    cmocka_unit_test(test_exec_null),
+  };
+
+  return cmocka_run_group_tests(tests, NULL, NULL);
+}
+// clang-format off
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
+// clang-format on

--- a/src/tests/unittests/test_process.c
+++ b/src/tests/unittests/test_process.c
@@ -25,6 +25,7 @@
 #include <stdarg.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <string.h>
 
 #include <cmocka.h>
 
@@ -32,6 +33,59 @@
 
 #ifdef _WIN32
 #include "win/main_wrapper.h"
+#include <glib/gstdio.h>
+#include <windows.h>
+
+typedef struct _decoy_interpreter
+{
+  gchar *directory;
+  gchar *path;
+} _decoy_interpreter_t;
+
+static _decoy_interpreter_t _create_decoy_interpreter(void)
+{
+  _decoy_interpreter_t decoy = { 0 };
+  GError *error = NULL;
+  decoy.directory = g_dir_make_tmp("darktable-process-test-XXXXXX", &error);
+  assert_non_null(decoy.directory);
+  assert_null(error);
+  decoy.path = g_build_filename(decoy.directory, "cmd.exe", NULL);
+
+  wchar_t module_path[32768];
+  const DWORD length = GetModuleFileNameW(NULL, module_path, G_N_ELEMENTS(module_path));
+  assert_true(length > 0 && length < G_N_ELEMENTS(module_path));
+  gunichar2 *wide_decoy = g_utf8_to_utf16(decoy.path, -1, NULL, NULL, NULL);
+  assert_non_null(wide_decoy);
+  assert_true(CopyFileW(module_path, (const wchar_t *)wide_decoy, FALSE));
+  g_free(wide_decoy);
+  return decoy;
+}
+
+static void _remove_decoy_interpreter(_decoy_interpreter_t *decoy)
+{
+  if(decoy->path)
+  {
+    g_remove(decoy->path);
+    g_free(decoy->path);
+  }
+  if(decoy->directory)
+  {
+    g_rmdir(decoy->directory);
+    g_free(decoy->directory);
+  }
+}
+
+static gchar *_save_comspec(void)
+{
+  return g_strdup(g_getenv("COMSPEC"));
+}
+
+static void _restore_comspec(gchar *saved)
+{
+  if(saved) g_setenv("COMSPEC", saved, TRUE);
+  else g_unsetenv("COMSPEC");
+  g_free(saved);
+}
 #endif
 
 static void test_exec_success(void **state)
@@ -57,13 +111,50 @@ static void test_exec_null(void **state)
   assert_int_equal(dt_exec_command_sync(NULL), -1);
 }
 
+#ifdef _WIN32
+static void test_exec_ignores_current_directory_decoy(void **state)
+{
+  _decoy_interpreter_t decoy = _create_decoy_interpreter();
+  gchar *original_directory = g_get_current_dir();
+  assert_int_equal(g_chdir(decoy.directory), 0);
+  const int status = dt_exec_command_sync("exit 0");
+  const int restore_status = g_chdir(original_directory);
+  g_free(original_directory);
+  _remove_decoy_interpreter(&decoy);
+
+  assert_int_equal(restore_status, 0);
+  assert_int_equal(status, 0);
+}
+
+static void test_exec_honors_comspec(void **state)
+{
+  _decoy_interpreter_t decoy = _create_decoy_interpreter();
+  gchar *saved_comspec = _save_comspec();
+  assert_true(g_setenv("COMSPEC", decoy.path, TRUE));
+  const int status = dt_exec_command_sync("exit 0");
+  _restore_comspec(saved_comspec);
+  _remove_decoy_interpreter(&decoy);
+
+  assert_int_equal(status, 91);
+}
+#endif
+
 int main(int argc, char *argv[])
 {
+#ifdef _WIN32
+  // the test executable doubles as a controlled COMSPEC target
+  if(argc > 1 && strcmp(argv[1], "/d") == 0) return 91;
+#endif
+
   const struct CMUnitTest tests[] = {
     cmocka_unit_test(test_exec_success),
     cmocka_unit_test(test_exec_shell_builtin),
     cmocka_unit_test(test_exec_nonzero_exit),
     cmocka_unit_test(test_exec_null),
+#ifdef _WIN32
+    cmocka_unit_test(test_exec_ignores_current_directory_decoy),
+    cmocka_unit_test(test_exec_honors_comspec),
+#endif
   };
 
   return cmocka_run_group_tests(tests, NULL, NULL);


### PR DESCRIPTION
## Summary

`dt.control.execute()` uses `system()`. On Windows, that launches a console
subprocess from darktable's console-less GUI process and causes a visible
console-window flash.

This PR adds `dt_exec_command_sync()` and routes `dt.control.execute()` through
it. On Windows, the helper invokes the configured `COMSPEC` interpreter with
`CREATE_NO_WINDOW`; if `COMSPEC` is unavailable, it uses the `cmd.exe` in the
Windows system directory. Other platforms continue to use `system()`.

The Windows helper resolves the interpreter to an explicit full path and passes
it as `CreateProcessW`'s application name. This avoids the application-directory
and current-directory executable search that occurs when the application name
is `NULL`, while preserving shell builtins, batch files, redirection, chaining,
Unicode commands, and configured `COMSPEC` behavior.

## Validation

- Fresh MSYS2/UCRT64 Release build of `lib_darktable` and `test_process`.
- `test_process`: 6/6 passing, covering success, shell builtins, nonzero status,
  `NULL`, a controlled current-directory `cmd.exe` decoy, and `COMSPEC`
  selection.
- The current-directory regression fails against the original implementation,
  where the decoy is launched, and passes with the explicit interpreter path.
- Earlier end-to-end testing with a built `darktable.exe` showed the same exit
  status with the flash removed for a persistent `dt.control.execute()` child.

## Scope

This addresses only `dt.control.execute()`. Lua's `os.execute()` and
`io.popen()` use separate implementations and remain follow-up work, so issue
#17193 should remain open after this PR.

## AI disclosure

OpenAI Codex assisted with implementation, adversarial review, and test
development. The changes were rebuilt and exercised locally as described above.

Related: #17193
