### PR TITLE
opencl: move the image2d_t bilinear resampler into bilinear.cl

### DIFF
--- a/data/kernels/basic.cl
+++ b/data/kernels/basic.cl
@@ -923,53 +923,6 @@ box_blur_5x5(read_only image2d_t in,
   write_imagef(out, (int2)(x, y), acc);
 }
 
-// works correctly with 1-4 channel float images
-kernel void interpolate_bilinear(read_only image2d_t in,
-                                const int width_in,
-                                const int height_in,
-                                write_only image2d_t out,
-                                const int width_out,
-                                const int height_out)
-{
-  const int x = get_global_id(0);
-  const int y = get_global_id(1);
-
-  if(x >= width_out || y >= height_out) return;
-
-  // Relative coordinates of the pixel in output space
-  const float x_out = (float)x /(float)width_out;
-  const float y_out = (float)y /(float)height_out;
-
-  // Corresponding absolute coordinates of the pixel in input space
-  const float x_in = x_out * (float)width_in;
-  const float y_in = y_out * (float)height_in;
-
-  // Nearest neighbours coordinates in input space
-  int x_prev = clamp((int)floor(x_in), 0, width_in - 1);
-  int x_next = clamp(x_prev + 1, 0, width_in - 1);
-  int y_prev = clamp((int)floor(y_in), 0, height_in - 1);
-  int y_next = clamp(y_prev + 1, 0, height_in - 1);
-
-  // Nearest pixels in input array (nodes in grid)
-  const float4 Q_NW = Areadpixel(in, x_prev, y_prev);
-  const float4 Q_NE = Areadpixel(in, x_next, y_prev);
-  const float4 Q_SE = Areadpixel(in, x_next, y_next);
-  const float4 Q_SW = Areadpixel(in, x_prev, y_next);
-
-  // Spatial differences between nodes
-  const float Dy_next = (float)y_next - y_in;
-  const float Dy_prev = 1.f - Dy_next; // because next - prev = 1
-  const float Dx_next = (float)x_next - x_in;
-  const float Dx_prev = 1.f - Dx_next; // because next - prev = 1
-
-  // Interpolate
-  const float4 pix_out = Dy_prev * (Q_SW * Dx_next + Q_SE * Dx_prev) +
-                         Dy_next * (Q_NW * Dx_next + Q_NE * Dx_prev);
-
-  // Full RGBa copy - 4 channels
-  write_imagef(out, (int2)(x, y), pix_out);
-}
-
 
 enum wavelets_scale_t
 {

--- a/data/kernels/bilinear.cl
+++ b/data/kernels/bilinear.cl
@@ -18,11 +18,13 @@
 
 #include "common.h"
 
-/* Bilinear interpolators on global buffers, GPU counterpart of
-   interpolate_bilinear() in common/fast_guided_filter.h.
+/* Bilinear interpolators, GPU counterpart of interpolate_bilinear() in
+   common/fast_guided_filter.h.
 
-   Used to down- and upscale the grey working buffers of the guided filters,
-   see dt_interpolate_bilinear_cl() in common/bilinear.h */
+   bilinear1/2/4 take global buffers and are used to down- and upscale the grey
+   working buffers of the guided filters, see dt_interpolate_bilinear_cl().
+   bilinear_image does the same for image2d_t, see
+   dt_interpolate_bilinear_image_cl(). Both are in common/bilinear.h */
 
 #define DT_BILINEAR_KERNEL(SUFFIX, TYPE)                                 \
 kernel void bilinear##SUFFIX(global const TYPE *const in,                \
@@ -75,3 +77,50 @@ kernel void bilinear##SUFFIX(global const TYPE *const in,                \
 DT_BILINEAR_KERNEL(1, float)
 DT_BILINEAR_KERNEL(2, float2)
 DT_BILINEAR_KERNEL(4, float4)
+
+// works correctly with 1-4 channel float images
+kernel void bilinear_image(read_only image2d_t in,
+                           const int width_in,
+                           const int height_in,
+                           write_only image2d_t out,
+                           const int width_out,
+                           const int height_out)
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+
+  if(x >= width_out || y >= height_out) return;
+
+  // Relative coordinates of the pixel in output space
+  const float x_out = (float)x /(float)width_out;
+  const float y_out = (float)y /(float)height_out;
+
+  // Corresponding absolute coordinates of the pixel in input space
+  const float x_in = x_out * (float)width_in;
+  const float y_in = y_out * (float)height_in;
+
+  // Nearest neighbours coordinates in input space
+  int x_prev = clamp((int)floor(x_in), 0, width_in - 1);
+  int x_next = clamp(x_prev + 1, 0, width_in - 1);
+  int y_prev = clamp((int)floor(y_in), 0, height_in - 1);
+  int y_next = clamp(y_prev + 1, 0, height_in - 1);
+
+  // Nearest pixels in input array (nodes in grid)
+  const float4 Q_NW = Areadpixel(in, x_prev, y_prev);
+  const float4 Q_NE = Areadpixel(in, x_next, y_prev);
+  const float4 Q_SE = Areadpixel(in, x_next, y_next);
+  const float4 Q_SW = Areadpixel(in, x_prev, y_next);
+
+  // Spatial differences between nodes
+  const float Dy_next = (float)y_next - y_in;
+  const float Dy_prev = 1.f - Dy_next; // because next - prev = 1
+  const float Dx_next = (float)x_next - x_in;
+  const float Dx_prev = 1.f - Dx_next; // because next - prev = 1
+
+  // Interpolate
+  const float4 pix_out = Dy_prev * (Q_SW * Dx_next + Q_SE * Dx_prev) +
+                         Dy_next * (Q_NW * Dx_next + Q_NE * Dx_prev);
+
+  // Full RGBa copy - 4 channels
+  write_imagef(out, (int2)(x, y), pix_out);
+}

