### PR TITLE
No more nightlies for Intel Macs

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -348,7 +348,6 @@ jobs:
       matrix:
         build:
           - { os: macos-14,       xcode: 16.2, deployment: 14.0 } # AppleClang 16, arm64
-          - { os: macos-15-intel, xcode: 26.3, deployment: 15.0 } # AppleClang 17, x86_64
         compiler:
           - { compiler: XCode,   CC: cc, CXX: c++ }
         btype: [ Release ]


### PR DESCRIPTION
This build failed for two days with the diagnostic message "Error: exiv2: no bottle available!". It looks like Homebrew is hinting to us that its package base for this platform is becoming unreliable and it's time to forget about Intel Macs and move on.

Maybe someone will find a solution to this problem later and we will bring back the Nightly builds for a while, but for now we need to successfully produce builds for other platforms.