### PR TITLE
fix for #22074 Added checks to ensure the binfo coordinates can't become negative in

### DIFF
--- a/src/develop/borders_helper.c
+++ b/src/develop/borders_helper.c
@@ -25,7 +25,6 @@ static inline void set_pixels(float *buf,
                               const dt_aligned_pixel_t color,
                               const int border_width)
 {
-  if(border_width <= 0) return;                 // guard against negative/zero counts
   for(int i = 0; i < border_width; i++)
   {
     copy_pixel_nontemporal(buf + 4*i,  color);
@@ -39,7 +38,6 @@ static inline void copy_pixels(float *out,
                                const float *const in,
                                const int border_width)
 {
-  if(border_width <= 0) return;                 // guard against negative/zero counts
   for(int i = 0; i < border_width; i++)
   {
     copy_pixel_nontemporal(out + 4*i, in + 4*i);

--- a/src/develop/borders_helper.c
+++ b/src/develop/borders_helper.c
@@ -23,10 +23,10 @@
 // need to parallelize further
 static inline void set_pixels(float *buf,
                               const dt_aligned_pixel_t color,
-                              const int npixels)
+                              const int border_width)
 {
-  if(npixels <= 0) return;                 // guard against negative/zero counts
-  for(size_t i = 0; i < (size_t)npixels; i++)
+  if(border_width <= 0) return;                 // guard against negative/zero counts
+  for(int i = 0; i < border_width; i++)
   {
     copy_pixel_nontemporal(buf + 4*i,  color);
   }
@@ -37,10 +37,10 @@ static inline void set_pixels(float *buf,
 // need to parallelize further
 static inline void copy_pixels(float *out,
                                const float *const in,
-                               const int npixels)
+                               const int border_width)
 {
-  if(npixels <= 0) return;                 // guard against negative/zero counts
-  for(size_t i = 0; i < (size_t)npixels; i++)
+  if(border_width <= 0) return;                 // guard against negative/zero counts
+  for(int i = 0; i < border_width; i++)
   {
     copy_pixel_nontemporal(out + 4*i, in + 4*i);
   }
@@ -252,17 +252,10 @@ void dt_iop_setup_binfo(const dt_dev_pixelpipe_iop_t *piece,
                       0, roi_out->height - 1);
 
     // need end+1 for these coordinates
-    binfo->fl_right     = binfo->frame_br_in_x + 1;
-    binfo->border_right = binfo->frame_br_out_x + 1;
-    binfo->fl_bot       = binfo->frame_br_in_y + 1;
-    binfo->border_bot   = binfo->frame_br_out_y +1;
-
-    // safety: these ranges must never go negative, or set_pixels()/copy_pixels()
-    // will be handed a negative pixel count that wraps to a huge size_t
-    binfo->fl_right     = MAX(binfo->fl_right, binfo->image_right);
-    binfo->border_right = MAX(binfo->border_right, binfo->fl_right);
-    binfo->fl_bot       = MAX(binfo->fl_bot, binfo->image_bot);
-    binfo->border_bot   = MAX(binfo->border_bot, binfo->fl_bot);
+    binfo->fl_right     = MIN(binfo->frame_br_in_x + 1, roi_out->width);
+    binfo->border_right = MIN(binfo->frame_br_out_x + 1, roi_out->width);
+    binfo->fl_bot       = MIN(binfo->frame_br_in_y + 1, roi_out->height);
+    binfo->border_bot   = MIN(binfo->frame_br_out_y + 1, roi_out->height);
   }
 }
 

--- a/src/develop/borders_helper.c
+++ b/src/develop/borders_helper.c
@@ -25,11 +25,13 @@ static inline void set_pixels(float *buf,
                               const dt_aligned_pixel_t color,
                               const int npixels)
 {
-  for(size_t i = 0; i < npixels; i++)
+  if(npixels <= 0) return;                 // guard against negative/zero counts
+  for(size_t i = 0; i < (size_t)npixels; i++)
   {
     copy_pixel_nontemporal(buf + 4*i,  color);
   }
 }
+
 
 // this will be called from inside an OpenMP parallel section, so no
 // need to parallelize further
@@ -37,11 +39,13 @@ static inline void copy_pixels(float *out,
                                const float *const in,
                                const int npixels)
 {
-  for(size_t i = 0; i < npixels; i++)
+  if(npixels <= 0) return;                 // guard against negative/zero counts
+  for(size_t i = 0; i < (size_t)npixels; i++)
   {
     copy_pixel_nontemporal(out + 4*i, in + 4*i);
   }
 }
+
 
 void dt_iop_copy_image_with_border(float *out,
                                    const float *const in,
@@ -248,10 +252,17 @@ void dt_iop_setup_binfo(const dt_dev_pixelpipe_iop_t *piece,
                       0, roi_out->height - 1);
 
     // need end+1 for these coordinates
-    binfo->fl_right     = binfo->frame_br_in_x;
-    binfo->border_right = binfo->frame_br_out_x;
-    binfo->fl_bot       = binfo->frame_br_in_y;
-    binfo->border_bot   = binfo->frame_br_out_y;
+    binfo->fl_right     = binfo->frame_br_in_x + 1;
+    binfo->border_right = binfo->frame_br_out_x + 1;
+    binfo->fl_bot       = binfo->frame_br_in_y + 1;
+    binfo->border_bot   = binfo->frame_br_out_y +1;
+
+    // safety: these ranges must never go negative, or set_pixels()/copy_pixels()
+    // will be handed a negative pixel count that wraps to a huge size_t
+    binfo->fl_right     = MAX(binfo->fl_right, binfo->image_right);
+    binfo->border_right = MAX(binfo->border_right, binfo->fl_right);
+    binfo->fl_bot       = MAX(binfo->fl_bot, binfo->image_bot);
+    binfo->border_bot   = MAX(binfo->border_bot, binfo->fl_bot);
   }
 }
 


### PR DESCRIPTION
#22074 
After confirmation on MacOS as well I tried to fix this. This is what I found.

frame_br_in_x an others are computed as an inclusive last-pixel index (note the -1 baked into the CLAMP). The comment right above the assignment states this // need end+1 for these coordinates — but the +1 never actually gets added. So fl_right/fl_bot/border_right/border_bot all end up one pixel short of where the rest of the struct's convention (exclusive bounds, like image_right) expects them to be.

```...
// need end+1 for these coordinates
binfo->fl_right     = binfo->frame_br_in_x;   // <-- missing "+1"
binfo->border_right = binfo->frame_br_out_x;  // <-- missing "+1"
binfo->fl_bot       = binfo->frame_br_in_y;   // <-- missing "+1"
binfo->border_bot   = binfo->frame_br_out_y;  // <-- missing "+1"```

// safety: these ranges must never go negative, or set_pixels()/copy_pixels()
// will be handed a negative pixel count that wraps to a huge size_t
binfo->fl_right     = MAX(binfo->fl_right, binfo->image_right);
binfo->border_right = MAX(binfo->border_right, binfo->fl_right);
binfo->fl_bot       = MAX(binfo->fl_bot, binfo->image_bot);
binfo->border_bot   = MAX(binfo->border_bot, binfo->fl_bot);

```
I've added some safeguards as well but feel free to remove these if it clutters too much

I've added a return 0 to set_pixels and copy_pixels as common safeguards as well in case somewhere else. Feel free to remove these if they clutter too much.

Note: I'm not fluent in C and this is my first contribution to Darktable, so suggestions are welcome 