### PR TITLE
OpenCL fast tiling fix plus maintenance

### DIFF
--- a/data/kernels/atrous.cl
+++ b/data/kernels/atrous.cl
@@ -45,7 +45,7 @@ eaw_decompose(__read_only image2d_t in,
 
   const int mult = 1<<scale;
 
-  const float4 pixel = read_imagef(in, sampleri, (int2)(x, y));
+  const float4 pixel = readpixel(in, x, y);
   float4 sum = (float4)(0.0f);
   float4 wgt = (float4)(0.0f);
   for(int j=0;j<5;j++) for(int i=0;i<5;i++)
@@ -79,8 +79,8 @@ eaw_synthesize(__write_only image2d_t out,
 
   if(x >= width || y >= height) return;
 
-  const float4 c = read_imagef(coarse, sampleri, (int2)(x, y));
-  const float4 d = read_imagef(detail, sampleri, (int2)(x, y));
+  const float4 c = readpixel(coarse, x, y);
+  const float4 d = readpixel(detail, x, y);
   const float4 amount = copysign(fmax((float4)(0.0f), fabs(d) - threshold), d);
   float4 sum = c + boost*amount;
   sum.w = c.w;
@@ -98,7 +98,7 @@ eaw_addbuffers(__write_only image2d_t out_out,
   const int y = get_global_id(1);
   if(x >= width || y >= height) return;
 
-  const float4 cs = read_imagef(diff, sampleri, (int2)(x, y));
-  const float4 o = read_imagef(out_in, sampleri, (int2)(x, y));
+  const float4 cs = readpixel(diff, x, y);
+  const float4 o = readpixel(out_in, x, y);
   write_imagef(out_out, (int2)(x, y), (cs + o));  
 }

--- a/data/kernels/basic.cl
+++ b/data/kernels/basic.cl
@@ -232,7 +232,7 @@ whitebalance_4f(read_only image2d_t in, write_only image2d_t out, const int widt
   const int x = get_global_id(0);
   const int y = get_global_id(1);
   if(x >= width || y >= height) return;
-  float4 pixel = readpixel(in, x, y);
+  float4 pixel = Areadpixel(in, x, y);
   write_imagef (out, (int2)(x, y), (float4)(pixel.x * coeffs[0], pixel.y * coeffs[1], pixel.z * coeffs[2], pixel.w));
 }
 
@@ -244,7 +244,7 @@ exposure (read_only image2d_t in, write_only image2d_t out, const int width, con
   const int y = get_global_id(1);
 
   if(x >= width || y >= height) return;
-  float4 pixel = readpixel(in, x, y);
+  float4 pixel = Areadpixel(in, x, y);
   pixel.xyz = ((pixel - black ) * scale).xyz;
   write_imagef (out, (int2)(x, y), pixel);
 }
@@ -260,7 +260,7 @@ highlights_4f_clip (read_only image2d_t in, write_only image2d_t out, const int 
 
   // 4f/pixel means that this has been debayered already.
   // it's thus hopeless to recover highlights here (this code path is just used for preview and non-raw images)
-  float4 pixel = readpixel(in, x, y);
+  float4 pixel = Areadpixel(in, x, y);
   // default: // 0, DT_IOP_HIGHLIGHTS_CLIP
   pixel.x = fmin(clip, pixel.x);
   pixel.y = fmin(clip, pixel.y);
@@ -287,7 +287,7 @@ highlights_1f_clip (read_only image2d_t in, write_only image2d_t out,
   if((icol >= 0) && (irow >= 0) && (irow < iheight) && (icol < iwidth))
   {
     const int color = fcol(irow, icol, filters, xtrans);
-    pixel = readsingle(in, icol, irow);
+    pixel = Areadsingle(in, icol, irow);
     pixel = fmin(clips[color], pixel);
   }
   write_imagef(out, (int2)(x, y), pixel);
@@ -317,7 +317,7 @@ kernel void highlights_false_color(read_only image2d_t in,
 
   if((irow >= 0) && (icol >= 0) && (icol < iwidth) && (irow < iheight))
   {
-    const float ival = readsingle(in, icol, irow);
+    const float ival = Areadsingle(in, icol, irow);
     const int c = fcol(irow, icol, filters, xtrans);
     oval = (ival < clips[c]) ? 0.2f * ival : 1.0f;
   }
@@ -340,7 +340,7 @@ static float _calc_refavg(read_only image2d_t in,
   {
     for(int dx = max(0, col - 1); dx < min(maxcol - 1, col + 2); dx++)
     {
-      const float val = fmax(0.0f, readsingle(in, dx, dy));
+      const float val = fmax(0.0f, Areadsingle(in, dx, dy));
       const int c = fcol(dy, dx, filters, xtrans);
       mean[c] += val;
       cnt[c] += 1.0f;
@@ -451,7 +451,7 @@ kernel void highlights_chroma(read_only image2d_t in,
   {
     const int idx = mad24(row, width, col);
     const int color = fcol(row, col, filters, xtrans);
-    const float inval = readsingle(in, col, row);
+    const float inval = Areadsingle(in, col, row);
     const int px = color * msize + mad24(row/3, mwidth, col/3);
     if(mask[px] && (inval > 0.2f*clips[color]) && (inval < clips[color]))
     {
@@ -495,7 +495,7 @@ kernel void highlights_opposed(read_only image2d_t in,
 
   if((icol >= 0) && (icol < iwidth) && (irow >= 0) && (irow < iheight))
   {
-    val = readsingle(in, icol, irow);
+    val = Areadsingle(in, icol, irow);
 
     if(!fastcopymode)
     {
@@ -1992,7 +1992,7 @@ float compute_upsampling_taps(const int itor_mode,
     return maketaps_bilinear(taps, 2*itor_width, (float)itor_width, t, -1.0f);
 }
 
-static inline float get_image_channel(read_only image2d_t in,
+static inline float _get_image_channel(read_only image2d_t in,
                                       const int x,
                                       const int y,
                                       const int c)
@@ -2043,7 +2043,7 @@ float interpolation_compute_single(read_only image2d_t in,
       float h = 0.0f;
       for(int j = 0; j < 2 * itor_width; j++)
       {
-        h += kernelh[j] * get_image_channel(in, clip_mirror(ix+j, width-1), clip_mirror(iy+i, height-1), channel);
+        h += kernelh[j] * _get_image_channel(in, clip_mirror(ix+j, width-1), clip_mirror(iy+i, height-1), channel);
       }
       s += kernelv[i] * h;
     }
@@ -3363,7 +3363,7 @@ rawoverexposed_mark_cfa (read_only image2d_t in,
   const int c = fcol(raw_y, raw_x, filters, xtrans);
   if(raw_pixel < threshold[c]) return;
 
-  float4 pixel = fmax(0.0f, read_imagef(in, sampleri, (int2)(x, y)));
+  float4 pixel = fmax(0.0f, Areadpixel(in, x, y));
   const float4 color = colors[c & 3];
 
   // cfa color
@@ -3403,7 +3403,7 @@ rawoverexposed_mark_solid (read_only image2d_t in,
   const int c = fcol(raw_y, raw_x, filters, xtrans);
   if(raw_pixel < threshold[c]) return;
 
-  float4 pixel = fmax(0.0f, read_imagef(in, sampleri, (int2)(x, y)));
+  float4 pixel = fmax(0.0f, Areadpixel(in, x, y));
 
   // solid color
   pixel.xyz = solid_color.xyz;
@@ -3442,7 +3442,7 @@ rawoverexposed_falsecolor (read_only image2d_t in,
   const int c = fcol(raw_y, raw_x, filters, xtrans);
   if(raw_pixel < threshold[c]) return;
 
-  float4 pixel = fmax(0.0f, read_imagef(in, sampleri, (int2)(x, y)));
+  float4 pixel = fmax(0.0f, Areadpixel(in, x, y));
   if(c == 2)      pixel.z = 0.0f;
   else if(c == 1) pixel.y = 0.0f;
   else if(c == 0) pixel.x = 0.0f;

--- a/data/kernels/blendop.cl
+++ b/data/kernels/blendop.cl
@@ -434,8 +434,8 @@ blendop_mask_Lab(__read_only image2d_t in_a, __read_only image2d_t in_b, __read_
   if(x >= width || y >= height) return;
 
   float4 a = readpixel(in_a, x+offs.x, y+offs.y); // see comment in blend.c:dt_develop_blend_process_cl()
-  float4 b = readpixel(in_b, x, y);
-  float form = readsingle(mask_in, x, y);
+  float4 b = Areadpixel(in_b, x, y);
+  float form = Areadsingle(mask_in, x, y);
 
   float conditional = blendif_factor_Lab(a, b, blendif, blendif_parameters, mask_mode, mask_combine);
 
@@ -454,7 +454,7 @@ blendop_mask_RAW(__read_only image2d_t in_a, __read_only image2d_t in_b, __read_
   const int y = get_global_id(1);
 
   if(x >= width || y >= height) return;
-  float form = readsingle(mask_in, x, y);
+  float form = Areadsingle(mask_in, x, y);
 
   float opacity = (mask_combine & DEVELOP_COMBINE_INV) ? 1.0f - form : form;
 
@@ -472,8 +472,8 @@ blendop_mask_rgb_hsl(__read_only image2d_t in_a, __read_only image2d_t in_b, __r
   if(x >= width || y >= height) return;
 
   float4 a = readpixel(in_a, x+offs.x, y+offs.y); // see comment in blend.c:dt_develop_blend_process_cl()
-  float4 b = readpixel(in_b, x, y);
-  float form = readsingle(mask_in, x, y);
+  float4 b = Areadpixel(in_b, x, y);
+  float form = Areadsingle(mask_in, x, y);
 
   const unsigned int invert_mask = (blendif >> 16) ^ (mask_combine & DEVELOP_COMBINE_INCL ? 0 : DEVELOP_BLENDIF_RGB_MASK);
 
@@ -496,8 +496,8 @@ blendop_mask_rgb_jzczhz(__read_only image2d_t in_a, __read_only image2d_t in_b, 
   if(x >= width || y >= height || use_work_profile == 0) return;
 
   float4 a = readpixel(in_a, x+offs.x, y+offs.y); // see comment in blend.c:dt_develop_blend_process_cl()
-  float4 b = readpixel(in_b, x, y);
-  float form = readsingle(mask_in, x, y);
+  float4 b = Areadpixel(in_b, x, y);
+  float form = Areadsingle(mask_in, x, y);
 
   const unsigned int invert_mask = (blendif >> 16) ^ (mask_combine & DEVELOP_COMBINE_INCL ? 0 : DEVELOP_BLENDIF_RGB_MASK);
 
@@ -526,14 +526,14 @@ blendop_Lab(__read_only image2d_t in_a, __read_only image2d_t in_b, __read_only 
   if((blend_mode & DEVELOP_BLEND_REVERSE) == DEVELOP_BLEND_REVERSE)
   {
     b = readpixel(in_a, x+offs.x, y+offs.y);
-    a = readpixel(in_b, x, y);
+    a = Areadpixel(in_b, x, y);
   }
   else
   {
     a = readpixel(in_a, x+offs.x, y+offs.y);
-    b = readpixel(in_b, x, y);
+    b = Areadpixel(in_b, x, y);
   }
-  float opacity = readsingle(mask, x, y);
+  float opacity = Areadsingle(mask, x, y);
 
   /* scale L down to [0; 1] and a,b to [-1; 1] */
   const float4 scale = (float4)(100.0f, 128.0f, 128.0f, 1.0f);
@@ -813,14 +813,14 @@ blendop_RAW(__read_only image2d_t in_a, __read_only image2d_t in_b, __read_only 
   if((blend_mode & DEVELOP_BLEND_REVERSE) == DEVELOP_BLEND_REVERSE)
   {
     b = readsingle(in_a, x+offs.x, y+offs.y);
-    a = readsingle(in_b, x, y);
+    a = Areadsingle(in_b, x, y);
   }
   else
   {
     a = readsingle(in_a, x+offs.x, y+offs.y);
-    b = readsingle(in_b, x, y);
+    b = Areadsingle(in_b, x, y);
   }
-  float opacity = readsingle(mask, x, y);
+  float opacity = Areadsingle(mask, x, y);
 
   const float min = 0.0f;
   const float max = 1.0f;
@@ -959,15 +959,15 @@ blendop_RAW4(__read_only image2d_t in_a, __read_only image2d_t in_b, __read_only
   if((blend_mode & DEVELOP_BLEND_REVERSE) == DEVELOP_BLEND_REVERSE)
   {
     b = readpixel(in_a, x+offs.x, y+offs.y);
-    a = readpixel(in_b, x, y);
+    a = Areadpixel(in_b, x, y);
   }
   else
   {
     a = readpixel(in_a, x+offs.x, y+offs.y);
-    b = readpixel(in_b, x, y);
+    b = Areadpixel(in_b, x, y);
   }
 
-  float4 opacity = readsingle(mask, x, y);
+  float4 opacity = Areadsingle(mask, x, y);
 
   const float4 min = 0.0f;
   const float4 max = 1.0f;
@@ -1109,14 +1109,14 @@ blendop_rgb_hsl(__read_only image2d_t in_a, __read_only image2d_t in_b, __read_o
   if((blend_mode & DEVELOP_BLEND_REVERSE) == DEVELOP_BLEND_REVERSE)
   {
     b = readpixel(in_a, x+offs.x, y+offs.y);
-    a = readpixel(in_b, x, y);
+    a = Areadpixel(in_b, x, y);
   }
   else
   {
     a = readpixel(in_a, x+offs.x, y+offs.y);
-    b = readpixel(in_b, x, y);
+    b = Areadpixel(in_b, x, y);
   }
-  float opacity = readsingle(mask, x, y);
+  float opacity = Areadsingle(mask, x, y);
 
   const float4 min = (float4)(0.0f, 0.0f, 0.0f, 1.0f);
   const float4 max = (float4)(1.0f, 1.0f, 1.0f, 1.0f);
@@ -1321,14 +1321,14 @@ blendop_rgb_jzczhz(__read_only image2d_t in_a, __read_only image2d_t in_b, __rea
   if((blend_mode & DEVELOP_BLEND_REVERSE) == DEVELOP_BLEND_REVERSE)
   {
     b = readpixel(in_a, x+offs.x, y+offs.y);
-    a = readpixel(in_b, x, y);
+    a = Areadpixel(in_b, x, y);
   }
   else
   {
     a = readpixel(in_a, x+offs.x, y+offs.y);
-    b = readpixel(in_b, x, y);
+    b = Areadpixel(in_b, x, y);
   }
-  float opacity = readsingle(mask, x, y);
+  float opacity = Areadsingle(mask, x, y);
   float norm_a;
   float norm_b;
 
@@ -1437,7 +1437,7 @@ blendop_mask_tone_curve(__read_only image2d_t mask_in,
 
   if (x >= width || y >= height) return;
 
-  float opacity = readsingle(mask_in, x, y);
+  float opacity = Areadsingle(mask_in, x, y);
   float scaled_opacity = 2.f * opacity / gopacity - 1.f;
   if (1.f - brightness <= 0.f)
     scaled_opacity = opacity <= mask_epsilon ? -1.f : 1.f;
@@ -1486,8 +1486,8 @@ blendop_display_channel(__read_only image2d_t in_a, __read_only image2d_t in_b, 
   if(x >= width || y >= height) return;
 
   float4 a = readpixel(in_a, x+offs.x, y+offs.y); // see comment in blend.c:dt_develop_blend_process_cl()
-  float4 b = readpixel(in_b, x, y);
-  float opacity = readsingle(mask, x, y);
+  float4 b = Areadpixel(in_b, x, y);
+  float opacity = Areadsingle(mask, x, y);
 
   float c;
   float4 LCH;

--- a/data/kernels/colorequal.cl
+++ b/data/kernels/colorequal.cl
@@ -267,7 +267,7 @@ __kernel void sample_input(__read_only image2d_t dev_in,
 
   const int k = mad24(row, width, col);
 
-  const float4 pix_in = read_imagef(dev_in, samplerA, (int2)(col, row));
+  const float4 pix_in = Areadpixel(dev_in, col, row);
   // calc saturation from input data
   const float dmin = fmin(pix_in.x, fmin(pix_in.y, pix_in.z));
   const float dmax = fmax(pix_in.x, fmax(pix_in.y, pix_in.z));

--- a/data/kernels/colorharmonizer.cl
+++ b/data/kernels/colorharmonizer.cl
@@ -94,7 +94,7 @@ kernel void colorharmonizer_map(read_only  image2d_t  in,
   const int y = get_global_id(1);
   if(x >= width || y >= height) return;
 
-  const float4 pix_in = read_imagef(in, sampleri, (int2)(x, y));
+  const float4 pix_in = readpixel(in, x, y);
   float4 XYZ_D65 = matrix_product_float4(fmax(0.0f, pix_in), matrix_in);
   float4 xyY = dt_D65_XYZ_to_xyY(XYZ_D65);
   float4 JCH = xyY_to_dt_UCS_JCH(xyY, L_white);

--- a/data/kernels/demosaic_markesteijn.cl
+++ b/data/kernels/demosaic_markesteijn.cl
@@ -50,7 +50,7 @@ markesteijn_initial_copy(read_only image2d_t in, global float *rgb, const int wi
 
   const int f = FCxtrans(y, x, xtrans);
 
-  const float p = fmax(0.0f, readsingle(in, x, y));
+  const float p = fmax(0.0f, Areadsingle(in, x, y));
 
   for(int c = 0; c < 3; c++)
     pix[c] = (c == f) ? p : 0.0f;
@@ -883,7 +883,7 @@ markesteijn_accu(read_only image2d_t in, write_only image2d_t out, global float 
 
   const int glidx = mad24(y, width, x);
 
-  float4 pixel = readpixel(in, x, y);
+  float4 pixel = Areadpixel(in, x, y);
   float4 add = vload4(glidx, rgb);
   add.w = 1.0f;
 
@@ -904,7 +904,7 @@ markesteijn_final(read_only image2d_t in, write_only image2d_t out, const int wi
   // take sufficient border into account
   if(x < border || x >= width-border || y < border || y >= height-border) return;
 
-  float4 pixel = readpixel(in, x, y);
+  float4 pixel = Areadpixel(in, x, y);
 
   pixel = (pixel.w > 0.0f) ? pixel/pixel.w : (float4)0.0f;
   pixel.w = 0.0f;

--- a/data/kernels/demosaic_other.cl
+++ b/data/kernels/demosaic_other.cl
@@ -29,7 +29,7 @@ passthrough_monochrome (__read_only image2d_t in, __write_only image2d_t out, co
 
   if(x >= width || y >= height) return;
 
-  const float pc = readsingle(in, x, y);
+  const float pc = Areadsingle(in, x, y);
   write_imagef(out, (int2)(x, y), (float4)pc);
 }
 
@@ -46,7 +46,7 @@ passthrough_color(__read_only image2d_t in,
 
   if(x >= width || y >= height) return;
 
-  const float ival = readsingle(in, x, y);
+  const float ival = Areadsingle(in, x, y);
   const int c = fcol(y, x, filters, xtrans);
 
   float4 oval = (float4)(0.0f, 0.0f, 0.0f, 0.0f);

--- a/data/kernels/extended.cl
+++ b/data/kernels/extended.cl
@@ -37,7 +37,7 @@ graduatedndp (read_only image2d_t in,
 
   if(x >= width || y >= height) return;
 
-  float4 pixel = readpixel(in, x, y);
+  float4 pixel = Areadpixel(in, x, y);
 
   float len = length_base + y*length_inc_y + x*length_inc_x;
   float dens = dtcl_exp2(density * clipf(0.5f + len));
@@ -62,7 +62,7 @@ graduatedndm (read_only image2d_t in,
 
   if(x >= width || y >= height) return;
 
-  float4 pixel = readpixel(in, x, y);
+  float4 pixel = Areadpixel(in, x, y);
 
   float len = length_base + y*length_inc_y + x*length_inc_x;
   float dens = dtcl_exp2(-density * clipf(0.5f - len));
@@ -79,7 +79,7 @@ colorize (read_only image2d_t in, write_only image2d_t out, const int width, con
 
   if(x >= width || y >= height) return;
 
-  float4 pixel = read_imagef(in, sampleri, (int2)(x, y));
+  float4 pixel = Areadpixel(in, x, y);
 
   pixel.x = pixel.x * mix + L - 50.0f * mix;
   pixel.y = a;
@@ -107,7 +107,7 @@ relight (read_only image2d_t in, write_only image2d_t out, const int width, cons
 
   if(x >= width || y >= height) return;
 
-  float4 pixel = read_imagef(in, sampleri, (int2)(x, y));
+  float4 pixel = Areadpixel(in, x, y);
 
   const float lightness = pixel.x/100.0f;
   const float value = -1.0f+(lightness*2.0f);
@@ -146,7 +146,7 @@ channelmixer (read_only image2d_t in, write_only image2d_t out, const int width,
 
   if(x >= width || y >= height) return;
 
-  float4 pixel = read_imagef(in, sampleri, (int2)(x, y));
+  float4 pixel = Areadpixel(in, x, y);
   float4 opixel = (float4)(0.0f, 0.0f, 0.0f, pixel.w);
   float gray, hmix, smix, lmix;
 
@@ -214,7 +214,7 @@ velvia (read_only image2d_t in, write_only image2d_t out, const int width, const
 
   if(x >= width || y >= height) return;
 
-  float4 pixel = read_imagef(in, sampleri, (int2)(x, y));
+  float4 pixel = Areadpixel(in, x, y);
 
   // calculate vibrance, and apply boost velvia saturation at least saturated pixels
   const float pmax = fmax(pixel.x, fmax(pixel.y, pixel.z));     // max value in RGB set
@@ -245,7 +245,7 @@ colorcontrast (read_only image2d_t in, write_only image2d_t out, const int width
 
   if(x >= width || y >= height) return;
 
-  float4 pixel = read_imagef(in, sampleri, (int2)(x, y));
+  float4 pixel = Areadpixel(in, x, y);
 
   pixel.xyz = (pixel * scale + offset).xyz;
   pixel.y = unbound ? pixel.y : clamp(pixel.y, -128.0f, 128.0f);
@@ -263,7 +263,7 @@ vibrance (read_only image2d_t in, write_only image2d_t out, const int width, con
 
   if(x >= width || y >= height) return;
 
-  float4 pixel = readpixel(in, x, y);
+  float4 pixel = Areadpixel(in, x, y);
 
   const float sw = dt_fast_hypot(pixel.y, pixel.z)/256.0f;
   const float ls = 1.0f - amount * sw * 0.25f;
@@ -320,7 +320,7 @@ vignette (read_only image2d_t in, write_only image2d_t out, const int width, con
 
   const float2 pv = fabs((float2)(x,y) * scale - roi_center_scaled);
 
-  const float cplen = pow(pow(pv.x, expt.x) + pow(pv.y, expt.x), expt.y);
+  const float cplen = dtcl_pow(dtcl_pow(pv.x, expt.x) + dtcl_pow(pv.y, expt.x), expt.y);
 
   float weight = 0.0f;
   float dith = 0.0f;
@@ -331,10 +331,10 @@ vignette (read_only image2d_t in, write_only image2d_t out, const int width, con
 
     dith = (weight <= 1.0f && weight >= 0.0f) ? dither * tpdf(tea_state[0]) : 0.0f;
 
-    weight = weight >= 1.0f ? 1.0f : (weight <= 0.0f ? 0.0f : 0.5f - cos(M_PI_F * weight) / 2.0f);
+    weight = weight >= 1.0f ? 1.0f : (weight <= 0.0f ? 0.0f : 0.5f - dtcl_cos(M_PI_F * weight) / 2.0f);
   }
 
-  float4 pixel = read_imagef(in, sampleri, (int2)(x, y));
+  float4 pixel = readpixel(in, x, y);
 
   if(weight > 0.0f)
   {
@@ -367,7 +367,7 @@ splittoning (read_only image2d_t in, write_only image2d_t out, const int width, 
 
   if(x >= width || y >= height) return;
 
-  float4 pixel = read_imagef(in, sampleri, (int2)(x, y));
+  float4 pixel = Areadpixel(in, x, y);
 
   float4 hsl = RGB_2_HSL(pixel);
 
@@ -472,7 +472,7 @@ global_tonemap_reinhard (read_only image2d_t in, write_only image2d_t out, const
 
   if(x >= width || y >= height) return;
 
-  float4 pixel = read_imagef(in, sampleri, (int2)(x, y));
+  float4 pixel = Areadpixel(in, x, y);
 
   const float l = pixel.x * 0.01f;
 
@@ -498,11 +498,11 @@ global_tonemap_drago (read_only image2d_t in, write_only image2d_t out, const in
   const float bl = parameters.z;
   const float lwmax = parameters.w;
 
-  float4 pixel = read_imagef(in, sampleri, (int2)(x, y));
+  float4 pixel = Areadpixel(in, x, y);
 
   const float lw = pixel.x * 0.01f;
 
-  pixel.x = 100.0f * (ldc * log(fmax(eps, lw + 1.0f)) / log(fmax(eps, 2.0f + (pow(lw/lwmax,bl)) * 8.0f)));
+  pixel.x = 100.0f * (ldc * dtcl_log(fmax(eps, lw + 1.0f)) / dtcl_log(fmax(eps, 2.0f + (dtcl_pow(lw/lwmax,bl)) * 8.0f)));
 
   write_imagef (out, (int2)(x, y), pixel);
 }
@@ -518,7 +518,7 @@ global_tonemap_filmic (read_only image2d_t in, write_only image2d_t out, const i
 
   if(x >= width || y >= height) return;
 
-  float4 pixel = read_imagef(in, sampleri, (int2)(x, y));
+  float4 pixel = Areadpixel(in, x, y);
 
   const float l = pixel.x * 0.01f;
   const float m = fmax(0.0f, l - 0.004f);
@@ -576,8 +576,8 @@ colormapping_mapping (read_only image2d_t in, read_only image2d_t tmp, write_onl
 
   if(x >= width || y >= height) return;
 
-  float4 ipixel = read_imagef(in, sampleri, (int2)(x, y));
-  const float dL = read_imagef(tmp, sampleri, (int2)(x, y)).x;
+  float4 ipixel = Areadpixel(in, x, y);
+  const float dL = readpixel(tmp, x, y).x;
   float weight[MAXN];
   float4 opixel = (float4)0.0f;
 
@@ -610,7 +610,7 @@ colorbalance (read_only image2d_t in, write_only image2d_t out, const int width,
 
   if(x >= width || y >= height) return;
 
-  float4 Lab = read_imagef(in, sampleri, (int2)(x, y));
+  float4 Lab = Areadpixel(in, x, y);
   float4 sRGB = XYZ_to_sRGB(Lab_to_XYZ(Lab));
 
   // Lift gamma gain
@@ -631,7 +631,7 @@ colorbalance_lgg (read_only image2d_t in, write_only image2d_t out, const int wi
 
   if(x >= width || y >= height) return;
 
-  float4 Lab = read_imagef(in, sampleri, (int2)(x, y));
+  float4 Lab = Areadpixel(in, x, y);
   const float4 XYZ = Lab_to_XYZ(Lab);
   float4 RGB = XYZ_to_prophotorgb(XYZ);
 
@@ -661,7 +661,7 @@ colorbalance_lgg (read_only image2d_t in, write_only image2d_t out, const int wi
   {
     const float4 contrast4 = contrast;
     const float4 grey4 = grey;
-    RGB = (RGB <= (float4)0.0f) ? (float4)0.0f : pow(RGB / grey4, contrast4) * grey4;
+    RGB = (RGB <= (float4)0.0f) ? (float4)0.0f : dtcl_pow(RGB / grey4, contrast4) * grey4;
   }
 
   Lab.xyz = prophotorgb_to_Lab(RGB).xyz;
@@ -678,7 +678,7 @@ colorbalance_cdl (read_only image2d_t in, write_only image2d_t out, const int wi
 
   if(x >= width || y >= height) return;
 
-  float4 Lab = read_imagef(in, sampleri, (int2)(x, y));
+  float4 Lab = Areadpixel(in, x, y);
   const float4 XYZ = Lab_to_XYZ(Lab);
   float4 RGB = XYZ_to_prophotorgb(XYZ);
 
@@ -715,13 +715,6 @@ colorbalance_cdl (read_only image2d_t in, write_only image2d_t out, const int wi
   write_imagef (out, (int2)(x, y), Lab);
 }
 
-
-static inline float sqf(const float x)
-{
-  return x * x;
-}
-
-
 static inline float4 opacity_masks(const float x,
                                    const float shadows_weight, const float highlights_weight,
                                    const float midtones_weight, const float mask_grey_fulcrum)
@@ -731,7 +724,7 @@ static inline float4 opacity_masks(const float x,
   const float x_offset_norm = x_offset / mask_grey_fulcrum;
   const float alpha = 1.f / (1.f + dtcl_exp(x_offset_norm * shadows_weight));    // opacity of shadows
   const float beta = 1.f / (1.f + dtcl_exp(-x_offset_norm * highlights_weight)); // opacity of highlights
-  const float gamma = dtcl_exp(-sqf(x_offset) * midtones_weight / 4.f) * sqf(1.f - alpha) * sqf(1.f - beta) * 8.f; // opacity of midtones
+  const float gamma = dtcl_exp(-fsquare(x_offset) * midtones_weight / 4.f) * fsquare(1.f - alpha) * fsquare(1.f - beta) * 8.f; // opacity of midtones
 
   output.x = alpha;
   output.y = gamma;
@@ -954,7 +947,7 @@ colorbalancergb (read_only image2d_t in, write_only image2d_t out,
     a = soft_clip(a, 0.5f * max_a, max_a);
 
     const float P_prime = (a - 1.f) * P;
-    const float W_prime = dtcl_sqrt(sqf(P) * (1.f - sqf(a)) + sqf(W)) * b;
+    const float W_prime = dtcl_sqrt(fsquare(P) * (1.f - fsquare(a)) + fsquare(W)) * b;
 
     HCB.y = fmax(M_rot_inv[0][0] * P_prime + M_rot_inv[0][1] * W_prime, 0.f);
     HCB.z = fmax(M_rot_inv[1][0] * P_prime + M_rot_inv[1][1] * W_prime, 0.f);
@@ -1053,7 +1046,7 @@ colorchecker (read_only image2d_t in, write_only image2d_t out, const int width,
   global float4 *coeff_Lab = params + num_patches;
   global float4 *poly_Lab = params + 2 * num_patches;
 
-  float4 ipixel = read_imagef(in, sampleri, (int2)(x, y));
+  float4 ipixel = readpixel(in, x, y);
 
   const float w = ipixel.w;
 
@@ -1081,7 +1074,7 @@ primaries(read_only image2d_t in,
   const int y = get_global_id(1);
   if(x >= width || y >= height) return;
 
-  const float4 ipixel = read_imagef(in, sampleri, (int2)(x, y));
+  const float4 ipixel = Areadpixel(in, x, y);
   float4 opixel = matrix_product_float4(ipixel, matrix);
   opixel.w = ipixel.w;
   write_imagef(out, (int2)(x, y), opixel);

--- a/data/kernels/highpass.cl
+++ b/data/kernels/highpass.cl
@@ -29,7 +29,7 @@ highpass_invert(read_only image2d_t in, write_only image2d_t out, const int widt
 
   if(x >= width || y >= height) return;
 
-  float4 pixel = read_imagef(in, sampleri, (int2)(x, y));
+  float4 pixel = Areadpixel(in, x, y);
   pixel.x = clamp(100.0f - pixel.x, 0.0f, 100.0f);
   write_imagef (out, (int2)(x, y), pixel);
 }
@@ -43,10 +43,9 @@ highpass_hblur(read_only image2d_t in, write_only image2d_t out, global float *m
   const int lsz = get_local_size(0);
   const int x = get_global_id(0);
   const int y = get_global_id(1);
-  float4 pixel = (float4)0.0f;
 
   /* read pixel and fill center part of buffer */
-  pixel = read_imagef(in, sampleri, (int2)(x, y));
+  float4 pixel = readpixel(in, x, y);
   buffer[rad + lid] = pixel.x;
 
   /* left wing of buffer */
@@ -95,10 +94,9 @@ highpass_vblur(read_only image2d_t in, write_only image2d_t out, global float *m
   const int lsz = get_local_size(1);
   const int x = get_global_id(0);
   const int y = get_global_id(1);
-  float4 pixel = (float4)0.0f;
 
   /* read pixel and fill center part of buffer */
-  pixel = read_imagef(in, sampleri, (int2)(x, y));
+  float4 pixel = readpixel(in, x, y);
   buffer[rad + lid] = pixel.x;
 
   /* left wing of buffer */
@@ -149,8 +147,8 @@ highpass_mix(read_only image2d_t in_a, read_only image2d_t in_b, write_only imag
   if(x >= width || y >= height) return;
 
   float4 o = 0.0f;
-  float4 a = read_imagef(in_a, sampleri, (int2)(x, y));
-  float4 b = read_imagef(in_b, sampleri, (int2)(x, y));
+  float4 a = readpixel(in_a, x, y);
+  float4 b = readpixel(in_b, x, y);
   float4 min = (float4)(0.0f, -128.0f, -128.0f, -INFINITY);
   float4 max = (float4)(100.0f, 128.0f, 128.0f, INFINITY);
 

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -3763,12 +3763,13 @@ dt_opencl_tilemode_t dt_opencl_image_fits_device(const int devid,
 
   // how much is available for each fast tile
   const int64_t tilemem = avail - overhead - iplane - oplane;
-  const int64_t perline = sizeof(float) * 4 * width * factor;
+  const int64_t perline = (ibpp + obpp) * width * factor;
   const int64_t tlines = tilemem / perline;
+  const int64_t vlines = tlines - 2*overlap;
 
   dt_print(DT_DEBUG_TILING | DT_DEBUG_VERBOSE,
-    "test cl tiling: dim=%dx%d, avail=%dMB overhead=%zuMB factor=%.3f tmem=%dMB perline=%dkB tlines=%d",
-    width, height, (int)(avail/DT_MEGA), overhead, factor, (int)(tilemem/DT_MEGA), (int)(perline/1024), (int)tlines);
+    "test cl tiling: dim=%dx%d, avail=%dMB overhead=%zuMB factor=%.3f tmem=%dMB perline=%dkB tlines=%d vlines=%d",
+    width, height, (int)(avail/DT_MEGA), overhead, factor, (int)(tilemem/DT_MEGA), (int)(perline/1024), (int)tlines, (int)vlines);
 
   // always tile as processed image is larger than what device or dt are providing
   if(miss_minimal || tilemem < DT_MEGA)
@@ -3779,7 +3780,7 @@ dt_opencl_tilemode_t dt_opencl_image_fits_device(const int devid,
     return cl->fast_tiling ? DT_OPENCL_FAST_TILING : DT_OPENCL_NO_TILING;
 
   // fast internal OpenCL tiling possible and with a good bet on performance?
-  const gboolean good_bet = (tlines - 2*overlap) > (tlines / 5);
+  const gboolean good_bet = vlines > (tlines / 5);
   return good_bet && !cl->no_fast_tiling ? DT_OPENCL_FAST_TILING : DT_OPENCL_TILING;
 }
 

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -2384,8 +2384,7 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
        image that replaces the original, so one extra full-size buffer is live while it
        happens. Reserve it in the untiled decision only: if the module has to tile, the
        conversion is done on the host instead and no device buffer is needed. */
-    const gboolean converting_cl =
-      input_cst_cl != module->input_colorspace(module, pipe, piece);
+    const gboolean converting_cl = input_cst_cl != module->input_colorspace(module, pipe, piece);
     const float untiled_factor_cl = tiling.factor_cl + (converting_cl ? 1.0f : 0.0f);
 
     const dt_opencl_tilemode_t fitter =

--- a/src/develop/tiling.c
+++ b/src/develop/tiling.c
@@ -1768,8 +1768,8 @@ int process_tiling_cl_fast(dt_dev_pixelpipe_iop_t *piece,
                            void *cl_in,
                            void *cl_out,
                            const dt_iop_roi_t *roi,
-                           const int in_bpp,
-                           const int bpp,
+                           const int ibpp,
+                           const int obpp,
                            const dt_develop_tiling_t *tiling)
 {
   dt_dev_pixelpipe_t *pipe = piece->pipe;
@@ -1777,13 +1777,13 @@ int process_tiling_cl_fast(dt_dev_pixelpipe_iop_t *piece,
   const int devid = pipe->devid;
   const int width = roi->width;
   const int height = roi->height;
-  const int aligner = MAX(tiling->align, dt_opencl_tiling_align(devid));
-  const int border = _align_up(tiling->overlap, aligner);
+  const int aligner = _align_up(tiling->align, dt_opencl_tiling_align(devid));
+  const int border = tiling->overlap;
   const int64_t overhead = tiling->overhead;
   const int64_t allmem = dt_opencl_get_device_available(devid);
-  const int64_t avail = allmem - (int64_t)(in_bpp + bpp)*width*height - overhead;
+  const int64_t avail = allmem - (int64_t)(ibpp + obpp)*width*height - overhead;
 
-  const int64_t per_line = sizeof(float) * 4 * width * tiling->factor;
+  const int64_t per_line = (ibpp + obpp) * width * tiling->factor;
   const int tile_height = MIN(_align_up((int)(avail / per_line), aligner), height);
   const int valid_rows = tile_height - 2*border;
   if(valid_rows < 1) // should never happen - just make sure, see dt_opencl_image_fits_device()
@@ -1796,8 +1796,8 @@ int process_tiling_cl_fast(dt_dev_pixelpipe_iop_t *piece,
     (int)(avail/DT_MEGA), num_tiles, valid_rows, border, (int)(per_line / 1024));
 
   cl_int err = CL_SUCCESS;
-  cl_mem t_in = dt_opencl_alloc_device(devid, width, tile_height, in_bpp);
-  cl_mem t_out = dt_opencl_alloc_device(devid, width, tile_height, bpp);
+  cl_mem t_in = dt_opencl_alloc_device(devid, width, tile_height, ibpp);
+  cl_mem t_out = dt_opencl_alloc_device(devid, width, tile_height, obpp);
   if(!t_in || !t_out)
   {
     err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
@@ -1879,8 +1879,8 @@ int process_tiling_cl_fast(dt_dev_pixelpipe_iop_t *piece,
                         void *cl_in,
                         void *cl_out,
                         const dt_iop_roi_t *roi,
-                        const int in_bpp,
-                        const int bpp,
+                        const int ibpp,
+                        const int obpp,
                         const dt_develop_tiling_t *tiling)
 {
   return DT_OPENCL_DEFAULT_ERROR;

--- a/src/iop/demosaicing/rcd.c
+++ b/src/iop/demosaicing/rcd.c
@@ -438,8 +438,8 @@ static cl_int process_rcd_cl(dt_iop_module_t *self,
     err = dt_opencl_local_buffer_opt(devid, gd->kernel_ppg_green, &locopt);
     if(err != CL_SUCCESS) goto error;
 
-    size_t sizes[2] = { ROUNDUP(width, locopt.sizex), ROUNDUP(height, locopt.sizey) };
-    size_t local[2] = { locopt.sizex, locopt.sizey };
+    const size_t sizes[2] = { ROUNDUP(width, locopt.sizex), ROUNDUP(height, locopt.sizey) };
+    const size_t local[2] = { locopt.sizex, locopt.sizey };
     err = dt_opencl_enqueue_kernel_2d_local_args(devid, gd->kernel_ppg_green, sizes, local,
         CLARG(dev_in), CLARG(dev_tmp), CLARG(width), CLARG(height), CLARG(filters),
         CLLOCAL(sizeof(float) * (locopt.sizex + 2*3) * (locopt.sizey + 2*3)), CLARGINT(32));
@@ -455,8 +455,8 @@ static cl_int process_rcd_cl(dt_iop_module_t *self,
     err = dt_opencl_local_buffer_opt(devid, gd->kernel_ppg_redblue, &locopt);
     if(err != CL_SUCCESS) goto error;
 
-    size_t sizes[2] = { ROUNDUP(width, locopt.sizex), ROUNDUP(height, locopt.sizey) };
-    size_t local[2] = { locopt.sizex, locopt.sizey };
+    const size_t sizes[2] = { ROUNDUP(width, locopt.sizex), ROUNDUP(height, locopt.sizey) };
+    const size_t local[2] = { locopt.sizex, locopt.sizey };
     err = dt_opencl_enqueue_kernel_2d_local_args(devid, gd->kernel_ppg_redblue, sizes, local,
       CLARG(dev_tmp), CLARG(dev_out), CLARG(width), CLARG(height), CLARG(filters),
       CLLOCAL(sizeof(float) * 4 * (locopt.sizex + 2) * (locopt.sizey + 2)), CLARGINT(16));
@@ -496,8 +496,8 @@ static cl_int process_rcd_cl(dt_iop_module_t *self,
   if(err != CL_SUCCESS) goto error;
 
   // Fused step1 code with locals.
-  size_t sizes[2] = { ROUNDUP(width, locopt.sizex), ROUNDUP(height, locopt.sizey) };
-  size_t local[2] = { locopt.sizex, locopt.sizey };
+  const size_t sizes[2] = { ROUNDUP(width, locopt.sizex), ROUNDUP(height, locopt.sizey) };
+  const size_t local[2] = { locopt.sizex, locopt.sizey };
   err = dt_opencl_enqueue_kernel_2d_local_args(devid, gd->kernel_rcd_step_1, sizes, local,
       CLARG(cfa), CLARG(VH_dir), CLARG(width), CLARG(height),
       CLLOCAL(sizeof(float) * (locopt.sizex + 8) * (locopt.sizey + 8)));

--- a/src/iop/demosaicing/vng.c
+++ b/src/iop/demosaicing/vng.c
@@ -490,8 +490,8 @@ static cl_int process_vng_cl(const dt_iop_module_t *self,
     err = dt_opencl_local_buffer_opt(devid, gd->kernel_vng_lin_interpolate, &locopt);
     if(err != CL_SUCCESS) goto finish;
 
-    size_t sizes[2] = { ROUNDUP(width, locopt.sizex), ROUNDUP(height, locopt.sizey) };
-    size_t local[2] = { locopt.sizex, locopt.sizey };
+    const size_t sizes[2] = { ROUNDUP(width, locopt.sizex), ROUNDUP(height, locopt.sizey) };
+    const size_t local[2] = { locopt.sizex, locopt.sizey };
     err = dt_opencl_enqueue_kernel_2d_local_args(devid, gd->kernel_vng_lin_interpolate, sizes, local,
         CLARG(dev_in), CLARG(tmp_out),
         CLARG(width), CLARG(height), CLARG(border),
@@ -513,8 +513,8 @@ static cl_int process_vng_cl(const dt_iop_module_t *self,
   err = dt_opencl_local_buffer_opt(devid, gd->kernel_vng_interpolate, &locopt);
   if(err != CL_SUCCESS) goto finish;
 
-  size_t sizes[2] = { ROUNDUP(width, locopt.sizex), ROUNDUP(height, locopt.sizey) };
-  size_t local[2] = { locopt.sizex, locopt.sizey };
+  const size_t sizes[2] = { ROUNDUP(width, locopt.sizex), ROUNDUP(height, locopt.sizey) };
+  const size_t local[2] = { locopt.sizex, locopt.sizey };
   err = dt_opencl_enqueue_kernel_2d_local_args(devid, gd->kernel_vng_interpolate, sizes, local,
         CLARG(dev_tmp), CLARG(dev_out),
         CLARG(width), CLARG(height), CLARG(filters4),

--- a/src/iop/demosaicing/xtrans.c
+++ b/src/iop/demosaicing/xtrans.c
@@ -1962,8 +1962,8 @@ static cl_int process_markesteijn_cl(const dt_iop_module_t *self,
 
     for(int d = 0; d < ndir; d++)
     {
-      size_t sizes[2] = { ROUNDUP(width, locopt_homo_sum.sizex), ROUNDUP(height, locopt_homo_sum.sizey) };
-      size_t local[2] = { locopt_homo_sum.sizex, locopt_homo_sum.sizey };
+      const size_t sizes[2] = { ROUNDUP(width, locopt_homo_sum.sizex), ROUNDUP(height, locopt_homo_sum.sizey) };
+      const size_t local[2] = { locopt_homo_sum.sizex, locopt_homo_sum.sizey };
       err = dt_opencl_enqueue_kernel_2d_local_args(devid, gd->kernel_markesteijn_homo_sum, sizes, local,
         CLARG(dev_homo[d]), CLARG(dev_homosum[d]),
         CLARG(width), CLARG(height), CLARG(pad_tile), CLLOCAL(sizeof(char) * (locopt_homo_sum.sizex + 2*2) * (locopt_homo_sum.sizey + 2*2)));

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -631,8 +631,8 @@ int process_cl(dt_iop_module_t *self,
     dev_xtrans = dt_opencl_copy_host_to_device_constant(devid, sizeof(piece->xtrans), piece->xtrans);
     if(dev_xtrans == NULL) goto finish;
 
-    size_t sizes[2] = { ROUNDUP(roi_in->width, blocksizex), ROUNDUP(roi_in->height, blocksizey) };
-    size_t local[2] = { blocksizex, blocksizey };
+    const size_t sizes[2] = { ROUNDUP(roi_in->width, blocksizex), ROUNDUP(roi_in->height, blocksizey) };
+    const size_t local[2] = { blocksizex, blocksizey };
     err = dt_opencl_enqueue_kernel_2d_local_args(devid, gd->kernel_highlights_1f_lch_xtrans, sizes, local,
       CLARG(dev_in), CLARG(dev_out),
       CLARG(roi_in->width), CLARG(roi_in->height),


### PR DESCRIPTION
1. The OpenCL fast tiling code had two bugs now fixed
     a) the per line requirements for tiling were calculated too small leading to larger tile sizes than allowed
     b) the aligning of tile sizes was wrong leading to bad overlaps (this could be seen in 0153 integration test having much larger CPU/GPU diffs)
2. Some maintenance and subtle perf improvements
  a) some constify
  b) more use of readpixel() variants - in some cases using the faster Aread.. variant
  c) more use of dtcl_xxx macros