### PR TITLE
borders: disable frame line controls when border geometry prevents it

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -200,6 +200,9 @@ changes (where available).
 - Fixed the feather of a drawn path being lost when the shape was resized
   with the scroll wheel.
 
+- Fixed numeric error in the framing module (borders) causing the frame
+  line to be off-center for certain border sizes.
+
 ## Lua
 
 ### API Version

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -85,6 +85,10 @@ changes (where available).
   XMPs can be used to create duplicates or replace the current
   edit. Multiple XMPs create one duplicate per file.
 
+- In the borders (framing) module, disable frame line controls
+  when the border settings would prevent the frame line from
+  being visible.
+
 ## Performance Improvements
 
 - Replaced quadratic XMP history writes with a linear algorithm.

--- a/src/develop/borders_helper.c
+++ b/src/develop/borders_helper.c
@@ -139,9 +139,9 @@ void dt_iop_setup_binfo(const dt_dev_pixelpipe_iop_t *piece,
   const int border_tot_height =
     ceilf((piece->buf_out.height - piece->buf_in.height) * roi_in->scale);
 
-  binfo->border_size_t = has_top    ? border_tot_height * pos_v : 0;
+  binfo->border_size_t = has_top    ? roundf(border_tot_height * pos_v) : 0;
   binfo->border_size_b = has_bottom ? border_tot_height - binfo->border_size_t : 0;
-  binfo->border_size_l = has_left   ? border_tot_width * pos_h : 0;
+  binfo->border_size_l = has_left   ? roundf(border_tot_width * pos_h) : 0;
   binfo->border_size_r = has_right  ? border_tot_width - binfo->border_size_l : 0;
 
   int image_right   = 0;
@@ -202,14 +202,14 @@ void dt_iop_setup_binfo(const dt_dev_pixelpipe_iop_t *piece,
                                       binfo->border_size_b),
                                   MIN(binfo->border_size_l,
                                       binfo->border_size_r));
-  binfo->frame_size = border_min_size * f_size;
+  binfo->frame_size = roundf(border_min_size * f_size);
 
   if(binfo->frame_size > 0)
   {
     const int image_lx = binfo->border_size_l - roi_out->x;
     const int image_ty = binfo->border_size_t - roi_out->y;
     const int frame_space = border_min_size - binfo->frame_size;
-    const int frame_offset = frame_space * f_offset;
+    const int frame_offset = roundf(frame_space * f_offset);
 
     binfo->frame_tl_in_x = MAX(border_in_x - frame_offset, 0);
     binfo->frame_tl_out_x = MAX(binfo->frame_tl_in_x - binfo->frame_size, 0);
@@ -227,27 +227,26 @@ void dt_iop_setup_binfo(const dt_dev_pixelpipe_iop_t *piece,
     const int frame_out_height = frame_in_height + binfo->frame_size * 2;
 
     binfo->frame_br_in_x
-      = CLAMP(image_lx - frame_offset + frame_in_width - 1,
-              0, roi_out->width - 1);
+      = CLAMP(image_lx - frame_offset + frame_in_width,
+              0, roi_out->width);
     binfo->frame_br_in_y
-      = CLAMP(image_ty - frame_offset + frame_in_height - 1,
-              0, roi_out->height - 1);
+      = CLAMP(image_ty - frame_offset + frame_in_height,
+              0, roi_out->height);
 
     // ... if 100% frame_offset we ensure frame_line "stick" the out border
     binfo->frame_br_out_x
         = (f_offset == 1.0f
            && (MIN(binfo->border_size_l, binfo->border_size_r) - border_min_size < 2))
               ? (roi_out->width)
-              : CLAMP(image_lx - frame_offset - binfo->frame_size + frame_out_width - 1,
-                      0, roi_out->width - 1);
+              : CLAMP(image_lx - frame_offset - binfo->frame_size + frame_out_width,
+                      0, roi_out->width);
     binfo->frame_br_out_y
         = (f_offset == 1.0f
            && (MIN(binfo->border_size_t, binfo->border_size_b) - border_min_size < 2))
               ? (roi_out->height)
-              : CLAMP(image_ty - frame_offset - binfo->frame_size + frame_out_height - 1,
-                      0, roi_out->height - 1);
+              : CLAMP(image_ty - frame_offset - binfo->frame_size + frame_out_height,
+                      0, roi_out->height);
 
-    // need end+1 for these coordinates
     binfo->fl_right     = binfo->frame_br_in_x;
     binfo->border_right = binfo->frame_br_out_x;
     binfo->fl_bot       = binfo->frame_br_in_y;

--- a/src/iop/borders.c
+++ b/src/iop/borders.c
@@ -124,6 +124,7 @@ typedef struct dt_iop_borders_gui_data_t
   GtkWidget *frame_offset;
   GtkWidget *frame_colorpick;
   GtkWidget *frame_picker; // the 2nd button
+  GtkWidget *frame_color_box;
 } dt_iop_borders_gui_data_t;
 
 // ******* Check and update legacy params...(esp. ver 4)
@@ -850,6 +851,43 @@ void gui_changed(dt_iop_module_t *self,
     }
     dt_bauhaus_combobox_set(g->pos_v, k);
   }
