### PR TITLE
highlights: fix out-of-bounds stack write on 4-colour CFA sensors

### DIFF
--- a/src/iop/hlreconstruct/opposed.c
+++ b/src/iop/hlreconstruct/opposed.c
@@ -270,7 +270,9 @@ static float *_process_opposed(dt_iop_module_t *self,
       {
         for(int mcol = 0; mcol < mwidth-1; mcol++)
         {
-          char mbuff[3] = { 0, 0, 0 };
+          // fcol() returns 0-3, the fourth index is only written for
+          // CYGM/RGBE sensors and never read back below.
+          char mbuff[4] = { 0, 0, 0, 0 };
           for(int y = 0; y < 3; y++)
           {
             for(int x = 0; x < 3; x++)


### PR DESCRIPTION
Within src/iop/hlreconstruct/opposed.c `fcol()` returns 0-3, but the clipped-photosite counter in the opposed reconstruction was a char[3]. On CYGM/RGBE images the write to mbuff[3] lands one byte past the array and trips the stack protector, aborting with "stack smashing detected" -  reproducible with integration test 0177-bayer4 (Canon PowerShot G1).

Only indices 0-2 are ever read back, so widening the array fixes the overflow without changing any output.

The nightly integration test run is green because it's UB: whether that byte hits the canary or padding depends on the reference build's compiler and hardening flags.

This issue showed up when I was running the integration test suite for https://github.com/darktable-org/darktable/pull/22042, see linked test log file with this output:
```
 Test 0177-bayer4
      Image bayer4.crw
      Timing cpu *** stack smashing detected ***: terminated
*** stack smashing detected ***: terminated
*** stack smashing detected ***: terminated
*** stack smashing detected ***: terminated
8,14s
      Timing gpu *** stack smashing detected ***: terminated
*** stack smashing detected ***: terminated
*** stack smashing detected ***: terminated
*** stack smashing detected ***: terminated
2,82s
  FAILS : darktable-cli errored
```

Disclaimer: this change was co-created with Claude.