### PR TITLE
spektrafilm: fix cpu vs gpu discrepancies

### DIFF
--- a/data/kernels/spektrafilm.cl
+++ b/data/kernels/spektrafilm.cl
@@ -45,6 +45,24 @@
  *   - exact-spectral quality has NO GPU path; process_cl falls back to CPU.
  */
 
+/* OpenCL C defaults FP_CONTRACT to ON, so the device compiler is free to fuse
+   every a*b+c in this file into a single-rounding mad/fma. The host side is
+   not fused the same way (and on some builds not at all), so each fused
+   expression lands a fraction of an ULP away from its CPU twin. That is
+   normally invisible, but sf_poisson()'s accept/reject loop compares prod
+   against limit, so a fraction of an ULP anywhere upstream of the grain
+   sampler occasionally moves a draw by a whole integer -- which is what the
+   remaining CPU/GPU pixel differences look like: isolated single pixels,
+   evenly scattered, uncorrelated with image structure.
+
+   NOTE: the matching host-side guarantee is NOT the "#pragma STDC
+   FP_CONTRACT OFF" in spektra_core.h. GCC does not implement that pragma
+   (it still emits vfmadd with it in force); only the -ffp-contract=off
+   command-line flag works, which is why the CMake change accompanying this
+   sets it on the spektra sources. Both halves are needed. */
+#pragma OPENCL FP_CONTRACT OFF
+
+
 #include "common.h"
 
 #define SF_NLE 256
@@ -69,11 +87,18 @@ static inline float sf_clampf(float x, float lo, float hi)
   return fmin(fmax(x, lo), hi);
 }
 
+/* Explicit fma, same nesting as the host twins (mat3_mulv_f in spektra_sim.c,
+   expose_pixel_f's inline form). The device compiler ignores
+   #pragma OPENCL FP_CONTRACT OFF -- that is why pinning the YvV recursion
+   with fma() moved the needle where the pragma alone did not -- while the
+   host really does honour -ffp-contract=off. So a bare a*b + c*d + e*f is
+   fused on one side and not the other, and every matrix multiply in the
+   pipeline lands a fraction of an ULP away from its twin. */
 static inline float3 sf_mat3(__constant const float *m, float3 v)
 {
-  return (float3)(m[0] * v.x + m[1] * v.y + m[2] * v.z,
-                  m[3] * v.x + m[4] * v.y + m[5] * v.z,
-                  m[6] * v.x + m[7] * v.y + m[8] * v.z);
+  return (float3)(fma(m[0], v.x, fma(m[1], v.y, m[2] * v.z)),
+                  fma(m[3], v.x, fma(m[4], v.y, m[5] * v.z)),
+                  fma(m[6], v.x, fma(m[7], v.y, m[8] * v.z)));
 }
 
 /* ---- [su] Mitchell-Netravali cubic on the tc_n×tc_n×3 spectral LUT ------ */
@@ -82,14 +107,16 @@ static float sf_mitchell(float t)
 {
   const float B = 1.0f / 3.0f, C = 1.0f / 3.0f;
   const float x = fabs(t);
+  /* fma-pinned, matching mitchell_weight_f() in spektra_sim.c term for term */
   if(x < 1.0f)
     return (1.0f / 6.0f)
-           * ((12.0f - 9.0f * B - 6.0f * C) * x * x * x
-              + (-18.0f + 12.0f * B + 6.0f * C) * x * x + (6.0f - 2.0f * B));
+           * fma((12.0f - 9.0f * B - 6.0f * C) * x * x, x,
+                 fma((-18.0f + 12.0f * B + 6.0f * C) * x, x, (6.0f - 2.0f * B)));
   else if(x < 2.0f)
     return (1.0f / 6.0f)
-           * ((-B - 6.0f * C) * x * x * x + (6.0f * B + 30.0f * C) * x * x
-              + (-12.0f * B - 48.0f * C) * x + (8.0f * B + 24.0f * C));
+           * fma((-B - 6.0f * C) * x * x, x,
+                 fma((6.0f * B + 30.0f * C) * x, x,
+                     fma((-12.0f * B - 48.0f * C), x, (8.0f * B + 24.0f * C))));
   return 0.0f;
 }
 
@@ -136,18 +163,29 @@ static float3 sf_cubic2d(__global const float *lut, int L, float x, float y)
       const float w = wx[i] * wy[j];
       wsum += w;
       const size_t o = ((size_t)xi * L + yj) * 3;
-      acc += w * (float3)(lut[o], lut[o + 1], lut[o + 2]);
+      /* fma, matching cubic_interp_2d_f()'s acc[c] += w * px[c] under
+         -ffp-contract=off ... see sf_mat3 above */
+      acc = (float3)(fma(w, lut[o], acc.x), fma(w, lut[o + 1], acc.y),
+                     fma(w, lut[o + 2], acc.z));
     }
   }
   return (wsum != 0.0f) ? acc / wsum : acc;
 }
 
 /* ---- [dc] density curve interpolation over the uniform le grid ---------- */
-/* x-axis = le/gamma  ->  index t = (x*gamma - le0)/le_step, endpoint-clamped */
+/* x-axis = le/gamma  ->  index t = (x*gamma - le0)*inv_le_step, endpoint-clamped.
+
+   inv_le_step is the host's sim->inv_le_step (1/le_step, rounded once from a
+   double-precision reciprocal) -- NOT recomputed on-device, and not a divide.
+   The CPU twin (interp_curve_uniform_f in spektra_sim.c) multiplies by that
+   same stored reciprocal, and x/step vs x*(1/step) differ by up to an ULP,
+   which is enough to land t on the other side of an integer and pick the
+   neighbouring curve segment. Same reasoning as enl_inv_range/scan_inv_range
+   in spektrafilm_print_expose below. */
 static inline float sf_curve(__global const float *curves, float x,
-                             float le0, float le_step, int c)
+                             float le0, float inv_le_step, int c)
 {
-  const float t = (x - le0) / le_step;
+  const float t = (x - le0) * inv_le_step;
   if(t <= 0.0f) return curves[c];
   if(t >= (float)(SF_NLE - 1)) return curves[(SF_NLE - 1) * 3 + c];
   const int i = (int)t;
@@ -206,6 +244,31 @@ static float3 sf_pchip3d(__global const float *lut, __global const float *sx,
   }
 #undef AT
   return (float3)(out[0], out[1], out[2]);
+}
+
+/* ---- base-10 <-> base-2, matching the host's SF_LOG10F/SF_POW10F -------- */
+/* spektra_sim.c does NOT call log10f()/exp10f(). It defines
+     SF_LOG10F(x) = log2f(x) * 0.3010299956639812f
+     SF_POW10F(x) = exp2f(x * 3.321928094887362f)
+   so calling log10()/exp10() here was not a more-or-less accurate version of
+   the same computation, it was a different computation: the host's scaling
+   multiply carries its own rounding that exp10()/log10() never perform. Use
+   the identical formulation so only the library ULP gap remains.
+
+   That remaining gap is real but small: OpenCL specs log2/exp2 to <=3 ULP and
+   most GPUs implement both in hardware, while glibc's log2f/exp2f are
+   correctly rounded. If the integration test still shows a residue after
+   this, these two are the next candidates for the portable-polynomial
+   treatment sf_exp_neg already got -- log2 via exponent extraction plus a
+   mantissa polynomial, exp2 via sf_exp2i plus a fractional polynomial. */
+static inline float sf_log10f(float x)
+{
+  return log2(x) * 0.3010299956639812f;
+}
+
+static inline float sf_pow10f(float x)
+{
+  return exp2(x * 3.321928094887362f);
 }
 
 /* ---- [gc] Reinhard knee + OkLCh output gamut compression ---------------- */
@@ -288,12 +351,40 @@ static inline uint sf_pixel_seed(uint xi, uint yi, uint chan)
 /* Single Poisson draw; must stay in lockstep with sf_poisson in spektra_core.h
    (exact below 12, bounded normal above -- see the derivation there). */
 #define SF_POISSON_EXACT_MAX 12.0f
+
+/* sf_exp2i / sf_exp_neg: see spektra_core.h for the full rationale -- this
+   must be the same portable polynomial as the host side, not the platform
+   exp(), because exp() is only spec'd to <=3 ULP here versus the
+   correctly-rounded +,-,* this is built from, and that slack was flipping
+   the accept/reject loop below by a whole grain-count draw on a small,
+   scene-independent fraction of pixels. Do not replace this with exp()
+   or native_exp() again without re-checking that regression. */
+static inline float sf_exp2i(int k)
+{
+  return as_float((uint)(k + 127) << 23);
+}
+
+static inline float sf_exp_neg(float lam)
+{
+  const float t = -lam;
+  const int k = (int)floor(t * 1.4426950216293335f + 0.5f); /* log2(e) */
+  const float r = t - (float)k * 0.6931471824645996f;       /* ln(2) */
+  float p = 0.00138888892f;                                 /* 1/720 */
+  p = p * r + 0.00833333377f;                               /* 1/120 */
+  p = p * r + 0.0416666679f;                                /* 1/24 */
+  p = p * r + 0.166666672f;                                 /* 1/6 */
+  p = p * r + 0.5f;
+  p = p * r + 1.0f;
+  p = p * r + 1.0f;
+  return p * sf_exp2i(k);
+}
+
 static float sf_poisson(float lam, uint seed)
 {
   if(lam <= 0.f) return 0.f;
   if(lam < SF_POISSON_EXACT_MAX)
   {
-    const float limit = exp(-lam);
+    const float limit = sf_exp_neg(lam);
     float prod = 1.f;
     int k = 0;
     do
@@ -303,7 +394,13 @@ static float sf_poisson(float lam, uint seed)
     } while(prod > limit && k < 64);
     return (float)(k - 1);
   }
-  return lam + native_sqrt(lam) * sf_nrm(seed);
+  /* Plain sqrt(), not native_sqrt(): this branch must reproduce the CPU's
+     sqrtf(lam) bit-for-bit (see spektra_core.h's sf_poisson and the
+     sf_exp_neg comment above on why exactness here matters) -- native_sqrt
+     has no accuracy guarantee at all and commonly maps to a low-precision
+     hardware rsqrt, which was decorrelating the two renders' grain for
+     every pixel landing in this branch (lam >= SF_POISSON_EXACT_MAX). */
+  return lam + sqrt(lam) * sf_nrm(seed);
 }
 
 /* Binomial(Poisson(lam), p) == Poisson(lam*p) exactly (Poisson thinning), so the
@@ -355,9 +452,9 @@ __kernel void spektrafilm_lograw(__global float4 *plane, const int w, const int 
   if(x >= w || y >= h) return;
   const size_t k = (size_t)y * w + x;
   float4 p = plane[k];
-  p.x = log10(fmax(p.x, 0.0f) + SF_LOG_EPS);
-  p.y = log10(fmax(p.y, 0.0f) + SF_LOG_EPS);
-  p.z = log10(fmax(p.z, 0.0f) + SF_LOG_EPS);
+  p.x = sf_log10f(fmax(p.x, 0.0f) + SF_LOG_EPS);
+  p.y = sf_log10f(fmax(p.y, 0.0f) + SF_LOG_EPS);
+  p.z = sf_log10f(fmax(p.z, 0.0f) + SF_LOG_EPS);
   plane[k] = p;
 }
 
@@ -367,9 +464,9 @@ __kernel void spektrafilm_develop_corr(__global const float4 *lograw, __global f
                                        const int w, const int h,
                                        __global const float *curves_norm,
                                        __constant float *mats, const float le0,
-                                       const float le_step, const float dmax0,
+                                       const float inv_le_step, const float dmax0,
                                        const float dmax1, const float dmax2,
-                                       const int positive)
+                                       const int positive, const int donor_lm)
 {
   const int x = get_global_id(0), y = get_global_id(1);
   if(x >= w || y >= h) return;
@@ -380,11 +477,23 @@ __kernel void spektrafilm_develop_corr(__global const float4 *lograw, __global f
   float silver[3];
   for(int c = 0; c < 3; c++)
   {
-    const float d = sf_curve(curves_norm, lgv[c], le0, le_step, c);
+    const float d = sf_curve(curves_norm, lgv[c], le0, inv_le_step, c);
     silver[c] = positive ? dmx[c] - d : d;
-    /* Langmuir donor saturation (dev packs); K=1e30 degenerates to linear */
-    const float K = mats[SF_M_LM_DONOR + c], Dref = mats[SF_M_LM_DONOR + 3 + c];
-    silver[c] = silver[c] * (K + Dref) / (K + silver[c]);
+    /* Langmuir donor saturation (dev packs). Gated on donor_lm, exactly as
+       sf_sim_develop_corr() gates it on sim->couplers_donor_lm.
+
+       This used to run unconditionally, relying on the host shipping K=1e30
+       to make the expression "degenerate to linear". It does not: the term
+       evaluates as (silver * 1e30f) / 1e30f, and x*y/y is not x in float --
+       13.6% of plausible silver values in [0,3] come back one ULP off. Every
+       pixel of the coupler correction was therefore slightly wrong whenever
+       the loaded pack has no donor Langmuir term, which the grain sampler
+       downstream then amplified into whole-integer draw differences. */
+    if(donor_lm)
+    {
+      const float K = mats[SF_M_LM_DONOR + c], Dref = mats[SF_M_LM_DONOR + 3 + c];
+      silver[c] = silver[c] * (K + Dref) / (K + silver[c]);
+    }
   }
   __constant const float *M = mats + SF_M_COUPLERS; /* row donor -> col receiver */
   float out[3];
