### PR TITLE
win: make the main wrapper C++ compatible

### DIFF
--- a/src/tests/unittests/test_hdr_alignment_internal.cc
+++ b/src/tests/unittests/test_hdr_alignment_internal.cc
@@ -191,8 +191,10 @@ static void test_xtrans_sampler_same_color_only(void **state)
 }
 #endif // HAVE_OPENCV
 
-int main(void)
+int main(int argc, char *argv[])
 {
+  (void)argc;
+  (void)argv;
 #ifdef HAVE_OPENCV
   const struct CMUnitTest tests[] = {
       cmocka_unit_test(test_percentile_bounds_accuracy),

--- a/src/win/main_wrapper.h
+++ b/src/win/main_wrapper.h
@@ -9,9 +9,9 @@ int main(int argc, char *argv[]);
 
 int wmain(int argc, wchar_t *argv[])
 {
-  char **_argv = g_malloc0((argc + 1) * sizeof(char *));
+  char **_argv = g_new0(char *, argc + 1);
   for(int i = 0; i < argc; i++)
-    _argv[i] = g_utf16_to_utf8(argv[i], -1, NULL, NULL, NULL);
+    _argv[i] = g_utf16_to_utf8((const gunichar2 *)argv[i], -1, NULL, NULL, NULL);
   int res = main(argc, _argv);
   g_strfreev(_argv);
   return res;


### PR DESCRIPTION
Closes #22027.

`test_hdr_alignment_internal` was converted from C to C++ in `330661f524d` but still includes
the Windows main wrapper. Compiling the wrapper as C++ exposes two type mismatches and an
incompatible `main` signature.

This change:

- uses `g_new0()` for the argument-vector allocation;
- passes the Windows UTF-16 arguments with the type expected by GLib; and
- gives the test the `main` signature declared by the wrapper.

Tested with a complete MSYS2 UCRT64 Release build using `BUILD_TESTING=ON`. The build completed
and all four configured CTest tests passed.