### PR TITLE
gui: own the default main context while the gui is up

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -216,6 +216,11 @@ changes (where available).
   sliders and comboboxes themselves, instead of only shrinking their
   font.
 
+- Fixed random crashes while starting up, mostly seen while the splash
+  screen was still showing, where a Lua script or a background task
+  could build and rearrange interface elements from its own thread
+  while the main window was still being assembled.
+
 ## Lua
 
 ### API Version

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1704,6 +1704,15 @@ int dt_init(int argc,
   {
     gtk_init(&argc, &argv);
 
+    /* own the default main context for the life of the gui: glib runs a
+     * g_main_context_invoke() callback in the calling thread when it can
+     * acquire the context, so a job or Lua thread would otherwise touch
+     * widgets while dt_init() builds the main window.  released in dt_cleanup() */
+    if(!g_main_context_acquire(g_main_context_default()))
+      dt_print(DT_DEBUG_ALWAYS,
+               "[dt_init] could not acquire the default main context,"
+               " gui calls from worker threads will not be serialized");
+
     darktable.themes = NULL;
     dt_gui_theme_init(darktable.gui);
 
@@ -2332,6 +2341,11 @@ void dt_cleanup()
 5. After dt_control_shutdown() has finished we are sure there are no background threads running any
      more so we can safely close all mentioned subsystems and continue.
 */
+    /* release before joining the threads: nothing pumps the loop from here on,
+     * so a thread waiting for marshalled gui work could never be joined */
+    if(g_main_context_is_owner(g_main_context_default()))
+      g_main_context_release(g_main_context_default());
+
     dt_control_shutdown();
   }
 #ifdef USE_LUA


### PR DESCRIPTION
g_main_context_invoke() runs its callback in the calling thread whenever it can acquire the context. During dt_init() the gui thread holds the context only inside dt_gui_process_events(), so Lua and job threads built and reparented widgets in parallel with the main window being assembled, crashing at random during startup.

Acquire the context after gtk_init() and release it before dt_control_shutdown() joins the worker threads.

Speculatively fixes #21996

AppImages for testing: https://github.com/da-phil/darktable/actions/runs/33894515106#artifacts

Disclaimer: this change was co-created with Claude.