### PR TITLE
remove mention of Intel Macs from README

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -487,7 +487,7 @@ jobs:
 
             The Windows package `*-win64.exe` requires at least Windows 10. The `*-woa64.exe` package requires at least Windows 11.
 
-            The macOS package `*-arm64.dmg` requires at least macOS 14.0 (Sonoma). The `*-x86_64.dmg` package requires at least macOS 15.0 (Sequoia).
+            The macOS package `*-arm64.dmg` requires at least macOS 14.0 (Sonoma).
 
             __Please help us improve Darktable by reporting any issues you encounter!__ :wink:
           artifacts: |

--- a/README.md
+++ b/README.md
@@ -62,7 +62,6 @@ Requirements
 * OpenBSD
 * Windows 10 and later
 * Apple Silicon Macs running macOS 14 and later
-* Intel Macs running macOS 15 and later
 
 *Big-endian platforms are not supported.*
 
@@ -159,7 +158,6 @@ you can build the software yourself following the instructions [below](#building
 
 * [Download package for Windows](https://github.com/darktable-org/darktable/releases/download/release-5.6.0/darktable-5.6.0-win64.exe)
 * [Download disk image for macOS on Apple Silicon](https://github.com/darktable-org/darktable/releases/download/release-5.6.0/darktable-5.6.0-arm64.dmg)
-* [Download disk image for macOS on Intel](https://github.com/darktable-org/darktable/releases/download/release-5.6.0/darktable-5.6.0-x86_64.dmg)
 * [Download AppImage for Linux](https://github.com/darktable-org/darktable/releases/download/release-5.6.0/Darktable-5.6.0-x86_64.AppImage)
 * [Install native packages or add a third-party repository for Linux distros](https://software.opensuse.org/download.html?project=graphics:darktable:stable&package=darktable)
 * [Install Flatpak package for Linux](https://flathub.org/apps/details/org.darktable.Darktable)


### PR DESCRIPTION
The next release will definitely have no support for Intel Macs because the macOS GitHub runner for Intel will be no longer available after fall 2026.