### PR TITLE
Fix path feather being lost on scroll resize

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -193,6 +193,9 @@ changes (where available).
 - Fixed broken dragging in sliders' precise-entry mode
   in GTK3.
 
+- Fixed the feather of a drawn path being lost when the shape was resized
+  with the scroll wheel.
+
 ## Lua
 
 ### API Version

--- a/src/develop/masks/path.c
+++ b/src/develop/masks/path.c
@@ -3045,6 +3045,9 @@ static int _path_events_mouse_scrolled(dt_iop_module_t *module,
            0.5f);
 
         dt_conf_set_float(DT_MASKS_CONF(form->type, path, border), masks_border);
+        // a resize restores the baseline's borders wholesale, so drop it
+        // here as _path_modify_property does for the same property
+        _resize_state_invalidate(form->formid);
         dt_toast_log(_("feather size: %3.2f%%"),
                      feather_size * 50.0f / g_list_length(form->points));
       }


### PR DESCRIPTION
Fixes #22052: a drawn path's feather collapses when the shape is resized with the scroll wheel.

Scroll-resizing a path morphs a cached baseline – a copy of the nodes taken when resizing started – and swaps the result in whole, borders included. The feather branch of the same scroll handler writes every node's `border[]` in place without dropping that cache, so the next resize restores whatever the baseline held. `_path_modify_property` already invalidates for `DT_MASKS_PROPERTY_FEATHER`, which is why the mask-manager slider is unaffected and why the value set there becomes what the wheel snaps back to. This makes the two paths agree.

Reproduce with: draw a path, scroll to resize it (this captures the baseline), shift+scroll to raise the feather, scroll again. The first resize is easy to omit, and without it there is no stale baseline. Circles and ellipses have no morph machinery, and it was reported against AI object masks only because those become vector paths.

Two related omissions left alone: `_path_resize_centroid` (Ctrl+Shift resize) rewrites every node without invalidating either, and `_path_revectorize` flattens per-node feather to a mean, so deliberately varying border is lost on any resize.

Builds on macOS arm64. I could not reproduce on macOS; the reporters confirmed the sequence above on Linux against an unpatched build, and the fixed build has not yet been through it. No new strings, preferences or dependencies, nothing touches `src/iop/` or the pixelpipe, and `RELEASE_NOTES.md` carries an entry under Bug Fixes in its own commit.

Written with AI assistance.