### PR TITLE
16 bit CUPS print pipeline for printer profiled prints

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -101,6 +101,9 @@ changes (where available).
   covering built-in and Lumix-branded lenses that lensfun has no
   profile for.
 
+- Printer (paper) profiled print jobs will remain 16 bit through
+  the full print pipeline
+
 ## Bug Fixes
 
 - Clarified multi-image rating toasts for un-reject and for mixed

--- a/src/common/pdf.c
+++ b/src/common/pdf.c
@@ -387,13 +387,15 @@ int dt_pdf_add_icc_from_data(dt_pdf_t *pdf,
 // to be in output device space, otherwise the ICC profile object is
 // referenced.  if image == NULL only the outline can be shown later
 dt_pdf_image_t *dt_pdf_add_image(dt_pdf_t *pdf,
-                                 const unsigned char *image,
+                                 const void *image,
                                  const int width,
                                  const int height,
                                  const int bpp,
                                  const int icc_id,
                                  const float border)
 {
+  const unsigned char *image = (const unsigned char *)buf; // uint16 can't cast directly to unsigned char, bring in void first then cast
+  
   size_t stream_size = 0;
   size_t bytes_written = 0;
 

--- a/src/common/pdf.c
+++ b/src/common/pdf.c
@@ -387,7 +387,7 @@ int dt_pdf_add_icc_from_data(dt_pdf_t *pdf,
 // to be in output device space, otherwise the ICC profile object is
 // referenced.  if image == NULL only the outline can be shown later
 dt_pdf_image_t *dt_pdf_add_image(dt_pdf_t *pdf,
-                                 const void *image,
+                                 const void *buf,
                                  const int width,
                                  const int height,
                                  const int bpp,

--- a/src/common/pdf.h
+++ b/src/common/pdf.h
@@ -126,7 +126,7 @@ int dt_pdf_add_icc_from_data(dt_pdf_t *pdf,
                              const unsigned char *data,
                              const size_t size);
 dt_pdf_image_t *dt_pdf_add_image(dt_pdf_t *pdf,
-                                 const unsigned char *image,
+                                 const void *image,
                                  const int width,
                                  const int height,
                                  const int bpp,

--- a/src/common/printing.h
+++ b/src/common/printing.h
@@ -43,6 +43,7 @@ typedef struct _image_box
   dt_image_pos pos;              // relative pos from screen.page
   dt_image_pos screen;           // current screen pos (in pixels)
   dt_image_pos print;            // current print pos (in pixels) depending on paper size + DPI
+  int img_bpp;                   // image bit per pixel metadata
   uint16_t *buf;
 } dt_image_box;
 

--- a/src/common/printprof.c
+++ b/src/common/printprof.c
@@ -65,7 +65,7 @@ int dt_apply_printer_profile(void **in, uint32_t width, uint32_t height, int bpp
     return 1;
   }
 
-  void *out = malloc((size_t)3 * width * height);
+  void *out = g_malloc((size_t)3 * (bpp == 8 ? 1 : 2) * width * height); //fixed for 16 bit printing: memory allocation was not accounting for bpp for out, was always 8 bit/channel
   if(!out)
   {
     dt_print(DT_DEBUG_ALWAYS, "unable to allocate buffer for printer-proofed image");
@@ -84,7 +84,7 @@ int dt_apply_printer_profile(void **in, uint32_t width, uint32_t height, int bpp
   else
   {
     const uint16_t *ptr_in = (uint16_t *)*in;
-    uint8_t *ptr_out = (uint8_t *)out;
+    uint16_t *ptr_out = (uint16_t *)out;
 
     DT_OMP_FOR(shared(hTransform))
     for(int k=0; k<height; k++)

--- a/src/common/printprof.c
+++ b/src/common/printprof.c
@@ -51,7 +51,7 @@ int dt_apply_printer_profile(void **in, uint32_t width, uint32_t height, int bpp
   wInput = ComputeFormatDescriptor (PT_RGB, (bpp==8?1:2));
 
   OutputColorSpace = _cmsLCMScolorSpace(cmsGetColorSpace(hOutProfile));
-  wOutput = ComputeOutputFormatDescriptor(wInput, OutputColorSpace, 1);
+  wOutput = ComputeOutputFormatDescriptor(wInput, OutputColorSpace, (bpp==8?1:2));
 
   hTransform = cmsCreateTransform
     (hInProfile,  wInput,
@@ -93,7 +93,7 @@ int dt_apply_printer_profile(void **in, uint32_t width, uint32_t height, int bpp
 
   cmsDeleteTransform(hTransform);
 
-  free(*in);
+  g_free(*in);
   *in = out;
 
   return 0;

--- a/src/libs/print_settings.c
+++ b/src/libs/print_settings.c
@@ -474,27 +474,29 @@ static void _create_pdf(dt_job_t *job,
   for(int k=0; k<imgs.count; k++)
   {
     const int resolution = params->prt.printer.resolution;
-    const dt_image_box *box = &imgs.box[k];
+    dt_image_box *box = &imgs.box[k];
 
     //If image is 16bit, it needs to be converted to big endian before sending for PDF creation
-    uint16_t *tmp = NULL;
 
     if(box->img_bpp == 16)
     {
-      size_t total_samples = (size_t)3 * box->exp_width * box->exp_height;
-      tmp = g_malloc(total_samples * sizeof(uint16_t));
+      const size_t total_samples = (size_t)3 * box->exp_width * box->exp_height;
+      uint16_t *tmp = g_malloc(total_samples * sizeof(uint16_t));
       const uint16_t *src = box->buf;
       for(size_t i = 0; i < total_samples; i++)
       {
         tmp[i] = GUINT16_TO_BE(src[i]);
       }
+      
+      g_free(box->buf);
+      box->buf = tmp;
     }
 
     if(dt_is_valid_imgid(box->imgid))
     {
       pdf_image[count] =
         dt_pdf_add_image(pdf, 
-                         (box->img_bpp == 16) ? tmp : box->buf,  //send the big endian converted buffer if 16 bit, send 8 bit as is
+                         box->buf,
                          box->exp_width, box->exp_height,
                          box->img_bpp, icc_id, 0.0);
 
@@ -505,7 +507,6 @@ static void _create_pdf(dt_job_t *job,
       pdf_image[count]->bb_height = dt_pdf_pixel_to_point(box->print.height, resolution);
       count++;
     }
-    if(tmp) g_free(tmp);
   }
 
   params->pdf_page = dt_pdf_add_page(pdf, pdf_image, count);

--- a/src/libs/print_settings.c
+++ b/src/libs/print_settings.c
@@ -402,7 +402,7 @@ static int _export_image(dt_job_t *job, dt_image_box *img)
                "cannot open printer profile `%s'",
                params->p_icc_profile);
       dt_control_queue_redraw();
-      return 1;
+      return 1;    
     }
     else
     {
@@ -431,7 +431,9 @@ static int _export_image(dt_job_t *job, dt_image_box *img)
     }
   }
 
+// In _export_image(): Print actual buffer address and size right before assigning to img->buf
   img->buf = params->buf;
+  img->img_bpp = dat.bpp; // Store the image bitdepth with the image being sent to print job
   params->buf = NULL;
 
   return 0;
@@ -475,11 +477,27 @@ static void _create_pdf(dt_job_t *job,
     const int resolution = params->prt.printer.resolution;
     const dt_image_box *box = &imgs.box[k];
 
+    //If image is 16bit, it needs to be converted to big endian before sending for PDF creation
+    uint16_t *tmp = NULL;
+
+    if(box->img_bpp == 16)
+    {
+      size_t total_samples = (size_t)3 * box->exp_width * box->exp_height;
+      tmp = g_malloc(total_samples * sizeof(uint16_t));
+      const uint16_t *src = box->buf;
+      for(size_t i = 0; i < total_samples; i++)
+      {
+        tmp[i] = GUINT16_TO_BE(src[i]);
+      }
+    }
+
     if(dt_is_valid_imgid(box->imgid))
     {
       pdf_image[count] =
-        dt_pdf_add_image(pdf, (uint8_t *)box->buf, box->exp_width, box->exp_height,
-                         8, icc_id, 0.0);
+        dt_pdf_add_image(pdf, 
+                         (box->img_bpp == 16) ? tmp : box->buf,  //send the big endian converted buffer if 16 bit, send 8 bit as is
+                         box->exp_width, box->exp_height,
+                         box->img_bpp, icc_id, 0.0);
 
       //  PDF bounding-box has origin on bottom-left
       pdf_image[count]->bb_x      = dt_pdf_pixel_to_point(box->print.x, resolution);
@@ -488,6 +506,7 @@ static void _create_pdf(dt_job_t *job,
       pdf_image[count]->bb_height = dt_pdf_pixel_to_point(box->print.height, resolution);
       count++;
     }
+    if(tmp) g_free(tmp);
   }
 
   params->pdf_page = dt_pdf_add_page(pdf, pdf_image, count);

--- a/src/libs/print_settings.c
+++ b/src/libs/print_settings.c
@@ -431,7 +431,6 @@ static int _export_image(dt_job_t *job, dt_image_box *img)
     }
   }
 
-// In _export_image(): Print actual buffer address and size right before assigning to img->buf
   img->buf = params->buf;
   img->img_bpp = dat.bpp; // Store the image bitdepth with the image being sent to print job
   params->buf = NULL;


### PR DESCRIPTION
Currently the print pipe on darktable handles use of an .icc printer (paper) profile through the color transform as 16 bit, but returns just an 8 bit encoded image, which is then processed through CUPS as an 8 bit PDF.  This code maintains 16 bit per channel (48 bit/pixel) color fidelity all the way to the printer provided a printer profile has been set.  

I have tested this on a Canon MF8200 all in one color laser printer and Epson ET-8550 color inkjet with both jpeg and raw image formats through both the printer managed (8 bit pipeline) and printer profiled (16 bit pipeline) with success.  Those are the only two physical printers accessible to me and I do not know what would happen with older equipment or non-CUPS drivers.  So there is possibility of regression here that should be tested.

This PR relates to PR #21988 in that some of the changes here are also needed to provide a 16 bit pipeline for Windows printing, notably those in printprof.c and those changes alone would break profiled printing on Linux (I tested and got corrupted output) and presumably MacOS.  If this PR is decided to not be merged, I can still make Windows printing work, but like with CUPS would be 8 bit to the printer once it leaves the LittleCMS color conversion for the .icc profile.