### PR TITLE
[Nightly] Drop support for macOS 14

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -347,7 +347,7 @@ jobs:
       fail-fast: true
       matrix:
         build:
-          - { os: macos-14,       xcode: 16.2, deployment: 14.0 } # AppleClang 16, arm64
+          - { os: macos-15,       xcode: 26.3, deployment: 15.0 } # AppleClang 17, arm64
         compiler:
           - { compiler: XCode,   CC: cc, CXX: c++ }
         btype: [ Release ]
@@ -487,7 +487,7 @@ jobs:
 
             The Windows package `*-win64.exe` requires at least Windows 10. The `*-woa64.exe` package requires at least Windows 11.
 
-            The macOS package `*-arm64.dmg` requires at least macOS 14.0 (Sonoma).
+            The macOS package `*-arm64.dmg` requires at least macOS 15.0 (Sequoia).
 
             __Please help us improve Darktable by reporting any issues you encounter!__ :wink:
           artifacts: |


### PR DESCRIPTION
The homebrew package base started breaking builds, and [macOS 14 is Tier 3](https://docs.brew.sh/Support-Tiers#:~:text=Tier%203%3A%20macOS%20Big%20Sur%2011%20through%20Sonoma%2014) for them, from which they [strongly recommend](https://docs.brew.sh/Support-Tiers#:~:text=Migration%20to%20a%20Tier%201%20or%202%20configuration%20or%20to%20a%20non%2DHomebrew%20tool%20is%20strongly%20recommended) switching to newer macOS. In other words, we should not expect this problem to be fixed quickly.