### PR TITLE
win: retain a shared console session

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -235,7 +235,12 @@ if(WIN32)
   configure_file("${CMAKE_SOURCE_DIR}/data/pixmaps/dt_logo_128x128.ico" "${CMAKE_BINARY_DIR}/data/pixmaps/dt_logo_128x128.ico" COPYONLY)
   SET(CMAKE_RC_COMPILE_OBJECT "<CMAKE_RC_COMPILER> -O coff <DEFINES> -i <SOURCE> -o <OBJECT>")
   set(RESOURCE_OBJECT "${CMAKE_CURRENT_BINARY_DIR}/win/darktable.rc")
+  configure_file("${CMAKE_CURRENT_SOURCE_DIR}/win/darktable.exe.manifest"
+                 "${CMAKE_CURRENT_BINARY_DIR}/win/darktable.exe.manifest"
+                 COPYONLY)
   configure_file("${CMAKE_CURRENT_SOURCE_DIR}/win/darktable.rc.in" "${CMAKE_CURRENT_BINARY_DIR}/win/darktable.rc")
+  set_property(SOURCE "${RESOURCE_OBJECT}" APPEND PROPERTY OBJECT_DEPENDS
+               "${CMAKE_CURRENT_BINARY_DIR}/win/darktable.exe.manifest")
 endif(WIN32)
 
 set(SOURCES ${SOURCE_FILES} ${HEADER_FILES})

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -129,6 +129,45 @@
 
 darktable_t darktable;
 
