### PR TITLE
Respect no-tiling module also for fast cl tiling

### DIFF
--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -2391,17 +2391,16 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
       dt_opencl_image_fits_device(pipe->devid, roi_in.width, roi_in.height,
                                   in_bpp, bpp, untiled_factor_cl, tiling.overhead, tiling.overlap);
 
+    const gboolean may_tile = _piece_may_tile(piece);
     const gboolean no_tiling = fitter == DT_OPENCL_NO_TILING;
     const gboolean fast_tiling = fitter == DT_OPENCL_FAST_TILING
         && !memcmp(&roi_in, roi_out, sizeof(roi_in))
-        && !(module->flags() & (IOP_FLAGS_WRITE_RASTER | IOP_FLAGS_WRITE_DETAILS));
+        && !(module->flags() & (IOP_FLAGS_WRITE_RASTER | IOP_FLAGS_WRITE_DETAILS)
+        && may_tile); // fast tiling is not allowed if the piece doesn't support tiling
     const gboolean fits_on_device = no_tiling || fast_tiling;
 
-    if(possible_cl && !fits_on_device)
-    {
-      if(!_piece_may_tile(piece))
-        possible_cl = FALSE;
-    }
+    if(possible_cl && !fits_on_device && !may_tile)
+      possible_cl = FALSE;
 
     if(possible_cl) // either direct or via tiling
     {


### PR DESCRIPTION
We must respect the information that a piece must not tile also for the OpenCL fast tiling mode.

Fixes #22100