### PR TITLE
develop: keep the mask pan allowance across pipe reprocessing

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -808,6 +808,19 @@ restart:
 
   if(port)
   {
+    // A displayed mask overlay enlarges the pannable canvas so handles lying
+    // outside the picture can be reached (see _clamp_zoom_to_mask), but the
+    // worker must not walk form_gui's mutable point arrays to learn by how
+    // much. Re-validating without them takes that allowance away: every mask
+    // edit dirties the pipe, so releasing a node dragged past the image edge
+    // sprang the view back to the picture. The GUI clamps with the overlay
+    // bounds on the next pan or zoom, and dt_masks_set_edit_mode() re-validates
+    // when the overlay goes away, so nothing stays stranded off-canvas.
+    // An image switch (port_loading) still validates: the overlay belongs to
+    // the image being left, and the pan must land inside the new one.
+    const gboolean mask_overlay_shown =
+      port == &dev->full && dev->form_visible && dev->form_gui;
+
     /* if just changed to an image with a different aspect ratio or
         altered image orientation, the prior zoom xy could now be beyond
         the image boundary.
@@ -838,7 +851,7 @@ restart:
       // Worker validation must not traverse GUI-owned mask overlay arrays.
       _dev_zoom_move(port, DT_ZOOM_POSITION, 0.0f, 0, rx, ry, TRUE, FALSE);
     }
-    else if(port_loading || require_zoom_test)
+    else if(port_loading || (require_zoom_test && !mask_overlay_shown))
     {
       dt_print_pipe(DT_DEBUG_PIPE, "dt_dev_zoom_move", pipe, NULL, DT_DEVICE_NONE, NULL, NULL, "%s%s",
         port_loading ? "port_loading " : "",


### PR DESCRIPTION
While a mask overlay is displayed, `_clamp_zoom_to_mask()` enlarges the region the viewport centre may travel over, so a node dragged outside the image stays reachable instead of being clamped away with the picture.

The pixelpipe worker re-validates the viewport whenever the pipe changes, and ce80c1e644 made that call pass `use_mask_overlay=FALSE`: a worker thread must not walk `form_gui`'s point arrays, which the GUI mutates underneath it. The clamp it runs therefore knows nothing about off-image overlay points and takes the allowance back. Every mask edit dirties the pipe, so the view sprang back to the image the moment a node dragged past its edge was released.

Skip that validation while an overlay is displayed on the full viewport. The GUI clamps with the real overlay bounds on the next pan or zoom, and `dt_masks_set_edit_mode()` re-validates when the overlay is hidden, so a pan cannot stay stranded off-canvas. An image switch still validates: the overlay belongs to the image being left, and the pan has to land inside the new one.

The cost is that a pipe geometry change made while an overlay is up (a crop, say) is not re-clamped until the next pan, zoom or overlay hide.

Co-authored with Claude.