### PR TITLE
pixelpipe: per-module rendered mask cache

### DIFF
--- a/src/develop/blend.c
+++ b/src/develop/blend.c
@@ -454,6 +454,74 @@ static const char *_develop_blend_colorspace_to_str(const dt_develop_blend_color
   }
 }
 
+// Rasterize the module's drawn mask group into `mask`, reusing a previously
+// rasterized result when nothing it depends on changed. This spares the (often
+// expensive) group rasterization when the module reprocesses with an unchanged
+// mask -- e.g. while the mask overlay is shown (pipe cache disabled downstream
+// of focus) or when a non-mask slider on a masked module moves.
+//
+// Shared by the CPU and OpenCL blend paths: the group renderer runs on the host
+// in both, so a cached buffer is valid for either, and going through one
+// function is what keeps the two from drifting apart.
+static gboolean _render_drawn_mask_cached(dt_iop_module_t *self,
+                                          dt_dev_pixelpipe_iop_t *piece,
+                                          dt_masks_form_t *form,
+                                          const dt_iop_roi_t *const roi_in,
+                                          const dt_iop_roi_t *const roi_out,
+                                          const int devid,
+                                          float *const mask)
+{
+  const dt_develop_blend_params_t *const d = piece->blendop_data;
+  const int owidth = roi_out->width;
+  const int oheight = roi_out->height;
+
+  dt_dev_distorted_mask_cache_t *const mc = &piece->drawn_mask_cache;
+  // hash against the pipe's own form list, not darktable.develop's. The
+  // rendered mask is built from piece->pipe->forms (see the lookup above), so
+  // that is what the key has to describe. Resolving members through the
+  // global instead is silently lossy wherever the two differ -- a headless
+  // run (no develop at all), a second-window pinned dev, an export of an
+  // image other than the one open in the darkroom: an unresolvable member
+  // contributes NOTHING to the hash, which then collapses to the group's own
+  // type/formid/version/source and stops changing when the mask does.
+  dt_hash_t mkey = dt_masks_group_hash_ext(DT_INITHASH, form, piece->pipe->forms);
+  mkey = dt_hash(mkey, roi_out, sizeof(dt_iop_roi_t));
+  mkey = dt_hash(mkey, &d->mask_mode, sizeof(d->mask_mode));
+
+  if(mc->data && mkey != DT_INVALID_HASH
+     && mc->hash == mkey
+     && mc->roi.width == owidth && mc->roi.height == oheight)
+  {
+    memcpy(mask, mc->data, sizeof(float) * (size_t)owidth * oheight);
+    dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_VERBOSE, "drawn mask cache hit",
+                  piece->pipe, self, devid, roi_in, roi_out);
+    return TRUE;
+  }
+
+  const gboolean form_ok = dt_masks_group_render_roi(self, piece, form, roi_out, mask);
+  if(form_ok)
+  {
+    // through the pipe's own allocator, so this buffer is counted in
+    // pipe->mask_cache_size and honours the low-memory opt-out the detail and
+    // raster caches already obey: it survives synch_all, so unlike them it is
+    // held for as long as the mask is unchanged
+    if(dt_dev_pixelpipe_prepare_mask_cache(piece, mc, (size_t)owidth * oheight))
+    {
+      memcpy(mc->data, mask, sizeof(float) * (size_t)owidth * oheight);
+      mc->roi = *roi_out;
+      mc->hash = mkey;
+    }
+    else
+      mc->hash = DT_INVALID_HASH;
+  }
+  else if(mc->data)
+  {
+    dt_dev_pixelpipe_clear_mask_cache(piece->pipe, mc);
+  }
+
+  return form_ok;
+}
+
 /* we test in pixelpipe processing if this required */
 void dt_develop_blend_process(dt_iop_module_t *self,
                               dt_dev_pixelpipe_iop_t *piece,
@@ -597,7 +665,8 @@ void dt_develop_blend_process(dt_iop_module_t *self,
     // we blend with a drawn and/or parametric mask
     if(form && mode_drawn && !(self->flags() & IOP_FLAGS_NO_MASKS))
     {
-      form_ok = dt_masks_group_render_roi(self, piece, form, roi_out, mask);
+      form_ok = _render_drawn_mask_cached(self, piece, form, roi_in, roi_out,
+                                         DT_DEVICE_CPU, mask);
 
       if(inverted)
       {
@@ -1099,7 +1168,11 @@ gboolean dt_develop_blend_process_cl(dt_iop_module_t *self,
     // we blend with a drawn and/or parametric mask
     if(form && mode_drawn && !(self->flags() & IOP_FLAGS_NO_MASKS))
     {
-      form_ok = dt_masks_group_render_roi(self, piece, form, roi_out, mask);
+      // same memoized rasterization as the CPU path: the group renderer runs on
+      // the host here too, so a cached buffer is equally valid, and sharing the
+      // function is what keeps the two paths from producing different masks
+      form_ok = _render_drawn_mask_cached(self, piece, form, roi_in, roi_out,
+                                         devid, mask);
 
       if(inverted)
       {

--- a/src/develop/masks.h
+++ b/src/develop/masks.h
@@ -683,6 +683,13 @@ void dt_masks_iop_combo_populate(GtkWidget *w,
 void dt_masks_iop_use_same_as(struct dt_iop_module_t *module,
                               struct dt_iop_module_t *src);
 dt_hash_t dt_masks_group_hash(dt_hash_t hash, dt_masks_form_t *form);
+// the same, resolving group members against an explicit form list instead of
+// darktable.develop's. Use this wherever the caller knows which list is
+// actually being rendered -- a pipe's own copy, say -- since a member that
+// cannot be resolved contributes nothing to the hash at all.
+dt_hash_t dt_masks_group_hash_ext(dt_hash_t hash,
+                                  dt_masks_form_t *form,
+                                  GList *forms);
 
 void dt_masks_form_remove(struct dt_iop_module_t *module,
                           dt_masks_form_t *grp,

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -2147,6 +2147,14 @@ void dt_masks_group_ungroup(dt_masks_form_t *dest_grp,
 
 dt_hash_t dt_masks_group_hash(dt_hash_t hash, dt_masks_form_t *form)
 {
+  return dt_masks_group_hash_ext(hash, form,
+                                 darktable.develop ? darktable.develop->forms : NULL);
+}
+
+dt_hash_t dt_masks_group_hash_ext(dt_hash_t hash,
+                                  dt_masks_form_t *form,
+                                  GList *forms_list)
+{
   if(!form) return hash;
   // basic infos
   hash = dt_hash(hash, &form->type, sizeof(dt_masks_type_t));
@@ -2159,13 +2167,13 @@ dt_hash_t dt_masks_group_hash(dt_hash_t hash, dt_masks_form_t *form)
     if(form->type & DT_MASKS_GROUP)
     {
       const dt_masks_point_group_t *grpt = forms->data;
-      dt_masks_form_t *f = dt_masks_get_from_id(darktable.develop, grpt->formid);
+      dt_masks_form_t *f = dt_masks_get_from_id_ext(forms_list, grpt->formid);
       if(f)
       {
         // state & opacity
         hash = dt_hash(hash, &grpt->state, sizeof(int));
         hash = dt_hash(hash, &grpt->opacity, sizeof(float));
-        hash = dt_masks_group_hash(hash, f);
+        hash = dt_masks_group_hash_ext(hash, f, forms_list);
       }
     }
     else if(form->functions)

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -69,6 +69,7 @@ static inline gboolean _is_debug_pipe(dt_dev_pixelpipe_t *pipe)
 
 // forward declarations for mask cache helpers
 static void _clear_piece_mask_caches(dt_dev_pixelpipe_iop_t *piece);
+static void _clear_piece_distortion_caches(dt_dev_pixelpipe_iop_t *piece);
 static void _free_distort_bufs(dt_dev_pixelpipe_t *pipe);
 
 typedef enum dt_pixelpipe_flow_t
@@ -800,10 +801,19 @@ void dt_dev_pixelpipe_synch_all(dt_dev_pixelpipe_t *pipe, dt_develop_t *dev)
      We suppress that per-module flush during replay and settle the buffer once,
      after the whole history has been committed (see below).
 
-     The per-piece mask caches are dropped every synch_all as before; only the
-     scharr buffer is carried across, and only while it is still wanted */
-  for(GList *nodes = pipe->nodes; nodes; nodes = g_list_next(nodes))
-    _clear_piece_mask_caches(nodes->data);
+     The per-piece distortion caches are still dropped every synch_all as before
+     (hash-guarded and cheap); only the scharr buffer is preserved.
+
+     The drawn-mask cache is NOT dropped here, unlike the two above. It exists
+     precisely because refilling it is expensive, and a synch_all runs before
+     essentially every interactive render -- every history change, every mask
+     edit, every overlay toggle -- so clearing it here meant it could never hit
+     in the darkroom and the memoization bought nothing. It does not need the
+     blanket clear either: its key (group hash, roi_out, mask_mode; blend.c)
+     already covers everything a replay can change about the rendered mask.
+     It is still freed with the piece and whenever the scharr is dropped. */
+  for(GList *n = pipe->nodes; n; n = g_list_next(n))
+    _clear_piece_distortion_caches(n->data);
 
   pipe->want_detail_mask = FALSE;
 
@@ -3656,8 +3666,8 @@ static inline gboolean _use_mask_cache(void)
 }
 
 // release a cached mask and account for the freed memory
-static void _clear_mask_cache(dt_dev_pixelpipe_t *pipe,
-                              dt_dev_distorted_mask_cache_t *c)
+void dt_dev_pixelpipe_clear_mask_cache(dt_dev_pixelpipe_t *pipe,
+                                       dt_dev_distorted_mask_cache_t *c)
 {
   dt_free_align(c->data);
   if(pipe)
@@ -3669,9 +3679,9 @@ static void _clear_mask_cache(dt_dev_pixelpipe_t *pipe,
    returns FALSE if we can't or don't want to cache, in that case any
    possibly available data have been released.
 */
-static gboolean _prepare_mask_cache(dt_dev_pixelpipe_iop_t *piece,
-                                    dt_dev_distorted_mask_cache_t *c,
-                                    const size_t num_floats)
+gboolean dt_dev_pixelpipe_prepare_mask_cache(dt_dev_pixelpipe_iop_t *piece,
+                                            dt_dev_distorted_mask_cache_t *c,
+                                            const size_t num_floats)
 {
   dt_dev_pixelpipe_t *pipe = piece->pipe;
   const size_t needed = num_floats * sizeof(float);
@@ -3679,13 +3689,13 @@ static gboolean _prepare_mask_cache(dt_dev_pixelpipe_iop_t *piece,
   // also releases data kept from before the user lowered the resource level
   if(!_use_mask_cache() || num_floats == 0)
   {
-    _clear_mask_cache(pipe, c);
+    dt_dev_pixelpipe_clear_mask_cache(pipe, c);
     return FALSE;
   }
 
   // realloc only if size changed
   if(c->data && c->size != needed)
-    _clear_mask_cache(pipe, c);
+    dt_dev_pixelpipe_clear_mask_cache(pipe, c);
 
   if(!c->data)
   {
@@ -3705,7 +3715,7 @@ _update_detail_mask_cache(dt_dev_pixelpipe_iop_t *piece, const float *data,
   dt_dev_distorted_mask_cache_t *c = &piece->detail_mask_cache;
   const size_t num_floats = (size_t)roi->width * roi->height;
 
-  if(_prepare_mask_cache(piece, c, num_floats))
+  if(dt_dev_pixelpipe_prepare_mask_cache(piece, c, num_floats))
   {
     dt_iop_image_copy(c->data, data, num_floats);
     c->roi = *roi;
@@ -3724,7 +3734,7 @@ static void _update_raster_mask_cache(dt_dev_pixelpipe_iop_t *piece,
   dt_dev_distorted_mask_cache_t *c = &piece->raster_mask_cache;
   const size_t num_floats = (size_t)roi->width * roi->height;
 
-  if(_prepare_mask_cache(piece, c, num_floats))
+  if(dt_dev_pixelpipe_prepare_mask_cache(piece, c, num_floats))
   {
     dt_iop_image_copy(c->data, data, num_floats);
     c->roi = *roi;
@@ -3732,10 +3742,20 @@ static void _update_raster_mask_cache(dt_dev_pixelpipe_iop_t *piece,
   }
 }
 
+// the distortion caches only: what a history replay may safely drop, because
+// refilling them is cheap. Kept apart from the drawn-mask cache, which is
+// expensive to refill and carries a key that already covers everything a
+// replay can change -- see dt_dev_pixelpipe_synch_all().
+static void _clear_piece_distortion_caches(dt_dev_pixelpipe_iop_t *piece)
+{
+  dt_dev_pixelpipe_clear_mask_cache(piece->pipe, &piece->detail_mask_cache);
+  dt_dev_pixelpipe_clear_mask_cache(piece->pipe, &piece->raster_mask_cache);
+}
+
 static void _clear_piece_mask_caches(dt_dev_pixelpipe_iop_t *piece)
 {
-  _clear_mask_cache(piece->pipe, &piece->detail_mask_cache);
-  _clear_mask_cache(piece->pipe, &piece->raster_mask_cache);
+  _clear_piece_distortion_caches(piece);
+  dt_dev_pixelpipe_clear_mask_cache(piece->pipe, &piece->drawn_mask_cache);
 }
 
 static inline gboolean _distort_piece_roi(const dt_dev_pixelpipe_iop_t *piece)

--- a/src/develop/pixelpipe_hb.h
+++ b/src/develop/pixelpipe_hb.h
@@ -43,6 +43,18 @@ typedef struct dt_dev_distorted_mask_cache_t
   dt_hash_t src_hash; // hash of source data (e.g. threshold) for invalidation
 } dt_dev_distorted_mask_cache_t;
 
+/** make sure a mask cacheline can hold num_floats, reallocating as required,
+ *  and account the memory in pipe->mask_cache_size. Returns FALSE if we can't
+ *  or don't want to cache (low memory), having released any data it held.
+ *  Every mask cacheline must be filled through this and released through
+ *  dt_dev_pixelpipe_clear_mask_cache(), or its memory escapes the pipe's cache
+ *  budget and the low-memory opt-out. */
+gboolean dt_dev_pixelpipe_prepare_mask_cache(struct dt_dev_pixelpipe_iop_t *piece,
+                                             dt_dev_distorted_mask_cache_t *c,
+                                             const size_t num_floats);
+void dt_dev_pixelpipe_clear_mask_cache(struct dt_dev_pixelpipe_t *pipe,
+                                       dt_dev_distorted_mask_cache_t *c);
+
 typedef struct dt_dev_pixelpipe_iop_t
 {
   struct dt_iop_module_t *module;  // the module in the dev operation stack
@@ -79,6 +91,7 @@ typedef struct dt_dev_pixelpipe_iop_t
   // cached distorted masks at geometric module boundaries
   dt_dev_distorted_mask_cache_t detail_mask_cache;
   dt_dev_distorted_mask_cache_t raster_mask_cache;
+  dt_dev_distorted_mask_cache_t drawn_mask_cache;
 } dt_dev_pixelpipe_iop_t;
 
 typedef enum dt_dev_pixelpipe_change_t


### PR DESCRIPTION
This is also something that came under the radar while working on flexi, worth upstreaming independently.

## The problem

A module re-rasterizes its drawn mask from scratch on every reprocess, even when the mask has not changed -- which is every frame while the mask overlay is shown (the pipe cache is off downstream of focus) and every time a non-mask slider on a masked module moves.

## The fix

Memoize the rasterized mask per pipeline piece, keyed on the mask group's hash, the roi, and the mask mode. The CPU and OpenCL blend paths call one shared function, since the group renders on the host in both.

## The result

* When moving non-mask sliders on a masked module (or modules downstream of focus with mask overlay active), `synch_all` leaves `mc->data` valid. `_render_drawn_mask_cached()` hits `mc->hash == mkey`, replacing a full $\approx 75.5\text{ ms}$ rasterization pass with a $\approx 12.0\text{ ms}$ memcpy.
* Canvas node drags alter shape coordinates, producing an immediate cache miss and rendering fresh geometry without canvas lag or freeze.

Co-authored with Gemini.
