### PR TITLE
Fix two memory leaks in variable expansion

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -276,6 +276,9 @@ changes (where available).
   not crash. The offending modules are now reset to use the default
   parameters and a message is displayed to the user.
 
+- Fixed small memory leaks when expanding variables, which grew with
+  the number of images exported or imported in one run.
+
 ## Lua
 
 ### API Version

--- a/src/common/variables.c
+++ b/src/common/variables.c
@@ -254,6 +254,8 @@ static void _cleanup_expansion(dt_variables_params_t *params)
     params->data->camera_maker = NULL;
     g_free(params->data->camera_alias);
     params->data->camera_alias = NULL;
+    g_free(params->data->exif_lens);
+    params->data->exif_lens = NULL;
   }
   g_free(params->data->homedir);
   params->data->homedir = NULL;

--- a/src/common/variables.c
+++ b/src/common/variables.c
@@ -250,13 +250,16 @@ static void _cleanup_expansion(dt_variables_params_t *params)
       g_date_time_unref(params->data->datetime);
       params->data->datetime = NULL;
     }
-    g_free(params->data->camera_maker);
-    params->data->camera_maker = NULL;
-    g_free(params->data->camera_alias);
-    params->data->camera_alias = NULL;
     g_free(params->data->exif_lens);
     params->data->exif_lens = NULL;
   }
+  // both branches of _init_expansion duplicate these, so free them either way.
+  // the datetime above cannot move out with them: without an image it aliases
+  // exif_time, which dt_variables_params_destroy owns
+  g_free(params->data->camera_maker);
+  params->data->camera_maker = NULL;
+  g_free(params->data->camera_alias);
+  params->data->camera_alias = NULL;
   g_free(params->data->homedir);
   params->data->homedir = NULL;
   g_free(params->data->pictures_folder);


### PR DESCRIPTION
Fixes #22217

`_init_expansion()` duplicates strings on every expansion, but `_cleanup_expansion()` only freed some of them, so anything holding one `dt_variables_params_t` across several expansions piles up - `disk.c` keeps one for a whole export, `import_session.c` one per imported file.

`exif_lens` was never freed there at all. `camera_maker` and `camera_alias` were, but inside the `dt_is_valid_imgid()` guard, while both branches of `_init_expansion()` allocate them - so the no-image path leaked both every time. Hence the diff looking like line-shuffling: one free belongs inside the guard, the other two outside. The `g_date_time_unref` stays put because without an image `datetime` aliases `exif_time` rather than owning it.

Checked under valgrind on a `BINARY_PACKAGE_BUILD` tree: a six-image export lost 5 blocks from `variables.c:168`, five expansions with no image lost 4 blocks each from lines 239 and 240. Both gone after the fix, no double frees.

Written with AI assistance.