--- a/src/common/bilinear.c
+++ b/src/common/bilinear.c
@@ -30,6 +30,7 @@ dt_bilinear_cl_global_t *dt_bilinear_init_cl_global(void)
   g->kernel_bilinear_1c = dt_opencl_create_kernel(program, "bilinear1");
   g->kernel_bilinear_2c = dt_opencl_create_kernel(program, "bilinear2");
   g->kernel_bilinear_4c = dt_opencl_create_kernel(program, "bilinear4");
+  g->kernel_bilinear_image = dt_opencl_create_kernel(program, "bilinear_image");
   return g;
 }
 
@@ -41,6 +42,7 @@ void dt_bilinear_free_cl_global(dt_bilinear_cl_global_t *g)
   dt_opencl_free_kernel(g->kernel_bilinear_1c);
   dt_opencl_free_kernel(g->kernel_bilinear_2c);
   dt_opencl_free_kernel(g->kernel_bilinear_4c);
+  dt_opencl_free_kernel(g->kernel_bilinear_image);
 
   free(g);
 }
@@ -74,6 +76,23 @@ cl_int dt_interpolate_bilinear_cl(const int devid,
   }
 
   return dt_opencl_enqueue_kernel_2d_args(devid, kernel, width_out, height_out,
+            CLARG(dev_in), CLARG(width_in), CLARG(height_in),
+            CLARG(dev_out), CLARG(width_out), CLARG(height_out));
+}
+
+
+cl_int dt_interpolate_bilinear_image_cl(const int devid,
+                                        cl_mem dev_in,
+                                        const int width_in,
+                                        const int height_in,
+                                        cl_mem dev_out,
+                                        const int width_out,
+                                        const int height_out)
+{
+  const dt_bilinear_cl_global_t *const g = darktable.opencl->bilinear;
+
+  return dt_opencl_enqueue_kernel_2d_args(devid, g->kernel_bilinear_image,
+            width_out, height_out,
             CLARG(dev_in), CLARG(width_in), CLARG(height_in),
             CLARG(dev_out), CLARG(width_out), CLARG(height_out));
 }

--- a/src/common/bilinear.h
+++ b/src/common/bilinear.h
@@ -27,6 +27,7 @@ typedef struct dt_bilinear_cl_global_t
   int kernel_bilinear_1c;
   int kernel_bilinear_2c;
   int kernel_bilinear_4c;
+  int kernel_bilinear_image;
 } dt_bilinear_cl_global_t;
 
 dt_bilinear_cl_global_t *dt_bilinear_init_cl_global(void);
@@ -49,6 +50,20 @@ cl_int dt_interpolate_bilinear_cl(const int devid,
                                   const int width_out,
                                   const int height_out,
                                   const int ch);
+
+/** Bilinear resampling of a device image holding 1 to 4 channels per pixel,
+ *  as allocated by dt_opencl_alloc_device().
+ *
+ *  Input and output must be distinct. This is the image2d_t counterpart of
+ *  dt_interpolate_bilinear_cl() above.
+ */
+cl_int dt_interpolate_bilinear_image_cl(const int devid,
+                                        cl_mem dev_in,
+                                        const int width_in,
+                                        const int height_in,
+                                        cl_mem dev_out,
+                                        const int width_out,
+                                        const int height_out);
 #endif
 
 // clang-format off

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -23,6 +23,7 @@
 #include <string.h>
 
 #include "bauhaus/bauhaus.h"
