### PR TITLE
Fix MCP export/render ignoring width above ~1600 px

### DIFF
--- a/data/mcp-tools.json
+++ b/data/mcp-tools.json
@@ -55,9 +55,10 @@
             "imgid": { "type": "integer" }
           }
         },
-        "width": { "type": "integer" },
-        "height": { "type": "integer" },
+        "width": { "description": "bounding box in pixels, not a target size: the image is fitted inside width x height keeping aspect ratio, so the smaller constraint wins. omit or pass 0 to leave a dimension unconstrained, which then limits by the other alone but never enlarges past the image's own size; give both to upscale. with neither given, defaults to 1024x1024", "type": "integer" },
+        "height": { "description": "bounding box in pixels, not a target size: the image is fitted inside width x height keeping aspect ratio, so the smaller constraint wins. omit or pass 0 to leave a dimension unconstrained, which then limits by the other alone but never enlarges past the image's own size; give both to upscale. with neither given, defaults to 1024x1024", "type": "integer" },
         "stack": {
+          "description": "edits layered on top of the base state, applied to a throwaway duplicate so the image's own history is never modified",
           "type": "array",
           "items": {
             "type": "object",
@@ -72,7 +73,7 @@
           }
         },
         "disable_tone_mappers": { "type": "boolean" },
-        "history_end": { "type": "integer" }
+        "history_end": { "description": "how many entries of the image's existing history to apply, counted from the start; -1 or omitted uses all of it. applied before `stack`, so the two compose: history_end picks the base state and stack adds edits on top of it", "type": "integer" }
       },
       "required": ["input"],
       "additionalProperties": false
@@ -91,11 +92,11 @@
             "imgid": { "type": "integer" }
           }
         },
-        "width": { "type": "integer" },
-        "height": { "type": "integer" },
-        "stack": { "type": "array", "items": { "type": "object" } },
+        "width": { "description": "bounding box in pixels, not a target size: the image is fitted inside width x height keeping aspect ratio, so the smaller constraint wins. omit or pass 0 to leave a dimension unconstrained, which then limits by the other alone but never enlarges past the image's own size; give both to upscale. with neither given, defaults to 512x512", "type": "integer" },
+        "height": { "description": "bounding box in pixels, not a target size: the image is fitted inside width x height keeping aspect ratio, so the smaller constraint wins. omit or pass 0 to leave a dimension unconstrained, which then limits by the other alone but never enlarges past the image's own size; give both to upscale. with neither given, defaults to 512x512", "type": "integer" },
+        "stack": { "description": "edits layered on top of the base state, applied to a throwaway duplicate so the image's own history is never modified", "type": "array", "items": { "type": "object" } },
         "disable_tone_mappers": { "type": "boolean" },
-        "history_end": { "type": "integer" }
+        "history_end": { "description": "how many entries of the image's existing history to apply, counted from the start; -1 or omitted uses all of it. applied before `stack`, so the two compose: history_end picks the base state and stack adds edits on top of it", "type": "integer" }
       },
       "required": ["input"],
       "additionalProperties": false
@@ -177,11 +178,11 @@
           }
         },
         "out_path": { "type": "string" },
-        "width": { "type": "integer" },
-        "height": { "type": "integer" },
-        "stack": { "type": "array", "items": { "type": "object" } },
+        "width": { "description": "bounding box in pixels, not a target size: the image is fitted inside width x height keeping aspect ratio, so the smaller constraint wins. omit or pass 0 to leave a dimension unconstrained, which then limits by the other alone but never enlarges past the image's own size; give both to upscale. with neither given, defaults to 1024x1024", "type": "integer" },
+        "height": { "description": "bounding box in pixels, not a target size: the image is fitted inside width x height keeping aspect ratio, so the smaller constraint wins. omit or pass 0 to leave a dimension unconstrained, which then limits by the other alone but never enlarges past the image's own size; give both to upscale. with neither given, defaults to 1024x1024", "type": "integer" },
+        "stack": { "description": "edits layered on top of the base state, applied to a throwaway duplicate so the image's own history is never modified", "type": "array", "items": { "type": "object" } },
         "disable_tone_mappers": { "type": "boolean" },
-        "history_end": { "type": "integer" }
+        "history_end": { "description": "how many entries of the image's existing history to apply, counted from the start; -1 or omitted uses all of it. applied before `stack`, so the two compose: history_end picks the base state and stack adds edits on top of it", "type": "integer" }
       },
       "required": ["input", "out_path"],
       "additionalProperties": false

