### PR TITLE
More tiling checks

### DIFF
--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -2395,8 +2395,8 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
     const gboolean no_tiling = fitter == DT_OPENCL_NO_TILING;
     const gboolean fast_tiling = fitter == DT_OPENCL_FAST_TILING
         && !memcmp(&roi_in, roi_out, sizeof(roi_in))
-        && !(module->flags() & (IOP_FLAGS_WRITE_RASTER | IOP_FLAGS_WRITE_DETAILS)
-        && may_tile); // fast tiling is not allowed if the piece doesn't support tiling
+        && !(module->flags() & (IOP_FLAGS_WRITE_RASTER | IOP_FLAGS_WRITE_DETAILS))
+        && may_tile; // fast tiling is not allowed if the piece doesn't support tiling
     const gboolean fits_on_device = no_tiling || fast_tiling;
 
     if(possible_cl && !fits_on_device && !may_tile)

--- a/src/iop/agx.c
+++ b/src/iop/agx.c
@@ -63,7 +63,7 @@ const char **description(dt_iop_module_t *self)
 
 int flags()
 {
-  return IOP_FLAGS_INCLUDE_IN_STYLES | IOP_FLAGS_SUPPORTS_BLENDING;
+  return IOP_FLAGS_INCLUDE_IN_STYLES | IOP_FLAGS_SUPPORTS_BLENDING | IOP_FLAGS_ALLOW_TILING;
 }
 
 int default_group()

--- a/src/iop/primaries.c
+++ b/src/iop/primaries.c
@@ -78,7 +78,7 @@ const char **description(dt_iop_module_t *self)
 
 int flags()
 {
-  return IOP_FLAGS_INCLUDE_IN_STYLES | IOP_FLAGS_SUPPORTS_BLENDING;
+  return IOP_FLAGS_INCLUDE_IN_STYLES | IOP_FLAGS_SUPPORTS_BLENDING | IOP_FLAGS_ALLOW_TILING;
 }
 
 int default_group()

--- a/src/iop/sigmoid.c
+++ b/src/iop/sigmoid.c
@@ -209,7 +209,7 @@ const char **description(dt_iop_module_t *self)
 
 int flags()
 {
-  return IOP_FLAGS_INCLUDE_IN_STYLES | IOP_FLAGS_SUPPORTS_BLENDING;
+  return IOP_FLAGS_INCLUDE_IN_STYLES | IOP_FLAGS_SUPPORTS_BLENDING | IOP_FLAGS_ALLOW_TILING;
 }
 
 int default_group()


### PR DESCRIPTION
**Fix logical typo for OpenCL fast tiling fitting check**

We may not tile if the `piece->tiling ready` flag is not `TRUE`. (This requires the `module->flags` including `IOP_FLAGS_ALLOW_TILING`)

**Fix some iop modules to support tiling**

The algorithm of these modules allow tiling mode both for OpenCL and CPU. A special `tiling_callback()` is not required as the default meets requirements. (As these modules have low mem requirements it was not evident performance-wise on most systems).

________________________________________________________________________________
I got aware of this via late comments by @kofa73 and his bots in  https://github.com/darktable-org/darktable/issues/22100#issuecomment-5536778528

And - yes - we must respect the `IOP_FLAGS_ALLOW_TILING` flag in all cases.

@TurboGit @masterpiga (colorharmoniter) @jandren (contrastntexture) @kofa73 (agx) @MStraeten, if any of us adds new iop modules we must always check
1. if the module algorithm supports tiling at all add `IOP_FLAGS_ALLOW_TILING`
2. possibly override this if OpenCL doesn't do that or other preconditions in `commit_params()`
3. check if a dedicated `tiling_callback()` is required
