### PR TITLE
Widen int to size_t in pixel processing loops

### DIFF
--- a/src/develop/borders_helper.c
+++ b/src/develop/borders_helper.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2017-2023 darktable developers.
+    Copyright (C) 2017-2026 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -25,7 +25,7 @@ static inline void set_pixels(float *buf,
                               const dt_aligned_pixel_t color,
                               const int npixels)
 {
-  for(int i = 0; i < npixels; i++)
+  for(size_t i = 0; i < npixels; i++)
   {
     copy_pixel_nontemporal(buf + 4*i,  color);
   }
@@ -37,7 +37,7 @@ static inline void copy_pixels(float *out,
                                const float *const in,
                                const int npixels)
 {
-  for(int i = 0; i < npixels; i++)
+  for(size_t i = 0; i < npixels; i++)
   {
     copy_pixel_nontemporal(out + 4*i, in + 4*i);
   }
@@ -260,3 +260,4 @@ void dt_iop_setup_binfo(const dt_dev_pixelpipe_iop_t *piece,
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
+

--- a/src/develop/masks/group.c
+++ b/src/develop/masks/group.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2013-2024 darktable developers.
+    Copyright (C) 2013-2026 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -493,7 +493,7 @@ static void _combine_masks_union(float *const restrict dest,
   if(inverted)
   {
     DT_OMP_FOR_SIMD(dt_omp_sharedconst(dest, newmask) aligned(dest, newmask : 64))
-    for(int index = 0; index < npixels; index++)
+    for(size_t index = 0; index < npixels; index++)
     {
       const float mask = opacity * (1.0f - newmask[index]);
       dest[index] = MAX(dest[index], mask);
@@ -502,7 +502,7 @@ static void _combine_masks_union(float *const restrict dest,
   else
   {
     DT_OMP_FOR_SIMD(aligned(dest, newmask : 64))
-    for(int index = 0; index < npixels; index++)
+    for(size_t index = 0; index < npixels; index++)
     {
       const float mask = opacity * newmask[index];
       dest[index] = MAX(dest[index], mask);
@@ -519,7 +519,7 @@ static void _combine_masks_intersect(float *const restrict dest,
   if(inverted)
   {
     DT_OMP_FOR_SIMD(aligned(dest, newmask : 64))
-    for(int index = 0; index < npixels; index++)
+    for(size_t index = 0; index < npixels; index++)
     {
       const float mask = opacity * (1.0f - newmask[index]);
       dest[index] = MIN(MAX(dest[index], 0.0f), MAX(mask, 0.0f));
@@ -528,7 +528,7 @@ static void _combine_masks_intersect(float *const restrict dest,
   else
   {
     DT_OMP_FOR_SIMD(aligned(dest, newmask : 64))
-    for(int index = 0; index < npixels; index++)
+    for(size_t index = 0; index < npixels; index++)
     {
       const float mask = opacity * newmask[index];
       dest[index] = MIN(MAX(dest[index], 0.0f), MAX(mask, 0.0f));
@@ -552,7 +552,7 @@ static void _combine_masks_difference(float *const restrict dest,
   if(inverted)
   {
     DT_OMP_FOR_SIMD(aligned(dest, newmask : 64))
-    for(int index = 0; index < npixels; index++)
+    for(size_t index = 0; index < npixels; index++)
     {
       const float mask = opacity * (1.0f - newmask[index]);
       dest[index] *= (1.0f - mask * both_positive(dest[index],mask));
@@ -561,7 +561,7 @@ static void _combine_masks_difference(float *const restrict dest,
   else
   {
     DT_OMP_FOR_SIMD(aligned(dest, newmask : 64))
-    for(int index = 0; index < npixels; index++)
+    for(size_t index = 0; index < npixels; index++)
     {
       const float mask = opacity * newmask[index];
       dest[index] *= (1.0f - mask * both_positive(dest[index],mask));
@@ -578,7 +578,7 @@ static void _combine_masks_sum(float *const restrict dest,
   if(inverted)
   {
     DT_OMP_FOR_SIMD(aligned(dest, newmask : 64))
-    for(int index = 0; index < npixels; index++)
+    for(size_t index = 0; index < npixels; index++)
     {
       const float mask = opacity * (1.0f - newmask[index]);
       dest[index] = MIN(1.0f, dest[index] + mask);
@@ -587,7 +587,7 @@ static void _combine_masks_sum(float *const restrict dest,
   else
   {
     DT_OMP_FOR_SIMD(aligned(dest, newmask : 64))
-    for(int index = 0; index < npixels; index++)
+    for(size_t index = 0; index < npixels; index++)
     {
       const float mask = opacity * newmask[index];
       dest[index] = MIN(1.0f, dest[index] + mask);
@@ -604,7 +604,7 @@ static void _combine_masks_exclusion(float *const restrict dest,
   if(inverted)
   {
     DT_OMP_FOR_SIMD(aligned(dest, newmask : 64))
-    for(int index = 0; index < npixels; index++)
+    for(size_t index = 0; index < npixels; index++)
     {
       const float mask = opacity * (1.0f - newmask[index]);
       const float pos = both_positive(dest[index], mask);
@@ -617,7 +617,7 @@ static void _combine_masks_exclusion(float *const restrict dest,
   else
   {
     DT_OMP_FOR_SIMD(aligned(dest, newmask : 64))
-    for(int index = 0; index < npixels; index++)
+    for(size_t index = 0; index < npixels; index++)
     {
       const float mask = opacity * newmask[index];
       const float pos = both_positive(dest[index], mask);
@@ -703,7 +703,7 @@ static int _group_get_mask_roi(const dt_iop_module_t *const restrict module,
              // the shape and null other parts
         {
           DT_OMP_FOR_SIMD(aligned(buffer, bufs : 64))
-          for(int index = 0; index < npixels; index++)
+          for(size_t index = 0; index < npixels; index++)
           {
             buffer[index] = op * (inverted ? (1.0f - bufs[index]) : bufs[index]);
           }

--- a/src/imageio/imageio_webp.c
+++ b/src/imageio/imageio_webp.c
@@ -145,7 +145,7 @@ dt_imageio_retval_t dt_imageio_open_webp(dt_image_t *img,
   }
 
   DT_OMP_FOR()
-  for(int i = 0; i < npixels; i++)
+  for(size_t i = 0; i < npixels; i++)
   {
     dt_aligned_pixel_t pix = {0.0f, 0.0f, 0.0f, 0.0f};
 

--- a/src/iop/colorchecker.c
+++ b/src/iop/colorchecker.c
@@ -629,7 +629,7 @@ void process(dt_iop_module_t *self,
       data->coeff_b[num_patches+3], 0.0f };
 
   DT_OMP_FOR()
-  for(int k=0; k < npixels; k++)
+  for(size_t k=0; k < npixels; k++)
   {
     dt_aligned_pixel_t inpx;
     copy_pixel(inpx, ((float *)ivoid) + 4*k);

--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -32,12 +32,15 @@
 #include "imageio/imageio_jpeg.h"
 #include "imageio/imageio_png.h"
 #include "imageio/imageio_tiff.h"
+
 #ifdef HAVE_LIBAVIF
 #include "imageio/imageio_avif.h"
 #endif
+
 #ifdef HAVE_LIBHEIF
 #include "imageio/imageio_heif.h"
 #endif
+
 #include "develop/imageop_math.h"
 #include "develop/imageop_gui.h"
 #include "iop/iop_api.h"
@@ -772,7 +775,7 @@ static void _process_cmatrix_bm(dt_iop_module_t *self,
   // dt_print(DT_DEBUG_ALWAYS, "Using cmatrix codepath");
   // only color matrix. use our optimized fast path!
   DT_OMP_FOR(shared(cmatrix, nmatrix, lmatrix))
-  for(int j = 0; j < npixels; j++)
+  for(size_t j = 0; j < npixels; j++)
   {
     const float *const restrict in = (const float *)ivoid + 4*j;
     float *const restrict out = (float *)ovoid + 4*j;

--- a/src/iop/dither.c
+++ b/src/iop/dither.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2012-2024 darktable developers.
+    Copyright (C) 2012-2026 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -419,7 +419,7 @@ static void _process_floyd_steinberg(
   const int graymode = _get_dither_parameters(data,piece,scale,&levels);
   if(graymode < 0)
   {
-    for(int j = 0; j < height * width; j++)
+    for(size_t j = 0; j < height * width; j++)
       _clipnan_pixel(out + 4*j, in + 4*j);
     return;
   }
@@ -431,7 +431,7 @@ static void _process_floyd_steinberg(
   // dither without error diffusion on very tiny images
   if(width < 3 || height < 3)
   {
-    for(int j = 0; j < height * width; j++)
+    for(size_t j = 0; j < height * width; j++)
     {
       _clipnan_pixel(out + 4 * j, in + 4 * j);
       _nearest_color(out + 4 * j, err, graymode, f, rf);
@@ -638,7 +638,7 @@ static void _process_posterize(
   const float rf = 1.0f / f;
 
   DT_OMP_FOR()
-  for(int k = 0; k < npixels; k++)
+  for(size_t k = 0; k < npixels; k++)
   {
     dt_aligned_pixel_t pixel;
     // quantize the pixel into the desired number of levels per color channel

--- a/src/iop/levels.c
+++ b/src/iop/levels.c
@@ -412,7 +412,7 @@ void process(dt_iop_module_t *self,
   const float *lut = d->lut;
 
   DT_OMP_FOR()
-  for(int i = 0; i < 4 * npixels; i += 4)
+  for(size_t i = 0; i < 4 * npixels; i += 4)
   {
     const float L_in = in[i] / 100.0f;
     float L_out;

--- a/src/iop/monochrome.c
+++ b/src/iop/monochrome.c
@@ -212,7 +212,7 @@ void process(dt_iop_module_t *self,
   const float d_a = d->a;
   const float d_b = d->b;
   DT_OMP_FOR_SIMD(aligned(in, out:64))
-  for(int k = 0; k < 4*npixels; k += 4)
+  for(size_t k = 0; k < 4*npixels; k += 4)
   {
     out[k+0] = 100.0f * _color_filter(in[k+1], in[k+2], d_a, d_b, sigma2);
     out[k+1] = out[k+2] = 0.0f;
@@ -243,7 +243,7 @@ void process(dt_iop_module_t *self,
 
   const float highlights = d->highlights;
   DT_OMP_FOR_SIMD(aligned(in, out:64))
-  for(int k = 0; k < 4*npixels; k += 4)
+  for(size_t k = 0; k < 4*npixels; k += 4)
   {
     const float tt = _envelope(in[k]);
     const float t = tt + (1.0f - tt) * (1.0f - highlights);

--- a/src/iop/rgbcurve.c
+++ b/src/iop/rgbcurve.c
@@ -1887,7 +1887,7 @@ void process(dt_iop_module_t *self,
   const _coeffs_table_ptr restrict unbounded_coeffs = d->unbounded_coeffs;
 
   DT_OMP_FOR()
-  for(int y = 0; y < 4*npixels; y += 4)
+  for(size_t y = 0; y < 4*npixels; y += 4)
   {
     if(autoscale == DT_S_SCALE_MANUAL_RGB)
     {

--- a/src/iop/rgblevels.c
+++ b/src/iop/rgblevels.c
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+
 #include "common/gdk_event_utils.h"
 
 #include "common/iop_profile.h"
@@ -1297,7 +1298,7 @@ void process(dt_iop_module_t *self,
     const dt_aligned_pixel_t max_levels
       = { d->params.levels[0][2], d->params.levels[1][2], d->params.levels[2][2], 1.0f };
     DT_OMP_FOR()
-    for(int k = 0; k < 4U*npixels; k += 4)
+    for(size_t k = 0; k < 4U*npixels; k += 4)
     {
       for(int c = 0; c < 3; c++)
       {
@@ -1332,7 +1333,7 @@ void process(dt_iop_module_t *self,
     const float max_level = levels[2];
     static const dt_aligned_pixel_t zero = { 0.0f, 0.0f, 0.0f, 0.0f };
     DT_OMP_FOR()
-    for(int k = 0; k < 4U*npixels; k += 4)
+    for(size_t k = 0; k < 4U*npixels; k += 4)
     {
       const float lum = dt_rgb_norm(in+k, d->params.preserve_colors, work_profile);
       if(lum > min_level)

--- a/src/iop/splittoning.c
+++ b/src/iop/splittoning.c
@@ -170,7 +170,7 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
   const float balance = data->balance;
 
   DT_OMP_FOR()
-  for(int k = 0; k < 4 * npixels; k += 4)
+  for(size_t k = 0; k < 4 * npixels; k += 4)
   {
     float h, s, l;
     rgb2hsl(in+k, &h, &s, &l);

--- a/src/iop/tonecurve.c
+++ b/src/iop/tonecurve.c
@@ -413,7 +413,7 @@ void process(dt_iop_module_t *self,
   float *const restrict out = (float*)o;
 
   DT_OMP_FOR()
-  for(int k = 0; k < 4*npixels; k += 4)
+  for(size_t k = 0; k < 4*npixels; k += 4)
   {
     const float L_in = in[k] / 100.0f;
 

--- a/src/iop/vibrance.c
+++ b/src/iop/vibrance.c
@@ -112,7 +112,7 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
   const int npixels = roi_out->height * roi_out->width;
 
   DT_OMP_FOR()
-  for(int k = 0; k < 4 * npixels; k += 4)
+  for(size_t k = 0; k < 4 * npixels; k += 4)
   {
     /* saturation weight 0 - 1 */
     const float sw = sqrtf((in[k + 1] * in[k + 1]) + (in[k + 2] * in[k + 2])) / 256.0f;


### PR DESCRIPTION
This is not a solution to an existing or soon-to-be-emerging issue. But after some time (in my opinion, in the medium term), a problem may arise and it is better to fix everything now.

The maximum "native" resolution of serial professional cameras is 150 megapixels (for example, in Phase One XF IQ4 digital backs), and with the help of the frame merging mode (Pixel Shift) this figure reaches 400 megapixels (Hasselblad H6D-400c Multi-Shot).

We still have loops in the code through the image pixels (more precisely, over the color channels of each pixel), which use an int variable as an index. Each pixel in darktable is represented by 4 channels (three real, RGB, and one dummy for alignment). So, in reality, the maximum index value is 4 times the number of image pixels. For a 400 megapixel image, this will be 1.6 billion. But the maximum value that an int variable can have without overflowing, INT_MAX, is approximately 2.14 billion.

It is easy to calculate that it is enough to create a camera that will create Pixel Shift images not at 400, but at 512 megapixels, and our loops with an int index will overflow.