### PR TITLE
Fix 21974 applied exposure disagreement

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -254,6 +254,10 @@ changes (where available).
   was unavailable, and black-point limits ignoring camera exposure
   compensation, which could invert the tonal range.
 
+- Fixed exposure's area mapping blowing out the image when its target
+  lightness was set to zero. Such a target cannot be reached, so the
+  correction is now left alone instead.
+
 ## Lua
 
 ### API Version

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -250,6 +250,10 @@ changes (where available).
 - Fixed corrupted output or a crash when an AI model returns more data
   than darktable reserved for it, affecting object masks and Lua models.
 
+- Fixed automatic exposure rendering a black image when its raw histogram
+  was unavailable, and black-point limits ignoring camera exposure
+  compensation, which could invert the tonal range.
+
 ## Lua
 
 ### API Version

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -97,6 +97,17 @@ typedef enum dt_clipping_preview_mode_t
   DT_CLIPPING_PREVIEW_SATURATION = 3
 } dt_clipping_preview_mode_t;
 
+// Cross-module access to the current settings of the exposure module, registered by
+// its gui_init() and currently used by the histogram, channelmixerrgb and agx.
+//
+// Thread contract: must only be called from the GTK main thread — the accessors read the
+// exposure module's live `params` and the `module` pointer itself, both owned by that
+// thread. See dev-doc/GUI_Threading.md, "Publishing gui_data Through a Proxy".
+//
+// TODO kofa73 remove once #22005 is fixed
+// Known violation tracked as #22005: channelmixerrgb calls dt_dev_exposure_get_exposure()
+// and dt_dev_exposure_get_black() from _extract_patches(), which runs in process() on the
+// preview pipe thread during colour-checker profiling.
 typedef struct dt_dev_proxy_exposure_t
 {
   struct dt_iop_module_t *module;
@@ -511,6 +522,8 @@ void dt_dev_get_viewport_params(dt_dev_viewport_t *port,
 
 void dt_dev_configure(dt_dev_viewport_t *port);
 
+/** the four calls below go through dt_dev_proxy_exposure_t: GTK main thread only,
+    see the thread contract on that struct */
 /** get exposure level */
 float dt_dev_exposure_get_exposure(dt_develop_t *dev);
 /** get final effective exposure level including compensations */

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -100,14 +100,14 @@ typedef enum dt_clipping_preview_mode_t
 // Cross-module access to the current settings of the exposure module, registered by
 // its gui_init() and currently used by the histogram, channelmixerrgb and agx.
 //
-// Thread contract: must only be called from the GTK main thread — the accessors read the
+// Thread contract: must only be called from the GTK main thread -- the accessors read the
 // exposure module's live `params` and the `module` pointer itself, both owned by that
 // thread. See dev-doc/GUI_Threading.md, "Publishing gui_data Through a Proxy".
 //
-// TODO kofa73 remove once #22005 is fixed
-// Known violation tracked as #22005: channelmixerrgb calls dt_dev_exposure_get_exposure()
-// and dt_dev_exposure_get_black() from _extract_patches(), which runs in process() on the
-// preview pipe thread during colour-checker profiling.
+// TODO: Known violation tracked as #22005 (remove this when fixed):
+// channelmixerrgb calls dt_dev_exposure_get_exposure() and dt_dev_exposure_get_black()
+// from _extract_patches(), which runs in process() on the preview pipe thread during
+// ColorChecker profiling.
 typedef struct dt_dev_proxy_exposure_t
 {
   struct dt_iop_module_t *module;

--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -86,7 +86,6 @@ typedef struct dt_iop_exposure_gui_data_t
   GtkLabel *deflicker_used_EC;
   GtkWidget *compensate_exposure_bias;
   GtkWidget *compensate_hilite_preserv;
-  float effective_exposure; // used to cache the final computed exposure
   float deflicker_computed_exposure;
 
   GtkWidget *spot_mode;
@@ -609,6 +608,26 @@ static float _get_highlight_bias(const dt_iop_module_t *self)
     return 0.0f;
 }
 
+// The exposure the pipe applies in manual mode: the user parameter plus the
+// compensations. commit_params() and the proxy accessor both go through this, so the
+// value other modules read cannot drift away from the one that is processed.
+static float _effective_manual_exposure(const dt_iop_module_t *const self,
+                                        const dt_iop_exposure_params_t *const p)
+{
+  float exposure = p->exposure;
+
+  // If exposure bias compensation has been required, add it on top of
+  // user exposure correction
+  if(p->compensate_exposure_bias)
+    exposure -= _get_exposure_bias(self);
+
+  // If highlight preservation compensation has been required, add it on top of
+  // the previous compensation values
+  if(p->compensate_hilite_pres)
+    exposure += _get_highlight_bias(self);
+
+  return exposure;
+}
 
 void commit_params(dt_iop_module_t *self,
                    dt_iop_params_t *p1,
@@ -619,27 +638,11 @@ void commit_params(dt_iop_module_t *self,
   dt_iop_exposure_data_t *d = piece->data;
 
   d->params.black = p->black;
-  d->params.exposure = p->exposure;
+  d->params.exposure = _effective_manual_exposure(self, p);
   d->params.deflicker_percentile = p->deflicker_percentile;
   d->params.deflicker_target_level = p->deflicker_target_level;
 
-  // If exposure bias compensation has been required, add it on top of
-  // user exposure correction
-  if(p->compensate_exposure_bias)
-    d->params.exposure -= _get_exposure_bias(self);
-
-  // If highlight preservation compensation has been required, add it on top of
-  // the previous compensation values
-//  d->params.compensate_hilite_pres = p->compensate_hilite_pres;
-  if(p->compensate_hilite_pres)
-    d->params.exposure += _get_highlight_bias(self);
-
   d->deflicker = 0;
-
-  if (self->gui_data)
-  {
-    ((dt_iop_exposure_gui_data_t *)self->gui_data)->effective_exposure = d->params.exposure;
-  }
 
   if(p->mode == EXPOSURE_MODE_DEFLICKER
      && dt_image_is_raw(&self->dev->image_storage)
@@ -821,10 +824,32 @@ static float _exposure_proxy_get_black(dt_iop_module_t *self)
   return p->black;
 }
 
+// The exposure that is actually applied, for other modules to read through
+// dev->proxy.exposure. Derived from the parameters on the caller's thread, like
+// _exposure_proxy_get_exposure() and _exposure_proxy_get_black() above: a value cached
+// by the pipe would be one commit behind whenever the caller asks right after a change.
+// Reading params this way is only safe on the GTK thread, which owns them - see the
+// thread contract on dt_dev_proxy_exposure_t in develop.h.
 static float _exposure_proxy_get_effective_exposure(dt_iop_module_t *self)
 {
-  const dt_iop_exposure_gui_data_t* const g = self->gui_data;
-  return g->effective_exposure;
+  const dt_iop_exposure_params_t *const p = self->params;
+
+  if(p->mode == EXPOSURE_MODE_DEFLICKER)
+  {
+    // deflicker computes its correction from the raw histogram inside the pipe, so the
+    // value it caches is the only source; it stays undefined until the preview pipe has
+    // run once, and there is no GUI to cache it in outside the darkroom
+    const dt_iop_exposure_gui_data_t *const g = self->gui_data;
+    if(!g) return 0.f;
+
+    dt_iop_gui_enter_critical_section(self);
+    const float computed = g->deflicker_computed_exposure;
+    dt_iop_gui_leave_critical_section(self);
+
+    return computed == EXPOSURE_CORRECTION_UNDEFINED ? 0.f : computed;
+  }
+
+  return _effective_manual_exposure(self, p);
 }
 
 static void _exposure_proxy_handle_event(int n_press,
@@ -905,16 +930,8 @@ static void _auto_set_exposure(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe)
 
   if(mode == DT_SPOT_MODE_MEASURE)
   {
-    // get the exposure setting
-    float expo = p->exposure;
-
-    // If the exposure bias compensation is on, we need to add it to the user param
-    if(p->compensate_exposure_bias)
-      expo -= _get_exposure_bias(self);
-
-    // If the highlight preservation mode is on, we need to add it to the user param
-    if(p->compensate_hilite_pres)
-      expo += _get_highlight_bias(self);
+    // the exposure the pipe applies, i.e. the user setting plus the compensations
+    const float expo = _effective_manual_exposure(self, p);
 
     const float white = exposure2white(-expo);
 

--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -40,6 +40,7 @@
 #include "gui/color_picker_proxy.h"
 #include "iop/iop_api.h"
 
+// 'white' is the value that is mapped to 1.0 after exposure correction
 #define exposure2white(x) exp2f(-(x))
 #define white2exposure(x) -dt_log2f(fmaxf(1e-20f, x))
 
@@ -513,7 +514,9 @@ static void _process_common_setup(dt_iop_module_t *self,
   }
 
   // no deflicker, or deflicker failed: use the user-set exposure
-  if(exposure == EXPOSURE_CORRECTION_UNDEFINED) exposure = d->params.exposure;
+  if(exposure == EXPOSURE_CORRECTION_UNDEFINED)
+    exposure = d->params.exposure;
+
   const float white = exposure2white(exposure);
   d->scale = 1.0 / (white - d->black);
 }
@@ -609,25 +612,44 @@ static float _get_highlight_bias(const dt_iop_module_t *self)
     return 0.0f;
 }
 
-// The exposure the pipe applies in manual mode: the user parameter plus the
-// compensations. commit_params() and the proxy accessor both go through this, so the
-// value other modules read cannot drift away from the one that is processed.
-static float _effective_manual_exposure(const dt_iop_module_t *const self,
-                                        const dt_iop_exposure_params_t *const p)
+// The correction, in EV, that the module adds on top of the user's exposure parameter to
+// account for the two biases recorded in EXIF.
+// Both directions of the conversion (see below) go through this, so they
+// cannot drift apart.
+static inline float _exposure_compensation_ev(const dt_iop_module_t *const self,
+                                              const dt_iop_exposure_params_t *const p)
 {
-  float exposure = p->exposure;
+  float compensation = 0.0f;
 
-  // If exposure bias compensation has been required, add it on top of
-  // user exposure correction
+  // compensate the correction the user dialled into the camera
   if(p->compensate_exposure_bias)
-    exposure -= _get_exposure_bias(self);
+    compensation -= _get_exposure_bias(self);
 
-  // If highlight preservation compensation has been required, add it on top of
-  // the previous compensation values
+  // undo the underexposure the camera applied automatically
   if(p->compensate_hilite_pres)
-    exposure += _get_highlight_bias(self);
+    compensation += _get_highlight_bias(self);
 
-  return exposure;
+  return compensation;
+}
+
+// The total exposure adjustment the pipe applies in manual mode: the slider plus the
+// exposure compensation. commit_params() and the proxy accessor both go through this,
+// so the value other modules read cannot drift away from the one that is processed.
+static inline float _total_adjustment_ev(const dt_iop_module_t *const self,
+                                         const dt_iop_exposure_params_t *const p)
+{
+  return p->exposure + _exposure_compensation_ev(self, p);
+}
+
+// The inverse: the value to store in p->exposure (i.e. where to move the exposure slider)
+// so that the pipe ends up applying `total_adjustment_ev`. The GUI needs it because it
+// reasons in terms of the total adjustment - that is what black has to stay below - but
+// writes the user parameter (slider value).
+static inline float _required_exposure_slider_ev(const dt_iop_module_t *const self,
+                                                 const dt_iop_exposure_params_t *const p,
+                                                 const float total_adjustment_ev)
+{
+  return total_adjustment_ev - _exposure_compensation_ev(self, p);
 }
 
 void commit_params(dt_iop_module_t *self,
@@ -639,7 +661,7 @@ void commit_params(dt_iop_module_t *self,
   dt_iop_exposure_data_t *d = piece->data;
 
   d->params.black = p->black;
-  d->params.exposure = _effective_manual_exposure(self, p);
+  d->params.exposure = _total_adjustment_ev(self, p);
   d->params.deflicker_percentile = p->deflicker_percentile;
   d->params.deflicker_target_level = p->deflicker_target_level;
 
@@ -766,12 +788,16 @@ void cleanup_global(dt_iop_module_so_t *self)
   self->data = NULL;
 }
 
+// Set the exposure parameter (slider value) such that 'white' is mapped to 1.0 after
+// commit_params() re-applies the compensations. Callers work in that domain
+// because p->black does too - black is never compensated - so the black clamps can
+// compare the two directly.
 static void _exposure_set_white(dt_iop_module_t *self,
                                 const float white)
 {
   dt_iop_exposure_params_t *p = self->params;
 
-  const float exposure = white2exposure(white);
+  const float exposure = _required_exposure_slider_ev(self, p, white2exposure(white));
   if(p->exposure == exposure) return;
 
   p->exposure = exposure;
@@ -807,7 +833,7 @@ static void _exposure_set_black(dt_iop_module_t *self,
   if(p->black == black) return;
 
   p->black = black;
-  if(p->black >= exposure2white(p->exposure))
+  if(p->black >= exposure2white(_total_adjustment_ev(self, p)))
   {
     _exposure_set_white(self, p->black + 0.01);
   }
@@ -850,7 +876,7 @@ static float _exposure_proxy_get_effective_exposure(dt_iop_module_t *self)
     return computed == EXPOSURE_CORRECTION_UNDEFINED ? 0.f : computed;
   }
 
-  return _effective_manual_exposure(self, p);
+  return _total_adjustment_ev(self, p);
 }
 
 static void _exposure_proxy_handle_event(int n_press,
@@ -932,9 +958,10 @@ static void _auto_set_exposure(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe)
   if(mode == DT_SPOT_MODE_MEASURE)
   {
     // the exposure the pipe applies, i.e. the user setting plus the compensations
-    const float expo = _effective_manual_exposure(self, p);
+    const float exposure_adjustment = _total_adjustment_ev(self, p);
 
-    const float white = exposure2white(-expo);
+    // the value that gets mapped to 1.0
+    const float white = exposure2white(-exposure_adjustment);
 
     // apply the exposure compensation
     dt_aligned_pixel_t XYZ_out = {0.0f };
@@ -968,20 +995,8 @@ static void _auto_set_exposure(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe)
     dt_aligned_pixel_t XYZ_target = { 0.f };
     dt_Lab_to_XYZ(Lab_target, XYZ_target);
 
-    // Get the ratio
-    float white =  XYZ[1] / XYZ_target[1];
-    float expo = -white2exposure(white);
-
-    // If the exposure bias compensation is on, we need to subtract it from the user param
-    if(p->compensate_exposure_bias)
-      expo -= _get_exposure_bias(self);
-
-    // If the highlight preservation mode is on, we need to add it to the user param
-    if(p->compensate_hilite_pres)
-      expo += _get_highlight_bias(self);
-
-    white = exposure2white(-expo);
-    _exposure_set_white(self, white);
+    // set exposure slider from the ratio
+    _exposure_set_white(self, XYZ[1] / XYZ_target[1]);
   }
 }
 
@@ -1030,15 +1045,28 @@ void gui_changed(dt_iop_module_t *self,
         break;
     }
   }
-  else if(w == g->exposure)
+  // The two branches below keep black under the white point the pipe will use, so that
+  // white - black stays positive and d->scale does not blow up or turn negative.
+  // Both are restricted to manual mode: only there is the white point defined by the
+  // parameters. In deflicker mode the pipe derives it from the raw histogram, so there
+  // is nothing here to validate against, and repairing by writing p->exposure would
+  // only move a control that the pipe ignores.
+  else if(p->mode == EXPOSURE_MODE_MANUAL
+          && (w == g->exposure
+              || w == g->compensate_exposure_bias
+              || w == g->compensate_hilite_preserv))
   {
-    const float white = exposure2white(p->exposure);
+    // If any of that changed, the exposure compensation may have changed (does not,
+    // if a checkbox was toggled whose corresponding value is 0). The 'white' point that will be
+    // mapped to 1.0 may have moved below the black point, so make sure black stays below that.
+    const float white = exposure2white(_total_adjustment_ev(self, p));
     if(p->black >= white)
       _exposure_set_black(self, white - 0.01);
   }
-  else if(w == g->black)
+  // the inverse path: black moved -> move the exposure slider to keep 'white' above black
+  else if(p->mode == EXPOSURE_MODE_MANUAL && w == g->black)
   {
-    const float white = exposure2white(p->exposure);
+    const float white = exposure2white(_total_adjustment_ev(self, p));
     if(p->black >= white)
       _exposure_set_white(self, p->black + 0.01);
   }

--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -436,15 +436,13 @@ static double _raw_to_ev(const uint32_t raw,
   return raw_ev;
 }
 
-static void _compute_correction(dt_iop_module_t *self,
-                                dt_iop_exposure_params_t *p,
+static void _compute_correction(dt_iop_exposure_params_t *p,
                                 dt_dev_pixelpipe_t *pipe,
                                 const uint32_t *const histogram,
                                 const dt_dev_histogram_stats_t *const histogram_stats,
                                 float *correction)
 {
-  *correction = EXPOSURE_CORRECTION_UNDEFINED;
-
+  // preserve caller's correction if we cannot compute anything
   if(histogram == NULL) return;
 
   const double thr
@@ -481,14 +479,15 @@ static void _process_common_setup(dt_iop_module_t *self,
   dt_iop_exposure_data_t *d = piece->data;
 
   d->black = d->params.black;
-  float exposure = d->params.exposure;
+  // stays undefined unless deflicker computes a correction below
+  float exposure = EXPOSURE_CORRECTION_UNDEFINED;
 
   if(d->deflicker)
   {
     if(g)
     {
       // histogram is precomputed and cached
-      _compute_correction(self, &d->params, piece->pipe,
+      _compute_correction(&d->params, piece->pipe,
                           g->deflicker_histogram, &g->deflicker_histogram_stats,
                           &exposure);
     }
@@ -497,7 +496,7 @@ static void _process_common_setup(dt_iop_module_t *self,
       uint32_t *histogram = NULL;
       dt_dev_histogram_stats_t histogram_stats;
       _deflicker_prepare_histogram(self, &histogram, &histogram_stats);
-      _compute_correction(self, &d->params, piece->pipe, histogram,
+      _compute_correction(&d->params, piece->pipe, histogram,
                           &histogram_stats, &exposure);
       dt_free_align(histogram);
     }
@@ -513,6 +512,8 @@ static void _process_common_setup(dt_iop_module_t *self,
     }
   }
 
+  // no deflicker, or deflicker failed: use the user-set exposure
+  if(exposure == EXPOSURE_CORRECTION_UNDEFINED) exposure = d->params.exposure;
   const float white = exposure2white(exposure);
   d->scale = 1.0 / (white - d->black);
 }

--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -437,7 +437,7 @@ static double _raw_to_ev(const uint32_t raw,
   return raw_ev;
 }
 
-static void _compute_correction(dt_iop_exposure_params_t *p,
+static void _compute_deflicker_correction(dt_iop_exposure_params_t *p,
                                 dt_dev_pixelpipe_t *pipe,
                                 const uint32_t *const histogram,
                                 const dt_dev_histogram_stats_t *const histogram_stats,
@@ -480,7 +480,7 @@ static void _process_common_setup(dt_iop_module_t *self,
   dt_iop_exposure_data_t *d = piece->data;
 
   d->black = d->params.black;
-  // the default is also the fallback for deflicker's _compute_correction below
+  // the default is also the fallback for _compute_deflicker_correction below
   float exposure = d->params.exposure;
 
   if(d->deflicker)
@@ -488,7 +488,7 @@ static void _process_common_setup(dt_iop_module_t *self,
     if(g)
     {
       // histogram is precomputed and cached
-      _compute_correction(&d->params, piece->pipe,
+      _compute_deflicker_correction(&d->params, piece->pipe,
                           g->deflicker_histogram, &g->deflicker_histogram_stats,
                           &exposure);
     }
@@ -497,7 +497,7 @@ static void _process_common_setup(dt_iop_module_t *self,
       uint32_t *histogram = NULL;
       dt_dev_histogram_stats_t histogram_stats;
       _deflicker_prepare_histogram(self, &histogram, &histogram_stats);
-      _compute_correction(&d->params, piece->pipe, histogram,
+      _compute_deflicker_correction(&d->params, piece->pipe, histogram,
                           &histogram_stats, &exposure);
       dt_free_align(histogram);
     }
@@ -934,7 +934,7 @@ static void _auto_set_exposure(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe)
   dt_aligned_pixel_t Lab;
   dot_product(RGB, input_profile->matrix_in, XYZ);
   dt_XYZ_to_Lab(XYZ, Lab);
-  Lab[1] = Lab[2] = Lab[3] = 0.f; // make color grey to get only the equivalent lighness
+  Lab[1] = Lab[2] = Lab[3] = 0.f; // make color gray to get only the equivalent lightness
   dt_Lab_to_XYZ(Lab, XYZ);
   dt_XYZ_to_sRGB(XYZ, g->spot_RGB);
 
@@ -966,7 +966,7 @@ static void _auto_set_exposure(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe)
     // Convert to Lab for GUI feedback
     dt_aligned_pixel_t Lab_out;
     dt_XYZ_to_Lab(XYZ_out, Lab_out);
-    Lab_out[1] = Lab_out[2] = 0.f; // make it grey
+    Lab_out[1] = Lab_out[2] = 0.f; // make it gray
 
     // Return the values in sliders
     DT_ENTER_GUI_UPDATE();

--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -639,8 +639,8 @@ static inline float _total_adjustment_ev(const dt_iop_module_t *const self,
 
 // The inverse: the value to store in p->exposure (i.e. where to move the exposure slider)
 // so that the pipe ends up applying `total_adjustment_ev`. The GUI needs it because it
-// reasons in terms of the total adjustment - that is what black has to stay below - but
-// writes the user parameter (slider value).
+// reasons in terms of the total adjustment - black has to stay below the white point
+// derived from it - but writes the user parameter (slider value).
 static inline float _required_exposure_slider_ev(const dt_iop_module_t *const self,
                                                  const dt_iop_exposure_params_t *const p,
                                                  const float total_adjustment_ev)
@@ -1005,13 +1005,14 @@ void color_picker_apply(dt_iop_module_t *self,
 }
 
 
-// keep black under the white point the pipe will map to 1.0, so that white - black
-// stays positive and d->scale neither blows up nor turns negative; the comparison is in
-// the compensated domain because that is what the pipe uses, while p->black is never
-// compensated
-static void _clamp_black_below_white(dt_iop_module_t *self,
-                                     const dt_iop_exposure_params_t *const p)
+// keep black under the white point the pipe will map to 1.0, so that
+// white - black cannot reach zero or turn negative; the comparison is in the
+// compensated domain because that is what the pipe uses, while p->black is
+// never compensated
+static void _clamp_black_below_white(dt_iop_module_t *self)
 {
+  const dt_iop_exposure_params_t *const p = self->params;
+
   const float white = exposure2white(_total_adjustment_ev(self, p));
   if(p->black >= white)
     _exposure_set_black(self, white - 0.01);
@@ -1052,34 +1053,31 @@ void gui_changed(dt_iop_module_t *self,
         gtk_stack_set_visible_child_name(GTK_STACK(g->mode_stack), "manual");
         break;
     }
+  }
 
-    // when entering (normal or forced - for unsupported image) manual mode,
-    // ensure black stays below white -- automatic mode used a different white,
-    // so currently set black may have been below that, but above manual mode's
-    // white
-    if(p->mode == EXPOSURE_MODE_MANUAL)
-      _clamp_black_below_white(self, p);
-  }
-  else if(p->mode == EXPOSURE_MODE_MANUAL
-          && (w == g->exposure
-              || w == g->compensate_exposure_bias
-              || w == g->compensate_hilite_preserv))
+  // black and the white point must not cross. to ensure that, adjust black if the user
+  // changed exposure controls, and adjust exposure if they moved black. only in manual
+  // mode: the manual white point is not applied in deflicker mode, but its hidden
+  // controls stay reachable via shortcuts, so manual white must not constrain the visible
+  // and active black
+  if(p->mode == EXPOSURE_MODE_MANUAL)
   {
-    // changed one of the controls influencing total manual exposure adjustment,
-    // so the MANUAL white point may have moved below black. This can happen even in deflicker
-    // mode, via shortcuts, when manual exposure controls are invisible and ineffective.
-    // DO NOT force (always effective) black below the manual white, ignored in deflicker mode.
-    _clamp_black_below_white(self, p);
-  }
-  // the inverse path: black moved -> move the exposure slider to keep 'white' above black,
-  // but only do it in manual mode, so black adjustments made in deflicker mode don't adjust
-  // exposure of manual mode. If we're returning from deflicker to manual mode, we prefer to
-  // keep the manual exposure and adjust black -- see end of if(w == g->mode)
-  else if(p->mode == EXPOSURE_MODE_MANUAL && w == g->black)
-  {
-    const float white = exposure2white(_total_adjustment_ev(self, p));
-    if(p->black >= white)
-      _exposure_set_white(self, p->black + 0.01);
+    if(w == g->black)
+    {
+      const float white = exposure2white(_total_adjustment_ev(self, p));
+      if(p->black >= white)
+        _exposure_set_white(self, p->black + 0.01);
+    }
+    else if(w == g->mode
+            || w == g->exposure
+            || w == g->compensate_exposure_bias
+            || w == g->compensate_hilite_preserv)
+    {
+      // the white point moved, or manual mode was just entered (normally, or
+      // forced for an unsupported image) with a black left over from deflicker
+      // mode's white point
+      _clamp_black_below_white(self);
+    }
   }
 }
 

--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -480,8 +480,8 @@ static void _process_common_setup(dt_iop_module_t *self,
   dt_iop_exposure_data_t *d = piece->data;
 
   d->black = d->params.black;
-  // stays undefined unless deflicker computes a correction below
-  float exposure = EXPOSURE_CORRECTION_UNDEFINED;
+  // the default is also the fallback for deflicker's _compute_correction below
+  float exposure = d->params.exposure;
 
   if(d->deflicker)
   {
@@ -512,10 +512,6 @@ static void _process_common_setup(dt_iop_module_t *self,
       g_idle_add(_show_computed, self);
     }
   }
-
-  // no deflicker, or deflicker failed: use the user-set exposure
-  if(exposure == EXPOSURE_CORRECTION_UNDEFINED)
-    exposure = d->params.exposure;
 
   const float white = exposure2white(exposure);
   d->scale = 1.0 / (white - d->black);
@@ -960,13 +956,12 @@ static void _auto_set_exposure(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe)
     // the exposure the pipe applies, i.e. the user setting plus the compensations
     const float exposure_adjustment = _total_adjustment_ev(self, p);
 
-    // the value that gets mapped to 1.0
-    const float white = exposure2white(-exposure_adjustment);
+    const float gain = exp2f(exposure_adjustment);
 
     // apply the exposure compensation
     dt_aligned_pixel_t XYZ_out = {0.0f };
     for(int c = 0; c < 3; c++)
-      XYZ_out[c] = XYZ[c] * white;
+      XYZ_out[c] = XYZ[c] * gain;
 
     // Convert to Lab for GUI feedback
     dt_aligned_pixel_t Lab_out;

--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -1005,6 +1005,18 @@ void color_picker_apply(dt_iop_module_t *self,
 }
 
 
+// keep black under the white point the pipe will map to 1.0, so that white - black
+// stays positive and d->scale neither blows up nor turns negative; the comparison is in
+// the compensated domain because that is what the pipe uses, while p->black is never
+// compensated
+static void _clamp_black_below_white(dt_iop_module_t *self,
+                                     const dt_iop_exposure_params_t *const p)
+{
+  const float white = exposure2white(_total_adjustment_ev(self, p));
+  if(p->black >= white)
+    _exposure_set_black(self, white - 0.01);
+}
+
 void gui_changed(dt_iop_module_t *self,
                  GtkWidget *w,
                  void *previous)
@@ -1025,6 +1037,7 @@ void gui_changed(dt_iop_module_t *self,
            || self->dev->image_storage.buf_dsc.channels != 1
            || self->dev->image_storage.buf_dsc.datatype != TYPE_UINT16)
         {
+          // force manual for unsupported image type
           p->mode = EXPOSURE_MODE_MANUAL;
           dt_bauhaus_combobox_set(g->mode, p->mode);
           gtk_widget_set_sensitive(GTK_WIDGET(g->mode), FALSE);
@@ -1039,26 +1052,29 @@ void gui_changed(dt_iop_module_t *self,
         gtk_stack_set_visible_child_name(GTK_STACK(g->mode_stack), "manual");
         break;
     }
+
+    // when entering (normal or forced - for unsupported image) manual mode,
+    // ensure black stays below white -- automatic mode used a different white,
+    // so currently set black may have been below that, but above manual mode's
+    // white
+    if(p->mode == EXPOSURE_MODE_MANUAL)
+      _clamp_black_below_white(self, p);
   }
-  // The two branches below keep black under the white point the pipe will use, so that
-  // white - black stays positive and d->scale does not blow up or turn negative.
-  // Both are restricted to manual mode: only there is the white point defined by the
-  // parameters. In deflicker mode the pipe derives it from the raw histogram, so there
-  // is nothing here to validate against, and repairing by writing p->exposure would
-  // only move a control that the pipe ignores.
   else if(p->mode == EXPOSURE_MODE_MANUAL
           && (w == g->exposure
               || w == g->compensate_exposure_bias
               || w == g->compensate_hilite_preserv))
   {
-    // If any of that changed, the exposure compensation may have changed (does not,
-    // if a checkbox was toggled whose corresponding value is 0). The 'white' point that will be
-    // mapped to 1.0 may have moved below the black point, so make sure black stays below that.
-    const float white = exposure2white(_total_adjustment_ev(self, p));
-    if(p->black >= white)
-      _exposure_set_black(self, white - 0.01);
+    // changed one of the controls influencing total manual exposure adjustment,
+    // so the MANUAL white point may have moved below black. This can happen even in deflicker
+    // mode, via shortcuts, when manual exposure controls are invisible and ineffective.
+    // DO NOT force (always effective) black below the manual white, ignored in deflicker mode.
+    _clamp_black_below_white(self, p);
   }
-  // the inverse path: black moved -> move the exposure slider to keep 'white' above black
+  // the inverse path: black moved -> move the exposure slider to keep 'white' above black,
+  // but only do it in manual mode, so black adjustments made in deflicker mode don't adjust
+  // exposure of manual mode. If we're returning from deflicker to manual mode, we prefer to
+  // keep the manual exposure and adjust black -- see end of if(w == g->mode)
   else if(p->mode == EXPOSURE_MODE_MANUAL && w == g->black)
   {
     const float white = exposure2white(_total_adjustment_ev(self, p));

--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -990,8 +990,9 @@ static void _auto_set_exposure(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe)
     dt_aligned_pixel_t XYZ_target = { 0.f };
     dt_Lab_to_XYZ(Lab_target, XYZ_target);
 
-    // set exposure slider from the ratio
-    _exposure_set_white(self, XYZ[1] / XYZ_target[1]);
+    // a near-black target cannot be matched, and a near-black sample explodes the ratio
+    if(XYZ[1] > 1e-5f && XYZ_target[1] > 1e-5f)
+      _exposure_set_white(self, XYZ[1] / XYZ_target[1]);
   }
 }
 

--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -617,7 +617,7 @@ static inline float _exposure_compensation_ev(const dt_iop_module_t *const self,
 {
   float compensation = 0.0f;
 
-  // compensate the correction the user dialled into the camera
+  // compensate the correction the user dialed into the camera
   if(p->compensate_exposure_bias)
     compensation -= _get_exposure_bias(self);
 

--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -103,7 +103,7 @@ typedef struct dt_iop_exposure_gui_data_t
 typedef struct dt_iop_exposure_data_t
 {
   dt_iop_exposure_params_t params;
-  int deflicker;
+  gboolean deflicker;
   float black;
   float scale;
 } dt_iop_exposure_data_t;
@@ -661,14 +661,14 @@ void commit_params(dt_iop_module_t *self,
   d->params.deflicker_percentile = p->deflicker_percentile;
   d->params.deflicker_target_level = p->deflicker_target_level;
 
-  d->deflicker = 0;
+  d->deflicker = FALSE;
 
   if(p->mode == EXPOSURE_MODE_DEFLICKER
      && dt_image_is_raw(&self->dev->image_storage)
      && self->dev->image_storage.buf_dsc.channels == 1
      && self->dev->image_storage.buf_dsc.datatype == TYPE_UINT16)
   {
-    d->deflicker = 1;
+    d->deflicker = TRUE;
   }
 }
 


### PR DESCRIPTION
# exposure: use one definition of the exposure the module applies

Fixes #21974.

TL;DR:
- publication of the exposure value via the proxy (consumed by AgX):
  - initial idea was to lock
  - but the value was only computed in commit_params, so could be lagging behind (unlikely)
  - manual mode: now the value is recomputed (cheap) in `_exposure_proxy_get_effective_exposure`
  - automatic (deflicker) mode reads the preview pipe’s computed correction under the GUI lock, returning 0 EV when unavailable; previously it reported the manual value even in automatic mode.
- fixed 2 rare possible image corruptions
  - in auto mode, if histogram was unavailable, the image would turn black
  - in manual mode, if black > 0, the image could be inverted, because the additional (in-camera exposure correction dialled in by the user + camera highlight preservation underexposure) were not taken into account. This was a problem because black must remain below **effective** (all manual + bias corrections applied) white, but the calculation that checked the limits only took the manual part into account.
- finally, when using the picker, if the sampled area was black or almost black, we could get division by zero (or by tiny number). I also disabled this "exposure matching" if the target is (almost) black -- no one would want to "exposure match" an image to black.
- some helper functions for clarity and consistency, so the back-and-forth calculation between "total exposure correction = user slider + compensation for in-camera biases" and "manual slider level to set = total exposure correction - compensation for in-camera biases" pair always remains consistent.
- also, some minor renaming, e.g. the result of 2^exposure is not 'white' but 'gain'

(^^^^^ That's not AI, it's my genuine, natural stupidity and bad writing ^^^^^)

ˇˇˇˇˇ AI from here on ˇˇˇˇˇ

## Background

The `exposure` module does not apply the exposure slider alone. It applies the
slider plus two corrections read from EXIF:

- `compensate camera exposure`: the exposure correction the user dialed into the
  camera (clamped to -5 .. +5 EV)
- `compensate camera highlight preservation`: the underexposure the camera
  applied by itself in an HDR / DR-boost / HLG mode (clamped to 0 .. +4 EV, on by
  default for the first instance of the module)

The sum is what `commit_params()` stores and what `process()` turns into `black`
and `scale`. This PR calls that sum the **total adjustment**.

Three places in the module used some other value where the total adjustment was
meant. This PR gives the module a single definition of it and routes every user
of it through that definition. Sharing that definition also exposed a fourth
defect, in the area exposure mapping tool, which is fixed here as well.

## What was fixed

### 1. The shared `effective_exposure` field: data race and stale value

This is the defect the issue was opened for.

`commit_params()` cached the applied exposure in a plain `float` inside
`gui_data`, from a pipe thread, with no lock.
`dt_dev_exposure_get_effective_exposure()` read the same field from the GTK
thread, also with no lock and with no NULL check on `gui_data`. `agx` reads it
in its "read exposure" button and writes the result into history.

**Locking it would have been the wrong fix.** The value was only ever produced by
`commit_params()`, so a caller asking before the pipe had re-committed got the
*previous* exposure. A lock removes the undefined behaviour and keeps the wrong
answer.

**The field is now gone.** In manual mode the accessor derives the value from the
parameters, on the caller's thread, exactly like the neighbouring
`_exposure_proxy_get_exposure()` and `_exposure_proxy_get_black()` already did.
There is no shared field left to race on.

Automatic (deflicker) mode is the exception: its correction is computed from the
raw histogram inside the pipe, so it has to be published rather than derived.
That branch now takes the module's GUI lock, checks `gui_data` for NULL, and
returns 0 EV while the value is still undefined, which is the case before the
preview pipe has run once. Before this PR the accessor returned the *manual*
composition in automatic mode as well, which is a quantity the module never
applied there.

The thread contract of the whole proxy is now written down on
`dt_dev_proxy_exposure_t` in `develop.h`: these accessors read live GTK-owned
state, so they may only be called from the GTK thread.

### 2. Automatic mode rendered a fully black image when the histogram was missing

`_compute_correction()` (renamed to `_compute_deflicker_correction()`) wrote its
"undefined" sentinel, `-FLT_MAX`, *before* its early return. The caller had
already seeded the same variable with the manual fallback, so the sentinel
destroyed it. The pipe then computed `white = exp2f(FLT_MAX)`, which is
infinity, so `scale = 1 / (inf - black) = 0` and every output pixel was 0.

This is deterministic, not a race: `_deflicker_prepare_histogram()` returns
without a histogram when the image is not single-channel `TYPE_UINT16`, or when
the raw buffer cannot be fetched. In that state automatic mode rendered black on
every pipe run.

The function now leaves the caller's value alone when it cannot compute
anything. The caller seeds it with the manual composition, and that same value
is both applied by the pipe and published to the proxy, so the two agree on what
the fallback was.

### 3. The black point was limited against the wrong white point, which could invert the image

The GUI keeps `black` below the white point so that `white - black`, and
therefore `scale`, stays positive. All the limit checks compared against the
white point derived from the **raw slider value**, while the pipe derives the
white point from the **total adjustment**. The two differ by the compensations,
so by up to 9 EV.

This was reachable with ordinary slider positions, and highlight-preservation
compensation is on by default. Reproduced in the GUI: camera exposure bias -2 EV
compensated, exposure slider +4 EV, so the pipe applies +6 EV and the real white
point is 2^-6 = 0.0156. Moving `black` to 0.0160 passed the old check, because
0.0160 < 2^-4 = 0.0625, and produced `scale = 1 / (0.0156 - 0.0160) = -2667`:
the image inverts.

black 0.0150, before the fix
<img width="1624" height="868" alt="inversion-bug-before-below" src="https://github.com/user-attachments/assets/8f52e7cf-9e6d-4bb0-a711-40f1613888f7" />

black 0.0160, before the fix
<img width="1624" height="868" alt="inversion-bug-before-above" src="https://github.com/user-attachments/assets/4b1e26e9-f2d9-4ebf-85bf-2fd533672065" />

With the fix, moving `black` to 0.0160 pulls the exposure slider down to
+3.265 EV, so the applied total is +5.265 EV and the white point stays above
black:
<img width="1624" height="868" alt="inversion-bug-fixed-above" src="https://github.com/user-attachments/assets/f78c6e24-db98-4176-b19a-5224b6df9516" />

What changed in the code:

- all the limit checks now compare `p->black` against
  `exposure2white(_total_adjustment_ev(self, p))`, which is the white point the
  pipe will actually use
- `_exposure_set_white()` converts back through
  `_required_exposure_slider_ev()`, so writing the slider really produces the
  requested white point instead of missing it by the compensation offset
- the check also runs when a compensation checkbox is toggled, and when the
  module returns to manual mode. The second case matters because black can be
  edited in automatic mode, where the manual exposure is not applied, so a
  configuration that was valid in automatic mode can be invalid the moment
  manual mode comes back
- the checks run in manual mode only. In automatic mode the manual controls are
  hidden but still reachable through keyboard shortcuts, and a white point that
  the pipe does not use must not move the black point that it does use

### 4. Area exposure mapping could store an out-of-range exposure

With the area picker active in "correct" mode, moving the target lightness to 0
made the module store an exposure of about +66 EV. The parameter's declared
range is -18 .. +18 EV, the slider cannot show such a value, and a history item
was recorded for it, so the image blew out until the target was set back.

The tool divides the sampled luminance by the target luminance to get the white
point. A target lightness of 0 is inside the lightness slider's range, and
`dt_Lab_to_XYZ()` converts it back to a Y of either exactly zero or, where the
compiler contracts `116 * x - 16` into an FMA, slightly negative. The ratio is
then infinite or large and negative, and `white2exposure()` floors its argument
at 1e-20, which is where +66 EV comes from.

The module now declines the correction when the sampled or the target luminance
is at or below 1e-5: no parameter is written and no history item is pushed.

Two separate reasons put the threshold at 1e-5 rather than at zero:

- **it is below the finest value a raw can carry.** `rawprepare` emits
  `(in - black) / (white - black)`, so the raw white point becomes 1.0 and the
  quantization step is `1 / (white - black)`: 1.53e-5 for a 16-bit raw with a
  zero black level, and coarser for everything else, such as 7.0e-5 for a
  14-bit raw with a black level of 2048. White balance multiplies by
  coefficients of order 1, and the camera matrix is normalized so that neutral
  maps to neutral, so the sampled luminance stays in that same scale
- **it keeps every accepted match representable.** A sample at 1e-5 needs
  +16.6 EV to reach the brightest possible target and +14.2 EV to reach
  mid-gray, both inside the declared range. At 1e-6 the same match would need
  19.9 EV, so the module would store an exposure outside its own limits again

A note for anyone bisecting this series: the simplification described below
removed a round trip that had incidentally clamped the ratio to a small positive
number, so between `9195d35176` and `362a3b8288` a negative ratio was also
stored as the black point, at about -3.8e9, which survived setting the target
back. Both halves are closed by the same check.

### Smaller changes in the same commits

- new helpers in `exposure.c`, all `static inline`:
  `_exposure_compensation_ev()` (the two EXIF corrections),
  `_total_adjustment_ev()` (slider plus corrections) and
  `_required_exposure_slider_ev()` (the inverse, used when the GUI knows the
  white point it wants and has to write the slider)
- the area exposure mapping "measure" branch used to repeat the compensation
  arithmetic and then apply it as `exposure2white(-expo)`, which is
  `exp2f(expo)` written in a confusing way. It now calls the shared helper and
  multiplies by a plain gain
- the "correct" branch had the same duplicated arithmetic followed by a
  round trip through `white2exposure`/`exposure2white`. It now passes the
  measured ratio straight to `_exposure_set_white()`, which does the inverse
  conversion in one place, guarded by the luminance check from section 4
- renames and comments: `_compute_correction()` is now
  `_compute_deflicker_correction()`, US spelling fixes in the two comments that
  were touched anyway, and a note explaining what `white` means in
  `exposure2white`

## Behaviour, and compatibility with existing edits

- rendering does not change for manual mode, and does not change for automatic
  mode when the histogram is available: `d->params.exposure`, `d->black` and
  `d->scale` are computed exactly as before
- no parameter change, no module version bump, no `legacy_params()` work
- the limit checks live in GUI callbacks only. Loading an existing edit that is
  already in the invalid state does not rewrite it, so old images still render
  as they did. Making the pipe itself reject an invalid transform is a separate
  decision, see the follow-ups
- what a user will notice: the black slider now stops at the real white point;
  automatic mode with an unusable raw histogram renders the manual fallback
  instead of a black frame; `agx`'s "read exposure" gets the correct value in
  automatic mode; setting the area mapping target lightness to 0 now does
  nothing instead of writing an exposure far outside the parameter's declared
  range of -18 .. +18 EV and pushing a history item for it

## Files touched

- `src/iop/exposure.c`: all of the above
- `src/develop/develop.h`: the thread contract on `dt_dev_proxy_exposure_t` and
  on the four accessors, plus a note about the one known violation
- `RELEASE_NOTES.md`

## Not fixed here

Reviewing this branch turned up more problems in the same area. All of them
exist on master today, none is a regression from this PR, and each one needs a
decision that does not belong in this change.

Filed:

- **#22005**: `channelmixerrgb`'s ColorChecker profiler reads exposure's
  GTK-owned parameters from the preview pipe thread, and inverts the exposure
  transform with the wrong quantity and the wrong formula. Only marked with a
  `TODO` here
- **#22006**: the deflicker histogram is freed and reallocated by the GTK thread
  while a pipe thread is reading it
- **#22007**: the idle source that shows the computed correction can outlive the
  module; teardown removes one source, but one is queued per preview pipe run
- **#22008**: `dt_dev_exposure_handle_event()` has no darkroom guard, unlike the
  three getters next to it, and it is the only one that writes parameters
- **#22009**: `agx` leaves `curve_gamma` stale in history after its "read
  exposure" button
- **#22172**: the published automatic correction carries no validity marker. A
  GUI refresh that is not an edit, for example opening the blending "display
  output channels" menu, resets it, and changing the target level or percentile
  does not invalidate it. `agx` can then store range values that belong to a
  different correction. A lock does not fix this; the published result needs to
  say which settings it describes
- **#22182**: the pipe does not check `white - black` at all. GUI limits cannot
  cover automatic mode, pasted or imported history, or edits made before this
  PR. A guard there changes how existing edits render, so it needs an explicit
  compatibility decision
- **#22183**: the area exposure mapping tool models exposure as a pure gain and
  ignores `black`, in both measurement and correction, while the pipe applies
  `(in - black) * scale`
- **#22184**: `_auto_set_exposure()` (the area exposure mapping tool) is
  manual-mode logic with no mode check. Normal mode changes reset the picker,
  but a user-assigned shortcut can re-activate it in automatic mode, where it
  would report and write values the pipe ignores

## Open point

The comment in `develop.h` refers to `dev-doc/GUI_Threading.md`, which is added
by #21912 and is still a draft.

## What was tested

- the branch builds clean, with no new warnings. Each commit was checked out and
  built on its own, so `git bisect` stays usable
- **no rendering change on existing edits.** Headless CPU exports of the
  `0001-exposure` integration image, with its original version-5 manual history
  and with a version-7 automatic-mode variant, were compared between the branch
  point and the branch: ImageMagick reports **0 differing pixels** for both
- **parameter sweep.** A harness that compiles the real `exposure.c` and calls
  the real `commit_params()` and `process()` covered 6,722 valid manual
  parameter combinations: both compensation switches, EXIF bias -5 .. +5 EV,
  highlight preservation 0/1/2/4 EV, exposure -18 .. +18 EV, and negative, zero
  and positive black. No parameter bytes were rewritten. Of 26,888 output
  floats, 76 differed, by at most 1.19e-07 absolute and 2.11e-07 relative, which
  is the reassociation of the same arithmetic, not a behaviour change
- **defect 3, the inversion:** reproduced in the GUI before the fix and confirmed
  gone after it, with the settings and screenshots above. The same case in the
  harness: `scale` goes from -2666.66 to +100, with the slider moved to
  +3.26534 EV
- **defect 4, the unusable exposure:** confirmed in the harness, which drives the
  module's real `color_picker_apply()`. With a sample luminance of 0.25 and the
  target moved to 0 and then back to 0.5, the branch point stored +66.4386 EV and
  one history item at the zero target; the branch stores nothing and pushes no
  history item, and the restored target gives the correct 0.5 at the sample on
  both. Between `9195d35176` and `362a3b8288` the same sequence also left
  `black` at -3.7887e9 and the sample at 1.0
- **defect 2, the black frame:** confirmed in the harness. With a missing
  histogram and a +2 EV manual fallback, `scale` was 0 and the output 0 before
  the fix; after it, `scale` is 4, an input of 0.18 becomes 0.72, and the proxy
  reports +2 EV, so the pipe and the proxy agree. Not reproduced in a GUI
  session, which would need a raw whose histogram cannot be built
- **defect 1, the race:** traced in the source only. Removing a shared field is
  not something a test run shows
- the integration test suite was **not** run: this container has no `opencv`,
  `numpy` or `colour-science` for its comparison script. The export comparison
  above uses the same image but compares the two revisions against each other,
  not against the suite's stored reference
- `process_cl()` was **not** exercised: OpenCL initialisation finds 0 platforms
  here, and an export that requested OpenCL fell back to the CPU. The OpenCL
  path is unchanged and consumes the same `d->black` and `d->scale` that the CPU
  path does, both produced by the shared `_process_common_setup()`; the kernel
  arithmetic in `data/kernels/basic.cl:241` is untouched
- not covered anywhere: a real GTK session for the proxy paths, forced tiling,
  and a build with OpenCL disabled at configure time

PR written by Claude Code.
