### PR TITLE
blending: read the mask back from the device before publishing it as raster

### DIFF
--- a/src/develop/blend.c
+++ b/src/develop/blend.c
@@ -1328,15 +1328,15 @@ gboolean dt_develop_blend_process_cl(dt_iop_module_t *self,
   // TODO: should we skip raster masks?
   if(dt_iop_piece_is_raster_mask_used(piece, BLEND_RASTER_ID))
   {
-    // get back final mask from the device as the raster mask
-    if(!raster)
+    // Get back the final mask from the device as the raster mask.
+    //
+    // This must be done unconditionally to avoid presenting downstream a different
+    // mask than the CPU one in the presence of refinements.
+    err = dt_opencl_copy_image_to_host(devid, mask, dev_mask, owidth, oheight, sizeof(float));
+    if(err != CL_SUCCESS)
     {
-      err = dt_opencl_copy_image_to_host(devid, mask, dev_mask, owidth, oheight, sizeof(float));
-      if(err != CL_SUCCESS)
-      {
-        dt_iop_piece_clear_raster(piece, _mask);
-        goto error;
-      }
+      dt_iop_piece_clear_raster(piece, _mask);
+      goto error;
     }
     dt_iop_piece_set_raster(piece, mask, roi_in, roi_out);
   }


### PR DESCRIPTION

While working on the migration code for Flexi I stumbled upon two issues that cause masks to render differently along the OpenCL and CPU paths.

Both findings are documented extensively in [this report](https://github.com/darktable-org/darktable/blob/3eca37ede776ece163c8ffc0beaa565b9eb2e0f1/upstreamed_rendering_fixes_from_flexi_migration.md).

Addressing both issues would make the CPU and OpenCL paths virtually identical wrt mask rendering, which they should be but currently are not.

This PR fixes the first, which is **an actual bug** on the OpenCL path, as detailed below. The second issue is a **divergence** between the OpenCL and CPU paths. The report has a concrete suggestion to resolve it. @TurboGit, let me know if you want me to act on it. Personally, I vote in favor.

### What this PR fixes

`dt_develop_blend_process_cl()` skips the device→host readback of the final mask when the module's own mask came from a raster mask, assuming the host buffer already holds it. That only holds if nothing touches it on the device afterwards — but the mask post-processing right above (feathering, blur, tone curve) reads and writes `dev_mask`. With any of those active, the published raster mask is the *unrefined* one: downstream consumers get a different mask than this module blended with, and a different one than the CPU path publishes for the same edit.

### The fix

Read back unconditionally.

Found by replaying harvested mask edits on both pipes and comparing. Bucketed by mask mode and active post-processing over 42,078 edits:

| mask mode | post-processing | diverge / edits |
|---|---|---:|
| raster | any | **61 / 61** |
| raster | none | 0 / 590 |
| drawn | any | 0 / 6,747 |

The drawn row rules out the post-processing implementations themselves and leaves the publication step. On a corpus of every distinct raster configuration found, divergent edits go 42/76 → **0**, worst CPU-vs-OpenCL gap 0.940 → 0.000153.

CPU renders are unchanged; OpenCL renders change to match them.

Co-authored with Claude. 