### PR TITLE
Various pixelpipe timing fixes

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -50,7 +50,12 @@
 #include "lua/call.h"
 #endif
 
-#define DT_DEV_AVERAGE_DELAY_COUNT 5
+/** The averaged time for a pipe run is calculated over DT_DEV_AVERAGE_DELAY_COUNT
+    runs and is kept in pipe->average_delay (microseconds)
+    With improved pipe caching this got bumped from 5 to 8 reducing effect of very
+    fast runs while editing.
+*/
+#define DT_DEV_AVERAGE_DELAY_COUNT 8
 
 // Margins (as a fraction of the image size) by which the editable "canvas" may
 // extend beyond the image while working on a mask, so off-image content can be
@@ -614,14 +619,11 @@ void dt_dev_invalidate_preview(dt_develop_t *dev)
     dev->preview2.pipe->input_timestamp = dev->timestamp;
 }
 
-static void _dev_average_delay_update(const dt_times_t *start,
-                                      uint32_t *average_delay)
+static void _dev_average_delay_update(gint64 elapsed,
+                                      gint64 *average_delay)
 {
-  dt_times_t end;
-  dt_get_times(&end);
-
-  *average_delay += ((end.clock - start->clock) * 1000 / DT_DEV_AVERAGE_DELAY_COUNT
-                     - *average_delay / DT_DEV_AVERAGE_DELAY_COUNT);
+  *average_delay += elapsed / DT_DEV_AVERAGE_DELAY_COUNT
+                     - *average_delay / DT_DEV_AVERAGE_DELAY_COUNT;
 }
 
 void dt_dev_pixelpipe_stop_and_lock_all(dt_develop_t *dev)
@@ -877,8 +879,8 @@ restart:
   const int x = port ? CLAMP(pipe_width  * (.5 + zoom_x) - wd / 2, 0, pipe_width  - wd) : 0;
   const int y = port ? CLAMP(pipe_height * (.5 + zoom_y) - ht / 2, 0, pipe_height - ht) : 0;
 
-  dt_get_times(&start);
-
+  dt_get_perf_times(&start);
+  pipe->started_time = g_get_monotonic_time();
   const gboolean early = dt_dev_pixelpipe_process(pipe, dev, x, y, wd, ht, scale, devid);
   const dt_dev_pixelpipe_stopper_t shutdown = dt_atomic_exch_int(&pipe->shutdown, DT_DEV_PIXELPIPE_STOP_NO);
   const gboolean stopped = early || shutdown > DT_DEV_PIXELPIPE_PROCESSING;
@@ -951,11 +953,16 @@ restart:
     }
   }
 
-  dt_print_pipe(DT_DEBUG_PIPE, "process_image_job done", pipe, NULL, DT_DEVICE_NONE, &proi, NULL, "\n");
   dt_show_times_f(&start,
                   "[dev_process_image] pixel pipeline", "processing `%s'",
                   dev->image_storage.filename);
-  _dev_average_delay_update(&start, &pipe->average_delay);
+
+  const gint64 elapsed = MAX(0, g_get_monotonic_time() - pipe->started_time);
+  _dev_average_delay_update(elapsed, &pipe->average_delay);
+
+  dt_print_pipe(DT_DEBUG_PIPE, "process_image_job done",
+    pipe, NULL, DT_DEVICE_NONE, &proi, NULL, "took %dms, average=%dms\n",
+    (int)elapsed / 1000, (int)pipe->average_delay / 1000);
 
   pipe->status = DT_DEV_PIXELPIPE_VALID;
   pipe->loading = FALSE;

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -188,7 +188,6 @@ typedef struct dt_develop_t
   double autosave_time;
   int32_t image_invalid_cnt;
   uint32_t timestamp;
-  uint32_t preview_average_delay;
   struct dt_iop_module_t *gui_module; // this module claims gui expose/event callbacks.
   struct dt_iop_module_t *header_buttons_module; // module whose header buttons are currently shown (if any)
 

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -44,6 +44,7 @@
 #include <strings.h>
 #include <unistd.h>
 
+// initial values for pipe->average_delay, these are in ms
 #define DT_DEV_AVERAGE_DELAY_START 250
 #define DT_DEV_PREVIEW_AVERAGE_DELAY_START 50
 
@@ -204,6 +205,11 @@ void dt_print_pipe_ext(const char *title,
                vtit, dev, pname, vmod, order, roi, roo, masking, vbuf);
 }
 
