### PR TITLE
jobs: do not try to delete duplicate XMP if it does not exist

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -170,6 +170,9 @@ changes (where available).
 
 ## Bug Fixes
 
+- Fixed a trashing error dialog when deleting a virgin duplicate of an
+  image while sidecar creation is set to "after edit".
+
 - Fixed color harmonizer's auto-detect harmony applying the hue
   histogram of the previously viewed image after switching images in the
   darkroom.

--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -1369,6 +1369,10 @@ static _dt_delete_status_t delete_file_from_disk
 {
   _dt_delete_status_t delete_status = _DT_DELETE_STATUS_UNKNOWN;
 
+  // if the file does not exist on disk, it is already deleted
+  if(!g_file_test(filename, G_FILE_TEST_EXISTS))
+    return _DT_DELETE_STATUS_DELETED;
+
   GFile *gfile = g_file_new_for_path(filename);
   int send_to_trash = dt_conf_get_bool("send_to_trash");
 


### PR DESCRIPTION
When deleting a duplicate image whose sidecar file does not exist on
disk (such as a virgin duplicate when XMP writing is set to "after
edit"), darktable still attempted to send the non-existent XMP file
to trash. On Windows, `dt_win_file_trash()` failed with `G_IO_ERROR_FAILED`
rather than `G_IO_ERROR_NOT_FOUND`, prompting the user with an error
dialog.

Check for file existence before attempting to delete the duplicate's
sidecar, and guard `delete_file_from_disk()` to treat absent files as
already deleted.

**UNTESTED**, as I do not have access to a windows machine.

Fixes #22160