### PR TITLE
[imageio] Better handling of missing TIFF tags

### DIFF
--- a/src/imageio/imageio_tiff.c
+++ b/src/imageio/imageio_tiff.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2010-2025 darktable developers.
+    Copyright (C) 2010-2026 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -29,6 +29,7 @@
 #include <stdio.h>
 #include <strings.h>
 #include <tiffio.h>
+
 #ifdef HAVE_IMATH
 #include "Imath/half.h"
 #endif
@@ -410,8 +411,15 @@ dt_imageio_retval_t dt_imageio_open_tiff(dt_image_t *img,
     return DT_IMAGEIO_LOAD_FAILED;
   }
 
-  TIFFGetField(t.tiff, TIFFTAG_IMAGEWIDTH, &t.width);
-  TIFFGetField(t.tiff, TIFFTAG_IMAGELENGTH, &t.height);
+  if(!TIFFGetField(t.tiff, TIFFTAG_IMAGEWIDTH, &t.width)
+     || !TIFFGetField(t.tiff, TIFFTAG_IMAGELENGTH, &t.height))
+  {
+    dt_print(DT_DEBUG_ALWAYS,
+             "[tiff_open] missing image dimensions in '%s'",
+             filename);
+    return DT_IMAGEIO_FILE_CORRUPTED;
+  }
+
   TIFFGetField(t.tiff, TIFFTAG_BITSPERSAMPLE, &t.bpp);
   TIFFGetFieldDefaulted(t.tiff, TIFFTAG_SAMPLESPERPIXEL, &t.spp);
   TIFFGetFieldDefaulted(t.tiff, TIFFTAG_SAMPLEFORMAT, &t.sampleformat);

--- a/src/imageio/imageio_tiff.c
+++ b/src/imageio/imageio_tiff.c
@@ -420,10 +420,19 @@ dt_imageio_retval_t dt_imageio_open_tiff(dt_image_t *img,
     return DT_IMAGEIO_FILE_CORRUPTED;
   }
 
-  TIFFGetField(t.tiff, TIFFTAG_BITSPERSAMPLE, &t.bpp);
+  // The default value for bits per sample in the TIFF Revision 6.0 Spec is 1
+  TIFFGetFieldDefaulted(t.tiff, TIFFTAG_BITSPERSAMPLE, &t.bpp);
+
+  // The default value for samples per pixel in the TIFF Revision 6.0 Spec is 1
   TIFFGetFieldDefaulted(t.tiff, TIFFTAG_SAMPLESPERPIXEL, &t.spp);
+
+  // The default value for sample format in the TIFF Revision 6.0 Spec is 1,
+  // which represents unsigned integer data
   TIFFGetFieldDefaulted(t.tiff, TIFFTAG_SAMPLEFORMAT, &t.sampleformat);
-  TIFFGetField(t.tiff, TIFFTAG_PLANARCONFIG, &config);
+
+  // The default value for planar config in the TIFF Revision 6.0 Spec is 1,
+  // which represents chunky or contiguous format
+  TIFFGetFieldDefaulted(t.tiff, TIFFTAG_PLANARCONFIG, &config);
   TIFFGetField(t.tiff, TIFFTAG_PHOTOMETRIC, &photometric);
 
   // Citing the TIFF 6.0 specification for SampleFormat:

--- a/src/imageio/imageio_tiff.c
+++ b/src/imageio/imageio_tiff.c
@@ -433,7 +433,14 @@ dt_imageio_retval_t dt_imageio_open_tiff(dt_image_t *img,
   // The default value for planar config in the TIFF Revision 6.0 Spec is 1,
   // which represents chunky or contiguous format
   TIFFGetFieldDefaulted(t.tiff, TIFFTAG_PLANARCONFIG, &config);
-  TIFFGetField(t.tiff, TIFFTAG_PHOTOMETRIC, &photometric);
+
+  if(!TIFFGetField(t.tiff, TIFFTAG_PHOTOMETRIC, &photometric))
+  {
+    dt_print(DT_DEBUG_ALWAYS,
+             "[tiff_open] missing photometric interpretation in '%s'",
+             filename);
+    return DT_IMAGEIO_FILE_CORRUPTED;
+  }
 
   // Citing the TIFF 6.0 specification for SampleFormat:
   // A reader would typically treat an image with “undefined” data as


### PR DESCRIPTION
This PR improves the robustness of TIFF image loading by adding error handling for missing required TIFF tags and by using default values for optional tags according to the TIFF 6.0 specification. This helps prevent crashes or incorrect behavior when loading malformed or incomplete TIFF files.

* Now checks for the presence of required TIFF tags (`IMAGEWIDTH`, `IMAGELENGTH`, and `PHOTOMETRIC`) and returns a file corruption error if they are missing, with debug logging for easier troubleshooting.
* Uses `TIFFGetFieldDefaulted` for optional tags (`BITSPERSAMPLE`, `PLANARCONFIG`) to ensure default values are used when these tags are not present, aligning with the TIFF 6.0 specification.