@@ -399,24 +508,28 @@ __kernel void spektrafilm_develop(__global const float4 *lograw, __global const 
                                   const int use_corr, __global float4 *cmy, const int w,
                                   const int h, __global const float *curves,
                                   __constant float *mats, const float le0,
-                                  const float le_step)
+                                  const float inv_le_step, const int recv_lm)
 {
   const int x = get_global_id(0), y = get_global_id(1);
   if(x >= w || y >= h) return;
   const size_t k = (size_t)y * w + x;
   const float4 lg = lograw[k];
   float4 cr = use_corr ? corr[k] : (float4)(0.0f);
-  /* receiver-side Langmuir on the ARRIVED (post-diffusion) inhibitor;
-     Kr=1e30 degenerates to linear */
+  /* receiver-side Langmuir on the ARRIVED (post-diffusion) inhibitor. Gated
+     on use_corr && recv_lm, matching sf_sim_develop()'s
+     `if(cr && sim->couplers_recv_lm)`. See the donor-side comment in
+     spektrafilm_develop_corr above for why the Kr=1e30 sentinel was not the
+     no-op it was assumed to be. */
   float crv[3] = { cr.x, cr.y, cr.z };
-  for(int c = 0; c < 3; c++)
-  {
-    const float Kr = mats[SF_M_LM_RECV + c], cref = mats[SF_M_LM_RECV + 3 + c];
-    crv[c] = crv[c] * (Kr + cref) / (Kr + crv[c]);
-  }
+  if(use_corr && recv_lm)
+    for(int c = 0; c < 3; c++)
+    {
+      const float Kr = mats[SF_M_LM_RECV + c], cref = mats[SF_M_LM_RECV + 3 + c];
+      crv[c] = crv[c] * (Kr + cref) / (Kr + crv[c]);
+    }
   const float lgv[3] = { lg.x - crv[0], lg.y - crv[1], lg.z - crv[2] };
   float out[3];
-  for(int c = 0; c < 3; c++) out[c] = sf_curve(curves, lgv[c], le0, le_step, c);
+  for(int c = 0; c < 3; c++) out[c] = sf_curve(curves, lgv[c], le0, inv_le_step, c);
   cmy[k] = (float4)(out[0], out[1], out[2], lg.w);
 }
 
@@ -584,10 +697,20 @@ __kernel void spektrafilm_grain_usm(__global float4 *cmy, __global const float4 
   if(x >= w || y >= h) return;
   const size_t k = (size_t)y * w + x;
   const float4 dmin = (float4)(dmin0, dmin1, dmin2, 0.0f);
-  const float4 D = orig[k] + dmin;
+  /* fmax(..., 0) on D, matching sf_multiplicative_unsharp_mask3 in
+     spektra_core.c: the CPU clamps the absolute density at zero before using
+     it both as the ratio numerator and as the outer multiplier. Without the
+     clamp a negative D flips the sign of the whole term here instead of
+     collapsing it -- a behavioural difference, not a rounding one. */
+  const float4 D = fmax(orig[k] + dmin, 0.0f);
   const float4 blur = cmy[k] + dmin;
   const float eps = 1e-6f;
   const float ratmax = 4.0f, ratmin = 1.0f / ratmax;
+  /* NOTE: pow() below is only spec'd to 16 ULP in OpenCL, against a host
+     powf() that is typically correctly rounded. That gap survives this
+     patch; if a residue remains and is localised to grained pixels, this is
+     the next candidate for a shared portable implementation (cf. sf_exp_neg
+     in spektra_core.h). */
   float4 out;
   out.x = fmax(D.x * pow(fmax(fmin(D.x / fmax(blur.x, eps), ratmax), ratmin), amount) - dmin.x,
                0.0f);
@@ -606,23 +729,42 @@ __kernel void spektrafilm_print_expose(__global const float4 *cmy, __global floa
                                        __global const float *sy, __global const float *sz,
                                        __global const float *cmn, __global const float *cmx,
                                        const int steps, const float lo0, const float lo1,
-                                       const float lo2, const float hi0, const float hi1,
-                                       const float hi2, const float print_exposure)
+                                       const float lo2, const float inv0, const float inv1,
+                                       const float inv2, const float log10_print_exposure)
 {
   const int x = get_global_id(0), y = get_global_id(1);
   if(x >= w || y >= h) return;
   const size_t k = (size_t)y * w + x;
   const float4 in = cmy[k];
   const float scale = (float)(steps - 1);
-  const float r = (in.x - lo0) / (hi0 - lo0) * scale;
-  const float g = (in.y - lo1) / (hi1 - lo1) * scale;
-  const float b = (in.z - lo2) / (hi2 - lo2) * scale;
+  /* inv0/inv1/inv2 are the host's sim->enl_inv_range[c] (1/(hi-lo), rounded
+     once from a double-precision subtraction) -- NOT computed here as
+     1/(hi-lo) in float32. hi and lo individually survive an extra float32
+     rounding each versus the host's double copies, and re-subtracting them
+     on-device is a catastrophic-cancellation hazard whenever a channel's
+     density range is narrow: the relative error in that difference blows
+     up right where the CPU fast path (sf_sim_print_expose/sf_sim_scan,
+     spektra_sim.c) stays exact, shifting r/g/b enough to flip floor() to
+     the neighbouring LUT cell for pixels near a cell boundary. Using the
+     same precomputed reciprocal as the CPU path makes this identical to
+     it by construction instead of hoping two different roundings agree. */
+  const float r = (in.x - lo0) * inv0 * scale;
+  const float g = (in.y - lo1) * inv1 * scale;
+  const float b = (in.z - lo2) * inv2 * scale;
   float3 l1 = sf_pchip3d(lut, sx, sy, sz, cmn, cmx, steps, r, g, b);
-  /* [st] raw = 10^l1 * print_exposure; back to log10 */
+  /* [st] raw = 10^l1 * print_exposure, back to log10 -- but done as the exact
+     identity log10(10^l1 * pe) == l1 + log10(pe), which is what
+     sf_sim_print_expose does on the CPU. The old round trip through
+     exp10()/log10() was not the same computation: OpenCL only specs those to
+     3 ULP each, and more importantly the + SF_LOG_EPS floored the result at
+     log10(1e-10) == -10 while the CPU floors at -30, so the two paths gave
+     visibly different values for any pixel dark enough to reach the floor.
+     One add, no library calls, no epsilon, and the same -30 guard the CPU
+     uses against -inf from degenerate inputs. */
   float3 out;
-  out.x = log10(fmax(exp10(l1.x) * print_exposure, 0.0f) + SF_LOG_EPS);
-  out.y = log10(fmax(exp10(l1.y) * print_exposure, 0.0f) + SF_LOG_EPS);
-  out.z = log10(fmax(exp10(l1.z) * print_exposure, 0.0f) + SF_LOG_EPS);
+  out.x = fmax(l1.x + log10_print_exposure, -30.0f);
+  out.y = fmax(l1.y + log10_print_exposure, -30.0f);
+  out.z = fmax(l1.z + log10_print_exposure, -30.0f);
   loge[k] = (float4)(out.x, out.y, out.z, in.w);
 }
 
