### PR TITLE
Fix dt_camctl_camera_set_property_float brokenness

### DIFF
--- a/src/common/camera_control.c
+++ b/src/common/camera_control.c
@@ -1874,8 +1874,8 @@ void dt_camctl_camera_set_property_float(const dt_camctl_t *c,
   dt_camera_t *camera = (dt_camera_t *)cam;
 
   _camctl_camera_set_property_float_job_t *job =
-    g_malloc(sizeof(_camctl_camera_set_property_int_job_t));
-  job->type = _JOB_TYPE_SET_PROPERTY_INT;
+    g_malloc(sizeof(_camctl_camera_set_property_float_job_t));
+  job->type = _JOB_TYPE_SET_PROPERTY_FLOAT;
   job->name = g_strdup(property_name);
   job->value = value;
 


### PR DESCRIPTION
The issue was caused by undetected copy-paste errors. `dt_camctl_camera_set_property_float()` looks like copy of the _int variant, in which not all the necessary changes have been made. Allocation was used size of wrong struct, fortunately their sizes was the same (as int and float both is 4 bytes on  most modern architectures).

The direct cause of the buggy behavior is the following assignment:
```
job->type = _JOB_TYPE_SET_PROPERTY_INT;
```
This type is used to select an option in the switch in the `_camera_process_job()` function. Because of this erroneous type, an execution path for an integer type will be chosen there, in which case the value from `job->value` will eventually be assigned to the int variable.

As a result, the fractional part will be discarded (not mathematical rounded, BTW), and the number will be stored as an integer. This means that the fractional properties of the camera will be significantly distorted.
