### PR TITLE
Pipe data change responsiveness

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -284,19 +284,25 @@ void dt_dev_cleanup(dt_develop_t *dev)
   g_list_free(dev->module_filter_out);
 }
 
+/** How do we handle UI responsiveness for pipes getting a changed parameter?
+    1. We know from pixelpipe started_time when last piperun started
+    2. For fast UI visualizing of processed pipe data we don't shutdown a running
+       pipe if the timespan from last start is less than half of averaged pipe runtime.
+       This possibly avoids superfluous piperuns thus less cache pressure.
+    3. Otherwise it's worth to do a shutdown to avoid further processing.
+*/
+static inline gboolean _inside_pipe_ui_frame(const dt_dev_pixelpipe_t *pipe)
+{
+  const gint64 elapsed = g_get_monotonic_time() - pipe->started_time;
+  return elapsed < pipe->average_delay/2;
+}
+
 void dt_dev_process_image(dt_develop_t *dev)
 {
   if(!dev->gui_attached) return;
   if(dt_pipe_processing(dev->full.pipe))
   {
-    /*  A pipe DT_DEV_PIXELPIPE_STOP_DATA shutdown is the fastest way to get the final
-        processed result presented in the main canvas (or second window as below) but
-        the user won't "see" any results while dragging a mouse slider.
-        Instead of using a timeout we simply use the old behaviour - no forced shutdown -
-        while the left mouse button is pressed (as when dragging a slider) but stay with
-        the faster shutdown system when using clicks as via a mouse scroll wheel.
-    */
-    if(dt_key_modifier_state() & GDK_BUTTON1_MASK)
+    if(_inside_pipe_ui_frame(dev->full.pipe))
       return;
     else
       dt_dev_pixelpipe_set_shutdown(dev->full.pipe, DT_DEV_PIXELPIPE_STOP_DATA);
@@ -318,7 +324,7 @@ void dt_dev_process_preview2(dt_develop_t *dev)
   if(!dev->gui_attached && !dev->preview2.widget) return;
   if(dt_pipe_processing(dev->preview2.pipe))
   {
-    if(dt_key_modifier_state() & GDK_BUTTON1_MASK)
+    if(_inside_pipe_ui_frame(dev->preview2.pipe))
       return;
     else
       dt_dev_pixelpipe_set_shutdown(dev->preview2.pipe, DT_DEV_PIXELPIPE_STOP_DATA);


### PR DESCRIPTION
As discussed multiple times (see late intensive discussion in #22104) we want a different pipe restart-behavior for UI responsiveness while changed parameters lead to a pipe restart.

EDITED after 73ac60224595ec29fc017b692ca1473de361a8af
We now use a timeslot based approach, the timeslot is based on averaged  pixelpipe runtimes.

Fixes #22104

comments after testing would be appreciated.