### PR TITLE
Possibly auto-disable highlights for non-altered images

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -138,6 +138,9 @@ changes (where available).
 - pixelpipe dump files requested via cli switches are now written
   in ppm or pgm format.
 
+- The default-on highlights opposed module will be disabled automatically
+  on non-altered images for performance if there are no clipped photosites.
+
 ## Bug Fixes
 
 - Clarified multi-image rating toasts for un-reject and for mixed

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -315,6 +315,8 @@ int legacy_params(dt_iop_module_t *self,
 static dt_aligned_pixel_t img_oppchroma;
 static gboolean img_oppclipped = TRUE;
 static dt_hash_t img_opphash = ULLONG_MAX;
+static gboolean disable_highlights = FALSE;
+static dt_imgid_t tested_id = NO_IMGID;
 
 #include "hlreconstruct/segmentation.c"
 #include "hlreconstruct/segbased.c"
@@ -538,6 +540,13 @@ int process_cl(dt_iop_module_t *self,
   const uint32_t filters = piece->filters;
   const int devid = pipe->devid;
 
+  const gboolean fullpipe = dt_pipe_is_full(pipe);
+  if(fullpipe)
+  {
+    disable_highlights = FALSE;
+    tested_id = NO_IMGID;
+  }
+
   if(pipe->mask_display == DT_DEV_PIXELPIPE_DISPLAY_PASSTHRU)
   {
     if(!filters)
@@ -550,7 +559,6 @@ int process_cl(dt_iop_module_t *self,
     }
   }
 
-  const gboolean fullpipe = dt_pipe_is_full(pipe);
   const dt_iop_highlights_mode_t dmode =  d->mode;
   const float clipper = d->clip * highlights_clip_magics[dmode];
 
@@ -823,6 +831,13 @@ void process(dt_iop_module_t *self,
   dt_iop_highlights_data_t *d = piece->data;
   dt_iop_highlights_gui_data_t *g = self->gui_data;
 
+  const gboolean fullpipe = dt_pipe_is_full(pipe);
+  if(fullpipe)
+  {
+    disable_highlights = FALSE;
+    tested_id = NO_IMGID;
+  }
+
   if(pipe->mask_display == DT_DEV_PIXELPIPE_DISPLAY_PASSTHRU)
   {
     if(!filters)
@@ -832,7 +847,6 @@ void process(dt_iop_module_t *self,
     return;
   }
 
-  const gboolean fullpipe = dt_pipe_is_full(pipe);
   const gboolean fastmode = dt_pipe_is_fast(pipe);
   const dt_iop_highlights_mode_t dmode = fastmode && (d->mode == DT_IOP_HIGHLIGHTS_SEGMENTS)
                                         ? DT_IOP_HIGHLIGHTS_OPPOSED
@@ -1262,6 +1276,24 @@ static void _quad_callback(GtkWidget *quad, dt_iop_module_t *self)
   dt_dev_reprocess_center(self->dev, self->iop_order);
 }
 
+static void _ui_pipe_done(gpointer instance, dt_iop_module_t *self)
+{
+  if(disable_highlights
+      && self && self->enabled
+      && ((const dt_iop_highlights_params_t *)self->params)->mode == DT_IOP_HIGHLIGHTS_OPPOSED
+      && self->dev->image_storage.id == tested_id
+      && !dt_image_altered(tested_id))
+  {
+    self->enabled = FALSE;
+    DT_ENTER_GUI_UPDATE();
+    dt_iop_gui_set_enable_button(self);
+    DT_LEAVE_GUI_UPDATE();
+    dt_print(DT_DEBUG_PIPE, "highlights UI pipe disables module with no clipped photosites");
+    dt_dev_add_history_item(darktable.develop, self, FALSE);
+  }
+  disable_highlights = FALSE;
+}
+
 void gui_focus(dt_iop_module_t *self, gboolean in)
 {
   dt_iop_highlights_gui_data_t *g = self->gui_data;
@@ -1344,6 +1376,7 @@ void gui_init(dt_iop_module_t *self)
   gtk_stack_set_homogeneous(GTK_STACK(self->widget), FALSE);
   gtk_stack_add_named(GTK_STACK(self->widget), notapplicable, "notapplicable");
   gtk_stack_add_named(GTK_STACK(self->widget), box_raw, "default");
+  DT_CONTROL_SIGNAL_HANDLE(DT_SIGNAL_DEVELOP_UI_PIPE_FINISHED, _ui_pipe_done);
 }
 
 // clang-format off

--- a/src/iop/hlreconstruct/opposed.c
+++ b/src/iop/hlreconstruct/opposed.c
@@ -103,6 +103,7 @@ static void _process_linear_opposed(dt_iop_module_t *self,
   const size_t msize = dt_round_size((size_t) mwidth, 8) * dt_round_size(mheight, 8);
 
   const dt_hash_t opphash = _opposed_hash(piece);
+  const gboolean fullpipe = dt_pipe_is_full(piece->pipe);
   dt_aligned_pixel_t chrominance = {0.0f, 0.0f, 0.0f, 0.0f};
 
   if(opphash == img_opphash)
@@ -180,7 +181,7 @@ static void _process_linear_opposed(dt_iop_module_t *self,
         for_three_channels(c)
           chrominance[c] = (cnts[c] > 30.0f) ? sums[c] / cnts[c] : 0.0f;
 
-        if(piece->pipe->type == DT_DEV_PIXELPIPE_FULL)
+        if(fullpipe)
         {
           for_three_channels(c)
             img_oppchroma[c] = chrominance[c];
@@ -195,6 +196,11 @@ static void _process_linear_opposed(dt_iop_module_t *self,
             img_oppclipped ? "" : " unclipped");
       }
       dt_free_align(mask);
+      if(fullpipe && !anyclipped)
+      {
+        disable_highlights = TRUE;
+        tested_id = self->dev->image_storage.id;
+      }
     }
   }
 
@@ -248,6 +254,7 @@ static float *_process_opposed(dt_iop_module_t *self,
 
   const dt_hash_t opphash = _opposed_hash(piece);
   dt_aligned_pixel_t chrominance = {0.0f, 0.0f, 0.0f, 0.0f};
+  const gboolean fullpipe = dt_pipe_is_full(piece->pipe);
 
   if(opphash == img_opphash)
   {
@@ -336,12 +343,14 @@ static float *_process_opposed(dt_iop_module_t *self,
           chrominance[c] = (cnts[c] > 100.0f) ? sums[c] / cnts[c] : 0.0f;
       }
 
-      if(piece->pipe->type == DT_DEV_PIXELPIPE_FULL)
+      if(fullpipe)
       {
         for_three_channels(c)
           img_oppchroma[c] = chrominance[c];
         img_opphash = opphash;
         img_oppclipped = anyclipped;
+        disable_highlights = !anyclipped;
+        tested_id = self->dev->image_storage.id;
       }
 
       dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_VERBOSE,
@@ -451,6 +460,7 @@ static cl_int process_opposed_cl(dt_iop_module_t *self,
 
   const dt_hash_t opphash = _opposed_hash(piece);
   const int fastcopymode = (opphash == img_opphash) && !img_oppclipped;
+  const gboolean fullpipe = dt_pipe_is_full(piece->pipe);
 
   if(!fastcopymode)
   {
@@ -536,12 +546,14 @@ static cl_int process_opposed_cl(dt_iop_module_t *self,
     for_three_channels(c)
       chrominance[c] = (cnts[c] > 100.0f) ? sums[c] / cnts[c] : 0.0f;
 
-    if(piece->pipe->type == DT_DEV_PIXELPIPE_FULL)
+    if(fullpipe)
     {
       for_three_channels(c)
         img_oppchroma[c] = chrominance[c];
       img_opphash = opphash;
       img_oppclipped = clipped > 0.0f;
+      disable_highlights = clipped == 0.0f;
+      tested_id = self->dev->image_storage.id;
     }
 
     dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_VERBOSE,


### PR DESCRIPTION
We have highlights module enabled using the opposed algorithm for a hassle-free import of raw images by default.

Yet this comes with some superfluous processing burden for images without any clipped photosites. As the opposed algorithm checks this anyway, we can keep the result of a full pipe process and possibly disable the module automatically via a DT_SIGNAL_DEVELOP_UI_PIPE_FINISHED callback.

Please note:
1. This happens only in darkroom if the image history is not altered by design as we don't want to interfere later with user actions.
2. Possibly we avoid module processing and might have smaller ROI