### PR TITLE
fix lighttable bottom-panel star and color label toggles

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -85,6 +85,10 @@ changes (where available).
   XMPs can be used to create duplicates or replace the current
   edit. Multiple XMPs create one duplicate per file.
 
+- Lighttable footer star ratings are now individual CSS-targetable
+  buttons (instead of a single drawing area), so spacing and sizing
+  can be themed. The rating filter reuses the same star paoint helper.
+
 - In the borders (framing) module, disable frame line controls
   when the border settings would prevent the frame line from
   being visible.
@@ -158,6 +162,9 @@ changes (where available).
 - Fixed an empty Media Type dropdown in the Print module for Canon
   printers whose drivers use the `CNIJMediaType` option instead of the
   standard `MediaType` option.
+
+- Fixed lighttable bottom-panel star rating and color label toggles
+  not responding on repeated clicks.
 
 - Fixed the feather on dense drawn path masks rendering stripes,
   phantom arcs and crossing lines.

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -539,8 +539,42 @@ separator
 #lib-rating-stars
 {
   min-height: 1.1em;
-  min-width: 9em;
   margin-right: 1em;
+}
+
+#lib-rating-stars .dt_rating_star
+{
+  /* keep the visual gap inside adjacent buttons so it remains clickable */
+  margin: 0.07em 0;
+  padding-left: 0.15em;
+  padding-right: 0.15em;
+  min-height: 1.18em;
+  min-width: 1.18em;
+}
+
+#lib-label-colors .dt_module_btn
+{
+  /* keep the visual gap inside adjacent buttons so it remains clickable */
+  margin: 0.07em 0;
+  padding-left: 0.07em;
+  padding-right: 0.07em;
+}
+
+#lib-rating-stars .dt_rating_star #button-canvas
+{
+  margin: 3px;
+}
+
+#lib-rating-stars .dt_rating_star:hover,
+#lib-rating-stars .dt_rating_star:checked
+{
+  background-color: transparent;
+  border-color: transparent;
+}
+
+#lib-rating-stars #rating-star-0
+{
+  color: shade(@fg_color, 0.9);
 }
 
 /* Set default button spacing  for specific buttons */
