### PR TITLE
control: free the history job data when no job takes it over

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -216,6 +216,9 @@ changes (where available).
   sliders and comboboxes themselves, instead of only shrinking their
   font.
 
+- Fixed a small memory leak each time a history stack was pasted onto the
+  image open in darkroom.
+
 ## Lua
 
 ### API Version

--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -2564,8 +2564,14 @@ static void _add_history_job_data(const char *title,
                                   dt_job_execute_callback execute,
                                   _images_job_data_t *images_job_data)
 {
+  // nothing below will take ownership of the data
   if(!images_job_data->imgs || !execute)
+  {
+    g_list_free(images_job_data->imgs);
+    g_list_free(images_job_data->styles);
+    g_free(images_job_data);
     return;
+  }
 
   GList *link = darktable.develop
     ? g_list_find(images_job_data->imgs,
@@ -2596,6 +2602,14 @@ static void _add_history_job_data(const char *title,
                        _control_generic_images_job_create(execute, title, 0,
                                                           (gpointer)images_job_data,
                                                           PROGRESS_BLOCKING, FALSE));
+  }
+  else
+  {
+    // nothing left for a job either. the strings behind styles belong to
+    // the job above, which shallow-copied them
+    g_list_free(images_job_data->imgs);
+    g_list_free(images_job_data->styles);
+    g_free(images_job_data);
   }
 }
 


### PR DESCRIPTION
`_add_history_job_data()` takes ownership of the caller's `_images_job_data_t`, which the job run functions release with `g_free(params->data)`. Two paths create no job at all, so nothing took it over: the early return on an empty list, and the case where the image open in darkroom was the whole list, leaving nothing for the asynchronous job. Both are ordinary in darkroom, where `dt_act_on_*` resolves to the edited image alone, or to nothing when the pointer is over a panel — so every `Ctrl+V` there leaked the struct. Only 24 bytes per paste, so nobody will have noticed.

Written with AI assistance.