+#include "common/bilinear.h"
 #include "common/box_filters.h"
 #include "common/bspline.h"
 #include "common/opencl.h"
@@ -161,7 +162,6 @@ typedef struct dt_iop_highlights_global_data_t
   int kernel_filmic_bspline_horizontal;
   int kernel_filmic_wavelets_detail;
 
-  int kernel_interpolate_bilinear;
 } dt_iop_highlights_global_data_t;
 
 
@@ -1065,7 +1065,6 @@ void init_global(dt_iop_module_so_t *self)
   gd->kernel_highlights_dilatemask = dt_opencl_create_kernel(program, "highlights_dilatemask");
   gd->kernel_highlights_chroma = dt_opencl_create_kernel(program, "highlights_chroma");
   gd->kernel_highlights_false_color = dt_opencl_create_kernel(program, "highlights_false_color");
-  gd->kernel_interpolate_bilinear = dt_opencl_create_kernel(program, "interpolate_bilinear");
 
   const int wavelets = 35; // bspline.cl, from programs.conf
   gd->kernel_filmic_bspline_horizontal = dt_opencl_create_kernel(wavelets, "blur_2D_Bspline_horizontal");
@@ -1090,7 +1089,6 @@ void cleanup_global(dt_iop_module_so_t *self)
   dt_opencl_free_kernel(gd->kernel_highlights_dilatemask);
   dt_opencl_free_kernel(gd->kernel_highlights_chroma);
   dt_opencl_free_kernel(gd->kernel_highlights_false_color);
-  dt_opencl_free_kernel(gd->kernel_interpolate_bilinear);
 
   dt_opencl_free_kernel(gd->kernel_filmic_bspline_vertical);
   dt_opencl_free_kernel(gd->kernel_filmic_bspline_horizontal);

--- a/src/iop/hlreconstruct/laplacian.c
+++ b/src/iop/hlreconstruct/laplacian.c
@@ -840,14 +840,12 @@ static cl_int process_laplacian_bayer_cl(dt_iop_module_t *self,
   if(err != CL_SUCCESS) goto error;
 
   // Downsample
-  err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_interpolate_bilinear, ds_width, ds_height,
-    CLARG(clipping_mask), CLARG(width), CLARG(height),
-    CLARG(ds_clipping_mask), CLARG(ds_width), CLARG(ds_height));
+  err = dt_interpolate_bilinear_image_cl(devid, clipping_mask, width, height,
+                                         ds_clipping_mask, ds_width, ds_height);
   if(err != CL_SUCCESS) goto error;
 
-  err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_interpolate_bilinear, ds_width, ds_height,
-    CLARG(interpolated), CLARG(width), CLARG(height),
-    CLARG(ds_interpolated), CLARG(ds_width), CLARG(ds_height));
+  err = dt_interpolate_bilinear_image_cl(devid, interpolated, width, height,
+                                         ds_interpolated, ds_width, ds_height);
 
   if(err != CL_SUCCESS) goto error;
 
@@ -864,9 +862,8 @@ static cl_int process_laplacian_bayer_cl(dt_iop_module_t *self,
   }
 
   // Upsample
-  err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_interpolate_bilinear, width, height,
-    CLARG(ds_interpolated), CLARG(ds_width), CLARG(ds_height),
-    CLARG(interpolated), CLARG(width), CLARG(height));
+  err = dt_interpolate_bilinear_image_cl(devid, ds_interpolated, ds_width, ds_height,
+                                         interpolated, width, height);
   if(err != CL_SUCCESS) goto error;
 
   // Remosaic


### PR DESCRIPTION
The guided-laplacian highlight reconstruction carried its own copy of a bilinear resampling kernel in basic.cl, duplicating the buffer variants that now live in bilinear.cl. Move it there as bilinear_image and expose it through dt_interpolate_bilinear_image_cl(), so all bilinear resamplers share one home and highlights no longer keeps a private kernel handle.

The kernel body is unchanged, image and buffer variants stay separate because OpenCL C cannot express one kernel over both image2d_t and global buffers.

No functional change. Tested locally against with a couple of images. But will follow-up with a full integration test run.

Disclaimer: this change was co-created with Claude.