### PR TITLE
Fix module warning messages

### DIFF
--- a/src/common/imagebuf.c
+++ b/src/common/imagebuf.c
@@ -110,7 +110,7 @@ gboolean dt_iop_alloc_image_buffers(struct dt_iop_module_t *const module,
   if(success)
   {
     if(module)
-      dt_iop_set_module_trouble_message(module, NULL, NULL, NULL);
+      dt_iop_clear_module_trouble_message(module);
   }
   else
   {

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -4320,9 +4320,9 @@ void dt_dev_clear_chroma_troubles(dt_develop_t *dev)
 
   dt_dev_chroma_t *chr = &dev->chroma;
   if(chr->temperature)
-    dt_iop_set_module_trouble_message(chr->temperature, NULL, NULL, NULL);
+    dt_iop_clear_module_trouble_message(chr->temperature);
   if(chr->adaptation)
-    dt_iop_set_module_trouble_message(chr->adaptation, NULL, NULL, NULL);
+    dt_iop_clear_module_trouble_message(chr->adaptation);
 }
 
 void dt_dev_reset_chroma(dt_develop_t *dev)

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -1415,14 +1415,14 @@ void dt_iop_set_module_trouble_message(dt_iop_module_t *const module,
                                        const char *const stderr_message)
 {
   //  first stderr message if any
-  if(stderr_message)
+  if(stderr_message || trouble_msg)
   {
     const dt_image_t *img = module ? &module->dev->image_storage : NULL;
     const char *name = module ? module->name() : "?";
 
-    dt_print(DT_DEBUG_ALWAYS, "Trouble: [%s] %s (%s %d)",
+    dt_print(DT_DEBUG_ALWAYS, "Trouble: [%s] '%s' (%s %d)",
              name,
-             stderr_message,
+             stderr_message ? stderr_message : trouble_msg,
              img ? img->filename : "?",
              img ? img->id : -1);
   }
@@ -1432,6 +1432,11 @@ void dt_iop_set_module_trouble_message(dt_iop_module_t *const module,
      && dt_conf_get_bool("plugins/darkroom/show_warnings"))
     DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_TROUBLE_MESSAGE,
                             module, trouble_msg, trouble_tooltip);
+}
+
+void dt_iop_clear_module_trouble_message(dt_iop_module_t *const module)
+{
+  dt_iop_set_module_trouble_message(module, NULL, NULL, NULL);
 }
 
 void dt_iop_gui_init(dt_iop_module_t *module)
@@ -4289,14 +4294,13 @@ gboolean dt_iop_have_required_input_format(const int req_ch,
     // and set the module's trouble message
     if(module)
     {
-      dt_iop_set_module_trouble_message
-        (module, _("unsupported input"),
-         _("you have placed this module at\n"
+      dt_iop_set_module_trouble_message(module,
+        _("unsupported input"),
+        _("you have placed this module at\n"
            "a position in the pipeline where\n"
            "the data format does not match\n"
-           "its requirements."), NULL);
-      dt_print_pipe(DT_DEBUG_ALWAYS,
-        "unsupported data format", NULL, module, DT_DEVICE_NONE, roi_in, roi_out);
+           "its requirements."),
+        "unsupported data format");
     }
     else
     {

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -555,6 +555,8 @@ void dt_iop_set_module_trouble_message(dt_iop_module_t *module,
                                        const char *const trouble_msg,
                                        const char *const trouble_tooltip,
                                        const char *stderr_message);
+// clear the trouble message
+void dt_iop_clear_module_trouble_message(dt_iop_module_t *const module);
 
 // format modules description going in tooltips
 const char **dt_iop_set_description(dt_iop_module_t *module,

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -608,16 +608,14 @@ static void _dev_pixelpipe_synch(dt_dev_pixelpipe_t *pipe,
       if(piece->enabled != hist->enabled)
       {
         if(piece->enabled)
-          dt_iop_set_module_trouble_message
-            (piece->module,
+          dt_iop_set_module_trouble_message(piece->module,
              _("enabled as required"),
              _("history had module disabled but it is required for"
                " this type of image.\nlikely introduced by applying a preset,"
                " style or history copy&paste"),
              NULL);
         else
-          dt_iop_set_module_trouble_message
-            (piece->module,
+          dt_iop_set_module_trouble_message(piece->module,
              _("disabled as not appropriate"),
              _("history had module enabled but it is not allowed for this type"
                " of image.\nlikely introduced by applying a preset, style or"

--- a/src/iop/bilateral.cc
+++ b/src/iop/bilateral.cc
@@ -149,7 +149,7 @@ void process(dt_iop_module_t *self,
   }
   else
   {
-    dt_iop_set_module_trouble_message(self, NULL, NULL, NULL);
+    dt_iop_clear_module_trouble_message(self);
   }
 
   dt_iop_bilateral_data_t *data = (dt_iop_bilateral_data_t *)piece->data;

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -1993,14 +1993,14 @@ static void _set_trouble_messages(dt_iop_module_t *self)
   if(!chr->temperature)
   {
     if(chr->adaptation)
-      dt_iop_set_module_trouble_message(chr->adaptation, NULL, NULL, NULL);
+      dt_iop_clear_module_trouble_message(chr->adaptation);
     return;
   }
 
   if(!chr->adaptation)
   {
-    dt_iop_set_module_trouble_message(chr->temperature, NULL, NULL, NULL);
-    dt_iop_set_module_trouble_message(self, NULL, NULL, NULL);
+    dt_iop_clear_module_trouble_message(chr->temperature);
+    dt_iop_clear_module_trouble_message(self);
     return;
   }
 
@@ -2034,21 +2034,9 @@ static void _set_trouble_messages(dt_iop_module_t *self)
                             && !temperature_enabled
                             && chr->temperature->default_enabled;
 
-  if(problem1 || problem2 || problem3)
-    dt_print_pipe(DT_DEBUG_PIPE, "chroma trouble", NULL, self, DT_DEVICE_NONE, NULL, NULL,
-      "%s%s%sD65=%s.  D65 %.3f %.3f %.3f, AS-SHOT %.3f %.3f %.3f ID=%i",
-      problem1 ? "white balance applied twice, " : "",
-      problem2 ? "double CAT applied, " : "",
-      problem3 ? "white balance missing, " : "",
-      STR_YESNO(_dev_is_D65_chroma(dev)),
-      chr->D65coeffs[0], chr->D65coeffs[1], chr->D65coeffs[2],
-      chr->as_shot[0], chr->as_shot[1], chr->as_shot[2],
-      dev->image_storage.id);
-
   if(problem2)
   {
-    dt_iop_set_module_trouble_message
-      (self,
+    dt_iop_set_module_trouble_message(self,
         _("double CAT applied"),
         _("you have 2 instances or more of color calibration,\n"
           "all providing chromatic adaptation.\n"
@@ -2060,8 +2048,7 @@ static void _set_trouble_messages(dt_iop_module_t *self)
 
   if(problem1)
   {
-    dt_iop_set_module_trouble_message
-      (chr->temperature,
+    dt_iop_set_module_trouble_message(chr->temperature,
         _("white balance applied twice (<u>details</u>)"),
         _("the color calibration module is enabled and already provides\n"
           "chromatic adaptation.\n"
@@ -2069,8 +2056,7 @@ static void _set_trouble_messages(dt_iop_module_t *self)
           "or disable chromatic adaptation in color calibration."),
         NULL);
 
-    dt_iop_set_module_trouble_message
-      (self,
+    dt_iop_set_module_trouble_message(self,
         _("white balance module error (<u>details</u>)"),
         _("the white balance module is not using the camera\n"
           "reference illuminant, which will cause issues here\n"
@@ -2082,8 +2068,7 @@ static void _set_trouble_messages(dt_iop_module_t *self)
 
   if(problem3)
   {
-    dt_iop_set_module_trouble_message
-      (chr->temperature,
+    dt_iop_set_module_trouble_message(chr->temperature,
         _("white balance missing (<u>details</u>)"),
         _("this module is not providing a valid reference illuminant\n"
           "causing chromatic adaptation issues in color calibration.\n"
@@ -2091,8 +2076,7 @@ static void _set_trouble_messages(dt_iop_module_t *self)
           "or disable chromatic adaptation in color calibration."),
         NULL);
 
-    dt_iop_set_module_trouble_message
-      (self,
+    dt_iop_set_module_trouble_message(self,
         _("white balance missing (<u>details</u>)"),
         _("the white balance module is not providing a valid reference\n"
           "illuminant causing issues with chromatic adaptation here.\n"
@@ -2104,8 +2088,8 @@ static void _set_trouble_messages(dt_iop_module_t *self)
 
   if(chr->adaptation && chr->adaptation == self)
   {
-    dt_iop_set_module_trouble_message(chr->temperature, NULL, NULL, NULL);
-    dt_iop_set_module_trouble_message(self, NULL, NULL, NULL);
+    dt_iop_clear_module_trouble_message(chr->temperature);
+    dt_iop_clear_module_trouble_message(self);
   }
 }
 

--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -2045,8 +2045,7 @@ static void _preview_pipe_finished_callback(gpointer instance, dt_iop_module_t *
   if(!self->gui_data) return;
   dt_iop_colorin_params_t *p = self->params;
   const gboolean on = p->blue_mapping;
-  dt_iop_set_module_trouble_message
-      (self,
+  dt_iop_set_module_trouble_message(self,
         on ? _("blue mapping") : NULL,
         on ? _("the blue mapping mode has been deprecated since very long and has been removed.\n"
               "reset to defaults or switch to any colorin profile and check results. minimal\n"

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -4307,8 +4307,8 @@ static void _display_errors(dt_iop_module_t *self)
      && self->enabled
      && p->method == DT_IOP_LENS_METHOD_LENSFUN)
   {
-    dt_iop_set_module_trouble_message
-      (self, _("camera/lens not found"),
+    dt_iop_set_module_trouble_message(self,
+       _("camera/lens not found"),
        _("pick a camera or lens from the buttons below --\n"
          "the lens button lists the whole database when the body is unknown\n"
          "scale, target geometry and the TCA override work without a profile\n"
@@ -4318,7 +4318,7 @@ static void _display_errors(dt_iop_module_t *self)
   }
   else
   {
-    dt_iop_set_module_trouble_message(self, NULL, NULL, NULL);
+    dt_iop_clear_module_trouble_message(self);
   }
 
   gtk_widget_queue_draw(self->widget);

--- a/src/iop/rawprepare.c
+++ b/src/iop/rawprepare.c
@@ -609,7 +609,7 @@ static gboolean _image_set_rawcrops(dt_iop_module_t *self,
        "invalid crop parameters");
   }
   else
-    dt_iop_set_module_trouble_message(self, NULL, NULL, NULL);
+    dt_iop_clear_module_trouble_message(self);
 
   // we update p_width & height both in the image_storage for fast access within the pipeline
   // and the database so we can access that also via dt_image_cache_get()

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -723,7 +723,7 @@ void commit_params(dt_iop_module_t *self,
   chr->late_correction = p->preset == DT_IOP_TEMP_D65_LATE;
   chr->temperature = piece->enabled ? self : NULL;
   if(dt_pipe_is_preview(pipe) && !piece->enabled)
-    dt_iop_set_module_trouble_message(self, NULL, NULL, NULL);
+    dt_iop_clear_module_trouble_message(self);
 }
 
 void init_pipe(dt_iop_module_t *self,

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -273,20 +273,12 @@ static dt_darkroom_layout_t _lib_darkroom_get_layout(dt_view_t *self)
   return DT_DARKROOM_LAYOUT_EDITING;
 }
 
-static gboolean _darkroom_module_is_active(const dt_view_t *view,
-                                           const dt_iop_module_t *module)
+static gboolean _darkroom_module_is_active(const dt_iop_module_t *module)
 {
-  if(!view || !module || view != dt_view_manager_get_current_view(darktable.view_manager)
-     || view->data != darktable.develop)
-    return FALSE;
-
-  // Trouble messages are delivered asynchronously and carry a borrowed module
-  // pointer.  Compare pointers while walking the live IOP list before reading
-  // anything from the payload; the old darkroom may have freed the module
-  // while its queued signal was waiting for the GUI thread.
-  const dt_develop_t *dev = view->data;
-  for(const GList *iter = dev->iop; iter; iter = g_list_next(iter))
-    if(iter->data == module)
+  // Compare module and it's gui stuff while walking the IOP list as darkroom may have
+  // freed the module while its queued signal was waiting for the GUI thread.
+  for(const GList *iter = darktable.develop->iop; iter; iter = g_list_next(iter))
+    if(iter->data == module && module->gui_data && module->widget)
       return TRUE;
 
   return FALSE;
@@ -297,9 +289,13 @@ void _display_module_trouble_message_callback(gpointer instance,
                                               const char *const trouble_msg,
                                               const char *const trouble_tooltip)
 {
-  if(!_darkroom_module_is_active(instance, module)
-     || !module->gui_data
-     || !module->widget)
+  if(!module || !instance || dt_view_get_current() != DT_VIEW_DARKROOM)
+    return;
+
+  const gboolean active = _darkroom_module_is_active(module);
+  dt_print(DT_DEBUG_DEV, "%s trouble for `%s` active=%s",
+    trouble_msg ? trouble_msg : "cleared", module->name(), STR_YESNO(active));
+  if(!active)
     return;
 
   GtkWidget *label_widget = NULL;


### PR DESCRIPTION
1. The `_darkroom_module_is_active()` check introduced in 2b87a053b95bd55025141b562dc3968061ff7b34 (@Arecsu ) broke the `_display_module_trouble_message_callback()`.
  I confess i didn't understand the way it should work, we now check for being in darkroom and traverse the list of modules for being in the list and having gui stuff ready.
3. Introduced `dt_iop_clear_module_trouble_message()` and make use of that
4. chroma trouble messages are now reported via the trouble logs for simplicity
5. Some minor reformatting for readability

Fixes #22098