@@ -1536,6 +1570,11 @@ filechooser row:hover .sidebar-icon
 #dt-range-band-icons:hover
 {
   color: @bauhaus_fg_hover;
+}
+
+#dt-range-rating #dt-range-band-icons
+{
+  min-height: 1.1em;
 }
 
 /*------------

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -142,6 +142,7 @@ FILE(GLOB SOURCE_FILES
   "dtgtk/paint.c"
   "dtgtk/paint_cell.c"
   "dtgtk/range.c"
+  "dtgtk/rating_stars.c"
   "dtgtk/resetlabel.c"
   "dtgtk/sidepanel.c"
   "dtgtk/stylemenu.c"

--- a/src/dtgtk/rating_stars.c
+++ b/src/dtgtk/rating_stars.c
@@ -1,0 +1,165 @@
+/*
+    This file is part of darktable,
+    Copyright (C) 2026 darktable developers.
+
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    darktable is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "dtgtk/rating_stars.h"
+#include "dtgtk/button.h"
+#include "dtgtk/paint.h"
+#include "control/control.h"
+#include "gui/accelerators.h"
+#include "gui/gtk.h"
+
+#define DT_RATING_STARS_N 6
+#define DT_RATING_STARS_BUTTONS_KEY "dt-rating-stars-buttons"
+
+/* Fill on prelight/active like the filter range icons (paint_star needs data). */
+void dtgtk_cairo_paint_rating_star(cairo_t *cr,
+                                   const gint x,
+                                   const gint y,
+                                   const gint w,
+                                   const gint h,
+                                   const gint flags,
+                                   void *data)
+{
+  void *fill = NULL;
+  GdkRGBA shade;
+
+  if((flags & CPF_PRELIGHT) || (flags & CPF_ACTIVE))
+  {
+    if(cairo_pattern_get_rgba(cairo_get_source(cr),
+                              &shade.red, &shade.green, &shade.blue, &shade.alpha)
+       == CAIRO_STATUS_SUCCESS)
+    {
+      shade.alpha *= 0.5;
+      fill = &shade;
+    }
+  }
+
+  dtgtk_cairo_paint_star(cr, x, y, w, h, flags, fill);
+}
+
+static GtkWidget **_stars_buttons(GtkWidget *box)
+{
+  return g_object_get_data(G_OBJECT(box), DT_RATING_STARS_BUTTONS_KEY);
+}
+
+static void _stars_set_prelight(GtkWidget *box,
+                                const int upto)
+{
+  GtkWidget **buttons = _stars_buttons(box);
+  if(!buttons) return;
+
+  for(int k = 1; k < DT_RATING_STARS_N; k++)
+  {
+    if(k <= upto)
+      gtk_widget_set_state_flags(buttons[k], GTK_STATE_FLAG_PRELIGHT, FALSE);
+    else
+      gtk_widget_unset_state_flags(buttons[k], GTK_STATE_FLAG_PRELIGHT);
+    gtk_widget_queue_draw(buttons[k]);
+  }
+}
+
+static void _stars_enter_cb(GtkEventControllerMotion *controller,
+                            const double x,
+                            const double y,
+                            gpointer user_data)
+{
+  GtkWidget *box = user_data;
+  GtkWidget *widget = dt_gui_get_widget(controller);
+  const int rating = dtgtk_rating_stars_get_value(widget);
+  if(rating < 0) return;
+
+  if(rating >= 1)
+    darktable.control->element = rating;
+
+  _stars_set_prelight(box, rating);
+}
+
+static void _stars_leave_cb(GtkEventControllerMotion *controller,
+                            gpointer user_data)
+{
+  _stars_set_prelight(user_data, 0);
+}
+
+int dtgtk_rating_stars_get_value(GtkWidget *button)
+{
+  if(!button) return -1;
+  if(!g_object_get_data(G_OBJECT(button), "dt-rating-stars-member"))
+    return -1;
+  return GPOINTER_TO_INT(g_object_get_data(G_OBJECT(button), DT_RATING_STARS_VALUE_KEY));
+}
+
+GtkWidget *dtgtk_rating_stars_new(GCallback pressed,
+                                  gpointer data)
+{
+  GtkWidget *box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
+  gtk_widget_set_name(box, "lib-rating-stars");
+  gtk_widget_set_halign(box, GTK_ALIGN_CENTER);
+  gtk_widget_set_valign(box, GTK_ALIGN_CENTER);
+
+  GtkWidget **buttons = g_malloc0_n(DT_RATING_STARS_N, sizeof(GtkWidget *));
+  g_object_set_data_full(G_OBJECT(box), DT_RATING_STARS_BUTTONS_KEY, buttons, g_free);
+
+  static const char *tooltips[DT_RATING_STARS_N] = {
+    N_("clear star rating of selected images"),
+    N_("set 1-star rating for selected images"),
+    N_("set 2-star rating for selected images"),
+    N_("set 3-star rating for selected images"),
+    N_("set 4-star rating for selected images"),
+    N_("set 5-star rating for selected images"),
+  };
+
+  for(int k = 0; k < DT_RATING_STARS_N; k++)
+  {
+    DTGTKCairoPaintIconFunc paint =
+      (k == 0) ? dtgtk_cairo_paint_unratestar : dtgtk_cairo_paint_rating_star;
+
+    GtkWidget *button = dtgtk_button_new(paint, 0, NULL);
+    buttons[k] = button;
+
+    char name[32];
+    g_snprintf(name, sizeof(name), "rating-star-%d", k);
+    gtk_widget_set_name(button, name);
+    dt_gui_add_class(button, "dt_rating_star");
+    dt_gui_add_class(button, "dt_transparent_background");
+    gtk_widget_set_tooltip_text(button, _(tooltips[k]));
+
+    g_object_set_data(G_OBJECT(button), DT_RATING_STARS_VALUE_KEY, GINT_TO_POINTER(k));
+    g_object_set_data(G_OBJECT(button), "dt-rating-stars-member", GINT_TO_POINTER(1));
+
+    /* GtkButton: claim so class handlers do not eat the first press
+     * (same gtk4-prep pattern as footer color labels). Prefer
+     * dt_gui_connect_click_claim() if that helper is already on the branch.*/
+    {
+      GtkGesture *gesture = gtk_gesture_multi_press_new(button);
+      gtk_event_controller_set_propagation_phase(GTK_EVENT_CONTROLLER(gesture),
+                                                 GTK_PHASE_CAPTURE);
+      dt_gui_add_controller(button, gesture);
+      if(pressed)
+        g_signal_connect(gesture, "pressed", G_CALLBACK(pressed), data);
+      g_signal_connect(gesture, "begin", G_CALLBACK(dt_gui_gesture_claim), NULL);
+      gtk_gesture_single_set_button(GTK_GESTURE_SINGLE(gesture), 0);
+      g_object_set_data(G_OBJECT(button), DT_ACTION_GESTURE_KEY, gesture);
+    }
+
+    dt_gui_connect_motion(button, NULL, _stars_enter_cb, _stars_leave_cb, box);
+
+    gtk_box_pack_start(GTK_BOX(box), button, FALSE, FALSE, 0);
+  }
+
+  return box;
+}

