### PR TITLE
colorspaces: compute JzAzBz's Az and Bz without cancellation

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -147,6 +147,9 @@ changes (where available).
 
 - Fixed OpenCL input gamma corrected scaling for some devices.
 
+- Compute JzAzBz's Az and Bz without cancellation so that results
+  computed by the CPU and OpenCL paths do not diverge.
+
 ## Lua
 
 ### API Version

--- a/data/kernels/colorspace.h
+++ b/data/kernels/colorspace.h
@@ -362,6 +362,12 @@ static inline float4 XYZ_to_JzAzBz(float4 XYZ_D65)
                         { 3.524000f, -4.066708f, 0.542708f, 0.0f },
                         { 0.199076f, 1.096799f, -1.295875f, 0.0f } };
 
+  const float n = 0.159301758f;
+  const float p = 134.034375f;
+  const float c1 = 0.8359375f;
+  const float c2 = 18.8515625f;
+  const float c3 = 18.6875f;
+
   float4 temp1, temp2;
   // XYZ -> X'Y'Z
   temp1.x = 1.15f * XYZ_D65.x - 0.15f * XYZ_D65.z;
@@ -373,16 +379,64 @@ static inline float4 XYZ_to_JzAzBz(float4 XYZ_D65)
   temp2.y = dot(M[1], temp1);
   temp2.z = dot(M[2], temp1);
   temp2.w = 0.f;
-  // LMS -> L'M'S'
-  temp2 = dtcl_pow(fmax(temp2 / 10000.f, 0.0f), 0.159301758f);
-  temp2 = dtcl_pow((0.8359375f + 18.8515625f * temp2) / (1.0f + 18.6875f * temp2), 134.034375f);
-  // L'M'S' -> Izazbz
-  temp1.x = dot(A[0], temp2);
-  temp1.y = dot(A[1], temp2);
-  temp1.z = dot(A[2], temp2);
+
+  const float l = temp2.x / 10000.f;
+  const float m = temp2.y / 10000.f;
+  const float s = temp2.z / 10000.f;
+
+  float4 out;
+  // Az and Bz are differences of near-equal numbers and are computed as such --
+  // see the long comment on dt_XYZ_2_JzAzBz() in
+  // src/common/colorspaces_inline_conversions.h, which this mirrors exactly.
+  if(l > 0.0f && m > 0.0f && s > 0.0f)
+  {
+    // raw differences from the matrix rows, not from the computed LMS
+    const float d_lm = dot(M[0] - M[1], temp1) / 10000.f;
+    const float d_sm = dot(M[2] - M[1], temp1) / 10000.f;
+    const float d_ls = dot(M[0] - M[2], temp1) / 10000.f;
+
+    // ... through x^n. x^k - y^k = y^k * expm1(k * log1p((x-y)/y)), which is
+    // accurate because log1p and expm1 are accurate near zero
+    const float t_l = dtcl_pow(l, n), t_m = dtcl_pow(m, n), t_s = dtcl_pow(s, n);
+    const float dt_lm = dtcl_pow(m, n) * expm1(n * log1p(d_lm / m));
+    const float dt_sm = dtcl_pow(m, n) * expm1(n * log1p(d_sm / m));
+    const float dt_ls = dtcl_pow(s, n) * expm1(n * log1p(d_ls / s));
+
+    // ... through the rational PQ step
+    const float k = c2 - c1 * c3;
+    const float q_l = 1.0f + c3 * t_l, q_m = 1.0f + c3 * t_m, q_s = 1.0f + c3 * t_s;
+    const float y_l = (c1 + c2 * t_l) / q_l;
+    const float y_m = (c1 + c2 * t_m) / q_m;
+    const float y_s = (c1 + c2 * t_s) / q_s;
+    const float dy_lm = k * dt_lm / (q_l * q_m);
+    const float dy_sm = k * dt_sm / (q_s * q_m);
+    const float dy_ls = k * dt_ls / (q_l * q_s);
+
+    // ... and through y^p, giving L'-M', S'-M' and L'-S' directly
+    const float d_LM = dtcl_pow(y_m, p) * expm1(p * log1p(dy_lm / y_m));
+    const float d_SM = dtcl_pow(y_m, p) * expm1(p * log1p(dy_sm / y_m));
+    const float d_LS = dtcl_pow(y_s, p) * expm1(p * log1p(dy_ls / y_s));
+
+    // Iz is a sum, not a difference
+    out.x = 0.5f * dtcl_pow(y_l, p) + 0.5f * dtcl_pow(y_m, p);
+    out.y = 3.524000f * d_LM + 0.542708f * d_SM;
+    out.z = 0.199076f * d_LS - 1.096799f * d_SM;
+    out.w = 0.f;
+  }
+  else
+  {
+    // LMS -> L'M'S'
+    temp2 = dtcl_pow(fmax(temp2 / 10000.f, 0.0f), n);
+    temp2 = dtcl_pow((c1 + c2 * temp2) / (1.0f + c3 * temp2), p);
+    // L'M'S' -> Izazbz
+    out.x = dot(A[0], temp2);
+    out.y = dot(A[1], temp2);
+    out.z = dot(A[2], temp2);
+    out.w = 0.f;
+  }
   // Iz -> Jz