@@ -630,7 +772,7 @@ __kernel void spektrafilm_print_expose(__global const float4 *cmy, __global floa
 __kernel void spektrafilm_print_develop(__global const float4 *loge, __global float4 *cmy,
                                         const int w, const int h,
                                         __global const float *print_curves, const float le0,
-                                        const float le_step)
+                                        const float inv_le_step)
 {
   const int x = get_global_id(0), y = get_global_id(1);
   if(x >= w || y >= h) return;
@@ -639,7 +781,7 @@ __kernel void spektrafilm_print_develop(__global const float4 *loge, __global fl
   const float lgv[3] = { in.x, in.y, in.z };
   float out[3];
   for(int c = 0; c < 3; c++)
-    out[c] = sf_curve(print_curves, lgv[c], le0, le_step, c);
+    out[c] = sf_curve(print_curves, lgv[c], le0, inv_le_step, c);
   cmy[k] = (float4)(out[0], out[1], out[2], in.w);
 }
 
@@ -656,8 +798,8 @@ __kernel void spektrafilm_scan(__global const float4 *cmy, __global float4 *rgb_
                                __global const float *sy, __global const float *sz,
                                __global const float *cmn, __global const float *cmx,
                                const int steps, const float lo0, const float lo1,
-                               const float lo2, const float hi0, const float hi1,
-                               const float hi2, __constant float *mats,
+                               const float lo2, const float inv0, const float inv1,
+                               const float inv2, __constant float *mats,
                                __global const float *cmax_table, const int cmax_nl,
                                const int cmax_nh, const int compress_mode,
                                const float out_luminance_boost,
@@ -669,11 +811,13 @@ __kernel void spektrafilm_scan(__global const float4 *cmy, __global float4 *rgb_
   const size_t k = (size_t)y * w + x;
   const float4 c4 = cmy[k];
   const float scale = (float)(steps - 1);
-  const float r = (c4.x - lo0) / (hi0 - lo0) * scale;
-  const float g = (c4.y - lo1) / (hi1 - lo1) * scale;
-  const float b = (c4.z - lo2) / (hi2 - lo2) * scale;
+  /* inv0/inv1/inv2 = host's sim->scan_inv_range[c]; see spektrafilm_print_expose
+     above for why this must not be recomputed as 1/(hi-lo) on-device. */
+  const float r = (c4.x - lo0) * inv0 * scale;
+  const float g = (c4.y - lo1) * inv1 * scale;
+  const float b = (c4.z - lo2) * inv2 * scale;
   float3 lx = sf_pchip3d(lut, sx, sy, sz, cmn, cmx, steps, r, g, b);
-  float3 xyz = (float3)(exp10(lx.x), exp10(lx.y), exp10(lx.z));
+  float3 xyz = (float3)(sf_pow10f(lx.x), sf_pow10f(lx.y), sf_pow10f(lx.z));
   if(out_luminance_boost != 1.0f) xyz *= out_luminance_boost;
   if(bw_on) /* scanner black/white point (positive film scans) */
   {
@@ -791,6 +935,13 @@ __kernel void spektrafilm_passthrough(__read_only image2d_t in, __write_only ima
    _sf_gauss_iir_1d on the CPU, so both paths deliver the identical blur above
    SF_GAUSS_EXACT_MAX_SIGMA. Launch with global size (h, 1) for rows and
    (w, 1) for columns. */
+/* Explicit fma(), in the same nesting as _sf_gauss_iir_1d() in
+   spektra_core.c -- see the long comment there. A bare
+   B*x + B1*w1 + B2*w2 + B3*w3 leaves the compiler free to fuse or reassociate,
+   the host and the device need not choose alike, and the recursion feeds the
+   result back in, so one differing rounding becomes a different filter rather
+   than a one-ULP difference. FP_CONTRACT pragmas do not settle this on either
+   side; an explicit fma does. */
 __kernel void spektrafilm_yvv_row_4c(__global const float4 *src, __global float4 *dst,
                                      const int w, const int h, const float B, const float B1,
                                      const float B2, const float B3)
@@ -807,13 +958,13 @@ __kernel void spektrafilm_yvv_row_4c(__global const float4 *src, __global float4
   float4 w1 = s[0], w2 = s[0], w3 = s[0];
   for(int j = 0; j < w; j++)
   {
-    const float4 v = B * s[j] + B1 * w1 + B2 * w2 + B3 * w3;
+    const float4 v = fma(B, s[j], fma(B1, w1, fma(B2, w2, B3 * w3)));
     d[j] = v; w3 = w2; w2 = w1; w1 = v;
   }
   float4 v1 = d[w - 1], v2 = v1, v3 = v1;
   for(int j = w - 1; j >= 0; j--)
   {
-    const float4 v = B * d[j] + B1 * v1 + B2 * v2 + B3 * v3;
+    const float4 v = fma(B, d[j], fma(B1, v1, fma(B2, v2, B3 * v3)));
     d[j] = v; v3 = v2; v2 = v1; v1 = v;
   }
 }
@@ -833,14 +984,14 @@ __kernel void spektrafilm_yvv_col_4c(__global const float4 *src, __global float4
   for(int i = 0; i < h; i++)
   {
     const size_t k = (size_t)i * w + col;
-    const float4 v = B * src[k] + B1 * w1 + B2 * w2 + B3 * w3;
+    const float4 v = fma(B, src[k], fma(B1, w1, fma(B2, w2, B3 * w3)));
     dst[k] = v; w3 = w2; w2 = w1; w1 = v;
   }
   float4 v1 = dst[(size_t)(h - 1) * w + col], v2 = v1, v3 = v1;
   for(int i = h - 1; i >= 0; i--)
   {
     const size_t k = (size_t)i * w + col;
-    const float4 v = B * dst[k] + B1 * v1 + B2 * v2 + B3 * v3;
+    const float4 v = fma(B, dst[k], fma(B1, v1, fma(B2, v2, B3 * v3)));
     dst[k] = v; v3 = v2; v2 = v1; v1 = v;
   }
 }
@@ -861,13 +1012,13 @@ __kernel void spektrafilm_yvv_row_1c(__global const float *src, __global float *
   float w1 = s[0], w2 = s[0], w3 = s[0];
   for(int j = 0; j < w; j++)
   {
-    const float v = B * s[j] + B1 * w1 + B2 * w2 + B3 * w3;
+    const float v = fma(B, s[j], fma(B1, w1, fma(B2, w2, B3 * w3)));
     d[j] = v; w3 = w2; w2 = w1; w1 = v;
   }
   float v1 = d[w - 1], v2 = v1, v3 = v1;
   for(int j = w - 1; j >= 0; j--)
   {
-    const float v = B * d[j] + B1 * v1 + B2 * v2 + B3 * v3;
+    const float v = fma(B, d[j], fma(B1, v1, fma(B2, v2, B3 * v3)));
     d[j] = v; v3 = v2; v2 = v1; v1 = v;
   }
 }
@@ -887,14 +1038,14 @@ __kernel void spektrafilm_yvv_col_1c(__global const float *src, __global float *
   for(int i = 0; i < h; i++)
   {
     const size_t k = (size_t)i * w + col;
-    const float v = B * src[k] + B1 * w1 + B2 * w2 + B3 * w3;
+    const float v = fma(B, src[k], fma(B1, w1, fma(B2, w2, B3 * w3)));
     dst[k] = v; w3 = w2; w2 = w1; w1 = v;
   }
   float v1 = dst[(size_t)(h - 1) * w + col], v2 = v1, v3 = v1;
   for(int i = h - 1; i >= 0; i--)
   {
     const size_t k = (size_t)i * w + col;
-    const float v = B * dst[k] + B1 * v1 + B2 * v2 + B3 * v3;
+    const float v = fma(B, dst[k], fma(B1, v1, fma(B2, v2, B3 * v3)));
     dst[k] = v; v3 = v2; v2 = v1; v1 = v;
   }
 }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1109,6 +1109,22 @@ add_library(lib_darktable SHARED ${DARKTABLE_BINDIR}/preferences_gen.h ${DARKTAB
 # since this isn't the same directory we do have to manually set it
 set_source_files_properties(${DARKTABLE_BINDIR}/version_gen.c PROPERTIES GENERATED TRUE)
 
+# spektrafilm's CPU path is required to reproduce its OpenCL twin bit-for-bit
+# (see sf_exp_neg in common/spektra_core.h and the FP_CONTRACT note at the top
+# of data/kernels/spektrafilm.cl). The "#pragma STDC FP_CONTRACT OFF" in that
+# header does not achieve this on GCC, which has never implemented the pragma
+# and happily emits vfmadd with it in force; -march=native then guarantees FMA
+# is available on any recent x86. Set the flag these files actually need.
+# Costs FMA in the per-pixel loops, buys a deterministic render across devices.
+check_c_compiler_flag("-ffp-contract=off" HAVE_FFP_CONTRACT_OFF)
+if(HAVE_FFP_CONTRACT_OFF)
+  set_source_files_properties(
+    "common/spektra_core.c"
+    "common/spektra_sim.c"
+    "iop/spektrafilm.c"
+    PROPERTIES COMPILE_OPTIONS "-ffp-contract=off")
+endif()
+
 add_dependencies(lib_darktable generate_styles_string)
 add_dependencies(lib_darktable generate_conf)
 add_dependencies(lib_darktable generate_version)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1118,11 +1118,21 @@ set_source_files_properties(${DARKTABLE_BINDIR}/version_gen.c PROPERTIES GENERAT
 # Costs FMA in the per-pixel loops, buys a deterministic render across devices.
 check_c_compiler_flag("-ffp-contract=off" HAVE_FFP_CONTRACT_OFF)
 if(HAVE_FFP_CONTRACT_OFF)
+  set(SPEKTRA_FP_CONTRACT_FLAGS "-ffp-contract=off")
+  if(CMAKE_C_COMPILER_ID MATCHES "Clang")
+    # Clang errors out (-Woverriding-option, hard error since Clang 18) if
+    # -ffp-contract=off is requested while -ffast-math (or anything implying
+    # it, e.g. -Ofast) is also in effect for these files -- which can happen
+    # via CMAKE_C_FLAGS or a build-type default regardless of anything this
+    # file sets. Explicitly turn fast-math back off first so there is
+    # nothing left to "override". GCC needs no such workaround.
+    set(SPEKTRA_FP_CONTRACT_FLAGS "-fno-fast-math" "${SPEKTRA_FP_CONTRACT_FLAGS}")
+  endif()
   set_source_files_properties(
     "common/spektra_core.c"
     "common/spektra_sim.c"
     "iop/spektrafilm.c"
-    PROPERTIES COMPILE_OPTIONS "-ffp-contract=off")
+    PROPERTIES COMPILE_OPTIONS "${SPEKTRA_FP_CONTRACT_FLAGS}")
 endif()
 
 add_dependencies(lib_darktable generate_styles_string)

--- a/src/common/spektra_core.c
+++ b/src/common/spektra_core.c
@@ -103,10 +103,27 @@ static void _sf_gauss_iir_1d(const float *const in,
                              const float B2,
                              const float B3)
 {
+  /* Explicit fmaf(), in this exact nesting, and the same in spektrafilm.cl's
+     four sf_yvv_* kernels. Not stylistic: this line is a sum of FOUR products,
+     so a compiler may fuse any of them into a mad or reassociate the sum, and
+     the two sides need not choose alike. Unlike the FIR path -- a single
+     accumulator chain, which both sides evaluate identically -- the result
+     here feeds straight back in as w1, so one differing rounding does not stay
+     one ULP: measured on a 2048-sample line, a single reassociation moves 74%
+     of the outputs and a single contraction 87%. That is a different filter,
+     not a rounding difference, and it was the bulk of the CPU/GPU divergence
+     in this module.
+
+     #pragma STDC FP_CONTRACT / #pragma OPENCL FP_CONTRACT are not enough:
+     GCC has never implemented the C one, and the OpenCL one is not honoured by
+     every driver. An explicit fma is IEEE-defined and correctly rounded, so
+     pinning the association here makes both sides agree by construction
+     instead of by flag. B3 * w3 stays a bare multiply -- also correctly
+     rounded -- so every operation in the line is fully specified. */
   float w1 = in[0], w2 = in[0], w3 = in[0];
   for(int i = 0; i < len; i++)
   {
-    const float v = B * in[i] + B1 * w1 + B2 * w2 + B3 * w3;
+    const float v = fmaf(B, in[i], fmaf(B1, w1, fmaf(B2, w2, B3 * w3)));
     out[i] = v;
     w3 = w2;
     w2 = w1;
@@ -115,7 +132,7 @@ static void _sf_gauss_iir_1d(const float *const in,
   float y1 = out[len - 1], y2 = y1, y3 = y1;
   for(int i = len - 1; i >= 0; i--)
   {
-    const float v = B * out[i] + B1 * y1 + B2 * y2 + B3 * y3;
+    const float v = fmaf(B, out[i], fmaf(B1, y1, fmaf(B2, y2, B3 * y3)));
     out[i] = v;
     y3 = y2;
     y2 = y1;
@@ -270,7 +287,7 @@ void sf_blur_plane3(float *const buf,
                     const float sigma,
                     float *const plane)
 {
-  if(sigma < 0.3f) return;
+  if(sigma < SF_GAUSS_MIN_SIGMA) return;
   float *const trans = dt_alloc_align_float((size_t)w * h);
   for(int c = 0; c < 3; c++) _blur_channel(buf, w, h, c, sigma, plane, trans, /*exact_only=*/1);
   dt_free_align(trans);
@@ -308,7 +325,7 @@ void sf_blur_plane3_fast(float *const buf,
                          const float sigma,
                          float *const plane)
 {
-  if(sigma < 0.3f) return;
+  if(sigma < SF_GAUSS_MIN_SIGMA) return;
   float *const trans = dt_alloc_align_float((size_t)w * h);
   for(int c = 0; c < 3; c++) _blur_channel(buf, w, h, c, sigma, plane, trans, /*exact_only=*/0);
   dt_free_align(trans);

--- a/src/common/spektra_core.h
+++ b/src/common/spektra_core.h
@@ -242,6 +242,13 @@ SPEKTRA_INLINE uint32_t sf_pixel_seed(uint32_t xi,
    and above it both sides now run the same Young-van Vliet filter, so a given
    sigma produces the same blur here, on the GPU, and in the app. */
 #define SF_GAUSS_EXACT_MAX_SIGMA 3.0f
+/* Below this the blur is skipped outright rather than run with a degenerate
+   kernel: dt_gaussian_kernel_1d() floors its radius at 1, so a sigma of 0.1
+   still produces a real 3-tap kernel with non-negligible side weights, not
+   an identity. sf_blur_plane3/_fast have always done this; the constant is
+   shared so spektrafilm.c's OpenCL path can apply the same cut at the same
+   call sites instead of blurring where the CPU does nothing. */
+#define SF_GAUSS_MIN_SIGMA 0.3f
 
 /* Young-van Vliet order-3 recursive Gaussian coefficients (B, B1, B2, B3),
    identical to the reference's _yvv_coeffs. Exported so the GPU host side can
@@ -288,13 +295,67 @@ void sf_gauss_yvv_coeffs(float sigma,
    lam+1 hashes (<= 13), the fast branch 4 -- against 8 for the two sf_nrm draws
    this replaces. */
 #define SF_POISSON_EXACT_MAX 12.0f
+
+/* sf_exp2i: construct 2^k exactly for integer k, by writing the IEEE-754
+   binary32 exponent field directly instead of calling ldexpf/exp2f. This is
+   bit manipulation, not arithmetic -- no rounding happens, so it is exact
+   and identical everywhere by construction. Only valid for k that keeps the
+   result normal (roughly -125..127); sf_exp_neg below never asks for
+   anything close to those limits over its intended domain. */
+SPEKTRA_INLINE float sf_exp2i(int k)
+{
+  union { uint32_t u; float f; } v;
+  v.u = (uint32_t)(k + 127) << 23;
+  return v.f;
+}
+
+/* sf_exp_neg: exp(-lam) for lam in (0, SF_POISSON_EXACT_MAX), built only from
+   +, -, * and the exact floor()/exponent-injection above -- deliberately NOT
+   a call to expf()/exp(). The platform exp() is only spec'd to within a few
+   ULP (OpenCL C requires just <=3 ULP for exp(), versus basic +,-,* which
+   IEEE-754 and the OpenCL spec both require to be correctly rounded), and
+   this value feeds an accept/reject loop in sf_poisson: prod *= sf_u01(...)
+   until prod <= limit. A few-ULP disagreement between the CPU's expf() and
+   the GPU's exp() only rarely lands close enough to prod to matter, but
+   when it does, the loop exits one iteration earlier or later and the
+   sampled grain count is off by a whole integer -- a real, visible
+   per-pixel difference from an invisible input difference. Every op used
+   here (+, -, *, floor, and the bit-exact 2^k above) is required to be
+   exact/correctly-rounded on both sides, so this reproduces bit-for-bit
+   given the same lam, unlike the library call it replaces. (Build systems:
+   this relies on the compiler NOT fusing any of these multiply+adds into a
+   single-rounding FMA on one side and not the other -- keep
+   -ffast-math/-ffp-contract=fast and -cl-mad-enable/-cl-fast-relaxed-math
+   off for this code.)
+
+   Implementation: standard exp(x) = 2^k * exp(r) range reduction, k =
+   round(x/ln2), r in [-ln2/2, ln2/2], exp(r) via a degree-6 Taylor
+   polynomial (evaluated with Horner's method). Max relative error over the
+   full (0,12) domain is ~1.1e-6 -- far tighter than grain needs, chosen
+   for auditability over a tighter minimax fit. */
+#pragma STDC FP_CONTRACT OFF
+SPEKTRA_INLINE float sf_exp_neg(float lam)
+{
+  const float t = -lam;
+  const int k = (int)floorf(t * 1.4426950216293335f + 0.5f); /* log2(e) */
+  const float r = t - (float)k * 0.6931471824645996f;        /* ln(2) */
+  float p = 0.00138888892f;                                  /* 1/720 */
+  p = p * r + 0.00833333377f;                                /* 1/120 */
+  p = p * r + 0.0416666679f;                                 /* 1/24 */
+  p = p * r + 0.166666672f;                                  /* 1/6 */
+  p = p * r + 0.5f;
+  p = p * r + 1.0f;
+  p = p * r + 1.0f;
+  return p * sf_exp2i(k);
+}
+
 SPEKTRA_INLINE float sf_poisson(float lam,
                                 uint32_t seed)
 {
   if(lam <= 0.0f) return 0.0f;
   if(lam < SF_POISSON_EXACT_MAX)
   {
-    const float limit = expf(-lam);
+    const float limit = sf_exp_neg(lam);
     float prod = 1.0f;
     int k = 0;
     do

--- a/src/common/spektra_sim.c
+++ b/src/common/spektra_sim.c
@@ -172,6 +172,35 @@ static void mat3_mulv(double out[3],
   out[2] = r2;
 }
 
+/* float sibling, matching spektrafilm.cl's sf_mat3 exactly (same operand
+   order) -- used by the scan-stage fast path so it accumulates in the same
+   precision as the GPU kernel. */
+/* ---- fma parity with spektrafilm.cl -------------------------------------
+   The dot products and polynomials below use explicit fmaf() in the same
+   nesting as their kernel twins (sf_mat3, sf_mitchell, sf_cubic2d).
+
+   Not cosmetic. The host honours -ffp-contract=off, so a bare a*b + c*d + e*f
+   compiles to separate multiplies and adds; the device compiler ignores
+   #pragma OPENCL FP_CONTRACT OFF and fuses anyway -- which is why pinning the
+   YvV recursion with fma() moved the CPU/GPU divergence where the pragma
+   alone did nothing. Left bare, every matrix multiply and every Mitchell
+   weight in the expose stage lands a fraction of an ULP from its twin, and
+   expose is stage one, so nothing downstream can agree afterwards. An
+   explicit fma is IEEE-defined and correctly rounded, so pinning both sides
+   makes them agree by construction rather than by compiler flag. */
+
+static inline void mat3_mulv_f(float out[3],
+                               const float m[9],
+                               const float v[3])
+{
+  const float r0 = fmaf(m[0], v[0], fmaf(m[1], v[1], m[2] * v[2]));
+  const float r1 = fmaf(m[3], v[0], fmaf(m[4], v[1], m[5] * v[2]));
+  const float r2 = fmaf(m[6], v[0], fmaf(m[7], v[1], m[8] * v[2]));
+  out[0] = r0;
+  out[1] = r1;
+  out[2] = r2;
+}
+
 static int mat3_inv(double out[9],
                     const double m[9])
 {
@@ -239,6 +268,21 @@ static const double SF_OKLAB_M1[9]
 static const double SF_OKLAB_M2[9]
     = { 0.2104542553, 0.7936177850, -0.0040720468, 1.9779984951, -2.4285922050,
         0.4505937099, 0.0259040371, 0.7827717662, -0.8086757660 };
+/* float mirrors of the two constants above, for sf_sim_scan's fast path --
+   see the *_f functions near xyz_to_oklab/oklab_to_xyz for why this needs to
+   be a float32 constant, not just SF_OKLAB_M1/M2 cast on the fly. */
+static const float SF_OKLAB_M1_F[9]
+    = { 0.8189330101f, 0.3618667424f, -0.1288597137f, 0.0329845436f, 0.9293118715f,
+        0.0361456387f, 0.0482003018f, 0.2643662691f, 0.6338517070f };
+static const float SF_OKLAB_M2_F[9]
+    = { 0.2104542553f, 0.7936177850f, -0.0040720468f, 1.9779984951f, -2.4285922050f,
+        0.4505937099f, 0.0259040371f, 0.7827717662f, -0.8086757660f };
+
+/* forward decl: defined near the other cpNf GPU-export helpers below, needed
+   here already to populate the *_f mirror matrices at build time (see
+   sf_sim_build) so sf_sim_scan's fast path can match spektrafilm.cl's
+   float32 arithmetic instead of running the scan/gamut stage in double. */
+static void cp9f(float dst[9], const double src[9]);
 
 /* ------------------------------------------------------------------------ */
 /* internal structures                                                      */
@@ -434,6 +478,9 @@ struct sf_sim_t
   double illum_view_xyz[3];
   double scan_lo[3], scan_hi[3];
   double m_out[9]; /* XYZ (viewing illum) -> linear output RGB (CAT02) */
+  float m_out_f[9]; /* float mirror, so the scan fast path (sf_sim_scan) runs
+                        this matrix multiply at the same precision as
+                        spektrafilm.cl's spektrafilm_scan kernel */
   /* scanner black/white point correction (positive film scans only):
      xyz *= clip(bw_m*Y + bw_q, 0, 1)/Y after xyz = 10^log_xyz.
      Mirrors color_reference.black_white_xyz_correction with
@@ -445,8 +492,13 @@ struct sf_sim_t
   int lut_steps;
   double *enl_lut, *enl_sx, *enl_sy, *enl_sz, *enl_cmin, *enl_cmax;
   double *scan_lut, *scan_sx, *scan_sy, *scan_sz, *scan_cmin, *scan_cmax;
-  float *enl_lut_f;   /* float copies for fast trilinear per-pixel path */
+  float *enl_lut_f;   /* float copies for the fast per-pixel path */
   float *scan_lut_f;
+  /* float copies of the slope/bound tables, so the fast path runs the same
+     monotone-PCHIP evaluator as sf_pchip3d() in spektrafilm.cl instead of
+     silently degrading to trilinear (see sf_sim_print_expose/sf_sim_scan). */
+  float *enl_sx_f, *enl_sy_f, *enl_sz_f, *enl_cmin_f, *enl_cmax_f;
+  float *scan_sx_f, *scan_sy_f, *scan_sz_f, *scan_cmin_f, *scan_cmax_f;
 
   /* output gamut compression */
   sf_output_compress_t out_compress;
@@ -454,6 +506,14 @@ struct sf_sim_t
   double out_scale;
   double out_rgb2xyz[9], out_xyz2rgb[9];
   double oklab_m1inv[9], oklab_m2inv[9];
+  /* float mirrors of the five matrices above (plus SF_OKLAB_M1/M2 themselves),
+     for the same reason as m_out_f: sf_sim_scan's OkLCh compression must run
+     in float, matching spektrafilm.cl's sf_xyz_to_oklab/sf_oklab_to_xyz, or
+     it silently diverges from the GPU path on every pixel that goes through
+     gamut compression -- not just on rounding at the edges of some branch,
+     the way most CPU/GPU drift in this module works. */
+  float out_rgb2xyz_f[9], out_xyz2rgb_f[9];
+  float oklab_m1inv_f[9], oklab_m2inv_f[9];
   float *cmax; /* SF_CMAX_NL × SF_CMAX_NH */
 };
 
@@ -1398,6 +1458,22 @@ static inline double reinhard_knee(double d,
   return threshold + scale * y;
 }
 
+/* float sibling -- matches spektrafilm.cl's sf_knee exactly. Used only by
+   the scan-stage fast path (compress_rgb_oklch_f/compress_rgb_aces_f); the
+   double version above stays for the tone curve knee, which runs once per
+   build_film_curves entry and has no GPU counterpart to match. */
+static inline float reinhard_knee_f(float d,
+                                    float threshold,
+                                    float limit,
+                                    float power)
+{
+  if(d <= threshold) return d;
+  const float scale = limit - threshold;
+  const float x = (d - threshold) / scale;
+  const float y = x / powf(1.0f + powf(x, power), 1.0f / power);
+  return threshold + scale * y;
+}
+
 /* distance from origin along unit direction to the first polygon crossing */
 static double ray_polygon_distance(const double origin[2],
                                    const double dir[2],
@@ -1460,6 +1536,27 @@ static inline double mitchell_weight(double t)
   return 0.0;
 }
 
+/* float twin of mitchell_weight(), matching spektrafilm.cl's sf_mitchell()
+   term for term (same B/C, same Horner-free expansion, all in float32). The
+   double version above stays for cubic_interp_2d(), which only runs at
+   sim-build time and has no GPU counterpart to agree with. */
+static inline float mitchell_weight_f(float t)
+{
+  const float B = 1.0f / 3.0f, C = 1.0f / 3.0f;
+  const float x = fabsf(t);
+  /* fma-pinned, matching sf_mitchell in spektrafilm.cl */
+  if(x < 1.0f)
+    return (1.0f / 6.0f)
+           * fmaf((12.0f - 9.0f * B - 6.0f * C) * x * x, x,
+                  fmaf((-18.0f + 12.0f * B + 6.0f * C) * x, x, (6.0f - 2.0f * B)));
+  else if(x < 2.0f)
+    return (1.0f / 6.0f)
+           * fmaf((-B - 6.0f * C) * x * x, x,
+                  fmaf((6.0f * B + 30.0f * C) * x, x,
+                       fmaf((-12.0f * B - 48.0f * C), x, (8.0f * B + 24.0f * C))));
+  return 0.0f;
+}
+
 static inline int safe_index(int idx,
                              int L)
 {
@@ -1497,6 +1594,31 @@ static inline void cubic_base_fraction(double coord,
     return;
   }
   *base = (int)floor(coord);
+  *frac = coord - *base;
+}
+
+/* float counterpart of cubic_base_fraction() (see above): same clamp-to-top
+   and NaN-hardening behaviour, just in single precision, so the fast path's
+   cell selection matches the double path and spektrafilm.cl's sf_base_frac()
+   bit-for-bit in intent. */
+static inline void cubic_base_fraction_f(float coord,
+                                         int L,
+                                         int *base,
+                                         float *frac)
+{
+  if(!(coord > 0.0f))
+  {
+    *base = 0;
+    *frac = 0.0f;
+    return;
+  }
+  if(coord >= (float)(L - 1))
+  {
+    *base = L - 2;
+    *frac = 1.0f;
+    return;
+  }
+  *base = (int)floorf(coord);
   *frac = coord - *base;
 }
 
@@ -1575,7 +1697,16 @@ static void bilinear_2d_clamped(double out[3],
    clamping flattens it -- which is exactly where the film response is steepest.
    The OpenCL kernel (sf_cubic2d) and the reference (apply_lut_cubic_2d in
    spectral_upsampling.py) both use this kernel, so anything else here renders
-   differently depending on which device ran. */
+   differently depending on which device ran.
+
+   Every step here is float32 -- base/fraction, the Mitchell weights, the
+   accumulator and the normalising divide -- because sf_cubic2d is. This
+   function used to carry the _f only in its name and its LUT type, and do all
+   of its arithmetic in double; that made the very first pipeline stage
+   disagree with the GPU on essentially every pixel, and since the grain
+   sampler downstream turns a sub-ULP input difference into a whole-integer
+   Poisson draw difference, nothing further down the pipe could ever agree
+   either. Keep this in float. */
 static void cubic_interp_2d_f(float out[3],
                               const float *lut,
                               int L,
@@ -1583,74 +1714,109 @@ static void cubic_interp_2d_f(float out[3],
                               float y)
 {
   int xb, yb;
-  double xf, yf;
-  cubic_base_fraction((double)x, L, &xb, &xf);
-  cubic_base_fraction((double)y, L, &yb, &yf);
-  double wx[4], wy[4];
+  float xf, yf;
+  cubic_base_fraction_f(x, L, &xb, &xf);
+  cubic_base_fraction_f(y, L, &yb, &yf);
+  float wx[4], wy[4];
   for(int i = 0; i < 4; i++)
   {
-    wx[i] = mitchell_weight(xf + 1.0 - i);
-    wy[i] = mitchell_weight(yf + 1.0 - i);
+    wx[i] = mitchell_weight_f(xf + 1.0f - i);
+    wy[i] = mitchell_weight_f(yf + 1.0f - i);
   }
-  double acc[3] = { 0, 0, 0 }, wsum = 0.0;
+  float acc[3] = { 0.0f, 0.0f, 0.0f }, wsum = 0.0f;
   for(int i = 0; i < 4; i++)
   {
     const int xi = safe_index(xb - 1 + i, L);
     for(int j = 0; j < 4; j++)
     {
       const int yj = safe_index(yb - 1 + j, L);
-      const double w = wx[i] * wy[j];
+      const float w = wx[i] * wy[j];
       wsum += w;
       const float *px = lut + ((size_t)xi * L + yj) * 3;
-      acc[0] += w * px[0];
-      acc[1] += w * px[1];
-      acc[2] += w * px[2];
+      /* fma, matching sf_cubic2d's accumulator */
+      acc[0] = fmaf(w, px[0], acc[0]);
+      acc[1] = fmaf(w, px[1], acc[1]);
+      acc[2] = fmaf(w, px[2], acc[2]);
     }
   }
-  if(wsum != 0.0)
+  if(wsum != 0.0f)
     for(int c = 0; c < 3; c++) acc[c] /= wsum;
-  out[0] = (float)acc[0];
-  out[1] = (float)acc[1];
-  out[2] = (float)acc[2];
+  out[0] = acc[0];
+  out[1] = acc[1];
+  out[2] = acc[2];
 }
 
-/* Trilinear 3D on a float LUT — replaces PCHIP 3D cubic for the hot scan/print
-   LUT path. The 17³ grid is smooth (density→log XYZ from spectral integrals),
-   so PCHIP's monotonicity guarantee adds negligible quality over linear. */
-static void trilinear_interp_3d_f(float out[3],
-                                  const float *lut,
-                                  int n,
-                                  float r,
-                                  float g,
-                                  float b)
+static inline float hermite_value_f(float y0,
+                                    float y1,
+                                    float m0,
+                                    float m1,
+                                    float t)
 {
-  r = CLAMP(r, 0.0f, (float)(n - 1));
-  g = CLAMP(g, 0.0f, (float)(n - 1));
-  b = CLAMP(b, 0.0f, (float)(n - 1));
-  const int i = (int)r, j = (int)g, k = (int)b;
-  const int i1 = i < n - 1 ? i + 1 : i;
-  const int j1 = j < n - 1 ? j + 1 : j;
-  const int k1 = k < n - 1 ? k + 1 : k;
-  const float tr = r - i, tg = g - j, tb = b - k;
-  const float omtr = 1.0f - tr, omtg = 1.0f - tg, omtb = 1.0f - tb;
-#define TL(idx) lut[((size_t)(idx) * n + (j)) * n + (k)]
-#define TL3(idx) lut[((((size_t)(idx) * n + (j)) * n + (k)) * 3]
+  const float t2 = t * t, t3 = t2 * t;
+  return (2.0f * t3 - 3.0f * t2 + 1.0f) * y0 + (t3 - 2.0f * t2 + t) * m0
+         + (-2.0f * t3 + 3.0f * t2) * y1 + (t3 - t2) * m1;
+}
+
+static inline float linear_mix_f(float v0,
+                                 float v1,
+                                 float t) { return v0 + t * (v1 - v0); }
+
+/* float, single-precision twin of pchip3d_interp() below -- same monotone
+   cubic Hermite blend over the same slope/bound tables, term for term the
+   same as sf_pchip3d() in spektrafilm.cl. This is what the fast per-pixel
+   path must call: falling back to plain trilinear here (as the old
+   trilinear_interp_3d_f() did) silently drops the PCHIP correction that the
+   OpenCL path always applies, which is a real CPU/GPU divergence, not a
+   rounding difference. r, g, b are in [0, n-1] index units. */
+static void pchip3d_interp_f(float out[3],
+                             const float *lut,
+                             const float *sx,
+                             const float *sy,
+                             const float *sz,
+                             const float *cmin,
+                             const float *cmax,
+                             int n,
+                             float r,
+                             float g,
+                             float b)
+{
+  const int m = n - 1;
+  int i, j, k;
+  float tr, tg, tb;
+  cubic_base_fraction_f(r, n, &i, &tr);
+  cubic_base_fraction_f(g, n, &j, &tg);
+  cubic_base_fraction_f(b, n, &k, &tb);
+#define AT(arr, ii, jj, kk, c) arr[((((size_t)(ii)) * n + (jj)) * n + (kk)) * 3 + (c)]
   for(int c = 0; c < 3; c++)
   {
-    const float v00 = lut[((((size_t)i) * n + j) * n + k) * 3 + c] * omtr
-                    + lut[((((size_t)i1) * n + j) * n + k) * 3 + c] * tr;
-    const float v01 = lut[((((size_t)i) * n + j1) * n + k) * 3 + c] * omtr
-                    + lut[((((size_t)i1) * n + j1) * n + k) * 3 + c] * tr;
-    const float v10 = lut[((((size_t)i) * n + j) * n + k1) * 3 + c] * omtr
-                    + lut[((((size_t)i1) * n + j) * n + k1) * 3 + c] * tr;
-    const float v11 = lut[((((size_t)i) * n + j1) * n + k1) * 3 + c] * omtr
-                    + lut[((((size_t)i1) * n + j1) * n + k1) * 3 + c] * tr;
-    const float v0 = v00 * omtg + v01 * tg;
-    const float v1 = v10 * omtg + v11 * tg;
-    out[c] = v0 * omtb + v1 * tb;
+    const float v000 = hermite_value_f(AT(lut, i, j, k, c), AT(lut, i + 1, j, k, c),
+                                       AT(sx, i, j, k, c), AT(sx, i + 1, j, k, c), tr);
+    const float v010 = hermite_value_f(AT(lut, i, j + 1, k, c), AT(lut, i + 1, j + 1, k, c),
+                                       AT(sx, i, j + 1, k, c), AT(sx, i + 1, j + 1, k, c), tr);
+    const float v001 = hermite_value_f(AT(lut, i, j, k + 1, c), AT(lut, i + 1, j, k + 1, c),
+                                       AT(sx, i, j, k + 1, c), AT(sx, i + 1, j, k + 1, c), tr);
+    const float v011
+        = hermite_value_f(AT(lut, i, j + 1, k + 1, c), AT(lut, i + 1, j + 1, k + 1, c),
+                          AT(sx, i, j + 1, k + 1, c), AT(sx, i + 1, j + 1, k + 1, c), tr);
+    const float sy00 = linear_mix_f(AT(sy, i, j, k, c), AT(sy, i + 1, j, k, c), tr);
+    const float sy10 = linear_mix_f(AT(sy, i, j + 1, k, c), AT(sy, i + 1, j + 1, k, c), tr);
+    const float sy01 = linear_mix_f(AT(sy, i, j, k + 1, c), AT(sy, i + 1, j, k + 1, c), tr);
+    const float sy11
+        = linear_mix_f(AT(sy, i, j + 1, k + 1, c), AT(sy, i + 1, j + 1, k + 1, c), tr);
+    const float vz0 = hermite_value_f(v000, v010, sy00, sy10, tg);
+    const float vz1 = hermite_value_f(v001, v011, sy01, sy11, tg);
+    const float sz0
+        = linear_mix_f(linear_mix_f(AT(sz, i, j, k, c), AT(sz, i + 1, j, k, c), tr),
+                       linear_mix_f(AT(sz, i, j + 1, k, c), AT(sz, i + 1, j + 1, k, c), tr), tg);
+    const float sz1 = linear_mix_f(
+        linear_mix_f(AT(sz, i, j, k + 1, c), AT(sz, i + 1, j, k + 1, c), tr),
+        linear_mix_f(AT(sz, i, j + 1, k + 1, c), AT(sz, i + 1, j + 1, k + 1, c), tr), tg);
+    float v = hermite_value_f(vz0, vz1, sz0, sz1, tb);
+    const size_t cidx = ((((size_t)i) * m + j) * m + k) * 3 + c;
+    v = CLAMP(v, cmin[cidx], cmax[cidx]);
+    out[c] = v;
   }
-#undef TL
-#undef TL3
+#undef AT
 }
 
 /* ------------------------------------------------------------------------ */
@@ -2538,6 +2704,31 @@ static inline void oklab_to_xyz(const sf_sim_t *s,
   mat3_mulv(xyz, s->oklab_m1inv, lms);
 }
 
+/* float siblings, matching spektrafilm.cl's sf_xyz_to_oklab/sf_oklab_to_xyz
+   (same cbrt-in-float and cube-by-multiplication, not pow()). Used only by
+   the scan-stage fast path (compress_rgb_oklch_f below); build_cmax_table
+   above keeps using the double versions since it runs once at sim-build
+   time, not per pixel, and both sides read the resulting table as the same
+   float array regardless. */
+static inline void xyz_to_oklab_f(const float xyz[3],
+                                  float lab[3])
+{
+  float lms[3];
+  mat3_mulv_f(lms, SF_OKLAB_M1_F, xyz);
+  for(int i = 0; i < 3; i++) lms[i] = cbrtf(lms[i]);
+  mat3_mulv_f(lab, SF_OKLAB_M2_F, lms);
+}
+
+static inline void oklab_to_xyz_f(const sf_sim_t *s,
+                                  const float lab[3],
+                                  float xyz[3])
+{
+  float lms[3];
+  mat3_mulv_f(lms, s->oklab_m2inv_f, lab);
+  for(int i = 0; i < 3; i++) lms[i] = lms[i] * lms[i] * lms[i];
+  mat3_mulv_f(xyz, s->oklab_m1inv_f, lms);
+}
+
 #define SF_CMAX_L_LO 0.02 /* [gc] _get_output_c_max_table oklch L_grid */
 #define SF_CMAX_L_HI 1.0
 
@@ -2582,67 +2773,88 @@ static bool build_cmax_table(sf_sim_t *s)
   return true;
 }
 
-/* [gc] _c_max_lookup — bilinear, L clamped, hue wrapped */
-static inline double cmax_lookup(const sf_sim_t *s,
-                                 double L,
-                                 double h)
+/* [gc] _c_max_lookup -- bilinear, L clamped, hue wrapped. Matches
+   spektrafilm.cl's sf_cmax_lookup (same clamp/wrap arithmetic, in float
+   throughout -- s->cmax is already a float table on both sides, so there is
+   no double step left in the lookup at all). Replaces the double
+   cmax_lookup this patch removes: compress_rgb_oklch_f was its only
+   caller. */
+static inline float cmax_lookup_f(const sf_sim_t *s,
+                                  float L,
+                                  float h)
 {
-  L = CLAMP(L, SF_CMAX_L_LO, SF_CMAX_L_HI);
-  const double h_step = 2.0 * M_PI / SF_CMAX_NH;
-  const double h_idx = (h + M_PI) / h_step;
-  const double h_floor = floor(h_idx);
+  L = CLAMP(L, (float)SF_CMAX_L_LO, (float)SF_CMAX_L_HI);
+  const float h_step = 2.0f * (float)M_PI / SF_CMAX_NH;
+  const float h_idx = (h + (float)M_PI) / h_step;
+  const float h_floor = floorf(h_idx);
   int h_lo = ((int)h_floor) % SF_CMAX_NH;
   if(h_lo < 0) h_lo += SF_CMAX_NH;
   const int h_hi = (h_lo + 1) % SF_CMAX_NH;
-  const double h_frac = h_idx - h_floor;
+  const float h_frac = h_idx - h_floor;
 
-  const double L_idx
-      = (L - SF_CMAX_L_LO) / (SF_CMAX_L_HI - SF_CMAX_L_LO) * (double)(SF_CMAX_NL - 1);
-  int L_lo = (int)floor(L_idx);
+  const float L_idx
+      = (L - (float)SF_CMAX_L_LO) / (float)(SF_CMAX_L_HI - SF_CMAX_L_LO) * (float)(SF_CMAX_NL - 1);
+  int L_lo = (int)floorf(L_idx);
   L_lo = CLAMP(L_lo, 0, SF_CMAX_NL - 2);
   const int L_hi = L_lo + 1;
-  const double L_frac = L_idx - L_lo;
+  const float L_frac = L_idx - L_lo;
 
   const float *T = s->cmax;
-  const double v00 = T[(size_t)L_lo * SF_CMAX_NH + h_lo];
-  const double v01 = T[(size_t)L_lo * SF_CMAX_NH + h_hi];
-  const double v10 = T[(size_t)L_hi * SF_CMAX_NH + h_lo];
-  const double v11 = T[(size_t)L_hi * SF_CMAX_NH + h_hi];
+  const float v00 = T[(size_t)L_lo * SF_CMAX_NH + h_lo];
+  const float v01 = T[(size_t)L_lo * SF_CMAX_NH + h_hi];
+  const float v10 = T[(size_t)L_hi * SF_CMAX_NH + h_lo];
+  const float v11 = T[(size_t)L_hi * SF_CMAX_NH + h_hi];
   return v00 * (1 - L_frac) * (1 - h_frac) + v01 * (1 - L_frac) * h_frac
          + v10 * L_frac * (1 - h_frac) + v11 * L_frac * h_frac;
 }
 
-/* [gc] compress_rgb_oklch_chroma with lightness_compression (0.7, 1, 2.2) */
-static void compress_rgb_oklch(const sf_sim_t *s,
-                               double rgb[3])
+/* [gc] compress_rgb_oklch_chroma with lightness_compression (0.7, 1, 2.2),
+   in float, matching spektrafilm.cl's compress_mode == 1 branch term for term
+   (same hypot/atan2 operand order, same knee constants). sf_sim_scan is the
+   only caller, so this replaces the double compress_rgb_oklch outright rather
+   than sitting next to it -- keeping both would leave the double one unused
+   and trip -Werror=unused-function.
+
+   The double xyz_to_oklab/oklab_to_xyz do survive, on their own merits:
+   oklab_to_xyz for build_cmax_table and xyz_to_oklab for the colour picker's
+   _probe_lightness_run. Neither has a GPU counterpart to agree with. */
+static void compress_rgb_oklch_f(const sf_sim_t *s,
+                                 float rgb[3])
 {
-  double xyz[3], lab[3];
-  mat3_mulv(xyz, s->out_rgb2xyz, rgb);
-  xyz_to_oklab(xyz, lab);
-  double L = lab[0];
-  const double a = lab[1], b = lab[2];
+  float xyz[3], lab[3];
+  mat3_mulv_f(xyz, s->out_rgb2xyz_f, rgb);
+  xyz_to_oklab_f(xyz, lab);
+  float L = lab[0];
+  const float a = lab[1], b = lab[2];
   /* lightness first, so C_max is looked up at the corrected L */
-  L = reinhard_knee(L, SF_OUT_LIGHT_T, SF_OUT_LIGHT_L, SF_OUT_LIGHT_P);
-  const double C = hypot(a, b);
-  const double h = atan2(b, a);
-  const double C_max = fmax(cmax_lookup(s, L, h), 1e-9);
-  const double d = reinhard_knee(C / C_max, SF_OUT_KNEE_T, SF_OUT_KNEE_L, SF_OUT_KNEE_P);
-  const double C_new = d * C_max;
-  const double lab_new[3] = { L, C_new * cos(h), C_new * sin(h) };
-  oklab_to_xyz(s, lab_new, xyz);
-  mat3_mulv(rgb, s->out_xyz2rgb, xyz);
+  L = reinhard_knee_f(L, (float)SF_OUT_LIGHT_T, (float)SF_OUT_LIGHT_L, (float)SF_OUT_LIGHT_P);
+  const float C = hypotf(a, b);
+  const float h = atan2f(b, a);
+  const float C_max = fmaxf(cmax_lookup_f(s, L, h), 1e-9f);
+  const float d = reinhard_knee_f(C / C_max, (float)SF_OUT_KNEE_T, (float)SF_OUT_KNEE_L,
+                                  (float)SF_OUT_KNEE_P);
+  const float C_new = d * C_max;
+  const float lab_new[3] = { L, C_new * cosf(h), C_new * sinf(h) };
+  oklab_to_xyz_f(s, lab_new, xyz);
+  mat3_mulv_f(rgb, s->out_xyz2rgb_f, xyz);
 }
 
-/* [gc] compress_rgb_aces_rgc — per-channel knee on achromatic distance */
-static void compress_rgb_aces(double rgb[3])
+/* [gc] compress_rgb_aces_rgc -- per-channel knee on achromatic distance, in
+   float, matching spektrafilm.cl's compress_mode == 2 branch (same 1e-12f
+   achromatic guard). Replaces the double compress_rgb_aces for the same
+   reason as compress_rgb_oklch_f above. test_spektra_sim.c called the double
+   version directly and is repointed here, so the tests now exercise the code
+   that actually ships. */
+static void compress_rgb_aces_f(float rgb[3])
 {
-  const double ach = fmax(rgb[0], fmax(rgb[1], rgb[2]));
-  if(ach <= 1e-12) return;
+  const float ach = fmaxf(rgb[0], fmaxf(rgb[1], rgb[2]));
+  if(ach <= 1e-12f) return;
   for(int c = 0; c < 3; c++)
   {
-    const double d = (ach - rgb[c]) / ach;
-    const double dc = reinhard_knee(d, SF_OUT_KNEE_T, SF_OUT_KNEE_L, SF_OUT_KNEE_P);
-    rgb[c] = ach * (1.0 - dc);
+    const float d = (ach - rgb[c]) / ach;
+    const float dc = reinhard_knee_f(d, (float)SF_OUT_KNEE_T, (float)SF_OUT_KNEE_L,
+                                     (float)SF_OUT_KNEE_P);
+    rgb[c] = ach * (1.0f - dc);
   }
 }
 
@@ -2696,7 +2908,7 @@ float sf_sim_probe_lightness_scale(const sf_sim_t *sim,
 }
 
 /* Runs one RGB triple through the full simulation up to (but not including)
- * the highlight/gamut compressor (compress_rgb_oklch/aces), using
+ * the highlight/gamut compressor (compress_rgb_oklch_f/aces_f), using
  * `boost_override` in place of sim->out_luminance_boost, and returns the
  * resulting OkLab lightness -- the precompression-boost picker's actual
  * measurement primitive. This needs the pre-compression value specifically:
@@ -2764,10 +2976,16 @@ static void expose_pixel_f(const float m_in[9],
                            float raw[3])
 {
   float xyz[3];
+  /* fma-pinned, matching sf_mat3 in spektrafilm.cl -- see mat3_mulv_f */
   for(int i = 0; i < 3; i++)
-    xyz[i] = m_in[i * 3] * rgb[0] + m_in[i * 3 + 1] * rgb[1] + m_in[i * 3 + 2] * rgb[2];
+    xyz[i] = fmaf(m_in[i * 3], rgb[0],
+                  fmaf(m_in[i * 3 + 1], rgb[1], m_in[i * 3 + 2] * rgb[2]));
   const float b = xyz[0] + xyz[1] + xyz[2];
-  const float xy[2] = { xyz[0] / fmaxf(b, 1e-10f), xyz[1] / fmaxf(b, 1e-10f) };
+  /* one reciprocal then two multiplies, not two divides -- spektrafilm_expose
+     does exactly this, and the two forms differ by up to an ULP each, which
+     is enough to move the tc index across a cell boundary. */
+  const float inv_b = 1.0f / fmaxf(b, 1e-10f);
+  const float xy[2] = { xyz[0] * inv_b, xyz[1] * inv_b };
   float tc[2];
   tri2quad_f(tc, xy);
   const float scale = (float)(tc_n - 1);
@@ -2883,6 +3101,10 @@ void sf_sim_free(sf_sim_t *s)
   free(s->scan_lut); free(s->scan_sx); free(s->scan_sy); free(s->scan_sz);
   free(s->scan_cmin); free(s->scan_cmax);
   free(s->enl_lut_f); free(s->scan_lut_f);
+  free(s->enl_sx_f); free(s->enl_sy_f); free(s->enl_sz_f);
+  free(s->enl_cmin_f); free(s->enl_cmax_f);
+  free(s->scan_sx_f); free(s->scan_sy_f); free(s->scan_sz_f);
+  free(s->scan_cmin_f); free(s->scan_cmax_f);
   free(s->cmax);
   g_free(s);
 }
@@ -3602,6 +3824,7 @@ sf_sim_t *sf_sim_build(const sf_pack_t *pack,
     double cat[9];
     cat_matrix(cat, SF_M_CAT02, view_xy, p->output_white_xy);
     mat3_mul(s->m_out, p->output_xyz_to_rgb, cat);
+    cp9f(s->m_out_f, s->m_out);
   }
 
   /* ----- scanner black/white point for positive film scans ---------------- */
@@ -3701,9 +3924,42 @@ sf_sim_t *sf_sim_build(const sf_pack_t *pack,
         return NULL;
       }
       const size_t n3 = (size_t)s->lut_steps * s->lut_steps * s->lut_steps * 3;
+      const size_t m3 = (size_t)(s->lut_steps - 1) * (s->lut_steps - 1) * (s->lut_steps - 1) * 3;
       s->enl_lut_f = malloc(n3 * sizeof(float));
-      if(s->enl_lut_f)
-        for(size_t i = 0; i < n3; i++) s->enl_lut_f[i] = (float)s->enl_lut[i];
+      s->enl_sx_f = malloc(n3 * sizeof(float));
+      s->enl_sy_f = malloc(n3 * sizeof(float));
+      s->enl_sz_f = malloc(n3 * sizeof(float));
+      s->enl_cmin_f = malloc(m3 * sizeof(float));
+      s->enl_cmax_f = malloc(m3 * sizeof(float));
+      /* Only commit the float set if every buffer in it landed: the fast
+         path below treats enl_lut_f as the switch for "float tables are
+         available" and must not run PCHIP against a table that came out
+         only partially converted. */
+      if(s->enl_lut_f && s->enl_sx_f && s->enl_sy_f && s->enl_sz_f
+         && s->enl_cmin_f && s->enl_cmax_f)
+      {
+        for(size_t i = 0; i < n3; i++)
+        {
+          s->enl_lut_f[i] = (float)s->enl_lut[i];
+          s->enl_sx_f[i] = (float)s->enl_sx[i];
+          s->enl_sy_f[i] = (float)s->enl_sy[i];
+          s->enl_sz_f[i] = (float)s->enl_sz[i];
+        }
+        for(size_t i = 0; i < m3; i++)
+        {
+          s->enl_cmin_f[i] = (float)s->enl_cmin[i];
+          s->enl_cmax_f[i] = (float)s->enl_cmax[i];
+        }
+      }
+      else
+      {
+        free(s->enl_lut_f); s->enl_lut_f = NULL;
+        free(s->enl_sx_f); s->enl_sx_f = NULL;
+        free(s->enl_sy_f); s->enl_sy_f = NULL;
+        free(s->enl_sz_f); s->enl_sz_f = NULL;
+        free(s->enl_cmin_f); s->enl_cmin_f = NULL;
+        free(s->enl_cmax_f); s->enl_cmax_f = NULL;
+      }
     }
     if(!build_lut3d(s, cmy_to_log_xyz, s->scan_lo, s->scan_hi, s->lut_steps, &s->scan_lut,
                     &s->scan_sx, &s->scan_sy, &s->scan_sz, &s->scan_cmin, &s->scan_cmax))
@@ -3714,9 +3970,38 @@ sf_sim_t *sf_sim_build(const sf_pack_t *pack,
     }
     {
       const size_t n3 = (size_t)s->lut_steps * s->lut_steps * s->lut_steps * 3;
+      const size_t m3 = (size_t)(s->lut_steps - 1) * (s->lut_steps - 1) * (s->lut_steps - 1) * 3;
       s->scan_lut_f = malloc(n3 * sizeof(float));
-      if(s->scan_lut_f)
-        for(size_t i = 0; i < n3; i++) s->scan_lut_f[i] = (float)s->scan_lut[i];
+      s->scan_sx_f = malloc(n3 * sizeof(float));
+      s->scan_sy_f = malloc(n3 * sizeof(float));
+      s->scan_sz_f = malloc(n3 * sizeof(float));
+      s->scan_cmin_f = malloc(m3 * sizeof(float));
+      s->scan_cmax_f = malloc(m3 * sizeof(float));
+      if(s->scan_lut_f && s->scan_sx_f && s->scan_sy_f && s->scan_sz_f
+         && s->scan_cmin_f && s->scan_cmax_f)
+      {
+        for(size_t i = 0; i < n3; i++)
+        {
+          s->scan_lut_f[i] = (float)s->scan_lut[i];
+          s->scan_sx_f[i] = (float)s->scan_sx[i];
+          s->scan_sy_f[i] = (float)s->scan_sy[i];
+          s->scan_sz_f[i] = (float)s->scan_sz[i];
+        }
+        for(size_t i = 0; i < m3; i++)
+        {
+          s->scan_cmin_f[i] = (float)s->scan_cmin[i];
+          s->scan_cmax_f[i] = (float)s->scan_cmax[i];
+        }
+      }
+      else
+      {
+        free(s->scan_lut_f); s->scan_lut_f = NULL;
+        free(s->scan_sx_f); s->scan_sx_f = NULL;
+        free(s->scan_sy_f); s->scan_sy_f = NULL;
+        free(s->scan_sz_f); s->scan_sz_f = NULL;
+        free(s->scan_cmin_f); s->scan_cmin_f = NULL;
+        free(s->scan_cmax_f); s->scan_cmax_f = NULL;
+      }
     }
   }
 
@@ -3725,6 +4010,10 @@ sf_sim_t *sf_sim_build(const sf_pack_t *pack,
   memcpy(s->out_xyz2rgb, p->output_xyz_to_rgb, sizeof(s->out_xyz2rgb));
   mat3_inv(s->oklab_m1inv, SF_OKLAB_M1);
   mat3_inv(s->oklab_m2inv, SF_OKLAB_M2);
+  cp9f(s->out_rgb2xyz_f, s->out_rgb2xyz);
+  cp9f(s->out_xyz2rgb_f, s->out_xyz2rgb);
+  cp9f(s->oklab_m1inv_f, s->oklab_m1inv);
+  cp9f(s->oklab_m2inv_f, s->oklab_m2inv);
   if(s->out_compress == SF_OUTPUT_COMPRESS_OKLCH && !build_cmax_table(s))
   {
     set_error(errmsg, "spektra_sim: out of memory for the gamut compression table");
@@ -3764,7 +4053,9 @@ void sf_sim_expose(const sf_sim_t *sim,
         const float *xyz_k = xyz + k * 3;
         float r[3];
         const float b = xyz_k[0] + xyz_k[1] + xyz_k[2];
-        const float xy[2] = { xyz_k[0] / fmaxf(b, 1e-10f), xyz_k[1] / fmaxf(b, 1e-10f) };
+        /* see expose_pixel_f: reciprocal-multiply, matching spektrafilm_expose */
+        const float inv_b = 1.0f / fmaxf(b, 1e-10f);
+        const float xy[2] = { xyz_k[0] * inv_b, xyz_k[1] * inv_b };
         float tc[2];
         tri2quad_f(tc, xy);
         const float scale = (float)(sim->tc_n - 1);
@@ -3905,7 +4196,8 @@ void sf_sim_print_expose(const sf_sim_t *sim,
       const float r = (in[0] - (float)sim->enl_lo[0]) * sim->enl_inv_range[0] * scale;
       const float g = (in[1] - (float)sim->enl_lo[1]) * sim->enl_inv_range[1] * scale;
       const float b = (in[2] - (float)sim->enl_lo[2]) * sim->enl_inv_range[2] * scale;
-      trilinear_interp_3d_f(l1, sim->enl_lut_f, steps, r, g, b);
+      pchip3d_interp_f(l1, sim->enl_lut_f, sim->enl_sx_f, sim->enl_sy_f, sim->enl_sz_f,
+                       sim->enl_cmin_f, sim->enl_cmax_f, steps, r, g, b);
     }
     else if(steps >= 2)
     {
@@ -3977,7 +4269,8 @@ void sf_sim_scan(const sf_sim_t *sim,
       const float r = (in[0] - (float)sim->scan_lo[0]) * sim->scan_inv_range[0] * scale;
       const float g = (in[1] - (float)sim->scan_lo[1]) * sim->scan_inv_range[1] * scale;
       const float b = (in[2] - (float)sim->scan_lo[2]) * sim->scan_inv_range[2] * scale;
-      trilinear_interp_3d_f(lx, sim->scan_lut_f, steps, r, g, b);
+      pchip3d_interp_f(lx, sim->scan_lut_f, sim->scan_sx_f, sim->scan_sy_f, sim->scan_sz_f,
+                       sim->scan_cmin_f, sim->scan_cmax_f, steps, r, g, b);
     }
     else if(steps >= 2)
     {
@@ -3998,28 +4291,34 @@ void sf_sim_scan(const sf_sim_t *sim,
       cmy_to_log_xyz(sim, c, lxd);
       lx[0] = (float)lxd[0]; lx[1] = (float)lxd[1]; lx[2] = (float)lxd[2];
     }
-    double xyz[3]; double rgb[3];
+    /* float from here on, matching spektrafilm_scan in spektrafilm.cl term
+       for term (POW10F is already float; lx above is float in every branch
+       above already too) -- this used to switch to double here for no
+       reason tied to accuracy, which meant every pixel's gamut compression
+       silently disagreed with the GPU path. See compress_rgb_oklch_f's
+       comment for what still legitimately stays in double (build_cmax_table). */
+    float xyz[3]; float rgb[3];
     for(int m = 0; m < 3; m++) xyz[m] = SF_POW10F(lx[m]);
     if(sim->out_luminance_boost != 1.0)
-      for(int m = 0; m < 3; m++) xyz[m] *= sim->out_luminance_boost;
+      for(int m = 0; m < 3; m++) xyz[m] *= (float)sim->out_luminance_boost;
     if(sim->scan_bw_on)
     {
-      const double y = xyz[1];
-      double yc = sim->scan_bw_m * y + sim->scan_bw_q;
-      yc = yc < 0.0 ? 0.0 : (yc > 1.0 ? 1.0 : yc);
-      const double sc = yc / (y + 1e-10);
+      const float y = xyz[1];
+      float yc = (float)sim->scan_bw_m * y + (float)sim->scan_bw_q;
+      yc = yc < 0.0f ? 0.0f : (yc > 1.0f ? 1.0f : yc);
+      const float sc = yc / (y + 1e-10f);
       for(int m = 0; m < 3; m++) xyz[m] *= sc;
     }
-    mat3_mulv(rgb, sim->m_out, xyz);
+    mat3_mulv_f(rgb, sim->m_out_f, xyz);
     if(sim->out_compress == SF_OUTPUT_COMPRESS_OKLCH)
-      compress_rgb_oklch(sim, rgb);
+      compress_rgb_oklch_f(sim, rgb);
     else if(sim->out_compress == SF_OUTPUT_COMPRESS_ACES_RGC)
-      compress_rgb_aces(rgb);
+      compress_rgb_aces_f(rgb);
     /* after the compressor, so it scales the finished colour instead of driving more of it into the
        compressor -- see out_scale in the header */
     if(sim->out_scale != 1.0)
-      for(int m = 0; m < 3; m++) rgb[m] *= sim->out_scale;
-    for(int c = 0; c < 3; c++) out[c] = (float)rgb[c];
+      for(int m = 0; m < 3; m++) rgb[m] *= (float)sim->out_scale;
+    for(int c = 0; c < 3; c++) out[c] = rgb[c];
   }
 }
 
@@ -4073,7 +4372,9 @@ sf_sim_gpu_t *sf_sim_gpu_export(const sf_sim_t *s)
   g->tc_lut = dup_f(s->tc_lut, (size_t)s->tc_n * s->tc_n * 3);
 
   g->le0 = (float)s->le0;
-  g->le_step = (float)s->le_step;
+  /* already the correctly-rounded reciprocal the CPU path itself uses; see
+     the inv_le_step comment in spektra_sim.h */
+  g->inv_le_step = s->inv_le_step;
   g->curves_norm = dup_f3(s->curves_norm, SF_NLE);
   g->curves_before = dup_f3(s->curves_before, SF_NLE);
   cp33f(g->couplers_M, (const double (*)[3])s->couplers_M);
@@ -4122,7 +4423,13 @@ sf_sim_gpu_t *sf_sim_gpu_export(const sf_sim_t *s)
     for(int c = 0; c < 3; c++)
     {
       g->enl_lo[c] = (float)s->enl_lo[c];
-      g->enl_hi[c] = (float)s->enl_hi[c];
+      /* Not (float)s->enl_hi[c] -- the kernel no longer receives hi at all.
+         See spektrafilm.cl's spektrafilm_print_expose for why re-deriving
+         hi-lo on-device is the wrong thing to upload; this is already the
+         single correctly-rounded reciprocal the CPU fast path itself uses
+         (sf_sim_print_expose above), so GPU and CPU now run byte-identical
+         range math instead of two different roundings of the same range. */
+      g->enl_inv_range[c] = s->enl_inv_range[c];
     }
     g->enl_lut = dup_f(s->enl_lut, n3);
     g->enl_sx = dup_f(s->enl_sx, n3);
@@ -4130,13 +4437,14 @@ sf_sim_gpu_t *sf_sim_gpu_export(const sf_sim_t *s)
     g->enl_sz = dup_f(s->enl_sz, n3);
     g->enl_cmin = dup_f(s->enl_cmin, m3);
     g->enl_cmax = dup_f(s->enl_cmax, m3);
-    g->print_exposure = (float)s->print_exposure;
+    g->log10_print_exposure = s->log10_print_exposure;
     g->print_curves = dup_f3(s->print_curves, SF_NLE);
   }
   for(int c = 0; c < 3; c++)
   {
     g->scan_lo[c] = (float)s->scan_lo[c];
-    g->scan_hi[c] = (float)s->scan_hi[c];
+    /* see the enl_inv_range comment above */
+    g->scan_inv_range[c] = s->scan_inv_range[c];
   }
   g->scan_lut = dup_f(s->scan_lut, n3);
   g->scan_sx = dup_f(s->scan_sx, n3);

--- a/src/common/spektra_sim.h
+++ b/src/common/spektra_sim.h
@@ -194,7 +194,12 @@ typedef struct sf_sim_gpu_t
   int tc_n;
   float *tc_lut; /* tc_n * tc_n * 3 */
   /* film develop */
-  float le0, le_step;
+  /* inv_le_step = 1/le_step, computed once in double by the host and rounded
+     a single time to float -- the same value the CPU path uses in
+     interp_curve_uniform_f(). Not le_step: the kernel must not re-derive the
+     reciprocal on-device from an independently-rounded le_step, for the same
+     reason as enl_inv_range below. */
+  float le0, inv_le_step;
   float *curves_norm;   /* SF_NLE*3 */
   float *curves_before; /* SF_NLE*3 (== curves_norm when couplers off) */
   float couplers_M[9];  /* row donor -> column receiver, amount-scaled */
@@ -202,13 +207,25 @@ typedef struct sf_sim_gpu_t
   int film_positive, couplers_active;
   /* printing (has_print == 0 in scan-film mode; buffers NULL then) */
   int has_print, steps;
-  float enl_lo[3], enl_hi[3];
+  /* enl_inv_range[c] = 1/(enl_hi[c]-enl_lo[c]), computed once in double
+     precision by the host (spektra_sim.c's sf_sim_build) and rounded a
+     single time to float -- the same value the CPU fast path uses in
+     sf_sim_print_expose. Not enl_hi: the kernel must not re-derive
+     hi-lo on-device from independently-rounded lo/hi, which is a
+     catastrophic-cancellation hazard on narrow-range channels and was
+     the source of a real CPU/GPU divergence (see spektrafilm.cl's
+     spektrafilm_print_expose). */
+  float enl_lo[3], enl_inv_range[3];
   float *enl_lut, *enl_sx, *enl_sy, *enl_sz; /* steps^3 * 3 */
   float *enl_cmin, *enl_cmax;                /* (steps-1)^3 * 3 */
-  float print_exposure;
+  /* log10_print_exposure, NOT print_exposure: the print exposure is applied
+     as an addition in the log domain (see spektrafilm_print_expose), matching
+     what sf_sim_print_expose does on the CPU. */
+  float log10_print_exposure;
   float *print_curves; /* SF_NLE*3 */
   /* scanning */
-  float scan_lo[3], scan_hi[3];
+  /* scan_inv_range[c] = 1/(scan_hi[c]-scan_lo[c]); see enl_inv_range above. */
+  float scan_lo[3], scan_inv_range[3];
   float *scan_lut, *scan_sx, *scan_sy, *scan_sz, *scan_cmin, *scan_cmax;
   float m_out[9]; /* XYZ(view illuminant) -> output RGB, CAT02 included */
   int scan_bw_on;   /* scanner black/white point (positive film scans) */

--- a/src/iop/spektrafilm.c
+++ b/src/iop/spektrafilm.c
@@ -2192,6 +2192,27 @@ int process_cl(dt_iop_module_t *self,
    fallback above SF_GAUSS_EXACT_MAX_SIGMA -- scatter's core/tail sigmas are
    normally small (sub-few-px), but the fallback is here for whatever a user's
    scatter_scale slider can push them to. */
+/* Exact-kernel-only single-channel blur, the GPU twin of sf_blur_plane1():
+   that function passes exact_only=1 unconditionally, so its call sites must
+   NOT fall back to the recursive approximation at large sigma the way
+   SF_GAUSS_BLUR1_L below does. Used by the grain dye-cloud blur. */
+#define SF_GAUSS_BLUR1_EXACT(buf, _sg) do { \
+    if(err == CL_SUCCESS) \
+    { \
+      float _kw[2 * SF_GAUSS_MAX_RADIUS + 1]; \
+      const int _kr = dt_gaussian_kernel_1d((_sg), _kw, SF_GAUSS_MAX_RADIUS); \
+      err = dt_opencl_write_buffer_to_device(devid, _kw, gauss_w, 0, \
+                                             sizeof(float) * (2 * _kr + 1), TRUE); \
+      if(err == CL_SUCCESS) \
+        err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_gauss_row_1c, w, h, \
+                                               CLARG(buf), CLARG(gtmp1), CLARG(w), CLARG(h), \
+                                               CLARG(gauss_w), CLARG(_kr)); \
+      if(err == CL_SUCCESS) \
+        err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_gauss_col_1c, w, h, \
+                                               CLARG(gtmp1), CLARG(buf), CLARG(w), CLARG(h), \
+                                               CLARG(gauss_w), CLARG(_kr)); \
+    } \
+  } while(0)
 #define SF_GAUSS_BLUR1_L(buf, _sg) do { \
     if(err == CL_SUCCESS) \
     { \
@@ -2241,10 +2262,17 @@ int process_cl(dt_iop_module_t *self,
                                d->p.diffusion_warmth, &plan)
        && plan.p_s > 0.0f)
     {
-      const float dsc = fmaxf(d->p.diffusion_scale, 1e-6f);
+      /* double, and no 1e-3f floor: sf_diffusion_filter() computes
+         (float)(sigma_um * sc / fmax(pixel_um, 1e-3)) with sc and the divide
+         both in double and no clamp on the result. Computing the same value
+         in float here gave a slightly different sigma, hence a different
+         kernel out of dt_gaussian_kernel_1d(), hence a different blur on
+         every pixel the filter touches. */
+      const double dsc = fmax((double)d->p.diffusion_scale, 1e-6);
       for(int j = 0; j < plan.n; j++)
       {
-        const float sigma = fmaxf(plan.sigma_um[j] * dsc / pixel_um, 1e-3f);
+        const float sigma
+            = (float)((double)plan.sigma_um[j] * dsc / fmax((double)pixel_um, 1e-3));
         SF_GAUSS_BLUR4_OP_L(plane, tmpa, sigma);
         if(err != CL_SUCCESS) break;
         const int reset = (j == 0);
@@ -2265,6 +2293,40 @@ int process_cl(dt_iop_module_t *self,
     }
   }
 
+  /* ---- sigma parity with the CPU ------------------------------------------
+     Every blur sigma below is derived from the SAME doubles, by the SAME
+     expression in the SAME association, at the SAME precision, with the SAME
+     floor as its twin in process()/spektra_core.c.
+
+     Both halves of that matter. Reading the float mirrors in sf_sim_gpu_t is
+     already wrong -- (double)(float)x != x -- so these call the sim accessors
+     directly, exactly as process() does, and only round at the end.
+
+     This is not pedantry. Above SF_GAUSS_EXACT_MAX_SIGMA both paths leave the
+     truncated kernel for the Young-van Vliet recursion. sf_gauss_yvv_coeffs()
+     maps sigma continuously onto B/B1/B2/B3, and an IIR response depends
+     globally on those: the forward pass carries any perturbation to the end of
+     every line, the backward pass carries it back, and the column pass spreads
+     it down every column it touched. So a last-place difference in sigma --
+     from float instead of double, from a*b*c/d instead of a*b/d*c, or from a
+     1e-3f floor instead of 1e-6f -- stops being a rounding difference and
+     becomes a different filter over the whole image. Below the threshold the
+     same mismatch is invisible, which is precisely the sigma-dependence the
+     CPU/GPU integration test showed.
+     -------------------------------------------------------------------- */
+  double cl_hal_strength[3], cl_hal_sigma_um = 0.0;
+  double cl_sc_core[3], cl_sc_tail[3], cl_sc_w[3];
+  if(d->p.halation_on)
+  {
+    sf_sim_halation_params(sim, cl_hal_strength, &cl_hal_sigma_um);
+    cl_hal_sigma_um = fmin(cl_hal_sigma_um, (double)SF_HALATION_FIRST_SIGMA_UM);
+    sf_sim_scatter_params(sim, cl_sc_core, cl_sc_tail, cl_sc_w);
+    for(int c = 0; c < 3; c++)
+    {
+      cl_sc_core[c] = fmin(cl_sc_core[c], (double)SF_SCATTER_CORE_CLAMP_UM);
+      cl_sc_tail[c] = fmin(cl_sc_tail[c], (double)SF_SCATTER_TAIL_CLAMP_UM);
+    }
+  }
   if(d->p.halation_on && (d->p.scatter_amount > 0.0f || d->p.halation_amount > 0.0f))
   {
     if(d->p.scatter_amount > 0.0f)
@@ -2276,13 +2338,9 @@ int process_cl(dt_iop_module_t *self,
          channel into the single-channel scratch buffer plane1, blur it
          alone (1x the work of a same-size float4 blur, not 4x), then
          kernel_channel_accum folds it into the target channel of tmpa/acc. */
-      /* per-film scatter PSF, same clamps as the CPU path */
-      float sc_core[3], sc_tail[3];
-      for(int c = 0; c < 3; c++)
-      {
-        sc_core[c] = fminf(g->scatter_core_um[c], SF_SCATTER_CORE_CLAMP_UM);
-        sc_tail[c] = fminf(g->scatter_tail_um[c], SF_SCATTER_TAIL_CLAMP_UM);
-      }
+      /* per-film scatter PSF: cl_sc_core/cl_sc_tail above, clamped in double
+         from the sim's own values -- not fminf() on sf_sim_gpu_t's float
+         mirrors, which rounds once more than the CPU does. */
       const float amp[3] = { 0.1633f, 0.6496f, 0.1870f }, rat[3] = { 0.5360f, 1.5236f, 2.7684f };
       for(int c = 0; c < 3; c++)
       {
@@ -2290,7 +2348,9 @@ int process_cl(dt_iop_module_t *self,
                                                CLARG(plane), CLARG(plane1), CLARG(w), CLARG(h),
                                                CLARG(c));
         if(err != CL_SUCCESS) break;
-        SF_GAUSS_BLUR1_L(plane1, fmaxf(sc_core[c] * sscl / pixel_um, 1e-6f));
+        /* CPU: fmaxf((float)(sc_core[c] * scl / pixel_um), 1e-6f) */
+        SF_GAUSS_BLUR1_L(plane1, fmaxf((float)(cl_sc_core[c] * (double)sscl
+                                               / (double)pixel_um), 1e-6f));
         if(err != CL_SUCCESS) break;
         const float core_weight = 1.0f;
         const int core_reset = (c == 0);
@@ -2306,7 +2366,10 @@ int process_cl(dt_iop_module_t *self,
                                                  CLARG(plane), CLARG(plane1), CLARG(w), CLARG(h),
                                                  CLARG(c));
           if(err != CL_SUCCESS) break;
-          const float sigma = fmaxf(rat[g3] * sc_tail[c] * sscl / pixel_um, 1e-6f);
+          /* CPU associates as rat * (tail * scl / pixel_um), in double */
+          const float sigma = fmaxf((float)((double)rat[g3]
+                                            * (cl_sc_tail[c] * (double)sscl
+                                               / (double)pixel_um)), 1e-6f);
           SF_GAUSS_BLUR1_L(plane1, sigma);
           if(err != CL_SUCCESS) break;
           const int reset = (g3 == 0 && c == 0);
@@ -2336,11 +2399,17 @@ int process_cl(dt_iop_module_t *self,
       /* per-film first-bounce radius (still ~65um / cine ~50um on real
          stocks); clamped to what modify_roi_in()/tiling_callback() padded
          for, see the matching comment in process(). */
-      const float first_sigma = fminf(g->halation_first_sigma_um, SF_HALATION_FIRST_SIGMA_UM);
+      /* clamped in double above, as process() clamps hal_sigma_um */
       const float dec[3] = { 1.0f/1.75f, 0.5f/1.75f, 0.25f/1.75f };
       for(int k = 1; k <= N; k++)
       {
-        SF_GAUSS_BLUR4_OP_L(plane, plane2, fmaxf(first_sigma * hscl * sqrtf((float)k) / pixel_um, 1e-3f));
+        /* CPU: fmaxf((float)((first_sigma_um * hscl / pixel_um) * sqrt((double)k)), 1e-6f).
+           Five mismatches lived on this line -- the float mirror instead of the
+           double, float arithmetic, sqrtf(float) for sqrt(double), the divide
+           moved to the end, and a 1e-3f floor against the CPU's 1e-6f. */
+        SF_GAUSS_BLUR4_OP_L(plane, plane2,
+                            fmaxf((float)((cl_hal_sigma_um * (double)hscl
+                                           / (double)pixel_um) * sqrt((double)k)), 1e-6f));
         if(err != CL_SUCCESS) break;
         const int reset = (k == 1);
         err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_accum, w, h, CLARG(plane2),
@@ -2373,8 +2442,8 @@ int process_cl(dt_iop_module_t *self,
     err = dt_opencl_enqueue_kernel_2d_args(
         devid, gd->kernel_develop_corr, w, h, CLARG(plane), CLARG(acc), CLARG(w), CLARG(h),
         CLARG(cn_cl), CLARG(mats_cl),
-        CLARG(g->le0), CLARG(g->le_step), CLARG(g->film_dmax[0]), CLARG(g->film_dmax[1]),
-        CLARG(g->film_dmax[2]), CLARG(g->film_positive));
+        CLARG(g->le0), CLARG(g->inv_le_step), CLARG(g->film_dmax[0]), CLARG(g->film_dmax[1]),
+        CLARG(g->film_dmax[2]), CLARG(g->film_positive), CLARG(g->couplers_donor_lm));
     SF_CL_STEP("develop_corr");
     /* DIR coupler inhibitor diffusion, gaussian sigma 20 um (reference value) */
     const float csigma = g->coupler_diff_um / fmaxf(pixel_um, 1e-3f);
@@ -2382,12 +2451,20 @@ int process_cl(dt_iop_module_t *self,
     {
       const float amp[4] = { 1.0f - g->coupler_tail_w, g->coupler_tail_w * SF_EXPTAIL_A0,
                              g->coupler_tail_w * SF_EXPTAIL_A1, g->coupler_tail_w * SF_EXPTAIL_A2 };
-      const float sig[4] = { csigma, SF_EXPTAIL_R0 * g->coupler_tail_um / fmaxf(pixel_um, 1e-3f),
-                             SF_EXPTAIL_R1 * g->coupler_tail_um / fmaxf(pixel_um, 1e-3f),
-                             SF_EXPTAIL_R2 * g->coupler_tail_um / fmaxf(pixel_um, 1e-3f) };
+      /* CPU computes tail_px = ctail_um / pixel_um once and then
+         rat[g3] * tail_px -- R * (tail / pixel), not (R * tail) / pixel. */
+      const float tail_px = g->coupler_tail_um / fmaxf(pixel_um, 1e-3f);
+      const float sig[4] = { csigma, SF_EXPTAIL_R0 * tail_px,
+                             SF_EXPTAIL_R1 * tail_px, SF_EXPTAIL_R2 * tail_px };
       for(int g3 = 0; g3 < 4; g3++)
       {
-        if(sig[g3] > 0.1f)
+        /* >= SF_GAUSS_MIN_SIGMA, not > 0.1f: the CPU twin guards with
+           `if(ts > 0.1f) sf_blur_plane3_fast(...)`, and sf_blur_plane3_fast
+           itself returns without touching the buffer below
+           SF_GAUSS_MIN_SIGMA -- so the CPU blurs iff the sigma clears 0.3.
+           Between 0.1 and 0.3 it copies the unblurred correction, which is
+           what the else branch below already does. */
+        if(sig[g3] >= SF_GAUSS_MIN_SIGMA)
         {
           SF_GAUSS_BLUR4_OP_L(acc, plane2, sig[g3]);
           if(err != CL_SUCCESS) break;
@@ -2406,13 +2483,16 @@ int process_cl(dt_iop_module_t *self,
       }
     }
     else if(csigma > 0.1f)
-      SF_GAUSS_BLUR4_FAST(acc, csigma, "coupler blur");
+      /* CPU twin is sf_blur_plane3_fast(), which returns without touching the
+         buffer below SF_GAUSS_MIN_SIGMA -- match that cut here. */
+      if(csigma >= SF_GAUSS_MIN_SIGMA)
+        SF_GAUSS_BLUR4_FAST(acc, csigma, "coupler blur");
   }
   cl_mem corr_buf = (g->coupler_tail_w > 0.0f) ? tmpa : acc;
   err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_develop, w, h, CLARG(plane),
                                          CLARG(corr_buf), CLARG(use_corr), CLARG(plane2), CLARG(w),
                                          CLARG(h), CLARG(cb_cl), CLARG(mats_cl), CLARG(g->le0),
-                                         CLARG(g->le_step));
+                                         CLARG(g->inv_le_step), CLARG(g->couplers_recv_lm));
   SF_CL_STEP("develop");
 
   /* ---- 4) grain on the developed CMY density ----------------------------- */
@@ -2518,7 +2598,9 @@ int process_cl(dt_iop_module_t *self,
                 CLARG(npart_scale), CLARG(d->grain_cl_dmax), CLARG(d->grain_cl_npart),
                 CLARG(d->grain_cl_dmin), CLARG(d->grain_cl_total), CLARG(d->grain_cl_curve));
             if(err == CL_SUCCESS && dye_sigma[channel_idx][sl] > 1e-6f)
-              SF_GAUSS_BLUR1_L(raw_buf[sl], dye_sigma[channel_idx][sl]);
+              /* exact-only: the CPU twin is sf_blur_plane1(), which never takes
+                 the recursive path (see SF_GAUSS_BLUR1_EXACT) */
+              SF_GAUSS_BLUR1_EXACT(raw_buf[sl], dye_sigma[channel_idx][sl]);
           }
           for(int sl = 0; sl < nsub && err == CL_SUCCESS; sl++)
           {
@@ -2558,13 +2640,21 @@ int process_cl(dt_iop_module_t *self,
        there for the empirical validation. */
     const float gsigma = SF_GRAIN_BLUR_FACTOR * fmaxf(d->p.grain_blur, SF_GRAIN_BLUR_MIN)
                           * preview_scale;
-    SF_GAUSS_BLUR4(plane2, gsigma, "grain blur");
+    /* CPU twin is sf_blur_plane3(), which skips below SF_GAUSS_MIN_SIGMA.
+       This one matters most: the clump blur runs on the grain field, which is
+       high-frequency by construction, so blurring here where the CPU does not
+       changes essentially every grained pixel. */
+    if(gsigma >= SF_GAUSS_MIN_SIGMA)
+      SF_GAUSS_BLUR4(plane2, gsigma, "grain blur");
     if(d->p.grain_usm_sigma > 0.0f && d->p.grain_usm_amount > 0.0f)
     {
       err = dt_opencl_enqueue_copy_buffer_to_buffer(devid, plane2, acc, 0, 0, npix * f * 4);
       if(err != CL_SUCCESS) goto cleanup;
       const float usig = d->p.grain_usm_sigma * preview_scale;
-      SF_GAUSS_BLUR4_FAST(plane2, usig, "grain USM blur");
+      /* sf_multiplicative_unsharp_mask3() blurs via sf_blur_plane3(), so this
+         is exact-only and skipped below SF_GAUSS_MIN_SIGMA -- not _FAST. */
+      if(usig >= SF_GAUSS_MIN_SIGMA)
+        SF_GAUSS_BLUR4(plane2, usig, "grain USM blur");
       err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_grain_usm, w, h, CLARG(plane2),
                                              CLARG(acc), CLARG(w), CLARG(h),
                                              CLARG(d->p.grain_usm_amount),
@@ -2581,7 +2671,8 @@ int process_cl(dt_iop_module_t *self,
         devid, gd->kernel_print_expose, w, h, CLARG(plane2), CLARG(plane), CLARG(w), CLARG(h),
         CLARG(el_cl), CLARG(ex_cl), CLARG(ey_cl), CLARG(ez_cl), CLARG(en_cl), CLARG(em_cl),
         CLARG(steps), CLARG(g->enl_lo[0]), CLARG(g->enl_lo[1]), CLARG(g->enl_lo[2]),
-        CLARG(g->enl_hi[0]), CLARG(g->enl_hi[1]), CLARG(g->enl_hi[2]), CLARG(g->print_exposure));
+        CLARG(g->enl_inv_range[0]), CLARG(g->enl_inv_range[1]), CLARG(g->enl_inv_range[2]),
+        CLARG(g->log10_print_exposure));
     SF_CL_STEP("print_expose");
     /* ---- print diffusion (optional, on the exposed print density) ---- */
     if(d->p.print_diffusion_on)
@@ -2592,10 +2683,12 @@ int process_cl(dt_iop_module_t *self,
                                  d->p.print_diffusion_warmth, &pplan)
          && pplan.p_s > 0.0f)
       {
-        const float pdsc = fmaxf(d->p.print_diffusion_scale, 1e-6f);
+        /* see the pre-film diffusion above for why this is in double */
+        const double pdsc = fmax((double)d->p.print_diffusion_scale, 1e-6);
         for(int j = 0; j < pplan.n; j++)
         {
-          const float sigma = fmaxf(pplan.sigma_um[j] * pdsc / pixel_um, 1e-3f);
+          const float sigma
+              = (float)((double)pplan.sigma_um[j] * pdsc / fmax((double)pixel_um, 1e-3));
           SF_GAUSS_BLUR4_OP_L(plane, tmpa, sigma);
           if(err != CL_SUCCESS) break;
           const int reset = (j == 0);
@@ -2617,7 +2710,7 @@ int process_cl(dt_iop_module_t *self,
     }
     err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_print_develop, w, h, CLARG(plane),
                                            CLARG(plane2), CLARG(w), CLARG(h), CLARG(pc_cl),
-                                           CLARG(g->le0), CLARG(g->le_step));
+                                           CLARG(g->le0), CLARG(g->inv_le_step));
     SF_CL_STEP("print_develop");
   }
 
@@ -2626,8 +2719,9 @@ int process_cl(dt_iop_module_t *self,
       devid, gd->kernel_scan, w, h, CLARG(plane2), CLARG(plane), CLARG(w), CLARG(h),
       CLARG(sl_cl), CLARG(sx_cl), CLARG(sy_cl),
       CLARG(sz_cl), CLARG(sn_cl), CLARG(sm_cl), CLARG(steps), CLARG(g->scan_lo[0]),
-      CLARG(g->scan_lo[1]), CLARG(g->scan_lo[2]), CLARG(g->scan_hi[0]), CLARG(g->scan_hi[1]),
-      CLARG(g->scan_hi[2]), CLARG(mats_cl), CLARG(cm_cl), CLARG(g->cmax_nl), CLARG(g->cmax_nh),
+      CLARG(g->scan_lo[1]), CLARG(g->scan_lo[2]), CLARG(g->scan_inv_range[0]),
+      CLARG(g->scan_inv_range[1]), CLARG(g->scan_inv_range[2]), CLARG(mats_cl), CLARG(cm_cl),
+      CLARG(g->cmax_nl), CLARG(g->cmax_nh),
       CLARG(g->out_compress), CLARG(g->out_luminance_boost), CLARG(g->out_scale),
       CLARG(g->scan_bw_on), CLARG(g->scan_bw_m),
       CLARG(g->scan_bw_q));
@@ -2636,13 +2730,18 @@ int process_cl(dt_iop_module_t *self,
   /* ---- 6b) scanner optics + viewing glare (mirrors process()) -------------- */
   if(d->p.scan_blur > 0.0f)
   {
-    SF_GAUSS_BLUR4(plane, d->p.scan_blur * preview_scale, "scanner blur");
+    /* CPU twin is sf_blur_plane3(); mirror its SF_GAUSS_MIN_SIGMA cut */
+    if(d->p.scan_blur * preview_scale >= SF_GAUSS_MIN_SIGMA)
+      SF_GAUSS_BLUR4(plane, d->p.scan_blur * preview_scale, "scanner blur");
   }
   if(d->p.scan_usm_sigma > 0.0f && d->p.scan_usm_amount > 0.0f)
   {
     err = dt_opencl_enqueue_copy_buffer_to_buffer(devid, plane, acc, 0, 0, npix * f * 4);
     if(err != CL_SUCCESS) goto cleanup;
-    SF_GAUSS_BLUR4_FAST(plane, d->p.scan_usm_sigma * preview_scale, "scanner USM blur");
+    /* sf_unsharp_mask3() blurs via sf_blur_plane3(): exact-only, and skipped
+       below SF_GAUSS_MIN_SIGMA -- not _FAST. */
+    if(d->p.scan_usm_sigma * preview_scale >= SF_GAUSS_MIN_SIGMA)
+      SF_GAUSS_BLUR4(plane, d->p.scan_usm_sigma * preview_scale, "scanner USM blur");
     err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_scan_usm, w, h, CLARG(plane),
                                            CLARG(acc), CLARG(w), CLARG(h),
                                            CLARG(d->p.scan_usm_amount));

--- a/src/tests/unittests/common/test_spektra_sim.c
+++ b/src/tests/unittests/common/test_spektra_sim.c
@@ -65,7 +65,11 @@
  */
 
 /* Comparison epsilon. The engine works in double, and every invariant tested
-   here is exact in exact arithmetic, so this only has to absorb rounding. */
+   here is exact in exact arithmetic, so this only has to absorb rounding.
+   The output gamut compressors are the exception -- they run in float to
+   match spektrafilm.cl -- but every value they are asserted against here
+   (0.0, 0.5, 1.5, 2.0) is exactly representable and comes back through an
+   untouched achromatic max, so E holds for those too. */
 #define E 1e-9
 
 /* Compare in double, whatever cmocka happens to be installed.
@@ -213,48 +217,48 @@ static void test_knee_is_continuous_at_threshold(void **state)
 static void test_aces_neutral_is_unchanged(void **state)
 {
   TR_STEP("achromatic pixels pass through the output compressor untouched");
-  double rgb[3] = { 0.5, 0.5, 0.5 };
-  compress_rgb_aces(rgb);
+  float rgb[3] = { 0.5f, 0.5f, 0.5f };
+  compress_rgb_aces_f(rgb);
   for(int c = 0; c < 3; c++) assert_double_close(rgb[c], 0.5, E);
 }
 
 static void test_aces_black_is_identity(void **state)
 {
   TR_STEP("pixels at or below black keep their values -- no chromaticity to compress");
-  double rgb[3] = { 0.0, 0.0, 0.0 };
-  compress_rgb_aces(rgb);
+  float rgb[3] = { 0.0f, 0.0f, 0.0f };
+  compress_rgb_aces_f(rgb);
   for(int c = 0; c < 3; c++) assert_double_close(rgb[c], 0.0, E);
 }
 
 static void test_aces_leaves_the_max_channel_alone(void **state)
 {
   TR_STEP("the achromatic max is the anchor and never moves");
-  double rgb[3] = { 2.0, -0.1, 0.3 };
-  compress_rgb_aces(rgb);
+  float rgb[3] = { 2.0f, -0.1f, 0.3f };
+  compress_rgb_aces_f(rgb);
   assert_double_close(rgb[0], 2.0, E);
 }
 
 static void test_aces_pulls_negatives_back_inside(void **state)
 {
   TR_STEP("out-of-gamut negatives come back non-negative, and by a real margin");
-  double rgb[3] = { 1.5, -0.1, -0.05 };
-  compress_rgb_aces(rgb);
+  float rgb[3] = { 1.5f, -0.1f, -0.05f };
+  compress_rgb_aces_f(rgb);
   assert_double_close(rgb[0], 1.5, E);
-  assert_true(rgb[1] >= 0.0);
-  assert_true(rgb[2] >= 0.0);
+  assert_true(rgb[1] >= 0.0f);
+  assert_true(rgb[2] >= 0.0f);
   /* not merely clipped to a hair above zero: the knee lands them well inside */
-  assert_true(rgb[1] < 0.2 * 1.5);
-  assert_true(rgb[2] < 0.2 * 1.5);
+  assert_true(rgb[1] < 0.2f * 1.5f);
+  assert_true(rgb[2] < 0.2f * 1.5f);
 }
 
 static void test_aces_compresses_stronger_excursions_harder(void **state)
 {
   TR_STEP("the further out of gamut, the closer to the boundary the result lands");
-  double mild[3] = { 1.0, -0.05, -0.05 };
-  double hard[3] = { 1.0, -1.0, -1.0 };
-  compress_rgb_aces(mild);
-  compress_rgb_aces(hard);
-  TR_DEBUG("mild=%e hard=%e", mild[1], hard[1]);
+  float mild[3] = { 1.0f, -0.05f, -0.05f };
+  float hard[3] = { 1.0f, -1.0f, -1.0f };
+  compress_rgb_aces_f(mild);
+  compress_rgb_aces_f(hard);
+  TR_DEBUG("mild=%e hard=%e", (double)mild[1], (double)hard[1]);
   assert_true(hard[1] < mild[1]);
   assert_true(hard[2] < mild[2]);
 }


### PR DESCRIPTION
@TurboGit after a long debug session following up yesterday's changes: With this I get the diff down to 6085 px, seems random over the image:
<img width="2048" height="1369" alt="diff-cl" src="https://github.com/user-attachments/assets/7c148a94-36de-4192-aaaf-d61c65a8fb36" />

The CPU and CL path also get different inputs, so I don't know if the remaining pixels are a real spektrafilm issue

fixes [issue 22165](https://github.com/darktable-org/darktable/issues/22165)

Created with Claude Opus