--- a/src/mcp/dt_bridge.c
+++ b/src/mcp/dt_bridge.c
@@ -629,7 +629,15 @@ static int _mcp_write(dt_imageio_module_data_t *data, const char *filename,
 {
   _mcp_fmt_t *d = (_mcp_fmt_t *)data;
   if(!in) return 1;
-  memcpy(d->buf, in, sizeof(uint32_t) * (size_t)data->width * data->height);
+
+  // the export writes the real size into data before calling us; sizing this
+  // from the requested box breaks once a dimension is left unconstrained
+  const size_t bytes = sizeof(uint32_t) * (size_t)data->width * data->height;
+  g_free(d->buf);
+  d->buf = g_malloc(bytes);
+  if(!d->buf) return 1;
+
+  memcpy(d->buf, in, bytes);
   d->width = data->width;
   d->height = data->height;
   return 0;
@@ -653,8 +661,15 @@ static void _free_cb(void *p) { g_free(p); }
 static cairo_surface_t *_render_to_surface(dt_imgid_t imgid, int w, int h,
                                            int history_end, char **err)
 {
-  if(w <= 0) w = 1024;
-  if(h <= 0) h = 1024;
+  // max_width/max_height is a bounding box and 0 means "no limit", so
+  // defaulting an unset dimension would cap the one actually asked for
+  if(w < 0) w = 0;
+  if(h < 0) h = 0;
+  if(w == 0 && h == 0)
+  {
+    w = 1024;
+    h = 1024;
+  }
 
   dt_imageio_module_format_t fmt;
   memset(&fmt, 0, sizeof(fmt));
@@ -671,7 +686,7 @@ static cairo_surface_t *_render_to_surface(dt_imgid_t imgid, int w, int h,
   dat.head.height = h;
   dat.head.style_append = TRUE;
   dat.bpp = 8;
-  dat.buf = g_malloc0(sizeof(uint32_t) * (size_t)w * h);
+  dat.buf = NULL; // allocated by _mcp_write once the real size is known
 
   // NB: dt_imageio_export_with_flags returns FALSE on success
   const gboolean failed = dt_imageio_export_with_flags(
@@ -734,6 +749,14 @@ static cairo_surface_t *_render_surface(const char *path, int imgid_in, int widt
     dt_develop_t dev;
     dt_dev_init(&dev, FALSE);
     dt_dev_load_image(&dev, work);
+
+    // truncate before the stack is written, not after: the export's own pop
+    // would otherwise discard the edits the caller just asked for
+    if(history_end != -1)
+    {
+      dt_dev_pop_history_items_ext(&dev, history_end);
+      history_end = -1;
+    }
 
     if(disable_tone_mappers)
     {
@@ -808,8 +831,12 @@ char *dt_bridge_image_stats_json(const char *path, int imgid_in, int width, int 
                                  int history_end, char **err)
 {
   dt_imgid_t dup = NO_IMGID;
-  cairo_surface_t *surf = _render_surface(path, imgid_in, width > 0 ? width : 512,
-                                          height > 0 ? height : 512,
+  // stats only need a small render, but substituting the default per dimension
+  // would cap whichever one the caller did ask for
+  const gboolean unsized = width <= 0 && height <= 0;
+  cairo_surface_t *surf = _render_surface(path, imgid_in,
+                                          unsized ? 512 : width,
+                                          unsized ? 512 : height,
                                           (JsonArray *)stack_jsonarray,
                                           disable_tone_mappers, history_end, &dup, err);
   if(!surf) return NULL;


### PR DESCRIPTION
The MCP `export`, `render` and `image_stats` tools ignored `width` above roughly 1600 px - a 6960x4640 raw came back 1534x1024 whatever was asked for. Fixes #22174.

`max_width`/`max_height` is a bounding box, not a target size, and both defaulted to 1024, so any requested width past that lost to a height nobody asked for. An unspecified dimension now passes through as 0, which `_get_pipescale()` already treats as "opt out of this constraint" - matching `darktable-cli --width`. 1024x1024 stays the fallback when neither is given; `image_stats` had the same bug from substituting its 512 default per dimension rather than as a pair.

That forced a second change: the pixel buffer was allocated from the *requested* box while the write callback copied the *processed* size back - fine while the box bounded the output, a zero-byte allocation once a dimension went unconstrained. The format module now allocates after the export writes the real size.

Separately, `history_end` ran after the stack had been written into the history, so the export popped the caller's own edits back off and returned a bare base render. Truncating first lets the two compose. **This is a behaviour change** and the piece worth reverting alone if you disagree, though the old combination did nothing useful.

I ran the sizing fix through the real server headless against a 6960x4640 CR3 - native, width-only, height-only and neither-given all correct. The `history_end` ordering I fixed by reading the code, not by running it, so that half is unverified. No integration tests, since this is the MCP bridge rather than an iop. No new strings, preferences or dependencies.

Written with AI assistance.