### PR TITLE
fix module-border-settings not saving

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -50,18 +50,18 @@
   </dtconfig>
   <dtconfig common="yes">
     <name>themes/focused-module-border</name>
-    <type>bool</type>
-    <default>false</default>
+    <type>int</type>
+    <default>0</default>
     <shortdescription>use small border around module</shortdescription>
   </dtconfig>
   <dtconfig common="yes">
     <name>themes/expanded-module-border</name>
-    <type>bool</type>
-    <default>false</default>
+    <type>int</type>
+    <default>0</default>
     <shortdescription>use small border around module</shortdescription>
   </dtconfig>
   <dtconfig common="yes">
-    <name>themes/colored-accent</name>
+    <name>themes/accent-color</name>
     <type>int</type>
     <default>0</default>
     <shortdescription>use colored accent for some UI elements</shortdescription>


### PR DESCRIPTION
The new settings general/focused module border + expanded module border were not being saved across launches of darktable.

Cause: themes/focused-module-border and themes/expanded-module-border are stored as combobox indices via dt_conf_set_int()/dt_conf_get_int(), but darktableconfig.xml.in  declared them as bool. 

_sanitize_confgen() treats any DT_BOOL-typed value that isn't literally "true"/"false" as garbage and resets it to the schema default when darktablerc is read on startup. Since the persisted value is always a plain index ("0"–"6"), both settings silently reverted to their default (disabled) on every restart, even though they applied correctly for the rest of the running session.

Also fixes a related mismatch: the code reads/writes themes/accent-color, while the schema registered themes/colored-accent under that same feature. Renamed the schema entry to match the code.

No release note as the feature isn't present in 5.6.1.

Co-Created with Claude Opus 5