### PR TITLE
Guard allocation failure and avoid overflow in buffer size calculation

### DIFF
--- a/src/imageio/imageio.c
+++ b/src/imageio/imageio.c
@@ -1731,7 +1731,7 @@ static int _preview_write_image(dt_imageio_module_data_t *data,
   _imageio_preview_t *d = (_imageio_preview_t *)data;
 
   if(!in) return 1;
-  memcpy(d->buf, in, sizeof(uint32_t) * data->width * data->height);
+  memcpy(d->buf, in, sizeof(uint32_t) * (size_t)data->width * data->height);
   d->width = data->width;
   d->height = data->height;
 

--- a/src/imageio/imageio.c
+++ b/src/imageio/imageio.c
@@ -1773,6 +1773,8 @@ cairo_surface_t *dt_imageio_preview(const dt_imgid_t imgid,
   dat.head.style_append = TRUE;
   dat.bpp = 8;
   dat.buf = (uint8_t *)dt_alloc_aligned(sizeof(uint32_t) * width * height);
+  if(!dat.buf)
+    return NULL;
 
   g_strlcpy(dat.head.style, style_name, sizeof(dat.head.style));
 


### PR DESCRIPTION
Since we are making `dt_imageio_preview` potentially NULL-producing, we also need to check if NULL can be safely handled further down the execution path. Currently there is only one consumer of `dt_imageio_preview` which simply returns what it gets from it - `dt_gui_get_style_preview`. In turn, `dt_gui_get_style_preview` is called only in one place and its result is checked for NULL there. So the change in this PR is safe.

While we're at it, also prevent a potential overflow in the calculation in the adjacent function where two potentially large `uint32_t` numbers are multiplied without converting to `size_t`.