--- a/src/dtgtk/rating_stars.h
+++ b/src/dtgtk/rating_stars.h
@@ -1,0 +1,50 @@
+/*
+    This file is part of darktable,
+    Copyright (C) 2026 darktable developers.
+
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    darktable is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include "dtgtk/paint.h"
+#include <gtk/gtk.h>
+
+G_BEGIN_DECLS
+
+/** Key for g_object_get_data() on each star button: GINT_TO_POINTER(0..5) */
+#define DT_RATING_STARS_VALUE_KEY "dt-rating-value"
+
+/**
+ * Horizontal strip of six CSS-targetable rating buttons (unrated + *1-*5).
+ * The returned widget is a GtkBox named "lib-rating-stars".
+ *
+ * @param pressed  gesture "pressed" callback (may be NULL)
+ * @param data     user data for pressed
+ */
+GtkWidget *dtgtk_rating_stars_new(GCallback pressed,
+                                  gpointer data);
+
+/** Rating 0..5 for a button from this strip, or -1 if not a strip button. */
+int dtgtk_rating_stars_get_value(GtkWidget *button);
+
+void dtgtk_cairo_paint_rating_star(cairo_t *cr,
+                                   const gint x,
+                                   const gint y,
+                                   const gint w,
+                                   const gint h,
+                                   const gint flags,
+                                   void *data);
+
+G_END_DECLS

--- a/src/libs/filtering.c
+++ b/src/libs/filtering.c
@@ -25,6 +25,7 @@
 #include "control/jobs.h"
 #include "dtgtk/button.h"
 #include "dtgtk/range.h"
+#include "dtgtk/rating_stars.h"
 #include "gui/accelerators.h"
 #include "gui/gtk.h"
 #include "libs/collect.h"

--- a/src/libs/filters/rating_range.c
+++ b/src/libs/filters/rating_range.c
@@ -175,29 +175,6 @@ static gchar *_rating_get_bounds_pretty(GtkDarktableRangeSelect *range)
   return dtgtk_range_select_get_bounds_pretty(range);
 }
 
