### PR TITLE
Fix neural restore raw denoise crash on some sensor sizes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -84,6 +84,10 @@ changes (where available).
 
 - Fixed collection module not updated properly on preset load.
 
+- Fixed a crash at the end of neural restore's raw denoise on certain
+  sensor sizes, where blending the tile seams wrote past the edge of
+  the image.
+
 ## Lua
 
 ### API Version

--- a/src/common/ai/restore_raw_bayer.c
+++ b/src/common/ai/restore_raw_bayer.c
@@ -377,9 +377,10 @@ int dt_restore_raw_bayer(dt_restore_context_t *ctx,
   // tile setup in packed (half-res) space
   const int O = OVERLAP_PACKED;
   const int T = dt_restore_get_tile_size(ctx);
-  if(T <= 2 * O) return 1;
+  // below 4 * O two adjacent tiles' seam ramps stop summing to 1: refuse the
+  // tile size rather than seam the output
+  if(T < 4 * O) return 1;
   const int step = T - 2 * O;
-  if(step <= 0) return 1;
   gboolean cpu_fallback_done = FALSE;
   const size_t tile_in_plane = (size_t)T * T;
   const size_t tile_out_w = 2 * (size_t)T;

--- a/src/common/ai/restore_raw_bayer.c
+++ b/src/common/ai/restore_raw_bayer.c
@@ -691,11 +691,14 @@ int dt_restore_raw_bayer(dt_restore_context_t *ctx,
       // tx-1 + tx ramps now sum to 1; strip = final value, flush + free
       if(v_strip_left)
       {
-        for(int sr = v_strip_left_sy0;
-            sr < v_strip_left_sy0 + v_strip_left_h; sr++)
+        // the strip reaches sensor_O past the tile edge, which on the last
+        // interior row/column is past the working area itself
+        const int v_sr_end = MIN(v_strip_left_sy0 + v_strip_left_h, y0 + 2 * Hh);
+        const int v_dxs_end = MIN(2 * sensor_O, x0 + 2 * Wh - v_strip_left_sx0);
+        for(int sr = v_strip_left_sy0; sr < v_sr_end; sr++)
         {
           const size_t vrow = (size_t)(sr - v_strip_left_sy0) * (2 * sensor_O);
-          for(int dxs = 0; dxs < 2 * sensor_O; dxs++)
+          for(int dxs = 0; dxs < v_dxs_end; dxs++)
           {
             const int sc = v_strip_left_sx0 + dxs;
             const float v = v_strip_left[vrow + dxs];
@@ -725,7 +728,8 @@ int dt_restore_raw_bayer(dt_restore_context_t *ctx,
     // were never written and would overwrite the cfa_in margin copy
     if(h_strip_top)
     {
-      for(int sr = h_strip_top_sy0; sr < h_strip_top_sy0 + hstrip_h; sr++)
+      const int h_sr_end = MIN(h_strip_top_sy0 + hstrip_h, y0 + 2 * Hh);
+      for(int sr = h_strip_top_sy0; sr < h_sr_end; sr++)
       {
         const size_t hrow = (size_t)(sr - h_strip_top_sy0) * width;
         for(int sc = x0; sc < x0 + 2 * Wh; sc++)

--- a/src/common/ai/restore_raw_linear.c
+++ b/src/common/ai/restore_raw_linear.c
@@ -631,10 +631,12 @@ int dt_restore_raw_linear(dt_restore_context_t *ctx,
         }
       }
 
-      const int ext_y0 = has_top  ? sensor_py_base - sensor_O : sensor_py_base;
-      const int ext_y1 = has_bot  ? sensor_py_end + sensor_O  : sensor_py_end;
-      const int ext_x0 = has_left ? sensor_px_base - sensor_O : sensor_px_base;
-      const int ext_x1 = has_right? sensor_px_end + sensor_O  : sensor_px_end;
+      // the seam reaches sensor_O past the tile edge, outside the buffer at
+      // the image border
+      const int ext_y0 = MAX(0, has_top  ? sensor_py_base - sensor_O : sensor_py_base);
+      const int ext_y1 = MIN(h, has_bot  ? sensor_py_end + sensor_O  : sensor_py_end);
+      const int ext_x0 = MAX(0, has_left ? sensor_px_base - sensor_O : sensor_px_base);
+      const int ext_x1 = MIN(w, has_right? sensor_px_end + sensor_O  : sensor_px_end);
 
       for(int sr = ext_y0; sr < ext_y1; sr++)
       {
@@ -733,11 +735,12 @@ int dt_restore_raw_linear(dt_restore_context_t *ctx,
       if(v_strip_left)
       {
         const size_t vchan = (size_t)(2 * sensor_O) * v_strip_left_h;
-        for(int sr = v_strip_left_sy0;
-            sr < v_strip_left_sy0 + v_strip_left_h; sr++)
+        const int v_sr_end = MIN(v_strip_left_sy0 + v_strip_left_h, h);
+        const int v_dxs_end = MIN(2 * sensor_O, w - v_strip_left_sx0);
+        for(int sr = v_strip_left_sy0; sr < v_sr_end; sr++)
         {
           const size_t vrow = (size_t)(sr - v_strip_left_sy0) * (2 * sensor_O);
-          for(int dxs = 0; dxs < 2 * sensor_O; dxs++)
+          for(int dxs = 0; dxs < v_dxs_end; dxs++)
           {
             const int sc = v_strip_left_sx0 + dxs;
             const size_t dst = (size_t)sr * w + sc;
@@ -762,10 +765,12 @@ int dt_restore_raw_linear(dt_restore_context_t *ctx,
     g_free(v_strip_left);
     v_strip_left = NULL;
 
-    // ramps sum to 1, flush. no column clamp needed (no working-region offset)
+    // ramps sum to 1, flush. columns need no clamp (the loop runs to w); the
+    // last strip's rows reach past the image
     if(h_strip_top)
     {
-      for(int sr = h_strip_top_sy0; sr < h_strip_top_sy0 + hstrip_h; sr++)
+      const int h_sr_end = MIN(h_strip_top_sy0 + hstrip_h, h);
+      for(int sr = h_strip_top_sy0; sr < h_sr_end; sr++)
       {
         const size_t hrow = (size_t)(sr - h_strip_top_sy0) * w;
         for(int sc = 0; sc < w; sc++)

--- a/src/common/ai/restore_raw_linear.c
+++ b/src/common/ai/restore_raw_linear.c
@@ -483,7 +483,8 @@ int dt_restore_raw_linear(dt_restore_context_t *ctx,
   // tile setup
   const int O = OVERLAP_LINEAR;
   const int T = dt_restore_get_tile_size(ctx);
-  if(T <= 2 * O)
+  // see restore_raw_bayer.c
+  if(T < 4 * O)
   {
     dt_free_align(rgb_src);
     dt_free_align(rgb_out);


### PR DESCRIPTION
Fixes the crash in #22023: neural restore's raw denoise segfaults at the very end of processing on some sensor sizes.

Each tile's seam strip spans `sensor_O` rows and columns past the tile edge, so it can reach outside the image. The flush loops that write those strips back bounded only the horizontal strip's columns, so a tile row ending within `sensor_O` of the image bottom wrote past the end of `cfa_out`. Whether that happens depends on where the last tile row lands, which is why it reproduced on a 44MP 8152x5432 sensor (10x7 tiles, the `ty=5` seam ending 8 rows past the last row) and not on a 24MP one. It also explains the reporter's impression of a file-writing bug: the seam flush is the last thing before the DNG is written.

The first commit clamps both flushes to the working area rather than the buffer, since the rows beyond it hold the `cfa_in` margin copy — the bound the horizontal strip's columns already used.

The second fixes the same defect class in `restore_raw_linear.c`, a near-copy: unclamped accumulation bounds, no column clamp in the vertical flush, no row clamp in the horizontal one. Two write past the end of `rgb_out`; the column one also wraps into the next row, overwriting correct output. Nothing reported this and I have no reproducer, so it is fixed by inspection and deserves a look from someone who knows that path.