### PR TITLE
Add protection against memory allocation failure in Color balance RGB

### DIFF
--- a/src/iop/colorbalancergb.c
+++ b/src/iop/colorbalancergb.c
@@ -1502,6 +1502,13 @@ static gboolean dt_iop_tonecurve_draw(GtkWidget *widget, cairo_t *crf, const dt_
   // draw y gradient as axis legend
   const int stride = cairo_format_stride_for_width(CAIRO_FORMAT_ARGB32, line_height);
   unsigned char *data = malloc(stride * graph_height);
+  if(!data)
+  {
+     cairo_destroy(cr);
+     cairo_surface_destroy(cst);
+     return TRUE;
+  }
+
   cairo_surface_t *surface = cairo_image_surface_create_for_data(data, CAIRO_FORMAT_ARGB32, (size_t)line_height, (size_t)graph_height, stride);
 
   const size_t checker_1 = DT_PIXEL_APPLY_DPI(6);


### PR DESCRIPTION
We have to check malloc result to prevent NULL-dereferencing and crash.

In this case, the graph in the mask tab remains undrawn. Although the graph is allocated a relatively large amount (not just a few hundred bytes like for some data structure), it is not many megabytes like for image buffers. Accordingly, the probability of not allocating memory of such a limited size is quite small and, in my opinion, it is enough to save the program from crashing, and adding text for dt_control_log probably does not make much practical sense.

For the same reason, this fix is ​​not important enough to be mentioned in the release notes.
