### PR TITLE
Fix Windows backslash paths in export and import

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -219,6 +219,9 @@ changes (where available).
 - Fixed a small memory leak each time a history stack was pasted onto the
   image open in darkroom.
 
+- Fixed Windows paths losing their backslashes in export and import
+  patterns, which sent files to the wrong location.
+
 ## Lua
 
 ### API Version

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -222,6 +222,9 @@ changes (where available).
 - Fixed Windows paths losing their backslashes in export and import
   patterns, which sent files to the wrong location.
 
+- Fixed wrong output or a crash from an export pattern containing an
+  unclosed variable substitution, such as "$(FILE_NAME/foo".
+
 ## Lua
 
 ### API Version

--- a/src/common/import_session.c
+++ b/src/common/import_session.c
@@ -337,7 +337,7 @@ static const char *_import_session_path(dt_import_session_t *self, const gboolea
     if(first >= 'A' && first <= 'Z' && new_path[1] == ':') // path format is <drive letter>:/path/to/file
       new_path[0] = first;                                 // drive letter in uppercase looks nicer
   }
-  /* Remove trailing spaces from each element in the the path separated by directory separator.
+  /* Remove trailing spaces from each element in the path separated by directory separator.
      So follow the usage in Windows. */
   if(new_path && (strlen(new_path) >= 1))
   {

--- a/src/common/import_session.c
+++ b/src/common/import_session.c
@@ -123,15 +123,9 @@ static gchar *_import_session_path_pattern()
     goto bail_out;
   }
 
-#ifdef WIN32
-  gchar *s1 = dt_str_replace(base, "/", "\\\\");
-  gchar *s2 = dt_str_replace(sub, "/", "\\\\");
-  res = g_build_path("\\\\", s1, s2, (char *)NULL);
-  g_free(s1);
-  g_free(s2);
-#else
+  // _import_session_path() expands this with dt_variables_expand_path(),
+  // which normalizes separators, so Windows needs no escaping workaround
   res = g_build_path(G_DIR_SEPARATOR_S, base, sub, (char *)NULL);
-#endif
 
 bail_out:
   return res;
@@ -333,21 +327,24 @@ static const char *_import_session_path(dt_import_session_t *self, const gboolea
     return NULL;
   }
 
