### PR TITLE
Collection of various minor fixes

### DIFF
--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -168,18 +168,21 @@ void dt_print_pipe_ext(const char *title,
   else if(device != DT_DEVICE_NONE)
     snprintf(dev, sizeof(dev), "??? %i", device);
 
-  const gboolean show_roo = roi_out && (!roi_in || memcmp(roi_in, roi_out, sizeof(dt_iop_roi_t)));
+  const gboolean identical = roi_in && roi_out && (memcmp(roi_in, roi_out, sizeof(dt_iop_roi_t)) == 0);
+  const gboolean show_roo = roi_out && !identical;
+
   if(roi_in)
   {
     snprintf(shift, sizeof(shift), "(%i/%i)", roi_in->x, roi_in->y);
     snprintf(area, sizeof(area), "%ix%i", roi_in->width, roi_in->height);
-    snprintf(roi, sizeof(roi), "%11s %10s sc=%.3f%s", shift, area, roi_in->scale, show_roo ? "" : ";");
+    snprintf(roi, sizeof(roi), "%11s %10s sc=%.4f%s", shift, area, roi_in->scale, show_roo ? "" : identical ? " same;" : " none;");
   }
+
   if(show_roo)
   {
     snprintf(shift, sizeof(shift), "(%i/%i)", roi_out->x, roi_out->y);
     snprintf(area, sizeof(area), "%ix%i", roi_out->width, roi_out->height);
-    snprintf(roo, sizeof(roo), " --> %11s %10s sc=%.3f;", shift, area, roi_out->scale);
+    snprintf(roo, sizeof(roo), "%s --> %11s %10s sc=%.4f;", roi_in ? "" : "none", shift, area, roi_out->scale);
   }
 
   if(pipe)
@@ -3426,7 +3429,7 @@ restart:
     dt_get_available_mem();
   #endif
   dt_print_pipe(DT_DEBUG_PIPE, "pipe starting",
-                  pipe, NULL, pipe->devid, &roi, &roi, "'%s' ID=%i using %luMB",
+                  pipe, NULL, pipe->devid, NULL, &roi, "'%s' ID=%i using %luMB",
                   pipe->image.filename, pipe->image.id, avail_mem / DT_MEGA);
   dt_print_mem_usage("before pixelpipe process");
 
@@ -3482,7 +3485,7 @@ restart:
     dt_dev_pixelpipe_change(pipe, dev);
 
     dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_OPENCL,
-      "pipe restarting on CPU", pipe, NULL, old_devid, &roi, &roi, "ID=%i",
+      "pipe restarting on CPU", pipe, NULL, old_devid, NULL, &roi, "ID=%i",
       pipe->image.id);
 
     goto restart; // try again (this time without opencl)
@@ -3544,7 +3547,7 @@ restart:
     dt_dev_pixelpipe_cache_report(pipe);
 
   dt_print_pipe(DT_DEBUG_PIPE, "pipe finished",
-                pipe, NULL, old_devid, &roi, &roi, "'%s' ID=%i",
+                pipe, NULL, old_devid, &roi, NULL, "'%s' ID=%i",
                 pipe->image.filename, pipe->image.id);
   dt_print_mem_usage("after pixelpipe process");
 
@@ -4071,14 +4074,13 @@ gboolean dt_dev_write_scharr_mask(dt_dev_pixelpipe_iop_t *piece,
   p->scharr.hash = dt_hash(DT_INITHASH, &p->scharr.roi, sizeof(dt_iop_roi_t));
 
   dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_VERBOSE, "write scharr mask CPU",
-                p, NULL, DT_DEVICE_CPU, NULL, NULL, "(%ix%i)",
-                roi->width, roi->height);
+                p, NULL, DT_DEVICE_CPU, roi, NULL);
   return FALSE;
 
  error:
   dt_print_pipe(DT_DEBUG_ALWAYS,
                 "couldn't write scharr mask CPU",
-                p, NULL, DT_DEVICE_CPU, NULL, NULL);
+                p, NULL, DT_DEVICE_CPU, roi, NULL);
   return TRUE;
 }
 
