### PR TITLE
Fix typo in the list of recommended controls to add to the QAP

### DIFF
--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+
 #include "common/gdk_event_utils.h"
 
 #include "bauhaus/bauhaus.h"
@@ -33,6 +34,7 @@
 #include "gui/presets.h"
 #include "libs/lib.h"
 #include "libs/lib_api.h"
+
 #ifdef GDK_WINDOWING_QUARTZ
 #include "osx/osx.h"
 #endif
@@ -52,7 +54,7 @@ DT_MODULE(1)
 // list of recommended basics widgets
 #define RECOMMENDED_BASICS                                                                                        \
   "|exposure/exposure|temperature/temperature|temperature/tint|colorbalancergb/contrast|colorbalancergb/global "        \
-  "vibrance|colorbalancergb/global chroma|colorbalancergb/global saturation|ashift/roration|denoiseprofile|lens|bilat|"
+  "vibrance|colorbalancergb/global chroma|colorbalancergb/global saturation|ashift/rotation|denoiseprofile|lens|bilat|"
 
 // if a preset cannot be loaded or the current preset deleted, this is the fallback preset
 


### PR DESCRIPTION
Due to a typo, `ashift/rotation` (i.e. the rotation control in the "rotation and perspective" module) was not matched in the list of recommended controls to add to the QAP (which contained the typo). Fortunately, this control is present in the default list, so this problem is not immediately apparent. However, if we remove this control from the QAP, it will not appear in the list of recommended widgets to add. Not a big deal, because we can always find it further down in the submenu of all available modules and their controls. But we wanted to recommend this control and make it easier to add, and this typo prevents that.

EDIT: Too minor an issue to be worth writing about in the release notes.