-  gchar *new_path = dt_variables_expand(self->vp, pattern, FALSE);
+  gchar *new_path = dt_variables_expand_path(self->vp, pattern, FALSE);
   g_free(pattern);
 
 #ifdef WIN32
   if(new_path && (strlen(new_path) > 1))
   {
     const char first = g_ascii_toupper(new_path[0]);
-    if(first >= 'A' && first <= 'Z' && new_path[1] == ':') // path format is <drive letter>:\path\to\file
+    if(first >= 'A' && first <= 'Z' && new_path[1] == ':') // path format is <drive letter>:/path/to/file
       new_path[0] = first;                                 // drive letter in uppercase looks nicer
   }
   /* Remove trailing spaces from each element in the the path separated by directory separator.
      So follow the usage in Windows. */
   if(new_path && (strlen(new_path) >= 1))
   {
-    char **directories = g_strsplit(new_path, G_DIR_SEPARATOR_S, -1);
+    // split on both separators: the pattern's own are normalized to '/' by
+    // dt_variables_expand_path(), but variables expand afterwards and their
+    // values still carry native '\', so a path can hold a mix of the two
+    char **directories = g_strsplit_set(new_path, "/\\", -1);
     for(int i=0; directories[i] != NULL; i++)
     {
       g_strchomp(directories[i]);

--- a/src/common/variables.c
+++ b/src/common/variables.c
@@ -1148,7 +1148,8 @@ static char *_variable_get_value(dt_variables_params_t *params, char **variable)
         if(mode == '/' || mode == '#' || mode == '%') (*variable)++;
         char *pattern = _expand_source(params, variable, '/');
         const size_t pattern_length = strlen(pattern);
-        (*variable)++;
+        // a truncated "$(var/pattern" stops at the NUL, not at a delimiter
+        if(**variable == '/') (*variable)++;
         char *replacement = _expand_source(params, variable, ')');
         const size_t replacement_length = strlen(replacement);
 

--- a/src/common/variables.c
+++ b/src/common/variables.c
@@ -1396,6 +1396,45 @@ char *dt_variables_expand(dt_variables_params_t *params,
   return result;
 }
 
+// rewrite '\' to '/', except before a '/': no path has a backslash there,
+// so "\/" can only be escaping a literal '/' in $(VAR/pattern/replacement)
+static gchar *_normalize_separators(const gchar *source)
+{
+  gchar *result = g_malloc(strlen(source) + 1);
+  gchar *out = result;
+
+  for(const gchar *in = source; *in; in++)
+  {
+    if(*in == '\\' && in[1] == '/')
+    {
+      *out++ = *in++;
+      *out++ = *in;
+    }
+    else
+      *out++ = (*in == '\\') ? '/' : *in;
+  }
+  *out = '\0';
+
+  return result;
+}
+
+char *dt_variables_expand_path(dt_variables_params_t *params,
+                               gchar *source,
+                               const gboolean iterate)
+{
+  // G_DIR_SEPARATOR is a compile-time constant, so this costs nothing off
+  // Windows and both branches still get compiled everywhere
+  gchar *normalized = (G_DIR_SEPARATOR == '\\')
+    ? _normalize_separators(source)
+    : NULL;
+
+  char *result = dt_variables_expand(params,
+                                     normalized ? normalized : source,
+                                     iterate);
+  g_free(normalized);
+  return result;
+}
+
 void dt_variables_params_init(dt_variables_params_t **params)
 {
   *params = g_malloc0(sizeof(dt_variables_params_t));

--- a/src/common/variables.h
+++ b/src/common/variables.h
@@ -77,6 +77,14 @@ void dt_variables_set_tags_flags(dt_variables_params_t *params,
 char *dt_variables_expand(dt_variables_params_t *params,
                           gchar *source,
                           const gboolean iterate);
+/** expands variables in a string naming a filesystem path. on Windows '\' is
+    taken as a separator rather than an escape, so "D:\photos\$(YEAR)" keeps
+    both; "\/" still escapes a '/' inside $(VAR/pattern/replacement). use
+    dt_variables_expand() for patterns that are not paths. the result should
+    be freed with g_free(). */
+char *dt_variables_expand_path(dt_variables_params_t *params,
+                               gchar *source,
+                               const gboolean iterate);
 /** reset sequence number */
 void dt_variables_reset_sequence(dt_variables_params_t *params);
 

--- a/src/common/variables.h
+++ b/src/common/variables.h
@@ -77,9 +77,9 @@ void dt_variables_set_tags_flags(dt_variables_params_t *params,
 char *dt_variables_expand(dt_variables_params_t *params,
                           gchar *source,
                           const gboolean iterate);
-/** expands variables in a string naming a filesystem path. on Windows '\' is
-    taken as a separator rather than an escape, so "D:\photos\$(YEAR)" keeps
-    both; "\/" still escapes a '/' inside $(VAR/pattern/replacement). use
+/** expands variables in a string naming a filesystem path. on Windows '\\' is
+    taken as a separator rather than an escape, so "D:\\photos\\$(YEAR)" keeps
+    both; "\\/" still escapes a '/' inside $(VAR/pattern/replacement). use
     dt_variables_expand() for patterns that are not paths. the result should
     be freed with g_free(). */
 char *dt_variables_expand_path(dt_variables_params_t *params,

--- a/src/imageio/storage/disk.c
+++ b/src/imageio/storage/disk.c
@@ -386,7 +386,7 @@ try_again:
 
     if(variable_expand)
     {
-      gchar *result_filename = dt_variables_expand(d->vp, pattern, TRUE);
+      gchar *result_filename = dt_variables_expand_path(d->vp, pattern, TRUE);
       g_strlcpy(filename, result_filename, sizeof(filename));
       g_free(result_filename);
 

--- a/src/imageio/storage/gallery.c
+++ b/src/imageio/storage/gallery.c
@@ -283,7 +283,7 @@ int store(dt_imageio_module_storage_t *self,
   d->vp->imgid = imgid;
   d->vp->sequence = num;
 
-  gchar *result_tmp_dir = dt_variables_expand(d->vp, d->filename, TRUE);
+  gchar *result_tmp_dir = dt_variables_expand_path(d->vp, d->filename, TRUE);
   g_strlcpy(tmp_dir, result_tmp_dir, sizeof(tmp_dir));
   g_free(result_tmp_dir);
 
@@ -305,7 +305,7 @@ int store(dt_imageio_module_storage_t *self,
   g_strlcpy(d->filename, fixed_path, sizeof(d->filename));
   g_free(fixed_path);
 
-  gchar *result_filename = dt_variables_expand(d->vp, d->filename, TRUE);
+  gchar *result_filename = dt_variables_expand_path(d->vp, d->filename, TRUE);
   g_strlcpy(filename, result_filename, sizeof(filename));
   g_free(result_filename);
 

--- a/src/imageio/storage/latex.c
+++ b/src/imageio/storage/latex.c
@@ -265,7 +265,7 @@ int store(dt_imageio_module_storage_t *self, dt_imageio_module_data_t *sdata, co
     d->vp->imgid = imgid;
     d->vp->sequence = num;
 
-    gchar *result_filename = dt_variables_expand(d->vp, d->filename, TRUE);
+    gchar *result_filename = dt_variables_expand_path(d->vp, d->filename, TRUE);
     g_strlcpy(filename, result_filename, sizeof(filename));
     g_free(result_filename);
 

--- a/src/libs/neural_restore.c
+++ b/src/libs/neural_restore.c
@@ -1569,9 +1569,7 @@ static int32_t _process_job_run(dt_job_t *job)
     dt_variables_params_init(&vp);
     vp->filename = srcpath;
     vp->imgid = imgid;
-    char *out_dir = dt_variables_expand(vp,
-                                        (gchar *)dir_pattern,
-                                        FALSE);
+    char *out_dir = dt_variables_expand_path(vp, (gchar *)dir_pattern, FALSE);
     dt_variables_params_destroy(vp);
 
     // if basename already ends with the suffix, don't

--- a/src/tests/variables.c
+++ b/src/tests/variables.c
@@ -18,7 +18,11 @@ typedef struct test_t
   test_case_t test_cases[];
 } test_t;
 
-int run_test(const test_t *test, int *n_tests, int *n_failed)
+// the two entry points differ only in separator handling, so the cases run
+// through whichever one the caller passes
+typedef char *(*expand_fn_t)(dt_variables_params_t *, gchar *, const gboolean);
+
+int run_test(const test_t *test, int *n_tests, int *n_failed, expand_fn_t expand)
 {
   dt_variables_params_t *params;
   dt_variables_params_init(&params);
@@ -31,7 +35,7 @@ int run_test(const test_t *test, int *n_tests, int *n_failed)
   for(const test_case_t *test_case = test->test_cases; test_case->input; test_case++)
   {
     (*n_tests)++;
-    char *result = dt_variables_expand(params, test_case->input, FALSE);
+    char *result = expand(params, test_case->input, FALSE);
     if(g_strcmp0(result, test_case->expected_result))
     {
       (*n_failed)++;
@@ -45,6 +49,7 @@ int run_test(const test_t *test, int *n_tests, int *n_failed)
 
   return *n_failed > 0 ? 1 : 0;
 }
+
 
 static const test_t test_variables = {
   "abcdef12345abcdef", "ABCDEF12345ABCDEF", 23,
@@ -191,11 +196,45 @@ static const test_t test_real_paths = {
     int n_failed = 0, n_tests = 0;\
     n_test_functions++;\
     printf("running test '" #t "'\n");\
-    n_test_functions_failed += run_test(&t, &n_tests, &n_failed);\
+    n_test_functions_failed += run_test(&t, &n_tests, &n_failed, dt_variables_expand);\
     n_tests_overall += n_tests;\
     n_failed_overall += n_failed;\
     printf("%d / %d tests failed\n\n", n_failed, n_tests);\
 }
+
+#define TEST_PATH(test)\
+{\
+    printf("[%s]\n", #test);\
+    int n_tests, n_failed;\
+    n_test_functions++;\
+    if(run_test(&test, &n_tests, &n_failed, dt_variables_expand_path)) n_test_functions_failed++;\
+    n_tests_overall += n_tests;\
+    n_failed_overall += n_failed;\
+    printf("%d / %d tests failed\n\n", n_failed, n_tests);\
+}
+
+static const test_t test_paths = {
+  "/home/test/Images/IMG_0123.CR2", "/home/test/", 23,
+  {
+    // a path pattern must survive expansion, separators and all
+    {"$(FILE_FOLDER)/exported/$(FILE_NAME)",
+     "/home/test/Images/exported/IMG_0123"},
+    {"/home/test/$(JOBCODE)/img_$(SEQUENCE)",
+     "/home/test//home/test//img_0023"},
+    // "\/" escapes the delimiter inside a substitution and must mean the
+    // same on every platform, so normalization has to leave it alone
+    {"$(FILE_FOLDER/\\/home/X)", "X/test/Images"},
+#ifdef _WIN32
+    // the case this entry point exists for: separators survive, and so
+    // does the variable that a trailing separator would otherwise escape
+    {"D:\\photos\\$(FILE_NAME)", "D:/photos/IMG_0123"},
+    // every other backslash is a separator here, so it cannot also escape
+    {"foo\\$(bar", "foo/$(bar"},
+#endif
+
+    {NULL, NULL}
+  }
+};
 
 int main(int argc, char* argv[])
 {
@@ -218,6 +257,8 @@ int main(int argc, char* argv[])
   TEST(test_escapes)
 
   TEST(test_real_paths)
+
+  TEST_PATH(test_paths)
 
   printf("%d / %d tests failed (%d / %d)\n",
          n_failed_overall,


### PR DESCRIPTION
On Windows `\` is both the path separator and the escape character in variable expansion, so `D:\photos\$(FILE_NAME)` loses both: the file lands in `D:\` with a literal `$(FILE_NAME)` in its name.

Adds `dt_variables_expand_path()`, which normalizes separators to `/` before expanding, and uses it wherever the result is a filesystem path: export to disk, gallery, LaTeX, neural restore, and import sessions. Display text and bare filenames keep `dt_variables_expand()` and its escaping. Pass-through on other platforms.

The second commit fixes a pre-existing out-of-bounds read in the same expander, found while testing this one: `$(var/pattern` with no closing delimiter walked past the terminator, and the tests covering it only passed about nine times in ten.

One behaviour change on Windows: `\$` no longer escapes, because there it is the separator before a variable and the string alone cannot say which was meant. `\/` is left alone, so escaping a literal `/` inside `$(VAR/pattern/replacement)` still works.

Written with AI assistance.

Fixes #20981

Replaces #21245, which fixed three storage modules but not import sessions, and would have dropped `\` escaping on Windows.