### PR TITLE
22182: keep the black-to-white range positive

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -268,8 +268,8 @@ changes (where available).
   malformed order is now ignored and the style keeps the default one.
 
 - Fixed automatic exposure rendering a black image when its raw histogram
-  was unavailable, and black-point limits ignoring camera exposure
-  compensation, which could invert the tonal range.
+  was unavailable, and black or inverted images when the black level was
+  set too high for the exposure applied.
 
 - Fixed exposure's area mapping blowing out the image when its target
   lightness was set to zero. Such a target cannot be reached, so the

--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -514,7 +514,9 @@ static void _process_common_setup(dt_iop_module_t *self,
   }
 
   const float white = exposure2white(exposure);
-  d->scale = 1.0 / (white - d->black);
+  if(d->black >= white)
+    d->black = white - 0.01f;
+  d->scale = 1.0f / (white - d->black);
 }
 
 #ifdef HAVE_OPENCL


### PR DESCRIPTION
A follow-up to #21974: in deflicker ("automatic") mode, or with invalid persisted settings, rendering black or inverted images was still possible. This commit adds the last sanitisation step.

Note: as this is a very unusual setup (black is usually kept negative, its default value is -0.0002 and users are advised in the manual not to use it as an artistic control, to deepen blacks), this is a **rendering-only** fix (no parameter fixes or migration, no preset or style sanitisation). Also, deflicker never adjusted blacks like manual mode does (the exposure / white level is calculated, not in params, and is derived from the histogram, so adjustment would require a larger coding effort).

As the fix does the same thing for deflicker and for persisted settings as what we already did for ones calculated for manual mode, I just updated the previous release notes entry added for 21974, with more generic wording regarding black being unsuitable for the resulting exposure correction.

Fixes #22182 