### PR TITLE
Fix possible crash in control jobs

### DIFF
--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -50,12 +50,15 @@
 #include <gio/gio.h>
 #include <glib.h>
 #include <glib/gstdio.h>
+
 #ifndef _WIN32
 #include <glob.h>
 #endif
+
 #ifdef __APPLE__
 #include "osx/osx.h"
 #endif
+
 #ifdef _WIN32
 #include "win/dtwin.h"
 #include <utime.h>
@@ -1051,6 +1054,15 @@ static int32_t _control_monochrome_images_job_run(dt_job_t *job)
 
 static char *_get_image_list(GList *l)
 {
+  // checking for an empty GList
+  if(l == NULL)
+  {
+    // is logged because such a call is a sign of a logical error elsewhere in the code
+    dt_print(DT_DEBUG_ALWAYS,
+             "[control_jobs] _get_image_list was called with empty GList, this should not happen");
+    return strdup("");
+  }
+
   const guint size = g_list_length(l);
   char num[8];
   char *buffer = calloc(size, sizeof(num));

--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -1065,7 +1065,20 @@ static char *_get_image_list(GList *l)
 
   const guint size = g_list_length(l);
   char num[8];
+
   char *buffer = calloc(size, sizeof(num));
+  // allocation size here is guaranteed to be non-zero
+  // so returning NULL from calloc is a result of memory allocation failure
+  if(buffer == NULL)
+  {
+    dt_print(DT_DEBUG_ALWAYS,
+             "[control_jobs] failed to allocate memory in _get_image_list");
+    // allocation in strdup could also fail, although extremely unlikely,
+    // given the tiny request size :)
+    // but at least we tried to return as correctly as possible
+    return strdup("");
+  }
+
   gboolean first = TRUE;
 
   buffer[0] = '\0';


### PR DESCRIPTION
This PR improves error handling and robustness in the `_get_image_list` function in `control_jobs.c`. We ensure that the function gracefully handles cases where it is called with an empty list or when memory allocation fails, providing clear debug messages for these situations.

The problem was found while reading the code , I didn't come across it in any issue.

Since this is only a robustness improvement, and there is no evidence of any crashes due to bad data being passed to this function, there is no point in adding it to the release notes.