### PR TITLE
toneequal: do not self-invalidate preview pixelpipe cache during processing

### DIFF
--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -1137,7 +1137,6 @@ void toneeq_process(dt_iop_module_t *self,
         dt_iop_gui_enter_critical_section(self);
         g->luminance_valid = TRUE;
         dt_iop_gui_leave_critical_section(self);
-        dt_dev_pixelpipe_cache_invalidate_later(piece->pipe, self->iop_order, "toneequal: ");
       }
     }
     else // make it dummy-proof


### PR DESCRIPTION
This is another performance fix upstreamed from Flexi work.

In `toneeq_process()`, recalculating the internal luminance mask for the GUI preview data buffer (`g->pd`) called `dt_dev_pixelpipe_cache_invalidate_later()` for `self->iop_order` on `piece->pipe`. Because `dt_dev_pixelpipe_cache_invalidate_later()` zeroes cachelines with `order >= self->iop_order`, toneequal invalidated its own freshly allocated output cacheline in `dev->preview_pipe` as well as all downstream preview cachelines.

Downstream modules in the preview pipe consume toneequal's RGBA pixel output, not `g->pd.buf` (which is read exclusively by the GUI for cursor EV picking and the EV histogram). Upstream and toneequal parameter changes are already tracked and invalidated by core pixelpipe hashing and `dt_iop_refresh_all()`.

Removing this spurious invalidation call allows toneequal and downstream preview cachelines to be retained across subsequent preview runs, recovering cache hit rates during darkroom editing and mask interactions.

Co-authored with Gemini.