-static void _rating_paint_icon(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
-{
-  // first, we set the color depending on the flags
-  void *my_data = NULL;
-  GdkRGBA shade_color;
-
-  if((flags & CPF_PRELIGHT) || (flags & CPF_ACTIVE))
-  {
-    // we want a filled icon
-    cairo_get_source(cr);
-    cairo_pattern_get_rgba(cairo_get_source(cr),
-                           &shade_color.red,
-                           &shade_color.green,
-                           &shade_color.blue,
-                           &shade_color.alpha);
-    shade_color.alpha *= 0.6;
-    my_data = &shade_color;
-  }
-
-  // then we draw the regular icon
-  dtgtk_cairo_paint_star(cr, x, y, w, h, flags, my_data);
-}
-
 enum
 {
   // DT_ACTION_EFFECT_TOGGLE = DT_ACTION_EFFECT_DEFAULT_KEY,
@@ -338,11 +315,11 @@ static void _rating_range_widget_init(dt_lib_filtering_rule_t *rule,
   dtgtk_range_select_add_icon(range, 7, -1, dtgtk_cairo_paint_reject, 0, NULL);
   dtgtk_range_select_add_icon(range, 22, 0, dtgtk_cairo_paint_unratestar, 0, NULL);
 
-  dtgtk_range_select_add_icon(range, 36, 1, _rating_paint_icon, 0, NULL);
-  dtgtk_range_select_add_icon(range, 50, 2, _rating_paint_icon, 0, NULL);
-  dtgtk_range_select_add_icon(range, 64, 3, _rating_paint_icon, 0, NULL);
-  dtgtk_range_select_add_icon(range, 78, 4, _rating_paint_icon, 0, NULL);
-  dtgtk_range_select_add_icon(range, 93, 5, _rating_paint_icon, 0, NULL);
+  dtgtk_range_select_add_icon(range, 36, 1, dtgtk_cairo_paint_rating_star, 0, NULL);
+  dtgtk_range_select_add_icon(range, 50, 2, dtgtk_cairo_paint_rating_star, 0, NULL);
+  dtgtk_range_select_add_icon(range, 64, 3, dtgtk_cairo_paint_rating_star, 0, NULL);
+  dtgtk_range_select_add_icon(range, 78, 4, dtgtk_cairo_paint_rating_star, 0, NULL);
+  dtgtk_range_select_add_icon(range, 93, 5, dtgtk_cairo_paint_rating_star, 0, NULL);
   range->print = _rating_print_func;
   range->current_bounds = _rating_get_bounds_pretty;
 

--- a/src/libs/tools/colorlabels.c
+++ b/src/libs/tools/colorlabels.c
@@ -143,7 +143,17 @@ void gui_init(dt_lib_module_t *self)
     dt_gui_add_class(d->buttons[k], "dt_no_hover");
     dt_gui_add_class(d->buttons[k], "dt_dimmed");
     gtk_box_pack_start(GTK_BOX(self->widget), button, TRUE, TRUE, 0);
-    dt_gui_connect_click_all(button, _lib_colorlabels_button_press_callback, NULL, self);
+    {
+      GtkGesture *gesture = gtk_gesture_multi_press_new(button);
+      gtk_event_controller_set_propagation_phase(GTK_EVENT_CONTROLLER(gesture),
+                                                   GTK_PHASE_CAPTURE);
+      dt_gui_add_controller(button, gesture);
+      g_signal_connect(gesture, "pressed",
+                       G_CALLBACK(_lib_colorlabels_button_press_callback), self);
+      g_signal_connect(gesture, "begin", G_CALLBACK(dt_gui_gesture_claim), NULL);
+      gtk_gesture_single_set_button(GTK_GESTURE_SINGLE(gesture), 0);
+      g_object_set_data(G_OBJECT(button), DT_ACTION_GESTURE_KEY, gesture);
+    }
     dt_gui_connect_motion(button, NULL, _lib_colorlabels_enter_notify_callback, NULL, self);
     ac = dt_action_widget(button);
   }

--- a/src/libs/tools/ratings.c
+++ b/src/libs/tools/ratings.c
@@ -20,6 +20,7 @@
 #include "common/debug.h"
 #include "control/control.h"
 #include "dtgtk/button.h"
+#include "dtgtk/rating_stars.h"
 #include "gui/draw.h"
 #include "gui/gtk.h"
 #include "gui/accelerators.h"
@@ -28,30 +29,10 @@
 
 DT_MODULE(1)
 
-typedef struct dt_lib_ratings_t
-{
-  gint current;
-  gint pointerx;
-  gint pointery;
-} dt_lib_ratings_t;
-
-/* redraw the ratings */
-static gboolean _lib_ratings_draw_callback(GtkWidget *widget, cairo_t *cr, dt_lib_module_t *self);
-/* motion notify handler*/
-static void _lib_ratings_motion_notify_callback(GtkEventControllerMotion *controller,
-                                                  double x, double y,
-                                                  dt_lib_module_t *self);
-/* motion leavel handler */
-static void _lib_ratings_leave_notify_callback(GtkEventControllerMotion *controller,
-                                                 dt_lib_module_t *self);
 /* button press handler */
 static void _lib_ratings_button_press_callback(GtkGestureSingle *gesture, int n_press,
                                                   double x, double y,
                                                   dt_lib_module_t *self);
-/* button release handler */
-static void _lib_ratings_button_release_callback(GtkGestureSingle *gesture, int n_press,
-                                                    double x, double y,
-                                                    dt_lib_module_t *self);
 
 const char *name(dt_lib_module_t *self)
 {
@@ -80,33 +61,17 @@ int position(const dt_lib_module_t *self)
 
 void gui_init(dt_lib_module_t *self)
 {
-  /* initialize ui widgets */
-  dt_lib_ratings_t *d = g_malloc0(sizeof(dt_lib_ratings_t));
-  self->data = (void *)d;
+  self->data = NULL;
+  self->widget = dtgtk_rating_stars_new(G_CALLBACK(_lib_ratings_button_press_callback), self);
 
-  self->widget = GTK_WIDGET(gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0));
-  gtk_widget_set_halign(self->widget, GTK_ALIGN_CENTER);
-  gtk_widget_set_valign(self->widget, GTK_ALIGN_CENTER);
+  /* map each button so shortcut mode sees the hovered widget as actionable */
+  GList *buttons = gtk_container_get_children(GTK_CONTAINER(self->widget));
+  dt_action_t *ac = NULL;
+  for(const GList *button = buttons; button; button = g_list_next(button))
+    ac = dt_action_define(&darktable.control->actions_thumb, NULL, N_("rating"),
+                          GTK_WIDGET(button->data), &dt_action_def_rating);
+  g_list_free(buttons);
 
-  GtkWidget *drawing = gtk_drawing_area_new();
-
-  gtk_widget_set_events(drawing, GDK_EXPOSURE_MASK | GDK_STRUCTURE_MASK
-                               | GDK_POINTER_MOTION_MASK
-                               | GDK_ENTER_NOTIFY_MASK | GDK_LEAVE_NOTIFY_MASK
-                               | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK);
-
-  /* connect callbacks */
-  gtk_widget_set_tooltip_text(drawing, _("set star rating for selected images"));
-  dt_gui_add_class(drawing, "dt_transparent_background");
-  g_signal_connect(G_OBJECT(drawing), "draw", G_CALLBACK(_lib_ratings_draw_callback), self);
-  dt_gui_connect_click(drawing, _lib_ratings_button_press_callback, _lib_ratings_button_release_callback, self);
-  dt_gui_connect_motion(drawing, _lib_ratings_motion_notify_callback, NULL, _lib_ratings_leave_notify_callback, self);
-
-  gtk_box_pack_start(GTK_BOX(self->widget), drawing, TRUE, TRUE, 0);
-
-  /* set size of navigation draw area */
-  gtk_widget_set_name(self->widget, "lib-rating-stars");
-  dt_action_t *ac = dt_action_define(&darktable.control->actions_thumb, NULL, N_("rating"), drawing, &dt_action_def_rating);
   dt_shortcut_register(ac, 0, 0, GDK_KEY_0, 0);
   dt_shortcut_register(ac, 1, 0, GDK_KEY_1, 0);
   dt_shortcut_register(ac, 2, 0, GDK_KEY_2, 0);
@@ -114,7 +79,6 @@ void gui_init(dt_lib_module_t *self)
   dt_shortcut_register(ac, 4, 0, GDK_KEY_4, 0);
   dt_shortcut_register(ac, 5, 0, GDK_KEY_5, 0);
   dt_shortcut_register(ac, 6, 0, GDK_KEY_r, 0);
-
 }
 
 void gui_cleanup(dt_lib_module_t *self)
@@ -123,110 +87,20 @@ void gui_cleanup(dt_lib_module_t *self)
   self->data = NULL;
 }
 
-static gboolean _lib_ratings_draw_callback(GtkWidget *widget, cairo_t *crf, dt_lib_module_t *self)
-{
-  dt_lib_ratings_t *d = self->data;
-
-  if(!dt_control_running()) return TRUE;
-
-  GtkAllocation allocation;
-  gtk_widget_get_allocation(widget, &allocation);
-
-  const float star_size = allocation.height;
-  const float star_spacing = (allocation.width - 6.0 * star_size) / 5.0;
-
-  cairo_surface_t *cst
-      = dt_cairo_image_surface_create(CAIRO_FORMAT_ARGB32, allocation.width, allocation.height);
-  cairo_t *cr = cairo_create(cst);
-
-  GtkStyleContext *context = gtk_widget_get_style_context(widget);
-
-  gtk_render_background(context, cr, 0, 0, allocation.width, allocation.height);
-
-  /* get current style */
-  GdkRGBA fg_color;
-  gtk_style_context_get_color(context, gtk_widget_get_state_flags(widget), &fg_color);
-
-  /* lets draw stars */
-  int x = 0;
-  cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(1));
-  gdk_cairo_set_source_rgba(cr, &fg_color);
-
-    // draw unrated star
-  cairo_set_source_rgba(cr, fg_color.red, fg_color.green, fg_color.blue, fg_color.alpha * 0.3);
-  dt_draw_star(cr, star_size / 2.0 + x, star_size / 2.0, star_size / 2.0, star_size / (2.0 * 2.5));
-  cairo_stroke(cr);
-  gdk_cairo_set_source_rgba(cr, &fg_color);
-  cairo_set_line_width(cr, 1.6 * cairo_get_line_width(cr));
-  cairo_move_to(cr, x + star_size * .1, star_size / 2.0);
-  cairo_line_to(cr, x + star_size * .9, star_size / 2.0);
-  cairo_stroke(cr);
-  cairo_set_line_width(cr, cairo_get_line_width(cr) / 1.6);
-  x += star_size + star_spacing;
-
-  //now the regular stars
-  d->current = 0;
-  for(int k = 0; k < 5; k++)
-  {
-    /* outline star */
-    dt_draw_star(cr, star_size / 2.0 + x, star_size / 2.0, star_size / 2.0, star_size / (2.0 * 2.5));
-    if(x < d->pointerx)
-    {
-      cairo_fill_preserve(cr);
-      cairo_set_source_rgba(cr, fg_color.red, fg_color.green, fg_color.blue, fg_color.alpha * 0.5);
-      cairo_stroke(cr);
-      gdk_cairo_set_source_rgba(cr, &fg_color);
-      if((k + 1) > d->current) d->current = darktable.control->element = (k + 1);
-    }
-    else
-      cairo_stroke(cr);
-    x += star_size + star_spacing;
-  }
-
-  /* blit memsurface onto widget*/
-  cairo_destroy(cr);
-  cairo_set_source_surface(crf, cst, 0, 0);
-  cairo_paint(crf);
-  cairo_surface_destroy(cst);
-
-  return TRUE;
-}
-
-static void _lib_ratings_motion_notify_callback(GtkEventControllerMotion *controller,
-                                                  double x, double y,
-                                                  dt_lib_module_t *self)
-{
-  dt_lib_ratings_t *d = self->data;
-
-  d->pointerx = x;
-  d->pointery = y;
-  gtk_widget_queue_draw(self->widget);
-}
-
 static void _lib_ratings_button_press_callback(GtkGestureSingle *gesture, int n_press,
                                                   double x, double y,
                                                   dt_lib_module_t *self)
 {
-  dt_lib_ratings_t *d = self->data;
+  GtkWidget *widget = dt_gui_get_widget(gesture);
+  const int rating = dtgtk_rating_stars_get_value(widget);
+  if(rating < 0) return;
+
   GList *imgs = dt_act_on_get_images(FALSE, TRUE, FALSE);
-  dt_ratings_apply_on_list(imgs, d->current, TRUE);
-  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_RATING_RANGE, imgs);
-
+  dt_ratings_apply_on_list(imgs, rating, TRUE);
+  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD,
+                             DT_COLLECTION_PROP_RATING_RANGE, imgs);
+  
   dt_control_queue_redraw_center();
-}
-
-static void _lib_ratings_button_release_callback(GtkGestureSingle *gesture, int n_press,
-                                                    double x, double y,
-                                                    dt_lib_module_t *self)
-{
-}
-
-static void _lib_ratings_leave_notify_callback(GtkEventControllerMotion *controller,
-                                                 dt_lib_module_t *self)
-{
-  dt_lib_ratings_t *d = self->data;
-  d->pointery = d->pointerx = 0;
-  gtk_widget_queue_draw(self->widget);
 }
 
 


### PR DESCRIPTION
Closes #21963 

The star rating widget applied d->current from the last draw pass, which could be stale when clicking the same star twice without moving the mouse after the gtk4-prep event-controller migration. Compute the rating from the press coordinates instead.
Color label buttons are GtkButton subclasses whose default click handling could swallow presses before our gesture handler ran. Wire a capture-phase multi-press gesture, claim the sequence on begin, and route shortcuts through DT_ACTION_GESTURE_KEY like other toggle buttons.