### PR TITLE
gui: fix touchscreen pan and pinch zoom in darkroom

### DIFF
--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -873,6 +873,10 @@ static void _record_touchpad_device(const GdkEvent *event)
              dt_gdk_event_get_type(event));
 }
 
+/* set while a touchscreen pinch runs on the center view, so the single-finger
+ * touch pan does not fight the zoom for the viewport */
+static gboolean _center_touch_pinching = FALSE;
+
 /* GtkGestureZoom replaces the old "event" signal handler that forwarded raw
  * GDK_TOUCHPAD_PINCH events: the phase field becomes the begin /
  * scale-changed / end signals (and "end" fires on cancel as well, so the
@@ -886,17 +890,26 @@ static void _pinch_event(GtkGesture *gesture,
 {
   (void)user_data;
   GtkWidget *widget = dt_gui_get_widget(gesture);
-  if(e->event) _record_touchpad_device(e->event);
+  // only a real touchpad may take over the scroll-stream pan routing
+  if(e->event && !e->touchscreen) _record_touchpad_device(e->event);
+
+  // a second finger on the screen hands the viewport over to the pinch, so the
+  // finger that is still dragging must stop panning (see _touch_moved)
+  if(e->touchscreen)
+    _center_touch_pinching = e->phase == GDK_TOUCHPAD_GESTURE_PHASE_BEGIN
+                             || e->phase == GDK_TOUCHPAD_GESTURE_PHASE_UPDATE;
 
   dt_print(DT_DEBUG_INPUT,
-           "[touchpad] pinch x=%.2f y=%.2f phase=%d dx=%.3f dy=%.3f scale=%.6f state=0x%x",
+           "[%s] pinch x=%.2f y=%.2f phase=%d dx=%.3f dy=%.3f scale=%.6f state=0x%x",
+           e->touchscreen ? "touchscreen" : "touchpad",
            e->x, e->y, e->phase, e->dx, e->dy, e->scale, e->state);
   if(dt_view_manager_gesture_pinch(darktable.view_manager, e->x, e->y,
                                    e->dx, e->dy, e->phase, e->scale, e->state))
     gtk_widget_queue_draw(widget);
   else
     dt_print(DT_DEBUG_INPUT,
-             "[touchpad] pinch ignored by current view");
+             "[%s] pinch ignored by current view",
+             e->touchscreen ? "touchscreen" : "touchpad");
 }
 
 gboolean dt_gui_scroll_should_pan(const GdkEvent *event)
@@ -1658,6 +1671,26 @@ static void _mouse_moved(GtkEventControllerMotion *controller,
 #endif
 }
 
+/* A finger drag reaches neither the motion controller nor, therefore,
+ * dt_control_mouse_moved() -- see dt_gui_connect_touch_motion().  Press and
+ * release still come from the click gesture, so feeding the motion is all it
+ * takes to make panning a zoomed image (and every other press-and-drag
+ * interaction) work with a finger again. */
+static void _touch_moved(GtkGesture *gesture,
+                         gdouble x,
+                         gdouble y,
+                         gpointer user_data)
+{
+  (void)user_data;
+  const guint state =
+    dt_gui_get_current_event_state(GTK_EVENT_CONTROLLER(gesture)) & 0xf;
+  dt_print(DT_DEBUG_INPUT,
+           "[touchscreen] motion x=%.1f y=%.1f state=0x%x%s",
+           x, y, state, _center_touch_pinching ? " ignored, pinch active" : "");
+  if(_center_touch_pinching) return;
+  dt_control_mouse_moved(x, y, 1.0, state);
+}
+
 static void _center_leave(GtkEventControllerMotion *controller,
                           gpointer user_data)
 {
@@ -2049,6 +2082,7 @@ int dt_gui_gtk_init(dt_gui_gtk_t *gui)
                           _scrolled, NULL);
 
     dt_gui_connect_pinch(widget, _pinch_event, NULL);
+    dt_gui_connect_touch_motion(widget, _touch_moved, gui);
   }
 
   // TODO: left, right, top, bottom:
@@ -5508,11 +5542,23 @@ typedef struct dt_gui_pinch_ctx_t
   dt_gui_pinch_handler_t handler;
   gpointer user_data;
   gboolean active;
+  gboolean touchscreen;      /* no GdkEventTouchpadPinch to read the pinch from */
+  gdouble focal_x, focal_y;  /* previous focal point, for the touchscreen deltas */
 } dt_gui_pinch_ctx_t;
