### PR TITLE
Fixes crash on pinned window followed by darkroom navigation

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -1033,8 +1033,10 @@ float dt_dev_get_zoom_scale(dt_dev_viewport_t *port,
 {
   float zoom_scale = .0f;
 
-  int procw, proch;
+  int procw = 0, proch = 0;
   dt_dev_get_processed_size(port, &procw, &proch);
+
+  if(procw <= 0 || proch <= 0) return 1.0f;
 
   const float w = (float)port->width / procw;
   const float h = (float)port->height / proch;
@@ -2970,14 +2972,15 @@ gboolean dt_dev_get_processed_size(dt_dev_viewport_t *port,
     return TRUE;
   }
 
-  const dt_develop_t *dev = darktable.develop;
+  const dt_develop_t *dev = (port && port->dev) ? port->dev : darktable.develop;
 
   // fallback on preview pipe
-  if(dev->preview_pipe && dev->preview_pipe->processed_width)
+  if(dev && dev->preview_pipe && dev->preview_pipe->processed_width)
   {
     const float scale = dev->preview_pipe->iscale;
     *procw = scale * dev->preview_pipe->processed_width;
     *proch = scale * dev->preview_pipe->processed_height;
+    return TRUE;
   }
   return FALSE;
 }
@@ -3326,11 +3329,11 @@ static void _dev_zoom_move(dt_dev_viewport_t *port,
   const dt_dev_zoom_t old_zoom = port->zoom;
   int old_closeup = port->closeup;
 
-  int procw, proch;
+  int procw = 0, proch = 0;
   dt_dev_get_processed_size(port, &procw, &proch);
 
-  float zoom_x = pts[0] / procw - 0.5f;
-  float zoom_y = pts[1] / proch - 0.5f;
+  float zoom_x = (procw > 0) ? (pts[0] / procw - 0.5f) : 0.0f;
+  float zoom_y = (proch > 0) ? (pts[1] / proch - 0.5f) : 0.0f;
 
   const float cur_scale = dt_dev_get_zoom_scale(port, port->zoom, 1<<port->closeup, FALSE);
 
@@ -3341,8 +3344,8 @@ static void _dev_zoom_move(dt_dev_viewport_t *port,
   }
   else if(zoom == DT_ZOOM_MOVE)
   {
-    zoom_x += scale * x / (procw * cur_scale);
-    zoom_y += scale * y / (proch * cur_scale);
+    if(procw > 0 && cur_scale > 0.0f) zoom_x += scale * x / (procw * cur_scale);
+    if(proch > 0 && cur_scale > 0.0f) zoom_y += scale * y / (proch * cur_scale);
     if(closeup) ++old_closeup; // force refresh
   }
   else
@@ -3548,8 +3551,8 @@ void dt_dev_get_pointer_zoom_pos(dt_dev_viewport_t *port,
   // offset from center now (current zoom_{x,y} points there)
   const float mouse_off_x = px - tb - .5f * port->width;
   const float mouse_off_y = py - tb - .5f * port->height;
-  zoom2_x += mouse_off_x / ((float)procw * scale);
-  zoom2_y += mouse_off_y / ((float)proch * scale);
+  if(procw > 0 && scale > 0.0f) zoom2_x += mouse_off_x / ((float)procw * scale);
+  if(proch > 0 && scale > 0.0f) zoom2_y += mouse_off_y / ((float)proch * scale);
   *zoom_x = zoom2_x + 0.5f;
   *zoom_y = zoom2_y + 0.5f;
   *zoom_scale = dt_dev_get_zoom_scale(port, zoom, 1<<closeup, TRUE);
@@ -3574,8 +3577,8 @@ void dt_dev_get_pointer_zoom_pos_from_bounds(dt_dev_viewport_t *port,
   // offset from center now (current zoom_{x,y} points there)
   const float mouse_off_x = px - tb - .5f * port->width;
   const float mouse_off_y = py - tb - .5f * port->height;
-  zoom2_x += mouse_off_x / ((float)procw * scale);
-  zoom2_y += mouse_off_y / ((float)proch * scale);
+  if(procw > 0 && scale > 0.0f) zoom2_x += mouse_off_x / ((float)procw * scale);
+  if(proch > 0 && scale > 0.0f) zoom2_y += mouse_off_y / ((float)proch * scale);
   *zoom_x = zoom2_x + 0.5f;
   *zoom_y = zoom2_y + 0.5f;
   *zoom_scale = dt_dev_get_zoom_scale(port, zoom, 1<<closeup, TRUE);

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -5674,8 +5674,11 @@ static void _pinch_dispatch(GtkGesture *gesture,
   ctx->handler(gesture, &e, ctx->user_data);
 }
 
-static void _pinch_begin(GtkGestureZoom *gesture, gpointer user_data)
+static void _pinch_begin(GtkGestureZoom *gesture,
+                         GdkEventSequence *sequence,
+                         gpointer user_data)
 {
+  (void)sequence;
   (void)user_data;
   dt_gui_pinch_ctx_t *ctx = g_object_get_data(G_OBJECT(gesture), "dt-gui-pinch-ctx");
   if(!ctx)
@@ -5721,8 +5724,11 @@ static void _pinch_scale_changed(GtkGestureZoom *gesture,
   _pinch_dispatch(GTK_GESTURE(gesture), GDK_TOUCHPAD_GESTURE_PHASE_UPDATE, TRUE, scale);
 }
 
-static void _pinch_end(GtkGestureZoom *gesture, gpointer user_data)
+static void _pinch_end(GtkGestureZoom *gesture,
+                       GdkEventSequence *sequence,
+                       gpointer user_data)
 {
+  (void)sequence;
   (void)user_data;
   dt_gui_pinch_ctx_t *ctx = g_object_get_data(G_OBJECT(gesture), "dt-gui-pinch-ctx");
   if(!ctx || !ctx->active)

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -5278,7 +5278,7 @@ static void _second_window_pinch(GtkGesture *gesture,
     _second_window_touch_pinching = e->phase == GDK_TOUCHPAD_GESTURE_PHASE_BEGIN
                                     || e->phase == GDK_TOUCHPAD_GESTURE_PHASE_UPDATE;
 
-  if(dev->gui_leaving)
+  if(!dev || dev->gui_leaving)
     return;
 
   // Use pinned viewport if pinned, otherwise main dev's preview2
@@ -5341,7 +5341,7 @@ static void _second_window_button_pressed_callback(GtkGestureSingle *gesture,
                                                      gdouble y,
                                                      dt_develop_t *dev)
 {
-  if(dev->gui_leaving) return;
+  if(!dev || dev->gui_leaving) return;
 
   // Use pinned viewport if pinned, otherwise main dev's preview2
   dt_develop_t *pinned_dev = dev->preview2_pinned ? dev->preview2_pinned_dev : NULL;
@@ -5379,16 +5379,18 @@ static void _second_window_button_released_callback(GtkGestureSingle *gesture,
                                                       gdouble y,
                                                       dt_develop_t *dev)
 {
-  if(gtk_gesture_single_get_current_button(gesture) == GDK_BUTTON_PRIMARY) _dt_second_window_change_cursor(dev, "default");
+  if(dev && gtk_gesture_single_get_current_button(gesture) == GDK_BUTTON_PRIMARY)
+    _dt_second_window_change_cursor(dev, "default");
 
   GtkWidget *w = dt_gui_get_widget(gesture);
   gtk_widget_queue_draw(w);
 }
 
 static void _second_window_pan(dt_develop_t *dev,
-                               const gdouble x,
-                               const gdouble y)
+                                const gdouble x,
+                                const gdouble y)
 {
+  if(!dev) return;
   dt_control_t *ctl = darktable.control;
 
   // Use pinned viewport if pinned, otherwise main dev's preview2
@@ -5409,7 +5411,7 @@ static void _second_window_mouse_moved_callback(GtkEventControllerMotion *contro
                                                   gdouble y,
                                                   dt_develop_t *dev)
 {
-  if(dev->gui_leaving) return;
+  if(!dev || dev->gui_leaving) return;
 
   const GdkModifierType state =
     dt_gui_get_current_event_state(GTK_EVENT_CONTROLLER(controller));
@@ -5427,7 +5429,7 @@ static void _second_window_touch_moved(GtkGesture *gesture,
 {
   (void)gesture;
   dt_develop_t *dev = user_data;
-  if(dev->gui_leaving || _second_window_touch_pinching)
+  if(!dev || dev->gui_leaving || _second_window_touch_pinching)
     return;
   _second_window_pan(dev, x, y);
 }
@@ -5435,7 +5437,7 @@ static void _second_window_touch_moved(GtkGesture *gesture,
 static void _second_window_leave_callback(GtkEventControllerMotion *controller,
                                             dt_develop_t *dev)
 {
-  _second_window_leave(dev);
+  if(dev) _second_window_leave(dev);
 }
 
 static gboolean _second_window_configure_callback(GtkWidget *da,


### PR DESCRIPTION
## Summary

Fixes a crash that occurs when pinning an image in the second darkroom window and navigating images in the main view, and hardens viewport dimension calculations against division-by-zero during image transitions.

## Problem & Root Cause

1. **GtkGesture Signal Signature Mismatch**:
   In GTK 3, the `GtkGesture::begin` and `GtkGesture::end` signals pass three arguments:
   `(GtkGesture *gesture, GdkEventSequence *sequence, gpointer user_data)`.
   The callback handlers omitted the `sequence` parameter (`(GtkGestureZoom *gesture, gpointer user_data)`). For touchpad gestures, GTK emits a `NULL` sequence; on ARM64, this placed `0x0` into the second argument register (`x1`), causing the callback to receive `dev = NULL`. Accessing `dev->preview2_pinned` (at offset `0xba0` in `dt_develop_t`) caused an immediate null pointer dereference.
2. **Intermediate Loading State Divisor Checks**:
   During image switches while second window callbacks are active, `dt_dev_get_processed_size` could return 0 for width/height before pipeline nodes are ready. Calling functions (`dt_dev_get_zoom_scale`, `_dev_zoom_move`, `dt_dev_get_pointer_zoom_pos`) did not guard against `procw <= 0` or `proch <= 0`, leading to potential division by zero / `inf` / `NaN`.
3. **Viewport Fallback**:
   `dt_dev_get_processed_size` always fell back to `darktable.develop->preview_pipe` instead of checking `port->dev->preview_pipe` when dealing with a pinned develop instance.

## Changes

- **`src/gui/gtk.c`**:
  - Corrected `_pinch_begin` and `_pinch_end` callback signatures to include `GdkEventSequence *sequence`.
- **`src/views/darkroom.c`**:
  - Added `!dev` checks across all second-window event callbacks (`_second_window_pinch`, button pressed/released, pan, mouse moved, touch moved, leave).
- **`src/develop/develop.c`**:
  - Updated `dt_dev_get_processed_size` fallback to respect `port->dev` when available.
  - Guarded against `procw <= 0`, `proch <= 0`, and `scale <= 0.0f` in `dt_dev_get_zoom_scale`, `_dev_zoom_move`, and `dt_dev_get_pointer_zoom_pos` / `dt_dev_get_pointer_zoom_pos_from_bounds`.

## Verification seqeuence

- Open second darkroom window and toggle the pin button on an image.
- Advance images in the main darkroom view (e.g. with `Space` / `Backspace`).
- Zoom and pan in both the main view and the pinned second window using touchpad pinch, wheel scroll, and drag.
- Unpin and verify normal second window synchronization.

## Crash report

[crash_report.txt](https://github.com/user-attachments/files/31649418/crash_report.txt)

Co-authored with Gemini.