+#ifdef _WIN32
+static gboolean _console_notice_requested = FALSE;
+
+void dt_request_console_notice(void)
+{
+  _console_notice_requested = TRUE;
+}
+
+static void _show_console_notice(void)
+{
+  const char *notice = _("This console window is required by darktable on this "
+                         "version of Windows.\n"
+                         "On Windows 11 24H2 and later, darktable normally runs "
+                         "without this window.\n"
+                         "Do not close it or press Ctrl+C while darktable is running.\n"
+                         "It will close automatically when darktable exits.\n");
+  gchar **notice_lines = g_strsplit(notice, "\n", -1);
+  gchar *console_notice = g_strjoinv("\r\n", notice_lines);
+  g_strfreev(notice_lines);
+
+  glong length = 0;
+  gunichar2 *wide_notice = g_utf8_to_utf16(console_notice, -1, NULL, &length, NULL);
+  g_free(console_notice);
+  if(!wide_notice) return;
+
+  const HANDLE output = CreateFileW(L"CONOUT$", GENERIC_WRITE,
+                                    FILE_SHARE_READ | FILE_SHARE_WRITE, NULL,
+                                    OPEN_EXISTING, 0, NULL);
+  if(output != INVALID_HANDLE_VALUE)
+  {
+    DWORD written;
+    WriteConsoleW(output, wide_notice, (DWORD)length, &written, NULL);
+    CloseHandle(output);
+  }
+
+  g_free(wide_notice);
+}
+#endif
+
 static int usage(const char *argv0)
 {
 #ifdef _WIN32
@@ -1697,6 +1736,14 @@ int dt_init(int argc,
 
   // set the interface language and prepare selection for prefs & confgen
   darktable.l10n = dt_l10n_init(init_gui);
+
+#ifdef _WIN32
+  if(_console_notice_requested)
+  {
+    _console_notice_requested = FALSE;
+    _show_console_notice();
+  }
+#endif
 
   gboolean has_workspace = FALSE;
 

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -527,6 +527,10 @@ int dt_init(int argc, char *argv[],
             const gboolean load_data,
             lua_State *L);
 
+#ifdef _WIN32
+void dt_request_console_notice(void);
+#endif
+
 void dt_get_sysresource_level();
 void dt_cleanup();
 

--- a/src/main.c
+++ b/src/main.c
@@ -31,6 +31,35 @@
 #ifdef _WIN32
 #include "win/main_wrapper.h"
 #include "common/datetime.h"
+
+typedef struct dt_alloc_console_options_t
+{
+  int mode;
+  BOOL use_show_window;
+  WORD show_window;
+} dt_alloc_console_options_t;
+
+typedef HRESULT(WINAPI *dt_alloc_console_with_options_t)(
+  dt_alloc_console_options_t *options,
+  int *result);
+
+static gboolean _allocate_console(void)
+{
+  const HMODULE kernel = GetModuleHandleW(L"kernel32.dll");
+  const FARPROC allocation_proc = GetProcAddress(kernel, "AllocConsoleWithOptions");
+  dt_alloc_console_with_options_t alloc_with_options = NULL;
+  memcpy(&alloc_with_options, &allocation_proc, sizeof(alloc_with_options));
+
+  if(alloc_with_options)
+  {
+    // mode 2 requests ALLOC_CONSOLE_MODE_NO_WINDOW, available since Windows 11 24H2
+    dt_alloc_console_options_t options = { 2, FALSE, SW_HIDE };
+    if(SUCCEEDED(alloc_with_options(&options, NULL)) && GetConsoleCP() != 0)
+      return TRUE;
+  }
+
+  return AllocConsole();
+}
 #endif
 
 #ifdef __APPLE__
@@ -54,6 +83,40 @@ int main(int argc, char *argv[])
 
   // Make sure to not redirect output when the output is already
   // being redirected, either to a file or a pipe.
+  if(GetConsoleCP() == 0)
+  {
+    const HANDLE initial_input_handle = GetStdHandle(STD_INPUT_HANDLE);
+    const HANDLE initial_output_handle = GetStdHandle(STD_OUTPUT_HANDLE);
+    const HANDLE initial_error_handle = GetStdHandle(STD_ERROR_HANDLE);
+    const DWORD initial_in_type = GetFileType(initial_input_handle);
+    const DWORD initial_out_type = GetFileType(initial_output_handle);
+    const DWORD initial_err_type = GetFileType(initial_error_handle);
+    const gboolean input_redirected =
+      initial_in_type == FILE_TYPE_DISK || initial_in_type == FILE_TYPE_PIPE;
+    const gboolean output_redirected =
+      initial_out_type == FILE_TYPE_DISK || initial_out_type == FILE_TYPE_PIPE;
+    const gboolean error_redirected =
+      initial_err_type == FILE_TYPE_DISK || initial_err_type == FILE_TYPE_PIPE;
+
+    if(_allocate_console())
+    {
+      if(input_redirected)
+        SetStdHandle(STD_INPUT_HANDLE, initial_input_handle);
+      else
+        g_freopen("CONIN$", "r", stdin);
+
+      if(output_redirected)
+        SetStdHandle(STD_OUTPUT_HANDLE, initial_output_handle);
+      else
+        g_freopen("CONOUT$", "w", stdout);
+
+      if(error_redirected)
+        SetStdHandle(STD_ERROR_HANDLE, initial_error_handle);
+      else
+        g_freopen("CONOUT$", "w", stderr);
+    }
+  }
+
   int out_type = GetFileType(GetStdHandle(STD_OUTPUT_HANDLE));
   int err_type = GetFileType(GetStdHandle(STD_ERROR_HANDLE));
   gboolean redirect_output = ((out_type != FILE_TYPE_DISK && out_type != FILE_TYPE_PIPE) &&
@@ -83,11 +146,12 @@ int main(int argc, char *argv[])
     g_mkdir_with_parents(logdir, 0700);
 
     g_freopen(logfile, "a", stdout);
+    dup2(fileno(stdout), STDOUT_FILENO);
+    dup2(fileno(stdout), STDERR_FILENO);
     dup2(fileno(stdout), fileno(stderr));
-
-    // We don't need the console window anymore, free it.
-    // This ensures that only darktable's main window will be visible.
-    FreeConsole();
+    const HANDLE output_handle = (HANDLE)_get_osfhandle(fileno(stdout));
+    SetStdHandle(STD_OUTPUT_HANDLE, output_handle);
+    SetStdHandle(STD_ERROR_HANDLE, output_handle);
 
     g_free(logdir);
     g_free(logfile);

--- a/src/main.c
+++ b/src/main.c
@@ -43,8 +43,10 @@ typedef HRESULT(WINAPI *dt_alloc_console_with_options_t)(
   dt_alloc_console_options_t *options,
   int *result);
 
-static gboolean _allocate_console(void)
+static gboolean _allocate_console(gboolean *visible)
 {
+  *visible = FALSE;
+
   const HMODULE kernel = GetModuleHandleW(L"kernel32.dll");
   const FARPROC allocation_proc = GetProcAddress(kernel, "AllocConsoleWithOptions");
   dt_alloc_console_with_options_t alloc_with_options = NULL;
@@ -58,7 +60,8 @@ static gboolean _allocate_console(void)
       return TRUE;
   }
 
-  return AllocConsole();
+  *visible = AllocConsole();
+  return *visible;
 }
 #endif
 
@@ -72,6 +75,8 @@ int main(int argc, char *argv[])
   dt_osx_prepare_environment();
 #endif
 #ifdef _WIN32
+  gboolean show_console_notice = FALSE;
+
   // On Windows we have a hard time showing stuff printed to stdout/stderr to the user.
   // Because of that we write it to a log file.
   char datetime[DT_DATETIME_EXIF_LENGTH];
@@ -98,7 +103,7 @@ int main(int argc, char *argv[])
     const gboolean error_redirected =
       initial_err_type == FILE_TYPE_DISK || initial_err_type == FILE_TYPE_PIPE;
 
-    if(_allocate_console())
+    if(_allocate_console(&show_console_notice))
     {
       if(input_redirected)
         SetStdHandle(STD_INPUT_HANDLE, initial_input_handle);
@@ -172,6 +177,9 @@ int main(int argc, char *argv[])
     printf("start: %s\n", datetime);
     printf("\n");
   }
+
+  if(show_console_notice)
+    dt_request_console_notice();
 
   // Make sure GTK client side decoration is disabled,
   // otherwise windows resizing issues can be observed.

--- a/src/win/darktable.exe.manifest
+++ b/src/win/darktable.exe.manifest
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+    <security>
+      <requestedPrivileges>
+        <requestedExecutionLevel level="asInvoker"/>
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
+      <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+      <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
+      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+    </application>
+  </compatibility>
+  <application>
+    <windowsSettings>
+      <consoleAllocationPolicy
+        xmlns="http://schemas.microsoft.com/SMI/2024/WindowsSettings"
+        >detached</consoleAllocationPolicy>
+    </windowsSettings>
+  </application>
+</assembly>

--- a/src/win/darktable.rc.in
+++ b/src/win/darktable.rc.in
@@ -6,6 +6,7 @@
 
 
 IDI_ICON1               ICON    DISCARDABLE     "../../data/pixmaps/dt_logo_128x128.ico"
+1                       24      "@CMAKE_CURRENT_BINARY_DIR@/win/darktable.exe.manifest"
 
 VS_VERSION_INFO VERSIONINFO
   FILEVERSION DT_VERSION


### PR DESCRIPTION
## Summary

This implements option 2 from
[issue #17193](https://github.com/darktable-org/darktable/issues/17193), as
requested by @wpferguson: stop calling `FreeConsole()` and retain one shared
console session for darktable's lifetime.

Keep darktable attached to one Windows console session so later `system()` and
`popen()` children reuse it instead of allocating visible console windows.

The patch extends the minimal `FreeConsole()` removal for launch states where
darktable starts without a console. In that case, it dynamically uses Windows
11 24H2's `AllocConsoleWithOptions()` no-window mode. If that export is
unavailable or the no-window allocation fails, it falls back to
`AllocConsole()`, which retains one visible console for the session.

Caller-supplied disk and pipe standard handles are preserved; ordinary output
continues to use `Documents\Darktable\darktable-log.txt`.
The visible fallback displays a short translatable notice explaining that the
console must remain open, will close with darktable, and is normally unnecessary
on Windows 11 24H2 and later. It does not expose log messages there. Showing logs
in the console would require a separate change to darktable's existing Windows
output-redirection policy.

The source string is in `src/common/darktable.c`, which is already registered
in `po/POTFILES.in`. Translations can be added through darktable's normal
`po/<locale>.po` catalogs; builds install the compiled catalogs as
`share/locale/<locale>/LC_MESSAGES/darktable.mo`.

The application remains a CUI executable. Its manifest preserves the existing
`asInvoker` and Windows compatibility declarations while adding the 24H2
detached console-allocation policy. This suppresses the initial Explorer console
on supported systems without changing CMD or PowerShell wait behavior.

Related: #17193

## Validation

- The production branch completed a fresh MSYS2 UCRT64 `BUILD_TESTING=ON`
  build. After the final manifest-only formatting amend at `50189c133e`, the
  affected targets rebuilt and CTest passed 4/4.
- A final 10-second Shell launch on Windows 11 build 26200 showed zero console
  windows and passed the full `dt.control.execute()`, `os.execute()`, and
  `io.popen()` read/write/lines/status/close/GC contract.
- A forced down-level fallback displayed the translatable console notice before
  database preparation. Exact buffer inspection found the full notice, and
  Ctrl+C still terminated darktable. Closing darktable normally removed the
  console in the manual test.
- The exact clean notice commit `b3dcd74eda` rebuilt successfully and CTest
  passed 4/4. A temporary German catalog was compiled, installed, selected
  through `ui_last/gui_language=de`, and captured as translated Unicode text in
  the visible console before the database screen. Closing that console still
  terminated darktable.
- The same translated notice appeared when stdout was supplied as a pipe. It is
  written directly to `CONOUT$`, so the caller's redirected stream remained
  separate.
- Its final 10-second Windows 11 build-26200 Shell probe observed zero console
  windows. The application remained running for the full probe and was closed by
  the harness.
- An explicit final-hash 10-second `DETACHED_PROCESS` launch also showed zero
  console windows and passed the same contract.
- Separate redirected stdin, stdout, and stderr probes preserved their streams.
- Redirected `--version`, `--help`, and `--gimp version` output and status were
  unchanged, and a CMD probe waited for the CUI process to finish.
- Exact resource extraction confirmed the embedded manifest retains the prior
  execution-level and supported-OS declarations plus the new allocation policy.
- The executable does not import `AllocConsoleWithOptions`; runtime lookup keeps
  it loadable when that export is unavailable. A forced missing-export run used
  the visible `AllocConsole()` fallback, showed no child consoles, and passed the
  full command contract.
- The same runtime and manifest semantics passed the complete probe on
  Windows 10 22H2 Pro build 19045 and Windows 11 23H2 Pro build 22631. Both
  systems lack the new export; both loaded the combined manifest, attached the
  fallback console, shared it with a native child, and preserved redirected
  stdin/stdout/stderr. This matrix used the exact packaged `50189c133e`
  candidate; each guest extracted the 1,026-byte final manifest and passed the
  full command contract.

All runtime changes in `src/main.c` and `src/common/darktable.c`, plus the
declaration in `src/common/darktable.h`, are inside `_WIN32` guards. The
manifest/resource wiring is inside CMake's existing `if(WIN32)` block, and the
resource file is Windows-only. Linux and macOS compile none of the changed
runtime or resource code.

## Limitations

- Before Windows 11 24H2, the fallback retains one visible console containing
  the explanatory notice for the darktable session. Closing that console or
  sending Ctrl+C terminates darktable.
- No permanent regression test is included; the Windows console and command
  contracts were validated with the external investigation harnesses described
  above.
- If both the no-window allocation and `AllocConsole()` fail, later native
  shell children can allocate their own consoles.
- A child that explicitly requests `CREATE_NEW_CONSOLE` can still create a
  separate console window.

## AI assistance

AI assisted with investigation, implementation, and validation.
