### PR TITLE
masks: fix shape, source, and handle drag snapping on release

### DIFF
--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -2208,18 +2208,6 @@ static int _brush_events_button_released(dt_iop_module_t *module,
     dt_masks_point_brush_t *point
         = (dt_masks_point_brush_t *)g_list_nth_data(form->points, gui->feather_dragging);
     gui->feather_dragging = -1;
-    float pts[2] = { pzx * wd, pzy * ht };
-    dt_dev_distort_backtransform(darktable.develop, pts, 1);
-
-    float p1x, p1y, p2x, p2y;
-    _brush_feather_to_ctrl(point->corner[0] * iwidth,
-                           point->corner[1] * iheight,
-                           pts[0], pts[1],
-                           &p1x, &p1y, &p2x, &p2y, TRUE);
-    point->ctrl1[0] = p1x / iwidth;
-    point->ctrl1[1] = p1y / iheight;
-    point->ctrl2[0] = p2x / iwidth;
-    point->ctrl2[1] = p2y / iheight;
 
     point->state = DT_MASKS_POINT_STATE_USER;
 

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -395,9 +395,6 @@ static int _circle_events_button_released(dt_iop_module_t *module,
                                           dt_masks_form_gui_t *gui,
                                           const int index)
 {
-  float wd, ht, iwidth, iheight;
-  dt_masks_get_image_size(&wd, &ht, &iwidth, &iheight);
-
   if(which == GDK_BUTTON_SECONDARY
      && dt_is_valid_maskid(parentid)
      && gui->edit_mode == DT_MASKS_EDIT_FULL)
@@ -432,18 +429,9 @@ static int _circle_events_button_released(dt_iop_module_t *module,
   }
   if(gui->form_dragging)
   {
-    // we get the circle
-    dt_masks_point_circle_t *circle = form->points->data;
-
     // we end the form dragging
     gui->form_dragging = FALSE;
 
-    // we change the center value
-    float pts[2] = { pzx * wd + gui->dx, pzy * ht + gui->dy };
-    dt_masks_clamp_move_pts(pts, wd, ht);
-    dt_dev_distort_backtransform(darktable.develop, pts, 1);
-    circle->center[0] = pts[0] / iwidth;
-    circle->center[1] = pts[1] / iheight;
     dt_dev_add_masks_history_item(darktable.develop, module, TRUE);
 
     // we recreate the form points
@@ -462,22 +450,6 @@ static int _circle_events_button_released(dt_iop_module_t *module,
     // we end the form dragging
     gui->source_dragging = FALSE;
 
-    if(gui->scrollx != 0.0 || gui->scrolly != 0.0)
-    {
-      // if there's no dragging the source is calculated in
-      // _circle_events_button_pressed()
-    }
-    else
-    {
-      // we change the center value
-      float pts[2] = { pzx * wd + gui->dx, pzy * ht + gui->dy };
-      dt_masks_clamp_move_pts(pts, wd, ht);
-
-      dt_dev_distort_backtransform(darktable.develop, pts, 1);
-
-      form->source[0] = pts[0] / iwidth;
-      form->source[1] = pts[1] / iheight;
-    }
     dt_dev_add_masks_history_item(darktable.develop, module, TRUE);
 
     // we recreate the form points

--- a/src/develop/masks/ellipse.c
+++ b/src/develop/masks/ellipse.c
@@ -795,9 +795,6 @@ static int _ellipse_events_button_released(dt_iop_module_t *module,
                                            dt_masks_form_gui_t *gui,
                                            const int index)
 {
-  float wd, ht, iwidth, iheight;
-  dt_masks_get_image_size(&wd, &ht, &iwidth, &iheight);
-
   if(which == 3
      && dt_is_valid_maskid(parentid)
      && gui->edit_mode == DT_MASKS_EDIT_FULL)
@@ -832,18 +829,9 @@ static int _ellipse_events_button_released(dt_iop_module_t *module,
   }
   if(gui->form_dragging)
   {
-    // we get the ellipse
-    dt_masks_point_ellipse_t *ellipse = form->points->data;
-
     // we end the form dragging
     gui->form_dragging = FALSE;
 
-    // we change the center value
-    float pts[2] = { pzx * wd + gui->dx, pzy * ht + gui->dy };
-    dt_masks_clamp_move_pts(pts, wd, ht);
-    dt_dev_distort_backtransform(darktable.develop, pts, 1);
-    ellipse->center[0] = pts[0] / iwidth;
-    ellipse->center[1] = pts[1] / iheight;
     dt_dev_add_masks_history_item(darktable.develop, module, TRUE);
 
     // we recreate the form points
@@ -895,54 +883,10 @@ static int _ellipse_events_button_released(dt_iop_module_t *module,
   }
   else if(gui->form_rotating && gui->edit_mode == DT_MASKS_EDIT_FULL)
   {
-    // we get the ellipse
-    dt_masks_point_ellipse_t *ellipse = form->points->data;
-
-    // we end the form rotating
+    // rotation was applied incrementally in mouse_moved; just finalise
     gui->form_rotating = FALSE;
-
-    const float x = pzx * wd;
-    const float y = pzy * ht;
-
-    // we need the reference point
-    dt_masks_form_gui_points_t *gpt = g_list_nth_data(gui->points, index);
-    if(!gpt) return 0;
-
-    // pivot for reading the final mouse sweep: the center of the shape the mouse
-    // is circling (source for a joint rotation grabbed on the source), matching
-    // the mouse_moved branch above.
-    const float xref = gui->rotate_about_source ? gpt->source[0] : gpt->points[0];
-    const float yref = gui->rotate_about_source ? gpt->source[1] : gpt->points[1];
-
-    const float pts[8] = { xref, yref, x , y, 0, 0, gui->dx, gui->dy };
-
-    const float dv = atan2f(pts[3] - pts[1],
-                            pts[2] - pts[0]) - atan2f(-(pts[7] - pts[5]),
-                                                      -(pts[6] - pts[4]));
-
-    float pts2[8] = { xref, yref, x , y, xref+10.0f, yref, xref, yref+10.0f };
-    dt_dev_distort_backtransform(darktable.develop, pts2, 4);
-
-    float check_angle = atan2f(pts2[7] - pts2[1],
-                               pts2[6] - pts2[0]) - atan2f(pts2[5] - pts2[1],
-                                                           pts2[4] - pts2[0]);
-    // Normalize to the range -180 to 180 degrees
-    check_angle = atan2f(sinf(check_angle), cosf(check_angle));
-    if(check_angle < 0)
-      ellipse->rotation -= rad2degf(dv);
-    else
-      ellipse->rotation += rad2degf(dv);
-
-    // Rotation behavior (counter_rotate_source is set at button-press time):
-    // - CTRL only (target): only the target rotates, the source stays fixed
-    //   (counter_rotate_source == TRUE, so the branch below is skipped)
-    // - CTRL+SHIFT: both shapes rotate together by the same amount
-    //   (counter_rotate_source == FALSE, so the source angle follows)
-    if(!gui->counter_rotate_source)
-      form->source[2] += dv;
-
-    dt_conf_set_float(DT_MASKS_CONF(form->type, ellipse, rotation), ellipse->rotation);
     gui->rotate_about_source = FALSE;
+    gui->scrollx = gui->scrolly = 0.0f;
 
     dt_dev_add_masks_history_item(darktable.develop, module, TRUE);
 
@@ -953,24 +897,9 @@ static int _ellipse_events_button_released(dt_iop_module_t *module,
   }
   else if(gui->source_rotating && gui->edit_mode == DT_MASKS_EDIT_FULL)
   {
+    // rotation was applied incrementally in mouse_moved; just finalise
     gui->source_rotating = FALSE;
-
-    const float x = pzx * wd;
-    const float y = pzy * ht;
-
-    dt_masks_form_gui_points_t *gpt = g_list_nth_data(gui->points, index);
-    if(!gpt) return 0;
-
-    const float xref = gpt->source[0];
-    const float yref = gpt->source[1];
-
-    const float pts[8] = { xref, yref, x , y, 0, 0, gui->dx, gui->dy };
-
-    const float dv = atan2f(pts[3] - pts[1],
-                            pts[2] - pts[0]) - atan2f(-(pts[7] - pts[5]),
-                                                      -(pts[6] - pts[4]));
-
-    form->source[2] += dv;
+    gui->scrollx = gui->scrolly = 0.0f;
 
     dt_dev_add_masks_history_item(darktable.develop, module, TRUE);
 
@@ -1003,23 +932,6 @@ static int _ellipse_events_button_released(dt_iop_module_t *module,
     // we end the form dragging
     gui->source_dragging = FALSE;
 
-    if(gui->scrollx != 0.0
-       || gui->scrolly != 0.0)
-    {
-      // if there's no dragging the source is calculated in
-      // _ellipse_events_button_pressed()
-    }
-    else
-    {
-      // we change the center value
-      float pts[2] = { pzx * wd + gui->dx, pzy * ht + gui->dy };
-      dt_masks_clamp_move_pts(pts, wd, ht);
-
-      dt_dev_distort_backtransform(darktable.develop, pts, 1);
-
-      form->source[0] = pts[0] / iwidth;
-      form->source[1] = pts[1] / iheight;
-    }
     dt_dev_add_masks_history_item(darktable.develop, module, TRUE);
 
     // we recreate the form points

--- a/src/develop/masks/gradient.c
+++ b/src/develop/masks/gradient.c
@@ -339,8 +339,8 @@ static int _gradient_events_button_released(dt_iop_module_t *module,
                                             dt_masks_form_gui_t *gui,
                                             const int index)
 {
-  float wd, ht, iwidth, iheight;
-  dt_masks_get_image_size(&wd, &ht, &iwidth, &iheight);
+  float wd, ht;
+  dt_masks_get_image_size(&wd, &ht, NULL, NULL);
 
   if(which == GDK_BUTTON_SECONDARY
      && dt_is_valid_maskid(parentid)
@@ -379,19 +379,9 @@ static int _gradient_events_button_released(dt_iop_module_t *module,
      && form->points
      && gui->edit_mode == DT_MASKS_EDIT_FULL)
   {
-    // we get the gradient
-    dt_masks_point_gradient_t *gradient = form->points->data;
-
-    // we end the form dragging
+    // the move was already applied incrementally in mouse_moved; just finalise
     gui->form_dragging = FALSE;
 
-    // we change the center value
-    float pts[2] = { pzx * wd + gui->dx, pzy * ht + gui->dy };
-    dt_masks_clamp_move_pts(pts, wd, ht);
-    dt_dev_distort_backtransform(darktable.develop, pts, 1);
-
-    gradient->anchor[0] = pts[0] / iwidth;
-    gradient->anchor[1] = pts[1] / iheight;
     dt_dev_add_masks_history_item(darktable.develop, module, TRUE);
 
     // we recreate the form points
@@ -403,40 +393,8 @@ static int _gradient_events_button_released(dt_iop_module_t *module,
           && form->points
           && gui->edit_mode == DT_MASKS_EDIT_FULL)
   {
-    // we get the gradient
-    dt_masks_point_gradient_t *gradient = form->points->data;
-
-    // we end the form rotating
+    // rotation was applied incrementally in mouse_moved; just finalise
     gui->form_rotating = FALSE;
-
-    const float x = pzx * wd;
-    const float y = pzy * ht;
-
-    // we need the reference point
-    dt_masks_form_gui_points_t *gpt = g_list_nth_data(gui->points, index);
-    if(!gpt) return 0;
-    const float xref = gpt->points[0];
-    const float yref = gpt->points[1];
-
-    const float pts[8] = { xref, yref, x , y, 0, 0, gui->dx, gui->dy };
-
-    const float dv = atan2f(pts[3] - pts[1],
-                            pts[2] - pts[0]) - atan2f(-(pts[7] - pts[5]),
-                                                      -(pts[6] - pts[4]));
-
-    float pts2[8] = { xref, yref, x , y, xref+10.0f, yref, xref, yref+10.0f };
-
-    dt_dev_distort_backtransform(darktable.develop, pts2, 4);
-
-    float check_angle = atan2f(pts2[7] - pts2[1],
-                               pts2[6] - pts2[0]) - atan2f(pts2[5] - pts2[1],
-                                                           pts2[4] - pts2[0]);
-    // Normalize to the range -180 to 180 degrees
-    check_angle = atan2f(sinf(check_angle), cosf(check_angle));
-    if(check_angle < 0)
-      gradient->rotation += rad2degf(dv);
-    else
-      gradient->rotation -= rad2degf(dv);
 
     dt_dev_add_masks_history_item(darktable.develop, module, TRUE);
 

--- a/src/develop/masks/path.c
+++ b/src/develop/masks/path.c
@@ -3600,10 +3600,6 @@ static int _path_events_button_released(dt_iop_module_t *module,
   dt_masks_form_gui_points_t *gpt = g_list_nth_data(gui->points, index);
   if(!gpt) return 0;
 
-  float wd, ht; // Backbuffer width and height
-  float iwidth, iheight; // Image width and height
-  dt_masks_get_image_size(&wd, &ht, &iwidth, &iheight);
-
   if(gui->form_dragging)
   {
     // the move was already applied incrementally, tick by tick, in
@@ -3707,12 +3703,6 @@ static int _path_events_button_released(dt_iop_module_t *module,
     dt_masks_point_path_t *point
         = (dt_masks_point_path_t *)g_list_nth_data(form->points, gui->feather_dragging);
     gui->feather_dragging = -1;
-    float pts[2] = { pzx * wd, pzy * ht };
-    dt_dev_distort_backtransform(darktable.develop, pts, 1);
-
-    _update_bezier_ctrl_points(point, pts[0] / iwidth, pts[1] / iheight,
-                               gui->bezier_ctrl, gui->bezier_mode,
-                               gui->bezier_ctrl_angle, gui->bezier_ctrl_scale, iwidth/iheight);
     gui->bezier_mode = DT_MASKS_BEZIER_NONE;
     point->state = DT_MASKS_POINT_STATE_USER;
 


### PR DESCRIPTION
This is a follow up to #21979. 

### The problem

`_events_mouse_moved` already moves or rotates the dragged shape, source,
or Bézier handle to its correct position on every tick. The matching
`_*_events_button_released` handlers for circles, ellipses, gradients,
paths, and brushes redundantly recomputed a target position or rotation
delta from the release event's own coordinates.

Whenever the release event's coordinates diverge from the last motion
tick (e.g. carrying a transient (0, 0)), this moved the shape or
control handle a second time, observed as snapping to the top-left
corner or jumping in angle on mouse-up.

### The fix
On release, finalize without recomputing or reapplying deltas.

Co-authored with Gemini.
