### PR TITLE
Fix condensed bauhaus key

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -212,6 +212,10 @@ changes (where available).
 - Fixed a crash or hang on Windows when checking a faulty custom ONNX
   Runtime library.
 
+- The "condensed panels' controls" preference now also condenses the
+  sliders and comboboxes themselves, instead of only shrinking their
+  font.
+
 ## Lua
 
 ### API Version

--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -973,7 +973,7 @@ void dt_bauhaus_load_theme()
                                                     : DT_BAUHAUS_MARKER_TRIANGLE;
 
   // absolute size in Cairo unit:
-  if(dt_conf_get_bool("bauhaus/condensed"))
+  if(dt_conf_get_bool("themes/condensed"))
   {
     bh->quad_width = bh->line_height * 0.8;
     bh->baseline_size = bh->line_height / 4.5f;
@@ -1033,7 +1033,7 @@ void dt_bauhaus_init()
   dt_bauhaus_popup_t *pop = &bh->popup;
 
   // honor the condensed setting
-  INNER_PADDING = dt_conf_get_bool("bauhaus/condensed") ? 1.0 : 4.0;
+  INNER_PADDING = dt_conf_get_bool("themes/condensed") ? 1.0 : 4.0;
 
   bh->keys_cnt = 0;
   bh->current = NULL;


### PR DESCRIPTION
https://github.com/darktable-org/darktable/commit/b5b581e12b01dbd680dbd30707788600c5f0992f added the "condensed panels' controls" preference and wired it to two things: the chunk-condensed.css import, and bauhaus's own metrics -- a thinner baseline, a larger marker relative to it, and INNER_PADDING of 1 instead of 4.

### Issue

The preference is registered and written as `themes/condensed`, but `dt_bauhaus_load_theme()` reads `bauhaus/condensed`, which no `darktableconfig.xml.in` entry defines. That lookup has always returned false, so only the css half of the setting ever took effect and condensed users get bauhaus widgets laid out at full-size padding inside a shrunk font.

### Fix

Read the same key the preference writes. `dt_bauhaus_load_theme()` is already called on toggle, via `reload_ui_last_theme()` in `preferences.c`, so the metrics now follow the checkbox without a restart.

Co-authored with Claude.