### PR TITLE
highlights: fix out-of-bounds read converting v1/v2 params

### DIFF
--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -231,7 +231,6 @@ int legacy_params(dt_iop_module_t *self,
     {
       dt_iop_highlights_mode_t mode;
       float blendL, blendC, blendh;
-      float strength;
     } dt_iop_highlights_params_v1_t;
 
     const dt_iop_highlights_params_v1_t *o = (dt_iop_highlights_params_v1_t *)old_params;
@@ -259,7 +258,6 @@ int legacy_params(dt_iop_module_t *self,
     {
       dt_iop_highlights_mode_t mode;
       float blendL, blendC, blendh;
-      float strength;
       float clip;
     } dt_iop_highlights_params_v2_t;
 


### PR DESCRIPTION
Something I discovered while setting up a consistent way to run our integration test suite with various active GCC/clang sanitizers, such as address, undefined behaviour, mem leak and thread sanitizers (PR will follow soon): this is something which will be found in many integration test runs, as some of them use pretty old XMP sidecar files from darktable 2.0.0 - 3.6.0 versions.

The v1 and v2 legacy structs listed both 'blendh' and 'strength', but 'strength' is only the current struct's name for the slot v1-v3 called 'blendh', not an extra member. That made them 4 bytes larger than the data on disk (v1 16, v2 20, as shipped in 2.0.0 - 3.6.0), so legacy_params memcpy'd past the end of the allocation dt_iop_legacy_params sized from the stored blob.

The conversion result is unchanged: both branches immediately overwrite the fields the stray bytes land in, and glibc leaves 24 usable bytes in both allocations, so the read stays inside the chunk. That is allocator luck, not a guarantee, under a guard-page allocator it faults, and it aborts every AddressSanitizer run during history load for most of the old integration test XMP sidecar files.

Disclaimer: this change was co-created with Claude.