### PR TITLE
Invalidate watermark cachelines for tag/metadata change

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -185,6 +185,8 @@ changes (where available).
 - Fixed crash when navigating images in the darkroom with an
   image pinned in the 2nd window.
 
+- Fixed darkroom watermark issues related to tag & metadata changes.
+
 - Fixed refinements to forwarded raster masks being ignored along
   the OpenCL path.
 

--- a/src/common/history.c
+++ b/src/common/history.c
@@ -1883,6 +1883,22 @@ void dt_history_hash_set_mipmap(const dt_imgid_t imgid)
   sqlite3_finalize(stmt);
 }
 
+void dt_history_hash_unset_mipmap(const dt_imgid_t imgid)
+{
+  if(!dt_is_valid_imgid(imgid)) return;
+  sqlite3_stmt *stmt;
+  // clang-format off
+  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
+                              "UPDATE main.history_hash"
+                              " SET mipmap_hash = 0"
+                              " WHERE imgid = ?1",
+                              -1, &stmt, NULL);
+  // clang-format on
+  DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, imgid);
+  sqlite3_step(stmt);
+  sqlite3_finalize(stmt);
+}
+
 dt_history_hash_t dt_history_hash_get_status(const dt_imgid_t imgid)
 {
   dt_history_hash_t status = DT_HISTORY_HASH_NONE;

--- a/src/common/history.h
+++ b/src/common/history.h
@@ -180,6 +180,9 @@ gboolean dt_history_hash_is_mipmap_synced(const dt_imgid_t imgid);
 /** update mipmap hash to db (= current_hash) */
 void dt_history_hash_set_mipmap(const dt_imgid_t imgid);
 
+/** clear mipmap hash */
+void dt_history_hash_unset_mipmap(const dt_imgid_t imgid);
+
 /** write hash values to db */
 void dt_history_hash_write(const dt_imgid_t imgid,
                            const dt_history_hash_values_t *const hash);

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -2027,6 +2027,14 @@ static void _dt_metadata_change_callback(gpointer instance,
                                          const int type,
                                          dt_thumbtable_t *table)
 {
+  dt_develop_t *dev = darktable.develop;
+  if(dev)
+  {
+    dev->full.pipe->cache_obsolete_order = 0;
+    dev->preview_pipe->cache_obsolete_order = 0;
+    dev->preview2.pipe->cache_obsolete_order = 0;
+  }
+
   if(!table)
     return;
 

--- a/src/iop/watermark.c
+++ b/src/iop/watermark.c
@@ -1389,6 +1389,25 @@ void init(dt_iop_module_t *self)
   dt_strlcpy_to_fixed(d->font, "DejaVu Sans 10", sizeof(d->font));
 }
 
+static inline void _invalidate_tag_meta(dt_iop_module_t *self)
+{
+  dt_iop_refresh_all(self);
+  dt_history_hash_unset_mipmap(self->dev->image_storage.id);
+}
+
+static void _metadata_changed(gpointer instance,
+                              const int type,
+                              dt_iop_module_t *self)
+{
+  if(self) _invalidate_tag_meta(self);
+}
+
+static void _tag_changed(gpointer instance,
+                         dt_iop_module_t *self)
+{
+  if(self) _invalidate_tag_meta(self);
+}
+
 void gui_init(dt_iop_module_t *self)
 {
   dt_iop_watermark_gui_data_t *g = IOP_GUI_ALLOC(watermark);
@@ -1546,6 +1565,9 @@ void gui_init(dt_iop_module_t *self)
                    G_CALLBACK(_colorpick_color_set), self);
   g_signal_connect(G_OBJECT(g->fontsel), "font-set",
                    G_CALLBACK(_fontsel_callback), self);
+
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_METADATA_CHANGED, _metadata_changed, self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_TAG_CHANGED, _tag_changed, self);
 }
 
 void gui_cleanup(dt_iop_module_t *self)


### PR DESCRIPTION
As reported a metadata or tag change leaves an invalid cacheline, the suggested fix is good and the performance penalty is neglectable as those changes are rare and the module has a high iop_order.

Fixes #22069