### PR TITLE
RELEASE_NOTES.md: add AI features notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -56,6 +56,14 @@ changes (where available).
   caused by handheld or shaky-tripod brackets. Enabled by default in builds with OpenCV,
   and tunable under preferences > processing > HDR alignment.
 
+- An MCP server for darktable. The new darktable-mcp binary, a headless sibling to darktable-cli,
+  lets an AI agent drive the raw pipeline over the Model Context Protocol: list modules and inspect
+  their parameter schemas, develop an image through a given module stack and get back a preview or
+  per-channel statistics, and read history, styles and metadata from the library. Parameters are
+  addressed by name through darktable's own introspection rather than by fixed offsets, so a stack
+  stays valid across module versions, and renders run on a throwaway duplicate so the source image
+  is never modified.
+
 ## UI/UX Improvements
 
 - Checkboxes are now Bauhaus widgets and are reset to default values
@@ -70,6 +78,24 @@ changes (where available).
 - Added a new collection filter for the original image dimensions.
 
 - Support for Canon's Highlight Tone Priority.
+
+- AI models can now be installed from additional repositories. Models
+  installed this way remember where they came from and are included
+  in the update check.
+
+- Added a preference to disable automatic AI model update checks,
+  with a manual check button for when it is off.
+
+- Added a compression option for the TIFF files written by neural
+  restore denoise and upscale, matching the TIFF export module.
+
+- Model packages can now declare their ONNX Runtime graph
+  optimization level, so models that misbehave under aggressive
+  optimization no longer need workarounds in feature code.
+
+- Panasonic RW2 files now offer embedded lens distortion correction,
+  covering built-in and Lumix-branded lenses that lensfun has no
+  profile for.
 
 ## Bug Fixes
 
@@ -87,6 +113,21 @@ changes (where available).
 - Fixed a crash at the end of neural restore's raw denoise on certain
   sensor sizes, where blending the tile seams wrote past the edge of
   the image.
+
+- Fixed the feather on dense drawn path masks rendering stripes,
+  phantom arcs and crossing lines.
+
+- Fixed the feather dipping inside the shape on paths with narrow
+  spikes.
+
+- Fixed AI segmentation masks being offset by up to several pixels
+  from the object they were generated for.
+
+- Fixed the AI raw denoise preview showing identical before and after
+  images on 4BAYER (CYGM/RGBE) raws, which now shows a warning.
+
+- Fixed auto-applied denoise presets running a second time on images
+  produced by AI raw denoise.
 
 ## Lua
 


### PR DESCRIPTION
Adds release notes for some merged PRs.

The entries, and what each covers:

| Section | PR |
|---|---|
| The Big Ones | [#21573](https://github.com/darktable-org/darktable/pull/21573) – MCP server |
| Other Changes | [#21827](https://github.com/darktable-org/darktable/pull/21827) – install models from additional repositories |
| Other Changes | [#21922](https://github.com/darktable-org/darktable/pull/21922) – preference to disable automatic model update checks |
| Other Changes | [#21656](https://github.com/darktable-org/darktable/pull/21656) – Panasonic RW2 embedded lens distortion correction |
| Other Changes | [#21435](https://github.com/darktable-org/darktable/pull/21435) – TIFF compression option for neural restore output |
| Other Changes | [#21567](https://github.com/darktable-org/darktable/pull/21567) – manifest-driven ORT optimization level |
| Bug Fixes | [#21568](https://github.com/darktable-org/darktable/pull/21568) – path feather on dense masks |
| Bug Fixes | [#21998](https://github.com/darktable-org/darktable/pull/21998) – path feather across narrow spikes |
| Bug Fixes | [#21797](https://github.com/darktable-org/darktable/pull/21797) – segmentation preprocessing sampling offset |
| Bug Fixes | [#21481](https://github.com/darktable-org/darktable/pull/21481) – 4BAYER raw denoise preview warning |
| Bug Fixes | [#21940](https://github.com/darktable-org/darktable/pull/21940) – auto-applied denoise presets on AI denoised output |
