### PR TITLE
borders: fix memory corruption on non-positive coordinate deltas

### DIFF
--- a/src/develop/borders_helper.c
+++ b/src/develop/borders_helper.c
@@ -23,9 +23,9 @@
 // need to parallelize further
 static inline void set_pixels(float *buf,
                               const dt_aligned_pixel_t color,
-                              const int npixels)
+                              const int border_width)
 {
-  for(size_t i = 0; i < npixels; i++)
+  for(int i = 0; i < border_width; i++)
   {
     copy_pixel_nontemporal(buf + 4*i,  color);
   }
@@ -35,9 +35,9 @@ static inline void set_pixels(float *buf,
 // need to parallelize further
 static inline void copy_pixels(float *out,
                                const float *const in,
-                               const int npixels)
+                               const int border_width)
 {
-  for(size_t i = 0; i < npixels; i++)
+  for(int i = 0; i < border_width; i++)
   {
     copy_pixel_nontemporal(out + 4*i, in + 4*i);
   }
@@ -152,7 +152,7 @@ void dt_iop_setup_binfo(const dt_dev_pixelpipe_iop_t *piece,
   if(has_right)
   {
     border_in_x = CLAMP(binfo->border_size_l - roi_out->x, 0, roi_out->width);
-    image_right = border_in_x + image_width;
+    image_right = CLAMP(border_in_x + image_width, border_in_x, roi_out->width);
   }
   else
   {
@@ -163,7 +163,7 @@ void dt_iop_setup_binfo(const dt_dev_pixelpipe_iop_t *piece,
   if(has_bottom)
   {
     border_in_y  = CLAMP(binfo->border_size_t - roi_out->y, 0, roi_out->height);
-    image_bottom = border_in_y + image_height;
+    image_bottom = CLAMP(border_in_y + image_height, border_in_y, roi_out->height);
   }
   else
   {


### PR DESCRIPTION

Commit 257e632e67 widened the loop counter in `set_pixels()` and `copy_pixels()` (`src/develop/borders_helper.c`) from `int` to `size_t`. In `dt_iop_copy_image_with_border()`, these helpers are called with slice lengths derived from coordinate differences (e.g., `fl_right - image_right`).

Under boundary and scaling conditions (such as thumbnail generation or tiling), coordinate differences can be non-positive ($\le 0$). With `size_t i`, `i < npixels` triggers signed-to-unsigned promotion, causing the loops to iterate `18446744073709551615` times and segfault (`EXC_BAD_ACCESS`).

This change:
1. Reverts loop counters in `set_pixels()` and `copy_pixels()` to signed `int` so non-positive counts safely perform 0 iterations.
2. Clamps `image_right` and `image_bottom` to `roi_out` bounds in `dt_iop_setup_binfo()`.

Tested:
- Verified clean build on macOS (ARM64).
- Verified pipeline and thumbnail generation for images with `borders` and `enlargecanvas` modules enabled.

Co-authored with Gemini.

[crash_report.txt](https://github.com/user-attachments/files/31695505/crash_report.txt)
