### PR TITLE
Color Calibration: Clearer WB error message

### DIFF
--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -2071,7 +2071,7 @@ static void _set_trouble_messages(dt_iop_module_t *self)
 
     dt_iop_set_module_trouble_message
       (self,
-        _("white balance module error (<u>details</u>)"),
+        _("bad input white balance (<u>details</u>)"),
         _("the white balance module is not using the camera\n"
           "reference illuminant, which will cause issues here\n"
           "with chromatic adaptation. either set it to reference\n"


### PR DESCRIPTION
A common issue for new users is that they see the `white balance module error` message in Color Calibration and freak out because they think something is broken. This rewords it to `bad input white balance`, which makes it clearer that the White Balance module has in fact not malfunctioned, but rather that it is not configured correctly.

The corresponding error in White Balance could probably also be improved, but it's not too bad, and so far I haven't been able to come up with anything better.

Related: https://github.com/darktable-org/darktable/issues/19374#issuecomment-5463903653
