### PR TITLE
Make dt_get_wtime() use the monotonic timer

### DIFF
--- a/src/common/ai/segmentation.c
+++ b/src/common/ai/segmentation.c
@@ -615,7 +615,7 @@ void dt_seg_warmup_decoder(dt_seg_context_t *ctx)
   if(!ctx || !ctx->decoder) return;
 
   dt_print(DT_DEBUG_AI, "[segmentation] warming up decoder...");
-  const double t0 = dt_get_wtime();
+  const double t0 = dt_get_debug_wtime();
   const gboolean is_sam = ctx->model_type == DT_SEG_MODEL_SAM;
   const int pm_dim = ctx->prev_mask_dim;
   const int nm = ctx->num_masks;

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -982,8 +982,6 @@ int dt_init(int argc,
             const gboolean load_data,
             lua_State *L)
 {
-  const double start_wtime = dt_get_wtime();
-
 #ifndef _WIN32
   if(getuid() == 0 || geteuid() == 0)
     dt_print(DT_DEBUG_ALWAYS,
@@ -1007,7 +1005,7 @@ int dt_init(int argc,
   // init all pointers to 0:
   memset(&darktable, 0, sizeof(darktable_t));
 
-  darktable.start_wtime = start_wtime;
+  darktable.start_mtime = g_get_monotonic_time();
 
   darktable.progname = argv[0];
 
@@ -2223,7 +2221,7 @@ int dt_init(int argc,
 #endif
 
   dt_print(DT_DEBUG_CONTROL,
-           "[dt_init] startup took %f seconds", dt_get_wtime() - start_wtime);
+           "[dt_init] startup took %f seconds", dt_get_wtime());
 
   dt_print_mem_usage("after successful startup");
 
@@ -2475,7 +2473,7 @@ void dt_print_ext(const char *msg, ...)
   vsnprintf(vbuf, sizeof(vbuf), msg, ap);
   va_end(ap);
 
-  printf("%11.4f %s\n", dt_get_wtime() - darktable.start_wtime, vbuf);
+  printf("%11.4f %s\n", dt_get_wtime(), vbuf);
   fflush(stdout);
 }
 

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -492,7 +492,7 @@ typedef struct darktable_t
   char *bench_module;
   dt_lua_state_t lua_state;
   GList *guides;
-  double start_wtime;
+  gint64 start_mtime;
   GList *themes;
   int32_t unmuted_signal_dbg_acts;
   gboolean unmuted_signal_dbg[DT_SIGNAL_COUNT];
@@ -735,9 +735,7 @@ void dt_capabilities_cleanup();
 
 static inline double dt_get_wtime(void)
 {
-  struct timeval time;
-  gettimeofday(&time, NULL);
-  return time.tv_sec - 1290608000 + (1.0 / 1000000.0) * time.tv_usec;
+  return(double)(g_get_monotonic_time() - darktable.start_mtime) * 1e-6;
 }
 
 static inline double dt_get_debug_wtime(void)

--- a/src/imageio/imageio_dng.c
+++ b/src/imageio/imageio_dng.c
@@ -55,7 +55,7 @@ static void _dt_dng_tiff_warning(const char *module,
   if(darktable.unmuted & DT_DEBUG_IMAGEIO)
   {
     fprintf(stderr, "%11.4f [imageio_dng] warning: %s: ",
-            dt_get_wtime() - darktable.start_wtime,
+            dt_get_wtime(),
             module ? module : "(none)");
     vfprintf(stderr, fmt, ap);
     fprintf(stderr, "\n");
@@ -66,7 +66,7 @@ static void _dt_dng_tiff_error(const char *module,
                                const char *fmt, va_list ap)
 {
   fprintf(stderr, "%11.4f [imageio_dng] error: %s: ",
-          dt_get_wtime() - darktable.start_wtime,
+          dt_get_wtime(),
           module ? module : "(none)");
   vfprintf(stderr, fmt, ap);
   fprintf(stderr, "\n");

--- a/src/imageio/imageio_tiff.c
+++ b/src/imageio/imageio_tiff.c
@@ -346,7 +346,7 @@ static void _warning_error_handler(const char *type,
   // to be consistent with dt_print
   fprintf(stderr,
           "%11.4f [tiff_open] %s: %s: ",
-          dt_get_wtime() - darktable.start_wtime,
+          dt_get_wtime(),
           type,
           module);
   vfprintf(stderr, fmt, ap);


### PR DESCRIPTION
`dt_get_wtime()` used deprecated `gettimeofday()` function and struct (see https://www.man7.org/linux/man-pages/man2/gettimeofday.2.html) Also the resolution of windows wallclock is not guaranteed.

Instead we should use the safer monotonic timer.