### PR TITLE
[cmake] Remove argument from endif() to avoid warnings

### DIFF
--- a/src/libs/CMakeLists.txt
+++ b/src/libs/CMakeLists.txt
@@ -113,7 +113,7 @@ set(MODULES ${MODULES} geotagging)
 if(CUPS_FOUND OR WIN32)
   add_library(print_settings MODULE "print_settings.c")
   set(MODULES ${MODULES} print_settings)
-endif(CUPS_FOUND)
+endif()
 
 # AI neural restore module
 if(USE_AI)

--- a/src/views/CMakeLists.txt
+++ b/src/views/CMakeLists.txt
@@ -25,7 +25,7 @@ endif(Gphoto2_FOUND)
 if(CUPS_FOUND OR WIN32)
     add_library(print MODULE "print.c")
     set(MODULES ${MODULES} print)
-endif(CUPS_FOUND)
+endif()
 
 foreach(module ${MODULES})
     target_link_libraries(${module} lib_darktable)


### PR DESCRIPTION
This PR replaces old-style `endif(<condition>)` statements with the modern `endif()` syntax. Prior to this fix, the argument in the two `endif` statements did not match the argument in the corresponding `if`, causing a CMake warning.