### PR TITLE
darkroom: expand the module instance that has the focus

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -140,6 +140,10 @@ changes (where available).
 
 ## Bug Fixes
 
+- Entering the darkroom no longer expands one instance of a module while
+  a different instance of it holds the focus. The instance that gets the
+  focus is now the one that is expanded.
+
 - Clarified multi-image rating toasts for un-reject and for mixed
   upgrade/downgrade results across the selection.
 

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -107,6 +107,41 @@ static void _darkroom_display_second_window(dt_develop_t *dev);
 static void _darkroom_ui_second_window_write_config(GtkWidget *widget);
 static void _darkroom_ui_second_window_cleanup(dt_develop_t *dev);
 
+// "plugins/darkroom/<op>/expanded" is per-operation, while focus is restored
+// onto a single instance of that operation. The expansion state was applied to
+// instance 0 regardless, so with several instances one of them came back
+// expanded and a different one focused; with "only one module expanded" that is
+// a state the user cannot produce by hand. Called once focus has been restored,
+// this hands the operation's expansion state to the instance that actually got
+// the focus. Its siblings are only collapsed in "only one module expanded"
+// mode, where two expanded instances would be just as wrong.
+static void _expand_focused_instance(dt_develop_t *dev)
+{
+  dt_iop_module_t *focused = dt_dev_gui_module();
+  if(!focused) return;
+
+  char option[1024];
+  snprintf(option, sizeof(option), "plugins/darkroom/%s/expanded", focused->op);
+  const gboolean expanded = dt_conf_get_bool(option);
+  const gboolean single = dt_conf_get_bool("darkroom/ui/single_module");
+
+  for(const GList *modules = dev->iop; modules; modules = g_list_next(modules))
+  {
+    dt_iop_module_t *module = modules->data;
+    if(!dt_iop_module_is(module, focused->op)) continue;
+
+    const gboolean want = module == focused
+      ? expanded
+      : (single ? FALSE : module->expanded);
+
+    if(module->expanded != want)
+    {
+      module->expanded = want;
+      dt_iop_gui_update_expanded(module);
+    }
+  }
+}
+
 const char *name(const dt_view_t *self)
 {
   return _("darkroom");
@@ -1634,6 +1669,7 @@ static gboolean _dev_load_requested_image(gpointer user_data)
       dt_conf_set_string("plugins/darkroom/active", "");
     }
   }
+  _expand_focused_instance(dev);
 
   // Signal develop initialize
   DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_DEVELOP_IMAGE_CHANGED);
@@ -4096,6 +4132,7 @@ void enter(dt_view_t *self)
         dt_iop_request_focus(module);
     }
   }
+  _expand_focused_instance(dev);
 
   // image should be there now.
   dt_dev_zoom_move(&dev->full, DT_ZOOM_MOVE, -1.f, 1, 0.0f, 0.0f, TRUE);


### PR DESCRIPTION

This replaces #22130 and has a smaller blast radius.

The objective is the same: resolve an inconsistency that should not be there: in accordion mode, if there is an expanded instance of any module, it must be the focused one.

This is how the bug shows up in master:

https://github.com/user-attachments/assets/c561e892-14f7-4f5a-8a09-b3b5fd239193

### Steps to reproduce

1. Enable accordion mode (expand one module at a time)
2. Create two instances of the same module, say exposure-1 and exposure-2
3. Leave the darkroom when one of them is focused
4. Open another image which also has two instances of exposure. Focus one of them and leave the darkroom
5. Go back to the first image. You may see (depending on relative order) that one instance is focused, and the other one is expanded.

### The issue

The expansion state lives in `plugins/darkroom/<op>/expanded`, one value
per operation, and entering the darkroom applied it to instance 0. Focus,
restored separately, lands on whichever instance of that operation comes
last in `dev->iop`. With more than one instance the two disagree: one is
expanded and a different one is focused, which under "only one module
expanded" is a state the user cannot produce by hand, and which makes
shortcuts act on an instance other than the visually prominent one.

### The fix

Hand the operation's expanded state to the instance that got the focus
instead, once focus has been restored. Siblings are collapsed only under
"only one module expanded", where two expanded instances would be equally
wrong. Nothing changes for an operation with a single instance, and how
the focused module is chosen and stored is left alone.

Co-authored with Claude.