+static gboolean _dev_pixelpipe_init_cached(dt_dev_pixelpipe_t *pipe,
+                                           const size_t size,
+                                           const int32_t entries,
+                                           const int32_t fraction,
+                                           const uint32_t delay);
 gboolean dt_dev_pixelpipe_init_export(dt_dev_pixelpipe_t *pipe,
                                       const int32_t width,
                                       const int32_t height,
@@ -211,7 +217,7 @@ gboolean dt_dev_pixelpipe_init_export(dt_dev_pixelpipe_t *pipe,
                                       const gboolean store_masks)
 {
   const gboolean res =
-    dt_dev_pixelpipe_init_cached(pipe, sizeof(float) * 4 * width * height, DT_PIPECACHE_MIN, 0);
+    _dev_pixelpipe_init_cached(pipe, sizeof(float) * 4 * width * height, DT_PIPECACHE_MIN, 0, 1);
   pipe->type = DT_DEV_PIXELPIPE_EXPORT;
   pipe->levels = levels;
   pipe->store_all_raster_masks = store_masks;
@@ -223,7 +229,7 @@ gboolean dt_dev_pixelpipe_init_thumbnail(dt_dev_pixelpipe_t *pipe,
                                          const int32_t height)
 {
   const gboolean res =
-    dt_dev_pixelpipe_init_cached(pipe, sizeof(float) * 4 * width * height, DT_PIPECACHE_MIN, 0);
+    _dev_pixelpipe_init_cached(pipe, sizeof(float) * 4 * width * height, DT_PIPECACHE_MIN, 0, 1);
   pipe->type = DT_DEV_PIXELPIPE_THUMBNAIL;
   return res;
 }
@@ -233,42 +239,40 @@ gboolean dt_dev_pixelpipe_init_dummy(dt_dev_pixelpipe_t *pipe,
                                      const int32_t height)
 {
   const gboolean res =
-    dt_dev_pixelpipe_init_cached(pipe, sizeof(float) * 4 * width * height, 0, 0);
+    _dev_pixelpipe_init_cached(pipe, sizeof(float) * 4 * width * height, 0, 0, DT_DEV_AVERAGE_DELAY_START);
   pipe->type = DT_DEV_PIXELPIPE_THUMBNAIL;
-  pipe->average_delay = DT_DEV_AVERAGE_DELAY_START;
   return res;
 }
 
 gboolean dt_dev_pixelpipe_init_preview(dt_dev_pixelpipe_t *pipe)
 {
   const gboolean res =
-    dt_dev_pixelpipe_init_cached(pipe, 0, darktable.pipe_cache ? 12 : DT_PIPECACHE_MIN, 32);
+    _dev_pixelpipe_init_cached(pipe, 0, darktable.pipe_cache ? 12 : DT_PIPECACHE_MIN, 32, DT_DEV_PREVIEW_AVERAGE_DELAY_START);
   pipe->type = DT_DEV_PIXELPIPE_PREVIEW;
-  pipe->average_delay = DT_DEV_PREVIEW_AVERAGE_DELAY_START;
   return res;
 }
 
 gboolean dt_dev_pixelpipe_init_preview2(dt_dev_pixelpipe_t *pipe)
 {
   const gboolean res =
-    dt_dev_pixelpipe_init_cached(pipe, 0, darktable.pipe_cache ? 5 : DT_PIPECACHE_MIN, 32);
+    _dev_pixelpipe_init_cached(pipe, 0, darktable.pipe_cache ? 5 : DT_PIPECACHE_MIN, 32, DT_DEV_AVERAGE_DELAY_START);
   pipe->type = DT_DEV_PIXELPIPE_PREVIEW2;
-  pipe->average_delay = DT_DEV_PREVIEW_AVERAGE_DELAY_START;
   return res;
 }
 
 gboolean dt_dev_pixelpipe_init(dt_dev_pixelpipe_t *pipe)
 {
   const gboolean res =
-    dt_dev_pixelpipe_init_cached(pipe, 0, darktable.pipe_cache ? 64 : DT_PIPECACHE_MIN, 8);
+    _dev_pixelpipe_init_cached(pipe, 0, darktable.pipe_cache ? 64 : DT_PIPECACHE_MIN, 8, DT_DEV_AVERAGE_DELAY_START);
   pipe->type = DT_DEV_PIXELPIPE_FULL;
   return res;
 }
 
-gboolean dt_dev_pixelpipe_init_cached(dt_dev_pixelpipe_t *pipe,
-                                      const size_t size,
-                                      const int32_t entries,
-                                      const int32_t fraction)
+static gboolean _dev_pixelpipe_init_cached(dt_dev_pixelpipe_t *pipe,
+                                           const size_t size,
+                                           const int32_t entries,
+                                           const int32_t fraction,
+                                           const uint32_t delay)
 {
   pipe->devid = DT_DEVICE_CPU;
   pipe->loading = FALSE;
@@ -293,6 +297,7 @@ gboolean dt_dev_pixelpipe_init_cached(dt_dev_pixelpipe_t *pipe,
   pipe->tiling = FALSE;
   pipe->mask_display = DT_DEV_PIXELPIPE_DISPLAY_NONE;
   pipe->bypass_blendif = FALSE;
+  pipe->average_delay = 1000 * delay;
   pipe->input_timestamp = 0;
   pipe->levels = IMAGEIO_RGB | IMAGEIO_INT8;
   dt_pthread_mutex_init(&pipe->mutex, NULL);

--- a/src/develop/pixelpipe_hb.h
+++ b/src/develop/pixelpipe_hb.h
@@ -242,7 +242,7 @@ typedef struct dt_dev_pixelpipe_t
   gboolean bypass_blendif;
   // input data based on this timestamp:
   int input_timestamp;
-  uint32_t average_delay;
+  gint64 average_delay;
   dt_dev_pixelpipe_type_t type;
   // the final output pixel format this pixelpipe will be converted to
   dt_imageio_levels_t levels;
@@ -272,6 +272,7 @@ typedef struct dt_dev_pixelpipe_t
   size_t mask_distort_buf_size[2];
   // sum of all per-piece detail/raster mask caches currently allocated in this pipe
   size_t mask_cache_size;
+  gint64 started_time; // monotonic timestamp (in microseconds) when the pipe started
 } dt_dev_pixelpipe_t;
 
 struct dt_develop_t;
@@ -370,12 +371,6 @@ gboolean dt_dev_pixelpipe_init_thumbnail(dt_dev_pixelpipe_t *pipe,
 gboolean dt_dev_pixelpipe_init_dummy(dt_dev_pixelpipe_t *pipe,
                                      const int32_t width,
                                      const int32_t height);
-// inits the pixelpipe with given cacheline size and number of
-// entries. returns TRUE in case of success
-gboolean dt_dev_pixelpipe_init_cached(dt_dev_pixelpipe_t *pipe,
-                                      const size_t size,
-                                      const int32_t entries,
-                                      const int32_t fraction);
 // returns available memory for the pipe
 size_t dt_get_available_pipe_mem(const dt_dev_pixelpipe_t *pipe);
 // constructs a new input buffer from given RGB float array.

--- a/src/dtgtk/gradientslider.c
+++ b/src/dtgtk/gradientslider.c
@@ -97,7 +97,7 @@ static gboolean _gradient_slider_postponed_value_change(gpointer data)
   if(!DTGTK_GRADIENT_SLIDER(data)->is_dragging) DTGTK_GRADIENT_SLIDER(data)->timeout_handle = 0;
   else
   {
-    const int delay = CLAMP(darktable.develop->full.pipe->average_delay * 3 / 2,
+    const int delay = CLAMP(darktable.develop->full.pipe->average_delay * 3 / 2000,
                             DTGTK_GRADIENT_SLIDER_VALUE_CHANGED_DELAY_MIN,
                             DTGTK_GRADIENT_SLIDER_VALUE_CHANGED_DELAY_MAX);
     DTGTK_GRADIENT_SLIDER(data)->timeout_handle = g_timeout_add(delay, _gradient_slider_postponed_value_change, data);
@@ -355,10 +355,14 @@ static void _gradient_slider_button_pressed(GtkGestureSingle *gesture,
 
       gslider->is_changed = TRUE;
       gslider->is_dragging = TRUE;
-      // timeout_handle should always be zero here, but check just in case
-      const int delay = CLAMP(darktable.develop->full.pipe->average_delay * 3 / 2,
+
+      /** We modify the slider's timeout_handle setting it to 150% of average_delay of the full pipe.
+          Note that g_timeout_add() delay is in ms and average_delay in microseconds!
+      */
+      const int delay = CLAMP(darktable.develop->full.pipe->average_delay * 3 / 2000,
                               DTGTK_GRADIENT_SLIDER_VALUE_CHANGED_DELAY_MIN,
                               DTGTK_GRADIENT_SLIDER_VALUE_CHANGED_DELAY_MAX);
+      // timeout_handle should always be zero here, but check just in case
       if(!gslider->timeout_handle)
         gslider->timeout_handle = g_timeout_add(delay, _gradient_slider_postponed_value_change, widget);
     }


### PR DESCRIPTION
1. The full pipe had no average_delay set as DT_DEV_AVERAGE_DELAY_START thus `_dev_average_delay_update()` and it's users (gradientslider for now) was broken.
2. As `_dev_pixelpipe_init_cached()` is local to `pixelpipe_hb` it's made static and it also initializes `average_delay`
3. Avoid the costly `dt_get_times()` for pipe delay updating and use `g_get_monotonic_time()` instead
4. keep pipe started time in the pipe struct and report pipe processed time and average via `-d pipe` logs.
5. `dev->preview_average_delay` was used nowhere in code so it got removed.
6. Use `DT_DEV_AVERAGE_DELAY_START` for preview2 pipe as that's certainly better
7. Internal averaging is done in `gint64` instead of `uint32_t`

Pre-requisite for proper UI smoothness following via #22148

@TurboGit the incorrectness of full pipe average delay was certainly a bug but was kept under control via range check in gradientslider
@ralfbrown yes, that averaged delay for full pipe was broken :-)