@@ -4135,14 +4137,13 @@ int dt_dev_write_scharr_mask_cl(dt_dev_pixelpipe_iop_t *piece,
   p->scharr.hash = dt_hash(DT_INITHASH, &p->scharr.roi, sizeof(dt_iop_roi_t));
 
   dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_VERBOSE, "write scharr mask CL",
-                p, NULL, devid, NULL, NULL, "(%ix%i)",
-                width, height);
+                p, NULL, devid, roi, NULL);
 
   error:
   if(err != CL_SUCCESS)
   {
     dt_print_pipe(DT_DEBUG_ALWAYS,
-                  "couldn't write scharr mask CL", p, NULL, devid, NULL, NULL,
+                  "couldn't write scharr mask CL", p, NULL, devid, roi, NULL,
                   "%s", cl_errstr(err));
     dt_dev_clear_scharr_mask(p);
   }

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -1206,8 +1206,12 @@ static void _declare_cat_on_pipe(dt_iop_module_t *self, const gboolean preset)
   }
 
   if(origcat != chr->adaptation)
-    dt_print(DT_DEBUG_PIPE, "changed CAT for %s%s from %p to %p",
-      self->op, dt_iop_get_instance_id(self), origcat, chr->adaptation);
+    dt_print(DT_DEBUG_PIPE, "changed CAT for %s%s from %s%s to %s%s",
+      self->op, dt_iop_get_instance_id(self),
+      origcat ? origcat->name() : "none",
+      origcat ? dt_iop_get_instance_id(origcat) : "",
+      chr->adaptation ? chr->adaptation->op : "none",
+      chr->adaptation ? dt_iop_get_instance_id(chr->adaptation) : "");
 }
 
 static void _update_illuminants(const dt_iop_module_t *self);

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -268,20 +268,16 @@ static gboolean _get_thumb_quality(const int width, const int height)
 }
 
 // can we avoid full demosaicing and use a fast interpolator instead?
-static gboolean _demosaic_full(const dt_dev_pixelpipe_iop_t *const piece,
-                               const dt_image_t *const img,
-                               const dt_iop_roi_t *const roi_out)
+static gboolean _demosaic_full(const dt_dev_pixelpipe_t *const pipe,
+                               const dt_image_t *const img)
 {
   if((img->flags & DT_IMAGE_4BAYER)   // half_size_f doesn't support 4bayer images
       || dt_image_is_mono_sraw(img)
-      || piece->pipe->want_detail_mask)
+      || pipe->want_detail_mask)
     return TRUE;
 
-  if(dt_pipe_is_thumb(piece->pipe))
-    return _get_thumb_quality(roi_out->width, roi_out->height);
-
-  if(dt_pipe_is_preview(piece->pipe))
-    return roi_out->scale > (piece->pipe->dsc.filters == 9u ? 0.667f : 0.5f);
+  if(dt_pipe_is_thumb(pipe))
+    return _get_thumb_quality(pipe->final_width, pipe->final_height);
 
   return TRUE;
 }
@@ -656,7 +652,7 @@ void process(dt_iop_module_t *self,
   const dt_iop_demosaic_gui_data_t *g = self->gui_data;
   const uint32_t filters = piece->filters;
 
-  const gboolean fullscale = _demosaic_full(piece, img, roi_out);
+  const gboolean fullscale = _demosaic_full(pipe, img);
   const gboolean is_xtrans = filters == 9u;
   const gboolean is_4bayer = img->flags & DT_IMAGE_4BAYER;
   const gboolean is_bayer = !is_4bayer && !is_xtrans && filters != 0;
@@ -918,7 +914,7 @@ int process_cl(dt_iop_module_t *self,
   cl_mem dev_xtrans = NULL;
 
   const uint32_t filters = piece->filters;
-  const gboolean fullscale = _demosaic_full(piece, img, roi_out);
+  const gboolean fullscale = _demosaic_full(pipe, img);
   const gboolean is_xtrans = filters == 9u;
   const gboolean is_bayer = !is_xtrans && filters != 0 && !true_monochrome;
 


### PR DESCRIPTION
1. `dt_print_pipe()` does better roi reporting like "none" or "same" and some callers got corrected or simplified.
2. reporting module names instead of non human-readable pointers while changing CAT.
3. corrected switch to fast approximating demosaicers
   - the preview pipe got it's data already downscaled so stay with normal but fast demosaicing mode.
   - for thumbs it should be chosen depending on final dimension instead of roi (respecting crops ...)