-  temp1.x = fmax(0.44f * temp1.x / (1.0f - 0.56f * temp1.x) - 1.6295499532821566e-11f, 0.f);
-  return temp1;
+  out.x = fmax(0.44f * out.x / (1.0f - 0.56f * out.x) - 1.6295499532821566e-11f, 0.f);
+  return out;
 }
 
 

--- a/data/kernels/colorspace.h
+++ b/data/kernels/colorspace.h
@@ -380,9 +380,9 @@ static inline float4 XYZ_to_JzAzBz(float4 XYZ_D65)
   temp2.z = dot(M[2], temp1);
   temp2.w = 0.f;
 
-  const float l = temp2.x / 10000.f;
-  const float m = temp2.y / 10000.f;
-  const float s = temp2.z / 10000.f;
+  const float l = temp2.x * 1e-4f;
+  const float m = temp2.y * 1e-4f;
+  const float s = temp2.z * 1e-4f;
 
   float4 out;
   // Az and Bz are differences of near-equal numbers and are computed as such --
@@ -391,16 +391,17 @@ static inline float4 XYZ_to_JzAzBz(float4 XYZ_D65)
   if(l > 0.0f && m > 0.0f && s > 0.0f)
   {
     // raw differences from the matrix rows, not from the computed LMS
-    const float d_lm = dot(M[0] - M[1], temp1) / 10000.f;
-    const float d_sm = dot(M[2] - M[1], temp1) / 10000.f;
-    const float d_ls = dot(M[0] - M[2], temp1) / 10000.f;
+    const float d_lm = dot(M[0] - M[1], temp1) * 1e-4f;
+    const float d_sm = dot(M[2] - M[1], temp1) * 1e-4f;
+    const float d_ls = dot(M[0] - M[2], temp1) * 1e-4f;
 
     // ... through x^n. x^k - y^k = y^k * expm1(k * log1p((x-y)/y)), which is
-    // accurate because log1p and expm1 are accurate near zero
+    // accurate because log1p and expm1 are accurate near zero. The y^k factors
+    // are t_m and t_s, already computed
     const float t_l = dtcl_pow(l, n), t_m = dtcl_pow(m, n), t_s = dtcl_pow(s, n);
-    const float dt_lm = dtcl_pow(m, n) * expm1(n * log1p(d_lm / m));
-    const float dt_sm = dtcl_pow(m, n) * expm1(n * log1p(d_sm / m));
-    const float dt_ls = dtcl_pow(s, n) * expm1(n * log1p(d_ls / s));
+    const float dt_lm = t_m * expm1(n * log1p(d_lm / m));
+    const float dt_sm = t_m * expm1(n * log1p(d_sm / m));
+    const float dt_ls = t_s * expm1(n * log1p(d_ls / s));
 
     // ... through the rational PQ step
     const float k = c2 - c1 * c3;
@@ -412,13 +413,16 @@ static inline float4 XYZ_to_JzAzBz(float4 XYZ_D65)
     const float dy_sm = k * dt_sm / (q_s * q_m);
     const float dy_ls = k * dt_ls / (q_l * q_s);
 
-    // ... and through y^p, giving L'-M', S'-M' and L'-S' directly
-    const float d_LM = dtcl_pow(y_m, p) * expm1(p * log1p(dy_lm / y_m));
-    const float d_SM = dtcl_pow(y_m, p) * expm1(p * log1p(dy_sm / y_m));
-    const float d_LS = dtcl_pow(y_s, p) * expm1(p * log1p(dy_ls / y_s));
+    // ... and through y^p, giving L'-M', S'-M' and L'-S' directly. M' also
+    // feeds Iz below, so it is computed once
+    const float Mp = dtcl_pow(y_m, p);
+    const float Sp = dtcl_pow(y_s, p);
+    const float d_LM = Mp * expm1(p * log1p(dy_lm / y_m));
+    const float d_SM = Mp * expm1(p * log1p(dy_sm / y_m));
+    const float d_LS = Sp * expm1(p * log1p(dy_ls / y_s));
 
     // Iz is a sum, not a difference
-    out.x = 0.5f * dtcl_pow(y_l, p) + 0.5f * dtcl_pow(y_m, p);
+    out.x = 0.5f * dtcl_pow(y_l, p) + 0.5f * Mp;
     out.y = 3.524000f * d_LM + 0.542708f * d_SM;
     out.z = 0.199076f * d_LS - 1.096799f * d_SM;
     out.w = 0.f;

--- a/src/common/colorspaces_inline_conversions.h
+++ b/src/common/colorspaces_inline_conversions.h
@@ -845,8 +845,8 @@ static inline void dt_XYZ_D65_2_XYZ_D50(const dt_aligned_pixel_t XYZ_D65, dt_ali
  *  https://www.osapublishing.org/oe/fulltext.cfm?uri=oe-25-13-15131&id=368272
  */
 
-/* x^k - y^k, given y and (x - y), without ever forming the two powers and
- * subtracting them.
+/* x^k - y^k, given y^k, y and (x - y), without ever forming the two powers and
+ * subtracting them. y^k is passed in because callers already have it.
  *
  * pow() is exact to within an ulp of a *large* value here: the JzAzBz PQ
  * exponent is 134.034375, so the results are O(1) numbers whose difference,
@@ -856,9 +856,12 @@ static inline void dt_XYZ_D65_2_XYZ_D50(const dt_aligned_pixel_t XYZ_D65, dt_ali
  * difference comes out with full relative precision.
  *
  * Requires y > 0 and x > 0; callers check. */
-static inline float _dt_pow_diff(const float y, const float k, const float x_minus_y)
+static inline float _dt_pow_diff(const float pow_y_k,
+                                 const float k,
+                                 const float y,
+                                 const float x_minus_y)
 {
-  return powf(y, k) * expm1f(k * log1pf(x_minus_y / y));
+  return pow_y_k * expm1f(k * log1pf(x_minus_y / y));
 }
 
 DT_OMP_DECLARE_SIMD(aligned(XYZ_D65, JzAzBz: 16))
@@ -895,9 +898,12 @@ static inline void dt_XYZ_2_JzAzBz(const dt_aligned_pixel_t XYZ_D65, dt_aligned_
   dt_aligned_pixel_t LMS = { 0.0f, 0.0f, 0.0f, 0.0f };
   dt_apply_transposed_color_matrix(XYZ, M_transposed, LMS);
 
-  const float l = LMS[0] / 10000.f;
-  const float m = LMS[1] / 10000.f;
-  const float s = LMS[2] / 10000.f;
+  // the paper's 1/10000 nit scaling, written as a multiply: 1e-4f is not the
+  // exact reciprocal, but the extra rounding is far below what the difference
+  // machinery below resolves, and multiplies are cheaper on CPU and GPU alike
+  const float l = LMS[0] * 1e-4f;
+  const float m = LMS[1] * 1e-4f;
+  const float s = LMS[2] * 1e-4f;
 
   /* Az and Bz are differences of near-equal numbers, and are computed as such.
    *
@@ -927,19 +933,19 @@ static inline void dt_XYZ_2_JzAzBz(const dt_aligned_pixel_t XYZ_D65, dt_aligned_
     // computed LMS, so they too are exact rather than cancelled
     const float d_lm = ((M_transposed[0][0] - M_transposed[0][1]) * XYZ[0]
                       + (M_transposed[1][0] - M_transposed[1][1]) * XYZ[1]
-                      + (M_transposed[2][0] - M_transposed[2][1]) * XYZ[2]) / 10000.f;
+                      + (M_transposed[2][0] - M_transposed[2][1]) * XYZ[2]) * 1e-4f;
     const float d_sm = ((M_transposed[0][2] - M_transposed[0][1]) * XYZ[0]
                       + (M_transposed[1][2] - M_transposed[1][1]) * XYZ[1]
-                      + (M_transposed[2][2] - M_transposed[2][1]) * XYZ[2]) / 10000.f;
+                      + (M_transposed[2][2] - M_transposed[2][1]) * XYZ[2]) * 1e-4f;
     const float d_ls = ((M_transposed[0][0] - M_transposed[0][2]) * XYZ[0]
                       + (M_transposed[1][0] - M_transposed[1][2]) * XYZ[1]
-                      + (M_transposed[2][0] - M_transposed[2][2]) * XYZ[2]) / 10000.f;
+                      + (M_transposed[2][0] - M_transposed[2][2]) * XYZ[2]) * 1e-4f;
 
     // ... through x^n
     const float t_l = powf(l, n), t_m = powf(m, n), t_s = powf(s, n);
-    const float dt_lm = _dt_pow_diff(m, n, d_lm);
-    const float dt_sm = _dt_pow_diff(m, n, d_sm);
-    const float dt_ls = _dt_pow_diff(s, n, d_ls);
+    const float dt_lm = _dt_pow_diff(t_m, n, m, d_lm);
+    const float dt_sm = _dt_pow_diff(t_m, n, m, d_sm);
+    const float dt_ls = _dt_pow_diff(t_s, n, s, d_ls);
 
     // ... through y = (c1 + c2 t) / (1 + c3 t), whose difference is exact in
     // this form: y_a - y_b = (c2 - c1 c3)(t_a - t_b) / ((1 + c3 t_a)(1 + c3 t_b))
@@ -952,15 +958,16 @@ static inline void dt_XYZ_2_JzAzBz(const dt_aligned_pixel_t XYZ_D65, dt_aligned_
     const float dy_sm = k * dt_sm / (q_s * q_m);
     const float dy_ls = k * dt_ls / (q_l * q_s);
 
-    // ... and through y^p, giving L'-M', S'-M', L'-S' directly
-    const float d_LM = _dt_pow_diff(y_m, p, dy_lm);
-    const float d_SM = _dt_pow_diff(y_m, p, dy_sm);
-    const float d_LS = _dt_pow_diff(y_s, p, dy_ls);
-
-    // Iz is a sum, not a difference, so it is computed the plain way
+    // ... and through y^p, giving L'-M', S'-M', L'-S' directly. M' feeds Iz
+    // below as well, so each power is computed once
     const float Lp = powf(y_l, p);
     const float Mp = powf(y_m, p);
+    const float Sp = powf(y_s, p);
+    const float d_LM = _dt_pow_diff(Mp, p, y_m, dy_lm);
+    const float d_SM = _dt_pow_diff(Mp, p, y_m, dy_sm);
+    const float d_LS = _dt_pow_diff(Sp, p, y_s, dy_ls);
 
+    // Iz is a sum, not a difference, so it is computed the plain way
     JzAzBz[0] = 0.5f * Lp + 0.5f * Mp;
     JzAzBz[1] = 3.524000f * d_LM + 0.542708f * d_SM;
     JzAzBz[2] = 0.199076f * d_LS - 1.096799f * d_SM;

--- a/src/common/colorspaces_inline_conversions.h
+++ b/src/common/colorspaces_inline_conversions.h
@@ -845,6 +845,22 @@ static inline void dt_XYZ_D65_2_XYZ_D50(const dt_aligned_pixel_t XYZ_D65, dt_ali
  *  https://www.osapublishing.org/oe/fulltext.cfm?uri=oe-25-13-15131&id=368272
  */
 
+/* x^k - y^k, given y and (x - y), without ever forming the two powers and
+ * subtracting them.
+ *
+ * pow() is exact to within an ulp of a *large* value here: the JzAzBz PQ
+ * exponent is 134.034375, so the results are O(1) numbers whose difference,
+ * for two nearby inputs, is many orders of magnitude smaller than either. The
+ * subtraction then keeps almost none of the digits it was given. log1p/expm1
+ * are accurate near zero, which is exactly where this operates, so the
+ * difference comes out with full relative precision.
+ *
+ * Requires y > 0 and x > 0; callers check. */
+static inline float _dt_pow_diff(const float y, const float k, const float x_minus_y)
+{
+  return powf(y, k) * expm1f(k * log1pf(x_minus_y / y));
+}
+
 DT_OMP_DECLARE_SIMD(aligned(XYZ_D65, JzAzBz: 16))
 static inline void dt_XYZ_2_JzAzBz(const dt_aligned_pixel_t XYZ_D65, dt_aligned_pixel_t JzAzBz)
 {
@@ -875,18 +891,93 @@ static inline void dt_XYZ_2_JzAzBz(const dt_aligned_pixel_t XYZ_D65, dt_aligned_
   XYZ[1] = g * XYZ_D65[1] - (g - 1.0f) * XYZ_D65[0];
   XYZ[2] = XYZ_D65[2];
 
-  // X'Y'Z -> L'M'S'
+  // X'Y'Z -> LMS
   dt_aligned_pixel_t LMS = { 0.0f, 0.0f, 0.0f, 0.0f };
   dt_apply_transposed_color_matrix(XYZ, M_transposed, LMS);
-  DT_OMP_SIMD(aligned(LMS, XYZ:16))
-  for(int i = 0; i < 3; i++)
+
+  const float l = LMS[0] / 10000.f;
+  const float m = LMS[1] / 10000.f;
+  const float s = LMS[2] / 10000.f;
+
+  /* Az and Bz are differences of near-equal numbers, and are computed as such.
+   *
+   * The A matrix rows for az and bz each sum to zero -- az is
+   * 3.524L' - 4.066708M' + 0.542708S' -- so for a near-neutral colour, where
+   * L', M' and S' are nearly the same O(1) number, the result is what is left
+   * after almost everything cancels. It is also the *only* input to hue, since
+   * hz = atan2(Bz, Az). Meanwhile the PQ exponent 134 multiplies any relative
+   * error in its argument by 134, so a single ulp anywhere upstream arrives
+   * here magnified. Evaluated directly, Az and Bz keep barely any correct
+   * digits for neutral colours, and no two float32 implementations agree --
+   * which is why the CPU and OpenCL paths render such pixels differently.
+   *
+   * Rewriting az and bz over the *differences* L'-M', S'-M' and L'-S' is
+   * algebraically identical (it is the same zero-sum rows, regrouped), and
+   * each difference is carried through the two power laws and the rational PQ
+   * step without ever subtracting two computed values -- so nothing cancels
+   * anywhere and the result has full relative precision.
+   *
+   * The rewrite needs every LMS component strictly positive, which is the
+   * common case; out-of-gamut inputs that clamp to zero take the direct path,
+   * where cancellation is not a concern because the components are no longer
+   * near-equal. */
+  if(l > 0.0f && m > 0.0f && s > 0.0f)
   {
-    LMS[i] = powf(fmaxf(LMS[i] / 10000.f, 0.0f), n);
-    LMS[i] = powf((c1 + c2 * LMS[i]) / (1.0f + c3 * LMS[i]), p);
+    // the raw differences, taken from the matrix rows rather than from the
+    // computed LMS, so they too are exact rather than cancelled
+    const float d_lm = ((M_transposed[0][0] - M_transposed[0][1]) * XYZ[0]
+                      + (M_transposed[1][0] - M_transposed[1][1]) * XYZ[1]
+                      + (M_transposed[2][0] - M_transposed[2][1]) * XYZ[2]) / 10000.f;
+    const float d_sm = ((M_transposed[0][2] - M_transposed[0][1]) * XYZ[0]
+                      + (M_transposed[1][2] - M_transposed[1][1]) * XYZ[1]
+                      + (M_transposed[2][2] - M_transposed[2][1]) * XYZ[2]) / 10000.f;
+    const float d_ls = ((M_transposed[0][0] - M_transposed[0][2]) * XYZ[0]
+                      + (M_transposed[1][0] - M_transposed[1][2]) * XYZ[1]
+                      + (M_transposed[2][0] - M_transposed[2][2]) * XYZ[2]) / 10000.f;
+
+    // ... through x^n
+    const float t_l = powf(l, n), t_m = powf(m, n), t_s = powf(s, n);
+    const float dt_lm = _dt_pow_diff(m, n, d_lm);
+    const float dt_sm = _dt_pow_diff(m, n, d_sm);
+    const float dt_ls = _dt_pow_diff(s, n, d_ls);
+
+    // ... through y = (c1 + c2 t) / (1 + c3 t), whose difference is exact in
+    // this form: y_a - y_b = (c2 - c1 c3)(t_a - t_b) / ((1 + c3 t_a)(1 + c3 t_b))
+    const float k = c2 - c1 * c3;
+    const float q_l = 1.0f + c3 * t_l, q_m = 1.0f + c3 * t_m, q_s = 1.0f + c3 * t_s;
+    const float y_l = (c1 + c2 * t_l) / q_l;
+    const float y_m = (c1 + c2 * t_m) / q_m;
+    const float y_s = (c1 + c2 * t_s) / q_s;
+    const float dy_lm = k * dt_lm / (q_l * q_m);
+    const float dy_sm = k * dt_sm / (q_s * q_m);
+    const float dy_ls = k * dt_ls / (q_l * q_s);
+
+    // ... and through y^p, giving L'-M', S'-M', L'-S' directly
+    const float d_LM = _dt_pow_diff(y_m, p, dy_lm);
+    const float d_SM = _dt_pow_diff(y_m, p, dy_sm);
+    const float d_LS = _dt_pow_diff(y_s, p, dy_ls);
+
+    // Iz is a sum, not a difference, so it is computed the plain way
+    const float Lp = powf(y_l, p);
+    const float Mp = powf(y_m, p);
+
+    JzAzBz[0] = 0.5f * Lp + 0.5f * Mp;
+    JzAzBz[1] = 3.524000f * d_LM + 0.542708f * d_SM;
+    JzAzBz[2] = 0.199076f * d_LS - 1.096799f * d_SM;
+    JzAzBz[3] = 0.0f;
+  }
+  else
+  {
+    dt_aligned_pixel_t LMSp = { 0.0f, 0.0f, 0.0f, 0.0f };
+    for(int i = 0; i < 3; i++)
+    {
+      LMSp[i] = powf(fmaxf(LMS[i] / 10000.f, 0.0f), n);
+      LMSp[i] = powf((c1 + c2 * LMSp[i]) / (1.0f + c3 * LMSp[i]), p);
+    }
+    // L'M'S' -> Izazbz
+    dt_apply_transposed_color_matrix(LMSp, A_transposed, JzAzBz);
   }
 
-  // L'M'S' -> Izazbz
-  dt_apply_transposed_color_matrix(LMS, A_transposed, JzAzBz);
   // Iz -> Jz
   JzAzBz[0] = fmaxf(((1.0f + d) * JzAzBz[0]) / (1.0f + d * JzAzBz[0]) - d0, 0.f);
 }


### PR DESCRIPTION
### Background

This is another OpenCL/CPU code inconsistency found working on flexi masks. I built a tool that replays mask edits from user libraries four ways (two code paths × CPU/OpenCL). I used it to processed >70K edits from a dozen darktable users. This made the pipeline disagreeing *with itself* very visible.

### The issue

`dt_XYZ_2_JzAzBz()` computes `az = 3.524L' − 4.066708M' + 0.542708S'`, whose coefficients sum to zero. For a near-neutral colour L', M' and S' are nearly the same O(1) number, so Az and Bz are whatever survives an almost total cancellation — and they are the only input to hue, since `hz = atan2(Bz, Az)`. The PQ exponent 134.034375 makes it worse: it multiplies any relative error in its argument by 134, so a single ulp anywhere upstream reaches that subtraction magnified.

The consequence is that **no two conforming float32 implementations can agree here**, and darktable has two: the host conversion and its OpenCL twin. The same edit renders differently depending on whether OpenCL is enabled. Measured on a standalone differential carrying verbatim copies of both, hue disagrees by up to 1.68e-03 overall, and by up to 0.045 below Cz 1e-5.

### The fix

 Rewrite az and bz over the differences `L'−M'`, `S'−M'`, `L'−S'` — the same zero-sum rows regrouped, so algebraically identical — and carry each difference through both power laws and the rational PQ step without ever subtracting two computed values:

- the raw differences come from the matrix rows, not the computed LMS;
- through each power law by `x^k − y^k = y^k·expm1(k·log1p((x−y)/y))`, accurate because `log1p`/`expm1` are accurate near zero;
- through the PQ step by `y_a − y_b = (c2 − c1·c3)(t_a − t_b) / ((1 + c3·t_a)(1 + c3·t_b))`.

`Iz` is a sum, not a difference, and is untouched. Inputs with a non-positive LMS component take the original path, where the components are not near-equal and cancellation is not a concern.

**Evidence.** On 200,000 samples, CPU vs OpenCL: Az/Bz max difference 6.27e-06 → 4.49e-07, hue 1.68e-03 → 3.13e-05 — 14× and 54×. Replaying two contributed libraries of real edits, counting those where the CPU and OpenCL renders of the *same* edit disagree by more than 1/255:

| corpus | before | after | |
|---|---:|---:|---|
| library A | 274 | **32** | −88% |
| library B | 135 | **27** | −80% |

No errors, and no edit whose own CPU/OpenCL gap widened. The residual is not this conversion: part is the guided filter used for mask feathering, part is `_blendif_compute_factor`'s hard `<=` against a slider limit, which swings 0 → 1 on an input difference of 5e-07. Both are separate issues.

**Does it change existing renders?** Yes, on both paths, because it changes a conversion shared with `colorbalancergb`, `colorequal`, `diffuse` and the JzCzhz picker. **The change is small and confined to near-neutral colours**: mean hue change 1.43e-05, max 0.0068, with 3 of 199,773 samples (0.002%) moving by more than 1/255 — smaller than the CPU/OpenCL disagreement it removes. **For the pixels most affected there is no stable rendering to preserve, since today they already render one way with OpenCL and another way without. It is also closer to the true value on both paths, not merely more consistent.**

### More details

There is a more extended version of this writeup [here](https://github.com/masterpiga/darktable/blob/masks_revamp/upstreamed_rendering_fixes_from_flexi_migration.md#finding-2----jzczhz-hue-diverges-by-design-not-by-drift).

Co-authored with Claude.