### PR TITLE
crop: apply the aspect ratio dialed in on the camera

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -138,6 +138,11 @@ changes (where available).
 - pixelpipe dump files requested via cli switches are now written
   in ppm or pgm format.
 
+- The aspect ratio chosen on the camera is now applied as a crop when
+  the raw was left uncropped, so a frame shot at 1:1 or 16:9 opens
+  framed as intended while the full sensor area stays available to
+  reframe within. Read from Canon and Olympus raws.
+
 ## Bug Fixes
 
 - Clarified multi-image rating toasts for un-reject and for mixed

--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -956,6 +956,99 @@ static bool _check_usercrop(Exiv2::ExifData &exifData,
   return FALSE;
 }
 
+// Support the aspect ratio dialed in on the camera while shooting. Every
+// vendor keeps it somewhere else in its own makernote, but what we need out
+// of it is the same everywhere: the ratio, and whether it differs from the
+// native one at all.
+//
+// The box a camera reports is always centered on the output area of that
+// camera, which is a little smaller than the sensor area we process. We
+// therefore keep the ratio alone and leave the centering to the crop module,
+// so we never have to match the vendor's idea of the full frame.
+//
+// To support another vendor, write a reader filling d:n and add it below.
+
+// Canon keeps it in AspectInfo as (ratio, width, height, left, top).
+// Magic-nr taken from the makernote spec, Exiv2 knows the tag by name
+// only from 0.27.4 on.
+static bool _camera_aspect_canon(Exiv2::ExifData &exifData,
+                                 int *d,
+                                 int *n)
+{
+  Exiv2::ExifData::const_iterator pos =
+    exifData.findKey(Exiv2::ExifKey("Exif.Canon.0x009a"));
+
+  if(pos == exifData.end() || pos->count() != 5 || !pos->size())
+    return FALSE;
+
+  // a box sitting at the origin covers the full frame, nothing was cropped
+  if(pos->toFloat(3) <= 0.0f && pos->toFloat(4) <= 0.0f)
+    return FALSE;
+
+  switch((int)pos->toFloat(0))
+  {
+    case 1:  *d = 1;   *n = 1;   break; // 1:1
+    case 2:  *d = 4;   *n = 3;   break; // 4:3
+    case 7:  *d = 16;  *n = 9;   break; // 16:9
+    case 12: *d = 185; *n = 100; break; // 1.85:1
+    default: return FALSE;              // 0 is native, the rest is unknown
+  }
+
+  return TRUE;
+}
+
+// Olympus keeps it in the image processing block as two bytes: the ratio,
+// and whether the raw data was cropped along with it. Only the second form
+// concerns us, the other one has nothing left to reproduce.
+static bool _camera_aspect_olympus(Exiv2::ExifData &exifData,
+                                   int *d,
+                                   int *n)
+{
+  Exiv2::ExifData::const_iterator pos =
+    exifData.findKey(Exiv2::ExifKey("Exif.OlympusIp.0x1112"));
+
+  if(pos == exifData.end() || pos->count() != 2 || !pos->size())
+    return FALSE;
+
+  // the second byte tells the raw data was left uncropped
+  if((int)pos->toFloat(1) != 1)
+    return FALSE;
+
+  switch((int)pos->toFloat(0))
+  {
+    case 2: *d = 3;  *n = 2; break; // 3:2
+    case 3: *d = 16; *n = 9; break; // 16:9
+    case 4: *d = 1;  *n = 1; break; // 1:1
+    default: return FALSE;          // 1 is the native 4:3, the rest is unknown
+  }
+
+  return TRUE;
+}
+
+static bool _check_camera_aspect(Exiv2::ExifData &exifData,
+                                 dt_image_t *img)
+{
+  static bool (*const readers[])(Exiv2::ExifData &, int *, int *) =
+  {
+    _camera_aspect_canon,
+    _camera_aspect_olympus,
+  };
+
+  for(size_t i = 0; i < sizeof(readers) / sizeof(readers[0]); i++)
+  {
+    int d = 0, n = 0;
+
+    if(readers[i](exifData, &d, &n) && d > 0 && n > 0)
+    {
+      img->camera_ratio_d = d;
+      img->camera_ratio_n = n;
+      return TRUE;
+    }
+  }
+
+  return FALSE;
+}
+
 static void _check_linear_response_limit(Exiv2::ExifData &exifData,
                                          dt_image_t *img)
 {
@@ -1404,6 +1497,7 @@ void dt_exif_img_check_additional_tags(dt_image_t *img,
     if(!exifData.empty())
     {
       _check_usercrop(exifData, img);
+      _check_camera_aspect(exifData, img);
       _check_dng_opcodes(exifData, img);
       _check_lens_correction_data(exifData, img);
       _check_linear_response_limit(exifData, img);
@@ -1719,7 +1813,9 @@ static bool _exif_decode_exif_data(dt_image_t *img, Exiv2::ExifData &exifData)
       }
     }
 
-    if(_check_usercrop(exifData, img))
+    // both are read, so no short-circuiting here
+    const bool has_usercrop = _check_usercrop(exifData, img);
+    if(_check_camera_aspect(exifData, img) || has_usercrop)
     {
       img->flags |= DT_IMAGE_HAS_ADDITIONAL_EXIF_TAGS;
       guint tagid = 0;

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -2254,6 +2254,7 @@ void dt_image_init(dt_image_t *img)
   img->wb_coeffs[3] = NAN;
   img->usercrop[0] = img->usercrop[1] = 0;
   img->usercrop[2] = img->usercrop[3] = 1;
+  img->camera_ratio_d = img->camera_ratio_n = 0;
   img->dng_gain_maps = NULL;
   img->exif_correction_type = CORRECTION_TYPE_NONE;
   memset(&img->exif_correction_data, 0, sizeof(img->exif_correction_data));

--- a/src/common/image.h
+++ b/src/common/image.h
@@ -358,6 +358,10 @@ typedef struct dt_image_t
   /* DefaultUserCrop */
   dt_boundingbox_t usercrop;
 
+  /* aspect ratio dialed in on the camera while shooting, as d:n following
+     the crop module convention; 0:0 if the native sensor ratio was used */
+  int32_t camera_ratio_d, camera_ratio_n;
+
   /* GainMaps from DNG OpcodeList2 exif tag */
   GList *dng_gain_maps;
 

--- a/src/iop/crop.c
+++ b/src/iop/crop.c
@@ -889,6 +889,67 @@ void reload_defaults(dt_iop_module_t *self)
   dp->cw = img->usercrop[3];
   dp->ch = img->usercrop[2];
   dp->ratio_n = dp->ratio_d = -1;
+
+  self->default_enabled = FALSE;
+
+  // A crop coming from the raw only preloads our parameters. An aspect ratio
+  // dialed in on the camera though is a framing decision taken while
+  // shooting, so reproduce it right away: center that ratio on the sensor
+  // area we are handed and switch ourselves on. The intended framing is
+  // applied but stays free to be moved around within the full frame.
+  const gboolean has_usercrop = dp->cx > 0.0f || dp->cy > 0.0f
+                             || dp->cw < 1.0f || dp->ch < 1.0f;
+
+  const float iwd = img->p_width > 0 ? img->p_width : img->width;
+  const float iht = img->p_height > 0 ? img->p_height : img->height;
+
+  if(has_usercrop
+     || img->camera_ratio_d < 1
+     || img->camera_ratio_n < 1
+     || iwd < 1.0f
+     || iht < 1.0f)
+    return;
+
+  // p_width and p_height are still in sensor orientation here
+  const float want = (float)img->camera_ratio_d / (float)img->camera_ratio_n;
+  const float have = iwd / iht;
+
+  float bx = 0.0f, by = 0.0f, bw = 1.0f, bh = 1.0f;
+  if(want < have)       // narrower than the sensor, take off left and right
+  {
+    bw = want / have;
+    bx = (1.0f - bw) * 0.5f;
+  }
+  else if(want > have)  // wider, take off top and bottom
+  {
+    bh = have / want;
+    by = (1.0f - bh) * 0.5f;
+  }
+
+  // The ratio is the one we are handed already, either because the vendor
+  // applied the crop to the raw data after all or because the value was read
+  // as something it is not. Nothing to reproduce, and staying off is the safe
+  // answer rather than adding a crop that does nothing.
+  if(bw > 0.995f && bh > 0.995f)
+    return;
+
+  // flip runs before us, so follow the image into portrait. The box is
+  // centered, which leaves the mirroring bits of the orientation a no-op.
+  if(dt_image_orientation(img) & ORIENTATION_SWAP_XY)
+  {
+    float t;
+    t = bx; bx = by; by = t;
+    t = bw; bw = bh; bh = t;
+  }
+
+  dp->cx = bx;
+  dp->cy = by;
+  dp->cw = bx + bw;
+  dp->ch = by + bh;
+  dp->ratio_d = img->camera_ratio_d;
+  dp->ratio_n = img->camera_ratio_n;
+
+  self->default_enabled = TRUE;
 }
 
 static void _float_to_fract(const char *num, int *n, int *d)


### PR DESCRIPTION
Reproduces the aspect ratio dialed in on the camera as a crop that is applied
on open but stays editable.

Addresses #22087, and picks up #19109 (closed as not planned) with the
brand-generic approach @kmilos asked for there.

Rebased onto current master and squashed into one commit. Sony has been
dropped since the first push, see below.

### What it does

Cameras that let you pick an aspect ratio in the viewfinder record the choice
in the raw without destroying the surrounding pixels. We showed the full
sensor readout, so the framing chosen while shooting was lost. Now the crop
module centers that ratio on the sensor area and enables itself: the intended
framing is there on open, the aspect is locked to it in the combo box, and
the whole frame is still available to reframe within or to get back by
switching crop off.

### Design notes

**The ratio is kept, the vendor's box is not.** @kmilos pointed out in #19109
that we do not apply the same full-sensor crop as the vendor. On an EOS R6
the camera reports its 1:1 crop as 3648x3648 at x=912 against its own
5472x3648 output area, while the pipe gets 5496x3670. Rather than track each
vendor's framing, only the ratio is taken and centered on the area we
actually produce. Users get marginally more image than the camera would have
given them.

**Vendor readers are a table.** `_check_camera_aspect()` walks a list of
per-vendor functions; everything downstream is brand agnostic. Adding a
vendor is one function and one line.

**Nothing happens rather than the wrong thing.** The module stays off when
the ratio it works out is the one it was handed anyway, so a vendor that
applied the crop to the raw data after all, or a value read as something it
is not, does nothing rather than cropping the image wrongly.

**`DefaultUserCrop` is untouched.** The DNG path keeps its current behaviour
of only preloading the parameters. `default_enabled` is set exclusively on
the camera-aspect path.

**Portrait.** `p_width`/`p_height` are still in sensor orientation at
`reload_defaults()` time while crop runs after flip, so the box is swapped
when the orientation swaps axes. The box is centered, which leaves the
mirroring bits a no-op.

### Vendors

| Vendor | Status |
| --- | --- |
| Canon | `Canon.AspectInfo` (0x9a), implemented and tested |
| Olympus | `OlympusIp.AspectRatio` (0x1112), implemented and tested |
| Nikon | nothing to do, it writes only the cropped area, as @ralfbrown noted |
| Fujifilm | not in the makernote, being done in darktable-org/rawspeed#988 |
| Sony | dropped, see below |

**On Sony.** I had added a reader in the first push and have removed it. It
cannot be made to work through Exiv2 and I could not verify it on anything.
On the only non-native A-mount sample available (DSLR-A580 from
raw.pixls.us) the ratio lives at `CameraSettings3` byte 0x0a, and Exiv2
parses that byte-oriented block as big endian shorts, so every `Sony2Cs`
value is two unrelated bytes glued together and 0x0a is not exposed at all.
Filed as Exiv2/exiv2#9469. Newer bodies keep the setting in the undecoded
`Tag2010`. Rather than ship a reader that fires on a misparsed block, Sony is
left out; it wants the rawspeed route as Fujifilm did.

### Testing

EOS R6 cRAW, and Olympus samples from raw.pixls.us, exported with
`darktable-cli`.

| Body | Aspect | Orientation | Output |
| --- | --- | --- | --- |
| EOS R6 | 1:1 | landscape / portrait | 3670x3670 both |
| EOS R6 | 4:3 | landscape / portrait | 4892x3669 / 3669x4892 |
| EOS R6 | 16:9 | landscape / portrait | 5488x3087 / 3087x5488 |
| EOS R6 | 3:2 native | portrait | 3670x5496, untouched |
| E-M10 Mark IV | 16:9 | landscape | 5200x2925 |
| E-P2 | 3:2 | landscape | 4098x2732 |
| TG-6 | 3:2 | landscape | 4014x2674 |
| E-PL9 | 4:3 native | landscape | 4608x3456, untouched |

Also confirmed in the GUI: crop shows enabled with the aspect locked, and
dragging reframes within the full sensor area.

The 1.85:1 entry in the Canon table is untested, no body I have offers it.

### Two things worth raising

Switching a module on by default is a policy call rather than a detail, and
it is the part I would most like review on. @jenshannoschwalm noted in #19109
that the DNG path is deliberately off-but-available; I left that alone and
scoped this strictly to camera aspect settings, but I can put the new
behaviour behind a preference instead if that is preferred.

Separately, and not caused by this: `modify_roi_out()` aligns width and
height independently to the ratio's factors when exporting, so the pair is
only exact when both land on the same multiple. The TG-6 3:2 above comes out
at 1.5011 for that reason, and a manually set ratio behaves the same way.
Happy to file it separately if you think it is worth fixing.

---

*Disclosure: designed, written and tested with AI assistance (Claude Code with Claude Opus 5).
Verified against current master and builds clean with no new warnings.*