+
+/* the gesture's last event.  Touch sequences are keyed by their
+ * GdkEventSequence, touchpad gestures by the NULL sequence, so ask for the
+ * sequence that was updated last rather than for NULL. */
+static const GdkEvent *_pinch_last_event(GtkGesture *gesture)
+{
+  return gtk_gesture_get_last_event(gesture,
+                                    gtk_gesture_get_last_updated_sequence(gesture));
+}
 
 static void _pinch_dispatch(GtkGesture *gesture,
                             const GdkTouchpadGesturePhase phase,
-                            const gboolean have_event)
+                            const gboolean have_event,
+                            const gdouble touch_scale)
 {
   dt_gui_pinch_ctx_t *ctx = g_object_get_data(G_OBJECT(gesture), "dt-gui-pinch-ctx");
   if(!ctx) return;
@@ -5520,26 +5566,52 @@ static void _pinch_dispatch(GtkGesture *gesture,
   dt_gui_pinch_event_t e = { 0 };
   e.phase = phase;
   e.scale = 1.0;   /* the default when the sequence's last event is gone (END) */
+  e.touchscreen = ctx->touchscreen;
   if(have_event)
   {
-    e.event = gtk_gesture_get_last_event(gesture, NULL);
+    e.event = _pinch_last_event(gesture);
     if(e.event)
     {
-      if(dt_gdk_event_get_type(e.event) != GDK_TOUCHPAD_PINCH)
-      {
-        // touchscreen pinches were never handled before: keep ignoring them
-        return;
-      }
-      dt_gdk_touchpad_pinch_get_deltas(e.event, &e.dx, &e.dy);
-      e.scale = dt_gdk_touchpad_pinch_get_scale(e.event);
+      const gboolean touchpad_pinch =
+        dt_gdk_event_get_type(e.event) == GDK_TOUCHPAD_PINCH;
+      // the source is decided once, at BEGIN: a sequence that changes kind
+      // mid-gesture would mix two incompatible scale references
+      if(touchpad_pinch == ctx->touchscreen) return;
+
       e.state = dt_gdk_event_get_state(e.event) & 0xf;
+      if(!ctx->touchscreen)
+      {
+        dt_gdk_touchpad_pinch_get_deltas(e.event, &e.dx, &e.dy);
+        e.scale = dt_gdk_touchpad_pinch_get_scale(e.event);
 #if GTK_CHECK_VERSION(4, 0, 0)
-      // GTK4 has no root-coords API: surface-relative position (see gtk.c)
-      gdk_event_get_position(e.event, &e.x, &e.y);
+        // GTK4 has no root-coords API: surface-relative position (see gtk.c)
+        gdk_event_get_position(e.event, &e.x, &e.y);
 #else
-      e.x = dt_gdk_event_get_root_x(e.event);
-      e.y = dt_gdk_event_get_root_y(e.event);
+        e.x = dt_gdk_event_get_root_x(e.event);
+        e.y = dt_gdk_event_get_root_y(e.event);
 #endif
+      }
+      else
+      {
+        gdouble cx = 0.0, cy = 0.0;
+        if(!gtk_gesture_get_bounding_box_center(gesture, &cx, &cy)) return;
+        e.scale = touch_scale > 0.0 ? touch_scale : 1.0;
+        // the bounding box is in the coordinate space the touch events were
+        // delivered in, and the last event carries the same point in both
+        // spaces: their difference is the window origin the consumers subtract
+        // again (zero on GTK4, where both are surface-relative)
+        e.x = cx + dt_gdk_event_get_root_x(e.event) - dt_gdk_event_get_x(e.event);
+        e.y = cy + dt_gdk_event_get_root_y(e.event) - dt_gdk_event_get_y(e.event);
+        if(phase == GDK_TOUCHPAD_GESTURE_PHASE_UPDATE)
+        {
+          // a viewport pan delta like the touchpad's dx/dy, but negated: on a
+          // touchscreen the content is expected to follow the fingers
+          e.dx = ctx->focal_x - e.x;
+          e.dy = ctx->focal_y - e.y;
+        }
+        ctx->focal_x = e.x;
+        ctx->focal_y = e.y;
+      }
     }
   }
 
@@ -5550,24 +5622,37 @@ static void _pinch_begin(GtkGestureZoom *gesture, gpointer user_data)
 {
   (void)user_data;
   dt_gui_pinch_ctx_t *ctx = g_object_get_data(G_OBJECT(gesture), "dt-gui-pinch-ctx");
-  if(!ctx || !darktable.gui->touchpad_gestures_enabled) return;
-  // GtkGestureZoom also recognizes touchscreen pinches, which were never
-  // handled before: only touchpad pinches set the active flag
-  const GdkEvent *event = gtk_gesture_get_last_event(GTK_GESTURE(gesture), NULL);
-  if(!event || dt_gdk_event_get_type(event) != GDK_TOUCHPAD_PINCH) return;
+  if(!ctx) return;
+  const GdkEvent *event = _pinch_last_event(GTK_GESTURE(gesture));
+  if(!event) return;
+  const GdkEventType type = dt_gdk_event_get_type(event);
+  if(type == GDK_TOUCHPAD_PINCH)
+  {
+    // the preference covers two-finger touchpad gestures only
+    if(!darktable.gui->touchpad_gestures_enabled) return;
+    ctx->touchscreen = FALSE;
+  }
+  else if(type == GDK_TOUCH_BEGIN || type == GDK_TOUCH_UPDATE || type == GDK_TOUCH_END)
+    ctx->touchscreen = TRUE;
+  else
+    return;
+
   ctx->active = TRUE;
-  _pinch_dispatch(GTK_GESTURE(gesture), GDK_TOUCHPAD_GESTURE_PHASE_BEGIN, TRUE);
+  _pinch_dispatch(GTK_GESTURE(gesture), GDK_TOUCHPAD_GESTURE_PHASE_BEGIN, TRUE, 1.0);
 }
 
 static void _pinch_scale_changed(GtkGestureZoom *gesture,
                                  gdouble scale,
                                  gpointer user_data)
 {
-  (void)scale;
   (void)user_data;
   dt_gui_pinch_ctx_t *ctx = g_object_get_data(G_OBJECT(gesture), "dt-gui-pinch-ctx");
-  if(!ctx || !darktable.gui->touchpad_gestures_enabled || !ctx->active) return;
-  _pinch_dispatch(GTK_GESTURE(gesture), GDK_TOUCHPAD_GESTURE_PHASE_UPDATE, TRUE);
+  // ctx->active already carries the preference decision taken at BEGIN, so a
+  // preference toggled mid-gesture cannot swallow the matching END
+  if(!ctx || !ctx->active) return;
+  // for a touchscreen the signal argument is the only scale there is: the
+  // distance between the fingers over their distance when the gesture began
+  _pinch_dispatch(GTK_GESTURE(gesture), GDK_TOUCHPAD_GESTURE_PHASE_UPDATE, TRUE, scale);
 }
 
 static void _pinch_end(GtkGestureZoom *gesture, gpointer user_data)
@@ -5576,11 +5661,10 @@ static void _pinch_end(GtkGestureZoom *gesture, gpointer user_data)
   dt_gui_pinch_ctx_t *ctx = g_object_get_data(G_OBJECT(gesture), "dt-gui-pinch-ctx");
   if(!ctx || !ctx->active) return;
   ctx->active = FALSE;
-  if(!darktable.gui->touchpad_gestures_enabled) return;
   // also fires after cancel (see gtkgesture.c: the cancel path ends the
   // sequence), so the consumer's END/CANCEL handling always runs; the
   // sequence's last event is already gone here, hence no event data
-  _pinch_dispatch(GTK_GESTURE(gesture), GDK_TOUCHPAD_GESTURE_PHASE_END, FALSE);
+  _pinch_dispatch(GTK_GESTURE(gesture), GDK_TOUCHPAD_GESTURE_PHASE_END, FALSE, 1.0);
 }
 
 GtkGesture *(dt_gui_connect_pinch)(GtkWidget *widget,
@@ -5600,6 +5684,54 @@ GtkGesture *(dt_gui_connect_pinch)(GtkWidget *widget,
   g_signal_connect(gesture, "begin", G_CALLBACK(_pinch_begin), NULL);
   g_signal_connect(gesture, "scale-changed", G_CALLBACK(_pinch_scale_changed), NULL);
   g_signal_connect(gesture, "end", G_CALLBACK(_pinch_end), NULL);
+
+  return gesture;
+}
+
+/* per-gesture state for dt_gui_connect_touch_motion, kept on the gesture
+ * object exactly like the pinch context above. */
+typedef struct dt_gui_touch_motion_ctx_t
+{
+  dt_gui_touch_motion_handler_t handler;
+  gpointer user_data;
+} dt_gui_touch_motion_ctx_t;
+
+static void _touch_motion_update(GtkGestureDrag *gesture,
+                                 gdouble offset_x,
+                                 gdouble offset_y,
+                                 gpointer user_data)
+{
+  (void)user_data;
+  dt_gui_touch_motion_ctx_t *ctx =
+    g_object_get_data(G_OBJECT(gesture), "dt-gui-touch-motion-ctx");
+  if(!ctx) return;
+
+  // the drag reports an offset from where the finger landed; motion handlers
+  // want the position itself
+  gdouble x = 0.0, y = 0.0;
+  if(!gtk_gesture_drag_get_start_point(gesture, &x, &y)) return;
+  ctx->handler(GTK_GESTURE(gesture), x + offset_x, y + offset_y, ctx->user_data);
+}
+
+GtkGesture *(dt_gui_connect_touch_motion)(GtkWidget *widget,
+                                          dt_gui_touch_motion_handler_t handler,
+                                          gpointer data)
+{
+  GtkGesture *gesture = gtk_gesture_drag_new(widget);
+  dt_gui_add_controller(widget, gesture);
+  // GTK4 GtkGesture *gesture = gtk_gesture_drag_new();
+  //      gtk_widget_add_controller(widget, GTK_EVENT_CONTROLLER(gesture));
+
+  // pointer drags already reach the motion controller; this gesture only fills
+  // in what GDK no longer emulates for touch
+  gtk_gesture_single_set_touch_only(GTK_GESTURE_SINGLE(gesture), TRUE);
+
+  dt_gui_touch_motion_ctx_t *ctx = g_new0(dt_gui_touch_motion_ctx_t, 1);
+  ctx->handler = handler;
+  ctx->user_data = data;
+  g_object_set_data_full(G_OBJECT(gesture), "dt-gui-touch-motion-ctx", ctx, g_free);
+
+  g_signal_connect(gesture, "drag-update", G_CALLBACK(_touch_motion_update), NULL);
 
   return gesture;
 }

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -891,13 +891,16 @@ static void _pinch_event(GtkGesture *gesture,
   (void)user_data;
   GtkWidget *widget = dt_gui_get_widget(gesture);
   // only a real touchpad may take over the scroll-stream pan routing
-  if(e->event && !e->touchscreen) _record_touchpad_device(e->event);
+  if(e->event && !e->touchscreen)
+    _record_touchpad_device(e->event);
 
   // a second finger on the screen hands the viewport over to the pinch, so the
   // finger that is still dragging must stop panning (see _touch_moved)
   if(e->touchscreen)
+  {
     _center_touch_pinching = e->phase == GDK_TOUCHPAD_GESTURE_PHASE_BEGIN
                              || e->phase == GDK_TOUCHPAD_GESTURE_PHASE_UPDATE;
+  }
 
   dt_print(DT_DEBUG_INPUT,
            "[%s] pinch x=%.2f y=%.2f phase=%d dx=%.3f dy=%.3f scale=%.6f state=0x%x",
@@ -905,19 +908,27 @@ static void _pinch_event(GtkGesture *gesture,
            e->x, e->y, e->phase, e->dx, e->dy, e->scale, e->state);
   if(dt_view_manager_gesture_pinch(darktable.view_manager, e->x, e->y,
                                    e->dx, e->dy, e->phase, e->scale, e->state))
+  {
     gtk_widget_queue_draw(widget);
+  }
   else
+  {
     dt_print(DT_DEBUG_INPUT,
              "[%s] pinch ignored by current view",
              e->touchscreen ? "touchscreen" : "touchpad");
+  }
 }
 
 gboolean dt_gui_scroll_should_pan(const GdkEvent *event)
 {
-  if(!darktable.gui->touchpad_gestures_enabled) return FALSE;
-  if(dt_modifiers_include(dt_gdk_event_get_state(event), GDK_CONTROL_MASK)) return FALSE;
-  if(dt_gdk_event_get_scroll_direction(event) != GDK_SCROLL_SMOOTH) return FALSE;
-  if(dt_gdk_event_is_scroll_stop(event)) return FALSE;
+  if(!darktable.gui->touchpad_gestures_enabled)
+    return FALSE;
+  if(dt_modifiers_include(dt_gdk_event_get_state(event), GDK_CONTROL_MASK))
+    return FALSE;
+  if(dt_gdk_event_get_scroll_direction(event) != GDK_SCROLL_SMOOTH)
+    return FALSE;
+  if(dt_gdk_event_is_scroll_stop(event))
+    return FALSE;
 #ifdef GDK_WINDOWING_QUARTZ
   /* Quartz exposes both the built-in trackpad and ordinary pointing devices
    * as the Core Pointer (GDK_SOURCE_MOUSE).  In the tested setup, trackpad
@@ -1671,24 +1682,22 @@ static void _mouse_moved(GtkEventControllerMotion *controller,
 #endif
 }
 
-/* A finger drag reaches neither the motion controller nor, therefore,
- * dt_control_mouse_moved() -- see dt_gui_connect_touch_motion().  Press and
- * release still come from the click gesture, so feeding the motion is all it
- * takes to make panning a zoomed image (and every other press-and-drag
- * interaction) work with a finger again. */
+/* Feed touch motion to dt_control_mouse_moved() for panning and
+ * press-and-drag interactions. See dt_gui_connect_touch_motion(). */
 static void _touch_moved(GtkGesture *gesture,
                          gdouble x,
                          gdouble y,
                          gpointer user_data)
 {
   (void)user_data;
-  const guint state =
+  const GdkModifierType state =
     dt_gui_get_current_event_state(GTK_EVENT_CONTROLLER(gesture)) & 0xf;
   dt_print(DT_DEBUG_INPUT,
            "[touchscreen] motion x=%.1f y=%.1f state=0x%x%s",
            x, y, state, _center_touch_pinching ? " ignored, pinch active" : "");
-  if(_center_touch_pinching) return;
-  dt_control_mouse_moved(x, y, 1.0, state);
+  if(_center_touch_pinching)
+    return;
+  dt_control_mouse_moved(x, y, 1.0, (int)state);
 }
 
 static void _center_leave(GtkEventControllerMotion *controller,
@@ -5576,7 +5585,8 @@ static void _pinch_dispatch(GtkGesture *gesture,
         dt_gdk_event_get_type(e.event) == GDK_TOUCHPAD_PINCH;
       // the source is decided once, at BEGIN: a sequence that changes kind
       // mid-gesture would mix two incompatible scale references
-      if(touchpad_pinch == ctx->touchscreen) return;
+      if(touchpad_pinch == ctx->touchscreen)
+        return;
 
       e.state = dt_gdk_event_get_state(e.event) & 0xf;
       if(!ctx->touchscreen)
@@ -5594,7 +5604,8 @@ static void _pinch_dispatch(GtkGesture *gesture,
       else
       {
         gdouble cx = 0.0, cy = 0.0;
-        if(!gtk_gesture_get_bounding_box_center(gesture, &cx, &cy)) return;
+        if(!gtk_gesture_get_bounding_box_center(gesture, &cx, &cy))
+          return;
         e.scale = touch_scale > 0.0 ? touch_scale : 1.0;
         // the bounding box is in the coordinate space the touch events were
         // delivered in, and the last event carries the same point in both
@@ -5622,20 +5633,29 @@ static void _pinch_begin(GtkGestureZoom *gesture, gpointer user_data)
 {
   (void)user_data;
   dt_gui_pinch_ctx_t *ctx = g_object_get_data(G_OBJECT(gesture), "dt-gui-pinch-ctx");
-  if(!ctx) return;
+  if(!ctx)
+    return;
+
   const GdkEvent *event = _pinch_last_event(GTK_GESTURE(gesture));
-  if(!event) return;
+  if(!event)
+    return;
+
   const GdkEventType type = dt_gdk_event_get_type(event);
   if(type == GDK_TOUCHPAD_PINCH)
   {
     // the preference covers two-finger touchpad gestures only
-    if(!darktable.gui->touchpad_gestures_enabled) return;
+    if(!darktable.gui->touchpad_gestures_enabled)
+      return;
     ctx->touchscreen = FALSE;
   }
   else if(type == GDK_TOUCH_BEGIN || type == GDK_TOUCH_UPDATE || type == GDK_TOUCH_END)
+  {
     ctx->touchscreen = TRUE;
+  }
   else
+  {
     return;
+  }
 
   ctx->active = TRUE;
   _pinch_dispatch(GTK_GESTURE(gesture), GDK_TOUCHPAD_GESTURE_PHASE_BEGIN, TRUE, 1.0);
@@ -5649,7 +5669,8 @@ static void _pinch_scale_changed(GtkGestureZoom *gesture,
   dt_gui_pinch_ctx_t *ctx = g_object_get_data(G_OBJECT(gesture), "dt-gui-pinch-ctx");
   // ctx->active already carries the preference decision taken at BEGIN, so a
   // preference toggled mid-gesture cannot swallow the matching END
-  if(!ctx || !ctx->active) return;
+  if(!ctx || !ctx->active)
+    return;
   // for a touchscreen the signal argument is the only scale there is: the
   // distance between the fingers over their distance when the gesture began
   _pinch_dispatch(GTK_GESTURE(gesture), GDK_TOUCHPAD_GESTURE_PHASE_UPDATE, TRUE, scale);
@@ -5659,7 +5680,8 @@ static void _pinch_end(GtkGestureZoom *gesture, gpointer user_data)
 {
   (void)user_data;
   dt_gui_pinch_ctx_t *ctx = g_object_get_data(G_OBJECT(gesture), "dt-gui-pinch-ctx");
-  if(!ctx || !ctx->active) return;
+  if(!ctx || !ctx->active)
+    return;
   ctx->active = FALSE;
   // also fires after cancel (see gtkgesture.c: the cancel path ends the
   // sequence), so the consumer's END/CANCEL handling always runs; the
@@ -5704,12 +5726,14 @@ static void _touch_motion_update(GtkGestureDrag *gesture,
   (void)user_data;
   dt_gui_touch_motion_ctx_t *ctx =
     g_object_get_data(G_OBJECT(gesture), "dt-gui-touch-motion-ctx");
-  if(!ctx) return;
+  if(!ctx)
+    return;
 
   // the drag reports an offset from where the finger landed; motion handlers
   // want the position itself
   gdouble x = 0.0, y = 0.0;
-  if(!gtk_gesture_drag_get_start_point(gesture, &x, &y)) return;
+  if(!gtk_gesture_drag_get_start_point(gesture, &x, &y))
+    return;
   ctx->handler(GTK_GESTURE(gesture), x + offset_x, y + offset_y, ctx->user_data);
 }
 
@@ -5717,12 +5741,14 @@ GtkGesture *(dt_gui_connect_touch_motion)(GtkWidget *widget,
                                           dt_gui_touch_motion_handler_t handler,
                                           gpointer data)
 {
+#if GTK_CHECK_VERSION(4, 0, 0)
+  GtkGesture *gesture = gtk_gesture_drag_new();
+#else
   GtkGesture *gesture = gtk_gesture_drag_new(widget);
+#endif
   dt_gui_add_controller(widget, gesture);
-  // GTK4 GtkGesture *gesture = gtk_gesture_drag_new();
-  //      gtk_widget_add_controller(widget, GTK_EVENT_CONTROLLER(gesture));
 
-  // pointer drags already reach the motion controller; this gesture only fills
+  // pointer drags already reach the motion controller, this gesture only fills
   // in what GDK no longer emulates for touch
   gtk_gesture_single_set_touch_only(GTK_GESTURE_SINGLE(gesture), TRUE);
 

--- a/src/gui/gtk.h
+++ b/src/gui/gtk.h
@@ -702,16 +702,28 @@ GtkGesture *(dt_gui_connect_drag)(GtkWidget *widget,
   ASSERT_FUNC_TYPE(drag_update, void(*)(GtkGestureDrag *, double, double, __typeof__(data))), \
   dt_gui_connect_drag(GTK_WIDGET(widget), G_CALLBACK(drag_begin), G_CALLBACK(drag_end), G_CALLBACK(drag_update), (data)))
 
-/* touchpad pinch via GtkGestureZoom: the old GTK3-only "event" signal
+/* pinch to zoom via GtkGestureZoom: the old GTK3-only "event" signal
  * handler forwarded raw GDK_TOUCHPAD_PINCH events; the phase field becomes
  * the begin / scale-changed / end signals (and "end" fires on cancel as
- * well, so the consumer's END/CANCEL reset still runs).  GtkGestureZoom also
- * recognizes touchscreen pinches, which were never handled before -- ignored
- * here for parity, only touchpad pinches reach the handler.  dx/dy, scale,
- * state and the focal point are pulled from the gesture's last event (root
- * coords on GTK3, surface-relative on GTK4 -- see dt_gui_get_event_coords);
- * on END the event is already gone, so the handler gets NULL and the deltas
- * default to zero.  The touchpad_gestures_enabled pref and the per-gesture
+ * well, so the consumer's END/CANCEL reset still runs).  Both pinch sources
+ * GtkGestureZoom recognizes are forwarded:
+ *
+ * - touchpad: scale, dx/dy, state and the focal point come from the
+ *   GdkEventTouchpadPinch the gesture last saw, and touchpad_gestures_enabled
+ *   gates the gesture as a whole.
+ * - touchscreen: there is no such event, so the scale is the gesture's own
+ *   cumulative scale and the focal point is the bounding-box center of the
+ *   touch points.  Not gated by the touchpad preference, which is documented
+ *   as covering two-finger *touchpad* gestures.
+ *
+ * dx/dy are a viewport pan delta in both cases, i.e. the direction the
+ * viewport should move: the touchpad's two-finger translation as GDK reports
+ * it, and the negated focal-point movement on a touchscreen, where the
+ * content is expected to follow the fingers.
+ *
+ * The focal point is in root coords on GTK3 and surface-relative on GTK4 (see
+ * dt_gui_get_event_coords); on END the event is already gone, so the handler
+ * gets NULL, scale 1.0 and zero deltas.  The preference and the per-gesture
  * active tracking live inside the helper; handlers only forward the parsed
  * event (e.g. to dt_view_manager_gesture_pinch). */
 typedef struct dt_gui_pinch_event_t
@@ -722,6 +734,7 @@ typedef struct dt_gui_pinch_event_t
   gdouble dx, dy;                 /* pan deltas */
   gdouble scale;                  /* pinch scale */
   guint state;                    /* modifier state (low 4 bits) */
+  gboolean touchscreen;           /* touchscreen pinch, not a touchpad one */
 } dt_gui_pinch_event_t;
 
 typedef void (*dt_gui_pinch_handler_t)(GtkGesture *gesture,
@@ -734,6 +747,27 @@ GtkGesture *(dt_gui_connect_pinch)(GtkWidget *widget,
 #define dt_gui_connect_pinch(widget, handler, data) ( \
   ASSERT_FUNC_TYPE(handler, void(*)(GtkGesture *, const dt_gui_pinch_event_t *, __typeof__(data))), \
   dt_gui_connect_pinch(GTK_WIDGET(widget), (handler), (data)))
+
+/* touch drags are not pointer motion: as soon as any GtkGesture is attached
+ * to a widget, GTK selects GDK_TOUCH_MASK on it, and GDK then stops rewriting
+ * the pointer-emulating touch sequence into button/motion events (see
+ * proxy_button_event() in gdk/gdkwindow.c), so GtkEventControllerMotion never
+ * sees a finger drag.  Press and release still arrive through
+ * dt_gui_connect_click() -- GtkGestureSingle reports touch as button 1 --
+ * only the motion in between is missing, and a touch-only GtkGestureDrag
+ * supplies it.  The handler gets widget coordinates, like a motion callback,
+ * and is called for the finger that started the drag only. */
+typedef void (*dt_gui_touch_motion_handler_t)(GtkGesture *gesture,
+                                              gdouble x,
+                                              gdouble y,
+                                              gpointer user_data);
+
+GtkGesture *(dt_gui_connect_touch_motion)(GtkWidget *widget,
+                                          dt_gui_touch_motion_handler_t handler,
+                                          gpointer data);
+#define dt_gui_connect_touch_motion(widget, handler, data) ( \
+  ASSERT_FUNC_TYPE(handler, void(*)(GtkGesture *, double, double, __typeof__(data))), \
+  dt_gui_connect_touch_motion(GTK_WIDGET(widget), (handler), (data)))
 
 GtkEventController *(dt_gui_connect_motion)(GtkWidget *widget,
                                             GCallback motion,

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -5259,20 +5259,27 @@ static void _second_window_scrolled_callback(GtkEventControllerScroll *controlle
 #endif
 }
 
-/* touchpad pinch in the second window via GtkGestureZoom: the old "event"
- * signal handler (GTK3-only) forwarded raw GDK_TOUCHPAD_PINCH events; the
- * phase field becomes the begin/scale-changed/end signals ("end" fires on
- * cancel too).  dx/dy are not used here (macOS delivers the pan as a separate
- * scroll stream, see _second_window_scrolled_callback). */
-static gboolean _second_window_pinch_active = FALSE;
+/* pinch in the second window, via the shared dt_gui_connect_pinch() bridge:
+ * it recognizes the touchpad and the touchscreen gesture alike, parses the
+ * scale and the focal point out of either and applies the touchpad
+ * preference, so only the mapping onto this window's viewport is left here.
+ * dx/dy are not used (macOS delivers the touchpad's pan as a separate scroll
+ * stream, see _second_window_scrolled_callback; a touchscreen pans with a
+ * single finger, see _second_window_touch_moved). */
+static gboolean _second_window_touch_pinching = FALSE;
 
-static gboolean _second_window_pinch_phase(dt_develop_t *dev,
-                                           GtkWidget *widget,
-                                           const GdkTouchpadGesturePhase phase,
-                                           const gdouble scale,
-                                           const GdkEvent *event)
+static void _second_window_pinch(GtkGesture *gesture,
+                                 const dt_gui_pinch_event_t *e,
+                                 gpointer user_data)
 {
-  if(!darktable.gui->touchpad_gestures_enabled) return FALSE;
+  dt_develop_t *dev = user_data;
+  // a second finger hands the viewport over to the pinch, so the finger that
+  // is still down must stop panning
+  if(e->touchscreen)
+    _second_window_touch_pinching = e->phase == GDK_TOUCHPAD_GESTURE_PHASE_BEGIN
+                                    || e->phase == GDK_TOUCHPAD_GESTURE_PHASE_UPDATE;
+
+  if(dev->gui_leaving) return;
 
   // Use pinned viewport if pinned, otherwise main dev's preview2
   dt_develop_t *pinned_dev = dev->preview2_pinned ? dev->preview2_pinned_dev : NULL;
@@ -5280,47 +5287,32 @@ static gboolean _second_window_pinch_phase(dt_develop_t *dev,
 
   dt_dev_viewport_t *port = pinned_dev ? &pinned_dev->preview2 : &dev->preview2;
 
-  int state = 0;
-  gdouble x_root = 0.0, y_root = 0.0;
-  if(event)
-  {
-    state = dt_gdk_event_get_state(event) & 0xf;
-    // GtkGestureZoom also recognizes touchscreen pinches, never handled before
-    if(dt_gdk_event_get_type(event) != GDK_TOUCHPAD_PINCH) return FALSE;
-#if GTK_CHECK_VERSION(4, 0, 0)
-    // GTK4 has no root-coords API: surface-relative position (see gtk.c)
-    gdk_event_get_position(event, &x_root, &y_root);
-#else
-    x_root = dt_gdk_event_get_root_x(event);
-    y_root = dt_gdk_event_get_root_y(event);
-#endif
-  }
   const gboolean constrained =
-    dev->constrain_zoom && !dt_modifier_is(state, GDK_CONTROL_MASK);
+    dev->constrain_zoom && !dt_modifier_is(e->state, GDK_CONTROL_MASK);
 
   // Zoom the second window proportionally to the pinch scale, mirroring the
   // main darkroom view's gesture_pinch().
   static float begin_tscale = 0.0f;
 
-  if(phase == GDK_TOUCHPAD_GESTURE_PHASE_BEGIN)
+  if(e->phase == GDK_TOUCHPAD_GESTURE_PHASE_BEGIN)
   {
     begin_tscale =
       dt_dev_get_zoom_scale(port, port->zoom, 1 << port->closeup, FALSE) * port->ppd;
-    return TRUE;
+    return;
   }
-  if(phase == GDK_TOUCHPAD_GESTURE_PHASE_END
-     || phase == GDK_TOUCHPAD_GESTURE_PHASE_CANCEL)
+  if(e->phase == GDK_TOUCHPAD_GESTURE_PHASE_END
+     || e->phase == GDK_TOUCHPAD_GESTURE_PHASE_CANCEL)
   {
     begin_tscale = 0.0f;
-    return TRUE;
+    return;
   }
-  if(phase != GDK_TOUCHPAD_GESTURE_PHASE_UPDATE) return FALSE;
-  if(begin_tscale <= 0.0f || scale <= 0.0) return FALSE;
+  if(e->phase != GDK_TOUCHPAD_GESTURE_PHASE_UPDATE) return;
+  if(begin_tscale <= 0.0f || e->scale <= 0.0) return;
 
   const float ppd = port->ppd;
   const float fitscale = dt_dev_get_zoom_scale(port, DT_ZOOM_FIT, 1, FALSE);
   const float tscalefloor = MIN(0.5f * fitscale * ppd, 1.0f);
-  const float tscale = CLAMP(begin_tscale * scale, tscalefloor, 16.0f);
+  const float tscale = CLAMP(begin_tscale * e->scale, tscalefloor, 16.0f);
   const float zoom_scale = tscale / ppd;
 
   // Convert root (screen-absolute) pinch coords to widget-local, which is the
@@ -5330,50 +5322,16 @@ static gboolean _second_window_pinch_phase(dt_develop_t *dev,
   // GTK4: event coords are already surface-relative, i.e. widget-local here
   ox = oy = 0;
 #else
-  GdkWindow *win = gtk_widget_get_window(widget);
+  GdkWindow *win = gtk_widget_get_window(dt_gui_get_widget(gesture));
   if(win) gdk_window_get_origin(win, &ox, &oy);
 #endif
-  const float x_local = (float)x_root - ox;
-  const float y_local = (float)y_root - oy;
+  const float x_local = (float)e->x - ox;
+  const float y_local = (float)e->y - oy;
   dt_print(DT_DEBUG_INPUT,
-           "[darkroom second window] pinch scale=%.6f tscale=%.6f zoom_scale=%.6f",
-           scale, tscale, zoom_scale);
+           "[darkroom second window] %s pinch scale=%.6f tscale=%.6f zoom_scale=%.6f",
+           e->touchscreen ? "touchscreen" : "touchpad",
+           e->scale, tscale, zoom_scale);
   dt_dev_zoom_move(port, DT_ZOOM_FREE, zoom_scale, 0, x_local, y_local, constrained);
-  return TRUE;
-}
-
-static void _second_window_pinch_begin(GtkGestureZoom *gesture,
-                                       gpointer user_data)
-{
-  dt_develop_t *dev = user_data;
-  // touchscreen pinches were never handled before: only touchpad pinches
-  // set the active flag
-  const GdkEvent *event = gtk_gesture_get_last_event(GTK_GESTURE(gesture), NULL);
-  if(!event || dt_gdk_event_get_type(event) != GDK_TOUCHPAD_PINCH) return;
-  _second_window_pinch_active = TRUE;
-  _second_window_pinch_phase(dev, dt_gui_get_widget(gesture),
-                             GDK_TOUCHPAD_GESTURE_PHASE_BEGIN, 1.0, event);
-}
-
-static void _second_window_pinch_scale_changed(GtkGestureZoom *gesture,
-                                               gdouble scale,
-                                               gpointer user_data)
-{
-  if(!_second_window_pinch_active) return;
-  dt_develop_t *dev = user_data;
-  const GdkEvent *event = gtk_gesture_get_last_event(GTK_GESTURE(gesture), NULL);
-  _second_window_pinch_phase(dev, dt_gui_get_widget(gesture),
-                             GDK_TOUCHPAD_GESTURE_PHASE_UPDATE, scale, event);
-}
-
-static void _second_window_pinch_end(GtkGestureZoom *gesture,
-                                     gpointer user_data)
-{
-  if(!_second_window_pinch_active) return;
-  _second_window_pinch_active = FALSE;
-  dt_develop_t *dev = user_data;
-  _second_window_pinch_phase(dev, dt_gui_get_widget(gesture),
-                             GDK_TOUCHPAD_GESTURE_PHASE_END, 1.0, NULL);
 }
 
 static void _second_window_button_pressed_callback(GtkGestureSingle *gesture,
@@ -5426,6 +5384,24 @@ static void _second_window_button_released_callback(GtkGestureSingle *gesture,
   gtk_widget_queue_draw(w);
 }
 
+static void _second_window_pan(dt_develop_t *dev,
+                               const gdouble x,
+                               const gdouble y)
+{
+  dt_control_t *ctl = darktable.control;
+
+  // Use pinned viewport if pinned, otherwise main dev's preview2
+  dt_develop_t *pinned_dev = dev->preview2_pinned ? dev->preview2_pinned_dev : NULL;
+  if(pinned_dev && pinned_dev->gui_leaving) pinned_dev = NULL;
+
+  dt_dev_viewport_t *port = pinned_dev ? &pinned_dev->preview2 : &dev->preview2;
+
+  dt_dev_zoom_move(port, DT_ZOOM_MOVE, -1.f, 0,
+                   x - ctl->button_x, y - ctl->button_y, TRUE);
+  ctl->button_x = x;
+  ctl->button_y = y;
+}
+
 static void _second_window_mouse_moved_callback(GtkEventControllerMotion *controller,
                                                   gdouble x,
                                                   gdouble y,
@@ -5436,20 +5412,21 @@ static void _second_window_mouse_moved_callback(GtkEventControllerMotion *contro
   const GdkModifierType state =
     dt_gui_get_current_event_state(GTK_EVENT_CONTROLLER(controller));
   if(state & GDK_BUTTON1_MASK)
-  {
-    dt_control_t *ctl = darktable.control;
+    _second_window_pan(dev, x, y);
+}
 
-    // Use pinned viewport if pinned, otherwise main dev's preview2
-    dt_develop_t *pinned_dev = dev->preview2_pinned ? dev->preview2_pinned_dev : NULL;
-    if(pinned_dev && pinned_dev->gui_leaving) pinned_dev = NULL;
-
-    dt_dev_viewport_t *port = pinned_dev ? &pinned_dev->preview2 : &dev->preview2;
-
-    dt_dev_zoom_move(port, DT_ZOOM_MOVE, -1.f, 0,
-                     x - ctl->button_x, y - ctl->button_y, TRUE);
-    ctl->button_x = x;
-    ctl->button_y = y;
-  }
+/* a finger drag is not pointer motion, see dt_gui_connect_touch_motion(): the
+ * press that started it came from the click gesture, only the motion has to be
+ * fed in by hand. */
+static void _second_window_touch_moved(GtkGesture *gesture,
+                                       gdouble x,
+                                       gdouble y,
+                                       gpointer user_data)
+{
+  (void)gesture;
+  dt_develop_t *dev = user_data;
+  if(dev->gui_leaving || _second_window_touch_pinching) return;
+  _second_window_pan(dev, x, y);
 }
 
 static void _second_window_leave_callback(GtkEventControllerMotion *controller,
@@ -5814,16 +5791,11 @@ static void _darkroom_display_second_window(dt_develop_t *dev)
                      G_CALLBACK(_second_window_draw_callback), dev);
     dt_gui_connect_scroll(dev->preview2.widget, GTK_EVENT_CONTROLLER_SCROLL_BOTH_AXES,
                           _second_window_scrolled_callback, dev);
-    // touchpad pinch via GtkGestureZoom (the old "event" signal handler is GTK3-only)
-    {
-      GtkGesture *zoom = gtk_gesture_zoom_new(dev->preview2.widget);
-      dt_gui_add_controller(dev->preview2.widget, zoom);
-      g_signal_connect(zoom, "begin", G_CALLBACK(_second_window_pinch_begin), dev);
-      g_signal_connect(zoom, "scale-changed", G_CALLBACK(_second_window_pinch_scale_changed), dev);
-      g_signal_connect(zoom, "end", G_CALLBACK(_second_window_pinch_end), dev);
-    }
+    // touchpad and touchscreen pinch (the old "event" signal handler is GTK3-only)
+    dt_gui_connect_pinch(dev->preview2.widget, _second_window_pinch, dev);
     dt_gui_connect_click_all(dev->preview2.widget, _second_window_button_pressed_callback, _second_window_button_released_callback, dev);
     dt_gui_connect_motion(dev->preview2.widget, _second_window_mouse_moved_callback, NULL, _second_window_leave_callback, dev);
+    dt_gui_connect_touch_motion(dev->preview2.widget, _second_window_touch_moved, dev);
     g_signal_connect(G_OBJECT(dev->preview2.widget), "configure-event",
                      G_CALLBACK(_second_window_configure_callback), dev);
 

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -5273,17 +5273,18 @@ static void _second_window_pinch(GtkGesture *gesture,
                                  gpointer user_data)
 {
   dt_develop_t *dev = user_data;
-  // a second finger hands the viewport over to the pinch, so the finger that
-  // is still down must stop panning
+  // a second finger hands the viewport over to the pinch, so the finger that is still down must stop panning
   if(e->touchscreen)
     _second_window_touch_pinching = e->phase == GDK_TOUCHPAD_GESTURE_PHASE_BEGIN
                                     || e->phase == GDK_TOUCHPAD_GESTURE_PHASE_UPDATE;
 
-  if(dev->gui_leaving) return;
+  if(dev->gui_leaving)
+    return;
 
   // Use pinned viewport if pinned, otherwise main dev's preview2
   dt_develop_t *pinned_dev = dev->preview2_pinned ? dev->preview2_pinned_dev : NULL;
-  if(pinned_dev && pinned_dev->gui_leaving) pinned_dev = NULL;
+  if(pinned_dev && pinned_dev->gui_leaving)
+    pinned_dev = NULL;
 
   dt_dev_viewport_t *port = pinned_dev ? &pinned_dev->preview2 : &dev->preview2;
 
@@ -5392,7 +5393,8 @@ static void _second_window_pan(dt_develop_t *dev,
 
   // Use pinned viewport if pinned, otherwise main dev's preview2
   dt_develop_t *pinned_dev = dev->preview2_pinned ? dev->preview2_pinned_dev : NULL;
-  if(pinned_dev && pinned_dev->gui_leaving) pinned_dev = NULL;
+  if(pinned_dev && pinned_dev->gui_leaving)
+    pinned_dev = NULL;
 
   dt_dev_viewport_t *port = pinned_dev ? &pinned_dev->preview2 : &dev->preview2;
 
@@ -5425,7 +5427,8 @@ static void _second_window_touch_moved(GtkGesture *gesture,
 {
   (void)gesture;
   dt_develop_t *dev = user_data;
-  if(dev->gui_leaving || _second_window_touch_pinching) return;
+  if(dev->gui_leaving || _second_window_touch_pinching)
+    return;
   _second_window_pan(dev, x, y);
 }
 


### PR DESCRIPTION
A regression in the touchscreen/touchpad code prevents pan and pinch zoom gestures in darkroom, see https://github.com/darktable-org/darktable/issues/22011

Attaching a GtkGesture selects GDK_TOUCH_MASK on its widget, so GDK stops rewriting touch sequences into button/motion events: since the center view moved to controllers, finger drags no longer reach dt_control_mouse_moved(), while the pinch bridge dropped touchscreen pinches outright.

dt_gui_connect_pinch() forwards them now, taking scale and focal point from GtkGestureZoom, and the new dt_gui_connect_touch_motion() feeds the missing motion from a touch-only GtkGestureDrag.  Both are wired on the center view and on the darkroom second window, which also moves to the shared bridge. Touch motion is traced under -d input.

Speculatively fixes: https://github.com/darktable-org/darktable/issues/22011


Disclaimer: this change was co-created with Claude.