### PR TITLE
Ensure module->gui_lock mutex initialize

### DIFF
--- a/src/libs/history.c
+++ b/src/libs/history.c
@@ -519,9 +519,10 @@ static gboolean _create_deleted_modules(GList **_iop_list, GList *history_list)
 
       if(!dt_iop_is_hidden(module))
       {
-        DT_ENTER_GUI_UPDATE();
-        module->gui_init(module);
-        DT_LEAVE_GUI_UPDATE();
+        /** this works inside correct DT_ENTER/LEAVE_GUI_UPDATE()
+            and ensures the module->gui_lock nutex is correctly intialized.
+        */
+        dt_iop_gui_init(module);
       }
 
       // adjust the multi_name of the new module


### PR DESCRIPTION
When re-creating the list of deleted iop modules in `_create_deleted_modules()` we must ensure the module's `gui_lock` mutex is correctly initialized.

Fixes #22062 

Another issue found by @kofa73 running the bots. I checked the analysis - that's all correct - and the suggested fix, that's also good and more readable. 

