### PR TITLE
Fix guides menu toggle

### DIFF
--- a/src/gui/guides.c
+++ b/src/gui/guides.c
@@ -21,6 +21,7 @@
 #include "bauhaus/bauhaus.h"
 #include "common/darktable.h"
 #include "common/math.h"
+#include "control/conf.h"
 #include "dtgtk/button.h"
 #include "gui/gtk.h"
 #include "gui/guides.h"
@@ -971,8 +972,7 @@ static void _settings_autoshow_change(GtkWidget *mi,
   gchar *key = _conf_get_path(module->op, "autoshow", NULL);
   dt_conf_set_bool(key, !dt_conf_get_bool(key));
   DT_ENTER_GUI_UPDATE();
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(module->guides_combo),
-                               dt_conf_get_bool(key));
+  dt_bauhaus_toggle_set(module->guides_combo, dt_conf_get_bool(key));
   DT_LEAVE_GUI_UPDATE();
   g_free(key);
   dt_control_queue_redraw_center();


### PR DESCRIPTION
Some iop modules have the "_show guides_" checkbox (crop, rotate & perspective, flip, lens, clipping...).

The state of this checkbox can also be toggled via the module's presets menu but in that case the checkbox in the module itself is not toggled.

Activating this menu item also throws a GTK critical error:

`Gtk-CRITICAL: gtk_toggle_button_set_active: assertion 'GTK_IS_TOGGLE_BUTTON (toggle_button)' failed`

<img width="342" height="207" alt="Bildschirmfoto 2026-08-30 um 20 31 51" src="https://github.com/user-attachments/assets/7230c4f6-05af-4b83-9b40-501219bace11" />