+
+  const char *reason = NULL;
+  if(p->size <= 0.0f)
+    reason = _("increase border size to enable the frame line");
+  else if(p->pos_h <= 0.0f)
+    reason = _("increase horizontal offset to enable the frame line");
+  else if(p->pos_h >= 1.0f)
+    reason = _("decrease horizontal offset to enable the frame line");
+  else if(p->pos_v <= 0.0f)
+    reason = _("increase vertical offset to enable the frame line");
+  else if(p->pos_v >= 1.0f)
+    reason = _("decrease vertical offset to enable the frame line");
+
+  const gboolean enable_frameline = (reason == NULL);
+
+  gtk_widget_set_sensitive(g->frame_size, enable_frameline);
+  gtk_widget_set_sensitive(g->frame_offset, enable_frameline);
+  gtk_widget_set_sensitive(g->frame_color_box, enable_frameline);
+
+  if(enable_frameline)
+  {
+    gtk_widget_set_tooltip_text(g->frame_size,
+                                _("size of the frame line in percent of min border width"));
+    gtk_widget_set_tooltip_text(g->frame_offset,
+                                _("offset of the frame line beginning on image side"));
+    gtk_widget_set_tooltip_text(g->frame_colorpick,
+                                _("select frame line color"));
+    gtk_widget_set_tooltip_text(g->frame_picker,
+                                _("pick frame line color from image"));
+  }
+  else
+  {
+    gtk_widget_set_tooltip_text(g->frame_size, reason);
+    gtk_widget_set_tooltip_text(g->frame_offset, reason);
+    gtk_widget_set_tooltip_text(g->frame_colorpick, reason);
+    gtk_widget_set_tooltip_text(g->frame_picker, reason);
+  }
 }
 
 static void _colorpick_color_set(GtkColorButton *widget,
@@ -1032,7 +1070,8 @@ void gui_init(dt_iop_module_t *self)
                               _("pick frame line color from image"));
   dt_action_define_iop(self, N_("pickers"), N_("frame line color"),
                        g->frame_picker, &dt_action_def_color_picker);
-  dt_gui_box_add(self->widget, dt_gui_hbox(dt_gui_expand(label), g->frame_colorpick, g->frame_picker));
+  g->frame_color_box = dt_gui_hbox(dt_gui_expand(label), g->frame_colorpick, g->frame_picker);
+  dt_gui_box_add(self->widget, g->frame_color_box);
 }
 
 // clang-format off


### PR DESCRIPTION
A small but significant UX improvement in the `borders` module.

The frame line width is proportional to the minimum border width across all four sides (`MIN(border_size_l, border_size_r, border_size_t, border_size_b)`). When border size is 0 or when horizontal/vertical offset is set to an extreme value (`0.0` or `1.0`), one or more side borders are absent, collapsing the minimum border width to 0 and preventing the frame line from rendering.

This PR:
1. Disables frame line width, offset, and color controls when border geometry prevents the frame line from being visible.
2. Dynamically updates their tooltips to explain the exact adjustment needed (e.g., *"increase border size to enable the frame line"*, *"decrease horizontal offset to enable the frame line"*).
3. Restores default tooltips and sensitivity when geometry allows a valid frame line.

Tested:
- Verified dynamic sensitivity and contextual tooltip updates in darkroom across various combinations of border size, horizontal offset, and vertical offset.

Co-authored with Gemini.

Note that this is stacked on top of #22107, which has a fix for a borders-related crash.

**EDIT**: also fixed centering of the frame line, as requested by @TurboGit in the comments.
