### PR TITLE
[Nightly] Bump libheif version to the latest for AppImage build

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -128,7 +128,7 @@ jobs:
             libxfixes-dev
       - name: Build and install fresh libheif with built-in decoders
         run: |
-          git clone --branch v1.23.2 --depth 1 https://github.com/strukturag/libheif src-libheif
+          git clone --branch v1.23.3 --depth 1 https://github.com/strukturag/libheif src-libheif
           cd src-libheif
           cmake -S . -B build -G Ninja \
             -DCMAKE_BUILD_TYPE=Release \


### PR DESCRIPTION
v1.23.3 is a security and bugfix release.  One of the fixed issues is rated critical, so all users are strongly advised to upgrade.
