### PR TITLE
Additional button to remove the star rating of an image

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -101,6 +101,11 @@ changes (where available).
   covering built-in and Lumix-branded lenses that lensfun has no
   profile for.
 
+- When installing development versions of darktable (snapshots, self
+  compiled etc.)  the Windows installer now allows to setup a custom
+  configuration-directory and custom shortcut-name, useful for
+  multiple parallel darktable installations.
+
 - Added a control in the bottom panel of the lighttable to reset 
   the star rating of images.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -101,6 +101,9 @@ changes (where available).
   covering built-in and Lumix-branded lenses that lensfun has no
   profile for.
 
+- Added a control in the bottom panel of the lighttable to reset 
+  the star rating of images.
+
 ## Bug Fixes
 
 - Clarified multi-image rating toasts for un-reject and for mixed

--- a/src/libs/tools/ratings.c
+++ b/src/libs/tools/ratings.c
@@ -133,7 +133,7 @@ static gboolean _lib_ratings_draw_callback(GtkWidget *widget, cairo_t *crf, dt_l
   gtk_widget_get_allocation(widget, &allocation);
 
   const float star_size = allocation.height;
-  const float star_spacing = (allocation.width - 5.0 * star_size) / 4.0;
+  const float star_spacing = (allocation.width - 6.0 * star_size) / 5.0;
 
   cairo_surface_t *cst
       = dt_cairo_image_surface_create(CAIRO_FORMAT_ARGB32, allocation.width, allocation.height);
@@ -151,6 +151,20 @@ static gboolean _lib_ratings_draw_callback(GtkWidget *widget, cairo_t *crf, dt_l
   int x = 0;
   cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(1));
   gdk_cairo_set_source_rgba(cr, &fg_color);
+
+    // draw unrated star
+  cairo_set_source_rgba(cr, fg_color.red, fg_color.green, fg_color.blue, fg_color.alpha * 0.3);
+  dt_draw_star(cr, star_size / 2.0 + x, star_size / 2.0, star_size / 2.0, star_size / (2.0 * 2.5));
+  cairo_stroke(cr);
+  gdk_cairo_set_source_rgba(cr, &fg_color);
+  cairo_set_line_width(cr, 1.6 * cairo_get_line_width(cr));
+  cairo_move_to(cr, x + star_size * .1, star_size / 2.0);
+  cairo_line_to(cr, x + star_size * .9, star_size / 2.0);
+  cairo_stroke(cr);
+  cairo_set_line_width(cr, cairo_get_line_width(cr) / 1.6);
+  x += star_size + star_spacing;
+
+  //now the regular stars
   d->current = 0;
   for(int k = 0; k < 5; k++)
   {

--- a/src/libs/tools/ratings.c
+++ b/src/libs/tools/ratings.c
@@ -208,14 +208,11 @@ static void _lib_ratings_button_press_callback(GtkGestureSingle *gesture, int n_
                                                   dt_lib_module_t *self)
 {
   dt_lib_ratings_t *d = self->data;
-  if(d->current > 0)
-  {
-    GList *imgs = dt_act_on_get_images(FALSE, TRUE, FALSE);
-    dt_ratings_apply_on_list(imgs, d->current, TRUE);
-    dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_RATING_RANGE, imgs);
+  GList *imgs = dt_act_on_get_images(FALSE, TRUE, FALSE);
+  dt_ratings_apply_on_list(imgs, d->current, TRUE);
+  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_RATING_RANGE, imgs);
 
-    dt_control_queue_redraw_center();
-  }
+  dt_control_queue_redraw_center();
 }
 
 static void _lib_ratings_button_release_callback(GtkGestureSingle *gesture, int n_press,


### PR DESCRIPTION
This is a proposal for issue https://github.com/darktable-org/darktable/issues/21127 .
Currently, the only way to remove the star rating of an image is either by using the shortcut 0 or by clicking the first star in a toggle fashion. When more than one star has been set for an image, you have to click the first star twice. This is not very intuitive.
With this PR a new dedicated button is introduced at the bottom of the lighttable to remove the star rating of an image in the same fashion as setting the rating.

<img width="319" height="99" alt="image" src="https://github.com/user-attachments/assets/4d250b17-eca1-42c3-9fbb-7a095e24b118" />

@TurboGit This is the replacement for my previous PR #21199, where we discussed this addition already.


closes https://github.com/darktable-org/darktable/issues/21127